### PR TITLE
Stop trying to use mount for image based drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## 0.5.3 (Unreleased) 
 
-__BACKWARDS INCOMPATIBILITIES:__
-  * Client must be run as user with ability to call mount syscall
-
 IMPROVEMENTS:
   * core: Introduce Constructor jobs and Dispatch command/API [GH-2128]
   * core: Cancel blocked evals upon successful one for job [GH-2155]

--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -150,11 +150,11 @@ func TestAllocDir_Snapshot(t *testing.T) {
 
 	// Build 2 task dirs
 	td1 := d.NewTaskDir(t1.Name)
-	if err := td1.Build(nil, cstructs.FSIsolationNone); err != nil {
+	if err := td1.Build(nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("error build task=%q dir: %v", t1.Name, err)
 	}
 	td2 := d.NewTaskDir(t2.Name)
-	if err := td2.Build(nil, cstructs.FSIsolationNone); err != nil {
+	if err := td2.Build(nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("error build task=%q dir: %v", t2.Name, err)
 	}
 
@@ -224,12 +224,12 @@ func TestAllocDir_Move(t *testing.T) {
 	defer d2.Destroy()
 
 	td1 := d1.NewTaskDir(t1.Name)
-	if err := td1.Build(nil, cstructs.FSIsolationNone); err != nil {
+	if err := td1.Build(nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("TaskDir.Build() faild: %v", err)
 	}
 
 	td2 := d2.NewTaskDir(t1.Name)
-	if err := td2.Build(nil, cstructs.FSIsolationNone); err != nil {
+	if err := td2.Build(nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("TaskDir.Build() faild: %v", err)
 	}
 
@@ -322,7 +322,7 @@ func TestAllocDir_ReadAt_SecretDir(t *testing.T) {
 	defer d.Destroy()
 
 	td := d.NewTaskDir(t1.Name)
-	if err := td.Build(nil, cstructs.FSIsolationNone); err != nil {
+	if err := td.Build(nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("TaskDir.Build() failed: %v", err)
 	}
 

--- a/client/allocdir/task_dir.go
+++ b/client/allocdir/task_dir.go
@@ -89,11 +89,12 @@ func (t *TaskDir) Build(chroot map[string]string, fsi cstructs.FSIsolation) erro
 		}
 	}
 
-	// Always link the shared task directory even though image based
-	// filesystem isolalation doesn't require it. This way we have a
-	// consistent task dir.
-	if err := linkDir(t.SharedAllocDir, t.SharedTaskDir); err != nil {
-		return fmt.Errorf("Failed to mount shared directory for task: %v", err)
+	// Only link alloc dir into task dir for no and chroot fs isolation.
+	// Image based isolation will bind the shared alloc dir in the driver.
+	if fsi == cstructs.FSIsolationNone || fsi == cstructs.FSIsolationChroot {
+		if err := linkDir(t.SharedAllocDir, t.SharedTaskDir); err != nil {
+			return fmt.Errorf("Failed to mount shared directory for task: %v", err)
+		}
 	}
 
 	// Create the secret directory


### PR DESCRIPTION
Fixes #2178 and allows using Docker and other image based drivers even
when nomad is run as a non-root user.

`client/allocdir` tests can be run as a non-root user to ensure this
behavior and tests that rely on root or non-root users properly detect
their effective user and skip instead of fail.

Switched some tests to use Image based isolation instead of No FS isolation to allow running more tests as non-root users.