### PR TITLE
Enforce ACLs on ACL related endpoints.

### DIFF
--- a/client/acl.go
+++ b/client/acl.go
@@ -82,7 +82,7 @@ func (c *Client) ResolveToken(secretID string) (*acl.ACL, error) {
 		return nil, err
 	}
 	if token == nil {
-		return nil, structs.TokenNotFound
+		return nil, structs.ErrTokenNotFound
 	}
 
 	// Check if this is a management token

--- a/client/acl.go
+++ b/client/acl.go
@@ -91,7 +91,7 @@ func (c *Client) ResolveToken(secretID string) (*acl.ACL, error) {
 	}
 
 	// Resolve the policies
-	policies, err := c.resolvePolicies(token.Policies)
+	policies, err := c.resolvePolicies(token.SecretID, token.Policies)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (c *Client) resolveTokenValue(secretID string) (*structs.ACLToken, error) {
 // We cache the policies locally, and fault them from a server as necessary. Policies
 // are cached for a TTL, and then refreshed. If a server cannot be reached, the cache TTL
 // will be ignored to gracefully handle outages.
-func (c *Client) resolvePolicies(policies []string) ([]*structs.ACLPolicy, error) {
+func (c *Client) resolvePolicies(secretID string, policies []string) ([]*structs.ACLPolicy, error) {
 	var out []*structs.ACLPolicy
 	var expired []*structs.ACLPolicy
 	var missing []string
@@ -184,8 +184,11 @@ func (c *Client) resolvePolicies(policies []string) ([]*structs.ACLPolicy, error
 		fetch = append(fetch, p.Name)
 	}
 	req := structs.ACLPolicySetRequest{
-		Names:        fetch,
-		QueryOptions: structs.QueryOptions{Region: c.Region()},
+		Names: fetch,
+		QueryOptions: structs.QueryOptions{
+			Region:   c.Region(),
+			SecretID: secretID,
+		},
 	}
 	var resp structs.ACLPolicySetResponse
 	if err := c.RPC("ACL.GetPolicies", &req, &resp); err != nil {

--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 func TestClient_ACL_resolveTokenValue(t *testing.T) {
-	s1, _ := testServer(t, nil)
+	s1, _, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	c1 := testClient(t, func(c *config.Config) {
 		c.RPCHandler = s1
+		c.ACLEnabled = true
 	})
 	defer c1.Shutdown()
 
@@ -60,12 +61,13 @@ func TestClient_ACL_resolveTokenValue(t *testing.T) {
 }
 
 func TestClient_ACL_resolvePolicies(t *testing.T) {
-	s1, _ := testServer(t, nil)
+	s1, _, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	c1 := testClient(t, func(c *config.Config) {
 		c.RPCHandler = s1
+		c.ACLEnabled = true
 	})
 	defer c1.Shutdown()
 
@@ -83,12 +85,12 @@ func TestClient_ACL_resolvePolicies(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test the client resolution
-	out, err := c1.resolvePolicies([]string{policy.Name, policy2.Name})
+	out, err := c1.resolvePolicies(root.SecretID, []string{policy.Name, policy2.Name})
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(out))
 
 	// Test caching
-	out2, err := c1.resolvePolicies([]string{policy.Name, policy2.Name})
+	out2, err := c1.resolvePolicies(root.SecretID, []string{policy.Name, policy2.Name})
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(out2))
 
@@ -115,7 +117,7 @@ func TestClient_ACL_ResolveToken_Disabled(t *testing.T) {
 }
 
 func TestClient_ACL_ResolveToken(t *testing.T) {
-	s1, _ := testServer(t, nil)
+	s1, _, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 

--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -159,6 +159,6 @@ func TestClient_ACL_ResolveToken(t *testing.T) {
 
 	// Test bad token
 	out4, err := c1.ResolveToken(structs.GenerateUUID())
-	assert.Equal(t, structs.TokenNotFound, err)
+	assert.Equal(t, structs.ErrTokenNotFound, err)
 	assert.Nil(t, out4)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -33,6 +33,21 @@ func getPort() int {
 	return 1030 + int(rand.Int31n(6440))
 }
 
+func testACLServer(t *testing.T, cb func(*nomad.Config)) (*nomad.Server, string, *structs.ACLToken) {
+	server, addr := testServer(t, func(c *nomad.Config) {
+		c.ACLEnabled = true
+		if cb != nil {
+			cb(c)
+		}
+	})
+	token := mock.ACLManagementToken()
+	err := server.State().BootstrapACLTokens(1, token)
+	if err != nil {
+		t.Fatalf("failed to bootstrap ACL token: %v", err)
+	}
+	return server, addr, token
+}
+
 func testServer(t *testing.T, cb func(*nomad.Config)) (*nomad.Server, string) {
 	// Setup the default settings
 	config := nomad.DefaultConfig()

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -84,7 +84,7 @@ func (s *HTTPServer) aclPolicyUpdate(resp http.ResponseWriter, req *http.Request
 	args := structs.ACLPolicyUpsertRequest{
 		Policies: []*structs.ACLPolicy{&policy},
 	}
-	s.parseRegion(req, &args.Region)
+	s.parseWrite(req, &args.WriteRequest)
 
 	var out structs.GenericResponse
 	if err := s.agent.RPC("ACL.UpsertPolicies", &args, &out); err != nil {
@@ -100,7 +100,7 @@ func (s *HTTPServer) aclPolicyDelete(resp http.ResponseWriter, req *http.Request
 	args := structs.ACLPolicyDeleteRequest{
 		Names: []string{policyName},
 	}
-	s.parseRegion(req, &args.Region)
+	s.parseWrite(req, &args.WriteRequest)
 
 	var out structs.GenericResponse
 	if err := s.agent.RPC("ACL.DeletePolicies", &args, &out); err != nil {
@@ -140,7 +140,7 @@ func (s *HTTPServer) ACLTokenBootstrap(resp http.ResponseWriter, req *http.Reque
 
 	// Format the request
 	args := structs.ACLTokenBootstrapRequest{}
-	s.parseRegion(req, &args.Region)
+	s.parseWrite(req, &args.WriteRequest)
 
 	var out structs.ACLTokenUpsertResponse
 	if err := s.agent.RPC("ACL.Bootstrap", &args, &out); err != nil {
@@ -220,7 +220,7 @@ func (s *HTTPServer) aclTokenUpdate(resp http.ResponseWriter, req *http.Request,
 	args := structs.ACLTokenUpsertRequest{
 		Tokens: []*structs.ACLToken{&token},
 	}
-	s.parseRegion(req, &args.Region)
+	s.parseWrite(req, &args.WriteRequest)
 
 	var out structs.ACLTokenUpsertResponse
 	if err := s.agent.RPC("ACL.UpsertTokens", &args, &out); err != nil {
@@ -239,7 +239,7 @@ func (s *HTTPServer) aclTokenDelete(resp http.ResponseWriter, req *http.Request,
 	args := structs.ACLTokenDeleteRequest{
 		AccessorIDs: []string{tokenAccessor},
 	}
-	s.parseRegion(req, &args.Region)
+	s.parseWrite(req, &args.WriteRequest)
 
 	var out structs.GenericResponse
 	if err := s.agent.RPC("ACL.DeleteTokens", &args, &out); err != nil {

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -17,8 +17,11 @@ func TestHTTP_ACLPolicyList(t *testing.T) {
 		p2 := mock.ACLPolicy()
 		p3 := mock.ACLPolicy()
 		args := structs.ACLPolicyUpsertRequest{
-			Policies:     []*structs.ACLPolicy{p1, p2, p3},
-			WriteRequest: structs.WriteRequest{Region: "global"},
+			Policies: []*structs.ACLPolicy{p1, p2, p3},
+			WriteRequest: structs.WriteRequest{
+				Region:   "global",
+				SecretID: s.Token.SecretID,
+			},
 		}
 		var resp structs.GenericResponse
 		if err := s.Agent.RPC("ACL.UpsertPolicies", &args, &resp); err != nil {
@@ -31,6 +34,7 @@ func TestHTTP_ACLPolicyList(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
+		setToken(req, s.Token)
 
 		// Make the request
 		obj, err := s.Server.ACLPoliciesRequest(respW, req)
@@ -62,8 +66,11 @@ func TestHTTP_ACLPolicyQuery(t *testing.T) {
 	httpACLTest(t, nil, func(s *TestAgent) {
 		p1 := mock.ACLPolicy()
 		args := structs.ACLPolicyUpsertRequest{
-			Policies:     []*structs.ACLPolicy{p1},
-			WriteRequest: structs.WriteRequest{Region: "global"},
+			Policies: []*structs.ACLPolicy{p1},
+			WriteRequest: structs.WriteRequest{
+				Region:   "global",
+				SecretID: s.Token.SecretID,
+			},
 		}
 		var resp structs.GenericResponse
 		if err := s.Agent.RPC("ACL.UpsertPolicies", &args, &resp); err != nil {
@@ -76,6 +83,7 @@ func TestHTTP_ACLPolicyQuery(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
+		setToken(req, s.Token)
 
 		// Make the request
 		obj, err := s.Server.ACLPolicySpecificRequest(respW, req)
@@ -113,6 +121,7 @@ func TestHTTP_ACLPolicyCreate(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
+		setToken(req, s.Token)
 
 		// Make the request
 		obj, err := s.Server.ACLPolicySpecificRequest(respW, req)
@@ -141,8 +150,11 @@ func TestHTTP_ACLPolicyDelete(t *testing.T) {
 	httpACLTest(t, nil, func(s *TestAgent) {
 		p1 := mock.ACLPolicy()
 		args := structs.ACLPolicyUpsertRequest{
-			Policies:     []*structs.ACLPolicy{p1},
-			WriteRequest: structs.WriteRequest{Region: "global"},
+			Policies: []*structs.ACLPolicy{p1},
+			WriteRequest: structs.WriteRequest{
+				Region:   "global",
+				SecretID: s.Token.SecretID,
+			},
 		}
 		var resp structs.GenericResponse
 		if err := s.Agent.RPC("ACL.UpsertPolicies", &args, &resp); err != nil {
@@ -155,6 +167,7 @@ func TestHTTP_ACLPolicyDelete(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
+		setToken(req, s.Token)
 
 		// Make the request
 		obj, err := s.Server.ACLPolicySpecificRequest(respW, req)
@@ -216,8 +229,11 @@ func TestHTTP_ACLTokenList(t *testing.T) {
 		p3 := mock.ACLToken()
 		p3.AccessorID = ""
 		args := structs.ACLTokenUpsertRequest{
-			Tokens:       []*structs.ACLToken{p1, p2, p3},
-			WriteRequest: structs.WriteRequest{Region: "global"},
+			Tokens: []*structs.ACLToken{p1, p2, p3},
+			WriteRequest: structs.WriteRequest{
+				Region:   "global",
+				SecretID: s.Token.SecretID,
+			},
 		}
 		var resp structs.ACLTokenUpsertResponse
 		if err := s.Agent.RPC("ACL.UpsertTokens", &args, &resp); err != nil {
@@ -230,6 +246,7 @@ func TestHTTP_ACLTokenList(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
+		setToken(req, s.Token)
 
 		// Make the request
 		obj, err := s.Server.ACLTokensRequest(respW, req)
@@ -262,8 +279,11 @@ func TestHTTP_ACLTokenQuery(t *testing.T) {
 		p1 := mock.ACLToken()
 		p1.AccessorID = ""
 		args := structs.ACLTokenUpsertRequest{
-			Tokens:       []*structs.ACLToken{p1},
-			WriteRequest: structs.WriteRequest{Region: "global"},
+			Tokens: []*structs.ACLToken{p1},
+			WriteRequest: structs.WriteRequest{
+				Region:   "global",
+				SecretID: s.Token.SecretID,
+			},
 		}
 		var resp structs.ACLTokenUpsertResponse
 		if err := s.Agent.RPC("ACL.UpsertTokens", &args, &resp); err != nil {
@@ -277,6 +297,7 @@ func TestHTTP_ACLTokenQuery(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
+		setToken(req, s.Token)
 
 		// Make the request
 		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)
@@ -313,6 +334,7 @@ func TestHTTP_ACLTokenCreate(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
+		setToken(req, s.Token)
 
 		// Make the request
 		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)
@@ -340,8 +362,11 @@ func TestHTTP_ACLTokenDelete(t *testing.T) {
 		p1 := mock.ACLToken()
 		p1.AccessorID = ""
 		args := structs.ACLTokenUpsertRequest{
-			Tokens:       []*structs.ACLToken{p1},
-			WriteRequest: structs.WriteRequest{Region: "global"},
+			Tokens: []*structs.ACLToken{p1},
+			WriteRequest: structs.WriteRequest{
+				Region:   "global",
+				SecretID: s.Token.SecretID,
+			},
 		}
 		var resp structs.ACLTokenUpsertResponse
 		if err := s.Agent.RPC("ACL.UpsertTokens", &args, &resp); err != nil {
@@ -355,6 +380,7 @@ func TestHTTP_ACLTokenDelete(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
+		setToken(req, s.Token)
 
 		// Make the request
 		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestHTTP_ACLPolicyList(t *testing.T) {
 	t.Parallel()
-	httpTest(t, nil, func(s *TestAgent) {
+	httpACLTest(t, nil, func(s *TestAgent) {
 		p1 := mock.ACLPolicy()
 		p2 := mock.ACLPolicy()
 		p3 := mock.ACLPolicy()
@@ -59,7 +59,7 @@ func TestHTTP_ACLPolicyList(t *testing.T) {
 
 func TestHTTP_ACLPolicyQuery(t *testing.T) {
 	t.Parallel()
-	httpTest(t, nil, func(s *TestAgent) {
+	httpACLTest(t, nil, func(s *TestAgent) {
 		p1 := mock.ACLPolicy()
 		args := structs.ACLPolicyUpsertRequest{
 			Policies:     []*structs.ACLPolicy{p1},
@@ -104,7 +104,7 @@ func TestHTTP_ACLPolicyQuery(t *testing.T) {
 
 func TestHTTP_ACLPolicyCreate(t *testing.T) {
 	t.Parallel()
-	httpTest(t, nil, func(s *TestAgent) {
+	httpACLTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
 		p1 := mock.ACLPolicy()
 		buf := encodeReq(p1)
@@ -138,7 +138,7 @@ func TestHTTP_ACLPolicyCreate(t *testing.T) {
 
 func TestHTTP_ACLPolicyDelete(t *testing.T) {
 	t.Parallel()
-	httpTest(t, nil, func(s *TestAgent) {
+	httpACLTest(t, nil, func(s *TestAgent) {
 		p1 := mock.ACLPolicy()
 		args := structs.ACLPolicyUpsertRequest{
 			Policies:     []*structs.ACLPolicy{p1},
@@ -176,7 +176,11 @@ func TestHTTP_ACLPolicyDelete(t *testing.T) {
 
 func TestHTTP_ACLTokenBootstrap(t *testing.T) {
 	t.Parallel()
-	httpTest(t, nil, func(s *TestAgent) {
+	conf := func(c *Config) {
+		c.ACL.Enabled = true
+		c.ACL.PolicyTTL = 0 // Special flag to disable auto-bootstrap
+	}
+	httpTest(t, conf, func(s *TestAgent) {
 		// Make the HTTP request
 		req, err := http.NewRequest("PUT", "/v1/acl/bootstrap", nil)
 		if err != nil {
@@ -204,7 +208,7 @@ func TestHTTP_ACLTokenBootstrap(t *testing.T) {
 
 func TestHTTP_ACLTokenList(t *testing.T) {
 	t.Parallel()
-	httpTest(t, nil, func(s *TestAgent) {
+	httpACLTest(t, nil, func(s *TestAgent) {
 		p1 := mock.ACLToken()
 		p1.AccessorID = ""
 		p2 := mock.ACLToken()
@@ -244,9 +248,9 @@ func TestHTTP_ACLTokenList(t *testing.T) {
 			t.Fatalf("missing last contact")
 		}
 
-		// Check the output
+		// Check the output (includes boostrap token)
 		n := obj.([]*structs.ACLTokenListStub)
-		if len(n) != 3 {
+		if len(n) != 4 {
 			t.Fatalf("bad: %#v", n)
 		}
 	})
@@ -254,7 +258,7 @@ func TestHTTP_ACLTokenList(t *testing.T) {
 
 func TestHTTP_ACLTokenQuery(t *testing.T) {
 	t.Parallel()
-	httpTest(t, nil, func(s *TestAgent) {
+	httpACLTest(t, nil, func(s *TestAgent) {
 		p1 := mock.ACLToken()
 		p1.AccessorID = ""
 		args := structs.ACLTokenUpsertRequest{
@@ -299,7 +303,7 @@ func TestHTTP_ACLTokenQuery(t *testing.T) {
 
 func TestHTTP_ACLTokenCreate(t *testing.T) {
 	t.Parallel()
-	httpTest(t, nil, func(s *TestAgent) {
+	httpACLTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
 		p1 := mock.ACLToken()
 		p1.AccessorID = ""
@@ -332,7 +336,7 @@ func TestHTTP_ACLTokenCreate(t *testing.T) {
 
 func TestHTTP_ACLTokenDelete(t *testing.T) {
 	t.Parallel()
-	httpTest(t, nil, func(s *TestAgent) {
+	httpACLTest(t, nil, func(s *TestAgent) {
 		p1 := mock.ACLToken()
 		p1.AccessorID = ""
 		args := structs.ACLTokenUpsertRequest{

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -146,6 +146,9 @@ func convertServerConfig(agentConfig *Config, logOutput io.Writer) (*nomad.Confi
 	if agentConfig.ACL.Enabled {
 		conf.ACLEnabled = true
 	}
+	if agentConfig.ACL.ReplicationToken != "" {
+		conf.ReplicationToken = agentConfig.ACL.ReplicationToken
+	}
 
 	// Set up the bind addresses
 	rpcAddr, err := net.ResolveTCPAddr("tcp", agentConfig.normalizedAddrs.RPC)

--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -87,6 +87,7 @@ acl {
     enabled = true
     token_ttl = "60s"
     policy_ttl = "60s"
+    replication_token = "foobar"
 }
 telemetry {
 	statsite_address = "127.0.0.1:1234"

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -248,6 +248,11 @@ type ACLConfig struct {
 	// to "30s". Reducing this impacts performance by forcing more
 	// frequent resolution.
 	PolicyTTL time.Duration `mapstructure:"policy_ttl"`
+
+	// ReplicationToken is used by servers to replicate tokens and policies
+	// from the authoritative region. This must be a valid management token
+	// within the authoritative region.
+	ReplicationToken string `mapstructure:"replication_token"`
 }
 
 // ServerConfig is configuration specific to the server mode
@@ -952,6 +957,9 @@ func (a *ACLConfig) Merge(b *ACLConfig) *ACLConfig {
 	}
 	if b.PolicyTTL != 0 {
 		result.PolicyTTL = b.PolicyTTL
+	}
+	if b.ReplicationToken != "" {
+		result.ReplicationToken = b.ReplicationToken
 	}
 	return &result
 }

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -573,6 +573,7 @@ func parseACL(result **ACLConfig, list *ast.ObjectList) error {
 		"enabled",
 		"token_ttl",
 		"policy_ttl",
+		"replication_token",
 	}
 	if err := checkHCLKeys(listVal, valid); err != nil {
 		return err

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -105,9 +105,10 @@ func TestConfig_Parse(t *testing.T) {
 					EncryptKey:             "abc",
 				},
 				ACL: &ACLConfig{
-					Enabled:   true,
-					TokenTTL:  60 * time.Second,
-					PolicyTTL: 60 * time.Second,
+					Enabled:          true,
+					TokenTTL:         60 * time.Second,
+					PolicyTTL:        60 * time.Second,
+					ReplicationToken: "foobar",
 				},
 				Telemetry: &Telemetry{
 					StatsiteAddr:             "127.0.0.1:1234",

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -103,9 +103,10 @@ func TestConfig_Merge(t *testing.T) {
 			MaxHeartbeatsPerSecond: 30.0,
 		},
 		ACL: &ACLConfig{
-			Enabled:   true,
-			TokenTTL:  60 * time.Second,
-			PolicyTTL: 60 * time.Second,
+			Enabled:          true,
+			TokenTTL:         60 * time.Second,
+			PolicyTTL:        60 * time.Second,
+			ReplicationToken: "foo",
 		},
 		Ports: &Ports{
 			HTTP: 4646,
@@ -247,9 +248,10 @@ func TestConfig_Merge(t *testing.T) {
 			retryInterval:          time.Second * 10,
 		},
 		ACL: &ACLConfig{
-			Enabled:   true,
-			TokenTTL:  20 * time.Second,
-			PolicyTTL: 20 * time.Second,
+			Enabled:          true,
+			TokenTTL:         20 * time.Second,
+			PolicyTTL:        20 * time.Second,
+			ReplicationToken: "foobar",
 		},
 		Ports: &Ports{
 			HTTP: 20000,

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -364,6 +364,12 @@ func (s *HTTPServer) parseToken(req *http.Request, token *string) {
 	}
 }
 
+// parseWrite is a convenience method for endpoints that call write methods
+func (s *HTTPServer) parseWrite(req *http.Request, b *structs.WriteRequest) {
+	s.parseRegion(req, &b.Region)
+	s.parseToken(req, &b.SecretID)
+}
+
 // parse is a convenience method for endpoints that need to parse multiple flags
 func (s *HTTPServer) parse(resp http.ResponseWriter, req *http.Request, r *string, b *structs.QueryOptions) bool {
 	s.parseRegion(req, r)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -356,9 +356,18 @@ func (s *HTTPServer) parseRegion(req *http.Request, r *string) {
 	}
 }
 
+// parseToken is used to parse the X-Nomad-Token param
+func (s *HTTPServer) parseToken(req *http.Request, token *string) {
+	if other := req.Header.Get("X-Nomad-Token"); other != "" {
+		*token = other
+		return
+	}
+}
+
 // parse is a convenience method for endpoints that need to parse multiple flags
 func (s *HTTPServer) parse(resp http.ResponseWriter, req *http.Request, r *string, b *structs.QueryOptions) bool {
 	s.parseRegion(req, r)
+	s.parseToken(req, &b.SecretID)
 	parseConsistency(req, b)
 	parsePrefix(req, b)
 	return parseWait(resp, req, b)

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -519,6 +519,10 @@ func httpACLTest(t testing.TB, cb func(c *Config), f func(srv *TestAgent)) {
 	f(s)
 }
 
+func setToken(req *http.Request, token *structs.ACLToken) {
+	req.Header.Set("X-Nomad-Token", token.SecretID)
+}
+
 func encodeReq(obj interface{}) io.ReadCloser {
 	buf := bytes.NewBuffer(nil)
 	enc := json.NewEncoder(buf)

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -331,6 +331,24 @@ func TestParseRegion(t *testing.T) {
 	}
 }
 
+func TestParseToken(t *testing.T) {
+	t.Parallel()
+	s := makeHTTPServer(t, nil)
+	defer s.Shutdown()
+
+	req, err := http.NewRequest("GET", "/v1/jobs", nil)
+	req.Header.Add("X-Nomad-Token", "foobar")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	var token string
+	s.Server.parseToken(req, &token)
+	if token != "foobar" {
+		t.Fatalf("bad %s", token)
+	}
+}
+
 // TestHTTP_VerifyHTTPSClient asserts that a client certificate signed by the
 // appropriate CA is required when VerifyHTTPSClient=true.
 func TestHTTP_VerifyHTTPSClient(t *testing.T) {

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -489,6 +489,18 @@ func httpTest(t testing.TB, cb func(c *Config), f func(srv *TestAgent)) {
 	f(s)
 }
 
+func httpACLTest(t testing.TB, cb func(c *Config), f func(srv *TestAgent)) {
+	s := makeHTTPServer(t, func(c *Config) {
+		c.ACL.Enabled = true
+		if cb != nil {
+			cb(c)
+		}
+	})
+	defer s.Shutdown()
+	testutil.WaitForLeader(t, s.Agent.RPC)
+	f(s)
+}
+
 func encodeReq(obj interface{}) io.ReadCloser {
 	buf := bytes.NewBuffer(nil)
 	enc := json.NewEncoder(buf)

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -46,7 +46,7 @@ func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *lru.TwoQueu
 			return nil, err
 		}
 		if token == nil {
-			return nil, structs.TokenNotFound
+			return nil, structs.ErrTokenNotFound
 		}
 	}
 

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -33,6 +33,13 @@ func (a *ACL) UpsertPolicies(args *structs.ACLPolicyUpsertRequest, reply *struct
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "upsert_policies"}, time.Now())
 
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
 	// Validate non-zero set of policies
 	if len(args.Policies) == 0 {
 		return fmt.Errorf("must specify as least one policy")
@@ -69,6 +76,13 @@ func (a *ACL) DeletePolicies(args *structs.ACLPolicyDeleteRequest, reply *struct
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "delete_policies"}, time.Now())
 
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
 	// Validate non-zero set of policies
 	if len(args.Names) == 0 {
 		return fmt.Errorf("must specify as least one policy")
@@ -94,6 +108,13 @@ func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.AC
 		return err
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "list_policies"}, time.Now())
+
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
 
 	// Setup the blocking query
 	opts := blockingOptions{
@@ -150,6 +171,13 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "get_policy"}, time.Now())
 
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
 	// Setup the blocking query
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
@@ -187,6 +215,13 @@ func (a *ACL) GetPolicies(args *structs.ACLPolicySetRequest, reply *structs.ACLP
 		return err
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "get_policies"}, time.Now())
+
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
 
 	// Setup the blocking query
 	opts := blockingOptions{
@@ -293,6 +328,13 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.A
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "upsert_tokens"}, time.Now())
 
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
 	// Validate non-zero set of tokens
 	if len(args.Tokens) == 0 {
 		return fmt.Errorf("must specify as least one token")
@@ -371,6 +413,13 @@ func (a *ACL) DeleteTokens(args *structs.ACLTokenDeleteRequest, reply *structs.G
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "delete_tokens"}, time.Now())
 
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
 	// Validate non-zero set of tokens
 	if len(args.AccessorIDs) == 0 {
 		return fmt.Errorf("must specify as least one token")
@@ -396,6 +445,13 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 		return err
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "list_tokens"}, time.Now())
+
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
 
 	// Setup the blocking query
 	opts := blockingOptions{
@@ -448,6 +504,13 @@ func (a *ACL) GetToken(args *structs.ACLTokenSpecificRequest, reply *structs.Sin
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "get_token"}, time.Now())
 
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
 	// Setup the blocking query
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
@@ -485,6 +548,13 @@ func (a *ACL) GetTokens(args *structs.ACLTokenSetRequest, reply *structs.ACLToke
 		return err
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "get_tokens"}, time.Now())
+
+	// Check management level permissions
+	if acl, err := a.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if acl == nil || !acl.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
 
 	// Setup the blocking query
 	opts := blockingOptions{

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -10,6 +10,11 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+var (
+	// aclDisabled is returned when an ACL endpoint is hit but ACLs are not enabled
+	aclDisabled = fmt.Errorf("ACL support disabled")
+)
+
 // ACL endpoint is used for manipulating ACL tokens and policies
 type ACL struct {
 	srv *Server
@@ -17,6 +22,12 @@ type ACL struct {
 
 // UpsertPolicies is used to create or update a set of policies
 func (a *ACL) UpsertPolicies(args *structs.ACLPolicyUpsertRequest, reply *structs.GenericResponse) error {
+	// Ensure ACLs are enabled, and always flow modification requests to the authoritative region
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
+	args.Region = a.srv.config.AuthoritativeRegion
+
 	if done, err := a.srv.forward("ACL.UpsertPolicies", args, args, reply); done {
 		return err
 	}
@@ -47,6 +58,12 @@ func (a *ACL) UpsertPolicies(args *structs.ACLPolicyUpsertRequest, reply *struct
 
 // DeletePolicies is used to delete policies
 func (a *ACL) DeletePolicies(args *structs.ACLPolicyDeleteRequest, reply *structs.GenericResponse) error {
+	// Ensure ACLs are enabled, and always flow modification requests to the authoritative region
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
+	args.Region = a.srv.config.AuthoritativeRegion
+
 	if done, err := a.srv.forward("ACL.DeletePolicies", args, args, reply); done {
 		return err
 	}
@@ -70,6 +87,9 @@ func (a *ACL) DeletePolicies(args *structs.ACLPolicyDeleteRequest, reply *struct
 
 // ListPolicies is used to list the policies
 func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.ACLPolicyListResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
 	if done, err := a.srv.forward("ACL.ListPolicies", args, args, reply); done {
 		return err
 	}
@@ -122,6 +142,9 @@ func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.AC
 
 // GetPolicy is used to get a specific policy
 func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.SingleACLPolicyResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
 	if done, err := a.srv.forward("ACL.GetPolicy", args, args, reply); done {
 		return err
 	}
@@ -157,6 +180,9 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 
 // GetPolicies is used to get a set of policies
 func (a *ACL) GetPolicies(args *structs.ACLPolicySetRequest, reply *structs.ACLPolicySetResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
 	if done, err := a.srv.forward("ACL.GetPolicies", args, args, reply); done {
 		return err
 	}
@@ -194,6 +220,12 @@ func (a *ACL) GetPolicies(args *structs.ACLPolicySetRequest, reply *structs.ACLP
 
 // Bootstrap is used to bootstrap the initial token
 func (a *ACL) Bootstrap(args *structs.ACLTokenBootstrapRequest, reply *structs.ACLTokenUpsertResponse) error {
+	// Ensure ACLs are enabled, and always flow modification requests to the authoritative region
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
+	args.Region = a.srv.config.AuthoritativeRegion
+
 	if done, err := a.srv.forward("ACL.Bootstrap", args, args, reply); done {
 		return err
 	}
@@ -250,6 +282,12 @@ func (a *ACL) Bootstrap(args *structs.ACLTokenBootstrapRequest, reply *structs.A
 
 // UpsertTokens is used to create or update a set of tokens
 func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.ACLTokenUpsertResponse) error {
+	// Ensure ACLs are enabled, and always flow modification requests to the authoritative region
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
+	args.Region = a.srv.config.AuthoritativeRegion
+
 	if done, err := a.srv.forward("ACL.UpsertTokens", args, args, reply); done {
 		return err
 	}
@@ -322,6 +360,12 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.A
 
 // DeleteTokens is used to delete tokens
 func (a *ACL) DeleteTokens(args *structs.ACLTokenDeleteRequest, reply *structs.GenericResponse) error {
+	// Ensure ACLs are enabled, and always flow modification requests to the authoritative region
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
+	args.Region = a.srv.config.AuthoritativeRegion
+
 	if done, err := a.srv.forward("ACL.DeleteTokens", args, args, reply); done {
 		return err
 	}
@@ -345,6 +389,9 @@ func (a *ACL) DeleteTokens(args *structs.ACLTokenDeleteRequest, reply *structs.G
 
 // ListTokens is used to list the tokens
 func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTokenListResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
 	if done, err := a.srv.forward("ACL.ListTokens", args, args, reply); done {
 		return err
 	}
@@ -393,6 +440,9 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 
 // GetToken is used to get a specific token
 func (a *ACL) GetToken(args *structs.ACLTokenSpecificRequest, reply *structs.SingleACLTokenResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
 	if done, err := a.srv.forward("ACL.GetToken", args, args, reply); done {
 		return err
 	}
@@ -428,6 +478,9 @@ func (a *ACL) GetToken(args *structs.ACLTokenSpecificRequest, reply *structs.Sin
 
 // GetTokens is used to get a set of token
 func (a *ACL) GetTokens(args *structs.ACLTokenSetRequest, reply *structs.ACLTokenSetResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
 	if done, err := a.srv.forward("ACL.GetTokens", args, args, reply); done {
 		return err
 	}
@@ -465,6 +518,9 @@ func (a *ACL) GetTokens(args *structs.ACLTokenSetRequest, reply *structs.ACLToke
 
 // ResolveToken is used to lookup a specific token by a secret ID. This is used for enforcing ACLs by clients.
 func (a *ACL) ResolveToken(args *structs.ResolveACLTokenRequest, reply *structs.ResolveACLTokenResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
 	if done, err := a.srv.forward("ACL.ResolveToken", args, args, reply); done {
 		return err
 	}

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestACLEndpoint_GetPolicy(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -46,7 +46,7 @@ func TestACLEndpoint_GetPolicy(t *testing.T) {
 
 func TestACLEndpoint_GetPolicy_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -124,7 +124,7 @@ func TestACLEndpoint_GetPolicy_Blocking(t *testing.T) {
 
 func TestACLEndpoint_GetPolicies(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -160,7 +160,7 @@ func TestACLEndpoint_GetPolicies(t *testing.T) {
 
 func TestACLEndpoint_GetPolicies_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -238,7 +238,7 @@ func TestACLEndpoint_GetPolicies_Blocking(t *testing.T) {
 
 func TestACLEndpoint_ListPolicies(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -279,7 +279,7 @@ func TestACLEndpoint_ListPolicies(t *testing.T) {
 
 func TestACLEndpoint_ListPolicies_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -338,7 +338,7 @@ func TestACLEndpoint_ListPolicies_Blocking(t *testing.T) {
 
 func TestACLEndpoint_DeletePolicies(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -361,7 +361,7 @@ func TestACLEndpoint_DeletePolicies(t *testing.T) {
 
 func TestACLEndpoint_UpsertPolicies(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -388,7 +388,7 @@ func TestACLEndpoint_UpsertPolicies(t *testing.T) {
 
 func TestACLEndpoint_UpsertPolicies_Invalid(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -412,7 +412,7 @@ func TestACLEndpoint_UpsertPolicies_Invalid(t *testing.T) {
 
 func TestACLEndpoint_GetToken(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -444,7 +444,7 @@ func TestACLEndpoint_GetToken(t *testing.T) {
 
 func TestACLEndpoint_GetToken_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -522,7 +522,7 @@ func TestACLEndpoint_GetToken_Blocking(t *testing.T) {
 
 func TestACLEndpoint_GetTokens(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -557,7 +557,7 @@ func TestACLEndpoint_GetTokens(t *testing.T) {
 
 func TestACLEndpoint_GetTokens_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -635,7 +635,7 @@ func TestACLEndpoint_GetTokens_Blocking(t *testing.T) {
 
 func TestACLEndpoint_ListTokens(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -658,7 +658,7 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	assert.Equal(t, uint64(1000), resp.Index)
-	assert.Equal(t, 2, len(resp.Tokens))
+	assert.Equal(t, 3, len(resp.Tokens))
 
 	// Lookup the tokens by prefix
 	get = &structs.ACLTokenListRequest{
@@ -686,12 +686,12 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	assert.Equal(t, uint64(1000), resp3.Index)
-	assert.Equal(t, 1, len(resp3.Tokens))
+	assert.Equal(t, 2, len(resp3.Tokens))
 }
 
 func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -702,7 +702,7 @@ func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 
 	// Upsert eval triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertACLTokens(2, []*structs.ACLToken{token}); err != nil {
+		if err := state.UpsertACLTokens(3, []*structs.ACLToken{token}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -710,7 +710,7 @@ func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 	req := &structs.ACLTokenListRequest{
 		QueryOptions: structs.QueryOptions{
 			Region:        "global",
-			MinQueryIndex: 1,
+			MinQueryIndex: 2,
 		},
 	}
 	start := time.Now()
@@ -722,19 +722,19 @@ func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
 		t.Fatalf("should block (returned in %s) %#v", elapsed, resp)
 	}
-	assert.Equal(t, uint64(2), resp.Index)
-	if len(resp.Tokens) != 1 || resp.Tokens[0].AccessorID != token.AccessorID {
+	assert.Equal(t, uint64(3), resp.Index)
+	if len(resp.Tokens) != 2 {
 		t.Fatalf("bad: %#v", resp.Tokens)
 	}
 
 	// Eval deletion triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.DeleteACLTokens(3, []string{token.AccessorID}); err != nil {
+		if err := state.DeleteACLTokens(4, []string{token.AccessorID}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
 
-	req.MinQueryIndex = 2
+	req.MinQueryIndex = 3
 	start = time.Now()
 	var resp2 structs.ACLTokenListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", req, &resp2); err != nil {
@@ -744,13 +744,13 @@ func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
 		t.Fatalf("should block (returned in %s) %#v", elapsed, resp2)
 	}
-	assert.Equal(t, uint64(3), resp2.Index)
-	assert.Equal(t, 0, len(resp2.Tokens))
+	assert.Equal(t, uint64(4), resp2.Index)
+	assert.Equal(t, 1, len(resp2.Tokens))
 }
 
 func TestACLEndpoint_DeleteTokens(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -773,7 +773,9 @@ func TestACLEndpoint_DeleteTokens(t *testing.T) {
 
 func TestACLEndpoint_Bootstrap(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1 := testServer(t, func(c *Config) {
+		c.ACLEnabled = true
+	})
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -806,7 +808,7 @@ func TestACLEndpoint_Bootstrap(t *testing.T) {
 
 func TestACLEndpoint_UpsertTokens(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -859,7 +861,7 @@ func TestACLEndpoint_UpsertTokens(t *testing.T) {
 
 func TestACLEndpoint_UpsertTokens_Invalid(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -883,7 +885,7 @@ func TestACLEndpoint_UpsertTokens_Invalid(t *testing.T) {
 
 func TestACLEndpoint_ResolveToken(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, nil)
+	s1, _ := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestACLEndpoint_GetPolicy(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -25,8 +25,11 @@ func TestACLEndpoint_GetPolicy(t *testing.T) {
 
 	// Lookup the policy
 	get := &structs.ACLPolicySpecificRequest{
-		Name:         policy.Name,
-		QueryOptions: structs.QueryOptions{Region: "global"},
+		Name: policy.Name,
+		QueryOptions: structs.QueryOptions{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.SingleACLPolicyResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetPolicy", get, &resp); err != nil {
@@ -46,7 +49,7 @@ func TestACLEndpoint_GetPolicy(t *testing.T) {
 
 func TestACLEndpoint_GetPolicy_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -78,6 +81,7 @@ func TestACLEndpoint_GetPolicy_Blocking(t *testing.T) {
 		QueryOptions: structs.QueryOptions{
 			Region:        "global",
 			MinQueryIndex: 150,
+			SecretID:      root.SecretID,
 		},
 	}
 	var resp structs.SingleACLPolicyResponse
@@ -124,7 +128,7 @@ func TestACLEndpoint_GetPolicy_Blocking(t *testing.T) {
 
 func TestACLEndpoint_GetPolicies(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -136,8 +140,11 @@ func TestACLEndpoint_GetPolicies(t *testing.T) {
 
 	// Lookup the policy
 	get := &structs.ACLPolicySetRequest{
-		Names:        []string{policy.Name, policy2.Name},
-		QueryOptions: structs.QueryOptions{Region: "global"},
+		Names: []string{policy.Name, policy2.Name},
+		QueryOptions: structs.QueryOptions{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.ACLPolicySetResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetPolicies", get, &resp); err != nil {
@@ -160,7 +167,7 @@ func TestACLEndpoint_GetPolicies(t *testing.T) {
 
 func TestACLEndpoint_GetPolicies_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -192,6 +199,7 @@ func TestACLEndpoint_GetPolicies_Blocking(t *testing.T) {
 		QueryOptions: structs.QueryOptions{
 			Region:        "global",
 			MinQueryIndex: 150,
+			SecretID:      root.SecretID,
 		},
 	}
 	var resp structs.ACLPolicySetResponse
@@ -238,7 +246,7 @@ func TestACLEndpoint_GetPolicies_Blocking(t *testing.T) {
 
 func TestACLEndpoint_ListPolicies(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -253,7 +261,10 @@ func TestACLEndpoint_ListPolicies(t *testing.T) {
 
 	// Lookup the policies
 	get := &structs.ACLPolicyListRequest{
-		QueryOptions: structs.QueryOptions{Region: "global"},
+		QueryOptions: structs.QueryOptions{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.ACLPolicyListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListPolicies", get, &resp); err != nil {
@@ -265,8 +276,9 @@ func TestACLEndpoint_ListPolicies(t *testing.T) {
 	// Lookup the policies by prefix
 	get = &structs.ACLPolicyListRequest{
 		QueryOptions: structs.QueryOptions{
-			Region: "global",
-			Prefix: "aaaabb",
+			Region:   "global",
+			Prefix:   "aaaabb",
+			SecretID: root.SecretID,
 		},
 	}
 	var resp2 structs.ACLPolicyListResponse
@@ -279,7 +291,7 @@ func TestACLEndpoint_ListPolicies(t *testing.T) {
 
 func TestACLEndpoint_ListPolicies_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -299,6 +311,7 @@ func TestACLEndpoint_ListPolicies_Blocking(t *testing.T) {
 		QueryOptions: structs.QueryOptions{
 			Region:        "global",
 			MinQueryIndex: 1,
+			SecretID:      root.SecretID,
 		},
 	}
 	start := time.Now()
@@ -338,7 +351,7 @@ func TestACLEndpoint_ListPolicies_Blocking(t *testing.T) {
 
 func TestACLEndpoint_DeletePolicies(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -349,8 +362,11 @@ func TestACLEndpoint_DeletePolicies(t *testing.T) {
 
 	// Lookup the policies
 	req := &structs.ACLPolicyDeleteRequest{
-		Names:        []string{p1.Name},
-		WriteRequest: structs.WriteRequest{Region: "global"},
+		Names: []string{p1.Name},
+		WriteRequest: structs.WriteRequest{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.GenericResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.DeletePolicies", req, &resp); err != nil {
@@ -361,7 +377,7 @@ func TestACLEndpoint_DeletePolicies(t *testing.T) {
 
 func TestACLEndpoint_UpsertPolicies(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -371,8 +387,11 @@ func TestACLEndpoint_UpsertPolicies(t *testing.T) {
 
 	// Lookup the policies
 	req := &structs.ACLPolicyUpsertRequest{
-		Policies:     []*structs.ACLPolicy{p1},
-		WriteRequest: structs.WriteRequest{Region: "global"},
+		Policies: []*structs.ACLPolicy{p1},
+		WriteRequest: structs.WriteRequest{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.GenericResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.UpsertPolicies", req, &resp); err != nil {
@@ -388,7 +407,7 @@ func TestACLEndpoint_UpsertPolicies(t *testing.T) {
 
 func TestACLEndpoint_UpsertPolicies_Invalid(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -399,8 +418,11 @@ func TestACLEndpoint_UpsertPolicies_Invalid(t *testing.T) {
 
 	// Lookup the policies
 	req := &structs.ACLPolicyUpsertRequest{
-		Policies:     []*structs.ACLPolicy{p1},
-		WriteRequest: structs.WriteRequest{Region: "global"},
+		Policies: []*structs.ACLPolicy{p1},
+		WriteRequest: structs.WriteRequest{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ACL.UpsertPolicies", req, &resp)
@@ -412,7 +434,7 @@ func TestACLEndpoint_UpsertPolicies_Invalid(t *testing.T) {
 
 func TestACLEndpoint_GetToken(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -423,8 +445,11 @@ func TestACLEndpoint_GetToken(t *testing.T) {
 
 	// Lookup the token
 	get := &structs.ACLTokenSpecificRequest{
-		AccessorID:   token.AccessorID,
-		QueryOptions: structs.QueryOptions{Region: "global"},
+		AccessorID: token.AccessorID,
+		QueryOptions: structs.QueryOptions{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.SingleACLTokenResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetToken", get, &resp); err != nil {
@@ -444,7 +469,7 @@ func TestACLEndpoint_GetToken(t *testing.T) {
 
 func TestACLEndpoint_GetToken_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -476,6 +501,7 @@ func TestACLEndpoint_GetToken_Blocking(t *testing.T) {
 		QueryOptions: structs.QueryOptions{
 			Region:        "global",
 			MinQueryIndex: 150,
+			SecretID:      root.SecretID,
 		},
 	}
 	var resp structs.SingleACLTokenResponse
@@ -522,7 +548,7 @@ func TestACLEndpoint_GetToken_Blocking(t *testing.T) {
 
 func TestACLEndpoint_GetTokens(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -534,8 +560,11 @@ func TestACLEndpoint_GetTokens(t *testing.T) {
 
 	// Lookup the token
 	get := &structs.ACLTokenSetRequest{
-		AccessorIDS:  []string{token.AccessorID, token2.AccessorID},
-		QueryOptions: structs.QueryOptions{Region: "global"},
+		AccessorIDS: []string{token.AccessorID, token2.AccessorID},
+		QueryOptions: structs.QueryOptions{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.ACLTokenSetResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetTokens", get, &resp); err != nil {
@@ -557,7 +586,7 @@ func TestACLEndpoint_GetTokens(t *testing.T) {
 
 func TestACLEndpoint_GetTokens_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -589,6 +618,7 @@ func TestACLEndpoint_GetTokens_Blocking(t *testing.T) {
 		QueryOptions: structs.QueryOptions{
 			Region:        "global",
 			MinQueryIndex: 150,
+			SecretID:      root.SecretID,
 		},
 	}
 	var resp structs.ACLTokenSetResponse
@@ -635,7 +665,7 @@ func TestACLEndpoint_GetTokens_Blocking(t *testing.T) {
 
 func TestACLEndpoint_ListTokens(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -651,7 +681,10 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 
 	// Lookup the tokens
 	get := &structs.ACLTokenListRequest{
-		QueryOptions: structs.QueryOptions{Region: "global"},
+		QueryOptions: structs.QueryOptions{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.ACLTokenListResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", get, &resp); err != nil {
@@ -663,8 +696,9 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 	// Lookup the tokens by prefix
 	get = &structs.ACLTokenListRequest{
 		QueryOptions: structs.QueryOptions{
-			Region: "global",
-			Prefix: "aaaabb",
+			Region:   "global",
+			Prefix:   "aaaabb",
+			SecretID: root.SecretID,
 		},
 	}
 	var resp2 structs.ACLTokenListResponse
@@ -678,7 +712,8 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 	get = &structs.ACLTokenListRequest{
 		GlobalOnly: true,
 		QueryOptions: structs.QueryOptions{
-			Region: "global",
+			Region:   "global",
+			SecretID: root.SecretID,
 		},
 	}
 	var resp3 structs.ACLTokenListResponse
@@ -691,7 +726,7 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 
 func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
@@ -711,6 +746,7 @@ func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 		QueryOptions: structs.QueryOptions{
 			Region:        "global",
 			MinQueryIndex: 2,
+			SecretID:      root.SecretID,
 		},
 	}
 	start := time.Now()
@@ -750,7 +786,7 @@ func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 
 func TestACLEndpoint_DeleteTokens(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -761,8 +797,11 @@ func TestACLEndpoint_DeleteTokens(t *testing.T) {
 
 	// Lookup the tokens
 	req := &structs.ACLTokenDeleteRequest{
-		AccessorIDs:  []string{p1.AccessorID},
-		WriteRequest: structs.WriteRequest{Region: "global"},
+		AccessorIDs: []string{p1.AccessorID},
+		WriteRequest: structs.WriteRequest{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.GenericResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.DeleteTokens", req, &resp); err != nil {
@@ -808,7 +847,7 @@ func TestACLEndpoint_Bootstrap(t *testing.T) {
 
 func TestACLEndpoint_UpsertTokens(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -819,8 +858,11 @@ func TestACLEndpoint_UpsertTokens(t *testing.T) {
 
 	// Lookup the tokens
 	req := &structs.ACLTokenUpsertRequest{
-		Tokens:       []*structs.ACLToken{p1},
-		WriteRequest: structs.WriteRequest{Region: "global"},
+		Tokens: []*structs.ACLToken{p1},
+		WriteRequest: structs.WriteRequest{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.ACLTokenUpsertResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.UpsertTokens", req, &resp); err != nil {
@@ -861,7 +903,7 @@ func TestACLEndpoint_UpsertTokens(t *testing.T) {
 
 func TestACLEndpoint_UpsertTokens_Invalid(t *testing.T) {
 	t.Parallel()
-	s1, _ := testACLServer(t, nil)
+	s1, root := testACLServer(t, nil)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -872,8 +914,11 @@ func TestACLEndpoint_UpsertTokens_Invalid(t *testing.T) {
 
 	// Lookup the tokens
 	req := &structs.ACLTokenUpsertRequest{
-		Tokens:       []*structs.ACLToken{p1},
-		WriteRequest: structs.WriteRequest{Region: "global"},
+		Tokens: []*structs.ACLToken{p1},
+		WriteRequest: structs.WriteRequest{
+			Region:   "global",
+			SecretID: root.SecretID,
+		},
 	}
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ACL.UpsertTokens", req, &resp)

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -43,7 +43,7 @@ func TestResolveACLToken(t *testing.T) {
 	// Attempt resolution of unknown token. Should fail.
 	randID := structs.GenerateUUID()
 	aclObj, err = resolveTokenFromSnapshotCache(snap, cache, randID)
-	assert.Equal(t, structs.TokenNotFound, err)
+	assert.Equal(t, structs.ErrTokenNotFound, err)
 	assert.Nil(t, aclObj)
 
 	// Attempt resolution of management token. Should get singleton.

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -235,6 +235,10 @@ type Config struct {
 	// ReplicationBackoff is how much we backoff when replication errors.
 	// This is a tunable knob for testing primarily.
 	ReplicationBackoff time.Duration
+
+	// ReplicationToken is the ACL Token Secret ID used to fetch from
+	// the Authoritative Region.
+	ReplicationToken string
 }
 
 // CheckVersion is used to check if the ProtocolVersion is valid

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -686,6 +686,7 @@ START:
 
 			// Fetch the list of policies
 			var resp structs.ACLPolicyListResponse
+			req.SecretID = s.ReplicationToken()
 			err := s.forwardRegion(s.config.AuthoritativeRegion,
 				"ACL.ListPolicies", &req, &resp)
 			if err != nil {
@@ -714,7 +715,8 @@ START:
 				req := structs.ACLPolicySetRequest{
 					Names: update,
 					QueryOptions: structs.QueryOptions{
-						Region: s.config.AuthoritativeRegion,
+						Region:   s.config.AuthoritativeRegion,
+						SecretID: s.ReplicationToken(),
 					},
 				}
 				var reply structs.ACLPolicySetResponse
@@ -826,6 +828,7 @@ START:
 
 			// Fetch the list of tokens
 			var resp structs.ACLTokenListResponse
+			req.SecretID = s.ReplicationToken()
 			err := s.forwardRegion(s.config.AuthoritativeRegion,
 				"ACL.ListTokens", &req, &resp)
 			if err != nil {
@@ -854,7 +857,8 @@ START:
 				req := structs.ACLTokenSetRequest{
 					AccessorIDS: update,
 					QueryOptions: structs.QueryOptions{
-						Region: s.config.AuthoritativeRegion,
+						Region:   s.config.AuthoritativeRegion,
+						SecretID: s.ReplicationToken(),
 					},
 				}
 				var reply structs.ACLTokenSetResponse

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -621,17 +621,18 @@ func TestLeader_RestoreVaultAccessors(t *testing.T) {
 
 func TestLeader_ReplicateACLPolicies(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, func(c *Config) {
+	s1, root := testACLServer(t, func(c *Config) {
 		c.Region = "region1"
 		c.AuthoritativeRegion = "region1"
 		c.ACLEnabled = true
 	})
 	defer s1.Shutdown()
-	s2 := testServer(t, func(c *Config) {
+	s2, _ := testACLServer(t, func(c *Config) {
 		c.Region = "region2"
 		c.AuthoritativeRegion = "region1"
 		c.ACLEnabled = true
 		c.ReplicationBackoff = 20 * time.Millisecond
+		c.ReplicationToken = root.SecretID
 	})
 	defer s2.Shutdown()
 	testJoin(t, s1, s2)
@@ -691,17 +692,18 @@ func TestLeader_DiffACLPolicies(t *testing.T) {
 
 func TestLeader_ReplicateACLTokens(t *testing.T) {
 	t.Parallel()
-	s1 := testServer(t, func(c *Config) {
+	s1, root := testACLServer(t, func(c *Config) {
 		c.Region = "region1"
 		c.AuthoritativeRegion = "region1"
 		c.ACLEnabled = true
 	})
 	defer s1.Shutdown()
-	s2 := testServer(t, func(c *Config) {
+	s2, _ := testACLServer(t, func(c *Config) {
 		c.Region = "region2"
 		c.AuthoritativeRegion = "region1"
 		c.ACLEnabled = true
 		c.ReplicationBackoff = 20 * time.Millisecond
+		c.ReplicationToken = root.SecretID
 	})
 	defer s2.Shutdown()
 	testJoin(t, s1, s2)

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -371,3 +371,16 @@ func ACLToken() *structs.ACLToken {
 		ModifyIndex: 20,
 	}
 }
+
+func ACLManagementToken() *structs.ACLToken {
+	return &structs.ACLToken{
+		AccessorID:  structs.GenerateUUID(),
+		SecretID:    structs.GenerateUUID(),
+		Name:        "management " + structs.GenerateUUID(),
+		Type:        "management",
+		Global:      true,
+		CreateTime:  time.Now().UTC(),
+		CreateIndex: 10,
+		ModifyIndex: 20,
+	}
+}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1152,6 +1152,12 @@ func (s *Server) GetConfig() *Config {
 	return s.config
 }
 
+// ReplicationToken returns the token used for replication. We use a method to support
+// dynamic reloading of this value later.
+func (s *Server) ReplicationToken() string {
+	return s.config.ReplicationToken
+}
+
 // peersInfoContent is used to help operators understand what happened to the
 // peers.json file. This is written to a file called peers.info in the same
 // location.

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/command/agent/consul"
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
@@ -36,6 +37,21 @@ func tmpDir(t *testing.T) string {
 		t.Fatalf("err: %v", err)
 	}
 	return dir
+}
+
+func testACLServer(t *testing.T, cb func(*Config)) (*Server, *structs.ACLToken) {
+	server := testServer(t, func(c *Config) {
+		c.ACLEnabled = true
+		if cb != nil {
+			cb(c)
+		}
+	})
+	token := mock.ACLManagementToken()
+	err := server.State().BootstrapACLTokens(1, token)
+	if err != nil {
+		t.Fatalf("failed to bootstrap ACL token: %v", err)
+	}
+	return server, token
 }
 
 func testServer(t *testing.T, cb func(*Config)) *Server {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5421,6 +5421,24 @@ func (a *ACLToken) Validate() error {
 	return mErr.ErrorOrNil()
 }
 
+// PolicySubset checks if a given set of policies is a subset of the token
+func (a *ACLToken) PolicySubset(policies []string) bool {
+	// Hot-path the management tokens, superset of all policies.
+	if a.Type == ACLManagementToken {
+		return true
+	}
+	associatedPolicies := make(map[string]struct{}, len(a.Policies))
+	for _, policy := range a.Policies {
+		associatedPolicies[policy] = struct{}{}
+	}
+	for _, policy := range policies {
+		if _, ok := associatedPolicies[policy]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // ACLTokenListRequest is used to request a list of tokens
 type ACLTokenListRequest struct {
 	GlobalOnly bool

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -34,8 +34,10 @@ import (
 )
 
 var (
-	ErrNoLeader     = fmt.Errorf("No cluster leader")
-	ErrNoRegionPath = fmt.Errorf("No path to region")
+	ErrNoLeader         = fmt.Errorf("No cluster leader")
+	ErrNoRegionPath     = fmt.Errorf("No path to region")
+	ErrTokenNotFound    = errors.New("ACL token not found")
+	ErrPermissionDenied = errors.New("Permission denied")
 
 	// validPolicyName is used to validate a policy name
 	validPolicyName = regexp.MustCompile("^[a-zA-Z0-9-]{1,128}$")
@@ -5348,9 +5350,6 @@ type ACLPolicyUpsertRequest struct {
 	Policies []*ACLPolicy
 	WriteRequest
 }
-
-// TokenNotFound indicates the Token was not found
-var TokenNotFound = errors.New("ACL token not found")
 
 // ACLToken represents a client token which is used to Authenticate
 type ACLToken struct {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -133,6 +133,9 @@ type QueryOptions struct {
 
 	// If set, used as prefix for resource list searches
 	Prefix string
+
+	// SecretID is secret portion of the ACL token used for the request
+	SecretID string
 }
 
 func (q QueryOptions) RequestRegion() string {
@@ -151,6 +154,9 @@ func (q QueryOptions) AllowStaleRead() bool {
 type WriteRequest struct {
 	// The target region for this write
 	Region string
+
+	// SecretID is secret portion of the ACL token used for the request
+	SecretID string
 }
 
 func (w WriteRequest) RequestRegion() string {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2300,3 +2300,28 @@ func TestACLTokenValidate(t *testing.T) {
 	err = tk.Validate()
 	assert.Nil(t, err)
 }
+
+func TestACLTokenPolicySubset(t *testing.T) {
+	tk := &ACLToken{
+		Type:     ACLClientToken,
+		Policies: []string{"foo", "bar", "baz"},
+	}
+
+	assert.Equal(t, true, tk.PolicySubset([]string{"foo", "bar", "baz"}))
+	assert.Equal(t, true, tk.PolicySubset([]string{"foo", "bar"}))
+	assert.Equal(t, true, tk.PolicySubset([]string{"foo"}))
+	assert.Equal(t, true, tk.PolicySubset([]string{}))
+	assert.Equal(t, false, tk.PolicySubset([]string{"foo", "bar", "new"}))
+	assert.Equal(t, false, tk.PolicySubset([]string{"new"}))
+
+	tk = &ACLToken{
+		Type: ACLManagementToken,
+	}
+
+	assert.Equal(t, true, tk.PolicySubset([]string{"foo", "bar", "baz"}))
+	assert.Equal(t, true, tk.PolicySubset([]string{"foo", "bar"}))
+	assert.Equal(t, true, tk.PolicySubset([]string{"foo"}))
+	assert.Equal(t, true, tk.PolicySubset([]string{}))
+	assert.Equal(t, true, tk.PolicySubset([]string{"foo", "bar", "new"}))
+	assert.Equal(t, true, tk.PolicySubset([]string{"new"}))
+}


### PR DESCRIPTION
This PR builds on #3064. It adds enforcement that ACL tokens are provided for ACL related endpoints. It also verifies that ACLs are enabled. For global tokens, Upsert/Delete requests are forwarded to the authoritative region.