### PR TITLE
Driver start recoverable

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -785,7 +785,7 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 	}
 
 	if err := d.createImage(driverConfig, client, taskDir); err != nil {
-		return nil, fmt.Errorf("failed to create image: %v", err)
+		return nil, err
 	}
 
 	image := driverConfig.ImageName

--- a/client/driver/mock_driver.go
+++ b/client/driver/mock_driver.go
@@ -27,6 +27,13 @@ func init() {
 // MockDriverConfig is the driver configuration for the MockDriver
 type MockDriverConfig struct {
 
+	// StartErr specifies the error that should be returned when starting the
+	// mock driver.
+	StartErr string `mapstructure:"start_error"`
+
+	// StartErrRecoverable marks the error returned is recoverable
+	StartErrRecoverable bool `mapstructure:"start_error_recoverable"`
+
 	// KillAfter is the duration after which the mock driver indicates the task
 	// has exited after getting the initial SIGINT signal
 	KillAfter time.Duration `mapstructure:"kill_after"`
@@ -81,6 +88,10 @@ func (m *MockDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	}
 	if err := dec.Decode(task.Config); err != nil {
 		return nil, err
+	}
+
+	if driverConfig.StartErr != "" {
+		return nil, structs.NewRecoverableError(errors.New(driverConfig.StartErr), driverConfig.StartErrRecoverable)
 	}
 
 	h := mockDriverHandle{

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1018,8 +1018,17 @@ func (r *TaskRunner) startTask() error {
 	// Start the job
 	handle, err := driver.Start(r.ctx, r.task)
 	if err != nil {
-		return fmt.Errorf("failed to start task '%s' for alloc '%s': %v",
+		wrapped := fmt.Errorf("failed to start task '%s' for alloc '%s': %v",
 			r.task.Name, r.alloc.ID, err)
+
+		r.logger.Printf("[INFO] client: %v", wrapped)
+
+		if rerr, ok := err.(*structs.RecoverableError); ok {
+			return structs.NewRecoverableError(wrapped, rerr.Recoverable)
+		}
+
+		return wrapped
+
 	}
 
 	r.handleLock.Lock()


### PR DESCRIPTION
This PR fixes a regression in which we weren't handling recoverable errors and adds unit tests to the task runner and docker driver to prevent them.

Fixes #1858 
