### PR TITLE
Allow to run post_command, postkill_command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ TODO.md
 .terraform
 *.tfstate*
 rkt-*
+
+.idea

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -493,6 +493,10 @@ func (d *DockerDriver) Prestart(ctx *ExecContext, task *structs.Task) (*Prestart
 	return resp, nil
 }
 
+func (h *DockerHandle) Poststart(*structs.Task) error {
+	return nil
+}
+
 func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 
 	pluginLogFile := filepath.Join(ctx.TaskDir.Dir, "executor.out")
@@ -1354,6 +1358,8 @@ func (h *DockerHandle) Kill() error {
 	h.logger.Printf("[INFO] driver.docker: stopped container %s", h.containerID)
 	return nil
 }
+
+func (h *DockerHandle) Postkill(*structs.Task) error { return nil }
 
 func (h *DockerHandle) Stats() (*cstructs.TaskResourceUsage, error) {
 	h.resourceUsageLock.RLock()

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -282,8 +282,12 @@ type DriverHandle interface {
 	// configurations.
 	Update(task *structs.Task) error
 
+	Poststart(task *structs.Task) error
+
 	// Kill is used to stop the task
 	Kill() error
+
+	Postkill(task *structs.Task) error
 
 	// Stats returns aggregated stats of the driver
 	Stats() (*cstructs.TaskResourceUsage, error)

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -37,8 +37,12 @@ type ExecDriver struct {
 }
 
 type ExecDriverConfig struct {
-	Command string   `mapstructure:"command"`
-	Args    []string `mapstructure:"args"`
+	Command         string   `mapstructure:"command"`
+	Args            []string `mapstructure:"args"`
+	PostCommand     string   `mapstructure:"post_command"`
+	PostArgs        []string `mapstructure:"post_args"`
+	PostKillCommand string   `mapstructure:"postkill_command"`
+	PostKillArgs    []string `mapstructure:"postkill_args"`
 }
 
 // execHandle is returned from Start/Open as a handle to the PID
@@ -70,6 +74,9 @@ func (d *ExecDriver) Validate(config map[string]interface{}) error {
 				Type:     fields.TypeString,
 				Required: true,
 			},
+			"post_command": &fields.FieldSchema{
+				Type: fields.TypeString,
+			},
 			"args": &fields.FieldSchema{
 				Type: fields.TypeArray,
 			},
@@ -100,6 +107,10 @@ func (d *ExecDriver) Periodic() (bool, time.Duration) {
 
 func (d *ExecDriver) Prestart(*ExecContext, *structs.Task) (*PrestartResponse, error) {
 	return nil, nil
+}
+
+func (h *execHandle) Poststart(*structs.Task) error {
+	return nil
 }
 
 func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
@@ -291,6 +302,8 @@ func (h *execHandle) Kill() error {
 	}
 	return nil
 }
+
+func (h *execHandle) Postkill(*structs.Task) error { return nil }
 
 func (h *execHandle) Stats() (*cstructs.TaskResourceUsage, error) {
 	return h.executor.Stats()

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -179,6 +179,10 @@ func (d *JavaDriver) Prestart(*ExecContext, *structs.Task) (*PrestartResponse, e
 	return nil, nil
 }
 
+func (h *javaHandle) Poststart(*structs.Task) error {
+	return nil
+}
+
 func NewJavaDriverConfig(task *structs.Task, env *env.TaskEnv) (*JavaDriverConfig, error) {
 	var driverConfig JavaDriverConfig
 	if err := mapstructure.WeakDecode(task.Config, &driverConfig); err != nil {
@@ -423,6 +427,8 @@ func (h *javaHandle) Kill() error {
 	}
 	return nil
 }
+
+func (h *javaHandle) Postkill(*structs.Task) error { return nil }
 
 func (h *javaHandle) Stats() (*cstructs.TaskResourceUsage, error) {
 	return h.executor.Stats()

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -177,6 +177,10 @@ func (d *LxcDriver) Prestart(*ExecContext, *structs.Task) (*PrestartResponse, er
 	return nil, nil
 }
 
+func (h *lxcDriverHandle) Poststart(*structs.Task) error {
+	return nil
+}
+
 // Start starts the LXC Driver
 func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 	var driverConfig LxcDriverConfig
@@ -392,6 +396,8 @@ func (h *lxcDriverHandle) Kill() error {
 	close(h.doneCh)
 	return nil
 }
+
+func (h *lxcDriverHandle) Postkill(*structs.Task) error { return nil }
 
 func (h *lxcDriverHandle) Signal(s os.Signal) error {
 	return fmt.Errorf("LXC does not support signals")

--- a/client/driver/mock_driver.go
+++ b/client/driver/mock_driver.go
@@ -88,6 +88,10 @@ func (d *MockDriver) Prestart(*ExecContext, *structs.Task) (*PrestartResponse, e
 	return nil, nil
 }
 
+func (h *mockDriverHandle) Poststart(*structs.Task) error {
+	return nil
+}
+
 // Start starts the mock driver
 func (m *MockDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 	var driverConfig MockDriverConfig
@@ -264,6 +268,8 @@ func (h *mockDriverHandle) Kill() error {
 	}
 	return nil
 }
+
+func (h *mockDriverHandle) Postkill(*structs.Task) error { return nil }
 
 // TODO Implement when we need it.
 func (h *mockDriverHandle) Stats() (*cstructs.TaskResourceUsage, error) {

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -135,6 +135,10 @@ func (d *QemuDriver) Prestart(*ExecContext, *structs.Task) (*PrestartResponse, e
 	return nil, nil
 }
 
+func (h *qemuHandle) Poststart(*structs.Task) error {
+	return nil
+}
+
 // Run an existing Qemu image. Start() will pull down an existing, valid Qemu
 // image and save it to the Drivers Allocation Dir
 func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
@@ -387,6 +391,8 @@ func (h *qemuHandle) Kill() error {
 		return nil
 	}
 }
+
+func (h *qemuHandle) Postkill(*structs.Task) error { return nil }
 
 func (h *qemuHandle) Stats() (*cstructs.TaskResourceUsage, error) {
 	return h.executor.Stats()

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -235,6 +235,10 @@ func (d *RktDriver) Prestart(ctx *ExecContext, task *structs.Task) (*PrestartRes
 	return nil, nil
 }
 
+func (h *rktHandle) Poststart(task *structs.Task) error {
+	return nil
+}
+
 // Run an existing Rkt image.
 func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, error) {
 	var driverConfig RktDriverConfig
@@ -620,6 +624,8 @@ func (h *rktHandle) Kill() error {
 		return h.executor.Exit()
 	}
 }
+
+func (h *rktHandle) Postkill(*structs.Task) error { return nil }
 
 func (h *rktHandle) Stats() (*cstructs.TaskResourceUsage, error) {
 	return nil, DriverStatsNotImplemented

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1337,6 +1337,10 @@ func (r *TaskRunner) startTask() error {
 
 	}
 
+	if err := handle.Poststart(r.task); err != nil {
+		r.logger.Printf("[WARN] client: failed to run Poststart command with err: %v", err)
+	}
+
 	if err := r.registerServices(drv, handle); err != nil {
 		// All IO is done asynchronously, so errors from registering
 		// services are hard failures.
@@ -1569,6 +1573,10 @@ func (r *TaskRunner) handleDestroy(handle driver.DriverHandle) (destroyed bool, 
 			time.Sleep(time.Duration(backoff))
 		} else {
 			// Kill was successful
+			err = handle.Postkill(r.task)
+			if err != nil {
+				r.logger.Printf("[WARN] client: failed to run Postkill command with err: %v", err)
+			}
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Hello, guys. 

I need to run commands after start and stop, it was mentioned in #1061

Please review an ability to run poststart/postkill hook for raw_exec driver.
I've tested this with simple redis-server job.

```
job "example" {
  datacenters = [ "dc1" ]
  group "test" {

    task "redis-server" {
      driver = "raw_exec"

      config {
        command = "redis-server"
        post_command = "touch"
        post_args = ["/tmp/post_run_nomad"]
        postkill_command = "touch"
        postkill_args = [ "/tmp/post_kill_nomad"]
      }

      service {
        tags = [ "redis" ]
        port = "redis"

        check {
          type     = "tcp"
          port     = "redis"
          interval = "10s"
          timeout  = "2s"
        }
      }

      resources {
        network {
          port "redis" {
            static = "6379"
          }
        }
      }
    }
  }
}