### PR TITLE
Fix computed class when the job has multiple task groups

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1245,6 +1245,15 @@ type TaskGroup struct {
 	Meta map[string]string
 }
 
+func (tg *TaskGroup) Copy() *TaskGroup {
+	i, err := copystructure.Copy(tg)
+	if err != nil {
+		panic(err)
+	}
+
+	return i.(*TaskGroup)
+}
+
 // InitFields is used to initialize fields in the TaskGroup.
 func (tg *TaskGroup) InitFields(job *Job) {
 	// Set the default restart policy.

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -153,6 +153,7 @@ func (s *GenericStack) Select(tg *structs.TaskGroup) (*RankedNode, *structs.Reso
 	s.taskGroupDrivers.SetDrivers(tgConstr.drivers)
 	s.taskGroupConstraint.SetConstraints(tgConstr.constraints)
 	s.proposedAllocConstraint.SetTaskGroup(tg)
+	s.wrappedChecks.SetTaskGroup(tg.Name)
 	s.binPack.SetTasks(tg.Tasks)
 
 	// Find the node with the max score
@@ -242,6 +243,7 @@ func (s *SystemStack) Select(tg *structs.TaskGroup) (*RankedNode, *structs.Resou
 	s.taskGroupDrivers.SetDrivers(tgConstr.drivers)
 	s.taskGroupConstraint.SetConstraints(tgConstr.constraints)
 	s.binPack.SetTasks(tg.Tasks)
+	s.wrappedChecks.SetTaskGroup(tg.Name)
 
 	// Get the next option that satisfies the constraints.
 	option := s.binPack.Next()


### PR DESCRIPTION
Fix computed class when the job has multiple task groups