### PR TITLE
Add interpolation support to chroot_env to allow the mapping of a task user's home directory into the chroot

### DIFF
--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -132,6 +132,7 @@ func setupTaskEnv(t *testing.T, driver string) (*allocdir.TaskDir, map[string]st
 	task := &structs.Task{
 		Name:   "Foo",
 		Driver: driver,
+		User:   "ubuntu",
 		Env: map[string]string{
 			"HELLO": "world",
 			"lorem": "ipsum",
@@ -211,6 +212,7 @@ func setupTaskEnv(t *testing.T, driver string) (*allocdir.TaskDir, map[string]st
 		"NOMAD_TASK_NAME":               task.Name,
 		"NOMAD_GROUP_NAME":              alloc.TaskGroup,
 		"NOMAD_JOB_NAME":                alloc.Job.Name,
+		"NOMAD_TASK_USER":               task.User,
 		"NOMAD_DC":                      "dc1",
 		"NOMAD_REGION":                  "global",
 	}

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	dstructs "github.com/hashicorp/nomad/client/driver/structs"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper"
 	hargs "github.com/hashicorp/nomad/helper/args"
@@ -49,6 +50,9 @@ const (
 
 	// JobName is the environment variable for passing the job name.
 	JobName = "NOMAD_JOB_NAME"
+
+	// TaskUser is the user the task will be run under.
+	TaskUser = "NOMAD_TASK_USER"
 
 	// AllocIndex is the environment variable for passing the allocation index.
 	AllocIndex = "NOMAD_ALLOC_INDEX"
@@ -206,6 +210,7 @@ type Builder struct {
 	cpuLimit         int
 	memLimit         int
 	taskName         string
+	taskUser         string
 	allocIndex       int
 	datacenter       string
 	region           string
@@ -293,6 +298,9 @@ func (b *Builder) Build() *TaskEnv {
 	if b.jobName != "" {
 		envMap[JobName] = b.jobName
 	}
+	if b.taskUser != "" {
+		envMap[TaskUser] = b.taskUser
+	}
 	if b.datacenter != "" {
 		envMap[Datacenter] = b.datacenter
 	}
@@ -378,6 +386,11 @@ func (b *Builder) setTask(task *structs.Task) *Builder {
 		for i, n := range task.Resources.Networks {
 			b.networks[i] = n.Copy()
 		}
+	}
+	if task.User == "" {
+		b.taskUser = dstructs.DefaultUnpriviledgedUser
+	} else {
+		b.taskUser = task.User
 	}
 	return b
 }

--- a/client/driver/env/env_test.go
+++ b/client/driver/env/env_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	dstructs "github.com/hashicorp/nomad/client/driver/structs"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -180,6 +181,7 @@ func TestEnvironment_AsList(t *testing.T) {
 		"NOMAD_IP_https=127.0.0.1",
 		"NOMAD_HOST_PORT_http=80",
 		"NOMAD_HOST_PORT_https=8080",
+		"NOMAD_TASK_USER=ubuntu",
 		"NOMAD_TASK_NAME=web",
 		"NOMAD_GROUP_NAME=web",
 		"NOMAD_ADDR_ssh_other=192.168.0.100:1234",
@@ -332,6 +334,7 @@ func TestEnvironment_UpdateTask(t *testing.T) {
 	a.Job.TaskGroups[0].Meta = map[string]string{"tgmeta": "tgmetaval"}
 	task := a.Job.TaskGroups[0].Tasks[0]
 	task.Name = "orig"
+	task.User = "user1"
 	task.Env = map[string]string{"taskenv": "taskenvval"}
 	task.Meta = map[string]string{"taskmeta": "taskmetaval"}
 	builder := NewBuilder(mock.Node(), a, task, "global")
@@ -339,6 +342,9 @@ func TestEnvironment_UpdateTask(t *testing.T) {
 	origMap := builder.Build().Map()
 	if origMap["NOMAD_TASK_NAME"] != "orig" {
 		t.Errorf("Expected NOMAD_TASK_NAME=orig but found %q", origMap["NOMAD_TASK_NAME"])
+	}
+	if origMap["NOMAD_TASK_USER"] != "user1" {
+		t.Errorf("Expected NOMAD_TASK_USER=user1 but found %q", origMap["NOMAD_TASK_USER"])
 	}
 	if origMap["NOMAD_META_taskmeta"] != "taskmetaval" {
 		t.Errorf("Expected NOMAD_META_taskmeta=taskmetaval but found %q", origMap["NOMAD_META_taskmeta"])
@@ -352,12 +358,16 @@ func TestEnvironment_UpdateTask(t *testing.T) {
 
 	a.Job.TaskGroups[0].Meta = map[string]string{"tgmeta2": "tgmetaval2"}
 	task.Name = "new"
+	task.User = ""
 	task.Env = map[string]string{"taskenv2": "taskenvval2"}
 	task.Meta = map[string]string{"taskmeta2": "taskmetaval2"}
 
 	newMap := builder.UpdateTask(a, task).Build().Map()
 	if newMap["NOMAD_TASK_NAME"] != "new" {
 		t.Errorf("Expected NOMAD_TASK_NAME=new but found %q", newMap["NOMAD_TASK_NAME"])
+	}
+	if newMap["NOMAD_TASK_USER"] != dstructs.DefaultUnpriviledgedUser {
+		t.Errorf("Expected NOMAD_TASK_USER=%s but found %q", dstructs.DefaultUnpriviledgedUser, newMap["NOMAD_TASK_USER"])
 	}
 	if newMap["NOMAD_META_taskmeta2"] != "taskmetaval2" {
 		t.Errorf("Expected NOMAD_META_taskmeta=taskmetaval but found %q", newMap["NOMAD_META_taskmeta2"])

--- a/client/driver/env/env_test.go
+++ b/client/driver/env/env_test.go
@@ -156,6 +156,7 @@ func TestEnvironment_AsList(t *testing.T) {
 		},
 	}
 	task := a.Job.TaskGroups[0].Tasks[0]
+	task.User = "ubuntu"
 	task.Env = map[string]string{
 		"taskEnvKey": "taskEnvVal",
 	}

--- a/website/source/docs/agent/configuration/client.html.md
+++ b/website/source/docs/agent/configuration/client.html.md
@@ -141,6 +141,14 @@ client {
 }
 ```
 
+Both source and destination paths support [interpretable Nomad variables]
+(/docs/runtime/interpolation.html) and so the task user's home directory can be
+mapped into the chroot by adding the following to the `chroot_env` map:
+
+```hcl
+    "/home/${NOMAD_TASK_USER}" = "/home/${NOMAD_TASK_USER}"
+```
+
 When `chroot_env` is unspecified, the `exec` driver will use a default chroot
 environment with the most commonly used parts of the operating system. Please
 see the [Nomad `exec` driver documentation](/docs/drivers/exec.html#chroot) for

--- a/website/source/docs/runtime/_envvars.html.md.erb
+++ b/website/source/docs/runtime/_envvars.html.md.erb
@@ -48,6 +48,10 @@
     <td>Allocation index; useful to distinguish instances of task groups. From 0 to (count - 1).</td>
   </tr>
   <tr>
+    <td><tt>NOMAD_TASK_USER</tt></td>
+    <td>User running the task</td>
+  </tr>
+  <tr>
     <td><tt>NOMAD_TASK_NAME</tt></td>
     <td>Task's name</td>
   </tr>


### PR DESCRIPTION
- Adds NOMAD_TASK_USER environment variable which contains the user which will run the task at execution time
- Adds interpolation support to the Client chroot_env config property for the exec driver, primarily to allow the chroot to map in the home directory of user who will run the task
- Updates documentation accordingly