### PR TITLE
Fix update limit calculation to avoid panic

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -548,6 +548,12 @@ func (a *allocReconciler) computeLimit(group *structs.TaskGroup, untainted, dest
 		}
 	}
 
+	// The limit can be less than zero in the case that the job was changed such
+	// that it required destructive changes and the count was scaled up.
+	if limit < 0 {
+		return 0
+	}
+
 	return limit
 }
 


### PR DESCRIPTION
This PR fixes the rolling update limit calculation to avoid a panic when
there are more allocations for a deployment that haven't determined
their health than the max_parallel count of the task group.

Fixes https://github.com/hashicorp/nomad/issues/2820