### PR TITLE
command/agent: fix tests on Windows

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -257,11 +257,27 @@ func DefaultConfig() *Config {
 	}
 }
 
-// GetListener can be used to get a new listener using a custom bind address.
+// Listener can be used to get a new listener using a custom bind address.
 // If the bind provided address is empty, the BindAddr is used instead.
 func (c *Config) Listener(proto, addr string, port int) (net.Listener, error) {
 	if addr == "" {
 		addr = c.BindAddr
+	}
+
+	// Do our own range check to avoid bugs in package net.
+	//
+	//   golang.org/issue/11715
+	//   golang.org/issue/13447
+	//
+	// Both of the above bugs were fixed by golang.org/cl/12447 which will be
+	// included in Go 1.6. The error returned below is the same as what Go 1.6
+	// will return.
+	if 0 > port || port > 65535 {
+		return nil, &net.OpError{
+			Op:  "listen",
+			Net: proto,
+			Err: &net.AddrError{Err: "invalid port", Addr: fmt.Sprint(port)},
+		}
 	}
 	return net.Listen(proto, fmt.Sprintf("%s:%d", addr, port))
 }

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -292,13 +292,16 @@ func TestConfig_Listener(t *testing.T) {
 	config := DefaultConfig()
 
 	// Fails on invalid input
-	if _, err := config.Listener("tcp", "nope", 8080); err == nil {
+	if ln, err := config.Listener("tcp", "nope", 8080); err == nil {
+		ln.Close()
 		t.Fatalf("expected addr error")
 	}
-	if _, err := config.Listener("nope", "127.0.0.1", 8080); err == nil {
+	if ln, err := config.Listener("nope", "127.0.0.1", 8080); err == nil {
+		ln.Close()
 		t.Fatalf("expected protocol err")
 	}
-	if _, err := config.Listener("tcp", "127.0.0.1", -1); err == nil {
+	if ln, err := config.Listener("tcp", "127.0.0.1", -1); err == nil {
+		ln.Close()
 		t.Fatalf("expected port error")
 	}
 


### PR DESCRIPTION
`TestConfig_Listener` was failing on Windows due to https://github.com/golang/go/issues/13447. That issue was fixed by https://github.com/golang/go/commit/b50b21d3e130cf19de99c2736d038b636dde75c3, which will be included in Go 1.6.

This PR replicates the behavior of Go 1.6.