### PR TITLE
Reading dockercfg files for authenticating with private registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ IMPROVEMENTS:
   * drivers: Interpret Nomad variables in environment variables/args [GH-653]
   * driver/rkt: Add support for CPU/Memory isolation [GH-610]
   * driver/rkt: Add support for mounting alloc/task directory [GH-645]
+  * driver/docker: Support for .dockercfg based auth for private registries
+    [GH-773]
 
 BUG FIXES:
   * core: Node drain could only be partially applied [GH-750]

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -438,6 +439,17 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 				Password:      driverConfig.Auth[0].Password,
 				Email:         driverConfig.Auth[0].Email,
 				ServerAddress: driverConfig.Auth[0].ServerAddress,
+			}
+		}
+
+		if authConfig := d.config.Read("docker.auth_config"); authConfig != "" {
+			if f, err := os.Open(authConfig); err == nil {
+				defer f.Close()
+				if authConfigurations, err := docker.NewAuthConfigurations(f); err == nil {
+					if authConfiguration, ok := authConfigurations.Configs[repo]; ok {
+						authOptions = authConfiguration
+					}
+				}
 			}
 		}
 

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -442,7 +442,7 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 			}
 		}
 
-		if authConfig := d.config.Read("docker.auth_config"); authConfig != "" {
+		if authConfig := d.config.Read("docker.auth.config"); authConfig != "" {
 			if f, err := os.Open(authConfig); err == nil {
 				defer f.Close()
 				if authConfigurations, err := docker.NewAuthConfigurations(f); err == nil {

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -247,6 +247,9 @@ The `docker` driver has the following host-level configuration options:
   to customize this if you use a non-standard socket (http or another
   location).
 
+* `docker.auth_config` - Allows an operator to specify a json file which is in
+  the dockercfg format containing authentication information for private registry. 
+
 * `docker.tls.cert` - Path to the server's certificate file (`.pem`). Specify
   this along with `docker.tls.key` and `docker.tls.ca` to use a TLS client to
   connect to the docker daemon. `docker.endpoint` must also be specified or

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -247,7 +247,7 @@ The `docker` driver has the following host-level configuration options:
   to customize this if you use a non-standard socket (http or another
   location).
 
-* `docker.auth_config` - Allows an operator to specify a json file which is in
+* `docker.auth.config` - Allows an operator to specify a json file which is in
   the dockercfg format containing authentication information for private registry. 
 
 * `docker.tls.cert` - Path to the server's certificate file (`.pem`). Specify


### PR DESCRIPTION
Fixed #660 and #702 