### PR TITLE
Fix race when shutting down in dev mode

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -378,12 +378,10 @@ func (c *Client) Shutdown() error {
 
 	// Destroy all the running allocations.
 	if c.config.DevMode {
-		c.allocLock.Lock()
-		for _, ar := range c.allocs {
+		for _, ar := range c.getAllocRunners() {
 			ar.Destroy()
 			<-ar.WaitCh()
 		}
-		c.allocLock.Unlock()
 	}
 
 	c.shutdown = true


### PR DESCRIPTION
Client.Shutdown holds the allocLock when destroying alloc runners in dev
mode.

Client.updateAllocStatus can be called during AllocRunner shutdown and
calls getAllocRunners which tries to acquire allocLock.RLock. This
deadlocks since Client.Shutdown already has the write lock.

Switching Client.Shutdown to use getAllocRunners and not hold a lock
during AllocRunner shutdown is the solution.