### PR TITLE
Don't exec uname for node attribute kernel.version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ IMPROVEMENTS:
   * client: Don't force uppercase meta keys in env vars [GH-2338]
   * client: Reproducible Node ID on OSes that provide system-level UUID
     [GH-2277]
+  * client: Don't exec `uname -r` for node attribute kernel.version [GH-2380]
   * driver/docker: Add support for volume drivers [GH-2351]
   * driver/docker: Docker image coordinator and caching [GH-2361]
   * jobspec: Add leader task to allow graceful shutdown of other tasks within

--- a/client/fingerprint/host.go
+++ b/client/fingerprint/host.go
@@ -32,11 +32,7 @@ func (f *HostFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) (b
 	node.Attributes["os.version"] = hostInfo.PlatformVersion
 
 	node.Attributes["kernel.name"] = runtime.GOOS
-	node.Attributes["kernel.version"] = ""
-
-	if runtime.GOOS != "windows" {
-		node.Attributes["kernel.version"] = hostInfo.KernelVersion
-	}
+	node.Attributes["kernel.version"] = hostInfo.KernelVersion
 
 	node.Attributes["unique.hostname"] = hostInfo.Hostname
 

--- a/client/fingerprint/host.go
+++ b/client/fingerprint/host.go
@@ -1,11 +1,8 @@
 package fingerprint
 
 import (
-	"fmt"
 	"log"
-	"os/exec"
 	"runtime"
-	"strings"
 
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -38,11 +35,7 @@ func (f *HostFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) (b
 	node.Attributes["kernel.version"] = ""
 
 	if runtime.GOOS != "windows" {
-		out, err := exec.Command("uname", "-r").Output()
-		if err != nil {
-			return false, fmt.Errorf("Failed to run uname: %s", err)
-		}
-		node.Attributes["kernel.version"] = strings.Trim(string(out), "\n")
+		node.Attributes["kernel.version"] = hostInfo.KernelVersion
 	}
 
 	node.Attributes["unique.hostname"] = hostInfo.Hostname


### PR DESCRIPTION
Previously with client fingerprinting, sys/exec's Command
function was being used to execute `uname -r` and the return
string processed into the kernel.version node attribute.

This change uses gopsutil/host KernelVersion function
instead.  This means we can drop the os/exec, strings and
fmt imports... and not execute an external binary.

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>