### PR TITLE
Fix reload of retry_join server addresses on SIGHUP

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -484,7 +484,7 @@ WAIT:
 	// Check if this is a SIGHUP
 	if sig == syscall.SIGHUP {
 		if conf := c.handleReload(config); conf != nil {
-			config = conf
+			*config = *conf
 		}
 		goto WAIT
 	}


### PR DESCRIPTION
The current code does not update the actual config, but only the local reference to it.

/cc @denderello