### PR TITLE
Make alloc-status and node-status work without access to stats

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -204,14 +204,6 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		return 0
 	}
 
-	var statsErr error
-	var stats *api.AllocResourceUsage
-	stats, statsErr = client.Allocations().Stats(alloc, nil)
-	if statsErr != nil {
-		c.Ui.Output("")
-		c.Ui.Error(fmt.Sprintf("couldn't retrieve stats (HINT: ensure Client.Advertise.HTTP is set): %v", statsErr))
-	}
-
 	// Format the allocation data
 	basic := []string{
 		fmt.Sprintf("ID|%s", limit(alloc.ID, length)),
@@ -236,6 +228,13 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	if short {
 		c.shortTaskStatus(alloc)
 	} else {
+		var statsErr error
+		var stats *api.AllocResourceUsage
+		stats, statsErr = client.Allocations().Stats(alloc, nil)
+		if statsErr != nil {
+			c.Ui.Output("")
+			c.Ui.Error(fmt.Sprintf("couldn't retrieve stats (HINT: ensure Client.Advertise.HTTP is set): %v", statsErr))
+		}
 		c.outputTaskDetails(alloc, stats, displayStats)
 	}
 

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -284,13 +284,6 @@ func (c *NodeStatusCommand) Run(args []string) int {
 }
 
 func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
-	// Get the host stats
-	hostStats, nodeStatsErr := client.Nodes().Stats(node.ID, nil)
-	if nodeStatsErr != nil {
-		c.Ui.Output("")
-		c.Ui.Error(fmt.Sprintf("error fetching node stats (HINT: ensure Client.Advertise.HTTP is set): %v", nodeStatsErr))
-	}
-
 	// Format the header output
 	basic := []string{
 		fmt.Sprintf("ID|%s", limit(node.ID, c.length)),
@@ -300,13 +293,22 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		fmt.Sprintf("Drain|%v", node.Drain),
 		fmt.Sprintf("Status|%s", node.Status),
 	}
-	if hostStats != nil {
-		uptime := time.Duration(hostStats.Uptime * uint64(time.Second))
-		basic = append(basic, fmt.Sprintf("Uptime|%s", uptime.String()))
-	}
-	c.Ui.Output(c.Colorize().Color(formatKV(basic)))
 
-	if !c.short {
+	if c.short {
+		c.Ui.Output(c.Colorize().Color(formatKV(basic)))
+	} else {
+		// Get the host stats
+		hostStats, nodeStatsErr := client.Nodes().Stats(node.ID, nil)
+		if nodeStatsErr != nil {
+			c.Ui.Output("")
+			c.Ui.Error(fmt.Sprintf("error fetching node stats (HINT: ensure Client.Advertise.HTTP is set): %v", nodeStatsErr))
+		}
+		if hostStats != nil {
+			uptime := time.Duration(hostStats.Uptime * uint64(time.Second))
+			basic = append(basic, fmt.Sprintf("Uptime|%s", uptime.String()))
+		}
+		c.Ui.Output(c.Colorize().Color(formatKV(basic)))
+
 		// Get list of running allocations on the node
 		runningAllocs, err := getRunningAllocs(client, node.ID)
 		if err != nil {


### PR DESCRIPTION
With this change, `nomad alloc-status -short <allocation>` and `nomad node-status -short <node>` will work without having to fetch any client stats. This in turn allows us to use these commands on machines that don't have direct access to advertised client addresses (without having to wait for the "couldn't retrieve stats" warning).