### PR TITLE
Node Register handles transistioning to ready and creating evals

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1100,7 +1100,9 @@ func (c *Client) watchAllocations(updates chan *allocUpdates) {
 // watchNodeUpdates periodically checks for changes to the node attributes or meta map
 func (c *Client) watchNodeUpdates() {
 	c.logger.Printf("[DEBUG] client: periodically checking for node changes at duration %v", nodeUpdateRetryIntv)
-	var attrHash, metaHash uint64
+
+	// Initialize the hashes
+	_, attrHash, metaHash := c.hasNodeChanged(0, 0)
 	var changed bool
 	for {
 		select {

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -212,6 +212,37 @@ func TestClientEndpoint_Register_GetEvals(t *testing.T) {
 	if out.ModifyIndex != resp.Index {
 		t.Fatalf("index mis-match")
 	}
+
+	// Transistion it to down and then ready
+	node.Status = structs.NodeStatusDown
+	reg = &structs.NodeRegisterRequest{
+		Node:         node,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	// Fetch the response
+	if err := msgpackrpc.CallWithCodec(codec, "Node.Register", reg, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(resp.EvalIDs) != 1 {
+		t.Fatalf("expected one eval; got %#v", resp.EvalIDs)
+	}
+
+	node.Status = structs.NodeStatusReady
+	reg = &structs.NodeRegisterRequest{
+		Node:         node,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	// Fetch the response
+	if err := msgpackrpc.CallWithCodec(codec, "Node.Register", reg, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(resp.EvalIDs) != 1 {
+		t.Fatalf("expected one eval; got %#v", resp.EvalIDs)
+	}
 }
 
 func TestClientEndpoint_UpdateStatus_GetEvals(t *testing.T) {


### PR DESCRIPTION
This fixes an issue in which a Node could register and not create evaluations, thus causing system jobs to not launch on them.

Fixes https://github.com/hashicorp/nomad/issues/1412