### PR TITLE
only check keys we know will be correct

### DIFF
--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -744,21 +744,14 @@ func TestJobEndpoint_GetJobSummary(t *testing.T) {
 	if err := msgpackrpc.CallWithCodec(codec, "Job.Summary", get, &resp2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp2.Index != resp.JobModifyIndex {
-		t.Fatalf("Bad index: %d %d", resp2.Index, resp.Index)
+	if job.ID != resp2.JobSummary.JobID {
+		t.Fatalf("expected: %v, actual: %v", job.ID, resp2.JobSummary.JobID)
 	}
-
-	expectedJobSummary := structs.JobSummary{
-		JobID: job.ID,
-		Summary: map[string]structs.TaskGroupSummary{
-			"web": structs.TaskGroupSummary{},
-		},
-		CreateIndex: job.CreateIndex,
-		ModifyIndex: job.CreateIndex,
+	if job.CreateIndex != resp2.JobSummary.CreateIndex {
+		t.Fatalf("expected: %v, actual: %v", job.CreateIndex, resp2.JobSummary.CreateIndex)
 	}
-
-	if !reflect.DeepEqual(resp2.JobSummary, &expectedJobSummary) {
-		t.Fatalf("exptected: %v, actual: %v", expectedJobSummary, resp2.JobSummary)
+	if _, ok := resp2.JobSummary.Summary["web"]; !ok {
+		t.Fatal("expected job summary to exist for 'web'");
 	}
 }
 


### PR DESCRIPTION
this test fix may be controversial, but I put a sleep before the  'Job.Summary' call and the JobIndex can be modified as the tasks in the Job start getting evaluated. Also, if any of those get queued then the deep equals will fail as well. 

```
--- FAIL: TestJobEndpoint_GetJobSummary (0.02s)
	job_endpoint_test.go:761: exptected: {0c11890d-f6b7-0abc-222b-a825f59cb304 map[web:{0 0 0 0 0 0}] 4 4}, actual: &{0c11890d-f6b7-0abc-222b-a825f59cb304 map[web:{10 0 0 0 0 0}] 4 4}
```

I do not see an easier, or clear way to make sure that the job index does not get changed, and that all of the jobs only get queued.