### PR TITLE
BUGFIX: fix consul verify_ssl merging

### DIFF
--- a/nomad/structs/config/consul.go
+++ b/nomad/structs/config/consul.go
@@ -121,7 +121,7 @@ func (a *ConsulConfig) Merge(b *ConsulConfig) *ConsulConfig {
 		result.EnableSSL = b.EnableSSL
 	}
 	if b.VerifySSL != nil {
-		result.VerifySSL = b.EnableSSL
+		result.VerifySSL = b.VerifySSL
 	}
 	if b.CAFile != "" {
 		result.CAFile = b.CAFile
@@ -180,19 +180,21 @@ func (c *ConsulConfig) ApiConfig() (*consul.Config, error) {
 		if c.VerifySSL != nil {
 			tlsConfig.InsecureSkipVerify = !*c.VerifySSL
 		}
-		tlsClientCfg, err := consul.SetupTLSConfig(&tlsConfig)
-		if err != nil {
-			return nil, fmt.Errorf("error creating tls client config for consul: %v", err)
-		}
-		config.HttpClient.Transport = &http.Transport{
-			TLSClientConfig: tlsClientCfg,
-		}
-	}
-	if c.EnableSSL != nil && !*c.VerifySSL {
-		config.HttpClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
+
+		if tlsConfig.InsecureSkipVerify {
+			config.HttpClient.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			}
+		} else {
+			tlsClientCfg, err := consul.SetupTLSConfig(&tlsConfig)
+			if err != nil {
+				return nil, fmt.Errorf("error creating tls client config for consul: %v", err)
+			}
+			config.HttpClient.Transport = &http.Transport{
+				TLSClientConfig: tlsClientCfg,
+			}
 		}
 	}
 

--- a/nomad/structs/config/consul.go
+++ b/nomad/structs/config/consul.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"strings"
@@ -181,20 +180,12 @@ func (c *ConsulConfig) ApiConfig() (*consul.Config, error) {
 			tlsConfig.InsecureSkipVerify = !*c.VerifySSL
 		}
 
-		if tlsConfig.InsecureSkipVerify {
-			config.HttpClient.Transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			}
-		} else {
-			tlsClientCfg, err := consul.SetupTLSConfig(&tlsConfig)
-			if err != nil {
-				return nil, fmt.Errorf("error creating tls client config for consul: %v", err)
-			}
-			config.HttpClient.Transport = &http.Transport{
-				TLSClientConfig: tlsClientCfg,
-			}
+		tlsClientCfg, err := consul.SetupTLSConfig(&tlsConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error creating tls client config for consul: %v", err)
+		}
+		config.HttpClient.Transport = &http.Transport{
+			TLSClientConfig: tlsClientCfg,
 		}
 	}
 


### PR DESCRIPTION
There are 2 issues with the tls code in 0.5.3-rc1:
1. typo in merging
2. one if statement that checks whether tls is enabled in tls config 