### PR TITLE
Remove 'disk space' from docs

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -254,9 +254,9 @@ job "example" {
       # }
 
       # The "resources" stanza describes the requirements a task needs to
-      # execute. Resource requirements include memory, disk space, network,
-      # cpu, and more. This ensures the task will execute on a machine that
-      # contains enough resource capacity.
+      # execute. Resource requirements include memory, network, cpu, and more.
+      # This ensures the task will execute on a machine that contains enough
+      # resource capacity.
       #
       # For more information and examples on the "resources" stanza, please see
       # the online documentation at:

--- a/website/source/docs/job-specification/resources.html.md
+++ b/website/source/docs/job-specification/resources.html.md
@@ -4,7 +4,7 @@ page_title: "resources Stanza - Job Specification"
 sidebar_current: "docs-job-specification-resources"
 description: |-
   The "resources" stanza describes the requirements a task needs to execute.
-  Resource requirements include memory, disk space, network, cpu, and more.
+  Resource requirements include memory, network, cpu, and more.
 ---
 
 # `resources` Stanza
@@ -19,7 +19,7 @@ description: |-
 </table>
 
 The `resources` stanza describes the requirements a task needs to execute.
-Resource requirements include memory, disk space, network, cpu, and more.
+Resource requirements include memory, network, cpu, and more.
 
 ```hcl
 job "docs" {


### PR DESCRIPTION
Remove old 'disk space' field from `resource` section.