### PR TITLE
Portable client/driver tests.

### DIFF
--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -119,6 +119,7 @@ func dockerSetup(t *testing.T, task *structs.Task) (*docker.Client, DriverHandle
 }
 
 func TestDockerDriver_Handle(t *testing.T) {
+	t.Parallel()
 	h := &DockerHandle{
 		imageID:     "imageid",
 		containerID: "containerid",
@@ -135,6 +136,7 @@ func TestDockerDriver_Handle(t *testing.T) {
 
 // This test should always pass, even if docker daemon is not available
 func TestDockerDriver_Fingerprint(t *testing.T) {
+	t.Parallel()
 	d := NewDockerDriver(testDockerDriverContext(""))
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -153,6 +155,7 @@ func TestDockerDriver_Fingerprint(t *testing.T) {
 }
 
 func TestDockerDriver_StartOpen_Wait(t *testing.T) {
+	t.Parallel()
 	if !dockerIsConnected(t) {
 		t.SkipNow()
 	}
@@ -190,6 +193,7 @@ func TestDockerDriver_StartOpen_Wait(t *testing.T) {
 }
 
 func TestDockerDriver_Start_Wait(t *testing.T) {
+	t.Parallel()
 	task := &structs.Task{
 		Name: "redis-demo",
 		Config: map[string]interface{}{
@@ -223,6 +227,7 @@ func TestDockerDriver_Start_Wait(t *testing.T) {
 }
 
 func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
+	t.Parallel()
 	// This test requires that the alloc dir be mounted into docker as a volume.
 	// Because this cannot happen when docker is run remotely, e.g. when running
 	// docker in a VM, we skip this when we detect Docker is being run remotely.
@@ -285,6 +290,7 @@ func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
 }
 
 func TestDockerDriver_Start_Kill_Wait(t *testing.T) {
+	t.Parallel()
 	task := &structs.Task{
 		Name: "redis-demo",
 		Config: map[string]interface{}{
@@ -317,6 +323,7 @@ func TestDockerDriver_Start_Kill_Wait(t *testing.T) {
 }
 
 func TestDocker_StartN(t *testing.T) {
+	t.Parallel()
 	if !dockerIsConnected(t) {
 		t.SkipNow()
 	}
@@ -371,6 +378,7 @@ func TestDocker_StartN(t *testing.T) {
 }
 
 func TestDocker_StartNVersions(t *testing.T) {
+	t.Parallel()
 	if !dockerIsConnected(t) {
 		t.SkipNow()
 	}
@@ -428,6 +436,7 @@ func TestDocker_StartNVersions(t *testing.T) {
 }
 
 func TestDockerHostNet(t *testing.T) {
+	t.Parallel()
 	expected := "host"
 
 	task := &structs.Task{
@@ -457,6 +466,7 @@ func TestDockerHostNet(t *testing.T) {
 }
 
 func TestDockerLabels(t *testing.T) {
+	t.Parallel()
 	task := dockerTask()
 	task.Config["labels"] = []map[string]string{
 		map[string]string{
@@ -483,6 +493,7 @@ func TestDockerLabels(t *testing.T) {
 }
 
 func TestDockerDNS(t *testing.T) {
+	t.Parallel()
 	task := dockerTask()
 	task.Config["dns_servers"] = []string{"8.8.8.8", "8.8.4.4"}
 	task.Config["dns_search_domains"] = []string{"example.com", "example.org", "example.net"}
@@ -514,6 +525,7 @@ func inSlice(needle string, haystack []string) bool {
 }
 
 func TestDockerPortsNoMap(t *testing.T) {
+	t.Parallel()
 	task := dockerTask()
 
 	client, handle, cleanup := dockerSetup(t, task)
@@ -564,6 +576,7 @@ func TestDockerPortsNoMap(t *testing.T) {
 }
 
 func TestDockerPortsMapping(t *testing.T) {
+	t.Parallel()
 	task := dockerTask()
 	task.Config["port_map"] = []map[string]string{
 		map[string]string{

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -61,6 +61,7 @@ func testDriverExecContext(task *structs.Task, driverCtx *DriverContext) *ExecCo
 }
 
 func TestDriver_TaskEnvironmentVariables(t *testing.T) {
+	t.Parallel()
 	ctx := &ExecContext{}
 	task := &structs.Task{
 		Env: map[string]string{
@@ -108,6 +109,7 @@ func TestDriver_TaskEnvironmentVariables(t *testing.T) {
 }
 
 func TestMapMergeStrInt(t *testing.T) {
+	t.Parallel()
 	a := map[string]int{
 		"cakes":   5,
 		"cookies": 3,
@@ -132,6 +134,7 @@ func TestMapMergeStrInt(t *testing.T) {
 }
 
 func TestMapMergeStrStr(t *testing.T) {
+	t.Parallel()
 	a := map[string]string{
 		"cake":   "chocolate",
 		"cookie": "caramel",

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/helper/testtask"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -28,6 +29,12 @@ var basicResources = &structs.Resources{
 
 func init() {
 	rand.Seed(49875)
+}
+
+func TestMain(m *testing.M) {
+	if !testtask.Run() {
+		os.Exit(m.Run())
+	}
 }
 
 func testLogger() *log.Logger {

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestExecDriver_Fingerprint(t *testing.T) {
+	t.Parallel()
 	ctestutils.ExecCompatible(t)
 	d := NewExecDriver(testDriverContext(""))
 	node := &structs.Node{
@@ -34,6 +35,7 @@ func TestExecDriver_Fingerprint(t *testing.T) {
 }
 
 func TestExecDriver_StartOpen_Wait(t *testing.T) {
+	t.Parallel()
 	ctestutils.ExecCompatible(t)
 	task := &structs.Task{
 		Name: "sleep",
@@ -68,6 +70,7 @@ func TestExecDriver_StartOpen_Wait(t *testing.T) {
 }
 
 func TestExecDriver_Start_Wait(t *testing.T) {
+	t.Parallel()
 	ctestutils.ExecCompatible(t)
 	task := &structs.Task{
 		Name: "sleep",
@@ -109,6 +112,7 @@ func TestExecDriver_Start_Wait(t *testing.T) {
 }
 
 func TestExecDriver_Start_Artifact_basic(t *testing.T) {
+	t.Parallel()
 	ctestutils.ExecCompatible(t)
 	file := "hi_linux_amd64"
 	checksum := "sha256:6f99b4c5184726e601ecb062500aeb9537862434dfe1898dbe5c68d9f50c179c"
@@ -153,6 +157,7 @@ func TestExecDriver_Start_Artifact_basic(t *testing.T) {
 }
 
 func TestExecDriver_Start_Artifact_expanded(t *testing.T) {
+	t.Parallel()
 	ctestutils.ExecCompatible(t)
 	file := "hi_linux_amd64"
 
@@ -199,6 +204,7 @@ func TestExecDriver_Start_Artifact_expanded(t *testing.T) {
 	}
 }
 func TestExecDriver_Start_Wait_AllocDir(t *testing.T) {
+	t.Parallel()
 	ctestutils.ExecCompatible(t)
 
 	exp := []byte{'w', 'i', 'n'}
@@ -251,6 +257,7 @@ func TestExecDriver_Start_Wait_AllocDir(t *testing.T) {
 }
 
 func TestExecDriver_Start_Kill_Wait(t *testing.T) {
+	t.Parallel()
 	ctestutils.ExecCompatible(t)
 	task := &structs.Task{
 		Name: "sleep",

--- a/client/driver/executor/exec.go
+++ b/client/driver/executor/exec.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -33,11 +32,6 @@ import (
 )
 
 var errNoResources = fmt.Errorf("No resources are associated with this task")
-
-// If testModeEnvVar is set in a process's environment variables, the
-// LinuxExecutor will detect it and inject the current binary into the chroot.
-// This enables using the test binary in tests to provide portability.
-var testModeEnvVar = "NOMAD_EXECUTOR_TEST_ONLY_13871827980214"
 
 // Executor is an interface that any platform- or capability-specific exec
 // wrapper must implement. You should not need to implement a Java executor.
@@ -111,19 +105,4 @@ func OpenId(id string) (Executor, error) {
 		return nil, err
 	}
 	return executor, nil
-}
-
-// isTest returns whether the cmd is a test binary.
-func isTest(cmd *exec.Cmd) bool {
-	if cmd == nil {
-		return false
-	}
-
-	for _, env := range cmd.Env {
-		if strings.HasPrefix(env, testModeEnvVar) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/client/driver/executor/exec_basic_test.go
+++ b/client/driver/executor/exec_basic_test.go
@@ -3,5 +3,6 @@ package executor
 import "testing"
 
 func TestExecutorBasic(t *testing.T) {
+	t.Parallel()
 	testExecutor(t, NewBasicExecutor, nil)
 }

--- a/client/driver/executor/exec_linux.go
+++ b/client/driver/executor/exec_linux.go
@@ -252,13 +252,6 @@ func (e *LinuxExecutor) ConfigureTaskDir(taskName string, alloc *allocdir.AllocD
 		return err
 	}
 
-	// Embed ourselves if this is a test. This needs to be done so the test
-	// binary is inside the chroot.
-	if isTest(&e.cmd) {
-		bin := e.cmd.Args[0]
-		alloc.Embed(taskName, map[string]string{bin: bin})
-	}
-
 	if err := alloc.Embed(taskName, chrootEnv); err != nil {
 		return err
 	}

--- a/client/driver/executor/exec_linux_test.go
+++ b/client/driver/executor/exec_linux_test.go
@@ -4,7 +4,13 @@ import (
 	"testing"
 
 	ctestutil "github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/testtask"
 )
+
+func init() {
+	// Add test binary to chroot during test run.
+	chrootEnv[testtask.Path()] = testtask.Path()
+}
 
 func TestExecutorLinux(t *testing.T) {
 	testExecutor(t, NewLinuxExecutor, ctestutil.ExecCompatible)

--- a/client/driver/executor/exec_linux_test.go
+++ b/client/driver/executor/exec_linux_test.go
@@ -13,5 +13,6 @@ func init() {
 }
 
 func TestExecutorLinux(t *testing.T) {
+	t.Parallel()
 	testExecutor(t, NewLinuxExecutor, ctestutil.ExecCompatible)
 }

--- a/client/driver/executor/test_harness_test.go
+++ b/client/driver/executor/test_harness_test.go
@@ -53,7 +53,7 @@ func testExecutor(t *testing.T, buildExecutor func() Executor, compatible func(*
 	command := func(name string, args ...string) Executor {
 		e := buildExecutor()
 		SetCommand(e, name, args)
-		testtask.SetEnv(e.Command())
+		testtask.SetCmdEnv(e.Command())
 		return e
 	}
 

--- a/client/driver/java_test.go
+++ b/client/driver/java_test.go
@@ -19,6 +19,7 @@ func javaLocated() bool {
 
 // The fingerprinter test should always pass, even if Java is not installed.
 func TestJavaDriver_Fingerprint(t *testing.T) {
+	t.Parallel()
 	ctestutils.JavaCompatible(t)
 	d := NewJavaDriver(testDriverContext(""))
 	node := &structs.Node{
@@ -42,6 +43,7 @@ func TestJavaDriver_Fingerprint(t *testing.T) {
 }
 
 func TestJavaDriver_StartOpen_Wait(t *testing.T) {
+	t.Parallel()
 	if !javaLocated() {
 		t.Skip("Java not found; skipping")
 	}
@@ -88,6 +90,7 @@ func TestJavaDriver_StartOpen_Wait(t *testing.T) {
 }
 
 func TestJavaDriver_Start_Wait(t *testing.T) {
+	t.Parallel()
 	if !javaLocated() {
 		t.Skip("Java not found; skipping")
 	}
@@ -134,6 +137,7 @@ func TestJavaDriver_Start_Wait(t *testing.T) {
 }
 
 func TestJavaDriver_Start_Kill_Wait(t *testing.T) {
+	t.Parallel()
 	if !javaLocated() {
 		t.Skip("Java not found; skipping")
 	}

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -12,6 +12,7 @@ import (
 
 // The fingerprinter test should always pass, even if QEMU is not installed.
 func TestQemuDriver_Fingerprint(t *testing.T) {
+	t.Parallel()
 	ctestutils.QemuCompatible(t)
 	d := NewQemuDriver(testDriverContext(""))
 	node := &structs.Node{
@@ -33,6 +34,7 @@ func TestQemuDriver_Fingerprint(t *testing.T) {
 }
 
 func TestQemuDriver_StartOpen_Wait(t *testing.T) {
+	t.Parallel()
 	ctestutils.QemuCompatible(t)
 	// TODO: use test server to load from a fixture
 	task := &structs.Task{
@@ -86,6 +88,7 @@ func TestQemuDriver_StartOpen_Wait(t *testing.T) {
 }
 
 func TestQemuDriver_RequiresMemory(t *testing.T) {
+	t.Parallel()
 	ctestutils.QemuCompatible(t)
 	// TODO: use test server to load from a fixture
 	task := &structs.Task{

--- a/client/driver/raw_exec_test.go
+++ b/client/driver/raw_exec_test.go
@@ -3,14 +3,16 @@ package driver
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/driver/environment"
+	"github.com/hashicorp/nomad/helper/testtask"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -52,11 +54,12 @@ func TestRawExecDriver_StartOpen_Wait(t *testing.T) {
 	task := &structs.Task{
 		Name: "sleep",
 		Config: map[string]interface{}{
-			"command": "/bin/sleep",
-			"args":    []string{"1"},
+			"command": testtask.Path(),
+			"args":    []string{"sleep", "1s"},
 		},
 		Resources: basicResources,
 	}
+	testtask.SetTaskEnv(task)
 	driverCtx := testDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)
 	defer ctx.AllocDir.Destroy()
@@ -88,25 +91,22 @@ func TestRawExecDriver_StartOpen_Wait(t *testing.T) {
 }
 
 func TestRawExecDriver_Start_Artifact_basic(t *testing.T) {
-	var file, checksum string
-	switch runtime.GOOS {
-	case "darwin":
-		file = "hi_darwin_amd64"
-		checksum = "md5:d7f2fdb13b36dcb7407721d78926b335"
-	default:
-		file = "hi_linux_amd64"
-		checksum = "md5:a9b14903a8942748e4f8474e11f795d3"
-	}
+	path := testtask.Path()
+	ts := httptest.NewServer(http.FileServer(http.Dir(filepath.Dir(path))))
+	defer ts.Close()
 
+	file := filepath.Base(path)
 	task := &structs.Task{
 		Name: "sleep",
 		Config: map[string]interface{}{
-			"artifact_source": fmt.Sprintf("https://dl.dropboxusercontent.com/u/47675/jar_thing/%s", file),
+			"artifact_source": fmt.Sprintf("%s/%s", ts.URL, file),
 			"command":         filepath.Join("$NOMAD_TASK_DIR", file),
-			"checksum":        checksum,
+			"args":            []string{"sleep", "1s"},
 		},
 		Resources: basicResources,
 	}
+	testtask.SetTaskEnv(task)
+
 	driverCtx := testDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)
 	defer ctx.AllocDir.Destroy()
@@ -138,26 +138,22 @@ func TestRawExecDriver_Start_Artifact_basic(t *testing.T) {
 }
 
 func TestRawExecDriver_Start_Artifact_expanded(t *testing.T) {
-	var file string
-	switch runtime.GOOS {
-	case "darwin":
-		file = "hi_darwin_amd64"
-	default:
-		file = "hi_linux_amd64"
-	}
+	path := testtask.Path()
+	ts := httptest.NewServer(http.FileServer(http.Dir(filepath.Dir(path))))
+	defer ts.Close()
 
+	file := filepath.Base(path)
 	task := &structs.Task{
 		Name: "sleep",
 		Config: map[string]interface{}{
-			"artifact_source": fmt.Sprintf("https://dl.dropboxusercontent.com/u/47675/jar_thing/%s", file),
-			"command":         "/bin/bash",
-			"args": []string{
-				"-c",
-				fmt.Sprintf(`'/bin/sleep 1 && %s'`, filepath.Join("$NOMAD_TASK_DIR", file)),
-			},
+			"artifact_source": fmt.Sprintf("%s/%s", ts.URL, file),
+			"command":         filepath.Join("$NOMAD_TASK_DIR", file),
+			"args":            []string{"sleep", "1s"},
 		},
 		Resources: basicResources,
 	}
+	testtask.SetTaskEnv(task)
+
 	driverCtx := testDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)
 	defer ctx.AllocDir.Destroy()
@@ -192,11 +188,12 @@ func TestRawExecDriver_Start_Wait(t *testing.T) {
 	task := &structs.Task{
 		Name: "sleep",
 		Config: map[string]interface{}{
-			"command": "/bin/sleep",
-			"args":    []string{"1"},
+			"command": testtask.Path(),
+			"args":    []string{"sleep", "1s"},
 		},
 		Resources: basicResources,
 	}
+	testtask.SetTaskEnv(task)
 
 	driverCtx := testDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)
@@ -231,17 +228,19 @@ func TestRawExecDriver_Start_Wait(t *testing.T) {
 func TestRawExecDriver_Start_Wait_AllocDir(t *testing.T) {
 	exp := []byte{'w', 'i', 'n'}
 	file := "output.txt"
+	outPath := fmt.Sprintf(`$%s/%s`, environment.AllocDir, file)
 	task := &structs.Task{
 		Name: "sleep",
 		Config: map[string]interface{}{
-			"command": "/bin/bash",
+			"command": testtask.Path(),
 			"args": []string{
-				"-c",
-				fmt.Sprintf(`sleep 1; echo -n %s > $%s/%s`, string(exp), environment.AllocDir, file),
+				"sleep", "1s",
+				"write", string(exp), outPath,
 			},
 		},
 		Resources: basicResources,
 	}
+	testtask.SetTaskEnv(task)
 
 	driverCtx := testDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)
@@ -282,11 +281,12 @@ func TestRawExecDriver_Start_Kill_Wait(t *testing.T) {
 	task := &structs.Task{
 		Name: "sleep",
 		Config: map[string]interface{}{
-			"command": "/bin/sleep",
-			"args":    []string{"1"},
+			"command": testtask.Path(),
+			"args":    []string{"sleep", "1s"},
 		},
 		Resources: basicResources,
 	}
+	testtask.SetTaskEnv(task)
 
 	driverCtx := testDriverContext(task.Name)
 	ctx := testDriverExecContext(task, driverCtx)

--- a/client/driver/raw_exec_test.go
+++ b/client/driver/raw_exec_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestRawExecDriver_Fingerprint(t *testing.T) {
+	t.Parallel()
 	d := NewRawExecDriver(testDriverContext(""))
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -51,6 +52,7 @@ func TestRawExecDriver_Fingerprint(t *testing.T) {
 }
 
 func TestRawExecDriver_StartOpen_Wait(t *testing.T) {
+	t.Parallel()
 	task := &structs.Task{
 		Name: "sleep",
 		Config: map[string]interface{}{
@@ -91,6 +93,7 @@ func TestRawExecDriver_StartOpen_Wait(t *testing.T) {
 }
 
 func TestRawExecDriver_Start_Artifact_basic(t *testing.T) {
+	t.Parallel()
 	path := testtask.Path()
 	ts := httptest.NewServer(http.FileServer(http.Dir(filepath.Dir(path))))
 	defer ts.Close()
@@ -138,6 +141,7 @@ func TestRawExecDriver_Start_Artifact_basic(t *testing.T) {
 }
 
 func TestRawExecDriver_Start_Artifact_expanded(t *testing.T) {
+	t.Parallel()
 	path := testtask.Path()
 	ts := httptest.NewServer(http.FileServer(http.Dir(filepath.Dir(path))))
 	defer ts.Close()
@@ -185,6 +189,7 @@ func TestRawExecDriver_Start_Artifact_expanded(t *testing.T) {
 }
 
 func TestRawExecDriver_Start_Wait(t *testing.T) {
+	t.Parallel()
 	task := &structs.Task{
 		Name: "sleep",
 		Config: map[string]interface{}{
@@ -226,6 +231,7 @@ func TestRawExecDriver_Start_Wait(t *testing.T) {
 }
 
 func TestRawExecDriver_Start_Wait_AllocDir(t *testing.T) {
+	t.Parallel()
 	exp := []byte{'w', 'i', 'n'}
 	file := "output.txt"
 	outPath := fmt.Sprintf(`$%s/%s`, environment.AllocDir, file)
@@ -278,6 +284,7 @@ func TestRawExecDriver_Start_Wait_AllocDir(t *testing.T) {
 }
 
 func TestRawExecDriver_Start_Kill_Wait(t *testing.T) {
+	t.Parallel()
 	task := &structs.Task{
 		Name: "sleep",
 		Config: map[string]interface{}{

--- a/client/driver/spawn/spawn_test.go
+++ b/client/driver/spawn/spawn_test.go
@@ -8,39 +8,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/nomad/helper/testtask"
 )
 
 func TestMain(m *testing.M) {
-	switch os.Getenv("TEST_MAIN") {
-	case "app":
-		appMain()
-	default:
+	if !testtask.Run() {
 		os.Exit(m.Run())
-	}
-}
-
-func appMain() {
-	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "no command provided")
-		os.Exit(1)
-	}
-	switch cmd := os.Args[1]; cmd {
-	case "echo":
-		fmt.Println(strings.Join(os.Args[2:], " "))
-	case "sleep":
-		if len(os.Args) != 3 {
-			fmt.Fprintln(os.Stderr, "expected 3 args")
-			os.Exit(1)
-		}
-		dur, err := time.ParseDuration(os.Args[2])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "could not parse sleep time: %v", err)
-			os.Exit(1)
-		}
-		time.Sleep(dur)
-	default:
-		fmt.Fprintln(os.Stderr, "unknown command:", cmd)
-		os.Exit(1)
 	}
 }
 
@@ -355,7 +329,7 @@ func tempFileName(t *testing.T) string {
 }
 
 func testCommand(args ...string) *exec.Cmd {
-	cmd := exec.Command(os.Args[0], args...)
-	cmd.Env = append(os.Environ(), "TEST_MAIN=app")
+	cmd := exec.Command(testtask.Path(), args...)
+	testtask.SetEnv(cmd)
 	return cmd
 }

--- a/client/driver/spawn/spawn_test.go
+++ b/client/driver/spawn/spawn_test.go
@@ -330,6 +330,6 @@ func tempFileName(t *testing.T) string {
 
 func testCommand(args ...string) *exec.Cmd {
 	cmd := exec.Command(testtask.Path(), args...)
-	testtask.SetEnv(cmd)
+	testtask.SetCmdEnv(cmd)
 	return cmd
 }

--- a/helper/testtask/testtask.go
+++ b/helper/testtask/testtask.go
@@ -1,0 +1,101 @@
+// Package testtask implements a portable set of commands useful as stand-ins
+// for user tasks.
+package testtask
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/kardianos/osext"
+)
+
+// Path returns the path to the currently running executable.
+func Path() string {
+	path, err := osext.Executable()
+	if err != nil {
+		panic(err)
+	}
+	return path
+}
+
+// SetEnv configures the environment of cmd so that Run executes a testtask
+// script when called from within cmd when executed.
+func SetEnv(cmd *exec.Cmd) {
+	cmd.Env = append(os.Environ(), "TEST_TASK=execute")
+}
+
+// Run interprets os.Args as a testtask script if the current program was
+// launched with an environment configured by SetEnv. It returns false if
+// the environment was not set by this package.
+func Run() bool {
+	switch tm := os.Getenv("TEST_TASK"); tm {
+	case "":
+		return false
+	case "execute":
+		execute()
+		return true
+	default:
+		fmt.Fprintf(os.Stderr, "unexpected value for TEST_TASK, \"%s\"\n", tm)
+		os.Exit(1)
+		return true
+	}
+}
+
+func execute() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "no command provided")
+		os.Exit(1)
+	}
+
+	args := os.Args[1:]
+
+	// popArg removes the first argument from args and returns it.
+	popArg := func() string {
+		s := args[0]
+		args = args[1:]
+		return s
+	}
+
+	// execute a sequence of operations from args
+	for len(args) > 0 {
+		switch cmd := popArg(); cmd {
+
+		case "sleep":
+			// sleep <dur>: sleep for a duration indicated by the first
+			// argument
+			if len(args) < 1 {
+				fmt.Fprintln(os.Stderr, "expected arg for sleep")
+				os.Exit(1)
+			}
+			dur, err := time.ParseDuration(popArg())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "could not parse sleep time: %v", err)
+				os.Exit(1)
+			}
+			time.Sleep(dur)
+
+		case "echo":
+			// echo <msg>: write the msg followed by a newline to stdout.
+			fmt.Println(popArg())
+
+		case "write":
+			// write <msg> <file>: write a message to a file. The first
+			// argument is the msg. The second argument is the path to the
+			// target file.
+			if len(args) < 2 {
+				fmt.Fprintln(os.Stderr, "expected two args for write")
+				os.Exit(1)
+			}
+			msg := popArg()
+			file := popArg()
+			ioutil.WriteFile(file, []byte(msg), 0666)
+
+		default:
+			fmt.Fprintln(os.Stderr, "unknown command:", cmd)
+			os.Exit(1)
+		}
+	}
+}

--- a/helper/testtask/testtask.go
+++ b/helper/testtask/testtask.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/kardianos/osext"
 )
 
@@ -21,15 +22,24 @@ func Path() string {
 	return path
 }
 
-// SetEnv configures the environment of cmd so that Run executes a testtask
-// script when called from within cmd when executed.
-func SetEnv(cmd *exec.Cmd) {
+// SetCmdEnv configures the environment of cmd so that Run executes a testtask
+// script when called from within cmd.
+func SetCmdEnv(cmd *exec.Cmd) {
 	cmd.Env = append(os.Environ(), "TEST_TASK=execute")
 }
 
+// SetTaskEnv configures the environment of t so that Run executes a testtask
+// script when called from within t.
+func SetTaskEnv(t *structs.Task) {
+	if t.Env == nil {
+		t.Env = map[string]string{}
+	}
+	t.Env["TEST_TASK"] = "execute"
+}
+
 // Run interprets os.Args as a testtask script if the current program was
-// launched with an environment configured by SetEnv. It returns false if
-// the environment was not set by this package.
+// launched with an environment configured by SetCmdEnv or SetTaskEnv. It
+// returns false if the environment was not set by this package.
 func Run() bool {
 	switch tm := os.Getenv("TEST_TASK"); tm {
 	case "":


### PR DESCRIPTION
This pull request includes the following changes:

* Factor out the portable test task code into package helper/testtask and use it to test the client/driver/... packages.
* Revert the recent addition of test specific code to `LinuxExecutor` in favor of appending to `executor.chrootEnv` in `exec_linux_test.go`.
* Run more tests in parallel.

With this PR tests for package client/driver pass on Windows.