### PR TITLE
Fix 'nomad run' on windows

### DIFF
--- a/command/helpers.go
+++ b/command/helpers.go
@@ -255,6 +255,10 @@ func (j *JobGetter) StructJob(jpath string) (*structs.Job, error) {
 		}
 		defer os.Remove(job.Name())
 
+		if err := job.Close(); err != nil {
+			return nil, err
+		}
+
 		// Get the pwd
 		pwd, err := os.Getwd()
 		if err != nil {


### PR DESCRIPTION
After PR https://github.com/hashicorp/nomad/pull/1511
there is a problem with running job on windows.

If I run sample job:
```
nomad.exe run .\example.nomad
```
I get an error:
```
Error getting job struct: Error getting jobfile from ".\\example.nomad": remove C:\Users\vagrant\AppData\Local\Temp\jobfile806333599: The process cannot access the file because it is being used by another process.
```

It's because ioutil.TempFile "opens the file for reading and writing" ([docs](https://golang.org/pkg/io/ioutil/#TempFile)).
And go-getter is trying to delete this file and create new.
Closing the file will let windows to delete the file without the error above.