### PR TITLE
Allow setting hostname for rkt driver

### DIFF
--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -33,9 +33,10 @@ var (
 
 const (
 	// minRktVersion is the earliest supported version of rkt. rkt added support
-	// for CPU and memory isolators in 0.14.0. We cannot support an earlier
-	// version to maintain an uniform interface across all drivers
-	minRktVersion = "0.14.0"
+	// for features like CPU and memory isolators, setting hostname etc. recently.
+	// We cannot support an earlier version to maintain an uniform interface across
+	// all drivers
+	minRktVersion = "1.2.0"
 
 	// bytesToMB is the conversion from bytes to megabytes.
 	bytesToMB = 1024 * 1024
@@ -111,7 +112,7 @@ func (d *RktDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, e
 	minVersion, _ := version.NewVersion(minRktVersion)
 	currentVersion, _ := version.NewVersion(node.Attributes["driver.rkt.version"])
 	if currentVersion.LessThan(minVersion) {
-		// Do not allow rkt < 0.14.0
+		// Do not allow rkt < 1.2.0
 		d.logger.Printf("[WARN] driver.rkt: please upgrade rkt to a version >= %s", minVersion)
 		node.Attributes["driver.rkt"] = "0"
 	}

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -54,6 +54,7 @@ type RktDriverConfig struct {
 	Args             []string `mapstructure:"args"`
 	DNSServers       []string `mapstructure:"dns_servers"`        // DNS Server for containers
 	DNSSearchDomains []string `mapstructure:"dns_search_domains"` // DNS Search domains for containers
+	Hostname         string   `mapstructure:"hostname"`           // Hostname for containers
 }
 
 // rktHandle is returned from Start/Open as a handle to the PID
@@ -203,6 +204,9 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	for _, domain := range driverConfig.DNSSearchDomains {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--dns-search=%s", domain))
 	}
+
+	// Add hostname
+	cmdArgs = append(cmdArgs, fmt.Sprintf("--hostname=%s", driverConfig.Hostname))
 
 	// Add user passed arguments.
 	if len(driverConfig.Args) != 0 {

--- a/client/driver/rkt_test.go
+++ b/client/driver/rkt_test.go
@@ -68,6 +68,7 @@ func TestRktDriver_Start_DNS(t *testing.T) {
 			"command":            "/etcd",
 			"dns_servers":        []string{"8.8.8.8", "8.8.4.4"},
 			"dns_search_domains": []string{"example.com", "example.org", "example.net"},
+			"hostname":	      "etcd-container",
 		},
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,

--- a/website/source/docs/drivers/rkt.html.md
+++ b/website/source/docs/drivers/rkt.html.md
@@ -42,6 +42,8 @@ The `rkt` driver supports the following configuration in the job spec:
 * `dns_search_domains` - (Optional) A list of DNS search domains to be used in
    the containers
 
+* `hostname` - (Optional) Set a host name for the rkt pod. If empty, it will be "rkt-$PODUUID"
+
 ## Task Directories
 
 The `rkt` driver currently does not support mounting of the `alloc/` and `local/` directory. 


### PR DESCRIPTION
Requires rkt > 1.2.0
rkt PR here https://github.com/coreos/rkt/pull/2251