### PR TITLE
travis: remove go tip build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: go
 
 go:
   - 1.6
-  - tip
 
 env:
   - DOCKER_VERSION=1.9.1


### PR DESCRIPTION
Uses up one less Travis builder per commit, makes for faster throughput.