### PR TITLE
Add ACL Bootstrap CLI

### DIFF
--- a/command/acl.go
+++ b/command/acl.go
@@ -1,0 +1,19 @@
+package command
+
+import "github.com/mitchellh/cli"
+
+type ACLCommand struct {
+	Meta
+}
+
+func (f *ACLCommand) Help() string {
+	return "This command is accessed by using one of the subcommands below."
+}
+
+func (f *ACLCommand) Synopsis() string {
+	return "Interact with ACL policies and tokens"
+}
+
+func (f *ACLCommand) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/command/acl_bootstrap.go
+++ b/command/acl_bootstrap.go
@@ -1,0 +1,100 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
+)
+
+type ACLBootstrapCommand struct {
+	Meta
+}
+
+func (c *ACLBootstrapCommand) Help() string {
+	helpText := `
+Usage: nomad acl bootstrap [options]
+
+Bootstrap is used to bootstrap the ACL system and get an initial token.
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *ACLBootstrapCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{})
+}
+
+func (c *ACLBootstrapCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *ACLBootstrapCommand) Synopsis() string {
+	return "Bootstrap the ACL system for initial token"
+}
+
+func (c *ACLBootstrapCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet("acl bootstrap", FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we got no arguments
+	args = flags.Args()
+	if l := len(args); l != 0 {
+		c.Ui.Error(c.Help())
+		return 1
+	}
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	// Get the bootstrap token
+	token, _, err := client.ACLTokens().Bootstrap(nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error bootstrapping: %s", err))
+		return 1
+	}
+
+	// Format the output
+	c.Ui.Output(formatKVACLToken(token))
+	return 0
+}
+
+// formatKVACLToken returns a K/V formatted ACL token
+func formatKVACLToken(token *api.ACLToken) string {
+	// Add the fixed preamble
+	output := []string{
+		fmt.Sprintf("Accessor ID|%s", token.AccessorID),
+		fmt.Sprintf("Secret ID|%s", token.SecretID),
+		fmt.Sprintf("Name|%s", token.Name),
+		fmt.Sprintf("Type|%s", token.Type),
+		fmt.Sprintf("Global|%v", token.Global),
+	}
+
+	// Special case the policy output
+	if token.Type == "management" {
+		output = append(output, "Policies|n/a")
+	} else {
+		output = append(output, fmt.Sprintf("Policies|%v", token.Policies))
+	}
+
+	// Add the generic output
+	output = append(output,
+		fmt.Sprintf("Create Time|%v", token.CreateTime),
+		fmt.Sprintf("Create Index|%d", token.CreateIndex),
+		fmt.Sprintf("Modify Index|%d", token.ModifyIndex),
+	)
+	return formatKV(output)
+}

--- a/command/acl_bootstrap_test.go
+++ b/command/acl_bootstrap_test.go
@@ -1,0 +1,12 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestACLBootstrapCommand_Implements(t *testing.T) {
+	t.Parallel()
+	var _ cli.Command = &ACLBootstrapCommand{}
+}

--- a/commands.go
+++ b/commands.go
@@ -26,6 +26,16 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 	}
 
 	return map[string]cli.CommandFactory{
+		"acl": func() (cli.Command, error) {
+			return &command.ACLCommand{
+				Meta: meta,
+			}, nil
+		},
+		"acl bootstrap": func() (cli.Command, error) {
+			return &command.ACLBootstrapCommand{
+				Meta: meta,
+			}, nil
+		},
 		"alloc-status": func() (cli.Command, error) {
 			return &command.AllocStatusCommand{
 				Meta: meta,

--- a/website/source/docs/commands/acl.html.md.erb
+++ b/website/source/docs/commands/acl.html.md.erb
@@ -1,0 +1,25 @@
+---
+layout: "docs"
+page_title: "Commands: acl"
+sidebar_current: "docs-commands-acl"
+description: >
+  The deployment command is used to interact with ACL policies and tokens.
+---
+
+# Nomad ACL
+
+Command: `nomad acl`
+
+The `acl` command is used to interact with ACL policies and tokens.
+
+## Usage
+
+Usage: `nomad acl <subcommand> [options]`
+
+Run `nomad acl <subcommand> -h` for help on that subcommand. The following
+subcommands are available:
+
+* [`acl bootstrap`][bootstrap] - Bootstrap the initial ACL token
+
+[bootstrap]: /docs/commands/acl/bootstrap.html
+

--- a/website/source/docs/commands/acl/bootstrap.html.md.erb
+++ b/website/source/docs/commands/acl/bootstrap.html.md.erb
@@ -1,0 +1,40 @@
+---
+layout: "docs"
+page_title: "Commands: acl bootstrap"
+sidebar_current: "docs-commands-acl-bootstrap"
+description: >
+  The deployment list command is used to list deployments.
+---
+
+# Command: acl bootstrap
+
+The `acl bootstrap` command is used to bootstrap the initial ACL token.
+
+## Usage
+
+```
+nomad acl bootstrap [options]
+```
+
+The `acl bootstrap` command requires no arguments.
+
+## General Options
+
+<%= partial "docs/commands/_general_options" %>
+
+## Examples
+
+Bootstrap the initial token:
+
+```
+$ nomad acl bootstrap
+Accessor ID  = 5b7fd453-d3f7-6814-81dc-fcfe6daedea5
+Secret ID    = 9184ec35-65d4-9258-61e3-0c066d0a45c5
+Name         = Bootstrap Token
+Type         = management
+Global       = true
+Policies     = n/a
+Create Time  = 2017-09-11 17:38:10.999089612 +0000 UTC
+Create Index = 7
+Modify Index = 7
+```

--- a/website/source/guides/acl.html.markdown
+++ b/website/source/guides/acl.html.markdown
@@ -83,25 +83,19 @@ Please take care to restart the servers one at a time, and ensure each server ha
 
 ### Generate the initial token
 
-Once the ACL system is enabled, we need to generate our initial token. This first token is used to bootstrap the system and care should be taken not to lose it. Once the ACL system is enabled, we use the [Bootstrap API](/api/acl-tokens.html#bootstrap-token):
+Once the ACL system is enabled, we need to generate our initial token. This first token is used to bootstrap the system and care should be taken not to lose it. Once the ACL system is enabled, we use the [Bootstrap CLI](/docs/commands/acl/bootstrap.html):
 
 ```text
-$ curl \
-    --request POST \
-    https://nomad.rocks/v1/acl/bootstrap?pretty=true
-```
-```json
-{
-    "AccessorID":"b780e702-98ce-521f-2e5f-c6b87de05b24",
-    "SecretID":"3f4a0fcd-7c42-773c-25db-2d31ba0c05fe",
-    "Name":"Bootstrap Token",
-    "Type":"management",
-    "Policies":null,
-    "Global":true,
-    "CreateTime":"2017-08-23T22:47:14.695408057Z",
-    "CreateIndex":7,
-    "ModifyIndex":7
-}
+$ nomad acl bootstrap
+Accessor ID  = 5b7fd453-d3f7-6814-81dc-fcfe6daedea5
+Secret ID    = 9184ec35-65d4-9258-61e3-0c066d0a45c5
+Name         = Bootstrap Token
+Type         = management
+Global       = true
+Policies     = n/a
+Create Time  = 2017-09-11 17:38:10.999089612 +0000 UTC
+Create Index = 7
+Modify Index = 7
 ```
 
 Once the initial bootstrap is performed, it cannot be performed again unless [reset](#reseting-acl-bootstrap). Make sure to save this AccessorID and SecretID.

--- a/website/source/guides/acl.html.markdown
+++ b/website/source/guides/acl.html.markdown
@@ -310,11 +310,9 @@ If all management tokens are lost, it is possible to reset the ACL bootstrap so 
 First, we need to determine the reset index, this can be done by calling the reset endpoint:
 
 ```
-$ curl \
-    --request POST \
-    https://nomad.rocks/v1/acl/bootstrap?pretty=true
+$ nomad acl bootstrap
 
-ACL bootstrap already done (reset index: 7)
+Error bootstrapping: Unexpected response code: 500 (ACL bootstrap already done (reset index: 7))
 ```
 
 Here we can see the `reset index`. To reset the ACL system, we create the `acl-bootstrap-reset` file in the data directory:
@@ -323,37 +321,27 @@ Here we can see the `reset index`. To reset the ACL system, we create the `acl-b
 $ echo 7 >> /nomad-data-dir/server/acl-bootstrap-reset
 ```
 
-Now, we can bootstrap like normal using the reset key:
+With the reset key setup, we can bootstrap like normal:
 
 ```
-$ curl \
-    --request POST \
-    https://nomad.rocks/v1/acl/bootstrap?pretty=true
-```
-
-```json
-{
-    "AccessorID":"52d3353d-d7b9-d945-0591-1af608732b76",
-    "SecretID":"4b0a41ca-6d32-1853-e64b-de0d347e4525",
-    "Name":"Bootstrap Token",
-    "Type":"management",
-    "Policies":null,
-    "Global":true,
-    "Hash":"BUJ3BerTfrqFVm1P+vZr1gz9ubOkd+JAvYjNAJyaU9Y=",
-    "CreateTime":"2017-09-10T23:11:49.34730714Z",
-    "CreateIndex":11,
-    "ModifyIndex":11
-}
+$ nomad acl bootstrap
+Accessor ID  = 52d3353d-d7b9-d945-0591-1af608732b76
+Secret ID    = 4b0a41ca-6d32-1853-e64b-de0d347e4525
+Name         = Bootstrap Token
+Type         = management
+Global       = true
+Policies     = n/a
+Create Time  = 2017-09-11 18:38:11.929089612 +0000 UTC
+Create Index = 11
+Modify Index = 11
 ```
 
 If we attempt to bootstrap again, we will get a mismatch on the reset index:
 
 ```
-$ curl \
-    --request POST \
-    https://nomad.rocks/v1/acl/bootstrap?pretty=true
+$ nomad acl bootstrap
 
-Invalid bootstrap reset index (specified 7, reset index: 11)
+Error bootstrapping: Unexpected response code: 500 (Invalid bootstrap reset index (specified 7, reset index: 11))
 ```
 
 This is because the reset file is in place, but with the incorrect index.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -167,6 +167,14 @@
       <li<%= sidebar_current("docs-commands") %>>
         <a href="/docs/commands/index.html">Commands (CLI)</a>
         <ul class="nav">
+          <li<%= sidebar_current("docs-commands-acl") %>>
+            <a href="/docs/commands/acl.html">acl</a>
+            <ul class="nav">
+              <li<%= sidebar_current("docs-commands-acl-bootstrap") %>>
+                <a href="/docs/commands/acl/bootstrap.html">acl bootstrap</a>
+              </li>
+            </ul>
+          </li>
           <li<%= sidebar_current("docs-commands-_agent") %>>
             <a href="/docs/commands/agent.html">agent</a>
           </li>


### PR DESCRIPTION
This PR adds the ACL bootstrap CLI. This makes the getting started guide much cleaner. Also adds the scaffolding to the website for the other ACL CLI commands.