### PR TITLE
Dev/docker envvars

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -44,6 +44,7 @@ type Task struct {
 	Driver      string
 	Config      map[string]string
 	Constraints []*Constraint
+	Env         map[string]string
 	Resources   *Resources
 	Meta        map[string]string
 }

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -153,14 +153,8 @@ func createContainer(ctx *ExecContext, task *structs.Task, logger *log.Logger) d
 		hostConfig.PortBindings = dockerPorts
 	}
 
-	// Merge Nomad-native with user-specified envvars
-	env := TaskEnvironmentVariables(ctx, task).List()
-	for k, v := range task.Env {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
-
 	config := &docker.Config{
-		Env:   env,
+		Env:   TaskEnvironmentVariables(ctx, task).List(),
 		Image: task.Config["image"],
 	}
 

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -153,8 +153,14 @@ func createContainer(ctx *ExecContext, task *structs.Task, logger *log.Logger) d
 		hostConfig.PortBindings = dockerPorts
 	}
 
+	// Merge Nomad-native with user-specified envvars
+	env := TaskEnvironmentVariables(ctx, task).List()
+	for k, v := range task.Env {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	config := &docker.Config{
-		Env:   TaskEnvironmentVariables(ctx, task).List(),
+		Env:   env,
 		Image: task.Config["image"],
 	}
 

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -125,5 +125,9 @@ func TaskEnvironmentVariables(ctx *ExecContext, task *structs.Task) environment.
 		}
 	}
 
+	if task.Env != nil {
+		env.SetEnvvars(task.Env)
+	}
+
 	return env
 }

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -50,6 +50,10 @@ func testDriverExecContext(task *structs.Task, driverCtx *DriverContext) *ExecCo
 func TestDriver_TaskEnvironmentVariables(t *testing.T) {
 	ctx := &ExecContext{}
 	task := &structs.Task{
+		Env: map[string]string{
+			"HELLO": "world",
+			"lorem": "ipsum",
+		},
 		Resources: &structs.Resources{
 			CPU:      1000,
 			MemoryMB: 500,
@@ -76,6 +80,8 @@ func TestDriver_TaskEnvironmentVariables(t *testing.T) {
 		"NOMAD_PORT_5000":       "12345",
 		"NOMAD_META_CHOCOLATE":  "cake",
 		"NOMAD_META_STRAWBERRY": "icecream",
+		"HELLO":                 "world",
+		"LOREM":                 "ipsum",
 	}
 
 	act := env.Map()

--- a/client/driver/environment/vars.go
+++ b/client/driver/environment/vars.go
@@ -99,6 +99,6 @@ func (t TaskEnvironment) SetMeta(m map[string]string) {
 
 func (t TaskEnvironment) SetEnvvars(m map[string]string) {
 	for k, v := range m {
-		t[strings.ToUpper(k)] = v
+		t[k] = v
 	}
 }

--- a/client/driver/environment/vars.go
+++ b/client/driver/environment/vars.go
@@ -96,3 +96,9 @@ func (t TaskEnvironment) SetMeta(m map[string]string) {
 		t[fmt.Sprintf("%s%s", MetaPrefix, strings.ToUpper(k))] = v
 	}
 }
+
+func (t TaskEnvironment) SetEnvvars(m map[string]string) {
+	for k, v := range m {
+		t[strings.ToUpper(k)] = v
+	}
+}

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -284,6 +284,7 @@ func parseTasks(result *[]*structs.Task, obj *hclobj.Object) error {
 			return err
 		}
 		delete(m, "config")
+		delete(m, "env")
 		delete(m, "constraint")
 		delete(m, "meta")
 		delete(m, "resources")
@@ -293,6 +294,19 @@ func parseTasks(result *[]*structs.Task, obj *hclobj.Object) error {
 		t.Name = o.Key
 		if err := mapstructure.WeakDecode(m, &t); err != nil {
 			return err
+		}
+
+		// If we have env, then parse them
+		if o := o.Get("env", false); o != nil {
+			for _, o := range o.Elem(false) {
+				var m map[string]interface{}
+				if err := hcl.DecodeObject(&m, o); err != nil {
+					return err
+				}
+				if err := mapstructure.WeakDecode(m, &t.Env); err != nil {
+					return err
+				}
+			}
 		}
 
 		// If we have config, then parse that

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -86,6 +86,10 @@ func TestParse(t *testing.T) {
 								Config: map[string]string{
 									"image": "hashicorp/binstore",
 								},
+								Env: map[string]string{
+									"HELLO": "world",
+									"LOREM": "ipsum",
+								},
 								Resources: &structs.Resources{
 									CPU:      500,
 									MemoryMB: 128,

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -36,6 +36,10 @@ job "binstore-storagelocker" {
             config {
                 image = "hashicorp/binstore"
             }
+            env {
+              HELLO = "world"
+              PLOP = "coucou"
+            }
             resources {
                 cpu = 500
                 memory = 128

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -38,7 +38,7 @@ job "binstore-storagelocker" {
             }
             env {
               HELLO = "world"
-              PLOP = "coucou"
+              LOREM = "ipsum"
             }
             resources {
                 cpu = 500

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -966,6 +966,9 @@ type Task struct {
 	// Config is provided to the driver to initialize
 	Config map[string]string
 
+	// Map of environment variables to be used by the driver
+	Env map[string]string
+
 	// Constraints can be specified at a task level and apply only to
 	// the particular task.
 	Constraints []*Constraint

--- a/website/source/docs/jobspec/index.html.md
+++ b/website/source/docs/jobspec/index.html.md
@@ -45,6 +45,11 @@ job "my-service" {
             config {
                 image = "hashicorp/web-frontend"
             }
+            env {
+                DB_HOST = "db01.example.com"
+                DB_USER = "web"
+                DB_PASSWORD = "loremipsum"
+            }
             resources {
                 cpu = 500
                 memory = 128
@@ -165,6 +170,9 @@ The `task` object supports the following keys:
 * `config` - A map of key/value configuration passed into the driver
   to start the task. The details of configurations are specific to
   each driver.
+
+* `env` - A map of key/value representing environment variables that
+  will be passed along to the running process.
 
 * `resources` - Provides the resource requirements of the task.
   See the resources reference for more details.


### PR DESCRIPTION
Solves hashicorp/nomad#173. Added a job specification directive, *env*, to add environment variables to a task.

```
task "mytask" {
  env {
    HELLO = "world"
  }
}
```

Also updated Docker driver to add those envvars to the container creation process. I will maybe do the same to the exec driver.