### PR TITLE
pins docker version for vagrant development

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,10 @@
 VAGRANTFILE_API_VERSION = "2"
 
 $script = <<SCRIPT
+# Set docker version from available versions at
+# https://apt.dockerproject.org/repo/pool/main/d/docker-engine/
+DOCKER_VERSION="1.10.1-0~trusty"
+
 # Install Prereq Packages
 sudo apt-get update
 sudo apt-get install -y build-essential curl git-core mercurial bzr libpcre3-dev pkg-config zip default-jre qemu libc6-dev-i386 silversearcher-ag jq htop vim unzip
@@ -52,7 +56,7 @@ sudo mv consul /usr/bin/consul
 echo deb https://apt.dockerproject.org/repo ubuntu-`lsb_release -c | awk '{print $2}'` main | sudo tee /etc/apt/sources.list.d/docker.list
 sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sudo apt-get update
-sudo apt-get install -y docker-engine
+sudo apt-get install -y docker-engine=$DOCKER_VERSION
 
 # Restart docker to make sure we get the latest version of the daemon if there is an upgrade
 sudo service docker restart

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -224,7 +224,7 @@ through Nomad plugins or dynamic job configuration.
 ## Host Requirements
 
 Nomad requires Docker to be installed and running on the host alongside the
-Nomad agent. Nomad was developed against Docker `1.8.2` and `1.9`.
+Nomad agent. Nomad was developed against Docker `1.8.2`, `1.9`, and `1.10.1`.
 
 By default Nomad communicates with the Docker daemon using the daemon's unix
 socket. Nomad will need to be able to read/write to this socket. If you do not


### PR DESCRIPTION
This PR pins the docker version for vagrant development to avoid brittle test failures due to changes in the docker API.  For example, there is a driver test failure when going from docker 1.10.1 to docker 1.10.2.