### PR TITLE
Block allocations when their chained allocation hasn't finished

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -554,3 +554,84 @@ func TestClient_Init(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func TestClient_BlockedAllocations(t *testing.T) {
+	s1, _ := testServer(t, nil)
+	defer s1.Shutdown()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1 := testClient(t, func(c *config.Config) {
+		c.RPCHandler = s1
+	})
+	//defer c1.Shutdown()
+
+	alloc := mock.Alloc()
+	alloc.NodeID = c1.Node().ID
+	alloc.Job.TaskGroups[0].Tasks[0].Driver = "mock_driver"
+	alloc.Job.TaskGroups[0].Tasks[0].KillTimeout = 1 * time.Second
+	alloc.Job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"kill_after":  "50s",
+		"run_for":     "100s",
+		"exit_code":   0,
+		"exit_signal": 0,
+		"exit_err":    "",
+	}
+
+	state := s1.State()
+	if err := state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID)); err != nil {
+		t.Fatal(err)
+	}
+	state.UpsertAllocs(100, []*structs.Allocation{alloc})
+
+	testutil.WaitForResult(func() (bool, error) {
+		out, err := state.AllocByID(alloc.ID)
+		if err != nil {
+			return false, err
+		}
+		if out == nil {
+			return false, fmt.Errorf("no such alloc")
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Change the desired state of the alloc to stop
+	alloc1 := alloc.Copy()
+	alloc1.DesiredStatus = structs.AllocDesiredStatusStop
+	if err := state.UpsertAllocs(200, []*structs.Allocation{alloc1}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Add a new chained alloc
+	alloc2 := alloc.Copy()
+	alloc2.ID = structs.GenerateUUID()
+	alloc2.Job = alloc.Job
+	alloc2.JobID = alloc.JobID
+	alloc2.PreviousAllocation = alloc.ID
+	if err := state.UpsertAllocs(300, []*structs.Allocation{alloc2}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Enusre that the chained allocation is being tracked as blocked
+	testutil.WaitForResult(func() (bool, error) {
+		alloc, ok := c1.blockedAllocations[alloc2.PreviousAllocation]
+		if ok && alloc.ID == alloc2.ID {
+			return true, nil
+		}
+		return false, fmt.Errorf("no blocked allocations")
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Enusre that no allocations are blocked
+	testutil.WaitForResult(func() (bool, error) {
+		_, ok := c1.blockedAllocations[alloc2.PreviousAllocation]
+		if ok {
+			return false, fmt.Errorf("blocked allocs present %#v", c1.blockedAllocations)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+}

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -19,12 +19,13 @@ import (
 // BuiltinDrivers contains the built in registered drivers
 // which are available for allocation handling
 var BuiltinDrivers = map[string]Factory{
-	"docker":   NewDockerDriver,
-	"exec":     NewExecDriver,
-	"raw_exec": NewRawExecDriver,
-	"java":     NewJavaDriver,
-	"qemu":     NewQemuDriver,
-	"rkt":      NewRktDriver,
+	"docker":      NewDockerDriver,
+	"exec":        NewExecDriver,
+	"raw_exec":    NewRawExecDriver,
+	"java":        NewJavaDriver,
+	"qemu":        NewQemuDriver,
+	"rkt":         NewRktDriver,
+	"mock_driver": NewMockDriver,
 }
 
 // NewDriver is used to instantiate and return a new driver

--- a/client/driver/mock_driver.go
+++ b/client/driver/mock_driver.go
@@ -1,0 +1,160 @@
+package driver
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/nomad/client/config"
+	dstructs "github.com/hashicorp/nomad/client/driver/structs"
+	"github.com/hashicorp/nomad/client/fingerprint"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// MockDriverConfig is the driver configuration for the MockDriver
+type MockDriverConfig struct {
+
+	// KillAfter is the duration after which the mock driver indicates the task
+	// has exited after getting the initial SIGINT signal
+	KillAfter time.Duration `mapstructure:"kill_after"`
+
+	// RunFor is the duration for which the fake task runs for. After this
+	// period the MockDriver responds to the task running indicating that the
+	// task has terminated
+	RunFor time.Duration `mapstructure:"run_for"`
+
+	// ExitCode is the exit code with which the MockDriver indicates the task
+	// has exited
+	ExitCode int `mapstructure:"exit_code"`
+
+	// ExitSignal is the signal with which the MockDriver indicates the task has
+	// been killed
+	ExitSignal int `mapstructure:"exit_signal"`
+
+	// ExitErrMsg is the error message that the task returns while exiting
+	ExitErrMsg string `mapstructure:"exit_err_msg"`
+}
+
+// MockDriver is a driver which is used for testing purposes
+type MockDriver struct {
+	DriverContext
+	fingerprint.StaticFingerprinter
+}
+
+// NewMockDriver is a factory method which returns a new Mock Driver
+func NewMockDriver(ctx *DriverContext) Driver {
+	return &MockDriver{DriverContext: *ctx}
+}
+
+// Start starts the mock driver
+func (m *MockDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
+	var driverConfig MockDriverConfig
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+		WeaklyTypedInput: true,
+		Result:           &driverConfig,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := dec.Decode(task.Config); err != nil {
+		return nil, err
+	}
+
+	h := mockDriverHandle{
+		runFor:      driverConfig.RunFor,
+		killAfter:   driverConfig.KillAfter,
+		killTimeout: task.KillTimeout,
+		exitCode:    driverConfig.ExitCode,
+		exitSignal:  driverConfig.ExitSignal,
+		logger:      m.logger,
+		doneCh:      make(chan struct{}),
+		waitCh:      make(chan *dstructs.WaitResult, 1),
+	}
+	if driverConfig.ExitErrMsg != "" {
+		h.exitErr = errors.New(driverConfig.ExitErrMsg)
+	}
+	go h.run()
+	return &h, nil
+}
+
+// TODO implement Open when we need it.
+// Open re-connects the driver to the running task
+func (m *MockDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error) {
+	return nil, nil
+}
+
+// TODO implement Open when we need it.
+// Validate validates the mock driver configuration
+func (m *MockDriver) Validate(map[string]interface{}) error {
+	return nil
+}
+
+// TODO implement Open when we need it.
+// Fingerprint fingerprints a node and returns if MockDriver is enabled
+func (m *MockDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
+	return true, nil
+}
+
+// MockDriverHandle is a driver handler which supervises a mock task
+type mockDriverHandle struct {
+	runFor      time.Duration
+	killAfter   time.Duration
+	killTimeout time.Duration
+	exitCode    int
+	exitSignal  int
+	exitErr     error
+	logger      *log.Logger
+	waitCh      chan *dstructs.WaitResult
+	doneCh      chan struct{}
+}
+
+// TODO Implement when we need it.
+func (h *mockDriverHandle) ID() string {
+	return ""
+}
+
+// TODO Implement when we need it.
+func (h *mockDriverHandle) WaitCh() chan *dstructs.WaitResult {
+	return h.waitCh
+}
+
+// TODO Implement when we need it.
+func (h *mockDriverHandle) Update(task *structs.Task) error {
+	return nil
+}
+
+// Kill kills a mock task
+func (h *mockDriverHandle) Kill() error {
+	select {
+	case <-h.doneCh:
+		return nil
+	case <-time.After(h.killTimeout):
+		close(h.doneCh)
+		return nil
+	}
+}
+
+// TODO Implement when we need it.
+func (h *mockDriverHandle) Stats() (*cstructs.TaskResourceUsage, error) {
+	return nil, nil
+}
+
+// run waits for the configured amount of time and then indicates the task has
+// terminated
+func (h *mockDriverHandle) run() {
+	timer := time.NewTimer(h.runFor)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			close(h.doneCh)
+		case <-h.doneCh:
+			h.waitCh <- dstructs.NewWaitResult(h.exitCode, h.exitSignal, h.exitErr)
+			return
+		}
+	}
+}

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -507,7 +507,9 @@ func (r *TaskRunner) collectResourceUsageStats(stopCollection <-chan struct{}) {
 			r.resourceUsageLock.Lock()
 			r.resourceUsage = ru
 			r.resourceUsageLock.Unlock()
-			r.emitStats(ru)
+			if ru != nil {
+				r.emitStats(ru)
+			}
 		case <-stopCollection:
 			return
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2626,6 +2626,16 @@ func (a *Allocation) TerminalStatus() bool {
 	}
 }
 
+// Terminating returns if the allocation is stopped and currently transitioning
+// to the terminal state
+func (a *Allocation) Terminating() bool {
+	if a.DesiredStatus == AllocDesiredStatusStop &&
+		(a.ClientStatus == AllocClientStatusRunning || a.ClientStatus == AllocClientStatusPending) {
+		return true
+	}
+	return false
+}
+
 // RanSuccessfully returns whether the client has ran the allocation and all
 // tasks finished successfully
 func (a *Allocation) RanSuccessfully() bool {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2626,11 +2626,11 @@ func (a *Allocation) TerminalStatus() bool {
 	}
 }
 
-// Terminating returns if the allocation is stopped and currently transitioning
-// to the terminal state
-func (a *Allocation) Terminating() bool {
-	if a.DesiredStatus == AllocDesiredStatusStop &&
-		(a.ClientStatus == AllocClientStatusRunning || a.ClientStatus == AllocClientStatusPending) {
+// Terminated returns if the allocation is in a terminal state on a client.
+func (a *Allocation) Terminated() bool {
+	if a.ClientStatus == AllocClientStatusFailed ||
+		a.ClientStatus == AllocClientStatusComplete ||
+		a.ClientStatus == AllocClientStatusLost {
 		return true
 	}
 	return false

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1096,29 +1096,29 @@ func TestAllocation_Terminating(t *testing.T) {
 	type desiredState struct {
 		ClientStatus  string
 		DesiredStatus string
-		Terminating   bool
+		Terminated    bool
 	}
 
 	harness := []desiredState{
 		{
 			ClientStatus:  AllocClientStatusPending,
 			DesiredStatus: AllocDesiredStatusStop,
-			Terminating:   true,
+			Terminated:    false,
 		},
 		{
 			ClientStatus:  AllocClientStatusRunning,
 			DesiredStatus: AllocDesiredStatusStop,
-			Terminating:   true,
+			Terminated:    false,
 		},
 		{
 			ClientStatus:  AllocClientStatusFailed,
 			DesiredStatus: AllocDesiredStatusStop,
-			Terminating:   false,
+			Terminated:    true,
 		},
 		{
 			ClientStatus:  AllocClientStatusFailed,
 			DesiredStatus: AllocDesiredStatusRun,
-			Terminating:   false,
+			Terminated:    true,
 		},
 	}
 
@@ -1126,8 +1126,8 @@ func TestAllocation_Terminating(t *testing.T) {
 		alloc := Allocation{}
 		alloc.DesiredStatus = state.DesiredStatus
 		alloc.ClientStatus = state.ClientStatus
-		if alloc.Terminating() != state.Terminating {
-			t.Fatalf("expected: %v, actual: %v", state.Terminating, alloc.Terminating())
+		if alloc.Terminated() != state.Terminated {
+			t.Fatalf("expected: %v, actual: %v", state.Terminated, alloc.Terminated())
 		}
 	}
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1091,3 +1091,43 @@ func TestTaskArtifact_Validate_Checksum(t *testing.T) {
 		}
 	}
 }
+
+func TestAllocation_Terminating(t *testing.T) {
+	type desiredState struct {
+		ClientStatus  string
+		DesiredStatus string
+		Terminating   bool
+	}
+
+	harness := []desiredState{
+		{
+			ClientStatus:  AllocClientStatusPending,
+			DesiredStatus: AllocDesiredStatusStop,
+			Terminating:   true,
+		},
+		{
+			ClientStatus:  AllocClientStatusRunning,
+			DesiredStatus: AllocDesiredStatusStop,
+			Terminating:   true,
+		},
+		{
+			ClientStatus:  AllocClientStatusFailed,
+			DesiredStatus: AllocDesiredStatusStop,
+			Terminating:   false,
+		},
+		{
+			ClientStatus:  AllocClientStatusFailed,
+			DesiredStatus: AllocDesiredStatusRun,
+			Terminating:   false,
+		},
+	}
+
+	for _, state := range harness {
+		alloc := Allocation{}
+		alloc.DesiredStatus = state.DesiredStatus
+		alloc.ClientStatus = state.ClientStatus
+		if alloc.Terminating() != state.Terminating {
+			t.Fatalf("expected: %v, actual: %v", state.Terminating, alloc.Terminating())
+		}
+	}
+}


### PR DESCRIPTION
*WIP* for running tests on travis

This PR adds the functionality for clients to block an allocation if the chained allocation hasn't stopped running.