### PR TITLE
Add cluster join command line options and configuration options

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -109,7 +109,7 @@ func (c *Command) readConfig() *Config {
 	if cmdConfig.Server.RetryInterval != "" {
 		dur, err := time.ParseDuration(cmdConfig.Server.RetryInterval)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error parsing retry interval: %s", err))
 			return nil
 		}
 		cmdConfig.Server.retryInterval = dur

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -278,9 +278,11 @@ func DefaultConfig() *Config {
 			NetworkSpeed: 100,
 		},
 		Server: &ServerConfig{
-			Enabled:   false,
-			StartJoin: []string{},
-			RetryJoin: []string{},
+			Enabled:          false,
+			StartJoin:        []string{},
+			RetryJoin:        []string{},
+			RetryInterval:    30 * time.Second,
+			RetryMaxAttempts: 0,
 		},
 	}
 }

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -388,6 +388,14 @@ func (a *Config) Merge(b *Config) *Config {
 		result.AdvertiseAddrs = result.AdvertiseAddrs.Merge(b.AdvertiseAddrs)
 	}
 
+	// Apply the Atlas configuration
+	if result.Atlas == nil && b.Atlas != nil {
+		atlasConfig := *b.Atlas
+		result.Atlas = &atlasConfig
+	} else if b.Atlas != nil {
+		result.Atlas = result.Atlas.Merge(b.Atlas)
+	}
+
 	return &result
 }
 
@@ -545,6 +553,25 @@ func (a *AdvertiseAddrs) Merge(b *AdvertiseAddrs) *AdvertiseAddrs {
 	}
 	if b.Serf != "" {
 		result.Serf = b.Serf
+	}
+	return &result
+}
+
+// Merge merges two Atlas configurations together.
+func (a *AtlasConfig) Merge(b *AtlasConfig) *AtlasConfig {
+	var result AtlasConfig = *a
+
+	if b.Infrastructure != "" {
+		result.Infrastructure = b.Infrastructure
+	}
+	if b.Token != "" {
+		result.Token = b.Token
+	}
+	if b.Join {
+		result.Join = true
+	}
+	if b.Endpoint != "" {
+		result.Endpoint = b.Endpoint
 	}
 	return &result
 }

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -281,7 +281,7 @@ func DefaultConfig() *Config {
 			Enabled:          false,
 			StartJoin:        []string{},
 			RetryJoin:        []string{},
-			RetryInterval:    30 * time.Second,
+			RetryInterval:    "30s",
 			RetryMaxAttempts: 0,
 		},
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcl"
 	client "github.com/hashicorp/nomad/client/config"
@@ -181,6 +182,31 @@ type ServerConfig struct {
 
 	// NodeGCThreshold contros how "old" a node must be to be collected by GC.
 	NodeGCThreshold string `hcl:"node_gc_threshold"`
+
+	// StartJoin is a list of addresses to attempt to join when the
+	// agent starts. If Serf is unable to communicate with any of these
+	// addresses, then the agent will error and exit.
+	StartJoin []string `hcl:"start_join"`
+
+	// RetryJoin is a list of addresses to join with retry enabled.
+	RetryJoin []string `hcl:"retry_join"`
+
+	// RetryMaxAttempts specifies the maximum number of times to retry joining a
+	// host on startup. This is useful for cases where we know the node will be
+	// online eventually.
+	RetryMaxAttempts int `hcl:"retry_max"`
+
+	// RetryInterval specifies the amount of time to wait in between join
+	// attempts on agent start. The minimum allowed value is 1 second and
+	// the default is 30s.
+	RetryInterval string        `hcl:"retry_interval"`
+	retryInterval time.Duration `hcl:"-"`
+
+	// RejoinAfterLeave controls our interaction with the cluster after leave.
+	// When set to false (default), a leave causes Consul to not rejoin
+	// the cluster until an explicit join is received. If this is set to
+	// true, we ignore the leave, and rejoin the cluster on start.
+	RejoinAfterLeave bool `hcl:"rejoin_after_leave"`
 }
 
 // Telemetry is the telemetry configuration for the server
@@ -252,7 +278,9 @@ func DefaultConfig() *Config {
 			NetworkSpeed: 100,
 		},
 		Server: &ServerConfig{
-			Enabled: false,
+			Enabled:   false,
+			StartJoin: []string{},
+			RetryJoin: []string{},
 		},
 	}
 }
@@ -358,14 +386,6 @@ func (a *Config) Merge(b *Config) *Config {
 		result.AdvertiseAddrs = result.AdvertiseAddrs.Merge(b.AdvertiseAddrs)
 	}
 
-	// Apply the Atlas configuration
-	if result.Atlas == nil && b.Atlas != nil {
-		atlasConfig := *b.Atlas
-		result.Atlas = &atlasConfig
-	} else if b.Atlas != nil {
-		result.Atlas = result.Atlas.Merge(b.Atlas)
-	}
-
 	return &result
 }
 
@@ -391,9 +411,29 @@ func (a *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 	if b.NodeGCThreshold != "" {
 		result.NodeGCThreshold = b.NodeGCThreshold
 	}
+	if b.RetryMaxAttempts != 0 {
+		result.RetryMaxAttempts = b.RetryMaxAttempts
+	}
+	if b.RetryInterval != "" {
+		result.RetryInterval = b.RetryInterval
+		result.retryInterval = b.retryInterval
+	}
+	if b.RejoinAfterLeave {
+		result.RejoinAfterLeave = true
+	}
 
 	// Add the schedulers
 	result.EnabledSchedulers = append(result.EnabledSchedulers, b.EnabledSchedulers...)
+
+	// Copy the start join addresses
+	result.StartJoin = make([]string, 0, len(a.StartJoin)+len(b.StartJoin))
+	result.StartJoin = append(result.StartJoin, a.StartJoin...)
+	result.StartJoin = append(result.StartJoin, b.StartJoin...)
+
+	// Copy the retry join addresses
+	result.RetryJoin = make([]string, 0, len(a.RetryJoin)+len(b.RetryJoin))
+	result.RetryJoin = append(result.RetryJoin, a.RetryJoin...)
+	result.RetryJoin = append(result.RetryJoin, b.RetryJoin...)
 
 	return &result
 }
@@ -503,25 +543,6 @@ func (a *AdvertiseAddrs) Merge(b *AdvertiseAddrs) *AdvertiseAddrs {
 	}
 	if b.Serf != "" {
 		result.Serf = b.Serf
-	}
-	return &result
-}
-
-// Merge merges two Atlas configurations together.
-func (a *AtlasConfig) Merge(b *AtlasConfig) *AtlasConfig {
-	var result AtlasConfig = *a
-
-	if b.Infrastructure != "" {
-		result.Infrastructure = b.Infrastructure
-	}
-	if b.Token != "" {
-		result.Token = b.Token
-	}
-	if b.Join {
-		result.Join = true
-	}
-	if b.Endpoint != "" {
-		result.Endpoint = b.Endpoint
 	}
 	return &result
 }

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -64,6 +64,12 @@ func TestConfig_Merge(t *testing.T) {
 			RPC:  "127.0.0.1",
 			Serf: "127.0.0.1",
 		},
+		Atlas: &AtlasConfig{
+			Infrastructure: "hashicorp/test1",
+			Token:          "abc",
+			Join:           false,
+			Endpoint:       "foo",
+		},
 	}
 
 	c2 := &Config{
@@ -128,6 +134,12 @@ func TestConfig_Merge(t *testing.T) {
 		AdvertiseAddrs: &AdvertiseAddrs{
 			RPC:  "127.0.0.2",
 			Serf: "127.0.0.2",
+		},
+		Atlas: &AtlasConfig{
+			Infrastructure: "hashicorp/test2",
+			Token:          "xyz",
+			Join:           true,
+			Endpoint:       "bar",
 		},
 	}
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -63,12 +64,6 @@ func TestConfig_Merge(t *testing.T) {
 			RPC:  "127.0.0.1",
 			Serf: "127.0.0.1",
 		},
-		Atlas: &AtlasConfig{
-			Infrastructure: "hashicorp/test1",
-			Token:          "abc",
-			Join:           false,
-			Endpoint:       "foo",
-		},
 	}
 
 	c2 := &Config{
@@ -114,6 +109,11 @@ func TestConfig_Merge(t *testing.T) {
 			NumSchedulers:     2,
 			EnabledSchedulers: []string{structs.JobTypeBatch},
 			NodeGCThreshold:   "12h",
+			RejoinAfterLeave:  true,
+			StartJoin:         []string{"1.1.1.1"},
+			RetryJoin:         []string{"1.1.1.1"},
+			RetryInterval:     "10s",
+			retryInterval:     time.Second * 10,
 		},
 		Ports: &Ports{
 			HTTP: 20000,
@@ -128,12 +128,6 @@ func TestConfig_Merge(t *testing.T) {
 		AdvertiseAddrs: &AdvertiseAddrs{
 			RPC:  "127.0.0.2",
 			Serf: "127.0.0.2",
-		},
-		Atlas: &AtlasConfig{
-			Infrastructure: "hashicorp/test2",
-			Token:          "xyz",
-			Join:           true,
-			Endpoint:       "bar",
 		},
 	}
 
@@ -384,6 +378,11 @@ func TestConfig_LoadConfigString(t *testing.T) {
 			NumSchedulers:     2,
 			EnabledSchedulers: []string{"test"},
 			NodeGCThreshold:   "12h",
+			RetryJoin:         []string{"1.1.1.1", "2.2.2.2"},
+			StartJoin:         []string{"1.1.1.1", "2.2.2.2"},
+			RetryInterval:     "15s",
+			RejoinAfterLeave:  true,
+			RetryMaxAttempts:  3,
 		},
 		Telemetry: &Telemetry{
 			StatsiteAddr:    "127.0.0.1:1234",
@@ -457,6 +456,11 @@ server {
 	num_schedulers = 2
 	enabled_schedulers = ["test"]
 	node_gc_threshold = "12h"
+	retry_join = [ "1.1.1.1", "2.2.2.2" ]
+	start_join = [ "1.1.1.1", "2.2.2.2" ]
+	retry_max = 3
+	retry_interval = "15s"
+	rejoin_after_leave = true
 }
 telemetry {
 	statsite_address = "127.0.0.1:1234"

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -177,6 +177,21 @@ configured on client nodes.
     "1.5h" or "25m". Valid time units are "ns", "us" (or "µs"), "ms", "s",
     "m", "h". Controls how long a node must be in a terminal state before it is
     garbage collected and purged from the system.
+  * <a name="_rejoin_after_leave"></a><a href="#_rejoin_after_leave">`rejoin_after_leave`</a> When provided, Nomad will ignore a previous leave and
+    attempt to rejoin the cluster when starting. By default, Nomad treats leave
+    as a permanent intent and does not attempt to join the cluster again when
+    starting. This flag allows the previous state to be used to rejoin the
+    cluster.
+  * <a name="_retry_join"></a><a href="#_retry_join">`retry_join`</a> Similar to [`start_join`](#_start_join) but allows retrying a join
+    if the first attempt fails. This is useful for cases where we know the
+    address will become available eventually.
+  * <a name="_retry_interval"></a><a href="#_retry_interval">`retry_interval`</a> The time to wait between join attempts. Defaults to 30s.
+  * <a name="_retry_max"></a><a href="#_retry_max">`retry_max`</a> The maximum number of join attempts to be made before exiting
+    with a return code of 1. By default, this is set to 0 which is interpreted
+    as infinite retries.
+  * <a name="_start_join"></a><a href="#_start_join">`start_join`</a> An array of strings specifying addresses of nodes to join upon startup.
+    If Nomad is unable to join with any of the specified addresses, agent startup will
+    fail. By default, the agent won't join any nodes when it starts up.
 
 ## Client-specific Options
 
@@ -301,6 +316,8 @@ via CLI arguments. The `agent` command accepts the following arguments:
 * `-dev`: Start the agent in development mode. This enables a pre-configured
   dual-role agent (client + server) which is useful for developing or testing
   Nomad. No other configuration is required to start the agent in this mode.
+* `-join=<address>`: Address of another agent to join upon starting up. This can
+  be specified multiple times to specify multiple agents to join.
 * `-log-level=<level>`: Equivalent to the [log_level](#log_level) config option.
 * `-meta=<key=value>`: Equivalent to the Client [meta](#meta) config option.
 * `-network-interface<interface>`: Equivalent to the Client
@@ -312,6 +329,10 @@ via CLI arguments. The `agent` command accepts the following arguments:
   config option.
 * `-node-id=<uuid>`: Equivalent to the Client [node_id](#node_id) config option.
 * `-region=<region>`: Equivalent to the [region](#region) config option.
+* `-rejoin`: Equivalent to the [rejoin_after_leave](#rejoin_after_leave) config option.
+* `-retry-interval`: Equivalent to the [retry_interval](#retry_interval) config option.
+* `-retry-join`: Similar to `-join` but allows retrying a join if the first attempt fails.
+* `-retry-max`: Similar to the [retry_max](#retry_max) config option.
 * `-server`: Enable server mode on the local agent.
 * `-servers=<host:port>`: Equivalent to the Client [servers](#servers) config
   option.

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -182,7 +182,7 @@ configured on client nodes.
     as a permanent intent and does not attempt to join the cluster again when
     starting. This flag allows the previous state to be used to rejoin the
     cluster.
-  * <a id="retry_join">`retry_join`</a> Similar to [`start_join`](#_start_join) but allows retrying a join
+  * <a id="retry_join">`retry_join`</a> Similar to [`start_join`](#start_join) but allows retrying a join
     if the first attempt fails. This is useful for cases where we know the
     address will become available eventually.
   * <a id="retry_interval">`retry_interval`</a> The time to wait between join attempts. Defaults to 30s.

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -177,19 +177,19 @@ configured on client nodes.
     "1.5h" or "25m". Valid time units are "ns", "us" (or "µs"), "ms", "s",
     "m", "h". Controls how long a node must be in a terminal state before it is
     garbage collected and purged from the system.
-  * <a name="_rejoin_after_leave"></a><a href="#_rejoin_after_leave">`rejoin_after_leave`</a> When provided, Nomad will ignore a previous leave and
+  * <a id="rejoin_after_leave">`rejoin_after_leave`</a> When provided, Nomad will ignore a previous leave and
     attempt to rejoin the cluster when starting. By default, Nomad treats leave
     as a permanent intent and does not attempt to join the cluster again when
     starting. This flag allows the previous state to be used to rejoin the
     cluster.
-  * <a name="_retry_join"></a><a href="#_retry_join">`retry_join`</a> Similar to [`start_join`](#_start_join) but allows retrying a join
+  * <a id="retry_join">`retry_join`</a> Similar to [`start_join`](#_start_join) but allows retrying a join
     if the first attempt fails. This is useful for cases where we know the
     address will become available eventually.
-  * <a name="_retry_interval"></a><a href="#_retry_interval">`retry_interval`</a> The time to wait between join attempts. Defaults to 30s.
-  * <a name="_retry_max"></a><a href="#_retry_max">`retry_max`</a> The maximum number of join attempts to be made before exiting
+  * <a id="retry_interval">`retry_interval`</a> The time to wait between join attempts. Defaults to 30s.
+  * <a id="retry_max">`retry_max`</a> The maximum number of join attempts to be made before exiting
     with a return code of 1. By default, this is set to 0 which is interpreted
     as infinite retries.
-  * <a name="_start_join"></a><a href="#_start_join">`start_join`</a> An array of strings specifying addresses of nodes to join upon startup.
+  * <a id="start_join">`start_join`</a> An array of strings specifying addresses of nodes to join upon startup.
     If Nomad is unable to join with any of the specified addresses, agent startup will
     fail. By default, the agent won't join any nodes when it starts up.
 


### PR DESCRIPTION
* Adds `-rejoin`, `-join`, `-retry-join`, `-retry-max` and `-retry-interval` command line options
* Adds `start_join`, `retry_join`, `retry_max`, `retry_interval` and `rejoin_after_leave` server configuration options