### PR TITLE
Server Deriving Tokens on behalf of Clients

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -457,7 +457,8 @@ func (n *nomadFSM) applyReconcileSummaries(buf []byte, index uint64) interface{}
 	return n.reconcileQueuedAllocations(index)
 }
 
-// applyUpsertVaultAccessor stores the Vault accessors for a given
+// applyUpsertVaultAccessor stores the Vault accessors for a given allocation
+// and task
 func (n *nomadFSM) applyUpsertVaultAccessor(buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "upsert_vault_accessor"}, time.Now())
 	var req structs.VaultAccessorRegisterRequest

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -976,6 +976,27 @@ func TestFSM_SnapshotRestore_JobSummary(t *testing.T) {
 	}
 }
 
+func TestFSM_SnapshotRestore_VaultAccessors(t *testing.T) {
+	// Add some state
+	fsm := testFSM(t)
+	state := fsm.State()
+	a1 := mock.VaultAccessor()
+	a2 := mock.VaultAccessor()
+	state.UpsertVaultAccessor(1000, []*structs.VaultAccessor{a1, a2})
+
+	// Verify the contents
+	fsm2 := testSnapshotRestore(t, fsm)
+	state2 := fsm2.State()
+	out1, _ := state2.VaultAccessor(a1.Accessor)
+	out2, _ := state2.VaultAccessor(a2.Accessor)
+	if !reflect.DeepEqual(a1, out1) {
+		t.Fatalf("bad: \n%#v\n%#v", out1, a1)
+	}
+	if !reflect.DeepEqual(a2, out2) {
+		t.Fatalf("bad: \n%#v\n%#v", out2, a2)
+	}
+}
+
 func TestFSM_SnapshotRestore_AddMissingSummary(t *testing.T) {
 	// Add some state
 	fsm := testFSM(t)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -83,7 +84,7 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 			}
 
 			vault := j.srv.vault
-			s, err := vault.LookupToken(args.Job.VaultToken)
+			s, err := vault.LookupToken(context.Background(), args.Job.VaultToken)
 			if err != nil {
 				return err
 			}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -290,6 +290,16 @@ func Alloc() *structs.Allocation {
 	return alloc
 }
 
+func VaultAccessor() *structs.VaultAccessor {
+	return &structs.VaultAccessor{
+		Accessor:    structs.GenerateUUID(),
+		NodeID:      structs.GenerateUUID(),
+		AllocID:     structs.GenerateUUID(),
+		CreationTTL: 86400,
+		Task:        "foo",
+	}
+}
+
 func Plan() *structs.Plan {
 	return &structs.Plan{
 		Priority: 50,

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -936,6 +936,9 @@ func (n *Node) DeriveVaultToken(args *structs.DeriveVaultTokenRequest,
 	if alloc.NodeID != args.NodeID {
 		return fmt.Errorf("Allocation %q not running on Node %q", args.AllocID, args.NodeID)
 	}
+	if alloc.TerminalStatus() {
+		return fmt.Errorf("Can't request Vault token for terminal allocation")
+	}
 
 	// Check the policies
 	policies := alloc.Job.VaultPolicies()
@@ -950,7 +953,7 @@ func (n *Node) DeriveVaultToken(args *structs.DeriveVaultTokenRequest,
 	var unneeded []string
 	for _, task := range args.Tasks {
 		taskVault := tg[task]
-		if len(taskVault.Policies) == 0 {
+		if taskVault == nil || len(taskVault.Policies) == 0 {
 			unneeded = append(unneeded, task)
 		}
 	}

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -23,6 +23,7 @@ func stateStoreSchema() *memdb.DBSchema {
 		periodicLaunchTableSchema,
 		evalTableSchema,
 		allocTableSchema,
+		vaultAccessorTableSchema,
 	}
 
 	// Add each of the tables
@@ -286,6 +287,44 @@ func allocTableSchema() *memdb.TableSchema {
 				Unique:       false,
 				Indexer: &memdb.UUIDFieldIndex{
 					Field: "EvalID",
+				},
+			},
+		},
+	}
+}
+
+// vaultAccessorTableSchema returns the MemDB schema for the Vault Accessor
+// Table. This table tracks Vault accessors for tokens created on behalf of
+// allocations required Vault tokens.
+func vaultAccessorTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "vault_accessors",
+		Indexes: map[string]*memdb.IndexSchema{
+			// The primary index is the accessor id
+			"id": &memdb.IndexSchema{
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "Accessor",
+				},
+			},
+
+			"alloc_id": &memdb.IndexSchema{
+				Name:         "alloc_id",
+				AllowMissing: false,
+				Unique:       false,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "AllocID",
+				},
+			},
+
+			"node_id": &memdb.IndexSchema{
+				Name:         "node_id",
+				AllowMissing: false,
+				Unique:       false,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "NodeID",
 				},
 			},
 		},

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -253,12 +253,12 @@ func SliceStringIsSubset(larger, smaller []string) (bool, []string) {
 
 // VaultPoliciesSet takes the structure returned by VaultPolicies and returns
 // the set of required policies
-func VaultPoliciesSet(policies map[string]map[string][]string) []string {
+func VaultPoliciesSet(policies map[string]map[string]*Vault) []string {
 	set := make(map[string]struct{})
 
 	for _, tgp := range policies {
 		for _, tp := range tgp {
-			for _, p := range tp {
+			for _, p := range tp.Policies {
 				set[p] = struct{}{}
 			}
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -354,6 +354,22 @@ type PeriodicForceRequest struct {
 	WriteRequest
 }
 
+type DeriveVaultTokenRequest struct {
+	NodeID   string
+	SecretID string
+	AllocID  string
+	Tasks    []string
+	QueryOptions
+}
+
+type DeriveVaultTokenResponse struct {
+	NodeID   string
+	SecretID string
+	AllocID  string
+	Tasks    []string
+	QueryMeta
+}
+
 // GenericRequest is used to request where no
 // specific information is needed.
 type GenericRequest struct {
@@ -1230,11 +1246,11 @@ func (j *Job) IsPeriodic() bool {
 }
 
 // VaultPolicies returns the set of Vault policies per task group, per task
-func (j *Job) VaultPolicies() map[string]map[string][]string {
-	policies := make(map[string]map[string][]string, len(j.TaskGroups))
+func (j *Job) VaultPolicies() map[string]map[string]*Vault {
+	policies := make(map[string]map[string]*Vault, len(j.TaskGroups))
 
 	for _, tg := range j.TaskGroups {
-		tgPolicies := make(map[string][]string, len(tg.Tasks))
+		tgPolicies := make(map[string]*Vault, len(tg.Tasks))
 		policies[tg.Name] = tgPolicies
 
 		for _, task := range tg.Tasks {
@@ -1242,7 +1258,7 @@ func (j *Job) VaultPolicies() map[string]map[string][]string {
 				continue
 			}
 
-			tgPolicies[task.Name] = task.Vault.Policies
+			tgPolicies[task.Name] = task.Vault
 		}
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -47,6 +47,7 @@ const (
 	AllocUpdateRequestType
 	AllocClientUpdateRequestType
 	ReconcileJobSummariesRequestType
+	VaultAccessorRegisterRequestType
 )
 
 const (
@@ -362,6 +363,24 @@ type DeriveVaultTokenRequest struct {
 	AllocID  string
 	Tasks    []string
 	QueryOptions
+}
+
+// VaultAccessorRegisterRequest is used to register a set of Vault accessors
+type VaultAccessorRegisterRequest struct {
+	Accessors []*VaultAccessor
+}
+
+// VaultAccessor is a reference to a created Vault token on behalf of
+// an allocation's task.
+type VaultAccessor struct {
+	AllocID     string
+	Task        string
+	NodeID      string
+	Accessor    string
+	CreationTTL int64
+
+	// Raft Indexes
+	CreateIndex uint64
 }
 
 // DeriveVaultTokenResponse returns the wrapped tokens for each requested task

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -354,6 +354,8 @@ type PeriodicForceRequest struct {
 	WriteRequest
 }
 
+// DeriveVaultTokenRequest is used to request wrapped Vault tokens for the
+// following tasks in the given allocation
 type DeriveVaultTokenRequest struct {
 	NodeID   string
 	SecretID string
@@ -362,11 +364,9 @@ type DeriveVaultTokenRequest struct {
 	QueryOptions
 }
 
+// DeriveVaultTokenResponse returns the wrapped tokens for each requested task
 type DeriveVaultTokenResponse struct {
-	NodeID   string
-	SecretID string
-	AllocID  string
-	Tasks    []string
+	Tasks map[string]string
 	QueryMeta
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -377,7 +377,7 @@ type VaultAccessor struct {
 	Task        string
 	NodeID      string
 	Accessor    string
-	CreationTTL int64
+	CreationTTL int
 
 	// Raft Indexes
 	CreateIndex uint64
@@ -385,6 +385,7 @@ type VaultAccessor struct {
 
 // DeriveVaultTokenResponse returns the wrapped tokens for each requested task
 type DeriveVaultTokenResponse struct {
+	// Tasks is a mapping between the task name and the wrapped token
 	Tasks map[string]string
 	QueryMeta
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -224,8 +224,25 @@ func TestJob_SystemJob_Validate(t *testing.T) {
 
 func TestJob_VaultPolicies(t *testing.T) {
 	j0 := &Job{}
-	e0 := make(map[string]map[string][]string, 0)
+	e0 := make(map[string]map[string]*Vault, 0)
 
+	vj1 := &Vault{
+		Policies: []string{
+			"p1",
+			"p2",
+		},
+	}
+	vj2 := &Vault{
+		Policies: []string{
+			"p3",
+			"p4",
+		},
+	}
+	vj3 := &Vault{
+		Policies: []string{
+			"p5",
+		},
+	}
 	j1 := &Job{
 		TaskGroups: []*TaskGroup{
 			&TaskGroup{
@@ -235,13 +252,8 @@ func TestJob_VaultPolicies(t *testing.T) {
 						Name: "t1",
 					},
 					&Task{
-						Name: "t2",
-						Vault: &Vault{
-							Policies: []string{
-								"p1",
-								"p2",
-							},
-						},
+						Name:  "t2",
+						Vault: vj1,
 					},
 				},
 			},
@@ -249,40 +261,31 @@ func TestJob_VaultPolicies(t *testing.T) {
 				Name: "bar",
 				Tasks: []*Task{
 					&Task{
-						Name: "t3",
-						Vault: &Vault{
-							Policies: []string{
-								"p3",
-								"p4",
-							},
-						},
+						Name:  "t3",
+						Vault: vj2,
 					},
 					&Task{
-						Name: "t4",
-						Vault: &Vault{
-							Policies: []string{
-								"p5",
-							},
-						},
+						Name:  "t4",
+						Vault: vj3,
 					},
 				},
 			},
 		},
 	}
 
-	e1 := map[string]map[string][]string{
-		"foo": map[string][]string{
-			"t2": []string{"p1", "p2"},
+	e1 := map[string]map[string]*Vault{
+		"foo": map[string]*Vault{
+			"t2": vj1,
 		},
-		"bar": map[string][]string{
-			"t3": []string{"p3", "p4"},
-			"t4": []string{"p5"},
+		"bar": map[string]*Vault{
+			"t3": vj2,
+			"t4": vj3,
 		},
 	}
 
 	cases := []struct {
 		Job      *Job
-		Expected map[string]map[string][]string
+		Expected map[string]map[string]*Vault
 	}{
 		{
 			Job:      j0,

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -421,7 +421,7 @@ func (v *vaultClient) Stop() {
 
 	v.l.Lock()
 	defer v.l.Unlock()
-	if !v.renewalRunning || !v.establishingConn {
+	if !v.renewalRunning && !v.establishingConn {
 		return
 	}
 

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -35,6 +35,7 @@ func TestVaultClient_BadConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	defer client.Stop()
 
 	if client.ConnectionEstablished() {
 		t.Fatalf("bad")
@@ -184,6 +185,7 @@ func TestVaultClient_LookupToken_Invalid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to build vault client: %v", err)
 	}
+	defer client.Stop()
 
 	_, err = client.LookupToken(context.Background(), "foo")
 	if err == nil || !strings.Contains(err.Error(), "disabled") {
@@ -222,6 +224,7 @@ func TestVaultClient_LookupToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to build vault client: %v", err)
 	}
+	defer client.Stop()
 
 	waitForConnection(client, t)
 
@@ -281,6 +284,7 @@ func TestVaultClient_LookupToken_RateLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to build vault client: %v", err)
 	}
+	defer client.Stop()
 	client.setLimit(rate.Limit(1.0))
 
 	waitForConnection(client, t)
@@ -334,6 +338,7 @@ func TestVaultClient_CreateToken_Root(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to build vault client: %v", err)
 	}
+	defer client.Stop()
 
 	waitForConnection(client, t)
 

--- a/nomad/vault_testing.go
+++ b/nomad/vault_testing.go
@@ -1,6 +1,8 @@
 package nomad
 
 import (
+	"context"
+
 	"github.com/hashicorp/nomad/nomad/structs"
 	vapi "github.com/hashicorp/vault/api"
 )
@@ -18,7 +20,7 @@ type TestVaultClient struct {
 	LookupTokenSecret map[string]*vapi.Secret
 }
 
-func (v *TestVaultClient) LookupToken(token string) (*vapi.Secret, error) {
+func (v *TestVaultClient) LookupToken(ctx context.Context, token string) (*vapi.Secret, error) {
 	var secret *vapi.Secret
 	var err error
 
@@ -64,7 +66,7 @@ func (v *TestVaultClient) SetLookupTokenAllowedPolicies(token string, policies [
 	v.SetLookupTokenSecret(token, s)
 }
 
-func (v *TestVaultClient) CreateToken(a *structs.Allocation, task string) (*vapi.Secret, error) {
+func (v *TestVaultClient) CreateToken(ctx context.Context, a *structs.Allocation, task string) (*vapi.Secret, error) {
 	return nil, nil
 }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Create a temp dir and clean it up on exit
 TEMPDIR=`mktemp -d -t nomad-test.XXX`

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export PING_SLEEP=30
 bash -c "while true; do echo \$(date) - building ...; sleep $PING_SLEEP; done" &

--- a/testutil/vault.go
+++ b/testutil/vault.go
@@ -119,6 +119,6 @@ func (tv *TestVault) waitForAPI() {
 // getPort returns the next available port to bind Vault against
 func getPort() uint64 {
 	p := vaultStartPort + vaultPortOffset
-	offset += 1
+	vaultPortOffset += 1
 	return p
 }

--- a/vendor/github.com/hashicorp/vault/api/auth_token.go
+++ b/vendor/github.com/hashicorp/vault/api/auth_token.go
@@ -170,6 +170,7 @@ type TokenCreateRequest struct {
 	Lease           string            `json:"lease,omitempty"`
 	TTL             string            `json:"ttl,omitempty"`
 	ExplicitMaxTTL  string            `json:"explicit_max_ttl,omitempty"`
+	Period          string            `json:"period,omitempty"`
 	NoParent        bool              `json:"no_parent,omitempty"`
 	NoDefaultPolicy bool              `json:"no_default_policy,omitempty"`
 	DisplayName     string            `json:"display_name"`

--- a/vendor/github.com/hashicorp/vault/api/sys_capabilities.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_capabilities.go
@@ -28,17 +28,14 @@ func (c *Sys) Capabilities(token, path string) ([]string, error) {
 	}
 	defer resp.Body.Close()
 
-	secret, err := ParseSecret(resp.Body)
+	var result map[string]interface{}
+	err = resp.DecodeJSON(&result)
 	if err != nil {
 		return nil, err
 	}
 
-	if secret == nil || secret.Data == nil || len(secret.Data) == 0 {
-		return nil, nil
-	}
-
 	var capabilities []string
-	capabilitiesRaw := secret.Data["capabilities"].([]interface{})
+	capabilitiesRaw := result["capabilities"].([]interface{})
 	for _, capability := range capabilitiesRaw {
 		capabilities = append(capabilities, capability.(string))
 	}

--- a/vendor/github.com/hashicorp/vault/api/sys_init.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_init.go
@@ -45,7 +45,9 @@ type InitStatusResponse struct {
 }
 
 type InitResponse struct {
-	Keys         []string `json:"keys"`
-	RecoveryKeys []string `json:"recovery_keys"`
-	RootToken    string   `json:"root_token"`
+	Keys            []string `json:"keys"`
+	KeysB64         []string `json:"keys_base64"`
+	RecoveryKeys    []string `json:"recovery_keys"`
+	RecoveryKeysB64 []string `json:"recovery_keys_base64"`
+	RootToken       string   `json:"root_token"`
 }

--- a/vendor/github.com/hashicorp/vault/api/sys_rekey.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_rekey.go
@@ -190,11 +190,13 @@ type RekeyUpdateResponse struct {
 	Nonce           string
 	Complete        bool
 	Keys            []string
+	KeysB64         []string `json:"keys_base64"`
 	PGPFingerprints []string `json:"pgp_fingerprints"`
 	Backup          bool
 }
 
 type RekeyRetrieveResponse struct {
-	Nonce string
-	Keys  map[string][]string
+	Nonce   string
+	Keys    map[string][]string
+	KeysB64 map[string][]string `json:"keys_base64"`
 }

--- a/vendor/github.com/hashicorp/vault/api/sys_rotate.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_rotate.go
@@ -1,10 +1,6 @@
 package api
 
-import (
-	"time"
-
-	"github.com/mitchellh/mapstructure"
-)
+import "time"
 
 func (c *Sys) Rotate() error {
 	r := c.c.NewRequest("POST", "/v1/sys/rotate")
@@ -23,25 +19,12 @@ func (c *Sys) KeyStatus() (*KeyStatus, error) {
 	}
 	defer resp.Body.Close()
 
-	secret, err := ParseSecret(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if secret == nil || secret.Data == nil || len(secret.Data) == 0 {
-		return nil, nil
-	}
-
-	var result KeyStatus
-	err = mapstructure.Decode(secret.Data, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result, err
+	result := new(KeyStatus)
+	err = resp.DecodeJSON(result)
+	return result, err
 }
 
 type KeyStatus struct {
-	Term        int
+	Term        int       `json:"term"`
 	InstallTime time.Time `json:"install_time"`
 }

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/vendor/golang.org/x/time/LICENSE
+++ b/vendor/golang.org/x/time/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/time/PATENTS
+++ b/vendor/golang.org/x/time/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/time/rate/rate.go
+++ b/vendor/golang.org/x/time/rate/rate.go
@@ -1,0 +1,368 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package rate provides a rate limiter.
+package rate
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// Limit defines the maximum frequency of some events.
+// Limit is represented as number of events per second.
+// A zero Limit allows no events.
+type Limit float64
+
+// Inf is the infinite rate limit; it allows all events (even if burst is zero).
+const Inf = Limit(math.MaxFloat64)
+
+// Every converts a minimum time interval between events to a Limit.
+func Every(interval time.Duration) Limit {
+	if interval <= 0 {
+		return Inf
+	}
+	return 1 / Limit(interval.Seconds())
+}
+
+// A Limiter controls how frequently events are allowed to happen.
+// It implements a "token bucket" of size b, initially full and refilled
+// at rate r tokens per second.
+// Informally, in any large enough time interval, the Limiter limits the
+// rate to r tokens per second, with a maximum burst size of b events.
+// As a special case, if r == Inf (the infinite rate), b is ignored.
+// See https://en.wikipedia.org/wiki/Token_bucket for more about token buckets.
+//
+// The zero value is a valid Limiter, but it will reject all events.
+// Use NewLimiter to create non-zero Limiters.
+//
+// Limiter has three main methods, Allow, Reserve, and Wait.
+// Most callers should use Wait.
+//
+// Each of the three methods consumes a single token.
+// They differ in their behavior when no token is available.
+// If no token is available, Allow returns false.
+// If no token is available, Reserve returns a reservation for a future token
+// and the amount of time the caller must wait before using it.
+// If no token is available, Wait blocks until one can be obtained
+// or its associated context.Context is canceled.
+//
+// The methods AllowN, ReserveN, and WaitN consume n tokens.
+type Limiter struct {
+	limit Limit
+	burst int
+
+	mu     sync.Mutex
+	tokens float64
+	// last is the last time the limiter's tokens field was updated
+	last time.Time
+	// lastEvent is the latest time of a rate-limited event (past or future)
+	lastEvent time.Time
+}
+
+// Limit returns the maximum overall event rate.
+func (lim *Limiter) Limit() Limit {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+	return lim.limit
+}
+
+// Burst returns the maximum burst size. Burst is the maximum number of tokens
+// that can be consumed in a single call to Allow, Reserve, or Wait, so higher
+// Burst values allow more events to happen at once.
+// A zero Burst allows no events, unless limit == Inf.
+func (lim *Limiter) Burst() int {
+	return lim.burst
+}
+
+// NewLimiter returns a new Limiter that allows events up to rate r and permits
+// bursts of at most b tokens.
+func NewLimiter(r Limit, b int) *Limiter {
+	return &Limiter{
+		limit: r,
+		burst: b,
+	}
+}
+
+// Allow is shorthand for AllowN(time.Now(), 1).
+func (lim *Limiter) Allow() bool {
+	return lim.AllowN(time.Now(), 1)
+}
+
+// AllowN reports whether n events may happen at time now.
+// Use this method if you intend to drop / skip events that exceed the rate limit.
+// Otherwise use Reserve or Wait.
+func (lim *Limiter) AllowN(now time.Time, n int) bool {
+	return lim.reserveN(now, n, 0).ok
+}
+
+// A Reservation holds information about events that are permitted by a Limiter to happen after a delay.
+// A Reservation may be canceled, which may enable the Limiter to permit additional events.
+type Reservation struct {
+	ok        bool
+	lim       *Limiter
+	tokens    int
+	timeToAct time.Time
+	// This is the Limit at reservation time, it can change later.
+	limit Limit
+}
+
+// OK returns whether the limiter can provide the requested number of tokens
+// within the maximum wait time.  If OK is false, Delay returns InfDuration, and
+// Cancel does nothing.
+func (r *Reservation) OK() bool {
+	return r.ok
+}
+
+// Delay is shorthand for DelayFrom(time.Now()).
+func (r *Reservation) Delay() time.Duration {
+	return r.DelayFrom(time.Now())
+}
+
+// InfDuration is the duration returned by Delay when a Reservation is not OK.
+const InfDuration = time.Duration(1<<63 - 1)
+
+// DelayFrom returns the duration for which the reservation holder must wait
+// before taking the reserved action.  Zero duration means act immediately.
+// InfDuration means the limiter cannot grant the tokens requested in this
+// Reservation within the maximum wait time.
+func (r *Reservation) DelayFrom(now time.Time) time.Duration {
+	if !r.ok {
+		return InfDuration
+	}
+	delay := r.timeToAct.Sub(now)
+	if delay < 0 {
+		return 0
+	}
+	return delay
+}
+
+// Cancel is shorthand for CancelAt(time.Now()).
+func (r *Reservation) Cancel() {
+	r.CancelAt(time.Now())
+	return
+}
+
+// CancelAt indicates that the reservation holder will not perform the reserved action
+// and reverses the effects of this Reservation on the rate limit as much as possible,
+// considering that other reservations may have already been made.
+func (r *Reservation) CancelAt(now time.Time) {
+	if !r.ok {
+		return
+	}
+
+	r.lim.mu.Lock()
+	defer r.lim.mu.Unlock()
+
+	if r.lim.limit == Inf || r.tokens == 0 || r.timeToAct.Before(now) {
+		return
+	}
+
+	// calculate tokens to restore
+	// The duration between lim.lastEvent and r.timeToAct tells us how many tokens were reserved
+	// after r was obtained. These tokens should not be restored.
+	restoreTokens := float64(r.tokens) - r.limit.tokensFromDuration(r.lim.lastEvent.Sub(r.timeToAct))
+	if restoreTokens <= 0 {
+		return
+	}
+	// advance time to now
+	now, _, tokens := r.lim.advance(now)
+	// calculate new number of tokens
+	tokens += restoreTokens
+	if burst := float64(r.lim.burst); tokens > burst {
+		tokens = burst
+	}
+	// update state
+	r.lim.last = now
+	r.lim.tokens = tokens
+	if r.timeToAct == r.lim.lastEvent {
+		prevEvent := r.timeToAct.Add(r.limit.durationFromTokens(float64(-r.tokens)))
+		if !prevEvent.Before(now) {
+			r.lim.lastEvent = prevEvent
+		}
+	}
+
+	return
+}
+
+// Reserve is shorthand for ReserveN(time.Now(), 1).
+func (lim *Limiter) Reserve() *Reservation {
+	return lim.ReserveN(time.Now(), 1)
+}
+
+// ReserveN returns a Reservation that indicates how long the caller must wait before n events happen.
+// The Limiter takes this Reservation into account when allowing future events.
+// ReserveN returns false if n exceeds the Limiter's burst size.
+// Usage example:
+//   r, ok := lim.ReserveN(time.Now(), 1)
+//   if !ok {
+//     // Not allowed to act! Did you remember to set lim.burst to be > 0 ?
+//   }
+//   time.Sleep(r.Delay())
+//   Act()
+// Use this method if you wish to wait and slow down in accordance with the rate limit without dropping events.
+// If you need to respect a deadline or cancel the delay, use Wait instead.
+// To drop or skip events exceeding rate limit, use Allow instead.
+func (lim *Limiter) ReserveN(now time.Time, n int) *Reservation {
+	r := lim.reserveN(now, n, InfDuration)
+	return &r
+}
+
+// Wait is shorthand for WaitN(ctx, 1).
+func (lim *Limiter) Wait(ctx context.Context) (err error) {
+	return lim.WaitN(ctx, 1)
+}
+
+// WaitN blocks until lim permits n events to happen.
+// It returns an error if n exceeds the Limiter's burst size, the Context is
+// canceled, or the expected wait time exceeds the Context's Deadline.
+func (lim *Limiter) WaitN(ctx context.Context, n int) (err error) {
+	if n > lim.burst {
+		return fmt.Errorf("rate: Wait(n=%d) exceeds limiter's burst %d", n, lim.burst)
+	}
+	// Check if ctx is already cancelled
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	// Determine wait limit
+	now := time.Now()
+	waitLimit := InfDuration
+	if deadline, ok := ctx.Deadline(); ok {
+		waitLimit = deadline.Sub(now)
+	}
+	// Reserve
+	r := lim.reserveN(now, n, waitLimit)
+	if !r.ok {
+		return fmt.Errorf("rate: Wait(n=%d) would exceed context deadline", n)
+	}
+	// Wait
+	t := time.NewTimer(r.DelayFrom(now))
+	defer t.Stop()
+	select {
+	case <-t.C:
+		// We can proceed.
+		return nil
+	case <-ctx.Done():
+		// Context was canceled before we could proceed.  Cancel the
+		// reservation, which may permit other events to proceed sooner.
+		r.Cancel()
+		return ctx.Err()
+	}
+}
+
+// SetLimit is shorthand for SetLimitAt(time.Now(), newLimit).
+func (lim *Limiter) SetLimit(newLimit Limit) {
+	lim.SetLimitAt(time.Now(), newLimit)
+}
+
+// SetLimitAt sets a new Limit for the limiter. The new Limit, and Burst, may be violated
+// or underutilized by those which reserved (using Reserve or Wait) but did not yet act
+// before SetLimitAt was called.
+func (lim *Limiter) SetLimitAt(now time.Time, newLimit Limit) {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+
+	now, _, tokens := lim.advance(now)
+
+	lim.last = now
+	lim.tokens = tokens
+	lim.limit = newLimit
+}
+
+// reserveN is a helper method for AllowN, ReserveN, and WaitN.
+// maxFutureReserve specifies the maximum reservation wait duration allowed.
+// reserveN returns Reservation, not *Reservation, to avoid allocation in AllowN and WaitN.
+func (lim *Limiter) reserveN(now time.Time, n int, maxFutureReserve time.Duration) Reservation {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+
+	if lim.limit == Inf {
+		return Reservation{
+			ok:        true,
+			lim:       lim,
+			tokens:    n,
+			timeToAct: now,
+		}
+	}
+
+	now, last, tokens := lim.advance(now)
+
+	// Calculate the remaining number of tokens resulting from the request.
+	tokens -= float64(n)
+
+	// Calculate the wait duration
+	var waitDuration time.Duration
+	if tokens < 0 {
+		waitDuration = lim.limit.durationFromTokens(-tokens)
+	}
+
+	// Decide result
+	ok := n <= lim.burst && waitDuration <= maxFutureReserve
+
+	// Prepare reservation
+	r := Reservation{
+		ok:    ok,
+		lim:   lim,
+		limit: lim.limit,
+	}
+	if ok {
+		r.tokens = n
+		r.timeToAct = now.Add(waitDuration)
+	}
+
+	// Update state
+	if ok {
+		lim.last = now
+		lim.tokens = tokens
+		lim.lastEvent = r.timeToAct
+	} else {
+		lim.last = last
+	}
+
+	return r
+}
+
+// advance calculates and returns an updated state for lim resulting from the passage of time.
+// lim is not changed.
+func (lim *Limiter) advance(now time.Time) (newNow time.Time, newLast time.Time, newTokens float64) {
+	last := lim.last
+	if now.Before(last) {
+		last = now
+	}
+
+	// Avoid making delta overflow below when last is very old.
+	maxElapsed := lim.limit.durationFromTokens(float64(lim.burst) - lim.tokens)
+	elapsed := now.Sub(last)
+	if elapsed > maxElapsed {
+		elapsed = maxElapsed
+	}
+
+	// Calculate the new number of tokens, due to time that passed.
+	delta := lim.limit.tokensFromDuration(elapsed)
+	tokens := lim.tokens + delta
+	if burst := float64(lim.burst); tokens > burst {
+		tokens = burst
+	}
+
+	return now, last, tokens
+}
+
+// durationFromTokens is a unit conversion function from the number of tokens to the duration
+// of time it takes to accumulate them at a rate of limit tokens per second.
+func (limit Limit) durationFromTokens(tokens float64) time.Duration {
+	seconds := tokens / float64(limit)
+	return time.Nanosecond * time.Duration(1e9*seconds)
+}
+
+// tokensFromDuration is a unit conversion function from a time duration to the number of tokens
+// which could be accumulated during that duration at a rate of limit tokens per second.
+func (limit Limit) tokensFromDuration(d time.Duration) float64 {
+	return d.Seconds() * float64(limit)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -834,6 +834,12 @@
 			"revisionTime": "2016-05-25T13:11:03Z"
 		},
 		{
+			"checksumSHA1": "S0DP7Pn7sZUmXc55IzZnNvERu6s=",
+			"path": "golang.org/x/sync/errgroup",
+			"revision": "316e794f7b5e3df4e95175a45a5fb8b12f85cb4f",
+			"revisionTime": "2016-07-15T18:54:39Z"
+		},
+		{
 			"path": "golang.org/x/sys/unix",
 			"revision": "50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e"
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -623,10 +623,16 @@
 			"revisionTime": "2016-06-09T00:18:40Z"
 		},
 		{
-			"checksumSHA1": "0rkVtm9F1/pW9EGhHYJpCnY99O8=",
+			"checksumSHA1": "RAJfRxZ8UmcL6+7VuXAZxBlnM/4=",
+			"path": "github.com/hashicorp/vault",
+			"revision": "fece3ca069fc5bafec5280bbcb0c0693ff69fdaf",
+			"revisionTime": "2016-08-17T21:47:06Z"
+		},
+		{
+			"checksumSHA1": "JH8wmQ8cWdn7mYu1T7gJ3IMIrec=",
 			"path": "github.com/hashicorp/vault/api",
-			"revision": "fbecd94926e289d3b81d8dae6136452a6c4c93f6",
-			"revisionTime": "2016-08-13T15:54:01Z"
+			"revision": "fece3ca069fc5bafec5280bbcb0c0693ff69fdaf",
+			"revisionTime": "2016-08-17T21:47:06Z"
 		},
 		{
 			"checksumSHA1": "5lR6EdY0ARRdKAq3hZcL38STD8Q=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -844,6 +844,12 @@
 			"revisionTime": "2016-04-21T02:29:30Z"
 		},
 		{
+			"checksumSHA1": "h/06ikMECfJoTkWj2e1nJ30aDDg=",
+			"path": "golang.org/x/time/rate",
+			"revision": "a4bde12657593d5e90d0533a3e4fd95e635124cb",
+			"revisionTime": "2016-02-02T18:34:45Z"
+		},
+		{
 			"checksumSHA1": "93uHIq25lffEKY47PV8dBPD+XuQ=",
 			"path": "gopkg.in/fsnotify.v1",
 			"revision": "a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb",


### PR DESCRIPTION
This PR adds:

* An endpoint for clients to hit to derive tokens
* Raft/FSM handling of VaultAccessors
* VaultAccessor MemDB table

This PR does *NOT* handle token revocation

@armon @diptanu @vishalnayak  for review