### PR TITLE
use snap.Alloc.TaskStates only after confirming snap.Alloc is not nil

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -122,7 +122,6 @@ func (r *AllocRunner) RestoreState() error {
 	r.ctx = snap.Context
 	r.allocClientStatus = snap.AllocClientStatus
 	r.allocClientDescription = snap.AllocClientDescription
-	r.taskStates = snap.Alloc.TaskStates
 
 	var snapshotErrors multierror.Error
 	if r.alloc == nil {
@@ -134,6 +133,8 @@ func (r *AllocRunner) RestoreState() error {
 	if e := snapshotErrors.ErrorOrNil(); e != nil {
 		return e
 	}
+
+	r.taskStates = snap.Alloc.TaskStates
 
 	// Restore the task runners
 	var mErr multierror.Error


### PR DESCRIPTION
Ran into this nil pointer deref when rebooting all nomad servers at once. Third node crashed at start on datadir:

```
Nov 07 11:08:29 nomad-eu-3.c.global-datacenter.internal nomad[1222]: client: alloc "940c5d9a-a641-b1bb-2694-ddad26c5dcc6" in terminal status, waiting for destroy
Nov 07 11:08:29 nomad-eu-3.c.global-datacenter.internal nomad[1222]: panic: runtime error: invalid memory address or nil pointer dereference
Nov 07 11:08:29 nomad-eu-3.c.global-datacenter.internal nomad[1222]: [signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0x547be5]
Nov 07 11:08:29 nomad-eu-3.c.global-datacenter.internal nomad[1222]: goroutine 1 [running]:
Nov 07 11:08:29 nomad-eu-3.c.global-datacenter.internal nomad[1222]: panic(0xfb2a80, 0xc420016030)
Nov 07 11:08:29 nomad-eu-3.c.global-datacenter.internal nomad[1222]:         /opt/go/src/runtime/panic.go:500 +0x1a1
Nov 07 11:08:29 nomad-eu-3.c.global-datacenter.internal nomad[1222]: github.com/hashicorp/nomad/client.(*AllocRunner).RestoreState(0xc4203843c0, 0xc420269a10, 0xc420535438)
Nov 07 11:08:29 nomad-eu-3.c.global-datacenter.internal nomad[1222]:         /opt/gopath/src/github.com/hashicorp/nomad/client/alloc_runner.go:125 +0x165
```
