### PR TITLE
Remove artifact tar after loading a docker image

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -676,6 +676,10 @@ func (d *DockerDriver) loadImage(driverConfig *DockerDriverConfig, client *docke
 			errors.Errors = append(errors.Errors, err)
 		}
 		f.Close()
+		// Cleanup archive after loading it into the docker daemon. If there is
+		// an error we're going to ignore it for now and assume the alloc GC
+		// will clean it up later.
+		os.Remove(archive)
 	}
 	return errors.ErrorOrNil()
 }

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -285,10 +285,10 @@ func TestDockerDriver_Start_LoadImage(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewDockerDriver(driverCtx)
 
-	// Copy the test jar into the task's directory
+	// Copy the test tar into the task's directory
 	taskDir, _ := execCtx.AllocDir.TaskDirs[task.Name]
 	dst := filepath.Join(taskDir, allocdir.TaskLocal, "busybox.tar")
-	copyFile("./test-resources/docker/busybox.tar", dst, t)
+	copyFile(filepath.Join("test-resources", "docker", "busybox.tar"), dst, t)
 
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
@@ -312,7 +312,11 @@ func TestDockerDriver_Start_LoadImage(t *testing.T) {
 	outputFile := filepath.Join(execCtx.AllocDir.LogDir(), "busybox-demo.stdout.0")
 	act, err := ioutil.ReadFile(outputFile)
 	if err != nil {
-		t.Fatalf("Couldn't read expected output: %v", err)
+		t.Errorf("Couldn't read expected output: %v", err)
+	}
+	// Check that the artifact tarball was removed after loading
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Errorf("Expected not to find artifact tarball %s", dst)
 	}
 
 	exp := "hello"


### PR DESCRIPTION
Nomad supports loading docker images from tarballs. When using a base like ubuntu these tars are quite large (1.4gb in my case) and each time Nomad places an allocation it will download the tar, load it, and then leave the tar in the allocation directory.

As a result if you have a loop of failures and re-allocations you will end up with tons of 1.4gb tarballs littered around your cluster and eventually Nomad will run out of disk space. This PR cleans up the tarball after it is loaded into the docker daemon and the tar is no longer needed.

This is similar to existing behavior for go-getter artifact downloads that download, extract, and then discard the tarball afterward.