### PR TITLE
Reduce verbosity of alloc-status

### DIFF
--- a/client/driver/executor/executor_test.go
+++ b/client/driver/executor/executor_test.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/driver/env"
+	cstructs "github.com/hashicorp/nomad/client/driver/structs"
 	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	tu "github.com/hashicorp/nomad/testutil"
-	cstructs "github.com/hashicorp/nomad/client/driver/structs"
 )
 
 var (

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -126,13 +126,21 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		fmt.Sprintf("Node ID|%s", limit(alloc.NodeID, length)),
 		fmt.Sprintf("Job ID|%s", alloc.JobID),
 		fmt.Sprintf("Client Status|%s", alloc.ClientStatus),
-		fmt.Sprintf("Evaluated Nodes|%d", alloc.Metrics.NodesEvaluated),
-		fmt.Sprintf("Filtered Nodes|%d", alloc.Metrics.NodesFiltered),
-		fmt.Sprintf("Exhausted Nodes|%d", alloc.Metrics.NodesExhausted),
-		fmt.Sprintf("Allocation Time|%s", alloc.Metrics.AllocationTime),
-		fmt.Sprintf("Failures|%d", alloc.Metrics.CoalescedFailures),
+	}
+
+	if verbose {
+		basic = append(basic,
+			fmt.Sprintf("Evaluated Nodes|%d", alloc.Metrics.NodesEvaluated),
+			fmt.Sprintf("Filtered Nodes|%d", alloc.Metrics.NodesFiltered),
+			fmt.Sprintf("Exhausted Nodes|%d", alloc.Metrics.NodesExhausted),
+			fmt.Sprintf("Allocation Time|%s", alloc.Metrics.AllocationTime),
+			fmt.Sprintf("Failures|%d", alloc.Metrics.CoalescedFailures))
 	}
 	c.Ui.Output(formatKV(basic))
+
+	if !short {
+		c.taskResources(alloc)
+	}
 
 	// Print the state of each task.
 	if short {
@@ -142,12 +150,9 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	}
 
 	// Format the detailed status
-	c.Ui.Output("\n==> Status")
-	dumpAllocStatus(c.Ui, alloc, length)
-
-	if !short {
-		c.Ui.Output("\n==> Task Resources")
-		c.taskResources(alloc)
+	if verbose || alloc.DesiredStatus == "failed" {
+		c.Ui.Output("\n==> Status")
+		dumpAllocStatus(c.Ui, alloc, length)
 	}
 
 	return 0
@@ -283,6 +288,11 @@ func (c *AllocStatusCommand) allocResources(alloc *api.Allocation) {
 
 // taskResources prints out the tasks current resource usage
 func (c *AllocStatusCommand) taskResources(alloc *api.Allocation) {
+	if len(alloc.TaskResources) == 0 {
+		return
+	}
+
+	c.Ui.Output("\n==> Task Resources")
 	firstLine := true
 	for task, resource := range alloc.TaskResources {
 		header := fmt.Sprintf("\nTask: %q", task)


### PR DESCRIPTION
Reduce verbosity of alloc-status by hiding uncommon fields when `-verbose` isn't specified.