### PR TITLE
Disable fuzzy search

### DIFF
--- a/ui/app/controllers/jobs/job/task-group.js
+++ b/ui/app/controllers/jobs/job/task-group.js
@@ -20,7 +20,7 @@ export default Controller.extend(Sortable, Searchable, {
   sortProperty: 'modifyIndex',
   sortDescending: true,
 
-  searchProps: computed(() => ['id', 'name']),
+  searchProps: computed(() => ['shortId', 'name']),
 
   allocations: computed('model.allocations.[]', function() {
     return this.get('model.allocations') || [];

--- a/ui/app/controllers/nodes/node.js
+++ b/ui/app/controllers/nodes/node.js
@@ -18,7 +18,7 @@ export default Controller.extend(Sortable, Searchable, {
   sortProperty: 'modifyIndex',
   sortDescending: true,
 
-  searchProps: computed(() => ['id', 'name']),
+  searchProps: computed(() => ['shortId', 'name']),
 
   listToSort: computed.alias('model.allocations'),
   listToSearch: computed.alias('listSorted'),

--- a/ui/app/mixins/searchable.js
+++ b/ui/app/mixins/searchable.js
@@ -14,8 +14,7 @@ const { Mixin, computed, get } = Ember;
     - listToSearch: the list of objects to search
 
   Properties provided:
-    - listSearched: a subset of listToSearch of items that meet the search criteria,
-                    ordered by relevance.
+    - listSearched: a subset of listToSearch of items that meet the search criteria
 */
 export default Mixin.create({
   searchTerm: '',
@@ -40,20 +39,16 @@ export default Mixin.create({
   listSearched: computed('fuse', 'searchTerm', function() {
     const { fuse, searchTerm } = this.getProperties('fuse', 'searchTerm');
     if (searchTerm && searchTerm.length) {
-      if (searchTerm.startsWith('/')) {
-        return regexSearch(searchTerm, fuse);
-      }
-      return fuse.search(searchTerm);
+      return regexSearch(searchTerm, fuse);
     }
     return this.get('listToSearch');
   }),
 });
 
 function regexSearch(term, { list, options: { keys } }) {
-  const regexStr = term.slice(1);
-  if (regexStr.length) {
+  if (term.length) {
     try {
-      const regex = new RegExp(regexStr, 'i');
+      const regex = new RegExp(term, 'i');
       // Test the value of each key for each object against the regex
       // All that match are returned.
       return list.filter(item => keys.some(key => regex.test(get(item, key))));

--- a/ui/app/mixins/searchable.js
+++ b/ui/app/mixins/searchable.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import Fuse from 'npm:fuse.js';
 
 const { Mixin, computed, get } = Ember;
 
@@ -21,31 +20,16 @@ export default Mixin.create({
   listToSearch: computed(() => []),
   searchProps: null,
 
-  fuse: computed('listToSearch.[]', 'searchProps.[]', function() {
-    return new Fuse(this.get('listToSearch'), {
-      shouldSort: true,
-      threshold: 0.6,
-      location: 0,
-      distance: 100,
-      maxPatternLength: 32,
-      minMatchCharLength: 1,
-      keys: this.get('searchProps') || [],
-      getFn(item, key) {
-        return get(item, key);
-      },
-    });
-  }),
-
-  listSearched: computed('fuse', 'searchTerm', function() {
-    const { fuse, searchTerm } = this.getProperties('fuse', 'searchTerm');
+  listSearched: computed('searchTerm', 'listToSearch.[]', 'searchProps.[]', function() {
+    const searchTerm = this.get('searchTerm');
     if (searchTerm && searchTerm.length) {
-      return regexSearch(searchTerm, fuse);
+      return regexSearch(searchTerm, this.get('listToSearch'), this.get('searchProps'));
     }
     return this.get('listToSearch');
   }),
 });
 
-function regexSearch(term, { list, options: { keys } }) {
+function regexSearch(term, list, keys) {
   if (term.length) {
     try {
       const regex = new RegExp(term, 'i');

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,10 +20,7 @@
         "prettier --single-quote --trailing-comma es5 --print-width 100 --write",
         "git add"
       ],
-      "ui/app/styles/**/*.*": [
-        "prettier --write",
-        "git add"
-      ]
+      "ui/app/styles/**/*.*": ["prettier --write", "git add"]
     }
   },
   "devDependencies": {
@@ -69,7 +66,6 @@
     "ember-welcome-page": "^3.0.0",
     "eslint": "^4.0.0",
     "flat": "^2.0.1",
-    "fuse.js": "^3.0.5",
     "husky": "^0.13.4",
     "json-formatter-js": "^2.2.0",
     "lint-staged": "^3.6.1",
@@ -81,9 +77,6 @@
   },
   "private": true,
   "ember-addon": {
-    "paths": [
-      "lib/bulma",
-      "lib/calendar"
-    ]
+    "paths": ["lib/bulma", "lib/calendar"]
   }
 }

--- a/ui/tests/unit/mixins/searchable-test.js
+++ b/ui/tests/unit/mixins/searchable-test.js
@@ -24,18 +24,6 @@ test('the searchable mixin does nothing when there is no search term', function(
   assert.deepEqual(subject.get('listSearched'), subject.get('source'));
 });
 
-test('the searchable mixin allows for fuzzy match search', function(assert) {
-  const subject = this.subject();
-  subject.set('source', [{ id: '1', name: 'hello' }, { id: '2', name: 'world' }]);
-
-  subject.set('searchTerm', 'helo');
-  assert.deepEqual(
-    subject.get('listSearched'),
-    [{ id: '1', name: 'hello' }],
-    'hello matched for the term helo'
-  );
-});
-
 test('the searchable mixin allows for regex search', function(assert) {
   const subject = this.subject();
   subject.set('source', [
@@ -44,7 +32,7 @@ test('the searchable mixin allows for regex search', function(assert) {
     { id: '3', name: 'oranges' },
   ]);
 
-  subject.set('searchTerm', '/.+l+[A-Z]$');
+  subject.set('searchTerm', '.+l+[A-Z]$');
   assert.deepEqual(
     subject.get('listSearched'),
     [{ id: '1', name: 'hello' }, { id: '2', name: 'world' }],
@@ -60,7 +48,7 @@ test('the searchable mixin only searches the declared search props', function(as
     { id: '3', name: 'Mexico', continent: 'North America' },
   ]);
 
-  subject.set('searchTerm', '/America');
+  subject.set('searchTerm', 'America');
   assert.deepEqual(
     subject.get('listSearched'),
     [{ id: '1', name: 'United States of America', continent: 'North America' }],

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4086,10 +4086,6 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fuse.js@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.0.5.tgz#b58d85878802321de94461654947b93af1086727"
-
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
It doesn't work well for highly precise values, or small datasets, or prefixes.
Which are our three use cases.