### PR TITLE
Specify IPv6 requirements for advertise addresses

### DIFF
--- a/website/source/docs/agent/configuration/index.html.md
+++ b/website/source/docs/agent/configuration/index.html.md
@@ -98,6 +98,8 @@ testing.
   [bind_addr](#bind_addr). If the bind address is `0.0.0.0` then the first
   private IP found is advertised. You may advertise an alternate port as well.
   The values support [go-sockaddr/template format][go-sockaddr/template].
+  Note that if you specify an IPv6 address, you need to enclose it into square
+  brackets and explicitly specify the port number.
 
   - `http` - The address to advertise for the HTTP interface. This should be
     reachable by all the nodes from which end users are going to use the Nomad


### PR DESCRIPTION
### Nomad version
On current Nomad's master: d784461962071257566910475c925b980941b9c3

### Operating system and Environment details
Debian Jessie amd64 with a (public) IPv6 address and a private IPv4 address.

### Issue
I'd like Nomad to advertise its IPv6 address instead of the IPv4 one, but there are some issues parsing the address value.

The following:
```
advertise {
  rpc = "2001:bc8:4400:2300::xx:yyy"
}
```
doesn't work, because it discovers too much semi-colon and fails with: `Failed to parse HTTP advertise address: Error parsing advertise address "2001:bc8:4400:2300::xx:yyy": address 2001:bc8:4400:2300::xx:yyy: too many colons in address`

The following:
```
advertise {
  rpc = "[2001:bc8:4400:2300::xx:yyy]"
}
```
also doesn't work, although this initially parses correctly, [`net.JoinHostPort()`](https://github.com/hashicorp/nomad/blob/master/command/agent/config.go#L840) then surrounds the address with additional square brackets before adding the port, which produces something like `[[2001:bc8:4400:2300::xx:yyy]]:4647`, which then fails to be parsed correctly by [`net.ResolveTCPAddr()`](https://github.com/hashicorp/nomad/blob/master/command/agent/agent.go#L153)

The following:
```
advertise {
  rpc = "[2001:bc8:4400:2300::xx:yyy]:4647"
}
```
works though.

I was initially playing with go-sockaddr/template and realized a bit late than the later was producing the right IPv6 address, but Nomad itself was failing to read the address correctly. Ideally the second case (bracketed IPv6 without port) should work, but I'm not sure how to address it without a gross hack.

In the meanwhile, I've updated the documentation to reflect the proper format to be used.