### PR TITLE
Add periodic cgroup fingerprinter

### DIFF
--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -46,7 +46,7 @@ func NewExecDriver(ctx *DriverContext) Driver {
 
 func (d *ExecDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
 	// Only enable if cgroups are available and we are root
-	if _, ok := node.Attributes["cgroup.mountpoint"]; !ok {
+	if _, ok := node.Attributes["unique.cgroup.mountpoint"]; !ok {
 		d.logger.Printf("[DEBUG] driver.exec: cgroups unavailable, disabling")
 		return false, nil
 	} else if syscall.Geteuid() != 0 {

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -22,7 +22,9 @@ func TestExecDriver_Fingerprint(t *testing.T) {
 	driverCtx, _ := testDriverContexts(&structs.Task{Name: "foo"})
 	d := NewExecDriver(driverCtx)
 	node := &structs.Node{
-		Attributes: make(map[string]string),
+		Attributes: map[string]string{
+			"cgroup.mountpoint": "/sys/fs/cgroup",
+		},
 	}
 	apply, err := d.Fingerprint(&config.Config{}, node)
 	if err != nil {

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -23,7 +23,7 @@ func TestExecDriver_Fingerprint(t *testing.T) {
 	d := NewExecDriver(driverCtx)
 	node := &structs.Node{
 		Attributes: map[string]string{
-			"cgroup.mountpoint": "/sys/fs/cgroup",
+			"unique.cgroup.mountpoint": "/sys/fs/cgroup",
 		},
 	}
 	apply, err := d.Fingerprint(&config.Config{}, node)

--- a/client/fingerprint/cgroup.go
+++ b/client/fingerprint/cgroup.go
@@ -22,12 +22,12 @@ type CGroupFingerprint struct {
 
 // An interface to isolate calls to the cgroup library
 // This facilitates testing where we can implement
-// fake mount points to test varios code paths
+// fake mount points to test various code paths
 type MountPointDetector interface {
 	MountPoint() (string, error)
 }
 
-// Implements the interface detector which calls net directly
+// Implements the interface detector which calls the cgroups library directly
 type DefaultMountPointDetector struct {
 }
 

--- a/client/fingerprint/cgroup.go
+++ b/client/fingerprint/cgroup.go
@@ -1,0 +1,82 @@
+package fingerprint
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	client "github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	cgroupAvailable   = "available"
+	cgroupUnavailable = "unavailable"
+)
+
+type CGroupFingerprint struct {
+	logger             *log.Logger
+	lastState          string
+	mountPointDetector MountPointDetector
+}
+
+// An interface to isolate calls to the cgroup library
+// This facilitates testing where we can implement
+// fake mount points to test varios code paths
+type MountPointDetector interface {
+	MountPoint() (string, error)
+}
+
+// Implements the interface detector which calls net directly
+type DefaultMountPointDetector struct {
+}
+
+// Call out to the default cgroup library
+func (b *DefaultMountPointDetector) MountPoint() (string, error) {
+	return FindCgroupMountpointDir()
+}
+
+func NewCGroupFingerprint(logger *log.Logger) Fingerprint {
+	f := &CGroupFingerprint{
+		logger:             logger,
+		lastState:          cgroupUnavailable,
+		mountPointDetector: &DefaultMountPointDetector{},
+	}
+	return f
+}
+
+func (f *CGroupFingerprint) Fingerprint(cfg *client.Config, node *structs.Node) (bool, error) {
+	// Try to find a valid cgroup mount point
+	mount, err := f.mountPointDetector.MountPoint()
+	if err != nil {
+		return false, fmt.Errorf("Failed to discover cgroup mount point: %s", err)
+	}
+
+	// Check if a cgroup mount point was found
+	if mount == "" {
+		// Clear any attributes from the previous fingerprint.
+		f.clearCGroupAttributes(node)
+
+		if f.lastState == cgroupAvailable {
+			f.logger.Printf("[INFO] fingerprint.cgroups: cgroups are unavailable")
+		}
+		f.lastState = cgroupUnavailable
+		return true, nil
+	}
+
+	node.Attributes["cgroup.mountpoint"] = mount
+
+	if f.lastState == cgroupUnavailable {
+		f.logger.Printf("[INFO] fingerprint.cgroups: cgroups are available")
+	}
+	f.lastState = cgroupAvailable
+	return true, nil
+}
+
+func (f *CGroupFingerprint) clearCGroupAttributes(n *structs.Node) {
+	delete(n.Attributes, "cgroup.mountpoint")
+}
+
+func (f *CGroupFingerprint) Periodic() (bool, time.Duration) {
+	return true, 15 * time.Second
+}

--- a/client/fingerprint/cgroup_linux.go
+++ b/client/fingerprint/cgroup_linux.go
@@ -6,6 +6,8 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
+// FindCgroupMountpointDir is used to find the cgroup mount point on a Linux
+// system.
 func FindCgroupMountpointDir() (string, error) {
 	mount, err := cgroups.FindCgroupMountpointDir()
 	if err != nil {

--- a/client/fingerprint/cgroup_linux.go
+++ b/client/fingerprint/cgroup_linux.go
@@ -1,0 +1,22 @@
+// +build linux
+
+package fingerprint
+
+import (
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+func FindCgroupMountpointDir() (string, error) {
+	mount, err := cgroups.FindCgroupMountpointDir()
+	if err != nil {
+		switch e := err.(type) {
+		case *cgroups.NotFoundError:
+			// It's okay if the mount point is not discovered
+			return "", nil
+		default:
+			// All other errors are passed back as is
+			return "", e
+		}
+	}
+	return mount, nil
+}

--- a/client/fingerprint/cgroup_test.go
+++ b/client/fingerprint/cgroup_test.go
@@ -1,0 +1,100 @@
+package fingerprint
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// A fake mount point detector that returns an empty path
+type MountPointDetectorNoMountPoint struct{}
+
+func (m *MountPointDetectorNoMountPoint) MountPoint() (string, error) {
+	return "", nil
+}
+
+// A fake mount point detector that returns an error
+type MountPointDetectorMountPointFail struct{}
+
+func (m *MountPointDetectorMountPointFail) MountPoint() (string, error) {
+	return "", fmt.Errorf("cgroup mountpoint discovery failed")
+}
+
+// A fake mount point detector that returns a valid path
+type MountPointDetectorValidMountPoint struct{}
+
+func (m *MountPointDetectorValidMountPoint) MountPoint() (string, error) {
+	return "/sys/fs/cgroup", nil
+}
+
+// A fake mount point detector that returns an empty path
+type MountPointDetectorEmptyMountPoint struct{}
+
+func (m *MountPointDetectorEmptyMountPoint) MountPoint() (string, error) {
+	return "", nil
+}
+
+func TestCGroupFingerprint(t *testing.T) {
+	f := &CGroupFingerprint{
+		logger:             testLogger(),
+		lastState:          cgroupUnavailable,
+		mountPointDetector: &MountPointDetectorMountPointFail{},
+	}
+
+	node := &structs.Node{
+		Attributes: make(map[string]string),
+	}
+
+	ok, err := f.Fingerprint(&config.Config{}, node)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if ok {
+		t.Fatalf("should not apply")
+	}
+	if a, ok := node.Attributes["cgroup.mountpoint"]; ok {
+		t.Fatalf("unexpected attribute found, %s", a)
+	}
+
+	f = &CGroupFingerprint{
+		logger:             testLogger(),
+		lastState:          cgroupUnavailable,
+		mountPointDetector: &MountPointDetectorValidMountPoint{},
+	}
+
+	node = &structs.Node{
+		Attributes: make(map[string]string),
+	}
+
+	ok, err = f.Fingerprint(&config.Config{}, node)
+	if err != nil {
+		t.Fatalf("unexpected error, %s", err)
+	}
+	if !ok {
+		t.Fatalf("should apply")
+	}
+	assertNodeAttributeContains(t, node, "cgroup.mountpoint")
+
+	f = &CGroupFingerprint{
+		logger:             testLogger(),
+		lastState:          cgroupUnavailable,
+		mountPointDetector: &MountPointDetectorEmptyMountPoint{},
+	}
+
+	node = &structs.Node{
+		Attributes: make(map[string]string),
+	}
+
+	ok, err = f.Fingerprint(&config.Config{}, node)
+	if err != nil {
+		t.Fatalf("unexpected error, %s", err)
+	}
+	if !ok {
+		t.Fatalf("should apply")
+	}
+	if a, ok := node.Attributes["cgroup.mountpoint"]; ok {
+		t.Fatalf("unexpected attribute found, %s", a)
+	}
+}

--- a/client/fingerprint/cgroup_test.go
+++ b/client/fingerprint/cgroup_test.go
@@ -54,7 +54,7 @@ func TestCGroupFingerprint(t *testing.T) {
 	if ok {
 		t.Fatalf("should not apply")
 	}
-	if a, ok := node.Attributes["cgroup.mountpoint"]; ok {
+	if a, ok := node.Attributes["unique.cgroup.mountpoint"]; ok {
 		t.Fatalf("unexpected attribute found, %s", a)
 	}
 
@@ -75,7 +75,7 @@ func TestCGroupFingerprint(t *testing.T) {
 	if !ok {
 		t.Fatalf("should apply")
 	}
-	assertNodeAttributeContains(t, node, "cgroup.mountpoint")
+	assertNodeAttributeContains(t, node, "unique.cgroup.mountpoint")
 
 	f = &CGroupFingerprint{
 		logger:             testLogger(),
@@ -94,7 +94,7 @@ func TestCGroupFingerprint(t *testing.T) {
 	if !ok {
 		t.Fatalf("should apply")
 	}
-	if a, ok := node.Attributes["cgroup.mountpoint"]; ok {
+	if a, ok := node.Attributes["unique.cgroup.mountpoint"]; ok {
 		t.Fatalf("unexpected attribute found, %s", a)
 	}
 }

--- a/client/fingerprint/cgroup_universal.go
+++ b/client/fingerprint/cgroup_universal.go
@@ -2,7 +2,7 @@
 
 package fingerprint
 
-// cgroups only exist on Linux
+// FindCgroupMountpointDir returns an empty path on non-Linux systems
 func FindCgroupMountpointDir() (string, error) {
 	return "", nil
 }

--- a/client/fingerprint/cgroup_universal.go
+++ b/client/fingerprint/cgroup_universal.go
@@ -1,0 +1,8 @@
+// +build !linux
+
+package fingerprint
+
+// cgroups only exist on Linux
+func FindCgroupMountpointDir() (string, error) {
+	return "", nil
+}

--- a/client/fingerprint/fingerprint.go
+++ b/client/fingerprint/fingerprint.go
@@ -16,6 +16,7 @@ const EmptyDuration = time.Duration(0)
 // fingerprints available, to provided an ordered iteration
 var BuiltinFingerprints = []string{
 	"arch",
+	"cgroup",
 	"consul",
 	"cpu",
 	"env_aws",
@@ -30,6 +31,7 @@ var BuiltinFingerprints = []string{
 // which are available, corresponding to a key found in BuiltinFingerprints
 var builtinFingerprintMap = map[string]Factory{
 	"arch":    NewArchFingerprint,
+	"cgroup":  NewCGroupFingerprint,
 	"consul":  NewConsulFingerprint,
 	"cpu":     NewCPUFingerprint,
 	"env_aws": NewEnvAWSFingerprint,
@@ -41,6 +43,7 @@ var builtinFingerprintMap = map[string]Factory{
 }
 
 // NewFingerprint is used to instantiate and return a new fingerprint
+
 // given the name and a logger
 func NewFingerprint(name string, logger *log.Logger) (Fingerprint, error) {
 	// Lookup the factory function

--- a/client/fingerprint/fingerprint.go
+++ b/client/fingerprint/fingerprint.go
@@ -12,7 +12,7 @@ import (
 // EmptyDuration is to be used by fingerprinters that are not periodic.
 const EmptyDuration = time.Duration(0)
 
-// BuiltinFingerprints is a slice containing the key names of all regestered
+// BuiltinFingerprints is a slice containing the key names of all registered
 // fingerprints available, to provided an ordered iteration
 var BuiltinFingerprints = []string{
 	"arch",
@@ -43,7 +43,6 @@ var builtinFingerprintMap = map[string]Factory{
 }
 
 // NewFingerprint is used to instantiate and return a new fingerprint
-
 // given the name and a logger
 func NewFingerprint(name string, logger *log.Logger) (Fingerprint, error) {
 	// Lookup the factory function


### PR DESCRIPTION
Periodically check for the availability of cgroups. Disable the exec driver if cgroups are not available.