### PR TITLE
show desired status and description for allocation

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -213,6 +213,8 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		fmt.Sprintf("Job ID|%s", alloc.JobID),
 		fmt.Sprintf("Client Status|%s", alloc.ClientStatus),
 		fmt.Sprintf("Client Description|%s", alloc.ClientDescription),
+		fmt.Sprintf("Desired Status|%s", alloc.DesiredStatus),
+		fmt.Sprintf("Desired Description|%s", alloc.DesiredDescription),
 		fmt.Sprintf("Created At|%s", formatUnixNanoTime(alloc.CreateTime)),
 	}
 


### PR DESCRIPTION
Feature request

It'd be nice to show the desired status and description for allocations. For example, if a node goes down, the allocation is killed and moved, but it's not clear why until you look at the JSON object.

If preferred, I can move to only where you specify `-verbose`, but I think it's important info regardless.

```
    "DesiredStatus": "stop",
    "DesiredDescription": "alloc is lost since its node is down",
    "ClientStatus": "complete",
    "ClientDescription": "",
```

alloc-status output doesn't indicate this fact
```
ID                 = a2b9827f
...
Client Status      = complete
Client Description = <none>

```
