### PR TITLE
Add docker.use_environment Client option

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -39,9 +39,10 @@ func NewDockerDriver(ctx *DriverContext) Driver {
 
 func (d *DockerDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
 	// Initialize docker API client
-	dockerEndpoint := d.config.ReadDefault("docker.endpoint", "unix:///var/run/docker.sock")
-	client, err := docker.NewClient(dockerEndpoint)
+	client, err := d.dockerClient()
+
 	if err != nil {
+		d.logger.Printf("[DEBUG] driver.docker: could not connect to docker daemon: %v", err)
 		return false, nil
 	}
 
@@ -56,6 +57,7 @@ func (d *DockerDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool
 
 	env, err := client.Version()
 	if err != nil {
+		d.logger.Printf("[DEBUG] driver.docker: could not read version from daemon: %v", err)
 		// Check the "no such file" error if the unix file is missing
 		if strings.Contains(err.Error(), "no such file") {
 			return false, nil
@@ -195,10 +197,9 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 	}
 
 	// Initialize docker API client
-	dockerEndpoint := d.config.ReadDefault("docker.endpoint", "unix:///var/run/docker.sock")
-	client, err := docker.NewClient(dockerEndpoint)
+	client, err := d.dockerClient()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to docker.endpoint (%s): %s", dockerEndpoint, err)
+		return nil, fmt.Errorf("Failed to connect to docker.endpoint (%s): %s", client.Endpoint(), err)
 	}
 
 	repo, tag := docker.ParseRepositoryTag(image)
@@ -292,10 +293,9 @@ func (d *DockerDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, er
 	d.logger.Printf("[INFO] driver.docker: re-attaching to docker process: %s", handleID)
 
 	// Initialize docker API client
-	dockerEndpoint := d.config.ReadDefault("docker.endpoint", "unix:///var/run/docker.sock")
-	client, err := docker.NewClient(dockerEndpoint)
+	client, err := d.dockerClient()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to docker.endpoint (%s): %s", dockerEndpoint, err)
+		return nil, fmt.Errorf("Failed to connect to docker.endpoint (%s): %s", client.Endpoint(), err)
 	}
 
 	// Look for a running container with this ID
@@ -331,6 +331,16 @@ func (d *DockerDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, er
 	}
 	go h.run()
 	return h, nil
+}
+
+// dockerClient returns a configured *docker.Client from the ClientConfig
+func (d *DockerDriver) dockerClient() (*docker.Client, error) {
+	dockerEndpoint := d.config.Read("docker.endpoint")
+	if dockerEndpoint == "" {
+		return docker.NewClientFromEnv()
+	} else {
+		return docker.NewClient(dockerEndpoint)
+	}
 }
 
 func (h *dockerHandle) ID() string {


### PR DESCRIPTION
Tells Nomad docker driver to use the environment for connection configuration. Useful for local development, especially when using Docker Machine.

- [x] ~~Add `docker.use_environment` code path in driver~~
- [x] ~~Add docs~~

**Edit:** Now defaults Nomad to use environment config, which defaults to sockets.

**Note:** Won't work without #140 