### PR TITLE
Vendor vault test deps

### DIFF
--- a/vendor/github.com/hashicorp/vault/helper/compressutil/compress.go
+++ b/vendor/github.com/hashicorp/vault/helper/compressutil/compress.go
@@ -1,0 +1,191 @@
+package compressutil
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/lzw"
+	"fmt"
+	"io"
+
+	"github.com/golang/snappy"
+)
+
+const (
+	// A byte value used as a canary prefix for the compressed information
+	// which is used to distinguish if a JSON input is compressed or not.
+	// The value of this constant should not be a first character of any
+	// valid JSON string.
+
+	// Byte value used as canary when using Gzip format
+	CompressionCanaryGzip byte = 'G'
+
+	// Byte value used as canary when using Lzw format
+	CompressionCanaryLzw byte = 'L'
+
+	// Byte value used as canary when using Snappy format
+	CompressionCanarySnappy byte = 'S'
+
+	CompressionTypeLzw = "lzw"
+
+	CompressionTypeGzip = "gzip"
+
+	CompressionTypeSnappy = "snappy"
+)
+
+// SnappyReadCloser embeds the snappy reader which implements the io.Reader
+// interface. The decompress procedure in this utility expectes an
+// io.ReadCloser. This type implements the io.Closer interface to retain the
+// generic way of decompression.
+type SnappyReadCloser struct {
+	*snappy.Reader
+}
+
+// Close is a noop method implemented only to satisfy the io.Closer interface
+func (s *SnappyReadCloser) Close() error {
+	return nil
+}
+
+// CompressionConfig is used to select a compression type to be performed by
+// Compress and Decompress utilities.
+// Supported types are:
+// * CompressionTypeLzw
+// * CompressionTypeGzip
+// * CompressionTypeSnappy
+//
+// When using CompressionTypeGzip, the compression levels can also be chosen:
+// * gzip.DefaultCompression
+// * gzip.BestSpeed
+// * gzip.BestCompression
+type CompressionConfig struct {
+	// Type of the compression algorithm to be used
+	Type string
+
+	// When using Gzip format, the compression level to employ
+	GzipCompressionLevel int
+}
+
+// Compress places the canary byte in a buffer and uses the same buffer to fill
+// in the compressed information of the given input. The configuration supports
+// two type of compression: LZW and Gzip. When using Gzip compression format,
+// if GzipCompressionLevel is not specified, the 'gzip.DefaultCompression' will
+// be assumed.
+func Compress(data []byte, config *CompressionConfig) ([]byte, error) {
+	var buf bytes.Buffer
+	var writer io.WriteCloser
+	var err error
+
+	if config == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+
+	// Write the canary into the buffer and create writer to compress the
+	// input data based on the configured type
+	switch config.Type {
+	case CompressionTypeLzw:
+		buf.Write([]byte{CompressionCanaryLzw})
+
+		writer = lzw.NewWriter(&buf, lzw.LSB, 8)
+	case CompressionTypeGzip:
+		buf.Write([]byte{CompressionCanaryGzip})
+
+		switch {
+		case config.GzipCompressionLevel == gzip.BestCompression,
+			config.GzipCompressionLevel == gzip.BestSpeed,
+			config.GzipCompressionLevel == gzip.DefaultCompression:
+			// These are valid compression levels
+		default:
+			// If compression level is set to NoCompression or to
+			// any invalid value, fallback to Defaultcompression
+			config.GzipCompressionLevel = gzip.DefaultCompression
+		}
+		writer, err = gzip.NewWriterLevel(&buf, config.GzipCompressionLevel)
+	case CompressionTypeSnappy:
+		buf.Write([]byte{CompressionCanarySnappy})
+		writer = snappy.NewBufferedWriter(&buf)
+	default:
+		return nil, fmt.Errorf("unsupported compression type")
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a compression writer; err: %v", err)
+	}
+
+	if writer == nil {
+		return nil, fmt.Errorf("failed to create a compression writer")
+	}
+
+	// Compress the input and place it in the same buffer containing the
+	// canary byte.
+	if _, err = writer.Write(data); err != nil {
+		return nil, fmt.Errorf("failed to compress input data; err: %v", err)
+	}
+
+	// Close the io.WriteCloser
+	if err = writer.Close(); err != nil {
+		return nil, err
+	}
+
+	// Return the compressed bytes with canary byte at the start
+	return buf.Bytes(), nil
+}
+
+// Decompress checks if the first byte in the input matches the canary byte.
+// If the first byte is a canary byte, then the input past the canary byte
+// will be decompressed using the method specified in the given configuration.
+// If the first byte isn't a canary byte, then the utility returns a boolean
+// value indicating that the input was not compressed.
+func Decompress(data []byte) ([]byte, bool, error) {
+	var err error
+	var reader io.ReadCloser
+	if data == nil || len(data) == 0 {
+		return nil, false, fmt.Errorf("'data' being decompressed is empty")
+	}
+
+	switch {
+	// If the first byte matches the canary byte, remove the canary
+	// byte and try to decompress the data that is after the canary.
+	case data[0] == CompressionCanaryGzip:
+		if len(data) < 2 {
+			return nil, false, fmt.Errorf("invalid 'data' after the canary")
+		}
+		data = data[1:]
+		reader, err = gzip.NewReader(bytes.NewReader(data))
+	case data[0] == CompressionCanaryLzw:
+		if len(data) < 2 {
+			return nil, false, fmt.Errorf("invalid 'data' after the canary")
+		}
+		data = data[1:]
+		reader = lzw.NewReader(bytes.NewReader(data), lzw.LSB, 8)
+
+	case data[0] == CompressionCanarySnappy:
+		if len(data) < 2 {
+			return nil, false, fmt.Errorf("invalid 'data' after the canary")
+		}
+		data = data[1:]
+		reader = &SnappyReadCloser{
+			Reader: snappy.NewReader(bytes.NewReader(data)),
+		}
+	default:
+		// If the first byte doesn't match the canary byte, it means
+		// that the content was not compressed at all. Indicate the
+		// caller that the input was not compressed.
+		return nil, true, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create a compression reader; err: %v", err)
+	}
+	if reader == nil {
+		return nil, false, fmt.Errorf("failed to create a compression reader")
+	}
+
+	// Close the io.ReadCloser
+	defer reader.Close()
+
+	// Read all the compressed data into a buffer
+	var buf bytes.Buffer
+	if _, err = io.Copy(&buf, reader); err != nil {
+		return nil, false, err
+	}
+
+	return buf.Bytes(), false, nil
+}

--- a/vendor/github.com/hashicorp/vault/helper/parseutil/parseutil.go
+++ b/vendor/github.com/hashicorp/vault/helper/parseutil/parseutil.go
@@ -1,0 +1,62 @@
+package parseutil
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+func ParseDurationSecond(in interface{}) (time.Duration, error) {
+	var dur time.Duration
+	jsonIn, ok := in.(json.Number)
+	if ok {
+		in = jsonIn.String()
+	}
+	switch in.(type) {
+	case string:
+		inp := in.(string)
+		var err error
+		// Look for a suffix otherwise its a plain second value
+		if strings.HasSuffix(inp, "s") || strings.HasSuffix(inp, "m") || strings.HasSuffix(inp, "h") {
+			dur, err = time.ParseDuration(inp)
+			if err != nil {
+				return dur, err
+			}
+		} else {
+			// Plain integer
+			secs, err := strconv.ParseInt(inp, 10, 64)
+			if err != nil {
+				return dur, err
+			}
+			dur = time.Duration(secs) * time.Second
+		}
+	case int:
+		dur = time.Duration(in.(int)) * time.Second
+	case int32:
+		dur = time.Duration(in.(int32)) * time.Second
+	case int64:
+		dur = time.Duration(in.(int64)) * time.Second
+	case uint:
+		dur = time.Duration(in.(uint)) * time.Second
+	case uint32:
+		dur = time.Duration(in.(uint32)) * time.Second
+	case uint64:
+		dur = time.Duration(in.(uint64)) * time.Second
+	default:
+		return 0, errors.New("could not parse duration from input")
+	}
+
+	return dur, nil
+}
+
+func ParseBool(in interface{}) (bool, error) {
+	var result bool
+	if err := mapstructure.WeakDecode(in, &result); err != nil {
+		return false, err
+	}
+	return result, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -917,10 +917,22 @@
 			"revisionTime": "2017-08-01T15:50:41Z"
 		},
 		{
+			"checksumSHA1": "au+CDkddC4sVFV15UaPiI7FvSw0=",
+			"path": "github.com/hashicorp/vault/helper/compressutil",
+			"revision": "1fd46cbcb10569bd205c3f662e7a4f16f1e69056",
+			"revisionTime": "2017-08-11T01:28:18Z"
+		},
+		{
 			"checksumSHA1": "yUiSTPf0QUuL2r/81sjuytqBoeQ=",
 			"path": "github.com/hashicorp/vault/helper/jsonutil",
 			"revision": "0c3e14f047aede0a70256e1e8b321610910b246e",
 			"revisionTime": "2017-08-01T15:50:41Z"
+		},
+		{
+			"checksumSHA1": "GGveKvOwScWGZAAnupzpyw+0Jko=",
+			"path": "github.com/hashicorp/vault/helper/parseutil",
+			"revision": "1fd46cbcb10569bd205c3f662e7a4f16f1e69056",
+			"revisionTime": "2017-08-11T01:28:18Z"
 		},
 		{
 			"checksumSHA1": "VMaF3Q7RIrRzvbnPbqxuSLryOvc=",


### PR DESCRIPTION
This is a weird one because `make bootstrap` does a `go get vault` so CI
never fails due to missing Vault dependencies. However developer
machines will have whatever version of vault they grabbed last time they
bootstrapped a new dev environment.

This can lead to surprising build issues and different devs testing
slightly different code.

So let's vendor all test deps to try to keep the Nomad repo
self-contained.