### PR TITLE
Add -self flag to node-drain

### DIFF
--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"testing"
+
+	"github.com/mitchellh/cli"
 )
 
 func TestHelpers_FormatKV(t *testing.T) {
@@ -25,5 +27,21 @@ func TestHelpers_FormatList(t *testing.T) {
 
 	if out != expect {
 		t.Fatalf("expect: %s, got: %s", expect, out)
+	}
+}
+
+func TestHelpers_NodeID(t *testing.T) {
+	srv, _, _ := testServer(t, nil)
+	defer srv.Stop()
+
+	meta := Meta{Ui: new(cli.MockUi)}
+	client, err := meta.Client()
+	if err != nil {
+		t.FailNow()
+	}
+
+	// This is because there is no client
+	if _, err := getLocalNodeID(client); err == nil {
+		t.Fatalf("getLocalNodeID() should fail")
 	}
 }

--- a/website/source/docs/commands/node-drain.html.md.erb
+++ b/website/source/docs/commands/node-drain.html.md.erb
@@ -21,9 +21,10 @@ nicely by providing the current drain status of a given node.
 nomad node-drain [options] <node>
 ```
 
-A node ID or prefix must be provided. If there is an exact match, the
-drain mode will be adjusted for that node. Otherwise, a list of matching
-nodes and information will be displayed.
+A `-self` flag can be used to drain the local node. If this is not supplied, a
+node ID or prefix must be provided. If there is an exact match, the drain mode
+will be adjusted for that node. Otherwise, a list of matching nodes and
+information will be displayed.
 
 It is also required to pass one of `-enable` or `-disable`, depending on which
 operation is desired.
@@ -36,11 +37,19 @@ operation is desired.
 
 * `-enable`: Enable node drain mode.
 * `-disable`: Disable node drain mode.
+* `-self`: Drain the local node.
+* `-yes`: Automtic yes to prompts.
 
 ## Examples
 
-Enable drain mode on node1:
+Enable drain mode on node with ID prefix "4d2ba53b":
 
 ```
-$ nomad node-drain -enable node1
+$ nomad node-drain -enable 4d2ba53b
+```
+
+Enable drain mode on the local node:
+
+```
+$ nomad node-drain -enable -self
 ```


### PR DESCRIPTION
This PR adds a -self option to `node-drain`, factorizes the code to determine the local node ID and fixes documentation.

Fixes https://github.com/hashicorp/nomad/issues/863
Fixes https://github.com/hashicorp/nomad/issues/926