### PR TITLE
Changed Default executor to use a factory

### DIFF
--- a/client/executor/exec_linux.go
+++ b/client/executor/exec_linux.go
@@ -44,6 +44,12 @@ func SetGID(command *cmd, groupid string) error {
 	return nil
 }
 
+func init() {
+	Register(func() Executor {
+		return &LinuxExecutor{}
+	})
+}
+
 // Linux executor is designed to run on linux kernel 2.8+. It will fork/exec as
 // a user you specify and limit resources using rlimit.
 type LinuxExecutor struct {


### PR DESCRIPTION
This change allows us to use build flags for the executor files. E.g. `exec_linux.go` can be included only on linux builds.

The downside to this change is that we lose direct control over the order in which executors are evaluated. Technically it's still deterministic based on the lexical order of the filenames and go build's import order, but it's pretty opaque, particularly in the case of plugins.

/cc @ryanuber In case you have any additional feedback.
