### PR TITLE
Add new gc_max_allocs tuneable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
  * api/job: Ability to revert job to older versions [GH-2575]
  * client: Environment variables for client DC and Region [GH-2507]
  * client: Hash host ID so its stable and well distributed [GH-2541]
+ * client: GC dead allocs if total allocs > `gc_max_allocs` tunable [GH-2636]
  * client: Persist state using bolt-db and more efficient write patterns
    [GH-2610]
  * client: Fingerprint all routable addresses on an interface including IPv6

--- a/client/client.go
+++ b/client/client.go
@@ -724,7 +724,13 @@ func (c *Client) getAllocRunners() map[string]*AllocRunner {
 // fulfill the AllocCounter interface for the GC.
 func (c *Client) NumAllocs() int {
 	c.allocLock.RLock()
+	c.blockedAllocsLock.Lock()
+	c.migratingAllocsLock.Lock()
 	n := len(c.allocs)
+	n += len(c.blockedAllocations)
+	n += len(c.migratingAllocs)
+	c.migratingAllocsLock.Unlock()
+	c.blockedAllocsLock.Unlock()
 	c.allocLock.RUnlock()
 	return n
 }

--- a/client/client.go
+++ b/client/client.go
@@ -240,13 +240,15 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulServic
 
 	// Add the garbage collector
 	gcConfig := &GCConfig{
+		MaxAllocs:           cfg.GCMaxAllocs,
 		DiskUsageThreshold:  cfg.GCDiskUsageThreshold,
 		InodeUsageThreshold: cfg.GCInodeUsageThreshold,
 		Interval:            cfg.GCInterval,
 		ParallelDestroys:    cfg.GCParallelDestroys,
 		ReservedDiskMB:      cfg.Node.Reserved.DiskMB,
 	}
-	c.garbageCollector = NewAllocGarbageCollector(logger, statsCollector, gcConfig)
+	c.garbageCollector = NewAllocGarbageCollector(logger, statsCollector, c, gcConfig)
+	go c.garbageCollector.Run()
 
 	// Setup the node
 	if err := c.setupNode(); err != nil {
@@ -482,17 +484,13 @@ func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
 // Stats is used to return statistics for debugging and insight
 // for various sub-systems
 func (c *Client) Stats() map[string]map[string]string {
-	c.allocLock.RLock()
-	numAllocs := len(c.allocs)
-	c.allocLock.RUnlock()
-
 	c.heartbeatLock.Lock()
 	defer c.heartbeatLock.Unlock()
 	stats := map[string]map[string]string{
 		"client": map[string]string{
 			"node_id":         c.Node().ID,
 			"known_servers":   c.servers.all().String(),
-			"num_allocations": strconv.Itoa(numAllocs),
+			"num_allocations": strconv.Itoa(c.NumAllocs()),
 			"last_heartbeat":  fmt.Sprintf("%v", time.Since(c.lastHeartbeat)),
 			"heartbeat_ttl":   fmt.Sprintf("%v", c.heartbeatTTL),
 		},
@@ -720,6 +718,15 @@ func (c *Client) getAllocRunners() map[string]*AllocRunner {
 		runners[id] = ar
 	}
 	return runners
+}
+
+// NumAllocs returns the number of allocs this client has. Used to
+// fulfill the AllocCounter interface for the GC.
+func (c *Client) NumAllocs() int {
+	c.allocLock.RLock()
+	n := len(c.allocs)
+	c.allocLock.RUnlock()
+	return n
 }
 
 // nodeID restores, or generates if necessary, a unique node ID and SecretID.

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -209,7 +209,7 @@ func DefaultConfig() *Config {
 		GCParallelDestroys:      2,
 		GCDiskUsageThreshold:    80,
 		GCInodeUsageThreshold:   70,
-		GCMaxAllocs:             200,
+		GCMaxAllocs:             50,
 	}
 }
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -171,6 +171,10 @@ type Config struct {
 	// beyond which the Nomad client triggers GC of the terminal allocations
 	GCInodeUsageThreshold float64
 
+	// GCMaxAllocs is the maximum number of allocations a node can have
+	// before garbage collection is triggered.
+	GCMaxAllocs int
+
 	// LogLevel is the level of the logs to putout
 	LogLevel string
 
@@ -205,6 +209,7 @@ func DefaultConfig() *Config {
 		GCParallelDestroys:      2,
 		GCDiskUsageThreshold:    80,
 		GCInodeUsageThreshold:   70,
+		GCMaxAllocs:             200,
 	}
 }
 

--- a/client/gc_test.go
+++ b/client/gc_test.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"log"
-	"os"
 	"testing"
 	"time"
 
@@ -11,11 +9,14 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-var gcConfig = GCConfig{
-	DiskUsageThreshold:  80,
-	InodeUsageThreshold: 70,
-	Interval:            1 * time.Minute,
-	ReservedDiskMB:      0,
+func gcConfig() *GCConfig {
+	return &GCConfig{
+		DiskUsageThreshold:  80,
+		InodeUsageThreshold: 70,
+		Interval:            1 * time.Minute,
+		ReservedDiskMB:      0,
+		MaxAllocs:           100,
+	}
 }
 
 func TestIndexedGCAllocPQ(t *testing.T) {
@@ -57,6 +58,15 @@ func TestIndexedGCAllocPQ(t *testing.T) {
 	}
 }
 
+// MockAllocCounter implements AllocCounter interface.
+type MockAllocCounter struct {
+	allocs int
+}
+
+func (m *MockAllocCounter) NumAllocs() int {
+	return m.allocs
+}
+
 type MockStatsCollector struct {
 	availableValues []uint64
 	usedPercents    []float64
@@ -90,8 +100,8 @@ func (m *MockStatsCollector) Stats() *stats.HostStats {
 }
 
 func TestAllocGarbageCollector_MarkForCollection(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
-	gc := NewAllocGarbageCollector(logger, &MockStatsCollector{}, &gcConfig)
+	logger := testLogger()
+	gc := NewAllocGarbageCollector(logger, &MockStatsCollector{}, &MockAllocCounter{}, gcConfig())
 
 	_, ar1 := testAllocRunnerFromAlloc(mock.Alloc(), false)
 	if err := gc.MarkForCollection(ar1); err != nil {
@@ -105,8 +115,8 @@ func TestAllocGarbageCollector_MarkForCollection(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_Collect(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
-	gc := NewAllocGarbageCollector(logger, &MockStatsCollector{}, &gcConfig)
+	logger := testLogger()
+	gc := NewAllocGarbageCollector(logger, &MockStatsCollector{}, &MockAllocCounter{}, gcConfig())
 
 	_, ar1 := testAllocRunnerFromAlloc(mock.Alloc(), false)
 	_, ar2 := testAllocRunnerFromAlloc(mock.Alloc(), false)
@@ -131,8 +141,8 @@ func TestAllocGarbageCollector_Collect(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_CollectAll(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
-	gc := NewAllocGarbageCollector(logger, &MockStatsCollector{}, &gcConfig)
+	logger := testLogger()
+	gc := NewAllocGarbageCollector(logger, &MockStatsCollector{}, &MockAllocCounter{}, gcConfig())
 
 	_, ar1 := testAllocRunnerFromAlloc(mock.Alloc(), false)
 	_, ar2 := testAllocRunnerFromAlloc(mock.Alloc(), false)
@@ -153,10 +163,11 @@ func TestAllocGarbageCollector_CollectAll(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_MakeRoomForAllocations_EnoughSpace(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
+	logger := testLogger()
 	statsCollector := &MockStatsCollector{}
-	gcConfig.ReservedDiskMB = 20
-	gc := NewAllocGarbageCollector(logger, statsCollector, &gcConfig)
+	conf := gcConfig()
+	conf.ReservedDiskMB = 20
+	gc := NewAllocGarbageCollector(logger, statsCollector, &MockAllocCounter{}, conf)
 
 	_, ar1 := testAllocRunnerFromAlloc(mock.Alloc(), false)
 	close(ar1.waitCh)
@@ -190,10 +201,11 @@ func TestAllocGarbageCollector_MakeRoomForAllocations_EnoughSpace(t *testing.T) 
 }
 
 func TestAllocGarbageCollector_MakeRoomForAllocations_GC_Partial(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
+	logger := testLogger()
 	statsCollector := &MockStatsCollector{}
-	gcConfig.ReservedDiskMB = 20
-	gc := NewAllocGarbageCollector(logger, statsCollector, &gcConfig)
+	conf := gcConfig()
+	conf.ReservedDiskMB = 20
+	gc := NewAllocGarbageCollector(logger, statsCollector, &MockAllocCounter{}, conf)
 
 	_, ar1 := testAllocRunnerFromAlloc(mock.Alloc(), false)
 	close(ar1.waitCh)
@@ -228,10 +240,11 @@ func TestAllocGarbageCollector_MakeRoomForAllocations_GC_Partial(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_MakeRoomForAllocations_GC_All(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
+	logger := testLogger()
 	statsCollector := &MockStatsCollector{}
-	gcConfig.ReservedDiskMB = 20
-	gc := NewAllocGarbageCollector(logger, statsCollector, &gcConfig)
+	conf := gcConfig()
+	conf.ReservedDiskMB = 20
+	gc := NewAllocGarbageCollector(logger, statsCollector, &MockAllocCounter{}, conf)
 
 	_, ar1 := testAllocRunnerFromAlloc(mock.Alloc(), false)
 	close(ar1.waitCh)
@@ -262,10 +275,11 @@ func TestAllocGarbageCollector_MakeRoomForAllocations_GC_All(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_MakeRoomForAllocations_GC_Fallback(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
+	logger := testLogger()
 	statsCollector := &MockStatsCollector{}
-	gcConfig.ReservedDiskMB = 20
-	gc := NewAllocGarbageCollector(logger, statsCollector, &gcConfig)
+	conf := gcConfig()
+	conf.ReservedDiskMB = 20
+	gc := NewAllocGarbageCollector(logger, statsCollector, &MockAllocCounter{}, conf)
 
 	_, ar1 := testAllocRunnerFromAlloc(mock.Alloc(), false)
 	close(ar1.waitCh)
@@ -294,11 +308,49 @@ func TestAllocGarbageCollector_MakeRoomForAllocations_GC_Fallback(t *testing.T) 
 	}
 }
 
+func TestAllocGarbageCollector_MakeRoomForAllocations_MaxAllocs(t *testing.T) {
+	const (
+		liveAllocs   = 3
+		maxAllocs    = 6
+		gcAllocs     = 4
+		gcAllocsLeft = 1
+	)
+
+	logger := testLogger()
+	statsCollector := &MockStatsCollector{
+		availableValues: []uint64{10 * 1024 * MB},
+		usedPercents:    []float64{0},
+		inodePercents:   []float64{0},
+	}
+	allocCounter := &MockAllocCounter{allocs: liveAllocs}
+	conf := gcConfig()
+	conf.MaxAllocs = maxAllocs
+	gc := NewAllocGarbageCollector(logger, statsCollector, allocCounter, conf)
+
+	for i := 0; i < gcAllocs; i++ {
+		_, ar := testAllocRunnerFromAlloc(mock.Alloc(), false)
+		close(ar.waitCh)
+		if err := gc.MarkForCollection(ar); err != nil {
+			t.Fatalf("error marking alloc for gc: %v", err)
+		}
+	}
+
+	if err := gc.MakeRoomFor([]*structs.Allocation{mock.Alloc(), mock.Alloc()}); err != nil {
+		t.Fatalf("error making room for 2 new allocs: %v", err)
+	}
+
+	// There should be gcAllocsLeft alloc runners left to be collected
+	if n := len(gc.allocRunners.index); n != gcAllocsLeft {
+		t.Fatalf("expected %d remaining GC-able alloc runners but found %d", gcAllocsLeft, n)
+	}
+}
+
 func TestAllocGarbageCollector_UsageBelowThreshold(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
+	logger := testLogger()
 	statsCollector := &MockStatsCollector{}
-	gcConfig.ReservedDiskMB = 20
-	gc := NewAllocGarbageCollector(logger, statsCollector, &gcConfig)
+	conf := gcConfig()
+	conf.ReservedDiskMB = 20
+	gc := NewAllocGarbageCollector(logger, statsCollector, &MockAllocCounter{}, conf)
 
 	_, ar1 := testAllocRunnerFromAlloc(mock.Alloc(), false)
 	close(ar1.waitCh)
@@ -329,10 +381,11 @@ func TestAllocGarbageCollector_UsageBelowThreshold(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_UsedPercentThreshold(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
+	logger := testLogger()
 	statsCollector := &MockStatsCollector{}
-	gcConfig.ReservedDiskMB = 20
-	gc := NewAllocGarbageCollector(logger, statsCollector, &gcConfig)
+	conf := gcConfig()
+	conf.ReservedDiskMB = 20
+	gc := NewAllocGarbageCollector(logger, statsCollector, &MockAllocCounter{}, conf)
 
 	_, ar1 := testAllocRunnerFromAlloc(mock.Alloc(), false)
 	close(ar1.waitCh)
@@ -361,5 +414,42 @@ func TestAllocGarbageCollector_UsedPercentThreshold(t *testing.T) {
 
 	if gcAlloc := gc.allocRunners.Pop(); gcAlloc != nil {
 		t.Fatalf("gcAlloc: %v", gcAlloc)
+	}
+}
+
+func TestAllocGarbageCollector_MaxAllocsThreshold(t *testing.T) {
+	const (
+		liveAllocs   = 3
+		maxAllocs    = 6
+		gcAllocs     = 4
+		gcAllocsLeft = 1
+	)
+
+	logger := testLogger()
+	statsCollector := &MockStatsCollector{
+		availableValues: []uint64{1000},
+		usedPercents:    []float64{0},
+		inodePercents:   []float64{0},
+	}
+	allocCounter := &MockAllocCounter{allocs: liveAllocs}
+	conf := gcConfig()
+	conf.MaxAllocs = 4
+	gc := NewAllocGarbageCollector(logger, statsCollector, allocCounter, conf)
+
+	for i := 0; i < gcAllocs; i++ {
+		_, ar := testAllocRunnerFromAlloc(mock.Alloc(), false)
+		close(ar.waitCh)
+		if err := gc.MarkForCollection(ar); err != nil {
+			t.Fatalf("error marking alloc for gc: %v", err)
+		}
+	}
+
+	if err := gc.keepUsageBelowThreshold(); err != nil {
+		t.Fatalf("error gc'ing: %v", err)
+	}
+
+	// We should have gc'd down to MaxAllocs
+	if n := len(gc.allocRunners.index); n != gcAllocsLeft {
+		t.Fatalf("expected remaining gc allocs (%d) to equal %d", n, gcAllocsLeft)
 	}
 }

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -31,7 +31,10 @@ func testLogger() *log.Logger {
 }
 
 func prefixedTestLogger(prefix string) *log.Logger {
-	return log.New(os.Stderr, prefix, log.LstdFlags)
+	if testing.Verbose() {
+		return log.New(os.Stderr, prefix, log.LstdFlags)
+	}
+	return log.New(ioutil.Discard, "", 0)
 }
 
 type MockTaskStateUpdater struct {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -321,6 +321,7 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	conf.GCParallelDestroys = a.config.Client.GCParallelDestroys
 	conf.GCDiskUsageThreshold = a.config.Client.GCDiskUsageThreshold
 	conf.GCInodeUsageThreshold = a.config.Client.GCInodeUsageThreshold
+	conf.GCMaxAllocs = a.config.Client.GCMaxAllocs
 	conf.NoHostUUID = a.config.Client.NoHostUUID
 
 	return conf, nil

--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -58,6 +58,7 @@ client {
     gc_parallel_destroys = 6
     gc_disk_usage_threshold = 82
     gc_inode_usage_threshold = 91
+    gc_max_allocs = 200
     no_host_uuid = true
 }
 server {

--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -58,7 +58,7 @@ client {
     gc_parallel_destroys = 6
     gc_disk_usage_threshold = 82
     gc_inode_usage_threshold = 91
-    gc_max_allocs = 200
+    gc_max_allocs = 50
     no_host_uuid = true
 }
 server {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -209,13 +209,17 @@ type ClientConfig struct {
 	// collector will allow.
 	GCParallelDestroys int `mapstructure:"gc_parallel_destroys"`
 
-	// GCInodeUsageThreshold is the inode usage threshold beyond which the Nomad
-	// client triggers GC of the terminal allocations
+	// GCDiskUsageThreshold is the disk usage threshold given as a percent
+	// beyond which the Nomad client triggers GC of terminal allocations
 	GCDiskUsageThreshold float64 `mapstructure:"gc_disk_usage_threshold"`
 
 	// GCInodeUsageThreshold is the inode usage threshold beyond which the Nomad
 	// client triggers GC of the terminal allocations
 	GCInodeUsageThreshold float64 `mapstructure:"gc_inode_usage_threshold"`
+
+	// GCMaxAllocs is the maximum number of allocations a node can have
+	// before garbage collection is triggered.
+	GCMaxAllocs int `mapstructure:"gc_max_allocs"`
 
 	// NoHostUUID disables using the host's UUID and will force generation of a
 	// random UUID.
@@ -503,6 +507,7 @@ func DevConfig() *Config {
 	conf.Client.GCInterval = 10 * time.Minute
 	conf.Client.GCDiskUsageThreshold = 99
 	conf.Client.GCInodeUsageThreshold = 99
+	conf.Client.GCMaxAllocs = 200
 
 	return conf
 }
@@ -532,8 +537,9 @@ func DefaultConfig() *Config {
 			Reserved:              &Resources{},
 			GCInterval:            1 * time.Minute,
 			GCParallelDestroys:    2,
-			GCInodeUsageThreshold: 70,
 			GCDiskUsageThreshold:  80,
+			GCInodeUsageThreshold: 70,
+			GCMaxAllocs:           200,
 		},
 		Server: &ServerConfig{
 			Enabled:          false,
@@ -948,6 +954,9 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 	if b.GCInodeUsageThreshold != 0 {
 		result.GCInodeUsageThreshold = b.GCInodeUsageThreshold
+	}
+	if b.GCMaxAllocs != 0 {
+		result.GCMaxAllocs = b.GCMaxAllocs
 	}
 	if b.NoHostUUID {
 		result.NoHostUUID = b.NoHostUUID

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -507,7 +507,7 @@ func DevConfig() *Config {
 	conf.Client.GCInterval = 10 * time.Minute
 	conf.Client.GCDiskUsageThreshold = 99
 	conf.Client.GCInodeUsageThreshold = 99
-	conf.Client.GCMaxAllocs = 200
+	conf.Client.GCMaxAllocs = 50
 
 	return conf
 }
@@ -539,7 +539,7 @@ func DefaultConfig() *Config {
 			GCParallelDestroys:    2,
 			GCDiskUsageThreshold:  80,
 			GCInodeUsageThreshold: 70,
-			GCMaxAllocs:           200,
+			GCMaxAllocs:           50,
 		},
 		Server: &ServerConfig{
 			Enabled:          false,

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -346,6 +346,7 @@ func parseClient(result **ClientConfig, list *ast.ObjectList) error {
 		"gc_disk_usage_threshold",
 		"gc_inode_usage_threshold",
 		"gc_parallel_destroys",
+		"gc_max_allocs",
 		"no_host_uuid",
 	}
 	if err := checkHCLKeys(listVal, valid); err != nil {

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -3,10 +3,12 @@ package agent
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/kr/pretty"
 )
 
 func TestConfig_Parse(t *testing.T) {
@@ -75,6 +77,7 @@ func TestConfig_Parse(t *testing.T) {
 					GCParallelDestroys:    6,
 					GCDiskUsageThreshold:  82,
 					GCInodeUsageThreshold: 91,
+					GCMaxAllocs:           50,
 					NoHostUUID:            true,
 				},
 				Server: &ServerConfig{
@@ -165,22 +168,20 @@ func TestConfig_Parse(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Logf("Testing parse: %s", tc.File)
+		t.Run(tc.File, func(t *testing.T) {
+			path, err := filepath.Abs(filepath.Join("./config-test-fixtures", tc.File))
+			if err != nil {
+				t.Fatalf("file: %s\n\n%s", tc.File, err)
+			}
 
-		path, err := filepath.Abs(filepath.Join("./config-test-fixtures", tc.File))
-		if err != nil {
-			t.Fatalf("file: %s\n\n%s", tc.File, err)
-			continue
-		}
+			actual, err := ParseConfigFile(path)
+			if (err != nil) != tc.Err {
+				t.Fatalf("file: %s\n\n%s", tc.File, err)
+			}
 
-		actual, err := ParseConfigFile(path)
-		if (err != nil) != tc.Err {
-			t.Fatalf("file: %s\n\n%s", tc.File, err)
-			continue
-		}
-
-		if !reflect.DeepEqual(actual, tc.Result) {
-			t.Fatalf("file: %s\n\n%#v\n\n%#v", tc.File, actual, tc.Result)
-		}
+			if !reflect.DeepEqual(actual, tc.Result) {
+				t.Errorf("file: %s  diff: (actual vs expected)\n\n%s", tc.File, strings.Join(pretty.Diff(actual, tc.Result), "\n"))
+			}
+		})
 	}
 }

--- a/website/source/docs/agent/configuration/client.html.md
+++ b/website/source/docs/agent/configuration/client.html.md
@@ -100,6 +100,12 @@ client {
 - `gc_inode_usage_threshold` `(float: 70)` - Specifies the inode usage percent
   which Nomad tries to maintain by garbage collecting terminal allocations.
 
+- `gc_max_allocs` `(int: 200)` - Specifies the maximum number of allocations
+  which a client will track before triggering a garbage collection of terminal
+  allocations. This will *not* limit the number of allocations a node can run at
+  a time, however after `gc_max_allocs` every new allocation will cause terminal
+  allocations to be GC'd.
+
 - `gc_parallel_destroys` `(int: 2)` - Specifies the maximum number of
   parallel destroys allowed by the garbage collector. This value should be
   relatively low to avoid high resource usage during garbage collections.

--- a/website/source/docs/agent/configuration/client.html.md
+++ b/website/source/docs/agent/configuration/client.html.md
@@ -100,7 +100,7 @@ client {
 - `gc_inode_usage_threshold` `(float: 70)` - Specifies the inode usage percent
   which Nomad tries to maintain by garbage collecting terminal allocations.
 
-- `gc_max_allocs` `(int: 200)` - Specifies the maximum number of allocations
+- `gc_max_allocs` `(int: 50)` - Specifies the maximum number of allocations
   which a client will track before triggering a garbage collection of terminal
   allocations. This will *not* limit the number of allocations a node can run at
   a time, however after `gc_max_allocs` every new allocation will cause terminal


### PR DESCRIPTION
More than gc_max_allocs may be running on a node, but terminal allocs
will be garbage collected to try to keep the total number below the
limit.

The default of 200 allocs was a guess. Let me know if you have a number with more science behind it.

I also split `go gc.run()` out of the `NewAllocGarbageCollector` function as tests were creating and leaking gc goroutines. Not a big deal, but since it's only called one place in runtime code it's not really any convenience to hide it away inside the New func.