### PR TITLE
Updating vagrant file for v0.4.1, logs section of tutorial references…

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ sudo apt-get install -y unzip curl wget vim
 # Download Nomad
 echo Fetching Nomad...
 cd /tmp/
-curl -sSL https://releases.hashicorp.com/nomad/0.4.0/nomad_0.4.0_linux_amd64.zip -o nomad.zip
+curl -sSL https://releases.hashicorp.com/nomad/0.4.1/nomad_0.4.1_linux_amd64.zip -o nomad.zip
 
 echo Installing Nomad...
 unzip nomad.zip


### PR DESCRIPTION
… 0.4.1


Currently the tutorial walks through the logs command, this command isn't available in v0.4.0.