### PR TITLE
Update go-cleanhttp

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -156,7 +156,7 @@
 		},
 		{
 			"ImportPath": "github.com/hashicorp/go-cleanhttp",
-			"Rev": "ce617e79981a8fff618bb643d155133a8f38db96"
+			"Rev": "875fb671b3ddc66f8e2f0acc33829c8cb989a38d"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/go-getter",

--- a/vendor/github.com/hashicorp/go-cleanhttp/cleanhttp.go
+++ b/vendor/github.com/hashicorp/go-cleanhttp/cleanhttp.go
@@ -3,13 +3,23 @@ package cleanhttp
 import (
 	"net"
 	"net/http"
-	"runtime"
 	"time"
 )
 
 // DefaultTransport returns a new http.Transport with the same default values
-// as http.DefaultTransport
+// as http.DefaultTransport, but with idle connections and keepalives disabled.
 func DefaultTransport() *http.Transport {
+	transport := DefaultPooledTransport()
+	transport.DisableKeepAlives = true
+	transport.MaxIdleConnsPerHost = -1
+	return transport
+}
+
+// DefaultPooledTransport returns a new http.Transport with similar default
+// values to http.DefaultTransport. Do not use this for transient transports as
+// it can leak file descriptors over time. Only use this for transports that
+// will be re-used for the same host(s).
+func DefaultPooledTransport() *http.Transport {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
@@ -17,24 +27,27 @@ func DefaultTransport() *http.Transport {
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
+		DisableKeepAlives:   false,
+		MaxIdleConnsPerHost: 1,
 	}
-	SetTransportFinalizer(transport)
 	return transport
 }
 
-// DefaultClient returns a new http.Client with the same default values as
-// http.Client, but with a non-shared Transport
+// DefaultClient returns a new http.Client with similar default values to
+// http.Client, but with a non-shared Transport, idle connections disabled, and
+// keepalives disabled.
 func DefaultClient() *http.Client {
 	return &http.Client{
 		Transport: DefaultTransport(),
 	}
 }
 
-// SetTransportFinalizer sets a finalizer on the transport to ensure that
-// idle connections are closed prior to garbage collection; otherwise
-// these may leak
-func SetTransportFinalizer(transport *http.Transport) {
-	runtime.SetFinalizer(&transport, func(t **http.Transport) {
-		(*t).CloseIdleConnections()
-	})
+// DefaultPooledClient returns a new http.Client with the same default values
+// as http.Client, but with a non-shared Transport. Do not use this function
+// for transient clients as it can leak file descriptors over time. Only use
+// this for clients that will be re-used for the same host(s).
+func DefaultPooledClient() *http.Client {
+	return &http.Client{
+		Transport: DefaultPooledTransport(),
+	}
 }

--- a/vendor/github.com/hashicorp/go-cleanhttp/doc.go
+++ b/vendor/github.com/hashicorp/go-cleanhttp/doc.go
@@ -1,0 +1,20 @@
+// Package cleanhttp offers convenience utilities for acquiring "clean"
+// http.Transport and http.Client structs.
+//
+// Values set on http.DefaultClient and http.DefaultTransport affect all
+// callers. This can have detrimental effects, esepcially in TLS contexts,
+// where client or root certificates set to talk to multiple endpoints can end
+// up displacing each other, leading to hard-to-debug issues. This package
+// provides non-shared http.Client and http.Transport structs to ensure that
+// the configuration will not be overwritten by other parts of the application
+// or dependencies.
+//
+// The DefaultClient and DefaultTransport functions disable idle connections
+// and keepalives. Without ensuring that idle connections are closed before
+// garbage collection, short-term clients/transports can leak file descriptors,
+// eventually leading to "too many open files" errors. If you will be
+// connecting to the same hosts repeatedly from the same client, you can use
+// DefaultPooledClient to receive a client that has connection pooling
+// semantics similar to http.DefaultClient.
+//
+package cleanhttp


### PR DESCRIPTION
This makes the handling of idle connections more robust and adds the Pooled functions.