### PR TITLE
Client watches for allocation health using task state and Consul checks

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -106,6 +106,7 @@ type Allocation struct {
 	ClientStatus       string
 	ClientDescription  string
 	TaskStates         map[string]*TaskState
+	DeploymentID       string
 	DeploymentStatus   *AllocDeploymentStatus
 	PreviousAllocation string
 	CreateIndex        uint64

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -448,6 +448,7 @@ func (t *Task) SetLogConfig(l *LogConfig) *Task {
 type TaskState struct {
 	State      string
 	Failed     bool
+	Restarts   uint64
 	StartedAt  time.Time
 	FinishedAt time.Time
 	Events     []*TaskEvent

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/vaultclient"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 
 	cstructs "github.com/hashicorp/nomad/client/structs"
@@ -51,6 +52,8 @@ type AllocRunner struct {
 	alloc                  *structs.Allocation
 	allocClientStatus      string // Explicit status of allocation. Set when there are failures
 	allocClientDescription string
+	allocHealth            *bool // Whether the allocation is healthy
+	allocBroadcast         *cstructs.AllocBroadcaster
 	allocLock              sync.Mutex
 
 	dirtyCh chan struct{}
@@ -132,20 +135,21 @@ func NewAllocRunner(logger *log.Logger, config *config.Config, stateDB *bolt.DB,
 	consulClient ConsulServiceAPI) *AllocRunner {
 
 	ar := &AllocRunner{
-		config:       config,
-		stateDB:      stateDB,
-		updater:      updater,
-		logger:       logger,
-		alloc:        alloc,
-		dirtyCh:      make(chan struct{}, 1),
-		tasks:        make(map[string]*TaskRunner),
-		taskStates:   copyTaskStates(alloc.TaskStates),
-		restored:     make(map[string]struct{}),
-		updateCh:     make(chan *structs.Allocation, 64),
-		destroyCh:    make(chan struct{}),
-		waitCh:       make(chan struct{}),
-		vaultClient:  vaultClient,
-		consulClient: consulClient,
+		config:         config,
+		stateDB:        stateDB,
+		updater:        updater,
+		logger:         logger,
+		alloc:          alloc,
+		allocBroadcast: cstructs.NewAllocBroadcaster(0),
+		dirtyCh:        make(chan struct{}, 1),
+		tasks:          make(map[string]*TaskRunner),
+		taskStates:     copyTaskStates(alloc.TaskStates),
+		restored:       make(map[string]struct{}),
+		updateCh:       make(chan *structs.Allocation, 64),
+		destroyCh:      make(chan struct{}),
+		waitCh:         make(chan struct{}),
+		vaultClient:    vaultClient,
+		consulClient:   consulClient,
 	}
 	return ar
 }
@@ -441,6 +445,14 @@ func (r *AllocRunner) Alloc() *structs.Allocation {
 		r.allocLock.Unlock()
 		return alloc
 	}
+
+	// The health has been set
+	if r.allocHealth != nil {
+		if alloc.DeploymentStatus == nil {
+			alloc.DeploymentStatus = &structs.AllocDeploymentStatus{}
+		}
+		alloc.DeploymentStatus.Healthy = helper.BoolToPtr(*r.allocHealth)
+	}
 	r.allocLock.Unlock()
 
 	// Scan the task states to determine the status of the alloc
@@ -502,6 +514,7 @@ func (r *AllocRunner) syncStatus() error {
 	// Get a copy of our alloc, update status server side and sync to disk
 	alloc := r.Alloc()
 	r.updater(alloc)
+	r.allocBroadcast.Send(alloc)
 	return r.saveAllocRunnerState()
 }
 
@@ -532,6 +545,9 @@ func (r *AllocRunner) setTaskState(taskName, state string, event *structs.TaskEv
 	if event != nil {
 		if event.FailsTask {
 			taskState.Failed = true
+		}
+		if event.Type == structs.TaskRestarting {
+			taskState.Restarts++
 		}
 		r.appendTaskEvent(taskState, event)
 	}
@@ -616,6 +632,7 @@ func (r *AllocRunner) appendTaskEvent(state *structs.TaskState, event *structs.T
 func (r *AllocRunner) Run() {
 	defer close(r.waitCh)
 	go r.dirtySyncState()
+	go r.watchHealth()
 
 	// Find the task group to run in the allocation
 	alloc := r.Alloc()
@@ -867,6 +884,7 @@ func (r *AllocRunner) Destroy() {
 	}
 	r.destroy = true
 	close(r.destroyCh)
+	r.allocBroadcast.Close()
 }
 
 // WaitCh returns a channel to wait for termination

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -712,20 +712,25 @@ OUTER:
 		case update := <-r.updateCh:
 			// Store the updated allocation.
 			r.allocLock.Lock()
+
+			// If the deployment ids have changed clear the health
+			if r.alloc.DeploymentID != update.DeploymentID {
+				r.allocHealth = nil
+			}
+
 			r.alloc = update
 			r.allocLock.Unlock()
-			r.logger.Printf("[ALEX---------------] client: alloc update")
+
+			// Create a new watcher
+			watcherCancel()
+			wCtx, watcherCancel = context.WithCancel(r.ctx)
+			go r.watchHealth(wCtx)
 
 			// Check if we're in a terminal status
 			if update.TerminalStatus() {
 				taskDestroyEvent = structs.NewTaskEvent(structs.TaskKilled)
 				break OUTER
 			}
-
-			// Create a new watcher
-			watcherCancel()
-			wCtx, watcherCancel = context.WithCancel(r.ctx)
-			go r.watchHealth(wCtx)
 
 			// Update the task groups
 			runners := r.getTaskRunners()

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -75,10 +76,9 @@ type AllocRunner struct {
 
 	otherAllocDir *allocdir.AllocDir
 
-	destroy     bool
-	destroyCh   chan struct{}
-	destroyLock sync.Mutex
-	waitCh      chan struct{}
+	ctx    context.Context
+	exitFn context.CancelFunc
+	waitCh chan struct{}
 
 	// State related fields
 	// stateDB is used to store the alloc runners state
@@ -146,11 +146,13 @@ func NewAllocRunner(logger *log.Logger, config *config.Config, stateDB *bolt.DB,
 		taskStates:     copyTaskStates(alloc.TaskStates),
 		restored:       make(map[string]struct{}),
 		updateCh:       make(chan *structs.Allocation, 64),
-		destroyCh:      make(chan struct{}),
 		waitCh:         make(chan struct{}),
 		vaultClient:    vaultClient,
 		consulClient:   consulClient,
 	}
+
+	// TODO Should be passed a context
+	ar.ctx, ar.exitFn = context.WithCancel(context.TODO())
 	return ar
 }
 
@@ -503,7 +505,7 @@ func (r *AllocRunner) dirtySyncState() {
 		select {
 		case <-r.dirtyCh:
 			r.syncStatus()
-		case <-r.destroyCh:
+		case <-r.ctx.Done():
 			return
 		}
 	}
@@ -632,7 +634,10 @@ func (r *AllocRunner) appendTaskEvent(state *structs.TaskState, event *structs.T
 func (r *AllocRunner) Run() {
 	defer close(r.waitCh)
 	go r.dirtySyncState()
-	go r.watchHealth()
+
+	// Start the watcher
+	wCtx, watcherCancel := context.WithCancel(r.ctx)
+	go r.watchHealth(wCtx)
 
 	// Find the task group to run in the allocation
 	alloc := r.Alloc()
@@ -709,12 +714,18 @@ OUTER:
 			r.allocLock.Lock()
 			r.alloc = update
 			r.allocLock.Unlock()
+			r.logger.Printf("[ALEX---------------] client: alloc update")
 
 			// Check if we're in a terminal status
 			if update.TerminalStatus() {
 				taskDestroyEvent = structs.NewTaskEvent(structs.TaskKilled)
 				break OUTER
 			}
+
+			// Create a new watcher
+			watcherCancel()
+			wCtx, watcherCancel = context.WithCancel(r.ctx)
+			go r.watchHealth(wCtx)
 
 			// Update the task groups
 			runners := r.getTaskRunners()
@@ -725,7 +736,7 @@ OUTER:
 			if err := r.syncStatus(); err != nil {
 				r.logger.Printf("[WARN] client: failed to sync status upon receiving alloc update: %v", err)
 			}
-		case <-r.destroyCh:
+		case <-r.ctx.Done():
 			taskDestroyEvent = structs.NewTaskEvent(structs.TaskKilled)
 			break OUTER
 		}
@@ -769,7 +780,7 @@ func (r *AllocRunner) handleDestroy() {
 
 	for {
 		select {
-		case <-r.destroyCh:
+		case <-r.ctx.Done():
 			if err := r.DestroyContext(); err != nil {
 				r.logger.Printf("[ERR] client: failed to destroy context for alloc '%s': %v",
 					r.alloc.ID, err)
@@ -876,14 +887,7 @@ func (r *AllocRunner) shouldUpdate(serverIndex uint64) bool {
 
 // Destroy is used to indicate that the allocation context should be destroyed
 func (r *AllocRunner) Destroy() {
-	r.destroyLock.Lock()
-	defer r.destroyLock.Unlock()
-
-	if r.destroy {
-		return
-	}
-	r.destroy = true
-	close(r.destroyCh)
+	r.exitFn()
 	r.allocBroadcast.Close()
 }
 

--- a/client/alloc_runner_health_watcher.go
+++ b/client/alloc_runner_health_watcher.go
@@ -109,7 +109,7 @@ OUTER:
 			case <-checkCh:
 				newChecks, err := r.consulClient.Checks(alloc)
 				if err != nil {
-					r.logger.Printf("[TRACE] client.alloc_watcher: failed to lookup consul checks for allocation %q: %v", alloc.ID, err)
+					r.logger.Printf("[WARN] client.alloc_watcher: failed to lookup consul checks for allocation %q: %v", alloc.ID, err)
 				}
 
 				checks = newChecks

--- a/client/alloc_runner_health_watcher.go
+++ b/client/alloc_runner_health_watcher.go
@@ -1,0 +1,145 @@
+package client
+
+import (
+	"time"
+
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// watchHealth is responsible for watching an allocation's task status and
+// potentially consul health check status to determine if the allocation is
+// healthy or unhealthy.
+func (r *AllocRunner) watchHealth() {
+	// Get our alloc and the task group
+	alloc := r.Alloc()
+	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
+	if tg == nil {
+		r.logger.Printf("[ERR] client.alloc_watcher: failed to lookup allocation's task group. Exiting watcher")
+		return
+	}
+
+	u := tg.Update
+
+	// Checks marks whether we should be watching for Consul health checks
+	checks := false
+	r.logger.Printf("XXX %v", checks)
+
+	switch {
+	case u == nil:
+		r.logger.Printf("[TRACE] client.alloc_watcher: no update block for alloc %q. exiting", alloc.ID)
+		return
+	case u.HealthCheck == structs.UpdateStrategyHealthCheck_Manual:
+		r.logger.Printf("[TRACE] client.alloc_watcher: update block has manual checks for alloc %q. exiting", alloc.ID)
+		return
+	case u.HealthCheck == structs.UpdateStrategyHealthCheck_Checks:
+		checks = true
+	}
+
+	// Get a listener so we know when an allocation is updated.
+	l := r.allocBroadcast.Listen()
+
+	// Create a deadline timer for the health
+	deadline := time.NewTimer(u.HealthyDeadline)
+
+	// Create a healthy timer
+	latestHealthyTime := time.Unix(0, 0)
+	healthyTimer := time.NewTimer(0)
+	if !healthyTimer.Stop() {
+		<-healthyTimer.C
+	}
+
+	// Cleanup function
+	defer func() {
+		if !deadline.Stop() {
+			<-deadline.C
+		}
+		if !healthyTimer.Stop() {
+			<-healthyTimer.C
+		}
+		l.Close()
+	}()
+
+	setHealth := func(h bool) {
+		r.allocLock.Lock()
+		r.allocHealth = helper.BoolToPtr(h)
+		r.allocLock.Unlock()
+		r.syncStatus()
+	}
+
+	first := true
+OUTER:
+	for {
+		if !first {
+			select {
+			case <-r.destroyCh:
+				return
+			case newAlloc, ok := <-l.Ch:
+				if !ok {
+					return
+				}
+
+				alloc = newAlloc
+				if alloc.DeploymentID == "" {
+					continue OUTER
+				}
+
+				r.logger.Printf("[TRACE] client.alloc_watcher: new alloc version for %q", alloc.ID)
+			case <-deadline.C:
+				// We have exceeded our deadline without being healthy.
+				setHealth(false)
+				return
+			case <-healthyTimer.C:
+				r.logger.Printf("[TRACE] client.alloc_watcher: alloc %q is healthy", alloc.ID)
+				setHealth(true)
+			}
+		}
+
+		first = false
+
+		// If the alloc is being stopped by the server just exit
+		switch alloc.DesiredStatus {
+		case structs.AllocDesiredStatusStop, structs.AllocDesiredStatusEvict:
+			r.logger.Printf("[TRACE] client.alloc_watcher: desired status terminal for alloc %q", alloc.ID)
+			return
+		}
+
+		// If the task is dead or has restarted, fail
+		for _, tstate := range alloc.TaskStates {
+			if tstate.Failed || !tstate.FinishedAt.IsZero() || tstate.Restarts != 0 {
+				r.logger.Printf("[TRACE] client.alloc_watcher: setting health to false for alloc %q", alloc.ID)
+				setHealth(false)
+				return
+			}
+		}
+
+		// Determine if the allocation is healthy
+		for task, tstate := range alloc.TaskStates {
+			if tstate.State != structs.TaskStateRunning {
+				r.logger.Printf("[TRACE] client.alloc_watcher: continuing since task %q hasn't started for alloc %q", task, alloc.ID)
+				continue OUTER
+			}
+
+			if tstate.StartedAt.After(latestHealthyTime) {
+				latestHealthyTime = tstate.StartedAt
+			}
+		}
+
+		// If we are already healthy we don't set the timer
+		healthyThreshold := latestHealthyTime.Add(u.MinHealthyTime)
+		if time.Now().After(healthyThreshold) {
+			continue OUTER
+		}
+
+		// Start the time til we are healthy
+		if !healthyTimer.Stop() {
+			select {
+			case <-healthyTimer.C:
+			default:
+			}
+		}
+		d := time.Until(healthyThreshold)
+		healthyTimer.Reset(d)
+		r.logger.Printf("[TRACE] client.alloc_watcher: setting healthy timer to %v for alloc %q", d, alloc.ID)
+	}
+}

--- a/client/alloc_runner_health_watcher.go
+++ b/client/alloc_runner_health_watcher.go
@@ -88,6 +88,7 @@ OUTER:
 			case <-deadline.C:
 				// We have exceeded our deadline without being healthy.
 				setHealth(false)
+				// XXX Think about in-place
 				return
 			case <-healthyTimer.C:
 				r.logger.Printf("[TRACE] client.alloc_watcher: alloc %q is healthy", alloc.ID)

--- a/client/client.go
+++ b/client/client.go
@@ -1284,6 +1284,7 @@ func (c *Client) updateAllocStatus(alloc *structs.Allocation) {
 	stripped.TaskStates = alloc.TaskStates
 	stripped.ClientStatus = alloc.ClientStatus
 	stripped.ClientDescription = alloc.ClientDescription
+	stripped.DeploymentStatus = alloc.DeploymentStatus
 
 	select {
 	case c.allocUpdates <- stripped:

--- a/client/consul.go
+++ b/client/consul.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/nomad/client/driver"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -11,4 +12,5 @@ type ConsulServiceAPI interface {
 	RegisterTask(allocID string, task *structs.Task, exec driver.ScriptExecutor) error
 	RemoveTask(allocID string, task *structs.Task)
 	UpdateTask(allocID string, existing, newTask *structs.Task, exec driver.ScriptExecutor) error
+	Checks(alloc *structs.Allocation) ([]*api.AgentCheck, error)
 }

--- a/client/driver/mock_driver.go
+++ b/client/driver/mock_driver.go
@@ -36,6 +36,9 @@ type MockDriverConfig struct {
 	// StartErrRecoverable marks the error returned is recoverable
 	StartErrRecoverable bool `mapstructure:"start_error_recoverable"`
 
+	// StartBlockFor specifies a duration in which to block before returning
+	StartBlockFor time.Duration `mapstructure:"start_block_for"`
+
 	// KillAfter is the duration after which the mock driver indicates the task
 	// has exited after getting the initial SIGINT signal
 	KillAfter time.Duration `mapstructure:"kill_after"`
@@ -101,6 +104,10 @@ func (m *MockDriver) Start(ctx *ExecContext, task *structs.Task) (DriverHandle, 
 	}
 	if err := dec.Decode(task.Config); err != nil {
 		return nil, err
+	}
+
+	if driverConfig.StartBlockFor != 0 {
+		time.Sleep(driverConfig.StartBlockFor)
 	}
 
 	if driverConfig.StartErr != "" {

--- a/client/structs/funcs.go
+++ b/client/structs/funcs.go
@@ -1,0 +1,81 @@
+package structs
+
+import (
+	"sync"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// AllocBroadcaster implements an allocation broadcast channel.
+// The zero value is a usable unbuffered channel.
+type AllocBroadcaster struct {
+	m         sync.Mutex
+	listeners map[int]chan<- *structs.Allocation // lazy init
+	nextId    int
+	capacity  int
+	closed    bool
+}
+
+// NewAllocBroadcaster returns a new AllocBroadcaster with the given capacity (0 means unbuffered).
+func NewAllocBroadcaster(n int) *AllocBroadcaster {
+	return &AllocBroadcaster{capacity: n}
+}
+
+// AllocListener implements a listening endpoint for an allocation broadcast channel.
+type AllocListener struct {
+	// Ch receives the broadcast messages.
+	Ch <-chan *structs.Allocation
+	b  *AllocBroadcaster
+	id int
+}
+
+// Send broadcasts a message to the channel.
+// Sending on a closed channel causes a runtime panic.
+func (b *AllocBroadcaster) Send(v *structs.Allocation) {
+	b.m.Lock()
+	defer b.m.Unlock()
+	if b.closed {
+		return
+	}
+	for _, l := range b.listeners {
+		select {
+		case l <- v:
+		default:
+		}
+	}
+}
+
+// Close closes the channel, disabling the sending of further messages.
+func (b *AllocBroadcaster) Close() {
+	b.m.Lock()
+	defer b.m.Unlock()
+	b.closed = true
+	for _, l := range b.listeners {
+		close(l)
+	}
+}
+
+// Listen returns a Listener for the broadcast channel.
+func (b *AllocBroadcaster) Listen() *AllocListener {
+	b.m.Lock()
+	defer b.m.Unlock()
+	if b.listeners == nil {
+		b.listeners = make(map[int]chan<- *structs.Allocation)
+	}
+	for b.listeners[b.nextId] != nil {
+		b.nextId++
+	}
+	ch := make(chan *structs.Allocation, b.capacity)
+	if b.closed {
+		close(ch)
+	}
+	b.listeners[b.nextId] = ch
+	return &AllocListener{ch, b, b.nextId}
+}
+
+// Close closes the Listener, disabling the receival of further messages.
+func (l *AllocListener) Close() {
+	l.b.m.Lock()
+	defer l.b.m.Unlock()
+	delete(l.b.listeners, l.id)
+}

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -32,7 +32,7 @@ func testLogger() *log.Logger {
 
 func prefixedTestLogger(prefix string) *log.Logger {
 	if testing.Verbose() {
-		return log.New(os.Stderr, prefix, log.LstdFlags)
+		return log.New(os.Stderr, prefix, log.LstdFlags|log.Lmicroseconds)
 	}
 	return log.New(ioutil.Discard, "", 0)
 }

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -564,6 +564,41 @@ func (c *ServiceClient) RemoveTask(allocID string, task *structs.Task) {
 	c.commit(&ops)
 }
 
+// Checks returns the checks registered against the agent for the given
+// allocation.
+func (c *ServiceClient) Checks(a *structs.Allocation) ([]*api.AgentCheck, error) {
+	tg := a.Job.LookupTaskGroup(a.TaskGroup)
+	if tg == nil {
+		return nil, fmt.Errorf("failed to find task group in alloc")
+	}
+
+	// Determine the checks that are relevant
+	relevant := make(map[string]struct{}, 4)
+	for _, task := range tg.Tasks {
+		for _, service := range task.Services {
+			id := makeTaskServiceID(a.ID, task.Name, service)
+			for _, check := range service.Checks {
+				relevant[createCheckID(id, check)] = struct{}{}
+			}
+		}
+	}
+
+	// Query all the checks
+	checks, err := c.client.Checks()
+	if err != nil {
+		return nil, err
+	}
+
+	allocChecks := make([]*api.AgentCheck, 0, len(relevant))
+	for checkID := range relevant {
+		if check, ok := checks[checkID]; ok {
+			allocChecks = append(allocChecks, check)
+		}
+	}
+
+	return allocChecks, nil
+}
+
 // Shutdown the Consul client. Update running task registations and deregister
 // agent from Consul. On first call blocks up to shutdownWait before giving up
 // on syncing operations.

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -214,6 +214,16 @@ func TestConsul_Integration(t *testing.T) {
 		}
 	}
 
+	// Assert the service client returns all the checks for the allocation.
+	checksOut, err := serviceClient.Checks(alloc)
+	if err != nil {
+		t.Fatalf("unexpected error retrieving allocation checks: %v", err)
+	}
+
+	if l := len(checksOut); l != 2 {
+		t.Fatalf("got %d checks; want %d", l, 2)
+	}
+
 	logger.Printf("[TEST] consul.test: killing task")
 
 	// Kill the task

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1434,9 +1434,15 @@ func (s *StateStore) nestedUpdateAllocFromClient(txn *memdb.Txn, index uint64, a
 	copyAlloc.ClientStatus = alloc.ClientStatus
 	copyAlloc.ClientDescription = alloc.ClientDescription
 	copyAlloc.TaskStates = alloc.TaskStates
+	copyAlloc.DeploymentStatus = alloc.DeploymentStatus
 
 	// Update the modify index
 	copyAlloc.ModifyIndex = index
+
+	// TODO TEST
+	if err := s.updateDeploymentWithAlloc(index, copyAlloc, exist, txn); err != nil {
+		return fmt.Errorf("error updating deployment: %v", err)
+	}
 
 	if err := s.updateSummaryWithAlloc(index, copyAlloc, exist, txn); err != nil {
 		return fmt.Errorf("error updating job summary: %v", err)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2517,7 +2517,8 @@ func (s *StateStore) updateSummaryWithJob(index uint64, job *structs.Job,
 }
 
 // updateDeploymentWithAlloc is used to update the deployment state associated
-// with the given allocation
+// with the given allocation. The passed alloc may be updated if the deployment
+// status has changed to capture the modify index at which it has changed.
 func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *structs.Allocation, txn *memdb.Txn) error {
 	// Nothing to do if the allocation is not associated with a deployment
 	if alloc.DeploymentID == "" {
@@ -2570,6 +2571,11 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 	// Nothing to do
 	if placed == 0 && healthy == 0 && unhealthy == 0 {
 		return nil
+	}
+
+	// Update the allocation's deployment status modify index
+	if alloc.DeploymentStatus != nil && healthy+unhealthy != 0 {
+		alloc.DeploymentStatus.ModifyIndex = index
 	}
 
 	// Create a copy of the deployment object

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3226,6 +3226,9 @@ type TaskState struct {
 	// Failed marks a task as having failed
 	Failed bool
 
+	// Restarts is the number of times the task has restarted
+	Restarts uint64
+
 	// StartedAt is the time the task is started. It is updated each time the
 	// task starts
 	StartedAt time.Time
@@ -3243,10 +3246,7 @@ func (ts *TaskState) Copy() *TaskState {
 		return nil
 	}
 	copy := new(TaskState)
-	copy.State = ts.State
-	copy.Failed = ts.Failed
-	copy.StartedAt = ts.StartedAt
-	copy.FinishedAt = ts.FinishedAt
+	*copy = *ts
 
 	if ts.Events != nil {
 		copy.Events = make([]*TaskEvent, len(ts.Events))

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -111,7 +111,8 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) error {
 	switch eval.TriggeredBy {
 	case structs.EvalTriggerJobRegister, structs.EvalTriggerNodeUpdate,
 		structs.EvalTriggerJobDeregister, structs.EvalTriggerRollingUpdate,
-		structs.EvalTriggerPeriodicJob, structs.EvalTriggerMaxPlans:
+		structs.EvalTriggerPeriodicJob, structs.EvalTriggerMaxPlans,
+		structs.EvalTriggerDeploymentWatcher:
 	default:
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -60,7 +60,8 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) error {
 	// Verify the evaluation trigger reason is understood
 	switch eval.TriggeredBy {
 	case structs.EvalTriggerJobRegister, structs.EvalTriggerNodeUpdate,
-		structs.EvalTriggerJobDeregister, structs.EvalTriggerRollingUpdate:
+		structs.EvalTriggerJobDeregister, structs.EvalTriggerRollingUpdate,
+		structs.EvalTriggerDeploymentWatcher:
 	default:
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)


### PR DESCRIPTION
This PR adds watching of allocation health at the client. The client can
watch for health based on the tasks running on time and also based on
the consul checks passing.