### PR TITLE
Fix allocations pointing to unknown deployment

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2543,7 +2543,7 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 		return err
 	}
 	if deployment == nil {
-		return fmt.Errorf("allocation %q references unknown deployment %q", alloc.ID, alloc.DeploymentID)
+		return nil
 	}
 
 	// Retrieve the deployment state object


### PR DESCRIPTION
This change brings two fixes:

1) Garbage collection of deployments takes into consideration the state of allocations referencing it.
2) Upserting allocs that reference an unknown deployment no longer causes an error as it is possible for the deployment to have been garbage collected.

Fixes https://github.com/hashicorp/nomad/issues/2823