### PR TITLE
Fix Vault Client panic when given nonexistant role

### DIFF
--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -782,6 +782,9 @@ func (v *vaultClient) validateRole(role string) error {
 	if err != nil {
 		return fmt.Errorf("failed to lookup role %q: %v", role, err)
 	}
+	if rsecret == nil {
+		return fmt.Errorf("Role %q does not exist", role)
+	}
 
 	// Read and parse the fields
 	var data struct {


### PR DESCRIPTION
The Vault API returns a nil secret and nil error when reading an object
that doesn't exist. The old code assumed an error would be returned and
thus will panic when trying to validate a non-existant role.

Fixes https://github.com/hashicorp/nomad/issues/2451