### PR TITLE
Copy the task states from the client update

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -556,6 +556,7 @@ func (s *StateStore) UpdateAllocFromClient(index uint64, alloc *structs.Allocati
 	// Pull in anything the client is the authority on
 	copyAlloc.ClientStatus = alloc.ClientStatus
 	copyAlloc.ClientDescription = alloc.ClientDescription
+	copyAlloc.TaskStates = alloc.TaskStates
 
 	// Update the modify index
 	copyAlloc.ModifyIndex = index


### PR DESCRIPTION
This fixes a bug where the allocation wasn't being updated properly