### PR TITLE
Switch port collision checking to use bitmap instead of map

### DIFF
--- a/nomad/structs/bitmap.go
+++ b/nomad/structs/bitmap.go
@@ -1,0 +1,39 @@
+package structs
+
+import "fmt"
+
+// Bitmap is a simple uncompressed bitmap
+type Bitmap []byte
+
+// NewBitmap returns a bitmap with up to size indexes
+func NewBitmap(size int) (Bitmap, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("bitmap must be positive size")
+	}
+	if size&7 != 0 {
+		return nil, fmt.Errorf("bitmap must be byte aligned")
+	}
+	b := make([]byte, size>>3)
+	return Bitmap(b), nil
+}
+
+// Set is used to set the given index of the bitmap
+func (b Bitmap) Set(idx uint) {
+	bucket := idx >> 3
+	mask := byte(1 << (idx & 7))
+	b[bucket] |= mask
+}
+
+// Check is used to check the given index of the bitmap
+func (b Bitmap) Check(idx uint) bool {
+	bucket := idx >> 3
+	mask := byte(1 << (idx & 7))
+	return (b[bucket] & mask) != 0
+}
+
+// Clear is used to efficiently clear the bitmap
+func (b Bitmap) Clear() {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/nomad/structs/bitmap_test.go
+++ b/nomad/structs/bitmap_test.go
@@ -1,0 +1,58 @@
+package structs
+
+import "testing"
+
+func TestBitmap(t *testing.T) {
+	// Check invalid sizes
+	_, err := NewBitmap(0)
+	if err == nil {
+		t.Fatalf("bad")
+	}
+	_, err = NewBitmap(7)
+	if err == nil {
+		t.Fatalf("bad")
+	}
+
+	// Create a normal bitmap
+	b, err := NewBitmap(256)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Set a few bits
+	b.Set(0)
+	b.Set(255)
+
+	// Verify the bytes
+	if b[0] == 0 {
+		t.Fatalf("bad")
+	}
+	if !b.Check(0) {
+		t.Fatalf("bad")
+	}
+
+	// Verify the bytes
+	if b[len(b)-1] == 0 {
+		t.Fatalf("bad")
+	}
+	if !b.Check(255) {
+		t.Fatalf("bad")
+	}
+
+	// All other bits should be unset
+	for i := 1; i < 255; i++ {
+		if b.Check(uint(i)) {
+			t.Fatalf("bad")
+		}
+	}
+
+	// Clear
+	b.Clear()
+
+	// All bits should be unset
+	for i := 0; i < 256; i++ {
+		if b.Check(uint(i)) {
+			t.Fatalf("bad")
+		}
+	}
+}

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -72,6 +72,7 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex) (bool, st
 	// Create the network index if missing
 	if netIdx == nil {
 		netIdx = NewNetworkIndex()
+		defer netIdx.Release()
 		if netIdx.SetNode(node) || netIdx.AddAllocs(allocs) {
 			return false, "reserved port collision", used, nil
 		}

--- a/nomad/structs/network_test.go
+++ b/nomad/structs/network_test.go
@@ -85,7 +85,7 @@ func TestNetworkIndex_SetNode(t *testing.T) {
 	if idx.UsedBandwidth["eth0"] != 1 {
 		t.Fatalf("Bad")
 	}
-	if _, ok := idx.UsedPorts["192.168.0.100"][22]; !ok {
+	if !idx.UsedPorts["192.168.0.100"].Check(22) {
 		t.Fatalf("Bad")
 	}
 }
@@ -130,13 +130,13 @@ func TestNetworkIndex_AddAllocs(t *testing.T) {
 	if idx.UsedBandwidth["eth0"] != 70 {
 		t.Fatalf("Bad")
 	}
-	if _, ok := idx.UsedPorts["192.168.0.100"][8000]; !ok {
+	if !idx.UsedPorts["192.168.0.100"].Check(8000) {
 		t.Fatalf("Bad")
 	}
-	if _, ok := idx.UsedPorts["192.168.0.100"][9000]; !ok {
+	if !idx.UsedPorts["192.168.0.100"].Check(9000) {
 		t.Fatalf("Bad")
 	}
-	if _, ok := idx.UsedPorts["192.168.0.100"][10000]; !ok {
+	if !idx.UsedPorts["192.168.0.100"].Check(10000) {
 		t.Fatalf("Bad")
 	}
 }
@@ -158,10 +158,10 @@ func TestNetworkIndex_AddReserved(t *testing.T) {
 	if idx.UsedBandwidth["eth0"] != 20 {
 		t.Fatalf("Bad")
 	}
-	if _, ok := idx.UsedPorts["192.168.0.100"][8000]; !ok {
+	if !idx.UsedPorts["192.168.0.100"].Check(8000) {
 		t.Fatalf("Bad")
 	}
-	if _, ok := idx.UsedPorts["192.168.0.100"][9000]; !ok {
+	if !idx.UsedPorts["192.168.0.100"].Check(9000) {
 		t.Fatalf("Bad")
 	}
 

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -193,6 +193,7 @@ OUTER:
 				if offer == nil {
 					iter.ctx.Metrics().ExhaustedNode(option.Node,
 						fmt.Sprintf("network: %s", err))
+					netIdx.Release()
 					continue OUTER
 				}
 
@@ -215,6 +216,7 @@ OUTER:
 
 		// Check if these allocations fit, if they do not, simply skip this node
 		fit, dim, util, _ := structs.AllocsFit(option.Node, proposed, netIdx)
+		netIdx.Release()
 		if !fit {
 			iter.ctx.Metrics().ExhaustedNode(option.Node, dim)
 			continue


### PR DESCRIPTION
The map was originally used assuming very few ports that are sparse. In practice, the clients may reserve large chunks of ports and the map is rapidly more expensive than maintaining an uncompressed bitmap. Additionally, we can cache the bitmaps to reduce the GC pressure.

/cc: @dadgar 