### PR TITLE
Use an interface name to find the bind addr for rpc, http and serf components

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -144,7 +144,7 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 		conf.SerfConfig.MemberlistConfig.BindAddr = ip.String()
 	}
 
-	if device := a.config.Interfaces.HTTP; device != "" {
+	if device := a.config.Interfaces.HTTP; device != "" && a.config.Addresses.HTTP == "" {
 		ip, err := ipOfDevice(device)
 		if err != nil {
 			return nil, err

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -220,6 +220,7 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error finding ip address from interface %q: %v", a.config.Interfaces.HTTP, err)
 		}
+		a.config.Addresses.HTTP = ip.String()
 		httpAddr = fmt.Sprintf("%s:%d", ip.String(), a.config.Ports.HTTP)
 	} else if a.config.AdvertiseAddrs.HTTP != "" {
 		addr, err := net.ResolveTCPAddr("tcp", a.config.AdvertiseAddrs.HTTP)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -71,7 +71,7 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 	conf.LogOutput = a.logOutput
 	conf.DevMode = a.config.DevMode
 	conf.Build = fmt.Sprintf("%s%s", a.config.Version, a.config.VersionPrerelease)
-	if a.config.Region != "" {
+	if i.config.Region != "" {
 		conf.Region = a.config.Region
 	}
 	if a.config.Datacenter != "" {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	// Addresses is used to override the network addresses we bind to.
 	Addresses *Addresses `mapstructure:"addresses"`
 
+	// Interfaces is used to override the network addresses we bind to by
+	// providing device names
 	Interfaces *Interfaces `mapstructure:"interfaces"`
 
 	// AdvertiseAddrs is used to control the addresses we advertise.

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -259,6 +259,8 @@ type Addresses struct {
 	Serf string `mapstructure:"serf"`
 }
 
+// Interfaces provides an alternative to the Addresses configuration. We pick an
+// ip configured on the devide specified and use that to bind.
 type Interfaces struct {
 	HTTP string `mapstructure:"http"`
 	RPC  string `mapstructure:"rpc"`

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	// Addresses is used to override the network addresses we bind to.
 	Addresses *Addresses `mapstructure:"addresses"`
 
+	Interfaces *Interfaces `mapstructure:"interfaces"`
+
 	// AdvertiseAddrs is used to control the addresses we advertise.
 	AdvertiseAddrs *AdvertiseAddrs `mapstructure:"advertise"`
 
@@ -255,6 +257,12 @@ type Addresses struct {
 	Serf string `mapstructure:"serf"`
 }
 
+type Interfaces struct {
+	HTTP string `mapstructure:"http"`
+	RPC  string `mapstructure:"rpc"`
+	Serf string `mapstructure:"serf"`
+}
+
 // AdvertiseAddrs is used to control the addresses we advertise out for
 // different network services. Not all network services support an
 // advertise address. All are optional and default to BindAddr.
@@ -366,6 +374,7 @@ func DefaultConfig() *Config {
 			Serf: 4648,
 		},
 		Addresses:      &Addresses{},
+		Interfaces:     &Interfaces{},
 		AdvertiseAddrs: &AdvertiseAddrs{},
 		Atlas:          &AtlasConfig{},
 		Client: &ClientConfig{
@@ -494,6 +503,14 @@ func (c *Config) Merge(b *Config) *Config {
 		result.Addresses = &addrs
 	} else if b.Addresses != nil {
 		result.Addresses = result.Addresses.Merge(b.Addresses)
+	}
+
+	// Apply the interfaces config
+	if result.Interfaces == nil && b.Interfaces != nil {
+		interfaces := *b.Interfaces
+		result.Interfaces = &interfaces
+	} else if b.Interfaces != nil {
+		result.Interfaces = result.Interfaces.Merge(b.Interfaces)
 	}
 
 	// Apply the advertise addrs config
@@ -662,6 +679,22 @@ func (a *Ports) Merge(b *Ports) *Ports {
 // Merge is used to merge two address configs together.
 func (a *Addresses) Merge(b *Addresses) *Addresses {
 	result := *a
+
+	if b.HTTP != "" {
+		result.HTTP = b.HTTP
+	}
+	if b.RPC != "" {
+		result.RPC = b.RPC
+	}
+	if b.Serf != "" {
+		result.Serf = b.Serf
+	}
+	return &result
+}
+
+// Merge is used to merge two interfaces configs together.
+func (i *Interfaces) Merge(b *Interfaces) *Interfaces {
+	result := *i
 
 	if b.HTTP != "" {
 		result.HTTP = b.HTTP

--- a/command/agent/util.go
+++ b/command/agent/util.go
@@ -25,7 +25,10 @@ func ipOfDevice(name string) (net.IP, error) {
 	if len(addrs) == 0 {
 		return nil, fmt.Errorf("no ips were detected on the interface: %v", name)
 	}
-	var ipv4Addrs []net.IP
+
+	// Iterating through the IPs configured for that device and returning the
+	// the first ipv4 address configured. If no ipv4 addresses are configured,
+	// we return the first ipv6 addr if any ipv6 addr is configured.
 	var ipv6Addrs []net.IP
 	for _, addr := range addrs {
 		var ip net.IP
@@ -33,8 +36,7 @@ func ipOfDevice(name string) (net.IP, error) {
 		case *net.IPNet:
 			ip = v.IP
 			if ip.To4() != nil {
-				ipv4Addrs = append(ipv4Addrs, ip)
-				continue
+				return ip, nil
 			}
 			if ip.To16() != nil {
 				ipv6Addrs = append(ipv6Addrs, ip)
@@ -43,9 +45,6 @@ func ipOfDevice(name string) (net.IP, error) {
 		case *net.IPAddr:
 			continue
 		}
-	}
-	if len(ipv4Addrs) > 0 {
-		return ipv4Addrs[0], nil
 	}
 	if len(ipv6Addrs) > 0 {
 		return ipv6Addrs[0], nil

--- a/command/agent/util.go
+++ b/command/agent/util.go
@@ -13,7 +13,7 @@ func randomStagger(intv time.Duration) time.Duration {
 }
 
 // IpOfDevice returns a routable ip addr of a device
-func IpOfDevice(name string) (net.IP, error) {
+func ipOfDevice(name string) (net.IP, error) {
 	intf, err := net.InterfaceByName(name)
 	if err != nil {
 		return nil, err
@@ -25,13 +25,30 @@ func IpOfDevice(name string) (net.IP, error) {
 	if len(addrs) == 0 {
 		return nil, fmt.Errorf("no ips were detected on the interface: %v", name)
 	}
+	var ipv4Addrs []net.IP
+	var ipv6Addrs []net.IP
 	for _, addr := range addrs {
+		var ip net.IP
 		switch v := (addr).(type) {
 		case *net.IPNet:
 			continue
 		case *net.IPAddr:
-			return v.IP, nil
+			ip = v.IP
+			if ip.To4() != nil {
+				ipv4Addrs = append(ipv4Addrs, ip)
+				continue
+			}
+			if ip.To16() != nil {
+				ipv6Addrs = append(ipv6Addrs, ip)
+				continue
+			}
 		}
+	}
+	if len(ipv4Addrs) > 0 {
+		return ipv4Addrs[0], nil
+	}
+	if len(ipv6Addrs) > 0 {
+		return ipv6Addrs[0], nil
 	}
 	return nil, fmt.Errorf("no ips were detected on the interface: %v", name)
 }

--- a/command/agent/util.go
+++ b/command/agent/util.go
@@ -1,11 +1,37 @@
 package agent
 
 import (
+	"fmt"
 	"math/rand"
+	"net"
 	"time"
 )
 
 // Returns a random stagger interval between 0 and the duration
 func randomStagger(intv time.Duration) time.Duration {
 	return time.Duration(uint64(rand.Int63()) % uint64(intv))
+}
+
+// IpOfDevice returns a routable ip addr of a device
+func IpOfDevice(name string) (net.IP, error) {
+	intf, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := intf.Addrs()
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no ips were detected on the interface: %v", name)
+	}
+	for _, addr := range addrs {
+		switch v := (addr).(type) {
+		case *net.IPNet:
+			continue
+		case *net.IPAddr:
+			return v.IP, nil
+		}
+	}
+	return nil, fmt.Errorf("no ips were detected on the interface: %v", name)
 }

--- a/command/agent/util.go
+++ b/command/agent/util.go
@@ -31,8 +31,6 @@ func ipOfDevice(name string) (net.IP, error) {
 		var ip net.IP
 		switch v := (addr).(type) {
 		case *net.IPNet:
-			continue
-		case *net.IPAddr:
 			ip = v.IP
 			if ip.To4() != nil {
 				ipv4Addrs = append(ipv4Addrs, ip)
@@ -42,6 +40,8 @@ func ipOfDevice(name string) (net.IP, error) {
 				ipv6Addrs = append(ipv6Addrs, ip)
 				continue
 			}
+		case *net.IPAddr:
+			continue
 		}
 	}
 	if len(ipv4Addrs) > 0 {

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -144,6 +144,22 @@ nodes, unless otherwise specified:
     server nodes from the same datacenter if possible. Used only on server
     nodes.
 
+* <a id="interfaces">`interfaces`</a>: Provides an alternative to the
+ `addresses` configuration. Operators can provide network device names to which
+ Nomad binds individual network services. Nomad looks for the first IPv4
+ address configured for the device and uses it, and if no IPv4 address is
+ present then it looks for an IPv6 address. The value is a map of device names of
+ network interfaces and supports the following keys:
+  <br>
+  * `http`: The device name the HTTP server is bound to. Applies to both clients and servers.
+  * `rpc`: The device name to bind the internal RPC interfaces to. Should be exposed
+    only to other cluster members if possible. Used only on server nodes, but
+    must be accessible from all agents.
+  * `serf`: The device name used to bind the gossip layer to. Both a TCP and UDP
+    listener will be exposed on this address. Should be restricted to only
+    server nodes from the same datacenter if possible. Used only on server
+    nodes.
+
 * `advertise`: Controls the advertise address for individual network services.
   This can be used to advertise a different address to the peers of a server
   node to support more complex network configurations such as NAT. This


### PR DESCRIPTION
This PR allows the operators to specify an interface name which Nomad will use to find an IP address and use it for the http service, serf and rpc.

For example, with the following configuration - 
```
interfaces {
   http = "eth2"
   serf = "eth0"
   rpc = "eth0"
}
```
Nomad will find the IPs configured for each of the network interfaces and use one of the IPs for binding the network services. IPv4 addresses are given preference over IPv6