### PR TITLE
bumps Nomad from 0.4.1 to 0.5.0

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ sudo apt-get install -y unzip curl wget vim
 # Download Nomad
 echo Fetching Nomad...
 cd /tmp/
-curl -sSL https://releases.hashicorp.com/nomad/0.4.1/nomad_0.4.1_linux_amd64.zip -o nomad.zip
+curl -sSL https://releases.hashicorp.com/nomad/0.5.0/nomad_0.5.0_linux_amd64.zip -o nomad.zip
 
 echo Installing Nomad...
 unzip nomad.zip


### PR DESCRIPTION
Noticed that the `Vagrantfile` still references `0.4.1` of Nomad.

Verified this still works by testing it with all steps listed in the [Getting-Started](https://www.nomadproject.io/intro/getting-started/jobs.html) guide.