### PR TITLE
Allow dashes in var names

### DIFF
--- a/helper/args/args.go
+++ b/helper/args/args.go
@@ -3,7 +3,7 @@ package args
 import "regexp"
 
 var (
-	envRe = regexp.MustCompile(`\${[a-zA-Z0-9_\.]+}`)
+	envRe = regexp.MustCompile(`\${[a-zA-Z0-9_\-\.]+}`)
 )
 
 // ReplaceEnv takes an arg and replaces all occurences of environment variables.

--- a/helper/args/args_test.go
+++ b/helper/args/args_test.go
@@ -13,6 +13,8 @@ const (
 	portVal   = ":80"
 	periodKey = "NOMAD.PERIOD"
 	periodVal = "period"
+	dashKey   = "NOMAD-DASH"
+	dashVal   = "dash"
 )
 
 var (
@@ -20,6 +22,7 @@ var (
 		ipKey:     ipVal,
 		portKey:   portVal,
 		periodKey: periodVal,
+		dashKey:   dashVal,
 	}
 )
 
@@ -46,6 +49,16 @@ func TestArgs_ReplaceEnv_Valid(t *testing.T) {
 func TestArgs_ReplaceEnv_Period(t *testing.T) {
 	input := fmt.Sprintf(`"${%v}"!`, periodKey)
 	exp := fmt.Sprintf("\"%s\"!", periodVal)
+	act := ReplaceEnv(input, envVars)
+
+	if !reflect.DeepEqual(act, exp) {
+		t.Fatalf("ReplaceEnv(%v, %v) returned %#v; want %#v", input, envVars, act, exp)
+	}
+}
+
+func TestArgs_ReplaceEnv_Dash(t *testing.T) {
+	input := fmt.Sprintf(`"${%v}"!`, dashKey)
+	exp := fmt.Sprintf("\"%s\"!", dashVal)
 	act := ReplaceEnv(input, envVars)
 
 	if !reflect.DeepEqual(act, exp) {


### PR DESCRIPTION
I don't really know in which direction to fix it:

- AWS fingerprinting ([env_aws.go#L111](https://github.com/hashicorp/nomad/blob/master/client/fingerprint/env_aws.go#L111)) sets the variables with dashes.
- Replacement regexp does not allow dashes in names.

Now there is no way to pass variables like `platform.aws.placement.availability-zone`, `unique.platform.aws.local-ipv4` to the process. 
Maybe lets allow it?
