### PR TITLE
Use compound index on node allocations to include terminal status

### DIFF
--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -256,14 +256,11 @@ func evaluateNodePlan(snap *state.StateSnapshot, plan *structs.Plan, nodeID stri
 		return false, nil
 	}
 
-	// Get the existing allocations
-	existingAlloc, err := snap.AllocsByNode(nodeID)
+	// Get the existing allocations that are non-terminal
+	existingAlloc, err := snap.AllocsByNodeTerminal(nodeID, false)
 	if err != nil {
 		return false, fmt.Errorf("failed to get existing allocations for '%s': %v", nodeID, err)
 	}
-
-	// Filter on alloc state
-	existingAlloc = structs.FilterTerminalAllocs(existingAlloc)
 
 	// Determine the proposed allocation by first removing allocations
 	// that are planned evictions and adding the new allocations.

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -865,8 +865,30 @@ func (s *StateStore) AllocsByIDPrefix(id string) (memdb.ResultIterator, error) {
 func (s *StateStore) AllocsByNode(node string) ([]*structs.Allocation, error) {
 	txn := s.db.Txn(false)
 
+	// Get an iterator over the node allocations, using only the
+	// node prefix which ignores the terminal status
+	iter, err := txn.Get("allocs", "node_prefix", node)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*structs.Allocation
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		out = append(out, raw.(*structs.Allocation))
+	}
+	return out, nil
+}
+
+// AllocsByNode returns all the allocations by node and terminal status
+func (s *StateStore) AllocsByNodeTerminal(node string, terminal bool) ([]*structs.Allocation, error) {
+	txn := s.db.Txn(false)
+
 	// Get an iterator over the node allocations
-	iter, err := txn.Get("allocs", "node", node)
+	iter, err := txn.Get("allocs", "node", node, terminal)
 	if err != nil {
 		return nil, err
 	}

--- a/scheduler/context.go
+++ b/scheduler/context.go
@@ -107,14 +107,11 @@ func (e *EvalContext) Reset() {
 }
 
 func (e *EvalContext) ProposedAllocs(nodeID string) ([]*structs.Allocation, error) {
-	// Get the existing allocations
-	existingAlloc, err := e.state.AllocsByNode(nodeID)
+	// Get the existing allocations that are non-terminal
+	existingAlloc, err := e.state.AllocsByNodeTerminal(nodeID, false)
 	if err != nil {
 		return nil, err
 	}
-
-	// Filter on alloc state
-	existingAlloc = structs.FilterTerminalAllocs(existingAlloc)
 
 	// Determine the proposed allocation by first removing allocations
 	// that are planned evictions and adding the new allocations.

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -63,6 +63,9 @@ type State interface {
 	// AllocsByNode returns all the allocations by node
 	AllocsByNode(node string) ([]*structs.Allocation, error)
 
+	// AllocsByNodeTerminal returns all the allocations by node filtering by terminal status
+	AllocsByNodeTerminal(node string, terminal bool) ([]*structs.Allocation, error)
+
 	// GetNodeByID is used to lookup a node by ID
 	NodeByID(nodeID string) (*structs.Node, error)
 


### PR DESCRIPTION
This PR extends the "node" index on the "allocs" table to include the terminal status using a compound index. This allows us to avoid the linear filter step in a few hot paths.

cc: @dadgar 