### PR TITLE
Fix NOMAD_{IP,PORT}_<task>_<label> env variables

### DIFF
--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -205,10 +205,10 @@ func (t *TaskEnvironment) Build() *TaskEnvironment {
 			for _, nw := range resources.Networks {
 				ports := make([]*structs.Port, 0, len(nw.ReservedPorts)+len(nw.DynamicPorts))
 				for _, port := range nw.ReservedPorts {
-					ports = append(ports, &port)
+					ports = append(ports, &structs.Port{port.Label, port.Value})
 				}
 				for _, port := range nw.DynamicPorts {
-					ports = append(ports, &port)
+					ports = append(ports, &structs.Port{port.Label, port.Value})
 				}
 				for _, p := range ports {
 					key := fmt.Sprintf("%s%s_%s", AddrPrefix, taskName, p.Label)

--- a/client/driver/env/env_test.go
+++ b/client/driver/env/env_test.go
@@ -139,6 +139,7 @@ func TestEnvironment_AsList(t *testing.T) {
 	n := mock.Node()
 	a := mock.Alloc()
 	a.TaskResources["web"].Networks[0].DynamicPorts[0].Value = 2000
+	//a.TaskResources["web2"].Networks[0].DynamicPorts[1].Value = 2000
 	env := NewTaskEnvironment(n).
 		SetNetworks(networks).
 		SetPortMap(portMap).
@@ -153,16 +154,25 @@ func TestEnvironment_AsList(t *testing.T) {
 		"NOMAD_IP_http=127.0.0.1",
 		"NOMAD_ADDR_https=127.0.0.1:443",
 		"NOMAD_PORT_https=443",
+		"NOMAD_PORT_web2_http21=0",
+		"NOMAD_PORT_web2_http22=0",
 		"NOMAD_IP_https=127.0.0.1",
 		"NOMAD_HOST_PORT_http=80",
 		"NOMAD_HOST_PORT_https=8080",
 		"NOMAD_META_FOO=baz",
 		"NOMAD_META_foo=baz",
+		"NOMAD_ADDR_web2_http22=192.168.0.100:0",
+		"NOMAD_ADDR_web2_http21=192.168.0.100:0",
 		"NOMAD_ADDR_web_main=192.168.0.100:5000",
+		"NOMAD_ADDR_web2_main2=192.168.0.100:5002",
 		"NOMAD_ADDR_web_http=192.168.0.100:2000",
 		"NOMAD_PORT_web_main=5000",
+		"NOMAD_PORT_web2_main2=5002",
 		"NOMAD_PORT_web_http=2000",
 		"NOMAD_IP_web_main=192.168.0.100",
+		"NOMAD_IP_web2_http21=192.168.0.100",
+		"NOMAD_IP_web2_http22=192.168.0.100",
+		"NOMAD_IP_web2_main2=192.168.0.100",
 		"NOMAD_IP_web_http=192.168.0.100",
 		"NOMAD_TASK_NAME=taskA",
 	}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -263,11 +263,17 @@ func Alloc() *structs.Allocation {
 			DiskMB:   150,
 			Networks: []*structs.NetworkResource{
 				&structs.NetworkResource{
-					Device:        "eth0",
-					IP:            "192.168.0.100",
-					ReservedPorts: []structs.Port{{Label: "main", Value: 5000}},
-					MBits:         50,
-					DynamicPorts:  []structs.Port{{Label: "http"}},
+					Device: "eth0",
+					IP:     "192.168.0.100",
+					ReservedPorts: []structs.Port{
+						{Label: "main", Value: 5000},
+						{Label: "main2", Value: 5002},
+					},
+					MBits: 50,
+					DynamicPorts: []structs.Port{
+						{Label: "http"},
+						{Label: "http2"},
+					},
 				},
 			},
 		},
@@ -282,6 +288,22 @@ func Alloc() *structs.Allocation {
 						ReservedPorts: []structs.Port{{Label: "main", Value: 5000}},
 						MBits:         50,
 						DynamicPorts:  []structs.Port{{Label: "http"}},
+					},
+				},
+			},
+			"web2": &structs.Resources{
+				CPU:      500,
+				MemoryMB: 256,
+				Networks: []*structs.NetworkResource{
+					&structs.NetworkResource{
+						Device:        "eth0",
+						IP:            "192.168.0.100",
+						ReservedPorts: []structs.Port{{Label: "main2", Value: 5002}},
+						MBits:         50,
+						DynamicPorts: []structs.Port{
+							{Label: "http21"},
+							{Label: "http22"},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
We iterated over a []struct.Port slice. This had the side effect that
we overwrote all but the last port in this slice.

I.e.

NOMAD_PORT_task1_label11
NOMAD_PORT_task1_label12

Would collapse to:

NOMAD_PORT_task1_label12