### PR TITLE
Moving the de-register once a task moves to DEAD state

### DIFF
--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -236,9 +236,6 @@ func (r *TaskRunner) run() {
 		// Register the services defined by the task with Consil
 		r.consulService.Register(r.task, r.alloc)
 
-		// De-Register the services belonging to the task from consul
-		defer r.consulService.Deregister(r.task, r.alloc)
-
 	OUTER:
 		// Wait for updates
 		for {
@@ -265,6 +262,9 @@ func (r *TaskRunner) run() {
 				destroyed = true
 			}
 		}
+
+		// De-Register the services belonging to the task from consul
+		r.consulService.Deregister(r.task, r.alloc)
 
 		// If the user destroyed the task, we do not attempt to do any restarts.
 		if destroyed {


### PR DESCRIPTION
This PR makes Nomad de-register a service the moment the driver for that task stops watching it. The current implementation was not de-registering services during the time when the Task was sleeping before it was re-started.