### PR TITLE
Only unblock if missed class was added after eval snapshot index

### DIFF
--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -207,9 +207,10 @@ func (b *BlockedEvals) missedUnblock(eval *structs.Evaluation) bool {
 		}
 
 		elig, ok := eval.ClassEligibility[class]
-		if !ok {
-			// The evaluation was processed and did not encounter this class.
-			// Thus for correctness we need to unblock it.
+		if !ok && eval.SnapshotIndex < index {
+			// The evaluation was processed and did not encounter this class
+			// because it was added after it was processed. Thus for correctness
+			// we need to unblock it.
 			return true
 		}
 

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -139,7 +139,11 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) error {
 	// If the current evaluation is a blocked evaluation and we didn't place
 	// everything, do not update the status to complete.
 	if s.eval.Status == structs.EvalStatusBlocked && len(s.failedTGAllocs) != 0 {
-		return s.planner.ReblockEval(s.eval)
+		e := s.ctx.Eligibility()
+		newEval := s.eval.Copy()
+		newEval.EscapedComputedClass = e.HasEscaped()
+		newEval.ClassEligibility = e.GetClasses()
+		return s.planner.ReblockEval(newEval)
 	}
 
 	// Update the status to complete


### PR DESCRIPTION
Avoids the scheduler looping infinitely because a node class wasn't hit. This can happen if the node is down or drained.