### PR TITLE
Limit length of string, taking into account its length

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -102,8 +102,8 @@ func (c *AllocStatusCommand) Run(args []string) int {
 			out[0] = "ID|Eval ID|Job ID|Task Group|Desired Status|Client Status"
 			for i, alloc := range allocs {
 				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s",
-					alloc.ID[:length],
-					alloc.EvalID[:length],
+					limit(alloc.ID, length),
+					limit(alloc.EvalID, length),
 					alloc.JobID,
 					alloc.TaskGroup,
 					alloc.DesiredStatus,
@@ -123,10 +123,10 @@ func (c *AllocStatusCommand) Run(args []string) int {
 
 	// Format the allocation data
 	basic := []string{
-		fmt.Sprintf("ID|%s", alloc.ID[:length]),
-		fmt.Sprintf("Eval ID|%s", alloc.EvalID[:length]),
+		fmt.Sprintf("ID|%s", limit(alloc.ID, length)),
+		fmt.Sprintf("Eval ID|%s", limit(alloc.EvalID, length)),
 		fmt.Sprintf("Name|%s", alloc.Name),
-		fmt.Sprintf("Node ID|%s", alloc.NodeID[:length]),
+		fmt.Sprintf("Node ID|%s", limit(alloc.NodeID, length)),
 		fmt.Sprintf("Job ID|%s", alloc.JobID),
 		fmt.Sprintf("Client Status|%s", alloc.ClientStatus),
 		fmt.Sprintf("Evaluated Nodes|%d", alloc.Metrics.NodesEvaluated),

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -21,3 +21,12 @@ func formatList(in []string) string {
 	columnConf.Empty = "<none>"
 	return columnize.Format(in, columnConf)
 }
+
+// Limits the length of the string.
+func limit(s string, length int) string {
+	if len(s) < length {
+		return s[:len(s)]
+	}
+
+	return s[:length]
+}

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -102,7 +102,7 @@ func (m *monitor) update(update *evalState) {
 	// Check if the evaluation was triggered by a node
 	if existing.node == "" && update.node != "" {
 		m.ui.Output(fmt.Sprintf("Evaluation triggered by node %q",
-			update.node[:m.length]))
+			limit(update.node, m.length)))
 	}
 
 	// Check if the evaluation was triggered by a job
@@ -136,13 +136,13 @@ func (m *monitor) update(update *evalState) {
 				// create index indicates modification
 				m.ui.Output(fmt.Sprintf(
 					"Allocation %q modified: node %q, group %q",
-					alloc.id[:m.length], alloc.node[:m.length], alloc.group))
+					limit(alloc.id, m.length), limit(alloc.node, m.length), alloc.group))
 
 			case alloc.desired == structs.AllocDesiredStatusRun:
 				// New allocation with desired status running
 				m.ui.Output(fmt.Sprintf(
 					"Allocation %q created: node %q, group %q",
-					alloc.id[:m.length], alloc.node[:m.length], alloc.group))
+					limit(alloc.id, m.length), limit(alloc.node, m.length), alloc.group))
 			}
 		} else {
 			switch {
@@ -150,7 +150,7 @@ func (m *monitor) update(update *evalState) {
 				// Allocation status has changed
 				m.ui.Output(fmt.Sprintf(
 					"Allocation %q status changed: %q -> %q (%s)",
-					alloc.id[:m.length], existing.client, alloc.client, alloc.clientDesc))
+					limit(alloc.id, m.length), existing.client, alloc.client, alloc.clientDesc))
 			}
 		}
 	}
@@ -221,7 +221,7 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 				out[0] = "ID|Priority|Type|Triggered By|Status"
 				for i, eval := range evals {
 					out[i+1] = fmt.Sprintf("%s|%d|%s|%s|%s",
-						eval.ID[:m.length],
+						limit(eval.ID, m.length),
 						eval.Priority,
 						eval.Type,
 						eval.TriggeredBy,
@@ -238,7 +238,7 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 		}
 
 		if !headerWritten {
-			m.ui.Info(fmt.Sprintf("Monitoring evaluation %q", eval.ID[:m.length]))
+			m.ui.Info(fmt.Sprintf("Monitoring evaluation %q", limit(eval.ID, m.length)))
 			headerWritten = true
 		}
 
@@ -290,7 +290,7 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 		switch eval.Status {
 		case structs.EvalStatusComplete, structs.EvalStatusFailed:
 			m.ui.Info(fmt.Sprintf("Evaluation %q finished with status %q",
-				eval.ID[:m.length], eval.Status))
+				limit(eval.ID, m.length), eval.Status))
 		default:
 			// Wait for the next update
 			time.Sleep(updateWait)
@@ -328,7 +328,7 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 func dumpAllocStatus(ui cli.Ui, alloc *api.Allocation, length int) {
 	// Print filter stats
 	ui.Output(fmt.Sprintf("Allocation %q status %q (%d/%d nodes filtered)",
-		alloc.ID[:length], alloc.ClientStatus,
+		limit(alloc.ID, length), alloc.ClientStatus,
 		alloc.Metrics.NodesFiltered, alloc.Metrics.NodesEvaluated))
 
 	// Print a helpful message if we have an eligibility problem

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -93,7 +93,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		out[0] = "ID|Datacenter|Name|Class|Drain|Status"
 		for i, node := range nodes {
 			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
-				node.ID[:length],
+				limit(node.ID, length),
 				node.Datacenter,
 				node.Name,
 				node.NodeClass,
@@ -138,7 +138,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 			out[0] = "ID|Datacenter|Name|Class|Drain|Status"
 			for i, node := range nodes {
 				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
-					node.ID[:length],
+					limit(node.ID, length),
 					node.Datacenter,
 					node.Name,
 					node.NodeClass,
@@ -173,7 +173,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 
 	// Format the output
 	basic := []string{
-		fmt.Sprintf("ID|%s", node.ID[:length]),
+		fmt.Sprintf("ID|%s", limit(node.ID, length)),
 		fmt.Sprintf("Name|%s", node.Name),
 		fmt.Sprintf("Class|%s", node.NodeClass),
 		fmt.Sprintf("Datacenter|%s", node.Datacenter),
@@ -196,8 +196,8 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		allocs[0] = "ID|Eval ID|Job ID|Task Group|Desired Status|Client Status"
 		for i, alloc := range nodeAllocs {
 			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s",
-				alloc.ID[:length],
-				alloc.EvalID[:length],
+				limit(alloc.ID, length),
+				limit(alloc.EvalID, length),
 				alloc.JobID,
 				alloc.TaskGroup,
 				alloc.DesiredStatus,

--- a/command/status.go
+++ b/command/status.go
@@ -241,7 +241,7 @@ func (c *StatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
 	evals[0] = "ID|Priority|Triggered By|Status"
 	for i, eval := range jobEvals {
 		evals[i+1] = fmt.Sprintf("%s|%d|%s|%s",
-			eval.ID[:c.length],
+			limit(eval.ID, c.length),
 			eval.Priority,
 			eval.TriggeredBy,
 			eval.Status)
@@ -252,9 +252,9 @@ func (c *StatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
 	allocs[0] = "ID|Eval ID|Node ID|Task Group|Desired|Status"
 	for i, alloc := range jobAllocs {
 		allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s",
-			alloc.ID[:c.length],
-			alloc.EvalID[:c.length],
-			alloc.NodeID[:c.length],
+			limit(alloc.ID, c.length),
+			limit(alloc.EvalID, c.length),
+			limit(alloc.NodeID, c.length),
 			alloc.TaskGroup,
 			alloc.DesiredStatus,
 			alloc.ClientStatus)


### PR DESCRIPTION
Limit length of string, taking into account its length

@iverberk: There was a bug if you did `nomad status <job>` on a job that ran but only created a failed alloc, it would panic