### PR TITLE
Make container exist errors non-retriable

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -949,8 +949,7 @@ func (d *DockerDriver) createContainer(config docker.CreateContainerOptions) (*d
 	recoverable := func(err error) *structs.RecoverableError {
 		r := false
 		if strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") ||
-			strings.Contains(err.Error(), "EOF") ||
-			strings.Contains(err.Error(), "container already exists") {
+			strings.Contains(err.Error(), "EOF") {
 			r = true
 		}
 		return structs.NewRecoverableError(err, r)
@@ -997,6 +996,7 @@ CREATE:
 
 		if attempted < 5 {
 			attempted++
+			time.Sleep(1 * time.Second)
 			goto CREATE
 		}
 	}

--- a/demo/vagrant/client1.hcl
+++ b/demo/vagrant/client1.hcl
@@ -29,3 +29,9 @@ client {
 ports {
     http = 5656
 }
+
+advertise {
+  http = "localhost"
+  rpc = "localhost"
+  serf = "localhost"
+}

--- a/demo/vagrant/client2.hcl
+++ b/demo/vagrant/client2.hcl
@@ -23,3 +23,9 @@ client {
 ports {
     http = 5657
 }
+
+advertise {
+  http = "localhost"
+  rpc = "localhost"
+  serf = "localhost"
+}

--- a/demo/vagrant/server.hcl
+++ b/demo/vagrant/server.hcl
@@ -11,3 +11,9 @@ server {
     # Self-elect, should be 3 or 5 for production
     bootstrap_expect = 1
 }
+
+advertise {
+  http = "localhost"
+  rpc = "localhost"
+  serf = "localhost"
+}


### PR DESCRIPTION
This change makes it so that the task runner does not retry container
exists errors and also a sleep is added on the local retry.