### PR TITLE
Parse Client config Options

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -192,6 +192,7 @@ func (a *Agent) setupClient() error {
 		conf.AllocDir = a.config.Client.AllocDir
 	}
 	conf.Servers = a.config.Client.Servers
+	conf.Options = a.config.Client.Options
 
 	// Setup the node
 	conf.Node = new(structs.Node)

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -137,6 +137,12 @@ type ClientConfig struct {
 	// NodeClass is used to group the node by class
 	NodeClass string `hcl:"node_class"`
 
+	// Options is used for configuration of nomad internals,
+	// like fingerprinters and drivers. The format is:
+	//
+	//  namespace.option = value
+	Options map[string]string `hcl:"options"`
+
 	// Metadata associated with the node
 	Meta map[string]string `hcl:"meta"`
 }
@@ -387,6 +393,14 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 
 	// Add the servers
 	result.Servers = append(result.Servers, b.Servers...)
+
+	// Add the options map values
+	if result.Options == nil {
+		result.Options = make(map[string]string)
+	}
+	for k, v := range b.Options {
+		result.Options[k] = v
+	}
 
 	// Add the meta map values
 	if result.Meta == nil {

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -201,6 +201,8 @@ configured on server nodes.
   * `node_class`: A string used to logically group client nodes by class. This
     can be used during job placement as a filter. This option is not required
     and has no default.
+  * `options`: This is a key/value mapping of internal configuration for clients,
+    such as for driver configuration.
   * `meta`: This is a key/value mapping of metadata pairs. This is a free-form
     map and can contain any string values.
 


### PR DESCRIPTION
This adds Options to the agent ClientConfig and fixes the merging logic
to include Options, which are required for things like defining the docker endpoint.

- [x] Parse options
- [x] Add `options` key to Client config docs