### PR TITLE
Improve Vault integration and validation

### DIFF
--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -121,6 +121,7 @@ vault {
     key_file = "/path/to/key/file"
     tls_server_name = "foobar"
     tls_skip_verify = true
+    create_from_role = "test_role"
 }
 tls {
     http = true

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -710,6 +710,7 @@ func parseVaultConfig(result **config.VaultConfig, list *ast.ObjectList) error {
 		"ca_file",
 		"ca_path",
 		"cert_file",
+		"create_from_role",
 		"key_file",
 		"tls_server_name",
 		"tls_skip_verify",

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -129,6 +129,7 @@ func TestConfig_Parse(t *testing.T) {
 					Addr:                 "127.0.0.1:9500",
 					AllowUnauthenticated: &trueValue,
 					Enabled:              &falseValue,
+					Role:                 "test_role",
 					TLSCaFile:            "/path/to/ca/file",
 					TLSCaPath:            "/path/to/ca",
 					TLSCertFile:          "/path/to/cert/file",

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -30,6 +30,13 @@ type VaultConfig struct {
 	// lifetime.
 	Token string `mapstructure:"token"`
 
+	// Role sets the role in which to create tokens from. The Token given to
+	// Nomad does not have to be created from this role but must have "update"
+	// capability on "auth/token/create/<create_from_role>". If this value is
+	// unset and the token is created from a role, the value is defaulted to the
+	// role the token is from.
+	Role string `mapstructure:"create_from_role"`
+
 	// AllowUnauthenticated allows users to submit jobs requiring Vault tokens
 	// without providing a Vault token proving they have access to these
 	// policies.
@@ -98,6 +105,9 @@ func (a *VaultConfig) Merge(b *VaultConfig) *VaultConfig {
 
 	if b.Token != "" {
 		result.Token = b.Token
+	}
+	if b.Role != "" {
+		result.Role = b.Role
 	}
 	if b.TaskTokenTTL != "" {
 		result.TaskTokenTTL = b.TaskTokenTTL

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -70,23 +70,28 @@ var (
 	vaultUnrecoverableError = regexp.MustCompile(`Code:\s+40(0|3|4)`)
 
 	// vaultCapabilitiesCapability is the expected capability of Nomad's Vault
-	// token on the the path.
+	// token on the the path. The token must have at least one of the
+	// capabilities.
 	vaultCapabilitiesCapability = []string{"update", "root"}
 
 	// vaultTokenLookupCapability is the expected capability Nomad's
-	// Vault token should have on the path
+	// Vault token should have on the path. The token must have at least one of
+	// the capabilities.
 	vaultTokenLookupCapability = []string{"update", "root"}
 
 	// vaultTokenRevokeCapability is the expected capability Nomad's
-	// Vault token should have on the path
+	// Vault token should have on the path. The token must have at least one of
+	// the capabilities.
 	vaultTokenRevokeCapability = []string{"update", "root"}
 
 	// vaultRoleLookupCapability is the the expected capability Nomad's Vault
-	// token should have on the path
+	// token should have on the path. The token must have at least one of the
+	// capabilities.
 	vaultRoleLookupCapability = []string{"read", "root"}
 
 	// vaultTokenRoleCreateCapability is the the expected capability Nomad's Vault
-	// token should have on the path
+	// token should have on the path. The token must have at least one of the
+	// capabilities.
 	vaultTokenRoleCreateCapability = []string{"update", "root"}
 )
 
@@ -552,6 +557,7 @@ func (v *vaultClient) parseSelfToken() error {
 		}
 	}
 
+	// Store the token data
 	data.Root = root
 	v.tokenData = &data
 
@@ -641,7 +647,8 @@ func (v *vaultClient) validateCapabilities(role string, root bool) error {
 			// can't tell if the Vault token will work
 			msg := fmt.Sprintf("Can not lookup token capabilities. "+
 				"As such certain operations may fail in the future. "+
-				"Please give Nomad a Vault token with %q on %q",
+				"Please give Nomad a Vault token with one of the following "+
+				"capabilities %q on %q so that the required capabilities can be verified",
 				vaultCapabilitiesCapability, vaultCapabilitiesLookupPath)
 			v.logger.Printf("[WARN] vault: %s", msg)
 			return nil
@@ -658,7 +665,7 @@ func (v *vaultClient) validateCapabilities(role string, root bool) error {
 			multierror.Append(&mErr, err)
 		} else if !ok {
 			multierror.Append(&mErr,
-				fmt.Errorf("token must have one of the following capabilities %v on %q; has %v", requiredCaps, path, caps))
+				fmt.Errorf("token must have one of the following capabilities %q on %q; has %v", requiredCaps, path, caps))
 		}
 	}
 

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -56,7 +56,7 @@ const (
 	vaultTokenLookupPath = "auth/token/lookup"
 
 	// vaultTokenRevokePath is the path used to revoke a token
-	vaultTokenRevokePath = "auth/token/revoke-accessor/*"
+	vaultTokenRevokePath = "auth/token/revoke-accessor"
 
 	// vaultRoleLookupPath is the path to lookup a role
 	vaultRoleLookupPath = "auth/token/roles/%s"

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -52,6 +52,9 @@ const (
 	// ones token.
 	vaultCapabilitiesLookupPath = "/sys/capabilities-self"
 
+	// vaultTokenRenewPath is the path used to renew our token
+	vaultTokenRenewPath = "auth/token/renew-self"
+
 	// vaultTokenLookupPath is the path used to lookup a token
 	vaultTokenLookupPath = "auth/token/lookup"
 
@@ -73,6 +76,11 @@ var (
 	// token on the the path. The token must have at least one of the
 	// capabilities.
 	vaultCapabilitiesCapability = []string{"update", "root"}
+
+	// vaultTokenRenewCapability is the expected capability Nomad's
+	// Vault token should have on the path. The token must have at least one of
+	// the capabilities.
+	vaultTokenRenewCapability = []string{"update", "root"}
 
 	// vaultTokenLookupCapability is the expected capability Nomad's
 	// Vault token should have on the path. The token must have at least one of
@@ -458,7 +466,7 @@ func (v *vaultClient) renewalLoop() {
 
 			// Set base values and add some backoff
 
-			v.logger.Printf("[DEBUG] vault: got error or bad auth, so backing off: %v", err)
+			v.logger.Printf("[WARN] vault: got error or bad auth, so backing off: %v", err)
 			switch {
 			case backoff < 5:
 				backoff = 5
@@ -673,6 +681,9 @@ func (v *vaultClient) validateCapabilities(role string, root bool) error {
 	if !v.config.AllowsUnauthenticated() {
 		verify(vaultTokenLookupPath, vaultTokenLookupCapability)
 	}
+
+	// Verify we can renew our selves tokens
+	verify(vaultTokenRenewPath, vaultTokenRenewCapability)
 
 	// Verify we can revoke tokens
 	verify(vaultTokenRevokePath, vaultTokenRevokeCapability)

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	// authPolicy is a policy that allows token creation operations
-	authPolicy = `path "auth/token/create/test" {
-	capabilities = ["create", "update"]
+	// nomadRoleManagementPolicy is a policy that allows nomad to manage tokens
+	nomadRoleManagementPolicy = `
+path "auth/token/renew-self" {
+	capabilities = ["update"]
 }
 
 path "auth/token/lookup" {
@@ -38,25 +39,73 @@ path "auth/token/revoke-accessor" {
 	capabilities = ["update"]
 }
 `
+
+	// tokenLookupPolicy allows a token to be looked up
+	tokenLookupPolicy = `
+path "auth/token/lookup" {
+	capabilities = ["update"]
+}
+`
+
+	// nomadRoleCreatePolicy gives the ability to create the role and derive tokens
+	// from the test role
+	nomadRoleCreatePolicy = `
+path "auth/token/create/test" {
+	capabilities = ["create", "update"]
+}
+`
+
+	// secretPolicy gives access to the secret mount
+	secretPolicy = `
+path "secret/*" {
+	capabilities = ["create", "read", "update", "delete", "list"]
+}
+`
 )
 
-// defaultTestVaultRoleAndToken creates a test Vault role and returns a token
+// defaultTestVaultWhitelistRoleAndToken creates a test Vault role and returns a token
 // created in that role
-func defaultTestVaultRoleAndToken(v *testutil.TestVault, t *testing.T, rolePeriod int) string {
+func defaultTestVaultWhitelistRoleAndToken(v *testutil.TestVault, t *testing.T, rolePeriod int) string {
+	vaultPolicies := map[string]string{
+		"nomad-role-create":     nomadRoleCreatePolicy,
+		"nomad-role-management": nomadRoleManagementPolicy,
+	}
 	d := make(map[string]interface{}, 2)
-	d["allowed_policies"] = "auth"
+	d["allowed_policies"] = "nomad-role-create,nomad-role-management"
 	d["period"] = rolePeriod
-	return testVaultRoleAndToken(v, t, d, []string{"auth"})
+	return testVaultRoleAndToken(v, t, vaultPolicies, d,
+		[]string{"nomad-role-create", "nomad-role-management"})
 }
 
-// testVaultRoleAndToken creates a test Vault role with the specified data after
-// creating the auth policy. It then returns a token created in that role with
-// the passed policies
-func testVaultRoleAndToken(v *testutil.TestVault, t *testing.T, data map[string]interface{}, policies []string) string {
-	// Build the auth policy
+// defaultTestVaultBlacklistRoleAndToken creates a test Vault role using
+// disallowed_policies and returns a token created in that role
+func defaultTestVaultBlacklistRoleAndToken(v *testutil.TestVault, t *testing.T, rolePeriod int) string {
+	vaultPolicies := map[string]string{
+		"nomad-role-create":     nomadRoleCreatePolicy,
+		"nomad-role-management": nomadRoleManagementPolicy,
+		"secrets":               secretPolicy,
+	}
+
+	// XXX if root is included it works but if not it doesn't. Seems like a
+	// Vault bug
+	d := make(map[string]interface{}, 2)
+	d["disallowed_policies"] = "nomad-role-create,root"
+	d["period"] = rolePeriod
+	return testVaultRoleAndToken(v, t, vaultPolicies, d,
+		[]string{"default", "nomad-role-create", "nomad-role-management"})
+}
+
+// testVaultRoleAndToken writes the vaultPolicies to vault and then creates a
+// test role with the passed data. After that it derives a token from the role
+// with the tokenPolicies
+func testVaultRoleAndToken(v *testutil.TestVault, t *testing.T, vaultPolicies map[string]string,
+	data map[string]interface{}, tokenPolicies []string) string {
+	// Write the policies
 	sys := v.Client.Sys()
-	if err := sys.PutPolicy("auth", authPolicy); err != nil {
-		t.Fatalf("failed to create auth policy: %v", err)
+	for p, data := range vaultPolicies {
+		if err := sys.PutPolicy(p, data); err != nil {
+			t.Fatalf("failed to create %q policy: %v", p, err)
+		}
 	}
 
 	// Build a role
@@ -66,7 +115,7 @@ func testVaultRoleAndToken(v *testutil.TestVault, t *testing.T, data map[string]
 	// Create a new token with the role
 	a := v.Client.Auth().Token()
 	req := vapi.TokenCreateRequest{
-		Policies: policies,
+		Policies: tokenPolicies,
 	}
 	s, err := a.CreateWithRole(&req, "test")
 	if err != nil {
@@ -137,13 +186,17 @@ func TestVaultClient_ValidateRole(t *testing.T) {
 	defer v.Stop()
 
 	// Set the configs token in a new test role
+	vaultPolicies := map[string]string{
+		"nomad-role-create":     nomadRoleCreatePolicy,
+		"nomad-role-management": nomadRoleManagementPolicy,
+	}
 	data := map[string]interface{}{
 		"allowed_policies": "default,root",
 		"orphan":           true,
 		"renewable":        true,
 		"explicit_max_ttl": 10,
 	}
-	v.Config.Token = testVaultRoleAndToken(v, t, data, nil)
+	v.Config.Token = testVaultRoleAndToken(v, t, vaultPolicies, data, nil)
 
 	logger := log.New(os.Stderr, "", log.LstdFlags)
 	v.Config.ConnectionRetryIntv = 100 * time.Millisecond
@@ -176,6 +229,59 @@ func TestVaultClient_ValidateRole(t *testing.T) {
 		t.Fatalf("Expect orphan error")
 	}
 	if !strings.Contains(errStr, "explicit max ttl") {
+		t.Fatalf("Expect explicit max ttl error")
+	}
+}
+
+func TestVaultClient_ValidateToken(t *testing.T) {
+	v := testutil.NewTestVault(t).Start()
+	defer v.Stop()
+
+	// Set the configs token in a new test role
+	vaultPolicies := map[string]string{
+		"nomad-role-create": nomadRoleCreatePolicy,
+		"token-lookup":      tokenLookupPolicy,
+	}
+	data := map[string]interface{}{
+		"allowed_policies": "token-lookup,nomad-role-create",
+		"period":           10,
+	}
+	v.Config.Token = testVaultRoleAndToken(v, t, vaultPolicies, data, []string{"token-lookup", "nomad-role-create"})
+
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	v.Config.ConnectionRetryIntv = 100 * time.Millisecond
+	client, err := NewVaultClient(v.Config, logger, nil)
+	if err != nil {
+		t.Fatalf("failed to build vault client: %v", err)
+	}
+	defer client.Stop()
+
+	// Wait for an error
+	var conn bool
+	var connErr error
+	testutil.WaitForResult(func() (bool, error) {
+		conn, connErr = client.ConnectionEstablished()
+		if conn {
+			return false, fmt.Errorf("Should not connect")
+		}
+
+		if connErr == nil {
+			return false, fmt.Errorf("expect an error")
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("bad: %v", err)
+	})
+
+	errStr := connErr.Error()
+	if !strings.Contains(errStr, vaultTokenRevokePath) {
+		t.Fatalf("Expect orphan error")
+	}
+	if !strings.Contains(errStr, fmt.Sprintf(vaultRoleLookupPath, "test")) {
+		t.Fatalf("Expect explicit max ttl error")
+	}
+	if !strings.Contains(errStr, "token must have one of the following") {
 		t.Fatalf("Expect explicit max ttl error")
 	}
 }
@@ -217,7 +323,7 @@ func TestVaultClient_SetConfig(t *testing.T) {
 	defer v2.Stop()
 
 	// Set the configs token in a new test role
-	v2.Config.Token = defaultTestVaultRoleAndToken(v2, t, 20)
+	v2.Config.Token = defaultTestVaultWhitelistRoleAndToken(v2, t, 20)
 
 	logger := log.New(os.Stderr, "", log.LstdFlags)
 	client, err := NewVaultClient(v.Config, logger, nil)
@@ -239,7 +345,7 @@ func TestVaultClient_SetConfig(t *testing.T) {
 
 	waitForConnection(client, t)
 
-	if client.tokenData == nil || len(client.tokenData.Policies) != 2 {
+	if client.tokenData == nil || len(client.tokenData.Policies) != 3 {
 		t.Fatalf("unexpected token: %v", client.tokenData)
 	}
 }
@@ -249,7 +355,7 @@ func TestVaultClient_RenewalLoop(t *testing.T) {
 	defer v.Stop()
 
 	// Set the configs token in a new test role
-	v.Config.Token = defaultTestVaultRoleAndToken(v, t, 5)
+	v.Config.Token = defaultTestVaultWhitelistRoleAndToken(v, t, 5)
 
 	// Start the client
 	logger := log.New(os.Stderr, "", log.LstdFlags)
@@ -389,7 +495,7 @@ func TestVaultClient_LookupToken_Role(t *testing.T) {
 	defer v.Stop()
 
 	// Set the configs token in a new test role
-	v.Config.Token = defaultTestVaultRoleAndToken(v, t, 5)
+	v.Config.Token = defaultTestVaultWhitelistRoleAndToken(v, t, 5)
 
 	logger := log.New(os.Stderr, "", log.LstdFlags)
 	client, err := NewVaultClient(v.Config, logger, nil)
@@ -412,7 +518,7 @@ func TestVaultClient_LookupToken_Role(t *testing.T) {
 		t.Fatalf("failed to parse policies: %v", err)
 	}
 
-	expected := []string{"auth", "default"}
+	expected := []string{"default", "nomad-role-create", "nomad-role-management"}
 	if !reflect.DeepEqual(policies, expected) {
 		t.Fatalf("Unexpected policies; got %v; want %v", policies, expected)
 	}
@@ -546,12 +652,12 @@ func TestVaultClient_CreateToken_Root(t *testing.T) {
 	}
 }
 
-func TestVaultClient_CreateToken_Role(t *testing.T) {
+func TestVaultClient_CreateToken_Whitelist_Role(t *testing.T) {
 	v := testutil.NewTestVault(t).Start()
 	defer v.Stop()
 
 	// Set the configs token in a new test role
-	v.Config.Token = defaultTestVaultRoleAndToken(v, t, 5)
+	v.Config.Token = defaultTestVaultWhitelistRoleAndToken(v, t, 5)
 
 	// Start the client
 	logger := log.New(os.Stderr, "", log.LstdFlags)
@@ -593,12 +699,109 @@ func TestVaultClient_CreateToken_Role(t *testing.T) {
 	}
 }
 
+func TestVaultClient_CreateToken_Root_Target_Role(t *testing.T) {
+	v := testutil.NewTestVault(t).Start()
+	defer v.Stop()
+
+	// Create the test role
+	defaultTestVaultWhitelistRoleAndToken(v, t, 5)
+
+	// Target the test role
+	v.Config.Role = "test"
+
+	// Start the client
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	client, err := NewVaultClient(v.Config, logger, nil)
+	if err != nil {
+		t.Fatalf("failed to build vault client: %v", err)
+	}
+	client.SetActive(true)
+	defer client.Stop()
+
+	waitForConnection(client, t)
+
+	// Create an allocation that requires a Vault policy
+	a := mock.Alloc()
+	task := a.Job.TaskGroups[0].Tasks[0]
+	task.Vault = &structs.Vault{Policies: []string{"default"}}
+
+	s, err := client.CreateToken(context.Background(), a, task.Name)
+	if err != nil {
+		t.Fatalf("CreateToken failed: %v", err)
+	}
+
+	// Ensure that created secret is a wrapped token
+	if s == nil || s.WrapInfo == nil {
+		t.Fatalf("Bad secret: %#v", s)
+	}
+
+	d, err := time.ParseDuration(vaultTokenCreateTTL)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	if s.WrapInfo.WrappedAccessor == "" {
+		t.Fatalf("Bad accessor: %v", s.WrapInfo.WrappedAccessor)
+	} else if s.WrapInfo.Token == "" {
+		t.Fatalf("Bad token: %v", s.WrapInfo.WrappedAccessor)
+	} else if s.WrapInfo.TTL != int(d.Seconds()) {
+		t.Fatalf("Bad ttl: %v", s.WrapInfo.WrappedAccessor)
+	}
+}
+
+func TestVaultClient_CreateToken_Blacklist_Role(t *testing.T) {
+	v := testutil.NewTestVault(t).Start()
+	defer v.Stop()
+
+	// Set the configs token in a new test role
+	v.Config.Token = defaultTestVaultBlacklistRoleAndToken(v, t, 5)
+
+	// Start the client
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	client, err := NewVaultClient(v.Config, logger, nil)
+	if err != nil {
+		t.Fatalf("failed to build vault client: %v", err)
+	}
+	client.SetActive(true)
+	defer client.Stop()
+
+	waitForConnection(client, t)
+
+	// Create an allocation that requires a Vault policy
+	a := mock.Alloc()
+	task := a.Job.TaskGroups[0].Tasks[0]
+	task.Vault = &structs.Vault{Policies: []string{"secrets"}}
+
+	s, err := client.CreateToken(context.Background(), a, task.Name)
+	if err != nil {
+		t.Fatalf("CreateToken failed: %v", err)
+	}
+
+	// Ensure that created secret is a wrapped token
+	if s == nil || s.WrapInfo == nil {
+		t.Fatalf("Bad secret: %#v", s)
+	}
+
+	d, err := time.ParseDuration(vaultTokenCreateTTL)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	if s.WrapInfo.WrappedAccessor == "" {
+		t.Fatalf("Bad accessor: %v", s.WrapInfo.WrappedAccessor)
+	} else if s.WrapInfo.Token == "" {
+		t.Fatalf("Bad token: %v", s.WrapInfo.WrappedAccessor)
+	} else if s.WrapInfo.TTL != int(d.Seconds()) {
+		t.Fatalf("Bad ttl: %v", s.WrapInfo.WrappedAccessor)
+	}
+}
+
 func TestVaultClient_CreateToken_Role_InvalidToken(t *testing.T) {
 	v := testutil.NewTestVault(t).Start()
 	defer v.Stop()
 
 	// Set the configs token in a new test role
-	defaultTestVaultRoleAndToken(v, t, 5)
+	defaultTestVaultWhitelistRoleAndToken(v, t, 5)
 	v.Config.Token = "foo-bar"
 
 	// Start the client
@@ -637,7 +840,7 @@ func TestVaultClient_CreateToken_Role_Unrecoverable(t *testing.T) {
 	defer v.Stop()
 
 	// Set the configs token in a new test role
-	v.Config.Token = defaultTestVaultRoleAndToken(v, t, 5)
+	v.Config.Token = defaultTestVaultWhitelistRoleAndToken(v, t, 5)
 
 	// Start the client
 	logger := log.New(os.Stderr, "", log.LstdFlags)
@@ -799,7 +1002,7 @@ func TestVaultClient_RevokeTokens_Role(t *testing.T) {
 	defer v.Stop()
 
 	// Set the configs token in a new test role
-	v.Config.Token = defaultTestVaultRoleAndToken(v, t, 5)
+	v.Config.Token = defaultTestVaultWhitelistRoleAndToken(v, t, 5)
 
 	purged := 0
 	purge := func(accessors []*structs.VaultAccessor) error {

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -26,15 +26,15 @@ const (
 	capabilities = ["create", "update"]
 }
 
-path "auth/token/lookup/*" {
-	capabilities = ["read"]
+path "auth/token/lookup" {
+	capabilities = ["update"]
 }
 
 path "auth/token/roles/test" {
 	capabilities = ["read"]
 }
 
-path "/auth/token/revoke-accessor/*" {
+path "auth/token/revoke-accessor/*" {
 	capabilities = ["update"]
 }
 `
@@ -227,7 +227,9 @@ func testVaultRoleAndToken(v *testutil.TestVault, t *testing.T, data map[string]
 
 	// Create a new token with the role
 	a := v.Client.Auth().Token()
-	req := vapi.TokenCreateRequest{}
+	req := vapi.TokenCreateRequest{
+		Policies: []string{"auth"},
+	}
 	s, err := a.CreateWithRole(&req, "test")
 	if err != nil {
 		t.Fatalf("failed to create child token: %v", err)

--- a/vendor/github.com/hashicorp/vault/api/logical.go
+++ b/vendor/github.com/hashicorp/vault/api/logical.go
@@ -3,12 +3,34 @@ package api
 import (
 	"bytes"
 	"fmt"
+	"net/http"
+	"os"
 
 	"github.com/hashicorp/vault/helper/jsonutil"
 )
 
 const (
 	wrappedResponseLocation = "cubbyhole/response"
+)
+
+var (
+	// The default TTL that will be used with `sys/wrapping/wrap`, can be
+	// changed
+	DefaultWrappingTTL = "5m"
+
+	// The default function used if no other function is set, which honors the
+	// env var and wraps `sys/wrapping/wrap`
+	DefaultWrappingLookupFunc = func(operation, path string) string {
+		if os.Getenv(EnvVaultWrapTTL) != "" {
+			return os.Getenv(EnvVaultWrapTTL)
+		}
+
+		if (operation == "PUT" || operation == "POST") && path == "sys/wrapping/wrap" {
+			return DefaultWrappingTTL
+		}
+
+		return ""
+	}
 )
 
 // Logical is used to perform logical backend operations on Vault.
@@ -38,7 +60,10 @@ func (c *Logical) Read(path string) (*Secret, error) {
 }
 
 func (c *Logical) List(path string) (*Secret, error) {
-	r := c.c.NewRequest("GET", "/v1/"+path)
+	r := c.c.NewRequest("LIST", "/v1/"+path)
+	// Set this for broader compatibility, but we use LIST above to be able to
+	// handle the wrapping lookup function
+	r.Method = "GET"
 	r.Params.Set("list", "true")
 	resp, err := c.c.RawRequest(r)
 	if resp != nil {
@@ -93,10 +118,48 @@ func (c *Logical) Delete(path string) (*Secret, error) {
 }
 
 func (c *Logical) Unwrap(wrappingToken string) (*Secret, error) {
-	origToken := c.c.Token()
-	defer c.c.SetToken(origToken)
+	var data map[string]interface{}
+	if wrappingToken != "" {
+		if c.c.Token() == "" {
+			c.c.SetToken(wrappingToken)
+		} else if wrappingToken != c.c.Token() {
+			data = map[string]interface{}{
+				"token": wrappingToken,
+			}
+		}
+	}
 
-	c.c.SetToken(wrappingToken)
+	r := c.c.NewRequest("PUT", "/v1/sys/wrapping/unwrap")
+	if err := r.SetJSONBody(data); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.RawRequest(r)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		if resp != nil && resp.StatusCode != 404 {
+			return nil, err
+		}
+	}
+	if resp == nil {
+		return nil, nil
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK: // New method is supported
+		return ParseSecret(resp.Body)
+	case http.StatusNotFound: // Fall back to old method
+	default:
+		return nil, nil
+	}
+
+	if wrappingToken != "" {
+		origToken := c.c.Token()
+		defer c.c.SetToken(origToken)
+		c.c.SetToken(wrappingToken)
+	}
 
 	secret, err := c.Read(wrappedResponseLocation)
 	if err != nil {

--- a/vendor/github.com/hashicorp/vault/api/sys_init.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_init.go
@@ -38,6 +38,7 @@ type InitRequest struct {
 	RecoveryShares    int      `json:"recovery_shares"`
 	RecoveryThreshold int      `json:"recovery_threshold"`
 	RecoveryPGPKeys   []string `json:"recovery_pgp_keys"`
+	RootTokenPGPKey   string   `json:"root_token_pgp_key"`
 }
 
 type InitStatusResponse struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -774,10 +774,10 @@
 			"revisionTime": "2016-08-21T23:40:57Z"
 		},
 		{
-			"checksumSHA1": "JH8wmQ8cWdn7mYu1T7gJ3IMIrec=",
+			"checksumSHA1": "31yBeS6U3xm7VJ7ZvDxRgBxXP0A=",
 			"path": "github.com/hashicorp/vault/api",
-			"revision": "182ba68a9589d4cef95234134aaa498a686e3de3",
-			"revisionTime": "2016-08-21T23:40:57Z"
+			"revision": "f4adc7fa960ed8e828f94bc6785bcdbae8d1b263",
+			"revisionTime": "2016-12-16T21:07:16Z"
 		},
 		{
 			"checksumSHA1": "5lR6EdY0ARRdKAq3hZcL38STD8Q=",

--- a/website/source/data/vault/nomad-server-policy.hcl
+++ b/website/source/data/vault/nomad-server-policy.hcl
@@ -1,6 +1,6 @@
 # Allow creating tokens under the role
 path "auth/token/create/nomad-server" {
-  capabilities = ["create", "update"]
+  capabilities = ["update"]
 }
 
 # Allow looking up the role

--- a/website/source/docs/agent/configuration/vault.html.md
+++ b/website/source/docs/agent/configuration/vault.html.md
@@ -47,6 +47,12 @@ vault {
 - `enabled` `(bool: false)` - Specifies if the Vault integration should be
   activated.
 
+- `create_from_role` `(string: "")` - Specifies the role to create tokens from.
+  The token given to Nomad does not have to be created from this role but must
+  have "update" capability on "auth/token/create/<create_from_role>" path in
+  Vault. If this value is unset and the token is created from a role, the value
+  is defaulted to the role the token is from.
+
 - `task_token_ttl` `(string: "")` - Specifies the TTL of created tokens when
   using a root token. This is specified using a label suffix like "30s" or "1h".
 

--- a/website/source/docs/vault-integration/index.html.md
+++ b/website/source/docs/vault-integration/index.html.md
@@ -69,7 +69,7 @@ when creating the role with the Vault endpoint `/auth/token/roles/<role_name>`:
     ```hcl
     # Allow creating tokens under the role
     path "auth/token/create/nomad-server" {
-        capabilities = ["create", "update"]
+        capabilities = ["update"]
     }
 
     # Allow looking up the role


### PR DESCRIPTION
This PR:

* Validates the token given to Nomad to ensure it has the required capabilities on the needed paths
* Allows specifying a role to create a token from even if the token is not from the given role.
* Adds tests to the blacklist pattern of Vault roles (disallowed_policies).
* updates the Vault API to use the new POST rather than GET methods such that the tokens are not written in the URL.