### PR TITLE
Remove disk usage enforcement

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -247,7 +247,6 @@ const (
 	TaskNotRestarting          = "Not Restarting"
 	TaskDownloadingArtifacts   = "Downloading Artifacts"
 	TaskArtifactDownloadFailed = "Failed Artifact Download"
-	TaskDiskExceeded           = "Disk Exceeded"
 	TaskVaultRenewalFailed     = "Vault token renewal failed"
 	TaskSiblingFailed          = "Sibling task failed"
 	TaskSignaling              = "Signaling"

--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -5,11 +5,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
-	"math"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"gopkg.in/tomb.v1"
@@ -17,20 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hpcloud/tail/watch"
-)
-
-const (
-	// The minimum frequency to use for disk monitoring.
-	minCheckDiskInterval = 3 * time.Minute
-
-	// The maximum frequency to use for disk monitoring.
-	maxCheckDiskInterval = 15 * time.Second
-
-	// The amount of time that maxCheckDiskInterval is always used after
-	// starting the allocation. This prevents unbounded disk usage that would
-	// otherwise be possible for a number of minutes if we started with the
-	// minCheckDiskInterval.
-	checkDiskMaxEnforcePeriod = 5 * time.Minute
 )
 
 var (
@@ -66,33 +49,6 @@ type AllocDir struct {
 
 	// TaskDirs is a mapping of task names to their non-shared directory.
 	TaskDirs map[string]string
-
-	// Size is the total consumed disk size of the shared directory in bytes
-	size     int64
-	sizeLock sync.RWMutex
-
-	// The minimum frequency to use for disk monitoring.
-	MinCheckDiskInterval time.Duration
-
-	// The maximum frequency to use for disk monitoring.
-	MaxCheckDiskInterval time.Duration
-
-	// The amount of time that maxCheckDiskInterval is always used after
-	// starting the allocation. This prevents unbounded disk usage that would
-	// otherwise be possible for a number of minutes if we started with the
-	// minCheckDiskInterval.
-	CheckDiskMaxEnforcePeriod time.Duration
-
-	// running reflects the state of the disk watcher process.
-	running bool
-
-	// watchCh signals that the alloc directory is being torn down and that
-	// any monitoring on it should stop.
-	watchCh chan struct{}
-
-	// MaxSize represents the total amount of megabytes that the shared allocation
-	// directory is allowed to consume.
-	MaxSize int
 }
 
 // AllocFileInfo holds information about a file inside the AllocDir
@@ -115,15 +71,11 @@ type AllocDirFS interface {
 }
 
 // NewAllocDir initializes the AllocDir struct with allocDir as base path for
-// the allocation directory and maxSize as the maximum allowed size in megabytes.
-func NewAllocDir(allocDir string, maxSize int) *AllocDir {
+// the allocation directory.
+func NewAllocDir(allocDir string) *AllocDir {
 	d := &AllocDir{
-		AllocDir:                  allocDir,
-		MaxCheckDiskInterval:      maxCheckDiskInterval,
-		MinCheckDiskInterval:      minCheckDiskInterval,
-		CheckDiskMaxEnforcePeriod: checkDiskMaxEnforcePeriod,
-		TaskDirs:                  make(map[string]string),
-		MaxSize:                   maxSize,
+		AllocDir: allocDir,
+		TaskDirs: make(map[string]string),
 	}
 	d.SharedDir = filepath.Join(d.AllocDir, SharedAllocName)
 	return d
@@ -595,85 +547,6 @@ func (d *AllocDir) pathExists(path string) bool {
 		}
 	}
 	return true
-}
-
-// GetSize returns the size of the shared allocation directory.
-func (d *AllocDir) GetSize() int64 {
-	d.sizeLock.Lock()
-	defer d.sizeLock.Unlock()
-
-	return d.size
-}
-
-// setSize sets the size of the shared allocation directory.
-func (d *AllocDir) setSize(size int64) {
-	d.sizeLock.Lock()
-	defer d.sizeLock.Unlock()
-
-	d.size = size
-}
-
-// StartDiskWatcher periodically checks the disk space consumed by the shared
-// allocation directory.
-func (d *AllocDir) StartDiskWatcher() {
-	start := time.Now()
-
-	sync := time.NewTimer(d.MaxCheckDiskInterval)
-	defer sync.Stop()
-
-	d.running = true
-	d.watchCh = make(chan struct{})
-
-	for {
-		select {
-		case <-d.watchCh:
-			return
-		case <-sync.C:
-			if err := d.syncDiskUsage(); err != nil {
-				log.Printf("[WARN] client: failed to sync disk usage: %v", err)
-			}
-			// Calculate the disk ratio.
-			diskRatio := float64(d.size) / float64(d.MaxSize*structs.BytesInMegabyte)
-
-			// Exponentially decrease the interval when the disk ratio increases.
-			nextInterval := time.Duration(int64(1.0/(0.1*math.Pow(diskRatio, 2))+5)) * time.Second
-
-			// Use the maximum interval for the first five minutes or if the
-			// disk ratio is sufficiently high. Also use the minimum check interval
-			// if the disk ratio becomes low enough.
-			if nextInterval < d.MaxCheckDiskInterval || time.Since(start) < d.CheckDiskMaxEnforcePeriod {
-				nextInterval = d.MaxCheckDiskInterval
-			} else if nextInterval > d.MinCheckDiskInterval {
-				nextInterval = d.MinCheckDiskInterval
-			}
-			sync.Reset(nextInterval)
-		}
-	}
-}
-
-// StopDiskWatcher closes the watch channel which causes the disk monitoring to stop.
-func (d *AllocDir) StopDiskWatcher() {
-	if d.running {
-		d.running = false
-		close(d.watchCh)
-	}
-}
-
-// syncDiskUsage walks the allocation directory recursively and
-// calculates the total consumed disk space.
-func (d *AllocDir) syncDiskUsage() error {
-	var size int64
-	err := filepath.Walk(d.AllocDir,
-		func(path string, info os.FileInfo, err error) error {
-			// Ignore paths that do not have a valid FileInfo object
-			if err == nil {
-				size += info.Size()
-			}
-			return nil
-		})
-	// Store the disk consumption
-	d.setSize(size)
-	return err
 }
 
 func (d *AllocDir) GetSecretDir(task string) (string, error) {

--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -58,7 +58,7 @@ func TestAllocDir_BuildAlloc(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	d := NewAllocDir(tmp, structs.DefaultResources().DiskMB)
+	d := NewAllocDir(tmp)
 	defer d.Destroy()
 	tasks := []*structs.Task{t1, t2}
 	if err := d.Build(tasks); err != nil {
@@ -93,7 +93,7 @@ func TestAllocDir_LogDir(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	d := NewAllocDir(tmp, structs.DefaultResources().DiskMB)
+	d := NewAllocDir(tmp)
 	defer d.Destroy()
 
 	expected := filepath.Join(d.AllocDir, SharedAllocName, LogDirName)
@@ -109,7 +109,7 @@ func TestAllocDir_EmbedNonExistent(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	d := NewAllocDir(tmp, structs.DefaultResources().DiskMB)
+	d := NewAllocDir(tmp)
 	defer d.Destroy()
 	tasks := []*structs.Task{t1, t2}
 	if err := d.Build(tasks); err != nil {
@@ -131,7 +131,7 @@ func TestAllocDir_EmbedDirs(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	d := NewAllocDir(tmp, structs.DefaultResources().DiskMB)
+	d := NewAllocDir(tmp)
 	defer d.Destroy()
 	tasks := []*structs.Task{t1, t2}
 	if err := d.Build(tasks); err != nil {
@@ -192,7 +192,7 @@ func TestAllocDir_MountSharedAlloc(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	d := NewAllocDir(tmp, structs.DefaultResources().DiskMB)
+	d := NewAllocDir(tmp)
 	defer d.Destroy()
 	tasks := []*structs.Task{t1, t2}
 	if err := d.Build(tasks); err != nil {
@@ -240,7 +240,7 @@ func TestAllocDir_Snapshot(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	d := NewAllocDir(tmp, structs.DefaultResources().DiskMB)
+	d := NewAllocDir(tmp)
 	defer d.Destroy()
 
 	tasks := []*structs.Task{t1, t2}
@@ -299,10 +299,10 @@ func TestAllocDir_Move(t *testing.T) {
 	defer os.RemoveAll(tmp)
 
 	// Create two alloc dirs
-	d1 := NewAllocDir(tmp, structs.DefaultResources().DiskMB)
+	d1 := NewAllocDir(tmp)
 	defer d1.Destroy()
 
-	d2 := NewAllocDir(tmp, structs.DefaultResources().DiskMB)
+	d2 := NewAllocDir(tmp)
 	defer d2.Destroy()
 
 	tasks := []*structs.Task{t1, t2}
@@ -356,7 +356,7 @@ func TestAllocDir_EscapeChecking(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	d := NewAllocDir(tmp, structs.DefaultResources().DiskMB)
+	d := NewAllocDir(tmp)
 	defer d.Destroy()
 	tasks := []*structs.Task{t1, t2}
 	if err := d.Build(tasks); err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -1516,7 +1516,7 @@ func (c *Client) migrateRemoteAllocDir(alloc *structs.Allocation, allocID string
 		// If the snapshot has ended then we create the previous
 		// allocdir
 		if err == io.EOF {
-			prevAllocDir := allocdir.NewAllocDir(pathToAllocDir, 0)
+			prevAllocDir := allocdir.NewAllocDir(pathToAllocDir)
 			return prevAllocDir, nil
 		}
 		// If there is an error then we avoid creating the alloc dir

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -973,7 +973,7 @@ func setupDockerVolumes(t *testing.T, cfg *config.Config) (*structs.Task, Driver
 		Resources: basicResources,
 	}
 
-	allocDir := allocdir.NewAllocDir(filepath.Join(cfg.AllocDir, structs.GenerateUUID()), task.Resources.DiskMB)
+	allocDir := allocdir.NewAllocDir(filepath.Join(cfg.AllocDir, structs.GenerateUUID()))
 	allocDir.Build([]*structs.Task{task})
 	alloc := mock.Alloc()
 	execCtx := NewExecContext(allocDir, alloc.ID)

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -79,7 +79,7 @@ func testConfig() *config.Config {
 
 func testDriverContexts(task *structs.Task) (*DriverContext, *ExecContext) {
 	cfg := testConfig()
-	allocDir := allocdir.NewAllocDir(filepath.Join(cfg.AllocDir, structs.GenerateUUID()), task.Resources.DiskMB)
+	allocDir := allocdir.NewAllocDir(filepath.Join(cfg.AllocDir, structs.GenerateUUID()))
 	allocDir.Build([]*structs.Task{task})
 	alloc := mock.Alloc()
 	execCtx := NewExecContext(allocDir, alloc.ID)

--- a/client/driver/executor/executor_test.go
+++ b/client/driver/executor/executor_test.go
@@ -37,7 +37,7 @@ func mockAllocDir(t *testing.T) (*structs.Task, *allocdir.AllocDir) {
 	alloc := mock.Alloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 
-	allocDir := allocdir.NewAllocDir(filepath.Join(os.TempDir(), alloc.ID), task.Resources.DiskMB)
+	allocDir := allocdir.NewAllocDir(filepath.Join(os.TempDir(), alloc.ID))
 	if err := allocDir.Build([]*structs.Task{task}); err != nil {
 		log.Panicf("allocDir.Build() failed: %v", err)
 	}

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -58,7 +58,7 @@ func testTaskRunnerFromAlloc(restarts bool, alloc *structs.Allocation) (*MockTas
 	// we have a mock so that doesn't happen.
 	task.Resources.Networks[0].ReservedPorts = []structs.Port{{"", 80}}
 
-	allocDir := allocdir.NewAllocDir(filepath.Join(conf.AllocDir, alloc.ID), task.Resources.DiskMB)
+	allocDir := allocdir.NewAllocDir(filepath.Join(conf.AllocDir, alloc.ID))
 	allocDir.Build([]*structs.Task{task})
 
 	vclient := vaultclient.NewMockVaultClient()

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -449,7 +449,7 @@ func tempAllocDir(t *testing.T) *allocdir.AllocDir {
 		t.Fatalf("failed to chmod dir: %v", err)
 	}
 
-	return allocdir.NewAllocDir(dir, structs.DefaultResources().DiskMB)
+	return allocdir.NewAllocDir(dir)
 }
 
 type nopWriteCloser struct {

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -343,12 +343,6 @@ func (c *AllocStatusCommand) outputTaskStatus(state *api.TaskState) {
 			} else {
 				desc = "Task exceeded restart policy"
 			}
-		case api.TaskDiskExceeded:
-			if event.DiskLimit != 0 && event.DiskSize != 0 {
-				desc = fmt.Sprintf("Disk size exceeded maximum: %d > %d", event.DiskSize, event.DiskLimit)
-			} else {
-				desc = "Task exceeded disk quota"
-			}
 		case api.TaskVaultRenewalFailed:
 			if event.VaultError != "" {
 				desc = event.VaultError

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2474,9 +2474,6 @@ type TaskEvent struct {
 	// The maximum allowed task disk size.
 	DiskLimit int64
 
-	// The recorded task disk size.
-	DiskSize int64
-
 	// Name of the sibling task that caused termination of the task that
 	// the TaskEvent refers to.
 	FailedSibling string
@@ -2597,11 +2594,6 @@ func (e *TaskEvent) SetKillTimeout(timeout time.Duration) *TaskEvent {
 
 func (e *TaskEvent) SetDiskLimit(limit int64) *TaskEvent {
 	e.DiskLimit = limit
-	return e
-}
-
-func (e *TaskEvent) SetDiskSize(size int64) *TaskEvent {
-	e.DiskSize = size
 	return e
 }
 


### PR DESCRIPTION
Many thanks to @iverberk for the original PR (#1609), but we ended up
not wanting to ship this implementation with 0.5.

We'll come back to it after 0.5 and hopefully find a way to leverage
filesystem accounting and quotas, so we can skip the expensive polling.