### PR TITLE
Handle max plans evaluation in generic scheduler

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -105,7 +105,7 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) error {
 	switch eval.TriggeredBy {
 	case structs.EvalTriggerJobRegister, structs.EvalTriggerNodeUpdate,
 		structs.EvalTriggerJobDeregister, structs.EvalTriggerRollingUpdate,
-		structs.EvalTriggerPeriodicJob:
+		structs.EvalTriggerPeriodicJob, structs.EvalTriggerMaxPlans:
 	default:
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)


### PR DESCRIPTION
Blocked evaluations due to max plan failures now use a new EvalStatus, this PR reflects that.

Fixes #1324