### PR TITLE
Fix syntax errors in example JSON job spec

### DIFF
--- a/website/source/docs/jobspec/json.html.md
+++ b/website/source/docs/jobspec/json.html.md
@@ -85,12 +85,13 @@ Below is an example of a json object that submits a `Periodic` job to Nomad:
               "Resources": {
                 "Networks": [
                   {
+                    "Mbits": 10,
                     "DynamicPorts": [
                       {
                         "Value": 0,
                         "Label": "db"
                       }
-                    ],
+                    ]
                   }
                 ],
                 "IOPS": 0,


### PR DESCRIPTION
The example JSON job specification at https://www.nomadproject.io/docs/jobspec/json.html has a couple of syntax errors:

 * a trailing comma at the end of the first `Networks` object (invalid JSON)
 * no value for the `Mbits` field in the first `Networks` object, which the causes the Nomad API to reject the job with "minimum MBits value is 1; got 0".

Also, I just wanted to take the chance to say thanks for all the awesome work you've put into Nomad!