### PR TITLE
Deployment object and new Plan Apply FSM codepath

### DIFF
--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1484,3 +1484,96 @@ func TestFSM_ReconcileSummaries(t *testing.T) {
 		t.Fatalf("expected: %#v, actual: %#v", &expected, out2)
 	}
 }
+
+func TestFSM_ApplyPlanResults(t *testing.T) {
+	fsm := testFSM(t)
+
+	// Create the request and create a deployment
+	alloc := mock.Alloc()
+	job := alloc.Job
+	alloc.Job = nil
+
+	d := mock.Deployment()
+	d.JobID = job.ID
+	d.JobModifyIndex = job.ModifyIndex
+	d.JobVersion = job.Version
+
+	alloc.DeploymentID = d.ID
+
+	fsm.State().UpsertJobSummary(1, mock.JobSummary(alloc.JobID))
+	req := structs.ApplyPlanResultsRequest{
+		AllocUpdateRequest: structs.AllocUpdateRequest{
+			Job:   job,
+			Alloc: []*structs.Allocation{alloc},
+		},
+		CreatedDeployment: d,
+	}
+	buf, err := structs.Encode(structs.ApplyPlanResultsRequestType, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp := fsm.Apply(makeLog(buf))
+	if resp != nil {
+		t.Fatalf("resp: %v", resp)
+	}
+
+	// Verify the allocation is registered
+	ws := memdb.NewWatchSet()
+	out, err := fsm.State().AllocByID(ws, alloc.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	alloc.CreateIndex = out.CreateIndex
+	alloc.ModifyIndex = out.ModifyIndex
+	alloc.AllocModifyIndex = out.AllocModifyIndex
+
+	// Job should be re-attached
+	alloc.Job = job
+	if !reflect.DeepEqual(alloc, out) {
+		t.Fatalf("bad: %#v %#v", alloc, out)
+	}
+
+	dout, err := fsm.State().DeploymentByID(ws, d.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if tg, ok := dout.TaskGroups[alloc.TaskGroup]; !ok || tg.PlacedAllocs != 1 {
+		t.Fatalf("err: %v %v", tg, err)
+	}
+
+	// Ensure that the original job is used
+	evictAlloc := alloc.Copy()
+	job = mock.Job()
+	job.Priority = 123
+
+	evictAlloc.Job = nil
+	evictAlloc.DesiredStatus = structs.AllocDesiredStatusEvict
+	req2 := structs.ApplyPlanResultsRequest{
+		AllocUpdateRequest: structs.AllocUpdateRequest{
+			Job:   job,
+			Alloc: []*structs.Allocation{evictAlloc},
+		},
+	}
+	buf, err = structs.Encode(structs.ApplyPlanResultsRequestType, req2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp = fsm.Apply(makeLog(buf))
+	if resp != nil {
+		t.Fatalf("resp: %v", resp)
+	}
+
+	// Verify we are evicted
+	out, err = fsm.State().AllocByID(ws, alloc.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out.DesiredStatus != structs.AllocDesiredStatusEvict {
+		t.Fatalf("alloc found!")
+	}
+	if out.Job == nil || out.Job.Priority == 123 {
+		t.Fatalf("bad job")
+	}
+}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -559,7 +559,7 @@ func (j *Job) GetJobVersions(args *structs.JobSpecificRequest,
 				reply.Index = out[0].ModifyIndex
 			} else {
 				// Use the last index that affected the nodes table
-				index, err := state.Index("job_versions")
+				index, err := state.Index("job_version")
 				if err != nil {
 					return err
 				}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -308,6 +308,20 @@ func VaultAccessor() *structs.VaultAccessor {
 	}
 }
 
+func Deployment() *structs.Deployment {
+	return &structs.Deployment{
+		ID:                structs.GenerateUUID(),
+		JobID:             structs.GenerateUUID(),
+		JobVersion:        2,
+		JobModifyIndex:    20,
+		JobCreateIndex:    18,
+		Status:            structs.DeploymentStatusRunning,
+		StatusDescription: structs.DeploymentStatusRunning,
+		ModifyIndex:       23,
+		CreateIndex:       21,
+	}
+}
+
 func Plan() *structs.Plan {
 	return &structs.Plan{
 		Priority: 50,

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -310,11 +310,16 @@ func VaultAccessor() *structs.VaultAccessor {
 
 func Deployment() *structs.Deployment {
 	return &structs.Deployment{
-		ID:                structs.GenerateUUID(),
-		JobID:             structs.GenerateUUID(),
-		JobVersion:        2,
-		JobModifyIndex:    20,
-		JobCreateIndex:    18,
+		ID:             structs.GenerateUUID(),
+		JobID:          structs.GenerateUUID(),
+		JobVersion:     2,
+		JobModifyIndex: 20,
+		JobCreateIndex: 18,
+		TaskGroups: map[string]*structs.DeploymentState{
+			"web": &structs.DeploymentState{
+				DesiredTotal: 10,
+			},
+		},
 		Status:            structs.DeploymentStatusRunning,
 		StatusDescription: structs.DeploymentStatusRunning,
 		ModifyIndex:       23,

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -136,6 +136,7 @@ func (s *Server) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap 
 			Alloc: make([]*structs.Allocation, 0, minUpdates),
 		},
 		CreatedDeployment: plan.CreatedDeployment,
+		DeploymentUpdates: plan.DeploymentUpdates,
 	}
 	for _, updateList := range result.NodeUpdate {
 		req.Alloc = append(req.Alloc, updateList...)

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -106,7 +106,7 @@ func (s *Server) planApply() {
 		}
 
 		// Dispatch the Raft transaction for the plan
-		future, err := s.applyPlan(pending.plan.Job, result, snap)
+		future, err := s.applyPlan(pending.plan, result, snap)
 		if err != nil {
 			s.logger.Printf("[ERR] nomad: failed to submit plan: %v", err)
 			pending.respond(nil, err)
@@ -120,16 +120,22 @@ func (s *Server) planApply() {
 }
 
 // applyPlan is used to apply the plan result and to return the alloc index
-func (s *Server) applyPlan(job *structs.Job, result *structs.PlanResult, snap *state.StateSnapshot) (raft.ApplyFuture, error) {
+func (s *Server) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap *state.StateSnapshot) (raft.ApplyFuture, error) {
 	// Determine the miniumum number of updates, could be more if there
 	// are multiple updates per node
 	minUpdates := len(result.NodeUpdate)
 	minUpdates += len(result.NodeAllocation)
 
+	// Grab the job
+	job := plan.Job
+
 	// Setup the update request
-	req := structs.AllocUpdateRequest{
-		Job:   job,
-		Alloc: make([]*structs.Allocation, 0, minUpdates),
+	req := structs.ApplyPlanResultsRequest{
+		AllocUpdateRequest: structs.AllocUpdateRequest{
+			Job:   job,
+			Alloc: make([]*structs.Allocation, 0, minUpdates),
+		},
+		CreatedDeployment: plan.CreatedDeployment,
 	}
 	for _, updateList := range result.NodeUpdate {
 		req.Alloc = append(req.Alloc, updateList...)
@@ -148,20 +154,15 @@ func (s *Server) applyPlan(job *structs.Job, result *structs.PlanResult, snap *s
 	}
 
 	// Dispatch the Raft transaction
-	future, err := s.raftApplyFuture(structs.AllocUpdateRequestType, &req)
+	future, err := s.raftApplyFuture(structs.ApplyPlanResultsRequestType, &req)
 	if err != nil {
 		return nil, err
 	}
 
 	// Optimistically apply to our state view
 	if snap != nil {
-		// Attach the job to all the allocations. It is pulled out in the
-		// payload to avoid the redundancy of encoding, but should be denormalized
-		// prior to being inserted into MemDB.
-		structs.DenormalizeAllocationJobs(req.Job, req.Alloc)
-
 		nextIdx := s.raft.AppliedIndex() + 1
-		if err := snap.UpsertAllocs(nextIdx, req.Alloc); err != nil {
+		if err := snap.UpsertPlanResults(nextIdx, &req); err != nil {
 			return future, err
 		}
 	}

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -238,27 +238,14 @@ func deploymentSchema() *memdb.TableSchema {
 				},
 			},
 
-			// Job index is used to lookup deployments by job and the deployment
-			// status
+			// Job index is used to lookup deployments by job
 			"job": &memdb.IndexSchema{
 				Name:         "job",
 				AllowMissing: false,
 				Unique:       false,
-
-				// Use a compound index so that the scheduler can quickly get
-				// any paused/deploying deployment
-				Indexer: &memdb.CompoundIndex{
-					Indexes: []memdb.Indexer{
-						&memdb.StringFieldIndex{
-							Field:     "JobID",
-							Lowercase: true,
-						},
-
-						&memdb.StringFieldIndex{
-							Field:     "Status",
-							Lowercase: true,
-						},
-					},
+				Indexer: &memdb.StringFieldIndex{
+					Field:     "JobID",
+					Lowercase: true,
 				},
 			},
 		},

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -20,7 +20,8 @@ func stateStoreSchema() *memdb.DBSchema {
 		nodeTableSchema,
 		jobTableSchema,
 		jobSummarySchema,
-		jobVersionsSchema,
+		jobVersionSchema,
+		deploymentSchema,
 		periodicLaunchTableSchema,
 		evalTableSchema,
 		allocTableSchema,
@@ -142,11 +143,11 @@ func jobSummarySchema() *memdb.TableSchema {
 	}
 }
 
-// jobVersionsSchema returns the memdb schema for the job version table which
+// jobVersionSchema returns the memdb schema for the job version table which
 // keeps a historical view of job versions.
-func jobVersionsSchema() *memdb.TableSchema {
+func jobVersionSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: "job_versions",
+		Name: "job_version",
 		Indexes: map[string]*memdb.IndexSchema{
 			"id": &memdb.IndexSchema{
 				Name:         "id",
@@ -221,6 +222,47 @@ func jobIsPeriodic(obj interface{}) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// deploymentSchema returns the MemDB schema tracking a job's deployments
+func deploymentSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "deployment",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": &memdb.IndexSchema{
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.UUIDFieldIndex{
+					Field: "ID",
+				},
+			},
+
+			// Job index is used to lookup deployments by job and the deployment
+			// status
+			"job": &memdb.IndexSchema{
+				Name:         "job",
+				AllowMissing: false,
+				Unique:       false,
+
+				// Use a compound index so that the scheduler can quickly get
+				// any paused/deploying deployment
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.StringFieldIndex{
+							Field:     "JobID",
+							Lowercase: true,
+						},
+
+						&memdb.StringFieldIndex{
+							Field:     "Status",
+							Lowercase: true,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 // periodicLaunchTableSchema returns the MemDB schema tracking the most recent

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2199,17 +2199,19 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 
 	// If there was no existing allocation, this is a placement and we increment
 	// the placement
+	existingHealthSet := existing.DeploymentStatus != nil && existing.DeploymentStatus.Healthy != nil
+	allocHealthSet := alloc.DeploymentStatus != nil && alloc.DeploymentStatus.Healthy != nil
 	if existing == nil {
 		placed++
-	} else if existing.DeploymentHealth == nil && alloc.DeploymentHealth != nil {
-		if *alloc.DeploymentHealth {
+	} else if !existingHealthSet && allocHealthSet {
+		if *alloc.DeploymentStatus.Healthy {
 			healthy++
 		} else {
 			unhealthy++
 		}
-	} else if existing.DeploymentHealth != nil && alloc.DeploymentHealth != nil {
+	} else if existingHealthSet && allocHealthSet {
 		// See if it has gone from healthy to unhealthy
-		if *existing.DeploymentHealth && !*alloc.DeploymentHealth {
+		if *existing.DeploymentStatus.Healthy && !*alloc.DeploymentStatus.Healthy {
 			healthy--
 			unhealthy++
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -372,6 +372,11 @@ type ApplyPlanResultsRequest struct {
 	// event. Any existing deployment should be cancelled when the new
 	// deployment is created.
 	CreatedDeployment *Deployment
+
+	// DeploymentUpdates is a set of status updates to apply to the given
+	// deployments. This allows the scheduler to cancel any unneeded deployment
+	// because the job is stopped or the update block is removed.
+	DeploymentUpdates []*DeploymentStatusUpdate
 }
 
 // AllocUpdateRequest is used to submit changes to allocations, either
@@ -3568,6 +3573,18 @@ func (d *DeploymentState) Copy() *DeploymentState {
 	return c
 }
 
+// DeploymentStatusUpdate is used to update the status of a given deployment
+type DeploymentStatusUpdate struct {
+	// DeploymentID is the ID of the deployment to update
+	DeploymentID string
+
+	// Status is the new status of the deployment.
+	Status string
+
+	// StatusDescription is the new status description of the deployment.
+	StatusDescription string
+}
+
 const (
 	AllocDesiredStatusRun   = "run"   // Allocation should run
 	AllocDesiredStatusStop  = "stop"  // Allocation should stop
@@ -4266,8 +4283,15 @@ type Plan struct {
 	Annotations *PlanAnnotations
 
 	// CreatedDeployment is the deployment created by the scheduler that should
-	// be applied by the planner.
+	// be applied by the planner. A created deployment will cancel all other
+	// deployments for a given job as there can only be a single running
+	// deployment.
 	CreatedDeployment *Deployment
+
+	// DeploymentUpdates is a set of status updates to apply to the given
+	// deployments. This allows the scheduler to cancel any unneeded deployment
+	// because the job is stopped or the update block is removed.
+	DeploymentUpdates []*DeploymentStatusUpdate
 }
 
 // AppendUpdate marks the allocation for eviction. The clientStatus of the

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3642,10 +3642,9 @@ type Allocation struct {
 	// particular deployment
 	DeploymentID string
 
-	// DeploymentHealth marks whether the allocation has been marked healthy or
-	// unhealthy as part of a deployment. It can be unset if it has neither been
-	// marked healthy or unhealthy.
-	DeploymentHealth *bool
+	// DeploymentStatus captures the status of the allocation as part of the
+	// given deployment
+	DeploymentStatus *AllocDeploymentStatus
 
 	// Canary marks this allocation as being a canary
 	Canary bool
@@ -3683,6 +3682,7 @@ func (a *Allocation) Copy() *Allocation {
 	}
 
 	na.Metrics = na.Metrics.Copy()
+	na.DeploymentStatus = na.DeploymentStatus.Copy()
 
 	if a.TaskStates != nil {
 		ts := make(map[string]*TaskState, len(na.TaskStates))
@@ -3923,6 +3923,30 @@ func (a *AllocMetric) ScoreNode(node *Node, name string, score float64) {
 	}
 	key := fmt.Sprintf("%s.%s", node.ID, name)
 	a.Scores[key] = score
+}
+
+// AllocDeploymentStatus captures the status of the allocation as part of the
+// deployment. This can include things like if the allocation has been marked as
+// heatlhy.
+type AllocDeploymentStatus struct {
+	// Healthy marks whether the allocation has been marked healthy or unhealthy
+	// as part of a deployment. It can be unset if it has neither been marked
+	// healthy or unhealthy.
+	Healthy *bool
+}
+
+func (a *AllocDeploymentStatus) Copy() *AllocDeploymentStatus {
+	if a == nil {
+		return nil
+	}
+
+	c := new(AllocDeploymentStatus)
+
+	if a.Healthy != nil {
+		c.Healthy = helper.BoolToPtr(*a.Healthy)
+	}
+
+	return c
 }
 
 const (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3492,6 +3492,31 @@ type Deployment struct {
 	ModifyIndex uint64
 }
 
+func (d *Deployment) Copy() *Deployment {
+	c := &Deployment{}
+	*c = *d
+
+	c.TaskGroups = nil
+	if l := len(d.TaskGroups); l != 0 {
+		c.TaskGroups = make(map[string]*DeploymentState, l)
+		for tg, s := range d.TaskGroups {
+			c.TaskGroups[tg] = s.Copy()
+		}
+	}
+
+	return c
+}
+
+// Active returns whether the deployment is active or terminal.
+func (d *Deployment) Active() bool {
+	switch d.Status {
+	case DeploymentStatusRunning, DeploymentStatusPaused:
+		return true
+	default:
+		return false
+	}
+}
+
 // DeploymentState tracks the state of a deployment for a given task group.
 type DeploymentState struct {
 	// Promoted marks whether the canaries have been. Promotion by
@@ -3521,6 +3546,12 @@ type DeploymentState struct {
 
 	// UnhealthyAllocs are allocations that have been marked as unhealthy.
 	UnhealthyAllocs int
+}
+
+func (d *DeploymentState) Copy() *DeploymentState {
+	c := &DeploymentState{}
+	*c = *d
+	return c
 }
 
 const (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3511,7 +3511,7 @@ func (d *Deployment) Copy() *Deployment {
 	*c = *d
 
 	c.TaskGroups = nil
-	if l := len(d.TaskGroups); l != 0 {
+	if l := len(d.TaskGroups); d.TaskGroups != nil {
 		c.TaskGroups = make(map[string]*DeploymentState, l)
 		for tg, s := range d.TaskGroups {
 			c.TaskGroups[tg] = s.Copy()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -53,6 +53,7 @@ const (
 	ReconcileJobSummariesRequestType
 	VaultAccessorRegisterRequestType
 	VaultAccessorDegisterRequestType
+	ApplyPlanResultsRequestType
 )
 
 const (
@@ -358,6 +359,19 @@ type EvalListRequest struct {
 type PlanRequest struct {
 	Plan *Plan
 	WriteRequest
+}
+
+// ApplyPlanResultsRequest is used by the planner to apply a Raft transaction
+// committing the result of a plan.
+type ApplyPlanResultsRequest struct {
+	// AllocUpdateRequest holds the allocation updates to be made by the
+	// scheduler.
+	AllocUpdateRequest
+
+	// CreatedDeployment is the deployment created as a result of a scheduling
+	// event. Any existing deployment should be cancelled when the new
+	// deployment is created.
+	CreatedDeployment *Deployment
 }
 
 // AllocUpdateRequest is used to submit changes to allocations, either


### PR DESCRIPTION
This PR introduces the Deployment object and creates a new FSM message type to be used by the plan applier. The old way only allowed atomic creation/updating of allocations however now a deployment object also may need to be made.

This PR followed by a PR to introduce the new Update block syntax will unblock the scheduler form creating Deployments as now they can be threaded through via the plan.