### PR TITLE
Docs: remove admonition about server-members command

### DIFF
--- a/website/source/docs/commands/server-members.html.md.erb
+++ b/website/source/docs/commands/server-members.html.md.erb
@@ -12,9 +12,6 @@ The `server-members` command displays a list of the known servers in the cluster
 and their current status. Member information is provided by the gossip protocol,
 which is only run on server nodes.
 
-~> **Only runs on servers!** This command can only be run from the server nodes.
-Running <tt>nomad server-members</tt> from a client will result in an error.
-
 ## Usage
 
 ```


### PR DESCRIPTION
The warning about `nomad server-members` resulting in an error when run on client nodes in the [Command: server-members documentation](https://www.nomadproject.io/docs/commands/server-members.html) does not appear to be true any longer, so I am proposing that it be removed in this PR.

Output from a Nomad client on version 0.5.1:

```
nomad agent-info
client
  heartbeat_ttl = 10.450798781s
  known_servers = 10.1.42.101:4647,10.1.42.102:4647
  last_heartbeat = 7.152186302s
  node_id = af4fa74e-2382-d95c-28d5-2fa663f698c5
  num_allocations = 0
runtime
  arch = amd64
  cpu_count = 2
  goroutines = 36
  kernel.name = linux
  max_procs = 2
  version = go1.7.3
```

and then attempting the command on the same client node works fine:

```
nomad server-members
Name         Address      Port  Status  Leader  Protocol  Build  Datacenter  Region
hfb1.global  10.1.42.101  4648  alive   true    2         0.5.1  dc1         global
hfb2.global  10.1.42.102  4648  alive   false   2         0.5.1  dc1         global
```
