### PR TITLE
Differentiate empty and forbidden states on list pages

### DIFF
--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -24,10 +24,9 @@ export default RESTAdapter.extend({
     return this._super(...arguments).catch(error => {
       const errorCodes = codesForError(error);
 
-      const isNotAuthorized = errorCodes.includes('403');
       const isNotImplemented = errorCodes.includes('501');
 
-      if (isNotAuthorized || isNotImplemented) {
+      if (isNotImplemented) {
         return [];
       }
 

--- a/ui/app/controllers/jobs.js
+++ b/ui/app/controllers/jobs.js
@@ -9,6 +9,8 @@ export default Controller.extend({
     jobNamespace: 'namespace',
   },
 
+  isForbidden: false,
+
   jobNamespace: 'default',
 
   // The namespace query param should act as an alias to the system active namespace.

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -6,6 +6,9 @@ const { Controller, computed, inject } = Ember;
 
 export default Controller.extend(Sortable, Searchable, {
   system: inject.service(),
+  jobsController: inject.controller('jobs'),
+
+  isForbidden: computed.alias('jobsController.isForbidden'),
 
   pendingJobs: computed.filterBy('model', 'status', 'pending'),
   runningJobs: computed.filterBy('model', 'status', 'running'),

--- a/ui/app/controllers/nodes.js
+++ b/ui/app/controllers/nodes.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Controller } = Ember;
+
+export default Controller.extend({
+  isForbidden: false,
+});

--- a/ui/app/controllers/nodes/index.js
+++ b/ui/app/controllers/nodes/index.js
@@ -2,9 +2,11 @@ import Ember from 'ember';
 import Sortable from 'nomad-ui/mixins/sortable';
 import Searchable from 'nomad-ui/mixins/searchable';
 
-const { Controller, computed } = Ember;
+const { Controller, computed, inject } = Ember;
 
 export default Controller.extend(Sortable, Searchable, {
+  nodesController: inject.controller('nodes'),
+
   nodes: computed.alias('model.nodes'),
   agents: computed.alias('model.agents'),
 
@@ -26,6 +28,8 @@ export default Controller.extend(Sortable, Searchable, {
   listToSort: computed.alias('nodes'),
   listToSearch: computed.alias('listSorted'),
   sortedNodes: computed.alias('listSearched'),
+
+  isForbidden: computed.alias('nodesController.isForbidden'),
 
   actions: {
     gotoNode(node) {

--- a/ui/app/controllers/servers.js
+++ b/ui/app/controllers/servers.js
@@ -19,6 +19,8 @@ export default Controller.extend(Sortable, {
   sortProperty: 'isLeader',
   sortDescending: true,
 
+  isForbidden: false,
+
   listToSort: computed.alias('agents'),
   sortedAgents: computed.alias('listSorted'),
 });

--- a/ui/app/controllers/servers/index.js
+++ b/ui/app/controllers/servers/index.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+const { Controller, computed, inject } = Ember;
+
+export default Controller.extend({
+  serversController: inject.controller('servers'),
+  isForbidden: computed.alias('serversController.isForbidden'),
+});

--- a/ui/app/mixins/with-forbidden-state.js
+++ b/ui/app/mixins/with-forbidden-state.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+const { Mixin } = Ember;
+
+export default Mixin.create({
+  setupController(controller) {
+    if (this.get('isForbidden')) {
+      this.set('isForbidden', undefined);
+      controller.set('isForbidden', true);
+    }
+    this._super(...arguments);
+  },
+
+  resetController(controller) {
+    controller.set('isForbidden', false);
+    this._super(...arguments);
+  },
+});

--- a/ui/app/routes/jobs.js
+++ b/ui/app/routes/jobs.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
+import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 
 const { Route, inject, run } = Ember;
 
-export default Route.extend({
+export default Route.extend(WithForbiddenState, {
   system: inject.service(),
   store: inject.service(),
 
@@ -11,7 +13,9 @@ export default Route.extend({
   },
 
   model() {
-    return this.get('store').findAll('job');
+    return this.get('store')
+      .findAll('job')
+      .catch(notifyForbidden(this));
   },
 
   syncToController(controller) {

--- a/ui/app/routes/nodes.js
+++ b/ui/app/routes/nodes.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
+import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 
 const { Route, inject, RSVP } = Ember;
 
-export default Route.extend({
+export default Route.extend(WithForbiddenState, {
   store: inject.service(),
   system: inject.service(),
 
@@ -14,6 +16,6 @@ export default Route.extend({
     return RSVP.hash({
       nodes: this.get('store').findAll('node'),
       agents: this.get('store').findAll('agent'),
-    });
+    }).catch(notifyForbidden(this));
   },
 });

--- a/ui/app/routes/servers.js
+++ b/ui/app/routes/servers.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
+import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 
 const { Route, inject, RSVP } = Ember;
 
-export default Route.extend({
+export default Route.extend(WithForbiddenState, {
   store: inject.service(),
   system: inject.service(),
 
@@ -14,6 +16,6 @@ export default Route.extend({
     return RSVP.hash({
       nodes: this.get('store').findAll('node'),
       agents: this.get('store').findAll('agent'),
-    });
+    }).catch(notifyForbidden(this));
   },
 });

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -3,54 +3,58 @@
 {{/global-header}}
 {{#gutter-menu class="page-body" onNamespaceChange=(action "refresh")}}
   <section class="section">
-    {{#if filteredJobs.length}}
-      <div class="content">
-        <div>{{search-box searchTerm=(mut searchTerm) placeholder="Search jobs..."}}</div>
-      </div>
-    {{/if}}
-    {{#list-pagination
-      source=sortedJobs
-      size=pageSize
-      page=currentPage as |p|}}
-      {{#list-table
-        source=p.list
-        sortProperty=sortProperty
-        sortDescending=sortDescending
-        class="with-foot" as |t|}}
-        {{#t.head}}
-          {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
-          {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
-          {{#t.sort-by prop="type"}}Type{{/t.sort-by}}
-          {{#t.sort-by prop="priority"}}Priority{{/t.sort-by}}
-          <th>Groups</th>
-          <th class="is-3">Allocation Status</th>
-        {{/t.head}}
-        {{#t.body key="model.id" as |row|}}
-          {{job-row job=row.model onClick=(action "gotoJob" row.model)}}
-        {{/t.body}}
-      {{/list-table}}
-      <div class="table-foot">
-        <nav class="pagination">
-          <div class="pagination-numbers">
-            {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedJobs.length}}
-          </div>
-          {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
-          {{#p.next class="pagination-next"}} &gt; {{/p.next}}
-          <ul class="pagination-list"></ul>
-        </nav>
-      </div>
+    {{#if isForbidden}}
+      {{partial "partials/forbidden-message"}}
     {{else}}
-      <div class="empty-message">
-        {{#if (eq filteredJobs.length 0)}}
-          <h3 class="empty-message-headline">No Jobs</h3>
-          <p class="empty-message-body">
-            There are currently no visible jobs in the cluster. It could be that the cluster is empty. It could also mean {{#link-to "settings.tokens"}}you don't have access to see any jobs{{/link-to}}.
-          </p>
-        {{else if searchTerm}}
-          <h3 class="empty-message-headline">No Matches</h3>
-          <p class="empty-message-body">No jobs match the term <strong>{{searchTerm}}</strong></p>
-        {{/if}}
-      </div>
-    {{/list-pagination}}
+      {{#if filteredJobs.length}}
+        <div class="content">
+          <div>{{search-box searchTerm=(mut searchTerm) placeholder="Search jobs..."}}</div>
+        </div>
+      {{/if}}
+      {{#list-pagination
+        source=sortedJobs
+        size=pageSize
+        page=currentPage as |p|}}
+        {{#list-table
+          source=p.list
+          sortProperty=sortProperty
+          sortDescending=sortDescending
+          class="with-foot" as |t|}}
+          {{#t.head}}
+            {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
+            {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
+            {{#t.sort-by prop="type"}}Type{{/t.sort-by}}
+            {{#t.sort-by prop="priority"}}Priority{{/t.sort-by}}
+            <th>Groups</th>
+            <th class="is-3">Allocation Status</th>
+          {{/t.head}}
+          {{#t.body key="model.id" as |row|}}
+            {{job-row job=row.model onClick=(action "gotoJob" row.model)}}
+          {{/t.body}}
+        {{/list-table}}
+        <div class="table-foot">
+          <nav class="pagination">
+            <div class="pagination-numbers">
+              {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedJobs.length}}
+            </div>
+            {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
+            {{#p.next class="pagination-next"}} &gt; {{/p.next}}
+            <ul class="pagination-list"></ul>
+          </nav>
+        </div>
+      {{else}}
+        <div class="empty-message">
+          {{#if (eq filteredJobs.length 0)}}
+            <h3 class="empty-message-headline">No Jobs</h3>
+            <p class="empty-message-body">
+              There are currently no visible jobs in the cluster. It could be that the cluster is empty. It could also mean {{#link-to "settings.tokens"}}you don't have access to see any jobs{{/link-to}}.
+            </p>
+          {{else if searchTerm}}
+            <h3 class="empty-message-headline">No Matches</h3>
+            <p class="empty-message-body">No jobs match the term <strong>{{searchTerm}}</strong></p>
+          {{/if}}
+        </div>
+      {{/list-pagination}}
+    {{/if}}
   </section>
 {{/gutter-menu}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -47,7 +47,7 @@
           {{#if (eq filteredJobs.length 0)}}
             <h3 class="empty-message-headline">No Jobs</h3>
             <p class="empty-message-body">
-              There are currently no visible jobs in the cluster. It could be that the cluster is empty. It could also mean {{#link-to "settings.tokens"}}you don't have access to see any jobs{{/link-to}}.
+              The cluster is currently empty.
             </p>
           {{else if searchTerm}}
             <h3 class="empty-message-headline">No Matches</h3>

--- a/ui/app/templates/nodes/index.hbs
+++ b/ui/app/templates/nodes/index.hbs
@@ -48,7 +48,7 @@
           {{#if (eq nodes.length 0)}}
             <h3 class="empty-message-headline">No Clients</h3>
             <p class="empty-message-body">
-              There are currently no visible nodes in the cluster. This could mean that the cluster is bootstrapped with no clients. It could also mean {{#link-to "settings.tokens"}}you don't have access to see any clients{{/link-to}}.
+              The cluster currently has no client nodes.
             </p>
           {{else if searchTerm}}
             <h3 class="empty-message-headline">No Matches</h3>

--- a/ui/app/templates/nodes/index.hbs
+++ b/ui/app/templates/nodes/index.hbs
@@ -3,55 +3,59 @@
 {{/global-header}}
 {{#gutter-menu class="page-body"}}
   <section class="section">
-    {{#if nodes.length}}
-      <div class="content">
-        <div>{{search-box searchTerm=(mut searchTerm) placeholder="Search nodes..."}}</div>
-      </div>
-    {{/if}}
-    {{#list-pagination
-      source=sortedNodes
-      size=pageSize
-      page=currentPage as |p|}}
-      {{#list-table
-        source=p.list
-        sortProperty=sortProperty
-        sortDescending=sortDescending
-        class="with-foot" as |t|}}
-        {{#t.head}}
-          {{#t.sort-by prop="id"}}ID{{/t.sort-by}}
-          {{#t.sort-by class="is-200px is-truncatable" prop="name"}}Name{{/t.sort-by}}
-          {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
-          <th>Address</th>
-          <th>Port</th>
-          {{#t.sort-by prop="datacenter"}}Datacenter{{/t.sort-by}}
-          <th># Allocs</th>
-        {{/t.head}}
-        {{#t.body as |row|}}
-          {{client-node-row node=row.model onClick=(action "gotoNode" row.model)}}
-        {{/t.body}}
-      {{/list-table}}
-      <div class="table-foot">
-        <nav class="pagination">
-          <div class="pagination-numbers">
-            {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedNodes.length}}
-          </div>
-          {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
-          {{#p.next class="pagination-next"}} &gt; {{/p.next}}
-          <ul class="pagination-list"></ul>
-        </nav>
-      </div>
+    {{#if isForbidden}}
+      {{partial "partials/forbidden-message"}}
     {{else}}
-      <div class="empty-message">
-        {{#if (eq nodes.length 0)}}
-          <h3 class="empty-message-headline">No Clients</h3>
-          <p class="empty-message-body">
-            There are currently no visible nodes in the cluster. This could mean that the cluster is bootstrapped with no clients. It could also mean {{#link-to "settings.tokens"}}you don't have access to see any clients{{/link-to}}.
-          </p>
-        {{else if searchTerm}}
-          <h3 class="empty-message-headline">No Matches</h3>
-          <p class="empty-message-body">No clients match the term <strong>{{searchTerm}}</strong></p>
-        {{/if}}
-      </div>
+      {{#if nodes.length}}
+        <div class="content">
+          <div>{{search-box searchTerm=(mut searchTerm) placeholder="Search nodes..."}}</div>
+        </div>
+      {{/if}}
+      {{#list-pagination
+        source=sortedNodes
+        size=pageSize
+        page=currentPage as |p|}}
+        {{#list-table
+          source=p.list
+          sortProperty=sortProperty
+          sortDescending=sortDescending
+          class="with-foot" as |t|}}
+          {{#t.head}}
+            {{#t.sort-by prop="id"}}ID{{/t.sort-by}}
+            {{#t.sort-by class="is-200px is-truncatable" prop="name"}}Name{{/t.sort-by}}
+            {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
+            <th>Address</th>
+            <th>Port</th>
+            {{#t.sort-by prop="datacenter"}}Datacenter{{/t.sort-by}}
+            <th># Allocs</th>
+          {{/t.head}}
+          {{#t.body as |row|}}
+            {{client-node-row node=row.model onClick=(action "gotoNode" row.model)}}
+          {{/t.body}}
+        {{/list-table}}
+        <div class="table-foot">
+          <nav class="pagination">
+            <div class="pagination-numbers">
+              {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedNodes.length}}
+            </div>
+            {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
+            {{#p.next class="pagination-next"}} &gt; {{/p.next}}
+            <ul class="pagination-list"></ul>
+          </nav>
+        </div>
+      {{else}}
+        <div class="empty-message">
+          {{#if (eq nodes.length 0)}}
+            <h3 class="empty-message-headline">No Clients</h3>
+            <p class="empty-message-body">
+              There are currently no visible nodes in the cluster. This could mean that the cluster is bootstrapped with no clients. It could also mean {{#link-to "settings.tokens"}}you don't have access to see any clients{{/link-to}}.
+            </p>
+          {{else if searchTerm}}
+            <h3 class="empty-message-headline">No Matches</h3>
+            <p class="empty-message-body">No clients match the term <strong>{{searchTerm}}</strong></p>
+          {{/if}}
+        </div>
     {{/list-pagination}}
+    {{/if}}
   </section>
 {{/gutter-menu}}

--- a/ui/app/templates/partials/forbidden-message.hbs
+++ b/ui/app/templates/partials/forbidden-message.hbs
@@ -1,0 +1,10 @@
+<div class="empty-message">
+  <h3 class="empty-message-headline">Not Authorized</h3>
+  <p class="empty-message-body">
+    {{#if token.secret}}
+      Your {{#link-to "settings.tokens"}}ACL token{{/link-to}} does not provide the required permissions. Contact your administrator if this is an error.
+    {{else}}
+      Provide an {{#link-to "settings.tokens"}}ACL token{{/link-to}} with requisite permissions to view this.
+    {{/if}}
+  </p>
+</div>

--- a/ui/app/templates/servers.hbs
+++ b/ui/app/templates/servers.hbs
@@ -4,50 +4,54 @@
   {{/global-header}}
   {{#gutter-menu class="page-body"}}
     <section class="section">
-      {{#list-pagination
-        source=sortedAgents
-        size=pageSize
-        page=currentPage as |p|}}
-        {{#list-table
-          source=p.list
-          sortProperty=sortProperty
-          sortDescending=sortDescending
-          class="with-foot" as |t|}}
-          {{#t.head}}
-            {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
-            {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
-            {{#t.sort-by prop="isLeader"}}Leader{{/t.sort-by}}
-            {{#t.sort-by prop="address"}}Address{{/t.sort-by}}
-            {{#t.sort-by prop="serfPort"}}port{{/t.sort-by}}
-            {{#t.sort-by prop="datacenter"}}Datacenter{{/t.sort-by}}
-          {{/t.head}}
-          {{#t.body as |row|}}
-            {{server-agent-row agent=row.model}}
-          {{/t.body}}
-        {{/list-table}}
-        <div class="table-foot">
-          <nav class="pagination">
-            <div class="pagination-numbers">
-              {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedAgents.length}}
-            </div>
-            {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
-            {{#p.next class="pagination-next"}} &gt; {{/p.next}}
-            <ul class="pagination-list"></ul>
-          </nav>
-        </div>
+      {{#if isForbidden}}
+        {{partial "partials/forbidden-message"}}
       {{else}}
-        <div class="empty-message">
-          <h3 class="empty-message-headline">Invalid Permissions</h3>
-          <p class="empty-message-body">
-            {{#if token.secret}}
-              Your ACL token does not grant access to see servers.
-            {{else}}
-              You have no ACL token set. {{#link-to "settings.tokens"}}Provide a token{{/link-to}} with the appropriate permissions to see servers.
-            {{/if}}
-          </p>
-        </div>
-      {{/list-pagination}}
-      {{outlet}}
+        {{#list-pagination
+          source=sortedAgents
+          size=pageSize
+          page=currentPage as |p|}}
+          {{#list-table
+            source=p.list
+            sortProperty=sortProperty
+            sortDescending=sortDescending
+            class="with-foot" as |t|}}
+            {{#t.head}}
+              {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
+              {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
+              {{#t.sort-by prop="isLeader"}}Leader{{/t.sort-by}}
+              {{#t.sort-by prop="address"}}Address{{/t.sort-by}}
+              {{#t.sort-by prop="serfPort"}}port{{/t.sort-by}}
+              {{#t.sort-by prop="datacenter"}}Datacenter{{/t.sort-by}}
+            {{/t.head}}
+            {{#t.body as |row|}}
+              {{server-agent-row agent=row.model}}
+            {{/t.body}}
+          {{/list-table}}
+          <div class="table-foot">
+            <nav class="pagination">
+              <div class="pagination-numbers">
+                {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedAgents.length}}
+              </div>
+              {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
+              {{#p.next class="pagination-next"}} &gt; {{/p.next}}
+              <ul class="pagination-list"></ul>
+            </nav>
+          </div>
+        {{else}}
+          <div class="empty-message">
+            <h3 class="empty-message-headline">Invalid Permissions</h3>
+            <p class="empty-message-body">
+              {{#if token.secret}}
+                Your ACL token does not grant access to see servers.
+              {{else}}
+                You have no ACL token set. {{#link-to "settings.tokens"}}Provide a token{{/link-to}} with the appropriate permissions to see servers.
+              {{/if}}
+            </p>
+          </div>
+        {{/list-pagination}}
+        {{outlet}}
+      {{/if}}
     </section>
   {{/gutter-menu}}
 </div>

--- a/ui/app/templates/servers.hbs
+++ b/ui/app/templates/servers.hbs
@@ -38,17 +38,6 @@
               <ul class="pagination-list"></ul>
             </nav>
           </div>
-        {{else}}
-          <div class="empty-message">
-            <h3 class="empty-message-headline">Invalid Permissions</h3>
-            <p class="empty-message-body">
-              {{#if token.secret}}
-                Your ACL token does not grant access to see servers.
-              {{else}}
-                You have no ACL token set. {{#link-to "settings.tokens"}}Provide a token{{/link-to}} with the appropriate permissions to see servers.
-              {{/if}}
-            </p>
-          </div>
         {{/list-pagination}}
         {{outlet}}
       {{/if}}

--- a/ui/app/utils/notify-forbidden.js
+++ b/ui/app/utils/notify-forbidden.js
@@ -1,0 +1,12 @@
+// An error handler to provide to a promise catch to set a
+// forbidden flag on the route
+import codesForError from './codes-for-error';
+export default function notifyForbidden(route) {
+  return error => {
+    if (codesForError(error).includes('403')) {
+      route.set('isForbidden', true);
+    } else {
+      throw error;
+    }
+  };
+}

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -139,3 +139,23 @@ test('when the namespace query param is set, only matching jobs are shown and th
     assert.equal(find('.job-row td').textContent, job2.name, 'The correct job is shown');
   });
 });
+
+test('when accessing jobs is forbidden, show a message with a link to the tokens page', function(
+  assert
+) {
+  server.pretender.get('/v1/jobs', () => [403, {}, null]);
+
+  visit('/jobs');
+
+  andThen(() => {
+    assert.equal(find('.empty-message-headline').textContent, 'Not Authorized');
+  });
+
+  andThen(() => {
+    click('.empty-message-body a');
+  });
+
+  andThen(() => {
+    assert.equal(currentURL(), '/settings/tokens');
+  });
+});

--- a/ui/tests/acceptance/nodes-list-test.js
+++ b/ui/tests/acceptance/nodes-list-test.js
@@ -193,27 +193,6 @@ test('each server should link to the server detail page', function(assert) {
   });
 });
 
-test('when the API returns no agents, show an empty message', function(assert) {
-  minimumSetup();
-
-  // Override the members handler to act as if server-side permissions
-  // are preventing a qualified response.
-  server.pretender.get('/v1/agent/members', () => [
-    200,
-    {},
-    JSON.stringify({
-      Members: [],
-    }),
-  ]);
-
-  visit('/servers');
-
-  andThen(() => {
-    assert.ok(find('.empty-message'));
-    assert.equal(find('.empty-message-headline').textContent, 'Invalid Permissions');
-  });
-});
-
 test('when accessing servers is forbidden, show a message with a link to the tokens page', function(
   assert
 ) {

--- a/ui/tests/acceptance/nodes-list-test.js
+++ b/ui/tests/acceptance/nodes-list-test.js
@@ -104,6 +104,28 @@ test('when there are clients, but no matches for a search term, there is an empt
   });
 });
 
+test('when accessing clients is forbidden, show a message with a link to the tokens page', function(
+  assert
+) {
+  server.create('agent');
+  server.create('node', { name: 'node' });
+  server.pretender.get('/v1/nodes', () => [403, {}, null]);
+
+  visit('/nodes');
+
+  andThen(() => {
+    assert.equal(find('.empty-message-headline').textContent, 'Not Authorized');
+  });
+
+  andThen(() => {
+    click('.empty-message-body a');
+  });
+
+  andThen(() => {
+    assert.equal(currentURL(), '/settings/tokens');
+  });
+});
+
 test('/servers should list all servers', function(assert) {
   const agentsCount = 10;
   const pageSize = 8;
@@ -189,5 +211,26 @@ test('when the API returns no agents, show an empty message', function(assert) {
   andThen(() => {
     assert.ok(find('.empty-message'));
     assert.equal(find('.empty-message-headline').textContent, 'Invalid Permissions');
+  });
+});
+
+test('when accessing servers is forbidden, show a message with a link to the tokens page', function(
+  assert
+) {
+  server.create('agent');
+  server.pretender.get('/v1/agent/members', () => [403, {}, null]);
+
+  visit('/servers');
+
+  andThen(() => {
+    assert.equal(find('.empty-message-headline').textContent, 'Not Authorized');
+  });
+
+  andThen(() => {
+    click('.empty-message-body a');
+  });
+
+  andThen(() => {
+    assert.equal(currentURL(), '/settings/tokens');
   });
 });


### PR DESCRIPTION
Most of this diff is template indentation changes.

Forbidden

![image](https://user-images.githubusercontent.com/174740/31972568-324ef08e-b8d6-11e7-8df8-d550383a8253.png)

Empty

![image](https://user-images.githubusercontent.com/174740/31972597-4cf88832-b8d6-11e7-8365-c778743af2d8.png)
