### PR TITLE
/v1/client/allocation/./{stats,gc} ACL enforcement

### DIFF
--- a/website/source/api/client.html.md
+++ b/website/source/api/client.html.md
@@ -147,9 +147,9 @@ The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and
 [required ACLs](/api/index.html#acls).
 
-| Blocking Queries | ACL Required |
-| ---------------- | ------------ |
-| `NO`             | `none`       |
+| Blocking Queries | ACL Required         |
+| ---------------- | -------------------- |
+| `NO`             | `namespace:read-job` |
 
 ### Parameters
 


### PR DESCRIPTION
The `/snapshots` endpoint will be covered in #3322 