### PR TITLE
Fixes a panic when fs commands with a job parameter return zero allocations

### DIFF
--- a/command/fs.go
+++ b/command/fs.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -29,6 +30,12 @@ func (f *FSCommand) Run(args []string) int {
 func getRandomJobAlloc(client *api.Client, jobID string) (string, error) {
 	var runningAllocs []*api.AllocationListStub
 	allocs, _, err := client.Jobs().Allocations(jobID, nil)
+
+	// Check that the job actually has allocations
+	if len(allocs) == 0 {
+		return "", fmt.Errorf("job %q doesn't exist or it has no allocations", jobID)
+	}
+
 	for _, v := range allocs {
 		if v.ClientStatus == "running" {
 			runningAllocs = append(runningAllocs, v)

--- a/command/fs_cat.go
+++ b/command/fs_cat.go
@@ -71,6 +71,7 @@ func (f *FSCatCommand) Run(args []string) int {
 		allocID, err = getRandomJobAlloc(client, args[0])
 		if err != nil {
 			f.Ui.Error(fmt.Sprintf("Error querying API: %v", err))
+			return 1
 		}
 	}
 

--- a/command/fs_stat.go
+++ b/command/fs_stat.go
@@ -76,6 +76,7 @@ func (f *FSStatCommand) Run(args []string) int {
 		allocID, err = getRandomJobAlloc(client, args[0])
 		if err != nil {
 			f.Ui.Error(fmt.Sprintf("Error querying API: %v", err))
+			return 1
 		}
 	}
 


### PR DESCRIPTION
Specifying a -job parameter on the fs {cat | ls | stat} command with a non-existent job would result in a panic.