### PR TITLE
Add the Nomad agent version to the node-status CLI output.

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -169,6 +169,7 @@ type NodeListStub struct {
 	Datacenter        string
 	Name              string
 	NodeClass         string
+	Build             string
 	Drain             bool
 	Status            string
 	StatusDescription string

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -169,7 +169,7 @@ type NodeListStub struct {
 	Datacenter        string
 	Name              string
 	NodeClass         string
-	Build             string
+	Version           string
 	Drain             bool
 	Status            string
 	StatusDescription string

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -292,6 +292,7 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	conf.Node.Name = a.config.NodeName
 	conf.Node.Meta = a.config.Client.Meta
 	conf.Node.NodeClass = a.config.Client.NodeClass
+	conf.Node.Build = fmt.Sprintf("%s%s", a.config.Version, a.config.VersionPrerelease)
 
 	// Set up the HTTP advertise address
 	conf.Node.HTTPAddr = a.config.AdvertiseAddrs.HTTP

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -292,7 +292,6 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	conf.Node.Name = a.config.NodeName
 	conf.Node.Meta = a.config.Client.Meta
 	conf.Node.NodeClass = a.config.Client.NodeClass
-	conf.Node.Build = fmt.Sprintf("%s%s", a.config.Version, a.config.VersionPrerelease)
 
 	// Set up the HTTP advertise address
 	conf.Node.HTTPAddr = a.config.AdvertiseAddrs.HTTP

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -57,7 +57,7 @@ Node Status Options:
   -self
     Query the status of the local node.
 
-  -stats 
+  -stats
     Display detailed resource usage statistics.
 
   -allocs
@@ -149,9 +149,9 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		// Format the nodes list
 		out := make([]string, len(nodes)+1)
 		if c.list_allocs {
-			out[0] = "ID|DC|Name|Class|Drain|Status|Running Allocs"
+			out[0] = "ID|DC|Name|Class|Build|Drain|Status|Running Allocs"
 		} else {
-			out[0] = "ID|DC|Name|Class|Drain|Status"
+			out[0] = "ID|DC|Name|Class|Build|Drain|Status"
 		}
 
 		for i, node := range nodes {
@@ -161,20 +161,22 @@ func (c *NodeStatusCommand) Run(args []string) int {
 					c.Ui.Error(fmt.Sprintf("Error querying node allocations: %s", err))
 					return 1
 				}
-				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s|%v",
+				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%v|%s|%v",
 					limit(node.ID, c.length),
 					node.Datacenter,
 					node.Name,
 					node.NodeClass,
+					node.Build,
 					node.Drain,
 					node.Status,
 					len(numAllocs))
 			} else {
-				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
+				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%v|%s",
 					limit(node.ID, c.length),
 					node.Datacenter,
 					node.Name,
 					node.NodeClass,
+					node.Build,
 					node.Drain,
 					node.Status)
 			}
@@ -220,13 +222,14 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		// Format the nodes list that matches the prefix so that the user
 		// can create a more specific request
 		out := make([]string, len(nodes)+1)
-		out[0] = "ID|DC|Name|Class|Drain|Status"
+		out[0] = "ID|DC|Name|Class|Build|Drain|Status"
 		for i, node := range nodes {
-			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
+			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%v|%s",
 				limit(node.ID, c.length),
 				node.Datacenter,
 				node.Name,
 				node.NodeClass,
+				node.Build,
 				node.Drain,
 				node.Status)
 		}

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -148,37 +148,40 @@ func (c *NodeStatusCommand) Run(args []string) int {
 
 		// Format the nodes list
 		out := make([]string, len(nodes)+1)
+
+		out[0] = "ID|DC|Name|Class|"
+
+		if c.verbose {
+			out[0] += "Version|"
+		}
+
+		out[0] += "Drain|Status"
+
 		if c.list_allocs {
-			out[0] = "ID|DC|Name|Class|Build|Drain|Status|Running Allocs"
-		} else {
-			out[0] = "ID|DC|Name|Class|Build|Drain|Status"
+			out[0] += "|Running Allocs"
 		}
 
 		for i, node := range nodes {
+			out[i+1] = fmt.Sprintf("%s|%s|%s|%s",
+				limit(node.ID, c.length),
+				node.Datacenter,
+				node.Name,
+				node.NodeClass)
+			if c.verbose {
+				out[i+1] += fmt.Sprintf("|%s",
+					node.Version)
+			}
+			out[i+1] += fmt.Sprintf("|%v|%s",
+				node.Drain,
+				node.Status)
 			if c.list_allocs {
 				numAllocs, err := getRunningAllocs(client, node.ID)
 				if err != nil {
 					c.Ui.Error(fmt.Sprintf("Error querying node allocations: %s", err))
 					return 1
 				}
-				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%v|%s|%v",
-					limit(node.ID, c.length),
-					node.Datacenter,
-					node.Name,
-					node.NodeClass,
-					node.Build,
-					node.Drain,
-					node.Status,
+				out[i+1] += fmt.Sprintf("|%v",
 					len(numAllocs))
-			} else {
-				out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%v|%s",
-					limit(node.ID, c.length),
-					node.Datacenter,
-					node.Name,
-					node.NodeClass,
-					node.Build,
-					node.Drain,
-					node.Status)
 			}
 		}
 
@@ -222,14 +225,13 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		// Format the nodes list that matches the prefix so that the user
 		// can create a more specific request
 		out := make([]string, len(nodes)+1)
-		out[0] = "ID|DC|Name|Class|Build|Drain|Status"
+		out[0] = "ID|DC|Name|Class|Drain|Status"
 		for i, node := range nodes {
-			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%v|%s",
+			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
 				limit(node.ID, c.length),
 				node.Datacenter,
 				node.Name,
 				node.NodeClass,
-				node.Build,
 				node.Drain,
 				node.Status)
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -996,6 +996,9 @@ type Node struct {
 	// together for the purpose of determining scheduling pressure.
 	NodeClass string
 
+	// Build represents the Nomad version the node is running
+	Build string
+
 	// ComputedClass is a unique id that identifies nodes with a common set of
 	// attributes and capabilities.
 	ComputedClass string
@@ -1057,6 +1060,7 @@ func (n *Node) Stub() *NodeListStub {
 		Datacenter:        n.Datacenter,
 		Name:              n.Name,
 		NodeClass:         n.NodeClass,
+		Build:             n.Build,
 		Drain:             n.Drain,
 		Status:            n.Status,
 		StatusDescription: n.StatusDescription,
@@ -1072,6 +1076,7 @@ type NodeListStub struct {
 	Datacenter        string
 	Name              string
 	NodeClass         string
+	Build             string
 	Drain             bool
 	Status            string
 	StatusDescription string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -996,9 +996,6 @@ type Node struct {
 	// together for the purpose of determining scheduling pressure.
 	NodeClass string
 
-	// Build represents the Nomad version the node is running
-	Build string
-
 	// ComputedClass is a unique id that identifies nodes with a common set of
 	// attributes and capabilities.
 	ComputedClass string
@@ -1060,7 +1057,7 @@ func (n *Node) Stub() *NodeListStub {
 		Datacenter:        n.Datacenter,
 		Name:              n.Name,
 		NodeClass:         n.NodeClass,
-		Build:             n.Build,
+		Version:           n.Attributes["nomad.version"],
 		Drain:             n.Drain,
 		Status:            n.Status,
 		StatusDescription: n.StatusDescription,
@@ -1076,7 +1073,7 @@ type NodeListStub struct {
 	Datacenter        string
 	Name              string
 	NodeClass         string
-	Build             string
+	Version           string
 	Drain             bool
 	Status            string
 	StatusDescription string


### PR DESCRIPTION
The Nomad agent version will now be displayed when running the `nomad node-status` command which brings the command inline with the `nomad server-members` command which already displays the version information.

Closes #2993 