### PR TITLE
Enable setting networking mode for docker

### DIFF
--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -287,3 +287,29 @@ func TestDocker_StartNVersions(t *testing.T) {
 
 	t.Log("==> Test complete!")
 }
+
+func TestDockerHostNet(t *testing.T) {
+        task := &structs.Task{
+                Config: map[string]string{
+                        "image": "redis",
+                        "network_mode": "host",
+                },
+                Resources: &structs.Resources{
+                        MemoryMB: 256,
+                        CPU:      512,
+                        },
+                }
+	driverCtx := testDriverContext(task.Name)
+	ctx := testDriverExecContext(task, driverCtx)
+	defer ctx.AllocDir.Destroy()
+	d := NewDockerDriver(driverCtx)
+
+	handle, err := d.Start(ctx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if handle == nil {
+		t.Fatalf("missing handle")
+	}
+	defer handle.Kill()
+}

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -23,6 +23,11 @@ The `docker` driver supports the following configuration in the job specificatio
 
 * `command` - (Optional) The command to run when starting the container.
 
+* `network_mode` - (Optional) The network mode to be used for the container.
+   Valid options are `net`, `bridge`, `host` or `none`. If nothing is
+   specified, the container will start in `bridge` mode. The `container`
+   network mode is not supported right now.
+
 ### Port Mapping
 
 Nomad uses port binding to expose services running in containers using the port


### PR DESCRIPTION
This patch enables setting networking mode for the docker
driver. This does not handle the `container` mode.
Closes #175