### PR TITLE
Ignore Consul deregister errors on executors

### DIFF
--- a/client/driver/utils.go
+++ b/client/driver/utils.go
@@ -90,10 +90,10 @@ func createExecutorWithConfig(config *plugin.ClientConfig, w io.Writer) (executo
 		return nil, nil, fmt.Errorf("unexpected executor rpc type: %T", raw)
 	}
 	// 0.6 Upgrade path: Deregister services from the executor as the Nomad
-	// client agent now handles all Consul interactions.
-	if err := executorPlugin.DeregisterServices(); err != nil {
-		return nil, nil, err
-	}
+	// client agent now handles all Consul interactions. Ignore errors as
+	// this shouldn't cause the alloc to fail and there's nothing useful to
+	// do with them.
+	executorPlugin.DeregisterServices()
 	return executorPlugin, executorClient, nil
 }
 


### PR DESCRIPTION
Errors here only occur if Consul is not running when Nomad is restarted.

Errors here are only an issue if:
 * Consul is being used but is down or misbehaving
 * The executor is old (<0.6)
 * The task has services
 * The services hit a pre-0.6 consul.Syncer bug

If all of those conditions are met the pre-0.6 bugs will persist for
this task until Nomad is restarted.