### PR TITLE
Change relative path from joining against the alloc dir to the task's directory.

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -609,7 +609,7 @@ func (d *DockerDriver) containerBinds(driverConfig *DockerDriverConfig, alloc *a
 
 		// Relative paths are always allowed as they mount within a container
 		// Expand path relative to alloc dir
-		parts[0] = filepath.Join(shared, parts[0])
+		parts[0] = filepath.Join(taskDir, parts[0])
 		binds = append(binds, strings.Join(parts, ":"))
 	}
 

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1083,13 +1083,19 @@ func TestDockerDriver_VolumesDisabled(t *testing.T) {
 			t.Fatalf("timeout")
 		}
 
-		if _, err := ioutil.ReadFile(filepath.Join(execCtx.AllocDir.SharedDir, fn)); err != nil {
+		taskDir, ok := execCtx.AllocDir.TaskDirs[task.Name]
+		if !ok {
+			t.Fatalf("Failed to get task dir")
+		}
+
+		if _, err := ioutil.ReadFile(filepath.Join(taskDir, fn)); err != nil {
 			t.Fatalf("unexpected error reading %s: %v", fn, err)
 		}
 	}
 
 }
 
+// TODO The test should really check that the container can access the file.
 func TestDockerDriver_VolumesEnabled(t *testing.T) {
 	cfg := testConfig()
 

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1095,7 +1095,6 @@ func TestDockerDriver_VolumesDisabled(t *testing.T) {
 
 }
 
-// TODO The test should really check that the container can access the file.
 func TestDockerDriver_VolumesEnabled(t *testing.T) {
 	cfg := testConfig()
 

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -166,9 +166,10 @@ The `docker` driver supports the following configuration in the job spec:
     ```
 
 * `volumes` - (Optional) A list of `host_path:container_path` strings to bind
-  host paths to container paths. Mounting host paths outside of the alloc
-  directory tasks normally have access to can be disabled on clients by setting
-  the `docker.volumes.enabled` option set to false.
+  host paths to container paths. Mounting host paths outside of the allocation
+  directory can be disabled on clients by setting the `docker.volumes.enabled`
+  option set to false. This will limit volumes to directories that exist inside
+  the allocation directory.
 
     ```hcl
     config {
@@ -177,7 +178,7 @@ The `docker` driver supports the following configuration in the job spec:
         "/path/on/host:/path/in/container",
 
         # Use relative paths to rebind paths already in the allocation dir
-        "relative/to/alloc:/also/in/container"
+        "relative/to/task:/also/in/container"
       ]
     }
     ```


### PR DESCRIPTION
This PR changes the behavior when given a relative host path when
mounting docker containers. Prior to this, the behavior was to mount by
joining against the alloc/ directory. This PR changes it to be against
the task/ directory.

@schmichael For review