### PR TITLE
Consul fingerprinter only creates one consul client

### DIFF
--- a/client/fingerprint/consul.go
+++ b/client/fingerprint/consul.go
@@ -15,6 +15,7 @@ import (
 // ConsulFingerprint is used to fingerprint the architecture
 type ConsulFingerprint struct {
 	logger *log.Logger
+	client *consul.Client
 }
 
 // NewConsulFingerprint is used to create an OS fingerprint
@@ -29,24 +30,28 @@ func (f *ConsulFingerprint) Fingerprint(config *client.Config, node *structs.Nod
 		node.Links = map[string]string{}
 	}
 
-	address := config.ReadDefault("consul.address", "127.0.0.1:8500")
-	timeout, err := time.ParseDuration(config.ReadDefault("consul.timeout", "10ms"))
-	if err != nil {
-		return false, fmt.Errorf("Unable to parse consul.timeout: %s", err)
-	}
+	// Only create the client once to avoid creating too many connections to
+	// Consul.
+	if f.client == nil {
+		address := config.ReadDefault("consul.address", "127.0.0.1:8500")
+		timeout, err := time.ParseDuration(config.ReadDefault("consul.timeout", "10ms"))
+		if err != nil {
+			return false, fmt.Errorf("Unable to parse consul.timeout: %s", err)
+		}
 
-	consulConfig := consul.DefaultConfig()
-	consulConfig.Address = address
-	consulConfig.HttpClient.Timeout = timeout
+		consulConfig := consul.DefaultConfig()
+		consulConfig.Address = address
+		consulConfig.HttpClient.Timeout = timeout
 
-	consulClient, err := consul.NewClient(consulConfig)
-	if err != nil {
-		return false, fmt.Errorf("Failed to initialize consul client: %s", err)
+		f.client, err = consul.NewClient(consulConfig)
+		if err != nil {
+			return false, fmt.Errorf("Failed to initialize consul client: %s", err)
+		}
 	}
 
 	// We'll try to detect consul by making a query to to the agent's self API.
 	// If we can't hit this URL consul is probably not running on this machine.
-	info, err := consulClient.Agent().Self()
+	info, err := f.client.Agent().Self()
 	if err != nil {
 		return false, nil
 	}

--- a/client/fingerprint/consul.go
+++ b/client/fingerprint/consul.go
@@ -53,6 +53,8 @@ func (f *ConsulFingerprint) Fingerprint(config *client.Config, node *structs.Nod
 	// If we can't hit this URL consul is probably not running on this machine.
 	info, err := f.client.Agent().Self()
 	if err != nil {
+		// Clear any attributes set by a previous fingerprint.
+		f.clearConsulAttributes(node)
 		return false, nil
 	}
 
@@ -67,6 +69,17 @@ func (f *ConsulFingerprint) Fingerprint(config *client.Config, node *structs.Nod
 		node.Attributes["consul.name"])
 
 	return true, nil
+}
+
+// clearConsulAttributes removes consul attributes and links from the passed
+// Node.
+func (f *ConsulFingerprint) clearConsulAttributes(n *structs.Node) {
+	delete(n.Attributes, "consul.server")
+	delete(n.Attributes, "consul.version")
+	delete(n.Attributes, "consul.revision")
+	delete(n.Attributes, "consul.name")
+	delete(n.Attributes, "consul.datacenter")
+	delete(n.Links, "consul")
 }
 
 func (f *ConsulFingerprint) Periodic() (bool, time.Duration) {


### PR DESCRIPTION
Consul fingerprinter only creates one consul client. Fixes #486 