### PR TITLE
Add job version to allocation tables

### DIFF
--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -26,6 +26,7 @@ export default Model.extend({
   taskGroupName: attr('string'),
   resources: fragment('resources'),
   modifyIndex: attr('number'),
+  jobVersion: attr('number'),
 
   // TEMPORARY: https://github.com/emberjs/data/issues/5209
   originalJobId: attr('string'),

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -9,6 +9,7 @@
   <span class="color-swatch {{allocation.clientStatus}}" /> {{allocation.clientStatus}}
 </td>
 {{#if (eq context "job")}}
+  <td>{{allocation.jobVersion}}</td>
   <td><a href="{{href-to "nodes.node" allocation.node}}">{{allocation.node.shortId}}</a></td>
 {{else if (eq context "node")}}
   <td>
@@ -19,6 +20,7 @@
       <span class="is-faded">/ {{allocation.taskGroup.name}}</span>
     {{/if}}
   </td>
+  <td>{{allocation.jobVersion}}</td>
 {{/if}}
 <td class="has-text-centered">
   {{#if allocation.stats.isPending}}

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -71,6 +71,7 @@
               {{#t.sort-by prop="modifyIndex" title="Modify Index"}}Modified{{/t.sort-by}}
               {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
               {{#t.sort-by prop="statusIndex"}}Status{{/t.sort-by}}
+              {{#t.sort-by prop="jobVersion"}}Version{{/t.sort-by}}
               {{#t.sort-by prop="node.shortId"}}Node{{/t.sort-by}}
               <th>CPU</th>
               <th>Memory</th>

--- a/ui/app/templates/nodes/node.hbs
+++ b/ui/app/templates/nodes/node.hbs
@@ -44,6 +44,7 @@
               {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
               {{#t.sort-by prop="statusIndex"}}Status{{/t.sort-by}}
               {{#t.sort-by prop="job.name"}}Job{{/t.sort-by}}
+              {{#t.sort-by prop="jobVersion"}}Version{{/t.sort-by}}
               <th>CPU</th>
               <th>Memory</th>
             {{/t.head}}

--- a/ui/mirage/factories/allocation.js
+++ b/ui/mirage/factories/allocation.js
@@ -10,6 +10,7 @@ export default Factory.extend({
   id: i => (i >= 100 ? `${UUIDS[i % 100]}-${i}` : UUIDS[i]),
 
   modifyIndex: () => faker.random.number({ min: 10, max: 2000 }),
+  jobVersion: () => faker.random.number(10),
 
   clientStatus: faker.list.random(...CLIENT_STATUSES),
   desiredStatus: faker.list.random(...DESIRED_STATUSES),

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -160,29 +160,36 @@ test('each allocation should have high-level details for the allocation', functi
         .includes(allocation.taskGroup),
       'Task group name'
     );
-    assert.equal(
+    assert.ok(
       allocationRow
         .find('td:eq(5)')
         .text()
-        .trim(),
-      allocStats.resourceUsage.CpuStats.Percent,
-      'CPU %'
-    );
-    assert.equal(
-      allocationRow.find('td:eq(5) .tooltip').attr('aria-label'),
-      `${Math.floor(allocStats.resourceUsage.CpuStats.TotalTicks)} / ${cpuUsed} MHz`,
-      'Detailed CPU information is in a tooltip'
+        .includes(allocation.jobVersion),
+      'Job Version'
     );
     assert.equal(
       allocationRow
         .find('td:eq(6)')
         .text()
         .trim(),
+      allocStats.resourceUsage.CpuStats.Percent,
+      'CPU %'
+    );
+    assert.equal(
+      allocationRow.find('td:eq(6) .tooltip').attr('aria-label'),
+      `${Math.floor(allocStats.resourceUsage.CpuStats.TotalTicks)} / ${cpuUsed} MHz`,
+      'Detailed CPU information is in a tooltip'
+    );
+    assert.equal(
+      allocationRow
+        .find('td:eq(7)')
+        .text()
+        .trim(),
       allocStats.resourceUsage.MemoryStats.RSS / 1024 / 1024 / memoryUsed,
       'Memory used'
     );
     assert.equal(
-      allocationRow.find('td:eq(6) .tooltip').attr('aria-label'),
+      allocationRow.find('td:eq(7) .tooltip').attr('aria-label'),
       `${formatBytes([allocStats.resourceUsage.MemoryStats.RSS])} / ${memoryUsed} MiB`,
       'Detailed memory information is in a tooltip'
     );

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -181,12 +181,20 @@ test('each allocation should show basic information about the allocation', funct
         .find('td:eq(4)')
         .text()
         .trim(),
+      allocation.jobVersion,
+      'Job Version'
+    );
+    assert.equal(
+      allocationRow
+        .find('td:eq(5)')
+        .text()
+        .trim(),
       server.db.nodes.find(allocation.nodeId).id.split('-')[0],
       'Node ID'
     );
   });
 
-  click(allocationRow.find('td:eq(4) a').get(0));
+  click(allocationRow.find('td:eq(5) a').get(0));
 
   andThen(() => {
     assert.equal(currentURL(), `/nodes/${allocation.nodeId}`, 'Node links to node page');
@@ -206,7 +214,7 @@ test('each allocation should show stats about the allocation, retrieved directly
 
   assert.equal(
     allocationRow
-      .find('td:eq(5)')
+      .find('td:eq(6)')
       .text()
       .trim(),
     allocStats.resourceUsage.CpuStats.Percent,
@@ -214,14 +222,14 @@ test('each allocation should show stats about the allocation, retrieved directly
   );
 
   assert.equal(
-    allocationRow.find('td:eq(5) .tooltip').attr('aria-label'),
+    allocationRow.find('td:eq(6) .tooltip').attr('aria-label'),
     `${Math.floor(allocStats.resourceUsage.CpuStats.TotalTicks)} / ${cpuUsed} MHz`,
     'Detailed CPU information is in a tooltip'
   );
 
   assert.equal(
     allocationRow
-      .find('td:eq(6)')
+      .find('td:eq(7)')
       .text()
       .trim(),
     allocStats.resourceUsage.MemoryStats.RSS / 1024 / 1024 / memoryUsed,
@@ -229,7 +237,7 @@ test('each allocation should show stats about the allocation, retrieved directly
   );
 
   assert.equal(
-    allocationRow.find('td:eq(6) .tooltip').attr('aria-label'),
+    allocationRow.find('td:eq(7) .tooltip').attr('aria-label'),
     `${formatBytes([allocStats.resourceUsage.MemoryStats.RSS])} / ${memoryUsed} MiB`,
     'Detailed memory information is in a tooltip'
   );


### PR DESCRIPTION
On the node detail page it's after the task group

![image](https://user-images.githubusercontent.com/174740/31738674-49a4b578-b400-11e7-98f0-81b43eb4455b.png)

On the task group page it's after the alloc status

![image](https://user-images.githubusercontent.com/174740/31738697-5e873f56-b400-11e7-8e75-148c38390856.png)
