### PR TITLE
Docu was misleading

### DIFF
--- a/website/source/docs/job-specification/artifact.html.md
+++ b/website/source/docs/job-specification/artifact.html.md
@@ -99,7 +99,7 @@ artifact {
 }
 ```
 
-To download from private repo, sshkeys need to be set. The key must be
+To download from private repo, sshkey need to be set. The key must be
 base64-encoded string. Run `base64 -w0 <file>`
 
 ```hcl
@@ -107,7 +107,7 @@ artifact {
   source      = "git@github.com:example/nomad-examples"
   destination = "local/repo"
   options {
-    sshkeys = "<string>"
+    sshkey = "<string>"
   }
 }
 ```


### PR DESCRIPTION
The actual parameter for go-getter is 'sshkey' and not 'sshkeys'. The current docu is wrong here... corrected this. kkthxbai