### PR TITLE
Use net.JoinHostPort instead of fmt.Sprintf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1 (Unreleased)
+
+BUG FIXES:
+  * agent/config: Fix use of IPv6 addresses [GH-2036]
+
 ## 0.5.0 (November 16, 2016)
 
 __BACKWARDS INCOMPATIBILITIES:__

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -153,8 +154,8 @@ func (t *TaskEnvironment) Build() *TaskEnvironment {
 			if forwardedPort, ok := t.PortMap[label]; ok {
 				value = forwardedPort
 			}
-			t.TaskEnv[fmt.Sprintf("%s%s", PortPrefix, label)] = fmt.Sprintf("%d", value)
-			IPPort := fmt.Sprintf("%s:%d", network.IP, value)
+			t.TaskEnv[fmt.Sprintf("%s%s", PortPrefix, label)] = strconv.Itoa(value)
+			IPPort := net.JoinHostPort(network.IP, strconv.Itoa(value))
 			t.TaskEnv[fmt.Sprintf("%s%s", AddrPrefix, label)] = IPPort
 
 		}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -529,7 +529,7 @@ func (c *Config) Listener(proto, addr string, port int) (net.Listener, error) {
 			Err: &net.AddrError{Err: "invalid port", Addr: fmt.Sprint(port)},
 		}
 	}
-	return net.Listen(proto, fmt.Sprintf("%s:%d", addr, port))
+	return net.Listen(proto, net.JoinHostPort(addr, strconv.Itoa(port)))
 }
 
 // Merge merges two configurations.
@@ -677,9 +677,9 @@ func (c *Config) normalizeAddrs() error {
 	c.Addresses.RPC = normalizeBind(c.Addresses.RPC, c.BindAddr)
 	c.Addresses.Serf = normalizeBind(c.Addresses.Serf, c.BindAddr)
 	c.normalizedAddrs = &Addresses{
-		HTTP: fmt.Sprintf("%s:%d", c.Addresses.HTTP, c.Ports.HTTP),
-		RPC:  fmt.Sprintf("%s:%d", c.Addresses.RPC, c.Ports.RPC),
-		Serf: fmt.Sprintf("%s:%d", c.Addresses.Serf, c.Ports.Serf),
+		HTTP: net.JoinHostPort(c.Addresses.HTTP, strconv.Itoa(c.Ports.HTTP)),
+		RPC:  net.JoinHostPort(c.Addresses.RPC, strconv.Itoa(c.Ports.RPC)),
+		Serf: net.JoinHostPort(c.Addresses.Serf, strconv.Itoa(c.Ports.Serf)),
 	}
 
 	addr, err := normalizeAdvertise(c.AdvertiseAddrs.HTTP, c.Addresses.HTTP, c.Ports.HTTP, c.DevMode)
@@ -735,7 +735,7 @@ func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string
 			}
 
 			// missing port, append the default
-			return fmt.Sprintf("%s:%d", addr, defport), nil
+			return net.JoinHostPort(addr, strconv.Itoa(defport)), nil
 		}
 		return addr, nil
 	}
@@ -749,11 +749,11 @@ func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string
 	// Return the first unicast address
 	for _, ip := range ips {
 		if ip.IsLinkLocalUnicast() || ip.IsGlobalUnicast() {
-			return fmt.Sprintf("%s:%d", ip, defport), nil
+			return net.JoinHostPort(ip.String(), strconv.Itoa(defport)), nil
 		}
 		if ip.IsLoopback() && dev {
 			// loopback is fine for dev mode
-			return fmt.Sprintf("%s:%d", ip, defport), nil
+			return net.JoinHostPort(ip.String(), strconv.Itoa(defport)), nil
 		}
 	}
 
@@ -772,11 +772,11 @@ func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string
 	// Return the first unicast address
 	for _, ip := range ips {
 		if ip.IsLinkLocalUnicast() || ip.IsGlobalUnicast() {
-			return fmt.Sprintf("%s:%d", ip, defport), nil
+			return net.JoinHostPort(ip.String(), strconv.Itoa(defport)), nil
 		}
 		if ip.IsLoopback() && dev {
 			// loopback is fine for dev mode
-			return fmt.Sprintf("%s:%d", ip, defport), nil
+			return net.JoinHostPort(ip.String(), strconv.Itoa(defport)), nil
 		}
 	}
 	return "", fmt.Errorf("No valid advertise addresses, please set `advertise` manually")

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 
@@ -107,7 +108,7 @@ func standardOutput(mem []*api.AgentMember, leaders map[string]string) []string 
 		regLeader, ok := leaders[reg]
 		isLeader := false
 		if ok {
-			if regLeader == fmt.Sprintf("%s:%s", member.Addr, member.Tags["port"]) {
+			if regLeader == net.JoinHostPort(member.Addr, member.Tags["port"]) {
 
 				isLeader = true
 			}


### PR DESCRIPTION
Using fmt.Sprintf breaks IPv6 addresses.