### PR TITLE
Bump Nomad version to 0.2.1 in demo Vagrantfile

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ sudo apt-get install -y unzip curl wget vim
 # Download Nomad
 echo Fetching Nomad...
 cd /tmp/
-curl -sSL https://releases.hashicorp.com/nomad/0.2.0/nomad_0.2.0_linux_amd64.zip -o nomad.zip
+curl -sSL https://releases.hashicorp.com/nomad/0.2.1/nomad_0.2.1_linux_amd64.zip -o nomad.zip
 
 echo Installing Nomad...
 unzip nomad.zip

--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -16,7 +16,7 @@ unzip nomad.zip
 sudo chmod +x nomad
 sudo mv nomad /usr/bin/nomad
 
-sudo mkdir /etc/nomad.d
+sudo mkdir -p /etc/nomad.d
 sudo chmod a+w /etc/nomad.d
 
 SCRIPT


### PR DESCRIPTION
* Bump Nomad version to 0.2.1 in demo Vagrantfile
* Make demo Vagrantfile idempotent. There should be `mkdir -p` to avoid failure if `/etc/nomad.d` already exists.