### PR TITLE
Enable consul script checks for raw_exec driver

### DIFF
--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -574,20 +574,7 @@ func (e *UniversalExecutor) createCheck(check *structs.ServiceCheck, checkID str
 		}, nil
 	}
 
-	if check.Type == structs.ServiceCheckScript && e.ctx.Driver == "exec" {
-		return &ExecScriptCheck{
-			id:          checkID,
-			interval:    check.Interval,
-			timeout:     check.Timeout,
-			cmd:         check.Command,
-			args:        check.Args,
-			taskDir:     e.taskDir,
-			FSIsolation: e.command.FSIsolation,
-		}, nil
-
-	}
-
-	if check.Type == structs.ServiceCheckScript && e.ctx.Driver == "raw_exec" {
+	if check.Type == structs.ServiceCheckScript && (e.ctx.Driver == "exec" || e.ctx.Driver == "raw_exec") {
 		return &ExecScriptCheck{
 			id:          checkID,
 			interval:    check.Interval,

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -586,6 +586,20 @@ func (e *UniversalExecutor) createCheck(check *structs.ServiceCheck, checkID str
 		}, nil
 
 	}
+
+	if check.Type == structs.ServiceCheckScript && e.ctx.Driver == "raw_exec" {
+		return &ExecScriptCheck{
+			id:          checkID,
+			interval:    check.Interval,
+			timeout:     check.Timeout,
+			cmd:         check.Command,
+			args:        check.Args,
+			taskDir:     e.taskDir,
+			FSIsolation: e.command.FSIsolation,
+		}, nil
+
+	}
+
 	return nil, fmt.Errorf("couldn't create check for %v", check.Name)
 }
 

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -574,7 +574,8 @@ func (e *UniversalExecutor) createCheck(check *structs.ServiceCheck, checkID str
 		}, nil
 	}
 
-	if check.Type == structs.ServiceCheckScript && (e.ctx.Driver == "exec" || e.ctx.Driver == "raw_exec") {
+	if check.Type == structs.ServiceCheckScript && (e.ctx.Driver == "exec" ||
+		e.ctx.Driver == "raw_exec" || e.ctx.Driver == "java") {
 		return &ExecScriptCheck{
 			id:          checkID,
 			interval:    check.Interval,

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -586,7 +586,6 @@ func (e *UniversalExecutor) createCheck(check *structs.ServiceCheck, checkID str
 		}, nil
 
 	}
-
 	return nil, fmt.Errorf("couldn't create check for %v", check.Name)
 }
 


### PR DESCRIPTION
Hi, I use nomad on windows platform. raw_exec is the only available driver there and it is fine to me. This request enables consul script checks that does not work currently with raw_exec