### PR TITLE
Not restoring Task Runners for Tasks which are dead

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -103,7 +103,12 @@ func (r *AllocRunner) RestoreState() error {
 
 	// Restore the task runners
 	var mErr multierror.Error
-	for name := range r.taskStatus {
+	for name, status := range r.taskStatus {
+		// TODO Think about what other cases when we won't need to restore
+		// Task Runner for tasks
+		if status.Status == structs.AllocClientStatusDead {
+			continue
+		}
 		task := &structs.Task{Name: name}
 		restartTracker := newRestartTracker(r.alloc.Job.Type, r.RestartPolicy)
 		tr := NewTaskRunner(r.logger, r.config, r.setTaskStatus, r.ctx, r.alloc.ID, task, restartTracker)


### PR DESCRIPTION
This PR fixes the bug which causes Nomad client to crash while restarting when user have stopped jobs on a node and the client tries to find the Task while restoring from a snapshot.

Follow up PRs will attempt to remove allocs from the snapshot which are dead.