### PR TITLE
Client Restore State Fixes

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -103,11 +103,18 @@ func (r *AllocRunner) RestoreState() error {
 
 	// Restore the task runners
 	var mErr multierror.Error
-	for name := range r.taskStatus {
+	for name, status := range r.taskStatus {
 		task := &structs.Task{Name: name}
 		restartTracker := newRestartTracker(r.alloc.Job.Type, r.RestartPolicy)
 		tr := NewTaskRunner(r.logger, r.config, r.setTaskStatus, r.ctx, r.alloc.ID, task, restartTracker)
 		r.tasks[name] = tr
+
+		// Skip tasks in terminal states.
+		if status.Status == structs.AllocClientStatusDead ||
+			status.Status == structs.AllocClientStatusFailed {
+			continue
+		}
+
 		if err := tr.RestoreState(); err != nil {
 			r.logger.Printf("[ERR] client: failed to restore state for alloc %s task '%s': %v", r.alloc.ID, name, err)
 			mErr.Errors = append(mErr.Errors, err)
@@ -302,7 +309,7 @@ func (r *AllocRunner) Run() {
 	r.taskLock.Lock()
 	for _, task := range tg.Tasks {
 		// Skip tasks that were restored
-		if _, ok := r.tasks[task.Name]; ok {
+		if _, ok := r.taskStatus[task.Name]; ok {
 			continue
 		}
 

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -117,12 +117,8 @@ func TestAllocRunner_Update(t *testing.T) {
 	}
 }
 
-/*
-TODO: This test is disabled til a follow-up api changes the restore state interface.
-The driver/executor interface will be changed from Open to Cleanup, in which
-clean-up tears down previous allocs.
-
 func TestAllocRunner_SaveRestoreState(t *testing.T) {
+	ctestutil.ExecCompatible(t)
 	upd, ar := testAllocRunner()
 
 	// Ensure task takes some time
@@ -163,8 +159,7 @@ func TestAllocRunner_SaveRestoreState(t *testing.T) {
 		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.taskStatus)
 	})
 
-	if time.Since(start) > time.Second {
+	if time.Since(start) > 15*time.Second {
 		t.Fatalf("took too long to terminate")
 	}
 }
-*/

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -126,16 +126,22 @@ func (d *AllocDir) Embed(task string, dirs map[string]string) error {
 			continue
 		}
 
+		// Check if destination directory exists. This can happen if restarting
+		// a failed task.
+		destDir := filepath.Join(taskdir, dest)
+		if _, err := os.Stat(destDir); err == nil {
+			continue
+		}
+
+		// Create destination directory.
+		if err := os.MkdirAll(destDir, s.Mode().Perm()); err != nil {
+			return fmt.Errorf("Couldn't create destination directory %v: %v", destDir, err)
+		}
+
 		// Enumerate the files in source.
 		entries, err := ioutil.ReadDir(source)
 		if err != nil {
 			return fmt.Errorf("Couldn't read directory %v: %v", source, err)
-		}
-
-		// Create destination directory.
-		destDir := filepath.Join(taskdir, dest)
-		if err := os.MkdirAll(destDir, s.Mode().Perm()); err != nil {
-			return fmt.Errorf("Couldn't create destination directory %v: %v", destDir, err)
 		}
 
 		for _, entry := range entries {

--- a/client/allocdir/alloc_dir_linux.go
+++ b/client/allocdir/alloc_dir_linux.go
@@ -8,7 +8,7 @@ import (
 // Bind mounts the shared directory into the task directory. Must be root to
 // run.
 func (d *AllocDir) mountSharedDir(taskDir string) error {
-	if err := os.Mkdir(taskDir, 0777); err != nil {
+	if err := os.MkdirAll(taskDir, 0777); err != nil {
 		return err
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -111,11 +111,6 @@ func NewClient(cfg *config.Config) (*Client, error) {
 		return nil, fmt.Errorf("failed intializing client: %v", err)
 	}
 
-	// Restore the state
-	if err := c.restoreState(); err != nil {
-		return nil, fmt.Errorf("failed to restore state: %v", err)
-	}
-
 	// Setup the node
 	if err := c.setupNode(); err != nil {
 		return nil, fmt.Errorf("node setup failed: %v", err)
@@ -133,6 +128,11 @@ func NewClient(cfg *config.Config) (*Client, error) {
 
 	// Set up the known servers list
 	c.SetServers(c.config.Servers)
+
+	// Restore the state
+	if err := c.restoreState(); err != nil {
+		return nil, fmt.Errorf("failed to restore state: %v", err)
+	}
 
 	// Start the client!
 	go c.run()
@@ -331,8 +331,7 @@ func (c *Client) restoreState() error {
 		ar := NewAllocRunner(c.logger, c.config, c.updateAllocStatus, alloc)
 		c.allocs[id] = ar
 		if err := ar.RestoreState(); err != nil {
-			c.logger.Printf("[ERR] client: failed to restore state for alloc %s: %v",
-				id, err)
+			c.logger.Printf("[ERR] client: failed to restore state for alloc %s: %v", id, err)
 			mErr.Errors = append(mErr.Errors, err)
 		} else {
 			go ar.Run()

--- a/client/client.go
+++ b/client/client.go
@@ -148,8 +148,15 @@ func (c *Client) init() error {
 			return fmt.Errorf("failed creating state dir: %s", err)
 		}
 
-		c.logger.Printf("[INFO] client: using state directory %v", c.config.StateDir)
+	} else {
+		// Othewise make a temp directory to use.
+		p, err := ioutil.TempDir("", "NomadClient")
+		if err != nil {
+			return fmt.Errorf("failed creating temporary directory for the StateDir: %v", err)
+		}
+		c.config.StateDir = p
 	}
+	c.logger.Printf("[INFO] client: using state directory %v", c.config.StateDir)
 
 	// Ensure the alloc dir exists if we have one
 	if c.config.AllocDir != "" {

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -33,11 +33,6 @@ func TestExecDriver_Fingerprint(t *testing.T) {
 	}
 }
 
-/*
-TODO: This test is disabled til a follow-up api changes the restore state interface.
-The driver/executor interface will be changed from Open to Cleanup, in which
-clean-up tears down previous allocs.
-
 func TestExecDriver_StartOpen_Wait(t *testing.T) {
 	ctestutils.ExecCompatible(t)
 	task := &structs.Task{
@@ -53,12 +48,6 @@ func TestExecDriver_StartOpen_Wait(t *testing.T) {
 	ctx := testDriverExecContext(task, driverCtx)
 	defer ctx.AllocDir.Destroy()
 	d := NewExecDriver(driverCtx)
-
-	if task.Resources == nil {
-		task.Resources = &structs.Resources{}
-	}
-	task.Resources.CPU = 0.5
-	task.Resources.MemoryMB = 2
 
 	handle, err := d.Start(ctx, task)
 	if err != nil {
@@ -77,7 +66,6 @@ func TestExecDriver_StartOpen_Wait(t *testing.T) {
 		t.Fatalf("missing handle")
 	}
 }
-*/
 
 func TestExecDriver_Start_Wait(t *testing.T) {
 	ctestutils.ExecCompatible(t)

--- a/client/driver/executor/exec_linux.go
+++ b/client/driver/executor/exec_linux.go
@@ -264,7 +264,7 @@ func (e *LinuxExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocD
 
 	// Mount dev
 	dev := filepath.Join(taskDir, "dev")
-	if err := os.Mkdir(dev, 0777); err != nil {
+	if err := os.MkdirAll(dev, 0777); err != nil {
 		return fmt.Errorf("Mkdir(%v) failed: %v", dev, err)
 	}
 
@@ -274,7 +274,7 @@ func (e *LinuxExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocD
 
 	// Mount proc
 	proc := filepath.Join(taskDir, "proc")
-	if err := os.Mkdir(proc, 0777); err != nil {
+	if err := os.MkdirAll(proc, 0777); err != nil {
 		return fmt.Errorf("Mkdir(%v) failed: %v", proc, err)
 	}
 

--- a/client/driver/executor/exec_linux.go
+++ b/client/driver/executor/exec_linux.go
@@ -264,22 +264,26 @@ func (e *LinuxExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocD
 
 	// Mount dev
 	dev := filepath.Join(taskDir, "dev")
-	if err := os.MkdirAll(dev, 0777); err != nil {
-		return fmt.Errorf("Mkdir(%v) failed: %v", dev, err)
-	}
+	if !e.pathExists(dev) {
+		if err := os.Mkdir(dev, 0777); err != nil {
+			return fmt.Errorf("Mkdir(%v) failed: %v", dev, err)
+		}
 
-	if err := syscall.Mount("", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
-		return fmt.Errorf("Couldn't mount /dev to %v: %v", dev, err)
+		if err := syscall.Mount("", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
+			return fmt.Errorf("Couldn't mount /dev to %v: %v", dev, err)
+		}
 	}
 
 	// Mount proc
 	proc := filepath.Join(taskDir, "proc")
-	if err := os.MkdirAll(proc, 0777); err != nil {
-		return fmt.Errorf("Mkdir(%v) failed: %v", proc, err)
-	}
+	if !e.pathExists(proc) {
+		if err := os.Mkdir(proc, 0777); err != nil {
+			return fmt.Errorf("Mkdir(%v) failed: %v", proc, err)
+		}
 
-	if err := syscall.Mount("", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
-		return fmt.Errorf("Couldn't mount /proc to %v: %v", proc, err)
+		if err := syscall.Mount("", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
+			return fmt.Errorf("Couldn't mount /proc to %v: %v", proc, err)
+		}
 	}
 
 	// Set the tasks AllocDir environment variable.

--- a/client/driver/java_test.go
+++ b/client/driver/java_test.go
@@ -41,18 +41,18 @@ func TestJavaDriver_Fingerprint(t *testing.T) {
 	}
 }
 
-/*
-TODO: This test is disabled til a follow-up api changes the restore state interface.
-The driver/executor interface will be changed from Open to Cleanup, in which
-clean-up tears down previous allocs.
 func TestJavaDriver_StartOpen_Wait(t *testing.T) {
-	ctestutils.ExecCompatible(t)
+	if !javaLocated() {
+		t.Skip("Java not found; skipping")
+	}
+
+	ctestutils.JavaCompatible(t)
 	task := &structs.Task{
 		Name: "demo-app",
 		Config: map[string]string{
-			"jar_source": "https://dl.dropboxusercontent.com/u/47675/jar_thing/demoapp.jar",
-			// "jar_source": "https://s3-us-west-2.amazonaws.com/java-jar-thing/demoapp.jar",
-			// "args": "-d64",
+			"artifact_source": "https://dl.dropboxusercontent.com/u/47675/jar_thing/demoapp.jar",
+			"jvm_options":     "-Xmx2048m -Xms256m",
+			"checksum":        "sha256:58d6e8130308d32e197c5108edd4f56ddf1417408f743097c2e662df0f0b17c8",
 		},
 		Resources: basicResources,
 	}
@@ -86,7 +86,6 @@ func TestJavaDriver_StartOpen_Wait(t *testing.T) {
 		t.Fatalf("Error: %s", err)
 	}
 }
-*/
 
 func TestJavaDriver_Start_Wait(t *testing.T) {
 	if !javaLocated() {

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -100,10 +100,12 @@ func (r *TaskRunner) RestoreState() error {
 		}
 
 		handle, err := driver.Open(r.ctx, snap.HandleID)
+
+		// In the case it fails, we relaunch the task in the Run() method.
 		if err != nil {
 			r.logger.Printf("[ERR] client: failed to open handle to task '%s' for alloc '%s': %v",
 				r.task.Name, r.allocID, err)
-			return err
+			return nil
 		}
 		r.handle = handle
 	}

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -187,7 +187,7 @@ func TestTaskRunner_SaveRestoreState(t *testing.T) {
 
 	select {
 	case <-tr.WaitCh():
-	case <-time.After(10 * time.Second):
+	case <-time.After(15 * time.Second):
 		t.Fatalf("timeout")
 	}
 }

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -167,7 +167,7 @@ func TestTaskRunner_SaveRestoreState(t *testing.T) {
 	defer tr.Destroy()
 
 	// Snapshot state
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	if err := tr.SaveState(); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestTaskRunner_SaveRestoreState(t *testing.T) {
 	defer tr2.Destroy()
 
 	// Destroy and wait
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	if tr2.handle == nil {
 		t.Fatalf("RestoreState() didn't open handle")
 	}

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -156,11 +156,6 @@ func TestTaskRunner_Update(t *testing.T) {
 	})
 }
 
-/*
-TODO: This test is disabled til a follow-up api changes the restore state interface.
-The driver/executor interface will be changed from Open to Cleanup, in which
-clean-up tears down previous allocs.
-
 func TestTaskRunner_SaveRestoreState(t *testing.T) {
 	upd, tr := testTaskRunner()
 
@@ -179,21 +174,20 @@ func TestTaskRunner_SaveRestoreState(t *testing.T) {
 
 	// Create a new task runner
 	tr2 := NewTaskRunner(tr.logger, tr.config, upd.Update,
-		tr.ctx, tr.allocID, &structs.Task{Name: tr.task.Name})
+		tr.ctx, tr.allocID, &structs.Task{Name: tr.task.Name}, tr.restartTracker)
 	err = tr2.RestoreState()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	go tr2.Run()
-	defer tr2.Destroy()
 
 	// Destroy and wait
+	time.Sleep(200 * time.Millisecond)
 	tr2.Destroy()
 
 	select {
 	case <-tr.WaitCh():
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("timeout")
 	}
 }
-*/

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -157,6 +157,7 @@ func TestTaskRunner_Update(t *testing.T) {
 }
 
 func TestTaskRunner_SaveRestoreState(t *testing.T) {
+	ctestutil.ExecCompatible(t)
 	upd, tr := testTaskRunner()
 
 	// Change command to ensure we run for a bit

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -167,27 +167,22 @@ func TestTaskRunner_SaveRestoreState(t *testing.T) {
 
 	// Snapshot state
 	time.Sleep(200 * time.Millisecond)
-	err := tr.SaveState()
-	if err != nil {
+	if err := tr.SaveState(); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Create a new task runner
 	tr2 := NewTaskRunner(tr.logger, tr.config, upd.Update,
 		tr.ctx, tr.allocID, &structs.Task{Name: tr.task.Name}, tr.restartTracker)
-	err = tr2.RestoreState()
-	if err != nil {
+	if err := tr2.RestoreState(); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	go tr2.Run()
+	defer tr2.Destroy()
 
 	// Destroy and wait
 	time.Sleep(200 * time.Millisecond)
-	tr2.Destroy()
-
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(15 * time.Second):
-		t.Fatalf("timeout")
+	if tr2.handle == nil {
+		t.Fatalf("RestoreState() didn't open handle")
 	}
 }


### PR DESCRIPTION
This PR updates how we restore state such that if a handle is not able to be opened we do not fail launching the client. Instead we now attempt to open the handle and if it fails, launch a new task_runner. This PR also re-enables the RestoreState and Open tests.

Fixes: #135, #176