### PR TITLE
Update references to "os" to use "kernel.name"

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -119,10 +119,10 @@ func TestClient_Fingerprint(t *testing.T) {
 	c := testClient(t, nil)
 	defer c.Shutdown()
 
-	// Ensure os and arch are always present
+	// Ensure kernel and arch are always present
 	node := c.Node()
-	if node.Attributes["os"] == "" {
-		t.Fatalf("missing OS")
+	if node.Attributes["kernel.name"] == "" {
+		t.Fatalf("missing kernel.name")
 	}
 	if node.Attributes["arch"] == "" {
 		t.Fatalf("missing arch")
@@ -133,7 +133,6 @@ func TestClient_Drivers(t *testing.T) {
 	c := testClient(t, nil)
 	defer c.Shutdown()
 
-	// Ensure os and arch are always present
 	node := c.Node()
 	if node.Attributes["driver.exec"] == "" {
 		t.Fatalf("missing exec driver")

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -27,7 +27,7 @@ func Node() *structs.Node {
 		Datacenter: "dc1",
 		Name:       "foobar",
 		Attributes: map[string]string{
-			"os":            "linux",
+			"kernel.name":   "linux",
 			"arch":          "x86",
 			"version":       "0.1.0",
 			"driver.docker": "1.0.0",
@@ -74,7 +74,7 @@ func Job() *structs.Job {
 		Constraints: []*structs.Constraint{
 			&structs.Constraint{
 				Hard:    true,
-				LTarget: "$attr.os",
+				LTarget: "$attr.kernel.name",
 				RTarget: "linux",
 				Operand: "=",
 			},

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -357,7 +357,7 @@ type Node struct {
 
 	// Attributes is an arbitrary set of key/value
 	// data that can be used for constraints. Examples
-	// include "os=linux", "arch=386", "driver.docker=1",
+	// include "kernel.name=linux", "arch=386", "driver.docker=1",
 	// "docker.runtime=1.8.3"
 	Attributes map[string]string
 

--- a/nomad/util.go
+++ b/nomad/util.go
@@ -25,12 +25,12 @@ func ensurePath(path string, dir bool) error {
 // RuntimeStats is used to return various runtime information
 func RuntimeStats() map[string]string {
 	return map[string]string{
-		"os":         runtime.GOOS,
-		"arch":       runtime.GOARCH,
-		"version":    runtime.Version(),
-		"max_procs":  strconv.FormatInt(int64(runtime.GOMAXPROCS(0)), 10),
-		"goroutines": strconv.FormatInt(int64(runtime.NumGoroutine()), 10),
-		"cpu_count":  strconv.FormatInt(int64(runtime.NumCPU()), 10),
+		"kernel.name": runtime.GOOS,
+		"arch":        runtime.GOARCH,
+		"version":     runtime.Version(),
+		"max_procs":   strconv.FormatInt(int64(runtime.GOMAXPROCS(0)), 10),
+		"goroutines":  strconv.FormatInt(int64(runtime.NumGoroutine()), 10),
+		"cpu_count":   strconv.FormatInt(int64(runtime.NumCPU()), 10),
 	}
 }
 

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -95,7 +95,7 @@ func TestConstraintIterator(t *testing.T) {
 	}
 	static := NewStaticIterator(ctx, nodes)
 
-	nodes[0].Attributes["os"] = "freebsd"
+	nodes[0].Attributes["kernel.name"] = "freebsd"
 	nodes[1].Datacenter = "dc2"
 
 	constraints := []*structs.Constraint{
@@ -108,7 +108,7 @@ func TestConstraintIterator(t *testing.T) {
 		&structs.Constraint{
 			Hard:    true,
 			Operand: "is",
-			LTarget: "$attr.os",
+			LTarget: "$attr.kernel.name",
 			RTarget: "linux",
 		},
 	}
@@ -156,9 +156,9 @@ func TestResolveConstraintTarget(t *testing.T) {
 			result: false,
 		},
 		{
-			target: "$attr.os",
+			target: "$attr.kernel.name",
 			node:   node,
-			val:    node.Attributes["os"],
+			val:    node.Attributes["kernel.name"],
 			result: true,
 		},
 		{

--- a/scheduler/stack_test.go
+++ b/scheduler/stack_test.go
@@ -116,7 +116,7 @@ func TestServiceStack_Select_ConstraintFilter(t *testing.T) {
 		mock.Node(),
 	}
 	zero := nodes[0]
-	zero.Attributes["os"] = "freebsd"
+	zero.Attributes["kernel.name"] = "freebsd"
 
 	stack := NewGenericStack(false, ctx, nodes)
 
@@ -140,7 +140,7 @@ func TestServiceStack_Select_ConstraintFilter(t *testing.T) {
 	if met.ClassFiltered["linux-medium-pci"] != 1 {
 		t.Fatalf("bad: %#v", met)
 	}
-	if met.ConstraintFiltered["$attr.os = freebsd"] != 1 {
+	if met.ConstraintFiltered["$attr.kernel.name = freebsd"] != 1 {
 		t.Fatalf("bad: %#v", met)
 	}
 }


### PR DESCRIPTION
This brings test code and mocks up to date with the fingerprinter. This was a slightly larger change than I anticipated, but I think it's good for two reasons:
1. More semanitcally correct. `os.name` is something like "Windows 10 Pro" or "Ubuntu", while `kernel.name` is "windows" or "linux". `os.version` and `kernel.version` match these semantics.
2. `kernel.name` is much easier to grep for than `os`, which is helpful because oracle can't help us with strings.
