### PR TITLE
Fix tests for nomad/client/driver/spawn package to work on Windows.

### DIFF
--- a/client/driver/spawn/spawn.go
+++ b/client/driver/spawn/spawn.go
@@ -73,10 +73,10 @@ func (s *Spawner) Spawn(cb func(pid int) error) error {
 	}
 
 	exitFile, err := os.OpenFile(s.StateFile, os.O_CREATE|os.O_WRONLY, 0666)
-	defer exitFile.Close()
 	if err != nil {
 		return fmt.Errorf("Error opening file to store exit status: %v", err)
 	}
+	defer exitFile.Close()
 
 	config, err := s.spawnConfig()
 	if err != nil {
@@ -87,17 +87,17 @@ func (s *Spawner) Spawn(cb func(pid int) error) error {
 
 	// Capture stdout
 	spawnStdout, err := spawn.StdoutPipe()
-	defer spawnStdout.Close()
 	if err != nil {
 		return fmt.Errorf("Failed to capture spawn-daemon stdout: %v", err)
 	}
+	defer spawnStdout.Close()
 
 	// Capture stdin.
 	spawnStdin, err := spawn.StdinPipe()
-	defer spawnStdin.Close()
 	if err != nil {
 		return fmt.Errorf("Failed to capture spawn-daemon stdin: %v", err)
 	}
+	defer spawnStdin.Close()
 
 	if err := spawn.Start(); err != nil {
 		return fmt.Errorf("Failed to call spawn-daemon on nomad executable: %v", err)
@@ -264,10 +264,10 @@ func (s *Spawner) pollWait() *structs.WaitResult {
 // returns an error if the file can't be read.
 func (s *Spawner) readExitCode() *structs.WaitResult {
 	f, err := os.Open(s.StateFile)
-	defer f.Close()
 	if err != nil {
 		return structs.NewWaitResult(-1, 0, fmt.Errorf("Failed to open %v to read exit code: %v", s.StateFile, err))
 	}
+	defer f.Close()
 
 	stat, err := f.Stat()
 	if err != nil {
@@ -289,7 +289,7 @@ func (s *Spawner) readExitCode() *structs.WaitResult {
 
 // Valid checks that the state of the Spawner is valid and that a subsequent
 // Wait could be called. This is useful to call when reopening a Spawner
-// throught client restarts. If Valid a nil error is returned.
+// through client restarts. If Valid a nil error is returned.
 func (s *Spawner) Valid() error {
 	// If the spawner is still alive, then the task is running and we can wait
 	// on it.

--- a/client/driver/spawn/spawn_test.go
+++ b/client/driver/spawn/spawn_test.go
@@ -12,26 +12,20 @@ import (
 )
 
 func TestSpawn_NoCmd(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	if err := spawn.Spawn(nil); err == nil {
 		t.Fatalf("Spawn() with no user command should fail")
 	}
 }
 
 func TestSpawn_InvalidCmd(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("foo"))
 	if err := spawn.Spawn(nil); err == nil {
 		t.Fatalf("Spawn() with no invalid command should fail")
@@ -46,23 +40,17 @@ func TestSpawn_SetsLogs(t *testing.T) {
 		t.Skip("Test fails on windows; unknown reason. Skipping")
 	}
 
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	exp := "foo"
 	spawn.SetCommand(exec.Command("echo", exp))
 
 	// Create file for stdout.
-	stdout, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(stdout.Name())
-	spawn.SetLogs(&Logs{Stdout: stdout.Name()})
+	stdout := tempFileName(t)
+	defer os.Remove(stdout)
+	spawn.SetLogs(&Logs{Stdout: stdout})
 
 	if err := spawn.Spawn(nil); err != nil {
 		t.Fatalf("Spawn() failed: %v", err)
@@ -72,7 +60,7 @@ func TestSpawn_SetsLogs(t *testing.T) {
 		t.Fatalf("Wait() returned %v, %v; want 0, nil", res.ExitCode, res.Err)
 	}
 
-	stdout2, err := os.Open(stdout.Name())
+	stdout2, err := os.Open(stdout)
 	if err != nil {
 		t.Fatalf("Open() failed: %v", err)
 	}
@@ -89,13 +77,10 @@ func TestSpawn_SetsLogs(t *testing.T) {
 }
 
 func TestSpawn_Callback(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("sleep", "1"))
 
 	called := false
@@ -115,13 +100,10 @@ func TestSpawn_Callback(t *testing.T) {
 }
 
 func TestSpawn_ParentWaitExited(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("echo", "foo"))
 	if err := spawn.Spawn(nil); err != nil {
 		t.Fatalf("Spawn() failed %v", err)
@@ -135,13 +117,10 @@ func TestSpawn_ParentWaitExited(t *testing.T) {
 }
 
 func TestSpawn_ParentWait(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("sleep", "2"))
 	if err := spawn.Spawn(nil); err != nil {
 		t.Fatalf("Spawn() failed %v", err)
@@ -153,13 +132,10 @@ func TestSpawn_ParentWait(t *testing.T) {
 }
 
 func TestSpawn_NonParentWaitExited(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("echo", "foo"))
 	if err := spawn.Spawn(nil); err != nil {
 		t.Fatalf("Spawn() failed %v", err)
@@ -175,13 +151,10 @@ func TestSpawn_NonParentWaitExited(t *testing.T) {
 }
 
 func TestSpawn_NonParentWait(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("sleep", "2"))
 	if err := spawn.Spawn(nil); err != nil {
 		t.Fatalf("Spawn() failed %v", err)
@@ -204,11 +177,8 @@ func TestSpawn_NonParentWait(t *testing.T) {
 }
 
 func TestSpawn_DeadSpawnDaemon_Parent(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
 	var spawnPid int
 	cb := func(pid int) error {
@@ -216,7 +186,7 @@ func TestSpawn_DeadSpawnDaemon_Parent(t *testing.T) {
 		return nil
 	}
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("sleep", "5"))
 	if err := spawn.Spawn(cb); err != nil {
 		t.Fatalf("Spawn() errored: %v", err)
@@ -241,11 +211,8 @@ func TestSpawn_DeadSpawnDaemon_Parent(t *testing.T) {
 }
 
 func TestSpawn_DeadSpawnDaemon_NonParent(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
 	var spawnPid int
 	cb := func(pid int) error {
@@ -253,7 +220,7 @@ func TestSpawn_DeadSpawnDaemon_NonParent(t *testing.T) {
 		return nil
 	}
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("sleep", "2"))
 	if err := spawn.Spawn(cb); err != nil {
 		t.Fatalf("Spawn() errored: %v", err)
@@ -280,13 +247,10 @@ func TestSpawn_DeadSpawnDaemon_NonParent(t *testing.T) {
 }
 
 func TestSpawn_Valid_TaskRunning(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("sleep", "2"))
 	if err := spawn.Spawn(nil); err != nil {
 		t.Fatalf("Spawn() failed %v", err)
@@ -302,13 +266,10 @@ func TestSpawn_Valid_TaskRunning(t *testing.T) {
 }
 
 func TestSpawn_Valid_TaskExit_ExitCode(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
-	defer os.Remove(f.Name())
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("echo", "foo"))
 	if err := spawn.Spawn(nil); err != nil {
 		t.Fatalf("Spawn() failed %v", err)
@@ -324,12 +285,10 @@ func TestSpawn_Valid_TaskExit_ExitCode(t *testing.T) {
 }
 
 func TestSpawn_Valid_TaskExit_NoExitCode(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("TempFile() failed")
-	}
+	tempFile := tempFileName(t)
+	defer os.Remove(tempFile)
 
-	spawn := NewSpawner(f.Name())
+	spawn := NewSpawner(tempFile)
 	spawn.SetCommand(exec.Command("echo", "foo"))
 	if err := spawn.Spawn(nil); err != nil {
 		t.Fatalf("Spawn() failed %v", err)
@@ -340,9 +299,18 @@ func TestSpawn_Valid_TaskExit_NoExitCode(t *testing.T) {
 	}
 
 	// Delete the file so that it can't find the exit code.
-	os.Remove(f.Name())
+	os.Remove(tempFile)
 
 	if err := spawn.Valid(); err == nil {
 		t.Fatalf("Valid() should have failed")
 	}
+}
+
+func tempFileName(t *testing.T) string {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("TempFile() failed")
+	}
+	defer f.Close()
+	return f.Name()
 }

--- a/client/driver/spawn/spawn_test.go
+++ b/client/driver/spawn/spawn_test.go
@@ -45,6 +45,7 @@ func appMain() {
 }
 
 func TestSpawn_NoCmd(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -55,6 +56,7 @@ func TestSpawn_NoCmd(t *testing.T) {
 }
 
 func TestSpawn_InvalidCmd(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -66,6 +68,7 @@ func TestSpawn_InvalidCmd(t *testing.T) {
 }
 
 func TestSpawn_SetsLogs(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -103,6 +106,7 @@ func TestSpawn_SetsLogs(t *testing.T) {
 }
 
 func TestSpawn_Callback(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -126,6 +130,7 @@ func TestSpawn_Callback(t *testing.T) {
 }
 
 func TestSpawn_ParentWaitExited(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -143,6 +148,7 @@ func TestSpawn_ParentWaitExited(t *testing.T) {
 }
 
 func TestSpawn_ParentWait(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -158,6 +164,7 @@ func TestSpawn_ParentWait(t *testing.T) {
 }
 
 func TestSpawn_NonParentWaitExited(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -177,6 +184,7 @@ func TestSpawn_NonParentWaitExited(t *testing.T) {
 }
 
 func TestSpawn_NonParentWait(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -203,6 +211,7 @@ func TestSpawn_NonParentWait(t *testing.T) {
 }
 
 func TestSpawn_DeadSpawnDaemon_Parent(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -237,6 +246,7 @@ func TestSpawn_DeadSpawnDaemon_Parent(t *testing.T) {
 }
 
 func TestSpawn_DeadSpawnDaemon_NonParent(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -273,6 +283,7 @@ func TestSpawn_DeadSpawnDaemon_NonParent(t *testing.T) {
 }
 
 func TestSpawn_Valid_TaskRunning(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -292,6 +303,7 @@ func TestSpawn_Valid_TaskRunning(t *testing.T) {
 }
 
 func TestSpawn_Valid_TaskExit_ExitCode(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 
@@ -311,6 +323,7 @@ func TestSpawn_Valid_TaskExit_ExitCode(t *testing.T) {
 }
 
 func TestSpawn_Valid_TaskExit_NoExitCode(t *testing.T) {
+	t.Parallel()
 	tempFile := tempFileName(t)
 	defer os.Remove(tempFile)
 


### PR DESCRIPTION
With these changes, all tests for this package pass on Windows.

Changes to improve test portability:

* Close temp files so `os.Remove` works on Windows.
* Add a TestMain that provides portable echo and sleep commands for use by tests.
* Enabled `TestSpawn_SetsLogs` on Windows, as it passes now.

Other changes:

* Moved several `defer f.Close()` calls after the `if err != nil {...}` check.
* Added a call to `t.Parallel()` in tests to reduce test run time.