### PR TITLE
Store alloc creation time

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -60,6 +60,7 @@ type Allocation struct {
 	TaskStates         map[string]*TaskState
 	CreateIndex        uint64
 	ModifyIndex        uint64
+	CreateTime         int64
 }
 
 // AllocationMetric is used to deserialize allocation metrics.
@@ -93,6 +94,7 @@ type AllocationListStub struct {
 	TaskStates         map[string]*TaskState
 	CreateIndex        uint64
 	ModifyIndex        uint64
+	CreateTime         int64
 }
 
 // AllocIndexSort reverse sorts allocs by CreateIndex.

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -127,6 +127,15 @@ func (s *Server) applyPlan(result *structs.PlanResult, snap *state.StateSnapshot
 	}
 	req.Alloc = append(req.Alloc, result.FailedAllocs...)
 
+	// Set the time the alloc was applied for the first time. This can be used
+	// to approximate the scheduling time.
+	now := time.Now().UTC().UnixNano()
+	for _, alloc := range req.Alloc {
+		if alloc.CreateTime == 0 {
+			alloc.CreateTime = now
+		}
+	}
+
 	// Dispatch the Raft transaction
 	future, err := s.raftApplyFuture(structs.AllocUpdateRequestType, &req)
 	if err != nil {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1765,6 +1765,10 @@ type Allocation struct {
 	// AllocModifyIndex is not updated when the client updates allocations. This
 	// lets the client pull only the allocs updated by the server.
 	AllocModifyIndex uint64
+
+	// CreateTime is the time the allocation has finished scheduling and been
+	// verified by the plan applier.
+	CreateTime int64
 }
 
 func (a *Allocation) Copy() *Allocation {
@@ -1811,6 +1815,7 @@ func (a *Allocation) Stub() *AllocListStub {
 		TaskStates:         a.TaskStates,
 		CreateIndex:        a.CreateIndex,
 		ModifyIndex:        a.ModifyIndex,
+		CreateTime:         a.CreateTime,
 	}
 }
 
@@ -1858,6 +1863,7 @@ type AllocListStub struct {
 	TaskStates         map[string]*TaskState
 	CreateIndex        uint64
 	ModifyIndex        uint64
+	CreateTime         int64
 }
 
 // AllocMetric is used to track various metrics while attempting


### PR DESCRIPTION
This PR stores the alloc creation time after it has been applied by the plan applier.