### PR TITLE
Fix state handling on restart

### DIFF
--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -416,6 +416,13 @@ func pre06ScriptCheck(ver, driver string, services []*structs.Service) bool {
 
 // SaveState is used to snapshot our state
 func (r *TaskRunner) SaveState() error {
+	r.destroyLock.Lock()
+	defer r.destroyLock.Unlock()
+	if r.destroy {
+		// Don't save state if already destroyed
+		return nil
+	}
+
 	r.persistLock.Lock()
 	defer r.persistLock.Unlock()
 	snap := taskRunnerState{


### PR DESCRIPTION
1. Do not persist state for destroyed (GC'd) allocs and tasks
2. Ensure periodic state syncing isn't performed concurrent with GC'ing
3. Mark restored task runners for terminal allocs as destroyed.
4. On restore don't create runners for dead tasks.