### PR TITLE
Fixed some issues with expose, port mapping, and environment variables

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -2,13 +2,14 @@ package client
 
 import (
 	"fmt"
-	consul "github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/nomad/nomad/structs"
 	"log"
 	"net/url"
 	"sync"
 	"time"
+
+	consul "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 const (
@@ -95,7 +96,7 @@ func (c *ConsulClient) ShutDown() {
 
 func (c *ConsulClient) findPortAndHostForLabel(portLabel string, task *structs.Task) (string, int) {
 	for _, network := range task.Resources.Networks {
-		if p, ok := network.MapLabelToValues()[portLabel]; ok {
+		if p, ok := network.MapLabelToValues(nil)[portLabel]; ok {
 			return network.IP, p
 		}
 	}

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -153,6 +153,10 @@ func TestDockerDriver_Fingerprint(t *testing.T) {
 }
 
 func TestDockerDriver_StartOpen_Wait(t *testing.T) {
+	if !dockerIsConnected(t) {
+		t.SkipNow()
+	}
+
 	task := &structs.Task{
 		Name: "redis-demo",
 		Config: map[string]interface{}{
@@ -222,7 +226,7 @@ func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
 	// This test requires that the alloc dir be mounted into docker as a volume.
 	// Because this cannot happen when docker is run remotely, e.g. when running
 	// docker in a VM, we skip this when we detect Docker is being run remotely.
-	if dockerIsRemote(t) {
+	if !dockerIsConnected(t) || dockerIsRemote(t) {
 		t.SkipNow()
 	}
 

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
+	"runtime/debug"
 	"testing"
 	"time"
 
@@ -92,7 +93,7 @@ func dockerSetup(t *testing.T, task *structs.Task) (*docker.Client, DriverHandle
 
 	client, err := docker.NewClientFromEnv()
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		t.Fatalf("Failed to initialize client: %s\nStack\n%s", err, debug.Stack())
 	}
 
 	driverCtx := testDockerDriverContext(task.Name)
@@ -102,11 +103,11 @@ func dockerSetup(t *testing.T, task *structs.Task) (*docker.Client, DriverHandle
 	handle, err := driver.Start(ctx, task)
 	if err != nil {
 		ctx.AllocDir.Destroy()
-		t.Fatalf("err: %v", err)
+		t.Fatalf("Failed to start driver: %s\nStack\n%s", err, debug.Stack())
 	}
 	if handle == nil {
 		ctx.AllocDir.Destroy()
-		t.Fatalf("missing handle")
+		t.Fatalf("handle is nil\nStack\n%s", debug.Stack())
 	}
 
 	cleanup := func() {

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -145,3 +145,23 @@ func TaskEnvironmentVariables(ctx *ExecContext, task *structs.Task) environment.
 
 	return env
 }
+
+func mapMergeStrInt(maps ...map[string]int) map[string]int {
+	out := map[string]int{}
+	for _, in := range maps {
+		for key, val := range in {
+			out[key] = val
+		}
+	}
+	return out
+}
+
+func mapMergeStrStr(maps ...map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, in := range maps {
+		for key, val := range in {
+			out[key] = val
+		}
+	}
+	return out
+}

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -135,7 +135,7 @@ func TaskEnvironmentVariables(ctx *ExecContext, task *structs.Task) environment.
 		if len(task.Resources.Networks) > 0 {
 			network := task.Resources.Networks[0]
 			env.SetTaskIp(network.IP)
-			env.SetPorts(network.MapLabelToValues())
+			env.SetPorts(network.MapLabelToValues(nil))
 		}
 	}
 

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -99,3 +99,51 @@ func TestDriver_TaskEnvironmentVariables(t *testing.T) {
 		t.Fatalf("TaskEnvironmentVariables(%#v, %#v) returned %#v; want %#v", ctx, task, act, exp)
 	}
 }
+
+func TestMapMergeStrInt(t *testing.T) {
+	a := map[string]int{
+		"cakes":   5,
+		"cookies": 3,
+	}
+
+	b := map[string]int{
+		"cakes": 3,
+		"pies":  2,
+	}
+
+	c := mapMergeStrInt(a, b)
+
+	d := map[string]int{
+		"cakes":   3,
+		"cookies": 3,
+		"pies":    2,
+	}
+
+	if !reflect.DeepEqual(c, d) {
+		t.Errorf("\nExpected\n%+v\nGot\n%+v\n", d, c)
+	}
+}
+
+func TestMapMergeStrStr(t *testing.T) {
+	a := map[string]string{
+		"cake":   "chocolate",
+		"cookie": "caramel",
+	}
+
+	b := map[string]string{
+		"cake": "strawberry",
+		"pie":  "apple",
+	}
+
+	c := mapMergeStrStr(a, b)
+
+	d := map[string]string{
+		"cake":   "strawberry",
+		"cookie": "caramel",
+		"pie":    "apple",
+	}
+
+	if !reflect.DeepEqual(c, d) {
+		t.Errorf("\nExpected\n%+v\nGot\n%+v\n", d, c)
+	}
+}

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -148,7 +148,7 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 		// reserved ports to the ports listenting in the VM
 		// Ex: hostfwd=tcp::22000-:22,hostfwd=tcp::80-:8080
 		var forwarding []string
-		taskPorts := task.Resources.Networks[0].MapLabelToValues()
+		taskPorts := task.Resources.Networks[0].MapLabelToValues(nil)
 		for label, guest := range driverConfig.PortMap[0] {
 			host, ok := taskPorts[label]
 			if !ok {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -662,11 +662,15 @@ func (n *NetworkResource) GoString() string {
 	return fmt.Sprintf("*%#v", *n)
 }
 
-func (n *NetworkResource) MapLabelToValues() map[string]int {
+func (n *NetworkResource) MapLabelToValues(port_map map[string]int) map[string]int {
 	labelValues := make(map[string]int)
 	ports := append(n.ReservedPorts, n.DynamicPorts...)
 	for _, port := range ports {
-		labelValues[port.Label] = port.Value
+		if mapping, ok := port_map[port.Label]; ok {
+			labelValues[port.Label] = mapping
+		} else {
+			labelValues[port.Label] = port.Value
+		}
 	}
 	return labelValues
 }


### PR DESCRIPTION
- Port mapping now works for reserved ports as well as dynamic ports
- Environment variables were being set twice in two different ways; now they are only set once
- Comprehensive tests for exposed ports, forwarded ports, and environment variables
- Cleaned up / DRYed up a lot of test code
- Flattened `[]map[string]int` to `map[string]int`