### PR TITLE
Client only pulls update allocations from server

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -61,18 +61,6 @@ func (n *Nodes) Allocations(nodeID string, q *QueryOptions) ([]*Allocation, *Que
 	return resp, qm, nil
 }
 
-// ClientAllocations is used to return a lightweight list of allocations associated with a node.
-// It is primarily used by the client in order to determine which allocations actually need
-// an update.
-func (n *Nodes) ClientAllocations(nodeID string, q *QueryOptions) (map[string]uint64, *QueryMeta, error) {
-	var resp map[string]uint64
-	qm, err := n.client.query("/v1/node/"+nodeID+"/clientallocations", &resp, q)
-	if err != nil {
-		return nil, nil, err
-	}
-	return resp, qm, nil
-}
-
 // ForceEvaluate is used to force-evaluate an existing node.
 func (n *Nodes) ForceEvaluate(nodeID string, q *WriteOptions) (string, *WriteMeta, error) {
 	var resp nodeEvalResponse

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -207,24 +207,6 @@ func TestNodes_Allocations(t *testing.T) {
 	}
 }
 
-func TestNodes_ClientAllocations(t *testing.T) {
-	c, s := makeClient(t, nil, nil)
-	defer s.Stop()
-	nodes := c.Nodes()
-
-	// Looking up by a non-existent node returns nothing. We
-	// don't check the index here because it's possible the node
-	// has already registered, in which case we will get a non-
-	// zero result anyways.
-	allocs, _, err := nodes.ClientAllocations("nope", nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if n := len(allocs); n != 0 {
-		t.Fatalf("expected 0 allocs, got: %d", n)
-	}
-}
-
 func TestNodes_ForceEvaluate(t *testing.T) {
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -21,12 +21,6 @@ const (
 	allocSyncRetryIntv = 15 * time.Second
 )
 
-// taskStatus is used to track the status of a task
-type taskStatus struct {
-	Status      string
-	Description string
-}
-
 // AllocStateUpdater is used to update the status of an allocation
 type AllocStateUpdater func(alloc *structs.Allocation) error
 
@@ -40,10 +34,15 @@ type AllocRunner struct {
 	alloc     *structs.Allocation
 	allocLock sync.Mutex
 
+	// Explicit status of allocation. Set when there are failures
+	allocClientStatus      string
+	allocClientDescription string
+
 	dirtyCh chan struct{}
 
 	ctx           *driver.ExecContext
 	tasks         map[string]*TaskRunner
+	taskStates    map[string]*structs.TaskState
 	restored      map[string]struct{}
 	RestartPolicy *structs.RestartPolicy
 	taskLock      sync.RWMutex
@@ -60,10 +59,12 @@ type AllocRunner struct {
 
 // allocRunnerState is used to snapshot the state of the alloc runner
 type allocRunnerState struct {
-	Alloc         *structs.Allocation
-	RestartPolicy *structs.RestartPolicy
-	TaskStatus    map[string]taskStatus
-	Context       *driver.ExecContext
+	Alloc                  *structs.Allocation
+	AllocClientStatus      string
+	AllocClientDescription string
+	RestartPolicy          *structs.RestartPolicy
+	TaskStates             map[string]*structs.TaskState
+	Context                *driver.ExecContext
 }
 
 // NewAllocRunner is used to create a new allocation context
@@ -77,6 +78,7 @@ func NewAllocRunner(logger *log.Logger, config *config.Config, updater AllocStat
 		consulService: consulService,
 		dirtyCh:       make(chan struct{}, 1),
 		tasks:         make(map[string]*TaskRunner),
+		taskStates:    alloc.TaskStates,
 		restored:      make(map[string]struct{}),
 		updateCh:      make(chan *structs.Allocation, 8),
 		destroyCh:     make(chan struct{}),
@@ -102,10 +104,13 @@ func (r *AllocRunner) RestoreState() error {
 	r.alloc = snap.Alloc
 	r.RestartPolicy = snap.RestartPolicy
 	r.ctx = snap.Context
+	r.allocClientStatus = snap.AllocClientStatus
+	r.allocClientDescription = snap.AllocClientDescription
+	r.taskStates = snap.TaskStates
 
 	// Restore the task runners
 	var mErr multierror.Error
-	for name, state := range r.alloc.TaskStates {
+	for name, state := range r.taskStates {
 		// Mark the task as restored.
 		r.restored[name] = struct{}{}
 
@@ -157,9 +162,12 @@ func (r *AllocRunner) saveAllocRunnerState() error {
 	r.allocLock.Lock()
 	defer r.allocLock.Unlock()
 	snap := allocRunnerState{
-		Alloc:         r.alloc,
-		RestartPolicy: r.RestartPolicy,
-		Context:       r.ctx,
+		Alloc:                  r.alloc,
+		RestartPolicy:          r.RestartPolicy,
+		Context:                r.ctx,
+		AllocClientStatus:      r.allocClientStatus,
+		AllocClientDescription: r.allocClientDescription,
+		TaskStates:             r.taskStates,
 	}
 	return persistState(r.stateFilePath(), &snap)
 }
@@ -186,8 +194,46 @@ func (r *AllocRunner) DestroyContext() error {
 // Alloc returns the associated allocation
 func (r *AllocRunner) Alloc() *structs.Allocation {
 	r.allocLock.Lock()
-	defer r.allocLock.Unlock()
-	return r.alloc.Copy()
+	alloc := r.alloc.Copy()
+	r.allocLock.Unlock()
+
+	// Scan the task states to determine the status of the alloc
+	var pending, running, dead, failed bool
+	r.taskStatusLock.RLock()
+	alloc.TaskStates = r.taskStates
+	for _, state := range r.taskStates {
+		switch state.State {
+		case structs.TaskStateRunning:
+			running = true
+		case structs.TaskStatePending:
+			pending = true
+		case structs.TaskStateDead:
+			last := len(state.Events) - 1
+			if state.Events[last].Type == structs.TaskDriverFailure {
+				failed = true
+			} else {
+				dead = true
+			}
+		}
+	}
+	r.taskStatusLock.RUnlock()
+
+	// The status has explicitely been set.
+	if r.allocClientStatus != "" || r.allocClientDescription != "" {
+		alloc.ClientStatus = r.allocClientStatus
+		alloc.ClientDescription = r.allocClientDescription
+		return alloc
+	}
+
+	// Determine the alloc status
+	if failed {
+		alloc.ClientStatus = structs.AllocClientStatusFailed
+	} else if running {
+		alloc.ClientStatus = structs.AllocClientStatusRunning
+	} else if dead && !pending {
+		alloc.ClientStatus = structs.AllocClientStatusDead
+	}
+	return alloc
 }
 
 // dirtySyncState is used to watch for state being marked dirty to sync
@@ -224,39 +270,6 @@ func (r *AllocRunner) syncStatus() error {
 	// Get a copy of our alloc.
 	alloc := r.Alloc()
 
-	// Scan the task states to determine the status of the alloc
-	var pending, running, dead, failed bool
-	r.taskStatusLock.RLock()
-	for name, tr := range r.tasks {
-		// Store the state of each task in the copied alloc.
-		state := tr.getState()
-		alloc.TaskStates[name] = state
-
-		switch state.State {
-		case structs.TaskStateRunning:
-			running = true
-		case structs.TaskStatePending:
-			pending = true
-		case structs.TaskStateDead:
-			last := len(state.Events) - 1
-			if state.Events[last].Type == structs.TaskDriverFailure {
-				failed = true
-			} else {
-				dead = true
-			}
-		}
-	}
-	r.taskStatusLock.RUnlock()
-
-	// Determine the alloc status
-	if failed {
-		alloc.ClientStatus = structs.AllocClientStatusFailed
-	} else if running {
-		alloc.ClientStatus = structs.AllocClientStatusRunning
-	} else if dead && !pending {
-		alloc.ClientStatus = structs.AllocClientStatusDead
-	}
-
 	// Attempt to update the status
 	if err := r.updater(alloc); err != nil {
 		r.logger.Printf("[ERR] client: failed to update alloc '%s' status to %s: %s",
@@ -277,11 +290,40 @@ func (r *AllocRunner) setStatus(status, desc string) {
 }
 
 // setTaskState is used to set the status of a task
-func (r *AllocRunner) setTaskState(taskName string) {
+func (r *AllocRunner) setTaskState(taskName, state string, event *structs.TaskEvent) {
+	r.taskStatusLock.Lock()
+	defer r.taskStatusLock.Unlock()
+	taskState, ok := r.taskStates[taskName]
+	if !ok {
+		r.logger.Printf("[ERR] client: setting task state for unknown task %q", taskName)
+		return
+	}
+
+	// Set the tasks state.
+	taskState.State = state
+	r.appendTaskEvent(taskState, event)
+
 	select {
 	case r.dirtyCh <- struct{}{}:
 	default:
 	}
+}
+
+// appendTaskEvent updates the task status by appending the new event.
+func (r *AllocRunner) appendTaskEvent(state *structs.TaskState, event *structs.TaskEvent) {
+	capacity := 10
+	if state.Events == nil {
+		state.Events = make([]*structs.TaskEvent, 0, capacity)
+	}
+
+	// If we hit capacity, then shift it.
+	if len(state.Events) == capacity {
+		old := state.Events
+		state.Events = make([]*structs.TaskEvent, 0, capacity)
+		state.Events = append(state.Events, old[1:]...)
+	}
+
+	state.Events = append(state.Events, event)
 }
 
 // Run is a long running goroutine used to manage an allocation

--- a/client/client.go
+++ b/client/client.go
@@ -795,8 +795,9 @@ func (c *Client) watchAllocations(updates chan *allocUpdates) {
 			runner, ok := c.allocs[allocID]
 			if !ok || runner.shouldUpdate(modifyIndex) {
 				pull = append(pull, allocID)
+			} else {
+				filtered[allocID] = struct{}{}
 			}
-			filtered[allocID] = struct{}{}
 		}
 		c.allocLock.Unlock()
 		c.logger.Printf("[DEBUG] client: updated allocations at index %d (pulled %d) (filtered %d)",

--- a/client/client.go
+++ b/client/client.go
@@ -627,7 +627,7 @@ func (c *Client) run() {
 	}
 
 	// Watch for changes in allocations
-	allocUpdates := make(chan []*structs.Allocation, 1)
+	allocUpdates := make(chan *allocUpdates, 1)
 	go c.watchAllocations(allocUpdates)
 
 	// Create a snapshot timer
@@ -642,8 +642,8 @@ func (c *Client) run() {
 				c.logger.Printf("[ERR] client: failed to save state: %v", err)
 			}
 
-		case allocs := <-allocUpdates:
-			c.runAllocs(allocs)
+		case update := <-allocUpdates:
+			c.runAllocs(update)
 
 		case <-heartbeat:
 			if err := c.updateNodeStatus(); err != nil {
@@ -722,8 +722,22 @@ func (c *Client) updateAllocStatus(alloc *structs.Allocation) error {
 	return nil
 }
 
+// allocUpdates holds the results of receiving updated allocations from the
+// servers.
+type allocUpdates struct {
+	// pulled is the set of allocations that were downloaded from the servers.
+	pulled map[string]*structs.Allocation
+
+	// filtered is the set of allocations that were not pulled because their
+	// AllocModifyIndex didn't change.
+	filtered map[string]struct{}
+}
+
 // watchAllocations is used to scan for updates to allocations
-func (c *Client) watchAllocations(allocUpdates chan []*structs.Allocation) {
+func (c *Client) watchAllocations(updates chan *allocUpdates) {
+	// The request and response for getting the map of allocations that should
+	// be running on the Node to their AllocModifyIndex which is incremented
+	// when the allocation is updated by the servers.
 	req := structs.NodeSpecificRequest{
 		NodeID: c.Node().ID,
 		QueryOptions: structs.QueryOptions{
@@ -731,12 +745,24 @@ func (c *Client) watchAllocations(allocUpdates chan []*structs.Allocation) {
 			AllowStale: true,
 		},
 	}
-	var resp structs.NodeAllocsResponse
+	var resp structs.NodeClientAllocsResponse
+
+	// The request and response for pulling down the set of allocations that are
+	// new, or updated server side.
+	allocsReq := structs.AllocsGetRequest{
+		QueryOptions: structs.QueryOptions{
+			Region:     c.config.Region,
+			AllowStale: true,
+		},
+	}
+	var allocsResp structs.AllocsGetResponse
 
 	for {
-		// Get the allocations, blocking for updates
-		resp = structs.NodeAllocsResponse{}
-		err := c.RPC("Node.GetAllocs", &req, &resp)
+		// Get the allocation modify index map, blocking for updates. We will
+		// use this to determine exactly what allocations need to be downloaded
+		// in full.
+		resp = structs.NodeClientAllocsResponse{}
+		err := c.RPC("Node.GetClientAllocs", &req, &resp)
 		if err != nil {
 			c.logger.Printf("[ERR] client: failed to query for node allocations: %v", err)
 			retry := c.retryIntv(getAllocRetryIntv)
@@ -755,16 +781,69 @@ func (c *Client) watchAllocations(allocUpdates chan []*structs.Allocation) {
 		default:
 		}
 
-		// Check for updates
+		// Filter all allocations whose AllocModifyIndex was not incremented.
+		// These are the allocations who have either not been updated, or whose
+		// updates are a result of the client sending an update for the alloc.
+		// This lets us reduce the network traffic to the server as we don't
+		// need to pull all the allocations.
+		var pull []string
+		filtered := make(map[string]struct{})
+		c.allocLock.Lock()
+		for allocID, modifyIndex := range resp.Allocs {
+			// Pull the allocation if we don't have an alloc runner for the
+			// allocation or if the alloc runner requires an updated allocation.
+			runner, ok := c.allocs[allocID]
+			if !ok || runner.shouldUpdate(modifyIndex) {
+				pull = append(pull, allocID)
+			}
+			filtered[allocID] = struct{}{}
+		}
+		c.allocLock.Unlock()
+		c.logger.Printf("[DEBUG] client: updated allocations at index %d (pulled %d) (filtered %d)",
+			resp.Index, len(pull), len(filtered))
+
+		// Pull the allocations that passed filtering.
+		allocsResp.Allocs = nil
+		if len(pull) != 0 {
+			// Pull the allocations that need to be updated.
+			allocsReq.AllocIDs = pull
+			allocsResp = structs.AllocsGetResponse{}
+			if err := c.RPC("Alloc.GetAllocs", &allocsReq, &allocsResp); err != nil {
+				c.logger.Printf("[ERR] client: failed to query updated allocations: %v", err)
+				retry := c.retryIntv(getAllocRetryIntv)
+				select {
+				case <-time.After(retry):
+					continue
+				case <-c.shutdownCh:
+					return
+				}
+			}
+
+			// Check for shutdown
+			select {
+			case <-c.shutdownCh:
+				return
+			default:
+			}
+		}
+
+		// Update the query index.
 		if resp.Index <= req.MinQueryIndex {
 			continue
 		}
 		req.MinQueryIndex = resp.Index
-		c.logger.Printf("[DEBUG] client: updated allocations at index %d (%d allocs)", resp.Index, len(resp.Allocs))
 
-		// Push the updates
+		// Push the updates.
+		pulled := make(map[string]*structs.Allocation, len(allocsResp.Allocs))
+		for _, alloc := range allocsResp.Allocs {
+			pulled[alloc.ID] = alloc
+		}
+		update := &allocUpdates{
+			filtered: filtered,
+			pulled:   pulled,
+		}
 		select {
-		case allocUpdates <- resp.Allocs:
+		case updates <- update:
 		case <-c.shutdownCh:
 			return
 		}
@@ -772,7 +851,7 @@ func (c *Client) watchAllocations(allocUpdates chan []*structs.Allocation) {
 }
 
 // runAllocs is invoked when we get an updated set of allocations
-func (c *Client) runAllocs(updated []*structs.Allocation) {
+func (c *Client) runAllocs(update *allocUpdates) {
 	// Get the existing allocs
 	c.allocLock.RLock()
 	exist := make([]*structs.Allocation, 0, len(c.allocs))
@@ -782,7 +861,7 @@ func (c *Client) runAllocs(updated []*structs.Allocation) {
 	c.allocLock.RUnlock()
 
 	// Diff the existing and updated allocations
-	diff := diffAllocs(exist, updated)
+	diff := diffAllocs(exist, update)
 	c.logger.Printf("[DEBUG] client: %#v", diff)
 
 	// Remove the old allocations

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -355,10 +355,14 @@ func TestClient_WatchAllocs(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Update the other allocation
-	alloc2.DesiredStatus = structs.AllocDesiredStatusStop
+	// Update the other allocation. Have to make a copy because the allocs are
+	// shared in memory in the test and the modify index would be updated in the
+	// alloc runner.
+	alloc2_2 := new(structs.Allocation)
+	*alloc2_2 = *alloc2
+	alloc2_2.DesiredStatus = structs.AllocDesiredStatusStop
 	err = state.UpsertAllocs(102,
-		[]*structs.Allocation{alloc2})
+		[]*structs.Allocation{alloc2_2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/client/util_test.go
+++ b/client/util_test.go
@@ -17,7 +17,7 @@ func TestDiffAllocs(t *testing.T) {
 	alloc2 := mock.Alloc() // Update
 	alloc2u := new(structs.Allocation)
 	*alloc2u = *alloc2
-	alloc2u.ModifyIndex += 1
+	alloc2u.AllocModifyIndex += 1
 	alloc3 := mock.Alloc() // Remove
 	alloc4 := mock.Alloc() // Add
 
@@ -26,13 +26,17 @@ func TestDiffAllocs(t *testing.T) {
 		alloc2,
 		alloc3,
 	}
-	updated := []*structs.Allocation{
-		alloc1,
-		alloc2u,
-		alloc4,
+	update := &allocUpdates{
+		pulled: map[string]*structs.Allocation{
+			alloc2u.ID: alloc2u,
+			alloc4.ID:  alloc4,
+		},
+		filtered: map[string]struct{}{
+			alloc1.ID: struct{}{},
+		},
 	}
 
-	result := diffAllocs(exist, updated)
+	result := diffAllocs(exist, update)
 
 	if len(result.ignore) != 1 || result.ignore[0] != alloc1 {
 		t.Fatalf("Bad: %#v", result.ignore)

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -36,9 +36,6 @@ func (s *HTTPServer) NodeSpecificRequest(resp http.ResponseWriter, req *http.Req
 	case strings.HasSuffix(path, "/evaluate"):
 		nodeName := strings.TrimSuffix(path, "/evaluate")
 		return s.nodeForceEvaluate(resp, req, nodeName)
-	case strings.HasSuffix(path, "/clientallocations"):
-		nodeName := strings.TrimSuffix(path, "/clientallocations")
-		return s.nodeClientAllocations(resp, req, nodeName)
 	case strings.HasSuffix(path, "/allocations"):
 		nodeName := strings.TrimSuffix(path, "/allocations")
 		return s.nodeAllocations(resp, req, nodeName)
@@ -89,27 +86,6 @@ func (s *HTTPServer) nodeAllocations(resp http.ResponseWriter, req *http.Request
 	if out.Allocs == nil {
 		out.Allocs = make([]*structs.Allocation, 0)
 	}
-	return out.Allocs, nil
-}
-
-func (s *HTTPServer) nodeClientAllocations(resp http.ResponseWriter, req *http.Request,
-	nodeID string) (interface{}, error) {
-	if req.Method != "GET" {
-		return nil, CodedError(405, ErrInvalidMethod)
-	}
-	args := structs.NodeSpecificRequest{
-		NodeID: nodeID,
-	}
-	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
-		return nil, nil
-	}
-
-	var out structs.NodeClientAllocsResponse
-	if err := s.agent.RPC("Node.GetClientAllocs", &args, &out); err != nil {
-		return nil, err
-	}
-
-	setMeta(resp, &out.QueryMeta)
 	return out.Allocs, nil
 }
 

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -214,60 +214,6 @@ func TestHTTP_NodeAllocations(t *testing.T) {
 	})
 }
 
-func TestHTTP_NodeClientAllocations(t *testing.T) {
-	httpTest(t, nil, func(s *TestServer) {
-		// Create the job
-		node := mock.Node()
-		args := structs.NodeRegisterRequest{
-			Node:         node,
-			WriteRequest: structs.WriteRequest{Region: "global"},
-		}
-		var resp structs.NodeUpdateResponse
-		if err := s.Agent.RPC("Node.Register", &args, &resp); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		// Directly manipulate the state
-		state := s.Agent.server.State()
-		alloc1 := mock.Alloc()
-		alloc1.NodeID = node.ID
-		err := state.UpsertAllocs(1000, []*structs.Allocation{alloc1})
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/node/"+node.ID+"/clientallocations", nil)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		respW := httptest.NewRecorder()
-
-		// Make the request
-		obj, err := s.Server.NodeSpecificRequest(respW, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		// Check for the index
-		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
-			t.Fatalf("missing index")
-		}
-		if respW.HeaderMap.Get("X-Nomad-KnownLeader") != "true" {
-			t.Fatalf("missing known leader")
-		}
-		if respW.HeaderMap.Get("X-Nomad-LastContact") == "" {
-			t.Fatalf("missing last contact")
-		}
-
-		// Check the node
-		allocs := obj.(map[string]uint64)
-		if len(allocs) != 1 || allocs[alloc1.ID] != 1000 {
-			t.Fatalf("bad: %#v", allocs)
-		}
-	})
-}
-
 func TestHTTP_NodeDrain(t *testing.T) {
 	httpTest(t, nil, func(s *TestServer) {
 		// Create the node

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -421,6 +421,7 @@ func TestFSM_UpsertAllocs(t *testing.T) {
 	}
 	alloc.CreateIndex = out.CreateIndex
 	alloc.ModifyIndex = out.ModifyIndex
+	alloc.AllocModifyIndex = out.AllocModifyIndex
 	if !reflect.DeepEqual(alloc, out) {
 		t.Fatalf("bad: %#v %#v", alloc, out)
 	}

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -387,7 +387,7 @@ func (n *Node) GetAllocs(args *structs.NodeSpecificRequest,
 	return n.srv.blockingRPC(&opts)
 }
 
-// GetClientAllocs is used to request a lightweight list of modify indexes
+// GetClientAllocs is used to request a lightweight list of alloc modify indexes
 // per allocation.
 func (n *Node) GetClientAllocs(args *structs.NodeSpecificRequest,
 	reply *structs.NodeClientAllocsResponse) error {
@@ -421,7 +421,7 @@ func (n *Node) GetClientAllocs(args *structs.NodeSpecificRequest,
 			// Setup the output
 			if len(allocs) != 0 {
 				for _, alloc := range allocs {
-					reply.Allocs[alloc.ID] = alloc.ModifyIndex
+					reply.Allocs[alloc.ID] = alloc.AllocModifyIndex
 					reply.Index = maxUint64(reply.Index, alloc.ModifyIndex)
 				}
 			} else {

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -666,7 +666,7 @@ func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 		allocUpdate.NodeID = alloc.NodeID
 		allocUpdate.ID = alloc.ID
 		allocUpdate.ClientStatus = structs.AllocClientStatusRunning
-		err := state.UpdateAllocFromClient(200, allocUpdate)
+		err := state.UpsertAllocs(200, []*structs.Allocation{allocUpdate})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -793,10 +793,12 @@ func (s *StateStore) UpsertAllocs(index uint64, allocs []*structs.Allocation) er
 		if existing == nil {
 			alloc.CreateIndex = index
 			alloc.ModifyIndex = index
+			alloc.AllocModifyIndex = index
 		} else {
 			exist := existing.(*structs.Allocation)
 			alloc.CreateIndex = exist.CreateIndex
 			alloc.ModifyIndex = index
+			alloc.AllocModifyIndex = index
 			alloc.ClientStatus = exist.ClientStatus
 			alloc.ClientDescription = exist.ClientDescription
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1675,8 +1675,11 @@ type Allocation struct {
 	TaskStates map[string]*TaskState
 
 	// Raft Indexes
-	CreateIndex      uint64
-	ModifyIndex      uint64
+	CreateIndex uint64
+	ModifyIndex uint64
+
+	// AllocModifyIndex is not updated when the client updates allocations. This
+	// lets the client pull only the allocs updated by the server.
 	AllocModifyIndex uint64
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -272,6 +272,12 @@ type AllocSpecificRequest struct {
 	QueryOptions
 }
 
+// AllocsGetcRequest is used to query a set of allocations
+type AllocsGetRequest struct {
+	AllocIDs []string
+	QueryOptions
+}
+
 // PeriodicForceReqeuest is used to force a specific periodic job.
 type PeriodicForceRequest struct {
 	JobID string
@@ -375,6 +381,12 @@ type JobListResponse struct {
 // SingleAllocResponse is used to return a single allocation
 type SingleAllocResponse struct {
 	Alloc *Allocation
+	QueryMeta
+}
+
+// AllocsGetResponse is used to return a set of allocations
+type AllocsGetResponse struct {
+	Allocs []*Allocation
 	QueryMeta
 }
 
@@ -1647,8 +1659,9 @@ type Allocation struct {
 	TaskStates map[string]*TaskState
 
 	// Raft Indexes
-	CreateIndex uint64
-	ModifyIndex uint64
+	CreateIndex      uint64
+	ModifyIndex      uint64
+	AllocModifyIndex uint64
 }
 
 // TerminalStatus returns if the desired or actual status is terminal and

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1448,6 +1448,16 @@ type TaskState struct {
 	Events []*TaskEvent
 }
 
+func (ts *TaskState) Copy() *TaskState {
+	copy := new(TaskState)
+	copy.State = ts.State
+	copy.Events = make([]*TaskEvent, len(ts.Events))
+	for i, e := range ts.Events {
+		copy.Events[i] = e.Copy()
+	}
+	return copy
+}
+
 const (
 	// A Driver failure indicates that the task could not be started due to a
 	// failure in the driver.
@@ -1480,6 +1490,12 @@ type TaskEvent struct {
 
 	// Task Killed Fields.
 	KillError string // Error killing the task.
+}
+
+func (te *TaskEvent) Copy() *TaskEvent {
+	copy := new(TaskEvent)
+	*copy = *te
+	return copy
 }
 
 func NewTaskEvent(event string) *TaskEvent {
@@ -1662,6 +1678,15 @@ type Allocation struct {
 	CreateIndex      uint64
 	ModifyIndex      uint64
 	AllocModifyIndex uint64
+}
+
+func (a *Allocation) Copy() *Allocation {
+	i, err := copystructure.Copy(a)
+	if err != nil {
+		panic(err)
+	}
+
+	return i.(*Allocation)
 }
 
 // TerminalStatus returns if the desired or actual status is terminal and

--- a/website/source/docs/http/node.html.md
+++ b/website/source/docs/http/node.html.md
@@ -311,44 +311,6 @@ be specified using the `?region=` query parameter.
   </dd>
 </dl>
 
-<dl>
-  <dt>Description</dt>
-  <dd>
-    Query the allocations belonging to a single node. This endpoint only returns
-    a map from allocation id to its modify index and is primarily used by the client
-    to determine which allocations need to be updated.
-  </dd>
-
-  <dt>Method</dt>
-  <dd>GET</dd>
-
-  <dt>URL</dt>
-  <dd>`/v1/node/<id>/clientallocations`</dd>
-
-  <dt>Parameters</dt>
-  <dd>
-    None
-  </dd>
-
-  <dt>Blocking Queries</dt>
-  <dd>
-    [Supported](/docs/http/index.html#blocking-queries)
-  </dd>
-
-  <dt>Returns</dt>
-  <dd>
-
-    ```javascript
-    {
-        "d66ea8d7-1d4c-119e-46b3-e23713a4ab72": 9,
-        "abf34c35-1d4c-119e-46b3-e23713a4ab72": 10
-    }
-    ```
-
-  </dd>
-</dl>
-
-
 ## PUT / POST
 
 <dl>


### PR DESCRIPTION
Previously the client would pull all its allocations whenever the modify index of an allocation that should be running on it changed.

This PR modifies the client to track how many updates have occurred locally to the running alloc and then only pulls a lightweight list of allocation ids to modify indexes from the server. It uses this to decide whether an updated version of the allocation needs to be pulled from the server.

This reduces network traffic when the client updates allocs to the server.