### PR TITLE
allow group and others to have executable permissions on allocdir

### DIFF
--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -76,7 +76,7 @@ func (d *AllocDir) Destroy() error {
 // Given a list of a task build the correct alloc structure.
 func (d *AllocDir) Build(tasks []*structs.Task) error {
 	// Make the alloc directory, owned by the nomad process.
-	if err := os.MkdirAll(d.AllocDir, 0700); err != nil {
+	if err := os.MkdirAll(d.AllocDir, 0755); err != nil {
 		return fmt.Errorf("Failed to make the alloc directory %v: %v", d.AllocDir, err)
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -196,7 +196,7 @@ func (c *Client) init() error {
 
 	// Ensure the alloc dir exists if we have one
 	if c.config.AllocDir != "" {
-		if err := os.MkdirAll(c.config.AllocDir, 0700); err != nil {
+		if err := os.MkdirAll(c.config.AllocDir, 0755); err != nil {
 			return fmt.Errorf("failed creating alloc dir: %s", err)
 		}
 	} else {


### PR DESCRIPTION
Unprivileged containers fails to mount task specific and shared alloc directories due to 0700 permission on them as well as their parent directory. this pr changes those directory permissions to 0755,