### PR TITLE
Fix repo name passed to docker credential helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ BUG FIXES:
  * driver/docker: Fix issue in which mounts could parse incorrectly [GH-3163]
  * driver/docker: Fix issue where potentially incorrect syslog server address is
    used [GH-3135]
+ * driver/docker: Fix server url passed to credential helpers and properly
+   capture error output [GH-3165]
  * jobspec: Allow distinct_host constraint to have L/RTarget set [GH-3136]
 
 ## 0.6.2 (August 28, 2017)

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1795,15 +1795,21 @@ func authFromHelper(helperName string) authBackend {
 		}
 		helper := dockerAuthHelperPrefix + helperName
 		cmd := exec.Command(helper, "get")
+
+		// Ensure that the HTTPs prefix exists
+		if !strings.HasPrefix(repo, "https://") {
+			repo = fmt.Sprintf("https://%s", repo)
+		}
+
 		cmd.Stdin = strings.NewReader(repo)
 
 		output, err := cmd.Output()
 		if err != nil {
-			switch e := err.(type) {
+			switch err.(type) {
 			default:
 				return nil, err
 			case *exec.ExitError:
-				return nil, fmt.Errorf("%s failed with stderr: %s", helper, string(e.Stderr))
+				return nil, fmt.Errorf("%s with input %q failed with stderr: %s", helper, repo, output)
 			}
 		}
 


### PR DESCRIPTION
This PR fixes the server url passed to docker credential helpers and
fixes stderr capture.

Fixes https://github.com/hashicorp/nomad/issues/2957