### PR TITLE
Set difference when picking random ports

### DIFF
--- a/nomad/structs/bitmap.go
+++ b/nomad/structs/bitmap.go
@@ -6,8 +6,8 @@ import "fmt"
 type Bitmap []byte
 
 // NewBitmap returns a bitmap with up to size indexes
-func NewBitmap(size int) (Bitmap, error) {
-	if size <= 0 {
+func NewBitmap(size uint) (Bitmap, error) {
+	if size == 0 {
 		return nil, fmt.Errorf("bitmap must be positive size")
 	}
 	if size&7 != 0 {
@@ -15,6 +15,32 @@ func NewBitmap(size int) (Bitmap, error) {
 	}
 	b := make([]byte, size>>3)
 	return Bitmap(b), nil
+}
+
+// Copy returns a copy of the Bitmap
+func (b Bitmap) Copy() (Bitmap, error) {
+	if b == nil {
+		return nil, fmt.Errorf("can't copy nil Bitmap")
+	}
+
+	nb, err := NewBitmap(b.Size())
+	if err != nil {
+		return nil, err
+	}
+
+	s := b.Size()
+	for i := uint(0); i < s; i++ {
+		if b.Check(i) {
+			nb.Set(i)
+		}
+	}
+
+	return nb, nil
+}
+
+// Size returns the size of the bitmap
+func (b Bitmap) Size() uint {
+	return uint(len(b) << 3)
 }
 
 // Set is used to set the given index of the bitmap
@@ -36,4 +62,19 @@ func (b Bitmap) Clear() {
 	for i := range b {
 		b[i] = 0
 	}
+}
+
+// IndexesFrom returns the indexes in which the values are either set or unset based
+// on the passed parameter starting from the passed index
+func (b Bitmap) IndexesFrom(set bool, from uint) []uint {
+	var indexes []uint
+	s := b.Size()
+	for i := from; i < s; i++ {
+		c := b.Check(i)
+		if c && set || !c && !set {
+			indexes = append(indexes, i)
+		}
+	}
+
+	return indexes
 }

--- a/nomad/structs/bitmap.go
+++ b/nomad/structs/bitmap.go
@@ -66,13 +66,13 @@ func (b Bitmap) Clear() {
 
 // IndexesFrom returns the indexes in which the values are either set or unset based
 // on the passed parameter starting from the passed index
-func (b Bitmap) IndexesFrom(set bool, from uint) []uint {
-	var indexes []uint
+func (b Bitmap) IndexesFrom(set bool, from uint) []int {
+	var indexes []int
 	s := b.Size()
 	for i := from; i < s; i++ {
 		c := b.Check(i)
 		if c && set || !c && !set {
-			indexes = append(indexes, i)
+			indexes = append(indexes, int(i))
 		}
 	}
 

--- a/nomad/structs/bitmap.go
+++ b/nomad/structs/bitmap.go
@@ -23,19 +23,9 @@ func (b Bitmap) Copy() (Bitmap, error) {
 		return nil, fmt.Errorf("can't copy nil Bitmap")
 	}
 
-	nb, err := NewBitmap(b.Size())
-	if err != nil {
-		return nil, err
-	}
-
-	s := b.Size()
-	for i := uint(0); i < s; i++ {
-		if b.Check(i) {
-			nb.Set(i)
-		}
-	}
-
-	return nb, nil
+	raw := make([]byte, len(b))
+	copy(raw, b)
+	return Bitmap(raw), nil
 }
 
 // Size returns the size of the bitmap
@@ -64,12 +54,11 @@ func (b Bitmap) Clear() {
 	}
 }
 
-// IndexesFrom returns the indexes in which the values are either set or unset based
-// on the passed parameter starting from the passed index
-func (b Bitmap) IndexesFrom(set bool, from uint) []int {
+// IndexesInRange returns the indexes in which the values are either set or unset based
+// on the passed parameter in the passed range
+func (b Bitmap) IndexesInRange(set bool, from, to uint) []int {
 	var indexes []int
-	s := b.Size()
-	for i := from; i < s; i++ {
+	for i := from; i < to; i++ {
 		c := b.Check(i)
 		if c && set || !c && !set {
 			indexes = append(indexes, int(i))

--- a/nomad/structs/bitmap_test.go
+++ b/nomad/structs/bitmap_test.go
@@ -56,13 +56,13 @@ func TestBitmap(t *testing.T) {
 
 	// Check the indexes
 	idxs := b.IndexesFrom(true, 0)
-	expected := []uint{0, 255}
+	expected := []int{0, 255}
 	if !reflect.DeepEqual(idxs, expected) {
 		t.Fatalf("bad: got %#v; want %#v", idxs, expected)
 	}
 
 	idxs = b.IndexesFrom(true, 1)
-	expected = []uint{255}
+	expected = []int{255}
 	if !reflect.DeepEqual(idxs, expected) {
 		t.Fatalf("bad: got %#v; want %#v", idxs, expected)
 	}

--- a/nomad/structs/bitmap_test.go
+++ b/nomad/structs/bitmap_test.go
@@ -1,6 +1,9 @@
 package structs
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestBitmap(t *testing.T) {
 	// Check invalid sizes
@@ -14,9 +17,14 @@ func TestBitmap(t *testing.T) {
 	}
 
 	// Create a normal bitmap
-	b, err := NewBitmap(256)
+	var s uint = 256
+	b, err := NewBitmap(s)
 	if err != nil {
 		t.Fatalf("err: %v", err)
+	}
+
+	if b.Size() != s {
+		t.Fatalf("bad size")
 	}
 
 	// Set a few bits
@@ -44,6 +52,34 @@ func TestBitmap(t *testing.T) {
 		if b.Check(uint(i)) {
 			t.Fatalf("bad")
 		}
+	}
+
+	// Check the indexes
+	idxs := b.IndexesFrom(true, 0)
+	expected := []uint{0, 255}
+	if !reflect.DeepEqual(idxs, expected) {
+		t.Fatalf("bad: got %#v; want %#v", idxs, expected)
+	}
+
+	idxs = b.IndexesFrom(true, 1)
+	expected = []uint{255}
+	if !reflect.DeepEqual(idxs, expected) {
+		t.Fatalf("bad: got %#v; want %#v", idxs, expected)
+	}
+
+	idxs = b.IndexesFrom(false, 0)
+	if len(idxs) != 254 {
+		t.Fatalf("bad")
+	}
+
+	// Check the copy is correct
+	b2, err := b.Copy()
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	if !reflect.DeepEqual(b, b2) {
+		t.Fatalf("bad")
 	}
 
 	// Clear

--- a/nomad/structs/bitmap_test.go
+++ b/nomad/structs/bitmap_test.go
@@ -55,20 +55,25 @@ func TestBitmap(t *testing.T) {
 	}
 
 	// Check the indexes
-	idxs := b.IndexesFrom(true, 0)
+	idxs := b.IndexesInRange(true, 0, 256)
 	expected := []int{0, 255}
 	if !reflect.DeepEqual(idxs, expected) {
 		t.Fatalf("bad: got %#v; want %#v", idxs, expected)
 	}
 
-	idxs = b.IndexesFrom(true, 1)
+	idxs = b.IndexesInRange(true, 1, 256)
 	expected = []int{255}
 	if !reflect.DeepEqual(idxs, expected) {
 		t.Fatalf("bad: got %#v; want %#v", idxs, expected)
 	}
 
-	idxs = b.IndexesFrom(false, 0)
+	idxs = b.IndexesInRange(false, 0, 256)
 	if len(idxs) != 254 {
+		t.Fatalf("bad")
+	}
+
+	idxs = b.IndexesInRange(false, 100, 200)
+	if len(idxs) != 100 {
 		t.Fatalf("bad")
 	}
 

--- a/nomad/structs/network.go
+++ b/nomad/structs/network.go
@@ -214,13 +214,13 @@ func (idx *NetworkIndex) AssignNetwork(ask *NetworkResource) (out *NetworkResour
 		var dynPorts []int
 		var dynErr error
 		dynPorts, dynErr = getDynamicPortsStochastic(used, ask)
-		if err != nil {
+		if err == nil {
 			goto BUILD_OFFER
 		}
 
 		// Fall back to the precise method if the random sampling failed.
 		dynPorts, dynErr = getDynamicPortsPrecise(used, ask)
-		if err != nil {
+		if dynErr != nil {
 			err = dynErr
 			return
 		}
@@ -263,7 +263,7 @@ func getDynamicPortsPrecise(nodeUsed Bitmap, ask *NetworkResource) ([]int, error
 	}
 
 	// Get the indexes of the unset
-	availablePorts := usedSet.IndexesFrom(false, MinDynamicPort)
+	availablePorts := usedSet.IndexesInRange(false, MinDynamicPort, MaxDynamicPort)
 
 	// Randomize the amount we need
 	numDyn := len(ask.DynamicPorts)

--- a/nomad/structs/network_test.go
+++ b/nomad/structs/network_test.go
@@ -398,7 +398,7 @@ func TestNetworkIndex_AssignNetwork_Dynamic_Contention(t *testing.T) {
 }
 
 func TestIntContains(t *testing.T) {
-	l := []Port{{"one", 1}, {"two", 2}, {"ten", 10}, {"twenty", 20}}
+	l := []int{1, 2, 10, 20}
 	if isPortReserved(l, 50) {
 		t.Fatalf("bad")
 	}

--- a/nomad/structs/network_test.go
+++ b/nomad/structs/network_test.go
@@ -343,6 +343,60 @@ func TestNetworkIndex_AssignNetwork(t *testing.T) {
 	}
 }
 
+// This test ensures that even with a small domain of available ports we are
+// able to make a dynamic port allocation.
+func TestNetworkIndex_AssignNetwork_Dynamic_Contention(t *testing.T) {
+
+	// Create a node that only has one free port
+	idx := NewNetworkIndex()
+	n := &Node{
+		Resources: &Resources{
+			Networks: []*NetworkResource{
+				&NetworkResource{
+					Device: "eth0",
+					CIDR:   "192.168.0.100/32",
+					MBits:  1000,
+				},
+			},
+		},
+		Reserved: &Resources{
+			Networks: []*NetworkResource{
+				&NetworkResource{
+					Device: "eth0",
+					IP:     "192.168.0.100",
+					MBits:  1,
+				},
+			},
+		},
+	}
+	for i := MinDynamicPort; i < MaxDynamicPort-1; i++ {
+		n.Reserved.Networks[0].ReservedPorts = append(n.Reserved.Networks[0].ReservedPorts, Port{Value: i})
+	}
+
+	idx.SetNode(n)
+
+	// Ask for dynamic ports
+	ask := &NetworkResource{
+		DynamicPorts: []Port{{"http", 0}},
+	}
+	offer, err := idx.AssignNetwork(ask)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if offer == nil {
+		t.Fatalf("bad")
+	}
+	if offer.IP != "192.168.0.100" {
+		t.Fatalf("bad: %#v", offer)
+	}
+	if len(offer.DynamicPorts) != 1 {
+		t.Fatalf("There should be three dynamic ports")
+	}
+	if p := offer.DynamicPorts[0].Value; p == MaxDynamicPort {
+		t.Fatalf("Dynamic Port: should have been assigned %d; got %d", p, MaxDynamicPort)
+	}
+}
+
 func TestIntContains(t *testing.T) {
 	l := []Port{{"one", 1}, {"two", 2}, {"ten", 10}, {"twenty", 20}}
 	if isPortReserved(l, 50) {


### PR DESCRIPTION
The way that dynamic port assignment is done currently doesn't work well at all if significant ranges of reserved_ports are specified in nomad client config. For example:

```
client {
  reserved {
    reserved_ports = "23000-65535" 
  }
}
```
With this config (which leaves ports 20000-22999 available for assignment), running a job requiring several dynamic ports will fail more often than not, as a random pick in the range 20000-60000 will fall in a reserved range >90% of the time.

This change ensures that acceptable ports are always assigned, so long as a sufficient number of free ports exist in any non-reserved range between MinDynamicPort (20000) and MaxDynamicPort (60000).

Thanks to @bagelswitch for reporting.

@armon  for review