### PR TITLE
Plan exit code map to whether allocations would change + bug fix

### DIFF
--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -18,7 +18,7 @@ func TestPlanCommand_Fails(t *testing.T) {
 	cmd := &PlanCommand{Meta: Meta{Ui: ui}}
 
 	// Fails on misuse
-	if code := cmd.Run([]string{"some", "bad", "args"}); code != 1 {
+	if code := cmd.Run([]string{"some", "bad", "args"}); code != 255 {
 		t.Fatalf("expected exit code 1, got: %d", code)
 	}
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, cmd.Help()) {
@@ -27,7 +27,7 @@ func TestPlanCommand_Fails(t *testing.T) {
 	ui.ErrorWriter.Reset()
 
 	// Fails when specified file does not exist
-	if code := cmd.Run([]string{"/unicorns/leprechauns"}); code != 1 {
+	if code := cmd.Run([]string{"/unicorns/leprechauns"}); code != 255 {
 		t.Fatalf("expect exit 1, got: %d", code)
 	}
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error opening") {
@@ -44,7 +44,7 @@ func TestPlanCommand_Fails(t *testing.T) {
 	if _, err := fh1.WriteString("nope"); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if code := cmd.Run([]string{fh1.Name()}); code != 1 {
+	if code := cmd.Run([]string{fh1.Name()}); code != 255 {
 		t.Fatalf("expect exit 1, got: %d", code)
 	}
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error parsing") {
@@ -61,7 +61,7 @@ func TestPlanCommand_Fails(t *testing.T) {
 	if _, err := fh2.WriteString(`job "job1" {}`); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if code := cmd.Run([]string{fh2.Name()}); code != 1 {
+	if code := cmd.Run([]string{fh2.Name()}); code != 255 {
 		t.Fatalf("expect exit 1, got: %d", code)
 	}
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error validating") {
@@ -94,7 +94,7 @@ job "job1" {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if code := cmd.Run([]string{"-address=nope", fh3.Name()}); code != 1 {
+	if code := cmd.Run([]string{"-address=nope", fh3.Name()}); code != 255 {
 		t.Fatalf("expected exit code 1, got: %d", code)
 	}
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error during plan") {
@@ -135,7 +135,7 @@ job "job1" {
 	}()
 
 	args := []string{"-"}
-	if code := cmd.Run(args); code != 1 {
+	if code := cmd.Run(args); code != 255 {
 		t.Fatalf("expected exit code 1, got %d: %q", code, ui.ErrorWriter.String())
 	}
 

--- a/scheduler/annotate.go
+++ b/scheduler/annotate.go
@@ -159,21 +159,30 @@ func annotateTask(diff *structs.TaskDiff, parent *structs.TaskGroupDiff) {
 		}
 	}
 
-	// All changes to primitive fields result in a destructive update.
+	// All changes to primitive fields result in a destructive update except
+	// KillTimeout
 	destructive := false
-	if len(diff.Fields) != 0 {
-		destructive = true
-	}
-
-	// Changes that can be done in-place are log configs, services and
-	// constraints.
-	for _, oDiff := range diff.Objects {
-		switch oDiff.Name {
-		case "LogConfig", "Service", "Constraint":
+	for _, fDiff := range diff.Fields {
+		switch fDiff.Name {
+		case "KillTimeout":
 			continue
 		default:
 			destructive = true
 			break
+		}
+	}
+
+	// Object changes that can be done in-place are log configs, services,
+	// constraints.
+	if !destructive {
+		for _, oDiff := range diff.Objects {
+			switch oDiff.Name {
+			case "LogConfig", "Service", "Constraint":
+				continue
+			default:
+				destructive = true
+				break
+			}
 		}
 	}
 

--- a/scheduler/annotate_test.go
+++ b/scheduler/annotate_test.go
@@ -347,6 +347,21 @@ func TestAnnotateTask(t *testing.T) {
 			Parent:  &structs.TaskGroupDiff{Type: structs.DiffTypeEdited},
 			Desired: AnnotationForcesInplaceUpdate,
 		},
+		{
+			Diff: &structs.TaskDiff{
+				Type: structs.DiffTypeEdited,
+				Fields: []*structs.FieldDiff{
+					{
+						Type: structs.DiffTypeEdited,
+						Name: "KillTimeout",
+						Old:  "200",
+						New:  "2000000",
+					},
+				},
+			},
+			Parent:  &structs.TaskGroupDiff{Type: structs.DiffTypeEdited},
+			Desired: AnnotationForcesInplaceUpdate,
+		},
 		// Task deleted new parent
 		{
 			Diff: &structs.TaskDiff{

--- a/website/source/docs/commands/plan.html.md.erb
+++ b/website/source/docs/commands/plan.html.md.erb
@@ -36,6 +36,12 @@ give insight into what the scheduler will attempt to do and why.
 If the job has specified the region, the `-region` flag and `NOMAD_REGION`
 environment variable are overridden and the the job's region is used.
 
+Plan will return one of the following exit codes:
+
+  * 0: No allocations created or destroyed.
+  * 1: Allocations created or destroyed.
+  * 255: Error determining plan results.
+
 ## General Options
 
 <%= general_options_usage %>


### PR DESCRIPTION
This PR makes plan return:

* 0: No allocations created or destroyed.
* 1: Allocations created or destroyed.
* 255: Error determining plan results.

Also fixes an issue in which we improperly classified modifications to KillTimeout as causing a create/destroy update.

Fixes #1495