### PR TITLE
Support blacklisting fingerprinters

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -721,7 +721,6 @@ func (c *Client) fingerprint() error {
 	whitelist := c.config.ReadStringListToMap("fingerprint.whitelist")
 	whitelistEnabled := len(whitelist) > 0
 	blacklist := c.config.ReadStringListToMap("fingerprint.blacklist")
-	blacklistEnabled := len(blacklist) > 0
 
 	c.logger.Printf("[DEBUG] client: built-in fingerprints: %v", fingerprint.BuiltinFingerprints())
 
@@ -733,8 +732,8 @@ func (c *Client) fingerprint() error {
 			skipped = append(skipped, name)
 			continue
 		}
-		// Skip modules that are in the blacklist if it is enabled.
-		if _, ok := blacklist[name]; blacklistEnabled && ok {
+		// Skip modules that are in the blacklist
+		if _, ok := blacklist[name]; ok {
 			skipped = append(skipped, name)
 			continue
 		}
@@ -790,7 +789,6 @@ func (c *Client) setupDrivers() error {
 	whitelist := c.config.ReadStringListToMap("driver.whitelist")
 	whitelistEnabled := len(whitelist) > 0
 	blacklist := c.config.ReadStringListToMap("driver.blacklist")
-	blacklistEnabled := len(blacklist) > 0
 
 	var avail []string
 	var skipped []string
@@ -802,8 +800,8 @@ func (c *Client) setupDrivers() error {
 			skipped = append(skipped, name)
 			continue
 		}
-		// Skip fingerprinting drivers that are in the blacklist if it is enabled.
-		if _, ok := blacklist[name]; blacklistEnabled && ok {
+		// Skip fingerprinting drivers that are in the blacklist
+		if _, ok := blacklist[name]; ok {
 			skipped = append(skipped, name)
 			continue
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -720,6 +720,9 @@ func (c *Client) reservePorts() {
 func (c *Client) fingerprint() error {
 	whitelist := c.config.ReadStringListToMap("fingerprint.whitelist")
 	whitelistEnabled := len(whitelist) > 0
+	blacklist := c.config.ReadStringListToMap("fingerprint.blacklist")
+	blacklistEnabled := len(blacklist) > 0
+
 	c.logger.Printf("[DEBUG] client: built-in fingerprints: %v", fingerprint.BuiltinFingerprints())
 
 	var applied []string
@@ -727,6 +730,11 @@ func (c *Client) fingerprint() error {
 	for _, name := range fingerprint.BuiltinFingerprints() {
 		// Skip modules that are not in the whitelist if it is enabled.
 		if _, ok := whitelist[name]; whitelistEnabled && !ok {
+			skipped = append(skipped, name)
+			continue
+		}
+		// Skip modules that are in the blacklist if it is enabled.
+		if _, ok := blacklist[name]; blacklistEnabled && ok {
 			skipped = append(skipped, name)
 			continue
 		}
@@ -754,7 +762,7 @@ func (c *Client) fingerprint() error {
 	}
 	c.logger.Printf("[DEBUG] client: applied fingerprints %v", applied)
 	if len(skipped) != 0 {
-		c.logger.Printf("[DEBUG] client: fingerprint modules skipped due to whitelist: %v", skipped)
+		c.logger.Printf("[DEBUG] client: fingerprint modules skipped due to white/blacklist: %v", skipped)
 	}
 	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -786,9 +786,11 @@ func (c *Client) fingerprintPeriodic(name string, f fingerprint.Fingerprint, d t
 
 // setupDrivers is used to find the available drivers
 func (c *Client) setupDrivers() error {
-	// Build the whitelist of drivers.
+	// Build the white/blacklists of drivers.
 	whitelist := c.config.ReadStringListToMap("driver.whitelist")
 	whitelistEnabled := len(whitelist) > 0
+	blacklist := c.config.ReadStringListToMap("driver.blacklist")
+	blacklistEnabled := len(blacklist) > 0
 
 	var avail []string
 	var skipped []string
@@ -797,6 +799,11 @@ func (c *Client) setupDrivers() error {
 		// Skip fingerprinting drivers that are not in the whitelist if it is
 		// enabled.
 		if _, ok := whitelist[name]; whitelistEnabled && !ok {
+			skipped = append(skipped, name)
+			continue
+		}
+		// Skip fingerprinting drivers that are in the blacklist if it is enabled.
+		if _, ok := blacklist[name]; blacklistEnabled && ok {
 			skipped = append(skipped, name)
 			continue
 		}
@@ -825,7 +832,7 @@ func (c *Client) setupDrivers() error {
 	c.logger.Printf("[DEBUG] client: available drivers %v", avail)
 
 	if len(skipped) != 0 {
-		c.logger.Printf("[DEBUG] client: drivers skipped due to whitelist: %v", skipped)
+		c.logger.Printf("[DEBUG] client: drivers skipped due to white/blacklist: %v", skipped)
 	}
 
 	return nil

--- a/website/source/docs/agent/configuration/client.html.md
+++ b/website/source/docs/agent/configuration/client.html.md
@@ -135,8 +135,7 @@ see the [drivers documentation](/docs/drivers/index.html).
 
 - `"driver.blacklist"` `(string: "")` - Specifies a comma-separated list of
   blacklisted drivers . If specified, drivers in the blacklist will be
-  disabled. If the blacklist is empty, all drivers are fingerprinted and enabled
-  where applicable.
+  disabled.
 
     ```hcl
     client {
@@ -228,7 +227,7 @@ see the [drivers documentation](/docs/drivers/index.html).
 
 - `"fingerprint.blacklist"` `(string: "")` - Specifies a comma-separated list of
   blacklisted fingerprinters. If specified, any fingerprinters in the blacklist
-  will be disabled. If the blacklist is empty, all fingerprinters are used.
+  will be disabled.
 
     ```hcl
     client {

--- a/website/source/docs/agent/configuration/client.html.md
+++ b/website/source/docs/agent/configuration/client.html.md
@@ -213,6 +213,18 @@ see the [drivers documentation](/docs/drivers/index.html).
     }
     ```
 
+- `"fingerprint.blacklist"` `(string: "")` - Specifies a comma-separated list of
+  blacklisted fingerprinters. If specified, any fingerprinters in the blacklist
+  will be disabled. If the blacklist is empty, all fingerprinters are used.
+
+    ```hcl
+    client {
+      options = {
+        "fingerprint.blacklist" = "network"
+      }
+    }
+    ```
+
 ### `reserved` Parameters
 
 - `cpu` `(int: 0)` - Specifies the amount of CPU to reserve, in MHz.

--- a/website/source/docs/agent/configuration/client.html.md
+++ b/website/source/docs/agent/configuration/client.html.md
@@ -133,6 +133,19 @@ see the [drivers documentation](/docs/drivers/index.html).
     }
     ```
 
+- `"driver.blacklist"` `(string: "")` - Specifies a comma-separated list of
+  blacklisted drivers . If specified, drivers in the blacklist will be
+  disabled. If the blacklist is empty, all drivers are fingerprinted and enabled
+  where applicable.
+
+    ```hcl
+    client {
+      options = {
+        "driver.blacklist" = "docker,qemu"
+      }
+    }
+    ```
+
 - `"env.blacklist"` `(string: see below)` - Specifies a comma-separated list of
   environment variable keys not to pass to these tasks. Nomad passes the host
   environment variables to `exec`, `raw_exec` and `java` tasks. If specified,


### PR DESCRIPTION
Currently there is a client option `fingerprint.whitelist`. It would be useful to extend it with a blacklisting option as well. 

Use case: we would like to disable `env_aws` since it picks up things from our Openstack platform which are nonsensical. Currently we need to figure out the list of available fingerprinters on the host, and then whitelist all of them except the aws one.