### PR TITLE
Vault integration in client

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -233,6 +233,8 @@ const (
 	TaskDownloadingArtifacts   = "Downloading Artifacts"
 	TaskArtifactDownloadFailed = "Failed Artifact Download"
 	TaskDiskExceeded           = "Disk Exceeded"
+	TaskVaultRenewalFailed     = "Vault token renewal failed"
+	TaskSiblingFailed          = "Sibling task failed"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -250,4 +252,8 @@ type TaskEvent struct {
 	StartDelay      int64
 	DownloadError   string
 	ValidationError string
+	DiskLimit       int64
+	DiskSize        int64
+	FailedSibling   string
+	VaultError      string
 }

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -662,7 +662,7 @@ func (r *AllocRunner) recoverVaultTokens() error {
 			return fmt.Errorf("failed to determine task %s secret dir in alloc %q: %v", task, r.alloc.ID, err)
 		}
 
-		// Write the token to the file system
+		// Read the token from the secret directory
 		tokenPath := filepath.Join(secretDir, vaultTokenFile)
 		data, err := ioutil.ReadFile(tokenPath)
 		if err != nil {

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -326,7 +326,7 @@ func TestAllocRunner_Destroy(t *testing.T) {
 
 	// Begin the tear down
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 		ar.Destroy()
 	}()
 

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -3,7 +3,9 @@ package client
 import (
 	"bufio"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -36,7 +38,7 @@ func testAllocRunnerFromAlloc(alloc *structs.Allocation, restarts bool) (*MockAl
 		*alloc.Job.LookupTaskGroup(alloc.TaskGroup).RestartPolicy = structs.RestartPolicy{Attempts: 0}
 		alloc.Job.Type = structs.JobTypeBatch
 	}
-	vclient, _ := vaultclient.NewVaultClient(conf.VaultConfig, logger, nil)
+	vclient := vaultclient.NewMockVaultClient()
 	ar := NewAllocRunner(logger, conf, upd.Update, alloc, vclient)
 	return upd, ar
 }
@@ -392,13 +394,15 @@ func TestAllocRunner_Update(t *testing.T) {
 }
 
 func TestAllocRunner_SaveRestoreState(t *testing.T) {
-	ctestutil.ExecCompatible(t)
-	upd, ar := testAllocRunner(false)
+	alloc := mock.Alloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{
+		"exit_code": "0",
+		"run_for":   "10s",
+	}
 
-	// Ensure task takes some time
-	task := ar.alloc.Job.TaskGroups[0].Tasks[0]
-	task.Config["command"] = "/bin/sleep"
-	task.Config["args"] = []string{"10"}
+	upd, ar := testAllocRunnerFromAlloc(alloc, false)
 	go ar.Run()
 
 	// Snapshot state
@@ -422,21 +426,36 @@ func TestAllocRunner_SaveRestoreState(t *testing.T) {
 	}
 	go ar2.Run()
 
+	testutil.WaitForResult(func() (bool, error) {
+		if len(ar2.tasks) != 1 {
+			return false, fmt.Errorf("Incorrect number of tasks")
+		}
+
+		if upd.Count == 0 {
+			return false, nil
+		}
+
+		last := upd.Allocs[upd.Count-1]
+		return last.ClientStatus == structs.AllocClientStatusRunning, nil
+	}, func(err error) {
+		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.alloc.TaskStates)
+	})
+
 	// Destroy and wait
 	ar2.Destroy()
 	start := time.Now()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
-			return false, nil
+		alloc := ar2.Alloc()
+		if alloc.ClientStatus != structs.AllocClientStatusComplete {
+			return false, fmt.Errorf("Bad client status; got %v; want %v", alloc.ClientStatus, structs.AllocClientStatusComplete)
 		}
-		last := upd.Allocs[upd.Count-1]
-		return last.ClientStatus != structs.AllocClientStatusPending, nil
+		return true, nil
 	}, func(err error) {
 		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.alloc.TaskStates)
 	})
 
-	if time.Since(start) > time.Duration(testutil.TestMultiplier()*15)*time.Second {
+	if time.Since(start) > time.Duration(testutil.TestMultiplier()*5)*time.Second {
 		t.Fatalf("took too long to terminate")
 	}
 }
@@ -598,4 +617,246 @@ func TestAllocRunner_TaskFailed_KillTG(t *testing.T) {
 	}, func(err error) {
 		t.Fatalf("err: %v", err)
 	})
+}
+
+func TestAllocRunner_SimpleRun_VaultToken(t *testing.T) {
+	alloc := mock.Alloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{"exit_code": "0"}
+	task.Vault = &structs.Vault{
+		Policies: []string{"default"},
+	}
+
+	upd, ar := testAllocRunnerFromAlloc(alloc, false)
+	go ar.Run()
+	defer ar.Destroy()
+
+	testutil.WaitForResult(func() (bool, error) {
+		if upd.Count == 0 {
+			return false, fmt.Errorf("No updates")
+		}
+		last := upd.Allocs[upd.Count-1]
+		if last.ClientStatus != structs.AllocClientStatusComplete {
+			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	tr, ok := ar.tasks[task.Name]
+	if !ok {
+		t.Fatalf("No task runner made")
+	}
+
+	// Check that the task runner was given the token
+	token := tr.vaultToken
+	if token == "" || tr.vaultRenewalCh == nil {
+		t.Fatalf("Vault token not set properly")
+	}
+
+	// Check that it was written to disk
+	secretDir, err := ar.ctx.AllocDir.GetSecretDir(task.Name)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	tokenPath := filepath.Join(secretDir, vaultTokenFile)
+	data, err := ioutil.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("token not written to disk: %v", err)
+	}
+
+	if string(data) != token {
+		t.Fatalf("Bad token written to disk")
+	}
+
+	// Check that we stopped renewing the token
+	mockVC := ar.vaultClient.(*vaultclient.MockVaultClient)
+	if len(mockVC.StoppedTokens) != 1 || mockVC.StoppedTokens[0] != token {
+		t.Fatalf("We didn't stop renewing the token")
+	}
+}
+
+func TestAllocRunner_SaveRestoreState_VaultTokens_Valid(t *testing.T) {
+	alloc := mock.Alloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{
+		"exit_code": "0",
+		"run_for":   "10s",
+	}
+	task.Vault = &structs.Vault{
+		Policies: []string{"default"},
+	}
+
+	upd, ar := testAllocRunnerFromAlloc(alloc, false)
+	go ar.Run()
+
+	// Snapshot state
+	var token string
+	testutil.WaitForResult(func() (bool, error) {
+		if len(ar.tasks) != 1 {
+			return false, fmt.Errorf("Task not started")
+		}
+
+		tr, ok := ar.tasks[task.Name]
+		if !ok {
+			return false, fmt.Errorf("Incorrect task runner")
+		}
+
+		if tr.vaultToken == "" {
+			return false, fmt.Errorf("Bad token")
+		}
+
+		token = tr.vaultToken
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("task never started: %v", err)
+	})
+
+	err := ar.SaveState()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Create a new alloc runner
+	ar2 := NewAllocRunner(ar.logger, ar.config, upd.Update,
+		&structs.Allocation{ID: ar.alloc.ID}, ar.vaultClient)
+	err = ar2.RestoreState()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	go ar2.Run()
+
+	testutil.WaitForResult(func() (bool, error) {
+		if len(ar2.tasks) != 1 {
+			return false, fmt.Errorf("Incorrect number of tasks")
+		}
+
+		tr, ok := ar2.tasks[task.Name]
+		if !ok {
+			return false, fmt.Errorf("Incorrect task runner")
+		}
+
+		if tr.vaultToken != token {
+			return false, fmt.Errorf("Got token %q; want %q", tr.vaultToken, token)
+		}
+
+		if upd.Count == 0 {
+			return false, nil
+		}
+
+		last := upd.Allocs[upd.Count-1]
+		return last.ClientStatus == structs.AllocClientStatusRunning, nil
+	}, func(err error) {
+		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.alloc.TaskStates)
+	})
+
+	// Destroy and wait
+	ar2.Destroy()
+	start := time.Now()
+
+	testutil.WaitForResult(func() (bool, error) {
+		alloc := ar2.Alloc()
+		if alloc.ClientStatus != structs.AllocClientStatusComplete {
+			return false, fmt.Errorf("Bad client status; got %v; want %v", alloc.ClientStatus, structs.AllocClientStatusComplete)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.alloc.TaskStates)
+	})
+
+	if time.Since(start) > time.Duration(testutil.TestMultiplier()*5)*time.Second {
+		t.Fatalf("took too long to terminate")
+	}
+}
+
+func TestAllocRunner_SaveRestoreState_VaultTokens_Invalid(t *testing.T) {
+	alloc := mock.Alloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{
+		"exit_code": "0",
+		"run_for":   "10s",
+	}
+	task.Vault = &structs.Vault{
+		Policies: []string{"default"},
+	}
+
+	upd, ar := testAllocRunnerFromAlloc(alloc, false)
+	go ar.Run()
+
+	// Snapshot state
+	var token string
+	testutil.WaitForResult(func() (bool, error) {
+		if len(ar.tasks) != 1 {
+			return false, fmt.Errorf("Task not started")
+		}
+
+		tr, ok := ar.tasks[task.Name]
+		if !ok {
+			return false, fmt.Errorf("Incorrect task runner")
+		}
+
+		if tr.vaultToken == "" {
+			return false, fmt.Errorf("Bad token")
+		}
+
+		token = tr.vaultToken
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("task never started: %v", err)
+	})
+
+	err := ar.SaveState()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Create a new alloc runner
+	ar2 := NewAllocRunner(ar.logger, ar.config, upd.Update,
+		&structs.Allocation{ID: ar.alloc.ID}, ar.vaultClient)
+
+	// Invalidate the token
+	mockVC := ar2.vaultClient.(*vaultclient.MockVaultClient)
+	renewErr := fmt.Errorf("Test disallowing renewal")
+	mockVC.SetRenewTokenError(token, renewErr)
+
+	// Restore and run
+	err = ar2.RestoreState()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	go ar2.Run()
+
+	testutil.WaitForResult(func() (bool, error) {
+		if upd.Count == 0 {
+			return false, nil
+		}
+
+		last := upd.Allocs[upd.Count-1]
+		return last.ClientStatus == structs.AllocClientStatusFailed, nil
+	}, func(err error) {
+		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.alloc.TaskStates)
+	})
+
+	// Destroy and wait
+	ar2.Destroy()
+	start := time.Now()
+
+	testutil.WaitForResult(func() (bool, error) {
+		alloc := ar2.Alloc()
+		if alloc.ClientStatus != structs.AllocClientStatusFailed {
+			return false, fmt.Errorf("Bad client status; got %v; want %v", alloc.ClientStatus, structs.AllocClientStatusFailed)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.alloc.TaskStates)
+	})
+
+	if time.Since(start) > time.Duration(testutil.TestMultiplier()*5)*time.Second {
+		t.Fatalf("took too long to terminate")
+	}
 }

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -552,3 +552,11 @@ func (d *AllocDir) syncDiskUsage() error {
 	d.setSize(size)
 	return err
 }
+
+func (d *AllocDir) GetSecretDir(task string) (string, error) {
+	if t, ok := d.TaskDirs[task]; !ok {
+		return "", fmt.Errorf("Allocation directory doesn't contain task %q", task)
+	} else {
+		return filepath.Join(t, TaskSecrets), nil
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -1293,16 +1293,6 @@ func (c *Client) addAlloc(alloc *structs.Allocation) error {
 // setupVaultClient creates an object to periodically renew tokens and secrets
 // with vault.
 func (c *Client) setupVaultClient() error {
-	// TODO Want the vault client to always be valid. Should just return an
-	// error if it is not enabled
-	if c.config.VaultConfig == nil {
-		return fmt.Errorf("nil vault config")
-	}
-
-	if !c.config.VaultConfig.Enabled {
-		return nil
-	}
-
 	var err error
 	if c.vaultClient, err =
 		vaultclient.NewVaultClient(c.config.VaultConfig, c.logger, c.deriveToken); err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -150,7 +150,7 @@ type Client struct {
 	shutdownCh   chan struct{}
 	shutdownLock sync.Mutex
 
-	// client to interact with vault for token and secret renewals
+	// vaultClient is used to interact with Vault for token and secret renewals
 	vaultClient vaultclient.VaultClient
 }
 
@@ -208,11 +208,6 @@ func NewClient(cfg *config.Config, consulSyncer *consul.Syncer, logger *log.Logg
 	}
 	c.configLock.RUnlock()
 
-	// Restore the state
-	if err := c.restoreState(); err != nil {
-		return nil, fmt.Errorf("failed to restore state: %v", err)
-	}
-
 	// Setup the Consul syncer
 	if err := c.setupConsulSyncer(); err != nil {
 		return nil, fmt.Errorf("failed to create client Consul syncer: %v", err)
@@ -221,6 +216,11 @@ func NewClient(cfg *config.Config, consulSyncer *consul.Syncer, logger *log.Logg
 	// Setup the vault client for token and secret renewals
 	if err := c.setupVaultClient(); err != nil {
 		return nil, fmt.Errorf("failed to setup vault client: %v", err)
+	}
+
+	// Restore the state
+	if err := c.restoreState(); err != nil {
+		return nil, fmt.Errorf("failed to restore state: %v", err)
 	}
 
 	// Register and then start heartbeating to the servers.
@@ -247,11 +247,6 @@ func NewClient(cfg *config.Config, consulSyncer *consul.Syncer, logger *log.Logg
 	// times out and there are no Nomad servers available, this data is
 	// populated by periodically polling Consul, if available.
 	go c.rpcProxy.Run()
-
-	// Start renewing tokens and secrets
-	if c.vaultClient != nil {
-		c.vaultClient.Start()
-	}
 
 	return c, nil
 }
@@ -469,7 +464,7 @@ func (c *Client) restoreState() error {
 		id := entry.Name()
 		alloc := &structs.Allocation{ID: id}
 		c.configLock.RLock()
-		ar := NewAllocRunner(c.logger, c.configCopy, c.updateAllocStatus, alloc)
+		ar := NewAllocRunner(c.logger, c.configCopy, c.updateAllocStatus, alloc, c.vaultClient)
 		c.configLock.RUnlock()
 		c.allocLock.Lock()
 		c.allocs[id] = ar
@@ -1284,7 +1279,7 @@ func (c *Client) updateAlloc(exist, update *structs.Allocation) error {
 // addAlloc is invoked when we should add an allocation
 func (c *Client) addAlloc(alloc *structs.Allocation) error {
 	c.configLock.RLock()
-	ar := NewAllocRunner(c.logger, c.configCopy, c.updateAllocStatus, alloc)
+	ar := NewAllocRunner(c.logger, c.configCopy, c.updateAllocStatus, alloc, c.vaultClient)
 	c.configLock.RUnlock()
 	go ar.Run()
 
@@ -1298,6 +1293,8 @@ func (c *Client) addAlloc(alloc *structs.Allocation) error {
 // setupVaultClient creates an object to periodically renew tokens and secrets
 // with vault.
 func (c *Client) setupVaultClient() error {
+	// TODO Want the vault client to always be valid. Should just return an
+	// error if it is not enabled
 	if c.config.VaultConfig == nil {
 		return fmt.Errorf("nil vault config")
 	}
@@ -1316,6 +1313,9 @@ func (c *Client) setupVaultClient() error {
 		c.logger.Printf("[ERR] client: failed to create vault client")
 		return fmt.Errorf("failed to create vault client")
 	}
+
+	// Start renewing tokens and secrets
+	c.vaultClient.Start()
 
 	return nil
 }

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -348,17 +348,24 @@ func (d *DockerDriver) containerBinds(alloc *allocdir.AllocDir, task *structs.Ta
 	if !ok {
 		return nil, fmt.Errorf("Failed to find task local directory: %v", task.Name)
 	}
+	secret, err := alloc.GetSecretDir(task.Name)
+	if err != nil {
+		return nil, err
+	}
 
 	allocDirBind := fmt.Sprintf("%s:%s", shared, allocdir.SharedAllocContainerPath)
 	taskLocalBind := fmt.Sprintf("%s:%s", local, allocdir.TaskLocalContainerPath)
+	secretDirBind := fmt.Sprintf("%s:%s", secret, allocdir.TaskSecretsContainerPath)
 
 	if selinuxLabel := d.config.Read("docker.volumes.selinuxlabel"); selinuxLabel != "" {
 		allocDirBind = fmt.Sprintf("%s:%s", allocDirBind, selinuxLabel)
 		taskLocalBind = fmt.Sprintf("%s:%s", taskLocalBind, selinuxLabel)
+		secretDirBind = fmt.Sprintf("%s:%s", secretDirBind, selinuxLabel)
 	}
 	return []string{
 		allocDirBind,
 		taskLocalBind,
+		secretDirBind,
 	}, nil
 }
 

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -135,7 +135,7 @@ func NewExecContext(alloc *allocdir.AllocDir, allocID string) *ExecContext {
 // GetTaskEnv converts the alloc dir, the node, task and alloc into a
 // TaskEnvironment.
 func GetTaskEnv(allocDir *allocdir.AllocDir, node *structs.Node,
-	task *structs.Task, alloc *structs.Allocation) (*env.TaskEnvironment, error) {
+	task *structs.Task, alloc *structs.Allocation, vaultToken string) (*env.TaskEnvironment, error) {
 
 	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
 	env := env.NewTaskEnvironment(node).
@@ -165,6 +165,9 @@ func GetTaskEnv(allocDir *allocdir.AllocDir, node *structs.Node,
 	if alloc != nil {
 		env.SetAlloc(alloc)
 	}
+
+	// TODO: make this conditional on the task's vault block allowing it
+	env.SetVaultToken(vaultToken, true)
 
 	return env.Build(), nil
 }

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -60,6 +60,9 @@ const (
 
 	// MetaPrefix is the prefix for passing task meta data.
 	MetaPrefix = "NOMAD_META_"
+
+	// VaultToken is the environment variable for passing the Vault token
+	VaultToken = "VAULT_TOKEN"
 )
 
 // The node values that can be interpreted.
@@ -77,22 +80,24 @@ const (
 // TaskEnvironment is used to expose information to a task via environment
 // variables and provide interpolation of Nomad variables.
 type TaskEnvironment struct {
-	Env           map[string]string
-	TaskMeta      map[string]string
-	TaskGroupMeta map[string]string
-	JobMeta       map[string]string
-	AllocDir      string
-	TaskDir       string
-	SecretDir     string
-	CpuLimit      int
-	MemLimit      int
-	TaskName      string
-	AllocIndex    int
-	AllocId       string
-	AllocName     string
-	Node          *structs.Node
-	Networks      []*structs.NetworkResource
-	PortMap       map[string]int
+	Env              map[string]string
+	TaskMeta         map[string]string
+	TaskGroupMeta    map[string]string
+	JobMeta          map[string]string
+	AllocDir         string
+	TaskDir          string
+	SecretDir        string
+	CpuLimit         int
+	MemLimit         int
+	TaskName         string
+	AllocIndex       int
+	AllocId          string
+	AllocName        string
+	Node             *structs.Node
+	Networks         []*structs.NetworkResource
+	PortMap          map[string]int
+	VaultToken       string
+	InjectVaultToken bool
 
 	// taskEnv is the variables that will be set in the tasks environment
 	TaskEnv map[string]string
@@ -201,6 +206,11 @@ func (t *TaskEnvironment) Build() *TaskEnvironment {
 		for k, v := range t.Node.Meta {
 			t.NodeValues[fmt.Sprintf("%s%s", nodeMetaPrefix, k)] = v
 		}
+	}
+
+	// Build the Vault Token
+	if t.InjectVaultToken && t.VaultToken != "" {
+		t.TaskEnv[VaultToken] = t.VaultToken
 	}
 
 	// Interpret the environment variables
@@ -444,5 +454,17 @@ func (t *TaskEnvironment) SetTaskName(name string) *TaskEnvironment {
 
 func (t *TaskEnvironment) ClearTaskName() *TaskEnvironment {
 	t.TaskName = ""
+	return t
+}
+
+func (t *TaskEnvironment) SetVaultToken(token string, inject bool) *TaskEnvironment {
+	t.VaultToken = token
+	t.InjectVaultToken = inject
+	return t
+}
+
+func (t *TaskEnvironment) ClearVaultToken() *TaskEnvironment {
+	t.VaultToken = ""
+	t.InjectVaultToken = false
 	return t
 }

--- a/client/driver/env/env_test.go
+++ b/client/driver/env/env_test.go
@@ -163,6 +163,23 @@ func TestEnvironment_AsList(t *testing.T) {
 	}
 }
 
+func TestEnvironment_VaultToken(t *testing.T) {
+	n := mock.Node()
+	env := NewTaskEnvironment(n).SetVaultToken("123", false).Build()
+
+	act := env.EnvList()
+	if len(act) != 0 {
+		t.Fatalf("Unexpected environment variables: %v", act)
+	}
+
+	env = env.SetVaultToken("123", true).Build()
+	act = env.EnvList()
+	exp := []string{"VAULT_TOKEN=123"}
+	if !reflect.DeepEqual(act, exp) {
+		t.Fatalf("env.List() returned %v; want %v", act, exp)
+	}
+}
+
 func TestEnvironment_ClearEnvvars(t *testing.T) {
 	n := mock.Node()
 	env := NewTaskEnvironment(n).

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -410,7 +410,7 @@ func (r *TaskRunner) run() {
 			case <-r.destroyCh:
 				// Store the task event that provides context on the task destroy.
 				if r.destroyEvent.Type != structs.TaskKilled {
-					r.setState(structs.TaskStateDead, r.destroyEvent)
+					r.setState(structs.TaskStateRunning, r.destroyEvent)
 				}
 
 				// Mark that we received the kill event

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -64,6 +64,11 @@ type TaskRunner struct {
 	// downloaded
 	artifactsDownloaded bool
 
+	// vaultToken and vaultRenewalCh are optionally set if the task requires
+	// Vault tokens
+	vaultToken     string
+	vaultRenewalCh <-chan error
+
 	destroy      bool
 	destroyCh    chan struct{}
 	destroyLock  sync.Mutex
@@ -112,6 +117,13 @@ func NewTaskRunner(logger *log.Logger, config *config.Config,
 	}
 
 	return tc
+}
+
+// SetVaultToken is used to set the Vault token and renewal channel for the task
+// runner
+func (r *TaskRunner) SetVaultToken(token string, renewalCh <-chan error) {
+	r.vaultToken = token
+	r.vaultRenewalCh = renewalCh
 }
 
 // MarkReceived marks the task as received.
@@ -218,7 +230,7 @@ func (r *TaskRunner) setState(state string, event *structs.TaskEvent) {
 // setTaskEnv sets the task environment. It returns an error if it could not be
 // created.
 func (r *TaskRunner) setTaskEnv() error {
-	taskEnv, err := driver.GetTaskEnv(r.ctx.AllocDir, r.config.Node, r.task.Copy(), r.alloc)
+	taskEnv, err := driver.GetTaskEnv(r.ctx.AllocDir, r.config.Node, r.task.Copy(), r.alloc, r.vaultToken)
 	if err != nil {
 		return err
 	}
@@ -384,7 +396,23 @@ func (r *TaskRunner) run() {
 				if err := r.handleUpdate(update); err != nil {
 					r.logger.Printf("[ERR] client: update to task %q failed: %v", r.task.Name, err)
 				}
+			case err := <-r.vaultRenewalCh:
+				if err == nil {
+					// Only handle once.
+					continue
+				}
+
+				// This is a fatal error as the task is not valid if it
+				// requested a Vault token and the token has now expired.
+				r.logger.Printf("[WARN] client: vault token for task %q not renewed: %v", r.task.Name, err)
+				r.Destroy(structs.NewTaskEvent(structs.TaskVaultRenewalFailed).SetVaultRenewalError(err))
+
 			case <-r.destroyCh:
+				// Store the task event that provides context on the task destroy.
+				if r.destroyEvent.Type != structs.TaskKilled {
+					r.setState(structs.TaskStateDead, r.destroyEvent)
+				}
+
 				// Mark that we received the kill event
 				timeout := driver.GetKillTimeout(r.task.KillTimeout, r.config.MaxKillTimeout)
 				r.setState(structs.TaskStateRunning,
@@ -402,11 +430,6 @@ func (r *TaskRunner) run() {
 
 				// Store that the task has been destroyed and any associated error.
 				r.setState(structs.TaskStateDead, structs.NewTaskEvent(structs.TaskKilled).SetKillError(err))
-
-				// Store the task event that provides context on the task destroy.
-				if r.destroyEvent.Type != structs.TaskKilled {
-					r.setState(structs.TaskStateDead, r.destroyEvent)
-				}
 
 				r.runningLock.Lock()
 				r.running = false

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -409,3 +409,65 @@ func TestTaskRunner_Validate_UserEnforcement(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestTaskRunner_VaultTokenRenewal(t *testing.T) {
+	alloc := mock.Alloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{
+		"exit_code": "0",
+		"run_for":   "10s",
+	}
+	task.Vault = &structs.Vault{
+		Policies: []string{"default"},
+	}
+
+	upd, tr := testTaskRunnerFromAlloc(false, alloc)
+	tr.MarkReceived()
+	renewalCh := make(chan error, 1)
+	renewalErr := fmt.Errorf("test vault renewal error")
+	tr.SetVaultToken(structs.GenerateUUID(), renewalCh)
+	go tr.Run()
+	defer tr.Destroy(structs.NewTaskEvent(structs.TaskKilled))
+	defer tr.ctx.AllocDir.Destroy()
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		renewalCh <- renewalErr
+		close(renewalCh)
+	}()
+
+	select {
+	case <-tr.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	if len(upd.events) != 5 {
+		t.Fatalf("should have 3 updates: %#v", upd.events)
+	}
+
+	if upd.state != structs.TaskStateDead {
+		t.Fatalf("TaskState %v; want %v", upd.state, structs.TaskStateDead)
+	}
+
+	if upd.events[0].Type != structs.TaskReceived {
+		t.Fatalf("First Event was %v; want %v", upd.events[0].Type, structs.TaskReceived)
+	}
+
+	if upd.events[1].Type != structs.TaskStarted {
+		t.Fatalf("Second Event was %v; want %v", upd.events[1].Type, structs.TaskStarted)
+	}
+
+	if upd.events[2].Type != structs.TaskVaultRenewalFailed {
+		t.Fatalf("Third Event was %v; want %v", upd.events[2].Type, structs.TaskVaultRenewalFailed)
+	}
+
+	if upd.events[3].Type != structs.TaskKilling {
+		t.Fatalf("Fourth Event was %v; want %v", upd.events[3].Type, structs.TaskKilling)
+	}
+
+	if upd.events[4].Type != structs.TaskKilled {
+		t.Fatalf("Fifth Event was %v; want %v", upd.events[4].Type, structs.TaskKilled)
+	}
+}

--- a/client/vaultclient/vaultclient_testing.go
+++ b/client/vaultclient/vaultclient_testing.go
@@ -1,0 +1,90 @@
+package vaultclient
+
+import (
+	"github.com/hashicorp/nomad/nomad/structs"
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+// MockVaultClient is used for testing the vaultclient integration
+type MockVaultClient struct {
+	// StoppedTokens tracks the tokens that have stopped renewing
+	StoppedTokens []string
+
+	// RenewTokens are the tokens that have been renewed and their error
+	// channels
+	RenewTokens map[string]chan error
+
+	// RenewTokenErrors is used to return an error when the RenewToken is called
+	// with the given token
+	RenewTokenErrors map[string]error
+
+	// DeriveTokenErrors maps an allocation ID and tasks to an error when the
+	// token is derived
+	DeriveTokenErrors map[string]map[string]error
+}
+
+// NewMockVaultClient returns a MockVaultClient for testing
+func NewMockVaultClient() *MockVaultClient { return &MockVaultClient{} }
+
+func (vc *MockVaultClient) DeriveToken(a *structs.Allocation, tasks []string) (map[string]string, error) {
+	tokens := make(map[string]string, len(tasks))
+	for _, task := range tasks {
+		if tasks, ok := vc.DeriveTokenErrors[a.ID]; ok {
+			if err, ok := tasks[task]; ok {
+				return nil, err
+			}
+		}
+
+		tokens[task] = structs.GenerateUUID()
+	}
+
+	return tokens, nil
+}
+
+func (vc *MockVaultClient) SetDeriveTokenError(allocID string, tasks []string, err error) {
+	if vc.DeriveTokenErrors == nil {
+		vc.DeriveTokenErrors = make(map[string]map[string]error, 10)
+	}
+
+	if _, ok := vc.RenewTokenErrors[allocID]; !ok {
+		vc.DeriveTokenErrors[allocID] = make(map[string]error, 10)
+	}
+
+	for _, task := range tasks {
+		vc.DeriveTokenErrors[allocID][task] = err
+	}
+}
+
+func (vc *MockVaultClient) RenewToken(token string, interval int) (<-chan error, error) {
+	if err, ok := vc.RenewTokenErrors[token]; ok {
+		return nil, err
+	}
+
+	renewCh := make(chan error)
+	if vc.RenewTokens == nil {
+		vc.RenewTokens = make(map[string]chan error, 10)
+	}
+	vc.RenewTokens[token] = renewCh
+	return renewCh, nil
+}
+
+func (vc *MockVaultClient) SetRenewTokenError(token string, err error) {
+	if vc.RenewTokenErrors == nil {
+		vc.RenewTokenErrors = make(map[string]error, 10)
+	}
+
+	vc.RenewTokenErrors[token] = err
+}
+
+func (vc *MockVaultClient) StopRenewToken(token string) error {
+	vc.StoppedTokens = append(vc.StoppedTokens, token)
+	return nil
+}
+
+func (vc *MockVaultClient) RenewLease(leaseId string, interval int) (<-chan error, error) {
+	return nil, nil
+}
+func (vc *MockVaultClient) StopRenewLease(leaseId string) error                   { return nil }
+func (vc *MockVaultClient) Start()                                                {}
+func (vc *MockVaultClient) Stop()                                                 {}
+func (vc *MockVaultClient) GetConsulACL(string, string) (*vaultapi.Secret, error) { return nil, nil }

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -212,6 +212,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		fmt.Sprintf("Node ID|%s", limit(alloc.NodeID, length)),
 		fmt.Sprintf("Job ID|%s", alloc.JobID),
 		fmt.Sprintf("Client Status|%s", alloc.ClientStatus),
+		fmt.Sprintf("Client Description|%s", alloc.ClientDescription),
 		fmt.Sprintf("Created At|%s", formatUnixNanoTime(alloc.CreateTime)),
 	}
 

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -335,6 +335,24 @@ func (c *AllocStatusCommand) outputTaskStatus(state *api.TaskState) {
 			} else {
 				desc = "Task exceeded restart policy"
 			}
+		case api.TaskDiskExceeded:
+			if event.DiskLimit != 0 && event.DiskSize != 0 {
+				desc = fmt.Sprintf("Disk size exceeded maximum: %d > %d", event.DiskSize, event.DiskLimit)
+			} else {
+				desc = "Task exceeded disk quota"
+			}
+		case api.TaskVaultRenewalFailed:
+			if event.VaultError != "" {
+				desc = event.VaultError
+			} else {
+				desc = "Task's Vault token failed to be renewed"
+			}
+		case api.TaskSiblingFailed:
+			if event.FailedSibling != "" {
+				desc = fmt.Sprintf("Task's sibling %q failed", event.FailedSibling)
+			} else {
+				desc = "Task's sibling failed"
+			}
 		}
 
 		// Reverse order so we are sorted by time

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2279,6 +2279,9 @@ const (
 	// TaskSiblingFailed indicates that a sibling task in the task group has
 	// failed.
 	TaskSiblingFailed = "Sibling task failed"
+
+	// TaskVaultRenewalFailed indicates that Vault token renewal failed
+	TaskVaultRenewalFailed = "Vault token renewal failed"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -2322,6 +2325,9 @@ type TaskEvent struct {
 	// Name of the sibling task that caused termination of the task that
 	// the TaskEvent refers to.
 	FailedSibling string
+
+	// VaultErr is the error from token renewal
+	VaultErr string
 }
 
 func (te *TaskEvent) GoString() string {
@@ -2416,6 +2422,13 @@ func (e *TaskEvent) SetDiskSize(size int64) *TaskEvent {
 
 func (e *TaskEvent) SetFailedSibling(sibling string) *TaskEvent {
 	e.FailedSibling = sibling
+	return e
+}
+
+func (e *TaskEvent) SetVaultRenewalError(err error) *TaskEvent {
+	if err != nil {
+		e.VaultErr = err.Error()
+	}
 	return e
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2209,7 +2209,8 @@ func (ts *TaskState) Failed() bool {
 	}
 
 	switch ts.Events[l-1].Type {
-	case TaskDiskExceeded, TaskNotRestarting, TaskArtifactDownloadFailed, TaskFailedValidation:
+	case TaskDiskExceeded, TaskNotRestarting, TaskArtifactDownloadFailed,
+		TaskFailedValidation, TaskVaultRenewalFailed:
 		return true
 	default:
 		return false
@@ -2326,8 +2327,8 @@ type TaskEvent struct {
 	// the TaskEvent refers to.
 	FailedSibling string
 
-	// VaultErr is the error from token renewal
-	VaultErr string
+	// VaultError is the error from token renewal
+	VaultError string
 }
 
 func (te *TaskEvent) GoString() string {
@@ -2427,7 +2428,7 @@ func (e *TaskEvent) SetFailedSibling(sibling string) *TaskEvent {
 
 func (e *TaskEvent) SetVaultRenewalError(err error) *TaskEvent {
 	if err != nil {
-		e.VaultErr = err.Error()
+		e.VaultError = err.Error()
 	}
 	return e
 }

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -320,8 +320,6 @@ OUTER:
 		}
 	}
 
-	atomic.StoreInt32(&v.connEstablished, 1)
-
 	// Retrieve our token, validate it and parse the lease duration
 	if err := v.parseSelfToken(); err != nil {
 		v.logger.Printf("[ERR] vault: failed to lookup self token and not retrying: %v", err)
@@ -340,6 +338,8 @@ OUTER:
 			time.Duration(v.tokenData.CreationTTL)*time.Second)
 		v.tomb.Go(wrapNilError(v.renewalLoop))
 	}
+
+	atomic.StoreInt32(&v.connEstablished, 1)
 }
 
 // renewalLoop runs the renew loop. This should only be called if we are given a
@@ -562,7 +562,7 @@ func (v *vaultClient) CreateToken(ctx context.Context, a *structs.Allocation, ta
 			"NodeID":       a.NodeID,
 		},
 		TTL:         v.childTTL,
-		DisplayName: fmt.Sprintf("%s: %s", a.ID, task),
+		DisplayName: fmt.Sprintf("%s-%s", a.ID, task),
 	}
 
 	// Ensure we are under our rate limit


### PR DESCRIPTION
This PR adds:

* Deriving Vault tokens for tasks that require them
* Writing them to disk
* Renewing the tokens
* Handling renewal errors
* Restoring Vault tokens
* Inject vault token environment variables
* Fixes output for various cases in alloc-status
* Cleans up the vault client and adds a mock version
* Fixes a race condition in the server side vault client when a request is made before connection has been established
* Changes the event ordering when a task is killed. Old style was (killing, killed, destroy reason). New style is (reason, killing, killed)