### PR TITLE
Fix syntax error in raw_exec config documentation

### DIFF
--- a/website/source/docs/drivers/raw_exec.html.md
+++ b/website/source/docs/drivers/raw_exec.html.md
@@ -36,13 +36,15 @@ The `raw_exec` driver supports the following configuration in the job spec:
 
 The `raw_exec` driver can run on all supported operating systems. It is however
 disabled by default. In order to be enabled, the Nomad client configuration must
-explicitly enable the `raw_exec` driver in the
+explicitly enable the `raw_exec` driver in the client's
 [options](../agent/config.html#options) field:
 
 ```
-options = {
-    driver.raw_exec.enable = "1"
-}
+  client {
+    options = {
+        "driver.raw_exec.enable" = "1"
+    }
+  }
 ```
 
 You must specify a `command` to be executed. Optionally you can specify an


### PR DESCRIPTION
Keys need to be surrounded by quotes if they contain periods. Using the original example from the docs resulted in this error:

```
==> Error loading configuration from config.hcl: At 3:13: expected: IDENT | STRING | ASSIGN | LBRACE got: PERIOD
```