### PR TITLE
Add killing event and mark task as not running when killed

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -207,6 +207,7 @@ const (
 	TaskFailedValidation       = "Failed Validation"
 	TaskStarted                = "Started"
 	TaskTerminated             = "Terminated"
+	TaskKilling                = "Killing"
 	TaskKilled                 = "Killed"
 	TaskRestarting             = "Restarting"
 	TaskNotRestarting          = "Not Restarting"
@@ -224,6 +225,7 @@ type TaskEvent struct {
 	ExitCode        int
 	Signal          int
 	Message         string
+	KillTimeout     time.Duration
 	KillError       string
 	StartDelay      int64
 	DownloadError   string

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -223,6 +223,12 @@ func (c *AllocStatusCommand) outputTaskStatus(state *api.TaskState) {
 			} else {
 				desc = "Failed to download artifacts"
 			}
+		case api.TaskKilling:
+			if event.KillTimeout != 0 {
+				desc = fmt.Sprintf("Sent interupt. Waiting %v before force killing", event.KillTimeout)
+			} else {
+				desc = "Sent interupt"
+			}
 		case api.TaskKilled:
 			if event.KillError != "" {
 				desc = event.KillError

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2100,6 +2100,9 @@ const (
 	// TaskTerminated indicates that the task was started and exited.
 	TaskTerminated = "Terminated"
 
+	// TaskKilling indicates a kill signal has been sent to the task.
+	TaskKilling = "Killing"
+
 	// TaskKilled indicates a user has killed the task.
 	TaskKilled = "Killed"
 
@@ -2135,6 +2138,9 @@ type TaskEvent struct {
 	ExitCode int    // The exit code of the task.
 	Signal   int    // The signal that terminated the task.
 	Message  string // A possible message explaining the termination of the task.
+
+	// Killing fields
+	KillTimeout time.Duration
 
 	// Task Killed Fields.
 	KillError string // Error killing the task.
@@ -2221,6 +2227,11 @@ func (e *TaskEvent) SetValidationError(err error) *TaskEvent {
 	if err != nil {
 		e.ValidationError = err.Error()
 	}
+	return e
+}
+
+func (e *TaskEvent) SetKillTimeout(timeout time.Duration) *TaskEvent {
+	e.KillTimeout = timeout
 	return e
 }
 

--- a/website/source/docs/http/alloc.html.md
+++ b/website/source/docs/http/alloc.html.md
@@ -254,6 +254,7 @@ be specified using the `?region=` query parameter.
     * `Started` - The task was started; either for the first time or due to a
       restart.
     * `Terminated` - The task was started and exited.
+    * `Killing` - The task has been sent the kill signal.
     * `Killed` - The task was killed by an user.
     * `Received` - The task has been pulled by the client at the given timestamp.
     * `Failed Validation` - The task was invalid and as such it didn't run.


### PR DESCRIPTION
```
Task "redis" is "dead"
Task Resources
CPU  Memory   Disk     IOPS  Addresses
500  256 MiB  300 MiB  0     db: 127.0.0.1:43968

Recent Events:
Time                   Type      Description
07/20/16 09:20:39 UTC  Killed    Task successfully killed
07/20/16 09:20:39 UTC  Killing   Sent interupt. Waiting 5s before force killing
07/20/16 09:20:35 UTC  Started   Task started by client
07/20/16 09:20:31 UTC  Received  Task received by client
```