### PR TITLE
Add more logging to restore state errors

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -299,7 +299,15 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulServic
 
 	// Restore the state
 	if err := c.restoreState(); err != nil {
-		return nil, fmt.Errorf("failed to restore state: %v", err)
+		logger.Printf("[ERR] client: failed to restore state: %v", err)
+		logger.Printf("[ERR] client: Nomad is unable to start due to corrupt state. "+
+			"The safest way to proceed is to manually stop running task processes "+
+			"and remove Nomad's state dir (%q) before restarting. Lost allocations "+
+			"will be rescheduled.", c.config.StateDir)
+		logger.Printf("[ERR] client: Corrupt state is often caused by a bug. Please " +
+			"report as much information as possible to " +
+			"https://github.com/hashicorp/nomad/issues")
+		return nil, fmt.Errorf("failed to restore state")
 	}
 
 	// Register and then start heartbeating to the servers.

--- a/client/client.go
+++ b/client/client.go
@@ -302,8 +302,9 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulServic
 		logger.Printf("[ERR] client: failed to restore state: %v", err)
 		logger.Printf("[ERR] client: Nomad is unable to start due to corrupt state. "+
 			"The safest way to proceed is to manually stop running task processes "+
-			"and remove Nomad's state dir (%q) before restarting. Lost allocations "+
-			"will be rescheduled.", c.config.StateDir)
+			"and remove Nomad's state (%q) and alloc (%d) directories before "+
+			"restarting. Lost allocations will be rescheduled.",
+			c.config.StateDir, c.config.AllocDir)
 		logger.Printf("[ERR] client: Corrupt state is often caused by a bug. Please " +
 			"report as much information as possible to " +
 			"https://github.com/hashicorp/nomad/issues")


### PR DESCRIPTION
Sample output:

>    2017/07/03 11:52:19.185581 [ERR] client: failed to restore state for alloc 9f3a1012-b39b-9494-4d31-0fb4992492fe: failed to read allocation state: failed to read alloc runner alloc_dir state: failed to decode data into passed object: EOF
>    2017/07/03 11:52:19.185597 [ERR] client: failed to restore state: 1 error(s) occurred:
>
>\* failed to read allocation state: failed to read alloc runner alloc_dir state: failed to decode data into passed object: EOF
>    2017/07/03 11:52:19.185601 [ERR] client: Nomad is unable to start due to corrupt state. The safest way to proceed is to manually stop running task processes and remove Nomad's state dir ("/tmp/nomad-devagent/client") before restarting. Lost allocations will be rescheduled.
>    2017/07/03 11:52:19.185603 [ERR] client: Corrupt state is often caused by a bug, please report as much information as possible to https://github.com/hashicorp/nomad/issues

To reproduce this error I started a client+server agent (not `-dev` as dev agents don't save/restore state), ran `example.nomad`, stopped nomad, and used a little tool to corrupt the state file:

```sh
boltq /tmp/nomad-devagent/client/state.db allocations.9f3a1012-b39b-9494-4d31-0fb4992492fe alloc-dir ""
```

https://github.com/schmichael/boltq