### PR TITLE
Follow symlinks that escape chroot folders via hardlink/copy

### DIFF
--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -46,7 +46,7 @@ func TestAllocRunner_SimpleRun(t *testing.T) {
 	go ar.Run()
 	defer ar.Destroy()
 
-	testutil.WaitForResult(func() (bool, error) {
+	testutil.WeightedWaitForResult(4000, func() (bool, error) {
 		if upd.Count == 0 {
 			return false, fmt.Errorf("No updates")
 		}
@@ -70,7 +70,7 @@ func TestAllocRunner_TerminalUpdate_Destroy(t *testing.T) {
 	task.Config["args"] = []string{"10"}
 	go ar.Run()
 
-	testutil.WaitForResult(func() (bool, error) {
+	testutil.WeightedWaitForResult(4000, func() (bool, error) {
 		if upd.Count == 0 {
 			return false, fmt.Errorf("No updates")
 		}
@@ -166,7 +166,7 @@ func TestAllocRunner_Destroy(t *testing.T) {
 		ar.Destroy()
 	}()
 
-	testutil.WaitForResult(func() (bool, error) {
+	testutil.WeightedWaitForResult(4000, func() (bool, error) {
 		if upd.Count == 0 {
 			return false, nil
 		}
@@ -238,7 +238,7 @@ func TestAllocRunner_SaveRestoreState(t *testing.T) {
 	go ar.Run()
 
 	// Snapshot state
-	testutil.WaitForResult(func() (bool, error) {
+	testutil.WeightedWaitForResult(4000, func() (bool, error) {
 		return len(ar.tasks) == 1, nil
 	}, func(err error) {
 		t.Fatalf("task never started: %v", err)
@@ -263,7 +263,7 @@ func TestAllocRunner_SaveRestoreState(t *testing.T) {
 	ar2.Destroy()
 	start := time.Now()
 
-	testutil.WaitForResult(func() (bool, error) {
+	testutil.WeightedWaitForResult(4000, func() (bool, error) {
 		if upd.Count == 0 {
 			return false, nil
 		}
@@ -288,7 +288,7 @@ func TestAllocRunner_SaveRestoreState_TerminalAlloc(t *testing.T) {
 	task.Config["args"] = []string{"10"}
 	go ar.Run()
 
-	testutil.WaitForResult(func() (bool, error) {
+	testutil.WeightedWaitForResult(4000, func() (bool, error) {
 		if upd.Count == 0 {
 			return false, fmt.Errorf("No updates")
 		}

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -175,6 +176,12 @@ func (d *AllocDir) Build(tasks []*structs.Task) error {
 // hardlink and then defaults to copying. If the path exists on the host and
 // can't be embeded an error is returned.
 func (d *AllocDir) Embed(task string, entries map[string]string) error {
+	return d.embedInternal(task, entries, entries)
+}
+
+// embedInternal embeds the given entries and hardlinks/copies any symlink that
+// escapes the given rootFolders.
+func (d *AllocDir) embedInternal(task string, entries, rootFolders map[string]string) error {
 	taskdir, ok := d.TaskDirs[task]
 	if !ok {
 		return fmt.Errorf("Task directory doesn't exist for task %v", task)
@@ -216,6 +223,7 @@ func (d *AllocDir) Embed(task string, entries map[string]string) error {
 			return fmt.Errorf("Couldn't read directory %v: %v", source, err)
 		}
 
+	DIRLOOP:
 		for _, entry := range dirEntries {
 			hostEntry := filepath.Join(source, entry.Name())
 			taskEntry := filepath.Join(destDir, filepath.Base(hostEntry))
@@ -236,18 +244,39 @@ func (d *AllocDir) Embed(task string, entries map[string]string) error {
 					continue
 				}
 
-				link, err := os.Readlink(hostEntry)
+				link, err := filepath.EvalSymlinks(hostEntry)
 				if err != nil {
-					return fmt.Errorf("Couldn't resolve symlink for %v: %v", source, err)
-				}
-
-				if err := os.Symlink(link, taskEntry); err != nil {
-					// Symlinking twice
-					if err.(*os.LinkError).Err.Error() != "file exists" {
-						return fmt.Errorf("Couldn't create symlink: %v", err)
+					link, err = os.Readlink(hostEntry)
+					if err != nil {
+						return fmt.Errorf("Couldn't resolve symlink for %v: %v", source, err)
 					}
 				}
-				continue
+
+				// Only symlink when the destination is being embedded.
+				for root, _ := range rootFolders {
+					if !filepath.IsAbs(link) || strings.HasPrefix(link, root) {
+						if err := os.Symlink(link, taskEntry); err != nil {
+							// Symlinking twice
+							if err.(*os.LinkError).Err.Error() != "file exists" {
+								return fmt.Errorf("Couldn't create symlink: %v", err)
+							}
+						}
+						continue DIRLOOP
+					}
+				}
+
+				// Hard link or copy unreachable symlinks.
+				hostEntry = link
+
+				stat, err := os.Lstat(hostEntry)
+				if err != nil {
+					// Destination file is missing; give up.
+					continue
+				}
+				if stat.IsDir() {
+					subdirs[hostEntry] = filepath.Join(dest, filepath.Base(hostEntry))
+					continue
+				}
 			}
 
 			if err := d.linkOrCopy(hostEntry, taskEntry, entry.Mode().Perm()); err != nil {
@@ -258,7 +287,7 @@ func (d *AllocDir) Embed(task string, entries map[string]string) error {
 
 	// Recurse on self to copy subdirectories.
 	if len(subdirs) != 0 {
-		return d.Embed(task, subdirs)
+		return d.embedInternal(task, subdirs, rootFolders)
 	}
 
 	return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -330,7 +330,7 @@ func TestClient_UpdateAllocStatus(t *testing.T) {
 	state := s1.State()
 	state.UpsertAllocs(100, []*structs.Allocation{alloc})
 
-	testutil.WaitForResult(func() (bool, error) {
+	testutil.WeightedWaitForResult(4000, func() (bool, error) {
 		out, err := state.AllocByID(alloc.ID)
 		if err != nil {
 			return false, err
@@ -446,7 +446,7 @@ func TestClient_SaveRestoreState(t *testing.T) {
 	}
 
 	// Allocations should get registered
-	testutil.WaitForResult(func() (bool, error) {
+	testutil.WeightedWaitForResult(4000, func() (bool, error) {
 		c1.allocLock.RLock()
 		ar := c1.allocs[alloc1.ID]
 		c1.allocLock.RUnlock()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,4 +10,4 @@ go build -o $TEMPDIR/nomad || exit 1
 
 # Run the tests
 echo "--> Running tests"
-go list ./... | grep -v '/vendor/' | sudo -E PATH=$TEMPDIR:$PATH xargs -n1 go test -cover -timeout=180s
+go list ./... | grep -v '/vendor/' | sudo -E PATH=$TEMPDIR:$PATH xargs -n1 go test -cover -timeout=300s

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -18,7 +18,11 @@ type testFn func() (bool, error)
 type errorFn func(error)
 
 func WaitForResult(test testFn, error errorFn) {
-	WaitForResultRetries(2000*TestMultiplier(), test, error)
+	WeightedWaitForResult(2000, test, error)
+}
+
+func WeightedWaitForResult(weight int64, test testFn, error errorFn) {
+	WaitForResultRetries(weight*TestMultiplier(), test, error)
 }
 
 func WaitForResultRetries(retries int64, test testFn, error errorFn) {


### PR DESCRIPTION
Executor: Solves the problem of files within the configured chroot folders having symlinks that are unreachable in the chroot not existing.