### PR TITLE
Vault implicit Task Group constraint + allow root tokens

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -830,8 +830,9 @@ func (c *Client) registerAndHeartbeat() {
 					c.retryRegisterNode()
 					heartbeat = time.After(lib.RandomStagger(initialHeartbeatStagger))
 				} else {
-					c.logger.Printf("[ERR] client: heartbeating failed: %v", err)
-					heartbeat = time.After(c.retryIntv(registerRetryIntv))
+					intv := c.retryIntv(registerRetryIntv)
+					c.logger.Printf("[ERR] client: heartbeating failed. Retrying in %v: %v", intv, err)
+					heartbeat = time.After(intv)
 				}
 			} else {
 				c.heartbeatLock.Lock()

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -547,6 +547,16 @@ func TestJobEndpoint_Register_Vault_Policies(t *testing.T) {
 		t.Fatalf("vault token not cleared")
 	}
 
+	// Check that an implicit constraint was created
+	constraints := out.TaskGroups[0].Constraints
+	if l := len(constraints); l != 1 {
+		t.Fatalf("Unexpected number of tests: %v", l)
+	}
+
+	if !constraints[0].Equal(vaultConstraint) {
+		t.Fatalf("bad constraint; got %#v; want %#v", constraints[0], vaultConstraint)
+	}
+
 	// Create the register request with another job asking for a vault policy but
 	// send the root Vault token
 	job2 := mock.Job()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2534,6 +2534,13 @@ type Constraint struct {
 	str     string // Memoized string
 }
 
+// Equal checks if two constraints are equal
+func (c *Constraint) Equal(o *Constraint) bool {
+	return c.LTarget == o.LTarget &&
+		c.RTarget == o.RTarget &&
+		c.Operand == o.Operand
+}
+
 func (c *Constraint) Copy() *Constraint {
 	if c == nil {
 		return nil


### PR DESCRIPTION
This PR:
* Adds an implicit constraint on TaskGroups requesting Vault tokens
* Allows a root token access to all policies