### PR TITLE
Pass task group name as NOMAD_GROUP_NAME environment variable

### DIFF
--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -209,6 +209,7 @@ func setupTaskEnv(t *testing.T, driver string) (*allocdir.TaskDir, map[string]st
 		"NOMAD_ALLOC_INDEX":             "0",
 		"NOMAD_ALLOC_NAME":              alloc.Name,
 		"NOMAD_TASK_NAME":               task.Name,
+		"NOMAD_GROUP_NAME":              alloc.TaskGroup,
 		"NOMAD_JOB_NAME":                alloc.Job.Name,
 		"NOMAD_DC":                      "dc1",
 		"NOMAD_REGION":                  "global",

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -44,6 +44,9 @@ const (
 	// TaskName is the environment variable for passing the task name.
 	TaskName = "NOMAD_TASK_NAME"
 
+	// GroupName is the environment variable for passing the task group name.
+	GroupName = "NOMAD_GROUP_NAME"
+
 	// JobName is the environment variable for passing the job name.
 	JobName = "NOMAD_JOB_NAME"
 
@@ -208,6 +211,7 @@ type Builder struct {
 	region           string
 	allocId          string
 	allocName        string
+	groupName        string
 	vaultToken       string
 	injectVaultToken bool
 	jobName          string
@@ -276,6 +280,9 @@ func (b *Builder) Build() *TaskEnv {
 	}
 	if b.allocName != "" {
 		envMap[AllocName] = b.allocName
+	}
+	if b.groupName != "" {
+		envMap[GroupName] = b.groupName
 	}
 	if b.allocIndex != -1 {
 		envMap[AllocIndex] = strconv.Itoa(b.allocIndex)
@@ -380,6 +387,7 @@ func (b *Builder) setTask(task *structs.Task) *Builder {
 func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 	b.allocId = alloc.ID
 	b.allocName = alloc.Name
+	b.groupName = alloc.TaskGroup
 	b.allocIndex = int(alloc.Index())
 	b.jobName = alloc.Job.Name
 

--- a/client/driver/env/env_test.go
+++ b/client/driver/env/env_test.go
@@ -181,6 +181,7 @@ func TestEnvironment_AsList(t *testing.T) {
 		"NOMAD_HOST_PORT_http=80",
 		"NOMAD_HOST_PORT_https=8080",
 		"NOMAD_TASK_NAME=web",
+		"NOMAD_GROUP_NAME=web",
 		"NOMAD_ADDR_ssh_other=192.168.0.100:1234",
 		"NOMAD_ADDR_ssh_ssh=192.168.0.100:22",
 		"NOMAD_IP_ssh_other=192.168.0.100",

--- a/website/source/docs/runtime/_envvars.html.md.erb
+++ b/website/source/docs/runtime/_envvars.html.md.erb
@@ -52,6 +52,10 @@
     <td>Task's name</td>
   </tr>
   <tr>
+    <td><tt>NOMAD_GROUP_NAME</tt></td>
+    <td>Group's name</td>
+  </tr>
+  <tr>
     <td><tt>NOMAD_JOB_NAME</tt></td>
     <td>Job's name</td>
   </tr>

--- a/website/source/docs/runtime/environment.html.md.erb
+++ b/website/source/docs/runtime/environment.html.md.erb
@@ -23,11 +23,11 @@ environment variable names such as `NOMAD_ADDR_<task>_<label>`.
 
 ## Task Identifiers
 
-Nomad will pass both the allocation ID and name as well as the task and job's
-names.  These are given as `NOMAD_ALLOC_ID`, `NOMAD_ALLOC_NAME`,
-`NOMAD_ALLOC_INDEX`, `NOMAD_JOB_NAME`, and `NOMAD_TASK_NAME`. The allocation ID
-and index can be useful when the task being run needs a unique identifier or to
-know its instance count.
+Nomad will pass both the allocation ID and name as well as the task, group and
+job's names.  These are given as `NOMAD_ALLOC_ID`, `NOMAD_ALLOC_NAME`,
+`NOMAD_ALLOC_INDEX`, `NOMAD_JOB_NAME`, `NOMAD_GROUP_NAME` and `NOMAD_TASK_NAME`.
+The allocation ID and index can be useful when the task being run needs a unique
+identifier or to know its instance count.
 
 ## Resources
 


### PR DESCRIPTION
Fixes #1943  which I found myself being useful.
Tested on real system:
```
# rkt enter 49cdd69b env | grep NOMAD_.*_NAME
NOMAD_GROUP_NAME=worker-group
NOMAD_JOB_NAME=worker
NOMAD_TASK_NAME=worker-task
NOMAD_ALLOC_NAME=worker.worker-group[0]
```
`make test` was complaining in my system, saw that master CI was also failing, so not sure how much that's related. Manual `go test` on ./client/driver was fine though. Let's see about CI on the PR.