### PR TITLE
Force Ruby 2.2.2 on Heroku

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+ruby "2.2.2"
+
 gem "middleman-hashicorp", github: "hashicorp/middleman-hashicorp"


### PR DESCRIPTION
This forces a Ruby version. If you don't do this, Heroku will just upgrade you randomly in the future and that causes a lot of errors :frowning:. 2.2.2 is the latest as of this PR.
