### PR TITLE
Fix test deadlock due to alloc runner not running

### DIFF
--- a/client/gc_test.go
+++ b/client/gc_test.go
@@ -117,6 +117,10 @@ func TestAllocGarbageCollector_Collect(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Fake that ar.Run() exits
+	close(ar1.waitCh)
+	close(ar2.waitCh)
+
 	if err := gc.Collect(ar1.Alloc().ID); err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
Don't actualy call AllocRunner.Run() because that executes so much
unneeded code for this test. Manually close the waitCh to simulate Run()
exiting.