### PR TITLE
Makes sure dependencies are up to date

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -10,4 +10,4 @@ GOOS=linux go get $DEP_ARGS github.com/opencontainers/runc/libcontainer/configs
 
 # Get the rest of the deps
 DEPS=$(go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
-go get $DEP_ARGS ./... $DEPS
+go get -u $DEP_ARGS ./... $DEPS


### PR DESCRIPTION
I ran into an issue where my dependencies would be present but outdated and the Makefile would fail compiling. So I added the `-u` flag to `go get` to make sure it updates the dependency if already present.