### PR TITLE
Change to the default redis port and use docker port mapping

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -122,7 +122,7 @@ job "example" {
 				memory = 256 # 256MB
 				network {
 					mbits = 10
-					dynamic_ports = ["redis"]
+					dynamic_ports = ["6379"]
 				}
 			}
 		}


### PR DESCRIPTION
This should make the redis init example work correctly, and eliminate some confusion with port mapping.

Fixes #201