### PR TITLE
Remove docker volumes while removing container

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1015,7 +1015,7 @@ func (h *DockerHandle) run() {
 	}
 
 	// Remove the container
-	if err := h.client.RemoveContainer(docker.RemoveContainerOptions{ID: h.containerID, Force: true}); err != nil {
+	if err := h.client.RemoveContainer(docker.RemoveContainerOptions{ID: h.containerID, RemoveVolumes: true, Force: true}); err != nil {
 		h.logger.Printf("[ERR] driver.docker: error removing container: %v", err)
 	}
 

--- a/client/driver/executor/checks_test.go
+++ b/client/driver/executor/checks_test.go
@@ -133,5 +133,5 @@ func TestDockerScriptCheck(t *testing.T) {
 // removeContainer kills and removes a container
 func removeContainer(client *docker.Client, containerID string) {
 	client.KillContainer(docker.KillContainerOptions{ID: containerID})
-	client.RemoveContainer(docker.RemoveContainerOptions{ID: containerID, Force: true})
+	client.RemoveContainer(docker.RemoveContainerOptions{ID: containerID, RemoveVolumes: true, Force: true})
 }


### PR DESCRIPTION
Currently the docker volumes are left on the disk and the host machines disk  is getting filled up with the unused docker volumes from the removed containers. 

This attempts to fix it.