### PR TITLE
Updating snapshots of a TaskRunner when status of Task changes

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -138,11 +138,11 @@ func (r *AllocRunner) SaveState(taskName string) error {
 	defer r.taskLock.RUnlock()
 	var mErr multierror.Error
 	if taskName != "" {
-		tr, ok := r.tasks[taskName]
-		if !ok {
+		if tr, ok := r.tasks[taskName]; ok {
+			r.saveTaskRunnerState(tr, &mErr)
+		} else {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("[ERR] client: Task with name %v not found in alloc runner %v", taskName, r.alloc.Name))
 		}
-		r.saveTaskRunnerState(tr, &mErr)
 		return mErr.ErrorOrNil()
 	}
 	for _, tr := range r.tasks {

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -123,7 +123,9 @@ func (r *AllocRunner) RestoreState() error {
 // is snapshotted. If fullSync is marked as true, we snapshot
 // all the Task Runners associated with the Alloc
 func (r *AllocRunner) SaveState() error {
-	r.saveAllocRunnerState()
+	if err := r.saveAllocRunnerState(); err != nil {
+		return err
+	}
 
 	// Save state for each task
 	r.taskLock.RLock()
@@ -146,11 +148,7 @@ func (r *AllocRunner) saveAllocRunnerState() error {
 		TaskStatus:    r.taskStatus,
 		Context:       r.ctx,
 	}
-	err := persistState(r.stateFilePath(), &snap)
-	if err != nil {
-		return err
-	}
-	return nil
+	return persistState(r.stateFilePath(), &snap)
 }
 
 func (r *AllocRunner) saveTaskRunnerState(tr *TaskRunner) error {

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -201,8 +201,7 @@ func (r *AllocRunner) dirtySyncState() {
 // retrySyncState is used to retry the state sync until success
 func (r *AllocRunner) retrySyncState(stopCh chan struct{}) {
 	for {
-		err := r.syncStatus()
-		if err == nil {
+		if err := r.syncStatus(); err == nil {
 			// The Alloc State might have been re-computed so we are
 			// snapshoting only the alloc runner
 			r.SaveState(false)

--- a/client/client.go
+++ b/client/client.go
@@ -351,7 +351,7 @@ func (c *Client) saveState() error {
 	c.allocLock.RLock()
 	defer c.allocLock.RUnlock()
 	for id, ar := range c.allocs {
-		if err := ar.SaveState(""); err != nil {
+		if err := ar.SaveState(true); err != nil {
 			c.logger.Printf("[ERR] client: failed to save state for alloc %s: %v",
 				id, err)
 			mErr.Errors = append(mErr.Errors, err)

--- a/client/client.go
+++ b/client/client.go
@@ -351,7 +351,7 @@ func (c *Client) saveState() error {
 	c.allocLock.RLock()
 	defer c.allocLock.RUnlock()
 	for id, ar := range c.allocs {
-		if err := ar.SaveState(); err != nil {
+		if err := ar.SaveState(""); err != nil {
 			c.logger.Printf("[ERR] client: failed to save state for alloc %s: %v",
 				id, err)
 			mErr.Errors = append(mErr.Errors, err)

--- a/client/client.go
+++ b/client/client.go
@@ -351,7 +351,7 @@ func (c *Client) saveState() error {
 	c.allocLock.RLock()
 	defer c.allocLock.RUnlock()
 	for id, ar := range c.allocs {
-		if err := ar.SaveState(true); err != nil {
+		if err := ar.SaveState(); err != nil {
 			c.logger.Printf("[ERR] client: failed to save state for alloc %s: %v",
 				id, err)
 			mErr.Errors = append(mErr.Errors, err)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -32,6 +32,8 @@ type TaskRunner struct {
 	destroyCh   chan struct{}
 	destroyLock sync.Mutex
 	waitCh      chan struct{}
+
+	snapshotLock sync.Mutex
 }
 
 // taskRunnerState is used to snapshot the state of the task runner
@@ -112,6 +114,8 @@ func (r *TaskRunner) RestoreState() error {
 
 // SaveState is used to snapshot our state
 func (r *TaskRunner) SaveState() error {
+	r.snapshotLock.Lock()
+	defer r.snapshotLock.Unlock()
 	snap := taskRunnerState{
 		Task: r.task,
 	}


### PR DESCRIPTION
This PR updates the snapshot only for a TaskRunner when it's state is updated. This doesn't fix the client errors while restarting if the drivers can't attached to running or failed tasks.