### PR TITLE
Do not validate the command does not contain spaces.

### DIFF
--- a/client/driver/utils.go
+++ b/client/driver/utils.go
@@ -118,11 +118,6 @@ func validateCommand(command, argField string) error {
 		return fmt.Errorf("command contains extra white space: %q", command)
 	}
 
-	split := strings.Split(trimmed, " ")
-	if len(split) != 1 {
-		return fmt.Errorf("command contained more than one input. Use %q field to pass arguments", argField)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This PR removes validation that the command string does not contain
spaces. This can cause issues where the path contains a folder that
includes a space ("C:\Program Files\Python35\python.exe").

Fixes #1737