### PR TITLE
Go's -X linker flag now requires only one argument

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,8 +12,8 @@ DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 cd "$DIR"
 
 # Get the git commit
-GIT_COMMIT=$(git rev-parse HEAD)
-GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
+GIT_COMMIT="$(git rev-parse HEAD)"
+GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
 
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
@@ -39,7 +39,7 @@ gox \
     -os="!openbsd" \
     -arch="${XC_ARCH}" \
     -osarch="!linux/arm !darwin/386" \
-    -ldflags "-X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
+    -ldflags "-X main.GitCommit='${GIT_COMMIT}${GIT_DIRTY}'" \
     -cgo \
     -output "pkg/{{.OS}}_{{.Arch}}/nomad" \
     .


### PR DESCRIPTION
This fixes building consul with Go >1.6. From https://golang.org/cmd/link/:

```
-X importpath.name=value
    Set the value of the string variable in importpath named name to value.
    Note that before Go 1.5 this option took two separate arguments.
    Now it takes one argument split on the first = sign.
```