### PR TITLE
Worker waitForIndex uses StateStore index, not Raft Applied Index

### DIFF
--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -44,8 +44,7 @@ func TestCoreScheduler_EvalGC(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobEvalGC)
-	gc.ModifyIndex = 2000
+	gc := s1.coreJobEval(structs.CoreJobEvalGC, 2000)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -112,8 +111,7 @@ func TestCoreScheduler_EvalGC_Partial(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobEvalGC)
-	gc.ModifyIndex = 2000
+	gc := s1.coreJobEval(structs.CoreJobEvalGC, 2000)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -173,8 +171,7 @@ func TestCoreScheduler_EvalGC_Batch_NoAllocs(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobEvalGC)
-	gc.ModifyIndex = 2000
+	gc := s1.coreJobEval(structs.CoreJobEvalGC, 2000)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -235,8 +232,7 @@ func TestCoreScheduler_EvalGC_Batch_Allocs_WithJob(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobEvalGC)
-	gc.ModifyIndex = 2000
+	gc := s1.coreJobEval(structs.CoreJobEvalGC, 2000)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -296,8 +292,7 @@ func TestCoreScheduler_EvalGC_Batch_Allocs_NoJob(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobEvalGC)
-	gc.ModifyIndex = 2000
+	gc := s1.coreJobEval(structs.CoreJobEvalGC, 2000)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -344,7 +339,7 @@ func TestCoreScheduler_EvalGC_Force(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobForceGC)
+	gc := s1.coreJobEval(structs.CoreJobForceGC, 1001)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -394,8 +389,7 @@ func TestCoreScheduler_NodeGC(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobNodeGC)
-	gc.ModifyIndex = 2000
+	gc := s1.coreJobEval(structs.CoreJobNodeGC, 2000)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -444,8 +438,7 @@ func TestCoreScheduler_NodeGC_TerminalAllocs(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobNodeGC)
-	gc.ModifyIndex = 2000
+	gc := s1.coreJobEval(structs.CoreJobNodeGC, 2000)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -496,8 +489,7 @@ func TestCoreScheduler_NodeGC_RunningAllocs(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobNodeGC)
-	gc.ModifyIndex = 2000
+	gc := s1.coreJobEval(structs.CoreJobNodeGC, 2000)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -535,7 +527,7 @@ func TestCoreScheduler_NodeGC_Force(t *testing.T) {
 	core := NewCoreScheduler(s1, snap)
 
 	// Attempt the GC
-	gc := s1.coreJobEval(structs.CoreJobForceGC)
+	gc := s1.coreJobEval(structs.CoreJobForceGC, 1000)
 	err = core.Process(gc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -621,8 +613,7 @@ func TestCoreScheduler_JobGC(t *testing.T) {
 		core := NewCoreScheduler(s1, snap)
 
 		// Attempt the GC
-		gc := s1.coreJobEval(structs.CoreJobJobGC)
-		gc.ModifyIndex = 2000
+		gc := s1.coreJobEval(structs.CoreJobJobGC, 2000)
 		err = core.Process(gc)
 		if err != nil {
 			t.Fatalf("test(%s) err: %v", test.test, err)
@@ -721,7 +712,7 @@ func TestCoreScheduler_JobGC_Force(t *testing.T) {
 		core := NewCoreScheduler(s1, snap)
 
 		// Attempt the GC
-		gc := s1.coreJobEval(structs.CoreJobForceGC)
+		gc := s1.coreJobEval(structs.CoreJobForceGC, 1002)
 		err = core.Process(gc)
 		if err != nil {
 			t.Fatalf("test(%s) err: %v", test.test, err)

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -254,17 +254,9 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 	// getLatest grabs the latest index from the state store. It returns true if
 	// the index was retrieved successfully.
 	getLatest := func() (uint64, bool) {
-		// Snapshot the current state
-		snap, err := s.fsm.State().Snapshot()
+		snapshotIndex, err := s.fsm.State().LatestIndex()
 		if err != nil {
-			s.logger.Printf("[ERR] nomad: failed to snapshot state for periodic GC: %v", err)
-			return 0, false
-		}
-
-		// Store the snapshot's index
-		snapshotIndex, err := snap.LatestIndex()
-		if err != nil {
-			s.logger.Printf("[ERR] nomad: failed to determine snapshot's index for periodic GC: %v", err)
+			s.logger.Printf("[ERR] nomad: failed to determine state store's index: %v", err)
 			return 0, false
 		}
 

--- a/nomad/system_endpoint.go
+++ b/nomad/system_endpoint.go
@@ -18,16 +18,10 @@ func (s *System) GarbageCollect(args *structs.GenericRequest, reply *structs.Gen
 		return err
 	}
 
-	// Snapshot the current state
-	snap, err := s.srv.fsm.State().Snapshot()
+	// Get the states current index
+	snapshotIndex, err := s.srv.fsm.State().LatestIndex()
 	if err != nil {
-		return fmt.Errorf("failed to snapshot state: %v", err)
-	}
-
-	// Store the snapshot's index
-	snapshotIndex, err := snap.LatestIndex()
-	if err != nil {
-		return fmt.Errorf("failed to determine snapshot's index: %v", err)
+		return fmt.Errorf("failed to determine state store's index: %v", err)
 	}
 
 	s.srv.evalBroker.Enqueue(s.srv.coreJobEval(structs.CoreJobForceGC, snapshotIndex))

--- a/nomad/system_endpoint.go
+++ b/nomad/system_endpoint.go
@@ -1,6 +1,8 @@
 package nomad
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -16,6 +18,18 @@ func (s *System) GarbageCollect(args *structs.GenericRequest, reply *structs.Gen
 		return err
 	}
 
-	s.srv.evalBroker.Enqueue(s.srv.coreJobEval(structs.CoreJobForceGC))
+	// Snapshot the current state
+	snap, err := s.srv.fsm.State().Snapshot()
+	if err != nil {
+		return fmt.Errorf("failed to snapshot state: %v", err)
+	}
+
+	// Store the snapshot's index
+	snapshotIndex, err := snap.LatestIndex()
+	if err != nil {
+		return fmt.Errorf("failed to determine snapshot's index: %v", err)
+	}
+
+	s.srv.evalBroker.Enqueue(s.srv.coreJobEval(structs.CoreJobForceGC, snapshotIndex))
 	return nil
 }

--- a/nomad/system_endpoint_test.go
+++ b/nomad/system_endpoint_test.go
@@ -11,9 +11,6 @@ import (
 )
 
 func TestSystemEndpoint_GarbageCollect(t *testing.T) {
-	//s1 := testServer(t, func(c *Config) {
-	//c.NumSchedulers = 0 // Prevent automatic dequeue
-	//})
 	s1 := testServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
@@ -23,7 +20,7 @@ func TestSystemEndpoint_GarbageCollect(t *testing.T) {
 	state := s1.fsm.State()
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
-	if err := state.UpsertJob(0, job); err != nil {
+	if err := state.UpsertJob(1000, job); err != nil {
 		t.Fatalf("UpsertAllocs() failed: %v", err)
 	}
 

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -203,7 +203,10 @@ func TestWorker_waitForIndex(t *testing.T) {
 	// Cause an increment
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		s1.raft.Barrier(0)
+		n := mock.Node()
+		if err := s1.fsm.state.UpsertNode(index+1, n); err != nil {
+			t.Fatalf("failed to upsert node: %v", err)
+		}
 	}()
 
 	// Wait for a future index


### PR DESCRIPTION
Fixes an issue in which the worker would incorrectly invoke the scheduler without having the proper state.

Should address the issue reported in https://github.com/hashicorp/nomad/issues/1330 in which the two jobs did not get started.