### PR TITLE
Fix docker driver lockup during nomad boot

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -878,7 +878,7 @@ func (d *DockerDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, er
 	if err != nil {
 		d.logger.Printf("[INFO] driver.docker: couldn't re-attach to the plugin process: %v", err)
 		d.logger.Printf("[DEBUG] driver.docker: stopping container %q", pid.ContainerID)
-		if e := client.StopContainer(pid.ContainerID, uint(pid.KillTimeout*time.Second)); e != nil {
+		if e := client.StopContainer(pid.ContainerID, uint(pid.KillTimeout.Seconds())); e != nil {
 			d.logger.Printf("[DEBUG] driver.docker: couldn't stop container: %v", e)
 		}
 		return nil, err


### PR DESCRIPTION
Unit mismatch caused docker driver to wait almost indefinitely during boot 
(when one or more containers were a bit uncooperative during StopContainer())
This should fix problems described in  #1202