### PR TITLE
Include number of allocations in node-status

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ dev: format generate
 bin: generate
 	@sh -c "'$(PWD)/scripts/build.sh'"
 
-release: 
+release:
 	@$(MAKE) bin
 
 cov:
@@ -31,7 +31,7 @@ test: generate
 	@sh -c "'$(PWD)/scripts/test.sh'"
 	@$(MAKE) vet
 
-cover: 
+cover:
 	go list ./... | xargs -n1 go test --cover
 
 format:

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -35,6 +35,9 @@ Node Status Options:
 
   -verbose
     Display full information.
+
+  -allocs
+    Display a count of running allocations for each node.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -90,15 +90,24 @@ func (c *NodeStatusCommand) Run(args []string) int {
 
 		// Format the nodes list
 		out := make([]string, len(nodes)+1)
-		out[0] = "ID|Datacenter|Name|Class|Drain|Status"
+		out[0] = "ID|Datacenter|Name|Class|Drain|Status|Allocations"
 		for i, node := range nodes {
-			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
+			// Fetch number of allocations per node
+			nodeAllocs, _, err := client.Nodes().Allocations(node.ID, nil)
+			if err != nil {
+				c.Ui.Error(fmt.Sprintf("Error querying node allocations: %s", err))
+				return 1
+			}
+			numAllocs := len(nodeAllocs)
+
+			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s|%v",
 				limit(node.ID, length),
 				node.Datacenter,
 				node.Name,
 				node.NodeClass,
 				node.Drain,
-				node.Status)
+				node.Status,
+				numAllocs)
 		}
 
 		// Dump the output

--- a/website/source/docs/commands/node-status.html.md.erb
+++ b/website/source/docs/commands/node-status.html.md.erb
@@ -35,6 +35,7 @@ Otherwise, a list of matching nodes and information will be displayed.
 * `-short`: Display short output. Used only when querying a single node. Drops
   verbose information about node allocations.
 * `-verbose`: Show full information.
+* `-allocs`: Show running allocations per node
 
 ## Examples
 
@@ -45,6 +46,15 @@ $ nomad node-status
 ID        DC   Name   Drain  Status
 a72dfba2  dc1  node1  false  ready
 1f3f03ea  dc1  node2  false  ready
+```
+
+List view, with running allocations:
+
+```
+$ nomad node-status -allocs
+ID        DC   Name   Class   Drain  Status  Running Allocs
+4d2ba53b  dc1  node1  <none>  false  ready   1
+34dfba32  dc1  node2  <none>  false  ready   3
 ```
 
 Single-node view in short mode:


### PR DESCRIPTION
We recently ran into an issue on a small percentage of nomad-clients
where the nomad-client was running successfully, but due to a race
condition, could not correctly bind to the docker socket. This caused
all of our nomad jobs to be allocated to a single nomad-client instead
of being spread evenly across our clients. The only way to discover this
was to run `nomad node-status <node>` and count each job allocation per
node.

This can lead to a fairly long debugging process if there are several
nomad-clients. Including the number of allocations for each node in the
`node-status` command would save a large amount of debug time.

```
jake@biscuits [12:08:41] [~]
-> % nomad node-status
ID        Datacenter  Name      Class   Drain  Status  Allocations
2b0aabc5  dc1         biscuits  <none>  false  ready   0
```

```
jake@biscuits [12:08:55] [~]
-> % nomad node-status
ID        Datacenter  Name      Class   Drain  Status  Allocations
2b0aabc5  dc1         biscuits  <none>  false  ready   1
```