### PR TITLE
Fix high CPU and FD usage on `nomad logs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ IMPROVEMENTS:
 
 BUG FIXES:
   * agent/config: Fix use of IPv6 addresses [GH-2036]
+  * api: Fix file descriptor leak and high CPU usage when using the logs
+    endpoint [GH-2079]
   * cli: Improve parsing error when a job without a name is specified [GH-2030]
   * client: Fixed permissions of migrated allocation directory [GH-2061]
   * client: Ensuring allocations are not blocked more than once [GH-2040]

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -206,6 +206,8 @@ func (s *HTTPServer) FileCatRequest(resp http.ResponseWriter, req *http.Request)
 }
 
 var (
+	// HeartbeatStreamFrame is the StreamFrame to send as a heartbeat, avoiding
+	// creating many instances of the empty StreamFrame
 	HeartbeatStreamFrame = &StreamFrame{}
 )
 

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -381,7 +381,7 @@ func getIndex(t *testing.T, resp *httptest.ResponseRecorder) uint64 {
 	return uint64(val)
 }
 
-func httpTest(t *testing.T, cb func(c *Config), f func(srv *TestServer)) {
+func httpTest(t testing.TB, cb func(c *Config), f func(srv *TestServer)) {
 	s := makeHTTPServer(t, cb)
 	defer s.Cleanup()
 	testutil.WaitForLeader(t, s.Agent.RPC)

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -54,7 +54,7 @@ func IsTravis() bool {
 
 type rpcFn func(string, interface{}, interface{}) error
 
-func WaitForLeader(t *testing.T, rpc rpcFn) {
+func WaitForLeader(t testing.TB, rpc rpcFn) {
 	WaitForResult(func() (bool, error) {
 		args := &structs.GenericRequest{}
 		var leader string


### PR DESCRIPTION
This PR:
* fixes high CPU and FD usage on `nomad logs` through better detection of closed connections and by not using `time.Tick`
* Generates encode/decode functions for stream frame making it more efficient

Fixes https://github.com/hashicorp/nomad/issues/2024