### PR TITLE
Default advertisment to hostname, not 127.0.0.1

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -544,7 +544,11 @@ func (a *Agent) getSerfAddr(bind bool) (*net.TCPAddr, error) {
 // advertise.
 func pickAddress(bind bool, globalBindAddr, advertiseAddr, bindAddr string, port int, service string) (*net.TCPAddr, error) {
 	var serverAddr string
-	if advertiseAddr != "" && !bind {
+
+	switch {
+
+	// Picking an advertise address and one is set; use it
+	case advertiseAddr != "" && !bind:
 		serverAddr = advertiseAddr
 
 		// Check if the advertise has a port
@@ -554,12 +558,25 @@ func pickAddress(bind bool, globalBindAddr, advertiseAddr, bindAddr string, port
 				port = parsed
 			}
 		}
-	} else if bindAddr != "" && !(bindAddr == "0.0.0.0" && !bind) {
+
+	// Bind address is set but it's not set to 0.0.0.0 when picking a bind address
+	case bindAddr != "" && !(bindAddr == "0.0.0.0" && !bind):
 		serverAddr = bindAddr
-	} else if globalBindAddr != "" && !(globalBindAddr == "0.0.0.0" && !bind) {
+
+	// Global bind addres is set but it's not set to 0.0.0.0 when picking a bind address
+	case globalBindAddr != "" && !(globalBindAddr == "0.0.0.0" && !bind):
 		serverAddr = globalBindAddr
-	} else {
-		serverAddr = "127.0.0.1"
+
+	// Fallback to 0.0.0.0 for bind
+	case bind:
+		serverAddr = "0.0.0.0"
+
+	// Fallback to hostname for advertisement
+	default:
+		var err error
+		if serverAddr, err = os.Hostname(); err != nil {
+			return nil, fmt.Errorf("Failed to determine hostname for advertisement: %v", err)
+		}
 	}
 
 	ip := net.ParseIP(serverAddr)

--- a/website/source/docs/agent/configuration/index.html.md
+++ b/website/source/docs/agent/configuration/index.html.md
@@ -90,11 +90,12 @@ testing.
     cluster members if possible.
 
 - `advertise` `(Advertise: see below)` - Specifies the advertise address for
-  individual network services. This can be used to advertise a different address
-  to the peers of a server or a client node to support more complex network
-  configurations such as NAT. This configuration is optional, and defaults to
-  the bind address of the specific network service if it is not provided. Any
-  values configured in this stanza take precedence over the default
+  individual network services. This can be used to advertise a different
+  address to the peers of a server or a client node to support more complex
+  network configurations such as NAT. This configuration is optional, and
+  defaults to the bind address of the specific network service if it is not
+  provided. If the bind address is `0.0.0.0` then the hostname will be used.
+  Any values configured in this stanza take precedence over the default
   [bind_addr](#bind_addr).
 
   - `http` - The address to advertise for the HTTP interface. This should be


### PR DESCRIPTION
Advertising localhost in a clustered environment can lead to a disaster
where nodes recursively call RPCs on themselves when attempting to
contact other nodes.