### PR TITLE
Add ACL Enforcement for Job Submission

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -41,6 +41,9 @@ type QueryOptions struct {
 
 	// Set HTTP parameters on the query.
 	Params map[string]string
+
+	// SecretID is the secret ID of an ACL token
+	SecretID string
 }
 
 // WriteOptions are used to parameterize a write
@@ -48,6 +51,9 @@ type WriteOptions struct {
 	// Providing a datacenter overwrites the region provided
 	// by the Config
 	Region string
+
+	// SecretID is the secret ID of an ACL token
+	SecretID string
 }
 
 // QueryMeta is used to return meta data about a query

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -692,6 +692,9 @@ func (j *Job) AddPeriodicConfig(cfg *PeriodicConfig) *Job {
 type WriteRequest struct {
 	// The target region for this write
 	Region string
+
+	// SecretID is the secret ID of an ACL token
+	SecretID string
 }
 
 // JobValidateRequest is used to validate a job

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -349,6 +349,7 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 		return nil, CodedError(400, "Job ID does not match name")
 	}
 	s.parseRegion(req, &args.Region)
+	s.parseToken(req, &args.SecretID)
 
 	sJob := ApiJobToStructJob(args.Job)
 
@@ -357,7 +358,8 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 		EnforceIndex:   args.EnforceIndex,
 		JobModifyIndex: args.JobModifyIndex,
 		WriteRequest: structs.WriteRequest{
-			Region: args.WriteRequest.Region,
+			Region:   args.WriteRequest.Region,
+			SecretID: args.WriteRequest.SecretID,
 		},
 	}
 	var out structs.JobRegisterResponse

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -171,6 +171,36 @@ func TestHTTP_JobsRegister(t *testing.T) {
 	})
 }
 
+func TestHTTP_JobsRegister_ACL(t *testing.T) {
+	t.Parallel()
+	httpACLTest(t, nil, func(s *TestAgent) {
+		// Create the job
+		job := api.MockJob()
+		args := api.JobRegisterRequest{
+			Job: job,
+			WriteRequest: api.WriteRequest{
+				Region: "global",
+			},
+		}
+		buf := encodeReq(args)
+
+		// Make the HTTP request
+		req, err := http.NewRequest("PUT", "/v1/jobs", buf)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respW := httptest.NewRecorder()
+		setToken(req, s.Token)
+
+		// Make the request
+		obj, err := s.Server.JobsRequest(respW, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		assert.NotNil(t, obj)
+	})
+}
+
 func TestHTTP_JobsRegister_Defaulting(t *testing.T) {
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -171,6 +171,7 @@ func TestHTTP_JobsRegister(t *testing.T) {
 	})
 }
 
+// Test that ACL token is properly threaded through to the RPC endpoint
 func TestHTTP_JobsRegister_ACL(t *testing.T) {
 	t.Parallel()
 	httpACLTest(t, nil, func(s *TestAgent) {

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -93,6 +93,49 @@ func TestJobEndpoint_Register(t *testing.T) {
 	}
 }
 
+func TestJobEndpoint_Register_ACL(t *testing.T) {
+	t.Parallel()
+	s1, root := testACLServer(t, func(c *Config) {
+		c.NumSchedulers = 0 // Prevent automatic dequeue
+	})
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	job := mock.Job()
+	req := &structs.JobRegisterRequest{
+		Job:          job,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	// Try without a token, expect failure
+	var resp structs.JobRegisterResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp); err == nil {
+		t.Fatalf("expected error")
+	}
+
+	// Try with a token
+	req.SecretID = root.SecretID
+	if err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp.Index == 0 {
+		t.Fatalf("bad index: %d", resp.Index)
+	}
+
+	// Check for the node in the FSM
+	state := s1.fsm.State()
+	ws := memdb.NewWatchSet()
+	out, err := state.JobByID(ws, job.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out == nil {
+		t.Fatalf("expected job")
+	}
+}
+
 func TestJobEndpoint_Register_InvalidDriverConfig(t *testing.T) {
 	t.Parallel()
 	s1 := testServer(t, func(c *Config) {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -108,6 +108,9 @@ const (
 	// ACLClientToken and ACLManagementToken are the only types of tokens
 	ACLClientToken     = "client"
 	ACLManagementToken = "management"
+
+	// DefaultNamespace is the default namespace.
+	DefaultNamespace = "default"
 )
 
 // RPCInfo is used to describe common information about query


### PR DESCRIPTION
This PR builds on #3065. Specifically, this implements the enforcement of ACLs for Job Submission, with all changes needed on the RPC endpoint and HTTP handler. It's an example of what needs to be extended to all endpoints.