### PR TITLE
Use go-testing-interface instead of testing

### DIFF
--- a/scheduler/testing.go
+++ b/scheduler/testing.go
@@ -5,12 +5,12 @@ import (
 	"log"
 	"os"
 	"sync"
-	"testing"
 	"time"
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/mitchellh/go-testing-interface"
 )
 
 // RejectPlan is used to always reject the entire plan and force a state refresh
@@ -55,7 +55,7 @@ type Harness struct {
 }
 
 // NewHarness is used to make a new testing harness
-func NewHarness(t *testing.T) *Harness {
+func NewHarness(t testing.T) *Harness {
 	state, err := state.NewStateStore(os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -70,7 +70,7 @@ func NewHarness(t *testing.T) *Harness {
 
 // NewHarnessWithState creates a new harness with the given state for testing
 // purposes.
-func NewHarnessWithState(t *testing.T, state *state.StateStore) *Harness {
+func NewHarnessWithState(t testing.T, state *state.StateStore) *Harness {
 	return &Harness{
 		State:     state,
 		nextIndex: 1,
@@ -215,7 +215,7 @@ func (h *Harness) Process(factory Factory, eval *structs.Evaluation) error {
 	return sched.Process(eval)
 }
 
-func (h *Harness) AssertEvalStatus(t *testing.T, state string) {
+func (h *Harness) AssertEvalStatus(t testing.T, state string) {
 	if len(h.Evals) != 1 {
 		t.Fatalf("bad: %#v", h.Evals)
 	}

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"os/exec"
 	"sync/atomic"
-	"testing"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/nomad/helper/discover"
+	"github.com/mitchellh/go-testing-interface"
 )
 
 // offset is used to atomically increment the port numbers.
@@ -117,7 +117,7 @@ func defaultServerConfig() *TestServerConfig {
 type TestServer struct {
 	cmd    *exec.Cmd
 	Config *TestServerConfig
-	t      *testing.T
+	t      testing.T
 
 	HTTPAddr   string
 	SerfAddr   string
@@ -126,7 +126,7 @@ type TestServer struct {
 
 // NewTestServer creates a new TestServer, and makes a call to
 // an optional callback function to modify the configuration.
-func NewTestServer(t *testing.T, cb ServerConfigCallback) *TestServer {
+func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 	path, err := discover.NomadExecutable()
 	if err != nil {
 		t.Skipf("nomad not found, skipping: %v", err)

--- a/testutil/vault.go
+++ b/testutil/vault.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	vapi "github.com/hashicorp/vault/api"
+	"github.com/mitchellh/go-testing-interface"
 )
 
 // TestVault is a test helper. It uses a fork/exec model to create a test Vault
@@ -24,7 +24,7 @@ import (
 // testing.
 type TestVault struct {
 	cmd    *exec.Cmd
-	t      *testing.T
+	t      testing.T
 	waitCh chan error
 
 	Addr      string
@@ -35,7 +35,7 @@ type TestVault struct {
 }
 
 // NewTestVault returns a new TestVault instance that has yet to be started
-func NewTestVault(t *testing.T) *TestVault {
+func NewTestVault(t testing.T) *TestVault {
 	port := getPort()
 	token := structs.GenerateUUID()
 	bind := fmt.Sprintf("-dev-listen-address=127.0.0.1:%d", port)

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -2,10 +2,10 @@ package testutil
 
 import (
 	"os"
-	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/mitchellh/go-testing-interface"
 )
 
 const (
@@ -69,7 +69,7 @@ func IsTravis() bool {
 
 type rpcFn func(string, interface{}, interface{}) error
 
-func WaitForLeader(t testing.TB, rpc rpcFn) {
+func WaitForLeader(t testing.T, rpc rpcFn) {
 	WaitForResult(func() (bool, error) {
 		args := &structs.GenericRequest{}
 		var leader string

--- a/vendor/github.com/hashicorp/go-plugin/testing.go
+++ b/vendor/github.com/hashicorp/go-plugin/testing.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"net"
 	"net/rpc"
-	"testing"
 
+	"github.com/mitchellh/go-testing-interface"
 	"google.golang.org/grpc"
 )
 
@@ -14,7 +14,7 @@ import (
 
 // TestConn is a helper function for returning a client and server
 // net.Conn connected to each other.
-func TestConn(t *testing.T) (net.Conn, net.Conn) {
+func TestConn(t testing.T) (net.Conn, net.Conn) {
 	// Listen to any local port. This listener will be closed
 	// after a single connection is established.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -48,7 +48,7 @@ func TestConn(t *testing.T) (net.Conn, net.Conn) {
 }
 
 // TestRPCConn returns a rpc client and server connected to each other.
-func TestRPCConn(t *testing.T) (*rpc.Client, *rpc.Server) {
+func TestRPCConn(t testing.T) (*rpc.Client, *rpc.Server) {
 	clientConn, serverConn := TestConn(t)
 
 	server := rpc.NewServer()
@@ -60,7 +60,7 @@ func TestRPCConn(t *testing.T) (*rpc.Client, *rpc.Server) {
 
 // TestPluginRPCConn returns a plugin RPC client and server that are connected
 // together and configured.
-func TestPluginRPCConn(t *testing.T, ps map[string]Plugin) (*RPCClient, *RPCServer) {
+func TestPluginRPCConn(t testing.T, ps map[string]Plugin) (*RPCClient, *RPCServer) {
 	// Create two net.Conns we can use to shuttle our control connection
 	clientConn, serverConn := TestConn(t)
 
@@ -79,7 +79,7 @@ func TestPluginRPCConn(t *testing.T, ps map[string]Plugin) (*RPCClient, *RPCServ
 
 // TestPluginGRPCConn returns a plugin gRPC client and server that are connected
 // together and configured. This is used to test gRPC connections.
-func TestPluginGRPCConn(t *testing.T, ps map[string]Plugin) (*GRPCClient, *GRPCServer) {
+func TestPluginGRPCConn(t testing.T, ps map[string]Plugin) (*GRPCClient, *GRPCServer) {
 	// Create a listener
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -12,19 +12,25 @@ import (
 type T interface {
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
 	Fail()
 	FailNow()
 	Failed() bool
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
 	Log(args ...interface{})
 	Logf(format string, args ...interface{})
+	Name() string
+	Skip(args ...interface{})
+	SkipNow()
+	Skipf(format string, args ...interface{})
+	Skipped() bool
 }
 
 // RuntimeT implements T and can be instantiated and run at runtime to
 // mimic *testing.T behavior. Unlike *testing.T, this will simply panic
 // for calls to Fatal. For calls to Error, you'll have to check the errors
-// list to determine whether to exit yourself.
+// list to determine whether to exit yourself. Name and Skip methods are
+// unimplemented noops.
 type RuntimeT struct {
 	failed bool
 }
@@ -68,3 +74,9 @@ func (t *RuntimeT) Log(args ...interface{}) {
 func (t *RuntimeT) Logf(format string, args ...interface{}) {
 	log.Println(fmt.Sprintf(format, args...))
 }
+
+func (t *RuntimeT) Name() string                             { return "" }
+func (t *RuntimeT) Skip(args ...interface{})                 {}
+func (t *RuntimeT) SkipNow()                                 {}
+func (t *RuntimeT) Skipf(format string, args ...interface{}) {}
+func (t *RuntimeT) Skipped() bool                            { return false }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -745,10 +745,10 @@
 			"revision": "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
 		},
 		{
-			"checksumSHA1": "E8TqY+R9ZMYRKTUT8CVlGaBXe8w=",
+			"checksumSHA1": "n3FFMGGYEdVmtgl7TzGTPkB0VGg=",
 			"path": "github.com/hashicorp/go-plugin",
-			"revision": "03136dc196bf3ce9ac05bb584e56d61ffeb2f1a7",
-			"revisionTime": "2017-07-21T18:05:46Z"
+			"revision": "4e5a3725c607a756be8d35bf3a521c0f9c422666",
+			"revisionTime": "2017-07-25T21:30:12Z"
 		},
 		{
 			"checksumSHA1": "ErJHGU6AVPZM9yoY/xV11TwSjQs=",
@@ -1006,10 +1006,10 @@
 			"revisionTime": "2017-03-09T13:30:38Z"
 		},
 		{
-			"checksumSHA1": "j83WZHiKiPF86Hj5QMQdWboizls=",
+			"checksumSHA1": "NRba2rT64faub6rtxKVj7xM+QAo=",
 			"path": "github.com/mitchellh/go-testing-interface",
-			"revision": "477c2d05a845d8b55912a5a7993b9b24abcc5ef8",
-			"revisionTime": "2017-04-30T14:07:22Z"
+			"revision": "e1449340a7b207d8ca90d41466272ece75cbb5b5",
+			"revisionTime": "2017-07-25T22:03:13Z"
 		},
 		{
 			"path": "github.com/mitchellh/hashstructure",


### PR DESCRIPTION
This drops the testings stdlib pkg from our dependencies. Saves a
whopping 46kb on our binary (was really hoping for more of a win there),
but also avoids potential ugliness with how testing sets flags.