### PR TITLE
duplicate check for deep equals of frame order

### DIFF
--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -375,9 +375,11 @@ func TestStreamFramer_Order(t *testing.T) {
 	select {
 	case <-resultCh:
 	case <-time.After(10 * time.Duration(testutil.TestMultiplier()) * bWindow):
-		got := receivedBuf.String()
-		want := expected.String()
-		t.Fatalf("Got %v; want %v", got, want)
+		if reflect.DeepEqual(expected, receivedBuf) {
+			got := receivedBuf.String()
+			want := expected.String()
+			t.Fatalf("Got %v; want %v", got, want)
+		}
 	}
 
 	// Close the reader and wait. This should cause the runner to exit


### PR DESCRIPTION
it is kind of annoying that this test fails because of a timeout, and then logs the wrong error message, wrong because it says two string that are possibly the same are not. it seems like the test times out doing the deep equals, and then prints an error saying that they are not equal. Adding a double check of the deep equals may not be the best solution, but it at least makes it so that the error message is correct.