### PR TITLE
If MaxParallel == 0 default limit to count

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -372,11 +372,11 @@ func (u *UpdateStrategy) Merge(o *UpdateStrategy) {
 }
 
 func (u *UpdateStrategy) Canonicalize() {
-	if u.MaxParallel == nil {
-		u.MaxParallel = helper.IntToPtr(0)
-	}
-
 	d := structs.DefaultUpdateStrategy
+
+	if u.MaxParallel == nil {
+		u.MaxParallel = helper.IntToPtr(d.MaxParallel)
+	}
 
 	if u.Stagger == nil {
 		u.Stagger = helper.TimeToPtr(d.Stagger)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2010,7 +2010,7 @@ var (
 	// jobs with the old policy or for populating field defaults.
 	DefaultUpdateStrategy = &UpdateStrategy{
 		Stagger:         30 * time.Second,
-		MaxParallel:     0,
+		MaxParallel:     1,
 		HealthCheck:     UpdateStrategyHealthCheck_Checks,
 		MinHealthyTime:  10 * time.Second,
 		HealthyDeadline: 5 * time.Minute,
@@ -2074,8 +2074,8 @@ func (u *UpdateStrategy) Validate() error {
 		multierror.Append(&mErr, fmt.Errorf("Invalid health check given: %q", u.HealthCheck))
 	}
 
-	if u.MaxParallel < 0 {
-		multierror.Append(&mErr, fmt.Errorf("Max parallel can not be less than zero: %d < 0", u.MaxParallel))
+	if u.MaxParallel < 1 {
+		multierror.Append(&mErr, fmt.Errorf("Max parallel can not be less than one: %d < 1", u.MaxParallel))
 	}
 	if u.Canary < 0 {
 		multierror.Append(&mErr, fmt.Errorf("Canary count can not be less than zero: %d < 0", u.Canary))

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1393,7 +1393,7 @@ func TestConstraint_Validate(t *testing.T) {
 
 func TestUpdateStrategy_Validate(t *testing.T) {
 	u := &UpdateStrategy{
-		MaxParallel:     -1,
+		MaxParallel:     0,
 		HealthCheck:     "foo",
 		MinHealthyTime:  -10,
 		HealthyDeadline: -15,
@@ -1406,7 +1406,7 @@ func TestUpdateStrategy_Validate(t *testing.T) {
 	if !strings.Contains(mErr.Errors[0].Error(), "Invalid health check given") {
 		t.Fatalf("err: %s", err)
 	}
-	if !strings.Contains(mErr.Errors[1].Error(), "Max parallel can not be less than zero") {
+	if !strings.Contains(mErr.Errors[1].Error(), "Max parallel can not be less than one") {
 		t.Fatalf("err: %s", err)
 	}
 	if !strings.Contains(mErr.Errors[2].Error(), "Canary count can not be less than zero") {


### PR DESCRIPTION
If you run a job with an `update` stanza but do not specify `max_parallel` it defaults to 0 which prevents any allocations from ever being updated. A `max_parallel` value of 0 should be treated the same as as a job with no `update` stanza specified.