### PR TITLE
Put lxc support behind a flag

### DIFF
--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -1,4 +1,4 @@
-//+build linux
+//+build linux,lxc
 
 package driver
 

--- a/client/driver/lxc_test.go
+++ b/client/driver/lxc_test.go
@@ -1,3 +1,5 @@
+//+build linux,lxc
+
 package driver
 
 import (

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,6 +46,24 @@ gox \
     -output "pkg/{{.OS}}_{{.Arch}}/nomad" \
     .
 
+echo ""
+if pkg-config --exists lxc; then
+    echo "==> Building linux_amd64_lxc..."
+    go build \
+        -tags lxc \
+        -ldflags "-X main.GitCommit='${GIT_COMMIT}${GIT_DIRTY}+lxc'" \
+        -o "pkg/linux_amd64_lxc/nomad"
+else
+    if [[ "${NOMAD_DEV}" ]]; then
+	 # No lxc in dev mode is no problem
+        echo "LXC not installed; skipping"
+    else
+	# Require LXC for release mode
+	echo "LXC not installed; install lxc-dev to build release binaries"
+	exit 1
+    fi
+fi
+
 # Move all the compiled things to the $GOPATH/bin
 GOPATH=${GOPATH:-$(go env GOPATH)}
 case $(uname) in

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,11 +7,11 @@ trap "rm -rf $TEMPDIR" EXIT HUP INT QUIT TERM
 
 # Build the Nomad binary for the API tests
 echo "--> Building nomad"
-go build -tags "nomad_test" -o $TEMPDIR/nomad || exit 1
+go build -tags "nomad_test lxc" -o $TEMPDIR/nomad || exit 1
 
 # Run the tests
 echo "--> Running tests"
 GOBIN="`which go`"
 sudo -E PATH=$TEMPDIR:$PATH  -E GOPATH=$GOPATH   -E NOMAD_TEST_RKT=1 \
-    $GOBIN test -tags "nomad_test" ${GOTEST_FLAGS:--cover -timeout=900s} $($GOBIN list ./... | grep -v /vendor/)
+    $GOBIN test -tags "nomad_test lxc" ${GOTEST_FLAGS:--cover -timeout=900s} $($GOBIN list ./... | grep -v /vendor/)
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
+GOTEST_TAGS="nomad_test lxc"
+
 # Create a temp dir and clean it up on exit
 TEMPDIR=`mktemp -d -t nomad-test.XXX`
 trap "rm -rf $TEMPDIR" EXIT HUP INT QUIT TERM
 
 # Build the Nomad binary for the API tests
 echo "--> Building nomad"
-go build -tags "nomad_test lxc" -o $TEMPDIR/nomad || exit 1
+go build -tags "$GOTEST_TAGS" -o $TEMPDIR/nomad || exit 1
 
 # Run the tests
 echo "--> Running tests"
 GOBIN="`which go`"
 sudo -E PATH=$TEMPDIR:$PATH  -E GOPATH=$GOPATH   -E NOMAD_TEST_RKT=1 \
-    $GOBIN test -tags "nomad_test lxc" ${GOTEST_FLAGS:--cover -timeout=900s} $($GOBIN list ./... | grep -v /vendor/)
+    $GOBIN test -tags "$GOTEST_TAGS" ${GOTEST_FLAGS:--cover -timeout=900s} $($GOBIN list ./... | grep -v /vendor/)
 


### PR DESCRIPTION
Since lxc support requires linking to a C lib at compile and runtime
I'm putting it behind a build flag to avoid forcing all nomad users to
install liblxc (lxc-dev for development).