### PR TITLE
Download artifacts to relative locations inside the task directory

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -99,6 +99,7 @@ type Task struct {
 type TaskArtifact struct {
 	GetterSource  string
 	GetterOptions map[string]string
+	RelativeDest  string
 }
 
 // NewTask creates and initializes a new Task.

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -112,7 +112,7 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	ps, err := exec.LaunchCmd(&executor.ExecCommand{Cmd: command, Args: driverConfig.Args}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()
-		return nil, fmt.Errorf("error starting process via the plugin: %v", err)
+		return nil, err
 	}
 	d.logger.Printf("[DEBUG] driver.exec: started process via plugin with pid: %v", ps.Pid)
 

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -145,20 +146,36 @@ func (e *UniversalExecutor) LaunchCmd(command *ExecCommand, ctx *ExecutorContext
 	e.cmd.Stderr = lre
 	e.lre = lre
 
-	// setting the env, path and args for the command
 	e.ctx.TaskEnv.Build()
-	e.cmd.Env = ctx.TaskEnv.EnvList()
-	e.cmd.Path = ctx.TaskEnv.ReplaceEnv(command.Cmd)
-	e.cmd.Args = append([]string{e.cmd.Path}, ctx.TaskEnv.ParseAndReplace(command.Args)...)
 
-	// Ensure that the binary being started is executable.
-	if err := e.makeExecutable(e.cmd.Path); err != nil {
+	// Look up the binary path and make it executable
+	absPath, err := e.lookupBin(ctx.TaskEnv.ReplaceEnv(command.Cmd))
+	if err != nil {
 		return nil, err
 	}
 
-	// starting the process
+	if err := e.makeExecutable(absPath); err != nil {
+		return nil, err
+	}
+
+	// Determine the path to run as it may have to be relative to the chroot.
+	path := absPath
+	if e.ctx.FSIsolation {
+		rel, err := filepath.Rel(e.taskDir, absPath)
+		if err != nil {
+			return nil, err
+		}
+		path = rel
+	}
+
+	// Set the commands arguments
+	e.cmd.Path = path
+	e.cmd.Args = append([]string{path}, ctx.TaskEnv.ParseAndReplace(command.Args)...)
+	e.cmd.Env = ctx.TaskEnv.EnvList()
+
+	// Start the process
 	if err := e.cmd.Start(); err != nil {
-		return nil, fmt.Errorf("error starting command: %v", err)
+		return nil, err
 	}
 	go e.wait()
 	ic := &cstructs.IsolationConfig{Cgroup: e.groups}
@@ -279,8 +296,36 @@ func (e *UniversalExecutor) configureTaskDir() error {
 	return nil
 }
 
-// makeExecutablePosix makes the given file executable for root,group,others.
-func (e *UniversalExecutor) makeExecutablePosix(binPath string) error {
+// lookupBin looks for path to the binary to run by looking for the binary in
+// the following locations, in-order: task/local/, task/, based on host $PATH.
+// The return path is absolute.
+func (e *UniversalExecutor) lookupBin(bin string) (string, error) {
+	// Check in the local directory
+	local := filepath.Join(e.taskDir, allocdir.TaskLocal, bin)
+	if _, err := os.Stat(local); err == nil {
+		return local, nil
+	}
+
+	// Check at the root of the task's directory
+	root := filepath.Join(e.taskDir, bin)
+	if _, err := os.Stat(root); err == nil {
+		return root, nil
+	}
+
+	// Check the $PATH
+	if host, err := exec.LookPath(bin); err == nil {
+		return host, nil
+	}
+
+	return "", fmt.Errorf("binary %q could not be found", bin)
+}
+
+// makeExecutable makes the given file executable for root,group,others.
+func (e *UniversalExecutor) makeExecutable(binPath string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
 	fi, err := os.Stat(binPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/client/driver/executor/executor_basic.go
+++ b/client/driver/executor/executor_basic.go
@@ -2,25 +2,7 @@
 
 package executor
 
-import (
-	"path/filepath"
-	"runtime"
-
-	cgroupConfig "github.com/opencontainers/runc/libcontainer/configs"
-)
-
-func (e *UniversalExecutor) makeExecutable(binPath string) error {
-	if runtime.GOOS == "windows" {
-		return nil
-	}
-
-	path := binPath
-	if !filepath.IsAbs(binPath) {
-		// The path must be relative the allocations directory.
-		path = filepath.Join(e.taskDir, binPath)
-	}
-	return e.makeExecutablePosix(path)
-}
+import cgroupConfig "github.com/opencontainers/runc/libcontainer/configs"
 
 func (e *UniversalExecutor) configureChroot() error {
 	return nil

--- a/client/driver/executor/executor_linux.go
+++ b/client/driver/executor/executor_linux.go
@@ -36,18 +36,6 @@ var (
 	}
 )
 
-func (e *UniversalExecutor) makeExecutable(binPath string) error {
-	path := binPath
-	if e.ctx.FSIsolation {
-		// The path must be relative the chroot
-		path = filepath.Join(e.taskDir, binPath)
-	} else if !filepath.IsAbs(binPath) {
-		// The path must be relative the allocations directory.
-		path = filepath.Join(e.taskDir, binPath)
-	}
-	return e.makeExecutablePosix(path)
-}
-
 // configureIsolation configures chroot and creates cgroups
 func (e *UniversalExecutor) configureIsolation() error {
 	if e.ctx.FSIsolation {

--- a/client/driver/executor/executor_test.go
+++ b/client/driver/executor/executor_test.go
@@ -218,3 +218,38 @@ func TestExecutor_Start_Kill(t *testing.T) {
 		t.Fatalf("Command output incorrectly: want %v; got %v", expected, act)
 	}
 }
+
+func TestExecutor_MakeExecutable(t *testing.T) {
+	// Create a temp file
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	// Set its permissions to be non-executable
+	f.Chmod(os.FileMode(0610))
+
+	// Make a fake exececutor
+	ctx := testExecutorContext(t)
+	defer ctx.AllocDir.Destroy()
+	executor := NewExecutor(log.New(os.Stdout, "", log.LstdFlags))
+
+	err = executor.(*UniversalExecutor).makeExecutable(f.Name())
+	if err != nil {
+		t.Fatalf("makeExecutable() failed: %v", err)
+	}
+
+	// Check the permissions
+	stat, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat() failed: %v", err)
+	}
+
+	act := stat.Mode().Perm()
+	exp := os.FileMode(0755)
+	if act != exp {
+		t.Fatalf("expected permissions %v; got %v", err)
+	}
+}

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -172,7 +172,7 @@ func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	ps, err := execIntf.LaunchCmd(&executor.ExecCommand{Cmd: absPath, Args: args}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()
-		return nil, fmt.Errorf("error starting process via the plugin: %v", err)
+		return nil, err
 	}
 	d.logger.Printf("[DEBUG] driver.java: started process with pid: %v", ps.Pid)
 

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -200,7 +200,7 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	ps, err := exec.LaunchCmd(&executor.ExecCommand{Cmd: args[0], Args: args[1:]}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()
-		return nil, fmt.Errorf("error starting process via the plugin: %v", err)
+		return nil, err
 	}
 	d.logger.Printf("[INFO] Started new QemuVM: %s", vmID)
 

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -105,7 +105,7 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandl
 	ps, err := exec.LaunchCmd(&executor.ExecCommand{Cmd: command, Args: driverConfig.Args}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()
-		return nil, fmt.Errorf("error starting process via the plugin: %v", err)
+		return nil, err
 	}
 	d.logger.Printf("[DEBUG] driver.raw_exec: started process with pid: %v", ps.Pid)
 

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -249,7 +249,7 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	ps, err := execIntf.LaunchCmd(&executor.ExecCommand{Cmd: absPath, Args: cmdArgs}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()
-		return nil, fmt.Errorf("error starting process via the plugin: %v", err)
+		return nil, err
 	}
 
 	d.logger.Printf("[DEBUG] driver.rkt: started ACI %q with: %v", img, cmdArgs)

--- a/client/getter/getter.go
+++ b/client/getter/getter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"path/filepath"
 	"sync"
 
 	gg "github.com/hashicorp/go-getter"
@@ -59,16 +60,17 @@ func getGetterUrl(artifact *structs.TaskArtifact) (string, error) {
 	return u.String(), nil
 }
 
-// GetArtifact downloads an artifact into the specified destination directory.
-func GetArtifact(artifact *structs.TaskArtifact, destDir string, logger *log.Logger) error {
+// GetArtifact downloads an artifact into the specified task directory.
+func GetArtifact(artifact *structs.TaskArtifact, taskDir string, logger *log.Logger) error {
 	url, err := getGetterUrl(artifact)
 	if err != nil {
 		return err
 	}
 
 	// Download the artifact
-	if err := getClient(url, destDir).Get(); err != nil {
-		return err
+	dest := filepath.Join(taskDir, artifact.RelativeDest)
+	if err := getClient(url, dest).Get(); err != nil {
+		return fmt.Errorf("GET error: %v", err)
 	}
 
 	return nil

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -617,6 +617,7 @@ func parseArtifacts(result *[]*structs.TaskArtifact, list *ast.ObjectList) error
 		valid := []string{
 			"source",
 			"options",
+			"destination",
 		}
 		if err := checkHCLKeys(o.Val, valid); err != nil {
 			return err
@@ -628,6 +629,11 @@ func parseArtifacts(result *[]*structs.TaskArtifact, list *ast.ObjectList) error
 		}
 
 		delete(m, "options")
+
+		// Default to downloading to the local directory.
+		if _, ok := m["destination"]; !ok {
+			m["destination"] = "local/"
+		}
 
 		var ta structs.TaskArtifact
 		if err := mapstructure.WeakDecode(m, &ta); err != nil {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -131,12 +131,14 @@ func TestParse(t *testing.T) {
 								Artifacts: []*structs.TaskArtifact{
 									{
 										GetterSource: "http://foo.com/artifact",
+										RelativeDest: "local/",
 										GetterOptions: map[string]string{
 											"checksum": "md5:b8a4f3f72ecab0510a6a31e997461c5f",
 										},
 									},
 									{
 										GetterSource: "http://bar.com/artifact",
+										RelativeDest: "local/",
 										GetterOptions: map[string]string{
 											"checksum": "md5:ff1cc0d3432dad54d607c1505fb7245c",
 										},
@@ -319,6 +321,58 @@ func TestParse(t *testing.T) {
 			"bad-artifact.hcl",
 			nil,
 			true,
+		},
+
+		{
+			"artifacts.hcl",
+			&structs.Job{
+				ID:       "binstore-storagelocker",
+				Name:     "binstore-storagelocker",
+				Type:     "service",
+				Priority: 50,
+				Region:   "global",
+
+				TaskGroups: []*structs.TaskGroup{
+					&structs.TaskGroup{
+						Name:  "binsl",
+						Count: 1,
+						Tasks: []*structs.Task{
+							&structs.Task{
+								Name:   "binstore",
+								Driver: "docker",
+								Resources: &structs.Resources{
+									CPU:      100,
+									MemoryMB: 10,
+									DiskMB:   300,
+									IOPS:     0,
+								},
+								LogConfig: &structs.LogConfig{
+									MaxFiles:      10,
+									MaxFileSizeMB: 10,
+								},
+								Artifacts: []*structs.TaskArtifact{
+									{
+										GetterSource:  "http://foo.com/bar",
+										GetterOptions: map[string]string{},
+										RelativeDest:  "",
+									},
+									{
+										GetterSource:  "http://foo.com/baz",
+										GetterOptions: map[string]string{},
+										RelativeDest:  "local/",
+									},
+									{
+										GetterSource:  "http://foo.com/bam",
+										GetterOptions: map[string]string{},
+										RelativeDest:  "var/foo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			false,
 		},
 	}
 

--- a/jobspec/test-fixtures/artifacts.hcl
+++ b/jobspec/test-fixtures/artifacts.hcl
@@ -1,0 +1,21 @@
+job "binstore-storagelocker" {
+    group "binsl" {
+        task "binstore" {
+            driver = "docker"
+
+            artifact {
+                source = "http://foo.com/bar"
+                destination = ""
+            }
+
+            artifact {
+                source = "http://foo.com/baz"
+            }
+            artifact {
+                source = "http://foo.com/bam"
+                destination = "var/foo"
+            }
+            resources {}
+        }
+    }
+}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -777,6 +777,28 @@ func TestTaskArtifact_Validate_Source(t *testing.T) {
 	}
 }
 
+func TestTaskArtifact_Validate_Dest(t *testing.T) {
+	valid := &TaskArtifact{GetterSource: "google.com"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	valid.RelativeDest = "local/"
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	valid.RelativeDest = "local/.."
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	valid.RelativeDest = "local/../.."
+	if err := valid.Validate(); err == nil {
+		t.Fatalf("expected error: %v", err)
+	}
+}
+
 func TestTaskArtifact_Validate_Checksum(t *testing.T) {
 	cases := []struct {
 		Input *TaskArtifact

--- a/website/source/docs/jobspec/index.html.md
+++ b/website/source/docs/jobspec/index.html.md
@@ -430,6 +430,10 @@ The `artifact` object maps supports the following keys:
 
 * `source` - The path to the artifact to download.
 
+* `destination` - An optional path to download the artifact into relative to the
+  root of the task's directory. If the `destination` key is omitted, it will
+  default to `local/`.
+
 * `options` - The `options` block allows setting parameters for `go-getter`. An
   example is given below: 
 

--- a/website/source/docs/jobspec/json.html.md
+++ b/website/source/docs/jobspec/json.html.md
@@ -414,13 +414,16 @@ is started.
 
 The `Artifact` object maps supports the following keys:
 
-* `Source` - The path to the artifact to download.
+* `GetterSource` - The path to the artifact to download.
 
-* `Options` - The `options` block allows setting parameters for `go-getter`. An
-  example is given below: 
+* `RelativeDest` - The destination to download the artifact relative the task's
+  directory.
+
+* `GetterOptions` - A `map[string]string` block of options for  `go-getter`. An
+  example is given below:
 
 ```
-"Options": {
+"GetterOptions": {
     "checksum": "md5:c4aa853ad2215426eb7d70a21922e794",
 
     "aws_access_key_id": "<id>",


### PR DESCRIPTION
This PR:
* Allows for downloading of artifacts to relative locations in the task's directory
* Adds binary path lookup
* Updates JSON documentation
* Makes the default download location the task's local directory.