### PR TITLE
Authenticated client volumes

### DIFF
--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -749,7 +749,7 @@ func TestAllocRunner_SaveRestoreState(t *testing.T) {
 	// Create a new alloc runner
 	l2 := prefixedTestLogger("----- ar2:  ")
 	alloc2 := &structs.Allocation{ID: ar.alloc.ID}
-	prevAlloc := newAllocWatcher(alloc2, ar, nil, ar.config, l2)
+	prevAlloc := newAllocWatcher(alloc2, ar, nil, ar.config, l2, "")
 	ar2 := NewAllocRunner(l2, ar.config, ar.stateDB, upd.Update,
 		alloc2, ar.vaultClient, ar.consulClient, prevAlloc)
 	err = ar2.RestoreState()
@@ -844,7 +844,7 @@ func TestAllocRunner_SaveRestoreState_TerminalAlloc(t *testing.T) {
 	// Create a new alloc runner
 	l2 := prefixedTestLogger("ar2: ")
 	alloc2 := &structs.Allocation{ID: ar.alloc.ID}
-	prevAlloc := newAllocWatcher(alloc2, ar, nil, ar.config, l2)
+	prevAlloc := newAllocWatcher(alloc2, ar, nil, ar.config, l2, "")
 	ar2 := NewAllocRunner(l2, ar.config, ar.stateDB, upd.Update,
 		alloc2, ar.vaultClient, ar.consulClient, prevAlloc)
 	err = ar2.RestoreState()
@@ -959,7 +959,7 @@ func TestAllocRunner_SaveRestoreState_Upgrade(t *testing.T) {
 	// Create a new alloc runner
 	l2 := prefixedTestLogger("ar2: ")
 	alloc2 := &structs.Allocation{ID: ar.alloc.ID}
-	prevAlloc := newAllocWatcher(alloc2, ar, nil, origConfig, l2)
+	prevAlloc := newAllocWatcher(alloc2, ar, nil, origConfig, l2, "")
 	ar2 := NewAllocRunner(l2, origConfig, ar.stateDB, upd.Update, alloc2, ar.vaultClient, ar.consulClient, prevAlloc)
 	err = ar2.RestoreState()
 	if err != nil {
@@ -1413,7 +1413,7 @@ func TestAllocRunner_MoveAllocDir(t *testing.T) {
 	upd2, ar2 := testAllocRunnerFromAlloc(alloc2, false)
 
 	// Set prevAlloc like Client does
-	ar2.prevAlloc = newAllocWatcher(alloc2, ar, nil, ar2.config, ar2.logger)
+	ar2.prevAlloc = newAllocWatcher(alloc2, ar, nil, ar2.config, ar2.logger, "")
 
 	go ar2.Run()
 	defer ar2.Destroy()

--- a/client/alloc_watcher_test.go
+++ b/client/alloc_watcher_test.go
@@ -29,7 +29,7 @@ func TestPrevAlloc_LocalPrevAlloc(t *testing.T) {
 	task.Driver = "mock_driver"
 	task.Config["run_for"] = "500ms"
 
-	waiter := newAllocWatcher(newAlloc, prevAR, nil, nil, testLogger())
+	waiter := newAllocWatcher(newAlloc, prevAR, nil, nil, testLogger(), "")
 
 	// Wait in a goroutine with a context to make sure it exits at the right time
 	ctx, cancel := context.WithCancel(context.Background())

--- a/client/client.go
+++ b/client/client.go
@@ -526,6 +526,9 @@ func (c *Client) LatestHostStats() *stats.HostStats {
 	return c.hostStatsCollector.Stats()
 }
 
+// ValidateMigrateToken verifies that a token is for a specific client and
+// allocation, and has been created by a trusted party that has privilaged
+// knowledge of the client's secret identifier
 func (c *Client) ValidateMigrateToken(allocID, migrateToken string) bool {
 	if !c.config.ACLEnabled {
 		return true

--- a/client/client.go
+++ b/client/client.go
@@ -527,7 +527,7 @@ func (c *Client) LatestHostStats() *stats.HostStats {
 }
 
 // ValidateMigrateToken verifies that a token is for a specific client and
-// allocation, and has been created by a trusted party that has privilaged
+// allocation, and has been created by a trusted party that has privileged
 // knowledge of the client's secret identifier
 func (c *Client) ValidateMigrateToken(allocID, migrateToken string) bool {
 	if !c.config.ACLEnabled {

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -88,12 +88,11 @@ func (s *HTTPServer) ClientAllocRequest(resp http.ResponseWriter, req *http.Requ
 		return nil, CodedError(404, resourceNotFoundErr)
 	}
 	allocID := tokens[0]
-	migrateToken := req.Header.Get("X-Nomad-Token")
 	switch tokens[1] {
 	case "stats":
 		return s.allocStats(allocID, resp, req)
 	case "snapshot":
-		return s.allocSnapshot(allocID, migrateToken, resp, req)
+		return s.allocSnapshot(allocID, resp, req)
 	case "gc":
 		return s.allocGC(allocID, resp, req)
 	}
@@ -135,8 +134,10 @@ func (s *HTTPServer) allocGC(allocID string, resp http.ResponseWriter, req *http
 	return nil, s.agent.Client().CollectAllocation(allocID)
 }
 
-func (s *HTTPServer) allocSnapshot(allocID, migrateToken string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if !s.agent.Client().ValidateMigrateToken(allocID, migrateToken) {
+func (s *HTTPServer) allocSnapshot(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	var secret string
+	s.parseToken(req, &secret)
+	if !s.agent.Client().ValidateMigrateToken(allocID, secret) {
 		return nil, fmt.Errorf("invalid migrate token for allocation %q", allocID)
 	}
 

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -138,7 +138,7 @@ func (s *HTTPServer) allocSnapshot(allocID string, resp http.ResponseWriter, req
 	var secret string
 	s.parseToken(req, &secret)
 	if !s.agent.Client().ValidateMigrateToken(allocID, secret) {
-		return nil, fmt.Errorf("invalid migrate token for allocation %q", allocID)
+		return nil, structs.ErrPermissionDenied
 	}
 
 	allocFS, err := s.agent.Client().GetAllocFS(allocID)

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -320,6 +320,11 @@ func TestHTTP_AllocSnapshot(t *testing.T) {
 
 func createMigrateTokenForClientAndAlloc(allocID, clientSecret string) (string, error) {
 	h, err := blake2b.New512([]byte(clientSecret))
+
+	if err != nil {
+		return "", err
+	}
+
 	h.Write([]byte(allocID))
 	validMigrateToken, err := string(h.Sum(nil)), nil
 	return validMigrateToken, err

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -342,7 +342,7 @@ func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
 		respW := httptest.NewRecorder()
 		_, err = s.Server.ClientAllocRequest(respW, req)
 		assert.NotNil(err)
-		assert.Contains(err.Error(), "invalid migrate token")
+		assert.EqualError(err, structs.ErrPermissionDenied.Error())
 
 		// Create an allocation
 		alloc := mock.Alloc()
@@ -360,7 +360,7 @@ func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
 		// Make the unauthorized request
 		respW = httptest.NewRecorder()
 		_, err = s.Server.ClientAllocRequest(respW, req)
-		assert.NotContains(err.Error(), "invalid migrate token")
+		assert.NotContains(err.Error(), structs.ErrPermissionDenied.Error())
 	})
 }
 

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -334,7 +334,7 @@ func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 	httpACLTest(t, nil, func(s *TestAgent) {
-		// Request without a token succeeds
+		// Request without a token fails
 		req, err := http.NewRequest("GET", "/v1/client/allocation/123/snapshot", nil)
 		assert.Nil(err)
 
@@ -345,9 +345,7 @@ func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
 		assert.Contains(err.Error(), "invalid migrate token")
 
 		// Create an allocation
-		state := s.Agent.server.State()
 		alloc := mock.Alloc()
-		state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID))
 
 		validMigrateToken, err := createMigrateTokenForClientAndAlloc(alloc.ID, s.Agent.Client().Node().SecretID)
 		assert.Nil(err)

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -317,6 +318,13 @@ func TestHTTP_AllocSnapshot(t *testing.T) {
 	})
 }
 
+func createMigrateTokenForClientAndAlloc(allocID, clientSecret string) (string, error) {
+	h, err := blake2b.New512([]byte(clientSecret))
+	h.Write([]byte(allocID))
+	validMigrateToken, err := string(h.Sum(nil)), nil
+	return validMigrateToken, err
+}
+
 func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
@@ -336,22 +344,20 @@ func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
 		alloc := mock.Alloc()
 		state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID))
 
-		// Set up data to create an authenticated request
-		h, err := blake2b.New512([]byte(s.Agent.Client().Node().SecretID))
-		h.Write([]byte(alloc.ID))
-		validMigrateToken, err := string(h.Sum(nil)), nil
+		validMigrateToken, err := createMigrateTokenForClientAndAlloc(alloc.ID, s.Agent.Client().Node().SecretID)
 		assert.Nil(err)
 
 		// Request with a token succeeds
-		req.Header.Set("X-Nomad-Token", validMigrateToken)
-		req, err = http.NewRequest("GET", "/v1/client/allocation/123/snapshot", nil)
+		url := fmt.Sprintf("/v1/client/allocation/%s/snapshot", alloc.ID)
+		req, err = http.NewRequest("GET", url, nil)
 		assert.Nil(err)
+
+		req.Header.Set("X-Nomad-Token", validMigrateToken)
 
 		// Make the unauthorized request
 		respW = httptest.NewRecorder()
 		_, err = s.Server.ClientAllocRequest(respW, req)
-		assert.NotNil(err)
-		assert.Contains(err.Error(), "invalid migrate token")
+		assert.NotContains(err.Error(), "invalid migrate token")
 	})
 }
 

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -316,6 +316,24 @@ func TestHTTP_AllocSnapshot(t *testing.T) {
 	})
 }
 
+func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	httpACLTest(t, nil, func(s *TestAgent) {
+		// TODO add an allocation, assert it is returned
+
+		// Request without a token succeeds
+		req, err := http.NewRequest("GET", "/v1/client/allocation/123/snapshot", nil)
+		assert.Nil(err)
+
+		// Make the unauthorized request
+		respW := httptest.NewRecorder()
+		_, err = s.Server.ClientAllocRequest(respW, req)
+		assert.NotNil(err)
+		assert.Contains(err.Error(), "invalid migrate token")
+	})
+}
+
 func TestHTTP_AllocGC(t *testing.T) {
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -704,6 +704,9 @@ func (n *Node) GetClientAllocs(args *structs.NodeSpecificRequest,
 					reply.Allocs[alloc.ID] = alloc.AllocModifyIndex
 
 					allocNode, err := state.NodeByID(ws, args.NodeID)
+					if err != nil {
+						return err
+					}
 					token, err := generateMigrateToken(alloc.ID, allocNode.SecretID)
 					if err != nil {
 						return err

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1384,7 +1384,7 @@ func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 	}
 }
 
-func TestClientEndpoint_GetClientAllocs_WIthMigrateTokens(t *testing.T) {
+func TestClientEndpoint_GetClientAllocs_WithMigrateTokens(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -818,7 +818,8 @@ type NodeAllocsResponse struct {
 type NodeClientAllocsResponse struct {
 	Allocs map[string]uint64
 
-	// MigrateTokens are used when ACLs are enabled to verify volume access
+	// MigrateTokens are used when ACLs are enabled to allow cross node,
+	// authenticated access to sticky volumes
 	MigrateTokens map[string]string
 
 	QueryMeta

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -817,6 +817,10 @@ type NodeAllocsResponse struct {
 // NodeClientAllocsResponse is used to return allocs meta data for a single node
 type NodeClientAllocsResponse struct {
 	Allocs map[string]uint64
+
+	// MigrateTokens are used when ACLs are enabled to verify volume access
+	MigrateTokens map[string]string
+
 	QueryMeta
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4690,6 +4690,10 @@ func (a *Allocation) RanSuccessfully() bool {
 
 // ShouldMigrate returns if the allocation needs data migration
 func (a *Allocation) ShouldMigrate() bool {
+	if a.PreviousAllocation == "" {
+		return false
+	}
+
 	if a.DesiredStatus == AllocDesiredStatusStop || a.DesiredStatus == AllocDesiredStatusEvict {
 		return false
 	}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2045,7 +2045,8 @@ func TestTaskArtifact_Validate_Dest(t *testing.T) {
 
 func TestAllocation_ShouldMigrate(t *testing.T) {
 	alloc := Allocation{
-		TaskGroup: "foo",
+		PreviousAllocation: "123",
+		TaskGroup:          "foo",
 		Job: &Job{
 			TaskGroups: []*TaskGroup{
 				{
@@ -2064,7 +2065,8 @@ func TestAllocation_ShouldMigrate(t *testing.T) {
 	}
 
 	alloc1 := Allocation{
-		TaskGroup: "foo",
+		PreviousAllocation: "123",
+		TaskGroup:          "foo",
 		Job: &Job{
 			TaskGroups: []*TaskGroup{
 				{
@@ -2080,7 +2082,8 @@ func TestAllocation_ShouldMigrate(t *testing.T) {
 	}
 
 	alloc2 := Allocation{
-		TaskGroup: "foo",
+		PreviousAllocation: "123",
+		TaskGroup:          "foo",
 		Job: &Job{
 			TaskGroups: []*TaskGroup{
 				{
@@ -2099,7 +2102,8 @@ func TestAllocation_ShouldMigrate(t *testing.T) {
 	}
 
 	alloc3 := Allocation{
-		TaskGroup: "foo",
+		PreviousAllocation: "123",
+		TaskGroup:          "foo",
 		Job: &Job{
 			TaskGroups: []*TaskGroup{
 				{
@@ -2111,6 +2115,26 @@ func TestAllocation_ShouldMigrate(t *testing.T) {
 
 	if alloc3.ShouldMigrate() {
 		t.Fatalf("bad: %v", alloc)
+	}
+
+	// No previous
+	alloc4 := Allocation{
+		TaskGroup: "foo",
+		Job: &Job{
+			TaskGroups: []*TaskGroup{
+				{
+					Name: "foo",
+					EphemeralDisk: &EphemeralDisk{
+						Migrate: true,
+						Sticky:  true,
+					},
+				},
+			},
+		},
+	}
+
+	if alloc4.ShouldMigrate() {
+		t.Fatalf("bad: %v", alloc4)
 	}
 }
 


### PR DESCRIPTION
This PR includes: 
- Adding migrateToken authentication for /v1/client/allocation/<alloc-id>/gc endpoint
- Adding migrateToken authentication for /v1/client/allocation/<alloc-id>/snapshot endpoint
- Client management of migrateTokens, fetched from the server and associated with a single sticky volume to migrate

Considerations: 
- Testing client functionality was difficult- any recommendation to do more integration testing here would be great. 