### PR TITLE
Remove Consul defaults from empty config

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -61,7 +61,7 @@ func (c *Command) readConfig() *Config {
 	// Make a new, empty config.
 	cmdConfig := &Config{
 		Atlas:  &AtlasConfig{},
-		Consul: config.DefaultConsulConfig(),
+		Consul: &config.ConsulConfig{},
 		Client: &ClientConfig{},
 		Ports:  &Ports{},
 		Server: &ServerConfig{},


### PR DESCRIPTION
This is to fix #1342. Reverts what looks like a find-and-replace error from commit 7dc7fcf.