### PR TITLE
Default to auth hard fail but optionally soft fail

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -158,6 +158,7 @@ type DockerDriverConfig struct {
 	LabelsRaw        []map[string]string `mapstructure:"labels"`             //
 	Labels           map[string]string   `mapstructure:"-"`                  // Labels to set when the container starts up
 	Auth             []DockerDriverAuth  `mapstructure:"auth"`               // Authentication credentials for a private Docker registry
+	AuthSoftFail     bool                `mapstructure:"auth_soft_fail"`     // Soft-fail if auth creds are provided but fail
 	TTY              bool                `mapstructure:"tty"`                // Allocate a Pseudo-TTY
 	Interactive      bool                `mapstructure:"interactive"`        // Keep STDIN open even if not attached
 	ShmSize          int64               `mapstructure:"shm_size"`           // Size of /dev/shm of the container in bytes
@@ -399,6 +400,9 @@ func (d *DockerDriver) Validate(config map[string]interface{}) error {
 			},
 			"auth": &fields.FieldSchema{
 				Type: fields.TypeArray,
+			},
+			"auth_soft_fail": &fields.FieldSchema{
+				Type: fields.TypeBool,
 			},
 			// COMPAT: Remove in 0.6.0. SSL is no longer needed
 			"ssl": &fields.FieldSchema{
@@ -1082,7 +1086,11 @@ func (d *DockerDriver) createImage(driverConfig *DockerDriverConfig, client *doc
 func (d *DockerDriver) pullImage(driverConfig *DockerDriverConfig, client *docker.Client, repo, tag string) (id string, err error) {
 	authOptions, err := d.resolveRegistryAuthentication(driverConfig, repo)
 	if err != nil {
-		d.logger.Printf("[WARN] Failed to find docker auth for repo %q: %v", repo, err)
+		if d.driverConfig.AuthSoftFail {
+			d.logger.Printf("[WARN] Failed to find docker auth for repo %q: %v", repo, err)
+		} else {
+			return "", fmt.Errorf("Failed to find docker auth for repo %q: %v", repo, err)
+		}
 	}
 
 	if authIsEmpty(authOptions) {

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -64,6 +64,10 @@ The `docker` driver supports the following configuration in the job spec.  Only
 
 * `auth` - (Optional) Provide authentication for a private registry (see below).
 
+* `auth_soft_fail` `(bool: false)` - Fallback to public images if auth fails.
+  Disabled by default to avoid accidently looking up private images in a public
+  repo, but provided as a convenience.
+
 * `command` - (Optional) The command to run when starting the container.
 
     ```hcl

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -64,9 +64,8 @@ The `docker` driver supports the following configuration in the job spec.  Only
 
 * `auth` - (Optional) Provide authentication for a private registry (see below).
 
-* `auth_soft_fail` `(bool: false)` - Fallback to public images if auth fails.
-  Disabled by default to avoid accidently looking up private images in a public
-  repo, but provided as a convenience.
+* `auth_soft_fail` `(bool: false)` - Don't fail the task on an auth failure.
+  Attempt to continue without auth.
 
 * `command` - (Optional) The command to run when starting the container.
 


### PR DESCRIPTION
Make the behavior change in #2744 optional: default to hard failing when auth doesn't work but allow soft failing to ease environments that mix public and private images.