### PR TITLE
Add relative and absolute volume mounting to Docker and rkt

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -64,7 +64,8 @@ const (
 
 	// dockerVolumesConfigOption is the key for enabling the use of custom
 	// bind volumes.
-	dockerVolumesConfigOption = "docker.volumes.enabled"
+	dockerVolumesConfigOption  = "docker.volumes.enabled"
+	dockerVolumesConfigDefault = true
 
 	// dockerPrivilegedConfigOption is the key for running containers in
 	// Docker's privileged mode.
@@ -369,7 +370,7 @@ func (d *DockerDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool
 	node.Attributes["driver.docker.version"] = env.Get("Version")
 
 	// Advertise if this node supports Docker volumes (by default we do not)
-	if d.config.ReadBoolDefault(dockerVolumesConfigOption, false) {
+	if d.config.ReadBoolDefault(dockerVolumesConfigOption, dockerVolumesConfigDefault) {
 		node.Attributes["driver."+dockerVolumesConfigOption] = "1"
 	}
 
@@ -394,7 +395,7 @@ func (d *DockerDriver) containerBinds(driverConfig *DockerDriverConfig, alloc *a
 	secretDirBind := fmt.Sprintf("%s:%s", secret, allocdir.TaskSecretsContainerPath)
 	binds := []string{allocDirBind, taskLocalBind, secretDirBind}
 
-	volumesEnabled := d.config.ReadBoolDefault(dockerVolumesConfigOption, false)
+	volumesEnabled := d.config.ReadBoolDefault(dockerVolumesConfigOption, dockerVolumesConfigDefault)
 	if len(driverConfig.Volumes) > 0 && !volumesEnabled {
 		return nil, fmt.Errorf("%s is false; cannot use Docker Volumes: %+q", dockerVolumesConfigOption, driverConfig.Volumes)
 	}

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -63,7 +63,7 @@ const (
 	dockerSELinuxLabelConfigOption = "docker.volumes.selinuxlabel"
 
 	// dockerVolumesConfigOption is the key for enabling the use of custom
-	// bind volumes.
+	// bind volumes to arbitrary host paths.
 	dockerVolumesConfigOption  = "docker.volumes.enabled"
 	dockerVolumesConfigDefault = true
 
@@ -396,12 +396,29 @@ func (d *DockerDriver) containerBinds(driverConfig *DockerDriverConfig, alloc *a
 	binds := []string{allocDirBind, taskLocalBind, secretDirBind}
 
 	volumesEnabled := d.config.ReadBoolDefault(dockerVolumesConfigOption, dockerVolumesConfigDefault)
-	if len(driverConfig.Volumes) > 0 && !volumesEnabled {
-		return nil, fmt.Errorf("%s is false; cannot use Docker Volumes: %+q", dockerVolumesConfigOption, driverConfig.Volumes)
-	}
+	for _, userbind := range driverConfig.Volumes {
+		parts := strings.Split(userbind, ":")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid docker volume: %q", userbind)
+		}
 
-	if len(driverConfig.Volumes) > 0 {
-		binds = append(binds, driverConfig.Volumes...)
+		// Resolve dotted path segments
+		parts[0] = filepath.Clean(parts[0])
+
+		// Absolute paths aren't always supported
+		if filepath.IsAbs(parts[0]) {
+			if !volumesEnabled {
+				// Disallow mounting arbitrary absolute paths
+				return nil, fmt.Errorf("%s is false; cannot mount host paths: %+q", dockerVolumesConfigOption, userbind)
+			}
+			binds = append(binds, userbind)
+			continue
+		}
+
+		// Relative paths are always allowed as they mount within a container
+		// Expand path relative to alloc dir
+		parts[0] = filepath.Join(shared, parts[0])
+		binds = append(binds, strings.Join(parts, ":"))
 	}
 
 	if selinuxLabel := d.config.Read(dockerSELinuxLabelConfigOption); selinuxLabel != "" {

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -918,6 +918,7 @@ func setupDockerVolumes(t *testing.T, cfg *config.Config) (*structs.Task, Driver
 
 func TestDockerDriver_VolumesDisabled(t *testing.T) {
 	cfg := testConfig()
+	cfg.Options = map[string]string{dockerVolumesConfigOption: "false"}
 
 	task, driver, execCtx, _, cleanup := setupDockerVolumes(t, cfg)
 	defer cleanup()
@@ -930,7 +931,6 @@ func TestDockerDriver_VolumesDisabled(t *testing.T) {
 
 func TestDockerDriver_VolumesEnabled(t *testing.T) {
 	cfg := testConfig()
-	cfg.Options = map[string]string{dockerVolumesConfigOption: "true"}
 
 	task, driver, execCtx, hostpath, cleanup := setupDockerVolumes(t, cfg)
 	defer cleanup()

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -45,7 +45,8 @@ const (
 
 	// rktVolumesConfigOption is the key for enabling the use of custom
 	// bind volumes.
-	rktVolumesConfigOption = "rkt.volumes.enabled"
+	rktVolumesConfigOption  = "rkt.volumes.enabled"
+	rktVolumesConfigDefault = true
 
 	// rktCmd is the command rkt is installed as.
 	rktCmd = "rkt"
@@ -233,7 +234,7 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 
 	// Mount arbitrary volumes if enabled
 	if len(driverConfig.Volumes) > 0 {
-		if enabled := d.config.ReadBoolDefault(rktVolumesConfigOption, false); !enabled {
+		if enabled := d.config.ReadBoolDefault(rktVolumesConfigOption, rktVolumesConfigDefault); !enabled {
 			return nil, fmt.Errorf("%s is false; cannot use rkt volumes: %+q", rktVolumesConfigOption, driverConfig.Volumes)
 		}
 

--- a/client/driver/rkt_test.go
+++ b/client/driver/rkt_test.go
@@ -259,7 +259,6 @@ func TestRktDriver_Start_Wait_AllocDir(t *testing.T) {
 	}
 
 	driverCtx, execCtx := testDriverContexts(task)
-	driverCtx.config.Options = map[string]string{rktVolumesConfigOption: "1"}
 	defer execCtx.AllocDir.Destroy()
 	d := NewRktDriver(driverCtx)
 

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -162,8 +162,8 @@ The `docker` driver supports the following configuration in the job spec:
     ```
 
 * `volumes` - (Optional) A list of `host_path:container_path` strings to bind
-  host paths to container paths. Can only be run on clients with the
-  `docker.volumes.enabled` option set to true.
+  host paths to container paths. Can be disabled on clients by setting the
+  `docker.volumes.enabled` option set to false.
 
     ```hcl
     config {
@@ -363,9 +363,8 @@ options](/docs/agent/config.html#options):
 * `docker.cleanup.image` Defaults to `true`. Changing this to `false` will
   prevent Nomad from removing images from stopped tasks.
 
-* `docker.volumes.enabled`: Defaults to `false`. Allows tasks to bind host
-  paths (`volumes`) or other containers (`volums_from`) inside their container.
-  Disabled by default as it removes the isolation between containers' data.
+* `docker.volumes.enabled`: Defaults to `true`. Allows tasks to bind host paths
+  (`volumes`) inside their container.
 
 * `docker.volumes.selinuxlabel`: Allows the operator to set a SELinux
   label to the allocation and task local bind-mounts to containers. If used

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -162,12 +162,19 @@ The `docker` driver supports the following configuration in the job spec:
     ```
 
 * `volumes` - (Optional) A list of `host_path:container_path` strings to bind
-  host paths to container paths. Can be disabled on clients by setting the
-  `docker.volumes.enabled` option set to false.
+  host paths to container paths. Mounting host paths outside of the alloc
+  directory tasks normally have access to can be disabled on clients by setting
+  the `docker.volumes.enabled` option set to false.
 
     ```hcl
     config {
-      volumes = ["/path/on/host:/path/in/container"]
+      volumes = [
+        # Use absolute paths to mount arbitrary paths on the host
+        "/path/on/host:/path/in/container",
+
+        # Use relative paths to rebind paths already in the allocation dir
+        "relative/to/alloc:/also/in/container"
+      ]
     }
     ```
 
@@ -364,7 +371,8 @@ options](/docs/agent/config.html#options):
   prevent Nomad from removing images from stopped tasks.
 
 * `docker.volumes.enabled`: Defaults to `true`. Allows tasks to bind host paths
-  (`volumes`) inside their container.
+  (`volumes`) inside their container. Binding relative paths is always allowed
+  and will be resolved relative to the allocation's directory.
 
 * `docker.volumes.selinuxlabel`: Allows the operator to set a SELinux
   label to the allocation and task local bind-mounts to containers. If used

--- a/website/source/docs/drivers/rkt.html.md
+++ b/website/source/docs/drivers/rkt.html.md
@@ -76,12 +76,19 @@ The `rkt` driver supports the following configuration in the job spec:
 * `debug` - (Optional) Enable rkt command debug option.
 
 * `volumes` - (Optional) A list of `host_path:container_path` strings to bind
-  host paths to container paths. Can be disabled on clients by setting the
-  `rkt.volumes.enabled` option set to false.
+  host paths to container paths. Mounting host paths outside of the alloc
+  directory tasks normally have access to can be disabled on clients by setting
+  the `rkt.volumes.enabled` option set to false.
 
     ```hcl
     config {
-      volumes = ["/path/on/host:/path/in/container"]
+      volumes = [
+        # Use absolute paths to mount arbitrary paths on the host
+        "/path/on/host:/path/in/container",
+
+        # Use relative paths to rebind paths already in the allocation dir
+        "relative/to/alloc:/also/in/container"
+      ]
     }
     ```
 
@@ -98,7 +105,9 @@ The `rkt` driver has the following [client configuration
 options](/docs/agent/config.html#options):
 
 * `rkt.volumes.enabled`: Defaults to `true`. Allows tasks to bind host paths
-  (`volumes`) inside their container.
+  (`volumes`) inside their container. Binding relative paths is always allowed
+  and will be resolved relative to the allocation's directory.
+
 
 ## Client Attributes
 

--- a/website/source/docs/drivers/rkt.html.md
+++ b/website/source/docs/drivers/rkt.html.md
@@ -76,8 +76,8 @@ The `rkt` driver supports the following configuration in the job spec:
 * `debug` - (Optional) Enable rkt command debug option.
 
 * `volumes` - (Optional) A list of `host_path:container_path` strings to bind
-  host paths to container paths. Can only be run on clients with the
-  `rkt.volumes.enabled` option set to true.
+  host paths to container paths. Can be disabled on clients by setting the
+  `rkt.volumes.enabled` option set to false.
 
     ```hcl
     config {
@@ -97,9 +97,8 @@ over HTTP.
 The `rkt` driver has the following [client configuration
 options](/docs/agent/config.html#options):
 
-* `rkt.volumes.enabled`: Defaults to `false`. Allows tasks to bind host paths
-  (`volumes`) inside their container.  Disabled by default as it removes the
-  isolation between containers' data.
+* `rkt.volumes.enabled`: Defaults to `true`. Allows tasks to bind host paths
+  (`volumes`) inside their container.
 
 ## Client Attributes
 


### PR DESCRIPTION
This PR allows both rkt and docker to mount paths inside an alloc dir to other locations inside the container.

In addition it now allows both rkt and docker to mount arbitrary host paths inside the container. Since this can allow jobs to escape containerization it can be disabled with a client configuration parameter per driver.

(Branched from #1812)