### PR TITLE
client.consul_bootstrap: Use Status.Peers instead of Status.Ping

### DIFF
--- a/demo/vagrant/client1_consul_bootstrap.hcl
+++ b/demo/vagrant/client1_consul_bootstrap.hcl
@@ -15,7 +15,6 @@ client {
     # For demo assume we are talking to server1. For production,
     # this should be like "nomad.service.consul:4647" and a system
     # like Consul used for service discovery.
-    servers = ["127.0.0.1:4647"]
     node_class = "foo"
     options {
         "driver.raw_exec.enable" = "1"


### PR DESCRIPTION
This PR makes the clients bootstrap via Consul using the Nomad Status.Peers endpoint. This endpoint supports region forwarding and will return all the peers in that region.

Also added some debug logging to show what has happened in the bootstrap.