### PR TITLE
Fixed git vet error on formatting

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -309,7 +309,7 @@ func (c *ConsulService) deregisterService(serviceId string) error {
 // makeCheck creates a Consul Check Registration struct
 func (c *ConsulService) makeCheck(service *structs.Service, check *structs.ServiceCheck, ip string, port int) *consul.AgentCheckRegistration {
 	if check.Name == "" {
-		check.Name = fmt.Sprintf("service: %q%s%q check", service.Name)
+		check.Name = fmt.Sprintf("service: %s check", service.Name)
 	}
 	check.Id = check.Hash(service.Id)
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -48,8 +48,9 @@ func TestJobEndpoint_Register(t *testing.T) {
 		t.Fatalf("index mis-match")
 	}
 	serviceName := out.TaskGroups[0].Tasks[0].Services[0].Name
-	if serviceName != "web-frontend" {
-		t.Fatalf("Expected Service Name: %s, Actual: %s", serviceName)
+	exptectedServiceName := "web-frontend"
+	if serviceName != expectedServiceName {
+		t.Fatalf("Expected Service Name: %s, Actual: %s", expectedServiceName, serviceName)
 	}
 
 	// Lookup the evaluation

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -48,7 +48,7 @@ func TestJobEndpoint_Register(t *testing.T) {
 		t.Fatalf("index mis-match")
 	}
 	serviceName := out.TaskGroups[0].Tasks[0].Services[0].Name
-	exptectedServiceName := "web-frontend"
+	expectedServiceName := "web-frontend"
 	if serviceName != expectedServiceName {
 		t.Fatalf("Expected Service Name: %s, Actual: %s", expectedServiceName, serviceName)
 	}


### PR DESCRIPTION
`make test` fails with `go tool vet` command. It's due to non-existing arguments of Sprintf and Fatalf. 