### PR TITLE
Prevent port conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ BUG FIXES:
  * driver/exec: Properly set file/dir ownership in chroots [GH-2552]
  * driver/docker: Fix panic in Docker driver on Windows [GH-2614]
  * driver/rkt: Fix env var interpolation [GH-2777]
+ * jobspec/validation: Prevent static port conflicts [GH-2807]
  * server: Reject non-TLS clients when TLS enabled [GH-2525]
  * server: Fix a panic in plan evaluation with partial failures and all_at_once
    set [GH-2544]

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2527,8 +2527,10 @@ func (tg *TaskGroup) Validate(j *Job) error {
 		}
 	}
 
-	// Check for duplicate tasks and that there is only leader task if any
+	// Check for duplicate tasks, that there is only leader task if any,
+	// and no duplicated static ports
 	tasks := make(map[string]int)
+	staticPorts := make(map[int]string)
 	leaderTasks := 0
 	for idx, task := range tg.Tasks {
 		if task.Name == "" {
@@ -2541,6 +2543,22 @@ func (tg *TaskGroup) Validate(j *Job) error {
 
 		if task.Leader {
 			leaderTasks++
+		}
+
+		if task.Resources == nil {
+			continue
+		}
+
+		for _, net := range task.Resources.Networks {
+			for _, port := range net.ReservedPorts {
+				if other, ok := staticPorts[port.Value]; ok {
+					err := fmt.Errorf("Task %q and %q both reserve static port %d",
+						other, task.Name, port.Value)
+					mErr.Errors = append(mErr.Errors, err)
+				} else {
+					staticPorts[port.Value] = task.Name
+				}
+			}
 		}
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2552,11 +2552,10 @@ func (tg *TaskGroup) Validate(j *Job) error {
 		for _, net := range task.Resources.Networks {
 			for _, port := range net.ReservedPorts {
 				if other, ok := staticPorts[port.Value]; ok {
-					err := fmt.Errorf("Task %q and %q both reserve static port %d",
-						other, task.Name, port.Value)
+					err := fmt.Errorf("Static port %d already reserved by %s", port.Value, other)
 					mErr.Errors = append(mErr.Errors, err)
 				} else {
-					staticPorts[port.Value] = task.Name
+					staticPorts[port.Value] = fmt.Sprintf("%s:%s", task.Name, port.Label)
 				}
 			}
 		}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -807,6 +807,36 @@ func TestTaskGroup_Validate(t *testing.T) {
 	}
 
 	tg = &TaskGroup{
+		Tasks: []*Task{
+			&Task{
+				Name: "task-a",
+				Resources: &Resources{
+					Networks: []*NetworkResource{
+						&NetworkResource{
+							ReservedPorts: []Port{{Label: "foo", Value: 123}},
+						},
+					},
+				},
+			},
+			&Task{
+				Name: "task-b",
+				Resources: &Resources{
+					Networks: []*NetworkResource{
+						&NetworkResource{
+							ReservedPorts: []Port{{Label: "foo", Value: 123}},
+						},
+					},
+				},
+			},
+		},
+	}
+	err = tg.Validate(&Job{})
+	expected := `Task "task-a" and "task-b" both reserve static port 123`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected %s but found: %v", expected, err)
+	}
+
+	tg = &TaskGroup{
 		Name:  "web",
 		Count: 1,
 		Tasks: []*Task{

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -831,7 +831,30 @@ func TestTaskGroup_Validate(t *testing.T) {
 		},
 	}
 	err = tg.Validate(&Job{})
-	expected := `Task "task-a" and "task-b" both reserve static port 123`
+	expected := `Static port 123 already reserved by task-a:foo`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected %s but found: %v", expected, err)
+	}
+
+	tg = &TaskGroup{
+		Tasks: []*Task{
+			&Task{
+				Name: "task-a",
+				Resources: &Resources{
+					Networks: []*NetworkResource{
+						&NetworkResource{
+							ReservedPorts: []Port{
+								{Label: "foo", Value: 123},
+								{Label: "bar", Value: 123},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err = tg.Validate(&Job{})
+	expected = `Static port 123 already reserved by task-a:foo`
 	if !strings.Contains(err.Error(), expected) {
 		t.Errorf("expected %s but found: %v", expected, err)
 	}


### PR DESCRIPTION
Validate that no two tasks in the same task group can reserve the same
static port.