### PR TITLE
Fix periodic dispatch and blocked evals not releasing lock

### DIFF
--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -106,6 +106,7 @@ func (b *BlockedEvals) SetEnabled(enabled bool) {
 	b.l.Lock()
 	if b.enabled == enabled {
 		// No-op
+		b.l.Unlock()
 		return
 	} else if enabled {
 		go b.watchCapacity()


### PR DESCRIPTION
Fixes a case where if the blocked evaluation tracker or periodic dispatcher was enabled twice a deadlock would occur.