### PR TITLE
Add Cleanup method to Driver interface

### DIFF
--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -405,6 +405,10 @@ func TestAllocRunner_SaveRestoreState_TerminalAlloc(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Ensure ar1 doesn't recreate the state file
+	ar.persistLock.Lock()
+	defer ar.persistLock.Unlock()
+
 	// Ensure both alloc runners don't destroy
 	ar.destroy = true
 

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -510,11 +510,12 @@ func (d *DockerDriver) Cleanup(_ *ExecContext, res *CreatedResources) error {
 			for _, value := range resources {
 				if err := d.cleanupImage(value); err != nil {
 					if structs.IsRecoverable(err) {
-						// This will be retried so put it back into the map
-						res.Add(key, value)
 						retry = true
 					}
 					merr.Errors = append(merr.Errors, err)
+
+					// Re-add all failures to the map
+					res.Add(key, value)
 				}
 			}
 		default:
@@ -945,8 +946,6 @@ func (d *DockerDriver) Periodic() (bool, time.Duration) {
 
 // createImage creates a docker image either by pulling it from a registry or by
 // loading it from the file system
-//
-// Returns true if an image was downloaded and should be cleaned up.
 func (d *DockerDriver) createImage(driverConfig *DockerDriverConfig, client *docker.Client, taskDir *allocdir.TaskDir) error {
 	image := driverConfig.ImageName
 	repo, tag := docker.ParseRepositoryTag(image)

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -504,6 +504,9 @@ func (d *DockerDriver) Cleanup(_ *ExecContext, res *CreatedResources) error {
 	for key, resources := range res.Resources {
 		switch key {
 		case dockerImageResKey:
+			// Remove and only add back images that failed to be
+			// removed in a retryable way
+			delete(res.Resources, key)
 			for _, value := range resources {
 				if err := d.cleanupImage(value); err != nil {
 					if structs.IsRecoverable(err) {

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -518,7 +518,7 @@ func (d *DockerDriver) Cleanup(_ *ExecContext, res *CreatedResources) error {
 				res.Remove(dockerImageResKey, value)
 			}
 		default:
-			d.logger.Printf("[WARN] driver.docker: unknown resource to cleanup: %q", key)
+			d.logger.Printf("[ERR] driver.docker: unknown resource to cleanup: %q", key)
 		}
 	}
 	return structs.NewRecoverableError(merr.ErrorOrNil(), retry)

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -101,6 +101,7 @@ type DockerDriver struct {
 	DriverContext
 
 	driverConfig *DockerDriverConfig
+	imageID      string
 }
 
 type DockerDriverAuth struct {
@@ -394,6 +395,7 @@ func (d *DockerDriver) Prestart(ctx *ExecContext, task *structs.Task) (*CreatedR
 
 	res := NewCreatedResources()
 	res.Add(dockerImageResKey, dockerImage.ID)
+	d.imageID = dockerImage.ID
 	return res, nil
 }
 
@@ -1042,7 +1044,8 @@ CREATE:
 		return container, nil
 	}
 
-	d.logger.Printf("[DEBUG] driver.docker: failed to create container %q (attempt %d): %v", config.Name, attempted+1, createErr)
+	d.logger.Printf("[DEBUG] driver.docker: failed to create container %q from image %q (ID: %q) (attempt %d): %v",
+		config.Name, d.driverConfig.ImageName, d.imageID, attempted+1, createErr)
 	if strings.Contains(strings.ToLower(createErr.Error()), "container already exists") {
 		containers, err := client.ListContainers(docker.ListContainersOptions{
 			All: true,

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -386,9 +386,6 @@ func (d *DockerDriver) Prestart(ctx *ExecContext, task *structs.Task) (*CreatedR
 	// still in use by another contianer.
 	dockerImage, err := client.InspectImage(driverConfig.ImageName)
 	if err != nil {
-		// When an error occurs we leak the image, but this should be
-		// extremely rare. There's no point in returning an error
-		// because the image won't be redownloaded as it now exists.
 		d.logger.Printf("[ERR] driver.docker: failed getting image id for %q: %v", driverConfig.ImageName, err)
 		return nil, err
 	}

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -444,9 +444,9 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle
 
 	config, err := d.createContainerConfig(ctx, task, d.driverConfig, syslogAddr)
 	if err != nil {
-		d.logger.Printf("[ERR] driver.docker: failed to create container configuration for image %q: %v", d.driverConfig.ImageName, err)
+		d.logger.Printf("[ERR] driver.docker: failed to create container configuration for image %q (%q): %v", d.driverConfig.ImageName, d.imageID, err)
 		pluginClient.Kill()
-		return nil, fmt.Errorf("Failed to create container configuration for image %q: %v", d.driverConfig.ImageName, err)
+		return nil, fmt.Errorf("Failed to create container configuration for image %q (%q): %v", d.driverConfig.ImageName, d.imageID, err)
 	}
 
 	container, err := d.createContainer(config)
@@ -723,7 +723,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 	}
 
 	config := &docker.Config{
-		Image:     driverConfig.ImageName,
+		Image:     d.imageID,
 		Hostname:  driverConfig.Hostname,
 		User:      task.User,
 		Tty:       driverConfig.TTY,

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -390,7 +390,7 @@ func (d *DockerDriver) Prestart(ctx *ExecContext, task *structs.Task) (*CreatedR
 		// extremely rare. There's no point in returning an error
 		// because the image won't be redownloaded as it now exists.
 		d.logger.Printf("[ERR] driver.docker: failed getting image id for %q: %v", driverConfig.ImageName, err)
-		return nil, nil
+		return nil, err
 	}
 
 	res := NewCreatedResources()

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1304,8 +1304,14 @@ func TestDockerDriver_Cleanup(t *testing.T) {
 	}
 
 	// Cleanup
-	if err := driver.Cleanup(tctx.ExecCtx, res.Copy()); err != nil {
+	rescopy := res.Copy()
+	if err := driver.Cleanup(tctx.ExecCtx, rescopy); err != nil {
 		t.Fatalf("Cleanup failed: %v", err)
+	}
+
+	// Make sure rescopy is updated
+	if len(rescopy.Resources) > 0 {
+		t.Errorf("Cleanup should have cleared resource map: %#v", rescopy.Resources)
 	}
 
 	// Ensure image was removed

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1304,7 +1304,7 @@ func TestDockerDriver_Cleanup(t *testing.T) {
 	}
 
 	// Cleanup
-	if err := driver.Cleanup(tctx.ExecCtx, dockerImageResKey, res.Resources[dockerImageResKey][0]); err != nil {
+	if err := driver.Cleanup(tctx.ExecCtx, res.Copy()); err != nil {
 		t.Fatalf("Cleanup failed: %v", err)
 	}
 
@@ -1315,7 +1315,7 @@ func TestDockerDriver_Cleanup(t *testing.T) {
 
 	// The image doesn't exist which shouldn't be an error when calling
 	// Cleanup, so call it again to make sure.
-	if err := driver.Cleanup(tctx.ExecCtx, dockerImageResKey, res.Resources[dockerImageResKey][0]); err != nil {
+	if err := driver.Cleanup(tctx.ExecCtx, res.Copy()); err != nil {
 		t.Fatalf("Cleanup failed: %v", err)
 	}
 }

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -99,25 +99,22 @@ func dockerSetupWithClient(t *testing.T, task *structs.Task, client *docker.Clie
 	driver := NewDockerDriver(tctx.DriverCtx)
 	copyImage(t, tctx.ExecCtx.TaskDir, "busybox.tar")
 
-	res, err := driver.Prestart(tctx.ExecCtx, task)
+	_, err := driver.Prestart(tctx.ExecCtx, task)
 	if err != nil {
 		tctx.AllocDir.Destroy()
 		t.Fatalf("error in prestart: %v", err)
 	}
 	handle, err := driver.Start(tctx.ExecCtx, task)
 	if err != nil {
-		driver.Cleanup(tctx.ExecCtx, res)
 		tctx.AllocDir.Destroy()
 		t.Fatalf("Failed to start driver: %s\nStack\n%s", err, debug.Stack())
 	}
 	if handle == nil {
-		driver.Cleanup(tctx.ExecCtx, res)
 		tctx.AllocDir.Destroy()
 		t.Fatalf("handle is nil\nStack\n%s", debug.Stack())
 	}
 
 	cleanup := func() {
-		driver.Cleanup(tctx.ExecCtx, res)
 		handle.Kill()
 		tctx.AllocDir.Destroy()
 	}
@@ -186,19 +183,16 @@ func TestDockerDriver_StartOpen_Wait(t *testing.T) {
 	d := NewDockerDriver(ctx.DriverCtx)
 	copyImage(t, ctx.ExecCtx.TaskDir, "busybox.tar")
 
-	res, err := d.Prestart(ctx.ExecCtx, task)
+	_, err := d.Prestart(ctx.ExecCtx, task)
 	if err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
-	defer d.Cleanup(ctx.ExecCtx, res)
 
 	handle, err := d.Start(ctx.ExecCtx, task)
 	if err != nil {
-		d.Cleanup(ctx.ExecCtx, res)
 		t.Fatalf("err: %v", err)
 	}
 	if handle == nil {
-		d.Cleanup(ctx.ExecCtx, res)
 		t.Fatalf("missing handle")
 	}
 	defer handle.Kill()
@@ -285,11 +279,10 @@ func TestDockerDriver_Start_LoadImage(t *testing.T) {
 	// Copy the image into the task's directory
 	copyImage(t, ctx.ExecCtx.TaskDir, "busybox.tar")
 
-	res, err := d.Prestart(ctx.ExecCtx, task)
+	_, err := d.Prestart(ctx.ExecCtx, task)
 	if err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
-	defer d.Cleanup(ctx.ExecCtx, res)
 	handle, err := d.Start(ctx.ExecCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -351,9 +344,8 @@ func TestDockerDriver_Start_BadPull_Recoverable(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewDockerDriver(ctx.DriverCtx)
 
-	res, err := d.Prestart(ctx.ExecCtx, task)
+	_, err := d.Prestart(ctx.ExecCtx, task)
 	if err == nil {
-		d.Cleanup(ctx.ExecCtx, res)
 		t.Fatalf("want error in prestart: %v", err)
 	}
 
@@ -403,11 +395,10 @@ func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
 	d := NewDockerDriver(ctx.DriverCtx)
 	copyImage(t, ctx.ExecCtx.TaskDir, "busybox.tar")
 
-	res, err := d.Prestart(ctx.ExecCtx, task)
+	_, err := d.Prestart(ctx.ExecCtx, task)
 	if err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
-	defer d.Cleanup(ctx.ExecCtx, res)
 	handle, err := d.Start(ctx.ExecCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -498,11 +489,10 @@ func TestDockerDriver_StartN(t *testing.T) {
 		d := NewDockerDriver(ctx.DriverCtx)
 		copyImage(t, ctx.ExecCtx.TaskDir, "busybox.tar")
 
-		res, err := d.Prestart(ctx.ExecCtx, task)
+		_, err := d.Prestart(ctx.ExecCtx, task)
 		if err != nil {
 			t.Fatalf("error in prestart #%d: %v", idx+1, err)
 		}
-		defer d.Cleanup(ctx.ExecCtx, res)
 		handles[idx], err = d.Start(ctx.ExecCtx, task)
 		if err != nil {
 			t.Errorf("Failed starting task #%d: %s", idx+1, err)
@@ -559,11 +549,10 @@ func TestDockerDriver_StartNVersions(t *testing.T) {
 		copyImage(t, ctx.ExecCtx.TaskDir, "busybox_musl.tar")
 		copyImage(t, ctx.ExecCtx.TaskDir, "busybox_glibc.tar")
 
-		res, err := d.Prestart(ctx.ExecCtx, task)
+		_, err := d.Prestart(ctx.ExecCtx, task)
 		if err != nil {
 			t.Fatalf("error in prestart #%d: %v", idx+1, err)
 		}
-		defer d.Cleanup(ctx.ExecCtx, res)
 		handles[idx], err = d.Start(ctx.ExecCtx, task)
 		if err != nil {
 			t.Errorf("Failed starting task #%d: %s", idx+1, err)
@@ -932,11 +921,10 @@ func TestDockerDriver_User(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	copyImage(t, ctx.ExecCtx.TaskDir, "busybox.tar")
 
-	res, err := driver.Prestart(ctx.ExecCtx, task)
+	_, err := driver.Prestart(ctx.ExecCtx, task)
 	if err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
-	defer driver.Cleanup(ctx.ExecCtx, res)
 
 	// It should fail because the user "alice" does not exist on the given
 	// image.
@@ -1090,11 +1078,10 @@ done
 		fmt.Errorf("Failed to write data")
 	}
 
-	res, err := d.Prestart(ctx.ExecCtx, task)
+	_, err := d.Prestart(ctx.ExecCtx, task)
 	if err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
-	defer d.Cleanup(ctx.ExecCtx, res)
 	handle, err := d.Start(ctx.ExecCtx, task)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -1214,11 +1201,10 @@ func TestDockerDriver_VolumesDisabled(t *testing.T) {
 		task, driver, execCtx, _, cleanup := setupDockerVolumes(t, cfg, tmpvol)
 		defer cleanup()
 
-		res, err := driver.Prestart(execCtx, task)
+		_, err = driver.Prestart(execCtx, task)
 		if err != nil {
 			t.Fatalf("error in prestart: %v", err)
 		}
-		defer driver.Cleanup(execCtx, res)
 		if _, err := driver.Start(execCtx, task); err == nil {
 			t.Fatalf("Started driver successfully when volumes should have been disabled.")
 		}
@@ -1229,11 +1215,10 @@ func TestDockerDriver_VolumesDisabled(t *testing.T) {
 		task, driver, execCtx, fn, cleanup := setupDockerVolumes(t, cfg, ".")
 		defer cleanup()
 
-		res, err := driver.Prestart(execCtx, task)
+		_, err := driver.Prestart(execCtx, task)
 		if err != nil {
 			t.Fatalf("error in prestart: %v", err)
 		}
-		defer driver.Cleanup(execCtx, res)
 		handle, err := driver.Start(execCtx, task)
 		if err != nil {
 			t.Fatalf("err: %v", err)
@@ -1267,11 +1252,10 @@ func TestDockerDriver_VolumesEnabled(t *testing.T) {
 	task, driver, execCtx, hostpath, cleanup := setupDockerVolumes(t, cfg, tmpvol)
 	defer cleanup()
 
-	res, err := driver.Prestart(execCtx, task)
+	_, err = driver.Prestart(execCtx, task)
 	if err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
-	defer driver.Cleanup(execCtx, res)
 	handle, err := driver.Start(execCtx, task)
 	if err != nil {
 		t.Fatalf("Failed to start docker driver: %v", err)
@@ -1320,11 +1304,19 @@ func TestDockerDriver_Cleanup(t *testing.T) {
 	}
 
 	// Cleanup
-	driver.Cleanup(tctx.ExecCtx, res)
+	if err := driver.Cleanup(tctx.ExecCtx, dockerImageResKey, res.Resources[dockerImageResKey][0]); err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
 
 	// Ensure image was removed
 	if _, err := client.InspectImage(driver.driverConfig.ImageName); err == nil {
 		t.Fatalf("image exists but should have been removed. Does another %v container exist?", imageName)
+	}
+
+	// The image doesn't exist which shouldn't be an error when calling
+	// Cleanup, so call it again to make sure.
+	if err := driver.Cleanup(tctx.ExecCtx, dockerImageResKey, res.Resources[dockerImageResKey][0]); err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
 	}
 }
 

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -85,6 +85,23 @@ func (r *CreatedResources) Add(k, v string) {
 	return
 }
 
+// Remove a resource. Return true if removed, otherwise false.
+//
+// Removes the entire key if the needle is the last value in the list.
+func (r *CreatedResources) Remove(k, needle string) bool {
+	haystack := r.Resources[k]
+	for i, item := range haystack {
+		if item == needle {
+			r.Resources[k] = append(haystack[:i], haystack[i+1:]...)
+			if len(r.Resources[k]) == 0 {
+				delete(r.Resources, k)
+			}
+			return true
+		}
+	}
+	return false
+}
+
 // Copy returns a new deep copy of CreatedResrouces.
 func (r *CreatedResources) Copy() *CreatedResources {
 	newr := CreatedResources{

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -137,8 +137,9 @@ type Driver interface {
 	// Cleanup is called to remove resources which were created for a task
 	// and no longer needed.
 	//
-	// Cleanup should log any errors it encounters.
-	Cleanup(*ExecContext, *CreatedResources)
+	// Cleanup is called once for every value for every key in
+	// CreatedResources. Errors will cause Cleanup to be retried.
+	Cleanup(ctx *ExecContext, key, value string) error
 
 	// Drivers must validate their configuration
 	Validate(map[string]interface{}) error

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -256,3 +256,42 @@ func TestMapMergeStrStr(t *testing.T) {
 		t.Errorf("\nExpected\n%+v\nGot\n%+v\n", d, c)
 	}
 }
+
+func TestCreatedResources(t *testing.T) {
+	res1 := NewCreatedResources()
+	res1.Add("k1", "v1")
+	res1.Add("k1", "v2")
+	res1.Add("k1", "v1")
+	res1.Add("k2", "v1")
+
+	expected := map[string][]string{
+		"k1": {"v1", "v2"},
+		"k2": {"v1"},
+	}
+	if !reflect.DeepEqual(expected, res1.Resources) {
+		t.Fatalf("1.  %#v != expected %#v", res1.Resources, expected)
+	}
+
+	// Make sure merging nil works
+	var res2 *CreatedResources
+	res1.Merge(res2)
+	if !reflect.DeepEqual(expected, res1.Resources) {
+		t.Fatalf("2.  %#v != expected %#v", res1.Resources, expected)
+	}
+
+	// Make sure a normal merge works
+	res2 = NewCreatedResources()
+	res2.Add("k1", "v3")
+	res2.Add("k2", "v1")
+	res2.Add("k3", "v3")
+	res1.Merge(res2)
+
+	expected = map[string][]string{
+		"k1": {"v1", "v2", "v3"},
+		"k2": {"v1"},
+		"k3": {"v3"},
+	}
+	if !reflect.DeepEqual(expected, res1.Resources) {
+		t.Fatalf("3.  %#v != expected %#v", res1.Resources, expected)
+	}
+}

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -257,7 +257,7 @@ func TestMapMergeStrStr(t *testing.T) {
 	}
 }
 
-func TestCreatedResources(t *testing.T) {
+func TestCreatedResources_AddMerge(t *testing.T) {
 	res1 := NewCreatedResources()
 	res1.Add("k1", "v1")
 	res1.Add("k1", "v2")
@@ -293,5 +293,43 @@ func TestCreatedResources(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, res1.Resources) {
 		t.Fatalf("3.  %#v != expected %#v", res1.Resources, expected)
+	}
+}
+
+func TestCreatedResources_CopyRemove(t *testing.T) {
+	res1 := NewCreatedResources()
+	res1.Add("k1", "v1")
+	res1.Add("k1", "v2")
+	res1.Add("k1", "v3")
+	res1.Add("k2", "v1")
+
+	// Assert Copy creates a deep copy
+	res2 := res1.Copy()
+
+	if !reflect.DeepEqual(res1, res2) {
+		t.Fatalf("%#v != %#v", res1, res2)
+	}
+
+	// Assert removing v1 from k1 returns true and updates Resources slice
+	if removed := res2.Remove("k1", "v1"); !removed {
+		t.Fatalf("expected v1 to be removed: %#v", res2)
+	}
+
+	if expected := []string{"v2", "v3"}; !reflect.DeepEqual(expected, res2.Resources["k1"]) {
+		t.Fatalf("unpexpected list for k1: %#v", res2.Resources["k1"])
+	}
+
+	// Assert removing the only value from a key removes the key
+	if removed := res2.Remove("k2", "v1"); !removed {
+		t.Fatalf("expected v1 to be removed from k2: %#v", res2.Resources)
+	}
+
+	if _, found := res2.Resources["k2"]; found {
+		t.Fatalf("k2 should have been removed from Resources: %#v", res2.Resources)
+	}
+
+	// Make sure res1 wasn't updated
+	if reflect.DeepEqual(res1, res2) {
+		t.Fatalf("res1 should not equal res2: #%v", res1)
 	}
 }

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -173,7 +173,7 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	return h, nil
 }
 
-func (d *ExecDriver) Cleanup(*ExecContext, *CreatedResources) {}
+func (d *ExecDriver) Cleanup(*ExecContext, string, string) error { return nil }
 
 type execId struct {
 	Version         string

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -173,7 +173,7 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	return h, nil
 }
 
-func (d *ExecDriver) Cleanup(*ExecContext, string, string) error { return nil }
+func (d *ExecDriver) Cleanup(*ExecContext, *CreatedResources) error { return nil }
 
 type execId struct {
 	Version         string

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -94,8 +94,8 @@ func (d *ExecDriver) Periodic() (bool, time.Duration) {
 	return true, 15 * time.Second
 }
 
-func (d *ExecDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
-	return nil
+func (d *ExecDriver) Prestart(*ExecContext, *structs.Task) (*CreatedResources, error) {
+	return nil, nil
 }
 
 func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
@@ -172,6 +172,8 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	go h.run()
 	return h, nil
 }
+
+func (d *ExecDriver) Cleanup(*ExecContext, *CreatedResources) {}
 
 type execId struct {
 	Version         string

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -67,7 +67,7 @@ func TestExecDriver_StartOpen_Wait(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -111,7 +111,7 @@ func TestExecDriver_KillUserPid_OnPluginReconnectFailure(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -175,7 +175,7 @@ func TestExecDriver_Start_Wait(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -229,7 +229,7 @@ func TestExecDriver_Start_Wait_AllocDir(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -283,7 +283,7 @@ func TestExecDriver_Start_Kill_Wait(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -349,7 +349,7 @@ done
 		fmt.Errorf("Failed to write data")
 	}
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -414,7 +414,7 @@ func TestExecDriverUser(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -260,7 +260,7 @@ func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	return h, nil
 }
 
-func (d *JavaDriver) Cleanup(*ExecContext, *CreatedResources) {}
+func (d *JavaDriver) Cleanup(*ExecContext, string, string) error { return nil }
 
 // cgroupsMounted returns true if the cgroups are mounted on a system otherwise
 // returns false

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -164,8 +164,8 @@ func (d *JavaDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, 
 	return true, nil
 }
 
-func (d *JavaDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
-	return nil
+func (d *JavaDriver) Prestart(*ExecContext, *structs.Task) (*CreatedResources, error) {
+	return nil, nil
 }
 
 func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
@@ -259,6 +259,8 @@ func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	go h.run()
 	return h, nil
 }
+
+func (d *JavaDriver) Cleanup(*ExecContext, *CreatedResources) {}
 
 // cgroupsMounted returns true if the cgroups are mounted on a system otherwise
 // returns false

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -260,7 +260,7 @@ func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	return h, nil
 }
 
-func (d *JavaDriver) Cleanup(*ExecContext, string, string) error { return nil }
+func (d *JavaDriver) Cleanup(*ExecContext, *CreatedResources) error { return nil }
 
 // cgroupsMounted returns true if the cgroups are mounted on a system otherwise
 // returns false

--- a/client/driver/java_test.go
+++ b/client/driver/java_test.go
@@ -94,7 +94,7 @@ func TestJavaDriver_StartOpen_Wait(t *testing.T) {
 	dst := ctx.ExecCtx.TaskDir.Dir
 	copyFile("./test-resources/java/demoapp.jar", filepath.Join(dst, "demoapp.jar"), t)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -149,7 +149,7 @@ func TestJavaDriver_Start_Wait(t *testing.T) {
 	dst := ctx.ExecCtx.TaskDir.Dir
 	copyFile("./test-resources/java/demoapp.jar", filepath.Join(dst, "demoapp.jar"), t)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -215,7 +215,7 @@ func TestJavaDriver_Start_Kill_Wait(t *testing.T) {
 	dst := ctx.ExecCtx.TaskDir.Dir
 	copyFile("./test-resources/java/demoapp.jar", filepath.Join(dst, "demoapp.jar"), t)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -277,7 +277,7 @@ func TestJavaDriver_Signal(t *testing.T) {
 	dst := ctx.ExecCtx.TaskDir.Dir
 	copyFile("./test-resources/java/demoapp.jar", filepath.Join(dst, "demoapp.jar"), t)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -336,7 +336,7 @@ func TestJavaDriverUser(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewJavaDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -286,7 +286,7 @@ func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	return &handle, nil
 }
 
-func (d *LxcDriver) Cleanup(*ExecContext, string, string) error { return nil }
+func (d *LxcDriver) Cleanup(*ExecContext, *CreatedResources) error { return nil }
 
 // Open creates the driver to monitor an existing LXC container
 func (d *LxcDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error) {

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -171,8 +171,8 @@ func (d *LxcDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, e
 	return true, nil
 }
 
-func (d *LxcDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
-	return nil
+func (d *LxcDriver) Prestart(*ExecContext, *structs.Task) (*CreatedResources, error) {
+	return nil, nil
 }
 
 // Start starts the LXC Driver
@@ -285,6 +285,8 @@ func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 
 	return &handle, nil
 }
+
+func (d *LxcDriver) Cleanup(*ExecContext, *CreatedResources) {}
 
 // Open creates the driver to monitor an existing LXC container
 func (d *LxcDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error) {

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -286,7 +286,7 @@ func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	return &handle, nil
 }
 
-func (d *LxcDriver) Cleanup(*ExecContext, *CreatedResources) {}
+func (d *LxcDriver) Cleanup(*ExecContext, string, string) error { return nil }
 
 // Open creates the driver to monitor an existing LXC container
 func (d *LxcDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error) {

--- a/client/driver/lxc_test.go
+++ b/client/driver/lxc_test.go
@@ -72,7 +72,7 @@ func TestLxcDriver_Start_Wait(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewLxcDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -148,7 +148,7 @@ func TestLxcDriver_Open_Wait(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewLxcDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)

--- a/client/driver/mock_driver.go
+++ b/client/driver/mock_driver.go
@@ -79,8 +79,8 @@ func (d *MockDriver) FSIsolation() cstructs.FSIsolation {
 	return cstructs.FSIsolationNone
 }
 
-func (d *MockDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
-	return nil
+func (d *MockDriver) Prestart(*ExecContext, *structs.Task) (*CreatedResources, error) {
+	return nil, nil
 }
 
 // Start starts the mock driver
@@ -123,6 +123,8 @@ func (m *MockDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	go h.run()
 	return &h, nil
 }
+
+func (m *MockDriver) Cleanup(*ExecContext, *CreatedResources) {}
 
 // Validate validates the mock driver configuration
 func (m *MockDriver) Validate(map[string]interface{}) error {

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -137,8 +137,8 @@ func (d *QemuDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, 
 	return true, nil
 }
 
-func (d *QemuDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
-	return nil
+func (d *QemuDriver) Prestart(*ExecContext, *structs.Task) (*CreatedResources, error) {
+	return nil, nil
 }
 
 // Run an existing Qemu image. Start() will pull down an existing, valid Qemu
@@ -340,6 +340,8 @@ func (d *QemuDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, erro
 	go h.run()
 	return h, nil
 }
+
+func (d *QemuDriver) Cleanup(*ExecContext, *CreatedResources) {}
 
 func (h *qemuHandle) ID() string {
 	id := qemuId{

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -341,7 +341,7 @@ func (d *QemuDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, erro
 	return h, nil
 }
 
-func (d *QemuDriver) Cleanup(*ExecContext, *CreatedResources) {}
+func (d *QemuDriver) Cleanup(*ExecContext, string, string) error { return nil }
 
 func (h *qemuHandle) ID() string {
 	id := qemuId{

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -341,7 +341,7 @@ func (d *QemuDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, erro
 	return h, nil
 }
 
-func (d *QemuDriver) Cleanup(*ExecContext, string, string) error { return nil }
+func (d *QemuDriver) Cleanup(*ExecContext, *CreatedResources) error { return nil }
 
 func (h *qemuHandle) ID() string {
 	id := qemuId{

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -80,7 +80,7 @@ func TestQemuDriver_StartOpen_Wait(t *testing.T) {
 	dst := ctx.ExecCtx.TaskDir.Dir
 	copyFile("./test-resources/qemu/linux-0.2.img", filepath.Join(dst, "linux-0.2.img"), t)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("Prestart faild: %v", err)
 	}
 
@@ -146,7 +146,7 @@ func TestQemuDriverUser(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewQemuDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("Prestart faild: %v", err)
 	}
 

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -182,7 +182,7 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandl
 	return h, nil
 }
 
-func (d *RawExecDriver) Cleanup(*ExecContext, string, string) error { return nil }
+func (d *RawExecDriver) Cleanup(*ExecContext, *CreatedResources) error { return nil }
 
 type rawExecId struct {
 	Version        string

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -182,7 +182,7 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandl
 	return h, nil
 }
 
-func (d *RawExecDriver) Cleanup(*ExecContext, *CreatedResources) {}
+func (d *RawExecDriver) Cleanup(*ExecContext, string, string) error { return nil }
 
 type rawExecId struct {
 	Version        string

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -108,8 +108,8 @@ func (d *RawExecDriver) Fingerprint(cfg *config.Config, node *structs.Node) (boo
 	return false, nil
 }
 
-func (d *RawExecDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
-	return nil
+func (d *RawExecDriver) Prestart(*ExecContext, *structs.Task) (*CreatedResources, error) {
+	return nil, nil
 }
 
 func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
@@ -181,6 +181,8 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandl
 	go h.run()
 	return h, nil
 }
+
+func (d *RawExecDriver) Cleanup(*ExecContext, *CreatedResources) {}
 
 type rawExecId struct {
 	Version        string

--- a/client/driver/raw_exec_test.go
+++ b/client/driver/raw_exec_test.go
@@ -77,7 +77,7 @@ func TestRawExecDriver_StartOpen_Wait(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRawExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -126,7 +126,7 @@ func TestRawExecDriver_Start_Wait(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRawExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -180,7 +180,7 @@ func TestRawExecDriver_Start_Wait_AllocDir(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRawExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -233,7 +233,7 @@ func TestRawExecDriver_Start_Kill_Wait(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRawExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -286,7 +286,7 @@ func TestRawExecDriverUser(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRawExecDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -335,7 +335,7 @@ done
 		fmt.Errorf("Failed to write data")
 	}
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("prestart err: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -208,8 +208,8 @@ func (d *RktDriver) Periodic() (bool, time.Duration) {
 	return true, 15 * time.Second
 }
 
-func (d *RktDriver) Prestart(ctx *ExecContext, task *structs.Task) error {
-	return nil
+func (d *RktDriver) Prestart(ctx *ExecContext, task *structs.Task) (*CreatedResources, error) {
+	return nil, nil
 }
 
 // Run an existing Rkt image.
@@ -455,6 +455,8 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	go h.run()
 	return h, nil
 }
+
+func (d *RktDriver) Cleanup(*ExecContext, *CreatedResources) {}
 
 func (d *RktDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error) {
 	// Parse the handle

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -456,7 +456,7 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	return h, nil
 }
 
-func (d *RktDriver) Cleanup(*ExecContext, string, string) error { return nil }
+func (d *RktDriver) Cleanup(*ExecContext, *CreatedResources) error { return nil }
 
 func (d *RktDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error) {
 	// Parse the handle

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -456,7 +456,7 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	return h, nil
 }
 
-func (d *RktDriver) Cleanup(*ExecContext, *CreatedResources) {}
+func (d *RktDriver) Cleanup(*ExecContext, string, string) error { return nil }
 
 func (d *RktDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error) {
 	// Parse the handle

--- a/client/driver/rkt_test.go
+++ b/client/driver/rkt_test.go
@@ -98,7 +98,7 @@ func TestRktDriver_Start_DNS(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRktDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -149,7 +149,7 @@ func TestRktDriver_Start_Wait(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRktDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -210,7 +210,7 @@ func TestRktDriver_Start_Wait_Skip_Trust(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRktDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -281,7 +281,7 @@ func TestRktDriver_Start_Wait_AllocDir(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRktDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -343,7 +343,7 @@ func TestRktDriverUser(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRktDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -384,7 +384,7 @@ func TestRktTrustPrefix(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRktDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)
@@ -462,7 +462,7 @@ func TestRktDriver_PortsMapping(t *testing.T) {
 	defer ctx.AllocDir.Destroy()
 	d := NewRktDriver(ctx.DriverCtx)
 
-	if err := d.Prestart(ctx.ExecCtx, task); err != nil {
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
 		t.Fatalf("error in prestart: %v", err)
 	}
 	handle, err := d.Start(ctx.ExecCtx, task)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1038,9 +1038,11 @@ func (r *TaskRunner) cleanup() {
 	var cleanupErr error
 	for retry := true; retry; attempts++ {
 		retry = false
-		if cleanupErr = drv.Cleanup(ctx, res); cleanupErr != nil {
-			retry = structs.IsRecoverable(cleanupErr)
+		cleanupErr = drv.Cleanup(ctx, res)
+		if cleanupErr == nil {
+			return
 		}
+		retry = structs.IsRecoverable(cleanupErr)
 
 		// Copy current createdResources state in case SaveState is
 		// called between retries

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1037,11 +1037,7 @@ func (r *TaskRunner) cleanup() {
 	attempts := 1
 	var cleanupErr error
 	for retry := true; retry; attempts++ {
-		retry = false
 		cleanupErr = drv.Cleanup(ctx, res)
-		if cleanupErr == nil {
-			return
-		}
 		retry = structs.IsRecoverable(cleanupErr)
 
 		// Copy current createdResources state in case SaveState is
@@ -1051,7 +1047,7 @@ func (r *TaskRunner) cleanup() {
 		r.createdResourcesLock.Unlock()
 
 		// Retry 3 times with sleeps between
-		if attempts > 3 {
+		if !retry || attempts > 3 {
 			break
 		}
 		time.Sleep(time.Duration(attempts) * time.Second)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1162,9 +1162,9 @@ func (r *TaskRunner) startTask() error {
 	res, err := drv.Prestart(ctx, r.task)
 
 	// Merge newly created resources into previously created resources
-	r.persistLock.Lock()
+	r.createdResourcesLock.Lock()
 	r.createdResources.Merge(res)
-	r.persistLock.Unlock()
+	r.createdResourcesLock.Unlock()
 
 	if err != nil {
 		wrapped := fmt.Errorf("failed to initialize task %q for alloc %q: %v",

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -944,7 +944,7 @@ func (n *Node) DeriveVaultToken(args *structs.DeriveVaultTokenRequest,
 	// setErr is a helper for setting the recoverable error on the reply and
 	// logging it
 	setErr := func(e error, recoverable bool) {
-		reply.Error = structs.NewRecoverableError(e, recoverable)
+		reply.Error = structs.NewRecoverableError(e, recoverable).(*structs.RecoverableError)
 		n.srv.logger.Printf("[ERR] nomad.client: DeriveVaultToken failed (recoverable %v): %v", recoverable, e)
 	}
 
@@ -1134,7 +1134,7 @@ func (n *Node) DeriveVaultToken(args *structs.DeriveVaultTokenRequest,
 		if rerr, ok := createErr.(*structs.RecoverableError); ok {
 			reply.Error = rerr
 		} else {
-			reply.Error = structs.NewRecoverableError(createErr, false)
+			reply.Error = structs.NewRecoverableError(createErr, false).(*structs.RecoverableError)
 		}
 
 		return nil

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4049,7 +4049,7 @@ type RecoverableError struct {
 
 // NewRecoverableError is used to wrap an error and mark it as recoverable or
 // not.
-func NewRecoverableError(e error, recoverable bool) *RecoverableError {
+func NewRecoverableError(e error, recoverable bool) error {
 	if e == nil {
 		return nil
 	}
@@ -4062,4 +4062,13 @@ func NewRecoverableError(e error, recoverable bool) *RecoverableError {
 
 func (r *RecoverableError) Error() string {
 	return r.Err
+}
+
+// IsRecoverable returns true if error is a RecoverableError with
+// Recoverable=true. Otherwise false is returned.
+func IsRecoverable(e error) bool {
+	if re, ok := e.(*RecoverableError); ok {
+		return re.Recoverable
+	}
+	return false
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1,6 +1,7 @@
 package structs
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -1503,5 +1504,23 @@ func TestDispatchInputConfig_Validate(t *testing.T) {
 	d.File = "../../../haha"
 	if err := d.Validate(); err == nil {
 		t.Fatalf("bad: %v", err)
+	}
+}
+
+func TestIsRecoverable(t *testing.T) {
+	if IsRecoverable(nil) {
+		t.Errorf("nil should not be recoverable")
+	}
+	if IsRecoverable(NewRecoverableError(nil, true)) {
+		t.Errorf("NewRecoverableError(nil, true) should not be recoverable")
+	}
+	if IsRecoverable(fmt.Errorf("i promise im recoverable")) {
+		t.Errorf("Custom errors should not be recoverable")
+	}
+	if IsRecoverable(NewRecoverableError(fmt.Errorf(""), false)) {
+		t.Errorf("Explicitly unrecoverable errors should not be recoverable")
+	}
+	if !IsRecoverable(NewRecoverableError(fmt.Errorf(""), true)) {
+		t.Errorf("Explicitly recoverable errors *should* be recoverable")
 	}
 }


### PR DESCRIPTION
Cleanup can be used for cleaning up resources created by drivers to run
a task. Initially the Docker driver is the only user (to remove
downloaded images).

TaskRunner tracks created resources between calls to drivers.

**Please check line 997 in taskrunner.go closely.** I made that path wait for the handler to die because otherwise the container might not be stopped when Cleanup attempted to remove the image.

This seems like a more correct way to exit to me, but I'm not sure if there was a reason it was omitted.