### PR TITLE
Use int32 for atomic ops to avoid alignment issues

### DIFF
--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -119,7 +119,7 @@ type ServiceClient struct {
 
 	// seen is 1 if Consul has ever been seen; otherise 0. Accessed with
 	// atomics.
-	seen int64
+	seen int32
 }
 
 // NewServiceClient creates a new Consul ServiceClient from an existing Consul API
@@ -150,13 +150,13 @@ const seen = 1
 // markSeen marks Consul as having been seen (meaning at least one operation
 // has succeeded).
 func (c *ServiceClient) markSeen() {
-	atomic.StoreInt64(&c.seen, seen)
+	atomic.StoreInt32(&c.seen, seen)
 }
 
 // hasSeen returns true if any Consul operation has ever succeeded. Useful to
 // squelch errors if Consul isn't running.
 func (c *ServiceClient) hasSeen() bool {
-	return atomic.LoadInt64(&c.seen) == seen
+	return atomic.LoadInt32(&c.seen) == seen
 }
 
 // Run the Consul main loop which retries operations against Consul. It should


### PR DESCRIPTION
Fixes #2963 

From https://golang.org/pkg/sync/atomic/#pkg-note-BUG :

On both ARM and x86-32, it is the caller's responsibility to arrange for
64-bit alignment of 64-bit words accessed atomically. The first word in
a global variable or in an allocated struct or slice can be relied upon
to be 64-bit aligned.

I chose to use an int32 instead of fixing the alignment issue with int64 because:
* I only need 1 bit anyway
* This seemed harder to accidently break in the future