### PR TITLE
just checked the known values in job summary instead of doing a deep equals

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -502,6 +502,7 @@ func TestJobs_JobSummary(t *testing.T) {
 
 	// Register the job
 	job := testJob()
+	taskName := job.TaskGroups[0].Name
 	_, wm, err := jobs.Register(job, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -515,18 +516,12 @@ func TestJobs_JobSummary(t *testing.T) {
 	}
 	assertQueryMeta(t, qm)
 
-	expectedJobSummary := JobSummary{
-		JobID: job.ID,
-		Summary: map[string]TaskGroupSummary{
-			job.TaskGroups[0].Name: {},
-		},
-		CreateIndex: result.CreateIndex,
-		ModifyIndex: result.ModifyIndex,
-	}
-
 	// Check that the result is what we expect
-	if !reflect.DeepEqual(&expectedJobSummary, result) {
-		t.Fatalf("expect: %#v, got: %#v", expectedJobSummary, result)
+	if (job.ID != result.JobID) {
+		t.Fatalf("err: expected job id of %s saw %s", job.ID, result.JobID)
+	}
+	if _, ok := result.Summary[taskName]; !ok {
+		t.Fatalf("err: unable to find %s key in job summary", taskName)
 	}
 }
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -517,7 +517,7 @@ func TestJobs_JobSummary(t *testing.T) {
 	assertQueryMeta(t, qm)
 
 	// Check that the result is what we expect
-	if (job.ID != result.JobID) {
+	if job.ID != result.JobID {
 		t.Fatalf("err: expected job id of %s saw %s", job.ID, result.JobID)
 	}
 	if _, ok := result.Summary[taskName]; !ok {


### PR DESCRIPTION
i believe this is checking the exact same things that were being attempted to be checked before, but without doing a deep equals. The deep equals was failing for me because it had 1 task set as queued. It would be nice for this test to check the job summary actually scored things correctly, but I am not sure if that is better checked in a unit test instead of an integration test, since we have no idea what state things are going to be in for the integration test moment in time.