### PR TITLE
Guard against NaN in disk stats

### DIFF
--- a/client/stats/host.go
+++ b/client/stats/host.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"math"
 	"runtime"
 	"time"
 
@@ -116,6 +117,12 @@ func (h *HostStatsCollector) Collect() (*HostStats, error) {
 					Available:         usage.Free,
 					UsedPercent:       usage.UsedPercent,
 					InodesUsedPercent: usage.InodesUsedPercent,
+				}
+				if math.IsNaN(ds.UsedPercent) {
+					ds.UsedPercent = 0.0
+				}
+				if math.IsNaN(ds.InodesUsedPercent) {
+					ds.InodesUsedPercent = 0.0
 				}
 				diskStats = append(diskStats, &ds)
 			}


### PR DESCRIPTION
Gopsutil could report NaN. This guards against us storing that value.