### PR TITLE
Update confusing terms in scheduling.html.md

### DIFF
--- a/website/source/docs/internals/scheduling.html.md
+++ b/website/source/docs/internals/scheduling.html.md
@@ -28,8 +28,8 @@ spelunking through the source code.
 
 There are four primary "nouns" in Nomad; jobs, nodes, allocations, and evaluations.
 Jobs are submitted by users and represent a _desired state_. A job is a declarative description
-of tasks to run which are bounded by constraints and require resources. Clients are nodes in the cluster 
-with Nomad agent that tasks can be scheduled on. The mapping of tasks in a job to clients is done
+of tasks to run which are bounded by constraints and require resources. Tasks can be scheduled on 
+nodes in the cluster runnaing the Nomad client. The mapping of tasks in a job to clients is done
 using allocations. An allocation is used to declare that a set of tasks in a job should be run
 on a particular node. Scheduling is the process of determining the appropriate allocations and
 is done as part of an evaluation.

--- a/website/source/docs/internals/scheduling.html.md
+++ b/website/source/docs/internals/scheduling.html.md
@@ -28,8 +28,8 @@ spelunking through the source code.
 
 There are four primary "nouns" in Nomad; jobs, nodes, allocations, and evaluations.
 Jobs are submitted by users and represent a _desired state_. A job is a declarative description
-of tasks to run which are bounded by constraints and require resources. Nodes are the servers
-in the clusters that tasks can be scheduled on. The mapping of tasks in a job to nodes is done
+of tasks to run which are bounded by constraints and require resources. Clients are nodes in the cluster 
+with Nomad agent that tasks can be scheduled on. The mapping of tasks in a job to clients is done
 using allocations. An allocation is used to declare that a set of tasks in a job should be run
 on a particular node. Scheduling is the process of determining the appropriate allocations and
 is done as part of an evaluation.

--- a/website/source/docs/internals/scheduling.html.md
+++ b/website/source/docs/internals/scheduling.html.md
@@ -29,7 +29,7 @@ spelunking through the source code.
 There are four primary "nouns" in Nomad; jobs, nodes, allocations, and evaluations.
 Jobs are submitted by users and represent a _desired state_. A job is a declarative description
 of tasks to run which are bounded by constraints and require resources. Tasks can be scheduled on 
-nodes in the cluster runnaing the Nomad client. The mapping of tasks in a job to clients is done
+nodes in the cluster running the Nomad client. The mapping of tasks in a job to clients is done
 using allocations. An allocation is used to declare that a set of tasks in a job should be run
 on a particular node. Scheduling is the process of determining the appropriate allocations and
 is done as part of an evaluation.


### PR DESCRIPTION
I think it creates confusion for new learners to call clients as nodes. A node may not have Nomad agent running and jobs can only be scheduled to clients.