### PR TITLE
Redact Vault.Token from AgentSelf response.

### DIFF
--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -62,7 +62,7 @@ func (s *HTTPServer) AgentSelfRequest(resp http.ResponseWriter, req *http.Reques
 		self.Config = ac.(*Config)
 	}
 
-	if self.Config.Vault.Token != "" {
+	if self.Config != nil && self.Config.Vault != nil && self.Config.Vault.Token != "" {
 		self.Config.Vault.Token = "<redacted>"
 	}
 

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/serf/serf"
+	"github.com/mitchellh/copystructure"
 )
 
 type Member struct {
@@ -52,10 +53,19 @@ func (s *HTTPServer) AgentSelfRequest(resp http.ResponseWriter, req *http.Reques
 	}
 
 	self := agentSelf{
-		Config: s.agent.config,
 		Member: nomadMember(member),
 		Stats:  s.agent.Stats(),
 	}
+	if ac, err := copystructure.Copy(s.agent.config); err != nil {
+		return nil, CodedError(500, err.Error())
+	} else {
+		self.Config = ac.(*Config)
+	}
+
+	if self.Config.Vault.Token != "" {
+		self.Config.Vault.Token = "<redacted>"
+	}
+
 	return self, nil
 }
 

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -36,6 +36,23 @@ func TestHTTP_AgentSelf(t *testing.T) {
 		if len(self.Stats) == 0 {
 			t.Fatalf("bad: %#v", self)
 		}
+
+		// Check the Vault config
+		if self.Config.Vault.Token != "" {
+			t.Fatalf("bad: %#v", self)
+		}
+
+		// Assign a Vault token and assert it is redacted.
+		s.Config.Vault.Token = "badc0deb-adc0-deba-dc0d-ebadc0debadc"
+		respW = httptest.NewRecorder()
+		obj, err = s.Server.AgentSelfRequest(respW, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		self = obj.(agentSelf)
+		if self.Config.Vault.Token != "<redacted>" {
+			t.Fatalf("bad: %#v", self)
+		}
 	})
 }
 


### PR DESCRIPTION
If Config.Vault.Token is defined, /v1/agent/self will return the string
`<redacted>`. If the token is not set, This endpoint will continue to
return the empty string.