### PR TITLE
Empty host ip for windows containers port bindings

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -490,8 +490,8 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 			hostPortStr := strconv.Itoa(port.Value)
 			containerPort := docker.Port(strconv.Itoa(containerPortInt))
 
-			publishedPorts[containerPort+"/tcp"] = []docker.PortBinding{docker.PortBinding{HostIP: network.IP, HostPort: hostPortStr}}
-			publishedPorts[containerPort+"/udp"] = []docker.PortBinding{docker.PortBinding{HostIP: network.IP, HostPort: hostPortStr}}
+			publishedPorts[containerPort+"/tcp"] = getPortBinding(network.IP, hostPortStr)
+			publishedPorts[containerPort+"/udp"] = getPortBinding(network.IP, hostPortStr)
 			d.logger.Printf("[DEBUG] driver.docker: allocated port %s:%d -> %d (static)", network.IP, port.Value, port.Value)
 
 			exposedPorts[containerPort+"/tcp"] = struct{}{}
@@ -511,8 +511,8 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 			hostPortStr := strconv.Itoa(port.Value)
 			containerPort := docker.Port(strconv.Itoa(containerPortInt))
 
-			publishedPorts[containerPort+"/tcp"] = []docker.PortBinding{docker.PortBinding{HostIP: network.IP, HostPort: hostPortStr}}
-			publishedPorts[containerPort+"/udp"] = []docker.PortBinding{docker.PortBinding{HostIP: network.IP, HostPort: hostPortStr}}
+			publishedPorts[containerPort+"/tcp"] = getPortBinding(network.IP, hostPortStr)
+			publishedPorts[containerPort+"/udp"] = getPortBinding(network.IP, hostPortStr)
 			d.logger.Printf("[DEBUG] driver.docker: allocated port %s:%d -> %d (mapped)", network.IP, port.Value, containerPortInt)
 
 			exposedPorts[containerPort+"/tcp"] = struct{}{}

--- a/client/driver/docker_default.go
+++ b/client/driver/docker_default.go
@@ -1,0 +1,9 @@
+//+build !windows
+
+package driver
+
+import docker "github.com/fsouza/go-dockerclient"
+
+func getPortBinding(ip string, port string) []docker.PortBinding {
+	return []docker.PortBinding{docker.PortBinding{HostIP: ip, HostPort: port}}
+}

--- a/client/driver/docker_windows.go
+++ b/client/driver/docker_windows.go
@@ -1,0 +1,8 @@
+package driver
+
+import docker "github.com/fsouza/go-dockerclient"
+
+//Currently Windows containers don't support host ip in port binding.
+func getPortBinding(ip string, port string) []docker.PortBinding {
+	return []docker.PortBinding{docker.PortBinding{HostIP: "", HostPort: port}}
+}


### PR DESCRIPTION
According to [this comment](https://github.com/docker/libnetwork/commit/6d4d4b87cb92c75638d7487c09e6f5561c2be1de#commitcomment-18387753) host ip is not supported in Windows containers port bindings (and won't be in RTM/GA of Windows Server 2016).
So it's a temporary workaround if we want nomad to run containers on windows when 2016 version becomes GA