### PR TITLE
Allow compilation on BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ EXTERNAL_TOOLS=\
 all: test
 
 dev: deps format
-	@NOMAD_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
+	@NOMAD_DEV=1 sh -c "'$(PWD)/scripts/build.sh'"
 
 bin:
-	@sh -c "'$(CURDIR)/scripts/build.sh'"
+	@sh -c "'$(PWD)/scripts/build.sh'"
 
 release: updatedeps
 	@$(MAKE) bin
@@ -26,14 +26,14 @@ cov:
 
 deps:
 	@echo "--> Installing build dependencies"
-	@DEP_ARGS="-d -v" sh -c "'$(CURDIR)/scripts/deps.sh'"
+	@DEP_ARGS="-d -v" sh -c "'$(PWD)/scripts/deps.sh'"
 
 updatedeps: deps
 	@echo "--> Updating build dependencies"
-	@DEP_ARGS="-d -f -u" sh -c "'$(CURDIR)/scripts/deps.sh'"
+	@DEP_ARGS="-d -f -u" sh -c "'$(PWD)/scripts/deps.sh'"
 
 test: deps
-	@sh -c "'$(CURDIR)/scripts/test.sh'"
+	@sh -c "'$(PWD)/scripts/test.sh'"
 	@$(MAKE) vet
 
 cover: deps

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script builds the application from source for multiple platforms.
 set -e

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # First get the OS-specific packages
 GOOS=windows go get $DEP_ARGS github.com/StackExchange/wmi

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Get the version from the command line


### PR DESCRIPTION
BSD Make uses `$.CURDIR` instead of `$CURDIR`. BSD and GNU share `$PWD`
though, so it works as a drop in replacement.

Also update scripts in `scripts/` to call `/usr/bin/env` in the shebang,
as BSD places `bash` at `/usr/local/bin/bash` instead of `/bin/bash`