### PR TITLE
Switch to a less timing dependent test command

### DIFF
--- a/client/driver/executor/executor_linux_test.go
+++ b/client/driver/executor/executor_linux_test.go
@@ -32,7 +32,7 @@ func testExecutorContextWithChroot(t *testing.T) (*ExecutorContext, *allocdir.Al
 		"/bin/ls":           "/bin/ls",
 		"/bin/echo":         "/bin/echo",
 		"/bin/bash":         "/bin/bash",
-		"/usr/bin/yes":      "/usr/bin/yes",
+		"/bin/sleep":        "/bin/sleep",
 		"/foobar":           "/does/not/exist",
 	}
 


### PR DESCRIPTION
`/usr/bin/yes` could produce output very quickly (100s of MBps on my
laptop) and therefore could cause log files to roll over.

A bash loop with a sleep avoids that issue. The test is slower but
should be much more resilient to the massive timing differences between
workstations and Travis.