### PR TITLE
Add support of Parallels Desktop for Mac

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,6 +55,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", inline: $script, privileged: false
   config.vm.synced_folder '.', '/opt/gopath/src/github.com/hashicorp/nomad'
 
+  config.vm.provider "parallels" do |p, o|
+    o.vm.box = "parallels/ubuntu-14.04"
+    p.memory = 2048
+  end
+
   config.vm.provider "virtualbox" do |v|
     v.memory = 1024
     v.cpus = 1

--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -29,6 +29,11 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = "nomad"
   config.vm.provision "shell", inline: $script, privileged: false
 
+  # Increase memory for Parallels Desktop
+  config.vm.provider "parallels" do |p, o|
+    p.memory = "1024"
+  end
+
   # Increase memory for Virtualbox
   config.vm.provider "virtualbox" do |vb|
         vb.memory = "1024"


### PR DESCRIPTION
This PR add a basic support of Parallels Desktop to Vagrant environments: to the both "demo" and "build" environments.

Demo environment is currently affected by the issue #146. Test jobs are not allocated du to this:
```
...
    Allocation "ff7fa405-a3bc-79c8-d69a-724a264460c7" status "failed" (0/1 nodes filtered)
      * Resources exhausted on 1 nodes
      * Dimension "network: bandwidth exceeded" exhausted on 1 nodes
...
```

cc: @dadgar 