### PR TITLE
Template emits events explaining why it is blocked

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -506,6 +506,7 @@ const (
 	TaskRestartSignal          = "Restart Signaled"
 	TaskLeaderDead             = "Leader Task Dead"
 	TaskBuildingTaskDir        = "Building Task Directory"
+	TaskGenericMessage         = "Generic"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -533,4 +534,5 @@ type TaskEvent struct {
 	VaultError       string
 	TaskSignalReason string
 	TaskSignal       string
+	GenericSource    string
 }

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -620,8 +620,9 @@ func (r *AllocRunner) setStatus(status, desc string) {
 	}
 }
 
-// setTaskState is used to set the status of a task. If state is empty then the
-// event is appended but not synced with the server. The event may be omitted
+// setTaskState is used to set the status of a task. If lazySync is set then the
+// event is appended but not synced with the server. If state is omitted, the
+// last known state is used.
 func (r *AllocRunner) setTaskState(taskName, state string, event *structs.TaskEvent, lazySync bool) {
 	r.taskStatusLock.Lock()
 	defer r.taskStatusLock.Unlock()

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -622,7 +622,7 @@ func (r *AllocRunner) setStatus(status, desc string) {
 
 // setTaskState is used to set the status of a task. If state is empty then the
 // event is appended but not synced with the server. The event may be omitted
-func (r *AllocRunner) setTaskState(taskName, state string, event *structs.TaskEvent) {
+func (r *AllocRunner) setTaskState(taskName, state string, event *structs.TaskEvent, lazySync bool) {
 	r.taskStatusLock.Lock()
 	defer r.taskStatusLock.Unlock()
 	taskState, ok := r.taskStates[taskName]
@@ -643,8 +643,16 @@ func (r *AllocRunner) setTaskState(taskName, state string, event *structs.TaskEv
 		r.appendTaskEvent(taskState, event)
 	}
 
-	if state == "" {
+	if lazySync {
 		return
+	}
+
+	// If the state hasn't been set use the existing state.
+	if state == "" {
+		state = taskState.State
+		if taskState.State == "" {
+			state = structs.TaskStatePending
+		}
 	}
 
 	switch state {

--- a/client/consul_template.go
+++ b/client/consul_template.go
@@ -48,6 +48,9 @@ type TaskHooks interface {
 	// Kill is used to kill the task because of the passed error. If fail is set
 	// to true, the task is marked as failed
 	Kill(source, reason string, fail bool)
+
+	// EmitEvent is used to emit an event to be stored in the tasks events.
+	EmitEvent(source, message string)
 }
 
 // TaskTemplateManager is used to run a set of templates for a given task

--- a/client/consul_template.go
+++ b/client/consul_template.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,6 +26,15 @@ const (
 	// hostSrcOption is the Client option that determines whether the template
 	// source may be from the host
 	hostSrcOption = "template.allow_host_source"
+
+	// missingDepEventLimit is the number of missing dependencies that will be
+	// logged before we switch to showing just the number of missing
+	// dependencies.
+	missingDepEventLimit = 3
+
+	// DefaultMaxTemplateEventRate is the default maximum rate at which a
+	// template event should be fired.
+	DefaultMaxTemplateEventRate = 3 * time.Second
 )
 
 var (
@@ -55,14 +65,11 @@ type TaskHooks interface {
 
 // TaskTemplateManager is used to run a set of templates for a given task
 type TaskTemplateManager struct {
-	// templates is the set of templates we are managing
-	templates []*structs.Template
+	// config holds the template managers configuration
+	config *TaskTemplateManagerConfig
 
 	// lookup allows looking up the set of Nomad templates by their consul-template ID
 	lookup map[string][]*structs.Template
-
-	// hooks is used to signal/restart the task as templates are rendered
-	hook TaskHooks
 
 	// runner is the consul-template runner
 	runner *manager.Runner
@@ -79,29 +86,67 @@ type TaskTemplateManager struct {
 	shutdownLock sync.Mutex
 }
 
-func NewTaskTemplateManager(hook TaskHooks, tmpls []*structs.Template,
-	config *config.Config, vaultToken, taskDir string,
-	envBuilder *env.Builder) (*TaskTemplateManager, error) {
+// TaskTemplateManagerConfig is used to configure an instance of the
+// TaskTemplateManager
+type TaskTemplateManagerConfig struct {
+	// Hooks is used to interact with the task the template manager is being run
+	// for
+	Hooks TaskHooks
 
+	// Templates is the set of templates we are managing
+	Templates []*structs.Template
+
+	// ClientConfig is the Nomad Client configuration
+	ClientConfig *config.Config
+
+	// VaultToken is the Vault token for the task.
+	VaultToken string
+
+	// TaskDir is the task's directory
+	TaskDir string
+
+	// EnvBuilder is the environment variable builder for the task.
+	EnvBuilder *env.Builder
+
+	// MaxTemplateEventRate is the maximum rate at which we should emit events.
+	MaxTemplateEventRate time.Duration
+
+	// retryRate is only used for testing and is used to increase the retry rate
+	retryRate time.Duration
+}
+
+// Validate validates the configuration.
+func (c *TaskTemplateManagerConfig) Validate() error {
+	if c == nil {
+		return fmt.Errorf("Nil config passed")
+	} else if c.Hooks == nil {
+		return fmt.Errorf("Invalid task hooks given")
+	} else if c.ClientConfig == nil {
+		return fmt.Errorf("Invalid client config given")
+	} else if c.TaskDir == "" {
+		return fmt.Errorf("Invalid task directory given")
+	} else if c.EnvBuilder == nil {
+		return fmt.Errorf("Invalid task environment given")
+	} else if c.MaxTemplateEventRate == 0 {
+		return fmt.Errorf("Invalid max template event rate given")
+	}
+
+	return nil
+}
+
+func NewTaskTemplateManager(config *TaskTemplateManagerConfig) (*TaskTemplateManager, error) {
 	// Check pre-conditions
-	if hook == nil {
-		return nil, fmt.Errorf("Invalid task hook given")
-	} else if config == nil {
-		return nil, fmt.Errorf("Invalid config given")
-	} else if taskDir == "" {
-		return nil, fmt.Errorf("Invalid task directory given")
-	} else if envBuilder == nil {
-		return nil, fmt.Errorf("Invalid task environment given")
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	tm := &TaskTemplateManager{
-		templates:  tmpls,
-		hook:       hook,
+		config:     config,
 		shutdownCh: make(chan struct{}),
 	}
 
 	// Parse the signals that we need
-	for _, tmpl := range tmpls {
+	for _, tmpl := range config.Templates {
 		if tmpl.ChangeSignal == "" {
 			continue
 		}
@@ -119,14 +164,14 @@ func NewTaskTemplateManager(hook TaskHooks, tmpls []*structs.Template,
 	}
 
 	// Build the consul-template runner
-	runner, lookup, err := templateRunner(tmpls, config, vaultToken, taskDir, envBuilder.Build())
+	runner, lookup, err := templateRunner(config)
 	if err != nil {
 		return nil, err
 	}
 	tm.runner = runner
 	tm.lookup = lookup
 
-	go tm.run(envBuilder, taskDir)
+	go tm.run()
 	return tm, nil
 }
 
@@ -149,22 +194,61 @@ func (tm *TaskTemplateManager) Stop() {
 }
 
 // run is the long lived loop that handles errors and templates being rendered
-func (tm *TaskTemplateManager) run(envBuilder *env.Builder, taskDir string) {
+func (tm *TaskTemplateManager) run() {
 	// Runner is nil if there is no templates
 	if tm.runner == nil {
 		// Unblock the start if there is nothing to do
-		tm.hook.UnblockStart("consul-template")
+		tm.config.Hooks.UnblockStart("Template")
 		return
 	}
 
 	// Start the runner
 	go tm.runner.Start()
 
-	// Track when they have all been rendered so we don't signal the task for
-	// any render event before hand
-	var allRenderedTime time.Time
+	// Block till all the templates have been rendered
+	tm.handleFirstRender()
 
-	// Handle the first rendering
+	// Detect if there was a shutdown.
+	select {
+	case <-tm.shutdownCh:
+		return
+	default:
+	}
+
+	// Read environment variables from env templates before we unblock
+	envMap, err := loadTemplateEnv(tm.config.Templates, tm.config.TaskDir)
+	if err != nil {
+		tm.config.Hooks.Kill("Template", err.Error(), true)
+		return
+	}
+	tm.config.EnvBuilder.SetTemplateEnv(envMap)
+
+	// Unblock the task
+	tm.config.Hooks.UnblockStart("Template")
+
+	// If all our templates are change mode no-op, then we can exit here
+	if tm.allTemplatesNoop() {
+		return
+	}
+
+	// handle all subsequent render events.
+	tm.handleTemplateRerenders(time.Now())
+}
+
+// handleFirstRender blocks till all templates have been rendered
+func (tm *TaskTemplateManager) handleFirstRender() {
+	// missingDependencies is the set of missing dependencies.
+	var missingDependencies map[string]struct{}
+
+	// eventTimer is used to trigger the firing of an event showing the missing
+	// dependencies.
+	var eventTimer *time.Timer
+	var eventTimerCh <-chan time.Time
+
+	// outstandingEvent tracks whether there is an outstanding event that should
+	// be fired.
+	outstandingEvent := false
+
 	// Wait till all the templates have been rendered
 WAIT:
 	for {
@@ -176,7 +260,7 @@ WAIT:
 				continue
 			}
 
-			tm.hook.Kill("consul-template", err.Error(), true)
+			tm.config.Hooks.Kill("template", err.Error(), true)
 		case <-tm.runner.TemplateRenderedCh():
 			// A template has been rendered, figure out what to do
 			events := tm.runner.RenderEvents()
@@ -194,28 +278,85 @@ WAIT:
 			}
 
 			break WAIT
+		case <-tm.runner.RenderEventCh():
+			events := tm.runner.RenderEvents()
+			joinedSet := make(map[string]struct{})
+			for _, event := range events {
+				missing := event.MissingDeps
+				if missing == nil {
+					continue
+				}
+
+				for _, dep := range missing.List() {
+					joinedSet[dep.String()] = struct{}{}
+				}
+			}
+
+			// Check to see if the new joined set is the same as the old
+			different := len(joinedSet) != len(missingDependencies)
+			if !different {
+				for k := range joinedSet {
+					if _, ok := missingDependencies[k]; !ok {
+						different = true
+						break
+					}
+				}
+			}
+
+			// Nothing to do
+			if !different {
+				continue
+			}
+
+			// Update the missing set
+			missingDependencies = joinedSet
+
+			// Update the event timer channel
+			if eventTimer == nil {
+				// We are creating the event channel for the first time.
+				eventTimer = time.NewTimer(tm.config.MaxTemplateEventRate)
+				eventTimerCh = eventTimer.C
+				defer eventTimer.Stop()
+				outstandingEvent = true
+				continue
+			} else if !outstandingEvent {
+				// We got new data so reset
+				outstandingEvent = true
+				eventTimer.Reset(tm.config.MaxTemplateEventRate)
+			}
+		case <-eventTimerCh:
+			if missingDependencies == nil {
+				continue
+			}
+
+			// Clear the outstanding event
+			outstandingEvent = false
+
+			// Build the missing set
+			missingSlice := make([]string, 0, len(missingDependencies))
+			for k := range missingDependencies {
+				missingSlice = append(missingSlice, k)
+			}
+			sort.Strings(missingSlice)
+
+			if l := len(missingSlice); l > missingDepEventLimit {
+				missingSlice[missingDepEventLimit] = fmt.Sprintf("and %d more", l-missingDepEventLimit)
+				missingSlice = missingSlice[:missingDepEventLimit+1]
+			}
+
+			missingStr := strings.Join(missingSlice, ", ")
+			tm.config.Hooks.EmitEvent("Template", fmt.Sprintf("Missing: %s", missingStr))
 		}
 	}
+}
 
-	// Read environment variables from env templates
-	envMap, err := loadTemplateEnv(tm.templates, taskDir)
-	if err != nil {
-		tm.hook.Kill("consul-template", err.Error(), true)
-		return
-	}
-	envBuilder.SetTemplateEnv(envMap)
-
-	allRenderedTime = time.Now()
-	tm.hook.UnblockStart("consul-template")
-
-	// If all our templates are change mode no-op, then we can exit here
-	if tm.allTemplatesNoop() {
-		return
-	}
-
+// handleTemplateRerenders is used to handle template render events after they
+// have all rendered. It takes action based on which set of templates re-render.
+// The passed allRenderedTime is the time at which all templates have rendered.
+// This is used to avoid signaling the task for any render event before hand.
+func (tm *TaskTemplateManager) handleTemplateRerenders(allRenderedTime time.Time) {
 	// A lookup for the last time the template was handled
-	numTemplates := len(tm.templates)
-	handledRenders := make(map[string]time.Time, numTemplates)
+	handledRenders := make(map[string]time.Time, len(tm.config.Templates))
 
 	for {
 		select {
@@ -226,7 +367,7 @@ WAIT:
 				continue
 			}
 
-			tm.hook.Kill("consul-template", err.Error(), true)
+			tm.config.Hooks.Kill("Template", err.Error(), true)
 		case <-tm.runner.TemplateRenderedCh():
 			// A template has been rendered, figure out what to do
 			var handling []string
@@ -251,17 +392,17 @@ WAIT:
 				// Lookup the template and determine what to do
 				tmpls, ok := tm.lookup[id]
 				if !ok {
-					tm.hook.Kill("consul-template", fmt.Sprintf("consul-template runner returned unknown template id %q", id), true)
+					tm.config.Hooks.Kill("Template", fmt.Sprintf("template runner returned unknown template id %q", id), true)
 					return
 				}
 
 				// Read environment variables from templates
-				envMap, err := loadTemplateEnv(tmpls, taskDir)
+				envMap, err := loadTemplateEnv(tmpls, tm.config.TaskDir)
 				if err != nil {
-					tm.hook.Kill("consul-template", err.Error(), true)
+					tm.config.Hooks.Kill("Template", err.Error(), true)
 					return
 				}
-				envBuilder.SetTemplateEnv(envMap)
+				tm.config.EnvBuilder.SetTemplateEnv(envMap)
 
 				for _, tmpl := range tmpls {
 					switch tmpl.ChangeMode {
@@ -300,11 +441,11 @@ WAIT:
 				}
 
 				if restart {
-					tm.hook.Restart("consul-template", "template with change_mode restart re-rendered")
+					tm.config.Hooks.Restart("template", "template with change_mode restart re-rendered")
 				} else if len(signals) != 0 {
 					var mErr multierror.Error
 					for signal := range signals {
-						err := tm.hook.Signal("consul-template", "template re-rendered", tm.signals[signal])
+						err := tm.config.Hooks.Signal("Template", "template re-rendered", tm.signals[signal])
 						if err != nil {
 							multierror.Append(&mErr, err)
 						}
@@ -315,7 +456,7 @@ WAIT:
 						for signal := range signals {
 							flat = append(flat, tm.signals[signal])
 						}
-						tm.hook.Kill("consul-template", fmt.Sprintf("Sending signals %v failed: %v", flat, err), true)
+						tm.config.Hooks.Kill("Template", fmt.Sprintf("Sending signals %v failed: %v", flat, err), true)
 					}
 				}
 			}
@@ -325,7 +466,7 @@ WAIT:
 
 // allTemplatesNoop returns whether all the managed templates have change mode noop.
 func (tm *TaskTemplateManager) allTemplatesNoop() bool {
-	for _, tmpl := range tm.templates {
+	for _, tmpl := range tm.config.Templates {
 		if tmpl.ChangeMode != structs.TemplateChangeModeNoop {
 			return false
 		}
@@ -335,25 +476,23 @@ func (tm *TaskTemplateManager) allTemplatesNoop() bool {
 }
 
 // templateRunner returns a consul-template runner for the given templates and a
-// lookup by destination to the template. If no templates are given, a nil
-// template runner and lookup is returned.
-func templateRunner(tmpls []*structs.Template, config *config.Config,
-	vaultToken, taskDir string, taskEnv *env.TaskEnv) (
+// lookup by destination to the template. If no templates are in the config, a
+// nil template runner and lookup is returned.
+func templateRunner(config *TaskTemplateManagerConfig) (
 	*manager.Runner, map[string][]*structs.Template, error) {
 
-	if len(tmpls) == 0 {
+	if len(config.Templates) == 0 {
 		return nil, nil, nil
 	}
 
 	// Parse the templates
-	allowAbs := config.ReadBoolDefault(hostSrcOption, true)
-	ctmplMapping, err := parseTemplateConfigs(tmpls, taskDir, taskEnv, allowAbs)
+	ctmplMapping, err := parseTemplateConfigs(config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Create the runner configuration.
-	runnerConfig, err := newRunnerConfig(config, vaultToken, ctmplMapping)
+	runnerConfig, err := newRunnerConfig(config, ctmplMapping)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -364,7 +503,7 @@ func templateRunner(tmpls []*structs.Template, config *config.Config,
 	}
 
 	// Set Nomad's environment variables
-	runner.Env = taskEnv.All()
+	runner.Env = config.EnvBuilder.Build().All()
 
 	// Build the lookup
 	idMap := runner.TemplateConfigMapping()
@@ -380,12 +519,14 @@ func templateRunner(tmpls []*structs.Template, config *config.Config,
 	return runner, lookup, nil
 }
 
-// parseTemplateConfigs converts the tasks templates into consul-templates
-func parseTemplateConfigs(tmpls []*structs.Template, taskDir string,
-	taskEnv *env.TaskEnv, allowAbs bool) (map[ctconf.TemplateConfig]*structs.Template, error) {
+// parseTemplateConfigs converts the tasks templates in the config into
+// consul-templates
+func parseTemplateConfigs(config *TaskTemplateManagerConfig) (map[ctconf.TemplateConfig]*structs.Template, error) {
+	allowAbs := config.ClientConfig.ReadBoolDefault(hostSrcOption, true)
+	taskEnv := config.EnvBuilder.Build()
 
-	ctmpls := make(map[ctconf.TemplateConfig]*structs.Template, len(tmpls))
-	for _, tmpl := range tmpls {
+	ctmpls := make(map[ctconf.TemplateConfig]*structs.Template, len(config.Templates))
+	for _, tmpl := range config.Templates {
 		var src, dest string
 		if tmpl.SourcePath != "" {
 			if filepath.IsAbs(tmpl.SourcePath) {
@@ -395,11 +536,11 @@ func parseTemplateConfigs(tmpls []*structs.Template, taskDir string,
 
 				src = tmpl.SourcePath
 			} else {
-				src = filepath.Join(taskDir, taskEnv.ReplaceEnv(tmpl.SourcePath))
+				src = filepath.Join(config.TaskDir, taskEnv.ReplaceEnv(tmpl.SourcePath))
 			}
 		}
 		if tmpl.DestPath != "" {
-			dest = filepath.Join(taskDir, taskEnv.ReplaceEnv(tmpl.DestPath))
+			dest = filepath.Join(config.TaskDir, taskEnv.ReplaceEnv(tmpl.DestPath))
 		}
 
 		ct := ctconf.DefaultTemplateConfig()
@@ -427,12 +568,11 @@ func parseTemplateConfigs(tmpls []*structs.Template, taskDir string,
 }
 
 // newRunnerConfig returns a consul-template runner configuration, setting the
-// Vault and Consul configurations based on the clients configs. The parameters
-// are the client config, Vault token if set and the mapping of consul-templates
-// to Nomad templates.
-func newRunnerConfig(config *config.Config, vaultToken string,
+// Vault and Consul configurations based on the clients configs.
+func newRunnerConfig(config *TaskTemplateManagerConfig,
 	templateMapping map[ctconf.TemplateConfig]*structs.Template) (*ctconf.Config, error) {
 
+	cc := config.ClientConfig
 	conf := ctconf.DefaultConfig()
 
 	// Gather the consul-template tempates
@@ -455,29 +595,29 @@ func newRunnerConfig(config *config.Config, vaultToken string,
 	}
 
 	// Force faster retries
-	if testRetryRate != 0 {
-		rate := testRetryRate
+	if config.retryRate != 0 {
+		rate := config.retryRate
 		conf.Consul.Retry.Backoff = &rate
 	}
 
 	// Setup the Consul config
-	if config.ConsulConfig != nil {
-		conf.Consul.Address = &config.ConsulConfig.Addr
-		conf.Consul.Token = &config.ConsulConfig.Token
+	if cc.ConsulConfig != nil {
+		conf.Consul.Address = &cc.ConsulConfig.Addr
+		conf.Consul.Token = &cc.ConsulConfig.Token
 
-		if config.ConsulConfig.EnableSSL != nil && *config.ConsulConfig.EnableSSL {
-			verify := config.ConsulConfig.VerifySSL != nil && *config.ConsulConfig.VerifySSL
+		if cc.ConsulConfig.EnableSSL != nil && *cc.ConsulConfig.EnableSSL {
+			verify := cc.ConsulConfig.VerifySSL != nil && *cc.ConsulConfig.VerifySSL
 			conf.Consul.SSL = &ctconf.SSLConfig{
 				Enabled: helper.BoolToPtr(true),
 				Verify:  &verify,
-				Cert:    &config.ConsulConfig.CertFile,
-				Key:     &config.ConsulConfig.KeyFile,
-				CaCert:  &config.ConsulConfig.CAFile,
+				Cert:    &cc.ConsulConfig.CertFile,
+				Key:     &cc.ConsulConfig.KeyFile,
+				CaCert:  &cc.ConsulConfig.CAFile,
 			}
 		}
 
-		if config.ConsulConfig.Auth != "" {
-			parts := strings.SplitN(config.ConsulConfig.Auth, ":", 2)
+		if cc.ConsulConfig.Auth != "" {
+			parts := strings.SplitN(cc.ConsulConfig.Auth, ":", 2)
 			if len(parts) != 2 {
 				return nil, fmt.Errorf("Failed to parse Consul Auth config")
 			}
@@ -495,22 +635,22 @@ func newRunnerConfig(config *config.Config, vaultToken string,
 	emptyStr := ""
 	conf.Vault.RenewToken = helper.BoolToPtr(false)
 	conf.Vault.Token = &emptyStr
-	if config.VaultConfig != nil && config.VaultConfig.IsEnabled() {
-		conf.Vault.Address = &config.VaultConfig.Addr
-		conf.Vault.Token = &vaultToken
+	if cc.VaultConfig != nil && cc.VaultConfig.IsEnabled() {
+		conf.Vault.Address = &cc.VaultConfig.Addr
+		conf.Vault.Token = &config.VaultToken
 		conf.Vault.Grace = helper.TimeToPtr(vaultGrace)
 
-		if strings.HasPrefix(config.VaultConfig.Addr, "https") || config.VaultConfig.TLSCertFile != "" {
-			skipVerify := config.VaultConfig.TLSSkipVerify != nil && *config.VaultConfig.TLSSkipVerify
+		if strings.HasPrefix(cc.VaultConfig.Addr, "https") || cc.VaultConfig.TLSCertFile != "" {
+			skipVerify := cc.VaultConfig.TLSSkipVerify != nil && *cc.VaultConfig.TLSSkipVerify
 			verify := !skipVerify
 			conf.Vault.SSL = &ctconf.SSLConfig{
 				Enabled:    helper.BoolToPtr(true),
 				Verify:     &verify,
-				Cert:       &config.VaultConfig.TLSCertFile,
-				Key:        &config.VaultConfig.TLSKeyFile,
-				CaCert:     &config.VaultConfig.TLSCaFile,
-				CaPath:     &config.VaultConfig.TLSCaPath,
-				ServerName: &config.VaultConfig.TLSServerName,
+				Cert:       &cc.VaultConfig.TLSCertFile,
+				Key:        &cc.VaultConfig.TLSKeyFile,
+				CaCert:     &cc.VaultConfig.TLSCaFile,
+				CaPath:     &cc.VaultConfig.TLSCaPath,
+				ServerName: &cc.VaultConfig.TLSServerName,
 			}
 		} else {
 			conf.Vault.SSL = &ctconf.SSLConfig{

--- a/client/consul_template_test.go
+++ b/client/consul_template_test.go
@@ -43,14 +43,18 @@ type MockTaskHooks struct {
 
 	KillReason string
 	KillCh     chan struct{}
+
+	Events      []string
+	EmitEventCh chan struct{}
 }
 
 func NewMockTaskHooks() *MockTaskHooks {
 	return &MockTaskHooks{
-		UnblockCh: make(chan struct{}, 1),
-		RestartCh: make(chan struct{}, 1),
-		SignalCh:  make(chan struct{}, 1),
-		KillCh:    make(chan struct{}, 1),
+		UnblockCh:   make(chan struct{}, 1),
+		RestartCh:   make(chan struct{}, 1),
+		SignalCh:    make(chan struct{}, 1),
+		KillCh:      make(chan struct{}, 1),
+		EmitEventCh: make(chan struct{}, 1),
 	}
 }
 func (m *MockTaskHooks) Restart(source, reason string) {
@@ -85,6 +89,14 @@ func (m *MockTaskHooks) UnblockStart(source string) {
 	}
 
 	m.Unblocked = true
+}
+
+func (m *MockTaskHooks) EmitEvent(source, message string) {
+	m.Events = append(m.Events, message)
+	select {
+	case m.EmitEventCh <- struct{}{}:
+	default:
+	}
 }
 
 // testHarness is used to test the TaskTemplateManager by spinning up

--- a/client/consul_template_test.go
+++ b/client/consul_template_test.go
@@ -112,6 +112,7 @@ type testHarness struct {
 	taskDir    string
 	vault      *testutil.TestVault
 	consul     *ctestutil.TestServer
+	emitRate   time.Duration
 }
 
 // newTestHarness returns a harness starting a dev consul and vault server,
@@ -123,6 +124,7 @@ func newTestHarness(t *testing.T, templates []*structs.Template, consul, vault b
 		templates: templates,
 		node:      mock.Node(),
 		config:    &config.Config{Region: region},
+		emitRate:  DefaultMaxTemplateEventRate,
 	}
 
 	// Build the task environment
@@ -158,20 +160,29 @@ func newTestHarness(t *testing.T, templates []*structs.Template, consul, vault b
 }
 
 func (h *testHarness) start(t *testing.T) {
-	manager, err := NewTaskTemplateManager(h.mockHooks, h.templates,
-		h.config, h.vaultToken, h.taskDir, h.envBuilder)
-	if err != nil {
+	if err := h.startWithErr(); err != nil {
 		t.Fatalf("failed to build task template manager: %v", err)
 	}
-
-	h.manager = manager
 }
 
 func (h *testHarness) startWithErr() error {
-	manager, err := NewTaskTemplateManager(h.mockHooks, h.templates,
-		h.config, h.vaultToken, h.taskDir, h.envBuilder)
-	h.manager = manager
+	var err error
+	h.manager, err = NewTaskTemplateManager(&TaskTemplateManagerConfig{
+		Hooks:                h.mockHooks,
+		Templates:            h.templates,
+		ClientConfig:         h.config,
+		VaultToken:           h.vaultToken,
+		TaskDir:              h.taskDir,
+		EnvBuilder:           h.envBuilder,
+		MaxTemplateEventRate: h.emitRate,
+		retryRate:            10 * time.Millisecond,
+	})
+
 	return err
+}
+
+func (h *testHarness) setEmitRate(d time.Duration) {
+	h.emitRate = d
 }
 
 // stop is used to stop any running Vault or Consul server plus the task manager
@@ -190,61 +201,118 @@ func (h *testHarness) stop() {
 	}
 }
 
-func TestTaskTemplateManager_Invalid(t *testing.T) {
+func TestTaskTemplateManager_InvalidConfig(t *testing.T) {
 	t.Parallel()
 	hooks := NewMockTaskHooks()
-	var tmpls []*structs.Template
-	region := "global"
-	config := &config.Config{Region: region}
+	clientConfig := &config.Config{Region: "global"}
 	taskDir := "foo"
-	vaultToken := ""
 	a := mock.Alloc()
-	envBuilder := env.NewBuilder(mock.Node(), a, a.Job.TaskGroups[0].Tasks[0], config.Region)
+	envBuilder := env.NewBuilder(mock.Node(), a, a.Job.TaskGroups[0].Tasks[0], clientConfig.Region)
 
-	_, err := NewTaskTemplateManager(nil, nil, nil, "", "", nil)
-	if err == nil {
-		t.Fatalf("Expected error")
+	cases := []struct {
+		name        string
+		config      *TaskTemplateManagerConfig
+		expectedErr string
+	}{
+		{
+			name:        "nil config",
+			config:      nil,
+			expectedErr: "Nil config passed",
+		},
+		{
+			name: "bad hooks",
+			config: &TaskTemplateManagerConfig{
+				ClientConfig:         clientConfig,
+				TaskDir:              taskDir,
+				EnvBuilder:           envBuilder,
+				MaxTemplateEventRate: DefaultMaxTemplateEventRate,
+			},
+			expectedErr: "task hooks",
+		},
+		{
+			name: "bad client config",
+			config: &TaskTemplateManagerConfig{
+				Hooks:                hooks,
+				TaskDir:              taskDir,
+				EnvBuilder:           envBuilder,
+				MaxTemplateEventRate: DefaultMaxTemplateEventRate,
+			},
+			expectedErr: "client config",
+		},
+		{
+			name: "bad task dir",
+			config: &TaskTemplateManagerConfig{
+				ClientConfig:         clientConfig,
+				Hooks:                hooks,
+				EnvBuilder:           envBuilder,
+				MaxTemplateEventRate: DefaultMaxTemplateEventRate,
+			},
+			expectedErr: "task directory",
+		},
+		{
+			name: "bad env builder",
+			config: &TaskTemplateManagerConfig{
+				ClientConfig:         clientConfig,
+				Hooks:                hooks,
+				TaskDir:              taskDir,
+				MaxTemplateEventRate: DefaultMaxTemplateEventRate,
+			},
+			expectedErr: "task environment",
+		},
+		{
+			name: "bad max event rate",
+			config: &TaskTemplateManagerConfig{
+				ClientConfig: clientConfig,
+				Hooks:        hooks,
+				TaskDir:      taskDir,
+				EnvBuilder:   envBuilder,
+			},
+			expectedErr: "template event rate",
+		},
+		{
+			name: "valid",
+			config: &TaskTemplateManagerConfig{
+				ClientConfig:         clientConfig,
+				Hooks:                hooks,
+				TaskDir:              taskDir,
+				EnvBuilder:           envBuilder,
+				MaxTemplateEventRate: DefaultMaxTemplateEventRate,
+			},
+		},
+		{
+			name: "invalid signal",
+			config: &TaskTemplateManagerConfig{
+				Templates: []*structs.Template{
+					{
+						DestPath:     "foo",
+						EmbeddedTmpl: "hello, world",
+						ChangeMode:   structs.TemplateChangeModeSignal,
+						ChangeSignal: "foobarbaz",
+					},
+				},
+				ClientConfig:         clientConfig,
+				Hooks:                hooks,
+				TaskDir:              taskDir,
+				EnvBuilder:           envBuilder,
+				MaxTemplateEventRate: DefaultMaxTemplateEventRate,
+			},
+			expectedErr: "parse signal",
+		},
 	}
 
-	_, err = NewTaskTemplateManager(nil, tmpls, config, vaultToken, taskDir, envBuilder)
-	if err == nil || !strings.Contains(err.Error(), "task hook") {
-		t.Fatalf("Expected invalid task hook error: %v", err)
-	}
-
-	_, err = NewTaskTemplateManager(hooks, tmpls, nil, vaultToken, taskDir, envBuilder)
-	if err == nil || !strings.Contains(err.Error(), "config") {
-		t.Fatalf("Expected invalid config error: %v", err)
-	}
-
-	_, err = NewTaskTemplateManager(hooks, tmpls, config, vaultToken, "", envBuilder)
-	if err == nil || !strings.Contains(err.Error(), "task directory") {
-		t.Fatalf("Expected invalid task dir error: %v", err)
-	}
-
-	_, err = NewTaskTemplateManager(hooks, tmpls, config, vaultToken, taskDir, nil)
-	if err == nil || !strings.Contains(err.Error(), "task environment") {
-		t.Fatalf("Expected invalid task environment error: %v", err)
-	}
-
-	tm, err := NewTaskTemplateManager(hooks, tmpls, config, vaultToken, taskDir, envBuilder)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	} else if tm == nil {
-		t.Fatalf("Bad %v", tm)
-	}
-
-	// Build a template with a bad signal
-	tmpl := &structs.Template{
-		DestPath:     "foo",
-		EmbeddedTmpl: "hello, world",
-		ChangeMode:   structs.TemplateChangeModeSignal,
-		ChangeSignal: "foobarbaz",
-	}
-
-	tmpls = append(tmpls, tmpl)
-	tm, err = NewTaskTemplateManager(hooks, tmpls, config, vaultToken, taskDir, envBuilder)
-	if err == nil || !strings.Contains(err.Error(), "Failed to parse signal") {
-		t.Fatalf("Expected signal parsing error: %v", err)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := NewTaskTemplateManager(c.config)
+			if err != nil {
+				if c.expectedErr == "" {
+					t.Fatalf("unexpected error: %v", err)
+				} else if !strings.Contains(err.Error(), c.expectedErr) {
+					t.Fatalf("expected error to contain %q; got %q", c.expectedErr, err.Error())
+				}
+			} else if c.expectedErr != "" {
+				t.Fatalf("expected an error to contain %q", c.expectedErr)
+			}
+		})
 	}
 }
 
@@ -460,9 +528,6 @@ func TestTaskTemplateManager_Unblock_Consul(t *testing.T) {
 		ChangeMode:   structs.TemplateChangeModeNoop,
 	}
 
-	// Drop the retry rate
-	testRetryRate = 10 * time.Millisecond
-
 	harness := newTestHarness(t, []*structs.Template{template}, true, false)
 	harness.start(t)
 	defer harness.stop()
@@ -509,9 +574,6 @@ func TestTaskTemplateManager_Unblock_Vault(t *testing.T) {
 		DestPath:     file,
 		ChangeMode:   structs.TemplateChangeModeNoop,
 	}
-
-	// Drop the retry rate
-	testRetryRate = 10 * time.Millisecond
 
 	harness := newTestHarness(t, []*structs.Template{template}, false, true)
 	harness.start(t)
@@ -568,9 +630,6 @@ func TestTaskTemplateManager_Unblock_Multi_Template(t *testing.T) {
 		DestPath:     consulFile,
 		ChangeMode:   structs.TemplateChangeModeNoop,
 	}
-
-	// Drop the retry rate
-	testRetryRate = 10 * time.Millisecond
 
 	harness := newTestHarness(t, []*structs.Template{template, template2}, true, false)
 	harness.start(t)
@@ -629,9 +688,6 @@ func TestTaskTemplateManager_Rerender_Noop(t *testing.T) {
 		DestPath:     file,
 		ChangeMode:   structs.TemplateChangeModeNoop,
 	}
-
-	// Drop the retry rate
-	testRetryRate = 10 * time.Millisecond
 
 	harness := newTestHarness(t, []*structs.Template{template}, true, false)
 	harness.start(t)
@@ -716,9 +772,6 @@ func TestTaskTemplateManager_Rerender_Signal(t *testing.T) {
 		ChangeSignal: "SIGBUS",
 	}
 
-	// Drop the retry rate
-	testRetryRate = 10 * time.Millisecond
-
 	harness := newTestHarness(t, []*structs.Template{template, template2}, true, false)
 	harness.start(t)
 	defer harness.stop()
@@ -801,9 +854,6 @@ func TestTaskTemplateManager_Rerender_Restart(t *testing.T) {
 		DestPath:     file1,
 		ChangeMode:   structs.TemplateChangeModeRestart,
 	}
-
-	// Drop the retry rate
-	testRetryRate = 10 * time.Millisecond
 
 	harness := newTestHarness(t, []*structs.Template{template}, true, false)
 	harness.start(t)
@@ -904,9 +954,6 @@ func TestTaskTemplateManager_Signal_Error(t *testing.T) {
 		ChangeMode:   structs.TemplateChangeModeSignal,
 		ChangeSignal: "SIGALRM",
 	}
-
-	// Drop the retry rate
-	testRetryRate = 10 * time.Millisecond
 
 	harness := newTestHarness(t, []*structs.Template{template}, true, false)
 	harness.start(t)
@@ -1075,7 +1122,11 @@ func TestTaskTemplateManager_Config_ServerName(t *testing.T) {
 		Addr:          "https://localhost/",
 		TLSServerName: "notlocalhost",
 	}
-	ctconf, err := newRunnerConfig(c, "token", nil)
+	config := &TaskTemplateManagerConfig{
+		ClientConfig: c,
+		VaultToken:   "token",
+	}
+	ctconf, err := newRunnerConfig(config, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1091,34 +1142,97 @@ func TestTaskTemplateManager_Config_VaultGrace(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 	c := config.DefaultConfig()
+	c.Node = mock.Node()
 	c.VaultConfig = &sconfig.VaultConfig{
 		Enabled:       helper.BoolToPtr(true),
 		Addr:          "https://localhost/",
 		TLSServerName: "notlocalhost",
 	}
 
-	// Make a template that will render immediately
-	templates := []*structs.Template{
-		{
-			EmbeddedTmpl: "bar",
-			DestPath:     "foo",
-			ChangeMode:   structs.TemplateChangeModeNoop,
-			VaultGrace:   10 * time.Second,
+	alloc := mock.Alloc()
+	config := &TaskTemplateManagerConfig{
+		ClientConfig: c,
+		VaultToken:   "token",
+
+		// Make a template that will render immediately
+		Templates: []*structs.Template{
+			{
+				EmbeddedTmpl: "bar",
+				DestPath:     "foo",
+				ChangeMode:   structs.TemplateChangeModeNoop,
+				VaultGrace:   10 * time.Second,
+			},
+			{
+				EmbeddedTmpl: "baz",
+				DestPath:     "bam",
+				ChangeMode:   structs.TemplateChangeModeNoop,
+				VaultGrace:   100 * time.Second,
+			},
 		},
-		{
-			EmbeddedTmpl: "baz",
-			DestPath:     "bam",
-			ChangeMode:   structs.TemplateChangeModeNoop,
-			VaultGrace:   100 * time.Second,
-		},
+		EnvBuilder: env.NewBuilder(c.Node, alloc, alloc.Job.TaskGroups[0].Tasks[0], c.Region),
 	}
 
-	taskEnv := env.NewTaskEnv(nil, nil)
-	ctmplMapping, err := parseTemplateConfigs(templates, "/fake/dir", taskEnv, false)
+	ctmplMapping, err := parseTemplateConfigs(config)
 	assert.Nil(err, "Parsing Templates")
 
-	ctconf, err := newRunnerConfig(c, "token", ctmplMapping)
+	ctconf, err := newRunnerConfig(config, ctmplMapping)
 	assert.Nil(err, "Building Runner Config")
 	assert.NotNil(ctconf.Vault.Grace, "Vault Grace Pointer")
 	assert.Equal(10*time.Second, *ctconf.Vault.Grace, "Vault Grace Value")
+}
+
+func TestTaskTemplateManager_BlockedEvents(t *testing.T) {
+	t.Parallel()
+	// Make a template that will render based on a key in Consul
+	var embedded string
+	for i := 0; i < 5; i++ {
+		embedded += fmt.Sprintf(`{{key "%d"}}`, i)
+	}
+
+	file := "my.tmpl"
+	template := &structs.Template{
+		EmbeddedTmpl: embedded,
+		DestPath:     file,
+		ChangeMode:   structs.TemplateChangeModeNoop,
+	}
+
+	harness := newTestHarness(t, []*structs.Template{template}, true, false)
+	harness.setEmitRate(100 * time.Millisecond)
+	harness.start(t)
+	defer harness.stop()
+
+	// Ensure that we get a blocked event
+	select {
+	case <-harness.mockHooks.UnblockCh:
+		t.Fatalf("Task unblock should have not have been called")
+	case <-harness.mockHooks.EmitEventCh:
+	case <-time.After(time.Duration(1*testutil.TestMultiplier()) * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	// Check to see we got a correct message
+	event := harness.mockHooks.Events[0]
+	if !strings.Contains(event, "and 2 more") {
+		t.Fatalf("bad event: %q", event)
+	}
+
+	// Write 3 keys to Consul
+	for i := 0; i < 3; i++ {
+		harness.consul.SetKV(t, fmt.Sprintf("%d", i), []byte{0xa})
+	}
+
+	// Ensure that we get a blocked event
+	select {
+	case <-harness.mockHooks.UnblockCh:
+		t.Fatalf("Task unblock should have not have been called")
+	case <-harness.mockHooks.EmitEventCh:
+	case <-time.After(time.Duration(1*testutil.TestMultiplier()) * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	// Check to see we got a correct message
+	event = harness.mockHooks.Events[len(harness.mockHooks.Events)-1]
+	if !strings.Contains(event, "Missing") || strings.Contains(event, "more") {
+		t.Fatalf("bad event: %q", event)
+	}
 }

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -41,7 +41,7 @@ type MockTaskStateUpdater struct {
 	events []*structs.TaskEvent
 }
 
-func (m *MockTaskStateUpdater) Update(name, state string, event *structs.TaskEvent) {
+func (m *MockTaskStateUpdater) Update(name, state string, event *structs.TaskEvent, _ bool) {
 	if state != "" {
 		m.state = state
 	}

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -398,6 +398,9 @@ func (c *AllocStatusCommand) outputTaskStatus(state *api.TaskState) {
 			desc = event.DriverMessage
 		case api.TaskLeaderDead:
 			desc = "Leader Task in Group dead"
+		case api.TaskGenericMessage:
+			event.Type = event.GenericSource
+			desc = event.Message
 		}
 
 		// Reverse order so we are sorted by time

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3539,6 +3539,9 @@ const (
 
 	// TaskLeaderDead indicates that the leader task within the has finished.
 	TaskLeaderDead = "Leader Task Dead"
+
+	// TaskGenericMessage is used by various subsystems to emit a message.
+	TaskGenericMessage = "Generic"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -3600,6 +3603,9 @@ type TaskEvent struct {
 
 	// DriverMessage indicates a driver action being taken.
 	DriverMessage string
+
+	// GenericSource is the source of a message.
+	GenericSource string
 }
 
 func (te *TaskEvent) GoString() string {
@@ -3736,6 +3742,11 @@ func (e *TaskEvent) SetVaultRenewalError(err error) *TaskEvent {
 
 func (e *TaskEvent) SetDriverMessage(m string) *TaskEvent {
 	e.DriverMessage = m
+	return e
+}
+
+func (e *TaskEvent) SetGenericSource(s string) *TaskEvent {
+	e.GenericSource = s
 	return e
 }
 

--- a/vendor/github.com/hashicorp/consul-template/manager/renderer.go
+++ b/vendor/github.com/hashicorp/consul-template/manager/renderer.go
@@ -66,7 +66,7 @@ func Render(i *RenderInput) (*RenderResult, error) {
 	return &RenderResult{
 		DidRender:   true,
 		WouldRender: true,
-		Contents:    existing,
+		Contents:    i.Contents,
 	}, nil
 }
 

--- a/vendor/github.com/hashicorp/consul-template/manager/runner.go
+++ b/vendor/github.com/hashicorp/consul-template/manager/runner.go
@@ -64,6 +64,12 @@ type Runner struct {
 	// renderedCh is used to signal that a template has been rendered
 	renderedCh chan struct{}
 
+	// renderEventCh is used to signal that there is a new render event. A
+	// render event doesn't necessarily mean that a template has been rendered,
+	// only that templates attempted to render and may have updated their
+	// dependency sets.
+	renderEventCh chan struct{}
+
 	// dependencies is the list of dependencies this runner is watching.
 	dependencies map[string]dep.Dependency
 
@@ -395,10 +401,16 @@ func (r *Runner) Stop() {
 	close(r.DoneCh)
 }
 
-// TemplateRenderedCh returns a channel that will return the path of the
-// template when it is rendered.
+// TemplateRenderedCh returns a channel that will be triggered when one or more
+// templates are rendered.
 func (r *Runner) TemplateRenderedCh() <-chan struct{} {
 	return r.renderedCh
+}
+
+// RenderEventCh returns a channel that will be triggered when there is a new
+// render event.
+func (r *Runner) RenderEventCh() <-chan struct{} {
+	return r.renderEventCh
 }
 
 // RenderEvents returns the render events for each template was rendered. The
@@ -486,202 +498,36 @@ func (r *Runner) Signal(s os.Signal) error {
 func (r *Runner) Run() error {
 	log.Printf("[INFO] (runner) initiating run")
 
-	var wouldRenderAny, renderedAny bool
-	var commands []*config.TemplateConfig
-	depsMap := make(map[string]dep.Dependency)
+	var newRenderEvent, wouldRenderAny, renderedAny bool
+	runCtx := &templateRunCtx{
+		depsMap: make(map[string]dep.Dependency),
+	}
 
 	for _, tmpl := range r.templates {
-		log.Printf("[DEBUG] (runner) checking template %s", tmpl.ID())
-
-		// Grab the last event
-		lastEvent := r.renderEvents[tmpl.ID()]
-
-		// Create the event
-		event := &RenderEvent{
-			Template:        tmpl,
-			TemplateConfigs: r.templateConfigsFor(tmpl),
-		}
-
-		if lastEvent != nil {
-			event.LastWouldRender = lastEvent.LastWouldRender
-			event.LastDidRender = lastEvent.LastDidRender
-		}
-
-		// Check if we are currently the leader instance
-		isLeader := true
-		if r.dedup != nil {
-			isLeader = r.dedup.IsLeader(tmpl)
-		}
-
-		// If we are in once mode and this template was already rendered, move
-		// onto the next one. We do not want to re-render the template if we are
-		// in once mode, and we certainly do not want to re-run any commands.
-		if r.once {
-			r.renderEventsLock.RLock()
-			_, rendered := r.renderEvents[tmpl.ID()]
-			r.renderEventsLock.RUnlock()
-			if rendered {
-				log.Printf("[DEBUG] (runner) once mode and already rendered")
-				continue
-			}
-		}
-
-		// Attempt to render the template, returning any missing dependencies and
-		// the rendered contents. If there are any missing dependencies, the
-		// contents cannot be rendered or trusted!
-		result, err := tmpl.Execute(&template.ExecuteInput{
-			Brain: r.brain,
-			Env:   r.childEnv(),
-		})
+		event, err := r.runTemplate(tmpl, runCtx)
 		if err != nil {
-			return errors.Wrap(err, tmpl.Source())
+			return err
 		}
 
-		// Grab the list of used and missing dependencies.
-		missing, used := result.Missing, result.Used
+		// If there was a render event store it
+		if event != nil {
+			r.renderEventsLock.Lock()
+			r.renderEvents[tmpl.ID()] = event
+			r.renderEventsLock.Unlock()
 
-		// Add the dependency to the list of dependencies for this runner.
-		for _, d := range used.List() {
-			// If we've taken over leadership for a template, we may have data
-			// that is cached, but not have the watcher. We must treat this as
-			// missing so that we create the watcher and re-run the template.
-			if isLeader && !r.watcher.Watching(d) {
-				missing.Add(d)
-			}
-			if _, ok := depsMap[d.String()]; !ok {
-				depsMap[d.String()] = d
-			}
-		}
+			// Record that there is at least one new render event
+			newRenderEvent = true
 
-		// Diff any missing dependencies the template reported with dependencies
-		// the watcher is watching.
-		unwatched := new(dep.Set)
-		for _, d := range missing.List() {
-			if !r.watcher.Watching(d) {
-				unwatched.Add(d)
-			}
-		}
-
-		// If there are unwatched dependencies, start the watcher and move onto the
-		// next one.
-		if l := unwatched.Len(); l > 0 {
-			log.Printf("[DEBUG] (runner) was not watching %d dependencies", l)
-			for _, d := range unwatched.List() {
-				// If we are deduplicating, we must still handle non-sharable
-				// dependencies, since those will be ignored.
-				if isLeader || !d.CanShare() {
-					r.watcher.Add(d)
-				}
-			}
-			continue
-		}
-
-		// If the template is missing data for some dependencies then we are not
-		// ready to render and need to move on to the next one.
-		if l := missing.Len(); l > 0 {
-			log.Printf("[DEBUG] (runner) missing data for %d dependencies", l)
-			continue
-		}
-
-		// Trigger an update of the de-duplicaiton manager
-		if r.dedup != nil && isLeader {
-			if err := r.dedup.UpdateDeps(tmpl, used.List()); err != nil {
-				log.Printf("[ERR] (runner) failed to update dependency data for de-duplication: %v", err)
-			}
-		}
-
-		// Update event information with dependencies.
-		event.MissingDeps = missing
-		event.UnwatchedDeps = unwatched
-		event.UsedDeps = used
-
-		// If quiescence is activated, start/update the timers and loop back around.
-		// We do not want to render the templates yet.
-		if q, ok := r.quiescenceMap[tmpl.ID()]; ok {
-			q.tick()
-			continue
-		}
-
-		// For each template configuration that is tied to this template, attempt to
-		// render it to disk and accumulate commands for later use.
-		for _, templateConfig := range r.templateConfigsFor(tmpl) {
-			log.Printf("[DEBUG] (runner) rendering %s", templateConfig.Display())
-
-			// Render the template, taking dry mode into account
-			result, err := Render(&RenderInput{
-				Backup:    config.BoolVal(templateConfig.Backup),
-				Contents:  result.Output,
-				Dry:       r.dry,
-				DryStream: r.outStream,
-				Path:      config.StringVal(templateConfig.Destination),
-				Perms:     config.FileModeVal(templateConfig.Perms),
-			})
-			if err != nil {
-				return errors.Wrap(err, "error rendering "+templateConfig.Display())
-			}
-
-			renderTime := time.Now().UTC()
-
-			// If we would have rendered this template (but we did not because the
-			// contents were the same or something), we should consider this template
-			// rendered even though the contents on disk have not been updated. We
-			// will not fire commands unless the template was _actually_ rendered to
-			// disk though.
-			if result.WouldRender {
-				// This event would have rendered
-				event.WouldRender = true
-				event.LastWouldRender = renderTime
-
-				// Record that at least one template would have been rendered.
+			// Record that at least one template would have been rendered.
+			if event.WouldRender {
 				wouldRenderAny = true
 			}
 
-			// If we _actually_ rendered the template to disk, we want to run the
-			// appropriate commands.
-			if result.DidRender {
-				log.Printf("[INFO] (runner) rendered %s", templateConfig.Display())
-
-				// This event did render
-				event.DidRender = true
-				event.LastDidRender = renderTime
-
-				// Update the contents
-				event.Contents = result.Contents
-
-				// Record that at least one template was rendered.
+			// Record that at least one template was rendered.
+			if event.DidRender {
 				renderedAny = true
-
-				if !r.dry {
-					// If the template was rendered (changed) and we are not in dry-run mode,
-					// aggregate commands, ignoring previously known commands
-					//
-					// Future-self Q&A: Why not use a map for the commands instead of an
-					// array with an expensive lookup option? Well I'm glad you asked that
-					// future-self! One of the API promises is that commands are executed
-					// in the order in which they are provided in the TemplateConfig
-					// definitions. If we inserted commands into a map, we would lose that
-					// relative ordering and people would be unhappy.
-					// if config.StringPresent(ctemplate.Command)
-					if c := config.StringVal(templateConfig.Exec.Command); c != "" {
-						existing := findCommand(templateConfig, commands)
-						if existing != nil {
-							log.Printf("[DEBUG] (runner) skipping command %q from %s (already appended from %s)",
-								c, templateConfig.Display(), existing.Display())
-						} else {
-							log.Printf("[DEBUG] (runner) appending command %q from %s",
-								c, templateConfig.Display())
-							commands = append(commands, templateConfig)
-						}
-					}
-				}
 			}
 		}
-
-		// Send updated render event
-		r.renderEventsLock.Lock()
-		event.UpdatedAt = time.Now().UTC()
-		r.renderEvents[tmpl.ID()] = event
-		r.renderEventsLock.Unlock()
 	}
 
 	// Check if we need to deliver any rendered signals
@@ -693,13 +539,21 @@ func (r *Runner) Run() error {
 		}
 	}
 
+	// Check if we need to deliver any event signals
+	if newRenderEvent {
+		select {
+		case r.renderEventCh <- struct{}{}:
+		default:
+		}
+	}
+
 	// Perform the diff and update the known dependencies.
-	r.diffAndUpdateDeps(depsMap)
+	r.diffAndUpdateDeps(runCtx.depsMap)
 
 	// Execute each command in sequence, collecting any errors that occur - this
 	// ensures all commands execute at least once.
 	var errs []error
-	for _, t := range commands {
+	for _, t := range runCtx.commands {
 		command := config.StringVal(t.Exec.Command)
 		log.Printf("[INFO] (runner) executing command %q from %s", command, t.Display())
 		env := t.Exec.Env.Copy()
@@ -742,6 +596,208 @@ func (r *Runner) Run() error {
 	}
 
 	return nil
+}
+
+type templateRunCtx struct {
+	// commands is the set of commands that will be executed after all templates
+	// have run. When adding to the commands, care should be taken not to
+	// duplicate any existing command from a previous template.
+	commands []*config.TemplateConfig
+
+	// depsMap is the set of dependencies shared across all templates.
+	depsMap map[string]dep.Dependency
+}
+
+// runTemplate is used to run a particular template. It takes as input the
+// template to run and a shared run context that allows sharing of information
+// between templates. The run returns a potentially nil render event and any
+// error that occured. The render event is nil in the case that the template has
+// been already rendered and is a once template or if there is an error.
+func (r *Runner) runTemplate(tmpl *template.Template, runCtx *templateRunCtx) (*RenderEvent, error) {
+	log.Printf("[DEBUG] (runner) checking template %s", tmpl.ID())
+
+	// Grab the last event
+	r.renderEventsLock.RLock()
+	lastEvent := r.renderEvents[tmpl.ID()]
+	r.renderEventsLock.RUnlock()
+
+	// Create the event
+	event := &RenderEvent{
+		Template:        tmpl,
+		TemplateConfigs: r.templateConfigsFor(tmpl),
+	}
+
+	if lastEvent != nil {
+		event.LastWouldRender = lastEvent.LastWouldRender
+		event.LastDidRender = lastEvent.LastDidRender
+	}
+
+	// Check if we are currently the leader instance
+	isLeader := true
+	if r.dedup != nil {
+		isLeader = r.dedup.IsLeader(tmpl)
+	}
+
+	// If we are in once mode and this template was already rendered, move
+	// onto the next one. We do not want to re-render the template if we are
+	// in once mode, and we certainly do not want to re-run any commands.
+	if r.once {
+		r.renderEventsLock.RLock()
+		event, ok := r.renderEvents[tmpl.ID()]
+		r.renderEventsLock.RUnlock()
+		if ok && (event.WouldRender || event.DidRender) {
+			log.Printf("[DEBUG] (runner) once mode and already rendered")
+			return nil, nil
+		}
+	}
+
+	// Attempt to render the template, returning any missing dependencies and
+	// the rendered contents. If there are any missing dependencies, the
+	// contents cannot be rendered or trusted!
+	result, err := tmpl.Execute(&template.ExecuteInput{
+		Brain: r.brain,
+		Env:   r.childEnv(),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, tmpl.Source())
+	}
+
+	// Grab the list of used and missing dependencies.
+	missing, used := result.Missing, result.Used
+
+	// Add the dependency to the list of dependencies for this runner.
+	for _, d := range used.List() {
+		// If we've taken over leadership for a template, we may have data
+		// that is cached, but not have the watcher. We must treat this as
+		// missing so that we create the watcher and re-run the template.
+		if isLeader && !r.watcher.Watching(d) {
+			missing.Add(d)
+		}
+		if _, ok := runCtx.depsMap[d.String()]; !ok {
+			runCtx.depsMap[d.String()] = d
+		}
+	}
+
+	// Diff any missing dependencies the template reported with dependencies
+	// the watcher is watching.
+	unwatched := new(dep.Set)
+	for _, d := range missing.List() {
+		if !r.watcher.Watching(d) {
+			unwatched.Add(d)
+		}
+	}
+
+	// Update the event with the new dependency information
+	event.MissingDeps = missing
+	event.UnwatchedDeps = unwatched
+	event.UsedDeps = used
+	event.UpdatedAt = time.Now().UTC()
+
+	// If there are unwatched dependencies, start the watcher and exit since we
+	// won't have data.
+	if l := unwatched.Len(); l > 0 {
+		log.Printf("[DEBUG] (runner) was not watching %d dependencies", l)
+		for _, d := range unwatched.List() {
+			// If we are deduplicating, we must still handle non-sharable
+			// dependencies, since those will be ignored.
+			if isLeader || !d.CanShare() {
+				r.watcher.Add(d)
+			}
+		}
+		return event, nil
+	}
+
+	// If the template is missing data for some dependencies then we are not
+	// ready to render and need to move on to the next one.
+	if l := missing.Len(); l > 0 {
+		log.Printf("[DEBUG] (runner) missing data for %d dependencies", l)
+		return event, nil
+	}
+
+	// Trigger an update of the de-duplicaiton manager
+	if r.dedup != nil && isLeader {
+		if err := r.dedup.UpdateDeps(tmpl, used.List()); err != nil {
+			log.Printf("[ERR] (runner) failed to update dependency data for de-duplication: %v", err)
+		}
+	}
+
+	// If quiescence is activated, start/update the timers and loop back around.
+	// We do not want to render the templates yet.
+	if q, ok := r.quiescenceMap[tmpl.ID()]; ok {
+		q.tick()
+		return event, nil
+	}
+
+	// For each template configuration that is tied to this template, attempt to
+	// render it to disk and accumulate commands for later use.
+	for _, templateConfig := range r.templateConfigsFor(tmpl) {
+		log.Printf("[DEBUG] (runner) rendering %s", templateConfig.Display())
+
+		// Render the template, taking dry mode into account
+		result, err := Render(&RenderInput{
+			Backup:    config.BoolVal(templateConfig.Backup),
+			Contents:  result.Output,
+			Dry:       r.dry,
+			DryStream: r.outStream,
+			Path:      config.StringVal(templateConfig.Destination),
+			Perms:     config.FileModeVal(templateConfig.Perms),
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "error rendering "+templateConfig.Display())
+		}
+
+		renderTime := time.Now().UTC()
+
+		// If we would have rendered this template (but we did not because the
+		// contents were the same or something), we should consider this template
+		// rendered even though the contents on disk have not been updated. We
+		// will not fire commands unless the template was _actually_ rendered to
+		// disk though.
+		if result.WouldRender {
+			// This event would have rendered
+			event.WouldRender = true
+			event.LastWouldRender = renderTime
+		}
+
+		// If we _actually_ rendered the template to disk, we want to run the
+		// appropriate commands.
+		if result.DidRender {
+			log.Printf("[INFO] (runner) rendered %s", templateConfig.Display())
+
+			// This event did render
+			event.DidRender = true
+			event.LastDidRender = renderTime
+
+			// Update the contents
+			event.Contents = result.Contents
+
+			if !r.dry {
+				// If the template was rendered (changed) and we are not in dry-run mode,
+				// aggregate commands, ignoring previously known commands
+				//
+				// Future-self Q&A: Why not use a map for the commands instead of an
+				// array with an expensive lookup option? Well I'm glad you asked that
+				// future-self! One of the API promises is that commands are executed
+				// in the order in which they are provided in the TemplateConfig
+				// definitions. If we inserted commands into a map, we would lose that
+				// relative ordering and people would be unhappy.
+				// if config.StringPresent(ctemplate.Command)
+				if c := config.StringVal(templateConfig.Exec.Command); c != "" {
+					existing := findCommand(templateConfig, runCtx.commands)
+					if existing != nil {
+						log.Printf("[DEBUG] (runner) skipping command %q from %s (already appended from %s)",
+							c, templateConfig.Display(), existing.Display())
+					} else {
+						log.Printf("[DEBUG] (runner) appending command %q from %s",
+							c, templateConfig.Display())
+						runCtx.commands = append(runCtx.commands, templateConfig)
+					}
+				}
+			}
+		}
+	}
+
+	return event, nil
 }
 
 // init() creates the Runner's underlying data structures and returns an error
@@ -809,6 +865,7 @@ func (r *Runner) init() error {
 	r.dependencies = make(map[string]dep.Dependency)
 
 	r.renderedCh = make(chan struct{}, 1)
+	r.renderEventCh = make(chan struct{}, 1)
 
 	r.ctemplatesMap = ctemplatesMap
 	r.inStream = os.Stdin

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -627,10 +627,10 @@
 			"revisionTime": "2017-08-01T00:58:49Z"
 		},
 		{
-			"checksumSHA1": "Cu8hIII8Z6FAuunFI/jXPLl0nQA=",
+			"checksumSHA1": "tkMwyjIrH+reCJWIg45lvcmkhVQ=",
 			"path": "github.com/hashicorp/consul-template/manager",
-			"revision": "7b3f45039cf3ad1a758683fd3eebb1cc72affa06",
-			"revisionTime": "2017-08-01T00:58:49Z"
+			"revision": "252f61dede55b1009323aae8b0ffcd2e2e933173",
+			"revisionTime": "2017-08-09T17:59:55Z"
 		},
 		{
 			"checksumSHA1": "oskgb0WteBKOItG8NNDduM7E/D0=",


### PR DESCRIPTION
This PR does the following:
* Adds a mechanism to emit events in the TaskRunner
* Vendors a new version of Consul-Template that allows extraction of
missing dependencies
* Adds logic to our consul_template.go to determine missing events and emit
them in a batched fashion.
* Refactors the consul_template code to split the run method and take in a
config struct rather than many parameters.

Fixes https://github.com/hashicorp/nomad/issues/2578