### PR TITLE
Fix typo in job-dispatch docs.

### DIFF
--- a/website/source/docs/commands/job-dispatch.html.md.erb
+++ b/website/source/docs/commands/job-dispatch.html.md.erb
@@ -9,7 +9,7 @@ description: >
 # Command: job dispatch
 
 ~> The `job dispatch` subcommand described here is available only in version
-0.5.3 and later. The release canidate is downloadable on the [releases
+0.5.3 and later. The release candidate is downloadable on the [releases
 page.](https://releases.hashicorp.com/nomad/0.5.3-rc1/)
 
 The `job dispatch` command is used to create new instances of a [parameterized


### PR DESCRIPTION
canidate -> candidate.