### PR TITLE
Allow specification of template delimiters

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -307,6 +307,8 @@ type Template struct {
 	ChangeSignal *string
 	Splay        *time.Duration
 	Perms        *string
+	LeftDelim    *string
+	RightDelim   *string
 }
 
 func (tmpl *Template) Canonicalize() {
@@ -325,6 +327,12 @@ func (tmpl *Template) Canonicalize() {
 	if tmpl.ChangeSignal != nil {
 		sig := *tmpl.ChangeSignal
 		tmpl.ChangeSignal = helper.StringToPtr(strings.ToUpper(sig))
+	}
+	if tmpl.LeftDelim == nil {
+		tmpl.LeftDelim = helper.StringToPtr("{{")
+	}
+	if tmpl.RightDelim == nil {
+		tmpl.RightDelim = helper.StringToPtr("}}")
 	}
 }
 

--- a/client/consul_template.go
+++ b/client/consul_template.go
@@ -394,6 +394,8 @@ func parseTemplateConfigs(tmpls []*structs.Template, taskDir string,
 		ct.Source = &src
 		ct.Destination = &dest
 		ct.Contents = &tmpl.EmbeddedTmpl
+		ct.LeftDelim = &tmpl.LeftDelim
+		ct.RightDelim = &tmpl.RightDelim
 
 		// Set the permissions
 		if tmpl.Perms != "" {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -568,6 +568,8 @@ func apiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 			ChangeSignal: *template.ChangeSignal,
 			Splay:        *template.Splay,
 			Perms:        *template.Perms,
+			LeftDelim:    *template.LeftDelim,
+			RightDelim:   *template.RightDelim,
 		}
 	}
 	if apiTask.DispatchPayload != nil {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -709,6 +709,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 			Spec:            helper.StringToPtr("spec"),
 			SpecType:        helper.StringToPtr("cron"),
 			ProhibitOverlap: helper.BoolToPtr(true),
+			TimeZone:        helper.StringToPtr("test zone"),
 		},
 		ParameterizedJob: &api.ParameterizedJobConfig{
 			Payload:      "payload",
@@ -747,6 +748,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 				Tasks: []*api.Task{
 					{
 						Name:   "task1",
+						Leader: true,
 						Driver: "docker",
 						User:   "mary",
 						Config: map[string]interface{}{
@@ -840,6 +842,8 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								ChangeSignal: helper.StringToPtr("signal"),
 								Splay:        helper.TimeToPtr(1 * time.Minute),
 								Perms:        helper.StringToPtr("666"),
+								LeftDelim:    helper.StringToPtr("abc"),
+								RightDelim:   helper.StringToPtr("def"),
 							},
 						},
 						DispatchPayload: &api.DispatchPayloadConfig{
@@ -882,6 +886,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 			Spec:            "spec",
 			SpecType:        "cron",
 			ProhibitOverlap: true,
+			TimeZone:        "test zone",
 		},
 		ParameterizedJob: &structs.ParameterizedJobConfig{
 			Payload:      "payload",
@@ -921,6 +926,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 					{
 						Name:   "task1",
 						Driver: "docker",
+						Leader: true,
 						User:   "mary",
 						Config: map[string]interface{}{
 							"lol": "code",
@@ -1010,6 +1016,8 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								ChangeSignal: "SIGNAL",
 								Splay:        1 * time.Minute,
 								Perms:        "666",
+								LeftDelim:    "abc",
+								RightDelim:   "def",
 							},
 						},
 						DispatchPayload: &structs.DispatchPayloadConfig{

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -879,7 +879,9 @@ func parseTemplates(result *[]*api.Template, list *ast.ObjectList) error {
 			"change_signal",
 			"data",
 			"destination",
+			"left_delimiter",
 			"perms",
+			"right_delimiter",
 			"source",
 			"splay",
 		}

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -178,6 +178,8 @@ func TestParse(t *testing.T) {
 										ChangeSignal: "",
 										Splay:        5 * time.Second,
 										Perms:        "777",
+										LeftDelim:    "--",
+										RightDelim:   "__",
 									},
 								},
 								Leader: true,

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -147,6 +147,8 @@ job "binstore-storagelocker" {
         source = "bar"
         destination = "bar"
         perms = "777"
+        left_delimiter = "--"
+        right_delimiter = "__"
       }
     }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2671,6 +2671,11 @@ type Template struct {
 
 	// Perms is the permission the file should be written out with.
 	Perms string `mapstructure:"perms"`
+
+	// LeftDelim and RightDelim are optional configurations to control what
+	// delimiter is utilized when parsing the template.
+	LeftDelim  string `mapstructure:"left_delimiter"`
+	RightDelim string `mapstructure:"right_delimiter"`
 }
 
 // DefaultTemplate returns a default template.

--- a/website/source/docs/http/json-jobs.html.md
+++ b/website/source/docs/http/json-jobs.html.md
@@ -667,19 +667,6 @@ README][ct].
 
 `Template` object supports following attributes:
 
-* `SourcePath` - Specifies the path to the template to be rendered. `SourcePath`
-  is mutually exclusive with `EmbeddedTmpl` attribute. The source can be fetched
-  using an [`Artifact`](#artifact) resource. The template must exist on the
-  machine prior to starting the task; it is not possible to reference a template
-  inside of a Docker container, for example.
-
-* `EmbeddedTmpl` -  Specifies the raw template to execute. One of `SourcePath`
-  or `EmbeddedTmpl` must be specified, but not both. This is useful for smaller
-  templates, but we recommend using `SourcePath` for larger templates.
-
-* `DestPath` - Specifies the location where the resulting template should be
-  rendered, relative to the task directory.
-
 - `ChangeMode` - Specifies the behavior Nomad should take if the rendered
   template changes. The default value is `"restart"`. The possible values are:
 
@@ -691,8 +678,29 @@ README][ct].
   "SIGUSR1" or "SIGINT". This option is required if the `ChangeMode` is
   `signal`.
 
-* `perms` - Specifies the rendered template's permissions. File permissions are
+* `DestPath` - Specifies the location where the resulting template should be
+  rendered, relative to the task directory.
+
+* `EmbeddedTmpl` -  Specifies the raw template to execute. One of `SourcePath`
+  or `EmbeddedTmpl` must be specified, but not both. This is useful for smaller
+  templates, but we recommend using `SourcePath` for larger templates.
+
+* `LeftDelim` - Specifies the left delimiter to use in the template. The default
+  is "{{" for some templates, it may be easier to use a different delimiter that
+  does not conflict with the output file itself.
+
+* `Perms` - Specifies the rendered template's permissions. File permissions are
   given as octal of the unix file permissions rwxrwxrwx.
+
+* `RightDelim` - Specifies the right delimiter to use in the template. The default
+  is "}}" for some templates, it may be easier to use a different delimiter that
+  does not conflict with the output file itself.
+
+* `SourcePath` - Specifies the path to the template to be rendered. `SourcePath`
+  is mutually exclusive with `EmbeddedTmpl` attribute. The source can be fetched
+  using an [`Artifact`](#artifact) resource. The template must exist on the
+  machine prior to starting the task; it is not possible to reference a template
+  inside of a Docker container, for example.
 
 * `Splay` - Specifies a random amount of time to wait between 0ms and the given
   splay value before invoking the change mode. Should be specified in

--- a/website/source/docs/job-specification/template.html.md
+++ b/website/source/docs/job-specification/template.html.md
@@ -65,8 +65,16 @@ README][ct].
 - `destination` `(string: <required>)` - Specifies the location where the
   resulting template should be rendered, relative to the task directory.
 
+* `left_delimiter` `(string: "{{")` - Specifies the left delimiter to use in the
+  template. The default is "{{" for some templates, it may be easier to use a
+  different delimiter that does not conflict with the output file itself.
+
 - `perms` `(string: "666")` - Specifies the rendered template's permissions.
   File permissions are given as octal of the unix file permissions rwxrwxrwx.
+
+* `right_delimiter` `(string: "}}")` - Specifies the right delimiter to use in the
+  template. The default is "}}" for some templates, it may be easier to use a
+  different delimiter that does not conflict with the output file itself.
 
 - `source` `(string: "")` - Specifies the path to the template to be rendered.
   One of `source` or `data` must be specified, but not both. This source can


### PR DESCRIPTION
This PR adds support for specifying the delimiters used in the template.

Fixes https://github.com/hashicorp/nomad/issues/2312