### PR TITLE
Add allocated/unallocated metrics to client

### DIFF
--- a/demo/vagrant/client1.hcl
+++ b/demo/vagrant/client1.hcl
@@ -22,14 +22,7 @@ client {
     }
     reserved {
        cpu = 500
-       memory = 512
-       disk = 1024
     }
-}
-
-telemetry {
-  publish_allocation_metrics = true
-  publish_node_metrics       = true 
 }
 
 # Modify our port to avoid a collision with server1

--- a/demo/vagrant/client1.hcl
+++ b/demo/vagrant/client1.hcl
@@ -22,7 +22,14 @@ client {
     }
     reserved {
        cpu = 500
+       memory = 512
+       disk = 1024
     }
+}
+
+telemetry {
+  publish_allocation_metrics = true
+  publish_node_metrics       = true 
 }
 
 # Modify our port to avoid a collision with server1

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -239,13 +239,75 @@ page for more details.
     <th>Type</th>
   </tr>
   <tr>
-    <td>`nomad.client.host.memmory.<HostID>.total`</td>
+    <td>`nomad.client.allocated.cpu.<HostID>`</td>
+    <td>Total amount of CPU shares the scheduler has allocated to tasks</td>
+    <td>MHz</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.unallocated.cpu.<HostID>`</td>
+    <td>Total amount of CPU shares free for the scheduler to allocate to tasks</td>
+    <td>MHz</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.allocated.memory.<HostID>`</td>
+    <td>Total amount of memory the scheduler has allocated to tasks</td>
+    <td>Megabytes</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.unallocated.memory.<HostID>`</td>
+    <td>Total amount of memory free for the scheduler to allocate to tasks</td>
+    <td>Megabytes</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.allocated.disk.<HostID>`</td>
+    <td>Total amount of disk space the scheduler has allocated to tasks</td>
+    <td>Megabytes</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.unallocated.disk.<HostID>`</td>
+    <td>Total amount of disk space free for the scheduler to allocate to tasks</td>
+    <td>Megabytes</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.allocated.iops.<HostID>`</td>
+    <td>Total amount of IOPS the scheduler has allocated to tasks</td>
+    <td>IOPS</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.unallocated.iops.<HostID>`</td>
+    <td>Total amount of IOPS free for the scheduler to allocate to tasks</td>
+    <td>IOPS</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.allocated.network.<Device-Name>.<HostID>`</td>
+    <td>Total amount of bandwidth the scheduler has allocated to tasks on the
+    given device</td>
+    <td>Megabits</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.unallocated.network.<Device-Name>.<HostID>`</td>
+    <td>Total amount of bandwidth free for the scheduler to allocate to tasks on
+    the given device</td>
+    <td>Megabits</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.host.memory.<HostID>.total`</td>
     <td>Total amount of physical memory on the node</td>
     <td>Bytes</td>
     <td>Gauge</td>
   </tr>
   <tr>
-    <td>`nomad.client.host.memmory.<HostID>.available`</td>
+    <td>`nomad.client.host.memory.<HostID>.available`</td>
     <td>Total amount of memory available to processes which includes free and
     cached memory</td>
     <td>Bytes</td>


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/2191

```
'nomad.client.allocated.cpu.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 500.000
'nomad.client.allocated.disk.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 300.000
'nomad.client.allocated.iops.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 0.000
'nomad.client.allocated.memory.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 256.000
'nomad.client.allocated.network.ens32.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 10.000
'nomad.client.unallocated.cpu.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 7709.000
'nomad.client.unallocated.disk.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 31287.000
'nomad.client.unallocated.iops.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 0.000
'nomad.client.unallocated.memory.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 1232.000
'nomad.client.unallocated.network.ens32.564dc0c6-1749-0d38-34f7-a3dfe5b8d22d': 990.000
```