### PR TITLE
Update taskconfig.html.md

### DIFF
--- a/website/source/docs/jobops/taskconfig.html.md
+++ b/website/source/docs/jobops/taskconfig.html.md
@@ -88,12 +88,12 @@ task "example" {
 
     # Download the binary to run
 	artifact {
-		source = "http://domain.com/example/my-app"
+		source = "http://example.com/example/my-app"
     }
 
 	# Download the config file
 	artifact {
-		source = "http://domain.com/example/config.cfg"
+		source = "http://example.com/example/config.cfg"
     }
 }
 ```


### PR DESCRIPTION
Remove references to domain.com. RFC 2606 (https://www.rfc-editor.org/rfc/rfc2606.txt) reserves `example.com` for use in documentation. `domain.com` is a real website.