### PR TITLE
Job Summary API

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -64,6 +64,16 @@ func (j *Jobs) Info(jobID string, q *QueryOptions) (*Job, *QueryMeta, error) {
 	return &resp, qm, nil
 }
 
+// Status retrieves the current state of a particular job given its unique ID.
+func (j *Jobs) Status(jobID string, q *QueryOptions) (*JobStatus, *QueryMeta, error) {
+	var resp JobStatus
+	qm, err := j.client.query("/v1/job/"+jobID+"/status", &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, qm, nil
+}
+
 // Allocations is used to return the allocs for a given job ID.
 func (j *Jobs) Allocations(jobID string, q *QueryOptions) ([]*AllocationListStub, *QueryMeta, error) {
 	var resp []*AllocationListStub
@@ -182,6 +192,7 @@ type JobListStub struct {
 	Name              string
 	Type              string
 	Priority          int
+	Periodic          bool
 	Status            string
 	StatusDescription string
 	CreateIndex       uint64
@@ -338,4 +349,18 @@ type DesiredUpdates struct {
 	Stop              uint64
 	InPlaceUpdate     uint64
 	DestructiveUpdate uint64
+}
+
+type JobStatus struct {
+	AllocStateCounts
+	TaskGroups map[string]AllocStateCounts
+	Status     string
+}
+
+type AllocStateCounts struct {
+	Pending  uint64
+	Starting uint64
+	Running  uint64
+	Complete uint64
+	Failed   uint64
 }

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -501,7 +501,6 @@ func (j *Job) Status(args *structs.JobSpecificRequest,
 	}
 	defer metrics.MeasureSince([]string{"nomad", "job", "status"}, time.Now())
 
-	// Setup the blocking query
 	snap, err := j.srv.fsm.State().Snapshot()
 	if err != nil {
 		return err

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/driver"
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/watch"
 	"github.com/hashicorp/nomad/scheduler"
@@ -429,38 +430,12 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 	// Insert the updated Job into the snapshot
 	snap.UpsertJob(index, args.Job)
 
-	// Create an eval and mark it as requiring annotations and insert that as well
-	eval := &structs.Evaluation{
-		ID:             structs.GenerateUUID(),
-		Priority:       args.Job.Priority,
-		Type:           args.Job.Type,
-		TriggeredBy:    structs.EvalTriggerJobRegister,
-		JobID:          args.Job.ID,
-		JobModifyIndex: index,
-		Status:         structs.EvalStatusPending,
-		AnnotatePlan:   true,
-	}
-
-	// Create an in-memory Planner that returns no errors and stores the
-	// submitted plan and created evals.
-	planner := &scheduler.Harness{
-		State: &snap.StateStore,
-	}
-
-	// Create the scheduler and run it
-	sched, err := scheduler.NewScheduler(eval.Type, j.srv.logger, snap, planner)
+	// Do the dry run
+	planner, err := j.dryrunJob(args.Job, snap)
 	if err != nil {
 		return err
 	}
 
-	if err := sched.Process(eval); err != nil {
-		return err
-	}
-
-	// Annotate and store the diff
-	if plans := len(planner.Plans); plans != 1 {
-		return fmt.Errorf("scheduler resulted in an unexpected number of plans: %d", plans)
-	}
 	annotations := planner.Plans[0].Annotations
 	if args.Diff {
 		jobDiff, err := oldJob.Diff(args.Job, true)
@@ -515,4 +490,157 @@ func validateJob(job *structs.Job) error {
 	}
 
 	return validationErrors.ErrorOrNil()
+}
+
+// Status returns a summary of the status of the job's allocations (how many
+// pending, running, complete, failed).
+func (j *Job) Status(args *structs.JobSpecificRequest,
+	reply *structs.JobStatusResponse) error {
+	if done, err := j.srv.forward("Job.Status", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "job", "status"}, time.Now())
+
+	// Setup the blocking query
+	snap, err := j.srv.fsm.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	out, err := snap.JobByID(args.JobID)
+	if err != nil {
+		return err
+	}
+
+	if out == nil {
+		return fmt.Errorf("job %q not found", args.JobID)
+	}
+
+	status, err := j.computeJobStatus(snap, out)
+	if err != nil {
+		return err
+	}
+
+	*reply = *status
+	reply.Index = out.ModifyIndex
+
+	// Set the query response
+	j.srv.setQueryMeta(&reply.QueryMeta)
+	return nil
+}
+
+// computeJobStatus takes a state snapshot and the job and computes is high
+// level status
+func (j *Job) computeJobStatus(snap *state.StateSnapshot, job *structs.Job) (*structs.JobStatusResponse, error) {
+	if job == nil {
+		return nil, fmt.Errorf("job can not be nil")
+	}
+
+	status := &structs.JobStatusResponse{
+		Status:     job.Status,
+		TaskGroups: make(map[string]structs.AllocStateCounts, len(job.TaskGroups)),
+	}
+	allocs, err := snap.AllocsByJob(job.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Periodic jobs can't have running instances
+	if job.IsPeriodic() {
+		return status, nil
+	}
+
+	var tgStat structs.AllocStateCounts
+	for _, alloc := range allocs {
+		// Starting =  Desired Running && Client Pending
+		// Running = Desired Running && Client Running
+		// Complete = Desired running && client complete
+		if alloc.DesiredStatus == structs.AllocDesiredStatusRun {
+			tgStat = status.TaskGroups[alloc.TaskGroup]
+
+			switch alloc.ClientStatus {
+			case structs.AllocClientStatusPending:
+				status.Starting++
+				tgStat.Starting++
+			case structs.AllocClientStatusRunning:
+				status.Running++
+				tgStat.Running++
+			case structs.AllocClientStatusComplete:
+				status.Complete++
+				tgStat.Complete++
+			}
+
+		}
+
+		// Failed = desired failed || client failed
+		if alloc.DesiredStatus == structs.AllocDesiredStatusFailed ||
+			alloc.ClientStatus == structs.AllocClientStatusFailed {
+			status.Failed++
+			tgStat.Failed++
+		}
+
+		status.TaskGroups[alloc.TaskGroup] = tgStat
+	}
+
+	// If the job is a system job, pending isn't applicable
+	if job.Type == structs.JobTypeSystem {
+		return status, nil
+	}
+
+	// Pending = Hasn't been scheduled
+	// Determine what is pending by dry-running the scheduler.
+	planner, err := j.dryrunJob(job, snap)
+	if err != nil {
+		return nil, err
+	}
+
+	annotations := planner.Plans[0].Annotations
+
+	for tg, update := range annotations.DesiredTGUpdates {
+		status.Pending += update.Place
+		tgStat = status.TaskGroups[tg]
+		tgStat.Pending += update.Place
+		status.TaskGroups[tg] = tgStat
+	}
+
+	return status, nil
+}
+
+// dryrunJob takes a job and a state snapshot and invokes the scheduler in
+// dryrun mode. The harness is returned which contains the created evaluation
+// and annotations
+func (j *Job) dryrunJob(job *structs.Job, snap *state.StateSnapshot) (*scheduler.Harness, error) {
+	eval := &structs.Evaluation{
+		ID:             structs.GenerateUUID(),
+		Priority:       job.Priority,
+		Type:           job.Type,
+		TriggeredBy:    structs.EvalTriggerJobRegister,
+		JobID:          job.ID,
+		JobModifyIndex: job.ModifyIndex,
+		Status:         structs.EvalStatusPending,
+		AnnotatePlan:   true,
+	}
+
+	// Create an in-memory Planner that returns no errors and stores the
+	// submitted plan and created evals.
+	planner := &scheduler.Harness{
+		State: &snap.StateStore,
+	}
+
+	// Create the scheduler and run it
+	sched, err := scheduler.NewScheduler(eval.Type, j.srv.logger, snap, planner)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := sched.Process(eval); err != nil {
+		return nil, err
+	}
+
+	// Annotate and store the diff
+	if plans := len(planner.Plans); plans != 1 {
+		return nil, fmt.Errorf("scheduler resulted in an unexpected number of plans: %d", plans)
+	}
+
+	return planner, nil
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -419,6 +419,30 @@ type JobPlanResponse struct {
 	WriteMeta
 }
 
+// JobStatusResponse returns the status of the job and its allocations. This is
+// to get a quick overview of the job.
+type JobStatusResponse struct {
+	// Rolled up across all Task Groups
+	AllocStateCounts
+
+	// Per Task Group status
+	TaskGroups map[string]AllocStateCounts
+
+	// The status of the job.
+	Status string
+
+	QueryMeta
+}
+
+// AllocStateCounts counts the number of allocations in each state.
+type AllocStateCounts struct {
+	Pending  uint64
+	Starting uint64
+	Running  uint64
+	Complete uint64
+	Failed   uint64
+}
+
 // SingleAllocResponse is used to return a single allocation
 type SingleAllocResponse struct {
 	Alloc *Allocation
@@ -1068,6 +1092,7 @@ func (j *Job) Stub() *JobListStub {
 		Name:              j.Name,
 		Type:              j.Type,
 		Priority:          j.Priority,
+		Periodic:          j.IsPeriodic(),
 		Status:            j.Status,
 		StatusDescription: j.StatusDescription,
 		CreateIndex:       j.CreateIndex,
@@ -1088,6 +1113,7 @@ type JobListStub struct {
 	Name              string
 	Type              string
 	Priority          int
+	Periodic          bool
 	Status            string
 	StatusDescription string
 	CreateIndex       uint64

--- a/website/source/docs/http/job.html.md
+++ b/website/source/docs/http/job.html.md
@@ -240,6 +240,59 @@ region is used; another region can be specified using the `?region=` query param
   </dd>
 </dl>
 
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Query the rolled up status of allocations belonging to a single job.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/v1/job/<id>/status`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+	{
+	  "TaskGroups": {
+		"cache": {
+		  "Pending": 0,
+		  "Starting": 1,
+		  "Running": 2,
+		  "Complete": 0,
+		  "Failed": 0
+		},
+		"web": {
+		  "Pending": 4,
+		  "Starting": 0,
+		  "Running": 1,
+		  "Complete": 0,
+		  "Failed": 0
+		},
+	  },
+	  "Status": "running",
+	  "Pending": 4,
+	  "Starting": 1,
+	  "Running": 3,
+	  "Complete": 0,
+	  "Failed": 0,
+	  "Index": 14,
+	  "LastContact": 0,
+	  "KnownLeader": true
+	}
+    ```
+
+  </dd>
+</dl>
+
 ## PUT / POST
 
 <dl>


### PR DESCRIPTION
This PR adds a Job Summary API that returns both the status for the job's task groups and an overall roll up