### PR TITLE
Fix marking unrecoverable errors as recoverable when deriving Vault token

### DIFF
--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -657,13 +657,9 @@ func TestVaultClient_CreateToken_Role_Unrecoverable(t *testing.T) {
 		t.Fatalf("CreateToken should have failed: %v", err)
 	}
 
-	rerr, ok := err.(*structs.RecoverableError)
-	if !ok {
-		t.Fatalf("CreateToken should have returned a recoverable error type: %v", err)
-	}
-
-	if rerr.Recoverable {
-		t.Fatalf("CreateToken should have returned a unrecoverable error: %v", err)
+	_, ok := err.(*structs.RecoverableError)
+	if ok {
+		t.Fatalf("CreateToken should not be a recoverable error type: %v", err)
 	}
 }
 

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -629,6 +629,44 @@ func TestVaultClient_CreateToken_Role_InvalidToken(t *testing.T) {
 	}
 }
 
+func TestVaultClient_CreateToken_Role_Unrecoverable(t *testing.T) {
+	v := testutil.NewTestVault(t).Start()
+	defer v.Stop()
+
+	// Set the configs token in a new test role
+	v.Config.Token = defaultTestVaultRoleAndToken(v, t, 5)
+
+	// Start the client
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	client, err := NewVaultClient(v.Config, logger, nil)
+	if err != nil {
+		t.Fatalf("failed to build vault client: %v", err)
+	}
+	client.SetActive(true)
+	defer client.Stop()
+
+	waitForConnection(client, t)
+
+	// Create an allocation that requires a Vault policy
+	a := mock.Alloc()
+	task := a.Job.TaskGroups[0].Tasks[0]
+	task.Vault = &structs.Vault{Policies: []string{"unknown_policy"}}
+
+	_, err = client.CreateToken(context.Background(), a, task.Name)
+	if err == nil {
+		t.Fatalf("CreateToken should have failed: %v", err)
+	}
+
+	rerr, ok := err.(*structs.RecoverableError)
+	if !ok {
+		t.Fatalf("CreateToken should have returned a recoverable error type: %v", err)
+	}
+
+	if rerr.Recoverable {
+		t.Fatalf("CreateToken should have returned a unrecoverable error: %v", err)
+	}
+}
+
 func TestVaultClient_CreateToken_Prestart(t *testing.T) {
 	v := testutil.NewTestVault(t)
 	defer v.Stop()


### PR DESCRIPTION
Fixes half of #1956