### PR TITLE
docker port allocation not mapping correctly

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -275,7 +275,8 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task, dri
 			}
 
 			hostPortStr := strconv.Itoa(port.Value)
-			containerPort := docker.Port(hostPortStr)
+			// containerPort := docker.Port(hostPortStr)
+			containerPort := docker.Port(strconv.Itoa(containerPortInt))
 
 			publishedPorts[containerPort+"/tcp"] = []docker.PortBinding{docker.PortBinding{HostIP: network.IP, HostPort: hostPortStr}}
 			publishedPorts[containerPort+"/udp"] = []docker.PortBinding{docker.PortBinding{HostIP: network.IP, HostPort: hostPortStr}}


### PR DESCRIPTION
Hi, 

today we have been trying 0.2.0 and all the new things worked except the port mappings. Don't know if bug or our poor knowledge.

 Same results on linux and mac+kitematic btw.

Reproduce steps:

````
nomad agent -dev

nomad init 
nomad run ./example.nomad
```


Port mappings maps the same port on host than container, but not the exposed one.

```
nomad run example.nomad
==> Monitoring evaluation "7c3a28ad-d99b-5d20-7257-7f13c7772cf1"
    Evaluation triggered by job "example"
    Allocation "93fa88f1-c821-1915-b152-aaa7c014574c" created: node "d293dbef-5cb2-056a-cb38-852297cecac7", group "cache"
    Evaluation status changed: "pending" -> "complete"
==> Evaluation "7c3a28ad-d99b-5d20-7257-7f13c7772cf1" finished with status "complete"

--- nomad server ---
2015/11/19 19:19:31 [DEBUG] client: starting runner for alloc '93fa88f1-c821-1915-b152-aaa7c014574c'
    2015/11/19 19:19:31 [DEBUG] client: starting task context for 'redis' (alloc '93fa88f1-c821-1915-b152-aaa7c014574c')
    2015/11/19 19:19:31 [DEBUG] http: Request /v1/evaluation/7c3a28ad-d99b-5d20-7257-7f13c7772cf1 (62.502µs)
    2015/11/19 19:19:31 [DEBUG] worker: updated evaluation <Eval '7c3a28ad-d99b-5d20-7257-7f13c7772cf1' JobID: 'example'>
    2015/11/19 19:19:31 [DEBUG] worker: ack for evaluation 7c3a28ad-d99b-5d20-7257-7f13c7772cf1
    2015/11/19 19:19:31 [DEBUG] http: Request /v1/evaluation/7c3a28ad-d99b-5d20-7257-7f13c7772cf1/allocations (181.09µs)
    2015/11/19 19:20:10 [DEBUG] driver.docker: docker pull redis:latest succeeded
    2015/11/19 19:20:10 [DEBUG] driver.docker: identified image redis:latest as e65f97c3eeb6744e76353067463a2fcd46664c18df4cdaaa0826051b5840f412
    2015/11/19 19:20:10 [DEBUG] driver.docker: using 268435456 bytes memory for redis:latest
    2015/11/19 19:20:10 [DEBUG] driver.docker: using 500 cpu shares for redis:latest
    2015/11/19 19:20:10 [DEBUG] driver.docker: binding directories []string{"/var/folders/zq/_cjqqlh51491h_mqgz9j9twh0000gn/T/NomadClient194406433/93fa88f1-c821-1915-b152-aaa7c014574c/alloc:/alloc:rw,z", "/var/folders/zq/_cjqqlh51491h_mqgz9j9twh0000gn/T/NomadClient194406433/93fa88f1-c821-1915-b152-aaa7c014574c/redis:/local:rw,Z"} for redis:latest
    2015/11/19 19:20:10 [DEBUG] driver.docker: networking mode not specified; defaulting to bridge
    2015/11/19 19:20:10 [DEBUG] driver.docker: allocated port 127.0.0.1:58517 -> 6379 (mapped)
    2015/11/19 19:20:10 [DEBUG] driver.docker: exposed port 58517
    2015/11/19 19:20:10 [DEBUG] driver.docker: setting container name to: redis-93fa88f1-c821-1915-b152-aaa7c014574c
    2015/11/19 19:20:10 [INFO] driver.docker: created container b27507463bccd5ad1148529ab55238c19a9a063e7fb9a093807d96690d75570d
    2015/11/19 19:20:10 [INFO] driver.docker: started container b27507463bccd5ad1148529ab55238c19a9a063e7fb9a093807d96690d75570d
...
...
...

docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED              STATUS              PORTS                                                              NAMES
b27507463bcc        redis:latest        "/entrypoint.sh redis"   About a minute ago   Up About a minute   6379/tcp, 127.0.0.1:58517->58517/tcp, 127.0.0.1:58517->58517/udp   redis-93fa88f1-c821-1915-b152-aaa7c014574c
```


After the little code change we got this.



````
nomad run example.nomad
==> Monitoring evaluation "e5978fa3-e13e-a1b0-3094-c773c4fa810f"
    Evaluation triggered by job "example"
    Allocation "ce181ffd-495f-6a0c-c418-a53ff22d3ab1" created: node "bc65c44b-5e86-d6ee-f907-9c93a5311d17", group "cache"
    Evaluation status changed: "pending" -> "complete"
==> Evaluation "e5978fa3-e13e-a1b0-3094-c773c4fa810f" finished with status "complete"


--- nomad server ---
2015/11/19 19:11:46 [DEBUG] client: starting runner for alloc 'ce181ffd-495f-6a0c-c418-a53ff22d3ab1'
    2015/11/19 19:11:46 [DEBUG] client: starting task context for 'redis' (alloc 'ce181ffd-495f-6a0c-c418-a53ff22d3ab1')
    2015/11/19 19:11:47 [DEBUG] http: Request /v1/evaluation/e5978fa3-e13e-a1b0-3094-c773c4fa810f (65.977µs)
    2015/11/19 19:11:47 [DEBUG] worker: updated evaluation <Eval 'e5978fa3-e13e-a1b0-3094-c773c4fa810f' JobID: 'example'>
    2015/11/19 19:11:47 [DEBUG] worker: ack for evaluation e5978fa3-e13e-a1b0-3094-c773c4fa810f
    2015/11/19 19:11:47 [DEBUG] http: Request /v1/evaluation/e5978fa3-e13e-a1b0-3094-c773c4fa810f/allocations (184.43µs)
    2015/11/19 19:13:12 [DEBUG] driver.docker: docker pull redis:latest succeeded
    2015/11/19 19:13:12 [DEBUG] driver.docker: identified image redis:latest as e65f97c3eeb6744e76353067463a2fcd46664c18df4cdaaa0826051b5840f412
    2015/11/19 19:13:12 [DEBUG] driver.docker: using 268435456 bytes memory for redis:latest
    2015/11/19 19:13:12 [DEBUG] driver.docker: using 500 cpu shares for redis:latest
    2015/11/19 19:13:12 [DEBUG] driver.docker: binding directories []string{"/var/folders/zq/_cjqqlh51491h_mqgz9j9twh0000gn/T/NomadClient042310149/ce181ffd-495f-6a0c-c418-a53ff22d3ab1/alloc:/alloc:rw,z", "/var/folders/zq/_cjqqlh51491h_mqgz9j9twh0000gn/T/NomadClient042310149/ce181ffd-495f-6a0c-c418-a53ff22d3ab1/redis:/local:rw,Z"} for redis:latest
    2015/11/19 19:13:12 [DEBUG] driver.docker: networking mode not specified; defaulting to bridge
    2015/11/19 19:13:12 [DEBUG] driver.docker: allocated port 127.0.0.1:22948 -> 6379 (mapped)
    2015/11/19 19:13:12 [DEBUG] driver.docker: exposed port 22948
    2015/11/19 19:13:12 [DEBUG] driver.docker: setting container name to: redis-ce181ffd-495f-6a0c-c418-a53ff22d3ab1
    2015/11/19 19:13:12 [INFO] driver.docker: created container feb0e23da7170360945e7e18b7b96c3d84ce5abcdefa5ccd67cf342aa8606211
    2015/11/19 19:13:12 [INFO] driver.docker: started container feb0e23da7170360945e7e18b7b96c3d84ce5abcdefa5ccd67cf342aa8606211
...
...
...



docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                                  NAMES
feb0e23da717        redis:latest        "/entrypoint.sh redis"   21 seconds ago      Up 21 seconds       127.0.0.1:22948->6379/udp, 127.0.0.1:22948->6379/tcp   redis-ce181ffd-495f-6a0c-c418-a53ff22d3ab1
```

