### PR TITLE
Fix node requests being blocked by acl

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1310,11 +1310,11 @@ func (c *Client) watchAllocations(updates chan *allocUpdates) {
 	// be running on the Node to their AllocModifyIndex which is incremented
 	// when the allocation is updated by the servers.
 	req := structs.NodeSpecificRequest{
-		NodeID:   c.NodeID(),
-		SecretID: c.secretNodeID(),
+		NodeID: c.NodeID(),
 		QueryOptions: structs.QueryOptions{
 			Region:     c.Region(),
 			AllowStale: true,
+			SecretID:   c.secretNodeID(),
 		},
 	}
 	var resp structs.NodeClientAllocsResponse

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1253,9 +1253,9 @@ func TestClientEndpoint_GetClientAllocs(t *testing.T) {
 	// Lookup the allocs
 	get := &structs.NodeSpecificRequest{
 		NodeID:       node.ID,
-		SecretID:     node.SecretID,
 		QueryOptions: structs.QueryOptions{Region: "global"},
 	}
+	get.SecretID = node.SecretID
 	var resp2 structs.NodeClientAllocsResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Node.GetClientAllocs", get, &resp2); err != nil {
 		t.Fatalf("err: %v", err)
@@ -1327,14 +1327,14 @@ func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 
 	// Lookup the allocs in a blocking query
 	req := &structs.NodeSpecificRequest{
-		NodeID:   node.ID,
-		SecretID: node.SecretID,
+		NodeID: node.ID,
 		QueryOptions: structs.QueryOptions{
 			Region:        "global",
 			MinQueryIndex: 50,
 			MaxQueryTime:  time.Second,
 		},
 	}
+	req.SecretID = node.SecretID
 	var resp2 structs.NodeClientAllocsResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Node.GetClientAllocs", req, &resp2); err != nil {
 		t.Fatalf("err: %v", err)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -299,8 +299,7 @@ type NodeEvaluateRequest struct {
 
 // NodeSpecificRequest is used when we just need to specify a target node
 type NodeSpecificRequest struct {
-	NodeID   string
-	SecretID string
+	NodeID string
 	QueryOptions
 }
 


### PR DESCRIPTION
This PR fix a bug that made all request made to /v1/node/ fail with permission denied (when ACLs were active).

The problem was that the SecretID was being set on structs.NodeSpecificRequest.QueryOptions by HTTPServer.parse. But when used, the value on structs.NodeSpecificRequest was used instead. Being the later always empty.