### PR TITLE
Fix nil-pointer dereference with empty timeout on eval_broker.Dequeue

### DIFF
--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -233,7 +233,7 @@ SCAN:
 	}
 
 	// Setup the timeout channel the first time around
-	if timeoutTimer == nil && timeout != 0 {
+	if timeoutTimer == nil {
 		timeoutTimer = time.NewTimer(timeout)
 	}
 

--- a/nomad/eval_broker_test.go
+++ b/nomad/eval_broker_test.go
@@ -400,6 +400,26 @@ func TestEvalBroker_Dequeue_Timeout(t *testing.T) {
 	}
 }
 
+func TestEvalBroker_Dequeue_Empty_Timeout(t *testing.T) {
+	b := testBroker(t, 0)
+	b.SetEnabled(true)
+
+	start := time.Now()
+	out, _, err := b.Dequeue(defaultSched, 0)
+	end := time.Now()
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("unexpected: %#v", out)
+	}
+
+	if diff := end.Sub(start); diff > 1*time.Millisecond {
+		t.Fatalf("bad: %#v", diff)
+	}
+}
+
 // Ensure higher priority dequeued first
 func TestEvalBroker_Dequeue_Priority(t *testing.T) {
 	b := testBroker(t, 0)


### PR DESCRIPTION
Fix nil-pointer dereference with empty timeout on eval_broker.Dequeue