### PR TITLE
Fix "http_api_response_headers" config not working

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -583,6 +583,14 @@ func (c *Config) Merge(b *Config) *Config {
 	// Merge config files lists
 	result.Files = append(result.Files, b.Files...)
 
+	// Add the http API response header map values
+	if result.HTTPAPIResponseHeaders == nil {
+		result.HTTPAPIResponseHeaders = make(map[string]string)
+	}
+	for k, v := range b.HTTPAPIResponseHeaders {
+		result.HTTPAPIResponseHeaders[k] = v
+	}
+
 	return &result
 }
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -80,6 +80,9 @@ func TestConfig_Merge(t *testing.T) {
 			Join:           false,
 			Endpoint:       "foo",
 		},
+		HTTPAPIResponseHeaders: map[string]string{
+			"Access-Control-Allow-Origin": "*",
+		},
 	}
 
 	c2 := &Config{
@@ -161,6 +164,10 @@ func TestConfig_Merge(t *testing.T) {
 			Token:          "xyz",
 			Join:           true,
 			Endpoint:       "bar",
+		},
+		HTTPAPIResponseHeaders: map[string]string{
+			"Access-Control-Allow-Origin":  "*",
+			"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
 		},
 	}
 


### PR DESCRIPTION
On startup, the agent starts with either a dev or default config.  Extra config files are merged into final config.

The `HTTPAPIResponseHeaders` config was missing from the merge logic therefore it would always result in empty value (regardlesss of any config files specified).