### PR TITLE
Disable AWS and GCE fingerprinting via environment variables

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -140,6 +140,33 @@ func TestClient_Fingerprint(t *testing.T) {
 	}
 }
 
+func TestClient_Fingerprint_InWhitelist(t *testing.T) {
+	ctestutil.ExecCompatible(t)
+	c := testClient(t, func(c *config.Config) {
+		// Weird spacing to test trimming. Whitelist all modules expect cpu.
+		c.Options["fingerprint.whitelist"] = "  arch, consul,env_aws,env_gce,host,memory,network,storage,foo,bar	"
+	})
+	defer c.Shutdown()
+
+	node := c.Node()
+	if node.Attributes["cpu.frequency"] == "" {
+		t.Fatalf("missing cpu fingerprint module")
+	}
+}
+
+func TestClient_Fingerprint_OutOfWhitelist(t *testing.T) {
+	ctestutil.ExecCompatible(t)
+	c := testClient(t, func(c *config.Config) {
+		c.Options["fingerprint.whitelist"] = "arch,consul,cpu,env_aws,env_gce,host,memory,network,storage,foo,bar"
+	})
+	defer c.Shutdown()
+
+	node := c.Node()
+	if node.Attributes["cpu.frequency"] != "" {
+		t.Fatalf("found cpu fingerprint module")
+	}
+}
+
 func TestClient_Drivers(t *testing.T) {
 	ctestutil.ExecCompatible(t)
 	c := testClient(t, nil)

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -97,4 +98,18 @@ func (c *Config) ReadBoolDefault(id string, defaultValue bool) bool {
 		return defaultValue
 	}
 	return val
+}
+
+// ReadStringListToMap tries to parse the specified option as a comma seperated list.
+// If there is an error in parsing, an empty list is returned.
+func (c *Config) ReadStringListToMap(key string) map[string]struct{} {
+	s := strings.TrimSpace(c.Read(key))
+	list := make(map[string]struct{})
+	if s != "" {
+		for _, e := range strings.Split(s, ",") {
+			trimmed := strings.TrimSpace(e)
+			list[trimmed] = struct{}{}
+		}
+	}
+	return list
 }

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -236,6 +236,13 @@ documentation [here](/docs/drivers/index.html)
   If the whitelist is empty, all drivers are fingerprinted and enabled where
   applicable.
 
+* `fingerprint.whitelist`: A comma seperated list of whitelisted modules (e.g.
+  "arch,consul,cpu,host,memory,network,storage" to enabled all current
+  implemented modules expect AWS and GCE). If specified, fingerprinting modules
+  not in the whitelist will be disabled.
+  If the whitelist is empty, all modules are fingerprinted and enabled where
+  applicable.
+
 ## Atlas Options
 
 **NOTE**: Nomad integration with Atlas is awaiting release of Atlas features


### PR DESCRIPTION
When setting `AWS_ENV_URL` or `GCE_ENV_URL` to `disabled` fingerprinting of this services is completely disabled.

Additionally, what do you think about moving this two variables to the config file?