### PR TITLE
Fix panic occuring from improper bitmap size

### DIFF
--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -264,7 +264,7 @@ func newAllocNameIndex(job, taskGroup string, count int, in allocSet) *allocName
 
 // bitmapFrom creates a bitmap from the given allocation set and a minimum size
 // maybe given. The size of the bitmap is as the larger of the passed minimum
-// and t the maximum alloc index of the passed input (byte aligned).
+// and the maximum alloc index of the passed input (byte alligned).
 func bitmapFrom(input allocSet, minSize uint) structs.Bitmap {
 	var max uint
 	for _, a := range input {
@@ -276,9 +276,16 @@ func bitmapFrom(input allocSet, minSize uint) structs.Bitmap {
 	if l := uint(len(input)); minSize < l {
 		minSize = l
 	}
+
 	if max < minSize {
 		max = minSize
+	} else if max > minSize && max%8 == 0 {
+		// This may be possible if the job was scaled down. We want to make sure
+		// that the max index is not byte-alligned otherwise we will overflow
+		// the bitmap.
+		max++
 	}
+
 	if max == 0 {
 		max = 8
 	}

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -264,7 +264,7 @@ func newAllocNameIndex(job, taskGroup string, count int, in allocSet) *allocName
 
 // bitmapFrom creates a bitmap from the given allocation set and a minimum size
 // maybe given. The size of the bitmap is as the larger of the passed minimum
-// and the maximum alloc index of the passed input (byte alligned).
+// and the maximum alloc index of the passed input (byte aligned).
 func bitmapFrom(input allocSet, minSize uint) structs.Bitmap {
 	var max uint
 	for _, a := range input {
@@ -279,7 +279,7 @@ func bitmapFrom(input allocSet, minSize uint) structs.Bitmap {
 
 	if max < minSize {
 		max = minSize
-	} else if max > minSize && max%8 == 0 {
+	} else if max%8 == 0 {
 		// This may be possible if the job was scaled down. We want to make sure
 		// that the max index is not byte-alligned otherwise we will overflow
 		// the bitmap.

--- a/scheduler/reconcile_util_test.go
+++ b/scheduler/reconcile_util_test.go
@@ -1,0 +1,26 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// Test that we properly create the bitmap even when the alloc set includes an
+// allocation with a higher count than the current min count and it is byte
+// alligned.
+// Ensure no regerssion from: https://github.com/hashicorp/nomad/issues/3008
+func TestBitmapFrom(t *testing.T) {
+	input := map[string]*structs.Allocation{
+		"8": {
+			JobID:     "foo",
+			TaskGroup: "bar",
+			Name:      "foo.bar[8]",
+		},
+	}
+	b := bitmapFrom(input, 1)
+	exp := uint(16)
+	if act := b.Size(); act != exp {
+		t.Fatalf("got %d; want %d", act, exp)
+	}
+}

--- a/scheduler/reconcile_util_test.go
+++ b/scheduler/reconcile_util_test.go
@@ -23,4 +23,9 @@ func TestBitmapFrom(t *testing.T) {
 	if act := b.Size(); act != exp {
 		t.Fatalf("got %d; want %d", act, exp)
 	}
+
+	b = bitmapFrom(input, 8)
+	if act := b.Size(); act != exp {
+		t.Fatalf("got %d; want %d", act, exp)
+	}
 }


### PR DESCRIPTION
This PR fixes an allignment calculation when determining the bitmap
size.

Fixes https://github.com/hashicorp/nomad/issues/3008