### PR TITLE
Enable passing DNS info to the rkt driver

### DIFF
--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -49,8 +50,10 @@ type RktDriver struct {
 }
 
 type RktDriverConfig struct {
-	ImageName string   `mapstructure:"image"`
-	Args      []string `mapstructure:"args"`
+	ImageName        string   `mapstructure:"image"`
+	Args             []string `mapstructure:"args"`
+	DNSServers       []string `mapstructure:"dns_servers"`        // DNS Server for containers
+	DNSSearchDomains []string `mapstructure:"dns_search_domains"` // DNS Search domains for containers
 }
 
 // rktHandle is returned from Start/Open as a handle to the PID
@@ -182,6 +185,22 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 
 	// Add CPU isolator
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--cpu=%vm", int64(task.Resources.CPU)))
+
+	// Add DNS servers
+	for _, ip := range driverConfig.DNSServers {
+		if err := net.ParseIP(ip); err == nil {
+			msg := fmt.Errorf("invalid ip address for container dns server %q", ip)
+			d.logger.Printf("[DEBUG] driver.rkt: %v", msg)
+			return nil, msg
+		} else {
+			cmdArgs = append(cmdArgs, fmt.Sprintf("--dns=%s", ip))
+		}
+	}
+
+	// set DNS search domains
+	for _, domain := range driverConfig.DNSSearchDomains {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--dns-search=%s", domain))
+	}
 
 	// Add user passed arguments.
 	if len(driverConfig.Args) != 0 {

--- a/client/driver/rkt_test.go
+++ b/client/driver/rkt_test.go
@@ -57,15 +57,17 @@ func TestRktDriver_Fingerprint(t *testing.T) {
 	}
 }
 
-func TestRktDriver_Start(t *testing.T) {
+func TestRktDriver_Start_DNS(t *testing.T) {
 	ctestutils.RktCompatible(t)
 	// TODO: use test server to load from a fixture
 	task := &structs.Task{
 		Name: "etcd",
 		Config: map[string]interface{}{
-			"trust_prefix": "coreos.com/etcd",
-			"image":        "coreos.com/etcd:v2.0.4",
-			"command":      "/etcd",
+			"trust_prefix":		"coreos.com/etcd",
+			"image":		"coreos.com/etcd:v2.0.4",
+			"command":		"/etcd",
+			"dns_servers":          []string{"8.8.8.8", "8.8.4.4"},
+			"dns_search_domains":   []string{"example.com", "example.org", "example.net"},
 		},
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,

--- a/website/source/docs/drivers/rkt.html.md
+++ b/website/source/docs/drivers/rkt.html.md
@@ -37,6 +37,11 @@ The `rkt` driver supports the following configuration in the job spec:
   reachable from the box running the nomad agent. If not specified, the image is
   run without verifying the image signature.
 
+* `dns_servers` - (Optional) A list of DNS servers to be used in the containers
+
+* `dns_search_domains` - (Optional) A list of DNS search domains to be used in
+   the containers
+
 ## Task Directories
 
 The `rkt` driver currently does not support mounting of the `alloc/` and `local/` directory. 


### PR DESCRIPTION
Pass DNS servers and search domains to the rkt CLI. These get written to the container's resolv.conf.