### PR TITLE
Include gocov stuff in tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ EXTERNAL_TOOLS=\
 	github.com/tools/godep \
 	github.com/mitchellh/gox \
 	golang.org/x/tools/cmd/cover \
-	golang.org/x/tools/cmd/vet
+	golang.org/x/tools/cmd/vet \
+	github.com/axw/gocov/gocov \
+	gopkg.in/matm/v1/gocov-html
 
 all: test
 


### PR DESCRIPTION
These two tools are used in the `cov` Makefile target, but installing these were not automated. This PR removes the ambiguity where a developer tries to do a `make cov` and finds that the tools are not installed.