### PR TITLE
Update Nomad version used in Vagrant demo to 0.4.0

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ sudo apt-get install -y unzip curl wget vim
 # Download Nomad
 echo Fetching Nomad...
 cd /tmp/
-curl -sSL https://releases.hashicorp.com/nomad/0.3.2/nomad_0.3.2_linux_amd64.zip -o nomad.zip
+curl -sSL https://releases.hashicorp.com/nomad/0.4.0/nomad_0.4.0_linux_amd64.zip -o nomad.zip
 
 echo Installing Nomad...
 unzip nomad.zip


### PR DESCRIPTION
Tried following the getting started documentation, but ran into missing the `-stats` option on `nomad alloc-status`, and `nomad plan` wasn't available.

Upgraded to Nomad 0.4.0 and it seems to work fine: I'm able to make progress on the getting started tutorial.