### PR TITLE
Nomad logs command to stream task logs

### DIFF
--- a/api/fs.go
+++ b/api/fs.go
@@ -279,15 +279,16 @@ func (a *AllocFS) Stream(alloc *Allocation, path, origin string, offset int64,
 // Logs streams the content of a tasks logs blocking on EOF.
 // The parameters are:
 // * allocation: the allocation to stream from.
+// * follow: Whether the logs should be followed.
 // * task: the tasks name to stream logs for.
 // * logType: Either "stdout" or "stderr"
-// * offset: The offset to start streaming data at.
 // * origin: Either "start" or "end" and defines from where the offset is applied.
+// * offset: The offset to start streaming data at.
 // * cancel: A channel that when closed, streaming will end.
 //
 // The return value is a channel that will emit StreamFrames as they are read.
-func (a *AllocFS) Logs(alloc *Allocation, task, logType, origin string, offset int64,
-	cancel <-chan struct{}, q *QueryOptions) (<-chan *StreamFrame, *QueryMeta, error) {
+func (a *AllocFS) Logs(alloc *Allocation, follow bool, task, logType, origin string,
+	offset int64, cancel <-chan struct{}, q *QueryOptions) (<-chan *StreamFrame, *QueryMeta, error) {
 
 	node, _, err := a.client.Nodes().Info(alloc.NodeID, q)
 	if err != nil {
@@ -303,6 +304,7 @@ func (a *AllocFS) Logs(alloc *Allocation, task, logType, origin string, offset i
 		Path:   fmt.Sprintf("/v1/client/fs/logs/%s", alloc.ID),
 	}
 	v := url.Values{}
+	v.Set("follow", strconv.FormatBool(follow))
 	v.Set("task", task)
 	v.Set("type", logType)
 	v.Set("origin", origin)

--- a/api/fs.go
+++ b/api/fs.go
@@ -367,10 +367,6 @@ type FrameReader struct {
 	frame       *StreamFrame
 	frameOffset int
 
-	// To handle printing the file events
-	fileEventOffset int
-	fileEvent       []byte
-
 	byteOffset int
 }
 
@@ -415,23 +411,6 @@ func (f *FrameReader) Read(p []byte) (n int, err error) {
 		case <-unblock:
 			return 0, nil
 		}
-	}
-
-	if f.frame.FileEvent != "" && len(f.fileEvent) == 0 {
-		f.fileEvent = []byte(fmt.Sprintf("\nnomad: %q\n", f.frame.FileEvent))
-		f.fileEventOffset = 0
-	}
-
-	// If there is a file event we inject it into the read stream
-	if l := len(f.fileEvent); l != 0 && l != f.fileEventOffset {
-		n = copy(p, f.fileEvent[f.fileEventOffset:])
-		f.fileEventOffset += n
-		return n, nil
-	}
-
-	if len(f.fileEvent) == f.fileEventOffset {
-		f.fileEvent = nil
-		f.fileEventOffset = 0
 	}
 
 	// Copy the data out of the frame and update our offset

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -546,7 +546,7 @@ func (s *HTTPServer) Stream(resp http.ResponseWriter, req *http.Request) (interf
 	framer.Run()
 	defer framer.Destroy()
 
-	err := s.stream(offset, path, fs, framer, nil)
+	err = s.stream(offset, path, fs, framer, nil)
 	if err != nil && err != syscall.EPIPE {
 		return nil, err
 	}

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -741,7 +741,7 @@ func (s *HTTPServer) logs(offset int64, origin, task, logType string, fs allocdi
 
 		//Since we successfully streamed, update the overall offset/idx.
 		offset = int64(0)
-		idx++
+		nextIdx++
 	}
 
 	return nil

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -742,4 +743,209 @@ func TestHTTP_Stream_Delete(t *testing.T) {
 		})
 
 	})
+}
+
+func TestLogs_findClosest(t *testing.T) {
+	task := "foo"
+	entries := []*allocdir.AllocFileInfo{
+		{
+			Name: "foo.stdout.0",
+			Size: 100,
+		},
+		{
+			Name: "foo.stdout.1",
+			Size: 100,
+		},
+		{
+			Name: "foo.stdout.2",
+			Size: 100,
+		},
+		{
+			Name: "foo.stdout.3",
+			Size: 100,
+		},
+		{
+			Name: "foo.stderr.0",
+			Size: 100,
+		},
+		{
+			Name: "foo.stderr.1",
+			Size: 100,
+		},
+		{
+			Name: "foo.stderr.2",
+			Size: 100,
+		},
+	}
+
+	cases := []struct {
+		Entries        []*allocdir.AllocFileInfo
+		DesiredIdx     int64
+		DesiredOffset  int64
+		Task           string
+		LogType        string
+		ExpectedFile   string
+		ExpectedIdx    int64
+		ExpectedOffset int64
+		Error          bool
+	}{
+		// Test error cases
+		{
+			Entries:    nil,
+			DesiredIdx: 0,
+			Task:       task,
+			LogType:    "stdout",
+			Error:      true,
+		},
+		{
+			Entries:    entries[0:3],
+			DesiredIdx: 0,
+			Task:       task,
+			LogType:    "stderr",
+			Error:      true,
+		},
+
+		// Test begining cases
+		{
+			Entries:      entries,
+			DesiredIdx:   0,
+			Task:         task,
+			LogType:      "stdout",
+			ExpectedFile: entries[0].Name,
+			ExpectedIdx:  0,
+		},
+		{
+			// Desired offset should be ignored at edges
+			Entries:        entries,
+			DesiredIdx:     0,
+			DesiredOffset:  -100,
+			Task:           task,
+			LogType:        "stdout",
+			ExpectedFile:   entries[0].Name,
+			ExpectedIdx:    0,
+			ExpectedOffset: 0,
+		},
+		{
+			// Desired offset should be ignored at edges
+			Entries:        entries,
+			DesiredIdx:     1,
+			DesiredOffset:  -1000,
+			Task:           task,
+			LogType:        "stdout",
+			ExpectedFile:   entries[0].Name,
+			ExpectedIdx:    0,
+			ExpectedOffset: 0,
+		},
+		{
+			Entries:      entries,
+			DesiredIdx:   0,
+			Task:         task,
+			LogType:      "stderr",
+			ExpectedFile: entries[4].Name,
+			ExpectedIdx:  0,
+		},
+		{
+			Entries:      entries,
+			DesiredIdx:   0,
+			Task:         task,
+			LogType:      "stdout",
+			ExpectedFile: entries[0].Name,
+			ExpectedIdx:  0,
+		},
+
+		// Test middle cases
+		{
+			Entries:      entries,
+			DesiredIdx:   1,
+			Task:         task,
+			LogType:      "stdout",
+			ExpectedFile: entries[1].Name,
+			ExpectedIdx:  1,
+		},
+		{
+			Entries:        entries,
+			DesiredIdx:     1,
+			DesiredOffset:  10,
+			Task:           task,
+			LogType:        "stdout",
+			ExpectedFile:   entries[1].Name,
+			ExpectedIdx:    1,
+			ExpectedOffset: 10,
+		},
+		{
+			Entries:        entries,
+			DesiredIdx:     1,
+			DesiredOffset:  110,
+			Task:           task,
+			LogType:        "stdout",
+			ExpectedFile:   entries[2].Name,
+			ExpectedIdx:    2,
+			ExpectedOffset: 10,
+		},
+		{
+			Entries:      entries,
+			DesiredIdx:   1,
+			Task:         task,
+			LogType:      "stderr",
+			ExpectedFile: entries[5].Name,
+			ExpectedIdx:  1,
+		},
+		// Test end cases
+		{
+			Entries:      entries,
+			DesiredIdx:   math.MaxInt64,
+			Task:         task,
+			LogType:      "stdout",
+			ExpectedFile: entries[3].Name,
+			ExpectedIdx:  3,
+		},
+		{
+			Entries:        entries,
+			DesiredIdx:     math.MaxInt64,
+			DesiredOffset:  math.MaxInt64,
+			Task:           task,
+			LogType:        "stdout",
+			ExpectedFile:   entries[3].Name,
+			ExpectedIdx:    3,
+			ExpectedOffset: 100,
+		},
+		{
+			Entries:        entries,
+			DesiredIdx:     math.MaxInt64,
+			DesiredOffset:  -10,
+			Task:           task,
+			LogType:        "stdout",
+			ExpectedFile:   entries[3].Name,
+			ExpectedIdx:    3,
+			ExpectedOffset: 90,
+		},
+		{
+			Entries:      entries,
+			DesiredIdx:   math.MaxInt64,
+			Task:         task,
+			LogType:      "stderr",
+			ExpectedFile: entries[6].Name,
+			ExpectedIdx:  2,
+		},
+	}
+
+	for i, c := range cases {
+		entry, idx, offset, err := findClosest(c.Entries, c.DesiredIdx, c.DesiredOffset, c.Task, c.LogType)
+		if err != nil {
+			if !c.Error {
+				t.Fatalf("case %d: Unexpected error: %v", i, err)
+			}
+			continue
+		}
+
+		if entry.Name != c.ExpectedFile {
+			t.Fatalf("case %d: Got file %q; want %q", i, entry.Name, c.ExpectedFile)
+		}
+		if idx != c.ExpectedIdx {
+			t.Fatalf("case %d: Got index %d; want %d", i, idx, c.ExpectedIdx)
+		}
+		if offset != c.ExpectedOffset {
+			t.Fatalf("case %d: Got offset %d; want %d", i, offset, c.ExpectedOffset)
+		}
+	}
 }

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -901,7 +900,7 @@ func TestHTTP_Logs_Follow(t *testing.T) {
 
 		// Start streaming logs
 		go func() {
-			if err := s.Server.logs(true, 0, OriginStart, task, logType, ad, wrappedW); err != nil && err != syscall.EPIPE {
+			if err := s.Server.logs(true, 0, OriginStart, task, logType, ad, wrappedW); err != nil {
 				t.Fatalf("logs() failed: %v", err)
 			}
 		}()
@@ -912,9 +911,11 @@ func TestHTTP_Logs_Follow(t *testing.T) {
 			t.Fatalf("did not receive data: got %q", string(received))
 		}
 
-		// We got the first chunk of data, write out the rest to the file to
-		// check that it is following
-		writeToFile(initialWrites, expected[initialWrites:])
+		// We got the first chunk of data, write out the rest to the next file
+		// at an index much ahead to check that it is following and detecting
+		// skips
+		skipTo := initialWrites + 10
+		writeToFile(skipTo, expected[initialWrites:])
 
 		select {
 		case <-fullResultCh:
@@ -930,7 +931,6 @@ func TestHTTP_Logs_Follow(t *testing.T) {
 		}, func(err error) {
 			t.Fatalf("connection not closed")
 		})
-
 	})
 }
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -60,7 +60,7 @@ func NewHTTPServer(agent *Agent, config *Config, logOutput io.Writer) (*HTTPServ
 		agent:    agent,
 		mux:      mux,
 		listener: ln,
-		logger:   log.New(logOutput, "", log.LstdFlags),
+		logger:   agent.logger,
 		addr:     ln.Addr().String(),
 	}
 	srv.registerHandlers(config.EnableDebug)

--- a/command/fs.go
+++ b/command/fs.go
@@ -50,7 +50,7 @@ FS Specific Options:
     Show full information.
 
   -job <job-id>
-    Use a random allocation from a specified job-id.
+    Use a random allocation from the specified job ID.
 
   -stat
     Show file stat information instead of displaying the file, or listing the directory.

--- a/command/fs.go
+++ b/command/fs.go
@@ -81,7 +81,7 @@ func (f *FSCommand) Run(args []string) int {
 	var verbose, machine, job, stat, tail, follow bool
 	var numLines, numBytes int64
 
-	flags := f.Meta.FlagSet("fs-list", FlagSetClient)
+	flags := f.Meta.FlagSet("fs", FlagSetClient)
 	flags.Usage = func() { f.Ui.Output(f.Help()) }
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.BoolVar(&machine, "H", false, "")
@@ -175,14 +175,6 @@ func (f *FSCommand) Run(args []string) int {
 	if err != nil {
 		f.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1
-	}
-
-	if alloc.DesiredStatus == "failed" {
-		allocID := limit(alloc.ID, length)
-		msg := fmt.Sprintf(`The allocation %q failed to be placed. To see the cause, run:
-nomad alloc-status %s`, allocID, allocID)
-		f.Ui.Error(msg)
-		return 0
 	}
 
 	// Get file stat info

--- a/command/fs.go
+++ b/command/fs.go
@@ -282,7 +282,7 @@ func (f *FSCommand) Run(args []string) int {
 
 			// If numLines is set, wrap the reader
 			if numLines != -1 {
-				r = NewLineLimitReader(r, int(numLines), int(numLines*bytesToLines))
+				r = NewLineLimitReader(r, int(numLines), int(numLines*bytesToLines), 0)
 			}
 		}
 
@@ -321,7 +321,7 @@ func (f *FSCommand) followFile(client *api.Client, alloc *api.Allocation,
 
 	// If numLines is set, wrap the reader
 	if numLines != -1 {
-		r = NewLineLimitReader(r, int(numLines), int(numLines*bytesToLines))
+		r = NewLineLimitReader(r, int(numLines), int(numLines*bytesToLines), 0)
 	}
 
 	go func() {

--- a/command/fs.go
+++ b/command/fs.go
@@ -329,9 +329,6 @@ func (f *FSCommand) followFile(client *api.Client, alloc *api.Allocation,
 
 		// End the streaming
 		r.Close()
-
-		// Output the last offset
-		f.Ui.Output(fmt.Sprintf("\nLast outputted offset (bytes): %d", frameReader.Offset()))
 	}()
 
 	return r, nil

--- a/command/fs.go
+++ b/command/fs.go
@@ -60,12 +60,12 @@ FS Specific Options:
 	rather to wait for additional output. 
 
   -tail 
-	Show the files contents with offsets relative to the end of the file. If no
-	offset is given, -n is defaulted to 10.
+    Show the files contents with offsets relative to the end of the file. If no
+    offset is given, -n is defaulted to 10.
 
   -n
-	Sets the tail location in best-efforted number of lines relative to the end
-	of the file.
+    Sets the tail location in best-efforted number of lines relative to the end
+    of the file.
 
   -c
 	Sets the tail location in number of bytes relative to the end of the file.

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -105,17 +105,26 @@ type LineLimitReader struct {
 	lines       int
 	searchLimit int
 
+	timeLimit time.Duration
+	lastRead  time.Time
+
 	buffer     *bytes.Buffer
 	bufFiled   bool
 	foundLines bool
 }
 
 // NewLineLimitReader takes the ReadCloser to wrap, the number of lines to find
-// searching backwards in the first searchLimit bytes.
-func NewLineLimitReader(r io.ReadCloser, lines, searchLimit int) *LineLimitReader {
+// searching backwards in the first searchLimit bytes. timeLimit can optionally
+// be specified by passing a non-zero duration. When set, the search for the
+// last n lines is aborted if no data has been read in the duration. This
+// can be used to flush what is had if no extra data is being received. When
+// used, the underlying reader must not block forever and must periodically
+// unblock even when no data has been read.
+func NewLineLimitReader(r io.ReadCloser, lines, searchLimit int, timeLimit time.Duration) *LineLimitReader {
 	return &LineLimitReader{
 		ReadCloser:  r,
 		searchLimit: searchLimit,
+		timeLimit:   timeLimit,
 		lines:       lines,
 		buffer:      bytes.NewBuffer(make([]byte, 0, searchLimit)),
 	}
@@ -124,14 +133,52 @@ func NewLineLimitReader(r io.ReadCloser, lines, searchLimit int) *LineLimitReade
 func (l *LineLimitReader) Read(p []byte) (n int, err error) {
 	// Fill up the buffer so we can find the correct number of lines.
 	if !l.bufFiled {
-		_, err := l.buffer.ReadFrom(io.LimitReader(l.ReadCloser, int64(l.searchLimit)))
-		if err != nil {
-			return 0, err
+		b := make([]byte, len(p))
+		n, err := l.ReadCloser.Read(b)
+		if n > 0 {
+			if _, err := l.buffer.Write(b[:n]); err != nil {
+				return 0, err
+			}
 		}
 
-		l.bufFiled = true
+		if err != nil {
+			if err != io.EOF {
+				return 0, err
+			}
+
+			l.bufFiled = true
+			goto READ
+		}
+
+		if l.buffer.Len() >= l.searchLimit {
+			l.bufFiled = true
+			goto READ
+		}
+
+		if l.timeLimit.Nanoseconds() > 0 {
+			if l.lastRead.IsZero() {
+				l.lastRead = time.Now()
+				return 0, nil
+			}
+
+			now := time.Now()
+			if n == 0 {
+				// We hit the limit
+				if l.lastRead.Add(l.timeLimit).Before(now) {
+					l.bufFiled = true
+					goto READ
+				} else {
+					return 0, nil
+				}
+			} else {
+				l.lastRead = now
+			}
+		}
+
+		return 0, nil
 	}
 
+READ:
 	if l.bufFiled && l.buffer.Len() != 0 {
 		b := l.buffer.Bytes()
 

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -1,9 +1,12 @@
 package command
 
 import (
+	"io"
 	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mitchellh/cli"
 )
@@ -48,7 +51,7 @@ func TestHelpers_NodeID(t *testing.T) {
 	}
 }
 
-func TestHelpers_LineLimitReader(t *testing.T) {
+func TestHelpers_LineLimitReader_NoTimeLimit(t *testing.T) {
 	helloString := `hello
 world
 this
@@ -114,7 +117,7 @@ test`,
 
 	for i, c := range cases {
 		in := ioutil.NopCloser(strings.NewReader(c.Input))
-		limit := NewLineLimitReader(in, c.Lines, c.SearchLimit)
+		limit := NewLineLimitReader(in, c.Lines, c.SearchLimit, 0)
 		outBytes, err := ioutil.ReadAll(limit)
 		if err != nil {
 			t.Fatalf("case %d failed: %v", i, err)
@@ -124,5 +127,61 @@ test`,
 		if out != c.Output {
 			t.Fatalf("case %d: got %q; want %q", i, out, c.Output)
 		}
+	}
+}
+
+type testReadCloser struct {
+	data chan []byte
+}
+
+func (t *testReadCloser) Read(p []byte) (n int, err error) {
+	select {
+	case b, ok := <-t.data:
+		if !ok {
+			return 0, io.EOF
+		}
+
+		return copy(p, b), nil
+	case <-time.After(10 * time.Millisecond):
+		return 0, nil
+	}
+}
+
+func (t *testReadCloser) Close() error {
+	close(t.data)
+	return nil
+}
+
+func TestHelpers_LineLimitReader_TimeLimit(t *testing.T) {
+	// Create the test reader
+	in := &testReadCloser{data: make(chan []byte)}
+
+	// Set up the reader such that it won't hit the line/buffer limit and could
+	// only terminate if it hits the time limit
+	limit := NewLineLimitReader(in, 1000, 1000, 100*time.Millisecond)
+
+	expected := []byte("hello world")
+
+	resultCh := make(chan struct{})
+	go func() {
+		outBytes, err := ioutil.ReadAll(limit)
+		if err != nil {
+			t.Fatalf("ReadAll failed: %v", err)
+		}
+
+		if reflect.DeepEqual(outBytes, expected) {
+			close(resultCh)
+			return
+		}
+	}()
+
+	// Send the data
+	in.data <- expected
+	in.Close()
+
+	select {
+	case <-resultCh:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("did not exit by time limit")
 	}
 }

--- a/command/logs.go
+++ b/command/logs.go
@@ -225,9 +225,6 @@ func (l *LogsCommand) followFile(client *api.Client, alloc *api.Allocation,
 
 		// End the streaming
 		r.Close()
-
-		// Output the last offset
-		l.Ui.Output(fmt.Sprintf("\nLast outputted offset (bytes): %d", frameReader.Offset()))
 	}()
 
 	return r, nil

--- a/command/logs.go
+++ b/command/logs.go
@@ -24,7 +24,7 @@ Usage: nomad logs [options] <alloc-id> <task>
 
 General Options:
 
-	` + generalOptionsUsage() + `
+  ` + generalOptionsUsage() + `
 
 Logs Specific Options:
 
@@ -32,7 +32,7 @@ Logs Specific Options:
     Show full information.
 
   -job <job-id>
-    Use a random allocation from a specified job-id.
+    Use a random allocation from the specified job ID.
 
   -f
     Causes the output to not stop when the end of the logs are reached, but
@@ -60,7 +60,7 @@ func (l *LogsCommand) Run(args []string) int {
 	var verbose, job, tail, stderr, follow bool
 	var numLines, numBytes int64
 
-	flags := l.Meta.FlagSet("logs-list", FlagSetClient)
+	flags := l.Meta.FlagSet("logs", FlagSetClient)
 	flags.Usage = func() { l.Ui.Output(l.Help()) }
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.BoolVar(&job, "job", false, "")
@@ -75,13 +75,17 @@ func (l *LogsCommand) Run(args []string) int {
 	}
 	args = flags.Args()
 
-	if len(args) < 1 {
+	if numArgs := len(args); numArgs < 1 {
 		if job {
-			l.Ui.Error("Job ID required")
+			l.Ui.Error("Job ID required. See help:\n")
 		} else {
-			l.Ui.Error("Allocation ID required")
+			l.Ui.Error("Allocation ID required. See help:\n")
 		}
 
+		l.Ui.Error(l.Help())
+		return 1
+	} else if numArgs > 2 {
+		l.Ui.Error(l.Help())
 		return 1
 	}
 

--- a/command/logs.go
+++ b/command/logs.go
@@ -20,11 +20,11 @@ func (l *LogsCommand) Help() string {
 	helpText := `
 Usage: nomad logs [options] <alloc-id> <task>
 
-TODO
+  Streams the stdout/stderr of the given allocation and task.
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+	` + generalOptionsUsage() + `
 
 Logs Specific Options:
 
@@ -35,21 +35,21 @@ Logs Specific Options:
     Use a random allocation from a specified job-id.
 
   -tail
-	Show the files contents with offsets relative to the end of the file. If no
-	offset is given, -n is defaulted to 10.
+    Show the files contents with offsets relative to the end of the file. If no
+    offset is given, -n is defaulted to 10.
 
   -n
-	Sets the tail location in best-efforted number of lines relative to the end
-	of the file.
+    Sets the tail location in best-efforted number of lines relative to the end
+    of the file.
 
   -c
-	Sets the tail location in number of bytes relative to the end of the file.
-`
+    Sets the tail location in number of bytes relative to the end of the file.
+	`
 	return strings.TrimSpace(helpText)
 }
 
 func (l *LogsCommand) Synopsis() string {
-	return "Inspect the contents of an allocation directory"
+	return "Streams the logs of a task."
 }
 
 func (l *LogsCommand) Run(args []string) int {

--- a/command/logs.go
+++ b/command/logs.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/nomad/api"
 )
@@ -33,7 +34,7 @@ Logs Specific Options:
   -job <job-id>
     Use a random allocation from a specified job-id.
 
-  -tail 
+  -tail
 	Show the files contents with offsets relative to the end of the file. If no
 	offset is given, -n is defaulted to 10.
 
@@ -182,7 +183,7 @@ func (l *LogsCommand) Run(args []string) int {
 
 		// If numLines is set, wrap the reader
 		if numLines != -1 {
-			r = NewLineLimitReader(r, int(numLines), int(numLines*bytesToLines))
+			r = NewLineLimitReader(r, int(numLines), int(numLines*bytesToLines), 1*time.Second)
 		}
 
 		if readErr != nil {
@@ -216,6 +217,7 @@ func (l *LogsCommand) followFile(client *api.Client, alloc *api.Allocation,
 	// Create a reader
 	var r io.ReadCloser
 	frameReader := api.NewFrameReader(frames, cancel)
+	frameReader.SetUnblockTime(500 * time.Millisecond)
 	r = frameReader
 
 	go func() {

--- a/command/logs.go
+++ b/command/logs.go
@@ -1,0 +1,237 @@
+package command
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+type LogsCommand struct {
+	Meta
+}
+
+func (l *LogsCommand) Help() string {
+	helpText := `
+Usage: nomad logs [options] <alloc-id> <task>
+
+TODO
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+Logs Specific Options:
+
+  -verbose
+    Show full information.
+
+  -job <job-id>
+    Use a random allocation from a specified job-id.
+
+  -tail 
+	Show the files contents with offsets relative to the end of the file. If no
+	offset is given, -n is defaulted to 10.
+
+  -n
+	Sets the tail location in best-efforted number of lines relative to the end
+	of the file.
+
+  -c
+	Sets the tail location in number of bytes relative to the end of the file.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (l *LogsCommand) Synopsis() string {
+	return "Inspect the contents of an allocation directory"
+}
+
+func (l *LogsCommand) Run(args []string) int {
+	var verbose, job, tail, stderr bool
+	var numLines, numBytes int64
+
+	flags := l.Meta.FlagSet("logs-list", FlagSetClient)
+	flags.Usage = func() { l.Ui.Output(l.Help()) }
+	flags.BoolVar(&verbose, "verbose", false, "")
+	flags.BoolVar(&job, "job", false, "")
+	flags.BoolVar(&tail, "tail", false, "")
+	flags.BoolVar(&stderr, "stderr", false, "")
+	flags.Int64Var(&numLines, "n", -1, "")
+	flags.Int64Var(&numBytes, "c", -1, "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	args = flags.Args()
+
+	if len(args) < 2 {
+		if job {
+			l.Ui.Error("job ID and task name required")
+		} else {
+			l.Ui.Error("allocation ID and task name required")
+		}
+
+		return 1
+	}
+
+	task := args[1]
+	if task == "" {
+		l.Ui.Error("task name required")
+		return 1
+	}
+
+	client, err := l.Meta.Client()
+	if err != nil {
+		l.Ui.Error(fmt.Sprintf("Error initializing client: %v", err))
+		return 1
+	}
+
+	// If -job is specified, use random allocation, otherwise use provided allocation
+	allocID := args[0]
+	if job {
+		allocID, err = getRandomJobAlloc(client, args[0])
+		if err != nil {
+			l.Ui.Error(fmt.Sprintf("Error fetching allocations: %v", err))
+			return 1
+		}
+	}
+
+	// Truncate the id unless full length is requested
+	length := shortId
+	if verbose {
+		length = fullId
+	}
+	// Query the allocation info
+	if len(allocID) == 1 {
+		l.Ui.Error(fmt.Sprintf("Alloc ID must contain at least two characters."))
+		return 1
+	}
+	if len(allocID)%2 == 1 {
+		// Identifiers must be of even length, so we strip off the last byte
+		// to provide a consistent user experience.
+		allocID = allocID[:len(allocID)-1]
+	}
+
+	allocs, _, err := client.Allocations().PrefixList(allocID)
+	if err != nil {
+		l.Ui.Error(fmt.Sprintf("Error querying allocation: %v", err))
+		return 1
+	}
+	if len(allocs) == 0 {
+		l.Ui.Error(fmt.Sprintf("No allocation(s) with prefix or id %q found", allocID))
+		return 1
+	}
+	if len(allocs) > 1 {
+		// Format the allocs
+		out := make([]string, len(allocs)+1)
+		out[0] = "ID|Eval ID|Job ID|Task Group|Desired Status|Client Status"
+		for i, alloc := range allocs {
+			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s",
+				limit(alloc.ID, length),
+				limit(alloc.EvalID, length),
+				alloc.JobID,
+				alloc.TaskGroup,
+				alloc.DesiredStatus,
+				alloc.ClientStatus,
+			)
+		}
+		l.Ui.Output(fmt.Sprintf("Prefix matched multiple allocations\n\n%s", formatList(out)))
+		return 0
+	}
+	// Prefix lookup matched a single allocation
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	if err != nil {
+		l.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
+		return 1
+	}
+
+	logType := "stdout"
+	if stderr {
+		logType = "stderr"
+	}
+
+	// We have a file, output it.
+	var r io.ReadCloser
+	var readErr error
+	if !tail {
+		r, readErr = l.followFile(client, alloc, task, logType, api.OriginStart, 0, -1)
+		if readErr != nil {
+			readErr = fmt.Errorf("Error reading file: %v", readErr)
+		}
+	} else {
+		// Parse the offset
+		var offset int64 = defaultTailLines * bytesToLines
+
+		if nLines, nBytes := numLines != -1, numBytes != -1; nLines && nBytes {
+			l.Ui.Error("Both -n and -c set")
+			return 1
+		} else if nLines {
+			offset = numLines * bytesToLines
+		} else if nBytes {
+			offset = numBytes
+		} else {
+			numLines = defaultTailLines
+		}
+
+		r, readErr = l.followFile(client, alloc, task, logType, api.OriginEnd, offset, numLines)
+
+		// If numLines is set, wrap the reader
+		if numLines != -1 {
+			r = NewLineLimitReader(r, int(numLines), int(numLines*bytesToLines))
+		}
+
+		if readErr != nil {
+			readErr = fmt.Errorf("Error tailing file: %v", readErr)
+		}
+	}
+
+	defer r.Close()
+	if readErr != nil {
+		l.Ui.Error(readErr.Error())
+		return 1
+	}
+
+	io.Copy(os.Stdout, r)
+	return 0
+}
+
+// followFile outputs the contents of the file to stdout relative to the end of
+// the file. If numLines does not equal -1, then tail -n behavior is used.
+func (l *LogsCommand) followFile(client *api.Client, alloc *api.Allocation,
+	task, logType, origin string, offset, numLines int64) (io.ReadCloser, error) {
+
+	cancel := make(chan struct{})
+	frames, _, err := client.AllocFS().Logs(alloc, task, logType, origin, offset, cancel, nil)
+	if err != nil {
+		return nil, err
+	}
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+
+	// Create a reader
+	var r io.ReadCloser
+	frameReader := api.NewFrameReader(frames, cancel)
+	r = frameReader
+
+	// If numLines is set, wrap the reader
+	if numLines != -1 {
+		r = NewLineLimitReader(r, int(numLines), int(numLines*bytesToLines))
+	}
+
+	go func() {
+		<-signalCh
+
+		// End the streaming
+		r.Close()
+
+		// Output the last offset
+		l.Ui.Output(fmt.Sprintf("\nLast outputted offset (bytes): %d", frameReader.Offset()))
+	}()
+
+	return r, nil
+}

--- a/command/logs_test.go
+++ b/command/logs_test.go
@@ -1,0 +1,65 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestLogsCommand_Implements(t *testing.T) {
+	var _ cli.Command = &LogsCommand{}
+}
+
+func TestLogsCommand_Fails(t *testing.T) {
+	srv, _, url := testServer(t, nil)
+	defer srv.Stop()
+
+	ui := new(cli.MockUi)
+	cmd := &LogsCommand{Meta: Meta{Ui: ui}}
+
+	// Fails on misuse
+	if code := cmd.Run([]string{"some", "bad", "args"}); code != 1 {
+		t.Fatalf("expected exit code 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, cmd.Help()) {
+		t.Fatalf("expected help output, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Fails on connection failure
+	if code := cmd.Run([]string{"-address=nope", "foobar"}); code != 1 {
+		t.Fatalf("expected exit code 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error querying allocation") {
+		t.Fatalf("expected failed query error, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Fails on missing alloc
+	if code := cmd.Run([]string{"-address=" + url, "26470238-5CF2-438F-8772-DC67CFB0705C"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No allocation(s) with prefix or id") {
+		t.Fatalf("expected not found error, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Fail on identifier with too few characters
+	if code := cmd.Run([]string{"-address=" + url, "2"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must contain at least two characters.") {
+		t.Fatalf("expected too few characters error, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Identifiers with uneven length should produce a query result
+	if code := cmd.Run([]string{"-address=" + url, "123"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No allocation(s) with prefix or id") {
+		t.Fatalf("expected not found error, got: %s", out)
+	}
+
+}

--- a/command/plan.go
+++ b/command/plan.go
@@ -63,8 +63,8 @@ General Options:
 Plan Options:
 
   -diff
-	Determines whether the diff between the remote job and planned job is shown.
-	Defaults to true.
+    Determines whether the diff between the remote job and planned job is shown.
+    Defaults to true.
 
   -verbose
     Increase diff verbosity.

--- a/command/run.go
+++ b/command/run.go
@@ -62,17 +62,17 @@ General Options:
 Run Options:
 
   -check-index
-	If set, the job is only registered or updated if the the passed
-	job modify index matches the server side version. If a check-index value of
-	zero is passed, the job is only registered if it does not yet exist. If a
-	non-zero value is passed, it ensures that the job is being updated from a
-	known state. The use of this flag is most common in conjunction with plan
-	command.
+    If set, the job is only registered or updated if the the passed
+    job modify index matches the server side version. If a check-index value of
+    zero is passed, the job is only registered if it does not yet exist. If a
+    non-zero value is passed, it ensures that the job is being updated from a
+    known state. The use of this flag is most common in conjunction with plan
+    command.
 
   -detach
-	Return immediately instead of entering monitor mode. After job submission,
-	the evaluation ID will be printed to the screen, which can be used to
-	examine the evaluation using the eval-status command.
+    Return immediately instead of entering monitor mode. After job submission,
+    the evaluation ID will be printed to the screen, which can be used to
+    examine the evaluation using the eval-status command.
 
   -verbose
     Display full information.

--- a/command/stop.go
+++ b/command/stop.go
@@ -27,9 +27,9 @@ Stop Options:
 
   -detach
     Return immediately instead of entering monitor mode. After the
-	deregister command is submitted, a new evaluation ID is printed to the
-	screen, which can be used to examine the evaluation using the eval-status
-	command.
+    deregister command is submitted, a new evaluation ID is printed to the
+    screen, which can be used to examine the evaluation using the eval-status
+    command.
 
   -yes
     Automatic yes to prompts.

--- a/commands.go
+++ b/commands.go
@@ -79,6 +79,11 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"logs": func() (cli.Command, error) {
+			return &command.LogsCommand{
+				Meta: meta,
+			}, nil
+		},
 		"node-drain": func() (cli.Command, error) {
 			return &command.NodeDrainCommand{
 				Meta: meta,


### PR DESCRIPTION
This PR introduces a `logs` command and a new client endpoint, `/v1/client/fs/logs/` for streaming task logs.