### PR TITLE
Fix exact job match when prefix of other job

### DIFF
--- a/command/status.go
+++ b/command/status.go
@@ -114,7 +114,7 @@ func (c *StatusCommand) Run(args []string) int {
 
 		// Only a single result should return, as this is a match against a full id
 		if matchCount > 1 || len(vers) > 1 {
-			c.outputMultipleMatches(id, res.Matches)
+			c.logMultiMatchError(id, res.Matches)
 			return 1
 		}
 	}
@@ -139,7 +139,9 @@ func (c *StatusCommand) Run(args []string) int {
 	return cmd.Run(argsCopy)
 }
 
-func (c *StatusCommand) outputMultipleMatches(id string, matches map[contexts.Context][]string) {
+// logMultiMatchError is used to log an error message when multiple matches are
+// found. The error message logged displays the matched IDs per context.
+func (c *StatusCommand) logMultiMatchError(id string, matches map[contexts.Context][]string) {
 	c.Ui.Error(fmt.Sprintf("Multiple matches found for id %q", id))
 	for ctx, vers := range matches {
 		if len(vers) == 0 {

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -91,7 +91,10 @@ func roundUUIDDownIfOdd(prefix string, context structs.Context) string {
 		return prefix
 	}
 
-	l := len(prefix)
+	// We ignore the count of hyphens when calculating if the prefix is even:
+	// E.g "e3671fa4-21"
+	numHyphens := strings.Count(prefix, "-")
+	l := len(prefix) - numHyphens
 	if l%2 == 0 {
 		return prefix
 	}

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -55,6 +55,48 @@ func TestSearch_PrefixSearch_Job(t *testing.T) {
 	assert.Equal(uint64(jobIndex), resp.Index)
 }
 
+func TestSearch_PrefixSearch_All_JobWithHyphen(t *testing.T) {
+	assert := assert.New(t)
+	prefix := "example-test"
+
+	t.Parallel()
+	s := testServer(t, func(c *Config) {
+		c.NumSchedulers = 0
+	})
+
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	// Register a job and an allocation
+	jobID := registerAndVerifyJob(s, t, prefix, 0)
+	alloc := mock.Alloc()
+	alloc.JobID = jobID
+	summary := mock.JobSummary(alloc.JobID)
+	state := s.fsm.State()
+
+	if err := state.UpsertJobSummary(999, summary); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	req := &structs.SearchRequest{
+		Prefix:  "example-",
+		Context: structs.All,
+	}
+
+	var resp structs.SearchResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Search.PrefixSearch", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	assert.Equal(1, len(resp.Matches[structs.Jobs]))
+	assert.Equal(jobID, resp.Matches[structs.Jobs][0])
+	assert.EqualValues(jobIndex, resp.Index)
+}
+
 // truncate should limit results to 20
 func TestSearch_PrefixSearch_Truncate(t *testing.T) {
 	assert := assert.New(t)
@@ -196,6 +238,59 @@ func TestSearch_PrefixSearch_Allocation(t *testing.T) {
 	assert.Equal(resp.Truncations[structs.Allocs], false)
 
 	assert.Equal(uint64(90), resp.Index)
+}
+
+func TestSearch_PrefixSearch_All_UUID_EvenPrefix(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+	s := testServer(t, func(c *Config) {
+		c.NumSchedulers = 0
+	})
+
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	alloc := mock.Alloc()
+	summary := mock.JobSummary(alloc.JobID)
+	state := s.fsm.State()
+
+	if err := state.UpsertJobSummary(999, summary); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	node := mock.Node()
+	if err := state.UpsertNode(1001, node); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	eval1 := mock.Eval()
+	eval1.ID = node.ID
+	if err := state.UpsertEvals(1002, []*structs.Evaluation{eval1}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	prefix := alloc.ID[:13]
+	t.Log(prefix)
+
+	req := &structs.SearchRequest{
+		Prefix:  prefix,
+		Context: structs.All,
+	}
+
+	var resp structs.SearchResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Search.PrefixSearch", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	assert.Equal(1, len(resp.Matches[structs.Allocs]))
+	assert.Equal(alloc.ID, resp.Matches[structs.Allocs][0])
+	assert.Equal(resp.Truncations[structs.Allocs], false)
+
+	assert.EqualValues(1002, resp.Index)
 }
 
 func TestSearch_PrefixSearch_Node(t *testing.T) {


### PR DESCRIPTION
This PR does the following:
* When given an exact match, prefix matching is short circuited allowing
querying of a job that is a prefix of another.
* Fixes an issue in which even length UUIDs with hyphens would fail prefix
searching. The other status commands still need to be updated.

Fixes https://github.com/hashicorp/nomad/issues/3117
Fixes https://github.com/hashicorp/nomad/issues/3118