### PR TITLE
Cleanup allocations when in dev mode

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -184,6 +184,15 @@ func (c *Client) Shutdown() error {
 	if c.shutdown {
 		return nil
 	}
+
+	// Destroy all the running allocations.
+	if c.config.DevMode {
+		for _, ar := range c.allocs {
+			ar.Destroy()
+			<-ar.WaitCh()
+		}
+	}
+
 	c.shutdown = true
 	close(c.shutdownCh)
 	c.connPool.Shutdown()


### PR DESCRIPTION
When in dev mode, allocations are destroyed upon client shutdown. This will cleanup alloc dirs and unmount directories mounted by the drivers.