### PR TITLE
core: store the job on allocations that are from stopped jobs

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2421,7 +2421,15 @@ type Plan struct {
 func (p *Plan) AppendUpdate(alloc *Allocation, status, desc string) {
 	newAlloc := new(Allocation)
 	*newAlloc = *alloc
-	newAlloc.Job = nil // Normalize the job
+
+	// If the job is not set in the plan we are deregistering a job so we
+	// extract the job from the allocation.
+	if p.Job == nil && newAlloc.Job != nil {
+		p.Job = newAlloc.Job
+	}
+
+	// Normalize the job
+	newAlloc.Job = nil
 	newAlloc.DesiredStatus = status
 	newAlloc.DesiredDescription = desc
 	node := alloc.NodeID

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -634,6 +634,13 @@ func TestServiceSched_JobDeregister(t *testing.T) {
 	out, err := h.State.AllocsByJob(job.ID)
 	noErr(t, err)
 
+	// Ensure that the job field on the allocation is still populated
+	for _, alloc := range out {
+		if alloc.Job == nil {
+			t.Fatalf("bad: %#v", alloc)
+		}
+	}
+
 	// Ensure no remaining allocations
 	out = structs.FilterTerminalAllocs(out)
 	if len(out) != 0 {


### PR DESCRIPTION
Fixes #847 which was introduced from job denormalization #832 

cc: @armon 