### PR TITLE
Add sticky bit to temp directory

### DIFF
--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -40,7 +40,7 @@ var (
 	TaskSecrets = "secrets"
 
 	// TaskDirs is the set of directories created in each tasks directory.
-	TaskDirs = []string{"tmp"}
+	TaskDirs = map[string]os.FileMode{"tmp": os.ModeSticky | 0777}
 )
 
 type AllocDir struct {
@@ -250,7 +250,7 @@ func (d *AllocDir) Build() error {
 	}
 
 	// Make the shared directory have non-root permissions.
-	if err := dropDirPermissions(d.SharedDir); err != nil {
+	if err := dropDirPermissions(d.SharedDir, os.ModePerm); err != nil {
 		return err
 	}
 
@@ -260,7 +260,7 @@ func (d *AllocDir) Build() error {
 		if err := os.MkdirAll(p, 0777); err != nil {
 			return err
 		}
-		if err := dropDirPermissions(p); err != nil {
+		if err := dropDirPermissions(p, os.ModePerm); err != nil {
 			return err
 		}
 	}

--- a/client/allocdir/fs_unix.go
+++ b/client/allocdir/fs_unix.go
@@ -28,8 +28,8 @@ var (
 
 // dropDirPermissions gives full access to a directory to all users and sets
 // the owner to nobody.
-func dropDirPermissions(path string) error {
-	if err := os.Chmod(path, 0777); err != nil {
+func dropDirPermissions(path string, desired os.FileMode) error {
+	if err := os.Chmod(path, desired|0777); err != nil {
 		return fmt.Errorf("Chmod(%v) failed: %v", path, err)
 	}
 

--- a/client/allocdir/fs_windows.go
+++ b/client/allocdir/fs_windows.go
@@ -51,7 +51,7 @@ func removeSecretDir(dir string) error {
 }
 
 // The windows version does nothing currently.
-func dropDirPermissions(path string) error {
+func dropDirPermissions(path string, desired os.FileMode) error {
 	return nil
 }
 

--- a/client/allocdir/task_dir.go
+++ b/client/allocdir/task_dir.go
@@ -66,7 +66,7 @@ func (t *TaskDir) Build(chrootCreated bool, chroot map[string]string, fsi cstruc
 	}
 
 	// Make the task directory have non-root permissions.
-	if err := dropDirPermissions(t.Dir); err != nil {
+	if err := dropDirPermissions(t.Dir, os.ModePerm); err != nil {
 		return err
 	}
 
@@ -75,18 +75,18 @@ func (t *TaskDir) Build(chrootCreated bool, chroot map[string]string, fsi cstruc
 		return err
 	}
 
-	if err := dropDirPermissions(t.LocalDir); err != nil {
+	if err := dropDirPermissions(t.LocalDir, os.ModePerm); err != nil {
 		return err
 	}
 
 	// Create the directories that should be in every task.
-	for _, dir := range TaskDirs {
+	for dir, perms := range TaskDirs {
 		absdir := filepath.Join(t.Dir, dir)
-		if err := os.MkdirAll(absdir, 0777); err != nil {
+		if err := os.MkdirAll(absdir, perms); err != nil {
 			return err
 		}
 
-		if err := dropDirPermissions(absdir); err != nil {
+		if err := dropDirPermissions(absdir, perms); err != nil {
 			return err
 		}
 	}
@@ -110,7 +110,7 @@ func (t *TaskDir) Build(chrootCreated bool, chroot map[string]string, fsi cstruc
 		return err
 	}
 
-	if err := dropDirPermissions(t.SecretsDir); err != nil {
+	if err := dropDirPermissions(t.SecretsDir, os.ModePerm); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes an issue where the Ruby runtime expects the sticky bit to be set
on the temp directory. The sticky bit is commonly set on the temp
directory since it is usually shared by many users. This change brings
ours in line with that assumption.