### PR TITLE
Fix AWS metadata url

### DIFF
--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -17,7 +17,7 @@ import (
 
 // This is where the AWS metadata server normally resides. We hardcode the
 // "instance" path as well since it's the only one we access here.
-const DEFAULT_AWS_URL = "http//169.254.169.254/latest/meta-data/"
+const DEFAULT_AWS_URL = "http://169.254.169.254/latest/meta-data/"
 
 // map of instance type to approximate speed, in Mbits/s
 // http://serverfault.com/questions/324883/aws-bandwidth-and-content-delivery/326797#326797


### PR DESCRIPTION
Fix URL. It was printing an error message on startup:
```
2015/11/13 15:49:21 [ERR] fingerprint.env_aws: Error querying AWS Metadata URL, skipping
```

By the way is it safe to use latest? Is there a chance that Amazon decides to change the format of the metadata? It could be safer to use something like `http://169.254.169.254/2014-11-05/meta-data`