### PR TITLE
Fix permissions of $GOPATH in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure(2) do |config|
 			'/opt/gopath/src/github.com/hashicorp/nomad'
 
 		vmCfg.vm.provision "shell",
-			privileged: true,
+			privileged: false,
 			path: './scripts/vagrant-linux-unpriv-bootstrap.sh'
 	end
 

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -21,11 +21,7 @@ install_go
 	
 # Ensure that the GOPATH tree is owned by vagrant:vagrant
 mkdir -p /opt/gopath
-chown vagrant:vagrant \
-	/opt/gopath \
-	/opt/gopath/src \
-	/opt/gopath/src/github.com \
-	/opt/gopath/src/github.com/hashicorp
+chown -R vagrant:vagrant /opt/gopath
 
 # Ensure Go is on PATH
 if [ ! -e /usr/bin/go ] ; then


### PR DESCRIPTION
Technically just the true->false is needed. The `chown -R` was a first
attempt that didn't fix the bug, but it's a nice simplification.