### PR TITLE
Improve alloc health watcher

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -143,6 +143,7 @@ type allocRunnerMutableState struct {
 	AllocClientStatus      string
 	AllocClientDescription string
 	TaskStates             map[string]*structs.TaskState
+	DeploymentStatus       *structs.AllocDeploymentStatus
 }
 
 // NewAllocRunner is used to create a new allocation context
@@ -255,6 +256,7 @@ func (r *AllocRunner) RestoreState() error {
 			r.allocClientDescription = mutable.AllocClientDescription
 			r.taskStates = mutable.TaskStates
 			r.alloc.ClientStatus = getClientStatus(r.taskStates)
+			r.alloc.DeploymentStatus = mutable.DeploymentStatus
 			return nil
 		})
 
@@ -422,6 +424,7 @@ func (r *AllocRunner) saveAllocRunnerState() error {
 			AllocClientStatus:      allocClientStatus,
 			AllocClientDescription: allocClientDescription,
 			TaskStates:             alloc.TaskStates,
+			DeploymentStatus:       alloc.DeploymentStatus,
 		}
 
 		if err := putObject(allocBkt, allocRunnerStateMutableKey, &mutable); err != nil {
@@ -583,7 +586,7 @@ func (r *AllocRunner) syncStatus() error {
 		time.Sleep(500 * time.Millisecond)
 	}
 	if !sent {
-		r.logger.Printf("[WARN] client: failed to broadcase update to allocation %q", r.allocID)
+		r.logger.Printf("[WARN] client: failed to broadcast update to allocation %q", r.allocID)
 	}
 
 	return r.saveAllocRunnerState()

--- a/client/alloc_runner_health_watcher.go
+++ b/client/alloc_runner_health_watcher.go
@@ -24,10 +24,7 @@ func (r *AllocRunner) watchHealth(ctx context.Context) {
 	if alloc.DeploymentID == "" {
 		r.logger.Printf("[TRACE] client.alloc_watcher: exiting because alloc isn't part of a deployment")
 		return
-	}
-
-	// TODO Add to persisted state
-	if alloc.DeploymentStatus.IsHealthy() || alloc.DeploymentStatus.IsUnhealthy() {
+	} else if alloc.DeploymentStatus.IsHealthy() || alloc.DeploymentStatus.IsUnhealthy() {
 		r.logger.Printf("[TRACE] client.alloc_watcher: exiting because alloc deployment health already determined")
 		return
 	}

--- a/client/structs/funcs.go
+++ b/client/structs/funcs.go
@@ -29,20 +29,24 @@ type AllocListener struct {
 	id int
 }
 
-// Send broadcasts a message to the channel.
-// Sending on a closed channel causes a runtime panic.
-func (b *AllocBroadcaster) Send(v *structs.Allocation) {
+// Send broadcasts a message to the channel. Send returns whether the message
+// was sent to all channels.
+func (b *AllocBroadcaster) Send(v *structs.Allocation) bool {
 	b.m.Lock()
 	defer b.m.Unlock()
 	if b.closed {
-		return
+		return false
 	}
+	sent := true
 	for _, l := range b.listeners {
 		select {
 		case l <- v:
 		default:
+			sent = false
 		}
 	}
+
+	return sent
 }
 
 // Close closes the channel, disabling the sending of further messages.


### PR DESCRIPTION
This PR does the following:

* Saves deployment state so that watchers don't run when the client is restoring unless they are needed.
* Handles the case of a broadcasted allocation state being missed (this was causing a bit of unreliability under high load). The likely fix was making the channel buffered but added better retry logic.
* Watcher cancels healthy timer under conditions where the allocation has entered the unhealthy state (check going from passing to critical).
* Watcher doesn't cancel and re-initialize the healthy timer if it doesn't have to.