### PR TITLE
jobspec: new HCL API

### DIFF
--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -228,6 +228,8 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		t.Logf("Testing parse: %s", tc.File)
+
 		path, err := filepath.Abs(filepath.Join("./test-fixtures", tc.File))
 		if err != nil {
 			t.Fatalf("file: %s\n\n%s", tc.File, err)


### PR DESCRIPTION
**DO NOT MERGE YET: Upstream HCL isn't updated yet, this is just staging the changes.**

This updates the HCL parsers to the new API. The tests are unchanged and verify the functionality.

Note @diptanu (I think): I was able to get rid of a lot of your `toDuration` and `toInteger` and so on by using `mapstructure`'s built-in decode hooks. We've done this before, and its a lot cleaner/easier this way and handles the edge cases for you!

I also updated some of the style to better match our normal HCL parsing.