### PR TITLE
Fix spelling error for CGO_ENABLED variable in build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,11 +46,11 @@ for target in $targets; do
             ;;
         "linux_amd64")
             echo "==> Building linux amd64..."
-            CGO_ENBALED=1 GOARCH="amd64" GOOS="linux" go build -ldflags "-X $LDFLAG" -o "pkg/linux_amd64/nomad"
+            CGO_ENABLED=1 GOARCH="amd64" GOOS="linux" go build -ldflags "-X $LDFLAG" -o "pkg/linux_amd64/nomad"
             ;;
         "linux_amd64-lxc")
             echo "==> Building linux amd64 with lxc..."
-            CGO_ENBALED=1 GOARCH="amd64" GOOS="linux" go build -ldflags "-X $LDFLAG" -o "pkg/linux_amd64-lxc/nomad" -tags "lxc"
+            CGO_ENABLED=1 GOARCH="amd64" GOOS="linux" go build -ldflags "-X $LDFLAG" -o "pkg/linux_amd64-lxc/nomad" -tags "lxc"
             ;;
         "linux_arm")
             echo "==> Building linux arm..."
@@ -113,4 +113,3 @@ done
 echo
 echo "==> Results:"
 tree pkg/
-


### PR DESCRIPTION
The linux/amd64 build lines in `scripts/build.sh` have the variable `CGO_ENBALED` set, when all others have `CGO_ENABLED`. Looks to be a spelling mistake.