### PR TITLE
Update the 'requirements.html.md' cluster docs with 'Ports Used'.

### DIFF
--- a/website/source/docs/cluster/requirements.html.md
+++ b/website/source/docs/cluster/requirements.html.md
@@ -54,3 +54,18 @@ are not participating in Raft. Thus clients can have 100+ millisecond latency to
 their servers. This allows having a set of Nomad servers that service clients
 that can be spread geographically over a continent or even the world in the case
 of having a single "global" region and many datacenter.
+
+## Ports Used
+
+Nomad requires up to 3 different ports to work properly, some on
+TCP, UDP, or both protocols. Below we document the requirements for each
+port.
+
+* HTTP API (Default 4646). This is used by clients to talk to the HTTP
+  API. TCP only.
+
+* Server RPC (Default 4647). This is used by servers to handle incoming
+  requests from other agents. TCP only.
+
+* Serf WAN (Default 4648). This is used by servers to gossip over the
+  WAN to other servers. TCP and UDP.


### PR DESCRIPTION
This adds a section detailing the ports and protocols used by Nomad. I have used the [Consul ports](https://www.consul.io/docs/agent/options.html#ports) documentation page as a basis for the wording and format.

If my knowledge is incorrect about the Nomad port setup, or the location/formatting is incorrect please let me know.

Closes #2120