### PR TITLE
Fix inconsistencies in usage cli output.

### DIFF
--- a/command/check.go
+++ b/command/check.go
@@ -21,7 +21,7 @@ type AgentCheckCommand struct {
 
 func (c *AgentCheckCommand) Help() string {
 	helpText := `
-Usage: nomad check
+Usage: nomad check [options]
 
   Display state of the Nomad agent. The exit code of the command is Nagios
   compatible and could be used with alerting systems.

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -14,7 +14,7 @@ type EvalStatusCommand struct {
 
 func (c *EvalStatusCommand) Help() string {
 	helpText := `
-Usage: nomad eval-status [options] <evaluation-id>
+Usage: nomad eval-status [options] <evaluation>
 
   Display information about evaluations. This command can be used to inspect the
   current status of an evaluation as well as determine the reason an evaluation

--- a/command/fs.go
+++ b/command/fs.go
@@ -31,7 +31,7 @@ type FSCommand struct {
 
 func (f *FSCommand) Help() string {
 	helpText := `
-Usage: nomad fs <alloc-id> <path>
+Usage: nomad fs [options] <allocation> <path>
 
   fs displays either the contents of an allocation directory for the passed allocation,
   or displays the file at the given path. The path is relative to the root of the alloc
@@ -59,7 +59,7 @@ FS Specific Options:
     Causes the output to not stop when the end of the file is reached, but rather to
     wait for additional output.
 
-  -tail 
+  -tail
     Show the files contents with offsets relative to the end of the file. If no
     offset is given, -n is defaulted to 10.
 

--- a/command/logs.go
+++ b/command/logs.go
@@ -28,7 +28,7 @@ General Options:
 
 Logs Specific Options:
 
-  -stderr:
+  -stderr
     Display stderr logs.
 
   -verbose

--- a/command/logs.go
+++ b/command/logs.go
@@ -18,7 +18,7 @@ type LogsCommand struct {
 
 func (l *LogsCommand) Help() string {
 	helpText := `
-Usage: nomad logs [options] <alloc-id> <task>
+Usage: nomad logs [options] <allocation> <task>
 
   Streams the stdout/stderr of the given allocation and task.
 
@@ -51,7 +51,7 @@ Logs Specific Options:
 
   -c
     Sets the tail location in number of bytes relative to the end of the logs.
-	`
+  `
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -31,7 +31,7 @@ type PlanCommand struct {
 
 func (c *PlanCommand) Help() string {
 	helpText := `
-Usage: nomad plan [options] <file>
+Usage: nomad plan [options] <path>
 
   Plan invokes a dry-run of the scheduler to determine the effects of submitting
   either a new or updated version of a job. The plan will not result in any

--- a/command/validate.go
+++ b/command/validate.go
@@ -12,7 +12,7 @@ type ValidateCommand struct {
 
 func (c *ValidateCommand) Help() string {
 	helpText := `
-Usage: nomad validate [options] <file>
+Usage: nomad validate [options] <path>
 
   Checks if a given HCL job file has a valid specification. This can be used to
   check for any syntax errors or validation problems with a job.


### PR DESCRIPTION
Fixed inconsistencies where `[options]` was not always printed and argument _terms_ were inconsistent.