### PR TITLE
Noted that ephemeral storage `size` not enforced

### DIFF
--- a/website/source/docs/job-specification/ephemeral_disk.html.md
+++ b/website/source/docs/job-specification/ephemeral_disk.html.md
@@ -43,7 +43,9 @@ job "docs" {
   cannot be made on the original node. During data migration, the task will
   block starting until the data migration has completed.
 
-- `size` `(int: 300)` - Specifies the size of the ephemeral disk in MB.
+- `size` `(int: 300)` - Specifies the size of the ephemeral disk in MB.  The
+  current Nomad ephemeral storage implementation does not enforce this limit;
+  however, it is used during job placement.
 
 - `sticky` `(bool: false)` - Specifies that Nomad should make a best-effort
   attempt to place the updated allocation on the same machine. This will move


### PR DESCRIPTION
This value is strictly used in the job placement, but is not enforced like a quota