### PR TITLE
home: livestream when LIVESTREAM_ACTIVE

### DIFF
--- a/website/config.rb
+++ b/website/config.rb
@@ -2,6 +2,13 @@
 # Configure Middleman
 #-------------------------------------------------------------------------
 
+helpers do
+  def livestream_active?
+    # Must set key for date
+    ENV["LIVESTREAM_ACTIVE"].present?
+  end
+end
+
 set :base_url, "https://www.nomadproject.io/"
 
 activate :hashicorp do |h|

--- a/website/source/assets/stylesheets/_livestream.scss
+++ b/website/source/assets/stylesheets/_livestream.scss
@@ -1,0 +1,38 @@
+body.livestream  {
+    background-color: black;
+}
+
+.livestream-container {
+    display: block;
+}
+
+
+.livestream-video {
+    display: block;
+    margin: 0 auto;
+    max-width: 1000px;
+}
+
+#live-stream-video {
+    margin-top: 15px;
+    border: 0 none transparent;
+    width: 100%;
+    height: 650px;
+
+    @media (min-width: 1200px) {
+      height: 650px;
+    }
+
+    @media (max-width: 992px) {
+      height: 500px;
+    }
+
+    @media (max-width: 768px) {
+      height: 325px;
+    }
+
+    @media (max-width: 422px) {
+      height: 225px;
+    }
+}
+

--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -28,3 +28,4 @@
 @import '_docs';
 @import '_downloads';
 @import '_api';
+@import '_livestream';

--- a/website/source/layouts/_meta.erb
+++ b/website/source/layouts/_meta.erb
@@ -18,4 +18,4 @@
     <%= yield_content :head %>
   </head>
 
-  <body id="page-<%= current_page.data.page_title ? "#{current_page.data.page_title}" : "home" %>" class="page-<%= current_page.data.page_title ? "#{current_page.data.page_title} layout-#{current_page.data.layout} page-sub" : "home layout-#{current_page.data.layout}" %>">
+  <body id="page-<%= current_page.data.page_title ? "#{current_page.data.page_title}" : "home" %>" class="<%= yield_content(:body_class) %> page-<%= current_page.data.page_title ? "#{current_page.data.page_title} layout-#{current_page.data.layout} page-sub" : "home layout-#{current_page.data.layout}" %>">

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -1,3 +1,19 @@
+<% if livestream_active? %>
+<% content_for(:body_class, "livestream") %>
+
+<%= partial "layouts/meta" %>
+<div class="livestream-container">
+    <div class="livestream-video">
+        <iframe src="https://www.ustream.tv/embed/21243866?html5ui=1" id="live-stream-video" webkitallowfullscreen allowfullscreen frameborder="no"></iframe>
+    </div>
+</div>
+
+<!-- closing tags from layouts/meta, keep this -->
+</body>
+</html>
+
+<% else %>
+
 <%= partial "layouts/meta" %>
 <%= partial "layouts/header" %>
 <%= partial "layouts/sidebar" %>
@@ -5,3 +21,4 @@
 <%= yield %>
 
 <%= partial "layouts/footer" %>
+<% end %>


### PR DESCRIPTION
This adds some stuff to takeover the whole site with
an embedded livestream. Our press goes out at 10am with links
to this website embedded in releases, but we don't want
to have folks see it until the keynote is concluded.

Unsetting LIVESTREAM_ACTIVE and re-deploying will
open it up.

Also fixed a configuration option.

You can test it out with:

LIVESTREAM_ACTIVE=true bundle exec middleman server
