### PR TITLE
Hash host ID so its stable and well distributed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -655,9 +655,13 @@ func (c *Client) getAllocRunners() map[string]*AllocRunner {
 func (c *Client) nodeID() (id, secret string, err error) {
 	var hostID string
 	hostInfo, err := host.Info()
-	if !c.config.NoHostUUID && err == nil && helper.IsUUID(hostInfo.HostID) {
-		hostID = hostInfo.HostID
-	} else {
+	if !c.config.NoHostUUID && err == nil {
+		if hashed, ok := helper.HashUUID(hostInfo.HostID); ok {
+			hostID = hashed
+		}
+	}
+
+	if hostID == "" {
 		// Generate a random hostID if no constant ID is available on
 		// this platform.
 		hostID = structs.GenerateUUID()

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -1,6 +1,8 @@
 package helper
 
 import (
+	"crypto/sha512"
+	"fmt"
 	"regexp"
 	"time"
 )
@@ -16,6 +18,23 @@ func IsUUID(str string) bool {
 	}
 
 	return validUUID.MatchString(str)
+}
+
+func HashUUID(input string) (output string, hashed bool) {
+	if !IsUUID(input) {
+		return "", false
+	}
+
+	// Hash the input
+	buf := sha512.Sum512([]byte(input))
+	output = fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
+		buf[0:4],
+		buf[4:6],
+		buf[6:8],
+		buf[8:10],
+		buf[10:16])
+
+	return output, true
 }
 
 // boolToPtr returns the pointer to a boolean

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -20,6 +20,8 @@ func IsUUID(str string) bool {
 	return validUUID.MatchString(str)
 }
 
+// HashUUID takes an input UUID and returns a hashed version of the UUID to
+// ensure it is well distributed.
 func HashUUID(input string) (output string, hashed bool) {
 	if !IsUUID(input) {
 		return "", false


### PR DESCRIPTION
This PR takes the host ID and runs it through a hash so that it is well
distributed. This makes it so that machines that report similar host IDs
are easily distinguished.

Instances of similar IDs occur on EC2 where the ID is prefixed and on
motherboards created in the same batch.

Fixes https://github.com/hashicorp/nomad/issues/2534