### PR TITLE
Fix autocmpleting global flags

### DIFF
--- a/vendor/github.com/mitchellh/cli/README.md
+++ b/vendor/github.com/mitchellh/cli/README.md
@@ -18,6 +18,9 @@ cli is the library that powers the CLI for
 * Optional support for default subcommands so `cli` does something
   other than error.
 
+* Support for shell autocompletion of subcommands, flags, and arguments
+  with callbacks in Go. You don't need to write any shell code.
+
 * Automatic help generation for listing subcommands
 
 * Automatic help flag recognition of `-h`, `--help`, etc.

--- a/vendor/github.com/mitchellh/cli/cli.go
+++ b/vendor/github.com/mitchellh/cli/cli.go
@@ -153,6 +153,14 @@ func (c *CLI) IsVersion() bool {
 func (c *CLI) Run() (int, error) {
 	c.once.Do(c.init)
 
+	// If this is a autocompletion request, satisfy it. This must be called
+	// first before anything else since its possible to be autocompleting
+	// -help or -version or other flags and we want to show completions
+	// and not actually write the help or version.
+	if c.Autocomplete && c.autocomplete.Complete() {
+		return 0, nil
+	}
+
 	// Just show the version and exit if instructed.
 	if c.IsVersion() && c.Version != "" {
 		c.HelpWriter.Write([]byte(c.Version + "\n"))
@@ -195,11 +203,6 @@ func (c *CLI) Run() (int, error) {
 				return 1, err
 			}
 
-			return 0, nil
-		}
-
-		// If this is a autocompletion request, satisfy it
-		if c.autocomplete.Complete() {
 			return 0, nil
 		}
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -976,10 +976,10 @@
 			"revision": "7e024ce8ce18b21b475ac6baf8fa3c42536bf2fa"
 		},
 		{
-			"checksumSHA1": "F9rKfF4/KI5jhVBBIMuf6eDnTN0=",
+			"checksumSHA1": "cwT95naFga0RFGUZsCT1NeX5ncI=",
 			"path": "github.com/mitchellh/cli",
-			"revision": "4796e5fef694378c14b647f7221591afa58e38cd",
-			"revisionTime": "2017-07-17T21:49:25Z"
+			"revision": "921cc83dadc195c0cd67f9df3a6ec822400a1df5",
+			"revisionTime": "2017-07-25T23:05:51Z"
 		},
 		{
 			"checksumSHA1": "ttEN1Aupb7xpPMkQLqb3tzLFdXs=",


### PR DESCRIPTION
This PR vendors a change to the CLI package that allows autocompleting
global flags at the top level command.