### PR TITLE
ACL Bootstrapping endpoint

### DIFF
--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -132,6 +132,27 @@ func (s *HTTPServer) ACLTokensRequest(resp http.ResponseWriter, req *http.Reques
 	return out.Tokens, nil
 }
 
+func (s *HTTPServer) ACLTokenBootstrap(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Ensure this is a PUT or POST
+	if !(req.Method == "PUT" || req.Method == "POST") {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	// Format the request
+	args := structs.ACLTokenBootstrapRequest{}
+	s.parseRegion(req, &args.Region)
+
+	var out structs.ACLTokenUpsertResponse
+	if err := s.agent.RPC("ACL.Bootstrap", &args, &out); err != nil {
+		return nil, err
+	}
+	setIndex(resp, out.Index)
+	if len(out.Tokens) > 0 {
+		return out.Tokens[0], nil
+	}
+	return nil, nil
+}
+
 func (s *HTTPServer) ACLTokenSpecificRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	accessor := strings.TrimPrefix(req.URL.Path, "/v1/acl/token")
 

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -174,6 +174,34 @@ func TestHTTP_ACLPolicyDelete(t *testing.T) {
 	})
 }
 
+func TestHTTP_ACLTokenBootstrap(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		// Make the HTTP request
+		req, err := http.NewRequest("PUT", "/v1/acl/bootstrap", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.ACLTokenBootstrap(respW, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Check for the index
+		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+			t.Fatalf("missing index")
+		}
+
+		// Check the output
+		n := obj.(*structs.ACLToken)
+		assert.NotNil(t, n)
+		assert.Equal(t, "Bootstrap Token", n.Name)
+	})
+}
+
 func TestHTTP_ACLTokenList(t *testing.T) {
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -104,8 +104,8 @@ func TestConfig_Merge(t *testing.T) {
 		},
 		ACL: &ACLConfig{
 			Enabled:   true,
-			TokenTTL:  "60s",
-			PolicyTTL: "60s",
+			TokenTTL:  60 * time.Second,
+			PolicyTTL: 60 * time.Second,
 		},
 		Ports: &Ports{
 			HTTP: 4646,
@@ -248,8 +248,8 @@ func TestConfig_Merge(t *testing.T) {
 		},
 		ACL: &ACLConfig{
 			Enabled:   true,
-			TokenTTL:  "20s",
-			PolicyTTL: "20s",
+			TokenTTL:  20 * time.Second,
+			PolicyTTL: 20 * time.Second,
 		},
 		Ports: &Ports{
 			HTTP: 20000,

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -151,6 +151,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/acl/policies", s.wrap(s.ACLPoliciesRequest))
 	s.mux.HandleFunc("/v1/acl/policy/", s.wrap(s.ACLPolicySpecificRequest))
 
+	s.mux.HandleFunc("/v1/acl/bootstrap", s.wrap(s.ACLTokenBootstrap))
 	s.mux.HandleFunc("/v1/acl/tokens", s.wrap(s.ACLTokensRequest))
 	s.mux.HandleFunc("/v1/acl/token", s.wrap(s.ACLTokenSpecificRequest))
 

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -177,6 +177,8 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyACLTokenUpsert(buf[1:], log.Index)
 	case structs.ACLTokenDeleteRequestType:
 		return n.applyACLTokenDelete(buf[1:], log.Index)
+	case structs.ACLTokenBootstrapRequestType:
+		return n.applyACLTokenBootstrap(buf[1:], log.Index)
 	default:
 		if ignoreUnknown {
 			n.logger.Printf("[WARN] nomad.fsm: ignoring unknown message type (%d), upgrade to newer version", msgType)
@@ -734,6 +736,21 @@ func (n *nomadFSM) applyACLTokenDelete(buf []byte, index uint64) interface{} {
 
 	if err := n.state.DeleteACLTokens(index, req.AccessorIDs); err != nil {
 		n.logger.Printf("[ERR] nomad.fsm: DeleteACLTokens failed: %v", err)
+		return err
+	}
+	return nil
+}
+
+// applyACLTokenBootstrap is used to bootstrap an ACL token
+func (n *nomadFSM) applyACLTokenBootstrap(buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_acl_token_bootstrap"}, time.Now())
+	var req structs.ACLTokenBootstrapRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.BootstrapACLTokens(index, req.Token); err != nil {
+		n.logger.Printf("[ERR] nomad.fsm: BootstrapACLToken failed: %v", err)
 		return err
 	}
 	return nil

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1570,6 +1570,30 @@ func TestFSM_DeleteACLPolicies(t *testing.T) {
 	assert.Nil(t, out)
 }
 
+func TestFSM_BootstrapACLTokens(t *testing.T) {
+	t.Parallel()
+	fsm := testFSM(t)
+
+	token := mock.ACLToken()
+	req := structs.ACLTokenBootstrapRequest{
+		Token: token,
+	}
+	buf, err := structs.Encode(structs.ACLTokenBootstrapRequestType, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp := fsm.Apply(makeLog(buf))
+	if resp != nil {
+		t.Fatalf("resp: %v", resp)
+	}
+
+	// Verify we are registered
+	out, err := fsm.State().ACLTokenByAccessorID(nil, token.AccessorID)
+	assert.Nil(t, err)
+	assert.NotNil(t, out)
+}
+
 func TestFSM_UpsertACLTokens(t *testing.T) {
 	t.Parallel()
 	fsm := testFSM(t)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2968,6 +2968,40 @@ func (s *StateStore) ACLTokensByGlobal(ws memdb.WatchSet, globalVal bool) (memdb
 	return iter, nil
 }
 
+// BootstrapACLToken is used to create an initial ACL token
+func (s *StateStore) BootstrapACLTokens(index uint64, token *structs.ACLToken) error {
+	txn := s.db.Txn(true)
+	defer txn.Abort()
+
+	// Check if we have already done a bootstrap
+	existing, err := txn.First("index", "id", "acl_token_bootstrap")
+	if err != nil {
+		return fmt.Errorf("bootstrap check failed: %v", err)
+	}
+	if existing != nil {
+		return fmt.Errorf("ACL bootstrap already done")
+	}
+
+	// Update the Create/Modify time
+	token.CreateIndex = index
+	token.ModifyIndex = index
+
+	// Insert the token
+	if err := txn.Insert("acl_token", token); err != nil {
+		return fmt.Errorf("upserting token failed: %v", err)
+	}
+
+	// Update the indexes table, prevents future bootstrap
+	if err := txn.Insert("index", &IndexEntry{"acl_token", index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+	if err := txn.Insert("index", &IndexEntry{"acl_token_bootstrap", index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+	txn.Commit()
+	return nil
+}
+
 // StateSnapshot is used to provide a point-in-time snapshot
 type StateSnapshot struct {
 	StateStore

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2968,6 +2968,15 @@ func (s *StateStore) ACLTokensByGlobal(ws memdb.WatchSet, globalVal bool) (memdb
 	return iter, nil
 }
 
+// CanBootstrapACLToken checks if bootstrapping is possible
+func (s *StateStore) CanBootstrapACLToken() (bool, error) {
+	txn := s.db.Txn(false)
+
+	// Lookup the bootstrap sentinel
+	out, err := txn.First("index", "id", "acl_token_bootstrap")
+	return out == nil, err
+}
+
 // BootstrapACLToken is used to create an initial ACL token
 func (s *StateStore) BootstrapACLTokens(index uint64, token *structs.ACLToken) error {
 	txn := s.db.Txn(true)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -5886,6 +5886,10 @@ func TestStateStore_BootstrapACLTokens(t *testing.T) {
 	tk1 := mock.ACLToken()
 	tk2 := mock.ACLToken()
 
+	ok, err := state.CanBootstrapACLToken()
+	assert.Nil(t, err)
+	assert.Equal(t, true, ok)
+
 	if err := state.BootstrapACLTokens(1000, tk1); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5893,6 +5897,10 @@ func TestStateStore_BootstrapACLTokens(t *testing.T) {
 	out, err := state.ACLTokenByAccessorID(nil, tk1.AccessorID)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, tk1, out)
+
+	ok, err = state.CanBootstrapACLToken()
+	assert.Nil(t, err)
+	assert.Equal(t, false, ok)
 
 	if err := state.BootstrapACLTokens(1001, tk2); err == nil {
 		t.Fatalf("expected error")

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -67,6 +67,7 @@ const (
 	ACLPolicyDeleteRequestType
 	ACLTokenUpsertRequestType
 	ACLTokenDeleteRequestType
+	ACLTokenBootstrapRequestType
 )
 
 const (
@@ -5466,6 +5467,12 @@ type ResolveACLTokenResponse struct {
 // ACLTokenDeleteRequest is used to delete a set of tokens
 type ACLTokenDeleteRequest struct {
 	AccessorIDs []string
+	WriteRequest
+}
+
+// ACLTokenBootstrapRequest is used to bootstrap ACLs
+type ACLTokenBootstrapRequest struct {
+	Token *ACLToken // Not client specifiable
 	WriteRequest
 }
 


### PR DESCRIPTION
This builds on #3063. This PR adds support for a `/v1/acl/bootstrap` endpoint which allows a one-time creation of an ACL management token. This allows the ACL system to be initially bootstrapped.