### PR TITLE
Gracefully handle 403s in the UI

### DIFF
--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import RESTAdapter from 'ember-data/adapters/rest';
+import codesForError from '../utils/codes-for-error';
 
 const { get, computed, inject } = Ember;
 
@@ -21,8 +22,12 @@ export default RESTAdapter.extend({
 
   findAll() {
     return this._super(...arguments).catch(error => {
-      if (error.code === '501' || (error.errors && error.errors.findBy('status', '501'))) {
-        // Feature is not implemented in this version of Nomad
+      const errorCodes = codesForError(error);
+
+      const isNotAuthorized = errorCodes.includes('403');
+      const isNotImplemented = errorCodes.includes('501');
+
+      if (isNotAuthorized || isNotImplemented) {
         return [];
       }
 

--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -27,6 +27,10 @@ export default Controller.extend({
       .map(code => '' + code);
   }),
 
+  is403: computed('errorCodes.[]', function() {
+    return this.get('errorCodes').includes('403');
+  }),
+
   is404: computed('errorCodes.[]', function() {
     return this.get('errorCodes').includes('404');
   }),

--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import codesForError from '../utils/codes-for-error';
 
 const { Controller, computed, inject, run, observer } = Ember;
 
@@ -12,19 +13,7 @@ export default Controller.extend({
   }),
 
   errorCodes: computed('error', function() {
-    const error = this.get('error');
-    const codes = [error.code];
-
-    if (error.errors) {
-      error.errors.forEach(err => {
-        codes.push(err.status);
-      });
-    }
-
-    return codes
-      .compact()
-      .uniq()
-      .map(code => '' + code);
+    return codesForError(this.get('error'));
   }),
 
   is403: computed('errorCodes.[]', function() {

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -11,8 +11,11 @@ export default Route.extend({
 
   actions: {
     didTransition() {
-      this.controllerFor('application').set('error', null);
       window.scrollTo(0, 0);
+    },
+
+    willTransition() {
+      this.controllerFor('application').set('error', null);
     },
 
     error(error) {

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -8,7 +8,7 @@ export default Route.extend({
 
   model({ job_id }) {
     return this.get('store')
-      .find('job', job_id)
+      .findRecord('job', job_id, { reload: true })
       .then(job => {
         return job.get('allocations').then(() => job);
       })

--- a/ui/app/serializers/agent.js
+++ b/ui/app/serializers/agent.js
@@ -28,7 +28,7 @@ export default ApplicationSerializer.extend({
   },
 
   normalizeResponse(store, typeClass, hash, ...args) {
-    return this._super(store, typeClass, hash.Members, ...args);
+    return this._super(store, typeClass, hash.Members || [], ...args);
   },
 
   normalizeSingleResponse(store, typeClass, hash, id, ...args) {

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -10,6 +10,13 @@
       {{else if is404}}
         <h1 class="title is-spaced">Not Found</h1>
         <p class="subtitle">What you're looking for couldn't be found. It either doesn't exist or you are not authorized to see it.</p>
+      {{else if is403}}
+        <h1 class="title is-spaced">Not Authorized</h1>
+        {{#if token.secret}}
+          <p class="subtitle">Your {{#link-to "settings.tokens"}}ACL token{{/link-to}} does not provide the required permissions. Contact your administrator if this is an error.</p>
+        {{else}}
+          <p class="subtitle">Provide an {{#link-to "settings.tokens"}}ACL token{{/link-to}} with requisite permissions to view this.</p>
+        {{/if}}
       {{else}}
         <h1 class="title is-spaced">Error</h1>
         <p class="subtitle">Something went wrong.</p>

--- a/ui/app/utils/codes-for-error.js
+++ b/ui/app/utils/codes-for-error.js
@@ -1,0 +1,15 @@
+// Returns an array of error codes as strings for an Ember error object
+export default function codesForError(error) {
+  const codes = [error.code];
+
+  if (error.errors) {
+    error.errors.forEach(err => {
+      codes.push(err.status);
+    });
+  }
+
+  return codes
+    .compact()
+    .uniq()
+    .map(code => '' + code);
+}


### PR DESCRIPTION
The HTTP API now throws 403s when ACLs are enforced and the token a request is made with isn't privileged to make said request.

The UI now never lets a user get into a state where there is no solution. This comes in two forms:

1. When a list request is a 403 (e.g., `/v1/jobs`), it is interpreted as empty and the jobs page empty state suggests providing a token.
  ![image](https://user-images.githubusercontent.com/174740/31525547-df355bc2-af75-11e7-911c-0f7c19a355eb.png)


2. When a single resource request is a 403, the application errors, but the error message includes a link to the ACL tokens page.
  ![image](https://user-images.githubusercontent.com/174740/31525537-c955290e-af75-11e7-9a5e-2183e56d6d32.png)
