### PR TITLE
Explain restart decision and display in alloc-status

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -163,7 +163,7 @@ const (
 	TaskTerminated             = "Terminated"
 	TaskKilled                 = "Killed"
 	TaskRestarting             = "Restarting"
-	TaskNotRestarting          = "Restarts Exceeded"
+	TaskNotRestarting          = "Not Restarting"
 	TaskDownloadingArtifacts   = "Downloading Artifacts"
 	TaskArtifactDownloadFailed = "Failed Artifact Download"
 )
@@ -173,6 +173,7 @@ const (
 type TaskEvent struct {
 	Type            string
 	Time            int64
+	RestartReason   string
 	DriverError     string
 	ExitCode        int
 	Signal          int

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1830,7 +1830,7 @@ const (
 
 	// TaskNotRestarting indicates that the task has failed and is not being
 	// restarted because it has exceeded its restart policy.
-	TaskNotRestarting = "Restarts Exceeded"
+	TaskNotRestarting = "Not Restarting"
 
 	// TaskDownloadingArtifacts means the task is downloading the artifacts
 	// specified in the task.
@@ -1846,6 +1846,9 @@ const (
 type TaskEvent struct {
 	Type string
 	Time int64 // Unix Nanosecond timestamp
+
+	// Restart fields.
+	RestartReason string
 
 	// Driver Failure fields.
 	DriverError string // A driver error occured while starting the task.
@@ -1921,6 +1924,11 @@ func (e *TaskEvent) SetKillError(err error) *TaskEvent {
 
 func (e *TaskEvent) SetRestartDelay(delay time.Duration) *TaskEvent {
 	e.StartDelay = int64(delay)
+	return e
+}
+
+func (e *TaskEvent) SetRestartReason(reason string) *TaskEvent {
+	e.RestartReason = reason
 	return e
 }
 


### PR DESCRIPTION
This PR adds an explanation to restart decisions and displays them in alloc-status