### PR TITLE
Convert example job file constraint to comment

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -83,10 +83,10 @@ job "example" {
 
 	# Restrict our job to only linux. We can specify multiple
 	# constraints as needed.
-	constraint {
-		attribute = "${attr.kernel.name}"
-		value = "linux"
-	}
+	# constraint {
+	#	attribute = "${attr.kernel.name}"
+	#	value = "linux"
+	# }
 
 	# Configure the job to do rolling updates
 	update {


### PR DESCRIPTION
This improves the "getting started" happy path experience for non-linux users who are running the native Docker tools on their machines. There is no need to constrain this job to linux, since driver detection for docker will already (basically) do this.

/cc @dadgar @KFishner 