### PR TITLE
spawn-daemon persists exit code; update exec_linux

### DIFF
--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -35,8 +35,11 @@ func NewExecDriver(ctx *DriverContext) Driver {
 }
 
 func (d *ExecDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
-	// Only enable if we are root when running on non-windows systems.
-	if runtime.GOOS != "windows" && syscall.Geteuid() != 0 {
+	// Only enable if we are root on linux.
+	if runtime.GOOS != "linux" {
+		d.logger.Printf("[DEBUG] driver.exec: only available on linux, disabling")
+		return false, nil
+	} else if syscall.Geteuid() != 0 {
 		d.logger.Printf("[DEBUG] driver.exec: must run as root user, disabling")
 		return false, nil
 	}
@@ -73,10 +76,8 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 		}
 
 		// Add execution permissions to the newly downloaded artifact
-		if runtime.GOOS != "windows" {
-			if err := syscall.Chmod(artifactFile, 0755); err != nil {
-				log.Printf("[ERR] driver.Exec: Error making artifact executable: %s", err)
-			}
+		if err := syscall.Chmod(artifactFile, 0755); err != nil {
+			log.Printf("[ERR] driver.exec: Error making artifact executable: %s", err)
 		}
 	}
 

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 	"time"
 
@@ -123,13 +122,7 @@ func TestExecDriver_Start_Wait(t *testing.T) {
 
 func TestExecDriver_Start_Artifact_basic(t *testing.T) {
 	ctestutils.ExecCompatible(t)
-	var file string
-	switch runtime.GOOS {
-	case "darwin":
-		file = "hi_darwin_amd64"
-	default:
-		file = "hi_linux_amd64"
-	}
+	file := "hi_linux_amd64"
 
 	task := &structs.Task{
 		Name: "sleep",
@@ -172,13 +165,7 @@ func TestExecDriver_Start_Artifact_basic(t *testing.T) {
 
 func TestExecDriver_Start_Artifact_expanded(t *testing.T) {
 	ctestutils.ExecCompatible(t)
-	var file string
-	switch runtime.GOOS {
-	case "darwin":
-		file = "hi_darwin_amd64"
-	default:
-		file = "hi_linux_amd64"
-	}
+	file := "hi_linux_amd64"
 
 	task := &structs.Task{
 		Name: "sleep",

--- a/client/executor/exec_linux.go
+++ b/client/executor/exec_linux.go
@@ -22,12 +22,10 @@ import (
 	"github.com/hashicorp/nomad/helper/discover"
 	"github.com/hashicorp/nomad/nomad/structs"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	cgroupFs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	cgroupConfig "github.com/opencontainers/runc/libcontainer/configs"
-)
-
-const (
-	cgroupMount = "/sys/fs/cgroup"
 )
 
 var (
@@ -45,17 +43,7 @@ var (
 )
 
 func NewExecutor() Executor {
-	e := LinuxExecutor{}
-
-	// TODO: In a follow-up PR make it so this only happens once per client.
-	// Fingerprinting shouldn't happen per task.
-
-	// Check that cgroups are available.
-	if _, err := os.Stat(cgroupMount); err == nil {
-		e.cgroupEnabled = true
-	}
-
-	return &e
+	return &LinuxExecutor{}
 }
 
 // Linux executor is designed to run on linux kernel 2.8+.
@@ -63,22 +51,24 @@ type LinuxExecutor struct {
 	cmd
 	user *user.User
 
-	// Finger print capabilities.
-	cgroupEnabled bool
-
 	// Isolation configurations.
 	groups   *cgroupConfig.Cgroup
 	alloc    *allocdir.AllocDir
 	taskName string
 	taskDir  string
 
-	// Tracking of child process.
-	spawnChild        exec.Cmd
+	// Tracking of spawn process.
+	spawnChild        *os.Process
 	spawnOutputWriter *os.File
 	spawnOutputReader *os.File
 
-	// Track whether there are filesystems mounted in the task dir.
-	mounts bool
+	// Tracking of user process.
+	exitStatusFile string
+	userPid        int
+}
+
+func (e *LinuxExecutor) Command() *cmd {
+	return &e.cmd
 }
 
 func (e *LinuxExecutor) Limit(resources *structs.Resources) error {
@@ -86,139 +76,62 @@ func (e *LinuxExecutor) Limit(resources *structs.Resources) error {
 		return errNoResources
 	}
 
-	if e.cgroupEnabled {
-		return e.configureCgroups(resources)
+	return e.configureCgroups(resources)
+}
+
+// execLinuxID contains the necessary information to reattach to an executed
+// process and cleanup the created cgroups.
+type ExecLinuxID struct {
+	Groups         *cgroupConfig.Cgroup
+	SpawnPid       int
+	UserPid        int
+	ExitStatusFile string
+	TaskDir        string
+}
+
+func (e *LinuxExecutor) Open(id string) error {
+	// De-serialize the ID.
+	dec := json.NewDecoder(strings.NewReader(id))
+	var execID ExecLinuxID
+	if err := dec.Decode(&execID); err != nil {
+		return fmt.Errorf("Failed to parse id: %v", err)
+	}
+
+	// Setup the executor.
+	e.groups = execID.Groups
+	e.exitStatusFile = execID.ExitStatusFile
+	e.userPid = execID.UserPid
+	e.taskDir = execID.TaskDir
+
+	proc, err := os.FindProcess(execID.SpawnPid)
+	if proc != nil && err == nil {
+		e.spawnChild = proc
 	}
 
 	return nil
 }
 
-func (e *LinuxExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocDir) error {
-	e.taskName = taskName
-	taskDir, ok := alloc.TaskDirs[taskName]
-	if !ok {
-		fmt.Errorf("Couldn't find task directory for task %v", taskName)
-	}
-	e.taskDir = taskDir
-
-	if err := alloc.MountSharedDir(taskName); err != nil {
-		return err
+func (e *LinuxExecutor) ID() (string, error) {
+	if e.spawnChild == nil {
+		return "", fmt.Errorf("Process has finished or was never started")
 	}
 
-	if err := alloc.Embed(taskName, chrootEnv); err != nil {
-		return err
+	// Build the ID.
+	id := ExecLinuxID{
+		Groups:         e.groups,
+		SpawnPid:       e.spawnChild.Pid,
+		UserPid:        e.userPid,
+		ExitStatusFile: e.exitStatusFile,
+		TaskDir:        e.taskDir,
 	}
 
-	// Mount dev
-	dev := filepath.Join(taskDir, "dev")
-	if err := os.Mkdir(dev, 0777); err != nil {
-		return fmt.Errorf("Mkdir(%v) failed: %v", dev, err)
+	var buffer bytes.Buffer
+	enc := json.NewEncoder(&buffer)
+	if err := enc.Encode(id); err != nil {
+		return "", fmt.Errorf("Failed to serialize id: %v", err)
 	}
 
-	if err := syscall.Mount("", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
-		return fmt.Errorf("Couldn't mount /dev to %v: %v", dev, err)
-	}
-
-	// Mount proc
-	proc := filepath.Join(taskDir, "proc")
-	if err := os.Mkdir(proc, 0777); err != nil {
-		return fmt.Errorf("Mkdir(%v) failed: %v", proc, err)
-	}
-
-	if err := syscall.Mount("", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
-		return fmt.Errorf("Couldn't mount /proc to %v: %v", proc, err)
-	}
-
-	// Set the tasks AllocDir environment variable.
-	env, err := environment.ParseFromList(e.Cmd.Env)
-	if err != nil {
-		return err
-	}
-	env.SetAllocDir(filepath.Join("/", allocdir.SharedAllocName))
-	env.SetTaskLocalDir(filepath.Join("/", allocdir.TaskLocal))
-	e.Cmd.Env = env.List()
-
-	e.alloc = alloc
-	e.mounts = true
-	return nil
-}
-
-func (e *LinuxExecutor) cleanTaskDir() error {
-	if e.alloc == nil {
-		return errors.New("ConfigureTaskDir() must be called before Start()")
-	}
-
-	if !e.mounts {
-		return nil
-	}
-
-	// Unmount dev.
-	errs := new(multierror.Error)
-	dev := filepath.Join(e.taskDir, "dev")
-	if err := syscall.Unmount(dev, 0); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("Failed to unmount dev (%v): %v", dev, err))
-	}
-
-	// Unmount proc.
-	proc := filepath.Join(e.taskDir, "proc")
-	if err := syscall.Unmount(proc, 0); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("Failed to unmount proc (%v): %v", proc, err))
-	}
-
-	e.mounts = false
-	return errs.ErrorOrNil()
-}
-
-func (e *LinuxExecutor) configureCgroups(resources *structs.Resources) error {
-	if !e.cgroupEnabled {
-		return nil
-	}
-
-	e.groups = &cgroupConfig.Cgroup{}
-
-	// Groups will be created in a heiarchy according to the resource being
-	// constrained, current session, and then this unique name. Restraints are
-	// then placed in the corresponding files.
-	// Ex: restricting a process to 2048Mhz CPU and 2MB of memory:
-	//   $ cat /sys/fs/cgroup/cpu/user/1000.user/4.session/<uuid>/cpu.shares
-	//		2028
-	//   $ cat /sys/fs/cgroup/memory/user/1000.user/4.session/<uuid>/memory.limit_in_bytes
-	//		2097152
-	e.groups.Name = structs.GenerateUUID()
-
-	// TODO: verify this is needed for things like network access
-	e.groups.AllowAllDevices = true
-
-	if resources.MemoryMB > 0 {
-		// Total amount of memory allowed to consume
-		e.groups.Memory = int64(resources.MemoryMB * 1024 * 1024)
-		// Disable swap to avoid issues on the machine
-		e.groups.MemorySwap = int64(-1)
-	}
-
-	if resources.CPU != 0 {
-		if resources.CPU < 2 {
-			return fmt.Errorf("resources.CPU must be equal to or greater than 2: %v", resources.CPU)
-		}
-
-		// Set the relative CPU shares for this cgroup.
-		// The simplest scale is 1 share to 1 MHz so 1024 = 1GHz. This means any
-		// given process will have at least that amount of resources, but likely
-		// more since it is (probably) rare that the machine will run at 100%
-		// CPU. This scale will cease to work if a node is overprovisioned.
-		e.groups.CpuShares = int64(resources.CPU)
-	}
-
-	if resources.IOPS != 0 {
-		// Validate it is in an acceptable range.
-		if resources.IOPS < 10 || resources.IOPS > 1000 {
-			return fmt.Errorf("resources.IOPS must be between 10 and 1000: %d", resources.IOPS)
-		}
-
-		e.groups.BlkioWeight = uint16(resources.IOPS)
-	}
-
-	return nil
+	return buffer.String(), nil
 }
 
 func (e *LinuxExecutor) runAs(userid string) error {
@@ -292,33 +205,30 @@ func (e *LinuxExecutor) spawnDaemon() error {
 		return fmt.Errorf("Failed to determine the nomad executable: %v", err)
 	}
 
+	c := command.DaemonConfig{
+		Cmd:            e.cmd.Cmd,
+		Chroot:         e.taskDir,
+		StdoutFile:     filepath.Join(e.taskDir, allocdir.TaskLocal, fmt.Sprintf("%v.stdout", e.taskName)),
+		StderrFile:     filepath.Join(e.taskDir, allocdir.TaskLocal, fmt.Sprintf("%v.stderr", e.taskName)),
+		StdinFile:      "/dev/null",
+		ExitStatusFile: e.exitStatusFile,
+	}
+
 	// Serialize the cmd and the cgroup configuration so it can be passed to the
 	// sub-process.
 	var buffer bytes.Buffer
 	enc := json.NewEncoder(&buffer)
-
-	c := command.DaemonConfig{
-		Cmd:        e.cmd.Cmd,
-		Chroot:     e.taskDir,
-		StdoutFile: filepath.Join(e.taskDir, allocdir.TaskLocal, fmt.Sprintf("%v.stdout", e.taskName)),
-		StderrFile: filepath.Join(e.taskDir, allocdir.TaskLocal, fmt.Sprintf("%v.stderr", e.taskName)),
-		StdinFile:  "/dev/null",
-	}
 	if err := enc.Encode(c); err != nil {
 		return fmt.Errorf("Failed to serialize daemon configuration: %v", err)
 	}
 
-	// Create a pipe to capture Stdout.
-	pr, pw, err := os.Pipe()
-	if err != nil {
+	// Create a pipe to capture stdout.
+	if e.spawnOutputReader, e.spawnOutputWriter, err = os.Pipe(); err != nil {
 		return err
 	}
-	e.spawnOutputWriter = pw
-	e.spawnOutputReader = pr
 
 	// Call ourselves using a hidden flag. The new instance of nomad will join
-	// the passed cgroup, forkExec the cmd, and output status codes through
-	// Stdout.
+	// the passed cgroup, forkExec the cmd, and return statuses through stdout.
 	escaped := strconv.Quote(buffer.String())
 	spawn := exec.Command(bin, "spawn-daemon", escaped)
 	spawn.Stdout = e.spawnOutputWriter
@@ -334,26 +244,19 @@ func (e *LinuxExecutor) spawnDaemon() error {
 	}
 
 	// Join the spawn-daemon to the cgroup.
-	if e.groups != nil {
-		manager := cgroupFs.Manager{}
-		manager.Cgroups = e.groups
+	manager := e.getCgroupManager(e.groups)
 
-		// Apply will place the current pid into the tasks file for each of the
-		// created cgroups:
-		//  /sys/fs/cgroup/memory/user/1000.user/4.session/<uuid>/tasks
-		//
-		// Apply requires superuser permissions, and may fail if Nomad is not run with
-		// the required permissions
-		if err := manager.Apply(spawn.Process.Pid); err != nil {
-			errs := new(multierror.Error)
-			errs = multierror.Append(errs, fmt.Errorf("Failed to join spawn-daemon to the cgroup (config => %+v): %v", manager.Cgroups, err))
+	// Apply will place the spawn dameon into the created cgroups.
+	if err := manager.Apply(spawn.Process.Pid); err != nil {
+		errs := new(multierror.Error)
+		errs = multierror.Append(errs,
+			fmt.Errorf("Failed to join spawn-daemon to the cgroup (%+v): %v", e.groups, err))
 
-			if err := sendAbortCommand(spawnStdIn); err != nil {
-				errs = multierror.Append(errs, err)
-			}
-
-			return errs
+		if err := sendAbortCommand(spawnStdIn); err != nil {
+			errs = multierror.Append(errs, err)
 		}
+
+		return errs
 	}
 
 	// Tell it to start.
@@ -372,7 +275,8 @@ func (e *LinuxExecutor) spawnDaemon() error {
 		return fmt.Errorf("Failed to execute user command: %s", resp.ErrorMsg)
 	}
 
-	e.spawnChild = *spawn
+	e.userPid = resp.UserPID
+	e.spawnChild = spawn.Process
 	return nil
 }
 
@@ -394,74 +298,22 @@ func sendAbortCommand(w io.Writer) error {
 	return nil
 }
 
-// Open's behavior is to kill all processes associated with the id and return an
-// error. This is done because it is not possible to re-attach to the
-// spawn-daemon's stdout to retrieve status messages.
-func (e *LinuxExecutor) Open(id string) error {
-	parts := strings.SplitN(id, ":", 2)
-	if len(parts) != 2 {
-		return fmt.Errorf("Invalid id: %v", id)
-	}
-
-	switch parts[0] {
-	case "PID":
-		pid, err := strconv.Atoi(parts[1])
-		if err != nil {
-			return fmt.Errorf("Invalid id: failed to parse pid %v", parts[1])
-		}
-
-		process, err := os.FindProcess(pid)
-		if err != nil {
-			return fmt.Errorf("Failed to find Pid %v: %v", pid, err)
-		}
-
-		if err := process.Kill(); err != nil {
-			return fmt.Errorf("Failed to kill Pid %v: %v", pid, err)
-		}
-	case "CGROUP":
-		if !e.cgroupEnabled {
-			return errors.New("Passed a a cgroup identifier, but cgroups are disabled")
-		}
-
-		// De-serialize the cgroup configuration.
-		dec := json.NewDecoder(strings.NewReader(parts[1]))
-		var groups cgroupConfig.Cgroup
-		if err := dec.Decode(&groups); err != nil {
-			return fmt.Errorf("Failed to parse cgroup configuration: %v", err)
-		}
-
-		e.groups = &groups
-		if err := e.destroyCgroup(); err != nil {
-			return err
-		}
-		// TODO: cleanTaskDir is a little more complicated here because the OS
-		// may have already unmounted in the case of a restart. Need to scan.
-	default:
-		return fmt.Errorf("Invalid id type: %v", parts[0])
-	}
-
-	return errors.New("Could not re-open to id (intended).")
-}
-
 func (e *LinuxExecutor) Wait() error {
-	if e.spawnChild.Process == nil {
-		return errors.New("Can not find child to wait on")
+	if e.spawnOutputReader != nil {
+		e.spawnOutputReader.Close()
 	}
 
-	defer e.spawnOutputWriter.Close()
-	defer e.spawnOutputReader.Close()
+	if e.spawnOutputWriter != nil {
+		e.spawnOutputWriter.Close()
+	}
 
 	errs := new(multierror.Error)
-	if err := e.spawnChild.Wait(); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("Wait failed on pid %v: %v", e.spawnChild.Process.Pid, err))
+	if err := e.spawnWait(); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("Wait failed on pid %v: %v", e.spawnChild.Pid, err))
 	}
 
-	// If they fork/exec and then exit, wait will return but they will be still
-	// running processes so we need to kill the full cgroup.
-	if e.groups != nil {
-		if err := e.destroyCgroup(); err != nil {
-			errs = multierror.Append(errs, err)
-		}
+	if err := e.destroyCgroup(); err != nil {
+		errs = multierror.Append(errs, err)
 	}
 
 	if err := e.cleanTaskDir(); err != nil {
@@ -471,27 +323,18 @@ func (e *LinuxExecutor) Wait() error {
 	return errs.ErrorOrNil()
 }
 
-// If cgroups are used, the ID is the cgroup structurue. Otherwise, it is the
-// PID of the spawn-daemon process. An error is returned if the process was
-// never started.
-func (e *LinuxExecutor) ID() (string, error) {
-	if e.spawnChild.Process != nil {
-		if e.cgroupEnabled && e.groups != nil {
-			// Serialize the cgroup structure so it can be undone on suabsequent
-			// opens.
-			var buffer bytes.Buffer
-			enc := json.NewEncoder(&buffer)
-			if err := enc.Encode(e.groups); err != nil {
-				return "", fmt.Errorf("Failed to serialize daemon configuration: %v", err)
-			}
-
-			return fmt.Sprintf("CGROUP:%v", buffer.String()), nil
-		}
-
-		return fmt.Sprintf("PID:%d", e.spawnChild.Process.Pid), nil
+// spawnWait waits on the spawn-daemon and can handle the spawn-daemon not being
+// a child of this process.
+func (e *LinuxExecutor) spawnWait() error {
+	// TODO: This needs to be able to wait on non-child processes.
+	state, err := e.spawnChild.Wait()
+	if err != nil {
+		return err
+	} else if !state.Success() {
+		return fmt.Errorf("exited with non-zero code")
 	}
 
-	return "", fmt.Errorf("Process has finished or was never started")
+	return nil
 }
 
 func (e *LinuxExecutor) Shutdown() error {
@@ -507,16 +350,6 @@ func (e *LinuxExecutor) ForceStop() error {
 		e.spawnOutputWriter.Close()
 	}
 
-	// If the task is not running inside a cgroup then just the spawn-daemon child is killed.
-	// TODO: Find a good way to kill the children of the spawn-daemon.
-	if e.groups == nil {
-		if err := e.spawnChild.Process.Kill(); err != nil {
-			return fmt.Errorf("Failed to kill child (%v): %v", e.spawnChild.Process.Pid, err)
-		}
-
-		return nil
-	}
-
 	errs := new(multierror.Error)
 	if e.groups != nil {
 		if err := e.destroyCgroup(); err != nil {
@@ -531,13 +364,131 @@ func (e *LinuxExecutor) ForceStop() error {
 	return errs.ErrorOrNil()
 }
 
+// Task Directory related functions.
+
+func (e *LinuxExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocDir) error {
+	e.taskName = taskName
+	taskDir, ok := alloc.TaskDirs[taskName]
+	if !ok {
+		fmt.Errorf("Couldn't find task directory for task %v", taskName)
+	}
+	e.taskDir = taskDir
+
+	if err := alloc.MountSharedDir(taskName); err != nil {
+		return err
+	}
+
+	if err := alloc.Embed(taskName, chrootEnv); err != nil {
+		return err
+	}
+
+	// Mount dev
+	dev := filepath.Join(taskDir, "dev")
+	if err := os.Mkdir(dev, 0777); err != nil {
+		return fmt.Errorf("Mkdir(%v) failed: %v", dev, err)
+	}
+
+	if err := syscall.Mount("", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("Couldn't mount /dev to %v: %v", dev, err)
+	}
+
+	// Mount proc
+	proc := filepath.Join(taskDir, "proc")
+	if err := os.Mkdir(proc, 0777); err != nil {
+		return fmt.Errorf("Mkdir(%v) failed: %v", proc, err)
+	}
+
+	if err := syscall.Mount("", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("Couldn't mount /proc to %v: %v", proc, err)
+	}
+
+	// Set the tasks AllocDir environment variable.
+	env, err := environment.ParseFromList(e.Cmd.Env)
+	if err != nil {
+		return err
+	}
+	env.SetAllocDir(filepath.Join("/", allocdir.SharedAllocName))
+	env.SetTaskLocalDir(filepath.Join("/", allocdir.TaskLocal))
+	e.Cmd.Env = env.List()
+
+	// Store the file path to save the exit status to.
+	e.exitStatusFile = filepath.Join(alloc.AllocDir, fmt.Sprintf("%s_%s", taskName, "exit_status"))
+
+	e.alloc = alloc
+	return nil
+}
+
+func (e *LinuxExecutor) pathExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *LinuxExecutor) cleanTaskDir() error {
+	// Unmount dev.
+	errs := new(multierror.Error)
+	dev := filepath.Join(e.taskDir, "dev")
+	if e.pathExists(dev) {
+		if err := syscall.Unmount(dev, 0); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("Failed to unmount dev (%v): %v", dev, err))
+		}
+	}
+
+	// Unmount proc.
+	proc := filepath.Join(e.taskDir, "proc")
+	if e.pathExists(proc) {
+		if err := syscall.Unmount(proc, 0); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("Failed to unmount proc (%v): %v", proc, err))
+		}
+	}
+
+	return errs.ErrorOrNil()
+}
+
+// Cgroup related functions.
+
+func (e *LinuxExecutor) configureCgroups(resources *structs.Resources) error {
+	e.groups = &cgroupConfig.Cgroup{}
+	e.groups.Name = structs.GenerateUUID()
+
+	// TODO: verify this is needed for things like network access
+	e.groups.AllowAllDevices = true
+
+	if resources.MemoryMB > 0 {
+		// Total amount of memory allowed to consume
+		e.groups.Memory = int64(resources.MemoryMB * 1024 * 1024)
+		// Disable swap to avoid issues on the machine
+		e.groups.MemorySwap = int64(-1)
+	}
+
+	if resources.CPU < 2 {
+		return fmt.Errorf("resources.CPU must be equal to or greater than 2: %v", resources.CPU)
+	}
+
+	// Set the relative CPU shares for this cgroup.
+	e.groups.CpuShares = int64(resources.CPU)
+
+	if resources.IOPS != 0 {
+		// Validate it is in an acceptable range.
+		if resources.IOPS < 10 || resources.IOPS > 1000 {
+			return fmt.Errorf("resources.IOPS must be between 10 and 1000: %d", resources.IOPS)
+		}
+
+		e.groups.BlkioWeight = uint16(resources.IOPS)
+	}
+
+	return nil
+}
+
 func (e *LinuxExecutor) destroyCgroup() error {
 	if e.groups == nil {
 		return errors.New("Can't destroy: cgroup configuration empty")
 	}
 
-	manager := cgroupFs.Manager{}
-	manager.Cgroups = e.groups
+	manager := e.getCgroupManager(e.groups)
 	pids, err := manager.GetPids()
 	if err != nil {
 		return fmt.Errorf("Failed to get pids in the cgroup %v: %v", e.groups.Name, err)
@@ -555,11 +506,6 @@ func (e *LinuxExecutor) destroyCgroup() error {
 			multierror.Append(errs, fmt.Errorf("Failed to kill Pid %v: %v", pid, err))
 			continue
 		}
-
-		if _, err := process.Wait(); err != nil {
-			multierror.Append(errs, fmt.Errorf("Failed to wait Pid %v: %v", pid, err))
-			continue
-		}
 	}
 
 	// Remove the cgroup.
@@ -574,6 +520,12 @@ func (e *LinuxExecutor) destroyCgroup() error {
 	return nil
 }
 
-func (e *LinuxExecutor) Command() *cmd {
-	return &e.cmd
+// getCgroupManager returns the correct libcontainer cgroup manager.
+func (e *LinuxExecutor) getCgroupManager(groups *cgroupConfig.Cgroup) cgroups.Manager {
+	var manager cgroups.Manager
+	manager = &cgroupFs.Manager{Cgroups: groups}
+	if systemd.UseSystemd() {
+		manager = &systemd.Manager{Cgroups: groups}
+	}
+	return manager
 }

--- a/client/executor/exec_universal.go
+++ b/client/executor/exec_universal.go
@@ -3,105 +3,20 @@
 package executor
 
 import (
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-
 	"github.com/hashicorp/nomad/client/allocdir"
-	"github.com/hashicorp/nomad/client/driver/args"
-	"github.com/hashicorp/nomad/client/driver/environment"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-func NewExecutor() Executor {
-	return &UniversalExecutor{}
-}
+// UniversalExecutor exists to make the exec driver compile on all operating systems.
+type UniversalExecutor struct{}
 
-// UniversalExecutor should work everywhere, and as a result does not include
-// any resource restrictions or runas capabilities.
-type UniversalExecutor struct {
-	cmd
-}
-
-func (e *UniversalExecutor) Limit(resources *structs.Resources) error {
-	if resources == nil {
-		return errNoResources
-	}
-	return nil
-}
-
-func (e *UniversalExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocDir) error {
-	taskDir, ok := alloc.TaskDirs[taskName]
-	if !ok {
-		return fmt.Errorf("Error finding task dir for (%s)", taskName)
-	}
-	e.Dir = taskDir
-	return nil
-}
-
-func (e *UniversalExecutor) Start() error {
-	// Parse the commands arguments and replace instances of Nomad environment
-	// variables.
-	envVars, err := environment.ParseFromList(e.cmd.Env)
-	if err != nil {
-		return err
-	}
-
-	parsedPath, err := args.ParseAndReplace(e.cmd.Path, envVars.Map())
-	if err != nil {
-		return err
-	} else if len(parsedPath) != 1 {
-		return fmt.Errorf("couldn't properly parse command path: %v", e.cmd.Path)
-	}
-
-	e.cmd.Path = parsedPath[0]
-	combined := strings.Join(e.cmd.Args, " ")
-	parsed, err := args.ParseAndReplace(combined, envVars.Map())
-	if err != nil {
-		return err
-	}
-	e.Cmd.Args = parsed
-
-	// We don't want to call ourself. We want to call Start on our embedded Cmd
-	return e.cmd.Start()
-}
-
-func (e *UniversalExecutor) Open(pid string) error {
-	pidNum, err := strconv.Atoi(pid)
-	if err != nil {
-		return fmt.Errorf("Failed to parse pid %v: %v", pid, err)
-	}
-
-	process, err := os.FindProcess(pidNum)
-	if err != nil {
-		return fmt.Errorf("Failed to reopen pid %d: %v", pidNum, err)
-	}
-	e.Process = process
-	return nil
-}
-
-func (e *UniversalExecutor) Wait() error {
-	// We don't want to call ourself. We want to call Start on our embedded Cmd
-	return e.cmd.Wait()
-}
-
-func (e *UniversalExecutor) ID() (string, error) {
-	if e.cmd.Process != nil {
-		return strconv.Itoa(e.cmd.Process.Pid), nil
-	} else {
-		return "", fmt.Errorf("Process has finished or was never started")
-	}
-}
-
-func (e *UniversalExecutor) Shutdown() error {
-	return e.ForceStop()
-}
-
-func (e *UniversalExecutor) ForceStop() error {
-	return e.Process.Kill()
-}
-
-func (e *UniversalExecutor) Command() *cmd {
-	return &e.cmd
-}
+func NewExecutor() Executor                                                    { return &UniversalExecutor{} }
+func (e *UniversalExecutor) Limit(resources *structs.Resources) error          { return nil }
+func (e *UniversalExecutor) ConfigureTaskDir(string, *allocdir.AllocDir) error { return nil }
+func (e *UniversalExecutor) Start() error                                      { return nil }
+func (e *UniversalExecutor) Open(pid string) error                             { return nil }
+func (e *UniversalExecutor) Wait() error                                       { return nil }
+func (e *UniversalExecutor) ID() (string, error)                               { return "", nil }
+func (e *UniversalExecutor) Shutdown() error                                   { return nil }
+func (e *UniversalExecutor) ForceStop() error                                  { return nil }
+func (e *UniversalExecutor) Command() *cmd                                     { return nil }

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -8,8 +8,8 @@ import (
 )
 
 func ExecCompatible(t *testing.T) {
-	if runtime.GOOS != "windows" && syscall.Geteuid() != 0 {
-		t.Skip("Must be root on non-windows environments to run test")
+	if runtime.GOOS != "linux" || syscall.Geteuid() != 0 {
+		t.Skip("Test only available running as root on linux")
 	}
 }
 

--- a/command/spawn_daemon.go
+++ b/command/spawn_daemon.go
@@ -192,7 +192,7 @@ func (c *SpawnDaemonCommand) outputStartStatus(err error, status int) int {
 		startStatus.ErrorMsg = err.Error()
 	}
 
-	if c.config != nil && c.config.Process == nil {
+	if c.config != nil && c.config.Process != nil {
 		startStatus.UserPID = c.config.Process.Pid
 	}
 

--- a/command/spawn_daemon.go
+++ b/command/spawn_daemon.go
@@ -2,19 +2,19 @@ package command
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
+	"syscall"
 )
 
 type SpawnDaemonCommand struct {
 	Meta
-}
-
-// Status of executing the user's command.
-type SpawnStartStatus struct {
-	// ErrorMsg will be empty if the user command was started successfully.
-	// Otherwise it will have an error message.
-	ErrorMsg string
+	config   *DaemonConfig
+	exitFile io.WriteCloser
 }
 
 func (c *SpawnDaemonCommand) Help() string {
@@ -23,21 +23,162 @@ Usage: nomad spawn-daemon [options] <daemon_config>
 
   INTERNAL ONLY
 
-  Spawns a daemon process optionally inside a cgroup. The required daemon_config is a json
-  encoding of the DaemonConfig struct containing the isolation configuration and command to run.
-  SpawnStartStatus is json serialized to Stdout upon running the user command or if any error
-  prevents its execution. If there is no error, the process waits on the users
-  command and then json serializes  SpawnExitStatus to Stdout after its termination.
-
-General Options:
-
-  ` + generalOptionsUsage()
+  Spawns a daemon process by double forking. The required daemon_config is a
+  json encoding of the DaemonConfig struct containing the isolation
+  configuration and command to run. SpawnStartStatus is json serialized to
+  stdout upon running the user command or if any error prevents its execution.
+  If there is no error, the process waits on the users command. Once the user
+  command exits, the exit code is written to a file specified in the
+  daemon_config and this process exits with the same exit status as the user
+  command.
+  `
 
 	return strings.TrimSpace(helpText)
 }
 
 func (c *SpawnDaemonCommand) Synopsis() string {
 	return "Spawn a daemon command with configurable isolation."
+}
+
+// Status of executing the user's command.
+type SpawnStartStatus struct {
+	// The PID of the user's command.
+	UserPID int
+
+	// ErrorMsg will be empty if the user command was started successfully.
+	// Otherwise it will have an error message.
+	ErrorMsg string
+}
+
+// Exit status of the user's command.
+type SpawnExitStatus struct {
+	// The exit code of the user's command.
+	ExitCode int
+}
+
+// Configuration for the command to start as a daemon.
+type DaemonConfig struct {
+	exec.Cmd
+
+	// The filepath to write the exit status to.
+	ExitStatusFile string
+
+	// The paths, if not /dev/null, must be either in the tasks root directory
+	// or in the shared alloc directory.
+	StdoutFile string
+	StdinFile  string
+	StderrFile string
+
+	// An optional path specifying the directory to chroot the process in.
+	Chroot string
+}
+
+// Whether to start the user command or abort.
+type TaskStart bool
+
+// parseConfig reads the DaemonConfig from the passed arguments. If not
+// successful, an error is returned.
+func (c *SpawnDaemonCommand) parseConfig(args []string) (*DaemonConfig, error) {
+	flags := c.Meta.FlagSet("spawn-daemon", FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return nil, fmt.Errorf("failed to parse args: %v", err)
+	}
+
+	// Check that we got json input.
+	args = flags.Args()
+	if len(args) != 1 {
+		return nil, fmt.Errorf("incorrect number of args; got %v; want 1", len(args))
+	}
+	jsonInput, err := strconv.Unquote(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unquote json input: %v", err)
+	}
+
+	// De-serialize the passed command.
+	var config DaemonConfig
+	dec := json.NewDecoder(strings.NewReader(jsonInput))
+	if err := dec.Decode(&config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// configureLogs creates the log files and redirects the process
+// stdin/stderr/stdout to them. If unsuccessful, an error is returned.
+func (c *SpawnDaemonCommand) configureLogs() error {
+	stdo, err := os.OpenFile(c.config.StdoutFile, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0666)
+	if err != nil {
+		return fmt.Errorf("Error opening file to redirect stdout: %v", err)
+	}
+
+	stde, err := os.OpenFile(c.config.StderrFile, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0666)
+	if err != nil {
+		return fmt.Errorf("Error opening file to redirect stderr: %v", err)
+	}
+
+	stdi, err := os.OpenFile(c.config.StdinFile, os.O_CREATE|os.O_RDONLY, 0666)
+	if err != nil {
+		return fmt.Errorf("Error opening file to redirect stdin: %v", err)
+	}
+
+	c.config.Cmd.Stdout = stdo
+	c.config.Cmd.Stderr = stde
+	c.config.Cmd.Stdin = stdi
+	return nil
+}
+
+func (c *SpawnDaemonCommand) Run(args []string) int {
+	var err error
+	c.config, err = c.parseConfig(args)
+	if err != nil {
+		return c.outputStartStatus(err, 1)
+	}
+
+	// Open the file we will be using to write exit codes to. We do this early
+	// to ensure that we don't start the user process when we can't capture its
+	// exit status.
+	c.exitFile, err = os.OpenFile(c.config.ExitStatusFile, os.O_CREATE|os.O_RDWR, 0666)
+	if err != nil {
+		return c.outputStartStatus(fmt.Errorf("Error opening file to store exit status: %v", err), 1)
+	}
+
+	// Isolate the user process.
+	if err := c.isolateCmd(); err != nil {
+		return c.outputStartStatus(err, 1)
+	}
+
+	// Redirect logs.
+	if err := c.configureLogs(); err != nil {
+		return c.outputStartStatus(err, 1)
+	}
+
+	// Chroot jail the process and set its working directory.
+	c.configureChroot()
+
+	// Wait to get the start command.
+	var start TaskStart
+	dec := json.NewDecoder(os.Stdin)
+	if err := dec.Decode(&start); err != nil {
+		return c.outputStartStatus(err, 1)
+	}
+
+	// Aborted by Nomad process.
+	if !start {
+		return 0
+	}
+
+	// Spawn the user process.
+	if err := c.config.Cmd.Start(); err != nil {
+		return c.outputStartStatus(fmt.Errorf("Error starting user command: %v", err), 1)
+	}
+
+	// Indicate that the command was started successfully.
+	c.outputStartStatus(nil, 0)
+
+	// Wait and then output the exit status.
+	return c.writeExitStatus(c.config.Cmd.Wait())
 }
 
 // outputStartStatus is a helper function that outputs a SpawnStartStatus to
@@ -51,6 +192,36 @@ func (c *SpawnDaemonCommand) outputStartStatus(err error, status int) int {
 		startStatus.ErrorMsg = err.Error()
 	}
 
+	if c.config != nil && c.config.Process == nil {
+		startStatus.UserPID = c.config.Process.Pid
+	}
+
 	enc.Encode(startStatus)
 	return status
+}
+
+// writeExitStatus takes in the error result from calling wait and writes out
+// the exit status to a file. It returns the same exit status as the user
+// command.
+func (c *SpawnDaemonCommand) writeExitStatus(exit error) int {
+	// Parse the exit code.
+	exitStatus := &SpawnExitStatus{}
+	if exit != nil {
+		// Default to exit code 1 if we can not get the actual exit code.
+		exitStatus.ExitCode = 1
+
+		if exiterr, ok := exit.(*exec.ExitError); ok {
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				exitStatus.ExitCode = status.ExitStatus()
+			}
+		}
+	}
+
+	if c.exitFile != nil {
+		enc := json.NewEncoder(c.exitFile)
+		enc.Encode(exitStatus)
+		c.exitFile.Close()
+	}
+
+	return exitStatus.ExitCode
 }

--- a/command/spawn_daemon_darwin.go
+++ b/command/spawn_daemon_darwin.go
@@ -1,0 +1,4 @@
+package command
+
+// No chroot on darwin.
+func (c *SpawnDaemonCommand) configureChroot() {}

--- a/command/spawn_daemon_linux.go
+++ b/command/spawn_daemon_linux.go
@@ -1,115 +1,16 @@
 package command
 
-import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
-	"syscall"
-)
+import "syscall"
 
-// Configuration for the command to start as a daemon.
-type DaemonConfig struct {
-	exec.Cmd
+// configureChroot enters the user command into a chroot if specified in the
+// config and on an OS that supports Chroots.
+func (c *SpawnDaemonCommand) configureChroot() {
+	if len(c.config.Chroot) != 0 {
+		if c.config.Cmd.SysProcAttr == nil {
+			c.config.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
 
-	// The paths, if not /dev/null, must be either in the tasks root directory
-	// or in the shared alloc directory.
-	StdoutFile string
-	StdinFile  string
-	StderrFile string
-
-	Chroot string
-}
-
-// Whether to start the user command or abort.
-type TaskStart bool
-
-func (c *SpawnDaemonCommand) Run(args []string) int {
-	flags := c.Meta.FlagSet("spawn-daemon", FlagSetClient)
-	flags.Usage = func() { c.Ui.Output(c.Help()) }
-
-	if err := flags.Parse(args); err != nil {
-		return 1
+		c.config.Cmd.SysProcAttr.Chroot = c.config.Chroot
+		c.config.Cmd.Dir = "/"
 	}
-
-	// Check that we got json input.
-	args = flags.Args()
-	if len(args) != 1 {
-		c.Ui.Error(c.Help())
-		return 1
-	}
-	jsonInput, err := strconv.Unquote(args[0])
-	if err != nil {
-		return c.outputStartStatus(fmt.Errorf("Failed to unquote json input: %v", err), 1)
-	}
-
-	// De-serialize the passed command.
-	var cmd DaemonConfig
-	dec := json.NewDecoder(strings.NewReader(jsonInput))
-	if err := dec.Decode(&cmd); err != nil {
-		return c.outputStartStatus(err, 1)
-	}
-
-	// Isolate the user process.
-	if _, err := syscall.Setsid(); err != nil {
-		return c.outputStartStatus(fmt.Errorf("Failed setting sid: %v", err), 1)
-	}
-
-	syscall.Umask(0)
-
-	// Redirect logs.
-	stdo, err := os.OpenFile(cmd.StdoutFile, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0666)
-	if err != nil {
-		return c.outputStartStatus(fmt.Errorf("Error opening file to redirect Stdout: %v", err), 1)
-	}
-
-	stde, err := os.OpenFile(cmd.StderrFile, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0666)
-	if err != nil {
-		return c.outputStartStatus(fmt.Errorf("Error opening file to redirect Stderr: %v", err), 1)
-	}
-
-	stdi, err := os.OpenFile(cmd.StdinFile, os.O_CREATE|os.O_RDONLY, 0666)
-	if err != nil {
-		return c.outputStartStatus(fmt.Errorf("Error opening file to redirect Stdin: %v", err), 1)
-	}
-
-	cmd.Cmd.Stdout = stdo
-	cmd.Cmd.Stderr = stde
-	cmd.Cmd.Stdin = stdi
-
-	// Chroot jail the process and set its working directory.
-	if cmd.Cmd.SysProcAttr == nil {
-		cmd.Cmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
-
-	cmd.Cmd.SysProcAttr.Chroot = cmd.Chroot
-	cmd.Cmd.Dir = "/"
-
-	// Wait to get the start command.
-	var start TaskStart
-	dec = json.NewDecoder(os.Stdin)
-	if err := dec.Decode(&start); err != nil {
-		return c.outputStartStatus(err, 1)
-	}
-
-	if !start {
-		return 0
-	}
-
-	// Spawn the user process.
-	if err := cmd.Cmd.Start(); err != nil {
-		return c.outputStartStatus(fmt.Errorf("Error starting user command: %v", err), 1)
-	}
-
-	// Indicate that the command was started successfully.
-	c.outputStartStatus(nil, 0)
-
-	// Wait and then output the exit status.
-	if err := cmd.Wait(); err != nil {
-		return 1
-	}
-
-	return 0
 }

--- a/command/spawn_daemon_test.go
+++ b/command/spawn_daemon_test.go
@@ -1,0 +1,48 @@
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+)
+
+type nopCloser struct {
+	io.ReadWriter
+}
+
+func (n *nopCloser) Close() error {
+	return nil
+}
+
+func TestSpawnDaemon_WriteExitStatus(t *testing.T) {
+	// Check if there is python.
+	path, err := exec.LookPath("python")
+	if err != nil {
+		t.Skip("python not detected")
+	}
+
+	var b bytes.Buffer
+	daemon := &SpawnDaemonCommand{exitFile: &nopCloser{&b}}
+
+	code := 3
+	cmd := exec.Command(path, "./test-resources/exiter.py", fmt.Sprintf("%d", code))
+	err = cmd.Run()
+	actual := daemon.writeExitStatus(err)
+	if actual != code {
+		t.Fatalf("writeExitStatus(%v) returned %v; want %v", err, actual, code)
+	}
+
+	// De-serialize the passed command.
+	var exitStatus SpawnExitStatus
+	dec := json.NewDecoder(&b)
+	if err := dec.Decode(&exitStatus); err != nil {
+		t.Fatalf("failed to decode exit status: %v", err)
+	}
+
+	if exitStatus.ExitCode != code {
+		t.Fatalf("writeExitStatus(%v) wrote exit status %v; want %v", err, exitStatus.ExitCode, code)
+	}
+}

--- a/command/spawn_daemon_universal.go
+++ b/command/spawn_daemon_universal.go
@@ -1,9 +1,0 @@
-// +build !linux
-
-package command
-
-import "errors"
-
-func (c *SpawnDaemonCommand) Run(args []string) int {
-	return c.outputStartStatus(errors.New("spawn-daemon not supported"), 1)
-}

--- a/command/spawn_daemon_unix.go
+++ b/command/spawn_daemon_unix.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package command
+
+import "syscall"
+
+// isolateCmd sets the session id for the process and the umask.
+func (c *SpawnDaemonCommand) isolateCmd() error {
+	if c.config.Cmd.SysProcAttr == nil {
+		c.config.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+
+	c.config.Cmd.SysProcAttr.Setsid = true
+	syscall.Umask(0)
+	return nil
+}

--- a/command/spawn_daemon_windows.go
+++ b/command/spawn_daemon_windows.go
@@ -1,0 +1,7 @@
+// build !linux !darwin
+
+package command
+
+// No isolation on Windows.
+func (c *SpawnDaemonCommand) isolateCmd() error { return nil }
+func (c *SpawnDaemonCommand) configureChroot()  {}

--- a/command/test-resources/exiter.py
+++ b/command/test-resources/exiter.py
@@ -1,0 +1,3 @@
+import sys
+
+sys.exit(int(sys.argv[1]))


### PR DESCRIPTION
This PR does the following:
* spawn-daemon is updated to be cross-platform and saves the exit code to disk.
* exec is disabled on all platforms other than linux running as root (only way to do isolation)
* exec_linux is updated to assume cgroups, support systemd, actually implement the Open() interface.

Work left on exec_linux is to support calling Wait() even when the spawn-daemon is not a child process and to read the exit code from the exit status file. This relies on a future PR.