### PR TITLE
Job Summary - Part 1

### DIFF
--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -26,7 +26,7 @@ func TestCoreScheduler_EvalGC(t *testing.T) {
 	// Insert "dead" alloc
 	alloc := mock.Alloc()
 	alloc.EvalID = eval.ID
-	alloc.DesiredStatus = structs.AllocDesiredStatusFailed
+	alloc.DesiredStatus = structs.AllocDesiredStatusStop
 	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -98,7 +98,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.JobID = job.ID
 	alloc.EvalID = eval.ID
-	alloc.DesiredStatus = structs.AllocDesiredStatusFailed
+	alloc.DesiredStatus = structs.AllocDesiredStatusStop
 	err = state.UpsertAllocs(1002, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -165,7 +165,7 @@ func TestCoreScheduler_EvalGC_Partial(t *testing.T) {
 	// Insert "dead" alloc
 	alloc := mock.Alloc()
 	alloc.EvalID = eval.ID
-	alloc.DesiredStatus = structs.AllocDesiredStatusFailed
+	alloc.DesiredStatus = structs.AllocDesiredStatusStop
 	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -241,7 +241,7 @@ func TestCoreScheduler_EvalGC_Force(t *testing.T) {
 	// Insert "dead" alloc
 	alloc := mock.Alloc()
 	alloc.EvalID = eval.ID
-	alloc.DesiredStatus = structs.AllocDesiredStatusFailed
+	alloc.DesiredStatus = structs.AllocDesiredStatusStop
 	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -467,19 +467,19 @@ func TestCoreScheduler_JobGC(t *testing.T) {
 		{
 			test:        "Terminal",
 			evalStatus:  structs.EvalStatusFailed,
-			allocStatus: structs.AllocDesiredStatusFailed,
+			allocStatus: structs.AllocDesiredStatusStop,
 			shouldExist: false,
 		},
 		{
 			test:        "Has Alloc",
 			evalStatus:  structs.EvalStatusFailed,
-			allocStatus: structs.AllocDesiredStatusRun,
+			allocStatus: structs.AllocDesiredStatusStop,
 			shouldExist: true,
 		},
 		{
 			test:        "Has Eval",
 			evalStatus:  structs.EvalStatusPending,
-			allocStatus: structs.AllocDesiredStatusFailed,
+			allocStatus: structs.AllocDesiredStatusStop,
 			shouldExist: true,
 		},
 	}
@@ -678,7 +678,7 @@ func TestCoreScheduler_JobGC_Force(t *testing.T) {
 		{
 			test:        "Terminal",
 			evalStatus:  structs.EvalStatusFailed,
-			allocStatus: structs.AllocDesiredStatusFailed,
+			allocStatus: structs.AllocDesiredStatusStop,
 			shouldExist: false,
 		},
 		{
@@ -690,7 +690,7 @@ func TestCoreScheduler_JobGC_Force(t *testing.T) {
 		{
 			test:        "Has Eval",
 			evalStatus:  structs.EvalStatusPending,
-			allocStatus: structs.AllocDesiredStatusFailed,
+			allocStatus: structs.AllocDesiredStatusStop,
 			shouldExist: true,
 		},
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -938,3 +938,29 @@ func TestFSM_SnapshotRestore_PeriodicLaunches(t *testing.T) {
 		t.Fatalf("bad: \n%#v\n%#v", out2, job2)
 	}
 }
+
+func TestFSM_SnapshotRestore_JobSummary(t *testing.T) {
+	// Add some state
+	fsm := testFSM(t)
+	state := fsm.State()
+
+	job1 := mock.Job()
+	state.UpsertJob(1000, job1)
+	js1, _ := state.JobSummaryByID(job1.ID)
+
+	job2 := mock.Job()
+	state.UpsertJob(1001, job2)
+	js2, _ := state.JobSummaryByID(job2.ID)
+
+	// Verify the contents
+	fsm2 := testSnapshotRestore(t, fsm)
+	state2 := fsm2.State()
+	out1, _ := state2.JobSummaryByID(job1.ID)
+	out2, _ := state2.JobSummaryByID(job2.ID)
+	if !reflect.DeepEqual(js1, out1) {
+		t.Fatalf("bad: \n%#v\n%#v", js1, job1)
+	}
+	if !reflect.DeepEqual(js2, out2) {
+		t.Fatalf("bad: \n%#v\n%#v", js2, job2)
+	}
+}

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -125,7 +125,7 @@ func jobTableSchema() *memdb.TableSchema {
 // jobSummarySchema returns the memdb schema for the job summary table
 func jobSummarySchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: "jobsummary",
+		Name: "job_summary",
 		Indexes: map[string]*memdb.IndexSchema{
 			"id": &memdb.IndexSchema{
 				Name:         "id",

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -19,6 +19,7 @@ func stateStoreSchema() *memdb.DBSchema {
 		indexTableSchema,
 		nodeTableSchema,
 		jobTableSchema,
+		jobSummarySchema,
 		periodicLaunchTableSchema,
 		evalTableSchema,
 		allocTableSchema,
@@ -115,6 +116,24 @@ func jobTableSchema() *memdb.TableSchema {
 				Unique:       false,
 				Indexer: &memdb.ConditionalIndex{
 					Conditional: jobIsPeriodic,
+				},
+			},
+		},
+	}
+}
+
+// jobSummarySchema returns the memdb schema for the job summary table
+func jobSummarySchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "jobsummary",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": &memdb.IndexSchema{
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field:     "ID",
+					Lowercase: true,
 				},
 			},
 		},

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -132,7 +132,7 @@ func jobSummarySchema() *memdb.TableSchema {
 				AllowMissing: false,
 				Unique:       true,
 				Indexer: &memdb.StringFieldIndex{
-					Field:     "ID",
+					Field:     "JobID",
 					Lowercase: true,
 				},
 			},

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -480,7 +480,7 @@ func (s *StateStore) JobSummaryByID(jobID string) (*structs.JobSummary, error) {
 	return nil, nil
 }
 
-// JobSummaries walks the entire job summary table and retuns all the job
+// JobSummaries walks the entire job summary table and returns all the job
 // summary objects
 func (s *StateStore) JobSummaries() (memdb.ResultIterator, error) {
 	txn := s.db.Txn(false)
@@ -776,7 +776,7 @@ func (s *StateStore) Evals() (memdb.ResultIterator, error) {
 	return iter, nil
 }
 
-// UStarting pdateAllocFromClient is used to update an allocation based on input
+// UpdateAllocsFromClient is used to update an allocation based on input
 
 // from a client. While the schedulers are the authority on the allocation for
 // most things, some updates are authoritative from the client. Specifically,
@@ -1280,7 +1280,7 @@ func (s *StateStore) updateSummaryWithAlloc(newAlloc *structs.Allocation,
 			s.logger.Printf("[WARN]: new allocation inserted into state store with id: %v and state: %v", newAlloc.ClientStatus)
 		}
 	} else if existingAlloc.ClientStatus != newAlloc.ClientStatus {
-		// Incrementing the clint of the bin of the current state
+		// Incrementing the client of the bin of the current state
 		switch newAlloc.ClientStatus {
 		case structs.AllocClientStatusRunning:
 			tgSummary.Running += 1

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -492,6 +492,18 @@ func (s *StateStore) JobSummaries() (memdb.ResultIterator, error) {
 	return iter, nil
 }
 
+// JobSummaryByPrefix is used to look up Job Summary by id prefix
+func (s *StateStore) JobSummaryByPrefix(id string) (memdb.ResultIterator, error) {
+	txn := s.db.Txn(false)
+
+	iter, err := txn.Get("jobsummary", "id_prefix", id)
+	if err != nil {
+		return nil, fmt.Errorf("eval lookup failed: %v", err)
+	}
+
+	return iter, nil
+}
+
 // UpsertPeriodicLaunch is used to register a launch or update it.
 func (s *StateStore) UpsertPeriodicLaunch(index uint64, launch *structs.PeriodicLaunch) error {
 	txn := s.db.Txn(true)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -764,7 +764,8 @@ func (s *StateStore) Evals() (memdb.ResultIterator, error) {
 	return iter, nil
 }
 
-// UpdateAllocFromClient is used to update an allocation based on input
+// UStarting pdateAllocFromClient is used to update an allocation based on input
+
 // from a client. While the schedulers are the authority on the allocation for
 // most things, some updates are authoritative from the client. Specifically,
 // the desired state comes from the schedulers, while the actual state comes
@@ -1272,7 +1273,9 @@ func (s *StateStore) updateSummaryWithAlloc(newAlloc *structs.Allocation,
 		case structs.AllocClientStatusRunning:
 			tgSummary.Running += 1
 		}
-		tgSummary.Queued -= 1
+		if tgSummary.Queued > 0 {
+			tgSummary.Queued -= 1
+		}
 	} else if existingAlloc.ClientStatus != newAlloc.ClientStatus {
 		// Incrementing the clint of the bin of the current state
 		switch newAlloc.ClientStatus {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -381,7 +381,7 @@ func (s *StateStore) DeleteJob(index uint64, jobID string) error {
 	}
 
 	// Delete the job summary
-	if _, err = txn.DeleteAll("jobsummary", "id", jobID); err != nil {
+	if _, err = txn.DeleteAll("job_summary", "id", jobID); err != nil {
 		return fmt.Errorf("deleing job summary failed: %v", err)
 	}
 
@@ -469,7 +469,7 @@ func (s *StateStore) JobsByGC(gc bool) (memdb.ResultIterator, error) {
 func (s *StateStore) JobSummaryByID(jobID string) (*structs.JobSummary, error) {
 	txn := s.db.Txn(false)
 
-	existing, err := txn.First("jobsummary", "id", jobID)
+	existing, err := txn.First("job_summary", "id", jobID)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +485,7 @@ func (s *StateStore) JobSummaryByID(jobID string) (*structs.JobSummary, error) {
 func (s *StateStore) JobSummaries() (memdb.ResultIterator, error) {
 	txn := s.db.Txn(false)
 
-	iter, err := txn.Get("jobsummary", "id")
+	iter, err := txn.Get("job_summary", "id")
 	if err != nil {
 		return nil, err
 	}
@@ -496,7 +496,7 @@ func (s *StateStore) JobSummaries() (memdb.ResultIterator, error) {
 func (s *StateStore) JobSummaryByPrefix(id string) (memdb.ResultIterator, error) {
 	txn := s.db.Txn(false)
 
-	iter, err := txn.Get("jobsummary", "id_prefix", id)
+	iter, err := txn.Get("job_summary", "id_prefix", id)
 	if err != nil {
 		return nil, fmt.Errorf("eval lookup failed: %v", err)
 	}
@@ -1242,7 +1242,7 @@ func (s *StateStore) updateSummaryWithJob(job *structs.Job, txn *memdb.Txn) erro
 		}
 	}
 
-	if err := txn.Insert("jobsummary", existing); err != nil {
+	if err := txn.Insert("job_summary", existing); err != nil {
 		return err
 	}
 	return nil
@@ -1319,7 +1319,7 @@ func (s *StateStore) updateSummaryWithAlloc(newAlloc *structs.Allocation,
 	}
 
 	existing.Summary[newAlloc.TaskGroup] = tgSummary
-	if err := txn.Insert("jobsummary", existing); err != nil {
+	if err := txn.Insert("job_summary", existing); err != nil {
 		return fmt.Errorf("inserting job summary failed: %v", err)
 	}
 	return nil
@@ -1413,7 +1413,7 @@ func (r *StateRestore) PeriodicLaunchRestore(launch *structs.PeriodicLaunch) err
 
 // JobSummaryRestore is used to restore a job summary
 func (r *StateRestore) JobSummaryRestore(jobSummary *structs.JobSummary) error {
-	if err := r.txn.Insert("jobsummary", jobSummary); err != nil {
+	if err := r.txn.Insert("job_summary", jobSummary); err != nil {
 		return fmt.Errorf("job summary insert failed: %v", err)
 	}
 	return nil

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1299,6 +1299,8 @@ func (s *StateStore) updateSummaryWithAlloc(newAlloc *structs.Allocation,
 			tgSummary.Starting += 1
 		case structs.AllocClientStatusComplete:
 			tgSummary.Complete += 1
+		case structs.AllocClientStatusLost:
+			tgSummary.Lost += 1
 		}
 
 		// Decrementing the count of the bin of the last state
@@ -1311,21 +1313,8 @@ func (s *StateStore) updateSummaryWithAlloc(newAlloc *structs.Allocation,
 			tgSummary.Starting -= 1
 		case structs.AllocClientStatusComplete:
 			tgSummary.Complete -= 1
-		}
-	} else if existingAlloc.DesiredStatus != newAlloc.DesiredStatus {
-		shouldDecrementStarting := false
-		switch newAlloc.DesiredStatus {
-		case structs.AllocDesiredStatusFailed:
-			tgSummary.Failed += 1
-			shouldDecrementStarting = true
-		case structs.AllocDesiredStatusStop:
-			tgSummary.Complete += 1
-			shouldDecrementStarting = true
-		}
-		if shouldDecrementStarting {
-			if newAlloc.ClientStatus == structs.AllocClientStatusPending {
-				tgSummary.Starting -= 1
-			}
+		case structs.AllocClientStatusLost:
+			tgSummary.Lost -= 1
 		}
 	}
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1205,7 +1205,6 @@ func (s *StateStore) updateSummaryWithJob(job *structs.Job, txn *memdb.Txn) erro
 	for _, tg := range job.TaskGroups {
 		if summary, ok := existing.Summary[tg.Name]; !ok {
 			newSummary := structs.TaskGroupSummary{
-				Name:     tg.Name,
 				Queued:   tg.Count,
 				Complete: 0,
 				Failed:   0,
@@ -1216,6 +1215,8 @@ func (s *StateStore) updateSummaryWithJob(job *structs.Job, txn *memdb.Txn) erro
 		} else {
 			if summary.Queued > tg.Count {
 				summary.Queued = tg.Count
+			} else {
+				summary.Queued += tg.Count - (summary.Total())
 			}
 			existing.Summary[tg.Name] = summary
 		}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2369,12 +2369,14 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 	alloc4.Job = alloc2.Job
 	alloc4.JobID = alloc2.JobID
 	alloc4.DesiredStatus = structs.AllocDesiredStatusStop
+	alloc4.ClientStatus = structs.AllocClientStatusComplete
 
 	alloc5 := mock.Alloc()
 	alloc5.ID = alloc3.ID
 	alloc5.Job = alloc3.Job
 	alloc5.JobID = alloc3.JobID
 	alloc5.DesiredStatus = structs.AllocDesiredStatusStop
+	alloc5.ClientStatus = structs.AllocClientStatusComplete
 
 	if err := state.UpsertAllocs(1004, []*structs.Allocation{alloc4, alloc5}); err != nil {
 		t.Fatalf("err: %v", err)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -402,12 +402,9 @@ func TestStateStore_UpsertJob_Job(t *testing.T) {
 	if summary.JobID != job.ID {
 		t.Fatalf("bad summary id: %v", summary.JobID)
 	}
-	webTgSummary, ok := summary.Summary["web"]
+	_, ok := summary.Summary["web"]
 	if !ok {
 		t.Fatalf("nil summary for task group")
-	}
-	if webTgSummary.Queued != 10 {
-		t.Fatalf("wrong summary: %#v", webTgSummary)
 	}
 	notify.verify(t)
 }
@@ -469,12 +466,9 @@ func TestStateStore_UpdateUpsertJob_Job(t *testing.T) {
 	if summary.JobID != job.ID {
 		t.Fatalf("bad summary id: %v", summary.JobID)
 	}
-	webTgSummary, ok := summary.Summary["web"]
+	_, ok := summary.Summary["web"]
 	if !ok {
 		t.Fatalf("nil summary for task group")
-	}
-	if webTgSummary.Queued != 10 {
-		t.Fatalf("wrong summary: %#v", webTgSummary)
 	}
 
 	notify.verify(t)
@@ -1083,7 +1077,7 @@ func TestStateStore_RestoreJobSummary(t *testing.T) {
 		JobID: job.ID,
 		Summary: map[string]structs.TaskGroupSummary{
 			"web": structs.TaskGroupSummary{
-				Queued: 10,
+				Starting: 10,
 			},
 		},
 	}
@@ -1623,9 +1617,6 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 	if tgSummary.Failed != 1 {
 		t.Fatalf("expected failed: %v, actual: %v, summary: %#v", 1, tgSummary.Failed, tgSummary)
 	}
-	if tgSummary.Queued != 9 {
-		t.Fatalf("expected queued: %v, actual: %v", 9, tgSummary.Running)
-	}
 
 	summary2, err := state.JobSummaryByID(alloc2.JobID)
 	if err != nil {
@@ -1634,9 +1625,6 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 	tgSummary2 := summary2.Summary["web"]
 	if tgSummary2.Running != 1 {
 		t.Fatalf("expected running: %v, actual: %v", 1, tgSummary2.Failed)
-	}
-	if tgSummary2.Queued != 9 {
-		t.Fatalf("expected queued: %v, actual: %v", 9, tgSummary2.Running)
 	}
 
 	notify.verify(t)
@@ -1689,9 +1677,6 @@ func TestStateStore_UpsertAlloc_Alloc(t *testing.T) {
 	if !ok {
 		t.Fatalf("no summary for task group web")
 	}
-	if tgSummary.Queued != 9 {
-		t.Fatalf("expected queued: %v, actual: %v", 9, tgSummary.Queued)
-	}
 	if tgSummary.Starting != 1 {
 		t.Fatalf("expected queued: %v, actual: %v", 1, tgSummary.Starting)
 	}
@@ -1719,9 +1704,6 @@ func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 	tgSummary := summary.Summary["web"]
 	if tgSummary.Starting != 1 {
 		t.Fatalf("expected starting: %v, actual: %v", 1, tgSummary.Starting)
-	}
-	if tgSummary.Queued != 9 {
-		t.Fatalf("expected starting: %v, actual: %v", 9, tgSummary.Queued)
 	}
 
 	alloc2 := mock.Alloc()
@@ -1773,9 +1755,6 @@ func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 	tgSummary = summary.Summary["web"]
 	if tgSummary.Starting != 1 {
 		t.Fatalf("expected starting: %v, actual: %v", 1, tgSummary.Starting)
-	}
-	if tgSummary.Queued != 9 {
-		t.Fatalf("expected starting: %v, actual: %v", 9, tgSummary.Queued)
 	}
 
 	notify.verify(t)
@@ -2338,7 +2317,7 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	summary, _ := state.JobSummaryByID(job.ID)
-	if summary.Summary["web"].Queued != 2 && summary.Summary["web"].Starting != 1 {
+	if summary.Summary["web"].Starting != 1 {
 		t.Fatalf("bad job summary: %v", summary)
 	}
 
@@ -2427,7 +2406,7 @@ func TestJobSummary_UpdateClientStatus(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	summary, _ := state.JobSummaryByID(job.ID)
-	if summary.Summary["web"].Queued != 0 || summary.Summary["web"].Starting != 3 {
+	if summary.Summary["web"].Starting != 3 {
 		t.Fatalf("bad job summary: %v", summary)
 	}
 
@@ -2453,7 +2432,7 @@ func TestJobSummary_UpdateClientStatus(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	summary, _ = state.JobSummaryByID(job.ID)
-	if summary.Summary["web"].Queued != 0 || summary.Summary["web"].Running != 1 || summary.Summary["web"].Failed != 1 || summary.Summary["web"].Complete != 1 {
+	if summary.Summary["web"].Running != 1 || summary.Summary["web"].Failed != 1 || summary.Summary["web"].Complete != 1 {
 		t.Fatalf("bad job summary: %v", summary)
 	}
 
@@ -2465,7 +2444,7 @@ func TestJobSummary_UpdateClientStatus(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	summary, _ = state.JobSummaryByID(job.ID)
-	if summary.Summary["web"].Queued != 0 || summary.Summary["web"].Starting != 1 || summary.Summary["web"].Running != 1 || summary.Summary["web"].Failed != 1 || summary.Summary["web"].Complete != 1 {
+	if summary.Summary["web"].Starting != 1 || summary.Summary["web"].Running != 1 || summary.Summary["web"].Failed != 1 || summary.Summary["web"].Complete != 1 {
 		t.Fatalf("bad job summary: %v", summary)
 	}
 }

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2360,8 +2360,16 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	summary, _ = state.JobSummaryByID(job.ID)
-	if summary.Summary["web"].Queued != 0 || summary.Summary["web"].Starting != 3 {
-		t.Fatalf("bad job summary: %v", summary)
+	expectedSummary := structs.JobSummary{
+		JobID: job.ID,
+		Summary: map[string]structs.TaskGroupSummary{
+			"web": {
+				Starting: 3,
+			},
+		},
+	}
+	if !reflect.DeepEqual(summary, &expectedSummary) {
+		t.Fatalf("expected summary: %v, actual: %v", expectedSummary, summary)
 	}
 
 	alloc4 := mock.Alloc()
@@ -2382,8 +2390,17 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	summary, _ = state.JobSummaryByID(job.ID)
-	if summary.Summary["web"].Queued != 0 || summary.Summary["web"].Starting != 1 || summary.Summary["web"].Complete != 2 {
-		t.Fatalf("bad job summary: %v", summary)
+	expectedSummary = structs.JobSummary{
+		JobID: job.ID,
+		Summary: map[string]structs.TaskGroupSummary{
+			"web": {
+				Complete: 2,
+				Starting: 1,
+			},
+		},
+	}
+	if !reflect.DeepEqual(summary, &expectedSummary) {
+		t.Fatalf("expected: %v, actual: %v", expectedSummary, summary)
 	}
 }
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -458,6 +458,26 @@ func TestStateStore_UpdateUpsertJob_Job(t *testing.T) {
 		t.Fatalf("bad: %d", index)
 	}
 
+	// Test that the job summary remains the same if the job is updated but
+	// count remains same
+	summary, err := state.JobSummary(job.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if summary == nil {
+		t.Fatalf("nil summary")
+	}
+	if summary.JobID != job.ID {
+		t.Fatalf("bad summary id: %v", summary.JobID)
+	}
+	webTgSummary, ok := summary.Summary["web"]
+	if !ok {
+		t.Fatalf("nil summary for task group")
+	}
+	if webTgSummary.Queued != 10 {
+		t.Fatalf("wrong summary: %#v", webTgSummary)
+	}
+
 	notify.verify(t)
 }
 
@@ -495,6 +515,14 @@ func TestStateStore_DeleteJob_Job(t *testing.T) {
 	}
 	if index != 1001 {
 		t.Fatalf("bad: %d", index)
+	}
+
+	summary, err := state.JobSummary(job.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("expected summary to be nil, but got: %v", summary)
 	}
 
 	notify.verify(t)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -1076,6 +1076,38 @@ func TestStateStore_RestorePeriodicLaunch(t *testing.T) {
 	notify.verify(t)
 }
 
+func TestStateStore_RestoreJobSummary(t *testing.T) {
+	state := testStateStore(t)
+	job := mock.Job()
+	jobSummary := &structs.JobSummary{
+		JobID: job.ID,
+		Summary: map[string]structs.TaskGroupSummary{
+			"web": structs.TaskGroupSummary{
+				Queued: 10,
+			},
+		},
+	}
+	restore, err := state.Restore()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	err = restore.JobSummaryRestore(jobSummary)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	restore.Commit()
+
+	out, err := state.JobSummaryByID(job.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if !reflect.DeepEqual(out, jobSummary) {
+		t.Fatalf("Bad: %#v %#v", out, jobSummary)
+	}
+}
+
 func TestStateStore_Indexes(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -392,7 +392,7 @@ func TestStateStore_UpsertJob_Job(t *testing.T) {
 		t.Fatalf("bad: %d", index)
 	}
 
-	summary, err := state.JobSummary(job.ID)
+	summary, err := state.JobSummaryByID(job.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -459,7 +459,7 @@ func TestStateStore_UpdateUpsertJob_Job(t *testing.T) {
 
 	// Test that the job summary remains the same if the job is updated but
 	// count remains same
-	summary, err := state.JobSummary(job.ID)
+	summary, err := state.JobSummaryByID(job.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestStateStore_DeleteJob_Job(t *testing.T) {
 		t.Fatalf("bad: %d", index)
 	}
 
-	summary, err := state.JobSummary(job.ID)
+	summary, err := state.JobSummaryByID(job.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1583,7 +1583,7 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 	}
 
 	// Ensure summaries have been updated
-	summary, err := state.JobSummary(alloc.JobID)
+	summary, err := state.JobSummaryByID(alloc.JobID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1595,7 +1595,7 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 		t.Fatalf("expected queued: %v, actual: %v", 9, tgSummary.Running)
 	}
 
-	summary2, err := state.JobSummary(alloc2.JobID)
+	summary2, err := state.JobSummaryByID(alloc2.JobID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1648,7 +1648,7 @@ func TestStateStore_UpsertAlloc_Alloc(t *testing.T) {
 		t.Fatalf("bad: %d", index)
 	}
 
-	summary, err := state.JobSummary(alloc.JobID)
+	summary, err := state.JobSummaryByID(alloc.JobID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1680,7 +1680,7 @@ func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	summary, err := state.JobSummary(alloc.JobID)
+	summary, err := state.JobSummaryByID(alloc.JobID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1734,7 +1734,7 @@ func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 	}
 
 	// Ensure that summary hasb't changed
-	summary, err = state.JobSummary(alloc.JobID)
+	summary, err = state.JobSummaryByID(alloc.JobID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	//	"fmt"
 	"os"
 	"reflect"
 	"sort"
@@ -392,6 +393,23 @@ func TestStateStore_UpsertJob_Job(t *testing.T) {
 		t.Fatalf("bad: %d", index)
 	}
 
+	summary, err := state.JobSummary(job.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if summary == nil {
+		t.Fatalf("nil summary")
+	}
+	if summary.JobID != job.ID {
+		t.Fatalf("bad summary id: %v", summary.JobID)
+	}
+	webTgSummary, ok := summary.Summary["web"]
+	if !ok {
+		t.Fatalf("nil summary for task group")
+	}
+	if webTgSummary.Queued != 10 {
+		t.Fatalf("wrong summary: %#v", webTgSummary)
+	}
 	notify.verify(t)
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -955,6 +955,7 @@ type TaskGroupSummary struct {
 	Failed   int
 	Running  int
 	Starting int
+	Lost     int
 }
 
 // Total returns the total number of allocations for the task group.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -950,17 +950,11 @@ type JobSummary struct {
 // TaskGroup summarizes the state of all the allocations of a particular
 // TaskGroup
 type TaskGroupSummary struct {
-	Queued   int
 	Complete int
 	Failed   int
 	Running  int
 	Starting int
 	Lost     int
-}
-
-// Total returns the total number of allocations for the task group.
-func (s *TaskGroupSummary) Total() int {
-	return s.Queued + s.Complete + s.Failed + s.Running + s.Starting
 }
 
 // Job is the scope of a scheduling request to Nomad. It is the largest
@@ -2323,10 +2317,9 @@ func (c *Constraint) Validate() error {
 }
 
 const (
-	AllocDesiredStatusRun    = "run"    // Allocation should run
-	AllocDesiredStatusStop   = "stop"   // Allocation should stop
-	AllocDesiredStatusEvict  = "evict"  // Allocation should stop, and was evicted
-	AllocDesiredStatusFailed = "failed" // Allocation failed to be done
+	AllocDesiredStatusRun   = "run"   // Allocation should run
+	AllocDesiredStatusStop  = "stop"  // Allocation should stop
+	AllocDesiredStatusEvict = "evict" // Allocation should stop, and was evicted
 )
 
 const (
@@ -2435,7 +2428,7 @@ func (a *Allocation) TerminalStatus() bool {
 	// First check the desired state and if that isn't terminal, check client
 	// state.
 	switch a.DesiredStatus {
-	case AllocDesiredStatusStop, AllocDesiredStatusEvict, AllocDesiredStatusFailed:
+	case AllocDesiredStatusStop, AllocDesiredStatusEvict:
 		return true
 	default:
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -345,10 +345,6 @@ type PeriodicForceRequest struct {
 	WriteRequest
 }
 
-type ServerMembersRequest struct {
-	QueryOptions
-}
-
 // GenericRequest is used to request where no
 // specific information is needed.
 type GenericRequest struct {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -957,6 +957,11 @@ type TaskGroupSummary struct {
 	Starting int
 }
 
+// Total returns the total number of allocations for the task group.
+func (s *TaskGroupSummary) Total() int {
+	return s.Queued + s.Complete + s.Failed + s.Running + s.Starting
+}
+
 // Job is the scope of a scheduling request to Nomad. It is the largest
 // scoped object, and is a named collection of task groups. Each task group
 // is further composed of tasks. A task group (TG) is the unit of scheduling

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -937,6 +937,20 @@ const (
 	CoreJobPriority = JobMaxPriority * 2
 )
 
+type JobSummary struct {
+	JobID   string
+	Summary map[string]TaskGroupSummary
+}
+
+type TaskGroupSummary struct {
+	Name     string
+	Queued   int
+	Complete int
+	Failed   int
+	Running  int
+	Starting int
+}
+
 // Job is the scope of a scheduling request to Nomad. It is the largest
 // scoped object, and is a named collection of task groups. Each task group
 // is further composed of tasks. A task group (TG) is the unit of scheduling

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -345,6 +345,10 @@ type PeriodicForceRequest struct {
 	WriteRequest
 }
 
+type ServerMembersRequest struct {
+	QueryOptions
+}
+
 // GenericRequest is used to request where no
 // specific information is needed.
 type GenericRequest struct {
@@ -937,13 +941,15 @@ const (
 	CoreJobPriority = JobMaxPriority * 2
 )
 
+// JobSummary summarizes the state of the allocations of a job
 type JobSummary struct {
 	JobID   string
 	Summary map[string]TaskGroupSummary
 }
 
+// TaskGroup summarizes the state of all the allocations of a particular
+// TaskGroup
 type TaskGroupSummary struct {
-	Name     string
 	Queued   int
 	Complete int
 	Failed   int

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -273,7 +273,7 @@ func (s *GenericScheduler) filterCompleteAllocs(allocs []*structs.Allocation) []
 			// status is failed so that they will be replaced. If they are
 			// complete but not failed, they shouldn't be replaced.
 			switch a.DesiredStatus {
-			case structs.AllocDesiredStatusStop, structs.AllocDesiredStatusEvict, structs.AllocDesiredStatusFailed:
+			case structs.AllocDesiredStatusStop, structs.AllocDesiredStatusEvict:
 				return !a.RanSuccessfully()
 			default:
 			}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -644,7 +644,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = nodes[i].ID
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
-		alloc.DesiredStatus = structs.AllocDesiredStatusFailed
+		alloc.DesiredStatus = structs.AllocDesiredStatusStop
 		terminal = append(terminal, alloc)
 	}
 	noErr(t, h.State.UpsertAllocs(h.NextIndex(), terminal))
@@ -833,7 +833,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = nodes[i].ID
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
-		alloc.DesiredStatus = structs.AllocDesiredStatusFailed
+		alloc.DesiredStatus = structs.AllocDesiredStatusStop
 		terminal = append(terminal, alloc)
 	}
 	noErr(t, h.State.UpsertAllocs(h.NextIndex(), terminal))

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -304,7 +304,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = nodes[i].ID
 		alloc.Name = "my-job.web[0]"
-		alloc.DesiredStatus = structs.AllocDesiredStatusFailed
+		alloc.DesiredStatus = structs.AllocDesiredStatusStop
 		terminal = append(terminal, alloc)
 	}
 	noErr(t, h.State.UpsertAllocs(h.NextIndex(), terminal))


### PR DESCRIPTION
This PR introduces the job summary table in the state store and updates the summary when jobs and allocations are inserted/updated/deleted.

Subsequent PRs would introduce the API and CLI support for the same.

This PR doesn't account for number of pending allocations, will come in a followup PR.