### PR TITLE
Fix invalid CPU stats on Windows

### DIFF
--- a/client/stats/cpu_test.go
+++ b/client/stats/cpu_test.go
@@ -1,8 +1,14 @@
 package stats
 
 import (
+	"log"
+	"math"
+	"os"
 	"testing"
 	"time"
+
+	shelpers "github.com/hashicorp/nomad/helper/stats"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCpuStatsPercent(t *testing.T) {
@@ -13,5 +19,41 @@ func TestCpuStatsPercent(t *testing.T) {
 	expectedPercent := 98.00
 	if percent < expectedPercent && percent > (expectedPercent+1.00) {
 		t.Fatalf("expected: %v, actual: %v", expectedPercent, percent)
+	}
+}
+
+func TestHostStats_CPU(t *testing.T) {
+	assert := assert.New(t)
+	assert.Nil(shelpers.Init())
+
+	logger := log.New(os.Stderr, "", log.LstdFlags|log.Lmicroseconds)
+	cwd, err := os.Getwd()
+	assert.Nil(err)
+	hs := NewHostStatsCollector(logger, cwd)
+
+	// Collect twice so we can calculate percents we need to generate some work
+	// so that the cpu values change
+	assert.Nil(hs.Collect())
+	total := 0
+	for i := 1; i < 1000000000; i++ {
+		total *= i
+		total = total % i
+	}
+	assert.Nil(hs.Collect())
+	stats := hs.Stats()
+
+	assert.NotZero(stats.CPUTicksConsumed)
+	assert.NotZero(len(stats.CPU))
+
+	for _, cpu := range stats.CPU {
+		assert.False(math.IsNaN(cpu.Idle))
+		assert.False(math.IsNaN(cpu.Total))
+		assert.False(math.IsNaN(cpu.System))
+		assert.False(math.IsNaN(cpu.User))
+
+		assert.False(math.IsInf(cpu.Idle, 0))
+		assert.False(math.IsInf(cpu.Total, 0))
+		assert.False(math.IsInf(cpu.System, 0))
+		assert.False(math.IsInf(cpu.User, 0))
 	}
 }

--- a/client/stats/cpu_unix.go
+++ b/client/stats/cpu_unix.go
@@ -1,0 +1,36 @@
+// +build !windows
+
+package stats
+
+import (
+	shelpers "github.com/hashicorp/nomad/helper/stats"
+	"github.com/shirou/gopsutil/cpu"
+)
+
+func (h *HostStatsCollector) collectCPUStats() (cpus []*CPUStats, totalTicks float64, err error) {
+
+	ticksConsumed := 0.0
+	cpuStats, err := cpu.Times(true)
+	if err != nil {
+		return nil, 0.0, err
+	}
+	cs := make([]*CPUStats, len(cpuStats))
+	for idx, cpuStat := range cpuStats {
+		percentCalculator, ok := h.statsCalculator[cpuStat.CPU]
+		if !ok {
+			percentCalculator = NewHostCpuStatsCalculator()
+			h.statsCalculator[cpuStat.CPU] = percentCalculator
+		}
+		idle, user, system, total := percentCalculator.Calculate(cpuStat)
+		cs[idx] = &CPUStats{
+			CPU:    cpuStat.CPU,
+			User:   user,
+			System: system,
+			Idle:   idle,
+			Total:  total,
+		}
+		ticksConsumed += (total / 100.0) * (shelpers.TotalTicksAvailable() / float64(len(cpuStats)))
+	}
+
+	return cs, ticksConsumed, nil
+}

--- a/client/stats/cpu_windows.go
+++ b/client/stats/cpu_windows.go
@@ -1,0 +1,53 @@
+// +build windows
+
+package stats
+
+import (
+	"fmt"
+
+	shelpers "github.com/hashicorp/nomad/helper/stats"
+	"github.com/shirou/gopsutil/cpu"
+)
+
+func (h *HostStatsCollector) collectCPUStats() (cpus []*CPUStats, totalTicks float64, err error) {
+	// Get the per cpu stats
+	cpuStats, err := cpu.Times(true)
+	if err != nil {
+		return nil, 0.0, err
+	}
+
+	cs := make([]*CPUStats, len(cpuStats))
+	for idx, cpuStat := range cpuStats {
+
+		// On windows they are already in percent
+		cs[idx] = &CPUStats{
+			CPU:    cpuStat.CPU,
+			User:   cpuStat.User,
+			System: cpuStat.System,
+			Idle:   cpuStat.Idle,
+			Total:  cpuStat.Total(),
+		}
+	}
+
+	// Get the number of ticks
+	allCpu, err := cpu.Times(false)
+	if err != nil {
+		return nil, 0.0, err
+	}
+	if len(allCpu) != 1 {
+		return nil, 0.0, fmt.Errorf("unexpected number of cpus (%d)", len(allCpu))
+	}
+
+	// We use the calculator because when retrieving against all cpus it is
+	// returned as ticks.
+	all := allCpu[0]
+	percentCalculator, ok := h.statsCalculator[all.CPU]
+	if !ok {
+		percentCalculator = NewHostCpuStatsCalculator()
+		h.statsCalculator[all.CPU] = percentCalculator
+	}
+	_, _, _, total := percentCalculator.Calculate(all)
+	ticks := (total / 100) * shelpers.TotalTicksAvailable()
+
+	return cs, ticks, nil
+}


### PR DESCRIPTION
This PR fixes an issue introduced in Nomad 0.6.0 due to
https://github.com/shirou/gopsutil/issues/420. The issue arised from the
fact that the Windows stats from gopsutil reports CPUs in
percentages where we expected ticks.