### PR TITLE
Fix timeout validation for script checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ BUG FIXES:
  * cli: Fix panic when using 0.6.0 cli with an older cluster [GH-2929]
  * deployment: Fix alloc health with services/checks using interpolation
    [GH-2984]
+ * discovery: Fix timeout validation for script checks [GH-3022]
  * driver/docker: Fix leaking plugin file used by syslog server [GH-2937]
 
 ## 0.6.0 (July 26, 2017)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2696,28 +2696,15 @@ func (sc *ServiceCheck) Canonicalize(serviceName string) {
 func (sc *ServiceCheck) validate() error {
 	switch strings.ToLower(sc.Type) {
 	case ServiceCheckTCP:
-		if sc.Timeout == 0 {
-			return fmt.Errorf("missing required value timeout. Timeout cannot be less than %v", minCheckInterval)
-		} else if sc.Timeout < minCheckTimeout {
-			return fmt.Errorf("timeout (%v) is lower than required minimum timeout %v", sc.Timeout, minCheckInterval)
-		}
 	case ServiceCheckHTTP:
 		if sc.Path == "" {
 			return fmt.Errorf("http type must have a valid http path")
 		}
 
-		if sc.Timeout == 0 {
-			return fmt.Errorf("missing required value timeout. Timeout cannot be less than %v", minCheckInterval)
-		} else if sc.Timeout < minCheckTimeout {
-			return fmt.Errorf("timeout (%v) is lower than required minimum timeout %v", sc.Timeout, minCheckInterval)
-		}
 	case ServiceCheckScript:
 		if sc.Command == "" {
 			return fmt.Errorf("script type must have a valid script path")
 		}
-
-		// TODO: enforce timeout on the Client side and reenable
-		// validation.
 	default:
 		return fmt.Errorf(`invalid type (%+q), must be one of "http", "tcp", or "script" type`, sc.Type)
 	}
@@ -2726,6 +2713,12 @@ func (sc *ServiceCheck) validate() error {
 		return fmt.Errorf("missing required value interval. Interval cannot be less than %v", minCheckInterval)
 	} else if sc.Interval < minCheckInterval {
 		return fmt.Errorf("interval (%v) cannot be lower than %v", sc.Interval, minCheckInterval)
+	}
+
+	if sc.Timeout == 0 {
+		return fmt.Errorf("missing required value timeout. Timeout cannot be less than %v", minCheckInterval)
+	} else if sc.Timeout < minCheckTimeout {
+		return fmt.Errorf("timeout (%v) is lower than required minimum timeout %v", sc.Timeout, minCheckInterval)
 	}
 
 	switch sc.InitialStatus {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1084,6 +1084,18 @@ func TestTask_Validate_Services(t *testing.T) {
 
 func TestTask_Validate_Service_Check(t *testing.T) {
 
+	invalidCheck := ServiceCheck{
+		Name:     "check-name",
+		Command:  "/bin/true",
+		Type:     ServiceCheckScript,
+		Interval: 10 * time.Second,
+	}
+
+	err := invalidCheck.validate()
+	if err == nil || !strings.Contains(err.Error(), "Timeout cannot be less") {
+		t.Fatalf("expected a timeout validation error but received: %q", err)
+	}
+
 	check1 := ServiceCheck{
 		Name:     "check-name",
 		Type:     ServiceCheckTCP,
@@ -1091,8 +1103,7 @@ func TestTask_Validate_Service_Check(t *testing.T) {
 		Timeout:  2 * time.Second,
 	}
 
-	err := check1.validate()
-	if err != nil {
+	if err := check1.validate(); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 


### PR DESCRIPTION
It appears this was disabled a year ago when defaulting and validation
code was probably different: 91bbc5c3c769f4f17134dbc603ec677a178a9e9e

Fixes an issue reported via the mailing list:
https://groups.google.com/d/msg/nomad-tool/yiPCTfOpYn4/yv7MMPUABQAJ