### PR TITLE
Using unix domain sockets for docker syslog collector

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -238,7 +238,7 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 		LogConfig: docker.LogConfig{
 			Type: "syslog",
 			Config: map[string]string{
-				"syslog-address": fmt.Sprintf("tcp://%v", syslogAddr),
+				"syslog-address": syslogAddr,
 			},
 		},
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -260,9 +261,11 @@ func (a *Agent) setupClient() error {
 		return fmt.Errorf("client setup failed: %v", err)
 	}
 
-	// Reserve some ports for the plugins
-	if err := a.reservePortsForClient(conf); err != nil {
-		return err
+	// Reserve some ports for the plugins if we are on Windows
+	if runtime.GOOS == "windows" {
+		if err := a.reservePortsForClient(conf); err != nil {
+			return err
+		}
 	}
 
 	// Create the client


### PR DESCRIPTION
This PR makes use of unix domain sockets for the syslog collector for Docker on *nix platforms.