### PR TITLE
Tab completion should only happen once

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 	"github.com/mitchellh/colorstring"
 
 	"github.com/hashicorp/nomad/api"
@@ -200,7 +200,12 @@ func (c *AllocStatusCommand) AutocompleteFlags() complete.Flags {
 
 func (c *AllocStatusCommand) AutocompleteArgs() complete.Predictor {
 	client, _ := c.Meta.Client()
+
 	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
 		resp, err := client.Search().PrefixSearch(a.Last, contexts.Allocs)
 		if err != nil {
 			return []string{}

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -183,4 +183,11 @@ func TestAllocStatusCommand_AutocompleteArgs(t *testing.T) {
 	res := predictor.Predict(args)
 	assert.Equal(1, len(res))
 	assert.Equal(allocID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "1", "2"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -227,6 +227,10 @@ func (c *EvalStatusCommand) AutocompleteFlags() complete.Flags {
 func (c *EvalStatusCommand) AutocompleteArgs() complete.Predictor {
 	client, _ := c.Meta.Client()
 	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
 		resp, err := client.Search().PrefixSearch(a.Last, contexts.Evals)
 		if err != nil {
 			return []string{}

--- a/command/eval_status_test.go
+++ b/command/eval_status_test.go
@@ -97,4 +97,11 @@ func TestEvalStatusCommand_AutocompleteArgs(t *testing.T) {
 	res := predictor.Predict(args)
 	assert.Equal(1, len(res))
 	assert.Equal(evalID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "1", "2"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -534,6 +534,10 @@ func (c *JobStatusCommand) AutocompleteFlags() complete.Flags {
 func (c *JobStatusCommand) AutocompleteArgs() complete.Predictor {
 	client, _ := c.Meta.Client()
 	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
 		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
 		if err != nil {
 			return []string{}

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -217,6 +217,14 @@ func TestJobStatusCommand_AutocompleteArgs(t *testing.T) {
 	res := predictor.Predict(args)
 	assert.Equal(1, len(res))
 	assert.Equal(jobID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	prefix = jobID[:len(jobID)-5]
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }
 
 func waitForSuccess(ui cli.Ui, client *api.Client, length int, t *testing.T, evalId string) int {

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -445,6 +445,10 @@ func (c *NodeStatusCommand) AutocompleteFlags() complete.Flags {
 func (c *NodeStatusCommand) AutocompleteArgs() complete.Predictor {
 	client, _ := c.Meta.Client()
 	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
 		resp, err := client.Search().PrefixSearch(a.Last, contexts.Nodes)
 		if err != nil {
 			return []string{}

--- a/command/node_status_test.go
+++ b/command/node_status_test.go
@@ -249,4 +249,11 @@ func TestNodeStatusCommand_AutocompleteArgs(t *testing.T) {
 	res := predictor.Predict(args)
 	assert.Equal(1, len(res))
 	assert.Equal(nodeID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "1", "2"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }


### PR DESCRIPTION
Currently, when autocompleting `job status`, `alloc-status`, `eval-status`, and `node-status`, the same autocomplete result will be repeated on each tab event. This ends up looking like: 

`nomad job status example example example`

This PR fixes this issue, limiting tab completion to one result. 