### PR TITLE
Return AgentSelf struct from Agent.Self() instead of map

### DIFF
--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -22,7 +22,7 @@ func TestAgent_Self(t *testing.T) {
 	}
 
 	// Check that we got a valid response
-	if name, ok := res["member"]["Name"]; !ok || name == "" {
+	if res.Member.Name == "" {
 		t.Fatalf("bad member name in response: %#v", res)
 	}
 

--- a/command/agent_info.go
+++ b/command/agent_info.go
@@ -55,17 +55,15 @@ func (c *AgentInfoCommand) Run(args []string) int {
 	}
 
 	// Sort and output agent info
-	var stats map[string]interface{}
-	stats, _ = info["stats"]
-	statsKeys := make([]string, 0, len(stats))
-	for key := range stats {
+	statsKeys := make([]string, 0, len(info.Stats))
+	for key := range info.Stats {
 		statsKeys = append(statsKeys, key)
 	}
 	sort.Strings(statsKeys)
 
 	for _, key := range statsKeys {
 		c.Ui.Output(key)
-		statsData, _ := stats[key].(map[string]interface{})
+		statsData, _ := info.Stats[key]
 		statsDataKeys := make([]string, len(statsData))
 		i := 0
 		for key := range statsData {

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -76,14 +76,12 @@ func getLocalNodeID(client *api.Client) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Error querying agent info: %s", err)
 	}
-	var stats map[string]interface{}
-	stats, _ = info["stats"]
-	clientStats, ok := stats["client"].(map[string]interface{})
+	clientStats, ok := info.Stats["client"]
 	if !ok {
 		return "", fmt.Errorf("Nomad not running in client mode")
 	}
 
-	nodeID, ok := clientStats["node_id"].(string)
+	nodeID, ok := clientStats["node_id"]
 	if !ok {
 		return "", fmt.Errorf("Failed to determine node ID")
 	}


### PR DESCRIPTION
api.AgentSelf mirrors command.agent.agentSelf, and makes it easier to
work with the results of a call to Agent.Self()