### PR TITLE
scheduler: adding regexp and version constraint cache

### DIFF
--- a/scheduler/context.go
+++ b/scheduler/context.go
@@ -2,7 +2,9 @@ package scheduler
 
 import (
 	"log"
+	"regexp"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -27,10 +29,36 @@ type Context interface {
 	// which is the existing allocations, removing evictions, and
 	// adding any planned placements.
 	ProposedAllocs(nodeID string) ([]*structs.Allocation, error)
+
+	// RegexpCache is a cache of regular expressions
+	RegexpCache() map[string]*regexp.Regexp
+
+	// ConstraintCache is a cache of version constraints
+	ConstraintCache() map[string]version.Constraints
+}
+
+// EvalCache is used to cache certain things during an evaluation
+type EvalCache struct {
+	reCache         map[string]*regexp.Regexp
+	constraintCache map[string]version.Constraints
+}
+
+func (e *EvalCache) RegexpCache() map[string]*regexp.Regexp {
+	if e.reCache == nil {
+		e.reCache = make(map[string]*regexp.Regexp)
+	}
+	return e.reCache
+}
+func (e *EvalCache) ConstraintCache() map[string]version.Constraints {
+	if e.constraintCache == nil {
+		e.constraintCache = make(map[string]version.Constraints)
+	}
+	return e.constraintCache
 }
 
 // EvalContext is a Context used during an Evaluation
 type EvalContext struct {
+	EvalCache
 	state   State
 	plan    *structs.Plan
 	logger  *log.Logger

--- a/scheduler/context_test.go
+++ b/scheduler/context_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-func testContext(t *testing.T) (*state.StateStore, *EvalContext) {
+func testContext(t testing.TB) (*state.StateStore, *EvalContext) {
 	state, err := state.NewStateStore(os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -262,7 +262,8 @@ func TestCheckConstraint(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		if res := checkConstraint(tc.op, tc.lVal, tc.rVal); res != tc.result {
+		_, ctx := testContext(t)
+		if res := checkConstraint(ctx, tc.op, tc.lVal, tc.rVal); res != tc.result {
 			t.Fatalf("TC: %#v, Result: %v", tc, res)
 		}
 	}
@@ -336,7 +337,8 @@ func TestCheckVersionConstraint(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		if res := checkVersionConstraint(tc.lVal, tc.rVal); res != tc.result {
+		_, ctx := testContext(t)
+		if res := checkVersionConstraint(ctx, tc.lVal, tc.rVal); res != tc.result {
 			t.Fatalf("TC: %#v, Result: %v", tc, res)
 		}
 	}
@@ -370,7 +372,8 @@ func TestCheckRegexpConstraint(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		if res := checkRegexpConstraint(tc.lVal, tc.rVal); res != tc.result {
+		_, ctx := testContext(t)
+		if res := checkRegexpConstraint(ctx, tc.lVal, tc.rVal); res != tc.result {
 			t.Fatalf("TC: %#v, Result: %v", tc, res)
 		}
 	}


### PR DESCRIPTION
This adds a simple cache of regular expressions and version constraints, which are likely to be re-evaluated against many nodes. Instead of re-compiling, we store them for the life of an evaluation.

Casual benchmarks show a 10x speed improvement on the simplest of expressions.