### PR TITLE
Adding support for regexp, version, and lexical ordering constraints

### DIFF
--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -242,6 +242,13 @@ func parseConstraints(result *[]*structs.Constraint, obj *hclobj.Object) error {
 			m["hard"] = true
 		}
 
+		// If "version" is provided, set the operand
+		// to "version" and the value to the "RTarget"
+		if constraint, ok := m["version"]; ok {
+			m["Operand"] = "version"
+			m["RTarget"] = constraint
+		}
+
 		// Build the constraint
 		var c structs.Constraint
 		if err := mapstructure.WeakDecode(m, &c); err != nil {

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -249,6 +249,13 @@ func parseConstraints(result *[]*structs.Constraint, obj *hclobj.Object) error {
 			m["RTarget"] = constraint
 		}
 
+		// If "regexp" is provided, set the operand
+		// to "regexp" and the value to the "RTarget"
+		if constraint, ok := m["regexp"]; ok {
+			m["Operand"] = "regexp"
+			m["RTarget"] = constraint
+		}
+
 		// Build the constraint
 		var c structs.Constraint
 		if err := mapstructure.WeakDecode(m, &c); err != nil {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -173,6 +173,26 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			"regexp-constraint.hcl",
+			&structs.Job{
+				ID:       "foo",
+				Name:     "foo",
+				Priority: 50,
+				Region:   "global",
+				Type:     "service",
+				Constraints: []*structs.Constraint{
+					&structs.Constraint{
+						Hard:    true,
+						LTarget: "$attr.kernel.version",
+						RTarget: "[0-9.]+",
+						Operand: "regexp",
+					},
+				},
+			},
+			false,
+		},
+
+		{
 			"specify-job.hcl",
 			&structs.Job{
 				ID:       "job1",

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -153,6 +153,26 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			"version-constraint.hcl",
+			&structs.Job{
+				ID:       "foo",
+				Name:     "foo",
+				Priority: 50,
+				Region:   "global",
+				Type:     "service",
+				Constraints: []*structs.Constraint{
+					&structs.Constraint{
+						Hard:    true,
+						LTarget: "$attr.kernel.version",
+						RTarget: "~> 3.2",
+						Operand: "version",
+					},
+				},
+			},
+			false,
+		},
+
+		{
 			"specify-job.hcl",
 			&structs.Job{
 				ID:       "job1",

--- a/jobspec/test-fixtures/regexp-constraint.hcl
+++ b/jobspec/test-fixtures/regexp-constraint.hcl
@@ -1,0 +1,6 @@
+job "foo" {
+    constraint {
+        attribute = "$attr.kernel.version"
+        regexp = "[0-9.]+"
+    }
+}

--- a/jobspec/test-fixtures/version-constraint.hcl
+++ b/jobspec/test-fixtures/version-constraint.hcl
@@ -1,0 +1,6 @@
+job "foo" {
+    constraint {
+        attribute = "$attr.kernel.version"
+        version = "~> 3.2"
+    }
+}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -125,6 +125,43 @@ func TestTask_Validate(t *testing.T) {
 	}
 }
 
+func TestConstraint_Validate(t *testing.T) {
+	c := &Constraint{}
+	err := c.Validate()
+	mErr := err.(*multierror.Error)
+	if !strings.Contains(mErr.Errors[0].Error(), "Missing constraint operand") {
+		t.Fatalf("err: %s", err)
+	}
+
+	c = &Constraint{
+		LTarget: "$attr.kernel.name",
+		RTarget: "linux",
+		Operand: "=",
+	}
+	err = c.Validate()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Perform additional regexp validation
+	c.Operand = "regexp"
+	c.RTarget = "(foo"
+	err = c.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Errors[0].Error(), "missing closing") {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Perform version validation
+	c.Operand = "version"
+	c.RTarget = "~> foo"
+	err = c.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Errors[0].Error(), "Malformed constraint") {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestResource_NetIndex(t *testing.T) {
 	r := &Resources{
 		Networks: []*NetworkResource{

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -250,12 +250,37 @@ func checkConstraint(operand string, lVal, rVal interface{}) bool {
 	case "!=", "not":
 		return !reflect.DeepEqual(lVal, rVal)
 	case "<", "<=", ">", ">=":
-		// TODO: Implement
-		return false
+		return checkLexicalOrder(operand, lVal, rVal)
 	case "version":
 		return checkVersionConstraint(lVal, rVal)
 	case "regexp":
 		return checkRegexpConstraint(lVal, rVal)
+	default:
+		return false
+	}
+}
+
+// checkLexicalOrder is used to check for lexical ordering
+func checkLexicalOrder(op string, lVal, rVal interface{}) bool {
+	// Ensure the values are strings
+	lStr, ok := lVal.(string)
+	if !ok {
+		return false
+	}
+	rStr, ok := rVal.(string)
+	if !ok {
+		return false
+	}
+
+	switch op {
+	case "<":
+		return lStr < rStr
+	case "<=":
+		return lStr <= rStr
+	case ">":
+		return lStr > rStr
+	case ">=":
+		return lStr >= rStr
 	default:
 		return false
 	}

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-version"
@@ -251,11 +252,10 @@ func checkConstraint(operand string, lVal, rVal interface{}) bool {
 	case "<", "<=", ">", ">=":
 		// TODO: Implement
 		return false
-	case "contains":
-		// TODO: Implement
-		return false
 	case "version":
 		return checkVersionConstraint(lVal, rVal)
+	case "regexp":
+		return checkRegexpConstraint(lVal, rVal)
 	default:
 		return false
 	}
@@ -295,4 +295,29 @@ func checkVersionConstraint(lVal, rVal interface{}) bool {
 
 	// Check the constraints against the version
 	return constraints.Check(vers)
+}
+
+// checkRegexpConstraint is used to compare a value on the
+// left hand side with a regexp on the right hand side
+func checkRegexpConstraint(lVal, rVal interface{}) bool {
+	// Ensure left-hand is string
+	lStr, ok := lVal.(string)
+	if !ok {
+		return false
+	}
+
+	// Regexp must be a string
+	regexpStr, ok := rVal.(string)
+	if !ok {
+		return false
+	}
+
+	// Parse the regexp
+	re, err := regexp.Compile(regexpStr)
+	if err != nil {
+		return false
+	}
+
+	// Look for a match
+	return re.MatchString(lStr)
 }

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -244,10 +244,49 @@ func TestCheckConstraint(t *testing.T) {
 			lVal: "foo", rVal: "bar",
 			result: true,
 		},
+		{
+			op:   "version",
+			lVal: "1.2.3", rVal: "~> 1.0",
+			result: true,
+		},
 	}
 
 	for _, tc := range cases {
 		if res := checkConstraint(tc.op, tc.lVal, tc.rVal); res != tc.result {
+			t.Fatalf("TC: %#v, Result: %v", tc, res)
+		}
+	}
+}
+
+func TestCheckVersionConstraint(t *testing.T) {
+	type tcase struct {
+		lVal, rVal interface{}
+		result     bool
+	}
+	cases := []tcase{
+		{
+			lVal: "1.2.3", rVal: "~> 1.0",
+			result: true,
+		},
+		{
+			lVal: "1.2.3", rVal: ">= 1.0, < 1.4",
+			result: true,
+		},
+		{
+			lVal: "2.0.1", rVal: "~> 1.0",
+			result: false,
+		},
+		{
+			lVal: "1.4", rVal: ">= 1.0, < 1.4",
+			result: false,
+		},
+		{
+			lVal: 1, rVal: "~> 1.0",
+			result: true,
+		},
+	}
+	for _, tc := range cases {
+		if res := checkVersionConstraint(tc.lVal, tc.rVal); res != tc.result {
 			t.Fatalf("TC: %#v, Result: %v", tc, res)
 		}
 	}

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -249,6 +249,11 @@ func TestCheckConstraint(t *testing.T) {
 			lVal: "1.2.3", rVal: "~> 1.0",
 			result: true,
 		},
+		{
+			op:   "regexp",
+			lVal: "foobarbaz", rVal: "[\\w]+",
+			result: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -287,6 +292,40 @@ func TestCheckVersionConstraint(t *testing.T) {
 	}
 	for _, tc := range cases {
 		if res := checkVersionConstraint(tc.lVal, tc.rVal); res != tc.result {
+			t.Fatalf("TC: %#v, Result: %v", tc, res)
+		}
+	}
+}
+
+func TestCheckRegexpConstraint(t *testing.T) {
+	type tcase struct {
+		lVal, rVal interface{}
+		result     bool
+	}
+	cases := []tcase{
+		{
+			lVal: "foobar", rVal: "bar",
+			result: true,
+		},
+		{
+			lVal: "foobar", rVal: "^foo",
+			result: true,
+		},
+		{
+			lVal: "foobar", rVal: "^bar",
+			result: false,
+		},
+		{
+			lVal: "zipzap", rVal: "foo",
+			result: false,
+		},
+		{
+			lVal: 1, rVal: "foo",
+			result: false,
+		},
+	}
+	for _, tc := range cases {
+		if res := checkRegexpConstraint(tc.lVal, tc.rVal); res != tc.result {
 			t.Fatalf("TC: %#v, Result: %v", tc, res)
 		}
 	}

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -254,10 +254,55 @@ func TestCheckConstraint(t *testing.T) {
 			lVal: "foobarbaz", rVal: "[\\w]+",
 			result: true,
 		},
+		{
+			op:   "<",
+			lVal: "foo", rVal: "bar",
+			result: false,
+		},
 	}
 
 	for _, tc := range cases {
 		if res := checkConstraint(tc.op, tc.lVal, tc.rVal); res != tc.result {
+			t.Fatalf("TC: %#v, Result: %v", tc, res)
+		}
+	}
+}
+
+func TestCheckLexicalOrder(t *testing.T) {
+	type tcase struct {
+		op         string
+		lVal, rVal interface{}
+		result     bool
+	}
+	cases := []tcase{
+		{
+			op:   "<",
+			lVal: "bar", rVal: "foo",
+			result: true,
+		},
+		{
+			op:   "<=",
+			lVal: "foo", rVal: "foo",
+			result: true,
+		},
+		{
+			op:   ">",
+			lVal: "bar", rVal: "foo",
+			result: false,
+		},
+		{
+			op:   ">=",
+			lVal: "bar", rVal: "bar",
+			result: true,
+		},
+		{
+			op:   ">",
+			lVal: 1, rVal: "foo",
+			result: false,
+		},
+	}
+	for _, tc := range cases {
+		if res := checkLexicalOrder(tc.op, tc.lVal, tc.rVal); res != tc.result {
 			t.Fatalf("TC: %#v, Result: %v", tc, res)
 		}
 	}

--- a/website/source/docs/jobspec/index.html.md
+++ b/website/source/docs/jobspec/index.html.md
@@ -218,7 +218,8 @@ The `constraint` object supports the following keys:
   to true. Soft constraints are not currently supported.
 
 * `operator` - Specifies the comparison operator. Defaults to equality,
-  and can be `=`, `==`, `is`, `!=`, `not`.
+  and can be `=`, `==`, `is`, `!=`, `not`, `>`, `>=`, `<`, `<=`. The
+  ordering is compared lexically.
 
 * `value` - Specifies the value to compare the attribute against.
   This can be a literal value or another attribute.

--- a/website/source/docs/jobspec/index.html.md
+++ b/website/source/docs/jobspec/index.html.md
@@ -230,6 +230,10 @@ The `constraint` object supports the following keys:
   [go-version](https://github.com/hashicorp/go-version) repository
   for examples.
 
+* `regexp` - Specifies a regular expression constraint against
+  the attribute. This sets the operator to "regexp" and the `value`
+  to the regular expression.
+
 Below is a table documenting the variables that can be interpreted:
 
 <table class="table table-bordered table-striped">

--- a/website/source/docs/jobspec/index.html.md
+++ b/website/source/docs/jobspec/index.html.md
@@ -223,6 +223,13 @@ The `constraint` object supports the following keys:
 * `value` - Specifies the value to compare the attribute against.
   This can be a literal value or another attribute.
 
+* `version` - Specifies a version constraint against the attribute.
+  This sets the operator to "version" and the `value` to what is
+  specified. This supports a comma seperated list of constraints,
+  including the pessimistic operator. See the
+  [go-version](https://github.com/hashicorp/go-version) repository
+  for examples.
+
 Below is a table documenting the variables that can be interpreted:
 
 <table class="table table-bordered table-striped">


### PR DESCRIPTION
This PR adds additional hard constraint filters, including regular expressions, version constraints, and lexical ordering. Additionally, the Job validation checks the constraints to provide earlier feedback to users.