### PR TITLE
Copy the patch from hashicorp/memberlist#86 silencing EOF messages.

### DIFF
--- a/vendor/github.com/hashicorp/memberlist/net.go
+++ b/vendor/github.com/hashicorp/memberlist/net.go
@@ -222,7 +222,9 @@ func (m *Memberlist) handleConn(conn *net.TCPConn) {
 	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
 	msgType, bufConn, dec, err := m.readTCP(conn)
 	if err != nil {
-		m.logger.Printf("[ERR] memberlist: failed to receive: %s %s", err, LogConn(conn))
+		if err != io.EOF {
+			m.logger.Printf("[ERR] memberlist: failed to receive: %s %s", err, LogConn(conn))
+		}
 		return
 	}
 


### PR DESCRIPTION
This can be backed out, we can comment out the health checks for Serf,
or re-update once hashicorp/memberlist#86 has been merged.  Continuous `[ERR]` spam is less than optimal.

CC @slackpad 