### PR TITLE
Allow specifying container IP with docker driver

### DIFF
--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -144,11 +144,11 @@ The `docker` driver supports the following configuration in the job spec:
     }
     ```
 
-* `ipv4_address` - (Optional) The IPv4 address to be used for the container. In
-  requires docker 1.13.0.
+* `ipv4_address` - (Optional) The IPv4 address to be used for the container.
+  Requires docker 1.13.0. Only works with user defined networks.
 
-* `ipv6_address` - (Optional) The IPv6 address to be used for the container. In
-  requires docker 1.13.0.
+* `ipv6_address` - (Optional) The IPv6 address to be used for the container.
+  Requires docker 1.13.0. Only works with user defined networks.
 
 * `hostname` - (Optional) The hostname to assign to the container. When
   launching more than one of a task (using `count`) with this option set, every

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -144,6 +144,12 @@ The `docker` driver supports the following configuration in the job spec:
     }
     ```
 
+* `ipv4_address` - (Optional) The IPv4 address to be used for the container. In
+  requires docker 1.13.0.
+
+* `ipv6_address` - (Optional) The IPv6 address to be used for the container. In
+  requires docker 1.13.0.
+
 * `hostname` - (Optional) The hostname to assign to the container. When
   launching more than one of a task (using `count`) with this option set, every
   container the task starts will have the same hostname.


### PR DESCRIPTION
The ability to specify a container IP was added in docker 1.13.0. This PR exposes those options to nomad.