### PR TITLE
update docs to use the new hostname attribute

### DIFF
--- a/website/source/docs/jobspec/interpreted.html.md
+++ b/website/source/docs/jobspec/interpreted.html.md
@@ -123,7 +123,7 @@ Below is a table documenting common node attributes:
     <td>See the [task drivers](/docs/drivers/index.html) for attribute documentation</td>
   </tr>
   <tr>
-    <td>hostname</td>
+    <td>unique.hostname</td>
     <td>Hostname of the client</td>
   </tr>
   <tr>


### PR DESCRIPTION
`hostname` changed to `unique.hostname` in this commit: https://github.com/hashicorp/nomad/commit/d87d988491c118bf29e627638c41eeef74c35dd7