### PR TITLE
autocomplete api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.6.1 (Unreleased)
 
 IMPROVEMENTS:
+ * core: Add autocomplete functionality for resources: allocations,
+   evaluations, jobs, and nodes [GH-2964]
  * core: `distinct_property` constraint can set the number of allocations that
    are allowed to share a property value [GH-2942]
  * driver/rkt: support read-only volume mounts [GH-2883]

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -145,6 +145,8 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/evaluations", s.wrap(s.EvalsRequest))
 	s.mux.HandleFunc("/v1/evaluation/", s.wrap(s.EvalSpecificRequest))
 
+	s.mux.HandleFunc("/v1/resources/", s.wrap(s.ResourcesRequest))
+
 	s.mux.HandleFunc("/v1/deployments", s.wrap(s.DeploymentsRequest))
 	s.mux.HandleFunc("/v1/deployment/", s.wrap(s.DeploymentSpecificRequest))
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -145,7 +145,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/evaluations", s.wrap(s.EvalsRequest))
 	s.mux.HandleFunc("/v1/evaluation/", s.wrap(s.EvalSpecificRequest))
 
-	s.mux.HandleFunc("/v1/resources/", s.wrap(s.ResourcesRequest))
+	s.mux.HandleFunc("/v1/resources/", s.wrap(s.ResourceListRequest))
 
 	s.mux.HandleFunc("/v1/deployments", s.wrap(s.DeploymentsRequest))
 	s.mux.HandleFunc("/v1/deployment/", s.wrap(s.DeploymentSpecificRequest))

--- a/command/agent/resources_endpoint.go
+++ b/command/agent/resources_endpoint.go
@@ -6,12 +6,10 @@ import (
 )
 
 func (s *HTTPServer) ResourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	switch req.Method {
-	case "POST":
+	if req.Method == "POST" || req.Method == "PUT" {
 		return s.resourcesRequest(resp, req)
-	default:
-		return nil, CodedError(405, ErrInvalidMethod)
 	}
+	return nil, CodedError(405, ErrInvalidMethod)
 }
 
 func (s *HTTPServer) resourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/resources_endpoint.go
+++ b/command/agent/resources_endpoint.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ResourcesRequest accepts a prefix and context and returns a list of matching
-// prefixes for that context.
+// IDs for that context.
 func (s *HTTPServer) ResourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if req.Method == "POST" || req.Method == "PUT" {
 		return s.resourcesRequest(resp, req)

--- a/command/agent/resources_endpoint.go
+++ b/command/agent/resources_endpoint.go
@@ -1,0 +1,30 @@
+package agent
+
+import (
+	"github.com/hashicorp/nomad/nomad/structs"
+	"net/http"
+)
+
+func (s *HTTPServer) ResourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	switch req.Method {
+	case "GET":
+		return s.resourcesRequest(resp, req)
+	default:
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+}
+
+func (s *HTTPServer) resourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// TODO test a failure case for this?
+	args := structs.ResourcesRequest{}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var out structs.ResourcesResponse
+	if err := s.agent.RPC("Resources.List", &args, &out); err != nil {
+		return nil, err
+	}
+
+	return &out.Resources, nil
+}

--- a/command/agent/resources_endpoint.go
+++ b/command/agent/resources_endpoint.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 )
 
-// ResourcesRequest accepts a prefix and context and returns a list of matching
+// ResourceListRequest accepts a prefix and context and returns a list of matching
 // IDs for that context.
-func (s *HTTPServer) ResourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (s *HTTPServer) ResourceListRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if req.Method == "POST" || req.Method == "PUT" {
 		return s.resourcesRequest(resp, req)
 	}
@@ -15,13 +15,13 @@ func (s *HTTPServer) ResourcesRequest(resp http.ResponseWriter, req *http.Reques
 }
 
 func (s *HTTPServer) resourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	args := structs.ResourcesRequest{}
+	args := structs.ResourceListRequest{}
 
 	if err := decodeBody(req, &args); err != nil {
 		return nil, CodedError(400, err.Error())
 	}
 
-	var out structs.ResourcesResponse
+	var out structs.ResourceListResponse
 	if err := s.agent.RPC("Resources.List", &args, &out); err != nil {
 		return nil, err
 	}

--- a/command/agent/resources_endpoint.go
+++ b/command/agent/resources_endpoint.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 )
 
+// ResourcesRequest accepts a prefix and context and returns a list of matching
+// prefixes for that context.
 func (s *HTTPServer) ResourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if req.Method == "POST" || req.Method == "PUT" {
 		return s.resourcesRequest(resp, req)
@@ -13,10 +15,8 @@ func (s *HTTPServer) ResourcesRequest(resp http.ResponseWriter, req *http.Reques
 }
 
 func (s *HTTPServer) resourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	// TODO test a failure case for this?
 	args := structs.ResourcesRequest{}
 
-	// TODO this should be tested
 	if err := decodeBody(req, &args); err != nil {
 		return nil, CodedError(400, err.Error())
 	}
@@ -26,5 +26,6 @@ func (s *HTTPServer) resourcesRequest(resp http.ResponseWriter, req *http.Reques
 		return nil, err
 	}
 
+	setMeta(resp, &out.QueryMeta)
 	return out, nil
 }

--- a/command/agent/resources_endpoint.go
+++ b/command/agent/resources_endpoint.go
@@ -7,7 +7,7 @@ import (
 
 func (s *HTTPServer) ResourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
-	case "GET":
+	case "POST":
 		return s.resourcesRequest(resp, req)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -17,8 +17,10 @@ func (s *HTTPServer) ResourcesRequest(resp http.ResponseWriter, req *http.Reques
 func (s *HTTPServer) resourcesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// TODO test a failure case for this?
 	args := structs.ResourcesRequest{}
-	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
-		return nil, nil
+
+	// TODO this should be tested
+	if err := decodeBody(req, &args); err != nil {
+		return nil, CodedError(400, err.Error())
 	}
 
 	var out structs.ResourcesResponse

--- a/command/agent/resources_endpoint.go
+++ b/command/agent/resources_endpoint.go
@@ -26,5 +26,5 @@ func (s *HTTPServer) resourcesRequest(resp http.ResponseWriter, req *http.Reques
 		return nil, err
 	}
 
-	return &out.Resources, nil
+	return out, nil
 }

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -36,7 +36,7 @@ func createJobForTest(jobID string, s *TestAgent, t *testing.T) {
 	}
 }
 
-func TestHTTP_ResourcesWithSingleJob(t *testing.T) {
+func TestHTTP_Resources_SingleJob(t *testing.T) {
 	testJob := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89706"
 	testJobPrefix := "aaaaaaaa-e8f7-fd38"
 	t.Parallel()
@@ -71,7 +71,7 @@ func TestHTTP_ResourcesWithSingleJob(t *testing.T) {
 	})
 }
 
-func TestHTTP_ResourcesWithMultipleJobs(t *testing.T) {
+func TestHTTP_Resources_MultipleJobs(t *testing.T) {
 	testJobA := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89706"
 	testJobB := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89707"
 	testJobC := "bbbbbbbb-e8f7-fd38-c855-ab94ceb89707"
@@ -113,7 +113,7 @@ func TestHTTP_ResourcesWithMultipleJobs(t *testing.T) {
 	})
 }
 
-func TestHTTP_ResoucesListForEvaluations(t *testing.T) {
+func TestHTTP_ResoucesList_Evaluation(t *testing.T) {
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {
 		state := s.Agent.server.State()

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -58,7 +58,7 @@ func TestHTTP_ResourcesWithSingleJob(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		res := resp.(*structs.ResourcesListStub)
+		res := resp.(structs.ResourcesResponse)
 		if len(res.Matches) != 1 {
 			t.Fatalf("No expected key values in resources list")
 		}
@@ -97,7 +97,7 @@ func TestHTTP_ResourcesWithMultipleJobs(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		res := resp.(*structs.ResourcesListStub)
+		res := resp.(structs.ResourcesResponse)
 		if len(res.Matches) != 1 {
 			t.Fatalf("No expected key values in resources list")
 		}

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -7,36 +7,37 @@ import (
 
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/stretchr/testify/assert"
+	a "github.com/stretchr/testify/assert"
 )
 
 func TestHTTP_ResourcesWithIllegalMethod(t *testing.T) {
+	assert := a.New(t)
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {
 		req, err := http.NewRequest("DELETE", "/v1/resources", nil)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
 		respW := httptest.NewRecorder()
 
 		_, err = s.Server.ResourcesRequest(respW, req)
-		assert.NotNil(t, err, "HTTP DELETE should not be accepted for this endpoint")
+		assert.NotNil(err, "HTTP DELETE should not be accepted for this endpoint")
 	})
 }
 
 func createJobForTest(jobID string, s *TestAgent, t *testing.T) {
+	assert := a.New(t)
+
 	job := mock.Job()
 	job.ID = jobID
 	job.TaskGroups[0].Count = 1
 
 	state := s.Agent.server.State()
 	err := state.UpsertJob(1000, job)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	assert.Nil(err)
 }
 
 func TestHTTP_Resources_POST(t *testing.T) {
+	assert := a.New(t)
+
 	testJob := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89706"
 	testJobPrefix := "aaaaaaaa-e8f7-fd38"
 	t.Parallel()
@@ -45,32 +46,30 @@ func TestHTTP_Resources_POST(t *testing.T) {
 
 		data := structs.ResourcesRequest{Prefix: testJobPrefix, Context: "jobs"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
+		assert.Nil(err)
 
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
 		respW := httptest.NewRecorder()
 
 		resp, err := s.Server.ResourcesRequest(respW, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
 
 		res := resp.(structs.ResourcesResponse)
 
-		assert.Equal(t, 1, len(res.Matches))
+		assert.Equal(1, len(res.Matches))
 
 		j := res.Matches["jobs"]
 
-		assert.Equal(t, 1, len(j))
-		assert.Equal(t, j[0], testJob)
+		assert.Equal(1, len(j))
+		assert.Equal(j[0], testJob)
 
-		assert.Equal(t, res.Truncations["job"], false)
-		assert.NotEqual(t, "0", respW.HeaderMap.Get("X-Nomad-Index"))
+		assert.Equal(res.Truncations["job"], false)
+		assert.NotEqual("0", respW.HeaderMap.Get("X-Nomad-Index"))
 	})
 }
 
 func TestHTTP_Resources_PUT(t *testing.T) {
+	assert := a.New(t)
+
 	testJob := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89706"
 	testJobPrefix := "aaaaaaaa-e8f7-fd38"
 	t.Parallel()
@@ -79,32 +78,30 @@ func TestHTTP_Resources_PUT(t *testing.T) {
 
 		data := structs.ResourcesRequest{Prefix: testJobPrefix, Context: "jobs"}
 		req, err := http.NewRequest("PUT", "/v1/resources", encodeReq(data))
+		assert.Nil(err)
 
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
 		respW := httptest.NewRecorder()
 
 		resp, err := s.Server.ResourcesRequest(respW, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
 
 		res := resp.(structs.ResourcesResponse)
 
-		assert.Equal(t, 1, len(res.Matches))
+		assert.Equal(1, len(res.Matches))
 
 		j := res.Matches["jobs"]
 
-		assert.Equal(t, 1, len(j))
-		assert.Equal(t, j[0], testJob)
+		assert.Equal(1, len(j))
+		assert.Equal(j[0], testJob)
 
-		assert.Equal(t, res.Truncations["job"], false)
-		assert.NotEqual(t, "0", respW.HeaderMap.Get("X-Nomad-Index"))
+		assert.Equal(res.Truncations["job"], false)
+		assert.NotEqual("0", respW.HeaderMap.Get("X-Nomad-Index"))
 	})
 }
 
 func TestHTTP_Resources_MultipleJobs(t *testing.T) {
+	assert := a.New(t)
+
 	testJobA := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89706"
 	testJobB := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89707"
 	testJobC := "bbbbbbbb-e8f7-fd38-c855-ab94ceb89707"
@@ -119,34 +116,32 @@ func TestHTTP_Resources_MultipleJobs(t *testing.T) {
 
 		data := structs.ResourcesRequest{Prefix: testJobPrefix, Context: "jobs"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
+		assert.Nil(err)
 
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
 		respW := httptest.NewRecorder()
 
 		resp, err := s.Server.ResourcesRequest(respW, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
 
 		res := resp.(structs.ResourcesResponse)
 
-		assert.Equal(t, 1, len(res.Matches))
+		assert.Equal(1, len(res.Matches))
 
 		j := res.Matches["jobs"]
 
-		assert.Equal(t, 2, len(j))
-		assert.Contains(t, j, testJobA)
-		assert.Contains(t, j, testJobB)
-		assert.NotContains(t, j, testJobC)
+		assert.Equal(2, len(j))
+		assert.Contains(j, testJobA)
+		assert.Contains(j, testJobB)
+		assert.NotContains(j, testJobC)
 
-		assert.Equal(t, res.Truncations["job"], false)
-		assert.NotEqual(t, "0", respW.HeaderMap.Get("X-Nomad-Index"))
+		assert.Equal(res.Truncations["job"], false)
+		assert.NotEqual("0", respW.HeaderMap.Get("X-Nomad-Index"))
 	})
 }
 
 func TestHTTP_ResoucesList_Evaluation(t *testing.T) {
+	assert := a.New(t)
+
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {
 		state := s.Agent.server.State()
@@ -154,63 +149,124 @@ func TestHTTP_ResoucesList_Evaluation(t *testing.T) {
 		eval2 := mock.Eval()
 		err := state.UpsertEvals(9000,
 			[]*structs.Evaluation{eval1, eval2})
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
 
 		prefix := eval1.ID[:len(eval1.ID)-2]
 		data := structs.ResourcesRequest{Prefix: prefix, Context: "evals"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
+
 		respW := httptest.NewRecorder()
 
 		resp, err := s.Server.ResourcesRequest(respW, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
 
 		res := resp.(structs.ResourcesResponse)
 
-		assert.Equal(t, 1, len(res.Matches))
+		assert.Equal(1, len(res.Matches))
 
 		j := res.Matches["evals"]
-		assert.Equal(t, 1, len(j))
-		assert.Contains(t, j, eval1.ID)
-		assert.NotContains(t, j, eval2.ID)
+		assert.Equal(1, len(j))
+		assert.Contains(j, eval1.ID)
+		assert.NotContains(j, eval2.ID)
 
-		assert.Equal(t, res.Truncations["evals"], false)
-		assert.Equal(t, "9000", respW.HeaderMap.Get("X-Nomad-Index"))
+		assert.Equal(res.Truncations["evals"], false)
+		assert.Equal("9000", respW.HeaderMap.Get("X-Nomad-Index"))
+	})
+}
+
+func TestHTTP_ResoucesList_Allocations(t *testing.T) {
+	assert := a.New(t)
+
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		state := s.Agent.server.State()
+		alloc := mock.Alloc()
+		err := state.UpsertAllocs(7000, []*structs.Allocation{alloc})
+		assert.Nil(err)
+
+		prefix := alloc.ID[:len(alloc.ID)-2]
+		data := structs.ResourcesRequest{Prefix: prefix, Context: "allocs"}
+		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
+		assert.Nil(err)
+
+		respW := httptest.NewRecorder()
+
+		resp, err := s.Server.ResourcesRequest(respW, req)
+		assert.Nil(err)
+
+		res := resp.(structs.ResourcesResponse)
+
+		assert.Equal(1, len(res.Matches))
+
+		a := res.Matches["allocs"]
+		assert.Equal(1, len(a))
+		assert.Contains(a, alloc.ID)
+
+		assert.Equal(res.Truncations["allocs"], false)
+		assert.Equal("7000", respW.HeaderMap.Get("X-Nomad-Index"))
+	})
+}
+
+func TestHTTP_ResoucesList_Nodes(t *testing.T) {
+	assert := a.New(t)
+
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		state := s.Agent.server.State()
+		node := mock.Node()
+		err := state.UpsertNode(6000, node)
+		assert.Nil(err)
+
+		prefix := node.ID[:len(node.ID)-2]
+		data := structs.ResourcesRequest{Prefix: prefix, Context: "nodes"}
+		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
+		assert.Nil(err)
+
+		respW := httptest.NewRecorder()
+
+		resp, err := s.Server.ResourcesRequest(respW, req)
+		assert.Nil(err)
+
+		res := resp.(structs.ResourcesResponse)
+
+		assert.Equal(1, len(res.Matches))
+
+		n := res.Matches["nodes"]
+		assert.Equal(1, len(n))
+		assert.Contains(n, node.ID)
+
+		assert.Equal(res.Truncations["nodes"], false)
+		assert.Equal("6000", respW.HeaderMap.Get("X-Nomad-Index"))
 	})
 }
 
 func TestHTTP_Resources_NoJob(t *testing.T) {
+	assert := a.New(t)
+
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {
 		data := structs.ResourcesRequest{Prefix: "12345", Context: "jobs"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
+		assert.Nil(err)
 
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
 		respW := httptest.NewRecorder()
 
 		resp, err := s.Server.ResourcesRequest(respW, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
 
 		res := resp.(structs.ResourcesResponse)
 
-		assert.Equal(t, 1, len(res.Matches))
-		assert.Equal(t, 0, len(res.Matches["jobs"]))
+		assert.Equal(1, len(res.Matches))
+		assert.Equal(0, len(res.Matches["jobs"]))
 
-		assert.Equal(t, "0", respW.HeaderMap.Get("X-Nomad-Index"))
+		assert.Equal("0", respW.HeaderMap.Get("X-Nomad-Index"))
 	})
 }
 
 func TestHTTP_Resources_NoContext(t *testing.T) {
+	assert := a.New(t)
+
 	testJobID := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89706"
 	testJobPrefix := "aaaaaaaa-e8f7-fd38"
 	t.Parallel()
@@ -222,32 +278,26 @@ func TestHTTP_Resources_NoContext(t *testing.T) {
 		eval1.ID = testJobID
 		err := state.UpsertEvals(9000,
 			[]*structs.Evaluation{eval1})
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
 
 		data := structs.ResourcesRequest{Prefix: testJobPrefix}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
+		assert.Nil(err)
 
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
 		respW := httptest.NewRecorder()
 
 		resp, err := s.Server.ResourcesRequest(respW, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		assert.Nil(err)
 
 		res := resp.(structs.ResourcesResponse)
 
 		matchedJobs := res.Matches["jobs"]
 		matchedEvals := res.Matches["evals"]
 
-		assert.Equal(t, 1, len(matchedJobs))
-		assert.Equal(t, 1, len(matchedEvals))
+		assert.Equal(1, len(matchedJobs))
+		assert.Equal(1, len(matchedEvals))
 
-		assert.Equal(t, matchedJobs[0], testJobID)
-		assert.Equal(t, matchedEvals[0], eval1.ID)
+		assert.Equal(matchedJobs[0], testJobID)
+		assert.Equal(matchedEvals[0], eval1.ID)
 	})
 }

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -276,8 +276,7 @@ func TestHTTP_Resources_NoContext(t *testing.T) {
 		state := s.Agent.server.State()
 		eval1 := mock.Eval()
 		eval1.ID = testJobID
-		err := state.UpsertEvals(9000,
-			[]*structs.Evaluation{eval1})
+		err := state.UpsertEvals(8000, []*structs.Evaluation{eval1})
 		assert.Nil(err)
 
 		data := structs.ResourcesRequest{Prefix: testJobPrefix}
@@ -299,5 +298,7 @@ func TestHTTP_Resources_NoContext(t *testing.T) {
 
 		assert.Equal(matchedJobs[0], testJobID)
 		assert.Equal(matchedEvals[0], eval1.ID)
+
+		assert.Equal("8000", respW.HeaderMap.Get("X-Nomad-Index"))
 	})
 }

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -28,12 +28,10 @@ func createJobForTest(jobID string, s *TestAgent, t *testing.T) {
 	job := mock.Job()
 	job.ID = jobID
 	job.TaskGroups[0].Count = 1
-	args := structs.JobRegisterRequest{
-		Job:          job,
-		WriteRequest: structs.WriteRequest{Region: "global"},
-	}
-	var resp structs.JobRegisterResponse
-	if err := s.Agent.RPC("Job.Register", &args, &resp); err != nil {
+
+	state := s.Agent.server.State()
+	err := state.UpsertJob(1000, job)
+	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,8 +45,9 @@ func TestHTTP_ResourcesWithSingleJob(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		createJobForTest(testJob, s, t)
 
-		endpoint := fmt.Sprintf("/v1/resources?context=job&prefix=%s&context=job", testJobPrefix)
-		req, err := http.NewRequest("GET", endpoint, nil)
+		data := structs.ResourcesRequest{Prefix: testJobPrefix, Context: "jobs"}
+		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
+
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -85,8 +85,9 @@ func TestHTTP_ResourcesWithMultipleJobs(t *testing.T) {
 		createJobForTest(testJobB, s, t)
 		createJobForTest(testJobC, s, t)
 
-		endpoint := fmt.Sprintf("/v1/resources?context=job&prefix=%s&context=job", testJobPrefix)
-		req, err := http.NewRequest("GET", endpoint, nil)
+		data := structs.ResourcesRequest{Prefix: testJobPrefix, Context: "jobs"}
+		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
+
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -113,6 +114,6 @@ func TestHTTP_ResourcesWithMultipleJobs(t *testing.T) {
 	})
 }
 
-//
+// TODO
 //func TestHTTP_ResourcesWithNoJob(t *testing.T) {
 //}

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -41,11 +41,12 @@ func createJobForTest(jobID string, s *TestAgent, t *testing.T) {
 
 func TestHTTP_ResourcesWithSingleJob(t *testing.T) {
 	testJob := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89706"
+	testJobPrefix := "aaaaaaaa-e8f7-fd38"
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {
 		createJobForTest(testJob, s, t)
 
-		endpoint := fmt.Sprintf("/v1/resources?context=job&prefix=%s", testJob)
+		endpoint := fmt.Sprintf("/v1/resources?context=job&prefix=%s", testJobPrefix)
 		req, err := http.NewRequest("GET", endpoint, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
@@ -67,8 +68,7 @@ func TestHTTP_ResourcesWithSingleJob(t *testing.T) {
 			t.Fatalf("The number of jobs that were returned does not equal the number of jobs we expected (1)", j)
 		}
 
-		// TODO verify that the job we are getting is the same that we created
-		//	assert.Equal(t, j[0], testJob)
+		assert.Equal(t, j[0], testJob)
 	})
 }
 

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -18,7 +18,7 @@ func TestHTTP_ResourcesWithIllegalMethod(t *testing.T) {
 		assert.Nil(err)
 		respW := httptest.NewRecorder()
 
-		_, err = s.Server.ResourcesRequest(respW, req)
+		_, err = s.Server.ResourceListRequest(respW, req)
 		assert.NotNil(err, "HTTP DELETE should not be accepted for this endpoint")
 	})
 }
@@ -44,16 +44,16 @@ func TestHTTP_Resources_POST(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		createJobForTest(testJob, s, t)
 
-		data := structs.ResourcesRequest{Prefix: testJobPrefix, Context: "jobs"}
+		data := structs.ResourceListRequest{Prefix: testJobPrefix, Context: "jobs"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
 		assert.Nil(err)
 
 		respW := httptest.NewRecorder()
 
-		resp, err := s.Server.ResourcesRequest(respW, req)
+		resp, err := s.Server.ResourceListRequest(respW, req)
 		assert.Nil(err)
 
-		res := resp.(structs.ResourcesResponse)
+		res := resp.(structs.ResourceListResponse)
 
 		assert.Equal(1, len(res.Matches))
 
@@ -76,16 +76,16 @@ func TestHTTP_Resources_PUT(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		createJobForTest(testJob, s, t)
 
-		data := structs.ResourcesRequest{Prefix: testJobPrefix, Context: "jobs"}
+		data := structs.ResourceListRequest{Prefix: testJobPrefix, Context: "jobs"}
 		req, err := http.NewRequest("PUT", "/v1/resources", encodeReq(data))
 		assert.Nil(err)
 
 		respW := httptest.NewRecorder()
 
-		resp, err := s.Server.ResourcesRequest(respW, req)
+		resp, err := s.Server.ResourceListRequest(respW, req)
 		assert.Nil(err)
 
-		res := resp.(structs.ResourcesResponse)
+		res := resp.(structs.ResourceListResponse)
 
 		assert.Equal(1, len(res.Matches))
 
@@ -114,16 +114,16 @@ func TestHTTP_Resources_MultipleJobs(t *testing.T) {
 		createJobForTest(testJobB, s, t)
 		createJobForTest(testJobC, s, t)
 
-		data := structs.ResourcesRequest{Prefix: testJobPrefix, Context: "jobs"}
+		data := structs.ResourceListRequest{Prefix: testJobPrefix, Context: "jobs"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
 		assert.Nil(err)
 
 		respW := httptest.NewRecorder()
 
-		resp, err := s.Server.ResourcesRequest(respW, req)
+		resp, err := s.Server.ResourceListRequest(respW, req)
 		assert.Nil(err)
 
-		res := resp.(structs.ResourcesResponse)
+		res := resp.(structs.ResourceListResponse)
 
 		assert.Equal(1, len(res.Matches))
 
@@ -152,16 +152,16 @@ func TestHTTP_ResoucesList_Evaluation(t *testing.T) {
 		assert.Nil(err)
 
 		prefix := eval1.ID[:len(eval1.ID)-2]
-		data := structs.ResourcesRequest{Prefix: prefix, Context: "evals"}
+		data := structs.ResourceListRequest{Prefix: prefix, Context: "evals"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
 		assert.Nil(err)
 
 		respW := httptest.NewRecorder()
 
-		resp, err := s.Server.ResourcesRequest(respW, req)
+		resp, err := s.Server.ResourceListRequest(respW, req)
 		assert.Nil(err)
 
-		res := resp.(structs.ResourcesResponse)
+		res := resp.(structs.ResourceListResponse)
 
 		assert.Equal(1, len(res.Matches))
 
@@ -186,16 +186,16 @@ func TestHTTP_ResoucesList_Allocations(t *testing.T) {
 		assert.Nil(err)
 
 		prefix := alloc.ID[:len(alloc.ID)-2]
-		data := structs.ResourcesRequest{Prefix: prefix, Context: "allocs"}
+		data := structs.ResourceListRequest{Prefix: prefix, Context: "allocs"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
 		assert.Nil(err)
 
 		respW := httptest.NewRecorder()
 
-		resp, err := s.Server.ResourcesRequest(respW, req)
+		resp, err := s.Server.ResourceListRequest(respW, req)
 		assert.Nil(err)
 
-		res := resp.(structs.ResourcesResponse)
+		res := resp.(structs.ResourceListResponse)
 
 		assert.Equal(1, len(res.Matches))
 
@@ -219,16 +219,16 @@ func TestHTTP_ResoucesList_Nodes(t *testing.T) {
 		assert.Nil(err)
 
 		prefix := node.ID[:len(node.ID)-2]
-		data := structs.ResourcesRequest{Prefix: prefix, Context: "nodes"}
+		data := structs.ResourceListRequest{Prefix: prefix, Context: "nodes"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
 		assert.Nil(err)
 
 		respW := httptest.NewRecorder()
 
-		resp, err := s.Server.ResourcesRequest(respW, req)
+		resp, err := s.Server.ResourceListRequest(respW, req)
 		assert.Nil(err)
 
-		res := resp.(structs.ResourcesResponse)
+		res := resp.(structs.ResourceListResponse)
 
 		assert.Equal(1, len(res.Matches))
 
@@ -246,16 +246,16 @@ func TestHTTP_Resources_NoJob(t *testing.T) {
 
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {
-		data := structs.ResourcesRequest{Prefix: "12345", Context: "jobs"}
+		data := structs.ResourceListRequest{Prefix: "12345", Context: "jobs"}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
 		assert.Nil(err)
 
 		respW := httptest.NewRecorder()
 
-		resp, err := s.Server.ResourcesRequest(respW, req)
+		resp, err := s.Server.ResourceListRequest(respW, req)
 		assert.Nil(err)
 
-		res := resp.(structs.ResourcesResponse)
+		res := resp.(structs.ResourceListResponse)
 
 		assert.Equal(1, len(res.Matches))
 		assert.Equal(0, len(res.Matches["jobs"]))
@@ -279,16 +279,16 @@ func TestHTTP_Resources_NoContext(t *testing.T) {
 		err := state.UpsertEvals(8000, []*structs.Evaluation{eval1})
 		assert.Nil(err)
 
-		data := structs.ResourcesRequest{Prefix: testJobPrefix}
+		data := structs.ResourceListRequest{Prefix: testJobPrefix}
 		req, err := http.NewRequest("POST", "/v1/resources", encodeReq(data))
 		assert.Nil(err)
 
 		respW := httptest.NewRecorder()
 
-		resp, err := s.Server.ResourcesRequest(respW, req)
+		resp, err := s.Server.ResourceListRequest(respW, req)
 		assert.Nil(err)
 
-		res := resp.(structs.ResourcesResponse)
+		res := resp.(structs.ResourceListResponse)
 
 		matchedJobs := res.Matches["jobs"]
 		matchedEvals := res.Matches["evals"]

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTP_ResourcesWithIllegalMethod(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		req, err := http.NewRequest("DELETE", "/v1/resources", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		_, err = s.Server.ResourcesRequest(respW, req)
+		assert.NotNil(t, err, "HTTP DELETE should not be accepted for this endpoint")
+	})
+}
+
+func createJobForTest(jobID string, s *TestAgent, t *testing.T) {
+	job := mock.Job()
+	job.ID = jobID
+	job.TaskGroups[0].Count = 1
+	args := structs.JobRegisterRequest{
+		Job:          job,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var resp structs.JobRegisterResponse
+	if err := s.Agent.RPC("Job.Register", &args, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestHTTP_ResourcesWithSingleJob(t *testing.T) {
+	testJob := "aaaaaaaa-e8f7-fd38-c855-ab94ceb89706"
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		createJobForTest(testJob, s, t)
+
+		endpoint := fmt.Sprintf("/v1/resources?context=job&prefix=%s", testJob)
+		req, err := http.NewRequest("GET", endpoint, nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		resp, err := s.Server.ResourcesRequest(respW, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		res := resp.(*structs.ResourcesListStub)
+		if len(res.Matches) != 1 {
+			t.Fatalf("No expected key values in resources list")
+		}
+
+		j := res.Matches["jobs"]
+		if j == nil || len(j) != 1 {
+			t.Fatalf("The number of jobs that were returned does not equal the number of jobs we expected (1)", j)
+		}
+
+		// TODO verify that the job we are getting is the same that we created
+		//	assert.Equal(t, j[0], testJob)
+	})
+}
+
+//
+//func TestHTTP_ResourcesWithNoJob(t *testing.T) {
+//}

--- a/command/agent/resources_endpoint_test.go
+++ b/command/agent/resources_endpoint_test.go
@@ -69,6 +69,7 @@ func TestHTTP_ResourcesWithSingleJob(t *testing.T) {
 		}
 
 		assert.Equal(t, j[0], testJob)
+		assert.Equal(t, res.Truncations["job"], false)
 	})
 }
 
@@ -152,6 +153,7 @@ func TestHTTP_ResoucesListForEvaluations(t *testing.T) {
 
 		assert.Contains(t, j, eval1.ID)
 		assert.NotContains(t, j, eval2.ID)
+		assert.Equal(t, res.Truncations["eval"], false)
 	})
 }
 

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -26,6 +26,10 @@ func getMatches(iter memdb.ResultIterator, context, prefix string) ([]string, bo
 				return i.(*structs.Job).ID
 			case *structs.Evaluation:
 				return i.(*structs.Evaluation).ID
+			case *structs.Allocation:
+				return i.(*structs.Allocation).ID
+			case *structs.Node:
+				return i.(*structs.Node).ID
 			default:
 				return ""
 			}
@@ -69,11 +73,16 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 				iter, err = state.JobsByIDPrefix(ws, args.Prefix)
 			} else if args.Context == "eval" {
 				iter, err = state.EvalsByIDPrefix(ws, args.Prefix)
+			} else if args.Context == "alloc" {
+				iter, err = state.AllocsByIDPrefix(ws, args.Prefix)
+			} else if args.Context == "node" {
+				iter, err = state.NodesByIDPrefix(ws, args.Prefix)
 			}
 
 			if err != nil {
 				return err
 			}
+
 			res, isTrunc = getMatches(iter, args.Context, args.Prefix)
 			reply.Matches[args.Context] = res
 			reply.Truncations[args.Context] = isTrunc

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -39,7 +39,7 @@ func getMatches(iter memdb.ResultIterator) ([]string, bool) {
 			case *structs.Node:
 				return i.(*structs.Node).ID, nil
 			default:
-				return "", fmt.Errorf("invalid context")
+				return "", fmt.Errorf("invalid type")
 			}
 		}
 
@@ -62,13 +62,13 @@ func getMatches(iter memdb.ResultIterator) ([]string, bool) {
 // that context
 func getResourceIter(context, prefix string, ws memdb.WatchSet, state *state.StateStore) (memdb.ResultIterator, error) {
 	switch context {
-	case "job":
+	case "jobs":
 		return state.JobsByIDPrefix(ws, prefix)
-	case "eval":
+	case "evals":
 		return state.EvalsByIDPrefix(ws, prefix)
-	case "alloc":
+	case "allocs":
 		return state.AllocsByIDPrefix(ws, prefix)
-	case "node":
+	case "nodes":
 		return state.NodesByIDPrefix(ws, prefix)
 	default:
 		return nil, fmt.Errorf("invalid context")
@@ -97,7 +97,7 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 				}
 				iters[args.Context] = iter
 			} else {
-				for _, e := range []string{"alloc", "node", "job", "eval"} {
+				for _, e := range []string{"allocs", "nodes", "jobs", "evals"} {
 					iter, err := getResourceIter(e, args.Prefix, ws, state)
 					if err != nil {
 						return err
@@ -106,7 +106,7 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 				}
 			}
 
-			// Return jobs matching given prefix
+			// Return matches for the given prefix
 			for k, v := range iters {
 				res, isTrunc := getMatches(v)
 				reply.Matches[k] = res
@@ -123,6 +123,7 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 				for k, v := range reply.Matches {
 					if len(v) != 0 {
 						index, err = state.Index(k)
+						break
 					}
 				}
 			}

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -13,7 +13,6 @@ type Resources struct {
 // List is used to list the jobs registered in the system
 // TODO logic to determine context, to return only that context if needed
 // TODO if no context, return all
-// TODO return top n matches
 // TODO refactor to prevent duplication
 func (r *Resources) List(args *structs.ResourcesRequest,
 	reply *structs.ResourcesResponse) error {
@@ -36,7 +35,7 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 			}
 
 			var jobs []string
-			for {
+			for i := 0; i < 20; i++ {
 				raw := iter.Next()
 				if raw == nil {
 					break

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -28,6 +28,7 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 			// return jobs matching given prefix
 			var err error
 			var iter memdb.ResultIterator
+			truncations := make(map[string]bool)
 
 			if args.Context == "job" {
 				iter, err = state.JobsByIDPrefix(ws, args.Prefix)
@@ -44,6 +45,10 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 
 					job := raw.(*structs.Job)
 					jobs = append(jobs, job.ID)
+				}
+
+				if iter.Next() != nil {
+					truncations["job"] = true
 				}
 
 				matches["job"] = jobs
@@ -66,10 +71,15 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 					evals = append(evals, eval.ID)
 				}
 
+				if iter.Next() != nil {
+					truncations["eval"] = true
+				}
+
 				matches["eval"] = evals
 			}
 
 			reply.Matches = matches
+			reply.Truncations = truncations
 
 			return nil
 		}}

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -1,0 +1,55 @@
+package nomad
+
+import (
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type Resources struct {
+	srv *Server
+}
+
+// List is used to list the jobs registered in the system
+// TODO logic to determine context, to return only that context if needed
+// TODO if no context, return all
+// TODO return top n matches
+// TODO refactor to prevent duplication
+func (r *Resources) List(args *structs.ResourcesRequest,
+	reply *structs.ResourcesResponse) error {
+
+	resources := structs.ResourcesListStub{}
+	resources.Matches = make(map[string][]string)
+
+	// Setup the blocking query
+	opts := blockingOptions{
+		queryOpts: &args.QueryOptions,
+		queryMeta: &reply.QueryMeta,
+		run: func(ws memdb.WatchSet, state *state.StateStore) error {
+
+			// return jobs matching given prefix
+			var err error
+			var iter memdb.ResultIterator
+			iter, err = state.JobsByIDPrefix(ws, args.QueryOptions.Prefix)
+			if err != nil {
+				return err
+			}
+
+			var jobs []string
+			for {
+				raw := iter.Next()
+				if raw == nil {
+					break
+				}
+
+				job := raw.(*structs.Job)
+				jobs = append(jobs, job.ID)
+			}
+
+			resources.Matches["jobs"] = jobs
+			reply.Resources = resources
+
+			return nil
+		}}
+	return r.srv.blockingRPC(&opts)
+}

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -109,16 +109,18 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 
 			// Set the index for the context. If the context has been specified, it
 			// is the only non-empty match set, and the index is set for it.
-			// If the context was not specified, we set the index of the first
-			// non-empty match set.
+			// If the context was not specified, we set the index to be the max index
+			// from  available contexts
+			reply.Index = 0
 			for k, v := range reply.Matches {
-				if len(v) != 0 {
+				if len(v) != 0 { // make sure matches exist for this context
 					index, err := state.Index(k)
 					if err != nil {
 						return err
 					}
-					reply.Index = index
-					break
+					if index > reply.Index {
+						reply.Index = index
+					}
 				}
 			}
 

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -17,8 +17,7 @@ type Resources struct {
 func (r *Resources) List(args *structs.ResourcesRequest,
 	reply *structs.ResourcesResponse) error {
 
-	resources := structs.ResourcesListStub{}
-	resources.Matches = make(map[string][]string)
+	matches := make(map[string][]string)
 
 	// Setup the blocking query
 	opts := blockingOptions{
@@ -45,8 +44,8 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 				jobs = append(jobs, job.ID)
 			}
 
-			resources.Matches["jobs"] = jobs
-			reply.Resources = resources
+			matches["jobs"] = jobs
+			reply.Matches = matches
 
 			return nil
 		}}

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -21,14 +21,14 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 
 	// Setup the blocking query
 	opts := blockingOptions{
-		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
+		queryOpts: &structs.QueryOptions{},
 		run: func(ws memdb.WatchSet, state *state.StateStore) error {
 
 			// return jobs matching given prefix
 			var err error
 			var iter memdb.ResultIterator
-			iter, err = state.JobsByIDPrefix(ws, args.QueryOptions.Prefix)
+			iter, err = state.JobsByIDPrefix(ws, args.Prefix)
 			if err != nil {
 				return err
 			}

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -91,6 +91,13 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 			reply.Matches[args.Context] = res
 			reply.Truncations[args.Context] = isTrunc
 
+			// Use the last index that affected the table
+			index, err := state.Index(args.Context)
+			if err != nil {
+				return err
+			}
+			reply.Index = index
+
 			return nil
 		}}
 	return r.srv.blockingRPC(&opts)

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -7,15 +7,22 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+// truncateLimit is the maximum number of matches that will be returned for a
+// prefix for a specific context
+const truncateLimit = 20
+
+// Resource endpoint is used to lookup matches for a given prefix and context
 type Resources struct {
 	srv *Server
 }
 
+// getMatches extracts matches for an iterator, and returns a list of ids for
+// these matches.
 func getMatches(iter memdb.ResultIterator) ([]string, bool) {
 	var matches []string
 	isTruncated := false
 
-	for i := 0; i < 20; i++ {
+	for i := 0; i < truncateLimit; i++ {
 		raw := iter.Next()
 		if raw == nil {
 			break
@@ -51,6 +58,8 @@ func getMatches(iter memdb.ResultIterator) ([]string, bool) {
 	return matches, isTruncated
 }
 
+// getResourceIter takes a context and returns a memdb iterator specific to
+// that context
 func getResourceIter(context, prefix string, ws memdb.WatchSet, state *state.StateStore) (memdb.ResultIterator, error) {
 	switch context {
 	case "job":
@@ -66,7 +75,8 @@ func getResourceIter(context, prefix string, ws memdb.WatchSet, state *state.Sta
 	}
 }
 
-// List is used to list the jobs registered in the system
+// List is used to list the resouces registered in the system that matches the
+// given prefix. Resources are jobs, evaluations, allocations, and/or nodes.
 func (r *Resources) List(args *structs.ResourcesRequest,
 	reply *structs.ResourcesResponse) error {
 	reply.Matches = make(map[string][]string)

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -11,7 +11,7 @@ type Resources struct {
 	srv *Server
 }
 
-func getMatches(iter memdb.ResultIterator, context, prefix string) ([]string, bool) {
+func getMatches(iter memdb.ResultIterator) ([]string, bool) {
 	var matches []string
 	isTruncated := false
 
@@ -21,23 +21,23 @@ func getMatches(iter memdb.ResultIterator, context, prefix string) ([]string, bo
 			break
 		}
 
-		getID := func(i interface{}) string {
+		getID := func(i interface{}) (string, error) {
 			switch i.(type) {
 			case *structs.Job:
-				return i.(*structs.Job).ID
+				return i.(*structs.Job).ID, nil
 			case *structs.Evaluation:
-				return i.(*structs.Evaluation).ID
+				return i.(*structs.Evaluation).ID, nil
 			case *structs.Allocation:
-				return i.(*structs.Allocation).ID
+				return i.(*structs.Allocation).ID, nil
 			case *structs.Node:
-				return i.(*structs.Node).ID
+				return i.(*structs.Node).ID, nil
 			default:
-				return ""
+				return "", fmt.Errorf("invalid context")
 			}
 		}
 
-		id := getID(raw)
-		if id == "" {
+		id, err := getID(raw)
+		if err != nil {
 			continue
 		}
 
@@ -51,8 +51,22 @@ func getMatches(iter memdb.ResultIterator, context, prefix string) ([]string, bo
 	return matches, isTruncated
 }
 
+func getResourceIter(context, prefix string, ws memdb.WatchSet, state *state.StateStore) (memdb.ResultIterator, error) {
+	switch context {
+	case "job":
+		return state.JobsByIDPrefix(ws, prefix)
+	case "eval":
+		return state.EvalsByIDPrefix(ws, prefix)
+	case "alloc":
+		return state.AllocsByIDPrefix(ws, prefix)
+	case "node":
+		return state.NodesByIDPrefix(ws, prefix)
+	default:
+		return nil, fmt.Errorf("invalid context")
+	}
+}
+
 // List is used to list the jobs registered in the system
-// TODO if no context, return all
 func (r *Resources) List(args *structs.ResourcesRequest,
 	reply *structs.ResourcesResponse) error {
 	reply.Matches = make(map[string][]string)
@@ -64,32 +78,30 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 		queryOpts: &structs.QueryOptions{},
 		run: func(ws memdb.WatchSet, state *state.StateStore) error {
 
+			iters := make(map[string]memdb.ResultIterator)
+
+			if args.Context != "" {
+				iter, err := getResourceIter(args.Context, args.Prefix, ws, state)
+				if err != nil {
+					return err
+				}
+				iters[args.Context] = iter
+			} else {
+				for _, e := range []string{"alloc", "node", "job", "eval"} {
+					iter, err := getResourceIter(e, args.Prefix, ws, state)
+					if err != nil {
+						return err
+					}
+					iters[e] = iter
+				}
+			}
+
 			// return jobs matching given prefix
-			var err error
-			var iter memdb.ResultIterator
-			res := make([]string, 0)
-			isTrunc := false
-
-			switch args.Context {
-			case "job":
-				iter, err = state.JobsByIDPrefix(ws, args.Prefix)
-			case "eval":
-				iter, err = state.EvalsByIDPrefix(ws, args.Prefix)
-			case "alloc":
-				iter, err = state.AllocsByIDPrefix(ws, args.Prefix)
-			case "node":
-				iter, err = state.NodesByIDPrefix(ws, args.Prefix)
-			default:
-				return fmt.Errorf("invalid context")
+			for k, v := range iters {
+				res, isTrunc := getMatches(v)
+				reply.Matches[k] = res
+				reply.Truncations[k] = isTrunc
 			}
-
-			if err != nil {
-				return err
-			}
-
-			res, isTrunc = getMatches(iter, args.Context, args.Prefix)
-			reply.Matches[args.Context] = res
-			reply.Truncations[args.Context] = isTrunc
 
 			// Use the last index that affected the table
 			index, err := state.Index(args.Context)

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -114,19 +114,16 @@ func (r *Resources) List(args *structs.ResourceListRequest,
 			}
 
 			// Set the index for the context. If the context has been specified, it
-			// is the only non-empty match set, and the index is set for it.
-			// If the context was not specified, we set the index to be the max index
-			// from  available matches.
+			// will be used as the index of the response. Otherwise, the
+			// maximum index from all resources will be used.
 			reply.Index = 0
-			for k, v := range reply.Matches {
-				if len(v) != 0 { // make sure matches exist for this context
-					index, err := state.Index(k)
-					if err != nil {
-						return err
-					}
-					if index > reply.Index {
-						reply.Index = index
-					}
+			for _, e := range contexts {
+				index, err := state.Index(e)
+				if err != nil {
+					return err
+				}
+				if index > reply.Index {
+					reply.Index = index
 				}
 			}
 

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"fmt"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -69,14 +70,17 @@ func (r *Resources) List(args *structs.ResourcesRequest,
 			res := make([]string, 0)
 			isTrunc := false
 
-			if args.Context == "job" {
+			switch args.Context {
+			case "job":
 				iter, err = state.JobsByIDPrefix(ws, args.Prefix)
-			} else if args.Context == "eval" {
+			case "eval":
 				iter, err = state.EvalsByIDPrefix(ws, args.Prefix)
-			} else if args.Context == "alloc" {
+			case "alloc":
 				iter, err = state.AllocsByIDPrefix(ws, args.Prefix)
-			} else if args.Context == "node" {
+			case "node":
 				iter, err = state.NodesByIDPrefix(ws, args.Prefix)
+			default:
+				return fmt.Errorf("invalid context")
 			}
 
 			if err != nil {

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -267,7 +267,7 @@ func TestResourcesEndpoint_List_NoContext(t *testing.T) {
 	assert.Equal(uint64(1000), resp.Index)
 }
 
-//// Tests that the top 20 matches are returned when no prefix is set
+// Tests that the top 20 matches are returned when no prefix is set
 func TestResourcesEndpoint_List_NoPrefix(t *testing.T) {
 	assert := assert.New(t)
 

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -39,12 +39,12 @@ func TestResourcesEndpoint_List(t *testing.T) {
 
 	jobID := registerAndVerifyJob(s, t, prefix, 0)
 
-	req := &structs.ResourcesRequest{
+	req := &structs.ResourceListRequest{
 		Prefix:  prefix,
 		Context: "jobs",
 	}
 
-	var resp structs.ResourcesResponse
+	var resp structs.ResourceListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -72,12 +72,12 @@ func TestResourcesEndpoint_List_Truncate(t *testing.T) {
 		registerAndVerifyJob(s, t, prefix, counter)
 	}
 
-	req := &structs.ResourcesRequest{
+	req := &structs.ResourceListRequest{
 		Prefix:  prefix,
 		Context: "jobs",
 	}
 
-	var resp structs.ResourcesResponse
+	var resp structs.ResourceListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -103,12 +103,12 @@ func TestResourcesEndpoint_List_Evals(t *testing.T) {
 
 	prefix := eval1.ID[:len(eval1.ID)-2]
 
-	req := &structs.ResourcesRequest{
+	req := &structs.ResourceListRequest{
 		Prefix:  prefix,
 		Context: "evals",
 	}
 
-	var resp structs.ResourcesResponse
+	var resp structs.ResourceListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -144,12 +144,12 @@ func TestResourcesEndpoint_List_Allocation(t *testing.T) {
 
 	prefix := alloc.ID[:len(alloc.ID)-2]
 
-	req := &structs.ResourcesRequest{
+	req := &structs.ResourceListRequest{
 		Prefix:  prefix,
 		Context: "allocs",
 	}
 
-	var resp structs.ResourcesResponse
+	var resp structs.ResourceListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -181,12 +181,12 @@ func TestResourcesEndpoint_List_Node(t *testing.T) {
 
 	prefix := node.ID[:len(node.ID)-2]
 
-	req := &structs.ResourcesRequest{
+	req := &structs.ResourceListRequest{
 		Prefix:  prefix,
 		Context: "nodes",
 	}
 
-	var resp structs.ResourcesResponse
+	var resp structs.ResourceListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -210,14 +210,14 @@ func TestResourcesEndpoint_List_InvalidContext(t *testing.T) {
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	req := &structs.ResourcesRequest{
+	req := &structs.ResourceListRequest{
 		Prefix:  "anyPrefix",
 		Context: "invalid",
 	}
 
-	var resp structs.ResourcesResponse
+	var resp structs.ResourceListResponse
 	err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp)
-	assert.Equal(err.Error(), "invalid context")
+	assert.Equal(err.Error(), "context must be one of [allocs nodes jobs evals]; got \"invalid\"")
 
 	assert.Equal(uint64(0), resp.Index)
 }
@@ -248,12 +248,12 @@ func TestResourcesEndpoint_List_NoContext(t *testing.T) {
 
 	prefix := node.ID[:len(node.ID)-2]
 
-	req := &structs.ResourcesRequest{
+	req := &structs.ResourceListRequest{
 		Prefix:  prefix,
 		Context: "",
 	}
 
-	var resp structs.ResourcesResponse
+	var resp structs.ResourceListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -284,12 +284,12 @@ func TestResourcesEndpoint_List_NoPrefix(t *testing.T) {
 
 	jobID := registerAndVerifyJob(s, t, prefix, 0)
 
-	req := &structs.ResourcesRequest{
+	req := &structs.ResourceListRequest{
 		Prefix:  "",
 		Context: "jobs",
 	}
 
-	var resp structs.ResourcesResponse
+	var resp structs.ResourceListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -315,12 +315,12 @@ func TestResourcesEndpoint_List_NoMatches(t *testing.T) {
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	req := &structs.ResourcesRequest{
+	req := &structs.ResourceListRequest{
 		Prefix:  prefix,
 		Context: "jobs",
 	}
 
-	var resp structs.ResourcesResponse
+	var resp structs.ResourceListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -17,8 +17,7 @@ func registerAndVerifyJob(s *Server, t *testing.T, prefix string, counter int) s
 
 	job.ID = prefix + strconv.Itoa(counter)
 	state := s.fsm.State()
-	err := state.UpsertJob(jobIndex, job)
-	if err != nil {
+	if err := state.UpsertJob(jobIndex, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -26,6 +25,7 @@ func registerAndVerifyJob(s *Server, t *testing.T, prefix string, counter int) s
 }
 
 func TestResourcesEndpoint_List(t *testing.T) {
+	assert := assert.New(t)
 	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
 	t.Parallel()
@@ -49,13 +49,14 @@ func TestResourcesEndpoint_List(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	assert.Equal(t, 1, len(resp.Matches["jobs"]))
-	assert.Equal(t, jobID, resp.Matches["jobs"][0])
-	assert.Equal(t, uint64(jobIndex), resp.Index)
+	assert.Equal(1, len(resp.Matches["jobs"]))
+	assert.Equal(jobID, resp.Matches["jobs"][0])
+	assert.Equal(uint64(jobIndex), resp.Index)
 }
 
 // truncate should limit results to 20
 func TestResourcesEndpoint_List_Truncate(t *testing.T) {
+	assert := assert.New(t)
 	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
 	t.Parallel()
@@ -81,12 +82,13 @@ func TestResourcesEndpoint_List_Truncate(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	assert.Equal(t, 20, len(resp.Matches["jobs"]))
-	assert.Equal(t, resp.Truncations["jobs"], true)
-	assert.Equal(t, uint64(jobIndex), resp.Index)
+	assert.Equal(20, len(resp.Matches["jobs"]))
+	assert.Equal(resp.Truncations["jobs"], true)
+	assert.Equal(uint64(jobIndex), resp.Index)
 }
 
 func TestResourcesEndpoint_List_Evals(t *testing.T) {
+	assert := assert.New(t)
 	t.Parallel()
 	s := testServer(t, func(c *Config) {
 		c.NumSchedulers = 0
@@ -111,14 +113,15 @@ func TestResourcesEndpoint_List_Evals(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	assert.Equal(t, 1, len(resp.Matches["evals"]))
-	assert.Equal(t, eval1.ID, resp.Matches["evals"][0])
-	assert.Equal(t, resp.Truncations["evals"], false)
+	assert.Equal(1, len(resp.Matches["evals"]))
+	assert.Equal(eval1.ID, resp.Matches["evals"][0])
+	assert.Equal(resp.Truncations["evals"], false)
 
-	assert.Equal(t, uint64(2000), resp.Index)
+	assert.Equal(uint64(2000), resp.Index)
 }
 
 func TestResourcesEndpoint_List_Allocation(t *testing.T) {
+	assert := assert.New(t)
 	t.Parallel()
 	s := testServer(t, func(c *Config) {
 		c.NumSchedulers = 0
@@ -151,14 +154,15 @@ func TestResourcesEndpoint_List_Allocation(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	assert.Equal(t, 1, len(resp.Matches["allocs"]))
-	assert.Equal(t, alloc.ID, resp.Matches["allocs"][0])
-	assert.Equal(t, resp.Truncations["allocs"], false)
+	assert.Equal(1, len(resp.Matches["allocs"]))
+	assert.Equal(alloc.ID, resp.Matches["allocs"][0])
+	assert.Equal(resp.Truncations["allocs"], false)
 
-	assert.Equal(t, uint64(90), resp.Index)
+	assert.Equal(uint64(90), resp.Index)
 }
 
 func TestResourcesEndpoint_List_Node(t *testing.T) {
+	assert := assert.New(t)
 	t.Parallel()
 	s := testServer(t, func(c *Config) {
 		c.NumSchedulers = 0
@@ -187,14 +191,16 @@ func TestResourcesEndpoint_List_Node(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	assert.Equal(t, 1, len(resp.Matches["nodes"]))
-	assert.Equal(t, node.ID, resp.Matches["nodes"][0])
-	assert.Equal(t, false, resp.Truncations["nodes"])
+	assert.Equal(1, len(resp.Matches["nodes"]))
+	assert.Equal(node.ID, resp.Matches["nodes"][0])
+	assert.Equal(false, resp.Truncations["nodes"])
 
-	assert.Equal(t, uint64(100), resp.Index)
+	assert.Equal(uint64(100), resp.Index)
 }
 
 func TestResourcesEndpoint_List_InvalidContext(t *testing.T) {
+	assert := assert.New(t)
+
 	t.Parallel()
 	s := testServer(t, func(c *Config) {
 		c.NumSchedulers = 0
@@ -211,12 +217,13 @@ func TestResourcesEndpoint_List_InvalidContext(t *testing.T) {
 
 	var resp structs.ResourcesResponse
 	err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp)
-	assert.Equal(t, err.Error(), "invalid context")
+	assert.Equal(err.Error(), "invalid context")
 
-	assert.Equal(t, uint64(0), resp.Index)
+	assert.Equal(uint64(0), resp.Index)
 }
 
 func TestResourcesEndpoint_List_NoContext(t *testing.T) {
+	assert := assert.New(t)
 	t.Parallel()
 	s := testServer(t, func(c *Config) {
 		c.NumSchedulers = 0
@@ -251,17 +258,19 @@ func TestResourcesEndpoint_List_NoContext(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	assert.Equal(t, 1, len(resp.Matches["nodes"]))
-	assert.Equal(t, 1, len(resp.Matches["evals"]))
+	assert.Equal(1, len(resp.Matches["nodes"]))
+	assert.Equal(1, len(resp.Matches["evals"]))
 
-	assert.Equal(t, node.ID, resp.Matches["nodes"][0])
-	assert.Equal(t, eval1.ID, resp.Matches["evals"][0])
+	assert.Equal(node.ID, resp.Matches["nodes"][0])
+	assert.Equal(eval1.ID, resp.Matches["evals"][0])
 
-	assert.NotEqual(t, uint64(0), resp.Index)
+	assert.NotEqual(uint64(0), resp.Index)
 }
 
-// Tests that the top 20 matches are returned when no prefix is set
+//// Tests that the top 20 matches are returned when no prefix is set
 func TestResourcesEndpoint_List_NoPrefix(t *testing.T) {
+	assert := assert.New(t)
+
 	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
 	t.Parallel()
@@ -285,14 +294,16 @@ func TestResourcesEndpoint_List_NoPrefix(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	assert.Equal(t, 1, len(resp.Matches["jobs"]))
-	assert.Equal(t, jobID, resp.Matches["jobs"][0])
-	assert.Equal(t, uint64(jobIndex), resp.Index)
+	assert.Equal(1, len(resp.Matches["jobs"]))
+	assert.Equal(jobID, resp.Matches["jobs"][0])
+	assert.Equal(uint64(jobIndex), resp.Index)
 }
 
-// Tests that the zero matches are returned when a prefix has no matching
-// results
+//// Tests that the zero matches are returned when a prefix has no matching
+//// results
 func TestResourcesEndpoint_List_NoMatches(t *testing.T) {
+	assert := assert.New(t)
+
 	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
 	t.Parallel()
@@ -314,6 +325,6 @@ func TestResourcesEndpoint_List_NoMatches(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	assert.Equal(t, 0, len(resp.Matches["jobs"]))
-	assert.Equal(t, uint64(0), resp.Index)
+	assert.Equal(0, len(resp.Matches["jobs"]))
+	assert.Equal(uint64(0), resp.Index)
 }

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -86,6 +86,8 @@ func TestResourcesEndpoint_List_ShouldTruncateResultsToUnder20(t *testing.T) {
 	if num_matches != 20 {
 		t.Fatalf(fmt.Sprintf("err: the number of jobs expected %d does not match the number of jobs returned %d", 20, num_matches))
 	}
+
+	assert.Equal(t, resp.Truncations["job"], true)
 }
 
 func TestResourcesEndpoint_List_ShouldReturnEvals(t *testing.T) {
@@ -122,4 +124,6 @@ func TestResourcesEndpoint_List_ShouldReturnEvals(t *testing.T) {
 	if recEval != eval1.ID {
 		t.Fatalf(fmt.Sprintf("err: expected %s evaluation but received %s", eval1.ID, recEval))
 	}
+
+	assert.Equal(t, resp.Truncations["job"], false)
 }

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -47,12 +47,12 @@ func TestResourcesEndpoint_List(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	num_matches := len(resp.Resources.Matches["jobs"])
+	num_matches := len(resp.Matches["jobs"])
 	if num_matches != 1 {
 		t.Fatalf(fmt.Sprintf("err: the number of jobs expected %d does not match the number of jobs registered %d", 1, num_matches))
 	}
 
-	assert.Equal(t, jobID, resp.Resources.Matches["jobs"][0])
+	assert.Equal(t, jobID, resp.Matches["jobs"][0])
 }
 
 func TestResourcesEndpoint_List_ShouldTruncateResultsToUnder20(t *testing.T) {
@@ -80,7 +80,7 @@ func TestResourcesEndpoint_List_ShouldTruncateResultsToUnder20(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	num_matches := len(resp.Resources.Matches["jobs"])
+	num_matches := len(resp.Matches["jobs"])
 	if num_matches != 20 {
 		t.Fatalf(fmt.Sprintf("err: the number of jobs expected %d does not match the number of jobs returned %d", 20, num_matches))
 	}

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -1,0 +1,72 @@
+package nomad
+
+import (
+	"fmt"
+	"github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/assert"
+	"net/rpc"
+	"testing"
+)
+
+func registerAndVerifyJob(codec rpc.ClientCodec, s *Server, t *testing.T) string {
+	// Create the register request
+	job := mock.Job()
+	state := s.fsm.State()
+	err := state.UpsertJob(1000, job)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Verify the job was created
+	get := &structs.JobListRequest{
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var resp2 structs.JobListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Job.List", get, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp2.Index != 1000 {
+		t.Fatalf("Bad index: %d %d", resp2.Index, 1000)
+	}
+
+	if len(resp2.Jobs) != 1 {
+		t.Fatalf("bad: %#v", resp2.Jobs)
+	}
+	if resp2.Jobs[0].ID != job.ID {
+		t.Fatalf("bad: %#v", resp2.Jobs[0])
+	}
+
+	return job.ID
+}
+
+func TestResourcesEndpoint_List(t *testing.T) {
+	t.Parallel()
+	s := testServer(t, func(c *Config) {
+		c.NumSchedulers = 0 // Prevent automatic dequeue
+	})
+
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	jobID := registerAndVerifyJob(codec, s, t)
+
+	req := &structs.ResourcesRequest{
+		QueryOptions: structs.QueryOptions{Region: "global", Prefix: jobID},
+	}
+
+	var resp structs.ResourcesResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	num_matches := len(resp.Resources.Matches["jobs"])
+	if num_matches != 1 {
+		t.Fatalf(fmt.Sprintf("err: the number of jobs expected %d does not match the number of jobs registered %d", 1, num_matches))
+	}
+
+	assert.Equal(t, jobID, resp.Resources.Matches["jobs"][0])
+}

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -127,3 +127,91 @@ func TestResourcesEndpoint_List_ShouldReturnEvals(t *testing.T) {
 
 	assert.Equal(t, resp.Truncations["job"], false)
 }
+
+func TestResourcesEndpoint_List_Allocation(t *testing.T) {
+	t.Parallel()
+	s := testServer(t, func(c *Config) {
+		c.NumSchedulers = 0
+	})
+
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	alloc := mock.Alloc()
+	summary := mock.JobSummary(alloc.JobID)
+	state := s.fsm.State()
+
+	if err := state.UpsertJobSummary(999, summary); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	prefix := alloc.ID[:len(alloc.ID)-2]
+
+	req := &structs.ResourcesRequest{
+		Prefix:  prefix,
+		Context: "alloc",
+	}
+
+	var resp structs.ResourcesResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	numMatches := len(resp.Matches["alloc"])
+	if numMatches != 1 {
+		t.Fatalf(fmt.Sprintf("err: the number of allocations expected %d does not match the number expected %d", 1, numMatches))
+	}
+
+	recAlloc := resp.Matches["alloc"][0]
+	if recAlloc != alloc.ID {
+		t.Fatalf(fmt.Sprintf("err: expected %s allocation but received %s", alloc.ID, recAlloc))
+	}
+
+	assert.Equal(t, resp.Truncations["alloc"], false)
+}
+
+func TestResourcesEndpoint_List_Node(t *testing.T) {
+	t.Parallel()
+	s := testServer(t, func(c *Config) {
+		c.NumSchedulers = 0
+	})
+
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	state := s.fsm.State()
+	node := mock.Node()
+
+	if err := state.UpsertNode(100, node); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	prefix := node.ID[:len(node.ID)-2]
+
+	req := &structs.ResourcesRequest{
+		Prefix:  prefix,
+		Context: "node",
+	}
+
+	var resp structs.ResourcesResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Resources.List", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	numMatches := len(resp.Matches["node"])
+	if numMatches != 1 {
+		t.Fatalf(fmt.Sprintf("err: the number of nodes expected %d does not match the number expected %d", 1, numMatches))
+	}
+
+	recNode := resp.Matches["node"][0]
+	if recNode != node.ID {
+		t.Fatalf(fmt.Sprintf("err: expected %s node but received %s", node.ID, recNode))
+	}
+
+	assert.Equal(t, resp.Truncations["node"], false)
+}

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -264,7 +264,7 @@ func TestResourcesEndpoint_List_NoContext(t *testing.T) {
 	assert.Equal(node.ID, resp.Matches["nodes"][0])
 	assert.Equal(eval1.ID, resp.Matches["evals"][0])
 
-	assert.NotEqual(uint64(0), resp.Index)
+	assert.Equal(uint64(1000), resp.Index)
 }
 
 //// Tests that the top 20 matches are returned when no prefix is set

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -39,7 +39,8 @@ func TestResourcesEndpoint_List(t *testing.T) {
 	jobID := registerAndVerifyJob(s, t, prefix, 0)
 
 	req := &structs.ResourcesRequest{
-		QueryOptions: structs.QueryOptions{Region: "global", Prefix: prefix},
+		Prefix:  prefix,
+		Context: "job",
 	}
 
 	var resp structs.ResourcesResponse
@@ -72,7 +73,8 @@ func TestResourcesEndpoint_List_ShouldTruncateResultsToUnder20(t *testing.T) {
 	}
 
 	req := &structs.ResourcesRequest{
-		QueryOptions: structs.QueryOptions{Region: "global", Prefix: prefix},
+		Prefix:  prefix,
+		Context: "job",
 	}
 
 	var resp structs.ResourcesResponse

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
-	"net/rpc"
+	"strconv"
 	"testing"
 )
 
-func registerAndVerifyJob(codec rpc.ClientCodec, s *Server, t *testing.T) string {
-	// Create the register request
+func registerAndVerifyJob(s *Server, t *testing.T, prefix string, counter int) string {
 	job := mock.Job()
+
+	job.ID = prefix + strconv.Itoa(counter)
 	state := s.fsm.State()
 	err := state.UpsertJob(1000, job)
 	if err != nil {
@@ -24,6 +25,8 @@ func registerAndVerifyJob(codec rpc.ClientCodec, s *Server, t *testing.T) string
 }
 
 func TestResourcesEndpoint_List(t *testing.T) {
+	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
+
 	t.Parallel()
 	s := testServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
@@ -33,7 +36,7 @@ func TestResourcesEndpoint_List(t *testing.T) {
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	jobID := registerAndVerifyJob(codec, s, t)
+	jobID := registerAndVerifyJob(s, t, prefix, 0)
 
 	req := &structs.ResourcesRequest{
 		QueryOptions: structs.QueryOptions{Region: "global", Prefix: jobID},

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -20,25 +20,6 @@ func registerAndVerifyJob(codec rpc.ClientCodec, s *Server, t *testing.T) string
 		t.Fatalf("err: %v", err)
 	}
 
-	// Verify the job was created
-	get := &structs.JobListRequest{
-		QueryOptions: structs.QueryOptions{Region: "global"},
-	}
-	var resp2 structs.JobListResponse
-	if err := msgpackrpc.CallWithCodec(codec, "Job.List", get, &resp2); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp2.Index != 1000 {
-		t.Fatalf("Bad index: %d %d", resp2.Index, 1000)
-	}
-
-	if len(resp2.Jobs) != 1 {
-		t.Fatalf("bad: %#v", resp2.Jobs)
-	}
-	if resp2.Jobs[0].ID != job.ID {
-		t.Fatalf("bad: %#v", resp2.Jobs[0])
-	}
-
 	return job.ID
 }
 

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -174,6 +174,7 @@ type endpoints struct {
 	Alloc      *Alloc
 	Deployment *Deployment
 	Region     *Region
+	Resources  *Resources
 	Periodic   *Periodic
 	System     *System
 	Operator   *Operator
@@ -725,6 +726,7 @@ func (s *Server) setupRPC(tlsWrap tlsutil.RegionWrapper) error {
 	s.endpoints.Region = &Region{s}
 	s.endpoints.Status = &Status{s}
 	s.endpoints.System = &System{s}
+	s.endpoints.Resources = &Resources{s}
 
 	// Register the handlers
 	s.rpcServer.Register(s.endpoints.Alloc)
@@ -738,6 +740,7 @@ func (s *Server) setupRPC(tlsWrap tlsutil.RegionWrapper) error {
 	s.rpcServer.Register(s.endpoints.Region)
 	s.rpcServer.Register(s.endpoints.Status)
 	s.rpcServer.Register(s.endpoints.System)
+	s.rpcServer.Register(s.endpoints.Resources)
 
 	list, err := net.ListenTCP("tcp", s.config.RPCAddr)
 	if err != nil {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -235,8 +235,12 @@ type NodeSpecificRequest struct {
 // the match list is truncated specific to each type of context.
 type ResourceListResponse struct {
 	// Map of context types to resource ids which match a specified prefix
-	Matches     map[string][]string
+	Matches map[string][]string
+
+	// Truncations indicates whether the matches for a particular context have
+	// been truncated
 	Truncations map[string]bool
+
 	QueryMeta
 }
 
@@ -247,6 +251,7 @@ type ResourceListRequest struct {
 	// Prefix is what resources are matched to. I.e, if the given prefix were
 	// "a", potential matches might be "abcd" or "aabb"
 	Prefix string
+
 	// Context is the resource that can be matched. A context can be a job, node,
 	// evaluation, allocation, or empty (indicated every context should be
 	// matched)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -232,13 +232,14 @@ type NodeSpecificRequest struct {
 }
 
 type ResourcesResponse struct {
-	Resources ResourcesListStub
+	Matches     map[string][]string
+	Truncations map[string]bool
 	QueryMeta
 }
 
-// TODO can there be a more generic Request object, if a specific one is not
-// needed?
-// ResourcesRequest is used to parameterize a resources request
+// ResourcesRequest is used to parameterize a resources request, and returns a
+// subset of information for jobs, allocations, evaluations, and nodes, along
+// with whether or not the information returned is truncated.
 type ResourcesRequest struct {
 	QueryOptions
 }
@@ -1881,12 +1882,6 @@ func (j *Job) SpecChanged(new *Job) bool {
 
 func (j *Job) SetSubmitTime() {
 	j.SubmitTime = time.Now().UTC().UnixNano()
-}
-
-// ResourcesListStub is used to return a subset of information
-// for jobs, allocations, evaluations, and nodes
-type ResourcesListStub struct {
-	Matches map[string][]string
 }
 
 // JobListStub is used to return a subset of job information

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -231,19 +231,25 @@ type NodeSpecificRequest struct {
 	QueryOptions
 }
 
-// ResourcesResponse is used to return matches and information about whether
+// ResourceListResponse is used to return matches and information about whether
 // the match list is truncated specific to each type of context.
-type ResourcesResponse struct {
+type ResourceListResponse struct {
+	// Map of context types to resource ids which match a specified prefix
 	Matches     map[string][]string
 	Truncations map[string]bool
 	QueryMeta
 }
 
-// ResourcesRequest is used to parameterize a resources request, and returns a
+// ResourceListRequest is used to parameterize a resources request, and returns a
 // subset of information for jobs, allocations, evaluations, and nodes, along
 // with whether or not the information returned is truncated.
-type ResourcesRequest struct {
-	Prefix  string
+type ResourceListRequest struct {
+	// Prefix is what resources are matched to. I.e, if the given prefix were
+	// "a", potential matches might be "abcd" or "aabb"
+	Prefix string
+	// Context is the resource that can be matched. A context can be a job, node,
+	// evaluation, allocation, or empty (indicated every context should be
+	// matched)
 	Context string
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -241,7 +241,8 @@ type ResourcesResponse struct {
 // subset of information for jobs, allocations, evaluations, and nodes, along
 // with whether or not the information returned is truncated.
 type ResourcesRequest struct {
-	QueryOptions
+	Prefix  string
+	Context string
 }
 
 // JobRegisterRequest is used for Job.Register endpoint

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -231,6 +231,18 @@ type NodeSpecificRequest struct {
 	QueryOptions
 }
 
+type ResourcesResponse struct {
+	Resources ResourcesListStub
+	QueryMeta
+}
+
+// TODO can there be a more generic Request object, if a specific one is not
+// needed?
+// ResourcesRequest is used to parameterize a resources request
+type ResourcesRequest struct {
+	QueryOptions
+}
+
 // JobRegisterRequest is used for Job.Register endpoint
 // to register a job as being a schedulable entity.
 type JobRegisterRequest struct {
@@ -1869,6 +1881,12 @@ func (j *Job) SpecChanged(new *Job) bool {
 
 func (j *Job) SetSubmitTime() {
 	j.SubmitTime = time.Now().UTC().UnixNano()
+}
+
+// ResourcesListStub is used to return a subset of information
+// for jobs, allocations, evaluations, and nodes
+type ResourcesListStub struct {
+	Matches map[string][]string
 }
 
 // JobListStub is used to return a subset of job information

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -231,6 +231,8 @@ type NodeSpecificRequest struct {
 	QueryOptions
 }
 
+// ResourcesResponse is used to return matches and information about whether
+// the match list is truncated, specific to each type of context.
 type ResourcesResponse struct {
 	Matches     map[string][]string
 	Truncations map[string]bool

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -232,7 +232,7 @@ type NodeSpecificRequest struct {
 }
 
 // ResourcesResponse is used to return matches and information about whether
-// the match list is truncated, specific to each type of context.
+// the match list is truncated specific to each type of context.
 type ResourcesResponse struct {
 	Matches     map[string][]string
 	Truncations map[string]bool


### PR DESCRIPTION
Adds an HTTP api which acceps a prefix and a context, which can be jobs, evaluations, allocations, or nodes. If a context is not set, all types are returned that match the given prefix. 

This will be used to extend autocomplete functionality for the CLI. 