### PR TITLE
Add a specific entry for the common error you may see

### DIFF
--- a/website/source/docs/drivers/exec.html.md
+++ b/website/source/docs/drivers/exec.html.md
@@ -54,7 +54,7 @@ running client, or a downloaded artifact.
 
 If you are receiving the error `* Constraint "missing drivers" filtered <> nodes`
 and using the exec driver, check to ensure that you are running Nomad as root. This
-also applies for running nomad in -dev mode.
+also applies for running Nomad in -dev mode.
 
 ## Examples
 

--- a/website/source/docs/drivers/exec.html.md
+++ b/website/source/docs/drivers/exec.html.md
@@ -52,6 +52,10 @@ You must specify a `command` to be executed. Optionally you can specify an
 `artifact_source` to be downloaded as well. Any `command` is assumed to be present on the 
 running client, or a downloaded artifact.
 
+If you are receiving the error `* Constraint "missing drivers" filtered <> nodes`
+and using the exec driver, check to ensure that you are running Nomad as root. This
+also applies for running nomad in -dev mode.
+
 ## Examples
 
 To run a binary present on the Node:


### PR DESCRIPTION
when using the exec driver but not running as root.