### PR TITLE
Passing in the AllocID to exec context

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -295,7 +295,7 @@ func (r *AllocRunner) Run() {
 			r.setStatus(structs.AllocClientStatusFailed, fmt.Sprintf("failed to build task dirs for '%s'", alloc.TaskGroup))
 			return
 		}
-		r.ctx = driver.NewExecContext(allocDir)
+		r.ctx = driver.NewExecContext(allocDir, r.alloc.ID)
 	}
 
 	// Start the task runners

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -100,11 +100,14 @@ type ExecContext struct {
 
 	// AllocDir contains information about the alloc directory structure.
 	AllocDir *allocdir.AllocDir
+
+	// Alloc ID
+	AllocID string
 }
 
 // NewExecContext is used to create a new execution context
-func NewExecContext(alloc *allocdir.AllocDir) *ExecContext {
-	return &ExecContext{AllocDir: alloc}
+func NewExecContext(alloc *allocdir.AllocDir, allocID string) *ExecContext {
+	return &ExecContext{AllocDir: alloc, AllocID: allocID}
 }
 
 // TaskEnvironmentVariables converts exec context and task configuration into a

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -43,7 +43,7 @@ func testDriverContext(task string) *DriverContext {
 func testDriverExecContext(task *structs.Task, driverCtx *DriverContext) *ExecContext {
 	allocDir := allocdir.NewAllocDir(filepath.Join(driverCtx.config.AllocDir, structs.GenerateUUID()))
 	allocDir.Build([]*structs.Task{task})
-	ctx := NewExecContext(allocDir)
+	ctx := NewExecContext(allocDir, "dummyAllocId")
 	return ctx
 }
 

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -51,7 +51,7 @@ func testTaskRunner() (*MockTaskStateUpdater, *TaskRunner) {
 	allocDir := allocdir.NewAllocDir(filepath.Join(conf.AllocDir, alloc.ID))
 	allocDir.Build([]*structs.Task{task})
 
-	ctx := driver.NewExecContext(allocDir)
+	ctx := driver.NewExecContext(allocDir, alloc.ID)
 	rp := structs.NewRestartPolicy(structs.JobTypeService)
 	restartTracker := newRestartTracker(structs.JobTypeService, rp)
 	tr := NewTaskRunner(logger, conf, upd.Update, ctx, alloc.ID, task, restartTracker)


### PR DESCRIPTION
This will allow drivers to name tasks after the AllocIDs so that monitoring systems can make sense of any metrics that goes out from them and co-relate back to jobs.