### PR TITLE
Add caveat about always pulling latest tag to docker driver docs

### DIFF
--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -33,8 +33,9 @@ The `docker` driver supports the following configuration in the job spec:
 
 * `image` - The Docker image to run. The image may include a tag or custom URL
   and should include `https://` if required. By default it will be fetched from
-  Docker Hub. If the image to be pulled exists in a registry that requires
-  authentication credentials must be provided to Nomad. Please see the
+  Docker Hub. If the tag is omitted or equal to `latest` the driver will always
+  try to pull the image. If the image to be pulled exists in a registry that
+  requires authentication credentials must be provided to Nomad. Please see the
   [Authentication section](#authentication).
 
     ```hcl


### PR DESCRIPTION
Hey,

Today we found out that if the tag is not specified in the docker driver's `image` parameter, [the image is always being pulled](https://github.com/hashicorp/nomad/blob/33133a3a496775313359b868a19fd2eff50517e7/client/driver/docker.go#L962). It might make sense to put this information also to the docs.