### PR TITLE
Change docker default port to support windows and boot2docker

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -4,12 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"runtime"
 	"strconv"
 	"strings"
 
 	docker "github.com/fsouza/go-dockerclient"
-	opts "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/opts"
 
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -35,20 +33,6 @@ type dockerHandle struct {
 	doneCh           chan struct{}
 }
 
-// getDefaultDockerHost is copied from fsouza. If it were exported we woudn't
-// need this here.
-func getDefaultDockerHost() (string, error) {
-	var defaultHost string
-	if runtime.GOOS == "windows" {
-		// If we do not have a host, default to TCP socket on Windows
-		defaultHost = fmt.Sprintf("tcp://%s:%d", opts.DefaultHTTPHost, opts.DefaultHTTPPort)
-	} else {
-		// If we do not have a host, default to unix socket
-		defaultHost = fmt.Sprintf("unix://%s", opts.DefaultUnixSocket)
-	}
-	return opts.ValidateHost(defaultHost)
-}
-
 func NewDockerDriver(ctx *DriverContext) Driver {
 	return &DockerDriver{*ctx}
 }
@@ -69,7 +53,7 @@ func (d *DockerDriver) dockerClient() (*docker.Client, error) {
 
 	// In prod mode we'll read the docker.endpoint configuration and fall back
 	// on the host-specific default. We do not read from the environment.
-	defaultEndpoint, err := getDefaultDockerHost()
+	defaultEndpoint, err := docker.DefaultDockerHost()
 	if err != nil {
 		return nil, fmt.Errorf("Unable to determine default docker endpoint: %s", err)
 	}

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -256,7 +256,7 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 	// Initialize docker API client
 	client, err := d.dockerClient()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to docker.endpoint (%s): %s", client.Endpoint(), err)
+		return nil, fmt.Errorf("Failed to connect to docker daemon: %s", err)
 	}
 
 	repo, tag := docker.ParseRepositoryTag(image)
@@ -352,7 +352,7 @@ func (d *DockerDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, er
 	// Initialize docker API client
 	client, err := d.dockerClient()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to docker.endpoint (%s): %s", client.Endpoint(), err)
+		return nil, fmt.Errorf("Failed to connect to docker daemon: %s", err)
 	}
 
 	// Look for a running container with this ID

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+func testDockerDriverContext(task string) *DriverContext {
+	cfg := testConfig()
+	cfg.DevMode = true
+	return NewDriverContext(task, cfg, cfg.Node, testLogger())
+}
+
 // dockerLocated looks to see whether docker is available on this system before
 // we try to run tests. We'll keep it simple and just check for the CLI.
 func dockerLocated() bool {
@@ -33,7 +39,7 @@ func TestDockerDriver_Handle(t *testing.T) {
 
 // The fingerprinter test should always pass, even if Docker is not installed.
 func TestDockerDriver_Fingerprint(t *testing.T) {
-	d := NewDockerDriver(testDriverContext(""))
+	d := NewDockerDriver(testDockerDriverContext(""))
 	node := &structs.Node{
 		Attributes: make(map[string]string),
 	}
@@ -56,14 +62,14 @@ func TestDockerDriver_StartOpen_Wait(t *testing.T) {
 	}
 
 	task := &structs.Task{
-		Name: "python-demo",
+		Name: "redis-demo",
 		Config: map[string]string{
 			"image": "redis",
 		},
 		Resources: basicResources,
 	}
 
-	driverCtx := testDriverContext(task.Name)
+	driverCtx := testDockerDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)
 	defer ctx.AllocDir.Destroy()
 	d := NewDockerDriver(driverCtx)
@@ -93,7 +99,7 @@ func TestDockerDriver_Start_Wait(t *testing.T) {
 	}
 
 	task := &structs.Task{
-		Name: "python-demo",
+		Name: "redis-demo",
 		Config: map[string]string{
 			"image":   "redis",
 			"command": "redis-server -v",
@@ -104,7 +110,7 @@ func TestDockerDriver_Start_Wait(t *testing.T) {
 		},
 	}
 
-	driverCtx := testDriverContext(task.Name)
+	driverCtx := testDockerDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)
 	defer ctx.AllocDir.Destroy()
 	d := NewDockerDriver(driverCtx)
@@ -140,7 +146,7 @@ func TestDockerDriver_Start_Kill_Wait(t *testing.T) {
 	}
 
 	task := &structs.Task{
-		Name: "python-demo",
+		Name: "redis-demo",
 		Config: map[string]string{
 			"image":   "redis",
 			"command": "sleep 10",
@@ -148,7 +154,7 @@ func TestDockerDriver_Start_Kill_Wait(t *testing.T) {
 		Resources: basicResources,
 	}
 
-	driverCtx := testDriverContext(task.Name)
+	driverCtx := testDockerDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)
 	defer ctx.AllocDir.Destroy()
 	d := NewDockerDriver(driverCtx)
@@ -219,7 +225,7 @@ func TestDocker_StartN(t *testing.T) {
 	// Let's spin up a bunch of things
 	var err error
 	for idx, task := range taskList {
-		driverCtx := testDriverContext(task.Name)
+		driverCtx := testDockerDriverContext(task.Name)
 		ctx := testDriverExecContext(task, driverCtx)
 		defer ctx.AllocDir.Destroy()
 		d := NewDockerDriver(driverCtx)
@@ -265,7 +271,7 @@ func TestDocker_StartNVersions(t *testing.T) {
 	// Let's spin up a bunch of things
 	var err error
 	for idx, task := range taskList {
-		driverCtx := testDriverContext(task.Name)
+		driverCtx := testDockerDriverContext(task.Name)
 		ctx := testDriverExecContext(task, driverCtx)
 		defer ctx.AllocDir.Destroy()
 		d := NewDockerDriver(driverCtx)
@@ -299,7 +305,7 @@ func TestDockerHostNet(t *testing.T) {
 			CPU:      512,
 		},
 	}
-	driverCtx := testDriverContext(task.Name)
+	driverCtx := testDockerDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)
 	defer ctx.AllocDir.Destroy()
 	d := NewDockerDriver(driverCtx)

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -111,11 +111,21 @@ The `docker` driver has the following configuration options:
 * `docker.endpoint` - Defaults to `unix:///var/run/docker.sock`. You will need
   to customize this if you use a non-standard socket (http or another location).
 
+* `docker.cleanup.container` Defaults to `true`. Changing this to `false` will
+  prevent Nomad from removing containers from stopped tasks.
+
+* `docker.cleanup.image` Defaults to `true`. Changing this to `false` will
+  prevent Nomad from removing images from stopped tasks.
+
+Note: When testing or using the `-dev` flag you can use `DOCKER_HOST`,
+`DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` to customize Nomad's behavior. In
+production Nomad will always read `docker.endpoint`.
+
 ## Client Attributes
 
 The `docker` driver will set the following client attributes:
 
-* `driver.Docker` - This will be set to "1", indicating the
+* `driver.docker` - This will be set to "1", indicating the
   driver is available.
 
 ## Resource Isolation


### PR DESCRIPTION
- In dev/test, Docker socket config can be customized using `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` to facilitate development and testing on Windows and OSX using boot2docker or a VM
- In production nomad reads the `docker.endpoint` config option, and falls back on a platform-specific default.

If merged, this also closes #141 