### PR TITLE
Fixes #505

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -44,7 +44,6 @@ gox \
     -arch="${XC_ARCH}" \
     -osarch="!linux/arm !darwin/386" \
     -ldflags "-X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
-    -cgo \
     -output "pkg/{{.OS}}_{{.Arch}}/nomad" \
     .
 


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/421 removed the last piece of CGO dependant code. We can stop building binaries with CGO
enabled.