### PR TITLE
Adding ACL Policy Endpoints

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1,0 +1,118 @@
+package nomad
+
+import (
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// ACL endpoint is used for manipulating ACL tokens and policies
+type ACL struct {
+	srv *Server
+}
+
+// UpsertPolicy is used to create or update a policy
+func (a *ACL) UpsertPolicy(args *structs.AllocListRequest, reply *structs.AllocListResponse) error {
+	if done, err := a.srv.forward("ACL.UpsertPolicy", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "acl", "upsert_policy"}, time.Now())
+	// TODO
+	return nil
+}
+
+// DeletePolicy is used to delete a policy
+func (a *ACL) DeletePolicy(args *structs.AllocListRequest, reply *structs.AllocListResponse) error {
+	if done, err := a.srv.forward("ACL.DeletePolicy", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "acl", "delete_policy"}, time.Now())
+	// TODO
+	return nil
+}
+
+// ListPolicies is used to list the policies
+func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.ACLPolicyListResponse) error {
+	if done, err := a.srv.forward("ACL.ListPolicies", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "acl", "list_policies"}, time.Now())
+
+	// Setup the blocking query
+	opts := blockingOptions{
+		queryOpts: &args.QueryOptions,
+		queryMeta: &reply.QueryMeta,
+		run: func(ws memdb.WatchSet, state *state.StateStore) error {
+			// Iterate over all the policies
+			var err error
+			var iter memdb.ResultIterator
+			if prefix := args.QueryOptions.Prefix; prefix != "" {
+				iter, err = state.ACLPolicyByNamePrefix(ws, prefix)
+			} else {
+				iter, err = state.ACLPolicies(ws)
+			}
+			if err != nil {
+				return err
+			}
+
+			// Convert all the policies to a list stub
+			reply.Policies = nil
+			for {
+				raw := iter.Next()
+				if raw == nil {
+					break
+				}
+				policy := raw.(*structs.ACLPolicy)
+				stub := new(structs.ACLPolicyListStub)
+				stub.FromPolicy(policy)
+				reply.Policies = append(reply.Policies, stub)
+			}
+
+			// Use the last index that affected the policy table
+			index, err := state.Index("acl_policy")
+			if err != nil {
+				return err
+			}
+			reply.Index = index
+			return nil
+		}}
+	return a.srv.blockingRPC(&opts)
+}
+
+// GetPolicy is used to get a specific policy
+func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.SingleACLPolicyResponse) error {
+	if done, err := a.srv.forward("ACL.GetPolicy", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "acl", "get_policy"}, time.Now())
+
+	// Setup the blocking query
+	opts := blockingOptions{
+		queryOpts: &args.QueryOptions,
+		queryMeta: &reply.QueryMeta,
+		run: func(ws memdb.WatchSet, state *state.StateStore) error {
+			// Look for the policy
+			out, err := state.ACLPolicyByName(ws, args.Name)
+			if err != nil {
+				return err
+			}
+
+			// Setup the output
+			reply.Policy = out
+			if out != nil {
+				reply.Index = out.ModifyIndex
+			} else {
+				// Use the last index that affected the policy table
+				index, err := state.Index("acl_policy")
+				if err != nil {
+					return err
+				}
+				reply.Index = index
+			}
+			return nil
+		}}
+	return a.srv.blockingRPC(&opts)
+}

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -1,0 +1,222 @@
+package nomad
+
+import (
+	"testing"
+	"time"
+
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestACLEndpoint_GetPolicy(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	policy := mock.ACLPolicy()
+	s1.fsm.State().UpsertACLPolicies(1000, []*structs.ACLPolicy{policy})
+
+	// Lookup the policy
+	get := &structs.ACLPolicySpecificRequest{
+		Name:         policy.Name,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var resp structs.SingleACLPolicyResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetPolicy", get, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp.Index)
+	assert.Equal(t, policy, resp.Policy)
+
+	// Lookup non-existing policy
+	get.Name = structs.GenerateUUID()
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetPolicy", get, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp.Index)
+	assert.Nil(t, resp.Policy)
+}
+
+func TestACLEndpoint_GetPolicy_Blocking(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	state := s1.fsm.State()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the policies
+	p1 := mock.ACLPolicy()
+	p2 := mock.ACLPolicy()
+
+	// First create an unrelated policy
+	time.AfterFunc(100*time.Millisecond, func() {
+		err := state.UpsertACLPolicies(100, []*structs.ACLPolicy{p1})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	// Upsert the policy we are watching later
+	time.AfterFunc(200*time.Millisecond, func() {
+		err := state.UpsertACLPolicies(200, []*structs.ACLPolicy{p2})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	// Lookup the policy
+	req := &structs.ACLPolicySpecificRequest{
+		Name: p2.Name,
+		QueryOptions: structs.QueryOptions{
+			Region:        "global",
+			MinQueryIndex: 150,
+		},
+	}
+	var resp structs.SingleACLPolicyResponse
+	start := time.Now()
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetPolicy", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
+		t.Fatalf("should block (returned in %s) %#v", elapsed, resp)
+	}
+	if resp.Index != 200 {
+		t.Fatalf("Bad index: %d %d", resp.Index, 200)
+	}
+	if resp.Policy == nil || resp.Policy.Name != p2.Name {
+		t.Fatalf("bad: %#v", resp.Policy)
+	}
+
+	// Eval delete triggers watches
+	time.AfterFunc(100*time.Millisecond, func() {
+		err := state.DeleteACLPolicies(300, []string{p2.Name})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	req.QueryOptions.MinQueryIndex = 250
+	var resp2 structs.SingleACLPolicyResponse
+	start = time.Now()
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetPolicy", req, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("should block (returned in %s) %#v", elapsed, resp2)
+	}
+	if resp2.Index != 300 {
+		t.Fatalf("Bad index: %d %d", resp2.Index, 300)
+	}
+	if resp2.Policy != nil {
+		t.Fatalf("bad: %#v", resp2.Policy)
+	}
+}
+
+func TestACLEndpoint_List(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	p1 := mock.ACLPolicy()
+	p2 := mock.ACLPolicy()
+
+	p1.Name = "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9"
+	p2.Name = "aaaabbbb-3350-4b4b-d185-0e1992ed43e9"
+	s1.fsm.State().UpsertACLPolicies(1000, []*structs.ACLPolicy{p1, p2})
+
+	// Lookup the policies
+	get := &structs.ACLPolicyListRequest{
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var resp structs.ACLPolicyListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListPolicies", get, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp.Index)
+	assert.Equal(t, 2, len(resp.Policies))
+
+	// Lookup the policies by prefix
+	get = &structs.ACLPolicyListRequest{
+		QueryOptions: structs.QueryOptions{
+			Region: "global",
+			Prefix: "aaaabb",
+		},
+	}
+	var resp2 structs.ACLPolicyListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListPolicies", get, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp2.Index)
+	assert.Equal(t, 1, len(resp2.Policies))
+}
+
+func TestACLEndpoint_List_Blocking(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	state := s1.fsm.State()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the policy
+	policy := mock.ACLPolicy()
+
+	// Upsert eval triggers watches
+	time.AfterFunc(100*time.Millisecond, func() {
+		if err := state.UpsertACLPolicies(2, []*structs.ACLPolicy{policy}); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	req := &structs.ACLPolicyListRequest{
+		QueryOptions: structs.QueryOptions{
+			Region:        "global",
+			MinQueryIndex: 1,
+		},
+	}
+	start := time.Now()
+	var resp structs.ACLPolicyListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListPolicies", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("should block (returned in %s) %#v", elapsed, resp)
+	}
+	assert.Equal(t, uint64(2), resp.Index)
+	if len(resp.Policies) != 1 || resp.Policies[0].Name != policy.Name {
+		t.Fatalf("bad: %#v", resp.Policies)
+	}
+
+	// Eval deletion triggers watches
+	time.AfterFunc(100*time.Millisecond, func() {
+		if err := state.DeleteACLPolicies(3, []string{policy.Name}); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	req.MinQueryIndex = 2
+	start = time.Now()
+	var resp2 structs.ACLPolicyListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListPolicies", req, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("should block (returned in %s) %#v", elapsed, resp2)
+	}
+	assert.Equal(t, uint64(3), resp2.Index)
+	assert.Equal(t, 0, len(resp2.Policies))
+}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1517,6 +1517,31 @@ func TestFSM_DeleteDeployment(t *testing.T) {
 	}
 }
 
+func TestFSM_UpsertACLPolicies(t *testing.T) {
+	t.Parallel()
+	fsm := testFSM(t)
+
+	policy := mock.ACLPolicy()
+	req := structs.ACLPolicyUpsertRequest{
+		Policies: []*structs.ACLPolicy{policy},
+	}
+	buf, err := structs.Encode(structs.ACLPolicyUpsertRequestType, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp := fsm.Apply(makeLog(buf))
+	if resp != nil {
+		t.Fatalf("resp: %v", resp)
+	}
+
+	// Verify we are registered
+	ws := memdb.NewWatchSet()
+	out, err := fsm.State().ACLPolicyByName(ws, policy.Name)
+	assert.Nil(t, err)
+	assert.NotNil(t, out)
+}
+
 func TestFSM_DeleteACLPolicies(t *testing.T) {
 	t.Parallel()
 	fsm := testFSM(t)

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1864,8 +1864,7 @@ func TestFSM_SnapshotRestore_ACLPolicy(t *testing.T) {
 	state := fsm.State()
 	p1 := mock.ACLPolicy()
 	p2 := mock.ACLPolicy()
-	state.UpsertACLPolicy(1000, p1)
-	state.UpsertACLPolicy(1001, p2)
+	state.UpsertACLPolicies(1000, []*structs.ACLPolicy{p1, p2})
 
 	// Verify the contents
 	fsm2 := testSnapshotRestore(t, fsm)

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -177,6 +177,7 @@ type endpoints struct {
 	Periodic   *Periodic
 	System     *System
 	Operator   *Operator
+	ACL        *ACL
 }
 
 // NewServer is used to construct a new Nomad server from the
@@ -714,6 +715,7 @@ func (s *Server) setupVaultClient() error {
 // setupRPC is used to setup the RPC listener
 func (s *Server) setupRPC(tlsWrap tlsutil.RegionWrapper) error {
 	// Create endpoints
+	s.endpoints.ACL = &ACL{s}
 	s.endpoints.Alloc = &Alloc{s}
 	s.endpoints.Eval = &Eval{s}
 	s.endpoints.Job = &Job{s}
@@ -727,6 +729,7 @@ func (s *Server) setupRPC(tlsWrap tlsutil.RegionWrapper) error {
 	s.endpoints.System = &System{s}
 
 	// Register the handlers
+	s.rpcServer.Register(s.endpoints.ACL)
 	s.rpcServer.Register(s.endpoints.Alloc)
 	s.rpcServer.Register(s.endpoints.Eval)
 	s.rpcServer.Register(s.endpoints.Job)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5245,19 +5245,21 @@ type ACLPolicy struct {
 	ModifyIndex uint64
 }
 
+func (a *ACLPolicy) Stub() *ACLPolicyListStub {
+	return &ACLPolicyListStub{
+		Name:        a.Name,
+		Description: a.Description,
+		CreateIndex: a.CreateIndex,
+		ModifyIndex: a.ModifyIndex,
+	}
+}
+
 // ACLPolicyListStub is used to for listing ACL policies
 type ACLPolicyListStub struct {
 	Name        string
 	Description string
 	CreateIndex uint64
 	ModifyIndex uint64
-}
-
-func (a *ACLPolicyListStub) FromPolicy(p *ACLPolicy) {
-	a.Name = p.Name
-	a.Description = p.Description
-	a.CreateIndex = p.CreateIndex
-	a.ModifyIndex = p.ModifyIndex
 }
 
 // ACLPolicyListRequest is used to request a list of policies

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -59,6 +59,8 @@ const (
 	DeploymentAllocHealthRequestType
 	DeploymentDeleteRequestType
 	JobStabilityRequestType
+	ACLPolicyUpsertRequestType
+	ACLPolicyDeleteRequestType
 )
 
 const (
@@ -5279,4 +5281,10 @@ type ACLPolicyListResponse struct {
 type SingleACLPolicyResponse struct {
 	Policy *ACLPolicy
 	QueryMeta
+}
+
+// ACLPolicyDeleteRequest is used to delete a set of policies
+type ACLPolicyDeleteRequest struct {
+	Names []string
+	WriteRequest
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5236,9 +5236,47 @@ func IsRecoverable(e error) bool {
 
 // ACLPolicy is used to represent an ACL policy
 type ACLPolicy struct {
-	Name  string // Unique name
-	Rules string // HCL or JSON format
-
+	Name        string // Unique name
+	Description string // Human readable
+	Rules       string // HCL or JSON format
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+// ACLPolicyListStub is used to for listing ACL policies
+type ACLPolicyListStub struct {
+	Name        string
+	Description string
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+func (a *ACLPolicyListStub) FromPolicy(p *ACLPolicy) {
+	a.Name = p.Name
+	a.Description = p.Description
+	a.CreateIndex = p.CreateIndex
+	a.ModifyIndex = p.ModifyIndex
+}
+
+// ACLPolicyListRequest is used to request a list of policies
+type ACLPolicyListRequest struct {
+	QueryOptions
+}
+
+// ACLPolicySpecificRequest is used to query a specific policy
+type ACLPolicySpecificRequest struct {
+	Name string
+	QueryOptions
+}
+
+// ACLPolicyListResponse is used for a list request
+type ACLPolicyListResponse struct {
+	Policies []*ACLPolicyListStub
+	QueryMeta
+}
+
+// SingleACLPolicyResponse is used to return a single policy
+type SingleACLPolicyResponse struct {
+	Policy *ACLPolicy
+	QueryMeta
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5288,3 +5288,9 @@ type ACLPolicyDeleteRequest struct {
 	Names []string
 	WriteRequest
 }
+
+// ACLPolicyUpsertRequest is used to upsert a set of policies
+type ACLPolicyUpsertRequest struct {
+	Policies []*ACLPolicy
+	WriteRequest
+}


### PR DESCRIPTION
This PR adds the ACL Policy endpoints and FSM methods to modify them. A follow up will add the HTTP endpoints.