### PR TITLE
Always purge stopped containers

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1275,10 +1275,11 @@ CREATE:
 		containerName := "/" + config.Name
 		d.logger.Printf("[DEBUG] driver.docker: searching for container name %q to purge", containerName)
 		for _, shimContainer := range containers {
-			d.logger.Printf("[DEBUG] driver.docker: listed container %+v", container)
+			d.logger.Printf("[DEBUG] driver.docker: listed container %+v", shimContainer.Names)
 			found := false
 			for _, name := range shimContainer.Names {
 				if name == containerName {
+					d.logger.Printf("[DEBUG] driver.docker: Found container %v: %v", containerName, shimContainer.ID)
 					found = true
 					break
 				}
@@ -1300,7 +1301,7 @@ CREATE:
 				// See #2802
 				return nil, structs.NewRecoverableError(err, true)
 			}
-			if container != nil && (container.State.Running || container.State.FinishedAt.IsZero()) {
+			if container != nil && container.State.Running {
 				return container, nil
 			}
 


### PR DESCRIPTION
Old containers should always be purged, even if they exited successfully. Because the logging socket is closed when the container exits, if the same container is restarted, instead of a new one being created it is unable to start because it cannot connect to the old logging socket.