### PR TITLE
Disallow root policy from being specified

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3238,21 +3238,28 @@ func (v *Vault) Validate() error {
 		return nil
 	}
 
+	var mErr multierror.Error
 	if len(v.Policies) == 0 {
-		return fmt.Errorf("Policy list cannot be empty")
+		multierror.Append(&mErr, fmt.Errorf("Policy list cannot be empty"))
+	}
+
+	for _, p := range v.Policies {
+		if p == "root" {
+			multierror.Append(&mErr, fmt.Errorf("Can not specifiy \"root\" policy"))
+		}
 	}
 
 	switch v.ChangeMode {
 	case VaultChangeModeSignal:
 		if v.ChangeSignal == "" {
-			return fmt.Errorf("Signal must be specified when using change mode %q", VaultChangeModeSignal)
+			multierror.Append(&mErr, fmt.Errorf("Signal must be specified when using change mode %q", VaultChangeModeSignal))
 		}
 	case VaultChangeModeNoop, VaultChangeModeRestart:
 	default:
-		return fmt.Errorf("Unknown change mode %q", v.ChangeMode)
+		multierror.Append(&mErr, fmt.Errorf("Unknown change mode %q", v.ChangeMode))
 	}
 
-	return nil
+	return mErr.ErrorOrNil()
 }
 
 const (

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1493,11 +1493,19 @@ func TestVault_Validate(t *testing.T) {
 		t.Fatalf("Expected policy list empty error")
 	}
 
-	v.Policies = []string{"foo"}
+	v.Policies = []string{"foo", "root"}
 	v.ChangeMode = VaultChangeModeSignal
 
-	if err := v.Validate(); err == nil || !strings.Contains(err.Error(), "Signal must") {
+	err := v.Validate()
+	if err == nil {
+		t.Fatalf("Expected validation errors")
+	}
+
+	if !strings.Contains(err.Error(), "Signal must") {
 		t.Fatalf("Expected signal empty error")
+	}
+	if !strings.Contains(err.Error(), "root") {
+		t.Fatalf("Expected root error")
 	}
 }
 


### PR DESCRIPTION
This PR disallows the specification of a root policy by a Nomad task.