### PR TITLE
Synchronously deregister agent on shutdown

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -289,6 +289,12 @@ func (r *AllocRunner) RestoreState() error {
 		name := task.Name
 		state := r.taskStates[name]
 
+		// Nomad exited before task could start, nothing to restore.
+		// AllocRunner.Run will start a new TaskRunner for this task
+		if state == nil {
+			continue
+		}
+
 		// Mark the task as restored.
 		r.restored[name] = struct{}{}
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -704,10 +704,8 @@ func (a *Agent) setupConsul(consulConfig *config.ConsulConfig) error {
 	}
 
 	// Determine version for TLSSkipVerify
-	seen := false
 	if self, err := client.Agent().Self(); err == nil {
 		a.consulSupportsTLSSkipVerify = consulSupportsTLSSkipVerify(self)
-		seen = true
 	}
 
 	// Create Consul Catalog client for service discovery.
@@ -715,12 +713,6 @@ func (a *Agent) setupConsul(consulConfig *config.ConsulConfig) error {
 
 	// Create Consul Service client for service advertisement and checks.
 	a.consulService = consul.NewServiceClient(client.Agent(), a.consulSupportsTLSSkipVerify, a.logger)
-
-	// If we've seen the Consul agent already, mark it so future Consul
-	// errors are logged
-	if seen {
-		a.consulService.MarkSeen()
-	}
 
 	// Run the Consul service client's sync'ing main loop
 	go a.consulService.Run()

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -704,8 +704,10 @@ func (a *Agent) setupConsul(consulConfig *config.ConsulConfig) error {
 	}
 
 	// Determine version for TLSSkipVerify
+	seen := false
 	if self, err := client.Agent().Self(); err == nil {
 		a.consulSupportsTLSSkipVerify = consulSupportsTLSSkipVerify(self)
+		seen = true
 	}
 
 	// Create Consul Catalog client for service discovery.
@@ -713,6 +715,14 @@ func (a *Agent) setupConsul(consulConfig *config.ConsulConfig) error {
 
 	// Create Consul Service client for service advertisement and checks.
 	a.consulService = consul.NewServiceClient(client.Agent(), a.consulSupportsTLSSkipVerify, a.logger)
+
+	// If we've seen the Consul agent already, mark it so future Consul
+	// errors are logged
+	if seen {
+		a.consulService.MarkSeen()
+	}
+
+	// Run the Consul service client's sync'ing main loop
 	go a.consulService.Run()
 	return nil
 }

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -648,28 +648,13 @@ func (c *ServiceClient) Shutdown() error {
 	// Serialize Shutdown calls with RegisterAgent to prevent leaking agent
 	// entries.
 	c.agentLock.Lock()
+	defer c.agentLock.Unlock()
 	select {
 	case <-c.shutdownCh:
 		return nil
 	default:
+		close(c.shutdownCh)
 	}
-
-	// Deregister Nomad agent Consul entries before closing shutdown.
-	ops := operations{}
-	for id := range c.agentServices {
-		ops.deregServices = append(ops.deregServices, id)
-	}
-	for id := range c.agentChecks {
-		ops.deregChecks = append(ops.deregChecks, id)
-	}
-	c.commit(&ops)
-
-	// Then signal shutdown
-	close(c.shutdownCh)
-
-	// Safe to unlock after shutdownCh closed as RegisterAgent will check
-	// shutdownCh before committing.
-	c.agentLock.Unlock()
 
 	// Give run loop time to sync, but don't block indefinitely
 	deadline := time.After(c.shutdownWait)
@@ -679,7 +664,19 @@ func (c *ServiceClient) Shutdown() error {
 	case <-c.exitCh:
 	case <-deadline:
 		// Don't wait forever though
-		return fmt.Errorf("timed out waiting for Consul operations to complete")
+	}
+
+	// Always attempt to deregister Nomad agent Consul entries, even if
+	// deadline was reached
+	for id := range c.agentServices {
+		if err := c.client.ServiceDeregister(id); err != nil {
+			c.logger.Printf("[ERR] consul.sync: error deregistering agent service (id: %q): %v", id, err)
+		}
+	}
+	for id := range c.agentChecks {
+		if err := c.client.CheckDeregister(id); err != nil {
+			c.logger.Printf("[ERR] consul.sync: error deregistering agent service (id: %q): %v", id, err)
+		}
 	}
 
 	// Give script checks time to exit (no need to lock as Run() has exited)

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -144,7 +144,7 @@ func NewServiceClient(consulClient AgentAPI, skipVerifySupport bool, logger *log
 	}
 }
 
-// seen is used by MarkSeen and Seen
+// seen is used by markSeen and hasSeen
 const seen = 1
 
 // markSeen marks Consul as having been seen (meaning at least one operation

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -180,8 +180,8 @@ func (c *ServiceClient) Run() {
 				if failures == 0 {
 					c.logger.Printf("[WARN] consul.sync: failed to update services in Consul: %v", err)
 				}
-				failures++
 			}
+			failures++
 			if !retryTimer.Stop() {
 				// Timer already expired, since the timer may
 				// or may not have been read in the select{}

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -31,7 +31,6 @@ func testLogger() *log.Logger {
 // TestConsul_Integration asserts TaskRunner properly registers and deregisters
 // services and checks with Consul using an embedded Consul agent.
 func TestConsul_Integration(t *testing.T) {
-	t.Skip("-short set; skipping")
 	if _, ok := driver.BuiltinDrivers["mock_driver"]; !ok {
 		t.Skip(`test requires mock_driver; run with "-tags nomad_test"`)
 	}

--- a/command/agent/consul/script_test.go
+++ b/command/agent/consul/script_test.go
@@ -36,6 +36,7 @@ func newBlockingScriptExec() *blockingScriptExec {
 func (b *blockingScriptExec) Exec(ctx context.Context, _ string, _ []string) ([]byte, int, error) {
 	b.running <- struct{}{}
 	cmd := exec.CommandContext(ctx, testtask.Path(), "sleep", "9000h")
+	testtask.SetCmdEnv(cmd)
 	err := cmd.Run()
 	code := 0
 	if exitErr, ok := err.(*exec.ExitError); ok {

--- a/demo/vagrant/server.hcl
+++ b/demo/vagrant/server.hcl
@@ -11,11 +11,3 @@ server {
     # Self-elect, should be 3 or 5 for production
     bootstrap_expect = 1
 }
-
-# Advertise must be set to a non-loopback address.
-# Defaults to the resolving the local hostname.
-#advertise {
-#    http = "10.0.2.1"
-#    rpc  = "10.0.2.1"
-#    serf = "10.0.2.1"
-#}


### PR DESCRIPTION
Fixes #2891

Previously the agent services and checks were being asynchronously deregistered on shutdown, so it was a race between the sync goroutine deregistering them and Nomad shutting down.

This switches to synchronously deregister agent services and checks. The only downside is that we can't use the main sync loops error tracking to know whether or not to log errors.

I added the `Seen()`/`MarkSeen()` methods to allow easily squelching error messages if Consul has never been seen. Might be useful elsewhere in the future.