### PR TITLE
Added note/link to Vagrant installation instructions

### DIFF
--- a/website/source/intro/getting-started/install.html.md
+++ b/website/source/intro/getting-started/install.html.md
@@ -15,6 +15,8 @@ Create a new directory, and download [this `Vagrantfile`](https://raw.githubuser
 
 ## Vagrant Setup
 
+Note: To use the Vagrant Setup first install Vagrant following these instructions: https://www.vagrantup.com/docs/installation/
+
 Once you have created a new directory and downloaded the `Vagrantfile`
 you must create the virtual machine:
 


### PR DESCRIPTION
So I spent an hour or more trying to figure out why Docker did not install, turns out installing Vagrant from the Linux distribution is a stupid idea.

So hopefully a link will help prevent other people running into this problem.