### PR TITLE
Disallow update stanza on batch jobs

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -290,8 +290,7 @@ type periodicForceResponse struct {
 
 // UpdateStrategy defines a task groups update strategy.
 type UpdateStrategy struct {
-	// COMPAT: Remove in 0.7.0. Stagger is deprecated in 0.6.0.
-	Stagger         time.Duration  `mapstructure:"stagger"`
+	Stagger         *time.Duration `mapstructure:"stagger"`
 	MaxParallel     *int           `mapstructure:"max_parallel"`
 	HealthCheck     *string        `mapstructure:"health_check"`
 	MinHealthyTime  *time.Duration `mapstructure:"min_healthy_time"`
@@ -307,8 +306,9 @@ func (u *UpdateStrategy) Copy() *UpdateStrategy {
 
 	copy := new(UpdateStrategy)
 
-	// COMPAT: Remove in 0.7.0. Stagger is deprecated in 0.6.0.
-	copy.Stagger = u.Stagger
+	if u.Stagger != nil {
+		copy.Stagger = helper.TimeToPtr(*u.Stagger)
+	}
 
 	if u.MaxParallel != nil {
 		copy.MaxParallel = helper.IntToPtr(*u.MaxParallel)
@@ -342,6 +342,10 @@ func (u *UpdateStrategy) Merge(o *UpdateStrategy) {
 		return
 	}
 
+	if o.Stagger != nil {
+		u.Stagger = helper.TimeToPtr(*o.Stagger)
+	}
+
 	if o.MaxParallel != nil {
 		u.MaxParallel = helper.IntToPtr(*o.MaxParallel)
 	}
@@ -373,6 +377,10 @@ func (u *UpdateStrategy) Canonicalize() {
 	}
 
 	d := structs.DefaultUpdateStrategy
+
+	if u.Stagger == nil {
+		u.Stagger = helper.TimeToPtr(d.Stagger)
+	}
 
 	if u.HealthCheck == nil {
 		u.HealthCheck = helper.StringToPtr(d.HealthCheck)
@@ -529,9 +537,6 @@ func (j *Job) Canonicalize() {
 	}
 	if j.Version == nil {
 		j.Version = helper.Uint64ToPtr(0)
-	}
-	if j.SubmitTime == nil {
-		j.SubmitTime = helper.Int64ToPtr(0)
 	}
 	if j.CreateIndex == nil {
 		j.CreateIndex = helper.Uint64ToPtr(0)

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -298,6 +298,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 				JobModifyIndex:    helper.Uint64ToPtr(0),
 				Datacenters:       []string{"dc1"},
 				Update: &UpdateStrategy{
+					Stagger:         helper.TimeToPtr(30 * time.Second),
 					MaxParallel:     helper.IntToPtr(1),
 					HealthCheck:     helper.StringToPtr("checks"),
 					MinHealthyTime:  helper.TimeToPtr(10 * time.Second),
@@ -322,6 +323,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 
 						Update: &UpdateStrategy{
+							Stagger:         helper.TimeToPtr(30 * time.Second),
 							MaxParallel:     helper.IntToPtr(1),
 							HealthCheck:     helper.StringToPtr("checks"),
 							MinHealthyTime:  helper.TimeToPtr(10 * time.Second),
@@ -444,6 +446,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 				ID:       helper.StringToPtr("bar"),
 				ParentID: helper.StringToPtr("lol"),
 				Update: &UpdateStrategy{
+					Stagger:         helper.TimeToPtr(1 * time.Second),
 					MaxParallel:     helper.IntToPtr(1),
 					HealthCheck:     helper.StringToPtr("checks"),
 					MinHealthyTime:  helper.TimeToPtr(10 * time.Second),
@@ -455,6 +458,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 					{
 						Name: helper.StringToPtr("bar"),
 						Update: &UpdateStrategy{
+							Stagger:        helper.TimeToPtr(2 * time.Second),
 							MaxParallel:    helper.IntToPtr(2),
 							HealthCheck:    helper.StringToPtr("manual"),
 							MinHealthyTime: helper.TimeToPtr(1 * time.Second),
@@ -495,6 +499,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 				ModifyIndex:       helper.Uint64ToPtr(0),
 				JobModifyIndex:    helper.Uint64ToPtr(0),
 				Update: &UpdateStrategy{
+					Stagger:         helper.TimeToPtr(1 * time.Second),
 					MaxParallel:     helper.IntToPtr(1),
 					HealthCheck:     helper.StringToPtr("checks"),
 					MinHealthyTime:  helper.TimeToPtr(10 * time.Second),
@@ -518,6 +523,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 							Mode:     helper.StringToPtr("delay"),
 						},
 						Update: &UpdateStrategy{
+							Stagger:         helper.TimeToPtr(2 * time.Second),
 							MaxParallel:     helper.IntToPtr(2),
 							HealthCheck:     helper.StringToPtr("manual"),
 							MinHealthyTime:  helper.TimeToPtr(1 * time.Second),
@@ -549,6 +555,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 							Mode:     helper.StringToPtr("delay"),
 						},
 						Update: &UpdateStrategy{
+							Stagger:         helper.TimeToPtr(1 * time.Second),
 							MaxParallel:     helper.IntToPtr(1),
 							HealthCheck:     helper.StringToPtr("checks"),
 							MinHealthyTime:  helper.TimeToPtr(10 * time.Second),
@@ -574,8 +581,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.input.Canonicalize()
 			if !reflect.DeepEqual(tc.input, tc.expected) {
-				t.Logf("Name: %v, Diffs:\n%v", tc.name, pretty.Diff(tc.expected, tc.input))
-				t.Fatalf("Name: %v, expected:\n%#v\nactual:\n%#v", tc.name, tc.expected, tc.input)
+				t.Fatalf("Name: %v, Diffs:\n%v", tc.name, pretty.Diff(tc.expected, tc.input))
 			}
 		})
 	}
@@ -665,6 +671,7 @@ func TestJobs_Revert(t *testing.T) {
 	}
 	assertWriteMeta(t, wm)
 
+	job.Meta = map[string]string{"foo": "new"}
 	resp, wm, err = jobs.Register(job, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -562,8 +562,10 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 
 	// COMPAT: Remove in 0.7.0. Update has been pushed into the task groups
 	if job.Update != nil {
-		j.Update = structs.UpdateStrategy{
-			Stagger: job.Update.Stagger,
+		j.Update = structs.UpdateStrategy{}
+
+		if job.Update.Stagger != nil {
+			j.Update.Stagger = *job.Update.Stagger
 		}
 		if job.Update.MaxParallel != nil {
 			j.Update.MaxParallel = *job.Update.MaxParallel
@@ -632,6 +634,7 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 
 	if taskGroup.Update != nil {
 		tg.Update = &structs.UpdateStrategy{
+			Stagger:         *taskGroup.Update.Stagger,
 			MaxParallel:     *taskGroup.Update.MaxParallel,
 			HealthCheck:     *taskGroup.Update.HealthCheck,
 			MinHealthyTime:  *taskGroup.Update.MinHealthyTime,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -884,6 +885,8 @@ func TestHTTP_JobRevert(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
+		// Change the job to get a new version
+		job.Datacenters = append(job.Datacenters, "foo")
 		if err := s.Agent.RPC("Job.Register", &regReq, &regResp); err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -991,7 +994,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 			},
 		},
 		Update: &api.UpdateStrategy{
-			Stagger:         1 * time.Second,
+			Stagger:         helper.TimeToPtr(1 * time.Second),
 			MaxParallel:     helper.IntToPtr(5),
 			HealthCheck:     helper.StringToPtr(structs.UpdateStrategyHealthCheck_Manual),
 			MinHealthyTime:  helper.TimeToPtr(1 * time.Minute),
@@ -1224,6 +1227,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 					Migrate: true,
 				},
 				Update: &structs.UpdateStrategy{
+					Stagger:         1 * time.Second,
 					MaxParallel:     5,
 					HealthCheck:     structs.UpdateStrategyHealthCheck_Checks,
 					MinHealthyTime:  2 * time.Minute,
@@ -1346,6 +1350,6 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 	structsJob := ApiJobToStructJob(apiJob)
 
 	if !reflect.DeepEqual(expected, structsJob) {
-		t.Fatalf("bad %#v", structsJob)
+		t.Fatalf("bad %#v", pretty.Diff(expected, structsJob))
 	}
 }

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -70,7 +70,7 @@ func TestAllocStatusCommand_Fails(t *testing.T) {
 	if code := cmd.Run([]string{"-address=" + url, "-json", "-t", "{{.ID}}"}); code != 1 {
 		t.Fatalf("expected exit 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both -json and -t are not allowed") {
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both json and template formatting are not allowed") {
 		t.Fatalf("expected getting formatter error, got: %s", out)
 	}
 }

--- a/command/eval_status_test.go
+++ b/command/eval_status_test.go
@@ -49,7 +49,7 @@ func TestEvalStatusCommand_Fails(t *testing.T) {
 	if code := cmd.Run([]string{"-address=" + url, "-json", "-t", "{{.ID}}"}); code != 1 {
 		t.Fatalf("expected exit 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both -json and -t are not allowed") {
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both json and template formatting are not allowed") {
 		t.Fatalf("expected getting formatter error, got: %s", out)
 	}
 

--- a/command/inspect_test.go
+++ b/command/inspect_test.go
@@ -49,7 +49,7 @@ func TestInspectCommand_Fails(t *testing.T) {
 	if code := cmd.Run([]string{"-address=" + url, "-json", "-t", "{{.ID}}"}); code != 1 {
 		t.Fatalf("expected exit 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both -json and -t are not allowed") {
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both json and template formatting are not allowed") {
 		t.Fatalf("expected getting formatter error, got: %s", out)
 	}
 }

--- a/command/job_revert_test.go
+++ b/command/job_revert_test.go
@@ -24,7 +24,7 @@ func TestJobRevertCommand_Fails(t *testing.T) {
 	}
 	ui.ErrorWriter.Reset()
 
-	if code := cmd.Run([]string{"-address=nope", "foo"}); code != 1 {
+	if code := cmd.Run([]string{"-address=nope", "foo", "1"}); code != 1 {
 		t.Fatalf("expected exit code 1, got: %d", code)
 	}
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error listing jobs") {

--- a/command/node_status_test.go
+++ b/command/node_status_test.go
@@ -206,7 +206,7 @@ func TestNodeStatusCommand_Fails(t *testing.T) {
 	if code := cmd.Run([]string{"-address=" + url, "-json", "-t", "{{.ID}}"}); code != 1 {
 		t.Fatalf("expected exit 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both -json and -t are not allowed") {
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both json and template formatting are not allowed") {
 		t.Fatalf("expected getting formatter error, got: %s", out)
 	}
 }

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -57,7 +57,7 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 	}
 
 	// Initialize the job fields (sets defaults and any necessary init work).
-	args.Job.Canonicalize()
+	canonicalizeWarnings := args.Job.Canonicalize()
 
 	// Add implicit constraints
 	setImplicitConstraints(args.Job)
@@ -66,9 +66,10 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 	err, warnings := validateJob(args.Job)
 	if err != nil {
 		return err
-	} else if warnings != nil {
-		reply.Warnings = warnings.Error()
 	}
+
+	// Set the warning message
+	reply.Warnings = structs.MergeMultierrorWarnings(warnings, canonicalizeWarnings)
 
 	// Lookup the current job
 	snap, err := j.srv.fsm.State().Snapshot()
@@ -302,6 +303,13 @@ func (j *Job) Summary(args *structs.JobSummaryRequest,
 func (j *Job) Validate(args *structs.JobValidateRequest, reply *structs.JobValidateResponse) error {
 	defer metrics.MeasureSince([]string{"nomad", "job", "validate"}, time.Now())
 
+	// Initialize the job fields (sets defaults and any necessary init work).
+	canonicalizeWarnings := args.Job.Canonicalize()
+
+	// Add implicit constraints
+	setImplicitConstraints(args.Job)
+
+	// Validate the job and capture any warnings
 	err, warnings := validateJob(args.Job)
 	if err != nil {
 		if merr, ok := err.(*multierror.Error); ok {
@@ -315,10 +323,8 @@ func (j *Job) Validate(args *structs.JobValidateRequest, reply *structs.JobValid
 		}
 	}
 
-	if warnings != nil {
-		reply.Warnings = warnings.Error()
-	}
-
+	// Set the warning message
+	reply.Warnings = structs.MergeMultierrorWarnings(warnings, canonicalizeWarnings)
 	reply.DriverConfigValidated = true
 	return nil
 }
@@ -863,7 +869,7 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 	}
 
 	// Initialize the job fields (sets defaults and any necessary init work).
-	args.Job.Canonicalize()
+	canonicalizeWarnings := args.Job.Canonicalize()
 
 	// Add implicit constraints
 	setImplicitConstraints(args.Job)
@@ -872,9 +878,10 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 	err, warnings := validateJob(args.Job)
 	if err != nil {
 		return err
-	} else if warnings != nil {
-		reply.Warnings = warnings.Error()
 	}
+
+	// Set the warning message
+	reply.Warnings = structs.MergeMultierrorWarnings(warnings, canonicalizeWarnings)
 
 	// Acquire a snapshot of the state
 	snap, err := j.srv.fsm.State().Snapshot()

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -101,18 +101,7 @@ func TestJob_Warnings(t *testing.T) {
 		Name     string
 		Job      *Job
 		Expected []string
-	}{
-		{
-			Name: "Old Update spec",
-			Job: &Job{
-				Update: UpdateStrategy{
-					MaxParallel: 2,
-					Stagger:     10 * time.Second,
-				},
-			},
-			Expected: []string{"Update stagger deprecated"},
-		},
-	}
+	}{}
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -140,10 +129,13 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 		Name     string
 		Job      *Job
 		Expected *Job
+		Warnings []string
 	}{
 		{
-			Name: "One task group",
+			Name:     "One task group",
+			Warnings: []string{"conversion to new update stanza"},
 			Job: &Job{
+				Type: JobTypeService,
 				Update: UpdateStrategy{
 					MaxParallel: 2,
 					Stagger:     10 * time.Second,
@@ -156,6 +148,7 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 				},
 			},
 			Expected: &Job{
+				Type: JobTypeService,
 				Update: UpdateStrategy{
 					MaxParallel: 2,
 					Stagger:     10 * time.Second,
@@ -164,8 +157,10 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 					{
 						Name:          "foo",
 						Count:         2,
+						RestartPolicy: NewRestartPolicy(JobTypeService),
 						EphemeralDisk: DefaultEphemeralDisk(),
 						Update: &UpdateStrategy{
+							Stagger:         30 * time.Second,
 							MaxParallel:     2,
 							HealthCheck:     UpdateStrategyHealthCheck_Checks,
 							MinHealthyTime:  10 * time.Second,
@@ -178,8 +173,135 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 			},
 		},
 		{
-			Name: "One task group; too high of parallelism",
+			Name:     "One task group batch",
+			Warnings: []string{"Update stanza is disallowed for batch jobs"},
 			Job: &Job{
+				Type: JobTypeBatch,
+				Update: UpdateStrategy{
+					MaxParallel: 2,
+					Stagger:     10 * time.Second,
+				},
+				TaskGroups: []*TaskGroup{
+					{
+						Name:  "foo",
+						Count: 2,
+					},
+				},
+			},
+			Expected: &Job{
+				Type:   JobTypeBatch,
+				Update: UpdateStrategy{},
+				TaskGroups: []*TaskGroup{
+					{
+						Name:          "foo",
+						Count:         2,
+						RestartPolicy: NewRestartPolicy(JobTypeBatch),
+						EphemeralDisk: DefaultEphemeralDisk(),
+					},
+				},
+			},
+		},
+		{
+			Name:     "One task group batch - new spec",
+			Warnings: []string{"Update stanza is disallowed for batch jobs"},
+			Job: &Job{
+				Type: JobTypeBatch,
+				Update: UpdateStrategy{
+					Stagger:         2 * time.Second,
+					MaxParallel:     2,
+					Canary:          2,
+					MinHealthyTime:  2 * time.Second,
+					HealthyDeadline: 10 * time.Second,
+					HealthCheck:     UpdateStrategyHealthCheck_Checks,
+				},
+				TaskGroups: []*TaskGroup{
+					{
+						Name:  "foo",
+						Count: 2,
+						Update: &UpdateStrategy{
+							Stagger:         2 * time.Second,
+							MaxParallel:     2,
+							Canary:          2,
+							MinHealthyTime:  2 * time.Second,
+							HealthyDeadline: 10 * time.Second,
+							HealthCheck:     UpdateStrategyHealthCheck_Checks,
+						},
+					},
+				},
+			},
+			Expected: &Job{
+				Type:   JobTypeBatch,
+				Update: UpdateStrategy{},
+				TaskGroups: []*TaskGroup{
+					{
+						Name:          "foo",
+						Count:         2,
+						RestartPolicy: NewRestartPolicy(JobTypeBatch),
+						EphemeralDisk: DefaultEphemeralDisk(),
+					},
+				},
+			},
+		},
+		{
+			Name: "One task group service - new spec",
+			Job: &Job{
+				Type: JobTypeService,
+				Update: UpdateStrategy{
+					Stagger:         2 * time.Second,
+					MaxParallel:     2,
+					Canary:          2,
+					MinHealthyTime:  2 * time.Second,
+					HealthyDeadline: 10 * time.Second,
+					HealthCheck:     UpdateStrategyHealthCheck_Checks,
+				},
+				TaskGroups: []*TaskGroup{
+					{
+						Name:  "foo",
+						Count: 2,
+						Update: &UpdateStrategy{
+							Stagger:         2 * time.Second,
+							MaxParallel:     2,
+							Canary:          2,
+							MinHealthyTime:  2 * time.Second,
+							HealthyDeadline: 10 * time.Second,
+							HealthCheck:     UpdateStrategyHealthCheck_Checks,
+						},
+					},
+				},
+			},
+			Expected: &Job{
+				Type: JobTypeService,
+				Update: UpdateStrategy{
+					Stagger:         2 * time.Second,
+					MaxParallel:     2,
+					Canary:          2,
+					MinHealthyTime:  2 * time.Second,
+					HealthyDeadline: 10 * time.Second,
+					HealthCheck:     UpdateStrategyHealthCheck_Checks,
+				},
+				TaskGroups: []*TaskGroup{
+					{
+						Name:          "foo",
+						Count:         2,
+						RestartPolicy: NewRestartPolicy(JobTypeService),
+						EphemeralDisk: DefaultEphemeralDisk(),
+						Update: &UpdateStrategy{
+							Stagger:         2 * time.Second,
+							MaxParallel:     2,
+							Canary:          2,
+							MinHealthyTime:  2 * time.Second,
+							HealthyDeadline: 10 * time.Second,
+							HealthCheck:     UpdateStrategyHealthCheck_Checks,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:     "One task group; too high of parallelism",
+			Warnings: []string{"conversion to new update stanza"},
+			Job: &Job{
+				Type: JobTypeService,
 				Update: UpdateStrategy{
 					MaxParallel: 200,
 					Stagger:     10 * time.Second,
@@ -192,6 +314,7 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 				},
 			},
 			Expected: &Job{
+				Type: JobTypeService,
 				Update: UpdateStrategy{
 					MaxParallel: 200,
 					Stagger:     10 * time.Second,
@@ -200,8 +323,10 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 					{
 						Name:          "foo",
 						Count:         2,
+						RestartPolicy: NewRestartPolicy(JobTypeService),
 						EphemeralDisk: DefaultEphemeralDisk(),
 						Update: &UpdateStrategy{
+							Stagger:         30 * time.Second,
 							MaxParallel:     2,
 							HealthCheck:     UpdateStrategyHealthCheck_Checks,
 							MinHealthyTime:  10 * time.Second,
@@ -214,8 +339,10 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 			},
 		},
 		{
-			Name: "Multiple task group; rounding",
+			Name:     "Multiple task group; rounding",
+			Warnings: []string{"conversion to new update stanza"},
 			Job: &Job{
+				Type: JobTypeService,
 				Update: UpdateStrategy{
 					MaxParallel: 2,
 					Stagger:     10 * time.Second,
@@ -236,6 +363,7 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 				},
 			},
 			Expected: &Job{
+				Type: JobTypeService,
 				Update: UpdateStrategy{
 					MaxParallel: 2,
 					Stagger:     10 * time.Second,
@@ -244,8 +372,10 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 					{
 						Name:          "foo",
 						Count:         2,
+						RestartPolicy: NewRestartPolicy(JobTypeService),
 						EphemeralDisk: DefaultEphemeralDisk(),
 						Update: &UpdateStrategy{
+							Stagger:         30 * time.Second,
 							MaxParallel:     1,
 							HealthCheck:     UpdateStrategyHealthCheck_Checks,
 							MinHealthyTime:  10 * time.Second,
@@ -257,8 +387,10 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 					{
 						Name:          "bar",
 						Count:         14,
+						RestartPolicy: NewRestartPolicy(JobTypeService),
 						EphemeralDisk: DefaultEphemeralDisk(),
 						Update: &UpdateStrategy{
+							Stagger:         30 * time.Second,
 							MaxParallel:     1,
 							HealthCheck:     UpdateStrategyHealthCheck_Checks,
 							MinHealthyTime:  10 * time.Second,
@@ -271,7 +403,9 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 						Name:          "foo",
 						Count:         26,
 						EphemeralDisk: DefaultEphemeralDisk(),
+						RestartPolicy: NewRestartPolicy(JobTypeService),
 						Update: &UpdateStrategy{
+							Stagger:         30 * time.Second,
 							MaxParallel:     3,
 							HealthCheck:     UpdateStrategyHealthCheck_Checks,
 							MinHealthyTime:  10 * time.Second,
@@ -287,9 +421,23 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			c.Job.Canonicalize()
+			warnings := c.Job.Canonicalize()
 			if !reflect.DeepEqual(c.Job, c.Expected) {
-				t.Fatalf("Got %# v; want %# v", pretty.Formatter(c.Job), pretty.Formatter(c.Expected))
+				t.Fatalf("Diff %#v", pretty.Diff(c.Job, c.Expected))
+			}
+
+			wErr := ""
+			if warnings != nil {
+				wErr = warnings.Error()
+			}
+			for _, w := range c.Warnings {
+				if !strings.Contains(wErr, w) {
+					t.Fatalf("Wanted warning %q: got %q", w, wErr)
+				}
+			}
+
+			if len(c.Warnings) == 0 && warnings != nil {
+				t.Fatalf("Wanted no warnings: got %q", wErr)
 			}
 		})
 	}
@@ -636,6 +784,7 @@ func TestJob_RequiredSignals(t *testing.T) {
 }
 
 func TestTaskGroup_Validate(t *testing.T) {
+	j := testJob()
 	tg := &TaskGroup{
 		Count: -1,
 		RestartPolicy: &RestartPolicy{
@@ -645,7 +794,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 			Mode:     RestartPolicyModeDelay,
 		},
 	}
-	err := tg.Validate()
+	err := tg.Validate(j)
 	mErr := err.(*multierror.Error)
 	if !strings.Contains(mErr.Errors[0].Error(), "group name") {
 		t.Fatalf("err: %s", err)
@@ -672,6 +821,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 			Mode:     RestartPolicyModeDelay,
 		},
 		Update: &UpdateStrategy{
+			Stagger:         10 * time.Second,
 			MaxParallel:     3,
 			HealthCheck:     UpdateStrategyHealthCheck_Manual,
 			MinHealthyTime:  1 * time.Second,
@@ -681,7 +831,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 		},
 	}
 
-	err = tg.Validate()
+	err = tg.Validate(j)
 	mErr = err.(*multierror.Error)
 	if !strings.Contains(mErr.Errors[0].Error(), "should have an ephemeral disk object") {
 		t.Fatalf("err: %s", err)
@@ -704,6 +854,13 @@ func TestTaskGroup_Validate(t *testing.T) {
 	if !strings.Contains(mErr.Errors[6].Error(), "Task web validation failed") {
 		t.Fatalf("err: %s", err)
 	}
+
+	// COMPAT: Enable in 0.7.0
+	//j.Type = JobTypeBatch
+	//err = tg.Validate(j)
+	//if !strings.Contains(err.Error(), "does not allow update block") {
+	//t.Fatalf("err: %s", err)
+	//}
 }
 
 func TestTask_Validate(t *testing.T) {


### PR DESCRIPTION
This PR:
* disallows update stanzas on batch jobs
* undeprecates the stagger field
* changes the way warnings are returned