### PR TITLE
Track Tasks State

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -52,6 +52,7 @@ type Allocation struct {
 	DesiredDescription string
 	ClientStatus       string
 	ClientDescription  string
+	TaskStates         map[string]*TaskState
 	CreateIndex        uint64
 	ModifyIndex        uint64
 }
@@ -83,6 +84,7 @@ type AllocationListStub struct {
 	DesiredDescription string
 	ClientStatus       string
 	ClientDescription  string
+	TaskStates         map[string]*TaskState
 	CreateIndex        uint64
 	ModifyIndex        uint64
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -110,3 +110,31 @@ func (t *Task) Constrain(c *Constraint) *Task {
 	t.Constraints = append(t.Constraints, c)
 	return t
 }
+
+// TaskState tracks the current state of a task and events that caused state
+// transistions.
+type TaskState struct {
+	State  string
+	Events []*TaskEvent
+}
+
+// TaskEventType is the set of events that effect the state of a task.
+type TaskEventType int
+
+const (
+	TaskDriverFailure TaskEventType = iota
+	TaskStarted
+	TaskTerminated
+	TaskKilled
+)
+
+// TaskEvent is an event that effects the state of a task and contains meta-data
+// appropriate to the events type.
+type TaskEvent struct {
+	Type        TaskEventType
+	Time        int64
+	DriverError error
+	ExitCode    int
+	Signal      int
+	Message     string
+}

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -137,4 +137,5 @@ type TaskEvent struct {
 	ExitCode    int
 	Signal      int
 	Message     string
+	KillError   string
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -118,20 +118,17 @@ type TaskState struct {
 	Events []*TaskEvent
 }
 
-// TaskEventType is the set of events that effect the state of a task.
-type TaskEventType int
-
 const (
-	TaskDriverFailure TaskEventType = iota
-	TaskStarted
-	TaskTerminated
-	TaskKilled
+	TaskDriverFailure = "Driver Failure"
+	TaskStarted       = "Started"
+	TaskTerminated    = "Terminated"
+	TaskKilled        = "Killed"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
 // appropriate to the events type.
 type TaskEvent struct {
-	Type        TaskEventType
+	Type        string
 	Time        int64
 	DriverError error
 	ExitCode    int

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -130,7 +130,7 @@ const (
 type TaskEvent struct {
 	Type        string
 	Time        int64
-	DriverError error
+	DriverError string
 	ExitCode    int
 	Signal      int
 	Message     string

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -183,16 +183,6 @@ func (r *AllocRunner) Alloc() *structs.Allocation {
 	return r.alloc
 }
 
-// setAlloc is used to update the allocation of the runner
-// we preserve the existing client status and description
-func (r *AllocRunner) setAlloc(alloc *structs.Allocation) {
-	if r.alloc != nil {
-		alloc.ClientStatus = r.alloc.ClientStatus
-		alloc.ClientDescription = r.alloc.ClientDescription
-	}
-	r.alloc = alloc
-}
-
 // dirtySyncState is used to watch for state being marked dirty to sync
 func (r *AllocRunner) dirtySyncState() {
 	for {

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -11,6 +11,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/driver/environment"
+	cstructs "github.com/hashicorp/nomad/client/driver/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -58,7 +59,7 @@ func TestDockerDriver_Handle(t *testing.T) {
 		imageID:     "imageid",
 		containerID: "containerid",
 		doneCh:      make(chan struct{}),
-		waitCh:      make(chan error, 1),
+		waitCh:      make(chan *cstructs.WaitResult, 1),
 	}
 
 	actual := h.ID()
@@ -163,9 +164,9 @@ func TestDockerDriver_Start_Wait(t *testing.T) {
 	}
 
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")
@@ -210,9 +211,9 @@ func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
 	defer handle.Kill()
 
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")
@@ -268,9 +269,9 @@ func TestDockerDriver_Start_Kill_Wait(t *testing.T) {
 	}()
 
 	select {
-	case err := <-handle.WaitCh():
-		if err == nil {
-			t.Fatalf("should err: %v", err)
+	case res := <-handle.WaitCh():
+		if res.Successful() {
+			t.Fatalf("should err: %v", res)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatalf("timeout")

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/nomad/client/driver/environment"
 	"github.com/hashicorp/nomad/client/fingerprint"
 	"github.com/hashicorp/nomad/nomad/structs"
+
+	cstructs "github.com/hashicorp/nomad/client/driver/structs"
 )
 
 // BuiltinDrivers contains the built in registered drivers
@@ -85,7 +87,7 @@ type DriverHandle interface {
 	ID() string
 
 	// WaitCh is used to return a channel used wait for task completion
-	WaitCh() chan error
+	WaitCh() chan *cstructs.WaitResult
 
 	// Update is used to update the task if possible
 	Update(task *structs.Task) error

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -99,9 +99,9 @@ func TestExecDriver_Start_Wait(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(4 * time.Second):
 		t.Fatalf("timeout")
@@ -143,9 +143,9 @@ func TestExecDriver_Start_Artifact_basic(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")
@@ -187,9 +187,9 @@ func TestExecDriver_Start_Artifact_expanded(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")
@@ -224,9 +224,9 @@ func TestExecDriver_Start_Wait_AllocDir(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timeout")
@@ -278,8 +278,8 @@ func TestExecDriver_Start_Kill_Wait(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err == nil {
+	case res := <-handle.WaitCh():
+		if res.Successful() {
 			t.Fatal("should err")
 		}
 	case <-time.After(8 * time.Second):

--- a/client/driver/executor/exec.go
+++ b/client/driver/executor/exec.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/nomad/structs"
+
+	cstructs "github.com/hashicorp/nomad/client/driver/structs"
 )
 
 var errNoResources = fmt.Errorf("No resources are associated with this task")
@@ -54,7 +56,7 @@ type Executor interface {
 	Open(string) error
 
 	// Wait waits till the user's command is completed.
-	Wait() error
+	Wait() *cstructs.WaitResult
 
 	// Returns a handle that is executor specific for use in reopening.
 	ID() (string, error)

--- a/client/driver/executor/exec_basic.go
+++ b/client/driver/executor/exec_basic.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/nomad/client/driver/environment"
 	"github.com/hashicorp/nomad/client/driver/spawn"
 	"github.com/hashicorp/nomad/nomad/structs"
+
+	cstructs "github.com/hashicorp/nomad/client/driver/structs"
 )
 
 // BasicExecutor should work everywhere, and as a result does not include
@@ -92,17 +94,8 @@ func (e *BasicExecutor) Open(id string) error {
 	return e.spawn.Valid()
 }
 
-func (e *BasicExecutor) Wait() error {
-	code, err := e.spawn.Wait()
-	if err != nil {
-		return err
-	}
-
-	if code != 0 {
-		return fmt.Errorf("Task exited with code: %d", code)
-	}
-
-	return nil
+func (e *BasicExecutor) Wait() *cstructs.WaitResult {
+	return e.spawn.Wait()
 }
 
 func (e *BasicExecutor) ID() (string, error) {

--- a/client/driver/executor/test_harness.go
+++ b/client/driver/executor/test_harness.go
@@ -127,8 +127,8 @@ func Executor_Start_Wait(t *testing.T, command buildExecCommand) {
 		log.Panicf("Start() failed: %v", err)
 	}
 
-	if err := e.Wait(); err != nil {
-		log.Panicf("Wait() failed: %v", err)
+	if res := e.Wait(); !res.Successful() {
+		log.Panicf("Wait() failed: %v", res)
 	}
 
 	output, err := ioutil.ReadFile(absFilePath)
@@ -215,8 +215,8 @@ func Executor_Open(t *testing.T, command buildExecCommand, newExecutor func() Ex
 		log.Panicf("Open(%v) failed: %v", id, err)
 	}
 
-	if err := e2.Wait(); err != nil {
-		log.Panicf("Wait() failed: %v", err)
+	if res := e2.Wait(); !res.Successful() {
+		log.Panicf("Wait() failed: %v", res)
 	}
 
 	output, err := ioutil.ReadFile(absFilePath)

--- a/client/driver/java_test.go
+++ b/client/driver/java_test.go
@@ -118,9 +118,9 @@ func TestJavaDriver_Start_Wait(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(2 * time.Second):
 		// expect the timeout b/c it's a long lived process
@@ -171,8 +171,8 @@ func TestJavaDriver_Start_Kill_Wait(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err == nil {
+	case res := <-handle.WaitCh():
+		if res.Successful() {
 			t.Fatal("should err")
 		}
 	case <-time.After(8 * time.Second):

--- a/client/driver/raw_exec_test.go
+++ b/client/driver/raw_exec_test.go
@@ -216,9 +216,9 @@ func TestRawExecDriver_Start_Wait(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timeout")
@@ -252,9 +252,9 @@ func TestRawExecDriver_Start_Wait_AllocDir(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timeout")
@@ -305,8 +305,8 @@ func TestRawExecDriver_Start_Kill_Wait(t *testing.T) {
 
 	// Task should terminate quickly
 	select {
-	case err := <-handle.WaitCh():
-		if err == nil {
+	case res := <-handle.WaitCh():
+		if res.Successful() {
 			t.Fatal("should err")
 		}
 	case <-time.After(2 * time.Second):

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -19,6 +19,8 @@ import (
 	"github.com/hashicorp/nomad/client/driver/args"
 	"github.com/hashicorp/nomad/client/fingerprint"
 	"github.com/hashicorp/nomad/nomad/structs"
+
+	cstructs "github.com/hashicorp/nomad/client/driver/structs"
 )
 
 var (
@@ -39,7 +41,7 @@ type rktHandle struct {
 	proc   *os.Process
 	image  string
 	logger *log.Logger
-	waitCh chan error
+	waitCh chan *cstructs.WaitResult
 	doneCh chan struct{}
 }
 
@@ -183,7 +185,7 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 		image:  img,
 		logger: d.logger,
 		doneCh: make(chan struct{}),
-		waitCh: make(chan error, 1),
+		waitCh: make(chan *cstructs.WaitResult, 1),
 	}
 	go h.run()
 	return h, nil
@@ -209,7 +211,7 @@ func (d *RktDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error
 		image:  qpid.Image,
 		logger: d.logger,
 		doneCh: make(chan struct{}),
-		waitCh: make(chan error, 1),
+		waitCh: make(chan *cstructs.WaitResult, 1),
 	}
 
 	go h.run()
@@ -229,7 +231,7 @@ func (h *rktHandle) ID() string {
 	return fmt.Sprintf("Rkt:%s", string(data))
 }
 
-func (h *rktHandle) WaitCh() chan error {
+func (h *rktHandle) WaitCh() chan *cstructs.WaitResult {
 	return h.waitCh
 }
 
@@ -253,10 +255,11 @@ func (h *rktHandle) Kill() error {
 func (h *rktHandle) run() {
 	ps, err := h.proc.Wait()
 	close(h.doneCh)
-	if err != nil {
-		h.waitCh <- err
-	} else if !ps.Success() {
-		h.waitCh <- fmt.Errorf("task exited with error")
+	code := 0
+	if !ps.Success() {
+		// TODO: Better exit code parsing.
+		code = 1
 	}
+	h.waitCh <- cstructs.NewWaitResult(code, 0, err)
 	close(h.waitCh)
 }

--- a/client/driver/rkt_test.go
+++ b/client/driver/rkt_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs"
 
+	cstructs "github.com/hashicorp/nomad/client/driver/structs"
 	ctestutils "github.com/hashicorp/nomad/client/testutil"
 )
 
@@ -35,7 +36,7 @@ func TestRktDriver_Handle(t *testing.T) {
 		proc:   &os.Process{Pid: 123},
 		image:  "foo",
 		doneCh: make(chan struct{}),
-		waitCh: make(chan error, 1),
+		waitCh: make(chan *cstructs.WaitResult, 1),
 	}
 
 	actual := h.ID()
@@ -143,9 +144,9 @@ func TestRktDriver_Start_Wait(t *testing.T) {
 	}
 
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")
@@ -184,9 +185,9 @@ func TestRktDriver_Start_Wait_Skip_Trust(t *testing.T) {
 	}
 
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")
@@ -220,9 +221,9 @@ func TestRktDriver_Start_Wait_Logs(t *testing.T) {
 	defer handle.Kill()
 
 	select {
-	case err := <-handle.WaitCh():
-		if err != nil {
-			t.Fatalf("err: %v", err)
+	case res := <-handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")

--- a/client/driver/spawn/spawn_test.go
+++ b/client/driver/spawn/spawn_test.go
@@ -68,8 +68,8 @@ func TestSpawn_SetsLogs(t *testing.T) {
 		t.Fatalf("Spawn() failed: %v", err)
 	}
 
-	if code, err := spawn.Wait(); code != 0 && err != nil {
-		t.Fatalf("Wait() returned %v, %v; want 0, nil", code, err)
+	if res := spawn.Wait(); res.ExitCode != 0 && res.Err != nil {
+		t.Fatalf("Wait() returned %v, %v; want 0, nil", res.ExitCode, res.Err)
 	}
 
 	stdout2, err := os.Open(stdout.Name())
@@ -129,13 +129,8 @@ func TestSpawn_ParentWaitExited(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	code, err := spawn.Wait()
-	if err != nil {
-		t.Fatalf("Wait() failed %v", err)
-	}
-
-	if code != 0 {
-		t.Fatalf("Wait() returned %v; want 0", code)
+	if res := spawn.Wait(); res.ExitCode != 0 && res.Err != nil {
+		t.Fatalf("Wait() returned %v, %v; want 0, nil", res.ExitCode, res.Err)
 	}
 }
 
@@ -152,13 +147,8 @@ func TestSpawn_ParentWait(t *testing.T) {
 		t.Fatalf("Spawn() failed %v", err)
 	}
 
-	code, err := spawn.Wait()
-	if err != nil {
-		t.Fatalf("Wait() failed %v", err)
-	}
-
-	if code != 0 {
-		t.Fatalf("Wait() returned %v; want 0", code)
+	if res := spawn.Wait(); res.ExitCode != 0 && res.Err != nil {
+		t.Fatalf("Wait() returned %v, %v; want 0, nil", res.ExitCode, res.Err)
 	}
 }
 
@@ -179,13 +169,8 @@ func TestSpawn_NonParentWaitExited(t *testing.T) {
 
 	// Force the wait to assume non-parent.
 	spawn.SpawnPpid = 0
-	code, err := spawn.Wait()
-	if err != nil {
-		t.Fatalf("Wait() failed %v", err)
-	}
-
-	if code != 0 {
-		t.Fatalf("Wait() returned %v; want 0", code)
+	if res := spawn.Wait(); res.ExitCode != 0 && res.Err != nil {
+		t.Fatalf("Wait() returned %v, %v; want 0, nil", res.ExitCode, res.Err)
 	}
 }
 
@@ -213,13 +198,8 @@ func TestSpawn_NonParentWait(t *testing.T) {
 
 	// Force the wait to assume non-parent.
 	spawn.SpawnPpid = 0
-	code, err := spawn.Wait()
-	if err != nil {
-		t.Fatalf("Wait() failed %v", err)
-	}
-
-	if code != 0 {
-		t.Fatalf("Wait() returned %v; want 0", code)
+	if res := spawn.Wait(); res.ExitCode != 0 && res.Err != nil {
+		t.Fatalf("Wait() returned %v, %v; want 0, nil", res.ExitCode, res.Err)
 	}
 }
 
@@ -255,8 +235,8 @@ func TestSpawn_DeadSpawnDaemon_Parent(t *testing.T) {
 		t.FailNow()
 	}
 
-	if _, err := spawn.Wait(); err == nil {
-		t.Fatalf("Wait() should have failed: %v", err)
+	if res := spawn.Wait(); res.Err == nil {
+		t.Fatalf("Wait() should have failed: %v", res.Err)
 	}
 }
 
@@ -294,8 +274,8 @@ func TestSpawn_DeadSpawnDaemon_NonParent(t *testing.T) {
 
 	// Force the wait to assume non-parent.
 	spawn.SpawnPpid = 0
-	if _, err := spawn.Wait(); err == nil {
-		t.Fatalf("Wait() should have failed: %v", err)
+	if res := spawn.Wait(); res.Err == nil {
+		t.Fatalf("Wait() should have failed: %v", res.Err)
 	}
 }
 
@@ -316,8 +296,8 @@ func TestSpawn_Valid_TaskRunning(t *testing.T) {
 		t.Fatalf("Valid() failed: %v", err)
 	}
 
-	if _, err := spawn.Wait(); err != nil {
-		t.Fatalf("Wait() failed %v", err)
+	if res := spawn.Wait(); res.Err != nil {
+		t.Fatalf("Wait() failed: %v", res.Err)
 	}
 }
 
@@ -334,8 +314,8 @@ func TestSpawn_Valid_TaskExit_ExitCode(t *testing.T) {
 		t.Fatalf("Spawn() failed %v", err)
 	}
 
-	if _, err := spawn.Wait(); err != nil {
-		t.Fatalf("Wait() failed %v", err)
+	if res := spawn.Wait(); res.Err != nil {
+		t.Fatalf("Wait() failed: %v", res.Err)
 	}
 
 	if err := spawn.Valid(); err != nil {
@@ -355,8 +335,8 @@ func TestSpawn_Valid_TaskExit_NoExitCode(t *testing.T) {
 		t.Fatalf("Spawn() failed %v", err)
 	}
 
-	if _, err := spawn.Wait(); err != nil {
-		t.Fatalf("Wait() failed %v", err)
+	if res := spawn.Wait(); res.Err != nil {
+		t.Fatalf("Wait() failed: %v", res.Err)
 	}
 
 	// Delete the file so that it can't find the exit code.

--- a/client/driver/structs/structs.go
+++ b/client/driver/structs/structs.go
@@ -1,0 +1,27 @@
+package structs
+
+import "fmt"
+
+// WaitResult stores the result of a Wait operation.
+type WaitResult struct {
+	ExitCode int
+	Signal   int
+	Err      error
+}
+
+func NewWaitResult(code, signal int, err error) *WaitResult {
+	return &WaitResult{
+		ExitCode: code,
+		Signal:   signal,
+		Err:      err,
+	}
+}
+
+func (r *WaitResult) Successful() bool {
+	return r.ExitCode == 0 && r.Signal == 0 && r.Err == nil
+}
+
+func (r *WaitResult) String() string {
+	return fmt.Sprintf("Wait returned exit code %v, signal %v, and error %v",
+		r.ExitCode, r.Signal, r.Err)
+}

--- a/client/restarts.go
+++ b/client/restarts.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"github.com/hashicorp/nomad/nomad/structs"
 	"time"
+
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // The errorCounter keeps track of the number of times a process has exited
@@ -28,6 +29,11 @@ func newRestartTracker(jobType string, restartPolicy *structs.RestartPolicy) res
 			delay:       restartPolicy.Delay,
 		}
 	}
+}
+
+// noRestartsTracker returns a RestartTracker that never restarts.
+func noRestartsTracker() restartTracker {
+	return &batchRestartTracker{maxAttempts: 0}
 }
 
 type batchRestartTracker struct {

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/driver"
 	"github.com/hashicorp/nomad/nomad/structs"
+
+	cstructs "github.com/hashicorp/nomad/client/driver/structs"
 )
 
 // TaskRunner is used to wrap a task within an allocation and provide the execution context.
@@ -25,6 +27,7 @@ type TaskRunner struct {
 	restartTracker restartTracker
 
 	task     *structs.Task
+	state    *structs.TaskState
 	updateCh chan *structs.Task
 	handle   driver.DriverHandle
 
@@ -42,13 +45,14 @@ type taskRunnerState struct {
 	HandleID string
 }
 
-// TaskStateUpdater is used to update the status of a task
-type TaskStateUpdater func(taskName, status, desc string)
+// TaskStateUpdater is used to signal that tasks state has changed.
+type TaskStateUpdater func(taskName string)
 
 // NewTaskRunner is used to create a new task context
 func NewTaskRunner(logger *log.Logger, config *config.Config,
 	updater TaskStateUpdater, ctx *driver.ExecContext,
-	allocID string, task *structs.Task, restartTracker restartTracker) *TaskRunner {
+	allocID string, task *structs.Task, state *structs.TaskState,
+	restartTracker restartTracker) *TaskRunner {
 
 	tc := &TaskRunner{
 		config:         config,
@@ -58,6 +62,7 @@ func NewTaskRunner(logger *log.Logger, config *config.Config,
 		ctx:            ctx,
 		allocID:        allocID,
 		task:           task,
+		state:          state,
 		updateCh:       make(chan *structs.Task, 8),
 		destroyCh:      make(chan struct{}),
 		waitCh:         make(chan struct{}),
@@ -132,12 +137,19 @@ func (r *TaskRunner) DestroyState() error {
 	return os.RemoveAll(r.stateFilePath())
 }
 
-// setStatus is used to update the status of the task runner
-func (r *TaskRunner) setStatus(status, desc string) {
+// setState is used to update the state of the task runner
+func (r *TaskRunner) setState(state string, event *structs.TaskEvent) {
+	// Update the task.
+	r.state.State = state
+	r.state.Events = append(r.state.Events, event)
+
+	// Persist our state to disk.
 	if err := r.SaveState(); err != nil {
 		r.logger.Printf("[ERR] client: failed to save state of Task Runner: %v", r.task.Name)
 	}
-	r.updater(r.task.Name, status, desc)
+
+	// Indicate the task has been updated.
+	r.updater(r.task.Name)
 }
 
 // createDriver makes a driver for the task
@@ -157,7 +169,8 @@ func (r *TaskRunner) startTask() error {
 	// Create a driver
 	driver, err := r.createDriver()
 	if err != nil {
-		r.setStatus(structs.AllocClientStatusFailed, err.Error())
+		e := structs.NewTaskEvent(structs.TaskDriverFailure).SetDriverError(err)
+		r.setState(structs.TaskStateDead, e)
 		return err
 	}
 
@@ -166,94 +179,115 @@ func (r *TaskRunner) startTask() error {
 	if err != nil {
 		r.logger.Printf("[ERR] client: failed to start task '%s' for alloc '%s': %v",
 			r.task.Name, r.allocID, err)
-		r.setStatus(structs.AllocClientStatusFailed,
-			fmt.Sprintf("failed to start: %v", err))
+		e := structs.NewTaskEvent(structs.TaskDriverFailure).
+			SetDriverError(fmt.Errorf("failed to start: %v", err))
+		r.setState(structs.TaskStateDead, e)
 		return err
 	}
 	r.handle = handle
-	r.setStatus(structs.AllocClientStatusRunning, "task started")
+	r.setState(structs.TaskStateRunning, structs.NewTaskEvent(structs.TaskStarted))
 	return nil
 }
 
 // Run is a long running routine used to manage the task
 func (r *TaskRunner) Run() {
-	var err error
 	defer close(r.waitCh)
 	r.logger.Printf("[DEBUG] client: starting task context for '%s' (alloc '%s')",
 		r.task.Name, r.allocID)
 
-	// Start the task if not yet started
-	if r.handle == nil {
+	r.run(false)
+	return
+}
+
+func (r *TaskRunner) run(forceStart bool) {
+	// Start the task if not yet started or it is being forced.
+	if r.handle == nil || forceStart {
 		if err := r.startTask(); err != nil {
 			return
 		}
 	}
 
-	// Monitoring the Driver
-	defer r.DestroyState()
-	err = r.monitorDriver(r.handle.WaitCh(), r.updateCh, r.destroyCh)
-	for err != nil {
-		r.logger.Printf("[ERR] client: failed to complete task '%s' for alloc '%s': %v",
-			r.task.Name, r.allocID, err)
-		shouldRestart, when := r.restartTracker.nextRestart()
-		if !shouldRestart {
-			r.logger.Printf("[INFO] client: Not restarting task: %v for alloc: %v ", r.task.Name, r.allocID)
-			r.setStatus(structs.AllocClientStatusDead, fmt.Sprintf("task failed with: %v", err))
-			return
-		}
+	// Store the errors that caused use to stop waiting for updates.
+	var waitRes *cstructs.WaitResult
+	var destroyErr error
+	destroyed := false
 
-		r.logger.Printf("[INFO] client: Restarting Task: %v", r.task.Name)
-		r.setStatus(structs.AllocClientStatusPending, "Task Restarting")
-		r.logger.Printf("[DEBUG] client: Sleeping for %v before restarting Task %v", when, r.task.Name)
-		select {
-		case <-time.After(when):
-		case <-r.destroyCh:
-		}
-		r.destroyLock.Lock()
-		if r.destroy {
-			r.logger.Printf("[DEBUG] client: Not restarting task: %v because it's destroyed by user", r.task.Name)
-			break
-		}
-		if err = r.startTask(); err != nil {
-			r.destroyLock.Unlock()
-			continue
-		}
-		r.destroyLock.Unlock()
-		err = r.monitorDriver(r.handle.WaitCh(), r.updateCh, r.destroyCh)
-	}
-
-	// Cleanup after ourselves
-	r.logger.Printf("[INFO] client: completed task '%s' for alloc '%s'", r.task.Name, r.allocID)
-	r.setStatus(structs.AllocClientStatusDead, "task completed")
-}
-
-// This functions listens to messages from the driver and blocks until the
-// driver exits
-func (r *TaskRunner) monitorDriver(waitCh chan error, updateCh chan *structs.Task, destroyCh chan struct{}) error {
-	var err error
 OUTER:
 	// Wait for updates
 	for {
 		select {
-		case err = <-waitCh:
+		case waitRes = <-r.handle.WaitCh():
 			break OUTER
-		case update := <-updateCh:
+		case update := <-r.updateCh:
 			// Update
 			r.task = update
 			if err := r.handle.Update(update); err != nil {
-				r.logger.Printf("[ERR] client: failed to update task '%s' for alloc '%s': %v",
-					r.task.Name, r.allocID, err)
+				r.logger.Printf("[ERR] client: failed to update task '%s' for alloc '%s': %v", r.task.Name, r.allocID, err)
 			}
-
-		case <-destroyCh:
+		case <-r.destroyCh:
 			// Send the kill signal, and use the WaitCh to block until complete
 			if err := r.handle.Kill(); err != nil {
-				r.logger.Printf("[ERR] client: failed to kill task '%s' for alloc '%s': %v",
-					r.task.Name, r.allocID, err)
+				r.logger.Printf("[ERR] client: failed to kill task '%s' for alloc '%s': %v", r.task.Name, r.allocID, err)
+				destroyErr = err
 			}
+			destroyed = true
 		}
 	}
-	return err
+
+	// If the user destroyed the task, we do not attempt to do any restarts.
+	if destroyed {
+		r.setState(structs.TaskStateDead, structs.NewTaskEvent(structs.TaskKilled).SetKillError(destroyErr))
+		return
+	}
+
+	// Log whether the task was successful or not.
+	if !waitRes.Successful() {
+		r.logger.Printf("[ERR] client: failed to complete task '%s' for alloc '%s': %v", r.task.Name, r.allocID, waitRes)
+	} else {
+		r.logger.Printf("[INFO] client: completed task '%s' for alloc '%s'", r.task.Name, r.allocID)
+	}
+
+	// Check if we should restart. If not mark task as dead and exit.
+	waitEvent := r.waitErrorToEvent(waitRes)
+	shouldRestart, when := r.restartTracker.nextRestart()
+	if !shouldRestart {
+		r.logger.Printf("[INFO] client: Not restarting task: %v for alloc: %v ", r.task.Name, r.allocID)
+		r.setState(structs.TaskStateDead, waitEvent)
+		return
+	}
+
+	r.logger.Printf("[INFO] client: Restarting Task: %v", r.task.Name)
+	r.logger.Printf("[DEBUG] client: Sleeping for %v before restarting Task %v", when, r.task.Name)
+	r.setState(structs.TaskStatePending, waitEvent)
+
+	// Sleep but watch for destroy events.
+	select {
+	case <-time.After(when):
+	case <-r.destroyCh:
+	}
+
+	// Destroyed while we were waiting to restart, so abort.
+	r.destroyLock.Lock()
+	destroyed = r.destroy
+	r.destroyLock.Unlock()
+	if destroyed {
+		r.logger.Printf("[DEBUG] client: Not restarting task: %v because it's destroyed by user", r.task.Name)
+		r.setState(structs.TaskStateDead, structs.NewTaskEvent(structs.TaskKilled))
+		return
+	}
+
+	// Recurse on ourselves and force the start since we are restarting the task.
+	r.run(true)
+	return
+}
+
+// Helper function for converting a WaitResult into a TaskTerminated event.
+func (r *TaskRunner) waitErrorToEvent(res *cstructs.WaitResult) *structs.TaskEvent {
+	e := structs.NewTaskEvent(structs.TaskTerminated).SetExitCode(res.ExitCode).SetSignal(res.Signal)
+	if res.Err != nil {
+		e.SetExitMessage(res.Err.Error())
+	}
+	return e
 }
 
 // Update is used to update the task of the context

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -303,11 +303,10 @@ func (r *TaskRunner) run() {
 
 // Helper function for converting a WaitResult into a TaskTerminated event.
 func (r *TaskRunner) waitErrorToEvent(res *cstructs.WaitResult) *structs.TaskEvent {
-	e := structs.NewTaskEvent(structs.TaskTerminated).SetExitCode(res.ExitCode).SetSignal(res.Signal)
-	if res.Err != nil {
-		e.SetExitMessage(res.Err.Error())
-	}
-	return e
+	return structs.NewTaskEvent(structs.TaskTerminated).
+		SetExitCode(res.ExitCode).
+		SetSignal(res.Signal).
+		SetExitMessage(res.Err)
 }
 
 // Update is used to update the task of the context

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -21,21 +20,11 @@ func testLogger() *log.Logger {
 	return log.New(os.Stderr, "", log.LstdFlags)
 }
 
-type MockTaskStateUpdater struct {
-	Count       int
-	Name        []string
-	Status      []string
-	Description []string
-}
+type MockTaskStateUpdater struct{}
 
-func (m *MockTaskStateUpdater) Update(name, status, desc string) {
-	m.Count += 1
-	m.Name = append(m.Name, name)
-	m.Status = append(m.Status, status)
-	m.Description = append(m.Description, desc)
-}
+func (m *MockTaskStateUpdater) Update(name string) {}
 
-func testTaskRunner() (*MockTaskStateUpdater, *TaskRunner) {
+func testTaskRunner(restarts bool) (*MockTaskStateUpdater, *TaskRunner) {
 	logger := testLogger()
 	conf := DefaultConfig()
 	conf.StateDir = os.TempDir()
@@ -54,13 +43,18 @@ func testTaskRunner() (*MockTaskStateUpdater, *TaskRunner) {
 	ctx := driver.NewExecContext(allocDir, alloc.ID)
 	rp := structs.NewRestartPolicy(structs.JobTypeService)
 	restartTracker := newRestartTracker(structs.JobTypeService, rp)
-	tr := NewTaskRunner(logger, conf, upd.Update, ctx, alloc.ID, task, restartTracker)
+	if !restarts {
+		restartTracker = noRestartsTracker()
+	}
+
+	state := alloc.TaskStates[task.Name]
+	tr := NewTaskRunner(logger, conf, upd.Update, ctx, alloc.ID, task, state, restartTracker)
 	return upd, tr
 }
 
 func TestTaskRunner_SimpleRun(t *testing.T) {
 	ctestutil.ExecCompatible(t)
-	upd, tr := testTaskRunner()
+	_, tr := testTaskRunner(false)
 	go tr.Run()
 	defer tr.Destroy()
 	defer tr.ctx.AllocDir.Destroy()
@@ -71,33 +65,26 @@ func TestTaskRunner_SimpleRun(t *testing.T) {
 		t.Fatalf("timeout")
 	}
 
-	if upd.Count != 2 {
-		t.Fatalf("should have 2 updates: %#v", upd)
-	}
-	if upd.Name[0] != tr.task.Name {
-		t.Fatalf("bad: %#v", upd.Name)
-	}
-	if upd.Status[0] != structs.AllocClientStatusRunning {
-		t.Fatalf("bad: %#v", upd.Status)
-	}
-	if upd.Description[0] != "task started" {
-		t.Fatalf("bad: %#v", upd.Description)
+	if len(tr.state.Events) != 2 {
+		t.Fatalf("should have 2 updates: %#v", tr.state.Events)
 	}
 
-	if upd.Name[1] != tr.task.Name {
-		t.Fatalf("bad: %#v", upd.Name)
+	if tr.state.State != structs.TaskStateDead {
+		t.Fatalf("TaskState %v; want %v", tr.state.State, structs.TaskStateDead)
 	}
-	if upd.Status[1] != structs.AllocClientStatusDead {
-		t.Fatalf("bad: %#v", upd.Status)
+
+	if tr.state.Events[0].Type != structs.TaskStarted {
+		t.Fatalf("First Event was %v; want %v", tr.state.Events[0].Type, structs.TaskStarted)
 	}
-	if upd.Description[1] != "task completed" {
-		t.Fatalf("bad: %#v", upd.Description)
+
+	if tr.state.Events[1].Type != structs.TaskTerminated {
+		t.Fatalf("First Event was %v; want %v", tr.state.Events[1].Type, structs.TaskTerminated)
 	}
 }
 
 func TestTaskRunner_Destroy(t *testing.T) {
 	ctestutil.ExecCompatible(t)
-	upd, tr := testTaskRunner()
+	_, tr := testTaskRunner(true)
 	defer tr.ctx.AllocDir.Destroy()
 
 	// Change command to ensure we run for a bit
@@ -113,27 +100,31 @@ func TestTaskRunner_Destroy(t *testing.T) {
 
 	select {
 	case <-tr.WaitCh():
-	case <-time.After(2 * time.Second):
+	case <-time.After(8 * time.Second):
 		t.Fatalf("timeout")
 	}
 
-	if upd.Count != 2 {
-		t.Fatalf("should have 2 updates: %#v", upd)
+	if len(tr.state.Events) != 2 {
+		t.Fatalf("should have 2 updates: %#v", tr.state.Events)
 	}
-	if upd.Status[0] != structs.AllocClientStatusRunning {
-		t.Fatalf("bad: %#v", upd.Status)
+
+	if tr.state.State != structs.TaskStateDead {
+		t.Fatalf("TaskState %v; want %v", tr.state.State, structs.TaskStateDead)
 	}
-	if upd.Status[1] != structs.AllocClientStatusDead {
-		t.Fatalf("bad: %#v", upd.Status)
+
+	if tr.state.Events[0].Type != structs.TaskStarted {
+		t.Fatalf("First Event was %v; want %v", tr.state.Events[0].Type, structs.TaskStarted)
 	}
-	if !strings.Contains(upd.Description[1], "task failed") {
-		t.Fatalf("bad: %#v", upd.Description)
+
+	if tr.state.Events[1].Type != structs.TaskKilled {
+		t.Fatalf("First Event was %v; want %v", tr.state.Events[1].Type, structs.TaskKilled)
 	}
+
 }
 
 func TestTaskRunner_Update(t *testing.T) {
 	ctestutil.ExecCompatible(t)
-	_, tr := testTaskRunner()
+	_, tr := testTaskRunner(false)
 
 	// Change command to ensure we run for a bit
 	tr.task.Config["command"] = "/bin/sleep"
@@ -158,7 +149,7 @@ func TestTaskRunner_Update(t *testing.T) {
 
 func TestTaskRunner_SaveRestoreState(t *testing.T) {
 	ctestutil.ExecCompatible(t)
-	upd, tr := testTaskRunner()
+	upd, tr := testTaskRunner(false)
 
 	// Change command to ensure we run for a bit
 	tr.task.Config["command"] = "/bin/sleep"
@@ -174,7 +165,7 @@ func TestTaskRunner_SaveRestoreState(t *testing.T) {
 
 	// Create a new task runner
 	tr2 := NewTaskRunner(tr.logger, tr.config, upd.Update,
-		tr.ctx, tr.allocID, &structs.Task{Name: tr.task.Name}, tr.restartTracker)
+		tr.ctx, tr.allocID, &structs.Task{Name: tr.task.Name}, tr.state, tr.restartTracker)
 	if err := tr2.RestoreState(); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1,8 +1,9 @@
 package mock
 
 import (
-	"github.com/hashicorp/nomad/nomad/structs"
 	"time"
+
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 func Node() *structs.Node {
@@ -219,6 +220,11 @@ func Alloc() *structs.Allocation {
 						DynamicPorts:  []string{"http"},
 					},
 				},
+			},
+		},
+		TaskStates: map[string]*structs.TaskState{
+			"web": &structs.TaskState{
+				State: structs.TaskStatePending,
 			},
 		},
 		Job:           Job(),

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1070,29 +1070,26 @@ type TaskState struct {
 	Events []*TaskEvent
 }
 
-// TaskEventType is the set of events that effect the state of a task.
-type TaskEventType int
-
 const (
 	// A Driver failure indicates that the task could not be started due to a
 	// failure in the driver.
-	TaskDriverFailure TaskEventType = iota
+	TaskDriverFailure = "Driver Failure"
 
 	// Task Started signals that the task was started and its timestamp can be
 	// used to determine the running length of the task.
-	TaskStarted
+	TaskStarted = "Started"
 
 	// Task terminated indicates that the task was started and exited.
-	TaskTerminated
+	TaskTerminated = "Terminated"
 
 	// Task Killed indicates a user has killed the task.
-	TaskKilled
+	TaskKilled = "Killed"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
 // appropriate to the events type.
 type TaskEvent struct {
-	Type TaskEventType
+	Type string
 	Time int64 // Unix Nanosecond timestamp
 
 	// Driver Failure fields.
@@ -1107,7 +1104,7 @@ type TaskEvent struct {
 	KillError string // Error killing the task.
 }
 
-func NewTaskEvent(event TaskEventType) *TaskEvent {
+func NewTaskEvent(event string) *TaskEvent {
 	return &TaskEvent{
 		Type: event,
 		Time: time.Now().UnixNano(),

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1128,8 +1128,10 @@ func (e *TaskEvent) SetSignal(s int) *TaskEvent {
 	return e
 }
 
-func (e *TaskEvent) SetExitMessage(m string) *TaskEvent {
-	e.Message = m
+func (e *TaskEvent) SetExitMessage(err error) *TaskEvent {
+	if err != nil {
+		e.Message = err.Error()
+	}
 	return e
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1096,12 +1096,51 @@ type TaskEvent struct {
 	Time int64 // Unix Nanosecond timestamp
 
 	// Driver Failure fields.
-	DriverError error // A driver error occured while starting the task.
+	DriverError string // A driver error occured while starting the task.
 
 	// Task Terminated Fields.
 	ExitCode int    // The exit code of the task.
 	Signal   int    // The signal that terminated the task.
 	Message  string // A possible message explaining the termination of the task.
+
+	// Task Killed Fields.
+	KillError string // Error killing the task.
+}
+
+func NewTaskEvent(event TaskEventType) *TaskEvent {
+	return &TaskEvent{
+		Type: event,
+		Time: time.Now().UnixNano(),
+	}
+}
+
+func (e *TaskEvent) SetDriverError(err error) *TaskEvent {
+	if err != nil {
+		e.DriverError = err.Error()
+	}
+	return e
+}
+
+func (e *TaskEvent) SetExitCode(c int) *TaskEvent {
+	e.ExitCode = c
+	return e
+}
+
+func (e *TaskEvent) SetSignal(s int) *TaskEvent {
+	e.Signal = s
+	return e
+}
+
+func (e *TaskEvent) SetExitMessage(m string) *TaskEvent {
+	e.Message = m
+	return e
+}
+
+func (e *TaskEvent) SetKillError(err error) *TaskEvent {
+	if err != nil {
+		e.KillError = err.Error()
+	}
+	return e
 }
 
 // Validate is used to sanity check a task group

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -285,11 +285,13 @@ func (s *GenericScheduler) computePlacements(place []allocTuple) error {
 			alloc.TaskResources = option.TaskResources
 			alloc.DesiredStatus = structs.AllocDesiredStatusRun
 			alloc.ClientStatus = structs.AllocClientStatusPending
+			alloc.TaskStates = initTaskState(missing.TaskGroup, structs.TaskStatePending)
 			s.plan.AppendAlloc(alloc)
 		} else {
 			alloc.DesiredStatus = structs.AllocDesiredStatusFailed
 			alloc.DesiredDescription = "failed to find a node for placement"
 			alloc.ClientStatus = structs.AllocClientStatusFailed
+			alloc.TaskStates = initTaskState(missing.TaskGroup, structs.TaskStateDead)
 			s.plan.AppendFailed(alloc)
 			failedTG[missing.TaskGroup] = alloc
 		}

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -252,11 +252,13 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 			alloc.TaskResources = option.TaskResources
 			alloc.DesiredStatus = structs.AllocDesiredStatusRun
 			alloc.ClientStatus = structs.AllocClientStatusPending
+			alloc.TaskStates = initTaskState(missing.TaskGroup, structs.TaskStatePending)
 			s.plan.AppendAlloc(alloc)
 		} else {
 			alloc.DesiredStatus = structs.AllocDesiredStatusFailed
 			alloc.DesiredDescription = "failed to find a node for placement"
 			alloc.ClientStatus = structs.AllocClientStatusFailed
+			alloc.TaskStates = initTaskState(missing.TaskGroup, structs.TaskStateDead)
 			s.plan.AppendFailed(alloc)
 			failedTG[missing.TaskGroup] = alloc
 		}

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -445,3 +445,11 @@ func taskGroupConstraints(tg *structs.TaskGroup) tgConstrainTuple {
 
 	return c
 }
+
+func initTaskState(tg *structs.TaskGroup, state string) map[string]*structs.TaskState {
+	states := make(map[string]*structs.TaskState, len(tg.Tasks))
+	for _, task := range tg.Tasks {
+		states[task.Name] = &structs.TaskState{State: state}
+	}
+	return states
+}

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -648,3 +648,26 @@ func TestTaskGroupConstraints(t *testing.T) {
 	}
 
 }
+
+func TestInitTaskState(t *testing.T) {
+	tg := &structs.TaskGroup{
+		Tasks: []*structs.Task{
+			&structs.Task{Name: "foo"},
+			&structs.Task{Name: "bar"},
+		},
+	}
+	expPending := map[string]*structs.TaskState{
+		"foo": &structs.TaskState{State: structs.TaskStatePending},
+		"bar": &structs.TaskState{State: structs.TaskStatePending},
+	}
+	expDead := map[string]*structs.TaskState{
+		"foo": &structs.TaskState{State: structs.TaskStateDead},
+		"bar": &structs.TaskState{State: structs.TaskStateDead},
+	}
+	actPending := initTaskState(tg, structs.TaskStatePending)
+	actDead := initTaskState(tg, structs.TaskStateDead)
+
+	if !(reflect.DeepEqual(expPending, actPending) && reflect.DeepEqual(expDead, actDead)) {
+		t.Fatal("Expected and actual not equal")
+	}
+}


### PR DESCRIPTION
This PR:

* Adds TaskState to the allocation.
* The Client is updated to track the Task through the States: Pending, Running, Dead and records the events that caused state transitions between these.

On a side note, this PR also fixes the alloc_runner and task_runner test regressions introduced with restart policies.