### PR TITLE
Track multiple job versions and introduce a stop state for jobs

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -297,6 +297,8 @@ type Job struct {
 	VaultToken        *string `mapstructure:"vault_token"`
 	Status            *string
 	StatusDescription *string
+	Stable            *bool
+	Version           *uint64
 	CreateIndex       *uint64
 	ModifyIndex       *uint64
 	JobModifyIndex    *uint64
@@ -342,6 +344,12 @@ func (j *Job) Canonicalize() {
 	}
 	if j.StatusDescription == nil {
 		j.StatusDescription = helper.StringToPtr("")
+	}
+	if j.Stable == nil {
+		j.Stable = helper.BoolToPtr(false)
+	}
+	if j.Version == nil {
+		j.Version = helper.Uint64ToPtr(0)
 	}
 	if j.CreateIndex == nil {
 		j.CreateIndex = helper.Uint64ToPtr(0)

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -106,6 +106,17 @@ func (j *Jobs) Info(jobID string, q *QueryOptions) (*Job, *QueryMeta, error) {
 	return &resp, qm, nil
 }
 
+// Versions is used to retrieve all versions of a particular
+// job given its unique ID.
+func (j *Jobs) Versions(jobID string, q *QueryOptions) ([]*Job, *QueryMeta, error) {
+	var resp []*Job
+	qm, err := j.client.query("/v1/job/"+jobID+"/versions", &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, qm, nil
+}
+
 // Allocations is used to return the allocs for a given job ID.
 func (j *Jobs) Allocations(jobID string, allAllocs bool, q *QueryOptions) ([]*AllocationListStub, *QueryMeta, error) {
 	var resp []*AllocationListStub

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -431,6 +431,8 @@ type JobListStub struct {
 	Name              string
 	Type              string
 	Priority          int
+	Periodic          bool
+	ParameterizedJob  bool
 	Stop              bool
 	Status            string
 	StatusDescription string

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/kr/pretty"
 )
 
 func TestJobs_Register(t *testing.T) {
@@ -107,6 +108,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 				VaultToken:        helper.StringToPtr(""),
 				Status:            helper.StringToPtr(""),
 				StatusDescription: helper.StringToPtr(""),
+				Stop:              helper.BoolToPtr(false),
+				Stable:            helper.BoolToPtr(false),
+				Version:           helper.Uint64ToPtr(0),
 				CreateIndex:       helper.Uint64ToPtr(0),
 				ModifyIndex:       helper.Uint64ToPtr(0),
 				JobModifyIndex:    helper.Uint64ToPtr(0),
@@ -162,6 +166,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 				Priority:          helper.IntToPtr(50),
 				AllAtOnce:         helper.BoolToPtr(false),
 				VaultToken:        helper.StringToPtr(""),
+				Stop:              helper.BoolToPtr(false),
+				Stable:            helper.BoolToPtr(false),
+				Version:           helper.Uint64ToPtr(0),
 				Status:            helper.StringToPtr(""),
 				StatusDescription: helper.StringToPtr(""),
 				CreateIndex:       helper.Uint64ToPtr(0),
@@ -277,6 +284,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 				Type:              helper.StringToPtr("service"),
 				AllAtOnce:         helper.BoolToPtr(false),
 				VaultToken:        helper.StringToPtr(""),
+				Stop:              helper.BoolToPtr(false),
+				Stable:            helper.BoolToPtr(false),
+				Version:           helper.Uint64ToPtr(0),
 				Status:            helper.StringToPtr(""),
 				StatusDescription: helper.StringToPtr(""),
 				CreateIndex:       helper.Uint64ToPtr(0),
@@ -379,6 +389,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 				Priority:          helper.IntToPtr(50),
 				AllAtOnce:         helper.BoolToPtr(false),
 				VaultToken:        helper.StringToPtr(""),
+				Stop:              helper.BoolToPtr(false),
+				Stable:            helper.BoolToPtr(false),
+				Version:           helper.Uint64ToPtr(0),
 				Status:            helper.StringToPtr(""),
 				StatusDescription: helper.StringToPtr(""),
 				CreateIndex:       helper.Uint64ToPtr(0),
@@ -399,6 +412,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.input.Canonicalize()
 			if !reflect.DeepEqual(tc.input, tc.expected) {
+				t.Logf("Name: %v, Diffs:\n%v", tc.name, pretty.Diff(tc.expected, tc.input))
 				t.Fatalf("Name: %v, expected:\n%#v\nactual:\n%#v", tc.name, tc.expected, tc.input)
 			}
 		})

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -506,6 +506,38 @@ func TestJobs_Info(t *testing.T) {
 	}
 }
 
+func TestJobs_Versions(t *testing.T) {
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+	jobs := c.Jobs()
+
+	// Trying to retrieve a job by ID before it exists returns an error
+	_, _, err := jobs.Versions("job1", nil)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got: %#v", err)
+	}
+
+	// Register the job
+	job := testJob()
+	_, wm, err := jobs.Register(job, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	assertWriteMeta(t, wm)
+
+	// Query the job again and ensure it exists
+	result, qm, err := jobs.Versions("job1", nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	assertQueryMeta(t, qm)
+
+	// Check that the result is what we expect
+	if len(result) == 0 || *result[0].ID != *job.ID {
+		t.Fatalf("expect: %#v, got: %#v", job, result)
+	}
+}
+
 func TestJobs_PrefixList(t *testing.T) {
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -690,17 +690,36 @@ func TestJobs_Deregister(t *testing.T) {
 	assertWriteMeta(t, wm)
 
 	// Attempting delete on non-existing job returns an error
-	if _, _, err = jobs.Deregister("nope", nil); err != nil {
+	if _, _, err = jobs.Deregister("nope", false, nil); err != nil {
 		t.Fatalf("unexpected error deregistering job: %v", err)
-
 	}
 
-	// Deleting an existing job works
-	evalID, wm3, err := jobs.Deregister("job1", nil)
+	// Do a soft deregister of an existing job
+	evalID, wm3, err := jobs.Deregister("job1", false, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	assertWriteMeta(t, wm3)
+	if evalID == "" {
+		t.Fatalf("missing eval ID")
+	}
+
+	// Check that the job is still queryable
+	out, qm1, err := jobs.Info("job1", nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	assertQueryMeta(t, qm1)
+	if out == nil {
+		t.Fatalf("missing job")
+	}
+
+	// Do a purge deregister of an existing job
+	evalID, wm4, err := jobs.Deregister("job1", true, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	assertWriteMeta(t, wm4)
 	if evalID == "" {
 		t.Fatalf("missing eval ID")
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -372,22 +372,17 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 	job.Canonicalize()
 
 	j := &structs.Job{
-		Region:            *job.Region,
-		ID:                *job.ID,
-		ParentID:          *job.ParentID,
-		Name:              *job.Name,
-		Type:              *job.Type,
-		Priority:          *job.Priority,
-		AllAtOnce:         *job.AllAtOnce,
-		Datacenters:       job.Datacenters,
-		Payload:           job.Payload,
-		Meta:              job.Meta,
-		VaultToken:        *job.VaultToken,
-		Status:            *job.Status,
-		StatusDescription: *job.StatusDescription,
-		CreateIndex:       *job.CreateIndex,
-		ModifyIndex:       *job.ModifyIndex,
-		JobModifyIndex:    *job.JobModifyIndex,
+		Region:      *job.Region,
+		ID:          *job.ID,
+		ParentID:    *job.ParentID,
+		Name:        *job.Name,
+		Type:        *job.Type,
+		Priority:    *job.Priority,
+		AllAtOnce:   *job.AllAtOnce,
+		Datacenters: job.Datacenters,
+		Payload:     job.Payload,
+		Meta:        job.Meta,
+		VaultToken:  *job.VaultToken,
 	}
 
 	j.Constraints = make([]*structs.Constraint, len(job.Constraints))

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -424,18 +424,22 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 		VaultToken:  *job.VaultToken,
 	}
 
-	j.Constraints = make([]*structs.Constraint, len(job.Constraints))
-	for i, c := range job.Constraints {
-		con := &structs.Constraint{}
-		ApiConstraintToStructs(c, con)
-		j.Constraints[i] = con
+	if l := len(job.Constraints); l != 0 {
+		j.Constraints = make([]*structs.Constraint, l)
+		for i, c := range job.Constraints {
+			con := &structs.Constraint{}
+			ApiConstraintToStructs(c, con)
+			j.Constraints[i] = con
+		}
 	}
+
 	if job.Update != nil {
 		j.Update = structs.UpdateStrategy{
 			Stagger:     job.Update.Stagger,
 			MaxParallel: job.Update.MaxParallel,
 		}
 	}
+
 	if job.Periodic != nil {
 		j.Periodic = &structs.PeriodicConfig{
 			Enabled:         *job.Periodic.Enabled,
@@ -443,10 +447,12 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 			ProhibitOverlap: *job.Periodic.ProhibitOverlap,
 			TimeZone:        *job.Periodic.TimeZone,
 		}
+
 		if job.Periodic.Spec != nil {
 			j.Periodic.Spec = *job.Periodic.Spec
 		}
 	}
+
 	if job.ParameterizedJob != nil {
 		j.ParameterizedJob = &structs.ParameterizedJobConfig{
 			Payload:      job.ParameterizedJob.Payload,
@@ -455,11 +461,13 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 		}
 	}
 
-	j.TaskGroups = make([]*structs.TaskGroup, len(job.TaskGroups))
-	for i, taskGroup := range job.TaskGroups {
-		tg := &structs.TaskGroup{}
-		ApiTgToStructsTG(taskGroup, tg)
-		j.TaskGroups[i] = tg
+	if l := len(job.TaskGroups); l != 0 {
+		j.TaskGroups = make([]*structs.TaskGroup, l)
+		for i, taskGroup := range job.TaskGroups {
+			tg := &structs.TaskGroup{}
+			ApiTgToStructsTG(taskGroup, tg)
+			j.TaskGroups[i] = tg
+		}
 	}
 
 	return j
@@ -469,29 +477,36 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 	tg.Name = *taskGroup.Name
 	tg.Count = *taskGroup.Count
 	tg.Meta = taskGroup.Meta
-	tg.Constraints = make([]*structs.Constraint, len(taskGroup.Constraints))
-	for k, constraint := range taskGroup.Constraints {
-		c := &structs.Constraint{}
-		ApiConstraintToStructs(constraint, c)
-		tg.Constraints[k] = c
+
+	if l := len(taskGroup.Constraints); l != 0 {
+		tg.Constraints = make([]*structs.Constraint, l)
+		for k, constraint := range taskGroup.Constraints {
+			c := &structs.Constraint{}
+			ApiConstraintToStructs(constraint, c)
+			tg.Constraints[k] = c
+		}
 	}
+
 	tg.RestartPolicy = &structs.RestartPolicy{
 		Attempts: *taskGroup.RestartPolicy.Attempts,
 		Interval: *taskGroup.RestartPolicy.Interval,
 		Delay:    *taskGroup.RestartPolicy.Delay,
 		Mode:     *taskGroup.RestartPolicy.Mode,
 	}
+
 	tg.EphemeralDisk = &structs.EphemeralDisk{
 		Sticky:  *taskGroup.EphemeralDisk.Sticky,
 		SizeMB:  *taskGroup.EphemeralDisk.SizeMB,
 		Migrate: *taskGroup.EphemeralDisk.Migrate,
 	}
-	tg.Meta = taskGroup.Meta
-	tg.Tasks = make([]*structs.Task, len(taskGroup.Tasks))
-	for l, task := range taskGroup.Tasks {
-		t := &structs.Task{}
-		ApiTaskToStructsTask(task, t)
-		tg.Tasks[l] = t
+
+	if l := len(taskGroup.Tasks); l != 0 {
+		tg.Tasks = make([]*structs.Task, l)
+		for l, task := range taskGroup.Tasks {
+			t := &structs.Task{}
+			ApiTaskToStructsTask(task, t)
+			tg.Tasks[l] = t
+		}
 	}
 }
 
@@ -501,77 +516,101 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 	structsTask.User = apiTask.User
 	structsTask.Leader = apiTask.Leader
 	structsTask.Config = apiTask.Config
-	structsTask.Constraints = make([]*structs.Constraint, len(apiTask.Constraints))
-	for i, constraint := range apiTask.Constraints {
-		c := &structs.Constraint{}
-		ApiConstraintToStructs(constraint, c)
-		structsTask.Constraints[i] = c
-	}
 	structsTask.Env = apiTask.Env
-	structsTask.Services = make([]*structs.Service, len(apiTask.Services))
-	for i, service := range apiTask.Services {
-		structsTask.Services[i] = &structs.Service{
-			Name:      service.Name,
-			PortLabel: service.PortLabel,
-			Tags:      service.Tags,
+	structsTask.Meta = apiTask.Meta
+	structsTask.KillTimeout = *apiTask.KillTimeout
+
+	if l := len(apiTask.Constraints); l != 0 {
+		structsTask.Constraints = make([]*structs.Constraint, l)
+		for i, constraint := range apiTask.Constraints {
+			c := &structs.Constraint{}
+			ApiConstraintToStructs(constraint, c)
+			structsTask.Constraints[i] = c
 		}
-		structsTask.Services[i].Checks = make([]*structs.ServiceCheck, len(service.Checks))
-		for j, check := range service.Checks {
-			structsTask.Services[i].Checks[j] = &structs.ServiceCheck{
-				Name:          check.Name,
-				Type:          check.Type,
-				Command:       check.Command,
-				Args:          check.Args,
-				Path:          check.Path,
-				Protocol:      check.Protocol,
-				PortLabel:     check.PortLabel,
-				Interval:      check.Interval,
-				Timeout:       check.Timeout,
-				InitialStatus: check.InitialStatus,
+	}
+
+	if l := len(apiTask.Services); l != 0 {
+		structsTask.Services = make([]*structs.Service, l)
+		for i, service := range apiTask.Services {
+			structsTask.Services[i] = &structs.Service{
+				Name:      service.Name,
+				PortLabel: service.PortLabel,
+				Tags:      service.Tags,
+			}
+
+			if l := len(service.Checks); l != 0 {
+				structsTask.Services[i].Checks = make([]*structs.ServiceCheck, l)
+				for j, check := range service.Checks {
+					structsTask.Services[i].Checks[j] = &structs.ServiceCheck{
+						Name:          check.Name,
+						Type:          check.Type,
+						Command:       check.Command,
+						Args:          check.Args,
+						Path:          check.Path,
+						Protocol:      check.Protocol,
+						PortLabel:     check.PortLabel,
+						Interval:      check.Interval,
+						Timeout:       check.Timeout,
+						InitialStatus: check.InitialStatus,
+					}
+				}
 			}
 		}
 	}
+
 	structsTask.Resources = &structs.Resources{
 		CPU:      *apiTask.Resources.CPU,
 		MemoryMB: *apiTask.Resources.MemoryMB,
 		IOPS:     *apiTask.Resources.IOPS,
 	}
-	structsTask.Resources.Networks = make([]*structs.NetworkResource, len(apiTask.Resources.Networks))
-	for i, nw := range apiTask.Resources.Networks {
-		structsTask.Resources.Networks[i] = &structs.NetworkResource{
-			CIDR:  nw.CIDR,
-			IP:    nw.IP,
-			MBits: *nw.MBits,
-		}
-		structsTask.Resources.Networks[i].DynamicPorts = make([]structs.Port, len(nw.DynamicPorts))
-		structsTask.Resources.Networks[i].ReservedPorts = make([]structs.Port, len(nw.ReservedPorts))
-		for j, dp := range nw.DynamicPorts {
-			structsTask.Resources.Networks[i].DynamicPorts[j] = structs.Port{
-				Label: dp.Label,
-				Value: dp.Value,
+
+	if l := len(apiTask.Resources.Networks); l != 0 {
+		structsTask.Resources.Networks = make([]*structs.NetworkResource, l)
+		for i, nw := range apiTask.Resources.Networks {
+			structsTask.Resources.Networks[i] = &structs.NetworkResource{
+				CIDR:  nw.CIDR,
+				IP:    nw.IP,
+				MBits: *nw.MBits,
 			}
-		}
-		for j, rp := range nw.ReservedPorts {
-			structsTask.Resources.Networks[i].ReservedPorts[j] = structs.Port{
-				Label: rp.Label,
-				Value: rp.Value,
+
+			if l := len(nw.DynamicPorts); l != 0 {
+				structsTask.Resources.Networks[i].DynamicPorts = make([]structs.Port, l)
+				for j, dp := range nw.DynamicPorts {
+					structsTask.Resources.Networks[i].DynamicPorts[j] = structs.Port{
+						Label: dp.Label,
+						Value: dp.Value,
+					}
+				}
+			}
+
+			if l := len(nw.ReservedPorts); l != 0 {
+				structsTask.Resources.Networks[i].ReservedPorts = make([]structs.Port, l)
+				for j, rp := range nw.ReservedPorts {
+					structsTask.Resources.Networks[i].ReservedPorts[j] = structs.Port{
+						Label: rp.Label,
+						Value: rp.Value,
+					}
+				}
 			}
 		}
 	}
-	structsTask.Meta = apiTask.Meta
-	structsTask.KillTimeout = *apiTask.KillTimeout
+
 	structsTask.LogConfig = &structs.LogConfig{
 		MaxFiles:      *apiTask.LogConfig.MaxFiles,
 		MaxFileSizeMB: *apiTask.LogConfig.MaxFileSizeMB,
 	}
-	structsTask.Artifacts = make([]*structs.TaskArtifact, len(apiTask.Artifacts))
-	for k, ta := range apiTask.Artifacts {
-		structsTask.Artifacts[k] = &structs.TaskArtifact{
-			GetterSource:  *ta.GetterSource,
-			GetterOptions: ta.GetterOptions,
-			RelativeDest:  *ta.RelativeDest,
+
+	if l := len(apiTask.Artifacts); l != 0 {
+		structsTask.Artifacts = make([]*structs.TaskArtifact, l)
+		for k, ta := range apiTask.Artifacts {
+			structsTask.Artifacts[k] = &structs.TaskArtifact{
+				GetterSource:  *ta.GetterSource,
+				GetterOptions: ta.GetterOptions,
+				RelativeDest:  *ta.RelativeDest,
+			}
 		}
 	}
+
 	if apiTask.Vault != nil {
 		structsTask.Vault = &structs.Vault{
 			Policies:     apiTask.Vault.Policies,
@@ -580,20 +619,24 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 			ChangeSignal: *apiTask.Vault.ChangeSignal,
 		}
 	}
-	structsTask.Templates = make([]*structs.Template, len(apiTask.Templates))
-	for i, template := range apiTask.Templates {
-		structsTask.Templates[i] = &structs.Template{
-			SourcePath:   *template.SourcePath,
-			DestPath:     *template.DestPath,
-			EmbeddedTmpl: *template.EmbeddedTmpl,
-			ChangeMode:   *template.ChangeMode,
-			ChangeSignal: *template.ChangeSignal,
-			Splay:        *template.Splay,
-			Perms:        *template.Perms,
-			LeftDelim:    *template.LeftDelim,
-			RightDelim:   *template.RightDelim,
+
+	if l := len(apiTask.Templates); l != 0 {
+		structsTask.Templates = make([]*structs.Template, l)
+		for i, template := range apiTask.Templates {
+			structsTask.Templates[i] = &structs.Template{
+				SourcePath:   *template.SourcePath,
+				DestPath:     *template.DestPath,
+				EmbeddedTmpl: *template.EmbeddedTmpl,
+				ChangeMode:   *template.ChangeMode,
+				ChangeSignal: *template.ChangeSignal,
+				Splay:        *template.Splay,
+				Perms:        *template.Perms,
+				LeftDelim:    *template.LeftDelim,
+				RightDelim:   *template.RightDelim,
+			}
 		}
 	}
+
 	if apiTask.DispatchPayload != nil {
 		structsTask.DispatchPayload = &structs.DispatchPayloadConfig{
 			File: apiTask.DispatchPayload.File,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -383,7 +383,7 @@ func TestHTTP_JobDelete(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		// Make the HTTP request
+		// Make the HTTP request to do a soft delete
 		req, err := http.NewRequest("DELETE", "/v1/job/"+job.ID, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
@@ -407,16 +407,56 @@ func TestHTTP_JobDelete(t *testing.T) {
 			t.Fatalf("missing index")
 		}
 
-		// Check the job is gone
-		getReq := structs.JobSpecificRequest{
+		// Check the job is still queryable
+		getReq1 := structs.JobSpecificRequest{
 			JobID:        job.ID,
 			QueryOptions: structs.QueryOptions{Region: "global"},
 		}
-		var getResp structs.SingleJobResponse
-		if err := s.Agent.RPC("Job.GetJob", &getReq, &getResp); err != nil {
+		var getResp1 structs.SingleJobResponse
+		if err := s.Agent.RPC("Job.GetJob", &getReq1, &getResp1); err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if getResp.Job != nil {
+		if getResp1.Job == nil {
+			t.Fatalf("job doesn't exists")
+		}
+		if !getResp1.Job.Stop {
+			t.Fatalf("job should be marked as stop")
+		}
+
+		// Make the HTTP request to do a purge delete
+		req2, err := http.NewRequest("DELETE", "/v1/job/"+job.ID+"?purge=true", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW.Flush()
+
+		// Make the request
+		obj, err = s.Server.JobSpecificRequest(respW, req2)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Check the response
+		dereg = obj.(structs.JobDeregisterResponse)
+		if dereg.EvalID == "" {
+			t.Fatalf("bad: %v", dereg)
+		}
+
+		// Check for the index
+		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+			t.Fatalf("missing index")
+		}
+
+		// Check the job is gone
+		getReq2 := structs.JobSpecificRequest{
+			JobID:        job.ID,
+			QueryOptions: structs.QueryOptions{Region: "global"},
+		}
+		var getResp2 structs.SingleJobResponse
+		if err := s.Agent.RPC("Job.GetJob", &getReq2, &getResp2); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if getResp2.Job != nil {
 			t.Fatalf("job still exists")
 		}
 	})
@@ -751,6 +791,7 @@ func TestHTTP_JobDispatch(t *testing.T) {
 
 func TestJobs_ApiJobToStructsJob(t *testing.T) {
 	apiJob := &api.Job{
+		Stop:        helper.BoolToPtr(true),
 		Region:      helper.StringToPtr("global"),
 		ID:          helper.StringToPtr("foo"),
 		ParentID:    helper.StringToPtr("lol"),
@@ -922,12 +963,14 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 		VaultToken:        helper.StringToPtr("token"),
 		Status:            helper.StringToPtr("status"),
 		StatusDescription: helper.StringToPtr("status_desc"),
+		Version:           helper.Uint64ToPtr(10),
 		CreateIndex:       helper.Uint64ToPtr(1),
 		ModifyIndex:       helper.Uint64ToPtr(3),
 		JobModifyIndex:    helper.Uint64ToPtr(5),
 	}
 
 	expected := &structs.Job{
+		Stop:        true,
 		Region:      "global",
 		ID:          "foo",
 		ParentID:    "lol",
@@ -1094,12 +1137,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 			},
 		},
 
-		VaultToken:        "token",
-		Status:            "status",
-		StatusDescription: "status_desc",
-		CreateIndex:       1,
-		ModifyIndex:       3,
-		JobModifyIndex:    5,
+		VaultToken: "token",
 	}
 
 	structsJob := ApiJobToStructJob(apiJob)

--- a/command/status.go
+++ b/command/status.go
@@ -147,13 +147,17 @@ func (c *StatusCommand) Run(args []string) int {
 	}
 
 	if periodic && !parameterized {
-		location, err := job.Periodic.GetLocation()
-		if err == nil {
-			now := time.Now().In(location)
-			next := job.Periodic.Next(now)
-			basic = append(basic, fmt.Sprintf("Next Periodic Launch|%s",
-				fmt.Sprintf("%s (%s from now)",
-					formatTime(next), formatTimeDifference(now, next, time.Second))))
+		if *job.Stop {
+			basic = append(basic, fmt.Sprintf("Next Periodic Launch|none (job stopped)"))
+		} else {
+			location, err := job.Periodic.GetLocation()
+			if err == nil {
+				now := time.Now().In(location)
+				next := job.Periodic.Next(now)
+				basic = append(basic, fmt.Sprintf("Next Periodic Launch|%s",
+					fmt.Sprintf("%s (%s from now)",
+						formatTime(next), formatTimeDifference(now, next, time.Second))))
+			}
 		}
 	}
 

--- a/command/status.go
+++ b/command/status.go
@@ -450,11 +450,25 @@ func createStatusListOutput(jobs []*api.JobListStub) string {
 	for i, job := range jobs {
 		out[i+1] = fmt.Sprintf("%s|%s|%d|%s",
 			job.ID,
-			job.Type,
+			getTypeString(job),
 			job.Priority,
 			getStatusString(job.Status, job.Stop))
 	}
 	return formatList(out)
+}
+
+func getTypeString(job *api.JobListStub) string {
+	t := job.Type
+
+	if job.Periodic {
+		t += "/periodic"
+	}
+
+	if job.ParameterizedJob {
+		t += "/parameterized"
+	}
+
+	return t
 }
 
 func getStatusString(status string, stop bool) string {

--- a/command/status.go
+++ b/command/status.go
@@ -141,7 +141,7 @@ func (c *StatusCommand) Run(args []string) int {
 		fmt.Sprintf("Type|%s", *job.Type),
 		fmt.Sprintf("Priority|%d", *job.Priority),
 		fmt.Sprintf("Datacenters|%s", strings.Join(job.Datacenters, ",")),
-		fmt.Sprintf("Status|%s", *job.Status),
+		fmt.Sprintf("Status|%s", getStatusString(*job.Status, *job.Stop)),
 		fmt.Sprintf("Periodic|%v", periodic),
 		fmt.Sprintf("Parameterized|%v", parameterized),
 	}
@@ -448,7 +448,14 @@ func createStatusListOutput(jobs []*api.JobListStub) string {
 			job.ID,
 			job.Type,
 			job.Priority,
-			job.Status)
+			getStatusString(job.Status, job.Stop))
 	}
 	return formatList(out)
+}
+
+func getStatusString(status string, stop bool) string {
+	if stop {
+		return fmt.Sprintf("%s (stopped)", status)
+	}
+	return status
 }

--- a/command/stop.go
+++ b/command/stop.go
@@ -31,6 +31,10 @@ Stop Options:
     screen, which can be used to examine the evaluation using the eval-status
     command.
 
+  -purge
+    Purge is used to stop the job and purge it from the system. If not set, the
+    job will still be queryable and will be purged by the garbage collector.
+
   -yes
     Automatic yes to prompts.
 
@@ -45,13 +49,14 @@ func (c *StopCommand) Synopsis() string {
 }
 
 func (c *StopCommand) Run(args []string) int {
-	var detach, verbose, autoYes bool
+	var detach, purge, verbose, autoYes bool
 
 	flags := c.Meta.FlagSet("stop", FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&detach, "detach", false, "")
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.BoolVar(&autoYes, "yes", false, "")
+	flags.BoolVar(&purge, "purge", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -132,7 +137,7 @@ func (c *StopCommand) Run(args []string) int {
 	}
 
 	// Invoke the stop
-	evalID, _, err := client.Jobs().Deregister(*job.ID, nil)
+	evalID, _, err := client.Jobs().Deregister(*job.ID, purge, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error deregistering job: %s", err))
 		return 1

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -272,10 +273,16 @@ func TestEvalEndpoint_Nack(t *testing.T) {
 	}
 
 	// Should get it back
-	out2, _, _ := s1.evalBroker.Dequeue(defaultSched, time.Second)
-	if out2 != out {
-		t.Fatalf("nack failed")
-	}
+	testutil.WaitForResult(func() (bool, error) {
+		out2, _, _ := s1.evalBroker.Dequeue(defaultSched, time.Second)
+		if out2 != out {
+			return false, fmt.Errorf("nack failed")
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatal(err)
+	})
 }
 
 func TestEvalEndpoint_Update(t *testing.T) {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -846,6 +846,10 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 		return fmt.Errorf("Specified job %q is not a parameterized job", args.JobID)
 	}
 
+	if parameterizedJob.Stop {
+		return fmt.Errorf("Specified job %q is stopped", args.JobID)
+	}
+
 	// Validate the arguments
 	if err := validateDispatchRequest(args, parameterizedJob); err != nil {
 		return err

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -475,6 +475,45 @@ func (j *Job) GetJob(args *structs.JobSpecificRequest,
 	return j.srv.blockingRPC(&opts)
 }
 
+// GetJobVersions is used to retrieve all tracked versions of a job.
+func (j *Job) GetJobVersions(args *structs.JobSpecificRequest,
+	reply *structs.JobVersionsResponse) error {
+	if done, err := j.srv.forward("Job.GetJobVersions", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "job", "get_job_versions"}, time.Now())
+
+	// Setup the blocking query
+	opts := blockingOptions{
+		queryOpts: &args.QueryOptions,
+		queryMeta: &reply.QueryMeta,
+		run: func(ws memdb.WatchSet, state *state.StateStore) error {
+			// Look for the job
+			out, err := state.JobVersionsByID(ws, args.JobID)
+			if err != nil {
+				return err
+			}
+
+			// Setup the output
+			reply.Versions = out
+			if len(out) != 0 {
+				reply.Index = out[0].ModifyIndex
+			} else {
+				// Use the last index that affected the nodes table
+				index, err := state.Index("job_versions")
+				if err != nil {
+					return err
+				}
+				reply.Index = index
+			}
+
+			// Set the query response
+			j.srv.setQueryMeta(&reply.QueryMeta)
+			return nil
+		}}
+	return j.srv.blockingRPC(&opts)
+}
+
 // List is used to list the jobs registered in the system
 func (j *Job) List(args *structs.JobListRequest,
 	reply *structs.JobListResponse) error {

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -146,6 +146,7 @@ func Job() *structs.Job {
 			"owner": "armon",
 		},
 		Status:         structs.JobStatusPending,
+		Version:        0,
 		CreateIndex:    42,
 		ModifyIndex:    99,
 		JobModifyIndex: 99,

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -158,7 +158,7 @@ func jobHistorySchema() *memdb.TableSchema {
 				Indexer: &memdb.CompoundIndex{
 					Indexes: []memdb.Indexer{
 						&memdb.StringFieldIndex{
-							Field:     "JobID",
+							Field:     "ID",
 							Lowercase: true,
 						},
 

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -20,7 +20,7 @@ func stateStoreSchema() *memdb.DBSchema {
 		nodeTableSchema,
 		jobTableSchema,
 		jobSummarySchema,
-		jobHistorySchema,
+		jobVersionsSchema,
 		periodicLaunchTableSchema,
 		evalTableSchema,
 		allocTableSchema,
@@ -142,11 +142,11 @@ func jobSummarySchema() *memdb.TableSchema {
 	}
 }
 
-// jobHistorySchema returns the memdb schema for the job history table which
-// keeps a historical view of jobs.
-func jobHistorySchema() *memdb.TableSchema {
+// jobVersionsSchema returns the memdb schema for the job version table which
+// keeps a historical view of job versions.
+func jobVersionsSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: "job_histories",
+		Name: "job_versions",
 		Indexes: map[string]*memdb.IndexSchema{
 			"id": &memdb.IndexSchema{
 				Name:         "id",

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -20,6 +20,7 @@ func stateStoreSchema() *memdb.DBSchema {
 		nodeTableSchema,
 		jobTableSchema,
 		jobSummarySchema,
+		jobHistorySchema,
 		periodicLaunchTableSchema,
 		evalTableSchema,
 		allocTableSchema,
@@ -135,6 +136,37 @@ func jobSummarySchema() *memdb.TableSchema {
 				Indexer: &memdb.StringFieldIndex{
 					Field:     "JobID",
 					Lowercase: true,
+				},
+			},
+		},
+	}
+}
+
+// jobHistorySchema returns the memdb schema for the job history table which
+// keeps a historical view of jobs.
+func jobHistorySchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "job_histories",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": &memdb.IndexSchema{
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+
+				// Use a compound index so the tuple of (JobID, Version) is
+				// uniquely identifying
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.StringFieldIndex{
+							Field:     "JobID",
+							Lowercase: true,
+						},
+
+						// Will need to create a new indexer
+						&memdb.UintFieldIndex{
+							Field: "Version",
+						},
+					},
 				},
 			},
 		},

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"sort"
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -469,7 +468,7 @@ func (s *StateStore) deleteJobVersions(index uint64, job *structs.Job, txn *memd
 		}
 
 		if _, err = txn.DeleteAll("job_versions", "id", job.ID, job.Version); err != nil {
-			return fmt.Errorf("deleing job versions failed: %v", err)
+			return fmt.Errorf("deleting job versions failed: %v", err)
 		}
 	}
 
@@ -595,10 +594,10 @@ func (s *StateStore) jobVersionByID(txn *memdb.Txn, ws *memdb.WatchSet, id strin
 		all = append(all, j)
 	}
 
-	// Sort with highest versions first
-	sort.Slice(all, func(i, j int) bool {
-		return all[i].Version >= all[j].Version
-	})
+	// Reverse so that highest versions first
+	for i, j := 0, len(all)-1; i < j; i, j = i+1, j-1 {
+		all[i], all[j] = all[j], all[i]
+	}
 
 	return all, nil
 }

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1787,6 +1787,11 @@ func (s *StateStore) getJobStatus(txn *memdb.Txn, job *structs.Job, evalDelete b
 	// job is periodic or is a parameterized job, we mark it as running as
 	// it will never have an allocation/evaluation against it.
 	if job.IsPeriodic() || job.IsParameterized() {
+		// If the job is stopped mark it as dead
+		if job.Stop {
+			return structs.JobStatusDead, nil
+		}
+
 		return structs.JobStatusRunning, nil
 	}
 	return structs.JobStatusPending, nil

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -421,8 +421,8 @@ func TestStateStore_UpsertJob_Job(t *testing.T) {
 		t.Fatalf("bad")
 	}
 
-	// Check the job history
-	allVersions, err := state.JobHistoryByID(ws, job.ID)
+	// Check the job versions
+	allVersions, err := state.JobVersionsByID(ws, job.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -504,8 +504,8 @@ func TestStateStore_UpdateUpsertJob_Job(t *testing.T) {
 		t.Fatalf("nil summary for task group")
 	}
 
-	// Check the job history
-	allVersions, err := state.JobHistoryByID(ws, job.ID)
+	// Check the job versions
+	allVersions, err := state.JobVersionsByID(ws, job.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -658,7 +658,7 @@ func TestStateStore_UpsertJob_ChildJob(t *testing.T) {
 	}
 }
 
-func TestStateStore_UpdateUpsertJob_JobHistory(t *testing.T) {
+func TestStateStore_UpdateUpsertJob_JobVersion(t *testing.T) {
 	state := testStateStore(t)
 
 	// Create a job and mark it as stable
@@ -668,7 +668,7 @@ func TestStateStore_UpdateUpsertJob_JobHistory(t *testing.T) {
 
 	// Create a watchset so we can test that upsert fires the watch
 	ws := memdb.NewWatchSet()
-	_, err := state.JobHistoryByID(ws, job.ID)
+	_, err := state.JobVersionsByID(ws, job.ID)
 	if err != nil {
 		t.Fatalf("bad: %v", err)
 	}
@@ -712,7 +712,7 @@ func TestStateStore_UpdateUpsertJob_JobHistory(t *testing.T) {
 		t.Fatalf("bad: %#v", out)
 	}
 
-	index, err := state.Index("job_histories")
+	index, err := state.Index("job_versions")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -720,12 +720,12 @@ func TestStateStore_UpdateUpsertJob_JobHistory(t *testing.T) {
 		t.Fatalf("bad: %d", index)
 	}
 
-	// Check the job history
-	allVersions, err := state.JobHistoryByID(ws, job.ID)
+	// Check the job versions
+	allVersions, err := state.JobVersionsByID(ws, job.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(allVersions) != structs.JobDefaultHistoricCount {
+	if len(allVersions) != structs.JobTrackedVersions {
 		t.Fatalf("got %d; want 1", len(allVersions))
 	}
 
@@ -737,7 +737,7 @@ func TestStateStore_UpdateUpsertJob_JobHistory(t *testing.T) {
 	}
 
 	// Ensure we didn't delete the stable job
-	if a := allVersions[structs.JobDefaultHistoricCount-1]; a.ID != job.ID ||
+	if a := allVersions[structs.JobTrackedVersions-1]; a.ID != job.ID ||
 		a.Version != 0 || a.Priority != 0 || !a.Stable {
 		t.Fatalf("bad: %+v", a)
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -797,6 +797,30 @@ func TestStateStore_DeleteJob_Job(t *testing.T) {
 		t.Fatalf("expected summary to be nil, but got: %v", summary)
 	}
 
+	index, err = state.Index("job_summary")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if index != 1001 {
+		t.Fatalf("bad: %d", index)
+	}
+
+	versions, err := state.JobVersionsByID(ws, job.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(versions) != 0 {
+		t.Fatalf("expected no job versions")
+	}
+
+	index, err = state.Index("job_summary")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if index != 1001 {
+		t.Fatalf("bad: %d", index)
+	}
+
 	if watchFired(ws) {
 		t.Fatalf("bad")
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -3760,6 +3760,59 @@ func TestStateStore_GetJobStatus_RunningAlloc(t *testing.T) {
 	}
 }
 
+func TestStateStore_GetJobStatus_PeriodicJob(t *testing.T) {
+	state := testStateStore(t)
+	job := mock.PeriodicJob()
+
+	txn := state.db.Txn(false)
+	status, err := state.getJobStatus(txn, job, false)
+	if err != nil {
+		t.Fatalf("getJobStatus() failed: %v", err)
+	}
+
+	if status != structs.JobStatusRunning {
+		t.Fatalf("getJobStatus() returned %v; expected %v", status, structs.JobStatusRunning)
+	}
+
+	// Mark it as stopped
+	job.Stop = true
+	status, err = state.getJobStatus(txn, job, false)
+	if err != nil {
+		t.Fatalf("getJobStatus() failed: %v", err)
+	}
+
+	if status != structs.JobStatusDead {
+		t.Fatalf("getJobStatus() returned %v; expected %v", status, structs.JobStatusDead)
+	}
+}
+
+func TestStateStore_GetJobStatus_ParameterizedJob(t *testing.T) {
+	state := testStateStore(t)
+	job := mock.Job()
+	job.ParameterizedJob = &structs.ParameterizedJobConfig{}
+
+	txn := state.db.Txn(false)
+	status, err := state.getJobStatus(txn, job, false)
+	if err != nil {
+		t.Fatalf("getJobStatus() failed: %v", err)
+	}
+
+	if status != structs.JobStatusRunning {
+		t.Fatalf("getJobStatus() returned %v; expected %v", status, structs.JobStatusRunning)
+	}
+
+	// Mark it as stopped
+	job.Stop = true
+	status, err = state.getJobStatus(txn, job, false)
+	if err != nil {
+		t.Fatalf("getJobStatus() failed: %v", err)
+	}
+
+	if status != structs.JobStatusDead {
+		t.Fatalf("getJobStatus() returned %v; expected %v", status, structs.JobStatusDead)
+	}
+}
+
 func TestStateStore_SetJobStatus_PendingEval(t *testing.T) {
 	state := testStateStore(t)
 	job := mock.Job()

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -176,6 +176,12 @@ func TestJobDiff(t *testing.T) {
 					},
 					{
 						Type: DiffTypeDeleted,
+						Name: "Stop",
+						Old:  "false",
+						New:  "",
+					},
+					{
+						Type: DiffTypeDeleted,
 						Name: "Type",
 						Old:  "batch",
 						New:  "",
@@ -250,6 +256,12 @@ func TestJobDiff(t *testing.T) {
 						Name: "Region",
 						Old:  "",
 						New:  "foo",
+					},
+					{
+						Type: DiffTypeAdded,
+						Name: "Stop",
+						Old:  "",
+						New:  "false",
 					},
 					{
 						Type: DiffTypeAdded,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1098,9 +1098,9 @@ const (
 	// for the system to remain healthy.
 	CoreJobPriority = JobMaxPriority * 2
 
-	// JobDefaultHistoricCount is the number of historic job versions that are
+	// JobTrackedVersions is the number of historic job versions that are
 	// kept.
-	JobDefaultHistoricCount = 6
+	JobTrackedVersions = 6
 )
 
 // Job is the scope of a scheduling request to Nomad. It is the largest

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1396,6 +1396,8 @@ func (j *Job) Stub(summary *JobSummary) *JobListStub {
 		Name:              j.Name,
 		Type:              j.Type,
 		Priority:          j.Priority,
+		Periodic:          j.IsPeriodic(),
+		ParameterizedJob:  j.IsParameterized(),
 		Stop:              j.Stop,
 		Status:            j.Status,
 		StatusDescription: j.StatusDescription,
@@ -1496,6 +1498,8 @@ type JobListStub struct {
 	Name              string
 	Type              string
 	Priority          int
+	Periodic          bool
+	ParameterizedJob  bool
 	Stop              bool
 	Status            string
 	StatusDescription string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1388,6 +1388,11 @@ func (j *Job) CombinedTaskMeta(groupName, taskName string) map[string]string {
 	return meta
 }
 
+// Stopped returns if a job is stopped.
+func (j *Job) Stopped() bool {
+	return j == nil || j.Stop
+}
+
 // Stub is used to return a summary of the job
 func (j *Job) Stub(summary *JobSummary) *JobListStub {
 	return &JobListStub{

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1097,6 +1097,10 @@ const (
 	// specified job so that it gets priority. This is important
 	// for the system to remain healthy.
 	CoreJobPriority = JobMaxPriority * 2
+
+	// JobDefaultHistoricCount is the number of historic job versions that are
+	// kept.
+	JobDefaultHistoricCount = 6
 )
 
 // Job is the scope of a scheduling request to Nomad. It is the largest
@@ -1171,6 +1175,15 @@ type Job struct {
 
 	// StatusDescription is meant to provide more human useful information
 	StatusDescription string
+
+	// Stable marks a job as stable. Stability is only defined on "service" and
+	// "system" jobs. The stability of a job will be set automatically as part
+	// of a deployment and can be manually set via APIs.
+	Stable bool
+
+	// Version is a monitonically increasing version number that is incremened
+	// on each job register.
+	Version uint64
 
 	// Raft Indexes
 	CreateIndex    uint64

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -536,7 +536,7 @@ type SingleNodeResponse struct {
 	QueryMeta
 }
 
-// JobListResponse is used for a list request
+// NodeListResponse is used for a list request
 type NodeListResponse struct {
 	Nodes []*NodeListStub
 	QueryMeta
@@ -565,6 +565,12 @@ type JobDispatchResponse struct {
 // JobListResponse is used for a list request
 type JobListResponse struct {
 	Jobs []*JobListStub
+	QueryMeta
+}
+
+// JobVersionsResponse is used for a job get versions request
+type JobVersionsResponse struct {
+	Versions []*Job
 	QueryMeta
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -239,6 +239,12 @@ type JobRegisterRequest struct {
 // to deregister a job as being a schedulable entity.
 type JobDeregisterRequest struct {
 	JobID string
+
+	// Purge controls whether the deregister purges the job from the system or
+	// whether the job is just marked as stopped and will be removed by the
+	// garbage collector
+	Purge bool
+
 	WriteRequest
 }
 
@@ -1114,6 +1120,12 @@ const (
 // is further composed of tasks. A task group (TG) is the unit of scheduling
 // however.
 type Job struct {
+	// Stop marks whether the user has stopped the job. A stopped job will
+	// have all created allocations stopped and acts as a way to stop a job
+	// without purging it from the system. This allows existing allocs to be
+	// queried and the job to be inspected as it is being killed.
+	Stop bool
+
 	// Region is the Nomad region that handles scheduling this job
 	Region string
 
@@ -1384,6 +1396,7 @@ func (j *Job) Stub(summary *JobSummary) *JobListStub {
 		Name:              j.Name,
 		Type:              j.Type,
 		Priority:          j.Priority,
+		Stop:              j.Stop,
 		Status:            j.Status,
 		StatusDescription: j.StatusDescription,
 		CreateIndex:       j.CreateIndex,
@@ -1483,6 +1496,7 @@ type JobListStub struct {
 	Name              string
 	Type              string
 	Priority          int
+	Stop              bool
 	Status            string
 	StatusDescription string
 	JobSummary        *JobSummary

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -83,12 +83,6 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) error {
 		s.queuedAllocs)
 }
 
-// isStoppedJob returns if the scheduling is for a stopped job and the scheduler
-// should stop all its allocations.
-func (s *SystemScheduler) isStoppedJob() bool {
-	return s.job == nil || s.job.Stop
-}
-
 // process is wrapped in retryMax to iteratively run the handler until we have no
 // further work or we've made the maximum number of attempts.
 func (s *SystemScheduler) process() (bool, error) {
@@ -101,13 +95,13 @@ func (s *SystemScheduler) process() (bool, error) {
 			s.eval.JobID, err)
 	}
 	numTaskGroups := 0
-	if !s.isStoppedJob() {
+	if !s.job.Stopped() {
 		numTaskGroups = len(s.job.TaskGroups)
 	}
 	s.queuedAllocs = make(map[string]int, numTaskGroups)
 
 	// Get the ready nodes in the required datacenters
-	if !s.isStoppedJob() {
+	if !s.job.Stopped() {
 		s.nodes, s.nodesByDC, err = readyNodesInDCs(s.state, s.job.Datacenters)
 		if err != nil {
 			return false, fmt.Errorf("failed to get ready nodes: %v", err)
@@ -125,7 +119,7 @@ func (s *SystemScheduler) process() (bool, error) {
 
 	// Construct the placement stack
 	s.stack = NewSystemStack(s.ctx)
-	if !s.isStoppedJob() {
+	if !s.job.Stopped() {
 		s.stack.SetJob(s.job)
 	}
 
@@ -234,7 +228,7 @@ func (s *SystemScheduler) computeJobAllocs() error {
 
 	// Check if a rolling upgrade strategy is being used
 	limit := len(diff.update)
-	if !s.isStoppedJob() && s.job.Update.Rolling() {
+	if !s.job.Stopped() && s.job.Update.Rolling() {
 		limit = s.job.Update.MaxParallel
 	}
 
@@ -243,7 +237,7 @@ func (s *SystemScheduler) computeJobAllocs() error {
 
 	// Nothing remaining to do if placement is not required
 	if len(diff.place) == 0 {
-		if !s.isStoppedJob() {
+		if !s.job.Stopped() {
 			for _, tg := range s.job.TaskGroups {
 				s.queuedAllocs[tg.Name] = 0
 			}

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -83,6 +83,12 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) error {
 		s.queuedAllocs)
 }
 
+// isStoppedJob returns if the scheduling is for a stopped job and the scheduler
+// should stop all its allocations.
+func (s *SystemScheduler) isStoppedJob() bool {
+	return s.job == nil || s.job.Stop
+}
+
 // process is wrapped in retryMax to iteratively run the handler until we have no
 // further work or we've made the maximum number of attempts.
 func (s *SystemScheduler) process() (bool, error) {
@@ -95,13 +101,13 @@ func (s *SystemScheduler) process() (bool, error) {
 			s.eval.JobID, err)
 	}
 	numTaskGroups := 0
-	if s.job != nil {
+	if !s.isStoppedJob() {
 		numTaskGroups = len(s.job.TaskGroups)
 	}
 	s.queuedAllocs = make(map[string]int, numTaskGroups)
 
 	// Get the ready nodes in the required datacenters
-	if s.job != nil {
+	if !s.isStoppedJob() {
 		s.nodes, s.nodesByDC, err = readyNodesInDCs(s.state, s.job.Datacenters)
 		if err != nil {
 			return false, fmt.Errorf("failed to get ready nodes: %v", err)
@@ -119,7 +125,7 @@ func (s *SystemScheduler) process() (bool, error) {
 
 	// Construct the placement stack
 	s.stack = NewSystemStack(s.ctx)
-	if s.job != nil {
+	if !s.isStoppedJob() {
 		s.stack.SetJob(s.job)
 	}
 
@@ -228,7 +234,7 @@ func (s *SystemScheduler) computeJobAllocs() error {
 
 	// Check if a rolling upgrade strategy is being used
 	limit := len(diff.update)
-	if s.job != nil && s.job.Update.Rolling() {
+	if !s.isStoppedJob() && s.job.Update.Rolling() {
 		limit = s.job.Update.MaxParallel
 	}
 
@@ -237,7 +243,7 @@ func (s *SystemScheduler) computeJobAllocs() error {
 
 	// Nothing remaining to do if placement is not required
 	if len(diff.place) == 0 {
-		if s.job != nil {
+		if !s.isStoppedJob() {
 			for _, tg := range s.job.TaskGroups {
 				s.queuedAllocs[tg.Name] = 0
 			}

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -21,7 +21,7 @@ type allocTuple struct {
 // a job requires. This is used to do the count expansion.
 func materializeTaskGroups(job *structs.Job) map[string]*structs.TaskGroup {
 	out := make(map[string]*structs.TaskGroup)
-	if job == nil {
+	if job == nil || job.Stop {
 		return out
 	}
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -21,7 +21,7 @@ type allocTuple struct {
 // a job requires. This is used to do the count expansion.
 func materializeTaskGroups(job *structs.Job) map[string]*structs.TaskGroup {
 	out := make(map[string]*structs.TaskGroup)
-	if job == nil || job.Stop {
+	if job.Stopped() {
 		return out
 	}
 

--- a/website/source/docs/commands/stop.html.md.erb
+++ b/website/source/docs/commands/stop.html.md.erb
@@ -41,6 +41,11 @@ the request. It is safe to exit the monitor early using ctrl+c.
 
 * `-yes`: Automatic yes to prompts.
 
+* `-purge`: Purge is used to stop the job and purge it from the system. If not
+set, the job will still be queryable and will be purged by the garbage
+collector.
+
+
 ## Examples
 
 Stop the job with ID "job1":

--- a/website/source/docs/http/job.html.md
+++ b/website/source/docs/http/job.html.md
@@ -133,9 +133,60 @@ region is used; another region can be specified using the `?region=` query param
     },
     "Status": "",
     "StatusDescription": "",
+    "Version": 3,
     "CreateIndex": 14,
     "ModifyIndex": 14
     }
+    ```
+  </dd>
+</dl>
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Query all versions of a single job.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/v1/job/<ID>/versions`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Blocking Queries</dt>
+  <dd>
+    [Supported](/docs/http/index.html#blocking-queries)
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    [
+        {
+            "Region": "global",
+            "ID": "binstore-storagelocker",
+            "Version": 2,
+            ...
+        },
+        {
+            "Region": "global",
+            "ID": "binstore-storagelocker",
+            "Version": 1,
+            ...
+        },
+        {
+            "Region": "global",
+            "ID": "binstore-storagelocker",
+            "Version": 0,
+            ...
+        }
+    ]
     ```
   </dd>
 </dl>


### PR DESCRIPTION
This PR introduces tracking of multiple versions of a job and introduces a stop state to the job.

This allows workflows such as:

```
$ nomad run example.nomad
$ nomad stop example
$ nomad status example
```

Previously there would be no way to check that status before.