### PR TITLE
Fix sysattr cross compilation issue on Windows

### DIFF
--- a/client/executor/exec.go
+++ b/client/executor/exec.go
@@ -18,11 +18,8 @@
 package executor
 
 import (
-	"fmt"
 	"os/exec"
 	"path/filepath"
-	"strconv"
-	"syscall"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -111,36 +108,4 @@ type cmd struct {
 
 	// RunAs may be a username or Uid. The implementation will decide how to use it.
 	RunAs string
-}
-
-// SetUID changes the Uid for this command (must be set before starting)
-func (c *cmd) SetUID(userid string) error {
-	uid, err := strconv.ParseUint(userid, 10, 32)
-	if err != nil {
-		return fmt.Errorf("Unable to convert userid to uint32: %s", err)
-	}
-	if c.SysProcAttr == nil {
-		c.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	if c.SysProcAttr.Credential == nil {
-		c.SysProcAttr.Credential = &syscall.Credential{}
-	}
-	c.SysProcAttr.Credential.Uid = uint32(uid)
-	return nil
-}
-
-// SetGID changes the Gid for this command (must be set before starting)
-func (c *cmd) SetGID(groupid string) error {
-	gid, err := strconv.ParseUint(groupid, 10, 32)
-	if err != nil {
-		return fmt.Errorf("Unable to convert groupid to uint32: %s", err)
-	}
-	if c.SysProcAttr == nil {
-		c.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	if c.SysProcAttr.Credential == nil {
-		c.SysProcAttr.Credential = &syscall.Credential{}
-	}
-	c.SysProcAttr.Credential.Uid = uint32(gid)
-	return nil
 }

--- a/client/executor/setuid.go
+++ b/client/executor/setuid.go
@@ -1,0 +1,41 @@
+// +build !windows
+
+package executor
+
+import (
+	"fmt"
+	"strconv"
+	"syscall"
+)
+
+// SetUID changes the Uid for this command (must be set before starting)
+func (c *cmd) SetUID(userid string) error {
+	uid, err := strconv.ParseUint(userid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("Unable to convert userid to uint32: %s", err)
+	}
+	if c.SysProcAttr == nil {
+		c.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	if c.SysProcAttr.Credential == nil {
+		c.SysProcAttr.Credential = &syscall.Credential{}
+	}
+	c.SysProcAttr.Credential.Uid = uint32(uid)
+	return nil
+}
+
+// SetGID changes the Gid for this command (must be set before starting)
+func (c *cmd) SetGID(groupid string) error {
+	gid, err := strconv.ParseUint(groupid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("Unable to convert groupid to uint32: %s", err)
+	}
+	if c.SysProcAttr == nil {
+		c.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	if c.SysProcAttr.Credential == nil {
+		c.SysProcAttr.Credential = &syscall.Credential{}
+	}
+	c.SysProcAttr.Credential.Uid = uint32(gid)
+	return nil
+}

--- a/client/executor/setuid_windows.go
+++ b/client/executor/setuid_windows.go
@@ -1,0 +1,13 @@
+package executor
+
+// SetUID changes the Uid for this command (must be set before starting)
+func (c *cmd) SetUID(userid string) error {
+	// TODO implement something for windows
+	return nil
+}
+
+// SetGID changes the Gid for this command (must be set before starting)
+func (c *cmd) SetGID(groupid string) error {
+	// TODO implement something for windows
+	return nil
+}


### PR DESCRIPTION
Windows does not support exec.Cmd.SysProcAttr.Credential call; this causes cross-compiltion to fail so it's behind a build flag now

Fixes part of #64
