### PR TITLE
CLI can forward request to different regions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -126,6 +126,11 @@ func NewClient(config *Config) (*Client, error) {
 	return client, nil
 }
 
+// SetRegion sets the region to forward API requests to.
+func (c *Client) SetRegion(region string) {
+	c.config.Region = region
+}
+
 // request is used to help build up a request
 type request struct {
 	config *Config

--- a/command/meta.go
+++ b/command/meta.go
@@ -115,7 +115,7 @@ func generalOptionsUsage() string {
     Default = http://127.0.0.1:4646
 
   -region=<region>
-    The region of the Nomad servers to forward commands too.
+    The region of the Nomad servers to forward commands to.
     Overrides the NOMAD_REGION environment variable if set.
     Defaults to the Agent's local region.
 `

--- a/command/meta.go
+++ b/command/meta.go
@@ -16,6 +16,7 @@ const (
 	// Names of environment variables used to supply various
 	// config options to the Nomad CLI.
 	EnvNomadAddress = "NOMAD_ADDR"
+	EnvNomadRegion  = "NOMAD_REGION"
 
 	// Constants for CLI identifier length
 	shortId = 8
@@ -42,6 +43,9 @@ type Meta struct {
 
 	// Whether to not-colorize output
 	noColor bool
+
+	// The region to send API requests
+	region string
 }
 
 // FlagSet returns a FlagSet with the common flags that every
@@ -55,6 +59,7 @@ func (m *Meta) FlagSet(n string, fs FlagSetFlags) *flag.FlagSet {
 	// client connectivity options.
 	if fs&FlagSetClient != 0 {
 		f.StringVar(&m.flagAddress, "address", "", "")
+		f.StringVar(&m.region, "region", "", "")
 		f.BoolVar(&m.noColor, "no-color", false, "")
 	}
 
@@ -84,6 +89,12 @@ func (m *Meta) Client() (*api.Client, error) {
 	if m.flagAddress != "" {
 		config.Address = m.flagAddress
 	}
+	if v := os.Getenv(EnvNomadRegion); v != "" {
+		config.Region = v
+	}
+	if m.region != "" {
+		config.Region = m.region
+	}
 	return api.NewClient(config)
 }
 
@@ -102,6 +113,11 @@ func generalOptionsUsage() string {
     The address of the Nomad server.
     Overrides the NOMAD_ADDR environment variable if set.
     Default = http://127.0.0.1:4646
+
+  -region=<region>
+    The region of the Nomad servers to forward commands too.
+    Overrides the NOMAD_REGION environment variable if set.
+    Defaults to the Agent's local region.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -18,7 +18,7 @@ func TestMeta_FlagSet(t *testing.T) {
 		},
 		{
 			FlagSetClient,
-			[]string{"address", "no-color"},
+			[]string{"address", "no-color", "region"},
 		},
 	}
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -45,7 +45,7 @@ Usage: nomad plan [options] <file>
   give insight into what the scheduler will attempt to do and why.
 
   If the job has specified the region, the -region flag and NOMAD_REGION
-  environment variable are overridden to the job's region.
+  environment variable are overridden and the the job's region is used.
 
 General Options:
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -44,6 +44,9 @@ Usage: nomad plan [options] <file>
   A structured diff between the local and remote job is displayed to
   give insight into what the scheduler will attempt to do and why.
 
+  If the job has specified the region, the -region flag and NOMAD_REGION
+  environment variable are overridden to the job's region.
+
 General Options:
 
   ` + generalOptionsUsage() + `
@@ -114,6 +117,11 @@ func (c *PlanCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
 		return 1
+	}
+
+	// Force the region to be that of the job.
+	if r := job.Region; r != "" {
+		client.SetRegion(r)
 	}
 
 	// Submit the job

--- a/command/run.go
+++ b/command/run.go
@@ -38,7 +38,7 @@ Usage: nomad run [options] <file>
   issues or internal errors, are indicated by exit code 1.
 
   If the job has specified the region, the -region flag and NOMAD_REGION
-  environment variable are overridden to the job's region.
+  environment variable are overridden and the the job's region is used.
 
 General Options:
 

--- a/command/run.go
+++ b/command/run.go
@@ -37,6 +37,9 @@ Usage: nomad run [options] <file>
   exit code will be 2. Any other errors, including client connection
   issues or internal errors, are indicated by exit code 1.
 
+  If the job has specified the region, the -region flag and NOMAD_REGION
+  environment variable are overridden to the job's region.
+
 General Options:
 
   ` + generalOptionsUsage() + `
@@ -132,6 +135,11 @@ func (c *RunCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
 		return 1
+	}
+
+	// Force the region to be that of the job.
+	if r := job.Region; r != "" {
+		client.SetRegion(r)
 	}
 
 	// Submit the job

--- a/website/helpers/command_helpers.rb
+++ b/website/helpers/command_helpers.rb
@@ -4,6 +4,10 @@ module CommandHelpers
     <<EOF
 * `-address=<addr>`: The address of the Nomad server. Overrides the `NOMAD_ADDR`
   environment variable if set. Defaults to `http://127.0.0.1:4646`.
+
+* `-region=<region>`: The region of the Nomad server to forward commands to.
+  Overrides the `NOMAD_REGION` environment variable if set. Defaults to the
+  Agent's local region.
 EOF
   end
 end

--- a/website/source/docs/commands/run.html.md.erb
+++ b/website/source/docs/commands/run.html.md.erb
@@ -32,6 +32,9 @@ there are job placement issues encountered (unsatisfiable constraints, resource
 exhaustion, etc), then the exit code will be 2. Any other errors, including
 client connection issues or internal errors, are indicated by exit code 1.
 
+If the job has specified the region, the -region flag and NOMAD_REGION
+environment variable are overridden and the the job's region is used.
+
 ## General Options
 
 <%= general_options_usage %>


### PR DESCRIPTION
This PR allows the CLI to forward request to different regions.

`nomad plan` and `nomad run` parse the region from the job file and set it automatically.

Fixes https://github.com/hashicorp/nomad/issues/1194, Fixes https://github.com/hashicorp/nomad/issues/1116