### PR TITLE
qemu: Add bound checks for memory assignment

### DIFF
--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -170,7 +170,10 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 	if d.driverConfig.Accelerator != "" {
 		accelerator = d.driverConfig.Accelerator
 	}
-	// TODO: Check a lower bounds, e.g. the default 128 of Qemu
+
+	if task.Resources.MemoryMB <= 0 || task.Resources.MemoryMB > 4000000 {
+		return nil, fmt.Errorf("Qemu memory assignment out of bounds")
+	}
 	mem := fmt.Sprintf("%dM", task.Resources.MemoryMB)
 
 	absPath, err := GetAbsolutePath("qemu-system-x86_64")

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -74,17 +74,17 @@ func (d *QemuDriver) Validate(config map[string]interface{}) error {
 	fd := &fields.FieldData{
 		Raw: config,
 		Schema: map[string]*fields.FieldSchema{
-			"image_path": &fields.FieldSchema{
+			"image_path": {
 				Type:     fields.TypeString,
 				Required: true,
 			},
-			"accelerator": &fields.FieldSchema{
+			"accelerator": {
 				Type: fields.TypeString,
 			},
-			"port_map": &fields.FieldSchema{
+			"port_map": {
 				Type: fields.TypeArray,
 			},
-			"args": &fields.FieldSchema{
+			"args": {
 				Type: fields.TypeArray,
 			},
 		},

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -171,7 +171,7 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 		accelerator = d.driverConfig.Accelerator
 	}
 
-	if task.Resources.MemoryMB <= 0 || task.Resources.MemoryMB > 4000000 {
+	if task.Resources.MemoryMB < 128 || task.Resources.MemoryMB > 4000000 {
 		return nil, fmt.Errorf("Qemu memory assignment out of bounds")
 	}
 	mem := fmt.Sprintf("%dM", task.Resources.MemoryMB)

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -72,7 +72,7 @@ func TestQemuDriver_StartOpen_Wait(t *testing.T) {
 			CPU:      500,
 			MemoryMB: 512,
 			Networks: []*structs.NetworkResource{
-				&structs.NetworkResource{
+				{
 					ReservedPorts: []structs.Port{{Label: "main", Value: 22000}, {Label: "web", Value: 80}},
 				},
 			},
@@ -121,7 +121,7 @@ func TestQemuDriverUser(t *testing.T) {
 		t.Parallel()
 	}
 	ctestutils.QemuCompatible(t)
-	tasks := []*structs.Task{&structs.Task{
+	tasks := []*structs.Task{{
 		Name:   "linux",
 		Driver: "qemu",
 		User:   "alice",
@@ -143,13 +143,13 @@ func TestQemuDriverUser(t *testing.T) {
 			CPU:      500,
 			MemoryMB: 512,
 			Networks: []*structs.NetworkResource{
-				&structs.NetworkResource{
+				{
 					ReservedPorts: []structs.Port{{Label: "main", Value: 22000}, {Label: "web", Value: 80}},
 				},
 			},
 		},
 	},
-		&structs.Task{
+		{
 			Name:   "linux",
 			Driver: "qemu",
 			User:   "alice",
@@ -171,7 +171,7 @@ func TestQemuDriverUser(t *testing.T) {
 				CPU:      500,
 				MemoryMB: -1,
 				Networks: []*structs.NetworkResource{
-					&structs.NetworkResource{
+					{
 						ReservedPorts: []structs.Port{{Label: "main", Value: 22000}, {Label: "web", Value: 80}},
 					},
 				},

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -121,7 +121,7 @@ func TestQemuDriverUser(t *testing.T) {
 		t.Parallel()
 	}
 	ctestutils.QemuCompatible(t)
-	task := &structs.Task{
+	tasks := []*structs.Task{&structs.Task{
 		Name:   "linux",
 		Driver: "qemu",
 		User:   "alice",
@@ -133,6 +133,7 @@ func TestQemuDriverUser(t *testing.T) {
 				"web":  8080,
 			}},
 			"args": []string{"-nodefconfig", "-nodefaults"},
+			"msg":  "unknown user alice",
 		},
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
@@ -147,23 +148,54 @@ func TestQemuDriverUser(t *testing.T) {
 				},
 			},
 		},
+	},
+		&structs.Task{
+			Name:   "linux",
+			Driver: "qemu",
+			User:   "alice",
+			Config: map[string]interface{}{
+				"image_path":  "linux-0.2.img",
+				"accelerator": "tcg",
+				"port_map": []map[string]int{{
+					"main": 22,
+					"web":  8080,
+				}},
+				"args": []string{"-nodefconfig", "-nodefaults"},
+				"msg":  "Qemu memory assignment out of bounds",
+			},
+			LogConfig: &structs.LogConfig{
+				MaxFiles:      10,
+				MaxFileSizeMB: 10,
+			},
+			Resources: &structs.Resources{
+				CPU:      500,
+				MemoryMB: -1,
+				Networks: []*structs.NetworkResource{
+					&structs.NetworkResource{
+						ReservedPorts: []structs.Port{{Label: "main", Value: 22000}, {Label: "web", Value: 80}},
+					},
+				},
+			},
+		},
 	}
 
-	ctx := testDriverContexts(t, task)
-	defer ctx.AllocDir.Destroy()
-	d := NewQemuDriver(ctx.DriverCtx)
+	for _, task := range tasks {
+		ctx := testDriverContexts(t, task)
+		defer ctx.AllocDir.Destroy()
+		d := NewQemuDriver(ctx.DriverCtx)
 
-	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
-		t.Fatalf("Prestart faild: %v", err)
-	}
+		if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+			t.Fatalf("Prestart faild: %v", err)
+		}
 
-	resp, err := d.Start(ctx.ExecCtx, task)
-	if err == nil {
-		resp.Handle.Kill()
-		t.Fatalf("Should've failed")
-	}
-	msg := "unknown user alice"
-	if !strings.Contains(err.Error(), msg) {
-		t.Fatalf("Expecting '%v' in '%v'", msg, err)
+		resp, err := d.Start(ctx.ExecCtx, task)
+		if err == nil {
+			resp.Handle.Kill()
+			t.Fatalf("Should've failed")
+		}
+		msg := task.Config["msg"].(string)
+		if !strings.Contains(err.Error(), msg) {
+			t.Fatalf("Expecting '%v' in '%v'", msg, err)
+		}
 	}
 }


### PR DESCRIPTION
This PR add bounds checks for upper [[1]](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Virtualization_Administration_Guide/sect-mem-dump-off.html)  and lower possible memory
assignments to a virtual machine using the QEMU driver.

Signed-off-by: Simarpreet Singh <simar@linux.com>