### PR TITLE
Add a chaos test for consul syncer and fix some races it found

### DIFF
--- a/command/agent/consul/chaos_test.go
+++ b/command/agent/consul/chaos_test.go
@@ -1,0 +1,193 @@
+// +build chaos
+
+package consul
+
+import (
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/nomad/structs/config"
+)
+
+func TestSyncerChaos(t *testing.T) {
+	// Create an embedded Consul server
+	testconsul := testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+		// If -v wasn't specified squelch consul logging
+		if !testing.Verbose() {
+			c.Stdout = ioutil.Discard
+			c.Stderr = ioutil.Discard
+		}
+	})
+	defer testconsul.Stop()
+
+	// Configure Syncer to talk to the test server
+	cconf := config.DefaultConsulConfig()
+	cconf.Addr = testconsul.HTTPAddr
+
+	clientSyncer, err := NewSyncer(cconf, nil, logger)
+	if err != nil {
+		t.Fatalf("Error creating Syncer: %v", err)
+	}
+	defer clientSyncer.Shutdown()
+
+	execSyncer, err := NewSyncer(cconf, nil, logger)
+	if err != nil {
+		t.Fatalf("Error creating Syncer: %v", err)
+	}
+	defer execSyncer.Shutdown()
+
+	clientService := &structs.Service{Name: "nomad-client"}
+	services := map[ServiceKey]*structs.Service{
+		GenerateServiceKey(clientService): clientService,
+	}
+	if err := clientSyncer.SetServices("client", services); err != nil {
+		t.Fatalf("error setting client service: %v", err)
+	}
+
+	const execn = 100
+	const reapern = 2
+	errors := make(chan error, 100)
+	wg := sync.WaitGroup{}
+
+	// Start goroutines to concurrently SetServices
+	for i := 0; i < execn; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			domain := ServiceDomain(fmt.Sprintf("exec-%d", i))
+			services := map[ServiceKey]*structs.Service{}
+			for ii := 0; ii < 10; ii++ {
+				s := &structs.Service{Name: fmt.Sprintf("exec-%d-%d", i, ii)}
+				services[GenerateServiceKey(s)] = s
+				if err := execSyncer.SetServices(domain, services); err != nil {
+					select {
+					case errors <- err:
+					default:
+					}
+					return
+				}
+				time.Sleep(1)
+			}
+		}(i)
+	}
+
+	// SyncServices runs a timer started by Syncer.Run which we don't use
+	// in this test, so run SyncServices concurrently
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < execn; i++ {
+			if err := execSyncer.SyncServices(); err != nil {
+				select {
+				case errors <- err:
+				default:
+				}
+				return
+			}
+			time.Sleep(100)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := clientSyncer.ReapUnmatched([]ServiceDomain{"nomad-client"}); err != nil {
+			select {
+			case errors <- err:
+			default:
+			}
+			return
+		}
+	}()
+
+	// Reap all but exec-0-* and possibly some of exec-99-*
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < execn; i++ {
+			if err := execSyncer.ReapUnmatched([]ServiceDomain{"exec-0", ServiceDomain(fmt.Sprintf("exec-%d", i))}); err != nil {
+				select {
+				case errors <- err:
+				default:
+				}
+			}
+			time.Sleep(100)
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(errors)
+	}()
+
+	for err := range errors {
+		if err != nil {
+			t.Errorf("error setting service from executor goroutine: %v", err)
+		}
+	}
+
+	// Do a final ReapUnmatched to get consul back into a deterministic state
+	if err := execSyncer.ReapUnmatched([]ServiceDomain{"exec-0"}); err != nil {
+		t.Fatalf("error doing final reap: %v", err)
+	}
+
+	// flattenedServices should be fully populated as ReapUnmatched doesn't
+	// touch Syncer's internal state
+	expected := map[string]struct{}{}
+	for i := 0; i < execn; i++ {
+		for ii := 0; ii < 10; ii++ {
+			expected[fmt.Sprintf("exec-%d-%d", i, ii)] = struct{}{}
+		}
+	}
+
+	for _, s := range execSyncer.flattenedServices() {
+		_, ok := expected[s.Name]
+		if !ok {
+			t.Errorf("%s unexpected", s.Name)
+		}
+		delete(expected, s.Name)
+	}
+	if len(expected) > 0 {
+		left := []string{}
+		for s := range expected {
+			left = append(left, s)
+		}
+		sort.Strings(left)
+		t.Errorf("Couldn't find %d names in flattened services:\n%s", len(expected), strings.Join(left, "\n"))
+	}
+
+	// All but exec-0 and possibly some of exec-99 should have been reaped
+	{
+		services, err := execSyncer.client.Agent().Services()
+		if err != nil {
+			t.Fatalf("Error getting services: %v", err)
+		}
+		expected := []int{}
+		for k, service := range services {
+			if service.Service == "consul" {
+				continue
+			}
+			i := -1
+			ii := -1
+			fmt.Sscanf(service.Service, "exec-%d-%d", &i, &ii)
+			switch {
+			case i == -1 || ii == -1:
+				t.Errorf("invalid service: %s -> %s", k, service.Service)
+			case i != 0 || ii > 9:
+				t.Errorf("unexpected service: %s -> %s", k, service.Service)
+			default:
+				expected = append(expected, ii)
+			}
+		}
+		if len(expected) != 10 {
+			t.Errorf("expected 0-9 but found: %#q", expected)
+		}
+	}
+}

--- a/command/agent/consul/chaos_test.go
+++ b/command/agent/consul/chaos_test.go
@@ -107,7 +107,7 @@ func TestSyncerChaos(t *testing.T) {
 		}
 	}()
 
-	// Reap all but exec-0-* and possibly some of exec-99-*
+	// Reap all but exec-0-*
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/command/agent/consul/syncer.go
+++ b/command/agent/consul/syncer.go
@@ -873,8 +873,8 @@ func (c *Syncer) SyncServices() error {
 // the syncer
 func (c *Syncer) filterConsulServices(consulServices map[string]*consul.AgentService) map[consulServiceID]*consul.AgentService {
 	localServices := make(map[consulServiceID]*consul.AgentService, len(consulServices))
-	c.registryLock.RLock()
-	defer c.registryLock.RUnlock()
+	c.groupsLock.RLock()
+	defer c.groupsLock.RUnlock()
 	for serviceID, service := range consulServices {
 		for domain := range c.servicesGroups {
 			if strings.HasPrefix(service.ID, fmt.Sprintf("%s-%s", nomadServicePrefix, domain)) {
@@ -890,8 +890,8 @@ func (c *Syncer) filterConsulServices(consulServices map[string]*consul.AgentSer
 // services with Syncer's idPrefix.
 func (c *Syncer) filterConsulChecks(consulChecks map[string]*consul.AgentCheck) map[consulCheckID]*consul.AgentCheck {
 	localChecks := make(map[consulCheckID]*consul.AgentCheck, len(consulChecks))
-	c.registryLock.RLock()
-	defer c.registryLock.RUnlock()
+	c.groupsLock.RLock()
+	defer c.groupsLock.RUnlock()
 	for checkID, check := range consulChecks {
 		for domain := range c.checkGroups {
 			if strings.HasPrefix(check.ServiceID, fmt.Sprintf("%s-%s", nomadServicePrefix, domain)) {

--- a/command/agent/consul/syncer.go
+++ b/command/agent/consul/syncer.go
@@ -168,6 +168,7 @@ func NewSyncer(consulConfig *config.ConsulConfig, shutdownCh chan struct{}, logg
 		checkGroups:       make(map[ServiceDomain]map[ServiceKey][]*consul.AgentCheckRegistration),
 		checkRunners:      make(map[consulCheckID]*CheckRunner),
 		periodicCallbacks: make(map[string]types.PeriodicCallback),
+		notifySyncCh:      make(chan struct{}, 1),
 		// default noop implementation of addrFinder
 		addrFinder: func(string) (string, int) { return "", 0 },
 	}
@@ -824,7 +825,7 @@ func (c *Syncer) Run() {
 				c.consulAvailable = true
 			}
 		case <-c.notifySyncCh:
-			sync.Reset(syncInterval)
+			sync.Reset(0)
 		case <-c.shutdownCh:
 			c.Shutdown()
 		case <-c.notifyShutdownCh:


### PR DESCRIPTION
Chaos test is hidden behind a `chaos` build tag because it takes ~60s to run (although a 2s version was actually sufficient to find the races initially, so we _could_ enable that by default).

Also convert other syncer tests to use an embedded consul server so they're always run.