### PR TITLE
[Docker driver] - Adding support for sysctl and ulimit configuration

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -142,6 +142,10 @@ type DockerDriverConfig struct {
 	PortMapRaw       []map[string]int    `mapstructure:"port_map"`           //
 	PortMap          map[string]int      `mapstructure:"-"`                  // A map of host port labels and the ports exposed on the container
 	Privileged       bool                `mapstructure:"privileged"`         // Flag to run the container in privileged mode
+	SysctlsRaw       []map[string]string `mapstructure:"sysctls"`            //
+	Sysctls          map[string]string   `mapstructure:"-"`                  // The sysctl custom configurations
+	UlimitsRaw       []map[string]string `mapstructure:"ulimits"`            //
+	Ulimits          []docker.ULimit     `mapstructure:"-"`                  // The ulimit custom configurations
 	DNSServers       []string            `mapstructure:"dns_servers"`        // DNS Server for containers
 	DNSSearchDomains []string            `mapstructure:"dns_search_domains"` // DNS Search domains for containers
 	Hostname         string              `mapstructure:"hostname"`           // Hostname for containers
@@ -158,6 +162,37 @@ type DockerDriverConfig struct {
 	ForcePull        bool                `mapstructure:"force_pull"`         // Always force pull before running image, useful if your tags are mutable
 }
 
+func sliceMergeUlimit(ulimitsRaw map[string]string) ([]docker.ULimit, error) {
+	var ulimits []docker.ULimit
+
+	for name, ulimitRaw := range ulimitsRaw {
+		splitted := strings.SplitN(ulimitRaw, ":", 2)
+
+		soft, err := strconv.Atoi(splitted[0])
+		if err != nil {
+			return []docker.ULimit{}, fmt.Errorf("Malformed ulimit %v: %v", name, ulimitRaw)
+		}
+
+		ulimit := docker.ULimit{
+			Name: name,
+			Soft: int64(soft),
+			Hard: int64(soft), // default: can be override
+		}
+
+		// hard limit is optional
+		if len(splitted) == 2 {
+			if hard, err := strconv.Atoi(splitted[1]); err != nil {
+				return []docker.ULimit{}, fmt.Errorf("Malformed ulimit %v: %v", name, ulimitRaw)
+			} else {
+				ulimit.Hard = int64(hard)
+			}
+		}
+
+		ulimits = append(ulimits, ulimit)
+	}
+	return ulimits, nil
+}
+
 // Validate validates a docker driver config
 func (c *DockerDriverConfig) Validate() error {
 	if c.ImageName == "" {
@@ -165,10 +200,18 @@ func (c *DockerDriverConfig) Validate() error {
 	}
 
 	c.PortMap = mapMergeStrInt(c.PortMapRaw...)
+	c.Sysctls = mapMergeStrStr(c.SysctlsRaw...)
 	c.Labels = mapMergeStrStr(c.LabelsRaw...)
 	if len(c.Logging) > 0 {
 		c.Logging[0].Config = mapMergeStrStr(c.Logging[0].ConfigRaw...)
 	}
+
+	mergedUlimitsRaw := mapMergeStrStr(c.UlimitsRaw...)
+	ulimits, err := sliceMergeUlimit(mergedUlimitsRaw)
+	if err != nil {
+		return err
+	}
+	c.Ulimits = ulimits
 	return nil
 }
 
@@ -196,6 +239,20 @@ func NewDockerDriverConfig(task *structs.Task, env *env.TaskEnvironment) (*Docke
 	dconf.VolumeDriver = env.ReplaceEnv(dconf.VolumeDriver)
 	dconf.DNSServers = env.ParseAndReplace(dconf.DNSServers)
 	dconf.DNSSearchDomains = env.ParseAndReplace(dconf.DNSSearchDomains)
+
+	for _, m := range dconf.SysctlsRaw {
+		for k, v := range m {
+			delete(m, k)
+			m[env.ReplaceEnv(k)] = env.ReplaceEnv(v)
+		}
+	}
+
+	for _, m := range dconf.UlimitsRaw {
+		for k, v := range m {
+			delete(m, k)
+			m[env.ReplaceEnv(k)] = env.ReplaceEnv(v)
+		}
+	}
 
 	for _, m := range dconf.LabelsRaw {
 		for k, v := range m {
@@ -349,6 +406,12 @@ func (d *DockerDriver) Validate(config map[string]interface{}) error {
 			},
 			"userns_mode": &fields.FieldSchema{
 				Type: fields.TypeString,
+			},
+			"sysctls": &fields.FieldSchema{
+				Type: fields.TypeArray,
+			},
+			"ulimits": &fields.FieldSchema{
+				Type: fields.TypeArray,
 			},
 			"port_map": &fields.FieldSchema{
 				Type: fields.TypeArray,
@@ -817,6 +880,8 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 	hostConfig.PidMode = driverConfig.PidMode
 	hostConfig.UTSMode = driverConfig.UTSMode
 	hostConfig.UsernsMode = driverConfig.UsernsMode
+	hostConfig.Sysctls = driverConfig.Sysctls
+	hostConfig.Ulimits = driverConfig.Ulimits
 
 	hostConfig.NetworkMode = driverConfig.NetworkMode
 	if hostConfig.NetworkMode == "" {

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -692,8 +692,8 @@ func TestDockerDriver_NetworkAliases_Bridge(t *testing.T) {
 func TestDockerDriver_Sysctls_Ulimits(t *testing.T) {
 	task, _, _ := dockerTask()
 	expectedUlimits := map[string]string{
-		"nproc":   "4242",
-		"nofiles": "2048:4096",
+		"nproc":  "4242",
+		"nofile": "2048:4096",
 	}
 	task.Config["sysctls"] = []map[string]string{
 		map[string]string{

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -689,6 +689,60 @@ func TestDockerDriver_NetworkAliases_Bridge(t *testing.T) {
 	}
 }
 
+func TestDockerDriver_Sysctls_Ulimits(t *testing.T) {
+	task, _, _ := dockerTask()
+	expectedUlimits := map[string]string{
+		"nproc":   "4242",
+		"nofiles": "2048:4096",
+	}
+	task.Config["sysctls"] = []map[string]string{
+		map[string]string{
+			"net.core.somaxconn": "16384",
+		},
+	}
+	task.Config["ulimits"] = []map[string]string{
+		expectedUlimits,
+	}
+
+	client, handle, cleanup := dockerSetup(t, task)
+	defer cleanup()
+
+	waitForExist(t, client, handle.(*DockerHandle))
+
+	container, err := client.InspectContainer(handle.(*DockerHandle).ContainerID())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if want, got := "16384", container.HostConfig.Sysctls["net.core.somaxconn"]; want != got {
+		t.Errorf("Wrong net.core.somaxconn config for docker job. Expect: %s, got: %s", want, got)
+	}
+
+	if want, got := 2, len(container.HostConfig.Ulimits); want != got {
+		t.Errorf("Wrong number of ulimit configs for docker job. Expect: %s, got: %s", want, got)
+	}
+	for _, got := range container.HostConfig.Ulimits {
+		if expectedStr, ok := expectedUlimits[got.Name]; ok == false {
+			t.Errorf("%s config unexpected for docker job.", got.Name)
+		} else {
+			if strings.Contains(expectedStr, ":") == false {
+				expectedStr = expectedStr + ":" + expectedStr
+			}
+
+			splitted := strings.SplitN(expectedStr, ":", 2)
+			soft, _ := strconv.Atoi(splitted[0])
+			hard, _ := strconv.Atoi(splitted[1])
+
+			if got.Soft != int64(soft) {
+				t.Errorf("Wrong soft %s ulimit for docker job. Expect: %d, got: %d", got.Name, soft, got.Soft)
+			}
+			if got.Hard != int64(hard) {
+				t.Errorf("Wrong hard %s ulimit for docker job. Expect: %d, got: %d", got.Name, hard, got.Hard)
+			}
+		}
+	}
+}
+
 func TestDockerDriver_Labels(t *testing.T) {
 	task, _, _ := dockerTask()
 	task.Config["labels"] = []map[string]string{

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -689,18 +689,18 @@ func TestDockerDriver_NetworkAliases_Bridge(t *testing.T) {
 	}
 }
 
-func TestDockerDriver_Sysctls_Ulimits(t *testing.T) {
+func TestDockerDriver_Sysctl_Ulimit(t *testing.T) {
 	task, _, _ := dockerTask()
 	expectedUlimits := map[string]string{
 		"nproc":  "4242",
 		"nofile": "2048:4096",
 	}
-	task.Config["sysctls"] = []map[string]string{
+	task.Config["sysctl"] = []map[string]string{
 		map[string]string{
 			"net.core.somaxconn": "16384",
 		},
 	}
-	task.Config["ulimits"] = []map[string]string{
+	task.Config["ulimit"] = []map[string]string{
 		expectedUlimits,
 	}
 
@@ -719,7 +719,7 @@ func TestDockerDriver_Sysctls_Ulimits(t *testing.T) {
 	}
 
 	if want, got := 2, len(container.HostConfig.Ulimits); want != got {
-		t.Errorf("Wrong number of ulimit configs for docker job. Expect: %s, got: %s", want, got)
+		t.Errorf("Wrong number of ulimit configs for docker job. Expect: %d, got: %d", want, got)
 	}
 	for _, got := range container.HostConfig.Ulimits {
 		if expectedStr, ok := expectedUlimits[got.Name]; ok == false {

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -97,6 +97,29 @@ The `docker` driver supports the following configuration in the job spec:
     }
     ```
 
+* `sysctls` - (Optional) A key-value map of sysctl configurations to set to the
+  containers on start.
+
+    ```hcl
+    config {
+      sysctls {
+        net.core.somaxconn = "16384"
+      }
+    }
+    ```
+
+* `ulimits` - (Optional) A key-value map of ulimits configurations to set to the
+  containers on start.
+
+    ```hcl
+    config {
+      ulimits {
+        nproc = "4242"
+        nofile = "2048:4096"
+      }
+    }
+    ```
+
 * `privileged` - (Optional) `true` or `false` (default). Privileged mode gives
   the container access to devices on the host. Note that this also requires the
   nomad agent and docker daemon to be configured to allow privileged

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -97,23 +97,23 @@ The `docker` driver supports the following configuration in the job spec:
     }
     ```
 
-* `sysctls` - (Optional) A key-value map of sysctl configurations to set to the
+* `sysctl` - (Optional) A key-value map of sysctl configurations to set to the
   containers on start.
 
     ```hcl
     config {
-      sysctls {
+      sysctl {
         net.core.somaxconn = "16384"
       }
     }
     ```
 
-* `ulimits` - (Optional) A key-value map of ulimits configurations to set to the
+* `ulimit` - (Optional) A key-value map of ulimit configurations to set to the
   containers on start.
 
     ```hcl
     config {
-      ulimits {
+      ulimit {
         nproc = "4242"
         nofile = "2048:4096"
       }


### PR DESCRIPTION
```hcl
task "db" {
    driver = "docker"
    config {
      image: "redis:3.2"
      sysctl {
        net.core.somaxconn = "16384"
      }
      ulimit {
        nproc = "4242"
        nofile = "2048:4096"
      }
    }
}
```