### PR TITLE
Set windows containers default network mode to 'nat'

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -451,8 +451,8 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 	hostConfig.NetworkMode = driverConfig.NetworkMode
 	if hostConfig.NetworkMode == "" {
 		// docker default
-		d.logger.Println("[DEBUG] driver.docker: networking mode not specified; defaulting to bridge")
-		hostConfig.NetworkMode = "bridge"
+		d.logger.Printf("[DEBUG] driver.docker: networking mode not specified; defaulting to %s", defaultNetworkMode)
+		hostConfig.NetworkMode = defaultNetworkMode
 	}
 
 	// Setup port mapping and exposed ports

--- a/client/driver/docker_default.go
+++ b/client/driver/docker_default.go
@@ -4,6 +4,11 @@ package driver
 
 import docker "github.com/fsouza/go-dockerclient"
 
+const (
+	//Setting default network mode for non-windows OS as bridge
+	defaultNetworkMode = "bridge"
+)
+
 func getPortBinding(ip string, port string) []docker.PortBinding {
 	return []docker.PortBinding{docker.PortBinding{HostIP: ip, HostPort: port}}
 }

--- a/client/driver/docker_windows.go
+++ b/client/driver/docker_windows.go
@@ -2,6 +2,11 @@ package driver
 
 import docker "github.com/fsouza/go-dockerclient"
 
+const (
+	//Default network mode for windows containers is nat
+	defaultNetworkMode = "nat"
+)
+
 //Currently Windows containers don't support host ip in port binding.
 func getPortBinding(ip string, port string) []docker.PortBinding {
 	return []docker.PortBinding{docker.PortBinding{HostIP: "", HostPort: port}}


### PR DESCRIPTION
As discussed in #1488: setting default network mode for windows containers to 'nat'