### PR TITLE
Send Driver events to servers immediately

### DIFF
--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -361,7 +361,7 @@ func (r *TaskRunner) createDriver() (driver.Driver, error) {
 	eventEmitter := func(m string, args ...interface{}) {
 		msg := fmt.Sprintf(m, args...)
 		r.logger.Printf("[DEBUG] client: driver event for alloc %q: %s", r.alloc.ID, msg)
-		r.setState("", structs.NewTaskEvent(structs.TaskDriverMessage).SetDriverMessage(msg))
+		r.setState(structs.TaskStatePending, structs.NewTaskEvent(structs.TaskDriverMessage).SetDriverMessage(msg))
 	}
 
 	driverCtx := driver.NewDriverContext(r.task.Name, r.config, r.config.Node, r.logger, env, eventEmitter)


### PR DESCRIPTION
This PR causes driver events to be sent to the server immediately rather
than waiting for Prestart() to finish.