### PR TITLE
Complete deployments mark jobs as stable

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -266,6 +266,23 @@ func (j *Jobs) Revert(jobID string, version uint64, enforcePriorVersion *uint64,
 	return &resp, wm, nil
 }
 
+// Stable is used to mark a job version's stability.
+func (j *Jobs) Stable(jobID string, version uint64, stable bool,
+	q *WriteOptions) (*JobStabilityResponse, *WriteMeta, error) {
+
+	var resp JobStabilityResponse
+	req := &JobStabilityRequest{
+		JobID:      jobID,
+		JobVersion: version,
+		Stable:     stable,
+	}
+	wm, err := j.client.write("/v1/job/"+jobID+"/stable", req, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, wm, nil
+}
+
 // periodicForceResponse is used to deserialize a force response
 type periodicForceResponse struct {
 	EvalID string
@@ -841,4 +858,21 @@ type JobVersionsResponse struct {
 	Versions []*Job
 	Diffs    []*JobDiff
 	QueryMeta
+}
+
+// JobStabilityRequest is used to marked a job as stable.
+type JobStabilityRequest struct {
+	// Job to set the stability on
+	JobID      string
+	JobVersion uint64
+
+	// Set the stability
+	Stable bool
+	WriteRequest
+}
+
+// JobStabilityResponse is the response when marking a job as stable.
+type JobStabilityResponse struct {
+	JobModifyIndex uint64
+	WriteMeta
 }

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -921,6 +921,57 @@ func TestHTTP_JobRevert(t *testing.T) {
 	})
 }
 
+func TestHTTP_JobStable(t *testing.T) {
+	httpTest(t, nil, func(s *TestServer) {
+		// Create the job and register it twice
+		job := mock.Job()
+		regReq := structs.JobRegisterRequest{
+			Job:          job,
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		var regResp structs.JobRegisterResponse
+		if err := s.Agent.RPC("Job.Register", &regReq, &regResp); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if err := s.Agent.RPC("Job.Register", &regReq, &regResp); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		args := structs.JobStabilityRequest{
+			JobID:        job.ID,
+			JobVersion:   0,
+			Stable:       true,
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		buf := encodeReq(args)
+
+		// Make the HTTP request
+		req, err := http.NewRequest("PUT", "/v1/job/"+job.ID+"/stable", buf)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.JobSpecificRequest(respW, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Check the response
+		stableResp := obj.(structs.JobStabilityResponse)
+		if stableResp.JobModifyIndex == 0 {
+			t.Fatalf("bad: %v", stableResp)
+		}
+
+		// Check for the index
+		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+			t.Fatalf("missing index")
+		}
+	})
+}
+
 func TestJobs_ApiJobToStructsJob(t *testing.T) {
 	apiJob := &api.Job{
 		Stop:        helper.BoolToPtr(true),

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -408,10 +408,10 @@ func (j *Job) Stable(args *structs.JobStabilityRequest, reply *structs.JobStabil
 		return fmt.Errorf("job %q at version %d not found", args.JobID, args.JobVersion)
 	}
 
-	// Commit this evaluation via Raft
+	// Commit this stability request via Raft
 	_, modifyIndex, err := j.srv.raftApply(structs.JobStabilityRequestType, args)
 	if err != nil {
-		j.srv.logger.Printf("[ERR] nomad.job: Eval create failed: %v", err)
+		j.srv.logger.Printf("[ERR] nomad.job: Job stability request failed: %v", err)
 		return err
 	}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -332,7 +332,7 @@ func (j *Job) Revert(args *structs.JobRevertRequest, reply *structs.JobRegisterR
 
 	// Validate the arguments
 	if args.JobID == "" {
-		return fmt.Errorf("missing job ID for evaluation")
+		return fmt.Errorf("missing job ID for revert")
 	}
 
 	// Lookup the job by version
@@ -379,6 +379,46 @@ func (j *Job) Revert(args *structs.JobRevertRequest, reply *structs.JobRegisterR
 
 	// Register the version.
 	return j.Register(reg, reply)
+}
+
+// Stable is used to mark the job version as stable
+func (j *Job) Stable(args *structs.JobStabilityRequest, reply *structs.JobStabilityResponse) error {
+	if done, err := j.srv.forward("Job.Stable", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "job", "stable"}, time.Now())
+
+	// Validate the arguments
+	if args.JobID == "" {
+		return fmt.Errorf("missing job ID for marking job as stable")
+	}
+
+	// Lookup the job by version
+	snap, err := j.srv.fsm.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	ws := memdb.NewWatchSet()
+	jobV, err := snap.JobByIDAndVersion(ws, args.JobID, args.JobVersion)
+	if err != nil {
+		return err
+	}
+	if jobV == nil {
+		return fmt.Errorf("job %q at version %d not found", args.JobID, args.JobVersion)
+	}
+
+	// Commit this evaluation via Raft
+	_, modifyIndex, err := j.srv.raftApply(structs.JobStabilityRequestType, args)
+	if err != nil {
+		j.srv.logger.Printf("[ERR] nomad.job: Eval create failed: %v", err)
+		return err
+	}
+
+	// Setup the reply
+	reply.JobModifyIndex = modifyIndex
+	reply.Index = modifyIndex
+	return nil
 }
 
 // Evaluate is used to force a job for re-evaluation
@@ -452,7 +492,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 
 	// Validate the arguments
 	if args.JobID == "" {
-		return fmt.Errorf("missing job ID for evaluation")
+		return fmt.Errorf("missing job ID for deregistering")
 	}
 
 	// Lookup the job

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -873,13 +873,15 @@ func (s *StateStore) jobVersionByID(txn *memdb.Txn, ws *memdb.WatchSet, id strin
 	return all, nil
 }
 
-// JobByIDAndVersion returns the job identified by its ID and Version
+// JobByIDAndVersion returns the job identified by its ID and Version. The
+// passed watchset may be nil.
 func (s *StateStore) JobByIDAndVersion(ws memdb.WatchSet, id string, version uint64) (*structs.Job, error) {
 	txn := s.db.Txn(false)
 	return s.jobByIDAndVersionImpl(ws, id, version, txn)
 }
 
-// jobByIDAndVersionImpl returns the job identified by its ID and Version
+// jobByIDAndVersionImpl returns the job identified by its ID and Version. The
+// passed watchset may be nil.
 func (s *StateStore) jobByIDAndVersionImpl(ws memdb.WatchSet, id string, version uint64, txn *memdb.Txn) (*structs.Job, error) {
 	watchCh, existing, err := txn.FirstWatch("job_version", "id", id, version)
 	if err != nil {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -138,30 +138,10 @@ func (s *StateStore) UpsertPlanResults(index uint64, results *structs.ApplyPlanR
 // upsertDeploymentUpdates updates the deployments given the passed status
 // updates.
 func (s *StateStore) upsertDeploymentUpdates(index uint64, updates []*structs.DeploymentStatusUpdate, txn *memdb.Txn) error {
-	for _, d := range updates {
-		raw, err := txn.First("deployment", "id", d.DeploymentID)
-		if err != nil {
+	for _, u := range updates {
+		if err := s.updateDeploymentStatusImpl(index, u, txn); err != nil {
 			return err
 		}
-		if raw == nil {
-			return fmt.Errorf("Deployment ID %q couldn't be updated as it does not exist", d.DeploymentID)
-		}
-
-		copy := raw.(*structs.Deployment).Copy()
-
-		// Apply the new status
-		copy.Status = d.Status
-		copy.StatusDescription = d.StatusDescription
-		copy.ModifyIndex = index
-
-		// Insert the deployment
-		if err := txn.Insert("deployment", copy); err != nil {
-			return err
-		}
-	}
-
-	if err := txn.Insert("index", &IndexEntry{"deployment", index}); err != nil {
-		return fmt.Errorf("index update failed: %v", err)
 	}
 
 	return nil
@@ -254,6 +234,13 @@ func (s *StateStore) upsertDeploymentImpl(index uint64, deployment *structs.Depl
 	// Update the indexes table for deployment
 	if err := txn.Insert("index", &IndexEntry{"deployment", index}); err != nil {
 		return fmt.Errorf("index update failed: %v", err)
+	}
+
+	// If the deployment is being marked as complete, set the job to stable.
+	if deployment.Status == structs.DeploymentStatusSuccessful {
+		if err := s.updateJobStability(index, deployment, txn); err != nil {
+			return fmt.Errorf("failed to update job stability: %v", err)
+		}
 	}
 
 	return nil
@@ -569,7 +556,7 @@ func (s *StateStore) Nodes(ws memdb.WatchSet) (memdb.ResultIterator, error) {
 func (s *StateStore) UpsertJob(index uint64, job *structs.Job) error {
 	txn := s.db.Txn(true)
 	defer txn.Abort()
-	if err := s.upsertJobImpl(index, job, txn); err != nil {
+	if err := s.upsertJobImpl(index, job, false, txn); err != nil {
 		return err
 	}
 	txn.Commit()
@@ -577,7 +564,7 @@ func (s *StateStore) UpsertJob(index uint64, job *structs.Job) error {
 }
 
 // upsertJobImpl is the inplementation for registering a job or updating a job definition
-func (s *StateStore) upsertJobImpl(index uint64, job *structs.Job, txn *memdb.Txn) error {
+func (s *StateStore) upsertJobImpl(index uint64, job *structs.Job, keepVersion bool, txn *memdb.Txn) error {
 	// Check if the job already exists
 	existing, err := txn.First("jobs", "id", job.ID)
 	if err != nil {
@@ -589,7 +576,13 @@ func (s *StateStore) upsertJobImpl(index uint64, job *structs.Job, txn *memdb.Tx
 		job.CreateIndex = existing.(*structs.Job).CreateIndex
 		job.ModifyIndex = index
 		job.JobModifyIndex = index
-		job.Version = existing.(*structs.Job).Version + 1
+
+		// Bump the version unless asked to keep it. This should only be done
+		// when changing an internal field such as Stable. A spec change should
+		// always come with a version bump
+		if !keepVersion {
+			job.Version = existing.(*structs.Job).Version + 1
+		}
 
 		// Compute the job status
 		var err error
@@ -883,12 +876,19 @@ func (s *StateStore) jobVersionByID(txn *memdb.Txn, ws *memdb.WatchSet, id strin
 // JobByIDAndVersion returns the job identified by its ID and Version
 func (s *StateStore) JobByIDAndVersion(ws memdb.WatchSet, id string, version uint64) (*structs.Job, error) {
 	txn := s.db.Txn(false)
+	return s.jobByIDAndVersionImpl(ws, id, version, txn)
+}
+
+// jobByIDAndVersionImpl returns the job identified by its ID and Version
+func (s *StateStore) jobByIDAndVersionImpl(ws memdb.WatchSet, id string, version uint64, txn *memdb.Txn) (*structs.Job, error) {
 	watchCh, existing, err := txn.FirstWatch("job_version", "id", id, version)
 	if err != nil {
 		return nil, err
 	}
 
-	ws.Add(watchCh)
+	if ws != nil {
+		ws.Add(watchCh)
+	}
 
 	if existing != nil {
 		job := existing.(*structs.Job)
@@ -1844,7 +1844,7 @@ func (s *StateStore) UpdateDeploymentStatus(index uint64, req *structs.Deploymen
 
 	// Upsert the job if necessary
 	if req.Job != nil {
-		if err := s.upsertJobImpl(index, req.Job, txn); err != nil {
+		if err := s.upsertJobImpl(index, req.Job, false, txn); err != nil {
 			return err
 		}
 	}
@@ -1889,7 +1889,43 @@ func (s *StateStore) updateDeploymentStatusImpl(index uint64, u *structs.Deploym
 		return fmt.Errorf("index update failed: %v", err)
 	}
 
+	// If the deployment is being marked as complete, set the job to stable.
+	if copy.Status == structs.DeploymentStatusSuccessful {
+		if err := s.updateJobStability(index, copy, txn); err != nil {
+			return fmt.Errorf("failed to update job stability: %v", err)
+		}
+	}
+
 	return nil
+}
+
+// updateJobStability updates the job version referenced by a successful
+// deployment to stable.
+func (s *StateStore) updateJobStability(index uint64, deployment *structs.Deployment, txn *memdb.Txn) error {
+	// Hot-path
+	if deployment.Status != structs.DeploymentStatusSuccessful {
+		return nil
+	}
+
+	// Get the job that is referenced
+	job, err := s.jobByIDAndVersionImpl(nil, deployment.JobID, deployment.JobVersion, txn)
+	if err != nil {
+		return err
+	}
+
+	// Has already been cleared, nothing to do
+	if job == nil {
+		return nil
+	}
+
+	// If the job is already stable, nothing to do
+	if job.Stable {
+		return nil
+	}
+
+	copy := job.Copy()
+	copy.Stable = true
+	return s.upsertJobImpl(index, copy, true, txn)
 }
 
 // UpdateDeploymentPromotion is used to promote canaries in a deployment and
@@ -1970,13 +2006,8 @@ func (s *StateStore) UpdateDeploymentPromotion(index uint64, req *structs.ApplyD
 	}
 
 	// Insert the deployment
-	if err := txn.Insert("deployment", copy); err != nil {
+	if err := s.upsertDeploymentImpl(index, copy, txn); err != nil {
 		return err
-	}
-
-	// Update the index
-	if err := txn.Insert("index", &IndexEntry{"deployment", index}); err != nil {
-		return fmt.Errorf("index update failed: %v", err)
 	}
 
 	// Upsert the optional eval
@@ -2068,7 +2099,7 @@ func (s *StateStore) UpdateDeploymentAllocHealth(index uint64, req *structs.Appl
 
 	// Upsert the job if necessary
 	if req.Job != nil {
-		if err := s.upsertJobImpl(index, req.Job, txn); err != nil {
+		if err := s.upsertJobImpl(index, req.Job, false, txn); err != nil {
 			return err
 		}
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -4809,6 +4809,57 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Successful(t *testing.T) {
 	}
 }
 
+func TestStateStore_UpdateJobStability(t *testing.T) {
+	state := testStateStore(t)
+
+	// Insert a job twice to get two versions
+	job := mock.Job()
+	if err := state.UpsertJob(1, job); err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	if err := state.UpsertJob(2, job); err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Update the stability to true
+	err := state.UpdateJobStability(3, job.ID, 0, true)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Check that the job was updated properly
+	ws := memdb.NewWatchSet()
+	jout, _ := state.JobByIDAndVersion(ws, job.ID, 0)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+	if jout == nil {
+		t.Fatalf("bad: %#v", jout)
+	}
+	if !jout.Stable {
+		t.Fatalf("job not marked stable %#v", jout)
+	}
+
+	// Update the stability to false
+	err = state.UpdateJobStability(3, job.ID, 0, false)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Check that the job was updated properly
+	jout, _ = state.JobByIDAndVersion(ws, job.ID, 0)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+	if jout == nil {
+		t.Fatalf("bad: %#v", jout)
+	}
+	if jout.Stable {
+		t.Fatalf("job marked stable %#v", jout)
+	}
+}
+
 // Test that non-existant deployment can't be promoted
 func TestStateStore_UpsertDeploymentPromotion_NonExistant(t *testing.T) {
 	state := testStateStore(t)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -4752,6 +4752,63 @@ func TestStateStore_UpsertDeploymentStatusUpdate_NonTerminal(t *testing.T) {
 	}
 }
 
+// Test that when a deployment is updated to successful the job is updated to
+// stable
+func TestStateStore_UpsertDeploymentStatusUpdate_Successful(t *testing.T) {
+	state := testStateStore(t)
+
+	// Insert a job
+	job := mock.Job()
+	if err := state.UpsertJob(1, job); err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Insert a deployment
+	d := structs.NewDeployment(job)
+	if err := state.UpsertDeployment(2, d); err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Update the deployment
+	req := &structs.DeploymentStatusUpdateRequest{
+		DeploymentUpdate: &structs.DeploymentStatusUpdate{
+			DeploymentID:      d.ID,
+			Status:            structs.DeploymentStatusSuccessful,
+			StatusDescription: structs.DeploymentStatusDescriptionSuccessful,
+		},
+	}
+	err := state.UpdateDeploymentStatus(3, req)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Check that the status was updated properly
+	ws := memdb.NewWatchSet()
+	dout, err := state.DeploymentByID(ws, d.ID)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+	if dout.Status != structs.DeploymentStatusSuccessful ||
+		dout.StatusDescription != structs.DeploymentStatusDescriptionSuccessful {
+		t.Fatalf("bad: %#v", dout)
+	}
+
+	// Check that the job was created
+	jout, _ := state.JobByID(ws, job.ID)
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+	if jout == nil {
+		t.Fatalf("bad: %#v", jout)
+	}
+	if !jout.Stable {
+		t.Fatalf("job not marked stable %#v", jout)
+	}
+	if jout.Version != d.JobVersion {
+		t.Fatalf("job version changed; got %d; want %d", jout.Version, d.JobVersion)
+	}
+}
+
 // Test that non-existant deployment can't be promoted
 func TestStateStore_UpsertDeploymentPromotion_NonExistant(t *testing.T) {
 	state := testStateStore(t)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -58,6 +58,7 @@ const (
 	DeploymentPromoteRequestType
 	DeploymentAllocHealthRequestType
 	DeploymentDeleteRequestType
+	JobStabilityRequestType
 )
 
 const (
@@ -312,6 +313,23 @@ type JobRevertRequest struct {
 	EnforcePriorVersion *uint64
 
 	WriteRequest
+}
+
+// JobStabilityRequest is used to marked a job as stable.
+type JobStabilityRequest struct {
+	// Job to set the stability on
+	JobID      string
+	JobVersion uint64
+
+	// Set the stability
+	Stable bool
+	WriteRequest
+}
+
+// JobStabilityResponse is the response when marking a job as stable.
+type JobStabilityResponse struct {
+	JobModifyIndex uint64
+	WriteMeta
 }
 
 // NodeListRequest is used to parameterize a list request

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -28,7 +28,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `prefix` `(string: "")`- Specifies a string to filter jobs on based on
+- `prefix` `(string: "")` - Specifies a string to filter jobs on based on
   an index prefix. This is specified as a querystring parameter.
 
 ### Sample Request
@@ -149,7 +149,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
 ### Sample Request
@@ -363,7 +363,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
 ### Sample Request
@@ -535,7 +535,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
 ### Sample Request
@@ -687,7 +687,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
 ### Sample Request
@@ -730,6 +730,151 @@ $ curl \
 ]
 ```
 
+## List Job Deployments
+
+This endpoint lists a single job's deployments
+
+| Method | Path                          | Produces                   |
+| ------ | ----------------------------- | -------------------------- |
+| `GET`  | `/v1/job/:job_id/deployments` | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries) and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `YES`            | `none`       |
+
+### Parameters
+
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
+  the job file during submission). This is specified as part of the path.
+
+### Sample Request
+
+```text
+$ curl \
+    https://nomad.rocks/v1/job/my-job/deployments
+```
+
+### Sample Response
+
+```json
+[
+  {
+    "ID": "85ee4a9a-339f-a921-a9ef-0550d20b2c61",
+    "JobID": "my-job",
+    "JobVersion": 1,
+    "JobModifyIndex": 19,
+    "JobCreateIndex": 7,
+    "TaskGroups": {
+      "cache": {
+        "AutoRevert": true,
+        "Promoted": false,
+        "PlacedCanaries": [
+          "d0ad0808-2765-abf6-1e15-79fb7fe5a416",
+          "38c70cd8-81f2-1489-a328-87bb29ec0e0f"
+        ],
+        "DesiredCanaries": 2,
+        "DesiredTotal": 3,
+        "PlacedAllocs": 2,
+        "HealthyAllocs": 2,
+        "UnhealthyAllocs": 0
+      }
+    },
+    "Status": "running",
+    "StatusDescription": "Deployment is running",
+    "CreateIndex": 21,
+    "ModifyIndex": 25
+  },
+  {
+    "ID": "fb6070fb-4a44-e255-4e6f-8213eba3871a",
+    "JobID": "my-job",
+    "JobVersion": 0,
+    "JobModifyIndex": 7,
+    "JobCreateIndex": 7,
+    "TaskGroups": {
+      "cache": {
+        "AutoRevert": true,
+        "Promoted": false,
+        "PlacedCanaries": null,
+        "DesiredCanaries": 0,
+        "DesiredTotal": 3,
+        "PlacedAllocs": 3,
+        "HealthyAllocs": 3,
+        "UnhealthyAllocs": 0
+      }
+    },
+    "Status": "successful",
+    "StatusDescription": "Deployment completed successfully",
+    "CreateIndex": 9,
+    "ModifyIndex": 17
+  }
+]
+```
+
+
+## Read Job's Most Recent Deployment
+
+This endpoint returns a single job's most recent deployment.
+
+| Method | Path                          | Produces                   |
+| ------ | ----------------------------- | -------------------------- |
+| `GET`  | `/v1/job/:job_id/deployment` | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries) and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `YES`            | `none`       |
+
+### Parameters
+
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
+  the job file during submission). This is specified as part of the path.
+
+### Sample Request
+
+```text
+$ curl \
+    https://nomad.rocks/v1/job/my-job/deployments
+```
+
+### Sample Response
+
+```json
+{
+  "ID": "85ee4a9a-339f-a921-a9ef-0550d20b2c61",
+  "JobID": "my-job",
+  "JobVersion": 1,
+  "JobModifyIndex": 19,
+  "JobCreateIndex": 7,
+  "TaskGroups": {
+    "cache": {
+      "AutoRevert": true,
+      "Promoted": false,
+      "PlacedCanaries": [
+        "d0ad0808-2765-abf6-1e15-79fb7fe5a416",
+        "38c70cd8-81f2-1489-a328-87bb29ec0e0f"
+      ],
+      "DesiredCanaries": 2,
+      "DesiredTotal": 3,
+      "PlacedAllocs": 2,
+      "HealthyAllocs": 2,
+      "UnhealthyAllocs": 0
+    }
+  },
+  "Status": "running",
+  "StatusDescription": "Deployment is running",
+  "CreateIndex": 21,
+  "ModifyIndex": 25
+}
+```
+
+
 ## Read Job Summary
 
 This endpoint reads summary information about a job.
@@ -748,7 +893,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
 ### Sample Request
@@ -801,7 +946,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
 - `Job` `(Job: <required>)` - Specifies the JSON definition of the job.
@@ -863,8 +1008,8 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
-  the job file during submission). This is specified as part of the path.
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified
+  in the job file during submission). This is specified as part of the path.
 
 - `Payload` `(string: "")` - Specifies a base64 encoded string containing the
   payload. This is limited to 15 KB.
@@ -889,7 +1034,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request POST \
     --payload @payload.json \
-    https://nomad.rocks/v1/job/my-job/summary
+    https://nomad.rocks/v1/job/my-job/dispatch
 ```
 
 ### Sample Response
@@ -901,6 +1046,115 @@ $ curl \
   "EvalCreateIndex": 13,
   "EvalID": "e5f55fac-bc69-119d-528a-1fc7ade5e02c",
   "DispatchedJobID": "example/dispatch-1485408778-81644024"
+}
+```
+
+## Revert to older Job Version
+
+This endpoint reverts the job to an older version.
+
+| Method  | Path                       | Produces                   |
+| ------- | -------------------------- | -------------------------- |
+| `POST`  | `/v1/job/:job_id/revert` | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries) and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `none`       |
+
+### Parameters
+
+- `JobID` `(string: <required>)` - Specifies the ID of the job (as specified
+  in the job file during submission). This is specified as part of the path.
+
+- `JobVersion` `(integer: 0) - Specifies the job version to revert to.
+
+- `EnforcePriorVersion` `(integer: nil)` - Optional value specifying the current
+  job's version. This is checked and acts as a check-and-set value before
+  reverting to the specified job.
+
+### Sample Payload
+
+```json
+{
+  "JobID": "my-job",
+  "JobVersion": 2,
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request POST \
+    --payload @payload.json \
+    https://nomad.rocks/v1/job/my-job/revert
+```
+
+### Sample Response
+
+```json
+{
+  "EvalID": "d092fdc0-e1fd-2536-67d8-43af8ca798ac",
+  "EvalCreateIndex": 35,
+  "JobModifyIndex": 34,
+}
+```
+
+
+## Set Job Stability
+
+This endpoint sets the job's stability.
+
+| Method  | Path                       | Produces                   |
+| ------- | -------------------------- | -------------------------- |
+| `POST`  | `/v1/job/:job_id/stable` | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries) and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `none`       |
+
+### Parameters
+
+- `JobID` `(string: <required>)` - Specifies the ID of the job (as specified
+  in the job file during submission). This is specified as part of the path.
+
+- `JobVersion` `(integer: 0) - Specifies the job version to set the stability on.
+
+- `Stable` `(bool: false)` - Specifies whether the job should be marked as
+  stable or not.
+
+### Sample Payload
+
+```json
+{
+  "JobID": "my-job",
+  "JobVersion": 2,
+  "Stable": true
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request POST \
+    --payload @payload.json \
+    https://nomad.rocks/v1/job/my-job/stable
+```
+
+### Sample Response
+
+```json
+{
+  "JobModifyIndex": 34,
 }
 ```
 
@@ -924,7 +1178,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
 ### Sample Request
@@ -963,7 +1217,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
 - the job file during submission). This is specified as part of the path.
 
 - `Job` `(string: <required>)` - Specifies the JSON definition of the job.
@@ -1141,14 +1395,14 @@ $ curl \
   which in turn contain Task Diffs. Each of these objects then has Object and
   Field Diff structures embedded.
 
-- `NextPeriodicLaunch`- If the job being planned is periodic, this field will
+- `NextPeriodicLaunch` - If the job being planned is periodic, this field will
   include the next launch time for the job.
 
 - `CreatedEvals` - A set of evaluations that were created as a result of the
   dry-run. These evaluations can signify a follow-up rolling update evaluation
   or a blocked evaluation.
 
-- `JobModifyIndex`- The `JobModifyIndex` of the server side version of this job.
+- `JobModifyIndex` - The `JobModifyIndex` of the server side version of this job.
 
 - `FailedTGAllocs` - A set of metrics to understand any allocation failures that
   occurred for the Task Group.
@@ -1178,7 +1432,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
 ### Sample Request
@@ -1216,7 +1470,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:job_id` `(string: <required>)`- Specifies the ID of the job (as specified in
+- `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
 ### Sample Request

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -821,7 +821,7 @@ This endpoint returns a single job's most recent deployment.
 
 | Method | Path                          | Produces                   |
 | ------ | ----------------------------- | -------------------------- |
-| `GET`  | `/v1/job/:job_id/deployment` | `application/json`         |
+| `GET`  | `/v1/job/:job_id/deployment`  | `application/json`         |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and
@@ -1070,7 +1070,7 @@ The table below shows this endpoint's support for
 - `JobID` `(string: <required>)` - Specifies the ID of the job (as specified
   in the job file during submission). This is specified as part of the path.
 
-- `JobVersion` `(integer: 0) - Specifies the job version to revert to.
+- `JobVersion` `(integer: 0)` - Specifies the job version to revert to.
 
 - `EnforcePriorVersion` `(integer: nil)` - Optional value specifying the current
   job's version. This is checked and acts as a check-and-set value before
@@ -1111,7 +1111,7 @@ This endpoint sets the job's stability.
 
 | Method  | Path                       | Produces                   |
 | ------- | -------------------------- | -------------------------- |
-| `POST`  | `/v1/job/:job_id/stable` | `application/json`         |
+| `POST`  | `/v1/job/:job_id/stable`   | `application/json`         |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and
@@ -1126,7 +1126,7 @@ The table below shows this endpoint's support for
 - `JobID` `(string: <required>)` - Specifies the ID of the job (as specified
   in the job file during submission). This is specified as part of the path.
 
-- `JobVersion` `(integer: 0) - Specifies the job version to set the stability on.
+- `JobVersion` `(integer: 0)` - Specifies the job version to set the stability on.
 
 - `Stable` `(bool: false)` - Specifies whether the job should be marked as
   stable or not.


### PR DESCRIPTION
This PR allows jobs to be marked as stable automatically by a successful deployment and manually via the HTTP API.