### PR TITLE
Don't retrieve Driver Stats if unsupported

### DIFF
--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -16,16 +17,22 @@ import (
 	cstructs "github.com/hashicorp/nomad/client/structs"
 )
 
-// BuiltinDrivers contains the built in registered drivers
-// which are available for allocation handling
-var BuiltinDrivers = map[string]Factory{
-	"docker":   NewDockerDriver,
-	"exec":     NewExecDriver,
-	"raw_exec": NewRawExecDriver,
-	"java":     NewJavaDriver,
-	"qemu":     NewQemuDriver,
-	"rkt":      NewRktDriver,
-}
+var (
+	// BuiltinDrivers contains the built in registered drivers
+	// which are available for allocation handling
+	BuiltinDrivers = map[string]Factory{
+		"docker":   NewDockerDriver,
+		"exec":     NewExecDriver,
+		"raw_exec": NewRawExecDriver,
+		"java":     NewJavaDriver,
+		"qemu":     NewQemuDriver,
+		"rkt":      NewRktDriver,
+	}
+
+	// DriverStatsNotImplemented is the error to be returned if a driver doesn't
+	// implement stats.
+	DriverStatsNotImplemented = errors.New("stats not implemented for driver")
+)
 
 // NewDriver is used to instantiate and return a new driver
 // given the name and a logger

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -541,7 +541,7 @@ func (h *rktHandle) Kill() error {
 }
 
 func (h *rktHandle) Stats() (*cstructs.TaskResourceUsage, error) {
-	return nil, fmt.Errorf("stats not implemented for rkt")
+	return nil, DriverStatsNotImplemented
 }
 
 func (h *rktHandle) run() {

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1150,6 +1150,12 @@ func (r *TaskRunner) collectResourceUsageStats(stopCollection <-chan struct{}) {
 			ru, err := r.handle.Stats()
 
 			if err != nil {
+				// Check if the driver doesn't implement stats
+				if err.Error() == driver.DriverStatsNotImplemented.Error() {
+					r.logger.Printf("[DEBUG] client: driver for task %q in allocation %q doesn't support stats", r.task.Name, r.alloc.ID)
+					return
+				}
+
 				// We do not log when the plugin is shutdown as this is simply a
 				// race between the stopCollection channel being closed and calling
 				// Stats on the handle.


### PR DESCRIPTION
This PR makes us only try to collect stats once if the Driver doesn't
support collecting stats.

Fixes https://github.com/hashicorp/nomad/issues/1986