### PR TITLE
Prevent state file corruption and check state file sanity on save

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -51,14 +51,13 @@ type AllocRunner struct {
 
 	dirtyCh chan struct{}
 
-	ctx     *driver.ExecContext
-	ctxLock sync.Mutex
+	ctx        *driver.ExecContext
+	ctxLock    sync.Mutex
+	tasks      map[string]*TaskRunner
+	taskStates map[string]*structs.TaskState
+	restored   map[string]struct{}
+	taskLock   sync.RWMutex
 
-	tasks    map[string]*TaskRunner
-	restored map[string]struct{}
-	taskLock sync.RWMutex
-
-	taskStates     map[string]*structs.TaskState
 	taskStatusLock sync.RWMutex
 
 	updateCh chan *structs.Allocation
@@ -126,6 +125,9 @@ func (r *AllocRunner) RestoreState() error {
 	var snapshotErrors multierror.Error
 	if r.alloc == nil {
 		snapshotErrors.Errors = append(snapshotErrors.Errors, fmt.Errorf("alloc_runner snapshot includes a nil allocation"))
+	}
+	if r.ctx == nil {
+		snapshotErrors.Errors = append(snapshotErrors.Errors, fmt.Errorf("alloc_runner snapshot includes a nil context"))
 	}
 	if e := snapshotErrors.ErrorOrNil(); e != nil {
 		return e

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -77,7 +77,6 @@ type allocRunnerState struct {
 	Alloc                  *structs.Allocation
 	AllocClientStatus      string
 	AllocClientDescription string
-	TaskStates             map[string]*structs.TaskState
 	Context                *driver.ExecContext
 }
 
@@ -121,7 +120,7 @@ func (r *AllocRunner) RestoreState() error {
 	r.ctx = snap.Context
 	r.allocClientStatus = snap.AllocClientStatus
 	r.allocClientDescription = snap.AllocClientDescription
-	r.taskStates = snap.TaskStates
+	r.taskStates = snap.Alloc.TaskStates
 
 	var snapshotErrors multierror.Error
 	if r.alloc == nil {
@@ -189,7 +188,6 @@ func (r *AllocRunner) saveAllocRunnerState() error {
 	alloc := r.Alloc()
 
 	r.allocLock.Lock()
-	states := alloc.TaskStates
 	allocClientStatus := r.allocClientStatus
 	allocClientDescription := r.allocClientDescription
 	r.allocLock.Unlock()
@@ -204,7 +202,6 @@ func (r *AllocRunner) saveAllocRunnerState() error {
 		Context:                ctx,
 		AllocClientStatus:      allocClientStatus,
 		AllocClientDescription: allocClientDescription,
-		TaskStates:             states,
 	}
 	return persistState(r.stateFilePath(), &snap)
 }

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -180,12 +180,9 @@ func (r *AllocRunner) SaveState() error {
 
 func (r *AllocRunner) saveAllocRunnerState() error {
 	// Create the snapshot.
-	r.taskStatusLock.RLock()
-	states := copyTaskStates(r.taskStates)
-	r.taskStatusLock.RUnlock()
-
 	alloc := r.Alloc()
 	r.allocLock.Lock()
+	states := alloc.TaskStates
 	allocClientStatus := r.allocClientStatus
 	allocClientDescription := r.allocClientDescription
 	r.allocLock.Unlock()

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -51,13 +51,14 @@ type AllocRunner struct {
 
 	dirtyCh chan struct{}
 
-	ctx        *driver.ExecContext
-	ctxLock    sync.Mutex
-	tasks      map[string]*TaskRunner
-	taskStates map[string]*structs.TaskState
-	restored   map[string]struct{}
-	taskLock   sync.RWMutex
+	ctx     *driver.ExecContext
+	ctxLock sync.Mutex
 
+	tasks    map[string]*TaskRunner
+	restored map[string]struct{}
+	taskLock sync.RWMutex
+
+	taskStates     map[string]*structs.TaskState
 	taskStatusLock sync.RWMutex
 
 	updateCh chan *structs.Allocation
@@ -125,9 +126,6 @@ func (r *AllocRunner) RestoreState() error {
 	var snapshotErrors multierror.Error
 	if r.alloc == nil {
 		snapshotErrors.Errors = append(snapshotErrors.Errors, fmt.Errorf("alloc_runner snapshot includes a nil allocation"))
-	}
-	if r.ctx == nil {
-		snapshotErrors.Errors = append(snapshotErrors.Errors, fmt.Errorf("alloc_runner snapshot includes a nil context"))
 	}
 	if e := snapshotErrors.ErrorOrNil(); e != nil {
 		return e

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -69,6 +69,9 @@ type TaskRunner struct {
 	destroyLock  sync.Mutex
 	destroyEvent *structs.TaskEvent
 	waitCh       chan struct{}
+
+	// serialize SaveState calls
+	persistLock sync.Mutex
 }
 
 // taskRunnerState is used to snapshot the state of the task runner
@@ -186,6 +189,9 @@ func (r *TaskRunner) RestoreState() error {
 
 // SaveState is used to snapshot our state
 func (r *TaskRunner) SaveState() error {
+	r.persistLock.Lock()
+	defer r.persistLock.Unlock()
+
 	snap := taskRunnerState{
 		Task:               r.task,
 		Version:            r.config.Version,

--- a/client/util.go
+++ b/client/util.go
@@ -92,6 +92,13 @@ func persistState(path string, data interface{}) error {
 	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("failed to rename tmp to path: %v", err)
 	}
+
+	// Sanity check since users have reported empty state files on disk
+	if stat, err := os.Stat(path); err != nil {
+		return fmt.Errorf("unable to stat state file %s: %v", path, err)
+	} else if stat.Size() == 0 {
+		return fmt.Errorf("persisted invalid state file %s; see https://github.com/hashicorp/nomad/issues/1367")
+	}
 	return nil
 }
 


### PR DESCRIPTION
2 changes to try to address #1367 

* Asserts persisted state files are nonzero
* Prevents interleaved state file persist calls which could cause #1367 

Here's the potential series of events that the lock is designed to guard against:

```
g1 - r.dirtyCh <- struct{}{}
g2 - r.syncStatus()
g1 - writes temporary file inside of persistState
g2 - truncates temporary file prior to writing to it inside of persistState
g1 - os.Renames truncated temporary file to state file
<process killed>
```

Using random temporary file names would also work but then we'd have to clean up temporary files leaked during unclean shutdowns.