### PR TITLE
Fix API panic and bad missing port check

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -118,7 +118,7 @@ func TestSetQueryOptions(t *testing.T) {
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
-	r := c.newRequest("GET", "/v1/jobs")
+	r, _ := c.newRequest("GET", "/v1/jobs")
 	q := &QueryOptions{
 		Region:     "foo",
 		AllowStale: true,
@@ -145,7 +145,7 @@ func TestSetWriteOptions(t *testing.T) {
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
-	r := c.newRequest("GET", "/v1/jobs")
+	r, _ := c.newRequest("GET", "/v1/jobs")
 	q := &WriteOptions{
 		Region: "foo",
 	}
@@ -160,7 +160,7 @@ func TestRequestToHTTP(t *testing.T) {
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
-	r := c.newRequest("DELETE", "/v1/jobs/foo")
+	r, _ := c.newRequest("DELETE", "/v1/jobs/foo")
 	q := &QueryOptions{
 		Region: "foo",
 	}
@@ -222,7 +222,7 @@ func TestQueryString(t *testing.T) {
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
-	r := c.newRequest("PUT", "/v1/abc?foo=bar&baz=zip")
+	r, _ := c.newRequest("PUT", "/v1/abc?foo=bar&baz=zip")
 	q := &WriteOptions{Region: "foo"}
 	r.setWriteOptions(q)
 

--- a/api/operator.go
+++ b/api/operator.go
@@ -45,7 +45,10 @@ type RaftConfiguration struct {
 
 // RaftGetConfiguration is used to query the current Raft peer set.
 func (op *Operator) RaftGetConfiguration(q *QueryOptions) (*RaftConfiguration, error) {
-	r := op.c.newRequest("GET", "/v1/operator/raft/configuration")
+	r, err := op.c.newRequest("GET", "/v1/operator/raft/configuration")
+	if err != nil {
+		return nil, err
+	}
 	r.setQueryOptions(q)
 	_, resp, err := requireOK(op.c.doRequest(r))
 	if err != nil {
@@ -64,7 +67,10 @@ func (op *Operator) RaftGetConfiguration(q *QueryOptions) (*RaftConfiguration, e
 // quorum but no longer known to Serf or the catalog) by address in the form of
 // "IP:port".
 func (op *Operator) RaftRemovePeerByAddress(address string, q *WriteOptions) error {
-	r := op.c.newRequest("DELETE", "/v1/operator/raft/peer")
+	r, err := op.c.newRequest("DELETE", "/v1/operator/raft/peer")
+	if err != nil {
+		return err
+	}
 	r.setWriteOptions(q)
 
 	// TODO (alexdadgar) Currently we made address a query parameter. Once

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -809,7 +809,7 @@ func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string
 func isMissingPort(err error) bool {
 	// matches error const in net/ipsock.go
 	const missingPort = "missing port in address"
-	return err != nil && strings.HasPrefix(err.Error(), missingPort)
+	return err != nil && strings.Contains(err.Error(), missingPort)
 }
 
 // Merge is used to merge two server configs together


### PR DESCRIPTION
The format of the missing port error message changed from Go 1.7 to 1.8.
The fix is to just use strings.Contains instead of strings.HasPrefix
when looking for the "missing port" part: https://github.com/golang/go/commit/866e01457f69b58b31ccb95f223aac80e1285332#diff-ae34eb42831ffecf011ea43c6429582c

Also add an error return to Client.newRequest as parsing the path
processes arbitrary user input and would panic if given an invalid URL.

See: https://groups.google.com/d/topic/nomad-tool/gi3-CTE7oXo/discussion