### PR TITLE
Remove clock granularity sensitive test assertion.

### DIFF
--- a/api/util_test.go
+++ b/api/util_test.go
@@ -17,9 +17,6 @@ func assertWriteMeta(t *testing.T, wm *WriteMeta) {
 	if wm.LastIndex == 0 {
 		t.Fatalf("bad index: %d", wm.LastIndex)
 	}
-	if wm.RequestTime == 0 {
-		t.Fatalf("bad request time: %d", wm.RequestTime)
-	}
 }
 
 func testJob() *Job {


### PR DESCRIPTION
TestRequestTime already verifies that the request time is properly recorded.

This change should have been part of PR #523.