### PR TITLE
Fix small typo in Docker auth docs

### DIFF
--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -103,7 +103,7 @@ task "secretservice" {
         image = "secret/service"
         auth {
             username = "dockerhub_user"
-            username = "dockerhub_password"
+            password = "dockerhub_password"
         }
     }
 }


### PR DESCRIPTION
This fixes a super minor typo in Docker auth docs.