### PR TITLE
client: add nomad fingerprinter

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -77,6 +77,9 @@ type Config struct {
 
 	// Version is the version of the Nomad client
 	Version string
+
+	// Revision is the commit number of the Nomad client
+	Revision string
 }
 
 func (c *Config) Copy() *Config {

--- a/client/fingerprint/fingerprint.go
+++ b/client/fingerprint/fingerprint.go
@@ -24,6 +24,7 @@ var BuiltinFingerprints = []string{
 	"host",
 	"memory",
 	"network",
+	"nomad",
 	"storage",
 }
 
@@ -38,7 +39,8 @@ var builtinFingerprintMap = map[string]Factory{
 	"env_gce": NewEnvGCEFingerprint,
 	"host":    NewHostFingerprint,
 	"memory":  NewMemoryFingerprint,
-	"network": NewNetworkFingerprinter,
+	"network": NewNetworkFingerprint,
+	"nomad":   NewNomadFingerprint,
 	"storage": NewStorageFingerprint,
 }
 

--- a/client/fingerprint/network.go
+++ b/client/fingerprint/network.go
@@ -47,9 +47,9 @@ func (b *DefaultNetworkInterfaceDetector) Addrs(intf *net.Interface) ([]net.Addr
 	return intf.Addrs()
 }
 
-// NewNetworkFingerprinter returns a new NetworkFingerprinter with the given
+// NewNetworkFingerprint returns a new NetworkFingerprinter with the given
 // logger
-func NewNetworkFingerprinter(logger *log.Logger) Fingerprint {
+func NewNetworkFingerprint(logger *log.Logger) Fingerprint {
 	f := &NetworkFingerprint{logger: logger, interfaceDetector: &DefaultNetworkInterfaceDetector{}}
 	return f
 }

--- a/client/fingerprint/nomad.go
+++ b/client/fingerprint/nomad.go
@@ -1,0 +1,26 @@
+package fingerprint
+
+import (
+	"log"
+
+	client "github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// NomadFingerprint is used to fingerprint the Nomad version
+type NomadFingerprint struct {
+	StaticFingerprinter
+	logger *log.Logger
+}
+
+// NewNomadFingerprint is used to create a Nomad fingerprint
+func NewNomadFingerprint(logger *log.Logger) Fingerprint {
+	f := &NomadFingerprint{logger: logger}
+	return f
+}
+
+func (f *NomadFingerprint) Fingerprint(config *client.Config, node *structs.Node) (bool, error) {
+	node.Attributes["nomad.version"] = config.Version
+	node.Attributes["nomad.revision"] = config.Revision
+	return true, nil
+}

--- a/client/fingerprint/nomad_test.go
+++ b/client/fingerprint/nomad_test.go
@@ -1,0 +1,34 @@
+package fingerprint
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func TestNomadFingerprint(t *testing.T) {
+	f := NewNomadFingerprint(testLogger())
+	node := &structs.Node{
+		Attributes: make(map[string]string),
+	}
+	v := "foo"
+	r := "123"
+	c := &config.Config{
+		Version:  v,
+		Revision: r,
+	}
+	ok, err := f.Fingerprint(c, node)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("should apply")
+	}
+	if node.Attributes["nomad.version"] != v {
+		t.Fatalf("incorrect version")
+	}
+	if node.Attributes["nomad.revision"] != r {
+		t.Fatalf("incorrect revision")
+	}
+}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -265,7 +265,8 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	r.IOPS = a.config.Client.Reserved.IOPS
 	conf.GloballyReservedPorts = a.config.Client.Reserved.ParsedReservedPorts
 
-	conf.Version = a.config.Version
+	conf.Version = fmt.Sprintf("%s%s", a.config.Version, a.config.VersionPrerelease)
+	conf.Revision = a.config.Revision
 
 	return conf, nil
 }


### PR DESCRIPTION
Adds a nomad fingerprinter which stores the version and revision of nomad in the attributes.

Fixes https://github.com/hashicorp/nomad/issues/84