### PR TITLE
ACL RPCs allow stale reads for scalability

### DIFF
--- a/client/acl.go
+++ b/client/acl.go
@@ -124,8 +124,11 @@ func (c *Client) resolveTokenValue(secretID string) (*structs.ACLToken, error) {
 
 	// Lookup the token
 	req := structs.ResolveACLTokenRequest{
-		SecretID:     secretID,
-		QueryOptions: structs.QueryOptions{Region: c.Region()},
+		SecretID: secretID,
+		QueryOptions: structs.QueryOptions{
+			Region:     c.Region(),
+			AllowStale: true,
+		},
 	}
 	var resp structs.ResolveACLTokenResponse
 	if err := c.RPC("ACL.ResolveToken", &req, &resp); err != nil {
@@ -186,8 +189,9 @@ func (c *Client) resolvePolicies(secretID string, policies []string) ([]*structs
 	req := structs.ACLPolicySetRequest{
 		Names: fetch,
 		QueryOptions: structs.QueryOptions{
-			Region:   c.Region(),
-			SecretID: secretID,
+			Region:     c.Region(),
+			SecretID:   secretID,
+			AllowStale: true,
 		},
 	}
 	var resp structs.ACLPolicySetResponse

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -669,7 +669,8 @@ REMOVE:
 func (s *Server) replicateACLPolicies(stopCh chan struct{}) {
 	req := structs.ACLPolicyListRequest{
 		QueryOptions: structs.QueryOptions{
-			Region: s.config.AuthoritativeRegion,
+			Region:     s.config.AuthoritativeRegion,
+			AllowStale: true,
 		},
 	}
 	limiter := rate.NewLimiter(replicationRateLimit, int(replicationRateLimit))
@@ -715,8 +716,9 @@ START:
 				req := structs.ACLPolicySetRequest{
 					Names: update,
 					QueryOptions: structs.QueryOptions{
-						Region:   s.config.AuthoritativeRegion,
-						SecretID: s.ReplicationToken(),
+						Region:     s.config.AuthoritativeRegion,
+						SecretID:   s.ReplicationToken(),
+						AllowStale: true,
 					},
 				}
 				var reply structs.ACLPolicySetResponse
@@ -811,7 +813,8 @@ func (s *Server) replicateACLTokens(stopCh chan struct{}) {
 	req := structs.ACLTokenListRequest{
 		GlobalOnly: true,
 		QueryOptions: structs.QueryOptions{
-			Region: s.config.AuthoritativeRegion,
+			Region:     s.config.AuthoritativeRegion,
+			AllowStale: true,
 		},
 	}
 	limiter := rate.NewLimiter(replicationRateLimit, int(replicationRateLimit))
@@ -857,8 +860,9 @@ START:
 				req := structs.ACLTokenSetRequest{
 					AccessorIDS: update,
 					QueryOptions: structs.QueryOptions{
-						Region:   s.config.AuthoritativeRegion,
-						SecretID: s.ReplicationToken(),
+						Region:     s.config.AuthoritativeRegion,
+						SecretID:   s.ReplicationToken(),
+						AllowStale: true,
 					},
 				}
 				var reply structs.ACLTokenSetResponse

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -716,9 +716,10 @@ START:
 				req := structs.ACLPolicySetRequest{
 					Names: update,
 					QueryOptions: structs.QueryOptions{
-						Region:     s.config.AuthoritativeRegion,
-						SecretID:   s.ReplicationToken(),
-						AllowStale: true,
+						Region:        s.config.AuthoritativeRegion,
+						SecretID:      s.ReplicationToken(),
+						AllowStale:    true,
+						MinQueryIndex: resp.Index - 1,
 					},
 				}
 				var reply structs.ACLPolicySetResponse
@@ -860,9 +861,10 @@ START:
 				req := structs.ACLTokenSetRequest{
 					AccessorIDS: update,
 					QueryOptions: structs.QueryOptions{
-						Region:     s.config.AuthoritativeRegion,
-						SecretID:   s.ReplicationToken(),
-						AllowStale: true,
+						Region:        s.config.AuthoritativeRegion,
+						SecretID:      s.ReplicationToken(),
+						AllowStale:    true,
+						MinQueryIndex: resp.Index - 1,
 					},
 				}
 				var reply structs.ACLTokenSetResponse


### PR DESCRIPTION
This PR changes all internal ACL related RPCs to `AllowStale = true`. This has the affect of spreading load within the authoritative region for replication of tokens and policies, which can tolerate staleness because we are actively replicating. This also spreads load within a region for client token resolution, and allows ACLs to be resolved during a leader outage.