### PR TITLE
Making sure we sync the real state of services of a Task with Consul

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -348,6 +348,19 @@ OUTER:
 
 				// Merge in the task resources
 				task.Resources = update.TaskResources[task.Name]
+			FOUND:
+				for _, updateGroup := range update.Job.TaskGroups {
+					if tg.Name != updateGroup.Name {
+						continue
+					}
+					for _, updateTask := range updateGroup.Tasks {
+						if updateTask.Name != task.Name {
+							continue
+						}
+						task.Services = updateTask.Services
+						break FOUND
+					}
+				}
 				tr.Update(task)
 			}
 			r.taskLock.RUnlock()

--- a/client/consul.go
+++ b/client/consul.go
@@ -103,13 +103,12 @@ func (c *ConsulClient) SyncWithConsul() {
 	for {
 		select {
 		case <-sync:
-			sync = time.After(syncInterval)
 			var consulServices map[string]*consul.AgentService
 			var err error
 
 			for serviceId, ts := range c.trackedServices {
 				if !ts.IsServiceValid() {
-					c.logger.Printf("[INFO] Removing service: %s since the task doesn't have it anymore", ts.service.Name)
+					c.logger.Printf("[INFO] consul: Removing service: %s since the task doesn't have it anymore", ts.service.Name)
 					c.deregisterService(serviceId)
 				}
 			}
@@ -141,6 +140,7 @@ func (c *ConsulClient) SyncWithConsul() {
 					}
 				}
 			}
+			sync = time.After(syncInterval)
 		case <-c.shutdownCh:
 			c.logger.Printf("[INFO] Shutting down Consul Client")
 			return


### PR DESCRIPTION
This PR adds or removes services from an existing job whose service block has been updated by the user.