### PR TITLE
Add dates to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ BUG FIXES:
   * client: All tasks in a task group are killed when a task fails [GH-962]
   * client: Fix common exec failures on CentOS and Amazon Linux [GH-1009]
 
-## 0.3.1
+## 0.3.1 (Mars 16, 2016)
 
 __BACKWARDS INCOMPATIBILITIES:__
   * Service names that dont conform to RFC-1123 and RFC-2782 will fail
@@ -70,7 +70,7 @@ BUG FIXES:
   * driver/exec: Stopping tasks with more than one pid in a cgroup [GH-855]
   * executor/linux: Add /run/resolvconf/ to chroot so DNS works [GH-905]
 
-## 0.3.0
+## 0.3.0 (February 25, 2016)
 
 __BACKWARDS INCOMPATIBILITIES:__
   * Stdout and Stderr log files of tasks have moved from task/local to


### PR DESCRIPTION
Scanning the change log is a common way of keeping track on a project. Time-stamped releases makes it easier to know if changes are recent or old.