### PR TITLE
Expect JobVersion in one of two places

### DIFF
--- a/ui/app/serializers/allocation.js
+++ b/ui/app/serializers/allocation.js
@@ -20,6 +20,8 @@ export default ApplicationSerializer.extend({
       return summary;
     });
 
+    hash.JobVersion = hash.JobVersion != null ? hash.JobVersion : get(hash, 'Job.Version');
+
     // TEMPORARY: https://github.com/emberjs/data/issues/5209
     hash.OriginalJobId = hash.JobID;
 


### PR DESCRIPTION
`/job/:id/allocations` has `JobVersion` as a property while `/allocation/:id` and `/node/:id/allocation` embeds the Job, which has a `Version` property.