### PR TITLE
Failed Allocation Metrics stored in Evaluation

### DIFF
--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -67,6 +67,7 @@ type Evaluation struct {
 	Wait              time.Duration
 	NextEval          string
 	PreviousEval      string
+	FailedTGAllocs    map[string]*AllocationMetric
 	CreateIndex       uint64
 	ModifyIndex       uint64
 }

--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -54,22 +54,23 @@ func (e *Evaluations) Allocations(evalID string, q *QueryOptions) ([]*Allocation
 
 // Evaluation is used to serialize an evaluation.
 type Evaluation struct {
-	ID                string
-	Priority          int
-	Type              string
-	TriggeredBy       string
-	JobID             string
-	JobModifyIndex    uint64
-	NodeID            string
-	NodeModifyIndex   uint64
-	Status            string
-	StatusDescription string
-	Wait              time.Duration
-	NextEval          string
-	PreviousEval      string
-	FailedTGAllocs    map[string]*AllocationMetric
-	CreateIndex       uint64
-	ModifyIndex       uint64
+	ID                 string
+	Priority           int
+	Type               string
+	TriggeredBy        string
+	JobID              string
+	JobModifyIndex     uint64
+	NodeID             string
+	NodeModifyIndex    uint64
+	Status             string
+	StatusDescription  string
+	Wait               time.Duration
+	NextEval           string
+	PreviousEval       string
+	SpawnedBlockedEval string
+	FailedTGAllocs     map[string]*AllocationMetric
+	CreateIndex        uint64
+	ModifyIndex        uint64
 }
 
 // EvalIndexSort is a wrapper to sort evaluations by CreateIndex.

--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -54,23 +54,23 @@ func (e *Evaluations) Allocations(evalID string, q *QueryOptions) ([]*Allocation
 
 // Evaluation is used to serialize an evaluation.
 type Evaluation struct {
-	ID                 string
-	Priority           int
-	Type               string
-	TriggeredBy        string
-	JobID              string
-	JobModifyIndex     uint64
-	NodeID             string
-	NodeModifyIndex    uint64
-	Status             string
-	StatusDescription  string
-	Wait               time.Duration
-	NextEval           string
-	PreviousEval       string
-	SpawnedBlockedEval string
-	FailedTGAllocs     map[string]*AllocationMetric
-	CreateIndex        uint64
-	ModifyIndex        uint64
+	ID                string
+	Priority          int
+	Type              string
+	TriggeredBy       string
+	JobID             string
+	JobModifyIndex    uint64
+	NodeID            string
+	NodeModifyIndex   uint64
+	Status            string
+	StatusDescription string
+	Wait              time.Duration
+	NextEval          string
+	PreviousEval      string
+	BlockedEval       string
+	FailedTGAllocs    map[string]*AllocationMetric
+	CreateIndex       uint64
+	ModifyIndex       uint64
 }
 
 // EvalIndexSort is a wrapper to sort evaluations by CreateIndex.

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -306,6 +306,11 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 					m.ui.Output(fmt.Sprintf("Task Group %q (failed to place %d %s):", tg, metrics.CoalescedFailures+1, noun))
 					dumpAllocMetrics(m.ui, metrics, false)
 				}
+
+				if eval.SpawnedBlockedEval != "" {
+					m.ui.Output(fmt.Sprintf("Spawned follow up blocked evaluation %q to place remainder",
+						limit(eval.SpawnedBlockedEval, m.length)))
+				}
 			}
 		default:
 			// Wait for the next update

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -147,10 +147,14 @@ func (m *monitor) update(update *evalState) {
 		} else {
 			switch {
 			case existing.client != alloc.client:
+				description := ""
+				if alloc.clientDesc != "" {
+					description = fmt.Sprintf(" (%s)", alloc.clientDesc)
+				}
 				// Allocation status has changed
 				m.ui.Output(fmt.Sprintf(
-					"Allocation %q status changed: %q -> %q (%s)",
-					limit(alloc.id, m.length), existing.client, alloc.client, alloc.clientDesc))
+					"Allocation %q status changed: %q -> %q%s",
+					limit(alloc.id, m.length), existing.client, alloc.client, description))
 			}
 		}
 	}
@@ -294,6 +298,7 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 					limit(eval.ID, m.length), eval.Status))
 			} else {
 				// There were failures making the allocations
+				schedFailure = true
 				m.ui.Info(fmt.Sprintf("Evaluation %q finished with status %q but failed to place all allocations:",
 					limit(eval.ID, m.length), eval.Status))
 

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -307,9 +307,9 @@ func (m *monitor) monitor(evalID string, allowPrefix bool) int {
 					dumpAllocMetrics(m.ui, metrics, false)
 				}
 
-				if eval.SpawnedBlockedEval != "" {
-					m.ui.Output(fmt.Sprintf("Spawned follow up blocked evaluation %q to place remainder",
-						limit(eval.SpawnedBlockedEval, m.length)))
+				if eval.BlockedEval != "" {
+					m.ui.Output(fmt.Sprintf("Evaluation %q waiting for additional capacity to place remainder",
+						limit(eval.BlockedEval, m.length)))
 				}
 			}
 		default:

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -124,7 +124,6 @@ func (s *Server) applyPlan(job *structs.Job, result *structs.PlanResult, snap *s
 	// are multiple updates per node
 	minUpdates := len(result.NodeUpdate)
 	minUpdates += len(result.NodeAllocation)
-	minUpdates += len(result.FailedAllocs)
 
 	// Setup the update request
 	req := structs.AllocUpdateRequest{
@@ -137,7 +136,6 @@ func (s *Server) applyPlan(job *structs.Job, result *structs.PlanResult, snap *s
 	for _, allocList := range result.NodeAllocation {
 		req.Alloc = append(req.Alloc, allocList...)
 	}
-	req.Alloc = append(req.Alloc, result.FailedAllocs...)
 
 	// Set the time the alloc was applied for the first time. This can be used
 	// to approximate the scheduling time.
@@ -200,7 +198,6 @@ func evaluatePlan(pool *EvaluatePool, snap *state.StateSnapshot, plan *structs.P
 	result := &structs.PlanResult{
 		NodeUpdate:     make(map[string][]*structs.Allocation),
 		NodeAllocation: make(map[string][]*structs.Allocation),
-		FailedAllocs:   plan.FailedAllocs,
 	}
 
 	// Collect all the nodeIDs

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -51,12 +51,10 @@ func TestPlanApply_applyPlan(t *testing.T) {
 
 	// Register alloc
 	alloc := mock.Alloc()
-	allocFail := mock.Alloc()
 	plan := &structs.PlanResult{
 		NodeAllocation: map[string][]*structs.Allocation{
 			node.ID: []*structs.Allocation{alloc},
 		},
-		FailedAllocs: []*structs.Allocation{allocFail},
 	}
 
 	// Snapshot the state
@@ -87,15 +85,6 @@ func TestPlanApply_applyPlan(t *testing.T) {
 
 	// Lookup the allocation
 	out, err := s1.fsm.State().AllocByID(alloc.ID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out == nil {
-		t.Fatalf("missing alloc")
-	}
-
-	// Lookup the allocation
-	out, err = s1.fsm.State().AllocByID(allocFail.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -178,12 +167,10 @@ func TestPlanApply_EvalPlan_Simple(t *testing.T) {
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
-	allocFail := mock.Alloc()
 	plan := &structs.Plan{
 		NodeAllocation: map[string][]*structs.Allocation{
 			node.ID: []*structs.Allocation{alloc},
 		},
-		FailedAllocs: []*structs.Allocation{allocFail},
 	}
 
 	pool := NewEvaluatePool(workerPoolSize, workerPoolBufferSize)
@@ -196,8 +183,8 @@ func TestPlanApply_EvalPlan_Simple(t *testing.T) {
 	if result == nil {
 		t.Fatalf("missing result")
 	}
-	if !reflect.DeepEqual(result.FailedAllocs, plan.FailedAllocs) {
-		t.Fatalf("missing failed allocs")
+	if !reflect.DeepEqual(result.NodeAllocation, plan.NodeAllocation) {
+		t.Fatalf("incorrect node allocations")
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2617,6 +2617,11 @@ type Evaluation struct {
 	// This is used to support rolling upgrades, where we need a chain of evaluations.
 	PreviousEval string
 
+	// SpawnedBlockedEval is the evaluation ID for a created blocked eval. A
+	// blocked eval will be created if all allocations could not be placed due
+	// to constraints or lacking resources.
+	SpawnedBlockedEval string
+
 	// FailedTGAllocs are task groups which have allocations that could not be
 	// made, but the metrics are persisted so that the user can use the feedback
 	// to determine the cause.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2617,10 +2617,10 @@ type Evaluation struct {
 	// This is used to support rolling upgrades, where we need a chain of evaluations.
 	PreviousEval string
 
-	// SpawnedBlockedEval is the evaluation ID for a created blocked eval. A
+	// BlockedEval is the evaluation ID for a created blocked eval. A
 	// blocked eval will be created if all allocations could not be placed due
 	// to constraints or lacking resources.
-	SpawnedBlockedEval string
+	BlockedEval string
 
 	// FailedTGAllocs are task groups which have allocations that could not be
 	// made, but the metrics are persisted so that the user can use the feedback
@@ -2744,10 +2744,10 @@ func (e *Evaluation) NextRollingEval(wait time.Duration) *Evaluation {
 	}
 }
 
-// BlockedEval creates a blocked evaluation to followup this eval to place any
+// CreateBlockedEval creates a blocked evaluation to followup this eval to place any
 // failed allocations. It takes the classes marked explicitly eligible or
 // ineligible and whether the job has escaped computed node classes.
-func (e *Evaluation) BlockedEval(classEligibility map[string]bool, escaped bool) *Evaluation {
+func (e *Evaluation) CreateBlockedEval(classEligibility map[string]bool, escaped bool) *Evaluation {
 	return &Evaluation{
 		ID:                   GenerateUUID(),
 		Priority:             e.Priority,

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -100,7 +100,7 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) error {
 	default:
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)
-		return setStatus(s.logger, s.planner, s.eval, s.nextEval, structs.EvalStatusFailed, desc)
+		return setStatus(s.logger, s.planner, s.eval, s.nextEval, s.blocked, structs.EvalStatusFailed, desc)
 	}
 
 	// Retry up to the maxScheduleAttempts and reset if progress is made.
@@ -117,7 +117,7 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) error {
 			if err := s.createBlockedEval(); err != nil {
 				mErr.Errors = append(mErr.Errors, err)
 			}
-			if err := setStatus(s.logger, s.planner, s.eval, s.nextEval, statusErr.EvalStatus, err.Error()); err != nil {
+			if err := setStatus(s.logger, s.planner, s.eval, s.nextEval, s.blocked, statusErr.EvalStatus, err.Error()); err != nil {
 				mErr.Errors = append(mErr.Errors, err)
 			}
 			return mErr.ErrorOrNil()
@@ -126,7 +126,7 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) error {
 	}
 
 	// Update the status to complete
-	return setStatus(s.logger, s.planner, s.eval, s.nextEval, structs.EvalStatusComplete, "")
+	return setStatus(s.logger, s.planner, s.eval, s.nextEval, s.blocked, structs.EvalStatusComplete, "")
 }
 
 // createBlockedEval creates a blocked eval and stores it.

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -158,6 +158,9 @@ func (s *GenericScheduler) process() (bool, error) {
 	// Create a plan
 	s.plan = s.eval.MakePlan(s.job)
 
+	// Reset the failed allocations
+	s.eval.FailedTGAllocs = nil
+
 	// Create an evaluation context
 	s.ctx = NewEvalContext(s.state, s.plan, s.logger)
 
@@ -171,6 +174,16 @@ func (s *GenericScheduler) process() (bool, error) {
 	if err := s.computeJobAllocs(); err != nil {
 		s.logger.Printf("[ERR] sched: %#v: %v", s.eval, err)
 		return false, err
+	}
+
+	// If there are failed allocations, we need to create a blocked evaluation
+	// to place the failed allocations when resources become available.
+	if len(s.eval.FailedTGAllocs) != 0 && s.blocked == nil {
+		if err := s.createBlockedEval(); err != nil {
+			s.logger.Printf("[ERR] sched: %#v failed to make blocked eval: %v", s.eval, err)
+			return false, err
+		}
+		s.logger.Printf("[DEBUG] sched: %#v: failed to place all allocations, blocked eval '%s' created", s.eval, s.blocked.ID)
 	}
 
 	// If the plan is a no-op, we can bail. If AnnotatePlan is set submit the plan
@@ -188,16 +201,6 @@ func (s *GenericScheduler) process() (bool, error) {
 			return false, err
 		}
 		s.logger.Printf("[DEBUG] sched: %#v: rolling update limit reached, next eval '%s' created", s.eval, s.nextEval.ID)
-	}
-
-	// If there are failed allocations, we need to create a blocked evaluation
-	// to place the failed allocations when resources become available.
-	if len(s.plan.FailedAllocs) != 0 && s.blocked == nil {
-		if err := s.createBlockedEval(); err != nil {
-			s.logger.Printf("[ERR] sched: %#v failed to make blocked eval: %v", s.eval, err)
-			return false, err
-		}
-		s.logger.Printf("[DEBUG] sched: %#v: failed to place all allocations, blocked eval '%s' created", s.eval, s.blocked.ID)
 	}
 
 	// Submit the plan and store the results.
@@ -365,50 +368,49 @@ func (s *GenericScheduler) computePlacements(place []allocTuple) error {
 	// Update the set of placement ndoes
 	s.stack.SetNodes(nodes)
 
-	// Track the failed task groups so that we can coalesce
-	// the failures together to avoid creating many failed allocs.
-	failedTG := make(map[*structs.TaskGroup]*structs.Allocation)
-
 	for _, missing := range place {
 		// Check if this task group has already failed
-		if alloc, ok := failedTG[missing.TaskGroup]; ok {
-			alloc.Metrics.CoalescedFailures += 1
-			continue
+		if s.eval.FailedTGAllocs != nil {
+			if metric, ok := s.eval.FailedTGAllocs[missing.TaskGroup.Name]; ok {
+				metric.CoalescedFailures += 1
+				continue
+			}
 		}
 
 		// Attempt to match the task group
 		option, _ := s.stack.Select(missing.TaskGroup)
-
-		// Create an allocation for this
-		alloc := &structs.Allocation{
-			ID:        structs.GenerateUUID(),
-			EvalID:    s.eval.ID,
-			Name:      missing.Name,
-			JobID:     s.job.ID,
-			TaskGroup: missing.TaskGroup.Name,
-			Metrics:   s.ctx.Metrics(),
-		}
 
 		// Store the available nodes by datacenter
 		s.ctx.Metrics().NodesAvailable = byDC
 
 		// Set fields based on if we found an allocation option
 		if option != nil {
+			// Create an allocation for this
+			alloc := &structs.Allocation{
+				ID:            structs.GenerateUUID(),
+				EvalID:        s.eval.ID,
+				Name:          missing.Name,
+				JobID:         s.job.ID,
+				TaskGroup:     missing.TaskGroup.Name,
+				Metrics:       s.ctx.Metrics(),
+				NodeID:        option.Node.ID,
+				TaskResources: option.TaskResources,
+				DesiredStatus: structs.AllocDesiredStatusRun,
+				ClientStatus:  structs.AllocClientStatusPending,
+			}
+
 			// Generate service IDs tasks in this allocation
 			// COMPAT - This is no longer required and would be removed in v0.4
 			alloc.PopulateServiceIDs(missing.TaskGroup)
 
-			alloc.NodeID = option.Node.ID
-			alloc.TaskResources = option.TaskResources
-			alloc.DesiredStatus = structs.AllocDesiredStatusRun
-			alloc.ClientStatus = structs.AllocClientStatusPending
 			s.plan.AppendAlloc(alloc)
 		} else {
-			alloc.DesiredStatus = structs.AllocDesiredStatusFailed
-			alloc.DesiredDescription = "failed to find a node for placement"
-			alloc.ClientStatus = structs.AllocClientStatusFailed
-			s.plan.AppendFailed(alloc)
-			failedTG[missing.TaskGroup] = alloc
+			// Lazy initialize the failed map
+			if s.eval.FailedTGAllocs == nil {
+				s.eval.FailedTGAllocs = make(map[string]*structs.AllocMetric)
+			}
+
+			s.eval.FailedTGAllocs[missing.TaskGroup.Name] = s.ctx.Metrics()
 		}
 	}
 

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -140,7 +140,7 @@ func (s *GenericScheduler) createBlockedEval() error {
 		classEligibility = e.GetClasses()
 	}
 
-	s.blocked = s.eval.BlockedEval(classEligibility, escaped)
+	s.blocked = s.eval.CreateBlockedEval(classEligibility, escaped)
 	return s.planner.CreateEval(s.blocked)
 }
 
@@ -370,11 +370,9 @@ func (s *GenericScheduler) computePlacements(place []allocTuple) error {
 
 	for _, missing := range place {
 		// Check if this task group has already failed
-		if s.eval.FailedTGAllocs != nil {
-			if metric, ok := s.eval.FailedTGAllocs[missing.TaskGroup.Name]; ok {
-				metric.CoalescedFailures += 1
-				continue
-			}
+		if metric, ok := s.eval.FailedTGAllocs[missing.TaskGroup.Name]; ok {
+			metric.CoalescedFailures += 1
+			continue
 		}
 
 		// Attempt to match the task group

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -48,6 +48,14 @@ func TestServiceSched_JobRegister(t *testing.T) {
 		t.Fatalf("expected no annotations")
 	}
 
+	// Ensure the eval has no spawned blocked eval
+	if len(h.Evals) != 1 {
+		t.Fatalf("bad: %#v", h.Evals)
+		if h.Evals[0].SpawnedBlockedEval != "" {
+			t.Fatalf("bad: %#v", h.Evals[0])
+		}
+	}
+
 	// Ensure the plan allocated
 	var planned []*structs.Allocation
 	for _, allocList := range plan.NodeAllocation {
@@ -239,6 +247,11 @@ func TestServiceSched_JobRegister_AllocFail(t *testing.T) {
 	}
 	outEval := h.Evals[0]
 
+	// Ensure the eval has its spawned blocked eval
+	if outEval.SpawnedBlockedEval != h.CreateEvals[0].ID {
+		t.Fatalf("bad: %#v", outEval)
+	}
+
 	// Ensure the plan failed to alloc
 	if outEval == nil || len(outEval.FailedTGAllocs) != 1 {
 		t.Fatalf("bad: %#v", outEval)
@@ -413,12 +426,17 @@ func TestServiceSched_JobRegister_FeasibleAndInfeasibleTG(t *testing.T) {
 		t.Fatalf("bad: %#v", out)
 	}
 
-	// Ensure the plan failed to alloc one tg
 	if len(h.Evals) != 1 {
 		t.Fatalf("incorrect number of updated eval: %#v", h.Evals)
 	}
 	outEval := h.Evals[0]
 
+	// Ensure the eval has its spawned blocked eval
+	if outEval.SpawnedBlockedEval != h.CreateEvals[0].ID {
+		t.Fatalf("bad: %#v", outEval)
+	}
+
+	// Ensure the plan failed to alloc one tg
 	if outEval == nil || len(outEval.FailedTGAllocs) != 1 {
 		t.Fatalf("bad: %#v", outEval)
 	}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -51,7 +51,7 @@ func TestServiceSched_JobRegister(t *testing.T) {
 	// Ensure the eval has no spawned blocked eval
 	if len(h.Evals) != 1 {
 		t.Fatalf("bad: %#v", h.Evals)
-		if h.Evals[0].SpawnedBlockedEval != "" {
+		if h.Evals[0].BlockedEval != "" {
 			t.Fatalf("bad: %#v", h.Evals[0])
 		}
 	}
@@ -248,7 +248,7 @@ func TestServiceSched_JobRegister_AllocFail(t *testing.T) {
 	outEval := h.Evals[0]
 
 	// Ensure the eval has its spawned blocked eval
-	if outEval.SpawnedBlockedEval != h.CreateEvals[0].ID {
+	if outEval.BlockedEval != h.CreateEvals[0].ID {
 		t.Fatalf("bad: %#v", outEval)
 	}
 
@@ -432,7 +432,7 @@ func TestServiceSched_JobRegister_FeasibleAndInfeasibleTG(t *testing.T) {
 	outEval := h.Evals[0]
 
 	// Ensure the eval has its spawned blocked eval
-	if outEval.SpawnedBlockedEval != h.CreateEvals[0].ID {
+	if outEval.BlockedEval != h.CreateEvals[0].ID {
 		t.Fatalf("bad: %#v", outEval)
 	}
 

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -237,7 +237,7 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 		// Attempt to match the task group
 		option, _ := s.stack.Select(missing.TaskGroup)
 
-		if option == nil && s.eval.FailedTGAllocs != nil {
+		if option == nil {
 			// Check if this task group has already failed
 			if metric, ok := s.eval.FailedTGAllocs[missing.TaskGroup.Name]; ok {
 				metric.CoalescedFailures += 1

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -60,20 +60,20 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) error {
 	default:
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)
-		return setStatus(s.logger, s.planner, s.eval, s.nextEval, structs.EvalStatusFailed, desc)
+		return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, structs.EvalStatusFailed, desc)
 	}
 
 	// Retry up to the maxSystemScheduleAttempts and reset if progress is made.
 	progress := func() bool { return progressMade(s.planResult) }
 	if err := retryMax(maxSystemScheduleAttempts, s.process, progress); err != nil {
 		if statusErr, ok := err.(*SetStatusError); ok {
-			return setStatus(s.logger, s.planner, s.eval, s.nextEval, statusErr.EvalStatus, err.Error())
+			return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, statusErr.EvalStatus, err.Error())
 		}
 		return err
 	}
 
 	// Update the status to complete
-	return setStatus(s.logger, s.planner, s.eval, s.nextEval, structs.EvalStatusComplete, "")
+	return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, structs.EvalStatusComplete, "")
 }
 
 // process is wrapped in retryMax to iteratively run the handler until we have no

--- a/scheduler/testing.go
+++ b/scheduler/testing.go
@@ -91,7 +91,6 @@ func (h *Harness) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, State, er
 	for _, allocList := range plan.NodeAllocation {
 		allocs = append(allocs, allocList...)
 	}
-	allocs = append(allocs, plan.FailedAllocs...)
 
 	// Attach the plan to all the allocations. It is pulled out in the
 	// payload to avoid the redundancy of encoding, but should be denormalized

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -365,7 +365,7 @@ func setStatus(logger *log.Logger, planner Planner, eval, nextEval, spawnedBlock
 		newEval.NextEval = nextEval.ID
 	}
 	if spawnedBlocked != nil {
-		newEval.SpawnedBlockedEval = spawnedBlocked.ID
+		newEval.BlockedEval = spawnedBlocked.ID
 	}
 	return planner.UpdateEval(newEval)
 }

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -356,13 +356,16 @@ func networkPortMap(n *structs.NetworkResource) map[string]int {
 }
 
 // setStatus is used to update the status of the evaluation
-func setStatus(logger *log.Logger, planner Planner, eval, nextEval *structs.Evaluation, status, desc string) error {
+func setStatus(logger *log.Logger, planner Planner, eval, nextEval, spawnedBlocked *structs.Evaluation, status, desc string) error {
 	logger.Printf("[DEBUG] sched: %#v: setting status to %s", eval, status)
 	newEval := eval.Copy()
 	newEval.Status = status
 	newEval.StatusDescription = desc
 	if nextEval != nil {
 		newEval.NextEval = nextEval.ID
+	}
+	if spawnedBlocked != nil {
+		newEval.SpawnedBlockedEval = spawnedBlocked.ID
 	}
 	return planner.UpdateEval(newEval)
 }

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -526,8 +526,8 @@ func TestSetStatus(t *testing.T) {
 	}
 
 	newEval = h.Evals[0]
-	if newEval.SpawnedBlockedEval != blocked.ID {
-		t.Fatalf("setStatus() didn't set SpawnedBlockedEval correctly: %v", newEval)
+	if newEval.BlockedEval != blocked.ID {
+		t.Fatalf("setStatus() didn't set BlockedEval correctly: %v", newEval)
 	}
 }
 

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -485,7 +485,7 @@ func TestSetStatus(t *testing.T) {
 	eval := mock.Eval()
 	status := "a"
 	desc := "b"
-	if err := setStatus(logger, h, eval, nil, status, desc); err != nil {
+	if err := setStatus(logger, h, eval, nil, nil, status, desc); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -498,9 +498,10 @@ func TestSetStatus(t *testing.T) {
 		t.Fatalf("setStatus() submited invalid eval: %v", newEval)
 	}
 
+	// Test next evals
 	h = NewHarness(t)
 	next := mock.Eval()
-	if err := setStatus(logger, h, eval, next, status, desc); err != nil {
+	if err := setStatus(logger, h, eval, next, nil, status, desc); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -511,6 +512,22 @@ func TestSetStatus(t *testing.T) {
 	newEval = h.Evals[0]
 	if newEval.NextEval != next.ID {
 		t.Fatalf("setStatus() didn't set nextEval correctly: %v", newEval)
+	}
+
+	// Test blocked evals
+	h = NewHarness(t)
+	blocked := mock.Eval()
+	if err := setStatus(logger, h, eval, nil, blocked, status, desc); err != nil {
+		t.Fatalf("setStatus() failed: %v", err)
+	}
+
+	if len(h.Evals) != 1 {
+		t.Fatalf("setStatus() didn't update plan: %v", h.Evals)
+	}
+
+	newEval = h.Evals[0]
+	if newEval.SpawnedBlockedEval != blocked.ID {
+		t.Fatalf("setStatus() didn't set SpawnedBlockedEval correctly: %v", newEval)
 	}
 }
 


### PR DESCRIPTION
This PR:
* The scheduler no longer creates a failed allocation per task group that failed to place
* Stores the failure metrics for debugging inside the Evaluation
* Updates the eval-monitor to print the task group failure metrics
* Adds a `SpawnedBlockedEval` field to the Evaluation so you can see that a blocked eval was created
 
A follow up PR will introduce a `eval-status` command that prints this information and will deprecate `eval-monitor` and introduce `eval-status -monitor`.

Sample output of the monitor with failures:
```
    Evaluation status changed: "pending" -> "complete"
==> Evaluation "d81bd79f" finished with status "complete" but failed to place all allocations:
    Task Group "api" (failed to place 6 allocations):
      * Resources exhausted on 1 nodes
      * Dimension "cpu exhausted" exhausted on 1 nodes
    Task Group "cache" (failed to place 5 allocations):
      * Resources exhausted on 1 nodes
      * Dimension "cpu exhausted" exhausted on 1 nodes
    Spawned follow up blocked evaluation "34ac2671" to place remainder
```