### PR TITLE
Sort /v1/agent/servers output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ IMPROVEMENTS:
 
 BUG FIXES:
  * core: *Fix restoration of stopped periodic jobs [GH-3201]
+ * api: Sort /v1/agent/servers output so that output of Consul checks does not
+   change [GH-3214]
  * api: Fix search handling of jobs with more than four hyphens and case were
    length could cause lookup error [GH-3203]
  * client: Fix lock contention that could cause a node to miss a heartbeat and

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"net"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -148,6 +149,7 @@ func (s *HTTPServer) listServers(resp http.ResponseWriter, req *http.Request) (i
 	}
 
 	peers := s.agent.client.GetServers()
+	sort.Strings(peers)
 	return peers, nil
 }
 

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -175,10 +176,10 @@ func TestHTTP_AgentSetServers(t *testing.T) {
 		respW = httptest.NewRecorder()
 
 		// Make the request and check the result
-		expected := map[string]bool{
-			"127.0.0.1:4647": true,
-			"127.0.0.2:4647": true,
-			"127.0.0.3:4647": true,
+		expected := []string{
+			"127.0.0.1:4647",
+			"127.0.0.2:4647",
+			"127.0.0.3:4647",
 		}
 		out, err := s.Server.AgentServersRequest(respW, req)
 		if err != nil {
@@ -188,19 +189,8 @@ func TestHTTP_AgentSetServers(t *testing.T) {
 		if n := len(servers); n != len(expected) {
 			t.Fatalf("expected %d servers, got: %d: %v", len(expected), n, servers)
 		}
-		received := make(map[string]bool, len(servers))
-		for _, server := range servers {
-			received[server] = true
-		}
-		foundCount := 0
-		for k, _ := range received {
-			_, found := expected[k]
-			if found {
-				foundCount++
-			}
-		}
-		if foundCount != len(expected) {
-			t.Fatalf("bad servers result")
+		if !reflect.DeepEqual(servers, expected) {
+			t.Fatalf("got %v; want %v", servers, expected)
 		}
 	})
 }


### PR DESCRIPTION
This PR sorts the output of the endpoint since its results are used as
part of Consul checks to avoid the value changing unnecessarily.

Fixes https://github.com/hashicorp/nomad/issues/3211