### PR TITLE
Add metrics to show allocations on the client

### DIFF
--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -54,24 +54,28 @@ func (e *Evaluations) Allocations(evalID string, q *QueryOptions) ([]*Allocation
 
 // Evaluation is used to serialize an evaluation.
 type Evaluation struct {
-	ID                string
-	Priority          int
-	Type              string
-	TriggeredBy       string
-	JobID             string
-	JobModifyIndex    uint64
-	NodeID            string
-	NodeModifyIndex   uint64
-	Status            string
-	StatusDescription string
-	Wait              time.Duration
-	NextEval          string
-	PreviousEval      string
-	BlockedEval       string
-	FailedTGAllocs    map[string]*AllocationMetric
-	QueuedAllocations map[string]int
-	CreateIndex       uint64
-	ModifyIndex       uint64
+	ID                   string
+	Priority             int
+	Type                 string
+	TriggeredBy          string
+	JobID                string
+	JobModifyIndex       uint64
+	NodeID               string
+	NodeModifyIndex      uint64
+	Status               string
+	StatusDescription    string
+	Wait                 time.Duration
+	NextEval             string
+	PreviousEval         string
+	BlockedEval          string
+	FailedTGAllocs       map[string]*AllocationMetric
+	ClassEligibility     map[string]bool
+	EscapedComputedClass bool
+	AnnotatePlan         bool
+	QueuedAllocations    map[string]int
+	SnapshotIndex        uint64
+	CreateIndex          uint64
+	ModifyIndex          uint64
 }
 
 // EvalIndexSort is a wrapper to sort evaluations by CreateIndex.

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -574,18 +574,22 @@ func (r *AllocRunner) destroyTaskRunners(destroyEvent *structs.TaskEvent) {
 // handleDestroy blocks till the AllocRunner should be destroyed and does the
 // necessary cleanup.
 func (r *AllocRunner) handleDestroy() {
-	select {
-	case <-r.destroyCh:
-		if err := r.DestroyContext(); err != nil {
-			r.logger.Printf("[ERR] client: failed to destroy context for alloc '%s': %v",
-				r.alloc.ID, err)
+	for {
+		select {
+		case <-r.destroyCh:
+			if err := r.DestroyContext(); err != nil {
+				r.logger.Printf("[ERR] client: failed to destroy context for alloc '%s': %v",
+					r.alloc.ID, err)
+			}
+			if err := r.DestroyState(); err != nil {
+				r.logger.Printf("[ERR] client: failed to destroy state for alloc '%s': %v",
+					r.alloc.ID, err)
+			}
+
+			return
+		case <-r.updateCh:
+			r.logger.Printf("[ERR] client: dropping update to terminal alloc '%s'", r.alloc.ID)
 		}
-		if err := r.DestroyState(); err != nil {
-			r.logger.Printf("[ERR] client: failed to destroy state for alloc '%s': %v",
-				r.alloc.ID, err)
-		}
-	case <-r.updateCh:
-		r.logger.Printf("[ERR] client: dropping update to terminal alloc '%s'", r.alloc.ID)
 	}
 }
 

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -584,6 +584,8 @@ func (r *AllocRunner) handleDestroy() {
 			r.logger.Printf("[ERR] client: failed to destroy state for alloc '%s': %v",
 				r.alloc.ID, err)
 		}
+	case <-r.updateCh:
+		r.logger.Printf("[ERR] client: dropping update to terminal alloc '%s'", r.alloc.ID)
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3827,14 +3827,14 @@ type Evaluation struct {
 	// during the evaluation. This should not be set during normal operations.
 	AnnotatePlan bool
 
+	// QueuedAllocations is the number of unplaced allocations at the time the
+	// evaluation was processed. The map is keyed by Task Group names.
+	QueuedAllocations map[string]int
+
 	// SnapshotIndex is the Raft index of the snapshot used to process the
 	// evaluation. As such it will only be set once it has gone through the
 	// scheduler.
 	SnapshotIndex uint64
-
-	// QueuedAllocations is the number of unplaced allocations at the time the
-	// evaluation was processed. The map is keyed by Task Group names.
-	QueuedAllocations map[string]int
 
 	// Raft Indexes
 	CreateIndex uint64


### PR DESCRIPTION
This PR adds the following metrics to the client:
```
client.allocations.migrating
client.allocations.blocked
client.allocations.pending
client.allocations.running
client.allocations.terminal
```

Also adds some missing fields to the API version of the evaluation.