### PR TITLE
fix testutil/wait.go:51: undefined: os.LookupEnv

### DIFF
--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -48,8 +48,12 @@ func TestMultiplier() int64 {
 }
 
 func IsTravis() bool {
-	_, ok := os.LookupEnv(TravisRunEnv)
-	return ok
+	ok := os.Getenv(TravisRunEnv)
+	if ok == "" {
+		return false
+	} else {
+		return true
+	}
 }
 
 type rpcFn func(string, interface{}, interface{}) error


### PR DESCRIPTION
fix
testutil/wait.go:51: undefined: os.LookupEnv