### PR TITLE
Autocomplete arguments for remaining commands

### DIFF
--- a/api/contexts/contexts.go
+++ b/api/contexts/contexts.go
@@ -4,9 +4,10 @@ package contexts
 type Context string
 
 const (
-	Allocs Context = "allocs"
-	Evals  Context = "evals"
-	Jobs   Context = "jobs"
-	Nodes  Context = "nodes"
-	All    Context = ""
+	Allocs      Context = "allocs"
+	Deployments Context = "deployment"
+	Evals       Context = "evals"
+	Jobs        Context = "jobs"
+	Nodes       Context = "nodes"
+	All         Context = ""
 )

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -60,6 +60,26 @@ func (c *AllocStatusCommand) Synopsis() string {
 	return "Display allocation status information and metadata"
 }
 
+func (c *AllocStatusCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *AllocStatusCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Allocs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Allocs]
+	})
+}
+
 func (c *AllocStatusCommand) Run(args []string) int {
 	var short, displayStats, verbose, json bool
 	var tmpl string
@@ -192,26 +212,6 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	}
 
 	return 0
-}
-
-func (c *AllocStatusCommand) AutocompleteFlags() complete.Flags {
-	return nil
-}
-
-func (c *AllocStatusCommand) AutocompleteArgs() complete.Predictor {
-	client, _ := c.Meta.Client()
-
-	return complete.PredictFunc(func(a complete.Args) []string {
-		if len(a.Completed) > 1 {
-			return nil
-		}
-
-		resp, err := client.Search().PrefixSearch(a.Last, contexts.Allocs)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Allocs]
-	})
 }
 
 func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength int, verbose bool) (string, error) {

--- a/command/deployment_fail.go
+++ b/command/deployment_fail.go
@@ -3,6 +3,9 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type DeploymentFailCommand struct {
@@ -37,6 +40,25 @@ Fail Options:
 
 func (c *DeploymentFailCommand) Synopsis() string {
 	return "Manually fail a deployment"
+}
+
+func (c *DeploymentFailCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *DeploymentFailCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Deployments)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Deployments]
+	})
 }
 
 func (c *DeploymentFailCommand) Run(args []string) int {

--- a/command/deployment_fail_test.go
+++ b/command/deployment_fail_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDeploymentFailCommand_Implements(t *testing.T) {
@@ -33,4 +36,35 @@ func TestDeploymentFailCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestDeploymentFailCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &DeploymentFailCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake deployment
+	state := srv.Agent.Server().State()
+	d := mock.Deployment()
+	assert.Nil(state.UpsertDeployment(1000, d))
+
+	prefix := d.ID[:5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(d.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/deployment_pause.go
+++ b/command/deployment_pause.go
@@ -3,6 +3,9 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type DeploymentPauseCommand struct {
@@ -30,6 +33,25 @@ Pause Options:
 
 func (c *DeploymentPauseCommand) Synopsis() string {
 	return "Pause a deployment"
+}
+
+func (c *DeploymentPauseCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *DeploymentPauseCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Deployments)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Deployments]
+	})
 }
 
 func (c *DeploymentPauseCommand) Run(args []string) int {

--- a/command/deployment_pause_test.go
+++ b/command/deployment_pause_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDeploymentPauseCommand_Implements(t *testing.T) {
@@ -33,4 +36,35 @@ func TestDeploymentPauseCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestDeploymentPauseCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &DeploymentPauseCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake deployment
+	state := srv.Agent.Server().State()
+	d := mock.Deployment()
+	assert.Nil(state.UpsertDeployment(1000, d))
+
+	prefix := d.ID[:5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(d.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/deployment_promote.go
+++ b/command/deployment_promote.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
 	flaghelper "github.com/hashicorp/nomad/helper/flag-helpers"
+	"github.com/posener/complete"
 )
 
 type DeploymentPromoteCommand struct {
@@ -47,6 +49,25 @@ Promote Options:
 
 func (c *DeploymentPromoteCommand) Synopsis() string {
 	return "Promote canaries in a deployment"
+}
+
+func (c *DeploymentPromoteCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *DeploymentPromoteCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Deployments)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Deployments]
+	})
 }
 
 func (c *DeploymentPromoteCommand) Run(args []string) int {

--- a/command/deployment_promote_test.go
+++ b/command/deployment_promote_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDeploymentPromoteCommand_Implements(t *testing.T) {
@@ -33,4 +36,35 @@ func TestDeploymentPromoteCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestDeploymentPromoteCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &DeploymentPromoteCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake deployment
+	state := srv.Agent.Server().State()
+	d := mock.Deployment()
+	assert.Nil(state.UpsertDeployment(1000, d))
+
+	prefix := d.ID[:5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(d.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/deployment_resume.go
+++ b/command/deployment_resume.go
@@ -3,6 +3,9 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type DeploymentResumeCommand struct {
@@ -35,6 +38,25 @@ Resume Options:
 
 func (c *DeploymentResumeCommand) Synopsis() string {
 	return "Resume a paused deployment"
+}
+
+func (c *DeploymentResumeCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *DeploymentResumeCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Deployments)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Deployments]
+	})
 }
 
 func (c *DeploymentResumeCommand) Run(args []string) int {

--- a/command/deployment_resume_test.go
+++ b/command/deployment_resume_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDeploymentResumeCommand_Implements(t *testing.T) {
@@ -33,4 +36,35 @@ func TestDeploymentResumeCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestDeploymentResumeCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &DeploymentResumeCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake deployment
+	state := srv.Agent.Server().State()
+	d := mock.Deployment()
+	assert.Nil(state.UpsertDeployment(1000, d))
+
+	prefix := d.ID[:5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(d.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type DeploymentStatusCommand struct {
@@ -38,6 +40,25 @@ Status Options:
 
 func (c *DeploymentStatusCommand) Synopsis() string {
 	return "Display the status of a deployment"
+}
+
+func (c *DeploymentStatusCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *DeploymentStatusCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Deployments)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Deployments]
+	})
 }
 
 func (c *DeploymentStatusCommand) Run(args []string) int {

--- a/command/deployment_status_test.go
+++ b/command/deployment_status_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDeploymentStatusCommand_Implements(t *testing.T) {
@@ -33,4 +36,35 @@ func TestDeploymentStatusCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestDeploymentStatusCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &DeploymentStatusCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake deployment
+	state := srv.Agent.Server().State()
+	d := mock.Deployment()
+	assert.Nil(state.UpsertDeployment(1000, d))
+
+	prefix := d.ID[:5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(d.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -48,6 +48,25 @@ func (c *EvalStatusCommand) Synopsis() string {
 	return "Display evaluation status and placement failure reasons"
 }
 
+func (c *EvalStatusCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *EvalStatusCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Evals)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Evals]
+	})
+}
+
 func (c *EvalStatusCommand) Run(args []string) int {
 	var monitor, verbose, json bool
 	var tmpl string
@@ -218,25 +237,6 @@ func (c *EvalStatusCommand) Run(args []string) int {
 	}
 
 	return 0
-}
-
-func (c *EvalStatusCommand) AutocompleteFlags() complete.Flags {
-	return nil
-}
-
-func (c *EvalStatusCommand) AutocompleteArgs() complete.Predictor {
-	client, _ := c.Meta.Client()
-	return complete.PredictFunc(func(a complete.Args) []string {
-		if len(a.Completed) > 1 {
-			return nil
-		}
-
-		resp, err := client.Search().PrefixSearch(a.Last, contexts.Evals)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Evals]
-	})
 }
 
 func sortedTaskGroupFromMetrics(groups map[string]*api.AllocationMetric) []string {

--- a/command/eval_status_test.go
+++ b/command/eval_status_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/stretchr/testify/assert"
@@ -63,40 +65,24 @@ func TestEvalStatusCommand_AutocompleteArgs(t *testing.T) {
 	assert := assert.New(t)
 	t.Parallel()
 
-	srv, client, url := testServer(t, true, nil)
+	srv, _, url := testServer(t, true, nil)
 	defer srv.Shutdown()
 
 	ui := new(cli.MockUi)
 	cmd := &EvalStatusCommand{Meta: Meta{Ui: ui, flagAddress: url}}
 
-	jobID := "job1_sfx"
-	job1 := testJob(jobID)
-	resp, _, err := client.Jobs().Register(job1, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if code := waitForSuccess(ui, client, fullId, t, resp.EvalID); code != 0 {
-		t.Fatalf("status code non zero saw %d", code)
-	}
+	// Create a fake eval
+	state := srv.Agent.Server().State()
+	e := mock.Eval()
+	assert.Nil(state.UpsertEvals(1000, []*structs.Evaluation{e}))
 
-	// get an eval id
-	evalID := ""
-	if evals, _, err := client.Jobs().Evaluations(jobID, nil); err == nil {
-		if len(evals) > 0 {
-			evalID = evals[0].ID
-		}
-	}
-	if evalID == "" {
-		t.Fatal("unable to find an evaluation")
-	}
-
-	prefix := evalID[:len(evalID)-5]
+	prefix := e.ID[:5]
 	args := complete.Args{Last: prefix}
 	predictor := cmd.AutocompleteArgs()
 
 	res := predictor.Predict(args)
 	assert.Equal(1, len(res))
-	assert.Equal(evalID, res[0])
+	assert.Equal(e.ID, res[0])
 
 	// Autocomplete should only complete once
 	args = complete.Args{Last: prefix, Completed: []string{prefix, "1", "2"}}

--- a/command/fs.go
+++ b/command/fs.go
@@ -12,6 +12,8 @@ import (
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 const (
@@ -75,6 +77,26 @@ FS Specific Options:
 
 func (f *FSCommand) Synopsis() string {
 	return "Inspect the contents of an allocation directory"
+}
+
+func (f *FSCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (f *FSCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := f.Meta.Client()
+
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Allocs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Allocs]
+	})
 }
 
 func (f *FSCommand) Run(args []string) int {

--- a/command/fs_test.go
+++ b/command/fs_test.go
@@ -4,7 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFSCommand_Implements(t *testing.T) {
@@ -81,5 +85,35 @@ func TestFSCommand_Fails(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No allocation(s) with prefix or id") {
 		t.Fatalf("expected not found error, got: %s", out)
 	}
+}
 
+func TestFSCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &FSCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake alloc
+	state := srv.Agent.Server().State()
+	a := mock.Alloc()
+	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+
+	prefix := a.ID[:5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(a.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "1", "2"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/inspect.go
+++ b/command/inspect.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type InspectCommand struct {
@@ -37,6 +39,25 @@ Inspect Options:
 
 func (c *InspectCommand) Synopsis() string {
 	return "Inspect a submitted job"
+}
+
+func (c *InspectCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *InspectCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
 }
 
 func (c *InspectCommand) Run(args []string) int {

--- a/command/inspect_test.go
+++ b/command/inspect_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInspectCommand_Implements(t *testing.T) {
@@ -54,4 +57,34 @@ func TestInspectCommand_Fails(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both json and template formatting are not allowed") {
 		t.Fatalf("expected getting formatter error, got: %s", out)
 	}
+}
+
+func TestInspectCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &JobStatusCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	state := srv.Agent.Server().State()
+	j := mock.Job()
+	assert.Nil(state.UpsertJob(1000, j))
+
+	prefix := j.ID[:len(j.ID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(j.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/inspect_test.go
+++ b/command/inspect_test.go
@@ -67,7 +67,7 @@ func TestInspectCommand_AutocompleteArgs(t *testing.T) {
 	defer srv.Shutdown()
 
 	ui := new(cli.MockUi)
-	cmd := &JobStatusCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+	cmd := &InspectCommand{Meta: Meta{Ui: ui, flagAddress: url}}
 
 	state := srv.Agent.Server().State()
 	j := mock.Job()

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -3,6 +3,9 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type JobDeploymentsCommand struct {
@@ -38,6 +41,25 @@ Deployments Options:
 
 func (c *JobDeploymentsCommand) Synopsis() string {
 	return "List deployments for a job"
+}
+
+func (c *JobDeploymentsCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *JobDeploymentsCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
 }
 
 func (c *JobDeploymentsCommand) Run(args []string) int {

--- a/command/job_deployments_test.go
+++ b/command/job_deployments_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJobDeploymentsCommand_Implements(t *testing.T) {
@@ -33,4 +36,35 @@ func TestJobDeploymentsCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestJobDeploymentsCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &JobDeploymentsCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake job
+	state := srv.Agent.Server().State()
+	j := mock.Job()
+	assert.Nil(state.UpsertJob(1000, j))
+
+	prefix := j.ID[:len(j.ID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(j.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/nomad/api/contexts"
 	flaghelper "github.com/hashicorp/nomad/helper/flag-helpers"
+	"github.com/posener/complete"
 )
 
 type JobDispatchCommand struct {
@@ -52,6 +54,25 @@ Dispatch Options:
 
 func (c *JobDispatchCommand) Synopsis() string {
 	return "Dispatch an instance of a parameterized job"
+}
+
+func (c *JobDispatchCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *JobDispatchCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
 }
 
 func (c *JobDispatchCommand) Run(args []string) int {

--- a/command/job_dispatch_test.go
+++ b/command/job_dispatch_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJobDispatchCommand_Implements(t *testing.T) {
@@ -42,4 +45,35 @@ func TestJobDispatchCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestJobDispatchCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &JobDispatchCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake job
+	state := srv.Agent.Server().State()
+	j := mock.Job()
+	assert.Nil(state.UpsertJob(1000, j))
+
+	prefix := j.ID[:len(j.ID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(j.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 	"github.com/ryanuber/columnize"
 )
 
@@ -50,6 +52,25 @@ History Options:
 
 func (c *JobHistoryCommand) Synopsis() string {
 	return "Display all tracked versions of a job"
+}
+
+func (c *JobHistoryCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *JobHistoryCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
 }
 
 func (c *JobHistoryCommand) Run(args []string) int {

--- a/command/job_history_test.go
+++ b/command/job_history_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJobHistoryCommand_Implements(t *testing.T) {
@@ -33,4 +36,35 @@ func TestJobHistoryCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestJobHistoryCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &JobHistoryCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake job
+	state := srv.Agent.Server().State()
+	j := mock.Job()
+	assert.Nil(state.UpsertJob(1000, j))
+
+	prefix := j.ID[:len(j.ID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(j.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
 	flaghelper "github.com/hashicorp/nomad/helper/flag-helpers"
+	"github.com/posener/complete"
 )
 
 type JobPromoteCommand struct {
@@ -48,6 +50,25 @@ Promote Options:
 
 func (c *JobPromoteCommand) Synopsis() string {
 	return "Promote a job's canaries"
+}
+
+func (c *JobPromoteCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *JobPromoteCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
 }
 
 func (c *JobPromoteCommand) Run(args []string) int {

--- a/command/job_promote_test.go
+++ b/command/job_promote_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJobPromoteCommand_Implements(t *testing.T) {
@@ -33,4 +36,35 @@ func TestJobPromoteCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed to promote error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestJobPromoteCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &JobPromoteCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake job
+	state := srv.Agent.Server().State()
+	j := mock.Job()
+	assert.Nil(state.UpsertJob(1000, j))
+
+	prefix := j.ID[:len(j.ID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(j.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -3,6 +3,9 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type JobRevertCommand struct {
@@ -35,6 +38,25 @@ Revert Options:
 
 func (c *JobRevertCommand) Synopsis() string {
 	return "Revert to a prior version of the job"
+}
+
+func (c *JobRevertCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *JobRevertCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
 }
 
 func (c *JobRevertCommand) Run(args []string) int {

--- a/command/job_revert_test.go
+++ b/command/job_revert_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJobRevertCommand_Implements(t *testing.T) {
@@ -33,4 +36,35 @@ func TestJobRevertCommand_Fails(t *testing.T) {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestJobRevertCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &JobRevertCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake job
+	state := srv.Agent.Server().State()
+	j := mock.Job()
+	assert.Nil(state.UpsertJob(1000, j))
+
+	prefix := j.ID[:len(j.ID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(j.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -60,6 +60,25 @@ func (c *JobStatusCommand) Synopsis() string {
 	return "Display status information about jobs"
 }
 
+func (c *JobStatusCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *JobStatusCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
+}
+
 func (c *JobStatusCommand) Run(args []string) int {
 	var short bool
 
@@ -525,25 +544,6 @@ func (c *JobStatusCommand) outputFailedPlacements(failedEval *api.Evaluation) {
 		trunc := fmt.Sprintf("\nPlacement failures truncated. To see remainder run:\nnomad eval-status %s", failedEval.ID)
 		c.Ui.Output(trunc)
 	}
-}
-
-func (c *JobStatusCommand) AutocompleteFlags() complete.Flags {
-	return nil
-}
-
-func (c *JobStatusCommand) AutocompleteArgs() complete.Predictor {
-	client, _ := c.Meta.Client()
-	return complete.PredictFunc(func(a complete.Args) []string {
-		if len(a.Completed) > 1 {
-			return nil
-		}
-
-		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
 }
 
 // list general information about a list of jobs

--- a/command/logs.go
+++ b/command/logs.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type LogsCommand struct {
@@ -57,6 +59,26 @@ Logs Specific Options:
 
 func (l *LogsCommand) Synopsis() string {
 	return "Streams the logs of a task."
+}
+
+func (l *LogsCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (l *LogsCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := l.Meta.Client()
+
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Allocs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Allocs]
+	})
 }
 
 func (l *LogsCommand) Run(args []string) int {

--- a/command/logs_test.go
+++ b/command/logs_test.go
@@ -4,7 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLogsCommand_Implements(t *testing.T) {
@@ -63,5 +67,35 @@ func TestLogsCommand_Fails(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No allocation(s) with prefix or id") {
 		t.Fatalf("expected not found error, got: %s", out)
 	}
+}
 
+func TestLogsCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &LogsCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake alloc
+	state := srv.Agent.Server().State()
+	a := mock.Alloc()
+	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+
+	prefix := a.ID[:5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(a.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "1", "2"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -3,6 +3,9 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type NodeDrainCommand struct {
@@ -40,6 +43,25 @@ Node Drain Options:
 
 func (c *NodeDrainCommand) Synopsis() string {
 	return "Toggle drain mode on a given node"
+}
+
+func (c *NodeDrainCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *NodeDrainCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Nodes)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Nodes]
+	})
 }
 
 func (c *NodeDrainCommand) Run(args []string) int {

--- a/command/node_drain_test.go
+++ b/command/node_drain_test.go
@@ -1,10 +1,14 @@
 package command
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNodeDrainCommand_Implements(t *testing.T) {
@@ -81,4 +85,46 @@ func TestNodeDrainCommand_Fails(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No node(s) with prefix or id") {
 		t.Fatalf("expected not exist error, got: %s", out)
 	}
+}
+
+func TestNodeDrainCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	// Wait for a node to appear
+	var nodeID string
+	testutil.WaitForResult(func() (bool, error) {
+		nodes, _, err := client.Nodes().List(nil)
+		if err != nil {
+			return false, err
+		}
+		if len(nodes) == 0 {
+			return false, fmt.Errorf("missing node")
+		}
+		nodeID = nodes[0].ID
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+
+	ui := new(cli.MockUi)
+	cmd := &NodeDrainCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	prefix := nodeID[:len(nodeID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(nodeID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "1", "2"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -85,6 +85,25 @@ func (c *NodeStatusCommand) Synopsis() string {
 	return "Display status information about nodes"
 }
 
+func (c *NodeStatusCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *NodeStatusCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Nodes)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Nodes]
+	})
+}
+
 func (c *NodeStatusCommand) Run(args []string) int {
 
 	flags := c.Meta.FlagSet("node-status", FlagSetClient)
@@ -441,25 +460,6 @@ func (c *NodeStatusCommand) printDiskStats(hostStats *api.HostStats) {
 			c.Ui.Output("")
 		}
 	}
-}
-
-func (c *NodeStatusCommand) AutocompleteFlags() complete.Flags {
-	return nil
-}
-
-func (c *NodeStatusCommand) AutocompleteArgs() complete.Predictor {
-	client, _ := c.Meta.Client()
-	return complete.PredictFunc(func(a complete.Args) []string {
-		if len(a.Completed) > 1 {
-			return nil
-		}
-
-		resp, err := client.Search().PrefixSearch(a.Last, contexts.Nodes)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Nodes]
-	})
 }
 
 // getRunningAllocs returns a slice of allocation id's running on the node

--- a/command/stop.go
+++ b/command/stop.go
@@ -3,6 +3,9 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
 )
 
 type StopCommand struct {
@@ -46,6 +49,25 @@ Stop Options:
 
 func (c *StopCommand) Synopsis() string {
 	return "Stop a running job"
+}
+
+func (c *StopCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *StopCommand) AutocompleteArgs() complete.Predictor {
+	client, _ := c.Meta.Client()
+	return complete.PredictFunc(func(a complete.Args) []string {
+		if len(a.Completed) > 1 {
+			return nil
+		}
+
+		resp, err := client.Search().PrefixSearch(a.Last, contexts.Jobs)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
 }
 
 func (c *StopCommand) Run(args []string) int {

--- a/command/stop_test.go
+++ b/command/stop_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStopCommand_Implements(t *testing.T) {
@@ -45,4 +48,34 @@ func TestStopCommand_Fails(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error deregistering job") {
 		t.Fatalf("expected failed query error, got: %s", out)
 	}
+}
+
+func TestStopCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &StopCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	state := srv.Agent.Server().State()
+	j := mock.Job()
+	assert.Nil(state.UpsertJob(1000, j))
+
+	prefix := j.ID[:len(j.ID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(j.ID, res[0])
+
+	// Autocomplete should only complete once
+	args = complete.Args{Last: prefix, Completed: []string{prefix, "a", "b"}}
+	predictor = cmd.AutocompleteArgs()
+
+	res = predictor.Predict(args)
+	assert.Nil(res)
 }

--- a/command/stop_test.go
+++ b/command/stop_test.go
@@ -60,6 +60,7 @@ func TestStopCommand_AutocompleteArgs(t *testing.T) {
 	ui := new(cli.MockUi)
 	cmd := &StopCommand{Meta: Meta{Ui: ui, flagAddress: url}}
 
+	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
 	assert.Nil(state.UpsertJob(1000, j))


### PR DESCRIPTION
This PR:
* Adds autocomplete to the remaining commands for their argument
* Moves the autocomplete functions to a consistent place under Synopsis
* Changes the way the old autocomplete tests work to inject state