### PR TITLE
Deployment desc  when no stable job and autorevert

### DIFF
--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -257,6 +257,8 @@ func (w *deploymentWatcher) FailDeployment(
 
 		if rollbackJob != nil {
 			desc = structs.DeploymentStatusDescriptionRollback(desc, rollbackJob.Version)
+		} else {
+			desc = structs.DeploymentStatusDescriptionNoRollbackTarget(desc)
 		}
 	}
 
@@ -361,6 +363,8 @@ func (w *deploymentWatcher) watch() {
 				// version N
 				if j != nil {
 					desc = structs.DeploymentStatusDescriptionRollback(desc, j.Version)
+				} else {
+					desc = structs.DeploymentStatusDescriptionNoRollbackTarget(desc)
 				}
 			}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4117,6 +4117,12 @@ func DeploymentStatusDescriptionRollback(baseDescription string, jobVersion uint
 	return fmt.Sprintf("%s - rolling back to job version %d", baseDescription, jobVersion)
 }
 
+// DeploymentStatusDescriptionNoRollbackTarget is used to get the status description of
+// a deployment when there is no target to rollback to but autorevet is desired.
+func DeploymentStatusDescriptionNoRollbackTarget(baseDescription string) string {
+	return fmt.Sprintf("%s - no stable job version to auto revert to", baseDescription)
+}
+
 // Deployment is the object that represents a job deployment which is used to
 // transition a job between versions.
 type Deployment struct {


### PR DESCRIPTION
This PR adds a specialized description when the job has autorevert set
and there is no job to revert to.