### PR TITLE
Adding support for log driver settings and volume bindings

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -439,9 +439,6 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 		d.logger.Printf("[DEBUG] driver.docker: Setting default logging options to syslog and %s", syslogAddr)
 		if driverConfig.Logging[0].Type == "" {
 			driverConfig.Logging[0].Type = "syslog"
-		}
-
-		if driverConfig.Logging[0].Config["syslog-address"] == "" {
 			driverConfig.Logging[0].Config["syslog-address"] = syslogAddr
 		}
 	}

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -74,6 +74,12 @@ type DockerDriverAuth struct {
 	ServerAddress string `mapstructure:"server_address"` // server address of the registry
 }
 
+type DockerLoggingOpts struct {
+	Type      string              `mapstructure:"type"`
+	ConfigRaw []map[string]string `mapstructure:"config"`
+	Config    map[string]string   `mapstructure:"-"`
+}
+
 type DockerDriverConfig struct {
 	ImageName        string              `mapstructure:"image"`              // Container's Image Name
 	LoadImages       []string            `mapstructure:"load"`               // LoadImage is array of paths to image archive files
@@ -97,6 +103,7 @@ type DockerDriverConfig struct {
 	Interactive      bool                `mapstructure:"interactive"`        // Keep STDIN open even if not attached
 	ShmSize          int64               `mapstructure:"shm_size"`           // Size of /dev/shm of the container in bytes
 	WorkDir          string              `mapstructure:"work_dir"`           // Working directory inside the container
+	Logging          []DockerLoggingOpts `mapstructure:"logging"`            // Logging options for syslog server
 }
 
 // Validate validates a docker driver config
@@ -107,6 +114,18 @@ func (c *DockerDriverConfig) Validate() error {
 
 	c.PortMap = mapMergeStrInt(c.PortMapRaw...)
 	c.Labels = mapMergeStrStr(c.LabelsRaw...)
+
+	//if no logging is present, set default values. Otherwise, convert the raw logging data into a logging object
+	if len(c.Logging) != 0 {
+		c.Logging[0].Config = mapMergeStrStr(c.Logging[0].ConfigRaw...)
+	} else {
+		c.Logging = []DockerLoggingOpts{
+			{
+				Type:   "syslog",
+				Config: make(map[string]string),
+			},
+		}
+	}
 
 	return nil
 }
@@ -226,6 +245,9 @@ func (d *DockerDriver) Validate(config map[string]interface{}) error {
 			},
 			"work_dir": &fields.FieldSchema{
 				Type: fields.TypeString,
+			},
+			"logging": &fields.FieldSchema{
+				Type: fields.TypeArray,
 			},
 		},
 	}
@@ -396,6 +418,20 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 	}
 
 	memLimit := int64(task.Resources.MemoryMB) * 1024 * 1024
+
+	if len(driverConfig.Logging) != 0 {
+		d.logger.Printf("[DEBUG] driver.docker: Setting default logging options to syslog and %s", syslogAddr)
+		if driverConfig.Logging[0].Type == "" {
+			driverConfig.Logging[0].Type = "syslog"
+		}
+
+		if driverConfig.Logging[0].Config["syslog-address"] == "" {
+			driverConfig.Logging[0].Config["syslog-address"] = syslogAddr
+		}
+	}
+
+	d.logger.Printf("[DEBUG] driver.docker: Using config for logging: %+v", driverConfig.Logging[0])
+
 	hostConfig := &docker.HostConfig{
 		// Convert MB to bytes. This is an absolute value.
 		Memory:     memLimit,
@@ -408,10 +444,8 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 		// used to share data between different tasks in the same task group.
 		Binds: binds,
 		LogConfig: docker.LogConfig{
-			Type: "syslog",
-			Config: map[string]string{
-				"syslog-address": syslogAddr,
-			},
+			Type:   driverConfig.Logging[0].Type,
+			Config: driverConfig.Logging[0].Config,
 		},
 	}
 

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -104,6 +104,8 @@ type DockerDriverConfig struct {
 	ShmSize          int64               `mapstructure:"shm_size"`           // Size of /dev/shm of the container in bytes
 	WorkDir          string              `mapstructure:"work_dir"`           // Working directory inside the container
 	Logging          []DockerLoggingOpts `mapstructure:"logging"`            // Logging options for syslog server
+	Volumes          []string            `mapstructure:"volumes"`            // Host-Volumes to mount in, syntax: /path/to/host/directory:/destination/path/in/container
+	VolumesFrom      []string            `mapstructure:"volumes_from"`       // List of volumes-from
 }
 
 // Validate validates a docker driver config
@@ -125,6 +127,14 @@ func (c *DockerDriverConfig) Validate() error {
 				Config: make(map[string]string),
 			},
 		}
+	}
+
+	if c.Volumes == nil {
+		c.Volumes = make([]string, 0)
+	}
+
+	if c.VolumesFrom == nil {
+		c.VolumesFrom = make([]string, 0)
 	}
 
 	return nil
@@ -247,6 +257,12 @@ func (d *DockerDriver) Validate(config map[string]interface{}) error {
 				Type: fields.TypeString,
 			},
 			"logging": &fields.FieldSchema{
+				Type: fields.TypeArray,
+			},
+			"volumes": &fields.FieldSchema{
+				Type: fields.TypeArray,
+			},
+			"volumes_from": &fields.FieldSchema{
 				Type: fields.TypeArray,
 			},
 		},
@@ -432,6 +448,10 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 
 	d.logger.Printf("[DEBUG] driver.docker: Using config for logging: %+v", driverConfig.Logging[0])
 
+	//Merge nomad container binds and user specified binds
+	d.logger.Printf("[DEBUG] Unmodified binds from nomad: %+v\n", binds)
+	binds = append(binds, driverConfig.Volumes...)
+
 	hostConfig := &docker.HostConfig{
 		// Convert MB to bytes. This is an absolute value.
 		Memory:     memLimit,
@@ -442,7 +462,8 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 		// Binds are used to mount a host volume into the container. We mount a
 		// local directory for storage and a shared alloc directory that can be
 		// used to share data between different tasks in the same task group.
-		Binds: binds,
+		Binds:       binds,
+		VolumesFrom: driverConfig.VolumesFrom,
 		LogConfig: docker.LogConfig{
 			Type:   driverConfig.Logging[0].Type,
 			Config: driverConfig.Logging[0].Config,
@@ -452,6 +473,7 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 	d.logger.Printf("[DEBUG] driver.docker: using %d bytes memory for %s", hostConfig.Memory, task.Name)
 	d.logger.Printf("[DEBUG] driver.docker: using %d cpu shares for %s", hostConfig.CPUShares, task.Name)
 	d.logger.Printf("[DEBUG] driver.docker: binding directories %#v for %s", hostConfig.Binds, task.Name)
+	d.logger.Printf("[DEBUG] driver.docker: binding Volumes-From: %#v for %s", hostConfig.VolumesFrom, task.Name)
 
 	//  set privileged mode
 	hostPrivileged := d.config.ReadBoolDefault("docker.privileged.enabled", false)


### PR DESCRIPTION
This PR adds support for log driver settings passed through the docker run command.

Docker has various log-drivers and coming with that a couple of log options for each drivers.
As of now, nomad would only support syslog writing to a nomad specific location. 

To use nomad in an environment with an existing logging infrastructure like awslog or SPLUNK, it is necessary to pass the right combination of settings to the docker run command.

This PR enables to insert a logging options block in the docker driver config in a nomad manifest.
Furthermore, it is now possible to mount host folders into containers and to use data volume container.

It could look like this:

`config {
  image = "redis:latest"
  port_map {
    db = 6379
  }
  
  volumes = ["/path/on/host:/path/in/container", "...", "..."]
  volumes_from = [
    "datastorage"
  ]

  logging {
    type = "syslog"
    config { 
      syslog-address = "tcp://127.0.0.1:1514"
      tag = "your/logging/tag/{{.ImageName}}/{{.Name}}" 
      syslog-format = "rfc3164"
    }
  }
}`





