### PR TITLE
Adding ACL Policy storage

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -37,6 +37,7 @@ type ACL struct {
 }
 
 // maxPrivilege returns the policy which grants the most privilege
+// This handles the case of Deny always taking maximum precedence.
 func maxPrivilege(a, b string) string {
 	switch {
 	case a == PolicyDeny || b == PolicyDeny:

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -1,0 +1,193 @@
+package acl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCapabilitySet(t *testing.T) {
+	var cs capabilitySet = make(map[string]struct{})
+
+	// Check no capabilities by default
+	if cs.Check(PolicyDeny) {
+		t.Fatalf("unexpected check")
+	}
+
+	// Do a set and check
+	cs.Set(PolicyDeny)
+	if !cs.Check(PolicyDeny) {
+		t.Fatalf("missing check")
+	}
+
+	// Clear and check
+	cs.Clear()
+	if cs.Check(PolicyDeny) {
+		t.Fatalf("unexpected check")
+	}
+}
+
+func TestMaxPrivilege(t *testing.T) {
+	type tcase struct {
+		Privilege      string
+		PrecedenceOver []string
+	}
+	tcases := []tcase{
+		{
+			PolicyDeny,
+			[]string{PolicyDeny, PolicyWrite, PolicyRead, ""},
+		},
+		{
+			PolicyWrite,
+			[]string{PolicyWrite, PolicyRead, ""},
+		},
+		{
+			PolicyRead,
+			[]string{PolicyRead, ""},
+		},
+	}
+
+	for idx1, tc := range tcases {
+		for idx2, po := range tc.PrecedenceOver {
+			if maxPrivilege(tc.Privilege, po) != tc.Privilege {
+				t.Fatalf("failed %d %d", idx1, idx2)
+			}
+			if maxPrivilege(po, tc.Privilege) != tc.Privilege {
+				t.Fatalf("failed %d %d", idx1, idx2)
+			}
+		}
+	}
+}
+
+func TestACLManagement(t *testing.T) {
+	// Create management ACL
+	acl, err := NewACL(true, nil)
+	assert.Nil(t, err)
+
+	// Check default namespace rights
+	assert.Equal(t, true, acl.AllowNamespaceOperation("default", NamespaceCapabilityListJobs))
+	assert.Equal(t, true, acl.AllowNamespaceOperation("default", NamespaceCapabilitySubmitJob))
+
+	// Check non-specified namespace
+	assert.Equal(t, true, acl.AllowNamespaceOperation("foo", NamespaceCapabilityListJobs))
+
+	// Check the other simpler operations
+	assert.Equal(t, true, acl.AllowAgentRead())
+	assert.Equal(t, true, acl.AllowAgentWrite())
+	assert.Equal(t, true, acl.AllowNodeRead())
+	assert.Equal(t, true, acl.AllowNodeWrite())
+	assert.Equal(t, true, acl.AllowOperatorRead())
+	assert.Equal(t, true, acl.AllowOperatorWrite())
+}
+
+func TestACLMerge(t *testing.T) {
+	// Merge read + write policy
+	p1, err := Parse(readAll)
+	assert.Nil(t, err)
+	p2, err := Parse(writeAll)
+	assert.Nil(t, err)
+	acl, err := NewACL(false, []*Policy{p1, p2})
+	assert.Nil(t, err)
+
+	// Check default namespace rights
+	assert.Equal(t, true, acl.AllowNamespaceOperation("default", NamespaceCapabilityListJobs))
+	assert.Equal(t, true, acl.AllowNamespaceOperation("default", NamespaceCapabilitySubmitJob))
+
+	// Check non-specified namespace
+	assert.Equal(t, false, acl.AllowNamespaceOperation("foo", NamespaceCapabilityListJobs))
+
+	// Check the other simpler operations
+	assert.Equal(t, true, acl.AllowAgentRead())
+	assert.Equal(t, true, acl.AllowAgentWrite())
+	assert.Equal(t, true, acl.AllowNodeRead())
+	assert.Equal(t, true, acl.AllowNodeWrite())
+	assert.Equal(t, true, acl.AllowOperatorRead())
+	assert.Equal(t, true, acl.AllowOperatorWrite())
+
+	// Merge read + blank
+	p3, err := Parse("")
+	assert.Nil(t, err)
+	acl, err = NewACL(false, []*Policy{p1, p3})
+	assert.Nil(t, err)
+
+	// Check default namespace rights
+	assert.Equal(t, true, acl.AllowNamespaceOperation("default", NamespaceCapabilityListJobs))
+	assert.Equal(t, false, acl.AllowNamespaceOperation("default", NamespaceCapabilitySubmitJob))
+
+	// Check non-specified namespace
+	assert.Equal(t, false, acl.AllowNamespaceOperation("foo", NamespaceCapabilityListJobs))
+
+	// Check the other simpler operations
+	assert.Equal(t, true, acl.AllowAgentRead())
+	assert.Equal(t, false, acl.AllowAgentWrite())
+	assert.Equal(t, true, acl.AllowNodeRead())
+	assert.Equal(t, false, acl.AllowNodeWrite())
+	assert.Equal(t, true, acl.AllowOperatorRead())
+	assert.Equal(t, false, acl.AllowOperatorWrite())
+
+	// Merge read + deny
+	p4, err := Parse(denyAll)
+	assert.Nil(t, err)
+	acl, err = NewACL(false, []*Policy{p1, p4})
+	assert.Nil(t, err)
+
+	// Check default namespace rights
+	assert.Equal(t, false, acl.AllowNamespaceOperation("default", NamespaceCapabilityListJobs))
+	assert.Equal(t, false, acl.AllowNamespaceOperation("default", NamespaceCapabilitySubmitJob))
+
+	// Check non-specified namespace
+	assert.Equal(t, false, acl.AllowNamespaceOperation("foo", NamespaceCapabilityListJobs))
+
+	// Check the other simpler operations
+	assert.Equal(t, false, acl.AllowAgentRead())
+	assert.Equal(t, false, acl.AllowAgentWrite())
+	assert.Equal(t, false, acl.AllowNodeRead())
+	assert.Equal(t, false, acl.AllowNodeWrite())
+	assert.Equal(t, false, acl.AllowOperatorRead())
+	assert.Equal(t, false, acl.AllowOperatorWrite())
+}
+
+var readAll = `
+namespace "default" {
+	policy = "read"
+}
+agent {
+	policy = "read"
+}
+node {
+	policy = "read"
+}
+operator {
+	policy = "read"
+}
+`
+
+var writeAll = `
+namespace "default" {
+	policy = "write"
+}
+agent {
+	policy = "write"
+}
+node {
+	policy = "write"
+}
+operator {
+	policy = "write"
+}
+`
+
+var denyAll = `
+namespace "default" {
+	policy = "deny"
+}
+agent {
+	policy = "deny"
+}
+node {
+	policy = "deny"
+}
+operator {
+	policy = "deny"
+}
+`

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/hcl"
 )
@@ -19,6 +20,10 @@ const (
 	NamespaceCapabilitySubmitJob = "submit-job"
 	NamespaceCapabilityReadLogs  = "read-logs"
 	NamespaceCapabilityReadFS    = "read-fs"
+)
+
+var (
+	validNamespace = regexp.MustCompile("^[a-zA-Z0-9-]{1,128}$")
 )
 
 // Policy represents a parsed HCL or JSON policy.
@@ -125,6 +130,9 @@ func Parse(rules string) (*Policy, error) {
 
 	// Validate the policy
 	for _, ns := range p.Namespaces {
+		if !validNamespace.MatchString(ns.Name) {
+			return nil, fmt.Errorf("Invalid namespace name: %#v", ns)
+		}
 		if ns.Policy != "" && !isPolicyValid(ns.Policy) {
 			return nil, fmt.Errorf("Invalid namespace policy: %#v", ns)
 		}

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -8,12 +8,19 @@ import (
 )
 
 const (
+	// The following levels are the only valid values for the `policy = "read"` stanza.
+	// When policies are merged together, the most privilege is granted, except for deny
+	// which always takes precedence and supercedes.
 	PolicyDeny  = "deny"
 	PolicyRead  = "read"
 	PolicyWrite = "write"
 )
 
 const (
+	// The following are the fine-grained capabilities that can be granted within a namespace.
+	// The Policy stanza is a short hand for granting several of these. When capabilities are
+	// combined we take the union of all capabilities. If the deny capability is present, it
+	// takes precedence and overwrites all other capabilities.
 	NamespaceCapabilityDeny      = "deny"
 	NamespaceCapabilityListJobs  = "list-jobs"
 	NamespaceCapabilityReadJob   = "read-job"
@@ -57,11 +64,7 @@ type OperatorPolicy struct {
 // isPolicyValid makes sure the given string matches one of the valid policies.
 func isPolicyValid(policy string) bool {
 	switch policy {
-	case PolicyDeny:
-		return true
-	case PolicyRead:
-		return true
-	case PolicyWrite:
+	case PolicyDeny, PolicyRead, PolicyWrite:
 		return true
 	default:
 		return false
@@ -71,17 +74,8 @@ func isPolicyValid(policy string) bool {
 // isNamespaceCapabilityValid ensures the given capability is valid for a namespace policy
 func isNamespaceCapabilityValid(cap string) bool {
 	switch cap {
-	case NamespaceCapabilityDeny:
-		return true
-	case NamespaceCapabilityListJobs:
-		return true
-	case NamespaceCapabilityReadJob:
-		return true
-	case NamespaceCapabilitySubmitJob:
-		return true
-	case NamespaceCapabilityReadLogs:
-		return true
-	case NamespaceCapabilityReadFS:
+	case NamespaceCapabilityDeny, NamespaceCapabilityListJobs, NamespaceCapabilityReadJob,
+		NamespaceCapabilitySubmitJob, NamespaceCapabilityReadLogs, NamespaceCapabilityReadFS:
 		return true
 	default:
 		return false
@@ -138,7 +132,7 @@ func Parse(rules string) (*Policy, error) {
 		}
 		for _, cap := range ns.Capabilities {
 			if !isNamespaceCapabilityValid(cap) {
-				return nil, fmt.Errorf("Invalid namespace capability: %#v", ns)
+				return nil, fmt.Errorf("Invalid namespace capability '%s': %#v", cap, ns)
 			}
 		}
 

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -1,0 +1,157 @@
+package acl
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl"
+)
+
+const (
+	PolicyDeny  = "deny"
+	PolicyRead  = "read"
+	PolicyWrite = "write"
+)
+
+const (
+	NamespaceCapabilityDeny      = "deny"
+	NamespaceCapabilityListJobs  = "list-jobs"
+	NamespaceCapabilityReadJob   = "read-job"
+	NamespaceCapabilitySubmitJob = "submit-job"
+	NamespaceCapabilityReadLogs  = "read-logs"
+	NamespaceCapabilityReadFS    = "read-fs"
+)
+
+// Policy represents a parsed HCL or JSON policy.
+type Policy struct {
+	Namespaces []*NamespacePolicy `hcl:"namespace,expand"`
+	Agent      *AgentPolicy       `hcl:"agent"`
+	Node       *NodePolicy        `hcl:"node"`
+	Operator   *OperatorPolicy    `hcl:"operator"`
+	Raw        string             `hcl:"-"`
+}
+
+// NamespacePolicy is the policy for a specific namespace
+type NamespacePolicy struct {
+	Name         string `hcl:",key"`
+	Policy       string
+	Capabilities []string
+}
+
+type AgentPolicy struct {
+	Policy string
+}
+
+type NodePolicy struct {
+	Policy string
+}
+
+type OperatorPolicy struct {
+	Policy string
+}
+
+// isPolicyValid makes sure the given string matches one of the valid policies.
+func isPolicyValid(policy string) bool {
+	switch policy {
+	case PolicyDeny:
+		return true
+	case PolicyRead:
+		return true
+	case PolicyWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+// isNamespaceCapabilityValid ensures the given capability is valid for a namespace policy
+func isNamespaceCapabilityValid(cap string) bool {
+	switch cap {
+	case NamespaceCapabilityDeny:
+		return true
+	case NamespaceCapabilityListJobs:
+		return true
+	case NamespaceCapabilityReadJob:
+		return true
+	case NamespaceCapabilitySubmitJob:
+		return true
+	case NamespaceCapabilityReadLogs:
+		return true
+	case NamespaceCapabilityReadFS:
+		return true
+	default:
+		return false
+	}
+}
+
+// expandNamespacePolicy provides the equivalent set of capabilities for
+// a namespace policy
+func expandNamespacePolicy(policy string) []string {
+	switch policy {
+	case PolicyDeny:
+		return []string{NamespaceCapabilityDeny}
+	case PolicyRead:
+		return []string{
+			NamespaceCapabilityListJobs,
+			NamespaceCapabilityReadJob,
+		}
+	case PolicyWrite:
+		return []string{
+			NamespaceCapabilityListJobs,
+			NamespaceCapabilityReadJob,
+			NamespaceCapabilitySubmitJob,
+			NamespaceCapabilityReadLogs,
+			NamespaceCapabilityReadFS,
+		}
+	default:
+		return nil
+	}
+}
+
+// Parse is used to parse the specified ACL rules into an
+// intermediary set of policies, before being compiled into
+// the ACL
+func Parse(rules string) (*Policy, error) {
+	// Decode the rules
+	p := &Policy{Raw: rules}
+	if rules == "" {
+		// Hot path for empty rules
+		return p, nil
+	}
+
+	// Attempt to parse
+	if err := hcl.Decode(p, rules); err != nil {
+		return nil, fmt.Errorf("Failed to parse ACL Policy: %v", err)
+	}
+
+	// Validate the policy
+	for _, ns := range p.Namespaces {
+		if ns.Policy != "" && !isPolicyValid(ns.Policy) {
+			return nil, fmt.Errorf("Invalid namespace policy: %#v", ns)
+		}
+		for _, cap := range ns.Capabilities {
+			if !isNamespaceCapabilityValid(cap) {
+				return nil, fmt.Errorf("Invalid namespace capability: %#v", ns)
+			}
+		}
+
+		// Expand the short hand policy to the capabilities and
+		// add to any existing capabilities
+		if ns.Policy != "" {
+			extraCap := expandNamespacePolicy(ns.Policy)
+			ns.Capabilities = append(ns.Capabilities, extraCap...)
+		}
+	}
+
+	if p.Agent != nil && !isPolicyValid(p.Agent.Policy) {
+		return nil, fmt.Errorf("Invalid agent policy: %#v", p.Agent)
+	}
+
+	if p.Node != nil && !isPolicyValid(p.Node.Policy) {
+		return nil, fmt.Errorf("Invalid node policy: %#v", p.Node)
+	}
+
+	if p.Operator != nil && !isPolicyValid(p.Operator.Policy) {
+		return nil, fmt.Errorf("Invalid operator policy: %#v", p.Operator)
+	}
+	return p, nil
+}

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -1,0 +1,166 @@
+package acl
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	type tcase struct {
+		Raw    string
+		ErrStr string
+		Expect *Policy
+	}
+	tcases := []tcase{
+		{
+			`
+			namespace "default" {
+				policy = "read"
+			}
+			`,
+			"",
+			&Policy{
+				Namespaces: []*NamespacePolicy{
+					&NamespacePolicy{
+						Name:   "default",
+						Policy: PolicyRead,
+						Capabilities: []string{
+							NamespaceCapabilityListJobs,
+							NamespaceCapabilityReadJob,
+						},
+					},
+				},
+			},
+		},
+		{
+			`
+			namespace "default" {
+				policy = "read"
+			}
+			namespace "other" {
+				policy = "write"
+			}
+			namespace "secret" {
+				capabilities = ["deny", "read-logs"]
+			}
+			agent {
+				policy = "read"
+			}
+			node {
+				policy = "write"
+			}
+			operator {
+				policy = "deny"
+			}
+			`,
+			"",
+			&Policy{
+				Namespaces: []*NamespacePolicy{
+					&NamespacePolicy{
+						Name:   "default",
+						Policy: PolicyRead,
+						Capabilities: []string{
+							NamespaceCapabilityListJobs,
+							NamespaceCapabilityReadJob,
+						},
+					},
+					&NamespacePolicy{
+						Name:   "other",
+						Policy: PolicyWrite,
+						Capabilities: []string{
+							NamespaceCapabilityListJobs,
+							NamespaceCapabilityReadJob,
+							NamespaceCapabilitySubmitJob,
+							NamespaceCapabilityReadLogs,
+							NamespaceCapabilityReadFS,
+						},
+					},
+					&NamespacePolicy{
+						Name: "secret",
+						Capabilities: []string{
+							NamespaceCapabilityDeny,
+							NamespaceCapabilityReadLogs,
+						},
+					},
+				},
+				Agent: &AgentPolicy{
+					Policy: PolicyRead,
+				},
+				Node: &NodePolicy{
+					Policy: PolicyWrite,
+				},
+				Operator: &OperatorPolicy{
+					Policy: PolicyDeny,
+				},
+			},
+		},
+		{
+			`
+			namespace "default" {
+				policy = "foo"
+			}
+			`,
+			"Invalid namespace policy",
+			nil,
+		},
+		{
+			`
+			namespace "default" {
+				capabilities = ["deny", "foo"]
+			}
+			`,
+			"Invalid namespace capability",
+			nil,
+		},
+		{
+			`
+			agent {
+				policy = "foo"
+			}
+			`,
+			"Invalid agent policy",
+			nil,
+		},
+		{
+			`
+			node {
+				policy = "foo"
+			}
+			`,
+			"Invalid node policy",
+			nil,
+		},
+		{
+			`
+			operator {
+				policy = "foo"
+			}
+			`,
+			"Invalid operator policy",
+			nil,
+		},
+	}
+
+	for idx, tc := range tcases {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			p, err := Parse(tc.Raw)
+			if err != nil {
+				if tc.ErrStr == "" {
+					t.Fatalf("Unexpected err: %v", err)
+				}
+				if !strings.Contains(err.Error(), tc.ErrStr) {
+					t.Fatalf("Unexpected err: %v", err)
+				}
+				return
+			}
+			if err == nil && tc.ErrStr != "" {
+				t.Fatalf("Missing expected err")
+			}
+			tc.Expect.Raw = tc.Raw
+			assert.EqualValues(t, tc.Expect, p)
+		})
+	}
+}

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -142,6 +142,15 @@ func TestParse(t *testing.T) {
 			"Invalid operator policy",
 			nil,
 		},
+		{
+			`
+			namespace "has a space"{
+				policy = "read"
+			}
+			`,
+			"Invalid namespace name",
+			nil,
+		},
 	}
 
 	for idx, tc := range tcases {

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -41,6 +41,7 @@ const (
 	VaultAccessorSnapshot
 	JobVersionSnapshot
 	DeploymentSnapshot
+	ACLPolicySnapshot
 )
 
 // nomadFSM implements a finite state machine that is used
@@ -826,6 +827,15 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 				return err
 			}
 
+		case ACLPolicySnapshot:
+			policy := new(structs.ACLPolicy)
+			if err := dec.Decode(policy); err != nil {
+				return err
+			}
+			if err := restore.ACLPolicyRestore(policy); err != nil {
+				return err
+			}
+
 		default:
 			return fmt.Errorf("Unrecognized snapshot type: %v", msgType)
 		}
@@ -1029,6 +1039,10 @@ func (s *nomadSnapshot) Persist(sink raft.SnapshotSink) error {
 		return err
 	}
 	if err := s.persistDeployments(sink, encoder); err != nil {
+		sink.Cancel()
+		return err
+	}
+	if err := s.persistACLPolicies(sink, encoder); err != nil {
 		sink.Cancel()
 		return err
 	}
@@ -1302,6 +1316,34 @@ func (s *nomadSnapshot) persistDeployments(sink raft.SnapshotSink,
 		// Write out a job registration
 		sink.Write([]byte{byte(DeploymentSnapshot)})
 		if err := encoder.Encode(deployment); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *nomadSnapshot) persistACLPolicies(sink raft.SnapshotSink,
+	encoder *codec.Encoder) error {
+	// Get all the jobs
+	ws := memdb.NewWatchSet()
+	policies, err := s.snap.ACLPolicies(ws)
+	if err != nil {
+		return err
+	}
+
+	for {
+		// Get the next item
+		raw := policies.Next()
+		if raw == nil {
+			break
+		}
+
+		// Prepare the request struct
+		policy := raw.(*structs.ACLPolicy)
+
+		// Write out a job registration
+		sink.Write([]byte{byte(ACLPolicySnapshot)})
+		if err := encoder.Encode(policy); err != nil {
 			return err
 		}
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1324,7 +1324,7 @@ func (s *nomadSnapshot) persistDeployments(sink raft.SnapshotSink,
 
 func (s *nomadSnapshot) persistACLPolicies(sink raft.SnapshotSink,
 	encoder *codec.Encoder) error {
-	// Get all the jobs
+	// Get all the policies
 	ws := memdb.NewWatchSet()
 	policies, err := s.snap.ACLPolicies(ws)
 	if err != nil {
@@ -1341,7 +1341,7 @@ func (s *nomadSnapshot) persistACLPolicies(sink raft.SnapshotSink,
 		// Prepare the request struct
 		policy := raw.(*structs.ACLPolicy)
 
-		// Write out a job registration
+		// Write out a policy registration
 		sink.Write([]byte{byte(ACLPolicySnapshot)})
 		if err := encoder.Encode(policy); err != nil {
 			return err

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/hashicorp/raft"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/assert"
 )
 
 type MockSink struct {
@@ -1854,6 +1855,26 @@ func TestFSM_SnapshotRestore_Deployments(t *testing.T) {
 	if !reflect.DeepEqual(d2, out2) {
 		t.Fatalf("bad: \n%#v\n%#v", out2, d2)
 	}
+}
+
+func TestFSM_SnapshotRestore_ACLPolicy(t *testing.T) {
+	t.Parallel()
+	// Add some state
+	fsm := testFSM(t)
+	state := fsm.State()
+	p1 := mock.ACLPolicy()
+	p2 := mock.ACLPolicy()
+	state.UpsertACLPolicy(1000, p1)
+	state.UpsertACLPolicy(1001, p2)
+
+	// Verify the contents
+	fsm2 := testSnapshotRestore(t, fsm)
+	state2 := fsm2.State()
+	ws := memdb.NewWatchSet()
+	out1, _ := state2.ACLPolicyByName(ws, p1.Name)
+	out2, _ := state2.ACLPolicyByName(ws, p2.Name)
+	assert.Equal(t, p1, out1)
+	assert.Equal(t, p2, out2)
 }
 
 func TestFSM_SnapshotRestore_AddMissingSummary(t *testing.T) {

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -335,4 +336,19 @@ func Plan() *structs.Plan {
 
 func PlanResult() *structs.PlanResult {
 	return &structs.PlanResult{}
+}
+
+func ACLPolicy() *structs.ACLPolicy {
+	return &structs.ACLPolicy{
+		Name: fmt.Sprintf("policy-%s", structs.GenerateUUID()),
+		Rules: `
+		namespace "default" {
+			policy = "write"
+		}
+		node = "read"
+		agent = "read"
+		`,
+		CreateIndex: 10,
+		ModifyIndex: 20,
+	}
 }

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -26,6 +26,7 @@ func stateStoreSchema() *memdb.DBSchema {
 		evalTableSchema,
 		allocTableSchema,
 		vaultAccessorTableSchema,
+		aclPolicyTableSchema,
 	}
 
 	// Add each of the tables
@@ -425,6 +426,24 @@ func vaultAccessorTableSchema() *memdb.TableSchema {
 				Unique:       false,
 				Indexer: &memdb.StringFieldIndex{
 					Field: "NodeID",
+				},
+			},
+		},
+	}
+}
+
+// aclPolicyTableSchema returns the MemDB schema for the policy table.
+// This table is used to store the policies which are refrenced by tokens
+func aclPolicyTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "acl_policy",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": &memdb.IndexSchema{
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "Name",
 				},
 			},
 		},

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2743,29 +2743,31 @@ func (s *StateStore) addEphemeralDiskToTaskGroups(job *structs.Job) {
 	}
 }
 
-// UpsertACLPolicy is used to create or update an ACL policy
-func (s *StateStore) UpsertACLPolicy(index uint64, policy *structs.ACLPolicy) error {
+// UpsertACLPolicies is used to create or update a set of ACL policies
+func (s *StateStore) UpsertACLPolicies(index uint64, policies []*structs.ACLPolicy) error {
 	txn := s.db.Txn(true)
 	defer txn.Abort()
 
-	// Check if the policy already exists
-	existing, err := txn.First("acl_policy", "id", policy.Name)
-	if err != nil {
-		return fmt.Errorf("policy lookup failed: %v", err)
-	}
+	for _, policy := range policies {
+		// Check if the policy already exists
+		existing, err := txn.First("acl_policy", "id", policy.Name)
+		if err != nil {
+			return fmt.Errorf("policy lookup failed: %v", err)
+		}
 
-	// Update all the indexes
-	if existing != nil {
-		policy.CreateIndex = existing.(*structs.ACLPolicy).CreateIndex
-		policy.ModifyIndex = index
-	} else {
-		policy.CreateIndex = index
-		policy.ModifyIndex = index
-	}
+		// Update all the indexes
+		if existing != nil {
+			policy.CreateIndex = existing.(*structs.ACLPolicy).CreateIndex
+			policy.ModifyIndex = index
+		} else {
+			policy.CreateIndex = index
+			policy.ModifyIndex = index
+		}
 
-	// Update the policy
-	if err := txn.Insert("acl_policy", policy); err != nil {
-		return fmt.Errorf("upserting policy failed: %v", err)
+		// Update the policy
+		if err := txn.Insert("acl_policy", policy); err != nil {
+			return fmt.Errorf("upserting policy failed: %v", err)
+		}
 	}
 
 	// Update the indexes tabl
@@ -2777,14 +2779,16 @@ func (s *StateStore) UpsertACLPolicy(index uint64, policy *structs.ACLPolicy) er
 	return nil
 }
 
-// DeleteACLPolicy deletes the policy with the given name
-func (s *StateStore) DeleteACLPolicy(index uint64, name string) error {
+// DeleteACLPolicies deletes the policies with the given names
+func (s *StateStore) DeleteACLPolicies(index uint64, names []string) error {
 	txn := s.db.Txn(true)
 	defer txn.Abort()
 
 	// Delete the policy
-	if _, err := txn.DeleteAll("acl_policy", "id", name); err != nil {
-		return fmt.Errorf("deleting acl policy failed: %v", err)
+	for _, name := range names {
+		if _, err := txn.DeleteAll("acl_policy", "id", name); err != nil {
+			return fmt.Errorf("deleting acl policy failed: %v", err)
+		}
 	}
 	if err := txn.Insert("index", &IndexEntry{"acl_policy", index}); err != nil {
 		return fmt.Errorf("index update failed: %v", err)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2743,6 +2743,98 @@ func (s *StateStore) addEphemeralDiskToTaskGroups(job *structs.Job) {
 	}
 }
 
+// UpsertACLPolicy is used to create or update an ACL policy
+func (s *StateStore) UpsertACLPolicy(index uint64, policy *structs.ACLPolicy) error {
+	txn := s.db.Txn(true)
+	defer txn.Abort()
+
+	// Check if the policy already exists
+	existing, err := txn.First("acl_policy", "id", policy.Name)
+	if err != nil {
+		return fmt.Errorf("policy lookup failed: %v", err)
+	}
+
+	// Update all the indexes
+	if existing != nil {
+		policy.CreateIndex = existing.(*structs.ACLPolicy).CreateIndex
+		policy.ModifyIndex = index
+	} else {
+		policy.CreateIndex = index
+		policy.ModifyIndex = index
+	}
+
+	// Update the policy
+	if err := txn.Insert("acl_policy", policy); err != nil {
+		return fmt.Errorf("upserting policy failed: %v", err)
+	}
+
+	// Update the indexes tabl
+	if err := txn.Insert("index", &IndexEntry{"acl_policy", index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+
+	txn.Commit()
+	return nil
+}
+
+// DeleteACLPolicy deletes the policy with the given name
+func (s *StateStore) DeleteACLPolicy(index uint64, name string) error {
+	txn := s.db.Txn(true)
+	defer txn.Abort()
+
+	// Delete the policy
+	if _, err := txn.DeleteAll("acl_policy", "id", name); err != nil {
+		return fmt.Errorf("deleting acl policy failed: %v", err)
+	}
+	if err := txn.Insert("index", &IndexEntry{"acl_policy", index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+	txn.Commit()
+	return nil
+}
+
+// ACLPolicyByName is used to lookup a policy by name
+func (s *StateStore) ACLPolicyByName(ws memdb.WatchSet, name string) (*structs.ACLPolicy, error) {
+	txn := s.db.Txn(false)
+
+	watchCh, existing, err := txn.FirstWatch("acl_policy", "id", name)
+	if err != nil {
+		return nil, fmt.Errorf("acl policy lookup failed: %v", err)
+	}
+	ws.Add(watchCh)
+
+	if existing != nil {
+		return existing.(*structs.ACLPolicy), nil
+	}
+	return nil, nil
+}
+
+// ACLPolicyByNamePrefix is used to lookup policies by prefix
+func (s *StateStore) ACLPolicyByNamePrefix(ws memdb.WatchSet, prefix string) (memdb.ResultIterator, error) {
+	txn := s.db.Txn(false)
+
+	iter, err := txn.Get("acl_policy", "id_prefix", prefix)
+	if err != nil {
+		return nil, fmt.Errorf("acl policy lookup failed: %v", err)
+	}
+	ws.Add(iter.WatchCh())
+
+	return iter, nil
+}
+
+// ACLPolicies returns an iterator over all the nodes
+func (s *StateStore) ACLPolicies(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+	txn := s.db.Txn(false)
+
+	// Walk the entire nodes table
+	iter, err := txn.Get("acl_policy", "id")
+	if err != nil {
+		return nil, err
+	}
+	ws.Add(iter.WatchCh())
+	return iter, nil
+}
+
 // StateSnapshot is used to provide a point-in-time snapshot
 type StateSnapshot struct {
 	StateStore
@@ -2858,6 +2950,14 @@ func (r *StateRestore) DeploymentRestore(deployment *structs.Deployment) error {
 func (r *StateRestore) VaultAccessorRestore(accessor *structs.VaultAccessor) error {
 	if err := r.txn.Insert("vault_accessors", accessor); err != nil {
 		return fmt.Errorf("vault accessor insert failed: %v", err)
+	}
+	return nil
+}
+
+// ACLPolicyRestore is used to restore an ACL policy
+func (r *StateRestore) ACLPolicyRestore(policy *structs.ACLPolicy) error {
+	if err := r.txn.Insert("acl_policy", policy); err != nil {
+		return fmt.Errorf("inserting acl policy failed: %v", err)
 	}
 	return nil
 }

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -5719,14 +5719,8 @@ func TestStateStore_UpsertACLPolicy(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := state.UpsertACLPolicy(1000, policy); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !watchFired(ws) {
-		t.Fatalf("bad")
-	}
-
-	if err := state.UpsertACLPolicy(1001, policy2); err != nil {
+	if err := state.UpsertACLPolicies(1000,
+		[]*structs.ACLPolicy{policy, policy2}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if !watchFired(ws) {
@@ -5776,9 +5770,11 @@ func TestStateStore_UpsertACLPolicy(t *testing.T) {
 func TestStateStore_DeleteACLPolicy(t *testing.T) {
 	state := testStateStore(t)
 	policy := mock.ACLPolicy()
+	policy2 := mock.ACLPolicy()
 
 	// Create the policy
-	if err := state.UpsertACLPolicy(1000, policy); err != nil {
+	if err := state.UpsertACLPolicies(1000,
+		[]*structs.ACLPolicy{policy, policy2}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5789,7 +5785,8 @@ func TestStateStore_DeleteACLPolicy(t *testing.T) {
 	}
 
 	// Delete the policy
-	if err := state.DeleteACLPolicy(1001, policy.Name); err != nil {
+	if err := state.DeleteACLPolicies(1001,
+		[]string{policy.Name, policy2.Name}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/assert"
 )
 
 func testStateStore(t *testing.T) *StateStore {
@@ -5703,6 +5704,207 @@ func TestStateStore_RestoreVaultAccessor(t *testing.T) {
 	if watchFired(ws) {
 		t.Fatalf("bad")
 	}
+}
+
+func TestStateStore_UpsertACLPolicy(t *testing.T) {
+	state := testStateStore(t)
+	policy := mock.ACLPolicy()
+	policy2 := mock.ACLPolicy()
+
+	ws := memdb.NewWatchSet()
+	if _, err := state.ACLPolicyByName(ws, policy.Name); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, err := state.ACLPolicyByName(ws, policy2.Name); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if err := state.UpsertACLPolicy(1000, policy); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !watchFired(ws) {
+		t.Fatalf("bad")
+	}
+
+	if err := state.UpsertACLPolicy(1001, policy2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !watchFired(ws) {
+		t.Fatalf("bad")
+	}
+
+	ws = memdb.NewWatchSet()
+	out, err := state.ACLPolicyByName(ws, policy.Name)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, policy, out)
+
+	out, err = state.ACLPolicyByName(ws, policy2.Name)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, policy2, out)
+
+	iter, err := state.ACLPolicies(ws)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure we see both policies
+	count := 0
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		count++
+	}
+	if count != 2 {
+		t.Fatalf("bad: %d", count)
+	}
+
+	index, err := state.Index("acl_policy")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if index != 1001 {
+		t.Fatalf("bad: %d", index)
+	}
+
+	if watchFired(ws) {
+		t.Fatalf("bad")
+	}
+}
+
+func TestStateStore_DeleteACLPolicy(t *testing.T) {
+	state := testStateStore(t)
+	policy := mock.ACLPolicy()
+
+	// Create the policy
+	if err := state.UpsertACLPolicy(1000, policy); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Create a watcher
+	ws := memdb.NewWatchSet()
+	if _, err := state.ACLPolicyByName(ws, policy.Name); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Delete the policy
+	if err := state.DeleteACLPolicy(1001, policy.Name); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure watching triggered
+	if !watchFired(ws) {
+		t.Fatalf("bad")
+	}
+
+	// Ensure we don't get the object back
+	ws = memdb.NewWatchSet()
+	out, err := state.ACLPolicyByName(ws, policy.Name)
+	assert.Equal(t, nil, err)
+	if out != nil {
+		t.Fatalf("bad: %#v", out)
+	}
+
+	iter, err := state.ACLPolicies(ws)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure we see both policies
+	count := 0
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		count++
+	}
+	if count != 0 {
+		t.Fatalf("bad: %d", count)
+	}
+
+	index, err := state.Index("acl_policy")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if index != 1001 {
+		t.Fatalf("bad: %d", index)
+	}
+
+	if watchFired(ws) {
+		t.Fatalf("bad")
+	}
+}
+
+func TestStateStore_ACLPolicyByNamePrefix(t *testing.T) {
+	state := testStateStore(t)
+	names := []string{
+		"foo",
+		"bar",
+		"foobar",
+		"foozip",
+		"zip",
+	}
+
+	// Create the policies
+	var baseIndex uint64 = 1000
+	for _, name := range names {
+		p := mock.ACLPolicy()
+		p.Name = name
+		if err := state.UpsertACLPolicy(baseIndex, p); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		baseIndex++
+	}
+
+	// Scan by prefix
+	iter, err := state.ACLPolicyByNamePrefix(nil, "foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure we see both policies
+	count := 0
+	out := []string{}
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		count++
+		out = append(out, raw.(*structs.ACLPolicy).Name)
+	}
+	if count != 3 {
+		t.Fatalf("bad: %d %v", count, out)
+	}
+	sort.Strings(out)
+
+	expect := []string{"foo", "foobar", "foozip"}
+	assert.Equal(t, expect, out)
+}
+
+func TestStateStore_RestoreACLPolicy(t *testing.T) {
+	state := testStateStore(t)
+	policy := mock.ACLPolicy()
+
+	restore, err := state.Restore()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	err = restore.ACLPolicyRestore(policy)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	restore.Commit()
+
+	ws := memdb.NewWatchSet()
+	out, err := state.ACLPolicyByName(ws, policy.Name)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, policy, out)
 }
 
 func TestStateStore_Abandon(t *testing.T) {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5233,3 +5233,12 @@ func IsRecoverable(e error) bool {
 	}
 	return false
 }
+
+// ACLPolicy is used to represent an ACL policy
+type ACLPolicy struct {
+	Name  string // Unique name
+	Rules string // HCL or JSON format
+
+	CreateIndex uint64
+	ModifyIndex uint64
+}


### PR DESCRIPTION
Depends on #2977.

This adds CRUD support to the state store for ACL policies and Snapshot/Restore to the FSM. This will be the foundation for the API endpoints and FSM operations.