### PR TITLE
Change SIGINT to SIGTERM

### DIFF
--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -113,7 +115,7 @@ func (h *execHandle) Update(task *structs.Task) error {
 // Kill is used to terminate the task. We send an Interrupt
 // and then provide a 5 second grace period before doing a Kill.
 func (h *execHandle) Kill() error {
-	h.proc.Signal(os.Interrupt)
+	h.proc.Signal(unix.SIGTERM)
 	select {
 	case <-h.doneCh:
 		return nil

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -188,7 +190,7 @@ func (h *javaHandle) Update(task *structs.Task) error {
 // Kill is used to terminate the task. We send an Interrupt
 // and then provide a 5 second grace period before doing a Kill.
 func (h *javaHandle) Kill() error {
-	h.proc.Signal(os.Interrupt)
+	h.proc.Signal(unix.SIGTERM)
 	select {
 	case <-h.doneCh:
 		return nil


### PR DESCRIPTION
The docs casually mention that `os.Interrupt` doesn't do anything on Windows, so I'm curious whether `proc.Signal` does anything at all on Windows or is silently ignored.

`unix.SIGTERM` should work on any POSIX OS.

Closes #27 
