### PR TITLE
Add nomad-freeze command

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -50,6 +50,16 @@ func (n *Nodes) ToggleDrain(nodeID string, drain bool, q *WriteOptions) (*WriteM
 	return wm, nil
 }
 
+// ToggleFreeze is used to toogle freeze mode on/off for a given node
+func (n *Nodes) ToggleFreeze(nodeID string, freeze bool, q *WriteOptions) (*WriteMeta, error) {
+	freezeArg := strconv.FormatBool(freeze)
+	wm, err := n.client.write("/v1/node/"+nodeID+"/freeze?enable="+freezeArg, nil, nil, q)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
 // Allocations is used to return the allocations associated with a node.
 func (n *Nodes) Allocations(nodeID string, q *QueryOptions) ([]*Allocation, *QueryMeta, error) {
 	var resp []*Allocation
@@ -108,6 +118,7 @@ type Node struct {
 	Meta              map[string]string
 	NodeClass         string
 	Drain             bool
+	Freeze            bool
 	Status            string
 	StatusDescription string
 	StatusUpdatedAt   int64
@@ -157,6 +168,7 @@ type NodeListStub struct {
 	NodeClass         string
 	Version           string
 	Drain             bool
+	Freeze            bool
 	Status            string
 	StatusDescription string
 	CreateIndex       uint64

--- a/command/node_freeze.go
+++ b/command/node_freeze.go
@@ -1,0 +1,197 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
+)
+
+type NodeFreezeCommand struct {
+	Meta
+}
+
+func (c *NodeFreezeCommand) Help() string {
+	helpText := `
+Usage: nomad node-freeze [options] <node>
+
+  Toogles node to not accept new allocations. It is required
+  that either -enable or -disable is specified, but not both.
+  The -self flag is useful to freeze the local node.
+
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+Node Freeze Options:
+
+  -disable
+    Disable freeze for the specified node.
+
+  -enable
+    Enable freeze for the specified node.
+
+  -self
+    Query the status of the local node.
+
+  -yes
+    Automatic yes to prompts.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NodeFreezeCommand) Synopsis() string {
+	return "Toggle freeze mode on a given node"
+}
+
+func (c *NodeFreezeCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-disable": complete.PredictNothing,
+			"-enable":  complete.PredictNothing,
+			"-self":    complete.PredictNothing,
+			"-yes":     complete.PredictNothing,
+		})
+}
+
+func (c *NodeFreezeCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := c.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Nodes, nil)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Nodes]
+	})
+}
+
+func (c *NodeFreezeCommand) Run(args []string) int {
+	var enable, disable, self, autoYes bool
+
+	flags := c.Meta.FlagSet("node-freeze", FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&enable, "enable", false, "Enable freeze mode")
+	flags.BoolVar(&disable, "disable", false, "Disable freeze mode")
+	flags.BoolVar(&self, "self", false, "")
+	flags.BoolVar(&autoYes, "yes", false, "Automatic yes to prompts.")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we got either enable or disable, but not both.
+	if (enable && disable) || (!enable && !disable) {
+		c.Ui.Error(c.Help())
+		return 1
+	}
+
+	// Check that we got a node ID
+	args = flags.Args()
+	if l := len(args); self && l != 0 || !self && l != 1 {
+		c.Ui.Error(c.Help())
+		return 1
+	}
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	// If -self flag is set then determine the current node.
+	nodeID := ""
+	if !self {
+		nodeID = args[0]
+	} else {
+		var err error
+		if nodeID, err = getLocalNodeID(client); err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+	}
+
+	// Check if node exists
+	if len(nodeID) == 1 {
+		c.Ui.Error(fmt.Sprintf("Identifier must contain at least two characters."))
+		return 1
+	}
+
+	nodeID = sanatizeUUIDPrefix(nodeID)
+	nodes, _, err := client.Nodes().PrefixList(nodeID)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error toggling freeze mode: %s", err))
+		return 1
+	}
+	// Return error if no nodes are found
+	if len(nodes) == 0 {
+		c.Ui.Error(fmt.Sprintf("No node(s) with prefix or id %q found", nodeID))
+		return 1
+	}
+	if len(nodes) > 1 {
+		// Format the nodes list that matches the prefix so that the user
+		// can create a more specific request
+		out := make([]string, len(nodes)+1)
+		out[0] = "ID|Datacenter|Name|Class|Drain|Freeze|Status"
+		for i, node := range nodes {
+			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%v|%s",
+				node.ID,
+				node.Datacenter,
+				node.Name,
+				node.NodeClass,
+				node.Drain,
+				node.Freeze,
+				node.Status)
+		}
+		// Dump the output
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple nodes\n\n%s", formatList(out)))
+		return 1
+	}
+
+	// Prefix lookup matched a single node
+	node, _, err := client.Nodes().Info(nodes[0].ID, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error toggling freeze mode: %s", err))
+		return 1
+	}
+
+	// Confirm freeze if the node was a prefix match.
+	if nodeID != node.ID && !autoYes {
+		verb := "enable"
+		if disable {
+			verb = "disable"
+		}
+		question := fmt.Sprintf("Are you sure you want to %s freeze mode for node %q? [y/N]", verb, node.ID)
+		answer, err := c.Ui.Ask(question)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to parse answer: %v", err))
+			return 1
+		}
+
+		if answer == "" || strings.ToLower(answer)[0] == 'n' {
+			// No case
+			c.Ui.Output("Canceling freeze toggle")
+			return 0
+		} else if strings.ToLower(answer)[0] == 'y' && len(answer) > 1 {
+			// Non exact match yes
+			c.Ui.Output("For confirmation, an exact ‘y’ is required.")
+			return 0
+		} else if answer != "y" {
+			c.Ui.Output("No confirmation detected. For confirmation, an exact 'y' is required.")
+			return 1
+		}
+	}
+
+	// Toggle node freeze
+	if _, err := client.Nodes().ToggleFreeze(node.ID, enable, nil); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error toggling freeze mode: %s", err))
+		return 1
+	}
+	return 0
+}

--- a/command/node_freeze_test.go
+++ b/command/node_freeze_test.go
@@ -1,0 +1,123 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeFreezeCommand_Implements(t *testing.T) {
+	t.Parallel()
+	var _ cli.Command = &NodeFreezeCommand{}
+}
+
+func TestNodeFreezeCommand_Fails(t *testing.T) {
+	t.Parallel()
+	srv, _, url := testServer(t, false, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &NodeFreezeCommand{Meta: Meta{Ui: ui}}
+
+	// Fails on misuse
+	if code := cmd.Run([]string{"some", "bad", "args"}); code != 1 {
+		t.Fatalf("expected exit code 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, cmd.Help()) {
+		t.Fatalf("expected help output, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Fails on connection failure
+	if code := cmd.Run([]string{"-address=nope", "-enable", "12345678-abcd-efab-cdef-123456789abc"}); code != 1 {
+		t.Fatalf("expected exit code 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error toggling") {
+		t.Fatalf("expected failed toggle error, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Fails on non-existent node
+	if code := cmd.Run([]string{"-address=" + url, "-enable", "12345678-abcd-efab-cdef-123456789abc"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No node(s) with prefix or id") {
+		t.Fatalf("expected not exist error, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Fails if both enable and disable specified
+	if code := cmd.Run([]string{"-enable", "-disable", "12345678-abcd-efab-cdef-123456789abc"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, cmd.Help()) {
+		t.Fatalf("expected help output, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Fails if neither enable or disable specified
+	if code := cmd.Run([]string{"12345678-abcd-efab-cdef-123456789abc"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, cmd.Help()) {
+		t.Fatalf("expected help output, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Fail on identifier with too few characters
+	if code := cmd.Run([]string{"-address=" + url, "-enable", "1"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must contain at least two characters.") {
+		t.Fatalf("expected too few characters error, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Identifiers with uneven length should produce a query result
+	if code := cmd.Run([]string{"-address=" + url, "-enable", "123"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No node(s) with prefix or id") {
+		t.Fatalf("expected not exist error, got: %s", out)
+	}
+}
+
+func TestNodeFreezeCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	// Wait for a node to appear
+	var nodeID string
+	testutil.WaitForResult(func() (bool, error) {
+		nodes, _, err := client.Nodes().List(nil)
+		if err != nil {
+			return false, err
+		}
+		if len(nodes) == 0 {
+			return false, fmt.Errorf("missing node")
+		}
+		nodeID = nodes[0].ID
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+
+	ui := new(cli.MockUi)
+	cmd := &NodeFreezeCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	prefix := nodeID[:len(nodeID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(nodeID, res[0])
+}

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -185,7 +185,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 			out[0] += "Version|"
 		}
 
-		out[0] += "Drain|Status"
+		out[0] += "Drain|Freeze|Status"
 
 		if c.list_allocs {
 			out[0] += "|Running Allocs"
@@ -201,8 +201,9 @@ func (c *NodeStatusCommand) Run(args []string) int {
 				out[i+1] += fmt.Sprintf("|%s",
 					node.Version)
 			}
-			out[i+1] += fmt.Sprintf("|%v|%s",
+			out[i+1] += fmt.Sprintf("|%v|%v|%s",
 				node.Drain,
+				node.Freeze,
 				node.Status)
 			if c.list_allocs {
 				numAllocs, err := getRunningAllocs(client, node.ID)
@@ -251,14 +252,15 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		// Format the nodes list that matches the prefix so that the user
 		// can create a more specific request
 		out := make([]string, len(nodes)+1)
-		out[0] = "ID|DC|Name|Class|Drain|Status"
+		out[0] = "ID|DC|Name|Class|Drain|Freeze|Status"
 		for i, node := range nodes {
-			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%s",
+			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%v|%v|%s",
 				limit(node.ID, c.length),
 				node.Datacenter,
 				node.Name,
 				node.NodeClass,
 				node.Drain,
+				node.Freeze,
 				node.Status)
 		}
 		// Dump the output
@@ -315,6 +317,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		fmt.Sprintf("Class|%s", node.NodeClass),
 		fmt.Sprintf("DC|%s", node.Datacenter),
 		fmt.Sprintf("Drain|%v", node.Drain),
+		fmt.Sprintf("Freeze|%v", node.Freeze),
 		fmt.Sprintf("Status|%s", node.Status),
 		fmt.Sprintf("Drivers|%s", strings.Join(nodeDrivers(node), ",")),
 	}

--- a/commands.go
+++ b/commands.go
@@ -168,6 +168,11 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"node-freeze": func() (cli.Command, error) {
+			return &command.NodeFreezeCommand{
+				Meta: meta,
+			}, nil
+		},
 		"node-status": func() (cli.Command, error) {
 			return &command.NodeStatusCommand{
 				Meta: meta,

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -47,7 +47,7 @@ type Node struct {
 	updatesLock sync.Mutex
 }
 
-// Register is used to upset a client that is available for scheduling
+// Register is used to upsert a client that is available for scheduling
 func (n *Node) Register(args *structs.NodeRegisterRequest, reply *structs.NodeUpdateResponse) error {
 	if done, err := n.srv.forward("Node.Register", args, args, reply); done {
 		return err

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -395,6 +395,8 @@ func evaluateNodePlan(snap *state.StateSnapshot, plan *structs.Plan, nodeID stri
 		return false, "node is not ready for placements", nil
 	} else if node.Drain {
 		return false, "node is draining", nil
+	} else if node.Freeze {
+		return false, "node is freezed", nil
 	}
 
 	// Get the existing allocations that are non-terminal

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -393,6 +393,8 @@ func evaluateNodePlan(snap *state.StateSnapshot, plan *structs.Plan, nodeID stri
 		return false, "node does not exist", nil
 	} else if node.Status != structs.NodeStatusReady {
 		return false, "node is not ready for placements", nil
+	} else if node.Drain && node.Freeze {
+		return false, "node is draining and freezed", nil
 	} else if node.Drain {
 		return false, "node is draining", nil
 	} else if node.Freeze {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1069,7 +1069,7 @@ type Node struct {
 	Drain bool
 
 	// Freeze is controlled by the servers, and not the client.
-	// If true, no jobs will be scheduled to this node, byt existing
+	// If true, no jobs will be scheduled to this node, but existing
 	// allocations will not be affected.
 	Freeze bool
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -249,6 +249,9 @@ func readyNodesInDCs(state State, dcs []string) ([]*structs.Node, map[string]int
 		if node.Drain {
 			continue
 		}
+		if node.Freeze {
+			continue
+		}
 		if _, ok := dcMap[node.Datacenter]; !ok {
 			continue
 		}


### PR DESCRIPTION
This is a proposal of a new command to prevent scheduler from putting new allocations on a node. 

Use cases:
1. Cluster rolling updates:
      Be able to tell scheduler not to migrate allocations from drained nodes to those with old nomad version: `nomad node-freeze -enable...` 

2. Debugging node:
       Sometimes there's a need to debug a node with allocations on it but without having new allocations arriving at the same time.

3. Retire node but without moving allocations, let them finish the job, and then stop the node.

 Why it's a separate command instead of `node-drain` flag ? Well because we are not performing any action on allocations  (we are simply tagging node to let scheduler know that this node can't be used).
