### PR TITLE
Docs: Fix list of chroot directories

### DIFF
--- a/website/source/docs/drivers/exec.html.md
+++ b/website/source/docs/drivers/exec.html.md
@@ -101,4 +101,4 @@ The chroot is populated with data in the following folders from the host
 machine:
 
 `["/bin", "/etc", "/lib", "/lib32", "/lib64", "/run/resolvconf", "/sbin",
-"/usr/bin", "/usr/lib", "/usr/sbin", "/usr/share"]`
+"/usr"]`


### PR DESCRIPTION
The chroot list was updated in https://github.com/hashicorp/nomad/commit/be1266e42d9951c746a2b50d6671f4679cf5e7be