### PR TITLE
Install codecgen from vendor

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -39,6 +39,7 @@ format:
 
 generate:
 	@echo "--> Running go generate"
+	@go install github.com/hashicorp/nomad/vendor/github.com/ugorji/go/codec/codecgen/
 	@go generate $(PACKAGES)
 	@sed -e 's|github.com/hashicorp/nomad/vendor/github.com/ugorji/go/codec|github.com/ugorji/go/codec|' nomad/structs/structs.generated.go >> structs.gen.tmp
 	@mv structs.gen.tmp nomad/structs/structs.generated.go


### PR DESCRIPTION
When running git clone && make I get the following error because `codecgen` is not present:

```
make
--> Running go generate
nomad/structs/structs_codegen.go:3: running "codecgen": exec: "codecgen": executable file not found in $PATH
make: *** [generate] Error 1
```