### PR TITLE
Throwing an error if ports are not named instead of crashing while parsing a job spec

### DIFF
--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -623,6 +623,9 @@ func parsePorts(networkObj *ast.ObjectList, nw *structs.NetworkResource) error {
 	portsObjList := networkObj.Filter("port")
 	knownPortLabels := make(map[string]bool)
 	for _, port := range portsObjList.Items {
+		if len(port.Keys) == 0 {
+			return fmt.Errorf("Nomad expects ports to be named")
+		}
 		label := port.Keys[0].Token.Value().(string)
 		if !reDynamicPorts.MatchString(label) {
 			return errPortLabel

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -624,7 +624,7 @@ func parsePorts(networkObj *ast.ObjectList, nw *structs.NetworkResource) error {
 	knownPortLabels := make(map[string]bool)
 	for _, port := range portsObjList.Items {
 		if len(port.Keys) == 0 {
-			return fmt.Errorf("Nomad expects ports to be named")
+			return fmt.Errorf("Ports must be named")
 		}
 		label := port.Keys[0].Token.Value().(string)
 		if !reDynamicPorts.MatchString(label) {


### PR DESCRIPTION
Nomad currently panics if ports are not named. This change makes Nomad throw an error instead which might be more comprehendable for an user.

Fixes #603 