### PR TITLE
Not restarting if a task exited properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ BUG FIXES:
   * driver/docker: Support `port_map` for static ports [GH-476]
   * driver/docker: Pass 0.2.0-style port environment variables to the docker container [GH-476]
   * client/service discovery: Make Service IDs unique [GH-479]
-  * client/restart policy: Not restarting Batch Jobs if the exit code is 0
+  * client/restart policy: Not restarting Batch Jobs if the exit code is 0 [GH-491]
 
 ## 0.2.0 (November 18, 2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
   * driver/docker: Support `port_map` for static ports [GH-476]
   * driver/docker: Pass 0.2.0-style port environment variables to the docker container [GH-476]
   * client/service discovery: Make Service IDs unique [GH-479]
+  * client/restart policy: Not restarting Batch Jobs if the exit code is 0
 
 ## 0.2.0 (November 18, 2015)
 

--- a/client/restarts.go
+++ b/client/restarts.go
@@ -48,7 +48,7 @@ func (b *batchRestartTracker) increment() {
 }
 
 func (b *batchRestartTracker) nextRestart(exitCode int) (bool, time.Duration) {
-	if (b.count < b.maxAttempts) && (exitCode > 0) {
+	if b.count < b.maxAttempts && exitCode > 0 {
 		b.increment()
 		return true, b.delay
 	}

--- a/client/restarts.go
+++ b/client/restarts.go
@@ -11,7 +11,7 @@ import (
 // For Batch jobs, the interval is set to zero value since the takss
 // will be restarted only upto maxAttempts times
 type restartTracker interface {
-	nextRestart() (bool, time.Duration)
+	nextRestart(exitCode int) (bool, time.Duration)
 }
 
 func newRestartTracker(jobType string, restartPolicy *structs.RestartPolicy) restartTracker {
@@ -47,8 +47,8 @@ func (b *batchRestartTracker) increment() {
 	b.count += 1
 }
 
-func (b *batchRestartTracker) nextRestart() (bool, time.Duration) {
-	if b.count < b.maxAttempts {
+func (b *batchRestartTracker) nextRestart(exitCode int) (bool, time.Duration) {
+	if (b.count < b.maxAttempts) && (exitCode > 0) {
 		b.increment()
 		return true, b.delay
 	}
@@ -68,7 +68,7 @@ func (s *serviceRestartTracker) increment() {
 	s.count += 1
 }
 
-func (s *serviceRestartTracker) nextRestart() (bool, time.Duration) {
+func (s *serviceRestartTracker) nextRestart(exitCode int) (bool, time.Duration) {
 	defer s.increment()
 	windowEndTime := s.startTime.Add(s.interval)
 	now := time.Now()

--- a/client/restarts_test.go
+++ b/client/restarts_test.go
@@ -73,7 +73,6 @@ func TestTaskRunner_BatchRestartOnSuccess(t *testing.T) {
 	shouldRestart, _ := rt.nextRestart(0)
 	if shouldRestart {
 		t.Fatalf("should restart returned %v, expected: %v", shouldRestart, false)
-		t.Fail()
 	}
 
 }

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -276,15 +276,17 @@ func (r *TaskRunner) run() {
 			return
 		}
 
+		waitEvent := r.waitErrorToEvent(waitRes)
 		// Log whether the task was successful or not.
 		if !waitRes.Successful() {
 			r.logger.Printf("[ERR] client: failed to complete task '%s' for alloc '%s': %v", r.task.Name, r.allocID, waitRes)
 		} else {
 			r.logger.Printf("[INFO] client: completed task '%s' for alloc '%s'", r.task.Name, r.allocID)
+			r.setState(structs.TaskStateDead, waitEvent)
+			return
 		}
 
 		// Check if we should restart. If not mark task as dead and exit.
-		waitEvent := r.waitErrorToEvent(waitRes)
 		shouldRestart, when := r.restartTracker.nextRestart()
 		if !shouldRestart {
 			r.logger.Printf("[INFO] client: Not restarting task: %v for alloc: %v ", r.task.Name, r.allocID)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -276,18 +276,16 @@ func (r *TaskRunner) run() {
 			return
 		}
 
-		waitEvent := r.waitErrorToEvent(waitRes)
 		// Log whether the task was successful or not.
 		if !waitRes.Successful() {
 			r.logger.Printf("[ERR] client: failed to complete task '%s' for alloc '%s': %v", r.task.Name, r.allocID, waitRes)
 		} else {
 			r.logger.Printf("[INFO] client: completed task '%s' for alloc '%s'", r.task.Name, r.allocID)
-			r.setState(structs.TaskStateDead, waitEvent)
-			return
 		}
 
 		// Check if we should restart. If not mark task as dead and exit.
-		shouldRestart, when := r.restartTracker.nextRestart()
+		shouldRestart, when := r.restartTracker.nextRestart(waitRes.ExitCode)
+		waitEvent := r.waitErrorToEvent(waitRes)
 		if !shouldRestart {
 			r.logger.Printf("[INFO] client: Not restarting task: %v for alloc: %v ", r.task.Name, r.allocID)
 			r.setState(structs.TaskStateDead, waitEvent)


### PR DESCRIPTION
Nomad shouldn't restart tasks which exit with 0 for jobs which are dispatched via the batch scheduler.