### PR TITLE
Allow retry of 500 API errors to be handled by restart policies

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -666,7 +666,7 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (*StartRespon
 		if err := d.startContainer(container); err != nil {
 			d.logger.Printf("[ERR] driver.docker: failed to start container %s: %s", container.ID, err)
 			pluginClient.Kill()
-			return nil, fmt.Errorf("Failed to start container %s: %s", container.ID, err)
+			return nil, structs.NewRecoverableError(fmt.Errorf("Failed to start container %s: %s", container.ID, err), structs.IsRecoverable(err))
 		}
 
 		// InspectContainer to get all of the container metadata as
@@ -1384,6 +1384,7 @@ START:
 			time.Sleep(1 * time.Second)
 			goto START
 		}
+		return structs.NewRecoverableError(startErr, true)
 	}
 
 	return recoverableErrTimeouts(startErr)


### PR DESCRIPTION
API error 500 from docker is often recoverable, in our case we typically see this error from a volume driver after a container crashes. The volume driver must wait for a timeout from the now dead container before allowing a new container to mount it. This can take longer than 5 seconds.

Allowing these retires to be handled by the jobs configured restart policies seems to be a more intuitive solution than having a special hard-coded retry just for these errors.