### PR TITLE
Adding Server-side ACL token resolution logic

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -204,3 +204,8 @@ func (a *ACL) AllowOperatorWrite() bool {
 		return false
 	}
 }
+
+// IsManagement checks if this represents a management token
+func (a *ACL) IsManagement() bool {
+	return a.management
+}

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -1,8 +1,21 @@
 package acl
 
 import (
+	"fmt"
+
 	iradix "github.com/hashicorp/go-immutable-radix"
 )
+
+// ManagementACL is a singleton used for management tokens
+var ManagementACL *ACL
+
+func init() {
+	var err error
+	ManagementACL, err = NewACL(true, nil)
+	if err != nil {
+		panic(fmt.Errorf("failed to setup management ACL: %v", err))
+	}
+}
 
 // capabilitySet is a type wrapper to help managing a set of capabilities
 type capabilitySet map[string]struct{}

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -72,6 +72,7 @@ func TestACLManagement(t *testing.T) {
 	assert.Equal(t, true, acl.AllowNamespaceOperation("foo", NamespaceCapabilityListJobs))
 
 	// Check the other simpler operations
+	assert.Equal(t, true, acl.IsManagement())
 	assert.Equal(t, true, acl.AllowAgentRead())
 	assert.Equal(t, true, acl.AllowAgentWrite())
 	assert.Equal(t, true, acl.AllowNodeRead())
@@ -97,6 +98,7 @@ func TestACLMerge(t *testing.T) {
 	assert.Equal(t, false, acl.AllowNamespaceOperation("foo", NamespaceCapabilityListJobs))
 
 	// Check the other simpler operations
+	assert.Equal(t, false, acl.IsManagement())
 	assert.Equal(t, true, acl.AllowAgentRead())
 	assert.Equal(t, true, acl.AllowAgentWrite())
 	assert.Equal(t, true, acl.AllowNodeRead())
@@ -118,6 +120,7 @@ func TestACLMerge(t *testing.T) {
 	assert.Equal(t, false, acl.AllowNamespaceOperation("foo", NamespaceCapabilityListJobs))
 
 	// Check the other simpler operations
+	assert.Equal(t, false, acl.IsManagement())
 	assert.Equal(t, true, acl.AllowAgentRead())
 	assert.Equal(t, false, acl.AllowAgentWrite())
 	assert.Equal(t, true, acl.AllowNodeRead())
@@ -139,6 +142,7 @@ func TestACLMerge(t *testing.T) {
 	assert.Equal(t, false, acl.AllowNamespaceOperation("foo", NamespaceCapabilityListJobs))
 
 	// Check the other simpler operations
+	assert.Equal(t, false, acl.IsManagement())
 	assert.Equal(t, false, acl.AllowAgentRead())
 	assert.Equal(t, false, acl.AllowAgentWrite())
 	assert.Equal(t, false, acl.AllowNodeRead())

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -940,7 +940,7 @@ func isTooManyColons(err error) bool {
 	return err != nil && strings.Contains(err.Error(), tooManyColons)
 }
 
-// Merge is used to merge two ACL configs together
+// Merge is used to merge two ACL configs together. The settings from the input always take precedence.
 func (a *ACLConfig) Merge(b *ACLConfig) *ACLConfig {
 	result := *a
 

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -1,0 +1,121 @@
+package nomad
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+var (
+	// tokenNotFound indicates the Token was not found
+	tokenNotFound = errors.New("ACL token not found")
+
+	// managementACL is used for all management tokens
+	managementACL *acl.ACL
+)
+
+func init() {
+	// managementACL has management flag enabled
+	var err error
+	managementACL, err = acl.NewACL(true, nil)
+	if err != nil {
+		panic(fmt.Errorf("failed to setup management ACL: %v", err))
+	}
+}
+
+// resolveToken is used to translate an ACL Token Secret ID into
+// an ACL object, nil if ACLs are disabled, or an error.
+func (s *Server) resolveToken(secretID string) (*acl.ACL, error) {
+	// Fast-path if ACLs are disabled
+	if !s.config.ACLEnabled {
+		return nil, nil
+	}
+	defer metrics.MeasureSince([]string{"nomad", "acl", "resolveToken"}, time.Now())
+
+	// Snapshot the state
+	snap, err := s.fsm.State().Snapshot()
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve the ACL
+	return resolveTokenFromSnapshotCache(snap, s.aclCache, secretID)
+}
+
+// resolveTokenFromSnapshotCache is used to resolve an ACL object from a snapshot of state,
+// using a cache to avoid parsing and ACL construction when possible. It is split from resolveToken
+// to simplify testing.
+func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *lru.TwoQueueCache, secretID string) (*acl.ACL, error) {
+	// Lookup the ACL Token
+	token, err := snap.ACLTokenBySecretID(nil, secretID)
+	if err != nil {
+		return nil, err
+	}
+	if token == nil {
+		return nil, tokenNotFound
+	}
+
+	// Check if this is a management token
+	if token.Type == structs.ACLManagementToken {
+		return managementACL, nil
+	}
+
+	// Get all associated policies
+	policies := make([]*structs.ACLPolicy, 0, len(token.Policies))
+	cacheKeyHash := sha1.New()
+	for _, policyName := range token.Policies {
+		policy, err := snap.ACLPolicyByName(nil, policyName)
+		if err != nil {
+			return nil, err
+		}
+		if policy == nil {
+			// Ignore policies that don't exist, since they don't grant any more privilege
+			continue
+		}
+
+		// Save the policy and update the cache key
+		policies = append(policies, policy)
+
+		// Update the cache key using (policy name, modify index).
+		// This ensures any updates to the policy cause the cache to be busted.
+		cacheKeyHash.Write([]byte(policyName))
+		binary.Write(cacheKeyHash, binary.BigEndian, policy.ModifyIndex)
+	}
+
+	// Finalize the cache key and check for a match
+	cacheKey := string(cacheKeyHash.Sum(nil))
+	aclRaw, ok := cache.Get(cacheKey)
+	if ok {
+		return aclRaw.(*acl.ACL), nil
+	}
+
+	// Parse the policies
+	parsed := make([]*acl.Policy, 0, len(policies))
+	for _, policy := range policies {
+		p, err := acl.Parse(policy.Rules)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %q: %v", policy.Name, err)
+		}
+		parsed = append(parsed, p)
+	}
+
+	// Create the ACL object
+	aclObj, err := acl.NewACL(false, parsed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct ACL: %v", err)
+	}
+
+	// Update the cache
+	cache.Add(cacheKey, aclObj)
+
+	// Return the ACL object
+	return aclObj, nil
+}

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -3,7 +3,6 @@ package nomad
 import (
 	"crypto/sha1"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"time"
 
@@ -13,23 +12,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
-
-var (
-	// tokenNotFound indicates the Token was not found
-	tokenNotFound = errors.New("ACL token not found")
-
-	// managementACL is used for all management tokens
-	managementACL *acl.ACL
-)
-
-func init() {
-	// managementACL has management flag enabled
-	var err error
-	managementACL, err = acl.NewACL(true, nil)
-	if err != nil {
-		panic(fmt.Errorf("failed to setup management ACL: %v", err))
-	}
-}
 
 // resolveToken is used to translate an ACL Token Secret ID into
 // an ACL object, nil if ACLs are disabled, or an error.
@@ -60,12 +42,12 @@ func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *lru.TwoQueu
 		return nil, err
 	}
 	if token == nil {
-		return nil, tokenNotFound
+		return nil, structs.TokenNotFound
 	}
 
 	// Check if this is a management token
 	if token.Type == structs.ACLManagementToken {
-		return managementACL, nil
+		return acl.ManagementACL, nil
 	}
 
 	// Get all associated policies

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -108,6 +108,9 @@ func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.AC
 			if err != nil {
 				return err
 			}
+
+			// Ensure we never set the index to zero, otherwise a blocking query cannot be used.
+			// We floor the index at one, since realistically the first write must have a higher index.
 			if index == 0 {
 				index = 1
 			}

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -38,7 +38,7 @@ func TestResolveACLToken(t *testing.T) {
 	// Attempt resolution of unknown token. Should fail.
 	randID := structs.GenerateUUID()
 	aclObj, err := resolveTokenFromSnapshotCache(snap, cache, randID)
-	assert.Equal(t, tokenNotFound, err)
+	assert.Equal(t, structs.TokenNotFound, err)
 	assert.Nil(t, aclObj)
 
 	// Attempt resolution of management token. Should get singleton.
@@ -46,7 +46,7 @@ func TestResolveACLToken(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, aclObj)
 	assert.Equal(t, true, aclObj.IsManagement())
-	if aclObj != managementACL {
+	if aclObj != acl.ManagementACL {
 		t.Fatalf("expected singleton")
 	}
 

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -1,0 +1,86 @@
+package nomad
+
+import (
+	"os"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveACLToken(t *testing.T) {
+	// Create mock state store and cache
+	state, err := state.NewStateStore(os.Stderr)
+	assert.Nil(t, err)
+	cache, err := lru.New2Q(16)
+	assert.Nil(t, err)
+
+	// Create a policy / token
+	policy := mock.ACLPolicy()
+	policy2 := mock.ACLPolicy()
+	token := mock.ACLToken()
+	token.Policies = []string{policy.Name, policy2.Name}
+	token2 := mock.ACLToken()
+	token2.Type = structs.ACLManagementToken
+	token2.Policies = nil
+	err = state.UpsertACLPolicies(100, []*structs.ACLPolicy{policy, policy2})
+	assert.Nil(t, err)
+	err = state.UpsertACLTokens(110, []*structs.ACLToken{token, token2})
+	assert.Nil(t, err)
+
+	snap, err := state.Snapshot()
+	assert.Nil(t, err)
+
+	// Attempt resolution of unknown token. Should fail.
+	randID := structs.GenerateUUID()
+	aclObj, err := resolveTokenFromSnapshotCache(snap, cache, randID)
+	assert.Equal(t, tokenNotFound, err)
+	assert.Nil(t, aclObj)
+
+	// Attempt resolution of management token. Should get singleton.
+	aclObj, err = resolveTokenFromSnapshotCache(snap, cache, token2.SecretID)
+	assert.Nil(t, err)
+	assert.NotNil(t, aclObj)
+	assert.Equal(t, true, aclObj.IsManagement())
+	if aclObj != managementACL {
+		t.Fatalf("expected singleton")
+	}
+
+	// Attempt resolution of client token
+	aclObj, err = resolveTokenFromSnapshotCache(snap, cache, token.SecretID)
+	assert.Nil(t, err)
+	assert.NotNil(t, aclObj)
+
+	// Check that the ACL object is sane
+	assert.Equal(t, false, aclObj.IsManagement())
+	allowed := aclObj.AllowNamespaceOperation("default", acl.NamespaceCapabilityListJobs)
+	assert.Equal(t, true, allowed)
+	allowed = aclObj.AllowNamespaceOperation("other", acl.NamespaceCapabilityListJobs)
+	assert.Equal(t, false, allowed)
+
+	// Resolve the same token again, should get cache value
+	aclObj2, err := resolveTokenFromSnapshotCache(snap, cache, token.SecretID)
+	assert.Nil(t, err)
+	assert.NotNil(t, aclObj2)
+	if aclObj != aclObj2 {
+		t.Fatalf("expected cached value")
+	}
+
+	// Bust the cache by upserting the policy
+	err = state.UpsertACLPolicies(120, []*structs.ACLPolicy{policy})
+	assert.Nil(t, err)
+	snap, err = state.Snapshot()
+	assert.Nil(t, err)
+
+	// Resolve the same token again, should get different value
+	aclObj3, err := resolveTokenFromSnapshotCache(snap, cache, token.SecretID)
+	assert.Nil(t, err)
+	assert.NotNil(t, aclObj3)
+	if aclObj == aclObj3 {
+		t.Fatalf("unexpected cached value")
+	}
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5330,6 +5330,9 @@ type ACLPolicyUpsertRequest struct {
 	WriteRequest
 }
 
+// TokenNotFound indicates the Token was not found
+var TokenNotFound = errors.New("ACL token not found")
+
 // ACLToken represents a client token which is used to Authenticate
 type ACLToken struct {
 	AccessorID  string    // Public Accessor ID (UUID)
@@ -5342,6 +5345,18 @@ type ACLToken struct {
 	CreateIndex uint64
 	ModifyIndex uint64
 }
+
+var (
+	// AnonymousACLToken is used no SecretID is provided, and the
+	// request is made anonymously.
+	AnonymousACLToken = &ACLToken{
+		AccessorID: "anonymous",
+		Name:       "Anonymous Token",
+		Type:       ACLClientToken,
+		Policies:   []string{"anonymous"},
+		Global:     false,
+	}
+)
 
 type ACLTokenListStub struct {
 	AccessorID  string


### PR DESCRIPTION
This PR adds the `Server.resolveToken` method which is used to do resolution of ACL objects. This is the basis for doing endpoint enforcement.