### PR TITLE
Added insecure_options config list

### DIFF
--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -81,6 +81,7 @@ type RktDriverConfig struct {
 	PortMapRaw       []map[string]string `mapstructure:"port_map"`           //
 	PortMap          map[string]string   `mapstructure:"-"`                  // A map of host port and the port name defined in the image manifest file
 	Volumes          []string            `mapstructure:"volumes"`            // Host-Volumes to mount in, syntax: /path/to/host/directory:/destination/path/in/container
+	InsecureOptions  []string            `mapstructure:"insecure_options"`   // list of args for --insecure-options
 
 	Debug bool `mapstructure:"debug"` // Enable debug option for rkt command
 }
@@ -153,6 +154,9 @@ func (d *RktDriver) Validate(config map[string]interface{}) error {
 				Type: fields.TypeBool,
 			},
 			"volumes": &fields.FieldSchema{
+				Type: fields.TypeArray,
+			},
+			"insecure_options": &fields.FieldSchema{
 				Type: fields.TypeArray,
 			},
 		},
@@ -262,6 +266,18 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 		// Disble signature verification if the trust command was not run.
 		insecure = true
 	}
+
+	// if we have a selective insecure_options, prefer them
+	// insecure options are rkt's global argument, so we do this before the actual "run"
+	if len(driverConfig.InsecureOptions) > 0 {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--insecure-options=%s", strings.Join(driverConfig.InsecureOptions, ",")))
+	} else if insecure {
+		cmdArgs = append(cmdArgs, "--insecure-options=all")
+	}
+
+	// same for debug
+	cmdArgs = append(cmdArgs, fmt.Sprintf("--debug=%t", debug))
+
 	cmdArgs = append(cmdArgs, "run")
 
 	// Write the UUID out to a file in the state dir so we can read it back
@@ -304,10 +320,6 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 	}
 
 	cmdArgs = append(cmdArgs, img)
-	if insecure {
-		cmdArgs = append(cmdArgs, "--insecure-options=all")
-	}
-	cmdArgs = append(cmdArgs, fmt.Sprintf("--debug=%t", debug))
 
 	// Inject environment variables
 	for k, v := range ctx.TaskEnv.Map() {

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -275,7 +275,7 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, e
 		cmdArgs = append(cmdArgs, "--insecure-options=all")
 	}
 
-	// same for debug
+	// debug is rkt's global argument, so add it before the actual "run"
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--debug=%t", debug))
 
 	cmdArgs = append(cmdArgs, "run")

--- a/website/source/docs/drivers/rkt.html.md
+++ b/website/source/docs/drivers/rkt.html.md
@@ -62,10 +62,10 @@ The `rkt` driver supports the following configuration in the job spec:
 
 * `trust_prefix` - (Optional) The trust prefix to be passed to rkt. Must be
   reachable from the box running the nomad agent. If not specified, the image is
-  run with ```--insecure-options=all```.
+  run with `--insecure-options=all`.
 
-* `insecure_options` - (Optional) List of insecure options for rkt. Consult ```rkt --help```
-  for list of supported values. This list overrides the ```--insecure-options=all``` when
+* `insecure_options` - (Optional) List of insecure options for rkt. Consult `rkt --help`
+  for list of supported values. This list overrides the `--insecure-options=all` default when
   no ```trust_prefix``` is provided in the job config, which can be effectively used to enforce
   secure runs, using ```insecure_options = ["none"]``` option.
 

--- a/website/source/docs/drivers/rkt.html.md
+++ b/website/source/docs/drivers/rkt.html.md
@@ -62,7 +62,19 @@ The `rkt` driver supports the following configuration in the job spec:
 
 * `trust_prefix` - (Optional) The trust prefix to be passed to rkt. Must be
   reachable from the box running the nomad agent. If not specified, the image is
-  run without verifying the image signature.
+  run with ```--insecure-options=all```.
+
+* `insecure_options` - (Optional) List of insecure options for rkt. Consult ```rkt --help```
+  for list of supported values. This list overrides the ```--insecure-options=all``` when
+  no ```trust_prefix``` is provided in the job config, which can be effectively used to enforce
+  secure runs, using ```insecure_options = ["none"]``` option.
+
+  ```hcl
+  config {
+      image = "example.com/image:1.0"
+      insecure_options = ["image", "tls", "ondisk"]
+  }
+  ```
 
 * `dns_servers` - (Optional) A list of DNS servers to be used in the container.
   Alternatively a list containing just `host` or `none`. `host` uses the host's


### PR DESCRIPTION
Follow-up of https://github.com/hashicorp/nomad/issues/2026
While doing my proof-of-concepting, I see some usecases for --insecure-options=ondisk for example. Nevertheless, the options right now are either 'none' or 'all', this config will take precedence over the "rkt trust wasn't done", so one can instead of just omiting trust_prefix (and losing all secure options) specify insecure_options = ["image"].
It also makes it possible to enforce --insecure-options=none.

I've moved --debug as well, as both --debug and --insecure-options are rkt global parameters - made better sense.