### PR TITLE
Using tls cert and key files while connecting to consul over https

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -255,13 +255,13 @@
 		},
 		{
 			"ImportPath": "github.com/hashicorp/consul/api",
-			"Comment": "v0.6.3-290-ge3f6c6a",
-			"Rev": "e3f6c6a7987ff879a1c138abcc4d14d8b65fc13f"
+			"Comment": "v0.6.3-363-gae32a3c",
+			"Rev": "ae32a3ceae9fddb431b933ed7b2a82110e41e1bf"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/consul/tlsutil",
-			"Comment": "v0.6.3-290-ge3f6c6a",
-			"Rev": "e3f6c6a7987ff879a1c138abcc4d14d8b65fc13f"
+			"Comment": "v0.6.3-363-gae32a3c",
+			"Rev": "ae32a3ceae9fddb431b933ed7b2a82110e41e1bf"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/errwrap",

--- a/client/driver/utils.go
+++ b/client/driver/utils.go
@@ -79,9 +79,9 @@ func consulContext(clientConfig *config.Config, containerID string) *executor.Co
 		Auth:      clientConfig.Read("consul.auth"),
 		EnableSSL: clientConfig.ReadBoolDefault("consul.ssl", false),
 		VerifySSL: clientConfig.ReadBoolDefault("consul.verifyssl", true),
-		CAFile:    clientConfig.Read("consul.cafile"),
-		CertFile:  clientConfig.Read("consul.certfile"),
-		KeyFile:   clientConfig.Read("consul.keyfile"),
+		CAFile:    clientConfig.Read("consul.tls_ca_file"),
+		CertFile:  clientConfig.Read("consul.tls_cert_file"),
+		KeyFile:   clientConfig.Read("consul.tls_key_file"),
 	}
 	return &executor.ConsulContext{
 		ConsulConfig:   &cfg,

--- a/client/driver/utils.go
+++ b/client/driver/utils.go
@@ -79,6 +79,9 @@ func consulContext(clientConfig *config.Config, containerID string) *executor.Co
 		Auth:      clientConfig.Read("consul.auth"),
 		EnableSSL: clientConfig.ReadBoolDefault("consul.ssl", false),
 		VerifySSL: clientConfig.ReadBoolDefault("consul.verifyssl", true),
+		CAFile:    clientConfig.Read("consul.cafile"),
+		CertFile:  clientConfig.Read("consul.certfile"),
+		KeyFile:   clientConfig.Read("consul.keyfile"),
 	}
 	return &executor.ConsulContext{
 		ConsulConfig:   &cfg,

--- a/website/source/docs/jobspec/servicediscovery.html.md
+++ b/website/source/docs/jobspec/servicediscovery.html.md
@@ -50,7 +50,7 @@ Nomad does not currently run Consul for you.
 * `consul.tls_key_file`: The path to the private key for Consul communication.
   Set accordingly to the
   [key_file](https://www.consul.io/docs/agent/options.html#key_file) setting in
-  Consul.j
+  Consul.
 
 ## Service Definition Syntax
 

--- a/website/source/docs/jobspec/servicediscovery.html.md
+++ b/website/source/docs/jobspec/servicediscovery.html.md
@@ -37,6 +37,20 @@ Nomad does not currently run Consul for you.
 * `consul.verifyssl`: This option enables SSL verification when the transport
  scheme for the Consul API client is `https`. This is set to true by default.
 
+* `consul.tls_ca_file`: The path to the CA certificate used for Consul communication.
+  Set accordingly to the
+  [ca_file](https://www.consul.io/docs/agent/options.html#ca_file) setting in
+  Consul.
+
+* `consul.tls_cert_file`: The path to the certificate for Consul communication. Set
+  accordingly
+  [cert_file](https://www.consul.io/docs/agent/options.html#cert_file) in
+  Consul.
+
+* `consul.tls_key_file`: The path to the private key for Consul communication.
+  Set accordingly to the
+  [key_file](https://www.consul.io/docs/agent/options.html#key_file) setting in
+  Consul.j
 
 ## Service Definition Syntax
 


### PR DESCRIPTION
Fixes #977 

Users have to provide the following the Nomad client options - `consul.tls_ca_file`, `consul.tls_cert_file` and `consul.tls_key_file` for consul client to talk to a consul agent over https.