### PR TITLE
Allow to set the nodename on telemetry

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -621,6 +621,10 @@ func (c *Command) setupTelemetry(config *Config) error {
 
 	metricsConf := metrics.DefaultConfig("nomad")
 	metricsConf.EnableHostname = !telConfig.DisableHostname
+	if telConfig.UseNodeName {
+		metricsConf.HostName = config.NodeName
+		metricsConf.EnableHostname = true
+	}
 
 	// Configure the statsite sink
 	var fanout metrics.FanoutSink

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -271,6 +271,7 @@ type Telemetry struct {
 	StatsdAddr               string        `mapstructure:"statsd_address"`
 	DataDogAddr              string        `mapstructure:"datadog_address"`
 	DisableHostname          bool          `mapstructure:"disable_hostname"`
+	UseNodeName              bool          `mapstructure:"use_node_name"`
 	CollectionInterval       string        `mapstructure:"collection_interval"`
 	collectionInterval       time.Duration `mapstructure:"-"`
 	PublishAllocationMetrics bool          `mapstructure:"publish_allocation_metrics"`

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -527,6 +527,7 @@ func parseTelemetry(result **Telemetry, list *ast.ObjectList) error {
 		"statsite_address",
 		"statsd_address",
 		"disable_hostname",
+		"use_node_name",
 		"collection_interval",
 		"publish_allocation_metrics",
 		"publish_node_metrics",

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -91,6 +91,7 @@ func TestConfig_Parse(t *testing.T) {
 					StatsiteAddr:             "127.0.0.1:1234",
 					StatsdAddr:               "127.0.0.1:2345",
 					DisableHostname:          true,
+					UseNodeName:              false,
 					CollectionInterval:       "3s",
 					collectionInterval:       3 * time.Second,
 					PublishAllocationMetrics: true,

--- a/website/source/docs/agent/configuration/telemetry.html.md
+++ b/website/source/docs/agent/configuration/telemetry.html.md
@@ -45,6 +45,10 @@ The following options are available on all telemetry configurations.
 - `disable_hostname` `(bool: false)` - Specifies if gauge values should be
   prefixed with the local hostname.
 
+- `use_node_name` `(bool: false)` - Specifies if gauge values should be
+  prefixed with the name of the node, instead of the hostname. If set it will
+  override [disable_hostname](#disable_hostname) value.
+
 - `publish_allocation_metrics` `(bool: false)` - Specifies if Nomad should
   publish runtime metrics of allocations.
 


### PR DESCRIPTION
Fixes #2094 