### PR TITLE
Check for environment variable updates for tasks

### DIFF
--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -80,6 +80,9 @@ func Job() *structs.Job {
 							"command": "/bin/date",
 							"args":    "+%s",
 						},
+						Env: map[string]string{
+							"FOO": "bar",
+						},
 						Resources: &structs.Resources{
 							CPU:      500,
 							MemoryMB: 256,

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -263,7 +263,7 @@ func shuffleNodes(nodes []*structs.Node) {
 }
 
 // tasksUpdated does a diff between task groups to see if the
-// tasks, their drivers or config have updated.
+// tasks, their drivers, environment variables or config have updated.
 func tasksUpdated(a, b *structs.TaskGroup) bool {
 	// If the number of tasks do not match, clearly there is an update
 	if len(a.Tasks) != len(b.Tasks) {
@@ -280,6 +280,9 @@ func tasksUpdated(a, b *structs.TaskGroup) bool {
 			return true
 		}
 		if !reflect.DeepEqual(at.Config, bt.Config) {
+			return true
+		}
+		if !reflect.DeepEqual(at.Env, bt.Env) {
 			return true
 		}
 

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -347,6 +347,12 @@ func TestTasksUpdated(t *testing.T) {
 	if !tasksUpdated(j1.TaskGroups[0], j6.TaskGroups[0]) {
 		t.Fatalf("bad")
 	}
+
+	j7 := mock.Job()
+	j7.TaskGroups[0].Tasks[0].Env["NEW_ENV"] = "NEW_VALUE"
+	if !tasksUpdated(j1.TaskGroups[0], j7.TaskGroups[0]) {
+		t.Fatalf("bad")
+	}
 }
 
 func TestEvictAndPlace_LimitLessThanAllocs(t *testing.T) {


### PR DESCRIPTION
This PR fixes a regression when we added environment variables to tasks. We need to check if the environment variables have changed in order to decided whether an update can be done in-place or not.