### PR TITLE
drivers: validate that command contains one field

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -369,6 +369,11 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 	// If the user specified a custom command to run as their entrypoint, we'll
 	// inject it here.
 	if driverConfig.Command != "" {
+		// Validate command
+		if err := validateCommand(driverConfig.Command, "args"); err != nil {
+			return c, err
+		}
+
 		cmd := []string{driverConfig.Command}
 		if len(driverConfig.Args) != 0 {
 			cmd = append(cmd, parsedArgs...)

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -77,8 +77,8 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	}
 	// Get the command to be ran
 	command := driverConfig.Command
-	if command == "" {
-		return nil, fmt.Errorf("missing command for exec driver")
+	if err := validateCommand(command, "args"); err != nil {
+		return nil, err
 	}
 
 	// Create a location to download the artifact.

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -77,8 +77,8 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandl
 
 	// Get the command to be ran
 	command := driverConfig.Command
-	if command == "" {
-		return nil, fmt.Errorf("missing command for Raw Exec driver")
+	if err := validateCommand(command, "args"); err != nil {
+		return nil, err
 	}
 
 	// Check if an artificat is specified and attempt to download it

--- a/client/driver/utils.go
+++ b/client/driver/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-plugin"
@@ -86,4 +87,25 @@ func destroyPlugin(pluginPid int, userPid int) error {
 		merr = multierror.Append(merr, err)
 	}
 	return merr
+}
+
+// validateCommand validates that the command only has a single value and
+// returns a user friendly error message telling them to use the passed
+// argField.
+func validateCommand(command, argField string) error {
+	trimmed := strings.TrimSpace(command)
+	if len(trimmed) == 0 {
+		return fmt.Errorf("command empty: %q", command)
+	}
+
+	if len(trimmed) != len(command) {
+		return fmt.Errorf("command contains extra white space: %q", command)
+	}
+
+	split := strings.Split(trimmed, " ")
+	if len(split) != 1 {
+		return fmt.Errorf("command contained more than one input. Use %q field to pass arguments", argField)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Drivers that support a command field now validate that a single input is given.