### PR TITLE
Client Config allows a driver whitelist.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -507,13 +507,13 @@ func (c *Client) setupDrivers() error {
 	whitelistEnabled := len(whitelist) > 0
 
 	var avail []string
-	var whitelisted []string
+	var skipped []string
 	driverCtx := driver.NewDriverContext("", c.config, c.config.Node, c.logger)
 	for name := range driver.BuiltinDrivers {
 		// Skip fingerprinting drivers that are not in the whitelist if it is
 		// enabled.
 		if _, ok := whitelist[name]; whitelistEnabled && !ok {
-			whitelisted = append(whitelisted, name)
+			skipped = append(skipped, name)
 			continue
 		}
 
@@ -532,8 +532,8 @@ func (c *Client) setupDrivers() error {
 
 	c.logger.Printf("[DEBUG] client: available drivers %v", avail)
 
-	if len(whitelisted) != 0 {
-		c.logger.Printf("[DEBUG] client: drivers disabled by whitelist: %v", whitelisted)
+	if len(skipped) != 0 {
+		c.logger.Printf("[DEBUG] client: drivers skipped due to whitelist: %v", skipped)
 	}
 
 	return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -151,6 +151,33 @@ func TestClient_Drivers(t *testing.T) {
 	}
 }
 
+func TestClient_Drivers_InWhitelist(t *testing.T) {
+	ctestutil.ExecCompatible(t)
+	c := testClient(t, func(c *config.Config) {
+		// Weird spacing to test trimming
+		c.Options["driver.whitelist"] = "   exec ,  foo	"
+	})
+	defer c.Shutdown()
+
+	node := c.Node()
+	if node.Attributes["driver.exec"] == "" {
+		t.Fatalf("missing exec driver")
+	}
+}
+
+func TestClient_Drivers_OutOfWhitelist(t *testing.T) {
+	ctestutil.ExecCompatible(t)
+	c := testClient(t, func(c *config.Config) {
+		c.Options["driver.whitelist"] = "foo,bar,baz"
+	})
+	defer c.Shutdown()
+
+	node := c.Node()
+	if node.Attributes["driver.exec"] != "" {
+		t.Fatalf("found exec driver")
+	}
+}
+
 func TestClient_Register(t *testing.T) {
 	s1, _ := testServer(t, nil)
 	defer s1.Shutdown()

--- a/demo/vagrant/client1.hcl
+++ b/demo/vagrant/client1.hcl
@@ -12,6 +12,9 @@ client {
     # this should be like "nomad.service.consul:4647" and a system
     # like Consul used for service discovery.
     servers = ["127.0.0.1:4647"]
+    options {
+	"driver.whitelist" = " exec, qemu "
+    }
 }
 
 # Modify our port to avoid a collision with server1

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -212,12 +212,29 @@ configured on server nodes.
   * <a id="meta">`meta`</a>: This is a key/value mapping of metadata pairs. This
     is a free-form map and can contain any string values.
   * <a id="options">`options`</a>: This is a key/value mapping of internal
-    configuration for clients, such as for driver configuration.
+    configuration for clients, such as for driver configuration. Please see
+    [here](#options_map) for a description of available options.
   * <a id="network_interface">`network_interface`</a>: This is a string to force
     network fingerprinting to use a specific network interface
   * <a id="network_speed">`network_speed`</a>: This is an int that sets the
     default link speed of network interfaces, in megabytes, if their speed can
     not be determined dynamically.
+
+### Client Options Map <a id="options_map"></a>
+
+The following is not an exhaustive list of options that can be passed to the
+Client, but rather the set of options that configure the Client and not the
+drivers. To find the options supported by an individual driver, see the drivers
+documentation [here](/docs/drivers/index.html)
+
+* `consul.address`: The address to the local Consul agent given in the format of
+  `host:port`. The default is the same as the Consul default address,
+  `127.0.0.1:8500`.
+
+* `driver.whitelist`: A comma seperated list of whitelisted drivers (e.g.
+  "docker,qemu"). If specified, drivers not in the whitelist will be disabled.
+  If the whitelist is empty, all drivers are fingerprinted and enabled where
+  applicable.
 
 ## Atlas Options
 

--- a/website/source/docs/jobspec/environment.html.md
+++ b/website/source/docs/jobspec/environment.html.md
@@ -38,7 +38,9 @@ cluster gets more or less busy.
 
 ### Networking
 
-Nomad assigns IPs and ports to your jobs and exposes them via environment variables. See the [Networking](/docs/jobspec/networking.html) page for more details.
+Nomad assigns IPs and ports to your jobs and exposes them via environment
+variables. See the [Networking](/docs/jobspec/networking.html) page for more
+details.
 
 ### Task Directories <a id="task_dir"></a>
 


### PR DESCRIPTION
Client Config allows a driver whitelist to disable unwanted drivers. This closes #467 