### PR TITLE
Better placement failure text for blocked evals

### DIFF
--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -3,7 +3,6 @@ package command
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -99,10 +98,7 @@ func (c *EvalStatusCommand) Run(args []string) int {
 		out := make([]string, len(evals)+1)
 		out[0] = "ID|Priority|Triggered By|Status|Placement Failures"
 		for i, eval := range evals {
-			failures := strconv.FormatBool(len(eval.FailedTGAllocs) != 0)
-			if eval.Status == "blocked" {
-				failures = "N/A - In Progress"
-			}
+			failures, _ := evalFailureStatus(eval)
 			out[i+1] = fmt.Sprintf("%s|%d|%s|%s|%s",
 				limit(eval.ID, length),
 				eval.Priority,
@@ -128,11 +124,7 @@ func (c *EvalStatusCommand) Run(args []string) int {
 		return 1
 	}
 
-	failures := len(eval.FailedTGAllocs) != 0
-	failureString := strconv.FormatBool(failures)
-	if eval.Status == "blocked" {
-		failureString = "N/A - In Progress"
-	}
+	failureString, failures := evalFailureStatus(eval)
 	triggerNoun, triggerSubj := getTriggerDetails(eval)
 	statusDesc := eval.StatusDescription
 	if statusDesc == "" {

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
@@ -68,4 +69,20 @@ func getLocalNodeID(client *api.Client) (string, error) {
 	}
 
 	return nodeID, nil
+}
+
+// evalFailureStatus returns whether the evaluation has failures and a string to
+// display when presenting users with whether there are failures for the eval
+func evalFailureStatus(eval *api.Evaluation) (string, bool) {
+	if eval == nil {
+		return "", false
+	}
+
+	hasFailures := len(eval.FailedTGAllocs) != 0
+	text := strconv.FormatBool(hasFailures)
+	if eval.Status == "blocked" {
+		text = "N/A - In Progress"
+	}
+
+	return text, hasFailures
 }

--- a/command/status.go
+++ b/command/status.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -253,11 +252,7 @@ func (c *StatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
 	evals = make([]string, len(jobEvals)+1)
 	evals[0] = "ID|Priority|Triggered By|Status|Placement Failures"
 	for i, eval := range jobEvals {
-		failures := strconv.FormatBool(len(eval.FailedTGAllocs) != 0)
-		if eval.Status == "blocked" {
-			failures = "N/A - In Progress"
-		}
-
+		failures, _ := evalFailureStatus(eval)
 		evals[i+1] = fmt.Sprintf("%s|%d|%s|%s|%s",
 			limit(eval.ID, c.length),
 			eval.Priority,

--- a/command/status.go
+++ b/command/status.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -252,12 +253,17 @@ func (c *StatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
 	evals = make([]string, len(jobEvals)+1)
 	evals[0] = "ID|Priority|Triggered By|Status|Placement Failures"
 	for i, eval := range jobEvals {
-		evals[i+1] = fmt.Sprintf("%s|%d|%s|%s|%t",
+		failures := strconv.FormatBool(len(eval.FailedTGAllocs) != 0)
+		if eval.Status == "blocked" {
+			failures = "N/A - In Progress"
+		}
+
+		evals[i+1] = fmt.Sprintf("%s|%d|%s|%s|%s",
 			limit(eval.ID, c.length),
 			eval.Priority,
 			eval.TriggeredBy,
 			eval.Status,
-			len(eval.FailedTGAllocs) != 0,
+			failures,
 		)
 
 		if eval.Status == "blocked" {


### PR DESCRIPTION
Better placement failure text for blocked evals:

Instead of false always - it shows "N/A - In Progress"