### PR TITLE
Added metrics to track task/alloc start/restarts/dead events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 IMPROVEMENTS:
  * api: Allocations now track and return modify time in addition to create time.
- * cli: Allocation create and modify times are displayed in a human readable relative format like `6 h ago`.
+ * cli: Allocation create and modify times are displayed in a human readable 
+   relative format like `6 h ago`.
  * core: Allow agents to be run in `rpc_upgrade_mode` when migrating a cluster
    to TLS rather than changing `heartbeat_grace`.
+ * client: Added metrics to track state transitions of allocations [GH-3061]
 
 BUG FIXES:
 

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -188,6 +188,10 @@ func NewAllocRunner(logger *log.Logger, config *config.Config, stateDB *bolt.DB,
 			Name:  "task_group",
 			Value: alloc.TaskGroup,
 		},
+		{
+			Name:  "node_id",
+			Value: ar.config.Node.ID,
+		},
 	}
 
 	return ar

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -675,7 +675,6 @@ func (r *AllocRunner) setTaskState(taskName, state string, event *structs.TaskEv
 	case structs.TaskStateDead:
 		// Capture the finished time. If it has never started there is no finish
 		// time
-		metrics.IncrCounter([]string{"client", "allocs", r.alloc.Job.Name, r.alloc.TaskGroup, taskName, "dead"}, 1)
 		if !taskState.StartedAt.IsZero() {
 			taskState.FinishedAt = time.Now().UTC()
 		}
@@ -750,9 +749,6 @@ func (r *AllocRunner) Run() {
 	defer close(r.waitCh)
 	go r.dirtySyncState()
 
-	// Increment alloc runner start counter. Incr'd even when restoring existing tasks so 1 start != 1 task execution
-	metrics.IncrCounter([]string{"client", "allocs", r.alloc.Job.Name, r.alloc.TaskGroup, "start"}, 1)
-
 	// Find the task group to run in the allocation
 	alloc := r.Alloc()
 	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
@@ -806,6 +802,9 @@ func (r *AllocRunner) Run() {
 		r.logger.Printf("[DEBUG] client: terminating runner for alloc '%s'", r.allocID)
 		return
 	}
+
+	// Increment alloc runner start counter. Incr'd even when restoring existing tasks so 1 start != 1 task execution
+	metrics.IncrCounter([]string{"client", "allocs", r.alloc.Job.Name, r.alloc.TaskGroup, "start"}, 1)
 
 	// Start the watcher
 	wCtx, watcherCancel := context.WithCancel(r.ctx)

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	metrics "github.com/armon/go-metrics"
 	"github.com/boltdb/bolt"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/allocdir"
@@ -645,6 +646,7 @@ func (r *AllocRunner) setTaskState(taskName, state string, event *structs.TaskEv
 			taskState.Failed = true
 		}
 		if event.Type == structs.TaskRestarting {
+			metrics.IncrCounter([]string{"client", "allocs", r.alloc.Job.Name, r.alloc.TaskGroup, taskName, "restart"}, 1)
 			taskState.Restarts++
 			taskState.LastRestart = time.Unix(0, event.Time)
 		}
@@ -668,12 +670,14 @@ func (r *AllocRunner) setTaskState(taskName, state string, event *structs.TaskEv
 		// Capture the start time if it is just starting
 		if taskState.State != structs.TaskStateRunning {
 			taskState.StartedAt = time.Now().UTC()
+			metrics.IncrCounter([]string{"client", "allocs", r.alloc.Job.Name, r.alloc.TaskGroup, taskName, "running"}, 1)
 		}
 	case structs.TaskStateDead:
 		// Capture the finished time. If it has never started there is no finish
 		// time
 		if !taskState.StartedAt.IsZero() {
 			taskState.FinishedAt = time.Now().UTC()
+			metrics.IncrCounter([]string{"client", "allocs", r.alloc.Job.Name, r.alloc.TaskGroup, taskName, "dead"}, 1)
 		}
 
 		// Find all tasks that are not the one that is dead and check if the one
@@ -739,6 +743,9 @@ func (r *AllocRunner) appendTaskEvent(state *structs.TaskState, event *structs.T
 func (r *AllocRunner) Run() {
 	defer close(r.waitCh)
 	go r.dirtySyncState()
+
+	// Incr alloc runner start counter
+	metrics.IncrCounter([]string{"client", "allocs", r.alloc.Job.Name, r.alloc.TaskGroup, "start"}, 1)
 
 	// Find the task group to run in the allocation
 	alloc := r.Alloc()
@@ -921,6 +928,14 @@ func (r *AllocRunner) handleDestroy() {
 	// Final state sync. We do this to ensure that the server has the correct
 	// state as we wait for a destroy.
 	alloc := r.Alloc()
+
+	// Incr the alloc destroy counter
+	metrics.IncrCounter([]string{"client", "allocs", r.alloc.Job.Name, r.alloc.TaskGroup, "destroy"}, 1)
+
+	//TODO(schmichael) updater can cause a GC which can block on this alloc
+	// runner shutting down. Since handleDestroy can be called by Run() we
+	// can't block shutdown here as it would cause a deadlock.
+	go r.updater(alloc)
 
 	// Broadcast and persist state synchronously
 	r.sendBroadcast(alloc)

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -419,6 +419,48 @@ Starting in version 0.7, Nomad will emit tagged metrics, in the below format:
     <td>Gauge</td>
     <td>node_id, datacenter, disk</td>
   </tr>
+  <tr>
+    <td>`nomad.client.allocs.start`</td>
+    <td>Number of allocations starting</td>
+    <td>Integer</td>
+    <td>Counter</td>
+    <td>job, task_group</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.allocs.running`</td>
+    <td>Number of allocations starting to run</td>
+    <td>Integer</td>
+    <td>Counter</td>
+    <td>job, task_group</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.allocs.failed`</td>
+    <td>Number of allocations failing</td>
+    <td>Integer</td>
+    <td>Counter</td>
+    <td>job, task_group</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.allocs.restart`</td>
+    <td>Number of allocations restarting</td>
+    <td>Integer</td>
+    <td>Counter</td>
+    <td>job, task_group</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.allocs.complete`</td>
+    <td>Number of allocations completing</td>
+    <td>Integer</td>
+    <td>Counter</td>
+    <td>job, task_group</td>
+  </tr>
+  <tr>
+    <td>`nomad.client.allocs.destroy`</td>
+    <td>Number of allocations being destroyed</td>
+    <td>Integer</td>
+    <td>Counter</td>
+    <td>job, task_group</td>
+  </tr>
 </table>
 
 ## Host Metrics (deprecated post Nomad 0.7)

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -424,42 +424,42 @@ Starting in version 0.7, Nomad will emit tagged metrics, in the below format:
     <td>Number of allocations starting</td>
     <td>Integer</td>
     <td>Counter</td>
-    <td>job, task_group</td>
+    <td>node_id, job, task_group</td>
   </tr>
   <tr>
     <td>`nomad.client.allocs.running`</td>
     <td>Number of allocations starting to run</td>
     <td>Integer</td>
     <td>Counter</td>
-    <td>job, task_group</td>
+    <td>node_id, job, task_group</td>
   </tr>
   <tr>
     <td>`nomad.client.allocs.failed`</td>
     <td>Number of allocations failing</td>
     <td>Integer</td>
     <td>Counter</td>
-    <td>job, task_group</td>
+    <td>node_id, job, task_group</td>
   </tr>
   <tr>
     <td>`nomad.client.allocs.restart`</td>
     <td>Number of allocations restarting</td>
     <td>Integer</td>
     <td>Counter</td>
-    <td>job, task_group</td>
+    <td>node_id, job, task_group</td>
   </tr>
   <tr>
     <td>`nomad.client.allocs.complete`</td>
     <td>Number of allocations completing</td>
     <td>Integer</td>
     <td>Counter</td>
-    <td>job, task_group</td>
+    <td>node_id, job, task_group</td>
   </tr>
   <tr>
     <td>`nomad.client.allocs.destroy`</td>
     <td>Number of allocations being destroyed</td>
     <td>Integer</td>
     <td>Counter</td>
-    <td>job, task_group</td>
+    <td>node_id, job, task_group</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Fixes #3060 

There could be better places to track the task state changes and increment counters. The task_runner and allocation runner code has changed a lot since I last touched them, so please suggest what's the best place to do this.

I didn't add the allocation ID to the metrics here since alloc IDs are unique and I think these metrics are more interesting for debugging cluster-wide problems than seeing what's happening with an individual allocation. People can always group the metrics by node IDs to get a sense of any node level outliers for restarts across racks and clusters. 

cc/ @dadgar @schmichael 