### PR TITLE
UnblockFailed needs to untrack the job

### DIFF
--- a/nomad/blocked_evals_test.go
+++ b/nomad/blocked_evals_test.go
@@ -404,6 +404,12 @@ func TestBlockedEvals_UnblockFailed(t *testing.T) {
 	// Trigger an unblock fail
 	blocked.UnblockFailed()
 
+	// Verify UnblockFailed caused the eval to be immediately unblocked
+	blockedStats := blocked.Stats()
+	if blockedStats.TotalBlocked != 0 && blockedStats.TotalEscaped != 0 {
+		t.Fatalf("bad: %#v", blockedStats)
+	}
+
 	testutil.WaitForResult(func() (bool, error) {
 		// Verify Unblock caused an enqueue
 		brokerStats := broker.Stats()


### PR DESCRIPTION
This could have caused an issue in which all future blocked evaluations for a job would get cancelled