### PR TITLE
ensuring bin directory exists before copying

### DIFF
--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -15,5 +15,8 @@ fi
 echo "--> Installing with tags: $TAGS"
 go install -ldflags "-X $LDFLAG" -tags "${TAGS}"
 
+echo "--> Ensuring bin directory exists..."
+mkdir -p bin
+
 echo "--> Copying to bin"
 cp $GOPATH/bin/nomad bin/nomad


### PR DESCRIPTION
The `bin` directory should be created before use. Otherwise `make dev` from [this page](https://www.nomadproject.io/docs/install/index.html) does not complete. After this change:

```
[vlm@~/go/src/github.com/hashicorp/nomad]>gmake dev
--> Running go fmt
--> Running go generate
--> Installing with tags: nomad_test
--> Ensuring bin directory exists...
--> Copying to bin
[vlm@~/go/src/github.com/hashicorp/nomad]>
```