### PR TITLE
Placing allocs counts towards placement limit

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -374,6 +374,9 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 		for _, p := range place {
 			a.result.place = append(a.result.place, p)
 		}
+
+		min := helper.IntMin(len(place), limit)
+		limit -= min
 	} else if !deploymentPlaceReady && len(lost) != 0 {
 		// We are in a situation where we shouldn't be placing more than we need
 		// to but we have lost allocations. It is a very weird user experience


### PR DESCRIPTION
This PR makes placing new allocations count towards the limit. We do not
restrict how many new placements are made by the limit but we still
count towards the limit. This has the nice affect that if you have a
group with count = 5 and max_parallel = 1 but only 3 allocs exist for it
and a change is made, you will create 2 more at the new version but not
destroy one, taking you down to two running as you would have
previously.

Fixes https://github.com/hashicorp/nomad/issues/3053