### PR TITLE
Append a newline when pretty-printing the response

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -184,6 +184,9 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 			var buf []byte
 			if prettyPrint {
 				buf, err = json.MarshalIndent(obj, "", "    ")
+				if err == nil {
+					buf = append(buf, "\n"...)
+				}
 			} else {
 				buf, err = json.Marshal(obj)
 			}

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -145,14 +145,18 @@ func TestContentTypeIsJSON(t *testing.T) {
 }
 
 func TestPrettyPrint(t *testing.T) {
-	testPrettyPrint("pretty=1", t)
+	testPrettyPrint("pretty=1", true, t)
+}
+
+func TestPrettyPrintOff(t *testing.T) {
+	testPrettyPrint("pretty=0", false, t)
 }
 
 func TestPrettyPrintBare(t *testing.T) {
-	testPrettyPrint("pretty", t)
+	testPrettyPrint("pretty", true, t)
 }
 
-func testPrettyPrint(pretty string, t *testing.T) {
+func testPrettyPrint(pretty string, prettyFmt bool, t *testing.T) {
 	s := makeHTTPServer(t, nil)
 	defer s.Cleanup()
 
@@ -168,6 +172,9 @@ func testPrettyPrint(pretty string, t *testing.T) {
 	s.Server.wrap(handler)(resp, req)
 
 	expected, _ := json.MarshalIndent(r, "", "    ")
+	if prettyFmt {
+		expected += "\n"
+	}
 	actual, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("err: %s", err)


### PR DESCRIPTION
Instead of typing `curl http://foo/v1/nodes?pretty; echo` to inject a newline into your terminal (or something similar when chaining commands together on the CLI), now pretty will provide its own newline.