### PR TITLE
Adding the current restart count and alloc id to the task name

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -302,6 +302,7 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task) (do
 	}
 
 	return docker.CreateContainerOptions{
+		Name:       d.taskName,
 		Config:     config,
 		HostConfig: hostConfig,
 	}, nil

--- a/client/restarts.go
+++ b/client/restarts.go
@@ -10,6 +10,7 @@ import (
 // For Batch jobs, the interval is set to zero value since the takss
 // will be restarted only upto maxAttempts times
 type restartTracker interface {
+	totalRestartCount() int
 	nextRestart() (bool, time.Duration)
 }
 
@@ -49,17 +50,23 @@ func (b *batchRestartTracker) nextRestart() (bool, time.Duration) {
 	return false, 0
 }
 
+func (b *batchRestartTracker) totalRestartCount() int {
+	return b.count
+}
+
 type serviceRestartTracker struct {
 	maxAttempts int
 	delay       time.Duration
 	interval    time.Duration
 
-	count     int
-	startTime time.Time
+	count         int
+	totalRestarts int
+	startTime     time.Time
 }
 
 func (s *serviceRestartTracker) increment() {
 	s.count += 1
+	s.totalRestarts += 1
 }
 
 func (s *serviceRestartTracker) nextRestart() (bool, time.Duration) {
@@ -80,4 +87,8 @@ func (s *serviceRestartTracker) nextRestart() (bool, time.Duration) {
 
 	// If we exhausted all the retries and are withing the time window
 	return true, windowEndTime.Sub(now)
+}
+
+func (s *serviceRestartTracker) totalRestartCount() int {
+	return s.totalRestarts
 }

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -142,7 +142,7 @@ func (r *TaskRunner) setStatus(status, desc string) {
 
 // createDriver makes a driver for the task
 func (r *TaskRunner) createDriver() (driver.Driver, error) {
-	taskName := fmt.Sprintf("%s-%s-%s", r.allocID, r.task.Name, r.restartTracker.totalRestartCount())
+	taskName := fmt.Sprintf("%s-%s-%v", r.allocID, r.task.Name, r.restartTracker.totalRestartCount())
 	driverCtx := driver.NewDriverContext(taskName, r.config, r.config.Node, r.logger)
 	driver, err := driver.NewDriver(r.task.Driver, driverCtx)
 	if err != nil {

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -142,7 +142,7 @@ func (r *TaskRunner) setStatus(status, desc string) {
 
 // createDriver makes a driver for the task
 func (r *TaskRunner) createDriver() (driver.Driver, error) {
-	taskName := fmt.Sprintf("%s-%s", r.task.Name, r.restartTracker.totalRestartCount())
+	taskName := fmt.Sprintf("%s-%s-%s", r.allocID, r.task.Name, r.restartTracker.totalRestartCount())
 	driverCtx := driver.NewDriverContext(taskName, r.config, r.config.Node, r.logger)
 	driver, err := driver.NewDriver(r.task.Driver, driverCtx)
 	if err != nil {

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -142,7 +142,8 @@ func (r *TaskRunner) setStatus(status, desc string) {
 
 // createDriver makes a driver for the task
 func (r *TaskRunner) createDriver() (driver.Driver, error) {
-	driverCtx := driver.NewDriverContext(r.task.Name, r.config, r.config.Node, r.logger)
+	taskName := fmt.Sprintf("%s-%s", r.task.Name, r.restartTracker.totalRestartCount())
+	driverCtx := driver.NewDriverContext(taskName, r.config, r.config.Node, r.logger)
 	driver, err := driver.NewDriver(r.task.Driver, driverCtx)
 	if err != nil {
 		err = fmt.Errorf("failed to create driver '%s' for alloc %s: %v",


### PR DESCRIPTION
Adding the restart count to the task name to make it unique within a node. When this is used along with the allocation id, the container name will be unique in the cluster