### PR TITLE
Enable autocompletion of flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.6.1 (Unreleased)
 
 IMPROVEMENTS:
- * core: Add autocomplete functionality for flags for all cli commands
+ * cli: Add autocomplete functionality for flags for all CLI command [GH 3087]
  * core: Add autocomplete functionality for resources: allocations,
    evaluations, jobs, and nodes [GH-2964]
  * core: `distinct_property` constraint can set the number of allocations that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.1 (Unreleased)
 
 IMPROVEMENTS:
+ * core: Add autocomplete functionality for flags for all cli commands
  * core: Add autocomplete functionality for resources: allocations,
    evaluations, jobs, and nodes [GH-2964]
  * core: `distinct_property` constraint can set the number of allocations that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.6.1 (Unreleased)
 
 IMPROVEMENTS:
- * cli: Add autocomplete functionality for flags for all CLI command [GH 3087]
  * core: Add autocomplete functionality for resources: allocations,
    evaluations, jobs, and nodes [GH-2964]
  * core: `distinct_property` constraint can set the number of allocations that
@@ -12,6 +11,7 @@ IMPROVEMENTS:
  * api: Redact Vault.Token from AgentSelf response [GH-2988]
  * cli: node-status displays node version [GH-3002]
  * cli: Disable color output when STDOUT is not a TTY [GH-3057]
+ * cli: Add autocomplete functionality for flags for all CLI command [GH 3087]
  * client: Unmount task directories when alloc is terminal [GH-3006]
  * client/template: Allow template to set Vault grace [GH-2947]
  * client/template: Template emits events explaining why it is blocked [GH-3001]

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -61,7 +61,12 @@ func (c *AllocStatusCommand) Synopsis() string {
 }
 
 func (c *AllocStatusCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-short":   complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+		"-json":    complete.PredictNothing,
+		"-t":       complete.PredictNothing,
+	}
 }
 
 func (c *AllocStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -61,12 +61,13 @@ func (c *AllocStatusCommand) Synopsis() string {
 }
 
 func (c *AllocStatusCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-short":   complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-short":   complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+			"-json":    complete.PredictNothing,
+			"-t":       complete.PredictAnything,
+		})
 }
 
 func (c *AllocStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -65,7 +65,7 @@ func (c *AllocStatusCommand) AutocompleteFlags() complete.Flags {
 		"-short":   complete.PredictNothing,
 		"-verbose": complete.PredictNothing,
 		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictNothing,
+		"-t":       complete.PredictAnything,
 	}
 }
 

--- a/command/check.go
+++ b/command/check.go
@@ -131,10 +131,11 @@ func (c *AgentCheckCommand) checkClientHealth(clientStats map[string]string, min
 }
 
 func (c *AgentCheckCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-min-peers":   complete.PredictAnything,
-		"-min-servers": complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-min-peers":   complete.PredictAnything,
+			"-min-servers": complete.PredictAnything,
+		})
 }
 
 func (c *AgentCheckCommand) AutocompleteArgs() complete.Predictor {

--- a/command/check.go
+++ b/command/check.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/posener/complete"
 )
 
 const (
@@ -126,4 +128,15 @@ func (c *AgentCheckCommand) checkClientHealth(clientStats map[string]string, min
 	}
 
 	return HealthPass
+}
+
+func (c *AgentCheckCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-min-peers":   complete.PredictNothing,
+		"-min-servers": complete.PredictNothing,
+	}
+}
+
+func (c *AgentCheckCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }

--- a/command/check.go
+++ b/command/check.go
@@ -132,8 +132,8 @@ func (c *AgentCheckCommand) checkClientHealth(clientStats map[string]string, min
 
 func (c *AgentCheckCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-min-peers":   complete.PredictNothing,
-		"-min-servers": complete.PredictNothing,
+		"-min-peers":   complete.PredictAnything,
+		"-min-servers": complete.PredictAnything,
 	}
 }
 

--- a/command/client_config.go
+++ b/command/client_config.go
@@ -115,7 +115,7 @@ func (c *ClientConfigCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
 			"-servers":        complete.PredictNothing,
-			"-update-servers": complete.PredictNothing,
+			"-update-servers": complete.PredictAnything,
 		})
 }
 

--- a/command/client_config.go
+++ b/command/client_config.go
@@ -3,6 +3,8 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/posener/complete"
 )
 
 type ClientConfigCommand struct {
@@ -107,4 +109,15 @@ func (c *ClientConfigCommand) Run(args []string) int {
 
 	// Should not make it this far
 	return 1
+}
+
+func (c *ClientConfigCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-servers":        complete.PredictNothing,
+		"-update-servers": complete.PredictNothing,
+	}
+}
+
+func (c *ClientConfigCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }

--- a/command/client_config.go
+++ b/command/client_config.go
@@ -112,10 +112,11 @@ func (c *ClientConfigCommand) Run(args []string) int {
 }
 
 func (c *ClientConfigCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-servers":        complete.PredictNothing,
-		"-update-servers": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-servers":        complete.PredictNothing,
+			"-update-servers": complete.PredictNothing,
+		})
 }
 
 func (c *ClientConfigCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_fail.go
+++ b/command/deployment_fail.go
@@ -43,10 +43,11 @@ func (c *DeploymentFailCommand) Synopsis() string {
 }
 
 func (c *DeploymentFailCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-detach":  complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-detach":  complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *DeploymentFailCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_fail.go
+++ b/command/deployment_fail.go
@@ -43,7 +43,10 @@ func (c *DeploymentFailCommand) Synopsis() string {
 }
 
 func (c *DeploymentFailCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-detach":  complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *DeploymentFailCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_list.go
+++ b/command/deployment_list.go
@@ -37,11 +37,12 @@ List Options:
 }
 
 func (c *DeploymentListCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictAnything,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-json":    complete.PredictNothing,
+			"-t":       complete.PredictAnything,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *DeploymentListCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_list.go
+++ b/command/deployment_list.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
 )
 
 type DeploymentListCommand struct {
@@ -33,6 +34,18 @@ List Options:
     Display full information.
 `
 	return strings.TrimSpace(helpText)
+}
+
+func (c *DeploymentListCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-json":    complete.PredictNothing,
+		"-t":       complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
+}
+
+func (c *DeploymentListCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }
 
 func (c *DeploymentListCommand) Synopsis() string {

--- a/command/deployment_list.go
+++ b/command/deployment_list.go
@@ -39,7 +39,7 @@ List Options:
 func (c *DeploymentListCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictNothing,
+		"-t":       complete.PredictAnything,
 		"-verbose": complete.PredictNothing,
 	}
 }

--- a/command/deployment_pause.go
+++ b/command/deployment_pause.go
@@ -32,11 +32,13 @@ Pause Options:
 }
 
 func (c *DeploymentPauseCommand) Synopsis() string {
-	return "Pause a deployment"
+	return "Pause a deployment."
 }
 
 func (c *DeploymentPauseCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *DeploymentPauseCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_pause.go
+++ b/command/deployment_pause.go
@@ -32,7 +32,7 @@ Pause Options:
 }
 
 func (c *DeploymentPauseCommand) Synopsis() string {
-	return "Pause a deployment."
+	return "Pause a deployment"
 }
 
 func (c *DeploymentPauseCommand) AutocompleteFlags() complete.Flags {

--- a/command/deployment_pause.go
+++ b/command/deployment_pause.go
@@ -36,9 +36,10 @@ func (c *DeploymentPauseCommand) Synopsis() string {
 }
 
 func (c *DeploymentPauseCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *DeploymentPauseCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_promote.go
+++ b/command/deployment_promote.go
@@ -53,7 +53,7 @@ func (c *DeploymentPromoteCommand) Synopsis() string {
 
 func (c *DeploymentPromoteCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-group":   complete.PredictNothing,
+		"-group":   complete.PredictAnything,
 		"-detach":  complete.PredictNothing,
 		"-verbose": complete.PredictNothing,
 	}

--- a/command/deployment_promote.go
+++ b/command/deployment_promote.go
@@ -48,7 +48,7 @@ Promote Options:
 }
 
 func (c *DeploymentPromoteCommand) Synopsis() string {
-	return "Promote canaries in a deployment."
+	return "Promote canaries in a deployment"
 }
 
 func (c *DeploymentPromoteCommand) AutocompleteFlags() complete.Flags {

--- a/command/deployment_promote.go
+++ b/command/deployment_promote.go
@@ -48,11 +48,15 @@ Promote Options:
 }
 
 func (c *DeploymentPromoteCommand) Synopsis() string {
-	return "Promote canaries in a deployment"
+	return "Promote canaries in a deployment."
 }
 
 func (c *DeploymentPromoteCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-group":   complete.PredictNothing,
+		"-detach":  complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *DeploymentPromoteCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_promote.go
+++ b/command/deployment_promote.go
@@ -52,11 +52,12 @@ func (c *DeploymentPromoteCommand) Synopsis() string {
 }
 
 func (c *DeploymentPromoteCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-group":   complete.PredictAnything,
-		"-detach":  complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-group":   complete.PredictAnything,
+			"-detach":  complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *DeploymentPromoteCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_resume.go
+++ b/command/deployment_resume.go
@@ -41,7 +41,10 @@ func (c *DeploymentResumeCommand) Synopsis() string {
 }
 
 func (c *DeploymentResumeCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-detach":  complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *DeploymentResumeCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_resume.go
+++ b/command/deployment_resume.go
@@ -41,10 +41,11 @@ func (c *DeploymentResumeCommand) Synopsis() string {
 }
 
 func (c *DeploymentResumeCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-detach":  complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-detach":  complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *DeploymentResumeCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -46,7 +46,7 @@ func (c *DeploymentStatusCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"-verbose": complete.PredictNothing,
 		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictNothing,
+		"-t":       complete.PredictAnything,
 	}
 }
 

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -43,11 +43,12 @@ func (c *DeploymentStatusCommand) Synopsis() string {
 }
 
 func (c *DeploymentStatusCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-verbose": complete.PredictNothing,
-		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-verbose": complete.PredictNothing,
+			"-json":    complete.PredictNothing,
+			"-t":       complete.PredictAnything,
+		})
 }
 
 func (c *DeploymentStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -43,7 +43,11 @@ func (c *DeploymentStatusCommand) Synopsis() string {
 }
 
 func (c *DeploymentStatusCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-verbose": complete.PredictNothing,
+		"-json":    complete.PredictNothing,
+		"-t":       complete.PredictNothing,
+	}
 }
 
 func (c *DeploymentStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -52,7 +52,7 @@ func (c *EvalStatusCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"-json":    complete.PredictNothing,
 		"-monitor": complete.PredictNothing,
-		"-t":       complete.PredictNothing,
+		"-t":       complete.PredictAnything,
 		"-verbose": complete.PredictNothing,
 	}
 }

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -49,12 +49,13 @@ func (c *EvalStatusCommand) Synopsis() string {
 }
 
 func (c *EvalStatusCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-json":    complete.PredictNothing,
-		"-monitor": complete.PredictNothing,
-		"-t":       complete.PredictAnything,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-json":    complete.PredictNothing,
+			"-monitor": complete.PredictNothing,
+			"-t":       complete.PredictAnything,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *EvalStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -49,7 +49,12 @@ func (c *EvalStatusCommand) Synopsis() string {
 }
 
 func (c *EvalStatusCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-json":    complete.PredictNothing,
+		"-monitor": complete.PredictNothing,
+		"-t":       complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *EvalStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/fs.go
+++ b/command/fs.go
@@ -80,16 +80,17 @@ func (f *FSCommand) Synopsis() string {
 }
 
 func (c *FSCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-H":       complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-		"-job":     complete.PredictAnything,
-		"-stat":    complete.PredictNothing,
-		"-f":       complete.PredictNothing,
-		"-tail":    complete.PredictNothing,
-		"-n":       complete.PredictAnything,
-		"-c":       complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-H":       complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+			"-job":     complete.PredictAnything,
+			"-stat":    complete.PredictNothing,
+			"-f":       complete.PredictNothing,
+			"-tail":    complete.PredictNothing,
+			"-n":       complete.PredictAnything,
+			"-c":       complete.PredictAnything,
+		})
 }
 
 func (f *FSCommand) AutocompleteArgs() complete.Predictor {

--- a/command/fs.go
+++ b/command/fs.go
@@ -79,8 +79,17 @@ func (f *FSCommand) Synopsis() string {
 	return "Inspect the contents of an allocation directory"
 }
 
-func (f *FSCommand) AutocompleteFlags() complete.Flags {
-	return nil
+func (c *FSCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-H":       complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+		"-job":     complete.PredictNothing,
+		"-stat":    complete.PredictNothing,
+		"-f":       complete.PredictNothing,
+		"-tail":    complete.PredictNothing,
+		"-n":       complete.PredictNothing,
+		"-c":       complete.PredictNothing,
+	}
 }
 
 func (f *FSCommand) AutocompleteArgs() complete.Predictor {

--- a/command/fs.go
+++ b/command/fs.go
@@ -83,12 +83,12 @@ func (c *FSCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"-H":       complete.PredictNothing,
 		"-verbose": complete.PredictNothing,
-		"-job":     complete.PredictNothing,
+		"-job":     complete.PredictAnything,
 		"-stat":    complete.PredictNothing,
 		"-f":       complete.PredictNothing,
 		"-tail":    complete.PredictNothing,
-		"-n":       complete.PredictNothing,
-		"-c":       complete.PredictNothing,
+		"-n":       complete.PredictAnything,
+		"-c":       complete.PredictAnything,
 	}
 }
 

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -12,6 +12,7 @@ import (
 	gg "github.com/hashicorp/go-getter"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/jobspec"
+	"github.com/posener/complete"
 
 	"github.com/ryanuber/columnize"
 )
@@ -317,4 +318,15 @@ func getVersion(job *api.Job) uint64 {
 	}
 
 	return 0
+}
+
+// mergeAutocompleteFlags is used to join multiple flag completion sets.
+func mergeAutocompleteFlags(flags ...complete.Flags) complete.Flags {
+	merged := make(map[string]complete.Predictor, len(flags))
+	for _, f := range flags {
+		for k, v := range f {
+			merged[k] = v
+		}
+	}
+	return merged
 }

--- a/command/inspect.go
+++ b/command/inspect.go
@@ -42,11 +42,12 @@ func (c *InspectCommand) Synopsis() string {
 }
 
 func (c *InspectCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-version": complete.PredictAnything,
-		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-version": complete.PredictAnything,
+			"-json":    complete.PredictNothing,
+			"-t":       complete.PredictAnything,
+		})
 }
 
 func (c *InspectCommand) AutocompleteArgs() complete.Predictor {

--- a/command/inspect.go
+++ b/command/inspect.go
@@ -42,7 +42,11 @@ func (c *InspectCommand) Synopsis() string {
 }
 
 func (c *InspectCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-version": complete.PredictNothing,
+		"-json":    complete.PredictNothing,
+		"-t":       complete.PredictNothing,
+	}
 }
 
 func (c *InspectCommand) AutocompleteArgs() complete.Predictor {

--- a/command/inspect.go
+++ b/command/inspect.go
@@ -43,9 +43,9 @@ func (c *InspectCommand) Synopsis() string {
 
 func (c *InspectCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-version": complete.PredictNothing,
+		"-version": complete.PredictAnything,
 		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictNothing,
+		"-t":       complete.PredictAnything,
 	}
 }
 

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -44,12 +44,13 @@ func (c *JobDeploymentsCommand) Synopsis() string {
 }
 
 func (c *JobDeploymentsCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictAnything,
-		"-latest":  complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-json":    complete.PredictNothing,
+			"-t":       complete.PredictAnything,
+			"-latest":  complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *JobDeploymentsCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -46,7 +46,7 @@ func (c *JobDeploymentsCommand) Synopsis() string {
 func (c *JobDeploymentsCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictNothing,
+		"-t":       complete.PredictAnything,
 		"-latest":  complete.PredictNothing,
 		"-verbose": complete.PredictNothing,
 	}

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -44,7 +44,12 @@ func (c *JobDeploymentsCommand) Synopsis() string {
 }
 
 func (c *JobDeploymentsCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-json":    complete.PredictNothing,
+		"-t":       complete.PredictNothing,
+		"-latest":  complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *JobDeploymentsCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -57,11 +57,12 @@ func (c *JobDispatchCommand) Synopsis() string {
 }
 
 func (c *JobDispatchCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-meta":    complete.PredictAnything,
-		"-detach":  complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-meta":    complete.PredictAnything,
+			"-detach":  complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *JobDispatchCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -58,7 +58,7 @@ func (c *JobDispatchCommand) Synopsis() string {
 
 func (c *JobDispatchCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-meta":    complete.PredictNothing,
+		"-meta":    complete.PredictAnything,
 		"-detach":  complete.PredictNothing,
 		"-verbose": complete.PredictNothing,
 	}

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -57,7 +57,11 @@ func (c *JobDispatchCommand) Synopsis() string {
 }
 
 func (c *JobDispatchCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-meta":    complete.PredictNothing,
+		"-detach":  complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *JobDispatchCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -34,7 +34,7 @@ History Options:
 
   -p
     Display the difference between each job and its predecessor.
-    
+
   -full
     Display the full job definition for each version.
 
@@ -54,8 +54,14 @@ func (c *JobHistoryCommand) Synopsis() string {
 	return "Display all tracked versions of a job"
 }
 
-func (c *JobHistoryCommand) AutocompleteFlags() complete.Flags {
-	return nil
+func (c *JobHistoryCommand) Autocompleteflags() complete.Flags {
+	return complete.Flags{
+		"-p":       complete.PredictNothing,
+		"-full":    complete.PredictNothing,
+		"-version": complete.PredictNothing,
+		"-json":    complete.PredictNothing,
+		"-t":       complete.PredictNothing,
+	}
 }
 
 func (c *JobHistoryCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -58,9 +58,9 @@ func (c *JobHistoryCommand) Autocompleteflags() complete.Flags {
 	return complete.Flags{
 		"-p":       complete.PredictNothing,
 		"-full":    complete.PredictNothing,
-		"-version": complete.PredictNothing,
+		"-version": complete.PredictAnything,
 		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictNothing,
+		"-t":       complete.PredictAnything,
 	}
 }
 

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -55,13 +55,14 @@ func (c *JobHistoryCommand) Synopsis() string {
 }
 
 func (c *JobHistoryCommand) Autocompleteflags() complete.Flags {
-	return complete.Flags{
-		"-p":       complete.PredictNothing,
-		"-full":    complete.PredictNothing,
-		"-version": complete.PredictAnything,
-		"-json":    complete.PredictNothing,
-		"-t":       complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-p":       complete.PredictNothing,
+			"-full":    complete.PredictNothing,
+			"-version": complete.PredictAnything,
+			"-json":    complete.PredictNothing,
+			"-t":       complete.PredictAnything,
+		})
 }
 
 func (c *JobHistoryCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -53,11 +53,12 @@ func (c *JobPromoteCommand) Synopsis() string {
 }
 
 func (c *JobPromoteCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-group":   complete.PredictAnything,
-		"-detach":  complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-group":   complete.PredictAnything,
+			"-detach":  complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *JobPromoteCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -53,7 +53,11 @@ func (c *JobPromoteCommand) Synopsis() string {
 }
 
 func (c *JobPromoteCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-group":   complete.PredictNothing,
+		"-detach":  complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *JobPromoteCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -54,7 +54,7 @@ func (c *JobPromoteCommand) Synopsis() string {
 
 func (c *JobPromoteCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-group":   complete.PredictNothing,
+		"-group":   complete.PredictAnything,
 		"-detach":  complete.PredictNothing,
 		"-verbose": complete.PredictNothing,
 	}

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -41,7 +41,10 @@ func (c *JobRevertCommand) Synopsis() string {
 }
 
 func (c *JobRevertCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-detach":  complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *JobRevertCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -41,10 +41,11 @@ func (c *JobRevertCommand) Synopsis() string {
 }
 
 func (c *JobRevertCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-detach":  complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-detach":  complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *JobRevertCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -61,7 +61,12 @@ func (c *JobStatusCommand) Synopsis() string {
 }
 
 func (c *JobStatusCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-all-allocs": complete.PredictNothing,
+		"-evals":      complete.PredictNothing,
+		"-short":      complete.PredictNothing,
+		"-verbose":    complete.PredictNothing,
+	}
 }
 
 func (c *JobStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -61,12 +61,13 @@ func (c *JobStatusCommand) Synopsis() string {
 }
 
 func (c *JobStatusCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-all-allocs": complete.PredictNothing,
-		"-evals":      complete.PredictNothing,
-		"-short":      complete.PredictNothing,
-		"-verbose":    complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-all-allocs": complete.PredictNothing,
+			"-evals":      complete.PredictNothing,
+			"-short":      complete.PredictNothing,
+			"-verbose":    complete.PredictNothing,
+		})
 }
 
 func (c *JobStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/keyring.go
+++ b/command/keyring.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 )
 
 // KeyringCommand is a Command implementation that handles querying, installing,
@@ -154,4 +155,16 @@ Keyring Options:
 
 func (c *KeyringCommand) Synopsis() string {
 	return "Manages gossip layer encryption keys"
+}
+
+func (c *KeyringCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-install": complete.PredictNothing,
+		"-list":    complete.PredictNothing,
+		"-remove":  complete.PredictNothing,
+		"-use":     complete.PredictNothing,
+	}
+}
+func (c *KeyringCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }

--- a/command/keyring.go
+++ b/command/keyring.go
@@ -158,12 +158,13 @@ func (c *KeyringCommand) Synopsis() string {
 }
 
 func (c *KeyringCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-install": complete.PredictAnything,
-		"-list":    complete.PredictNothing,
-		"-remove":  complete.PredictAnything,
-		"-use":     complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-install": complete.PredictAnything,
+			"-list":    complete.PredictNothing,
+			"-remove":  complete.PredictAnything,
+			"-use":     complete.PredictAnything,
+		})
 }
 func (c *KeyringCommand) AutocompleteArgs() complete.Predictor {
 	return complete.PredictNothing

--- a/command/keyring.go
+++ b/command/keyring.go
@@ -159,10 +159,10 @@ func (c *KeyringCommand) Synopsis() string {
 
 func (c *KeyringCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-install": complete.PredictNothing,
+		"-install": complete.PredictAnything,
 		"-list":    complete.PredictNothing,
-		"-remove":  complete.PredictNothing,
-		"-use":     complete.PredictNothing,
+		"-remove":  complete.PredictAnything,
+		"-use":     complete.PredictAnything,
 	}
 }
 func (c *KeyringCommand) AutocompleteArgs() complete.Predictor {

--- a/command/logs.go
+++ b/command/logs.go
@@ -62,15 +62,16 @@ func (l *LogsCommand) Synopsis() string {
 }
 
 func (c *LogsCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-stderr":  complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-		"-job":     complete.PredictAnything,
-		"-f":       complete.PredictNothing,
-		"-tail":    complete.PredictAnything,
-		"-n":       complete.PredictAnything,
-		"-c":       complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-stderr":  complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+			"-job":     complete.PredictAnything,
+			"-f":       complete.PredictNothing,
+			"-tail":    complete.PredictAnything,
+			"-n":       complete.PredictAnything,
+			"-c":       complete.PredictAnything,
+		})
 }
 
 func (l *LogsCommand) AutocompleteArgs() complete.Predictor {

--- a/command/logs.go
+++ b/command/logs.go
@@ -61,8 +61,16 @@ func (l *LogsCommand) Synopsis() string {
 	return "Streams the logs of a task."
 }
 
-func (l *LogsCommand) AutocompleteFlags() complete.Flags {
-	return nil
+func (c *LogsCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-stderr":  complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+		"-job":     complete.PredictNothing,
+		"-f":       complete.PredictNothing,
+		"-tail":    complete.PredictNothing,
+		"-n":       complete.PredictNothing,
+		"-c":       complete.PredictNothing,
+	}
 }
 
 func (l *LogsCommand) AutocompleteArgs() complete.Predictor {

--- a/command/logs.go
+++ b/command/logs.go
@@ -65,11 +65,11 @@ func (c *LogsCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"-stderr":  complete.PredictNothing,
 		"-verbose": complete.PredictNothing,
-		"-job":     complete.PredictNothing,
+		"-job":     complete.PredictAnything,
 		"-f":       complete.PredictNothing,
-		"-tail":    complete.PredictNothing,
-		"-n":       complete.PredictNothing,
-		"-c":       complete.PredictNothing,
+		"-tail":    complete.PredictAnything,
+		"-n":       complete.PredictAnything,
+		"-c":       complete.PredictAnything,
 	}
 }
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/colorstring"
+	"github.com/posener/complete"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -93,6 +94,25 @@ func (m *Meta) FlagSet(n string, fs FlagSetFlags) *flag.FlagSet {
 	return f
 }
 
+// AutocompleteFlags returns a set of flag completions for the given flag set.
+func (m *Meta) AutocompleteFlags(fs FlagSetFlags) complete.Flags {
+	if fs&FlagSetClient == 0 {
+		return nil
+	}
+
+	return complete.Flags{
+		"-address":         complete.PredictAnything,
+		"-region":          complete.PredictAnything,
+		"-no-color":        complete.PredictNothing,
+		"-ca-cert":         complete.PredictFiles("*"),
+		"-ca-path":         complete.PredictDirs("*"),
+		"-client-cert":     complete.PredictFiles("*"),
+		"-client-key":      complete.PredictFiles("*"),
+		"-insecure":        complete.PredictNothing,
+		"-tls-skip-verify": complete.PredictNothing,
+	}
+}
+
 // Client is used to initialize and return a new API client using
 // the default command line arguments and env vars.
 func (m *Meta) Client() (*api.Client, error) {
@@ -144,32 +164,32 @@ func generalOptionsUsage() string {
     The region of the Nomad servers to forward commands to.
     Overrides the NOMAD_REGION environment variable if set.
     Defaults to the Agent's local region.
-  
+
   -no-color
     Disables colored command output.
 
-  -ca-cert=<path>           
-    Path to a PEM encoded CA cert file to use to verify the 
-    Nomad server SSL certificate.  Overrides the NOMAD_CACERT 
+  -ca-cert=<path>
+    Path to a PEM encoded CA cert file to use to verify the
+    Nomad server SSL certificate.  Overrides the NOMAD_CACERT
     environment variable if set.
 
-  -ca-path=<path>           
-    Path to a directory of PEM encoded CA cert files to verify 
-    the Nomad server SSL certificate. If both -ca-cert and 
-    -ca-path are specified, -ca-cert is used. Overrides the 
+  -ca-path=<path>
+    Path to a directory of PEM encoded CA cert files to verify
+    the Nomad server SSL certificate. If both -ca-cert and
+    -ca-path are specified, -ca-cert is used. Overrides the
     NOMAD_CAPATH environment variable if set.
 
-  -client-cert=<path>       
-    Path to a PEM encoded client certificate for TLS authentication 
-    to the Nomad server. Must also specify -client-key. Overrides 
+  -client-cert=<path>
+    Path to a PEM encoded client certificate for TLS authentication
+    to the Nomad server. Must also specify -client-key. Overrides
     the NOMAD_CLIENT_CERT environment variable if set.
 
-  -client-key=<path>        
-    Path to an unencrypted PEM encoded private key matching the 
-    client certificate from -client-cert. Overrides the 
+  -client-key=<path>
+    Path to an unencrypted PEM encoded private key matching the
+    client certificate from -client-cert. Overrides the
     NOMAD_CLIENT_KEY environment variable if set.
 
-  -tls-skip-verify        
+  -tls-skip-verify
     Do not verify TLS certificate. This is highly not recommended. Verification
     will also be skipped if NOMAD_SKIP_VERIFY is set.
 `

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -46,7 +46,12 @@ func (c *NodeDrainCommand) Synopsis() string {
 }
 
 func (c *NodeDrainCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-disable": complete.PredictNothing,
+		"-enable":  complete.PredictNothing,
+		"-self":    complete.PredictNothing,
+		"-yes":     complete.PredictNothing,
+	}
 }
 
 func (c *NodeDrainCommand) AutocompleteArgs() complete.Predictor {

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -46,12 +46,13 @@ func (c *NodeDrainCommand) Synopsis() string {
 }
 
 func (c *NodeDrainCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-disable": complete.PredictNothing,
-		"-enable":  complete.PredictNothing,
-		"-self":    complete.PredictNothing,
-		"-yes":     complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-disable": complete.PredictNothing,
+			"-enable":  complete.PredictNothing,
+			"-self":    complete.PredictNothing,
+			"-yes":     complete.PredictNothing,
+		})
 }
 
 func (c *NodeDrainCommand) AutocompleteArgs() complete.Predictor {

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -86,7 +86,15 @@ func (c *NodeStatusCommand) Synopsis() string {
 }
 
 func (c *NodeStatusCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-allocs":  complete.PredictNothing,
+		"-json":    complete.PredictNothing,
+		"-self":    complete.PredictNothing,
+		"-short":   complete.PredictNothing,
+		"-stats":   complete.PredictNothing,
+		"-t":       complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *NodeStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -92,7 +92,7 @@ func (c *NodeStatusCommand) AutocompleteFlags() complete.Flags {
 		"-self":    complete.PredictNothing,
 		"-short":   complete.PredictNothing,
 		"-stats":   complete.PredictNothing,
-		"-t":       complete.PredictNothing,
+		"-t":       complete.PredictAnything,
 		"-verbose": complete.PredictNothing,
 	}
 }

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -86,15 +86,16 @@ func (c *NodeStatusCommand) Synopsis() string {
 }
 
 func (c *NodeStatusCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-allocs":  complete.PredictNothing,
-		"-json":    complete.PredictNothing,
-		"-self":    complete.PredictNothing,
-		"-short":   complete.PredictNothing,
-		"-stats":   complete.PredictNothing,
-		"-t":       complete.PredictAnything,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-allocs":  complete.PredictNothing,
+			"-json":    complete.PredictNothing,
+			"-self":    complete.PredictNothing,
+			"-short":   complete.PredictNothing,
+			"-stats":   complete.PredictNothing,
+			"-t":       complete.PredictAnything,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *NodeStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/command/operator_raft_list.go
+++ b/command/operator_raft_list.go
@@ -35,7 +35,7 @@ List Peers Options:
 
 func (c *OperatorRaftListCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-stale": complete.PredictNothing,
+		"-stale": complete.PredictAnything,
 	}
 }
 

--- a/command/operator_raft_list.go
+++ b/command/operator_raft_list.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
 	"github.com/ryanuber/columnize"
 )
 
@@ -30,6 +31,16 @@ List Peers Options:
     to set -stale to "true" to get the configuration from a non-leader server.
 `
 	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorRaftListCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-stale": complete.PredictNothing,
+	}
+}
+
+func (c *OperatorRaftListCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }
 
 func (c *OperatorRaftListCommand) Synopsis() string {

--- a/command/operator_raft_list.go
+++ b/command/operator_raft_list.go
@@ -34,9 +34,10 @@ List Peers Options:
 }
 
 func (c *OperatorRaftListCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-stale": complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-stale": complete.PredictAnything,
+		})
 }
 
 func (c *OperatorRaftListCommand) AutocompleteArgs() complete.Predictor {

--- a/command/operator_raft_remove.go
+++ b/command/operator_raft_remove.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
 )
 
 type OperatorRaftRemoveCommand struct {
@@ -34,6 +35,16 @@ Remove Peer Options:
     Remove a Nomad server with given address from the Raft configuration.
 `
 	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorRaftRemoveCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-peer-address": complete.PredictNothing,
+	}
+}
+
+func (c *OperatorRaftRemoveCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }
 
 func (c *OperatorRaftRemoveCommand) Synopsis() string {

--- a/command/operator_raft_remove.go
+++ b/command/operator_raft_remove.go
@@ -38,9 +38,10 @@ Remove Peer Options:
 }
 
 func (c *OperatorRaftRemoveCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-peer-address": complete.PredictAnything,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-peer-address": complete.PredictAnything,
+		})
 }
 
 func (c *OperatorRaftRemoveCommand) AutocompleteArgs() complete.Predictor {

--- a/command/operator_raft_remove.go
+++ b/command/operator_raft_remove.go
@@ -39,7 +39,7 @@ Remove Peer Options:
 
 func (c *OperatorRaftRemoveCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-peer-address": complete.PredictNothing,
+		"-peer-address": complete.PredictAnything,
 	}
 }
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -79,7 +79,10 @@ func (c *PlanCommand) Synopsis() string {
 }
 
 func (c *PlanCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-diff":    complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *PlanCommand) AutocompleteArgs() complete.Predictor {

--- a/command/plan.go
+++ b/command/plan.go
@@ -79,10 +79,11 @@ func (c *PlanCommand) Synopsis() string {
 }
 
 func (c *PlanCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-diff":    complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-diff":    complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *PlanCommand) AutocompleteArgs() complete.Predictor {

--- a/command/run.go
+++ b/command/run.go
@@ -98,13 +98,14 @@ func (c *RunCommand) Synopsis() string {
 }
 
 func (c *RunCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-check-index": complete.PredictNothing,
-		"-detach":      complete.PredictNothing,
-		"-verbose":     complete.PredictNothing,
-		"-vault-token": complete.PredictAnything,
-		"-output":      complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-check-index": complete.PredictNothing,
+			"-detach":      complete.PredictNothing,
+			"-verbose":     complete.PredictNothing,
+			"-vault-token": complete.PredictAnything,
+			"-output":      complete.PredictNothing,
+		})
 }
 
 func (c *RunCommand) AutocompleteArgs() complete.Predictor {

--- a/command/run.go
+++ b/command/run.go
@@ -98,7 +98,13 @@ func (c *RunCommand) Synopsis() string {
 }
 
 func (c *RunCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-check-index": complete.PredictNothing,
+		"-detach":      complete.PredictNothing,
+		"-verbose":     complete.PredictNothing,
+		"-vault-token": complete.PredictNothing,
+		"-output":      complete.PredictNothing,
+	}
 }
 
 func (c *RunCommand) AutocompleteArgs() complete.Predictor {

--- a/command/run.go
+++ b/command/run.go
@@ -102,7 +102,7 @@ func (c *RunCommand) AutocompleteFlags() complete.Flags {
 		"-check-index": complete.PredictNothing,
 		"-detach":      complete.PredictNothing,
 		"-verbose":     complete.PredictNothing,
-		"-vault-token": complete.PredictNothing,
+		"-vault-token": complete.PredictAnything,
 		"-output":      complete.PredictNothing,
 	}
 }

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
 	"github.com/ryanuber/columnize"
 )
 
@@ -33,6 +34,16 @@ Server Members Options:
     default output format.
 `
 	return strings.TrimSpace(helpText)
+}
+
+func (c *ServerMembersCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-detailed": complete.PredictNothing,
+	}
+}
+
+func (c *ServerMembersCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }
 
 func (c *ServerMembersCommand) Synopsis() string {

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -37,9 +37,10 @@ Server Members Options:
 }
 
 func (c *ServerMembersCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-detailed": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-detailed": complete.PredictNothing,
+		})
 }
 
 func (c *ServerMembersCommand) AutocompleteArgs() complete.Predictor {

--- a/command/stop.go
+++ b/command/stop.go
@@ -52,12 +52,13 @@ func (c *StopCommand) Synopsis() string {
 }
 
 func (c *StopCommand) AutocompleteFlags() complete.Flags {
-	return complete.Flags{
-		"-detach":  complete.PredictNothing,
-		"-purge":   complete.PredictNothing,
-		"-yes":     complete.PredictNothing,
-		"-verbose": complete.PredictNothing,
-	}
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-detach":  complete.PredictNothing,
+			"-purge":   complete.PredictNothing,
+			"-yes":     complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
 }
 
 func (c *StopCommand) AutocompleteArgs() complete.Predictor {

--- a/command/stop.go
+++ b/command/stop.go
@@ -52,7 +52,12 @@ func (c *StopCommand) Synopsis() string {
 }
 
 func (c *StopCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return complete.Flags{
+		"-detach":  complete.PredictNothing,
+		"-purge":   complete.PredictNothing,
+		"-yes":     complete.PredictNothing,
+		"-verbose": complete.PredictNothing,
+	}
 }
 
 func (c *StopCommand) AutocompleteArgs() complete.Predictor {


### PR DESCRIPTION
This PR adds flag autocompletion for all CLI commands. 

This PR does allow specific flags to continue to tab complete more than once. 

Other considerations: 
  - AutocompleteArgs functions which return only complete.PredictNothing are not under test, but I can add tests if we think it is necessary
  - Logic for limiting tab completion only once for a specific argument should probably live in https://github.com/mitchellh/cli, as this would be useful for projects other than Nomad
- Should flags be alphabetized when autocompleting? 