### PR TITLE
/v1/client/agent/* ACL enforcement

### DIFF
--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -29,6 +29,11 @@ func NamespacePolicy(namespace string, policy string, capabilities []string) str
 	return policyHCL
 }
 
+// AgentPolicy is a helper for generating the hcl for a given agent policy.
+func AgentPolicy(policy string) string {
+	return fmt.Sprintf("agent {\n\tpolicy = %q\n}\n", policy)
+}
+
 // NodePolicy is a helper for generating the hcl for a given node policy.
 func NodePolicy(policy string) string {
 	return fmt.Sprintf("node {\n\tpolicy = %q\n}\n", policy)

--- a/website/source/api/agent.html.md
+++ b/website/source/api/agent.html.md
@@ -27,7 +27,7 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | ACL Required |
 | ---------------- | ------------ |
-| `NO`             | `none`       |
+| `NO`             | `node:read`  |
 
 ### Sample Request
 
@@ -88,7 +88,7 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | ACL Required |
 | ---------------- | ------------ |
-| `NO`             | `none`       |
+| `NO`             | `agent:read` |
 
 ### Sample Request
 
@@ -118,9 +118,9 @@ The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and
 [required ACLs](/api/index.html#acls).
 
-| Blocking Queries | ACL Required |
-| ---------------- | ------------ |
-| `NO`             | `none`       |
+| Blocking Queries | ACL Required  |
+| ---------------- | ------------- |
+| `NO`             | `agent:write` |
 
 ### Parameters
 
@@ -147,9 +147,9 @@ The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and
 [required ACLs](/api/index.html#acls).
 
-| Blocking Queries | Consistency Modes | ACL Required |
-| ---------------- | ----------------- | ------------ |
-| `NO`             | `none`            | `none`       |
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `agent:read` |
 
 ### Sample Request
 
@@ -440,9 +440,9 @@ The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and
 [required ACLs](/api/index.html#acls).
 
-| Blocking Queries | ACL Required |
-| ---------------- | ------------ |
-| `NO`             | `none`       |
+| Blocking Queries | ACL Required  |
+| ---------------- | ------------- |
+| `NO`             | `agent:write` |
 
 ### Parameters
 


### PR DESCRIPTION
Skipped documentation for the keyring endpoints, as I didn't see any existing docs for those endpoints.