### PR TITLE
Correct that rpc parameter doesn't enable serf tls

### DIFF
--- a/website/source/docs/agent/configuration/tls.html.md
+++ b/website/source/docs/agent/configuration/tls.html.md
@@ -50,9 +50,8 @@ the [Agent's Gossip and RPC Encryption](/docs/agent/encryption.html).
   endpoints on the Nomad agent, including the API.
 
 - `rpc` `(bool: false)` - Specifies if TLS should be enabled on the RPC
-  endpoints and [Raft][raft] traffic between the Nomad servers. Enabling this on
-  a Nomad client makes the client use TLS for making RPC requests to the Nomad
-  servers.
+  endpoints. Enabling this on a Nomad client makes the client use TLS for 
+  making RPC requests to the Nomad servers.
 
 - `verify_server_hostname` `(bool: false)` - Specifies if outgoing TLS
   connections should verify the server's hostname.
@@ -78,5 +77,3 @@ tls {
   key_file  = "/etc/certs/nomad.key"
 }
 ```
-
-[raft]: https://github.com/hashicorp/serf "Serf by HashiCorp"


### PR DESCRIPTION
Prove me wrong, but I cannot verify that Serf uses TLS for its TCP connections. The documentation of serf only vaguely mentions custom encrypted protocol on top of TCP:

> TCP provides a stream abstraction and therefore we must provide our own framing. This introduces a potential attack vector since we cannot verify the tag until the entire message is received, and the message length must be in plaintext.

> When we first receive a TCP encrypted message, we check the message type. If any party has encryption enabled, the other party must as well. Otherwise we are vulnerable to a downgrade attack where one side can force the other into a non-encrypted mode of operation.

https://www.serf.io/docs/internals/security.html
