### PR TITLE
get a free port from the kernel

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -3,9 +3,9 @@ package agent
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,10 +13,18 @@ import (
 	sconfig "github.com/hashicorp/nomad/nomad/structs/config"
 )
 
-var nextPort uint32 = 17000
-
 func getPort() int {
-	return int(atomic.AddUint32(&nextPort, 1))
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		panic(err)
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
 }
 
 func tmpDir(t testing.TB) string {


### PR DESCRIPTION
Fixes the following test error by getting a free port from the kernel instead of getting a hard coded one.

```
2016/08/16 20:57:16.503563 [ERR] nomad: failed to start serf WAN: Failed to create memberlist: Failed to start UDP listener. Err: listen udp 127.0.0.1:17139: bind: address already in use
--- FAIL: TestHTTP_NodeAllocations (0.41s)
	agent_test.go:69: err: server setup failed: Failed to start serf: Failed to create memberlist: Failed to start UDP listener. Err: listen udp 127.0.0.1:17139: bind: address already in use
```