### PR TITLE
Do not update the job of allocations that are being stopped

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -374,7 +374,7 @@ func (n *nomadFSM) applyAllocUpdate(buf []byte, index uint64) interface{} {
 	// prior to being inserted into MemDB.
 	if j := req.Job; j != nil {
 		for _, alloc := range req.Alloc {
-			if alloc.Job == nil {
+			if alloc.Job == nil && !alloc.TerminalStatus() {
 				alloc.Job = j
 			}
 		}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -577,9 +577,12 @@ func TestFSM_UpsertAllocs_SharedJob(t *testing.T) {
 		t.Fatalf("bad: %#v %#v", alloc, out)
 	}
 
+	// Ensure that the original job is used
 	evictAlloc := new(structs.Allocation)
 	*evictAlloc = *alloc
-	job = evictAlloc.Job
+	job = mock.Job()
+	job.Priority = 123
+
 	evictAlloc.Job = nil
 	evictAlloc.DesiredStatus = structs.AllocDesiredStatusEvict
 	req2 := structs.AllocUpdateRequest{
@@ -604,8 +607,8 @@ func TestFSM_UpsertAllocs_SharedJob(t *testing.T) {
 	if out.DesiredStatus != structs.AllocDesiredStatusEvict {
 		t.Fatalf("alloc found!")
 	}
-	if out.Job == nil {
-		t.Fatalf("missing job")
+	if out.Job == nil || out.Job.Priority == 123 {
+		t.Fatalf("bad job")
 	}
 }
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -961,6 +961,11 @@ func (s *StateStore) UpsertAllocs(index uint64, allocs []*structs.Allocation) er
 			alloc.AllocModifyIndex = index
 			alloc.ClientStatus = exist.ClientStatus
 			alloc.ClientDescription = exist.ClientDescription
+
+			// The job has been denormalized so re-attach the original job
+			if alloc.Job == nil {
+				alloc.Job = exist.Job
+			}
 		}
 		if err := txn.Insert("allocs", alloc); err != nil {
 			return fmt.Errorf("alloc insert failed: %v", err)


### PR DESCRIPTION
This fixes an issue in which a job could be updated and the job attached to historic allocations would also get updated rather than just new allocations.