### PR TITLE
Back-pressure on Nacks and ensure scheduling progress on failures

### DIFF
--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -103,7 +103,10 @@ type PendingEvaluations []*structs.Evaluation
 // NewEvalBroker creates a new evaluation broker. This is parameterized
 // with the timeout used for messages that are not acknowledged before we
 // assume a Nack and attempt to redeliver as well as the deliveryLimit
-// which prevents a failing eval from being endlessly delivered.
+// which prevents a failing eval from being endlessly delivered. The
+// initialNackDelay is the delay before making a Nacked evalution available
+// again for the first Nack and subsequentNackDelay is the compounding delay
+// after the first Nack.
 func NewEvalBroker(timeout, initialNackDelay, subsequentNackDelay time.Duration, deliveryLimit int) (*EvalBroker, error) {
 	if timeout < 0 {
 		return nil, fmt.Errorf("timeout cannot be negative")

--- a/nomad/eval_broker_test.go
+++ b/nomad/eval_broker_test.go
@@ -17,18 +17,33 @@ var (
 	}
 )
 
+func testBrokerConfig() *Config {
+	config := DefaultConfig()
+
+	// Tune the Nack timeout
+	config.EvalNackTimeout = 5 * time.Second
+
+	// Tune the Nack delay
+	config.EvalNackInitialReenqueueDelay = 5 * time.Millisecond
+	config.EvalNackSubsequentReenqueueDelay = 50 * time.Millisecond
+	return config
+}
+
 func testBroker(t *testing.T, timeout time.Duration) *EvalBroker {
-	if timeout == 0 {
-		timeout = 5 * time.Second
+	config := testBrokerConfig()
+
+	if timeout != 0 {
+		config.EvalNackTimeout = timeout
 	}
-	b, err := NewEvalBroker(timeout, 3)
+
+	return testBrokerFromConfig(t, config)
+}
+
+func testBrokerFromConfig(t *testing.T, c *Config) *EvalBroker {
+	b, err := NewEvalBroker(c.EvalNackTimeout, c.EvalNackInitialReenqueueDelay, c.EvalNackSubsequentReenqueueDelay, 3)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	// Tune the Nack delay
-	b.initialNackDelay = 5 * time.Millisecond
-	b.subsequentNackDelay = 50 * time.Millisecond
 
 	return b
 }

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -20,15 +20,6 @@ const (
 	// unblocked to re-enter the scheduler. A failed evaluation occurs under
 	// high contention when the schedulers plan does not make progress.
 	failedEvalUnblockInterval = 1 * time.Minute
-
-	// failedEvalFollowUpBaseLineWait is the minimum time waited before retrying
-	// a failed evaluation.
-	failedEvalFollowUpBaseLineWait = 1 * time.Minute
-
-	// failedEvalFollowUpWaitRange defines the the range of additional time from
-	// the minimum in which to wait before retrying a failed evaluation. A value
-	// from this range should be selected using a uniform distribution.
-	failedEvalFollowUpWaitRange = 9 * time.Minute
 )
 
 // monitorLeadership is used to monitor if we acquire or lose our role
@@ -405,8 +396,8 @@ func (s *Server) reapFailedEvaluations(stopCh chan struct{}) {
 			// Create a follow-up evaluation that will be used to retry the
 			// scheduling for the job after the cluster is hopefully more stable
 			// due to the fairly large backoff.
-			followupEvalWait := failedEvalFollowUpBaseLineWait +
-				time.Duration(rand.Int63n(int64(failedEvalFollowUpWaitRange)))
+			followupEvalWait := s.config.EvalFailedFollowupBaselineDelay +
+				time.Duration(rand.Int63n(int64(s.config.EvalFailedFollowupDelayRange)))
 			followupEval := eval.CreateFailedFollowUpEval(followupEvalWait)
 
 			// Update via Raft

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -397,10 +397,10 @@ func (s *Server) reapFailedEvaluations(stopCh chan struct{}) {
 			}
 
 			// Update the status to failed
-			newEval := eval.Copy()
-			newEval.Status = structs.EvalStatusFailed
-			newEval.StatusDescription = fmt.Sprintf("evaluation reached delivery limit (%d)", s.config.EvalDeliveryLimit)
-			s.logger.Printf("[WARN] nomad: eval %#v reached delivery limit, marking as failed", newEval)
+			updateEval := eval.Copy()
+			updateEval.Status = structs.EvalStatusFailed
+			updateEval.StatusDescription = fmt.Sprintf("evaluation reached delivery limit (%d)", s.config.EvalDeliveryLimit)
+			s.logger.Printf("[WARN] nomad: eval %#v reached delivery limit, marking as failed", updateEval)
 
 			// Create a follow-up evaluation that will be used to retry the
 			// scheduling for the job after the cluster is hopefully more stable
@@ -411,10 +411,10 @@ func (s *Server) reapFailedEvaluations(stopCh chan struct{}) {
 
 			// Update via Raft
 			req := structs.EvalUpdateRequest{
-				Evals: []*structs.Evaluation{newEval, followupEval},
+				Evals: []*structs.Evaluation{updateEval, followupEval},
 			}
 			if _, _, err := s.raftApply(structs.EvalUpdateRequestType, &req); err != nil {
-				s.logger.Printf("[ERR] nomad: failed to update failed eval %#v: %v", newEval, err)
+				s.logger.Printf("[ERR] nomad: failed to update failed eval %#v and create a follow-up: %v", updateEval, err)
 				continue
 			}
 

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -543,8 +543,8 @@ func TestLeader_ReapFailedEval(t *testing.T) {
 					e.Status, structs.EvalStatusPending)
 			}
 
-			if e.Wait < failedEvalFollowUpBaseLineWait ||
-				e.Wait > failedEvalFollowUpBaseLineWait+failedEvalFollowUpWaitRange {
+			if e.Wait < s1.config.EvalFailedFollowupBaselineDelay ||
+				e.Wait > s1.config.EvalFailedFollowupBaselineDelay+s1.config.EvalFailedFollowupDelayRange {
 				return false, fmt.Errorf("bad wait: %v", e.Wait)
 			}
 

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -508,7 +508,7 @@ func TestLeader_ReapFailedEval(t *testing.T) {
 	}
 	s1.evalBroker.Nack(out.ID, token)
 
-	// Wait updated evaluation
+	// Wait for an updated and followup evaluation
 	state := s1.fsm.State()
 	testutil.WaitForResult(func() (bool, error) {
 		ws := memdb.NewWatchSet()
@@ -516,7 +516,45 @@ func TestLeader_ReapFailedEval(t *testing.T) {
 		if err != nil {
 			return false, err
 		}
-		return out != nil && out.Status == structs.EvalStatusFailed, nil
+		if out == nil {
+			return false, fmt.Errorf("expect original evaluation to exist")
+		}
+		if out.Status != structs.EvalStatusFailed {
+			return false, fmt.Errorf("got status %v; want %v", out.Status, structs.EvalStatusFailed)
+		}
+
+		// See if there is a followup
+		evals, err := state.EvalsByJob(ws, eval.JobID)
+		if err != nil {
+			return false, err
+		}
+
+		if l := len(evals); l != 2 {
+			return false, fmt.Errorf("got %d evals, want 2", l)
+		}
+
+		for _, e := range evals {
+			if e.ID == eval.ID {
+				continue
+			}
+
+			if e.Status != structs.EvalStatusPending {
+				return false, fmt.Errorf("follow up eval has status %v; want %v",
+					e.Status, structs.EvalStatusPending)
+			}
+
+			if e.Wait < failedEvalFollowUpBaseLineWait ||
+				e.Wait > failedEvalFollowUpBaseLineWait+failedEvalFollowUpWaitRange {
+				return false, fmt.Errorf("bad wait: %v", e.Wait)
+			}
+
+			if e.TriggeredBy != structs.EvalTriggerFailedFollowUp {
+				return false, fmt.Errorf("follow up eval TriggeredBy %v; want %v",
+					e.TriggeredBy, structs.EvalTriggerFailedFollowUp)
+			}
+		}
+
+		return true, nil
 	}, func(err error) {
 		t.Fatalf("err: %v", err)
 	})

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -174,7 +174,11 @@ func NewServer(config *Config, consulSyncer *consul.Syncer, logger *log.Logger) 
 	}
 
 	// Create an eval broker
-	evalBroker, err := NewEvalBroker(config.EvalNackTimeout, config.EvalDeliveryLimit)
+	evalBroker, err := NewEvalBroker(
+		config.EvalNackTimeout,
+		config.EvalNackInitialReenqueueDelay,
+		config.EvalNackSubsequentReenqueueDelay,
+		config.EvalDeliveryLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3736,13 +3736,14 @@ const (
 )
 
 const (
-	EvalTriggerJobRegister   = "job-register"
-	EvalTriggerJobDeregister = "job-deregister"
-	EvalTriggerPeriodicJob   = "periodic-job"
-	EvalTriggerNodeUpdate    = "node-update"
-	EvalTriggerScheduled     = "scheduled"
-	EvalTriggerRollingUpdate = "rolling-update"
-	EvalTriggerMaxPlans      = "max-plan-attempts"
+	EvalTriggerJobRegister    = "job-register"
+	EvalTriggerJobDeregister  = "job-deregister"
+	EvalTriggerPeriodicJob    = "periodic-job"
+	EvalTriggerNodeUpdate     = "node-update"
+	EvalTriggerScheduled      = "scheduled"
+	EvalTriggerRollingUpdate  = "rolling-update"
+	EvalTriggerFailedFollowUp = "failed-eval-follow-up"
+	EvalTriggerMaxPlans       = "max-plan-attempts"
 )
 
 const (
@@ -3982,6 +3983,23 @@ func (e *Evaluation) CreateBlockedEval(classEligibility map[string]bool, escaped
 		PreviousEval:         e.ID,
 		ClassEligibility:     classEligibility,
 		EscapedComputedClass: escaped,
+	}
+}
+
+// CreateFailedFollowUpEval creates a follow up evaluation when the current one
+// has been marked as failed becasue it has hit the delivery limit and will not
+// be retried by the eval_broker.
+func (e *Evaluation) CreateFailedFollowUpEval(wait time.Duration) *Evaluation {
+	return &Evaluation{
+		ID:             GenerateUUID(),
+		Priority:       e.Priority,
+		Type:           e.Type,
+		TriggeredBy:    EvalTriggerFailedFollowUp,
+		JobID:          e.JobID,
+		JobModifyIndex: e.JobModifyIndex,
+		Status:         EvalStatusPending,
+		Wait:           wait,
+		PreviousEval:   e.ID,
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3742,7 +3742,7 @@ const (
 	EvalTriggerNodeUpdate     = "node-update"
 	EvalTriggerScheduled      = "scheduled"
 	EvalTriggerRollingUpdate  = "rolling-update"
-	EvalTriggerFailedFollowUp = "failed-eval-follow-up"
+	EvalTriggerFailedFollowUp = "failed-follow-up"
 	EvalTriggerMaxPlans       = "max-plan-attempts"
 )
 


### PR DESCRIPTION
This PR adds two things to increase robustness under high contention:

1) Evaluation's that are Nack'd are not immediately re-enqueued, providing some back-pressure.
2) If an evaluations hits its delivery limit and is marked as failed, when reaped, a follow up evaluation will be created with a fairly substantial delay. This gives the cluster time to recover and ensures progress for jobs with failed evaluations.