### PR TITLE
Add Driver.Prestart method

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -252,30 +252,32 @@ const (
 	TaskSiblingFailed          = "Sibling task failed"
 	TaskSignaling              = "Signaling"
 	TaskRestartSignal          = "Restart Signaled"
+	TaskInitializing           = "Initializing"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
 // appropriate to the events type.
 type TaskEvent struct {
-	Type             string
-	Time             int64
-	FailsTask        bool
-	RestartReason    string
-	SetupError       string
-	DriverError      string
-	ExitCode         int
-	Signal           int
-	Message          string
-	KillReason       string
-	KillTimeout      time.Duration
-	KillError        string
-	StartDelay       int64
-	DownloadError    string
-	ValidationError  string
-	DiskLimit        int64
-	DiskSize         int64
-	FailedSibling    string
-	VaultError       string
-	TaskSignalReason string
-	TaskSignal       string
+	Type                  string
+	Time                  int64
+	FailsTask             bool
+	RestartReason         string
+	SetupError            string
+	DriverError           string
+	ExitCode              int
+	Signal                int
+	Message               string
+	KillReason            string
+	KillTimeout           time.Duration
+	KillError             string
+	StartDelay            int64
+	DownloadError         string
+	ValidationError       string
+	DiskLimit             int64
+	DiskSize              int64
+	FailedSibling         string
+	VaultError            string
+	TaskSignalReason      string
+	TaskSignal            string
+	InitializationMessage string
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -238,6 +238,7 @@ type TaskState struct {
 const (
 	TaskSetupFailure           = "Setup Failure"
 	TaskDriverFailure          = "Driver Failure"
+	TaskDriverMessage          = "Driver"
 	TaskReceived               = "Received"
 	TaskFailedValidation       = "Failed Validation"
 	TaskStarted                = "Started"
@@ -252,32 +253,31 @@ const (
 	TaskSiblingFailed          = "Sibling task failed"
 	TaskSignaling              = "Signaling"
 	TaskRestartSignal          = "Restart Signaled"
-	TaskInitializing           = "Initializing"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
 // appropriate to the events type.
 type TaskEvent struct {
-	Type                  string
-	Time                  int64
-	FailsTask             bool
-	RestartReason         string
-	SetupError            string
-	DriverError           string
-	ExitCode              int
-	Signal                int
-	Message               string
-	KillReason            string
-	KillTimeout           time.Duration
-	KillError             string
-	StartDelay            int64
-	DownloadError         string
-	ValidationError       string
-	DiskLimit             int64
-	DiskSize              int64
-	FailedSibling         string
-	VaultError            string
-	TaskSignalReason      string
-	TaskSignal            string
-	InitializationMessage string
+	Type             string
+	Time             int64
+	FailsTask        bool
+	RestartReason    string
+	SetupError       string
+	DriverError      string
+	DriverMessage    string
+	ExitCode         int
+	Signal           int
+	Message          string
+	KillReason       string
+	KillTimeout      time.Duration
+	KillError        string
+	StartDelay       int64
+	DownloadError    string
+	ValidationError  string
+	DiskLimit        int64
+	DiskSize         int64
+	FailedSibling    string
+	VaultError       string
+	TaskSignalReason string
+	TaskSignal       string
 }

--- a/client/client.go
+++ b/client/client.go
@@ -792,7 +792,7 @@ func (c *Client) setupDrivers() error {
 
 	var avail []string
 	var skipped []string
-	driverCtx := driver.NewDriverContext("", c.config, c.config.Node, c.logger, nil)
+	driverCtx := driver.NewDriverContext("", c.config, c.config.Node, c.logger, nil, nil)
 	for name := range driver.BuiltinDrivers {
 		// Skip fingerprinting drivers that are not in the whitelist if it is
 		// enabled.

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -950,6 +950,7 @@ func (d *DockerDriver) pullImage(driverConfig *DockerDriverConfig, client *docke
 		}
 	}
 
+	d.emitEvent("Downloading image")
 	err := client.PullImage(pullOptions, authOptions)
 	if err != nil {
 		d.logger.Printf("[ERR] driver.docker: failed pulling container %s:%s: %s", repo, tag, err)

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -454,7 +454,7 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 	// and are running
 	if !container.State.Running {
 		// Start the container
-		if err := client.StartContainer(container.ID, container.HostConfig); err != nil {
+		if err := d.startContainer(container); err != nil {
 			d.logger.Printf("[ERR] driver.docker: failed to start container %s: %s", container.ID, err)
 			pluginClient.Kill()
 			return nil, fmt.Errorf("Failed to start container %s: %s", container.ID, err)

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -950,7 +950,7 @@ func (d *DockerDriver) pullImage(driverConfig *DockerDriverConfig, client *docke
 		}
 	}
 
-	d.emitEvent("Downloading image")
+	d.emitEvent("Downloading image %s:%s", repo, tag)
 	err := client.PullImage(pullOptions, authOptions)
 	if err != nil {
 		d.logger.Printf("[ERR] driver.docker: failed pulling container %s:%s: %s", repo, tag, err)

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -93,7 +93,6 @@ type DockerDriver struct {
 	DriverContext
 
 	imageID      string
-	waitClient   *docker.Client
 	driverConfig *DockerDriverConfig
 }
 
@@ -359,7 +358,7 @@ func (d *DockerDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
 	}
 
 	// Initialize docker API clients
-	client, waitClient, err := d.dockerClients()
+	client, _, err := d.dockerClients()
 	if err != nil {
 		return fmt.Errorf("Failed to connect to docker daemon: %s", err)
 	}
@@ -379,7 +378,6 @@ func (d *DockerDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
 
 	// Set state needed by Start()
 	d.imageID = dockerImage.ID
-	d.waitClient = waitClient
 	d.driverConfig = driverConfig
 	return nil
 }
@@ -469,7 +467,7 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 	maxKill := d.DriverContext.config.MaxKillTimeout
 	h := &DockerHandle{
 		client:         client,
-		waitClient:     d.waitClient,
+		waitClient:     waitClient,
 		executor:       exec,
 		pluginClient:   pluginClient,
 		cleanupImage:   cleanupImage,

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1055,7 +1055,7 @@ func setupDockerVolumes(t *testing.T, cfg *config.Config, hostpath string) (*str
 		}
 	}
 
-	taskEnv, err := GetTaskEnv(allocDir, cfg.Node, task, alloc, "")
+	taskEnv, err := GetTaskEnv(allocDir, cfg.Node, task, alloc, cfg, "")
 	if err != nil {
 		cleanup()
 		t.Fatalf("Failed to get task env: %v", err)

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -89,7 +89,11 @@ func testDriverContexts(task *structs.Task) (*DriverContext, *ExecContext) {
 		return nil, nil
 	}
 
-	driverCtx := NewDriverContext(task.Name, cfg, cfg.Node, testLogger(), taskEnv)
+	logger := testLogger()
+	emitter := func(m string, args ...interface{}) {
+		logger.Printf("[EVENT] "+m, args...)
+	}
+	driverCtx := NewDriverContext(task.Name, cfg, cfg.Node, logger, taskEnv, emitter)
 	return driverCtx, execCtx
 }
 

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -7,13 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/allocdir"
-	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/driver/executor"
 	dstructs "github.com/hashicorp/nomad/client/driver/structs"
 	cstructs "github.com/hashicorp/nomad/client/structs"
@@ -93,9 +91,6 @@ func (d *ExecDriver) Periodic() (bool, time.Duration) {
 }
 
 func (d *ExecDriver) Prestart(execctx *ExecContext, task *structs.Task) error {
-	// Set the host environment variables.
-	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
-	d.taskEnv.AppendHostEnvvars(filter)
 	return nil
 }
 

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -92,6 +92,13 @@ func (d *ExecDriver) Periodic() (bool, time.Duration) {
 	return true, 15 * time.Second
 }
 
+func (d *ExecDriver) Prestart(execctx *ExecContext, task *structs.Task) error {
+	// Set the host environment variables.
+	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
+	d.taskEnv.AppendHostEnvvars(filter)
+	return nil
+}
+
 func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 	var driverConfig ExecDriverConfig
 	if err := mapstructure.WeakDecode(task.Config, &driverConfig); err != nil {
@@ -103,10 +110,6 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	if err := validateCommand(command, "args"); err != nil {
 		return nil, err
 	}
-
-	// Set the host environment variables.
-	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
-	d.taskEnv.AppendHostEnvvars(filter)
 
 	// Get the task directory for storing the executor logs.
 	taskDir, ok := ctx.AllocDir.TaskDirs[d.DriverContext.taskName]

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -65,6 +65,9 @@ func TestExecDriver_StartOpen_Wait(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -105,6 +108,9 @@ func TestExecDriver_KillUserPid_OnPluginReconnectFailure(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -165,6 +171,9 @@ func TestExecDriver_Start_Wait(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -215,6 +224,9 @@ func TestExecDriver_Start_Wait_AllocDir(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -265,6 +277,9 @@ func TestExecDriver_Start_Kill_Wait(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -327,6 +342,9 @@ done
 		fmt.Errorf("Failed to write data")
 	}
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -388,6 +406,9 @@ func TestExecDriverUser(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err == nil {
 		handle.Kill()

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -164,9 +164,6 @@ func (d *JavaDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, 
 }
 
 func (d *JavaDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
-	// Set the host environment variables.
-	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
-	d.taskEnv.AppendHostEnvvars(filter)
 	return nil
 }
 

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -163,15 +163,18 @@ func (d *JavaDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, 
 	return true, nil
 }
 
+func (d *JavaDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
+	// Set the host environment variables.
+	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
+	d.taskEnv.AppendHostEnvvars(filter)
+	return nil
+}
+
 func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 	var driverConfig JavaDriverConfig
 	if err := mapstructure.WeakDecode(task.Config, &driverConfig); err != nil {
 		return nil, err
 	}
-
-	// Set the host environment variables.
-	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
-	d.taskEnv.AppendHostEnvvars(filter)
 
 	taskDir, ok := ctx.AllocDir.TaskDirs[d.DriverContext.taskName]
 	if !ok {

--- a/client/driver/java_test.go
+++ b/client/driver/java_test.go
@@ -92,6 +92,9 @@ func TestJavaDriver_StartOpen_Wait(t *testing.T) {
 	dst, _ := execCtx.AllocDir.TaskDirs[task.Name]
 	copyFile("./test-resources/java/demoapp.jar", filepath.Join(dst, "demoapp.jar"), t)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -142,6 +145,9 @@ func TestJavaDriver_Start_Wait(t *testing.T) {
 	dst, _ := execCtx.AllocDir.TaskDirs[task.Name]
 	copyFile("./test-resources/java/demoapp.jar", filepath.Join(dst, "demoapp.jar"), t)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -204,6 +210,9 @@ func TestJavaDriver_Start_Kill_Wait(t *testing.T) {
 	dst, _ := execCtx.AllocDir.TaskDirs[task.Name]
 	copyFile("./test-resources/java/demoapp.jar", filepath.Join(dst, "demoapp.jar"), t)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -262,6 +271,9 @@ func TestJavaDriver_Signal(t *testing.T) {
 	dst, _ := execCtx.AllocDir.TaskDirs[task.Name]
 	copyFile("./test-resources/java/demoapp.jar", filepath.Join(dst, "demoapp.jar"), t)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -317,6 +329,9 @@ func TestJavaDriverUser(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewJavaDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err == nil {
 		handle.Kill()

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -168,6 +168,10 @@ func (d *LxcDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, e
 	return true, nil
 }
 
+func (d *LxcDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
+	return nil
+}
+
 // Start starts the LXC Driver
 func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 	var driverConfig LxcDriverConfig

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -169,6 +169,9 @@ func (d *LxcDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, e
 }
 
 func (d *LxcDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
+	d.taskEnv.SetAllocDir(allocdir.SharedAllocContainerPath)
+	d.taskEnv.SetTaskLocalDir(allocdir.TaskLocalContainerPath)
+	d.taskEnv.SetSecretsDir(allocdir.TaskSecretsContainerPath)
 	return nil
 }
 

--- a/client/driver/lxc_test.go
+++ b/client/driver/lxc_test.go
@@ -69,6 +69,9 @@ func TestLxcDriver_Start_Wait(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewLxcDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -141,6 +144,9 @@ func TestLxcDriver_Open_Wait(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewLxcDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/client/driver/mock_driver.go
+++ b/client/driver/mock_driver.go
@@ -75,6 +75,10 @@ func (d *MockDriver) Abilities() DriverAbilities {
 	}
 }
 
+func (d *MockDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
+	return nil
+}
+
 // Start starts the mock driver
 func (m *MockDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 	var driverConfig MockDriverConfig

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -135,6 +135,10 @@ func (d *QemuDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, 
 	return true, nil
 }
 
+func (d *QemuDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
+	return nil
+}
+
 // Run an existing Qemu image. Start() will pull down an existing, valid Qemu
 // image and save it to the Drivers Allocation Dir
 func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-plugin"
@@ -108,9 +107,6 @@ func (d *RawExecDriver) Fingerprint(cfg *config.Config, node *structs.Node) (boo
 }
 
 func (d *RawExecDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
-	// Set the host environment variables.
-	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
-	d.taskEnv.AppendHostEnvvars(filter)
 	return nil
 }
 

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -107,6 +107,13 @@ func (d *RawExecDriver) Fingerprint(cfg *config.Config, node *structs.Node) (boo
 	return false, nil
 }
 
+func (d *RawExecDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
+	// Set the host environment variables.
+	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
+	d.taskEnv.AppendHostEnvvars(filter)
+	return nil
+}
+
 func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 	var driverConfig ExecDriverConfig
 	if err := mapstructure.WeakDecode(task.Config, &driverConfig); err != nil {
@@ -124,10 +131,6 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandl
 	if err := validateCommand(command, "args"); err != nil {
 		return nil, err
 	}
-
-	// Set the host environment variables.
-	filter := strings.Split(d.config.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
-	d.taskEnv.AppendHostEnvvars(filter)
 
 	bin, err := discover.NomadExecutable()
 	if err != nil {

--- a/client/driver/raw_exec_test.go
+++ b/client/driver/raw_exec_test.go
@@ -75,6 +75,9 @@ func TestRawExecDriver_StartOpen_Wait(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewRawExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -120,6 +123,9 @@ func TestRawExecDriver_Start_Wait(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewRawExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -170,6 +176,9 @@ func TestRawExecDriver_Start_Wait_AllocDir(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewRawExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -219,6 +228,9 @@ func TestRawExecDriver_Start_Kill_Wait(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewRawExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -268,6 +280,9 @@ func TestRawExecDriverUser(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewRawExecDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err == nil {
 		handle.Kill()
@@ -313,6 +328,9 @@ done
 		fmt.Errorf("Failed to write data")
 	}
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("prestart err: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -206,6 +206,13 @@ func (d *RktDriver) Periodic() (bool, time.Duration) {
 	return true, 15 * time.Second
 }
 
+func (d *RktDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
+	d.taskEnv.SetAllocDir(allocdir.SharedAllocContainerPath)
+	d.taskEnv.SetTaskLocalDir(allocdir.TaskLocalContainerPath)
+	d.taskEnv.SetSecretsDir(allocdir.TaskSecretsContainerPath)
+	return nil
+}
+
 // Run an existing Rkt image.
 func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 	var driverConfig RktDriverConfig
@@ -289,10 +296,6 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--debug=%t", debug))
 
 	// Inject environment variables
-	d.taskEnv.SetAllocDir(allocdir.SharedAllocContainerPath)
-	d.taskEnv.SetTaskLocalDir(allocdir.TaskLocalContainerPath)
-	d.taskEnv.SetSecretsDir(allocdir.TaskSecretsContainerPath)
-	d.taskEnv.Build()
 	for k, v := range d.taskEnv.EnvMap() {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--set-env=%v=%v", k, v))
 	}

--- a/client/driver/rkt_test.go
+++ b/client/driver/rkt_test.go
@@ -98,6 +98,9 @@ func TestRktDriver_Start_DNS(t *testing.T) {
 
 	d := NewRktDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -145,6 +148,9 @@ func TestRktDriver_Start_Wait(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewRktDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -202,6 +208,9 @@ func TestRktDriver_Start_Wait_Skip_Trust(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewRktDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -252,6 +261,7 @@ func TestRktDriver_Start_Wait_AllocDir(t *testing.T) {
 				"-c",
 				fmt.Sprintf(`echo -n %s > foo/%s`, string(exp), file),
 			},
+			"net":     []string{"none"},
 			"volumes": []string{fmt.Sprintf("%s:/foo", tmpvol)},
 		},
 		LogConfig: &structs.LogConfig{
@@ -268,6 +278,9 @@ func TestRktDriver_Start_Wait_AllocDir(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewRktDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -326,6 +339,9 @@ func TestRktDriverUser(t *testing.T) {
 	defer execCtx.AllocDir.Destroy()
 	d := NewRktDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err == nil {
 		handle.Kill()
@@ -364,6 +380,9 @@ func TestRktTrustPrefix(t *testing.T) {
 
 	d := NewRktDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err == nil {
 		handle.Kill()
@@ -438,6 +457,9 @@ func TestRktDriver_PortsMapping(t *testing.T) {
 
 	d := NewRktDriver(driverCtx)
 
+	if err := d.Prestart(execCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
 	handle, err := d.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -324,7 +324,8 @@ func (r *TaskRunner) setTaskEnv() error {
 	r.taskEnvLock.Lock()
 	defer r.taskEnvLock.Unlock()
 
-	taskEnv, err := driver.GetTaskEnv(r.ctx.AllocDir, r.config.Node, r.task.Copy(), r.alloc, r.vaultFuture.Get())
+	taskEnv, err := driver.GetTaskEnv(r.ctx.AllocDir, r.config.Node,
+		r.task.Copy(), r.alloc, r.config, r.vaultFuture.Get())
 	if err != nil {
 		return err
 	}

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -350,8 +350,8 @@ func (r *TaskRunner) createDriver() (driver.Driver, error) {
 	// state to drivers
 	eventEmitter := func(m string, args ...interface{}) {
 		msg := fmt.Sprintf(m, args...)
-		r.logger.Printf("[DEBUG] client: initialization event for alloc %q: %s", r.alloc.ID, msg)
-		r.setState("", structs.NewTaskEvent(structs.TaskInitializing).SetInitializationMessage(msg))
+		r.logger.Printf("[DEBUG] client: driver event for alloc %q: %s", r.alloc.ID, msg)
+		r.setState("", structs.NewTaskEvent(structs.TaskDriverMessage).SetDriverMessage(msg))
 	}
 
 	driverCtx := driver.NewDriverContext(r.task.Name, r.config, r.config.Node, r.logger, env, eventEmitter)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -346,7 +346,15 @@ func (r *TaskRunner) createDriver() (driver.Driver, error) {
 		return nil, fmt.Errorf("task environment not made for task %q in allocation %q", r.task.Name, r.alloc.ID)
 	}
 
-	driverCtx := driver.NewDriverContext(r.task.Name, r.config, r.config.Node, r.logger, env)
+	// Create a task-specific event emitter callback to expose minimal
+	// state to drivers
+	eventEmitter := func(m string, args ...interface{}) {
+		msg := fmt.Sprintf(m, args...)
+		r.logger.Printf("[DEBUG] client: initialization event for alloc %q: %s", r.alloc.ID, msg)
+		r.setState("", structs.NewTaskEvent(structs.TaskInitializing).SetInitializationMessage(msg))
+	}
+
+	driverCtx := driver.NewDriverContext(r.task.Name, r.config, r.config.Node, r.logger, env, eventEmitter)
 	driver, err := driver.NewDriver(r.task.Driver, driverCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create driver '%s' for alloc %s: %v",
@@ -1019,17 +1027,31 @@ func (r *TaskRunner) startTask() error {
 	// Create a driver
 	driver, err := r.createDriver()
 	if err != nil {
-		return fmt.Errorf("failed to create driver of task '%s' for alloc '%s': %v",
+		return fmt.Errorf("failed to create driver of task %q for alloc %q: %v",
 			r.task.Name, r.alloc.ID, err)
+	}
+
+	// Run prestart
+	if err := driver.Prestart(r.ctx, r.task); err != nil {
+		wrapped := fmt.Errorf("failed to initialize task %q for alloc %q: %v",
+			r.task.Name, r.alloc.ID, err)
+
+		r.logger.Printf("[WARN] client: %v", wrapped)
+
+		if rerr, ok := err.(*structs.RecoverableError); ok {
+			return structs.NewRecoverableError(wrapped, rerr.Recoverable)
+		}
+
+		return wrapped
 	}
 
 	// Start the job
 	handle, err := driver.Start(r.ctx, r.task)
 	if err != nil {
-		wrapped := fmt.Errorf("failed to start task '%s' for alloc '%s': %v",
+		wrapped := fmt.Errorf("failed to start task %q for alloc %q: %v",
 			r.task.Name, r.alloc.ID, err)
 
-		r.logger.Printf("[INFO] client: %v", wrapped)
+		r.logger.Printf("[WARN] client: %v", wrapped)
 
 		if rerr, ok := err.(*structs.RecoverableError); ok {
 			return structs.NewRecoverableError(wrapped, rerr.Recoverable)

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -378,6 +378,8 @@ func (c *AllocStatusCommand) outputTaskStatus(state *api.TaskState) {
 			} else {
 				desc = "Task signaled to restart"
 			}
+		case api.TaskInitializing:
+			desc = event.InitializationMessage
 		}
 
 		// Reverse order so we are sorted by time

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -378,8 +378,8 @@ func (c *AllocStatusCommand) outputTaskStatus(state *api.TaskState) {
 			} else {
 				desc = "Task signaled to restart"
 			}
-		case api.TaskInitializing:
-			desc = event.InitializationMessage
+		case api.TaskDriverMessage:
+			desc = event.DriverMessage
 		}
 
 		// Reverse order so we are sorted by time

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2555,6 +2555,10 @@ const (
 	// TaskSiblingFailed indicates that a sibling task in the task group has
 	// failed.
 	TaskSiblingFailed = "Sibling task failed"
+
+	// TaskInitializing indicates that a task is performing a potentially
+	// slow initialization action such as downloading a Docker image.
+	TaskInitializing = "Initializing"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -2613,6 +2617,9 @@ type TaskEvent struct {
 
 	// TaskSignal is the signal that was sent to the task
 	TaskSignal string
+
+	// InitializationMessage indicates the initialization step being executed.
+	InitializationMessage string
 }
 
 func (te *TaskEvent) GoString() string {
@@ -2738,6 +2745,11 @@ func (e *TaskEvent) SetVaultRenewalError(err error) *TaskEvent {
 	if err != nil {
 		e.VaultError = err.Error()
 	}
+	return e
+}
+
+func (e *TaskEvent) SetInitializationMessage(m string) *TaskEvent {
+	e.InitializationMessage = m
 	return e
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2556,9 +2556,10 @@ const (
 	// failed.
 	TaskSiblingFailed = "Sibling task failed"
 
-	// TaskInitializing indicates that a task is performing a potentially
-	// slow initialization action such as downloading a Docker image.
-	TaskInitializing = "Initializing"
+	// TaskDriverMessage is an informational event message emitted by
+	// drivers such as when they're performing a long running action like
+	// downloading an image.
+	TaskDriverMessage = "Driver"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -2618,8 +2619,8 @@ type TaskEvent struct {
 	// TaskSignal is the signal that was sent to the task
 	TaskSignal string
 
-	// InitializationMessage indicates the initialization step being executed.
-	InitializationMessage string
+	// DriverMessage indicates a driver action being taken.
+	DriverMessage string
 }
 
 func (te *TaskEvent) GoString() string {
@@ -2748,8 +2749,8 @@ func (e *TaskEvent) SetVaultRenewalError(err error) *TaskEvent {
 	return e
 }
 
-func (e *TaskEvent) SetInitializationMessage(m string) *TaskEvent {
-	e.InitializationMessage = m
+func (e *TaskEvent) SetDriverMessage(m string) *TaskEvent {
+	e.DriverMessage = m
 	return e
 }
 


### PR DESCRIPTION
The Driver.Prestart method currently does very little but lays the foundation for where lifecycle plugins can interleave execution _after_ task environment setup but _before_ the task starts.

Currently Prestart does two things:

* Any driver specific task environment building
* Download Docker images

This change also attaches a TaskEvent emitter to Drivers, so they can emit events during task initialization.