### PR TITLE
`distinct_property` constraint

### DIFF
--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -412,12 +412,13 @@ func parseConstraints(result *[]*api.Constraint, list *ast.ObjectList) error {
 		// Check for invalid keys
 		valid := []string{
 			"attribute",
+			"distinct_hosts",
+			"distinct_property",
 			"operator",
+			"regexp",
+			"set_contains",
 			"value",
 			"version",
-			"regexp",
-			"distinct_hosts",
-			"set_contains",
 		}
 		if err := checkHCLKeys(o.Val, valid); err != nil {
 			return err
@@ -465,6 +466,11 @@ func parseConstraints(result *[]*api.Constraint, list *ast.ObjectList) error {
 			}
 
 			m["Operand"] = structs.ConstraintDistinctHosts
+		}
+
+		if property, ok := m[structs.ConstraintDistinctProperty]; ok {
+			m["Operand"] = structs.ConstraintDistinctProperty
+			m["LTarget"] = property
 		}
 
 		// Build the constraint

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -304,6 +304,21 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			"distinctProperty-constraint.hcl",
+			&api.Job{
+				ID:   helper.StringToPtr("foo"),
+				Name: helper.StringToPtr("foo"),
+				Constraints: []*api.Constraint{
+					&api.Constraint{
+						Operand: structs.ConstraintDistinctProperty,
+						LTarget: "${meta.rack}",
+					},
+				},
+			},
+			false,
+		},
+
+		{
 			"periodic-cron.hcl",
 			&api.Job{
 				ID:   helper.StringToPtr("foo"),

--- a/jobspec/test-fixtures/distinctProperty-constraint.hcl
+++ b/jobspec/test-fixtures/distinctProperty-constraint.hcl
@@ -1,0 +1,5 @@
+job "foo" {
+    constraint {
+        distinct_property = "${meta.rack}"
+    }
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3189,10 +3189,11 @@ func (ta *TaskArtifact) Validate() error {
 }
 
 const (
-	ConstraintDistinctHosts = "distinct_hosts"
-	ConstraintRegex         = "regexp"
-	ConstraintVersion       = "version"
-	ConstraintSetContains   = "set_contains"
+	ConstraintDistinctProperty = "distinct_property"
+	ConstraintDistinctHosts    = "distinct_hosts"
+	ConstraintRegex            = "regexp"
+	ConstraintVersion          = "version"
+	ConstraintSetContains      = "set_contains"
 )
 
 // Constraints are used to restrict placement options.

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -267,6 +267,9 @@ func NewDistinctPropertyIterator(ctx Context, source FeasibleIterator) *Distinct
 
 func (iter *DistinctPropertyIterator) SetTaskGroup(tg *structs.TaskGroup) {
 	iter.tg = tg
+
+	// Check if there is a distinct property
+	iter.hasDistinctPropertyConstraints = len(iter.jobPropertySets) != 0 || len(iter.groupPropertySets[tg.Name]) != 0
 }
 
 func (iter *DistinctPropertyIterator) SetJob(job *structs.Job) {
@@ -278,7 +281,6 @@ func (iter *DistinctPropertyIterator) SetJob(job *structs.Job) {
 			continue
 		}
 
-		iter.hasDistinctPropertyConstraints = true
 		pset := NewPropertySet(iter.ctx, job)
 		pset.SetJobConstraint(c)
 		iter.jobPropertySets = append(iter.jobPropertySets, pset)
@@ -290,7 +292,6 @@ func (iter *DistinctPropertyIterator) SetJob(job *structs.Job) {
 				continue
 			}
 
-			iter.hasDistinctPropertyConstraints = true
 			pset := NewPropertySet(iter.ctx, job)
 			pset.SetTGConstraint(c, tg.Name)
 			iter.groupPropertySets[tg.Name] = append(iter.groupPropertySets[tg.Name], pset)

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -154,34 +154,39 @@ type ProposedAllocConstraintIterator struct {
 	tg     *structs.TaskGroup
 	job    *structs.Job
 
+	// distinctProperties is used to track the distinct properties of the job
+	// and to check if node options satisfy these constraints.
+	distinctProperties *propertySet
+
 	// Store whether the Job or TaskGroup has a distinct_hosts constraints so
 	// they don't have to be calculated every time Next() is called.
 	tgDistinctHosts  bool
 	jobDistinctHosts bool
-
-	tgDistinctPropertyConstraints  []*structs.Constraint
-	jobDistinctPropertyConstraints []*structs.Constraint
 }
 
 // NewProposedAllocConstraintIterator creates a ProposedAllocConstraintIterator
 // from a source.
 func NewProposedAllocConstraintIterator(ctx Context, source FeasibleIterator) *ProposedAllocConstraintIterator {
 	return &ProposedAllocConstraintIterator{
-		ctx:    ctx,
-		source: source,
+		ctx:                ctx,
+		source:             source,
+		distinctProperties: NewPropertySet(ctx),
 	}
 }
 
 func (iter *ProposedAllocConstraintIterator) SetTaskGroup(tg *structs.TaskGroup) {
 	iter.tg = tg
 	iter.tgDistinctHosts = iter.hasDistinctHostsConstraint(tg.Constraints)
-	iter.tgDistinctPropertyConstraints = getDistinctPropertyConstraints(tg.Constraints)
 }
 
 func (iter *ProposedAllocConstraintIterator) SetJob(job *structs.Job) {
 	iter.job = job
 	iter.jobDistinctHosts = iter.hasDistinctHostsConstraint(job.Constraints)
-	iter.jobDistinctPropertyConstraints = getDistinctPropertyConstraints(job.Constraints)
+
+	if err := iter.distinctProperties.SetJob(job); err != nil {
+		iter.ctx.Logger().Printf(
+			"[ERR] scheduler.dynamic-constraint: failed to build property set: %v", err)
+	}
 }
 
 func (iter *ProposedAllocConstraintIterator) hasDistinctHostsConstraint(constraints []*structs.Constraint) bool {
@@ -194,20 +199,7 @@ func (iter *ProposedAllocConstraintIterator) hasDistinctHostsConstraint(constrai
 	return false
 }
 
-// getDistinctPropertyConstraints filters the input constraints returning a list
-// of distinct_property constraints.
-func getDistinctPropertyConstraints(constraints []*structs.Constraint) []*structs.Constraint {
-	var distinctProperties []*structs.Constraint
-	for _, con := range constraints {
-		if con.Operand == structs.ConstraintDistinctProperty {
-			distinctProperties = append(distinctProperties, con)
-		}
-	}
-	return distinctProperties
-}
-
 func (iter *ProposedAllocConstraintIterator) Next() *structs.Node {
-OUTER:
 	for {
 		// Get the next option from the source
 		option := iter.source.Next()
@@ -215,7 +207,7 @@ OUTER:
 		// Hot-path if the option is nil or there are no distinct_hosts or
 		// distinct_property constraints.
 		hosts := iter.jobDistinctHosts || iter.tgDistinctHosts
-		properties := len(iter.jobDistinctPropertyConstraints) != 0 || len(iter.tgDistinctPropertyConstraints) != 0
+		properties := iter.distinctProperties.HasDistinctPropertyConstraints()
 		if option == nil || !(hosts || properties) {
 			return option
 		}
@@ -230,18 +222,10 @@ OUTER:
 
 		// Check if the property constraints are satisfied
 		if properties {
-			for _, con := range iter.jobDistinctPropertyConstraints {
-				if !iter.satisfiesDistinctProperty(option, con, true) {
-					iter.ctx.Metrics().FilterNode(option, con.String())
-					continue OUTER
-				}
-			}
-
-			for _, con := range iter.tgDistinctPropertyConstraints {
-				if !iter.satisfiesDistinctProperty(option, con, true) {
-					iter.ctx.Metrics().FilterNode(option, con.String())
-					continue OUTER
-				}
+			satisfied, reason := iter.distinctProperties.SatisfiesDistinctProperties(option, iter.tg.Name)
+			if !satisfied {
+				iter.ctx.Metrics().FilterNode(option, reason)
+				continue
 			}
 		}
 
@@ -280,97 +264,356 @@ func (iter *ProposedAllocConstraintIterator) satisfiesDistinctHosts(option *stru
 	return true
 }
 
-// satisfiesDistinctProperty checks if the node satisfies the
-// distinct_property constraint for the passed constraint.
-// XXX it is insane to do all this work per constraint. Pass in all constraints
-func (iter *ProposedAllocConstraintIterator) satisfiesDistinctProperty(
-	option *structs.Node, con *structs.Constraint, jobConstraint bool) bool {
+func (iter *ProposedAllocConstraintIterator) Reset() {
+	iter.source.Reset()
 
-	// Check if this node has the property
-	val, ok := resolveConstraintTarget(con.LTarget, option)
-	if !ok {
-		return false
+	// Repopulate the proposed set every time we are reset because an
+	// additional allocation may have been added
+	if err := iter.distinctProperties.PopulateProposed(); err != nil {
+		iter.ctx.Logger().Printf(
+			"[ERR] scheduler.dynamic-constraint: failed to populate proposed properties: %v", err)
 	}
-	optionValue, ok := val.(string)
-	if !ok {
-		return false
+}
+
+// propertySet is used to track used values for a particular node property.
+type propertySet struct {
+
+	// ctx is used to lookup the plan and state
+	ctx Context
+
+	// job stores the job the property set is tracking
+	job *structs.Job
+
+	// jobConstrainedProperties stores the set of LTargets that we are
+	// constrained on. The outer key is the task group name. The values stored
+	// in key "" are those constrained at the job level.
+	jobConstrainedProperties map[string]map[string]struct{}
+
+	// existingProperties is a mapping of task group/job to properties (LTarget)
+	// to a string set of used values for pre-placed allocation.
+	existingProperties map[string]map[string]map[string]struct{}
+
+	// proposedCreateProperties is a mapping of task group/job to properties (LTarget)
+	// to a string set of used values for proposed allocations.
+	proposedCreateProperties map[string]map[string]map[string]struct{}
+
+	// clearedProposedProperties is a mapping of task group/job to properties (LTarget)
+	// to a string set of values that have been cleared and are no longer used
+	clearedProposedProperties map[string]map[string]map[string]struct{}
+}
+
+// NewPropertySet returns a new property set used to guarantee unique property
+// values for new allocation placements.
+func NewPropertySet(ctx Context) *propertySet {
+	p := &propertySet{
+		ctx: ctx,
+		jobConstrainedProperties:  make(map[string]map[string]struct{}),
+		existingProperties:        make(map[string]map[string]map[string]struct{}),
+		proposedCreateProperties:  make(map[string]map[string]map[string]struct{}),
+		clearedProposedProperties: make(map[string]map[string]map[string]struct{}),
+	}
+
+	return p
+}
+
+// setJob sets the job the property set is tracking. The distinct property
+// constraints and property values already used by existing allocations are
+// calculated.
+func (p *propertySet) SetJob(j *structs.Job) error {
+	p.job = j
+
+	p.buildDistinctProperties()
+	if err := p.populateExisting(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// HasDistinctPropertyConstraints returns whether there are distinct_property
+// constraints on the job.
+func (p *propertySet) HasDistinctPropertyConstraints() bool {
+	return len(p.jobConstrainedProperties) != 0
+}
+
+// PopulateProposed populates the set of property values used by the proposed
+// allocations for the job. This should be called on every reset
+func (p *propertySet) PopulateProposed() error {
+	// Hot path since there is nothing to do
+	if !p.HasDistinctPropertyConstraints() {
+		return nil
+	}
+
+	// Reset the proposed properties
+	p.proposedCreateProperties = make(map[string]map[string]map[string]struct{})
+	p.clearedProposedProperties = make(map[string]map[string]map[string]struct{})
+
+	// Gather the set of proposed stops.
+	var stopping []*structs.Allocation
+	for _, updates := range p.ctx.Plan().NodeUpdate {
+		stopping = append(stopping, updates...)
+	}
+
+	// build the property set for the proposed stopped allocations
+	// This should be called before building the property set for the created
+	// allocs.
+	if err := p.buildProperySet(stopping, false, true); err != nil {
+		return err
+	}
+
+	// Gather the proposed allocations
+	var proposed []*structs.Allocation
+	for _, pallocs := range p.ctx.Plan().NodeAllocation {
+		proposed = append(proposed, pallocs...)
+	}
+
+	// build the property set for the proposed new allocations
+	return p.buildProperySet(proposed, false, false)
+}
+
+// satisfiesDistinctProperties checks if the option satisfies all
+// distinct_property constraints given the existing placements and proposed
+// placements. If the option does not satisfy the constraints an explanation is
+// given.
+func (p *propertySet) SatisfiesDistinctProperties(option *structs.Node, tg string) (bool, string) {
+	// Hot path if there is nothing to do
+	jobConstrainedProperties := p.jobConstrainedProperties[""]
+	tgConstrainedProperties := p.jobConstrainedProperties[tg]
+	if len(jobConstrainedProperties) == 0 && len(tgConstrainedProperties) == 0 {
+		return true, ""
+	}
+
+	// both is used to iterate over both the proposed and existing used
+	// properties
+	bothAll := []map[string]map[string]map[string]struct{}{p.existingProperties, p.proposedCreateProperties}
+
+	// Check if the option is unique for all the job properties
+	for constrainedProperty := range jobConstrainedProperties {
+		// Get the nodes property value
+		nValue, ok := p.getProperty(option, constrainedProperty)
+		if !ok {
+			return false, fmt.Sprintf("missing property %q", constrainedProperty)
+		}
+
+		// Check if the nodes value has already been used.
+		for _, usedProperties := range bothAll {
+			// Since we are checking at the job level, check all task groups
+			for group, properties := range usedProperties {
+				setValues, ok := properties[constrainedProperty]
+				if !ok {
+					continue
+				}
+
+				// Check if the nodes value has been used
+				_, used := setValues[nValue]
+				if !used {
+					continue
+				}
+
+				// The last check is to ensure that the value hasn't been
+				// removed in the proposed removals.
+				if _, cleared := p.clearedProposedProperties[group][constrainedProperty][nValue]; cleared {
+					continue
+				}
+
+				return false, fmt.Sprintf("distinct_property: %s=%s already used", constrainedProperty, nValue)
+			}
+		}
+	}
+
+	// bothTG is both filtered at by the task group
+	bothTG := []map[string]map[string]struct{}{p.existingProperties[tg], p.proposedCreateProperties[tg]}
+
+	// Check if the option is unique for all the task group properties
+	for constrainedProperty := range tgConstrainedProperties {
+		// Get the nodes property value
+		nValue, ok := p.getProperty(option, constrainedProperty)
+		if !ok {
+			return false, fmt.Sprintf("missing property %q", constrainedProperty)
+		}
+
+		// Check if the nodes value has already been used.
+		for _, properties := range bothTG {
+			setValues, ok := properties[constrainedProperty]
+			if !ok {
+				continue
+			}
+
+			// Check if the nodes value has been used
+			if _, used := setValues[nValue]; !used {
+				continue
+			}
+
+			// The last check is to ensure that the value hasn't been
+			// removed in the proposed removals.
+			if _, cleared := p.clearedProposedProperties[tg][constrainedProperty][nValue]; cleared {
+				continue
+			}
+
+			return false, fmt.Sprintf("distinct_property: %s=%s already used", constrainedProperty, nValue)
+		}
+	}
+
+	return true, ""
+}
+
+// buildDistinctProperties takes the job and populates the map of distinct
+// properties that are constrained on for the job.
+func (p *propertySet) buildDistinctProperties() {
+	for _, c := range p.job.Constraints {
+		if c.Operand != structs.ConstraintDistinctProperty {
+			continue
+		}
+
+		// Store job properties in the magic empty string since it can't be used
+		// by any task group.
+		if _, ok := p.jobConstrainedProperties[""]; !ok {
+			p.jobConstrainedProperties[""] = make(map[string]struct{})
+		}
+
+		p.jobConstrainedProperties[""][c.LTarget] = struct{}{}
+	}
+
+	for _, tg := range p.job.TaskGroups {
+		for _, c := range tg.Constraints {
+			if c.Operand != structs.ConstraintDistinctProperty {
+				continue
+			}
+
+			if _, ok := p.jobConstrainedProperties[tg.Name]; !ok {
+				p.jobConstrainedProperties[tg.Name] = make(map[string]struct{})
+			}
+
+			p.jobConstrainedProperties[tg.Name][c.LTarget] = struct{}{}
+		}
+	}
+}
+
+// populateExisting populates the set of property values used by existing
+// allocations for the job.
+func (p *propertySet) populateExisting() error {
+	// Hot path since there is nothing to do
+	if !p.HasDistinctPropertyConstraints() {
+		return nil
 	}
 
 	// Retrieve all previously placed allocations
-	// XXX this should be cached
 	ws := memdb.NewWatchSet()
-	allocs, err := iter.ctx.State().AllocsByJob(ws, iter.job.ID, false)
+	allocs, err := p.ctx.State().AllocsByJob(ws, p.job.ID, false)
 	if err != nil {
-		iter.ctx.Logger().Printf("[ERR] scheduler.dynamic-constraint: failed to get job's allocations: %v", err)
-		return false
+		return fmt.Errorf("failed to get job's allocations: %v", err)
 	}
 
-	// Add the proposed allocations
-	for _, pallocs := range iter.ctx.Plan().NodeAllocation {
-		allocs = append(allocs, pallocs...)
+	return p.buildProperySet(allocs, true, false)
+}
+
+// buildProperySet takes a set of allocations and determines what property
+// values have been used by them. The existing boolean marks whether these are
+// existing allocations or proposed allocations. Stopping marks whether the
+// allocations are being stopped.
+func (p *propertySet) buildProperySet(allocs []*structs.Allocation, existing, stopping bool) error {
+	// Only want running allocs
+	filtered := allocs
+	if !stopping {
+		filtered, _ = structs.FilterTerminalAllocs(allocs)
 	}
 
-	// Filter to relevant allocations
-	var filteredAllocs []*structs.Allocation
-	for _, alloc := range allocs {
-		// Ensure the allocation is for the same job
-		if alloc.JobID != iter.job.ID {
-			continue
-		}
-
-		// Ensure the allocation is non-terminal
-		if alloc.TerminalStatus() {
-			continue
-		}
-
-		// We are working on a particular task group so filter allocs not from
-		// it.
-		if !jobConstraint && alloc.TaskGroup != iter.tg.Name {
-			continue
-		}
-
-		filteredAllocs = append(filteredAllocs, alloc)
-	}
-
-	// Get all the nodes that have already been used
+	// Get all the nodes that have been used by the allocs
+	ws := memdb.NewWatchSet()
 	nodes := make(map[string]*structs.Node)
-	for _, alloc := range filteredAllocs {
+	for _, alloc := range filtered {
 		if _, ok := nodes[alloc.NodeID]; ok {
 			continue
 		}
 
-		node, err := iter.ctx.State().NodeByID(ws, alloc.NodeID)
+		node, err := p.ctx.State().NodeByID(ws, alloc.NodeID)
 		if err != nil {
-			iter.ctx.Logger().Printf("[ERR] scheduler.dynamic-constraint: failed to lookup node ID %q: %v", alloc.NodeID, err)
-			return false
+			return fmt.Errorf("failed to lookup node ID %q: %v", alloc.NodeID, err)
 		}
 
 		nodes[alloc.NodeID] = node
 	}
 
-	// Check if this options value for the target propery collides with a
-	// previously selected property value
-	for _, n := range nodes {
-		val, ok := resolveConstraintTarget(con.LTarget, n)
-		if !ok {
-			continue
-		}
-		nodeValue, ok := val.(string)
-		if !ok {
-			continue
+	// propertySet is the set we are operating on
+	propertySet := p.existingProperties
+	if !existing && !stopping {
+		propertySet = p.proposedCreateProperties
+	} else if stopping {
+		propertySet = p.clearedProposedProperties
+	}
+
+	// Go through each allocation and build the set of property values that have
+	// been used
+	for _, alloc := range filtered {
+		// Gather job related constrained properties
+		jobProperties := p.jobConstrainedProperties[""]
+		for constrainedProperty := range jobProperties {
+			nProperty, ok := p.getProperty(nodes[alloc.NodeID], constrainedProperty)
+			if !ok {
+				continue
+			}
+
+			if _, exists := propertySet[""]; !exists {
+				propertySet[""] = make(map[string]map[string]struct{})
+			}
+
+			if _, exists := propertySet[""][constrainedProperty]; !exists {
+				propertySet[""][constrainedProperty] = make(map[string]struct{})
+			}
+
+			propertySet[""][constrainedProperty][nProperty] = struct{}{}
+
+			// This is a newly created allocation so clear out the fact that
+			// proposed property is not being used anymore
+			if !existing && !stopping {
+				delete(p.clearedProposedProperties[""][constrainedProperty], nProperty)
+			}
 		}
 
-		// We have a duplicate so we aren't valid
-		if nodeValue == optionValue {
-			return false
+		// Gather task group related constrained properties
+		groupProperties := p.jobConstrainedProperties[alloc.TaskGroup]
+		for constrainedProperty := range groupProperties {
+			nProperty, ok := p.getProperty(nodes[alloc.NodeID], constrainedProperty)
+			if !ok {
+				continue
+			}
+
+			if _, exists := propertySet[alloc.TaskGroup]; !exists {
+				propertySet[alloc.TaskGroup] = make(map[string]map[string]struct{})
+			}
+			if _, exists := propertySet[alloc.TaskGroup][constrainedProperty]; !exists {
+				propertySet[alloc.TaskGroup][constrainedProperty] = make(map[string]struct{})
+			}
+
+			propertySet[alloc.TaskGroup][constrainedProperty][nProperty] = struct{}{}
+
+			// This is a newly created allocation so clear out the fact that
+			// proposed property is not being used anymore
+			if !existing && !stopping {
+				delete(p.clearedProposedProperties[alloc.TaskGroup][constrainedProperty], nProperty)
+			}
 		}
 	}
 
-	return true
+	return nil
 }
 
-func (iter *ProposedAllocConstraintIterator) Reset() {
-	iter.source.Reset()
+// getProperty is used to lookup the property value on the node
+func (p *propertySet) getProperty(n *structs.Node, property string) (string, bool) {
+	if n == nil || property == "" {
+		return "", false
+	}
+
+	val, ok := resolveConstraintTarget(property, n)
+	if !ok {
+		return "", false
+	}
+	nodeValue, ok := val.(string)
+	if !ok {
+		return "", false
+	}
+
+	return nodeValue, true
 }
 
 // ConstraintChecker is a FeasibilityChecker which returns nodes that match a

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -307,10 +307,8 @@ type propertySet struct {
 func NewPropertySet(ctx Context) *propertySet {
 	p := &propertySet{
 		ctx: ctx,
-		jobConstrainedProperties:  make(map[string]map[string]struct{}),
-		existingProperties:        make(map[string]map[string]map[string]struct{}),
-		proposedCreateProperties:  make(map[string]map[string]map[string]struct{}),
-		clearedProposedProperties: make(map[string]map[string]map[string]struct{}),
+		jobConstrainedProperties: make(map[string]map[string]struct{}),
+		existingProperties:       make(map[string]map[string]map[string]struct{}),
 	}
 
 	return p
@@ -320,9 +318,13 @@ func NewPropertySet(ctx Context) *propertySet {
 // constraints and property values already used by existing allocations are
 // calculated.
 func (p *propertySet) SetJob(j *structs.Job) error {
+	// Store the job
 	p.job = j
 
+	// Capture all the distinct property constraints in the job
 	p.buildDistinctProperties()
+
+	// Capture all the used values for those properties
 	if err := p.populateExisting(); err != nil {
 		return err
 	}

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -437,7 +437,7 @@ func TestCheckRegexpConstraint(t *testing.T) {
 
 // This test puts allocations on the node to test if it detects infeasibility of
 // nodes correctly and picks the only feasible one
-func TestProposedAllocConstraint_JobDistinctHosts(t *testing.T) {
+func TestDistinctHostsIterator_JobDistinctHosts(t *testing.T) {
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -488,7 +488,7 @@ func TestProposedAllocConstraint_JobDistinctHosts(t *testing.T) {
 		},
 	}
 
-	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed := NewDistinctHostsIterator(ctx, static)
 	proposed.SetTaskGroup(tg1)
 	proposed.SetJob(job)
 
@@ -502,7 +502,7 @@ func TestProposedAllocConstraint_JobDistinctHosts(t *testing.T) {
 	}
 }
 
-func TestProposedAllocConstraint_JobDistinctHosts_InfeasibleCount(t *testing.T) {
+func TestDistinctHostsIterator_JobDistinctHosts_InfeasibleCount(t *testing.T) {
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -539,7 +539,7 @@ func TestProposedAllocConstraint_JobDistinctHosts_InfeasibleCount(t *testing.T) 
 		},
 	}
 
-	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed := NewDistinctHostsIterator(ctx, static)
 	proposed.SetTaskGroup(tg3)
 	proposed.SetJob(job)
 
@@ -550,7 +550,7 @@ func TestProposedAllocConstraint_JobDistinctHosts_InfeasibleCount(t *testing.T) 
 	}
 }
 
-func TestProposedAllocConstraint_TaskGroupDistinctHosts(t *testing.T) {
+func TestDistinctHostsIterator_TaskGroupDistinctHosts(t *testing.T) {
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -585,7 +585,7 @@ func TestProposedAllocConstraint_TaskGroupDistinctHosts(t *testing.T) {
 		},
 	}
 
-	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed := NewDistinctHostsIterator(ctx, static)
 	proposed.SetTaskGroup(tg1)
 	proposed.SetJob(&structs.Job{ID: "foo"})
 
@@ -613,7 +613,7 @@ func TestProposedAllocConstraint_TaskGroupDistinctHosts(t *testing.T) {
 // This test puts creates allocations across task groups that use a property
 // value to detect if the constraint at the job level properly considers all
 // task groups.
-func TestProposedAllocConstraint_JobDistinctProperty(t *testing.T) {
+func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -753,7 +753,7 @@ func TestProposedAllocConstraint_JobDistinctProperty(t *testing.T) {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
-	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed := NewDistinctPropertyIterator(ctx, static)
 	proposed.SetJob(job)
 	proposed.SetTaskGroup(tg2)
 	proposed.Reset()
@@ -770,7 +770,7 @@ func TestProposedAllocConstraint_JobDistinctProperty(t *testing.T) {
 // This test checks that if a node has an allocation on it that gets stopped,
 // there is a plan to re-use that for a new allocation, that the next select
 // won't select that node.
-func TestProposedAllocConstraint_JobDistinctProperty_RemoveAndReplace(t *testing.T) {
+func TestDistinctPropertyIterator_JobDistinctProperty_RemoveAndReplace(t *testing.T) {
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -831,7 +831,7 @@ func TestProposedAllocConstraint_JobDistinctProperty_RemoveAndReplace(t *testing
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
-	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed := NewDistinctPropertyIterator(ctx, static)
 	proposed.SetJob(job)
 	proposed.SetTaskGroup(tg1)
 	proposed.Reset()
@@ -845,7 +845,7 @@ func TestProposedAllocConstraint_JobDistinctProperty_RemoveAndReplace(t *testing
 // This test creates previous allocations selecting certain property values to
 // test if it detects infeasibility of property values correctly and picks the
 // only feasible one
-func TestProposedAllocConstraint_JobDistinctProperty_Infeasible(t *testing.T) {
+func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible(t *testing.T) {
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -903,7 +903,7 @@ func TestProposedAllocConstraint_JobDistinctProperty_Infeasible(t *testing.T) {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
-	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed := NewDistinctPropertyIterator(ctx, static)
 	proposed.SetJob(job)
 	proposed.SetTaskGroup(tg3)
 	proposed.Reset()
@@ -917,7 +917,7 @@ func TestProposedAllocConstraint_JobDistinctProperty_Infeasible(t *testing.T) {
 // This test creates previous allocations selecting certain property values to
 // test if it detects infeasibility of property values correctly and picks the
 // only feasible one when the constraint is at the task group.
-func TestProposedAllocConstraint_TaskGroupDistinctProperty(t *testing.T) {
+func TestDistinctPropertyIterator_TaskGroupDistinctProperty(t *testing.T) {
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -1007,7 +1007,7 @@ func TestProposedAllocConstraint_TaskGroupDistinctProperty(t *testing.T) {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
-	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed := NewDistinctPropertyIterator(ctx, static)
 	proposed.SetJob(job)
 	proposed.SetTaskGroup(tg1)
 	proposed.Reset()

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -434,47 +435,12 @@ func TestCheckRegexpConstraint(t *testing.T) {
 	}
 }
 
+// This test puts allocations on the node to test if it detects infeasibility of
+// nodes correctly and picks the only feasible one
 func TestProposedAllocConstraint_JobDistinctHosts(t *testing.T) {
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
-		mock.Node(),
-		mock.Node(),
-		mock.Node(),
-	}
-	static := NewStaticIterator(ctx, nodes)
-
-	// Create a job with a distinct_hosts constraint and two task groups.
-	tg1 := &structs.TaskGroup{Name: "bar"}
-	tg2 := &structs.TaskGroup{Name: "baz"}
-
-	job := &structs.Job{
-		ID:          "foo",
-		Constraints: []*structs.Constraint{{Operand: structs.ConstraintDistinctHosts}},
-		TaskGroups:  []*structs.TaskGroup{tg1, tg2},
-	}
-
-	propsed := NewProposedAllocConstraintIterator(ctx, static)
-	propsed.SetTaskGroup(tg1)
-	propsed.SetJob(job)
-
-	out := collectFeasible(propsed)
-	if len(out) != 4 {
-		t.Fatalf("Bad: %#v", out)
-	}
-
-	selected := make(map[string]struct{}, 4)
-	for _, option := range out {
-		if _, ok := selected[option.ID]; ok {
-			t.Fatalf("selected node %v for more than one alloc", option)
-		}
-		selected[option.ID] = struct{}{}
-	}
-}
-
-func TestProposedAllocConstraint_JobDistinctHosts_Infeasible(t *testing.T) {
-	_, ctx := testContext(t)
-	nodes := []*structs.Node{
 		mock.Node(),
 		mock.Node(),
 	}
@@ -491,7 +457,7 @@ func TestProposedAllocConstraint_JobDistinctHosts_Infeasible(t *testing.T) {
 	}
 
 	// Add allocs placing tg1 on node1 and tg2 on node2. This should make the
-	// job unsatisfiable.
+	// job unsatisfiable on all nodes but node3
 	plan := ctx.Plan()
 	plan.NodeAllocation[nodes[0].ID] = []*structs.Allocation{
 		&structs.Allocation{
@@ -522,13 +488,17 @@ func TestProposedAllocConstraint_JobDistinctHosts_Infeasible(t *testing.T) {
 		},
 	}
 
-	propsed := NewProposedAllocConstraintIterator(ctx, static)
-	propsed.SetTaskGroup(tg1)
-	propsed.SetJob(job)
+	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed.SetTaskGroup(tg1)
+	proposed.SetJob(job)
 
-	out := collectFeasible(propsed)
-	if len(out) != 0 {
+	out := collectFeasible(proposed)
+	if len(out) != 1 {
 		t.Fatalf("Bad: %#v", out)
+	}
+
+	if out[0].ID != nodes[2].ID {
+		t.Fatalf("wrong node picked")
 	}
 }
 
@@ -551,13 +521,31 @@ func TestProposedAllocConstraint_JobDistinctHosts_InfeasibleCount(t *testing.T) 
 		TaskGroups:  []*structs.TaskGroup{tg1, tg2, tg3},
 	}
 
-	propsed := NewProposedAllocConstraintIterator(ctx, static)
-	propsed.SetTaskGroup(tg1)
-	propsed.SetJob(job)
+	// Add allocs placing tg1 on node1 and tg2 on node2. This should make the
+	// job unsatisfiable for tg3
+	plan := ctx.Plan()
+	plan.NodeAllocation[nodes[0].ID] = []*structs.Allocation{
+		&structs.Allocation{
+			TaskGroup: tg1.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+		},
+	}
+	plan.NodeAllocation[nodes[1].ID] = []*structs.Allocation{
+		&structs.Allocation{
+			TaskGroup: tg2.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+		},
+	}
+
+	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed.SetTaskGroup(tg3)
+	proposed.SetJob(job)
 
 	// It should not be able to place 3 tasks with only two nodes.
-	out := collectFeasible(propsed)
-	if len(out) != 2 {
+	out := collectFeasible(proposed)
+	if len(out) != 0 {
 		t.Fatalf("Bad: %#v", out)
 	}
 }
@@ -571,18 +559,19 @@ func TestProposedAllocConstraint_TaskGroupDistinctHosts(t *testing.T) {
 	static := NewStaticIterator(ctx, nodes)
 
 	// Create a task group with a distinct_hosts constraint.
-	taskGroup := &structs.TaskGroup{
+	tg1 := &structs.TaskGroup{
 		Name: "example",
 		Constraints: []*structs.Constraint{
 			{Operand: structs.ConstraintDistinctHosts},
 		},
 	}
+	tg2 := &structs.TaskGroup{Name: "baz"}
 
 	// Add a planned alloc to node1.
 	plan := ctx.Plan()
 	plan.NodeAllocation[nodes[0].ID] = []*structs.Allocation{
 		&structs.Allocation{
-			TaskGroup: taskGroup.Name,
+			TaskGroup: tg1.Name,
 			JobID:     "foo",
 		},
 	}
@@ -591,16 +580,16 @@ func TestProposedAllocConstraint_TaskGroupDistinctHosts(t *testing.T) {
 	// different job.
 	plan.NodeAllocation[nodes[1].ID] = []*structs.Allocation{
 		&structs.Allocation{
-			TaskGroup: taskGroup.Name,
+			TaskGroup: tg1.Name,
 			JobID:     "bar",
 		},
 	}
 
-	propsed := NewProposedAllocConstraintIterator(ctx, static)
-	propsed.SetTaskGroup(taskGroup)
-	propsed.SetJob(&structs.Job{ID: "foo"})
+	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed.SetTaskGroup(tg1)
+	proposed.SetJob(&structs.Job{ID: "foo"})
 
-	out := collectFeasible(propsed)
+	out := collectFeasible(proposed)
 	if len(out) != 1 {
 		t.Fatalf("Bad: %#v", out)
 	}
@@ -609,6 +598,308 @@ func TestProposedAllocConstraint_TaskGroupDistinctHosts(t *testing.T) {
 	// the same task group.
 	if out[0] != nodes[1] {
 		t.Fatalf("Bad: %v", out)
+	}
+
+	// Since the other task group doesn't have the constraint, both nodes should
+	// be feasible.
+	proposed.Reset()
+	proposed.SetTaskGroup(tg2)
+	out = collectFeasible(proposed)
+	if len(out) != 2 {
+		t.Fatalf("Bad: %#v", out)
+	}
+}
+
+// This test puts creates allocations across task groups that use a property
+// value to detect if the constraint at the job level properly considers all
+// task groups.
+func TestProposedAllocConstraint_JobDistinctProperty(t *testing.T) {
+	state, ctx := testContext(t)
+	nodes := []*structs.Node{
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+	}
+
+	for i, n := range nodes {
+		n.Meta["rack"] = fmt.Sprintf("%d", i)
+
+		// Add to state store
+		if err := state.UpsertNode(uint64(100+i), n); err != nil {
+			t.Fatalf("failed to upsert node: %v", err)
+		}
+	}
+
+	static := NewStaticIterator(ctx, nodes)
+
+	// Create a job with a distinct_property constraint and a task groups.
+	tg1 := &structs.TaskGroup{Name: "bar"}
+	tg2 := &structs.TaskGroup{Name: "baz"}
+
+	job := &structs.Job{
+		ID: "foo",
+		Constraints: []*structs.Constraint{
+			{
+				Operand: structs.ConstraintDistinctProperty,
+				LTarget: "${meta.rack}",
+			},
+		},
+		TaskGroups: []*structs.TaskGroup{tg1, tg2},
+	}
+
+	// Add allocs placing tg1 on node1 and 2 and tg2 on node3 and 4. This should make the
+	// job unsatisfiable on all nodes but node5. Also mix the allocations
+	// existing in the plan and the state store.
+	plan := ctx.Plan()
+	plan.NodeAllocation[nodes[0].ID] = []*structs.Allocation{
+		&structs.Allocation{
+			TaskGroup: tg1.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+			NodeID:    nodes[0].ID,
+		},
+
+		// Should be ignored as it is a different job.
+		&structs.Allocation{
+			TaskGroup: tg2.Name,
+			JobID:     "ignore 2",
+			ID:        structs.GenerateUUID(),
+			NodeID:    nodes[0].ID,
+		},
+	}
+	plan.NodeAllocation[nodes[2].ID] = []*structs.Allocation{
+		&structs.Allocation{
+			TaskGroup: tg2.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+			NodeID:    nodes[2].ID,
+		},
+
+		// Should be ignored as it is a different job.
+		&structs.Allocation{
+			TaskGroup: tg1.Name,
+			JobID:     "ignore 2",
+			ID:        structs.GenerateUUID(),
+			NodeID:    nodes[2].ID,
+		},
+	}
+
+	upserting := []*structs.Allocation{
+		&structs.Allocation{
+			TaskGroup: tg1.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+			EvalID:    structs.GenerateUUID(),
+			NodeID:    nodes[1].ID,
+		},
+
+		// Should be ignored as it is a different job.
+		&structs.Allocation{
+			TaskGroup: tg2.Name,
+			JobID:     "ignore 2",
+			ID:        structs.GenerateUUID(),
+			EvalID:    structs.GenerateUUID(),
+			NodeID:    nodes[1].ID,
+		},
+		&structs.Allocation{
+			TaskGroup: tg2.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+			EvalID:    structs.GenerateUUID(),
+			NodeID:    nodes[3].ID,
+		},
+
+		// Should be ignored as it is a different job.
+		&structs.Allocation{
+			TaskGroup: tg1.Name,
+			JobID:     "ignore 2",
+			ID:        structs.GenerateUUID(),
+			EvalID:    structs.GenerateUUID(),
+			NodeID:    nodes[3].ID,
+		},
+	}
+	if err := state.UpsertAllocs(1000, upserting); err != nil {
+		t.Fatalf("failed to UpsertAllocs: %v", err)
+	}
+
+	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed.SetTaskGroup(tg2)
+	proposed.SetJob(job)
+
+	out := collectFeasible(proposed)
+	if len(out) != 1 {
+		t.Fatalf("Bad: %#v", out)
+	}
+	if out[0].ID != nodes[4].ID {
+		t.Fatalf("wrong node picked")
+	}
+}
+
+// This test creates previous allocations selecting certain property values to
+// test if it detects infeasibility of property values correctly and picks the
+// only feasible one
+func TestProposedAllocConstraint_JobDistinctProperty_Infeasible(t *testing.T) {
+	state, ctx := testContext(t)
+	nodes := []*structs.Node{
+		mock.Node(),
+		mock.Node(),
+	}
+
+	for i, n := range nodes {
+		n.Meta["rack"] = fmt.Sprintf("%d", i)
+
+		// Add to state store
+		if err := state.UpsertNode(uint64(100+i), n); err != nil {
+			t.Fatalf("failed to upsert node: %v", err)
+		}
+	}
+
+	static := NewStaticIterator(ctx, nodes)
+
+	// Create a job with a distinct_property constraint and a task groups.
+	tg1 := &structs.TaskGroup{Name: "bar"}
+	tg2 := &structs.TaskGroup{Name: "baz"}
+	tg3 := &structs.TaskGroup{Name: "bam"}
+
+	job := &structs.Job{
+		ID: "foo",
+		Constraints: []*structs.Constraint{
+			{
+				Operand: structs.ConstraintDistinctProperty,
+				LTarget: "${meta.rack}",
+			},
+		},
+		TaskGroups: []*structs.TaskGroup{tg1, tg2, tg3},
+	}
+
+	// Add allocs placing tg1 on node1 and tg2 on node2. This should make the
+	// job unsatisfiable for tg3.
+	plan := ctx.Plan()
+	plan.NodeAllocation[nodes[0].ID] = []*structs.Allocation{
+		&structs.Allocation{
+			TaskGroup: tg1.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+			NodeID:    nodes[0].ID,
+		},
+	}
+	upserting := []*structs.Allocation{
+		&structs.Allocation{
+			TaskGroup: tg2.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+			EvalID:    structs.GenerateUUID(),
+			NodeID:    nodes[1].ID,
+		},
+	}
+	if err := state.UpsertAllocs(1000, upserting); err != nil {
+		t.Fatalf("failed to UpsertAllocs: %v", err)
+	}
+
+	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed.SetTaskGroup(tg3)
+	proposed.SetJob(job)
+
+	out := collectFeasible(proposed)
+	if len(out) != 0 {
+		t.Fatalf("Bad: %#v", out)
+	}
+}
+
+// This test creates previous allocations selecting certain property values to
+// test if it detects infeasibility of property values correctly and picks the
+// only feasible one when the constraint is at the task group.
+func TestProposedAllocConstraint_TaskGroupDistinctProperty(t *testing.T) {
+	state, ctx := testContext(t)
+	nodes := []*structs.Node{
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+	}
+
+	for i, n := range nodes {
+		n.Meta["rack"] = fmt.Sprintf("%d", i)
+
+		// Add to state store
+		if err := state.UpsertNode(uint64(100+i), n); err != nil {
+			t.Fatalf("failed to upsert node: %v", err)
+		}
+	}
+
+	static := NewStaticIterator(ctx, nodes)
+
+	// Create a job with a task group with the distinct_property constraint
+	tg1 := &structs.TaskGroup{
+		Name: "example",
+		Constraints: []*structs.Constraint{
+			{
+				Operand: structs.ConstraintDistinctProperty,
+				LTarget: "${meta.rack}",
+			},
+		},
+	}
+	tg2 := &structs.TaskGroup{Name: "baz"}
+
+	job := &structs.Job{
+		ID:         "foo",
+		TaskGroups: []*structs.TaskGroup{tg1, tg2},
+	}
+
+	// Add allocs placing tg1 on node1 and 2. This should make the
+	// job unsatisfiable on all nodes but node3. Also mix the allocations
+	// existing in the plan and the state store.
+	plan := ctx.Plan()
+	plan.NodeAllocation[nodes[0].ID] = []*structs.Allocation{
+		&structs.Allocation{
+			TaskGroup: tg1.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+			NodeID:    nodes[0].ID,
+		},
+	}
+	upserting := []*structs.Allocation{
+		&structs.Allocation{
+			TaskGroup: tg1.Name,
+			JobID:     job.ID,
+			ID:        structs.GenerateUUID(),
+			EvalID:    structs.GenerateUUID(),
+			NodeID:    nodes[1].ID,
+		},
+
+		// Should be ignored as it is a different job.
+		&structs.Allocation{
+			TaskGroup: tg1.Name,
+			JobID:     "ignore 2",
+			ID:        structs.GenerateUUID(),
+			EvalID:    structs.GenerateUUID(),
+			NodeID:    nodes[2].ID,
+		},
+	}
+	if err := state.UpsertAllocs(1000, upserting); err != nil {
+		t.Fatalf("failed to UpsertAllocs: %v", err)
+	}
+
+	proposed := NewProposedAllocConstraintIterator(ctx, static)
+	proposed.SetTaskGroup(tg1)
+	proposed.SetJob(job)
+
+	out := collectFeasible(proposed)
+	if len(out) != 1 {
+		t.Fatalf("Bad: %#v", out)
+	}
+	if out[0].ID != nodes[2].ID {
+		t.Fatalf("wrong node picked")
+	}
+
+	// Since the other task group doesn't have the constraint, both nodes should
+	// be feasible.
+	proposed.Reset()
+	proposed.SetTaskGroup(tg2)
+	out = collectFeasible(proposed)
+	if len(out) != 3 {
+		t.Fatalf("Bad: %#v", out)
 	}
 }
 

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -399,6 +399,83 @@ func TestServiceSched_JobRegister_DistinctProperty(t *testing.T) {
 	h.AssertEvalStatus(t, structs.EvalStatusComplete)
 }
 
+func TestServiceSched_JobRegister_DistinctProperty_TaskGroup(t *testing.T) {
+	h := NewHarness(t)
+
+	// Create some nodes
+	for i := 0; i < 2; i++ {
+		node := mock.Node()
+		node.Meta["ssd"] = "true"
+		noErr(t, h.State.UpsertNode(h.NextIndex(), node))
+	}
+
+	// Create a job that uses distinct property and has count higher than what is
+	// possible.
+	job := mock.Job()
+	job.TaskGroups = append(job.TaskGroups, job.TaskGroups[0].Copy())
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Constraints = append(job.TaskGroups[0].Constraints,
+		&structs.Constraint{
+			Operand: structs.ConstraintDistinctProperty,
+			LTarget: "${meta.ssd}",
+		})
+
+	job.TaskGroups[1].Name = "tg2"
+	job.TaskGroups[1].Count = 1
+	noErr(t, h.State.UpsertJob(h.NextIndex(), job))
+
+	// Create a mock evaluation to register the job
+	eval := &structs.Evaluation{
+		ID:          structs.GenerateUUID(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+	}
+
+	// Process the evaluation
+	err := h.Process(NewServiceScheduler, eval)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure a single plan
+	if len(h.Plans) != 1 {
+		t.Fatalf("bad: %#v", h.Plans)
+	}
+	plan := h.Plans[0]
+
+	// Ensure the plan doesn't have annotations.
+	if plan.Annotations != nil {
+		t.Fatalf("expected no annotations")
+	}
+
+	// Ensure the eval hasn't spawned blocked eval
+	if len(h.CreateEvals) != 0 {
+		t.Fatalf("bad: %#v", h.CreateEvals[0])
+	}
+
+	// Ensure the plan allocated
+	var planned []*structs.Allocation
+	for _, allocList := range plan.NodeAllocation {
+		planned = append(planned, allocList...)
+	}
+	if len(planned) != 2 {
+		t.Fatalf("bad: %#v", plan)
+	}
+
+	// Lookup the allocations by JobID
+	ws := memdb.NewWatchSet()
+	out, err := h.State.AllocsByJob(ws, job.ID, false)
+	noErr(t, err)
+
+	// Ensure all allocations placed
+	if len(out) != 2 {
+		t.Fatalf("bad: %#v", out)
+	}
+
+	h.AssertEvalStatus(t, structs.EvalStatusComplete)
+}
+
 func TestServiceSched_JobRegister_Annotate(t *testing.T) {
 	h := NewHarness(t)
 

--- a/scheduler/propertyset.go
+++ b/scheduler/propertyset.go
@@ -1,0 +1,264 @@
+package scheduler
+
+import (
+	"fmt"
+
+	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// propertySet is used to track the values used for a particular property.
+type propertySet struct {
+	// ctx is used to lookup the plan and state
+	ctx Context
+
+	jobID string
+
+	// constraint is the constraint this property set is checking
+	constraint *structs.Constraint
+
+	// errorBuilding marks whether there was an error when building the property
+	// set
+	errorBuilding error
+
+	// existingValues is the set of values for the given property that have been
+	// used by pre-existing allocations.
+	existingValues map[string]struct{}
+
+	// proposedValues is the set of values for the given property that are used
+	// from proposed allocations.
+	proposedValues map[string]struct{}
+
+	// clearedValues is the set of values that are no longer being used by
+	// existingValues because of proposed stops.
+	clearedValues map[string]struct{}
+}
+
+// NewPropertySet returns a new property set used to guarantee unique property
+// values for new allocation placements.
+func NewPropertySet(ctx Context, job *structs.Job) *propertySet {
+	p := &propertySet{
+		ctx:            ctx,
+		jobID:          job.ID,
+		existingValues: make(map[string]struct{}),
+	}
+
+	return p
+}
+
+// SetJobConstraint is used to parameterize the property set for a
+// distinct_property constraint set at the job level.
+func (p *propertySet) SetJobConstraint(constraint *structs.Constraint) {
+	// Store the constraint
+	p.constraint = constraint
+
+	// Retrieve all previously placed allocations
+	ws := memdb.NewWatchSet()
+	allocs, err := p.ctx.State().AllocsByJob(ws, p.jobID, false)
+	if err != nil {
+		p.errorBuilding = fmt.Errorf("failed to get job's allocations: %v", err)
+		p.ctx.Logger().Printf("[ERR] scheduler.dynamic-constraint: %v", p.errorBuilding)
+		return
+	}
+
+	// Only want running allocs
+	filtered, _ := structs.FilterTerminalAllocs(allocs)
+
+	// Get all the nodes that have been used by the allocs
+	nodes, err := p.buildNodeMap(filtered)
+	if err != nil {
+		p.errorBuilding = err
+		p.ctx.Logger().Printf("[ERR] scheduler.dynamic-constraint: %v", err)
+		return
+	}
+
+	p.populateExisting(constraint, filtered, nodes)
+}
+
+// SetTGConstraint is used to parameterize the property set for a
+// distinct_property constraint set at the task group level. The inputs are the
+// constraint and the task group name.
+func (p *propertySet) SetTGConstraint(constraint *structs.Constraint, taskGroup string) {
+	// Store the constraint
+	p.constraint = constraint
+
+	// Retrieve all previously placed allocations
+	ws := memdb.NewWatchSet()
+	allocs, err := p.ctx.State().AllocsByJob(ws, p.jobID, false)
+	if err != nil {
+		p.errorBuilding = fmt.Errorf("failed to get job's allocations: %v", err)
+		p.ctx.Logger().Printf("[ERR] scheduler.dynamic-constraint: %v", p.errorBuilding)
+		return
+	}
+
+	// Only want running allocs from the task group
+	n := len(allocs)
+	for i := 0; i < n; i++ {
+		if allocs[i].TaskGroup != taskGroup || allocs[i].TerminalStatus() {
+			allocs[i], allocs[n-1] = allocs[n-1], nil
+			i--
+			n--
+		}
+	}
+	allocs = allocs[:n]
+
+	// Get all the nodes that have been used by the allocs
+	nodes, err := p.buildNodeMap(allocs)
+	if err != nil {
+		p.errorBuilding = err
+		p.ctx.Logger().Printf("[ERR] scheduler.dynamic-constraint: %v", err)
+		return
+	}
+
+	p.populateExisting(constraint, allocs, nodes)
+}
+
+// populateExisting is a helper shared when setting the constraint to populate
+// the existing values. The allocations should be filtered appropriately prior
+// to calling.
+func (p *propertySet) populateExisting(constraint *structs.Constraint, jobAllocs []*structs.Allocation, nodes map[string]*structs.Node) {
+	for _, alloc := range jobAllocs {
+		nProperty, ok := p.getProperty(nodes[alloc.NodeID], constraint.LTarget)
+		if !ok {
+			continue
+		}
+
+		p.existingValues[nProperty] = struct{}{}
+	}
+}
+
+// PopulateProposed populates the proposed values and recomputes any cleared
+// value. It should be called whenever the plan is updated to ensure correct
+// results when checking an option.
+func (p *propertySet) PopulateProposed() {
+
+	// Reset the proposed properties
+	p.proposedValues = make(map[string]struct{})
+	p.clearedValues = make(map[string]struct{})
+
+	// Gather the set of proposed stops.
+	var stopping []*structs.Allocation
+	for _, updates := range p.ctx.Plan().NodeUpdate {
+		stopping = append(stopping, updates...)
+	}
+
+	// Gather the proposed allocations
+	var proposed []*structs.Allocation
+	for _, pallocs := range p.ctx.Plan().NodeAllocation {
+		proposed = append(proposed, pallocs...)
+	}
+	proposed, _ = structs.FilterTerminalAllocs(proposed)
+
+	// Get the used nodes
+	both := make([]*structs.Allocation, 0, len(stopping)+len(proposed))
+	both = append(both, stopping...)
+	both = append(both, proposed...)
+	nodes, err := p.buildNodeMap(both)
+	if err != nil {
+		p.errorBuilding = err
+		p.ctx.Logger().Printf("[ERR] scheduler.dynamic-constraint: %v", err)
+		return
+	}
+
+	// Populate the cleared values
+	for _, alloc := range stopping {
+		nProperty, ok := p.getProperty(nodes[alloc.NodeID], p.constraint.LTarget)
+		if !ok {
+			continue
+		}
+
+		p.clearedValues[nProperty] = struct{}{}
+	}
+
+	// Populate the proposed values
+	for _, alloc := range proposed {
+		nProperty, ok := p.getProperty(nodes[alloc.NodeID], p.constraint.LTarget)
+		if !ok {
+			continue
+		}
+
+		p.proposedValues[nProperty] = struct{}{}
+
+		// If it was cleared, it is now being used
+		delete(p.clearedValues, nProperty)
+	}
+}
+
+// SatisfiesDistinctProperties checks if the option satisfies the
+// distinct_property constraints given the existing placements and proposed
+// placements. If the option does not satisfy the constraints an explanation is
+// given.
+func (p *propertySet) SatisfiesDistinctProperties(option *structs.Node, tg string) (bool, string) {
+	// Check if there was an error building
+	if p.errorBuilding != nil {
+		return false, p.errorBuilding.Error()
+	}
+
+	// Get the nodes property value
+	nValue, ok := p.getProperty(option, p.constraint.LTarget)
+	if !ok {
+		return false, fmt.Sprintf("missing property %q", p.constraint.LTarget)
+	}
+
+	// both is used to iterate over both the proposed and existing used
+	// properties
+	bothAll := []map[string]struct{}{p.existingValues, p.proposedValues}
+
+	// Check if the nodes value has already been used.
+	for _, usedProperties := range bothAll {
+		// Check if the nodes value has been used
+		_, used := usedProperties[nValue]
+		if !used {
+			continue
+		}
+
+		// Check if the value has been cleared from a proposed stop
+		if _, cleared := p.clearedValues[nValue]; cleared {
+			continue
+		}
+
+		return false, fmt.Sprintf("distinct_property: %s=%s already used", p.constraint.LTarget, nValue)
+	}
+
+	return true, ""
+}
+
+// buildNodeMap takes a list of allocations and returns a map of the nodes used
+// by those allocations
+func (p *propertySet) buildNodeMap(allocs []*structs.Allocation) (map[string]*structs.Node, error) {
+	// Get all the nodes that have been used by the allocs
+	nodes := make(map[string]*structs.Node)
+	ws := memdb.NewWatchSet()
+	for _, alloc := range allocs {
+		if _, ok := nodes[alloc.NodeID]; ok {
+			continue
+		}
+
+		node, err := p.ctx.State().NodeByID(ws, alloc.NodeID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to lookup node ID %q: %v", alloc.NodeID, err)
+		}
+
+		nodes[alloc.NodeID] = node
+	}
+
+	return nodes, nil
+}
+
+// getProperty is used to lookup the property value on the node
+func (p *propertySet) getProperty(n *structs.Node, property string) (string, bool) {
+	if n == nil || property == "" {
+		return "", false
+	}
+
+	val, ok := resolveConstraintTarget(property, n)
+	if !ok {
+		return "", false
+	}
+	nodeValue, ok := val.(string)
+	if !ok {
+		return "", false
+	}
+
+	return nodeValue, true
+}

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -464,11 +464,6 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 
 		// Check if the task drivers or config has changed, requires
 		// a rolling upgrade since that cannot be done in-place.
-		//existing := update.Alloc.Job.LookupTaskGroup(update.TaskGroup.Name)
-		//if tasksUpdated(update.TaskGroup, existing) {
-		//continue
-		//}
-
 		existing := update.Alloc.Job
 		if tasksUpdated(job, existing, update.TaskGroup.Name) {
 			continue


### PR DESCRIPTION
This PR introduces a distinct property constraint. This allows constraints such as:

```
constraint {
  distinct_property = "${meta.rack}"
}
```

Which causes each placement to be on a node with a distinct value of `${meta.rack}`.

Fixes https://github.com/hashicorp/nomad/issues/1387