### PR TITLE
Don't autoadvertise private ip if bind=localhost

### DIFF
--- a/website/source/docs/agent/configuration/index.html.md
+++ b/website/source/docs/agent/configuration/index.html.md
@@ -99,8 +99,8 @@ testing.
   configurations such as NAT. This configuration is optional, and defaults to
   the bind address of the specific network service if it is not provided. Any
   values configured in this stanza take precedence over the default
-  [bind_addr](#bind_addr). If the bind address is `0.0.0.0` then the hostname
-  is advertised. You may advertise an alternate port as well.
+  [bind_addr](#bind_addr). If the bind address is `0.0.0.0` then the first
+  private IP found is advertised. You may advertise an alternate port as well.
   The values support [go-sockaddr/template format][go-sockaddr/template].
 
   - `http` - The address to advertise for the HTTP interface. This should be


### PR DESCRIPTION
A slight improvement to #2399 - if bind is localhost, return an error
instead of advertising a private ip. The advertised ip isn't valid and
will just cause errors on use. It's better to fail with an error message
instructing users how to fix the problem.

This does preserve #2399's really nice property of picking a reasonable advertise IP if bind is 0.0.0.0.