### PR TITLE
Root permissions are needed for testing certain functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ install:
   - make bootstrap
 
 script:
-  - make travis
+  - sudo -E "PATH=$PATH" make travis


### PR DESCRIPTION
When running tests, some require root permissions to test certain functionality, such as container creation