### PR TITLE
Qemu driver: graceful shutdown feature

### DIFF
--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -161,9 +161,9 @@ func (d *QemuDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, 
 	fixedSocketPathLenVer := semver.New("2.10.1")
 	if currentVer.LessThan(*fixedSocketPathLenVer) {
 		node.Attributes[qemuDriverLongMonitorPathAttr] = "0"
-		d.logger.Printf("[DEBUG] driver.qemu - long socket paths are not available in this version of QEMU")
+		d.logger.Printf("[DEBUG] driver.qemu: long socket paths are not available in this version of QEMU")
 	} else {
-		d.logger.Printf("[DEBUG] driver.qemu - long socket paths available in this version of QEMU")
+		d.logger.Printf("[DEBUG] driver.qemu: long socket paths available in this version of QEMU")
 		node.Attributes[qemuDriverLongMonitorPathAttr] = "1"
 	}
 	return true, nil
@@ -232,10 +232,10 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 		// to perform graceful shutdowns)
 		monitorPath, err = getMonitorPath(ctx.TaskDir.Dir, ctx.TaskEnv.NodeAttrs[qemuDriverLongMonitorPathAttr])
 		if err == nil {
-			d.logger.Printf("[DEBUG] driver.qemu - got monitor path OK: %s", monitorPath)
+			d.logger.Printf("[DEBUG] driver.qemu: got monitor path OK: %s", monitorPath)
 			args = append(args, "-monitor", fmt.Sprintf("unix:%s,server,nowait", monitorPath))
 		} else {
-			d.logger.Printf("[WARN] driver.qemu - %s", err)
+			d.logger.Printf("[WARN] driver.qemu: %s", err)
 		}
 	}
 
@@ -288,7 +288,7 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 		)
 	}
 
-	d.logger.Printf("[DEBUG] driver.qemu - starting QemuVM command: %q", strings.Join(args, " "))
+	d.logger.Printf("[DEBUG] driver.qemu: starting QemuVM command: %q", strings.Join(args, " "))
 	pluginLogFile := filepath.Join(ctx.TaskDir.Dir, "executor.out")
 	executorConfig := &dstructs.ExecutorConfig{
 		LogFile:  pluginLogFile,
@@ -321,7 +321,7 @@ func (d *QemuDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 		pluginClient.Kill()
 		return nil, err
 	}
-	d.logger.Printf("[INFO] driver.qemu - started new QemuVM: %s", vmID)
+	d.logger.Printf("[INFO] driver.qemu: started new QemuVM: %s", vmID)
 
 	// Create and Return Handle
 	maxKill := d.DriverContext.config.MaxKillTimeout
@@ -367,7 +367,7 @@ func (d *QemuDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, erro
 
 	exec, pluginClient, err := createExecutorWithConfig(pluginConfig, d.config.LogOutput)
 	if err != nil {
-		d.logger.Println("[ERR] driver.qemu - error connecting to plugin so destroying plugin pid and user pid")
+		d.logger.Println("[ERR] driver.qemu: error connecting to plugin so destroying plugin pid and user pid")
 		if e := destroyPlugin(id.PluginConfig.Pid, id.UserPid); e != nil {
 			d.logger.Printf("[ERR] driver.qemu: error destroying plugin and userpid: %v", e)
 		}
@@ -438,16 +438,16 @@ func (h *qemuHandle) Kill() error {
 		monitorSocket, err := net.Dial("unix", h.monitorPath)
 		if err == nil {
 			defer monitorSocket.Close()
-			h.logger.Printf("[DEBUG] driver.qemu - sending graceful shutdown command to qemu monitor socket at %s", h.monitorPath)
+			h.logger.Printf("[DEBUG] driver.qemu: sending graceful shutdown command to qemu monitor socket at %s", h.monitorPath)
 			_, err = monitorSocket.Write([]byte(qemuGracefulShutdownMsg))
 			if err == nil {
 				return nil
 			}
-			h.logger.Printf("[WARN] driver.qemu - failed to send '%s' to monitor socket '%s': %s", qemuGracefulShutdownMsg, h.monitorPath, err)
+			h.logger.Printf("[WARN] driver.qemu: failed to send '%s' to monitor socket '%s': %s", qemuGracefulShutdownMsg, h.monitorPath, err)
 		} else {
 			// OK, that didn't work - we'll continue on and
 			// attempt to kill the process as a last resort
-			h.logger.Printf("[WARN] driver.qemu - could not connect to qemu monitor at %s: %s", h.monitorPath, err)
+			h.logger.Printf("[WARN] driver.qemu: could not connect to qemu monitor at %s: %s", h.monitorPath, err)
 		}
 	}
 
@@ -462,7 +462,7 @@ func (h *qemuHandle) Kill() error {
 	case <-h.doneCh:
 		return nil
 	case <-time.After(h.killTimeout):
-		h.logger.Printf("[DEBUG] driver.qemu - kill timeout exceeded")
+		h.logger.Printf("[DEBUG] driver.qemu: kill timeout exceeded")
 		if h.pluginClient.Exited() {
 			return nil
 		}
@@ -481,7 +481,7 @@ func (h *qemuHandle) run() {
 	ps, werr := h.executor.Wait()
 	if ps.ExitCode == 0 && werr != nil {
 		if e := killProcess(h.userPid); e != nil {
-			h.logger.Printf("[ERR] driver.qemu - error killing user process: %v", e)
+			h.logger.Printf("[ERR] driver.qemu: error killing user process: %v", e)
 		}
 	}
 	close(h.doneCh)

--- a/client/driver/qemu.go
+++ b/client/driver/qemu.go
@@ -491,13 +491,11 @@ func (h *qemuHandle) run() {
 }
 
 func sendQemuShutdown(logger *log.Logger, monitorPath string, userPid int) error {
-	var err error
 	if monitorPath == "" {
 		logger.Printf("[DEBUG] driver.qemu: monitorPath not set; will not attempt graceful shutdown for user process pid %d", userPid)
-		err = errors.New("monitorPath not set")
+		return errors.New("monitorPath not set")
 	} else {
-		var monitorSocket net.Conn
-		monitorSocket, err = net.Dial("unix", monitorPath)
+		monitorSocket, err := net.Dial("unix", monitorPath)
 		if err == nil {
 			defer monitorSocket.Close()
 			logger.Printf("[DEBUG] driver.qemu: sending graceful shutdown command to qemu monitor socket %q for user process pid %d", monitorPath, userPid)
@@ -508,6 +506,6 @@ func sendQemuShutdown(logger *log.Logger, monitorPath string, userPid int) error
 		} else {
 			logger.Printf("[WARN] driver.qemu: could not connect to qemu monitor %q for user process pid %d: %s", monitorPath, userPid, err)
 		}
+		return err
 	}
-	return err
 }

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -2,10 +2,12 @@ package driver
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -69,7 +71,7 @@ func TestQemuDriver_StartOpen_Wait(t *testing.T) {
 		Config: map[string]interface{}{
 			"image_path":        "linux-0.2.img",
 			"accelerator":       "tcg",
-			"graceful_shutdown": true,
+			"graceful_shutdown": false,
 			"port_map": []map[string]int{{
 				"main": 22,
 				"web":  8080,
@@ -121,6 +123,96 @@ func TestQemuDriver_StartOpen_Wait(t *testing.T) {
 	}
 	if handle2 == nil {
 		t.Fatalf("missing handle")
+	}
+
+	// Clean up
+	if err := resp.Handle.Kill(); err != nil {
+		fmt.Printf("\nError killing Qemu test: %s", err)
+	}
+}
+
+func TestQemuDriver_GracefulShutdown(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	ctestutils.QemuCompatible(t)
+	task := &structs.Task{
+		Name:   "linux",
+		Driver: "qemu",
+		Config: map[string]interface{}{
+			"image_path":        "linux-0.2.img",
+			"accelerator":       "tcg",
+			"graceful_shutdown": true,
+			"port_map": []map[string]int{{
+				"main": 22,
+				"web":  8080,
+			}},
+			"args": []string{"-nodefconfig", "-nodefaults"},
+		},
+		// With the use of tcg acceleration, it's very unlikely a qemu instance
+		// will boot (and gracefully halt) in a reasonable amount of time, so
+		// this timeout is kept low to reduce test execution time
+		KillTimeout: time.Duration(1 * time.Second),
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			CPU:      500,
+			MemoryMB: 512,
+			Networks: []*structs.NetworkResource{
+				{
+					ReservedPorts: []structs.Port{{Label: "main", Value: 22000}, {Label: "web", Value: 80}},
+				},
+			},
+		},
+	}
+
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewQemuDriver(ctx.DriverCtx)
+
+	dst := ctx.ExecCtx.TaskDir.Dir
+
+	copyFile("./test-resources/qemu/linux-0.2.img", filepath.Join(dst, "linux-0.2.img"), t)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("Prestart failed: %v", err)
+	}
+
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// The monitor socket will not exist immediately, so we'll wait up to
+	// 5 seconds for it to become available.
+	monitorPath := fmt.Sprintf("%s/linux/%s", ctx.AllocDir.AllocDir, qemuMonitorSocketName)
+	monitorPathExists := false
+	for i := 0; i < 5; i++ {
+		if _, err := os.Stat(monitorPath); !os.IsNotExist(err) {
+			fmt.Printf("Monitor socket exists at %q\n", monitorPath)
+			monitorPathExists = true
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if monitorPathExists == false {
+		t.Fatalf("monitor socket did not exist after waiting 5 seconds")
+	}
+
+	// userPid supplied in sendQemuShutdown calls is bogus (it's used only
+	// for log output)
+	if err := sendQemuShutdown(ctx.DriverCtx.logger, "", 0); err == nil {
+		t.Fatalf("sendQemuShutdown should return an error if monitorPath parameter is empty")
+	}
+
+	if err := sendQemuShutdown(ctx.DriverCtx.logger, "/path/that/does/not/exist", 0); err == nil {
+		t.Fatalf("sendQemuShutdown should return an error if file does not exist at monitorPath")
+	}
+
+	if err := sendQemuShutdown(ctx.DriverCtx.logger, monitorPath, 0); err != nil {
+		t.Fatalf("unexpected error from sendQemuShutdown: %s", err)
 	}
 
 	// Clean up

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -16,14 +16,6 @@ import (
 	ctestutils "github.com/hashicorp/nomad/client/testutil"
 )
 
-func generateString(length int) string {
-	var newString string
-	for i := 0; i < length; i++ {
-		newString = newString + "x"
-	}
-	return string(newString)
-}
-
 // The fingerprinter test should always pass, even if QEMU is not installed.
 func TestQemuDriver_Fingerprint(t *testing.T) {
 	if !testutil.IsTravis() {
@@ -309,13 +301,13 @@ func TestQemuDriverUser(t *testing.T) {
 }
 
 func TestQemuDriverGetMonitorPath(t *testing.T) {
-	shortPath := generateString(10)
+	shortPath := strings.Repeat("x", 10)
 	_, err := getMonitorPath(shortPath, "0")
 	if err != nil {
 		t.Fatal("Should not have returned an error")
 	}
 
-	longPath := generateString(legacyMaxMonitorPathLen + 100)
+	longPath := strings.Repeat("x", legacyMaxMonitorPathLen+100)
 	_, err = getMonitorPath(longPath, "0")
 	if err == nil {
 		t.Fatal("Should have returned an error")
@@ -325,7 +317,7 @@ func TestQemuDriverGetMonitorPath(t *testing.T) {
 		t.Fatal("Should not have returned an error")
 	}
 
-	maxLengthPath := generateString(legacyMaxMonitorPathLen)
+	maxLengthPath := strings.Repeat("x", legacyMaxMonitorPathLen)
 	_, err = getMonitorPath(maxLengthPath, "0")
 	if err != nil {
 		t.Fatal("Should not have returned an error")

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -179,6 +179,13 @@ func TestQemuDriver_GracefulShutdown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Clean up
+	defer func() {
+		if err := resp.Handle.Kill(); err != nil {
+			logger.Printf("Error killing Qemu test: %s", err)
+		}
+	}()
+
 	// The monitor socket will not exist immediately, so we'll wait up to
 	// 5 seconds for it to become available.
 	monitorPath := fmt.Sprintf("%s/linux/%s", ctx.AllocDir.AllocDir, qemuMonitorSocketName)
@@ -208,13 +215,6 @@ func TestQemuDriver_GracefulShutdown(t *testing.T) {
 	if err := sendQemuShutdown(ctx.DriverCtx.logger, monitorPath, 0); err != nil {
 		t.Fatalf("unexpected error from sendQemuShutdown: %s", err)
 	}
-
-	// Clean up
-	defer func() {
-		if err := resp.Handle.Kill(); err != nil {
-			logger.Printf("Error killing Qemu test: %s", err)
-		}
-	}()
 }
 
 func TestQemuDriverUser(t *testing.T) {

--- a/website/source/docs/drivers/qemu.html.md
+++ b/website/source/docs/drivers/qemu.html.md
@@ -29,9 +29,10 @@ task "webservice" {
   driver = "qemu"
 
   config {
-    image_path  = "/path/to/my/linux.img"
-    accelerator = "kvm"
-    args        = ["-nodefaults", "-nodefconfig"]
+    image_path        = "/path/to/my/linux.img"
+    accelerator       = "kvm"
+    graceful_shutdown = true
+    args              = ["-nodefaults", "-nodefconfig"]
   }
 }  
 ```
@@ -46,6 +47,8 @@ The `qemu` driver supports the following configuration in the job spec:
 * `accelerator` - (Optional) The type of accelerator to use in the invocation.
   If the host machine has `qemu` installed with KVM support, users can specify
   `kvm` for the `accelerator`. Default is `tcg`.
+
+* `graceful_shutdown` `(bool: false)` - Using the [qemu monitor](https://en.wikibooks.org/wiki/QEMU/Monitor), send an ACPI shutdown signal to virtual machines rather than simply terminating them. This emulates a physical power button press, and gives instances a chance to shut down cleanly. If the VM is still running after ``kill_timeout``, it will be forcefully terminated. (Note that [prior to qemu 2.10.1](https://github.com/qemu/qemu/commit/ad9579aaa16d5b385922d49edac2c96c79bcfb6), the monitor socket path is limited to 108 characters. Graceful shutdown will be disabled if qemu is < 2.10.1 and the generated monitor path exceeds this length. You may encounter this issue if you set long [data_dir](https://www.nomadproject.io/docs/agent/configuration/index.html#data_dir) or [alloc_dir](https://www.nomadproject.io/docs/agent/configuration/client.html#alloc_dir) paths.)
 
 * `port_map` - (Optional) A key-value map of port labels.
 

--- a/website/source/docs/drivers/qemu.html.md
+++ b/website/source/docs/drivers/qemu.html.md
@@ -48,7 +48,20 @@ The `qemu` driver supports the following configuration in the job spec:
   If the host machine has `qemu` installed with KVM support, users can specify
   `kvm` for the `accelerator`. Default is `tcg`.
 
-* `graceful_shutdown` `(bool: false)` - Using the [qemu monitor](https://en.wikibooks.org/wiki/QEMU/Monitor), send an ACPI shutdown signal to virtual machines rather than simply terminating them. This emulates a physical power button press, and gives instances a chance to shut down cleanly. If the VM is still running after ``kill_timeout``, it will be forcefully terminated. (Note that [prior to qemu 2.10.1](https://github.com/qemu/qemu/commit/ad9579aaa16d5b385922d49edac2c96c79bcfb6), the monitor socket path is limited to 108 characters. Graceful shutdown will be disabled if qemu is < 2.10.1 and the generated monitor path exceeds this length. You may encounter this issue if you set long [data_dir](https://www.nomadproject.io/docs/agent/configuration/index.html#data_dir) or [alloc_dir](https://www.nomadproject.io/docs/agent/configuration/client.html#alloc_dir) paths.)
+* `graceful_shutdown` `(bool: false)` - Using the [qemu
+  monitor](https://en.wikibooks.org/wiki/QEMU/Monitor), send an ACPI shutdown
+  signal to virtual machines rather than simply terminating them. This emulates
+  a physical power button press, and gives instances a chance to shut down
+  cleanly. If the VM is still running after ``kill_timeout``, it will be
+  forcefully terminated. (Note that
+  [prior to qemu 2.10.1](https://github.com/qemu/qemu/commit/ad9579aaa16d5b385922d49edac2c96c79bcfb6),
+  the monitor socket path is limited to 108 characters. Graceful shutdown will
+  be disabled if qemu is < 2.10.1 and the generated monitor path exceeds this
+  length. You may encounter this issue if you set long
+  [data_dir](https://www.nomadproject.io/docs/agent/configuration/index.html#data_dir)
+  or
+  [alloc_dir](https://www.nomadproject.io/docs/agent/configuration/client.html#alloc_dir)
+  paths.)
 
 * `port_map` - (Optional) A key-value map of port labels.
 


### PR DESCRIPTION
This PR enables the Qemu driver to attempt a graceful shutdown of guest VMs by passing an ACPI-shutdown via the [Qemu monitor](https://en.wikibooks.org/wiki/QEMU/Monitor).

This is a best-effort mechanism for notifying guests of their impending termination. The driver will still forcibly terminate the process if the kill timeout expires.

I think the integration tests can be improved; any suggestions in that area are especially appreciated.

Thank you!