### PR TITLE
Handle destructive changes before placements

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -455,7 +455,8 @@ func (s *GenericScheduler) computeJobAllocs() error {
 	return s.computePlacements(destructive, place)
 }
 
-// computePlacements computes placements for allocations
+// computePlacements computes placements for allocations. It is given the set of
+// destructive updates to place and the set of new placements to place.
 func (s *GenericScheduler) computePlacements(destructive, place []placementResult) error {
 	// Get the base nodes
 	nodes, byDC, err := readyNodesInDCs(s.state, s.job.Datacenters)


### PR DESCRIPTION
This PR updates the generic scheduler to handle destructive changes before
handling placements. This is important because the destructive change may
be due to a lowering of resources. If this is the case, the handling of the
destructive changes first may make it possible for the placement to happen.

To reason about this imagine there is one node with CPU = 500.

If the group originally had:
* `count = 1`
* `cpu = 400`

And then the job was updated such that the group had:
* `count = 4`
* `cpu = 120`

If the original alloc isn't discounted first, nothing would be able to
place.