### PR TITLE
Add parsing of client configuration from the commandline

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -104,8 +104,9 @@ func (c *Command) readConfig() *Config {
 	}
 
 	// Parse the meta flags.
-	if len(meta) != 0 {
-		cmdConfig.Client.Meta = make(map[string]string)
+	metaLength := len(meta)
+	if metaLength != 0 {
+		cmdConfig.Client.Meta = make(map[string]string, metaLength)
 		for _, kv := range meta {
 			parts := strings.SplitN(kv, "=", 2)
 			if len(parts) != 2 {

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -164,11 +164,8 @@ func (c *Command) readConfig() *Config {
 		return config
 	}
 
-	// Check for valid modes.
-	if config.Server.Enabled && config.Client.Enabled {
-		c.Ui.Error("To run both as a server and client, use -dev mode.")
-		return nil
-	} else if !(config.Server.Enabled || config.Client.Enabled) {
+	// Check that the server is running in at least one mode.
+	if !(config.Server.Enabled || config.Client.Enabled) {
 		c.Ui.Error("Must specify either server, client or dev mode for the agent.")
 		return nil
 	}
@@ -177,9 +174,11 @@ func (c *Command) readConfig() *Config {
 	if config.Server.Enabled && config.DataDir == "" {
 		c.Ui.Error("Must specify data directory")
 		return nil
-	} else if config.Client.Enabled && config.DataDir == "" {
-		// The config is valid if the top-level data-dir is set or if both
-		// alloc-dir and state-dir are set.
+	}
+
+	// The config is valid if the top-level data-dir is set or if both
+	// alloc-dir and state-dir are set.
+	if config.Client.Enabled && config.DataDir == "" {
 		if config.Client.AllocDir == "" || config.Client.StateDir == "" {
 			c.Ui.Error("Must specify both the state and alloc dir if data-dir is omitted.")
 			return nil

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -50,6 +50,8 @@ type Command struct {
 func (c *Command) readConfig() *Config {
 	var dev bool
 	var configPath []string
+	var servers string
+	var meta []string
 
 	// Make a new, empty config.
 	cmdConfig := &Config{
@@ -75,11 +77,7 @@ func (c *Command) readConfig() *Config {
 	flags.StringVar(&cmdConfig.Client.AllocDir, "alloc-dir", "", "")
 	flags.StringVar(&cmdConfig.Client.NodeID, "node-id", "", "")
 	flags.StringVar(&cmdConfig.Client.NodeClass, "node-class", "", "")
-
-	var servers string
 	flags.StringVar(&servers, "servers", "", "")
-
-	var meta []string
 	flags.Var((*sliceflag.StringFlag)(&meta), "meta", "")
 
 	// General options
@@ -109,7 +107,7 @@ func (c *Command) readConfig() *Config {
 	if len(meta) != 0 {
 		cmdConfig.Client.Meta = make(map[string]string)
 		for _, kv := range meta {
-			parts := strings.Split(kv, "=")
+			parts := strings.SplitN(kv, "=", 2)
 			if len(parts) != 2 {
 				c.Ui.Error(fmt.Sprintf("Error parsing Client.Meta value: %v", kv))
 				return nil

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -27,15 +27,27 @@ func TestCommand_Args(t *testing.T) {
 	tcases := []tcase{
 		{
 			[]string{},
-			"Must specify data directory",
+			"Must specify either server, client or dev mode for the agent.",
 		},
 		{
-			[]string{"-data-dir=" + tmpDir, "-bootstrap-expect=1"},
+			[]string{"-client", "-server"},
+			"To run both as a server and client, use -dev mode.",
+		},
+		{
+			[]string{"-client", "-data-dir=" + tmpDir, "-bootstrap-expect=1"},
 			"Bootstrap requires server mode to be enabled",
 		},
 		{
 			[]string{"-data-dir=" + tmpDir, "-server", "-bootstrap-expect=1"},
 			"WARNING: Bootstrap mode enabled!",
+		},
+		{
+			[]string{"-server"},
+			"Must specify data directory",
+		},
+		{
+			[]string{"-client", "-alloc-dir="},
+			"Must specify both the state and alloc dir if data-dir is omitted.",
 		},
 	}
 	for _, tc := range tcases {

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -30,10 +30,6 @@ func TestCommand_Args(t *testing.T) {
 			"Must specify either server, client or dev mode for the agent.",
 		},
 		{
-			[]string{"-client", "-server"},
-			"To run both as a server and client, use -dev mode.",
-		},
-		{
 			[]string{"-client", "-data-dir=" + tmpDir, "-bootstrap-expect=1"},
 			"Bootstrap requires server mode to be enabled",
 		},


### PR DESCRIPTION
Allows configuring a nomad client agent from the command line. Solves https://github.com/hashicorp/nomad/issues/187