### PR TITLE
Reap process after sending kill signal

### DIFF
--- a/client/executor/exec_linux.go
+++ b/client/executor/exec_linux.go
@@ -542,6 +542,11 @@ func (e *LinuxExecutor) destroyCgroup() error {
 			multierror.Append(errs, fmt.Errorf("Failed to kill Pid %v: %v", pid, err))
 			continue
 		}
+
+		if _, err := process.Wait(); err != nil {
+			multierror.Append(errs, fmt.Errorf("Failed to wait Pid %v: %v", pid, err))
+			continue
+		}
 	}
 
 	// Remove the cgroup.


### PR DESCRIPTION
Without waiting on the process after sending a kill will cause zombies
and we all know what happens when we have a zombies outbreak.

There are other calls to kill in this file but they are done on the main
process for the task so they should have the wait method called at
sometime in their lifecycle.