### PR TITLE
Add a no_overlay option for the rkt task config.

### DIFF
--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -82,7 +82,8 @@ type RktDriverConfig struct {
 	PortMap          map[string]string   `mapstructure:"-"`                  // A map of host port and the port name defined in the image manifest file
 	Volumes          []string            `mapstructure:"volumes"`            // Host-Volumes to mount in, syntax: /path/to/host/directory:/destination/path/in/container
 
-	Debug bool `mapstructure:"debug"` // Enable debug option for rkt command
+	NoOverlay        bool                `mapstructure:"no_overlay"`         // disable overlayfs for rkt run
+	Debug            bool                `mapstructure:"debug"`              // Enable debug option for rkt command
 }
 
 // rktHandle is returned from Start/Open as a handle to the PID
@@ -154,6 +155,9 @@ func (d *RktDriver) Validate(config map[string]interface{}) error {
 			},
 			"volumes": &fields.FieldSchema{
 				Type: fields.TypeArray,
+			},
+			"no_overlay": &fields.FieldSchema{
+				Type: fields.TypeBool,
 			},
 		},
 	}
@@ -263,6 +267,11 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 		insecure = true
 	}
 	cmdArgs = append(cmdArgs, "run")
+
+	// disable overlayfs
+	if driverConfig.NoOverlay {
+		cmdArgs = append(cmdArgs, "--no-overlay=true")
+	}
 
 	// Write the UUID out to a file in the state dir so we can read it back
 	// in and access the pod by UUID from other commands

--- a/website/source/docs/drivers/rkt.html.md
+++ b/website/source/docs/drivers/rkt.html.md
@@ -88,7 +88,7 @@ The `rkt` driver supports the following configuration in the job spec:
 
 * `debug` - (Optional) Enable rkt command debug option.
 
-* `no_overlay` - (Optional) When enabled, will use --no-overlay=true flag for 'rkt run'.
+* `no_overlay` - (Optional) When enabled, will use `--no-overlay=true` flag for 'rkt run'.
   Useful when running jobs on older systems affected by https://github.com/rkt/rkt/issues/1922
 
 * `volumes` - (Optional) A list of `host_path:container_path` strings to bind

--- a/website/source/docs/drivers/rkt.html.md
+++ b/website/source/docs/drivers/rkt.html.md
@@ -88,6 +88,9 @@ The `rkt` driver supports the following configuration in the job spec:
 
 * `debug` - (Optional) Enable rkt command debug option.
 
+* `no_overlay` - (Optional) When enabled, will use --no-overlay=true flag for 'rkt run'.
+  Useful when running jobs on older systems affected by https://github.com/rkt/rkt/issues/1922
+
 * `volumes` - (Optional) A list of `host_path:container_path` strings to bind
   host paths to container paths.
 


### PR DESCRIPTION
Directly relates to https://github.com/rkt/rkt/issues/1922 - for various reasons, I have to keep up with RHEL 7 systems, and --no-overlay for rkt run seems to help with the bug above.