### PR TITLE
nomad: shrink the recv buffer of idle streams

### DIFF
--- a/nomad/pool.go
+++ b/nomad/pool.go
@@ -89,6 +89,12 @@ func (c *Conn) returnClient(client *StreamClient) {
 	if c.clients.Len() < c.pool.maxStreams && atomic.LoadInt32(&c.shouldClose) == 0 {
 		c.clients.PushFront(client)
 		didSave = true
+
+		// If this is a Yamux stream, shrink the internal buffers so that
+		// we can GC the idle memory
+		if ys, ok := client.stream.(*yamux.Stream); ok {
+			ys.Shrink()
+		}
 	}
 	c.clientLock.Unlock()
 	if !didSave {


### PR DESCRIPTION
Shrink idle yamux streams in the connection pool to reduce memory overhead. Otherwise, each stream may allocate up to 512KB of buffers, and we may have up to 64 idle streams per remote peer.

/cc: @diptanu @dadgar 

Depends on https://github.com/hashicorp/yamux/pull/21