### PR TITLE
Allow docker to decide where to bind port

### DIFF
--- a/client/driver/docker_default.go
+++ b/client/driver/docker_default.go
@@ -10,5 +10,5 @@ const (
 )
 
 func getPortBinding(ip string, port string) []docker.PortBinding {
-	return []docker.PortBinding{docker.PortBinding{HostIP: ip, HostPort: port}}
+	return []docker.PortBinding{docker.PortBinding{HostIP: "", HostPort: port}}
 }


### PR DESCRIPTION
This fixes following issue:

I decided to run nomad inside docker container, so I could use weave net for inter-nomad communication. At the same time I wanted nomad to be able to schedule containers directly on the host each agent is running on. This seems like chicken-egg issue, but can be easily solved by privileging nomad process, and binding docker socket inside the nomad container.

I've configured nomad client to bind to eth1 interface (with `network_interface = "eth1"`) that happens to be a bridge interface that docker expects contained processes to bind ports to for exposing ports. It's IP address is `172.18.0.3`.

Nomad properly attaches to this address when using fork/exec driver, but it does something strange when running docker driver, an equivalent of executing container with `--publish 172.18.0.3:80:80`, but `172.18.0.3` is the bridge address for container in which nomad is running, not of the `eth0` interface on the host that docker is configured to bind published ports to. This results in nomad being unable to schedule such job.

This change leaves decision to which port to bind for docker, what results in a command equivalent of `--publish 80:80` when running job in docker container. 

This change can also potentially fix #1187, but I didn't test it.