### PR TITLE
Correct name of interpolated variable node.unique.hostname to node.unique.name

### DIFF
--- a/website/source/docs/runtime/interpolation.html.md
+++ b/website/source/docs/runtime/interpolation.html.md
@@ -127,7 +127,7 @@ Below is a table documenting common node properties:
     <td>See the [task drivers](/docs/drivers/index.html) for property documentation</td>
   </tr>
   <tr>
-    <td><tt>unique.hostname</tt></td>
+    <td><tt>unique.name</tt></td>
     <td>Hostname of the client</td>
   </tr>
   <tr>


### PR DESCRIPTION
The interpolated variable name `${node.unique.hostname}` doesn't work. Rather `${node.unique.name}` should be used.

Looking at the source code, `node.unique.hostname` is not defined as an interpreted name:

* https://github.com/hashicorp/nomad/blob/master/client/driver/env/env.go#L76

Also found a couple of references to `node.unique.hostname` here, but I can't tell if those need to be updated:

* https://github.com/hashicorp/nomad/blob/master/client/fingerprint/host.go#L48
* https://github.com/hashicorp/nomad/blob/master/client/fingerprint/host_test.go#L24


Appreciate your help in looking at this & adjusting as necessary.