### PR TITLE
Writing logs to alloc dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.3.0 (UNRELEASED)
 
 __BACKWARDS INCOMPATIBILITIES:__
+  * Stdout and Stderr log files of tasks have moved from task/local to
+    alloc/logs [GH-851]
   * Any users of the runtime environment variable `$NOMAD_PORT_` will need to
     update to the new `${NOMAD_ADDR_}` varriable [GH-704]
   * Service names that include periods will fail validation. To fix, remove any

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -16,8 +16,11 @@ var (
 	// The name of the directory that is shared across tasks in a task group.
 	SharedAllocName = "alloc"
 
+	// Name of the directory where logs of Tasks are written
+	LogDirName = "logs"
+
 	// The set of directories that exist inside eache shared alloc directory.
-	SharedAllocDirs = []string{"logs", "tmp", "data"}
+	SharedAllocDirs = []string{LogDirName, "tmp", "data"}
 
 	// The name of the directory that exists inside each task directory
 	// regardless of driver.
@@ -273,6 +276,11 @@ func (d *AllocDir) MountSharedDir(task string) error {
 	}
 
 	return nil
+}
+
+// LogDir returns the log dir in the current allocation directory
+func (d *AllocDir) LogDir() string {
+	return filepath.Join(d.AllocDir, SharedAllocName, LogDirName)
 }
 
 // List returns the list of files at a path relative to the alloc dir

--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -70,6 +70,22 @@ func TestAllocDir_BuildAlloc(t *testing.T) {
 	}
 }
 
+func TestAllocDir_LogDir(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "AllocDir")
+	if err != nil {
+		t.Fatalf("Couldn't create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	d := NewAllocDir(tmp)
+	defer d.Destroy()
+
+	expected := filepath.Join(d.AllocDir, SharedAllocName, LogDirName)
+	if d.LogDir() != expected {
+		t.Fatalf("expected: %v, got: %v", expected, d.LogDir())
+	}
+}
+
 func TestAllocDir_EmbedNonExistent(t *testing.T) {
 	tmp, err := ioutil.TempDir("", "AllocDir")
 	if err != nil {

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -103,13 +103,13 @@ func TestExecDriver_KillUserPid_OnPluginReconnectFailure(t *testing.T) {
 	d := NewExecDriver(driverCtx)
 
 	handle, err := d.Start(execCtx, task)
-	defer handle.Kill()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if handle == nil {
 		t.Fatalf("missing handle")
 	}
+	defer handle.Kill()
 
 	id := &execId{}
 	if err := json.Unmarshal([]byte(handle.ID()), id); err != nil {

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -129,8 +129,7 @@ func (e *UniversalExecutor) LaunchCmd(command *ExecCommand, ctx *ExecutorContext
 	}
 
 	logFileSize := int64(ctx.LogConfig.MaxFileSizeMB * 1024 * 1024)
-	path := filepath.Join(e.taskDir, allocdir.TaskLocal)
-	lro, err := logging.NewFileRotator(path, fmt.Sprintf("%v.stdout", ctx.TaskName),
+	lro, err := logging.NewFileRotator(ctx.AllocDir.LogDir(), fmt.Sprintf("%v.stdout", ctx.TaskName),
 		ctx.LogConfig.MaxFiles, logFileSize, e.logger)
 
 	if err != nil {
@@ -139,7 +138,7 @@ func (e *UniversalExecutor) LaunchCmd(command *ExecCommand, ctx *ExecutorContext
 	e.cmd.Stdout = lro
 	e.lro = lro
 
-	lre, err := logging.NewFileRotator(path, fmt.Sprintf("%v.stderr", ctx.TaskName),
+	lre, err := logging.NewFileRotator(ctx.AllocDir.LogDir(), fmt.Sprintf("%v.stderr", ctx.TaskName),
 		ctx.LogConfig.MaxFiles, logFileSize, e.logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating log rotator for stderr of task %v", err)

--- a/client/driver/executor/executor_test.go
+++ b/client/driver/executor/executor_test.go
@@ -99,18 +99,11 @@ func TestExecutor_Start_Wait(t *testing.T) {
 		t.Fatalf("error in waiting for command: %v", err)
 	}
 
-	task := "web"
-	taskDir, ok := ctx.AllocDir.TaskDirs[task]
-	if !ok {
-		log.Panicf("No task directory found for task %v", task)
-	}
-
 	expected := "hello world"
-	file := filepath.Join(allocdir.TaskLocal, "web.stdout.0")
-	absFilePath := filepath.Join(taskDir, file)
-	output, err := ioutil.ReadFile(absFilePath)
+	file := filepath.Join(ctx.AllocDir.LogDir(), "web.stdout.0")
+	output, err := ioutil.ReadFile(file)
 	if err != nil {
-		t.Fatalf("Couldn't read file %v", absFilePath)
+		t.Fatalf("Couldn't read file %v", file)
 	}
 
 	act := strings.TrimSpace(string(output))
@@ -143,18 +136,11 @@ func TestExecutor_IsolationAndConstraints(t *testing.T) {
 		t.Fatalf("error in waiting for command: %v", err)
 	}
 
-	task := "web"
-	taskDir, ok := ctx.AllocDir.TaskDirs[task]
-	if !ok {
-		log.Panicf("No task directory found for task %v", task)
-	}
-
 	expected := "hello world"
-	file := filepath.Join(allocdir.TaskLocal, "web.stdout.0")
-	absFilePath := filepath.Join(taskDir, file)
-	output, err := ioutil.ReadFile(absFilePath)
+	file := filepath.Join(ctx.AllocDir.LogDir(), "web.stdout.0")
+	output, err := ioutil.ReadFile(file)
 	if err != nil {
-		t.Fatalf("Couldn't read file %v", absFilePath)
+		t.Fatalf("Couldn't read file %v", file)
 	}
 
 	act := strings.TrimSpace(string(output))
@@ -180,20 +166,12 @@ func TestExecutor_Start_Kill(t *testing.T) {
 		t.Fatalf("error in waiting for command: %v", err)
 	}
 
-	task := "web"
-	taskDir, ok := ctx.AllocDir.TaskDirs[task]
-	if !ok {
-		t.Fatalf("No task directory found for task %v", task)
-	}
-
-	file := filepath.Join(allocdir.TaskLocal, "web.stdout.0")
-	absFilePath := filepath.Join(taskDir, file)
-
+	file := filepath.Join(ctx.AllocDir.LogDir(), "web.stdout.0")
 	time.Sleep(time.Duration(tu.TestMultiplier()*2) * time.Second)
 
-	output, err := ioutil.ReadFile(absFilePath)
+	output, err := ioutil.ReadFile(file)
 	if err != nil {
-		t.Fatalf("Couldn't read file %v", absFilePath)
+		t.Fatalf("Couldn't read file %v", file)
 	}
 
 	expected := ""

--- a/client/driver/java_test.go
+++ b/client/driver/java_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -143,8 +142,7 @@ func TestJavaDriver_Start_Wait(t *testing.T) {
 	}
 
 	// Get the stdout of the process and assrt that it's not empty
-	taskDir := execCtx.AllocDir.TaskDirs["demo-app"]
-	stdout := filepath.Join(taskDir, allocdir.TaskLocal, "demo-app.stdout.0")
+	stdout := filepath.Join(execCtx.AllocDir.LogDir(), "demo-app.stdout.0")
 	fInfo, err := os.Stat(stdout)
 	if err != nil {
 		t.Fatalf("failed to get stdout of process: %v", err)

--- a/client/driver/logging/universal_collector.go
+++ b/client/driver/logging/universal_collector.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"log/syslog"
 	"net"
-	"path/filepath"
 
 	"github.com/hashicorp/nomad/client/allocdir"
 	cstructs "github.com/hashicorp/nomad/client/driver/structs"
@@ -90,8 +89,7 @@ func (s *SyslogCollector) LaunchCollector(ctx *LogCollectorContext) (*SyslogColl
 	go s.server.Start()
 	logFileSize := int64(ctx.LogConfig.MaxFileSizeMB * 1024 * 1024)
 
-	path := filepath.Join(s.taskDir, allocdir.TaskLocal)
-	lro, err := NewFileRotator(path, fmt.Sprintf("%v.stdout", ctx.TaskName),
+	lro, err := NewFileRotator(ctx.AllocDir.LogDir(), fmt.Sprintf("%v.stdout", ctx.TaskName),
 		ctx.LogConfig.MaxFiles, logFileSize, s.logger)
 
 	if err != nil {
@@ -99,7 +97,7 @@ func (s *SyslogCollector) LaunchCollector(ctx *LogCollectorContext) (*SyslogColl
 	}
 	s.lro = lro
 
-	lre, err := NewFileRotator(path, fmt.Sprintf("%v.stderr", ctx.TaskName),
+	lre, err := NewFileRotator(ctx.AllocDir.LogDir(), fmt.Sprintf("%v.stderr", ctx.TaskName),
 		ctx.LogConfig.MaxFiles, logFileSize, s.logger)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
cc/ @pshima @grubernaut 

This PR writes logs into ```alloc/logs/redis.stdout.0``` and so on instead of ```redis/local/redis.stdout.0``` which should allow your log shippers to access all the logs from tasks running in an allocation.