### PR TITLE
Add hostname parameter to Docker driver

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -43,6 +43,7 @@ type DockerDriverConfig struct {
 	Privileged    bool             `mapstructure:"privileged"`     // Flag to run the container in priviledged mode
 	DNS           string           `mapstructure:"dns_server"`     // DNS Server for containers
 	SearchDomains string           `mapstructure:"search_domains"` // DNS Search domains for containers
+	Hostname      string           `mapstructure:"hostname"`       // Hostname for containers
 }
 
 func (c *DockerDriverConfig) Validate() error {
@@ -167,7 +168,8 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task, dri
 	env.SetTaskLocalDir(filepath.Join("/", allocdir.TaskLocal))
 
 	config := &docker.Config{
-		Image: driverConfig.ImageName,
+		Image:    driverConfig.ImageName,
+		Hostname: driverConfig.Hostname,
 	}
 
 	hostConfig := &docker.HostConfig{

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -42,6 +42,8 @@ The `docker` driver supports the following configuration in the job specificatio
 
 * `search-domains` - (optional) A comma separated list of DNS search domains for the 
   container to use.
+
+* `hostname` - (optional) The hostname to assign to the container. 
   
 **Authentication**  
 Registry authentication can be set per task with the following authentication 

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -43,7 +43,9 @@ The `docker` driver supports the following configuration in the job specificatio
 * `search-domains` - (optional) A comma separated list of DNS search domains for the 
   container to use.
 
-* `hostname` - (optional) The hostname to assign to the container. 
+* `hostname` - (optional) The hostname to assign to the container. When launching more
+  than one of a task (using `count`) with this option set, every container the task 
+  starts will have the same hostname.
   
 **Authentication**  
 Registry authentication can be set per task with the following authentication 


### PR DESCRIPTION
This adds the `hostname` parameter to the Docker driver. This is useful because some service discovery packages, such as Weave, use the hostname to group together containers into a service (in lieu of using the container names, which are unique per host).