### PR TITLE
Remove `structs` import from `api`

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -317,7 +317,7 @@ func TestClient_NodeClient(t *testing.T) {
 	http := "testdomain:4646"
 	tlsNode := func(string, *QueryOptions) (*Node, *QueryMeta, error) {
 		return &Node{
-			ID:         structs.GenerateUUID(),
+			ID:         uuid.Generate(),
 			Status:     "ready",
 			HTTPAddr:   http,
 			TLSEnabled: true,
@@ -325,7 +325,7 @@ func TestClient_NodeClient(t *testing.T) {
 	}
 	noTlsNode := func(string, *QueryOptions) (*Node, *QueryMeta, error) {
 		return &Node{
-			ID:         structs.GenerateUUID(),
+			ID:         uuid.Generate(),
 			Status:     "ready",
 			HTTPAddr:   http,
 			TLSEnabled: false,

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gorhill/cronexpr"
 	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 const (
@@ -330,6 +329,20 @@ type UpdateStrategy struct {
 	Canary          *int           `mapstructure:"canary"`
 }
 
+// DefaultUpdateStrategy provides a baseline that can be used to upgrade
+// jobs with the old policy or for populating field defaults.
+func DefaultUpdateStrategy() *UpdateStrategy {
+	return &UpdateStrategy{
+		Stagger:         helper.TimeToPtr(30 * time.Second),
+		MaxParallel:     helper.IntToPtr(1),
+		HealthCheck:     helper.StringToPtr("checks"),
+		MinHealthyTime:  helper.TimeToPtr(10 * time.Second),
+		HealthyDeadline: helper.TimeToPtr(5 * time.Minute),
+		AutoRevert:      helper.BoolToPtr(false),
+		Canary:          helper.IntToPtr(0),
+	}
+}
+
 func (u *UpdateStrategy) Copy() *UpdateStrategy {
 	if u == nil {
 		return nil
@@ -403,34 +416,34 @@ func (u *UpdateStrategy) Merge(o *UpdateStrategy) {
 }
 
 func (u *UpdateStrategy) Canonicalize() {
-	d := structs.DefaultUpdateStrategy
+	d := DefaultUpdateStrategy()
 
 	if u.MaxParallel == nil {
-		u.MaxParallel = helper.IntToPtr(d.MaxParallel)
+		u.MaxParallel = d.MaxParallel
 	}
 
 	if u.Stagger == nil {
-		u.Stagger = helper.TimeToPtr(d.Stagger)
+		u.Stagger = d.Stagger
 	}
 
 	if u.HealthCheck == nil {
-		u.HealthCheck = helper.StringToPtr(d.HealthCheck)
+		u.HealthCheck = d.HealthCheck
 	}
 
 	if u.HealthyDeadline == nil {
-		u.HealthyDeadline = helper.TimeToPtr(d.HealthyDeadline)
+		u.HealthyDeadline = d.HealthyDeadline
 	}
 
 	if u.MinHealthyTime == nil {
-		u.MinHealthyTime = helper.TimeToPtr(d.MinHealthyTime)
+		u.MinHealthyTime = d.MinHealthyTime
 	}
 
 	if u.AutoRevert == nil {
-		u.AutoRevert = helper.BoolToPtr(d.AutoRevert)
+		u.AutoRevert = d.AutoRevert
 	}
 
 	if u.Canary == nil {
-		u.Canary = helper.IntToPtr(d.Canary)
+		u.Canary = d.Canary
 	}
 }
 

--- a/api/jobs_testing.go
+++ b/api/jobs_testing.go
@@ -4,13 +4,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
 )
 
 func MockJob() *Job {
 	job := &Job{
 		Region:      helper.StringToPtr("global"),
-		ID:          helper.StringToPtr(structs.GenerateUUID()),
+		ID:          helper.StringToPtr(uuid.Generate()),
 		Name:        helper.StringToPtr("my-job"),
 		Type:        helper.StringToPtr("service"),
 		Priority:    helper.IntToPtr(50),

--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -160,7 +161,7 @@ func TestClient_ACL_ResolveToken(t *testing.T) {
 	}
 
 	// Test bad token
-	out4, err := c1.ResolveToken(structs.GenerateUUID())
+	out4, err := c1.ResolveToken(uuid.Generate())
 	assert.Equal(t, structs.ErrTokenNotFound, err)
 	assert.Nil(t, out4)
 }

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/command/agent/consul"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -122,7 +123,7 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_BadStart(t *testing.T) {
 	task.Config["start_error"] = "test error"
 
 	// Make the alloc be part of a deployment
-	ar.alloc.DeploymentID = structs.GenerateUUID()
+	ar.alloc.DeploymentID = uuid.Generate()
 	ar.alloc.Job.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	ar.alloc.Job.TaskGroups[0].Update.HealthCheck = structs.UpdateStrategyHealthCheck_TaskStates
 	ar.alloc.Job.TaskGroups[0].Update.MaxParallel = 1
@@ -171,7 +172,7 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_Deadline(t *testing.T) {
 	task.Config["run_for"] = "10s"
 
 	// Make the alloc be part of a deployment
-	ar.alloc.DeploymentID = structs.GenerateUUID()
+	ar.alloc.DeploymentID = uuid.Generate()
 	ar.alloc.Job.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	ar.alloc.Job.TaskGroups[0].Update.HealthCheck = structs.UpdateStrategyHealthCheck_TaskStates
 	ar.alloc.Job.TaskGroups[0].Update.MaxParallel = 1
@@ -224,7 +225,7 @@ func TestAllocRunner_DeploymentHealth_Healthy_NoChecks(t *testing.T) {
 	task2.Config["start_block_for"] = "500ms"
 
 	// Make the alloc be part of a deployment
-	ar.alloc.DeploymentID = structs.GenerateUUID()
+	ar.alloc.DeploymentID = uuid.Generate()
 	ar.alloc.Job.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	ar.alloc.Job.TaskGroups[0].Update.HealthCheck = structs.UpdateStrategyHealthCheck_TaskStates
 	ar.alloc.Job.TaskGroups[0].Update.MaxParallel = 1
@@ -272,14 +273,14 @@ func TestAllocRunner_DeploymentHealth_Healthy_Checks(t *testing.T) {
 	task2.Services = nil
 
 	// Make the alloc be part of a deployment
-	ar.alloc.DeploymentID = structs.GenerateUUID()
+	ar.alloc.DeploymentID = uuid.Generate()
 	ar.alloc.Job.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	ar.alloc.Job.TaskGroups[0].Update.HealthCheck = structs.UpdateStrategyHealthCheck_Checks
 	ar.alloc.Job.TaskGroups[0].Update.MaxParallel = 1
 	ar.alloc.Job.TaskGroups[0].Update.MinHealthyTime = 100 * time.Millisecond
 
 	checkHealthy := &api.AgentCheck{
-		CheckID: structs.GenerateUUID(),
+		CheckID: uuid.Generate(),
 		Status:  api.HealthPassing,
 	}
 	checkUnhealthy := &api.AgentCheck{
@@ -359,7 +360,7 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_Checks(t *testing.T) {
 	task.Config["run_for"] = "10s"
 
 	// Make the alloc be part of a deployment
-	ar.alloc.DeploymentID = structs.GenerateUUID()
+	ar.alloc.DeploymentID = uuid.Generate()
 	ar.alloc.Job.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	ar.alloc.Job.TaskGroups[0].Update.HealthCheck = structs.UpdateStrategyHealthCheck_Checks
 	ar.alloc.Job.TaskGroups[0].Update.MaxParallel = 1
@@ -367,7 +368,7 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_Checks(t *testing.T) {
 	ar.alloc.Job.TaskGroups[0].Update.HealthyDeadline = 1 * time.Second
 
 	checkUnhealthy := &api.AgentCheck{
-		CheckID: structs.GenerateUUID(),
+		CheckID: uuid.Generate(),
 		Status:  api.HealthWarning,
 	}
 
@@ -428,7 +429,7 @@ func TestAllocRunner_DeploymentHealth_Healthy_UpdatedDeployment(t *testing.T) {
 	task.Config["run_for"] = "30s"
 
 	// Make the alloc be part of a deployment
-	ar.alloc.DeploymentID = structs.GenerateUUID()
+	ar.alloc.DeploymentID = uuid.Generate()
 	ar.alloc.Job.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	ar.alloc.Job.TaskGroups[0].Update.HealthCheck = structs.UpdateStrategyHealthCheck_TaskStates
 	ar.alloc.Job.TaskGroups[0].Update.MaxParallel = 1
@@ -455,7 +456,7 @@ func TestAllocRunner_DeploymentHealth_Healthy_UpdatedDeployment(t *testing.T) {
 	// Mimick an update to a new deployment id
 	oldCount, last := upd.Last()
 	last.DeploymentStatus = nil
-	last.DeploymentID = structs.GenerateUUID()
+	last.DeploymentID = uuid.Generate()
 	ar.Update(last)
 
 	testutil.WaitForResult(func() (bool, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/tlsutil"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/structs"
 	vaultapi "github.com/hashicorp/vault/api"
@@ -733,12 +734,12 @@ func (c *Client) nodeID() (id, secret string, err error) {
 	if hostID == "" {
 		// Generate a random hostID if no constant ID is available on
 		// this platform.
-		hostID = structs.GenerateUUID()
+		hostID = uuid.Generate()
 	}
 
 	// Do not persist in dev mode
 	if c.config.DevMode {
-		return hostID, structs.GenerateUUID(), nil
+		return hostID, uuid.Generate(), nil
 	}
 
 	// Attempt to read existing ID
@@ -771,7 +772,7 @@ func (c *Client) nodeID() (id, secret string, err error) {
 		secret = string(secretBuf)
 	} else {
 		// Generate new ID
-		secret = structs.GenerateUUID()
+		secret = uuid.Generate()
 
 		// Persist the ID
 		if err := ioutil.WriteFile(secretPath, []byte(secret), 0700); err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad/client/fingerprint"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -908,7 +909,7 @@ func TestClient_BlockedAllocations(t *testing.T) {
 
 	// Add a new chained alloc
 	alloc2 := alloc.Copy()
-	alloc2.ID = structs.GenerateUUID()
+	alloc2.ID = uuid.Generate()
 	alloc2.Job = alloc.Job
 	alloc2.JobID = alloc.JobID
 	alloc2.PreviousAllocation = alloc.ID

--- a/client/driver/docker_coordinator_test.go
+++ b/client/driver/docker_coordinator_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/testutil"
 )
 
@@ -46,7 +46,7 @@ func (m *mockImageClient) RemoveImage(id string) error {
 func TestDockerCoordinator_ConcurrentPulls(t *testing.T) {
 	t.Parallel()
 	image := "foo"
-	imageID := structs.GenerateUUID()
+	imageID := uuid.Generate()
 	mapping := map[string]string{imageID: image}
 
 	// Add a delay so we can get multiple queued up
@@ -64,7 +64,7 @@ func TestDockerCoordinator_ConcurrentPulls(t *testing.T) {
 	id := ""
 	for i := 0; i < 10; i++ {
 		go func() {
-			id, _ = coordinator.PullImage(image, nil, structs.GenerateUUID())
+			id, _ = coordinator.PullImage(image, nil, uuid.Generate())
 		}()
 	}
 
@@ -93,7 +93,7 @@ func TestDockerCoordinator_ConcurrentPulls(t *testing.T) {
 func TestDockerCoordinator_Pull_Remove(t *testing.T) {
 	t.Parallel()
 	image := "foo"
-	imageID := structs.GenerateUUID()
+	imageID := uuid.Generate()
 	mapping := map[string]string{imageID: image}
 
 	// Add a delay so we can get multiple queued up
@@ -111,7 +111,7 @@ func TestDockerCoordinator_Pull_Remove(t *testing.T) {
 	id := ""
 	callerIDs := make([]string, 10, 10)
 	for i := 0; i < 10; i++ {
-		callerIDs[i] = structs.GenerateUUID()
+		callerIDs[i] = uuid.Generate()
 		id, _ = coordinator.PullImage(image, nil, callerIDs[i])
 	}
 
@@ -157,7 +157,7 @@ func TestDockerCoordinator_Pull_Remove(t *testing.T) {
 func TestDockerCoordinator_Remove_Cancel(t *testing.T) {
 	t.Parallel()
 	image := "foo"
-	imageID := structs.GenerateUUID()
+	imageID := uuid.Generate()
 	mapping := map[string]string{imageID: image}
 
 	mock := newMockImageClient(mapping, 1*time.Millisecond)
@@ -170,7 +170,7 @@ func TestDockerCoordinator_Remove_Cancel(t *testing.T) {
 
 	// Create a coordinator
 	coordinator := NewDockerCoordinator(config)
-	callerID := structs.GenerateUUID()
+	callerID := uuid.Generate()
 
 	// Pull image
 	id, _ := coordinator.PullImage(image, nil, callerID)
@@ -205,7 +205,7 @@ func TestDockerCoordinator_Remove_Cancel(t *testing.T) {
 func TestDockerCoordinator_No_Cleanup(t *testing.T) {
 	t.Parallel()
 	image := "foo"
-	imageID := structs.GenerateUUID()
+	imageID := uuid.Generate()
 	mapping := map[string]string{imageID: image}
 
 	mock := newMockImageClient(mapping, 1*time.Millisecond)
@@ -218,7 +218,7 @@ func TestDockerCoordinator_No_Cleanup(t *testing.T) {
 
 	// Create a coordinator
 	coordinator := NewDockerCoordinator(config)
-	callerID := structs.GenerateUUID()
+	callerID := uuid.Generate()
 
 	// Pull image
 	id, _ := coordinator.PullImage(image, nil, callerID)

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/nomad/client/driver/env"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	tu "github.com/hashicorp/nomad/testutil"
@@ -1234,7 +1235,7 @@ func setupDockerVolumes(t *testing.T, cfg *config.Config, hostpath string) (*str
 	}
 
 	// Build alloc and task directory structure
-	allocDir := allocdir.NewAllocDir(testLogger(), filepath.Join(cfg.AllocDir, structs.GenerateUUID()))
+	allocDir := allocdir.NewAllocDir(testLogger(), filepath.Join(cfg.AllocDir, uuid.Generate()))
 	if err := allocDir.Build(); err != nil {
 		t.Fatalf("failed to build alloc dir: %v", err)
 	}

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/driver/env"
 	"github.com/hashicorp/nomad/helper/testtask"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -92,7 +93,7 @@ type testContext struct {
 func testDriverContexts(t *testing.T, task *structs.Task) *testContext {
 	cfg := testConfig()
 	cfg.Node = mock.Node()
-	allocDir := allocdir.NewAllocDir(testLogger(), filepath.Join(cfg.AllocDir, structs.GenerateUUID()))
+	allocDir := allocdir.NewAllocDir(testLogger(), filepath.Join(cfg.AllocDir, uuid.Generate()))
 	if err := allocDir.Build(); err != nil {
 		t.Fatalf("AllocDir.Build() failed: %v", err)
 	}

--- a/client/driver/executor/executor_linux.go
+++ b/client/driver/executor/executor_linux.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hashicorp/nomad/client/stats"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -72,7 +73,7 @@ func (e *UniversalExecutor) applyLimits(pid int) error {
 func (e *UniversalExecutor) configureCgroups(resources *structs.Resources) error {
 	e.resConCtx.groups = &cgroupConfig.Cgroup{}
 	e.resConCtx.groups.Resources = &cgroupConfig.Resources{}
-	cgroupName := structs.GenerateUUID()
+	cgroupName := uuid.Generate()
 	e.resConCtx.groups.Path = filepath.Join("/nomad", cgroupName)
 
 	// TODO: verify this is needed for things like network access

--- a/client/util_test.go
+++ b/client/util_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -57,7 +58,7 @@ func TestShuffleStrings(t *testing.T) {
 	// Generate input
 	inp := make([]string, 10)
 	for idx := range inp {
-		inp[idx] = structs.GenerateUUID()
+		inp[idx] = uuid.Generate()
 	}
 
 	// Copy the input

--- a/client/vaultclient/vaultclient_testing.go
+++ b/client/vaultclient/vaultclient_testing.go
@@ -1,6 +1,7 @@
 package vaultclient
 
 import (
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	vaultapi "github.com/hashicorp/vault/api"
 )
@@ -44,7 +45,7 @@ func (vc *MockVaultClient) DeriveToken(a *structs.Allocation, tasks []string) (m
 			}
 		}
 
-		tokens[task] = structs.GenerateUUID()
+		tokens[task] = uuid.Generate()
 	}
 
 	return tokens, nil

--- a/helper/uuid/uuid.go
+++ b/helper/uuid/uuid.go
@@ -1,0 +1,21 @@
+package uuid
+
+import (
+	crand "crypto/rand"
+	"fmt"
+)
+
+// Generate is used to generate a random UUID
+func Generate() string {
+	buf := make([]byte, 16)
+	if _, err := crand.Read(buf); err != nil {
+		panic(fmt.Errorf("failed to read random bytes: %v", err))
+	}
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
+		buf[0:4],
+		buf[4:6],
+		buf[6:8],
+		buf[8:10],
+		buf[10:16])
+}

--- a/helper/uuid/uuid_test.go
+++ b/helper/uuid/uuid_test.go
@@ -1,0 +1,22 @@
+package uuid
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	prev := Generate()
+	for i := 0; i < 100; i++ {
+		id := Generate()
+		if prev == id {
+			t.Fatalf("Should get a new ID!")
+		}
+
+		matched, err := regexp.MatchString(
+			"[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}", id)
+		if !matched || err != nil {
+			t.Fatalf("expected match %s %v %s", id, matched, err)
+		}
+	}
+}

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -9,6 +9,7 @@ import (
 
 	metrics "github.com/armon/go-metrics"
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -313,8 +314,8 @@ func (a *ACL) Bootstrap(args *structs.ACLTokenBootstrapRequest, reply *structs.A
 
 	// Create a new global management token, override any parameter
 	args.Token = &structs.ACLToken{
-		AccessorID: structs.GenerateUUID(),
-		SecretID:   structs.GenerateUUID(),
+		AccessorID: uuid.Generate(),
+		SecretID:   uuid.Generate(),
 		Name:       "Bootstrap Token",
 		Type:       structs.ACLManagementToken,
 		Global:     true,
@@ -431,8 +432,8 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.A
 
 		// Generate an accessor and secret ID if new
 		if token.AccessorID == "" {
-			token.AccessorID = structs.GenerateUUID()
-			token.SecretID = structs.GenerateUUID()
+			token.AccessorID = uuid.Generate()
+			token.SecretID = uuid.Generate()
 			token.CreateTime = time.Now().UTC()
 
 		} else {

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -43,7 +44,7 @@ func TestACLEndpoint_GetPolicy(t *testing.T) {
 	assert.Equal(t, policy, resp.Policy)
 
 	// Lookup non-existing policy
-	get.Name = structs.GenerateUUID()
+	get.Name = uuid.Generate()
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetPolicy", get, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -160,7 +161,7 @@ func TestACLEndpoint_GetPolicies(t *testing.T) {
 	assert.Equal(t, policy2, resp.Policies[policy2.Name])
 
 	// Lookup non-existing policy
-	get.Names = []string{structs.GenerateUUID()}
+	get.Names = []string{uuid.Generate()}
 	resp = structs.ACLPolicySetResponse{}
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetPolicies", get, &resp); err != nil {
 		t.Fatalf("err: %v", err)
@@ -503,7 +504,7 @@ func TestACLEndpoint_GetToken(t *testing.T) {
 	assert.Equal(t, token, resp.Token)
 
 	// Lookup non-existing token
-	get.AccessorID = structs.GenerateUUID()
+	get.AccessorID = uuid.Generate()
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetToken", get, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -619,7 +620,7 @@ func TestACLEndpoint_GetTokens(t *testing.T) {
 	assert.Equal(t, token, resp.Tokens[token.AccessorID])
 
 	// Lookup non-existing token
-	get.AccessorIDS = []string{structs.GenerateUUID()}
+	get.AccessorIDS = []string{uuid.Generate()}
 	resp = structs.ACLTokenSetResponse{}
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetTokens", get, &resp); err != nil {
 		t.Fatalf("err: %v", err)
@@ -1060,7 +1061,7 @@ func TestACLEndpoint_ResolveToken(t *testing.T) {
 	assert.Equal(t, token, resp.Token)
 
 	// Lookup non-existing token
-	get.SecretID = structs.GenerateUUID()
+	get.SecretID = uuid.Generate()
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.ResolveToken", get, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -6,6 +6,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -41,7 +42,7 @@ func TestResolveACLToken(t *testing.T) {
 	assert.NotNil(t, aclObj)
 
 	// Attempt resolution of unknown token. Should fail.
-	randID := structs.GenerateUUID()
+	randID := uuid.Generate()
 	aclObj, err = resolveTokenFromSnapshotCache(snap, cache, randID)
 	assert.Equal(t, structs.ErrTokenNotFound, err)
 	assert.Nil(t, aclObj)

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -10,6 +10,7 @@ import (
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -445,7 +446,7 @@ func (w *deploymentWatcher) createEvalBatched(forIndex uint64) {
 // getEval returns an evaluation suitable for the deployment
 func (w *deploymentWatcher) getEval() *structs.Evaluation {
 	return &structs.Evaluation{
-		ID:           structs.GenerateUUID(),
+		ID:           uuid.Generate(),
 		Namespace:    w.j.Namespace,
 		Priority:     w.j.Priority,
 		Type:         w.j.Type,

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -7,6 +7,7 @@ import (
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -83,13 +84,13 @@ func TestWatcher_UnknownDeployment(t *testing.T) {
 	w.SetEnabled(true, m.state)
 
 	// The expected error is that it should be an unknown deployment
-	dID := structs.GenerateUUID()
+	dID := uuid.Generate()
 	expected := fmt.Sprintf("unknown deployment %q", dID)
 
 	// Request setting the health against an unknown deployment
 	req := &structs.DeploymentAllocHealthRequest{
 		DeploymentID:         dID,
-		HealthyAllocationIDs: []string{structs.GenerateUUID()},
+		HealthyAllocationIDs: []string{uuid.Generate()},
 	}
 	var resp structs.DeploymentUpdateResponse
 	err := w.SetAllocHealth(req, &resp)

--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -383,7 +384,7 @@ func (b *EvalBroker) dequeueForSched(sched string) (*structs.Evaluation, string,
 	eval := raw.(*structs.Evaluation)
 
 	// Generate a UUID for the token
-	token := structs.GenerateUUID()
+	token := uuid.Generate()
 
 	// Setup Nack timer
 	nackTimer := time.AfterFunc(b.nackTimeout, func() {

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -9,6 +9,7 @@ import (
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler"
@@ -44,7 +45,7 @@ func TestEvalEndpoint_GetEval(t *testing.T) {
 	}
 
 	// Lookup non-existing node
-	get.EvalID = structs.GenerateUUID()
+	get.EvalID = uuid.Generate()
 	if err := msgpackrpc.CallWithCodec(codec, "Eval.GetEval", get, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler"
@@ -1095,7 +1096,7 @@ func (n *nomadFSM) reconcileQueuedAllocations(index uint64) error {
 		}
 		// Create an eval and mark it as requiring annotations and insert that as well
 		eval := &structs.Evaluation{
-			ID:             structs.GenerateUUID(),
+			ID:             uuid.Generate(),
 			Namespace:      job.Namespace,
 			Priority:       job.Priority,
 			Type:           job.Type,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/client/driver"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler"
@@ -201,7 +202,7 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 
 	// Create a new evaluation
 	eval := &structs.Evaluation{
-		ID:             structs.GenerateUUID(),
+		ID:             uuid.Generate(),
 		Namespace:      args.RequestNamespace(),
 		Priority:       args.Job.Priority,
 		Type:           args.Job.Type,
@@ -531,7 +532,7 @@ func (j *Job) Evaluate(args *structs.JobEvaluateRequest, reply *structs.JobRegis
 
 	// Create a new evaluation
 	eval := &structs.Evaluation{
-		ID:             structs.GenerateUUID(),
+		ID:             uuid.Generate(),
 		Namespace:      args.RequestNamespace(),
 		Priority:       job.Priority,
 		Type:           job.Type,
@@ -610,7 +611,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 	// priority even if the job was. The scheduler itself also doesn't matter,
 	// since all should be able to handle deregistration in the same way.
 	eval := &structs.Evaluation{
-		ID:             structs.GenerateUUID(),
+		ID:             uuid.Generate(),
 		Namespace:      args.RequestNamespace(),
 		Priority:       structs.JobDefaultPriority,
 		Type:           structs.JobTypeService,
@@ -1062,7 +1063,7 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 
 	// Create an eval and mark it as requiring annotations and insert that as well
 	eval := &structs.Evaluation{
-		ID:             structs.GenerateUUID(),
+		ID:             uuid.Generate(),
 		Namespace:      args.RequestNamespace(),
 		Priority:       args.Job.Priority,
 		Type:           args.Job.Type,
@@ -1296,7 +1297,7 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 	if !dispatchJob.IsPeriodic() {
 		// Create a new evaluation
 		eval := &structs.Evaluation{
-			ID:             structs.GenerateUUID(),
+			ID:             uuid.Generate(),
 			Namespace:      args.RequestNamespace(),
 			Priority:       dispatchJob.Priority,
 			Type:           dispatchJob.Type,

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -11,6 +11,7 @@ import (
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -735,19 +736,19 @@ func TestJobEndpoint_Register_Vault_Policies(t *testing.T) {
 	// not and one that returns an error
 	policy := "foo"
 
-	badToken := structs.GenerateUUID()
+	badToken := uuid.Generate()
 	badPolicies := []string{"a", "b", "c"}
 	tvc.SetLookupTokenAllowedPolicies(badToken, badPolicies)
 
-	goodToken := structs.GenerateUUID()
+	goodToken := uuid.Generate()
 	goodPolicies := []string{"foo", "bar", "baz"}
 	tvc.SetLookupTokenAllowedPolicies(goodToken, goodPolicies)
 
-	rootToken := structs.GenerateUUID()
+	rootToken := uuid.Generate()
 	rootPolicies := []string{"root"}
 	tvc.SetLookupTokenAllowedPolicies(rootToken, rootPolicies)
 
-	errToken := structs.GenerateUUID()
+	errToken := uuid.Generate()
 	expectedErr := fmt.Errorf("return errors from vault")
 	tvc.SetLookupTokenError(errToken, expectedErr)
 
@@ -3471,7 +3472,7 @@ func TestJobEndpoint_ImplicitConstraints_Vault(t *testing.T) {
 	s1.vault = tvc
 
 	policy := "foo"
-	goodToken := structs.GenerateUUID()
+	goodToken := uuid.Generate()
 	goodPolicies := []string{"foo", "bar", "baz"}
 	tvc.SetLookupTokenAllowedPolicies(goodToken, goodPolicies)
 

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/raft"
@@ -406,7 +407,7 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 // coreJobEval returns an evaluation for a core job
 func (s *Server) coreJobEval(job string, modifyIndex uint64) *structs.Evaluation {
 	return &structs.Evaluation{
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Namespace:   "-",
 		Priority:    structs.CoreJobPriority,
 		Type:        structs.JobTypeCore,

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 func Node() *structs.Node {
 	node := &structs.Node{
-		ID:         structs.GenerateUUID(),
-		SecretID:   structs.GenerateUUID(),
+		ID:         uuid.Generate(),
+		SecretID:   uuid.Generate(),
 		Datacenter: "dc1",
 		Name:       "foobar",
 		Attributes: map[string]string{
@@ -63,7 +64,7 @@ func Node() *structs.Node {
 func Job() *structs.Job {
 	job := &structs.Job{
 		Region:      "global",
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Name:        "my-job",
 		Namespace:   structs.DefaultNamespace,
 		Type:        structs.JobTypeService,
@@ -161,7 +162,7 @@ func SystemJob() *structs.Job {
 	job := &structs.Job{
 		Region:      "global",
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Name:        "my-job",
 		Type:        structs.JobTypeSystem,
 		Priority:    100,
@@ -233,11 +234,11 @@ func PeriodicJob() *structs.Job {
 
 func Eval() *structs.Evaluation {
 	eval := &structs.Evaluation{
-		ID:        structs.GenerateUUID(),
+		ID:        uuid.Generate(),
 		Namespace: structs.DefaultNamespace,
 		Priority:  50,
 		Type:      structs.JobTypeService,
-		JobID:     structs.GenerateUUID(),
+		JobID:     uuid.Generate(),
 		Status:    structs.EvalStatusPending,
 	}
 	return eval
@@ -259,8 +260,8 @@ func JobSummary(jobID string) *structs.JobSummary {
 
 func Alloc() *structs.Allocation {
 	alloc := &structs.Allocation{
-		ID:        structs.GenerateUUID(),
-		EvalID:    structs.GenerateUUID(),
+		ID:        uuid.Generate(),
+		EvalID:    uuid.Generate(),
 		NodeID:    "12345678-abcd-efab-cdef-123456789abc",
 		Namespace: structs.DefaultNamespace,
 		TaskGroup: "web",
@@ -306,9 +307,9 @@ func Alloc() *structs.Allocation {
 
 func VaultAccessor() *structs.VaultAccessor {
 	return &structs.VaultAccessor{
-		Accessor:    structs.GenerateUUID(),
-		NodeID:      structs.GenerateUUID(),
-		AllocID:     structs.GenerateUUID(),
+		Accessor:    uuid.Generate(),
+		NodeID:      uuid.Generate(),
+		AllocID:     uuid.Generate(),
 		CreationTTL: 86400,
 		Task:        "foo",
 	}
@@ -316,8 +317,8 @@ func VaultAccessor() *structs.VaultAccessor {
 
 func Deployment() *structs.Deployment {
 	return &structs.Deployment{
-		ID:             structs.GenerateUUID(),
-		JobID:          structs.GenerateUUID(),
+		ID:             uuid.Generate(),
+		JobID:          uuid.Generate(),
 		Namespace:      structs.DefaultNamespace,
 		JobVersion:     2,
 		JobModifyIndex: 20,
@@ -346,7 +347,7 @@ func PlanResult() *structs.PlanResult {
 
 func ACLPolicy() *structs.ACLPolicy {
 	ap := &structs.ACLPolicy{
-		Name:        fmt.Sprintf("policy-%s", structs.GenerateUUID()),
+		Name:        fmt.Sprintf("policy-%s", uuid.Generate()),
 		Description: "Super cool policy!",
 		Rules: `
 		namespace "default" {
@@ -368,9 +369,9 @@ func ACLPolicy() *structs.ACLPolicy {
 
 func ACLToken() *structs.ACLToken {
 	tk := &structs.ACLToken{
-		AccessorID:  structs.GenerateUUID(),
-		SecretID:    structs.GenerateUUID(),
-		Name:        "my cool token " + structs.GenerateUUID(),
+		AccessorID:  uuid.Generate(),
+		SecretID:    uuid.Generate(),
+		Name:        "my cool token " + uuid.Generate(),
 		Type:        "client",
 		Policies:    []string{"foo", "bar"},
 		Global:      false,
@@ -384,9 +385,9 @@ func ACLToken() *structs.ACLToken {
 
 func ACLManagementToken() *structs.ACLToken {
 	return &structs.ACLToken{
-		AccessorID:  structs.GenerateUUID(),
-		SecretID:    structs.GenerateUUID(),
-		Name:        "management " + structs.GenerateUUID(),
+		AccessorID:  uuid.Generate(),
+		SecretID:    uuid.Generate(),
+		Name:        "management " + uuid.Generate(),
 		Type:        "management",
 		Global:      true,
 		CreateTime:  time.Now().UTC(),

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/raft"
@@ -909,7 +910,7 @@ func (n *Node) createNodeEvals(nodeID string, nodeIndex uint64) ([]string, uint6
 
 		// Create a new eval
 		eval := &structs.Evaluation{
-			ID:              structs.GenerateUUID(),
+			ID:              uuid.Generate(),
 			Namespace:       alloc.Namespace,
 			Priority:        alloc.Job.Priority,
 			Type:            alloc.Job.Type,
@@ -933,7 +934,7 @@ func (n *Node) createNodeEvals(nodeID string, nodeIndex uint64) ([]string, uint6
 
 		// Create a new eval
 		eval := &structs.Evaluation{
-			ID:              structs.GenerateUUID(),
+			ID:              uuid.Generate(),
 			Namespace:       job.Namespace,
 			Priority:        job.Priority,
 			Type:            job.Type,

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -10,6 +10,7 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -128,7 +129,7 @@ func TestClientEndpoint_Register_SecretMismatch(t *testing.T) {
 	}
 
 	// Update the nodes SecretID
-	node.SecretID = structs.GenerateUUID()
+	node.SecretID = uuid.Generate()
 	err := msgpackrpc.CallWithCodec(codec, "Node.Register", req, &resp)
 	if err == nil || !strings.Contains(err.Error(), "Not registering") {
 		t.Fatalf("Expecting error regarding mismatching secret id: %v", err)
@@ -1277,7 +1278,7 @@ func TestClientEndpoint_GetClientAllocs(t *testing.T) {
 	}
 
 	// Lookup non-existing node
-	get.NodeID = structs.GenerateUUID()
+	get.NodeID = uuid.Generate()
 	var resp4 structs.NodeClientAllocsResponse
 	if err := msgpackrpc.CallWithCodec(codec, "Node.GetClientAllocs", get, &resp4); err != nil {
 		t.Fatalf("err: %v", err)
@@ -2179,7 +2180,7 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 
 	req := &structs.DeriveVaultTokenRequest{
 		NodeID:   node.ID,
-		SecretID: structs.GenerateUUID(),
+		SecretID: uuid.Generate(),
 		AllocID:  alloc.ID,
 		Tasks:    tasks,
 		QueryOptions: structs.QueryOptions{
@@ -2270,8 +2271,8 @@ func TestClientEndpoint_DeriveVaultToken(t *testing.T) {
 	}
 
 	// Return a secret for the task
-	token := structs.GenerateUUID()
-	accessor := structs.GenerateUUID()
+	token := uuid.Generate()
+	accessor := uuid.Generate()
 	ttl := 10
 	secret := &vapi.Secret{
 		WrapInfo: &vapi.SecretWrapInfo{

--- a/nomad/periodic.go
+++ b/nomad/periodic.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -62,7 +63,7 @@ func (s *Server) DispatchJob(job *structs.Job) (*structs.Evaluation, error) {
 
 	// Create a new evaluation
 	eval := &structs.Evaluation{
-		ID:             structs.GenerateUUID(),
+		ID:             uuid.Generate(),
 		Namespace:      job.Namespace,
 		Priority:       job.Priority,
 		Type:           job.Type,

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -253,7 +254,7 @@ func TestPlanApply_EvalPlan_Simple(t *testing.T) {
 		Deployment: mock.Deployment(),
 		DeploymentUpdates: []*structs.DeploymentStatusUpdate{
 			{
-				DeploymentID:      structs.GenerateUUID(),
+				DeploymentID:      uuid.Generate(),
 				Status:            "foo",
 				StatusDescription: "bar",
 			},
@@ -359,7 +360,7 @@ func TestPlanApply_EvalPlan_Partial_AllAtOnce(t *testing.T) {
 		Deployment: mock.Deployment(),
 		DeploymentUpdates: []*structs.DeploymentStatusUpdate{
 			{
-				DeploymentID:      structs.GenerateUUID(),
+				DeploymentID:      uuid.Generate(),
 				Status:            "foo",
 				StatusDescription: "bar",
 			},

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/command/agent/consul"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -267,7 +268,7 @@ func TestServer_Reload_Vault(t *testing.T) {
 	tr := true
 	config := s1.config
 	config.VaultConfig.Enabled = &tr
-	config.VaultConfig.Token = structs.GenerateUUID()
+	config.VaultConfig.Token = uuid.Generate()
 
 	if err := s1.Reload(config); err != nil {
 		t.Fatalf("Reload failed: %v", err)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -12,6 +12,7 @@ import (
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/assert"
@@ -205,7 +206,7 @@ func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
 
 	// Update the allocs to be part of a new deployment
 	d2 := d.Copy()
-	d2.ID = structs.GenerateUUID()
+	d2.ID = uuid.Generate()
 
 	allocNew := alloc.Copy()
 	allocNew.DeploymentID = d2.ID
@@ -4904,7 +4905,7 @@ func TestStateStore_UpsertDeploymentStatusUpdate_NonExistent(t *testing.T) {
 	// Update the non-existent deployment
 	req := &structs.DeploymentStatusUpdateRequest{
 		DeploymentUpdate: &structs.DeploymentStatusUpdate{
-			DeploymentID: structs.GenerateUUID(),
+			DeploymentID: uuid.Generate(),
 			Status:       structs.DeploymentStatusRunning,
 		},
 	}
@@ -5114,7 +5115,7 @@ func TestStateStore_UpsertDeploymentPromotion_NonExistent(t *testing.T) {
 	// Promote the non-existent deployment
 	req := &structs.ApplyDeploymentPromoteRequest{
 		DeploymentPromoteRequest: structs.DeploymentPromoteRequest{
-			DeploymentID: structs.GenerateUUID(),
+			DeploymentID: uuid.Generate(),
 			All:          true,
 		},
 	}
@@ -5431,8 +5432,8 @@ func TestStateStore_UpsertDeploymentAllocHealth_NonExistent(t *testing.T) {
 	// Set health against the non-existent deployment
 	req := &structs.ApplyDeploymentAllocHealthRequest{
 		DeploymentAllocHealthRequest: structs.DeploymentAllocHealthRequest{
-			DeploymentID:         structs.GenerateUUID(),
-			HealthyAllocationIDs: []string{structs.GenerateUUID()},
+			DeploymentID:         uuid.Generate(),
+			HealthyAllocationIDs: []string{uuid.Generate()},
 		},
 	}
 	err := state.UpdateDeploymentAllocHealth(2, req)
@@ -5457,7 +5458,7 @@ func TestStateStore_UpsertDeploymentAllocHealth_Terminal(t *testing.T) {
 	req := &structs.ApplyDeploymentAllocHealthRequest{
 		DeploymentAllocHealthRequest: structs.DeploymentAllocHealthRequest{
 			DeploymentID:         d.ID,
-			HealthyAllocationIDs: []string{structs.GenerateUUID()},
+			HealthyAllocationIDs: []string{uuid.Generate()},
 		},
 	}
 	err := state.UpdateDeploymentAllocHealth(2, req)
@@ -5480,7 +5481,7 @@ func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_NonExistent(t *testing.
 	req := &structs.ApplyDeploymentAllocHealthRequest{
 		DeploymentAllocHealthRequest: structs.DeploymentAllocHealthRequest{
 			DeploymentID:         d.ID,
-			HealthyAllocationIDs: []string{structs.GenerateUUID()},
+			HealthyAllocationIDs: []string{uuid.Generate()},
 		},
 	}
 	err := state.UpdateDeploymentAllocHealth(2, req)

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -1,7 +1,6 @@
 package structs
 
 import (
-	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -192,21 +191,6 @@ func ScoreFit(node *Node, util *Resources) float64 {
 		score = 0
 	}
 	return score
-}
-
-// GenerateUUID is used to generate a random UUID
-func GenerateUUID() string {
-	buf := make([]byte, 16)
-	if _, err := crand.Read(buf); err != nil {
-		panic(fmt.Errorf("failed to read random bytes: %v", err))
-	}
-
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
-		buf[0:4],
-		buf[4:6],
-		buf[6:8],
-		buf[8:10],
-		buf[10:16])
 }
 
 func CopySliceConstraints(s []*Constraint) []*Constraint {

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -2,10 +2,10 @@ package structs
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -257,28 +257,12 @@ func TestScoreFit(t *testing.T) {
 	}
 }
 
-func TestGenerateUUID(t *testing.T) {
-	prev := GenerateUUID()
-	for i := 0; i < 100; i++ {
-		id := GenerateUUID()
-		if prev == id {
-			t.Fatalf("Should get a new ID!")
-		}
-
-		matched, err := regexp.MatchString(
-			"[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}", id)
-		if !matched || err != nil {
-			t.Fatalf("expected match %s %v %s", id, matched, err)
-		}
-	}
-}
-
 func TestACLPolicyListHash(t *testing.T) {
 	h1 := ACLPolicyListHash(nil)
 	assert.NotEqual(t, "", h1)
 
 	p1 := &ACLPolicy{
-		Name:        fmt.Sprintf("policy-%s", GenerateUUID()),
+		Name:        fmt.Sprintf("policy-%s", uuid.Generate()),
 		Description: "Super cool policy!",
 		Rules: `
 		namespace "default" {
@@ -302,7 +286,7 @@ func TestACLPolicyListHash(t *testing.T) {
 	// Create P2 as copy of P1 with new name
 	p2 := &ACLPolicy{}
 	*p2 = *p1
-	p2.Name = fmt.Sprintf("policy-%s", GenerateUUID())
+	p2.Name = fmt.Sprintf("policy-%s", uuid.Generate())
 
 	h3 := ACLPolicyListHash([]*ACLPolicy{p1, p2})
 	assert.NotEqual(t, "", h3)
@@ -321,7 +305,7 @@ func TestACLPolicyListHash(t *testing.T) {
 
 func TestCompileACLObject(t *testing.T) {
 	p1 := &ACLPolicy{
-		Name:        fmt.Sprintf("policy-%s", GenerateUUID()),
+		Name:        fmt.Sprintf("policy-%s", uuid.Generate()),
 		Description: "Super cool policy!",
 		Rules: `
 		namespace "default" {
@@ -341,7 +325,7 @@ func TestCompileACLObject(t *testing.T) {
 	// Create P2 as copy of P1 with new name
 	p2 := &ACLPolicy{}
 	*p2 = *p1
-	p2.Name = fmt.Sprintf("policy-%s", GenerateUUID())
+	p2.Name = fmt.Sprintf("policy-%s", uuid.Generate())
 
 	// Create a small cache
 	cache, err := lru.New2Q(16)

--- a/nomad/structs/node_class_test.go
+++ b/nomad/structs/node_class_test.go
@@ -3,11 +3,13 @@ package structs
 import (
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/nomad/helper/uuid"
 )
 
 func testNode() *Node {
 	return &Node{
-		ID:         GenerateUUID(),
+		ID:         uuid.Generate(),
 		Datacenter: "dc1",
 		Name:       "foobar",
 		Attributes: map[string]string{

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/args"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/mitchellh/copystructure"
 	"github.com/ugorji/go/codec"
 
@@ -2419,7 +2420,7 @@ func (d *ParameterizedJobConfig) Copy() *ParameterizedJobConfig {
 // DispatchedID returns an ID appropriate for a job dispatched against a
 // particular parameterized job
 func DispatchedID(templateID string, t time.Time) string {
-	u := GenerateUUID()[:8]
+	u := uuid.Generate()[:8]
 	return fmt.Sprintf("%s%s%d-%s", templateID, DispatchLaunchSuffix, t.Unix(), u)
 }
 
@@ -4351,7 +4352,7 @@ type Deployment struct {
 // NewDeployment creates a new deployment given the job.
 func NewDeployment(job *Job) *Deployment {
 	return &Deployment{
-		ID:                GenerateUUID(),
+		ID:                uuid.Generate(),
 		Namespace:         job.Namespace,
 		JobID:             job.ID,
 		JobVersion:        job.Version,
@@ -5140,7 +5141,7 @@ func (e *Evaluation) MakePlan(j *Job) *Plan {
 // NextRollingEval creates an evaluation to followup this eval for rolling updates
 func (e *Evaluation) NextRollingEval(wait time.Duration) *Evaluation {
 	return &Evaluation{
-		ID:             GenerateUUID(),
+		ID:             uuid.Generate(),
 		Namespace:      e.Namespace,
 		Priority:       e.Priority,
 		Type:           e.Type,
@@ -5158,7 +5159,7 @@ func (e *Evaluation) NextRollingEval(wait time.Duration) *Evaluation {
 // ineligible and whether the job has escaped computed node classes.
 func (e *Evaluation) CreateBlockedEval(classEligibility map[string]bool, escaped bool) *Evaluation {
 	return &Evaluation{
-		ID:                   GenerateUUID(),
+		ID:                   uuid.Generate(),
 		Namespace:            e.Namespace,
 		Priority:             e.Priority,
 		Type:                 e.Type,
@@ -5177,7 +5178,7 @@ func (e *Evaluation) CreateBlockedEval(classEligibility map[string]bool, escaped
 // be retried by the eval_broker.
 func (e *Evaluation) CreateFailedFollowUpEval(wait time.Duration) *Evaluation {
 	return &Evaluation{
-		ID:             GenerateUUID(),
+		ID:             uuid.Generate(),
 		Namespace:      e.Namespace,
 		Priority:       e.Priority,
 		Type:           e.Type,

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 )
@@ -64,7 +65,7 @@ func TestJob_Validate(t *testing.T) {
 
 	j = &Job{
 		Region:      "global",
-		ID:          GenerateUUID(),
+		ID:          uuid.Generate(),
 		Namespace:   "test",
 		Name:        "my-job",
 		Type:        JobTypeService,
@@ -530,7 +531,7 @@ func TestJob_SpecChanged(t *testing.T) {
 func testJob() *Job {
 	return &Job{
 		Region:      "global",
-		ID:          GenerateUUID(),
+		ID:          uuid.Generate(),
 		Namespace:   "test",
 		Name:        "my-job",
 		Type:        JobTypeService,
@@ -2329,7 +2330,7 @@ func TestACLTokenValidate(t *testing.T) {
 	}
 
 	// Name too long policices
-	tk.Name = GenerateUUID() + GenerateUUID()
+	tk.Name = uuid.Generate() + uuid.Generate()
 	tk.Policies = nil
 	err = tk.Validate()
 	assert.NotNil(t, err)

--- a/nomad/util_test.go
+++ b/nomad/util_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	version "github.com/hashicorp/go-version"
-	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/serf/serf"
 )
 
@@ -156,7 +156,7 @@ func TestShuffleStrings(t *testing.T) {
 	// Generate input
 	inp := make([]string, 10)
 	for idx := range inp {
-		inp[idx] = structs.GenerateUUID()
+		inp[idx] = uuid.Generate()
 	}
 
 	// Copy the input

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -539,7 +540,7 @@ func TestVaultClient_LookupToken_Invalid(t *testing.T) {
 	conf := &config.VaultConfig{
 		Enabled: &tr,
 		Addr:    "http://foobar:12345",
-		Token:   structs.GenerateUUID(),
+		Token:   uuid.Generate(),
 	}
 
 	// Enable vault but use a bad address so it never establishes a conn
@@ -1024,7 +1025,7 @@ func TestVaultClient_CreateToken_Prestart(t *testing.T) {
 	t.Parallel()
 	vconfig := &config.VaultConfig{
 		Enabled: helper.BoolToPtr(true),
-		Token:   structs.GenerateUUID(),
+		Token:   uuid.Generate(),
 		Addr:    "http://127.0.0.1:0",
 	}
 
@@ -1057,7 +1058,7 @@ func TestVaultClient_RevokeTokens_PreEstablishs(t *testing.T) {
 	t.Parallel()
 	vconfig := &config.VaultConfig{
 		Enabled: helper.BoolToPtr(true),
-		Token:   structs.GenerateUUID(),
+		Token:   uuid.Generate(),
 		Addr:    "http://127.0.0.1:0",
 	}
 	logger := log.New(os.Stderr, "", log.LstdFlags)

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler"
@@ -317,7 +318,7 @@ func TestWorker_invokeScheduler(t *testing.T) {
 	eval := mock.Eval()
 	eval.Type = "noop"
 
-	err := w.invokeScheduler(eval, structs.GenerateUUID())
+	err := w.invokeScheduler(eval, uuid.Generate())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/scheduler/context_test.go
+++ b/scheduler/context_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -33,7 +34,7 @@ func TestEvalContext_ProposedAlloc(t *testing.T) {
 		{
 			Node: &structs.Node{
 				// Perfect fit
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 				Resources: &structs.Resources{
 					CPU:      2048,
 					MemoryMB: 2048,
@@ -43,7 +44,7 @@ func TestEvalContext_ProposedAlloc(t *testing.T) {
 		{
 			Node: &structs.Node{
 				// Perfect fit
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 				Resources: &structs.Resources{
 					CPU:      2048,
 					MemoryMB: 2048,
@@ -55,9 +56,9 @@ func TestEvalContext_ProposedAlloc(t *testing.T) {
 	// Add existing allocations
 	j1, j2 := mock.Job(), mock.Job()
 	alloc1 := &structs.Allocation{
-		ID:        structs.GenerateUUID(),
+		ID:        uuid.Generate(),
 		Namespace: structs.DefaultNamespace,
-		EvalID:    structs.GenerateUUID(),
+		EvalID:    uuid.Generate(),
 		NodeID:    nodes[0].Node.ID,
 		JobID:     j1.ID,
 		Job:       j1,
@@ -70,9 +71,9 @@ func TestEvalContext_ProposedAlloc(t *testing.T) {
 		TaskGroup:     "web",
 	}
 	alloc2 := &structs.Allocation{
-		ID:        structs.GenerateUUID(),
+		ID:        uuid.Generate(),
 		Namespace: structs.DefaultNamespace,
-		EvalID:    structs.GenerateUUID(),
+		EvalID:    uuid.Generate(),
 		NodeID:    nodes[1].Node.ID,
 		JobID:     j2.ID,
 		Job:       j2,

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -466,7 +467,7 @@ func TestDistinctHostsIterator_JobDistinctHosts(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 		},
 
 		// Should be ignored as it is a different job.
@@ -475,7 +476,7 @@ func TestDistinctHostsIterator_JobDistinctHosts(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 		},
 	}
 	plan.NodeAllocation[nodes[1].ID] = []*structs.Allocation{
@@ -484,7 +485,7 @@ func TestDistinctHostsIterator_JobDistinctHosts(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 		},
 
 		// Should be ignored as it is a different job.
@@ -493,7 +494,7 @@ func TestDistinctHostsIterator_JobDistinctHosts(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 		},
 	}
 
@@ -539,7 +540,7 @@ func TestDistinctHostsIterator_JobDistinctHosts_InfeasibleCount(t *testing.T) {
 			Namespace: structs.DefaultNamespace,
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 		},
 	}
 	plan.NodeAllocation[nodes[1].ID] = []*structs.Allocation{
@@ -547,7 +548,7 @@ func TestDistinctHostsIterator_JobDistinctHosts_InfeasibleCount(t *testing.T) {
 			Namespace: structs.DefaultNamespace,
 			TaskGroup: tg2.Name,
 			JobID:     job.ID,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 		},
 	}
 
@@ -671,7 +672,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 	// job unsatisfiable on all nodes but node5. Also mix the allocations
 	// existing in the plan and the state store.
 	plan := ctx.Plan()
-	alloc1ID := structs.GenerateUUID()
+	alloc1ID := uuid.Generate()
 	plan.NodeAllocation[nodes[0].ID] = []*structs.Allocation{
 		{
 			Namespace: structs.DefaultNamespace,
@@ -688,7 +689,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 	}
@@ -698,7 +699,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[2].ID,
 		},
 
@@ -708,13 +709,13 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[2].ID,
 		},
 	}
 
 	// Put an allocation on Node 5 but make it stopped in the plan
-	stoppingAllocID := structs.GenerateUUID()
+	stoppingAllocID := uuid.Generate()
 	plan.NodeUpdate[nodes[4].ID] = []*structs.Allocation{
 		{
 			Namespace: structs.DefaultNamespace,
@@ -735,7 +736,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			JobID:     job.ID,
 			Job:       job,
 			ID:        alloc1ID,
-			EvalID:    structs.GenerateUUID(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 
@@ -744,8 +745,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 
@@ -755,8 +756,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 		{
@@ -764,8 +765,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[3].ID,
 		},
 
@@ -775,8 +776,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[3].ID,
 		},
 		{
@@ -785,7 +786,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			JobID:     job.ID,
 			Job:       job,
 			ID:        stoppingAllocID,
-			EvalID:    structs.GenerateUUID(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[4].ID,
 		},
 	}
@@ -850,7 +851,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 	// node 3. This should make the job unsatisfiable on all nodes but node5.
 	// Also mix the allocations existing in the plan and the state store.
 	plan := ctx.Plan()
-	alloc1ID := structs.GenerateUUID()
+	alloc1ID := uuid.Generate()
 	plan.NodeAllocation[nodes[0].ID] = []*structs.Allocation{
 		{
 			Namespace: structs.DefaultNamespace,
@@ -876,7 +877,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 	}
@@ -886,7 +887,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 
@@ -895,7 +896,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 
@@ -905,7 +906,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 	}
@@ -915,7 +916,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[2].ID,
 		},
 
@@ -925,13 +926,13 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[2].ID,
 		},
 	}
 
 	// Put an allocation on Node 3 but make it stopped in the plan
-	stoppingAllocID := structs.GenerateUUID()
+	stoppingAllocID := uuid.Generate()
 	plan.NodeUpdate[nodes[2].ID] = []*structs.Allocation{
 		{
 			Namespace: structs.DefaultNamespace,
@@ -952,7 +953,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			JobID:     job.ID,
 			Job:       job,
 			ID:        alloc1ID,
-			EvalID:    structs.GenerateUUID(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 
@@ -961,8 +962,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 
@@ -971,8 +972,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 
@@ -982,8 +983,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 		{
@@ -991,8 +992,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 	}
@@ -1053,12 +1054,12 @@ func TestDistinctPropertyIterator_JobDistinctProperty_RemoveAndReplace(t *testin
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 	}
 
-	stoppingAllocID := structs.GenerateUUID()
+	stoppingAllocID := uuid.Generate()
 	plan.NodeUpdate[nodes[0].ID] = []*structs.Allocation{
 		{
 			Namespace: structs.DefaultNamespace,
@@ -1077,7 +1078,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_RemoveAndReplace(t *testin
 			JobID:     job.ID,
 			Job:       job,
 			ID:        stoppingAllocID,
-			EvalID:    structs.GenerateUUID(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 	}
@@ -1143,7 +1144,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 	}
@@ -1153,8 +1154,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible(t *testing.T) {
 			TaskGroup: tg2.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 	}
@@ -1221,7 +1222,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible_Count(t *testin
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 		{
@@ -1229,7 +1230,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible_Count(t *testin
 			TaskGroup: tg2.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 	}
@@ -1239,8 +1240,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible_Count(t *testin
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 		{
@@ -1248,8 +1249,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible_Count(t *testin
 			TaskGroup: tg2.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 	}
@@ -1318,13 +1319,13 @@ func TestDistinctPropertyIterator_TaskGroupDistinctProperty(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
+			ID:        uuid.Generate(),
 			NodeID:    nodes[0].ID,
 		},
 	}
 
 	// Put an allocation on Node 3 but make it stopped in the plan
-	stoppingAllocID := structs.GenerateUUID()
+	stoppingAllocID := uuid.Generate()
 	plan.NodeUpdate[nodes[2].ID] = []*structs.Allocation{
 		{
 			Namespace: structs.DefaultNamespace,
@@ -1342,8 +1343,8 @@ func TestDistinctPropertyIterator_TaskGroupDistinctProperty(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     job.ID,
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[1].ID,
 		},
 
@@ -1353,8 +1354,8 @@ func TestDistinctPropertyIterator_TaskGroupDistinctProperty(t *testing.T) {
 			TaskGroup: tg1.Name,
 			JobID:     "ignore 2",
 			Job:       job,
-			ID:        structs.GenerateUUID(),
-			EvalID:    structs.GenerateUUID(),
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[2].ID,
 		},
 
@@ -1364,7 +1365,7 @@ func TestDistinctPropertyIterator_TaskGroupDistinctProperty(t *testing.T) {
 			JobID:     job.ID,
 			Job:       job,
 			ID:        stoppingAllocID,
-			EvalID:    structs.GenerateUUID(),
+			EvalID:    uuid.Generate(),
 			NodeID:    nodes[2].ID,
 		},
 	}

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -7,6 +7,7 @@ import (
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -488,7 +489,7 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 			if option != nil {
 				// Create an allocation for this
 				alloc := &structs.Allocation{
-					ID:            structs.GenerateUUID(),
+					ID:            uuid.Generate(),
 					Namespace:     s.job.Namespace,
 					EvalID:        s.eval.ID,
 					Name:          missing.Name(),

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -9,6 +9,7 @@ import (
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ func TestServiceSched_JobRegister(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -113,7 +114,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -144,7 +145,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create a mock evaluation to handle the update
 	eval = &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -201,7 +202,7 @@ func TestServiceSched_JobRegister_DiskConstraints(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -270,7 +271,7 @@ func TestServiceSched_JobRegister_DistinctHosts(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -359,7 +360,7 @@ func TestServiceSched_JobRegister_DistinctProperty(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -451,7 +452,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -543,7 +544,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -596,7 +597,7 @@ func TestServiceSched_JobRegister_Annotate(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:    structs.DefaultNamespace,
-		ID:           structs.GenerateUUID(),
+		ID:           uuid.Generate(),
 		Priority:     job.Priority,
 		TriggeredBy:  structs.EvalTriggerJobRegister,
 		JobID:        job.ID,
@@ -674,7 +675,7 @@ func TestServiceSched_JobRegister_CountZero(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -715,7 +716,7 @@ func TestServiceSched_JobRegister_AllocFail(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -797,7 +798,7 @@ func TestServiceSched_JobRegister_CreateBlockedEval(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -894,7 +895,7 @@ func TestServiceSched_JobRegister_FeasibleAndInfeasibleTG(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -970,7 +971,7 @@ func TestServiceSched_EvaluateMaxPlanEval(t *testing.T) {
 	// Create a mock blocked evaluation
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Status:      structs.EvalStatusBlocked,
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerMaxPlans,
@@ -1011,7 +1012,7 @@ func TestServiceSched_Plan_Partial_Progress(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1071,7 +1072,7 @@ func TestServiceSched_EvaluateBlockedEval(t *testing.T) {
 	// Create a mock blocked evaluation
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Status:      structs.EvalStatusBlocked,
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
@@ -1122,7 +1123,7 @@ func TestServiceSched_EvaluateBlockedEval_Finished(t *testing.T) {
 	// Create a mock blocked evaluation
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Status:      structs.EvalStatusBlocked,
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
@@ -1240,7 +1241,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1324,7 +1325,7 @@ func TestServiceSched_JobModify_IncrCount_NodeLimit(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1431,7 +1432,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1525,7 +1526,7 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1630,7 +1631,7 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1731,7 +1732,7 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1839,7 +1840,7 @@ func TestServiceSched_JobModify_InPlace(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1953,7 +1954,7 @@ func TestServiceSched_JobModify_DistinctProperty(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -2039,7 +2040,7 @@ func TestServiceSched_JobDeregister_Purged(t *testing.T) {
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobDeregister,
 		JobID:       job.ID,
@@ -2106,7 +2107,7 @@ func TestServiceSched_JobDeregister_Stopped(t *testing.T) {
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobDeregister,
 		JobID:       job.ID,
@@ -2195,7 +2196,7 @@ func TestServiceSched_NodeDown(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -2261,7 +2262,7 @@ func TestServiceSched_NodeUpdate(t *testing.T) {
 	// Create a mock evaluation which won't trigger any new placements
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -2312,7 +2313,7 @@ func TestServiceSched_NodeDrain(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -2413,7 +2414,7 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -2487,7 +2488,7 @@ func TestServiceSched_NodeDrain_Queued_Allocations(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -2544,7 +2545,7 @@ func TestServiceSched_NodeDrain_UpdateStrategy(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -2603,7 +2604,7 @@ func TestServiceSched_RetryLimit(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -2659,7 +2660,7 @@ func TestBatchSched_Run_CompleteAlloc(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -2714,7 +2715,7 @@ func TestBatchSched_Run_FailedAlloc(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -2776,7 +2777,7 @@ func TestBatchSched_Run_FailedAllocQueuedAllocations(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -2836,7 +2837,7 @@ func TestBatchSched_ReRun_SuccessfullyFinishedAlloc(t *testing.T) {
 	// Create a mock evaluation to rerun the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -2899,7 +2900,7 @@ func TestBatchSched_JobModify_InPlace_Terminal(t *testing.T) {
 	// Create a mock evaluation to trigger the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -2980,7 +2981,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -3034,7 +3035,7 @@ func TestBatchSched_NodeDrain_Running_OldJob(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -3097,7 +3098,7 @@ func TestBatchSched_NodeDrain_Complete(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -3149,7 +3150,7 @@ func TestBatchSched_ScaleDown_SameName(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -3192,7 +3193,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -3221,7 +3222,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 	// Create a mock evaluation to update the job
 	eval1 := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job1.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job1.ID,
@@ -3281,7 +3282,7 @@ func TestServiceSched_NodeDrain_Sticky(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       alloc.Job.ID,
@@ -3339,7 +3340,7 @@ func TestServiceSched_CancelDeployment_Stopped(t *testing.T) {
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobDeregister,
 		JobID:       job.ID,
@@ -3408,7 +3409,7 @@ func TestServiceSched_CancelDeployment_NewerJob(t *testing.T) {
 	// Create a mock evaluation to kick the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,

--- a/scheduler/rank_test.go
+++ b/scheduler/rank_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -105,7 +106,7 @@ func TestBinPackIterator_PlannedAlloc(t *testing.T) {
 		{
 			Node: &structs.Node{
 				// Perfect fit
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 				Resources: &structs.Resources{
 					CPU:      2048,
 					MemoryMB: 2048,
@@ -115,7 +116,7 @@ func TestBinPackIterator_PlannedAlloc(t *testing.T) {
 		{
 			Node: &structs.Node{
 				// Perfect fit
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 				Resources: &structs.Resources{
 					CPU:      2048,
 					MemoryMB: 2048,
@@ -181,7 +182,7 @@ func TestBinPackIterator_ExistingAlloc(t *testing.T) {
 		{
 			Node: &structs.Node{
 				// Perfect fit
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 				Resources: &structs.Resources{
 					CPU:      2048,
 					MemoryMB: 2048,
@@ -191,7 +192,7 @@ func TestBinPackIterator_ExistingAlloc(t *testing.T) {
 		{
 			Node: &structs.Node{
 				// Perfect fit
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 				Resources: &structs.Resources{
 					CPU:      2048,
 					MemoryMB: 2048,
@@ -205,8 +206,8 @@ func TestBinPackIterator_ExistingAlloc(t *testing.T) {
 	j1, j2 := mock.Job(), mock.Job()
 	alloc1 := &structs.Allocation{
 		Namespace: structs.DefaultNamespace,
-		ID:        structs.GenerateUUID(),
-		EvalID:    structs.GenerateUUID(),
+		ID:        uuid.Generate(),
+		EvalID:    uuid.Generate(),
 		NodeID:    nodes[0].Node.ID,
 		JobID:     j1.ID,
 		Job:       j1,
@@ -220,8 +221,8 @@ func TestBinPackIterator_ExistingAlloc(t *testing.T) {
 	}
 	alloc2 := &structs.Allocation{
 		Namespace: structs.DefaultNamespace,
-		ID:        structs.GenerateUUID(),
-		EvalID:    structs.GenerateUUID(),
+		ID:        uuid.Generate(),
+		EvalID:    uuid.Generate(),
 		NodeID:    nodes[1].Node.ID,
 		JobID:     j2.ID,
 		Job:       j2,
@@ -270,7 +271,7 @@ func TestBinPackIterator_ExistingAlloc_PlannedEvict(t *testing.T) {
 		{
 			Node: &structs.Node{
 				// Perfect fit
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 				Resources: &structs.Resources{
 					CPU:      2048,
 					MemoryMB: 2048,
@@ -280,7 +281,7 @@ func TestBinPackIterator_ExistingAlloc_PlannedEvict(t *testing.T) {
 		{
 			Node: &structs.Node{
 				// Perfect fit
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 				Resources: &structs.Resources{
 					CPU:      2048,
 					MemoryMB: 2048,
@@ -294,8 +295,8 @@ func TestBinPackIterator_ExistingAlloc_PlannedEvict(t *testing.T) {
 	j1, j2 := mock.Job(), mock.Job()
 	alloc1 := &structs.Allocation{
 		Namespace: structs.DefaultNamespace,
-		ID:        structs.GenerateUUID(),
-		EvalID:    structs.GenerateUUID(),
+		ID:        uuid.Generate(),
+		EvalID:    uuid.Generate(),
 		NodeID:    nodes[0].Node.ID,
 		JobID:     j1.ID,
 		Job:       j1,
@@ -309,8 +310,8 @@ func TestBinPackIterator_ExistingAlloc_PlannedEvict(t *testing.T) {
 	}
 	alloc2 := &structs.Allocation{
 		Namespace: structs.DefaultNamespace,
-		ID:        structs.GenerateUUID(),
-		EvalID:    structs.GenerateUUID(),
+		ID:        uuid.Generate(),
+		EvalID:    uuid.Generate(),
 		NodeID:    nodes[1].Node.ID,
 		JobID:     j2.ID,
 		Job:       j2,
@@ -366,12 +367,12 @@ func TestJobAntiAffinity_PlannedAlloc(t *testing.T) {
 	nodes := []*RankedNode{
 		{
 			Node: &structs.Node{
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 			},
 		},
 		{
 			Node: &structs.Node{
-				ID: structs.GenerateUUID(),
+				ID: uuid.Generate(),
 			},
 		},
 	}
@@ -381,11 +382,11 @@ func TestJobAntiAffinity_PlannedAlloc(t *testing.T) {
 	plan := ctx.Plan()
 	plan.NodeAllocation[nodes[0].Node.ID] = []*structs.Allocation{
 		{
-			ID:    structs.GenerateUUID(),
+			ID:    uuid.Generate(),
 			JobID: "foo",
 		},
 		{
-			ID:    structs.GenerateUUID(),
+			ID:    uuid.Generate(),
 			JobID: "foo",
 		},
 	}

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/kr/pretty"
@@ -360,7 +361,7 @@ func TestReconciler_Place_Existing(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -398,7 +399,7 @@ func TestReconciler_ScaleDown_Partial(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -437,7 +438,7 @@ func TestReconciler_ScaleDown_Zero(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -476,7 +477,7 @@ func TestReconciler_ScaleDown_Zero_DuplicateNames(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i%2))
 		allocs = append(allocs, alloc)
 		expectedStopped = append(expectedStopped, i%2)
@@ -512,7 +513,7 @@ func TestReconciler_Inplace(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -550,7 +551,7 @@ func TestReconciler_Inplace_ScaleUp(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -590,7 +591,7 @@ func TestReconciler_Inplace_ScaleDown(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -627,7 +628,7 @@ func TestReconciler_Destructive(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -663,7 +664,7 @@ func TestReconciler_Destructive_ScaleUp(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -702,7 +703,7 @@ func TestReconciler_Destructive_ScaleDown(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -738,7 +739,7 @@ func TestReconciler_LostNode(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -788,7 +789,7 @@ func TestReconciler_LostNode_ScaleUp(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -838,7 +839,7 @@ func TestReconciler_LostNode_ScaleDown(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -883,7 +884,7 @@ func TestReconciler_DrainNode(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -933,7 +934,7 @@ func TestReconciler_DrainNode_ScaleUp(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -984,7 +985,7 @@ func TestReconciler_DrainNode_ScaleDown(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -1032,7 +1033,7 @@ func TestReconciler_RemovedTG(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -1097,7 +1098,7 @@ func TestReconciler_JobStopped(t *testing.T) {
 				alloc := mock.Alloc()
 				alloc.Job = c.job
 				alloc.JobID = c.jobID
-				alloc.NodeID = structs.GenerateUUID()
+				alloc.NodeID = uuid.Generate()
 				alloc.Name = structs.AllocName(c.jobID, c.taskGroup, uint(i))
 				alloc.TaskGroup = c.taskGroup
 				allocs = append(allocs, alloc)
@@ -1138,7 +1139,7 @@ func TestReconciler_MultiTG(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		allocs = append(allocs, alloc)
 	}
@@ -1225,7 +1226,7 @@ func TestReconciler_CancelDeployment_JobStop(t *testing.T) {
 				alloc := mock.Alloc()
 				alloc.Job = c.job
 				alloc.JobID = c.jobID
-				alloc.NodeID = structs.GenerateUUID()
+				alloc.NodeID = uuid.Generate()
 				alloc.Name = structs.AllocName(c.jobID, c.taskGroup, uint(i))
 				alloc.TaskGroup = c.taskGroup
 				allocs = append(allocs, alloc)
@@ -1302,7 +1303,7 @@ func TestReconciler_CancelDeployment_JobUpdate(t *testing.T) {
 				alloc := mock.Alloc()
 				alloc.Job = job
 				alloc.JobID = job.ID
-				alloc.NodeID = structs.GenerateUUID()
+				alloc.NodeID = uuid.Generate()
 				alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 				alloc.TaskGroup = job.TaskGroups[0].Name
 				allocs = append(allocs, alloc)
@@ -1351,7 +1352,7 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Destructive(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -1392,7 +1393,7 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Inplace(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -1432,7 +1433,7 @@ func TestReconciler_DontCreateDeployment_NoChanges(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -1498,7 +1499,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreCanaries(t *testing.T) {
 				alloc := mock.Alloc()
 				alloc.Job = job
 				alloc.JobID = job.ID
-				alloc.NodeID = structs.GenerateUUID()
+				alloc.NodeID = uuid.Generate()
 				alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 				alloc.TaskGroup = job.TaskGroups[0].Name
 				allocs = append(allocs, alloc)
@@ -1508,7 +1509,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreCanaries(t *testing.T) {
 			canary := mock.Alloc()
 			canary.Job = job
 			canary.JobID = job.ID
-			canary.NodeID = structs.GenerateUUID()
+			canary.NodeID = uuid.Generate()
 			canary.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, 0)
 			canary.TaskGroup = job.TaskGroups[0].Name
 			canary.DeploymentID = d.ID
@@ -1575,7 +1576,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMorePlacements(t *testing.T) {
 				alloc := mock.Alloc()
 				alloc.Job = job
 				alloc.JobID = job.ID
-				alloc.NodeID = structs.GenerateUUID()
+				alloc.NodeID = uuid.Generate()
 				alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 				alloc.TaskGroup = job.TaskGroups[0].Name
 				allocs = append(allocs, alloc)
@@ -1638,7 +1639,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreDestructiveUpdates(t *testing
 				alloc := mock.Alloc()
 				alloc.Job = job
 				alloc.JobID = job.ID
-				alloc.NodeID = structs.GenerateUUID()
+				alloc.NodeID = uuid.Generate()
 				alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 				alloc.TaskGroup = job.TaskGroups[0].Name
 				allocs = append(allocs, alloc)
@@ -1648,7 +1649,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreDestructiveUpdates(t *testing
 			newAlloc := mock.Alloc()
 			newAlloc.Job = job
 			newAlloc.JobID = job.ID
-			newAlloc.NodeID = structs.GenerateUUID()
+			newAlloc.NodeID = uuid.Generate()
 			newAlloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, 0)
 			newAlloc.TaskGroup = job.TaskGroups[0].Name
 			newAlloc.DeploymentID = d.ID
@@ -1726,7 +1727,7 @@ func TestReconciler_PausedOrFailedDeployment_Migrations(t *testing.T) {
 				alloc := mock.Alloc()
 				alloc.Job = job
 				alloc.JobID = job.ID
-				alloc.NodeID = structs.GenerateUUID()
+				alloc.NodeID = uuid.Generate()
 				alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 				alloc.TaskGroup = job.TaskGroups[0].Name
 				alloc.DeploymentID = d.ID
@@ -1785,7 +1786,7 @@ func TestReconciler_DrainNode_Canary(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -1798,7 +1799,7 @@ func TestReconciler_DrainNode_Canary(t *testing.T) {
 		canary := mock.Alloc()
 		canary.Job = job
 		canary.JobID = job.ID
-		canary.NodeID = structs.GenerateUUID()
+		canary.NodeID = uuid.Generate()
 		canary.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		canary.TaskGroup = job.TaskGroups[0].Name
 		canary.DeploymentID = d.ID
@@ -1857,7 +1858,7 @@ func TestReconciler_LostNode_Canary(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -1870,7 +1871,7 @@ func TestReconciler_LostNode_Canary(t *testing.T) {
 		canary := mock.Alloc()
 		canary.Job = job
 		canary.JobID = job.ID
-		canary.NodeID = structs.GenerateUUID()
+		canary.NodeID = uuid.Generate()
 		canary.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		canary.TaskGroup = job.TaskGroups[0].Name
 		s.PlacedCanaries = append(s.PlacedCanaries, canary.ID)
@@ -1933,7 +1934,7 @@ func TestReconciler_StopOldCanaries(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -1945,7 +1946,7 @@ func TestReconciler_StopOldCanaries(t *testing.T) {
 		canary := mock.Alloc()
 		canary.Job = job
 		canary.JobID = job.ID
-		canary.NodeID = structs.GenerateUUID()
+		canary.NodeID = uuid.Generate()
 		canary.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		canary.TaskGroup = job.TaskGroups[0].Name
 		s.PlacedCanaries = append(s.PlacedCanaries, canary.ID)
@@ -2000,7 +2001,7 @@ func TestReconciler_NewCanaries(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -2049,7 +2050,7 @@ func TestReconciler_NewCanaries_MultiTG(t *testing.T) {
 			alloc := mock.Alloc()
 			alloc.Job = job
 			alloc.JobID = job.ID
-			alloc.NodeID = structs.GenerateUUID()
+			alloc.NodeID = uuid.Generate()
 			alloc.Name = structs.AllocName(job.ID, job.TaskGroups[j].Name, uint(i))
 			alloc.TaskGroup = job.TaskGroups[j].Name
 			allocs = append(allocs, alloc)
@@ -2103,7 +2104,7 @@ func TestReconciler_NewCanaries_ScaleUp(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -2151,7 +2152,7 @@ func TestReconciler_NewCanaries_ScaleDown(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -2214,7 +2215,7 @@ func TestReconciler_NewCanaries_FillNames(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -2226,7 +2227,7 @@ func TestReconciler_NewCanaries_FillNames(t *testing.T) {
 		canary := mock.Alloc()
 		canary.Job = job
 		canary.JobID = job.ID
-		canary.NodeID = structs.GenerateUUID()
+		canary.NodeID = uuid.Generate()
 		canary.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		canary.TaskGroup = job.TaskGroups[0].Name
 		s.PlacedCanaries = append(s.PlacedCanaries, canary.ID)
@@ -2277,7 +2278,7 @@ func TestReconciler_PromoteCanaries_Unblock(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -2290,7 +2291,7 @@ func TestReconciler_PromoteCanaries_Unblock(t *testing.T) {
 		canary := mock.Alloc()
 		canary.Job = job
 		canary.JobID = job.ID
-		canary.NodeID = structs.GenerateUUID()
+		canary.NodeID = uuid.Generate()
 		canary.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		canary.TaskGroup = job.TaskGroups[0].Name
 		s.PlacedCanaries = append(s.PlacedCanaries, canary.ID)
@@ -2350,7 +2351,7 @@ func TestReconciler_PromoteCanaries_CanariesEqualCount(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -2363,7 +2364,7 @@ func TestReconciler_PromoteCanaries_CanariesEqualCount(t *testing.T) {
 		canary := mock.Alloc()
 		canary.Job = job
 		canary.JobID = job.ID
-		canary.NodeID = structs.GenerateUUID()
+		canary.NodeID = uuid.Generate()
 		canary.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		canary.TaskGroup = job.TaskGroups[0].Name
 		s.PlacedCanaries = append(s.PlacedCanaries, canary.ID)
@@ -2449,7 +2450,7 @@ func TestReconciler_DeploymentLimit_HealthAccounting(t *testing.T) {
 				alloc := mock.Alloc()
 				alloc.Job = job
 				alloc.JobID = job.ID
-				alloc.NodeID = structs.GenerateUUID()
+				alloc.NodeID = uuid.Generate()
 				alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 				alloc.TaskGroup = job.TaskGroups[0].Name
 				allocs = append(allocs, alloc)
@@ -2461,7 +2462,7 @@ func TestReconciler_DeploymentLimit_HealthAccounting(t *testing.T) {
 				new := mock.Alloc()
 				new.Job = job
 				new.JobID = job.ID
-				new.NodeID = structs.GenerateUUID()
+				new.NodeID = uuid.Generate()
 				new.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 				new.TaskGroup = job.TaskGroups[0].Name
 				new.DeploymentID = d.ID
@@ -2518,7 +2519,7 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -2530,7 +2531,7 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 		new := mock.Alloc()
 		new.Job = job
 		new.JobID = job.ID
-		new.NodeID = structs.GenerateUUID()
+		new.NodeID = uuid.Generate()
 		new.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		new.TaskGroup = job.TaskGroups[0].Name
 		new.DeploymentID = d.ID
@@ -2603,7 +2604,7 @@ func TestReconciler_FailedDeployment_PlacementLost(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -2615,7 +2616,7 @@ func TestReconciler_FailedDeployment_PlacementLost(t *testing.T) {
 		new := mock.Alloc()
 		new.Job = job
 		new.JobID = job.ID
-		new.NodeID = structs.GenerateUUID()
+		new.NodeID = uuid.Generate()
 		new.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		new.TaskGroup = job.TaskGroups[0].Name
 		new.DeploymentID = d.ID
@@ -2686,7 +2687,7 @@ func TestReconciler_CompleteDeployment(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		alloc.DeploymentID = d.ID
@@ -2756,7 +2757,7 @@ func TestReconciler_FailedDeployment_CancelCanaries(t *testing.T) {
 			new := mock.Alloc()
 			new.Job = job
 			new.JobID = job.ID
-			new.NodeID = structs.GenerateUUID()
+			new.NodeID = uuid.Generate()
 			new.Name = structs.AllocName(job.ID, job.TaskGroups[group].Name, uint(i))
 			new.TaskGroup = job.TaskGroups[group].Name
 			new.DeploymentID = d.ID
@@ -2775,7 +2776,7 @@ func TestReconciler_FailedDeployment_CancelCanaries(t *testing.T) {
 			alloc := mock.Alloc()
 			alloc.Job = job
 			alloc.JobID = job.ID
-			alloc.NodeID = structs.GenerateUUID()
+			alloc.NodeID = uuid.Generate()
 			alloc.Name = structs.AllocName(job.ID, job.TaskGroups[group].Name, uint(i))
 			alloc.TaskGroup = job.TaskGroups[group].Name
 			allocs = append(allocs, alloc)
@@ -2827,7 +2828,7 @@ func TestReconciler_FailedDeployment_NewJob(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -2838,7 +2839,7 @@ func TestReconciler_FailedDeployment_NewJob(t *testing.T) {
 		new := mock.Alloc()
 		new.Job = job
 		new.JobID = job.ID
-		new.NodeID = structs.GenerateUUID()
+		new.NodeID = uuid.Generate()
 		new.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		new.TaskGroup = job.TaskGroups[0].Name
 		new.DeploymentID = d.ID
@@ -2895,7 +2896,7 @@ func TestReconciler_MarkDeploymentComplete(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		alloc.DeploymentID = d.ID
@@ -2948,7 +2949,7 @@ func TestReconciler_TaintedNode_MultiGroups(t *testing.T) {
 			alloc := mock.Alloc()
 			alloc.Job = job
 			alloc.JobID = job.ID
-			alloc.NodeID = structs.GenerateUUID()
+			alloc.NodeID = uuid.Generate()
 			alloc.Name = structs.AllocName(job.ID, job.TaskGroups[j].Name, uint(i))
 			alloc.TaskGroup = job.TaskGroups[j].Name
 			allocs = append(allocs, alloc)
@@ -3019,7 +3020,7 @@ func TestReconciler_JobChange_ScaleUp_SecondEval(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -3032,7 +3033,7 @@ func TestReconciler_JobChange_ScaleUp_SecondEval(t *testing.T) {
 		alloc.Job = job
 		alloc.JobID = job.ID
 		alloc.DeploymentID = d.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)
@@ -3069,7 +3070,7 @@ func TestReconciler_RollingUpgrade_MissingAllocs(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job = job
 		alloc.JobID = job.ID
-		alloc.NodeID = structs.GenerateUUID()
+		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		allocs = append(allocs, alloc)

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -306,7 +307,7 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 		if option != nil {
 			// Create an allocation for this
 			alloc := &structs.Allocation{
-				ID:            structs.GenerateUUID(),
+				ID:            uuid.Generate(),
 				Namespace:     s.job.Namespace,
 				EvalID:        s.eval.ID,
 				Name:          missing.Name,

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -27,7 +28,7 @@ func TestSystemSched_JobRegister(t *testing.T) {
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -100,7 +101,7 @@ func TestSystemeSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -129,7 +130,7 @@ func TestSystemeSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create a mock evaluation to handle the update
 	eval = &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -176,7 +177,7 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -202,7 +203,7 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval1 := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job1.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job1.ID,
@@ -236,7 +237,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    svcJob.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       svcJob.ID,
@@ -255,7 +256,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval1 := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -301,7 +302,7 @@ func TestSystemSched_JobRegister_Annotate(t *testing.T) {
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
 		Namespace:    structs.DefaultNamespace,
-		ID:           structs.GenerateUUID(),
+		ID:           uuid.Generate(),
 		Priority:     job.Priority,
 		TriggeredBy:  structs.EvalTriggerJobRegister,
 		JobID:        job.ID,
@@ -400,7 +401,7 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -467,7 +468,7 @@ func TestSystemSched_JobRegister_AllocFail(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -537,7 +538,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -628,7 +629,7 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -723,7 +724,7 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -817,7 +818,7 @@ func TestSystemSched_JobDeregister_Purged(t *testing.T) {
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobDeregister,
 		JobID:       job.ID,
@@ -889,7 +890,7 @@ func TestSystemSched_JobDeregister_Stopped(t *testing.T) {
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerJobDeregister,
 		JobID:       job.ID,
@@ -950,7 +951,7 @@ func TestSystemSched_NodeDown(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -1015,7 +1016,7 @@ func TestSystemSched_NodeDrain_Down(t *testing.T) {
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -1074,7 +1075,7 @@ func TestSystemSched_NodeDrain(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -1137,7 +1138,7 @@ func TestSystemSched_NodeUpdate(t *testing.T) {
 	// Create a mock evaluation to deal
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -1175,7 +1176,7 @@ func TestSystemSched_RetryLimit(t *testing.T) {
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1224,7 +1225,7 @@ func TestSystemSched_Queued_With_Constraints(t *testing.T) {
 	// Create a mock evaluation to deal
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -1259,7 +1260,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job.ID,
@@ -1294,7 +1295,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 	// Create a mock evaluation to update the job
 	eval1 := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    job1.Priority,
 		TriggeredBy: structs.EvalTriggerJobRegister,
 		JobID:       job1.ID,
@@ -1383,7 +1384,7 @@ func TestSystemSched_PlanWithDrainedNode(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,
@@ -1454,7 +1455,7 @@ func TestSystemSched_QueuedAllocsMultTG(t *testing.T) {
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
-		ID:          structs.GenerateUUID(),
+		ID:          uuid.Generate(),
 		Priority:    50,
 		TriggeredBy: structs.EvalTriggerNodeUpdate,
 		JobID:       job.ID,

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -61,7 +62,7 @@ func TestDiffAllocs(t *testing.T) {
 	allocs := []*structs.Allocation{
 		// Update the 1st
 		{
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "zip",
 			Name:   "my-job.web[0]",
 			Job:    oldJob,
@@ -69,7 +70,7 @@ func TestDiffAllocs(t *testing.T) {
 
 		// Ignore the 2rd
 		{
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "zip",
 			Name:   "my-job.web[1]",
 			Job:    job,
@@ -77,7 +78,7 @@ func TestDiffAllocs(t *testing.T) {
 
 		// Evict 11th
 		{
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "zip",
 			Name:   "my-job.web[10]",
 			Job:    oldJob,
@@ -85,14 +86,14 @@ func TestDiffAllocs(t *testing.T) {
 
 		// Migrate the 3rd
 		{
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "drainNode",
 			Name:   "my-job.web[2]",
 			Job:    oldJob,
 		},
 		// Mark the 4th lost
 		{
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "dead",
 			Name:   "my-job.web[3]",
 			Job:    oldJob,
@@ -102,19 +103,19 @@ func TestDiffAllocs(t *testing.T) {
 	// Have three terminal allocs
 	terminalAllocs := map[string]*structs.Allocation{
 		"my-job.web[4]": {
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "zip",
 			Name:   "my-job.web[4]",
 			Job:    job,
 		},
 		"my-job.web[5]": {
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "zip",
 			Name:   "my-job.web[5]",
 			Job:    job,
 		},
 		"my-job.web[6]": {
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "zip",
 			Name:   "my-job.web[6]",
 			Job:    job,
@@ -198,7 +199,7 @@ func TestDiffSystemAllocs(t *testing.T) {
 	allocs := []*structs.Allocation{
 		// Update allocation on baz
 		{
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "baz",
 			Name:   "my-job.web[0]",
 			Job:    oldJob,
@@ -206,7 +207,7 @@ func TestDiffSystemAllocs(t *testing.T) {
 
 		// Ignore allocation on bar
 		{
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "bar",
 			Name:   "my-job.web[0]",
 			Job:    job,
@@ -214,14 +215,14 @@ func TestDiffSystemAllocs(t *testing.T) {
 
 		// Stop allocation on draining node.
 		{
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: drainNode.ID,
 			Name:   "my-job.web[0]",
 			Job:    oldJob,
 		},
 		// Mark as lost on a dead node
 		{
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: deadNode.ID,
 			Name:   "my-job.web[0]",
 			Job:    oldJob,
@@ -231,7 +232,7 @@ func TestDiffSystemAllocs(t *testing.T) {
 	// Have three terminal allocs
 	terminalAllocs := map[string]*structs.Allocation{
 		"my-job.web[0]": {
-			ID:     structs.GenerateUUID(),
+			ID:     uuid.Generate(),
 			NodeID: "pipe",
 			Name:   "my-job.web[0]",
 			Job:    job,
@@ -576,10 +577,10 @@ func TestTasksUpdated(t *testing.T) {
 func TestEvictAndPlace_LimitLessThanAllocs(t *testing.T) {
 	_, ctx := testContext(t)
 	allocs := []allocTuple{
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 	}
 	diff := &diffResult{}
 
@@ -600,10 +601,10 @@ func TestEvictAndPlace_LimitLessThanAllocs(t *testing.T) {
 func TestEvictAndPlace_LimitEqualToAllocs(t *testing.T) {
 	_, ctx := testContext(t)
 	allocs := []allocTuple{
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 	}
 	diff := &diffResult{}
 
@@ -706,7 +707,7 @@ func TestSetStatus(t *testing.T) {
 	}
 
 	h = NewHarness(t)
-	dID := structs.GenerateUUID()
+	dID := uuid.Generate()
 	if err := setStatus(logger, h, eval, nil, nil, metrics, status, desc, queuedAllocs, dID); err != nil {
 		t.Fatalf("setStatus() failed: %v", err)
 	}
@@ -732,7 +733,7 @@ func TestInplaceUpdate_ChangedTaskGroup(t *testing.T) {
 	// Register an alloc
 	alloc := &structs.Allocation{
 		Namespace: structs.DefaultNamespace,
-		ID:        structs.GenerateUUID(),
+		ID:        uuid.Generate(),
 		EvalID:    eval.ID,
 		NodeID:    node.ID,
 		JobID:     job.ID,
@@ -781,7 +782,7 @@ func TestInplaceUpdate_NoMatch(t *testing.T) {
 	// Register an alloc
 	alloc := &structs.Allocation{
 		Namespace: structs.DefaultNamespace,
-		ID:        structs.GenerateUUID(),
+		ID:        uuid.Generate(),
 		EvalID:    eval.ID,
 		NodeID:    node.ID,
 		JobID:     job.ID,
@@ -829,7 +830,7 @@ func TestInplaceUpdate_Success(t *testing.T) {
 	// Register an alloc
 	alloc := &structs.Allocation{
 		Namespace: structs.DefaultNamespace,
-		ID:        structs.GenerateUUID(),
+		ID:        uuid.Generate(),
 		EvalID:    eval.ID,
 		NodeID:    node.ID,
 		JobID:     job.ID,
@@ -922,10 +923,10 @@ func TestInplaceUpdate_Success(t *testing.T) {
 func TestEvictAndPlace_LimitGreaterThanAllocs(t *testing.T) {
 	_, ctx := testContext(t)
 	allocs := []allocTuple{
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
-		{Alloc: &structs.Allocation{ID: structs.GenerateUUID()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
+		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 	}
 	diff := &diffResult{}
 
@@ -1012,7 +1013,7 @@ func TestProgressMade(t *testing.T) {
 	deployment := &structs.PlanResult{Deployment: mock.Deployment()}
 	deploymentUpdates := &structs.PlanResult{
 		DeploymentUpdates: []*structs.DeploymentStatusUpdate{
-			{DeploymentID: structs.GenerateUUID()},
+			{DeploymentID: uuid.Generate()},
 		},
 	}
 	if !(progressMade(both) && progressMade(update) && progressMade(alloc) &&

--- a/testutil/vault.go
+++ b/testutil/vault.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	vapi "github.com/hashicorp/vault/api"
 	"github.com/mitchellh/go-testing-interface"
@@ -37,7 +37,7 @@ type TestVault struct {
 func NewTestVault(t testing.T) *TestVault {
 	for i := 10; i >= 0; i-- {
 		port := getPort()
-		token := structs.GenerateUUID()
+		token := uuid.Generate()
 		bind := fmt.Sprintf("-dev-listen-address=127.0.0.1:%d", port)
 		http := fmt.Sprintf("http://127.0.0.1:%d", port)
 		root := fmt.Sprintf("-dev-root-token-id=%s", token)
@@ -118,7 +118,7 @@ func NewTestVault(t testing.T) *TestVault {
 // port conflicts that may occur and retry accordingly.
 func NewTestVaultDelayed(t testing.T) *TestVault {
 	port := getPort()
-	token := structs.GenerateUUID()
+	token := uuid.Generate()
 	bind := fmt.Sprintf("-dev-listen-address=127.0.0.1:%d", port)
 	http := fmt.Sprintf("http://127.0.0.1:%d", port)
 	root := fmt.Sprintf("-dev-root-token-id=%s", token)


### PR DESCRIPTION
Goes a step further and removes structs import from api's tests as well by moving GenerateUUID to its own package. Not strictly necessary, but it seems safest to just avoid pulling in structs at all (especially for a simple GenerateUUID function).