### PR TITLE
Introduce FS API

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -3,7 +3,6 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -426,14 +425,6 @@ func (r *AllocRunner) WaitCh() <-chan struct{} {
 	return r.waitCh
 }
 
-func (r *AllocRunner) FSList(path string) ([]*allocdir.AllocFileInfo, error) {
-	return r.ctx.AllocDir.List(path)
-}
-
-func (r *AllocRunner) FSStat(path string) (*allocdir.AllocFileInfo, error) {
-	return r.ctx.AllocDir.Stat(path)
-}
-
-func (r *AllocRunner) FSReadAt(allocID string, path string, offset int64, limit int64, w io.Writer) error {
-	return r.ctx.AllocDir.ReadAt(allocID, path, offset, limit, w)
+func (r *AllocRunner) GetAllocFS(allocID string) allocdir.AllocDirFS {
+	return r.ctx.AllocDir
 }

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -424,7 +424,3 @@ func (r *AllocRunner) Destroy() {
 func (r *AllocRunner) WaitCh() <-chan struct{} {
 	return r.waitCh
 }
-
-func (r *AllocRunner) GetAllocFS(allocID string) allocdir.AllocDirFS {
-	return r.ctx.AllocDir
-}

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -428,3 +428,7 @@ func (r *AllocRunner) WaitCh() <-chan struct{} {
 func (r *AllocRunner) FSList(path string) ([]*allocdir.AllocFile, error) {
 	return r.ctx.AllocDir.FSList(path)
 }
+
+func (r *AllocRunner) FSStat(path string) (*allocdir.AllocFile, error) {
+	return r.ctx.AllocDir.FSStat(path)
+}

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -424,3 +424,7 @@ func (r *AllocRunner) Destroy() {
 func (r *AllocRunner) WaitCh() <-chan struct{} {
 	return r.waitCh
 }
+
+func (r *AllocRunner) FSList(path string) ([]*allocdir.AllocFile, error) {
+	return r.ctx.AllocDir.FSList(path)
+}

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -426,14 +426,14 @@ func (r *AllocRunner) WaitCh() <-chan struct{} {
 	return r.waitCh
 }
 
-func (r *AllocRunner) FSList(path string) ([]*allocdir.AllocFile, error) {
-	return r.ctx.AllocDir.FSList(path)
+func (r *AllocRunner) FSList(path string) ([]*allocdir.AllocFileInfo, error) {
+	return r.ctx.AllocDir.List(path)
 }
 
-func (r *AllocRunner) FSStat(path string) (*allocdir.AllocFile, error) {
-	return r.ctx.AllocDir.FSStat(path)
+func (r *AllocRunner) FSStat(path string) (*allocdir.AllocFileInfo, error) {
+	return r.ctx.AllocDir.Stat(path)
 }
 
 func (r *AllocRunner) FSReadAt(allocID string, path string, offset int64, limit int64, w io.Writer) error {
-	return r.ctx.AllocDir.FSReadAt(allocID, path, offset, limit, w)
+	return r.ctx.AllocDir.ReadAt(allocID, path, offset, limit, w)
 }

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -431,4 +432,8 @@ func (r *AllocRunner) FSList(path string) ([]*allocdir.AllocFile, error) {
 
 func (r *AllocRunner) FSStat(path string) (*allocdir.AllocFile, error) {
 	return r.ctx.AllocDir.FSStat(path)
+}
+
+func (r *AllocRunner) FSReadAt(allocID string, path string, offset int64, limit int64, w io.Writer) error {
+	return r.ctx.AllocDir.FSReadAt(allocID, path, offset, limit, w)
 }

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -229,6 +229,7 @@ func (d *AllocDir) MountSharedDir(task string) error {
 	return nil
 }
 
+// List returns the list of files at a path relative to the alloc dir
 func (d *AllocDir) List(path string) ([]*AllocFileInfo, error) {
 	p := filepath.Join(d.AllocDir, path)
 	finfos, err := ioutil.ReadDir(p)
@@ -246,6 +247,7 @@ func (d *AllocDir) List(path string) ([]*AllocFileInfo, error) {
 	return files, err
 }
 
+// Stat returns information about the file at path relative to the alloc dir
 func (d *AllocDir) Stat(path string) (*AllocFileInfo, error) {
 	p := filepath.Join(d.AllocDir, path)
 	info, err := os.Stat(p)
@@ -260,16 +262,20 @@ func (d *AllocDir) Stat(path string) (*AllocFileInfo, error) {
 	}, nil
 }
 
+// ReadAt returns a reader  for a file at the path relative to the alloc dir
+//which will read a chunk of bytes at a particular offset
 func (d *AllocDir) ReadAt(path string, offset int64, limit int64) (io.ReadCloser, error) {
 	p := filepath.Join(d.AllocDir, path)
 	f, err := os.Open(p)
 	if err != nil {
 		return nil, err
 	}
-	return &LimitReadCloser{Reader: io.LimitReader(f, limit), Closer: f}, nil
+	return &FileReadCloser{Reader: io.LimitReader(f, limit), Closer: f}, nil
 }
 
-type LimitReadCloser struct {
+// FileReadCloser wraps a LimitReader so that a file is closed once it has been
+// read
+type FileReadCloser struct {
 	io.Reader
 	io.Closer
 }

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -254,15 +254,19 @@ func (d *AllocDir) FSStat(path string) (*AllocFile, error) {
 	}, nil
 }
 
-func (d *AllocDir) FSReadAt(allocID string, path string, offset int64, limit int64) ([]byte, error) {
+func (d *AllocDir) FSReadAt(allocID string, path string, offset int64, limit int64, w io.Writer) error {
+	buf := make([]byte, limit)
 	p := filepath.Join(d.AllocDir, path)
 	f, err := os.Open(p)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	b := make([]byte, limit)
-	f.ReadAt(b, offset)
-	return b, nil
+	n, err := f.ReadAt(buf, offset)
+	if err != nil {
+		return err
+	}
+	w.Write(buf[:n])
+	return nil
 }
 
 func fileCopy(src, dst string, perm os.FileMode) error {

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -241,7 +241,8 @@ func (d *AllocDir) FSList(path string) ([]*AllocFile, error) {
 }
 
 func (d *AllocDir) FSStat(path string) (*AllocFile, error) {
-	info, err := os.Stat(path)
+	p := filepath.Join(d.AllocDir, path)
+	info, err := os.Stat(p)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +252,17 @@ func (d *AllocDir) FSStat(path string) (*AllocFile, error) {
 		Name:  info.Name(),
 		IsDir: info.IsDir(),
 	}, nil
+}
 
+func (d *AllocDir) FSReadAt(allocID string, path string, offset int64, limit int64) ([]byte, error) {
+	p := filepath.Join(d.AllocDir, path)
+	f, err := os.Open(p)
+	if err != nil {
+		return nil, err
+	}
+	b := make([]byte, limit)
+	f.ReadAt(b, offset)
+	return b, nil
 }
 
 func fileCopy(src, dst string, perm os.FileMode) error {

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -227,7 +227,7 @@ func (d *AllocDir) List(path string) ([]*AllocFileInfo, error) {
 	p := filepath.Join(d.AllocDir, path)
 	finfos, err := ioutil.ReadDir(p)
 	if err != nil {
-		return []*AllocFileInfo{}, nil
+		return []*AllocFileInfo{}, err
 	}
 	files := make([]*AllocFileInfo, len(finfos))
 	for idx, info := range finfos {

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -38,12 +38,14 @@ type AllocDir struct {
 	mounted []string
 }
 
+// AllocFileInfo holds information about a file inside the AllocDir
 type AllocFileInfo struct {
 	Name  string
 	IsDir bool
 	Size  int64
 }
 
+// AllocDirFS returns methods which exposes file operations on the alloc dir
 type AllocDirFS interface {
 	List(path string) ([]*AllocFileInfo, error)
 	Stat(path string) (*AllocFileInfo, error)

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -260,6 +260,7 @@ func (d *AllocDir) FSReadAt(allocID string, path string, offset int64, limit int
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	io.Copy(w, io.LimitReader(f, limit))
 	return nil
 }

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -41,6 +41,7 @@ type AllocDir struct {
 type AllocFile struct {
 	Name  string
 	IsDir bool
+	Size  int64
 }
 
 func NewAllocDir(allocDir string) *AllocDir {
@@ -233,9 +234,24 @@ func (d *AllocDir) FSList(path string) ([]*AllocFile, error) {
 		files[idx] = &AllocFile{
 			Name:  info.Name(),
 			IsDir: info.IsDir(),
+			Size:  info.Size(),
 		}
 	}
 	return files, err
+}
+
+func (d *AllocDir) FSStat(path string) (*AllocFile, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AllocFile{
+		Size:  info.Size(),
+		Name:  info.Name(),
+		IsDir: info.IsDir(),
+	}, nil
+
 }
 
 func fileCopy(src, dst string, perm os.FileMode) error {

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -255,15 +255,13 @@ func (d *AllocDir) FSStat(path string) (*AllocFile, error) {
 }
 
 func (d *AllocDir) FSReadAt(allocID string, path string, offset int64, limit int64, w io.Writer) error {
-	buf := make([]byte, limit)
 	p := filepath.Join(d.AllocDir, path)
 	f, err := os.Open(p)
 	if err != nil {
 		return err
 	}
-	n, err := f.ReadAt(buf, offset)
-	w.Write(buf[:n])
-	return err
+	io.Copy(w, io.LimitReader(f, limit))
+	return nil
 }
 
 func fileCopy(src, dst string, perm os.FileMode) error {

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -38,7 +38,7 @@ type AllocDir struct {
 	mounted []string
 }
 
-type AllocFile struct {
+type AllocFileInfo struct {
 	Name  string
 	IsDir bool
 	Size  int64
@@ -223,15 +223,15 @@ func (d *AllocDir) MountSharedDir(task string) error {
 	return nil
 }
 
-func (d *AllocDir) FSList(path string) ([]*AllocFile, error) {
+func (d *AllocDir) List(path string) ([]*AllocFileInfo, error) {
 	p := filepath.Join(d.AllocDir, path)
 	finfos, err := ioutil.ReadDir(p)
 	if err != nil {
-		return []*AllocFile{}, nil
+		return []*AllocFileInfo{}, nil
 	}
-	files := make([]*AllocFile, len(finfos))
+	files := make([]*AllocFileInfo, len(finfos))
 	for idx, info := range finfos {
-		files[idx] = &AllocFile{
+		files[idx] = &AllocFileInfo{
 			Name:  info.Name(),
 			IsDir: info.IsDir(),
 			Size:  info.Size(),
@@ -240,21 +240,21 @@ func (d *AllocDir) FSList(path string) ([]*AllocFile, error) {
 	return files, err
 }
 
-func (d *AllocDir) FSStat(path string) (*AllocFile, error) {
+func (d *AllocDir) Stat(path string) (*AllocFileInfo, error) {
 	p := filepath.Join(d.AllocDir, path)
 	info, err := os.Stat(p)
 	if err != nil {
 		return nil, err
 	}
 
-	return &AllocFile{
+	return &AllocFileInfo{
 		Size:  info.Size(),
 		Name:  info.Name(),
 		IsDir: info.IsDir(),
 	}, nil
 }
 
-func (d *AllocDir) FSReadAt(allocID string, path string, offset int64, limit int64, w io.Writer) error {
+func (d *AllocDir) ReadAt(allocID string, path string, offset int64, limit int64, w io.Writer) error {
 	p := filepath.Join(d.AllocDir, path)
 	f, err := os.Open(p)
 	if err != nil {

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -262,11 +262,8 @@ func (d *AllocDir) FSReadAt(allocID string, path string, offset int64, limit int
 		return err
 	}
 	n, err := f.ReadAt(buf, offset)
-	if err != nil {
-		return err
-	}
 	w.Write(buf[:n])
-	return nil
+	return err
 }
 
 func fileCopy(src, dst string, perm os.FileMode) error {

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -38,6 +38,11 @@ type AllocDir struct {
 	mounted []string
 }
 
+type AllocFile struct {
+	Name  string
+	IsDir bool
+}
+
 func NewAllocDir(allocDir string) *AllocDir {
 	d := &AllocDir{AllocDir: allocDir, TaskDirs: make(map[string]string)}
 	d.SharedDir = filepath.Join(d.AllocDir, SharedAllocName)
@@ -215,6 +220,22 @@ func (d *AllocDir) MountSharedDir(task string) error {
 
 	d.mounted = append(d.mounted, taskLoc)
 	return nil
+}
+
+func (d *AllocDir) FSList(path string) ([]*AllocFile, error) {
+	p := filepath.Join(d.AllocDir, path)
+	finfos, err := ioutil.ReadDir(p)
+	if err != nil {
+		return []*AllocFile{}, nil
+	}
+	files := make([]*AllocFile, len(finfos))
+	for idx, info := range finfos {
+		files[idx] = &AllocFile{
+			Name:  info.Name(),
+			IsDir: info.IsDir(),
+		}
+	}
+	return files, err
 }
 
 func fileCopy(src, dst string, perm os.FileMode) error {

--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -371,8 +372,12 @@ func (c *Client) FSStat(allocID string, path string) (*allocdir.AllocFile, error
 	return ar.FSStat(path)
 }
 
-func (c *Client) FSReadAt(allocID string, path string, offset int64, limit int64) ([]byte, error) {
-	return nil, nil
+func (c *Client) FSReadAt(allocID string, path string, offset int64, limit int64, w io.Writer) error {
+	ar, ok := c.allocs[allocID]
+	if !ok {
+		return fmt.Errorf("alloc not found")
+	}
+	return ar.FSReadAt(allocID, path, offset, limit, w)
 }
 
 // restoreState is used to restore our state from the data dir

--- a/client/client.go
+++ b/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -355,29 +354,13 @@ func (c *Client) Node() *structs.Node {
 	return c.config.Node
 }
 
-func (c *Client) FSList(allocID string, path string) ([]*allocdir.AllocFileInfo, error) {
-	ar, ok := c.allocs[allocID]
-	if !ok {
-		return nil, fmt.Errorf("alloc not present")
-	}
-
-	return ar.FSList(path)
-}
-
-func (c *Client) FSStat(allocID string, path string) (*allocdir.AllocFileInfo, error) {
+func (c *Client) GetAllocFS(allocID string) (allocdir.AllocDirFS, error) {
 	ar, ok := c.allocs[allocID]
 	if !ok {
 		return nil, fmt.Errorf("alloc not found")
 	}
-	return ar.FSStat(path)
-}
+	return ar.GetAllocFS(allocID), nil
 
-func (c *Client) FSReadAt(allocID string, path string, offset int64, limit int64, w io.Writer) error {
-	ar, ok := c.allocs[allocID]
-	if !ok {
-		return fmt.Errorf("alloc not found")
-	}
-	return ar.FSReadAt(allocID, path, offset, limit, w)
 }
 
 // restoreState is used to restore our state from the data dir

--- a/client/client.go
+++ b/client/client.go
@@ -354,12 +354,13 @@ func (c *Client) Node() *structs.Node {
 	return c.config.Node
 }
 
+// GetAllocFS returns the AllocFS interface for the alloc dir of an allocation
 func (c *Client) GetAllocFS(allocID string) (allocdir.AllocDirFS, error) {
 	ar, ok := c.allocs[allocID]
 	if !ok {
 		return nil, fmt.Errorf("alloc not found")
 	}
-	return ar.GetAllocFS(allocID), nil
+	return ar.ctx.AllocDir, nil
 
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/driver"
 	"github.com/hashicorp/nomad/client/fingerprint"
@@ -351,6 +352,15 @@ func (c *Client) Stats() map[string]map[string]string {
 // Node returns the locally registered node
 func (c *Client) Node() *structs.Node {
 	return c.config.Node
+}
+
+func (c *Client) FSList(allocID string, path string) ([]*allocdir.AllocFile, error) {
+	ar, ok := c.allocs[allocID]
+	if !ok {
+		return nil, fmt.Errorf("alloc not present")
+	}
+
+	return ar.FSList(path)
 }
 
 // restoreState is used to restore our state from the data dir

--- a/client/client.go
+++ b/client/client.go
@@ -371,6 +371,10 @@ func (c *Client) FSStat(allocID string, path string) (*allocdir.AllocFile, error
 	return ar.FSStat(path)
 }
 
+func (c *Client) FSReadAt(allocID string, path string, offset int64, limit int64) ([]byte, error) {
+	return nil, nil
+}
+
 // restoreState is used to restore our state from the data dir
 func (c *Client) restoreState() error {
 	if c.config.DevMode {

--- a/client/client.go
+++ b/client/client.go
@@ -363,6 +363,14 @@ func (c *Client) FSList(allocID string, path string) ([]*allocdir.AllocFile, err
 	return ar.FSList(path)
 }
 
+func (c *Client) FSStat(allocID string, path string) (*allocdir.AllocFile, error) {
+	ar, ok := c.allocs[allocID]
+	if !ok {
+		return nil, fmt.Errorf("alloc not found")
+	}
+	return ar.FSStat(path)
+}
+
 // restoreState is used to restore our state from the data dir
 func (c *Client) restoreState() error {
 	if c.config.DevMode {

--- a/client/client.go
+++ b/client/client.go
@@ -355,7 +355,7 @@ func (c *Client) Node() *structs.Node {
 	return c.config.Node
 }
 
-func (c *Client) FSList(allocID string, path string) ([]*allocdir.AllocFile, error) {
+func (c *Client) FSList(allocID string, path string) ([]*allocdir.AllocFileInfo, error) {
 	ar, ok := c.allocs[allocID]
 	if !ok {
 		return nil, fmt.Errorf("alloc not present")
@@ -364,7 +364,7 @@ func (c *Client) FSList(allocID string, path string) ([]*allocdir.AllocFile, err
 	return ar.FSList(path)
 }
 
-func (c *Client) FSStat(allocID string, path string) (*allocdir.AllocFile, error) {
+func (c *Client) FSStat(allocID string, path string) (*allocdir.AllocFileInfo, error) {
 	ar, ok := c.allocs[allocID]
 	if !ok {
 		return nil, fmt.Errorf("alloc not found")

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -29,7 +29,7 @@ func (s *HTTPServer) FileStatRequest(resp http.ResponseWriter, req *http.Request
 	if allocID = strings.TrimPrefix(req.URL.Path, "/v1/client/fs/stat/"); allocID == "" {
 		return nil, allocIDNotPresentErr
 	}
-	if path := req.URL.Query().Get("path"); path == "" {
+	if path = req.URL.Query().Get("path"); path == "" {
 		return nil, fileNameNotPresentErr
 	}
 	return s.agent.client.FSStat(allocID, path)

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func (s *HTTPServer) DirectoryListRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	allocID := strings.TrimPrefix(req.URL.Path, "/v1/client/fs/ls/")
+	path := req.URL.Query().Get("path")
+	if path == "" {
+		path = "/"
+	}
+	if allocID == "" {
+		resp.WriteHeader(http.StatusNotFound)
+		return nil, fmt.Errorf("alloc id not found")
+	}
+	files, err := s.agent.client.FSList(allocID, path)
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func (s *HTTPServer) FileStatRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	return nil, nil
+}
+
+func (s *HTTPServer) FileReadAtRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	return nil, nil
+}

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -8,69 +8,51 @@ import (
 )
 
 func (s *HTTPServer) DirectoryListRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	allocID := strings.TrimPrefix(req.URL.Path, "/v1/client/fs/ls/")
-	path := req.URL.Query().Get("path")
-	if path == "" {
-		path = "/"
-	}
-	if allocID == "" {
-		resp.WriteHeader(http.StatusNotFound)
+	var allocID, path string
+
+	if allocID = strings.TrimPrefix(req.URL.Path, "/v1/client/fs/ls/"); allocID == "" {
 		return nil, fmt.Errorf("alloc id not found")
 	}
-	files, err := s.agent.client.FSList(allocID, path)
-	if err != nil {
-		return nil, err
+	if path = req.URL.Query().Get("path"); path == "" {
+		path = "/"
 	}
-	return files, nil
+	return s.agent.client.FSList(allocID, path)
 }
 
 func (s *HTTPServer) FileStatRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	allocID := strings.TrimPrefix(req.URL.Path, "/v1/client/fs/stat/")
-	path := req.URL.Query().Get("path")
-	if path == "" {
-		resp.WriteHeader(http.StatusNotFound)
-		return nil, fmt.Errorf("must provide a file name")
-	}
-	if allocID == "" {
-		resp.WriteHeader(http.StatusNotFound)
+	var allocID, path string
+
+	if allocID = strings.TrimPrefix(req.URL.Path, "/v1/client/fs/stat/"); allocID == "" {
 		return nil, fmt.Errorf("alloc id not found")
 	}
-	fileInfo, err := s.agent.client.FSStat(allocID, path)
-	if err != nil {
-		return nil, err
+	if path := req.URL.Query().Get("path"); path == "" {
+		return nil, fmt.Errorf("must provide a file name")
 	}
-	return fileInfo, nil
+	return s.agent.client.FSStat(allocID, path)
 }
 
 func (s *HTTPServer) FileReadAtRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	allocID := strings.TrimPrefix(req.URL.Path, "/v1/client/fs/readat/")
-	path := req.URL.Query().Get("path")
-	ofs := req.URL.Query().Get("offset")
-	if ofs == "" {
-		ofs = "0"
-	}
+	var allocID, path string
+	var offset, limit int64
+	var err error
 
-	offset, err := strconv.ParseInt(ofs, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing offset: %v", err)
-	}
-	lim := req.URL.Query().Get("limit")
-	limit, err := strconv.ParseInt(lim, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing limit: %v", err)
-	}
+	q := req.URL.Query()
 
-	if path == "" {
-		resp.WriteHeader(http.StatusNotFound)
+	if allocID = strings.TrimPrefix(req.URL.Path, "/v1/client/fs/readat/"); allocID == "" {
+		return nil, fmt.Errorf("alloc id not found")
+	}
+	if path = q.Get("path"); path == "" {
 		return nil, fmt.Errorf("must provide a file name")
 	}
-	if allocID == "" {
-		resp.WriteHeader(http.StatusNotFound)
-		return nil, fmt.Errorf("alloc id not found")
+
+	if offset, err = strconv.ParseInt(q.Get("offset"), 10, 64); err != nil {
+		return nil, fmt.Errorf("error parsing offset: %v", err)
+	}
+	if limit, err = strconv.ParseInt(q.Get("limit"), 10, 64); err != nil {
+		return nil, fmt.Errorf("error parsing limit: %v", err)
 	}
 	if err = s.agent.client.FSReadAt(allocID, path, offset, limit, resp); err != nil {
 		return nil, err
 	}
 	return nil, nil
-
 }

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -7,11 +7,16 @@ import (
 	"strings"
 )
 
+var (
+	allocIDNotPresentErr  = fmt.Errorf("must provide a valid alloc id")
+	fileNameNotPresentErr = fmt.Errorf("must provide a file name")
+)
+
 func (s *HTTPServer) DirectoryListRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	var allocID, path string
 
 	if allocID = strings.TrimPrefix(req.URL.Path, "/v1/client/fs/ls/"); allocID == "" {
-		return nil, fmt.Errorf("alloc id not found")
+		return nil, allocIDNotPresentErr
 	}
 	if path = req.URL.Query().Get("path"); path == "" {
 		path = "/"
@@ -22,10 +27,10 @@ func (s *HTTPServer) DirectoryListRequest(resp http.ResponseWriter, req *http.Re
 func (s *HTTPServer) FileStatRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	var allocID, path string
 	if allocID = strings.TrimPrefix(req.URL.Path, "/v1/client/fs/stat/"); allocID == "" {
-		return nil, fmt.Errorf("alloc id not found")
+		return nil, allocIDNotPresentErr
 	}
 	if path := req.URL.Query().Get("path"); path == "" {
-		return nil, fmt.Errorf("must provide a file name")
+		return nil, fileNameNotPresentErr
 	}
 	return s.agent.client.FSStat(allocID, path)
 }
@@ -38,10 +43,10 @@ func (s *HTTPServer) FileReadAtRequest(resp http.ResponseWriter, req *http.Reque
 	q := req.URL.Query()
 
 	if allocID = strings.TrimPrefix(req.URL.Path, "/v1/client/fs/readat/"); allocID == "" {
-		return nil, fmt.Errorf("alloc id not found")
+		return nil, allocIDNotPresentErr
 	}
 	if path = q.Get("path"); path == "" {
-		return nil, fmt.Errorf("must provide a file name")
+		return nil, fileNameNotPresentErr
 	}
 
 	if offset, err = strconv.ParseInt(q.Get("offset"), 10, 64); err != nil {

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -21,7 +21,6 @@ func (s *HTTPServer) DirectoryListRequest(resp http.ResponseWriter, req *http.Re
 
 func (s *HTTPServer) FileStatRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	var allocID, path string
-
 	if allocID = strings.TrimPrefix(req.URL.Path, "/v1/client/fs/stat/"); allocID == "" {
 		return nil, fmt.Errorf("alloc id not found")
 	}

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -24,7 +24,21 @@ func (s *HTTPServer) DirectoryListRequest(resp http.ResponseWriter, req *http.Re
 }
 
 func (s *HTTPServer) FileStatRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	return nil, nil
+	allocID := strings.TrimPrefix(req.URL.Path, "/v1/client/fs/ls/")
+	path := req.URL.Query().Get("path")
+	if path == "" {
+		resp.WriteHeader(http.StatusNotFound)
+		return nil, fmt.Errorf("must provide a file name")
+	}
+	if allocID == "" {
+		resp.WriteHeader(http.StatusNotFound)
+		return nil, fmt.Errorf("alloc id not found")
+	}
+	fileInfo, err := s.agent.client.FSStat(allocID, path)
+	if err != nil {
+		return nil, err
+	}
+	return fileInfo, nil
 }
 
 func (s *HTTPServer) FileReadAtRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -24,7 +24,7 @@ func (s *HTTPServer) DirectoryListRequest(resp http.ResponseWriter, req *http.Re
 }
 
 func (s *HTTPServer) FileStatRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	allocID := strings.TrimPrefix(req.URL.Path, "/v1/client/fs/ls/")
+	allocID := strings.TrimPrefix(req.URL.Path, "/v1/client/fs/stat/")
 	path := req.URL.Query().Get("path")
 	if path == "" {
 		resp.WriteHeader(http.StatusNotFound)

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTP_FSDirectoryList(t *testing.T) {
+	httpTest(t, nil, func(s *TestServer) {
+		req, err := http.NewRequest("GET", "/v1/client/fs/ls", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		_, err = s.Server.DirectoryListRequest(respW, req)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestHTTP_FSStat(t *testing.T) {
+	httpTest(t, nil, func(s *TestServer) {
+		req, err := http.NewRequest("GET", "/v1/client/fs/stat/", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		_, err = s.Server.FileStatRequest(respW, req)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+
+		req, err = http.NewRequest("GET", "/v1/client/fs/stat/foo", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW = httptest.NewRecorder()
+
+		_, err = s.Server.FileStatRequest(respW, req)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestHTTP_FSDirectoryList(t *testing.T) {
+func TestAllocDirFS_List(t *testing.T) {
 	httpTest(t, nil, func(s *TestServer) {
 		req, err := http.NewRequest("GET", "/v1/client/fs/ls/", nil)
 		if err != nil {
@@ -21,7 +21,7 @@ func TestHTTP_FSDirectoryList(t *testing.T) {
 	})
 }
 
-func TestHTTP_FSStat(t *testing.T) {
+func TestAllocDirFS_Stat(t *testing.T) {
 	httpTest(t, nil, func(s *TestServer) {
 		req, err := http.NewRequest("GET", "/v1/client/fs/stat/", nil)
 		if err != nil {
@@ -48,7 +48,7 @@ func TestHTTP_FSStat(t *testing.T) {
 	})
 }
 
-func TestHTTP_FSReadAt(t *testing.T) {
+func TestAllocDirFS_ReadAt(t *testing.T) {
 	httpTest(t, nil, func(s *TestServer) {
 		req, err := http.NewRequest("GET", "/v1/client/fs/readat/", nil)
 		if err != nil {

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -3,21 +3,20 @@ package agent
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 )
 
 func TestHTTP_FSDirectoryList(t *testing.T) {
 	httpTest(t, nil, func(s *TestServer) {
-		req, err := http.NewRequest("GET", "/v1/client/fs/ls", nil)
+		req, err := http.NewRequest("GET", "/v1/client/fs/ls/", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
 
 		_, err = s.Server.DirectoryListRequest(respW, req)
-		if err == nil {
-			t.Fatal("expected error")
+		if err != allocIDNotPresentErr {
+			t.Fatalf("expected err: %v, actual: %v", allocIDNotPresentErr, err)
 		}
 	})
 }
@@ -31,8 +30,8 @@ func TestHTTP_FSStat(t *testing.T) {
 		respW := httptest.NewRecorder()
 
 		_, err = s.Server.FileStatRequest(respW, req)
-		if !strings.HasPrefix(err.Error(), "alloc id not found") {
-			t.Fatal("expected error")
+		if err != allocIDNotPresentErr {
+			t.Fatalf("expected err: %v, actual: %v", allocIDNotPresentErr, err)
 		}
 
 		req, err = http.NewRequest("GET", "/v1/client/fs/stat/foo", nil)
@@ -42,9 +41,10 @@ func TestHTTP_FSStat(t *testing.T) {
 		respW = httptest.NewRecorder()
 
 		_, err = s.Server.FileStatRequest(respW, req)
-		if !strings.HasPrefix(err.Error(), "must provide a file name") {
-			t.Fatal("expected error")
+		if err != fileNameNotPresentErr {
+			t.Fatalf("expected err: %v, actual: %v", allocIDNotPresentErr, err)
 		}
+
 	})
 }
 

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -30,7 +31,7 @@ func TestHTTP_FSStat(t *testing.T) {
 		respW := httptest.NewRecorder()
 
 		_, err = s.Server.FileStatRequest(respW, req)
-		if err == nil {
+		if !strings.HasPrefix(err.Error(), "alloc id not found") {
 			t.Fatal("expected error")
 		}
 
@@ -41,6 +42,43 @@ func TestHTTP_FSStat(t *testing.T) {
 		respW = httptest.NewRecorder()
 
 		_, err = s.Server.FileStatRequest(respW, req)
+		if !strings.HasPrefix(err.Error(), "must provide a file name") {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestHTTP_FSReadAt(t *testing.T) {
+	httpTest(t, nil, func(s *TestServer) {
+		req, err := http.NewRequest("GET", "/v1/client/fs/readat/", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		_, err = s.Server.FileReadAtRequest(respW, req)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+
+		req, err = http.NewRequest("GET", "/v1/client/fs/readat/foo", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW = httptest.NewRecorder()
+
+		_, err = s.Server.FileReadAtRequest(respW, req)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+
+		req, err = http.NewRequest("GET", "/v1/client/fs/readat/foo?path=/path/to/file", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW = httptest.NewRecorder()
+
+		_, err = s.Server.FileReadAtRequest(respW, req)
 		if err == nil {
 			t.Fatal("expected error")
 		}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -103,6 +103,10 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/evaluations", s.wrap(s.EvalsRequest))
 	s.mux.HandleFunc("/v1/evaluation/", s.wrap(s.EvalSpecificRequest))
 
+	s.mux.HandleFunc("/v1/client/fs/ls/", s.wrap(s.DirectoryListRequest))
+	s.mux.HandleFunc("/v1/client/fs/stat/", s.wrap(s.FileStatRequest))
+	s.mux.HandleFunc("/v1/client/fs/readat/", s.wrap(s.FileReadAtRequest))
+
 	s.mux.HandleFunc("/v1/agent/self", s.wrap(s.AgentSelfRequest))
 	s.mux.HandleFunc("/v1/agent/join", s.wrap(s.AgentJoinRequest))
 	s.mux.HandleFunc("/v1/agent/members", s.wrap(s.AgentMembersRequest))


### PR DESCRIPTION
The following APIs has been introduced in the client -

```
/v1/client/fs/ls/:alloc-id/?path=/path/relative/to/alloc/dir

/v1/client/fs/stat/:alloc-id/?path=/path/relative/to/alloc/dir

/v1/client/fs/readat/:alloc-id?path=/path/relative/to/alloc/dir&limit=K&offset=N
```

@armon These APIs currently don't do any forwarding because to forward the request, the Agent has to make two API calls to the server, first get the allocation for the alloc id and then another API call to get the node information from the node id of the allocation. So every API call is going to result into two API calls to the server.
Instead, the tools using the APIs could make the two calls to the server to determine the correct addr of the client on which the allocation is running and cache the information. And from there on keep making the API calls to the same client for the allocation. What you think? (It's easy to introduce forwarding if we want)