### PR TITLE
Fix sidebar nav highlight for Qemu Driver

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -56,7 +56,7 @@
 							<a href="/docs/drivers/java.html">Java</a>
 						</li>
 
-						<li<%= sidebar_current("docs-drivers-qeumu") %>>
+						<li<%= sidebar_current("docs-drivers-qemu") %>>
 							<a href="/docs/drivers/qemu.html">Qemu</a>
 						</li>
 


### PR DESCRIPTION
When you are on the https://www.nomadproject.io/docs/drivers/qemu.html page, the side navbar is not highlighted, minor tweak to fix that issue.