### PR TITLE
Gracefully handle unreachable symlinks in chroot

### DIFF
--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -103,7 +103,7 @@ func TestAllocDir_EmbedNonExistent(t *testing.T) {
 	fakeDir := "/foobarbaz"
 	task := tasks[0].Name
 	mapping := map[string]string{fakeDir: fakeDir}
-	if err := d.Embed(task, mapping); err != nil {
+	if err := d.Embed(task, mapping, mapping); err != nil {
 		t.Fatalf("Embed(%v, %v) should should skip %v since it does not exist", task, mapping, fakeDir)
 	}
 }
@@ -150,7 +150,7 @@ func TestAllocDir_EmbedDirs(t *testing.T) {
 	task := tasks[0].Name
 	taskDest := "bin/test/"
 	mapping := map[string]string{host: taskDest}
-	if err := d.Embed(task, mapping); err != nil {
+	if err := d.Embed(task, mapping, mapping); err != nil {
 		t.Fatalf("Embed(%v, %v) failed: %v", task, mapping, err)
 	}
 

--- a/client/driver/executor/executor_linux.go
+++ b/client/driver/executor/executor_linux.go
@@ -158,7 +158,7 @@ func (e *UniversalExecutor) configureChroot() error {
 		return err
 	}
 
-	if err := allocDir.Embed(e.ctx.TaskName, chrootEnv); err != nil {
+	if err := allocDir.Embed(e.ctx.TaskName, chrootEnv, chrootEnv); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- Fixes a bug on Ubuntu 14.04, where /etc/resolv.conf is a symlink to /run/resolvconf/resolv.conf
- Notice /run is not included in the chroot. The net effect is that DNS resolutions are not possible from the chroot
- During recursive chroot copy, resolve symlinks to absolute paths for comparison againt chroot directories
- Use symlinks for reachable files, or hardlink/copy unreachable files