### PR TITLE
Change folder permission event when not root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ BUG FIXES:
     [GH-1802]
   * cli: `alloc-status` does not query for allocation statistics if node is down
     [GH-1844]
+  * client: Folder permissions are dropped even when not running as root [GH-1888]
   * client: Prevent race when persisting state file [GH-1682]
   * client: Artifact download failures will be retried before failing tasks
     [GH-1558]

--- a/client/allocdir/alloc_dir_unix.go
+++ b/client/allocdir/alloc_dir_unix.go
@@ -43,7 +43,11 @@ func (d *AllocDir) linkOrCopy(src, dst string, perm os.FileMode) error {
 }
 
 func (d *AllocDir) dropDirPermissions(path string) error {
-	// Can't do anything if not root.
+	if err := os.Chmod(path, 0777); err != nil {
+		return fmt.Errorf("Chmod(%v) failed: %v", path, err)
+	}
+
+	// Can't change owner if not root.
 	if unix.Geteuid() != 0 {
 		return nil
 	}
@@ -65,10 +69,6 @@ func (d *AllocDir) dropDirPermissions(path string) error {
 
 	if err := os.Chown(path, uid, gid); err != nil {
 		return fmt.Errorf("Couldn't change owner/group of %v to (uid: %v, gid: %v): %v", path, uid, gid, err)
-	}
-
-	if err := os.Chmod(path, 0777); err != nil {
-		return fmt.Errorf("Chmod(%v) failed: %v", path, err)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes an issue where the created permissions weren't writable by the nobody user.