### PR TITLE
client: Driver starting is included in restart policy.

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -148,9 +148,12 @@ type TaskState struct {
 
 const (
 	TaskDriverFailure = "Driver Failure"
+	TaskReceived      = "Received"
 	TaskStarted       = "Started"
 	TaskTerminated    = "Terminated"
 	TaskKilled        = "Killed"
+	TaskRestarting    = "Restarting"
+	TaskNotRestarting = "Restarts Exceeded"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -163,4 +166,5 @@ type TaskEvent struct {
 	Signal      int
 	Message     string
 	KillError   string
+	StartDelay  int64
 }

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -245,8 +245,7 @@ func (r *AllocRunner) Alloc() *structs.Allocation {
 		case structs.TaskStatePending:
 			pending = true
 		case structs.TaskStateDead:
-			last := len(state.Events) - 1
-			if state.Events[last].Type == structs.TaskDriverFailure {
+			if state.Failed() {
 				failed = true
 			} else {
 				dead = true

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -277,8 +277,7 @@ func (h *execHandle) run() {
 			h.logger.Printf("[ERR] driver.exec: unmounting dev,proc and alloc dirs failed: %v", e)
 		}
 	}
-	h.waitCh <- &cstructs.WaitResult{ExitCode: ps.ExitCode, Signal: 0,
-		Err: err}
+	h.waitCh <- cstructs.NewWaitResult(ps.ExitCode, 0, err)
 	close(h.waitCh)
 	h.pluginClient.Kill()
 }

--- a/client/driver/structs/structs.go
+++ b/client/driver/structs/structs.go
@@ -2,6 +2,7 @@ package structs
 
 import (
 	"fmt"
+
 	cgroupConfig "github.com/opencontainers/runc/libcontainer/configs"
 )
 
@@ -33,4 +34,24 @@ func (r *WaitResult) String() string {
 // uses to put resource constraints and isolation on the user process
 type IsolationConfig struct {
 	Cgroup *cgroupConfig.Cgroup
+}
+
+// RecoverableError wraps an error and marks whether it is recoverable and could
+// be retried or it is fatal.
+type RecoverableError struct {
+	Err         error
+	Recoverable bool
+}
+
+// NewRecoverableError is used to wrap an error and mark it as recoverable or
+// not.
+func NewRecoverableError(e error, recoverable bool) *RecoverableError {
+	return &RecoverableError{
+		Err:         e,
+		Recoverable: recoverable,
+	}
+}
+
+func (r *RecoverableError) Error() string {
+	return r.Err.Error()
 }

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -309,7 +309,9 @@ func (r *TaskRunner) run() {
 		}
 
 		// Clear the handle so a new driver will be created.
+		r.handleLock.Lock()
 		r.handle = nil
+		r.handleLock.Unlock()
 	}
 }
 

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -203,33 +203,6 @@ func (r *TaskRunner) createDriver() (driver.Driver, error) {
 	return driver, err
 }
 
-// startTask is used to start the task if there is no handle
-func (r *TaskRunner) startTask() error {
-	// Create a driver
-	driver, err := r.createDriver()
-	if err != nil {
-		e := structs.NewTaskEvent(structs.TaskDriverFailure).SetDriverError(err)
-		r.setState(structs.TaskStateDead, e)
-		return err
-	}
-
-	// Start the job
-	handle, err := driver.Start(r.ctx, r.task)
-	if err != nil {
-		r.logger.Printf("[ERR] client: failed to start task '%s' for alloc '%s': %v",
-			r.task.Name, r.alloc.ID, err)
-		e := structs.NewTaskEvent(structs.TaskDriverFailure).
-			SetDriverError(fmt.Errorf("failed to start: %v", err))
-		r.setState(structs.TaskStateDead, e)
-		return err
-	}
-	r.handleLock.Lock()
-	r.handle = handle
-	r.handleLock.Unlock()
-	r.setState(structs.TaskStateRunning, structs.NewTaskEvent(structs.TaskStarted))
-	return nil
-}
-
 // Run is a long running routine used to manage the task
 func (r *TaskRunner) Run() {
 	defer close(r.waitCh)
@@ -241,33 +214,48 @@ func (r *TaskRunner) Run() {
 }
 
 func (r *TaskRunner) run() {
-	var forceStart bool
 	for {
-		// Start the task if not yet started or it is being forced.
+		// Start the task if not yet started or it is being forced. This logic
+		// is necessary because in the case of a restore the handle already
+		// exists.
 		r.handleLock.Lock()
 		handleEmpty := r.handle == nil
 		r.handleLock.Unlock()
-		if handleEmpty || forceStart {
-			forceStart = false
-			if err := r.startTask(); err != nil {
-				return
+		if handleEmpty {
+			startErr := r.startTask()
+			r.restartTracker.SetStartError(startErr)
+			if startErr != nil {
+				r.setState(structs.TaskStateDead, structs.NewTaskEvent(structs.TaskDriverFailure).SetDriverError(startErr))
+				goto RESTART
 			}
 		}
 
-		// Store the errors that caused use to stop waiting for updates.
-		var waitRes *cstructs.WaitResult
-		var destroyErr error
-		destroyed := false
-
-		// Register the services defined by the task with Consil
+		// Mark the task as started and register it with Consul.
+		r.setState(structs.TaskStateRunning, structs.NewTaskEvent(structs.TaskStarted))
 		r.consulService.Register(r.task, r.alloc)
 
-	OUTER:
 		// Wait for updates
+	WAIT:
 		for {
 			select {
-			case waitRes = <-r.handle.WaitCh():
-				break OUTER
+			case waitRes := <-r.handle.WaitCh():
+				// De-Register the services belonging to the task from consul
+				r.consulService.Deregister(r.task, r.alloc)
+
+				if waitRes == nil {
+					panic("nil wait")
+				}
+
+				// Log whether the task was successful or not.
+				r.restartTracker.SetWaitResult(waitRes)
+				r.setState(structs.TaskStateDead, r.waitErrorToEvent(waitRes))
+				if !waitRes.Successful() {
+					r.logger.Printf("[INFO] client: task %q for alloc %q failed: %v", r.task.Name, r.alloc.ID, waitRes)
+				} else {
+					r.logger.Printf("[INFO] client: task %q for alloc %q completed successfully", r.task.Name, r.alloc.ID)
+				}
+
+				break WAIT
 			case update := <-r.updateCh:
 				if err := r.handleUpdate(update); err != nil {
 					r.logger.Printf("[ERR] client: update to task %q failed: %v", r.task.Name, err)
@@ -278,49 +266,31 @@ func (r *TaskRunner) run() {
 				if !destroySuccess {
 					// We couldn't successfully destroy the resource created.
 					r.logger.Printf("[ERR] client: failed to kill task %q. Resources may have been leaked: %v", r.task.Name, err)
-				} else {
-					// Wait for the task to exit but cap the time to ensure we don't block.
-					select {
-					case waitRes = <-r.handle.WaitCh():
-					case <-time.After(3 * time.Second):
-					}
 				}
 
 				// Store that the task has been destroyed and any associated error.
-				destroyed = true
-				destroyErr = err
-				break OUTER
+				r.setState(structs.TaskStateDead, structs.NewTaskEvent(structs.TaskKilled).SetKillError(err))
+				r.consulService.Deregister(r.task, r.alloc)
+				return
 			}
 		}
 
-		// De-Register the services belonging to the task from consul
-		r.consulService.Deregister(r.task, r.alloc)
-
-		// If the user destroyed the task, we do not attempt to do any restarts.
-		if destroyed {
-			r.setState(structs.TaskStateDead, structs.NewTaskEvent(structs.TaskKilled).SetKillError(destroyErr))
-			return
-		}
-
-		// Log whether the task was successful or not.
-		if !waitRes.Successful() {
-			r.logger.Printf("[ERR] client: failed to complete task '%s' for alloc '%s': %v", r.task.Name, r.alloc.ID, waitRes)
-		} else {
-			r.logger.Printf("[INFO] client: completed task '%s' for alloc '%s'", r.task.Name, r.alloc.ID)
-		}
-
-		// Check if we should restart. If not mark task as dead and exit.
-		shouldRestart, when := r.restartTracker.NextRestart(waitRes.ExitCode)
-		waitEvent := r.waitErrorToEvent(waitRes)
-		if !shouldRestart {
+	RESTART:
+		state, when := r.restartTracker.GetState()
+		switch state {
+		case structs.TaskNotRestarting, structs.TaskTerminated:
 			r.logger.Printf("[INFO] client: Not restarting task: %v for alloc: %v ", r.task.Name, r.alloc.ID)
-			r.setState(structs.TaskStateDead, waitEvent)
+			if state == structs.TaskNotRestarting {
+				r.setState(structs.TaskStateDead, structs.NewTaskEvent(structs.TaskNotRestarting))
+			}
+			return
+		case structs.TaskRestarting:
+			r.logger.Printf("[INFO] client: Restarting task %q for alloc %q in %v", r.task.Name, r.alloc.ID, when)
+			r.setState(structs.TaskStatePending, structs.NewTaskEvent(structs.TaskRestarting).SetRestartDelay(when))
+		default:
+			r.logger.Printf("[ERR] client: restart tracker returned unknown state: %q", state)
 			return
 		}
-
-		r.logger.Printf("[INFO] client: Restarting Task: %v", r.task.Name)
-		r.logger.Printf("[DEBUG] client: Sleeping for %v before restarting Task %v", when, r.task.Name)
-		r.setState(structs.TaskStatePending, waitEvent)
 
 		// Sleep but watch for destroy events.
 		select {
@@ -330,7 +300,7 @@ func (r *TaskRunner) run() {
 
 		// Destroyed while we were waiting to restart, so abort.
 		r.destroyLock.Lock()
-		destroyed = r.destroy
+		destroyed := r.destroy
 		r.destroyLock.Unlock()
 		if destroyed {
 			r.logger.Printf("[DEBUG] client: Not restarting task: %v because it's destroyed by user", r.task.Name)
@@ -338,9 +308,32 @@ func (r *TaskRunner) run() {
 			return
 		}
 
-		// Set force start because we are restarting the task.
-		forceStart = true
+		// Clear the handle so a new driver will be created.
+		r.handle = nil
 	}
+}
+
+func (r *TaskRunner) startTask() error {
+	// Create a driver
+	driver, err := r.createDriver()
+	if err != nil {
+		r.logger.Printf("[ERR] client: failed to create driver of task '%s' for alloc '%s': %v",
+			r.task.Name, r.alloc.ID, err)
+		return err
+	}
+
+	// Start the job
+	handle, err := driver.Start(r.ctx, r.task)
+	if err != nil {
+		r.logger.Printf("[ERR] client: failed to start task '%s' for alloc '%s': %v",
+			r.task.Name, r.alloc.ID, err)
+		return err
+	}
+
+	r.handleLock.Lock()
+	r.handle = handle
+	r.handleLock.Unlock()
+	return nil
 }
 
 // handleUpdate takes an updated allocation and updates internal state to

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -190,10 +190,22 @@ func (c *AllocStatusCommand) taskStatus(alloc *api.Allocation) {
 			// Build up the description based on the event type.
 			var desc string
 			switch event.Type {
+			case api.TaskStarted:
+				desc = "Task started by client"
+			case api.TaskReceived:
+				desc = "Task received by client"
 			case api.TaskDriverFailure:
-				desc = event.DriverError
+				if event.DriverError != "" {
+					desc = event.DriverError
+				} else {
+					desc = "Failed to start task"
+				}
 			case api.TaskKilled:
-				desc = event.KillError
+				if event.KillError != "" {
+					desc = event.KillError
+				} else {
+					desc = "Task successfully killed"
+				}
 			case api.TaskTerminated:
 				var parts []string
 				parts = append(parts, fmt.Sprintf("Exit Code: %d", event.ExitCode))
@@ -206,6 +218,10 @@ func (c *AllocStatusCommand) taskStatus(alloc *api.Allocation) {
 					parts = append(parts, fmt.Sprintf("Exit Message: %q", event.Message))
 				}
 				desc = strings.Join(parts, ", ")
+			case api.TaskRestarting:
+				desc = fmt.Sprintf("Task restarting in %v", time.Duration(event.StartDelay))
+			case api.TaskNotRestarting:
+				desc = "Task exceeded restart policy"
 			}
 
 			// Reverse order so we are sorted by time

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1689,6 +1689,16 @@ func (ts *TaskState) Copy() *TaskState {
 	return copy
 }
 
+// Failed returns if the task has has failed.
+func (ts *TaskState) Failed() bool {
+	l := len(ts.Events)
+	if ts.State != TaskStateDead || l == 0 {
+		return false
+	}
+
+	return ts.Events[l-1].Type == TaskNotRestarting
+}
+
 const (
 	// A Driver failure indicates that the task could not be started due to a
 	// failure in the driver.
@@ -1707,6 +1717,13 @@ const (
 
 	// Task Killed indicates a user has killed the task.
 	TaskKilled = "Killed"
+
+	// TaskRestarting indicates that task terminated and is being restarted.
+	TaskRestarting = "Restarting"
+
+	// TaskNotRestarting indicates that the task has failed and is not being
+	// restarted because it has exceeded its restart policy.
+	TaskNotRestarting = "Restarts Exceeded"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -1725,6 +1742,13 @@ type TaskEvent struct {
 
 	// Task Killed Fields.
 	KillError string // Error killing the task.
+
+	// TaskRestarting fields.
+	StartDelay int64 // The sleep period before restarting the task in unix nanoseconds.
+}
+
+func (te *TaskEvent) GoString() string {
+	return fmt.Sprintf("%v at %v", te.Type, te.Time)
 }
 
 func (te *TaskEvent) Copy() *TaskEvent {
@@ -1771,6 +1795,11 @@ func (e *TaskEvent) SetKillError(err error) *TaskEvent {
 	if err != nil {
 		e.KillError = err.Error()
 	}
+	return e
+}
+
+func (e *TaskEvent) SetRestartDelay(delay time.Duration) *TaskEvent {
+	e.StartDelay = int64(delay)
 	return e
 }
 


### PR DESCRIPTION
This PR:
* Refactors the task_runner `run()` method.
* Updates the restart tracker to take in both exit codes and start errors
* Makes Docker Pull a recoverable error so that it may be retried.
* Improves the output of `nomad alloc-status`