### PR TITLE
nomad run -output emits the JSON representation of the job

### DIFF
--- a/website/source/docs/commands/run.html.md.erb
+++ b/website/source/docs/commands/run.html.md.erb
@@ -42,6 +42,9 @@ client connection issues or internal errors, are indicated by exit code 1.
   will be output, which can be used to call the monitor later using the
   [eval-monitor](/docs/commands/eval-monitor.html) command.
 
+* `-output`: Output the JSON that would be submitted to the HTTP API without
+  submitting the job.
+
 ## Status Options
 
 * `-verbose`: Show full information.

--- a/website/source/docs/jobspec/json.html.md
+++ b/website/source/docs/jobspec/json.html.md
@@ -9,7 +9,9 @@ description: |-
 # Job Specification
 
 Jobs can be specified either in [HCL](https://github.com/hashicorp/hcl) or JSON.
-This guide covers the json syntax for submitting jobs to Nomad.
+This guide covers the json syntax for submitting jobs to Nomad. A useful command
+for generating valid JSON versions of HCL jobs is `nomad run -output <job.nomad>`
+which will emit a JSON version of the job.
 
 ## JSON Syntax
 


### PR DESCRIPTION
This PR adds an `-output` flag to `nomad run` which emits the JSON version of the job that would have been submitted to the HTTP API.