### PR TITLE
[WIP] Azure instance attributes from metadata endpoint

### DIFF
--- a/client/fingerprint/env_azure.go
+++ b/client/fingerprint/env_azure.go
@@ -1,0 +1,49 @@
+package fingerprint
+
+import (
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+const DEFAULT_AZURE_URL = ""
+
+type EnvAzureFingerprint struct {
+	StaticFingerprinter
+	client      *http.Client
+	logger      *log.Logger
+	metadataURL string
+}
+
+func NewEnvAzureFingerprint(logger *log.Logger) Fingerprint {
+	// Read the internal metadata URL from the environment, allowing test files to
+	// provide their own
+	metadataURL := os.Getenv("AZURE_ENV_URL")
+	if metadataURL == "" {
+		metadataURL = DEFAULT_AZURE_URL
+	}
+
+	// assume 2 seconds is enough time for inside Azure network
+	client := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: cleanhttp.DefaultTransport(),
+	}
+
+	return &EnvAzureFingerprint{
+		client:      client,
+		logger:      logger,
+		metadataURL: metadataURL,
+	}
+}
+
+func (f *EnvAzureFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
+	return false, nil
+}
+
+func (f *EnvAzureFingerprint) isAzure() bool {
+	return false
+}

--- a/client/fingerprint/env_azure.go
+++ b/client/fingerprint/env_azure.go
@@ -8,9 +8,30 @@ import (
 	"net/http"
 	"os"
 	"time"
+	"fmt"
 )
 
-const DEFAULT_AZURE_URL = ""
+// Details: https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-instancemetadataservice-overview
+const DEFAULT_AZURE_API_VERSION = "2017-03-01"
+const DEFAULT_AZURE_URL = "http://169.254.169.254/metadata/instance?api-version=" + DEFAULT_AZURE_API_VERSION
+
+type AzureMetadataNetworkInterface struct {
+	AccessConfigs []struct {
+		ExternalIp string
+		Type       string
+	}
+	ForwardedIps []string
+	Ip           string
+	Network      string
+}
+
+type AzureReqError struct {
+	StatusCode int
+}
+
+func (e AzureReqError) Error() string {
+	return http.StatusText(e.StatusCode)
+}
 
 type EnvAzureFingerprint struct {
 	StaticFingerprinter
@@ -40,10 +61,47 @@ func NewEnvAzureFingerprint(logger *log.Logger) Fingerprint {
 	}
 }
 
+func (f *EnvAzureFingerprint) Get(attribute string, isText bool) {
+	// By default; return JSON
+
+	// unless specifically mentioned to be Text
+
+}
+// Mapping of Azure Compute Units (ACUs); IO, Network refer to below:
+// https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-windows-sizes
 func (f *EnvAzureFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
+
+	if !f.isAzure() {
+		return false, nil
+	}
+
+	if node.Links == nil {
+		node.Links = make(map[string]string)
+	}
+	// Keys and whether they should be namespaced as unique. Any key whose value
+	// uniquely identifies a node, such as ip, should be marked as unique. When
+	// marked as unique, the key isn't included in the computed node class.
+	keys := map[string]bool{
+		"vm-id":                          true,
+		"vm-size":                        false,
+		"os-type":                        false,
+		"local-ipv4":                     true,
+		"public-ipv4":                    true,
+		"placement/update-domain":        false,
+		"placement/fault-domain":         false,
+		"scheduling/automatic-restart":   false,
+		"scheduling/on-host-maintenance": false,
+	}
+
+	fmt.Printf("%v", keys)
+
 	return false, nil
 }
 
 func (f *EnvAzureFingerprint) isAzure() bool {
+	// Call the instance name; if returns something; consider that it is proxy for Azure
+	// any other way?
+
+	f.client.Get()
 	return false
 }

--- a/client/fingerprint/env_azure_test.go
+++ b/client/fingerprint/env_azure_test.go
@@ -1,34 +1,159 @@
 package fingerprint
 
-import "testing"
+import (
+	"testing"
+	"os"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/client/config"
+	"hashicorp/packer/common/json"
+	"net/http/httptest"
+	"net/http"
+	"fmt"
+	"time"
+	"github.com/hashicorp/go-cleanhttp"
+	"net/url"
+	"io/ioutil"
+)
 
 func TestEnvAzureFingerprint_nonAzure(t *testing.T) {
+	os.Setenv("AZURE_ENV_URL", "http://localhost/metadata/instance?api-version=2017-03-01")
+	f := NewEnvAzureFingerprint(testLogger())
 
-	t.Fatal("Die!")
+	node := &structs.Node{
+		Attributes: make(map[string]string),
+	}
+
+	ok, err := f.Fingerprint(&config.Config{}, node)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if ok {
+		t.Fatal("Should not reach here without mock server running!")
+	}
 }
 
 func TestEnvAzureFingerprint_azure(t *testing.T) {
-
 	t.Fatal("Die!")
 }
 
 type AzureRM_routes struct {
-	Endpoints []*endpoint `json:"endpoints"`
+	Endpoints []*Azure_endpoint `json:"endpoints"`
 }
 type Azure_endpoint struct {
 	Uri         string `json:"uri"`
+	Header      string `json:"header"`
 	ContentType string `json:"content-type"`
+	HTTPStatus  string `json:http-status`
 	Body        string `json:"body"`
 }
 
+// In order to investigate the scenarios; you can use the curl command as per below (NOTE: -i for header):
+// curl -i  --header "Metadata:true"  "http://169.254.169.254/metadata?api-version=2017-03-01&format=text"
 const Azure_routes = `
 {
   "endpoints": [
     {
-      "uri": "/computeMetadata/v1/instance/id",
+      "uri": "/metadata/instance/compute/location?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
       "content-type": "text/plain",
-      "body": "12345"
+      "http-status": "200",
+      "body": "SouthEastAsia"
     },
+    {
+      "uri": "/metadata/instance/compute/osType?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "Linux"
+    },
+    {
+      "uri": "/metadata/instance/compute/platformUpdateDomain?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "1"
+    },
+    {
+      "uri": "/metadata/instance/compute/platformFaultDomain?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "5"
+    },
+    {
+      "uri": "/metadata/instance/compute/vmId?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "5c08b38e-4d57-4c23-ac45-aca61037f084"
+    },
+    {
+      "uri": "/metadata/instance/compute/vmSize?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "Standard_DS2"
+    },
+    {
+      "uri": "/metadata/instance/network/interface/0/ipv4/ipaddress/0/ipaddress?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "10.0.0.4"
+    },
+    {
+      "uri": "/metadata/instance/network/interface/0/ipv4/ipaddress/0/publicip?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "54.128.200.22"
+    },
+    {
+      "uri": "/metadata/instance/network/interface/0/ipv4/subnet/0/prefix?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "24"
+    },
+    {
+      "uri": "/metadata/instance/network/interface/0/ipv4/subnet/0/address?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "10.0.101.0"
+    },
+    {
+      "uri": "/metadata/instance/network/interface/0/ipv4/subnet/0/dnsservers/1/ipaddress?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "10.0.0.3"
+    },
+    {
+      "uri": "/metadata/instance/network/interface/0/mac?api-version=2017-03-01&format=text",
+      "header": "Metadata:true",
+      "content-type": "text/plain",
+      "http-status": "200",
+      "body": "000D3A00FA89"
+    },
+    {
+      "uri": "/metadata/scheduledevents?api-version=2017-03-01",
+      "header": "Metadata:true",
+      "content-type": "application/json",
+      "http-status": "200",
+      "body": "{\"DocumentIncarnation\":0, \"Events\":[]}"
+    },
+    {
+      "uri": "/metadata/instance/unknown?api-version=2017-03-01",
+      "header": "Metadata:true",
+      "content-type": "application/json",
+      "http-status": "404",
+      "body": "{ \"error\": \"Not found\" }"
+    }
+  ]
+}
 `
 
 func TestNetworkFingerprint_Azure(t *testing.T) {
@@ -39,6 +164,139 @@ func TestNetworkFingerprint_Azure_network(t *testing.T) {
 	t.Fatal("Die!")
 }
 
+// Correctly catches that it is not OK if it is not a valid Azure metadata endpoint
 func TestNetworkFingerprint_notAzure(t *testing.T) {
-	t.Fatal("Die!")
+
+	// TODO: Should do more of Network testing ..
+	os.Setenv("AZURE_ENV_URL", "http://localhost/metadata/instance?api-version=2017-03-01")
+	f := NewEnvAzureFingerprint(testLogger())
+
+	node := &structs.Node{
+		Attributes: make(map[string]string),
+	}
+
+	ok, err := f.Fingerprint(&config.Config{}, node)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if ok {
+		t.Fatal("Should not reach here as it is not a valid Azure metadata endpoint!")
+	}
+}
+
+func testFingerprint_Azure(t *testing.T, withExternalIp bool) {
+	// configure mock server with fixture routes, data
+	routes := routes{}
+	if err := json.Unmarshal([]byte(Azure_routes), &routes); err != nil {
+		t.Fatalf("Failed to unmarshall JSON in Azure ENV test: %s", err)
+	}
+
+	for _, e := range routes.Endpoints {
+		fmt.Printf("%v", e)
+	}
+
+}
+
+func TestFingerprint_AzureWithExternalIp(t *testing.T) {
+	testFingerprint_Azure(t, true)
+}
+
+func TestFingerprint_AzureWithoutExternalIp(t *testing.T) {
+	testFingerprint_Azure(t, false)
+}
+
+func TestAzureMetadataEndpoint(t *testing.T) {
+
+	// Setup client and legal + illegal EnvAzureFingerprint
+	// assume 2 seconds is enough time for inside Azure network
+	client := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: cleanhttp.DefaultTransport(),
+	}
+
+	// isAzure without test server
+	f_not_azure := &EnvAzureFingerprint{
+		client:      client,
+		logger:      testLogger(),
+		metadataURL: "http://localhost/metadata?api-version=" + DEFAULT_AZURE_API_VERSION + "&format=text",
+	}
+
+	if f_not_azure.isAzure() != false {
+		t.Fatal("WRONG!!")
+	}
+
+	// Now for tests with server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// For test; only text output returned
+		w.Header().Set("Content-Type", "text/plain")
+		if r.Header.Get("Metadata") != "true" {
+			// Needs to be set; otherwise it is Bad Request
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "Bad request. Required metadata header not specified")
+		} else if r.Header.Get("X-Forward-For") != "" {
+			// Cannot forward via Proxy ..
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "Bad Request")
+		} else {
+			// For isAzure test
+			if r.RequestURI == "/metadata?api-version=2017-03-01&format=text" {
+				fmt.Fprint(w, "instance/")
+			}
+		}
+	}))
+	defer ts.Close()
+
+	f := &EnvAzureFingerprint{
+		client:      client,
+		logger:      testLogger(),
+		metadataURL: ts.URL + "/metadata?api-version=" + DEFAULT_AZURE_API_VERSION + "&format=text",
+	}
+
+	parsedUrl, err := url.Parse(f.metadataURL)
+	if err != nil {
+		t.Fatalf("Parse err: %v", err)
+	}
+
+	missing_metadata_req := &http.Request{
+		Method: "GET",
+		URL:    parsedUrl,
+		Header: http.Header{},
+	}
+
+	if res, err := f.client.Do(missing_metadata_req); err != nil {
+		t.Fatalf("err: %v", err)
+	} else {
+		mybody, _ := ioutil.ReadAll(res.Body)
+		f.logger.Printf("Body: %v", string(mybody))
+		// If not passing the correct header for Metadata; it should be caught
+		if res.StatusCode != http.StatusBadRequest {
+			t.Fatal("Should catch if no metadata header being passed")
+		}
+	}
+
+	illegal_forward_req := &http.Request{
+		Method: "GET",
+		URL:    parsedUrl,
+		Header: http.Header{
+			"Metadata":      []string{"true"},
+			"X-Forward-For": []string{"202.188.1.3"},
+		},
+	}
+	if res, err := f.client.Do(illegal_forward_req); err != nil {
+		t.Fatalf("err: %v", err)
+	} else {
+		mybody, _ := ioutil.ReadAll(res.Body)
+		f.logger.Printf("Body: %v", string(mybody))
+		// If not passing the correct header for Metadata; it should be caught
+		if res.StatusCode != http.StatusBadRequest {
+			t.Fatal("Should catch if no metadata being passed")
+		}
+	}
+
+	// Final test; with real server
+	if f.isAzure() != true {
+		t.Fatal("WRONG!")
+	}
 }

--- a/client/fingerprint/env_azure_test.go
+++ b/client/fingerprint/env_azure_test.go
@@ -1,0 +1,44 @@
+package fingerprint
+
+import "testing"
+
+func TestEnvAzureFingerprint_nonAzure(t *testing.T) {
+
+	t.Fatal("Die!")
+}
+
+func TestEnvAzureFingerprint_azure(t *testing.T) {
+
+	t.Fatal("Die!")
+}
+
+type AzureRM_routes struct {
+	Endpoints []*endpoint `json:"endpoints"`
+}
+type Azure_endpoint struct {
+	Uri         string `json:"uri"`
+	ContentType string `json:"content-type"`
+	Body        string `json:"body"`
+}
+
+const Azure_routes = `
+{
+  "endpoints": [
+    {
+      "uri": "/computeMetadata/v1/instance/id",
+      "content-type": "text/plain",
+      "body": "12345"
+    },
+`
+
+func TestNetworkFingerprint_Azure(t *testing.T) {
+	t.Fatal("Die!")
+}
+
+func TestNetworkFingerprint_Azure_network(t *testing.T) {
+	t.Fatal("Die!")
+}
+
+func TestNetworkFingerprint_notAzure(t *testing.T) {
+	t.Fatal("Die!")
+}


### PR DESCRIPTION
Description: Leverage on the new Azure Metadata endpoint to get extended properties.  This will allow Nomad Job constraint to use Azure specific attributes.  Example: set tasks to be spread out among fault domains.  Ensure it will have parity with AWS + GCE.

Changesets:
- Cannot link yet to fingerprint.go as there is error
- Factory methods for AzureFingerprint
- All fail tests