### PR TITLE
Change CPU from float64 to int

### DIFF
--- a/api/compose_test.go
+++ b/api/compose_test.go
@@ -12,7 +12,7 @@ func TestCompose(t *testing.T) {
 		SetMeta("foo", "bar").
 		Constrain(HardConstraint("kernel.name", "=", "linux")).
 		Require(&Resources{
-		CPU:      1.25,
+		CPU:      1250,
 		MemoryMB: 1024,
 		DiskMB:   2048,
 		IOPS:     1024,
@@ -78,7 +78,7 @@ func TestCompose(t *testing.T) {
 						Name:   "task1",
 						Driver: "exec",
 						Resources: &Resources{
-							CPU:      1.25,
+							CPU:      1250,
 							MemoryMB: 1024,
 							DiskMB:   2048,
 							IOPS:     1024,

--- a/api/resources.go
+++ b/api/resources.go
@@ -3,7 +3,7 @@ package api
 // Resources encapsulates the required resources of
 // a given task or task group.
 type Resources struct {
-	CPU      float64
+	CPU      int
 	MemoryMB int
 	DiskMB   int
 	IOPS     int

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -166,7 +166,7 @@ func TestTask_Require(t *testing.T) {
 
 	// Create some require resources
 	resources := &Resources{
-		CPU:      1.25,
+		CPU:      1250,
 		MemoryMB: 128,
 		DiskMB:   2048,
 		IOPS:     1024,

--- a/client/fingerprint/cpu.go
+++ b/client/fingerprint/cpu.go
@@ -61,7 +61,7 @@ func (f *CPUFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) (bo
 			node.Resources = &structs.Resources{}
 		}
 
-		node.Resources.CPU = tc
+		node.Resources.CPU = int(tc)
 	}
 
 	if modelName != "" {

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -14,7 +14,7 @@ func Node() *structs.Node {
 			"driver.exec": "1",
 		},
 		Resources: &structs.Resources{
-			CPU:      4.0,
+			CPU:      4000,
 			MemoryMB: 8192,
 			DiskMB:   100 * 1024,
 			IOPS:     150,
@@ -27,7 +27,7 @@ func Node() *structs.Node {
 			},
 		},
 		Reserved: &structs.Resources{
-			CPU:      0.1,
+			CPU:      100,
 			MemoryMB: 256,
 			DiskMB:   4 * 1024,
 			Networks: []*structs.NetworkResource{
@@ -81,7 +81,7 @@ func Job() *structs.Job {
 							"args":    "+%s",
 						},
 						Resources: &structs.Resources{
-							CPU:      0.5,
+							CPU:      500,
 							MemoryMB: 256,
 							Networks: []*structs.NetworkResource{
 								&structs.NetworkResource{
@@ -127,7 +127,7 @@ func Alloc() *structs.Allocation {
 		NodeID:    "foo",
 		TaskGroup: "web",
 		Resources: &structs.Resources{
-			CPU:      0.5,
+			CPU:      500,
 			MemoryMB: 256,
 			Networks: []*structs.NetworkResource{
 				&structs.NetworkResource{
@@ -141,7 +141,7 @@ func Alloc() *structs.Allocation {
 		},
 		TaskResources: map[string]*structs.Resources{
 			"web": &structs.Resources{
-				CPU:      0.5,
+				CPU:      500,
 				MemoryMB: 256,
 				Networks: []*structs.NetworkResource{
 					&structs.NetworkResource{

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -91,9 +91,9 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex) (bool, st
 // This is equivalent to their BestFit v3
 func ScoreFit(node *Node, util *Resources) float64 {
 	// Determine the node availability
-	nodeCpu := node.Resources.CPU
+	nodeCpu := float64(node.Resources.CPU)
 	if node.Reserved != nil {
-		nodeCpu -= node.Reserved.CPU
+		nodeCpu -= float64(node.Reserved.CPU)
 	}
 	nodeMem := float64(node.Resources.MemoryMB)
 	if node.Reserved != nil {
@@ -101,7 +101,7 @@ func ScoreFit(node *Node, util *Resources) float64 {
 	}
 
 	// Compute the free percentage
-	freePctCpu := 1 - (util.CPU / nodeCpu)
+	freePctCpu := 1 - (float64(util.CPU) / nodeCpu)
 	freePctRam := 1 - (float64(util.MemoryMB) / nodeMem)
 
 	// Total will be "maximized" the smaller the value is.

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -89,7 +89,7 @@ func TestAllocsFit_PortsOvercommitted(t *testing.T) {
 func TestAllocsFit(t *testing.T) {
 	n := &Node{
 		Resources: &Resources{
-			CPU:      2.0,
+			CPU:      2000,
 			MemoryMB: 2048,
 			DiskMB:   10000,
 			IOPS:     100,
@@ -102,7 +102,7 @@ func TestAllocsFit(t *testing.T) {
 			},
 		},
 		Reserved: &Resources{
-			CPU:      1.0,
+			CPU:      1000,
 			MemoryMB: 1024,
 			DiskMB:   5000,
 			IOPS:     50,
@@ -119,7 +119,7 @@ func TestAllocsFit(t *testing.T) {
 
 	a1 := &Allocation{
 		Resources: &Resources{
-			CPU:      1.0,
+			CPU:      1000,
 			MemoryMB: 1024,
 			DiskMB:   5000,
 			IOPS:     50,
@@ -144,7 +144,7 @@ func TestAllocsFit(t *testing.T) {
 	}
 
 	// Sanity check the used resources
-	if used.CPU != 2.0 {
+	if used.CPU != 2000 {
 		t.Fatalf("bad: %#v", used)
 	}
 	if used.MemoryMB != 2048 {
@@ -161,7 +161,7 @@ func TestAllocsFit(t *testing.T) {
 	}
 
 	// Sanity check the used resources
-	if used.CPU != 3.0 {
+	if used.CPU != 3000 {
 		t.Fatalf("bad: %#v", used)
 	}
 	if used.MemoryMB != 3072 {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -534,7 +534,7 @@ type NodeListStub struct {
 // Resources is used to define the resources available
 // on a client
 type Resources struct {
-	CPU      float64
+	CPU      int
 	MemoryMB int `mapstructure:"memory"`
 	DiskMB   int `mapstructure:"disk"`
 	IOPS     int

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -146,13 +146,13 @@ func TestResource_NetIndex(t *testing.T) {
 
 func TestResource_Superset(t *testing.T) {
 	r1 := &Resources{
-		CPU:      2.0,
+		CPU:      2000,
 		MemoryMB: 2048,
 		DiskMB:   10000,
 		IOPS:     100,
 	}
 	r2 := &Resources{
-		CPU:      1.0,
+		CPU:      2000,
 		MemoryMB: 1024,
 		DiskMB:   5000,
 		IOPS:     50,
@@ -174,7 +174,7 @@ func TestResource_Superset(t *testing.T) {
 
 func TestResource_Add(t *testing.T) {
 	r1 := &Resources{
-		CPU:      2.0,
+		CPU:      2000,
 		MemoryMB: 2048,
 		DiskMB:   10000,
 		IOPS:     100,
@@ -187,7 +187,7 @@ func TestResource_Add(t *testing.T) {
 		},
 	}
 	r2 := &Resources{
-		CPU:      1.0,
+		CPU:      2000,
 		MemoryMB: 1024,
 		DiskMB:   5000,
 		IOPS:     50,
@@ -206,7 +206,7 @@ func TestResource_Add(t *testing.T) {
 	}
 
 	expect := &Resources{
-		CPU:      3.0,
+		CPU:      3000,
 		MemoryMB: 3072,
 		DiskMB:   15000,
 		IOPS:     150,

--- a/scheduler/stack_test.go
+++ b/scheduler/stack_test.go
@@ -67,7 +67,7 @@ func TestServiceStack_Select_Size(t *testing.T) {
 		t.Fatalf("missing size")
 	}
 
-	if size.CPU != 0.5 || size.MemoryMB != 256 {
+	if size.CPU != 500 || size.MemoryMB != 256 {
 		t.Fatalf("bad: %#v", size)
 	}
 


### PR DESCRIPTION
Originally the design was to measure `1.0` as a single core, but that makes no sense given that each CPU has a different frequency. This changed into Mhz \* Cores which then is a number like 4000, so it doesn't make sense to use float anymore.
