### PR TITLE
Client Side Restarts - Part 1

### DIFF
--- a/api/compose_test.go
+++ b/api/compose_test.go
@@ -69,6 +69,7 @@ func TestCompose(t *testing.T) {
 						Operand: "=",
 					},
 				},
+				RestartPolicy: NewRestartPolicy(),
 				Tasks: []*Task{
 					&Task{
 						Name:   "task1",

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -12,6 +12,14 @@ type RestartPolicy struct {
 	Delay    time.Duration
 }
 
+func NewRestartPolicy() *RestartPolicy {
+	return &RestartPolicy{
+		Attempts: 10,
+		Interval: 3 * time.Minute,
+		Delay:    5 * time.Second,
+	}
+}
+
 // TaskGroup is the unit of scheduling.
 type TaskGroup struct {
 	Name          string
@@ -24,9 +32,11 @@ type TaskGroup struct {
 
 // NewTaskGroup creates a new TaskGroup.
 func NewTaskGroup(name string, count int) *TaskGroup {
+	restartPolicy := NewRestartPolicy()
 	return &TaskGroup{
-		Name:  name,
-		Count: count,
+		Name:          name,
+		Count:         count,
+		RestartPolicy: restartPolicy,
 	}
 }
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1,12 +1,25 @@
 package api
 
+import (
+	"time"
+)
+
+//RestartPolicy defines how the Nomad client restarts
+//tasks in a taskgroup when they fail
+type RestartPolicy struct {
+	Interval time.Duration
+	Attempts int
+	Delay    time.Duration
+}
+
 // TaskGroup is the unit of scheduling.
 type TaskGroup struct {
-	Name        string
-	Count       int
-	Constraints []*Constraint
-	Tasks       []*Task
-	Meta        map[string]string
+	Name          string
+	Count         int
+	Constraints   []*Constraint
+	Tasks         []*Task
+	RestartPolicy *RestartPolicy
+	Meta          map[string]string
 }
 
 // NewTaskGroup creates a new TaskGroup.

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -4,8 +4,8 @@ import (
 	"time"
 )
 
-//RestartPolicy defines how the Nomad client restarts
-//tasks in a taskgroup when they fail
+// RestartPolicy defines how the Nomad client restarts
+// tasks in a taskgroup when they fail
 type RestartPolicy struct {
 	Interval time.Duration
 	Attempts int

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -8,8 +8,9 @@ import (
 func TestTaskGroup_NewTaskGroup(t *testing.T) {
 	grp := NewTaskGroup("grp1", 2)
 	expect := &TaskGroup{
-		Name:  "grp1",
-		Count: 2,
+		Name:          "grp1",
+		Count:         2,
+		RestartPolicy: NewRestartPolicy(),
 	}
 	if !reflect.DeepEqual(grp, expect) {
 		t.Fatalf("expect: %#v, got: %#v", expect, grp)

--- a/command/init.go
+++ b/command/init.go
@@ -110,9 +110,9 @@ job "example" {
 		# The delay value makes Nomad wait for that duration to restart after a Task
 		# fails or crashes.
 		restart {
-			interval = 5m
+			interval = "5m"
 			attempts = 10
-			delay = 25s
+			delay = "25s"
 		}
 
 		# Define a task to run

--- a/command/init.go
+++ b/command/init.go
@@ -104,8 +104,8 @@ job "example" {
 		# Defaults to 1
 		# count = 1
 
-		# Restart Policy - This block defines the restart policy for TaskGroups
-		# attempts defines the number of restarts Nomad will do if Tasks
+		# Restart Policy - This block defines the restart policy for TaskGroups,
+		# the attempts value defines the number of restarts Nomad will do if Tasks
 		# in this TaskGroup fails in a rolling window of interval duration
 		# The delay value makes Nomad wait for that duration to restart after a Task
 		# fails or crashes.

--- a/command/init.go
+++ b/command/init.go
@@ -104,6 +104,17 @@ job "example" {
 		# Defaults to 1
 		# count = 1
 
+		# Restart Policy - This block defines the restart policy for TaskGroups
+		# attempts defines the number of restarts Nomad will do if Tasks
+		# in this TaskGroup fails in a rolling window of interval duration
+		# The delay value makes Nomad wait for that duration to restart after a Task
+		# fails or crashes.
+		restart {
+			interval = 5m
+			attempts = 10
+			delay = 25s
+		}
+
 		# Define a task to run
 		task "redis" {
 			# Use Docker to run the task.

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -202,8 +202,9 @@ func parseGroups(result *structs.Job, obj *hclobj.Object) error {
 				return err
 			}
 		}
+		g.RestartPolicy = structs.NewRestartPolicy(result.Type)
 
-		if err := parseRestartPolicy(structs.NewRestartPolicy(result.Type), o); err != nil {
+		if err := parseRestartPolicy(g.RestartPolicy, o); err != nil {
 			return err
 		}
 

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -30,6 +30,7 @@ func Parse(r io.Reader) (*structs.Job, error) {
 
 	// Parse the buffer
 	obj, err := hcl.Parse(buf.String())
+
 	if err != nil {
 		return nil, fmt.Errorf("error parsing: %s", err)
 	}
@@ -124,7 +125,7 @@ func parseJob(result *structs.Job, obj *hclobj.Object) error {
 		}
 	}
 
-	// If we have tasks outside, do those
+	// If we have tasks outside, create TaskGroups for them
 	if o := obj.Get("task", false); o != nil {
 		var tasks []*structs.Task
 		if err := parseTasks(&tasks, o); err != nil {
@@ -134,9 +135,10 @@ func parseJob(result *structs.Job, obj *hclobj.Object) error {
 		result.TaskGroups = make([]*structs.TaskGroup, len(tasks), len(tasks)*2)
 		for i, t := range tasks {
 			result.TaskGroups[i] = &structs.TaskGroup{
-				Name:  t.Name,
-				Count: 1,
-				Tasks: []*structs.Task{t},
+				Name:          t.Name,
+				Count:         1,
+				Tasks:         []*structs.Task{t},
+				RestartPolicy: structs.NewRestartPolicy(result.Type),
 			}
 		}
 	}
@@ -180,6 +182,7 @@ func parseGroups(result *structs.Job, obj *hclobj.Object) error {
 		delete(m, "constraint")
 		delete(m, "meta")
 		delete(m, "task")
+		delete(m, "restart")
 
 		// Default count to 1 if not specified
 		if _, ok := m["count"]; !ok {
@@ -198,6 +201,10 @@ func parseGroups(result *structs.Job, obj *hclobj.Object) error {
 			if err := parseConstraints(&g.Constraints, o); err != nil {
 				return err
 			}
+		}
+
+		if err := parseRestartPolicy(structs.NewRestartPolicy(result.Type), o); err != nil {
+			return err
 		}
 
 		// Parse out meta fields. These are in HCL as a list so we need
@@ -225,6 +232,42 @@ func parseGroups(result *structs.Job, obj *hclobj.Object) error {
 	}
 
 	result.TaskGroups = append(result.TaskGroups, collection...)
+	return nil
+}
+
+func parseRestartPolicy(result *structs.RestartPolicy, obj *hclobj.Object) error {
+	var restartHclObj *hclobj.Object
+	var m map[string]interface{}
+	if restartHclObj = obj.Get("restart", false); restartHclObj == nil {
+		return nil
+	}
+	if err := hcl.DecodeObject(&m, restartHclObj); err != nil {
+		return err
+	}
+
+	if delay, ok := m["delay"]; ok {
+		d, err := toDuration(delay)
+		if err != nil {
+			return fmt.Errorf("Invalid Delay time in restart policy: %v", err)
+		}
+		result.Delay = d
+	}
+
+	if interval, ok := m["interval"]; ok {
+		i, err := toDuration(interval)
+		if err != nil {
+			return fmt.Errorf("Invalid Interval time in restart policy: %v", err)
+		}
+		result.Interval = i
+	}
+
+	if attempts, ok := m["attempts"]; ok {
+		a, err := toInteger(attempts)
+		if err != nil {
+			return fmt.Errorf("Invalid value in attempts: %v", err)
+		}
+		result.Attempts = a
+	}
 	return nil
 }
 
@@ -476,4 +519,36 @@ func parseUpdate(result *structs.UpdateStrategy, obj *hclobj.Object) error {
 		}
 	}
 	return nil
+}
+
+func toDuration(value interface{}) (time.Duration, error) {
+	var dur time.Duration
+	var err error
+	switch v := value.(type) {
+	case string:
+		dur, err = time.ParseDuration(v)
+	case int:
+		dur = time.Duration(v) * time.Second
+	default:
+		err = fmt.Errorf("Invalid time %s", value)
+	}
+
+	return dur, err
+}
+
+func toInteger(value interface{}) (int, error) {
+	var integer int
+	var err error
+	switch v := value.(type) {
+	case string:
+		var i int64
+		i, err = strconv.ParseInt(v, 10, 32)
+		integer = int(i)
+	case int:
+		integer = v
+	default:
+		err = fmt.Errorf("Value: %v can't be parsed into int", value)
+	}
+
+	return integer, err
 }

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -30,7 +30,6 @@ func Parse(r io.Reader) (*structs.Job, error) {
 
 	// Parse the buffer
 	obj, err := hcl.Parse(buf.String())
-
 	if err != nil {
 		return nil, fmt.Errorf("error parsing: %s", err)
 	}

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -499,19 +499,11 @@ func parseUpdate(result *structs.UpdateStrategy, obj *hclobj.Object) error {
 		}
 		for _, key := range []string{"stagger", "Stagger"} {
 			if raw, ok := m[key]; ok {
-				switch v := raw.(type) {
-				case string:
-					dur, err := time.ParseDuration(v)
-					if err != nil {
-						return fmt.Errorf("invalid stagger time '%s'", raw)
-					}
-					m[key] = dur
-				case int:
-					m[key] = time.Duration(v) * time.Second
-				default:
-					return fmt.Errorf("invalid type for stagger time '%s'",
-						raw)
+				staggerTime, err := toDuration(raw)
+				if err != nil {
+					return fmt.Errorf("Invalid stagger time: %v", err)
 				}
+				m[key] = staggerTime
 			}
 		}
 

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -48,6 +48,11 @@ func TestParse(t *testing.T) {
 					&structs.TaskGroup{
 						Name:  "outside",
 						Count: 1,
+						RestartPolicy: &structs.RestartPolicy{
+							Attempts: 2,
+							Interval: 1 * time.Minute,
+							Delay:    15 * time.Second,
+						},
 						Tasks: []*structs.Task{
 							&structs.Task{
 								Name:   "outside",

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -82,6 +82,11 @@ func TestParse(t *testing.T) {
 							"elb_interval": "10",
 							"elb_checks":   "3",
 						},
+						RestartPolicy: &structs.RestartPolicy{
+							Interval: 10 * time.Minute,
+							Attempts: 5,
+							Delay:    15 * time.Second,
+						},
 						Tasks: []*structs.Task{
 							&structs.Task{
 								Name:   "binstore",

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -31,6 +31,11 @@ job "binstore-storagelocker" {
 
     group "binsl" {
         count = 5
+        restart {
+            attempts = 5
+            interval = "10m"
+            delay = "15s"
+        }
         task "binstore" {
             driver = "docker"
             config {

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1,6 +1,9 @@
 package mock
 
-import "github.com/hashicorp/nomad/nomad/structs"
+import (
+	"github.com/hashicorp/nomad/nomad/structs"
+	"time"
+)
 
 func Node() *structs.Node {
 	node := &structs.Node{
@@ -71,6 +74,11 @@ func Job() *structs.Job {
 			&structs.TaskGroup{
 				Name:  "web",
 				Count: 10,
+				RestartPolicy: &structs.RestartPolicy{
+					Attempts: 3,
+					Interval: 10 * time.Minute,
+					Delay:    1 * time.Minute,
+				},
 				Tasks: []*structs.Task{
 					&structs.Task{
 						Name:   "web",
@@ -131,6 +139,11 @@ func SystemJob() *structs.Job {
 			&structs.TaskGroup{
 				Name:  "web",
 				Count: 1,
+				RestartPolicy: &structs.RestartPolicy{
+					Attempts: 3,
+					Interval: 10 * time.Minute,
+					Delay:    1 * time.Minute,
+				},
 				Tasks: []*structs.Task{
 					&structs.Task{
 						Name:   "web",

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -14,17 +14,8 @@ import (
 )
 
 var (
-	ErrNoLeader           = fmt.Errorf("No cluster leader")
-	ErrNoRegionPath       = fmt.Errorf("No path to region")
-	BatchJobRestartPolicy = RestartPolicy{
-		Delay:    15 * time.Second,
-		Attempts: 15,
-	}
-	ServiceJobRestartPolicy = RestartPolicy{
-		Delay:    15 * time.Second,
-		Attempts: 2,
-		Interval: 1 * time.Minute,
-	}
+	ErrNoLeader     = fmt.Errorf("No cluster leader")
+	ErrNoRegionPath = fmt.Errorf("No path to region")
 )
 
 type MessageType uint8
@@ -925,9 +916,16 @@ func (r *RestartPolicy) Validate() error {
 func NewRestartPolicy(jobType string) *RestartPolicy {
 	switch jobType {
 	case JobTypeService:
-		return &ServiceJobRestartPolicy
+		return &RestartPolicy{
+			Delay:    15 * time.Second,
+			Attempts: 2,
+			Interval: 1 * time.Minute,
+		}
 	case JobTypeBatch:
-		return &BatchJobRestartPolicy
+		return &RestartPolicy{
+			Delay:    15 * time.Second,
+			Attempts: 15,
+		}
 	default:
 		return nil
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -974,10 +974,8 @@ func (tg *TaskGroup) Validate() error {
 		}
 	}
 
-	if tg.RestartPolicy != nil {
-		if err := tg.RestartPolicy.Validate(); err != nil {
-			mErr.Errors = append(mErr.Errors, err)
-		}
+	if err := tg.RestartPolicy.Validate(); err != nil {
+		mErr.Errors = append(mErr.Errors, err)
 	}
 
 	// Check for duplicate tasks

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -14,8 +14,17 @@ import (
 )
 
 var (
-	ErrNoLeader     = fmt.Errorf("No cluster leader")
-	ErrNoRegionPath = fmt.Errorf("No path to region")
+	ErrNoLeader           = fmt.Errorf("No cluster leader")
+	ErrNoRegionPath       = fmt.Errorf("No path to region")
+	BatchJobRestartPolicy = RestartPolicy{
+		Delay:    15 * time.Second,
+		Attempts: 15,
+	}
+	ServiceJobRestartPolicy = RestartPolicy{
+		Delay:    15 * time.Second,
+		Attempts: 2,
+		Interval: 1 * time.Minute,
+	}
 )
 
 type MessageType uint8
@@ -914,18 +923,13 @@ func (r *RestartPolicy) Validate() error {
 }
 
 func NewRestartPolicy(jobType string) *RestartPolicy {
-	defaultDelayBetweenRestarts := 15 * time.Second
-	defaultAttempts := 15
-	var defaultRestartInterval time.Duration
-
-	if jobType == "service" {
-		defaultRestartInterval = 1 * time.Minute
-		defaultAttempts = 2
-	}
-	return &RestartPolicy{
-		Attempts: defaultAttempts,
-		Interval: defaultRestartInterval,
-		Delay:    defaultDelayBetweenRestarts,
+	switch jobType {
+	case JobTypeService:
+		return &ServiceJobRestartPolicy
+	case JobTypeBatch:
+		return &BatchJobRestartPolicy
+	default:
+		return nil
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -16,6 +16,15 @@ import (
 var (
 	ErrNoLeader     = fmt.Errorf("No cluster leader")
 	ErrNoRegionPath = fmt.Errorf("No path to region")
+    defaultServiceJobRestartPolicy = RestartPolicy{
+			Delay:    15 * time.Second,
+			Attempts: 2,
+			Interval: 1 * time.Minute,
+		}
+	defaultBatchJobRestartPolicy = RestartPolicy{
+			Delay:    15 * time.Second,
+			Attempts: 15,
+		}
 )
 
 type MessageType uint8
@@ -916,19 +925,13 @@ func (r *RestartPolicy) Validate() error {
 func NewRestartPolicy(jobType string) *RestartPolicy {
 	switch jobType {
 	case JobTypeService:
-		return &RestartPolicy{
-			Delay:    15 * time.Second,
-			Attempts: 2,
-			Interval: 1 * time.Minute,
-		}
+		rp := defaultServiceJobRestartPolicy
+		return &rp
 	case JobTypeBatch:
-		return &RestartPolicy{
-			Delay:    15 * time.Second,
-			Attempts: 15,
-		}
-	default:
-		return nil
+		rp  := defaultBatchJobRestartPolicy
+		return &rp
 	}
+	return nil
 }
 
 // TaskGroup is an atomic unit of placement. Each task group belongs to

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -992,7 +992,6 @@ func (tg *TaskGroup) Validate() error {
 
 	// Validate the tasks
 	for idx, task := range tg.Tasks {
-
 		if err := task.Validate(); err != nil {
 			outer := fmt.Errorf("Task %d validation failed: %s", idx+1, err)
 			mErr.Errors = append(mErr.Errors, outer)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -974,8 +974,10 @@ func (tg *TaskGroup) Validate() error {
 		}
 	}
 
-	if err := tg.RestartPolicy.Validate(); err != nil {
-		mErr.Errors = append(mErr.Errors, err)
+	if tg.RestartPolicy != nil {
+		if err := tg.RestartPolicy.Validate(); err != nil {
+			mErr.Errors = append(mErr.Errors, err)
+		}
 	}
 
 	// Check for duplicate tasks

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1,11 +1,11 @@
 package structs
 
 import (
+	"github.com/hashicorp/go-multierror"
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/hashicorp/go-multierror"
+	"time"
 )
 
 func TestJob_Validate(t *testing.T) {
@@ -44,11 +44,27 @@ func TestJob_Validate(t *testing.T) {
 		TaskGroups: []*TaskGroup{
 			&TaskGroup{
 				Name: "web",
+				RestartPolicy: &RestartPolicy{
+					Interval: 5 * time.Minute,
+					Delay:    10 * time.Second,
+					Attempts: 10,
+				},
 			},
 			&TaskGroup{
 				Name: "web",
+				RestartPolicy: &RestartPolicy{
+					Interval: 5 * time.Minute,
+					Delay:    10 * time.Second,
+					Attempts: 10,
+				},
 			},
-			&TaskGroup{},
+			&TaskGroup{
+				RestartPolicy: &RestartPolicy{
+					Interval: 5 * time.Minute,
+					Delay:    10 * time.Second,
+					Attempts: 10,
+				},
+			},
 		},
 	}
 	err = j.Validate()
@@ -65,7 +81,13 @@ func TestJob_Validate(t *testing.T) {
 }
 
 func TestTaskGroup_Validate(t *testing.T) {
-	tg := &TaskGroup{}
+	tg := &TaskGroup{
+		RestartPolicy: &RestartPolicy{
+			Interval: 5 * time.Minute,
+			Delay:    10 * time.Second,
+			Attempts: 10,
+		},
+	}
 	err := tg.Validate()
 	mErr := err.(*multierror.Error)
 	if !strings.Contains(mErr.Errors[0].Error(), "group name") {
@@ -85,6 +107,11 @@ func TestTaskGroup_Validate(t *testing.T) {
 			&Task{Name: "web"},
 			&Task{Name: "web"},
 			&Task{},
+		},
+		RestartPolicy: &RestartPolicy{
+			Interval: 5 * time.Minute,
+			Delay:    10 * time.Second,
+			Attempts: 10,
 		},
 	}
 	err = tg.Validate()


### PR DESCRIPTION
This PR implements the logic of parsing Restart Policies at a TaskGroup level and passing it on to clients

The syntax of the Restart Policy would be -

```
group "cache" {
count = 300
....
   restart {
        attempts = 10
        interval = 10m
        delay = 30s
   }
   task "redis" {
        ....
   }

    task "backup_agent" {
         ....
    }
```

In the above example Nomad will restart tasks in the group cache ten times in a duration of 10 minutes if the tasks fails or crashes. We are currently going to support only the one-for-one restart strategy, which means when a task in a Task Group fails we will restart only the failed task. 

For service jobs, restarts will be done indefinitely with ```n``` restarts within the interval specifiedin the restart policy. However, for batch jobs Nomad is going to ignore interval and only do a maximum of ```n``` attempts based on the configuration with a delay of ```m``` seconds.

Tasks which are outside TaskGroups are going to get default restart policies based on the type of their scheduler.

This PR contains only logic of parsing and persisting restart policies, following PRs would implement the logic of implementing restarts on the client side and also restart TaskGroups when a node fails.