### PR TITLE
Ensure there are no periods in the service name

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1414,6 +1414,13 @@ func (s *Service) InitFields(job string, taskGroup string, task string) {
 // Validate checks if the Check definition is valid
 func (s *Service) Validate() error {
 	var mErr multierror.Error
+
+	// Ensure the name does not have a period in it.
+	// RFC-2782: https://tools.ietf.org/html/rfc2782
+	if strings.Contains(s.Name, ".") {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("service name can't contain periods: %q", s.Name))
+	}
+
 	for _, c := range s.Checks {
 		if err := c.Validate(); err != nil {
 			mErr.Errors = append(mErr.Errors, err)

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -490,7 +490,7 @@ func TestInvalidServiceCheck(t *testing.T) {
 		Name:      "service.name",
 		PortLabel: "bar",
 	}
-	if err := s.Validate(); err != nil {
+	if err := s.Validate(); err == nil {
 		t.Fatalf("Service should be invalid: %v", err)
 	}
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -485,6 +485,14 @@ func TestInvalidServiceCheck(t *testing.T) {
 	if err := s.Validate(); err == nil {
 		t.Fatalf("Service should be invalid")
 	}
+
+	s = Service{
+		Name:      "service.name",
+		PortLabel: "bar",
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("Service should be invalid: %v", err)
+	}
 }
 
 func TestDistinctCheckID(t *testing.T) {


### PR DESCRIPTION
https://tools.ietf.org/html/rfc2782