### PR TITLE
Fixes docker-driver Auth-config interpolation

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -170,11 +170,11 @@ func NewDockerDriverConfig(task *structs.Task, env *env.TaskEnvironment) (*Docke
 		}
 	}
 
-	for _, a := range dconf.Auth {
-		a.Username = env.ReplaceEnv(a.Username)
-		a.Password = env.ReplaceEnv(a.Password)
-		a.Email = env.ReplaceEnv(a.Email)
-		a.ServerAddress = env.ReplaceEnv(a.ServerAddress)
+	for i, a := range dconf.Auth {
+		dconf.Auth[i].Username = env.ReplaceEnv(a.Username)
+		dconf.Auth[i].Password = env.ReplaceEnv(a.Password)
+		dconf.Auth[i].Email = env.ReplaceEnv(a.Email)
+		dconf.Auth[i].ServerAddress = env.ReplaceEnv(a.ServerAddress)
 	}
 
 	for _, l := range dconf.Logging {


### PR DESCRIPTION
When the docker driver creates a new config, it evaluates configured `DockerDriverConfig.Auth` elements, interpolating meta or variables for each one.  The code that ranges over `Auth` and reassigns its fields the interpolated value only affects the local scope.  The outer scoped `DockerDriverConfig` variable is not updated.