### PR TITLE
Print resource usage w/ alloc-status + node-status

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -148,6 +148,11 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	c.Ui.Output("\n==> Status")
 	dumpAllocStatus(c.Ui, alloc, length)
 
+	if !short {
+		c.Ui.Output("\n==> Resources")
+		c.taskResources(alloc)
+	}
+
 	return 0
 }
 
@@ -257,4 +262,16 @@ func (c *AllocStatusCommand) sortedTaskStateIterator(m map[string]*api.TaskState
 
 	close(output)
 	return output
+}
+
+// taskResources prints out the tasks current resource usage
+func (c *AllocStatusCommand) taskResources(alloc *api.Allocation) {
+	resources := make([]string, 2)
+	resources[0] = "CPU|MemoryMB|DiskMB|IOPS"
+	resources[1] = fmt.Sprintf("%v|%v|%v|%v",
+		alloc.Resources.CPU,
+		alloc.Resources.MemoryMB,
+		alloc.Resources.DiskMB,
+		alloc.Resources.IOPS)
+	c.Ui.Output(formatList(resources))
 }

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -267,7 +267,7 @@ func (c *AllocStatusCommand) sortedTaskStateIterator(m map[string]*api.TaskState
 // taskResources prints out the tasks current resource usage
 func (c *AllocStatusCommand) taskResources(alloc *api.Allocation) {
 	resources := make([]string, 2)
-	resources[0] = "CPU|MemoryMB|DiskMB|IOPS"
+	resources[0] = "CPU|Memory MB|Disk MB|IOPS"
 	resources[1] = fmt.Sprintf("%v|%v|%v|%v",
 		alloc.Resources.CPU,
 		alloc.Resources.MemoryMB,


### PR DESCRIPTION
When alloc-status is called, in it's long form only, print the resource
utilization for that single allocation.

When node-status is called, in it's long form only, print the TOTAL
resource utilization that is occurring on that single node.

Nomad Alloc Status:

```
% nomad alloc-status 195d3bf2
ID              = 195d3bf2
Eval ID         = c917e3ee
Name            = example.cache[1]
Node ID         = 1b2520a7
Job ID          = example
Client Status   = running
Evaluated Nodes = 1
Filtered Nodes  = 0
Exhausted Nodes = 0
Allocation Time = 17.73µs
Failures        = 0

==> Task "redis" is "running"
Recent Events:
Time                   Type      Description
04/03/16 21:20:45 EST  Started   Task started by client
04/03/16 21:20:42 EST  Received  Task received by client

==> Status
Allocation "195d3bf2" status "running" (0/1 nodes filtered)
  * Score "1b2520a7-6714-e78d-a8f7-68467dda6db7.binpack" = 1.209464
  * Score "1b2520a7-6714-e78d-a8f7-68467dda6db7.job-anti-affinity" = -10.000000

==> Resources
CPU  MemoryMB  DiskMB  IOPS
500  256       300     0
```

Nomad Node Status:

```
% nomad node-status 57b3a55a
ID         = 57b3a55a
Name       = biscuits
Class      = <none>
DC         = dc1
Drain      = false
Status     = ready
Attributes = arch:amd64, cpu.frequency:3753.458875, cpu.modelname:Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz, cpu.numcores:8, cpu.totalcompute:30027.671000, driver.docker:1, driver.docker.version:1.10.2, driver.exec:1, driver.raw_exec:1, hostname:biscuits, kernel.name:linux, kernel.version:4.4.0-9-generic, memory.totalbytes:25208934400, os.name:ubuntu, os.version:16.04, unique.cgroup.mountpoint:/sys/fs/cgroup, unique.network.ip-address:127.0.0.1, unique.storage.bytesfree:219781419008, unique.storage.bytestotal:246059892736, unique.storage.volume:/dev/sdb3

==> Allocations
ID        Eval ID   Job ID   Task Group  Desired Status  Client Status
2c236883  aa11aca8  example  cache       run             running
32f6e3d6  aa11aca8  example  cache       run             running

==> Resource Utilization
CPU   MemoryMB  DiskMB  IOPS
1000  512       600     0
```

Fixes: #872 