### PR TITLE
Reset evaluation Nack timer in response to scheduler operations

### DIFF
--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -381,6 +381,21 @@ func (b *EvalBroker) Outstanding(evalID string) (string, bool) {
 	return unack.Token, true
 }
 
+// OutstandingReset resets the Nack timer for the EvalID if the
+// token matches and the eval is outstanding
+func (b *EvalBroker) OutstandingReset(evalID, token string) bool {
+	b.l.RLock()
+	defer b.l.RUnlock()
+	unack, ok := b.unack[evalID]
+	if !ok {
+		return false
+	}
+	if unack.Token != token {
+		return false
+	}
+	return unack.NackTimer.Reset(b.nackTimeout)
+}
+
 // Ack is used to positively acknowledge handling an evaluation
 func (b *EvalBroker) Ack(evalID, token string) error {
 	b.l.Lock()

--- a/nomad/eval_broker_test.go
+++ b/nomad/eval_broker_test.go
@@ -90,13 +90,17 @@ func TestEvalBroker_Enqueue_Dequeue_Nack_Ack(t *testing.T) {
 	}
 
 	// OutstandingReset should verify the token
-	reset := b.OutstandingReset(out.ID, "foo")
-	if reset {
-		t.Fatalf("bad")
+	err = b.OutstandingReset("nope", "foo")
+	if err != ErrNotOutstanding {
+		t.Fatalf("err: %v", err)
 	}
-	reset = b.OutstandingReset(out.ID, tokenOut)
-	if !reset {
-		t.Fatalf("bad")
+	err = b.OutstandingReset(out.ID, "foo")
+	if err != ErrTokenMismatch {
+		t.Fatalf("err: %v", err)
+	}
+	err = b.OutstandingReset(out.ID, tokenOut)
+	if err != nil {
+		t.Fatalf("err: %v", err)
 	}
 
 	// Check the stats
@@ -594,8 +598,8 @@ func TestEvalBroker_Nack_TimeoutReset(t *testing.T) {
 
 	// Reset in 2 milliseconds
 	time.Sleep(2 * time.Millisecond)
-	if reset := b.OutstandingReset(out.ID, token); !reset {
-		t.Fatalf("bad")
+	if err := b.OutstandingReset(out.ID, token); err != nil {
+		t.Fatalf("err: %v", err)
 	}
 
 	// Dequeue, should block on Nack timer

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -134,12 +134,8 @@ func (e *Eval) Update(args *structs.EvalUpdateRequest,
 	eval := args.Evals[0]
 
 	// Verify the evaluation is outstanding, and that the tokens match.
-	token, ok := e.srv.evalBroker.Outstanding(eval.ID)
-	if !ok {
-		return fmt.Errorf("evaluation is not outstanding")
-	}
-	if args.EvalToken != token {
-		return fmt.Errorf("evaluation token does not match")
+	if err := e.srv.evalBroker.OutstandingReset(eval.ID, args.EvalToken); err != nil {
+		return err
 	}
 
 	// Update via Raft
@@ -168,12 +164,8 @@ func (e *Eval) Create(args *structs.EvalUpdateRequest,
 	eval := args.Evals[0]
 
 	// Verify the parent evaluation is outstanding, and that the tokens match.
-	token, ok := e.srv.evalBroker.Outstanding(eval.PreviousEval)
-	if !ok {
-		return fmt.Errorf("previous evaluation is not outstanding")
-	}
-	if args.EvalToken != token {
-		return fmt.Errorf("previous evaluation token does not match")
+	if err := e.srv.evalBroker.OutstandingReset(eval.PreviousEval, args.EvalToken); err != nil {
+		return err
 	}
 
 	// Look for the eval

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -50,17 +50,10 @@ func (s *Server) planApply() {
 		}
 
 		// Verify the evaluation is outstanding, and that the tokens match.
-		token, ok := s.evalBroker.Outstanding(pending.plan.EvalID)
-		if !ok {
-			s.logger.Printf("[ERR] nomad: plan received for non-outstanding evaluation %s",
-				pending.plan.EvalID)
-			pending.respond(nil, fmt.Errorf("evaluation is not outstanding"))
-			continue
-		}
-		if pending.plan.EvalToken != token {
-			s.logger.Printf("[ERR] nomad: plan received for evaluation %s with wrong token",
-				pending.plan.EvalID)
-			pending.respond(nil, fmt.Errorf("evaluation token does not match"))
+		if err := s.evalBroker.OutstandingReset(pending.plan.EvalID, pending.plan.EvalToken); err != nil {
+			s.logger.Printf("[ERR] nomad: plan rejected for evaluation %s: %v",
+				pending.plan.EvalID, err)
+			pending.respond(nil, err)
 			continue
 		}
 


### PR DESCRIPTION
Currently the evaluations have a fixed Nack timeout period of 60 seconds. If they do not complete, the eval broker will always cause a Nack to happen. This is probably fine, except for under high contention or high load situations where its possible to exceed that timeout. This PR causes the Nack timer to be reset if the scheduler is submitting plans or modifying evaluations, as this still proves the liveness of the scheduler. It is still possible for an extremely slow scheduler to hit the Nack timeout, but this should make it much less likely.