### PR TITLE
api /v1/node/<id>/allocations returns an array of Allocation objects,…

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -47,13 +47,13 @@ func (n *Nodes) ToggleDrain(nodeID string, drain bool, q *WriteOptions) (*WriteM
 }
 
 // Allocations is used to return the allocations associated with a node.
-func (n *Nodes) Allocations(nodeID string, q *QueryOptions) ([]*AllocationListStub, *QueryMeta, error) {
-	var resp []*AllocationListStub
+func (n *Nodes) Allocations(nodeID string, q *QueryOptions) ([]*Allocation, *QueryMeta, error) {
+	var resp []*Allocation
 	qm, err := n.client.query("/v1/node/"+nodeID+"/allocations", &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
-	sort.Sort(AllocIndexSort(resp))
+	sort.Sort(AllocationSort(resp))
 	return resp, qm, nil
 }
 
@@ -116,4 +116,19 @@ func (n NodeIndexSort) Swap(i, j int) {
 // nodeEvalResponse is used to decode a force-eval.
 type nodeEvalResponse struct {
 	EvalID string
+}
+
+// AllocationSort reverse sorts allocs by CreateIndex.
+type AllocationSort []*Allocation
+
+func (a AllocationSort) Len() int {
+	return len(a)
+}
+
+func (a AllocationSort) Less(i, j int) bool {
+	return a[i].CreateIndex > a[j].CreateIndex
+}
+
+func (a AllocationSort) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
 }

--- a/website/source/docs/http/node.html.md
+++ b/website/source/docs/http/node.html.md
@@ -114,20 +114,141 @@ be specified using the `?region=` query parameter.
 
     ```javascript
     [
-    {
-        "ID": "3575ba9d-7a12-0c96-7b28-add168c67984",
-        "EvalID": "151accaa-1ac6-90fe-d427-313e70ccbb88",
-        "Name": "binstore-storagelocker.binsl[0]",
-        "NodeID": "a703c3ca-5ff8-11e5-9213-970ee8879d1b",
-        "JobID": "binstore-storagelocker",
-        "TaskGroup": "binsl",
+      {
+        "ID": "8a0c24d9-cdfc-ce67-1208-8d4524b1a9b3",
+        "EvalID": "2c699410-8697-6109-86b7-430909b00bb9",
+        "Name": "example.cache[0]",
+        "NodeID": "12d3409b-9d27-fcad-a03d-b3c18887d153",
+        "JobID": "example",
+        "Job": {
+          "Region": "global",
+          "ID": "example",
+          "Name": "example",
+          "Type": "service",
+          "Priority": 50,
+          "AllAtOnce": false,
+          "Datacenters": [
+            "lon1"
+          ],
+          "Constraints": [
+            {
+              "Hard": true,
+              "LTarget": "$attr.kernel.name",
+              "RTarget": "linux",
+              "Operand": "=",
+              "Weight": 0
+            }
+          ],
+          "TaskGroups": [
+            {
+              "Name": "cache",
+              "Count": 1,
+              "Constraints": null,
+              "Tasks": [
+                {
+                  "Name": "redis",
+                  "Driver": "docker",
+                  "Config": {
+                    "image": "redis:latest"
+                  },
+                  "Env": null,
+                  "Constraints": null,
+                  "Resources": {
+                    "CPU": 500,
+                    "MemoryMB": 256,
+                    "DiskMB": 0,
+                    "IOPS": 0,
+                    "Networks": [
+                      {
+                        "Device": "",
+                        "CIDR": "",
+                        "IP": "",
+                        "MBits": 10,
+                        "ReservedPorts": null,
+                        "DynamicPorts": [
+                          "6379"
+                        ]
+                      }
+                    ]
+                  },
+                  "Meta": null
+                }
+              ],
+              "Meta": null
+            }
+          ],
+          "Update": {
+            "Stagger": 0,
+            "MaxParallel": 0
+          },
+          "Meta": null,
+          "Status": "",
+          "StatusDescription": "",
+          "CreateIndex": 6,
+          "ModifyIndex": 6
+        },
+        "TaskGroup": "cache",
+        "Resources": {
+          "CPU": 500,
+          "MemoryMB": 256,
+          "DiskMB": 0,
+          "IOPS": 0,
+          "Networks": [
+            {
+              "Device": "",
+              "CIDR": "",
+              "IP": "",
+              "MBits": 10,
+              "ReservedPorts": null,
+              "DynamicPorts": [
+                "6379"
+              ]
+            }
+          ]
+        },
+        "TaskResources": {
+          "redis": {
+            "CPU": 500,
+            "MemoryMB": 256,
+            "DiskMB": 0,
+            "IOPS": 0,
+            "Networks": [
+              {
+                "Device": "eth0",
+                "CIDR": "",
+                "IP": "10.16.0.222",
+                "MBits": 0,
+                "ReservedPorts": [
+                  23889
+                ],
+                "DynamicPorts": [
+                  "6379"
+                ]
+              }
+            ]
+          }
+        },
+        "Metrics": {
+          "NodesEvaluated": 1,
+          "NodesFiltered": 0,
+          "ClassFiltered": null,
+          "ConstraintFiltered": null,
+          "NodesExhausted": 0,
+          "ClassExhausted": null,
+          "DimensionExhausted": null,
+          "Scores": {
+            "12d3409b-9d27-fcad-a03d-b3c18887d153.binpack": 10.779215064231561
+          },
+          "AllocationTime": 75232,
+          "CoalescedFailures": 0
+        },
         "DesiredStatus": "run",
         "DesiredDescription": "",
-        "ClientStatus": "running",
+        "ClientStatus": "pending",
         "ClientDescription": "",
-        "CreateIndex": 16,
-        "ModifyIndex": 16
-    },
+        "CreateIndex": 8,
+        "ModifyIndex": 8
+      },
     ...
     ]
     ```


### PR DESCRIPTION
… not AllocationIndexStub


Endpoint for node allocations returns full allocations information instead of stub ones.

Probably the real goal for the endpoint was on return simpler information, so the endpoint to fix is on the server side instead of the client.

Anytime having that information there helps and simplifies getting info, so probably it can be interesting to have a `/api/node/<id>/allocations` and a  `/api/node/<id>/allocations?full=true` with extended information.

Endpoint asked with a curl:
```
curl http://localhost:4646/v1/node/node-4/allocations?pretty=true
[
    {
        "ID": "0fe63e23-e7bf-28ea-c4c3-3703c07e5a13",
        "EvalID": "65824dc6-6416-c600-5a60-d1c4eb7d70ee",
        "Name": "111.cache[3]",
        "NodeID": "node-4",
        "JobID": "111",
        "Job": {
            "Region": "global",
            "ID": "111",
            "Name": "111",
            "Type": "service",
            "Priority": 50,
            "AllAtOnce": false,
            "Datacenters": [
                "ams3"
            ],
            "Constraints": [ ...],
            "TaskGroups": [ ... ]

...
...
]
    

