### PR TITLE
meta: Set main.VersionPrerelease="dev"

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,7 +15,7 @@ const Version = "0.6.0"
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
-const VersionPrerelease = ""
+const VersionPrerelease = "dev"
 
 // GetVersionParts returns the Nomad version strings. Printing of the Nomad
 // version should be used in conjunction with the PrettyVersion method.


### PR DESCRIPTION
For most projects using this versioning system, making a commit bumping the version and re-adding the development tag is part of the release SOP (certainly it was for Terraform!)

I'm not sure why it didn't happen here, but without this, all development builds show up as Nomad v0.6.0 with no dirty marker or commit marker.

It might make sense to change this such that the special case is for _release_ builds rather than for prerelease builds in order to prevent this happening again.