### PR TITLE
Do not soft purge

### DIFF
--- a/website/scripts/deploy.sh
+++ b/website/scripts/deploy.sh
@@ -89,7 +89,7 @@ if [ -z "$NO_UPLOAD" ]; then
     modify "s3://hc-sites/$PROJECT/latest/"
 fi
 
-# Perform a soft-purge of the surrogate key.
+# Perform a purge of the surrogate key.
 if [ -z "$NO_PURGE" ]; then
   echo "Purging Fastly cache..."
   curl \
@@ -99,7 +99,6 @@ if [ -z "$NO_PURGE" ]; then
     --request "POST" \
     --header "Accept: application/json" \
     --header "Fastly-Key: $FASTLY_API_KEY" \
-    --header "Fastly-Soft-Purge: 1" \
     "https://api.fastly.com/service/$FASTLY_SERVICE_ID/purge/site-$PROJECT"
 fi
 


### PR DESCRIPTION
Soft purging is great, but we warm the cache immediately after deploy, and even then, if a user happens to be visiting the site in that few hundred milliseconds, they eat the time of a Fastly-S3 lookup, which is still 100x better than 99% of the websites out there.