### PR TITLE
Don't force -cgo when building binaries

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,7 +40,6 @@ gox \
     -os="!openbsd" \
     -os="!solaris" \
     -arch="${XC_ARCH}" \
-    -cgo \
     -osarch="!darwin/386" \
     -ldflags "-X main.GitCommit='${GIT_COMMIT}${GIT_DIRTY}'" \
     -output "pkg/{{.OS}}_{{.Arch}}/nomad" \


### PR DESCRIPTION
Consul doesn't cgo for building releases because it's incompatible with running in alpine for the docker image: https://github.com/hashicorp/consul/blob/master/scripts/consul-builder/Dockerfile#L21-L23.

Nomad doesn't seem to need cgo, so can we remove the flag when building to get compatibility with alpine for docker?