### PR TITLE
Add creation time to job status

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -194,7 +194,7 @@ func (c *AllocStatusCommand) outputTaskStatus(state *api.TaskState) {
 
 	size := len(state.Events)
 	for i, event := range state.Events {
-		formatedTime := c.formatUnixNanoTime(event.Time)
+		formatedTime := formatUnixNanoTime(event.Time)
 
 		// Build up the description based on the event type.
 		var desc string
@@ -400,7 +400,7 @@ func (c *AllocStatusCommand) shortTaskStatus(alloc *api.Allocation) {
 		if l != 0 {
 			last := state.Events[l-1]
 			lastEvent = last.Type
-			lastTime = c.formatUnixNanoTime(last.Time)
+			lastTime = formatUnixNanoTime(last.Time)
 		}
 
 		tasks = append(tasks, fmt.Sprintf("%s|%s|%s|%s",
@@ -429,10 +429,4 @@ func (c *AllocStatusCommand) sortedTaskStateIterator(m map[string]*api.TaskState
 
 	close(output)
 	return output
-}
-
-// formatUnixNanoTime is a helper for formating time for output.
-func (c *AllocStatusCommand) formatUnixNanoTime(nano int64) string {
-	t := time.Unix(0, nano)
-	return formatTime(t)
 }

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -51,6 +51,12 @@ func formatTime(t time.Time) string {
 	return t.Format("01/02/06 15:04:05 MST")
 }
 
+// formatUnixNanoTime is a helper for formatting time for output.
+func formatUnixNanoTime(nano int64) string {
+	t := time.Unix(0, nano)
+	return formatTime(t)
+}
+
 // formatTimeDifference takes two times and determines their duration difference
 // truncating to a passed unit.
 // E.g. formatTimeDifference(first=1m22s33ms, second=1m28s55ms, time.Second) -> 6s

--- a/command/status.go
+++ b/command/status.go
@@ -310,7 +310,7 @@ func (c *StatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
 				alloc.TaskGroup,
 				alloc.DesiredStatus,
 				alloc.ClientStatus,
-				c.formatUnixNanoTime(alloc.CreateTime))
+				formatUnixNanoTime(alloc.CreateTime))
 		}
 
 		c.Ui.Output(formatList(allocs))
@@ -345,12 +345,6 @@ func (c *StatusCommand) outputFailedPlacements(failedEval *api.Evaluation) {
 		trunc := fmt.Sprintf("\nPlacement failures truncated. To see remainder run:\nnomad eval-status %s", failedEval.ID)
 		c.Ui.Output(trunc)
 	}
-}
-
-// formatUnixNanoTime is a helper for formatting time for output.
-func (c *StatusCommand) formatUnixNanoTime(nano int64) string {
-	t := time.Unix(0, nano)
-	return formatTime(t)
 }
 
 // convertApiJob is used to take a *api.Job and convert it to an *struct.Job.

--- a/command/status.go
+++ b/command/status.go
@@ -23,7 +23,6 @@ type StatusCommand struct {
 	length  int
 	evals   bool
 	verbose bool
-	time    bool
 }
 
 func (c *StatusCommand) Help() string {
@@ -46,9 +45,6 @@ Status Options:
   -evals
     Display the evaluations associated with the job.
 
-  -time
-    Display allocation creation time.
-
   -verbose
     Display full information.
 `
@@ -67,7 +63,6 @@ func (c *StatusCommand) Run(args []string) int {
 	flags.BoolVar(&short, "short", false, "")
 	flags.BoolVar(&c.evals, "evals", false, "")
 	flags.BoolVar(&c.verbose, "verbose", false, "")
-	flags.BoolVar(&c.time, "time", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -306,22 +301,16 @@ func (c *StatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
 	c.Ui.Output(c.Colorize().Color("\n[bold]Allocations[reset]"))
 	if len(jobAllocs) > 0 {
 		allocs = make([]string, len(jobAllocs)+1)
-		allocs[0] = "ID|Eval ID|Node ID|Task Group|Desired|Status"
-		if c.time {
-			allocs[0] += "|Created"
-		}
+		allocs[0] = "ID|Eval ID|Node ID|Task Group|Desired|Status|Created"
 		for i, alloc := range jobAllocs {
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s",
+			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
 				limit(alloc.ID, c.length),
 				limit(alloc.EvalID, c.length),
 				limit(alloc.NodeID, c.length),
 				alloc.TaskGroup,
 				alloc.DesiredStatus,
-				alloc.ClientStatus)
-			if c.time {
-				allocs[i+1] += fmt.Sprintf("|%s",
-					c.formatUnixNanoTime(alloc.CreateTime))
-			}
+				alloc.ClientStatus,
+				c.formatUnixNanoTime(alloc.CreateTime))
 		}
 
 		c.Ui.Output(formatList(allocs))

--- a/command/status.go
+++ b/command/status.go
@@ -301,7 +301,7 @@ func (c *StatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
 	c.Ui.Output(c.Colorize().Color("\n[bold]Allocations[reset]"))
 	if len(jobAllocs) > 0 {
 		allocs = make([]string, len(jobAllocs)+1)
-		allocs[0] = "ID|Eval ID|Node ID|Task Group|Desired|Status|Created"
+		allocs[0] = "ID|Eval ID|Node ID|Task Group|Desired|Status|Created At"
 		for i, alloc := range jobAllocs {
 			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
 				limit(alloc.ID, c.length),

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mitchellh/cli"
-	"github.com/hashicorp/nomad/testutil"
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/mitchellh/cli"
 )
 
 func TestStatusCommand_Implements(t *testing.T) {
@@ -46,7 +46,7 @@ func TestStatusCommand_Run(t *testing.T) {
 	}
 
 	job2 := testJob("job2_sfx")
-	evalId2, _, err := client.Jobs().Register(job2, nil);
+	evalId2, _, err := client.Jobs().Register(job2, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -109,22 +109,6 @@ func TestStatusCommand_Run(t *testing.T) {
 	}
 	if !strings.Contains(out, "Allocations") {
 		t.Fatalf("should dump allocations")
-	}
-	if strings.Contains(out, "Created") {
-		t.Fatal("should not have created header")
-	}
-	ui.OutputWriter.Reset()
-
-	// Query a single job in time mode
-	if code := cmd.Run([]string{"-address=" + url, "-time", "job1_sfx"}); code != 0 {
-		t.Fatalf("expected exit 0, got: %d", code)
-	}
-	out = ui.OutputWriter.String()
-	if strings.Contains(out, "job2_sfx") || !strings.Contains(out, "job1_sfx") {
-		t.Fatalf("expected only job1_sfx, got: %s", out)
-	}
-	if !strings.Contains(out, "Allocations") {
-		t.Fatal("should dump allocations")
 	}
 	if !strings.Contains(out, "Created") {
 		t.Fatal("should have created header")

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -110,7 +110,7 @@ func TestStatusCommand_Run(t *testing.T) {
 	if !strings.Contains(out, "Allocations") {
 		t.Fatalf("should dump allocations")
 	}
-	if !strings.Contains(out, "Created") {
+	if !strings.Contains(out, "Created At") {
 		t.Fatal("should have created header")
 	}
 	ui.OutputWriter.Reset()

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -39,7 +39,7 @@ func testServer(
 }
 
 func testJob(jobID string) *api.Job {
-	task := api.NewTask("task1", "exec").
+	task := api.NewTask("task1", "raw_exec").
 		SetConfig("command", "/bin/sleep").
 		Require(&api.Resources{
 			MemoryMB: 256,

--- a/commands.go
+++ b/commands.go
@@ -94,13 +94,11 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
-
 		"plan": func() (cli.Command, error) {
 			return &command.PlanCommand{
 				Meta: meta,
 			}, nil
 		},
-
 		"run": func() (cli.Command, error) {
 			return &command.RunCommand{
 				Meta: meta,

--- a/commands.go
+++ b/commands.go
@@ -94,11 +94,13 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+
 		"plan": func() (cli.Command, error) {
 			return &command.PlanCommand{
 				Meta: meta,
 			}, nil
 		},
+
 		"run": func() (cli.Command, error) {
 			return &command.RunCommand{
 				Meta: meta,

--- a/website/source/docs/commands/status.html.md.erb
+++ b/website/source/docs/commands/status.html.md.erb
@@ -76,8 +76,8 @@ Status      = running
 Periodic    = false
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status
-24cfd201  81efc2fa  8d0331e9  cache       run      running
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+24cfd201  81efc2fa  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
 ```
 
 Full status information of a job with placement failures:
@@ -98,12 +98,12 @@ Task Group "cache":
   * Dimension "cpu exhausted" exhausted on 1 nodes
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status
-0b8b9e37  8bf94335  8d0331e9  cache       run      running
-b206088c  8bf94335  8d0331e9  cache       run      running
-b82f58b6  8bf94335  8d0331e9  cache       run      running
-ed3665f5  8bf94335  8d0331e9  cache       run      running
-24cfd201  8bf94335  8d0331e9  cache       run      running
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+0b8b9e37  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
+b206088c  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:18 CDT
+b82f58b6  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:17 CDT
+ed3665f5  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:21 CDT
+24cfd201  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
 ```
 
 Full status information showing evaluations with a placement failure. The in
@@ -133,10 +133,10 @@ Task Group "cache":
   * Dimension "cpu exhausted" exhausted on 1 nodes
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status
-0b8b9e37  8bf94335  8d0331e9  cache       run      running
-b206088c  8bf94335  8d0331e9  cache       run      running
-b82f58b6  8bf94335  8d0331e9  cache       run      running
-ed3665f5  8bf94335  8d0331e9  cache       run      running
-24cfd201  8bf94335  8d0331e9  cache       run      running
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+0b8b9e37  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
+b206088c  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
+b82f58b6  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
+ed3665f5  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
+24cfd201  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
 ```

--- a/website/source/docs/commands/status.html.md.erb
+++ b/website/source/docs/commands/status.html.md.erb
@@ -76,7 +76,7 @@ Status      = running
 Periodic    = false
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created At
 24cfd201  81efc2fa  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
 ```
 
@@ -98,7 +98,7 @@ Task Group "cache":
   * Dimension "cpu exhausted" exhausted on 1 nodes
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created At
 0b8b9e37  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
 b206088c  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:18 CDT
 b82f58b6  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:17 CDT
@@ -133,7 +133,7 @@ Task Group "cache":
   * Dimension "cpu exhausted" exhausted on 1 nodes
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created At
 0b8b9e37  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
 b206088c  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT
 b82f58b6  8bf94335  8d0331e9  cache       run      running  08/08/16 21:03:19 CDT

--- a/website/source/docs/jobops/inspecting.html.md
+++ b/website/source/docs/jobops/inspecting.html.md
@@ -39,14 +39,14 @@ Task Group "cache":
   * Dimension "cpu exhausted" exhausted on 1 nodes
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status
-12681940  8e38e6cf  4beef22f  cache       run      running
-395c5882  8e38e6cf  4beef22f  cache       run      running
-4d7c6f84  8e38e6cf  4beef22f  cache       run      running
-843b07b8  8e38e6cf  4beef22f  cache       run      running
-a8bc6d3e  8e38e6cf  4beef22f  cache       run      running
-b0beb907  8e38e6cf  4beef22f  cache       run      running
-da21c1fd  8e38e6cf  4beef22f  cache       run      running
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+12681940  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT
+395c5882  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT
+4d7c6f84  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT
+843b07b8  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT
+a8bc6d3e  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT
+b0beb907  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT
+da21c1fd  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT
 ```
 
 In the above example we see that the job has a "blocked" evaluation that is in

--- a/website/source/docs/jobops/inspecting.html.md
+++ b/website/source/docs/jobops/inspecting.html.md
@@ -39,7 +39,7 @@ Task Group "cache":
   * Dimension "cpu exhausted" exhausted on 1 nodes
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created At
 12681940  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT
 395c5882  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT
 4d7c6f84  8e38e6cf  4beef22f  cache       run      running  08/08/16 21:03:19 CDT

--- a/website/source/intro/getting-started/cluster.html.md
+++ b/website/source/intro/getting-started/cluster.html.md
@@ -185,7 +185,7 @@ Status      = running
 Periodic    = false
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created At
 501154ac  8e0a7cf9  c887deef  cache       run      running  08/08/16 21:03:19 CDT
 7e2b3900  8e0a7cf9  fca62612  cache       run      running  08/08/16 21:03:19 CDT
 9c66fcaf  8e0a7cf9  c887deef  cache       run      running  08/08/16 21:03:19 CDT

--- a/website/source/intro/getting-started/cluster.html.md
+++ b/website/source/intro/getting-started/cluster.html.md
@@ -185,10 +185,10 @@ Status      = running
 Periodic    = false
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status
-501154ac  8e0a7cf9  c887deef  cache       run      running
-7e2b3900  8e0a7cf9  fca62612  cache       run      running
-9c66fcaf  8e0a7cf9  c887deef  cache       run      running
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+501154ac  8e0a7cf9  c887deef  cache       run      running  08/08/16 21:03:19 CDT
+7e2b3900  8e0a7cf9  fca62612  cache       run      running  08/08/16 21:03:19 CDT
+9c66fcaf  8e0a7cf9  c887deef  cache       run      running  08/08/16 21:03:19 CDT
 ```
 
 We can see that all our tasks have been allocated and are running.

--- a/website/source/intro/getting-started/jobs.html.md
+++ b/website/source/intro/getting-started/jobs.html.md
@@ -71,7 +71,7 @@ Status      = running
 Periodic    = false
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created At
 dadcdb81  61b0b423  72687b1a  cache       run      running  06/23/16 01:41:13 UTC
 ```
 

--- a/website/source/intro/getting-started/jobs.html.md
+++ b/website/source/intro/getting-started/jobs.html.md
@@ -71,8 +71,8 @@ Status      = running
 Periodic    = false
 
 Allocations
-ID        Eval ID   Node ID   Task Group  Desired  Status
-dadcdb81  61b0b423  72687b1a  cache       run      running
+ID        Eval ID   Node ID   Task Group  Desired  Status   Created
+dadcdb81  61b0b423  72687b1a  cache       run      running  06/23/16 01:41:13 UTC
 ```
 
 Here we can see that the result of our evaluation was the creation of an


### PR DESCRIPTION
closes #1217 

I decided to take the approach of adding a command line flag to add the extra metadata, the other idea would be to make -verbose add the extra metadata.