### PR TITLE
Fix documentation of -tail/-f

### DIFF
--- a/website/source/docs/operating-a-job/accessing-logs.html.md
+++ b/website/source/docs/operating-a-job/accessing-logs.html.md
@@ -60,13 +60,21 @@ $ nomad logs 04d9627d server
 
 The logs command supports both displaying the logs as well as following logs,
 blocking for more output, similar to `tail -f`. To follow the logs, use the
-`-tail` flag:
+appropriately named `-f` flag:
 
 ```shell
-$ nomad logs -tail 04d9627d
+$ nomad logs -f 04d9627d
 ```
 
 This will stream logs to our console.
+
+If you wish to see only the tail of a log, use the `-tail` and `-n` flags:
+
+```shell
+$ nomad logs -tail -n 25 04d9627d
+```
+This will show the last 25 lines. If you omit the `-n` flag, `-tail` will
+default to 10 lines.
 
 By default, only the logs on stdout are displayed. To show the log output from
 stderr, use the `-stderr` flag:


### PR DESCRIPTION
Previously, -tail is erroneously documented as -f and -f and -n are not documented at all. 

This patch fixes both.