### PR TITLE
Update job.html read most recent deployment sample

### DIFF
--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -921,7 +921,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://nomad.rocks/v1/job/my-job/deployments
+    https://nomad.rocks/v1/job/my-job/deployment
 ```
 
 ### Sample Response


### PR DESCRIPTION
The sample request incorrectly used `https://nomad.rocks/v1/job/my-job/deployments` which listed all deployments for the specified job. The sample request has therefore been updated to use the correct endpoint which returns only the jobs most recent deployment.