### PR TITLE
agent: apply merges for atlas config

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -358,6 +358,14 @@ func (a *Config) Merge(b *Config) *Config {
 		result.AdvertiseAddrs = result.AdvertiseAddrs.Merge(b.AdvertiseAddrs)
 	}
 
+	// Apply the Atlas configuration
+	if result.Atlas == nil && b.Atlas != nil {
+		atlasConfig := *b.Atlas
+		result.Atlas = &atlasConfig
+	} else if b.Atlas != nil {
+		result.Atlas = result.Atlas.Merge(b.Atlas)
+	}
+
 	return &result
 }
 
@@ -495,6 +503,25 @@ func (a *AdvertiseAddrs) Merge(b *AdvertiseAddrs) *AdvertiseAddrs {
 	}
 	if b.Serf != "" {
 		result.Serf = b.Serf
+	}
+	return &result
+}
+
+// Merge merges two Atlas configurations together.
+func (a *AtlasConfig) Merge(b *AtlasConfig) *AtlasConfig {
+	var result AtlasConfig = *a
+
+	if b.Infrastructure != "" {
+		result.Infrastructure = b.Infrastructure
+	}
+	if b.Token != "" {
+		result.Token = b.Token
+	}
+	if b.Join {
+		result.Join = true
+	}
+	if b.Endpoint != "" {
+		result.Endpoint = b.Endpoint
 	}
 	return &result
 }

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -63,6 +63,12 @@ func TestConfig_Merge(t *testing.T) {
 			RPC:  "127.0.0.1",
 			Serf: "127.0.0.1",
 		},
+		Atlas: &AtlasConfig{
+			Infrastructure: "hashicorp/test1",
+			Token:          "abc",
+			Join:           false,
+			Endpoint:       "foo",
+		},
 	}
 
 	c2 := &Config{
@@ -122,6 +128,12 @@ func TestConfig_Merge(t *testing.T) {
 		AdvertiseAddrs: &AdvertiseAddrs{
 			RPC:  "127.0.0.2",
 			Serf: "127.0.0.2",
+		},
+		Atlas: &AtlasConfig{
+			Infrastructure: "hashicorp/test2",
+			Token:          "xyz",
+			Join:           true,
+			Endpoint:       "bar",
 		},
 	}
 


### PR DESCRIPTION
Adds missing config merges for the Atlas configuration. Needed to allow configuring the SCADA provider for Atlas.