### PR TITLE
Plan queue apply overlaps plan verification with plan application to increase throughput

### DIFF
--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -228,6 +228,7 @@ func TestLeader_EvalBroker_Reset(t *testing.T) {
 	defer s3.Shutdown()
 	servers := []*Server{s1, s2, s3}
 	testJoin(t, s1, s2, s3)
+	testutil.WaitForLeader(t, s1.RPC)
 
 	for _, s := range servers {
 		testutil.WaitForResult(func() (bool, error) {

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -75,7 +75,7 @@ func (s *Server) planApply() {
 
 		// Snapshot the state so that we have a consistent view of the world
 		// if no snapshot is available
-		if snap == nil {
+		if waitCh == nil || snap == nil {
 			snap, err = s.fsm.State().Snapshot()
 			if err != nil {
 				s.logger.Printf("[ERR] nomad: failed to snapshot state: %v", err)

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -17,7 +17,7 @@ import (
 // Naively, we could simply dequeue a plan, verify, apply and then respond.
 // However, the plan application is bounded by the Raft apply time and
 // subject to some latency. This creates a stall condition, where we are
-// not evaluating, but simply waiting for a transaction to complete.
+// not evaluating, but simply waiting for a transaction to apply.
 //
 // To avoid this, we overlap verification with apply. This means once
 // we've verified plan N we attempt to apply it. However, while waiting
@@ -37,9 +37,8 @@ import (
 // but there are many of those and only a single plan verifier.
 //
 func (s *Server) planApply() {
-	// waitCh is used to track an outstanding application
-	// while snap holds an optimistic state which includes
-	// that plan application.
+	// waitCh is used to track an outstanding application while snap
+	// holds an optimistic state which includes that plan application.
 	var waitCh chan struct{}
 	var snap *state.StateSnapshot
 
@@ -98,9 +97,8 @@ func (s *Server) planApply() {
 			continue
 		}
 
-		// Ensure any parallel apply is complete before
-		// starting the next one. This also limits how out
-		// of date our snapshot can be.
+		// Ensure any parallel apply is complete before starting the next one.
+		// This also limits how out of date our snapshot can be.
 		if waitCh != nil {
 			<-waitCh
 			snap, err = s.fsm.State().Snapshot()

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -46,7 +46,11 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	}
 
 	// Apply the plan
-	index, err := s1.applyPlan(plan)
+	future, err := s1.applyPlan(plan)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	index, err := s1.planWaitFuture(future)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -87,7 +91,11 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	}
 
 	// Apply the plan
-	index, err = s1.applyPlan(plan)
+	future, err = s1.applyPlan(plan)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	index, err = s1.planWaitFuture(future)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -55,7 +55,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	}
 
 	// Apply the plan
-	future, err := s1.applyPlan(plan)
+	future, err := s1.applyPlan(plan, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	}
 
 	// Apply the plan
-	future, err = s1.applyPlan(plan)
+	future, err = s1.applyPlan(plan, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -7,7 +7,16 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/hashicorp/raft"
 )
+
+// planWaitFuture is used to wait for the Raft future to complete
+func planWaitFuture(future raft.ApplyFuture) (uint64, error) {
+	if err := future.Error(); err != nil {
+		return 0, err
+	}
+	return future.Index(), nil
+}
 
 func testRegisterNode(t *testing.T, s *Server, n *structs.Node) {
 	// Create the register request
@@ -50,7 +59,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	index, err := s1.planWaitFuture(future)
+	index, err := planWaitFuture(future)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -95,7 +104,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	index, err = s1.planWaitFuture(future)
+	index, err = planWaitFuture(future)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/raft"
 	"github.com/hashicorp/yamux"
 )
 
@@ -225,12 +226,11 @@ func (s *Server) forwardRegion(region, method string, args interface{}, reply in
 	return s.connPool.RPC(region, server.Addr, server.Version, method, args, reply)
 }
 
-// raftApply is used to encode a message, run it through raft, and return
-// the FSM response along with any errors
-func (s *Server) raftApply(t structs.MessageType, msg interface{}) (interface{}, uint64, error) {
+// raftApplyFuture is used to encode a message, run it through raft, and return the Raft future.
+func (s *Server) raftApplyFuture(t structs.MessageType, msg interface{}) (raft.ApplyFuture, error) {
 	buf, err := structs.Encode(t, msg)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to encode request: %v", err)
+		return nil, fmt.Errorf("Failed to encode request: %v", err)
 	}
 
 	// Warn if the command is very large
@@ -240,9 +240,18 @@ func (s *Server) raftApply(t structs.MessageType, msg interface{}) (interface{},
 
 	future := s.raft.Apply(buf, enqueueLimit)
 	if err := future.Error(); err != nil {
+		return nil, err
+	}
+	return future, nil
+}
+
+// raftApply is used to encode a message, run it through raft, and return
+// the FSM response along with any errors
+func (s *Server) raftApply(t structs.MessageType, msg interface{}) (interface{}, uint64, error) {
+	future, err := s.raftApplyFuture(t, msg)
+	if err != nil {
 		return nil, 0, err
 	}
-
 	return future.Response(), future.Index(), nil
 }
 

--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -239,9 +239,6 @@ func (s *Server) raftApplyFuture(t structs.MessageType, msg interface{}) (raft.A
 	}
 
 	future := s.raft.Apply(buf, enqueueLimit)
-	if err := future.Error(); err != nil {
-		return nil, err
-	}
 	return future, nil
 }
 
@@ -250,6 +247,9 @@ func (s *Server) raftApplyFuture(t structs.MessageType, msg interface{}) (raft.A
 func (s *Server) raftApply(t structs.MessageType, msg interface{}) (interface{}, uint64, error) {
 	future, err := s.raftApplyFuture(t, msg)
 	if err != nil {
+		return nil, 0, err
+	}
+	if err := future.Error(); err != nil {
 		return nil, 0, err
 	}
 	return future.Response(), future.Index(), nil

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -52,7 +52,12 @@ func TestWorker_dequeueEvaluation(t *testing.T) {
 
 	// Create the evaluation
 	eval1 := mock.Eval()
-	s1.evalBroker.Enqueue(eval1)
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.evalBroker.Enqueue(eval1)
+		return err == nil, err
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
 
 	// Create a worker
 	w := &Worker{srv: s1, logger: s1.logger}
@@ -82,7 +87,12 @@ func TestWorker_dequeueEvaluation_paused(t *testing.T) {
 
 	// Create the evaluation
 	eval1 := mock.Eval()
-	s1.evalBroker.Enqueue(eval1)
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.evalBroker.Enqueue(eval1)
+		return err == nil, err
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
 
 	// Create a worker
 	w := &Worker{srv: s1, logger: s1.logger}
@@ -153,7 +163,12 @@ func TestWorker_sendAck(t *testing.T) {
 
 	// Create the evaluation
 	eval1 := mock.Eval()
-	s1.evalBroker.Enqueue(eval1)
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.evalBroker.Enqueue(eval1)
+		return err == nil, err
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
 
 	// Create a worker
 	w := &Worker{srv: s1, logger: s1.logger}


### PR DESCRIPTION
The plan apply would previously always do dequeue, verify, apply, respond. This meant that the time spent in apply which is just waiting for a Raft commit would prevent any other verification from happening.

Now, the plan does dequeue and verify, and then does an async apply and respond. While we are waiting for the plan to apply, we optimistically apply the plan to a snapshot of state and begin verifying the next plan. This allows us to overlap the application with the verification to reduce the amount of time spent waiting.

This PR supports only a single level of overlap (apply N, verify N+1), but it can be extended in the future to support K levels of verify-ahead (apply N, verify N+1, ..., verify N+K).