### PR TITLE
Integration test for round tripping a job.

### DIFF
--- a/command/integration_test.go
+++ b/command/integration_test.go
@@ -1,10 +1,16 @@
-package command_test
+package command
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
+
+	"github.com/hashicorp/nomad/api"
 )
 
 func TestIntegration_Command_NomadInit(t *testing.T) {
@@ -29,6 +35,62 @@ func TestIntegration_Command_NomadInit(t *testing.T) {
 		cmd.Env = []string{`NOMAD_ADDR=http://127.0.0.1:0`}
 		if err := cmd.Run(); err != nil {
 			t.Fatalf("error validating example.nomad: %v", err)
+		}
+	}
+}
+
+func TestIntegration_Command_RoundTripJob(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := ioutil.TempDir("", "nomadtest-rootsecretdir")
+	if err != nil {
+		t.Fatalf("unable to create tempdir for test: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Start in dev mode so we get a node registration
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	{
+		cmd := exec.Command("nomad", "init")
+		cmd.Dir = tmpDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("error running init: %v", err)
+		}
+	}
+
+	{
+		cmd := exec.Command("nomad", "run", "example.nomad")
+		cmd.Dir = tmpDir
+		cmd.Env = []string{fmt.Sprintf("NOMAD_ADDR=%s", url)}
+		err := cmd.Run()
+		if err != nil && !strings.Contains(err.Error(), "exit status 2") {
+			t.Fatalf("error running example.nomad: %v", err)
+		}
+	}
+
+	{
+		cmd := exec.Command("nomad", "inspect", "example")
+		cmd.Dir = tmpDir
+		cmd.Env = []string{fmt.Sprintf("NOMAD_ADDR=%s", url)}
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("error validating example.nomad: %v", err)
+		}
+
+		var req api.JobRegisterRequest
+		dec := json.NewDecoder(bytes.NewReader(out))
+		if err := dec.Decode(&req); err != nil {
+			t.Fatalf("failed to demarshal into register request: %v", err)
+		}
+
+		var resp api.JobRegisterResponse
+		if _, err := client.Raw().Write("/v1/jobs", req, &resp, nil); err != nil {
+			t.Fatalf("failed to put job: %v", err)
+		}
+
+		if resp.EvalID == "" {
+			t.Fatalf("didn't create an eval")
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a test that does:
1) nomad init
2) nomad run example.nomad
3) nomad inspect example
4) Equivalent of `curl -XPUT -d @job.json nomad/v1/job/example