### PR TITLE
Fixes docker-driver docker.auth.config processing

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -992,7 +992,8 @@ func (d *DockerDriver) pullImage(driverConfig *DockerDriverConfig, client *docke
 			ServerAddress: driverConfig.Auth[0].ServerAddress,
 		}
 	} else if authConfigFile := d.config.Read("docker.auth.config"); authConfigFile != "" {
-		authOptions, err := authOptionFrom(authConfigFile, repo)
+		var err error
+		authOptions, err = authOptionFrom(authConfigFile, repo)
 		if err != nil {
 			d.logger.Printf("[INFO] driver.docker: failed to find docker auth for repo %q: %v", repo, err)
 			return "", fmt.Errorf("Failed to find docker auth for repo %q: %v", repo, err)


### PR DESCRIPTION
Fixes a variable-shadowing bug in the docker driver that causes private Docker repository auth config to be lost.

See issue #2388