### PR TITLE
Improve spawn-daemon and Nomad Client usage of it

### DIFF
--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -35,8 +35,11 @@ func NewExecDriver(ctx *DriverContext) Driver {
 }
 
 func (d *ExecDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
-	// Only enable if we are root when running on non-windows systems.
-	if runtime.GOOS != "windows" && syscall.Geteuid() != 0 {
+	// Only enable if we are root on linux.
+	if runtime.GOOS != "linux" {
+		d.logger.Printf("[DEBUG] driver.exec: only available on linux, disabling")
+		return false, nil
+	} else if syscall.Geteuid() != 0 {
 		d.logger.Printf("[DEBUG] driver.exec: must run as root user, disabling")
 		return false, nil
 	}
@@ -73,10 +76,8 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 		}
 
 		// Add execution permissions to the newly downloaded artifact
-		if runtime.GOOS != "windows" {
-			if err := syscall.Chmod(artifactFile, 0755); err != nil {
-				log.Printf("[ERR] driver.Exec: Error making artifact executable: %s", err)
-			}
+		if err := syscall.Chmod(artifactFile, 0755); err != nil {
+			log.Printf("[ERR] driver.exec: Error making artifact executable: %s", err)
 		}
 	}
 

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -293,7 +293,7 @@ func TestExecDriver_Start_Kill_Wait(t *testing.T) {
 		if err == nil {
 			t.Fatal("should err")
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(8 * time.Second):
 		t.Fatalf("timeout")
 	}
 }

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 	"time"
 
@@ -123,13 +122,7 @@ func TestExecDriver_Start_Wait(t *testing.T) {
 
 func TestExecDriver_Start_Artifact_basic(t *testing.T) {
 	ctestutils.ExecCompatible(t)
-	var file string
-	switch runtime.GOOS {
-	case "darwin":
-		file = "hi_darwin_amd64"
-	default:
-		file = "hi_linux_amd64"
-	}
+	file := "hi_linux_amd64"
 
 	task := &structs.Task{
 		Name: "sleep",
@@ -172,13 +165,7 @@ func TestExecDriver_Start_Artifact_basic(t *testing.T) {
 
 func TestExecDriver_Start_Artifact_expanded(t *testing.T) {
 	ctestutils.ExecCompatible(t)
-	var file string
-	switch runtime.GOOS {
-	case "darwin":
-		file = "hi_darwin_amd64"
-	default:
-		file = "hi_linux_amd64"
-	}
+	file := "hi_linux_amd64"
 
 	task := &structs.Task{
 		Name: "sleep",

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -38,8 +38,8 @@ func NewJavaDriver(ctx *DriverContext) Driver {
 
 func (d *JavaDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
 	// Only enable if we are root when running on non-windows systems.
-	if runtime.GOOS != "windows" && syscall.Geteuid() != 0 {
-		d.logger.Printf("[DEBUG] driver.java: must run as root user, disabling")
+	if runtime.GOOS == "linux" && syscall.Geteuid() != 0 {
+		d.logger.Printf("[DEBUG] driver.java: must run as root user on linux, disabling")
 		return false, nil
 	}
 

--- a/client/driver/java_test.go
+++ b/client/driver/java_test.go
@@ -19,7 +19,7 @@ func javaLocated() bool {
 
 // The fingerprinter test should always pass, even if Java is not installed.
 func TestJavaDriver_Fingerprint(t *testing.T) {
-	ctestutils.ExecCompatible(t)
+	ctestutils.JavaCompatible(t)
 	d := NewJavaDriver(testDriverContext(""))
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -93,7 +93,7 @@ func TestJavaDriver_Start_Wait(t *testing.T) {
 		t.Skip("Java not found; skipping")
 	}
 
-	ctestutils.ExecCompatible(t)
+	ctestutils.JavaCompatible(t)
 	task := &structs.Task{
 		Name: "demo-app",
 		Config: map[string]string{
@@ -141,7 +141,7 @@ func TestJavaDriver_Start_Kill_Wait(t *testing.T) {
 		t.Skip("Java not found; skipping")
 	}
 
-	ctestutils.ExecCompatible(t)
+	ctestutils.JavaCompatible(t)
 	task := &structs.Task{
 		Name: "demo-app",
 		Config: map[string]string{

--- a/client/driver/java_test.go
+++ b/client/driver/java_test.go
@@ -179,7 +179,7 @@ func TestJavaDriver_Start_Kill_Wait(t *testing.T) {
 		if err == nil {
 			t.Fatal("should err")
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(8 * time.Second):
 		t.Fatalf("timeout")
 	}
 

--- a/client/executor/exec_basic.go
+++ b/client/executor/exec_basic.go
@@ -1,0 +1,107 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/driver/args"
+	"github.com/hashicorp/nomad/client/driver/environment"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// BasicExecutor should work everywhere, and as a result does not include
+// any resource restrictions or runas capabilities.
+type BasicExecutor struct {
+	cmd
+}
+
+// TODO: Update to use the Spawner.
+// TODO: Have raw_exec use this as well.
+func NewBasicExecutor() Executor {
+	return &BasicExecutor{}
+}
+
+func (e *BasicExecutor) Limit(resources *structs.Resources) error {
+	if resources == nil {
+		return errNoResources
+	}
+	return nil
+}
+
+func (e *BasicExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocDir) error {
+	taskDir, ok := alloc.TaskDirs[taskName]
+	if !ok {
+		return fmt.Errorf("Error finding task dir for (%s)", taskName)
+	}
+	e.Dir = taskDir
+	return nil
+}
+
+func (e *BasicExecutor) Start() error {
+	// Parse the commands arguments and replace instances of Nomad environment
+	// variables.
+	envVars, err := environment.ParseFromList(e.cmd.Env)
+	if err != nil {
+		return err
+	}
+
+	parsedPath, err := args.ParseAndReplace(e.cmd.Path, envVars.Map())
+	if err != nil {
+		return err
+	} else if len(parsedPath) != 1 {
+		return fmt.Errorf("couldn't properly parse command path: %v", e.cmd.Path)
+	}
+
+	e.cmd.Path = parsedPath[0]
+	combined := strings.Join(e.cmd.Args, " ")
+	parsed, err := args.ParseAndReplace(combined, envVars.Map())
+	if err != nil {
+		return err
+	}
+	e.Cmd.Args = parsed
+
+	// We don't want to call ourself. We want to call Start on our embedded Cmd
+	return e.cmd.Start()
+}
+
+func (e *BasicExecutor) Open(pid string) error {
+	pidNum, err := strconv.Atoi(pid)
+	if err != nil {
+		return fmt.Errorf("Failed to parse pid %v: %v", pid, err)
+	}
+
+	process, err := os.FindProcess(pidNum)
+	if err != nil {
+		return fmt.Errorf("Failed to reopen pid %d: %v", pidNum, err)
+	}
+	e.Process = process
+	return nil
+}
+
+func (e *BasicExecutor) Wait() error {
+	// We don't want to call ourself. We want to call Start on our embedded Cmd
+	return e.cmd.Wait()
+}
+
+func (e *BasicExecutor) ID() (string, error) {
+	if e.cmd.Process != nil {
+		return strconv.Itoa(e.cmd.Process.Pid), nil
+	} else {
+		return "", fmt.Errorf("Process has finished or was never started")
+	}
+}
+
+func (e *BasicExecutor) Shutdown() error {
+	return e.ForceStop()
+}
+
+func (e *BasicExecutor) ForceStop() error {
+	return e.Process.Kill()
+}
+
+func (e *BasicExecutor) Command() *cmd {
+	return &e.cmd
+}

--- a/client/executor/exec_linux.go
+++ b/client/executor/exec_linux.go
@@ -22,12 +22,10 @@ import (
 	"github.com/hashicorp/nomad/helper/discover"
 	"github.com/hashicorp/nomad/nomad/structs"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	cgroupFs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	cgroupConfig "github.com/opencontainers/runc/libcontainer/configs"
-)
-
-const (
-	cgroupMount = "/sys/fs/cgroup"
 )
 
 var (
@@ -45,17 +43,7 @@ var (
 )
 
 func NewExecutor() Executor {
-	e := LinuxExecutor{}
-
-	// TODO: In a follow-up PR make it so this only happens once per client.
-	// Fingerprinting shouldn't happen per task.
-
-	// Check that cgroups are available.
-	if _, err := os.Stat(cgroupMount); err == nil {
-		e.cgroupEnabled = true
-	}
-
-	return &e
+	return &LinuxExecutor{}
 }
 
 // Linux executor is designed to run on linux kernel 2.8+.
@@ -63,22 +51,24 @@ type LinuxExecutor struct {
 	cmd
 	user *user.User
 
-	// Finger print capabilities.
-	cgroupEnabled bool
-
 	// Isolation configurations.
 	groups   *cgroupConfig.Cgroup
 	alloc    *allocdir.AllocDir
 	taskName string
 	taskDir  string
 
-	// Tracking of child process.
-	spawnChild        exec.Cmd
+	// Tracking of spawn process.
+	spawnChild        *os.Process
 	spawnOutputWriter *os.File
 	spawnOutputReader *os.File
 
-	// Track whether there are filesystems mounted in the task dir.
-	mounts bool
+	// Tracking of user process.
+	exitStatusFile string
+	userPid        int
+}
+
+func (e *LinuxExecutor) Command() *cmd {
+	return &e.cmd
 }
 
 func (e *LinuxExecutor) Limit(resources *structs.Resources) error {
@@ -86,139 +76,62 @@ func (e *LinuxExecutor) Limit(resources *structs.Resources) error {
 		return errNoResources
 	}
 
-	if e.cgroupEnabled {
-		return e.configureCgroups(resources)
+	return e.configureCgroups(resources)
+}
+
+// execLinuxID contains the necessary information to reattach to an executed
+// process and cleanup the created cgroups.
+type ExecLinuxID struct {
+	Groups         *cgroupConfig.Cgroup
+	SpawnPid       int
+	UserPid        int
+	ExitStatusFile string
+	TaskDir        string
+}
+
+func (e *LinuxExecutor) Open(id string) error {
+	// De-serialize the ID.
+	dec := json.NewDecoder(strings.NewReader(id))
+	var execID ExecLinuxID
+	if err := dec.Decode(&execID); err != nil {
+		return fmt.Errorf("Failed to parse id: %v", err)
+	}
+
+	// Setup the executor.
+	e.groups = execID.Groups
+	e.exitStatusFile = execID.ExitStatusFile
+	e.userPid = execID.UserPid
+	e.taskDir = execID.TaskDir
+
+	proc, err := os.FindProcess(execID.SpawnPid)
+	if proc != nil && err == nil {
+		e.spawnChild = proc
 	}
 
 	return nil
 }
 
-func (e *LinuxExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocDir) error {
-	e.taskName = taskName
-	taskDir, ok := alloc.TaskDirs[taskName]
-	if !ok {
-		fmt.Errorf("Couldn't find task directory for task %v", taskName)
-	}
-	e.taskDir = taskDir
-
-	if err := alloc.MountSharedDir(taskName); err != nil {
-		return err
+func (e *LinuxExecutor) ID() (string, error) {
+	if e.spawnChild == nil {
+		return "", fmt.Errorf("Process has finished or was never started")
 	}
 
-	if err := alloc.Embed(taskName, chrootEnv); err != nil {
-		return err
+	// Build the ID.
+	id := ExecLinuxID{
+		Groups:         e.groups,
+		SpawnPid:       e.spawnChild.Pid,
+		UserPid:        e.userPid,
+		ExitStatusFile: e.exitStatusFile,
+		TaskDir:        e.taskDir,
 	}
 
-	// Mount dev
-	dev := filepath.Join(taskDir, "dev")
-	if err := os.Mkdir(dev, 0777); err != nil {
-		return fmt.Errorf("Mkdir(%v) failed: %v", dev, err)
+	var buffer bytes.Buffer
+	enc := json.NewEncoder(&buffer)
+	if err := enc.Encode(id); err != nil {
+		return "", fmt.Errorf("Failed to serialize id: %v", err)
 	}
 
-	if err := syscall.Mount("", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
-		return fmt.Errorf("Couldn't mount /dev to %v: %v", dev, err)
-	}
-
-	// Mount proc
-	proc := filepath.Join(taskDir, "proc")
-	if err := os.Mkdir(proc, 0777); err != nil {
-		return fmt.Errorf("Mkdir(%v) failed: %v", proc, err)
-	}
-
-	if err := syscall.Mount("", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
-		return fmt.Errorf("Couldn't mount /proc to %v: %v", proc, err)
-	}
-
-	// Set the tasks AllocDir environment variable.
-	env, err := environment.ParseFromList(e.Cmd.Env)
-	if err != nil {
-		return err
-	}
-	env.SetAllocDir(filepath.Join("/", allocdir.SharedAllocName))
-	env.SetTaskLocalDir(filepath.Join("/", allocdir.TaskLocal))
-	e.Cmd.Env = env.List()
-
-	e.alloc = alloc
-	e.mounts = true
-	return nil
-}
-
-func (e *LinuxExecutor) cleanTaskDir() error {
-	if e.alloc == nil {
-		return errors.New("ConfigureTaskDir() must be called before Start()")
-	}
-
-	if !e.mounts {
-		return nil
-	}
-
-	// Unmount dev.
-	errs := new(multierror.Error)
-	dev := filepath.Join(e.taskDir, "dev")
-	if err := syscall.Unmount(dev, 0); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("Failed to unmount dev (%v): %v", dev, err))
-	}
-
-	// Unmount proc.
-	proc := filepath.Join(e.taskDir, "proc")
-	if err := syscall.Unmount(proc, 0); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("Failed to unmount proc (%v): %v", proc, err))
-	}
-
-	e.mounts = false
-	return errs.ErrorOrNil()
-}
-
-func (e *LinuxExecutor) configureCgroups(resources *structs.Resources) error {
-	if !e.cgroupEnabled {
-		return nil
-	}
-
-	e.groups = &cgroupConfig.Cgroup{}
-
-	// Groups will be created in a heiarchy according to the resource being
-	// constrained, current session, and then this unique name. Restraints are
-	// then placed in the corresponding files.
-	// Ex: restricting a process to 2048Mhz CPU and 2MB of memory:
-	//   $ cat /sys/fs/cgroup/cpu/user/1000.user/4.session/<uuid>/cpu.shares
-	//		2028
-	//   $ cat /sys/fs/cgroup/memory/user/1000.user/4.session/<uuid>/memory.limit_in_bytes
-	//		2097152
-	e.groups.Name = structs.GenerateUUID()
-
-	// TODO: verify this is needed for things like network access
-	e.groups.AllowAllDevices = true
-
-	if resources.MemoryMB > 0 {
-		// Total amount of memory allowed to consume
-		e.groups.Memory = int64(resources.MemoryMB * 1024 * 1024)
-		// Disable swap to avoid issues on the machine
-		e.groups.MemorySwap = int64(-1)
-	}
-
-	if resources.CPU != 0 {
-		if resources.CPU < 2 {
-			return fmt.Errorf("resources.CPU must be equal to or greater than 2: %v", resources.CPU)
-		}
-
-		// Set the relative CPU shares for this cgroup.
-		// The simplest scale is 1 share to 1 MHz so 1024 = 1GHz. This means any
-		// given process will have at least that amount of resources, but likely
-		// more since it is (probably) rare that the machine will run at 100%
-		// CPU. This scale will cease to work if a node is overprovisioned.
-		e.groups.CpuShares = int64(resources.CPU)
-	}
-
-	if resources.IOPS != 0 {
-		// Validate it is in an acceptable range.
-		if resources.IOPS < 10 || resources.IOPS > 1000 {
-			return fmt.Errorf("resources.IOPS must be between 10 and 1000: %d", resources.IOPS)
-		}
-
-		e.groups.BlkioWeight = uint16(resources.IOPS)
-	}
-
-	return nil
+	return buffer.String(), nil
 }
 
 func (e *LinuxExecutor) runAs(userid string) error {
@@ -292,33 +205,30 @@ func (e *LinuxExecutor) spawnDaemon() error {
 		return fmt.Errorf("Failed to determine the nomad executable: %v", err)
 	}
 
+	c := command.DaemonConfig{
+		Cmd:            e.cmd.Cmd,
+		Chroot:         e.taskDir,
+		StdoutFile:     filepath.Join(e.taskDir, allocdir.TaskLocal, fmt.Sprintf("%v.stdout", e.taskName)),
+		StderrFile:     filepath.Join(e.taskDir, allocdir.TaskLocal, fmt.Sprintf("%v.stderr", e.taskName)),
+		StdinFile:      "/dev/null",
+		ExitStatusFile: e.exitStatusFile,
+	}
+
 	// Serialize the cmd and the cgroup configuration so it can be passed to the
 	// sub-process.
 	var buffer bytes.Buffer
 	enc := json.NewEncoder(&buffer)
-
-	c := command.DaemonConfig{
-		Cmd:        e.cmd.Cmd,
-		Chroot:     e.taskDir,
-		StdoutFile: filepath.Join(e.taskDir, allocdir.TaskLocal, fmt.Sprintf("%v.stdout", e.taskName)),
-		StderrFile: filepath.Join(e.taskDir, allocdir.TaskLocal, fmt.Sprintf("%v.stderr", e.taskName)),
-		StdinFile:  "/dev/null",
-	}
 	if err := enc.Encode(c); err != nil {
 		return fmt.Errorf("Failed to serialize daemon configuration: %v", err)
 	}
 
-	// Create a pipe to capture Stdout.
-	pr, pw, err := os.Pipe()
-	if err != nil {
+	// Create a pipe to capture stdout.
+	if e.spawnOutputReader, e.spawnOutputWriter, err = os.Pipe(); err != nil {
 		return err
 	}
-	e.spawnOutputWriter = pw
-	e.spawnOutputReader = pr
 
 	// Call ourselves using a hidden flag. The new instance of nomad will join
-	// the passed cgroup, forkExec the cmd, and output status codes through
-	// Stdout.
+	// the passed cgroup, forkExec the cmd, and return statuses through stdout.
 	escaped := strconv.Quote(buffer.String())
 	spawn := exec.Command(bin, "spawn-daemon", escaped)
 	spawn.Stdout = e.spawnOutputWriter
@@ -334,26 +244,19 @@ func (e *LinuxExecutor) spawnDaemon() error {
 	}
 
 	// Join the spawn-daemon to the cgroup.
-	if e.groups != nil {
-		manager := cgroupFs.Manager{}
-		manager.Cgroups = e.groups
+	manager := e.getCgroupManager(e.groups)
 
-		// Apply will place the current pid into the tasks file for each of the
-		// created cgroups:
-		//  /sys/fs/cgroup/memory/user/1000.user/4.session/<uuid>/tasks
-		//
-		// Apply requires superuser permissions, and may fail if Nomad is not run with
-		// the required permissions
-		if err := manager.Apply(spawn.Process.Pid); err != nil {
-			errs := new(multierror.Error)
-			errs = multierror.Append(errs, fmt.Errorf("Failed to join spawn-daemon to the cgroup (config => %+v): %v", manager.Cgroups, err))
+	// Apply will place the spawn dameon into the created cgroups.
+	if err := manager.Apply(spawn.Process.Pid); err != nil {
+		errs := new(multierror.Error)
+		errs = multierror.Append(errs,
+			fmt.Errorf("Failed to join spawn-daemon to the cgroup (%+v): %v", e.groups, err))
 
-			if err := sendAbortCommand(spawnStdIn); err != nil {
-				errs = multierror.Append(errs, err)
-			}
-
-			return errs
+		if err := sendAbortCommand(spawnStdIn); err != nil {
+			errs = multierror.Append(errs, err)
 		}
+
+		return errs
 	}
 
 	// Tell it to start.
@@ -372,7 +275,8 @@ func (e *LinuxExecutor) spawnDaemon() error {
 		return fmt.Errorf("Failed to execute user command: %s", resp.ErrorMsg)
 	}
 
-	e.spawnChild = *spawn
+	e.userPid = resp.UserPID
+	e.spawnChild = spawn.Process
 	return nil
 }
 
@@ -394,74 +298,22 @@ func sendAbortCommand(w io.Writer) error {
 	return nil
 }
 
-// Open's behavior is to kill all processes associated with the id and return an
-// error. This is done because it is not possible to re-attach to the
-// spawn-daemon's stdout to retrieve status messages.
-func (e *LinuxExecutor) Open(id string) error {
-	parts := strings.SplitN(id, ":", 2)
-	if len(parts) != 2 {
-		return fmt.Errorf("Invalid id: %v", id)
-	}
-
-	switch parts[0] {
-	case "PID":
-		pid, err := strconv.Atoi(parts[1])
-		if err != nil {
-			return fmt.Errorf("Invalid id: failed to parse pid %v", parts[1])
-		}
-
-		process, err := os.FindProcess(pid)
-		if err != nil {
-			return fmt.Errorf("Failed to find Pid %v: %v", pid, err)
-		}
-
-		if err := process.Kill(); err != nil {
-			return fmt.Errorf("Failed to kill Pid %v: %v", pid, err)
-		}
-	case "CGROUP":
-		if !e.cgroupEnabled {
-			return errors.New("Passed a a cgroup identifier, but cgroups are disabled")
-		}
-
-		// De-serialize the cgroup configuration.
-		dec := json.NewDecoder(strings.NewReader(parts[1]))
-		var groups cgroupConfig.Cgroup
-		if err := dec.Decode(&groups); err != nil {
-			return fmt.Errorf("Failed to parse cgroup configuration: %v", err)
-		}
-
-		e.groups = &groups
-		if err := e.destroyCgroup(); err != nil {
-			return err
-		}
-		// TODO: cleanTaskDir is a little more complicated here because the OS
-		// may have already unmounted in the case of a restart. Need to scan.
-	default:
-		return fmt.Errorf("Invalid id type: %v", parts[0])
-	}
-
-	return errors.New("Could not re-open to id (intended).")
-}
-
 func (e *LinuxExecutor) Wait() error {
-	if e.spawnChild.Process == nil {
-		return errors.New("Can not find child to wait on")
+	if e.spawnOutputReader != nil {
+		e.spawnOutputReader.Close()
 	}
 
-	defer e.spawnOutputWriter.Close()
-	defer e.spawnOutputReader.Close()
+	if e.spawnOutputWriter != nil {
+		e.spawnOutputWriter.Close()
+	}
 
 	errs := new(multierror.Error)
-	if err := e.spawnChild.Wait(); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("Wait failed on pid %v: %v", e.spawnChild.Process.Pid, err))
+	if err := e.spawnWait(); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("Wait failed on pid %v: %v", e.spawnChild.Pid, err))
 	}
 
-	// If they fork/exec and then exit, wait will return but they will be still
-	// running processes so we need to kill the full cgroup.
-	if e.groups != nil {
-		if err := e.destroyCgroup(); err != nil {
-			errs = multierror.Append(errs, err)
-		}
+	if err := e.destroyCgroup(); err != nil {
+		errs = multierror.Append(errs, err)
 	}
 
 	if err := e.cleanTaskDir(); err != nil {
@@ -471,27 +323,18 @@ func (e *LinuxExecutor) Wait() error {
 	return errs.ErrorOrNil()
 }
 
-// If cgroups are used, the ID is the cgroup structurue. Otherwise, it is the
-// PID of the spawn-daemon process. An error is returned if the process was
-// never started.
-func (e *LinuxExecutor) ID() (string, error) {
-	if e.spawnChild.Process != nil {
-		if e.cgroupEnabled && e.groups != nil {
-			// Serialize the cgroup structure so it can be undone on suabsequent
-			// opens.
-			var buffer bytes.Buffer
-			enc := json.NewEncoder(&buffer)
-			if err := enc.Encode(e.groups); err != nil {
-				return "", fmt.Errorf("Failed to serialize daemon configuration: %v", err)
-			}
-
-			return fmt.Sprintf("CGROUP:%v", buffer.String()), nil
-		}
-
-		return fmt.Sprintf("PID:%d", e.spawnChild.Process.Pid), nil
+// spawnWait waits on the spawn-daemon and can handle the spawn-daemon not being
+// a child of this process.
+func (e *LinuxExecutor) spawnWait() error {
+	// TODO: This needs to be able to wait on non-child processes.
+	state, err := e.spawnChild.Wait()
+	if err != nil {
+		return err
+	} else if !state.Success() {
+		return fmt.Errorf("exited with non-zero code")
 	}
 
-	return "", fmt.Errorf("Process has finished or was never started")
+	return nil
 }
 
 func (e *LinuxExecutor) Shutdown() error {
@@ -507,16 +350,6 @@ func (e *LinuxExecutor) ForceStop() error {
 		e.spawnOutputWriter.Close()
 	}
 
-	// If the task is not running inside a cgroup then just the spawn-daemon child is killed.
-	// TODO: Find a good way to kill the children of the spawn-daemon.
-	if e.groups == nil {
-		if err := e.spawnChild.Process.Kill(); err != nil {
-			return fmt.Errorf("Failed to kill child (%v): %v", e.spawnChild.Process.Pid, err)
-		}
-
-		return nil
-	}
-
 	errs := new(multierror.Error)
 	if e.groups != nil {
 		if err := e.destroyCgroup(); err != nil {
@@ -531,13 +364,131 @@ func (e *LinuxExecutor) ForceStop() error {
 	return errs.ErrorOrNil()
 }
 
+// Task Directory related functions.
+
+func (e *LinuxExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocDir) error {
+	e.taskName = taskName
+	taskDir, ok := alloc.TaskDirs[taskName]
+	if !ok {
+		fmt.Errorf("Couldn't find task directory for task %v", taskName)
+	}
+	e.taskDir = taskDir
+
+	if err := alloc.MountSharedDir(taskName); err != nil {
+		return err
+	}
+
+	if err := alloc.Embed(taskName, chrootEnv); err != nil {
+		return err
+	}
+
+	// Mount dev
+	dev := filepath.Join(taskDir, "dev")
+	if err := os.Mkdir(dev, 0777); err != nil {
+		return fmt.Errorf("Mkdir(%v) failed: %v", dev, err)
+	}
+
+	if err := syscall.Mount("", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("Couldn't mount /dev to %v: %v", dev, err)
+	}
+
+	// Mount proc
+	proc := filepath.Join(taskDir, "proc")
+	if err := os.Mkdir(proc, 0777); err != nil {
+		return fmt.Errorf("Mkdir(%v) failed: %v", proc, err)
+	}
+
+	if err := syscall.Mount("", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("Couldn't mount /proc to %v: %v", proc, err)
+	}
+
+	// Set the tasks AllocDir environment variable.
+	env, err := environment.ParseFromList(e.Cmd.Env)
+	if err != nil {
+		return err
+	}
+	env.SetAllocDir(filepath.Join("/", allocdir.SharedAllocName))
+	env.SetTaskLocalDir(filepath.Join("/", allocdir.TaskLocal))
+	e.Cmd.Env = env.List()
+
+	// Store the file path to save the exit status to.
+	e.exitStatusFile = filepath.Join(alloc.AllocDir, fmt.Sprintf("%s_%s", taskName, "exit_status"))
+
+	e.alloc = alloc
+	return nil
+}
+
+func (e *LinuxExecutor) pathExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *LinuxExecutor) cleanTaskDir() error {
+	// Unmount dev.
+	errs := new(multierror.Error)
+	dev := filepath.Join(e.taskDir, "dev")
+	if e.pathExists(dev) {
+		if err := syscall.Unmount(dev, 0); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("Failed to unmount dev (%v): %v", dev, err))
+		}
+	}
+
+	// Unmount proc.
+	proc := filepath.Join(e.taskDir, "proc")
+	if e.pathExists(proc) {
+		if err := syscall.Unmount(proc, 0); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("Failed to unmount proc (%v): %v", proc, err))
+		}
+	}
+
+	return errs.ErrorOrNil()
+}
+
+// Cgroup related functions.
+
+func (e *LinuxExecutor) configureCgroups(resources *structs.Resources) error {
+	e.groups = &cgroupConfig.Cgroup{}
+	e.groups.Name = structs.GenerateUUID()
+
+	// TODO: verify this is needed for things like network access
+	e.groups.AllowAllDevices = true
+
+	if resources.MemoryMB > 0 {
+		// Total amount of memory allowed to consume
+		e.groups.Memory = int64(resources.MemoryMB * 1024 * 1024)
+		// Disable swap to avoid issues on the machine
+		e.groups.MemorySwap = int64(-1)
+	}
+
+	if resources.CPU < 2 {
+		return fmt.Errorf("resources.CPU must be equal to or greater than 2: %v", resources.CPU)
+	}
+
+	// Set the relative CPU shares for this cgroup.
+	e.groups.CpuShares = int64(resources.CPU)
+
+	if resources.IOPS != 0 {
+		// Validate it is in an acceptable range.
+		if resources.IOPS < 10 || resources.IOPS > 1000 {
+			return fmt.Errorf("resources.IOPS must be between 10 and 1000: %d", resources.IOPS)
+		}
+
+		e.groups.BlkioWeight = uint16(resources.IOPS)
+	}
+
+	return nil
+}
+
 func (e *LinuxExecutor) destroyCgroup() error {
 	if e.groups == nil {
 		return errors.New("Can't destroy: cgroup configuration empty")
 	}
 
-	manager := cgroupFs.Manager{}
-	manager.Cgroups = e.groups
+	manager := e.getCgroupManager(e.groups)
 	pids, err := manager.GetPids()
 	if err != nil {
 		return fmt.Errorf("Failed to get pids in the cgroup %v: %v", e.groups.Name, err)
@@ -555,11 +506,6 @@ func (e *LinuxExecutor) destroyCgroup() error {
 			multierror.Append(errs, fmt.Errorf("Failed to kill Pid %v: %v", pid, err))
 			continue
 		}
-
-		if _, err := process.Wait(); err != nil {
-			multierror.Append(errs, fmt.Errorf("Failed to wait Pid %v: %v", pid, err))
-			continue
-		}
 	}
 
 	// Remove the cgroup.
@@ -574,6 +520,12 @@ func (e *LinuxExecutor) destroyCgroup() error {
 	return nil
 }
 
-func (e *LinuxExecutor) Command() *cmd {
-	return &e.cmd
+// getCgroupManager returns the correct libcontainer cgroup manager.
+func (e *LinuxExecutor) getCgroupManager(groups *cgroupConfig.Cgroup) cgroups.Manager {
+	var manager cgroups.Manager
+	manager = &cgroupFs.Manager{Cgroups: groups}
+	if systemd.UseSystemd() {
+		manager = &systemd.Manager{Cgroups: groups}
+	}
+	return manager
 }

--- a/client/executor/exec_universal.go
+++ b/client/executor/exec_universal.go
@@ -2,21 +2,11 @@
 
 package executor
 
-import (
-	"github.com/hashicorp/nomad/client/allocdir"
-	"github.com/hashicorp/nomad/nomad/structs"
-)
+func NewExecutor() Executor {
+	return &UniversalExecutor{BasicExecutor{}}
+}
 
-// UniversalExecutor exists to make the exec driver compile on all operating systems.
-type UniversalExecutor struct{}
-
-func NewExecutor() Executor                                                    { return &UniversalExecutor{} }
-func (e *UniversalExecutor) Limit(resources *structs.Resources) error          { return nil }
-func (e *UniversalExecutor) ConfigureTaskDir(string, *allocdir.AllocDir) error { return nil }
-func (e *UniversalExecutor) Start() error                                      { return nil }
-func (e *UniversalExecutor) Open(pid string) error                             { return nil }
-func (e *UniversalExecutor) Wait() error                                       { return nil }
-func (e *UniversalExecutor) ID() (string, error)                               { return "", nil }
-func (e *UniversalExecutor) Shutdown() error                                   { return nil }
-func (e *UniversalExecutor) ForceStop() error                                  { return nil }
-func (e *UniversalExecutor) Command() *cmd                                     { return nil }
+// UniversalExecutor wraps the BasicExecutor
+type UniversalExecutor struct {
+	BasicExecutor
+}

--- a/client/executor/exec_universal.go
+++ b/client/executor/exec_universal.go
@@ -3,105 +3,20 @@
 package executor
 
 import (
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-
 	"github.com/hashicorp/nomad/client/allocdir"
-	"github.com/hashicorp/nomad/client/driver/args"
-	"github.com/hashicorp/nomad/client/driver/environment"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-func NewExecutor() Executor {
-	return &UniversalExecutor{}
-}
+// UniversalExecutor exists to make the exec driver compile on all operating systems.
+type UniversalExecutor struct{}
 
-// UniversalExecutor should work everywhere, and as a result does not include
-// any resource restrictions or runas capabilities.
-type UniversalExecutor struct {
-	cmd
-}
-
-func (e *UniversalExecutor) Limit(resources *structs.Resources) error {
-	if resources == nil {
-		return errNoResources
-	}
-	return nil
-}
-
-func (e *UniversalExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocDir) error {
-	taskDir, ok := alloc.TaskDirs[taskName]
-	if !ok {
-		return fmt.Errorf("Error finding task dir for (%s)", taskName)
-	}
-	e.Dir = taskDir
-	return nil
-}
-
-func (e *UniversalExecutor) Start() error {
-	// Parse the commands arguments and replace instances of Nomad environment
-	// variables.
-	envVars, err := environment.ParseFromList(e.cmd.Env)
-	if err != nil {
-		return err
-	}
-
-	parsedPath, err := args.ParseAndReplace(e.cmd.Path, envVars.Map())
-	if err != nil {
-		return err
-	} else if len(parsedPath) != 1 {
-		return fmt.Errorf("couldn't properly parse command path: %v", e.cmd.Path)
-	}
-
-	e.cmd.Path = parsedPath[0]
-	combined := strings.Join(e.cmd.Args, " ")
-	parsed, err := args.ParseAndReplace(combined, envVars.Map())
-	if err != nil {
-		return err
-	}
-	e.Cmd.Args = parsed
-
-	// We don't want to call ourself. We want to call Start on our embedded Cmd
-	return e.cmd.Start()
-}
-
-func (e *UniversalExecutor) Open(pid string) error {
-	pidNum, err := strconv.Atoi(pid)
-	if err != nil {
-		return fmt.Errorf("Failed to parse pid %v: %v", pid, err)
-	}
-
-	process, err := os.FindProcess(pidNum)
-	if err != nil {
-		return fmt.Errorf("Failed to reopen pid %d: %v", pidNum, err)
-	}
-	e.Process = process
-	return nil
-}
-
-func (e *UniversalExecutor) Wait() error {
-	// We don't want to call ourself. We want to call Start on our embedded Cmd
-	return e.cmd.Wait()
-}
-
-func (e *UniversalExecutor) ID() (string, error) {
-	if e.cmd.Process != nil {
-		return strconv.Itoa(e.cmd.Process.Pid), nil
-	} else {
-		return "", fmt.Errorf("Process has finished or was never started")
-	}
-}
-
-func (e *UniversalExecutor) Shutdown() error {
-	return e.ForceStop()
-}
-
-func (e *UniversalExecutor) ForceStop() error {
-	return e.Process.Kill()
-}
-
-func (e *UniversalExecutor) Command() *cmd {
-	return &e.cmd
-}
+func NewExecutor() Executor                                                    { return &UniversalExecutor{} }
+func (e *UniversalExecutor) Limit(resources *structs.Resources) error          { return nil }
+func (e *UniversalExecutor) ConfigureTaskDir(string, *allocdir.AllocDir) error { return nil }
+func (e *UniversalExecutor) Start() error                                      { return nil }
+func (e *UniversalExecutor) Open(pid string) error                             { return nil }
+func (e *UniversalExecutor) Wait() error                                       { return nil }
+func (e *UniversalExecutor) ID() (string, error)                               { return "", nil }
+func (e *UniversalExecutor) Shutdown() error                                   { return nil }
+func (e *UniversalExecutor) ForceStop() error                                  { return nil }
+func (e *UniversalExecutor) Command() *cmd                                     { return nil }

--- a/client/spawn/spawn.go
+++ b/client/spawn/spawn.go
@@ -225,10 +225,8 @@ func (s *Spawner) waitAsParent() (int, error) {
 		}
 	}
 
-	if state, err := s.spawn.Wait(); err != nil {
+	if _, err := s.spawn.Wait(); err != nil {
 		return -1, err
-	} else if !state.Exited() {
-		return -1, fmt.Errorf("Task was killed or crashed")
 	}
 
 	return s.waitOnStatusFile()

--- a/client/spawn/spawn.go
+++ b/client/spawn/spawn.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/docker/docker/vendor/src/gopkg.in/fsnotify.v1"
+	"github.com/go-fsnotify/fsnotify"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/command"
 	"github.com/hashicorp/nomad/helper/discover"

--- a/client/spawn/spawn.go
+++ b/client/spawn/spawn.go
@@ -1,0 +1,322 @@
+package spawn
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/docker/docker/vendor/src/gopkg.in/fsnotify.v1"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/command"
+	"github.com/hashicorp/nomad/helper/discover"
+)
+
+// Spawner is used to start a user command in an isolated fashion that is
+// resistent to Nomad agent failure.
+type Spawner struct {
+	spawn     *os.Process
+	SpawnPid  int
+	SpawnPpid int
+	StateFile string
+
+	// User configuration
+	UserCmd *exec.Cmd
+	Logs    *Logs
+	Chroot  string
+}
+
+// Logs is used to define the filepaths the user command's logs should be
+// redirected to. The files do not need to exist.
+type Logs struct {
+	Stdin, Stdout, Stderr string
+}
+
+// NewSpawner takes a path to a state file. This state file can be used to
+// create a new Spawner that can be used to wait on the exit status of a
+// process even through Nomad restarts.
+func NewSpawner(stateFile string) *Spawner {
+	return &Spawner{StateFile: stateFile}
+}
+
+// SetCommand sets the user command to spawn.
+func (s *Spawner) SetCommand(cmd *exec.Cmd) {
+	s.UserCmd = cmd
+}
+
+// SetLogs sets the redirection of user command log files.
+func (s *Spawner) SetLogs(l *Logs) {
+	s.Logs = l
+}
+
+// SetChroot puts the user command into a chroot.
+func (s *Spawner) SetChroot(root string) {
+	s.Chroot = root
+}
+
+// Spawn does a double-fork to start and isolate the user command. It takes a
+// call-back that is invoked with the pid of the intermediary process. If the
+// call back returns an error, the user command is not started and the spawn is
+// cancelled. This can be used to put the process into a cgroup or jail and
+// cancel starting the user process if that was not successful. An error is
+// returned if the call-back returns an error or the user-command couldn't be
+// started.
+func (s *Spawner) Spawn(cb func(pid int) error) error {
+	bin, err := discover.NomadExecutable()
+	if err != nil {
+		return fmt.Errorf("Failed to determine the nomad executable: %v", err)
+	}
+
+	exitFile, err := os.OpenFile(s.StateFile, os.O_CREATE|os.O_WRONLY, 0666)
+	defer exitFile.Close()
+	if err != nil {
+		return fmt.Errorf("Error opening file to store exit status: %v", err)
+	}
+
+	config, err := s.spawnConfig()
+	if err != nil {
+		return err
+	}
+
+	spawn := exec.Command(bin, "spawn-daemon", config)
+
+	// Capture stdout
+	spawnStdout, err := spawn.StdoutPipe()
+	defer spawnStdout.Close()
+	if err != nil {
+		return fmt.Errorf("Failed to capture spawn-daemon stdout: %v", err)
+	}
+
+	// Capture stdin.
+	spawnStdin, err := spawn.StdinPipe()
+	defer spawnStdin.Close()
+	if err != nil {
+		return fmt.Errorf("Failed to capture spawn-daemon stdin: %v", err)
+	}
+
+	if err := spawn.Start(); err != nil {
+		return fmt.Errorf("Failed to call spawn-daemon on nomad executable: %v", err)
+	}
+
+	if cb != nil {
+		cbErr := cb(spawn.Process.Pid)
+		if cbErr != nil {
+			errs := new(multierror.Error)
+			errs = multierror.Append(errs, cbErr)
+			if err := s.sendAbortCommand(spawnStdin); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+
+			return errs
+		}
+	}
+
+	if err := s.sendStartCommand(spawnStdin); err != nil {
+		return err
+	}
+
+	respCh := make(chan command.SpawnStartStatus, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		var resp command.SpawnStartStatus
+		dec := json.NewDecoder(spawnStdout)
+		if err := dec.Decode(&resp); err != nil {
+			errCh <- fmt.Errorf("Failed to parse spawn-daemon start response: %v", err)
+		}
+		respCh <- resp
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case resp := <-respCh:
+		if resp.ErrorMsg != "" {
+			return fmt.Errorf("Failed to execute user command: %s", resp.ErrorMsg)
+		}
+	case <-time.After(5 * time.Second):
+		return fmt.Errorf("timed out waiting for response")
+	}
+
+	// Store the spawn process.
+	s.spawn = spawn.Process
+	s.SpawnPpid = os.Getpid()
+	return nil
+}
+
+// spawnConfig returns a serialized config to pass to the Nomad spawn-daemon
+// command.
+func (s *Spawner) spawnConfig() (string, error) {
+	if s.UserCmd == nil {
+		return "", fmt.Errorf("Must specify user command")
+	}
+
+	config := command.DaemonConfig{
+		Cmd:            *s.UserCmd,
+		Chroot:         s.Chroot,
+		ExitStatusFile: s.StateFile,
+	}
+
+	if s.Logs != nil {
+		config.StdoutFile = s.Logs.Stdout
+		config.StdinFile = s.Logs.Stdin
+		config.StderrFile = s.Logs.Stderr
+	}
+
+	var buffer bytes.Buffer
+	enc := json.NewEncoder(&buffer)
+	if err := enc.Encode(config); err != nil {
+		return "", fmt.Errorf("Failed to serialize configuration: %v", err)
+	}
+
+	return strconv.Quote(buffer.String()), nil
+}
+
+// sendStartCommand sends the necessary command to the spawn-daemon to have it
+// start the user process.
+func (s *Spawner) sendStartCommand(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(true); err != nil {
+		return fmt.Errorf("Failed to serialize start command: %v", err)
+	}
+
+	return nil
+}
+
+// sendAbortCommand sends the necessary command to the spawn-daemon to have it
+// abort starting the user process. This should be invoked if the spawn-daemon
+// could not be isolated into a cgroup.
+func (s *Spawner) sendAbortCommand(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(false); err != nil {
+		return fmt.Errorf("Failed to serialize abort command: %v", err)
+	}
+
+	return nil
+}
+
+// Wait returns the exit code of the user process or an error if the wait
+// failed.
+func (s *Spawner) Wait() (int, error) {
+	if os.Getpid() == s.SpawnPpid {
+		return s.waitAsParent()
+	}
+
+	return s.waitOnStatusFile()
+}
+
+// waitAsParent waits on the process if the current process was the spawner.
+func (s *Spawner) waitAsParent() (int, error) {
+	if s.SpawnPpid != os.Getpid() {
+		return -1, fmt.Errorf("not the parent. Spawner parent is %v; current pid is %v", s.SpawnPpid, os.Getpid())
+	}
+
+	// Try to reattach to the spawn.
+	if s.spawn == nil {
+		// If it can't be reattached, it means the spawn process has exited so
+		// we should just read its exit file.
+		var err error
+		if s.spawn, err = os.FindProcess(s.SpawnPid); err != nil {
+			return s.waitOnStatusFile()
+		}
+	}
+
+	if state, err := s.spawn.Wait(); err != nil {
+		return -1, err
+	} else if !state.Exited() {
+		return -1, fmt.Errorf("Task was killed or crashed")
+	}
+
+	return s.waitOnStatusFile()
+}
+
+// waitOnStatusFile uses OS level file watching APIs to wait on the status file
+// and returns the exit code and possibly an error.
+func (s *Spawner) waitOnStatusFile() (int, error) {
+	// Set up a watcher for the exit status file.
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return -1, fmt.Errorf("Failed to create file watcher to read exit code: %v", err)
+	}
+
+	if err := watcher.Add(s.StateFile); err != nil {
+		return -1, fmt.Errorf("Failed to watch %v to read exit code: %v", s.StateFile, err)
+	}
+
+	// Stat to check if it is there to avoid a race condition.
+	stat, err := os.Stat(s.StateFile)
+	if err != nil {
+		return -1, fmt.Errorf("Failed to Stat exit status file %v: %v", s.StateFile, err)
+	}
+
+	// If there is data it means that the file has already been written.
+	if stat.Size() > 0 {
+		return s.readExitCode()
+	}
+
+	// Store the mod time as a way to heartbeat. If the file doesn't get touched
+	// then we know the spawner has died. This avoids an infinite loop.
+	prevModTime := stat.ModTime()
+
+	// Wait on watcher.
+	for {
+		select {
+		case event := <-watcher.Events:
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				stat, err := os.Stat(s.StateFile)
+				if err != nil {
+					return -1, fmt.Errorf("Failed to Stat exit status file %v: %v", s.StateFile, err)
+				}
+
+				if stat.Size() > 0 {
+					return s.readExitCode()
+				}
+			}
+		case err := <-watcher.Errors:
+			return -1, fmt.Errorf("Failed to watch %v for an exit code: %v", s.StateFile, err)
+		case <-time.After(5 * time.Second):
+			stat, err := os.Stat(s.StateFile)
+			if err != nil {
+				return -1, fmt.Errorf("Failed to Stat exit status file %v: %v", s.StateFile, err)
+			}
+
+			modTime := stat.ModTime()
+			if modTime.Equal(prevModTime) {
+				return -1, fmt.Errorf("Task is dead and exit code unreadable")
+			}
+
+			prevModTime = modTime
+		}
+	}
+}
+
+// readExitCode parses the state file and returns the exit code of the task. It
+// returns an error if the file can't be read.
+func (s *Spawner) readExitCode() (int, error) {
+	f, err := os.Open(s.StateFile)
+	defer f.Close()
+	if err != nil {
+		return -1, fmt.Errorf("Failed to open %v to read exit code: %v", s.StateFile, err)
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		return -1, fmt.Errorf("Failed to stat file %v: %v", s.StateFile, err)
+	}
+
+	if stat.Size() == 0 {
+		return -1, fmt.Errorf("Empty state file: %v", s.StateFile)
+	}
+
+	var exitStatus command.SpawnExitStatus
+	dec := json.NewDecoder(f)
+	if err := dec.Decode(&exitStatus); err != nil {
+		return -1, fmt.Errorf("Failed to parse exit status from %v: %v", s.StateFile, err)
+	}
+
+	return exitStatus.ExitCode, nil
+}

--- a/client/spawn/spawn_posix.go
+++ b/client/spawn/spawn_posix.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package spawn
+
+import "syscall"
+
+func (s *Spawner) Alive() bool {
+	if s.spawn == nil {
+		return false
+	}
+
+	err := s.spawn.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/client/spawn/spawn_test.go
+++ b/client/spawn/spawn_test.go
@@ -106,7 +106,7 @@ func TestSpawn_Callback(t *testing.T) {
 	}
 
 	if err := spawn.Spawn(cb); err == nil {
-		t.Fatalf("Spawn(%#v) should have errored; want %v", cb, err, cbErr)
+		t.Fatalf("Spawn(%#v) should have errored; want %v", cb, cbErr)
 	}
 
 	if !called {

--- a/client/spawn/spawn_test.go
+++ b/client/spawn/spawn_test.go
@@ -202,6 +202,15 @@ func TestSpawn_NonParentWait(t *testing.T) {
 		t.Fatalf("Spawn() failed %v", err)
 	}
 
+	// Need to wait on the spawner, otherwise it becomes a zombie and the test
+	// only finishes after the init process cleans it. This speeds that up.
+	go func() {
+		time.Sleep(3 * time.Second)
+		if _, err := spawn.spawn.Wait(); err != nil {
+			t.FailNow()
+		}
+	}()
+
 	// Force the wait to assume non-parent.
 	spawn.SpawnPpid = 0
 	code, err := spawn.Wait()
@@ -265,7 +274,7 @@ func TestSpawn_DeadSpawnDaemon_NonParent(t *testing.T) {
 	}
 
 	spawn := NewSpawner(f.Name())
-	spawn.SetCommand(exec.Command("sleep", "5"))
+	spawn.SetCommand(exec.Command("sleep", "2"))
 	if err := spawn.Spawn(cb); err != nil {
 		t.Fatalf("Spawn() errored: %v", err)
 	}

--- a/client/spawn/spawn_test.go
+++ b/client/spawn/spawn_test.go
@@ -1,0 +1,252 @@
+package spawn
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSpawn_NoCmd(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(f.Name())
+
+	spawn := NewSpawner(f.Name())
+	if err := spawn.Spawn(nil); err == nil {
+		t.Fatalf("Spawn() with no user command should fail")
+	}
+}
+
+func TestSpawn_InvalidCmd(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(f.Name())
+
+	spawn := NewSpawner(f.Name())
+	spawn.SetCommand(exec.Command("foo"))
+	if err := spawn.Spawn(nil); err == nil {
+		t.Fatalf("Spawn() with no invalid command should fail")
+	}
+}
+
+func TestSpawn_SetsLogs(t *testing.T) {
+	// TODO: Figure out why this test fails. If the spawn-daemon directly writes
+	// to the opened stdout file it works but not the user command. Maybe a
+	// flush issue?
+	if runtime.GOOS == "windows" {
+		t.Skip("Test fails on windows; unknown reason. Skipping")
+	}
+
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(f.Name())
+
+	spawn := NewSpawner(f.Name())
+	exp := "foo"
+	spawn.SetCommand(exec.Command("echo", exp))
+
+	// Create file for stdout.
+	stdout, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(stdout.Name())
+	spawn.SetLogs(&Logs{Stdout: stdout.Name()})
+
+	if err := spawn.Spawn(nil); err != nil {
+		t.Fatalf("Spawn() failed: %v", err)
+	}
+
+	if code, err := spawn.Wait(); code != 0 && err != nil {
+		t.Fatalf("Wait() returned %v, %v; want 0, nil", code, err)
+	}
+
+	stdout2, err := os.Open(stdout.Name())
+	if err != nil {
+		t.Fatalf("Open() failed: %v", err)
+	}
+
+	data, err := ioutil.ReadAll(stdout2)
+	if err != nil {
+		t.Fatalf("ReadAll() failed: %v", err)
+	}
+
+	act := strings.TrimSpace(string(data))
+	if act != exp {
+		t.Fatalf("Unexpected data written to stdout; got %v; want %v", act, exp)
+	}
+}
+
+func TestSpawn_Callback(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(f.Name())
+
+	spawn := NewSpawner(f.Name())
+	spawn.SetCommand(exec.Command("sleep", "1"))
+
+	called := false
+	cbErr := fmt.Errorf("ERROR CB")
+	cb := func(_ int) error {
+		called = true
+		return cbErr
+	}
+
+	if err := spawn.Spawn(cb); err == nil {
+		t.Fatalf("Spawn(%#v) should have errored; want %v", cb, err, cbErr)
+	}
+
+	if !called {
+		t.Fatalf("Spawn(%#v) didn't call callback", cb)
+	}
+}
+
+func TestSpawn_ParentWaitExited(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(f.Name())
+
+	spawn := NewSpawner(f.Name())
+	spawn.SetCommand(exec.Command("echo", "foo"))
+	if err := spawn.Spawn(nil); err != nil {
+		t.Fatalf("Spawn() failed %v", err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	code, err := spawn.Wait()
+	if err != nil {
+		t.Fatalf("Wait() failed %v", err)
+	}
+
+	if code != 0 {
+		t.Fatalf("Wait() returned %v; want 0", code)
+	}
+}
+
+func TestSpawn_ParentWait(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(f.Name())
+
+	spawn := NewSpawner(f.Name())
+	spawn.SetCommand(exec.Command("sleep", "2"))
+	if err := spawn.Spawn(nil); err != nil {
+		t.Fatalf("Spawn() failed %v", err)
+	}
+
+	code, err := spawn.Wait()
+	if err != nil {
+		t.Fatalf("Wait() failed %v", err)
+	}
+
+	if code != 0 {
+		t.Fatalf("Wait() returned %v; want 0", code)
+	}
+}
+
+func TestSpawn_NonParentWaitExited(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(f.Name())
+
+	spawn := NewSpawner(f.Name())
+	spawn.SetCommand(exec.Command("echo", "foo"))
+	if err := spawn.Spawn(nil); err != nil {
+		t.Fatalf("Spawn() failed %v", err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	// Force the wait to assume non-parent.
+	spawn.SpawnPpid = 0
+	code, err := spawn.Wait()
+	if err != nil {
+		t.Fatalf("Wait() failed %v", err)
+	}
+
+	if code != 0 {
+		t.Fatalf("Wait() returned %v; want 0", code)
+	}
+}
+
+func TestSpawn_NonParentWait(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(f.Name())
+
+	spawn := NewSpawner(f.Name())
+	spawn.SetCommand(exec.Command("sleep", "2"))
+	if err := spawn.Spawn(nil); err != nil {
+		t.Fatalf("Spawn() failed %v", err)
+	}
+
+	// Force the wait to assume non-parent.
+	spawn.SpawnPpid = 0
+	code, err := spawn.Wait()
+	if err != nil {
+		t.Fatalf("Wait() failed %v", err)
+	}
+
+	if code != 0 {
+		t.Fatalf("Wait() returned %v; want 0", code)
+	}
+}
+
+func TestSpawn_DeadSpawnDaemon(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer os.Remove(f.Name())
+
+	var spawnPid int
+	cb := func(pid int) error {
+		spawnPid = pid
+		return nil
+	}
+
+	spawn := NewSpawner(f.Name())
+	spawn.SetCommand(exec.Command("sleep", "5"))
+	if err := spawn.Spawn(cb); err != nil {
+		t.Fatalf("Spawn() errored: %v", err)
+	}
+
+	proc, err := os.FindProcess(spawnPid)
+	if err != nil {
+		t.FailNow()
+	}
+
+	if err := proc.Kill(); err != nil {
+		t.FailNow()
+	}
+
+	if _, err := proc.Wait(); err != nil {
+		t.FailNow()
+	}
+
+	if _, err := spawn.Wait(); err == nil {
+		t.Fatalf("Wait() should have failed: %v", err)
+	}
+}

--- a/client/spawn/spawn_windows.go
+++ b/client/spawn/spawn_windows.go
@@ -1,0 +1,21 @@
+package spawn
+
+import "syscall"
+
+const STILL_ACTIVE = 259
+
+func (s *Spawner) Alive() bool {
+	const da = syscall.STANDARD_RIGHTS_READ | syscall.PROCESS_QUERY_INFORMATION | syscall.SYNCHRONIZE
+	h, e := syscall.OpenProcess(da, false, uint32(s.SpawnPid))
+	if e != nil {
+		return false
+	}
+
+	var ec uint32
+	e = syscall.GetExitCodeProcess(h, &ec)
+	if e != nil {
+		return false
+	}
+
+	return ec == STILL_ACTIVE
+}

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -8,8 +8,8 @@ import (
 )
 
 func ExecCompatible(t *testing.T) {
-	if runtime.GOOS != "windows" && syscall.Geteuid() != 0 {
-		t.Skip("Must be root on non-windows environments to run test")
+	if runtime.GOOS != "linux" || syscall.Geteuid() != 0 {
+		t.Skip("Test only available running as root on linux")
 	}
 }
 

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -13,6 +13,12 @@ func ExecCompatible(t *testing.T) {
 	}
 }
 
+func JavaCompatible(t *testing.T) {
+	if runtime.GOOS == "linux" && syscall.Geteuid() != 0 {
+		t.Skip("Test only available when running as root on linux")
+	}
+}
+
 func QemuCompatible(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Must be on non-windows environments to run test")

--- a/command/spawn_daemon.go
+++ b/command/spawn_daemon.go
@@ -192,7 +192,7 @@ func (c *SpawnDaemonCommand) outputStartStatus(err error, status int) int {
 		startStatus.ErrorMsg = err.Error()
 	}
 
-	if c.config != nil && c.config.Process == nil {
+	if c.config != nil && c.config.Process != nil {
 		startStatus.UserPID = c.config.Process.Pid
 	}
 

--- a/command/spawn_daemon.go
+++ b/command/spawn_daemon.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 )
 
 type SpawnDaemonCommand struct {
@@ -184,17 +183,6 @@ func (c *SpawnDaemonCommand) Run(args []string) int {
 
 	// Indicate that the command was started successfully.
 	c.outputStartStatus(nil, 0)
-
-	// Start a go routine that touches the exit file periodically.
-	go func() {
-		for {
-			select {
-			case <-time.After(2 * time.Second):
-				now := time.Now()
-				os.Chtimes(c.config.ExitStatusFile, now, now)
-			}
-		}
-	}()
 
 	// Wait and then output the exit status.
 	return c.writeExitStatus(c.config.Cmd.Wait())

--- a/command/spawn_daemon.go
+++ b/command/spawn_daemon.go
@@ -2,19 +2,19 @@ package command
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
+	"syscall"
 )
 
 type SpawnDaemonCommand struct {
 	Meta
-}
-
-// Status of executing the user's command.
-type SpawnStartStatus struct {
-	// ErrorMsg will be empty if the user command was started successfully.
-	// Otherwise it will have an error message.
-	ErrorMsg string
+	config   *DaemonConfig
+	exitFile io.WriteCloser
 }
 
 func (c *SpawnDaemonCommand) Help() string {
@@ -23,21 +23,162 @@ Usage: nomad spawn-daemon [options] <daemon_config>
 
   INTERNAL ONLY
 
-  Spawns a daemon process optionally inside a cgroup. The required daemon_config is a json
-  encoding of the DaemonConfig struct containing the isolation configuration and command to run.
-  SpawnStartStatus is json serialized to Stdout upon running the user command or if any error
-  prevents its execution. If there is no error, the process waits on the users
-  command and then json serializes  SpawnExitStatus to Stdout after its termination.
-
-General Options:
-
-  ` + generalOptionsUsage()
+  Spawns a daemon process by double forking. The required daemon_config is a
+  json encoding of the DaemonConfig struct containing the isolation
+  configuration and command to run. SpawnStartStatus is json serialized to
+  stdout upon running the user command or if any error prevents its execution.
+  If there is no error, the process waits on the users command. Once the user
+  command exits, the exit code is written to a file specified in the
+  daemon_config and this process exits with the same exit status as the user
+  command.
+  `
 
 	return strings.TrimSpace(helpText)
 }
 
 func (c *SpawnDaemonCommand) Synopsis() string {
 	return "Spawn a daemon command with configurable isolation."
+}
+
+// Status of executing the user's command.
+type SpawnStartStatus struct {
+	// The PID of the user's command.
+	UserPID int
+
+	// ErrorMsg will be empty if the user command was started successfully.
+	// Otherwise it will have an error message.
+	ErrorMsg string
+}
+
+// Exit status of the user's command.
+type SpawnExitStatus struct {
+	// The exit code of the user's command.
+	ExitCode int
+}
+
+// Configuration for the command to start as a daemon.
+type DaemonConfig struct {
+	exec.Cmd
+
+	// The filepath to write the exit status to.
+	ExitStatusFile string
+
+	// The paths, if not /dev/null, must be either in the tasks root directory
+	// or in the shared alloc directory.
+	StdoutFile string
+	StdinFile  string
+	StderrFile string
+
+	// An optional path specifying the directory to chroot the process in.
+	Chroot string
+}
+
+// Whether to start the user command or abort.
+type TaskStart bool
+
+// parseConfig reads the DaemonConfig from the passed arguments. If not
+// successful, an error is returned.
+func (c *SpawnDaemonCommand) parseConfig(args []string) (*DaemonConfig, error) {
+	flags := c.Meta.FlagSet("spawn-daemon", FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return nil, fmt.Errorf("failed to parse args: %v", err)
+	}
+
+	// Check that we got json input.
+	args = flags.Args()
+	if len(args) != 1 {
+		return nil, fmt.Errorf("incorrect number of args; got %v; want 1", len(args))
+	}
+	jsonInput, err := strconv.Unquote(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unquote json input: %v", err)
+	}
+
+	// De-serialize the passed command.
+	var config DaemonConfig
+	dec := json.NewDecoder(strings.NewReader(jsonInput))
+	if err := dec.Decode(&config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// configureLogs creates the log files and redirects the process
+// stdin/stderr/stdout to them. If unsuccessful, an error is returned.
+func (c *SpawnDaemonCommand) configureLogs() error {
+	stdo, err := os.OpenFile(c.config.StdoutFile, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0666)
+	if err != nil {
+		return fmt.Errorf("Error opening file to redirect stdout: %v", err)
+	}
+
+	stde, err := os.OpenFile(c.config.StderrFile, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0666)
+	if err != nil {
+		return fmt.Errorf("Error opening file to redirect stderr: %v", err)
+	}
+
+	stdi, err := os.OpenFile(c.config.StdinFile, os.O_CREATE|os.O_RDONLY, 0666)
+	if err != nil {
+		return fmt.Errorf("Error opening file to redirect stdin: %v", err)
+	}
+
+	c.config.Cmd.Stdout = stdo
+	c.config.Cmd.Stderr = stde
+	c.config.Cmd.Stdin = stdi
+	return nil
+}
+
+func (c *SpawnDaemonCommand) Run(args []string) int {
+	var err error
+	c.config, err = c.parseConfig(args)
+	if err != nil {
+		return c.outputStartStatus(err, 1)
+	}
+
+	// Open the file we will be using to write exit codes to. We do this early
+	// to ensure that we don't start the user process when we can't capture its
+	// exit status.
+	c.exitFile, err = os.OpenFile(c.config.ExitStatusFile, os.O_CREATE|os.O_RDWR, 0666)
+	if err != nil {
+		return c.outputStartStatus(fmt.Errorf("Error opening file to store exit status: %v", err), 1)
+	}
+
+	// Isolate the user process.
+	if err := c.isolateCmd(); err != nil {
+		return c.outputStartStatus(err, 1)
+	}
+
+	// Redirect logs.
+	if err := c.configureLogs(); err != nil {
+		return c.outputStartStatus(err, 1)
+	}
+
+	// Chroot jail the process and set its working directory.
+	c.configureChroot()
+
+	// Wait to get the start command.
+	var start TaskStart
+	dec := json.NewDecoder(os.Stdin)
+	if err := dec.Decode(&start); err != nil {
+		return c.outputStartStatus(err, 1)
+	}
+
+	// Aborted by Nomad process.
+	if !start {
+		return 0
+	}
+
+	// Spawn the user process.
+	if err := c.config.Cmd.Start(); err != nil {
+		return c.outputStartStatus(fmt.Errorf("Error starting user command: %v", err), 1)
+	}
+
+	// Indicate that the command was started successfully.
+	c.outputStartStatus(nil, 0)
+
+	// Wait and then output the exit status.
+	return c.writeExitStatus(c.config.Cmd.Wait())
 }
 
 // outputStartStatus is a helper function that outputs a SpawnStartStatus to
@@ -51,6 +192,36 @@ func (c *SpawnDaemonCommand) outputStartStatus(err error, status int) int {
 		startStatus.ErrorMsg = err.Error()
 	}
 
+	if c.config != nil && c.config.Process == nil {
+		startStatus.UserPID = c.config.Process.Pid
+	}
+
 	enc.Encode(startStatus)
 	return status
+}
+
+// writeExitStatus takes in the error result from calling wait and writes out
+// the exit status to a file. It returns the same exit status as the user
+// command.
+func (c *SpawnDaemonCommand) writeExitStatus(exit error) int {
+	// Parse the exit code.
+	exitStatus := &SpawnExitStatus{}
+	if exit != nil {
+		// Default to exit code 1 if we can not get the actual exit code.
+		exitStatus.ExitCode = 1
+
+		if exiterr, ok := exit.(*exec.ExitError); ok {
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				exitStatus.ExitCode = status.ExitStatus()
+			}
+		}
+	}
+
+	if c.exitFile != nil {
+		enc := json.NewEncoder(c.exitFile)
+		enc.Encode(exitStatus)
+		c.exitFile.Close()
+	}
+
+	return exitStatus.ExitCode
 }

--- a/command/spawn_daemon_darwin.go
+++ b/command/spawn_daemon_darwin.go
@@ -1,0 +1,4 @@
+package command
+
+// No chroot on darwin.
+func (c *SpawnDaemonCommand) configureChroot() {}

--- a/command/spawn_daemon_linux.go
+++ b/command/spawn_daemon_linux.go
@@ -1,115 +1,16 @@
 package command
 
-import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
-	"syscall"
-)
+import "syscall"
 
-// Configuration for the command to start as a daemon.
-type DaemonConfig struct {
-	exec.Cmd
+// configureChroot enters the user command into a chroot if specified in the
+// config and on an OS that supports Chroots.
+func (c *SpawnDaemonCommand) configureChroot() {
+	if len(c.config.Chroot) != 0 {
+		if c.config.Cmd.SysProcAttr == nil {
+			c.config.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
 
-	// The paths, if not /dev/null, must be either in the tasks root directory
-	// or in the shared alloc directory.
-	StdoutFile string
-	StdinFile  string
-	StderrFile string
-
-	Chroot string
-}
-
-// Whether to start the user command or abort.
-type TaskStart bool
-
-func (c *SpawnDaemonCommand) Run(args []string) int {
-	flags := c.Meta.FlagSet("spawn-daemon", FlagSetClient)
-	flags.Usage = func() { c.Ui.Output(c.Help()) }
-
-	if err := flags.Parse(args); err != nil {
-		return 1
+		c.config.Cmd.SysProcAttr.Chroot = c.config.Chroot
+		c.config.Cmd.Dir = "/"
 	}
-
-	// Check that we got json input.
-	args = flags.Args()
-	if len(args) != 1 {
-		c.Ui.Error(c.Help())
-		return 1
-	}
-	jsonInput, err := strconv.Unquote(args[0])
-	if err != nil {
-		return c.outputStartStatus(fmt.Errorf("Failed to unquote json input: %v", err), 1)
-	}
-
-	// De-serialize the passed command.
-	var cmd DaemonConfig
-	dec := json.NewDecoder(strings.NewReader(jsonInput))
-	if err := dec.Decode(&cmd); err != nil {
-		return c.outputStartStatus(err, 1)
-	}
-
-	// Isolate the user process.
-	if _, err := syscall.Setsid(); err != nil {
-		return c.outputStartStatus(fmt.Errorf("Failed setting sid: %v", err), 1)
-	}
-
-	syscall.Umask(0)
-
-	// Redirect logs.
-	stdo, err := os.OpenFile(cmd.StdoutFile, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0666)
-	if err != nil {
-		return c.outputStartStatus(fmt.Errorf("Error opening file to redirect Stdout: %v", err), 1)
-	}
-
-	stde, err := os.OpenFile(cmd.StderrFile, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0666)
-	if err != nil {
-		return c.outputStartStatus(fmt.Errorf("Error opening file to redirect Stderr: %v", err), 1)
-	}
-
-	stdi, err := os.OpenFile(cmd.StdinFile, os.O_CREATE|os.O_RDONLY, 0666)
-	if err != nil {
-		return c.outputStartStatus(fmt.Errorf("Error opening file to redirect Stdin: %v", err), 1)
-	}
-
-	cmd.Cmd.Stdout = stdo
-	cmd.Cmd.Stderr = stde
-	cmd.Cmd.Stdin = stdi
-
-	// Chroot jail the process and set its working directory.
-	if cmd.Cmd.SysProcAttr == nil {
-		cmd.Cmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
-
-	cmd.Cmd.SysProcAttr.Chroot = cmd.Chroot
-	cmd.Cmd.Dir = "/"
-
-	// Wait to get the start command.
-	var start TaskStart
-	dec = json.NewDecoder(os.Stdin)
-	if err := dec.Decode(&start); err != nil {
-		return c.outputStartStatus(err, 1)
-	}
-
-	if !start {
-		return 0
-	}
-
-	// Spawn the user process.
-	if err := cmd.Cmd.Start(); err != nil {
-		return c.outputStartStatus(fmt.Errorf("Error starting user command: %v", err), 1)
-	}
-
-	// Indicate that the command was started successfully.
-	c.outputStartStatus(nil, 0)
-
-	// Wait and then output the exit status.
-	if err := cmd.Wait(); err != nil {
-		return 1
-	}
-
-	return 0
 }

--- a/command/spawn_daemon_test.go
+++ b/command/spawn_daemon_test.go
@@ -1,0 +1,48 @@
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+)
+
+type nopCloser struct {
+	io.ReadWriter
+}
+
+func (n *nopCloser) Close() error {
+	return nil
+}
+
+func TestSpawnDaemon_WriteExitStatus(t *testing.T) {
+	// Check if there is python.
+	path, err := exec.LookPath("python")
+	if err != nil {
+		t.Skip("python not detected")
+	}
+
+	var b bytes.Buffer
+	daemon := &SpawnDaemonCommand{exitFile: &nopCloser{&b}}
+
+	code := 3
+	cmd := exec.Command(path, "./test-resources/exiter.py", fmt.Sprintf("%d", code))
+	err = cmd.Run()
+	actual := daemon.writeExitStatus(err)
+	if actual != code {
+		t.Fatalf("writeExitStatus(%v) returned %v; want %v", err, actual, code)
+	}
+
+	// De-serialize the passed command.
+	var exitStatus SpawnExitStatus
+	dec := json.NewDecoder(&b)
+	if err := dec.Decode(&exitStatus); err != nil {
+		t.Fatalf("failed to decode exit status: %v", err)
+	}
+
+	if exitStatus.ExitCode != code {
+		t.Fatalf("writeExitStatus(%v) wrote exit status %v; want %v", err, exitStatus.ExitCode, code)
+	}
+}

--- a/command/spawn_daemon_universal.go
+++ b/command/spawn_daemon_universal.go
@@ -1,9 +1,0 @@
-// +build !linux
-
-package command
-
-import "errors"
-
-func (c *SpawnDaemonCommand) Run(args []string) int {
-	return c.outputStartStatus(errors.New("spawn-daemon not supported"), 1)
-}

--- a/command/spawn_daemon_unix.go
+++ b/command/spawn_daemon_unix.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package command
+
+import "syscall"
+
+// isolateCmd sets the session id for the process and the umask.
+func (c *SpawnDaemonCommand) isolateCmd() error {
+	if c.config.Cmd.SysProcAttr == nil {
+		c.config.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+
+	c.config.Cmd.SysProcAttr.Setsid = true
+	syscall.Umask(0)
+	return nil
+}

--- a/command/spawn_daemon_windows.go
+++ b/command/spawn_daemon_windows.go
@@ -1,0 +1,7 @@
+// build !linux !darwin
+
+package command
+
+// No isolation on Windows.
+func (c *SpawnDaemonCommand) isolateCmd() error { return nil }
+func (c *SpawnDaemonCommand) configureChroot()  {}

--- a/command/test-resources/exiter.py
+++ b/command/test-resources/exiter.py
@@ -1,0 +1,3 @@
+import sys
+
+sys.exit(int(sys.argv[1]))

--- a/helper/discover/discover.go
+++ b/helper/discover/discover.go
@@ -3,6 +3,7 @@ package discover
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 
@@ -24,6 +25,11 @@ func NomadExecutable() (string, error) {
 	}
 
 	if filepath.Base(bin) == nomadExe {
+		return bin, nil
+	}
+
+	// Check the $PATH
+	if bin, err := exec.LookPath(nomadExe); err == nil {
 		return bin, nil
 	}
 

--- a/helper/discover/discover.go
+++ b/helper/discover/discover.go
@@ -4,17 +4,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/kardianos/osext"
-)
-
-const (
-	nomadExe = "nomad"
 )
 
 // Checks the current executable, then $GOPATH/bin, and finally the CWD, in that
 // order. If it can't be found, an error is returned.
 func NomadExecutable() (string, error) {
+	nomadExe := "nomad"
+	if runtime.GOOS == "windows" {
+		nomadExe = "nomad.exe"
+	}
+
 	// Check the current executable.
 	bin, err := osext.Executable()
 	if err != nil {

--- a/website/source/docs/drivers/exec.html.md
+++ b/website/source/docs/drivers/exec.html.md
@@ -11,7 +11,7 @@ description: |-
 Name: `exec`
 
 The `exec` driver is used to simply execute a particular command for a task.
-However unlike [`raw_exec`](raw_exec.html) it uses the underlying isolation
+However, unlike [`raw_exec`](raw_exec.html) it uses the underlying isolation
 primitives of the operating system to limit the tasks access to resources. While
 simple, since the `exec` driver  can invoke any command, it can be used to call
 scripts or other wrappers which provide higher level features.
@@ -28,9 +28,10 @@ must reference it in the `command` as show in the examples below
 
 ## Client Requirements
 
-The `exec` driver can run on all supported operating systems but to provide
-proper isolation the client must be run as root on non-Windows operating systems.
-Further, to support cgroups, `/sys/fs/cgroups/` must be mounted.
+The `exec` driver can only be run when on Linux and running Nomad as root.
+`exec` is limited to this configuration because currently isolation of resources
+is only guaranteed on Linux. Further the host must have cgroups mounted properly
+in order for the driver to work.
 
 You must specify a `command` to be executed. Optionally you can specify an
 `artifact_source` to be downloaded as well. Any `command` is assumed to be present on the 
@@ -68,8 +69,5 @@ The `exec` driver will set the following client attributes:
 The resource isolation provided varies by the operating system of
 the client and the configuration.
 
-On Linux, Nomad will use cgroups, namespaces, and chroot to isolate the
+On Linux, Nomad will use cgroups, and a chroot to isolate the
 resources of a process and as such the Nomad agent must be run as root.
-
-On Windows, the task driver will just execute the command with no additional
-resource isolation.


### PR DESCRIPTION
This PR does the following:

* spawn-daemon is refactored, updated to be cross-platform and saves the exit code to disk.
* Create Spawner package that is used to create the spawn-daemon and handles IPC with it.
* exec is disabled on all platforms other than linux running as root (only way to do isolation).
* exec_linux is updated to assume cgroups, support systemd, actually implement the Open() interface.
* Create a BasicExecutor which can be used by both exec_universal and raw_exec.