### PR TITLE
Fix purging job versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ IMPROVEMENTS:
    deregistering from Consul [GH-3043]
 
 BUG FIXES:
+ * core: Fix purging of job versions [GH-3056]
  * core: Fix race creating EvalFuture [GH-3051]
  * core: Fix panic occuring from improper bitmap size [GH-3023]
  * core: Fix restoration of parameterized, periodic jobs [GH-2959]

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -737,7 +737,7 @@ func (s *StateStore) deleteJobVersions(index uint64, job *structs.Job, txn *memd
 			continue
 		}
 
-		if _, err = txn.DeleteAll("job_version", "id", job.ID, job.Version); err != nil {
+		if _, err = txn.DeleteAll("job_version", "id", j.ID, j.Version); err != nil {
 			return fmt.Errorf("deleting job versions failed: %v", err)
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue in which the job versions weren't properly
cleaned when removing a job.

Fixes https://github.com/hashicorp/nomad/issues/3052