### PR TITLE
Add check-index flag to nomad run

### DIFF
--- a/command/inspect.go
+++ b/command/inspect.go
@@ -84,7 +84,7 @@ func (c *InspectCommand) Run(args []string) int {
 	}
 
 	// Print the contents of the job
-	req := api.RegisterJobRequest{job}
+	req := api.RegisterJobRequest{Job: job}
 	buf, err := json.MarshalIndent(req, "", "    ")
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error converting job: %s", err))

--- a/command/run_test.go
+++ b/command/run_test.go
@@ -136,4 +136,14 @@ job "job1" {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error submitting job") {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
+
+	// Fails on invalid check-index (requires a valid job)
+	if code := cmd.Run([]string{"-check-index=bad", fh3.Name()}); code != 1 {
+		t.Fatalf("expected exit code 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "parsing check-index") {
+		t.Fatalf("expected parse error, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -182,6 +182,13 @@ type NodeSpecificRequest struct {
 // to register a job as being a schedulable entity.
 type JobRegisterRequest struct {
 	Job *Job
+
+	// If EnforceIndex is set then the job will only be registered if the passed
+	// JobModifyIndex matches the current Jobs index. If the index is zero, the
+	// register only occurs if the job is new.
+	EnforceIndex   bool
+	JobModifyIndex uint64
+
 	WriteRequest
 }
 
@@ -1075,6 +1082,7 @@ func (j *Job) Stub() *JobListStub {
 		StatusDescription: j.StatusDescription,
 		CreateIndex:       j.CreateIndex,
 		ModifyIndex:       j.ModifyIndex,
+		JobModifyIndex:    j.JobModifyIndex,
 	}
 }
 
@@ -1095,6 +1103,7 @@ type JobListStub struct {
 	StatusDescription string
 	CreateIndex       uint64
 	ModifyIndex       uint64
+	JobModifyIndex    uint64
 }
 
 // UpdateStrategy is used to modify how updates are done

--- a/website/source/docs/commands/run.html.md.erb
+++ b/website/source/docs/commands/run.html.md.erb
@@ -41,6 +41,13 @@ environment variable are overridden and the the job's region is used.
 
 ## Run Options
 
+* `-check-index`: If set, the job is only registered or updated if the the
+  passed job modify index matches the server side version. If a check-index value
+  of zero is passed, the job is only registered if it does not yet exist. If a
+  non-zero value is passed, it ensures that the job is being updated from a known
+  state. The use of this flag is most common in conjunction with [plan
+  command](/docs/commands/plan.html).
+
 * `-detach`: Return immediately instead of monitoring. A new evaluation ID
   will be output, which can be used to examine the evaluation using the
   [eval-status](/docs/commands/eval-status.html) command
@@ -63,6 +70,20 @@ $ nomad run job1.nomad
     Allocation "5e0b39f0" status changed: "pending" -> "running"
     Evaluation status changed: "pending" -> "complete"
 ==> Evaluation "52dee78a" finished with status "complete"
+```
+
+Update the job using check-index:
+```
+$ nomad run -check-index 5 example.nomad
+Enforcing job modify index 5: job exists with conflicting job modify index: 6
+Job not updated
+
+$ nomad run -check-index 6 example.nomad
+==> Monitoring evaluation "5ef16dff"
+    Evaluation triggered by job "example"
+    Allocation "6ec7d16f" modified: node "6e1f9bf6", group "cache"
+    Evaluation status changed: "pending" -> "complete"
+==> Evaluation "5ef16dff" finished with status "complete"
 ```
 
 Schedule the job contained in `job1.nomad` and return immediately:


### PR DESCRIPTION
Add check-index flag to nomad run which verifies the server side version of the job's modify index matches the passed one. Used with `nomad plan`