### PR TITLE
client: Updating kill timeout adheres to operator specified maximum

### DIFF
--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -152,18 +152,19 @@ func TestDockerDriver_Handle(t *testing.T) {
 	defer pluginClient.Kill()
 
 	h := &DockerHandle{
-		version:      "version",
-		imageID:      "imageid",
-		logCollector: logCollector,
-		pluginClient: pluginClient,
-		containerID:  "containerid",
-		killTimeout:  5 * time.Nanosecond,
-		doneCh:       make(chan struct{}),
-		waitCh:       make(chan *cstructs.WaitResult, 1),
+		version:        "version",
+		imageID:        "imageid",
+		logCollector:   logCollector,
+		pluginClient:   pluginClient,
+		containerID:    "containerid",
+		killTimeout:    5 * time.Nanosecond,
+		maxKillTimeout: 15 * time.Nanosecond,
+		doneCh:         make(chan struct{}),
+		waitCh:         make(chan *cstructs.WaitResult, 1),
 	}
 
 	actual := h.ID()
-	expected := fmt.Sprintf("DOCKER:{\"Version\":\"version\",\"ImageID\":\"imageid\",\"ContainerID\":\"containerid\",\"KillTimeout\":5,\"PluginConfig\":{\"Pid\":%d,\"AddrNet\":\"unix\",\"AddrName\":\"%s\"}}",
+	expected := fmt.Sprintf("DOCKER:{\"Version\":\"version\",\"ImageID\":\"imageid\",\"ContainerID\":\"containerid\",\"KillTimeout\":5,\"MaxKillTimeout\":15,\"PluginConfig\":{\"Pid\":%d,\"AddrNet\":\"unix\",\"AddrName\":\"%s\"}}",
 		pluginClient.ReattachConfig().Pid, pluginClient.ReattachConfig().Addr.String())
 	if actual != expected {
 		t.Errorf("Expected `%s`, found `%s`", expected, actual)

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
@@ -82,24 +81,6 @@ func NewDriverContext(taskName string, config *config.Config, node *structs.Node
 		logger:   logger,
 		taskEnv:  taskEnv,
 	}
-}
-
-// KillTimeout returns the timeout that should be used for the task between
-// signaling and killing the task.
-func (d *DriverContext) KillTimeout(task *structs.Task) time.Duration {
-	max := d.config.MaxKillTimeout.Nanoseconds()
-	desired := task.KillTimeout.Nanoseconds()
-
-	// Make the minimum time between signal and kill, 1 second.
-	if desired == 0 {
-		desired = (1 * time.Second).Nanoseconds()
-	}
-
-	if desired < max {
-		return time.Duration(desired)
-	}
-
-	return d.config.MaxKillTimeout
 }
 
 // DriverHandle is an opaque handle into a driver used for task

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -66,24 +66,6 @@ func testDriverContexts(task *structs.Task) (*DriverContext, *ExecContext) {
 	return driverCtx, execCtx
 }
 
-func TestDriver_KillTimeout(t *testing.T) {
-	expected := 1 * time.Second
-	task := &structs.Task{Name: "foo", KillTimeout: expected}
-	ctx, _ := testDriverContexts(task)
-	ctx.config.MaxKillTimeout = 10 * time.Second
-
-	if actual := ctx.KillTimeout(task); expected != actual {
-		t.Fatalf("KillTimeout(%v) returned %v; want %v", task, actual, expected)
-	}
-
-	expected = 10 * time.Second
-	task = &structs.Task{KillTimeout: 11 * time.Second}
-
-	if actual := ctx.KillTimeout(task); expected != actual {
-		t.Fatalf("KillTimeout(%v) returned %v; want %v", task, actual, expected)
-	}
-}
-
 func TestDriver_GetTaskEnv(t *testing.T) {
 	t.Parallel()
 	task := &structs.Task{

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -44,15 +44,16 @@ type QemuDriverConfig struct {
 
 // qemuHandle is returned from Start/Open as a handle to the PID
 type qemuHandle struct {
-	pluginClient *plugin.Client
-	userPid      int
-	executor     executor.Executor
-	allocDir     *allocdir.AllocDir
-	killTimeout  time.Duration
-	logger       *log.Logger
-	version      string
-	waitCh       chan *cstructs.WaitResult
-	doneCh       chan struct{}
+	pluginClient   *plugin.Client
+	userPid        int
+	executor       executor.Executor
+	allocDir       *allocdir.AllocDir
+	killTimeout    time.Duration
+	maxKillTimeout time.Duration
+	logger         *log.Logger
+	version        string
+	waitCh         chan *cstructs.WaitResult
+	doneCh         chan struct{}
 }
 
 // NewQemuDriver is used to create a new exec driver
@@ -219,16 +220,18 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	d.logger.Printf("[INFO] Started new QemuVM: %s", vmID)
 
 	// Create and Return Handle
+	maxKill := d.DriverContext.config.MaxKillTimeout
 	h := &qemuHandle{
-		pluginClient: pluginClient,
-		executor:     exec,
-		userPid:      ps.Pid,
-		allocDir:     ctx.AllocDir,
-		killTimeout:  d.DriverContext.KillTimeout(task),
-		version:      d.config.Version,
-		logger:       d.logger,
-		doneCh:       make(chan struct{}),
-		waitCh:       make(chan *cstructs.WaitResult, 1),
+		pluginClient:   pluginClient,
+		executor:       exec,
+		userPid:        ps.Pid,
+		allocDir:       ctx.AllocDir,
+		killTimeout:    GetKillTimeout(task.KillTimeout, maxKill),
+		maxKillTimeout: maxKill,
+		version:        d.config.Version,
+		logger:         d.logger,
+		doneCh:         make(chan struct{}),
+		waitCh:         make(chan *cstructs.WaitResult, 1),
 	}
 
 	go h.run()
@@ -236,11 +239,12 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 }
 
 type qemuId struct {
-	Version      string
-	KillTimeout  time.Duration
-	UserPid      int
-	PluginConfig *PluginReattachConfig
-	AllocDir     *allocdir.AllocDir
+	Version        string
+	KillTimeout    time.Duration
+	MaxKillTimeout time.Duration
+	UserPid        int
+	PluginConfig   *PluginReattachConfig
+	AllocDir       *allocdir.AllocDir
 }
 
 func (d *QemuDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error) {
@@ -264,15 +268,16 @@ func (d *QemuDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, erro
 
 	// Return a driver handle
 	h := &qemuHandle{
-		pluginClient: pluginClient,
-		executor:     executor,
-		userPid:      id.UserPid,
-		allocDir:     id.AllocDir,
-		logger:       d.logger,
-		killTimeout:  id.KillTimeout,
-		version:      id.Version,
-		doneCh:       make(chan struct{}),
-		waitCh:       make(chan *cstructs.WaitResult, 1),
+		pluginClient:   pluginClient,
+		executor:       executor,
+		userPid:        id.UserPid,
+		allocDir:       id.AllocDir,
+		logger:         d.logger,
+		killTimeout:    id.KillTimeout,
+		maxKillTimeout: id.MaxKillTimeout,
+		version:        id.Version,
+		doneCh:         make(chan struct{}),
+		waitCh:         make(chan *cstructs.WaitResult, 1),
 	}
 	go h.run()
 	return h, nil
@@ -280,11 +285,12 @@ func (d *QemuDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, erro
 
 func (h *qemuHandle) ID() string {
 	id := qemuId{
-		Version:      h.version,
-		KillTimeout:  h.killTimeout,
-		PluginConfig: NewPluginReattachConfig(h.pluginClient.ReattachConfig()),
-		UserPid:      h.userPid,
-		AllocDir:     h.allocDir,
+		Version:        h.version,
+		KillTimeout:    h.killTimeout,
+		MaxKillTimeout: h.maxKillTimeout,
+		PluginConfig:   NewPluginReattachConfig(h.pluginClient.ReattachConfig()),
+		UserPid:        h.userPid,
+		AllocDir:       h.allocDir,
 	}
 
 	data, err := json.Marshal(id)
@@ -300,7 +306,7 @@ func (h *qemuHandle) WaitCh() chan *cstructs.WaitResult {
 
 func (h *qemuHandle) Update(task *structs.Task) error {
 	// Store the updated kill timeout.
-	h.killTimeout = task.KillTimeout
+	h.killTimeout = GetKillTimeout(task.KillTimeout, h.maxKillTimeout)
 	h.executor.UpdateLogConfig(task.LogConfig)
 
 	// Update is not possible

--- a/client/driver/utils_test.go
+++ b/client/driver/utils_test.go
@@ -1,0 +1,22 @@
+package driver
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDriver_KillTimeout(t *testing.T) {
+	expected := 1 * time.Second
+	max := 10 * time.Second
+
+	if actual := GetKillTimeout(expected, max); expected != actual {
+		t.Fatalf("GetKillTimeout() returned %v; want %v", actual, expected)
+	}
+
+	expected = 10 * time.Second
+	input := 11 * time.Second
+
+	if actual := GetKillTimeout(input, max); expected != actual {
+		t.Fatalf("KillTimeout() returned %v; want %v", actual, expected)
+	}
+}


### PR DESCRIPTION
This fixes an issue in which the task could be updated to have a longer kill timeout then then operator allows, 