### PR TITLE
Add options ipc_mode, pid_mode and uts_mode to docker driver.

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -42,7 +42,10 @@ type DockerDriverConfig struct {
 	ImageName        string              `mapstructure:"image"`              // Container's Image Name
 	Command          string              `mapstructure:"command"`            // The Command/Entrypoint to run when the container starts up
 	Args             []string            `mapstructure:"args"`               // The arguments to the Command/Entrypoint
+	IpcMode          string              `mapstructure:"ipc_mode"`           // The IPC mode of the container - host and none
 	NetworkMode      string              `mapstructure:"network_mode"`       // The network mode of the container - host, net and none
+	PidMode          string              `mapstructure:"pid_mode"`           // The PID mode of the container - host and none
+	UTSMode          string              `mapstructure:"uts_mode"`           // The UTS mode of the container - host and none
 	PortMapRaw       []map[string]int    `mapstructure:"port_map"`           //
 	PortMap          map[string]int      `mapstructure:"-"`                  // A map of host port labels and the ports exposed on the container
 	Privileged       bool                `mapstructure:"privileged"`         // Flag to run the container in priviledged mode
@@ -254,6 +257,30 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task, dri
 	for _, domain := range driverConfig.DNSSearchDomains {
 		hostConfig.DNSSearch = append(hostConfig.DNSSearch, domain)
 	}
+
+	if driverConfig.IpcMode != "" {
+		if !hostPrivileged {
+			return c, fmt.Errorf(`Docker privileged mode is disabled on this Nomad agent, setting ipc mode not allowed`)
+		}
+		d.logger.Printf("[DEBUG] driver.docker: setting ipc mode to %s", driverConfig.IpcMode)
+	}
+	hostConfig.IpcMode = driverConfig.IpcMode
+
+	if driverConfig.PidMode != "" {
+		if !hostPrivileged {
+			return c, fmt.Errorf(`Docker privileged mode is disabled on this Nomad agent, setting pid mode not allowed`)
+		}
+		d.logger.Printf("[DEBUG] driver.docker: setting pid mode to %s", driverConfig.PidMode)
+	}
+	hostConfig.PidMode = driverConfig.PidMode
+
+	if driverConfig.UTSMode != "" {
+		if !hostPrivileged {
+			return c, fmt.Errorf(`Docker privileged mode is disabled on this Nomad agent, setting UTS mode not allowed`)
+		}
+		d.logger.Printf("[DEBUG] driver.docker: setting UTS mode to %s", driverConfig.UTSMode)
+	}
+	hostConfig.UTSMode = driverConfig.UTSMode
 
 	hostConfig.NetworkMode = driverConfig.NetworkMode
 	if hostConfig.NetworkMode == "" {

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -48,6 +48,10 @@ The following options are available for use in the job specification.
   nomad agent and docker daemon to be configured to allow privileged
   containers.
 
+* `pid_mode` - (Optional) `host` or not set (default). et to `host`  Note that this also requires the
+  nomad agent and docker daemon to be configured to allow privileged
+  containers.
+
 * `network_mode` - (Optional) The network mode to be used for the container. In
   order to support userspace networking plugins in Docker 1.9 this accepts any
   value. The default is `bridge`. Other networking modes may not work without
@@ -250,6 +254,9 @@ The `docker` driver has the following host-level configuration options:
   allow containers to use `privileged` mode, which gives the containers full
   access to the host's devices. Note that you must set a similar setting on the
   Docker daemon for this to work.
+  `true` will also allow containers to run with ipc_mode, pid_mode and uts_mode
+  set to `host`, which gives access to the hosts ipc, pid and UTS namespaces
+  respectively.  
 
     cert := d.config.Read("docker.tls.cert")
     key := d.config.Read("docker.tls.key")

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -48,9 +48,20 @@ The following options are available for use in the job specification.
   nomad agent and docker daemon to be configured to allow privileged
   containers.
 
-* `pid_mode` - (Optional) `host` or not set (default). et to `host`  Note that this also requires the
-  nomad agent and docker daemon to be configured to allow privileged
-  containers.
+* `ipc_mode` - (Optional) The IPC mode to be used for the container. The default
+  is `none` for a private IPC namespace. Other values are `host` for sharing
+  the host IPC namespace or the name or id of an existing container. Note that
+  it is not possible to refer to Nomad started Docker containers since their
+  names are not known in advance. Note that setting this option also requires the
+  Nomad agent to be configured to allow privileged containers.
+
+* `pid_mode` - (Optional) `host` or not set (default). Set to `host` to share
+  the PID namespace with the host. Note that this also requires the Nomad agent
+  to be configured to allow privileged containers.
+
+* `uts_mode` - (Optional) `host` or not set (default). Set to `host` to share
+  the UTS namsepce with the host. Note that this also requires the Nomad agent
+  to be configured to allow privileged containers.
 
 * `network_mode` - (Optional) The network mode to be used for the container. In
   order to support userspace networking plugins in Docker 1.9 this accepts any


### PR DESCRIPTION
May only be used if priviliged mode is enabled in driver config.

implements issue #661 