### PR TITLE
Make the client only reserve 512 ports.

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -297,7 +297,7 @@ func DefaultConfig() *Config {
 			NetworkSpeed:   100,
 			MaxKillTimeout: "30s",
 			ClientMinPort:  14000,
-			ClientMaxPort:  19000,
+			ClientMaxPort:  14512,
 		},
 		Server: &ServerConfig{
 			Enabled:          false,


### PR DESCRIPTION
This PR reduces the number of ports the client reserves by default to a more reasonable value.