### PR TITLE
Use minimum OS specific path.

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -613,7 +613,7 @@ func LoadConfig(path string) (*Config, error) {
 	if fi.IsDir() {
 		return LoadConfigDir(path)
 	}
-	return LoadConfigFile(path)
+	return LoadConfigFile(filepath.Clean(path))
 }
 
 // LoadConfigString is used to parse a config string

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -327,7 +327,7 @@ func TestConfig_LoadConfigsFileOrder(t *testing.T) {
 	config := config1.Merge(config2)
 
 	if !reflect.DeepEqual(config.Files, expected) {
-		t.Errorf("Loaded configs don't match\nExpected\n%+vGot\n%+v\n",
+		t.Errorf("Loaded configs don't match\nwant: %+v\n got: %+v\n",
 			expected, config.Files)
 	}
 }


### PR DESCRIPTION
This change ensures LoadConfig and LoadConfigDir report consistent paths to files and those paths use the appropriate path separator for the target OS. Note that LoadConfigDir constructs paths with filepath.Join, which calls filepath.Clean, which calls filepath.FromSlash.

Without this change TestConfig_LoadConfigsFileOrder was failing on Windows.