### PR TITLE
Fix image based drivers having host env vars set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ IMPROVEMENTS:
 BUG FIXES:
   * client: Fix issue where allocations weren't pulled for several minutes. This
     manifested as slow starts, delayed kills, etc [GH-2177]
+  * driver: Fix image based drivers (eg docker) having host env vars set [GH-2211]
   * driver/docker: Fix Docker auth/logging interprelation [GH-2063, GH-2130]
 
 ## 0.5.2 (December 23, 2016)

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -206,9 +206,11 @@ func GetTaskEnv(taskDir *allocdir.TaskDir, node *structs.Node,
 		env.SetVaultToken(vaultToken, task.Vault.Env)
 	}
 
-	// Set the host environment variables.
-	filter := strings.Split(conf.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
-	env.AppendHostEnvvars(filter)
+	// Set the host environment variables for non-image based drivers
+	if drv.FSIsolation() != cstructs.FSIsolationImage {
+		filter := strings.Split(conf.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
+		env.AppendHostEnvvars(filter)
+	}
 
 	return env.Build(), nil
 }


### PR DESCRIPTION
Add detailed tests for GetTaskEnv to avoid this issue happening again!

Fixes #2211