### PR TITLE
UI for Namespaces (enterprise only)

### DIFF
--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -19,6 +19,18 @@ export default RESTAdapter.extend({
     );
   }),
 
+  findAll() {
+    return this._super(...arguments).catch(error => {
+      if (error.code === '501' || (error.errors && error.errors.findBy('status', '501'))) {
+        // Feature is not implemented in this version of Nomad
+        return [];
+      }
+
+      // Rethrow to be handled downstream
+      throw error;
+    });
+  },
+
   // Single record requests deviate from REST practice by using
   // the singular form of the resource name.
   //

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -1,10 +1,24 @@
 import Ember from 'ember';
 import ApplicationAdapter from './application';
 
-const { RSVP } = Ember;
+const { RSVP, inject } = Ember;
 
 export default ApplicationAdapter.extend({
+  system: inject.service(),
+
   shouldReloadAll: () => true,
+
+  buildQuery(snapshot) {
+    const namespace = this.get('system.activeNamespace');
+
+    // SnapshotRecordArray isn't exported, so the best we can do is duck-type.
+    const isSnapshotRecordArray = snapshot && snapshot._recordArray;
+    if ((!snapshot || isSnapshotRecordArray) && namespace) {
+      return {
+        namespace: namespace.get('name'),
+      };
+    }
+  },
 
   findRecord(store, { modelName }, id, snapshot) {
     // To make a findRecord response reflect the findMany response, the JobSummary

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -22,11 +22,9 @@ export default ApplicationAdapter.extend({
 
   findAll() {
     const namespace = this.get('system.activeNamespace');
-    console.log('setting ns to', namespace.get('id'));
     return this._super(...arguments).then(data => {
       data.forEach(job => {
-        job.NamespaceID = namespace.get('id');
-        console.log(job);
+        job.NamespaceID = namespace && namespace.get('id');
       });
       return data;
     });

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -20,6 +20,18 @@ export default ApplicationAdapter.extend({
     }
   },
 
+  findAll() {
+    const namespace = this.get('system.activeNamespace');
+    console.log('setting ns to', namespace.get('id'));
+    return this._super(...arguments).then(data => {
+      data.forEach(job => {
+        job.NamespaceID = namespace.get('id');
+        console.log(job);
+      });
+      return data;
+    });
+  },
+
   findRecord(store, { modelName }, id, snapshot) {
     // To make a findRecord response reflect the findMany response, the JobSummary
     // from /summary needs to be stitched into the response.

--- a/ui/app/components/allocation-row.js
+++ b/ui/app/components/allocation-row.js
@@ -47,10 +47,15 @@ export default Component.extend({
     // and manually re-link the two records here.
 
     const allocation = this.get('allocation');
-    this.get('store')
-      .findRecord('job', allocation.get('originalJobId'))
-      .then(job => {
-        allocation.set('job', job);
-      });
+    const job = this.get('store').peekRecord('job', allocation.get('originalJobId'));
+    if (job) {
+      allocation.set('job', job);
+    } else {
+      this.get('store')
+        .findRecord('job', allocation.get('originalJobId'))
+        .then(job => {
+          allocation.set('job', job);
+        });
+    }
   },
 });

--- a/ui/app/components/gutter-menu.js
+++ b/ui/app/components/gutter-menu.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+const { Component, inject } = Ember;
+
+export default Component.extend({
+  system: inject.service(),
+
+  onNamespaceChange() {},
+});

--- a/ui/app/components/gutter-menu.js
+++ b/ui/app/components/gutter-menu.js
@@ -1,9 +1,35 @@
 import Ember from 'ember';
 
-const { Component, inject } = Ember;
+const { Component, inject, computed } = Ember;
 
 export default Component.extend({
   system: inject.service(),
+
+  sortedNamespaces: computed('system.namespaces.@each.name', function() {
+    const namespaces = this.get('system.namespaces').toArray() || [];
+
+    return namespaces.sort((a, b) => {
+      const aName = a.get('name');
+      const bName = b.get('name');
+
+      // Make sure the default namespace is always first in the list
+      if (aName === 'default') {
+        return -1;
+      }
+      if (bName === 'default') {
+        return 1;
+      }
+
+      if (aName < bName) {
+        return -1;
+      }
+      if (aName > bName) {
+        return 1;
+      }
+
+      return 0;
+    });
+  }),
 
   onNamespaceChange() {},
 });

--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
 
-const { Controller, computed } = Ember;
+const { Controller, computed, inject, run, observer } = Ember;
 
 export default Controller.extend({
+  config: inject.service(),
+
   error: null,
 
   errorStr: computed('error', function() {
@@ -31,5 +33,13 @@ export default Controller.extend({
 
   is500: computed('errorCodes.[]', function() {
     return this.get('errorCodes').includes('500');
+  }),
+
+  throwError: observer('error', function() {
+    if (this.get('config.isDev')) {
+      run.next(() => {
+        throw this.get('error');
+      });
+    }
   }),
 });

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -2,9 +2,11 @@ import Ember from 'ember';
 import Sortable from 'nomad-ui/mixins/sortable';
 import Searchable from 'nomad-ui/mixins/searchable';
 
-const { Controller, computed } = Ember;
+const { Controller, computed, observer, inject } = Ember;
 
 export default Controller.extend(Sortable, Searchable, {
+  system: inject.service(),
+
   pendingJobs: computed.filterBy('model', 'status', 'pending'),
   runningJobs: computed.filterBy('model', 'status', 'running'),
   deadJobs: computed.filterBy('model', 'status', 'dead'),
@@ -14,21 +16,47 @@ export default Controller.extend(Sortable, Searchable, {
     searchTerm: 'search',
     sortProperty: 'sort',
     sortDescending: 'desc',
+    jobNamespace: 'namespace',
   },
 
   currentPage: 1,
   pageSize: 10,
+  jobNamespace: 'default',
 
   sortProperty: 'modifyIndex',
   sortDescending: true,
 
   searchProps: computed(() => ['id', 'name']),
 
-  listToSort: computed.alias('model'),
+  filteredJobs: computed('model.[]', 'jobNamespace', function() {
+    if (this.get('system.namespaces.length')) {
+      return this.get('model').filterBy('namespace.name', this.get('jobNamespace'));
+    } else {
+      return this.get('model');
+    }
+  }),
+
+  listToSort: computed.alias('filteredJobs'),
   listToSearch: computed.alias('listSorted'),
   sortedJobs: computed.alias('listSearched'),
 
   isShowingDeploymentDetails: false,
+
+  // The namespace query param should act as an alias to the system active namespace.
+  // But query param defaults can't be CPs: https://github.com/emberjs/ember.js/issues/9819
+  syncNamespaceService: observer('jobNamespace', function() {
+    const newNamespace = this.get('jobNamespace');
+    const currentNamespace = this.get('system.activeNamespace.id');
+    const bothAreDefault =
+      currentNamespace == undefined ||
+      (currentNamespace === 'default' && newNamespace == undefined) ||
+      newNamespace === 'default';
+
+    if (currentNamespace !== newNamespace && !bothAreDefault) {
+      this.set('system.activeNamespace', newNamespace);
+      this.send('refreshRoute');
+    }
+  }),
 
   actions: {
     gotoJob(job) {

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -34,5 +34,9 @@ export default Controller.extend(Sortable, Searchable, {
     gotoJob(job) {
       this.transitionToRoute('jobs.job', job);
     },
+
+    refresh() {
+      this.send('refreshRoute');
+    },
   },
 });

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import { hasMany } from 'ember-data/relationships';
+import { belongsTo, hasMany } from 'ember-data/relationships';
 import { fragmentArray } from 'ember-data-model-fragments/attributes';
 import sumAggregation from '../utils/properties/sum-aggregation';
 
@@ -52,6 +52,7 @@ export default Model.extend({
   versions: hasMany('job-versions'),
   allocations: hasMany('allocations'),
   deployments: hasMany('deployments'),
+  namespace: belongsTo('namespace'),
 
   runningDeployment: computed('deployments.@each.status', function() {
     return this.get('deployments').findBy('status', 'running');

--- a/ui/app/models/namespace.js
+++ b/ui/app/models/namespace.js
@@ -1,0 +1,8 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+export default Model.extend({
+  name: attr('string'),
+  hash: attr('string'),
+  description: attr('string'),
+});

--- a/ui/app/routes/jobs.js
+++ b/ui/app/routes/jobs.js
@@ -3,9 +3,20 @@ import Ember from 'ember';
 const { Route, inject } = Ember;
 
 export default Route.extend({
+  system: inject.service(),
   store: inject.service(),
+
+  beforeModel() {
+    return this.get('system.namespaces');
+  },
 
   model() {
     return this.get('store').findAll('job');
+  },
+
+  actions: {
+    refreshRoute() {
+      this.refresh();
+    },
   },
 });

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+const { Route, inject } = Ember;
+
+export default Route.extend({
+  system: inject.service(),
+
+  setupController(controller) {
+    this._super(...arguments);
+
+    const namespace = this.get('system.activeNamespace.id');
+    if (namespace && namespace !== 'default') {
+      controller.set('jobNamespace', namespace);
+    } else {
+      controller.set('jobNamespace', 'default');
+    }
+  },
+});

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import ApplicationSerializer from './application';
 
-const { get } = Ember;
+const { get, assign } = Ember;
 
 export default ApplicationSerializer.extend({
   attrs: {
@@ -39,7 +39,7 @@ export default ApplicationSerializer.extend({
       .adapterFor(modelName)
       .buildURL(modelName, this.extractId(modelClass, hash), hash, 'findRecord');
 
-    return {
+    return assign(this._super(...arguments), {
       allocations: {
         links: {
           related: `${jobURL}/allocations`,
@@ -55,6 +55,6 @@ export default ApplicationSerializer.extend({
           related: `${jobURL}/deployments`,
         },
       },
-    };
+    });
   },
 });

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -1,14 +1,18 @@
 import Ember from 'ember';
-import fetch from 'fetch';
 import PromiseObject from '../utils/classes/promise-object';
 import { namespace } from '../adapters/application';
 
-const { Service, computed } = Ember;
+const { Service, computed, inject } = Ember;
 
 export default Service.extend({
+  token: inject.service(),
+
   leader: computed(function() {
+    const token = this.get('token');
+
     return PromiseObject.create({
-      promise: fetch(`/${namespace}/status/leader`)
+      promise: token
+        .authorizedRequest(`/${namespace}/status/leader`)
         .then(res => res.json())
         .then(rpcAddr => ({ rpcAddr }))
         .then(leader => {

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -36,10 +36,12 @@ export default Service.extend({
     set(key, value) {
       if (value == null) {
         window.localStorage.removeItem('nomadActiveNamespace');
-      } else {
+      } else if (typeof value === 'string') {
         window.localStorage.nomadActiveNamespace = value;
+        return this.get('namespaces').findBy('id', value);
       }
-      return this.get('namespaces').findBy('id', value);
+      window.localStorage.nomadActiveNamespace = value.get('name');
+      return value;
     },
   }),
 });

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -6,6 +6,7 @@ const { Service, computed, inject } = Ember;
 
 export default Service.extend({
   token: inject.service(),
+  store: inject.service(),
 
   leader: computed(function() {
     const token = this.get('token');
@@ -21,5 +22,24 @@ export default Service.extend({
           return leader;
         }),
     });
+  }),
+
+  namespaces: computed(function() {
+    return this.get('store').findAll('namespace');
+  }),
+
+  activeNamespace: computed('namespaces.[]', {
+    get() {
+      const namespaceId = window.localStorage.nomadActiveNamespace || 'default';
+      return this.get('namespaces').findBy('id', namespaceId);
+    },
+    set(key, value) {
+      if (value == null) {
+        window.localStorage.removeItem('nomadActiveNamespace');
+      } else {
+        window.localStorage.nomadActiveNamespace = value;
+      }
+      return this.get('namespaces').findBy('id', value);
+    },
   }),
 });

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import fetch from 'fetch';
 
-const { Service, computed } = Ember;
+const { Service, computed, assign } = Ember;
 
 export default Service.extend({
   accessor: computed({
@@ -31,4 +32,15 @@ export default Service.extend({
       return value;
     },
   }),
+
+  authorizedRequest(url, options = {}) {
+    const headers = {};
+    const token = this.get('secret');
+
+    if (token) {
+      headers['X-Nomad-Token'] = token;
+    }
+
+    return fetch(url, assign(options, { headers }));
+  },
 });

--- a/ui/app/styles/app.scss
+++ b/ui/app/styles/app.scss
@@ -1,3 +1,5 @@
 @import "./core";
 @import "./components";
 @import "./charts";
+
+@import "ember-power-select";

--- a/ui/app/styles/components.scss
+++ b/ui/app/styles/components.scss
@@ -1,6 +1,7 @@
 @import "./components/badge";
 @import "./components/boxed-section";
 @import "./components/breadcrumbs";
+@import "./components/ember-power-select";
 @import "./components/empty-message";
 @import "./components/error-container";
 @import "./components/gutter";

--- a/ui/app/styles/components/ember-power-select.scss
+++ b/ui/app/styles/components/ember-power-select.scss
@@ -1,0 +1,3 @@
+.ember-power-select-trigger {
+  cursor: pointer;
+}

--- a/ui/app/styles/core/menu.scss
+++ b/ui/app/styles/core/menu.scss
@@ -15,6 +15,10 @@
         color: $blue;
       }
     }
+
+    .menu-item {
+      margin: 0.5rem 1.5rem;
+    }
   }
 
   .menu-label {

--- a/ui/app/styles/core/typography.scss
+++ b/ui/app/styles/core/typography.scss
@@ -19,3 +19,7 @@ code {
 .nowrap {
   white-space: nowrap;
 }
+
+.is-interactive {
+  cursor: pointer;
+}

--- a/ui/app/styles/utils/z-indices.scss
+++ b/ui/app/styles/utils/z-indices.scss
@@ -1,5 +1,5 @@
-$z-tooltip: 2500;
-$z-header: 2000;
-$z-gutter: 2000;
-$z-subnav: 2000;
+$z-tooltip: 250;
+$z-header: 200;
+$z-gutter: 200;
+$z-subnav: 200;
 $z-base: 100;

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -5,6 +5,20 @@
         Workload
       </p>
       <ul class="menu-list">
+        <li>
+          <select
+            class="menu-item"
+            onchange={{action (queue
+              (action (mut system.activeNamespace))
+              (action onNamespaceChange)
+            ) value="target.value"}}>
+            {{#each system.namespaces as |namespace|}}
+              <option value="{{namespace.name}}" selected={{eq namespace system.activeNamespace}}>
+                {{namespace.name}}
+              </option>
+            {{/each}}
+          </select>
+        </li>
         <li>{{#link-to "jobs" activeClass="is-active"}}Jobs{{/link-to}}</li>
       </ul>
       <p class="menu-label">

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -5,20 +5,28 @@
         Workload
       </p>
       <ul class="menu-list">
-        <li>
-          <select
-            class="menu-item"
-            onchange={{action (queue
-              (action (mut system.activeNamespace))
-              (action onNamespaceChange)
-            ) value="target.value"}}>
-            {{#each system.namespaces as |namespace|}}
-              <option value="{{namespace.name}}" selected={{eq namespace system.activeNamespace}}>
-                {{namespace.name}}
-              </option>
-            {{/each}}
-          </select>
-        </li>
+        {{#if system.namespaces.length}}
+          <li>
+            <div class="menu-item">
+              {{#power-select
+                options=system.namespaces
+                selected=system.activeNamespace
+                searchField="name"
+                searchEnabled=(gt system.namespaces.length 10)
+                onchange=(action (queue
+                  (action (mut system.activeNamespace))
+                  (action onNamespaceChange)
+                ))
+                as |namespace|}}
+                {{#if (eq namespace.name "default")}}
+                  Default Namespace
+                {{else}}
+                  {{namespace.name}}
+                {{/if}}
+              {{/power-select}}
+            </div>
+          </li>
+        {{/if}}
         <li>{{#link-to "jobs" activeClass="is-active"}}Jobs{{/link-to}}</li>
       </ul>
       <p class="menu-label">

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -9,14 +9,16 @@
           <li>
             <div class="menu-item">
               {{#power-select
-                options=system.namespaces
+                options=sortedNamespaces
                 selected=system.activeNamespace
                 searchField="name"
-                searchEnabled=(gt system.namespaces.length 10)
+                searchEnabled=(gt sortedNamespaces.length 10)
                 onchange=(action (queue
                   (action (mut system.activeNamespace))
                   (action onNamespaceChange)
                 ))
+                tagName="div"
+                class="namespace-switcher"
                 as |namespace|}}
                 {{#if (eq namespace.name "default")}}
                   Default Namespace

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -1,7 +1,7 @@
 {{#global-header class="page-header"}}
   Jobs
 {{/global-header}}
-{{#gutter-menu class="page-body"}}
+{{#gutter-menu class="page-body" onNamespaceChange=(action "refresh")}}
   <section class="section">
     {{#if model.length}}
       <div class="content">

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -3,7 +3,7 @@
 {{/global-header}}
 {{#gutter-menu class="page-body" onNamespaceChange=(action "refresh")}}
   <section class="section">
-    {{#if model.length}}
+    {{#if filteredJobs.length}}
       <div class="content">
         <div>{{search-box searchTerm=(mut searchTerm) placeholder="Search jobs..."}}</div>
       </div>
@@ -41,7 +41,7 @@
       </div>
     {{else}}
       <div class="empty-message">
-        {{#if (eq model.length 0)}}
+        {{#if (eq filteredJobs.length 0)}}
           <h3 class="empty-message-headline">No Jobs</h3>
           <p class="empty-message-body">
             There are currently no visible jobs in the cluster. It could be that the cluster is empty. It could also mean {{#link-to "settings.tokens"}}you don't have access to see any jobs{{/link-to}}.

--- a/ui/app/templates/jobs/job/index.hbs
+++ b/ui/app/templates/jobs/job/index.hbs
@@ -19,9 +19,9 @@
     <div class="boxed-section job-stats">
       <div class="boxed-section-body">
         <span><strong>Type:</strong> {{model.type}} | </span>
-        <span><strong>Priority:</strong> {{model.priority}} | </span>
+        <span><strong>Priority:</strong> {{model.priority}} </span>
         {{#if model.namespace}}
-          <span><strong>Namespace:</strong> {{model.namespace.name}}</span>
+          <span> | <strong>Namespace:</strong> {{model.namespace.name}}</span>
         {{/if}}
       </div>
     </div>

--- a/ui/app/templates/jobs/job/index.hbs
+++ b/ui/app/templates/jobs/job/index.hbs
@@ -19,7 +19,10 @@
     <div class="boxed-section job-stats">
       <div class="boxed-section-body">
         <span><strong>Type:</strong> {{model.type}} | </span>
-        <span><strong>Priority:</strong> {{model.priority}}</span>
+        <span><strong>Priority:</strong> {{model.priority}} | </span>
+        {{#if model.namespace}}
+          <span><strong>Namespace:</strong> {{model.namespace.name}}</span>
+        {{/if}}
       </div>
     </div>
 

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -13,9 +13,11 @@ export default function() {
 
   this.namespace = 'v1';
 
-  this.get('/jobs', function({ jobs }) {
+  this.get('/jobs', function({ jobs }, { queryParams }) {
     const json = this.serialize(jobs.all());
-    return json.map(job => filterKeys(job, 'TaskGroups', 'NamespaceID'));
+    return json
+      .filter(job => (queryParams.namespace ? job.NamespaceID === queryParams.namespace : true))
+      .map(job => filterKeys(job, 'TaskGroups', 'NamespaceID'));
   });
 
   this.get('/job/:id');

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -58,6 +58,9 @@ export default function() {
 
   this.get('/allocation/:id');
 
+  this.get('/namespaces');
+  this.get('/namespace/:id');
+
   this.get('/agent/members', function({ agents }) {
     return {
       Members: this.serialize(agents.all()),

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Response from 'ember-cli-mirage/response';
 import { HOSTS } from './common';
 
 const { copy } = Ember;
@@ -60,8 +61,23 @@ export default function() {
 
   this.get('/allocation/:id');
 
-  this.get('/namespaces');
-  this.get('/namespace/:id');
+  this.get('/namespaces', function({ namespaces }) {
+    const records = namespaces.all();
+
+    if (records.length) {
+      return this.serialize(records);
+    }
+
+    return new Response(501, {}, null);
+  });
+
+  this.get('/namespace/:id', function({ namespaces }, { params }) {
+    if (namespaces.all().length) {
+      return this.serialize(namespaces.find(params.id));
+    }
+
+    return new Response(501, {}, null);
+  });
 
   this.get('/agent/members', function({ agents }) {
     return {

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -9,13 +9,13 @@ export function findLeader(schema) {
 }
 
 export default function() {
-  this.timing = 200; // delay for each request, automatically set to 0 during testing
+  this.timing = 0; // delay for each request, automatically set to 0 during testing
 
   this.namespace = 'v1';
 
   this.get('/jobs', function({ jobs }) {
     const json = this.serialize(jobs.all());
-    return json.map(job => filterKeys(job, 'TaskGroups'));
+    return json.map(job => filterKeys(job, 'TaskGroups', 'NamespaceID'));
   });
 
   this.get('/job/:id');

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -50,8 +50,13 @@ export default Factory.extend({
     job.update({
       taskGroupIds: groups.mapBy('id'),
       task_group_ids: groups.mapBy('id'),
-      namespaceId: server.db.namespaces.length ? pickOne(server.db.namespaces).id : null,
     });
+
+    if (!job.namespaceId) {
+      job.update({
+        namespaceId: server.db.namespaces.length ? pickOne(server.db.namespaces).id : null,
+      });
+    }
 
     const jobSummary = server.create('job-summary', {
       groupNames: groups.mapBy('name'),

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -1,5 +1,5 @@
 import { Factory, faker } from 'ember-cli-mirage';
-import { provide, provider } from '../utils';
+import { provide, provider, pickOne } from '../utils';
 import { DATACENTERS } from '../common';
 
 const JOB_PREFIXES = provide(5, faker.hacker.abbreviation);
@@ -50,6 +50,7 @@ export default Factory.extend({
     job.update({
       taskGroupIds: groups.mapBy('id'),
       task_group_ids: groups.mapBy('id'),
+      namespaceId: server.db.namespaces.length && pickOne(server.db.namespaces).id,
     });
 
     const jobSummary = server.create('job-summary', {

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -50,7 +50,7 @@ export default Factory.extend({
     job.update({
       taskGroupIds: groups.mapBy('id'),
       task_group_ids: groups.mapBy('id'),
-      namespaceId: server.db.namespaces.length && pickOne(server.db.namespaces).id,
+      namespaceId: server.db.namespaces.length ? pickOne(server.db.namespaces).id : null,
     });
 
     const jobSummary = server.create('job-summary', {

--- a/ui/mirage/factories/namespace.js
+++ b/ui/mirage/factories/namespace.js
@@ -1,10 +1,12 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  id: i => `namespace-${i}`,
+  id: i => (i === 0 ? 'default' : `namespace-${i}`),
+
   name() {
     return this.id;
   },
+
   hash: () => faker.random.uuid(),
   description: '',
 });

--- a/ui/mirage/factories/namespace.js
+++ b/ui/mirage/factories/namespace.js
@@ -1,0 +1,10 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  id: i => `namespace-${i}`,
+  name() {
+    return this.id;
+  },
+  hash: () => faker.random.uuid(),
+  description: '',
+});

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -2,7 +2,6 @@ export default function(server) {
   server.createList('agent', 3);
   server.createList('node', 50);
 
-  server.create('namespace', { id: 'default' });
   server.createList('namespace', 3);
 
   server.createList('job', 15);

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -1,5 +1,9 @@
 export default function(server) {
   server.createList('agent', 3);
   server.createList('node', 50);
+
+  server.create('namespace', { id: 'default' });
+  server.createList('namespace', 3);
+
   server.createList('job', 15);
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,6 +61,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-moment": "^7.3.1",
     "ember-native-dom-helpers": "^0.5.4",
+    "ember-power-select": "^1.9.9",
     "ember-resolver": "^4.0.0",
     "ember-sinon": "^0.7.0",
     "ember-source": "~2.14.0",

--- a/ui/tests/.eslintrc.js
+++ b/ui/tests/.eslintrc.js
@@ -1,6 +1,10 @@
 module.exports = {
   globals: {
     server: true,
+    selectChoose: true,
+    selectSearch: true,
+    removeMultipleOption: true,
+    clearSelected: true,
   },
   env: {
     embertest: true,

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -40,6 +40,7 @@ test('the job detail page should contain basic information about the job', funct
   assert.ok(findAll('.title .tag')[0].textContent.includes(job.status), 'Status');
   assert.ok(findAll('.job-stats span')[0].textContent.includes(job.type), 'Type');
   assert.ok(findAll('.job-stats span')[1].textContent.includes(job.priority), 'Priority');
+  assert.notOk(findAll('.job-stats span')[2], 'Namespace is not included');
 });
 
 test('the job detail page should list all task groups', function(assert) {
@@ -278,6 +279,23 @@ test('when the job is not found, an error message is shown, but the URL persists
       find('.error-message .title').textContent,
       'Not Found',
       'Error message is for 404'
+    );
+  });
+});
+
+test('when there are namespaces, the job detail page states the namespace for the job', function(
+  assert
+) {
+  server.createList('namespace', 2);
+  job = server.create('job');
+  const namespace = server.db.namespaces.find(job.namespaceId);
+
+  visit(`/jobs/${job.id}`);
+
+  andThen(() => {
+    assert.ok(
+      findAll('.job-stats span')[2].textContent.includes(namespace.name),
+      'Namespace included in stats'
     );
   });
 });

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -107,3 +107,26 @@ test('when there are jobs, but no matches for a search result, there is an empty
     assert.equal(find('.empty-message-headline').textContent, 'No Matches');
   });
 });
+
+test('when the namespace query param is set, only matching jobs are shown and the namespace value is forwarded to app state', function(
+  assert
+) {
+  server.createList('namespace', 2);
+  const job1 = server.create('job', { namespaceId: server.db.namespaces[0].id });
+  const job2 = server.create('job', { namespaceId: server.db.namespaces[1].id });
+
+  visit('/jobs');
+
+  andThen(() => {
+    assert.equal(findAll('.job-row').length, 1, 'One job in the default namespace');
+    assert.equal(find('.job-row td').textContent, job1.name, 'The correct job is shown');
+  });
+
+  const secondNamespace = server.db.namespaces[1];
+  visit(`/jobs?namespace=${secondNamespace.id}`);
+
+  andThen(() => {
+    assert.equal(findAll('.job-row').length, 1, `One job in the ${secondNamespace.name} namespace`);
+    assert.equal(find('.job-row td').textContent, job2.name, 'The correct job is shown');
+  });
+});

--- a/ui/tests/acceptance/namespaces-test.js
+++ b/ui/tests/acceptance/namespaces-test.js
@@ -1,0 +1,120 @@
+import { visit, find, findAll, click } from 'ember-native-dom-helpers';
+import { test } from 'qunit';
+import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | namespaces (disabled)', {
+  beforeEach() {
+    server.create('agent');
+    server.create('node');
+    server.createList('job', 5);
+  },
+});
+
+test('the namespace switcher is not in the gutter menu', function(assert) {
+  visit('/jobs');
+
+  andThen(() => {
+    assert.notOk(find('.gutter .menu .namespace-switcher'), 'No namespace switcher found');
+  });
+});
+
+test('the jobs request is made with no query params', function(assert) {
+  visit('/jobs');
+
+  andThen(() => {
+    const request = server.pretender.handledRequests.findBy('url', '/v1/jobs');
+    assert.equal(request.queryParams.namespace, undefined, 'No namespace query param');
+  });
+});
+
+moduleForAcceptance('Acceptance | namespaces (enabled)', {
+  beforeEach() {
+    server.createList('namespace', 3);
+    server.create('agent');
+    server.create('node');
+    server.createList('job', 5);
+  },
+});
+
+test('the namespace switcher lists all namespaces', function(assert) {
+  const namespaces = server.db.namespaces;
+
+  visit('/jobs');
+
+  andThen(() => {
+    assert.ok(find('.gutter .menu .namespace-switcher'), 'Namespace switcher found');
+  });
+
+  andThen(() => {
+    click('.gutter .menu .namespace-switcher .ember-power-select-trigger');
+  });
+
+  andThen(() => {
+    // TODO this selector should be scoped to only the namespace switcher options,
+    // but ember-wormhole makes that difficult.
+    assert.equal(
+      findAll('.ember-power-select-option').length,
+      namespaces.length,
+      'All namespaces are in the switcher'
+    );
+    assert.equal(
+      find('.ember-power-select-option').textContent.trim(),
+      'Default Namespace',
+      'The first namespace is always the default one'
+    );
+
+    namespaces
+      .slice(1)
+      .sortBy('name')
+      .forEach((namespace, index) => {
+        assert.equal(
+          findAll('.ember-power-select-option')[index + 1].textContent.trim(),
+          namespace.name,
+          `index ${index + 1}: ${namespace.name}`
+        );
+      });
+  });
+});
+
+test('changing the namespace sets the namespace in localStorage', function(assert) {
+  const namespace = server.db.namespaces[1];
+
+  visit('/jobs');
+
+  selectChoose('.namespace-switcher', namespace.name);
+  andThen(() => {
+    assert.equal(
+      window.localStorage.nomadActiveNamespace,
+      namespace.id,
+      'Active namespace was set'
+    );
+  });
+});
+
+test('changing the namespace refreshes the jobs list when on the jobs page', function(assert) {
+  const namespace = server.db.namespaces[1];
+
+  visit('/jobs');
+
+  andThen(() => {
+    const requests = server.pretender.handledRequests.filter(req => req.url.startsWith('/v1/jobs'));
+    assert.equal(requests.length, 1, 'First request to jobs');
+    assert.equal(
+      requests[0].queryParams.namespace,
+      'default',
+      'Namespace query param is defaulted to "default"'
+    );
+  });
+
+  selectChoose('.namespace-switcher', namespace.name);
+
+  andThen(() => {
+    const requests = server.pretender.handledRequests.filter(req => req.url.startsWith('/v1/jobs'));
+    assert.equal(requests.length, 2, 'Second request to jobs');
+    assert.equal(
+      requests[1].queryParams.namespace,
+      namespace.name,
+      'Namespace query param on second request'
+    );
+  });
+});

--- a/ui/tests/helpers/module-for-acceptance.js
+++ b/ui/tests/helpers/module-for-acceptance.js
@@ -11,6 +11,9 @@ export default function(name, options = {}) {
       // Clear session storage (a side effect of token storage)
       window.sessionStorage.clear();
 
+      // Also clear local storage (a side effect of namespaces)
+      window.localStorage.clear();
+
       this.application = startApp();
 
       if (options.beforeEach) {

--- a/ui/tests/helpers/start-app.js
+++ b/ui/tests/helpers/start-app.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
+import registerPowerSelectHelpers from '../../tests/helpers/ember-power-select';
+
+registerPowerSelectHelpers();
 
 export default function startApp(attrs) {
   let attributes = Ember.merge({}, config.APP);

--- a/ui/tests/unit/adapters/job-test.js
+++ b/ui/tests/unit/adapters/job-test.js
@@ -3,7 +3,7 @@ import { startMirage } from 'nomad-ui/initializers/ember-cli-mirage';
 
 moduleFor('adapter:job', 'Unit | Adapter | Job', {
   unit: true,
-  needs: ['service:token'],
+  needs: ['service:token', 'service:system', 'model:namespace', 'adapter:application'],
   beforeEach() {
     window.sessionStorage.clear();
 
@@ -24,8 +24,8 @@ test('The job summary is stitched into the job request', function(assert) {
 
   assert.deepEqual(
     pretender.handledRequests.mapBy('url'),
-    [`/v1/job/${jobId}`, `/v1/job/${jobId}/summary`],
-    'The two requests made are /job/:id and /job/:id/summary'
+    ['/v1/namespaces', `/v1/job/${jobId}`, `/v1/job/${jobId}/summary`],
+    'The three requests made are /namespaces, /job/:id, and /job/:id/summary'
   );
 });
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -473,7 +473,7 @@ babel-core@^5.0.0:
     trim-right "^1.0.0"
     try-resolve "^1.0.0"
 
-babel-core@^6.14.0, babel-core@^6.26.0:
+babel-core@^6.14.0, babel-core@^6.24.1, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -642,6 +642,12 @@ babel-plugin-ember-modules-api-polyfill@^1.5.1:
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.6.0.tgz#abd1afa4237b3121cb51222f9bf3283cad8990aa"
   dependencies:
     ember-rfc176-data "^0.2.0"
+
+babel-plugin-ember-modules-api-polyfill@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.1.0.tgz#78848cc4fcc2274882a6c15cbb23fefcdc771301"
+  dependencies:
+    ember-rfc176-data "^0.3.0"
 
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
@@ -2548,6 +2554,15 @@ ember-ajax@^3.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
+ember-basic-dropdown@^0.33.1:
+  version "0.33.6"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-0.33.6.tgz#120d462c33ee5ea5ccb25a169e2b5af20d762d8a"
+  dependencies:
+    ember-cli-babel "^6.8.1"
+    ember-cli-htmlbars "^2.0.3"
+    ember-native-dom-helpers "^0.5.4"
+    ember-wormhole "^0.5.2"
+
 ember-browserify@^1.1.13:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-browserify/-/ember-browserify-1.2.0.tgz#c774896dc44ab2c5c608226f31628994348a3fd5"
@@ -2592,6 +2607,23 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-be
     amd-name-resolver "0.0.7"
     babel-plugin-debug-macros "^0.1.11"
     babel-plugin-ember-modules-api-polyfill "^1.5.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.0.0"
+
+ember-cli-babel@^6.0.0-beta.4:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.0.1"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"
     babel-polyfill "^6.16.0"
     babel-preset-env "^1.5.1"
@@ -2663,6 +2695,15 @@ ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1, ember-cli-htmlbars@^1.3.0:
     hash-for-dep "^1.0.2"
     json-stable-stringify "^1.0.0"
     strip-bom "^2.0.0"
+
+ember-cli-htmlbars@^2.0.1, ember-cli-htmlbars@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.3.tgz#e116e1500dba12f29c94b05b9ec90f52cb8bb042"
+  dependencies:
+    broccoli-persistent-filter "^1.0.3"
+    hash-for-dep "^1.0.2"
+    json-stable-stringify "^1.0.0"
+    strip-bom "^3.0.0"
 
 ember-cli-import-polyfill@^0.2.0:
   version "0.2.0"
@@ -2968,6 +3009,15 @@ ember-composable-helpers@^2.0.3:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.1.0"
 
+ember-concurrency@^0.8.1:
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.10.tgz#5788d1a43ed1e73562495719b29efe903c789675"
+  dependencies:
+    babel-core "^6.24.1"
+    ember-cli-babel "^6.6.0"
+    ember-getowner-polyfill "^2.0.0"
+    ember-maybe-import-regenerator "^0.1.5"
+
 ember-data-model-fragments@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/ember-data-model-fragments/-/ember-data-model-fragments-2.14.0.tgz#f31a03cdcf2449eaaaf84e0996324bf6af6c7b8e"
@@ -3069,7 +3119,7 @@ ember-getowner-polyfill@^1.2.2:
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
 
-ember-getowner-polyfill@^2.0.1:
+ember-getowner-polyfill@^2.0.0, ember-getowner-polyfill@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.0.1.tgz#9bfe2b4d527ed174e76fef2c8f30937d77cb66fb"
   dependencies:
@@ -3130,6 +3180,15 @@ ember-macro-helpers@^0.15.1:
     ember-cli-test-info "^1.0.0"
     ember-weakmap "^2.0.0"
 
+ember-maybe-import-regenerator@^0.1.5:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz#35d41828afa6d6a59bc0da3ce47f34c573d776ca"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    ember-cli-babel "^6.0.0-beta.4"
+    regenerator-runtime "^0.9.5"
+
 ember-moment@^7.3.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/ember-moment/-/ember-moment-7.4.1.tgz#88018c4d981643bb4521ad39539f60ba3ec6bf42"
@@ -3144,6 +3203,17 @@ ember-native-dom-helpers@^0.5.4:
   dependencies:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
+
+ember-power-select@^1.9.9:
+  version "1.9.9"
+  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-1.9.9.tgz#24b733f5be603a434dffdb57dffe702759448ca5"
+  dependencies:
+    ember-basic-dropdown "^0.33.1"
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-concurrency "^0.8.1"
+    ember-text-measurer "^0.3.3"
+    ember-truth-helpers "^1.3.0"
 
 ember-qunit@^2.1.3:
   version "2.2.0"
@@ -3166,6 +3236,10 @@ ember-resolver@^4.0.0:
 ember-rfc176-data@^0.2.0:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz#bd355bc9b473e08096b518784170a23388bc973b"
+
+ember-rfc176-data@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.0.tgz#6aee728cb521c5f80710990965027b9c320f6f08"
 
 ember-router-generator@^1.0.0:
   version "1.2.3"
@@ -3218,6 +3292,12 @@ ember-test-helpers@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
+ember-text-measurer@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/ember-text-measurer/-/ember-text-measurer-0.3.3.tgz#0762809a71c2e1f2e60ab00c53c6eb1b63c9f963"
+  dependencies:
+    ember-cli-babel "^5.1.6"
+
 ember-truth-helpers@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.3.0.tgz#6ed9f83ce9a49f52bb416d55e227426339a64c60"
@@ -3264,6 +3344,13 @@ ember-welcome-page@^3.0.0:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.0.0-beta.9"
     ember-cli-htmlbars "^1.0.3"
+
+ember-wormhole@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.5.2.tgz#cc0ceb7db4f8b8da0fd852edc81d75cb1dcd92f1"
+  dependencies:
+    ember-cli-babel "^6.0.0"
+    ember-cli-htmlbars "^1.1.1"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -6584,6 +6671,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
+regenerator-runtime@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
**Namespaces are an enterprise only feature, but the UI for namespaces is open source.**

1. Namespace is a globally set filter on jobs.
2. It's also an entry point as a query param on the jobs list page.
3. When namespaces aren't supported (open source binary), the UI removes all mentions of the concept.

![image](https://user-images.githubusercontent.com/174740/31466767-39819a26-ae8d-11e7-84a6-816e464c66e3.png)
