### PR TITLE
Improve link speed fingerprint error reporting

### DIFF
--- a/client/fingerprint/network_unix.go
+++ b/client/fingerprint/network_unix.go
@@ -146,7 +146,7 @@ func (f *NetworkFingerprint) linkSpeedEthtool(path, device string) int {
 func (f *NetworkFingerprint) ifConfig(device string) string {
 	ifConfigPath, _ := exec.LookPath("ifconfig")
 	if ifConfigPath == "" {
-		f.logger.Println("[WARN] fingerprint.network: Ethtool not found")
+		f.logger.Println("[WARN] fingerprint.network: ifconfig not found")
 		return ""
 	}
 


### PR DESCRIPTION
With disconnected eth0 log output now looks like:

```
[WARN] fingerprint.network: Unable to parse IP in output of '/bin/ifconfig eth0'
[WARN] fingerprint.network: Unable to parse Speed in output of '/usr/sbin/ethtool eth0'
```

In a virtual machine:

```
[WARN] fingerprint.network: Unable to parse Speed in output of '/sbin/ethtool eth0'
[WARN] fingerprint.network: Unable to read link speed from /sys/class/net/eth0/speed
```

I would rebase this after #138 is merged to resolve conflicts.