### PR TITLE
Allow ports to be optional when adding servers

### DIFF
--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -152,7 +152,7 @@ func TestAgent_SetServers(t *testing.T) {
 	if n := len(out); n != 2 {
 		t.Fatalf("expected 2 servers, got: %d", n)
 	}
-	if out[0] != "foo" || out[1] != "bar" {
+	if out[0] != "foo:4647" || out[1] != "bar:4647" {
 		t.Fatalf("bad server list: %v", out)
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -338,12 +338,12 @@ func (c *Client) SetServers(servers []string) {
 				c.logger.Printf("[WARN] client: port not specified, using default port")
 				setServers[i] = fmt.Sprintf("%s:4647", setServers[i])
 			} else {
-				c.logger.Printf("[ERR] client: error in server address %s", err)
+				c.logger.Printf("[WARN] client: server address %q invalid: %v", setServers[i], err)
 			}
 		}
 	}
 
-	c.logger.Printf("[INFO] client: adding servers '%s'", setServers)
+	c.logger.Printf("[INFO] client: adding servers: %s", setServers)
 	c.servers = setServers
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -336,14 +336,14 @@ func (c *Client) SetServers(servers []string) {
 			// multiple errors can be returned here, only searching for missing
 			if strings.Contains(err.Error(), "missing port") {
 				c.logger.Printf("[WARN] client: port not specified, using default port")
-				setServers[i] = fmt.Sprintf("%s:4647", setServers[i])
+				setServers[i] = net.JoinHostPort(setServers[i], "4647")
 			} else {
 				c.logger.Printf("[WARN] client: server address %q invalid: %v", setServers[i], err)
 			}
 		}
 	}
 
-	c.logger.Printf("[INFO] client: adding servers: %s", setServers)
+	c.logger.Printf("[INFO] client: setting server address list: %s", setServers)
 	c.servers = setServers
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -333,7 +333,7 @@ func (c *Client) SetServers(servers []string) {
 	copy(setServers, servers)
 	for i := 0; i < len(setServers); i++ {
 		if _, _, err := net.SplitHostPort(setServers[i]); err != nil {
-			// multiple errors can be returned here, only searching for mising
+			// multiple errors can be returned here, only searching for missing
 			if strings.Contains(err.Error(), "missing port") {
 				c.logger.Printf("[WARN] client: port not specified, using default port")
 				setServers[i] = fmt.Sprintf("%s:4647", setServers[i])

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -475,28 +475,28 @@ func TestClient_SetServers(t *testing.T) {
 	}
 
 	// Set the initial servers list
-	expect := []string{"foo"}
+	expect := []string{"foo:4647"}
 	client.SetServers(expect)
 	if !reflect.DeepEqual(client.servers, expect) {
 		t.Fatalf("expect %v, got %v", expect, client.servers)
 	}
 
 	// Add a server
-	expect = []string{"foo", "bar"}
+	expect = []string{"foo:5445", "bar:8080"}
 	client.SetServers(expect)
 	if !reflect.DeepEqual(client.servers, expect) {
 		t.Fatalf("expect %v, got %v", expect, client.servers)
 	}
 
 	// Remove a server
-	expect = []string{"bar"}
+	expect = []string{"bar:8080"}
 	client.SetServers(expect)
 	if !reflect.DeepEqual(client.servers, expect) {
 		t.Fatalf("expect %v, got %v", expect, client.servers)
 	}
 
 	// Add and remove a server
-	expect = []string{"baz", "zip"}
+	expect = []string{"baz:9090", "zip:4545"}
 	client.SetServers(expect)
 	if !reflect.DeepEqual(client.servers, expect) {
 		t.Fatalf("expect %v, got %v", expect, client.servers)
@@ -505,5 +505,13 @@ func TestClient_SetServers(t *testing.T) {
 	// Query the servers list
 	if servers := client.Servers(); !reflect.DeepEqual(servers, expect) {
 		t.Fatalf("expect %v, got %v", expect, servers)
+	}
+
+	// Add servers without ports, and remove old servers
+	servers := []string{"foo", "bar", "baz"}
+	expect = []string{"foo:4647", "bar:4647", "baz:4647"}
+	client.SetServers(servers)
+	if !reflect.DeepEqual(client.servers, expect) {
+		t.Fatalf("expect %v, got %v", expect, client.servers)
 	}
 }

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -149,7 +149,7 @@ func TestHTTP_AgentSetServers(t *testing.T) {
 		if n := len(servers); n != 2 {
 			t.Fatalf("expected 2 servers, got: %d", n)
 		}
-		if servers[0] != "foo" || servers[1] != "bar" {
+		if servers[0] != "foo:4647" || servers[1] != "bar:4647" {
 			t.Fatalf("bad servers result: %v", servers)
 		}
 	})

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -272,7 +272,8 @@ configured on server nodes.
     "alloc" sub-path. It must be specified as an absolute path.
   * <a id="servers">`servers`</a>: An array of server addresses. This list is
     used to register the client with the server nodes and advertise the
-    available resources so that the agent can receive work.
+    available resources so that the agent can receive work. If a port is not specified
+    in the array of server addresses, the default port `4647` will be used.
   * <a id="node_id">`node_id`</a>: This is the value used to uniquely identify
     the local agent's node registration with the servers. This can be any
     arbitrary string but must be unique to the cluster. By default, if not

--- a/website/source/docs/commands/client-config.html.md.erb
+++ b/website/source/docs/commands/client-config.html.md.erb
@@ -37,7 +37,8 @@ description below for specific usage information and requirements.
   arguments. Multiple server addresses may be passed using multiple arguments.
   When updating the servers list, you must specify ALL of the server nodes you
   wish to configure. The set is updated atomically. It is an error to specify
-  this flag without any server addresses.
+  this flag without any server addresses. If you do _not_ specify a port for each
+  server address, the default port `4647` will be used.
 
 ## Examples
 
@@ -52,5 +53,5 @@ server2:4647
 Update the list of servers:
 
 ```
-$ nomad client-config -update-servers server1:4647 server2:4647 server3:4647
+$ nomad client-config -update-servers server1:4647 server2:4647 server3:4647 server4
 ```


### PR DESCRIPTION
When updating a clients servers, as nomad does not use the gossip
protocol over a specified port for clients, it was required to specify
ports along with server addresses.

Now specifying ports are optional, and if unspecified the default `4647`
port is used, reflecting a notice back to the user.