### PR TITLE
Remove CGO dependency for user lookup in allocdir

### DIFF
--- a/client/allocdir/alloc_dir_posix.go
+++ b/client/allocdir/alloc_dir_posix.go
@@ -5,9 +5,11 @@ package allocdir
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/user"
 	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -26,7 +28,7 @@ func (d *AllocDir) dropDirPermissions(path string) error {
 		return nil
 	}
 
-	u, err := user.Lookup("nobody")
+	u, err := userLookup("nobody")
 	if err != nil {
 		return err
 	}
@@ -68,4 +70,29 @@ func getGid(u *user.User) (int, error) {
 	}
 
 	return gid, nil
+}
+
+// userLookup checks if the given username or uid is present in /etc/passwd
+// and returns the user struct.
+// If the username is not found, an error is returned.
+// Credit to @creak, https://github.com/docker/docker/pull/1096
+func userLookup(uid string) (*user.User, error) {
+	file, err := ioutil.ReadFile("/etc/passwd")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, line := range strings.Split(string(file), "\n") {
+		data := strings.Split(line, ":")
+		if len(data) > 5 && (data[0] == uid || data[2] == uid) {
+			return &user.User{
+				Uid:      data[2],
+				Gid:      data[3],
+				Username: data[0],
+				Name:     data[4],
+				HomeDir:  data[5],
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("User not found in /etc/passwd")
 }

--- a/client/allocdir/alloc_dir_posix.go
+++ b/client/allocdir/alloc_dir_posix.go
@@ -5,11 +5,10 @@ package allocdir
 
 import (
 	"fmt"
-	"io/ioutil"
+	"github.com/hashicorp/nomad/helper/user-lookup"
 	"os"
 	"os/user"
 	"strconv"
-	"strings"
 	"syscall"
 )
 
@@ -28,7 +27,7 @@ func (d *AllocDir) dropDirPermissions(path string) error {
 		return nil
 	}
 
-	u, err := userLookup("nobody")
+	u, err := userlookup.Lookup("nobody")
 	if err != nil {
 		return err
 	}
@@ -70,29 +69,4 @@ func getGid(u *user.User) (int, error) {
 	}
 
 	return gid, nil
-}
-
-// userLookup checks if the given username or uid is present in /etc/passwd
-// and returns the user struct.
-// If the username is not found, an error is returned.
-// Credit to @creak, https://github.com/docker/docker/pull/1096
-func userLookup(uid string) (*user.User, error) {
-	file, err := ioutil.ReadFile("/etc/passwd")
-	if err != nil {
-		return nil, err
-	}
-
-	for _, line := range strings.Split(string(file), "\n") {
-		data := strings.Split(line, ":")
-		if len(data) > 5 && (data[0] == uid || data[2] == uid) {
-			return &user.User{
-				Uid:      data[2],
-				Gid:      data[3],
-				Username: data[0],
-				Name:     data[4],
-				HomeDir:  data[5],
-			}, nil
-		}
-	}
-	return nil, fmt.Errorf("User not found in /etc/passwd")
 }

--- a/client/driver/executor/exec_linux.go
+++ b/client/driver/executor/exec_linux.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/nomad/client/driver/args"
 	"github.com/hashicorp/nomad/client/driver/environment"
 	"github.com/hashicorp/nomad/client/driver/spawn"
+	"github.com/hashicorp/nomad/helper/user-lookup"
 	"github.com/hashicorp/nomad/nomad/structs"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -122,7 +123,7 @@ func (e *LinuxExecutor) ID() (string, error) {
 // runAs takes a user id as a string and looks up the user, and sets the command
 // to execute as that user.
 func (e *LinuxExecutor) runAs(userid string) error {
-	u, err := user.Lookup(userid)
+	u, err := userlookup.Lookup(userid)
 	if err != nil {
 		return fmt.Errorf("Failed to identify user %v: %v", userid, err)
 	}

--- a/helper/user-lookup/user-lookup.go
+++ b/helper/user-lookup/user-lookup.go
@@ -1,0 +1,33 @@
+package userlookup
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/user"
+	"strings"
+)
+
+// Lookup checks if the given username or uid is present in /etc/passwd
+// and returns the user struct.
+// If the username is not found, an error is returned.
+// Credit to @creak, https://github.com/docker/docker/pull/1096
+func Lookup(uid string) (*user.User, error) {
+	file, err := ioutil.ReadFile("/etc/passwd")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, line := range strings.Split(string(file), "\n") {
+		data := strings.Split(line, ":")
+		if len(data) > 5 && (data[0] == uid || data[2] == uid) {
+			return &user.User{
+				Uid:      data[2],
+				Gid:      data[3],
+				Username: data[0],
+				Name:     data[4],
+				HomeDir:  data[5],
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("User not found in /etc/passwd")
+}


### PR DESCRIPTION
os/user's user.Lookup requires that the artifact be compiled with CGO
support enabled. This change instead reads /etc/passwd directly.

The code was acquired from docker/docker#1096

I'm not 100% sure this is necessary. But I was having trouble compiling Nomad to linux/amd64 because I was getting `Lookup is not implmented for linux/amd64`, so I'm gunna throw it out here.

This change was adopted by Docker, so it seems like a nice way to not have to mess with CGO when building Nomad.