### PR TITLE
fix nil pointer exception when running status with failed allocations

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1330,7 +1330,7 @@ func (s *StateStore) AllocsByJob(ws memdb.WatchSet, jobID string, all bool) ([]*
 		// If the allocation belongs to a job with the same ID but a different
 		// create index and we are not getting all the allocations whose Jobs
 		// matches the same Job ID then we skip it
-		if !all && job != nil && alloc.Job.CreateIndex != job.CreateIndex {
+		if !all && job != nil && alloc.Job != nil && alloc.Job.CreateIndex != job.CreateIndex {
 			continue
 		}
 		out = append(out, raw.(*structs.Allocation))


### PR DESCRIPTION
When a job has an allocation which failed to be created alloc.Job is nil, causing a nil pointer exception and an empty file to be returned to `nomad status`.