### PR TITLE
Disallow GC of  parameterized jobs

### DIFF
--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -192,6 +192,8 @@ func (c *CoreScheduler) evalGC(eval *structs.Evaluation) error {
 
 		// The Evaluation GC should not handle batch jobs since those need to be
 		// garbage collected in one shot
+		// XXX believe there is a bug that if a batch job gets stopped, there is no
+		// way for it to GC the eval/allocs
 		gc, allocs, err := c.gcEval(eval, oldThreshold, false)
 		if err != nil {
 			return err

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -149,9 +149,10 @@ func jobIsGCable(obj interface{}) (bool, error) {
 		return false, fmt.Errorf("Unexpected type: %v", obj)
 	}
 
-	// The job is GCable if it is batch and it is not periodic
+	// The job is GCable if it is batch, it is not periodic and is not a
+	// parameterized job.
 	periodic := j.Periodic != nil && j.Periodic.Enabled
-	gcable := j.Type == structs.JobTypeBatch && !periodic
+	gcable := j.Type == structs.JobTypeBatch && !periodic && !j.IsParameterized()
 	return gcable, nil
 }
 


### PR DESCRIPTION
This PR makes it so parameterized jobs do not get garbage collected and
adds a test.