### PR TITLE
add data_dir to server and client configuration

### DIFF
--- a/website/source/guides/cluster/automatic.html.md
+++ b/website/source/guides/cluster/automatic.html.md
@@ -38,6 +38,8 @@ the following Nomad configuration file:
 ```hcl
 # /etc/nomad.d/server.hcl
 
+data_dir = "/etc/nomad.d"
+
 server {
   enabled          = true
   bootstrap_expect = 3
@@ -56,6 +58,7 @@ A similar configuration is available for Nomad clients:
 # /etc/nomad.d/client.hcl
 
 datacenter = "dc1"
+data_dir   = "/etc/nomad.d"
 
 client {
   enabled = true


### PR DESCRIPTION
This changes adds `data_dir` to the configuration files for server and client which allow the example to run without further changes.