### PR TITLE
nomad/examples: update systemd config files

### DIFF
--- a/dist/systemd/nomad.service
+++ b/dist/systemd/nomad.service
@@ -4,3 +4,7 @@ Documentation=https://nomadproject.io/docs/
 
 [Service]
 ExecStart=/usr/bin/nomad agent -config /etc/nomad
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The existing nomad.service is having minor configuration and this change
adds the following:
 * Install section that allows nomad to be able enabled in systemd
 * Default limit of open files is set to 65536