### PR TITLE
Update agent CLI to include Consul config option flags.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -65,6 +65,7 @@ func (c *Command) readConfig() *Config {
 	cmdConfig := &Config{
 		Atlas:  &AtlasConfig{},
 		Client: &ClientConfig{},
+		Consul: &config.ConsulConfig{},
 		Ports:  &Ports{},
 		Server: &ServerConfig{},
 		Vault:  &config.VaultConfig{},
@@ -109,6 +110,39 @@ func (c *Command) readConfig() *Config {
 	flags.StringVar(&cmdConfig.Atlas.Infrastructure, "atlas", "", "")
 	flags.BoolVar(&cmdConfig.Atlas.Join, "atlas-join", false, "")
 	flags.StringVar(&cmdConfig.Atlas.Token, "atlas-token", "", "")
+
+	// Consul options
+	flags.StringVar(&cmdConfig.Consul.Auth, "consul-auth", "", "")
+	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
+		cmdConfig.Consul.AutoAdvertise = &b
+		return nil
+	}), "consul-auto-advertise", "")
+	flags.StringVar(&cmdConfig.Consul.CAFile, "consul-ca-file", "", "")
+	flags.StringVar(&cmdConfig.Consul.CertFile, "consul-cert-file", "", "")
+	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
+		cmdConfig.Consul.ChecksUseAdvertise = &b
+		return nil
+	}), "consul-checks-use-advertise", "")
+	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
+		cmdConfig.Consul.ClientAutoJoin = &b
+		return nil
+	}), "consul-client-auto-join", "")
+	flags.StringVar(&cmdConfig.Consul.ClientServiceName, "consul-client-service-name", "", "")
+	flags.StringVar(&cmdConfig.Consul.KeyFile, "consul-key-file", "", "")
+	flags.StringVar(&cmdConfig.Consul.ServerServiceName, "consul-server-service-name", "", "")
+	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
+		cmdConfig.Consul.ServerAutoJoin = &b
+		return nil
+	}), "consul-server-auto-join", "")
+	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
+		cmdConfig.Consul.EnableSSL = &b
+		return nil
+	}), "consul-ssl", "")
+	flags.StringVar(&cmdConfig.Consul.Token, "consul-token", "", "")
+	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
+		cmdConfig.Consul.VerifySSL = &b
+		return nil
+	}), "consul-verify-ssl", "")
 
 	// Vault options
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
@@ -949,6 +983,67 @@ Client Options:
   -network-speed
     The default speed for network interfaces in MBits if the link speed can not
     be determined dynamically.
+
+Consul Options:
+
+  -consul-address=<addr>
+    Specifies the address to the local Consul agent, given in the format host:port.
+    Supports Unix sockets with the format: unix:///tmp/consul/consul.sock
+
+  -consul-auth=<auth>
+    Specifies the HTTP Basic Authentication information to use for access to the
+    Consul Agent, given in the format username:password.
+
+  -consul-auto-advertise
+    Specifies if Nomad should advertise its services in Consul. The services
+    are named according to server_service_name and client_service_name. Nomad
+    servers and clients advertise their respective services, each tagged
+    appropriately with either http or rpc tag. Nomad servers also advertise a
+    serf tagged service.
+
+  -consul-ca-file=<path>
+    Specifies an optional path to the CA certificate used for Consul communication.
+    This defaults to the system bundle if unspecified.
+
+  -consul-cert-file=<path>
+    Specifies the path to the certificate used for Consul communication. If this
+    is set then you need to also set key_file.
+
+  -consul-checks-use-advertise
+    Specifies if Consul heath checks should bind to the advertise address. By
+    default, this is the bind address.
+
+  -consul-client-auto-join
+    Specifies if the Nomad clients should automatically discover servers in the
+    same region by searching for the Consul service name defined in the
+    server_service_name option.
+
+  -consul-client-service-name=<name>
+    Specifies the name of the service in Consul for the Nomad clients.
+
+  -consul-key-file=<path>
+    Specifies the path to the private key used for Consul communication. If this
+    is set then you need to also set cert_file.
+
+  -consul-server-service-name=<name>
+    Specifies the name of the service in Consul for the Nomad servers.
+
+  -consul-server-auto-join
+    Specifies if the Nomad servers should automatically discover and join other
+    Nomad servers by searching for the Consul service name defined in the
+    server_service_name option. This search only happens if the server does not
+    have a leader.
+
+  -consul-ssl
+    Specifies if the transport scheme should use HTTPS to communicate with the
+    Consul agent.
+
+  -consul-token=<token>
+    Specifies the token used to provide a per-request ACL token.
+
+  -consul-verify-ssl
+    Specifies if SSL peer verification should be used when communicating to the
+    Consul API client over HTTPS.
 
 Vault Options:
 

--- a/website/source/docs/commands/agent.html.md.erb
+++ b/website/source/docs/commands/agent.html.md.erb
@@ -30,6 +30,20 @@ via CLI arguments. The `agent` command accepts the following arguments:
 * `-client`: Enable client mode on the local agent.
 * `-config=<path>`: Specifies the path to a configuration file or a directory of
   configuration files to load. Can be specified multiple times.
+* `-consul-address=<addr>`: Equivalent to the [address](/docs/agent/configuration/consul.html#address) config option.
+* `-consul-auth=<auth>`: Equivalent to the [auth](/docs/agent/configuration/consul.html#auth) config option.
+* `-consul-auto-advertise`: Equivalent to the [auto_advertise](/docs/agent/configuration/consul.html#auto_advertise) config option.
+* `-consul-ca-file=<path>`: Equivalent to the [ca_file](/docs/agent/configuration/consul.html#ca_file) config option.
+* `-consul-cert-file=<path>`: Equivalent to the [cert_file](/docs/agent/configuration/consul.html#cert_file) config option.
+* `-consul-checks-use-advertise`: Equivalent to the [checks_use_advertise](/docs/agent/configuration/consul.html#checks_use_advertise) config option.
+* `-consul-client-auto-join`: Equivalent to the [client_auto_join](/docs/agent/configuration/consul.html#client_auto_join) config option.
+* `-consul-client-service-name=<name>`: Equivalent to the [client_service_name](/docs/agent/configuration/consul.html#client_service_name) config option.
+* `-consul-key-file=<path>`: Equivalent to the [key_file](/docs/agent/configuration/consul.html#key_file) config option.
+* `-consul-server-service-name=<name>`: Equivalent to the [server_service_name](/docs/agent/configuration/consul.html#server_service_name) config option.
+* `-consul-server-auto-join`: Equivalent to the [server_auto_join](/docs/agent/configuration/consul.html#server_auto_join) config option.
+* `-consul-ssl`: Equivalent to the [ssl](/docs/agent/configuration/consul.html#ssl) config option.
+* `-consul-token=<token>`: Equivalent to the [token](/docs/agent/configuration/consul.html#token) config option.
+* `-consul-verify-ssl`: Equivalent to the [verify_ssl](/docs/agent/configuration/consul.html#verify_ssl) config option.
 * `-data-dir=<path>`: Equivalent to the [data_dir](#data_dir) config option.
 * `-dc=<datacenter>`: Equivalent to the [datacenter](#datacenter) config option.
 * `-dev`: Start the agent in development mode. This enables a pre-configured


### PR DESCRIPTION
This update introduces command line flags for all Consul options thus allowing users to both use a config file and CLI options to configure Consul.

Website documentation has also been updated.

The change was tested running a local build with the command `nomad agent -dev -consul-server-service-name=jrasell-nomad -consul-client-service-name=jrasell-nomad-client`. Consul confirming the correct configuration:

```
$ curl -s localhost:8500/v1/health/checks/jrasell-nomad | jq '.[0].ServiceName'
"jrasell-nomad"

 $ curl -s localhost:8500/v1/health/checks/jrasell-nomad-client | jq '.[0].ServiceName'
"jrasell-nomad-client"
```

Closes #3304