### PR TITLE
Do not fail when no docker registry auth is available

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1016,7 +1016,7 @@ func (d *DockerDriver) createImage(driverConfig *DockerDriverConfig, client *doc
 func (d *DockerDriver) pullImage(driverConfig *DockerDriverConfig, client *docker.Client, repo, tag string) (id string, err error) {
 	authOptions, err := d.resolveRegistryAuthentication(driverConfig, repo)
 	if err != nil {
-		return "", fmt.Errorf("Failed to find docker auth for repo %q: %v", repo, err)
+		d.logger.Printf("[WARN] Failed to find docker auth for repo %q: %v", repo, err)
 	}
 
 	if authIsEmpty(authOptions) {


### PR DESCRIPTION
this amends the behaviour introduced with #2651
and allows pulling public images when docker.auth.helper is set to https://github.com/awslabs/amazon-ecr-credential-helper