### PR TITLE
(bug)Fix error message. Pass on template args

### DIFF
--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -182,7 +182,7 @@ func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	containerName := fmt.Sprintf("%s-%s", task.Name, ctx.AllocID)
 	c, err := lxc.NewContainer(containerName, lxcPath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create container: %v", err)
+		return nil, fmt.Errorf("unable to initialize container: %v", err)
 	}
 
 	var verbosity lxc.Verbosity
@@ -223,6 +223,7 @@ func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 		Arch:                 driverConfig.Arch,
 		FlushCache:           driverConfig.FlushCache,
 		DisableGPGValidation: driverConfig.DisableGPGValidation,
+		ExtraArgs:            driverConfig.TemplateArgs,
 	}
 
 	if err := c.Create(options); err != nil {


### PR DESCRIPTION
- Pass on template args from config to lxc create options
- Fix error message while instantiating lxc struct