### PR TITLE
Choose safer default advertise address

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -132,11 +132,11 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 	// Set up the bind addresses
 	rpcAddr, err := net.ResolveTCPAddr("tcp", a.config.Addresses.RPC)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to parse RPC address %q: %v", a.config.Addresses.RPC, err)
 	}
 	serfAddr, err := net.ResolveTCPAddr("tcp", a.config.Addresses.Serf)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to parse Serf address %q: %v", a.config.Addresses.Serf, err)
 	}
 	conf.RPCAddr.Port = rpcAddr.Port
 	conf.RPCAddr.IP = rpcAddr.IP
@@ -146,11 +146,11 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 	// Set up the advertise addresses
 	rpcAddr, err = net.ResolveTCPAddr("tcp", a.config.AdvertiseAddrs.RPC)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to parse RPC advertise address %q: %v", a.config.AdvertiseAddrs.RPC, err)
 	}
 	serfAddr, err = net.ResolveTCPAddr("tcp", a.config.AdvertiseAddrs.Serf)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to parse Serf advertise address %q: %v", a.config.AdvertiseAddrs.Serf, err)
 	}
 	conf.RPCAdvertise = rpcAddr
 	conf.SerfConfig.MemberlistConfig.AdvertiseAddr = serfAddr.IP.String()

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -131,13 +131,13 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 	}
 
 	// Set up the bind addresses
-	rpcAddr, err := net.ResolveTCPAddr("tcp", a.config.Addresses.RPC)
+	rpcAddr, err := net.ResolveTCPAddr("tcp", a.config.normalizedAddrs.RPC)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse RPC address %q: %v", a.config.Addresses.RPC, err)
+		return nil, fmt.Errorf("Failed to parse RPC address %q: %v", a.config.normalizedAddrs.RPC, err)
 	}
-	serfAddr, err := net.ResolveTCPAddr("tcp", a.config.Addresses.Serf)
+	serfAddr, err := net.ResolveTCPAddr("tcp", a.config.normalizedAddrs.Serf)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse Serf address %q: %v", a.config.Addresses.Serf, err)
+		return nil, fmt.Errorf("Failed to parse Serf address %q: %v", a.config.normalizedAddrs.Serf, err)
 	}
 	conf.RPCAddr.Port = rpcAddr.Port
 	conf.RPCAddr.IP = rpcAddr.IP
@@ -256,7 +256,7 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	conf.Node.NodeClass = a.config.Client.NodeClass
 
 	// Set up the HTTP advertise address
-	conf.Node.HTTPAddr = a.config.Addresses.HTTP
+	conf.Node.HTTPAddr = a.config.AdvertiseAddrs.HTTP
 
 	// Reserve resources on the node.
 	r := conf.Node.Reserved
@@ -315,9 +315,9 @@ func (a *Agent) setupServer() error {
 	a.server = server
 
 	// Consul check addresses default to bind but can be toggled to use advertise
-	httpCheckAddr := a.config.Addresses.HTTP
-	rpcCheckAddr := a.config.Addresses.RPC
-	serfCheckAddr := a.config.Addresses.Serf
+	httpCheckAddr := a.config.normalizedAddrs.HTTP
+	rpcCheckAddr := a.config.normalizedAddrs.RPC
+	serfCheckAddr := a.config.normalizedAddrs.Serf
 	if a.config.Consul.ChecksUseAdvertise {
 		httpCheckAddr = a.config.AdvertiseAddrs.HTTP
 		rpcCheckAddr = a.config.AdvertiseAddrs.RPC
@@ -438,7 +438,7 @@ func (a *Agent) setupClient() error {
 	a.client = client
 
 	// Resolve the http check address
-	httpCheckAddr := a.config.Addresses.HTTP
+	httpCheckAddr := a.config.normalizedAddrs.HTTP
 	if a.config.Consul.ChecksUseAdvertise {
 		httpCheckAddr = a.config.AdvertiseAddrs.HTTP
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/nomad/client"
@@ -45,13 +44,9 @@ type Agent struct {
 	// consulSyncer registers the Nomad agent with the Consul Agent
 	consulSyncer *consul.Syncer
 
-	client         *client.Client
-	clientHTTPAddr string
+	client *client.Client
 
-	server         *nomad.Server
-	serverHTTPAddr string
-	serverRPCAddr  string
-	serverSerfAddr string
+	server *nomad.Server
 
 	shutdown     bool
 	shutdownCh   chan struct{}
@@ -115,7 +110,7 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 		if a.config.Server.BootstrapExpect == 1 {
 			conf.Bootstrap = true
 		} else {
-			atomic.StoreInt32(&conf.BootstrapExpect, int32(a.config.Server.BootstrapExpect))
+			conf.BootstrapExpect = int32(a.config.Server.BootstrapExpect)
 		}
 	}
 	if a.config.DataDir != "" {
@@ -135,11 +130,11 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 	}
 
 	// Set up the bind addresses
-	rpcAddr, err := a.getRPCAddr(true)
+	rpcAddr, err := net.ResolveTCPAddr("tcp", a.config.Addresses.RPC)
 	if err != nil {
 		return nil, err
 	}
-	serfAddr, err := a.getSerfAddr(true)
+	serfAddr, err := net.ResolveTCPAddr("tcp", a.config.Addresses.Serf)
 	if err != nil {
 		return nil, err
 	}
@@ -149,21 +144,14 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 	conf.SerfConfig.MemberlistConfig.BindAddr = serfAddr.IP.String()
 
 	// Set up the advertise addresses
-	httpAddr, err := a.getHTTPAddr(false)
+	rpcAddr, err = net.ResolveTCPAddr("tcp", a.config.AdvertiseAddrs.RPC)
 	if err != nil {
 		return nil, err
 	}
-	rpcAddr, err = a.getRPCAddr(false)
+	serfAddr, err = net.ResolveTCPAddr("tcp", a.config.AdvertiseAddrs.Serf)
 	if err != nil {
 		return nil, err
 	}
-	serfAddr, err = a.getSerfAddr(false)
-	if err != nil {
-		return nil, err
-	}
-	a.serverHTTPAddr = net.JoinHostPort(httpAddr.IP.String(), strconv.Itoa(httpAddr.Port))
-	a.serverRPCAddr = net.JoinHostPort(rpcAddr.IP.String(), strconv.Itoa(rpcAddr.Port))
-	a.serverSerfAddr = net.JoinHostPort(serfAddr.IP.String(), strconv.Itoa(serfAddr.Port))
 	conf.RPCAdvertise = rpcAddr
 	conf.SerfConfig.MemberlistConfig.AdvertiseAddr = serfAddr.IP.String()
 	conf.SerfConfig.MemberlistConfig.AdvertisePort = serfAddr.Port
@@ -267,12 +255,7 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	conf.Node.NodeClass = a.config.Client.NodeClass
 
 	// Set up the HTTP advertise address
-	httpAddr, err := a.selectAddr(a.getHTTPAddr, false)
-	if err != nil {
-		return nil, err
-	}
-	conf.Node.HTTPAddr = httpAddr
-	a.clientHTTPAddr = httpAddr
+	conf.Node.HTTPAddr = a.config.Addresses.HTTP
 
 	// Reserve resources on the node.
 	r := conf.Node.Reserved
@@ -330,18 +313,14 @@ func (a *Agent) setupServer() error {
 	}
 	a.server = server
 
-	// Resolve consul check addresses. Always use advertise address for services
-	httpCheckAddr, err := a.selectAddr(a.getHTTPAddr, !a.config.Consul.ChecksUseAdvertise)
-	if err != nil {
-		return err
-	}
-	rpcCheckAddr, err := a.selectAddr(a.getRPCAddr, !a.config.Consul.ChecksUseAdvertise)
-	if err != nil {
-		return err
-	}
-	serfCheckAddr, err := a.selectAddr(a.getSerfAddr, !a.config.Consul.ChecksUseAdvertise)
-	if err != nil {
-		return err
+	// Consul check addresses default to bind but can be toggled to use advertise
+	httpCheckAddr := a.config.Addresses.HTTP
+	rpcCheckAddr := a.config.Addresses.RPC
+	serfCheckAddr := a.config.Addresses.Serf
+	if a.config.Consul.ChecksUseAdvertise {
+		httpCheckAddr = a.config.AdvertiseAddrs.HTTP
+		rpcCheckAddr = a.config.AdvertiseAddrs.RPC
+		serfCheckAddr = a.config.AdvertiseAddrs.Serf
 	}
 
 	// Create the Nomad Server services for Consul
@@ -349,7 +328,7 @@ func (a *Agent) setupServer() error {
 	if a.config.Consul.AutoAdvertise {
 		httpServ := &structs.Service{
 			Name:      a.config.Consul.ServerServiceName,
-			PortLabel: a.serverHTTPAddr,
+			PortLabel: a.config.AdvertiseAddrs.HTTP,
 			Tags:      []string{consul.ServiceTagHTTP},
 			Checks: []*structs.ServiceCheck{
 				&structs.ServiceCheck{
@@ -365,7 +344,7 @@ func (a *Agent) setupServer() error {
 		}
 		rpcServ := &structs.Service{
 			Name:      a.config.Consul.ServerServiceName,
-			PortLabel: a.serverRPCAddr,
+			PortLabel: a.config.AdvertiseAddrs.RPC,
 			Tags:      []string{consul.ServiceTagRPC},
 			Checks: []*structs.ServiceCheck{
 				&structs.ServiceCheck{
@@ -378,8 +357,8 @@ func (a *Agent) setupServer() error {
 			},
 		}
 		serfServ := &structs.Service{
-			PortLabel: a.serverSerfAddr,
 			Name:      a.config.Consul.ServerServiceName,
+			PortLabel: a.config.AdvertiseAddrs.Serf,
 			Tags:      []string{consul.ServiceTagSerf},
 			Checks: []*structs.ServiceCheck{
 				&structs.ServiceCheck{
@@ -458,9 +437,9 @@ func (a *Agent) setupClient() error {
 	a.client = client
 
 	// Resolve the http check address
-	httpCheckAddr, err := a.selectAddr(a.getHTTPAddr, !a.config.Consul.ChecksUseAdvertise)
-	if err != nil {
-		return err
+	httpCheckAddr := a.config.Addresses.HTTP
+	if a.config.Consul.ChecksUseAdvertise {
+		httpCheckAddr = a.config.AdvertiseAddrs.HTTP
 	}
 
 	// Create the Nomad Client  services for Consul
@@ -469,7 +448,7 @@ func (a *Agent) setupClient() error {
 	if a.config.Consul.AutoAdvertise {
 		httpServ := &structs.Service{
 			Name:      a.config.Consul.ClientServiceName,
-			PortLabel: a.clientHTTPAddr,
+			PortLabel: a.config.AdvertiseAddrs.HTTP,
 			Tags:      []string{consul.ServiceTagHTTP},
 			Checks: []*structs.ServiceCheck{
 				&structs.ServiceCheck{
@@ -491,103 +470,6 @@ func (a *Agent) setupClient() error {
 	}
 
 	return nil
-}
-
-// Defines the selector interface
-type addrSelector func(bool) (*net.TCPAddr, error)
-
-// selectAddr returns the right address given a selector, and return it as a PortLabel
-// preferBind is a weak preference, and will skip 0.0.0.0
-func (a *Agent) selectAddr(selector addrSelector, preferBind bool) (string, error) {
-	addr, err := selector(preferBind)
-	if err != nil {
-		return "", err
-	}
-
-	if preferBind && addr.IP.String() == "0.0.0.0" {
-		addr, err = selector(false)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	address := net.JoinHostPort(addr.IP.String(), strconv.Itoa(addr.Port))
-	return address, nil
-}
-
-// getHTTPAddr returns the HTTP address to use based on the clients
-// configuration. If bind is true, an address appropriate for binding is
-// returned, otherwise an address for advertising is returned. Skip 0.0.0.0
-// unless returning a bind address, since that's the only time it's useful.
-func (a *Agent) getHTTPAddr(bind bool) (*net.TCPAddr, error) {
-	advertAddr := a.config.AdvertiseAddrs.HTTP
-	bindAddr := a.config.Addresses.HTTP
-	globalBindAddr := a.config.BindAddr
-	port := a.config.Ports.HTTP
-	return pickAddress(bind, globalBindAddr, advertAddr, bindAddr, port, "HTTP")
-}
-
-// getRPCAddr returns the HTTP address to use based on the clients
-// configuration. If bind is true, an address appropriate for binding is
-// returned, otherwise an address for advertising is returned. Skip 0.0.0.0
-// unless returning a bind address, since that's the only time it's useful.
-func (a *Agent) getRPCAddr(bind bool) (*net.TCPAddr, error) {
-	advertAddr := a.config.AdvertiseAddrs.RPC
-	bindAddr := a.config.Addresses.RPC
-	globalBindAddr := a.config.BindAddr
-	port := a.config.Ports.RPC
-	return pickAddress(bind, globalBindAddr, advertAddr, bindAddr, port, "RPC")
-}
-
-// getSerfAddr returns the Serf address to use based on the clients
-// configuration. If bind is true, an address appropriate for binding is
-// returned, otherwise an address for advertising is returned. Skip 0.0.0.0
-// unless returning a bind address, since that's the only time it's useful.
-func (a *Agent) getSerfAddr(bind bool) (*net.TCPAddr, error) {
-	advertAddr := a.config.AdvertiseAddrs.Serf
-	bindAddr := a.config.Addresses.Serf
-	globalBindAddr := a.config.BindAddr
-	port := a.config.Ports.Serf
-	return pickAddress(bind, globalBindAddr, advertAddr, bindAddr, port, "Serf")
-}
-
-// pickAddress is a shared helper to pick the address to either bind to or
-// advertise.
-func pickAddress(bind bool, globalBindAddr, advertiseAddr, bindAddr string, port int, service string) (*net.TCPAddr, error) {
-	var serverAddr string
-	if advertiseAddr != "" && !bind {
-		serverAddr = advertiseAddr
-
-		// Check if the advertise has a port
-		if host, pport, err := net.SplitHostPort(advertiseAddr); err == nil {
-			if parsed, err := strconv.Atoi(pport); err == nil {
-				serverAddr = host
-				port = parsed
-			}
-		}
-	} else if bindAddr != "" && !(bindAddr == "0.0.0.0" && !bind) {
-		serverAddr = bindAddr
-	} else if globalBindAddr != "" && !(globalBindAddr == "0.0.0.0" && !bind) {
-		serverAddr = globalBindAddr
-	} else {
-		serverAddr = "127.0.0.1"
-	}
-
-	ip := net.ParseIP(serverAddr)
-	if ip == nil {
-		joined := net.JoinHostPort(serverAddr, strconv.Itoa(port))
-		addr, err := net.ResolveTCPAddr("tcp", joined)
-		if err == nil {
-			return addr, nil
-		}
-
-		return nil, fmt.Errorf("Failed to parse %s %q as IP and failed to resolve address: %v", service, serverAddr, err)
-	}
-
-	return &net.TCPAddr{
-		IP:   ip,
-		Port: port,
-	}, nil
 }
 
 // reservePortsForClient reserves a range of ports for the client to use when

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/nomad/client"
@@ -110,7 +111,7 @@ func (a *Agent) serverConfig() (*nomad.Config, error) {
 		if a.config.Server.BootstrapExpect == 1 {
 			conf.Bootstrap = true
 		} else {
-			conf.BootstrapExpect = int32(a.config.Server.BootstrapExpect)
+			atomic.StoreInt32(&conf.BootstrapExpect, int32(a.config.Server.BootstrapExpect))
 		}
 	}
 	if a.config.DataDir != "" {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -94,6 +94,10 @@ func TestAgent_RPCPing(t *testing.T) {
 func TestAgent_ServerConfig(t *testing.T) {
 	conf := DefaultConfig()
 	a := &Agent{config: conf}
+	testlogger := func(s string) {
+		t.Log(s)
+	}
+	dev := false
 
 	// Returns error on bad serf addr
 	conf.AdvertiseAddrs.Serf = "nope"
@@ -113,6 +117,9 @@ func TestAgent_ServerConfig(t *testing.T) {
 	conf.AdvertiseAddrs.HTTP = "10.10.11.1:4005"
 
 	// Parses the advertise addrs correctly
+	if ok := conf.normalize(testlogger, dev); !ok {
+		t.Fatalf("failed to normalize config")
+	}
 	out, err := a.serverConfig()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -125,20 +132,27 @@ func TestAgent_ServerConfig(t *testing.T) {
 	if serfPort != 4000 {
 		t.Fatalf("expected 4000, got: %d", serfPort)
 	}
-	if addr := out.RPCAdvertise; addr.IP.String() != "127.0.0.1" || addr.Port != 4001 {
+
+	// Assert addresses weren't changed
+	if addr := conf.AdvertiseAddrs.RPC; addr != "127.0.0.1:4001" {
 		t.Fatalf("bad rpc advertise addr: %#v", addr)
 	}
-	if addr := a.serverHTTPAddr; addr != "10.10.11.1:4005" {
+	if addr := conf.AdvertiseAddrs.HTTP; addr != "10.10.11.1:4005" {
 		t.Fatalf("expect 10.11.11.1:4005, got: %v", addr)
 	}
-	if addr := a.serverRPCAddr; addr != "127.0.0.1:4001" {
-		t.Fatalf("expect 127.0.0.1:4001, got: %v", addr)
+	if addr := conf.Addresses.RPC; addr != "0.0.0.0:4647" {
+		t.Fatalf("expect 0.0.0.0:4001, got: %v", addr)
 	}
 
 	// Sets up the ports properly
+	conf.Addresses.RPC = ""
+	conf.Addresses.Serf = ""
 	conf.Ports.RPC = 4003
 	conf.Ports.Serf = 4004
 
+	if ok := conf.normalize(testlogger, dev); !ok {
+		t.Fatalf("failed to normalize config")
+	}
 	out, err = a.serverConfig()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -152,93 +166,83 @@ func TestAgent_ServerConfig(t *testing.T) {
 
 	// Prefers advertise over bind addr
 	conf.BindAddr = "127.0.0.3"
+	conf.Addresses.HTTP = "127.0.0.2"
 	conf.Addresses.RPC = "127.0.0.2"
 	conf.Addresses.Serf = "127.0.0.2"
-	conf.Addresses.HTTP = "127.0.0.2"
 	conf.AdvertiseAddrs.HTTP = "10.0.0.10"
 	conf.AdvertiseAddrs.RPC = ""
 	conf.AdvertiseAddrs.Serf = "10.0.0.12:4004"
 
+	if ok := conf.normalize(testlogger, dev); !ok {
+		t.Fatalf("failed to normalize config")
+	}
 	out, err = a.serverConfig()
+	fmt.Println(conf.Addresses.RPC)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	if addr := out.RPCAddr.IP.String(); addr != "127.0.0.2" {
 		t.Fatalf("expect 127.0.0.2, got: %s", addr)
 	}
+	if port := out.RPCAddr.Port; port != 4003 {
+		t.Fatalf("expect 4647, got: %d", port)
+	}
 	if addr := out.SerfConfig.MemberlistConfig.BindAddr; addr != "127.0.0.2" {
 		t.Fatalf("expect 127.0.0.2, got: %s", addr)
 	}
-	if addr := a.serverHTTPAddr; addr != "10.0.0.10:4646" {
-		t.Fatalf("expect 10.0.0.10:4646, got: %s", addr)
+	if port := out.SerfConfig.MemberlistConfig.BindPort; port != 4004 {
+		t.Fatalf("expect 4648, got: ^d", port)
 	}
-	// NOTE: AdvertiseAddr > Addresses > BindAddr > Defaults
-	if addr := a.serverRPCAddr; addr != "127.0.0.2:4003" {
-		t.Fatalf("expect 127.0.0.2:4003, got: %s", addr)
-	}
-	if addr := a.serverSerfAddr; addr != "10.0.0.12:4004" {
-		t.Fatalf("expect 10.0.0.12:4004, got: %s", addr)
-	}
-
-	// It correctly identifies the bind and advertise address when requested
-	if addr, err := a.selectAddr(a.getHTTPAddr, true); addr != "127.0.0.2:4646" || err != nil {
+	if addr := conf.Addresses.HTTP; addr != "127.0.0.2:4646" {
 		t.Fatalf("expect 127.0.0.2:4646, got: %s", addr)
 	}
-
-	if addr, err := a.selectAddr(a.getHTTPAddr, false); addr != "10.0.0.10:4646" || err != nil {
-		t.Fatalf("expect 10.0.0.10:4646, got: %s", addr)
-	}
-
-	if addr, err := a.selectAddr(a.getRPCAddr, true); addr != "127.0.0.2:4003" || err != nil {
+	if addr := conf.Addresses.RPC; addr != "127.0.0.2:4003" {
 		t.Fatalf("expect 127.0.0.2:4003, got: %s", addr)
 	}
-
-	if addr, err := a.selectAddr(a.getRPCAddr, false); addr != "127.0.0.2:4003" || err != nil {
-		t.Fatalf("expect 127.0.0.2:4003, got: %s", addr)
-	}
-
-	if addr, err := a.selectAddr(a.getSerfAddr, true); addr != "127.0.0.2:4004" || err != nil {
-		t.Fatalf("expect 127.0.0.2:4004, got: %s", addr)
-	}
-
-	if addr, err := a.selectAddr(a.getSerfAddr, false); addr != "10.0.0.12:4004" || err != nil {
+	if addr := conf.Addresses.Serf; addr != "127.0.0.2:4004" {
 		t.Fatalf("expect 10.0.0.12:4004, got: %s", addr)
 	}
-
-	// We don't resolve 0.0.0.0 unless we're asking for bind
-	conf.Addresses.HTTP = "0.0.0.0"
-	conf.AdvertiseAddrs.HTTP = ""
-	if addr, err := a.getHTTPAddr(false); addr.IP.String() != "127.0.0.3" || err != nil {
-		t.Fatalf("expect 127.0.0.3, got: %s", addr.IP.String())
+	if addr := conf.AdvertiseAddrs.HTTP; addr != "10.0.0.10:4646" {
+		t.Fatalf("expect 10.0.0.10:4646, got: %s", addr)
 	}
-
-	// We still get 0.0.0.0 when explicitly asking for bind
-	if addr, err := a.getHTTPAddr(true); addr.IP.String() != "0.0.0.0" || err != nil {
-		t.Fatalf("expect 0.0.0.0, got: %s", addr.IP.String())
+	if addr := conf.AdvertiseAddrs.RPC; addr != "127.0.0.3:4003" {
+		t.Fatalf("expect 127.0.0.3:4003, got: %s", addr)
 	}
-
-	// selectAddr does not return 0.0.0.0 with preferBind
-	if addr, err := a.selectAddr(a.getHTTPAddr, true); addr != "127.0.0.3:4646" || err != nil {
-		t.Fatalf("expect 127.0.0.3:4646, got: %s", addr)
+	if addr := conf.AdvertiseAddrs.Serf; addr != "10.0.0.12:4004" {
+		t.Fatalf("expect 10.0.0.12:4004, got: %s", addr)
 	}
 
 	conf.Server.NodeGCThreshold = "42g"
+	if ok := conf.normalize(testlogger, dev); !ok {
+		t.Fatalf("failed to normalize config")
+	}
 	out, err = a.serverConfig()
 	if err == nil || !strings.Contains(err.Error(), "unknown unit") {
 		t.Fatalf("expected unknown unit error, got: %#v", err)
 	}
+
 	conf.Server.NodeGCThreshold = "10s"
+	if ok := conf.normalize(testlogger, dev); !ok {
+		t.Fatalf("failed to normalize config")
+	}
 	out, err = a.serverConfig()
 	if threshold := out.NodeGCThreshold; threshold != time.Second*10 {
 		t.Fatalf("expect 10s, got: %s", threshold)
 	}
 
 	conf.Server.HeartbeatGrace = "42g"
+	if ok := conf.normalize(testlogger, dev); !ok {
+		t.Fatalf("failed to normalize config")
+	}
 	out, err = a.serverConfig()
 	if err == nil || !strings.Contains(err.Error(), "unknown unit") {
 		t.Fatalf("expected unknown unit error, got: %#v", err)
 	}
+
 	conf.Server.HeartbeatGrace = "37s"
+	if ok := conf.normalize(testlogger, dev); !ok {
+		t.Fatalf("failed to normalize config")
+	}
 	out, err = a.serverConfig()
 	if threshold := out.HeartbeatGrace; threshold != time.Second*37 {
 		t.Fatalf("expect 37s, got: %s", threshold)
@@ -254,6 +258,9 @@ func TestAgent_ServerConfig(t *testing.T) {
 	conf.Ports.HTTP = 4646
 	conf.Ports.RPC = 4647
 	conf.Ports.Serf = 4648
+	if ok := conf.normalize(testlogger, dev); !ok {
+		t.Fatalf("failed to normalize config")
+	}
 	out, err = a.serverConfig()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -264,13 +271,13 @@ func TestAgent_ServerConfig(t *testing.T) {
 	if addr := out.SerfConfig.MemberlistConfig.BindAddr; addr != "127.0.0.3" {
 		t.Fatalf("expect 127.0.0.3, got: %s", addr)
 	}
-	if addr := a.serverHTTPAddr; addr != "127.0.0.3:4646" {
+	if addr := conf.Addresses.HTTP; addr != "127.0.0.3:4646" {
 		t.Fatalf("expect 127.0.0.3:4646, got: %s", addr)
 	}
-	if addr := a.serverRPCAddr; addr != "127.0.0.3:4647" {
+	if addr := conf.Addresses.RPC; addr != "127.0.0.3:4647" {
 		t.Fatalf("expect 127.0.0.3:4647, got: %s", addr)
 	}
-	if addr := a.serverSerfAddr; addr != "127.0.0.3:4648" {
+	if addr := conf.Addresses.Serf; addr != "127.0.0.3:4648" {
 		t.Fatalf("expect 127.0.0.3:4648, got: %s", addr)
 	}
 

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -178,7 +178,7 @@ func TestAgent_ServerConfig(t *testing.T) {
 		t.Fatalf("expect 127.0.0.2, got: %s", addr)
 	}
 	if port := out.SerfConfig.MemberlistConfig.BindPort; port != 4004 {
-		t.Fatalf("expect 4648, got: ^d", port)
+		t.Fatalf("expect 4648, got: %d", port)
 	}
 	if addr := conf.Addresses.HTTP; addr != "127.0.0.2" {
 		t.Fatalf("expect 127.0.0.2, got: %s", addr)

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -318,11 +318,16 @@ func TestAgent_ServerConfig(t *testing.T) {
 
 func TestAgent_ClientConfig(t *testing.T) {
 	conf := DefaultConfig()
+	// enabled just to allow using localhost for all addresses
+	conf.DevMode = true
 	a := &Agent{config: conf}
 	conf.Client.Enabled = true
 	conf.Addresses.HTTP = "127.0.0.1"
 	conf.Ports.HTTP = 5678
 
+	if ok := conf.normalize(getTestLogger(t), conf.DevMode); !ok {
+		t.Fatalf("error normalizing config")
+	}
 	c, err := a.clientConfig()
 	if err != nil {
 		t.Fatalf("got err: %v", err)
@@ -334,10 +339,14 @@ func TestAgent_ClientConfig(t *testing.T) {
 	}
 
 	conf = DefaultConfig()
+	conf.DevMode = true
 	a = &Agent{config: conf}
 	conf.Client.Enabled = true
 	conf.Addresses.HTTP = "127.0.0.1"
 
+	if ok := conf.normalize(getTestLogger(t), conf.DevMode); !ok {
+		t.Fatalf("error normalizing config")
+	}
 	c, err = a.clientConfig()
 	if err != nil {
 		t.Fatalf("got err: %v", err)

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -246,8 +246,12 @@ func (c *Command) readConfig() *Config {
 		}
 		ip, err := net.ResolveIPAddr("ip", host)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Unable to resolve hostname to set advertise address: %v", err))
-			return false
+			// Just because this node can't resolve its advertise
+			// address doesn't mean it's a bad address; use it
+			defaultAdvertise = host
+			newaddr := fmt.Sprintf("%s:%d", defaultAdvertise, port)
+			*addr = newaddr
+			return true
 		}
 		if ip.IP.IsLoopback() && !dev {
 			c.Ui.Error("Unable to select default advertise address as hostname resolves to localhost")

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -61,7 +61,7 @@ func TestCommand_Args(t *testing.T) {
 
 		// To prevent test failures on hosts whose hostname resolves to
 		// a loopback address, we must append a bind address
-		tc.args = append(tc.args, "-bind=127.0.0.1")
+		tc.args = append(tc.args, "-bind=169.254.0.1")
 		if code := cmd.Run(tc.args); code != 1 {
 			t.Fatalf("args: %v\nexit: %d\n", tc.args, code)
 		}

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -59,6 +59,9 @@ func TestCommand_Args(t *testing.T) {
 			ShutdownCh: shutdownCh,
 		}
 
+		// To prevent test failures on hosts whose hostname resolves to
+		// a loopback address, we must append a bind address
+		tc.args = append(tc.args, "-bind=127.0.0.1")
 		if code := cmd.Run(tc.args); code != 1 {
 			t.Fatalf("args: %v\nexit: %d\n", tc.args, code)
 		}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -772,7 +772,7 @@ func normalizeBind(addr *string, bind string, defport *int) error {
 		}
 
 		// missing port, add default
-		newaddr := fmt.Sprintf("%s:%d", *addr, defport)
+		newaddr := fmt.Sprintf("%s:%d", *addr, *defport)
 		*addr = newaddr
 		return nil
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -431,6 +431,7 @@ func (r *Resources) ParseReserved() error {
 // DevConfig is a Config that is used for dev mode of Nomad.
 func DevConfig() *Config {
 	conf := DefaultConfig()
+	conf.BindAddr = "127.0.0.1"
 	conf.LogLevel = "DEBUG"
 	conf.Client.Enabled = true
 	conf.Server.Enabled = true
@@ -459,7 +460,7 @@ func DefaultConfig() *Config {
 		LogLevel:   "INFO",
 		Region:     "global",
 		Datacenter: "dc1",
-		BindAddr:   "127.0.0.1",
+		BindAddr:   "0.0.0.0",
 		Ports: &Ports{
 			HTTP: 4646,
 			RPC:  4647,

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -663,8 +663,8 @@ func (c *Config) Merge(b *Config) *Config {
 	return &result
 }
 
-// normalize Addresses and AdvertiseAddrs to always be initialized and have
-// sane defaults.
+// normalizeAddrs normalizes Addresses and AdvertiseAddrs to always be
+// initialized and have sane defaults.
 func (c *Config) normalizeAddrs() error {
 	c.Addresses.HTTP = normalizeBind(c.Addresses.HTTP, c.BindAddr)
 	c.Addresses.RPC = normalizeBind(c.Addresses.RPC, c.BindAddr)

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -539,5 +540,16 @@ func TestResources_ParseReserved(t *testing.T) {
 			t.Fatalf("test case %d: \n\n%#v\n\n%#v", i, r.ParsedReservedPorts, tc.Parsed)
 		}
 
+	}
+}
+
+func TestIsMissingPort(t *testing.T) {
+	_, _, err := net.SplitHostPort("localhost")
+	if missing := isMissingPort(err); !missing {
+		t.Errorf("expected missing port error, but got %v", err)
+	}
+	_, _, err = net.SplitHostPort("localhost:9000")
+	if missing := isMissingPort(err); missing {
+		t.Errorf("expected no error, but got %v", err)
 	}
 }

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -49,7 +49,7 @@ type HTTPServer struct {
 // NewHTTPServer starts new HTTP server over the agent
 func NewHTTPServer(agent *Agent, config *Config, logOutput io.Writer) (*HTTPServer, error) {
 	// Start the listener
-	lnAddr, err := net.ResolveTCPAddr("tcp", config.Addresses.HTTP)
+	lnAddr, err := net.ResolveTCPAddr("tcp", config.normalizedAddrs.HTTP)
 	if err != nil {
 		return nil, err
 	}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -49,7 +49,7 @@ type HTTPServer struct {
 // NewHTTPServer starts new HTTP server over the agent
 func NewHTTPServer(agent *Agent, config *Config, logOutput io.Writer) (*HTTPServer, error) {
 	// Start the listener
-	lnAddr, err := agent.getHTTPAddr(true)
+	lnAddr, err := net.ResolveTCPAddr("tcp", config.Addresses.HTTP)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* -dev mode defaults bind & advertise to localhost
* Normal mode defaults bind to 0.0.0.0 & advertise to the resolved
  hostname. If the hostname resolves to localhost it will refuse to
  start and advertise must be manually set.