### PR TITLE
Remove AllocID from ExecutorContext

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -614,7 +614,6 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (*StartRespon
 		TaskEnv:        ctx.TaskEnv,
 		Task:           task,
 		Driver:         "docker",
-		AllocID:        d.DriverContext.allocID,
 		LogDir:         ctx.TaskDir.LogDir,
 		TaskDir:        ctx.TaskDir.Dir,
 		PortLowerBound: d.config.ClientMinPort,

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -120,7 +120,6 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 	executorCtx := &executor.ExecutorContext{
 		TaskEnv: ctx.TaskEnv,
 		Driver:  "exec",
-		AllocID: d.DriverContext.allocID,
 		LogDir:  ctx.TaskDir.LogDir,
 		TaskDir: ctx.TaskDir.Dir,
 		Task:    task,

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -71,9 +71,6 @@ type ExecutorContext struct {
 	// Task is the task whose executor is being launched
 	Task *structs.Task
 
-	// AllocID is the allocation id to which the task belongs
-	AllocID string
-
 	// TaskDir is the host path to the task's root
 	TaskDir string
 

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -251,7 +251,6 @@ func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 	executorCtx := &executor.ExecutorContext{
 		TaskEnv: ctx.TaskEnv,
 		Driver:  "java",
-		AllocID: d.DriverContext.allocID,
 		Task:    task,
 		TaskDir: ctx.TaskDir.Dir,
 		LogDir:  ctx.TaskDir.LogDir,

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -253,7 +253,6 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 	executorCtx := &executor.ExecutorContext{
 		TaskEnv: ctx.TaskEnv,
 		Driver:  "qemu",
-		AllocID: d.DriverContext.allocID,
 		Task:    task,
 		TaskDir: ctx.TaskDir.Dir,
 		LogDir:  ctx.TaskDir.LogDir,

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -135,7 +135,6 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (*StartRespo
 	executorCtx := &executor.ExecutorContext{
 		TaskEnv: ctx.TaskEnv,
 		Driver:  "raw_exec",
-		AllocID: d.DriverContext.allocID,
 		Task:    task,
 		TaskDir: ctx.TaskDir.Dir,
 		LogDir:  ctx.TaskDir.LogDir,


### PR DESCRIPTION
It seems it's not used anywhere. This decouples a little plugin setup from driver instance.