### PR TITLE
build: Remove gox as a tool dependency

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,6 @@
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 EXTERNAL_TOOLS=\
 	       github.com/kardianos/govendor \
-	       github.com/mitchellh/gox \
 	       golang.org/x/tools/cmd/cover \
 	       github.com/axw/gocov/gocov \
 	       gopkg.in/matm/v1/gocov-html \


### PR DESCRIPTION
Gox has not been used since commit 1aec23bb8, so there is no need to install it during bootstrap.