### PR TITLE
client/allocdir: Add missing functions on Solaris

### DIFF
--- a/client/allocdir/fs_solaris.go
+++ b/client/allocdir/fs_solaris.go
@@ -1,0 +1,26 @@
+package allocdir
+
+import (
+	"os"
+	"syscall"
+)
+
+// linkDir hardlinks src to dst. The src and dst must be on the same filesystem.
+func linkDir(src, dst string) error {
+	return syscall.Link(src, dst)
+}
+
+// unlinkDir removes a directory link.
+func unlinkDir(dir string) error {
+	return syscall.Unlink(dir)
+}
+
+// createSecretDir creates the secrets dir folder at the given path
+func createSecretDir(dir string) error {
+	return os.MkdirAll(dir, 0777)
+}
+
+// removeSecretDir removes the secrets dir folder
+func removeSecretDir(dir string) error {
+	return os.RemoveAll(dir)
+}


### PR DESCRIPTION
This commit adds Solaris versions of the following functions:

- `linkDir`
- `unlinkDir`
- `createSecretDir`
- `removeSecretDir`

I believe this requires Go 1.8 in order to compile, as the unlink syscall was previously missing.