### PR TITLE
Include the current version along side the available version.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -339,7 +339,12 @@ func (c *Command) checkpointResults(results *checkpoint.CheckResponse, err error
 		return
 	}
 	if results.Outdated {
-		c.Ui.Error(fmt.Sprintf("Newer Nomad version available: %s", results.CurrentVersion))
+		versionStr := c.Version
+		if c.VersionPrerelease != "" {
+			versionStr += fmt.Sprintf("-%s", c.VersionPrerelease)
+		}
+
+		c.Ui.Error(fmt.Sprintf("Newer Nomad version available: %s (currently running: %s)", results.CurrentVersion, versionStr))
 	}
 	for _, alert := range results.Alerts {
 		switch alert.Level {


### PR DESCRIPTION
When checkpoint emits a log message indicating an agent is out of
date, include the current version along with the available version
according to checkpoint.

Inspired by: log output in hashicorp/consul#993