### PR TITLE
Detect a half-byte prefix

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -77,10 +77,16 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	// Query the allocation info
 	alloc, _, err := client.Allocations().Info(allocID, nil)
 	if err != nil {
-		if len(allocID)%2 != 0 {
-			c.Ui.Error(fmt.Sprintf("Identifier (without hyphens) must be of even length."))
+		if len(allocID) == 1 {
+			c.Ui.Error(fmt.Sprintf("Identifier must contain at least two characters."))
 			return 1
 		}
+		if len(allocID)%2 == 1 {
+			// Identifiers must be of even length, so we strip off the last byte
+			// to provide a consistent user experience.
+			allocID = allocID[:len(allocID)-1]
+		}
+
 		allocs, _, err := client.Allocations().PrefixList(allocID)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error querying allocation: %v", err))

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -77,6 +77,10 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	// Query the allocation info
 	alloc, _, err := client.Allocations().Info(allocID, nil)
 	if err != nil {
+		if len(allocID)%2 != 0 {
+			c.Ui.Error(fmt.Sprintf("Identifier (without hyphens) must be of even length."))
+			return 1
+		}
 		allocs, _, err := client.Allocations().PrefixList(allocID)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error querying allocation: %v", err))

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -28,7 +28,7 @@ func TestAllocStatusCommand_Fails(t *testing.T) {
 	ui.ErrorWriter.Reset()
 
 	// Fails on connection failure
-	if code := cmd.Run([]string{"-address=nope", "foo"}); code != 1 {
+	if code := cmd.Run([]string{"-address=nope", "foobar"}); code != 1 {
 		t.Fatalf("expected exit code 1, got: %d", code)
 	}
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error querying allocation") {
@@ -42,5 +42,13 @@ func TestAllocStatusCommand_Fails(t *testing.T) {
 	}
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No allocation(s) with prefix or id") {
 		t.Fatalf("expected not found error, got: %s", out)
+	}
+
+	// Fail on uneven identifier length
+	if code := cmd.Run([]string{"-address=" + url, "26470238-5CF2-438F-8772-DC67CFB0705"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must be of even length.") {
+		t.Fatalf("expected even length error, got: %s", out)
 	}
 }

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -43,12 +43,23 @@ func TestAllocStatusCommand_Fails(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No allocation(s) with prefix or id") {
 		t.Fatalf("expected not found error, got: %s", out)
 	}
+	ui.ErrorWriter.Reset()
 
-	// Fail on uneven identifier length
-	if code := cmd.Run([]string{"-address=" + url, "26470238-5CF2-438F-8772-DC67CFB0705"}); code != 1 {
+	// Fail on identifier with too few characters
+	if code := cmd.Run([]string{"-address=" + url, "2"}); code != 1 {
 		t.Fatalf("expected exit 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must be of even length.") {
-		t.Fatalf("expected even length error, got: %s", out)
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must contain at least two characters.") {
+		t.Fatalf("expected too few characters error, got: %s", out)
 	}
+	ui.ErrorWriter.Reset()
+
+	// Identifiers with uneven length should produce a query result
+	if code := cmd.Run([]string{"-address=" + url, "123"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No allocation(s) with prefix or id") {
+		t.Fatalf("expected not found error, got: %s", out)
+	}
+
 }

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -196,9 +196,14 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 				m.ui.Error(fmt.Sprintf("No evaluation with id %q found", evalID))
 				return 1
 			}
-			if len(evalID)%2 != 0 {
-				m.ui.Error(fmt.Sprintf("Identifier (without hyphens) must be of even length."))
+			if len(evalID) == 1 {
+				m.ui.Error(fmt.Sprintf("Identifier must contain at least two characters."))
 				return 1
+			}
+			if len(evalID)%2 == 1 {
+				// Identifiers must be of even length, so we strip off the last byte
+				// to provide a consistent user experience.
+				evalID = evalID[:len(evalID)-1]
 			}
 
 			evals, _, err := m.client.Evaluations().PrefixList(evalID)

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -196,6 +196,10 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 				m.ui.Error(fmt.Sprintf("No evaluation with id %q found", evalID))
 				return 1
 			}
+			if len(evalID)%2 != 0 {
+				m.ui.Error(fmt.Sprintf("Identifier (without hyphens) must be of even length."))
+				return 1
+			}
 
 			evals, _, err := m.client.Evaluations().PrefixList(evalID)
 			if err != nil {

--- a/command/monitor_test.go
+++ b/command/monitor_test.go
@@ -324,16 +324,24 @@ func TestMonitor_MonitorWithPrefix(t *testing.T) {
 		t.Fatalf("missing final status\n\n%s", out)
 	}
 
-	// Test identifiers of uneven length
-	code = mon.monitor(evalID[:7], true)
+	// Fail on identifier with too few characters
+	code = mon.monitor(evalID[:1], true)
 	if code != 1 {
 		t.Fatalf("expect exit 1, got: %d", code)
 	}
-	out = ui.ErrorWriter.String()
-	t.Logf("dus: %s", out)
-	if !strings.Contains(out, "must be of even length.") {
-		t.Fatalf("expect even length error, got %s", out)
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must contain at least two characters.") {
+		t.Fatalf("expected too few characters error, got: %s", out)
 	}
+	ui.ErrorWriter.Reset()
+
+	code = mon.monitor(evalID[:3], true)
+	if code != 2 {
+		t.Fatalf("expect exit 2, got: %d", code)
+	}
+	if out := ui.OutputWriter.String(); !strings.Contains(out, "Monitoring evaluation") {
+		t.Fatalf("expected evaluation monitoring output, got: %s", out)
+	}
+
 }
 
 func TestMonitor_DumpAllocStatus(t *testing.T) {

--- a/command/monitor_test.go
+++ b/command/monitor_test.go
@@ -323,6 +323,17 @@ func TestMonitor_MonitorWithPrefix(t *testing.T) {
 	if !strings.Contains(out, "finished with status") {
 		t.Fatalf("missing final status\n\n%s", out)
 	}
+
+	// Test identifiers of uneven length
+	code = mon.monitor(evalID[:7], true)
+	if code != 1 {
+		t.Fatalf("expect exit 1, got: %d", code)
+	}
+	out = ui.ErrorWriter.String()
+	t.Logf("dus: %s", out)
+	if !strings.Contains(out, "must be of even length.") {
+		t.Fatalf("expect even length error, got %s", out)
+	}
 }
 
 func TestMonitor_DumpAllocStatus(t *testing.T) {

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -71,6 +71,11 @@ func (c *NodeDrainCommand) Run(args []string) int {
 	// Check if node exists
 	node, _, err := client.Nodes().Info(nodeID, nil)
 	if err != nil {
+		if len(nodeID)%2 != 0 {
+			c.Ui.Error(fmt.Sprintf("Identifier (without hyphens) must be of even length."))
+			return 1
+		}
+
 		// Exact lookup failed, try with prefix based search
 		nodes, _, err := client.Nodes().PrefixList(nodeID)
 		if err != nil {

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -71,9 +71,14 @@ func (c *NodeDrainCommand) Run(args []string) int {
 	// Check if node exists
 	node, _, err := client.Nodes().Info(nodeID, nil)
 	if err != nil {
-		if len(nodeID)%2 != 0 {
-			c.Ui.Error(fmt.Sprintf("Identifier (without hyphens) must be of even length."))
+		if len(nodeID) == 1 {
+			c.Ui.Error(fmt.Sprintf("Identifier must contain at least two characters."))
 			return 1
+		}
+		if len(nodeID)%2 == 1 {
+			// Identifiers must be of even length, so we strip off the last byte
+			// to provide a consistent user experience.
+			nodeID = nodeID[:len(nodeID)-1]
 		}
 
 		// Exact lookup failed, try with prefix based search

--- a/command/node_drain_test.go
+++ b/command/node_drain_test.go
@@ -61,4 +61,13 @@ func TestNodeDrainCommand_Fails(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, cmd.Help()) {
 		t.Fatalf("expected help output, got: %s", out)
 	}
+	ui.ErrorWriter.Reset()
+
+	// Fail on uneven identifier length
+	if code := cmd.Run([]string{"-address=" + url, "-enable", "1234567-abcd-efab-cdef-123456789abc"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must be of even length.") {
+		t.Fatalf("expected even length error, got: %s", out)
+	}
 }

--- a/command/node_drain_test.go
+++ b/command/node_drain_test.go
@@ -63,11 +63,20 @@ func TestNodeDrainCommand_Fails(t *testing.T) {
 	}
 	ui.ErrorWriter.Reset()
 
-	// Fail on uneven identifier length
-	if code := cmd.Run([]string{"-address=" + url, "-enable", "1234567-abcd-efab-cdef-123456789abc"}); code != 1 {
+	// Fail on identifier with too few characters
+	if code := cmd.Run([]string{"-address=" + url, "-enable", "1"}); code != 1 {
 		t.Fatalf("expected exit 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must be of even length.") {
-		t.Fatalf("expected even length error, got: %s", out)
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must contain at least two characters.") {
+		t.Fatalf("expected too few characters error, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Identifiers with uneven length should produce a query result
+	if code := cmd.Run([]string{"-address=" + url, "-enable", "123"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No node(s) with prefix or id") {
+		t.Fatalf("expected not exist error, got: %s", out)
 	}
 }

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -110,6 +110,11 @@ func (c *NodeStatusCommand) Run(args []string) int {
 	nodeID := args[0]
 	node, _, err := client.Nodes().Info(nodeID, nil)
 	if err != nil {
+		if len(nodeID)%2 != 0 {
+			c.Ui.Error(fmt.Sprintf("Identifier (without hyphens) must be of even length."))
+			return 1
+		}
+
 		// Exact lookup failed, try with prefix based search
 		nodes, _, err := client.Nodes().PrefixList(nodeID)
 		if err != nil {

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -110,9 +110,14 @@ func (c *NodeStatusCommand) Run(args []string) int {
 	nodeID := args[0]
 	node, _, err := client.Nodes().Info(nodeID, nil)
 	if err != nil {
-		if len(nodeID)%2 != 0 {
-			c.Ui.Error(fmt.Sprintf("Identifier (without hyphens) must be of even length."))
+		if len(nodeID) == 1 {
+			c.Ui.Error(fmt.Sprintf("Identifier must contain at least two characters."))
 			return 1
+		}
+		if len(nodeID)%2 == 1 {
+			// Identifiers must be of even length, so we strip off the last byte
+			// to provide a consistent user experience.
+			nodeID = nodeID[:len(nodeID)-1]
 		}
 
 		// Exact lookup failed, try with prefix based search

--- a/command/node_status_test.go
+++ b/command/node_status_test.go
@@ -104,6 +104,14 @@ func TestNodeStatusCommand_Run(t *testing.T) {
 	}
 	ui.OutputWriter.Reset()
 
+	// Identifiers with uneven length should produce a query result
+	if code := cmd.Run([]string{"-address=" + url, nodeID[:3]}); code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+	out = ui.OutputWriter.String()
+	if !strings.Contains(out, "mynode") {
+		t.Fatalf("expect to find mynode, got: %s", out)
+	}
 }
 
 func TestNodeStatusCommand_Fails(t *testing.T) {
@@ -140,11 +148,11 @@ func TestNodeStatusCommand_Fails(t *testing.T) {
 	}
 	ui.ErrorWriter.Reset()
 
-	// Fail on uneven identifier length
-	if code := cmd.Run([]string{"-address=" + url, "1234567-abcd-efab-cdef-123456789abc"}); code != 1 {
+	// Fail on identifier with too few characters
+	if code := cmd.Run([]string{"-address=" + url, "1"}); code != 1 {
 		t.Fatalf("expected exit 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must be of even length.") {
-		t.Fatalf("expected even length error, got: %s", out)
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must contain at least two characters.") {
+		t.Fatalf("expected too few characters error, got: %s", out)
 	}
 }

--- a/command/node_status_test.go
+++ b/command/node_status_test.go
@@ -138,4 +138,13 @@ func TestNodeStatusCommand_Fails(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No node(s) with prefix") {
 		t.Fatalf("expected not found error, got: %s", out)
 	}
+	ui.ErrorWriter.Reset()
+
+	// Fail on uneven identifier length
+	if code := cmd.Run([]string{"-address=" + url, "1234567-abcd-efab-cdef-123456789abc"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must be of even length.") {
+		t.Fatalf("expected even length error, got: %s", out)
+	}
 }


### PR DESCRIPTION
This PR prevents unnecessary API calls when the prefix is of uneven length and it displays an informative error message to the user.