### PR TITLE
issue #1636:  start CheckRunner if check exists in consul already

### DIFF
--- a/command/agent/consul/check.go
+++ b/command/agent/consul/check.go
@@ -47,6 +47,7 @@ func (r *CheckRunner) Start() {
 	r.started = true
 }
 
+// Started returns if the check runner has started running
 func (r *CheckRunner) Started() bool {
 	r.startedLock.Lock()
 	defer r.startedLock.Unlock()

--- a/command/agent/consul/check.go
+++ b/command/agent/consul/check.go
@@ -47,6 +47,12 @@ func (r *CheckRunner) Start() {
 	r.started = true
 }
 
+func (r *CheckRunner) Started() bool {
+	r.startedLock.Lock()
+	defer r.startedLock.Unlock()
+	return r.started
+}
+
 // Stop is used to stop the check.
 func (r *CheckRunner) Stop() {
 	r.stopLock.Lock()

--- a/command/agent/consul/syncer.go
+++ b/command/agent/consul/syncer.go
@@ -394,7 +394,7 @@ func (c *Syncer) syncChecks() error {
 	}
 
 	// Synchronize checks with Consul
-	missingChecks, _, changedChecks, staleChecks := c.calcChecksDiff(consulChecks)
+	missingChecks, existingChecks, changedChecks, staleChecks := c.calcChecksDiff(consulChecks)
 	for _, check := range missingChecks {
 		if err := c.registerCheck(check); err != nil {
 			mErr.Errors = append(mErr.Errors, err)
@@ -402,6 +402,9 @@ func (c *Syncer) syncChecks() error {
 		c.registryLock.Lock()
 		c.trackedChecks[consulCheckID(check.ID)] = check
 		c.registryLock.Unlock()
+	}
+	for _, check := range existingChecks {
+		c.ensureCheckRunning(check)
 	}
 	for _, check := range changedChecks {
 		// NOTE(sean@): Do we need to deregister the check before
@@ -682,6 +685,20 @@ func (c *Syncer) registerCheck(chkReg *consul.AgentCheckRegistration) error {
 	}
 	c.registryLock.RUnlock()
 	return c.client.Agent().CheckRegister(chkReg)
+}
+
+// ensureCheckRunning verifies that registerd check is in running state
+func (c *Syncer) ensureCheckRunning(chk *consul.AgentCheckRegistration) {
+	c.registryLock.RLock()
+	defer c.registryLock.RUnlock()
+	cr, ok := c.checkRunners[consulCheckID(chk.ID)]
+	if !ok {
+		return
+	}
+	if !cr.Started() {
+		c.logger.Printf("[DEBUG] ensureCheckRunning Running existing check. %v", chk)
+		cr.Start()
+	}
 }
 
 // createCheckReg creates a Check that can be registered with Nomad. It also

--- a/command/agent/consul/syncer.go
+++ b/command/agent/consul/syncer.go
@@ -687,16 +687,12 @@ func (c *Syncer) registerCheck(chkReg *consul.AgentCheckRegistration) error {
 	return c.client.Agent().CheckRegister(chkReg)
 }
 
-// ensureCheckRunning verifies that registerd check is in running state
+// ensureCheckRunning starts the check runner for a check if it's not already running
 func (c *Syncer) ensureCheckRunning(chk *consul.AgentCheckRegistration) {
 	c.registryLock.RLock()
 	defer c.registryLock.RUnlock()
-	cr, ok := c.checkRunners[consulCheckID(chk.ID)]
-	if !ok {
-		return
-	}
-	if !cr.Started() {
-		c.logger.Printf("[DEBUG] ensureCheckRunning Running existing check. %v", chk)
+	if cr, ok := c.checkRunners[consulCheckID(chk.ID)]; ok && !cr.Started() {
+		c.logger.Printf("[DEBUG] consul.syncer: starting runner for existing check. %v", chk.ID)
 		cr.Start()
 	}
 }


### PR DESCRIPTION
CheckRunner currently starts only during check registration in registerCheck() method. This is a problem when check already exists in consul (nomad executor registered it during previews run). In that case registerCheck is not called for a check and nobody calls .Start() method of CheckRunner. In result we have check in TTL expired state