### PR TITLE
Distinct Property supports arbitrary limit

### DIFF
--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -76,6 +76,20 @@ func IntMin(a, b int) int {
 	return b
 }
 
+func IntMax(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func Uint64Max(a, b uint64) uint64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 // MapStringStringSliceValueSet returns the set of values in a map[string][]string
 func MapStringStringSliceValueSet(m map[string][]string) []string {
 	set := make(map[string]struct{})

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1323,6 +1323,61 @@ func TestConstraint_Validate(t *testing.T) {
 	if !strings.Contains(mErr.Errors[0].Error(), "Malformed constraint") {
 		t.Fatalf("err: %s", err)
 	}
+
+	// Perform distinct_property validation
+	c.Operand = ConstraintDistinctProperty
+	c.RTarget = "0"
+	err = c.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Errors[0].Error(), "count of 1 or greater") {
+		t.Fatalf("err: %s", err)
+	}
+
+	c.RTarget = "-1"
+	err = c.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Errors[0].Error(), "to uint64") {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Perform distinct_hosts validation
+	c.Operand = ConstraintDistinctHosts
+	c.RTarget = "foo"
+	err = c.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Errors[0].Error(), "doesn't allow RTarget") {
+		t.Fatalf("err: %s", err)
+	}
+	if !strings.Contains(mErr.Errors[1].Error(), "doesn't allow LTarget") {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Perform set_contains validation
+	c.Operand = ConstraintSetContains
+	c.RTarget = ""
+	err = c.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Errors[0].Error(), "requires an RTarget") {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Perform LTarget validation
+	c.Operand = ConstraintRegex
+	c.RTarget = "foo"
+	c.LTarget = ""
+	err = c.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Errors[0].Error(), "No LTarget") {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Perform constraint type validation
+	c.Operand = "foo"
+	err = c.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Errors[0].Error(), "Unknown constraint type") {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestUpdateStrategy_Validate(t *testing.T) {

--- a/scheduler/propertyset.go
+++ b/scheduler/propertyset.go
@@ -2,8 +2,10 @@ package scheduler
 
 import (
 	"fmt"
+	"strconv"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -21,21 +23,25 @@ type propertySet struct {
 	// constraint is the constraint this property set is checking
 	constraint *structs.Constraint
 
+	// allowedCount is the allowed number of allocations that can have the
+	// distinct property
+	allowedCount uint64
+
 	// errorBuilding marks whether there was an error when building the property
 	// set
 	errorBuilding error
 
-	// existingValues is the set of values for the given property that have been
-	// used by pre-existing allocations.
-	existingValues map[string]struct{}
+	// existingValues is a mapping of the values of a property to the number of
+	// times the value has been used by pre-existing allocations.
+	existingValues map[string]uint64
 
-	// proposedValues is the set of values for the given property that are used
-	// from proposed allocations.
-	proposedValues map[string]struct{}
+	// proposedValues is a mapping of the values of a property to the number of
+	// times the value has been used by proposed allocations.
+	proposedValues map[string]uint64
 
-	// clearedValues is the set of values that are no longer being used by
-	// existingValues because of proposed stops.
-	clearedValues map[string]struct{}
+	// clearedValues is a mapping of the values of a property to the number of
+	// times the value has been used by proposed stopped allocations.
+	clearedValues map[string]uint64
 }
 
 // NewPropertySet returns a new property set used to guarantee unique property
@@ -44,7 +50,7 @@ func NewPropertySet(ctx Context, job *structs.Job) *propertySet {
 	p := &propertySet{
 		ctx:            ctx,
 		jobID:          job.ID,
-		existingValues: make(map[string]struct{}),
+		existingValues: make(map[string]uint64),
 	}
 
 	return p
@@ -53,26 +59,42 @@ func NewPropertySet(ctx Context, job *structs.Job) *propertySet {
 // SetJobConstraint is used to parameterize the property set for a
 // distinct_property constraint set at the job level.
 func (p *propertySet) SetJobConstraint(constraint *structs.Constraint) {
-	// Store the constraint
-	p.constraint = constraint
-	p.populateExisting(constraint)
-
-	// Populate the proposed when setting the constraint. We do this because
-	// when detecting if we can inplace update an allocation we stage an
-	// eviction and then select. This means the plan has an eviction before a
-	// single select has finished.
-	p.PopulateProposed()
+	p.setConstraint(constraint, "")
 }
 
 // SetTGConstraint is used to parameterize the property set for a
 // distinct_property constraint set at the task group level. The inputs are the
 // constraint and the task group name.
 func (p *propertySet) SetTGConstraint(constraint *structs.Constraint, taskGroup string) {
+	p.setConstraint(constraint, taskGroup)
+}
+
+// setConstraint is a shared helper for setting a job or task group constraint.
+func (p *propertySet) setConstraint(constraint *structs.Constraint, taskGroup string) {
 	// Store that this is for a task group
-	p.taskGroup = taskGroup
+	if taskGroup != "" {
+		p.taskGroup = taskGroup
+	}
 
 	// Store the constraint
 	p.constraint = constraint
+
+	// Determine the number of allowed allocations with the property.
+	if v := constraint.RTarget; v != "" {
+		c, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			p.errorBuilding = fmt.Errorf("failed to convert RTarget %q to uint64: %v", v, err)
+			p.ctx.Logger().Printf("[ERR] scheduler.dynamic-constraint: %v", p.errorBuilding)
+			return
+		}
+
+		p.allowedCount = c
+	} else {
+		p.allowedCount = 1
+	}
+
+	// Determine the number of existing allocations that are using a property
+	// value
 	p.populateExisting(constraint)
 
 	// Populate the proposed when setting the constraint. We do this because
@@ -80,6 +102,7 @@ func (p *propertySet) SetTGConstraint(constraint *structs.Constraint, taskGroup 
 	// eviction and then select. This means the plan has an eviction before a
 	// single select has finished.
 	p.PopulateProposed()
+
 }
 
 // populateExisting is a helper shared when setting the constraint to populate
@@ -115,8 +138,8 @@ func (p *propertySet) populateExisting(constraint *structs.Constraint) {
 func (p *propertySet) PopulateProposed() {
 
 	// Reset the proposed properties
-	p.proposedValues = make(map[string]struct{})
-	p.clearedValues = make(map[string]struct{})
+	p.proposedValues = make(map[string]uint64)
+	p.clearedValues = make(map[string]uint64)
 
 	// Gather the set of proposed stops.
 	var stopping []*structs.Allocation
@@ -151,7 +174,14 @@ func (p *propertySet) PopulateProposed() {
 
 	// Remove any cleared value that is now being used by the proposed allocs
 	for value := range p.proposedValues {
-		delete(p.clearedValues, value)
+		current, ok := p.clearedValues[value]
+		if !ok {
+			continue
+		} else if current == 0 {
+			delete(p.clearedValues, value)
+		} else if current > 1 {
+			p.clearedValues[value]--
+		}
 	}
 }
 
@@ -171,27 +201,40 @@ func (p *propertySet) SatisfiesDistinctProperties(option *structs.Node, tg strin
 		return false, fmt.Sprintf("missing property %q", p.constraint.LTarget)
 	}
 
-	// both is used to iterate over both the proposed and existing used
-	// properties
-	bothAll := []map[string]struct{}{p.existingValues, p.proposedValues}
-
-	// Check if the nodes value has already been used.
-	for _, usedProperties := range bothAll {
-		// Check if the nodes value has been used
-		_, used := usedProperties[nValue]
-		if !used {
-			continue
+	// combine the counts of how many times the property has been used by
+	// existing and proposed allocations
+	combinedUse := make(map[string]uint64, helper.IntMax(len(p.existingValues), len(p.proposedValues)))
+	for _, usedValues := range []map[string]uint64{p.existingValues, p.proposedValues} {
+		for propertyValue, usedCount := range usedValues {
+			combinedUse[propertyValue] += usedCount
 		}
-
-		// Check if the value has been cleared from a proposed stop
-		if _, cleared := p.clearedValues[nValue]; cleared {
-			continue
-		}
-
-		return false, fmt.Sprintf("distinct_property: %s=%s already used", p.constraint.LTarget, nValue)
 	}
 
-	return true, ""
+	// Go through and discount the combined count when the value has been
+	// cleared by a proposed stop.
+	for propertyValue, clearedCount := range p.clearedValues {
+		combined, ok := combinedUse[propertyValue]
+		if !ok {
+			continue
+		}
+
+		// Don't clear below 0.
+		combinedUse[propertyValue] = helper.Uint64Max(0, combined-clearedCount)
+	}
+
+	usedCount, used := combinedUse[nValue]
+	if !used {
+		// The property value has never been used so we can use it.
+		return true, ""
+	}
+
+	// The property value has been used but within the number of allowed
+	// allocations.
+	if usedCount < p.allowedCount {
+		return true, ""
+	}
+
+	return false, fmt.Sprintf("distinct_property: %s=%s used by %d allocs", p.constraint.LTarget, nValue, usedCount)
 }
 
 // filterAllocs filters a set of allocations to just be those that are running
@@ -245,7 +288,7 @@ func (p *propertySet) buildNodeMap(allocs []*structs.Allocation) (map[string]*st
 // populateProperties goes through all allocations and builds up the used
 // properties from the nodes storing the results in the passed properties map.
 func (p *propertySet) populateProperties(allocs []*structs.Allocation, nodes map[string]*structs.Node,
-	properties map[string]struct{}) {
+	properties map[string]uint64) {
 
 	for _, alloc := range allocs {
 		nProperty, ok := getProperty(nodes[alloc.NodeID], p.constraint.LTarget)
@@ -253,7 +296,7 @@ func (p *propertySet) populateProperties(allocs []*structs.Allocation, nodes map
 			continue
 		}
 
-		properties[nProperty] = struct{}{}
+		properties[nProperty]++
 	}
 }
 

--- a/scheduler/propertyset.go
+++ b/scheduler/propertyset.go
@@ -102,7 +102,6 @@ func (p *propertySet) setConstraint(constraint *structs.Constraint, taskGroup st
 	// eviction and then select. This means the plan has an eviction before a
 	// single select has finished.
 	p.PopulateProposed()
-
 }
 
 // populateExisting is a helper shared when setting the constraint to populate
@@ -219,7 +218,11 @@ func (p *propertySet) SatisfiesDistinctProperties(option *structs.Node, tg strin
 		}
 
 		// Don't clear below 0.
-		combinedUse[propertyValue] = helper.Uint64Max(0, combined-clearedCount)
+		if combined >= clearedCount {
+			combinedUse[propertyValue] = combined - clearedCount
+		} else {
+			combinedUse[propertyValue] = 0
+		}
 	}
 
 	usedCount, used := combinedUse[nValue]

--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -537,7 +537,9 @@ The `Constraint` object supports the following keys:
         omitted.
 
   - `distinct_property` - If set, the scheduler selects nodes that have a
-        distinct value of the specified property for each allocation. This can
+        distinct value of the specified property. The `RTarget` specifies how
+        many allocations are allowed to share the value of a property. The
+        `RTarget` must be 1 or greater and if omitted, defaults to 1. This can
         be specified as a job constraint which applies the constraint to all
         task groups in the job, or as a task group constraint which scopes the
         effect to just that group. The constraint may not be specified at the

--- a/website/source/docs/job-specification/constraint.html.md
+++ b/website/source/docs/job-specification/constraint.html.md
@@ -75,6 +75,8 @@ all groups (and tasks) in the job.
     >=
     <
     <=
+    distinct_hosts
+    distinct_property
     regexp
     set_contains
     version
@@ -124,16 +126,18 @@ constraint {
     ```
 
 - `"distinct_property"` - Instructs the scheduler to select nodes that have a
-  distinct value of the specified property for each allocation. When specified
-  as a job constraint, it applies to all groups in the job. When specified as a
-  group constraint, the effect is constrained to that group. This constraint can
-  not be specified at the task level. Note that the `value` parameter should be
-  omitted when using this constraint.
+  distinct value of the specified property. The `value` parameter specifies how
+  many allocations are allowed to share the value of a property. The `value`
+  must be 1 or greater and if omitted, defaults to 1.  When specified as a job
+  constraint, it applies to all groups in the job. When specified as a group
+  constraint, the effect is constrained to that group. This constraint can not
+  be specified at the task level. 
 
     ```hcl
     constraint {
       operator  = "distinct_property"
       attribute = "${meta.rack}"
+      value     = "3"
     }
     ```
 
@@ -142,7 +146,8 @@ constraint {
 
     ```hcl
     constraint {
-        distinct_property = "${meta.rack}"
+      distinct_property = "${meta.rack}"
+      value     = "3"
     }
     ```
 
@@ -209,13 +214,14 @@ constraint {
 A potential use case of the `distinct_property` constraint is to spread a
 service with `count > 1` across racks to minimize correlated failure. Nodes can
 be annotated with which rack they are on using [client
-metadata][client-metadata] with values
-such as "rack-12-1", "rack-12-2", etc. The following constraint would then
-assure no two instances of the task group existed on the same rack.
+metadata][client-metadata] with values such as "rack-12-1", "rack-12-2", etc.
+The following constraint would assure that an individual rack is not running
+more than 2 instances of the task group.
 
 ```hcl
 constraint {
   distinct_property = "${meta.rack}"
+  value = "2"
 }
 ```
 


### PR DESCRIPTION
This PR enhances the distinct_property constraint such that a limit can be
specified in the RTarget/value parameter. This allows constraints such as:

``` constraint {
 distinct_property = "${meta.rack}"
 value = "2"
}
```

This restricts any given rack from running more than 2 allocations from the
task group.

This PR also adds better validation of the constraints.

Fixes https://github.com/hashicorp/nomad/issues/1146