### PR TITLE
Updated documentation, fixed typo in CLI

### DIFF
--- a/command/deployment_promote.go
+++ b/command/deployment_promote.go
@@ -49,7 +49,7 @@ Promote Options:
 }
 
 func (c *DeploymentPromoteCommand) Synopsis() string {
-	return "Manually fail a deployment"
+	return "Manually promote a deployment"
 }
 
 func (c *DeploymentPromoteCommand) Run(args []string) int {

--- a/website/source/docs/job-specification/update.html.md
+++ b/website/source/docs/job-specification/update.html.md
@@ -82,6 +82,11 @@ job "docs" {
   allocations off nodes marked for draining. This is specified using a label
   suffix like "30s" or "1h".
 
+- `canary` `(int: 0)` - Specifies that Nomad will create a canary allocation, 
+  the canary is created without stopping any previous allocations. To remove
+  the old allocations the operator must manually promote the canary. [Canary Up
+  grades](/docs/job-specification/update.html#canary-upgrades)
+
 ## `update` Examples
 
 The following examples only show the `update` stanzas. Remember that the
@@ -131,6 +136,14 @@ update {
   max_parallel = 3
 }
 ```
+
+Promotion of the canary allocation can be completed using the cli with the command:
+
+```bash
+$ nomad deployment promote [options] <deployment id>
+```
+
+or by using the [Nomad API](/api/deployments.html#promote-deployment)
 
 ### Serial Upgrades
 


### PR DESCRIPTION
Hey, 

I spotted a couple of problems with the 0.6 docs and the text. in the CLI, give me a shout if the wording for the docs is a little off I did struggle a bit with the canary attribute.

Nic