### PR TITLE
fix logging re-init

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -924,7 +924,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 
 	memLimit := int64(task.Resources.MemoryMB) * 1024 * 1024
 
-	if len(driverConfig.Logging) == 0 {
+	if len(driverConfig.Logging) == 0 || driverConfig.Logging[0].Type == "syslog" {
 		if runtime.GOOS != "darwin" {
 			d.logger.Printf("[DEBUG] driver.docker: Setting default logging options to syslog and %s", syslogAddr)
 			driverConfig.Logging = []DockerLoggingOpts{


### PR DESCRIPTION
The check in [L927](https://github.com/clinta/nomad/blob/cfffce07a002ed93d22cdd31b50bcbb9b377f7c7/client/driver/docker.go#L927) should be the same as the check in [L612](https://github.com/clinta/nomad/blob/cfffce07a002ed93d22cdd31b50bcbb9b377f7c7/client/driver/docker.go#L612).

Without this fix a retried task will fail because the logging config will point to an old socket from the previous attempt.