### PR TITLE
Fix syntax of docker.cleanup.image example

### DIFF
--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -445,7 +445,7 @@ An example is given below:
 
 ```hcl
 client {
-  options = {
+  options {
     "docker.cleanup.image" = "false"
   }
 }


### PR DESCRIPTION
I found this syntax issue because I copy-pasted the snippet into my config file and attempted to run Nomad with it. Whoops