### PR TITLE
Add Periodic config to job

### DIFF
--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -675,7 +675,7 @@ func parseUpdate(result *structs.UpdateStrategy, list *ast.ObjectList) error {
 	return dec.Decode(m)
 }
 
-func parsePeriodic(result *structs.PeriodicConfig, list *ast.ObjectList) error {
+func parsePeriodic(result **structs.PeriodicConfig, list *ast.ObjectList) error {
 	list = list.Elem()
 	if len(list.Items) > 1 {
 		return fmt.Errorf("only one 'periodic' block allowed per job")
@@ -711,6 +711,6 @@ func parsePeriodic(result *structs.PeriodicConfig, list *ast.ObjectList) error {
 	if err := mapstructure.WeakDecode(m, &p); err != nil {
 		return err
 	}
-	*result = p
+	*result = &p
 	return nil
 }

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -232,6 +232,23 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			"periodic-cron.hcl",
+			&structs.Job{
+				ID:       "foo",
+				Name:     "foo",
+				Priority: 50,
+				Region:   "global",
+				Type:     "service",
+				Periodic: structs.PeriodicConfig{
+					Enabled:  true,
+					SpecType: structs.PeriodicSpecCron,
+					Spec:     "*/5 * * *",
+				},
+			},
+			false,
+		},
+
+		{
 			"specify-job.hcl",
 			&structs.Job{
 				ID:       "job1",

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -239,7 +239,7 @@ func TestParse(t *testing.T) {
 				Priority: 50,
 				Region:   "global",
 				Type:     "service",
-				Periodic: structs.PeriodicConfig{
+				Periodic: &structs.PeriodicConfig{
 					Enabled:  true,
 					SpecType: structs.PeriodicSpecCron,
 					Spec:     "*/5 * * *",

--- a/jobspec/test-fixtures/periodic-cron.hcl
+++ b/jobspec/test-fixtures/periodic-cron.hcl
@@ -1,0 +1,5 @@
+job "foo" {
+    periodic {
+        cron_spec = "*/5 * * *"
+    }
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gorhill/cronexpr"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-version"
@@ -760,6 +761,9 @@ type Job struct {
 	// Update is used to control the update strategy
 	Update UpdateStrategy
 
+	// Periodic is used to define the interval the job is run at.
+	Periodic PeriodicConfig
+
 	// Meta is used to associate arbitrary metadata with this
 	// job. This is opaque to Nomad.
 	Meta map[string]string
@@ -841,6 +845,13 @@ func (j *Job) Validate() error {
 			mErr.Errors = append(mErr.Errors, outer)
 		}
 	}
+
+	// Validate periodic is only used with batch jobs.
+	if j.Periodic.Enabled && j.Type != JobTypeBatch {
+		mErr.Errors = append(mErr.Errors,
+			fmt.Errorf("Periodic can only be used with %q scheduler", JobTypeBatch))
+	}
+
 	return mErr.ErrorOrNil()
 }
 
@@ -893,6 +904,61 @@ type UpdateStrategy struct {
 // Rolling returns if a rolling strategy should be used
 func (u *UpdateStrategy) Rolling() bool {
 	return u.Stagger > 0 && u.MaxParallel > 0
+}
+
+const (
+	// PeriodicSpecCron is used for a cron spec.
+	PeriodicSpecCron = "cron"
+)
+
+// Periodic defines the interval a job should be run at.
+type PeriodicConfig struct {
+	// Enabled determines if the job should be run periodically.
+	Enabled bool
+
+	// Spec specifies the interval the job should be run as. It is parsed based
+	// on the SpecType.
+	Spec string
+
+	// SpecType defines the format of the spec.
+	SpecType string
+}
+
+func (p *PeriodicConfig) Validate() error {
+	if !p.Enabled {
+		return nil
+	}
+
+	if p.SpecType == "" {
+		return fmt.Errorf("Must specify a spec type to be able to parse the interval")
+	}
+
+	switch p.SpecType {
+	case PeriodicSpecCron:
+		// Validate the cron spec
+		if _, err := cronexpr.Parse(p.Spec); err != nil {
+			return fmt.Errorf("Invalid cron spec %q: %v", p.Spec, err)
+		}
+	default:
+		return fmt.Errorf("Unknown specification type %q", p.SpecType)
+	}
+
+	return nil
+}
+
+// Next returns the closest time instant matching the spec that is after the
+// passed time. If no matching instance exists, the zero value of time.Time is
+// returned. The `time.Location` of the returned value matches that of the
+// passed time.
+func (p *PeriodicConfig) Next(fromTime time.Time) time.Time {
+	switch p.SpecType {
+	case PeriodicSpecCron:
+		if e, err := cronexpr.Parse(p.Spec); err == nil {
+			return e.Next(fromTime)
+		}
+	}
+
+	return time.Time{}
 }
 
 // RestartPolicy influences how Nomad restarts Tasks when they

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -929,8 +929,8 @@ func (p *PeriodicConfig) Validate() error {
 		return nil
 	}
 
-	if p.SpecType == "" {
-		return fmt.Errorf("Must specify a spec type to be able to parse the interval")
+	if p.Spec == "" {
+		return fmt.Errorf("Must specify a spec")
 	}
 
 	switch p.SpecType {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -762,7 +762,7 @@ type Job struct {
 	Update UpdateStrategy
 
 	// Periodic is used to define the interval the job is run at.
-	Periodic PeriodicConfig
+	Periodic *PeriodicConfig
 
 	// Meta is used to associate arbitrary metadata with this
 	// job. This is opaque to Nomad.
@@ -847,7 +847,7 @@ func (j *Job) Validate() error {
 	}
 
 	// Validate periodic is only used with batch jobs.
-	if j.Periodic.Enabled && j.Type != JobTypeBatch {
+	if j.Periodic != nil && j.Periodic.Enabled && j.Type != JobTypeBatch {
 		mErr.Errors = append(mErr.Errors,
 			fmt.Errorf("Periodic can only be used with %q scheduler", JobTypeBatch))
 	}
@@ -877,6 +877,11 @@ func (j *Job) Stub() *JobListStub {
 		CreateIndex:       j.CreateIndex,
 		ModifyIndex:       j.ModifyIndex,
 	}
+}
+
+// IsPeriodic returns whether a job is periodic.
+func (j *Job) IsPeriodic() bool {
+	return j.Periodic != nil
 }
 
 // JobListStub is used to return a subset of job information

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -37,7 +37,7 @@ func TestJob_Validate(t *testing.T) {
 
 	j = &Job{
 		Type: JobTypeService,
-		Periodic: PeriodicConfig{
+		Periodic: &PeriodicConfig{
 			Enabled: true,
 		},
 	}
@@ -90,6 +90,25 @@ func TestJob_Validate(t *testing.T) {
 	}
 	if !strings.Contains(mErr.Errors[2].Error(), "Task group 1 validation failed") {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestJob_IsPeriodic(t *testing.T) {
+	j := &Job{
+		Type: JobTypeService,
+		Periodic: &PeriodicConfig{
+			Enabled: true,
+		},
+	}
+	if !j.IsPeriodic() {
+		t.Fatalf("IsPeriodic() returned false on periodic job")
+	}
+
+	j = &Job{
+		Type: JobTypeService,
+	}
+	if j.IsPeriodic() {
+		t.Fatalf("IsPeriodic() returned true on non-periodic job")
 	}
 }
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1,11 +1,12 @@
 package structs
 
 import (
-	"github.com/hashicorp/go-multierror"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 func TestJob_Validate(t *testing.T) {
@@ -31,6 +32,18 @@ func TestJob_Validate(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if !strings.Contains(mErr.Errors[6].Error(), "task groups") {
+		t.Fatalf("err: %s", err)
+	}
+
+	j = &Job{
+		Type: JobTypeService,
+		Periodic: PeriodicConfig{
+			Enabled: true,
+		},
+	}
+	err = j.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Error(), "Periodic") {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -487,4 +500,57 @@ func TestJob_ExpandServiceNames(t *testing.T) {
 		t.Fatalf("Expected Service Name: %s, Actual: %s", "jmx", service2Name)
 	}
 
+}
+
+func TestPeriodicConfig_EnabledInvalid(t *testing.T) {
+	// Create a config that is enabled but with no interval specified.
+	p := &PeriodicConfig{Enabled: true}
+	if err := p.Validate(); err == nil {
+		t.Fatal("Enabled PeriodicConfig with no spec or type shouldn't be valid")
+	}
+
+	// Create a config that is enabled, with a spec but no type specified.
+	p = &PeriodicConfig{Enabled: true, Spec: "foo"}
+	if err := p.Validate(); err == nil {
+		t.Fatal("Enabled PeriodicConfig with no spec type shouldn't be valid")
+	}
+
+	// Create a config that is enabled, with a spec type but no spec specified.
+	p = &PeriodicConfig{Enabled: true, SpecType: PeriodicSpecCron}
+	if err := p.Validate(); err == nil {
+		t.Fatal("Enabled PeriodicConfig with no spec shouldn't be valid")
+	}
+}
+
+func TestPeriodicConfig_InvalidCron(t *testing.T) {
+	specs := []string{"foo", "* *", "@foo"}
+	for _, spec := range specs {
+		p := &PeriodicConfig{Enabled: true, SpecType: PeriodicSpecCron, Spec: spec}
+		if err := p.Validate(); err == nil {
+			t.Fatal("Invalid cron spec")
+		}
+	}
+}
+
+func TestPeriodicConfig_ValidCron(t *testing.T) {
+	specs := []string{"0 0 29 2 *", "@hourly", "0 0-15 * * *"}
+	for _, spec := range specs {
+		p := &PeriodicConfig{Enabled: true, SpecType: PeriodicSpecCron, Spec: spec}
+		if err := p.Validate(); err != nil {
+			t.Fatal("Passed valid cron")
+		}
+	}
+}
+
+func TestPeriodicConfig_NextCron(t *testing.T) {
+	from := time.Date(2009, time.November, 10, 23, 22, 30, 0, time.UTC)
+	specs := []string{"0 0 29 2 * 1980", "*/5 * * * *"}
+	expected := []time.Time{time.Time{}, time.Date(2009, time.November, 10, 23, 25, 0, 0, time.UTC)}
+	for i, spec := range specs {
+		p := &PeriodicConfig{Enabled: true, SpecType: PeriodicSpecCron, Spec: spec}
+		n := p.Next(from)
+		if expected[i] != n {
+			t.Fatalf("Next(%v) returned %v; want %v", from, n, expected[i])
+		}
+	}
 }


### PR DESCRIPTION
This PR adds:

* `PeriodicConfig` struct to the `Job` struct
* HCL parsing of the "periodic" block

Currently the only supported spec type is cron style, but the implementation is such that additional interval specifications can be added easily. 