### PR TITLE
Search handles prefix longer than allowed UUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.3 (Unreleased)
 
 BUG FIXES:
+ * api: Search handles prefix longer than allowed UUIDs [GH-3138]
  * api: Search endpoint handles even UUID prefixes with hyphens [GH-3120]
  * cli: All status commands handle even UUID prefixes with hyphens [GH-3122]
  * cli: Fix autocompletion of paths that include directories on zsh [GH-3129] 

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -125,9 +125,13 @@ func (s *Search) PrefixSearch(args *structs.SearchRequest,
 				iter, err := getResourceIter(ctx, roundUUIDDownIfOdd(args.Prefix, args.Context), ws, state)
 
 				if err != nil {
+					e := err.Error()
+					switch {
 					// Searching other contexts with job names raises an error, which in
 					// this case we want to ignore.
-					if !strings.Contains(err.Error(), "Invalid UUID: encoding/hex") {
+					case strings.Contains(e, "Invalid UUID: encoding/hex"):
+					case strings.Contains(e, "UUID have 36 characters"):
+					default:
 						return err
 					}
 				} else {


### PR DESCRIPTION
This PR fixes an issue in which the Search endpoint would error if the
prefix was longer than the allowed 36 characters of a UUID.

Fixes https://github.com/hashicorp/nomad/issues/3134