### PR TITLE
fix docs for specifying multiple config files

### DIFF
--- a/website/source/docs/agent/config.html.md
+++ b/website/source/docs/agent/config.html.md
@@ -19,7 +19,7 @@ the Nomad agent.
 When specifying multiple config file options on the command-line, the files are
 loaded in the order they are specified. For example:
 
-    nomad agent -config server.conf /etc/nomad extra.json
+    nomad agent -config server.conf -config /etc/nomad -config extra.json
 
 Will load configuration from `server.conf`, from `.hcl` and `.json` files under
 `/etc/nomad`, and finally from `extra.json`.


### PR DESCRIPTION
When trying the command:
`nomad agent -config conf1.hcl conf2.hcl`
as specified in the docs only the first config was picked up.