### PR TITLE
Allow fs commands to use job-id

### DIFF
--- a/command/fs.go
+++ b/command/fs.go
@@ -1,6 +1,12 @@
 package command
 
-import "github.com/mitchellh/cli"
+import (
+	"math/rand"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/mitchellh/cli"
+)
 
 type FSCommand struct {
 	Meta
@@ -16,4 +22,24 @@ func (f *FSCommand) Synopsis() string {
 
 func (f *FSCommand) Run(args []string) int {
 	return cli.RunResultHelp
+}
+
+// Get Random Allocation ID from a known jobID. Prefer to use a running allocation,
+// but use a dead allocation if no running allocations are found
+func getRandomJobAlloc(client *api.Client, jobID string) (string, error) {
+	var runningAllocs []*api.AllocationListStub
+	allocs, _, err := client.Jobs().Allocations(jobID, nil)
+	for _, v := range allocs {
+		if v.ClientStatus == "running" {
+			runningAllocs = append(runningAllocs, v)
+		}
+	}
+	// If we don't have any allocations running, use dead allocations
+	if len(runningAllocs) < 1 {
+		runningAllocs = allocs
+	}
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	allocID := runningAllocs[r.Intn(len(runningAllocs))].ID
+	return allocID, err
 }

--- a/website/source/docs/commands/fs.html.md.erb
+++ b/website/source/docs/commands/fs.html.md.erb
@@ -23,7 +23,7 @@ nomad fs stat <alloc-id> <path>
 nomad fs cat <alloc-id> <path>
 ```
 
-A valid allocation id is necessary and the path is relative to the root of the allocation directory.
+A valid allocation id is necessary unless `-job` is specified and the path is relative to the root of the allocation directory.
 The path is optional and it defaults to `/` of the allocation directory
 
 ## Examples
@@ -50,3 +50,14 @@ $ nomad fs cat redis/local/redis.stdout
 6710:C 27 Jan 22:04:03.794 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
 6710:M 27 Jan 22:04:03.795 * Increased maximum number of open files to 10032 (it was originally set to 256).
 
+## Using Job-ID instead of Alloc-ID
+
+Passing `-job` into one of the `fs` commands will allow the `fs` command to randomly select an allocation ID from the specified job.
+
+```
+nomad fs ls -job <job-id> <path>
+```
+
+Nomad will prefer to select a running allocation ID for the job, but if no running allocations for the job are found, Nomad will use a dead allocation.
+
+This can be useful for debugging a job that has multiple allocations, and it's not really required to use a specific allocation ID.


### PR DESCRIPTION
Adds `-job` flag argument to `nomad fs` commands to randomly lookup a
job's allocation-id to use in an `fs` command.

Can be used when debugging a job, where a specific allocation ID is not
a strict requirement.