### PR TITLE
Fix typo in documentation link

### DIFF
--- a/website/source/docs/operating-a-job/update-strategies/rolling-upgrades.html.md
+++ b/website/source/docs/operating-a-job/update-strategies/rolling-upgrades.html.md
@@ -50,7 +50,7 @@ that is configured with the same rolling update strategy from above.
 +        image = "nginx:1.11"
 ```
 
-The [`nomad plan` command](http://localhost:4567/docs/commands/plan.html) allows
+The [`nomad plan` command](/docs/commands/plan.html) allows
 us to visualize the series of steps the scheduler would perform. We can analyze
 this output to confirm it is correct:
 


### PR DESCRIPTION
Remove localhost URL in `nomad plan` command link

Remove the reference to `http://localhost:4567` within the Rolling Upgrade
strategy documentation and fix the link to the `nomad plan` command
documentation.