### PR TITLE
Allow count zero task groups

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1344,8 +1344,8 @@ func (tg *TaskGroup) Validate() error {
 	if tg.Name == "" {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing task group name"))
 	}
-	if tg.Count <= 0 {
-		mErr.Errors = append(mErr.Errors, errors.New("Task group count must be positive"))
+	if tg.Count < 0 {
+		mErr.Errors = append(mErr.Errors, errors.New("Task group count can't be negative"))
 	}
 	if len(tg.Tasks) == 0 {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing tasks for task group"))

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -196,6 +196,7 @@ func TestJob_IsPeriodic(t *testing.T) {
 
 func TestTaskGroup_Validate(t *testing.T) {
 	tg := &TaskGroup{
+		Count: -1,
 		RestartPolicy: &RestartPolicy{
 			Interval: 5 * time.Minute,
 			Delay:    10 * time.Second,
@@ -208,7 +209,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 	if !strings.Contains(mErr.Errors[0].Error(), "group name") {
 		t.Fatalf("err: %s", err)
 	}
-	if !strings.Contains(mErr.Errors[1].Error(), "count must be positive") {
+	if !strings.Contains(mErr.Errors[1].Error(), "count can't be negative") {
 		t.Fatalf("err: %s", err)
 	}
 	if !strings.Contains(mErr.Errors[2].Error(), "Missing tasks") {


### PR DESCRIPTION
This PR allows count zero task groups. This is useful for doing blue/green deploys

@pshima 