### PR TITLE
Allow distinct_host to have L/RTarget set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ BUG FIXES:
    another job [GH-3120]
  * cli: Fix setting of TLSServerName for node API Client. This fixes an issue of
    contacting nodes that are using TLS [GH-3127]
+ * jobspec: Allow distinct_host constraint to have L/RTarget set [GH-3136]
 
 ## 0.6.2 (August 28, 2017)
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3973,12 +3973,6 @@ func (c *Constraint) Validate() error {
 	switch c.Operand {
 	case ConstraintDistinctHosts:
 		requireLtarget = false
-		if c.RTarget != "" {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("Distinct hosts constraint doesn't allow RTarget. Got %q", c.RTarget))
-		}
-		if c.LTarget != "" {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("Distinct hosts constraint doesn't allow LTarget. Got %q", c.LTarget))
-		}
 	case ConstraintSetContains:
 		if c.RTarget == "" {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Set contains constraint requires an RTarget"))

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1353,14 +1353,10 @@ func TestConstraint_Validate(t *testing.T) {
 
 	// Perform distinct_hosts validation
 	c.Operand = ConstraintDistinctHosts
-	c.RTarget = "foo"
-	err = c.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "doesn't allow RTarget") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[1].Error(), "doesn't allow LTarget") {
-		t.Fatalf("err: %s", err)
+	c.LTarget = ""
+	c.RTarget = ""
+	if err := c.Validate(); err != nil {
+		t.Fatalf("expected valid constraint: %v", err)
 	}
 
 	// Perform set_contains validation


### PR DESCRIPTION
This PR removes validation that could break job backwards compatibility.
The targets are ignored so there is no side effects.

Fixes https://github.com/hashicorp/nomad/issues/3130