### PR TITLE
Add replication for ACL Policies and Tokens

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -106,6 +106,15 @@ func convertServerConfig(agentConfig *Config, logOutput io.Writer) (*nomad.Confi
 	if agentConfig.Region != "" {
 		conf.Region = agentConfig.Region
 	}
+
+	// Set the Authoritative Region if set, otherwise default to
+	// the same as the local region.
+	if agentConfig.Server.AuthoritativeRegion != "" {
+		conf.AuthoritativeRegion = agentConfig.Server.AuthoritativeRegion
+	} else if agentConfig.Region != "" {
+		conf.AuthoritativeRegion = agentConfig.Region
+	}
+
 	if agentConfig.Datacenter != "" {
 		conf.Datacenter = agentConfig.Datacenter
 	}
@@ -133,6 +142,9 @@ func convertServerConfig(agentConfig *Config, logOutput io.Writer) (*nomad.Confi
 	}
 	if len(agentConfig.Server.EnabledSchedulers) != 0 {
 		conf.EnabledSchedulers = agentConfig.Server.EnabledSchedulers
+	}
+	if agentConfig.ACL.Enabled {
+		conf.ACLEnabled = true
 	}
 
 	// Set up the bind addresses

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -57,6 +57,7 @@ func TestAgent_ServerConfig(t *testing.T) {
 	conf.AdvertiseAddrs.Serf = "127.0.0.1:4000"
 	conf.AdvertiseAddrs.RPC = "127.0.0.1:4001"
 	conf.AdvertiseAddrs.HTTP = "10.10.11.1:4005"
+	conf.ACL.Enabled = true
 
 	// Parses the advertise addrs correctly
 	if err := conf.normalizeAddrs(); err != nil {
@@ -73,6 +74,12 @@ func TestAgent_ServerConfig(t *testing.T) {
 	serfPort := out.SerfConfig.MemberlistConfig.AdvertisePort
 	if serfPort != 4000 {
 		t.Fatalf("expected 4000, got: %d", serfPort)
+	}
+	if out.AuthoritativeRegion != "global" {
+		t.Fatalf("bad: %#v", out.AuthoritativeRegion)
+	}
+	if !out.ACLEnabled {
+		t.Fatalf("ACL not enabled")
 	}
 
 	// Assert addresses weren't changed

--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -85,8 +85,8 @@ server {
 }
 acl {
     enabled = true
-    token_ttl = "30s"
-    policy_ttl = "30s"
+    token_ttl = "60s"
+    policy_ttl = "60s"
 }
 telemetry {
 	statsite_address = "127.0.0.1:1234"

--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -63,6 +63,7 @@ client {
 }
 server {
 	enabled = true
+    authoritative_region = "foobar"
 	bootstrap_expect = 5
 	data_dir = "/tmp/data"
 	protocol_version = 3
@@ -81,6 +82,11 @@ server {
 	retry_interval = "15s"
 	rejoin_after_leave = true
     encrypt = "abc"
+}
+acl {
+    enabled = true
+    token_ttl = "30s"
+    policy_ttl = "30s"
 }
 telemetry {
 	statsite_address = "127.0.0.1:1234"

--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -63,7 +63,7 @@ client {
 }
 server {
 	enabled = true
-    authoritative_region = "foobar"
+	authoritative_region = "foobar"
 	bootstrap_expect = 5
 	data_dir = "/tmp/data"
 	protocol_version = 3

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -66,6 +66,9 @@ type Config struct {
 	// Server has our server related settings
 	Server *ServerConfig `mapstructure:"server"`
 
+	// ACL has our acl related settings
+	ACL *ACLConfig `mapstructure:"acl"`
+
 	// Telemetry is used to configure sending telemetry
 	Telemetry *Telemetry `mapstructure:"telemetry"`
 
@@ -229,10 +232,34 @@ type ClientConfig struct {
 	NoHostUUID *bool `mapstructure:"no_host_uuid"`
 }
 
+// ACLConfig is configuration specific to the ACL system
+type ACLConfig struct {
+	// Enabled controls if we are enforce and manage ACLs
+	Enabled bool `mapstructure:"enabled"`
+
+	// TokenTTL controls how long we cache ACL tokens. This controls
+	// how stale they can be when we are enforcing policies. Defaults
+	// to "30s". Reducing this impacts performance by forcing more
+	// frequent resolution.
+	TokenTTL string        `mapstructure:"token_ttl"`
+	tokenTTL time.Duration `mapstructure:"-"`
+
+	// PolicyTTL controls how long we cache ACL policies. This controls
+	// how stale they can be when we are enforcing policies. Defaults
+	// to "30s". Reducing this impacts performance by forcing more
+	// frequent resolution.
+	PolicyTTL string        `mapstructure:"policy_ttl"`
+	policyTTL time.Duration `mapstructure:"-"`
+}
+
 // ServerConfig is configuration specific to the server mode
 type ServerConfig struct {
 	// Enabled controls if we are a server
 	Enabled bool `mapstructure:"enabled"`
+
+	// AuthoritativeRegion is used to control which region is treated as
+	// the source of truth for global tokens and ACL policies.
+	AuthoritativeRegion string `mapstructure:"authoritative_region"`
 
 	// BootstrapExpect tries to automatically bootstrap the Consul cluster,
 	// by withholding peers until enough servers join.
@@ -566,6 +593,11 @@ func DefaultConfig() *Config {
 			RetryInterval:    "30s",
 			RetryMaxAttempts: 0,
 		},
+		ACL: &ACLConfig{
+			Enabled:   false,
+			TokenTTL:  "30s",
+			PolicyTTL: "30s",
+		},
 		SyslogFacility: "LOCAL0",
 		Telemetry: &Telemetry{
 			CollectionInterval: "1s",
@@ -674,6 +706,14 @@ func (c *Config) Merge(b *Config) *Config {
 		result.Server = &server
 	} else if b.Server != nil {
 		result.Server = result.Server.Merge(b.Server)
+	}
+
+	// Apply the acl config
+	if result.ACL == nil && b.ACL != nil {
+		server := *b.ACL
+		result.ACL = &server
+	} else if b.ACL != nil {
+		result.ACL = result.ACL.Merge(b.ACL)
 	}
 
 	// Apply the ports config
@@ -902,12 +942,31 @@ func isTooManyColons(err error) bool {
 	return err != nil && strings.Contains(err.Error(), tooManyColons)
 }
 
+// Merge is used to merge two ACL configs together
+func (a *ACLConfig) Merge(b *ACLConfig) *ACLConfig {
+	result := *a
+
+	if b.Enabled {
+		result.Enabled = true
+	}
+	if b.TokenTTL != "" {
+		result.TokenTTL = b.TokenTTL
+	}
+	if b.PolicyTTL != "" {
+		result.PolicyTTL = b.PolicyTTL
+	}
+	return &result
+}
+
 // Merge is used to merge two server configs together
 func (a *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 	result := *a
 
 	if b.Enabled {
 		result.Enabled = true
+	}
+	if b.AuthoritativeRegion != "" {
+		result.AuthoritativeRegion = b.AuthoritativeRegion
 	}
 	if b.BootstrapExpect > 0 {
 		result.BootstrapExpect = b.BootstrapExpect

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -241,15 +241,13 @@ type ACLConfig struct {
 	// how stale they can be when we are enforcing policies. Defaults
 	// to "30s". Reducing this impacts performance by forcing more
 	// frequent resolution.
-	TokenTTL string        `mapstructure:"token_ttl"`
-	tokenTTL time.Duration `mapstructure:"-"`
+	TokenTTL time.Duration `mapstructure:"token_ttl"`
 
 	// PolicyTTL controls how long we cache ACL policies. This controls
 	// how stale they can be when we are enforcing policies. Defaults
 	// to "30s". Reducing this impacts performance by forcing more
 	// frequent resolution.
-	PolicyTTL string        `mapstructure:"policy_ttl"`
-	policyTTL time.Duration `mapstructure:"-"`
+	PolicyTTL time.Duration `mapstructure:"policy_ttl"`
 }
 
 // ServerConfig is configuration specific to the server mode
@@ -595,8 +593,8 @@ func DefaultConfig() *Config {
 		},
 		ACL: &ACLConfig{
 			Enabled:   false,
-			TokenTTL:  "30s",
-			PolicyTTL: "30s",
+			TokenTTL:  30 * time.Second,
+			PolicyTTL: 30 * time.Second,
 		},
 		SyslogFacility: "LOCAL0",
 		Telemetry: &Telemetry{
@@ -949,10 +947,10 @@ func (a *ACLConfig) Merge(b *ACLConfig) *ACLConfig {
 	if b.Enabled {
 		result.Enabled = true
 	}
-	if b.TokenTTL != "" {
+	if b.TokenTTL != 0 {
 		result.TokenTTL = b.TokenTTL
 	}
-	if b.PolicyTTL != "" {
+	if b.PolicyTTL != 0 {
 		result.PolicyTTL = b.PolicyTTL
 	}
 	return &result

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -96,6 +96,7 @@ func parseConfig(result *Config, list *ast.ObjectList) error {
 		"vault",
 		"tls",
 		"http_api_response_headers",
+		"acl",
 	}
 	if err := checkHCLKeys(list, valid); err != nil {
 		return multierror.Prefix(err, "config:")
@@ -118,6 +119,7 @@ func parseConfig(result *Config, list *ast.ObjectList) error {
 	delete(m, "vault")
 	delete(m, "tls")
 	delete(m, "http_api_response_headers")
+	delete(m, "acl")
 
 	// Decode the rest
 	if err := mapstructure.WeakDecode(m, result); err != nil {
@@ -156,6 +158,13 @@ func parseConfig(result *Config, list *ast.ObjectList) error {
 	if o := list.Filter("server"); len(o.Items) > 0 {
 		if err := parseServer(&result.Server, o); err != nil {
 			return multierror.Prefix(err, "server ->")
+		}
+	}
+
+	// Parse ACL config
+	if o := list.Filter("acl"); len(o.Items) > 0 {
+		if err := parseACL(&result.ACL, o); err != nil {
+			return multierror.Prefix(err, "acl ->")
 		}
 	}
 
@@ -514,6 +523,7 @@ func parseServer(result **ServerConfig, list *ast.ObjectList) error {
 		"retry_interval",
 		"rejoin_after_leave",
 		"encrypt",
+		"authoritative_region",
 	}
 	if err := checkHCLKeys(listVal, valid); err != nil {
 		return err
@@ -525,6 +535,55 @@ func parseServer(result **ServerConfig, list *ast.ObjectList) error {
 	}
 
 	var config ServerConfig
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+		WeaklyTypedInput: true,
+		Result:           &config,
+	})
+	if err != nil {
+		return err
+	}
+	if err := dec.Decode(m); err != nil {
+		return err
+	}
+
+	*result = &config
+	return nil
+}
+
+func parseACL(result **ACLConfig, list *ast.ObjectList) error {
+	list = list.Elem()
+	if len(list.Items) > 1 {
+		return fmt.Errorf("only one 'acl' block allowed")
+	}
+
+	// Get our server object
+	obj := list.Items[0]
+
+	// Value should be an object
+	var listVal *ast.ObjectList
+	if ot, ok := obj.Val.(*ast.ObjectType); ok {
+		listVal = ot.List
+	} else {
+		return fmt.Errorf("acl value: should be an object")
+	}
+
+	// Check for invalid keys
+	valid := []string{
+		"enabled",
+		"token_ttl",
+		"policy_ttl",
+	}
+	if err := checkHCLKeys(listVal, valid); err != nil {
+		return err
+	}
+
+	var m map[string]interface{}
+	if err := hcl.DecodeObject(&m, listVal); err != nil {
+		return err
+	}
+
+	var config ACLConfig
 	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
 		WeaklyTypedInput: true,

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -84,6 +84,7 @@ func TestConfig_Parse(t *testing.T) {
 				},
 				Server: &ServerConfig{
 					Enabled:                true,
+					AuthoritativeRegion:    "foobar",
 					BootstrapExpect:        5,
 					DataDir:                "/tmp/data",
 					ProtocolVersion:        3,
@@ -102,6 +103,11 @@ func TestConfig_Parse(t *testing.T) {
 					RejoinAfterLeave:       true,
 					RetryMaxAttempts:       3,
 					EncryptKey:             "abc",
+				},
+				ACL: &ACLConfig{
+					Enabled:   true,
+					TokenTTL:  "30s",
+					PolicyTTL: "30s",
 				},
 				Telemetry: &Telemetry{
 					StatsiteAddr:             "127.0.0.1:1234",

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -106,8 +106,8 @@ func TestConfig_Parse(t *testing.T) {
 				},
 				ACL: &ACLConfig{
 					Enabled:   true,
-					TokenTTL:  "30s",
-					PolicyTTL: "30s",
+					TokenTTL:  60 * time.Second,
+					PolicyTTL: 60 * time.Second,
 				},
 				Telemetry: &Telemetry{
 					StatsiteAddr:             "127.0.0.1:1234",

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -27,6 +27,7 @@ func TestConfig_Merge(t *testing.T) {
 		Telemetry:      &Telemetry{},
 		Client:         &ClientConfig{},
 		Server:         &ServerConfig{},
+		ACL:            &ACLConfig{},
 		Ports:          &Ports{},
 		Addresses:      &Addresses{},
 		AdvertiseAddrs: &AdvertiseAddrs{},
@@ -91,6 +92,7 @@ func TestConfig_Merge(t *testing.T) {
 		},
 		Server: &ServerConfig{
 			Enabled:                false,
+			AuthoritativeRegion:    "global",
 			BootstrapExpect:        1,
 			DataDir:                "/tmp/data1",
 			ProtocolVersion:        1,
@@ -99,6 +101,11 @@ func TestConfig_Merge(t *testing.T) {
 			HeartbeatGrace:         30 * time.Second,
 			MinHeartbeatTTL:        30 * time.Second,
 			MaxHeartbeatsPerSecond: 30.0,
+		},
+		ACL: &ACLConfig{
+			Enabled:   true,
+			TokenTTL:  "60s",
+			PolicyTTL: "60s",
 		},
 		Ports: &Ports{
 			HTTP: 4646,
@@ -223,6 +230,7 @@ func TestConfig_Merge(t *testing.T) {
 		},
 		Server: &ServerConfig{
 			Enabled:                true,
+			AuthoritativeRegion:    "global2",
 			BootstrapExpect:        2,
 			DataDir:                "/tmp/data2",
 			ProtocolVersion:        2,
@@ -237,6 +245,11 @@ func TestConfig_Merge(t *testing.T) {
 			RetryJoin:              []string{"1.1.1.1"},
 			RetryInterval:          "10s",
 			retryInterval:          time.Second * 10,
+		},
+		ACL: &ACLConfig{
+			Enabled:   true,
+			TokenTTL:  "20s",
+			PolicyTTL: "20s",
 		},
 		Ports: &Ports{
 			HTTP: 20000,

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -108,6 +108,9 @@ func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.AC
 			if err != nil {
 				return err
 			}
+			if index == 0 {
+				index = 1
+			}
 			reply.Index = index
 			return nil
 		}}

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -258,6 +258,8 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 			var iter memdb.ResultIterator
 			if prefix := args.QueryOptions.Prefix; prefix != "" {
 				iter, err = state.ACLTokenByAccessorIDPrefix(ws, prefix)
+			} else if args.GlobalOnly {
+				iter, err = state.ACLTokensByGlobal(ws, true)
 			} else {
 				iter, err = state.ACLTokens(ws)
 			}

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -416,6 +416,7 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 	// Create the register request
 	p1 := mock.ACLToken()
 	p2 := mock.ACLToken()
+	p2.Global = true
 
 	p1.AccessorID = "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9"
 	p2.AccessorID = "aaaabbbb-3350-4b4b-d185-0e1992ed43e9"
@@ -445,6 +446,20 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 	}
 	assert.Equal(t, uint64(1000), resp2.Index)
 	assert.Equal(t, 1, len(resp2.Tokens))
+
+	// Lookup the global tokens
+	get = &structs.ACLTokenListRequest{
+		GlobalOnly: true,
+		QueryOptions: structs.QueryOptions{
+			Region: "global",
+		},
+	}
+	var resp3 structs.ACLTokenListResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", get, &resp3); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp3.Index)
+	assert.Equal(t, 1, len(resp3.Tokens))
 }
 
 func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -101,6 +101,10 @@ type Config struct {
 	// Region is the region this Nomad server belongs to.
 	Region string
 
+	// AuthoritativeRegion is the region which is treated as the authoritative source
+	// for ACLs and Policies. This provides a single source of truth to resolve conflicts.
+	AuthoritativeRegion string
+
 	// Datacenter is the datacenter this Nomad server belongs to.
 	Datacenter string
 
@@ -224,6 +228,9 @@ type Config struct {
 
 	// TLSConfig holds various TLS related configurations
 	TLSConfig *config.TLSConfig
+
+	// ACLEnabled controls if ACL enforcement and management is enabled.
+	ACLEnabled bool
 }
 
 // CheckVersion is used to check if the ProtocolVersion is valid

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -231,6 +231,10 @@ type Config struct {
 
 	// ACLEnabled controls if ACL enforcement and management is enabled.
 	ACLEnabled bool
+
+	// ReplicationBackoff is how much we backoff when replication errors.
+	// This is a tunable knob for testing primarily.
+	ReplicationBackoff time.Duration
 }
 
 // CheckVersion is used to check if the ProtocolVersion is valid
@@ -254,6 +258,7 @@ func DefaultConfig() *Config {
 
 	c := &Config{
 		Region:                           DefaultRegion,
+		AuthoritativeRegion:              DefaultRegion,
 		Datacenter:                       DefaultDC,
 		NodeName:                         hostname,
 		ProtocolVersion:                  ProtocolVersionMax,
@@ -286,6 +291,7 @@ func DefaultConfig() *Config {
 		VaultConfig:                      config.DefaultVaultConfig(),
 		RPCHoldTimeout:                   5 * time.Second,
 		TLSConfig:                        &config.TLSConfig{},
+		ReplicationBackoff:               30 * time.Second,
 	}
 
 	// Enable all known schedulers by default

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -802,10 +802,136 @@ func diffACLPolicies(state *state.StateStore, minIndex uint64, remoteList []*str
 // replicateACLTokens is used to replicate global ACL tokens from
 // the authoritative region to this region.
 func (s *Server) replicateACLTokens(stopCh chan struct{}) {
+	req := structs.ACLTokenListRequest{
+		GlobalOnly: true,
+	}
+	req.Region = s.config.AuthoritativeRegion
+	limiter := rate.NewLimiter(replicationRateLimit, int(replicationRateLimit))
+	s.logger.Printf("[DEBUG] nomad: starting ACL token replication from authoritative region '%s'", req.Region)
+
+START:
 	for {
 		select {
 		case <-stopCh:
 			return
+		default:
+			// Rate limit how often we attempt replication
+			limiter.Wait(context.Background())
+
+			// Fetch the list of tokens
+			var resp structs.ACLTokenListResponse
+			err := s.forwardRegion(s.config.AuthoritativeRegion,
+				"ACL.ListTokens", &req, &resp)
+			if err != nil {
+				s.logger.Printf("[ERR] nomad: failed to fetch tokens from authoritative region: %v", err)
+				goto ERR_WAIT
+			}
+
+			// Perform a two-way diff
+			delete, update := diffACLTokens(s.State(), req.MinQueryIndex, resp.Tokens)
+
+			// Delete tokens that should not exist
+			if len(delete) > 0 {
+				args := &structs.ACLTokenDeleteRequest{
+					AccessorIDs: delete,
+				}
+				_, _, err := s.raftApply(structs.ACLTokenDeleteRequestType, args)
+				if err != nil {
+					s.logger.Printf("[ERR] nomad: failed to delete tokens: %v", err)
+					goto ERR_WAIT
+				}
+			}
+
+			// Fetch any outdated policies
+			var fetched []*structs.ACLToken
+			for _, tokenID := range update {
+				req := structs.ACLTokenSpecificRequest{
+					AccessorID: tokenID,
+				}
+				req.Region = s.config.AuthoritativeRegion
+				var reply structs.SingleACLTokenResponse
+				err := s.forwardRegion(s.config.AuthoritativeRegion,
+					"ACL.GetToken", &req, &reply)
+				if err != nil {
+					s.logger.Printf("[ERR] nomad: failed to fetch token '%s' from authoritative region: %v", tokenID, err)
+					goto ERR_WAIT
+				}
+				if reply.Token != nil {
+					fetched = append(fetched, reply.Token)
+				}
+			}
+
+			// Update local tokensj
+			if len(fetched) > 0 {
+				args := &structs.ACLTokenUpsertRequest{
+					Tokens: fetched,
+				}
+				_, _, err := s.raftApply(structs.ACLTokenUpsertRequestType, args)
+				if err != nil {
+					s.logger.Printf("[ERR] nomad: failed to update tokens: %v", err)
+					goto ERR_WAIT
+				}
+			}
+
+			// Update the minimum query index, blocks until there
+			// is a change.
+			req.MinQueryIndex = resp.Index
 		}
 	}
+
+ERR_WAIT:
+	select {
+	case <-time.After(s.config.ReplicationBackoff):
+		goto START
+	case <-stopCh:
+		return
+	}
+}
+
+// diffACLTokens is used to perform a two-way diff between the local
+// tokens and the remote tokens to determine which tokens need to
+// be deleted or updated.
+func diffACLTokens(state *state.StateStore, minIndex uint64, remoteList []*structs.ACLTokenListStub) (delete []string, update []string) {
+	// Construct a set of the local and remote policies
+	local := make(map[string]struct{})
+	remote := make(map[string]struct{})
+
+	// Add all the local global tokens
+	iter, err := state.ACLTokensByGlobal(nil, true)
+	if err != nil {
+		panic("failed to iterate local tokens")
+	}
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		token := raw.(*structs.ACLToken)
+		local[token.AccessorID] = struct{}{}
+	}
+
+	// Iterate over the remote tokens
+	for _, rp := range remoteList {
+		remote[rp.AccessorID] = struct{}{}
+
+		// Check if the token is missing locally
+		if _, ok := local[rp.AccessorID]; !ok {
+			update = append(update, rp.AccessorID)
+
+			// Check if token is newer remotely
+			// TODO: Eventually would be nice to use an object
+			// hash or something to avoid fetching tokens that
+			// are unchanged.
+		} else if rp.ModifyIndex > minIndex {
+			update = append(update, rp.AccessorID)
+		}
+	}
+
+	// Check if local token should be deleted
+	for lp := range local {
+		if _, ok := remote[lp]; !ok {
+			delete = append(delete, lp)
+		}
+	}
+	return
 }

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -3,13 +3,16 @@ package nomad
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLeader_LeftServer(t *testing.T) {
@@ -614,4 +617,74 @@ func TestLeader_RestoreVaultAccessors(t *testing.T) {
 	if len(tvc.RevokedTokens) != 1 && tvc.RevokedTokens[0].Accessor != va.Accessor {
 		t.Fatalf("Bad revoked accessors: %v", tvc.RevokedTokens)
 	}
+}
+
+func TestLeader_ReplicateACLPolicies(t *testing.T) {
+	t.Parallel()
+	s1 := testServer(t, func(c *Config) {
+		c.Region = "region1"
+		c.AuthoritativeRegion = "region1"
+		c.ACLEnabled = true
+	})
+	defer s1.Shutdown()
+	s2 := testServer(t, func(c *Config) {
+		c.Region = "region2"
+		c.AuthoritativeRegion = "region1"
+		c.ACLEnabled = true
+		c.ReplicationBackoff = 20 * time.Millisecond
+	})
+	defer s2.Shutdown()
+	testJoin(t, s1, s2)
+	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForLeader(t, s2.RPC)
+
+	// Write a policy to the authoritative region
+	p1 := mock.ACLPolicy()
+	if err := s1.State().UpsertACLPolicies(100, []*structs.ACLPolicy{p1}); err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Wait for the policy to replicate
+	testutil.WaitForResult(func() (bool, error) {
+		state := s2.State()
+		out, err := state.ACLPolicyByName(nil, p1.Name)
+		return out != nil, err
+	}, func(err error) {
+		t.Fatalf("should replicate policy")
+	})
+}
+
+func TestLeader_DiffACLPolicies(t *testing.T) {
+	t.Parallel()
+
+	state, err := state.NewStateStore(os.Stderr)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Populate the local state
+	p1 := mock.ACLPolicy()
+	p2 := mock.ACLPolicy()
+	p3 := mock.ACLPolicy()
+	err = state.UpsertACLPolicies(100, []*structs.ACLPolicy{p1, p2, p3})
+	assert.Nil(t, err)
+
+	// Simulate a remote list
+	p2Stub := p2.Stub()
+	p2Stub.ModifyIndex = 50 // Ignored, same index
+	p3Stub := p3.Stub()
+	p3Stub.ModifyIndex = 100 // Updated, higher index
+	p4 := mock.ACLPolicy()
+	remoteList := []*structs.ACLPolicyListStub{
+		p2Stub,
+		p3Stub,
+		p4.Stub(),
+	}
+	delete, update := diffACLPolicies(state, 50, remoteList)
+
+	// P1 does not exist on the remote side, should delete
+	assert.Equal(t, []string{p1.Name}, delete)
+
+	// P2 is un-modified - ignore. P3 modified, P4 new.
+	assert.Equal(t, []string{p3.Name, p4.Name}, update)
 }

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -473,6 +473,14 @@ func aclTokenTableSchema() *memdb.TableSchema {
 					Field: "SecretID",
 				},
 			},
+			"global": &memdb.IndexSchema{
+				Name:         "global",
+				AllowMissing: false,
+				Unique:       false,
+				Indexer: &memdb.FieldSetIndex{
+					Field: "Global",
+				},
+			},
 		},
 	}
 }

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2955,6 +2955,19 @@ func (s *StateStore) ACLTokens(ws memdb.WatchSet) (memdb.ResultIterator, error) 
 	return iter, nil
 }
 
+// ACLTokensByGlobal returns an iterator over all the tokens filtered by global value
+func (s *StateStore) ACLTokensByGlobal(ws memdb.WatchSet, globalVal bool) (memdb.ResultIterator, error) {
+	txn := s.db.Txn(false)
+
+	// Walk the entire table
+	iter, err := txn.Get("acl_token", "global", globalVal)
+	if err != nil {
+		return nil, err
+	}
+	ws.Add(iter.WatchCh())
+	return iter, nil
+}
+
 // StateSnapshot is used to provide a point-in-time snapshot
 type StateSnapshot struct {
 	StateStore

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -6087,6 +6087,38 @@ func TestStateStore_RestoreACLPolicy(t *testing.T) {
 	assert.Equal(t, policy, out)
 }
 
+func TestStateStore_ACLTokensByGlobal(t *testing.T) {
+	state := testStateStore(t)
+	tk1 := mock.ACLToken()
+	tk2 := mock.ACLToken()
+	tk3 := mock.ACLToken()
+	tk4 := mock.ACLToken()
+	tk3.Global = true
+
+	if err := state.UpsertACLTokens(1000,
+		[]*structs.ACLToken{tk1, tk2, tk3, tk4}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	iter, err := state.ACLTokensByGlobal(nil, true)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure we see the one global policies
+	count := 0
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		count++
+	}
+	if count != 1 {
+		t.Fatalf("bad: %d", count)
+	}
+}
+
 func TestStateStore_RestoreACLToken(t *testing.T) {
 	state := testStateStore(t)
 	token := mock.ACLToken()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5390,6 +5390,7 @@ func (a *ACLToken) Validate() error {
 
 // ACLTokenListRequest is used to request a list of tokens
 type ACLTokenListRequest struct {
+	GlobalOnly bool
 	QueryOptions
 }
 


### PR DESCRIPTION
This PR builds on #3017. It adds the `acl` configuration block to the agent, and threads it through to the server. Upon acquiring leadership, non-authoritative regions will begin rate limited replication of ACL policies and global tokens. 

This does not yet handle proper region forwarding.