### PR TITLE
jobspec: default job ID also comes from key

### DIFF
--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -77,7 +77,8 @@ func parseJob(result *structs.Job, obj *hclobj.Object) error {
 	delete(m, "constraint")
 	delete(m, "meta")
 
-	// Set the name to the object key
+	// Set the ID and name to the object key
+	result.ID = obj.Key
 	result.Name = obj.Key
 
 	// Defaults

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -17,6 +17,7 @@ func TestParse(t *testing.T) {
 		{
 			"basic.hcl",
 			&structs.Job{
+				ID:          "binstore-storagelocker",
 				Name:        "binstore-storagelocker",
 				Type:        "service",
 				Priority:    50,
@@ -128,7 +129,20 @@ func TestParse(t *testing.T) {
 		{
 			"default-job.hcl",
 			&structs.Job{
+				ID:       "foo",
 				Name:     "foo",
+				Priority: 50,
+				Region:   "global",
+				Type:     "service",
+			},
+			false,
+		},
+
+		{
+			"specify-job.hcl",
+			&structs.Job{
+				ID:       "job1",
+				Name:     "My Job",
 				Priority: 50,
 				Region:   "global",
 				Type:     "service",

--- a/jobspec/test-fixtures/specify-job.hcl
+++ b/jobspec/test-fixtures/specify-job.hcl
@@ -1,0 +1,4 @@
+job "default" {
+    id = "job1"
+    name = "My Job"
+}


### PR DESCRIPTION
Feels more natural to just:

```
job "job1" {
   ...
}
```

Rather than:

```
job "job1" {
    id = "job1"
    ...
}
```
