### PR TITLE
Add chroot_bindings for exec driver to configure bind-mounts

### DIFF
--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -229,7 +229,7 @@ func (d *AllocDir) UnmountAll() error {
 		}
 
 		// Unmount dev/ and proc/ have been mounted.
-		if err := dir.unmountSpecialDirs(); err != nil {
+		if err := dir.unmount(); err != nil {
 			mErr.Errors = append(mErr.Errors, err)
 		}
 	}

--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -106,11 +106,11 @@ func TestAllocDir_MountSharedAlloc(t *testing.T) {
 
 	// Build 2 task dirs
 	td1 := d.NewTaskDir(t1.Name)
-	if err := td1.Build(false, nil, cstructs.FSIsolationChroot); err != nil {
+	if err := td1.Build(false, nil, nil, cstructs.FSIsolationChroot); err != nil {
 		t.Fatalf("error build task=%q dir: %v", t1.Name, err)
 	}
 	td2 := d.NewTaskDir(t2.Name)
-	if err := td2.Build(false, nil, cstructs.FSIsolationChroot); err != nil {
+	if err := td2.Build(false, nil, nil, cstructs.FSIsolationChroot); err != nil {
 		t.Fatalf("error build task=%q dir: %v", t2.Name, err)
 	}
 
@@ -151,11 +151,11 @@ func TestAllocDir_Snapshot(t *testing.T) {
 
 	// Build 2 task dirs
 	td1 := d.NewTaskDir(t1.Name)
-	if err := td1.Build(false, nil, cstructs.FSIsolationImage); err != nil {
+	if err := td1.Build(false, nil, nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("error build task=%q dir: %v", t1.Name, err)
 	}
 	td2 := d.NewTaskDir(t2.Name)
-	if err := td2.Build(false, nil, cstructs.FSIsolationImage); err != nil {
+	if err := td2.Build(false, nil, nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("error build task=%q dir: %v", t2.Name, err)
 	}
 
@@ -225,7 +225,7 @@ func TestAllocDir_Move(t *testing.T) {
 	defer d2.Destroy()
 
 	td1 := d1.NewTaskDir(t1.Name)
-	if err := td1.Build(false, nil, cstructs.FSIsolationImage); err != nil {
+	if err := td1.Build(false, nil, nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("TaskDir.Build() faild: %v", err)
 	}
 
@@ -322,7 +322,7 @@ func TestAllocDir_ReadAt_SecretDir(t *testing.T) {
 	defer d.Destroy()
 
 	td := d.NewTaskDir(t1.Name)
-	if err := td.Build(false, nil, cstructs.FSIsolationImage); err != nil {
+	if err := td.Build(false, nil, nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("TaskDir.Build() failed: %v", err)
 	}
 

--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -32,7 +32,7 @@ func linkDir(src, dst string) error {
 // hardlinking directories. If the dir is already unmounted no error is
 // returned.
 func unlinkDir(dir string) error {
-	if err := syscall.Unmount(dir, 0); err != nil {
+	if err := syscall.Unmount(dir, syscall.MNT_DETACH); err != nil {
 		if err != syscall.EINVAL {
 			return err
 		}

--- a/client/allocdir/task_dir_linux.go
+++ b/client/allocdir/task_dir_linux.go
@@ -24,9 +24,11 @@ func (t *TaskDir) mountSpecialDirs() error {
 		return fmt.Errorf("error listing %q: %v", dev, err)
 	}
 	if devEmpty {
+		fstype := "devtmpfs"
 		if err := syscall.Mount("none", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
 			return fmt.Errorf("Couldn't mount /dev to %v: %v", dev, err)
 		}
+		t.Mounts[dev] = fstype
 	}
 
 	// Mount proc
@@ -41,37 +43,77 @@ func (t *TaskDir) mountSpecialDirs() error {
 		return fmt.Errorf("error listing %q: %v", proc, err)
 	}
 	if procEmpty {
+		fstype := "proc"
 		if err := syscall.Mount("none", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
 			return fmt.Errorf("Couldn't mount /proc to %v: %v", proc, err)
 		}
+		t.Mounts[proc] = fstype
 	}
 
 	return nil
 }
 
-// unmountSpecialDirs unmounts the dev and proc file system from the chroot. No
-// error is returned if the directories do not exist or have already been
-// unmounted.
-func (t *TaskDir) unmountSpecialDirs() error {
+// unmount unmounts all the mounts within task dir (special dirs and rbind mounts)
+func (t *TaskDir) unmount() error {
 	errs := new(multierror.Error)
-	dev := filepath.Join(t.Dir, "dev")
-	if pathExists(dev) {
-		if err := unlinkDir(dev); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("Failed to unmount dev %q: %v", dev, err))
-		} else if err := os.RemoveAll(dev); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("Failed to delete dev directory %q: %v", dev, err))
-		}
-	}
 
-	// Unmount proc.
-	proc := filepath.Join(t.Dir, "proc")
-	if pathExists(proc) {
-		if err := unlinkDir(proc); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("Failed to unmount proc %q: %v", proc, err))
-		} else if err := os.RemoveAll(proc); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("Failed to delete proc directory %q: %v", dev, err))
+	for mountPoint, mountType := range t.Mounts {
+		if pathExists(mountPoint) {
+			if err := unlinkDir(mountPoint); err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("Failed to unmount %v (%v): %v", mountPoint, mountType, err))
+			} else if err := os.RemoveAll(mountPoint); err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("Failed to delete %v (%v): %v", mountPoint, mountType, err))
+			}
 		}
 	}
 
 	return errs.ErrorOrNil()
+}
+
+// bindDirs rbind-mounts files & dirs from the host to the chroot
+func (t *TaskDir) bindDirs(entries map[string]string) error {
+	for src, dst := range entries {
+		// Check to see if file/directory exists on host.
+		s, err := os.Stat(src)
+		if os.IsNotExist(err) {
+			continue
+		}
+
+		path := filepath.Join(t.Dir, dst)
+		if !pathExists(path) {
+			if s.IsDir() {
+				if err := os.MkdirAll(path, s.Mode()); err != nil {
+					return fmt.Errorf("Mkdir(%v) failed: %v", path, err)
+				}
+			} else {
+				sourceDir := filepath.Dir(src)
+				sourceDirStat, err := os.Stat(sourceDir)
+
+				if err != nil {
+					return fmt.Errorf("Stat(%v) failed: %v", sourceDir, err)
+				}
+
+				destDir := filepath.Dir(path)
+				if !pathExists(destDir) {
+					if err := os.MkdirAll(destDir, sourceDirStat.Mode()); err != nil {
+						return fmt.Errorf("Mkdir(%v) failed: %v", destDir, err)
+					}
+				}
+				newFile, err := os.Create(path)
+				if err != nil {
+					return fmt.Errorf("Create(%v) failed: %v", path, err)
+				}
+				newFile.Close()
+			}
+
+			// syscall.MS_PRIVATE - don't propagate unmount to the nested mounts
+			// syscall.MS_BIND|syscall.MS_REC - include nested mounts
+			if err := syscall.Mount(src, path, "", syscall.MS_PRIVATE|syscall.MS_BIND|syscall.MS_REC, ""); err != nil {
+				return fmt.Errorf("Couldn't mount %s to %v: %v", src, path, err)
+			}
+			t.Mounts[path] = src
+		}
+	}
+
+	return nil
 }

--- a/client/allocdir/task_dir_test.go
+++ b/client/allocdir/task_dir_test.go
@@ -103,7 +103,7 @@ func TestTaskDir_NonRoot_Image(t *testing.T) {
 		t.Fatalf("Build() failed: %v", err)
 	}
 
-	if err := td.Build(false, nil, cstructs.FSIsolationImage); err != nil {
+	if err := td.Build(false, nil, nil, cstructs.FSIsolationImage); err != nil {
 		t.Fatalf("TaskDir.Build failed: %v", err)
 	}
 }
@@ -126,7 +126,7 @@ func TestTaskDir_NonRoot(t *testing.T) {
 		t.Fatalf("Build() failed: %v", err)
 	}
 
-	if err := td.Build(false, nil, cstructs.FSIsolationNone); err != nil {
+	if err := td.Build(false, nil, nil, cstructs.FSIsolationNone); err != nil {
 		t.Fatalf("TaskDir.Build failed: %v", err)
 	}
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -53,6 +53,7 @@ var (
 		"/sbin":           "/sbin",
 		"/usr":            "/usr",
 	}
+	DefaultChrootBindings = map[string]string{}
 )
 
 // RPCHandler can be provided to the Client if there is a local server
@@ -121,6 +122,10 @@ type Config struct {
 	// A mapping of directories on the host OS to attempt to embed inside each
 	// task's chroot.
 	ChrootEnv map[string]string
+
+	// A mapping of files/directories on the host OS to attempt to bind-mount inside each
+	// task's chroot.
+	ChrootBindings map[string]string
 
 	// Options provides arbitrary key-value configuration for nomad internals,
 	// like fingerprinters and drivers. The format is:

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1171,7 +1171,7 @@ func setupDockerVolumes(t *testing.T, cfg *config.Config, hostpath string) (*str
 		t.Fatalf("failed to build alloc dir: %v", err)
 	}
 	taskDir := allocDir.NewTaskDir(task.Name)
-	if err := taskDir.Build(false, nil, cstructs.FSIsolationImage); err != nil {
+	if err := taskDir.Build(false, nil, nil, cstructs.FSIsolationImage); err != nil {
 		allocDir.Destroy()
 		t.Fatalf("failed to build task dir: %v", err)
 	}

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -104,7 +104,7 @@ func testDriverContexts(t *testing.T, task *structs.Task) *testContext {
 
 	// Build the task dir
 	td := allocDir.NewTaskDir(task.Name)
-	if err := td.Build(false, config.DefaultChrootEnv, tmpdrv.FSIsolation()); err != nil {
+	if err := td.Build(false, config.DefaultChrootEnv, config.DefaultChrootBindings, tmpdrv.FSIsolation()); err != nil {
 		allocDir.Destroy()
 		t.Fatalf("TaskDir.Build(%#v, %q) failed: %v", config.DefaultChrootEnv, tmpdrv.FSIsolation(), err)
 		return nil

--- a/client/driver/executor/executor_linux_test.go
+++ b/client/driver/executor/executor_linux_test.go
@@ -45,7 +45,7 @@ func testExecutorContextWithChroot(t *testing.T) (*ExecutorContext, *allocdir.Al
 	if err := allocDir.Build(); err != nil {
 		log.Fatalf("AllocDir.Build() failed: %v", err)
 	}
-	if err := allocDir.NewTaskDir(task.Name).Build(false, chrootEnv, cstructs.FSIsolationChroot); err != nil {
+	if err := allocDir.NewTaskDir(task.Name).Build(false, chrootEnv, nil, cstructs.FSIsolationChroot); err != nil {
 		allocDir.Destroy()
 		log.Fatalf("allocDir.NewTaskDir(%q) failed: %v", task.Name, err)
 	}

--- a/client/driver/executor/executor_test.go
+++ b/client/driver/executor/executor_test.go
@@ -49,7 +49,7 @@ func testExecutorContext(t *testing.T) (*ExecutorContext, *allocdir.AllocDir) {
 	if err := allocDir.Build(); err != nil {
 		log.Fatalf("AllocDir.Build() failed: %v", err)
 	}
-	if err := allocDir.NewTaskDir(task.Name).Build(false, nil, cstructs.FSIsolationNone); err != nil {
+	if err := allocDir.NewTaskDir(task.Name).Build(false, nil, nil, cstructs.FSIsolationNone); err != nil {
 		allocDir.Destroy()
 		log.Fatalf("allocDir.NewTaskDir(%q) failed: %v", task.Name, err)
 	}

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1237,12 +1237,17 @@ func (r *TaskRunner) buildTaskDir(fsi cstructs.FSIsolation) error {
 		r.setState(structs.TaskStatePending, structs.NewTaskEvent(structs.TaskSetup).
 			SetMessage(structs.TaskBuildingTaskDir))
 	}
-
-	chroot := config.DefaultChrootEnv
+	links := config.DefaultChrootEnv
 	if len(r.config.ChrootEnv) > 0 {
-		chroot = r.config.ChrootEnv
+		links = r.config.ChrootEnv
 	}
-	if err := r.taskDir.Build(built, chroot, fsi); err != nil {
+
+	bindings := config.DefaultChrootBindings
+	if len(r.config.ChrootBindings) > 0 {
+		bindings = r.config.ChrootBindings
+	}
+
+	if err := r.taskDir.Build(built, links, bindings, fsi); err != nil {
 		return err
 	}
 

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -98,7 +98,7 @@ func testTaskRunnerFromAlloc(t *testing.T, restarts bool, alloc *structs.Allocat
 		fsi = cstructs.FSIsolationChroot
 	}
 	taskDir := allocDir.NewTaskDir(task.Name)
-	if err := taskDir.Build(false, config.DefaultChrootEnv, fsi); err != nil {
+	if err := taskDir.Build(false, config.DefaultChrootEnv, config.DefaultChrootBindings, fsi); err != nil {
 		t.Fatalf("error building task dir %q: %v", task.Name, err)
 		return nil
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -240,6 +240,7 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 		conf.NetworkInterface = a.config.Client.NetworkInterface
 	}
 	conf.ChrootEnv = a.config.Client.ChrootEnv
+	conf.ChrootBindings = a.config.Client.ChrootBindings
 	conf.Options = a.config.Client.Options
 	// Logging deprecation messages about consul related configuration in client
 	// options

--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -37,6 +37,9 @@ client {
 		"/opt/myapp/etc" = "/etc"
 		"/opt/myapp/bin" = "/bin"
 	}
+	chroot_bindings {
+        "/opt/myapp/var" = "/var"
+    }
 	network_interface = "eth0"
 	network_speed = 100
 	cpu_total_compute = 4444

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -175,6 +175,10 @@ type ClientConfig struct {
 	// task's chroot.
 	ChrootEnv map[string]string `mapstructure:"chroot_env"`
 
+	// A mapping of files/directories on the host OS to attempt to bind-mount inside each
+	// task's chroot.
+	ChrootBindings map[string]string `mapstructure:"chroot_bindings"`
+
 	// Interface to use for network fingerprinting
 	NetworkInterface string `mapstructure:"network_interface"`
 
@@ -978,6 +982,14 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 	for k, v := range b.ChrootEnv {
 		result.ChrootEnv[k] = v
+	}
+
+	// Add the chroot_bindings map values
+	if result.ChrootBindings == nil {
+		result.ChrootBindings = make(map[string]string)
+	}
+	for k, v := range b.ChrootBindings {
+		result.ChrootBindings[k] = v
 	}
 
 	return &result

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -334,6 +334,7 @@ func parseClient(result **ClientConfig, list *ast.ObjectList) error {
 		"options",
 		"meta",
 		"chroot_env",
+		"chroot_bindings",
 		"network_interface",
 		"network_speed",
 		"cpu_total_compute",
@@ -360,6 +361,7 @@ func parseClient(result **ClientConfig, list *ast.ObjectList) error {
 	delete(m, "options")
 	delete(m, "meta")
 	delete(m, "chroot_env")
+	delete(m, "chroot_bindings")
 	delete(m, "reserved")
 	delete(m, "stats")
 
@@ -413,6 +415,20 @@ func parseClient(result **ClientConfig, list *ast.ObjectList) error {
 				return err
 			}
 			if err := mapstructure.WeakDecode(m, &config.ChrootEnv); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Parse out chroot_bindings fields. These are in HCL as a list so we need to
+	// iterate over them and merge them.
+	if chrootBindingsO := listVal.Filter("chroot_bindings"); len(chrootBindingsO.Items) > 0 {
+		for _, o := range chrootBindingsO.Elem().Items {
+			var m map[string]interface{}
+			if err := hcl.DecodeObject(&m, o.Val); err != nil {
+				return err
+			}
+			if err := mapstructure.WeakDecode(m, &config.ChrootBindings); err != nil {
 				return err
 			}
 		}

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -57,6 +57,9 @@ func TestConfig_Parse(t *testing.T) {
 						"/opt/myapp/etc": "/etc",
 						"/opt/myapp/bin": "/bin",
 					},
+					ChrootBindings: map[string]string{
+						"/opt/myapp/var": "/var",
+					},
 					NetworkInterface: "eth0",
 					NetworkSpeed:     100,
 					CpuCompute:       4444,

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -200,6 +200,7 @@ func TestConfig_Merge(t *testing.T) {
 				"baz": "zip",
 			},
 			ChrootEnv:      map[string]string{},
+			ChrootBindings: map[string]string{},
 			ClientMaxPort:  20000,
 			ClientMinPort:  22000,
 			NetworkSpeed:   105,


### PR DESCRIPTION
Addresses #2115.

As ability to bind-mount parts of host FS while running under `exec` driver is essential for our organization to be able to adopt Nomad I decided to give it a shot. I've made a build from this branch and it runs without an issue on dozens of hosts while we continue our experiments with Nomad. Would be amazing if it could become a part of Nomad itself.

In terms of the implementation I think it's done although it'd be nice to add few tests. Also I'm not sure about styling - whether config option name is appropriate and so on so I decided to bounce this PR with Hashicorp and community. If it's something you don't mind to merge into the core I'd be glad to polish the PR unless you're happy with it or handle the sources to you (well, I already did that :) ) if you prefer to finish it on your own.

Please let me know what you think.