### PR TITLE
Add test logger to improve test logging output

### DIFF
--- a/client/alloc_watcher_test.go
+++ b/client/alloc_watcher_test.go
@@ -13,13 +13,14 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 )
 
 // TestPrevAlloc_LocalPrevAlloc asserts that when a previous alloc runner is
 // set a localPrevAlloc will block on it.
 func TestPrevAlloc_LocalPrevAlloc(t *testing.T) {
-	_, prevAR := testAllocRunner(false)
+	_, prevAR := testAllocRunner(t, false)
 	prevAR.alloc.Job.TaskGroups[0].Tasks[0].Config["run_for"] = "10s"
 
 	newAlloc := mock.Alloc()
@@ -29,7 +30,7 @@ func TestPrevAlloc_LocalPrevAlloc(t *testing.T) {
 	task.Driver = "mock_driver"
 	task.Config["run_for"] = "500ms"
 
-	waiter := newAllocWatcher(newAlloc, prevAR, nil, nil, testLogger())
+	waiter := newAllocWatcher(newAlloc, prevAR, nil, nil, testlog.New(t))
 
 	// Wait in a goroutine with a context to make sure it exits at the right time
 	ctx, cancel := context.WithCancel(context.Background())
@@ -166,7 +167,7 @@ func TestPrevAlloc_StreamAllocDir(t *testing.T) {
 
 	rc := ioutil.NopCloser(buf)
 
-	prevAlloc := &remotePrevAlloc{logger: testLogger()}
+	prevAlloc := &remotePrevAlloc{logger: testlog.New(t)}
 	if err := prevAlloc.streamAllocDir(context.Background(), rc, dir1); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -22,22 +21,12 @@ import (
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/command/agent/consul"
+	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/kr/pretty"
 )
-
-func testLogger() *log.Logger {
-	return prefixedTestLogger("")
-}
-
-func prefixedTestLogger(prefix string) *log.Logger {
-	if testing.Verbose() {
-		return log.New(os.Stderr, prefix, log.LstdFlags|log.Lmicroseconds)
-	}
-	return log.New(ioutil.Discard, "", 0)
-}
 
 type MockTaskStateUpdater struct {
 	state  string
@@ -94,7 +83,7 @@ func testTaskRunner(t *testing.T, restarts bool) *taskRunnerTestCtx {
 //
 // Callers should defer Cleanup() to cleanup after completion
 func testTaskRunnerFromAlloc(t *testing.T, restarts bool, alloc *structs.Allocation) *taskRunnerTestCtx {
-	logger := testLogger()
+	logger := testlog.New(t)
 	conf := config.DefaultConfig()
 	conf.Node = mock.Node()
 	conf.StateDir = os.TempDir()
@@ -115,7 +104,7 @@ func testTaskRunnerFromAlloc(t *testing.T, restarts bool, alloc *structs.Allocat
 	// we have a mock so that doesn't happen.
 	task.Resources.Networks[0].ReservedPorts = []structs.Port{{Label: "", Value: 80}}
 
-	allocDir := allocdir.NewAllocDir(testLogger(), filepath.Join(conf.AllocDir, alloc.ID))
+	allocDir := allocdir.NewAllocDir(testlog.New(t), filepath.Join(conf.AllocDir, alloc.ID))
 	if err := allocDir.Build(); err != nil {
 		t.Fatalf("error building alloc dir: %v", err)
 		return nil

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -39,7 +39,7 @@ func tmpDir(t testing.TB) string {
 
 func TestAgent_RPCPing(t *testing.T) {
 	t.Parallel()
-	agent := NewTestAgent(t.Name(), nil)
+	agent := NewTestAgent(t, nil)
 	defer agent.Shutdown()
 
 	var out struct{}

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -82,7 +82,7 @@ func TestCommand_Args(t *testing.T) {
 // TODO Why is this failing
 func TestRetryJoin(t *testing.T) {
 	t.Parallel()
-	agent := NewTestAgent(t.Name(), nil)
+	agent := NewTestAgent(t, nil)
 	defer agent.Shutdown()
 
 	doneCh := make(chan struct{})

--- a/command/agent/consul/check_watcher_test.go
+++ b/command/agent/consul/check_watcher_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -113,9 +114,9 @@ func (c *fakeChecksAPI) Checks() (map[string]*api.AgentCheck, error) {
 
 // testWatcherSetup sets up a fakeChecksAPI and a real checkWatcher with a test
 // logger and faster poll frequency.
-func testWatcherSetup() (*fakeChecksAPI, *checkWatcher) {
+func testWatcherSetup(t *testing.T) (*fakeChecksAPI, *checkWatcher) {
 	fakeAPI := newFakeChecksAPI()
-	cw := newCheckWatcher(testLogger(), fakeAPI)
+	cw := newCheckWatcher(testlog.New(t), fakeAPI)
 	cw.pollFreq = 10 * time.Millisecond
 	return fakeAPI, cw
 }
@@ -141,7 +142,7 @@ func TestCheckWatcher_Skip(t *testing.T) {
 	check := testCheck()
 	check.CheckRestart = nil
 
-	cw := newCheckWatcher(testLogger(), newFakeChecksAPI())
+	cw := newCheckWatcher(testlog.New(t), newFakeChecksAPI())
 	restarter1 := newFakeCheckRestarter(cw, "testalloc1", "testtask1", "testcheck1", check)
 	cw.Watch("testalloc1", "testtask1", "testcheck1", check, restarter1)
 
@@ -155,7 +156,7 @@ func TestCheckWatcher_Skip(t *testing.T) {
 func TestCheckWatcher_Healthy(t *testing.T) {
 	t.Parallel()
 
-	fakeAPI, cw := testWatcherSetup()
+	fakeAPI, cw := testWatcherSetup(t)
 
 	check1 := testCheck()
 	restarter1 := newFakeCheckRestarter(cw, "testalloc1", "testtask1", "testcheck1", check1)
@@ -190,7 +191,7 @@ func TestCheckWatcher_Healthy(t *testing.T) {
 func TestCheckWatcher_HealthyWarning(t *testing.T) {
 	t.Parallel()
 
-	fakeAPI, cw := testWatcherSetup()
+	fakeAPI, cw := testWatcherSetup(t)
 
 	check1 := testCheck()
 	check1.CheckRestart.Limit = 1
@@ -218,7 +219,7 @@ func TestCheckWatcher_HealthyWarning(t *testing.T) {
 func TestCheckWatcher_Flapping(t *testing.T) {
 	t.Parallel()
 
-	fakeAPI, cw := testWatcherSetup()
+	fakeAPI, cw := testWatcherSetup(t)
 
 	check1 := testCheck()
 	check1.CheckRestart.Grace = 0
@@ -247,7 +248,7 @@ func TestCheckWatcher_Flapping(t *testing.T) {
 func TestCheckWatcher_Unwatch(t *testing.T) {
 	t.Parallel()
 
-	fakeAPI, cw := testWatcherSetup()
+	fakeAPI, cw := testWatcherSetup(t)
 
 	// Unwatch immediately
 	check1 := testCheck()
@@ -276,7 +277,7 @@ func TestCheckWatcher_Unwatch(t *testing.T) {
 func TestCheckWatcher_MultipleChecks(t *testing.T) {
 	t.Parallel()
 
-	fakeAPI, cw := testWatcherSetup()
+	fakeAPI, cw := testWatcherSetup(t)
 
 	check1 := testCheck()
 	check1.CheckRestart.Limit = 1

--- a/command/agent/consul/script_test.go
+++ b/command/agent/consul/script_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/testtask"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -59,7 +60,7 @@ func TestConsulScript_Exec_Cancel(t *testing.T) {
 	exec := newBlockingScriptExec()
 
 	// pass nil for heartbeater as it shouldn't be called
-	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, nil, testLogger(), nil)
+	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, nil, testlog.NewTest(t), nil)
 	handle := check.run()
 
 	// wait until Exec is called
@@ -111,7 +112,7 @@ func TestConsulScript_Exec_Timeout(t *testing.T) {
 	exec := newBlockingScriptExec()
 
 	hb := newFakeHeartbeater()
-	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testLogger(), nil)
+	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testlog.NewTest(t), nil)
 	handle := check.run()
 	defer handle.cancel() // just-in-case cleanup
 	<-exec.running
@@ -160,7 +161,7 @@ func TestConsulScript_Exec_TimeoutCritical(t *testing.T) {
 		Timeout:  time.Nanosecond,
 	}
 	hb := newFakeHeartbeater()
-	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, sleeperExec{}, hb, testLogger(), nil)
+	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, sleeperExec{}, hb, testlog.NewTest(t), nil)
 	handle := check.run()
 	defer handle.cancel() // just-in-case cleanup
 
@@ -205,7 +206,7 @@ func TestConsulScript_Exec_Shutdown(t *testing.T) {
 	hb := newFakeHeartbeater()
 	shutdown := make(chan struct{})
 	exec := newSimpleExec(0, nil)
-	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testLogger(), shutdown)
+	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testlog.NewTest(t), shutdown)
 	handle := check.run()
 	defer handle.cancel() // just-in-case cleanup
 
@@ -242,7 +243,7 @@ func TestConsulScript_Exec_Codes(t *testing.T) {
 			hb := newFakeHeartbeater()
 			shutdown := make(chan struct{})
 			exec := newSimpleExec(code, err)
-			check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testLogger(), shutdown)
+			check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testlog.NewTest(t), shutdown)
 			handle := check.run()
 			defer handle.cancel()
 

--- a/command/agent/consul/script_test.go
+++ b/command/agent/consul/script_test.go
@@ -60,7 +60,7 @@ func TestConsulScript_Exec_Cancel(t *testing.T) {
 	exec := newBlockingScriptExec()
 
 	// pass nil for heartbeater as it shouldn't be called
-	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, nil, testlog.NewTest(t), nil)
+	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, nil, testlog.New(t), nil)
 	handle := check.run()
 
 	// wait until Exec is called
@@ -112,7 +112,7 @@ func TestConsulScript_Exec_Timeout(t *testing.T) {
 	exec := newBlockingScriptExec()
 
 	hb := newFakeHeartbeater()
-	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testlog.NewTest(t), nil)
+	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testlog.New(t), nil)
 	handle := check.run()
 	defer handle.cancel() // just-in-case cleanup
 	<-exec.running
@@ -161,7 +161,7 @@ func TestConsulScript_Exec_TimeoutCritical(t *testing.T) {
 		Timeout:  time.Nanosecond,
 	}
 	hb := newFakeHeartbeater()
-	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, sleeperExec{}, hb, testlog.NewTest(t), nil)
+	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, sleeperExec{}, hb, testlog.New(t), nil)
 	handle := check.run()
 	defer handle.cancel() // just-in-case cleanup
 
@@ -206,7 +206,7 @@ func TestConsulScript_Exec_Shutdown(t *testing.T) {
 	hb := newFakeHeartbeater()
 	shutdown := make(chan struct{})
 	exec := newSimpleExec(0, nil)
-	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testlog.NewTest(t), shutdown)
+	check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testlog.New(t), shutdown)
 	handle := check.run()
 	defer handle.cancel() // just-in-case cleanup
 
@@ -243,7 +243,7 @@ func TestConsulScript_Exec_Codes(t *testing.T) {
 			hb := newFakeHeartbeater()
 			shutdown := make(chan struct{})
 			exec := newSimpleExec(code, err)
-			check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testlog.NewTest(t), shutdown)
+			check := newScriptCheck("allocid", "testtask", "checkid", &serviceCheck, exec, hb, testlog.New(t), shutdown)
 			handle := check.run()
 			defer handle.cancel()
 

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -3,9 +3,6 @@ package consul
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -14,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/kr/pretty"
 )
@@ -105,7 +103,7 @@ func (t *testFakeCtx) syncOnce() error {
 func setupFake(t *testing.T) *testFakeCtx {
 	fc := NewMockAgent()
 	return &testFakeCtx{
-		ServiceClient: NewServiceClient(fc, true, testlog.NewTest(t)),
+		ServiceClient: NewServiceClient(fc, true, testlog.New(t)),
 		FakeConsul:    fc,
 		Task:          testTask(),
 		Restarter:     &restartRecorder{},
@@ -966,7 +964,7 @@ func TestConsul_ShutdownBlocked(t *testing.T) {
 // TLSSkipVerify=true are skipped when Consul doesn't support TLSSkipVerify.
 func TestConsul_NoTLSSkipVerifySupport(t *testing.T) {
 	ctx := setupFake(t)
-	ctx.ServiceClient = NewServiceClient(ctx.FakeConsul, false, testlog.NewTest(t))
+	ctx.ServiceClient = NewServiceClient(ctx.FakeConsul, false, testlog.New(t))
 	ctx.Task.Services[0].Checks = []*structs.ServiceCheck{
 		// This check sets TLSSkipVerify so it should get dropped
 		{

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -26,7 +26,7 @@ import (
 // makeHTTPServer returns a test server whose logs will be written to
 // the passed writer. If the writer is nil, the logs are written to stderr.
 func makeHTTPServer(t testing.TB, cb func(c *Config)) *TestAgent {
-	return NewTestAgent(t.Name(), cb)
+	return NewTestAgent(t, cb)
 }
 
 func BenchmarkHTTPRequests(b *testing.B) {

--- a/command/agent/keyring_test.go
+++ b/command/agent/keyring_test.go
@@ -13,7 +13,7 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 	key := "tbLJg26ZJyJ9pK3qhc9jig=="
 
 	// Should be no configured keyring file by default
-	agent1 := NewTestAgent(t.Name(), nil)
+	agent1 := NewTestAgent(t, nil)
 	defer agent1.Shutdown()
 
 	c := agent1.server.GetConfig()

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -16,6 +16,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/client/fingerprint"
+	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -73,12 +74,22 @@ type TestAgent struct {
 	Token *structs.ACLToken
 }
 
+// TestingT is the subset of *testing.T needed by the TestAgent
+type TestingT interface {
+	Name() string
+	Logf(format string, args ...interface{})
+}
+
 // NewTestAgent returns a started agent with the given name and
 // configuration. It panics if the agent could not be started. The
 // caller should call Shutdown() to stop the agent and remove temporary
 // directories.
-func NewTestAgent(name string, configCallback func(*Config)) *TestAgent {
-	a := &TestAgent{Name: name, ConfigCallback: configCallback}
+func NewTestAgent(t TestingT, configCallback func(*Config)) *TestAgent {
+	a := &TestAgent{
+		Name:           t.Name(),
+		ConfigCallback: configCallback,
+		LogOutput:      testlog.NewWriter(t),
+	}
 	a.Start()
 	return a
 }

--- a/helper/testlog/testlog.go
+++ b/helper/testlog/testlog.go
@@ -1,0 +1,32 @@
+// Package testlog creates a *log.Logger backed by testing.T to ease logging in
+// tests.
+package testlog
+
+import (
+	"log"
+)
+
+// TestLogger is the methods of testing.T (or testing.B) needed by the test
+// logger.
+type TestLogger interface {
+	Logf(format string, args ...interface{})
+}
+
+type testWriter struct {
+	t TestLogger
+}
+
+func (w *testWriter) Write(p []byte) (n int, err error) {
+	w.t.Logf(string(p))
+	return len(p), nil
+}
+
+// New test logger. See https://golang.org/pkg/log/#New
+func New(t TestLogger, prefix string, flag int) *log.Logger {
+	return log.New(&testWriter{t}, prefix, flag)
+}
+
+// NewTest logger with "TEST" prefix and the Lmicroseconds flag.
+func NewTest(t TestLogger) *log.Logger {
+	return New(t, "TEST ", log.Lmicroseconds)
+}


### PR DESCRIPTION
Benefits:
- When in verbose logging mode with parallel tests, test logs are
  grouped by test.
- When not in verbose logging mode, log output is only printed for
  failed tests.
- No more copying and pasting testLogger() around.