### PR TITLE
Docker labels configuration should be of type "array" in schema

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -176,7 +176,7 @@ func (d *DockerDriver) Validate(config map[string]interface{}) error {
 				Type: fields.TypeString,
 			},
 			"labels": &fields.FieldSchema{
-				Type: fields.TypeMap,
+				Type: fields.TypeArray,
 			},
 			"auth": &fields.FieldSchema{
 				Type: fields.TypeArray,

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -91,6 +91,11 @@ func TestParse(t *testing.T) {
 								User:   "bob",
 								Config: map[string]interface{}{
 									"image": "hashicorp/binstore",
+									"labels": []map[string]interface{}{
+										map[string]interface{}{
+											"FOO": "bar",
+										},
+									},
 								},
 								Services: []*structs.Service{
 									{

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -47,6 +47,10 @@ job "binstore-storagelocker" {
 
       config {
         image = "hashicorp/binstore"
+
+        labels {
+          FOO = "bar"
+        }
       }
 
       logs {


### PR DESCRIPTION
Fixes #1125

Labels configuration type was accidentally set to map.