### PR TITLE
Adding support for creating and managing ACL Tokens 

### DIFF
--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -109,3 +109,118 @@ func (s *HTTPServer) aclPolicyDelete(resp http.ResponseWriter, req *http.Request
 	setIndex(resp, out.Index)
 	return nil, nil
 }
+
+func (s *HTTPServer) ACLTokensRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != "GET" {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	args := structs.ACLTokenListRequest{}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var out structs.ACLTokenListResponse
+	if err := s.agent.RPC("ACL.ListTokens", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+	if out.Tokens == nil {
+		out.Tokens = make([]*structs.ACLTokenListStub, 0)
+	}
+	return out.Tokens, nil
+}
+
+func (s *HTTPServer) ACLTokenSpecificRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	accessor := strings.TrimPrefix(req.URL.Path, "/v1/acl/token")
+
+	// If there is no accessor, this must be a create
+	if len(accessor) == 0 {
+		if !(req.Method == "PUT" || req.Method == "POST") {
+			return nil, CodedError(405, ErrInvalidMethod)
+		}
+		return s.aclTokenUpdate(resp, req, "")
+	}
+
+	// Check if no accessor is given past the slash
+	accessor = accessor[1:]
+	if accessor == "" {
+		return nil, CodedError(400, "Missing Token Accessor")
+	}
+
+	switch req.Method {
+	case "GET":
+		return s.aclTokenQuery(resp, req, accessor)
+	case "PUT", "POST":
+		return s.aclTokenUpdate(resp, req, accessor)
+	case "DELETE":
+		return s.aclTokenDelete(resp, req, accessor)
+	default:
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+}
+
+func (s *HTTPServer) aclTokenQuery(resp http.ResponseWriter, req *http.Request,
+	tokenAccessor string) (interface{}, error) {
+	args := structs.ACLTokenSpecificRequest{
+		AccessorID: tokenAccessor,
+	}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var out structs.SingleACLTokenResponse
+	if err := s.agent.RPC("ACL.GetToken", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+	if out.Token == nil {
+		return nil, CodedError(404, "ACL token not found")
+	}
+	return out.Token, nil
+}
+
+func (s *HTTPServer) aclTokenUpdate(resp http.ResponseWriter, req *http.Request,
+	tokenAccessor string) (interface{}, error) {
+	// Parse the token
+	var token structs.ACLToken
+	if err := decodeBody(req, &token); err != nil {
+		return nil, CodedError(500, err.Error())
+	}
+
+	// Ensure the token accessor matches
+	if tokenAccessor != "" && (token.AccessorID != tokenAccessor) {
+		return nil, CodedError(400, "ACL token accessor does not match request path")
+	}
+
+	// Format the request
+	args := structs.ACLTokenUpsertRequest{
+		Tokens: []*structs.ACLToken{&token},
+	}
+	s.parseRegion(req, &args.Region)
+
+	var out structs.GenericResponse
+	if err := s.agent.RPC("ACL.UpsertTokens", &args, &out); err != nil {
+		return nil, err
+	}
+	setIndex(resp, out.Index)
+	return nil, nil
+}
+
+func (s *HTTPServer) aclTokenDelete(resp http.ResponseWriter, req *http.Request,
+	tokenAccessor string) (interface{}, error) {
+
+	args := structs.ACLTokenDeleteRequest{
+		AccessorIDs: []string{tokenAccessor},
+	}
+	s.parseRegion(req, &args.Region)
+
+	var out structs.GenericResponse
+	if err := s.agent.RPC("ACL.DeleteTokens", &args, &out); err != nil {
+		return nil, err
+	}
+	setIndex(resp, out.Index)
+	return nil, nil
+}

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -201,11 +201,14 @@ func (s *HTTPServer) aclTokenUpdate(resp http.ResponseWriter, req *http.Request,
 	}
 	s.parseRegion(req, &args.Region)
 
-	var out structs.GenericResponse
+	var out structs.ACLTokenUpsertResponse
 	if err := s.agent.RPC("ACL.UpsertTokens", &args, &out); err != nil {
 		return nil, err
 	}
 	setIndex(resp, out.Index)
+	if len(out.Tokens) > 0 {
+		return out.Tokens[0], nil
+	}
 	return nil, nil
 }
 

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -173,3 +173,167 @@ func TestHTTP_ACLPolicyDelete(t *testing.T) {
 		assert.Nil(t, out)
 	})
 }
+
+func TestHTTP_ACLTokenList(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		p1 := mock.ACLToken()
+		p2 := mock.ACLToken()
+		p3 := mock.ACLToken()
+		args := structs.ACLTokenUpsertRequest{
+			Tokens:       []*structs.ACLToken{p1, p2, p3},
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		var resp structs.GenericResponse
+		if err := s.Agent.RPC("ACL.UpsertTokens", &args, &resp); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Make the HTTP request
+		req, err := http.NewRequest("GET", "/v1/acl/tokens", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.ACLTokensRequest(respW, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Check for the index
+		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+			t.Fatalf("missing index")
+		}
+		if respW.HeaderMap.Get("X-Nomad-KnownLeader") != "true" {
+			t.Fatalf("missing known leader")
+		}
+		if respW.HeaderMap.Get("X-Nomad-LastContact") == "" {
+			t.Fatalf("missing last contact")
+		}
+
+		// Check the output
+		n := obj.([]*structs.ACLTokenListStub)
+		if len(n) != 3 {
+			t.Fatalf("bad: %#v", n)
+		}
+	})
+}
+
+func TestHTTP_ACLTokenQuery(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		p1 := mock.ACLToken()
+		args := structs.ACLTokenUpsertRequest{
+			Tokens:       []*structs.ACLToken{p1},
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		var resp structs.GenericResponse
+		if err := s.Agent.RPC("ACL.UpsertTokens", &args, &resp); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Make the HTTP request
+		req, err := http.NewRequest("GET", "/v1/acl/token/"+p1.AccessorID, nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Check for the index
+		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+			t.Fatalf("missing index")
+		}
+		if respW.HeaderMap.Get("X-Nomad-KnownLeader") != "true" {
+			t.Fatalf("missing known leader")
+		}
+		if respW.HeaderMap.Get("X-Nomad-LastContact") == "" {
+			t.Fatalf("missing last contact")
+		}
+
+		// Check the output
+		n := obj.(*structs.ACLToken)
+		if n.AccessorID != p1.AccessorID {
+			t.Fatalf("bad: %#v", n)
+		}
+	})
+}
+
+func TestHTTP_ACLTokenCreate(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		// Make the HTTP request
+		p1 := mock.ACLToken()
+		buf := encodeReq(p1)
+		req, err := http.NewRequest("PUT", "/v1/acl/token", buf)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)
+		assert.Nil(t, err)
+		assert.Nil(t, obj)
+
+		// Check for the index
+		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+			t.Fatalf("missing index")
+		}
+
+		// Check token was created
+		state := s.Agent.server.State()
+		out, err := state.ACLTokenByAccessorID(nil, p1.AccessorID)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		p1.CreateIndex, p1.ModifyIndex = out.CreateIndex, out.ModifyIndex
+		assert.Equal(t, p1.Name, out.Name)
+		assert.Equal(t, p1, out)
+	})
+}
+
+func TestHTTP_ACLTokenDelete(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		p1 := mock.ACLToken()
+		args := structs.ACLTokenUpsertRequest{
+			Tokens:       []*structs.ACLToken{p1},
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		var resp structs.GenericResponse
+		if err := s.Agent.RPC("ACL.UpsertTokens", &args, &resp); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Make the HTTP request
+		req, err := http.NewRequest("DELETE", "/v1/acl/token/"+p1.AccessorID, nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)
+		assert.Nil(t, err)
+		assert.Nil(t, obj)
+
+		// Check for the index
+		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+			t.Fatalf("missing index")
+		}
+
+		// Check token was created
+		state := s.Agent.server.State()
+		out, err := state.ACLTokenByAccessorID(nil, p1.AccessorID)
+		assert.Nil(t, err)
+		assert.Nil(t, out)
+	})
+}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -151,6 +151,9 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/acl/policies", s.wrap(s.ACLPoliciesRequest))
 	s.mux.HandleFunc("/v1/acl/policy/", s.wrap(s.ACLPolicySpecificRequest))
 
+	s.mux.HandleFunc("/v1/acl/tokens", s.wrap(s.ACLTokensRequest))
+	s.mux.HandleFunc("/v1/acl/token", s.wrap(s.ACLTokenSpecificRequest))
+
 	s.mux.HandleFunc("/v1/client/fs/", s.wrap(s.FsRequest))
 	s.mux.HandleFunc("/v1/client/stats", s.wrap(s.ClientStatsRequest))
 	s.mux.HandleFunc("/v1/client/allocation/", s.wrap(s.ClientAllocRequest))

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -150,7 +150,7 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 }
 
 // UpsertTokens is used to create or update a set of tokens
-func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.GenericResponse) error {
+func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.ACLTokenUpsertResponse) error {
 	if done, err := a.srv.forward("ACL.UpsertTokens", args, args, reply); done {
 		return err
 	}
@@ -161,10 +161,39 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.G
 		return fmt.Errorf("must specify as least one token")
 	}
 
+	// Snapshot the state
+	state := a.srv.State()
+
 	// Validate each token
 	for idx, token := range args.Tokens {
 		if err := token.Validate(); err != nil {
 			return fmt.Errorf("token %d invalid: %v", idx, err)
+		}
+
+		// Generate an accessor and secret ID if new
+		if token.AccessorID == "" {
+			token.AccessorID = structs.GenerateUUID()
+			token.SecretID = structs.GenerateUUID()
+			token.CreateTime = time.Now().UTC()
+
+		} else {
+			// Verify the token exists
+			out, err := state.ACLTokenByAccessorID(nil, token.AccessorID)
+			if err != nil {
+				return fmt.Errorf("token lookup failed: %v", err)
+			}
+			if out == nil {
+				return fmt.Errorf("cannot find token %s", token.AccessorID)
+			}
+
+			// Do not allow the secret ID or create time to be changed
+			token.SecretID = out.SecretID
+			token.CreateTime = out.CreateTime
+
+			// Cannot toggle the "Global" mode
+			if token.Global != out.Global {
+				return fmt.Errorf("cannot toggle global mode of %s", token.AccessorID)
+			}
 		}
 	}
 
@@ -172,6 +201,17 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.G
 	_, index, err := a.srv.raftApply(structs.ACLTokenUpsertRequestType, args)
 	if err != nil {
 		return err
+	}
+
+	// Populate the response. We do a lookup against the state to
+	// pickup the proper create / modify times.
+	state = a.srv.State()
+	for _, token := range args.Tokens {
+		out, err := state.ACLTokenByAccessorID(nil, token.AccessorID)
+		if err != nil {
+			return fmt.Errorf("token lookup failed: %v", err)
+		}
+		reply.Tokens = append(reply.Tokens, out)
 	}
 
 	// Update the index

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -234,7 +234,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 					break
 				}
 				token := raw.(*structs.ACLToken)
-				reply.Tokens = append(reply.Tokens, token)
+				reply.Tokens = append(reply.Tokens, token.Stub())
 			}
 
 			// Use the last index that affected the token table

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -218,7 +218,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 			var err error
 			var iter memdb.ResultIterator
 			if prefix := args.QueryOptions.Prefix; prefix != "" {
-				iter, err = state.ACLTokenByPublicIDPrefix(ws, prefix)
+				iter, err = state.ACLTokenByAccessorIDPrefix(ws, prefix)
 			} else {
 				iter, err = state.ACLTokens(ws)
 			}
@@ -261,7 +261,7 @@ func (a *ACL) GetToken(args *structs.ACLTokenSpecificRequest, reply *structs.Sin
 		queryMeta: &reply.QueryMeta,
 		run: func(ws memdb.WatchSet, state *state.StateStore) error {
 			// Look for the token
-			out, err := state.ACLTokenByPublicID(ws, args.AccessorID)
+			out, err := state.ACLTokenByAccessorID(ws, args.AccessorID)
 			if err != nil {
 				return err
 			}

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -186,10 +186,6 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.A
 				return fmt.Errorf("cannot find token %s", token.AccessorID)
 			}
 
-			// Do not allow the secret ID or create time to be changed
-			token.SecretID = out.SecretID
-			token.CreateTime = out.CreateTime
-
 			// Cannot toggle the "Global" mode
 			if token.Global != out.Global {
 				return fmt.Errorf("cannot toggle global mode of %s", token.AccessorID)

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -551,7 +551,7 @@ func TestACLEndpoint_UpsertTokens(t *testing.T) {
 	assert.NotEqual(t, uint64(0), resp.Index)
 
 	// Check we created the token
-	out, err := s1.fsm.State().ACLTokenByPublicID(nil, p1.AccessorID)
+	out, err := s1.fsm.State().ACLTokenByAccessorID(nil, p1.AccessorID)
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
 }

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -122,7 +122,7 @@ func TestACLEndpoint_GetPolicy_Blocking(t *testing.T) {
 	}
 }
 
-func TestACLEndpoint_List(t *testing.T) {
+func TestACLEndpoint_ListPolicies(t *testing.T) {
 	t.Parallel()
 	s1 := testServer(t, nil)
 	defer s1.Shutdown()
@@ -163,7 +163,7 @@ func TestACLEndpoint_List(t *testing.T) {
 	assert.Equal(t, 1, len(resp2.Policies))
 }
 
-func TestACLEndpoint_List_Blocking(t *testing.T) {
+func TestACLEndpoint_ListPolicies_Blocking(t *testing.T) {
 	t.Parallel()
 	s1 := testServer(t, nil)
 	defer s1.Shutdown()
@@ -292,6 +292,290 @@ func TestACLEndpoint_UpsertPolicies_Invalid(t *testing.T) {
 	err := msgpackrpc.CallWithCodec(codec, "ACL.UpsertPolicies", req, &resp)
 	assert.NotNil(t, err)
 	if !strings.Contains(err.Error(), "failed to parse") {
+		t.Fatalf("bad: %s", err)
+	}
+}
+
+func TestACLEndpoint_GetToken(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	token := mock.ACLToken()
+	s1.fsm.State().UpsertACLTokens(1000, []*structs.ACLToken{token})
+
+	// Lookup the token
+	get := &structs.ACLTokenSpecificRequest{
+		AccessorID:   token.AccessorID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var resp structs.SingleACLTokenResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetToken", get, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp.Index)
+	assert.Equal(t, token, resp.Token)
+
+	// Lookup non-existing token
+	get.AccessorID = structs.GenerateUUID()
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetToken", get, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp.Index)
+	assert.Nil(t, resp.Token)
+}
+
+func TestACLEndpoint_GetToken_Blocking(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	state := s1.fsm.State()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the tokens
+	p1 := mock.ACLToken()
+	p2 := mock.ACLToken()
+
+	// First create an unrelated token
+	time.AfterFunc(100*time.Millisecond, func() {
+		err := state.UpsertACLTokens(100, []*structs.ACLToken{p1})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	// Upsert the token we are watching later
+	time.AfterFunc(200*time.Millisecond, func() {
+		err := state.UpsertACLTokens(200, []*structs.ACLToken{p2})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	// Lookup the token
+	req := &structs.ACLTokenSpecificRequest{
+		AccessorID: p2.AccessorID,
+		QueryOptions: structs.QueryOptions{
+			Region:        "global",
+			MinQueryIndex: 150,
+		},
+	}
+	var resp structs.SingleACLTokenResponse
+	start := time.Now()
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetToken", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
+		t.Fatalf("should block (returned in %s) %#v", elapsed, resp)
+	}
+	if resp.Index != 200 {
+		t.Fatalf("Bad index: %d %d", resp.Index, 200)
+	}
+	if resp.Token == nil || resp.Token.AccessorID != p2.AccessorID {
+		t.Fatalf("bad: %#v", resp.Token)
+	}
+
+	// Eval delete triggers watches
+	time.AfterFunc(100*time.Millisecond, func() {
+		err := state.DeleteACLTokens(300, []string{p2.AccessorID})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	req.QueryOptions.MinQueryIndex = 250
+	var resp2 structs.SingleACLTokenResponse
+	start = time.Now()
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetToken", req, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("should block (returned in %s) %#v", elapsed, resp2)
+	}
+	if resp2.Index != 300 {
+		t.Fatalf("Bad index: %d %d", resp2.Index, 300)
+	}
+	if resp2.Token != nil {
+		t.Fatalf("bad: %#v", resp2.Token)
+	}
+}
+
+func TestACLEndpoint_ListTokens(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	p1 := mock.ACLToken()
+	p2 := mock.ACLToken()
+
+	p1.AccessorID = "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9"
+	p2.AccessorID = "aaaabbbb-3350-4b4b-d185-0e1992ed43e9"
+	s1.fsm.State().UpsertACLTokens(1000, []*structs.ACLToken{p1, p2})
+
+	// Lookup the tokens
+	get := &structs.ACLTokenListRequest{
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var resp structs.ACLTokenListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", get, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp.Index)
+	assert.Equal(t, 2, len(resp.Tokens))
+
+	// Lookup the tokens by prefix
+	get = &structs.ACLTokenListRequest{
+		QueryOptions: structs.QueryOptions{
+			Region: "global",
+			Prefix: "aaaabb",
+		},
+	}
+	var resp2 structs.ACLTokenListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", get, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp2.Index)
+	assert.Equal(t, 1, len(resp2.Tokens))
+}
+
+func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	state := s1.fsm.State()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the token
+	token := mock.ACLToken()
+
+	// Upsert eval triggers watches
+	time.AfterFunc(100*time.Millisecond, func() {
+		if err := state.UpsertACLTokens(2, []*structs.ACLToken{token}); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	req := &structs.ACLTokenListRequest{
+		QueryOptions: structs.QueryOptions{
+			Region:        "global",
+			MinQueryIndex: 1,
+		},
+	}
+	start := time.Now()
+	var resp structs.ACLTokenListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("should block (returned in %s) %#v", elapsed, resp)
+	}
+	assert.Equal(t, uint64(2), resp.Index)
+	if len(resp.Tokens) != 1 || resp.Tokens[0].AccessorID != token.AccessorID {
+		t.Fatalf("bad: %#v", resp.Tokens)
+	}
+
+	// Eval deletion triggers watches
+	time.AfterFunc(100*time.Millisecond, func() {
+		if err := state.DeleteACLTokens(3, []string{token.AccessorID}); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	req.MinQueryIndex = 2
+	start = time.Now()
+	var resp2 structs.ACLTokenListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", req, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("should block (returned in %s) %#v", elapsed, resp2)
+	}
+	assert.Equal(t, uint64(3), resp2.Index)
+	assert.Equal(t, 0, len(resp2.Tokens))
+}
+
+func TestACLEndpoint_DeleteTokens(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	p1 := mock.ACLToken()
+	s1.fsm.State().UpsertACLTokens(1000, []*structs.ACLToken{p1})
+
+	// Lookup the tokens
+	req := &structs.ACLTokenDeleteRequest{
+		AccessorIDs:  []string{p1.AccessorID},
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var resp structs.GenericResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.DeleteTokens", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.NotEqual(t, uint64(0), resp.Index)
+}
+
+func TestACLEndpoint_UpsertTokens(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	p1 := mock.ACLToken()
+
+	// Lookup the tokens
+	req := &structs.ACLTokenUpsertRequest{
+		Tokens:       []*structs.ACLToken{p1},
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var resp structs.GenericResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.UpsertTokens", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.NotEqual(t, uint64(0), resp.Index)
+
+	// Check we created the token
+	out, err := s1.fsm.State().ACLTokenByPublicID(nil, p1.AccessorID)
+	assert.Nil(t, err)
+	assert.NotNil(t, out)
+}
+
+func TestACLEndpoint_UpsertTokens_Invalid(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	p1 := mock.ACLToken()
+	p1.Type = "blah blah"
+
+	// Lookup the tokens
+	req := &structs.ACLTokenUpsertRequest{
+		Tokens:       []*structs.ACLToken{p1},
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ACL.UpsertTokens", req, &resp)
+	assert.NotNil(t, err)
+	if !strings.Contains(err.Error(), "client or management") {
 		t.Fatalf("bad: %s", err)
 	}
 }

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -173,6 +173,10 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyACLPolicyUpsert(buf[1:], log.Index)
 	case structs.ACLPolicyDeleteRequestType:
 		return n.applyACLPolicyDelete(buf[1:], log.Index)
+	case structs.ACLTokenUpsertRequestType:
+		return n.applyACLTokenUpsert(buf[1:], log.Index)
+	case structs.ACLTokenDeleteRequestType:
+		return n.applyACLTokenDelete(buf[1:], log.Index)
 	default:
 		if ignoreUnknown {
 			n.logger.Printf("[WARN] nomad.fsm: ignoring unknown message type (%d), upgrade to newer version", msgType)
@@ -700,6 +704,36 @@ func (n *nomadFSM) applyACLPolicyDelete(buf []byte, index uint64) interface{} {
 
 	if err := n.state.DeleteACLPolicies(index, req.Names); err != nil {
 		n.logger.Printf("[ERR] nomad.fsm: DeleteACLPolicies failed: %v", err)
+		return err
+	}
+	return nil
+}
+
+// applyACLTokenUpsert is used to upsert a set of policies
+func (n *nomadFSM) applyACLTokenUpsert(buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_acl_token_upsert"}, time.Now())
+	var req structs.ACLTokenUpsertRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.UpsertACLTokens(index, req.Tokens); err != nil {
+		n.logger.Printf("[ERR] nomad.fsm: UpsertACLTokens failed: %v", err)
+		return err
+	}
+	return nil
+}
+
+// applyACLTokenDelete is used to delete a set of policies
+func (n *nomadFSM) applyACLTokenDelete(buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_acl_token_delete"}, time.Now())
+	var req structs.ACLTokenDeleteRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.DeleteACLTokens(index, req.AccessorIDs); err != nil {
+		n.logger.Printf("[ERR] nomad.fsm: DeleteACLTokens failed: %v", err)
 		return err
 	}
 	return nil

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1929,6 +1929,25 @@ func TestFSM_SnapshotRestore_ACLPolicy(t *testing.T) {
 	assert.Equal(t, p2, out2)
 }
 
+func TestFSM_SnapshotRestore_ACLTokens(t *testing.T) {
+	t.Parallel()
+	// Add some state
+	fsm := testFSM(t)
+	state := fsm.State()
+	tk1 := mock.ACLToken()
+	tk2 := mock.ACLToken()
+	state.UpsertACLTokens(1000, []*structs.ACLToken{tk1, tk2})
+
+	// Verify the contents
+	fsm2 := testSnapshotRestore(t, fsm)
+	state2 := fsm2.State()
+	ws := memdb.NewWatchSet()
+	out1, _ := state2.ACLTokenByPublicID(ws, tk1.AccessorID)
+	out2, _ := state2.ACLTokenByPublicID(ws, tk2.AccessorID)
+	assert.Equal(t, tk1, out1)
+	assert.Equal(t, tk2, out2)
+}
+
 func TestFSM_SnapshotRestore_AddMissingSummary(t *testing.T) {
 	t.Parallel()
 	// Add some state

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1590,7 +1590,7 @@ func TestFSM_UpsertACLTokens(t *testing.T) {
 
 	// Verify we are registered
 	ws := memdb.NewWatchSet()
-	out, err := fsm.State().ACLTokenByPublicID(ws, token.AccessorID)
+	out, err := fsm.State().ACLTokenByAccessorID(ws, token.AccessorID)
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
 }
@@ -1618,7 +1618,7 @@ func TestFSM_DeleteACLTokens(t *testing.T) {
 
 	// Verify we are NOT registered
 	ws := memdb.NewWatchSet()
-	out, err := fsm.State().ACLTokenByPublicID(ws, token.AccessorID)
+	out, err := fsm.State().ACLTokenByAccessorID(ws, token.AccessorID)
 	assert.Nil(t, err)
 	assert.Nil(t, out)
 }
@@ -1995,8 +1995,8 @@ func TestFSM_SnapshotRestore_ACLTokens(t *testing.T) {
 	fsm2 := testSnapshotRestore(t, fsm)
 	state2 := fsm2.State()
 	ws := memdb.NewWatchSet()
-	out1, _ := state2.ACLTokenByPublicID(ws, tk1.AccessorID)
-	out2, _ := state2.ACLTokenByPublicID(ws, tk2.AccessorID)
+	out1, _ := state2.ACLTokenByAccessorID(ws, tk1.AccessorID)
+	out2, _ := state2.ACLTokenByAccessorID(ws, tk2.AccessorID)
 	assert.Equal(t, tk1, out1)
 	assert.Equal(t, tk2, out2)
 }

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -357,3 +357,17 @@ func ACLPolicy() *structs.ACLPolicy {
 		ModifyIndex: 20,
 	}
 }
+
+func ACLToken() *structs.ACLToken {
+	return &structs.ACLToken{
+		AccessorID:  structs.GenerateUUID(),
+		SecretID:    structs.GenerateUUID(),
+		Name:        "my cool token " + structs.GenerateUUID(),
+		Type:        "client",
+		Policies:    []string{"foo", "bar"},
+		Global:      false,
+		CreateTime:  time.Now().UTC(),
+		CreateIndex: 10,
+		ModifyIndex: 20,
+	}
+}

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -27,6 +27,7 @@ func stateStoreSchema() *memdb.DBSchema {
 		allocTableSchema,
 		vaultAccessorTableSchema,
 		aclPolicyTableSchema,
+		aclTokenTableSchema,
 	}
 
 	// Add each of the tables
@@ -444,6 +445,32 @@ func aclPolicyTableSchema() *memdb.TableSchema {
 				Unique:       true,
 				Indexer: &memdb.StringFieldIndex{
 					Field: "Name",
+				},
+			},
+		},
+	}
+}
+
+// aclTokenTableSchema returns the MemDB schema for the tokens table.
+// This table is used to store the bearer tokens which are used to authenticate
+func aclTokenTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "acl_token",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": &memdb.IndexSchema{
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.UUIDFieldIndex{
+					Field: "AccessorID",
+				},
+			},
+			"secret": &memdb.IndexSchema{
+				Name:         "secret",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.UUIDFieldIndex{
+					Field: "SecretID",
 				},
 			},
 		},

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2853,8 +2853,14 @@ func (s *StateStore) UpsertACLTokens(index uint64, tokens []*structs.ACLToken) e
 
 		// Update all the indexes
 		if existing != nil {
-			token.CreateIndex = existing.(*structs.ACLToken).CreateIndex
+			existTK := existing.(*structs.ACLToken)
+			token.CreateIndex = existTK.CreateIndex
 			token.ModifyIndex = index
+
+			// Do not allow SecretID or create time to change
+			token.SecretID = existTK.SecretID
+			token.CreateTime = existTK.CreateTime
+
 		} else {
 			token.CreateIndex = index
 			token.ModifyIndex = index

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2892,8 +2892,8 @@ func (s *StateStore) DeleteACLTokens(index uint64, ids []string) error {
 	return nil
 }
 
-// ACLTokenByPublicID is used to lookup a token by accessor ID
-func (s *StateStore) ACLTokenByPublicID(ws memdb.WatchSet, id string) (*structs.ACLToken, error) {
+// ACLTokenByAccessorID is used to lookup a token by accessor ID
+func (s *StateStore) ACLTokenByAccessorID(ws memdb.WatchSet, id string) (*structs.ACLToken, error) {
 	txn := s.db.Txn(false)
 
 	watchCh, existing, err := txn.FirstWatch("acl_token", "id", id)
@@ -2924,8 +2924,8 @@ func (s *StateStore) ACLTokenBySecretID(ws memdb.WatchSet, secretID string) (*st
 	return nil, nil
 }
 
-// ACLTokenByPublicIDPrefix is used to lookup tokens by prefix
-func (s *StateStore) ACLTokenByPublicIDPrefix(ws memdb.WatchSet, prefix string) (memdb.ResultIterator, error) {
+// ACLTokenByAccessorIDPrefix is used to lookup tokens by prefix
+func (s *StateStore) ACLTokenByAccessorIDPrefix(ws memdb.WatchSet, prefix string) (memdb.ResultIterator, error) {
 	txn := s.db.Txn(false)
 
 	iter, err := txn.Get("acl_token", "id_prefix", prefix)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -5758,7 +5758,7 @@ func TestStateStore_UpsertACLPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if index != 1001 {
+	if index != 1000 {
 		t.Fatalf("bad: %d", index)
 	}
 
@@ -5849,7 +5849,7 @@ func TestStateStore_ACLPolicyByNamePrefix(t *testing.T) {
 	for _, name := range names {
 		p := mock.ACLPolicy()
 		p.Name = name
-		if err := state.UpsertACLPolicy(baseIndex, p); err != nil {
+		if err := state.UpsertACLPolicies(baseIndex, []*structs.ACLPolicy{p}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		baseIndex++

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -5887,10 +5887,10 @@ func TestStateStore_UpsertACLTokens(t *testing.T) {
 	tk2 := mock.ACLToken()
 
 	ws := memdb.NewWatchSet()
-	if _, err := state.ACLTokenByPublicID(ws, tk1.AccessorID); err != nil {
+	if _, err := state.ACLTokenByAccessorID(ws, tk1.AccessorID); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := state.ACLTokenByPublicID(ws, tk2.AccessorID); err != nil {
+	if _, err := state.ACLTokenByAccessorID(ws, tk2.AccessorID); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5903,11 +5903,11 @@ func TestStateStore_UpsertACLTokens(t *testing.T) {
 	}
 
 	ws = memdb.NewWatchSet()
-	out, err := state.ACLTokenByPublicID(ws, tk1.AccessorID)
+	out, err := state.ACLTokenByAccessorID(ws, tk1.AccessorID)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, tk1, out)
 
-	out, err = state.ACLTokenByPublicID(ws, tk2.AccessorID)
+	out, err = state.ACLTokenByAccessorID(ws, tk2.AccessorID)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, tk2, out)
 
@@ -5963,7 +5963,7 @@ func TestStateStore_DeleteACLTokens(t *testing.T) {
 
 	// Create a watcher
 	ws := memdb.NewWatchSet()
-	if _, err := state.ACLTokenByPublicID(ws, tk1.AccessorID); err != nil {
+	if _, err := state.ACLTokenByAccessorID(ws, tk1.AccessorID); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5980,7 +5980,7 @@ func TestStateStore_DeleteACLTokens(t *testing.T) {
 
 	// Ensure we don't get the object back
 	ws = memdb.NewWatchSet()
-	out, err := state.ACLTokenByPublicID(ws, tk1.AccessorID)
+	out, err := state.ACLTokenByAccessorID(ws, tk1.AccessorID)
 	assert.Equal(t, nil, err)
 	if out != nil {
 		t.Fatalf("bad: %#v", out)
@@ -6017,7 +6017,7 @@ func TestStateStore_DeleteACLTokens(t *testing.T) {
 	}
 }
 
-func TestStateStore_ACLTokenByPublicIDPrefix(t *testing.T) {
+func TestStateStore_ACLTokenByAccessorIDPrefix(t *testing.T) {
 	state := testStateStore(t)
 	prefixes := []string{
 		"aaaa",
@@ -6039,7 +6039,7 @@ func TestStateStore_ACLTokenByPublicIDPrefix(t *testing.T) {
 	}
 
 	// Scan by prefix
-	iter, err := state.ACLTokenByPublicIDPrefix(nil, "aa")
+	iter, err := state.ACLTokenByAccessorIDPrefix(nil, "aa")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -6103,7 +6103,7 @@ func TestStateStore_RestoreACLToken(t *testing.T) {
 	restore.Commit()
 
 	ws := memdb.NewWatchSet()
-	out, err := state.ACLTokenByPublicID(ws, token.AccessorID)
+	out, err := state.ACLTokenByAccessorID(ws, token.AccessorID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -5881,6 +5881,189 @@ func TestStateStore_ACLPolicyByNamePrefix(t *testing.T) {
 	assert.Equal(t, expect, out)
 }
 
+func TestStateStore_UpsertACLTokens(t *testing.T) {
+	state := testStateStore(t)
+	tk1 := mock.ACLToken()
+	tk2 := mock.ACLToken()
+
+	ws := memdb.NewWatchSet()
+	if _, err := state.ACLTokenByPublicID(ws, tk1.AccessorID); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, err := state.ACLTokenByPublicID(ws, tk2.AccessorID); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if err := state.UpsertACLTokens(1000,
+		[]*structs.ACLToken{tk1, tk2}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !watchFired(ws) {
+		t.Fatalf("bad")
+	}
+
+	ws = memdb.NewWatchSet()
+	out, err := state.ACLTokenByPublicID(ws, tk1.AccessorID)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, tk1, out)
+
+	out, err = state.ACLTokenByPublicID(ws, tk2.AccessorID)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, tk2, out)
+
+	out, err = state.ACLTokenBySecretID(ws, tk1.SecretID)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, tk1, out)
+
+	out, err = state.ACLTokenBySecretID(ws, tk2.SecretID)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, tk2, out)
+
+	iter, err := state.ACLTokens(ws)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure we see both policies
+	count := 0
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		count++
+	}
+	if count != 2 {
+		t.Fatalf("bad: %d", count)
+	}
+
+	index, err := state.Index("acl_token")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if index != 1000 {
+		t.Fatalf("bad: %d", index)
+	}
+
+	if watchFired(ws) {
+		t.Fatalf("bad")
+	}
+}
+
+func TestStateStore_DeleteACLTokens(t *testing.T) {
+	state := testStateStore(t)
+	tk1 := mock.ACLToken()
+	tk2 := mock.ACLToken()
+
+	// Create the tokens
+	if err := state.UpsertACLTokens(1000,
+		[]*structs.ACLToken{tk1, tk2}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Create a watcher
+	ws := memdb.NewWatchSet()
+	if _, err := state.ACLTokenByPublicID(ws, tk1.AccessorID); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Delete the token
+	if err := state.DeleteACLTokens(1001,
+		[]string{tk1.AccessorID, tk2.AccessorID}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure watching triggered
+	if !watchFired(ws) {
+		t.Fatalf("bad")
+	}
+
+	// Ensure we don't get the object back
+	ws = memdb.NewWatchSet()
+	out, err := state.ACLTokenByPublicID(ws, tk1.AccessorID)
+	assert.Equal(t, nil, err)
+	if out != nil {
+		t.Fatalf("bad: %#v", out)
+	}
+
+	iter, err := state.ACLTokens(ws)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure we see both policies
+	count := 0
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		count++
+	}
+	if count != 0 {
+		t.Fatalf("bad: %d", count)
+	}
+
+	index, err := state.Index("acl_token")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if index != 1001 {
+		t.Fatalf("bad: %d", index)
+	}
+
+	if watchFired(ws) {
+		t.Fatalf("bad")
+	}
+}
+
+func TestStateStore_ACLTokenByPublicIDPrefix(t *testing.T) {
+	state := testStateStore(t)
+	prefixes := []string{
+		"aaaa",
+		"aabb",
+		"bbbb",
+		"bbcc",
+		"ffff",
+	}
+
+	// Create the tokens
+	var baseIndex uint64 = 1000
+	for _, prefix := range prefixes {
+		tk := mock.ACLToken()
+		tk.AccessorID = prefix + tk.AccessorID[4:]
+		if err := state.UpsertACLTokens(baseIndex, []*structs.ACLToken{tk}); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		baseIndex++
+	}
+
+	// Scan by prefix
+	iter, err := state.ACLTokenByPublicIDPrefix(nil, "aa")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure we see both tokens
+	count := 0
+	out := []string{}
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		count++
+		out = append(out, raw.(*structs.ACLToken).AccessorID[:4])
+	}
+	if count != 2 {
+		t.Fatalf("bad: %d %v", count, out)
+	}
+	sort.Strings(out)
+
+	expect := []string{"aaaa", "aabb"}
+	assert.Equal(t, expect, out)
+}
+
 func TestStateStore_RestoreACLPolicy(t *testing.T) {
 	state := testStateStore(t)
 	policy := mock.ACLPolicy()
@@ -5902,6 +6085,29 @@ func TestStateStore_RestoreACLPolicy(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	assert.Equal(t, policy, out)
+}
+
+func TestStateStore_RestoreACLToken(t *testing.T) {
+	state := testStateStore(t)
+	token := mock.ACLToken()
+
+	restore, err := state.Restore()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	err = restore.ACLTokenRestore(token)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	restore.Commit()
+
+	ws := memdb.NewWatchSet()
+	out, err := state.ACLTokenByPublicID(ws, token.AccessorID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, token, out)
 }
 
 func TestStateStore_Abandon(t *testing.T) {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5422,3 +5422,9 @@ type ACLTokenUpsertRequest struct {
 	Tokens []*ACLToken
 	WriteRequest
 }
+
+// ACLTokenUpsertResponse is used to return from an ACLTokenUpsertRequest
+type ACLTokenUpsertResponse struct {
+	Tokens []*ACLToken
+	WriteMeta
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -96,6 +96,13 @@ const (
 
 	// maxPolicyDescriptionLength limits a policy description length
 	maxPolicyDescriptionLength = 256
+
+	// maxTokenNameLength limits a ACL token name length
+	maxTokenNameLength = 64
+
+	// ACLClientToken and ACLManagementToken are the only types of tokens
+	ACLClientToken     = "client"
+	ACLManagementToken = "management"
 )
 
 // RPCInfo is used to describe common information about query
@@ -5319,4 +5326,38 @@ type ACLPolicyDeleteRequest struct {
 type ACLPolicyUpsertRequest struct {
 	Policies []*ACLPolicy
 	WriteRequest
+}
+
+// ACLToken represents a client token which is used to Authenticate
+type ACLToken struct {
+	AccessorID  string    // Public Accessor ID (UUID)
+	SecretID    string    // Secret ID, private (UUID)
+	Name        string    // Human friendly name
+	Type        string    // Client or Management
+	Policies    []string  // Policies this token ties to
+	Global      bool      // Global or Region local
+	CreateTime  time.Time // Time of creation
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// Validate is used to sanity check a token
+func (a *ACLToken) Validate() error {
+	var mErr multierror.Error
+	if len(a.Name) > maxTokenNameLength {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("token name too long"))
+	}
+	switch a.Type {
+	case ACLClientToken:
+		if len(a.Policies) == 0 {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("client token missing policies"))
+		}
+	case ACLManagementToken:
+		if len(a.Policies) != 0 {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("management token cannot be associated with policies"))
+		}
+	default:
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("token type must be client or management"))
+	}
+	return mErr.ErrorOrNil()
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5343,6 +5343,30 @@ type ACLToken struct {
 	ModifyIndex uint64
 }
 
+type ACLTokenListStub struct {
+	AccessorID  string
+	Name        string
+	Type        string
+	Policies    []string
+	Global      bool
+	CreateTime  time.Time
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+func (a *ACLToken) Stub() *ACLTokenListStub {
+	return &ACLTokenListStub{
+		AccessorID:  a.AccessorID,
+		Name:        a.Name,
+		Type:        a.Type,
+		Policies:    a.Policies,
+		Global:      a.Global,
+		CreateTime:  a.CreateTime,
+		CreateIndex: a.CreateIndex,
+		ModifyIndex: a.ModifyIndex,
+	}
+}
+
 // Validate is used to sanity check a token
 func (a *ACLToken) Validate() error {
 	var mErr multierror.Error
@@ -5377,7 +5401,7 @@ type ACLTokenSpecificRequest struct {
 
 // ACLTokenListResponse is used for a list request
 type ACLTokenListResponse struct {
-	Tokens []*ACLToken
+	Tokens []*ACLTokenListStub
 	QueryMeta
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -65,6 +65,8 @@ const (
 	JobStabilityRequestType
 	ACLPolicyUpsertRequestType
 	ACLPolicyDeleteRequestType
+	ACLTokenUpsertRequestType
+	ACLTokenDeleteRequestType
 )
 
 const (
@@ -5360,4 +5362,39 @@ func (a *ACLToken) Validate() error {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("token type must be client or management"))
 	}
 	return mErr.ErrorOrNil()
+}
+
+// ACLTokenListRequest is used to request a list of tokens
+type ACLTokenListRequest struct {
+	QueryOptions
+}
+
+// ACLTokenSpecificRequest is used to query a specific token
+type ACLTokenSpecificRequest struct {
+	AccessorID string
+	QueryOptions
+}
+
+// ACLTokenListResponse is used for a list request
+type ACLTokenListResponse struct {
+	Tokens []*ACLToken
+	QueryMeta
+}
+
+// SingleACLTokenResponse is used to return a single token
+type SingleACLTokenResponse struct {
+	Token *ACLToken
+	QueryMeta
+}
+
+// ACLTokenDeleteRequest is used to delete a set of tokens
+type ACLTokenDeleteRequest struct {
+	AccessorIDs []string
+	WriteRequest
+}
+
+// ACLTokenUpsertRequest is used to upsert a set of tokens
+type ACLTokenUpsertRequest struct {
+	Tokens []*ACLToken
+	WriteRequest
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJob_Validate(t *testing.T) {
@@ -2256,4 +2257,46 @@ func TestIsRecoverable(t *testing.T) {
 	if !IsRecoverable(NewRecoverableError(fmt.Errorf(""), true)) {
 		t.Errorf("Explicitly recoverable errors *should* be recoverable")
 	}
+}
+
+func TestACLTokenValidate(t *testing.T) {
+	tk := &ACLToken{}
+
+	// Mising a type
+	err := tk.Validate()
+	assert.NotNil(t, err)
+	if !strings.Contains(err.Error(), "client or management") {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Missing policies
+	tk.Type = ACLClientToken
+	err = tk.Validate()
+	assert.NotNil(t, err)
+	if !strings.Contains(err.Error(), "missing policies") {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Invalid policices
+	tk.Type = ACLManagementToken
+	tk.Policies = []string{"foo"}
+	err = tk.Validate()
+	assert.NotNil(t, err)
+	if !strings.Contains(err.Error(), "associated with policies") {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Name too long policices
+	tk.Name = GenerateUUID() + GenerateUUID()
+	tk.Policies = nil
+	err = tk.Validate()
+	assert.NotNil(t, err)
+	if !strings.Contains(err.Error(), "too long") {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Make it valid
+	tk.Name = "foo"
+	err = tk.Validate()
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
This PR adds the concept of ACL Tokens. CRUD of the tokens are exposed via HTTP APIs, RPC endpoints, and the state store.