### PR TITLE
ACL CLI

### DIFF
--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
@@ -213,6 +214,55 @@ func TestJobStatusCommand_AutocompleteArgs(t *testing.T) {
 	res := predictor.Predict(args)
 	assert.Equal(1, len(res))
 	assert.Equal(j.ID, res[0])
+}
+
+func TestJobStatusCommand_WithAccessPolicy(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	config := func(c *agent.Config) {
+		c.ACL.Enabled = true
+	}
+
+	srv, client, url := testServer(t, true, config)
+	defer srv.Shutdown()
+
+	// Bootstrap an initial ACL token
+	token := srv.Token
+	assert.NotNil(token, "failed to bootstrap ACL token")
+
+	// Register a job
+	j := testJob("job1_sfx")
+
+	invalidToken := mock.ACLToken()
+
+	ui := new(cli.MockUi)
+	cmd := &JobStatusCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// registering a job without a token fails
+	client.SetSecretID(invalidToken.SecretID)
+	resp, _, err := client.Jobs().Register(j, nil)
+	assert.NotNil(err)
+
+	// registering a job with a valid token succeeds
+	client.SetSecretID(token.SecretID)
+	resp, _, err = client.Jobs().Register(j, nil)
+	assert.Nil(err)
+	code := waitForSuccess(ui, client, fullId, t, resp.EvalID)
+	assert.Equal(0, code)
+
+	// Request Job List without providing a valid token
+	code = cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID, "-short"})
+	assert.Equal(1, code)
+
+	// Request Job List with a valid token
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, "-short"})
+	assert.Equal(0, code)
+
+	out := ui.OutputWriter.String()
+	if !strings.Contains(out, *j.ID) {
+		t.Fatalf("should contain full identifiers, got %s", out)
+	}
 }
 
 func waitForSuccess(ui cli.Ui, client *api.Client, length int, t *testing.T, evalId string) int {

--- a/command/meta.go
+++ b/command/meta.go
@@ -209,9 +209,8 @@ func generalOptionsUsage() string {
     will also be skipped if NOMAD_SKIP_VERIFY is set.
 
   -token
-    Provide an ACL token to access privilated information
-		The SecretID of an ACL token to use to authenticate API requests with.
-		Additionally, the NOMAD_TOKEN env var will also be sourced.
+    The SecretID of an ACL token to use to authenticate API requests with.
+    Overrides the NOMAD_TOKEN environment variable if set.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -210,6 +210,8 @@ func generalOptionsUsage() string {
 
   -token
     Provide an ACL token to access privilated information
+		The SecretID of an ACL token to use to authenticate API requests with.
+		Additionally, the NOMAD_TOKEN env var will also be sourced.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -47,6 +47,9 @@ type Meta struct {
 	// namespace to send API requests
 	namespace string
 
+	// token is used for ACLs to access privilaged information
+	token string
+
 	caCert     string
 	caPath     string
 	clientCert string
@@ -74,6 +77,7 @@ func (m *Meta) FlagSet(n string, fs FlagSetFlags) *flag.FlagSet {
 		f.StringVar(&m.clientKey, "client-key", "", "")
 		f.BoolVar(&m.insecure, "insecure", false, "")
 		f.BoolVar(&m.insecure, "tls-skip-verify", false, "")
+		f.StringVar(&m.token, "token", "", "")
 
 	}
 
@@ -110,6 +114,7 @@ func (m *Meta) AutocompleteFlags(fs FlagSetFlags) complete.Flags {
 		"-client-key":      complete.PredictFiles("*"),
 		"-insecure":        complete.PredictNothing,
 		"-tls-skip-verify": complete.PredictNothing,
+		"-token":           complete.PredictAnything,
 	}
 }
 
@@ -140,6 +145,10 @@ func (m *Meta) Client() (*api.Client, error) {
 			Insecure:   m.insecure,
 		}
 		config.TLSConfig = t
+	}
+
+	if m.token != "" {
+		config.SecretID = m.token
 	}
 
 	return api.NewClient(config)
@@ -198,6 +207,9 @@ func generalOptionsUsage() string {
   -tls-skip-verify
     Do not verify TLS certificate. This is highly not recommended. Verification
     will also be skipped if NOMAD_SKIP_VERIFY is set.
+
+  -token
+    Provide an ACL token to access privilated information
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -30,6 +30,7 @@ func TestMeta_FlagSet(t *testing.T) {
 				"client-key",
 				"insecure",
 				"tls-skip-verify",
+				"token",
 			},
 		},
 	}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -281,6 +281,7 @@ func getSignalConstraint(signals []string) *structs.Constraint {
 // Summary retreives the summary of a job
 func (j *Job) Summary(args *structs.JobSummaryRequest,
 	reply *structs.JobSummaryResponse) error {
+
 	if done, err := j.srv.forward("Job.Summary", args, args, reply); done {
 		return err
 	}


### PR DESCRIPTION
Adds the ability to interact with access-protected resources from the CLI. Builds on #3192 

Adds a test for an API resource to ensure that tokens are correctly passed through. 

Requires #3219 to be first merged