### PR TITLE
Pass environment variables from host to exec based tasks

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -10,6 +10,18 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+var (
+	// DefaultEnvBlacklist is the default set of environment variables that are
+	// filtered when passing the environment variables of the host to a task.
+	DefaultEnvBlacklist = strings.Join([]string{
+		"CONSUL_TOKEN",
+		"VAULT_TOKEN",
+		"ATLAS_TOKEN",
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+	}, ",")
+)
+
 // RPCHandler can be provided to the Client if there is a local server
 // to avoid going over the network. If not provided, the Client will
 // maintain a connection pool to the servers

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -306,6 +306,9 @@ func (t *TaskEnvironment) AppendEnvvars(m map[string]string) *TaskEnvironment {
 	return t
 }
 
+// AppendHostEnvvars adds the host environment variables to the tasks. The
+// filter parameter can be use to filter host environment from entering the
+// tasks.
 func (t *TaskEnvironment) AppendHostEnvvars(filter []string) *TaskEnvironment {
 	hostEnv := os.Environ()
 	if t.Env == nil {
@@ -321,7 +324,14 @@ func (t *TaskEnvironment) AppendHostEnvvars(filter []string) *TaskEnvironment {
 	for _, e := range hostEnv {
 		parts := strings.Split(e, "=")
 		key, value := parts[0], parts[1]
-		if _, filtered := index[key]; !filtered {
+
+		// Skip filtered environment variables
+		if _, filtered := index[key]; filtered {
+			continue
+		}
+
+		// Don't override the tasks environment variables.
+		if _, existing := t.Env[key]; !existing {
 			t.Env[key] = value
 		}
 	}

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -302,6 +303,29 @@ func (t *TaskEnvironment) AppendEnvvars(m map[string]string) *TaskEnvironment {
 	for k, v := range m {
 		t.Env[k] = v
 	}
+	return t
+}
+
+func (t *TaskEnvironment) AppendHostEnvvars(filter []string) *TaskEnvironment {
+	hostEnv := os.Environ()
+	if t.Env == nil {
+		t.Env = make(map[string]string, len(hostEnv))
+	}
+
+	// Index the filtered environment variables.
+	index := make(map[string]struct{}, len(filter))
+	for _, f := range filter {
+		index[f] = struct{}{}
+	}
+
+	for _, e := range hostEnv {
+		parts := strings.Split(e, "=")
+		key, value := parts[0], parts[1]
+		if _, filtered := index[key]; !filtered {
+			t.Env[key] = value
+		}
+	}
+
 	return t
 }
 

--- a/client/driver/env/env_test.go
+++ b/client/driver/env/env_test.go
@@ -2,8 +2,10 @@ package env
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -202,5 +204,24 @@ func TestEnvironment_Interprolate(t *testing.T) {
 	sort.Strings(exp)
 	if !reflect.DeepEqual(act, exp) {
 		t.Fatalf("env.List() returned %v; want %v", act, exp)
+	}
+}
+
+func TestEnvironment_AppendHostEnvVars(t *testing.T) {
+	host := os.Environ()
+	if len(host) < 2 {
+		t.Skip("No host environment variables. Can't test")
+	}
+	skip := strings.Split(host[0], "=")[0]
+	env := testTaskEnvironment().
+		AppendHostEnvvars([]string{skip}).
+		Build()
+
+	act := env.EnvMap()
+	if len(act) < 1 {
+		t.Fatalf("Host environment variables not properly set")
+	}
+	if _, ok := act[skip]; ok {
+		t.Fatalf("Didn't filter environment variable %q", skip)
 	}
 }

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -117,6 +117,11 @@ func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	if err := mapstructure.WeakDecode(task.Config, &driverConfig); err != nil {
 		return nil, err
 	}
+
+	// Set the host environment variables.
+	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
+	d.taskEnv.AppendHostEnvvars(filter)
+
 	taskDir, ok := ctx.AllocDir.TaskDirs[d.DriverContext.taskName]
 	if !ok {
 		return nil, fmt.Errorf("Could not find task directory for task: %v", d.DriverContext.taskName)

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-plugin"
@@ -81,6 +82,10 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandl
 	if err := validateCommand(command, "args"); err != nil {
 		return nil, err
 	}
+
+	// Set the host environment variables.
+	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
+	d.taskEnv.AppendHostEnvvars(filter)
 
 	bin, err := discover.NomadExecutable()
 	if err != nil {

--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -370,6 +370,17 @@ documentation [here](/docs/drivers/index.html)
   If the whitelist is empty, all drivers are fingerprinted and enabled where
   applicable.
 
+*   `env.blacklist`: Nomad passes the host environment variables to `exec`,
+    `raw_exec` and `java` tasks. `env.blacklist` is a comma seperated list of
+    environment variable keys not to pass to these tasks. If specified, the
+    defaults are overriden. The following are the default:
+    
+    * `CONSUL_TOKEN`
+    * `VAULT_TOKEN`
+    * `ATLAS_TOKEN`
+    * `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`
+    * `GOOGLE_APPLICATION_CREDENTIALS`
+
 * `fingerprint.whitelist`: A comma separated list of whitelisted fingerprinters.
   If specified, fingerprinters not in the whitelist will be disabled. If the
   whitelist is empty, all fingerprinters are used.


### PR DESCRIPTION
This PR makes it so `raw_exec`, `exec` and `java` pass environment variables set from the host. There is an operator controllable blacklist specifiable in the client variables as `env.blacklist`

Fixes https://github.com/hashicorp/nomad/issues/955