### PR TITLE
Canaries are only tracked in deployment object

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -155,7 +155,6 @@ type AllocationListStub struct {
 // heatlhy.
 type AllocDeploymentStatus struct {
 	Healthy     *bool
-	Promoted    bool
 	ModifyIndex uint64
 }
 

--- a/command/agent/deployment_endpoint_test.go
+++ b/command/agent/deployment_endpoint_test.go
@@ -17,8 +17,8 @@ func TestHTTP_DeploymentList(t *testing.T) {
 		state := s.Agent.server.State()
 		d1 := mock.Deployment()
 		d2 := mock.Deployment()
-		assert.Nil(state.UpsertDeployment(999, d1, false), "UpsertDeployment")
-		assert.Nil(state.UpsertDeployment(1000, d2, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(999, d1), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(1000, d2), "UpsertDeployment")
 
 		// Make the HTTP request
 		req, err := http.NewRequest("GET", "/v1/deployments", nil)
@@ -49,8 +49,8 @@ func TestHTTP_DeploymentPrefixList(t *testing.T) {
 		d1.ID = "aaabbbbb-e8f7-fd38-c855-ab94ceb89706"
 		d2 := mock.Deployment()
 		d2.ID = "aaabbbbb-e8f7-fd38-c855-ab94ceb89706"
-		assert.Nil(state.UpsertDeployment(999, d1, false), "UpsertDeployment")
-		assert.Nil(state.UpsertDeployment(1000, d2, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(999, d1), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(1000, d2), "UpsertDeployment")
 
 		// Make the HTTP request
 		req, err := http.NewRequest("GET", "/v1/deployments?prefix=aaab", nil)
@@ -88,8 +88,8 @@ func TestHTTP_DeploymentAllocations(t *testing.T) {
 		a2.JobID = j.ID
 		a2.DeploymentID = d.ID
 		assert.Nil(state.UpsertJob(998, j), "UpsertJob")
-		assert.Nil(state.UpsertDeployment(999, d, false), "UpsertDeployment")
-		assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a1, a2}), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
+		assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a1, a2}), "UpsertAllocs")
 
 		// Make the HTTP request
 		req, err := http.NewRequest("GET", "/v1/deployment/allocations/"+d.ID, nil)
@@ -117,7 +117,7 @@ func TestHTTP_DeploymentQuery(t *testing.T) {
 		// Directly manipulate the state
 		state := s.Agent.server.State()
 		d := mock.Deployment()
-		assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Make the HTTP request
 		req, err := http.NewRequest("GET", "/v1/deployment/"+d.ID, nil)
@@ -148,7 +148,7 @@ func TestHTTP_DeploymentPause(t *testing.T) {
 		d := mock.Deployment()
 		d.JobID = j.ID
 		assert.Nil(state.UpsertJob(999, j), "UpsertJob")
-		assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Create the pause request
 		args := structs.DeploymentPauseRequest{
@@ -185,7 +185,7 @@ func TestHTTP_DeploymentPromote(t *testing.T) {
 		d := mock.Deployment()
 		d.JobID = j.ID
 		assert.Nil(state.UpsertJob(999, j), "UpsertJob")
-		assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Create the pause request
 		args := structs.DeploymentPromoteRequest{
@@ -225,7 +225,7 @@ func TestHTTP_DeploymentAllocHealth(t *testing.T) {
 		a.JobID = j.ID
 		a.DeploymentID = d.ID
 		assert.Nil(state.UpsertJob(998, j), "UpsertJob")
-		assert.Nil(state.UpsertDeployment(999, d, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
 		assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}), "UpsertAllocs")
 
 		// Create the pause request
@@ -263,7 +263,7 @@ func TestHTTP_DeploymentFail(t *testing.T) {
 		d := mock.Deployment()
 		d.JobID = j.ID
 		assert.Nil(state.UpsertJob(998, j), "UpsertJob")
-		assert.Nil(state.UpsertDeployment(999, d, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
 
 		// Make the HTTP request
 		req, err := http.NewRequest("PUT", "/v1/deployment/fail/"+d.ID, nil)

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -617,7 +617,7 @@ func TestHTTP_JobDeployments(t *testing.T) {
 		state := s.Agent.server.State()
 		d := mock.Deployment()
 		d.JobID = j.ID
-		assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Make the HTTP request
 		req, err := http.NewRequest("GET", "/v1/job/"+j.ID+"/deployments", nil)
@@ -655,7 +655,7 @@ func TestHTTP_JobDeployment(t *testing.T) {
 		state := s.Agent.server.State()
 		d := mock.Deployment()
 		d.JobID = j.ID
-		assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Make the HTTP request
 		req, err := http.NewRequest("GET", "/v1/job/"+j.ID+"/deployment", nil)

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -1329,8 +1329,8 @@ func TestCoreScheduler_DeploymentGC(t *testing.T) {
 	state := s1.fsm.State()
 	d1, d2 := mock.Deployment(), mock.Deployment()
 	d1.Status = structs.DeploymentStatusFailed
-	assert.Nil(state.UpsertDeployment(1000, d1, false), "UpsertDeployment")
-	assert.Nil(state.UpsertDeployment(1001, d2, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1000, d1), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1001, d2), "UpsertDeployment")
 
 	// Update the time tables to make this work
 	tt := s1.fsm.TimeTable()
@@ -1368,8 +1368,8 @@ func TestCoreScheduler_DeploymentGC_Force(t *testing.T) {
 	state := s1.fsm.State()
 	d1, d2 := mock.Deployment(), mock.Deployment()
 	d1.Status = structs.DeploymentStatusFailed
-	assert.Nil(state.UpsertDeployment(1000, d1, false), "UpsertDeployment")
-	assert.Nil(state.UpsertDeployment(1001, d2, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1000, d1), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1001, d2), "UpsertDeployment")
 
 	// Create a core scheduler
 	snap, err := state.Snapshot()

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -237,13 +237,6 @@ func TestDeploymentEndpoint_Promote(t *testing.T) {
 	assert.Len(dout.TaskGroups, 1, "should have one group")
 	assert.Contains(dout.TaskGroups, "web", "should have web group")
 	assert.True(dout.TaskGroups["web"].Promoted, "web group should be promoted")
-
-	// Lookup the allocation
-	aout, err := state.AllocByID(ws, a.ID)
-	assert.Nil(err, "AllocByID")
-	assert.NotNil(aout, "alloc")
-	assert.NotNil(aout.DeploymentStatus, "alloc deployment status")
-	assert.True(aout.DeploymentStatus.Promoted, "alloc deployment promoted")
 }
 
 func TestDeploymentEndpoint_SetAllocHealth(t *testing.T) {

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -194,7 +194,7 @@ func TestDeploymentEndpoint_Promote(t *testing.T) {
 	d.TaskGroups["web"].DesiredCanaries = 2
 	d.JobID = j.ID
 	a := mock.Alloc()
-	a.Canary = true
+	d.TaskGroups[a.TaskGroup].PlacedCanaries = []string{a.ID}
 	a.DeploymentID = d.ID
 	a.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: helper.BoolToPtr(true),

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -27,7 +27,7 @@ func TestDeploymentEndpoint_GetDeployment(t *testing.T) {
 	state := s1.fsm.State()
 
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
-	assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Lookup the deployments
 	get := &structs.DeploymentSpecificRequest{
@@ -61,12 +61,12 @@ func TestDeploymentEndpoint_GetDeployment_Blocking(t *testing.T) {
 
 	// Upsert a deployment we are not interested in first.
 	time.AfterFunc(100*time.Millisecond, func() {
-		assert.Nil(state.UpsertDeployment(100, d1, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(100, d1), "UpsertDeployment")
 	})
 
 	// Upsert another deployment later which should trigger the watch.
 	time.AfterFunc(200*time.Millisecond, func() {
-		assert.Nil(state.UpsertDeployment(200, d2, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(200, d2), "UpsertDeployment")
 	})
 
 	// Lookup the deployments
@@ -103,7 +103,7 @@ func TestDeploymentEndpoint_Fail(t *testing.T) {
 	state := s1.fsm.State()
 
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
-	assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Mark the deployment as failed
 	req := &structs.DeploymentFailRequest{
@@ -151,7 +151,7 @@ func TestDeploymentEndpoint_Pause(t *testing.T) {
 	state := s1.fsm.State()
 
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
-	assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Mark the deployment as failed
 	req := &structs.DeploymentPauseRequest{
@@ -202,7 +202,7 @@ func TestDeploymentEndpoint_Promote(t *testing.T) {
 
 	state := s1.fsm.State()
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
-	assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Promote the deployment
@@ -267,7 +267,7 @@ func TestDeploymentEndpoint_SetAllocHealth(t *testing.T) {
 
 	state := s1.fsm.State()
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
-	assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Set the alloc as healthy
@@ -326,7 +326,7 @@ func TestDeploymentEndpoint_List(t *testing.T) {
 	state := s1.fsm.State()
 
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
-	assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Lookup the deployments
 	get := &structs.DeploymentListRequest{
@@ -367,7 +367,7 @@ func TestDeploymentEndpoint_List_Blocking(t *testing.T) {
 
 	// Upsert alloc triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		assert.Nil(state.UpsertDeployment(3, d, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(3, d), "UpsertDeployment")
 	})
 
 	req := &structs.DeploymentListRequest{
@@ -390,7 +390,7 @@ func TestDeploymentEndpoint_List_Blocking(t *testing.T) {
 	d2 := d.Copy()
 	d2.Status = structs.DeploymentStatusPaused
 	time.AfterFunc(100*time.Millisecond, func() {
-		assert.Nil(state.UpsertDeployment(5, d2, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(5, d2), "UpsertDeployment")
 	})
 
 	req.MinQueryIndex = 3
@@ -423,7 +423,7 @@ func TestDeploymentEndpoint_Allocations(t *testing.T) {
 
 	assert.Nil(state.UpsertJob(998, j), "UpsertJob")
 	assert.Nil(state.UpsertJobSummary(999, summary), "UpsertJobSummary")
-	assert.Nil(state.UpsertDeployment(1000, d, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Lookup the allocations
@@ -455,7 +455,7 @@ func TestDeploymentEndpoint_Allocations_Blocking(t *testing.T) {
 	summary := mock.JobSummary(a.JobID)
 
 	assert.Nil(state.UpsertJob(1, j), "UpsertJob")
-	assert.Nil(state.UpsertDeployment(2, d, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(2, d), "UpsertDeployment")
 	assert.Nil(state.UpsertJobSummary(3, summary), "UpsertJobSummary")
 
 	// Upsert alloc triggers watches
@@ -512,7 +512,7 @@ func TestDeploymentEndpoint_Reap(t *testing.T) {
 
 	// Create the register request
 	d1 := mock.Deployment()
-	assert.Nil(s1.fsm.State().UpsertDeployment(1000, d1, false), "UpsertDeployment")
+	assert.Nil(s1.fsm.State().UpsertDeployment(1000, d1), "UpsertDeployment")
 
 	// Reap the eval
 	get := &structs.DeploymentDeleteRequest{

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -401,7 +401,7 @@ func TestWatcher_PromoteDeployment_HealthyCanaries(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	a := mock.Alloc()
-	a.Canary = true
+	d.TaskGroups[a.TaskGroup].PlacedCanaries = []string{a.ID}
 	a.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: helper.BoolToPtr(true),
 	}
@@ -459,7 +459,7 @@ func TestWatcher_PromoteDeployment_UnhealthyCanaries(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	a := mock.Alloc()
-	a.Canary = true
+	d.TaskGroups[a.TaskGroup].PlacedCanaries = []string{a.ID}
 	a.DeploymentID = d.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -176,7 +176,7 @@ func TestWatcher_SetAllocHealth_Unknown(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// Assert the following methods will be called
 	m.On("List", mocker.Anything, mocker.Anything).Return(nil).Run(m.listFromState)
@@ -199,7 +199,7 @@ func TestWatcher_SetAllocHealth_Unknown(t *testing.T) {
 		Eval:         true,
 	}
 	matcher := matchDeploymentAllocHealthRequest(matchConfig)
-	m.On("UpsertDeploymentAllocHealth", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentAllocHealth", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call SetAllocHealth
 	req := &structs.DeploymentAllocHealthRequest{
@@ -226,7 +226,7 @@ func TestWatcher_SetAllocHealth_Healthy(t *testing.T) {
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	assert.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Assert the following methods will be called
@@ -249,7 +249,7 @@ func TestWatcher_SetAllocHealth_Healthy(t *testing.T) {
 		Eval:         true,
 	}
 	matcher := matchDeploymentAllocHealthRequest(matchConfig)
-	m.On("UpsertDeploymentAllocHealth", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentAllocHealth", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call SetAllocHealth
 	req := &structs.DeploymentAllocHealthRequest{
@@ -260,7 +260,7 @@ func TestWatcher_SetAllocHealth_Healthy(t *testing.T) {
 	err := w.SetAllocHealth(req, &resp)
 	assert.Nil(err, "SetAllocHealth")
 	assert.Equal(1, len(w.watchers), "Deployment should still be active")
-	m.AssertCalled(t, "UpsertDeploymentAllocHealth", mocker.MatchedBy(matcher))
+	m.AssertCalled(t, "UpdateDeploymentAllocHealth", mocker.MatchedBy(matcher))
 }
 
 // Test setting allocation unhealthy
@@ -275,7 +275,7 @@ func TestWatcher_SetAllocHealth_Unhealthy(t *testing.T) {
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	assert.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Assert the following methods will be called
@@ -303,7 +303,7 @@ func TestWatcher_SetAllocHealth_Unhealthy(t *testing.T) {
 		},
 	}
 	matcher := matchDeploymentAllocHealthRequest(matchConfig)
-	m.On("UpsertDeploymentAllocHealth", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentAllocHealth", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call SetAllocHealth
 	req := &structs.DeploymentAllocHealthRequest{
@@ -316,7 +316,7 @@ func TestWatcher_SetAllocHealth_Unhealthy(t *testing.T) {
 
 	testutil.WaitForResult(func() (bool, error) { return 0 == len(w.watchers), nil },
 		func(err error) { assert.Equal(0, len(w.watchers), "Should have no deployment") })
-	m.AssertNumberOfCalls(t, "UpsertDeploymentAllocHealth", 1)
+	m.AssertNumberOfCalls(t, "UpdateDeploymentAllocHealth", 1)
 }
 
 // Test setting allocation unhealthy and that there should be a rollback
@@ -332,10 +332,11 @@ func TestWatcher_SetAllocHealth_Unhealthy_Rollback(t *testing.T) {
 	j.Stable = true
 	d := mock.Deployment()
 	d.JobID = j.ID
+	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	assert.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Upsert the job again to get a new version
@@ -351,7 +352,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_Rollback(t *testing.T) {
 		mocker.Anything).Return(nil).Run(m.evaluationsFromState)
 	m.On("GetJob", mocker.MatchedBy(matchJobSpecificRequest(j.ID)),
 		mocker.Anything).Return(nil).Run(m.getJobFromState)
-	m.On("GetJobVersions", mocker.MatchedBy(matchJobSpecificRequest(j.ID)),
+	m.On("GetJobVersions", mocker.MatchedBy(matchJobVersionsRequest(j.ID)),
 		mocker.Anything).Return(nil).Run(m.getJobVersionsFromState)
 
 	w.SetEnabled(true)
@@ -371,7 +372,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_Rollback(t *testing.T) {
 		JobVersion: helper.Uint64ToPtr(0),
 	}
 	matcher := matchDeploymentAllocHealthRequest(matchConfig)
-	m.On("UpsertDeploymentAllocHealth", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentAllocHealth", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call SetAllocHealth
 	req := &structs.DeploymentAllocHealthRequest{
@@ -384,7 +385,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_Rollback(t *testing.T) {
 
 	testutil.WaitForResult(func() (bool, error) { return 0 == len(w.watchers), nil },
 		func(err error) { assert.Equal(0, len(w.watchers), "Should have no deployment") })
-	m.AssertNumberOfCalls(t, "UpsertDeploymentAllocHealth", 1)
+	m.AssertNumberOfCalls(t, "UpdateDeploymentAllocHealth", 1)
 }
 
 // Test promoting a deployment
@@ -406,7 +407,7 @@ func TestWatcher_PromoteDeployment_HealthyCanaries(t *testing.T) {
 	}
 	a.DeploymentID = d.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	assert.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Assert the following methods will be called
@@ -431,7 +432,7 @@ func TestWatcher_PromoteDeployment_HealthyCanaries(t *testing.T) {
 		Eval: true,
 	}
 	matcher := matchDeploymentPromoteRequest(matchConfig)
-	m.On("UpsertDeploymentPromotion", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentPromotion", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call PromoteDeployment
 	req := &structs.DeploymentPromoteRequest{
@@ -442,7 +443,7 @@ func TestWatcher_PromoteDeployment_HealthyCanaries(t *testing.T) {
 	err := w.PromoteDeployment(req, &resp)
 	assert.Nil(err, "PromoteDeployment")
 	assert.Equal(1, len(w.watchers), "Deployment should still be active")
-	m.AssertCalled(t, "UpsertDeploymentPromotion", mocker.MatchedBy(matcher))
+	m.AssertCalled(t, "UpdateDeploymentPromotion", mocker.MatchedBy(matcher))
 }
 
 // Test promoting a deployment with unhealthy canaries
@@ -461,7 +462,7 @@ func TestWatcher_PromoteDeployment_UnhealthyCanaries(t *testing.T) {
 	a.Canary = true
 	a.DeploymentID = d.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	assert.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Assert the following methods will be called
@@ -486,7 +487,7 @@ func TestWatcher_PromoteDeployment_UnhealthyCanaries(t *testing.T) {
 		Eval: true,
 	}
 	matcher := matchDeploymentPromoteRequest(matchConfig)
-	m.On("UpsertDeploymentPromotion", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentPromotion", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call SetAllocHealth
 	req := &structs.DeploymentPromoteRequest{
@@ -500,7 +501,7 @@ func TestWatcher_PromoteDeployment_UnhealthyCanaries(t *testing.T) {
 	}
 
 	assert.Equal(1, len(w.watchers), "Deployment should still be active")
-	m.AssertCalled(t, "UpsertDeploymentPromotion", mocker.MatchedBy(matcher))
+	m.AssertCalled(t, "UpdateDeploymentPromotion", mocker.MatchedBy(matcher))
 }
 
 // Test pausing a deployment that is running
@@ -513,7 +514,7 @@ func TestWatcher_PauseDeployment_Pause_Running(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// Assert the following methods will be called
 	m.On("List", mocker.Anything, mocker.Anything).Return(nil).Run(m.listFromState)
@@ -535,7 +536,7 @@ func TestWatcher_PauseDeployment_Pause_Running(t *testing.T) {
 		StatusDescription: structs.DeploymentStatusDescriptionPaused,
 	}
 	matcher := matchDeploymentStatusUpdateRequest(matchConfig)
-	m.On("UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentStatus", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call PauseDeployment
 	req := &structs.DeploymentPauseRequest{
@@ -547,7 +548,7 @@ func TestWatcher_PauseDeployment_Pause_Running(t *testing.T) {
 	assert.Nil(err, "PauseDeployment")
 
 	assert.Equal(1, len(w.watchers), "Deployment should still be active")
-	m.AssertCalled(t, "UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher))
+	m.AssertCalled(t, "UpdateDeploymentStatus", mocker.MatchedBy(matcher))
 }
 
 // Test pausing a deployment that is paused
@@ -561,7 +562,7 @@ func TestWatcher_PauseDeployment_Pause_Paused(t *testing.T) {
 	d.JobID = j.ID
 	d.Status = structs.DeploymentStatusPaused
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// Assert the following methods will be called
 	m.On("List", mocker.Anything, mocker.Anything).Return(nil).Run(m.listFromState)
@@ -583,7 +584,7 @@ func TestWatcher_PauseDeployment_Pause_Paused(t *testing.T) {
 		StatusDescription: structs.DeploymentStatusDescriptionPaused,
 	}
 	matcher := matchDeploymentStatusUpdateRequest(matchConfig)
-	m.On("UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentStatus", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call PauseDeployment
 	req := &structs.DeploymentPauseRequest{
@@ -595,7 +596,7 @@ func TestWatcher_PauseDeployment_Pause_Paused(t *testing.T) {
 	assert.Nil(err, "PauseDeployment")
 
 	assert.Equal(1, len(w.watchers), "Deployment should still be active")
-	m.AssertCalled(t, "UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher))
+	m.AssertCalled(t, "UpdateDeploymentStatus", mocker.MatchedBy(matcher))
 }
 
 // Test unpausing a deployment that is paused
@@ -609,7 +610,7 @@ func TestWatcher_PauseDeployment_Unpause_Paused(t *testing.T) {
 	d.JobID = j.ID
 	d.Status = structs.DeploymentStatusPaused
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// Assert the following methods will be called
 	m.On("List", mocker.Anything, mocker.Anything).Return(nil).Run(m.listFromState)
@@ -632,7 +633,7 @@ func TestWatcher_PauseDeployment_Unpause_Paused(t *testing.T) {
 		Eval:              true,
 	}
 	matcher := matchDeploymentStatusUpdateRequest(matchConfig)
-	m.On("UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentStatus", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call PauseDeployment
 	req := &structs.DeploymentPauseRequest{
@@ -644,7 +645,7 @@ func TestWatcher_PauseDeployment_Unpause_Paused(t *testing.T) {
 	assert.Nil(err, "PauseDeployment")
 
 	assert.Equal(1, len(w.watchers), "Deployment should still be active")
-	m.AssertCalled(t, "UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher))
+	m.AssertCalled(t, "UpdateDeploymentStatus", mocker.MatchedBy(matcher))
 }
 
 // Test unpausing a deployment that is running
@@ -657,7 +658,7 @@ func TestWatcher_PauseDeployment_Unpause_Running(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// Assert the following methods will be called
 	m.On("List", mocker.Anything, mocker.Anything).Return(nil).Run(m.listFromState)
@@ -680,7 +681,7 @@ func TestWatcher_PauseDeployment_Unpause_Running(t *testing.T) {
 		Eval:              true,
 	}
 	matcher := matchDeploymentStatusUpdateRequest(matchConfig)
-	m.On("UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentStatus", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call PauseDeployment
 	req := &structs.DeploymentPauseRequest{
@@ -692,7 +693,7 @@ func TestWatcher_PauseDeployment_Unpause_Running(t *testing.T) {
 	assert.Nil(err, "PauseDeployment")
 
 	assert.Equal(1, len(w.watchers), "Deployment should still be active")
-	m.AssertCalled(t, "UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher))
+	m.AssertCalled(t, "UpdateDeploymentStatus", mocker.MatchedBy(matcher))
 }
 
 // Test failing a deployment that is running
@@ -705,7 +706,7 @@ func TestWatcher_FailDeployment_Running(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// Assert the following methods will be called
 	m.On("List", mocker.Anything, mocker.Anything).Return(nil).Run(m.listFromState)
@@ -728,7 +729,7 @@ func TestWatcher_FailDeployment_Running(t *testing.T) {
 		Eval:              true,
 	}
 	matcher := matchDeploymentStatusUpdateRequest(matchConfig)
-	m.On("UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher)).Return(nil)
+	m.On("UpdateDeploymentStatus", mocker.MatchedBy(matcher)).Return(nil)
 
 	// Call PauseDeployment
 	req := &structs.DeploymentFailRequest{
@@ -739,7 +740,7 @@ func TestWatcher_FailDeployment_Running(t *testing.T) {
 	assert.Nil(err, "FailDeployment")
 
 	assert.Equal(1, len(w.watchers), "Deployment should still be active")
-	m.AssertCalled(t, "UpsertDeploymentStatusUpdate", mocker.MatchedBy(matcher))
+	m.AssertCalled(t, "UpdateDeploymentStatus", mocker.MatchedBy(matcher))
 }
 
 // Tests that the watcher properly watches for allocation changes and takes the
@@ -756,10 +757,11 @@ func TestDeploymentWatcher_Watch(t *testing.T) {
 	j.Stable = true
 	d := mock.Deployment()
 	d.JobID = j.ID
+	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	assert.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Upsert the job again to get a new version
@@ -775,7 +777,7 @@ func TestDeploymentWatcher_Watch(t *testing.T) {
 		mocker.Anything).Return(nil).Run(m.evaluationsFromState)
 	m.On("GetJob", mocker.MatchedBy(matchJobSpecificRequest(j.ID)),
 		mocker.Anything).Return(nil).Run(m.getJobFromState)
-	m.On("GetJobVersions", mocker.MatchedBy(matchJobSpecificRequest(j.ID)),
+	m.On("GetJobVersions", mocker.MatchedBy(matchJobVersionsRequest(j.ID)),
 		mocker.Anything).Return(nil).Run(m.getJobVersionsFromState)
 
 	w.SetEnabled(true)
@@ -824,7 +826,7 @@ func TestDeploymentWatcher_Watch(t *testing.T) {
 		Eval:              true,
 	}
 	m2 := matchDeploymentStatusUpdateRequest(c)
-	m.On("UpsertDeploymentStatusUpdate", mocker.MatchedBy(m2)).Return(nil)
+	m.On("UpdateDeploymentStatus", mocker.MatchedBy(m2)).Return(nil)
 
 	// Update the allocs health to unhealthy which should create a job rollback,
 	// status update and eval
@@ -865,7 +867,7 @@ func TestDeploymentWatcher_Watch(t *testing.T) {
 		Eval:              true,
 	}
 	m3 := matchDeploymentStatusUpdateRequest(c2)
-	m.AssertCalled(t, "UpsertDeploymentStatusUpdate", mocker.MatchedBy(m3))
+	m.AssertCalled(t, "UpdateDeploymentStatus", mocker.MatchedBy(m3))
 	testutil.WaitForResult(func() (bool, error) { return 0 == len(w.watchers), nil },
 		func(err error) { assert.Equal(0, len(w.watchers), "Should have no deployment") })
 }
@@ -890,8 +892,8 @@ func TestWatcher_BatchEvals(t *testing.T) {
 
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j1), "UpsertJob")
 	assert.Nil(m.state.UpsertJob(m.nextIndex(), j2), "UpsertJob")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d1, false), "UpsertDeployment")
-	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d2, false), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d1), "UpsertDeployment")
+	assert.Nil(m.state.UpsertDeployment(m.nextIndex(), d2), "UpsertDeployment")
 	assert.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a1}), "UpsertAllocs")
 	assert.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a2}), "UpsertAllocs")
 
@@ -913,9 +915,9 @@ func TestWatcher_BatchEvals(t *testing.T) {
 	m.On("GetJob", mocker.MatchedBy(matchJobSpecificRequest(j2.ID)),
 		mocker.Anything).Return(nil).Run(m.getJobFromState)
 
-	m.On("GetJobVersions", mocker.MatchedBy(matchJobSpecificRequest(j1.ID)),
+	m.On("GetJobVersions", mocker.MatchedBy(matchJobVersionsRequest(j1.ID)),
 		mocker.Anything).Return(nil).Run(m.getJobVersionsFromState)
-	m.On("GetJobVersions", mocker.MatchedBy(matchJobSpecificRequest(j2.ID)),
+	m.On("GetJobVersions", mocker.MatchedBy(matchJobVersionsRequest(j2.ID)),
 		mocker.Anything).Return(nil).Run(m.getJobVersionsFromState)
 
 	w.SetEnabled(true)

--- a/nomad/deploymentwatcher/testutil_test.go
+++ b/nomad/deploymentwatcher/testutil_test.go
@@ -324,7 +324,7 @@ func (m *mockBackend) GetJobVersions(args *structs.JobVersionsRequest, reply *st
 }
 
 func (m *mockBackend) getJobVersionsFromState(in mocker.Arguments) {
-	args, reply := in.Get(0).(*structs.JobSpecificRequest), in.Get(1).(*structs.JobVersionsResponse)
+	args, reply := in.Get(0).(*structs.JobVersionsRequest), in.Get(1).(*structs.JobVersionsResponse)
 	ws := memdb.NewWatchSet()
 	versions, _ := m.state.JobVersionsByID(ws, args.JobID)
 	reply.Versions = versions
@@ -356,6 +356,14 @@ func matchDeploymentSpecificRequest(dID string) func(args *structs.DeploymentSpe
 // request is for the passed job id
 func matchJobSpecificRequest(jID string) func(args *structs.JobSpecificRequest) bool {
 	return func(args *structs.JobSpecificRequest) bool {
+		return args.JobID == jID
+	}
+}
+
+// matchJobVersionsRequest is used to match that a job version
+// request is for the passed job id
+func matchJobVersionsRequest(jID string) func(args *structs.JobVersionsRequest) bool {
+	return func(args *structs.JobVersionsRequest) bool {
 		return args.JobID == jID
 	}
 }

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1070,7 +1070,7 @@ func TestFSM_ApplyPlanResults(t *testing.T) {
 			Job:   job,
 			Alloc: []*structs.Allocation{alloc},
 		},
-		CreatedDeployment: d,
+		Deployment: d,
 	}
 	buf, err := structs.Encode(structs.ApplyPlanResultsRequestType, req)
 	if err != nil {
@@ -1149,7 +1149,7 @@ func TestFSM_DeploymentStatusUpdate(t *testing.T) {
 
 	// Upsert a deployment
 	d := mock.Deployment()
-	if err := state.UpsertDeployment(1, d, false); err != nil {
+	if err := state.UpsertDeployment(1, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1238,7 +1238,7 @@ func TestFSM_DeploymentPromotion(t *testing.T) {
 			DesiredCanaries: 1,
 		},
 	}
-	if err := state.UpsertDeployment(2, d, false); err != nil {
+	if err := state.UpsertDeployment(2, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1340,7 +1340,7 @@ func TestFSM_DeploymentAllocHealth(t *testing.T) {
 
 	// Insert a deployment
 	d := mock.Deployment()
-	if err := state.UpsertDeployment(1, d, false); err != nil {
+	if err := state.UpsertDeployment(1, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1445,7 +1445,7 @@ func TestFSM_DeleteDeployment(t *testing.T) {
 
 	// Upsert a deployments
 	d := mock.Deployment()
-	if err := state.UpsertDeployment(1, d, false); err != nil {
+	if err := state.UpsertDeployment(1, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1784,8 +1784,8 @@ func TestFSM_SnapshotRestore_Deployments(t *testing.T) {
 	state := fsm.State()
 	d1 := mock.Deployment()
 	d2 := mock.Deployment()
-	state.UpsertDeployment(1000, d1, false)
-	state.UpsertDeployment(1001, d2, false)
+	state.UpsertDeployment(1000, d1)
+	state.UpsertDeployment(1001, d2)
 
 	// Verify the contents
 	fsm2 := testSnapshotRestore(t, fsm)

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1298,25 +1298,6 @@ func TestFSM_DeploymentPromotion(t *testing.T) {
 		}
 	}
 
-	// Check that the allocs were promoted
-	out1, err := state.AllocByID(ws, c1.ID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	out2, err := state.AllocByID(ws, c2.ID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	for _, alloc := range []*structs.Allocation{out1, out2} {
-		if alloc.DeploymentStatus == nil {
-			t.Fatalf("bad: alloc %q has nil deployment status", alloc.ID)
-		}
-		if !alloc.DeploymentStatus.Promoted {
-			t.Fatalf("bad: alloc %q not promoted", alloc.ID)
-		}
-	}
-
 	// Check that the evaluation was created
 	eout, _ := state.EvalByID(ws, e.ID)
 	if err != nil {

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1246,14 +1246,14 @@ func TestFSM_DeploymentPromotion(t *testing.T) {
 	c1 := mock.Alloc()
 	c1.JobID = j.ID
 	c1.DeploymentID = d.ID
-	c1.Canary = true
+	d.TaskGroups[c1.TaskGroup].PlacedCanaries = append(d.TaskGroups[c1.TaskGroup].PlacedCanaries, c1.ID)
 	c1.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: helper.BoolToPtr(true),
 	}
 	c2 := mock.Alloc()
 	c2.JobID = j.ID
 	c2.DeploymentID = d.ID
-	c2.Canary = true
+	d.TaskGroups[c2.TaskGroup].PlacedCanaries = append(d.TaskGroups[c2.TaskGroup].PlacedCanaries, c2.ID)
 	c2.TaskGroup = tg2.Name
 	c2.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: helper.BoolToPtr(true),

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1385,6 +1385,10 @@ func TestJobEndpoint_GetJob(t *testing.T) {
 		}
 	}
 
+	// Clear the submit times
+	j.SubmitTime = 0
+	resp2.Job.SubmitTime = 0
+
 	if !reflect.DeepEqual(j, resp2.Job) {
 		t.Fatalf("bad: %#v %#v", job, resp2.Job)
 	}
@@ -2168,8 +2172,8 @@ func TestJobEndpoint_Deployments(t *testing.T) {
 	d1.JobID = j.ID
 	d2.JobID = j.ID
 	assert.Nil(state.UpsertJob(1000, j), "UpsertJob")
-	assert.Nil(state.UpsertDeployment(1001, d1, false), "UpsertDeployment")
-	assert.Nil(state.UpsertDeployment(1002, d2, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1001, d1), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1002, d2), "UpsertDeployment")
 
 	// Lookup the jobs
 	get := &structs.JobSpecificRequest{
@@ -2199,12 +2203,12 @@ func TestJobEndpoint_Deployments_Blocking(t *testing.T) {
 
 	// First upsert an unrelated eval
 	time.AfterFunc(100*time.Millisecond, func() {
-		assert.Nil(state.UpsertDeployment(100, d1, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(100, d1), "UpsertDeployment")
 	})
 
 	// Upsert an eval for the job we are interested in later
 	time.AfterFunc(200*time.Millisecond, func() {
-		assert.Nil(state.UpsertDeployment(200, d2, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(200, d2), "UpsertDeployment")
 	})
 
 	// Lookup the jobs
@@ -2220,7 +2224,7 @@ func TestJobEndpoint_Deployments_Blocking(t *testing.T) {
 	assert.Nil(msgpackrpc.CallWithCodec(codec, "Job.Deployments", get, &resp), "RPC")
 	assert.EqualValues(200, resp.Index, "response index")
 	assert.Len(resp.Deployments, 1, "deployments for job")
-	assert.Equal(d2.ID, resp.Deployments[0], "returned deployment")
+	assert.Equal(d2.ID, resp.Deployments[0].ID, "returned deployment")
 	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
 		t.Fatalf("should block (returned in %s) %#v", elapsed, resp)
 	}
@@ -2243,8 +2247,8 @@ func TestJobEndpoint_LatestDeployment(t *testing.T) {
 	d2.CreateIndex = d1.CreateIndex + 100
 	d2.ModifyIndex = d2.CreateIndex + 100
 	assert.Nil(state.UpsertJob(1000, j), "UpsertJob")
-	assert.Nil(state.UpsertDeployment(1001, d1, false), "UpsertDeployment")
-	assert.Nil(state.UpsertDeployment(1002, d2, false), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1001, d1), "UpsertDeployment")
+	assert.Nil(state.UpsertDeployment(1002, d2), "UpsertDeployment")
 
 	// Lookup the jobs
 	get := &structs.JobSpecificRequest{
@@ -2275,12 +2279,12 @@ func TestJobEndpoint_LatestDeployment_Blocking(t *testing.T) {
 
 	// First upsert an unrelated eval
 	time.AfterFunc(100*time.Millisecond, func() {
-		assert.Nil(state.UpsertDeployment(100, d1, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(100, d1), "UpsertDeployment")
 	})
 
 	// Upsert an eval for the job we are interested in later
 	time.AfterFunc(200*time.Millisecond, func() {
-		assert.Nil(state.UpsertDeployment(200, d2, false), "UpsertDeployment")
+		assert.Nil(state.UpsertDeployment(200, d2), "UpsertDeployment")
 	})
 
 	// Lookup the jobs

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -328,7 +328,6 @@ OUTER:
 	return result, mErr.ErrorOrNil()
 }
 
-// TODO test
 // correctDeploymentCanaries ensures that the deployment object doesn't list any
 // canaries as placed if they didn't actually get placed. This could happen if
 // the plan had a partial commit.

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -132,7 +132,7 @@ func (s *Server) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap 
 			Job:   plan.Job,
 			Alloc: make([]*structs.Allocation, 0, minUpdates),
 		},
-		CreatedDeployment: plan.CreatedDeployment,
+		Deployment:        plan.Deployment,
 		DeploymentUpdates: plan.DeploymentUpdates,
 	}
 	for _, updateList := range result.NodeUpdate {

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -132,8 +132,8 @@ func (s *Server) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap 
 			Job:   plan.Job,
 			Alloc: make([]*structs.Allocation, 0, minUpdates),
 		},
-		Deployment:        plan.Deployment,
-		DeploymentUpdates: plan.DeploymentUpdates,
+		Deployment:        result.Deployment,
+		DeploymentUpdates: result.DeploymentUpdates,
 	}
 	for _, updateList := range result.NodeUpdate {
 		req.Alloc = append(req.Alloc, updateList...)
@@ -201,8 +201,10 @@ func evaluatePlan(pool *EvaluatePool, snap *state.StateSnapshot, plan *structs.P
 
 	// Create a result holder for the plan
 	result := &structs.PlanResult{
-		NodeUpdate:     make(map[string][]*structs.Allocation),
-		NodeAllocation: make(map[string][]*structs.Allocation),
+		NodeUpdate:        make(map[string][]*structs.Allocation),
+		NodeAllocation:    make(map[string][]*structs.Allocation),
+		Deployment:        plan.Deployment.Copy(),
+		DeploymentUpdates: plan.DeploymentUpdates,
 	}
 
 	// Collect all the nodeIDs
@@ -242,6 +244,8 @@ func evaluatePlan(pool *EvaluatePool, snap *state.StateSnapshot, plan *structs.P
 			if plan.AllAtOnce {
 				result.NodeUpdate = nil
 				result.NodeAllocation = nil
+				result.DeploymentUpdates = nil
+				result.Deployment = nil
 				return true
 			}
 
@@ -315,8 +319,52 @@ OUTER:
 			err := fmt.Errorf("partialCommit with RefreshIndex of 0 (%d node, %d alloc)", nodeIndex, allocIndex)
 			mErr.Errors = append(mErr.Errors, err)
 		}
+
+		// If there was a partial commit and we are operating within a
+		// deployment correct for any canary that may have been desired to be
+		// placed but wasn't actually placed
+		correctDeploymentCanaries(result)
 	}
 	return result, mErr.ErrorOrNil()
+}
+
+// TODO test
+// correctDeploymentCanaries ensures that the deployment object doesn't list any
+// canaries as placed if they didn't actually get placed. This could happen if
+// the plan had a partial commit.
+func correctDeploymentCanaries(result *structs.PlanResult) {
+	// Hot path
+	if result.Deployment == nil || !result.Deployment.HasPlacedCanaries() {
+		return
+	}
+
+	// Build a set of all the allocations IDs that were placed
+	placedAllocs := make(map[string]struct{}, len(result.NodeAllocation))
+	for _, placed := range result.NodeAllocation {
+		for _, alloc := range placed {
+			placedAllocs[alloc.ID] = struct{}{}
+		}
+	}
+
+	// Go through all the canaries and ensure that the result list only contains
+	// those that have been placed
+	for _, group := range result.Deployment.TaskGroups {
+		canaries := group.PlacedCanaries
+		if len(canaries) == 0 {
+			continue
+		}
+
+		// Prune the canaries in place to avoid allocating an extra slice
+		i := 0
+		for _, canaryID := range canaries {
+			if _, ok := placedAllocs[canaryID]; ok {
+				canaries[i] = canaryID
+				i++
+			}
+		}
+
+		group.PlacedCanaries = canaries[:i]
+	}
 }
 
 // evaluateNodePlan is used to evalute the plan for a single node,

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -84,8 +84,8 @@ func TestPlanApply_applyPlan(t *testing.T) {
 
 	// Create the plan with a deployment
 	plan := &structs.Plan{
-		Job:               alloc.Job,
-		CreatedDeployment: mock.Deployment(),
+		Job:        alloc.Job,
+		Deployment: mock.Deployment(),
 	}
 
 	// Apply the plan
@@ -100,7 +100,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 		t.Fatalf("bad: %v %v", out, err)
 	}
 
-	if out, err := snap.DeploymentByID(ws, plan.CreatedDeployment.ID); err != nil || out == nil {
+	if out, err := snap.DeploymentByID(ws, plan.Deployment.ID); err != nil || out == nil {
 		t.Fatalf("bad: %v %v", out, err)
 	}
 
@@ -124,7 +124,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	}
 
 	// Lookup the deployment
-	dout, err := fsmState.DeploymentByID(ws, plan.CreatedDeployment.ID)
+	dout, err := fsmState.DeploymentByID(ws, plan.Deployment.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -67,13 +67,34 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	node := mock.Node()
 	testRegisterNode(t, s1, node)
 
-	// Register alloc
+	// Register a fake deployment
+	oldDeployment := mock.Deployment()
+	if err := s1.State().UpsertDeployment(900, oldDeployment); err != nil {
+		t.Fatalf("UpsertDeployment failed: %v", err)
+	}
+
+	// Create a deployment
+	dnew := mock.Deployment()
+
+	// Create a deployment update for the old deployment id
+	desiredStatus, desiredStatusDescription := "foo", "bar"
+	updates := []*structs.DeploymentStatusUpdate{
+		{
+			DeploymentID:      oldDeployment.ID,
+			Status:            desiredStatus,
+			StatusDescription: desiredStatusDescription,
+		},
+	}
+
+	// Register alloc, deployment and deployment update
 	alloc := mock.Alloc()
 	s1.State().UpsertJobSummary(1000, mock.JobSummary(alloc.JobID))
 	planRes := &structs.PlanResult{
 		NodeAllocation: map[string][]*structs.Allocation{
 			node.ID: []*structs.Allocation{alloc},
 		},
+		Deployment:        dnew,
+		DeploymentUpdates: updates,
 	}
 
 	// Snapshot the state
@@ -84,8 +105,9 @@ func TestPlanApply_applyPlan(t *testing.T) {
 
 	// Create the plan with a deployment
 	plan := &structs.Plan{
-		Job:        alloc.Job,
-		Deployment: mock.Deployment(),
+		Job:               alloc.Job,
+		Deployment:        dnew,
+		DeploymentUpdates: updates,
 	}
 
 	// Apply the plan
@@ -123,13 +145,25 @@ func TestPlanApply_applyPlan(t *testing.T) {
 		t.Fatalf("missing alloc")
 	}
 
-	// Lookup the deployment
+	// Lookup the new deployment
 	dout, err := fsmState.DeploymentByID(ws, plan.Deployment.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if dout == nil {
 		t.Fatalf("missing deployment")
+	}
+
+	// Lookup the updated deployment
+	dout2, err := fsmState.DeploymentByID(ws, oldDeployment.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if dout2 == nil {
+		t.Fatalf("missing deployment")
+	}
+	if dout2.Status != desiredStatus || dout2.StatusDescription != desiredStatusDescription {
+		t.Fatalf("bad status: %#v", dout2)
 	}
 
 	// Evict alloc, Register alloc2
@@ -214,6 +248,14 @@ func TestPlanApply_EvalPlan_Simple(t *testing.T) {
 		NodeAllocation: map[string][]*structs.Allocation{
 			node.ID: []*structs.Allocation{alloc},
 		},
+		Deployment: mock.Deployment(),
+		DeploymentUpdates: []*structs.DeploymentStatusUpdate{
+			{
+				DeploymentID:      structs.GenerateUUID(),
+				Status:            "foo",
+				StatusDescription: "bar",
+			},
+		},
 	}
 
 	pool := NewEvaluatePool(workerPoolSize, workerPoolBufferSize)
@@ -229,6 +271,12 @@ func TestPlanApply_EvalPlan_Simple(t *testing.T) {
 	if !reflect.DeepEqual(result.NodeAllocation, plan.NodeAllocation) {
 		t.Fatalf("incorrect node allocations")
 	}
+	if !reflect.DeepEqual(result.Deployment, plan.Deployment) {
+		t.Fatalf("incorrect deployment")
+	}
+	if !reflect.DeepEqual(result.DeploymentUpdates, plan.DeploymentUpdates) {
+		t.Fatalf("incorrect deployment updates")
+	}
 }
 
 func TestPlanApply_EvalPlan_Partial(t *testing.T) {
@@ -242,11 +290,17 @@ func TestPlanApply_EvalPlan_Partial(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc2 := mock.Alloc() // Ensure alloc2 does not fit
 	alloc2.Resources = node2.Resources
+
+	// Create a deployment where the allocs are markeda as canaries
+	d := mock.Deployment()
+	d.TaskGroups["web"].PlacedCanaries = []string{alloc.ID, alloc2.ID}
+
 	plan := &structs.Plan{
 		NodeAllocation: map[string][]*structs.Allocation{
 			node.ID:  []*structs.Allocation{alloc},
 			node2.ID: []*structs.Allocation{alloc2},
 		},
+		Deployment: d,
 	}
 
 	pool := NewEvaluatePool(workerPoolSize, workerPoolBufferSize)
@@ -266,6 +320,16 @@ func TestPlanApply_EvalPlan_Partial(t *testing.T) {
 	if _, ok := result.NodeAllocation[node2.ID]; ok {
 		t.Fatalf("should not allow alloc2")
 	}
+
+	// Check the deployment was updated
+	if result.Deployment == nil || len(result.Deployment.TaskGroups) == 0 {
+		t.Fatalf("bad: %v", result.Deployment)
+	}
+	placedCanaries := result.Deployment.TaskGroups["web"].PlacedCanaries
+	if len(placedCanaries) != 1 || placedCanaries[0] != alloc.ID {
+		t.Fatalf("bad: %v", placedCanaries)
+	}
+
 	if result.RefreshIndex != 1001 {
 		t.Fatalf("bad: %d", result.RefreshIndex)
 	}
@@ -288,6 +352,14 @@ func TestPlanApply_EvalPlan_Partial_AllAtOnce(t *testing.T) {
 			node.ID:  []*structs.Allocation{alloc},
 			node2.ID: []*structs.Allocation{alloc2},
 		},
+		Deployment: mock.Deployment(),
+		DeploymentUpdates: []*structs.DeploymentStatusUpdate{
+			{
+				DeploymentID:      structs.GenerateUUID(),
+				Status:            "foo",
+				StatusDescription: "bar",
+			},
+		},
 	}
 
 	pool := NewEvaluatePool(workerPoolSize, workerPoolBufferSize)
@@ -306,6 +378,9 @@ func TestPlanApply_EvalPlan_Partial_AllAtOnce(t *testing.T) {
 	}
 	if result.RefreshIndex != 1001 {
 		t.Fatalf("bad: %d", result.RefreshIndex)
+	}
+	if result.Deployment != nil || len(result.DeploymentUpdates) != 0 {
+		t.Fatalf("bad: %v", result)
 	}
 }
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -92,9 +92,9 @@ func (s *StateStore) UpsertPlanResults(index uint64, results *structs.ApplyPlanR
 	txn := s.db.Txn(true)
 	defer txn.Abort()
 
-	// Upsert the newly created deployment
-	if results.CreatedDeployment != nil {
-		if err := s.upsertDeploymentImpl(index, results.CreatedDeployment, true, txn); err != nil {
+	// Upsert the newly created or updated deployment
+	if results.Deployment != nil {
+		if err := s.upsertDeploymentImpl(index, results.Deployment, txn); err != nil {
 			return err
 		}
 	}
@@ -220,22 +220,17 @@ func (s *StateStore) DeleteJobSummary(index uint64, id string) error {
 
 // UpsertDeployment is used to insert a new deployment. If cancelPrior is set to
 // true, all prior deployments for the same job will be cancelled.
-func (s *StateStore) UpsertDeployment(index uint64, deployment *structs.Deployment, cancelPrior bool) error {
+func (s *StateStore) UpsertDeployment(index uint64, deployment *structs.Deployment) error {
 	txn := s.db.Txn(true)
 	defer txn.Abort()
-	if err := s.upsertDeploymentImpl(index, deployment, cancelPrior, txn); err != nil {
+	if err := s.upsertDeploymentImpl(index, deployment, txn); err != nil {
 		return err
 	}
 	txn.Commit()
 	return nil
 }
 
-func (s *StateStore) upsertDeploymentImpl(index uint64, deployment *structs.Deployment, cancelPrior bool, txn *memdb.Txn) error {
-	// Go through and cancel any active deployment for the job.
-	if cancelPrior {
-		s.cancelPriorDeployments(index, deployment, txn)
-	}
-
+func (s *StateStore) upsertDeploymentImpl(index uint64, deployment *structs.Deployment, txn *memdb.Txn) error {
 	// Check if the deployment already exists
 	existing, err := txn.First("deployment", "id", deployment.ID)
 	if err != nil {
@@ -261,39 +256,6 @@ func (s *StateStore) upsertDeploymentImpl(index uint64, deployment *structs.Depl
 		return fmt.Errorf("index update failed: %v", err)
 	}
 
-	return nil
-}
-
-// cancelPriorDeployments cancels any prior deployments for the job.
-func (s *StateStore) cancelPriorDeployments(index uint64, deployment *structs.Deployment, txn *memdb.Txn) error {
-	iter, err := txn.Get("deployment", "job", deployment.JobID)
-	if err != nil {
-		return fmt.Errorf("deployment lookup failed: %v", err)
-	}
-
-	for {
-		raw := iter.Next()
-		if raw == nil {
-			break
-		}
-
-		// Ensure the deployment is active
-		d := raw.(*structs.Deployment)
-		if !d.Active() {
-			continue
-		}
-
-		// We need to cancel so make a copy and set its status
-		cancelled := d.Copy()
-		cancelled.ModifyIndex = index
-		cancelled.Status = structs.DeploymentStatusCancelled
-		cancelled.StatusDescription = fmt.Sprintf("Cancelled in favor of deployment %q", deployment.ID)
-
-		// Insert the cancelled deployment
-		if err := txn.Insert("deployment", cancelled); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -2587,8 +2549,8 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 	state.HealthyAllocs += healthy
 	state.UnhealthyAllocs += unhealthy
 
-	// Upsert the new deployment
-	if err := s.upsertDeploymentImpl(index, deploymentCopy, false, txn); err != nil {
+	// Upsert the deployment
+	if err := s.upsertDeploymentImpl(index, deploymentCopy, txn); err != nil {
 		return err
 	}
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -99,7 +99,7 @@ func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
 			Alloc: []*structs.Allocation{alloc, alloc2},
 			Job:   job,
 		},
-		CreatedDeployment: d,
+		Deployment: d,
 	}
 
 	err := state.UpsertPlanResults(1000, &res)
@@ -139,98 +139,6 @@ func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
 	}
 }
 
-// This test checks that when a new deployment is made, the old ones are
-// cancelled.
-func TestStateStore_UpsertPlanResults_Deployment_CancelOld(t *testing.T) {
-	state := testStateStore(t)
-
-	// Create a job that applies to all
-	job := mock.Job()
-	if err := state.UpsertJob(998, job); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	// Create two deployments:
-	// One that is already terminal and assert its modify index isn't touched
-	// A second that is outstanding and assert it gets cancelled.
-	dterminal := mock.Deployment()
-	dterminal.Status = structs.DeploymentStatusFailed
-	dterminal.JobID = job.ID
-	doutstanding := mock.Deployment()
-	doutstanding.JobID = job.ID
-
-	if err := state.UpsertDeployment(999, dterminal, false); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if err := state.UpsertDeployment(1000, doutstanding, false); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	alloc := mock.Alloc()
-	alloc2 := mock.Alloc()
-	alloc.Job = nil
-	alloc2.Job = nil
-
-	dnew := mock.Deployment()
-	dnew.JobID = job.ID
-	alloc.DeploymentID = dnew.ID
-	alloc2.DeploymentID = dnew.ID
-
-	// Create a plan result
-	res := structs.ApplyPlanResultsRequest{
-		AllocUpdateRequest: structs.AllocUpdateRequest{
-			Alloc: []*structs.Allocation{alloc, alloc2},
-			Job:   job,
-		},
-		CreatedDeployment: dnew,
-	}
-
-	err := state.UpsertPlanResults(1001, &res)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	ws := memdb.NewWatchSet()
-
-	// Check the deployments are correctly updated.
-	dout, err := state.DeploymentByID(ws, dnew.ID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if dout == nil {
-		t.Fatalf("bad: nil deployment")
-	}
-
-	tg, ok := dout.TaskGroups[alloc.TaskGroup]
-	if !ok {
-		t.Fatalf("bad: nil deployment state")
-	}
-	if tg == nil || tg.PlacedAllocs != 2 {
-		t.Fatalf("bad: %v", dout)
-	}
-
-	dterminalout, err := state.DeploymentByID(ws, dterminal.ID)
-	if err != nil || dterminalout == nil {
-		t.Fatalf("bad: %v %v", err, dterminalout)
-	}
-	if !reflect.DeepEqual(dterminalout, dterminal) {
-		t.Fatalf("bad: %v %v", dterminal, dterminalout)
-	}
-
-	doutstandingout, err := state.DeploymentByID(ws, doutstanding.ID)
-	if err != nil || doutstandingout == nil {
-		t.Fatalf("bad: %v %v", err, doutstandingout)
-	}
-	if doutstandingout.Status != structs.DeploymentStatusCancelled || doutstandingout.ModifyIndex != 1001 {
-		t.Fatalf("bad: %v", doutstandingout)
-	}
-
-	if watchFired(ws) {
-		t.Fatalf("bad")
-	}
-}
-
 // This test checks that deployment updates are applied correctly
 func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 	state := testStateStore(t)
@@ -245,7 +153,7 @@ func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 	doutstanding := mock.Deployment()
 	doutstanding.JobID = job.ID
 
-	if err := state.UpsertDeployment(1000, doutstanding, false); err != nil {
+	if err := state.UpsertDeployment(1000, doutstanding); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -269,7 +177,7 @@ func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 			Alloc: []*structs.Allocation{alloc},
 			Job:   job,
 		},
-		CreatedDeployment: dnew,
+		Deployment:        dnew,
 		DeploymentUpdates: []*structs.DeploymentStatusUpdate{update},
 	}
 
@@ -322,7 +230,7 @@ func TestStateStore_UpsertDeployment(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	err = state.UpsertDeployment(1000, deployment, false)
+	err = state.UpsertDeployment(1000, deployment)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -353,83 +261,16 @@ func TestStateStore_UpsertDeployment(t *testing.T) {
 	}
 }
 
-func TestStateStore_UpsertDeployment_Cancel(t *testing.T) {
-	state := testStateStore(t)
-	deployment := mock.Deployment()
-	deployment2 := mock.Deployment()
-	deployment2.JobID = deployment.JobID
-
-	// Create a deployment that shares the job id prefix
-	deployment3 := mock.Deployment()
-	deployment3.JobID = deployment.JobID + "foo"
-
-	if err := state.UpsertDeployment(1000, deployment, false); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if err := state.UpsertDeployment(1001, deployment2, true); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if err := state.UpsertDeployment(1002, deployment3, true); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	ws := memdb.NewWatchSet()
-	out, err := state.DeploymentByID(ws, deployment.ID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	// Check to see that the deployment was cancelled
-	if out.Status != structs.DeploymentStatusCancelled {
-		t.Fatalf("got status %v; want %v", out.Status, structs.DeploymentStatusCancelled)
-	} else if out.ModifyIndex != 1001 {
-		t.Fatalf("got modify index %v; want %v", out.ModifyIndex, 1001)
-	}
-
-	// Get the deployments by job
-	deployments, err := state.DeploymentsByJobID(ws, deployment.JobID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if l := len(deployments); l != 2 {
-		t.Fatalf("got %d deployments; want %v", l, 2)
-	}
-
-	latest, err := state.LatestDeploymentByJobID(ws, deployment.JobID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if latest == nil || latest.CreateIndex != 1001 {
-		t.Fatalf("bad: %+v", latest)
-	}
-
-	index, err := state.Index("deployment")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if index != 1002 {
-		t.Fatalf("bad: %d", index)
-	}
-
-	if watchFired(ws) {
-		t.Fatalf("bad")
-	}
-}
-
 func TestStateStore_DeleteDeployment(t *testing.T) {
 	state := testStateStore(t)
 	d1 := mock.Deployment()
 	d2 := mock.Deployment()
 
-	err := state.UpsertDeployment(1000, d1, false)
+	err := state.UpsertDeployment(1000, d1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertDeployment(1001, d2, false); err != nil {
+	if err := state.UpsertDeployment(1001, d2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -479,7 +320,7 @@ func TestStateStore_Deployments(t *testing.T) {
 		deployment := mock.Deployment()
 		deployments = append(deployments, deployment)
 
-		err := state.UpsertDeployment(1000+uint64(i), deployment, false)
+		err := state.UpsertDeployment(1000+uint64(i), deployment)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -520,7 +361,7 @@ func TestStateStore_DeploymentsByIDPrefix(t *testing.T) {
 	deploy := mock.Deployment()
 
 	deploy.ID = "11111111-662e-d0ab-d1c9-3e434af7bdb4"
-	err := state.UpsertDeployment(1000, deploy, false)
+	err := state.UpsertDeployment(1000, deploy)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -566,7 +407,7 @@ func TestStateStore_DeploymentsByIDPrefix(t *testing.T) {
 
 	deploy = mock.Deployment()
 	deploy.ID = "11222222-662e-d0ab-d1c9-3e434af7bdb4"
-	err = state.UpsertDeployment(1001, deploy, false)
+	err = state.UpsertDeployment(1001, deploy)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3351,7 +3192,7 @@ func TestStateStore_UpsertAlloc_Deployment(t *testing.T) {
 	if err := state.UpsertJob(999, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertDeployment(1000, deployment, false); err != nil {
+	if err := state.UpsertDeployment(1000, deployment); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4834,7 +4675,7 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Terminal(t *testing.T) {
 	d := mock.Deployment()
 	d.Status = structs.DeploymentStatusFailed
 
-	if err := state.UpsertDeployment(1, d, false); err != nil {
+	if err := state.UpsertDeployment(1, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -4858,7 +4699,7 @@ func TestStateStore_UpsertDeploymentStatusUpdate_NonTerminal(t *testing.T) {
 
 	// Insert a deployment
 	d := mock.Deployment()
-	if err := state.UpsertDeployment(1, d, false); err != nil {
+	if err := state.UpsertDeployment(1, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -4936,7 +4777,7 @@ func TestStateStore_UpsertDeploymentPromotion_Terminal(t *testing.T) {
 	d := mock.Deployment()
 	d.Status = structs.DeploymentStatusFailed
 
-	if err := state.UpsertDeployment(1, d, false); err != nil {
+	if err := state.UpsertDeployment(1, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -4966,7 +4807,7 @@ func TestStateStore_UpsertDeploymentPromotion_Unhealthy(t *testing.T) {
 	// Create a deployment
 	d := mock.Deployment()
 	d.JobID = j.ID
-	if err := state.UpsertDeployment(2, d, false); err != nil {
+	if err := state.UpsertDeployment(2, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -5030,7 +4871,7 @@ func TestStateStore_UpsertDeploymentPromotion_All(t *testing.T) {
 			DesiredCanaries: 1,
 		},
 	}
-	if err := state.UpsertDeployment(2, d, false); err != nil {
+	if err := state.UpsertDeployment(2, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -5142,7 +4983,7 @@ func TestStateStore_UpsertDeploymentPromotion_Subset(t *testing.T) {
 			DesiredCanaries: 1,
 		},
 	}
-	if err := state.UpsertDeployment(2, d, false); err != nil {
+	if err := state.UpsertDeployment(2, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -5252,7 +5093,7 @@ func TestStateStore_UpsertDeploymentAllocHealth_Terminal(t *testing.T) {
 	d := mock.Deployment()
 	d.Status = structs.DeploymentStatusFailed
 
-	if err := state.UpsertDeployment(1, d, false); err != nil {
+	if err := state.UpsertDeployment(1, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -5275,7 +5116,7 @@ func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_NonExistant(t *testing.
 
 	// Insert a deployment
 	d := mock.Deployment()
-	if err := state.UpsertDeployment(1, d, false); err != nil {
+	if err := state.UpsertDeployment(1, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -5300,10 +5141,10 @@ func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_MismatchDeployment(t *t
 	// Insert two  deployment
 	d1 := mock.Deployment()
 	d2 := mock.Deployment()
-	if err := state.UpsertDeployment(1, d1, false); err != nil {
+	if err := state.UpsertDeployment(1, d1); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
-	if err := state.UpsertDeployment(2, d2, false); err != nil {
+	if err := state.UpsertDeployment(2, d2); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -5333,7 +5174,7 @@ func TestStateStore_UpsertDeploymentAllocHealth(t *testing.T) {
 
 	// Insert a deployment
 	d := mock.Deployment()
-	if err := state.UpsertDeployment(1, d, false); err != nil {
+	if err := state.UpsertDeployment(1, d); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -4927,25 +4927,6 @@ func TestStateStore_UpsertDeploymentPromotion_All(t *testing.T) {
 		}
 	}
 
-	// Check that the allocs were promoted
-	out1, err := state.AllocByID(ws, c1.ID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	out2, err := state.AllocByID(ws, c2.ID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	for _, alloc := range []*structs.Allocation{out1, out2} {
-		if alloc.DeploymentStatus == nil {
-			t.Fatalf("bad: alloc %q has nil deployment status", alloc.ID)
-		}
-		if !alloc.DeploymentStatus.Promoted {
-			t.Fatalf("bad: alloc %q not promoted", alloc.ID)
-		}
-	}
-
 	// Check that the evaluation was created
 	eout, _ := state.EvalByID(ws, e.ID)
 	if err != nil {
@@ -5039,23 +5020,6 @@ func TestStateStore_UpsertDeploymentPromotion_Subset(t *testing.T) {
 	}
 	if !stateout.Promoted {
 		t.Fatalf("bad: task group web not promoted: %#v", stateout)
-	}
-
-	// Check that the allocs were promoted
-	out1, err := state.AllocByID(ws, c1.ID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	out2, err := state.AllocByID(ws, c2.ID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if !out1.DeploymentStatus.Promoted {
-		t.Fatalf("bad: alloc %q not promoted", out1.ID)
-	}
-	if out2.DeploymentStatus.Promoted {
-		t.Fatalf("bad: alloc %q promoted", out2.ID)
 	}
 
 	// Check that the evaluation was created

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -4815,11 +4815,11 @@ func TestStateStore_UpsertDeploymentPromotion_Unhealthy(t *testing.T) {
 	c1 := mock.Alloc()
 	c1.JobID = j.ID
 	c1.DeploymentID = d.ID
-	c1.Canary = true
+	d.TaskGroups[c1.TaskGroup].PlacedCanaries = append(d.TaskGroups[c1.TaskGroup].PlacedCanaries, c1.ID)
 	c2 := mock.Alloc()
 	c2.JobID = j.ID
 	c2.DeploymentID = d.ID
-	c2.Canary = true
+	d.TaskGroups[c2.TaskGroup].PlacedCanaries = append(d.TaskGroups[c2.TaskGroup].PlacedCanaries, c2.ID)
 
 	if err := state.UpsertAllocs(3, []*structs.Allocation{c1, c2}); err != nil {
 		t.Fatalf("err: %v", err)
@@ -4879,14 +4879,14 @@ func TestStateStore_UpsertDeploymentPromotion_All(t *testing.T) {
 	c1 := mock.Alloc()
 	c1.JobID = j.ID
 	c1.DeploymentID = d.ID
-	c1.Canary = true
+	d.TaskGroups[c1.TaskGroup].PlacedCanaries = append(d.TaskGroups[c1.TaskGroup].PlacedCanaries, c1.ID)
 	c1.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: helper.BoolToPtr(true),
 	}
 	c2 := mock.Alloc()
 	c2.JobID = j.ID
 	c2.DeploymentID = d.ID
-	c2.Canary = true
+	d.TaskGroups[c2.TaskGroup].PlacedCanaries = append(d.TaskGroups[c2.TaskGroup].PlacedCanaries, c2.ID)
 	c2.TaskGroup = tg2.Name
 	c2.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: helper.BoolToPtr(true),
@@ -4972,14 +4972,14 @@ func TestStateStore_UpsertDeploymentPromotion_Subset(t *testing.T) {
 	c1 := mock.Alloc()
 	c1.JobID = j.ID
 	c1.DeploymentID = d.ID
-	c1.Canary = true
+	d.TaskGroups[c1.TaskGroup].PlacedCanaries = append(d.TaskGroups[c1.TaskGroup].PlacedCanaries, c1.ID)
 	c1.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: helper.BoolToPtr(true),
 	}
 	c2 := mock.Alloc()
 	c2.JobID = j.ID
 	c2.DeploymentID = d.ID
-	c2.Canary = true
+	d.TaskGroups[c2.TaskGroup].PlacedCanaries = append(d.TaskGroups[c2.TaskGroup].PlacedCanaries, c2.ID)
 	c2.TaskGroup = tg2.Name
 	c2.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: helper.BoolToPtr(true),

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -62,7 +62,7 @@ func (j *Job) Diff(other *Job, contextual bool) (*JobDiff, error) {
 	diff := &JobDiff{Type: DiffTypeNone}
 	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
 	filter := []string{"ID", "Status", "StatusDescription", "Version", "Stable", "CreateIndex",
-		"ModifyIndex", "JobModifyIndex", "Update"}
+		"ModifyIndex", "JobModifyIndex", "Update", "SubmitTime"}
 
 	if j == nil && other == nil {
 		return diff, nil

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4372,10 +4372,6 @@ type AllocDeploymentStatus struct {
 	// healthy or unhealthy.
 	Healthy *bool
 
-	// Promoted marks whether the allocation is promoted. This field is only
-	// used if the allocation is a canary.
-	Promoted bool
-
 	// ModifyIndex is the raft index in which the deployment status was last
 	// changed.
 	ModifyIndex uint64
@@ -4399,15 +4395,6 @@ func (a *AllocDeploymentStatus) IsUnhealthy() bool {
 	}
 
 	return a.Healthy != nil && !*a.Healthy
-}
-
-// IsPromoted returns if the allocation is promoted as as part of a deployment
-func (a *AllocDeploymentStatus) IsPromoted() bool {
-	if a == nil {
-		return false
-	}
-
-	return a.Promoted
 }
 
 func (a *AllocDeploymentStatus) Copy() *AllocDeploymentStatus {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3845,6 +3845,7 @@ const (
 	// deployment can be in.
 	DeploymentStatusDescriptionRunning           = "Deployment is running"
 	DeploymentStatusDescriptionPaused            = "Deployment is paused"
+	DeploymentStatusDescriptionSuccessful        = "Deployment completed successfully"
 	DeploymentStatusDescriptionStoppedJob        = "Cancelled because job is stopped"
 	DeploymentStatusDescriptionNewerJob          = "Cancelled due to newer version of job"
 	DeploymentStatusDescriptionFailedAllocations = "Failed due to unhealthy allocations"
@@ -3907,6 +3908,10 @@ func NewDeployment(job *Job) *Deployment {
 }
 
 func (d *Deployment) Copy() *Deployment {
+	if d == nil {
+		return nil
+	}
+
 	c := &Deployment{}
 	*c = *d
 
@@ -3969,14 +3974,14 @@ type DeploymentState struct {
 }
 
 func (d *DeploymentState) GoString() string {
-	base := fmt.Sprintf("Desired Total: %d", d.DesiredTotal)
-	base += fmt.Sprintf("\nDesired Canaries: %d", d.DesiredCanaries)
-	base += fmt.Sprintf("\nPlaced Canaries: %#v", d.PlacedCanaries)
-	base += fmt.Sprintf("\nPromoted: %v", d.Promoted)
-	base += fmt.Sprintf("\nPlaced: %d", d.PlacedAllocs)
-	base += fmt.Sprintf("\nHealthy: %d", d.HealthyAllocs)
-	base += fmt.Sprintf("\nUnhealthy: %d", d.UnhealthyAllocs)
-	base += fmt.Sprintf("\nAutoRevert: %v", d.AutoRevert)
+	base := fmt.Sprintf("\tDesired Total: %d", d.DesiredTotal)
+	base += fmt.Sprintf("\n\tDesired Canaries: %d", d.DesiredCanaries)
+	base += fmt.Sprintf("\n\tPlaced Canaries: %#v", d.PlacedCanaries)
+	base += fmt.Sprintf("\n\tPromoted: %v", d.Promoted)
+	base += fmt.Sprintf("\n\tPlaced: %d", d.PlacedAllocs)
+	base += fmt.Sprintf("\n\tHealthy: %d", d.HealthyAllocs)
+	base += fmt.Sprintf("\n\tUnhealthy: %d", d.UnhealthyAllocs)
+	base += fmt.Sprintf("\n\tAutoRevert: %v", d.AutoRevert)
 	return base
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3944,6 +3944,19 @@ func (d *Deployment) GetID() string {
 	return d.ID
 }
 
+// HasPlacedCanaries returns whether the deployment has placed canaries
+func (d *Deployment) HasPlacedCanaries() bool {
+	if d == nil || len(d.TaskGroups) == 0 {
+		return false
+	}
+	for _, group := range d.TaskGroups {
+		if len(group.PlacedCanaries) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func (d *Deployment) GoString() string {
 	base := fmt.Sprintf("Deployment ID %q for job %q has status %q (%v):", d.ID, d.JobID, d.Status, d.StatusDescription)
 	for group, state := range d.TaskGroups {
@@ -4825,6 +4838,12 @@ type PlanResult struct {
 	// NodeAllocation contains all the allocations that were committed.
 	NodeAllocation map[string][]*Allocation
 
+	// Deployment is the deployment that was committed.
+	Deployment *Deployment
+
+	// DeploymentUpdates is the set of deployment updates that were commited.
+	DeploymentUpdates []*DeploymentStatusUpdate
+
 	// RefreshIndex is the index the worker should refresh state up to.
 	// This allows all evictions and allocations to be materialized.
 	// If any allocations were rejected due to stale data (node state,
@@ -4838,7 +4857,8 @@ type PlanResult struct {
 
 // IsNoOp checks if this plan result would do nothing
 func (p *PlanResult) IsNoOp() bool {
-	return len(p.NodeUpdate) == 0 && len(p.NodeAllocation) == 0
+	return len(p.NodeUpdate) == 0 && len(p.NodeAllocation) == 0 &&
+		len(p.DeploymentUpdates) == 0 && p.Deployment == nil
 }
 
 // FullCommit is used to check if all the allocations in a plan

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3936,6 +3936,14 @@ func (d *Deployment) Active() bool {
 	}
 }
 
+// GetID is a helper for getting the ID when the object may be nil
+func (d *Deployment) GetID() string {
+	if d == nil {
+		return ""
+	}
+	return d.ID
+}
+
 func (d *Deployment) GoString() string {
 	base := fmt.Sprintf("Deployment ID %q for job %q has status %q (%v):", d.ID, d.JobID, d.Status, d.StatusDescription)
 	for group, state := range d.TaskGroups {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4103,9 +4103,6 @@ type Allocation struct {
 	// given deployment
 	DeploymentStatus *AllocDeploymentStatus
 
-	// Canary marks this allocation as being a canary
-	Canary bool
-
 	// Raft Indexes
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -409,6 +409,7 @@ func (s *GenericScheduler) computeJobAllocs() error {
 		s.plan.AppendUpdate(stop.alloc, structs.AllocDesiredStatusStop, stop.statusDescription, stop.clientStatus)
 	}
 
+	// TODO test
 	// Handle the in-place updates
 	deploymentID := ""
 	if s.plan.Deployment != nil {

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -396,12 +396,12 @@ func (s *GenericScheduler) computeJobAllocs() error {
 	}
 
 	// Add the deployment changes to the plan
-	s.plan.CreatedDeployment = results.createDeployment
+	s.plan.Deployment = results.deployment
 	s.plan.DeploymentUpdates = results.deploymentUpdates
 
 	// Update the stored deployment
-	if results.createDeployment != nil {
-		s.deployment = results.createDeployment
+	if results.deployment != nil {
+		s.deployment = results.deployment
 	}
 
 	// Handle the stop

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -411,7 +411,6 @@ func (s *GenericScheduler) computeJobAllocs() error {
 		s.plan.AppendUpdate(stop.alloc, structs.AllocDesiredStatusStop, stop.statusDescription, stop.clientStatus)
 	}
 
-	// TODO test
 	// Handle the in-place updates
 	for _, update := range results.inplaceUpdate {
 		if update.DeploymentID != s.deployment.GetID() {
@@ -507,7 +506,6 @@ func (s *GenericScheduler) computePlacements(place []allocPlaceResult) error {
 				alloc.PreviousAllocation = missing.previousAlloc.ID
 			}
 
-			// TODO test
 			// If we are placing a canary and we found a match, add the canary
 			// to the deployment state object.
 			if missing.canary {

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -1462,6 +1462,11 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 
 	h.AssertEvalStatus(t, structs.EvalStatusComplete)
 
+	// Check that the deployment id is attached to the eval
+	if h.Evals[0].DeploymentID == "" {
+		t.Fatalf("Eval not annotated with deployment id")
+	}
+
 	// Ensure a deployment was created
 	if plan.Deployment == nil {
 		t.Fatalf("bad: %#v", plan)

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -1463,10 +1463,10 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 	h.AssertEvalStatus(t, structs.EvalStatusComplete)
 
 	// Ensure a deployment was created
-	if plan.CreatedDeployment == nil {
+	if plan.Deployment == nil {
 		t.Fatalf("bad: %#v", plan)
 	}
-	state, ok := plan.CreatedDeployment.TaskGroups[job.TaskGroups[0].Name]
+	state, ok := plan.Deployment.TaskGroups[job.TaskGroups[0].Name]
 	if !ok {
 		t.Fatalf("bad: %#v", plan)
 	}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -2872,7 +2872,7 @@ func TestServiceSched_CancelDeployment_Stopped(t *testing.T) {
 	d.JobID = job.ID
 	d.JobCreateIndex = job.CreateIndex
 	d.JobModifyIndex = job.JobModifyIndex - 1
-	noErr(t, h.State.UpsertDeployment(h.NextIndex(), d, false))
+	noErr(t, h.State.UpsertDeployment(h.NextIndex(), d))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -2937,7 +2937,7 @@ func TestServiceSched_CancelDeployment_NewerJob(t *testing.T) {
 	// Create a deployment for an old version of the job
 	d := mock.Deployment()
 	d.JobID = job.ID
-	noErr(t, h.State.UpsertDeployment(h.NextIndex(), d, false))
+	noErr(t, h.State.UpsertDeployment(h.NextIndex(), d))
 
 	// Upsert again to bump job version
 	noErr(t, h.State.UpsertJob(h.NextIndex(), job))

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -157,10 +157,14 @@ func (a *allocReconciler) Compute() *reconcileResults {
 		complete = complete && groupComplete
 	}
 
+	// TODO test
 	// Mark the deployment as complete if possible
 	if a.deployment != nil && complete {
-		a.deployment.Status = structs.DeploymentStatusSuccessful
-		a.deployment.StatusDescription = structs.DeploymentStatusDescriptionSuccessful
+		a.result.deploymentUpdates = append(a.result.deploymentUpdates, &structs.DeploymentStatusUpdate{
+			DeploymentID:      a.deployment.ID,
+			Status:            structs.DeploymentStatusSuccessful,
+			StatusDescription: structs.DeploymentStatusDescriptionSuccessful,
+		})
 	}
 
 	return a.result
@@ -257,7 +261,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 
 	// Get the deployment state for the group
 	var dstate *structs.DeploymentState
-	var existingDeployment bool
+	existingDeployment := false
 	deploymentComplete := true
 	if a.deployment != nil {
 		dstate, existingDeployment = a.deployment.TaskGroups[group]

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -192,12 +192,14 @@ func (a *allocReconciler) cancelDeployments() {
 	}
 
 	// Check if the deployment is active and referencing an older job and cancel it
-	if d.Active() && (d.JobCreateIndex != a.job.CreateIndex || d.JobModifyIndex != a.job.JobModifyIndex) {
-		a.result.deploymentUpdates = append(a.result.deploymentUpdates, &structs.DeploymentStatusUpdate{
-			DeploymentID:      a.deployment.ID,
-			Status:            structs.DeploymentStatusCancelled,
-			StatusDescription: structs.DeploymentStatusDescriptionNewerJob,
-		})
+	if d.JobCreateIndex != a.job.CreateIndex || d.JobModifyIndex != a.job.JobModifyIndex {
+		if d.Active() {
+			a.result.deploymentUpdates = append(a.result.deploymentUpdates, &structs.DeploymentStatusUpdate{
+				DeploymentID:      a.deployment.ID,
+				Status:            structs.DeploymentStatusCancelled,
+				StatusDescription: structs.DeploymentStatusDescriptionNewerJob,
+			})
+		}
 
 		a.oldDeployment = d
 		a.deployment = nil

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -249,7 +249,9 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) {
 		if a.deployment != nil {
 			// Stop all non-promoted canaries from older deployments
 			current, older := canaries.filterByDeployment(a.deployment.ID)
-			nonPromotedOlder := older.filterByPromoted(false)
+			// TODO
+			//nonPromotedOlder := older.filterByPromoted(false)
+			nonPromotedOlder := older
 			a.markStop(nonPromotedOlder, "", allocNotNeeded)
 			desiredChanges.Stop += uint64(len(nonPromotedOlder))
 
@@ -264,7 +266,9 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) {
 			all = all.difference(nonPromotedOlder, migrate, lost)
 		} else {
 			// Stop all non-promoted canaries
-			nonPromoted := canaries.filterByPromoted(false)
+			// TODO
+			//nonPromoted := canaries.filterByPromoted(false)
+			nonPromoted := canaries
 			a.markStop(nonPromoted, "", allocNotNeeded)
 			desiredChanges.Stop += uint64(len(nonPromoted))
 			all = all.difference(nonPromoted)

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -61,9 +61,9 @@ type allocReconciler struct {
 // reconcileResults contains the results of the reconciliation and should be
 // applied by the scheduler.
 type reconcileResults struct {
-	// createDeployment is the deployment that should be created as a result of
-	// scheduling
-	createDeployment *structs.Deployment
+	// deployment is the deployment that should be created or updated as a
+	// result of scheduling
+	deployment *structs.Deployment
 
 	// deploymentUpdates contains a set of deployment updates that should be
 	// applied as a result of scheduling
@@ -393,7 +393,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) {
 	// Create a new deployment if necessary
 	if a.deployment == nil && strategy != nil && dstate.DesiredTotal != 0 {
 		a.deployment = structs.NewDeployment(a.job)
-		a.result.createDeployment = a.deployment
+		a.result.deployment = a.deployment
 		a.deployment.TaskGroups[group] = dstate
 	}
 }

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -157,7 +157,6 @@ func (a *allocReconciler) Compute() *reconcileResults {
 		complete = complete && groupComplete
 	}
 
-	// TODO test
 	// Mark the deployment as complete if possible
 	if a.deployment != nil && complete {
 		a.result.deploymentUpdates = append(a.result.deploymentUpdates, &structs.DeploymentStatusUpdate{

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -249,16 +249,16 @@ type resultExpectation struct {
 
 func assertResults(t *testing.T, r *reconcileResults, exp *resultExpectation) {
 
-	if exp.createDeployment != nil && r.createDeployment == nil {
+	if exp.createDeployment != nil && r.deployment == nil {
 		t.Fatalf("Expect a created deployment got none")
-	} else if exp.createDeployment == nil && r.createDeployment != nil {
-		t.Fatalf("Expect no created deployment; got %#v", r.createDeployment)
-	} else if exp.createDeployment != nil && r.createDeployment != nil {
+	} else if exp.createDeployment == nil && r.deployment != nil {
+		t.Fatalf("Expect no created deployment; got %#v", r.deployment)
+	} else if exp.createDeployment != nil && r.deployment != nil {
 		// Clear the deployment ID
-		r.createDeployment.ID, exp.createDeployment.ID = "", ""
-		if !reflect.DeepEqual(r.createDeployment, exp.createDeployment) {
+		r.deployment.ID, exp.createDeployment.ID = "", ""
+		if !reflect.DeepEqual(r.deployment, exp.createDeployment) {
 			t.Fatalf("Unexpected createdDeployment; got\n %#v\nwant\n%#v\nDiff: %v",
-				r.createDeployment, exp.createDeployment, pretty.Diff(r.createDeployment, exp.createDeployment))
+				r.deployment, exp.createDeployment, pretty.Diff(r.deployment, exp.createDeployment))
 		}
 	}
 

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -2541,8 +2541,9 @@ func TestReconciler_CompleteDeployment(t *testing.T) {
 		if i < 2 {
 			alloc.Canary = true
 			alloc.DeploymentStatus = &structs.AllocDeploymentStatus{
-				Healthy:  helper.BoolToPtr(true),
-				Promoted: true,
+				Healthy: helper.BoolToPtr(true),
+				// TODO
+				//Promoted: true,
 			}
 		}
 		allocs = append(allocs, alloc)

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -2636,7 +2636,6 @@ func TestReconciler_FailedDeployment_CancelCanaries(t *testing.T) {
 
 			// Add the alloc to the canary list
 			if i < 2 {
-
 				state.PlacedCanaries = append(state.PlacedCanaries, new.ID)
 			}
 		}
@@ -2675,3 +2674,5 @@ func TestReconciler_FailedDeployment_CancelCanaries(t *testing.T) {
 
 	assertNamesHaveIndexes(t, intRange(0, 1), stopResultsToNames(r.stop))
 }
+
+// TODO Test that a failed deployment and updated job works

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -164,17 +164,6 @@ func (a allocSet) filterByTainted(nodes map[string]*structs.Node) (untainted, mi
 	return
 }
 
-// filterByCanary returns a new allocation set that contains only canaries
-func (a allocSet) filterByCanary() allocSet {
-	canaries := make(map[string]*structs.Allocation)
-	for _, alloc := range a {
-		if alloc.Canary {
-			canaries[alloc.ID] = alloc
-		}
-	}
-	return canaries
-}
-
 // filterByDeployment filters allocations into two sets, those that match the
 // given deployment ID and those that don't
 func (a allocSet) filterByDeployment(id string) (match, nonmatch allocSet) {

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -116,6 +116,19 @@ func (a allocSet) union(others ...allocSet) allocSet {
 	return union
 }
 
+// fromKeys returns an alloc set matching the passed keys
+func (a allocSet) fromKeys(keys ...[]string) allocSet {
+	from := make(map[string]*structs.Allocation)
+	for _, set := range keys {
+		for _, k := range set {
+			if alloc, ok := a[k]; ok {
+				from[k] = alloc
+			}
+		}
+	}
+	return from
+}
+
 // fitlerByTainted takes a set of tainted nodes and filters the allocation set
 // into three groups:
 // 1. Those that exist on untainted nodes

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -162,23 +162,6 @@ func (a allocSet) filterByCanary() allocSet {
 	return canaries
 }
 
-// filterByPromoted filters the allocset by whether the canaries are promoted or
-// not
-func (a allocSet) filterByPromoted(p bool) allocSet {
-	promoted := make(map[string]*structs.Allocation)
-	for _, alloc := range a {
-		if !alloc.Canary {
-			continue
-		}
-		if p && alloc.DeploymentStatus.IsPromoted() {
-			promoted[alloc.ID] = alloc
-		} else if !p && !alloc.DeploymentStatus.IsPromoted() {
-			promoted[alloc.ID] = alloc
-		}
-	}
-	return promoted
-}
-
 // filterByDeployment filters allocations into two sets, those that match the
 // given deployment ID and those that don't
 func (a allocSet) filterByDeployment(id string) (match, nonmatch allocSet) {

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -66,7 +66,7 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) error {
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)
 		return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, s.failedTGAllocs, structs.EvalStatusFailed, desc,
-			s.queuedAllocs)
+			s.queuedAllocs, "")
 	}
 
 	// Retry up to the maxSystemScheduleAttempts and reset if progress is made.
@@ -74,14 +74,14 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) error {
 	if err := retryMax(maxSystemScheduleAttempts, s.process, progress); err != nil {
 		if statusErr, ok := err.(*SetStatusError); ok {
 			return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, s.failedTGAllocs, statusErr.EvalStatus, err.Error(),
-				s.queuedAllocs)
+				s.queuedAllocs, "")
 		}
 		return err
 	}
 
 	// Update the status to complete
 	return setStatus(s.logger, s.planner, s.eval, s.nextEval, nil, s.failedTGAllocs, structs.EvalStatusComplete, "",
-		s.queuedAllocs)
+		s.queuedAllocs, "")
 }
 
 // process is wrapped in retryMax to iteratively run the handler until we have no

--- a/scheduler/testing.go
+++ b/scheduler/testing.go
@@ -124,7 +124,7 @@ func (h *Harness) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, State, er
 			Job:   plan.Job,
 			Alloc: allocs,
 		},
-		CreatedDeployment: plan.CreatedDeployment,
+		Deployment:        plan.Deployment,
 		DeploymentUpdates: plan.DeploymentUpdates,
 	}
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -290,8 +290,8 @@ func retryMax(max int, cb func() (bool, error), reset func() bool) error {
 // If the result is nil, false is returned.
 func progressMade(result *structs.PlanResult) bool {
 	return result != nil && (len(result.NodeUpdate) != 0 ||
-		len(result.NodeAllocation) != 0) || result.Deployment != nil ||
-		len(result.DeploymentUpdates) != 0
+		len(result.NodeAllocation) != 0 || result.Deployment != nil ||
+		len(result.DeploymentUpdates) != 0)
 }
 
 // taintedNodes is used to scan the allocations and then check if the

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -290,7 +290,8 @@ func retryMax(max int, cb func() (bool, error), reset func() bool) error {
 // If the result is nil, false is returned.
 func progressMade(result *structs.PlanResult) bool {
 	return result != nil && (len(result.NodeUpdate) != 0 ||
-		len(result.NodeAllocation) != 0)
+		len(result.NodeAllocation) != 0) || result.Deployment != nil ||
+		len(result.DeploymentUpdates) != 0
 }
 
 // taintedNodes is used to scan the allocations and then check if the

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -430,12 +430,13 @@ func networkPortMap(n *structs.NetworkResource) map[string]int {
 func setStatus(logger *log.Logger, planner Planner,
 	eval, nextEval, spawnedBlocked *structs.Evaluation,
 	tgMetrics map[string]*structs.AllocMetric, status, desc string,
-	queuedAllocs map[string]int) error {
+	queuedAllocs map[string]int, deploymentID string) error {
 
 	logger.Printf("[DEBUG] sched: %#v: setting status to %s", eval, status)
 	newEval := eval.Copy()
 	newEval.Status = status
 	newEval.StatusDescription = desc
+	newEval.DeploymentID = deploymentID
 	newEval.FailedTGAllocs = tgMetrics
 	if nextEval != nil {
 		newEval.NextEval = nextEval.ID

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -1006,7 +1006,14 @@ func TestProgressMade(t *testing.T) {
 	}
 	update := &structs.PlanResult{NodeUpdate: m}
 	alloc := &structs.PlanResult{NodeAllocation: m}
-	if !(progressMade(both) && progressMade(update) && progressMade(alloc)) {
+	deployment := &structs.PlanResult{Deployment: mock.Deployment()}
+	deploymentUpdates := &structs.PlanResult{
+		DeploymentUpdates: []*structs.DeploymentStatusUpdate{
+			{DeploymentID: structs.GenerateUUID()},
+		},
+	}
+	if !(progressMade(both) && progressMade(update) && progressMade(alloc) &&
+		progressMade(deployment) && progressMade(deploymentUpdates)) {
 		t.Fatal("bad")
 	}
 }

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -627,7 +627,7 @@ func TestSetStatus(t *testing.T) {
 	eval := mock.Eval()
 	status := "a"
 	desc := "b"
-	if err := setStatus(logger, h, eval, nil, nil, nil, status, desc, nil); err != nil {
+	if err := setStatus(logger, h, eval, nil, nil, nil, status, desc, nil, ""); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -643,7 +643,7 @@ func TestSetStatus(t *testing.T) {
 	// Test next evals
 	h = NewHarness(t)
 	next := mock.Eval()
-	if err := setStatus(logger, h, eval, next, nil, nil, status, desc, nil); err != nil {
+	if err := setStatus(logger, h, eval, next, nil, nil, status, desc, nil, ""); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -659,7 +659,7 @@ func TestSetStatus(t *testing.T) {
 	// Test blocked evals
 	h = NewHarness(t)
 	blocked := mock.Eval()
-	if err := setStatus(logger, h, eval, nil, blocked, nil, status, desc, nil); err != nil {
+	if err := setStatus(logger, h, eval, nil, blocked, nil, status, desc, nil, ""); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -675,7 +675,7 @@ func TestSetStatus(t *testing.T) {
 	// Test metrics
 	h = NewHarness(t)
 	metrics := map[string]*structs.AllocMetric{"foo": nil}
-	if err := setStatus(logger, h, eval, nil, nil, metrics, status, desc, nil); err != nil {
+	if err := setStatus(logger, h, eval, nil, nil, metrics, status, desc, nil, ""); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -692,7 +692,7 @@ func TestSetStatus(t *testing.T) {
 	h = NewHarness(t)
 	queuedAllocs := map[string]int{"web": 1}
 
-	if err := setStatus(logger, h, eval, nil, nil, metrics, status, desc, queuedAllocs); err != nil {
+	if err := setStatus(logger, h, eval, nil, nil, metrics, status, desc, queuedAllocs, ""); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
 
@@ -703,6 +703,21 @@ func TestSetStatus(t *testing.T) {
 	newEval = h.Evals[0]
 	if !reflect.DeepEqual(newEval.QueuedAllocations, queuedAllocs) {
 		t.Fatalf("setStatus() didn't set failed task group metrics correctly: %v", newEval)
+	}
+
+	h = NewHarness(t)
+	dID := structs.GenerateUUID()
+	if err := setStatus(logger, h, eval, nil, nil, metrics, status, desc, queuedAllocs, dID); err != nil {
+		t.Fatalf("setStatus() failed: %v", err)
+	}
+
+	if len(h.Evals) != 1 {
+		t.Fatalf("setStatus() didn't update plan: %v", h.Evals)
+	}
+
+	newEval = h.Evals[0]
+	if newEval.DeploymentID != dID {
+		t.Fatalf("setStatus() didn't set deployment id correctly: %v", newEval)
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -256,6 +256,12 @@
 			"revisionTime": "2016-11-21T13:51:53Z"
 		},
 		{
+			"checksumSHA1": "5qEuqnavYqfukAMm7WimC/cX0HE=",
+			"path": "github.com/dadgar/columnize",
+			"revision": "36facc107c7b0258ea8d6e96a45a46087b6d7ef9",
+			"revisionTime": "2017-06-30T01:36:23Z"
+		},
+		{
 			"checksumSHA1": "/5cvgU+J4l7EhMXTK76KaCAfOuU=",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
@@ -366,26 +372,26 @@
 		{
 			"checksumSHA1": "iP5slJJPRZUm0rfdII8OiATAACA=",
 			"path": "github.com/docker/docker/pkg/idtools",
-			"revision": "52debcd58ac91bf68503ce60561536911b74ff05",
-			"revisionTime": "2016-05-20T15:17:10Z"
+			"revision": "02caa73df411debed164f520a6a1304778f8b88c",
+			"revisionTime": "2016-05-28T10:48:36Z"
 		},
 		{
 			"checksumSHA1": "iP5slJJPRZUm0rfdII8OiATAACA=",
 			"path": "github.com/docker/docker/pkg/idtools",
-			"revision": "02caa73df411debed164f520a6a1304778f8b88c",
-			"revisionTime": "2016-05-28T10:48:36Z"
+			"revision": "52debcd58ac91bf68503ce60561536911b74ff05",
+			"revisionTime": "2016-05-20T15:17:10Z"
+		},
+		{
+			"checksumSHA1": "tdhmIGUaoOMEDymMC23qTS7bt0g=",
+			"path": "github.com/docker/docker/pkg/ioutils",
+			"revision": "52debcd58ac91bf68503ce60561536911b74ff05",
+			"revisionTime": "2016-05-20T15:17:10Z"
 		},
 		{
 			"checksumSHA1": "tdhmIGUaoOMEDymMC23qTS7bt0g=",
 			"path": "github.com/docker/docker/pkg/ioutils",
 			"revision": "da39e9a4f920a15683dd0f23923c302d4db6eed5",
 			"revisionTime": "2016-05-28T08:11:04Z"
-		},
-		{
-			"checksumSHA1": "tdhmIGUaoOMEDymMC23qTS7bt0g=",
-			"path": "github.com/docker/docker/pkg/ioutils",
-			"revision": "52debcd58ac91bf68503ce60561536911b74ff05",
-			"revisionTime": "2016-05-20T15:17:10Z"
 		},
 		{
 			"checksumSHA1": "BlFSSK7zUjPzPuxkLmM/0wpvku8=",
@@ -408,14 +414,14 @@
 		{
 			"checksumSHA1": "rArZ5mYIe9I1L5PRQOJu8BwafFw=",
 			"path": "github.com/docker/docker/pkg/pools",
-			"revision": "da39e9a4f920a15683dd0f23923c302d4db6eed5",
-			"revisionTime": "2016-05-28T08:11:04Z"
+			"revision": "52debcd58ac91bf68503ce60561536911b74ff05",
+			"revisionTime": "2016-05-20T15:17:10Z"
 		},
 		{
 			"checksumSHA1": "rArZ5mYIe9I1L5PRQOJu8BwafFw=",
 			"path": "github.com/docker/docker/pkg/pools",
-			"revision": "52debcd58ac91bf68503ce60561536911b74ff05",
-			"revisionTime": "2016-05-20T15:17:10Z"
+			"revision": "da39e9a4f920a15683dd0f23923c302d4db6eed5",
+			"revisionTime": "2016-05-28T08:11:04Z"
 		},
 		{
 			"checksumSHA1": "txf3EORYff4hO6PEvwBm2lyh1MU=",


### PR DESCRIPTION
This PR moves tracking of canaries and promotion out of the allocation and into the deployment object. Further, it makes the plan applier aware of deployments and can partially apply canary placements.

There are also fixes to the reconciler in marking deployments as complete and handling canary stopping on failed deployments.

Also removes canceling behavior in UpsertDeployment