### PR TITLE
[cli] Fix panic while running latest deployment command witch -latest flag

### DIFF
--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -169,6 +169,9 @@ func getDeployment(client *api.Deployments, dID string) (match *api.Deployment, 
 }
 
 func formatDeployment(d *api.Deployment, uuidLength int) string {
+	if d == nil {
+		return "No deployment found"
+	}
 	// Format the high-level elements
 	high := []string{
 		fmt.Sprintf("ID|%s", limit(d.ID, uuidLength)),


### PR DESCRIPTION
Trying to check latest deployment of a job which has no deployments (no update stanza), nomad fails witch this error

```    
$ nomad job deployments -latest nomad-exporter

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x10c771a]

goroutine 1 [running]:
github.com/hashicorp/nomad/command.formatDeployment(0x0, 0x8, 0xe, 0x0)
	/opt/gopath/src/github.com/hashicorp/nomad/command/deployment_status.go:169 +0x3a
github.com/hashicorp/nomad/command.(*JobDeploymentsCommand).Run(0xc420449880, 0xc420074080, 0x2, 0x2, 0xc4201655f0)
	/opt/gopath/src/github.com/hashicorp/nomad/command/job_deployments.go:138 +0x7b6
github.com/hashicorp/nomad/vendor/github.com/mitchellh/cli.(*CLI).Run(0xc4203eaa20, 0xc4203eaa20, 0x2a, 0x14c84a8)
	/opt/gopath/src/github.com/hashicorp/nomad/vendor/github.com/mitchellh/cli/cli.go:242 +0x229
main.RunCustom(0xc420074060, 0x4, 0x4, 0xc42040f740, 0x0)
	/opt/gopath/src/github.com/hashicorp/nomad/main.go:54 +0xf2d
main.Run(0xc420074060, 0x4, 0x4, 0xc4200001a0)
	/opt/gopath/src/github.com/hashicorp/nomad/main.go:24 +0x56
main.main()
	/opt/gopath/src/github.com/hashicorp/nomad/main.go:20 +0x64
```