### PR TITLE
Change 'fs ls' cmd to 'fs' cmd

### DIFF
--- a/website/source/intro/getting-started/jobs.html.md
+++ b/website/source/intro/getting-started/jobs.html.md
@@ -115,7 +115,7 @@ CPU  Memory MB  Disk MB  IOPS  Addresses
 500  256        300      0     db: 127.0.0.1:52004
 ```
 
-To inspect the file system of a running allocation, we can use the [`fs ls`
+To inspect the file system of a running allocation, we can use the [`fs`
 command](/docs/commands/fs.html):
 
 ```


### PR DESCRIPTION
Hi, 

i was reading the docs, and saw the link to the `fs ls` command, which was a link to a `fs.html`. Also `nomad help` shows a `fs` command and not a `fs ls` command. This is the reason that i think it should just be `fs`. If not, please just close this PR. 

Thanks!