### PR TITLE
Prevent df on linux from adding line breaks to output

### DIFF
--- a/client/fingerprint/storage.go
+++ b/client/fingerprint/storage.go
@@ -95,7 +95,15 @@ func (f *StorageFingerprint) Fingerprint(cfg *config.Config, node *structs.Node)
 		}
 
 		// Use -k to standardize the output values between darwin and linux
-		mountOutput, err := exec.Command("df", "-k", path).Output()
+		var dfArgs string
+		if runtime.GOOS == "linux" {
+			// df on linux needs the -P option to prevent linebreaks on long filesystem paths
+			dfArgs = "-kP"
+		} else {
+			dfArgs = "-k"
+		}
+
+		mountOutput, err := exec.Command("df", dfArgs, path).Output()
 		if err != nil {
 			return false, fmt.Errorf("Failed to determine mount point for %s", path)
 		}


### PR DESCRIPTION
This should fix #151. Apologies in advance if this is not idiomatic code, I'm a total go newbie.