### PR TITLE
meta: Fix goimports for command/agent/syslog.go

### DIFF
--- a/command/agent/syslog.go
+++ b/command/agent/syslog.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+
 	"github.com/hashicorp/go-syslog"
 	"github.com/hashicorp/logutils"
 )


### PR DESCRIPTION
This commit allows the `goimports` linter to pass correctly.