### PR TITLE
Escape hostname in agent encryption docs

### DIFF
--- a/website/source/docs/agent/encryption.html.md
+++ b/website/source/docs/agent/encryption.html.md
@@ -43,7 +43,7 @@ a certificate is provided that is signed by the Certificate Authority from the
 
 If `verify_server_hostname` is set, then outgoing connections perform
 hostname verification. All servers must have a certificate valid for
-"server.<region>.nomad" or the client will reject the handshake. It is also
+"server.\<region\>.nomad" or the client will reject the handshake. It is also
 recommended for the certificate to sign `localhost` such that the CLI can
 validate the server name.
 

--- a/website/source/docs/agent/encryption.html.md
+++ b/website/source/docs/agent/encryption.html.md
@@ -43,7 +43,7 @@ a certificate is provided that is signed by the Certificate Authority from the
 
 If `verify_server_hostname` is set, then outgoing connections perform
 hostname verification. All servers must have a certificate valid for
-"server.\<region\>.nomad" or the client will reject the handshake. It is also
+`server.<region>.nomad` or the client will reject the handshake. It is also
 recommended for the certificate to sign `localhost` such that the CLI can
 validate the server name.
 


### PR DESCRIPTION
"server.<region>.nomad" was rendering as "server..nomad"