### PR TITLE
it is possible to have more than 1 eval if the eval fails, use the last one

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -281,9 +281,11 @@ func TestJobs_Evaluations(t *testing.T) {
 	}
 	assertQueryMeta(t, qm)
 
-	// Check that we got the evals back
-	if n := len(evals); n == 0 || evals[0].ID != evalID {
-		t.Fatalf("expected 1 eval (%s), got: %#v", evalID, evals)
+	// Check that we got the evals back, evals are in order most recent to least recent
+	// so the last eval is the original registered eval
+	idx := len(evals) - 1
+	if n := len(evals); n == 0 || evals[idx].ID != evalID {
+		t.Fatalf("expected >= 1 eval (%s), got: %#v", evalID, evals[idx])
 	}
 }
 


### PR DESCRIPTION
I noticed this while running on mac, which doesn't have 'exec' driver available by default. not sure if it would be better to fix this test like I did, or fix it to use something like 'raw_exec' which is more likely to exist on all os's