### PR TITLE
Upgrading to Go 1.5.1 for building Nomad in developer VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,8 +19,8 @@ ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
 
 # Install Go
 cd /tmp
-wget -q https://storage.googleapis.com/golang/go1.4.2.linux-${ARCH}.tar.gz
-tar -xf go1.4.2.linux-${ARCH}.tar.gz
+wget -q https://storage.googleapis.com/golang/go1.5.1.linux-${ARCH}.tar.gz
+tar -xf go1.5.1.linux-${ARCH}.tar.gz
 sudo mv go $SRCROOT
 sudo chmod 775 $SRCROOT
 sudo chown vagrant:vagrant $SRCROOT


### PR DESCRIPTION
Which version of GoLang are we using to build Nomad? Please feel free to ignore and close this PR if we are supposed to continue to use 1.4.2 for some reason.