### PR TITLE
Allow cli package to handle version.

### DIFF
--- a/command/job_history.go
+++ b/command/job_history.go
@@ -36,7 +36,7 @@ History Options:
   -full
     Display the full job definition for each version.
 
-  -job-version <job version>
+  -version <job version>
     Display only the history for the given job version.
 
   -json
@@ -61,7 +61,7 @@ func (c *JobHistoryCommand) Run(args []string) int {
 	flags.BoolVar(&diff, "p", false, "")
 	flags.BoolVar(&full, "full", false, "")
 	flags.BoolVar(&json, "json", false, "")
-	flags.StringVar(&versionStr, "job-version", "", "")
+	flags.StringVar(&versionStr, "version", "", "")
 	flags.StringVar(&tmpl, "t", "", "")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/version.go
+++ b/command/version.go
@@ -1,18 +1,13 @@
 package command
 
 import (
-	"bytes"
-	"fmt"
-
 	"github.com/mitchellh/cli"
 )
 
 // VersionCommand is a Command implementation prints the version.
 type VersionCommand struct {
-	Revision          string
-	Version           string
-	VersionPrerelease string
-	Ui                cli.Ui
+	Version string
+	Ui      cli.Ui
 }
 
 func (c *VersionCommand) Help() string {
@@ -20,18 +15,7 @@ func (c *VersionCommand) Help() string {
 }
 
 func (c *VersionCommand) Run(_ []string) int {
-	var versionString bytes.Buffer
-
-	fmt.Fprintf(&versionString, "Nomad v%s", c.Version)
-	if c.VersionPrerelease != "" {
-		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
-
-		if c.Revision != "" {
-			fmt.Fprintf(&versionString, " (%s)", c.Revision)
-		}
-	}
-
-	c.Ui.Output(versionString.String())
+	c.Ui.Output(c.Version)
 	return 0
 }
 

--- a/commands.go
+++ b/commands.go
@@ -231,24 +231,9 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 			}, nil
 		},
 		"version": func() (cli.Command, error) {
-			ver := Version
-			rel := VersionPrerelease
-			if GitDescribe != "" {
-				ver = GitDescribe
-				// Trim off a leading 'v', we append it anyways.
-				if ver[0] == 'v' {
-					ver = ver[1:]
-				}
-			}
-			if GitDescribe == "" && rel == "" && VersionPrerelease != "" {
-				rel = "dev"
-			}
-
 			return &command.VersionCommand{
-				Revision:          GitCommit,
-				Version:           ver,
-				VersionPrerelease: rel,
-				Ui:                meta.Ui,
+				Version: PrettyVersion(GetVersionParts()),
+				Ui:      meta.Ui,
 			}, nil
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -21,18 +21,6 @@ func Run(args []string) int {
 }
 
 func RunCustom(args []string, commands map[string]cli.CommandFactory) int {
-	// Get the command line args. We shortcut "--version" and "-v" to
-	// just show the version.
-	for _, arg := range args {
-		if arg == "-v" || arg == "-version" || arg == "--version" {
-			newArgs := make([]string, len(args)+1)
-			newArgs[0] = "version"
-			copy(newArgs[1:], args)
-			args = newArgs
-			break
-		}
-	}
-
 	// Build the commands to include in the help now.
 	commandsInclude := make([]string, 0, len(commands))
 	for k, _ := range commands {
@@ -51,6 +39,7 @@ func RunCustom(args []string, commands map[string]cli.CommandFactory) int {
 	}
 
 	cli := &cli.CLI{
+		Version:  PrettyVersion(GetVersionParts()),
 		Args:     args,
 		Commands: commands,
 		HelpFunc: cli.FilteredHelpFunc(commandsInclude, cli.BasicHelpFunc("nomad")),

--- a/version.go
+++ b/version.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"bytes"
+	"fmt"
+)
+
 // The git commit that was compiled. This will be filled in by the compiler.
 var GitCommit string
 var GitDescribe string
@@ -11,3 +16,39 @@ const Version = "0.6.0"
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
 const VersionPrerelease = "rc1"
+
+// GetVersionParts returns the Nomad version strings. Printing of the Nomad
+// version should be used in conjunction with the PrettyVersion method.
+func GetVersionParts() (rev, ver, rel string) {
+	ver = Version
+	rel = VersionPrerelease
+	if GitDescribe != "" {
+		ver = GitDescribe
+		// Trim off a leading 'v', we append it anyways.
+		if ver[0] == 'v' {
+			ver = ver[1:]
+		}
+	}
+	if GitDescribe == "" && rel == "" && VersionPrerelease != "" {
+		rel = "dev"
+	}
+
+	return GitCommit, ver, rel
+}
+
+// PrettyVersion takes the version parts and formats it in a human readable
+// string.
+func PrettyVersion(revision, version, versionPrerelease string) string {
+	var versionString bytes.Buffer
+
+	fmt.Fprintf(&versionString, "Nomad v%s", version)
+	if versionPrerelease != "" {
+		fmt.Fprintf(&versionString, "-%s", versionPrerelease)
+
+		if revision != "" {
+			fmt.Fprintf(&versionString, " (%s)", revision)
+		}
+	}
+
+	return versionString.String()
+}


### PR DESCRIPTION
This PR removes our custom handling of the version flag and updates job
history to use a version flag instead of `-job-version`.