### PR TITLE
Validate that min_healthy_time < healthy_deadline

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2044,6 +2044,9 @@ func (u *UpdateStrategy) Validate() error {
 	if u.HealthyDeadline <= 0 {
 		multierror.Append(&mErr, fmt.Errorf("Healthy deadline must be greater than zero: %v", u.HealthyDeadline))
 	}
+	if u.MinHealthyTime >= u.HealthyDeadline {
+		multierror.Append(&mErr, fmt.Errorf("Minimum healthy time must be less than healthy deadline: %v > %v", u.MinHealthyTime, u.HealthyDeadline))
+	}
 	if u.Stagger <= 0 {
 		multierror.Append(&mErr, fmt.Errorf("Stagger must be greater than zero: %v", u.Stagger))
 	}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1314,7 +1314,7 @@ func TestUpdateStrategy_Validate(t *testing.T) {
 		MaxParallel:     -1,
 		HealthCheck:     "foo",
 		MinHealthyTime:  -10,
-		HealthyDeadline: -10,
+		HealthyDeadline: -15,
 		AutoRevert:      false,
 		Canary:          -1,
 	}
@@ -1334,6 +1334,9 @@ func TestUpdateStrategy_Validate(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if !strings.Contains(mErr.Errors[4].Error(), "Healthy deadline must be greater than zero") {
+		t.Fatalf("err: %s", err)
+	}
+	if !strings.Contains(mErr.Errors[5].Error(), "Minimum healthy time must be less than healthy deadline") {
 		t.Fatalf("err: %s", err)
 	}
 }


### PR DESCRIPTION
This PR adds a validation check to the update stanza to ensure that the
min_healthy_time is feasible.