### PR TITLE
Handle interfaces that only have link-local addrs

### DIFF
--- a/client/fingerprint/network_test.go
+++ b/client/fingerprint/network_test.go
@@ -46,6 +46,24 @@ var (
 		HardwareAddr: []byte{23, 44, 54, 70},
 		Flags:        net.FlagUp | net.FlagBroadcast | net.FlagMulticast,
 	}
+
+	// One link local address
+	eth3 = net.Interface{
+		Index:        4,
+		MTU:          1500,
+		Name:         "eth3",
+		HardwareAddr: []byte{23, 44, 54, 71},
+		Flags:        net.FlagUp | net.FlagBroadcast | net.FlagMulticast,
+	}
+
+	// One link local address and one globally routable address
+	eth4 = net.Interface{
+		Index:        4,
+		MTU:          1500,
+		Name:         "eth4",
+		HardwareAddr: []byte{23, 44, 54, 72},
+		Flags:        net.FlagUp | net.FlagBroadcast | net.FlagMulticast,
+	}
 )
 
 // A fake network detector which returns no devices
@@ -109,6 +127,10 @@ func (n *NetworkInterfaceDetectorMultipleInterfaces) InterfaceByName(name string
 		intf = &eth1
 	case "eth2":
 		intf = &eth2
+	case "eth3":
+		intf = &eth3
+	case "eth4":
+		intf = &eth4
 	}
 	if intf != nil {
 		return intf, nil
@@ -140,6 +162,18 @@ func (n *NetworkInterfaceDetectorMultipleInterfaces) Addrs(intf *net.Interface) 
 	if intf.Name == "eth2" {
 		return []net.Addr{}, nil
 	}
+
+	if intf.Name == "eth3" {
+		_, ipnet1, _ := net.ParseCIDR("169.254.155.20/32")
+		return []net.Addr{ipnet1}, nil
+	}
+
+	if intf.Name == "eth4" {
+		_, ipnet1, _ := net.ParseCIDR("169.254.155.20/32")
+		_, ipnet2, _ := net.ParseCIDR("100.64.0.10/10")
+		return []net.Addr{ipnet1, ipnet2}, nil
+	}
+
 	return nil, fmt.Errorf("Can't find addresses for device: %v", intf.Name)
 }
 
@@ -319,5 +353,116 @@ func TestNetworkFingerPrint_excludelo_down_interfaces(t *testing.T) {
 	// Ensure that the link local address isn't fingerprinted
 	if len(node.Resources.Networks) != 2 {
 		t.Fatalf("bad number of IPs %v", len(node.Resources.Networks))
+	}
+}
+
+func TestNetworkFingerPrint_LinkLocal_Allowed(t *testing.T) {
+	f := &NetworkFingerprint{logger: testLogger(), interfaceDetector: &NetworkInterfaceDetectorMultipleInterfaces{}}
+	node := &structs.Node{
+		Attributes: make(map[string]string),
+	}
+	cfg := &config.Config{NetworkSpeed: 100, NetworkInterface: "eth3"}
+
+	ok, err := f.Fingerprint(cfg, node)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("should apply")
+	}
+
+	assertNodeAttributeContains(t, node, "unique.network.ip-address")
+
+	ip := node.Attributes["unique.network.ip-address"]
+	match := net.ParseIP(ip)
+	if match == nil {
+		t.Fatalf("Bad IP match: %s", ip)
+	}
+
+	if node.Resources == nil || len(node.Resources.Networks) == 0 {
+		t.Fatal("Expected to find Network Resources")
+	}
+
+	// Test at least the first Network Resource
+	net := node.Resources.Networks[0]
+	if net.IP == "" {
+		t.Fatal("Expected Network Resource to not be empty")
+	}
+	if net.CIDR == "" {
+		t.Fatal("Expected Network Resource to have a CIDR")
+	}
+	if net.Device == "" {
+		t.Fatal("Expected Network Resource to have a Device Name")
+	}
+	if net.MBits == 0 {
+		t.Fatal("Expected Network Resource to have a non-zero bandwidth")
+	}
+}
+
+func TestNetworkFingerPrint_LinkLocal_Allowed_MixedIntf(t *testing.T) {
+	f := &NetworkFingerprint{logger: testLogger(), interfaceDetector: &NetworkInterfaceDetectorMultipleInterfaces{}}
+	node := &structs.Node{
+		Attributes: make(map[string]string),
+	}
+	cfg := &config.Config{NetworkSpeed: 100, NetworkInterface: "eth4"}
+
+	ok, err := f.Fingerprint(cfg, node)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("should apply")
+	}
+
+	assertNodeAttributeContains(t, node, "unique.network.ip-address")
+
+	ip := node.Attributes["unique.network.ip-address"]
+	match := net.ParseIP(ip)
+	if match == nil {
+		t.Fatalf("Bad IP match: %s", ip)
+	}
+
+	if node.Resources == nil || len(node.Resources.Networks) == 0 {
+		t.Fatal("Expected to find Network Resources")
+	}
+
+	// Test at least the first Network Resource
+	net := node.Resources.Networks[0]
+	if net.IP == "" {
+		t.Fatal("Expected Network Resource to not be empty")
+	}
+	if net.IP == "169.254.155.20" {
+		t.Fatalf("expected non-link local address; got %v", net.IP)
+	}
+	if net.CIDR == "" {
+		t.Fatal("Expected Network Resource to have a CIDR")
+	}
+	if net.Device == "" {
+		t.Fatal("Expected Network Resource to have a Device Name")
+	}
+	if net.MBits == 0 {
+		t.Fatal("Expected Network Resource to have a non-zero bandwidth")
+	}
+}
+
+func TestNetworkFingerPrint_LinkLocal_Disallowed(t *testing.T) {
+	f := &NetworkFingerprint{logger: testLogger(), interfaceDetector: &NetworkInterfaceDetectorMultipleInterfaces{}}
+	node := &structs.Node{
+		Attributes: make(map[string]string),
+	}
+	cfg := &config.Config{
+		NetworkSpeed:     100,
+		NetworkInterface: "eth3",
+		Options: map[string]string{
+			networkDisallowLinkLocalOption: "true",
+		},
+	}
+
+	ok, err := f.Fingerprint(cfg, node)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("should not apply")
 	}
 }

--- a/website/source/docs/agent/configuration/client.html.md
+++ b/website/source/docs/agent/configuration/client.html.md
@@ -92,7 +92,7 @@ client {
  "client", like `"/opt/nomad/client"`. This must be an absolute path.
 
 - `gc_interval` `(string: "1m")` - Specifies the interval at which Nomad
-  attempts to garbage collect terminal allocation directories. 
+  attempts to garbage collect terminal allocation directories.
 
 - `gc_disk_usage_threshold` `(float: 80)` - Specifies the disk usage percent which
   Nomad tries to maintain by garbage collecting terminal allocations.
@@ -264,6 +264,19 @@ see the [drivers documentation](/docs/drivers/index.html).
     client {
       options = {
         "fingerprint.blacklist" = "network"
+      }
+    }
+    ```
+
+- `"fingerprint.network.disallow_link_local"` `(string: "false")` - Specifies
+  whether the network fingerprinter should ignore link-local addresses in the
+  case that no globally routable address is found. The fingerprinter will always
+  prefer globally routable addresses.
+
+    ```hcl
+    client {
+      options = {
+        "fingerprint.network.disallow_link_local" = "true"
       }
     }
     ```


### PR DESCRIPTION
This PR changes the fingerprint handling of network interfaces that only
contain link local addresses. The new behavior is to prefer globally
routable addresses and if none are detected, to fall back to link local
addresses if the operator hasn't disallowed it. This gives us pre 0.6
behavior for interfaces with only link local addresses but 0.6+ behavior
for IPv6 interfaces that will always have a link-local address.

Fixes https://github.com/hashicorp/nomad/issues/3005

/cc @diptanu