### PR TITLE
Don't error if docker auth file doesn't exist

### DIFF
--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1408,9 +1408,9 @@ func TestDockerDriver_AuthConfiguration(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		act, err := authOptionFrom(path, c.Repo)
-		if err != nil {
-			t.Fatalf("Test %d failed: %v", i+1, err)
+		act, warning, err := authOptionFrom(path, c.Repo)
+		if err != nil || warning != nil {
+			t.Fatalf("Test %d failed: %v, %v", i+1, warning, err)
 		}
 
 		if !reflect.DeepEqual(act, c.AuthConfig) {


### PR DESCRIPTION
This PR makes it so that if the docker driver is configured to use an
auth file, if the auth file doesn't exist a warning is shown and empty
auth rather than hard failing.