### PR TITLE
Get Qemu to fingerprint and test properly on both windows and linux

### DIFF
--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -57,6 +57,8 @@ func NewQemuDriver(ctx *DriverContext) Driver {
 func (d *QemuDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
 	bin := "qemu-system-x86_64"
 	if runtime.GOOS == "windows" {
+		// On windows, the "qemu-system-x86_64" command does not respond to the
+		// version flag.
 		bin = "qemu-img"
 	}
 	outBytes, err := exec.Command(bin, "--version").Output()

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -15,7 +15,11 @@ func ExecCompatible(t *testing.T) {
 
 func QemuCompatible(t *testing.T) {
 	// Check if qemu exists
-	_, err := exec.Command("qemu-system-x86_64", "-version").CombinedOutput()
+	bin := "qemu-system-x86_64"
+	if runtime.GOOS == "windows" {
+		bin = "qemu-img"
+	}
+	_, err := exec.Command(bin, "--version").CombinedOutput()
 	if err != nil {
 		t.Skip("Must have Qemu installed for Qemu specific tests to run")
 	}

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -14,10 +14,7 @@ func ExecCompatible(t *testing.T) {
 }
 
 func QemuCompatible(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Must be on non-windows environments to run test")
-	}
-	// else see if qemu exists
+	// Check if qemu exists
 	_, err := exec.Command("qemu-system-x86_64", "-version").CombinedOutput()
 	if err != nil {
 		t.Skip("Must have Qemu installed for Qemu specific tests to run")


### PR DESCRIPTION
On Windows `qemu-system-x86_64` does not respond to `--version` but `qemu-img` does. Also removed the precondition that you have to be root because you don't