### PR TITLE
System jobs should be running until stopped

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2130,14 +2130,8 @@ func (s *StateStore) getJobStatus(txn *memdb.Txn, job *structs.Job, evalDelete b
 			return structs.JobStatusDead, nil
 		}
 
-		if hasEval {
-			// At least one completed eval
-			return structs.JobStatusRunning, nil
-		}
-
 		// Pending until at least one eval has completed
-		return structs.JobStatusPending, nil
-
+		return structs.JobStatusRunning, nil
 	}
 
 	// The job is dead if all the allocations and evals are terminal or if there

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -1635,6 +1635,7 @@ func TestStateStore_JobsByScheduler(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		job := mock.SystemJob()
+		job.Status = structs.JobStatusRunning
 		sysJobs = append(sysJobs, job)
 
 		err := state.UpsertJob(2000+uint64(i), job)


### PR DESCRIPTION
Prior to this commit they would be marked as dead if they had no
currently running allocations -- even though they would spring back to
life (running) if the cluster state changed such that a new eval+alloc
was created.