### PR TITLE
[needs testing] make bin creates a release binary for the host arch

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,8 +15,8 @@ dev: format generate
 bin: generate
 	@sh -c "'$(PWD)/scripts/build.sh'"
 
-release:
-	@$(MAKE) bin
+release: generate
+	@sh -c "TARGETS=release '$(PWD)/scripts/build.sh'"
 
 cov:
 	gocov test ./... | gocov-html > /tmp/coverage.html

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -14,3 +14,6 @@ fi
 
 echo "--> Installing with tags: $TAGS"
 go install -ldflags "-X $LDFLAG" -tags "${TAGS}"
+
+echo "--> Copying to bin"
+cp $GOPATH/bin/nomad bin/nomad

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,8 +22,8 @@ rm -f bin/*
 rm -rf pkg/*
 mkdir -p bin/
 
-targets=$TARGETS
-if [ -z TARGETS ]; then
+targets="$(go env GOOS)_$(go env GOARCH)"
+if [[ "$TARGETS" == "release" ]]; then
     if [[ $(uname) == "Linux" ]]; then
         targets="linux_386 linux_amd64 linux_amd64-lxc linux_arm linux_arm64 windows_386 windows_amd64"
     elif [[ $(uname) == "Darwin" ]]; then
@@ -80,7 +80,7 @@ done
 
 set -e
 
-# Move all the compiled things to the $GOPATH/bin
+# Move all the compiled things to $GOPATH/bin
 GOPATH=${GOPATH:-$(go env GOPATH)}
 case $(uname) in
     CYGWIN*)


### PR DESCRIPTION
make dev properly copies the binary into bin/ again.

make release still creates binaries for as many archs as possible.

Fixes #2407 

*My bash is weak, so I should test this a bit more before merging.*