### PR TITLE
Datacenter balance constraint

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3186,11 +3186,11 @@ func (ta *TaskArtifact) Validate() error {
 }
 
 const (
-	ConstraintBalance       = "balance_datacenter"
-	ConstraintDistinctHosts = "distinct_hosts"
-	ConstraintRegex         = "regexp"
-	ConstraintVersion       = "version"
-	ConstraintSetContains   = "set_contains"
+	ConstraintBalanceDatacenters = "balance_datacenters"
+	ConstraintDistinctHosts      = "distinct_hosts"
+	ConstraintRegex              = "regexp"
+	ConstraintVersion            = "version"
+	ConstraintSetContains        = "set_contains"
 )
 
 // Constraints are used to restrict placement options.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3186,6 +3186,7 @@ func (ta *TaskArtifact) Validate() error {
 }
 
 const (
+	ConstraintBalance       = "balance_datacenter"
 	ConstraintDistinctHosts = "distinct_hosts"
 	ConstraintRegex         = "regexp"
 	ConstraintVersion       = "version"

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -260,7 +260,7 @@ func (iter *ProposedAllocConstraintIterator) satisfiesDistinctHosts(option *stru
 }
 
 // satisfiesBalance checks if the allocation on this node would make the zones
-// unbalanced, this implies a greater then 1 difference between the lowest, and the
+// unbalanced, this implies a greater than 1 difference between the lowest, and the
 // highest zone
 func (iter *ProposedAllocConstraintIterator) satisfiesBalance(option *structs.Node) bool {
 	// Check if there is no constraint set.
@@ -268,13 +268,13 @@ func (iter *ProposedAllocConstraintIterator) satisfiesBalance(option *structs.No
 		return true
 	}
 
-	// fill the map with all the dc's in the selected datacenter
-	balanceMap := make(map[string]int)
-
 	if len(iter.job.Datacenters) == 0 {
 		iter.ctx.Logger().Print("[ERR] Job needs at least 1 datacenter to use balance")
 		return false
 	}
+
+	// fill the map with all the dc's in the selected datacenter
+	balanceMap := make(map[string]int)
 
 	for _, dc := range iter.job.Datacenters {
 		balanceMap[dc] = 0
@@ -295,13 +295,6 @@ func (iter *ProposedAllocConstraintIterator) satisfiesBalance(option *structs.No
 
 		node := next.(*structs.Node)
 
-		// current allocations
-		allocs, err := iter.ctx.State().AllocsByNode(node.ID)
-		if err != nil {
-			iter.ctx.Logger().Printf("[ERR] scheduler.dynamic-constraint: failed to get node allocations: %v", err)
-			return false
-		}
-
 		// proposed allocations
 		proposed, err := iter.ctx.ProposedAllocs(node.ID)
 		if err != nil {
@@ -310,10 +303,6 @@ func (iter *ProposedAllocConstraintIterator) satisfiesBalance(option *structs.No
 		}
 
 		for _, alloc := range proposed {
-			allocs = append(allocs, alloc)
-		}
-
-		for _, alloc := range allocs {
 			jobCollision := alloc.JobID == iter.job.ID
 			taskCollision := alloc.TaskGroup == iter.tg.Name
 
@@ -322,7 +311,7 @@ func (iter *ProposedAllocConstraintIterator) satisfiesBalance(option *structs.No
 				continue
 			}
 
-			// skip allocation with DesiredStatus other then running
+			// skip allocation with DesiredStatus other than running
 			if alloc.DesiredStatus != structs.AllocDesiredStatusRun {
 				continue
 			}
@@ -339,9 +328,7 @@ func (iter *ProposedAllocConstraintIterator) satisfiesBalance(option *structs.No
 		}
 	}
 
-	iter.ctx.Logger().Printf("[DEBUG] Allocs per DC: Current: %d (%s), Lowest: %d", balanceMap[option.Datacenter], option.Datacenter, min)
-
-	// if the current DC is higher then the minium, the node is not eligible
+	// if the current DC is higher than the minium, the node is not eligible
 	if balanceMap[option.Datacenter] > min {
 		return false
 	}

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -721,3 +721,26 @@ func updateNonTerminalAllocsToLost(plan *structs.Plan, tainted map[string]*struc
 		}
 	}
 }
+
+// allocationsPerDatacenter returns a partition with an equal spread of the number of allocations per datacenter
+// the allocations will be equally spread (allocations/len(datacenters)) and the remaining x allocations will be
+// placed on the first x datacenters.
+func allocationsPerDatacenter(allocations int, datacenters []string) map[string]int {
+	dcCount := len(datacenters)
+	result := make(map[string]int, dcCount)
+	remainder := allocations % dcCount
+
+	for _, dc := range datacenters {
+		// integer division of the number of allocations by the number of datacenters
+		// this will leave a "remainder", which we will add as long as there is some left
+		result[dc] = allocations / dcCount
+
+		// divide the remainder across the first x datacenters until the remainder equals zero
+		if remainder > 0 {
+			result[dc]++
+			remainder--
+		}
+	}
+
+	return result
+}

--- a/website/source/docs/job-specification/constraint.html.md
+++ b/website/source/docs/job-specification/constraint.html.md
@@ -114,15 +114,16 @@ constraint {
     }
     ```
 
-- `"balance_datacenter"` - Instructs the scheduler to force an equal spread across
-  all datacenters specified in the Job. When specified as a job constraint, it
-  applies to all groups in the job. When specified as a group constraint, the
-  effect is constrained to that group. Note that the `attribute` parameter should
-  be omitted when using this constraint.
+- `"balance_datacenters"` - Instructs the scheduler to force an equal spread across
+  all datacenters specified in the job's [datacenter 
+  list](https://www.nomadproject.io/docs/job-specification/job.html#datacenters). 
+  When specified as a job constraint, it applies to all groups in the job. When 
+  specified as a group constraint, the effect is constrained to that group. Note 
+  that the `attribute` parameter should be omitted when using this constraint.
 
     ```hcl
     constraint {
-      operator  = "balance_datacenter"
+      operator  = "balance_datacenters"
       value     = "true"
     }
     ```

--- a/website/source/docs/job-specification/constraint.html.md
+++ b/website/source/docs/job-specification/constraint.html.md
@@ -114,6 +114,19 @@ constraint {
     }
     ```
 
+- `"balance_datacenter"` - Instructs the scheduler to force an equal spread across
+  all datacenters specified in the Job. When specified as a job constraint, it
+  applies to all groups in the job. When specified as a group constraint, the
+  effect is constrained to that group. Note that the `attribute` parameter should
+  be omitted when using this constraint.
+
+    ```hcl
+    constraint {
+      operator  = "balance_datacenter"
+      value     = "true"
+    }
+    ```
+
 - `"regexp"` - Specifies a regular expression constraint against the attribute.
   The syntax of the regular expressions accepted is the same general syntax used
   by Perl, Python, and many other languages. More precisely, it is the syntax


### PR DESCRIPTION
This patch implements a dynamic constraint to force balancing of a job/task across multiple datacenters.

For some tasks, such as applications requiring quorum, it is desired (required) to spread them equally across all datacenters to prevent a loss of quorum when multiple allocations are running on the same DC.

Implements #517