### PR TITLE
Fixed validation logic for restart policy when interval is zero

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -885,6 +885,9 @@ type RestartPolicy struct {
 }
 
 func (r *RestartPolicy) Validate() error {
+	if r.Interval == 0 {
+		return nil
+	}
 	if time.Duration(r.Attempts)*r.Delay > r.Interval {
 		return fmt.Errorf("Nomad can't restart the TaskGroup %v times in an interval of %v with a delay of %v", r.Attempts, r.Interval, r.Delay)
 	}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -356,3 +356,10 @@ func TestEncodeDecode(t *testing.T) {
 		t.Fatalf("bad: %#v %#v", arg, out)
 	}
 }
+
+func TestBatchRestartPolicyValidate(t *testing.T) {
+	rp := RestartPolicy{Attempts: 10, Delay: 25 * time.Second}
+	if err := rp.Validate(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}


### PR DESCRIPTION
This fixes #423 