### PR TITLE
Use soft docker memory limit instead of hard one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ IMPROVEMENTS:
  * driver/docker: Add `driver.docker.bridge_ip` node attribute [GH-2797]
  * driver/docker: Allow setting container IP with user defined networks
    [GH-2535]
+ * driver/docker: Allow using soft memory limit instead of hard one [GH-2771]
  * driver/rkt: Support `no_overlay` [GH-2702]
  * driver/rkt: Support `insecure_options` list [GH-2695]
  * server: Allow tuning of node heartbeat TTLs [GH-2859]

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -254,6 +254,8 @@ The `docker` driver supports the following configuration in the job spec.  Only
 
 * `work_dir` - (Optional) The working directory inside the container.
 
+* `mem_limit_disable` - (Optional) `true` or `false` (default). Run docker container with soft memory limit instead of hard limit.
+
 ### Container Name
 
 Nomad creates a container after pulling an image. Containers are named


### PR DESCRIPTION
As duscussed in couple of open issues(like [this)](https://github.com/hashicorp/nomad/issues/2169) there is sometime a need to run docker containters without hard memory limit.
`mem_limit_disable` option will run docker container as it [described](https://docs.docker.com/engine/admin/resource_constraints/#limit-a-containers-access-to-memory) with soft memory limit. So docker will not limit memory allocation for container, but will honor it to know who to kill if host memory is exhausted.

