### PR TITLE
nomad: fix error printing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -246,7 +246,7 @@ func (c *Client) pickServer() (net.Addr, error) {
 			c.lastRPCTime = time.Now()
 			return addr, nil
 		}
-		c.logger.Printf("[WARN] client: failed to resolve '%s': %s", servers[i], err)
+		c.logger.Printf("[WARN] client: failed to resolve '%s': %v", servers[i], err)
 	}
 
 	// Bail if we reach this point

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -226,7 +226,7 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 		authOptions := docker.AuthConfiguration{}
 		err = client.PullImage(pullOptions, authOptions)
 		if err != nil {
-			d.logger.Printf("[ERR] driver.docker: pulling container %s", err)
+			d.logger.Printf("[ERR] driver.docker: pulling container %v", err)
 			return nil, fmt.Errorf("Failed to pull `%s`: %s", image, err)
 		}
 		d.logger.Printf("[DEBUG] driver.docker: docker pull %s:%s succeeded", repo, tag)
@@ -244,7 +244,7 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 	// Create a container
 	container, err := client.CreateContainer(createContainer(ctx, task, d.logger))
 	if err != nil {
-		d.logger.Printf("[ERR] driver.docker: %s", err)
+		d.logger.Printf("[ERR] driver.docker: %v", err)
 		return nil, fmt.Errorf("Failed to create container from image %s", image)
 	}
 	d.logger.Printf("[INFO] driver.docker: created container %s", container.ID)
@@ -341,7 +341,7 @@ func (h *dockerHandle) ID() string {
 	}
 	data, err := json.Marshal(pid)
 	if err != nil {
-		h.logger.Printf("[ERR] driver.docker: failed to marshal docker PID to JSON: %s", err)
+		h.logger.Printf("[ERR] driver.docker: failed to marshal docker PID to JSON: %v", err)
 	}
 	return fmt.Sprintf("DOCKER:%s", string(data))
 }

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -283,7 +283,7 @@ func (h *qemuHandle) ID() string {
 	}
 	data, err := json.Marshal(pid)
 	if err != nil {
-		log.Printf("[ERR] failed to marshal Qemu PID to JSON: %s", err)
+		log.Printf("[ERR] failed to marshal Qemu PID to JSON: %v", err)
 	}
 	return fmt.Sprintf("QEMU:%s", string(data))
 }

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -105,7 +105,7 @@ func TestQemuDriver_Start(t *testing.T) {
 
 	// Clean up
 	if err := handle.Kill(); err != nil {
-		fmt.Printf("\nError killing Qemu test: %s", err)
+		fmt.Printf("\nError killing Qemu test: %v", err)
 	}
 }
 

--- a/client/fingerprint/consul_test.go
+++ b/client/fingerprint/consul_test.go
@@ -31,7 +31,7 @@ func TestConsulFingerprint(t *testing.T) {
 
 	ok, err := fp.Fingerprint(consulConfig, node)
 	if err != nil {
-		t.Fatalf("Failed to fingerprint: %s", err)
+		t.Fatalf("Failed to fingerprint: %v", err)
 	}
 	if !ok {
 		t.Fatalf("Failed to apply node attributes")

--- a/client/fingerprint/fingerprint_test.go
+++ b/client/fingerprint/fingerprint_test.go
@@ -18,7 +18,7 @@ func testLogger() *log.Logger {
 func assertFingerprintOK(t *testing.T, fp Fingerprint, node *structs.Node) {
 	ok, err := fp.Fingerprint(new(config.Config), node)
 	if err != nil {
-		t.Fatalf("Failed to fingerprint: %s", err)
+		t.Fatalf("Failed to fingerprint: %v", err)
 	}
 	if !ok {
 		t.Fatalf("Failed to apply node attributes")

--- a/client/fingerprint/memory.go
+++ b/client/fingerprint/memory.go
@@ -25,7 +25,7 @@ func NewMemoryFingerprint(logger *log.Logger) Fingerprint {
 func (f *MemoryFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
 	memInfo, err := mem.VirtualMemory()
 	if err != nil {
-		f.logger.Println("[WARN] Error reading memory information: %s", err)
+		f.logger.Printf("[WARN] Error reading memory information: %v", err)
 		return false, err
 	}
 

--- a/client/fingerprint/network_unix.go
+++ b/client/fingerprint/network_unix.go
@@ -145,7 +145,7 @@ func (f *NetworkFingerprint) linkSpeedEthtool(path, device string) int {
 			return mbs
 		}
 	}
-	f.logger.Printf("[ERR] fingerprint.network: Error calling ethtool (%s): %s", path, err)
+	f.logger.Printf("[ERR] fingerprint.network: Error calling ethtool (%s): %v", path, err)
 	return 0
 }
 
@@ -184,7 +184,7 @@ func (f *NetworkFingerprint) ifConfig(device string) string {
 				return ip
 			}
 		}
-		f.logger.Printf("[ERR] fingerprint.network: Error calling ifconfig (%s): %s", ifConfigPath, err)
+		f.logger.Printf("[ERR] fingerprint.network: Error calling ifconfig (%s): %v", ifConfigPath, err)
 		return ""
 	}
 

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -134,7 +134,7 @@ func (r *TaskRunner) createDriver() (driver.Driver, error) {
 	if err != nil {
 		err = fmt.Errorf("failed to create driver '%s' for alloc %s: %v",
 			r.task.Driver, r.allocID, err)
-		r.logger.Printf("[ERR] client: %s", err)
+		r.logger.Printf("[ERR] client: %v", err)
 	}
 	return driver, err
 }

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -199,7 +199,7 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer) error {
 	c.Ui.Output("Starting Nomad agent...")
 	agent, err := NewAgent(config, logOutput)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error starting agent: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error starting agent: %v", err))
 		return err
 	}
 	c.agent = agent
@@ -207,7 +207,7 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer) error {
 	// Enable the SCADA integration
 	if err := c.setupSCADA(config); err != nil {
 		agent.Shutdown()
-		c.Ui.Error(fmt.Sprintf("Error starting SCADA: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error starting SCADA: %v", err))
 		return err
 	}
 
@@ -215,7 +215,7 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer) error {
 	http, err := NewHTTPServer(agent, config, logOutput)
 	if err != nil {
 		agent.Shutdown()
-		c.Ui.Error(fmt.Sprintf("Error starting http server: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error starting http server: %v", err))
 		return err
 	}
 	c.httpServer = http
@@ -288,7 +288,7 @@ func (c *Command) Run(args []string) int {
 
 	// Initialize the telemetry
 	if err := c.setupTelementry(config); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing telemetry: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing telemetry: %v", err))
 		return 1
 	}
 
@@ -395,7 +395,7 @@ WAIT:
 	c.Ui.Output("Gracefully shutting down agent...")
 	go func() {
 		if err := c.agent.Leave(); err != nil {
-			c.Ui.Error(fmt.Sprintf("Error: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error: %v", err))
 			return
 		}
 		close(gracefulCh)

--- a/command/agent_info.go
+++ b/command/agent_info.go
@@ -42,14 +42,14 @@ func (c *AgentInfoCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
 	// Query the agent info
 	info, err := client.Agent().Self()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error querying agent info: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error querying agent info: %v", err))
 		return 1
 	}
 

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -46,14 +46,14 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
 	// Query the allocation info
 	alloc, _, err := client.Allocations().Info(allocID, nil)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error querying allocation: %v", err))
 		return 1
 	}
 

--- a/command/client_config.go
+++ b/command/client_config.go
@@ -70,7 +70,7 @@ func (c *ClientConfigCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
@@ -83,7 +83,7 @@ func (c *ClientConfigCommand) Run(args []string) int {
 
 		// Set the servers list
 		if err := client.Agent().SetServers(args); err != nil {
-			c.Ui.Error(fmt.Sprintf("Error updating server list: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error updating server list: %v", err))
 			return 1
 		}
 		return 0
@@ -93,7 +93,7 @@ func (c *ClientConfigCommand) Run(args []string) int {
 		// Query the current server list
 		servers, err := client.Agent().Servers()
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error querying server list: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error querying server list: %v", err))
 			return 1
 		}
 

--- a/command/eval_monitor.go
+++ b/command/eval_monitor.go
@@ -55,7 +55,7 @@ func (c *EvalMonitorCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -182,7 +182,7 @@ func (m *monitor) monitor(evalID string) int {
 		// Query the evaluation
 		eval, _, err := m.client.Evaluations().Info(evalID, nil)
 		if err != nil {
-			m.ui.Error(fmt.Sprintf("Error reading evaluation: %s", err))
+			m.ui.Error(fmt.Sprintf("Error reading evaluation: %v", err))
 			return 1
 		}
 
@@ -198,7 +198,7 @@ func (m *monitor) monitor(evalID string) int {
 		// Query the allocations associated with the evaluation
 		allocs, _, err := m.client.Evaluations().Allocations(evalID, nil)
 		if err != nil {
-			m.ui.Error(fmt.Sprintf("Error reading allocations: %s", err))
+			m.ui.Error(fmt.Sprintf("Error reading allocations: %v", err))
 			return 1
 		}
 
@@ -221,7 +221,7 @@ func (m *monitor) monitor(evalID string) int {
 				schedFailure = true
 				failed, _, err := m.client.Allocations().Info(alloc.ID, nil)
 				if err != nil {
-					m.ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
+					m.ui.Error(fmt.Sprintf("Error querying allocation: %v", err))
 					return 1
 				}
 				state.allocs[alloc.ID].full = failed

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -64,13 +64,13 @@ func (c *NodeDrainCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
 	// Toggle node draining
 	if _, err := client.Nodes().ToggleDrain(nodeID, enable, nil); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error toggling drain mode: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error toggling drain mode: %v", err))
 		return 1
 	}
 	return 0

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -59,7 +59,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
@@ -68,7 +68,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		// Query the node info
 		nodes, _, err := client.Nodes().List(nil)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error querying node status: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error querying node status: %v", err))
 			return 1
 		}
 
@@ -99,7 +99,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 	nodeID := args[0]
 	node, _, err := client.Nodes().Info(nodeID, nil)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error querying node info: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error querying node info: %v", err))
 		return 1
 	}
 
@@ -118,7 +118,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		// Query the node allocations
 		nodeAllocs, _, err := client.Nodes().Allocations(nodeID, nil)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error querying node allocations: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error querying node allocations: %v", err))
 			return 1
 		}
 

--- a/command/run.go
+++ b/command/run.go
@@ -76,34 +76,34 @@ func (c *RunCommand) Run(args []string) int {
 	// Parse the job file
 	job, err := jobspec.ParseFile(file)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error parsing job file %s: %s", file, err))
+		c.Ui.Error(fmt.Sprintf("Error parsing job file %s: %v", file, err))
 		return 1
 	}
 
 	// Check that the job is valid
 	if err := job.Validate(); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error validating job: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error validating job: %v", err))
 		return 1
 	}
 
 	// Convert it to something we can use
 	apiJob, err := convertJob(job)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error converting job: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error converting job: %v", err))
 		return 1
 	}
 
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
 	// Submit the job
 	evalID, _, err := client.Jobs().Register(apiJob, nil)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error submitting job: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error submitting job: %v", err))
 		return 1
 	}
 

--- a/command/server_force_leave.go
+++ b/command/server_force_leave.go
@@ -46,13 +46,13 @@ func (c *ServerForceLeaveCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
 	// Call force-leave on the node
 	if err := client.Agent().ForceLeave(node); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error force-leaving server %s: %s", node, err))
+		c.Ui.Error(fmt.Sprintf("Error force-leaving server %s: %v", node, err))
 		return 1
 	}
 

--- a/command/server_join.go
+++ b/command/server_join.go
@@ -47,14 +47,14 @@ func (c *ServerJoinCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
 	// Attempt the join
 	n, err := client.Agent().Join(nodes...)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error joining: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error joining: %v", err))
 		return 1
 	}
 

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -57,14 +57,14 @@ func (c *ServerMembersCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
 	// Query the members
 	mem, err := client.Agent().Members()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error querying servers: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error querying servers: %v", err))
 		return 1
 	}
 

--- a/command/status.go
+++ b/command/status.go
@@ -55,7 +55,7 @@ func (c *StatusCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
@@ -63,7 +63,7 @@ func (c *StatusCommand) Run(args []string) int {
 	if len(args) == 0 {
 		jobs, _, err := client.Jobs().List(nil)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error querying jobs: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error querying jobs: %v", err))
 			return 1
 		}
 
@@ -89,7 +89,7 @@ func (c *StatusCommand) Run(args []string) int {
 	jobID := args[0]
 	job, _, err := client.Jobs().Info(jobID, nil)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error querying job: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error querying job: %v", err))
 		return 1
 	}
 
@@ -108,14 +108,14 @@ func (c *StatusCommand) Run(args []string) int {
 		// Query the evaluations
 		jobEvals, _, err := client.Jobs().Evaluations(jobID, nil)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error querying job evaluations: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error querying job evaluations: %v", err))
 			return 1
 		}
 
 		// Query the allocations
 		jobAllocs, _, err := client.Jobs().Allocations(jobID, nil)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error querying job allocations: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error querying job allocations: %v", err))
 			return 1
 		}
 

--- a/command/stop.go
+++ b/command/stop.go
@@ -60,20 +60,20 @@ func (c *StopCommand) Run(args []string) int {
 	// Get the HTTP client
 	client, err := c.Meta.Client()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
 		return 1
 	}
 
 	// Check if the job exists
 	if _, _, err := client.Jobs().Info(jobID, nil); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error deregistering job: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error deregistering job: %v", err))
 		return 1
 	}
 
 	// Invoke the stop
 	evalID, _, err := client.Jobs().Deregister(jobID, nil)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error deregistering job: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error deregistering job: %v", err))
 		return 1
 	}
 

--- a/command/validate.go
+++ b/command/validate.go
@@ -44,13 +44,13 @@ func (c *ValidateCommand) Run(args []string) int {
 	// Parse the job file
 	job, err := jobspec.ParseFile(file)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error parsing job file %s: %s", file, err))
+		c.Ui.Error(fmt.Sprintf("Error parsing job file %s: %v", file, err))
 		return 1
 	}
 
 	// Check that the job is valid
 	if err := job.Validate(); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error validating job: %s", err))
+		c.Ui.Error(fmt.Sprintf("Error validating job: %v", err))
 		return 1
 	}
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func RunCustom(args []string, commands map[string]cli.CommandFactory) int {
 
 	exitCode, err := cli.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error executing CLI: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Error executing CLI: %v\n", err)
 		return 1
 	}
 	return exitCode

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -183,14 +183,14 @@ func NewServer(config *Config) (*Server, error) {
 	// TODO: TLS...
 	if err := s.setupRPC(nil); err != nil {
 		s.Shutdown()
-		logger.Printf("[ERR] nomad: failed to start RPC layer: %s", err)
+		logger.Printf("[ERR] nomad: failed to start RPC layer: %v", err)
 		return nil, fmt.Errorf("Failed to start RPC layer: %v", err)
 	}
 
 	// Initialize the Raft server
 	if err := s.setupRaft(); err != nil {
 		s.Shutdown()
-		logger.Printf("[ERR] nomad: failed to start Raft: %s", err)
+		logger.Printf("[ERR] nomad: failed to start Raft: %v", err)
 		return nil, fmt.Errorf("Failed to start Raft: %v", err)
 	}
 
@@ -198,14 +198,14 @@ func NewServer(config *Config) (*Server, error) {
 	s.serf, err = s.setupSerf(config.SerfConfig, s.eventCh, serfSnapshot)
 	if err != nil {
 		s.Shutdown()
-		logger.Printf("[ERR] nomad: failed to start serf WAN: %s", err)
+		logger.Printf("[ERR] nomad: failed to start serf WAN: %v", err)
 		return nil, fmt.Errorf("Failed to start serf: %v", err)
 	}
 
 	// Intialize the scheduling workers
 	if err := s.setupWorkers(); err != nil {
 		s.Shutdown()
-		logger.Printf("[ERR] nomad: failed to start workers: %s", err)
+		logger.Printf("[ERR] nomad: failed to start workers: %v", err)
 		return nil, fmt.Errorf("Failed to start workers: %v", err)
 	}
 
@@ -253,7 +253,7 @@ func (s *Server) Shutdown() error {
 		s.raftLayer.Close()
 		future := s.raft.Shutdown()
 		if err := future.Error(); err != nil {
-			s.logger.Printf("[WARN] nomad: Error shutting down raft: %s", err)
+			s.logger.Printf("[WARN] nomad: Error shutting down raft: %v", err)
 		}
 		if s.raftStore != nil {
 			s.raftStore.Close()

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -192,7 +192,7 @@ OUTER:
 				offer, err := netIdx.AssignNetwork(ask)
 				if offer == nil {
 					iter.ctx.Metrics().ExhaustedNode(option.Node,
-						fmt.Sprintf("network: %s", err))
+						fmt.Sprintf("network: %v", err))
 					continue OUTER
 				}
 


### PR DESCRIPTION
There were a lot of places where an error was printed with `%s` format which results in output like `%!s(<nil>)`.

I fixed those that matched `grep -n '[Pp]rint' $(find -name '*.go') | egrep -v '%(#?)v' | grep '%s' | grep err`.