### PR TITLE
Fix panic in emitting tagged allocation metrics

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1940,6 +1940,7 @@ func (c *Client) setGaugeForDiskStats(nodeID string, hStats *stats.HostStats) {
 
 // setGaugeForAllocationStats proxies metrics for allocation specific statistics
 func (c *Client) setGaugeForAllocationStats(nodeID string) {
+	c.configLock.RLock()
 	node := c.configCopy.Node
 	c.configLock.RUnlock()
 	total := node.Resources


### PR DESCRIPTION
Addresses panic reported in #3188 

Introduced in #3147