### PR TITLE
Add ACL for job endpoint GetJobVersions

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -671,6 +671,13 @@ func (j *Job) GetJobVersions(args *structs.JobVersionsRequest,
 	}
 	defer metrics.MeasureSince([]string{"nomad", "job", "get_job_versions"}, time.Now())
 
+	// Check for read-job permissions
+	if aclObj, err := j.srv.resolveToken(args.SecretID); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
+		return structs.ErrPermissionDenied
+	}
+
 	// Setup the blocking query
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -450,9 +450,9 @@ The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and
 [required ACLs](/api/index.html#acls).
 
-| Blocking Queries | ACL Required |
-| ---------------- | ------------ |
-| `YES`            | `none`       |
+| Blocking Queries | ACL Required               |
+| ---------------- | -------------------------- |
+| `YES`            | `namespace:read-job`       |
 
 ### Parameters
 


### PR DESCRIPTION
This endpoint is undocumented, so this PR does not include ACL documentation. 