### PR TITLE
Update docs to specify that the termination signal is a SIGTERM

### DIFF
--- a/website/source/docs/job-specification/task.html.md
+++ b/website/source/docs/job-specification/task.html.md
@@ -49,7 +49,7 @@ job "docs" {
 
 - `kill_timeout` `(string: "5s")` - Specifies the duration to wait for an
   application to gracefully quit before force-killing. Nomad sends an `SIGINT`.
-  If the task does not exit before the configured timeout, `SIGKILL` is sent to
+  If the task does not exit before the configured timeout, `SIGTERM` is sent to
   the task. Note that the value set here is capped at the value set for
   [`max_kill_timeout`][max_kill] on the agent running the task, which has a
   default value of 30 seconds.


### PR DESCRIPTION
Thee docs suggest that when the `kill_timeout` is specified, a task is sent a SIGINT. However, I'm seeing my task get a SIGTERM.

[This comment](https://github.com/hashicorp/nomad/issues/522 ) by @dadgar also suggests that it's a SIGTERM that gets sent to a task. 