### PR TITLE
Don't deepcopy job when retrieving copy of Alloc

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -70,7 +70,8 @@ type AllocRunner struct {
 	waitCh      chan struct{}
 
 	// serialize saveAllocRunnerState calls
-	persistLock sync.Mutex
+	jobPersisted bool
+	persistLock  sync.Mutex
 }
 
 // allocRunnerState is used to snapshot the state of the alloc runner
@@ -126,11 +127,24 @@ func (r *AllocRunner) stateFilePath() string {
 	return path
 }
 
+// jobFilePath returns the path to our job file
+func (r *AllocRunner) jobFilePath() string {
+	r.allocLock.Lock()
+	defer r.allocLock.Unlock()
+	path := filepath.Join(r.config.StateDir, "alloc", r.alloc.ID, "job.json")
+	return path
+}
+
 // RestoreState is used to restore the state of the alloc runner
 func (r *AllocRunner) RestoreState() error {
-	// Load the snapshot
+	// Load the snapshot and the job
 	var snap allocRunnerState
 	if err := restoreState(r.stateFilePath(), &snap); err != nil {
+		return err
+	}
+
+	var job structs.Job
+	if err := restoreState(r.jobFilePath(), &job); err != nil {
 		return err
 	}
 
@@ -152,11 +166,23 @@ func (r *AllocRunner) RestoreState() error {
 
 	var snapshotErrors multierror.Error
 	if r.alloc == nil {
-		snapshotErrors.Errors = append(snapshotErrors.Errors, fmt.Errorf("alloc_runner snapshot includes a nil allocation"))
+		snapshotErrors.Errors = append(snapshotErrors.Errors,
+			fmt.Errorf("alloc_runner snapshot includes a nil allocation"))
 	}
 	if r.allocDir == nil {
-		snapshotErrors.Errors = append(snapshotErrors.Errors, fmt.Errorf("alloc_runner snapshot includes a nil alloc dir"))
+		snapshotErrors.Errors = append(snapshotErrors.Errors,
+			fmt.Errorf("alloc_runner snapshot includes a nil alloc dir"))
 	}
+
+	// Handle the upgrade path of the job file potentially not existing
+	if r.alloc.Job == nil && job.ID == "" {
+		snapshotErrors.Errors = append(snapshotErrors.Errors,
+			fmt.Errorf("alloc_runner snapshot doesn't include job and job not persisted seperately"))
+	} else if job.ID != "" {
+		r.jobPersisted = true
+		r.alloc.Job = &job
+	}
+
 	if e := snapshotErrors.ErrorOrNil(); e != nil {
 		return e
 	}
@@ -229,6 +255,20 @@ func (r *AllocRunner) saveAllocRunnerState() error {
 
 	// Create the snapshot.
 	alloc := r.Alloc()
+
+	// Strip the job as that is the largest part of the allocation and we want
+	// to avoid rewriting it many times
+	job := alloc.Job
+	alloc.Job = nil
+
+	// Persist the job only if it doesn't exist
+	if !r.jobPersisted {
+		if err := persistState(r.jobFilePath(), job); err != nil {
+			return err
+		}
+
+		r.jobPersisted = true
+	}
 
 	r.allocLock.Lock()
 	allocClientStatus := r.allocClientStatus

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -279,7 +279,16 @@ func copyTaskStates(states map[string]*structs.TaskState) map[string]*structs.Ta
 // Alloc returns the associated allocation
 func (r *AllocRunner) Alloc() *structs.Allocation {
 	r.allocLock.Lock()
+
+	// Clear the job before copying
+	job := r.alloc.Job
+	r.alloc.Job = nil
+
 	alloc := r.alloc.Copy()
+
+	// Restore
+	r.alloc.Job = job
+	alloc.Job = job
 
 	// The status has explicitly been set.
 	if r.allocClientStatus != "" || r.allocClientDescription != "" {

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -343,11 +343,6 @@ func (r *TaskRunner) DestroyState() error {
 
 // setState is used to update the state of the task runner
 func (r *TaskRunner) setState(state string, event *structs.TaskEvent) {
-	// Persist our state to disk.
-	if err := r.SaveState(); err != nil {
-		r.logger.Printf("[ERR] client: failed to save state of Task Runner for task %q: %v", r.task.Name, err)
-	}
-
 	// Indicate the task has been updated.
 	r.updater(r.task.Name, state, event)
 }

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hpcloud/tail/watch"
 	"github.com/ugorji/go/codec"
 )
@@ -290,7 +291,7 @@ func NewStreamFramer(out io.WriteCloser, plainTxt bool,
 	heartbeatRate, batchWindow time.Duration, frameSize int) *StreamFramer {
 
 	// Create a JSON encoder
-	enc := codec.NewEncoder(out, jsonHandle)
+	enc := codec.NewEncoder(out, structs.JsonHandle)
 
 	// Create the heartbeat and flush ticker
 	heartbeat := time.NewTicker(heartbeatRate)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -29,18 +29,6 @@ const (
 	scadaHTTPAddr = "SCADA"
 )
 
-var (
-	// jsonHandle and jsonHandlePretty are the codec handles to JSON encode
-	// structs. The pretty handle will add indents for easier human consumption.
-	jsonHandle = &codec.JsonHandle{
-		HTMLCharsAsIs: true,
-	}
-	jsonHandlePretty = &codec.JsonHandle{
-		HTMLCharsAsIs: true,
-		Indent:        4,
-	}
-)
-
 // HTTPServer is used to wrap an Agent and expose it over an HTTP interface
 type HTTPServer struct {
 	agent    *Agent
@@ -248,13 +236,13 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 		if obj != nil {
 			var buf bytes.Buffer
 			if prettyPrint {
-				enc := codec.NewEncoder(&buf, jsonHandlePretty)
+				enc := codec.NewEncoder(&buf, structs.JsonHandlePretty)
 				err = enc.Encode(obj)
 				if err == nil {
 					buf.Write([]byte("\n"))
 				}
 			} else {
-				enc := codec.NewEncoder(&buf, jsonHandle)
+				enc := codec.NewEncoder(&buf, structs.JsonHandle)
 				err = enc.Encode(obj)
 			}
 			if err != nil {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4231,6 +4231,18 @@ var MsgpackHandle = func() *codec.MsgpackHandle {
 	return h
 }()
 
+var (
+	// JsonHandle and JsonHandlePretty are the codec handles to JSON encode
+	// structs. The pretty handle will add indents for easier human consumption.
+	JsonHandle = &codec.JsonHandle{
+		HTMLCharsAsIs: true,
+	}
+	JsonHandlePretty = &codec.JsonHandle{
+		HTMLCharsAsIs: true,
+		Indent:        4,
+	}
+)
+
 var HashiMsgpackHandle = func() *hcodec.MsgpackHandle {
 	h := &hcodec.MsgpackHandle{RawToString: true}
 


### PR DESCRIPTION
This PR removes deepcopying of the job attached to the allocation in the
alloc runner. This operation is called very often so removing reflect
from the code path and the potentially large number of mallocs need to
create a job reduced memory and cpu pressure.