### PR TITLE
Warn the user when they specify a config file / folder that doesn't add any configuration options

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -133,6 +134,12 @@ func (c *Command) readConfig() *Config {
 			c.Ui.Error(fmt.Sprintf(
 				"Error loading configuration from %s: %s", path, err))
 			return nil
+		}
+
+		// The user asked us to load some config here but we didn't find any,
+		// so we'll complain but continue.
+		if current == nil || reflect.DeepEqual(current, &Config{}) {
+			c.Ui.Warn(fmt.Sprintf("No configuration loaded from %s", path))
 		}
 
 		if config == nil {


### PR DESCRIPTION
This was previously opened as #531. I made some additional changes which I decided to discard because they cause a BC break and also make configuration more complicated.

The warning is less invasive and more operator-friendly since it allows you to specify a config directory in the debian-style service.d pattern which may be initially empty.