### PR TITLE
Force GC checks nodes last and fix eval GC to cleanup deregistered batch jobs

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -270,14 +270,6 @@ func (s *Server) coreJobEval(job string) *structs.Evaluation {
 	}
 }
 
-// forceCoreJobEval returns an evaluation for a core job that will ignore GC
-// cutoffs.
-func (s *Server) forceCoreJobEval(job string) *structs.Evaluation {
-	eval := s.coreJobEval(job)
-	eval.TriggeredBy = structs.EvalTriggerForceGC
-	return eval
-}
-
 // reapFailedEvaluations is used to reap evaluations that
 // have reached their delivery limit and should be failed
 func (s *Server) reapFailedEvaluations(stopCh chan struct{}) {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2435,7 +2435,6 @@ const (
 	EvalTriggerPeriodicJob   = "periodic-job"
 	EvalTriggerNodeUpdate    = "node-update"
 	EvalTriggerScheduled     = "scheduled"
-	EvalTriggerForceGC       = "force-gc"
 	EvalTriggerRollingUpdate = "rolling-update"
 )
 
@@ -2456,6 +2455,9 @@ const (
 	// evaluations and allocations are terminal. If so, we delete these out of
 	// the system.
 	CoreJobJobGC = "job-gc"
+
+	// CoreJobForceGC is used to force garbage collection of all GCable objects.
+	CoreJobForceGC = "force-gc"
 )
 
 // Evaluation is used anytime we need to apply business logic as a result

--- a/nomad/system_endpoint.go
+++ b/nomad/system_endpoint.go
@@ -16,8 +16,6 @@ func (s *System) GarbageCollect(args *structs.GenericRequest, reply *structs.Gen
 		return err
 	}
 
-	s.srv.evalBroker.Enqueue(s.srv.forceCoreJobEval(structs.CoreJobEvalGC))
-	s.srv.evalBroker.Enqueue(s.srv.forceCoreJobEval(structs.CoreJobNodeGC))
-	s.srv.evalBroker.Enqueue(s.srv.forceCoreJobEval(structs.CoreJobJobGC))
+	s.srv.evalBroker.Enqueue(s.srv.coreJobEval(structs.CoreJobForceGC))
 	return nil
 }


### PR DESCRIPTION
This PR makes it so:
* A forced GC will garbage collect nodes last so that the eval/job gc clean up allocations that were associated with the node first.
* Fix an issue in which we would not GC evals/allocs associated with deregistered batch jobs.
* Removes confusing log message when running a force as the index is meaningless.

@armon @diptanu for review.

Fixes https://github.com/hashicorp/nomad/issues/1027
