### PR TITLE
Enable job normalization during planning

### DIFF
--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -128,8 +128,16 @@ func (s *Server) planApply() {
 
 // applyPlan is used to apply the plan result and to return the alloc index
 func (s *Server) applyPlan(job *structs.Job, result *structs.PlanResult, snap *state.StateSnapshot) (raft.ApplyFuture, error) {
+	// Determine the miniumum number of updates, could be more if there
+	// are multiple updates per node
+	minUpdates := len(result.NodeUpdate)
+	minUpdates += len(result.NodeAllocation)
+	minUpdates += len(result.FailedAllocs)
+
+	// Setup the update request
 	req := structs.AllocUpdateRequest{
-		Job: job,
+		Job:   job,
+		Alloc: make([]*structs.Allocation, 0, minUpdates),
 	}
 	for _, updateList := range result.NodeUpdate {
 		req.Alloc = append(req.Alloc, updateList...)

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -113,7 +113,7 @@ func (s *Server) planApply() {
 		}
 
 		// Dispatch the Raft transaction for the plan
-		future, err := s.applyPlan(result, snap)
+		future, err := s.applyPlan(pending.plan.Job, result, snap)
 		if err != nil {
 			s.logger.Printf("[ERR] nomad: failed to submit plan: %v", err)
 			pending.respond(nil, err)
@@ -127,8 +127,10 @@ func (s *Server) planApply() {
 }
 
 // applyPlan is used to apply the plan result and to return the alloc index
-func (s *Server) applyPlan(result *structs.PlanResult, snap *state.StateSnapshot) (raft.ApplyFuture, error) {
-	req := structs.AllocUpdateRequest{}
+func (s *Server) applyPlan(job *structs.Job, result *structs.PlanResult, snap *state.StateSnapshot) (raft.ApplyFuture, error) {
+	req := structs.AllocUpdateRequest{
+		Job: job,
+	}
 	for _, updateList := range result.NodeUpdate {
 		req.Alloc = append(req.Alloc, updateList...)
 	}

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -66,7 +66,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	}
 
 	// Apply the plan
-	future, err := s1.applyPlan(plan, snap)
+	future, err := s1.applyPlan(alloc.Job, plan, snap)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -107,7 +107,10 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	allocEvict := new(structs.Allocation)
 	*allocEvict = *alloc
 	allocEvict.DesiredStatus = structs.AllocDesiredStatusEvict
+	job := allocEvict.Job
+	allocEvict.Job = nil
 	alloc2 := mock.Alloc()
+	alloc2.Job = nil
 	plan = &structs.PlanResult{
 		NodeUpdate: map[string][]*structs.Allocation{
 			node.ID: []*structs.Allocation{allocEvict},
@@ -124,7 +127,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	}
 
 	// Apply the plan
-	future, err = s1.applyPlan(plan, snap)
+	future, err = s1.applyPlan(job, plan, snap)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -151,6 +154,9 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	if out.DesiredStatus != structs.AllocDesiredStatusEvict {
 		t.Fatalf("should be evicted alloc: %#v", out)
 	}
+	if out.Job == nil {
+		t.Fatalf("missing job")
+	}
 
 	// Lookup the allocation
 	out, err = s1.fsm.State().AllocByID(alloc2.ID)
@@ -159,6 +165,9 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	}
 	if out == nil {
 		t.Fatalf("missing alloc")
+	}
+	if out.Job == nil {
+		t.Fatalf("missing job")
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2023,29 +2023,25 @@ func (a *Allocation) Stub() *AllocListStub {
 
 // PopulateServiceIDs generates the service IDs for all the service definitions
 // in that Allocation
-func (a *Allocation) PopulateServiceIDs() {
-	// Make a copy of the old map which contains the service names and their
-	// generated IDs
-	oldIDs := make(map[string]string)
-	for k, v := range a.Services {
-		oldIDs[k] = v
-	}
-
+func (a *Allocation) PopulateServiceIDs(tg *TaskGroup) {
+	// Retain the old services, and re-initialize. We may be removing
+	// services, so we cannot update the existing map.
+	previous := a.Services
 	a.Services = make(map[string]string)
-	tg := a.Job.LookupTaskGroup(a.TaskGroup)
+
 	for _, task := range tg.Tasks {
 		for _, service := range task.Services {
-			// If the ID for a service name is already generated then we re-use
-			// it
-			if ID, ok := oldIDs[service.Name]; ok {
-				a.Services[service.Name] = ID
-			} else {
-				// If the service hasn't been generated an ID, we generate one.
-				// We add a prefix to the Service ID so that we can know that this service
-				// is managed by Nomad since Consul can also have service which are not
-				// managed by Nomad
-				a.Services[service.Name] = fmt.Sprintf("%s-%s", NomadConsulPrefix, GenerateUUID())
+			// Retain the service if an ID is already generated
+			if id, ok := previous[service.Name]; ok {
+				a.Services[service.Name] = id
+				continue
 			}
+
+			// If the service hasn't been generated an ID, we generate one.
+			// We add a prefix to the Service ID so that we can know that this service
+			// is managed by Nomad since Consul can also have service which are not
+			// managed by Nomad
+			a.Services[service.Name] = fmt.Sprintf("%s-%s", NomadConsulPrefix, GenerateUUID())
 		}
 	}
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -260,6 +260,11 @@ type PlanRequest struct {
 type AllocUpdateRequest struct {
 	// Alloc is the list of new allocations to assign
 	Alloc []*Allocation
+
+	// Job is the shared parent job of the allocations.
+	// It is pulled out since it is common to reduce payload size.
+	Job *Job
+
 	WriteRequest
 }
 
@@ -2328,6 +2333,7 @@ func (e *Evaluation) MakePlan(j *Job) *Plan {
 	p := &Plan{
 		EvalID:         e.ID,
 		Priority:       e.Priority,
+		Job:            j,
 		NodeUpdate:     make(map[string][]*Allocation),
 		NodeAllocation: make(map[string][]*Allocation),
 	}
@@ -2392,6 +2398,11 @@ type Plan struct {
 	// If this is false, a plan may be partially applied. Otherwise, the
 	// entire plan must be able to make progress.
 	AllAtOnce bool
+
+	// Job is the parent job of all the allocations in the Plan.
+	// Since a Plan only involves a single Job, we can reduce the size
+	// of the plan by only including it once.
+	Job *Job
 
 	// NodeUpdate contains all the allocations for each node. For each node,
 	// this is a list of the allocations to update to either stop or evict.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2421,9 +2421,7 @@ type Plan struct {
 func (p *Plan) AppendUpdate(alloc *Allocation, status, desc string) {
 	newAlloc := new(Allocation)
 	*newAlloc = *alloc
-	if p.Job != nil {
-		newAlloc.Job = nil // Normalize the job
-	}
+	newAlloc.Job = nil // Normalize the job
 	newAlloc.DesiredStatus = status
 	newAlloc.DesiredDescription = desc
 	node := alloc.NodeID

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2421,6 +2421,9 @@ type Plan struct {
 func (p *Plan) AppendUpdate(alloc *Allocation, status, desc string) {
 	newAlloc := new(Allocation)
 	*newAlloc = *alloc
+	if p.Job != nil {
+		newAlloc.Job = nil // Normalize the job
+	}
 	newAlloc.DesiredStatus = status
 	newAlloc.DesiredDescription = desc
 	node := alloc.NodeID

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -350,9 +350,8 @@ func (s *GenericScheduler) computePlacements(place []allocTuple) error {
 
 		// Set fields based on if we found an allocation option
 		if option != nil {
-			// Generate the service ids for the tasks which this allocation is going
-			// to run
-			alloc.PopulateServiceIDs()
+			// Generate service IDs tasks in this allocation
+			alloc.PopulateServiceIDs(missing.TaskGroup)
 
 			alloc.NodeID = option.Node.ID
 			alloc.TaskResources = option.TaskResources

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -339,7 +339,6 @@ func (s *GenericScheduler) computePlacements(place []allocTuple) error {
 			EvalID:    s.eval.ID,
 			Name:      missing.Name,
 			JobID:     s.job.ID,
-			Job:       s.job,
 			TaskGroup: missing.TaskGroup.Name,
 			Resources: size,
 			Metrics:   s.ctx.Metrics(),

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -93,6 +93,17 @@ func (h *Harness) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, State, er
 	}
 	allocs = append(allocs, plan.FailedAllocs...)
 
+	// Attach the plan to all the allocations. It is pulled out in the
+	// payload to avoid the redundancy of encoding, but should be denormalized
+	// prior to being inserted into MemDB.
+	if j := plan.Job; j != nil {
+		for _, alloc := range allocs {
+			if alloc.Job == nil {
+				alloc.Job = j
+			}
+		}
+	}
+
 	// Apply the full plan
 	err := h.State.UpsertAllocs(index, allocs)
 	return result, nil, err

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -255,9 +255,8 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 
 		// Set fields based on if we found an allocation option
 		if option != nil {
-			// Generate the service ids for the tasks that this allocation is going
-			// to run
-			alloc.PopulateServiceIDs()
+			// Generate service IDs tasks in this allocation
+			alloc.PopulateServiceIDs(missing.TaskGroup)
 
 			alloc.NodeID = option.Node.ID
 			alloc.TaskResources = option.TaskResources

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -244,7 +244,6 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 			EvalID:    s.eval.ID,
 			Name:      missing.Name,
 			JobID:     s.job.ID,
-			Job:       s.job,
 			TaskGroup: missing.TaskGroup.Name,
 			Resources: size,
 			Metrics:   s.ctx.Metrics(),

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -391,7 +391,7 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 
 		// Update the allocation
 		newAlloc.EvalID = eval.ID
-		newAlloc.Job = job
+		newAlloc.Job = nil // Use the Job in the Plan
 		newAlloc.Resources = size
 		newAlloc.TaskResources = option.TaskResources
 		newAlloc.Metrics = ctx.Metrics()

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -397,7 +397,7 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 		newAlloc.Metrics = ctx.Metrics()
 		newAlloc.DesiredStatus = structs.AllocDesiredStatusRun
 		newAlloc.ClientStatus = structs.AllocClientStatusPending
-		newAlloc.PopulateServiceIDs()
+		newAlloc.PopulateServiceIDs(update.TaskGroup)
 		ctx.Plan().AppendAlloc(newAlloc)
 
 		// Remove this allocation from the slice

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -575,7 +575,7 @@ func TestInplaceUpdate_Success(t *testing.T) {
 		DesiredStatus: structs.AllocDesiredStatusRun,
 	}
 	alloc.TaskResources = map[string]*structs.Resources{"web": alloc.Resources}
-	alloc.PopulateServiceIDs()
+	alloc.PopulateServiceIDs(job.TaskGroups[0])
 	noErr(t, state.UpsertAllocs(1001, []*structs.Allocation{alloc}))
 
 	webFeSrvID := alloc.Services["web-frontend"]


### PR DESCRIPTION
This PR allows a Job to be normalized across many allocations during planning. Since Plans are restricted to a single Job, we can pull out the Job from every alloc and share it. This reduces the serialization cost and payload size. This requires that the Allocation be denormalized prior to going into MemDB, but that is post-deserialization and the immutable design allows us to share a single instance.

The PR also includes minor cleanups to `PopulateServiceIDs` to avoid the task group lookup and a map allocation.

cc: @dadgar 