### PR TITLE
Executors/Linux: Update Executor config struct

### DIFF
--- a/client/driver/executor/exec_linux.go
+++ b/client/driver/executor/exec_linux.go
@@ -345,16 +345,17 @@ func (e *LinuxExecutor) cleanTaskDir() error {
 // cgroup configuration. It returns an error if the resources are invalid.
 func (e *LinuxExecutor) configureCgroups(resources *structs.Resources) error {
 	e.groups = &cgroupConfig.Cgroup{}
+	e.groups.Resources = &cgroupConfig.Resources{}
 	e.groups.Name = structs.GenerateUUID()
 
 	// TODO: verify this is needed for things like network access
-	e.groups.AllowAllDevices = true
+	e.groups.Resources.AllowAllDevices = true
 
 	if resources.MemoryMB > 0 {
 		// Total amount of memory allowed to consume
-		e.groups.Memory = int64(resources.MemoryMB * 1024 * 1024)
+		e.groups.Resources.Memory = int64(resources.MemoryMB * 1024 * 1024)
 		// Disable swap to avoid issues on the machine
-		e.groups.MemorySwap = int64(-1)
+		e.groups.Resources.MemorySwap = int64(-1)
 	}
 
 	if resources.CPU < 2 {
@@ -362,7 +363,7 @@ func (e *LinuxExecutor) configureCgroups(resources *structs.Resources) error {
 	}
 
 	// Set the relative CPU shares for this cgroup.
-	e.groups.CpuShares = int64(resources.CPU)
+	e.groups.Resources.CpuShares = int64(resources.CPU)
 
 	if resources.IOPS != 0 {
 		// Validate it is in an acceptable range.
@@ -370,7 +371,7 @@ func (e *LinuxExecutor) configureCgroups(resources *structs.Resources) error {
 			return fmt.Errorf("resources.IOPS must be between 10 and 1000: %d", resources.IOPS)
 		}
 
-		e.groups.BlkioWeight = uint16(resources.IOPS)
+		e.groups.Resources.BlkioWeight = uint16(resources.IOPS)
 	}
 
 	return nil


### PR DESCRIPTION
**TLDR;** is the `Cgroup` struct got broken into `Cgroup` and a sub `Resources` struct. This PR patches that up

Errors I was getting with `make dev`: 

```
==> Getting dependencies...
# github.com/hashicorp/nomad/client/driver/executor
client/driver/executor/exec_linux.go:351: e.groups.AllowAllDevices undefined (type *configs.Cgroup has no field or method AllowAllDevices)
client/driver/executor/exec_linux.go:355: e.groups.Memory undefined (type *configs.Cgroup has no field or method Memory)
client/driver/executor/exec_linux.go:357: e.groups.MemorySwap undefined (type *configs.Cgroup has no field or method MemorySwap)
client/driver/executor/exec_linux.go:365: e.groups.CpuShares undefined (type *configs.Cgroup has no field or method CpuShares)
client/driver/executor/exec_linux.go:373: e.groups.BlkioWeight undefined (type *configs.Cgroup has no field or method BlkioWeight)
```

It seems that runc made a change, and Nomad's cgroup config struct broke:

- https://github.com/opencontainers/runc/commit/55a49f2110f04a65f4196c0e32ed390e45d486ea#diff-59086fa085b41a95dbb5aaf343f6e4ff
