### PR TITLE
Change Metrics API nav option to 'Metrics'

### DIFF
--- a/website/source/layouts/api.erb
+++ b/website/source/layouts/api.erb
@@ -56,7 +56,7 @@
       </li>
 
       <li<%= sidebar_current("api-metrics") %>>
-        <a href="/api/metrics.html">Search</a>
+        <a href="/api/metrics.html">Metrics</a>
       </li>
 
       <li<%= sidebar_current("api-operator") %>>


### PR DESCRIPTION
The nav option for Metrics currently reads "Search". This changes it to "Metrics".