### PR TITLE
Validate config keys in the jobspec

### DIFF
--- a/command/run_test.go
+++ b/command/run_test.go
@@ -86,7 +86,7 @@ job "job1" {
 			resources = {
 				cpu = 1000
 				disk = 150
-				mem = 512
+				memory = 512
 			}
 		}
 	}

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -33,7 +33,7 @@ job "job1" {
 			resources = {
 				cpu = 1000
 				disk = 150
-				mem = 512
+				memory = 512
 			}
 		}
 	}

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -370,3 +370,20 @@ func TestIncompleteServiceDefn(t *testing.T) {
 		t.Fatalf("Expected collision error; got %v", err)
 	}
 }
+
+func TestIncorrectKey(t *testing.T) {
+	path, err := filepath.Abs(filepath.Join("./test-fixtures", "basic_wrong_key.hcl"))
+	if err != nil {
+		t.Fatalf("Can't get absolute path for file: %s", err)
+	}
+
+	_, err = ParseFile(path)
+
+	if err == nil {
+		t.Fatalf("Expected an error")
+	}
+
+	if !strings.Contains(err.Error(), "* group: 'binsl', task: 'binstore', service: 'binstore-storagelocker-binsl-binstore', check -> invalid key: nterval") {
+		t.Fatalf("Expected collision error; got %v", err)
+	}
+}

--- a/jobspec/test-fixtures/basic_wrong_key.hcl
+++ b/jobspec/test-fixtures/basic_wrong_key.hcl
@@ -56,7 +56,7 @@ job "binstore-storagelocker" {
                 check {
                     name = "check-name"
                     type = "tcp"
-                    interval = "10s"
+                    nterval = "10s"
                     timeout = "2s"
                 }
             }


### PR DESCRIPTION
Prevent wrong or misplaced configuration keys in the jobspec from being parsed to a valid config and tell the user exactly where to problem is.