### PR TITLE
Clarify that exec copies all chroot_env directories

### DIFF
--- a/website/source/docs/drivers/exec.html.md
+++ b/website/source/docs/drivers/exec.html.md
@@ -125,5 +125,10 @@ machine:
 ]
 ```
 
+Nomad will copy these directories into the job's chroot, so make sure you have
+enough disk space. Also take into consideration that allocations are not
+removed immediately after a job has completed, so you might need some margin if
+you run many batch jobs.
+
 This list is configurable through the agent client
 [configuration file](/docs/agent/configuration/client.html#chroot_env).


### PR DESCRIPTION
This was not clear to me ([and others](https://github.com/hashicorp/nomad/issues/1478)) and is very important to understand since you can quickly fill up your disk if you run batch jobs.

I hope I've matched the tone of the rest of the documentation. I'm happy to revise if necessary.