### PR TITLE
driver/qemu: Update docs, we use SHA256 not MD5

### DIFF
--- a/website/source/docs/drivers/qemu.html.md
+++ b/website/source/docs/drivers/qemu.html.md
@@ -25,7 +25,7 @@ The `Qemu` driver supports the following configuration in the job spec:
 
 * `image_source` - **(Required)** The hosted location of the source Qemu image. Must be accessible
 from the Nomad client, via HTTP.
-* `checksum` - **(Required)** The MD5 checksum of the `qemu` image. If the
+* `checksum` - **(Required)** The SHA256 checksum of the `qemu` image. If the
 checksums do not match, the `Qemu` diver will fail to start the image
 * `accelerator` - (Optional) The type of accelerator to use in the invocation.
  If the host machine has `Qemu` installed with KVM support, users can specify `kvm` for the `accelerator`. Default is `tcg`


### PR DESCRIPTION
The Qemu driver actually [computes and checks a SHA256 checksum][1], not a MD5.



[1]: https://github.com/hashicorp/nomad/blob/master/client/driver/qemu.go#L132-L150