### PR TITLE
De-nest docker registry auth and reformat related doc

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -25,26 +25,21 @@ type DockerDriver struct {
 	fingerprint.StaticFingerprinter
 }
 
-type DockerAuthConfig struct {
-	UserName      string `mapstructure:"auth.username"`       // user name of the registry
-	Password      string `mapstructure:"auth.password"`       // password to access the registry
-	Email         string `mapstructure:"auth.email"`          // email address of the user who is allowed to access the registry
-	ServerAddress string `mapstructure:"auth.server_address"` // server address of the registry
-
-}
-
 type DockerDriverConfig struct {
-	DockerAuthConfig
-	ImageName     string              `mapstructure:"image"`          // Container's Image Name
-	Command       string              `mapstructure:"command"`        // The Command/Entrypoint to run when the container starts up
-	Args          string              `mapstructure:"args"`           // The arguments to the Command/Entrypoint
-	NetworkMode   string              `mapstructure:"network_mode"`   // The network mode of the container - host, net and none
-	PortMap       []map[string]int    `mapstructure:"port_map"`       // A map of host port labels and the ports exposed on the container
-	Privileged    bool                `mapstructure:"privileged"`     // Flag to run the container in priviledged mode
-	DNS           string              `mapstructure:"dns_server"`     // DNS Server for containers
-	SearchDomains string              `mapstructure:"search_domains"` // DNS Search domains for containers
-	Hostname      string              `mapstructure:"hostname"`       // Hostname for containers
-	Labels        []map[string]string `mapstructure:"labels"`         // Labels to set when the container starts up
+	ImageName     string              `mapstructure:"image"`               // Container's Image Name
+	Command       string              `mapstructure:"command"`             // The Command/Entrypoint to run when the container starts up
+	Args          string              `mapstructure:"args"`                // The arguments to the Command/Entrypoint
+	NetworkMode   string              `mapstructure:"network_mode"`        // The network mode of the container - host, net and none
+	PortMap       []map[string]int    `mapstructure:"port_map"`            // A map of host port labels and the ports exposed on the container
+	Privileged    bool                `mapstructure:"privileged"`          // Flag to run the container in priviledged mode
+	DNS           string              `mapstructure:"dns_server"`          // DNS Server for containers
+	SearchDomains string              `mapstructure:"search_domains"`      // DNS Search domains for containers
+	Hostname      string              `mapstructure:"hostname"`            // Hostname for containers
+	Labels        []map[string]string `mapstructure:"labels"`              // Labels to set when the container starts up
+	UserName      string              `mapstructure:"auth_username"`       // user name of the registry
+	Password      string              `mapstructure:"auth_password"`       // password to access the registry
+	Email         string              `mapstructure:"auth_email"`          // email address of the user who is allowed to access the registry
+	ServerAddress string              `mapstructure:"auth_server_address"` // server address of the registry
 }
 
 func (c *DockerDriverConfig) Validate() error {
@@ -392,6 +387,9 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 			ServerAddress: driverConfig.ServerAddress,
 		}
 
+		d.logger.Printf("[DEBUG] TASKCONFIG: %v", task.Config)
+		d.logger.Printf("[DEBUG] DRIVERCONFIG: %v", driverConfig)
+		d.logger.Printf("[DEBUG] AUTH: %v", authOptions)
 		err = client.PullImage(pullOptions, authOptions)
 		if err != nil {
 			d.logger.Printf("[ERR] driver.docker: failed pulling container %s:%s: %s", repo, tag, err)

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -57,10 +57,12 @@ following authentication parameters.  These options can provide access to
 private repositories that utilize the docker remote api (e.g. dockerhub,
 quay.io)
 
-* `auth_username` - (Optional) The account username.
-* `auth_password` - (Optional) The account password.
-* `auth_email` - (Optional) The account email.
-* `auth_server-address` - (Optional) The server domain/ip without the protocol.
+The `auth` object supports the following keys:
+
+* `username` - (Optional) The account username.
+* `password` - (Optional) The account password.
+* `email` - (Optional) The account email.
+* `server_address` - (Optional) The server domain/ip without the protocol.
 
 ### Port Mapping
 

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -56,11 +56,11 @@ specification:
 following authentication parameters.  These options can provide access to
 private repositories that utilize the docker remote api (e.g. dockerhub,
 quay.io)
-    - `auth.username` - (Optional) The account username
-    - `auth.password` - (Optional) The account password
-    - `auth.email` - (Optional) The account email
-    - `auth.server-address` - (Optional) The server domain/ip without the
-      protocol
+
+* `auth_username` - (Optional) The account username.
+* `auth_password` - (Optional) The account password.
+* `auth_email` - (Optional) The account email.
+* `auth_server-address` - (Optional) The server domain/ip without the protocol.
 
 ### Port Mapping
 


### PR DESCRIPTION
I'm not sure what happened here, but it looks like the Docker registry authentication parameters added in #390 aren't being decoded?

De-nesting the parameters seems to fix it. I'm guessing it's something to do with how `mapstructure` decodes the driver config struct.

I also removed the periods (`.`) from the related keys as they are awkward to type in HCL files as they have to be wrapped in quotes, and re-formatted the related docs a bit so that it's more clear the keys are at the same "level" as the rest of the driver config parameters. I can revert these though if there's a good reason they should be the way they were before.