### PR TITLE
add vault example for JSON api

### DIFF
--- a/website/source/docs/http/json-jobs.html.md
+++ b/website/source/docs/http/json-jobs.html.md
@@ -82,6 +82,12 @@ Below is an example of a JSON object that submits a `periodic` job to Nomad:
                 ]
               }
             ],
+            "Vault": {
+              "Policies": ["policy-name"],
+              "Env": true,
+              "ChangeMode": "restart",
+              "ChangeSignal": ""
+            },
             "Resources":{
               "CPU":500,
               "MemoryMB":256,


### PR DESCRIPTION
missing on docs right now, had to look at https://github.com/hashicorp/nomad/blob/master/nomad/structs/structs.go#L2958