### PR TITLE
Making sure a Task Group has a restart policy

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -979,8 +979,12 @@ func (tg *TaskGroup) Validate() error {
 		}
 	}
 
-	if err := tg.RestartPolicy.Validate(); err != nil {
-		mErr.Errors = append(mErr.Errors, err)
+	if tg.RestartPolicy != nil {
+		if err := tg.RestartPolicy.Validate(); err != nil {
+			mErr.Errors = append(mErr.Errors, err)
+		}
+	} else {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("Task Group %v should have a restart policy", tg.Name))
 	}
 
 	// Check for duplicate tasks


### PR DESCRIPTION
This ensures that the Job submitted to a Nomad Job Register API has a valid restart policy in a Task Group. 

If a user is submitting the job via HCL, then we insert a default restart policy if the restart policy is empty.