### PR TITLE
Fix template documentation references

### DIFF
--- a/website/source/docs/http/json-jobs.html.md
+++ b/website/source/docs/http/json-jobs.html.md
@@ -119,6 +119,15 @@ Below is an example of a JSON object that submits a `periodic` job to Nomad:
               "MaxFiles":10,
               "MaxFileSizeMB":10
             },
+            "Templates":[
+              {
+                "SourcePath": "local/config.conf.tpl",
+                "DestPath": "local/config.conf",
+                "ChangeMode": "signal",
+                "ChangeSignal": "SIGUSR1",
+                "Splay": 5000000000
+              }
+            ],
             "Artifacts":[
               {
                 "GetterSource":"http://foo.com/artifact.tar.gz",
@@ -377,6 +386,7 @@ The `Task` object supports the following keys:
          * `Args`: Additional arguments to the `command` for script based health
            checks.
 
+* `Templates` - Array of `Template` objects which describe renderable templates.
 
 * `User` - Set the user that will run the task. It defaults to the same user
   the Nomad client is being run as. This can only be set on Linux platforms.
@@ -589,4 +599,39 @@ Virtual hosted based style
     }
   ]
 }
+```
+
+### Template
+
+Nomad allows runtime template rendering, that could be used for populating configs using Nomad Consul KV data, Nomad runtime variables or Vault data.
+Consul-Template is utilized for template rendering.
+
+`Template` object supports following attributes:
+
+* `SourcePath` - Specifies the path to the template to be rendered. Mutally exclusive with `EmbeddedTmpl` attribute.
+
+* `EmbeddedTmpl` -  Specifies the raw template to execute. Mutally exclusive with `SourcePath` attribute.
+
+* `DestPath` - Specifies the location where the resulting template should be rendered, relative to the task directory.
+
+* `ChangeMode` - Specifies the behavior Nomad should take if the rendered template changes. The possible values are: `noop`, `restart`, `signal`
+
+* `ChangeSignal` - Specifies the signal to send to the task as a string like "SIGUSR1" or "SIGINT". This option is required if the `change_mode` is `signal`.
+
+* `Splay` - Specifies a random amount of time to wait between 0ms and the given splay value before invoking the change mode. Should be specified in nanoseconds.
+
+
+```json
+{
+  "Templates": [
+    {
+      "SourcePath": "local/config.conf.tpl",
+      "DestPath": "local/config.conf",
+      "ChangeMode": "signal",
+      "ChangeSignal": "SIGUSR1",
+      "Splay": 5000000000
+    }
+  ]
+}
+
 ```

--- a/website/source/docs/job-specification/task.html.md
+++ b/website/source/docs/job-specification/task.html.md
@@ -69,6 +69,8 @@ job "docs" {
   [which drivers][user_drivers] are allowed to run tasks as
   [certain users][user_blacklist].
 
+- `template` <code>([Template][]: nil)</code> - Specifies template rendering configuration for Consul-Template.
+
 - `vault` <code>([Vault][]: nil)</code> - Specifies the set of Vault policies
   required by the task. This overrides any `vault` block set at the `group` or
   `job` level.
@@ -167,5 +169,6 @@ task "server" {
 [java]: /docs/drivers/java.html "Nomad Java Driver"
 [Docker]: /docs/drivers/docker.html "Nomad Docker Driver"
 [rkt]: /docs/drivers/rkt.html "Nomad rkt Driver"
+[template]: /docs/job-specification/template.html "Nomad template Job Specification"
 [user_drivers]: /docs/agent/configuration/client.html#_quot_user_checked_drivers_quot_
 [user_blacklist]: /docs/agent/configuration/client.html#_quot_user_blacklist_quot_


### PR DESCRIPTION
At this moment templates are missing in JSON objects and task object attributes.

Please check spelling, i am not native english speaker, and might fuckup spelling a little bit.