### PR TITLE
Update incorrect interpolations in documentation

### DIFF
--- a/website/source/docs/runtime/interpolation.html.md.erb
+++ b/website/source/docs/runtime/interpolation.html.md.erb
@@ -149,11 +149,11 @@ Below is a table documenting common node properties:
     <td>Version of the client kernel (e.g. <tt>3.19.0-25-generic</tt>, <tt>15.0.0</tt>)</td>
   </tr>
   <tr>
-    <td><tt>${attr.platform.aws.ami-id}</tt></td>
+    <td><tt>${attr.unique.platform.aws.ami-id}</tt></td>
     <td>AMI ID of the client (if on AWS EC2)</td>
   </tr>
   <tr>
-    <td><tt>${attr.platform.aws.instance-type}</tt></td>
+    <td><tt>${attr.unique.platform.aws.instance-type}</tt></td>
     <td>Instance type of the client (if on AWS EC2)</td>
   </tr>
   <tr>


### PR DESCRIPTION
This change updates incorrectly detailed AWS interpolations in the website documentation.

Closes #2997 