### PR TITLE
Add e2e test for testing migrations

### DIFF
--- a/e2e/migrations/Dockerfile
+++ b/e2e/migrations/Dockerfile
@@ -6,18 +6,10 @@ RUN apt-get install -y \
     build-essential \
     git \
     golang \
-    liblxc1 \
-    libpcre3-dev \
-    lxc-dev \
-    lxc-templates \
-    pkg-config
-
-ENV NOMAD_VERSION 0.7.0-beta1
-ENV NOMAD_SHA256 174794d96d2617252875e2e2ff9e496120acc4a97be54965c324b9a5d11b37ab
+    liblxc1
 
 ENV GOPATH=$HOME/gopkg
 ENV PATH=$PATH:$GOPATH/bin:/usr/local/lib
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
 COPY nomad /bin/nomad
 

--- a/e2e/migrations/Dockerfile
+++ b/e2e/migrations/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:17.10
+
+RUN apt-get update -y
+
+RUN apt-get install -y \
+    build-essential \
+    git \
+    golang \
+    liblxc1 \
+    libpcre3-dev \
+    lxc-dev \
+    lxc-templates \
+    pkg-config
+
+ENV NOMAD_VERSION 0.7.0-beta1
+ENV NOMAD_SHA256 174794d96d2617252875e2e2ff9e496120acc4a97be54965c324b9a5d11b37ab
+
+ENV GOPATH=$HOME/gopkg
+ENV PATH=$PATH:$GOPATH/bin:/usr/local/lib
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+COPY nomad /bin/nomad
+
+RUN mkdir -p /nomad/data && \
+    mkdir -p /etc/nomad && \
+    mkdir -p gopkg/src/migrations
+
+RUN go get github.com/stretchr/testify/assert

--- a/e2e/migrations/Dockerfile
+++ b/e2e/migrations/Dockerfile
@@ -15,6 +15,6 @@ COPY nomad /bin/nomad
 
 RUN mkdir -p /nomad/data && \
     mkdir -p /etc/nomad && \
-    mkdir -p gopkg/src/migrations
+    mkdir -p gopkg/src/github.com/nomad
 
 RUN go get github.com/stretchr/testify/assert

--- a/e2e/migrations/README.md
+++ b/e2e/migrations/README.md
@@ -1,0 +1,16 @@
+## End to end tests for migrating data in sticky volumes
+
+These tests run in a docker container to ensure proper setup/teardown.
+
+To create the testing image:
+`./docker-init.sh`
+
+To run tests:
+`./docker-run.sh`
+
+TODO:
+  1. Specify how many servers/clients in the test
+  2. Have a callback to specify the client options
+  3. Run servers/clients in the docker container, return IP addresses for each
+     instance, but have the test run on the host.
+

--- a/e2e/migrations/README.md
+++ b/e2e/migrations/README.md
@@ -13,4 +13,6 @@ TODO:
   2. Have a callback to specify the client options
   3. Run servers/clients in the docker container, return IP addresses for each
      instance, but have the test run on the host.
+  4. There should be a 1:1 mapping from container to agent, rather than running
+     the entire cluster in a container.
 

--- a/e2e/migrations/client1.hcl
+++ b/e2e/migrations/client1.hcl
@@ -1,0 +1,18 @@
+log_level = "DEBUG"
+
+data_dir = "/tmp/client1"
+
+datacenter = "dc1"
+
+client {
+  enabled = true
+  servers = ["127.0.0.1:4647"]
+  meta {
+    secondary = 1
+  }
+}
+
+ports {
+  http = 5656
+}
+

--- a/e2e/migrations/client2.hcl
+++ b/e2e/migrations/client2.hcl
@@ -1,0 +1,18 @@
+log_level = "DEBUG"
+
+data_dir = "/tmp/client2"
+
+datacenter = "dc1"
+
+client {
+  enabled = true
+  servers = ["127.0.0.1:4647"]
+  meta {
+    secondary = 0
+  }
+}
+
+ports {
+  http = 5657
+}
+

--- a/e2e/migrations/docker-init.sh
+++ b/e2e/migrations/docker-init.sh
@@ -1,0 +1,2 @@
+
+docker build -t nomad-e2e .

--- a/e2e/migrations/docker-run.sh
+++ b/e2e/migrations/docker-run.sh
@@ -1,3 +1,3 @@
-CURRENT_DIRECTORY=` pwd`
+CURRENT_DIRECTORY=`pwd`
 
 docker run --privileged -v $CURRENT_DIRECTORY:/gopkg/src/migrations -it nomad-e2e /bin/bash -c "cd gopkg/src/migrations && go test"

--- a/e2e/migrations/docker-run.sh
+++ b/e2e/migrations/docker-run.sh
@@ -1,0 +1,3 @@
+CURRENT_DIRECTORY=` pwd`
+
+docker run --privileged -v $CURRENT_DIRECTORY:/gopkg/src/migrations -it nomad-e2e /bin/bash -c "cd gopkg/src/migrations && go test"

--- a/e2e/migrations/docker-run.sh
+++ b/e2e/migrations/docker-run.sh
@@ -1,6 +1,7 @@
 CURRENT_DIRECTORY=`pwd`
+ROOT_DIRECTORY="$( dirname "$(dirname "$CURRENT_DIRECTORY")")"
 
 docker run --privileged -v \
-$CURRENT_DIRECTORY:/gopkg/src/github.com/hashicorp/nomad \
+$ROOT_DIRECTORY:/gopkg/src/github.com/hashicorp/nomad \
 -it nomad-e2e /bin/bash \
 -c "cd gopkg/src/github.com/hashicorp/nomad/e2e/migrations && go test -integration"

--- a/e2e/migrations/docker-run.sh
+++ b/e2e/migrations/docker-run.sh
@@ -1,3 +1,6 @@
 CURRENT_DIRECTORY=`pwd`
 
-docker run --privileged -v $CURRENT_DIRECTORY:/gopkg/src/github.com/hashicorp/nomad -it nomad-e2e /bin/bash -c "cd gopkg/src/github.com/hashicorp/nomad/e2e/migrations && go test"
+docker run --privileged -v \
+$CURRENT_DIRECTORY:/gopkg/src/github.com/hashicorp/nomad \
+-it nomad-e2e /bin/bash \
+-c "cd gopkg/src/github.com/hashicorp/nomad/e2e/migrations && go test -integration"

--- a/e2e/migrations/docker-run.sh
+++ b/e2e/migrations/docker-run.sh
@@ -1,3 +1,3 @@
 CURRENT_DIRECTORY=`pwd`
 
-docker run --privileged -v $CURRENT_DIRECTORY:/gopkg/src/migrations -it nomad-e2e /bin/bash -c "cd gopkg/src/migrations && go test"
+docker run --privileged -v $CURRENT_DIRECTORY:/gopkg/src/github.com/hashicorp/nomad -it nomad-e2e /bin/bash -c "cd gopkg/src/github.com/hashicorp/nomad/e2e/migrations && go test"

--- a/e2e/migrations/migrations_test.go
+++ b/e2e/migrations/migrations_test.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
-	"strings"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/e2e/migrations/migrations_test.go
+++ b/e2e/migrations/migrations_test.go
@@ -1,0 +1,147 @@
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// requires nomad executable on the path
+func startCluster() (func(), error) {
+	serverCmd := exec.Command("nomad", "agent", "-config", "server.hcl")
+	err := serverCmd.Start()
+	if err != nil {
+		return func() {}, err
+	}
+
+	time.Sleep(10 * time.Second)
+
+	clientCmd := exec.Command("nomad", "agent", "-config", "client1.hcl")
+	err = clientCmd.Start()
+	if err != nil {
+		return func() {}, err
+	}
+
+	time.Sleep(10 * time.Second)
+
+	secondClientCmd := exec.Command("nomad", "agent", "-config", "client2.hcl")
+	err = secondClientCmd.Start()
+	if err != nil {
+		return func() {}, err
+	}
+
+	time.Sleep(10 * time.Second)
+
+	f := func() {
+		clientCmd.Process.Kill()
+		secondClientCmd.Process.Kill()
+		serverCmd.Process.Kill()
+	}
+
+	return f, nil
+}
+
+func TestJobMigrations(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	stopCluster, err := startCluster()
+	assert.Nil(err)
+	defer stopCluster()
+
+	fh, err := ioutil.TempFile("", "nomad-sleep-1")
+	assert.Nil(err)
+
+	defer os.Remove(fh.Name())
+	_, err = fh.WriteString(`
+	job "sleep" {
+		type = "batch"
+		datacenters = ["dc1"]
+		constraint {
+			attribute = "${meta.secondary}"
+			value     = 1
+		}
+		group "group1" {
+			restart {
+				mode = "fail"
+			}
+			count = 1
+			ephemeral_disk {
+				migrate = true
+				sticky = true
+			}
+			task "sleep" {
+				template {
+					data = "hello world"
+					destination = "/local/hello-world"
+				}
+				driver = "exec"
+				config {
+					command = "/bin/sleep"
+					args = [ "infinity" ]
+				}
+			}
+		}
+	}`)
+
+	jobCmd := exec.Command("nomad", "run", fh.Name())
+	err = jobCmd.Run()
+	assert.Nil(err)
+
+	time.Sleep(20 * time.Second)
+
+	fh2, err := ioutil.TempFile("", "nomad-sleep-2")
+	assert.Nil(err)
+
+	defer os.Remove(fh2.Name())
+	_, err = fh2.WriteString(`
+	job "sleep" {
+		type = "batch"
+		datacenters = ["dc1"]
+		constraint {
+			attribute = "${meta.secondary}"
+			value     = 1
+		}
+		group "group1" {
+			restart {
+				mode     = "fail"
+			}
+			count = 1
+			ephemeral_disk {
+				migrate = true
+				sticky = true
+			}
+			task "sleep" {
+				driver = "exec"
+
+				config {
+					command = "test"
+					args = [ "-f", "/local/hello-world" ]
+				}
+			}
+		}
+	}`)
+
+	secondJobCmd := exec.Command("nomad", "run", fh2.Name())
+	err = secondJobCmd.Run()
+	assert.Nil(err)
+
+	time.Sleep(20 * time.Second)
+
+	jobStatusCmd := exec.Command("nomad", "job", "status", "sleep")
+	var jobStatusOut bytes.Buffer
+	jobStatusCmd.Stdout = &jobStatusOut
+
+	err = jobStatusCmd.Run()
+	assert.Nil(err)
+
+	jobOutput := jobStatusOut.String()
+	assert.NotContains(jobOutput, "failed")
+	assert.Contains(jobOutput, "complete")
+}

--- a/e2e/migrations/migrations_test.go
+++ b/e2e/migrations/migrations_test.go
@@ -72,6 +72,11 @@ const sleepJobTwo = `job "sleep" {
 	}
 }`
 
+// isSuccess waits until a given keyword is not present in the output of a
+// command. For example, isSuccess will poll for a given timeperiod as long as
+// the output of the command of "nomad node-status" includes the keyword
+// "initializing." The absence of this keyword means this command has returned
+// successfully.
 func isSuccess(execCmd *exec.Cmd, retries int, keyword string) (string, error) {
 	var successOut string
 	var err error
@@ -189,5 +194,6 @@ func TestJobMigrations(t *testing.T) {
 	jobOutput, err := jobIsReady(20, "sleep")
 	assert.Nil(err)
 	assert.NotContains(jobOutput, "failed")
+	assert.NotContains(jobOutput, "pending")
 	assert.Contains(jobOutput, "complete")
 }

--- a/e2e/migrations/migrations_test.go
+++ b/e2e/migrations/migrations_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"bytes"
+	"flag"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -11,6 +12,8 @@ import (
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
 )
+
+var integration = flag.Bool("integration", false, "run integration tests")
 
 const sleepJobOne = `job "sleep" {
 	type = "batch"
@@ -139,6 +142,11 @@ func startCluster(clusterConfig []string) (func(), error) {
 }
 
 func TestJobMigrations(t *testing.T) {
+	flag.Parse()
+	if !*integration {
+		t.Skip("skipping test in non-integration mode.")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/e2e/migrations/migrations_test.go
+++ b/e2e/migrations/migrations_test.go
@@ -175,9 +175,10 @@ func TestJobMigrations(t *testing.T) {
 	err = jobCmd.Run()
 	assert.Nil(err)
 
-	firstJoboutput, err := jobIsReady(20, "sleep")
+	firstJobOutput, err := jobIsReady(20, "sleep")
 	assert.Nil(err)
-	assert.NotContains(firstJoboutput, "failed")
+	assert.NotContains(firstJobOutput, "failed")
+	assert.NotContains(firstJobOutput, "pending")
 
 	fh2, err := ioutil.TempFile("", "nomad-sleep-2")
 	assert.Nil(err)

--- a/e2e/migrations/server.hcl
+++ b/e2e/migrations/server.hcl
@@ -1,0 +1,10 @@
+log_level = "DEBUG"
+
+data_dir = "/tmp/server1"
+
+server {
+  enabled = true
+
+  bootstrap_expect = 1
+}
+


### PR DESCRIPTION
This runs in a docker container, which allows for a clean post-test environment (no leftover temporary files or processes). 

I will add an E2E tests for migrations with ACLs in a different PR. 