### PR TITLE
Proper reference counting through task restarts

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -857,7 +857,7 @@ func (c *Client) setupDrivers() error {
 
 	var avail []string
 	var skipped []string
-	driverCtx := driver.NewDriverContext("", c.config, c.config.Node, c.logger, nil, nil)
+	driverCtx := driver.NewDriverContext("", "", c.config, c.config.Node, c.logger, nil, nil)
 	for name := range driver.BuiltinDrivers {
 		// Skip fingerprinting drivers that are not in the whitelist if it is
 		// enabled.

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1177,7 +1177,7 @@ func setupDockerVolumes(t *testing.T, cfg *config.Config, hostpath string) (*str
 	}
 
 	alloc := mock.Alloc()
-	execCtx := NewExecContext(taskDir, alloc.ID)
+	execCtx := NewExecContext(taskDir)
 	cleanup := func() {
 		allocDir.Destroy()
 		if filepath.IsAbs(hostpath) {
@@ -1195,7 +1195,7 @@ func setupDockerVolumes(t *testing.T, cfg *config.Config, hostpath string) (*str
 	emitter := func(m string, args ...interface{}) {
 		logger.Printf("[EVENT] "+m, args...)
 	}
-	driverCtx := NewDriverContext(task.Name, cfg, cfg.Node, testLogger(), taskEnv, emitter)
+	driverCtx := NewDriverContext(task.Name, alloc.ID, cfg, cfg.Node, testLogger(), taskEnv, emitter)
 	driver := NewDockerDriver(driverCtx)
 	copyImage(t, taskDir, "busybox.tar")
 

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -201,6 +201,7 @@ type LogEventFn func(message string, args ...interface{})
 // each time we do it. Used in conjection with Factory, above.
 type DriverContext struct {
 	taskName string
+	allocID  string
 	config   *config.Config
 	logger   *log.Logger
 	node     *structs.Node
@@ -219,10 +220,11 @@ func NewEmptyDriverContext() *DriverContext {
 // This enables other packages to create DriverContexts but keeps the fields
 // private to the driver. If we want to change this later we can gorename all of
 // the fields in DriverContext.
-func NewDriverContext(taskName string, config *config.Config, node *structs.Node,
+func NewDriverContext(taskName, allocID string, config *config.Config, node *structs.Node,
 	logger *log.Logger, taskEnv *env.TaskEnvironment, eventEmitter LogEventFn) *DriverContext {
 	return &DriverContext{
 		taskName:  taskName,
+		allocID:   allocID,
 		config:    config,
 		node:      node,
 		logger:    logger,
@@ -258,16 +260,12 @@ type DriverHandle interface {
 type ExecContext struct {
 	// TaskDir contains information about the task directory structure.
 	TaskDir *allocdir.TaskDir
-
-	// Alloc ID
-	AllocID string
 }
 
 // NewExecContext is used to create a new execution context
-func NewExecContext(td *allocdir.TaskDir, allocID string) *ExecContext {
+func NewExecContext(td *allocdir.TaskDir) *ExecContext {
 	return &ExecContext{
 		TaskDir: td,
-		AllocID: allocID,
 	}
 }
 

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -110,7 +110,7 @@ func testDriverContexts(t *testing.T, task *structs.Task) *testContext {
 		return nil
 	}
 
-	execCtx := NewExecContext(td, alloc.ID)
+	execCtx := NewExecContext(td)
 
 	taskEnv, err := GetTaskEnv(td, cfg.Node, task, alloc, cfg, "")
 	if err != nil {
@@ -123,7 +123,7 @@ func testDriverContexts(t *testing.T, task *structs.Task) *testContext {
 	emitter := func(m string, args ...interface{}) {
 		logger.Printf("[EVENT] "+m, args...)
 	}
-	driverCtx := NewDriverContext(task.Name, cfg, cfg.Node, logger, taskEnv, emitter)
+	driverCtx := NewDriverContext(task.Name, alloc.ID, cfg, cfg.Node, logger, taskEnv, emitter)
 
 	return &testContext{allocDir, driverCtx, execCtx}
 }

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -124,7 +124,7 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	executorCtx := &executor.ExecutorContext{
 		TaskEnv: d.taskEnv,
 		Driver:  "exec",
-		AllocID: ctx.AllocID,
+		AllocID: d.DriverContext.allocID,
 		LogDir:  ctx.TaskDir.LogDir,
 		TaskDir: ctx.TaskDir.Dir,
 		Task:    task,

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -248,7 +248,7 @@ func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	executorCtx := &executor.ExecutorContext{
 		TaskEnv: d.taskEnv,
 		Driver:  "java",
-		AllocID: ctx.AllocID,
+		AllocID: d.DriverContext.allocID,
 		Task:    task,
 		TaskDir: ctx.TaskDir.Dir,
 		LogDir:  ctx.TaskDir.LogDir,

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -186,7 +186,7 @@ func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 		lxcPath = path
 	}
 
-	containerName := fmt.Sprintf("%s-%s", task.Name, ctx.AllocID)
+	containerName := fmt.Sprintf("%s-%s", task.Name, d.DriverContext.allocID)
 	c, err := lxc.NewContainer(containerName, lxcPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize container: %v", err)

--- a/client/driver/lxc_test.go
+++ b/client/driver/lxc_test.go
@@ -102,7 +102,7 @@ func TestLxcDriver_Start_Wait(t *testing.T) {
 	})
 
 	// Look for mounted directories in their proper location
-	containerName := fmt.Sprintf("%s-%s", task.Name, ctx.ExecCtx.AllocID)
+	containerName := fmt.Sprintf("%s-%s", task.Name, ctx.DriverCtx.allocID)
 	for _, mnt := range []string{"alloc", "local", "secrets"} {
 		fullpath := filepath.Join(lxcHandle.lxcPath, containerName, "rootfs", mnt)
 		stat, err := os.Stat(fullpath)

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -238,7 +238,7 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	executorCtx := &executor.ExecutorContext{
 		TaskEnv: d.taskEnv,
 		Driver:  "qemu",
-		AllocID: ctx.AllocID,
+		AllocID: d.DriverContext.allocID,
 		Task:    task,
 		TaskDir: ctx.TaskDir.Dir,
 		LogDir:  ctx.TaskDir.LogDir,

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -129,7 +129,7 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandl
 	executorCtx := &executor.ExecutorContext{
 		TaskEnv: d.taskEnv,
 		Driver:  "raw_exec",
-		AllocID: ctx.AllocID,
+		AllocID: d.DriverContext.allocID,
 		Task:    task,
 		TaskDir: ctx.TaskDir.Dir,
 		LogDir:  ctx.TaskDir.LogDir,

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -257,17 +257,17 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	sanitizedName := strings.Replace(task.Name, "_", "-", -1)
 
 	// Mount /alloc
-	allocVolName := fmt.Sprintf("%s-%s-alloc", ctx.AllocID, sanitizedName)
+	allocVolName := fmt.Sprintf("%s-%s-alloc", d.DriverContext.allocID, sanitizedName)
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--volume=%s,kind=host,source=%s", allocVolName, ctx.TaskDir.SharedAllocDir))
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--mount=volume=%s,target=%s", allocVolName, allocdir.SharedAllocContainerPath))
 
 	// Mount /local
-	localVolName := fmt.Sprintf("%s-%s-local", ctx.AllocID, sanitizedName)
+	localVolName := fmt.Sprintf("%s-%s-local", d.DriverContext.allocID, sanitizedName)
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--volume=%s,kind=host,source=%s", localVolName, ctx.TaskDir.LocalDir))
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--mount=volume=%s,target=%s", localVolName, allocdir.TaskLocalContainerPath))
 
 	// Mount /secrets
-	secretsVolName := fmt.Sprintf("%s-%s-secrets", ctx.AllocID, sanitizedName)
+	secretsVolName := fmt.Sprintf("%s-%s-secrets", d.DriverContext.allocID, sanitizedName)
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--volume=%s,kind=host,source=%s", secretsVolName, ctx.TaskDir.SecretsDir))
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--mount=volume=%s,target=%s", secretsVolName, allocdir.TaskSecretsContainerPath))
 
@@ -281,7 +281,7 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 			if len(parts) != 2 {
 				return nil, fmt.Errorf("invalid rkt volume: %q", rawvol)
 			}
-			volName := fmt.Sprintf("%s-%s-%d", ctx.AllocID, sanitizedName, i)
+			volName := fmt.Sprintf("%s-%s-%d", d.DriverContext.allocID, sanitizedName, i)
 			cmdArgs = append(cmdArgs, fmt.Sprintf("--volume=%s,kind=host,source=%s", volName, parts[0]))
 			cmdArgs = append(cmdArgs, fmt.Sprintf("--mount=volume=%s,target=%s", volName, parts[1]))
 		}
@@ -413,7 +413,7 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	executorCtx := &executor.ExecutorContext{
 		TaskEnv: d.taskEnv,
 		Driver:  "rkt",
-		AllocID: ctx.AllocID,
+		AllocID: d.DriverContext.allocID,
 		Task:    task,
 		TaskDir: ctx.TaskDir.Dir,
 		LogDir:  ctx.TaskDir.LogDir,

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -280,7 +280,7 @@ func (r *TaskRunner) RestoreState() error {
 			return err
 		}
 
-		ctx := driver.NewExecContext(r.taskDir, r.alloc.ID)
+		ctx := driver.NewExecContext(r.taskDir)
 		handle, err := d.Open(ctx, snap.HandleID)
 
 		// In the case it fails, we relaunch the task in the Run() method.
@@ -378,7 +378,7 @@ func (r *TaskRunner) createDriver() (driver.Driver, error) {
 		r.setState(structs.TaskStatePending, structs.NewTaskEvent(structs.TaskDriverMessage).SetDriverMessage(msg))
 	}
 
-	driverCtx := driver.NewDriverContext(r.task.Name, r.config, r.config.Node, r.logger, env, eventEmitter)
+	driverCtx := driver.NewDriverContext(r.task.Name, r.alloc.ID, r.config, r.config.Node, r.logger, env, eventEmitter)
 	driver, err := driver.NewDriver(r.task.Driver, driverCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create driver '%s' for alloc %s: %v",
@@ -1061,7 +1061,7 @@ func (r *TaskRunner) cleanup() {
 
 	res := r.getCreatedResources()
 
-	ctx := driver.NewExecContext(r.taskDir, r.alloc.ID)
+	ctx := driver.NewExecContext(r.taskDir)
 	attempts := 1
 	var cleanupErr error
 	for retry := true; retry; attempts++ {
@@ -1182,7 +1182,7 @@ func (r *TaskRunner) startTask() error {
 	}
 
 	// Run prestart
-	ctx := driver.NewExecContext(r.taskDir, r.alloc.ID)
+	ctx := driver.NewExecContext(r.taskDir)
 	res, err := drv.Prestart(ctx, r.task)
 
 	// Merge newly created resources into previously created resources


### PR DESCRIPTION
This PR fixes an issue in which the reference count on a Docker image
would become inflated through task restarts.