### PR TITLE
client/docker: add `interactive` option

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -73,7 +73,8 @@ type DockerDriverConfig struct {
 	Labels           map[string]string   `mapstructure:"-"`                  // Labels to set when the container starts up
 	Auth             []DockerDriverAuth  `mapstructure:"auth"`               // Authentication credentials for a private Docker registry
 	SSL              bool                `mapstructure:"ssl"`                // Flag indicating repository is served via https
-	TTY              bool                `mapstructure:"tty"`
+	TTY              bool                `mapstructure:"tty"`                // Allocate a Pseudo-TTY
+	Interactive      bool                `mapstructure:"interactive"`        // Keep STDIN open even if not attached
 }
 
 func (c *DockerDriverConfig) Init() error {
@@ -235,10 +236,11 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 	d.taskEnv.SetTaskLocalDir(filepath.Join("/", allocdir.TaskLocal))
 
 	config := &docker.Config{
-		Image:    driverConfig.ImageName,
-		Hostname: driverConfig.Hostname,
-		User:     task.User,
-		Tty:      driverConfig.TTY,
+		Image:     driverConfig.ImageName,
+		Hostname:  driverConfig.Hostname,
+		User:      task.User,
+		Tty:       driverConfig.TTY,
+		OpenStdin: driverConfig.Interactive,
 	}
 
 	hostConfig := &docker.HostConfig{

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -97,6 +97,12 @@ The following options are available for use in the job specification.
 
 * `auth` - (Optional) Provide authentication for a private registry (see below).
 
+* `tty` - (Optional) `true` or `false` (default). Allocate a pseudo-TTY for the
+  container.
+
+* `interactive` - (Optional) `true` or `false` (default). Keep STDIN open on
+  the container.
+
 ### Container Name
 
 Nomad creates a container after pulling an image. Containers are named


### PR DESCRIPTION
Equivalent to `docker run --interactive` - keeps STDIN open.

Also adds docs for both `tty` and `interactive` docker config.