### PR TITLE
Return error for invalid policy

### DIFF
--- a/acl/policy.go
+++ b/acl/policy.go
@@ -137,7 +137,7 @@ func Parse(rules string) (*Policy, error) {
 	// At least one valid policy must be specified, we don't want to store only
 	// raw data
 	if len(p.Namespaces) < 1 && p.Agent == nil && p.Node == nil && p.Operator == nil && p.Quota == nil {
-		return nil, fmt.Errorf("Invalid rule set due to missing namespace name: %s", p.Raw)
+		return nil, fmt.Errorf("Invalid policy: %s", p.Raw)
 	}
 
 	// Validate the policy

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -45,6 +45,16 @@ type Policy struct {
 	Raw        string             `hcl:"-"`
 }
 
+// IsEmpty checks to make sure that at least one policy has been set and is not
+// comprised of only a raw policy.
+func (p *Policy) IsEmpty() bool {
+	return len(p.Namespaces) == 0 &&
+		p.Agent == nil &&
+		p.Node == nil &&
+		p.Operator == nil &&
+		p.Quota == nil
+}
+
 // NamespacePolicy is the policy for a specific namespace
 type NamespacePolicy struct {
 	Name         string `hcl:",key"`
@@ -136,7 +146,7 @@ func Parse(rules string) (*Policy, error) {
 
 	// At least one valid policy must be specified, we don't want to store only
 	// raw data
-	if len(p.Namespaces) < 1 && p.Agent == nil && p.Node == nil && p.Operator == nil && p.Quota == nil {
+	if p.IsEmpty() {
 		return nil, fmt.Errorf("Invalid policy: %s", p.Raw)
 	}
 

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -134,6 +134,12 @@ func Parse(rules string) (*Policy, error) {
 		return nil, fmt.Errorf("Failed to parse ACL Policy: %v", err)
 	}
 
+	// At least one valid policy must be specified, we don't want to store only
+	// raw data
+	if len(p.Namespaces) < 1 && p.Agent == nil && p.Node == nil && p.Operator == nil && p.Quota == nil {
+		return nil, fmt.Errorf("Invalid rule set due to missing namespace name: %s", p.Raw)
+	}
+
 	// Validate the policy
 	for _, ns := range p.Namespaces {
 		if !validNamespace.MatchString(ns.Name) {

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -160,6 +160,17 @@ func TestParse(t *testing.T) {
 		},
 		{
 			`
+			{
+				"Name": "my-policy",
+				"Description": "This is a great policy",
+				"Rules": "anything"
+			}
+			`,
+			"Invalid rule set due to missing namespace name",
+			nil,
+		},
+		{
+			`
 			namespace "has a space"{
 				policy = "read"
 			}

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -166,7 +166,7 @@ func TestParse(t *testing.T) {
 				"Rules": "anything"
 			}
 			`,
-			"Invalid rule set due to missing namespace name",
+			"Invalid policy",
 			nil,
 		},
 		{


### PR DESCRIPTION
If a namespace is not specified for a valid rule set, an invalid policy will return success and store the policy with only raw content. 

A policy should have at least one valid policy and should not store only raw data that has failed to otherwise parse.

Fixes #3239