### PR TITLE
website: clean up HTTP docs, add blocking queries

### DIFF
--- a/website/source/docs/http/alloc.html.md
+++ b/website/source/docs/http/alloc.html.md
@@ -31,6 +31,11 @@ be specified using the `?region=` query parameter.
     None
   </dd>
 
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
   <dt>Returns</dt>
   <dd>
 
@@ -179,4 +184,3 @@ be specified using the `?region=` query parameter.
 
   </dd>
 </dl>
-

--- a/website/source/docs/http/allocs.html.md
+++ b/website/source/docs/http/allocs.html.md
@@ -31,6 +31,11 @@ be specified using the `?region=` query parameter.
     None
   </dd>
 
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
   <dt>Returns</dt>
   <dd>
 
@@ -56,4 +61,3 @@ be specified using the `?region=` query parameter.
 
   </dd>
 </dl>
-

--- a/website/source/docs/http/eval.html.md
+++ b/website/source/docs/http/eval.html.md
@@ -3,7 +3,7 @@ layout: "http"
 page_title: "HTTP API: /v1/evaluation"
 sidebar_current: "docs-http-eval-"
 description: |-
-  The '/1/evaluation' endpoint is used to query a specific evaluation.
+  The '/v1/evaluation' endpoint is used to query a specific evaluation.
 ---
 
 # /v1/evaluation
@@ -17,7 +17,7 @@ be specified using the `?region=` query parameter.
 <dl>
   <dt>Description</dt>
   <dd>
-    Lists all the evaluations.
+    Query a specific evaluation.
   </dd>
 
   <dt>Method</dt>
@@ -29,6 +29,11 @@ be specified using the `?region=` query parameter.
   <dt>Parameters</dt>
   <dd>
     None
+  </dd>
+
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
   </dd>
 
   <dt>Returns</dt>
@@ -57,9 +62,6 @@ be specified using the `?region=` query parameter.
   </dd>
 </dl>
 
-# /v1/evaluation/\<ID\>/allocations
-## GET
-
 <dl>
   <dt>Description</dt>
   <dd>
@@ -75,6 +77,11 @@ be specified using the `?region=` query parameter.
   <dt>Parameters</dt>
   <dd>
     None
+  </dd>
+
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
   </dd>
 
   <dt>Returns</dt>
@@ -102,4 +109,3 @@ be specified using the `?region=` query parameter.
 
   </dd>
 </dl>
-

--- a/website/source/docs/http/evals.html.md
+++ b/website/source/docs/http/evals.html.md
@@ -31,6 +31,11 @@ be specified using the `?region=` query parameter.
     None
   </dd>
 
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
   <dt>Returns</dt>
   <dd>
 
@@ -59,4 +64,3 @@ be specified using the `?region=` query parameter.
 
   </dd>
 </dl>
-

--- a/website/source/docs/http/index.html.md
+++ b/website/source/docs/http/index.html.md
@@ -31,6 +31,7 @@ The API is modeled closely on the underlying data model. Use the links to the le
 documentation about specific endpoints. There are also "Agent" APIs which interact with
 a specific agent and not the broader cluster used for administration.
 
+<a name="blocking-queries"></a>
 ## Blocking Queries
 
 Certain endpoints support a feature called a "blocking query." A blocking query

--- a/website/source/docs/http/job.html.md
+++ b/website/source/docs/http/job.html.md
@@ -6,7 +6,7 @@ description: |-
   The '/1/job' endpoint is used for CRUD on a single job.
 ---
 
-# /v1/job/\<ID\>
+# /v1/job
 
 The `job` endpoint is used for CRUD on a single job. By default, the agent's local
 region is used; another region can be specified using the `?region=` query parameter.
@@ -28,6 +28,11 @@ region is used; another region can be specified using the `?region=` query param
   <dt>Parameters</dt>
   <dd>
     None
+  </dd>
+
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
   </dd>
 
   <dt>Returns</dt>
@@ -136,6 +141,105 @@ region is used; another region can be specified using the `?region=` query param
   </dd>
 </dl>
 
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Query the allocations belonging to a single job.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/v1/job/<id>/allocations`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    [
+    {
+        "ID": "3575ba9d-7a12-0c96-7b28-add168c67984",
+        "EvalID": "151accaa-1ac6-90fe-d427-313e70ccbb88",
+        "Name": "binstore-storagelocker.binsl[0]",
+        "NodeID": "a703c3ca-5ff8-11e5-9213-970ee8879d1b",
+        "JobID": "binstore-storagelocker",
+        "TaskGroup": "binsl",
+        "DesiredStatus": "run",
+        "DesiredDescription": "",
+        "ClientStatus": "running",
+        "ClientDescription": "",
+        "CreateIndex": 16,
+        "ModifyIndex": 16
+    },
+    ...
+    ]
+    ```
+
+  </dd>
+</dl>
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Query the evaluations belonging to a single job.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/v1/job/<id>/evaluations`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    [
+    {
+        "ID": "151accaa-1ac6-90fe-d427-313e70ccbb88",
+        "Priority": 50,
+        "Type": "service",
+        "TriggeredBy": "job-register",
+        "JobID": "binstore-storagelocker",
+        "JobModifyIndex": 14,
+        "NodeID": "",
+        "NodeModifyIndex": 0,
+        "Status": "complete",
+        "StatusDescription": "",
+        "Wait": 0,
+        "NextEval": "",
+        "PreviousEval": "",
+        "CreateIndex": 15,
+        "ModifyIndex": 17
+    },
+    ...
+    ]
+    ```
+
+  </dd>
+</dl>
+
 ## PUT / POST
 
 <dl>
@@ -161,6 +265,38 @@ region is used; another region can be specified using the `?region=` query param
         the return response of GET.
       </li>
     </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+    "EvalID": "d092fdc0-e1fd-2536-67d8-43af8ca798ac",
+    "EvalCreateIndex": 35,
+    "JobModifyIndex": 34,
+    }
+    ```
+
+  </dd>
+</dl>
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Creates a new evaluation for the given job. This can be used to force
+    run the scheduling logic if necessary.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>PUT or POST</dd>
+
+  <dt>URL</dt>
+  <dd>`/v1/job/<ID>/evaluate`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
   </dd>
 
   <dt>Returns</dt>
@@ -209,134 +345,3 @@ region is used; another region can be specified using the `?region=` query param
 
   </dd>
 </dl>
-
-# /v1/job/\<ID\>/allocations
-## GET
-
-<dl>
-  <dt>Description</dt>
-  <dd>
-    Query the allocations belonging to a single job.
-  </dd>
-
-  <dt>Method</dt>
-  <dd>GET</dd>
-
-  <dt>URL</dt>
-  <dd>`/v1/job/<id>/allocations`</dd>
-
-  <dt>Parameters</dt>
-  <dd>
-    None
-  </dd>
-
-  <dt>Returns</dt>
-  <dd>
-
-    ```javascript
-    [
-    {
-        "ID": "3575ba9d-7a12-0c96-7b28-add168c67984",
-        "EvalID": "151accaa-1ac6-90fe-d427-313e70ccbb88",
-        "Name": "binstore-storagelocker.binsl[0]",
-        "NodeID": "a703c3ca-5ff8-11e5-9213-970ee8879d1b",
-        "JobID": "binstore-storagelocker",
-        "TaskGroup": "binsl",
-        "DesiredStatus": "run",
-        "DesiredDescription": "",
-        "ClientStatus": "running",
-        "ClientDescription": "",
-        "CreateIndex": 16,
-        "ModifyIndex": 16
-    },
-    ...
-    ]
-    ```
-
-  </dd>
-</dl>
-
-# /v1/job/\<ID\>/evaluate
-## PUT / POST
-
-<dl>
-  <dt>Description</dt>
-  <dd>
-    Creates a new evaluation for the given job. This can be used to force
-    run the scheduling logic if necessary.
-  </dd>
-
-  <dt>Method</dt>
-  <dd>PUT or POST</dd>
-
-  <dt>URL</dt>
-  <dd>`/v1/job/<ID>/evaluate`</dd>
-
-  <dt>Parameters</dt>
-  <dd>
-    None
-  </dd>
-
-  <dt>Returns</dt>
-  <dd>
-
-    ```javascript
-    {
-    "EvalID": "d092fdc0-e1fd-2536-67d8-43af8ca798ac",
-    "EvalCreateIndex": 35,
-    "JobModifyIndex": 34,
-    }
-    ```
-
-  </dd>
-</dl>
-
-# /v1/job/\<ID\>/evaluations
-## GET
-
-<dl>
-  <dt>Description</dt>
-  <dd>
-    Query the evaluations belonging to a single job.
-  </dd>
-
-  <dt>Method</dt>
-  <dd>GET</dd>
-
-  <dt>URL</dt>
-  <dd>`/v1/job/<id>/evaluations`</dd>
-
-  <dt>Parameters</dt>
-  <dd>
-    None
-  </dd>
-
-  <dt>Returns</dt>
-  <dd>
-
-    ```javascript
-    [
-    {
-        "ID": "151accaa-1ac6-90fe-d427-313e70ccbb88",
-        "Priority": 50,
-        "Type": "service",
-        "TriggeredBy": "job-register",
-        "JobID": "binstore-storagelocker",
-        "JobModifyIndex": 14,
-        "NodeID": "",
-        "NodeModifyIndex": 0,
-        "Status": "complete",
-        "StatusDescription": "",
-        "Wait": 0,
-        "NextEval": "",
-        "PreviousEval": "",
-        "CreateIndex": 15,
-        "ModifyIndex": 17
-    },
-    ...
-    ]
-    ```
-
-  </dd>
-</dl>
-

--- a/website/source/docs/http/jobs.html.md
+++ b/website/source/docs/http/jobs.html.md
@@ -31,6 +31,11 @@ another region can be specified using the `?region=` query parameter.
     None
   </dd>
 
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
   <dt>Returns</dt>
   <dd>
 
@@ -93,4 +98,3 @@ another region can be specified using the `?region=` query parameter.
 
   </dd>
 </dl>
-

--- a/website/source/docs/http/node.html.md
+++ b/website/source/docs/http/node.html.md
@@ -31,6 +31,11 @@ be specified using the `?region=` query parameter.
     None
   </dd>
 
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
   <dt>Returns</dt>
   <dd>
 
@@ -82,9 +87,6 @@ be specified using the `?region=` query parameter.
   </dd>
 </dl>
 
-# /v1/node/\<ID\>/allocations
-## GET
-
 <dl>
   <dt>Description</dt>
   <dd>
@@ -100,6 +102,11 @@ be specified using the `?region=` query parameter.
   <dt>Parameters</dt>
   <dd>
     None
+  </dd>
+
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
   </dd>
 
   <dt>Returns</dt>
@@ -128,7 +135,6 @@ be specified using the `?region=` query parameter.
   </dd>
 </dl>
 
-# /v1/node/\<ID\>/evaluate
 ## PUT / POST
 
 <dl>
@@ -163,9 +169,6 @@ be specified using the `?region=` query parameter.
   </dd>
 </dl>
 
-# /v1/node/\<ID\>/drain
-## PUT / POST
-
 <dl>
   <dt>Description</dt>
   <dd>
@@ -175,7 +178,7 @@ be specified using the `?region=` query parameter.
   </dd>
 
   <dt>Method</dt>
-  <dd>PUT or POSt</dd>
+  <dd>PUT or POST</dd>
 
   <dt>URL</dt>
   <dd>`/v1/node/<ID>/drain`</dd>
@@ -205,4 +208,3 @@ be specified using the `?region=` query parameter.
 
   </dd>
 </dl>
-

--- a/website/source/docs/http/nodes.html.md
+++ b/website/source/docs/http/nodes.html.md
@@ -31,6 +31,11 @@ be specified using the `?region=` query parameter.
     None
   </dd>
 
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
   <dt>Returns</dt>
   <dd>
 
@@ -53,5 +58,3 @@ be specified using the `?region=` query parameter.
 
   </dd>
 </dl>
-
-


### PR DESCRIPTION
Makes the structure of the HTTP docs easier to follow, organizing endpoints by HTTP verbs. Also adds an indicator for GET methods which support blocking queries and links that to the overview description, which includes the blocking query parameters, headers, etc.

Requires #366 before merge.