### PR TITLE
Rolling node drains using max_parallel and stagger

### DIFF
--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -2308,10 +2308,11 @@ func TestServiceSched_NodeDrain_UpdateStrategy(t *testing.T) {
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
 	mp := 5
-	job.Update = structs.UpdateStrategy{
-		Stagger:     time.Second,
-		MaxParallel: mp,
-	}
+	u := structs.DefaultUpdateStrategy.Copy()
+	u.MaxParallel = mp
+	u.Stagger = time.Second
+	job.TaskGroups[0].Update = u
+
 	noErr(t, h.State.UpsertJob(h.NextIndex(), job))
 
 	var allocs []*structs.Allocation

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"log"
+	"time"
 
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -84,6 +85,10 @@ type reconcileResults struct {
 	// desiredTGUpdates captures the desired set of changes to make for each
 	// task group.
 	desiredTGUpdates map[string]*structs.DesiredUpdates
+
+	// followupEvalWait is set if there should be a followup eval run after the
+	// given duration
+	followupEvalWait time.Duration
 }
 
 // allocPlaceResult contains the information required to place a single
@@ -332,7 +337,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 
 	// Determine how many we can place
 	canaryState = dstate != nil && dstate.DesiredCanaries != 0 && !dstate.Promoted
-	limit := a.computeLimit(tg, untainted, destructive, canaryState)
+	limit := a.computeLimit(tg, untainted, destructive, migrate, canaryState)
 
 	// Place if:
 	// * The deployment is not paused or failed
@@ -370,28 +375,49 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 		desiredChanges.Ignore += uint64(len(destructive))
 	}
 
-	// TODO Migrations should be done using a stagger and max_parallel.
-	if !a.deploymentFailed {
-		desiredChanges.Migrate += uint64(len(migrate))
+	// Calculate the allowed number of changes and set the desired changes
+	// accordingly.
+	min := helper.IntMin(len(migrate), limit)
+	if !a.deploymentFailed && !a.deploymentPaused {
+		desiredChanges.Migrate += uint64(min)
+		desiredChanges.Ignore += uint64(len(migrate) - min)
 	} else {
 		desiredChanges.Stop += uint64(len(migrate))
 	}
 
-	for _, alloc := range migrate {
+	followup := false
+	migrated := 0
+	for _, alloc := range migrate.nameOrder() {
+		// If the deployment is failed or paused, don't replace it, just mark as stop.
+		if a.deploymentFailed || a.deploymentPaused {
+			a.result.stop = append(a.result.stop, allocStopResult{
+				alloc:             alloc,
+				statusDescription: allocNodeTainted,
+			})
+			continue
+		}
+
+		if migrated >= limit {
+			followup = true
+			break
+		}
+
+		migrated++
 		a.result.stop = append(a.result.stop, allocStopResult{
 			alloc:             alloc,
 			statusDescription: allocMigrating,
 		})
+		a.result.place = append(a.result.place, allocPlaceResult{
+			name:          alloc.Name,
+			canary:        false,
+			taskGroup:     tg,
+			previousAlloc: alloc,
+		})
+	}
 
-		// If the deployment is failed, just stop the allocation
-		if !a.deploymentFailed {
-			a.result.place = append(a.result.place, allocPlaceResult{
-				name:          alloc.Name,
-				canary:        false,
-				taskGroup:     tg,
-				previousAlloc: alloc,
-			})
-		}
+	// We need to create a followup evaluation.
+	if followup && strategy != nil && a.result.followupEvalWait < strategy.Stagger {
+		a.result.followupEvalWait = strategy.Stagger
 	}
 
 	// Create a new deployment if necessary
@@ -473,12 +499,12 @@ func (a *allocReconciler) handleGroupCanaries(all allocSet, desiredChanges *stru
 }
 
 // computeLimit returns the placement limit for a particular group. The inputs
-// are the group definition, the untainted and destructive allocation set and
-// whether we are in a canary state.
-func (a *allocReconciler) computeLimit(group *structs.TaskGroup, untainted, destructive allocSet, canaryState bool) int {
+// are the group definition, the untainted, destructive, and migrate allocation
+// set and whether we are in a canary state.
+func (a *allocReconciler) computeLimit(group *structs.TaskGroup, untainted, destructive, migrate allocSet, canaryState bool) int {
 	// If there is no update stategy or deployment for the group we can deploy
 	// as many as the group has
-	if group.Update == nil || len(destructive) == 0 {
+	if group.Update == nil || len(destructive)+len(migrate) == 0 {
 		return group.Count
 	} else if a.deploymentPaused || a.deploymentFailed {
 		// If the deployment is paused or failed, do not create anything else

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -38,7 +38,7 @@ Basic Tests:
 √  Handle job being stopped both as .Stopped and nil
 √  Place more that one group
 
-Deployment Tests:
+Update stanza Tests:
 √  Stopped job cancels any active deployment
 √  Stopped job doesn't cancel terminal deployment
 √  JobIndex change cancels any active deployment
@@ -67,6 +67,7 @@ Deployment Tests:
 √  Failed deployment cancels non-promoted task groups
 √  Failed deployment and updated job works
 √  Finished deployment gets marked as complete
+√  The stagger is correctly calculated when it is applied across multiple task groups.
 */
 
 var (
@@ -76,6 +77,7 @@ var (
 		HealthCheck:     structs.UpdateStrategyHealthCheck_Checks,
 		MinHealthyTime:  10 * time.Second,
 		HealthyDeadline: 10 * time.Minute,
+		Stagger:         31 * time.Second,
 	}
 
 	noCanaryUpdate = &structs.UpdateStrategy{
@@ -83,6 +85,7 @@ var (
 		HealthCheck:     structs.UpdateStrategyHealthCheck_Checks,
 		MinHealthyTime:  10 * time.Second,
 		HealthyDeadline: 10 * time.Minute,
+		Stagger:         31 * time.Second,
 	}
 )
 
@@ -255,6 +258,7 @@ type resultExpectation struct {
 	inplace           int
 	stop              int
 	desiredTGUpdates  map[string]*structs.DesiredUpdates
+	followupEvalWait  time.Duration
 }
 
 func assertResults(t *testing.T, r *reconcileResults, exp *resultExpectation) {
@@ -286,6 +290,9 @@ func assertResults(t *testing.T, r *reconcileResults, exp *resultExpectation) {
 	}
 	if l := len(r.desiredTGUpdates); l != len(exp.desiredTGUpdates) {
 		t.Fatalf("Expected %d task group desired tg updates annotations; got %d", len(exp.desiredTGUpdates), l)
+	}
+	if r.followupEvalWait != exp.followupEvalWait {
+		t.Fatalf("Unexpected followup eval wait time. Got %v; want %v", r.followupEvalWait, exp.followupEvalWait)
 	}
 
 	// Check the desired updates happened
@@ -1638,12 +1645,12 @@ func TestReconciler_PausedOrFailedDeployment_Migrations(t *testing.T) {
 		stopAnnotation    uint64
 	}{
 		{
-			name:              "paused deployment",
-			deploymentStatus:  structs.DeploymentStatusPaused,
-			place:             3,
-			stop:              3,
-			ignoreAnnotation:  5,
-			migrateAnnotation: 3,
+			name:             "paused deployment",
+			deploymentStatus: structs.DeploymentStatusPaused,
+			place:            0,
+			stop:             3,
+			ignoreAnnotation: 5,
+			stopAnnotation:   3,
 		},
 		{
 			name:              "failed deployment",
@@ -2403,9 +2410,9 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 		PlacedAllocs: 4,
 	}
 
-	// Create 6 allocations from the old job
+	// Create 3 allocations from the old job
 	var allocs []*structs.Allocation
-	for i := 4; i < 10; i++ {
+	for i := 7; i < 10; i++ {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
@@ -2417,7 +2424,7 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 
 	// Create the healthy replacements
 	handled := make(map[string]allocUpdateType)
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 7; i++ {
 		new := mock.Alloc()
 		new.Job = job
 		new.JobID = job.ID
@@ -2433,10 +2440,10 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 	}
 
 	// Build a map of tainted nodes
-	tainted := make(map[string]*structs.Node, 2)
-	for i := 0; i < 2; i++ {
+	tainted := make(map[string]*structs.Node, 3)
+	for i := 0; i < 3; i++ {
 		n := mock.Node()
-		n.ID = allocs[6+i].NodeID
+		n.ID = allocs[3+i].NodeID
 		if i == 0 {
 			n.Status = structs.NodeStatusDown
 		} else {
@@ -2453,22 +2460,23 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 	assertResults(t, r, &resultExpectation{
 		createDeployment:  nil,
 		deploymentUpdates: nil,
-		place:             6,
+		place:             5,
 		inplace:           0,
-		stop:              6,
+		stop:              5,
+		followupEvalWait:  31 * time.Second,
 		desiredTGUpdates: map[string]*structs.DesiredUpdates{
 			job.TaskGroups[0].Name: {
 				Place:             1, // Place the lost
 				Stop:              1, // Stop the lost
 				Migrate:           1, // Migrate the tainted
-				DestructiveUpdate: 4,
-				Ignore:            4,
+				DestructiveUpdate: 3,
+				Ignore:            5,
 			},
 		},
 	})
 
-	assertNamesHaveIndexes(t, intRange(0, 1, 4, 7), placeResultsToNames(r.place))
-	assertNamesHaveIndexes(t, intRange(0, 1, 4, 7), stopResultsToNames(r.stop))
+	assertNamesHaveIndexes(t, intRange(0, 1, 7, 9), placeResultsToNames(r.place))
+	assertNamesHaveIndexes(t, intRange(0, 1, 7, 9), stopResultsToNames(r.stop))
 }
 
 // Tests the reconciler handles a failed deployment and does no placements
@@ -2538,6 +2546,7 @@ func TestReconciler_FailedDeployment_NoPlacements(t *testing.T) {
 		place:             0,
 		inplace:           0,
 		stop:              2,
+		followupEvalWait:  0, // Since the deployment is failed, there should be no followup
 		desiredTGUpdates: map[string]*structs.DesiredUpdates{
 			job.TaskGroups[0].Name: {
 				Stop:   2,
@@ -2817,4 +2826,70 @@ func TestReconciler_MarkDeploymentComplete(t *testing.T) {
 			},
 		},
 	})
+}
+
+// Tests the reconciler picks the maximum of the staggers when multiple task
+// groups are under going node drains.
+func TestReconciler_TaintedNode_MultiGroups(t *testing.T) {
+	// Create a job with two task groups
+	job := mock.Job()
+	job.TaskGroups[0].Update = noCanaryUpdate
+	job.TaskGroups = append(job.TaskGroups, job.TaskGroups[0].Copy())
+	job.TaskGroups[1].Name = "two"
+	job.TaskGroups[1].Update.Stagger = 100 * time.Second
+
+	// Create the allocations
+	var allocs []*structs.Allocation
+	for j := 0; j < 2; j++ {
+		for i := 0; i < 10; i++ {
+			alloc := mock.Alloc()
+			alloc.Job = job
+			alloc.JobID = job.ID
+			alloc.NodeID = structs.GenerateUUID()
+			alloc.Name = structs.AllocName(job.ID, job.TaskGroups[j].Name, uint(i))
+			alloc.TaskGroup = job.TaskGroups[j].Name
+			allocs = append(allocs, alloc)
+		}
+	}
+
+	// Build a map of tainted nodes
+	tainted := make(map[string]*structs.Node, 15)
+	for i := 0; i < 15; i++ {
+		n := mock.Node()
+		n.ID = allocs[i].NodeID
+		n.Drain = true
+		tainted[n.ID] = n
+	}
+
+	reconciler := NewAllocReconciler(testLogger(), allocUpdateFnIgnore, false, job.ID, job, nil, allocs, tainted)
+	r := reconciler.Compute()
+
+	// Assert the correct results
+	assertResults(t, r, &resultExpectation{
+		createDeployment:  nil,
+		deploymentUpdates: nil,
+		place:             8,
+		inplace:           0,
+		stop:              8,
+		followupEvalWait:  100 * time.Second,
+		desiredTGUpdates: map[string]*structs.DesiredUpdates{
+			job.TaskGroups[0].Name: {
+				Place:             0,
+				Stop:              0,
+				Migrate:           4,
+				DestructiveUpdate: 0,
+				Ignore:            6,
+			},
+			job.TaskGroups[1].Name: {
+				Place:             0,
+				Stop:              0,
+				Migrate:           4,
+				DestructiveUpdate: 0,
+				Ignore:            6,
+			},
+		},
+	})
+
+	assertNamesHaveIndexes(t, intRange(0, 3, 0, 3), placeResultsToNames(r.place))
+	assertNamesHaveIndexes(t, intRange(0, 3, 0, 3), stopResultsToNames(r.stop))
 }

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -16,7 +16,7 @@ const (
 
 	// allocNodeTainted is the status used when stopping an alloc because it's
 	// node is tainted.
-	allocNodeTainted = "system alloc not needed as node is tainted"
+	allocNodeTainted = "alloc not needed as node is tainted"
 )
 
 // SystemScheduler is used for 'system' jobs. This scheduler is


### PR DESCRIPTION
This PR adds rolling node drains done at max_parallel and stagger of the
update spec. It brings it inline with old behavior.