### PR TITLE
Making the docker driver retry when an image is not found

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -53,7 +53,8 @@ var (
 	recoverableErrTimeouts = func(err error) *structs.RecoverableError {
 		r := false
 		if strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") ||
-			strings.Contains(err.Error(), "EOF") {
+			strings.Contains(err.Error(), "EOF") ||
+			strings.Contains(err.Error(), "no such image") {
 			r = true
 		}
 		return structs.NewRecoverableError(err, r)

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -54,6 +54,9 @@ var (
 		r := false
 		if strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") ||
 			strings.Contains(err.Error(), "EOF") ||
+			// TODO Remove when we implement global co-ordination among docker
+			// drivers to not remove images which are in use by instances of
+			// other drivers
 			strings.Contains(err.Error(), "no such image") {
 			r = true
 		}


### PR DESCRIPTION
Fixes #2014 