### PR TITLE
Don't link shared alloc dir into task dir for raw_exec

### DIFF
--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -106,11 +106,11 @@ func TestAllocDir_MountSharedAlloc(t *testing.T) {
 
 	// Build 2 task dirs
 	td1 := d.NewTaskDir(t1.Name)
-	if err := td1.Build(nil, cstructs.FSIsolationNone); err != nil {
+	if err := td1.Build(nil, cstructs.FSIsolationChroot); err != nil {
 		t.Fatalf("error build task=%q dir: %v", t1.Name, err)
 	}
 	td2 := d.NewTaskDir(t2.Name)
-	if err := td2.Build(nil, cstructs.FSIsolationNone); err != nil {
+	if err := td2.Build(nil, cstructs.FSIsolationChroot); err != nil {
 		t.Fatalf("error build task=%q dir: %v", t2.Name, err)
 	}
 
@@ -126,11 +126,12 @@ func TestAllocDir_MountSharedAlloc(t *testing.T) {
 		taskFile := filepath.Join(td.SharedTaskDir, filename)
 		act, err := ioutil.ReadFile(taskFile)
 		if err != nil {
-			t.Fatalf("Failed to read shared alloc file from task dir: %v", err)
+			t.Errorf("Failed to read shared alloc file from task dir: %v", err)
+			continue
 		}
 
 		if !bytes.Equal(act, contents) {
-			t.Fatalf("Incorrect data read from task dir: want %v; got %v", contents, act)
+			t.Errorf("Incorrect data read from task dir: want %v; got %v", contents, act)
 		}
 	}
 }

--- a/client/allocdir/task_dir.go
+++ b/client/allocdir/task_dir.go
@@ -89,9 +89,11 @@ func (t *TaskDir) Build(chroot map[string]string, fsi cstructs.FSIsolation) erro
 		}
 	}
 
-	// Only link alloc dir into task dir for no and chroot fs isolation.
+	// Only link alloc dir into task dir for chroot fs isolation.
 	// Image based isolation will bind the shared alloc dir in the driver.
-	if fsi == cstructs.FSIsolationNone || fsi == cstructs.FSIsolationChroot {
+	// If there's no isolation the task will use the host path to the
+	// shared alloc dir.
+	if fsi == cstructs.FSIsolationChroot {
 		if err := linkDir(t.SharedAllocDir, t.SharedTaskDir); err != nil {
 			return fmt.Errorf("Failed to mount shared directory for task: %v", err)
 		}


### PR DESCRIPTION
Fixes running raw_exec tasks when nomad isn't root.

Thanks @nugend!