### PR TITLE
Update docs to specify that the termination signal is a SIGTERM

### DIFF
--- a/website/source/docs/job-specification/task.html.md
+++ b/website/source/docs/job-specification/task.html.md
@@ -48,7 +48,7 @@ job "docs" {
   be passed to the running process.
 
 - `kill_timeout` `(string: "5s")` - Specifies the duration to wait for an
-  application to gracefully quit before force-killing. Nomad sends an `SIGINT`.
+  application to gracefully quit before force-killing. Nomad sends an `SIGTERM`.
   If the task does not exit before the configured timeout, `SIGKILL` is sent to
   the task. Note that the value set here is capped at the value set for
   [`max_kill_timeout`][max_kill] on the agent running the task, which has a


### PR DESCRIPTION
I'm running Nomad v0.5.2. The [docs](https://www.nomadproject.io/docs/job-specification/task.html#kill_timeout) suggest that when the `kill_timeout` is specified, a task is sent a SIGINT. 

However, I'm seeing my task get a SIGTERM.  I have an application trap both a SIGINT and a SIGTERM, and the only signal the application sees is a SIGTERM. This comment by @dadgar also suggests that it's a SIGTERM that gets sent to a task. https://github.com/hashicorp/nomad/issues/522 



