### PR TITLE
Ensure backwards compatibility between 0.6.X CLI and 0.5.X

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -199,7 +199,7 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 		fmt.Sprintf("Name|%s", alloc.Name),
 		fmt.Sprintf("Node ID|%s", limit(alloc.NodeID, uuidLength)),
 		fmt.Sprintf("Job ID|%s", alloc.JobID),
-		fmt.Sprintf("Job Version|%d", *alloc.Job.Version),
+		fmt.Sprintf("Job Version|%d", getVersion(alloc.Job)),
 		fmt.Sprintf("Client Status|%s", alloc.ClientStatus),
 		fmt.Sprintf("Client Description|%s", alloc.ClientDescription),
 		fmt.Sprintf("Desired Status|%s", alloc.DesiredStatus),

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -292,3 +292,29 @@ func (j *JobGetter) ApiJob(jpath string) (*api.Job, error) {
 
 	return jobStruct, nil
 }
+
+// COMPAT: Remove in 0.7.0
+// Nomad 0.6.0 introduces the submit time field so CLI's interacting with
+// older versions of Nomad would SEGFAULT as reported here:
+// https://github.com/hashicorp/nomad/issues/2918
+// getSubmitTime returns a submit time of the job converting to time.Time
+func getSubmitTime(job *api.Job) time.Time {
+	if job.SubmitTime != nil {
+		return time.Unix(0, *job.SubmitTime)
+	}
+
+	return time.Time{}
+}
+
+// COMPAT: Remove in 0.7.0
+// Nomad 0.6.0 introduces job Versions so CLI's interacting with
+// older versions of Nomad would SEGFAULT as reported here:
+// https://github.com/hashicorp/nomad/issues/2918
+// getVersion returns a version of the job in safely.
+func getVersion(job *api.Job) uint64 {
+	if job.Version != nil {
+		return *job.Version
+	}
+
+	return 0
+}

--- a/command/status.go
+++ b/command/status.go
@@ -138,11 +138,11 @@ func (c *StatusCommand) Run(args []string) int {
 	basic := []string{
 		fmt.Sprintf("ID|%s", *job.ID),
 		fmt.Sprintf("Name|%s", *job.Name),
-		fmt.Sprintf("Submit Date|%s", formatTime(time.Unix(0, *job.SubmitTime))),
+		fmt.Sprintf("Submit Date|%s", formatTime(getSubmitTime(job))),
 		fmt.Sprintf("Type|%s", *job.Type),
 		fmt.Sprintf("Priority|%d", *job.Priority),
 		fmt.Sprintf("Datacenters|%s", strings.Join(job.Datacenters, ",")),
-		fmt.Sprintf("Status|%s", getStatusString(*job.Status, *job.Stop)),
+		fmt.Sprintf("Status|%s", getStatusString(*job.Status, job.Stop)),
 		fmt.Sprintf("Periodic|%v", periodic),
 		fmt.Sprintf("Parameterized|%v", parameterized),
 	}
@@ -421,7 +421,7 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 				limit(alloc.EvalID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
 				alloc.TaskGroup,
-				*alloc.Job.Version,
+				getVersion(alloc.Job),
 				alloc.DesiredStatus,
 				alloc.ClientStatus,
 				formatUnixNanoTime(alloc.CreateTime))
@@ -433,7 +433,7 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 				limit(alloc.ID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
 				alloc.TaskGroup,
-				*alloc.Job.Version,
+				getVersion(alloc.Job),
 				alloc.DesiredStatus,
 				alloc.ClientStatus,
 				formatUnixNanoTime(alloc.CreateTime))
@@ -534,7 +534,7 @@ func createStatusListOutput(jobs []*api.JobListStub) string {
 			job.ID,
 			getTypeString(job),
 			job.Priority,
-			getStatusString(job.Status, job.Stop),
+			getStatusString(job.Status, &job.Stop),
 			formatTime(time.Unix(0, job.SubmitTime)))
 	}
 	return formatList(out)
@@ -554,8 +554,8 @@ func getTypeString(job *api.JobListStub) string {
 	return t
 }
 
-func getStatusString(status string, stop bool) string {
-	if stop {
+func getStatusString(status string, stop *bool) string {
+	if stop != nil && *stop {
 		return fmt.Sprintf("%s (stopped)", status)
 	}
 	return status


### PR DESCRIPTION
This PR goes through the CLI commands and ensures that a 0.6.X cli
gracefully handles interacting with a 0.5.X Nomad Agent.

Fixes https://github.com/hashicorp/nomad/issues/2918