### PR TITLE
Use codegen for json marshalling

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -18,7 +18,7 @@ func getPort() int {
 	return int(atomic.AddUint32(&nextPort, 1))
 }
 
-func tmpDir(t *testing.T) string {
+func tmpDir(t testing.TB) string {
 	dir, err := ioutil.TempDir("", "nomad")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -26,7 +26,7 @@ func tmpDir(t *testing.T) string {
 	return dir
 }
 
-func makeAgent(t *testing.T, cb func(*Config)) (string, *Agent) {
+func makeAgent(t testing.TB, cb func(*Config)) (string, *Agent) {
 	dir := tmpDir(t)
 	conf := DevConfig()
 


### PR DESCRIPTION
On the included benchmark, the switch was: 
* 20% faster
* 12% less bytes allocated
* 85% less allocations