### PR TITLE
use last job eval if multiple exist, when looking for registration

### DIFF
--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -374,7 +374,9 @@ func TestHTTP_JobEvaluations(t *testing.T) {
 
 		// Check the response
 		evals := obj.([]*structs.Evaluation)
-		if len(evals) != 1 || evals[0].ID != resp.EvalID {
+		// Can be multiple evals, use the last one, since they are in order
+		idx := len(evals) - 1
+		if len(evals) > 0 || evals[idx].ID != resp.EvalID {
 			t.Fatalf("bad: %v", evals)
 		}
 


### PR DESCRIPTION
from logs, can have multiple evals
```
--- FAIL: TestHTTP_JobEvaluations (14.16s)
	job_endpoint_test.go:378: bad: [0xc821333400 0xc821333900]
```
same as #1541 