### PR TITLE
Document disk space resource constraint

### DIFF
--- a/website/source/docs/job-specification/resources.html.md
+++ b/website/source/docs/job-specification/resources.html.md
@@ -46,10 +46,12 @@ job "docs" {
 
 - `cpu` `(int: 100)` - Specifies the CPU required to run this task in MHz.
 
+- `disk` `(int: 0)` - Specifies the disk space required in MB.
+
 - `iops` `(int: 0)` - Specifies the number of IOPS required given as a weight
   between 0-1000.
 
-- `memory` `(int: 300)` - Specifies the memory required in MB
+- `memory` `(int: 300)` - Specifies the memory required in MB.
 
 - `network` <code>([Network][]: <required>)</code> - Specifies the network
   requirements, including static and dynamic port allocations.


### PR DESCRIPTION
Had to hunt around to find the disk space resource constraint. Finally found it in https://www.nomadproject.io/docs/http/json-jobs.html#DiskMB and traced it back in the source code.