### PR TITLE
Skip setting MemorySwap on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ BUG FIXES:
   * client: Fix race condition with deriving vault tokens [GH-2275]
   * config: Fix Consul Config Merging/Copying [GH-2278]
   * config: Fix Client reserved resource merging panic [GH-2281]
+  * driver/docker: Fix Docker 1.13 on Windows [GH-2342]
   * server: Fix panic when forwarding Vault derivation requests from non-leader
     servers [GH-2267]
 

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -753,8 +753,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 
 	hostConfig := &docker.HostConfig{
 		// Convert MB to bytes. This is an absolute value.
-		Memory:     memLimit,
-		MemorySwap: memLimit, // MemorySwap is memory + swap.
+		Memory: memLimit,
 		// Convert Mhz to shares. This is a relative value.
 		CPUShares: int64(task.Resources.CPU),
 
@@ -762,6 +761,11 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 		// local directory for storage and a shared alloc directory that can be
 		// used to share data between different tasks in the same task group.
 		Binds: binds,
+	}
+
+	// Windows does not support MemorySwap #2193
+	if runtime.GOOS != "windows" {
+		hostConfig.MemorySwap = memLimit // MemorySwap is memory + swap.
 	}
 
 	if len(driverConfig.Logging) != 0 {


### PR DESCRIPTION
Windows doesn't support this Docker setting.

Fixes #2193