### PR TITLE
/v1/client/gc ACL enforcement

### DIFF
--- a/command/acl_policy_apply_test.go
+++ b/command/acl_policy_apply_test.go
@@ -23,7 +23,7 @@ func TestACLPolicyApplyCommand(t *testing.T) {
 	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
-	token := srv.Token
+	token := srv.RootToken
 	assert.NotNil(token, "failed to bootstrap ACL token")
 
 	ui := new(cli.MockUi)

--- a/command/acl_policy_delete_test.go
+++ b/command/acl_policy_delete_test.go
@@ -26,7 +26,7 @@ func TestACLPolicyDeleteCommand(t *testing.T) {
 	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
-	token := srv.Token
+	token := srv.RootToken
 	assert.NotNil(token, "failed to bootstrap ACL token")
 
 	// Create a test ACLPolicy

--- a/command/acl_policy_info_test.go
+++ b/command/acl_policy_info_test.go
@@ -25,7 +25,7 @@ func TestACLPolicyListCommand(t *testing.T) {
 	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
-	token := srv.Token
+	token := srv.RootToken
 	assert.NotNil(token, "failed to bootstrap ACL token")
 
 	// Create a test ACLPolicy

--- a/command/acl_token_create_test.go
+++ b/command/acl_token_create_test.go
@@ -21,7 +21,7 @@ func TestACLTokenCreateCommand(t *testing.T) {
 	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
-	token := srv.Token
+	token := srv.RootToken
 	assert.NotNil(token, "failed to bootstrap ACL token")
 
 	ui := new(cli.MockUi)

--- a/command/acl_token_delete_test.go
+++ b/command/acl_token_delete_test.go
@@ -25,7 +25,7 @@ func TestACLTokenDeleteCommand_ViaEnvVariable(t *testing.T) {
 	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
-	token := srv.Token
+	token := srv.RootToken
 	assert.NotNil(token, "failed to bootstrap ACL token")
 
 	ui := new(cli.MockUi)

--- a/command/acl_token_info_test.go
+++ b/command/acl_token_info_test.go
@@ -25,7 +25,7 @@ func TestACLTokenInfoCommand_ViaEnvVar(t *testing.T) {
 	state := srv.Agent.Server().State()
 
 	// Bootstrap an initial ACL token
-	token := srv.Token
+	token := srv.RootToken
 	assert.NotNil(token, "failed to bootstrap ACL token")
 
 	ui := new(cli.MockUi)

--- a/command/acl_token_update_test.go
+++ b/command/acl_token_update_test.go
@@ -22,7 +22,7 @@ func TestACLTokenUpdateCommand(t *testing.T) {
 	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
-	token := srv.Token
+	token := srv.RootToken
 	assert.NotNil(token, "failed to bootstrap ACL token")
 
 	ui := new(cli.MockUi)

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -20,7 +20,7 @@ func TestHTTP_ACLPolicyList(t *testing.T) {
 			Policies: []*structs.ACLPolicy{p1, p2, p3},
 			WriteRequest: structs.WriteRequest{
 				Region:   "global",
-				SecretID: s.Token.SecretID,
+				SecretID: s.RootToken.SecretID,
 			},
 		}
 		var resp structs.GenericResponse
@@ -34,7 +34,7 @@ func TestHTTP_ACLPolicyList(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
-		setToken(req, s.Token)
+		setToken(req, s.RootToken)
 
 		// Make the request
 		obj, err := s.Server.ACLPoliciesRequest(respW, req)
@@ -69,7 +69,7 @@ func TestHTTP_ACLPolicyQuery(t *testing.T) {
 			Policies: []*structs.ACLPolicy{p1},
 			WriteRequest: structs.WriteRequest{
 				Region:   "global",
-				SecretID: s.Token.SecretID,
+				SecretID: s.RootToken.SecretID,
 			},
 		}
 		var resp structs.GenericResponse
@@ -83,7 +83,7 @@ func TestHTTP_ACLPolicyQuery(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
-		setToken(req, s.Token)
+		setToken(req, s.RootToken)
 
 		// Make the request
 		obj, err := s.Server.ACLPolicySpecificRequest(respW, req)
@@ -121,7 +121,7 @@ func TestHTTP_ACLPolicyCreate(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
-		setToken(req, s.Token)
+		setToken(req, s.RootToken)
 
 		// Make the request
 		obj, err := s.Server.ACLPolicySpecificRequest(respW, req)
@@ -153,7 +153,7 @@ func TestHTTP_ACLPolicyDelete(t *testing.T) {
 			Policies: []*structs.ACLPolicy{p1},
 			WriteRequest: structs.WriteRequest{
 				Region:   "global",
-				SecretID: s.Token.SecretID,
+				SecretID: s.RootToken.SecretID,
 			},
 		}
 		var resp structs.GenericResponse
@@ -167,7 +167,7 @@ func TestHTTP_ACLPolicyDelete(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
-		setToken(req, s.Token)
+		setToken(req, s.RootToken)
 
 		// Make the request
 		obj, err := s.Server.ACLPolicySpecificRequest(respW, req)
@@ -232,7 +232,7 @@ func TestHTTP_ACLTokenList(t *testing.T) {
 			Tokens: []*structs.ACLToken{p1, p2, p3},
 			WriteRequest: structs.WriteRequest{
 				Region:   "global",
-				SecretID: s.Token.SecretID,
+				SecretID: s.RootToken.SecretID,
 			},
 		}
 		var resp structs.ACLTokenUpsertResponse
@@ -246,7 +246,7 @@ func TestHTTP_ACLTokenList(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
-		setToken(req, s.Token)
+		setToken(req, s.RootToken)
 
 		// Make the request
 		obj, err := s.Server.ACLTokensRequest(respW, req)
@@ -282,7 +282,7 @@ func TestHTTP_ACLTokenQuery(t *testing.T) {
 			Tokens: []*structs.ACLToken{p1},
 			WriteRequest: structs.WriteRequest{
 				Region:   "global",
-				SecretID: s.Token.SecretID,
+				SecretID: s.RootToken.SecretID,
 			},
 		}
 		var resp structs.ACLTokenUpsertResponse
@@ -297,7 +297,7 @@ func TestHTTP_ACLTokenQuery(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
-		setToken(req, s.Token)
+		setToken(req, s.RootToken)
 
 		// Make the request
 		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)
@@ -334,7 +334,7 @@ func TestHTTP_ACLTokenCreate(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
-		setToken(req, s.Token)
+		setToken(req, s.RootToken)
 
 		// Make the request
 		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)
@@ -365,7 +365,7 @@ func TestHTTP_ACLTokenDelete(t *testing.T) {
 			Tokens: []*structs.ACLToken{p1},
 			WriteRequest: structs.WriteRequest{
 				Region:   "global",
-				SecretID: s.Token.SecretID,
+				SecretID: s.RootToken.SecretID,
 			},
 		}
 		var resp structs.ACLTokenUpsertResponse
@@ -380,7 +380,7 @@ func TestHTTP_ACLTokenDelete(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
-		setToken(req, s.Token)
+		setToken(req, s.RootToken)
 
 		// Make the request
 		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -103,6 +103,17 @@ func (s *HTTPServer) ClientGCRequest(resp http.ResponseWriter, req *http.Request
 	if s.agent.client == nil {
 		return nil, clientNotRunning
 	}
+
+	var secret string
+	s.parseToken(req, &secret)
+
+	// Check node write permissions
+	if aclObj, err := s.agent.Client().ResolveToken(secret); err != nil {
+		return nil, err
+	} else if aclObj != nil && !aclObj.AllowNodeWrite() {
+		return nil, structs.ErrPermissionDenied
+	}
+
 	return nil, s.agent.Client().CollectAllAllocs()
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -200,7 +200,7 @@ func TestHTTP_JobsRegister_ACL(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		respW := httptest.NewRecorder()
-		setToken(req, s.Token)
+		setToken(req, s.RootToken)
 
 		// Make the request
 		obj, err := s.Server.JobsRequest(respW, req)

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -69,8 +69,8 @@ type TestAgent struct {
 	// It is valid after Start().
 	*Agent
 
-	// Token is auto-bootstrapped if ACLs are enabled
-	Token *structs.ACLToken
+	// RootToken is auto-bootstrapped if ACLs are enabled
+	RootToken *structs.ACLToken
 }
 
 // NewTestAgent returns a started agent with the given name and
@@ -174,9 +174,9 @@ func (a *TestAgent) Start() *TestAgent {
 	// to do a bypass of this step. This is so we can test bootstrap
 	// without having to pass down a special flag.
 	if a.Config.ACL.Enabled && a.Config.Server.Enabled && a.Config.ACL.PolicyTTL != 0 {
-		a.Token = mock.ACLManagementToken()
+		a.RootToken = mock.ACLManagementToken()
 		state := a.Agent.server.State()
-		if err := state.BootstrapACLTokens(1, 0, a.Token); err != nil {
+		if err := state.BootstrapACLTokens(1, 0, a.RootToken); err != nil {
 			panic(fmt.Sprintf("token bootstrap failed: %v", err))
 		}
 	}

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -228,7 +228,7 @@ func TestJobStatusCommand_WithAccessPolicy(t *testing.T) {
 	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
-	token := srv.Token
+	token := srv.RootToken
 	assert.NotNil(token, "failed to bootstrap ACL token")
 
 	// Register a job

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -101,10 +101,10 @@ func TestAllocEndpoint_List_ACL(t *testing.T) {
 	stubAllocs[0].ModifyIndex = 1000
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	// Lookup the allocs without a token and expect failure
 	get := &structs.AllocListRequest{
@@ -262,10 +262,10 @@ func TestAllocEndpoint_GetAlloc_ACL(t *testing.T) {
 	assert.Nil(state.UpsertAllocs(1000, allocs), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	// Lookup the alloc without a token and expect failure
 	get := &structs.AllocSpecificRequest{

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -63,10 +63,10 @@ func TestDeploymentEndpoint_GetDeployment_ACL(t *testing.T) {
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	// Lookup the deployments without a token and expect failure
 	get := &structs.DeploymentSpecificRequest{
@@ -216,10 +216,10 @@ func TestDeploymentEndpoint_Fail_ACL(t *testing.T) {
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	// Mark the deployment as failed
 	req := &structs.DeploymentFailRequest{
@@ -408,10 +408,10 @@ func TestDeploymentEndpoint_Pause_ACL(t *testing.T) {
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	// Mark the deployment as failed
 	req := &structs.DeploymentPauseRequest{
@@ -551,10 +551,10 @@ func TestDeploymentEndpoint_Promote_ACL(t *testing.T) {
 	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	// Promote the deployment
 	req := &structs.DeploymentPromoteRequest{
@@ -703,10 +703,10 @@ func TestDeploymentEndpoint_SetAllocHealth_ACL(t *testing.T) {
 	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	// Set the alloc as healthy
 	req := &structs.DeploymentAllocHealthRequest{
@@ -921,10 +921,10 @@ func TestDeploymentEndpoint_List_ACL(t *testing.T) {
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get := &structs.DeploymentListRequest{
 		QueryOptions: structs.QueryOptions{
@@ -1088,10 +1088,10 @@ func TestDeploymentEndpoint_Allocations_ACL(t *testing.T) {
 	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get := &structs.DeploymentSpecificRequest{
 		DeploymentID: d.ID,

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -73,10 +73,10 @@ func TestEvalEndpoint_GetEval_ACL(t *testing.T) {
 	state.UpsertEvals(1000, []*structs.Evaluation{eval1})
 
 	// Create ACL tokens
-	validToken := CreatePolicyAndToken(t, state, 1003, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1001, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1003, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get := &structs.EvalSpecificRequest{
 		EvalID:       eval1.ID,
@@ -611,10 +611,10 @@ func TestEvalEndpoint_List_ACL(t *testing.T) {
 	assert.Nil(state.UpsertEvals(1000, []*structs.Evaluation{eval1, eval2}))
 
 	// Create ACL tokens
-	validToken := CreatePolicyAndToken(t, state, 1003, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1001, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1003, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get := &structs.EvalListRequest{
 		QueryOptions: structs.QueryOptions{
@@ -781,10 +781,10 @@ func TestEvalEndpoint_Allocations_ACL(t *testing.T) {
 	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{alloc1, alloc2}))
 
 	// Create ACL tokens
-	validToken := CreatePolicyAndToken(t, state, 1003, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
-	invalidToken := CreatePolicyAndToken(t, state, 1001, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1003, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get := &structs.EvalSpecificRequest{
 		EvalID:       alloc1.EvalID,

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1064,8 +1064,8 @@ func TestJobEndpoint_Revert_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Attempt to fetch the response with an invalid token
-	invalidToken := CreatePolicyAndToken(t, state, 1001, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	revertReq.SecretID = invalidToken.SecretID
 	var invalidResp structs.JobRegisterResponse
@@ -1080,8 +1080,8 @@ func TestJobEndpoint_Revert_ACL(t *testing.T) {
 	assert.Nil(err)
 
 	// Try with a valid non-management token
-	validToken := CreatePolicyAndToken(t, state, 1003, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1003, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
 
 	revertReq.SecretID = validToken.SecretID
 	var validResp2 structs.JobRegisterResponse
@@ -1187,8 +1187,8 @@ func TestJobEndpoint_Stable_ACL(t *testing.T) {
 	assert.Contains("Permission denied", err.Error())
 
 	// Expect failure for request with an invalid token
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	stableReq.SecretID = invalidToken.SecretID
 	var invalidStableResp structs.JobStabilityResponse
@@ -1203,8 +1203,8 @@ func TestJobEndpoint_Stable_ACL(t *testing.T) {
 	assert.Nil(err)
 
 	// Attempt to fetch with a valid token
-	validToken := CreatePolicyAndToken(t, state, 1005, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1005, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
 
 	stableReq.SecretID = validToken.SecretID
 	var validStableResp2 structs.JobStabilityResponse
@@ -1331,8 +1331,8 @@ func TestJobEndpoint_Evaluate_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Attempt to fetch the response with an invalid token
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	reEval.SecretID = invalidToken.SecretID
 	var invalidResp structs.JobRegisterResponse
@@ -1347,8 +1347,8 @@ func TestJobEndpoint_Evaluate_ACL(t *testing.T) {
 	assert.Nil(err)
 
 	// Fetch the response with a valid token
-	validToken := CreatePolicyAndToken(t, state, 1005, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1005, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	reEval.SecretID = validToken.SecretID
 	var validResp2 structs.JobRegisterResponse
@@ -1636,8 +1636,8 @@ func TestJobEndpoint_Deregister_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Expect failure for request with an invalid token
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 	req.SecretID = invalidToken.SecretID
 
 	var invalidResp structs.JobDeregisterResponse
@@ -1654,8 +1654,8 @@ func TestJobEndpoint_Deregister_ACL(t *testing.T) {
 	assert.NotEqual(validResp.Index, 0)
 
 	// Expect success with a valid token
-	validToken := CreatePolicyAndToken(t, state, 1005, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1005, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
 	req.SecretID = validToken.SecretID
 
 	var validResp2 structs.JobDeregisterResponse
@@ -1970,8 +1970,8 @@ func TestJobEndpoint_GetJob_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Expect failure for request with an invalid token
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get.SecretID = invalidToken.SecretID
 	var invalidResp structs.SingleJobResponse
@@ -1987,8 +1987,8 @@ func TestJobEndpoint_GetJob_ACL(t *testing.T) {
 	assert.Equal(job.ID, validResp.Job.ID)
 
 	// Looking up the job with a valid token should succeed
-	validToken := CreatePolicyAndToken(t, state, 1005, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1005, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	get.SecretID = validToken.SecretID
 	var validResp2 structs.SingleJobResponse
@@ -2181,8 +2181,8 @@ func TestJobEndpoint_GetJobVersions_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Expect failure for request with an invalid token
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get.SecretID = invalidToken.SecretID
 	var invalidResp structs.JobVersionsResponse
@@ -2197,8 +2197,8 @@ func TestJobEndpoint_GetJobVersions_ACL(t *testing.T) {
 	assert.Nil(err)
 
 	// Expect success for request with a valid token
-	validToken := CreatePolicyAndToken(t, state, 1005, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1005, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	get.SecretID = validToken.SecretID
 	var validResp2 structs.JobVersionsResponse
@@ -2522,8 +2522,8 @@ func TestJobEndpoint_Summary_ACL(t *testing.T) {
 	state := srv.fsm.State()
 
 	// Expect failure for request with an invalid token
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	req.SecretID = invalidToken.SecretID
 	var invalidResp structs.JobSummaryResponse
@@ -2531,8 +2531,8 @@ func TestJobEndpoint_Summary_ACL(t *testing.T) {
 	assert.NotNil(err)
 
 	// Try with a valid token
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	req.SecretID = validToken.SecretID
 	var authResp structs.JobSummaryResponse
@@ -2735,8 +2735,8 @@ func TestJobEndpoint_ListJobs_WithACL(t *testing.T) {
 	assert.Equal(job.ID, mgmtResp.Jobs[0].ID)
 
 	// Expect failure for request with a token that has incorrect permissions
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	req.SecretID = invalidToken.SecretID
 	var invalidResp structs.JobListResponse
@@ -2744,8 +2744,8 @@ func TestJobEndpoint_ListJobs_WithACL(t *testing.T) {
 	assert.NotNil(err)
 
 	// Try with a valid token with correct permissions
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 	var validResp structs.JobListResponse
 	req.SecretID = validToken.SecretID
 
@@ -2898,8 +2898,8 @@ func TestJobEndpoint_Allocations_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Attempt to fetch the response with an invalid token should fail
-	invalidToken := CreatePolicyAndToken(t, state, 1001, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get.SecretID = invalidToken.SecretID
 	var invalidResp structs.JobAllocationsResponse
@@ -2914,8 +2914,8 @@ func TestJobEndpoint_Allocations_ACL(t *testing.T) {
 	assert.Nil(err)
 
 	// Attempt to fetch the response with valid management token should succeed
-	validToken := CreatePolicyAndToken(t, state, 1005, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1005, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	get.SecretID = validToken.SecretID
 	var validResp2 structs.JobAllocationsResponse
@@ -3055,8 +3055,8 @@ func TestJobEndpoint_Evaluations_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Attempt to fetch the response with an invalid token
-	invalidToken := CreatePolicyAndToken(t, state, 1001, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get.SecretID = invalidToken.SecretID
 	var invalidResp structs.JobEvaluationsResponse
@@ -3072,8 +3072,8 @@ func TestJobEndpoint_Evaluations_ACL(t *testing.T) {
 	assert.Equal(2, len(validResp.Evaluations))
 
 	// Attempt to fetch with valid token should succeed
-	validToken := CreatePolicyAndToken(t, state, 1003, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1003, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	get.SecretID = validToken.SecretID
 	var validResp2 structs.JobEvaluationsResponse
@@ -3205,8 +3205,8 @@ func TestJobEndpoint_Deployments_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Attempt to fetch the response with an invalid token
-	invalidToken := CreatePolicyAndToken(t, state, 1001, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get.SecretID = invalidToken.SecretID
 	var invalidResp structs.DeploymentListResponse
@@ -3222,8 +3222,8 @@ func TestJobEndpoint_Deployments_ACL(t *testing.T) {
 	assert.Len(validResp.Deployments, 2, "deployments for job")
 
 	// Lookup with valid token should succeed
-	validToken := CreatePolicyAndToken(t, state, 1005, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1005, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	get.SecretID = validToken.SecretID
 	var validResp2 structs.DeploymentListResponse
@@ -3352,8 +3352,8 @@ func TestJobEndpoint_LatestDeployment_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Attempt to fetch the response with an invalid token should fail
-	invalidToken := CreatePolicyAndToken(t, state, 1001, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
 	get.SecretID = invalidToken.SecretID
 	var invalidResp structs.SingleDeploymentResponse
@@ -3370,8 +3370,8 @@ func TestJobEndpoint_LatestDeployment_ACL(t *testing.T) {
 	assert.Equal(d2.ID, validResp.Deployment.ID, "latest deployment for job")
 
 	// Fetching latest deployment with a valid token should succeed
-	validToken := CreatePolicyAndToken(t, state, 1004, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1004, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	get.SecretID = validToken.SecretID
 	var validResp2 structs.SingleDeploymentResponse
@@ -3852,8 +3852,8 @@ func TestJobEndpoint_Dispatch_ACL(t *testing.T) {
 	assert.Contains(err.Error(), "Permission denied")
 
 	// Attempt to fetch the response with an invalid token should fail
-	invalidToken := CreatePolicyAndToken(t, state, 1001, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 	req.SecretID = invalidToken.SecretID
 
 	var invalidResp structs.JobDispatchResponse
@@ -3872,8 +3872,8 @@ func TestJobEndpoint_Dispatch_ACL(t *testing.T) {
 	assert.NotEqual(validResp.DispatchedJobID, "")
 
 	// Dispatch with a valid token should succeed
-	validToken := CreatePolicyAndToken(t, state, 1003, "test-valid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityDispatchJob}))
+	validToken := mock.CreatePolicyAndToken(t, state, 1003, "test-valid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityDispatchJob}))
 	req.SecretID = validToken.SecretID
 
 	var validResp2 structs.JobDispatchResponse

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -674,8 +674,8 @@ func TestClientEndpoint_UpdateDrain_ACL(t *testing.T) {
 	assert.Nil(state.UpsertNode(1, node), "UpsertNode")
 
 	// Create the policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid", NodePolicy(acl.PolicyWrite))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid", NodePolicy(acl.PolicyRead))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyWrite))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid", mock.NodePolicy(acl.PolicyRead))
 
 	// Update the status without a token and expect failure
 	dereg := &structs.NodeUpdateDrainRequest{
@@ -925,8 +925,8 @@ func TestClientEndpoint_GetNode_ACL(t *testing.T) {
 	assert.Nil(state.UpsertNode(1, node), "UpsertNode")
 
 	// Create the policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid", NodePolicy(acl.PolicyRead))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid", NodePolicy(acl.PolicyDeny))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyRead))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid", mock.NodePolicy(acl.PolicyDeny))
 
 	// Lookup the node without a token and expect failure
 	req := &structs.NodeSpecificRequest{
@@ -1158,11 +1158,11 @@ func TestClientEndpoint_GetAllocs_ACL(t *testing.T) {
 	assert.Nil(state.UpsertAllocs(5, allocs), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
-	validDefaultToken := CreatePolicyAndToken(t, state, 1001, "test-default-valid", NodePolicy(acl.PolicyRead)+
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
-	validNoNSToken := CreatePolicyAndToken(t, state, 1003, "test-alt-valid", NodePolicy(acl.PolicyRead))
-	invalidToken := CreatePolicyAndToken(t, state, 1004, "test-invalid",
-		NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validDefaultToken := mock.CreatePolicyAndToken(t, state, 1001, "test-default-valid", mock.NodePolicy(acl.PolicyRead)+
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+	validNoNSToken := mock.CreatePolicyAndToken(t, state, 1003, "test-alt-valid", mock.NodePolicy(acl.PolicyRead))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1004, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	// Lookup the node without a token and expect failure
 	req := &structs.NodeSpecificRequest{
@@ -1861,8 +1861,8 @@ func TestClientEndpoint_Evaluate_ACL(t *testing.T) {
 	assert.Nil(state.UpsertAllocs(3, []*structs.Allocation{alloc}), "UpsertAllocs")
 
 	// Create the policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid", NodePolicy(acl.PolicyWrite))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid", NodePolicy(acl.PolicyRead))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyWrite))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid", mock.NodePolicy(acl.PolicyRead))
 
 	// Re-evaluate without a token and expect failure
 	req := &structs.NodeEvaluateRequest{
@@ -1975,8 +1975,8 @@ func TestClientEndpoint_ListNodes_ACL(t *testing.T) {
 	assert.Nil(state.UpsertNode(1, node), "UpsertNode")
 
 	// Create the namespace policy and tokens
-	validToken := CreatePolicyAndToken(t, state, 1001, "test-valid", NodePolicy(acl.PolicyRead))
-	invalidToken := CreatePolicyAndToken(t, state, 1003, "test-invalid", NodePolicy(acl.PolicyDeny))
+	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyRead))
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid", mock.NodePolicy(acl.PolicyDeny))
 
 	// Lookup the node without a token and expect failure
 	req := &structs.NodeListRequest{

--- a/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
@@ -1,4 +1,9 @@
-// +build !go1.9
+// +build go1.9
+
+// NOTE: This is a temporary copy of testing.go for Go 1.9 with the addition
+// of "Helper" to the T interface. Go 1.9 at the time of typing is in RC
+// and is set for release shortly. We'll support this on master as the default
+// as soon as 1.9 is released.
 
 package testing
 
@@ -26,15 +31,16 @@ type T interface {
 	SkipNow()
 	Skipf(format string, args ...interface{})
 	Skipped() bool
+	Helper()
 }
 
 // RuntimeT implements T and can be instantiated and run at runtime to
 // mimic *testing.T behavior. Unlike *testing.T, this will simply panic
 // for calls to Fatal. For calls to Error, you'll have to check the errors
-// list to determine whether to exit yourself. Name and Skip methods are
-// unimplemented noops.
+// list to determine whether to exit yourself.
 type RuntimeT struct {
-	failed bool
+	skipped bool
+	failed  bool
 }
 
 func (t *RuntimeT) Error(args ...interface{}) {
@@ -43,18 +49,8 @@ func (t *RuntimeT) Error(args ...interface{}) {
 }
 
 func (t *RuntimeT) Errorf(format string, args ...interface{}) {
-	log.Println(fmt.Sprintf(format, args...))
+	log.Printf(format, args...)
 	t.Fail()
-}
-
-func (t *RuntimeT) Fatal(args ...interface{}) {
-	log.Println(fmt.Sprintln(args...))
-	t.FailNow()
-}
-
-func (t *RuntimeT) Fatalf(format string, args ...interface{}) {
-	log.Println(fmt.Sprintf(format, args...))
-	t.FailNow()
 }
 
 func (t *RuntimeT) Fail() {
@@ -69,6 +65,16 @@ func (t *RuntimeT) Failed() bool {
 	return t.failed
 }
 
+func (t *RuntimeT) Fatal(args ...interface{}) {
+	log.Print(args...)
+	t.FailNow()
+}
+
+func (t *RuntimeT) Fatalf(format string, args ...interface{}) {
+	log.Printf(format, args...)
+	t.FailNow()
+}
+
 func (t *RuntimeT) Log(args ...interface{}) {
 	log.Println(fmt.Sprintln(args...))
 }
@@ -77,8 +83,26 @@ func (t *RuntimeT) Logf(format string, args ...interface{}) {
 	log.Println(fmt.Sprintf(format, args...))
 }
 
-func (t *RuntimeT) Name() string                             { return "" }
-func (t *RuntimeT) Skip(args ...interface{})                 {}
-func (t *RuntimeT) SkipNow()                                 {}
-func (t *RuntimeT) Skipf(format string, args ...interface{}) {}
-func (t *RuntimeT) Skipped() bool                            { return false }
+func (t *RuntimeT) Name() string {
+	return ""
+}
+
+func (t *RuntimeT) Skip(args ...interface{}) {
+	log.Print(args...)
+	t.SkipNow()
+}
+
+func (t *RuntimeT) SkipNow() {
+	t.skipped = true
+}
+
+func (t *RuntimeT) Skipf(format string, args ...interface{}) {
+	log.Printf(format, args...)
+	t.SkipNow()
+}
+
+func (t *RuntimeT) Skipped() bool {
+	return t.skipped
+}
+
+func (t *RuntimeT) Helper() {}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1130,10 +1130,10 @@
 			"revisionTime": "2017-03-09T13:30:38Z"
 		},
 		{
-			"checksumSHA1": "NRba2rT64faub6rtxKVj7xM+QAo=",
+			"checksumSHA1": "bDdhmDk8q6utWrccBhEOa6IoGkE=",
 			"path": "github.com/mitchellh/go-testing-interface",
-			"revision": "e1449340a7b207d8ca90d41466272ece75cbb5b5",
-			"revisionTime": "2017-07-25T22:03:13Z"
+			"revision": "a61a99592b77c9ba629d254a693acffaeb4b7e28",
+			"revisionTime": "2017-10-04T22:19:16Z"
 		},
 		{
 			"path": "github.com/mitchellh/hashstructure",


### PR DESCRIPTION
This PR got a bit out of hand because of the following:

- I renamed `TestAgent.Token -> RootToken` now that our agent tests need to use a variety of tokens.
- I moved `nomad/acl_testutil_test.go -> nomad/mock/acl.go` so I could use it in `command/agent/` tests.
  - That necessitated a `go-testing-interface` fork/PR/merge
- A bug in anonymous policy handling had to be fixed in the `ACL.GetPolicies` RPC
- Finally the ACL enforcement could be added to `/v1/client/gc`