### PR TITLE
Put access to Docker volume drivers behind flag

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -680,6 +680,10 @@ func (d *DockerDriver) containerBinds(driverConfig *DockerDriverConfig, taskDir 
 
 	volumesEnabled := d.config.ReadBoolDefault(dockerVolumesConfigOption, dockerVolumesConfigDefault)
 
+	if !volumesEnabled && driverConfig.VolumeDriver != "" {
+		return nil, fmt.Errorf("%s is false; cannot use volume driver %q", dockerVolumesConfigOption, driverConfig.VolumeDriver)
+	}
+
 	for _, userbind := range driverConfig.Volumes {
 		parts := strings.Split(userbind, ":")
 		if len(parts) < 2 {

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1243,6 +1243,20 @@ func TestDockerDriver_VolumesDisabled(t *testing.T) {
 		}
 	}
 
+	// Volume Drivers should be rejected (error)
+	{
+		task, driver, execCtx, _, cleanup := setupDockerVolumes(t, cfg, "fake_flocker_vol")
+		defer cleanup()
+		task.Config["volume_driver"] = "flocker"
+
+		if _, err := driver.Prestart(execCtx, task); err != nil {
+			t.Fatalf("error in prestart: %v", err)
+		}
+		if _, err := driver.Start(execCtx, task); err == nil {
+			t.Fatalf("Started driver successfully when volume drivers should have been disabled.")
+		}
+	}
+
 }
 
 func TestDockerDriver_VolumesEnabled(t *testing.T) {

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -204,7 +204,8 @@ The `docker` driver supports the following configuration in the job spec:
 * `volume_driver` - (Optional) The name of the volume driver used to mount
   volumes. Must be used along with `volumes`.
   Using a `volume_driver` also allows to use `volumes` with a named volume as
-  well as regular paths.
+  well as absolute paths. If `docker.volumes.enabled` is false then volume
+  drivers are disallowed.
 
   ```hcl
     config {
@@ -410,8 +411,9 @@ options](/docs/agent/configuration/client.html#options):
   prevent Nomad from removing images from stopped tasks.
 
 * `docker.volumes.enabled`: Defaults to `true`. Allows tasks to bind host paths
-  (`volumes`) inside their container. Binding relative paths is always allowed
-  and will be resolved relative to the allocation's directory.
+  (`volumes`) inside their container and use volume drivers (`volume_driver`).
+  Binding relative paths is always allowed and will be resolved relative to the
+  allocation's directory.
 
 * `docker.volumes.selinuxlabel`: Allows the operator to set a SELinux
   label to the allocation and task local bind-mounts to containers. If used


### PR DESCRIPTION
Missed this when merging #2351 -- we need to put it behind the same flag as absolute path volumes as both allow full system access. (The flag allows absolute paths and volume drivers by default.)