### PR TITLE
Validate interval

### DIFF
--- a/command/agent/consul/syncer.go
+++ b/command/agent/consul/syncer.go
@@ -158,7 +158,7 @@ func NewSyncer(consulConfig *config.ConsulConfig, shutdownCh chan struct{}, logg
 
 	cfg := consul.DefaultConfig()
 
-	// If a nil config was provided, fall back to the default config
+	// If a nil consulConfig was provided, fall back to the default config
 	if consulConfig == nil {
 		consulConfig = cconfig.DefaultConfig().ConsulConfig
 	}

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2486,12 +2486,6 @@ func TestTaskDiff(t *testing.T) {
 								Old:  "foo",
 								New:  "bar",
 							},
-							{
-								Type: DiffTypeNone,
-								Name: "ServiceID",
-								Old:  "",
-								New:  "",
-							},
 						},
 					},
 				},
@@ -2754,12 +2748,6 @@ func TestTaskDiff(t *testing.T) {
 							{
 								Type: DiffTypeNone,
 								Name: "PortLabel",
-								Old:  "",
-								New:  "",
-							},
-							{
-								Type: DiffTypeNone,
-								Name: "ServiceID",
 								Old:  "",
 								New:  "",
 							},

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1484,7 +1484,6 @@ func (tg *TaskGroup) GoString() string {
 const (
 	ServiceCheckHTTP   = "http"
 	ServiceCheckTCP    = "tcp"
-	ServiceCheckDocker = "docker"
 	ServiceCheckScript = "script"
 )
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1509,7 +1509,8 @@ func (sc *ServiceCheck) Copy() *ServiceCheck {
 	return nsc
 }
 
-func (sc *ServiceCheck) Validate() error {
+// validate a Service's ServiceCheck
+func (sc *ServiceCheck) validate() error {
 	t := strings.ToLower(sc.Type)
 	if t != ServiceCheckTCP && t != ServiceCheckHTTP && t != ServiceCheckScript {
 		return fmt.Errorf("service check must be either http, tcp or script type")
@@ -1622,7 +1623,7 @@ func (s *Service) Validate() error {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("check %q is not valid since service %q doesn't have port", c.Name, s.Name))
 			continue
 		}
-		if err := c.Validate(); err != nil {
+		if err := c.validate(); err != nil {
 			mErr.Errors = append(mErr.Errors, err)
 		}
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1530,10 +1530,6 @@ func (sc *ServiceCheck) validate() error {
 		if sc.Command == "" {
 			return fmt.Errorf("script type must have a valid script path")
 		}
-
-		if sc.Timeout <= minCheckTimeout {
-			return fmt.Errorf("timeout %v is lower than required minimum timeout %v", sc.Timeout, minCheckInterval)
-		}
 	default:
 		return fmt.Errorf(`invalid type (%+q), must be one of "http", "tcp", or "script" type`, sc.Type)
 	}
@@ -1541,6 +1537,11 @@ func (sc *ServiceCheck) validate() error {
 	if sc.Interval <= minCheckInterval {
 		return fmt.Errorf("interval (%v) can not be lower than %v", sc.Interval, minCheckInterval)
 	}
+
+	if sc.Timeout <= minCheckTimeout {
+		return fmt.Errorf("timeout %v is lower than required minimum timeout %v", sc.Timeout, minCheckInterval)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This change will likely result in `interval = 10s` being noticed as broken  when it is the last member in a check definition.  The correct syntax is to quote the `10s`: `interval = "10s"`