### PR TITLE
Add new RPC call to fetch a lightweight list of allocation information.

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -61,6 +61,18 @@ func (n *Nodes) Allocations(nodeID string, q *QueryOptions) ([]*Allocation, *Que
 	return resp, qm, nil
 }
 
+// ClientAllocations is used to return a lightweight list of allocations associated with a node.
+// It is primarily used by the client in order to determine which allocations actually need
+// an update.
+func (n *Nodes) ClientAllocations(nodeID string, q *QueryOptions) (map[string]uint64, *QueryMeta, error) {
+	var resp map[string]uint64
+	qm, err := n.client.query("/v1/node/"+nodeID+"/clientallocations", &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, qm, nil
+}
+
 // ForceEvaluate is used to force-evaluate an existing node.
 func (n *Nodes) ForceEvaluate(nodeID string, q *WriteOptions) (string, *WriteMeta, error) {
 	var resp nodeEvalResponse

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -207,6 +207,24 @@ func TestNodes_Allocations(t *testing.T) {
 	}
 }
 
+func TestNodes_ClientAllocations(t *testing.T) {
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+	nodes := c.Nodes()
+
+	// Looking up by a non-existent node returns nothing. We
+	// don't check the index here because it's possible the node
+	// has already registered, in which case we will get a non-
+	// zero result anyways.
+	allocs, _, err := nodes.ClientAllocations("nope", nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if n := len(allocs); n != 0 {
+		t.Fatalf("expected 0 allocs, got: %d", n)
+	}
+}
+
 func TestNodes_ForceEvaluate(t *testing.T) {
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -214,6 +214,60 @@ func TestHTTP_NodeAllocations(t *testing.T) {
 	})
 }
 
+func TestHTTP_NodeClientAllocations(t *testing.T) {
+	httpTest(t, nil, func(s *TestServer) {
+		// Create the job
+		node := mock.Node()
+		args := structs.NodeRegisterRequest{
+			Node:         node,
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		var resp structs.NodeUpdateResponse
+		if err := s.Agent.RPC("Node.Register", &args, &resp); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Directly manipulate the state
+		state := s.Agent.server.State()
+		alloc1 := mock.Alloc()
+		alloc1.NodeID = node.ID
+		err := state.UpsertAllocs(1000, []*structs.Allocation{alloc1})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Make the HTTP request
+		req, err := http.NewRequest("GET", "/v1/node/"+node.ID+"/clientallocations", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.NodeSpecificRequest(respW, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Check for the index
+		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+			t.Fatalf("missing index")
+		}
+		if respW.HeaderMap.Get("X-Nomad-KnownLeader") != "true" {
+			t.Fatalf("missing known leader")
+		}
+		if respW.HeaderMap.Get("X-Nomad-LastContact") == "" {
+			t.Fatalf("missing last contact")
+		}
+
+		// Check the node
+		allocs := obj.(map[string]uint64)
+		if len(allocs) != 1 || allocs[alloc1.ID] != 1000 {
+			t.Fatalf("bad: %#v", allocs)
+		}
+	})
+}
+
 func TestHTTP_NodeDrain(t *testing.T) {
 	httpTest(t, nil, func(s *TestServer) {
 		// Create the node

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -532,6 +532,156 @@ func TestClientEndpoint_GetAllocs(t *testing.T) {
 	}
 }
 
+func TestClientEndpoint_GetClientAllocs(t *testing.T) {
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	node := mock.Node()
+	reg := &structs.NodeRegisterRequest{
+		Node:         node,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	// Fetch the response
+	var resp structs.GenericResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Node.Register", reg, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	node.CreateIndex = resp.Index
+	node.ModifyIndex = resp.Index
+
+	// Inject fake evaluations
+	alloc := mock.Alloc()
+	alloc.NodeID = node.ID
+	state := s1.fsm.State()
+	err := state.UpsertAllocs(100, []*structs.Allocation{alloc})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Lookup the allocs
+	get := &structs.NodeSpecificRequest{
+		NodeID:       node.ID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var resp2 structs.NodeClientAllocsResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Node.GetClientAllocs", get, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp2.Index != 100 {
+		t.Fatalf("Bad index: %d %d", resp2.Index, 100)
+	}
+
+	if len(resp2.Allocs) != 1 || resp2.Allocs[alloc.ID] != 100 {
+		t.Fatalf("bad: %#v", resp2.Allocs)
+	}
+
+	// Lookup non-existing node
+	get.NodeID = "foobarbaz"
+	var resp3 structs.NodeClientAllocsResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Node.GetClientAllocs", get, &resp3); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp3.Index != 100 {
+		t.Fatalf("Bad index: %d %d", resp3.Index, 100)
+	}
+	if len(resp3.Allocs) != 0 {
+		t.Fatalf("unexpected node %#v", resp3.Allocs)
+	}
+}
+
+func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	node := mock.Node()
+	reg := &structs.NodeRegisterRequest{
+		Node:         node,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	// Fetch the response
+	var resp structs.GenericResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Node.Register", reg, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	node.CreateIndex = resp.Index
+	node.ModifyIndex = resp.Index
+
+	// Inject fake evaluations async
+	alloc := mock.Alloc()
+	alloc.NodeID = node.ID
+	state := s1.fsm.State()
+	start := time.Now()
+	time.AfterFunc(100*time.Millisecond, func() {
+		err := state.UpsertAllocs(100, []*structs.Allocation{alloc})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	// Lookup the allocs in a blocking query
+	req := &structs.NodeSpecificRequest{
+		NodeID: node.ID,
+		QueryOptions: structs.QueryOptions{
+			Region:        "global",
+			MinQueryIndex: 50,
+			MaxQueryTime:  time.Second,
+		},
+	}
+	var resp2 structs.NodeClientAllocsResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Node.GetClientAllocs", req, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Should block at least 100ms
+	if time.Since(start) < 100*time.Millisecond {
+		t.Fatalf("too fast")
+	}
+
+	if resp2.Index != 100 {
+		t.Fatalf("Bad index: %d %d", resp2.Index, 100)
+	}
+
+	if len(resp2.Allocs) != 1 || resp2.Allocs[alloc.ID] != 100 {
+		t.Fatalf("bad: %#v", resp2.Allocs)
+	}
+
+	// Alloc updates fire watches
+	time.AfterFunc(100*time.Millisecond, func() {
+		allocUpdate := mock.Alloc()
+		allocUpdate.NodeID = alloc.NodeID
+		allocUpdate.ID = alloc.ID
+		allocUpdate.ClientStatus = structs.AllocClientStatusRunning
+		err := state.UpdateAllocFromClient(200, allocUpdate)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	req.QueryOptions.MinQueryIndex = 150
+	var resp3 structs.NodeClientAllocsResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Node.GetClientAllocs", req, &resp3); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if time.Since(start) < 100*time.Millisecond {
+		t.Fatalf("too fast")
+	}
+	if resp3.Index != 200 {
+		t.Fatalf("Bad index: %d %d", resp3.Index, 200)
+	}
+	if len(resp3.Allocs) != 1 || resp3.Allocs[alloc.ID] != 200 {
+		t.Fatalf("bad: %#v", resp3.Allocs)
+	}
+}
+
 func TestClientEndpoint_GetAllocs_Blocking(t *testing.T) {
 	s1 := testServer(t, nil)
 	defer s1.Shutdown()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -342,6 +342,12 @@ type NodeAllocsResponse struct {
 	QueryMeta
 }
 
+// NodeClientAllocsResponse is used to return allocs meta data for a single node
+type NodeClientAllocsResponse struct {
+	Allocs map[string]uint64
+	QueryMeta
+}
+
 // SingleNodeResponse is used to return a single node
 type SingleNodeResponse struct {
 	Node *Node

--- a/website/source/docs/http/node.html.md
+++ b/website/source/docs/http/node.html.md
@@ -311,6 +311,44 @@ be specified using the `?region=` query parameter.
   </dd>
 </dl>
 
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Query the allocations belonging to a single node. This endpoint only returns
+    a map from allocation id to modifyindex and is primarily used by the client
+    to determine which allocations need to be updated.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/v1/node/<id>/clientallocations`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+        "d66ea8d7-1d4c-119e-46b3-e23713a4ab72": 9,
+        "abf34c35-1d4c-119e-46b3-e23713a4ab72": 10
+    }
+    ```
+
+  </dd>
+</dl>
+
+
 ## PUT / POST
 
 <dl>


### PR DESCRIPTION
This is the first step in preventing clients from processing their own update notifications.