### PR TITLE
Remove misleading "any URL as defined by go-getter" doc

### DIFF
--- a/website/source/docs/job-specification/artifact.html.md
+++ b/website/source/docs/job-specification/artifact.html.md
@@ -52,7 +52,6 @@ before the starting the task.
   as a directory and source files will be downloaded into that directory path.
 
 - `source` `(string: <required>)` - Specifies the URL of the artifact to download.
- The can be any URL as defined by the [`go-getter`][go-getter] library.
 
 - `options` `(map<string|string>: nil)` - Specifies configuration parameters to
   fetch the artifact. The key-value pairs map directly to parameters appended to

--- a/website/source/docs/job-specification/artifact.html.md
+++ b/website/source/docs/job-specification/artifact.html.md
@@ -52,6 +52,8 @@ before the starting the task.
   as a directory and source files will be downloaded into that directory path.
 
 - `source` `(string: <required>)` - Specifies the URL of the artifact to download.
+  Only `http`, `https`, and `s3` URLs are supported. See [`go-getter`][go-getter]
+  for details.
 
 - `options` `(map<string|string>: nil)` - Specifies configuration parameters to
   fetch the artifact. The key-value pairs map directly to parameters appended to


### PR DESCRIPTION
A paragraph above this line we specify what URLs are supported, so just removing this (poorly worded) line seems fine to me.