### PR TITLE
Fix the GO_VERSION in the Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 DEFAULT_CPU_COUNT = 2
 $script = <<SCRIPT
-GO_VERSION="1.8.0"
+GO_VERSION="1.8"
 
 export DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
  * Change the GO_VERSION to match the correct upstream version from
    (https://storage.googleapis.com/golang/)