### PR TITLE
Allow the clients to update status of multiple allocations server side

### DIFF
--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -109,7 +109,7 @@ func TestAllocEndpoint_List_Blocking(t *testing.T) {
 	alloc2.ID = alloc.ID
 	alloc2.ClientStatus = structs.AllocClientStatusRunning
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpdateAllocFromClient(3, alloc2); err != nil {
+		if err := state.UpdateAllocsFromClient(3, []*structs.Allocation{alloc2}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -608,14 +608,20 @@ func TestFSM_UpdateAllocFromClient(t *testing.T) {
 	// Create a completed eval
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
-	state.UpsertAllocs(1, []*structs.Allocation{alloc})
+	alloc2 := mock.Alloc()
+	alloc2.NodeID = node.ID
+	state.UpsertAllocs(1, []*structs.Allocation{alloc, alloc2})
 
 	clientAlloc := new(structs.Allocation)
 	*clientAlloc = *alloc
 	clientAlloc.ClientStatus = structs.AllocClientStatusDead
+	update2 := &structs.Allocation{
+		ID:           alloc2.ID,
+		ClientStatus: structs.AllocClientStatusRunning,
+	}
 
 	req := structs.AllocUpdateRequest{
-		Alloc: []*structs.Allocation{clientAlloc},
+		Alloc: []*structs.Allocation{clientAlloc, update2},
 	}
 	buf, err := structs.Encode(structs.AllocClientUpdateRequestType, req)
 	if err != nil {
@@ -627,7 +633,7 @@ func TestFSM_UpdateAllocFromClient(t *testing.T) {
 		t.Fatalf("resp: %v", resp)
 	}
 
-	// Verify we are registered
+	// Verify we are updated
 	out, err := fsm.State().AllocByID(alloc.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -636,6 +642,18 @@ func TestFSM_UpdateAllocFromClient(t *testing.T) {
 	clientAlloc.ModifyIndex = out.ModifyIndex
 	if !reflect.DeepEqual(clientAlloc, out) {
 		t.Fatalf("bad: %#v %#v", clientAlloc, out)
+	}
+
+	out, err = fsm.State().AllocByID(alloc2.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	alloc2.CreateIndex = out.CreateIndex
+	alloc2.ModifyIndex = out.ModifyIndex
+	alloc2.ClientStatus = structs.AllocClientStatusRunning
+	alloc2.TaskStates = nil
+	if !reflect.DeepEqual(alloc2, out) {
+		t.Fatalf("bad: %#v %#v", alloc2, out)
 	}
 
 	// Verify the eval was unblocked.

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -587,7 +587,7 @@ func TestFSM_UpsertAllocs_SharedJob(t *testing.T) {
 	}
 }
 
-func TestFSM_UpdateAllocFromClient(t *testing.T) {
+func TestFSM_UpdateAllocFromClient_Unblock(t *testing.T) {
 	fsm := testFSM(t)
 	fsm.blockedEvals.SetEnabled(true)
 	state := fsm.State()
@@ -668,7 +668,7 @@ func TestFSM_UpdateAllocFromClient(t *testing.T) {
 	})
 }
 
-func TestFSM_UpdateAllocFromClient_Unblock(t *testing.T) {
+func TestFSM_UpdateAllocFromClient(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -452,8 +452,8 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 	defer metrics.MeasureSince([]string{"nomad", "client", "update_alloc"}, time.Now())
 
 	// Ensure only a single alloc
-	if len(args.Alloc) != 1 {
-		return fmt.Errorf("must update a single allocation")
+	if len(args.Alloc) == 0 {
+		return fmt.Errorf("must update at least one allocation")
 	}
 
 	// Commit this update via Raft

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -451,7 +451,7 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 	}
 	defer metrics.MeasureSince([]string{"nomad", "client", "update_alloc"}, time.Now())
 
-	// Ensure only a single alloc
+	// Ensure at least a single alloc
 	if len(args.Alloc) == 0 {
 		return fmt.Errorf("must update at least one allocation")
 	}

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -755,7 +755,7 @@ func TestClientEndpoint_GetAllocs_Blocking(t *testing.T) {
 		allocUpdate.NodeID = alloc.NodeID
 		allocUpdate.ID = alloc.ID
 		allocUpdate.ClientStatus = structs.AllocClientStatusRunning
-		err := state.UpdateAllocFromClient(200, allocUpdate)
+		err := state.UpdateAllocsFromClient(200, []*structs.Allocation{allocUpdate})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}


### PR DESCRIPTION
This PR allows clients to update the status of multiple allocations in a single RPC call to enable batching. It also restricts what we inspect to the Allocation ID, ClientStatus, ClientDescription and TaskStates to allow those fields to be omitted.

cc: @dadgar 