### PR TITLE
Validate driver config on job register

### DIFF
--- a/api/util_test.go
+++ b/api/util_test.go
@@ -21,6 +21,7 @@ func assertWriteMeta(t *testing.T, wm *WriteMeta) {
 
 func testJob() *Job {
 	task := NewTask("task1", "exec").
+		SetConfig("command", "/bin/sleep").
 		Require(&Resources{
 			CPU:      100,
 			MemoryMB: 256,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -67,6 +67,7 @@ func TestHTTP_PrefixJobsList(t *testing.T) {
 			// Create the job
 			job := mock.Job()
 			job.ID = ids[i]
+			job.TaskGroups[0].Count = 1
 			args := structs.JobRegisterRequest{
 				Job:          job,
 				WriteRequest: structs.WriteRequest{Region: "global"},

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -40,6 +40,7 @@ func testServer(
 
 func testJob(jobID string) *api.Job {
 	task := api.NewTask("task1", "exec").
+		SetConfig("command", "/bin/sleep").
 		Require(&api.Resources{
 			MemoryMB: 256,
 			DiskMB:   20,

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,4 +10,4 @@ go build -o $TEMPDIR/nomad || exit 1
 
 # Run the tests
 echo "--> Running tests"
-go list ./... | grep -v '/vendor/' | sudo -E PATH=$TEMPDIR:$PATH xargs -n1 go test -cover -timeout=300s
+go list ./... | grep -v '/vendor/' | sudo -E PATH=$TEMPDIR:$PATH xargs -n1 go test -cover -timeout=360s


### PR DESCRIPTION
@iverberk: Decent work around to the circular dependency problem! And in the end this may be the best place to have it, since the server may not have all the drivers so it would require richer logic.