### PR TITLE
Fix panic when Ack occurs at delivery limit

### DIFF
--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -448,7 +448,7 @@ func (b *EvalBroker) Ack(evalID, token string) error {
 	// Update the stats
 	b.stats.TotalUnacked -= 1
 	queue := unack.Eval.Type
-	if b.evals[evalID] >= b.deliveryLimit {
+	if b.evals[evalID] > b.deliveryLimit {
 		queue = failedQueue
 	}
 	bySched := b.stats.ByScheduler[queue]


### PR DESCRIPTION
This PR fixes a panic when Ack occurs at delivery limit. This was because of an off by one error.