### PR TITLE
Remove unrelated code snippet from docs

### DIFF
--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -305,10 +305,6 @@ options](/docs/agent/config.html#options):
   set to `host`, which gives access to the hosts ipc, pid and UTS namespaces
   respectively.  
 
-    cert := d.config.Read("docker.tls.cert")
-    key := d.config.Read("docker.tls.key")
-    ca := d.config.Read("docker.tls.ca")
-
 Note: When testing or using the `-dev` flag you can use `DOCKER_HOST`,
 `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` to customize Nomad's behavior. If
 `docker.endpoint` is set Nomad will **only** read client configuration from the

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -43,15 +43,14 @@ The following options are available for use in the job specification.
 
 * `command` - (Optional) The command to run when starting the container.
 
-*   `args` - (Optional) A list of arguments to the optional `command`. If no
-    `command` is present, `args` are ignored. References to environment variables
-    or any [interpretable Nomad
-    variables](/docs/jobspec/interpreted.html) will be interpreted
-    before launching the task. For example:
+* `args` - (Optional) A list of arguments to the optional `command`. If no
+  `command` is present, `args` are ignored. References to environment variables
+  or any [interpretable Nomad variables](/docs/jobspec/interpreted.html) will be
+  interpreted before launching the task. For example:
 
-    ```
-        args = ["${nomad.datacenter}", "${MY_ENV}", "${meta.foo}"]
-    ```
+  ```
+  args = ["${nomad.datacenter}", "${MY_ENV}", "${meta.foo}"]
+  ```
 
 * `labels` - (Optional) A key/value map of labels to set to the containers on
   start.


### PR DESCRIPTION
While at it, fix indent of `args` block.