### PR TITLE
Refactor Vagrantfiles and release script

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,7 +45,7 @@ format:
 generate:
 	@echo "--> Running go generate"
 	@go generate $(PACKAGES)
-	@sed -i -e 's|github.com/hashicorp/nomad/vendor/github.com/ugorji/go/codec|github.com/ugorji/go/codec|' nomad/structs/structs.generated.go
+	@sed -i.old -e 's|github.com/hashicorp/nomad/vendor/github.com/ugorji/go/codec|github.com/ugorji/go/codec|' nomad/structs/structs.generated.go
 
 vet:
 	@go tool vet 2>/dev/null ; if [ $$? -eq 3 ]; then \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 all: test
 
 dev: format generate
-	@NOMAD_DEV=1 sh -c "'$(PWD)/scripts/build.sh'"
+	@scripts/build-dev.sh
 
 bin: generate
 	@sh -c "'$(PWD)/scripts/build.sh'"
@@ -45,8 +45,7 @@ format:
 generate:
 	@echo "--> Running go generate"
 	@go generate $(PACKAGES)
-	@sed -e 's|github.com/hashicorp/nomad/vendor/github.com/ugorji/go/codec|github.com/ugorji/go/codec|' nomad/structs/structs.generated.go >> structs.gen.tmp
-	@mv structs.gen.tmp nomad/structs/structs.generated.go
+	@sed -i -e 's|github.com/hashicorp/nomad/vendor/github.com/ugorji/go/codec|github.com/ugorji/go/codec|' nomad/structs/structs.generated.go
 
 vet:
 	@go tool vet 2>/dev/null ; if [ $$? -eq 3 ]; then \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,9 +8,20 @@ DEFAULT_CPU_COUNT = 2
 $script = <<SCRIPT
 GO_VERSION="1.7.4"
 
-# Install Prereq Packages
 sudo apt-get update
-sudo apt-get install -y build-essential curl git-core mercurial bzr libpcre3-dev pkg-config zip default-jre qemu gcc-4.8-arm-linux-gnueabihf libc6-dev-i386 silversearcher-ag jq htop vim unzip liblxc1 lxc-dev
+
+# Install base dependencies
+sudo apt-get install -y build-essential curl git-core mercurial bzr libpcre3-dev pkg-config zip default-jre qemu silversearcher-ag jq htop vim unzip liblxc1 lxc-dev tree
+
+# Install cross-compilation dependencies
+# ARM64 / Aarch64 compiler
+sudo apt-get install -y gcc-4.8-aarch64-linux-gnu binutils-aarch64-linux-gnu
+
+# ARM hard-float (32bit) compiler
+sudo apt-get install -y gcc-4.8-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
+
+# i386 dependencies
+sudo apt-get install -y libc6-dev-i386 linux-libc-dev:i386
 
 # Setup go, for development of Nomad
 SRCROOT="/opt/go"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ GO_VERSION="1.7.4"
 
 # Install Prereq Packages
 sudo apt-get update
-sudo apt-get install -y build-essential curl git-core mercurial bzr libpcre3-dev pkg-config zip default-jre qemu libc6-dev-i386 silversearcher-ag jq htop vim unzip liblxc1 lxc-dev
+sudo apt-get install -y build-essential curl git-core mercurial bzr libpcre3-dev pkg-config zip default-jre qemu gcc-4.8-arm-linux-gnueabihf libc6-dev-i386 silversearcher-ag jq htop vim unzip liblxc1 lxc-dev
 
 # Setup go, for development of Nomad
 SRCROOT="/opt/go"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,9 +14,10 @@ sudo apt-get update
 # Install base dependencies
 sudo apt-get install -y build-essential curl git-core mercurial bzr \
      libpcre3-dev pkg-config zip default-jre qemu silversearcher-ag jq htop \
-     vim unzip liblxc1 lxc-dev tree \
-     gcc-5-aarch64-linux-gnu binutils-aarch64-linux-gnu \  # arm64
-     libc6-dev-i386 linux-libc-dev:i386                 \  # i386
+     vim unzip tree \
+     liblxc1 lxc-dev lxc-templates                      \ # lxc
+     gcc-5-aarch64-linux-gnu binutils-aarch64-linux-gnu \ # arm64
+     libc6-dev-i386 linux-libc-dev:i386                 \ # i386
      gcc-5-arm-linux-gnueabi gcc-5-multilib-arm-linux-gnueabi binutils-arm-linux-gnueabi # arm
 
 # Setup go, for development of Nomad

--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -4,7 +4,7 @@
 $script = <<SCRIPT
 # Update apt and get dependencies
 sudo apt-get update
-sudo apt-get install -y unzip curl wget vim
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y unzip curl wget vim
 
 # Download Nomad
 echo Fetching Nomad...
@@ -25,7 +25,7 @@ sudo sed -i -e "s/.*nomad.*/$(ip route get 1 | awk '{print $NF;exit}') nomad/" /
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "puphpet/ubuntu1404-x64"
+  config.vm.box = "ubuntu/xenial64" # 16.04 LTS
   config.vm.hostname = "nomad"
   config.vm.provision "shell", inline: $script, privileged: false
   config.vm.provision "docker" # Just install it

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+GIT_COMMIT="$(git rev-parse HEAD)"
+GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
+LDFLAG="main.GitCommit=${GIT_COMMIT}${GIT_DIRTY}"
+
+TAGS="nomad_test"
+if [[ $(uname) == "Linux" ]]; then
+	if pkg-config --exists lxc; then
+		TAGS="$TAGS lxc"
+	fi
+fi
+
+echo "--> Installing with tags: $TAGS"
+go install -ldflags "-X $LDFLAG" -tags "${TAGS}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,10 +33,10 @@ if [[ $(uname) == "Linux" ]]; then
     CGO_ENBALED=1 GOARCH="amd64" GOOS="linux"   go build -ldflags "-X $LDFLAG" -o "pkg/linux_amd64-lxc/nomad" -tags "lxc"
 
     echo "==> Building linux arm..."
-    CC="arm-linux-gnueabihf-gcc-4.8" GOOS=linux GOARCH="arm"   CGO_ENABLED=1 go build -ldflags "-X $LDFLAG" -o "pkg/linux_arm/nomad"
+    CC="arm-linux-gnueabi-gcc-5" GOOS=linux GOARCH="arm"   CGO_ENABLED=1 go build -ldflags "-X $LDFLAG" -o "pkg/linux_arm/nomad"
 
     echo "==> Building linux arm64..."
-    CC="aarch64-linux-gnu-gcc-4.8"   GOOS=linux GOARCH="arm64" CGO_ENABLED=1 go build -ldflags "-X $LDFLAG" -o "pkg/linux_arm64/nomad"
+    CC="aarch64-linux-gnu-gcc-5"  GOOS=linux GOARCH="arm64" CGO_ENABLED=1 go build -ldflags "-X $LDFLAG" -o "pkg/linux_arm64/nomad"
 
     echo "==> Building windows 386..."
     CGO_ENABLED=1 GOARCH="386"   GOOS="windows" go build -ldflags "-X $LDFLAG" -o "pkg/windows_386/nomad"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,14 +14,7 @@ cd "$DIR"
 # Get the git commit
 GIT_COMMIT="$(git rev-parse HEAD)"
 GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
-
-# Determine the arch/os combos we're building for
-# XC_ARCH=${XC_ARCH:-"386 amd64"}
-# XC_OS=${XC_OS:-linux}
-
-XC_ARCH=${XC_ARCH:-"386 amd64 arm arm64"}
-XC_OS=${XC_OS:-"linux"}
-XC_EXCLUDE=${XC_EXCLUDE:-"!darwin/arm !darwin/386"}
+LDFLAG="main.GitCommit=${GIT_COMMIT}${GIT_DIRTY}"
 
 # Delete the old dir
 echo "==> Removing old directory..."
@@ -29,30 +22,33 @@ rm -f bin/*
 rm -rf pkg/*
 mkdir -p bin/
 
-# Build!
-echo "==> Building..."
-gox \
-    -os="${XC_OS}" \
-    -arch="${XC_ARCH}" \
-    -osarch="${XC_EXCLUDE}" \
-    -cgo \
-    -ldflags "-X main.GitCommit='${GIT_COMMIT}${GIT_DIRTY}'" \
-    -output "pkg/{{.OS}}_{{.Arch}}/nomad" \
-    .
-
-echo ""
 if [[ $(uname) == "Linux" ]]; then
-    if pkg-config --exists lxc; then
-        echo "==> Building linux_amd64-lxc..."
-        go build \
-            -tags lxc \
-            -ldflags "-X main.GitCommit='${GIT_COMMIT}${GIT_DIRTY}+lxc'" \
-            -o "pkg/linux_amd64-lxc/nomad"
-    else
-	# Require LXC for release mode
-	echo "LXC not installed; install lxc-dev to build release binaries"
-	exit 1
-    fi
+    echo "==> Building linux 386..."
+    CGO_ENABLED=1 GOARCH="386"   GOOS="linux"   go build -ldflags "-X $LDFLAG" -o "pkg/linux_386/nomad"
+
+    echo "==> Building linux amd64..."
+    CGO_ENBALED=1 GOARCH="amd64" GOOS="linux"   go build -ldflags "-X $LDFLAG" -o "pkg/linux_amd64/nomad"
+
+    echo "==> Building linux amd64 with lxc..."
+    CGO_ENBALED=1 GOARCH="amd64" GOOS="linux"   go build -ldflags "-X $LDFLAG" -o "pkg/linux_amd64-lxc/nomad" -tags "lxc"
+
+    echo "==> Building linux arm..."
+    CC="arm-linux-gnueabihf-gcc-4.8" GOOS=linux GOARCH="arm"   CGO_ENABLED=1 go build -ldflags "-X $LDFLAG" -o "pkg/linux_arm/nomad"
+
+    echo "==> Building linux arm64..."
+    CC="aarch64-linux-gnu-gcc-4.8"   GOOS=linux GOARCH="arm64" CGO_ENABLED=1 go build -ldflags "-X $LDFLAG" -o "pkg/linux_arm64/nomad"
+
+    echo "==> Building windows 386..."
+    CGO_ENABLED=1 GOARCH="386"   GOOS="windows" go build -ldflags "-X $LDFLAG" -o "pkg/windows_386/nomad"
+
+    echo "==> Building windows amd64..."
+    CGO_ENABLED=1 GOARCH="amd64" GOOS="windows" go build -ldflags "-X $LDFLAG" -o "pkg/windows_amd64/nomad"
+elif [[ $(uname) == "Darwin" ]]; then
+    echo "==> Building darwin amd64..."
+    CGO_ENABLED=1 GOARCH="amd64" GOOS="darwin"  go build -ldflags "-X $LDFLAG" -o "pkg/darwin_amd64/nomad"
+else
+    echo "Unable to build on $(uname). Use Linux or Darwin."
+    exit 1
 fi
 
 # Move all the compiled things to the $GOPATH/bin
@@ -87,4 +83,4 @@ done
 # Done!
 echo
 echo "==> Results:"
-ls -hl bin/
+tree pkg/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
 # XC_ARCH=${XC_ARCH:-"386 amd64"}
 # XC_OS=${XC_OS:-linux}
 
-XC_ARCH=${XC_ARCH:-"386 amd64"}
+XC_ARCH=${XC_ARCH:-"386 amd64 arm arm64"}
 XC_OS=${XC_OS:-"linux"}
 XC_EXCLUDE=${XC_EXCLUDE:-"!darwin/arm !darwin/386"}
 

--- a/scripts/install_consul.sh
+++ b/scripts/install_consul.sh
@@ -5,7 +5,7 @@ set -e
 CONSUL_VERSION="0.7.3"
 CURDIR=`pwd`
 
-if [[ $(consul version | head -n 1 | cut -d ' ' -f 2) == "v$CONSUL_VERSION" ]]; then
+if [[ $(which consul >/dev/null && consul version | head -n 1 | cut -d ' ' -f 2) == "v$CONSUL_VERSION" ]]; then
     echo "Consul v$CONSUL_VERSION already installed; Skipping"
     exit
 fi

--- a/scripts/install_consul.sh
+++ b/scripts/install_consul.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
-set -ex
+set -e
 
-CONSUL_VERSION="0.7.2"
+CONSUL_VERSION="0.7.3"
 CURDIR=`pwd`
+
+if [[ $(consul version | head -n 1 | cut -d ' ' -f 2) == "v$CONSUL_VERSION" ]]; then
+    echo "Consul v$CONSUL_VERSION already installed; Skipping"
+    exit
+fi
 
 echo Fetching Consul...
 cd /tmp/
-wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip -O consul.zip
+wget -q https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip -O consul.zip
 echo Installing Consul...
 unzip consul.zip
 sudo chmod +x consul

--- a/scripts/install_rkt.sh
+++ b/scripts/install_rkt.sh
@@ -2,8 +2,7 @@
 
 set -ex
 
-RKT_VERSION="v1.17.0"
-RKT_SHA512="30fd15716e148afa34ed28e6d5d778226e5e9761e9df3eb98f397cb2a7f3e3fc78e3dad2b717eee4157afc58183778cb1872aa82f3d05cc2bc9fb41193e81a7f"
+RKT_VERSION="v1.18.0"
 CMD="cp"
 
 if [ ! -v DEST_DIR ]; then
@@ -15,9 +14,7 @@ if [ ! -d "rkt-${RKT_VERSION}" ]; then
     printf "rkt-%s/ doesn't exist\n" "${RKT_VERSION}"
     if [ ! -f "rkt-${RKT_VERSION}.tar.gz" ]; then
         printf "Fetching rkt-%s.tar.gz\n" "${RKT_VERSION}"
-	echo "$RKT_SHA512  rkt-${RKT_VERSION}.tar.gz" > rkt-$RKT_VERSION.tar.gz.sha512sum
         wget https://github.com/coreos/rkt/releases/download/$RKT_VERSION/rkt-$RKT_VERSION.tar.gz
-	sha512sum --check rkt-$RKT_VERSION.tar.gz.sha512sum
         tar xzvf rkt-$RKT_VERSION.tar.gz
     fi
 fi

--- a/scripts/install_rkt.sh
+++ b/scripts/install_rkt.sh
@@ -10,16 +10,16 @@ if [ ! -v DEST_DIR ]; then
 	CMD="sudo cp"
 fi
 
-if [ ! -d "rkt-${RKT_VERSION}" ]; then
-    printf "rkt-%s/ doesn't exist\n" "${RKT_VERSION}"
-    if [ ! -f "rkt-${RKT_VERSION}.tar.gz" ]; then
-        printf "Fetching rkt-%s.tar.gz\n" "${RKT_VERSION}"
-        wget -q https://github.com/coreos/rkt/releases/download/$RKT_VERSION/rkt-$RKT_VERSION.tar.gz
-        tar xzvf rkt-$RKT_VERSION.tar.gz
-    fi
-fi
+if [[ $(which rkt >/dev/null && rkt version | head -n 1) == "rkt Version: 1.18.0" ]]; then
+    echo "rkt installed; Skipping"
+else
+    printf "Fetching rkt-%s.tar.gz\n" "${RKT_VERSION}"
+    cd /tmp
+    wget -q https://github.com/coreos/rkt/releases/download/$RKT_VERSION/rkt-$RKT_VERSION.tar.gz -O rkt.tar.gz
+    tar xzf rkt.tar.gz
 
-$CMD rkt-$RKT_VERSION/rkt $DEST_DIR
-$CMD rkt-$RKT_VERSION/*.aci $DEST_DIR
+    $CMD rkt-$RKT_VERSION/rkt $DEST_DIR
+    $CMD rkt-$RKT_VERSION/*.aci $DEST_DIR
+fi
 
 rkt version

--- a/scripts/install_rkt.sh
+++ b/scripts/install_rkt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 RKT_VERSION="v1.18.0"
 CMD="cp"
@@ -14,7 +14,7 @@ if [ ! -d "rkt-${RKT_VERSION}" ]; then
     printf "rkt-%s/ doesn't exist\n" "${RKT_VERSION}"
     if [ ! -f "rkt-${RKT_VERSION}.tar.gz" ]; then
         printf "Fetching rkt-%s.tar.gz\n" "${RKT_VERSION}"
-        wget https://github.com/coreos/rkt/releases/download/$RKT_VERSION/rkt-$RKT_VERSION.tar.gz
+        wget -q https://github.com/coreos/rkt/releases/download/$RKT_VERSION/rkt-$RKT_VERSION.tar.gz
         tar xzvf rkt-$RKT_VERSION.tar.gz
     fi
 fi

--- a/scripts/install_rkt_vagrant.sh
+++ b/scripts/install_rkt_vagrant.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-
-set -ex
+set -e
 
 # Configure rkt networking
 sudo mkdir -p /etc/rkt/net.d
-echo '{"name": "default", "type": "ptp", "ipMasq": false, "ipam": { "type": "host-local", "subnet": "172.16.28.0/24", "routes": [ { "dst": "0.0.0.0/0" } ] } }' | sudo tee -a /etc/rkt/net.d/99-network.conf
+if [[ -f /etc/rkt/net.d/99-network.conf ]]; then
+    echo "rkt network already configured; Skipping"
+    exit
+fi
+echo '{"name": "default", "type": "ptp", "ipMasq": false, "ipam": { "type": "host-local", "subnet": "172.16.28.0/24", "routes": [ { "dst": "0.0.0.0/0" } ] } }' | jq . | sudo tee -a /etc/rkt/net.d/99-network.conf
 

--- a/scripts/install_vault.sh
+++ b/scripts/install_vault.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
-set -ex
+set -e
 
-VAULT_VERSION="0.6.2"
+VAULT_VERSION="0.6.4"
 CURDIR=`pwd`
+
+if [[ $(vault version | cut -d ' ' -f 2) == "v$VAULT_VERSION" ]]; then
+    echo "Vault v$VAULT_VERSION already installed; Skipping"
+    exit
+fi
 
 echo Fetching Vault ${VAULT_VERSION}...
 cd /tmp/
-wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip -O vault.zip
+wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip -O vault.zip
 echo Installing Vault...
 unzip vault.zip
 sudo chmod +x vault

--- a/scripts/install_vault.sh
+++ b/scripts/install_vault.sh
@@ -5,7 +5,7 @@ set -e
 VAULT_VERSION="0.6.4"
 CURDIR=`pwd`
 
-if [[ $(vault version | cut -d ' ' -f 2) == "v$VAULT_VERSION" ]]; then
+if [[ $(which vault >/dev/null && vault version | cut -d ' ' -f 2) == "v$VAULT_VERSION" ]]; then
     echo "Vault v$VAULT_VERSION already installed; Skipping"
     exit
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-GOTEST_TAGS="nomad_test lxc"
+GOTEST_TAGS="nomad_test"
+if [[ $(uname) == "Linux" ]]; then
+	if pkg-config --exists lxc; then
+		GOTEST_TAGS="$GOTEST_TAGS lxc"
+	fi
+fi
 
 # Create a temp dir and clean it up on exit
 TEMPDIR=`mktemp -d -t nomad-test.XXX`
@@ -9,7 +14,7 @@ trap "rm -rf $TEMPDIR" EXIT HUP INT QUIT TERM
 
 # Build the Nomad binary for the API tests
 echo "--> Building nomad"
-go build -tags "$GOTEST_TAGS" -o $TEMPDIR/nomad || exit 1
+go build -i -tags "$GOTEST_TAGS" -o $TEMPDIR/nomad || exit 1
 
 # Run the tests
 echo "--> Running tests"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,7 +14,7 @@ trap "rm -rf $TEMPDIR" EXIT HUP INT QUIT TERM
 
 # Build the Nomad binary for the API tests
 echo "--> Building nomad"
-echo go build -i -tags "$GOTEST_TAGS" -o $TEMPDIR/nomad
+echo go build -i -tags \"$GOTEST_TAGS\" -o $TEMPDIR/nomad
 go build -i -tags "$GOTEST_TAGS" -o $TEMPDIR/nomad || exit 1
 
 # Run the tests

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,6 +14,7 @@ trap "rm -rf $TEMPDIR" EXIT HUP INT QUIT TERM
 
 # Build the Nomad binary for the API tests
 echo "--> Building nomad"
+echo go build -i -tags "$GOTEST_TAGS" -o $TEMPDIR/nomad
 go build -i -tags "$GOTEST_TAGS" -o $TEMPDIR/nomad || exit 1
 
 # Run the tests

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-export PING_SLEEP=30
+export PING_SLEEP=60
 bash -c "while true; do echo \$(date) - building ...; sleep $PING_SLEEP; done" &
 PING_LOOP_PID=$!
 


### PR DESCRIPTION
* Upgraded both Vagrantfiles to Xenial 16.04
* Upgraded deps (go, rkt, vault, consul)
* Drop `gox` in favor of individual build commands.
  * Already had to run the lxc build manually
  * Makes debugging cross-compiling issues a ton easier
  * go build can use multiple cores, so running multiple builds at once probably doesn't speed anything up
  * Our vm only has 1 core anyway
* `make dev` only builds lxc if lxc is installed
  * **TODO** put behind flag to make it optional!
  * Moved dev build out of the main build script since they didn't actually share that much