### PR TITLE
Replace `Operator` with `Operand`

### DIFF
--- a/website/source/docs/jobspec/json.html.md
+++ b/website/source/docs/jobspec/json.html.md
@@ -433,8 +433,8 @@ The `Constraint` object supports the following keys:
   This can be a literal value, another attribute or a regular expression if
   the `Operator` is in "regexp" mode.
 
-*   `Operator` - `Operator` if omitted defaults to `==` and an take on the
-    following values:
+* `Operand` - Specifies the test to be performed on the two targets. It takes on the
+  following values:
   
   * `regexp` - Allows the `RTarget` to be a regular expression to be matched.
 


### PR DESCRIPTION
* while HCL job-spec uses `operator`, JSON uses `Operand`
* `Operand` is required, it no longer defaults to `==`
  (@see nomad/structs/structs.go#L2297)

BTW, I think `Test` may actually be a better term for this than `Operand`. At the least, it really should be `Operator`, like HCL, instead of `Operand`. But that is a code fix instead of documentation.