### PR TITLE
Don't require serf advertise address for clients

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -318,12 +318,13 @@ func TestAgent_ServerConfig(t *testing.T) {
 
 func TestAgent_ClientConfig(t *testing.T) {
 	conf := DefaultConfig()
-	// enabled just to allow using localhost for all addresses
-	conf.DevMode = true
-	a := &Agent{config: conf}
 	conf.Client.Enabled = true
-	conf.Addresses.HTTP = "127.0.0.1"
+
+	// For Clients HTTP and RPC must be set (Serf can be skipped)
+	conf.Addresses.HTTP = "169.254.0.1"
+	conf.Addresses.RPC = "169.254.0.1"
 	conf.Ports.HTTP = 5678
+	a := &Agent{config: conf}
 
 	if err := conf.normalizeAddrs(); err != nil {
 		t.Fatalf("error normalizing config: %v", err)
@@ -333,7 +334,7 @@ func TestAgent_ClientConfig(t *testing.T) {
 		t.Fatalf("got err: %v", err)
 	}
 
-	expectedHttpAddr := "127.0.0.1:5678"
+	expectedHttpAddr := "169.254.0.1:5678"
 	if c.Node.HTTPAddr != expectedHttpAddr {
 		t.Fatalf("Expected http addr: %v, got: %v", expectedHttpAddr, c.Node.HTTPAddr)
 	}
@@ -342,7 +343,7 @@ func TestAgent_ClientConfig(t *testing.T) {
 	conf.DevMode = true
 	a = &Agent{config: conf}
 	conf.Client.Enabled = true
-	conf.Addresses.HTTP = "127.0.0.1"
+	conf.Addresses.HTTP = "169.254.0.1"
 
 	if err := conf.normalizeAddrs(); err != nil {
 		t.Fatalf("error normalizing config: %v", err)
@@ -352,7 +353,7 @@ func TestAgent_ClientConfig(t *testing.T) {
 		t.Fatalf("got err: %v", err)
 	}
 
-	expectedHttpAddr = "127.0.0.1:4646"
+	expectedHttpAddr = "169.254.0.1:4646"
 	if c.Node.HTTPAddr != expectedHttpAddr {
 		t.Fatalf("Expected http addr: %v, got: %v", expectedHttpAddr, c.Node.HTTPAddr)
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -694,11 +694,14 @@ func (c *Config) normalizeAddrs() error {
 	}
 	c.AdvertiseAddrs.RPC = addr
 
-	addr, err = normalizeAdvertise(c.AdvertiseAddrs.Serf, c.Addresses.Serf, c.Ports.Serf, c.DevMode)
-	if err != nil {
-		return fmt.Errorf("Failed to parse Serf advertise address: %v", err)
+	// Skip serf if server is disabled
+	if c.Server != nil && c.Server.Enabled {
+		addr, err = normalizeAdvertise(c.AdvertiseAddrs.Serf, c.Addresses.Serf, c.Ports.Serf, c.DevMode)
+		if err != nil {
+			return fmt.Errorf("Failed to parse Serf advertise address: %v", err)
+		}
+		c.AdvertiseAddrs.Serf = addr
 	}
-	c.AdvertiseAddrs.Serf = addr
 
 	return nil
 }


### PR DESCRIPTION
Fixes a bug in 0.5's new address configuration code reported by @ketzacoatl in gitter.