### PR TITLE
Disallow stale queries when deriving Vault tokens

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1795,7 +1795,7 @@ func (c *Client) deriveToken(alloc *structs.Allocation, taskNames []string, vcli
 		Tasks:    verifiedTasks,
 		QueryOptions: structs.QueryOptions{
 			Region:     c.Region(),
-			AllowStale: true,
+			AllowStale: false,
 		},
 	}
 


### PR DESCRIPTION
This PR disallows stale queries when deriving a Vault token. Allowing
stale queries could result in the allocation not existing on the server
that is servicing the request.

Fixes https://github.com/hashicorp/nomad/issues/2050