### PR TITLE
Blocked evals don't store TG alloc metrics

### DIFF
--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -60,20 +60,20 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) error {
 	default:
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)
-		return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, structs.EvalStatusFailed, desc)
+		return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, nil, structs.EvalStatusFailed, desc)
 	}
 
 	// Retry up to the maxSystemScheduleAttempts and reset if progress is made.
 	progress := func() bool { return progressMade(s.planResult) }
 	if err := retryMax(maxSystemScheduleAttempts, s.process, progress); err != nil {
 		if statusErr, ok := err.(*SetStatusError); ok {
-			return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, statusErr.EvalStatus, err.Error())
+			return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, nil, statusErr.EvalStatus, err.Error())
 		}
 		return err
 	}
 
 	// Update the status to complete
-	return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, structs.EvalStatusComplete, "")
+	return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, nil, structs.EvalStatusComplete, "")
 }
 
 // process is wrapped in retryMax to iteratively run the handler until we have no

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -366,11 +366,15 @@ func networkPortMap(n *structs.NetworkResource) map[string]int {
 }
 
 // setStatus is used to update the status of the evaluation
-func setStatus(logger *log.Logger, planner Planner, eval, nextEval, spawnedBlocked *structs.Evaluation, status, desc string) error {
+func setStatus(logger *log.Logger, planner Planner,
+	eval, nextEval, spawnedBlocked *structs.Evaluation,
+	tgMetrics map[string]*structs.AllocMetric, status, desc string) error {
+
 	logger.Printf("[DEBUG] sched: %#v: setting status to %s", eval, status)
 	newEval := eval.Copy()
 	newEval.Status = status
 	newEval.StatusDescription = desc
+	newEval.FailedTGAllocs = tgMetrics
 	if nextEval != nil {
 		newEval.NextEval = nextEval.ID
 	}

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -488,7 +488,7 @@ func TestSetStatus(t *testing.T) {
 	eval := mock.Eval()
 	status := "a"
 	desc := "b"
-	if err := setStatus(logger, h, eval, nil, nil, status, desc); err != nil {
+	if err := setStatus(logger, h, eval, nil, nil, nil, status, desc); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -504,7 +504,7 @@ func TestSetStatus(t *testing.T) {
 	// Test next evals
 	h = NewHarness(t)
 	next := mock.Eval()
-	if err := setStatus(logger, h, eval, next, nil, status, desc); err != nil {
+	if err := setStatus(logger, h, eval, next, nil, nil, status, desc); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -520,7 +520,7 @@ func TestSetStatus(t *testing.T) {
 	// Test blocked evals
 	h = NewHarness(t)
 	blocked := mock.Eval()
-	if err := setStatus(logger, h, eval, nil, blocked, status, desc); err != nil {
+	if err := setStatus(logger, h, eval, nil, blocked, nil, status, desc); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -531,6 +531,22 @@ func TestSetStatus(t *testing.T) {
 	newEval = h.Evals[0]
 	if newEval.BlockedEval != blocked.ID {
 		t.Fatalf("setStatus() didn't set BlockedEval correctly: %v", newEval)
+	}
+
+	// Test metrics
+	h = NewHarness(t)
+	metrics := map[string]*structs.AllocMetric{"foo": nil}
+	if err := setStatus(logger, h, eval, nil, nil, metrics, status, desc); err != nil {
+		t.Fatalf("setStatus() failed: %v", err)
+	}
+
+	if len(h.Evals) != 1 {
+		t.Fatalf("setStatus() didn't update plan: %v", h.Evals)
+	}
+
+	newEval = h.Evals[0]
+	if !reflect.DeepEqual(newEval.FailedTGAllocs, metrics) {
+		t.Fatalf("setStatus() didn't set failed task group metrics correctly: %v", newEval)
 	}
 }
 


### PR DESCRIPTION
Avoids only the leader being able to show updated metrics since the re-block operation doesn't go through Raft