### PR TITLE
Volume binds for windows containers

### DIFF
--- a/client/allocdir/alloc_dir_unix.go
+++ b/client/allocdir/alloc_dir_unix.go
@@ -7,9 +7,18 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 
 	"golang.org/x/sys/unix"
+)
+
+var (
+	//Path inside container for mounted directory shared across tasks in a task group.
+	SharedAllocContainerPath = filepath.Join("/", SharedAllocName)
+
+	//Path inside container for mounted directory for local storage.
+	TaskLocalContainerPath = filepath.Join("/", TaskLocal)
 )
 
 func (d *AllocDir) linkOrCopy(src, dst string, perm os.FileMode) error {

--- a/client/allocdir/alloc_dir_windows.go
+++ b/client/allocdir/alloc_dir_windows.go
@@ -3,6 +3,15 @@ package allocdir
 import (
 	"errors"
 	"os"
+	"path/filepath"
+)
+
+var (
+	//Path inside container for mounted directory that is shared across tasks in a task group.
+	SharedAllocContainerPath = filepath.Join("c:\\", SharedAllocName)
+
+	//Path inside container for mounted directory for local storage.
+	TaskLocalContainerPath = filepath.Join("c:\\", TaskLocal)
 )
 
 func (d *AllocDir) linkOrCopy(src, dst string, perm os.FileMode) error {

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -321,8 +321,8 @@ func (d *DockerDriver) containerBinds(alloc *allocdir.AllocDir, task *structs.Ta
 		return nil, fmt.Errorf("Failed to find task local directory: %v", task.Name)
 	}
 
-	allocDirBind := fmt.Sprintf("%s:/%s", shared, allocdir.SharedAllocName)
-	taskLocalBind := fmt.Sprintf("%s:/%s", local, allocdir.TaskLocal)
+	allocDirBind := fmt.Sprintf("%s:%s", shared, allocdir.SharedAllocContainerPath)
+	taskLocalBind := fmt.Sprintf("%s:%s", local, allocdir.TaskLocalContainerPath)
 
 	if selinuxLabel := d.config.Read("docker.volumes.selinuxlabel"); selinuxLabel != "" {
 		allocDirBind = fmt.Sprintf("%s:%s", allocDirBind, selinuxLabel)
@@ -351,8 +351,8 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 	}
 
 	// Set environment variables.
-	d.taskEnv.SetAllocDir(filepath.Join("/", allocdir.SharedAllocName))
-	d.taskEnv.SetTaskLocalDir(filepath.Join("/", allocdir.TaskLocal))
+	d.taskEnv.SetAllocDir(allocdir.SharedAllocContainerPath)
+	d.taskEnv.SetTaskLocalDir(allocdir.TaskLocalContainerPath)
 
 	config := &docker.Config{
 		Image:     driverConfig.ImageName,


### PR DESCRIPTION
Windows containers needs separate definition of paths for mounted volumes (with drive letters). 
Without this patch we get an error during creating container, f.e.:
```
2016/06/18 13:50:54 [ERR] client: failed to start task 'redis' for alloc 'f66e0366-7137-7e29-9e11-3d21dceeaa4e': 
Failed to create container from image microsoft/sample-redis:nanoserver: API error (500): 
Invalid bind mount spec "C:\\Users\\vagrant\\AppData\\Local\\Temp\\NomadClient916164026\\f66e0366-7137-7e29-9e11-3d21dceeaa4e\\alloc:/alloc": 
Invalid volume specification: 'C:\Users\vagrant\AppData\Local\Temp\NomadClient916164026\f66e0366-7137-7e29-9e11-3d21dceeaa4e\alloc:/alloc'
```
