### PR TITLE
Include parent ID in job info returned by Go API

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -191,6 +191,7 @@ type PeriodicConfig struct {
 type Job struct {
 	Region            string
 	ID                string
+	ParentID          string
 	Name              string
 	Type              string
 	Priority          int


### PR DESCRIPTION
At the moment, this ID is only included when using `Jobs().List()`, which returns `api.JobListStub`.

With this change, the ID will also be available when using `Jobs().Info()`, which returns `api.Job`.

In fact, `ParentID` is currently the only field present in `api.JobListStub` that is not part of `api.Job`.

Note: This has the side effect that `nomad run -output` will now include an empty `ParentID`.