### PR TITLE
Expose FSM errors into deployment watcher and API

### DIFF
--- a/nomad/deployment_watcher_shims.go
+++ b/nomad/deployment_watcher_shims.go
@@ -89,12 +89,25 @@ type deploymentWatcherRaftShim struct {
 	apply raftApplyFn
 }
 
+// convertApplyErrors parses the results of a raftApply and returns the index at
+// which it was applied and any error that occured. Raft Apply returns two
+// seperate errors, Raft library errors and user returned errors from the FSM.
+// This helper, joins the errors by inspecting the applyResponse for an error.
+func (d *deploymentWatcherRaftShim) convertApplyErrors(applyResp interface{}, index uint64, err error) (uint64, error) {
+	if applyResp != nil {
+		if fsmErr, ok := applyResp.(error); ok && fsmErr != nil {
+			return index, fsmErr
+		}
+	}
+	return index, err
+}
+
 func (d *deploymentWatcherRaftShim) UpsertEvals(evals []*structs.Evaluation) (uint64, error) {
 	update := &structs.EvalUpdateRequest{
 		Evals: evals,
 	}
-	_, index, err := d.apply(structs.EvalUpdateRequestType, update)
-	return index, err
+	fsmErrIntf, index, raftErr := d.apply(structs.EvalUpdateRequestType, update)
+	return d.convertApplyErrors(fsmErrIntf, index, raftErr)
 }
 
 func (d *deploymentWatcherRaftShim) UpsertJob(job *structs.Job) (uint64, error) {
@@ -102,21 +115,21 @@ func (d *deploymentWatcherRaftShim) UpsertJob(job *structs.Job) (uint64, error) 
 	update := &structs.JobRegisterRequest{
 		Job: job,
 	}
-	_, index, err := d.apply(structs.JobRegisterRequestType, update)
-	return index, err
+	fsmErrIntf, index, raftErr := d.apply(structs.JobRegisterRequestType, update)
+	return d.convertApplyErrors(fsmErrIntf, index, raftErr)
 }
 
 func (d *deploymentWatcherRaftShim) UpdateDeploymentStatus(u *structs.DeploymentStatusUpdateRequest) (uint64, error) {
-	_, index, err := d.apply(structs.DeploymentStatusUpdateRequestType, u)
-	return index, err
+	fsmErrIntf, index, raftErr := d.apply(structs.DeploymentStatusUpdateRequestType, u)
+	return d.convertApplyErrors(fsmErrIntf, index, raftErr)
 }
 
 func (d *deploymentWatcherRaftShim) UpdateDeploymentPromotion(req *structs.ApplyDeploymentPromoteRequest) (uint64, error) {
-	_, index, err := d.apply(structs.DeploymentPromoteRequestType, req)
-	return index, err
+	fsmErrIntf, index, raftErr := d.apply(structs.DeploymentPromoteRequestType, req)
+	return d.convertApplyErrors(fsmErrIntf, index, raftErr)
 }
 
 func (d *deploymentWatcherRaftShim) UpdateDeploymentAllocHealth(req *structs.ApplyDeploymentAllocHealthRequest) (uint64, error) {
-	_, index, err := d.apply(structs.DeploymentAllocHealthRequestType, req)
-	return index, err
+	fsmErrIntf, index, raftErr := d.apply(structs.DeploymentAllocHealthRequestType, req)
+	return d.convertApplyErrors(fsmErrIntf, index, raftErr)
 }

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1973,6 +1973,7 @@ func (s *StateStore) UpdateDeploymentPromotion(index uint64, req *structs.ApplyD
 		}
 	}
 
+	haveCanaries := false
 	var unhealthyErr multierror.Error
 	for {
 		raw := iter.Next()
@@ -1997,10 +1998,16 @@ func (s *StateStore) UpdateDeploymentPromotion(index uint64, req *structs.ApplyD
 			multierror.Append(&unhealthyErr, fmt.Errorf("Canary allocation %q for group %q is not healthy", alloc.ID, alloc.TaskGroup))
 			continue
 		}
+
+		haveCanaries = true
 	}
 
 	if err := unhealthyErr.ErrorOrNil(); err != nil {
 		return err
+	}
+
+	if !haveCanaries {
+		return fmt.Errorf("no canaries to promote")
 	}
 
 	// Update deployment


### PR DESCRIPTION
This PR exposes errors returned by the FSM to the deployment watcher and
thus the API. It also adds an error to handle the case of promoting a
deployment that has no eligible canaries.