### PR TITLE
Require TLS for server RPC when enabled

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -414,12 +414,13 @@ func TestClient_MixedTLS(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Region: "global"},
 	}
 	var out structs.SingleNodeResponse
-	deadline := time.Now().Add(1234 * time.Millisecond)
+	deadline := time.Now().Add(100 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		err := c1.RPC("Node.GetNode", &req, &out)
 		if err == nil {
 			t.Fatalf("client RPC succeeded when it should have failed:\n%+v", out)
 		}
+		time.Sleep(3 * time.Millisecond)
 	}
 }
 
@@ -466,12 +467,13 @@ func TestClient_BadTLS(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Region: "global"},
 	}
 	var out structs.SingleNodeResponse
-	deadline := time.Now().Add(1234 * time.Millisecond)
+	deadline := time.Now().Add(100 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		err := c1.RPC("Node.GetNode", &req, &out)
 		if err == nil {
 			t.Fatalf("client RPC succeeded when it should have failed:\n%+v", out)
 		}
+		time.Sleep(3 * time.Millisecond)
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -414,14 +414,18 @@ func TestClient_MixedTLS(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Region: "global"},
 	}
 	var out structs.SingleNodeResponse
-	deadline := time.Now().Add(100 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		err := c1.RPC("Node.GetNode", &req, &out)
-		if err == nil {
-			t.Fatalf("client RPC succeeded when it should have failed:\n%+v", out)
-		}
-		time.Sleep(3 * time.Millisecond)
-	}
+	testutil.AssertUntil(100*time.Millisecond,
+		func() (bool, error) {
+			err := c1.RPC("Node.GetNode", &req, &out)
+			if err == nil {
+				return false, fmt.Errorf("client RPC succeeded when it should have failed:\n%+v", out)
+			}
+			return true, nil
+		},
+		func(err error) {
+			t.Fatalf(err.Error())
+		},
+	)
 }
 
 // TestClient_BadTLS asserts that when a client and server are running with TLS
@@ -467,14 +471,18 @@ func TestClient_BadTLS(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Region: "global"},
 	}
 	var out structs.SingleNodeResponse
-	deadline := time.Now().Add(100 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		err := c1.RPC("Node.GetNode", &req, &out)
-		if err == nil {
-			t.Fatalf("client RPC succeeded when it should have failed:\n%+v", out)
-		}
-		time.Sleep(3 * time.Millisecond)
-	}
+	testutil.AssertUntil(100*time.Millisecond,
+		func() (bool, error) {
+			err := c1.RPC("Node.GetNode", &req, &out)
+			if err == nil {
+				return false, fmt.Errorf("client RPC succeeded when it should have failed:\n%+v", out)
+			}
+			return true, nil
+		},
+		func(err error) {
+			t.Fatalf(err.Error())
+		},
+	)
 }
 
 func TestClient_Register(t *testing.T) {

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -92,9 +92,6 @@ type Config struct {
 	// RaftTimeout is applied to any network traffic for raft. Defaults to 10s.
 	RaftTimeout time.Duration
 
-	// RequireTLS ensures that all RPC traffic is protected with TLS
-	RequireTLS bool
-
 	// SerfConfig is the configuration for the serf cluster
 	SerfConfig *serf.Config
 

--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -97,8 +97,8 @@ func (s *Server) handleConn(conn net.Conn, isTLS bool) {
 		return
 	}
 
-	// Enforce TLS if VerifyIncoming is set
-	if s.config.RequireTLS && !isTLS && RPCType(buf[0]) != rpcTLS {
+	// Enforce TLS if EnableRPC is set
+	if s.config.TLSConfig.EnableRPC && !isTLS && RPCType(buf[0]) != rpcTLS {
 		s.logger.Printf("[WARN] nomad.rpc: Non-TLS connection attempted with RequireTLS set")
 		conn.Close()
 		return

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -37,6 +37,21 @@ func WaitForResultRetries(retries int64, test testFn, error errorFn) {
 	}
 }
 
+// AssertUntil asserts the test function passes throughout the given duration.
+// Otherwise error is called on failure.
+func AssertUntil(until time.Duration, test testFn, error errorFn) {
+	deadline := time.Now().Add(until)
+	for time.Now().Before(deadline) {
+		success, err := test()
+		if !success {
+			error(err)
+			return
+		}
+		// Sleep some arbitrary fraction of the deadline
+		time.Sleep(until / 30)
+	}
+}
+
 // TestMultiplier returns a multiplier for retries and waits given environment
 // the tests are being run under.
 func TestMultiplier() int64 {


### PR DESCRIPTION
Fixes #2525

We used to be checking a RequireTLS field that was never set. Instead we
can just check the TLSConfig.EnableRPC field and require TLS if it's
enabled.

Added a few unfortunately slow integration tests to assert the intended
behavior of misconfigured RPC TLS.

Also disable a lot of noisy test logging when -v isn't specified.