### PR TITLE
Track task start/finish time & improve logs errors

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -424,9 +424,11 @@ func (t *Task) SetLogConfig(l *LogConfig) *Task {
 // TaskState tracks the current state of a task and events that caused state
 // transitions.
 type TaskState struct {
-	State  string
-	Failed bool
-	Events []*TaskEvent
+	State      string
+	Failed     bool
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Events     []*TaskEvent
 }
 
 const (

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -633,6 +633,9 @@ func TestAllocRunner_TaskFailed_KillTG(t *testing.T) {
 		if state1.State != structs.TaskStateDead {
 			return false, fmt.Errorf("got state %v; want %v", state1.State, structs.TaskStateDead)
 		}
+		if state1.FinishedAt.IsZero() || state1.StartedAt.IsZero() {
+			return false, fmt.Errorf("expected to have a start and finish time")
+		}
 		if len(state1.Events) < 2 {
 			// At least have a received and destroyed
 			return false, fmt.Errorf("Unexpected number of events")
@@ -700,6 +703,9 @@ func TestAllocRunner_TaskLeader_KillTG(t *testing.T) {
 		if state1.State != structs.TaskStateDead {
 			return false, fmt.Errorf("got state %v; want %v", state1.State, structs.TaskStateDead)
 		}
+		if state1.FinishedAt.IsZero() || state1.StartedAt.IsZero() {
+			return false, fmt.Errorf("expected to have a start and finish time")
+		}
 		if len(state1.Events) < 2 {
 			// At least have a received and destroyed
 			return false, fmt.Errorf("Unexpected number of events")
@@ -720,6 +726,9 @@ func TestAllocRunner_TaskLeader_KillTG(t *testing.T) {
 		state2 := last.TaskStates[task2.Name]
 		if state2.State != structs.TaskStateDead {
 			return false, fmt.Errorf("got state %v; want %v", state2.State, structs.TaskStateDead)
+		}
+		if state2.FinishedAt.IsZero() || state2.StartedAt.IsZero() {
+			return false, fmt.Errorf("expected to have a start and finish time")
 		}
 
 		return true, nil

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2774,6 +2774,14 @@ type TaskState struct {
 	// Failed marks a task as having failed
 	Failed bool
 
+	// StartedAt is the time the task is started. It is updated each time the
+	// task starts
+	StartedAt time.Time
+
+	// FinishedAt is the time at which the task transistioned to dead and will
+	// not be started again.
+	FinishedAt time.Time
+
 	// Series of task events that transition the state of the task.
 	Events []*TaskEvent
 }
@@ -2785,6 +2793,8 @@ func (ts *TaskState) Copy() *TaskState {
 	copy := new(TaskState)
 	copy.State = ts.State
 	copy.Failed = ts.Failed
+	copy.StartedAt = ts.StartedAt
+	copy.FinishedAt = ts.FinishedAt
 
 	if ts.Events != nil {
 		copy.Events = make([]*TaskEvent, len(ts.Events))

--- a/website/source/docs/http/alloc.html.md
+++ b/website/source/docs/http/alloc.html.md
@@ -225,6 +225,8 @@ be specified using the `?region=` query parameter.
             }
           ],
           "State": "running"
+          "FinishedAt": "0001-01-01T00:00:00Z",
+          "StartedAt": "2017-03-31T22:51:40.248633594Z",
           "Failed": false,
         }
       },
@@ -246,6 +248,10 @@ be specified using the `?region=` query parameter.
       time or due to a restart.
     * `TaskStateRunning` - The task is currently running.
     * `TaskStateDead` - The task is dead and will not run again.
+
+    Further the state contains the `StartedAt` and `FinishedAt` times of the
+    task. `StartedAt` can be updated multiple times if the task restarts but
+    `FinishedAt` is set only when the task transistions to `TaskStateDead`
 
     <p>The latest 10 events are stored per task. Each event is timestamped (unix nano-seconds)
     and has one of the following types:</p>


### PR DESCRIPTION
This PR adds tracking to when a task starts and finishes and the logs
API takes advantage of this and returns better errors when asking for
logs that do not exist.