### PR TITLE
making the storage driver periodic

### DIFF
--- a/client/fingerprint/storage.go
+++ b/client/fingerprint/storage.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -15,7 +16,6 @@ const bytesPerMegabyte = 1024 * 1024
 // StorageFingerprint is used to measure the amount of storage free for
 // applications that the Nomad agent will run on this machine.
 type StorageFingerprint struct {
-	StaticFingerprinter
 	logger *log.Logger
 }
 
@@ -56,4 +56,8 @@ func (f *StorageFingerprint) Fingerprint(cfg *config.Config, node *structs.Node)
 	node.Resources.DiskMB = int(free / bytesPerMegabyte)
 
 	return true, nil
+}
+
+func (f *StorageFingerprint) Periodic() (bool, time.Duration) {
+	return true, 15 * time.Second
 }


### PR DESCRIPTION
This makes the storage driver fingerprint periodically to report the correct amount of available disk space to the scheduler.

Currently the fingerprinter reports available disk space only when the agent starts which isn't sufficient since we don't account for the container root-fs and the container images which allocations use and over time if the actual disk space is exhausted before other resources are exhausted the scheduler will think it can allocate more containers even though there is no disk space. 

Also when drivers leaks resources(like Docker) it's essential that the scheduler is aware of that.