### PR TITLE
Support Docker Volumes and Logging

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -368,6 +368,7 @@ func (d *DockerDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool
 	node.Attributes[dockerDriverAttr] = "1"
 	node.Attributes["driver.docker.version"] = env.Get("Version")
 
+	// Advertise if this node supports Docker volumes (by default we do not)
 	if d.config.ReadBoolDefault(dockerVolumesConfigOption, false) {
 		node.Attributes["driver."+dockerVolumesConfigOption] = "1"
 	}
@@ -395,7 +396,7 @@ func (d *DockerDriver) containerBinds(driverConfig *DockerDriverConfig, alloc *a
 
 	volumesEnabled := d.config.ReadBoolDefault(dockerVolumesConfigOption, false)
 	if len(driverConfig.Volumes) > 0 && !volumesEnabled {
-		return nil, fmt.Errorf(dockerVolumesConfigOption+" is false; cannot use Docker Volumes: %+q", driverConfig.Volumes)
+		return nil, fmt.Errorf("%s is false; cannot use Docker Volumes: %+q", dockerVolumesConfigOption, driverConfig.Volumes)
 	}
 
 	if len(driverConfig.Volumes) > 0 {

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -446,9 +446,6 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 		d.logger.Printf("[DEBUG] driver.docker: Setting default logging options to syslog and %s", syslogAddr)
 		if driverConfig.Logging[0].Type == "" {
 			driverConfig.Logging[0].Type = "syslog"
-		}
-
-		if driverConfig.Logging[0].Config["syslog-address"] == "" {
 			driverConfig.Logging[0].Config["syslog-address"] = syslogAddr
 		}
 	}

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -104,6 +104,8 @@ type DockerDriverConfig struct {
 	ShmSize          int64               `mapstructure:"shm_size"`           // Size of /dev/shm of the container in bytes
 	WorkDir          string              `mapstructure:"work_dir"`           // Working directory inside the container
 	Logging          []DockerLoggingOpts `mapstructure:"logging"`            // Logging options for syslog server
+	Volumes          []string            `mapstructure:"volumes"`            // Host-Volumes to mount in, syntax: /path/to/host/directory:/destination/path/in/container
+	VolumesFrom      []string            `mapstructure:"volumes_from"`       // List of volumes-from
 }
 
 // Validate validates a docker driver config
@@ -125,6 +127,14 @@ func (c *DockerDriverConfig) Validate() error {
 				Config: make(map[string]string),
 			},
 		}
+	}
+
+	if c.Volumes == nil {
+		c.Volumes = make([]string, 0)
+	}
+
+	if c.VolumesFrom == nil {
+		c.VolumesFrom = make([]string, 0)
 	}
 
 	return nil
@@ -247,6 +257,12 @@ func (d *DockerDriver) Validate(config map[string]interface{}) error {
 				Type: fields.TypeString,
 			},
 			"logging": &fields.FieldSchema{
+				Type: fields.TypeArray,
+			},
+			"volumes": &fields.FieldSchema{
+				Type: fields.TypeArray,
+			},
+			"volumes_from": &fields.FieldSchema{
 				Type: fields.TypeArray,
 			},
 		},
@@ -439,6 +455,10 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 
 	d.logger.Printf("[DEBUG] driver.docker: Using config for logging: %+v", driverConfig.Logging[0])
 
+	//Merge nomad container binds and user specified binds
+	d.logger.Printf("[DEBUG] Unmodified binds from nomad: %+v\n", binds)
+	binds = append(binds, driverConfig.Volumes...)
+
 	hostConfig := &docker.HostConfig{
 		// Convert MB to bytes. This is an absolute value.
 		Memory:     memLimit,
@@ -449,7 +469,8 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 		// Binds are used to mount a host volume into the container. We mount a
 		// local directory for storage and a shared alloc directory that can be
 		// used to share data between different tasks in the same task group.
-		Binds: binds,
+		Binds:       binds,
+		VolumesFrom: driverConfig.VolumesFrom,
 		LogConfig: docker.LogConfig{
 			Type:   driverConfig.Logging[0].Type,
 			Config: driverConfig.Logging[0].Config,
@@ -459,6 +480,7 @@ func (d *DockerDriver) createContainer(ctx *ExecContext, task *structs.Task,
 	d.logger.Printf("[DEBUG] driver.docker: using %d bytes memory for %s", hostConfig.Memory, task.Name)
 	d.logger.Printf("[DEBUG] driver.docker: using %d cpu shares for %s", hostConfig.CPUShares, task.Name)
 	d.logger.Printf("[DEBUG] driver.docker: binding directories %#v for %s", hostConfig.Binds, task.Name)
+	d.logger.Printf("[DEBUG] driver.docker: binding Volumes-From: %#v for %s", hostConfig.VolumesFrom, task.Name)
 
 	//  set privileged mode
 	hostPrivileged := d.config.ReadBoolDefault("docker.privileged.enabled", false)

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -58,9 +58,17 @@ const (
 	// driver
 	dockerDriverAttr = "driver.docker"
 
+	// dockerSELinuxLabelConfigOption is the key for configuring the
+	// SELinux label for binds.
 	dockerSELinuxLabelConfigOption = "docker.volumes.selinuxlabel"
-	dockerVolumesConfigOption      = "docker.volumes.enabled"
-	dockerPrivilegedConfigOption   = "docker.privileged.enabled"
+
+	// dockerVolumesConfigOption is the key for enabling the use of custom
+	// bind volumes.
+	dockerVolumesConfigOption = "docker.volumes.enabled"
+
+	// dockerPrivilegedConfigOption is the key for running containers in
+	// Docker's privileged mode.
+	dockerPrivilegedConfigOption = "docker.privileged.enabled"
 
 	// dockerTimeout is the length of time a request can be outstanding before
 	// it is timed out.

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -432,6 +432,9 @@ func DevConfig() *Config {
 	conf.Client.Options = map[string]string{
 		"driver.raw_exec.enable": "true",
 	}
+	conf.Client.Options = map[string]string{
+		"driver.docker.volumes": "true",
+	}
 
 	return conf
 }

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -137,6 +137,14 @@ The `docker` driver supports the following configuration in the job spec:
 
 * `shm_size` - (Optional) The size (bytes) of /dev/shm for the container.
 
+* `volumes` - (Optional) A list of `host_path:container_path` strings to bind
+  host paths to container paths. Can only be run on clients with the
+  `docker.volumes.enabled` option set to true.
+
+* `volumes_from` - (Optional) A list of volumes to inherit from another
+  container. Can only be run on clients with the `docker.volumes.enabled`
+  option set to true.
+
 * `work_dir` - (Optional) The working directory inside the container.
 
 ### Container Name
@@ -329,8 +337,14 @@ options](/docs/agent/config.html#options):
 * `docker.cleanup.image` Defaults to `true`. Changing this to `false` will
   prevent Nomad from removing images from stopped tasks.
 
+* `docker.volumes.enabled`: Defaults to `false`. Allows tasks to bind host
+  paths (`volumes`) or other containers (`volums_from`) inside their container.
+  Disabled by default as it removes the isolation between containers' data.
+
 * `docker.volumes.selinuxlabel`: Allows the operator to set a SELinux
-  label to the allocation and task local bind-mounts to containers.
+  label to the allocation and task local bind-mounts to containers. If used
+  with `docker.volumes.enabled` set to false, the labels will still be applied
+  to the standard binds in the container. 
 
 * `docker.privileged.enabled` Defaults to `false`. Changing this to `true` will
   allow containers to use `privileged` mode, which gives the containers full


### PR DESCRIPTION
Thanks to @Fluxxo for his initial work on this in PR #1736!

We on the Nomad team wanted to disable Docker volume support by default since allowing it enables any task to access any other task's data on a given node. We want our defaults to always securely isolate tasks, so users must opt-in explicitly.