### PR TITLE
Updated AWS fingerprint test for ami-id

### DIFF
--- a/client/fingerprint/env_aws_test.go
+++ b/client/fingerprint/env_aws_test.go
@@ -61,7 +61,7 @@ func TestEnvAWSFingerprint_aws(t *testing.T) {
 	}
 
 	keys := []string{
-		"unique.platform.aws.ami-id",
+		"platform.aws.ami-id",
 		"unique.platform.aws.hostname",
 		"unique.platform.aws.instance-id",
 		"platform.aws.instance-type",


### PR DESCRIPTION
In https://github.com/hashicorp/nomad/pull/2999, I changed ami-id to non-unique.  This updates the test to reflect that.