### PR TITLE
build: Apply goimports formatting to various files

### DIFF
--- a/command/agent/resources_endpoint.go
+++ b/command/agent/resources_endpoint.go
@@ -1,8 +1,9 @@
 package agent
 
 import (
-	"github.com/hashicorp/nomad/nomad/structs"
 	"net/http"
+
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // ResourceListRequest accepts a prefix and context and returns a list of matching

--- a/nomad/resources_endpoint.go
+++ b/nomad/resources_endpoint.go
@@ -2,6 +2,7 @@ package nomad
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"

--- a/nomad/resources_endpoint_test.go
+++ b/nomad/resources_endpoint_test.go
@@ -1,13 +1,14 @@
 package nomad
 
 import (
+	"strconv"
+	"testing"
+
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
-	"strconv"
-	"testing"
 )
 
 const jobIndex = 1000


### PR DESCRIPTION
The following files were not formatted as the output of goimports(1) would create, causing the goimports linter to fail:

- command/agent/resources_endpoint.go
- nomad/resources_endpoint.go
- nomad/resources_endpoint_test.go