### PR TITLE
Improved ACL Token page

### DIFF
--- a/ui/app/adapters/policy.js
+++ b/ui/app/adapters/policy.js
@@ -1,0 +1,5 @@
+import { default as ApplicationAdapter, namespace } from './application';
+
+export default ApplicationAdapter.extend({
+  namespace: namespace + '/acl',
+});

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -1,0 +1,5 @@
+import { default as ApplicationAdapter, namespace } from './application';
+
+export default ApplicationAdapter.extend({
+  namespace: namespace + '/acl',
+});

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -1,5 +1,21 @@
+import Ember from 'ember';
 import { default as ApplicationAdapter, namespace } from './application';
 
+const { inject } = Ember;
+
 export default ApplicationAdapter.extend({
+  store: inject.service(),
+
   namespace: namespace + '/acl',
+
+  findSelf() {
+    return this.ajax(`${this.buildURL()}/token/self`).then(token => {
+      const store = this.get('store');
+      store.pushPayload('token', {
+        tokens: [token],
+      });
+
+      return store.peekRecord('token', store.normalize('token', token).data.id);
+    });
+  },
 });

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -5,11 +5,11 @@ const { Controller, inject, computed, getOwner } = Ember;
 export default Controller.extend({
   token: inject.service(),
 
-  tokenRecord: null,
   secret: computed.reads('token.secret'),
 
   tokenIsValid: false,
   tokenIsInvalid: false,
+  tokenRecord: null,
 
   actions: {
     clearTokenProperties() {
@@ -41,8 +41,8 @@ export default Controller.extend({
         () => {
           this.set('token.secret', null);
           this.setProperties({
-            tokenIsInvalid: true,
             tokenIsValid: false,
+            tokenIsInvalid: true,
             tokenRecord: null,
           });
         }

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -1,20 +1,53 @@
 import Ember from 'ember';
 
-const { Controller, inject } = Ember;
+const { Controller, inject, computed } = Ember;
 
 export default Controller.extend({
   token: inject.service(),
 
-  actions: {
-    setTokenProperty(property, event) {
-      this.get('token').set(property, event.currentTarget.value);
-    },
+  tokenRecord: null,
+  secret: computed.reads('token.secret'),
+  accessor: computed.reads('token.accessor'),
 
+  tokenIsValid: false,
+  tokenIsInvalid: false,
+
+  actions: {
     clearTokenProperties() {
       this.get('token').setProperties({
         secret: undefined,
         accessor: undefined,
       });
+      this.setProperties({
+        tokenIsValid: false,
+        tokenIsInvalid: false,
+      });
+    },
+
+    verifyToken() {
+      const { secret, accessor } = this.getProperties('secret', 'accessor');
+
+      this.set('token.secret', secret);
+      this.get('store')
+        .findRecord('token', accessor)
+        .then(
+          token => {
+            this.set('token.accessor', accessor);
+            this.setProperties({
+              tokenIsValid: true,
+              tokenIsInvalid: false,
+              tokenRecord: token,
+            });
+          },
+          () => {
+            this.set('token.secret', null);
+            this.setProperties({
+              tokenIsInvalid: true,
+              tokenIsValid: false,
+              tokenRecord: null,
+            });
+          }
+        );
     },
   },
 });

--- a/ui/app/models/policy.js
+++ b/ui/app/models/policy.js
@@ -1,0 +1,8 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+export default Model.extend({
+  name: attr('string'),
+  description: attr('string'),
+  rules: attr('string'),
+});

--- a/ui/app/models/token.js
+++ b/ui/app/models/token.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import { hasMany } from 'ember-data/relationships';
+
+const { computed } = Ember;
+
+export default Model.extend({
+  secret: attr('string'),
+  name: attr('string'),
+  global: attr('boolean'),
+  createTime: attr('date'),
+  type: attr('string'),
+  policies: hasMany('policy'),
+  policyNames: attr(),
+
+  accessor: computed.alias('id'),
+});

--- a/ui/app/serializers/application.js
+++ b/ui/app/serializers/application.js
@@ -11,7 +11,10 @@ export default JSONSerializer.extend({
   },
 
   keyForRelationship(attr, relationshipType) {
-    const key = `${attr.camelize().capitalize()}ID`;
+    const key = `${attr
+      .singularize()
+      .camelize()
+      .capitalize()}ID`;
     return relationshipType === 'hasMany' ? key.pluralize() : key;
   },
 

--- a/ui/app/serializers/policy.js
+++ b/ui/app/serializers/policy.js
@@ -1,0 +1,8 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  normalize(typeHash, hash) {
+    hash.ID = hash.Name;
+    return this._super(typeHash, hash);
+  },
+});

--- a/ui/app/serializers/token.js
+++ b/ui/app/serializers/token.js
@@ -7,7 +7,6 @@ export default ApplicationSerializer.extend({
   primaryKey: 'AccessorID',
 
   attrs: {
-    taskGroupName: 'TaskGroup',
     secret: 'SecretID',
   },
 

--- a/ui/app/serializers/token.js
+++ b/ui/app/serializers/token.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+import ApplicationSerializer from './application';
+
+const { copy } = Ember;
+
+export default ApplicationSerializer.extend({
+  primaryKey: 'AccessorID',
+
+  attrs: {
+    taskGroupName: 'TaskGroup',
+    secret: 'SecretID',
+  },
+
+  normalize(typeHash, hash) {
+    hash.PolicyIDs = hash.Policies;
+    hash.PolicyNames = copy(hash.Policies);
+    return this._super(typeHash, hash);
+  },
+});

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -4,20 +4,6 @@ import fetch from 'fetch';
 const { Service, computed, assign } = Ember;
 
 export default Service.extend({
-  accessor: computed({
-    get() {
-      return window.sessionStorage.nomadTokenAccessor;
-    },
-    set(key, value) {
-      if (value == null) {
-        window.sessionStorage.removeItem('nomadTokenAccessor');
-      } else {
-        window.sessionStorage.nomadTokenAccessor = value;
-      }
-      return value;
-    },
-  }),
-
   secret: computed({
     get() {
       return window.sessionStorage.nomadTokenSecret;

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -25,13 +25,6 @@
           <p class="help">Sent with every request to determine authorization</p>
         </div>
 
-        <div class="field">
-          <label class="label">Accessor ID</label>
-          <div class="control">
-            <input class="input token-accessor" type="text" placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" value={{token.accessor}} oninput={{action (mut accessor) value="target.value"}}>
-          </div>
-          <p class="help">Used to look up authorized policies</p>
-        </div>
         <p class="content"><button class="button is-primary token-submit" {{action "verifyToken"}}>Set Token</button></p>
       {{/if}}
 
@@ -51,7 +44,7 @@
           <div class="columns">
             <div class="column">
               <h3 class="title is-4">Token Failed to Authenticate</h3>
-              <p>The token secret and accessor you have provided do not match.</p>
+              <p>The token secret you have provided does not match an existing token.</p>
             </div>
           </div>
         </div>

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -16,21 +16,80 @@
         </div>
       </div>
 
-      <div class="field">
-        <label class="label">Secret ID</label>
-        <div class="control">
-          <input class="input token-secret" type="text" placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" value={{token.secret}} oninput={{action "setTokenProperty" "secret"}}>
+      {{#if (not tokenIsValid)}}
+        <div class="field">
+          <label class="label">Secret ID</label>
+          <div class="control">
+            <input class="input token-secret" type="text" placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" value={{token.secret}} oninput={{action (mut secret) value="target.value"}}>
+          </div>
+          <p class="help">Sent with every request to determine authorization</p>
         </div>
-        <p class="help">Sent with every request to determine authorization</p>
-      </div>
 
-      <div class="field">
-        <label class="label">Accessor ID</label>
-        <div class="control">
-          <input class="input token-accessor" type="text" placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" value={{token.accessor}} oninput={{action "setTokenProperty" "accessor"}}>
+        <div class="field">
+          <label class="label">Accessor ID</label>
+          <div class="control">
+            <input class="input token-accessor" type="text" placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" value={{token.accessor}} oninput={{action (mut accessor) value="target.value"}}>
+          </div>
+          <p class="help">Used to look up authorized policies</p>
         </div>
-        <p class="help">Used to look up authorized policies</p>
-      </div>
+        <p class="content"><button class="button is-primary" {{action "verifyToken"}}>Set Token</button></p>
+      {{/if}}
+
+      {{#if tokenIsValid}}
+        <div class="notification is-success">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">Token Authenticated!</h3>
+              <p>Your token is valid and authorized for the following policies.</p>
+            </div>
+          </div>
+        </div>
+      {{/if}}
+
+      {{#if tokenIsInvalid}}
+        <div class="notification is-danger">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">Token Failed to Authenticate</h3>
+              <p>The token secret and accessor you have provided do not match.</p>
+            </div>
+          </div>
+        </div>
+      {{/if}}
+
+      {{#if tokenRecord}}
+        <h3 class="title is-4">Token: {{tokenRecord.name}}</h3>
+        <div class="content">
+          <div>AccessorID: <code>{{tokenRecord.accessor}}</code></div>
+          <div>SecretID: <code>{{tokenRecord.secret}}</code></div>
+        </div>
+        <h3 class="title is-4">Policies</h3>
+        {{#if (eq tokenRecord.type "management")}}
+          <div class="boxed-section">
+            <div class="boxed-section-body has-centered-text">
+              The management token has all permissions
+            </div>
+          </div>
+        {{else}}
+          {{#each tokenRecord.policies as |policy|}}
+            <div class="boxed-section">
+              <div class="boxed-section-head">
+                {{policy.name}}
+              </div>
+              <div class="boxed-section-body">
+                <p class="content">
+                  {{#if policy.description}}
+                    {{policy.description}}
+                  {{else}}
+                    <em>No description</em>
+                  {{/if}}
+                </p>
+                <pre><code>{{policy.rules}}</code></pre>
+              </div>
+            </div>
+          {{/each}}
+        {{/if}}
+      {{/if}}
     </div>
   </div>
 </section>

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -32,11 +32,11 @@
           </div>
           <p class="help">Used to look up authorized policies</p>
         </div>
-        <p class="content"><button class="button is-primary" {{action "verifyToken"}}>Set Token</button></p>
+        <p class="content"><button class="button is-primary token-submit" {{action "verifyToken"}}>Set Token</button></p>
       {{/if}}
 
       {{#if tokenIsValid}}
-        <div class="notification is-success">
+        <div class="notification is-success token-success">
           <div class="columns">
             <div class="column">
               <h3 class="title is-4">Token Authenticated!</h3>
@@ -47,7 +47,7 @@
       {{/if}}
 
       {{#if tokenIsInvalid}}
-        <div class="notification is-danger">
+        <div class="notification is-danger token-error">
           <div class="columns">
             <div class="column">
               <h3 class="title is-4">Token Failed to Authenticate</h3>
@@ -65,14 +65,14 @@
         </div>
         <h3 class="title is-4">Policies</h3>
         {{#if (eq tokenRecord.type "management")}}
-          <div class="boxed-section">
+          <div class="boxed-section token-management-message">
             <div class="boxed-section-body has-centered-text">
               The management token has all permissions
             </div>
           </div>
         {{else}}
           {{#each tokenRecord.policies as |policy|}}
-            <div class="boxed-section">
+            <div class="boxed-section token-policy">
               <div class="boxed-section-head">
                 {{policy.name}}
               </div>

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -89,6 +89,19 @@ export default function() {
     return JSON.stringify(findLeader(schema));
   });
 
+  this.get('/acl/token/self', function({ tokens }, req) {
+    const secret = req.requestHeaders['X-Nomad-Token'];
+    const tokenForSecret = tokens.findBy({ secretId: secret });
+
+    // Return the token if it exists
+    if (tokenForSecret) {
+      return this.serialize(tokenForSecret);
+    }
+
+    // Client error if it doesn't
+    return new Response(400, {}, null);
+  });
+
   this.get('/acl/token/:id', function({ tokens }, req) {
     const token = tokens.find(req.params.id);
     const secret = req.requestHeaders['X-Nomad-Token'];

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -89,6 +89,40 @@ export default function() {
     return JSON.stringify(findLeader(schema));
   });
 
+  this.get('/acl/token/:id', function({ tokens }, req) {
+    const token = tokens.find(req.params.id);
+    const secret = req.requestHeaders['X-Nomad-Token'];
+    const tokenForSecret = tokens.findBy({ secretId: secret });
+
+    // Return the token only if the request header matches the token
+    // or the token is of type management
+    if (token.secretId === secret || (tokenForSecret && tokenForSecret.type === 'management')) {
+      return this.serialize(token);
+    }
+
+    // Return not authorized otherwise
+    return new Response(403, {}, null);
+  });
+
+  this.get('/acl/policy/:id', function({ policies, tokens }, req) {
+    const policy = policies.find(req.params.id);
+    const secret = req.requestHeaders['X-Nomad-Token'];
+    const tokenForSecret = tokens.findBy({ secretId: secret });
+
+    // Return the policy only if the token that matches the request header
+    // includes the policy or if the token that matches the request header
+    // is of type management
+    if (
+      tokenForSecret &&
+      (tokenForSecret.policies.includes(policy) || tokenForSecret.type === 'management')
+    ) {
+      return this.serialize(policy);
+    }
+
+    // Return not authorized otherwise
+    return new Response(403, {}, null);
+  });
+
   // TODO: in the future, this hack may be replaceable with dynamic host name
   // support in pretender: https://github.com/pretenderjs/pretender/issues/210
   HOSTS.forEach(host => {

--- a/ui/mirage/factories/policy.js
+++ b/ui/mirage/factories/policy.js
@@ -1,0 +1,18 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  id: () => faker.hacker.verb(),
+  name() {
+    return this.id;
+  },
+  description: () => (Math.random() > 0.2 ? faker.lorem.sentence() : null),
+  rules: `
+# Allow read only access to the default namespace
+namespace "default" {
+    policy = "read"
+}
+
+node {
+    policy = "read"
+}`,
+});

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -13,7 +13,8 @@ export default Factory.extend({
   afterCreate(token, server) {
     const policyIds = Array(faker.random.number({ min: 1, max: 5 }))
       .fill(0)
-      .map(() => faker.hacker.verb());
+      .map(() => faker.hacker.verb())
+      .uniq();
 
     policyIds.forEach(policy => {
       const dbPolicy = server.db.policies.find(policy);

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -1,0 +1,27 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  id: () => faker.random.uuid(),
+  accessorId() {
+    return this.id;
+  },
+  secretId: () => faker.random.uuid(),
+  name: () => faker.name.findName(),
+  global: () => faker.random.boolean(),
+  type: i => (i === 0 ? 'management' : 'client'),
+
+  afterCreate(token, server) {
+    const policyIds = Array(faker.random.number({ min: 1, max: 5 }))
+      .fill(0)
+      .map(() => faker.hacker.verb());
+
+    policyIds.forEach(policy => {
+      const dbPolicy = server.db.policies.find(policy);
+      if (!dbPolicy) {
+        server.create('policy', { id: policy });
+      }
+    });
+
+    token.update({ policyIds });
+  },
+});

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -5,4 +5,21 @@ export default function(server) {
   server.createList('namespace', 3);
 
   server.createList('job', 15);
+
+  server.createList('token', 3);
+  logTokens(server);
 }
+
+/* eslint-disable */
+function logTokens(server) {
+  console.log('TOKENS:');
+  server.db.tokens.forEach(token => {
+    console.log(`
+Name: ${token.name}
+Secret: ${token.secretId}
+Accessor: ${token.accessorId}
+
+`);
+  });
+}
+/* eslint-enable */

--- a/ui/mirage/serializers/token.js
+++ b/ui/mirage/serializers/token.js
@@ -1,0 +1,12 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  serializeIds: 'always',
+
+  keyForRelationshipIds(relationship) {
+    if (relationship === 'policies') {
+      return 'Policies';
+    }
+    return ApplicationSerializer.prototype.keyForRelationshipIds.apply(this, arguments);
+  },
+});

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -21,27 +21,24 @@ moduleForAcceptance('Acceptance | tokens', {
 });
 
 test('the token form sets the token in session storage', function(assert) {
-  const { secretId, accessorId } = managementToken;
+  const { secretId } = managementToken;
 
   visit('/settings/tokens');
 
   andThen(() => {
     assert.ok(window.sessionStorage.nomadTokenSecret == null, 'No token secret set');
-    assert.ok(window.sessionStorage.nomadTokenAccessor == null, 'No token accessor set');
 
     fillIn('.token-secret', secretId);
-    fillIn('.token-accessor', accessorId);
     click('.token-submit');
 
     andThen(() => {
       assert.equal(window.sessionStorage.nomadTokenSecret, secretId, 'Token secret was set');
-      assert.equal(window.sessionStorage.nomadTokenAccessor, accessorId, 'Token accessor was set');
     });
   });
 });
 
 test('the X-Nomad-Token header gets sent with requests once it is set', function(assert) {
-  const { secretId, accessorId } = managementToken;
+  const { secretId } = managementToken;
   let requestPosition = 0;
 
   visit(`/jobs/${job.id}`);
@@ -60,7 +57,6 @@ test('the X-Nomad-Token header gets sent with requests once it is set', function
   visit('/settings/tokens');
   andThen(() => {
     fillIn('.token-secret', secretId);
-    fillIn('.token-accessor', accessorId);
     click('.token-submit');
   });
 
@@ -78,7 +74,7 @@ test('the X-Nomad-Token header gets sent with requests once it is set', function
 });
 
 test('an error message is shown when authenticating a token fails', function(assert) {
-  const { secretId, accessorId } = managementToken;
+  const { secretId } = managementToken;
   const bogusSecret = 'this-is-not-the-secret';
   assert.notEqual(
     secretId,
@@ -90,17 +86,12 @@ test('an error message is shown when authenticating a token fails', function(ass
 
   andThen(() => {
     fillIn('.token-secret', bogusSecret);
-    fillIn('.token-accessor', accessorId);
     click('.token-submit');
 
     andThen(() => {
       assert.ok(
         window.sessionStorage.nomadTokenSecret == null,
         'Token secret is discarded on failure'
-      );
-      assert.ok(
-        window.sessionStorage.nomadTokenAccessor == null,
-        'Token accessor is discarded on failure'
       );
       assert.ok(find('.token-error'), 'Token error message is shown');
       assert.notOk(find('.token-success'), 'Token success message is not shown');
@@ -112,13 +103,12 @@ test('an error message is shown when authenticating a token fails', function(ass
 test('a success message and a special management token message are shown when authenticating succeeds', function(
   assert
 ) {
-  const { secretId, accessorId } = managementToken;
+  const { secretId } = managementToken;
 
   visit('/settings/tokens');
 
   andThen(() => {
     fillIn('.token-secret', secretId);
-    fillIn('.token-accessor', accessorId);
     click('.token-submit');
 
     andThen(() => {
@@ -133,7 +123,7 @@ test('a success message and a special management token message are shown when au
 test('a success message and associated policies are shown when authenticating succeeds', function(
   assert
 ) {
-  const { secretId, accessorId } = clientToken;
+  const { secretId } = clientToken;
   const policy = clientToken.policies.models[0];
   policy.update('description', 'Make sure there is a description');
 
@@ -141,7 +131,6 @@ test('a success message and associated policies are shown when authenticating su
 
   andThen(() => {
     fillIn('.token-secret', secretId);
-    fillIn('.token-accessor', accessorId);
     click('.token-submit');
 
     andThen(() => {

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -1,21 +1,27 @@
-import { fillIn, visit } from 'ember-native-dom-helpers';
+import { find, findAll, fillIn, click, visit } from 'ember-native-dom-helpers';
+import Ember from 'ember';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 
+const { $ } = Ember;
+
 let job;
 let node;
+let managementToken;
+let clientToken;
 
 moduleForAcceptance('Acceptance | tokens', {
   beforeEach() {
     server.create('agent');
     node = server.create('node');
     job = server.create('job');
+    managementToken = server.create('token');
+    clientToken = server.create('token');
   },
 });
 
 test('the token form sets the token in session storage', function(assert) {
-  const secret = 'this-is-the-secret';
-  const accessor = 'this-is-the-accessor';
+  const { secretId, accessorId } = managementToken;
 
   visit('/settings/tokens');
 
@@ -23,27 +29,19 @@ test('the token form sets the token in session storage', function(assert) {
     assert.ok(window.sessionStorage.nomadTokenSecret == null, 'No token secret set');
     assert.ok(window.sessionStorage.nomadTokenAccessor == null, 'No token accessor set');
 
-    andThen(() => {
-      fillIn('.token-secret', secret);
-    });
+    fillIn('.token-secret', secretId);
+    fillIn('.token-accessor', accessorId);
+    click('.token-submit');
 
     andThen(() => {
-      assert.equal(window.sessionStorage.nomadTokenSecret, secret, 'Token secret was set');
-      assert.ok(window.sessionStorage.nomadTokenAccessor == null, 'Token accessor was not set');
-    });
-
-    andThen(() => {
-      fillIn('.token-accessor', accessor);
-    });
-
-    andThen(() => {
-      assert.equal(window.sessionStorage.nomadTokenAccessor, accessor, 'Token accessor was set');
+      assert.equal(window.sessionStorage.nomadTokenSecret, secretId, 'Token secret was set');
+      assert.equal(window.sessionStorage.nomadTokenAccessor, accessorId, 'Token accessor was set');
     });
   });
 });
 
 test('the X-Nomad-Token header gets sent with requests once it is set', function(assert) {
-  const secret = 'this-is-the-secret';
+  const { secretId, accessorId } = managementToken;
   let requestPosition = 0;
 
   visit(`/jobs/${job.id}`);
@@ -61,7 +59,9 @@ test('the X-Nomad-Token header gets sent with requests once it is set', function
 
   visit('/settings/tokens');
   andThen(() => {
-    fillIn('.token-secret', secret);
+    fillIn('.token-secret', secretId);
+    fillIn('.token-accessor', accessorId);
+    click('.token-submit');
   });
 
   visit(`/jobs/${job.id}`);
@@ -72,7 +72,111 @@ test('the X-Nomad-Token header gets sent with requests once it is set', function
     assert.ok(newRequests.length > 1, 'New requests have been made');
 
     newRequests.forEach(req => {
-      assert.equal(req.requestHeaders['X-Nomad-Token'], secret, `Token set for ${req.url}`);
+      assert.equal(req.requestHeaders['X-Nomad-Token'], secretId, `Token set for ${req.url}`);
+    });
+  });
+});
+
+test('an error message is shown when authenticating a token fails', function(assert) {
+  const { secretId, accessorId } = managementToken;
+  const bogusSecret = 'this-is-not-the-secret';
+  assert.notEqual(
+    secretId,
+    bogusSecret,
+    'bogus secret is not somehow coincidentally equal to the real secret'
+  );
+
+  visit('/settings/tokens');
+
+  andThen(() => {
+    fillIn('.token-secret', bogusSecret);
+    fillIn('.token-accessor', accessorId);
+    click('.token-submit');
+
+    andThen(() => {
+      assert.ok(
+        window.sessionStorage.nomadTokenSecret == null,
+        'Token secret is discarded on failure'
+      );
+      assert.ok(
+        window.sessionStorage.nomadTokenAccessor == null,
+        'Token accessor is discarded on failure'
+      );
+      assert.ok(find('.token-error'), 'Token error message is shown');
+      assert.notOk(find('.token-success'), 'Token success message is not shown');
+      assert.notOk(find('.token-policy'), 'No token policies are shown');
+    });
+  });
+});
+
+test('a success message and a special management token message are shown when authenticating succeeds', function(
+  assert
+) {
+  const { secretId, accessorId } = managementToken;
+
+  visit('/settings/tokens');
+
+  andThen(() => {
+    fillIn('.token-secret', secretId);
+    fillIn('.token-accessor', accessorId);
+    click('.token-submit');
+
+    andThen(() => {
+      assert.ok(find('.token-success'), 'Token success message is shown');
+      assert.notOk(find('.token-error'), 'Token error message is not shown');
+      assert.ok(find('.token-management-message'), 'Token management message is shown');
+      assert.notOk(find('.token-policy'), 'No token policies are shown');
+    });
+  });
+});
+
+test('a success message and associated policies are shown when authenticating succeeds', function(
+  assert
+) {
+  const { secretId, accessorId } = clientToken;
+  const policy = clientToken.policies.models[0];
+  policy.update('description', 'Make sure there is a description');
+
+  visit('/settings/tokens');
+
+  andThen(() => {
+    fillIn('.token-secret', secretId);
+    fillIn('.token-accessor', accessorId);
+    click('.token-submit');
+
+    andThen(() => {
+      assert.ok(find('.token-success'), 'Token success message is shown');
+      assert.notOk(find('.token-error'), 'Token error message is not shown');
+      assert.notOk(find('.token-management-message'), 'Token management message is not shown');
+      assert.equal(
+        findAll('.token-policy').length,
+        clientToken.policies.length,
+        'Each policy associated with the token is listed'
+      );
+
+      const policyElement = $(find('.token-policy'));
+
+      assert.equal(
+        policyElement
+          .find('.boxed-section-head')
+          .text()
+          .trim(),
+        policy.name,
+        'Policy Name'
+      );
+      assert.equal(
+        policyElement
+          .find('.boxed-section-body p.content')
+          .text()
+          .trim(),
+        policy.description,
+        'Policy Description'
+      );
+      assert.equal(
+        policyElement.find('.boxed-section-body pre code').text(),
+        policy.rules,
+        'Policy Rules'
+      );
     });
   });
 });


### PR DESCRIPTION
**Rebased on #3377**

Two big changes:

1. Only the token secret is necessary now
2. Authenticating a token lists its associated policies and rules

![image](https://user-images.githubusercontent.com/174740/31578837-4b1dc4a0-b0de-11e7-99a7-fc4882af29ab.png)


![image](https://user-images.githubusercontent.com/174740/31578829-177565e0-b0de-11e7-9c07-da222bd6ebc2.png)
