### PR TITLE
Allow querying self token

### DIFF
--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -509,6 +509,16 @@ func TestACLEndpoint_GetToken(t *testing.T) {
 	}
 	assert.Equal(t, uint64(1000), resp.Index)
 	assert.Nil(t, resp.Token)
+
+	// Lookup the token by accessor id using the tokens secret ID
+	get.AccessorID = token.AccessorID
+	get.SecretID = token.SecretID
+	var resp2 structs.SingleACLTokenResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetToken", get, &resp2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp2.Index)
+	assert.Equal(t, token, resp2.Token)
 }
 
 func TestACLEndpoint_GetToken_Blocking(t *testing.T) {

--- a/website/source/api/acl-tokens.html.md
+++ b/website/source/api/acl-tokens.html.md
@@ -241,7 +241,7 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | Consistency Modes | ACL Required |
 | ---------------- | ----------------- | ------------ |
-| `YES`            | `all`             | `management` |
+| `YES`            | `all`             | `management` for query other tokens<br>Matching SecretID to AccessorID for querying self |
 
 ### Sample Request
 

--- a/website/source/api/acl-tokens.html.md
+++ b/website/source/api/acl-tokens.html.md
@@ -241,7 +241,7 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | Consistency Modes | ACL Required |
 | ---------------- | ----------------- | ------------ |
-| `YES`            | `all`             | `management` for query other tokens<br>Matching SecretID to AccessorID for querying self |
+| `YES`            | `all`             | `management` or a SecretID matching the AccessorID |
 
 ### Sample Request
 


### PR DESCRIPTION
This PR allows querying self ACL token when the SecretID is for the
AccessorID in question.