### PR TITLE
Adds client-side ACL resolution logic.

### DIFF
--- a/client/acl.go
+++ b/client/acl.go
@@ -1,0 +1,165 @@
+package client
+
+import (
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// cachedACLValue is used to manage ACL Token or Policy TTLs
+type cachedACLValue struct {
+	Token     *structs.ACLToken
+	Policy    *structs.ACLPolicy
+	CacheTime time.Time
+}
+
+// Age is the time since the token was cached
+func (c *cachedACLValue) Age() time.Duration {
+	return time.Now().Sub(c.CacheTime)
+}
+
+// resolveToken is used to translate an ACL Token Secret ID into
+// an ACL object, nil if ACLs are disabled, or an error.
+func (c *Client) resolveToken(secretID string) (*acl.ACL, error) {
+	// Fast-path if ACLs are disabled
+	if !c.config.ACLEnabled {
+		return nil, nil
+	}
+	defer metrics.MeasureSince([]string{"client", "acl", "resolveToken"}, time.Now())
+
+	// Resolve the token value
+	token, err := c.resolveTokenValue(secretID)
+	if err != nil {
+		return nil, err
+	}
+	if token == nil {
+		return nil, structs.TokenNotFound
+	}
+
+	// Check if this is a management token
+	if token.Type == structs.ACLManagementToken {
+		return acl.ManagementACL, nil
+	}
+
+	// Resolve the policies
+	policies, err := c.resolvePolicies(token.Policies)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve the ACL object
+	aclObj, err := structs.CompileACLObject(c.aclCache, policies)
+	if err != nil {
+		return nil, err
+	}
+	return aclObj, nil
+}
+
+// resolveTokenValue is used to translate a secret ID into an ACL token with caching
+// We use a local cache up to the TTL limit, and then resolve via a server. If we cannot
+// reach a server, but have a cached value we extend the TTL to gracefully handle outages.
+func (c *Client) resolveTokenValue(secretID string) (*structs.ACLToken, error) {
+	// Hot-path the anonymous token
+	if secretID == "" {
+		return structs.AnonymousACLToken, nil
+	}
+
+	// Lookup the token in the cache
+	raw, ok := c.tokenCache.Get(secretID)
+	if ok {
+		cached := raw.(*cachedACLValue)
+		if cached.Age() <= c.config.ACLTokenTTL {
+			return cached.Token, nil
+		}
+	}
+
+	// Lookup the token
+	req := structs.ResolveACLTokenRequest{
+		SecretID:     secretID,
+		QueryOptions: structs.QueryOptions{Region: c.Region()},
+	}
+	var resp structs.ResolveACLTokenResponse
+	if err := c.RPC("ACL.ResolveToken", &req, &resp); err != nil {
+		// If we encounter an error but have a cached value, mask the error and extend the cache
+		if ok {
+			c.logger.Printf("[WARN] client: failed to resolve token, using expired cached value: %v", err)
+			cached := raw.(*cachedACLValue)
+			return cached.Token, nil
+		}
+		return nil, err
+	}
+
+	// Cache the response (positive or negative)
+	c.tokenCache.Add(secretID, &cachedACLValue{
+		Token:     resp.Token,
+		CacheTime: time.Now(),
+	})
+	return resp.Token, nil
+}
+
+// resolvePolicies is used to translate a set of named ACL policies into the objects.
+// We cache the policies locally, and fault them from a server as necessary. Policies
+// are cached for a TTL, and then refreshed. If a server cannot be reached, the cache TTL
+// will be ignored to gracefully handle outages.
+func (c *Client) resolvePolicies(policies []string) ([]*structs.ACLPolicy, error) {
+	var out []*structs.ACLPolicy
+	var expired []*structs.ACLPolicy
+	var missing []string
+
+	// Scan the cache for each policy
+	for _, policyName := range policies {
+		// Lookup the policy in the cache
+		raw, ok := c.policyCache.Get(policyName)
+		if !ok {
+			missing = append(missing, policyName)
+			continue
+		}
+
+		// Check if the cached value is valid or expired
+		cached := raw.(*cachedACLValue)
+		if cached.Age() <= c.config.ACLPolicyTTL {
+			out = append(out, cached.Policy)
+		} else {
+			expired = append(expired, cached.Policy)
+		}
+	}
+
+	// Hot-path if we have no missing or expired policies
+	if len(missing)+len(expired) == 0 {
+		return out, nil
+	}
+
+	// Lookup the missing and expired policies
+	fetch := missing
+	for _, p := range expired {
+		fetch = append(fetch, p.Name)
+	}
+	req := structs.ACLPolicySetRequest{
+		Names:        fetch,
+		QueryOptions: structs.QueryOptions{Region: c.Region()},
+	}
+	var resp structs.ACLPolicySetResponse
+	if err := c.RPC("ACL.GetPolicies", &req, &resp); err != nil {
+		// If we encounter an error but have cached policies, mask the error and extend the cache
+		if len(missing) == 0 {
+			c.logger.Printf("[WARN] client: failed to resolve policies, using expired cached value: %v", err)
+			out = append(out, expired...)
+			return out, nil
+		}
+		return nil, err
+	}
+
+	// Handle each output
+	for _, policy := range resp.Policies {
+		c.policyCache.Add(policy.Name, &cachedACLValue{
+			Policy:    policy,
+			CacheTime: time.Now(),
+		})
+		out = append(out, policy)
+	}
+
+	// Return the valid policies
+	return out, nil
+}

--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -98,7 +98,7 @@ func TestClient_ACL_resolvePolicies(t *testing.T) {
 	}
 }
 
-func TestClient_ACL_resolveToken_Disabled(t *testing.T) {
+func TestClient_ACL_ResolveToken_Disabled(t *testing.T) {
 	s1, _ := testServer(t, nil)
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
@@ -109,12 +109,12 @@ func TestClient_ACL_resolveToken_Disabled(t *testing.T) {
 	defer c1.Shutdown()
 
 	// Should always get nil when disabled
-	aclObj, err := c1.resolveToken("blah")
+	aclObj, err := c1.ResolveToken("blah")
 	assert.Nil(t, err)
 	assert.Nil(t, aclObj)
 }
 
-func TestClient_ACL_resolveToken(t *testing.T) {
+func TestClient_ACL_ResolveToken(t *testing.T) {
 	s1, _ := testServer(t, nil)
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
@@ -139,26 +139,26 @@ func TestClient_ACL_resolveToken(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test the client resolution
-	out, err := c1.resolveToken(token.SecretID)
+	out, err := c1.ResolveToken(token.SecretID)
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
 
 	// Test caching
-	out2, err := c1.resolveToken(token.SecretID)
+	out2, err := c1.ResolveToken(token.SecretID)
 	assert.Nil(t, err)
 	if out != out2 {
 		t.Fatalf("should be cached")
 	}
 
 	// Test management token
-	out3, err := c1.resolveToken(token2.SecretID)
+	out3, err := c1.ResolveToken(token2.SecretID)
 	assert.Nil(t, err)
 	if acl.ManagementACL != out3 {
 		t.Fatalf("should be management")
 	}
 
 	// Test bad token
-	out4, err := c1.resolveToken(structs.GenerateUUID())
+	out4, err := c1.ResolveToken(structs.GenerateUUID())
 	assert.Equal(t, structs.TokenNotFound, err)
 	assert.Nil(t, out4)
 }

--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -1,0 +1,164 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_ACL_resolveTokenValue(t *testing.T) {
+	s1, _ := testServer(t, nil)
+	defer s1.Shutdown()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1 := testClient(t, func(c *config.Config) {
+		c.RPCHandler = s1
+	})
+	defer c1.Shutdown()
+
+	// Create a policy / token
+	policy := mock.ACLPolicy()
+	policy2 := mock.ACLPolicy()
+	token := mock.ACLToken()
+	token.Policies = []string{policy.Name, policy2.Name}
+	token2 := mock.ACLToken()
+	token2.Type = structs.ACLManagementToken
+	token2.Policies = nil
+	err := s1.State().UpsertACLPolicies(100, []*structs.ACLPolicy{policy, policy2})
+	assert.Nil(t, err)
+	err = s1.State().UpsertACLTokens(110, []*structs.ACLToken{token, token2})
+	assert.Nil(t, err)
+
+	// Test the client resolution
+	out0, err := c1.resolveTokenValue("")
+	assert.Nil(t, err)
+	assert.NotNil(t, out0)
+	assert.Equal(t, structs.AnonymousACLToken, out0)
+
+	// Test the client resolution
+	out1, err := c1.resolveTokenValue(token.SecretID)
+	assert.Nil(t, err)
+	assert.NotNil(t, out1)
+	assert.Equal(t, token, out1)
+
+	out2, err := c1.resolveTokenValue(token2.SecretID)
+	assert.Nil(t, err)
+	assert.NotNil(t, out2)
+	assert.Equal(t, token2, out2)
+
+	out3, err := c1.resolveTokenValue(token.SecretID)
+	assert.Nil(t, err)
+	assert.NotNil(t, out3)
+	if out1 != out3 {
+		t.Fatalf("bad caching")
+	}
+}
+
+func TestClient_ACL_resolvePolicies(t *testing.T) {
+	s1, _ := testServer(t, nil)
+	defer s1.Shutdown()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1 := testClient(t, func(c *config.Config) {
+		c.RPCHandler = s1
+	})
+	defer c1.Shutdown()
+
+	// Create a policy / token
+	policy := mock.ACLPolicy()
+	policy2 := mock.ACLPolicy()
+	token := mock.ACLToken()
+	token.Policies = []string{policy.Name, policy2.Name}
+	token2 := mock.ACLToken()
+	token2.Type = structs.ACLManagementToken
+	token2.Policies = nil
+	err := s1.State().UpsertACLPolicies(100, []*structs.ACLPolicy{policy, policy2})
+	assert.Nil(t, err)
+	err = s1.State().UpsertACLTokens(110, []*structs.ACLToken{token, token2})
+	assert.Nil(t, err)
+
+	// Test the client resolution
+	out, err := c1.resolvePolicies([]string{policy.Name, policy2.Name})
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(out))
+
+	// Test caching
+	out2, err := c1.resolvePolicies([]string{policy.Name, policy2.Name})
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(out2))
+
+	// Check we get the same objects back (ignore ordering)
+	if out[0] != out2[0] && out[0] != out2[1] {
+		t.Fatalf("bad caching")
+	}
+}
+
+func TestClient_ACL_resolveToken_Disabled(t *testing.T) {
+	s1, _ := testServer(t, nil)
+	defer s1.Shutdown()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1 := testClient(t, func(c *config.Config) {
+		c.RPCHandler = s1
+	})
+	defer c1.Shutdown()
+
+	// Should always get nil when disabled
+	aclObj, err := c1.resolveToken("blah")
+	assert.Nil(t, err)
+	assert.Nil(t, aclObj)
+}
+
+func TestClient_ACL_resolveToken(t *testing.T) {
+	s1, _ := testServer(t, nil)
+	defer s1.Shutdown()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1 := testClient(t, func(c *config.Config) {
+		c.RPCHandler = s1
+		c.ACLEnabled = true
+	})
+	defer c1.Shutdown()
+
+	// Create a policy / token
+	policy := mock.ACLPolicy()
+	policy2 := mock.ACLPolicy()
+	token := mock.ACLToken()
+	token.Policies = []string{policy.Name, policy2.Name}
+	token2 := mock.ACLToken()
+	token2.Type = structs.ACLManagementToken
+	token2.Policies = nil
+	err := s1.State().UpsertACLPolicies(100, []*structs.ACLPolicy{policy, policy2})
+	assert.Nil(t, err)
+	err = s1.State().UpsertACLTokens(110, []*structs.ACLToken{token, token2})
+	assert.Nil(t, err)
+
+	// Test the client resolution
+	out, err := c1.resolveToken(token.SecretID)
+	assert.Nil(t, err)
+	assert.NotNil(t, out)
+
+	// Test caching
+	out2, err := c1.resolveToken(token.SecretID)
+	assert.Nil(t, err)
+	if out != out2 {
+		t.Fatalf("should be cached")
+	}
+
+	// Test management token
+	out3, err := c1.resolveToken(token2.SecretID)
+	assert.Nil(t, err)
+	if acl.ManagementACL != out3 {
+		t.Fatalf("should be management")
+	}
+
+	// Test bad token
+	out4, err := c1.resolveToken(structs.GenerateUUID())
+	assert.Equal(t, structs.TokenNotFound, err)
+	assert.Nil(t, out4)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -20,6 +20,7 @@ import (
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/go-multierror"
+	lru "github.com/hashicorp/golang-lru"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
@@ -80,6 +81,14 @@ const (
 	// allocSyncRetryIntv is the interval on which we retry updating
 	// the status of the allocation
 	allocSyncRetryIntv = 5 * time.Second
+
+	// policyCacheSize is the number of ACL policies to keep cached. Policies have a fetching cost
+	// cost, so we keep the hot policies cached to reduce the ACL token resolution time.
+	policyCacheSize = 64
+
+	// aclCacheSize is the number of ACL objects to keep cached. ACLs have a parsing and
+	// construction cost, so we keep the hot objects cached to reduce the ACL token resolution time.
+	aclCacheSize = 64
 )
 
 // ClientStatsReporter exposes all the APIs related to resource usage of a Nomad
@@ -162,6 +171,12 @@ type Client struct {
 	// garbageCollector is used to garbage collect terminal allocations present
 	// in the node automatically
 	garbageCollector *AllocGarbageCollector
+
+	// aclCache is used to maintain the parsed ACL objects
+	aclCache *lru.TwoQueueCache
+
+	// policyCache is used to maintain the fetched policy objects
+	policyCache *lru.TwoQueueCache
 }
 
 // migrateAllocCtrl indicates whether migration is complete
@@ -210,6 +225,15 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulServic
 		}
 		tlsWrap = tw
 	}
+	// Create the ACL object cache
+	aclCache, err := lru.New2Q(aclCacheSize)
+	if err != nil {
+		return nil, err
+	}
+	policyCache, err := lru.New2Q(policyCacheSize)
+	if err != nil {
+		return nil, err
+	}
 
 	// Create the client
 	c := &Client{
@@ -227,6 +251,8 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulServic
 		servers:             newServerList(),
 		triggerDiscoveryCh:  make(chan struct{}),
 		serversDiscoveredCh: make(chan struct{}),
+		aclCache:            aclCache,
+		policyCache:         policyCache,
 	}
 
 	// Initialize the client

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -181,6 +181,15 @@ type Config struct {
 	// NoHostUUID disables using the host's UUID and will force generation of a
 	// random UUID.
 	NoHostUUID bool
+
+	// ACLEnabled controls if ACL enforcement and management is enabled.
+	ACLEnabled bool
+
+	// ACLTokenTTL is how long we cache token values for
+	ACLTokenTTL time.Duration
+
+	// ACLPolicyTTL is how long we cache policy values for
+	ACLPolicyTTL time.Duration
 }
 
 func (c *Config) Copy() *Config {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -350,6 +350,11 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 		conf.NoHostUUID = true
 	}
 
+	// Setup the ACLs
+	conf.ACLEnabled = a.config.ACL.Enabled
+	conf.ACLTokenTTL = a.config.ACL.TokenTTL
+	conf.ACLPolicyTTL = a.config.ACL.PolicyTTL
+
 	return conf, nil
 }
 

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -35,9 +35,14 @@ func TestResolveACLToken(t *testing.T) {
 	snap, err := state.Snapshot()
 	assert.Nil(t, err)
 
+	// Attempt resolution of blank token. Should return anonymous policy
+	aclObj, err := resolveTokenFromSnapshotCache(snap, cache, "")
+	assert.Nil(t, err)
+	assert.NotNil(t, aclObj)
+
 	// Attempt resolution of unknown token. Should fail.
 	randID := structs.GenerateUUID()
-	aclObj, err := resolveTokenFromSnapshotCache(snap, cache, randID)
+	aclObj, err = resolveTokenFromSnapshotCache(snap, cache, randID)
 	assert.Equal(t, structs.TokenNotFound, err)
 	assert.Nil(t, aclObj)
 

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -709,22 +709,22 @@ START:
 			}
 
 			// Fetch any outdated policies
-			// TODO: Optimize this fetching to batch all the requests.
 			var fetched []*structs.ACLPolicy
-			for _, policyName := range update {
-				req := structs.ACLPolicySpecificRequest{
-					Name: policyName,
+			if len(update) > 0 {
+				req := structs.ACLPolicySetRequest{
+					Names: update,
+					QueryOptions: structs.QueryOptions{
+						Region: s.config.AuthoritativeRegion,
+					},
 				}
-				req.Region = s.config.AuthoritativeRegion
-				var reply structs.SingleACLPolicyResponse
-				err := s.forwardRegion(s.config.AuthoritativeRegion,
-					"ACL.GetPolicy", &req, &reply)
-				if err != nil {
-					s.logger.Printf("[ERR] nomad: failed to fetch policy %q from authoritative region: %v", policyName, err)
+				var reply structs.ACLPolicySetResponse
+				if err := s.forwardRegion(s.config.AuthoritativeRegion,
+					"ACL.GetPolicies", &req, &reply); err != nil {
+					s.logger.Printf("[ERR] nomad: failed to fetch policies from authoritative region: %v", err)
 					goto ERR_WAIT
 				}
-				if reply.Policy != nil {
-					fetched = append(fetched, reply.Policy)
+				for _, policy := range reply.Policies {
+					fetched = append(fetched, policy)
 				}
 			}
 
@@ -849,22 +849,22 @@ START:
 			}
 
 			// Fetch any outdated policies.
-			// TODO: Optimize this fetching to batch all the requests.
 			var fetched []*structs.ACLToken
-			for _, tokenID := range update {
-				req := structs.ACLTokenSpecificRequest{
-					AccessorID: tokenID,
+			if len(update) > 0 {
+				req := structs.ACLTokenSetRequest{
+					AccessorIDS: update,
+					QueryOptions: structs.QueryOptions{
+						Region: s.config.AuthoritativeRegion,
+					},
 				}
-				req.Region = s.config.AuthoritativeRegion
-				var reply structs.SingleACLTokenResponse
-				err := s.forwardRegion(s.config.AuthoritativeRegion,
-					"ACL.GetToken", &req, &reply)
-				if err != nil {
-					s.logger.Printf("[ERR] nomad: failed to fetch token %q from authoritative region: %v", tokenID, err)
+				var reply structs.ACLTokenSetResponse
+				if err := s.forwardRegion(s.config.AuthoritativeRegion,
+					"ACL.GetTokens", &req, &reply); err != nil {
+					s.logger.Printf("[ERR] nomad: failed to fetch tokens from authoritative region: %v", err)
 					goto ERR_WAIT
 				}
-				if reply.Token != nil {
-					fetched = append(fetched, reply.Token)
+				for _, token := range reply.Tokens {
+					fetched = append(fetched, token)
 				}
 			}
 

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -2,6 +2,8 @@ package structs
 
 import (
 	crand "crypto/rand"
+	"crypto/sha1"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"strings"
@@ -254,4 +256,15 @@ func DenormalizeAllocationJobs(job *Job, allocs []*Allocation) {
 // AllocName returns the name of the allocation given the input.
 func AllocName(job, group string, idx uint) string {
 	return fmt.Sprintf("%s.%s[%d]", job, group, idx)
+}
+
+// ACLPolicyListHash returns a consistent hash for a set of policies.
+func ACLPolicyListHash(policies []*ACLPolicy) string {
+	cacheKeyHash := sha1.New()
+	for _, policy := range policies {
+		cacheKeyHash.Write([]byte(policy.Name))
+		binary.Write(cacheKeyHash, binary.BigEndian, policy.ModifyIndex)
+	}
+	cacheKey := string(cacheKeyHash.Sum(nil))
+	return cacheKey
 }

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -279,7 +279,9 @@ func ACLPolicyListHash(policies []*ACLPolicy) string {
 // CompileACLObject compiles a set of ACL policies into an ACL object with a cache
 func CompileACLObject(cache *lru.TwoQueueCache, policies []*ACLPolicy) (*acl.ACL, error) {
 	// Sort the policies to ensure consistent ordering
-	sort.Sort(ACLPolicyList(policies))
+	sort.Slice(policies, func(i, j int) bool {
+		return policies[i].Name < policies[j].Name
+	})
 
 	// Determine the cache key
 	cacheKey := ACLPolicyListHash(policies)
@@ -307,19 +309,4 @@ func CompileACLObject(cache *lru.TwoQueueCache, policies []*ACLPolicy) (*acl.ACL
 	// Update the cache
 	cache.Add(cacheKey, aclObj)
 	return aclObj, nil
-}
-
-// ACLPolicyList is used to sort a set of policies by name
-type ACLPolicyList []*ACLPolicy
-
-func (l ACLPolicyList) Len() int {
-	return len(l)
-}
-
-func (l ACLPolicyList) Swap(i, j int) {
-	l[i], l[j] = l[j], l[i]
-}
-
-func (l ACLPolicyList) Less(i, j int) bool {
-	return l[i].Name < l[j].Name
 }

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -2,12 +2,13 @@ package structs
 
 import (
 	crand "crypto/rand"
-	"crypto/sha1"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"sort"
 	"strings"
+
+	"golang.org/x/crypto/blake2b"
 
 	multierror "github.com/hashicorp/go-multierror"
 	lru "github.com/hashicorp/golang-lru"
@@ -263,7 +264,10 @@ func AllocName(job, group string, idx uint) string {
 
 // ACLPolicyListHash returns a consistent hash for a set of policies.
 func ACLPolicyListHash(policies []*ACLPolicy) string {
-	cacheKeyHash := sha1.New()
+	cacheKeyHash, err := blake2b.New256(nil)
+	if err != nil {
+		panic(err)
+	}
 	for _, policy := range policies {
 		cacheKeyHash.Write([]byte(policy.Name))
 		binary.Write(cacheKeyHash, binary.BigEndian, policy.ModifyIndex)

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
@@ -273,6 +274,9 @@ func ACLPolicyListHash(policies []*ACLPolicy) string {
 
 // CompileACLObject compiles a set of ACL policies into an ACL object with a cache
 func CompileACLObject(cache *lru.TwoQueueCache, policies []*ACLPolicy) (*acl.ACL, error) {
+	// Sort the policies to ensure consistent ordering
+	sort.Sort(ACLPolicyList(policies))
+
 	// Determine the cache key
 	cacheKey := ACLPolicyListHash(policies)
 	aclRaw, ok := cache.Get(cacheKey)
@@ -299,4 +303,19 @@ func CompileACLObject(cache *lru.TwoQueueCache, policies []*ACLPolicy) (*acl.ACL
 	// Update the cache
 	cache.Add(cacheKey, aclObj)
 	return aclObj, nil
+}
+
+// ACLPolicyList is used to sort a set of policies by name
+type ACLPolicyList []*ACLPolicy
+
+func (l ACLPolicyList) Len() int {
+	return len(l)
+}
+
+func (l ACLPolicyList) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+func (l ACLPolicyList) Less(i, j int) bool {
+	return l[i].Name < l[j].Name
 }

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -366,4 +366,12 @@ func TestCompileACLObject(t *testing.T) {
 	if aclObj == aclObj3 {
 		t.Fatalf("unexpected same object")
 	}
+
+	// Should be order independent
+	aclObj4, err := CompileACLObject(cache, []*ACLPolicy{p2, p1})
+	assert.Nil(t, err)
+	assert.NotNil(t, aclObj4)
+	if aclObj3 != aclObj4 {
+		t.Fatalf("expected same object")
+	}
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5427,6 +5427,18 @@ type SingleACLTokenResponse struct {
 	QueryMeta
 }
 
+// ResolveACLTokenRequest is used to resolve a specific token
+type ResolveACLTokenRequest struct {
+	SecretID string
+	QueryOptions
+}
+
+// ResolveACLTokenResponse is used to resolve a single token
+type ResolveACLTokenResponse struct {
+	Token *ACLToken
+	QueryMeta
+}
+
 // ACLTokenDeleteRequest is used to delete a set of tokens
 type ACLTokenDeleteRequest struct {
 	AccessorIDs []string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5306,6 +5306,12 @@ type ACLPolicySpecificRequest struct {
 	QueryOptions
 }
 
+// ACLPolicySetRequest is used to query a set of policies
+type ACLPolicySetRequest struct {
+	Names []string
+	QueryOptions
+}
+
 // ACLPolicyListResponse is used for a list request
 type ACLPolicyListResponse struct {
 	Policies []*ACLPolicyListStub
@@ -5315,6 +5321,12 @@ type ACLPolicyListResponse struct {
 // SingleACLPolicyResponse is used to return a single policy
 type SingleACLPolicyResponse struct {
 	Policy *ACLPolicy
+	QueryMeta
+}
+
+// ACLPolicySetResponse is used to return a set of policies
+type ACLPolicySetResponse struct {
+	Policies map[string]*ACLPolicy
 	QueryMeta
 }
 
@@ -5415,6 +5427,12 @@ type ACLTokenSpecificRequest struct {
 	QueryOptions
 }
 
+// ACLTokenSetRequest is used to query a set of tokens
+type ACLTokenSetRequest struct {
+	AccessorIDS []string
+	QueryOptions
+}
+
 // ACLTokenListResponse is used for a list request
 type ACLTokenListResponse struct {
 	Tokens []*ACLTokenListStub
@@ -5424,6 +5442,12 @@ type ACLTokenListResponse struct {
 // SingleACLTokenResponse is used to return a single token
 type SingleACLTokenResponse struct {
 	Token *ACLToken
+	QueryMeta
+}
+
+// ACLTokenSetResponse is used to return a set of token
+type ACLTokenSetResponse struct {
+	Tokens map[string]*ACLToken // Keyed by Accessor ID
 	QueryMeta
 }
 


### PR DESCRIPTION
This PR builds on #3062. We add a `Client.resolveToken` which is the basis for endpoint enforcement. This method is used to resolve a token from a SecretID and construct an ACL enforcement object. This handles the caching of tokens, policies, and ACL objects to do this efficiently.

This also introduces new batch endpoints for `ACL.GetPolicies` and `ACL.GetTokens` which is now used to more efficiently replicate those between the authoritative region and other regions.