### PR TITLE
website: update middleman and link to header

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/hashicorp/middleman-hashicorp.git
-  revision: 8dcc6d5533d6f3e8d8273c83ed358fab598c5aca
+  revision: 92b553abc3eb26361328111db2ecb587717666b7
   specs:
     middleman-hashicorp (0.2.0)
       bootstrap-sass (~> 3.3)
@@ -27,7 +27,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    autoprefixer-rails (6.3.3.1)
+    autoprefixer-rails (6.3.4)
       execjs
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)

--- a/website/source/docs/jobspec/index.html.md
+++ b/website/source/docs/jobspec/index.html.md
@@ -260,7 +260,7 @@ The `task` object supports the following keys:
     ```
 
 * `resources` - Provides the resource requirements of the task.
-  See the resources reference for more details.
+  See the [resources reference](#resources) for more details.
 
 * `meta` - Annotates the task group with opaque metadata.
 


### PR DESCRIPTION
Following up with linking these following https://github.com/hashicorp/middleman-hashicorp/pull/24
being merged.