### PR TITLE
client: added the "user" option to tasks

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -84,6 +84,7 @@ type LogConfig struct {
 type Task struct {
 	Name        string
 	Driver      string
+	User        string
 	Config      map[string]interface{}
 	Constraints []*Constraint
 	Env         map[string]string

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -17,7 +17,6 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 
 	"github.com/hashicorp/go-plugin"
-
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/driver/executor"
@@ -224,6 +223,7 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 	config := &docker.Config{
 		Image:    driverConfig.ImageName,
 		Hostname: driverConfig.Hostname,
+		User:     task.User,
 	}
 
 	hostConfig := &docker.HostConfig{

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -74,6 +74,7 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	if err := mapstructure.WeakDecode(task.Config, &driverConfig); err != nil {
 		return nil, err
 	}
+
 	// Get the command to be ran
 	command := driverConfig.Command
 	if err := validateCommand(command, "args"); err != nil {
@@ -104,12 +105,13 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 		AllocDir: ctx.AllocDir,
 		Task:     task,
 	}
+
 	ps, err := exec.LaunchCmd(&executor.ExecCommand{
 		Cmd:            command,
 		Args:           driverConfig.Args,
 		FSIsolation:    true,
 		ResourceLimits: true,
-		User:           cstructs.DefaultUnpriviledgedUser,
+		User:           getExecutorUser(task),
 	}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -148,6 +148,7 @@ func (e *UniversalExecutor) LaunchCmd(command *ExecCommand, ctx *ExecutorContext
 
 	// setting the user of the process
 	if command.User != "" {
+		e.logger.Printf("[DEBUG] executor: running command as %s", command.User)
 		if err := e.runAs(command.User); err != nil {
 			return nil, err
 		}

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -169,7 +169,7 @@ func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 		Args:           args,
 		FSIsolation:    true,
 		ResourceLimits: true,
-		User:           cstructs.DefaultUnpriviledgedUser,
+		User:           getExecutorUser(task),
 	}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -195,7 +195,11 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 		AllocDir: ctx.AllocDir,
 		Task:     task,
 	}
-	ps, err := exec.LaunchCmd(&executor.ExecCommand{Cmd: args[0], Args: args[1:]}, executorCtx)
+	ps, err := exec.LaunchCmd(&executor.ExecCommand{
+		Cmd:  args[0],
+		Args: args[1:],
+		User: task.User,
+	}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()
 		return nil, err

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -100,7 +100,12 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandl
 		AllocDir: ctx.AllocDir,
 		Task:     task,
 	}
-	ps, err := exec.LaunchCmd(&executor.ExecCommand{Cmd: command, Args: driverConfig.Args}, executorCtx)
+
+	ps, err := exec.LaunchCmd(&executor.ExecCommand{
+		Cmd:  command,
+		Args: driverConfig.Args,
+		User: task.User,
+	}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()
 		return nil, err

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -243,7 +243,11 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 		return nil, err
 	}
 
-	ps, err := execIntf.LaunchCmd(&executor.ExecCommand{Cmd: absPath, Args: cmdArgs}, executorCtx)
+	ps, err := execIntf.LaunchCmd(&executor.ExecCommand{
+		Cmd:  absPath,
+		Args: cmdArgs,
+		User: task.User,
+	}, executorCtx)
 	if err != nil {
 		pluginClient.Kill()
 		return nil, err

--- a/client/driver/utils.go
+++ b/client/driver/utils.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/driver/executor"
 	"github.com/hashicorp/nomad/client/driver/logging"
+	cstructs "github.com/hashicorp/nomad/client/driver/structs"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // createExecutor launches an executor plugin and returns an instance of the
@@ -145,4 +147,13 @@ func GetAbsolutePath(bin string) (string, error) {
 	}
 
 	return filepath.EvalSymlinks(lp)
+}
+
+// getExecutorUser returns the user of the task, defaulting to
+// cstructs.DefaultUnprivilegedUser if none was given.
+func getExecutorUser(task *structs.Task) string {
+	if task.User == "" {
+		return cstructs.DefaultUnpriviledgedUser
+	}
+	return task.User
 }

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -460,6 +460,7 @@ func parseTasks(jobName string, taskGroupName string, result *[]*structs.Task, l
 		// Check for invalid keys
 		valid := []string{
 			"driver",
+			"user",
 			"env",
 			"service",
 			"config",

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -88,6 +88,7 @@ func TestParse(t *testing.T) {
 							&structs.Task{
 								Name:   "binstore",
 								Driver: "docker",
+								User:   "bob",
 								Config: map[string]interface{}{
 									"image": "hashicorp/binstore",
 								},
@@ -148,6 +149,7 @@ func TestParse(t *testing.T) {
 							&structs.Task{
 								Name:   "storagelocker",
 								Driver: "java",
+								User:   "",
 								Config: map[string]interface{}{
 									"image": "hashicorp/storagelocker",
 								},

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -39,6 +39,7 @@ job "binstore-storagelocker" {
         }
         task "binstore" {
             driver = "docker"
+            user = "bob"
             config {
                 image = "hashicorp/binstore"
             }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1583,6 +1583,10 @@ type Task struct {
 	// Driver is used to control which driver is used
 	Driver string
 
+	// User is used to determine which user will run the task. It defaults to
+	// the same user the Nomad client is being run as.
+	User string
+
 	// Config is provided to the driver to initialize
 	Config map[string]interface{}
 

--- a/website/source/docs/jobspec/index.html.md
+++ b/website/source/docs/jobspec/index.html.md
@@ -228,6 +228,9 @@ The `task` object supports the following keys:
   task. See the [driver documentation](/docs/drivers/index.html) for what
   is available. Examples include `docker`, `qemu`, `java`, and `exec`.
 
+* `user` - Set the user that will run the task. It defaults to the same user
+  the Nomad client is being run as.
+
 * `constraint` - This can be provided multiple times to define additional
   constraints. See the constraint reference for more details.
 
@@ -435,7 +438,7 @@ The `artifact` object maps supports the following keys:
   default to `local/`.
 
 * `options` - The `options` block allows setting parameters for `go-getter`. An
-  example is given below: 
+  example is given below:
 
 ```
 options {
@@ -453,7 +456,7 @@ An example of downloading and unzipping an archive is as simple as:
 
 ```
 artifact {
-  # The archive will be extracted before the task is run, making 
+  # The archive will be extracted before the task is run, making
   # it easy to ship configurations with your binary.
   source = "https://example.com/my.zip"
 


### PR DESCRIPTION
The `runAs` method already makes sure that the command to be executed is
performed with the given user. Therefore, in this commit this option is just
exported to the configuration of both drivers.

Fixes #276

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>