### PR TITLE
Log Rotator

### DIFF
--- a/client/driver/logs.go
+++ b/client/driver/logs.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	bufSize = 32 * 1024
+	bufSize = 32 * 1024 // Max number of bytes read from a buffer
 )
 
 // LogRotator rotates files for a buffer and retains only the last N rotated

--- a/client/driver/logs.go
+++ b/client/driver/logs.go
@@ -25,7 +25,7 @@ type LogRotator struct {
 	logger *log.Logger
 }
 
-func NewLogRotator(path string, fileName string, maxFiles int, fileSize int64) (*LogRotator, error) {
+func NewLogRotator(path string, fileName string, maxFiles int, fileSize int64, logger *log.Logger) (*LogRotator, error) {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err
@@ -34,10 +34,6 @@ func NewLogRotator(path string, fileName string, maxFiles int, fileSize int64) (
 	logFileIdx := 0
 	for _, f := range files {
 		if strings.HasPrefix(f.Name(), fileName) {
-			if f.IsDir() {
-				logFileIdx += 1
-				continue
-			}
 			fileIdx := strings.TrimPrefix(f.Name(), fmt.Sprintf("%s.", fileName))
 			n, err := strconv.Atoi(fileIdx)
 			if err != nil {
@@ -55,6 +51,7 @@ func NewLogRotator(path string, fileName string, maxFiles int, fileSize int64) (
 		path:       path,
 		fileName:   fileName,
 		logFileIdx: logFileIdx,
+		logger:     logger,
 	}, nil
 }
 

--- a/client/driver/logs.go
+++ b/client/driver/logs.go
@@ -27,6 +27,10 @@ func NewLogRotator(path string, fileName string, maxFiles int, fileSize int64) (
 	logFileIdx := 0
 	for _, f := range files {
 		if strings.HasPrefix(f.Name(), fileName) {
+			if f.IsDir() {
+				logFileIdx += 1
+				continue
+			}
 			fileIdx := strings.TrimPrefix(f.Name(), fmt.Sprintf("%s.", fileName))
 			n, err := strconv.Atoi(fileIdx)
 			if err != nil {
@@ -51,6 +55,12 @@ func (l *LogRotator) Start(r io.Reader) error {
 	buf := make([]byte, 32*1024)
 	for {
 		logFileName := filepath.Join(l.path, fmt.Sprintf("%s.%d", l.fileName, l.logFileIdx))
+		if f, err := os.Stat(logFileName); err == nil {
+			if f.IsDir() {
+				l.logFileIdx += 1
+				continue
+			}
+		}
 		f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		if err != nil {
 			return err

--- a/client/driver/logs.go
+++ b/client/driver/logs.go
@@ -1,0 +1,71 @@
+package driver
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type LogRotator struct {
+	maxFiles   int
+	fileSize   int64
+	path       string
+	fileName   string
+	logFileIdx int
+}
+
+func NewLogRotor(path string, fileName string, maxFiles int, fileSize int64) (*LogRotator, error) {
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	logFileIdx := 0
+	for _, f := range files {
+		if strings.HasPrefix(f.Name(), fileName) {
+			fileIdx := strings.TrimPrefix(f.Name(), fmt.Sprintf("%s.", fileName))
+			n, err := strconv.Atoi(fileIdx)
+			if err != nil {
+				continue
+			}
+			if n > logFileIdx {
+				logFileIdx = n
+			}
+		}
+	}
+
+	return &LogRotator{
+		maxFiles:   maxFiles,
+		fileSize:   fileSize,
+		path:       path,
+		fileName:   fileName,
+		logFileIdx: logFileIdx,
+	}, nil
+}
+
+func (l *LogRotator) Start(r io.Reader) error {
+	for {
+		logFileName := filepath.Join(l.path, fmt.Sprintf("%s.%d", l.fileName, l.logFileIdx))
+		f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 066)
+		if err != nil {
+			return err
+		}
+		remainingSize := l.fileSize
+		if finfo, err := os.Stat(logFileName); err == nil {
+			remainingSize = l.fileSize - finfo.Size()
+		}
+		if remainingSize < 1 {
+			l.logFileIdx = l.logFileIdx + 1
+			continue
+		}
+		if _, err := io.Copy(f, io.LimitReader(r, remainingSize)); err != nil {
+			return err
+		}
+		l.logFileIdx = l.logFileIdx + 1
+	}
+	return nil
+}

--- a/client/driver/logs.go
+++ b/client/driver/logs.go
@@ -65,21 +65,19 @@ func (l *LogRotator) Start(r io.Reader) error {
 	buf := make([]byte, bufSize)
 	for {
 		logFileName := filepath.Join(l.path, fmt.Sprintf("%s.%d", l.fileName, l.logFileIdx))
+		remainingSize := l.fileSize
 		if f, err := os.Stat(logFileName); err == nil {
 			if f.IsDir() {
 				l.logFileIdx += 1
 				continue
 			}
+			remainingSize = l.fileSize - f.Size()
 		}
 		f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		if err != nil {
 			return err
 		}
 		l.logger.Println("[INFO] logrotator: opened a new file: %s", logFileName)
-		remainingSize := l.fileSize
-		if finfo, err := os.Stat(logFileName); err == nil {
-			remainingSize -= finfo.Size()
-		}
 		if remainingSize < 1 {
 			l.logFileIdx = l.logFileIdx + 1
 			f.Close()

--- a/client/driver/logs.go
+++ b/client/driver/logs.go
@@ -35,11 +35,12 @@ func NewLogRotator(path string, fileName string, maxFiles int, fileSize int64, l
 		return nil, err
 	}
 
-	// finding out the log file with the largest index
+	// Finding out the log file with the largest index
 	logFileIdx := 0
+	prefix := fmt.Sprintf("%s.", fileName)
 	for _, f := range files {
-		if strings.HasPrefix(f.Name(), fileName) {
-			fileIdx := strings.TrimPrefix(f.Name(), fmt.Sprintf("%s.", fileName))
+		if strings.HasPrefix(f.Name(), prefix) {
+			fileIdx := strings.TrimPrefix(f.Name(), prefix)
 			n, err := strconv.Atoi(fileIdx)
 			if err != nil {
 				continue
@@ -68,12 +69,12 @@ func (l *LogRotator) Start(r io.Reader) error {
 		logFileName := filepath.Join(l.path, fmt.Sprintf("%s.%d", l.fileName, l.logFileIdx))
 		remainingSize := l.fileSize
 		if f, err := os.Stat(logFileName); err == nil {
-			// skipping the current file if it happens to be a directory
+			// Skipping the current file if it happens to be a directory
 			if f.IsDir() {
 				l.logFileIdx += 1
 				continue
 			}
-			// calculating the remaining capacity of the log file
+			// Calculating the remaining capacity of the log file
 			remainingSize = l.fileSize - f.Size()
 		}
 		f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
@@ -82,14 +83,14 @@ func (l *LogRotator) Start(r io.Reader) error {
 		}
 		l.logger.Printf("[DEBUG] client.logrotator: opened a new file: %s", logFileName)
 
-		// closing the current log file if it doesn't have any more capacity
+		// Closing the current log file if it doesn't have any more capacity
 		if remainingSize <= 0 {
 			l.logFileIdx = l.logFileIdx + 1
 			f.Close()
 			continue
 		}
 
-		// reading from the reader and writing into the current log file as long
+		// Reading from the reader and writing into the current log file as long
 		// as it has capacity or the reader closes
 		for {
 			var nr int
@@ -143,7 +144,7 @@ func (l *LogRotator) PurgeOldFiles() {
 		}
 	}
 
-	// sorting the file indexes so that we can purge the older files and keep
+	// Sorting the file indexes so that we can purge the older files and keep
 	// only the number of files as configured by the user
 	sort.Sort(sort.IntSlice(fIndexes))
 	toDelete := fIndexes[l.maxFiles-1 : len(fIndexes)-1]

--- a/client/driver/logs.go
+++ b/client/driver/logs.go
@@ -81,8 +81,9 @@ func (l *LogRotator) Start(r io.Reader) error {
 			return err
 		}
 		l.logger.Printf("[DEBUG] client.logrotator: opened a new file: %s", logFileName)
+
 		// closing the current log file if it doesn't have any more capacity
-		if remainingSize < 1 {
+		if remainingSize <= 0 {
 			l.logFileIdx = l.logFileIdx + 1
 			f.Close()
 			continue

--- a/client/driver/logs.go
+++ b/client/driver/logs.go
@@ -24,7 +24,7 @@ func NewLogRotor(path string, fileName string, maxFiles int, fileSize int64) (*L
 		return nil, err
 	}
 
-	logFileIdx := 0
+	logFileIdx := 1
 	for _, f := range files {
 		if strings.HasPrefix(f.Name(), fileName) {
 			fileIdx := strings.TrimPrefix(f.Name(), fmt.Sprintf("%s.", fileName))

--- a/client/driver/logs_test.go
+++ b/client/driver/logs_test.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,6 +20,7 @@ func TestLogRotator_FindCorrectIndex(t *testing.T) {
 	if err := os.Mkdir(path, os.ModeDir|os.ModePerm); err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
+	defer os.RemoveAll(path)
 
 	fname := filepath.Join(path, "redis.stdout.1")
 	if f, err := os.Create(fname); err == nil {
@@ -37,4 +39,25 @@ func TestLogRotator_FindCorrectIndex(t *testing.T) {
 	if r.logFileIdx != 2 {
 		t.Fatalf("Expected log file idx: %v, actual: %v", 2, r.logFileIdx)
 	}
+}
+
+func TestLogRotator_AppendToCurrentFile(t *testing.T) {
+	path := "/tmp/tmplogrator"
+	if err := os.Mkdir(path, os.ModeDir|os.ModePerm); err != nil {
+		t.Fatalf("test setup err: %v", err)
+	}
+	defer os.RemoveAll(path)
+	fname := filepath.Join(path, "redis.stdout.1")
+	if f, err := os.Create(fname); err == nil {
+		f.Close()
+	}
+
+	r, err := NewLogRotor(path, "redis.stdout", 10, 10)
+	if err != nil {
+		t.Fatalf("test setup err: %v", err)
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("hello")
+	r.Start(&buf)
 }

--- a/client/driver/logs_test.go
+++ b/client/driver/logs_test.go
@@ -15,10 +15,10 @@ var (
 	path   = "/tmp/logrotator"
 )
 
-func TestLogRotator_IncorrectPath(t *testing.T) {
-	incorrectPath := "/foo"
+func TestLogRotator_InvalidPath(t *testing.T) {
+	invalidPath := "/foo"
 
-	if _, err := NewLogRotator(incorrectPath, "redis.stdout", 10, 10, logger); err == nil {
+	if _, err := NewLogRotator(invalidPath, "redis.stdout", 10, 10, logger); err == nil {
 		t.Fatal("expected err")
 	}
 }

--- a/client/driver/logs_test.go
+++ b/client/driver/logs_test.go
@@ -3,16 +3,21 @@ package driver
 import (
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
+var (
+	logger = log.New(os.Stdout, "", log.LstdFlags)
+)
+
 func TestLogRotator_IncorrectPath(t *testing.T) {
 	incorrectPath := "/foo"
 
-	if _, err := NewLogRotator(incorrectPath, "redis.stdout", 10, 10); err == nil {
+	if _, err := NewLogRotator(incorrectPath, "redis.stdout", 10, 10, logger); err == nil {
 		t.Fatal("expected err")
 	}
 }
@@ -34,7 +39,7 @@ func TestLogRotator_FindCorrectIndex(t *testing.T) {
 		f.Close()
 	}
 
-	r, err := NewLogRotator(path, "redis.stdout", 10, 10)
+	r, err := NewLogRotator(path, "redis.stdout", 10, 10, logger)
 	if err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
@@ -55,7 +60,7 @@ func TestLogRotator_AppendToCurrentFile(t *testing.T) {
 		f.Close()
 	}
 
-	l, err := NewLogRotator(path, "redis.stdout", 10, 6)
+	l, err := NewLogRotator(path, "redis.stdout", 10, 6, logger)
 	if err != nil && err != io.EOF {
 		t.Fatalf("test setup err: %v", err)
 	}
@@ -90,7 +95,7 @@ func TestLogRotator_RotateFiles(t *testing.T) {
 		f.Close()
 	}
 
-	l, err := NewLogRotator(path, "redis.stdout", 10, 6)
+	l, err := NewLogRotator(path, "redis.stdout", 10, 6, logger)
 	if err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
@@ -128,7 +133,7 @@ func TestLogRotator_StartFromEmptyDir(t *testing.T) {
 		t.Fatalf("test setup err: %v", err)
 	}
 
-	l, err := NewLogRotator(path, "redis.stdout", 10, 10)
+	l, err := NewLogRotator(path, "redis.stdout", 10, 10, logger)
 	if err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
@@ -160,7 +165,7 @@ func TestLogRotator_SetPathAsFile(t *testing.T) {
 		t.Fatalf("test setup problem: %v", err)
 	}
 
-	_, err := NewLogRotator(path, "redis.stdout", 10, 10)
+	_, err := NewLogRotator(path, "redis.stdout", 10, 10, logger)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -176,7 +181,7 @@ func TestLogRotator_ExcludeDirs(t *testing.T) {
 		t.Fatalf("test setup err: %v", err)
 	}
 
-	l, err := NewLogRotator(path, "redis.stdout", 10, 6)
+	l, err := NewLogRotator(path, "redis.stdout", 10, 6, logger)
 	if err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}

--- a/client/driver/logs_test.go
+++ b/client/driver/logs_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	logger = log.New(os.Stdout, "", log.LstdFlags)
-	path   = "/tmp/logrotator"
+	logger     = log.New(os.Stdout, "", log.LstdFlags)
+	pathPrefix = "logrotator"
 )
 
 func TestLogRotator_InvalidPath(t *testing.T) {
@@ -24,7 +24,9 @@ func TestLogRotator_InvalidPath(t *testing.T) {
 }
 
 func TestLogRotator_FindCorrectIndex(t *testing.T) {
-	if err := os.Mkdir(path, os.ModeDir|os.ModePerm); err != nil {
+	var path string
+	var err error
+	if path, err = ioutil.TempDir("", pathPrefix); err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
 	defer os.RemoveAll(path)
@@ -49,8 +51,10 @@ func TestLogRotator_FindCorrectIndex(t *testing.T) {
 }
 
 func TestLogRotator_AppendToCurrentFile(t *testing.T) {
+	var path string
+	var err error
 	defer os.RemoveAll(path)
-	if err := os.Mkdir(path, os.ModeDir|os.ModePerm); err != nil {
+	if path, err = ioutil.TempDir("", pathPrefix); err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
 	fname := filepath.Join(path, "redis.stdout.0")
@@ -83,8 +87,10 @@ func TestLogRotator_AppendToCurrentFile(t *testing.T) {
 }
 
 func TestLogRotator_RotateFiles(t *testing.T) {
+	var path string
+	var err error
 	defer os.RemoveAll(path)
-	if err := os.Mkdir(path, os.ModeDir|os.ModePerm); err != nil {
+	if path, err = ioutil.TempDir("", pathPrefix); err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
 	fname := filepath.Join(path, "redis.stdout.0")
@@ -125,8 +131,10 @@ func TestLogRotator_RotateFiles(t *testing.T) {
 }
 
 func TestLogRotator_StartFromEmptyDir(t *testing.T) {
+	var path string
+	var err error
 	defer os.RemoveAll(path)
-	if err := os.Mkdir(path, os.ModeDir|os.ModePerm); err != nil {
+	if path, err = ioutil.TempDir("", pathPrefix); err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
 
@@ -156,20 +164,26 @@ func TestLogRotator_StartFromEmptyDir(t *testing.T) {
 }
 
 func TestLogRotator_SetPathAsFile(t *testing.T) {
+	var f *os.File
+	var err error
+	var path string
 	defer os.RemoveAll(path)
-	if _, err := os.Create(path); err != nil {
+	if f, err = ioutil.TempFile("", pathPrefix); err != nil {
 		t.Fatalf("test setup problem: %v", err)
 	}
 
-	_, err := NewLogRotator(path, "redis.stdout", 10, 10, logger)
-	if err == nil {
+	path = f.Name()
+
+	if _, err = NewLogRotator(f.Name(), "redis.stdout", 10, 10, logger); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
 func TestLogRotator_ExcludeDirs(t *testing.T) {
+	var path string
+	var err error
 	defer os.RemoveAll(path)
-	if err := os.Mkdir(path, os.ModeDir|os.ModePerm); err != nil {
+	if path, err = ioutil.TempDir("", pathPrefix); err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
 	if err := os.Mkdir(filepath.Join(path, "redis.stdout.0"), os.ModeDir|os.ModePerm); err != nil {
@@ -201,8 +215,10 @@ func TestLogRotator_ExcludeDirs(t *testing.T) {
 }
 
 func TestLogRotator_PurgeDirs(t *testing.T) {
+	var path string
+	var err error
 	defer os.RemoveAll(path)
-	if err := os.Mkdir(path, os.ModeDir|os.ModePerm); err != nil {
+	if path, err = ioutil.TempDir("", pathPrefix); err != nil {
 		t.Fatalf("test setup err: %v", err)
 	}
 

--- a/client/driver/logs_test.go
+++ b/client/driver/logs_test.go
@@ -105,6 +105,7 @@ func TestLogRotator_RotateFiles(t *testing.T) {
 
 	r, w := io.Pipe()
 	go func() {
+		// This should make the current log file rotate
 		w.Write([]byte("fg"))
 		w.Close()
 	}()

--- a/client/driver/logs_test.go
+++ b/client/driver/logs_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -114,19 +113,20 @@ func TestLogRotator_RotateFiles(t *testing.T) {
 		t.Fatalf("Failure in logrotator start %v", err)
 	}
 
-	files, err := ioutil.ReadDir(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	numFiles := 0
-	for _, f := range files {
-		if strings.HasPrefix(f.Name(), "redis.stdout.") {
-			numFiles += 1
+	if finfo, err := os.Stat(filepath.Join(path, "redis.stdout.1")); err == nil {
+		if finfo.Size() != 1 {
+			t.Fatalf("expected number of bytes: %v, actual: %v", 1, finfo.Size())
 		}
+	} else {
+		t.Fatal("expected file redis.stdout.1")
 	}
 
-	if numFiles != 2 {
-		t.Fatalf("Expected number of files: %v, actual: %v", 2, numFiles)
+	if finfo, err := os.Stat(filepath.Join(path, "redis.stdout.0")); err == nil {
+		if finfo.Size() != 6 {
+			t.Fatalf("expected number of bytes: %v, actual: %v", 1, finfo.Size())
+		}
+	} else {
+		t.Fatal("expected file redis.stdout.0")
 	}
 }
 
@@ -171,9 +171,7 @@ func TestLogRotator_SetPathAsFile(t *testing.T) {
 	if f, err = ioutil.TempFile("", pathPrefix); err != nil {
 		t.Fatalf("test setup problem: %v", err)
 	}
-
 	path = f.Name()
-
 	if _, err = NewLogRotator(f.Name(), "redis.stdout", 10, 10, logger); err == nil {
 		t.Fatal("expected error")
 	}

--- a/client/driver/logs_test.go
+++ b/client/driver/logs_test.go
@@ -1,0 +1,40 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLogRotator_IncorrectPath(t *testing.T) {
+	incorrectPath := "/foo"
+
+	if _, err := NewLogRotor(incorrectPath, "redis.stdout", 10, 10); err == nil {
+		t.Fatal("expected err")
+	}
+}
+
+func TestLogRotator_FindCorrectIndex(t *testing.T) {
+	path := "/tmp/tmplogrator"
+	if err := os.Mkdir(path, os.ModeDir|os.ModePerm); err != nil {
+		t.Fatalf("test setup err: %v", err)
+	}
+
+	fname := filepath.Join(path, "redis.stdout.1")
+	if f, err := os.Create(fname); err == nil {
+		f.Close()
+	}
+
+	fname = filepath.Join(path, "redis.stdout.2")
+	if f, err := os.Create(fname); err == nil {
+		f.Close()
+	}
+
+	r, err := NewLogRotor(path, "redis.stdout", 10, 10)
+	if err != nil {
+		t.Fatalf("test setup err: %v", err)
+	}
+	if r.logFileIdx != 2 {
+		t.Fatalf("Expected log file idx: %v, actual: %v", 2, r.logFileIdx)
+	}
+}


### PR DESCRIPTION
This is a library for rotating files written on a buffer. It will be used for log rotation of the stdout/stderr buffers by various drivers.