### PR TITLE
Added subnet IP address parsing for advertise addresses (eg. 10.1.0.0…

### DIFF
--- a/helper/inet/inet.go
+++ b/helper/inet/inet.go
@@ -1,0 +1,81 @@
+package inet
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+const (
+	advertiseIp = iota
+	advertisePort
+)
+
+const (
+	address = iota
+	cidr
+)
+
+func AdvertiseIpFromSubnet(ip string) (string, error) {
+	// Return raw IP address if it is not in subnet-form
+	if !strings.Contains(ip, "/") {
+		return ip, nil
+	}
+
+	// Split subnet CIDR IP from the port
+	advertiseTokens := strings.Split(ip, ":")
+	if len(advertiseTokens) != 2 {
+		return "", errors.New(fmt.Sprintf("port was not given in advertise subnet: `%s`", ip))
+	}
+
+	// Split subnet IP and CIDR netmask by slash separator
+	ipTokens := strings.Split(advertiseTokens[advertiseIp], "/")
+	if len(ipTokens) != 2 {
+		return "", errors.New(fmt.Sprintf("cannot parse advertise subnet: `%s`", ip))
+	}
+
+	// Parse subnet IP and netmask
+	subnetIp := net.ParseIP(ipTokens[address])
+	if subnetIp == nil {
+		return "", errors.New(fmt.Sprintf("advertise subnet address out of range: `%s`", ipTokens[address]))
+	}
+	subnetCidr, err := strconv.ParseInt(ipTokens[cidr], 10, 32)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("cannot parse advertise subnet CIDR: `%s`", ipTokens[cidr]))
+	}
+
+	subnet := net.IPNet{IP: subnetIp, Mask: net.CIDRMask(int(subnetCidr), 32)}
+	if subnet.Mask == nil {
+		return "", errors.New(fmt.Sprintf("advertise subnet CIDR out of range: `%s`", ipTokens[cidr]))
+	}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", errors.New("could not retrieve interface list")
+	}
+
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			continue
+		}
+
+		// Select the first IP address included in our subnet
+		for _, a := range addrs {
+			switch v := a.(type) {
+			case *net.IPNet:
+				if subnet.Contains(v.IP) {
+					return fmt.Sprintf("%s:%s", v.IP.String(), advertiseTokens[advertisePort]), nil
+				}
+			case *net.IPAddr:
+				if subnet.Contains(v.IP) {
+					return fmt.Sprintf("%s:%s", v.IP.String(), advertiseTokens[advertisePort]), nil
+				}
+			}
+		}
+	}
+
+	return "", errors.New(fmt.Sprintf("found no IP matching `%s` subnet", ip))
+}

--- a/helper/inet/inet_test.go
+++ b/helper/inet/inet_test.go
@@ -5,18 +5,19 @@ import (
 	"testing"
 )
 
-func TestAdvertiseFromSubnet(t *testing.T) {
-	// CIDR is out of range
+func TestAdvertiseFromSubnet_CidrOutOfRange(t *testing.T) {
 	if ad, err := AdvertiseIpFromSubnet("127.0.0.0/43:4648"); err == nil {
 		t.Fatalf("expected advertise subnet error, got: %s", ad)
 	}
+}
 
-	// IP subnet is out of range
+func TestAdvertiseFromSubnet_IpSubnetOutOfRange(t *testing.T) {
 	if ad, err := AdvertiseIpFromSubnet("333.0.0.0/8:4648"); err == nil {
 		t.Fatalf("expected advertise subnet error, got: %s", ad)
 	}
+}
 
-	// Regular unicast IP definition: should return untouched string
+func TestAdvertiseFromSubnet_ShouldPassthrough(t *testing.T) {
 	expected := "127.0.0.1:4648"
 	ad, err := AdvertiseIpFromSubnet(expected)
 	if err != nil {
@@ -25,9 +26,11 @@ func TestAdvertiseFromSubnet(t *testing.T) {
 	if !reflect.DeepEqual(ad, expected) {
 		t.Fatalf("expected to get %s, got %s", expected, ad)
 	}
+}
 
-	// Actual subnet definition: should succeed
-	ad, err = AdvertiseIpFromSubnet("127.0.0.0/8:4648")
+func TestAdvertiseFromSubnet_ShouldPass(t *testing.T) {
+	expected := "127.0.0.1:4648"
+  ad, err := AdvertiseIpFromSubnet("127.0.0.0/8:4648")
 	if err != nil {
 		t.Fatalf("expected success, got: %s", err)
 	}

--- a/helper/inet/inet_test.go
+++ b/helper/inet/inet_test.go
@@ -1,0 +1,37 @@
+package inet
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAdvertiseFromSubnet(t *testing.T) {
+	// CIDR is out of range
+	if ad, err := AdvertiseIpFromSubnet("127.0.0.0/43:4648"); err == nil {
+		t.Fatalf("expected advertise subnet error, got: %s", ad)
+	}
+
+	// IP subnet is out of range
+	if ad, err := AdvertiseIpFromSubnet("333.0.0.0/8:4648"); err == nil {
+		t.Fatalf("expected advertise subnet error, got: %s", ad)
+	}
+
+	// Regular unicast IP definition: should return untouched string
+	expected := "127.0.0.1:4648"
+	ad, err := AdvertiseIpFromSubnet(expected)
+	if err != nil {
+		t.Fatalf("expected success, got: %s", err)
+	}
+	if !reflect.DeepEqual(ad, expected) {
+		t.Fatalf("expected to get %s, got %s", expected, ad)
+	}
+
+	// Actual subnet definition: should succeed
+	ad, err = AdvertiseIpFromSubnet("127.0.0.0/8:4648")
+	if err != nil {
+		t.Fatalf("expected success, got: %s", err)
+	}
+	if !reflect.DeepEqual(ad, expected) {
+		t.Fatalf("expected to get %s, got %s", expected, ad)
+	}
+}

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -84,7 +84,7 @@ nodes, unless otherwise specified:
     TCP and UDP should be routable between the server nodes on this port.
     Defaults to `4648`. Only used on server nodes.
 
-* <a id="addresses">`addresses`</a>: Controls the bind address for individual 
+* <a id="addresses">`addresses`</a>: Controls the bind address for individual
   network services. Any values configured in this block take precedence over the
   default [bind_addr](#bind_addr). The value is a map of IP addresses and
   supports the following keys:
@@ -103,8 +103,10 @@ nodes, unless otherwise specified:
   This can be used to advertise a different address to the peers of a server
   node to support more complex network configurations such as NAT. This
   configuration is optional, and defaults to the bind address of the specific
-  network service if it is not provided. This configuration is only appicable
-  on server nodes. The value is a map of IP addresses and supports the
+  network service if it is not provided. This configuration is only applicable
+  on server nodes. A subnet value with CIDR-form (eg. 10.1.0.0/16:4648) is also
+  accepted; in that case, the first configured IP address contained in that
+  subnet will be selected. The value is a map of IP addresses and supports the
   following keys:
   <br>
   * `rpc`: The address to advertise for the RPC interface. This address should
@@ -154,7 +156,7 @@ configured on client nodes.
   * `enabled`: A boolean indicating if server mode should be enabled for the
     local agent. All other server options depend on this value being set.
     Defaults to `false`.
-  * <a id="bootstrap_expect">`bootstrap_expect`</a>: This is an integer 
+  * <a id="bootstrap_expect">`bootstrap_expect`</a>: This is an integer
     representing the number of server nodes to wait for before bootstrapping. It
     is most common to use the odd-numbered integers `3` or `5` for this value,
     depending on the cluster size. A value of `1` does not provide any fault
@@ -205,7 +207,7 @@ configured on server nodes.
   * <a id="node_class">`node_class`</a>: A string used to logically group client
     nodes by class. This can be used during job placement as a filter. This
     option is not required and has no default.
-  * <a id="meta">`meta`</a>: This is a key/value mapping of metadata pairs. This 
+  * <a id="meta">`meta`</a>: This is a key/value mapping of metadata pairs. This
     is a free-form map and can contain any string values.
 
 ## Atlas Options


### PR DESCRIPTION
This was mentionned in #186 

This pull request adds the possibility of specifying advertise addresses as a subnet in CIDR form. We will iterate through the host's interfaces to find a configured IP address within that subnet and use it for advertising.

I used the form ```10.0.0.0/8:4648``` for the specification, not sure if that's the more readable, comments could be welcome.

Also, I assume the port is given in the advertise address, I don't know if the server config spec allows to specify the advertise address without a port (where we would use the port from the ```ports``` section), I could easily add that feature if necessary.

Regards,
Antoine.