### PR TITLE
Remove xargs(1) from testing and rely on `go test -v`.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,4 +10,4 @@ go build -o $TEMPDIR/nomad || exit 1
 
 # Run the tests
 echo "--> Running tests"
-go list ./... | grep -v '/vendor/' | sudo -E PATH=$TEMPDIR:$PATH xargs -n1 go test ${GOTEST_FLAGS:--cover -timeout=900s}
+go list ./... | grep -v '/vendor/' | sudo -E PATH=$TEMPDIR:$PATH go test ${GOTEST_FLAGS:--cover -timeout=900s -v}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,4 +15,4 @@ go list ./... | grep -v '/vendor/' | \
     sudo \
         -E PATH=$TEMPDIR:$PATH \
         -E GOPATH=$GOPATH \
-        $GOBIN test ${GOTEST_FLAGS:--cover -timeout=900s -v}
+        xargs $GOBIN test ${GOTEST_FLAGS:--cover -timeout=900s}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,9 +10,9 @@ go build -o $TEMPDIR/nomad || exit 1
 
 # Run the tests
 echo "--> Running tests"
-printf "go(1) path: %s\n" "`which go`"
+GOBIN="`which go`"
 go list ./... | grep -v '/vendor/' | \
     sudo \
         -E PATH=$TEMPDIR:$PATH \
         -E GOPATH=$GOPATH \
-        go test ${GOTEST_FLAGS:--cover -timeout=900s -v}
+        $GOBIN test ${GOTEST_FLAGS:--cover -timeout=900s -v}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,4 +10,9 @@ go build -o $TEMPDIR/nomad || exit 1
 
 # Run the tests
 echo "--> Running tests"
-go list ./... | grep -v '/vendor/' | sudo -E PATH=$TEMPDIR:$PATH go test ${GOTEST_FLAGS:--cover -timeout=900s -v}
+printf "go(1) path: %s\n" "`which go`"
+go list ./... | grep -v '/vendor/' | \
+    sudo \
+        -E PATH=$TEMPDIR:$PATH \
+        -E GOPATH=$GOPATH \
+        go test ${GOTEST_FLAGS:--cover -timeout=900s -v}


### PR DESCRIPTION
Tests are approaching 30min largely due to recompiling every package.
Out of a ~30min build, only ~5min are actually spent running the tests,
the remaining time is spent recompiling.