### PR TITLE
Restart unhealthy tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
  * api: Metrics endpoint exposes Prometheus formatted metrics [GH-3171]
+ * discovery: Allow restarting unhealthy tasks with `check_restart` [GH-3105]
  * telemetry: Add support for tagged metrics for Nomad clients [GH-3147]
 
 BUG FIXES:

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -82,20 +82,23 @@ func (r *RestartPolicy) Merge(rp *RestartPolicy) {
 // The ServiceCheck data model represents the consul health check that
 // Nomad registers for a Task
 type ServiceCheck struct {
-	Id            string
-	Name          string
-	Type          string
-	Command       string
-	Args          []string
-	Path          string
-	Protocol      string
-	PortLabel     string `mapstructure:"port"`
-	Interval      time.Duration
-	Timeout       time.Duration
-	InitialStatus string `mapstructure:"initial_status"`
-	TLSSkipVerify bool   `mapstructure:"tls_skip_verify"`
-	Header        map[string][]string
-	Method        string
+	Id             string
+	Name           string
+	Type           string
+	Command        string
+	Args           []string
+	Path           string
+	Protocol       string
+	PortLabel      string `mapstructure:"port"`
+	Interval       time.Duration
+	Timeout        time.Duration
+	InitialStatus  string `mapstructure:"initial_status"`
+	TLSSkipVerify  bool   `mapstructure:"tls_skip_verify"`
+	Header         map[string][]string
+	Method         string
+	RestartAfter   int
+	RestartGrace   time.Duration
+	RestartWarning bool
 }
 
 // The Service model represents a Consul service definition

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -82,9 +82,9 @@ func (r *RestartPolicy) Merge(rp *RestartPolicy) {
 // CheckRestart describes if and when a task should be restarted based on
 // failing health checks.
 type CheckRestart struct {
-	Limit     int           `mapstructure:"limit"`
-	Grace     time.Duration `mapstructure:"grace_period"`
-	OnWarning bool          `mapstructure:"on_warning"`
+	Limit          int           `mapstructure:"limit"`
+	Grace          time.Duration `mapstructure:"grace_period"`
+	IgnoreWarnings bool          `mapstructure:"ignore_warnings"`
 }
 
 // The ServiceCheck data model represents the consul health check that

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -87,6 +87,63 @@ type CheckRestart struct {
 	IgnoreWarnings bool           `mapstructure:"ignore_warnings"`
 }
 
+// Canonicalize CheckRestart fields if not nil.
+func (c *CheckRestart) Canonicalize() {
+	if c == nil {
+		return
+	}
+
+	if c.Grace == nil {
+		c.Grace = helper.TimeToPtr(1 * time.Second)
+	}
+}
+
+// Copy returns a copy of CheckRestart or nil if unset.
+func (c *CheckRestart) Copy() *CheckRestart {
+	if c == nil {
+		return nil
+	}
+
+	nc := new(CheckRestart)
+	nc.Limit = c.Limit
+	if c.Grace != nil {
+		g := *c.Grace
+		nc.Grace = &g
+	}
+	nc.IgnoreWarnings = c.IgnoreWarnings
+	return nc
+}
+
+// Merge values from other CheckRestart over default values on this
+// CheckRestart and return merged copy.
+func (c *CheckRestart) Merge(o *CheckRestart) *CheckRestart {
+	if c == nil {
+		// Just return other
+		return o
+	}
+
+	nc := c.Copy()
+
+	if o == nil {
+		// Nothing to merge
+		return nc
+	}
+
+	if nc.Limit == 0 {
+		nc.Limit = o.Limit
+	}
+
+	if nc.Grace == nil {
+		nc.Grace = o.Grace
+	}
+
+	if nc.IgnoreWarnings {
+		nc.IgnoreWarnings = o.IgnoreWarnings
+	}
+
+	return nc
+}
+
 // The ServiceCheck data model represents the consul health check that
 // Nomad registers for a Task
 type ServiceCheck struct {
@@ -105,14 +162,6 @@ type ServiceCheck struct {
 	Header        map[string][]string
 	Method        string
 	CheckRestart  *CheckRestart `mapstructure:"check_restart"`
-}
-
-func (c *ServiceCheck) Canonicalize() {
-	if c.CheckRestart != nil {
-		if c.CheckRestart.Grace == nil {
-			c.CheckRestart.Grace = helper.TimeToPtr(1 * time.Second)
-		}
-	}
 }
 
 // The Service model represents a Consul service definition
@@ -136,8 +185,11 @@ func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {
 		s.AddressMode = "auto"
 	}
 
+	s.CheckRestart.Canonicalize()
+
 	for _, c := range s.Checks {
-		c.Canonicalize()
+		c.CheckRestart.Canonicalize()
+		c.CheckRestart = c.CheckRestart.Merge(s.CheckRestart)
 	}
 }
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -79,36 +79,43 @@ func (r *RestartPolicy) Merge(rp *RestartPolicy) {
 	}
 }
 
+// CheckRestart describes if and when a task should be restarted based on
+// failing health checks.
+type CheckRestart struct {
+	Limit     int           `mapstructure:"limit"`
+	Grace     time.Duration `mapstructure:"grace_period"`
+	OnWarning bool          `mapstructure:"on_warning"`
+}
+
 // The ServiceCheck data model represents the consul health check that
 // Nomad registers for a Task
 type ServiceCheck struct {
-	Id             string
-	Name           string
-	Type           string
-	Command        string
-	Args           []string
-	Path           string
-	Protocol       string
-	PortLabel      string `mapstructure:"port"`
-	Interval       time.Duration
-	Timeout        time.Duration
-	InitialStatus  string `mapstructure:"initial_status"`
-	TLSSkipVerify  bool   `mapstructure:"tls_skip_verify"`
-	Header         map[string][]string
-	Method         string
-	RestartAfter   int
-	RestartGrace   time.Duration
-	RestartWarning bool
+	Id            string
+	Name          string
+	Type          string
+	Command       string
+	Args          []string
+	Path          string
+	Protocol      string
+	PortLabel     string `mapstructure:"port"`
+	Interval      time.Duration
+	Timeout       time.Duration
+	InitialStatus string `mapstructure:"initial_status"`
+	TLSSkipVerify bool   `mapstructure:"tls_skip_verify"`
+	Header        map[string][]string
+	Method        string
+	CheckRestart  *CheckRestart `mapstructure:"check_restart"`
 }
 
 // The Service model represents a Consul service definition
 type Service struct {
-	Id          string
-	Name        string
-	Tags        []string
-	PortLabel   string `mapstructure:"port"`
-	AddressMode string `mapstructure:"address_mode"`
-	Checks      []ServiceCheck
+	Id           string
+	Name         string
+	Tags         []string
+	PortLabel    string `mapstructure:"port"`
+	AddressMode  string `mapstructure:"address_mode"`
+	Checks       []ServiceCheck
+	CheckRestart *CheckRestart `mapstructure:"check_restart"`
 }
 
 func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -187,6 +187,8 @@ func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {
 
 	s.CheckRestart.Canonicalize()
 
+	// Canonicallize CheckRestart on Checks and merge Service.CheckRestart
+	// into each check.
 	for _, c := range s.Checks {
 		c.CheckRestart.Canonicalize()
 		c.CheckRestart = c.CheckRestart.Merge(s.CheckRestart)

--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -336,7 +336,8 @@ func (r *AllocRunner) RestoreState() error {
 			// Restart task runner if RestoreState gave a reason
 			if restartReason != "" {
 				r.logger.Printf("[INFO] client: restarting alloc %s task %s: %v", r.allocID, name, restartReason)
-				tr.Restart("upgrade", restartReason)
+				const failure = false
+				tr.Restart("upgrade", restartReason, failure)
 			}
 		} else {
 			tr.Destroy(taskDestroyEvent)

--- a/client/consul.go
+++ b/client/consul.go
@@ -10,8 +10,8 @@ import (
 // ConsulServiceAPI is the interface the Nomad Client uses to register and
 // remove services and checks from Consul.
 type ConsulServiceAPI interface {
-	RegisterTask(allocID string, task *structs.Task, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error
+	RegisterTask(allocID string, task *structs.Task, restarter consul.TaskRestarter, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error
 	RemoveTask(allocID string, task *structs.Task)
-	UpdateTask(allocID string, existing, newTask *structs.Task, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error
+	UpdateTask(allocID string, existing, newTask *structs.Task, restart consul.TaskRestarter, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error
 	AllocRegistrations(allocID string) (*consul.AllocRegistration, error)
 }

--- a/client/consul_template.go
+++ b/client/consul_template.go
@@ -49,7 +49,7 @@ var (
 // TaskHooks is an interface which provides hooks into the tasks life-cycle
 type TaskHooks interface {
 	// Restart is used to restart the task
-	Restart(source, reason string)
+	Restart(source, reason string, failure bool)
 
 	// Signal is used to signal the task
 	Signal(source, reason string, s os.Signal) error
@@ -439,7 +439,8 @@ func (tm *TaskTemplateManager) handleTemplateRerenders(allRenderedTime time.Time
 				}
 
 				if restart {
-					tm.config.Hooks.Restart(consulTemplateSourceName, "template with change_mode restart re-rendered")
+					const failure = false
+					tm.config.Hooks.Restart(consulTemplateSourceName, "template with change_mode restart re-rendered", failure)
 				} else if len(signals) != 0 {
 					var mErr multierror.Error
 					for signal := range signals {

--- a/client/consul_template_test.go
+++ b/client/consul_template_test.go
@@ -57,7 +57,7 @@ func NewMockTaskHooks() *MockTaskHooks {
 		EmitEventCh: make(chan struct{}, 1),
 	}
 }
-func (m *MockTaskHooks) Restart(source, reason string) {
+func (m *MockTaskHooks) Restart(source, reason string, failure bool) {
 	m.Restarts++
 	select {
 	case m.RestartCh <- struct{}{}:

--- a/client/consul_test.go
+++ b/client/consul_test.go
@@ -60,7 +60,7 @@ func newMockConsulServiceClient() *mockConsulServiceClient {
 	return &m
 }
 
-func (m *mockConsulServiceClient) UpdateTask(allocID string, old, new *structs.Task, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error {
+func (m *mockConsulServiceClient) UpdateTask(allocID string, old, new *structs.Task, restarter consul.TaskRestarter, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.logger.Printf("[TEST] mock_consul: UpdateTask(%q, %v, %v, %T, %x)", allocID, old, new, exec, net.Hash())
@@ -68,7 +68,7 @@ func (m *mockConsulServiceClient) UpdateTask(allocID string, old, new *structs.T
 	return nil
 }
 
-func (m *mockConsulServiceClient) RegisterTask(allocID string, task *structs.Task, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error {
+func (m *mockConsulServiceClient) RegisterTask(allocID string, task *structs.Task, restarter consul.TaskRestarter, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.logger.Printf("[TEST] mock_consul: RegisterTask(%q, %q, %T, %x)", allocID, task.Name, exec, net.Hash())

--- a/client/restarts.go
+++ b/client/restarts.go
@@ -75,19 +75,14 @@ func (r *RestartTracker) SetWaitResult(res *dstructs.WaitResult) *RestartTracker
 
 // SetRestartTriggered is used to mark that the task has been signalled to be
 // restarted
-func (r *RestartTracker) SetRestartTriggered() *RestartTracker {
+func (r *RestartTracker) SetRestartTriggered(failure bool) *RestartTracker {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	r.restartTriggered = true
-	return r
-}
-
-// SetFailure is used to mark that a task should be restarted due to failure
-// such as a failed Consul healthcheck.
-func (r *RestartTracker) SetFailure() *RestartTracker {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	r.failure = true
+	if failure {
+		r.failure = true
+	} else {
+		r.restartTriggered = true
+	}
 	return r
 }
 

--- a/client/restarts.go
+++ b/client/restarts.go
@@ -74,7 +74,9 @@ func (r *RestartTracker) SetWaitResult(res *dstructs.WaitResult) *RestartTracker
 }
 
 // SetRestartTriggered is used to mark that the task has been signalled to be
-// restarted
+// restarted. Setting the failure to true restarts according to the restart
+// policy. When failure is false the task is restarted without considering the
+// restart policy.
 func (r *RestartTracker) SetRestartTriggered(failure bool) *RestartTracker {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -159,6 +161,9 @@ func (r *RestartTracker) GetState() (string, time.Duration) {
 			}
 		}
 
+		// If this task has been restarted due to failures more times
+		// than the restart policy allows within an interval fail
+		// according to the restart policy's mode.
 		if r.count > r.policy.Attempts {
 			if r.policy.Mode == structs.RestartPolicyModeFail {
 				r.reason = fmt.Sprintf(

--- a/client/restarts_test.go
+++ b/client/restarts_test.go
@@ -99,7 +99,7 @@ func TestClient_RestartTracker_RestartTriggered(t *testing.T) {
 	p := testPolicy(true, structs.RestartPolicyModeFail)
 	p.Attempts = 0
 	rt := newRestartTracker(p, structs.JobTypeService)
-	if state, when := rt.SetRestartTriggered().GetState(); state != structs.TaskRestarting && when != 0 {
+	if state, when := rt.SetRestartTriggered(false).GetState(); state != structs.TaskRestarting && when != 0 {
 		t.Fatalf("expect restart immediately, got %v %v", state, when)
 	}
 }

--- a/client/restarts_test.go
+++ b/client/restarts_test.go
@@ -104,6 +104,19 @@ func TestClient_RestartTracker_RestartTriggered(t *testing.T) {
 	}
 }
 
+func TestClient_RestartTracker_RestartTriggered_Failure(t *testing.T) {
+	t.Parallel()
+	p := testPolicy(true, structs.RestartPolicyModeFail)
+	p.Attempts = 1
+	rt := newRestartTracker(p, structs.JobTypeService)
+	if state, when := rt.SetRestartTriggered(true).GetState(); state != structs.TaskRestarting || when == 0 {
+		t.Fatalf("expect restart got %v %v", state, when)
+	}
+	if state, when := rt.SetRestartTriggered(true).GetState(); state != structs.TaskNotRestarting || when != 0 {
+		t.Fatalf("expect failed got %v %v", state, when)
+	}
+}
+
 func TestClient_RestartTracker_StartError_Recoverable_Fail(t *testing.T) {
 	t.Parallel()
 	p := testPolicy(true, structs.RestartPolicyModeFail)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -75,9 +75,9 @@ type taskRestartEvent struct {
 	failure bool
 }
 
-func newTaskRestartEvent(source, reason string, failure bool) *taskRestartEvent {
+func newTaskRestartEvent(reason string, failure bool) *taskRestartEvent {
 	return &taskRestartEvent{
-		taskEvent: structs.NewTaskEvent(source).SetRestartReason(reason),
+		taskEvent: structs.NewTaskEvent(structs.TaskRestartSignal).SetRestartReason(reason),
 		failure:   failure,
 	}
 }
@@ -1708,7 +1708,7 @@ func (r *TaskRunner) handleDestroy(handle driver.DriverHandle) (destroyed bool, 
 // Restart will restart the task.
 func (r *TaskRunner) Restart(source, reason string, failure bool) {
 	reasonStr := fmt.Sprintf("%s: %s", source, reason)
-	event := newTaskRestartEvent(source, reasonStr, failure)
+	event := newTaskRestartEvent(reasonStr, failure)
 
 	select {
 	case r.restartCh <- event:

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -158,10 +158,6 @@ type TaskRunner struct {
 	// restartCh is used to restart a task
 	restartCh chan *taskRestartEvent
 
-	// lastStart tracks the last time this task was started or restarted
-	lastStart   time.Time
-	lastStartMu sync.Mutex
-
 	// signalCh is used to send a signal to a task
 	signalCh chan SignalEvent
 
@@ -1388,11 +1384,6 @@ func (r *TaskRunner) killTask(killingEvent *structs.TaskEvent) {
 
 // startTask creates the driver, task dir, and starts the task.
 func (r *TaskRunner) startTask() error {
-	// Update lastStart
-	r.lastStartMu.Lock()
-	r.lastStart = time.Now()
-	r.lastStartMu.Unlock()
-
 	// Create a driver
 	drv, err := r.createDriver()
 	if err != nil {

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1716,10 +1716,11 @@ func (r *TaskRunner) Restart(source, reason string, failure bool) {
 	}
 }
 
-// RestartDelay returns the value of the delay for this task's restart policy
-// for use by the healtcheck watcher.
+// RestartDelay returns the *max* value of the delay for this task's restart
+// policy for use by the healtcheck watcher.
 func (r *TaskRunner) RestartDelay() time.Duration {
-	return r.alloc.Job.LookupTaskGroup(r.alloc.TaskGroup).RestartPolicy.Delay
+	delay := r.alloc.Job.LookupTaskGroup(r.alloc.TaskGroup).RestartPolicy.Delay
+	return delay + time.Duration(float64(delay)*jitter)
 }
 
 // Signal will send a signal to the task

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -102,10 +102,6 @@ type TaskRunner struct {
 	task    *structs.Task
 	taskDir *allocdir.TaskDir
 
-	// Synchronizes access to alloc and task since the main Run loop may
-	// update them concurrent with reads in exported methods.
-	allocLock sync.Mutex
-
 	// envBuilder is used to build the task's environment
 	envBuilder *env.Builder
 
@@ -1747,9 +1743,6 @@ func (r *TaskRunner) Signal(source, reason string, s os.Signal) error {
 // Kill will kill a task and store the error, no longer restarting the task. If
 // fail is set, the task is marked as having failed.
 func (r *TaskRunner) Kill(source, reason string, fail bool) {
-	r.allocLock.Lock()
-	defer r.allocLock.Unlock()
-
 	reasonStr := fmt.Sprintf("%s: %s", source, reason)
 	event := structs.NewTaskEvent(structs.TaskKilling).SetKillReason(reasonStr)
 	if fail {

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1703,13 +1703,6 @@ func (r *TaskRunner) Restart(source, reason string, failure bool) {
 	}
 }
 
-// RestartDelay returns the *max* value of the delay for this task's restart
-// policy for use by the healtcheck watcher.
-func (r *TaskRunner) RestartDelay() time.Duration {
-	delay := r.alloc.Job.LookupTaskGroup(r.alloc.TaskGroup).RestartPolicy.Delay
-	return delay + time.Duration(float64(delay)*jitter)
-}
-
 // Signal will send a signal to the task
 func (r *TaskRunner) Signal(source, reason string, s os.Signal) error {
 

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1175,13 +1175,7 @@ func (r *TaskRunner) run() {
 					<-handleWaitCh
 				}
 
-				if restartEvent.failure {
-					r.restartTracker.SetFailure()
-				} else {
-					// Since the restart isn't from a failure, restart immediately
-					// and don't count against the restart policy
-					r.restartTracker.SetRestartTriggered()
-				}
+				r.restartTracker.SetRestartTriggered(restartEvent.failure)
 				break WAIT
 
 			case <-r.destroyCh:

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -789,8 +789,8 @@ OUTER:
 					return
 				}
 			case structs.VaultChangeModeRestart:
-				const failure = false
-				r.Restart("vault", "new Vault token acquired", failure)
+				const noFailure = false
+				r.Restart("vault", "new Vault token acquired", noFailure)
 			case structs.VaultChangeModeNoop:
 				fallthrough
 			default:

--- a/client/task_runner_unix_test.go
+++ b/client/task_runner_unix_test.go
@@ -53,7 +53,7 @@ func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
 	}
 
 	// Send a restart
-	ctx.tr.Restart("test", "don't panic")
+	ctx.tr.Restart("test", "don't panic", false)
 
 	if len(ctx.upd.events) != 2 {
 		t.Fatalf("should have 2 ctx.updates: %#v", ctx.upd.events)

--- a/command/agent/consul/catalog_testing.go
+++ b/command/agent/consul/catalog_testing.go
@@ -1,7 +1,9 @@
 package consul
 
 import (
+	"fmt"
 	"log"
+	"sync"
 
 	"github.com/hashicorp/consul/api"
 )
@@ -24,4 +26,120 @@ func (m *MockCatalog) Datacenters() ([]string, error) {
 func (m *MockCatalog) Service(service, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error) {
 	m.logger.Printf("[DEBUG] mock_consul: Service(%q, %q, %#v) -> (nil, nil, nil)", service, tag, q)
 	return nil, nil, nil
+}
+
+// MockAgent is a fake in-memory Consul backend for ServiceClient.
+type MockAgent struct {
+	// maps of what services and checks have been registered
+	services map[string]*api.AgentServiceRegistration
+	checks   map[string]*api.AgentCheckRegistration
+	mu       sync.Mutex
+
+	// when UpdateTTL is called the check ID will have its counter inc'd
+	checkTTLs map[string]int
+
+	// What check status to return from Checks()
+	checkStatus string
+}
+
+// NewMockAgent that returns all checks as passing.
+func NewMockAgent() *MockAgent {
+	return &MockAgent{
+		services:    make(map[string]*api.AgentServiceRegistration),
+		checks:      make(map[string]*api.AgentCheckRegistration),
+		checkTTLs:   make(map[string]int),
+		checkStatus: api.HealthPassing,
+	}
+}
+
+// SetStatus that Checks() should return. Returns old status value.
+func (c *MockAgent) SetStatus(s string) string {
+	c.mu.Lock()
+	old := c.checkStatus
+	c.checkStatus = s
+	c.mu.Unlock()
+	return old
+}
+
+func (c *MockAgent) Services() (map[string]*api.AgentService, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	r := make(map[string]*api.AgentService, len(c.services))
+	for k, v := range c.services {
+		r[k] = &api.AgentService{
+			ID:                v.ID,
+			Service:           v.Name,
+			Tags:              make([]string, len(v.Tags)),
+			Port:              v.Port,
+			Address:           v.Address,
+			EnableTagOverride: v.EnableTagOverride,
+		}
+		copy(r[k].Tags, v.Tags)
+	}
+	return r, nil
+}
+
+func (c *MockAgent) Checks() (map[string]*api.AgentCheck, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	r := make(map[string]*api.AgentCheck, len(c.checks))
+	for k, v := range c.checks {
+		r[k] = &api.AgentCheck{
+			CheckID:     v.ID,
+			Name:        v.Name,
+			Status:      c.checkStatus,
+			Notes:       v.Notes,
+			ServiceID:   v.ServiceID,
+			ServiceName: c.services[v.ServiceID].Name,
+		}
+	}
+	return r, nil
+}
+
+func (c *MockAgent) CheckRegister(check *api.AgentCheckRegistration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.checks[check.ID] = check
+
+	// Be nice and make checks reachable-by-service
+	scheck := check.AgentServiceCheck
+	c.services[check.ServiceID].Checks = append(c.services[check.ServiceID].Checks, &scheck)
+	return nil
+}
+
+func (c *MockAgent) CheckDeregister(checkID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.checks, checkID)
+	delete(c.checkTTLs, checkID)
+	return nil
+}
+
+func (c *MockAgent) ServiceRegister(service *api.AgentServiceRegistration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.services[service.ID] = service
+	return nil
+}
+
+func (c *MockAgent) ServiceDeregister(serviceID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.services, serviceID)
+	return nil
+}
+
+func (c *MockAgent) UpdateTTL(id string, output string, status string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	check, ok := c.checks[id]
+	if !ok {
+		return fmt.Errorf("unknown check id: %q", id)
+	}
+	// Flip initial status to passing
+	check.Status = "passing"
+	c.checkTTLs[id]++
+	return nil
 }

--- a/command/agent/consul/check_watcher.go
+++ b/command/agent/consul/check_watcher.go
@@ -269,7 +269,7 @@ func (w *checkWatcher) Run(ctx context.Context) {
 
 // Watch a task and restart it if unhealthy.
 func (w *checkWatcher) Watch(allocID, taskName, checkID string, check *structs.ServiceCheck, restarter TaskRestarter) {
-	if !check.Watched() {
+	if !check.TriggersRestarts() {
 		// Not watched, noop
 		return
 	}

--- a/command/agent/consul/check_watcher.go
+++ b/command/agent/consul/check_watcher.go
@@ -1,0 +1,244 @@
+package consul
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	// defaultPollFreq is the default rate to poll the Consul Checks API
+	defaultPollFreq = 900 * time.Millisecond
+)
+
+type ConsulChecks interface {
+	Checks() (map[string]*api.AgentCheck, error)
+}
+
+type TaskRestarter interface {
+	LastStart() time.Time
+	RestartBy(deadline time.Time, source, reason string)
+}
+
+// checkRestart handles restarting a task if a check is unhealthy.
+type checkRestart struct {
+	allocID   string
+	taskName  string
+	checkID   string
+	checkName string
+
+	// remove this checkID (if true only checkID will be set)
+	remove bool
+
+	task      TaskRestarter
+	grace     time.Duration
+	interval  time.Duration
+	timeLimit time.Duration
+	warning   bool
+
+	// unhealthyStart is the time a check first went unhealthy. Set to the
+	// zero value if the check passes before timeLimit.
+	// This is the only mutable field on checkRestart.
+	unhealthyStart time.Time
+
+	logger *log.Logger
+}
+
+// update restart state for check and restart task if necessary. Currrent
+// timestamp is passed in so all check updates have the same view of time (and
+// to ease testing).
+func (c *checkRestart) update(now time.Time, status string) {
+	switch status {
+	case api.HealthCritical:
+	case api.HealthWarning:
+		if !c.warning {
+			// Warnings are ok, reset state and exit
+			c.unhealthyStart = time.Time{}
+			return
+		}
+	default:
+		// All other statuses are ok, reset state and exit
+		c.unhealthyStart = time.Time{}
+		return
+	}
+
+	if now.Before(c.task.LastStart().Add(c.grace)) {
+		// In grace period, reset state and exit
+		c.unhealthyStart = time.Time{}
+		return
+	}
+
+	if c.unhealthyStart.IsZero() {
+		// First failure, set restart deadline
+		c.unhealthyStart = now
+	}
+
+	// restart timeLimit after start of this check becoming unhealthy
+	restartAt := c.unhealthyStart.Add(c.timeLimit)
+
+	// Must test >= because if limit=1, restartAt == first failure
+	if now.UnixNano() >= restartAt.UnixNano() {
+		// hasn't become healthy by deadline, restart!
+		c.logger.Printf("[DEBUG] consul.health: restarting alloc %q task %q due to unhealthy check %q", c.allocID, c.taskName, c.checkName)
+		c.task.RestartBy(now, "healthcheck", fmt.Sprintf("check %q unhealthy", c.checkName))
+	}
+}
+
+// checkWatcher watches Consul checks and restarts tasks when they're
+// unhealthy.
+type checkWatcher struct {
+	consul ConsulChecks
+
+	pollFreq time.Duration
+
+	watchCh chan *checkRestart
+
+	// done is closed when Run has exited
+	done chan struct{}
+
+	// lastErr is true if the last Consul call failed. It is used to
+	// squelch repeated error messages.
+	lastErr bool
+
+	logger *log.Logger
+}
+
+// newCheckWatcher creates a new checkWatcher but does not call its Run method.
+func newCheckWatcher(logger *log.Logger, consul ConsulChecks) *checkWatcher {
+	return &checkWatcher{
+		consul:   consul,
+		pollFreq: defaultPollFreq,
+		watchCh:  make(chan *checkRestart, 8),
+		done:     make(chan struct{}),
+		logger:   logger,
+	}
+}
+
+// Run the main Consul checks watching loop to restart tasks when their checks
+// fail. Blocks until context is canceled.
+func (w *checkWatcher) Run(ctx context.Context) {
+	defer close(w.done)
+
+	// map of check IDs to their metadata
+	checks := map[string]*checkRestart{}
+
+	// timer for check polling
+	checkTimer := time.NewTimer(0)
+	defer checkTimer.Stop() // ensure timer is never leaked
+	resetTimer := func(d time.Duration) {
+		if !checkTimer.Stop() {
+			<-checkTimer.C
+		}
+		checkTimer.Reset(d)
+	}
+
+	// Main watch loop
+	for {
+		// Don't start watching until we actually have checks that
+		// trigger restarts.
+		for len(checks) == 0 {
+			select {
+			case c := <-w.watchCh:
+				if c.remove {
+					// should not happen
+					w.logger.Printf("[DEBUG] consul.health: told to stop watching an unwatched check: %q", c.checkID)
+				} else {
+					checks[c.checkID] = c
+
+					// First check should be after grace period
+					resetTimer(c.grace)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		// As long as there are checks to be watched, keep watching
+		for len(checks) > 0 {
+			select {
+			case c := <-w.watchCh:
+				if c.remove {
+					delete(checks, c.checkID)
+				} else {
+					checks[c.checkID] = c
+					w.logger.Printf("[DEBUG] consul.health: watching alloc %q task %q check %q", c.allocID, c.taskName, c.checkName)
+				}
+			case <-ctx.Done():
+				return
+			case <-checkTimer.C:
+				checkTimer.Reset(w.pollFreq)
+
+				// Set "now" as the point in time the following check results represent
+				now := time.Now()
+
+				results, err := w.consul.Checks()
+				if err != nil {
+					if !w.lastErr {
+						w.lastErr = true
+						w.logger.Printf("[ERR] consul.health: error retrieving health checks: %q", err)
+					}
+					continue
+				}
+
+				w.lastErr = false
+
+				// Loop over watched checks and update their status from results
+				for cid, check := range checks {
+					result, ok := results[cid]
+					if !ok {
+						w.logger.Printf("[WARN] consul.health: watched check %q (%s) not found in Consul", check.checkName, cid)
+						continue
+					}
+
+					check.update(now, result.Status)
+				}
+			}
+		}
+	}
+}
+
+// Watch a task and restart it if unhealthy.
+func (w *checkWatcher) Watch(allocID, taskName, checkID string, check *structs.ServiceCheck, restarter TaskRestarter) {
+	if !check.Watched() {
+		// Not watched, noop
+		return
+	}
+
+	c := checkRestart{
+		allocID:   allocID,
+		taskName:  taskName,
+		checkID:   checkID,
+		checkName: check.Name,
+		task:      restarter,
+		interval:  check.Interval,
+		grace:     check.CheckRestart.Grace,
+		timeLimit: check.Interval * time.Duration(check.CheckRestart.Limit-1),
+		warning:   check.CheckRestart.OnWarning,
+		logger:    w.logger,
+	}
+
+	select {
+	case w.watchCh <- &c:
+		// sent watch
+	case <-w.done:
+		// exited; nothing to do
+	}
+}
+
+// Unwatch a task.
+func (w *checkWatcher) Unwatch(cid string) {
+	c := checkRestart{
+		checkID: cid,
+		remove:  true,
+	}
+	select {
+	case w.watchCh <- &c:
+		// sent remove watch
+	case <-w.done:
+		// exited; nothing to do
+	}
+}

--- a/command/agent/consul/check_watcher.go
+++ b/command/agent/consul/check_watcher.go
@@ -267,7 +267,7 @@ func (w *checkWatcher) Run(ctx context.Context) {
 	}
 }
 
-// Watch a task and restart it if unhealthy.
+// Watch a check and restart its task if unhealthy.
 func (w *checkWatcher) Watch(allocID, taskName, checkID string, check *structs.ServiceCheck, restarter TaskRestarter) {
 	if !check.TriggersRestarts() {
 		// Not watched, noop
@@ -302,7 +302,7 @@ func (w *checkWatcher) Watch(allocID, taskName, checkID string, check *structs.S
 	}
 }
 
-// Unwatch a task.
+// Unwatch a check.
 func (w *checkWatcher) Unwatch(cid string) {
 	c := checkWatchUpdate{
 		checkID: cid,

--- a/command/agent/consul/check_watcher_test.go
+++ b/command/agent/consul/check_watcher_test.go
@@ -1,0 +1,252 @@
+package consul
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// checkResponse is a response returned by the fakeChecksAPI after the given
+// time.
+type checkResponse struct {
+	at     time.Time
+	id     string
+	status string
+}
+
+// fakeChecksAPI implements the Checks() method for testing Consul.
+type fakeChecksAPI struct {
+	// responses is a map of check ids to their status at a particular
+	// time. checkResponses must be in chronological order.
+	responses map[string][]checkResponse
+}
+
+func newFakeChecksAPI() *fakeChecksAPI {
+	return &fakeChecksAPI{responses: make(map[string][]checkResponse)}
+}
+
+// add a new check status to Consul at the given time.
+func (c *fakeChecksAPI) add(id, status string, at time.Time) {
+	c.responses[id] = append(c.responses[id], checkResponse{at, id, status})
+}
+
+func (c *fakeChecksAPI) Checks() (map[string]*api.AgentCheck, error) {
+	now := time.Now()
+	result := make(map[string]*api.AgentCheck, len(c.responses))
+
+	// Use the latest response for each check
+	for k, vs := range c.responses {
+		for _, v := range vs {
+			if v.at.After(now) {
+				break
+			}
+			result[k] = &api.AgentCheck{
+				CheckID: k,
+				Name:    k,
+				Status:  v.status,
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// testWatcherSetup sets up a fakeChecksAPI and a real checkWatcher with a test
+// logger and faster poll frequency.
+func testWatcherSetup() (*fakeChecksAPI, *checkWatcher) {
+	fakeAPI := newFakeChecksAPI()
+	cw := newCheckWatcher(testLogger(), fakeAPI)
+	cw.pollFreq = 10 * time.Millisecond
+	return fakeAPI, cw
+}
+
+func testCheck() *structs.ServiceCheck {
+	return &structs.ServiceCheck{
+		Name:     "testcheck",
+		Interval: 100 * time.Millisecond,
+		Timeout:  100 * time.Millisecond,
+		CheckRestart: &structs.CheckRestart{
+			Limit:          3,
+			Grace:          100 * time.Millisecond,
+			IgnoreWarnings: false,
+		},
+	}
+}
+
+// TestCheckWatcher_Skip asserts unwatched checks are ignored.
+func TestCheckWatcher_Skip(t *testing.T) {
+	t.Parallel()
+
+	// Create a check with restarting disabled
+	check := testCheck()
+	check.CheckRestart = nil
+
+	cw := newCheckWatcher(testLogger(), newFakeChecksAPI())
+	restarter1 := newFakeCheckRestarter()
+	cw.Watch("testalloc1", "testtask1", "testcheck1", check, restarter1)
+
+	// Check should have been dropped as it's not watched
+	if n := len(cw.watchCh); n != 0 {
+		t.Fatalf("expected 0 checks to be enqueued for watching but found %d", n)
+	}
+}
+
+// TestCheckWatcher_Healthy asserts healthy tasks are not restarted.
+func TestCheckWatcher_Healthy(t *testing.T) {
+	t.Parallel()
+
+	fakeAPI, cw := testWatcherSetup()
+
+	check1 := testCheck()
+	restarter1 := newFakeCheckRestarter()
+	cw.Watch("testalloc1", "testtask1", "testcheck1", check1, restarter1)
+
+	check2 := testCheck()
+	check2.CheckRestart.Limit = 1
+	check2.CheckRestart.Grace = 0
+	restarter2 := newFakeCheckRestarter()
+	cw.Watch("testalloc2", "testtask2", "testcheck2", check2, restarter2)
+
+	// Make both checks healthy from the beginning
+	fakeAPI.add("testcheck1", "passing", time.Time{})
+	fakeAPI.add("testcheck2", "passing", time.Time{})
+
+	// Run for 1 second
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	cw.Run(ctx)
+
+	// Assert Restart was never called
+	if n := len(restarter1.restarts); n > 0 {
+		t.Errorf("expected check 1 to not be restarted but found %d", n)
+	}
+	if n := len(restarter2.restarts); n > 0 {
+		t.Errorf("expected check 2 to not be restarted but found %d", n)
+	}
+}
+
+// TestCheckWatcher_Unhealthy asserts unhealthy tasks are not restarted.
+func TestCheckWatcher_Unhealthy(t *testing.T) {
+	t.Parallel()
+
+	fakeAPI, cw := testWatcherSetup()
+
+	check1 := testCheck()
+	restarter1 := newFakeCheckRestarter()
+	cw.Watch("testalloc1", "testtask1", "testcheck1", check1, restarter1)
+
+	check2 := testCheck()
+	check2.CheckRestart.Limit = 1
+	check2.CheckRestart.Grace = 0
+	restarter2 := newFakeCheckRestarter()
+	restarter2.restartDelay = 600 * time.Millisecond
+	cw.Watch("testalloc2", "testtask2", "testcheck2", check2, restarter2)
+
+	// Check 1 always passes, check 2 always fails
+	fakeAPI.add("testcheck1", "passing", time.Time{})
+	fakeAPI.add("testcheck2", "critical", time.Time{})
+
+	// Run for 1 second
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	cw.Run(ctx)
+
+	// Ensure restart was never called on check 1
+	if n := len(restarter1.restarts); n > 0 {
+		t.Errorf("expected check 1 to not be restarted but found %d", n)
+	}
+
+	// Ensure restart was called twice on check 2
+	if n := len(restarter2.restarts); n != 2 {
+		t.Errorf("expected check 2 to be restarted 2 times but found %d:\n%s", n, restarter2)
+	}
+}
+
+// TestCheckWatcher_HealthyWarning asserts checks in warning with
+// ignore_warnings=true do not restart tasks.
+func TestCheckWatcher_HealthyWarning(t *testing.T) {
+	t.Parallel()
+
+	fakeAPI, cw := testWatcherSetup()
+
+	check1 := testCheck()
+	check1.CheckRestart.Limit = 1
+	check1.CheckRestart.Grace = 0
+	check1.CheckRestart.IgnoreWarnings = true
+	restarter1 := newFakeCheckRestarter()
+	restarter1.restartDelay = 1100 * time.Millisecond
+	cw.Watch("testalloc1", "testtask1", "testcheck1", check1, restarter1)
+
+	// Check is always in warning but that's ok
+	fakeAPI.add("testcheck1", "warning", time.Time{})
+
+	// Run for 1 second
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	cw.Run(ctx)
+
+	// Ensure restart was never called on check 1
+	if n := len(restarter1.restarts); n > 0 {
+		t.Errorf("expected check 1 to not be restarted but found %d", n)
+	}
+}
+
+// TestCheckWatcher_Flapping asserts checks that flap from healthy to unhealthy
+// before the unhealthy limit is reached do not restart tasks.
+func TestCheckWatcher_Flapping(t *testing.T) {
+	t.Parallel()
+
+	fakeAPI, cw := testWatcherSetup()
+
+	check1 := testCheck()
+	check1.CheckRestart.Grace = 0
+	restarter1 := newFakeCheckRestarter()
+	cw.Watch("testalloc1", "testtask1", "testcheck1", check1, restarter1)
+
+	// Check flaps and is never failing for the full 200ms needed to restart
+	now := time.Now()
+	fakeAPI.add("testcheck1", "passing", now)
+	fakeAPI.add("testcheck1", "critical", now.Add(100*time.Millisecond))
+	fakeAPI.add("testcheck1", "passing", now.Add(250*time.Millisecond))
+	fakeAPI.add("testcheck1", "critical", now.Add(300*time.Millisecond))
+	fakeAPI.add("testcheck1", "passing", now.Add(450*time.Millisecond))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	cw.Run(ctx)
+
+	// Ensure restart was never called on check 1
+	if n := len(restarter1.restarts); n > 0 {
+		t.Errorf("expected check 1 to not be restarted but found %d\n%s", n, restarter1)
+	}
+}
+
+// TestCheckWatcher_Unwatch asserts unwatching checks prevents restarts.
+func TestCheckWatcher_Unwatch(t *testing.T) {
+	t.Parallel()
+
+	fakeAPI, cw := testWatcherSetup()
+
+	// Unwatch immediately
+	check1 := testCheck()
+	check1.CheckRestart.Limit = 1
+	check1.CheckRestart.Grace = 100 * time.Millisecond
+	restarter1 := newFakeCheckRestarter()
+	cw.Watch("testalloc1", "testtask1", "testcheck1", check1, restarter1)
+	cw.Unwatch("testcheck1")
+
+	// Always failing
+	fakeAPI.add("testcheck1", "critical", time.Time{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	cw.Run(ctx)
+
+	// Ensure restart was never called on check 1
+	if n := len(restarter1.restarts); n > 0 {
+		t.Errorf("expected check 1 to not be restarted but found %d\n%s", n, restarter1)
+	}
+}

--- a/command/agent/consul/check_watcher_test.go
+++ b/command/agent/consul/check_watcher_test.go
@@ -249,13 +249,12 @@ func TestCheckWatcher_MultipleChecks(t *testing.T) {
 	defer cancel()
 	cw.Run(ctx)
 
-	// Ensure restart was only called on restarter1
-	if n := len(restarter1.restarts); n != 1 {
-		t.Errorf("expected check 1 to be restarted 1 time but found %d\n%s", n, restarter1)
-	}
-
-	if n := len(restarter2.restarts); n != 0 {
-		t.Errorf("expected check 2 to not be restarted but found %d:\n%s", n, restarter2)
+	// Ensure that restart was only called once on check 1 or 2. Since
+	// checks are in a map it's random which check triggers the restart
+	// first.
+	if n := len(restarter1.restarts) + len(restarter2.restarts); n != 1 {
+		t.Errorf("expected check 1 & 2 to be restarted 1 time but found %d\ncheck 1:\n%s\ncheck 2:%s",
+			n, restarter1, restarter2)
 	}
 
 	if n := len(restarter3.restarts); n != 0 {

--- a/command/agent/consul/check_watcher_test.go
+++ b/command/agent/consul/check_watcher_test.go
@@ -89,7 +89,7 @@ func TestCheckWatcher_Skip(t *testing.T) {
 	cw.Watch("testalloc1", "testtask1", "testcheck1", check, restarter1)
 
 	// Check should have been dropped as it's not watched
-	if n := len(cw.watchCh); n != 0 {
+	if n := len(cw.checkUpdateCh); n != 0 {
 		t.Fatalf("expected 0 checks to be enqueued for watching but found %d", n)
 	}
 }

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -697,7 +697,7 @@ func (c *ServiceClient) RegisterTask(allocID string, task *structs.Task, restart
 	for _, service := range task.Services {
 		serviceID := makeTaskServiceID(allocID, task.Name, service)
 		for _, check := range service.Checks {
-			if check.Watched() {
+			if check.TriggersRestarts() {
 				checkID := makeCheckID(serviceID, check)
 				c.checkWatcher.Watch(allocID, task.Name, checkID, check, restarter)
 			}
@@ -737,7 +737,7 @@ func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Ta
 				ops.deregChecks = append(ops.deregChecks, cid)
 
 				// Unwatch watched checks
-				if check.Watched() {
+				if check.TriggersRestarts() {
 					c.checkWatcher.Unwatch(cid)
 				}
 			}
@@ -787,7 +787,7 @@ func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Ta
 			}
 
 			// Update all watched checks as CheckRestart fields aren't part of ID
-			if check.Watched() {
+			if check.TriggersRestarts() {
 				c.checkWatcher.Watch(allocID, newTask.Name, checkID, check, restarter)
 			}
 		}
@@ -797,7 +797,7 @@ func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Ta
 			ops.deregChecks = append(ops.deregChecks, cid)
 
 			// Unwatch checks
-			if check.Watched() {
+			if check.TriggersRestarts() {
 				c.checkWatcher.Unwatch(cid)
 			}
 		}
@@ -823,7 +823,7 @@ func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Ta
 	for _, service := range newIDs {
 		serviceID := makeTaskServiceID(allocID, newTask.Name, service)
 		for _, check := range service.Checks {
-			if check.Watched() {
+			if check.TriggersRestarts() {
 				checkID := makeCheckID(serviceID, check)
 				c.checkWatcher.Watch(allocID, newTask.Name, checkID, check, restarter)
 			}
@@ -846,7 +846,7 @@ func (c *ServiceClient) RemoveTask(allocID string, task *structs.Task) {
 			cid := makeCheckID(id, check)
 			ops.deregChecks = append(ops.deregChecks, cid)
 
-			if check.Watched() {
+			if check.TriggersRestarts() {
 				c.checkWatcher.Unwatch(cid)
 			}
 		}

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -64,7 +64,6 @@ type checkRestartRecord struct {
 
 // fakeCheckRestarter is a test implementation of
 type fakeCheckRestarter struct {
-
 	// restartDelay is returned by RestartDelay to control the behavior of
 	// the checkWatcher
 	restartDelay time.Duration

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -688,7 +688,7 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 			if service.CheckRestart != nil {
 				structsTask.Services[i].CheckRestart = &structs.CheckRestart{
 					Limit:          service.CheckRestart.Limit,
-					Grace:          service.CheckRestart.Grace,
+					Grace:          *service.CheckRestart.Grace,
 					IgnoreWarnings: service.CheckRestart.IgnoreWarnings,
 				}
 			}
@@ -714,7 +714,7 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 					if check.CheckRestart != nil {
 						structsTask.Services[i].Checks[j].CheckRestart = &structs.CheckRestart{
 							Limit:          check.CheckRestart.Limit,
-							Grace:          check.CheckRestart.Grace,
+							Grace:          *check.CheckRestart.Grace,
 							IgnoreWarnings: check.CheckRestart.IgnoreWarnings,
 						}
 					}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -685,27 +685,38 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 				Tags:        service.Tags,
 				AddressMode: service.AddressMode,
 			}
+			if service.CheckRestart != nil {
+				structsTask.Services[i].CheckRestart = &structs.CheckRestart{
+					Limit:     service.CheckRestart.Limit,
+					Grace:     service.CheckRestart.Grace,
+					OnWarning: service.CheckRestart.OnWarning,
+				}
+			}
 
 			if l := len(service.Checks); l != 0 {
 				structsTask.Services[i].Checks = make([]*structs.ServiceCheck, l)
 				for j, check := range service.Checks {
 					structsTask.Services[i].Checks[j] = &structs.ServiceCheck{
-						Name:           check.Name,
-						Type:           check.Type,
-						Command:        check.Command,
-						Args:           check.Args,
-						Path:           check.Path,
-						Protocol:       check.Protocol,
-						PortLabel:      check.PortLabel,
-						Interval:       check.Interval,
-						Timeout:        check.Timeout,
-						InitialStatus:  check.InitialStatus,
-						TLSSkipVerify:  check.TLSSkipVerify,
-						Header:         check.Header,
-						Method:         check.Method,
-						RestartAfter:   check.RestartAfter,
-						RestartGrace:   check.RestartGrace,
-						RestartWarning: check.RestartWarning,
+						Name:          check.Name,
+						Type:          check.Type,
+						Command:       check.Command,
+						Args:          check.Args,
+						Path:          check.Path,
+						Protocol:      check.Protocol,
+						PortLabel:     check.PortLabel,
+						Interval:      check.Interval,
+						Timeout:       check.Timeout,
+						InitialStatus: check.InitialStatus,
+						TLSSkipVerify: check.TLSSkipVerify,
+						Header:        check.Header,
+						Method:        check.Method,
+					}
+					if check.CheckRestart != nil {
+						structsTask.Services[i].Checks[j].CheckRestart = &structs.CheckRestart{
+							Limit:     check.CheckRestart.Limit,
+							Grace:     check.CheckRestart.Grace,
+							OnWarning: check.CheckRestart.OnWarning,
+						}
 					}
 				}
 			}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -685,13 +685,6 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 				Tags:        service.Tags,
 				AddressMode: service.AddressMode,
 			}
-			if service.CheckRestart != nil {
-				structsTask.Services[i].CheckRestart = &structs.CheckRestart{
-					Limit:          service.CheckRestart.Limit,
-					Grace:          *service.CheckRestart.Grace,
-					IgnoreWarnings: service.CheckRestart.IgnoreWarnings,
-				}
-			}
 
 			if l := len(service.Checks); l != 0 {
 				structsTask.Services[i].Checks = make([]*structs.ServiceCheck, l)

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -690,19 +690,22 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 				structsTask.Services[i].Checks = make([]*structs.ServiceCheck, l)
 				for j, check := range service.Checks {
 					structsTask.Services[i].Checks[j] = &structs.ServiceCheck{
-						Name:          check.Name,
-						Type:          check.Type,
-						Command:       check.Command,
-						Args:          check.Args,
-						Path:          check.Path,
-						Protocol:      check.Protocol,
-						PortLabel:     check.PortLabel,
-						Interval:      check.Interval,
-						Timeout:       check.Timeout,
-						InitialStatus: check.InitialStatus,
-						TLSSkipVerify: check.TLSSkipVerify,
-						Header:        check.Header,
-						Method:        check.Method,
+						Name:           check.Name,
+						Type:           check.Type,
+						Command:        check.Command,
+						Args:           check.Args,
+						Path:           check.Path,
+						Protocol:       check.Protocol,
+						PortLabel:      check.PortLabel,
+						Interval:       check.Interval,
+						Timeout:        check.Timeout,
+						InitialStatus:  check.InitialStatus,
+						TLSSkipVerify:  check.TLSSkipVerify,
+						Header:         check.Header,
+						Method:         check.Method,
+						RestartAfter:   check.RestartAfter,
+						RestartGrace:   check.RestartGrace,
+						RestartWarning: check.RestartWarning,
 					}
 				}
 			}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -687,9 +687,9 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 			}
 			if service.CheckRestart != nil {
 				structsTask.Services[i].CheckRestart = &structs.CheckRestart{
-					Limit:     service.CheckRestart.Limit,
-					Grace:     service.CheckRestart.Grace,
-					OnWarning: service.CheckRestart.OnWarning,
+					Limit:          service.CheckRestart.Limit,
+					Grace:          service.CheckRestart.Grace,
+					IgnoreWarnings: service.CheckRestart.IgnoreWarnings,
 				}
 			}
 
@@ -713,9 +713,9 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 					}
 					if check.CheckRestart != nil {
 						structsTask.Services[i].Checks[j].CheckRestart = &structs.CheckRestart{
-							Limit:     check.CheckRestart.Limit,
-							Grace:     check.CheckRestart.Grace,
-							OnWarning: check.CheckRestart.OnWarning,
+							Limit:          check.CheckRestart.Limit,
+							Grace:          check.CheckRestart.Grace,
+							IgnoreWarnings: check.CheckRestart.IgnoreWarnings,
 						}
 					}
 				}

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1216,6 +1216,11 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 										Interval:      4 * time.Second,
 										Timeout:       2 * time.Second,
 										InitialStatus: "ok",
+										CheckRestart: &api.CheckRestart{
+											Limit:          3,
+											Grace:          helper.TimeToPtr(10 * time.Second),
+											IgnoreWarnings: true,
+										},
 									},
 								},
 							},
@@ -1406,6 +1411,11 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 										Interval:      4 * time.Second,
 										Timeout:       2 * time.Second,
 										InitialStatus: "ok",
+										CheckRestart: &structs.CheckRestart{
+											Limit:          3,
+											Grace:          10 * time.Second,
+											IgnoreWarnings: true,
+										},
 									},
 								},
 							},

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -1063,7 +1063,7 @@ func parseCheckRestart(cro *ast.ObjectItem) (*api.CheckRestart, error) {
 	valid := []string{
 		"limit",
 		"grace_period",
-		"on_warning",
+		"ignore_warnings",
 	}
 
 	if err := checkHCLKeys(cro.Val, valid); err != nil {

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -965,6 +965,9 @@ func parseChecks(service *api.Service, checkObjs *ast.ObjectList) error {
 			"tls_skip_verify",
 			"header",
 			"method",
+			"restart_grace_period",
+			"restart_on_warning",
+			"restart_after_unhealthy",
 		}
 		if err := checkHCLKeys(co.Val, valid); err != nil {
 			return multierror.Prefix(err, "check ->")

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -130,6 +130,11 @@ func TestParse(t *testing.T) {
 												PortLabel: "admin",
 												Interval:  10 * time.Second,
 												Timeout:   2 * time.Second,
+												CheckRestart: &api.CheckRestart{
+													Limit:          3,
+													Grace:          helper.TimeToPtr(10 * time.Second),
+													IgnoreWarnings: true,
+												},
 											},
 										},
 									},

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -95,6 +95,12 @@ job "binstore-storagelocker" {
           interval = "10s"
           timeout  = "2s"
           port     = "admin"
+
+          check_restart {
+            limit = 3
+            grace_period = "10s"
+            ignore_warnings = true
+          }
         }
       }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3842,7 +3842,7 @@ type TaskEvent struct {
 }
 
 func (te *TaskEvent) GoString() string {
-	return fmt.Sprintf("%v at %v", te.Type, te.Time)
+	return fmt.Sprintf("%v - %v", te.Time, te.Type)
 }
 
 // SetMessage sets the message of TaskEvent

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2942,6 +2942,12 @@ func (sc *ServiceCheck) RequiresPort() bool {
 	}
 }
 
+// Watched returns true if this check should be watched and trigger a restart
+// on failure.
+func (sc *ServiceCheck) Watched() bool {
+	return sc.CheckRestart != nil && sc.CheckRestart.Limit > 0
+}
+
 // Hash all ServiceCheck fields and the check's corresponding service ID to
 // create an identifier. The identifier is not guaranteed to be unique as if
 // the PortLabel is blank, the Service's PortLabel will be used after Hash is

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2760,9 +2760,9 @@ func (tg *TaskGroup) GoString() string {
 // CheckRestart describes if and when a task should be restarted based on
 // failing health checks.
 type CheckRestart struct {
-	Limit     int           // Restart task after this many unhealthy intervals
-	Grace     time.Duration // Grace time to give tasks after starting to get healthy
-	OnWarning bool          // If true treat checks in `warning` as unhealthy
+	Limit          int           // Restart task after this many unhealthy intervals
+	Grace          time.Duration // Grace time to give tasks after starting to get healthy
+	IgnoreWarnings bool          // If true treat checks in `warning` as passing
 }
 
 func (c *CheckRestart) Copy() *CheckRestart {
@@ -2798,8 +2798,8 @@ func (c *CheckRestart) Merge(o *CheckRestart) *CheckRestart {
 		nc.Grace = o.Grace
 	}
 
-	if !nc.OnWarning {
-		nc.OnWarning = o.OnWarning
+	if nc.IgnoreWarnings {
+		nc.IgnoreWarnings = o.IgnoreWarnings
 	}
 
 	return nc

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2912,9 +2912,9 @@ func (sc *ServiceCheck) RequiresPort() bool {
 	}
 }
 
-// Watched returns true if this check should be watched and trigger a restart
+// TriggersRestarts returns true if this check should be watched and trigger a restart
 // on failure.
-func (sc *ServiceCheck) Watched() bool {
+func (sc *ServiceCheck) TriggersRestarts() bool {
 	return sc.CheckRestart != nil && sc.CheckRestart.Limit > 0
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2775,19 +2775,22 @@ const (
 // The ServiceCheck data model represents the consul health check that
 // Nomad registers for a Task
 type ServiceCheck struct {
-	Name          string              // Name of the check, defaults to id
-	Type          string              // Type of the check - tcp, http, docker and script
-	Command       string              // Command is the command to run for script checks
-	Args          []string            // Args is a list of argumes for script checks
-	Path          string              // path of the health check url for http type check
-	Protocol      string              // Protocol to use if check is http, defaults to http
-	PortLabel     string              // The port to use for tcp/http checks
-	Interval      time.Duration       // Interval of the check
-	Timeout       time.Duration       // Timeout of the response from the check before consul fails the check
-	InitialStatus string              // Initial status of the check
-	TLSSkipVerify bool                // Skip TLS verification when Protocol=https
-	Method        string              // HTTP Method to use (GET by default)
-	Header        map[string][]string // HTTP Headers for Consul to set when making HTTP checks
+	Name           string              // Name of the check, defaults to id
+	Type           string              // Type of the check - tcp, http, docker and script
+	Command        string              // Command is the command to run for script checks
+	Args           []string            // Args is a list of argumes for script checks
+	Path           string              // path of the health check url for http type check
+	Protocol       string              // Protocol to use if check is http, defaults to http
+	PortLabel      string              // The port to use for tcp/http checks
+	Interval       time.Duration       // Interval of the check
+	Timeout        time.Duration       // Timeout of the response from the check before consul fails the check
+	InitialStatus  string              // Initial status of the check
+	TLSSkipVerify  bool                // Skip TLS verification when Protocol=https
+	Method         string              // HTTP Method to use (GET by default)
+	Header         map[string][]string // HTTP Headers for Consul to set when making HTTP checks
+	RestartAfter   int                 // Restart task after this many unhealthy intervals
+	RestartGrace   time.Duration       // Grace time to give tasks after starting to get healthy
+	RestartWarning bool                // If true treat checks in `warning` as unhealthy
 }
 
 func (sc *ServiceCheck) Copy() *ServiceCheck {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2780,15 +2780,16 @@ func (c *CheckRestart) Validate() error {
 		return nil
 	}
 
+	var mErr multierror.Error
 	if c.Limit < 0 {
-		return fmt.Errorf("limit must be greater than or equal to 0 but found %d", c.Limit)
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("limit must be greater than or equal to 0 but found %d", c.Limit))
 	}
 
 	if c.Grace < 0 {
-		return fmt.Errorf("grace period must be greater than or equal to 0 but found %d", c.Grace)
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("grace period must be greater than or equal to 0 but found %d", c.Grace))
 	}
 
-	return nil
+	return mErr.ErrorOrNil()
 }
 
 const (

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1154,6 +1154,24 @@ func TestTask_Validate_Service_Check(t *testing.T) {
 	}
 }
 
+func TestTask_Validate_Service_Check_CheckRestart(t *testing.T) {
+	invalidCheckRestart := &CheckRestart{
+		Limit: -1,
+		Grace: -1,
+	}
+
+	err := invalidCheckRestart.Validate()
+	assert.NotNil(t, err, "invalidateCheckRestart.Validate()")
+	assert.Len(t, err.(*multierror.Error).Errors, 2)
+
+	validCheckRestart := &CheckRestart{}
+	assert.Nil(t, validCheckRestart.Validate())
+
+	validCheckRestart.Limit = 1
+	validCheckRestart.Grace = 1
+	assert.Nil(t, validCheckRestart.Validate())
+}
+
 func TestTask_Validate_LogConfig(t *testing.T) {
 	task := &Task{
 		LogConfig: DefaultLogConfig(),

--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -66,7 +66,12 @@ Below is the JSON representation of the job outputed by `$ nomad init`:
                         "Interval": 10000000000,
                         "Timeout": 2000000000,
                         "InitialStatus": "",
-                        "TLSSkipVerify": false
+                        "TLSSkipVerify": false,
+                        "CheckRestart": {
+                            "Limit": 3,
+                            "Grace": "30s",
+                            "IgnoreWarnings": false
+                        }
                     }]
                 }],
                 "Resources": {
@@ -376,6 +381,20 @@ The `Task` object supports the following keys:
 
 	 - `TLSSkipVerify`: If true, Consul will not attempt to verify the
 	   certificate when performing HTTPS checks. Requires Consul >= 0.7.2.
+
+	   - `CheckRestart`: `CheckRestart` is an object which enables
+	     restarting of tasks based upon Consul health checks.
+
+	     - `Limit`: The number of unhealthy checks allowed before the
+	       service is restarted. Defaults to `0` which disables
+               health-based restarts.
+
+	     - `Grace`: The duration to wait after a task starts or restarts
+	       before counting unhealthy checks count against the limit.
+               Defaults to "1s".
+
+	     - `IgnoreWarnings`: Treat checks that are warning as passing.
+	       Defaults to false which means warnings are considered unhealthy.
 
 - `ShutdownDelay` - Specifies the duration to wait when killing a task between
   removing it from Consul and sending it a shutdown signal. Ideally services

--- a/website/source/docs/job-specification/check_restart.html.md
+++ b/website/source/docs/job-specification/check_restart.html.md
@@ -1,0 +1,151 @@
+---
+layout: "docs"
+page_title: "check_restart Stanza - Job Specification"
+sidebar_current: "docs-job-specification-check_restart"
+description: |-
+  The "check_restart" stanza instructs Nomad when to restart tasks with
+  unhealthy service checks.
+---
+
+# `check_restart` Stanza
+
+<table class="table table-bordered table-striped">
+  <tr>
+    <th width="120">Placement</th>
+    <td>
+      <code>job -> group -> task -> service -> **check_restart**</code>
+    </td>
+  </tr>
+  <tr>
+    <th width="120">Placement</th>
+    <td>
+      <code>job -> group -> task -> service -> check -> **check_restart**</code>
+    </td>
+  </tr>
+</table>
+
+As of Nomad 0.7 the `check_restart` stanza instructs Nomad when to restart
+tasks with unhealthy service checks.  When a health check in Consul has been
+unhealthy for the `limit` specified in a `check_restart` stanza, it is
+restarted according to the task group's [`restart` policy][restart_stanza]. The
+`check_restart` settings apply to [`check`s][check_stanza], but may also be
+placed on [`service`s][service_stanza] to apply to all checks on a service.
+
+```hcl
+job "mysql" {
+  group "mysqld" {
+
+    restart {
+      attempts = 3
+      delay    = "10s"
+      interval = "10m"
+      mode     = "fail"
+    }
+
+    task "server" {
+      service {
+        tags = ["leader", "mysql"]
+
+        port = "db"
+
+        check {
+          type     = "tcp"
+          port     = "db"
+          interval = "10s"
+          timeout  = "2s"
+        }
+
+        check {
+          type     = "script"
+          name     = "check_table"
+          command  = "/usr/local/bin/check_mysql_table_status"
+          args     = ["--verbose"]
+          interval = "60s"
+          timeout  = "5s"
+
+          check_restart {
+            limit = 3
+            grace = "90s"
+
+            ignore_warnings = false
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- `limit` `(int: 0)` - Restart task when a health check has failed `limit`
+  times.  For example 1 causes a restart on the first failure. The default,
+  `0`, disables healtcheck based restarts. Failures must be consecutive. A
+  single passing check will reset the count, so flapping services may not be
+  restarted.
+
+- `grace` `(string: "1s")` - Duration to wait after a task starts or restarts
+  before checking its health.
+
+- `ignore_warnings` `(bool: false)` - By default checks with both `critical`
+  and `warning` statuses are considered unhealthy. Setting `ignore_warnings =
+  true` treats a `warning` status like `passing` and will not trigger a restart.
+
+## Example Behavior
+
+Using the example `mysql` above would have the following behavior:
+
+```hcl
+check_restart {
+  # ...
+  grace = "90s"
+  # ...
+}
+```
+
+When the `server` task first starts and is registered in Consul, its health
+will not be checked for 90 seconds. This gives the server time to startup.
+
+```hcl
+check_restart {
+  limit = 3
+  # ...
+}
+```
+
+After the grace period if the script check fails, it has 180 seconds (`60s
+interval * 3 limit`) to pass before a restart is triggered. Once a restart is
+triggered the task group's [`restart` policy][restart_stanza] takes control:
+
+```hcl
+restart {
+  # ...
+  delay    = "10s"
+  # ...
+}
+```
+
+The [`restart` stanza][restart_stanza] controls the restart behavior of the
+task. In this case it will wait 10 seconds before restarting. Note that even if
+the check passes in this time the restart will still occur.
+
+Once the task restarts Nomad waits the `grace` period again before starting to
+check the task's health.
+
+
+```hcl
+restart {
+  attempts = 3
+  # ...
+  interval = "10m"
+  mode     = "fail"
+}
+```
+
+If the check continues to fail, the task will be restarted up to `attempts`
+times within an `interval`. If the `restart` attempts are reached within the
+`limit` then the `mode` controls the behavior. In this case the task would fail
+and not be restarted again. See the [`restart` stanza][restart_stanza] for
+details.
+
+[check_stanza]:  /docs/job-specification/service.html#check-parameters "check stanza"
+[restart_stanza]: /docs/job-specification/restart.html "restart stanza"
+[service_stanza]: /docs/job-specification/service.html "service stanza"

--- a/website/source/docs/job-specification/check_restart.html.md
+++ b/website/source/docs/job-specification/check_restart.html.md
@@ -30,8 +30,8 @@ unhealthy for the `limit` specified in a `check_restart` stanza, it is
 restarted according to the task group's [`restart` policy][restart_stanza]. The
 `check_restart` settings apply to [`check`s][check_stanza], but may also be
 placed on [`service`s][service_stanza] to apply to all checks on a service.
-`check_restart` settings on `service` will only overwrite unset `check_restart`
-settings on `checks.`
+If `check_restart` is set on both the check and service, the stanza's are
+merged with the check values taking precedence.
 
 ```hcl
 job "mysql" {

--- a/website/source/docs/job-specification/check_restart.html.md
+++ b/website/source/docs/job-specification/check_restart.html.md
@@ -30,6 +30,8 @@ unhealthy for the `limit` specified in a `check_restart` stanza, it is
 restarted according to the task group's [`restart` policy][restart_stanza]. The
 `check_restart` settings apply to [`check`s][check_stanza], but may also be
 placed on [`service`s][service_stanza] to apply to all checks on a service.
+`check_restart` settings on `service` will only overwrite unset `check_restart`
+settings on `checks.`
 
 ```hcl
 job "mysql" {
@@ -66,7 +68,6 @@ job "mysql" {
           check_restart {
             limit = 3
             grace = "90s"
-
             ignore_warnings = false
           }
         }
@@ -78,7 +79,7 @@ job "mysql" {
 
 - `limit` `(int: 0)` - Restart task when a health check has failed `limit`
   times.  For example 1 causes a restart on the first failure. The default,
-  `0`, disables healtcheck based restarts. Failures must be consecutive. A
+  `0`, disables health check based restarts. Failures must be consecutive. A
   single passing check will reset the count, so flapping services may not be
   restarted.
 
@@ -124,8 +125,8 @@ restart {
 ```
 
 The [`restart` stanza][restart_stanza] controls the restart behavior of the
-task. In this case it will wait 10 seconds before restarting. Note that even if
-the check passes in this time the restart will still occur.
+task. In this case it will stop the task and then wait 10 seconds before
+starting it again.
 
 Once the task restarts Nomad waits the `grace` period again before starting to
 check the task's health.

--- a/website/source/docs/job-specification/service.html.md
+++ b/website/source/docs/job-specification/service.html.md
@@ -117,6 +117,8 @@ scripts.
 - `args` `(array<string>: [])` - Specifies additional arguments to the
   `command`. This only applies to script-based health checks.
 
+- `check_restart` - See [`check_restart` stanza][check_restart_stanza].
+
 - `command` `(string: <varies>)` - Specifies the command to run for performing
   the health check. The script must exit: 0 for passing, 1 for warning, or any
   other value for a failing health check. This is required for script-based
@@ -167,72 +169,6 @@ scripts.
 
 - `tls_skip_verify` `(bool: false)` - Skip verifying TLS certificates for HTTPS
   checks. Requires Consul >= 0.7.2.
-
-#### `check_restart` Stanza
-
-As of Nomad 0.7 `check` stanzas may include a `check_restart` stanza to restart
-tasks with unhealthy checks. Restarts use the parameters from the
-[`restart`][restart_stanza] stanza, so if a task group has the default `15s`
-delay, tasks won't be restarted for an extra 15 seconds after the
-`check_restart` block considers it failed. `check_restart` stanzas have the
-follow parameters:
-
-- `limit` `(int: 0)` - Restart task after `limit` failing health checks. For
-  example 1 causes a restart on the first failure. The default, `0`, disables
-  healtcheck based restarts. Failures must be consecutive. A single passing
-  check will reset the count, so flapping services may not be restarted.
-
-- `grace` `(string: "1s")` - Duration to wait after a task starts or restarts
-  before checking its health. On restarts the `delay` and max jitter is added
-  to the grace period to prevent checking a task's health before it has
-  restarted.
-
-- `ignore_warnings` `(bool: false)` - By default checks with both `critical`
-  and `warning` statuses are considered unhealthy. Setting `ignore_warnings =
-  true` treats a `warning` status like `passing` and will not trigger a restart.
-
-For example:
-
-```hcl
-restart {
-  delay = "8s"
-}
-
-task "mysqld" {
-  service {
-    # ...
-    check {
-      type     = "script"
-      name     = "check_table"
-      command  = "/usr/local/bin/check_mysql_table_status"
-      args     = ["--verbose"]
-      interval = "20s"
-      timeout  = "5s"
-  
-      check_restart {
-        # Restart the task after 3 consecutive failed checks (180s)
-        limit = 3
-  
-        # Ignore failed checks for 90s after a service starts or restarts
-        grace = "90s"
-  
-        # Treat warnings as unhealthy (the default)
-        ignore_warnings = false
-      }
-    }
-  }
-}
-```
-
-In this example the `mysqld` task has `90s` from startup to begin passing
-healthchecks. After the grace period if `mysqld` would remain unhealthy for
-`60s` (as determined by `limit * interval`) it would be restarted after `8s`
-(as determined by the `restart.delay`). Nomad would then wait `100s` (as
-determined by `grace + delay + (delay * 0.25)`) before checking `mysqld`'s
-health again.
-
-~> `check_restart` stanzas may also be placed in `service` stanzas to apply the
-   same restart logic to multiple checks.
 
 #### `header` Stanza
 
@@ -388,6 +324,7 @@ service {
 [qemu driver][qemu] since the Nomad client does not have access to the file
 system of a task for that driver.</small>
 
+[check_restart_stanza]: /docs/job-specification/check_restart.html "check_restart stanza"
 [service-discovery]: /docs/service-discovery/index.html "Nomad Service Discovery"
 [interpolation]: /docs/runtime/interpolation.html "Nomad Runtime Interpolation"
 [network]: /docs/job-specification/network.html "Nomad network Job Specification"

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -26,6 +26,9 @@
           <li<%= sidebar_current("docs-job-specification-artifact")%>>
             <a href="/docs/job-specification/artifact.html">artifact</a>
           </li>
+          <li<%= sidebar_current("docs-job-specification-check_restart")%>>
+            <a href="/docs/job-specification/check_restart.html">check_restart</a>
+          </li>
           <li<%= sidebar_current("docs-job-specification-constraint")%>>
             <a href="/docs/job-specification/constraint.html">constraint</a>
           </li>


### PR DESCRIPTION
Fixes #876 

Unhealthy checks can now restart tasks. See docs in PR for intended behavior.

- [x] Code
- [x] Docs
- [x] Changelog
- [x] *Tests*
