### PR TITLE
Fix TestAllocRunner_TaskLeader_StopTG and unrelated races

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -849,26 +849,37 @@ func (r *AllocRunner) SetPreviousAllocDir(allocDir *allocdir.AllocDir) {
 // destroyTaskRunners destroys the task runners, waits for them to terminate and
 // then saves state.
 func (r *AllocRunner) destroyTaskRunners(destroyEvent *structs.TaskEvent) {
-	runners := r.getTaskRunners()
-
-	// First destroy the leader
-	for _, tr := range runners {
-		if tr.task.Leader {
-			r.logger.Printf("[DEBUG] client: destroying leader task %q of task group %q first", tr.task.Name, tr.alloc.TaskGroup)
-			tr.Destroy(destroyEvent)
-			<-tr.WaitCh()
+	// First destroy the leader if one exists
+	tg := r.alloc.Job.LookupTaskGroup(r.alloc.TaskGroup)
+	leader := ""
+	for _, task := range tg.Tasks {
+		if task.Leader {
+			leader = task.Name
+			break
 		}
+	}
+	if leader != "" {
+		r.taskLock.RLock()
+		tr := r.tasks[leader]
+		r.taskLock.RUnlock()
+
+		r.logger.Printf("[DEBUG] client: alloc %q destroying leader task %q of task group %q first",
+			r.allocID, leader, r.alloc.TaskGroup)
+		tr.Destroy(destroyEvent)
+		<-tr.WaitCh()
 	}
 
 	// Then destroy non-leader tasks concurrently
-	for _, tr := range runners {
-		if !tr.task.Leader {
+	r.taskLock.RLock()
+	for name, tr := range r.tasks {
+		if name != leader {
 			tr.Destroy(destroyEvent)
 		}
 	}
+	r.taskLock.RUnlock()
 
 	// Wait for termination of the task runners
-	for _, tr := range runners {
+	for _, tr := range r.getTaskRunners() {
 		<-tr.WaitCh()
 	}
 }

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -348,8 +348,9 @@ func (r *AllocRunner) SaveState() error {
 	runners := r.getTaskRunners()
 	var mErr multierror.Error
 	for _, tr := range runners {
-		if err := r.saveTaskRunnerState(tr); err != nil {
-			mErr.Errors = append(mErr.Errors, err)
+		if err := tr.SaveState(); err != nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("failed to save state for alloc %s task %q: %v",
+				r.allocID, tr.task.Name, err))
 		}
 	}
 	return mErr.ErrorOrNil()
@@ -444,14 +445,6 @@ func (r *AllocRunner) saveAllocRunnerState() error {
 
 		return nil
 	})
-}
-
-func (r *AllocRunner) saveTaskRunnerState(tr *TaskRunner) error {
-	if err := tr.SaveState(); err != nil {
-		return fmt.Errorf("failed to save state for alloc %s task '%s': %v",
-			r.allocID, tr.task.Name, err)
-	}
-	return nil
 }
 
 // DestroyState is used to cleanup after ourselves

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -629,7 +629,8 @@ func TestAllocRunner_SaveRestoreState(t *testing.T) {
 
 		return last.ClientStatus == structs.AllocClientStatusRunning, nil
 	}, func(err error) {
-		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar2.alloc.TaskStates["web"])
+		_, last := upd.Last()
+		t.Fatalf("err: %v %#v %#v", err, last, last.TaskStates["web"])
 	})
 
 	// Destroy and wait
@@ -643,7 +644,8 @@ func TestAllocRunner_SaveRestoreState(t *testing.T) {
 		}
 		return true, nil
 	}, func(err error) {
-		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.alloc.TaskStates)
+		_, last := upd.Last()
+		t.Fatalf("err: %v %#v %#v", err, last, last.TaskStates)
 	})
 
 	if time.Since(start) > time.Duration(testutil.TestMultiplier()*5)*time.Second {
@@ -728,7 +730,8 @@ func TestAllocRunner_SaveRestoreState_TerminalAlloc(t *testing.T) {
 
 		return true, nil
 	}, func(err error) {
-		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.alloc.TaskStates)
+		_, last := upd.Last()
+		t.Fatalf("err: %v %#v %#v", err, last, last.TaskStates)
 	})
 
 	// Send the destroy signal and ensure the AllocRunner cleans up.
@@ -845,7 +848,8 @@ func TestAllocRunner_SaveRestoreState_Upgrade(t *testing.T) {
 		}
 		return true, nil
 	}, func(err error) {
-		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar.alloc.TaskStates)
+		_, last := upd.Last()
+		t.Fatalf("err: %v %#v %#v", err, last, last.TaskStates)
 	})
 
 	if time.Since(start) > time.Duration(testutil.TestMultiplier()*5)*time.Second {

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -685,7 +685,7 @@ func TestAllocRunner_SaveRestoreState_TerminalAlloc(t *testing.T) {
 	ar.Update(update)
 
 	testutil.WaitForResult(func() (bool, error) {
-		return ar.alloc.DesiredStatus == structs.AllocDesiredStatusStop, nil
+		return ar.Alloc().DesiredStatus == structs.AllocDesiredStatusStop, nil
 	}, func(err error) {
 		t.Fatalf("err: %v", err)
 	})
@@ -1196,15 +1196,20 @@ func TestAllocRunner_TaskLeader_StopTG(t *testing.T) {
 			return false, fmt.Errorf("no new updates (count: %d)", newCount)
 		}
 		if last.TaskStates["leader"].FinishedAt.UnixNano() >= last.TaskStates["follower1"].FinishedAt.UnixNano() {
-			t.Fatalf("expected leader to finish before follower1: %s >= %s",
+			return false, fmt.Errorf("expected leader to finish before follower1: %s >= %s",
 				last.TaskStates["leader"].FinishedAt, last.TaskStates["follower1"].FinishedAt)
 		}
 		if last.TaskStates["leader"].FinishedAt.UnixNano() >= last.TaskStates["follower2"].FinishedAt.UnixNano() {
-			t.Fatalf("expected leader to finish before follower2: %s >= %s",
+			return false, fmt.Errorf("expected leader to finish before follower2: %s >= %s",
 				last.TaskStates["leader"].FinishedAt, last.TaskStates["follower2"].FinishedAt)
 		}
 		return true, nil
 	}, func(err error) {
+		count, last := upd.Last()
+		t.Logf("Updates: %d", count)
+		for name, state := range last.TaskStates {
+			t.Logf("%s: %s", name, state.State)
+		}
 		t.Fatalf("err: %v", err)
 	})
 }

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -596,6 +596,8 @@ func TestAllocRunner_SaveRestoreState(t *testing.T) {
 
 	// Snapshot state
 	testutil.WaitForResult(func() (bool, error) {
+		ar.taskLock.RLock()
+		defer ar.taskLock.RUnlock()
 		return len(ar.tasks) == 1, nil
 	}, func(err error) {
 		t.Fatalf("task never started: %v", err)

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/kr/pretty"
 
 	"github.com/hashicorp/nomad/client/config"
 	ctestutil "github.com/hashicorp/nomad/client/testutil"
@@ -23,13 +25,26 @@ import (
 )
 
 type MockAllocStateUpdater struct {
-	Count  int
 	Allocs []*structs.Allocation
+	mu     sync.Mutex
 }
 
+// Update fulfills the TaskStateUpdater interface
 func (m *MockAllocStateUpdater) Update(alloc *structs.Allocation) {
-	m.Count += 1
+	m.mu.Lock()
 	m.Allocs = append(m.Allocs, alloc)
+	m.mu.Unlock()
+}
+
+// Last returns the total number of updates and the last alloc (or nil)
+func (m *MockAllocStateUpdater) Last() (int, *structs.Allocation) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := len(m.Allocs)
+	if n == 0 {
+		return 0, nil
+	}
+	return n, m.Allocs[n-1].Copy()
 }
 
 func testAllocRunnerFromAlloc(alloc *structs.Allocation, restarts bool) (*MockAllocStateUpdater, *AllocRunner) {
@@ -61,10 +76,10 @@ func TestAllocRunner_SimpleRun(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusComplete {
 			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
 		}
@@ -96,10 +111,10 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_BadStart(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if *last.DeploymentStatus.Healthy {
@@ -136,10 +151,10 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_Deadline(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if *last.DeploymentStatus.Healthy {
@@ -181,10 +196,10 @@ func TestAllocRunner_DeploymentHealth_Healthy_NoChecks(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if !*last.DeploymentStatus.Healthy {
@@ -249,10 +264,10 @@ func TestAllocRunner_DeploymentHealth_Healthy_Checks(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if !*last.DeploymentStatus.Healthy {
@@ -291,10 +306,10 @@ func TestAllocRunner_DeploymentHealth_Healthy_UpdatedDeployment(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if !*last.DeploymentStatus.Healthy {
@@ -306,17 +321,16 @@ func TestAllocRunner_DeploymentHealth_Healthy_UpdatedDeployment(t *testing.T) {
 	})
 
 	// Mimick an update to a new deployment id
-	oldCount := upd.Count
-	last := upd.Allocs[oldCount-1].Copy()
+	oldCount, last := upd.Last()
 	last.DeploymentStatus = nil
 	last.DeploymentID = structs.GenerateUUID()
 	ar.Update(last)
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count <= oldCount {
+		newCount, last := upd.Last()
+		if newCount <= oldCount {
 			return false, fmt.Errorf("No new updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if !*last.DeploymentStatus.Healthy {
@@ -360,10 +374,10 @@ func TestAllocRunner_RetryArtifact(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count < 6 {
-			return false, fmt.Errorf("Not enough updates")
+		count, last := upd.Last()
+		if min := 6; count < min {
+			return false, fmt.Errorf("Not enough updates (%d < %d)", count, min)
 		}
-		last := upd.Allocs[upd.Count-1]
 
 		// web task should have completed successfully while bad task
 		// retries artififact fetching
@@ -399,10 +413,10 @@ func TestAllocRunner_TerminalUpdate_Destroy(t *testing.T) {
 	go ar.Run()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusRunning {
 			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusRunning)
 		}
@@ -418,12 +432,12 @@ func TestAllocRunner_TerminalUpdate_Destroy(t *testing.T) {
 	ar.Update(update)
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
-			return false, nil
+		_, last := upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("No updates")
 		}
 
 		// Check the status has changed.
-		last := upd.Allocs[upd.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusComplete {
 			return false, fmt.Errorf("got client status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
 		}
@@ -453,12 +467,12 @@ func TestAllocRunner_TerminalUpdate_Destroy(t *testing.T) {
 	ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
-			return false, nil
+		_, last := upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("No updates")
 		}
 
 		// Check the status has changed.
-		last := upd.Allocs[upd.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusComplete {
 			return false, fmt.Errorf("got client status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
 		}
@@ -504,12 +518,12 @@ func TestAllocRunner_Destroy(t *testing.T) {
 	}()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
-			return false, nil
+		_, last := upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("No updates")
 		}
 
 		// Check the status has changed.
-		last := upd.Allocs[upd.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusComplete {
 			return false, fmt.Errorf("got client status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
 		}
@@ -608,11 +622,11 @@ func TestAllocRunner_SaveRestoreState(t *testing.T) {
 			return false, fmt.Errorf("Incorrect number of tasks")
 		}
 
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, nil
 		}
 
-		last := upd.Allocs[upd.Count-1]
 		return last.ClientStatus == structs.AllocClientStatusRunning, nil
 	}, func(err error) {
 		t.Fatalf("err: %v %#v %#v", err, upd.Allocs[0], ar2.alloc.TaskStates["web"])
@@ -649,10 +663,11 @@ func TestAllocRunner_SaveRestoreState_TerminalAlloc(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
+
 		if last.ClientStatus != structs.AllocClientStatusRunning {
 			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusRunning)
 		}
@@ -721,12 +736,12 @@ func TestAllocRunner_SaveRestoreState_TerminalAlloc(t *testing.T) {
 	ar2.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
-			return false, nil
+		_, last := upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("No updates")
 		}
 
 		// Check the status has changed.
-		last := upd.Allocs[upd.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusComplete {
 			return false, fmt.Errorf("got client status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
 		}
@@ -775,10 +790,11 @@ func TestAllocRunner_SaveRestoreState_Upgrade(t *testing.T) {
 
 	// Snapshot state
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
+
 		if last.ClientStatus != structs.AllocClientStatusRunning {
 			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusRunning)
 		}
@@ -803,22 +819,19 @@ func TestAllocRunner_SaveRestoreState_Upgrade(t *testing.T) {
 	defer ar2.Destroy() // Just-in-case of failure before Destroy below
 
 	testutil.WaitForResult(func() (bool, error) {
-		if len(ar2.tasks) != 1 {
-			return false, fmt.Errorf("Incorrect number of tasks")
+		count, last := upd.Last()
+		if min := 3; count < min {
+			return false, fmt.Errorf("expected at least %d updates but found %d", min, count)
 		}
-
-		if upd.Count < 3 {
-			return false, nil
-		}
-
-		for _, ev := range ar2.taskStates["web"].Events {
+		for _, ev := range last.TaskStates["web"].Events {
 			if strings.HasSuffix(ev.RestartReason, pre06ScriptCheckReason) {
 				return true, nil
 			}
 		}
 		return false, fmt.Errorf("no restart with proper reason found")
 	}, func(err error) {
-		t.Fatalf("err: %v\nAllocs: %#v\nWeb State: %#v", err, upd.Allocs, ar2.taskStates["web"])
+		count, last := upd.Last()
+		t.Fatalf("err: %v\nAllocs: %d\nweb state: % #v", err, count, pretty.Formatter(last.TaskStates["web"]))
 	})
 
 	// Destroy and wait
@@ -996,10 +1009,10 @@ func TestAllocRunner_TaskFailed_KillTG(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusFailed {
 			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusFailed)
 		}
@@ -1061,12 +1074,13 @@ func TestAllocRunner_TaskLeader_KillTG(t *testing.T) {
 	ar.alloc.Job.TaskGroups[0].Tasks = append(ar.alloc.Job.TaskGroups[0].Tasks, task2)
 	ar.alloc.TaskResources[task2.Name] = task2.Resources
 	go ar.Run()
+	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusComplete {
 			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
 		}
@@ -1142,30 +1156,53 @@ func TestAllocRunner_TaskLeader_StopTG(t *testing.T) {
 	}
 	ar.alloc.Job.TaskGroups[0].Tasks = append(ar.alloc.Job.TaskGroups[0].Tasks, task2, task3)
 	ar.alloc.TaskResources[task2.Name] = task2.Resources
+	defer ar.Destroy()
 
-	// Destroy before running so it shuts down the alloc runner right after
-	// starting all tasks
-	ar.Destroy()
 	go ar.Run()
-	select {
-	case <-ar.WaitCh():
-	case <-time.After(8 * time.Second):
-		t.Fatalf("timed out waiting for alloc runner to exit")
-	}
 
-	if len(upd.Allocs) != 1 {
-		t.Fatalf("expected 1 alloc update but found %d", len(upd.Allocs))
-	}
+	// Wait for tasks to start
+	oldCount, last := upd.Last()
+	testutil.WaitForResult(func() (bool, error) {
+		oldCount, last = upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("No updates")
+		}
+		if n := len(last.TaskStates); n != 3 {
+			return false, fmt.Errorf("Not enough task states (want: 3; found %d)", n)
+		}
+		for name, state := range last.TaskStates {
+			if state.State != structs.TaskStateRunning {
+				return false, fmt.Errorf("Task %q is not running yet (it's %q)", name, state.State)
+			}
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
 
-	a := upd.Allocs[0]
-	if a.TaskStates["leader"].FinishedAt.UnixNano() >= a.TaskStates["follower1"].FinishedAt.UnixNano() {
-		t.Fatalf("expected leader to finish before follower1: %s >= %s",
-			a.TaskStates["leader"].FinishedAt, a.TaskStates["follower1"].FinishedAt)
-	}
-	if a.TaskStates["leader"].FinishedAt.UnixNano() >= a.TaskStates["follower2"].FinishedAt.UnixNano() {
-		t.Fatalf("expected leader to finish before follower2: %s >= %s",
-			a.TaskStates["leader"].FinishedAt, a.TaskStates["follower2"].FinishedAt)
-	}
+	// Stop alloc
+	update := ar.Alloc()
+	update.DesiredStatus = structs.AllocDesiredStatusStop
+	ar.Update(update)
+
+	// Wait for tasks to stop
+	testutil.WaitForResult(func() (bool, error) {
+		newCount, last := upd.Last()
+		if newCount == oldCount {
+			return false, fmt.Errorf("no new updates (count: %d)", newCount)
+		}
+		if last.TaskStates["leader"].FinishedAt.UnixNano() >= last.TaskStates["follower1"].FinishedAt.UnixNano() {
+			t.Fatalf("expected leader to finish before follower1: %s >= %s",
+				last.TaskStates["leader"].FinishedAt, last.TaskStates["follower1"].FinishedAt)
+		}
+		if last.TaskStates["leader"].FinishedAt.UnixNano() >= last.TaskStates["follower2"].FinishedAt.UnixNano() {
+			t.Fatalf("expected leader to finish before follower2: %s >= %s",
+				last.TaskStates["leader"].FinishedAt, last.TaskStates["follower2"].FinishedAt)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
 }
 
 func TestAllocRunner_MoveAllocDir(t *testing.T) {
@@ -1181,10 +1218,10 @@ func TestAllocRunner_MoveAllocDir(t *testing.T) {
 	defer ar.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd.Count == 0 {
+		_, last := upd.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd.Allocs[upd.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusComplete {
 			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
 		}
@@ -1213,10 +1250,10 @@ func TestAllocRunner_MoveAllocDir(t *testing.T) {
 	defer ar1.Destroy()
 
 	testutil.WaitForResult(func() (bool, error) {
-		if upd1.Count == 0 {
+		_, last := upd1.Last()
+		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		last := upd1.Allocs[upd1.Count-1]
 		if last.ClientStatus != structs.AllocClientStatusComplete {
 			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
 		}

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -559,6 +559,9 @@ func TestAllocRunner_Destroy(t *testing.T) {
 func TestAllocRunner_Update(t *testing.T) {
 	_, ar := testAllocRunner(false)
 
+	// Deep copy the alloc to avoid races when updating
+	newAlloc := ar.Alloc().Copy()
+
 	// Ensure task takes some time
 	task := ar.alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
@@ -567,8 +570,6 @@ func TestAllocRunner_Update(t *testing.T) {
 	defer ar.Destroy()
 
 	// Update the alloc definition
-	newAlloc := new(structs.Allocation)
-	*newAlloc = *ar.alloc
 	newAlloc.Name = "FOO"
 	newAlloc.AllocModifyIndex++
 	ar.Update(newAlloc)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -867,10 +867,12 @@ func (r *TaskRunner) updatedTokenHandler() {
 }
 
 // prestart handles life-cycle tasks that occur before the task has started.
-func (r *TaskRunner) prestart(resultCh chan bool) {
-	if r.task.Vault != nil {
+// Since it's run asynchronously with the main Run() loop the alloc & task are
+// passed in to avoid racing with updates.
+func (r *TaskRunner) prestart(alloc *structs.Allocation, task *structs.Task, resultCh chan bool) {
+	if task.Vault != nil {
 		// Wait for the token
-		r.logger.Printf("[DEBUG] client: waiting for Vault token for task %v in alloc %q", r.task.Name, r.alloc.ID)
+		r.logger.Printf("[DEBUG] client: waiting for Vault token for task %v in alloc %q", task.Name, alloc.ID)
 		tokenCh := r.vaultFuture.Wait()
 		select {
 		case <-tokenCh:
@@ -878,16 +880,16 @@ func (r *TaskRunner) prestart(resultCh chan bool) {
 			resultCh <- false
 			return
 		}
-		r.logger.Printf("[DEBUG] client: retrieved Vault token for task %v in alloc %q", r.task.Name, r.alloc.ID)
-		r.envBuilder.SetVaultToken(r.vaultFuture.Get(), r.task.Vault.Env)
+		r.logger.Printf("[DEBUG] client: retrieved Vault token for task %v in alloc %q", task.Name, alloc.ID)
+		r.envBuilder.SetVaultToken(r.vaultFuture.Get(), task.Vault.Env)
 	}
 
 	// If the job is a dispatch job and there is a payload write it to disk
-	requirePayload := len(r.alloc.Job.Payload) != 0 &&
+	requirePayload := len(alloc.Job.Payload) != 0 &&
 		(r.task.DispatchPayload != nil && r.task.DispatchPayload.File != "")
 	if !r.payloadRendered && requirePayload {
-		renderTo := filepath.Join(r.taskDir.LocalDir, r.task.DispatchPayload.File)
-		decoded, err := snappy.Decode(nil, r.alloc.Job.Payload)
+		renderTo := filepath.Join(r.taskDir.LocalDir, task.DispatchPayload.File)
+		decoded, err := snappy.Decode(nil, alloc.Job.Payload)
 		if err != nil {
 			r.setState(
 				structs.TaskStateDead,
@@ -921,10 +923,10 @@ func (r *TaskRunner) prestart(resultCh chan bool) {
 		r.persistLock.Unlock()
 
 		// Download the task's artifacts
-		if !downloaded && len(r.task.Artifacts) > 0 {
+		if !downloaded && len(task.Artifacts) > 0 {
 			r.setState(structs.TaskStatePending, structs.NewTaskEvent(structs.TaskDownloadingArtifacts))
 			taskEnv := r.envBuilder.Build()
-			for _, artifact := range r.task.Artifacts {
+			for _, artifact := range task.Artifacts {
 				if err := getter.GetArtifact(taskEnv, artifact, r.taskDir.Dir); err != nil {
 					wrapped := fmt.Errorf("failed to download artifact %q: %v", artifact.GetterSource, err)
 					r.logger.Printf("[DEBUG] client: %v", wrapped)
@@ -941,7 +943,7 @@ func (r *TaskRunner) prestart(resultCh chan bool) {
 		}
 
 		// We don't have to wait for any template
-		if len(r.task.Templates) == 0 {
+		if len(task.Templates) == 0 {
 			// Send the start signal
 			select {
 			case r.startCh <- struct{}{}:
@@ -955,12 +957,12 @@ func (r *TaskRunner) prestart(resultCh chan bool) {
 		// Build the template manager
 		if r.templateManager == nil {
 			var err error
-			r.templateManager, err = NewTaskTemplateManager(r, r.task.Templates,
+			r.templateManager, err = NewTaskTemplateManager(r, task.Templates,
 				r.config, r.vaultFuture.Get(), r.taskDir.Dir, r.envBuilder)
 			if err != nil {
 				err := fmt.Errorf("failed to build task's template manager: %v", err)
 				r.setState(structs.TaskStateDead, structs.NewTaskEvent(structs.TaskSetupFailure).SetSetupError(err).SetFailsTask())
-				r.logger.Printf("[ERR] client: alloc %q, task %q %v", r.alloc.ID, r.task.Name, err)
+				r.logger.Printf("[ERR] client: alloc %q, task %q %v", alloc.ID, task.Name, err)
 				resultCh <- false
 				return
 			}
@@ -1022,7 +1024,7 @@ func (r *TaskRunner) run() {
 	for {
 		// Do the prestart activities
 		prestartResultCh := make(chan bool, 1)
-		go r.prestart(prestartResultCh)
+		go r.prestart(r.alloc, r.task, prestartResultCh)
 
 	WAIT:
 		for {


### PR DESCRIPTION
TestAllocRunner_TaskLeader_StopTG was just written awful, but in rewriting it I got annoyed that our  mock task updater was racy. So I fixed that.

Then I noticed we had some races around task interpolation, so I switched interpolation to be on a copy. I would do it once in NewTaskRunner except interpolation varies depending on the task env which can mutate at runtime.