### PR TITLE
Remove internal field names from the CLI output

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -89,7 +89,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		if len(allocs) > 1 {
 			// Format the allocs
 			out := make([]string, len(allocs)+1)
-			out[0] = "ID|EvalID|JobID|TaskGroup|DesiredStatus|ClientStatus"
+			out[0] = "ID|Eval ID|Job ID|Task Group|Desired Status|Client Status"
 			for i, alloc := range allocs {
 				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s",
 					alloc.ID[:length],
@@ -114,16 +114,16 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	// Format the allocation data
 	basic := []string{
 		fmt.Sprintf("ID|%s", alloc.ID[:length]),
-		fmt.Sprintf("EvalID|%s", alloc.EvalID[:length]),
+		fmt.Sprintf("Eval ID|%s", alloc.EvalID[:length]),
 		fmt.Sprintf("Name|%s", alloc.Name),
-		fmt.Sprintf("NodeID|%s", alloc.NodeID[:length]),
-		fmt.Sprintf("JobID|%s", alloc.JobID),
-		fmt.Sprintf("ClientStatus|%s", alloc.ClientStatus),
-		fmt.Sprintf("NodesEvaluated|%d", alloc.Metrics.NodesEvaluated),
-		fmt.Sprintf("NodesFiltered|%d", alloc.Metrics.NodesFiltered),
-		fmt.Sprintf("NodesExhausted|%d", alloc.Metrics.NodesExhausted),
-		fmt.Sprintf("AllocationTime|%s", alloc.Metrics.AllocationTime),
-		fmt.Sprintf("CoalescedFailures|%d", alloc.Metrics.CoalescedFailures),
+		fmt.Sprintf("Node ID|%s", alloc.NodeID[:length]),
+		fmt.Sprintf("Job ID|%s", alloc.JobID),
+		fmt.Sprintf("Client Status|%s", alloc.ClientStatus),
+		fmt.Sprintf("Evaluated Nodes|%d", alloc.Metrics.NodesEvaluated),
+		fmt.Sprintf("Filtered Nodes|%d", alloc.Metrics.NodesFiltered),
+		fmt.Sprintf("Exhausted Nodes|%d", alloc.Metrics.NodesExhausted),
+		fmt.Sprintf("Allocation Time|%s", alloc.Metrics.AllocationTime),
+		fmt.Sprintf("Failures|%d", alloc.Metrics.CoalescedFailures),
 	}
 	c.Ui.Output(formatKV(basic))
 
@@ -144,7 +144,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 // shortTaskStatus prints out the current state of each task.
 func (c *AllocStatusCommand) shortTaskStatus(alloc *api.Allocation) {
 	tasks := make([]string, 0, len(alloc.TaskStates)+1)
-	tasks = append(tasks, "Name|State|LastEvent|Time")
+	tasks = append(tasks, "Name|State|Last Event|Time")
 	for task := range c.sortedTaskStateIterator(alloc.TaskStates) {
 		fmt.Println(task)
 		state := alloc.TaskStates[task]

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -209,7 +209,7 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 			if len(evals) > 1 {
 				// Format the evaluations
 				out := make([]string, len(evals)+1)
-				out[0] = "ID|Priority|Type|TriggeredBy|Status"
+				out[0] = "ID|Priority|Type|Triggered By|Status"
 				for i, eval := range evals {
 					out[i+1] = fmt.Sprintf("%s|%d|%s|%s|%s",
 						eval.ID[:m.length],

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -86,7 +86,7 @@ func (c *NodeDrainCommand) Run(args []string) int {
 			// Format the nodes list that matches the prefix so that the user
 			// can create a more specific request
 			out := make([]string, len(nodes)+1)
-			out[0] = "ID|DC|Name|Class|Drain|Status"
+			out[0] = "ID|Datacenter|Name|Class|Drain|Status"
 			for i, node := range nodes {
 				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
 					node.ID,

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -90,7 +90,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 
 		// Format the nodes list
 		out := make([]string, len(nodes)+1)
-		out[0] = "ID|DC|Name|Class|Drain|Status"
+		out[0] = "ID|Datacenter|Name|Class|Drain|Status"
 		for i, node := range nodes {
 			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
 				node.ID[:length],
@@ -125,7 +125,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 			// Format the nodes list that matches the prefix so that the user
 			// can create a more specific request
 			out := make([]string, len(nodes)+1)
-			out[0] = "ID|DC|Name|Class|Drain|Status"
+			out[0] = "ID|Datacenter|Name|Class|Drain|Status"
 			for i, node := range nodes {
 				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
 					node.ID[:length],
@@ -183,7 +183,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 
 		// Format the allocations
 		allocs = make([]string, len(nodeAllocs)+1)
-		allocs[0] = "ID|EvalID|JobID|TaskGroup|DesiredStatus|ClientStatus"
+		allocs[0] = "ID|Eval ID|Job ID|Task Group|Desired Status|Client Status"
 		for i, alloc := range nodeAllocs {
 			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s",
 				alloc.ID[:length],

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -88,7 +88,7 @@ func (c *ServerMembersCommand) Run(args []string) int {
 func standardOutput(mem []*api.AgentMember) []string {
 	// Format the members list
 	members := make([]string, len(mem)+1)
-	members[0] = "Name|Addr|Port|Status|Proto|Build|DC|Region"
+	members[0] = "Name|Address|Port|Status|Protocol|Build|Datacenter|Region"
 	for i, member := range mem {
 		members[i+1] = fmt.Sprintf("%s|%s|%d|%s|%d|%s|%s|%s",
 			member.Name,
@@ -106,7 +106,7 @@ func standardOutput(mem []*api.AgentMember) []string {
 func detailedOutput(mem []*api.AgentMember) []string {
 	// Format the members list
 	members := make([]string, len(mem)+1)
-	members[0] = "Name|Addr|Port|Tags"
+	members[0] = "Name|Address|Port|Tags"
 	for i, member := range mem {
 		// Format the tags
 		tagPairs := make([]string, 0, len(member.Tags))

--- a/command/status.go
+++ b/command/status.go
@@ -238,7 +238,7 @@ func (c *StatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
 
 	// Format the evals
 	evals = make([]string, len(jobEvals)+1)
-	evals[0] = "ID|Priority|TriggeredBy|Status"
+	evals[0] = "ID|Priority|Triggered By|Status"
 	for i, eval := range jobEvals {
 		evals[i+1] = fmt.Sprintf("%s|%d|%s|%s",
 			eval.ID[:c.length],
@@ -249,7 +249,7 @@ func (c *StatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
 
 	// Format the allocs
 	allocs = make([]string, len(jobAllocs)+1)
-	allocs[0] = "ID|EvalID|NodeID|TaskGroup|Desired|Status"
+	allocs[0] = "ID|Eval ID|Node ID|Task Group|Desired|Status"
 	for i, alloc := range jobAllocs {
 		allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s",
 			alloc.ID[:c.length],


### PR DESCRIPTION
This PR cleans up some cryptic internal names that are used as (header-)field names in the CLI output.