### PR TITLE
Create evals for system jobs on node registration

### DIFF
--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -155,7 +155,9 @@ func (n *Node) UpdateStatus(args *structs.NodeUpdateStatusRequest, reply *struct
 
 	// Check if we should trigger evaluations
 	initToReady := node.Status == structs.NodeStatusInit && args.Status == structs.NodeStatusReady
-	if structs.ShouldDrainNode(args.Status) || initToReady {
+	terminalToReady := node.Status == structs.NodeStatusDown && args.Status == structs.NodeStatusReady
+	transitionToReady := initToReady || terminalToReady
+	if structs.ShouldDrainNode(args.Status) || transitionToReady {
 		evalIDs, evalIndex, err := n.createNodeEvals(args.NodeID, index)
 		if err != nil {
 			n.srv.logger.Printf("[ERR] nomad.client: eval creation failed: %v", err)

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -452,10 +452,14 @@ func (n *Node) createNodeEvals(nodeID string, nodeIndex uint64) ([]string, uint6
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to find system jobs for '%s': %v", nodeID, err)
 	}
-	nextJob := sysJobsIter.Next()
+
+	var sysJobs []*structs.Job
+	for job := sysJobsIter.Next(); job != nil; job = sysJobsIter.Next() {
+		sysJobs = append(sysJobs, job.(*structs.Job))
+	}
 
 	// Fast-path if nothing to do
-	if len(allocs) == 0 && nextJob == nil {
+	if len(allocs) == 0 && len(sysJobs) == 0 {
 		return nil, 0, nil
 	}
 
@@ -484,14 +488,6 @@ func (n *Node) createNodeEvals(nodeID string, nodeIndex uint64) ([]string, uint6
 		}
 		evals = append(evals, eval)
 		evalIDs = append(evalIDs, eval.ID)
-	}
-
-	var sysJobs []*structs.Job
-	if nextJob != nil {
-		sysJobs = append(sysJobs, nextJob.(*structs.Job))
-		for job := sysJobsIter.Next(); job != nil; job = sysJobsIter.Next() {
-			sysJobs = append(sysJobs, job.(*structs.Job))
-		}
 	}
 
 	// Create an evaluation for each system job.

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -91,6 +91,15 @@ func jobTableSchema() *memdb.TableSchema {
 					Lowercase: true,
 				},
 			},
+			"type": &memdb.IndexSchema{
+				Name:         "type",
+				AllowMissing: false,
+				Unique:       false,
+				Indexer: &memdb.StringFieldIndex{
+					Field:     "Type",
+					Lowercase: false,
+				},
+			},
 		},
 	}
 }

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -399,6 +399,19 @@ func (s *StateStore) Jobs() (memdb.ResultIterator, error) {
 	return iter, nil
 }
 
+// JobsByScheduler returns an iterator over all the jobs with the specific
+// scheduler type.
+func (s *StateStore) JobsByScheduler(schedulerType string) (memdb.ResultIterator, error) {
+	txn := s.db.Txn(false)
+
+	// Return an iterator for jobs with the specific type.
+	iter, err := txn.Get("jobs", "type", schedulerType)
+	if err != nil {
+		return nil, err
+	}
+	return iter, nil
+}
+
 // UpsertEvaluation is used to upsert an evaluation
 func (s *StateStore) UpsertEvals(index uint64, evals []*structs.Evaluation) error {
 	txn := s.db.Txn(true)


### PR DESCRIPTION
This PR adds:
* A secondary index to allow job indexing by scheduler type.
* Creates evals for system jobs when a node transitions from Init to Ready.