### PR TITLE
Move env file parsing to a library

### DIFF
--- a/client/consul_template_test.go
+++ b/client/consul_template_test.go
@@ -921,7 +921,7 @@ func TestTaskTemplateManager_Env(t *testing.T) {
 
 FOO=bar
 foo=123
-ANYTHING-goes=Spaces are=ok!
+ANYTHING_goes=Spaces are=ok!
 `,
 		DestPath:   "test.env",
 		ChangeMode: structs.TemplateChangeModeNoop,

--- a/vendor/github.com/schmichael/go-envparse/LICENSE
+++ b/vendor/github.com/schmichael/go-envparse/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/schmichael/go-envparse/NOTICES.txt
+++ b/vendor/github.com/schmichael/go-envparse/NOTICES.txt
@@ -1,0 +1,2 @@
+go-envparse
+Copyright 2017 HashiCorp, Inc.

--- a/vendor/github.com/schmichael/go-envparse/README.md
+++ b/vendor/github.com/schmichael/go-envparse/README.md
@@ -1,0 +1,93 @@
+[![GoDoc](https://godoc.org/github.com/schmichael/go-envparse?status.svg)](https://godoc.org/github.com/schmichael/go-envparse)
+[![Build Status](https://travis-ci.org/schmichael/go-envparse.svg?branch=master)](https://travis-ci.org/schmichael/go-envparse)
+[![Build status](https://ci.appveyor.com/api/projects/status/o6mdepblusp1g74d?svg=true)](https://ci.appveyor.com/project/schmichael/go-envparse)
+[![Coverage Status](https://coveralls.io/repos/github/schmichael/go-envparse/badge.svg?branch=master)](https://coveralls.io/github/schmichael/go-envparse?branch=master)
+
+# go-envparse
+
+A minimal Go environment variable parser. It's intended to be used to parse
+`.env` style files similar to [godotenv](https://github.com/joho/godotenv) or
+[rubydotenv](https://github.com/bkeepers/dotenv), but perform minimal
+allocations, handle more complex quoting, and be better tested.
+
+Parsing a line does 2 allocations regardless of line length or complexity.
+
+The parser supports JSON strings which allows for cross-language/platform
+encoding of arbitrarily complex data.
+
+For example if you are parsing environment variables from a templated file, the
+template can JSON encode data that may contain newlines:
+
+```
+FOO={{ some_template_function | toJSON }}
+```
+
+...would be templated to:
+
+```
+FOO="The template value\nmay have included\nsome newlines!\n\ud83d\udd25"
+```
+
+...and `envparse.Parse()` would return:
+
+```go
+map[string]string{
+	"FOO": "The template value\nmay have included\nsome newlines!\n🔥",
+}
+```
+
+## Minimal
+
+The following common features *are intentionaly missing*:
+
+* Full shell quoting semantics
+* Full shell escape sequence support
+  * Only JSON escape sequences are supported (see below)
+* Variable interpolation
+  * Use [Go's os.Expand](https://golang.org/pkg/os/#Expand) on the parsed
+    values
+* Anything YAML related
+  * No
+
+However, comments, unquoted, single quoted, and double quoted text may all be
+used within a single value:
+
+```
+SOME_KEY = normal unquoted \text 'plus single quoted\' "\"double quoted " # EOL
+```
+
+...parses to:
+
+```go
+map[string]string{
+	"SOME_KEY": `normal unquoted \text plus single quoted\ "double quoted `
+}
+```
+
+(Note the trailing space inside the double quote is kept, but the space between
+the final `"` and `#` is trimmed.)
+
+## Format
+
+* Keys should be of the form: `[A-Za-z_][A-Za-z0-9_]?`
+  * Keys may be prefixed with `export ` which will be ignored
+  * Whitespace around keys will be trimmed
+* Values should be valid ASCII or UTF-8 encoded.
+* Newlines are always treated as delimiters, so newlines within values *must*
+  be escaped.
+* Values may use one of more quoting styles:
+  * Unquoted - `FOO=bar baz`
+    * No escape sequences
+    * Ends at `#`, `"`, `'`, or newline
+    * Preceeding and trailing whitespace will be trimmed
+  * Double Quotes - `FOO="bar baz"`
+    * Supports JSON escape sequences: `\uXXXX`, `\r`, `\n`, `\t`, `\\`, and
+      `\"`
+    * Ends at unescaped `"`
+    * No whitespace trimming
+  * Single Quotes - `FOO='bar baz'`
+    * No escape sequences
+    * Ends at `'`
+    * No whitespace trimming
+
+See `envparse_test.go` for examples of valid and invalid data.

--- a/vendor/github.com/schmichael/go-envparse/envparse.go
+++ b/vendor/github.com/schmichael/go-envparse/envparse.go
@@ -1,0 +1,336 @@
+// Package envparse is a minimal environment variable parser. It handles empty
+// lines, comments, single quotes, double quotes, and JSON escape sequences.
+//
+// Non-empty or comment lines should be of the form:
+//
+//	KEY=value
+//
+// While extraneous characters are discouraged, an "export" prefix, preceeding
+// whitespace, and trailing whitespace are all removed:
+//
+//	KEY = This is ok! # Parses to {"KEY": "This is ok!"}
+//	KEY2= Also ok.    # Parses to {"KEY2": "Also ok."}
+//	export FOO=bar    # Parses to {"FOO": "bar"}
+package envparse
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+var (
+	ErrMissingSeparator = fmt.Errorf("missing =")
+	ErrEmptyKey         = fmt.Errorf("empty key")
+	ErrUnmatchedDouble  = fmt.Errorf(`unmatched "`)
+	ErrUnmatchedSingle  = fmt.Errorf("unmatched '")
+	ErrIncompleteEscape = fmt.Errorf("incomplete escape sequence")
+	ErrIncompleteHex    = fmt.Errorf("incomplete hex sequence")
+	ErrIncompleteSur    = fmt.Errorf("incomplete Unicode surrogate pair")
+	ErrMultibyteEscape  = fmt.Errorf("multibyte characters disallowed in escape sequences")
+)
+
+// ParseError is returned whenever the Parse function encounters an error. It
+// includes the line number and underlying error.
+type ParseError struct {
+	Line int
+	Err  error
+}
+
+func (e *ParseError) Error() string {
+	if e.Line > 0 {
+		return fmt.Sprintf("error on line %d: %v", e.Line, e.Err)
+	}
+	return fmt.Sprintf("error reading: %v", e.Err)
+}
+
+func parseError(line int, err error) error {
+	return &ParseError{
+		Line: line,
+		Err:  err,
+	}
+}
+
+// Parse environmnet variables from an io.Reader into a map or return a
+// ParseError.
+func Parse(r io.Reader) (map[string]string, error) {
+	env := make(map[string]string)
+	scanner := bufio.NewScanner(r)
+
+	// Track line number
+	i := 0
+
+	// Main scan loop
+	for scanner.Scan() {
+		i++
+		k, v, err := parseLine(scanner.Bytes())
+		if err != nil {
+			return nil, parseError(i, err)
+		}
+
+		// Skip blank lines
+		if len(k) > 0 {
+			env[string(k)] = string(v)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, parseError(i, err)
+	}
+	return env, nil
+}
+
+const (
+	normalMode  = iota
+	doubleQuote = iota
+	singleQuote = iota
+	escapeMode  = iota
+	unicodeMode = iota
+)
+
+var (
+	empty        = []byte{}
+	separator    = []byte{'='}
+	exportPrefix = []byte("export ")
+)
+
+// parseLine parses the given line into a key and value or error.
+//
+// Empty lines are returned as zero length slices
+func parseLine(ln []byte) ([]byte, []byte, error) {
+	ln = bytes.TrimSpace(ln)
+	if len(ln) == 0 || ln[0] == '#' {
+		return empty, empty, nil
+	}
+
+	parts := bytes.SplitN(ln, separator, 2)
+	if len(parts) != 2 {
+		return nil, nil, ErrMissingSeparator
+	}
+
+	// Trim whitespace
+	key, value := bytes.TrimSpace(parts[0]), bytes.TrimSpace(parts[1])
+
+	// Ensure key is of the form [A-Za-z][A-Za-z0-9_]? with an optional
+	// leading 'export ', but only trim leading export if there's another
+	// key name.
+	if len(key) > len(exportPrefix) {
+		key = bytes.TrimPrefix(key, exportPrefix)
+	}
+	if len(key) == 0 {
+		return nil, nil, ErrEmptyKey
+	}
+	if key[0] < 'A' {
+		return nil, nil, fmt.Errorf("key must start with [A-Za-z_] but found %q", key[0])
+	}
+	if key[0] > 'Z' && key[0] < 'a' && key[0] != '_' {
+		return nil, nil, fmt.Errorf("key must start with [A-Za-z_] but found %q", key[0])
+	}
+	if key[0] > 'z' {
+		return nil, nil, fmt.Errorf("key must start with [A-Za-z_] but found %q", key[0])
+	}
+
+	for _, v := range key[1:] {
+		switch {
+		case v == '_':
+		case v >= 'A' && v <= 'Z':
+		case v >= 'a' && v <= 'z':
+		case v >= '0' && v <= '9':
+		default:
+			return nil, nil, fmt.Errorf("key characters must be [A-Za-z0-9_] but found %q", v)
+		}
+	}
+
+	// Evaluate the value
+	if len(value) == 0 {
+		// Empty values are ok! Shortcircuit
+		return key, value, nil
+	}
+
+	// Scratch buffer for unescaped value
+	newv := make([]byte, len(value))
+	newi := 0
+	// Track last significant character for trimming unquoted whitespace preceeding a trailing comment
+	lastSig := 0
+
+	// Parser State
+	mode := normalMode
+
+	for i := 0; i < len(value); i++ {
+		v := value[i]
+
+		// Control characters are always an error
+		if v < 32 {
+			return nil, nil, fmt.Errorf("0x%0.2x is an invalid value character", v)
+		}
+
+		// High bit set means it is part of a multibyte character, pass
+		// it through as only ASCII characters have special meaning.
+		if v > 127 {
+			if mode == escapeMode {
+				return nil, nil, ErrMultibyteEscape
+			}
+			// All multibyte characters are significant
+			lastSig = newi
+			newv[newi] = v
+			newi++
+			continue
+		}
+
+		switch mode {
+		case normalMode:
+			switch v {
+			case '"':
+				mode = doubleQuote
+			case '\'':
+				mode = singleQuote
+			case '#':
+				// Start of a comment, nothing left to parse
+				return key, newv[:lastSig], nil
+			case ' ', '\t':
+				// Make sure whitespace doesn't get tracked
+				newv[newi] = v
+				newi++
+			default:
+				// Add the character to the new value
+				newv[newi] = v
+				newi++
+
+				// Track last non-WS char for trimming on trailing comments
+				lastSig = newi
+			}
+		case doubleQuote:
+			switch v {
+			case '"':
+				mode = normalMode
+			case '\\':
+				mode = escapeMode
+			default:
+				// Add the character to the new value
+				newv[newi] = v
+				newi++
+
+				// All quoted characters are significant
+				lastSig = newi
+			}
+		case escapeMode:
+			// We're in double quotes and the last character was a backslash
+			switch v {
+			case '"':
+				newv[newi] = v
+			case '\\':
+				newv[newi] = v
+			case '/':
+				newv[newi] = v
+			case 'b':
+				newv[newi] = '\b'
+			case 'f':
+				newv[newi] = '\f'
+			case 'r':
+				newv[newi] = '\r'
+			case 'n':
+				newv[newi] = '\n'
+			case 't':
+				newv[newi] = '\t'
+			case 'u':
+				// Parse-ahead to capture unicode
+				r, err := h2r(value[i+1:])
+				if err != nil {
+					return nil, nil, err
+				}
+
+				// Bump index by width of hex chars
+				i += 4
+
+				// Check if we need to get another rune
+				if utf16.IsSurrogate(r) {
+					if len(value) < i+6 {
+						//TODO Use replacement character instead?
+						return nil, nil, ErrIncompleteSur
+					}
+					if value[i+1] != '\\' || value[i+2] != 'u' {
+						//TODO Use replacement character instead?
+						return nil, nil, ErrIncompleteSur
+					}
+
+					r2, err := h2r(value[i+3:])
+					if err != nil {
+						return nil, nil, err
+					}
+
+					// Bump index by width of \uXXXX
+					i += 6
+
+					r = utf16.DecodeRune(r, r2)
+				}
+				n := utf8.EncodeRune(newv[newi:], r)
+				newi += n - 1 // because it's incremented outside the switch
+			default:
+				return nil, nil, fmt.Errorf("invalid escape sequence: %q", string(v))
+			}
+			// Add the character to the new value
+			newi++
+
+			// All escaped characters are significant
+			lastSig = newi
+
+			// Switch back to quote mode
+			mode = doubleQuote
+		case singleQuote:
+			switch v {
+			case '\'':
+				mode = normalMode
+			default:
+				// Add all other characters to the new value
+				newv[newi] = v
+				newi++
+
+				// All single quoted characters are significant
+				lastSig = newi
+			}
+		default:
+			panic(fmt.Errorf("BUG: invalid mode: %v", mode))
+		}
+	}
+
+	switch mode {
+	case normalMode:
+		// All escape sequences are complete and all quotes are matched
+		return key, newv[:newi], nil
+	case doubleQuote:
+		return nil, nil, ErrUnmatchedDouble
+	case singleQuote:
+		return nil, nil, ErrUnmatchedSingle
+	case escapeMode:
+		return nil, nil, ErrIncompleteEscape
+	default:
+		panic(fmt.Errorf("BUG: invalid mode: %v", mode))
+	}
+}
+
+// convert hex characters into a rune
+func h2r(buf []byte) (rune, error) {
+	if len(buf) < 4 {
+		return 0, ErrIncompleteHex
+	}
+	var r rune
+	for i := 0; i < 4; i++ {
+		d := buf[i]
+		switch {
+		case '0' <= d && d <= '9':
+			d = d - '0'
+		case 'a' <= d && d <= 'f':
+			d = d - 'a' + 10
+		case 'A' <= d && d <= 'F':
+			d = d - 'A' + 10
+		default:
+			return 0, fmt.Errorf("invalid hex character: %q", string(d))
+		}
+
+		r *= 16
+		r += rune(d)
+	}
+	return r, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1054,6 +1054,12 @@
 			"revisionTime": "2016-06-28T05:25:20Z"
 		},
 		{
+			"checksumSHA1": "0nmSguB9Hrc2vM2FTV1NRmOW1JE=",
+			"path": "github.com/schmichael/go-envparse",
+			"revision": "ec769f639d2838f80ec2aeed0e2753d8db06963a",
+			"revisionTime": "2017-06-02T21:50:00Z"
+		},
+		{
 			"checksumSHA1": "tnMZLo/kR9Kqx6GtmWwowtTLlA8=",
 			"path": "github.com/sean-/seed",
 			"revision": "e2103e2c35297fb7e17febb81e49b312087a2372",

--- a/website/source/docs/job-specification/template.html.md
+++ b/website/source/docs/job-specification/template.html.md
@@ -196,9 +196,17 @@ This allows [12factor app](https://12factor.net/config) style environment
 variable based configuration while keeping all of the familiar features and
 semantics of Nomad templates.
 
-The parser reads each line, discards empty lines or lines starting
-with a `#`, and then splits on the first `=`. The first part of the split is
-the key name, the second part is the key's value.
+If a value may include newlines you should JSON encode it:
+
+```
+CERT_PEM={{ file "path/to/cert.pem" | toJSON }}
+```
+
+The parser will read the JSON string, so the `$CERT_PEM` environment variable
+will be identical to the contents of the file.
+
+For more details see [go-envparser's
+README](https://github.com/schmichael/go-envparse#readme).
 
 ## Client Configuration
 


### PR DESCRIPTION
So I got frustrated with the limitations of some of the popular 3rd party libraries out there that provide env file parsing and implemented my own: https://github.com/schmichael/go-envparse Sorry!

The critical feature is supporting JSON string parsing so that our docs can instruct users to simply `{{ ... | toJSON }}` anything that might contain a newline.

Followup to #2654 