### PR TITLE
B 208 increase decrease group count r2

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -414,10 +413,6 @@ func (s *HTTPServer) updateJobValues(resp http.ResponseWriter, req *http.Request
 			if newCount < 0 {
 				outErr := fmt.Sprintf("Task group count may not be less than 0: 0 > %d",
 					newCount)
-				return nil, CodedError(400, outErr)
-			} else if newCount < taskGroup.Update.MaxParallel {
-				outErr := fmt.Sprintf("Task group count may not be less than update strategy max parallel: %d > %d",
-					taskGroup.Update.MaxParallel, newCount)
 				return nil, CodedError(400, outErr)
 			}
 			taskGroup.Count = newCount


### PR DESCRIPTION
This implements #208 

Right now the update job struct is returned after the update. This could possibly be changed to return a diff struct instead. I chose not to this as you may handle this in the calling method instead.

It could be updated to provide values such as disk/ram/CPU etc. I have tooling which does this.

Example usage:
 curl -d '{"count":1, "taskgroupid":"cache"}' $NOMAD_ADDR/v1/job/example/increase 

Please let me know if you have any comments or if I misunderstood something regarding the issue. 