### PR TITLE
Use node name always false

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1053,6 +1053,10 @@ func (a *Telemetry) Merge(b *Telemetry) *Telemetry {
 	if b.DisableHostname {
 		result.DisableHostname = true
 	}
+
+	if b.UseNodeName {
+		result.UseNodeName = true
+	}
 	if b.CollectionInterval != "" {
 		result.CollectionInterval = b.CollectionInterval
 	}


### PR DESCRIPTION
Fixing issue where use_node_name was not being set when merging telemetry configurations