### PR TITLE
Add ability to reset ACL bootstrap process

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -39,7 +39,7 @@ func testACLServer(t *testing.T, cb func(*nomad.Config)) (*nomad.Server, string,
 		}
 	})
 	token := mock.ACLManagementToken()
-	err := server.State().BootstrapACLTokens(1, token)
+	err := server.State().BootstrapACLTokens(1, 0, token)
 	if err != nil {
 		t.Fatalf("failed to bootstrap ACL token: %v", err)
 	}

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -176,7 +176,7 @@ func (a *TestAgent) Start() *TestAgent {
 	if a.Config.ACL.Enabled && a.Config.Server.Enabled && a.Config.ACL.PolicyTTL != 0 {
 		a.Token = mock.ACLManagementToken()
 		state := a.Agent.server.State()
-		if err := state.BootstrapACLTokens(1, a.Token); err != nil {
+		if err := state.BootstrapACLTokens(1, 0, a.Token); err != nil {
 			panic(fmt.Sprintf("token bootstrap failed: %v", err))
 		}
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -792,7 +792,7 @@ func (n *nomadFSM) applyACLTokenBootstrap(buf []byte, index uint64) interface{} 
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.BootstrapACLTokens(index, req.Token); err != nil {
+	if err := n.state.BootstrapACLTokens(index, req.ResetIndex, req.Token); err != nil {
 		n.logger.Printf("[ERR] nomad.fsm: BootstrapACLToken failed: %v", err)
 		return err
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1624,7 +1624,7 @@ func TestFSM_BootstrapACLTokens(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
 
-	// Teset with reset
+	// Test with reset
 	token2 := mock.ACLToken()
 	req = structs.ACLTokenBootstrapRequest{
 		Token:      token2,

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1623,6 +1623,27 @@ func TestFSM_BootstrapACLTokens(t *testing.T) {
 	out, err := fsm.State().ACLTokenByAccessorID(nil, token.AccessorID)
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
+
+	// Teset with reset
+	token2 := mock.ACLToken()
+	req = structs.ACLTokenBootstrapRequest{
+		Token:      token2,
+		ResetIndex: out.CreateIndex,
+	}
+	buf, err = structs.Encode(structs.ACLTokenBootstrapRequestType, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp = fsm.Apply(makeLog(buf))
+	if resp != nil {
+		t.Fatalf("resp: %v", resp)
+	}
+
+	// Verify we are registered
+	out2, err := fsm.State().ACLTokenByAccessorID(nil, token2.AccessorID)
+	assert.Nil(t, err)
+	assert.NotNil(t, out2)
 }
 
 func TestFSM_UpsertACLTokens(t *testing.T) {

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -47,7 +47,7 @@ func testACLServer(t *testing.T, cb func(*Config)) (*Server, *structs.ACLToken) 
 		}
 	})
 	token := mock.ACLManagementToken()
-	err := server.State().BootstrapACLTokens(1, token)
+	err := server.State().BootstrapACLTokens(1, 0, token)
 	if err != nil {
 		t.Fatalf("failed to bootstrap ACL token: %v", err)
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5707,7 +5707,8 @@ type ACLTokenDeleteRequest struct {
 
 // ACLTokenBootstrapRequest is used to bootstrap ACLs
 type ACLTokenBootstrapRequest struct {
-	Token *ACLToken // Not client specifiable
+	Token      *ACLToken // Not client specifiable
+	ResetIndex uint64    // Reset index is used to clear the bootstrap token
 	WriteRequest
 }
 

--- a/website/source/api/acl-tokens.html.md
+++ b/website/source/api/acl-tokens.html.md
@@ -14,7 +14,8 @@ For more details about ACLs, please see the [ACL Guide](/guides/acl.html).
 ## Bootstrap Token
 
 This endpoint is used to bootstrap the ACL system and provide the initial management token.
-This request is always forwarded to the authoritative region. It can only be invoked once.
+This request is always forwarded to the authoritative region. It can only be invoked once
+until a [bootstrap reset](/guides/acl.html#reseting-acl-bootstrap) is performed.
 
 | Method | Path                         | Produces                   |
 | ------ | ---------------------------- | -------------------------- |

--- a/website/source/guides/acl.html.markdown
+++ b/website/source/guides/acl.html.markdown
@@ -104,7 +104,7 @@ $ curl \
 }
 ```
 
-Once the initial bootstrap is performed, it cannot be performed again until [reset](#reseting-acl-bootstrap). Make sure to save this AccessorID and SecretID.
+Once the initial bootstrap is performed, it cannot be performed again unless [reset](#reseting-acl-bootstrap). Make sure to save this AccessorID and SecretID.
 The bootstrap token is a `management` type token, meaning it can perform any operation. It should be used to setup the ACL policies and create additional ACL tokens. The bootstrap token can be deleted and is like any other token, so care should be taken to not revoke all management tokens.
 
 ### Enable ACLs on Nomad Clients


### PR DESCRIPTION
This PR allows the ACL bootstrapping process to be reset. The user creates a special file in `<datadir>/server/acl-bootstrap-reset` with the reset index, and then uses the standard ACL bootstrapping endpoint.