### PR TITLE
Properly autodetect Docker IP in Windows

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -744,8 +744,9 @@ func (d *DockerDriver) detectIP(c *docker.Container) (string, bool) {
 		ip = net.IPAddress
 		ipName = name
 
-		// Don't auto-advertise bridge IPs
-		if name != "bridge" {
+		// Don't auto-advertise IPs for default networks (bridge on
+		// Linux, nat on Windows)
+		if name != "bridge" && name != "nat" {
 			auto = true
 		}
 

--- a/website/source/docs/job-specification/service.html.md
+++ b/website/source/docs/job-specification/service.html.md
@@ -106,6 +106,7 @@ does not automatically enable service discovery.
   behaves the same as `host` unless the driver determines its IP should be used.
   This setting was added in Nomad 0.6 and only supported by the Docker driver.
   It will advertise the container IP if a network plugin is used (e.g. weave).
+  Support was added to the rkt driver in 0.7.
 
 ### `check` Parameters
 

--- a/website/source/docs/job-specification/service.html.md
+++ b/website/source/docs/job-specification/service.html.md
@@ -104,9 +104,8 @@ does not automatically enable service discovery.
   and port. `driver` advertises the IP used in the driver (e.g. Docker's internal
   IP) and uses the ports specified in the port map. The default is `auto` which
   behaves the same as `host` unless the driver determines its IP should be used.
-  This setting was added in Nomad 0.6 and only supported by the Docker driver.
-  It will advertise the container IP if a network plugin is used (e.g. weave).
-  Support was added to the rkt driver in 0.7.
+  This setting supported Docker since Nomad 0.6 and rkt since Nomad 0.7. It
+  will advertise the container IP if a network plugin is used (e.g. weave).
 
 ### `check` Parameters
 


### PR DESCRIPTION
Our Docker network plugin autodetection code was erroneously treating
Window's default network `nat` as a plugin and defaulting to it instead
of the host.

Fixes #3218 

Tested manually.