### PR TITLE
Do not restart successful batch jobs when the node is tainted (removed/drained)

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1904,6 +1904,21 @@ func (ts *TaskState) Failed() bool {
 	}
 }
 
+// Successful returns whether a task finished successfully.
+func (ts *TaskState) Successful() bool {
+	l := len(ts.Events)
+	if ts.State != TaskStateDead || l == 0 {
+		return false
+	}
+
+	e := ts.Events[l-1]
+	if e.Type != TaskTerminated {
+		return false
+	}
+
+	return e.ExitCode == 0
+}
+
 const (
 	// TaskDriveFailure indicates that the task could not be started due to a
 	// failure in the driver.
@@ -2334,6 +2349,23 @@ func (a *Allocation) TerminalStatus() bool {
 	default:
 		return false
 	}
+}
+
+// RanSuccessfully returns whether the client has ran the allocation and all
+// tasks finished successfully
+func (a *Allocation) RanSuccessfully() bool {
+	// Handle the case the client hasn't started the allocation.
+	if len(a.TaskStates) == 0 {
+		return false
+	}
+
+	// Check to see if all the tasks finised successfully in the allocation
+	allSuccess := true
+	for _, state := range a.TaskStates {
+		allSuccess = allSuccess && state.Successful()
+	}
+
+	return allSuccess
 }
 
 // Stub returns a list stub for the allocation

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -235,12 +235,12 @@ func (s *GenericScheduler) filterCompleteAllocs(allocs []*structs.Allocation) []
 	filter := func(a *structs.Allocation) bool {
 		if s.batch {
 			// Allocs from batch jobs should be filtered when the desired status
-			// is terminal or when the client status is failed so that they will
-			// be replaced. If they are complete but not failed, they shouldn't
-			// be replaced.
+			// is terminal and the client did not finish or when the client
+			// status is failed so that they will be replaced. If they are
+			// complete but not failed, they shouldn't be replaced.
 			switch a.DesiredStatus {
 			case structs.AllocDesiredStatusStop, structs.AllocDesiredStatusEvict, structs.AllocDesiredStatusFailed:
-				return true
+				return !a.RanSuccessfully()
 			default:
 			}
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -84,13 +84,14 @@ func diffAllocs(job *structs.Job, taintedNodes map[string]bool,
 		// If we are on a tainted node, we must migrate if we are a service or
 		// if the batch allocation did not finish
 		if taintedNodes[exist.NodeID] {
-			if exist.Job.Type != structs.JobTypeBatch || !exist.RanSuccessfully() {
-				result.migrate = append(result.migrate, allocTuple{
-					Name:      name,
-					TaskGroup: tg,
-					Alloc:     exist,
-				})
+			if exist.Job.Type == structs.JobTypeBatch && exist.RanSuccessfully() {
+				goto IGNORE
 			}
+			result.migrate = append(result.migrate, allocTuple{
+				Name:      name,
+				TaskGroup: tg,
+				Alloc:     exist,
+			})
 			continue
 		}
 
@@ -105,6 +106,7 @@ func diffAllocs(job *structs.Job, taintedNodes map[string]bool,
 		}
 
 		// Everything is up-to-date
+	IGNORE:
 		result.ignore = append(result.ignore, allocTuple{
 			Name:      name,
 			TaskGroup: tg,

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -84,6 +84,11 @@ func diffAllocs(job *structs.Job, taintedNodes map[string]bool,
 		// If we are on a tainted node, we must migrate if we are a service or
 		// if the batch allocation did not finish
 		if taintedNodes[exist.NodeID] {
+			// If the job is batch and finished succesfully, the fact that the
+			// node is tainted does not mean it should be migrated as the work
+			// was already succesfully finished. However for service/system
+			// jobs, tasks should never complete. The check of batch type,
+			// defends against client bugs.
 			if exist.Job.Type == structs.JobTypeBatch && exist.RanSuccessfully() {
 				goto IGNORE
 			}

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -81,13 +81,16 @@ func diffAllocs(job *structs.Job, taintedNodes map[string]bool,
 			continue
 		}
 
-		// If we are on a tainted node, we must migrate
+		// If we are on a tainted node, we must migrate if we are a service or
+		// if the batch allocation did not finish
 		if taintedNodes[exist.NodeID] {
-			result.migrate = append(result.migrate, allocTuple{
-				Name:      name,
-				TaskGroup: tg,
-				Alloc:     exist,
-			})
+			if exist.Job.Type != structs.JobTypeBatch || !exist.RanSuccessfully() {
+				result.migrate = append(result.migrate, allocTuple{
+					Name:      name,
+					TaskGroup: tg,
+					Alloc:     exist,
+				})
+			}
 			continue
 		}
 

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -74,6 +74,7 @@ func TestDiffAllocs(t *testing.T) {
 			ID:     structs.GenerateUUID(),
 			NodeID: "zip",
 			Name:   "my-job.web[10]",
+			Job:    oldJob,
 		},
 
 		// Migrate the 3rd
@@ -81,6 +82,7 @@ func TestDiffAllocs(t *testing.T) {
 			ID:     structs.GenerateUUID(),
 			NodeID: "dead",
 			Name:   "my-job.web[2]",
+			Job:    oldJob,
 		},
 	}
 
@@ -155,6 +157,7 @@ func TestDiffSystemAllocs(t *testing.T) {
 			ID:     structs.GenerateUUID(),
 			NodeID: "dead",
 			Name:   "my-job.web[0]",
+			Job:    oldJob,
 		},
 	}
 


### PR DESCRIPTION
This PR fixes an issue in which batch allocations would be restarted when the node that ran the allocation was drained.

Fixes #1193, Fixes #1178 

@armon for review