### PR TITLE
Guard against restoring a nil task in task_runner

### DIFF
--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -146,7 +146,13 @@ func (r *TaskRunner) RestoreState() error {
 	}
 
 	// Restore fields
-	r.task = snap.Task
+	if snap.Task == nil {
+		err := fmt.Errorf("task runner snapshot include nil Task")
+		r.logger.Printf("[ERR] client: %v", err)
+		return err
+	} else {
+		r.task = snap.Task
+	}
 	r.artifactsDownloaded = snap.ArtifactDownloaded
 
 	if err := r.setTaskEnv(); err != nil {


### PR DESCRIPTION
Couldn't reproduce #1277 but guard against it.

Fixes #1277 