### PR TITLE
Bumping up Vagrantfile's nomad version

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -7,9 +7,10 @@ sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y unzip curl wget vim
 
 # Download Nomad
+NOMAD_VERSION=0.5.6
 echo Fetching Nomad...
 cd /tmp/
-curl -sSL https://releases.hashicorp.com/nomad/0.5.4/nomad_0.5.4_linux_amd64.zip -o nomad.zip
+curl -sSL https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip -o nomad.zip
 
 echo Installing Nomad...
 unzip nomad.zip


### PR DESCRIPTION
Hi there! Just a small change here, while I was doing the "demo" I noticed the vagrantfile did not have nomad's latest version, so I bumped it up to 0.5.6 and set it up as an environment variable so next time it'll be easier to do so :)

Let me know if you need anything else (I can provide Vagrant's log output if necessary), just tested it and it works like a charm!