### PR TITLE
Vault block improvements

### DIFF
--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -166,8 +166,9 @@ func GetTaskEnv(allocDir *allocdir.AllocDir, node *structs.Node,
 		env.SetAlloc(alloc)
 	}
 
-	// TODO: make this conditional on the task's vault block allowing it
-	env.SetVaultToken(vaultToken, true)
+	if task.Vault != nil {
+		env.SetVaultToken(vaultToken, task.Vault.Env)
+	}
 
 	return env.Build(), nil
 }

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -1126,6 +1126,7 @@ func parseVault(result *structs.Vault, list *ast.ObjectList) error {
 	// Check for invalid keys
 	valid := []string{
 		"policies",
+		"env",
 	}
 	if err := checkHCLKeys(listVal, valid); err != nil {
 		return multierror.Prefix(err, "vault ->")
@@ -1134,6 +1135,11 @@ func parseVault(result *structs.Vault, list *ast.ObjectList) error {
 	var m map[string]interface{}
 	if err := hcl.DecodeObject(&m, o.Val); err != nil {
 		return err
+	}
+
+	// Default the env bool
+	if _, ok := m["env"]; !ok {
+		m["env"] = true
 	}
 
 	if err := mapstructure.WeakDecode(m, result); err != nil {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -440,6 +440,54 @@ func TestParse(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"vault_inheritance.hcl",
+			&structs.Job{
+				ID:       "example",
+				Name:     "example",
+				Type:     "service",
+				Priority: 50,
+				Region:   "global",
+				TaskGroups: []*structs.TaskGroup{
+					&structs.TaskGroup{
+						Name:      "cache",
+						Count:     1,
+						LocalDisk: structs.DefaultLocalDisk(),
+						Tasks: []*structs.Task{
+							&structs.Task{
+								Name:      "redis",
+								LogConfig: structs.DefaultLogConfig(),
+								Vault: &structs.Vault{
+									Policies: []string{"group"},
+								},
+							},
+							&structs.Task{
+								Name:      "redis2",
+								LogConfig: structs.DefaultLogConfig(),
+								Vault: &structs.Vault{
+									Policies: []string{"task"},
+								},
+							},
+						},
+					},
+					&structs.TaskGroup{
+						Name:      "cache2",
+						Count:     1,
+						LocalDisk: structs.DefaultLocalDisk(),
+						Tasks: []*structs.Task{
+							&structs.Task{
+								Name:      "redis",
+								LogConfig: structs.DefaultLogConfig(),
+								Vault: &structs.Vault{
+									Policies: []string{"job"},
+								},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -160,6 +160,7 @@ func TestParse(t *testing.T) {
 								},
 								Vault: &structs.Vault{
 									Policies: []string{"foo", "bar"},
+									Env:      true,
 								},
 							},
 							&structs.Task{
@@ -459,6 +460,7 @@ func TestParse(t *testing.T) {
 								LogConfig: structs.DefaultLogConfig(),
 								Vault: &structs.Vault{
 									Policies: []string{"group"},
+									Env:      true,
 								},
 							},
 							&structs.Task{
@@ -466,6 +468,7 @@ func TestParse(t *testing.T) {
 								LogConfig: structs.DefaultLogConfig(),
 								Vault: &structs.Vault{
 									Policies: []string{"task"},
+									Env:      false,
 								},
 							},
 						},
@@ -480,6 +483,7 @@ func TestParse(t *testing.T) {
 								LogConfig: structs.DefaultLogConfig(),
 								Vault: &structs.Vault{
 									Policies: []string{"job"},
+									Env:      true,
 								},
 							},
 						},

--- a/jobspec/test-fixtures/vault_inheritance.hcl
+++ b/jobspec/test-fixtures/vault_inheritance.hcl
@@ -1,0 +1,22 @@
+job "example" {
+    vault {
+        policies = ["job"]
+    }
+	group "cache" {
+        vault {
+            policies = ["group"]
+        }
+
+		task "redis" { }
+
+		task "redis2" {
+            vault {
+                policies = ["task"]
+                env = false
+            }
+		}
+	}
+	group "cache2" {
+		task "redis" { }
+	}
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2630,6 +2630,10 @@ func (d *EphemeralDisk) Copy() *EphemeralDisk {
 type Vault struct {
 	// Policies is the set of policies that the task needs access to
 	Policies []string
+
+	// Env marks whether the Vault Token should be exposed as an environment
+	// variable
+	Env bool
 }
 
 // Copy returns a copy of this Vault block.

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -359,6 +359,9 @@ func tasksUpdated(a, b *structs.TaskGroup) bool {
 		if !reflect.DeepEqual(at.Artifacts, bt.Artifacts) {
 			return true
 		}
+		if !reflect.DeepEqual(at.Vault, bt.Vault) {
+			return true
+		}
 
 		// Inspect the network to see if the dynamic ports are different
 		if len(at.Resources.Networks) != len(bt.Resources.Networks) {

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -540,6 +540,12 @@ func TestTasksUpdated(t *testing.T) {
 	if !tasksUpdated(j1.TaskGroups[0], j14.TaskGroups[0]) {
 		t.Fatalf("bad")
 	}
+
+	j15 := mock.Job()
+	j15.TaskGroups[0].Tasks[0].Vault = &structs.Vault{Policies: []string{"foo"}}
+	if !tasksUpdated(j1.TaskGroups[0], j15.TaskGroups[0]) {
+		t.Fatalf("bad")
+	}
 }
 
 func TestEvictAndPlace_LimitLessThanAllocs(t *testing.T) {


### PR DESCRIPTION
This PR adds the following:

- Vault block can be defined at the Job and Task group level in hcl
- Vault block has a `env` option
- Vault block changes are taken into consideration when the task is updated.