### PR TITLE
Teach Nomad servers how to fall back to Consul.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1255,8 +1255,8 @@ func (c *Client) setupConsulSyncer() error {
 			// a new set of servers so it's okay.
 			nearestDC := dcs[0]
 			otherDCs := make([]string, 0, len(dcs))
-			otherDCs = dcs[1:lib.MinInt(len(dcs), datacenterQueryLimit)]
 			shuffleStrings(otherDCs)
+			otherDCs = dcs[1:lib.MinInt(len(dcs), datacenterQueryLimit)]
 
 			dcs = append([]string{nearestDC}, otherDCs...)
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -1272,7 +1272,7 @@ func (c *Client) setupConsulSyncer() error {
 		var mErr multierror.Error
 		const defaultMaxNumNomadServers = 8
 		nomadServerServices := make([]string, 0, defaultMaxNumNomadServers)
-		c.logger.Printf("[DEBUG] client.consul: bootstrap contacting following Consul DCs: %q", dcs)
+		c.logger.Printf("[DEBUG] client.consul: bootstrap contacting following Consul DCs: %+q", dcs)
 		for _, dc := range dcs {
 			consulOpts := &consulapi.QueryOptions{
 				AllowStale: true,

--- a/client/client.go
+++ b/client/client.go
@@ -39,7 +39,7 @@ const (
 
 	// datacenterQueryLimit searches through up to this many adjacent
 	// datacenters looking for the Nomad server service.
-	datacenterQueryLimit = 5
+	datacenterQueryLimit = 9
 
 	// registerRetryIntv is minimum interval on which we retry
 	// registration. We pick a value between this and 2x this.

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -235,7 +235,7 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 		return nil, fmt.Errorf("server_service_name must be set when auto_advertise is enabled")
 	}
 
-	// conf.ConsulConfig = a.config.Consul
+	conf.ConsulConfig = a.config.Consul
 
 	return conf, nil
 }
@@ -379,7 +379,7 @@ func (a *Agent) setupServer() error {
 	}
 
 	// Create the server
-	server, err := nomad.NewServer(conf)
+	server, err := nomad.NewServer(conf, a.consulSyncer)
 	if err != nil {
 		return fmt.Errorf("server setup failed: %v", err)
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/nomad/client"
@@ -110,7 +111,7 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 		if a.config.Server.BootstrapExpect == 1 {
 			conf.Bootstrap = true
 		} else {
-			conf.BootstrapExpect = a.config.Server.BootstrapExpect
+			atomic.StoreInt32(&conf.BootstrapExpect, int32(a.config.Server.BootstrapExpect))
 		}
 	}
 	if a.config.DataDir != "" {

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -52,8 +52,9 @@ type Config struct {
 
 	// BootstrapExpect mode is used to automatically bring up a
 	// collection of Nomad servers. This can be used to automatically
-	// bring up a collection of nodes.
-	BootstrapExpect int
+	// bring up a collection of nodes.  All operations on BootstrapExpect
+	// must be handled via `atomic.*Int32()` calls.
+	BootstrapExpect int32
 
 	// DataDir is the directory to store our state in
 	DataDir string

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/scheduler"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
@@ -176,6 +177,9 @@ type Config struct {
 	// a new leader is elected, since we no longer know the status
 	// of all the heartbeats.
 	FailoverHeartbeatTTL time.Duration
+
+	// ConsulConfig is this Agent's Consul configuration
+	ConsulConfig *config.ConsulConfig
 }
 
 // CheckVersion is used to check if the ProtocolVersion is valid

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -465,7 +465,7 @@ func (s *Server) setupConsulSyncer() error {
 		if err != nil {
 			return fmt.Errorf("contacted %d Nomad Servers: %v", numServersContacted, err)
 		}
-		s.logger.Printf("[INFO] successfully contacted %d Nomad Servers", numServersContacted)
+		s.logger.Printf("[INFO] server.consul: successfully contacted %d Nomad Servers", numServersContacted)
 
 		return nil
 	}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -415,8 +415,8 @@ func (s *Server) setupConsulSyncer() error {
 			// form a quorum.
 			nearestDC := dcs[0]
 			otherDCs := make([]string, 0, len(dcs))
-			otherDCs = dcs[1:lib.MinInt(len(dcs), s.config.BootstrapExpect*datacenterQueryFactor)]
 			shuffleStrings(otherDCs)
+			otherDCs = dcs[1:lib.MinInt(len(dcs), s.config.BootstrapExpect*datacenterQueryFactor)]
 
 			dcs = append([]string{nearestDC}, otherDCs...)
 		}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -31,9 +31,10 @@ import (
 const (
 	// datacenterQueryFactor sets the max number of DCs that a Nomad
 	// Server will query to find bootstrap_expect servers.  If
-	// bootstrap_expect is 3, then the Nomad Server bootstrapFn handler
-	// will search through up to 9 Consul DCs to find its quorum.
-	datacenterQueryFactor = 3
+	// bootstrap_expect is 5, then the Nomad Server bootstrapFn handler
+	// will search through up to 15 Consul DCs to find possible Serf
+	// peers.
+	datacenterQueryFactor = 5
 
 	raftState         = "raft/"
 	serfSnapshot      = "serf/snapshot"

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -392,11 +392,11 @@ func (s *Server) setupConsulSyncer() error {
 			return nil
 		}
 
-		// If the the number of Raft peers or Members in Serf is more
-		// than the min quorum, do nothing.
+		// If the the number of Raft peers is more than the min
+		// quorum, do nothing.
 		raftPeers, err := s.raftPeers.Peers()
 		minQuorum := (s.config.BootstrapExpect / 2) + 1
-		if err == nil && (len(raftPeers) >= minQuorum || len(s.Members()) >= minQuorum) {
+		if err == nil && len(raftPeers) >= minQuorum {
 			return nil
 		}
 

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -500,8 +500,9 @@ func (s *Server) setupBootstrapHandler() error {
 			}
 			consulServices, _, err := consulCatalog.Service(nomadServerServiceName, consul.ServiceTagSerf, consulOpts)
 			if err != nil {
-				s.logger.Printf("[WARN] server.consul: failed to query service %+q in Consul datacenter %+q: %v", nomadServerServiceName, dc, err)
-				mErr.Errors = append(mErr.Errors, fmt.Errorf("unable to query service %q from Consul datacenter %q: %v", nomadServerServiceName, dc, err))
+				err := fmt.Errorf("failed to query service %q in Consul datacenter %q: %v", nomadServerServiceName, dc, err)
+				s.logger.Printf("[WARN] server.consul: %v", err)
+				mErr.Errors = append(mErr.Errors, err)
 				continue
 			}
 
@@ -552,14 +553,13 @@ func (s *Server) setupBootstrapHandler() error {
 // setupConsulSyncer creates Server-mode consul.Syncer which periodically
 // executes callbacks on a fixed interval.
 func (s *Server) setupConsulSyncer() error {
-	var mErr multierror.Error
 	if s.config.ConsulConfig.ServerAutoJoin {
 		if err := s.setupBootstrapHandler(); err != nil {
-			mErr.Errors = append(mErr.Errors, err)
+			return err
 		}
 	}
 
-	return mErr.ErrorOrNil()
+	return nil
 }
 
 // setupRPC is used to setup the RPC listener

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -469,7 +469,9 @@ func (s *Server) setupConsulSyncer() error {
 
 		return nil
 	}
-	s.consulSyncer.AddPeriodicHandler("Nomad Server Fallback Server Handler", bootstrapFn)
+	if s.config.ConsulConfig.ServerAutoJoin {
+		s.consulSyncer.AddPeriodicHandler("Nomad Server Fallback Server Handler", bootstrapFn)
+	}
 
 	return nil
 }

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -651,8 +652,9 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 	if s.config.Bootstrap || (s.config.DevMode && !s.config.DevDisableBootstrap) {
 		conf.Tags["bootstrap"] = "1"
 	}
-	if s.config.BootstrapExpect != 0 {
-		conf.Tags["expect"] = fmt.Sprintf("%d", s.config.BootstrapExpect)
+	bootstrapExpect := atomic.LoadInt32(&s.config.BootstrapExpect)
+	if bootstrapExpect != 0 {
+		conf.Tags["expect"] = fmt.Sprintf("%d", bootstrapExpect)
 	}
 	conf.MemberlistConfig.LogOutput = s.config.LogOutput
 	conf.LogOutput = s.config.LogOutput

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -67,7 +66,7 @@ func testServer(t *testing.T, cb func(*Config)) *Server {
 	config.RaftConfig.StartAsLeader = !config.DevDisableBootstrap
 
 	shutdownCh := make(chan struct{})
-	consulSyncer, err := consul.NewSyncer(config.ConsulConfig, shutdownCh, log.New(os.Stderr, "", log.LstdFlags))
+	consulSyncer, err := consul.NewSyncer(config.ConsulConfig, shutdownCh, log.New(config.LogOutput, "", log.LstdFlags))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -3,11 +3,14 @@ package nomad
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/testutil"
 )
 
@@ -63,8 +66,14 @@ func testServer(t *testing.T, cb func(*Config)) *Server {
 	// Enable raft as leader if we have bootstrap on
 	config.RaftConfig.StartAsLeader = !config.DevDisableBootstrap
 
+	shutdownCh := make(chan struct{})
+	consulSyncer, err := consul.NewSyncer(config.ConsulConfig, shutdownCh, log.New(os.Stderr, "", log.LstdFlags))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	// Create server
-	server, err := NewServer(config)
+	server, err := NewServer(config, consulSyncer)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
It is now possible to omit `retry_join` from server configs if Consul is available.