### PR TITLE
Fix documentation for interpolating attrs/meta

### DIFF
--- a/website/source/docs/job-specification/constraint.html.md
+++ b/website/source/docs/job-specification/constraint.html.md
@@ -46,7 +46,7 @@ job "docs" {
     task "server" {
       # All tasks must run where "my_custom_value" is greater than 3.
       constraint {
-        attribute = "${node.meta.my_custom_value}"
+        attribute = "${meta.my_custom_value}"
         operator  = ">"
         value     = "3"
       }
@@ -210,7 +210,7 @@ utilizing node [metadata][meta].
 
 ```hcl
 constraint {
-  attribute    = "${node.meta.cached_binaries}"
+  attribute    = "${meta.cached_binaries}"
   set_contains = "redis,cypress,nginx"
 }
 ```

--- a/website/source/docs/runtime/interpolation.html.md
+++ b/website/source/docs/runtime/interpolation.html.md
@@ -92,12 +92,12 @@ driver.
     <td><tt>linux-64bit</tt></td>
   </tr>
   <tr>
-    <td><tt>${node.attr.&lt;property&gt;}</tt></td>
+    <td><tt>${attr.&lt;property&gt;}</tt></td>
     <td>Property given by <tt>property</tt> on the client</td>
     <td><tt>${attr.arch} => amd64</tt></td>
   </tr>
   <tr>
-    <td><tt>${node.meta.&lt;key&gt;}</tt></td>
+    <td><tt>${meta.&lt;key&gt;}</tt></td>
     <td>Metadata value given by <tt>key</tt> on the client</td>
     <td><tt>${meta.foo} => bar</tt></td>
   </tr>


### PR DESCRIPTION
This PR fixes the website documentation to correctly present the way of
specifying constraints on node meta and attributes.