### PR TITLE
Fix panic when restarting non-running task

### DIFF
--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -981,7 +981,7 @@ func (r *TaskRunner) run() {
 				r.runningLock.Unlock()
 				common := fmt.Sprintf("task %v for alloc %q", r.task.Name, r.alloc.ID)
 				if !running {
-					r.logger.Printf("[DEBUG] client: skipping restart of %v: task isn't running")
+					r.logger.Printf("[DEBUG] client: skipping restart of %v: task isn't running", common)
 					continue
 				}
 

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -316,10 +316,10 @@ func TestTaskRunner_Update(t *testing.T) {
 			return false, fmt.Errorf("Task not copied")
 		}
 		if ctx.tr.restartTracker.policy.Mode != newMode {
-			return false, fmt.Errorf("restart policy not ctx.upd.ted")
+			return false, fmt.Errorf("restart policy not ctx.updated")
 		}
 		if ctx.tr.handle.ID() == oldHandle {
-			return false, fmt.Errorf("handle not ctx.upd.ted")
+			return false, fmt.Errorf("handle not ctx.updated")
 		}
 		return true, nil
 	}, func(err error) {
@@ -642,6 +642,66 @@ func TestTaskRunner_RestartTask(t *testing.T) {
 
 	if ctx.upd.events[9].Type != structs.TaskKilled {
 		t.Fatalf("Tenth Event was %v; want %v", ctx.upd.events[9].Type, structs.TaskKilled)
+	}
+}
+
+// This test is just to make sure we are resilient to failures when a restart or
+// signal is triggered and the task is not running.
+func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
+	alloc := mock.Alloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{
+		"exit_code": "0",
+		"run_for":   "100s",
+	}
+
+	// Use vault to block the start
+	task.Vault = &structs.Vault{Policies: []string{"default"}}
+
+	ctx := testTaskRunnerFromAlloc(t, true, alloc)
+	ctx.tr.MarkReceived()
+	defer ctx.Cleanup()
+
+	// Control when we get a Vault token
+	token := "1234"
+	waitCh := make(chan struct{})
+	defer close(waitCh)
+	handler := func(*structs.Allocation, []string) (map[string]string, error) {
+		<-waitCh
+		return map[string]string{task.Name: token}, nil
+	}
+	ctx.tr.vaultClient.(*vaultclient.MockVaultClient).DeriveTokenFn = handler
+	go ctx.tr.Run()
+
+	select {
+	case <-ctx.tr.WaitCh():
+		t.Fatalf("premature exit")
+	case <-time.After(1 * time.Second):
+	}
+
+	// Send a signal and restart
+	if err := ctx.tr.Signal("test", "don't panic", syscall.SIGCHLD); err != nil {
+		t.Fatalf("Signalling errored: %v", err)
+	}
+
+	// Send a restart
+	ctx.tr.Restart("test", "don't panic")
+
+	if len(ctx.upd.events) != 2 {
+		t.Fatalf("should have 2 ctx.updates: %#v", ctx.upd.events)
+	}
+
+	if ctx.upd.state != structs.TaskStatePending {
+		t.Fatalf("TaskState %v; want %v", ctx.upd.state, structs.TaskStatePending)
+	}
+
+	if ctx.upd.events[0].Type != structs.TaskReceived {
+		t.Fatalf("First Event was %v; want %v", ctx.upd.events[0].Type, structs.TaskReceived)
+	}
+
+	if ctx.upd.events[1].Type != structs.TaskSetup {
+		t.Fatalf("Second Event was %v; want %v", ctx.upd.events[1].Type, structs.TaskSetup)
 	}
 }
 
@@ -1148,7 +1208,7 @@ func TestTaskRunner_Template_NewVaultToken(t *testing.T) {
 		}
 
 		if originalManager == ctx.tr.templateManager {
-			return false, fmt.Errorf("Template manager not ctx.upd.ted")
+			return false, fmt.Errorf("Template manager not ctx.updated")
 		}
 
 		return true, nil


### PR DESCRIPTION
This PR fixes an issue that is hit when running templates with restart
mode in which the client could panic when the handle is not running.

Fixes https://github.com/hashicorp/nomad/issues/2479