### PR TITLE
Service Discovery Integration

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -41,6 +41,7 @@ func (g *TaskGroup) AddTask(t *Task) *TaskGroup {
 // Task is a single process in a task group.
 type Task struct {
 	Name        string
+	Discover    string
 	Driver      string
 	Config      map[string]string
 	Constraints []*Constraint

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -106,7 +106,9 @@ func (r *AllocRunner) RestoreState() error {
 	var mErr multierror.Error
 	for name := range r.taskStatus {
 		task := &structs.Task{Name: name}
-		tr := NewTaskRunner(r.logger, r.config, r.setTaskStatus, r.ctx, r.alloc.ID, task, r.discovery)
+		tr := NewTaskRunner(
+			r.logger, r.config, r.setTaskStatus, r.ctx, r.alloc.ID,
+			r.alloc.JobID, r.alloc.TaskGroup, task, r.discovery)
 		r.tasks[name] = tr
 		if err := tr.RestoreState(); err != nil {
 			r.logger.Printf("[ERR] client: failed to restore state for alloc %s task '%s': %v", r.alloc.ID, name, err)
@@ -300,7 +302,9 @@ func (r *AllocRunner) Run() {
 		// Merge in the task resources
 		task.Resources = alloc.TaskResources[task.Name]
 
-		tr := NewTaskRunner(r.logger, r.config, r.setTaskStatus, r.ctx, r.alloc.ID, task, r.discovery)
+		tr := NewTaskRunner(
+			r.logger, r.config, r.setTaskStatus, r.ctx, r.alloc.ID,
+			r.alloc.JobID, r.alloc.TaskGroup, task, r.discovery)
 		r.tasks[task.Name] = tr
 		go tr.Run()
 	}

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -38,7 +38,7 @@ type AllocRunner struct {
 	updater AllocStateUpdater
 	logger  *log.Logger
 
-	discovery []discovery.Discovery
+	discovery *discovery.DiscoveryLayer
 
 	alloc *structs.Allocation
 
@@ -68,12 +68,12 @@ type allocRunnerState struct {
 // NewAllocRunner is used to create a new allocation context
 func NewAllocRunner(
 	logger *log.Logger, config *config.Config, updater AllocStateUpdater,
-	discovery []discovery.Discovery, alloc *structs.Allocation) *AllocRunner {
+	disc *discovery.DiscoveryLayer, alloc *structs.Allocation) *AllocRunner {
 	ar := &AllocRunner{
 		config:     config,
 		updater:    updater,
 		logger:     logger,
-		discovery:  discovery,
+		discovery:  disc,
 		alloc:      alloc,
 		dirtyCh:    make(chan struct{}, 1),
 		tasks:      make(map[string]*TaskRunner),

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -31,7 +31,7 @@ func testAllocRunner() (*MockAllocStateUpdater, *AllocRunner) {
 	conf.AllocDir = os.TempDir()
 	upd := &MockAllocStateUpdater{}
 	alloc := mock.Alloc()
-	ar := NewAllocRunner(logger, conf, upd.Update, alloc)
+	ar := NewAllocRunner(logger, conf, upd.Update, nil, alloc)
 	return upd, ar
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -472,13 +472,14 @@ func (c *Client) setupDrivers() error {
 // setupDiscovery sets up the discovery layers and initializes them.
 func (c *Client) setupDiscovery() error {
 	// Create the discovery layer
-	disc, err := discovery.NewDiscoveryLayer(c.config, c.logger, c.config.Node)
+	disc, err := discovery.NewDiscoveryLayer(discovery.Builtins, c.config,
+		c.logger, c.config.Node)
 	if err != nil {
 		return err
 	}
 	c.discovery = disc
 
-	avail := disc.Providers()
+	avail := disc.EnabledProviders()
 	c.logger.Printf("[DEBUG] client: available discovery layers: %v", avail)
 	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -115,6 +115,11 @@ func NewClient(cfg *config.Config) (*Client, error) {
 		return nil, fmt.Errorf("failed intializing client: %v", err)
 	}
 
+	// Setup the node
+	if err := c.setupNode(); err != nil {
+		return nil, fmt.Errorf("node setup failed: %v", err)
+	}
+
 	// Set up service discovery
 	if err := c.setupDiscovery(); err != nil {
 		return nil, fmt.Errorf("discovery setup failed: %v", err)
@@ -123,11 +128,6 @@ func NewClient(cfg *config.Config) (*Client, error) {
 	// Restore the state
 	if err := c.restoreState(); err != nil {
 		return nil, fmt.Errorf("failed to restore state: %v", err)
-	}
-
-	// Setup the node
-	if err := c.setupNode(); err != nil {
-		return nil, fmt.Errorf("node setup failed: %v", err)
 	}
 
 	// Fingerprint the node

--- a/client/client.go
+++ b/client/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/client/discovery"
 	"github.com/hashicorp/nomad/client/driver"
 	"github.com/hashicorp/nomad/client/fingerprint"
 	"github.com/hashicorp/nomad/nomad"
@@ -457,6 +458,22 @@ func (c *Client) setupDrivers() error {
 		}
 	}
 	c.logger.Printf("[DEBUG] client: available drivers %v", avail)
+	return nil
+}
+
+func (c *Client) setupDiscovery() error {
+	var avail []string
+	ctx := discovery.NewContext(c.config, c.logger, c.config.Node)
+	for name, fn := range discovery.Builtins {
+		disc, err := fn(ctx)
+		if err != nil {
+			return err
+		}
+		if disc.Enabled() {
+			avail = append(avail, name)
+		}
+	}
+	c.logger.Printf("[DEBUG] client: available discovery layers: %v", avail)
 	return nil
 }
 

--- a/client/discovery/consul.go
+++ b/client/discovery/consul.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"strings"
+
 	"github.com/hashicorp/consul/api"
 )
 
@@ -57,4 +59,8 @@ func (c *consulDiscovery) Register(name string, port int) error {
 func (c *consulDiscovery) Deregister(name string) error {
 	// Send the deregister request
 	return c.client.Agent().ServiceDeregister(name)
+}
+
+func (c *consulDiscovery) DiscoverName(parts []string) string {
+	return strings.Join(parts, "-")
 }

--- a/client/discovery/consul.go
+++ b/client/discovery/consul.go
@@ -4,19 +4,19 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-// ConsulDiscovery is a back-end for service discovery which can be used
+// consulDiscovery is a back-end for service discovery which can be used
 // to populate a local Consul agent with service information. Because
 // Consul already has information about the local node, some shortcuts
 // can be taken in this back-end. Specifically, the IP address of the Nomad
 // agent does not need to be used, because Consul has this information
 // already and may even be configured to expose services on an alternate
 // advertise address.
-type ConsulDiscovery struct {
-	ctx    *Context
+type consulDiscovery struct {
+	ctx    *context
 	client *api.Client
 }
 
-func NewConsulDiscovery(ctx *Context) (Discovery, error) {
+func newConsulDiscovery(ctx *context) (provider, error) {
 	// Build the config
 	conf := api.DefaultConfig()
 	conf.Datacenter = ctx.node.Datacenter
@@ -31,14 +31,18 @@ func NewConsulDiscovery(ctx *Context) (Discovery, error) {
 	}
 
 	// Create and return the discovery provider
-	return &ConsulDiscovery{ctx, client}, nil
+	return &consulDiscovery{ctx, client}, nil
 }
 
-func (c *ConsulDiscovery) Enabled() bool {
+func (c *consulDiscovery) Name() string {
+	return "consul"
+}
+
+func (c *consulDiscovery) Enabled() bool {
 	return c.ctx.config.Read("discovery.consul.enable") == "true"
 }
 
-func (c *ConsulDiscovery) Register(name string, port int) error {
+func (c *consulDiscovery) Register(name string, port int) error {
 	// Build the service definition
 	svc := &api.AgentServiceRegistration{
 		ID:   name,
@@ -50,7 +54,7 @@ func (c *ConsulDiscovery) Register(name string, port int) error {
 	return c.client.Agent().ServiceRegister(svc)
 }
 
-func (c *ConsulDiscovery) Deregister(name string) error {
+func (c *consulDiscovery) Deregister(name string) error {
 	// Send the deregister request
 	return c.client.Agent().ServiceDeregister(name)
 }

--- a/client/discovery/consul.go
+++ b/client/discovery/consul.go
@@ -18,6 +18,8 @@ type consulDiscovery struct {
 	client *api.Client
 }
 
+// newConsulDiscovery creates a new Consul discovery provider using the
+// configuration provided in the client options.
 func newConsulDiscovery(ctx *context) (provider, error) {
 	// Build the config
 	conf := api.DefaultConfig()
@@ -36,14 +38,20 @@ func newConsulDiscovery(ctx *context) (provider, error) {
 	return &consulDiscovery{ctx, client}, nil
 }
 
+// Name returns the name of the discovery provider.
 func (c *consulDiscovery) Name() string {
 	return "consul"
 }
 
+// Enabled determines if the Consul layer is enabled. This just looks at a
+// client option and doesn't do any connection testing, as Consul may or may
+// not be available at the time of Nomad's start.
 func (c *consulDiscovery) Enabled() bool {
 	return c.ctx.config.Read("discovery.consul.enable") == "true"
 }
 
+// Register registers a service name into a Consul agent. The agent will then
+// sync this definition into the service catalog.
 func (c *consulDiscovery) Register(name string, port int) error {
 	// Build the service definition
 	svc := &api.AgentServiceRegistration{
@@ -56,11 +64,16 @@ func (c *consulDiscovery) Register(name string, port int) error {
 	return c.client.Agent().ServiceRegister(svc)
 }
 
+// Deregister removes a service from the Consul agent. Anti-entropy will
+// then handle deregistering the service from the catalog.
 func (c *consulDiscovery) Deregister(name string) error {
 	// Send the deregister request
 	return c.client.Agent().ServiceDeregister(name)
 }
 
+// DiscoverName returns the service name in Consul, given the parts of the
+// name. This is a simple hyphen-joined string so that we can easily support
+// DNS lookups from Consul.
 func (c *consulDiscovery) DiscoverName(parts []string) string {
 	return strings.Join(parts, "-")
 }

--- a/client/discovery/consul.go
+++ b/client/discovery/consul.go
@@ -39,7 +39,7 @@ func (c *ConsulDiscovery) Enabled() bool {
 	return ok
 }
 
-func (c *ConsulDiscovery) Register(_, name, _ string, port int) error {
+func (c *ConsulDiscovery) Register(name string, port int) error {
 	// Build the service definition
 	svc := &api.AgentServiceRegistration{
 		ID:   name,
@@ -51,7 +51,7 @@ func (c *ConsulDiscovery) Register(_, name, _ string, port int) error {
 	return c.client.Agent().ServiceRegister(svc)
 }
 
-func (c *ConsulDiscovery) Deregister(node, name string) error {
+func (c *ConsulDiscovery) Deregister(name string) error {
 	// Send the deregister request
 	return c.client.Agent().ServiceDeregister(name)
 }

--- a/client/discovery/consul.go
+++ b/client/discovery/consul.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/consul/api"
@@ -52,10 +53,11 @@ func (c *ConsulDiscovery) Enabled() bool {
 
 // Register registers a service name into a Consul agent. The agent will then
 // sync this definition into the service catalog.
-func (c *ConsulDiscovery) Register(name string, port int) error {
+func (c *ConsulDiscovery) Register(allocID, name string, port int) error {
 	// Build the service definition
+	serviceID := fmt.Sprintf("%s:%s", name, allocID)
 	svc := &api.AgentServiceRegistration{
-		ID:   name,
+		ID:   serviceID,
 		Name: name,
 		Port: port,
 	}
@@ -66,9 +68,10 @@ func (c *ConsulDiscovery) Register(name string, port int) error {
 
 // Deregister removes a service from the Consul agent. Anti-entropy will
 // then handle deregistering the service from the catalog.
-func (c *ConsulDiscovery) Deregister(name string) error {
+func (c *ConsulDiscovery) Deregister(allocID, name string) error {
 	// Send the deregister request
-	return c.client.Agent().ServiceDeregister(name)
+	serviceID := fmt.Sprintf("%s:%s", name, allocID)
+	return c.client.Agent().ServiceDeregister(serviceID)
 }
 
 // DiscoverName returns the service name in Consul, given the parts of the

--- a/client/discovery/consul.go
+++ b/client/discovery/consul.go
@@ -34,42 +34,24 @@ func NewConsulDiscovery(ctx *Context) (Discovery, error) {
 }
 
 func (c *ConsulDiscovery) Enabled() bool {
+	return true
 	_, ok := c.ctx.config.Options["discovery.consul.enable"]
 	return ok
 }
 
-func (c *ConsulDiscovery) Register(
-	node, name, addr string,
-	meta map[string]string,
-	port int) error {
-
+func (c *ConsulDiscovery) Register(_, name, _ string, port int) error {
 	// Build the service definition
-	svc := &api.CatalogRegistration{
-		Node:       node,
-		Address:    addr,
-		Datacenter: c.ctx.node.Datacenter,
-		Service: &api.AgentService{
-			ID:      name,
-			Service: name,
-			Port:    port,
-			Address: addr,
-		},
+	svc := &api.AgentServiceRegistration{
+		ID:   name,
+		Name: name,
+		Port: port,
 	}
 
 	// Attempt to register
-	_, err := c.client.Catalog().Register(svc, nil)
-	return err
+	return c.client.Agent().ServiceRegister(svc)
 }
 
 func (c *ConsulDiscovery) Deregister(node, name string) error {
-	// Build the dereg request
-	dereg := &api.CatalogDeregistration{
-		Datacenter: c.ctx.node.Datacenter,
-		Node:       node,
-		ServiceID:  name,
-	}
-
 	// Send the deregister request
-	_, err := c.client.Catalog().Deregister(dereg, nil)
-	return err
+	return c.client.Agent().ServiceDeregister(name)
 }

--- a/client/discovery/consul_test.go
+++ b/client/discovery/consul_test.go
@@ -30,10 +30,14 @@ func TestConsulDiscovery_Register(t *testing.T) {
 	logBuf := new(bytes.Buffer)
 	logger := log.New(logBuf, "", log.LstdFlags)
 	node := &structs.Node{}
-	ctx := NewContext(conf, logger, node)
+	ctx := &context{
+		config: conf,
+		logger: logger,
+		node:   node,
+	}
 
 	// Create the discovery layer
-	disc, err := NewConsulDiscovery(ctx)
+	disc, err := newConsulDiscovery(ctx)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -48,7 +52,7 @@ func TestConsulDiscovery_Register(t *testing.T) {
 		"discovery.consul.enable":  "true",
 		"discovery.consul.address": srv.HTTPAddr,
 	}
-	disc, err = NewConsulDiscovery(ctx)
+	disc, err = newConsulDiscovery(ctx)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/client/discovery/consul_test.go
+++ b/client/discovery/consul_test.go
@@ -63,7 +63,7 @@ func TestConsulDiscovery_Register(t *testing.T) {
 	}
 
 	// Should register a service
-	if err := disc.Register("foobar", 123); err != nil {
+	if err := disc.Register("alloc1", "foobar", 123); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -74,6 +74,9 @@ func TestConsulDiscovery_Register(t *testing.T) {
 	}
 	for _, svc := range services {
 		if svc.Service == "foobar" {
+			if svc.ID != "foobar:alloc1" {
+				t.Fatalf("bad id: %s", svc.ID)
+			}
 			if svc.Port != 123 {
 				t.Fatalf("bad port: %d", svc.Port)
 			}
@@ -84,7 +87,7 @@ func TestConsulDiscovery_Register(t *testing.T) {
 
 REGISTERED:
 	// Deregister the service
-	if err := disc.Deregister("foobar"); err != nil {
+	if err := disc.Deregister("alloc1", "foobar"); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/client/discovery/consul_test.go
+++ b/client/discovery/consul_test.go
@@ -2,7 +2,9 @@ package discovery
 
 import (
 	"bytes"
+	"io"
 	"log"
+	"os"
 	"testing"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -28,16 +30,16 @@ func TestConsulDiscovery_Register(t *testing.T) {
 	// Build the context
 	conf := &config.Config{}
 	logBuf := new(bytes.Buffer)
-	logger := log.New(logBuf, "", log.LstdFlags)
+	logger := log.New(io.MultiWriter(logBuf, os.Stdout), "", log.LstdFlags)
 	node := &structs.Node{}
-	ctx := &context{
+	ctx := Context{
 		config: conf,
 		logger: logger,
 		node:   node,
 	}
 
 	// Create the discovery layer
-	disc, err := newConsulDiscovery(ctx)
+	disc, err := NewConsulDiscovery(ctx)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -52,7 +54,7 @@ func TestConsulDiscovery_Register(t *testing.T) {
 		"discovery.consul.enable":  "true",
 		"discovery.consul.address": srv.HTTPAddr,
 	}
-	disc, err = newConsulDiscovery(ctx)
+	disc, err = NewConsulDiscovery(ctx)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/client/discovery/consul_test.go
+++ b/client/discovery/consul_test.go
@@ -1,0 +1,95 @@
+package discovery
+
+import (
+	"bytes"
+	"log"
+	"testing"
+
+	consulapi "github.com/hashicorp/consul/api"
+	consultest "github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func TestConsulDiscovery_Register(t *testing.T) {
+	srv := consultest.NewTestServerConfig(t, func(c *consultest.TestServerConfig) {
+		c.Bootstrap = false
+	})
+	defer srv.Stop()
+
+	// Make the consul client
+	consulConfig := consulapi.DefaultConfig()
+	consulConfig.Address = srv.HTTPAddr
+	consulClient, err := consulapi.NewClient(consulConfig)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Build the context
+	conf := &config.Config{}
+	logBuf := new(bytes.Buffer)
+	logger := log.New(logBuf, "", log.LstdFlags)
+	node := &structs.Node{}
+	ctx := NewContext(conf, logger, node)
+
+	// Create the discovery layer
+	disc, err := NewConsulDiscovery(ctx)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Returns false if not enabled
+	if disc.Enabled() {
+		t.Fatalf("should not be enabled")
+	}
+
+	// Enable the discovery layer
+	conf.Options = map[string]string{
+		"discovery.consul.enable":  "true",
+		"discovery.consul.address": srv.HTTPAddr,
+	}
+	disc, err = NewConsulDiscovery(ctx)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if !disc.Enabled() {
+		t.Fatalf("should be enabled")
+	}
+
+	// Should register a service
+	if err := disc.Register("foobar", 123); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Check that the service exists
+	services, err := consulClient.Agent().Services()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	for _, svc := range services {
+		if svc.Service == "foobar" {
+			if svc.Port != 123 {
+				t.Fatalf("bad port: %d", svc.Port)
+			}
+			goto REGISTERED
+		}
+	}
+	t.Fatalf("missing service")
+
+REGISTERED:
+	// Deregister the service
+	if err := disc.Deregister("foobar"); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Check that the service is gone
+	services, err = consulClient.Agent().Services()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	for _, svc := range services {
+		if svc.Service == "foobar" {
+			t.Fatalf("foobar service should be deregistered")
+		}
+	}
+}

--- a/client/discovery/discovery.go
+++ b/client/discovery/discovery.go
@@ -1,0 +1,14 @@
+package discovery
+
+// Discovery provides a generic interface which can be used to implement
+// service discovery back-ends in Nomad.
+type Discovery interface {
+	// Register is used to register a new entry into a service discovery
+	// system. The address and port are the location of the service, and
+	// the name is the symbolic name used to query it. The node is the
+	// unique node ID known to Nomad.
+	Register(node, name, address string, port int) error
+
+	// Deregister is used to deregister a service from a discovery system.
+	Deregister(node, name string) error
+}

--- a/client/discovery/discovery.go
+++ b/client/discovery/discovery.go
@@ -26,7 +26,7 @@ type Discovery interface {
 	// system. The address and port are the location of the service, and
 	// the name is the symbolic name used to query it. The node is the
 	// unique node ID known to Nomad.
-	Register(node, name, address string, meta map[string]string, port int) error
+	Register(node, name, address string, port int) error
 
 	// Deregister is used to deregister a service from a discovery system.
 	Deregister(node, name string) error

--- a/client/discovery/discovery.go
+++ b/client/discovery/discovery.go
@@ -7,48 +7,117 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-// Builtins is a set of discovery layer implementations for various
+// builtins is a set of discovery layer implementations for various
 // providers.
-var Builtins = map[string]Factory{
-	"consul": NewConsulDiscovery,
+var builtins = []factory{
+	newConsulDiscovery,
 }
 
-// Factory is a function interface which creates new discovery layers.
-type Factory func(ctx *Context) (Discovery, error)
+// factory is a function interface to create new discovery providers.
+type factory func(ctx *context) (provider, error)
 
-// Discovery provides a generic interface which can be used to implement
+// provider is a generic interface which can be used to implement
 // service discovery back-ends in Nomad.
-type Discovery interface {
+type provider interface {
+	// Name returns the name of the service discovery subsystem. This
+	// is used to identify the system in log messages.
+	Name() string
+
 	// Enabled determines if the discovery layer has been enabled.
 	Enabled() bool
 
 	// Register is used to register a new entry into a service discovery
-	// system. The address and port are the location of the service, and
-	// the name is the symbolic name used to query it. The node is the
-	// unique node ID known to Nomad.
+	// system. Only the name and port are required. The name is a symbolic
+	// name used to refer to the service. The context can be used from
+	// this function for internal node information such as IP address.
 	Register(name string, port int) error
 
 	// Deregister is used to deregister a service from a discovery system.
 	Deregister(name string) error
 }
 
-// Context is used to initialize a discovery backend.
-type Context struct {
+// context is used to initialize a discovery backend.
+type context struct {
 	config *config.Config
 	logger *log.Logger
 	node   *structs.Node
 }
 
-// NewContext is used to create a new DiscoveryContext based
-// on the current settings of the client.
-func NewContext(
+// DiscoveryLayer wraps a set of discovery providers and provides
+// easy calls to register/deregister into all of them.
+type DiscoveryLayer struct {
+	ctx       *context
+	providers []provider
+}
+
+// NewDiscoveryLayer is used to initialize the discovery layer. It
+// automatically initializes all of the built-in providers and
+// checks their configuration.
+func NewDiscoveryLayer(
 	config *config.Config,
 	logger *log.Logger,
-	node *structs.Node) *Context {
+	node *structs.Node) (*DiscoveryLayer, error) {
 
-	return &Context{
+	// Make the context
+	ctx := &context{
 		config: config,
 		logger: logger,
 		node:   node,
+	}
+
+	// Create the DiscoveryLayer
+	dl := &DiscoveryLayer{ctx: ctx}
+
+	// Initialize the providers
+	for _, factory := range builtins {
+		provider, err := factory(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if provider.Enabled() {
+			dl.providers = append(dl.providers, provider)
+		}
+	}
+	return dl, nil
+}
+
+// Providers returns the names of the enabled discovery providers.
+func (d *DiscoveryLayer) Providers() []string {
+	avail := make([]string, len(d.providers))
+	for i, provider := range d.providers {
+		avail[i] = provider.Name()
+	}
+	return avail
+}
+
+// Register iterates all of the providers and registers the given
+// service information with them. If an error is encountered, it is
+// only logged to prevent a single failure from crippling the entire
+// discovery layer.
+func (d *DiscoveryLayer) Register(name string, port int) {
+	for _, disc := range d.providers {
+		if err := disc.Register(name, port); err != nil {
+			d.ctx.logger.Printf(
+				"[ERR] client.discovery: error registering %q with %s: %s",
+				name, disc.Name(), err)
+			return
+		}
+		d.ctx.logger.Printf("[DEBUG] client.discovery: registered %q with %s",
+			name, disc.Name())
+	}
+}
+
+// Deregister is like Register, but removes the named service from
+// the discovery subsystems.
+func (d *DiscoveryLayer) Deregister(name string) {
+	for _, disc := range d.providers {
+		if err := disc.Deregister(name); err != nil {
+			d.ctx.logger.Printf(
+				"[ERR] client.discovery: error deregistering %q from %s: %s",
+				name, disc.Name(), err)
+			return
+		}
+		d.ctx.logger.Printf("[DEBUG] client.discovery: deregistered %q from %s",
+			name, disc.Name())
 	}
 }

--- a/client/discovery/discovery.go
+++ b/client/discovery/discovery.go
@@ -1,14 +1,54 @@
 package discovery
 
+import (
+	"log"
+
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// Builtins is a set of discovery layer implementations for various
+// providers.
+var Builtins = map[string]Factory{
+	"consul": NewConsulDiscovery,
+}
+
+// Factory is a function interface which creates new discovery layers.
+type Factory func(ctx *Context) (Discovery, error)
+
 // Discovery provides a generic interface which can be used to implement
 // service discovery back-ends in Nomad.
 type Discovery interface {
+	// Enabled determines if the discovery layer has been enabled.
+	Enabled() bool
+
 	// Register is used to register a new entry into a service discovery
 	// system. The address and port are the location of the service, and
 	// the name is the symbolic name used to query it. The node is the
 	// unique node ID known to Nomad.
-	Register(node, name, address string, port int) error
+	Register(node, name, address string, meta map[string]string, port int) error
 
 	// Deregister is used to deregister a service from a discovery system.
 	Deregister(node, name string) error
+}
+
+// Context is used to initialize a discovery backend.
+type Context struct {
+	config *config.Config
+	logger *log.Logger
+	node   *structs.Node
+}
+
+// NewContext is used to create a new DiscoveryContext based
+// on the current settings of the client.
+func NewContext(
+	config *config.Config,
+	logger *log.Logger,
+	node *structs.Node) *Context {
+
+	return &Context{
+		config: config,
+		logger: logger,
+		node:   node,
+	}
 }

--- a/client/discovery/discovery.go
+++ b/client/discovery/discovery.go
@@ -26,10 +26,10 @@ type Discovery interface {
 	// system. The address and port are the location of the service, and
 	// the name is the symbolic name used to query it. The node is the
 	// unique node ID known to Nomad.
-	Register(node, name, address string, port int) error
+	Register(name string, port int) error
 
 	// Deregister is used to deregister a service from a discovery system.
-	Deregister(node, name string) error
+	Deregister(name string) error
 }
 
 // Context is used to initialize a discovery backend.

--- a/client/discovery/discovery.go
+++ b/client/discovery/discovery.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/nomad/client/config"
@@ -72,7 +73,8 @@ func NewDiscoveryLayer(
 	for _, factory := range builtins {
 		provider, err := factory(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed initializing %s discovery: %s",
+				provider.Name(), err)
 		}
 		if provider.Enabled() {
 			dl.providers = append(dl.providers, provider)

--- a/client/discovery/discovery.go
+++ b/client/discovery/discovery.go
@@ -9,7 +9,7 @@ import (
 )
 
 // builtins is a set of discovery layer implementations for various
-// providers.
+// providers. Each provider must implement the provider interface.
 var builtins = []factory{
 	newConsulDiscovery,
 }
@@ -21,7 +21,8 @@ type factory func(ctx *context) (provider, error)
 // service discovery back-ends in Nomad.
 type provider interface {
 	// Name returns the type of the service discovery subsystem. This
-	// is used to identify the system in log messages.
+	// is used to identify the system in log messages and usually
+	// returns a static string value.
 	Name() string
 
 	// Enabled determines if the discovery layer has been enabled.
@@ -97,10 +98,9 @@ func (d *DiscoveryLayer) Providers() []string {
 	return avail
 }
 
-// Register iterates all of the providers and registers the given
-// service information with them. If an error is encountered, it is
-// only logged to prevent a single failure from crippling the entire
-// discovery layer.
+// Register iterates all of the providers and registers the given service
+// information with them. If an error is encountered, it is only logged to
+// prevent a single failure from crippling the entire discovery layer.
 func (d *DiscoveryLayer) Register(parts []string, port int) {
 	for _, disc := range d.providers {
 		name := disc.DiscoverName(parts)
@@ -115,8 +115,7 @@ func (d *DiscoveryLayer) Register(parts []string, port int) {
 	}
 }
 
-// Deregister is like Register, but removes the named service from
-// the discovery subsystems.
+// Deregister is like Register, but removes a service from the providers.
 func (d *DiscoveryLayer) Deregister(parts []string) {
 	for _, disc := range d.providers {
 		name := disc.DiscoverName(parts)

--- a/client/discovery/discovery_consul.go
+++ b/client/discovery/discovery_consul.go
@@ -1,0 +1,59 @@
+package discovery
+
+import (
+	"github.com/hashicorp/consul/api"
+)
+
+type ConsulDiscovery struct {
+	client *api.Client
+}
+
+func NewConsulDiscovery() (*ConsulDiscovery, error) {
+	// Build the config
+	conf := api.DefaultConfig()
+
+	// Create the client
+	client, err := api.NewClient(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create and return the discovery provider
+	return &ConsulDiscovery{client}, nil
+}
+
+func (c *ConsulDiscovery) Register(
+	node, name, addr string,
+	meta map[string]string,
+	port int) error {
+
+	// Build the service definition
+	svc := &api.CatalogRegistration{
+		Node:       node,
+		Address:    addr,
+		Datacenter: c.config.Datacenter,
+		Service: &api.AgentService{
+			ID:      name,
+			Service: name,
+			Tags:    meta,
+			Port:    port,
+			Address: addr,
+		},
+	}
+
+	// Attempt to register
+	return c.client.Catalog().Register(svc)
+}
+
+func (c *ConsulDiscovery) Deregister(node, addr, name string) error {
+	// Build the dereg request
+	dereg := &api.CatalogDeregistration{
+		Datacenter: c.config.Datacenter,
+		Node:       node,
+		ServiceID:  name,
+	}
+
+	// Send the deregister request
+	_, err := c.client.Catalog().Deregister(dereg)
+	return err
+}

--- a/client/discovery/discovery_test.go
+++ b/client/discovery/discovery_test.go
@@ -1,0 +1,127 @@
+package discovery
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+)
+
+// mockDiscovery is a basic discovery provider which just logs
+// various things about the calls to it.
+type mockDiscovery struct {
+	registered map[string]int
+	enabled    bool
+	name       string
+}
+
+// newMockDiscovery makes a new MockDiscovery.
+func newMockDiscovery(ctx *context) (provider, error) {
+	return &mockDiscovery{
+		registered: make(map[string]int),
+		enabled:    true,
+		name:       "mock",
+	}, nil
+}
+
+func (m *mockDiscovery) Name() string {
+	return m.name
+}
+
+func (m *mockDiscovery) Enabled() bool {
+	return m.enabled
+}
+
+func (m *mockDiscovery) Register(name string, port int) error {
+	m.registered[name] = port
+	return nil
+}
+
+func (m *mockDiscovery) Deregister(name string) error {
+	delete(m.registered, name)
+	return nil
+}
+
+// newDisabledMockDiscovery makes a new discovery provider which
+// is disabled.
+func newDisabledMockDiscovery(ctx *context) (provider, error) {
+	return &mockDiscovery{
+		registered: make(map[string]int),
+		enabled:    false,
+		name:       "disabled_mock",
+	}, nil
+}
+
+// newErrorMockDiscovery makes a new discovery provider which
+// returns an error on creation.
+func newErrorMockDiscovery(ctx *context) (provider, error) {
+	disc := &mockDiscovery{
+		registered: make(map[string]int),
+		enabled:    true,
+		name:       "error_mock",
+	}
+	err := errors.New("failed")
+	return disc, err
+}
+
+func TestDiscoveryLayer_Fails(t *testing.T) {
+	builtins = []factory{
+		newMockDiscovery,
+		newDisabledMockDiscovery,
+		newErrorMockDiscovery,
+	}
+
+	// Returns error if a layer fails to initialize
+	dl, err := NewDiscoveryLayer(nil, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "error_mock") {
+		t.Fatalf("expected mock discovery error, got: %#v", err)
+	}
+	if dl != nil {
+		t.Fatalf("discovery layer should be nil")
+	}
+}
+
+func TestDiscoveryLayer(t *testing.T) {
+	builtins = []factory{
+		newMockDiscovery,
+		newDisabledMockDiscovery,
+	}
+
+	// Create a logger
+	logBuf := new(bytes.Buffer)
+	logger := log.New(logBuf, "", log.LstdFlags)
+
+	// Create the discovery layer
+	dl, err := NewDiscoveryLayer(nil, logger, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Check the enabled providers
+	if p := dl.Providers(); len(p) != 1 || p[0] != "mock" {
+		t.Fatalf("expected only mock provider, got: %v", p)
+	}
+	provider := dl.providers[0].(*mockDiscovery)
+
+	// Register a service
+	dl.Register("foobar", 123)
+	if port, ok := provider.registered["foobar"]; !ok || port != 123 {
+		t.Fatalf("bad registered services: %v", provider.registered)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, `registered "foobar" with mock`) {
+		t.Fatalf("should log registration\n\n%s", logs)
+	}
+	logBuf.Reset()
+
+	// Deregister the service
+	dl.Deregister("foobar")
+	if _, ok := provider.registered["foobar"]; ok {
+		t.Fatalf("should deregister")
+	}
+	logs = logBuf.String()
+	if !strings.Contains(logs, `deregistered "foobar" from mock`) {
+		t.Fatalf("should log deregistration\n\n%s", logs)
+	}
+}

--- a/client/discovery/discovery_test.go
+++ b/client/discovery/discovery_test.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"log"
 	"os"
@@ -10,79 +9,15 @@ import (
 	"testing"
 )
 
-// mockDiscovery is a basic discovery provider which just logs
-// various things about the calls to it.
-type mockDiscovery struct {
-	registered map[string]int
-	enabled    bool
-	name       string
-}
-
-// newMockDiscovery makes a new MockDiscovery.
-func newMockDiscovery(ctx *context) (provider, error) {
-	return &mockDiscovery{
-		registered: make(map[string]int),
-		enabled:    true,
-		name:       "mock",
-	}, nil
-}
-
-func (m *mockDiscovery) Name() string {
-	return m.name
-}
-
-func (m *mockDiscovery) Enabled() bool {
-	return m.enabled
-}
-
-func (m *mockDiscovery) DiscoverName(parts []string) string {
-	return strings.Join(parts, ".")
-}
-
-func (m *mockDiscovery) Register(name string, port int) error {
-	m.registered[name] = port
-	return nil
-}
-
-func (m *mockDiscovery) Deregister(name string) error {
-	delete(m.registered, name)
-	return nil
-}
-
-// newDisabledMockDiscovery makes a new discovery provider which
-// is disabled.
-func newDisabledMockDiscovery(ctx *context) (provider, error) {
-	return &mockDiscovery{
-		registered: make(map[string]int),
-		enabled:    false,
-		name:       "disabled_mock",
-	}, nil
-}
-
-// newErrorMockDiscovery makes a new discovery provider which
-// returns an error on creation.
-func newErrorMockDiscovery(ctx *context) (provider, error) {
-	disc := &mockDiscovery{
-		registered: make(map[string]int),
-		enabled:    true,
-		name:       "error_mock",
-	}
-	err := errors.New("failed")
-	return disc, err
-}
-
 func TestDiscoveryLayer_Fails(t *testing.T) {
-	restore := append([]factory{}, builtins...)
-	defer func() { builtins = restore }()
-
-	builtins = []factory{
-		newMockDiscovery,
-		newDisabledMockDiscovery,
-		newErrorMockDiscovery,
+	providers := []Factory{
+		NewMockDiscovery,
+		NewDisabledMockDiscovery,
+		NewErrorMockDiscovery,
 	}
 
 	// Returns error if a layer fails to initialize
-	dl, err := NewDiscoveryLayer(nil, nil, nil)
+	dl, err := NewDiscoveryLayer(providers, nil, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "error_mock") {
 		t.Fatalf("expected mock discovery error, got: %#v", err)
 	}
@@ -92,12 +27,9 @@ func TestDiscoveryLayer_Fails(t *testing.T) {
 }
 
 func TestDiscoveryLayer(t *testing.T) {
-	restore := append([]factory{}, builtins...)
-	defer func() { builtins = restore }()
-
-	builtins = []factory{
-		newMockDiscovery,
-		newDisabledMockDiscovery,
+	providers := []Factory{
+		NewMockDiscovery,
+		NewDisabledMockDiscovery,
 	}
 
 	// Create a logger
@@ -105,21 +37,21 @@ func TestDiscoveryLayer(t *testing.T) {
 	logger := log.New(io.MultiWriter(logBuf, os.Stdout), "", log.LstdFlags)
 
 	// Create the discovery layer
-	dl, err := NewDiscoveryLayer(nil, logger, nil)
+	dl, err := NewDiscoveryLayer(providers, nil, logger, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	// Check the enabled providers
-	if p := dl.Providers(); len(p) != 1 || p[0] != "mock" {
+	if p := dl.EnabledProviders(); len(p) != 1 || p[0] != "mock" {
 		t.Fatalf("expected only mock provider, got: %v", p)
 	}
-	provider := dl.providers[0].(*mockDiscovery)
+	provider := dl.Providers[0].(*MockDiscovery)
 
 	// Register a service
 	dl.Register([]string{"foo", "bar"}, 123)
-	if port, ok := provider.registered["foo.bar"]; !ok || port != 123 {
-		t.Fatalf("bad registered services: %v", provider.registered)
+	if port, ok := provider.Registered["foo.bar"]; !ok || port != 123 {
+		t.Fatalf("bad registered services: %v", provider.Registered)
 	}
 	logs := logBuf.String()
 	if !strings.Contains(logs, `registered "foo.bar" with mock`) {
@@ -129,7 +61,7 @@ func TestDiscoveryLayer(t *testing.T) {
 
 	// Deregister the service
 	dl.Deregister([]string{"foo", "bar"})
-	if _, ok := provider.registered["foo.bar"]; ok {
+	if _, ok := provider.Registered["foo.bar"]; ok {
 		t.Fatalf("should deregister")
 	}
 	logs = logBuf.String()

--- a/client/discovery/discovery_test.go
+++ b/client/discovery/discovery_test.go
@@ -49,23 +49,23 @@ func TestDiscoveryLayer(t *testing.T) {
 	provider := dl.Providers[0].(*MockDiscovery)
 
 	// Register a service
-	dl.Register([]string{"foo", "bar"}, 123)
-	if port, ok := provider.Registered["foo.bar"]; !ok || port != 123 {
+	dl.Register("1", []string{"foo", "bar"}, 123)
+	if port, ok := provider.Registered["foo.bar:1"]; !ok || port != 123 {
 		t.Fatalf("bad registered services: %v", provider.Registered)
 	}
 	logs := logBuf.String()
-	if !strings.Contains(logs, `registered "foo.bar" with mock`) {
+	if !strings.Contains(logs, `registered "foo.bar" with mock (alloc 1)`) {
 		t.Fatalf("should log registration\n\n%s", logs)
 	}
 	logBuf.Reset()
 
 	// Deregister the service
-	dl.Deregister([]string{"foo", "bar"})
-	if _, ok := provider.Registered["foo.bar"]; ok {
+	dl.Deregister("1", []string{"foo", "bar"})
+	if _, ok := provider.Registered["foo.bar:1"]; ok {
 		t.Fatalf("should deregister")
 	}
 	logs = logBuf.String()
-	if !strings.Contains(logs, `deregistered "foo.bar" from mock`) {
+	if !strings.Contains(logs, `deregistered "foo.bar" from mock (alloc 1)`) {
 		t.Fatalf("should log deregistration\n\n%s", logs)
 	}
 }

--- a/client/discovery/discovery_test.go
+++ b/client/discovery/discovery_test.go
@@ -66,6 +66,9 @@ func newErrorMockDiscovery(ctx *context) (provider, error) {
 }
 
 func TestDiscoveryLayer_Fails(t *testing.T) {
+	restore := append([]factory{}, builtins...)
+	defer func() { builtins = restore }()
+
 	builtins = []factory{
 		newMockDiscovery,
 		newDisabledMockDiscovery,
@@ -83,6 +86,9 @@ func TestDiscoveryLayer_Fails(t *testing.T) {
 }
 
 func TestDiscoveryLayer(t *testing.T) {
+	restore := append([]factory{}, builtins...)
+	defer func() { builtins = restore }()
+
 	builtins = []factory{
 		newMockDiscovery,
 		newDisabledMockDiscovery,

--- a/client/discovery/mock.go
+++ b/client/discovery/mock.go
@@ -34,13 +34,13 @@ func (m *MockDiscovery) DiscoverName(parts []string) string {
 	return strings.Join(parts, ".")
 }
 
-func (m *MockDiscovery) Register(name string, port int) error {
-	m.Registered[name] = port
+func (m *MockDiscovery) Register(allocID, name string, port int) error {
+	m.Registered[name+":"+allocID] = port
 	return nil
 }
 
-func (m *MockDiscovery) Deregister(name string) error {
-	delete(m.Registered, name)
+func (m *MockDiscovery) Deregister(allocID, name string) error {
+	delete(m.Registered, name+":"+allocID)
 	return nil
 }
 

--- a/client/discovery/mock.go
+++ b/client/discovery/mock.go
@@ -1,0 +1,67 @@
+package discovery
+
+import (
+	"errors"
+	"strings"
+)
+
+// MockDiscovery is a basic discovery provider which just logs
+// various things about the calls to it.
+type MockDiscovery struct {
+	Registered map[string]int
+	enabled    bool
+	name       string
+}
+
+// NewMockDiscovery makes a new MockDiscovery.
+func NewMockDiscovery(ctx Context) (Provider, error) {
+	return &MockDiscovery{
+		Registered: make(map[string]int),
+		enabled:    true,
+		name:       "mock",
+	}, nil
+}
+
+func (m *MockDiscovery) Name() string {
+	return m.name
+}
+
+func (m *MockDiscovery) Enabled() bool {
+	return m.enabled
+}
+
+func (m *MockDiscovery) DiscoverName(parts []string) string {
+	return strings.Join(parts, ".")
+}
+
+func (m *MockDiscovery) Register(name string, port int) error {
+	m.Registered[name] = port
+	return nil
+}
+
+func (m *MockDiscovery) Deregister(name string) error {
+	delete(m.Registered, name)
+	return nil
+}
+
+// NewDisabledMockDiscovery makes a new discovery provider which
+// is disabled.
+func NewDisabledMockDiscovery(ctx Context) (Provider, error) {
+	return &MockDiscovery{
+		Registered: make(map[string]int),
+		enabled:    false,
+		name:       "disabled_mock",
+	}, nil
+}
+
+// NewErrorMockDiscovery makes a new discovery provider which
+// returns an error on creation.
+func NewErrorMockDiscovery(ctx Context) (Provider, error) {
+	disc := &MockDiscovery{
+		Registered: make(map[string]int),
+		enabled:    true,
+		name:       "error_mock",
+	}
+	err := errors.New("failed")
+	return disc, err
+}

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -263,17 +263,19 @@ func (r *TaskRunner) handleDiscovery(deregister bool) {
 	}
 
 	// Check if we have a specific discovery name, or apply a default.
-	name := r.task.Discover
-	if name == "" {
-		name = fmt.Sprintf("%s-%s-%s", r.jobID, r.taskGroup, r.task.Name)
+	var parts []string
+	if r.task.Discover != "" {
+		parts = []string{r.task.Discover}
+	} else {
+		parts = []string{r.jobID, r.taskGroup, r.task.Name}
 	}
 
 	// Handle registration of the main task. This can be used
 	// to locate apps with static port bindings.
 	if deregister {
-		r.discovery.Deregister(name)
+		r.discovery.Deregister(parts)
 	} else {
-		r.discovery.Register(name, 0)
+		r.discovery.Register(parts, 0)
 	}
 
 	// Register the dynamic ports. These are named ports which
@@ -281,11 +283,11 @@ func (r *TaskRunner) handleDiscovery(deregister bool) {
 	if networks := r.task.Resources.Networks; networks != nil {
 		for _, net := range networks {
 			for dynName, port := range net.MapDynamicPorts() {
-				dynName = fmt.Sprintf("%s-%s", name, dynName)
+				dynParts := append(parts, dynName)
 				if deregister {
-					r.discovery.Deregister(dynName)
+					r.discovery.Deregister(dynParts)
 				} else {
-					r.discovery.Register(dynName, port)
+					r.discovery.Register(dynParts, port)
 				}
 			}
 		}

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -159,6 +159,9 @@ func (r *TaskRunner) startTask() error {
 	}
 	r.handle = handle
 	r.setStatus(structs.AllocClientStatusRunning, "task started")
+
+	// TODO: Register with service discovery
+
 	return nil
 }
 

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -159,9 +159,6 @@ func (r *TaskRunner) startTask() error {
 	}
 	r.handle = handle
 	r.setStatus(structs.AllocClientStatusRunning, "task started")
-
-	// TODO: Register with service discovery
-
 	return nil
 }
 

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -273,9 +273,9 @@ func (r *TaskRunner) handleDiscovery(deregister bool) {
 	// Handle registration of the main task. This can be used
 	// to locate apps with static port bindings.
 	if deregister {
-		r.discovery.Deregister(parts)
+		r.discovery.Deregister(r.allocID, parts)
 	} else {
-		r.discovery.Register(parts, 0)
+		r.discovery.Register(r.allocID, parts, 0)
 	}
 
 	// Register the dynamic ports. These are named ports which
@@ -285,9 +285,9 @@ func (r *TaskRunner) handleDiscovery(deregister bool) {
 			for dynName, port := range net.MapDynamicPorts() {
 				dynParts := append(parts, dynName)
 				if deregister {
-					r.discovery.Deregister(dynParts)
+					r.discovery.Deregister(r.allocID, dynParts)
 				} else {
-					r.discovery.Register(dynParts, port)
+					r.discovery.Register(r.allocID, dynParts, port)
 				}
 			}
 		}

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -204,6 +204,7 @@ func TestTaskRunner_HandleDiscovery(t *testing.T) {
 	_, tr := testTaskRunner()
 
 	// Modify the job so we have predictable results
+	tr.allocID = "1"
 	tr.jobID = "job1"
 	tr.taskGroup = "group1"
 	tr.task.Name = "web"
@@ -227,9 +228,9 @@ func TestTaskRunner_HandleDiscovery(t *testing.T) {
 
 	// Check the result
 	expect := map[string]int{
-		"job1.group1.web":       0,
-		"job1.group1.web.http":  80,
-		"job1.group1.web.https": 443,
+		"job1.group1.web:1":       0,
+		"job1.group1.web.http:1":  80,
+		"job1.group1.web.https:1": 443,
 	}
 	if !reflect.DeepEqual(expect, mp.Registered) {
 		t.Fatalf("bad: %#v", mp.Registered)
@@ -245,9 +246,9 @@ func TestTaskRunner_HandleDiscovery(t *testing.T) {
 	tr.task.Discover = "web"
 	tr.handleDiscovery(false)
 	expect = map[string]int{
-		"web":       0,
-		"web.http":  80,
-		"web.https": 443,
+		"web:1":       0,
+		"web.http:1":  80,
+		"web.https:1": 443,
 	}
 	if !reflect.DeepEqual(expect, mp.Registered) {
 		t.Fatalf("bad: %#v", mp.Registered)

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -52,7 +52,8 @@ func testTaskRunner() (*MockTaskStateUpdater, *TaskRunner) {
 	allocDir.Build([]*structs.Task{task})
 
 	ctx := driver.NewExecContext(allocDir)
-	tr := NewTaskRunner(logger, conf, upd.Update, ctx, alloc.ID, task)
+	tr := NewTaskRunner(logger, conf, upd.Update, ctx, alloc.ID, alloc.JobID,
+		alloc.TaskGroup, task, nil)
 	return upd, tr
 }
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -208,15 +208,6 @@ type AdvertiseAddrs struct {
 	Serf string `hcl:"serf"`
 }
 
-// ConsulConfig is used to describe a connection to an existing Consul
-// cluster. During job registration this configuration can be used to
-// connect to Consul and register services, which is useful for
-// discovery purposes post-deployment.
-type ConsulConfig struct {
-	Address string `hcl:"address"`
-	Token   string `hcl:"token"`
-}
-
 // DevConfig is a Config that is used for dev mode of Nomad.
 func DevConfig() *Config {
 	conf := DefaultConfig()
@@ -425,14 +416,6 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 		result.Meta[k] = v
 	}
 
-	// Apply the consul config
-	if result.Consul == nil && b.Consul != nil {
-		consulConf := *b.Consul
-		result.Consul = &consulConf
-	} else if b.Consul != nil {
-		result.Consul = result.Consul.Merge(b.Consul)
-	}
-
 	return &result
 }
 
@@ -493,19 +476,6 @@ func (a *AdvertiseAddrs) Merge(b *AdvertiseAddrs) *AdvertiseAddrs {
 	}
 	if b.Serf != "" {
 		result.Serf = b.Serf
-	}
-	return &result
-}
-
-// Merge merges two Consul configuration blocks together.
-func (a *ConsulConfig) Merge(b *ConsulConfig) *ConsulConfig {
-	var result ConsulConfig = *a
-
-	if b.Address != "" {
-		result.Address = b.Address
-	}
-	if b.Token != "" {
-		result.Token = b.Token
 	}
 	return &result
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -960,6 +960,15 @@ type Task struct {
 	// Name of the task
 	Name string
 
+	// Discover is a symbolic name which will be used in place of the
+	// default task name when registering a task with a service discovery
+	// system. By default, the job ID, group, and task name are combined
+	// to create a reasonably unique entry. This can be used to create a
+	// more simple name. It is possible that other jobs in the system may
+	// already have this name, so it is important to take care in setting
+	// the correct value.
+	Discover string
+
 	// Driver is used to control which driver is used
 	Driver string
 

--- a/website/source/docs/discovery/consul.html.md
+++ b/website/source/docs/discovery/consul.html.md
@@ -59,7 +59,7 @@ used a dynamic port, labeled `https`, it would also be registered as
 The default prefix is sufficient for uniquely identifying specific tasks,
 however it may be undesirable if a shorter, unique service name can be provided.
 These shorter names may be specified using the
-[discovery](/docs/jobspec/index.html#discovery) argument within a given task
+[discover](/docs/jobspec/index.html#discover) argument within a given task
 definition. For example, if the `discovery = "web"` option is given in the task
 definition, then the entries would instead be registered as `web` and
 `web-https`. **Important**: Take care when specifying an explicit discovery name.

--- a/website/source/docs/discovery/consul.html.md
+++ b/website/source/docs/discovery/consul.html.md
@@ -1,0 +1,67 @@
+---
+layout: "docs"
+page_title: "Discovery with Consul"
+sidebar_current: "docs-discovery-consul"
+description: >
+  Nomad integrates with Consul to provide seamless service discovery for
+  running jobs and tasks.
+---
+
+# Consul Discovery Integration
+
+[Consul](https://consul.io) is a tool for service discovery produced by
+HashiCorp. It is distributed, highly available, and fault tolerant. Consul
+provides a very convenient DNS interface which can be used to query for
+registered nodes and services. Nomad can leverage Consul's service discovery
+abilities using the built-in Consul discovery provider.
+
+In addition to service discovery, Consul also provides rich health checking
+abilities which directly tie into discovery results. A gossip-based failure
+detector is used to provide near real-time updates of node status and
+failures, and route away from them if possible. This means that by simply
+registering a Nomad task with Consul, you are automatically able to query and
+load balance requests using the DNS interface, and avoid routing to unhealthy
+instances.
+
+## Configuration
+
+This discovery provider allows specifying connectivity settings using Nomad's
+[client options](/docs/agent/config.html#options). The following settins are
+configurable:
+
+* `discovery.consul.enable`: If set to `true`, enables the Consul discovery
+  back-end. Defaults to false.
+* `discovery.consul.address`: Specifies the address of the Consul agent to
+  register with. Defaults to `127.0.0.1:8500`.
+* `discovery.consul.scheme`: Specifies the address scheme to use while
+  connecting. Defaults to `http`.
+* `discovery.consul.token`: Specifies a specific Consul ACL token to use for
+  performing service registration operations.
+
+## Registration with a Consul agent
+
+This discovery back-end registers services against a local Consul agent. What
+this means is that the Consul agent's information about the local node,
+including its IP address, are used to register the service. This enables
+leveraging the scalability and health checking abilities that Consul has to
+offer. For more information on how Consul is architected, see the
+[consul architecture](https://consul.io/docs/internals/architecture.html) page.
+
+## Service names with Consul and Nomad
+
+The Consul discovery backend registers tasks using a common task prefix. Dynamic
+ports are registered as separate services by joining the task with the port
+label. For example, a job `job1` with task group `group1`, and a task named
+`task1` would, by default, register as `job1-group1-task1`. If that same task
+used a dynamic port, labeled `https`, it would also be registered as
+`job1-group1-task1-https`.
+
+The default prefix is sufficient for uniquely identifying specific tasks,
+however it may be undesirable if a shorter, unique service name can be provided.
+These shorter names may be specified using the
+[discovery](/docs/jobspec/index.html#discovery) argument within a given task
+definition. For example, if the `discovery = "web"` option is given in the task
+definition, then the entries would instead be registered as `web` and
+`web-https`. **Important**: Take care when specifying an explicit discovery name.
+If the name is not unique, multiple, unrelated tasks may be discovered by the
+same name.

--- a/website/source/docs/discovery/index.html.md
+++ b/website/source/docs/discovery/index.html.md
@@ -1,0 +1,42 @@
+---
+layout: "docs"
+page_title: "Service Discovery"
+sidebar_current: "docs-discovery"
+description: >
+  Service Discovery integration in Nomad enables automatic discovery of
+  running tasks and services.
+---
+
+# Service Discovery
+
+Nomad provides fast and extensible abilities for scheduling work onto machines
+in the cluster. The next logical step in using the application is to query for
+where the service can be found. Typically this involves an IP address and port
+numbers to connect to the service. Nomad itself does not implement or expose
+service discovery primitives, but provides seamless integration with existing
+tools which solve this problem elegantly.
+
+Service discovery integration is optional. The supported providers are detailed
+in this section and can be found in the navigation bar to the left.
+
+## Exposing tasks with service discovery
+
+In the context of service discovery, a task may be simple or complex, depending
+on its networking requirements. A simple service with static port bindings may
+need only a single entry in a discovery back-end. However, tasks which leverage
+Nomad's [dynamic ports](/docs/jobspec/index.html#dynamic_ports) must advertise
+additional information to convey port details to consumers.
+
+The following items will be registered in each enabled discovery back-end:
+
+* Basic task location. This is always registered, but contains no information
+  about network ports. This can be used to locate the node a task is running on
+  if the port is known beforehand by consumers.
+
+* Dynamic ports, by label. If dynamic ports are used within a task, then each
+  port label will be registered with the enabled discovery back-ends. This
+  registration contains the port number allocated at runtime to the
+  task.
+
+Each discovery back-end will handle service registration differently. Refer to
+the specific providers documentation for details.

--- a/website/source/docs/jobspec/index.html.md
+++ b/website/source/docs/jobspec/index.html.md
@@ -159,6 +159,12 @@ The `task` object supports the following keys:
   task. See the [driver documentation](/docs/drivers/index.html) for what
   is available. Examples include "docker", "qemu", "java", and "exec".
 
+* `discover` - An alternative name to use for
+  [service discovery](/docs/discovery/index.html). This name takes the place
+  of the default prefix, which is composed of the job ID, task group, and task
+  name. This is useful if the default discovery name is undesirable. This name
+  should be unique, although this is not enforced.
+
 * `constraint` - This can be provided multiple times to define additional
   constraints. See the constraint reference for more details.
 

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -66,6 +66,14 @@
 					</ul>
                 </li>
 
+				<li<%= sidebar_current("docs-discovery") %>>
+					<a href="/docs/discovery/index.html">Service Discovery</a>
+					<ul class="nav">
+						<li<%= sidebar_current("docs-discovery-consul") %>>
+							<a href="/docs/discovery/consul.html">Consul</a>
+						</li>
+					</ul>
+				</li>
 
 				<li<%= sidebar_current("docs-commands") %>>
 					<a href="/docs/commands/index.html">Commands (CLI)</a>


### PR DESCRIPTION
This implements an additional layer on Nomad clients, which can manage registering and deregistering tasks in a discovery back-end like Consul. This includes Consul integration as well.

I think we may be able to make some adjustments here and in other areas to make this experience nicer.

What currently works:
* Register/deregister when tasks start/end.
* Registration of the task itself (no port information)
* Registration of labeled dynamic ports (port info also registered)

One slightly strange detail is that by default, service registration entries have a long name, like `job1-group1-task1`. I've added a field to override this in the jobspec at the task level so that you can still get names like `db`, `web`, `redis`, etc., however, this opens up the possibility of overlapping names.