### PR TITLE
Fix GC'd alloc tracking

### DIFF
--- a/client/alloc_runner.go
+++ b/client/alloc_runner.go
@@ -921,7 +921,6 @@ func (r *AllocRunner) handleDestroy() {
 	// Final state sync. We do this to ensure that the server has the correct
 	// state as we wait for a destroy.
 	alloc := r.Alloc()
-	r.updater(alloc)
 
 	// Broadcast and persist state synchronously
 	r.sendBroadcast(alloc)
@@ -935,6 +934,11 @@ func (r *AllocRunner) handleDestroy() {
 	if err := r.allocDir.UnmountAll(); err != nil {
 		r.logger.Printf("[ERR] client: alloc %q unable unmount task directories: %v", r.allocID, err)
 	}
+
+	// Update the server with the alloc's status -- also marks the alloc as
+	// being eligible for GC, so from this point on the alloc can be gc'd
+	// at any time.
+	r.updater(alloc)
 
 	for {
 		select {

--- a/client/client.go
+++ b/client/client.go
@@ -124,7 +124,8 @@ type Client struct {
 	// successfully
 	serversDiscoveredCh chan struct{}
 
-	// allocs is the current set of allocations
+	// allocs maps alloc IDs to their AllocRunner. This map includes all
+	// AllocRunners - running and GC'd - until the server GCs them.
 	allocs    map[string]*AllocRunner
 	allocLock sync.RWMutex
 
@@ -487,14 +488,14 @@ func (c *Client) Stats() map[string]map[string]string {
 }
 
 // CollectAllocation garbage collects a single allocation
-func (c *Client) CollectAllocation(allocID string) error {
-	return c.garbageCollector.Collect(allocID)
+func (c *Client) CollectAllocation(allocID string) {
+	c.garbageCollector.Collect(allocID)
 }
 
 // CollectAllAllocs garbage collects all allocations on a node in the terminal
 // state
-func (c *Client) CollectAllAllocs() error {
-	return c.garbageCollector.CollectAll()
+func (c *Client) CollectAllAllocs() {
+	c.garbageCollector.CollectAll()
 }
 
 // Node returns the locally registered node
@@ -721,11 +722,16 @@ func (c *Client) getAllocRunners() map[string]*AllocRunner {
 	return runners
 }
 
-// NumAllocs returns the number of allocs this client has. Used to
+// NumAllocs returns the number of un-GC'd allocs this client has. Used to
 // fulfill the AllocCounter interface for the GC.
 func (c *Client) NumAllocs() int {
+	n := 0
 	c.allocLock.RLock()
-	n := len(c.allocs)
+	for _, a := range c.allocs {
+		if !a.IsDestroyed() {
+			n++
+		}
+	}
 	c.allocLock.RUnlock()
 	return n
 }
@@ -1205,6 +1211,7 @@ func (c *Client) updateNodeStatus() error {
 	for _, s := range resp.Servers {
 		addr, err := resolveServer(s.RPCAdvertiseAddr)
 		if err != nil {
+			c.logger.Printf("[WARN] client: ignoring invalid server %q: %v", s.RPCAdvertiseAddr, err)
 			continue
 		}
 		e := endpoint{name: s.RPCAdvertiseAddr, addr: addr}
@@ -1234,8 +1241,14 @@ func (c *Client) updateNodeStatus() error {
 // updateAllocStatus is used to update the status of an allocation
 func (c *Client) updateAllocStatus(alloc *structs.Allocation) {
 	if alloc.Terminated() {
-		// Terminated, mark for GC
-		if ar, ok := c.getAllocRunners()[alloc.ID]; ok {
+		// Terminated, mark for GC if we're still tracking this alloc
+		// runner. If it's not being tracked that means the server has
+		// already GC'd it (see removeAlloc).
+		c.allocLock.RLock()
+		ar, ok := c.allocs[alloc.ID]
+		c.allocLock.RUnlock()
+
+		if ok {
 			c.garbageCollector.MarkForCollection(ar)
 		}
 	}
@@ -1531,9 +1544,7 @@ func (c *Client) runAllocs(update *allocUpdates) {
 
 	// Remove the old allocations
 	for _, remove := range diff.removed {
-		if err := c.removeAlloc(remove); err != nil {
-			c.logger.Printf("[ERR] client: failed to remove alloc '%s': %v", remove.ID, err)
-		}
+		c.removeAlloc(remove)
 	}
 
 	// Update the existing allocations
@@ -1542,6 +1553,11 @@ func (c *Client) runAllocs(update *allocUpdates) {
 			c.logger.Printf("[ERR] client: failed to update alloc %q: %v",
 				update.exist.ID, err)
 		}
+	}
+
+	// Make room for new allocations before running
+	if err := c.garbageCollector.MakeRoomFor(diff.added); err != nil {
+		c.logger.Printf("[ERR] client: error making room for new allocations: %v", err)
 	}
 
 	// Start the new allocations
@@ -1554,24 +1570,27 @@ func (c *Client) runAllocs(update *allocUpdates) {
 	}
 }
 
-// removeAlloc is invoked when we should remove an allocation
-func (c *Client) removeAlloc(alloc *structs.Allocation) error {
+// removeAlloc is invoked when we should remove an allocation because it has
+// been removed by the server.
+func (c *Client) removeAlloc(alloc *structs.Allocation) {
 	c.allocLock.Lock()
 	ar, ok := c.allocs[alloc.ID]
 	if !ok {
 		c.allocLock.Unlock()
 		c.logger.Printf("[WARN] client: missing context for alloc '%s'", alloc.ID)
-		return nil
+		return
 	}
+
+	// Stop tracking alloc runner as it's been GC'd by the server
 	delete(c.allocs, alloc.ID)
 	c.allocLock.Unlock()
 
 	// Ensure the GC has a reference and then collect. Collecting through the GC
 	// applies rate limiting
 	c.garbageCollector.MarkForCollection(ar)
-	go c.garbageCollector.Collect(alloc.ID)
 
-	return nil
+	// GC immediately since the server has GC'd it
+	go c.garbageCollector.Collect(alloc.ID)
 }
 
 // updateAlloc is invoked when we should update an allocation
@@ -1592,9 +1611,9 @@ func (c *Client) updateAlloc(exist, update *structs.Allocation) error {
 func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error {
 	// Check if we already have an alloc runner
 	c.allocLock.Lock()
+	defer c.allocLock.Unlock()
 	if _, ok := c.allocs[alloc.ID]; ok {
 		c.logger.Printf("[DEBUG]: client: dropping duplicate add allocation request: %q", alloc.ID)
-		c.allocLock.Unlock()
 		return nil
 	}
 
@@ -1616,14 +1635,6 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 
 	if err := ar.SaveState(); err != nil {
 		c.logger.Printf("[WARN] client: initial save state for alloc %q failed: %v", alloc.ID, err)
-	}
-
-	// Must release allocLock as GC acquires it to count allocs
-	c.allocLock.Unlock()
-
-	// Make room for the allocation before running it
-	if err := c.garbageCollector.MakeRoomFor([]*structs.Allocation{alloc}); err != nil {
-		c.logger.Printf("[ERR] client: error making room for allocation: %v", err)
 	}
 
 	go ar.Run()

--- a/client/client.go
+++ b/client/client.go
@@ -1250,6 +1250,10 @@ func (c *Client) updateAllocStatus(alloc *structs.Allocation) {
 
 		if ok {
 			c.garbageCollector.MarkForCollection(ar)
+
+			// Trigger a GC in case we're over thresholds and just
+			// waiting for eligible allocs.
+			c.garbageCollector.Trigger()
 		}
 	}
 
@@ -1568,6 +1572,10 @@ func (c *Client) runAllocs(update *allocUpdates) {
 				add.ID, err)
 		}
 	}
+
+	// Trigger the GC once more now that new allocs are started that could
+	// have caused thesholds to be exceeded
+	c.garbageCollector.Trigger()
 }
 
 // removeAlloc is invoked when we should remove an allocation because it has

--- a/client/client.go
+++ b/client/client.go
@@ -487,9 +487,10 @@ func (c *Client) Stats() map[string]map[string]string {
 	return stats
 }
 
-// CollectAllocation garbage collects a single allocation
-func (c *Client) CollectAllocation(allocID string) {
-	c.garbageCollector.Collect(allocID)
+// CollectAllocation garbage collects a single allocation on a node. Returns
+// true if alloc was found and garbage collected; otherwise false.
+func (c *Client) CollectAllocation(allocID string) bool {
+	return c.garbageCollector.Collect(allocID)
 }
 
 // CollectAllAllocs garbage collects all allocations on a node in the terminal

--- a/client/gc.go
+++ b/client/gc.go
@@ -196,14 +196,16 @@ func (a *AllocGarbageCollector) Stop() {
 	close(a.shutdownCh)
 }
 
-// Collect garbage collects a single allocation on a node
-func (a *AllocGarbageCollector) Collect(allocID string) {
+// Collect garbage collects a single allocation on a node. Returns true if
+// alloc was found and garbage collected; otherwise false.
+func (a *AllocGarbageCollector) Collect(allocID string) bool {
 	if gcAlloc := a.allocRunners.Remove(allocID); gcAlloc != nil {
 		a.destroyAllocRunner(gcAlloc.allocRunner, "forced collection")
-		return
+		return true
 	}
 
 	a.logger.Printf("[DEBUG] client.gc: alloc %s is invalid or was already garbage collected", allocID)
+	return false
 }
 
 // CollectAll garbage collects all termianated allocations on a node

--- a/client/gc.go
+++ b/client/gc.go
@@ -28,8 +28,8 @@ type GCConfig struct {
 	ParallelDestroys    int
 }
 
-// AllocCounter is used by AllocGarbageCollector to discover how many
-// allocations a node has and is generally fulfilled by the Client.
+// AllocCounter is used by AllocGarbageCollector to discover how many un-GC'd
+// allocations a client has and is generally fulfilled by the Client.
 type AllocCounter interface {
 	NumAllocs() int
 }
@@ -95,24 +95,15 @@ func (a *AllocGarbageCollector) keepUsageBelowThreshold() error {
 		}
 
 		// Check if we have enough free space
-		err := a.statsCollector.Collect()
-		if err != nil {
+		if err := a.statsCollector.Collect(); err != nil {
 			return err
 		}
 
 		// See if we are below thresholds for used disk space and inode usage
-		// TODO(diptanu) figure out why this is nil
-		stats := a.statsCollector.Stats()
-		if stats == nil {
-			break
-		}
-
-		diskStats := stats.AllocDirStats
-		if diskStats == nil {
-			break
-		}
-
+		diskStats := a.statsCollector.Stats().AllocDirStats
 		reason := ""
+
+		liveAllocs := a.allocCounter.NumAllocs()
 
 		switch {
 		case diskStats.UsedPercent > a.config.DiskUsageThreshold:
@@ -121,8 +112,8 @@ func (a *AllocGarbageCollector) keepUsageBelowThreshold() error {
 		case diskStats.InodesUsedPercent > a.config.InodeUsageThreshold:
 			reason = fmt.Sprintf("inode usage of %.0f is over gc threshold of %.0f",
 				diskStats.InodesUsedPercent, a.config.InodeUsageThreshold)
-		case a.numAllocs() > a.config.MaxAllocs:
-			reason = fmt.Sprintf("number of allocations is over the limit (%d)", a.config.MaxAllocs)
+		case liveAllocs > a.config.MaxAllocs:
+			reason = fmt.Sprintf("number of allocations (%d) is over the limit (%d)", liveAllocs, a.config.MaxAllocs)
 		}
 
 		// No reason to gc, exit
@@ -178,32 +169,31 @@ func (a *AllocGarbageCollector) Stop() {
 }
 
 // Collect garbage collects a single allocation on a node
-func (a *AllocGarbageCollector) Collect(allocID string) error {
-	gcAlloc, err := a.allocRunners.Remove(allocID)
-	if err != nil {
-		return fmt.Errorf("unable to collect allocation %q: %v", allocID, err)
+func (a *AllocGarbageCollector) Collect(allocID string) {
+	if gcAlloc := a.allocRunners.Remove(allocID); gcAlloc != nil {
+		a.destroyAllocRunner(gcAlloc.allocRunner, "forced collection")
+		return
 	}
-	a.destroyAllocRunner(gcAlloc.allocRunner, "forced collection")
-	return nil
+
+	a.logger.Printf("[DEBUG] client.gc: alloc %s is invalid or was already garbage collected", allocID)
 }
 
 // CollectAll garbage collects all termianated allocations on a node
-func (a *AllocGarbageCollector) CollectAll() error {
+func (a *AllocGarbageCollector) CollectAll() {
 	for {
 		select {
 		case <-a.shutdownCh:
-			return nil
+			return
 		default:
 		}
 
 		gcAlloc := a.allocRunners.Pop()
 		if gcAlloc == nil {
-			break
+			return
 		}
 
-		go a.destroyAllocRunner(gcAlloc.allocRunner, "forced full collection")
+		go a.destroyAllocRunner(gcAlloc.allocRunner, "forced full node collection")
 	}
-	return nil
 }
 
 // MakeRoomFor garbage collects enough number of allocations in the terminal
@@ -211,7 +201,7 @@ func (a *AllocGarbageCollector) CollectAll() error {
 func (a *AllocGarbageCollector) MakeRoomFor(allocations []*structs.Allocation) error {
 	// GC allocs until below the max limit + the new allocations
 	max := a.config.MaxAllocs - len(allocations)
-	for a.numAllocs() > max {
+	for a.allocCounter.NumAllocs() > max {
 		select {
 		case <-a.shutdownCh:
 			return nil
@@ -227,8 +217,9 @@ func (a *AllocGarbageCollector) MakeRoomFor(allocations []*structs.Allocation) e
 		}
 
 		// Destroy the alloc runner and wait until it exits
-		a.destroyAllocRunner(gcAlloc.allocRunner, "new allocations")
+		a.destroyAllocRunner(gcAlloc.allocRunner, fmt.Sprintf("new allocations and over max (%d)", a.config.MaxAllocs))
 	}
+
 	totalResource := &structs.Resources{}
 	for _, alloc := range allocations {
 		if err := totalResource.Add(alloc.Resources); err != nil {
@@ -303,26 +294,9 @@ func (a *AllocGarbageCollector) MarkForCollection(ar *AllocRunner) {
 		return
 	}
 
-	a.logger.Printf("[INFO] client: marking allocation %v for GC", ar.Alloc().ID)
-	a.allocRunners.Push(ar)
-}
-
-// Remove removes an alloc runner without garbage collecting it
-func (a *AllocGarbageCollector) Remove(ar *AllocRunner) {
-	if ar == nil || ar.Alloc() == nil {
-		return
+	if a.allocRunners.Push(ar) {
+		a.logger.Printf("[INFO] client.gc: marking allocation %v for GC", ar.Alloc().ID)
 	}
-
-	alloc := ar.Alloc()
-	if _, err := a.allocRunners.Remove(alloc.ID); err == nil {
-		a.logger.Printf("[INFO] client: removed alloc runner %v from garbage collector", alloc.ID)
-	}
-}
-
-// numAllocs returns the total number of allocs tracked by the client as well
-// as those marked for GC.
-func (a *AllocGarbageCollector) numAllocs() int {
-	return a.allocRunners.Length() + a.allocCounter.NumAllocs()
 }
 
 // GCAlloc wraps an allocation runner and an index enabling it to be used within
@@ -381,15 +355,16 @@ func NewIndexedGCAllocPQ() *IndexedGCAllocPQ {
 	}
 }
 
-// Push an alloc runner into the GC queue
-func (i *IndexedGCAllocPQ) Push(ar *AllocRunner) {
+// Push an alloc runner into the GC queue. Returns true if alloc was added,
+// false if the alloc already existed.
+func (i *IndexedGCAllocPQ) Push(ar *AllocRunner) bool {
 	i.pqLock.Lock()
 	defer i.pqLock.Unlock()
 
 	alloc := ar.Alloc()
 	if _, ok := i.index[alloc.ID]; ok {
 		// No work to do
-		return
+		return false
 	}
 	gcAlloc := &GCAlloc{
 		timeStamp:   time.Now(),
@@ -397,7 +372,7 @@ func (i *IndexedGCAllocPQ) Push(ar *AllocRunner) {
 	}
 	i.index[alloc.ID] = gcAlloc
 	heap.Push(&i.heap, gcAlloc)
-	return
+	return true
 }
 
 func (i *IndexedGCAllocPQ) Pop() *GCAlloc {
@@ -413,17 +388,18 @@ func (i *IndexedGCAllocPQ) Pop() *GCAlloc {
 	return gcAlloc
 }
 
-func (i *IndexedGCAllocPQ) Remove(allocID string) (*GCAlloc, error) {
+// Remove alloc from GC. Returns nil if alloc doesn't exist.
+func (i *IndexedGCAllocPQ) Remove(allocID string) *GCAlloc {
 	i.pqLock.Lock()
 	defer i.pqLock.Unlock()
 
 	if gcAlloc, ok := i.index[allocID]; ok {
 		heap.Remove(&i.heap, gcAlloc.index)
 		delete(i.index, allocID)
-		return gcAlloc, nil
+		return gcAlloc
 	}
 
-	return nil, fmt.Errorf("alloc %q not present", allocID)
+	return nil
 }
 
 func (i *IndexedGCAllocPQ) Length() int {

--- a/client/stats/host.go
+++ b/client/stats/host.go
@@ -190,9 +190,6 @@ func (h *HostStatsCollector) Stats() *HostStats {
 
 // toDiskStats merges UsageStat and PartitionStat to create a DiskStat
 func (h *HostStatsCollector) toDiskStats(usage *disk.UsageStat, partitionStat *disk.PartitionStat) *DiskStats {
-	if usage == nil {
-		return nil
-	}
 	ds := DiskStats{
 		Size:              usage.Total,
 		Used:              usage.Used,

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -115,7 +115,8 @@ func (s *HTTPServer) ClientGCRequest(resp http.ResponseWriter, req *http.Request
 		return nil, structs.ErrPermissionDenied
 	}
 
-	return nil, s.agent.Client().CollectAllAllocs()
+	s.agent.Client().CollectAllAllocs()
+	return nil, nil
 }
 
 func (s *HTTPServer) allocGC(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -131,7 +132,9 @@ func (s *HTTPServer) allocGC(allocID string, resp http.ResponseWriter, req *http
 	} else if aclObj != nil && !aclObj.AllowNsOp(namespace, acl.NamespaceCapabilitySubmitJob) {
 		return nil, structs.ErrPermissionDenied
 	}
-	return nil, s.agent.Client().CollectAllocation(allocID)
+
+	s.agent.Client().CollectAllocation(allocID)
+	return nil, nil
 }
 
 func (s *HTTPServer) allocSnapshot(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -133,7 +133,10 @@ func (s *HTTPServer) allocGC(allocID string, resp http.ResponseWriter, req *http
 		return nil, structs.ErrPermissionDenied
 	}
 
-	s.agent.Client().CollectAllocation(allocID)
+	if !s.agent.Client().CollectAllocation(allocID) {
+		// Could not find alloc
+		return nil, fmt.Errorf("unable to collect allocation: not present")
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
The two important changes:

- The Client.allocs map now contains all AllocRunners again, not just un-GC'd AllocRunners. Client.allocs is only pruned when the server GCs allocs.
- Client.NumAllocs - which is called by the GC to determine if it the node is over the max allocs - properly counts *all* non-GC'd allocs.

Removes error returns from lots of methods that never actually returned errors. Actual GC'ing by the AllocRunner is a best-effort, so there's rarely a meaningful error to return in those call chains.

Testing the GC in a meaningful way is very difficult. A couple of the existing unit tests made incorrect assumptions about how the units they were testing (the GC's max allocs calculation) behaved, and therefore weren't actually testing any realistic behavior. This is what allowed bugs to persist in the face of what would appear to be reasonable test coverage. I replaced a couple of those small unit tests with a a larger integration test (integration in that it spins up a server & client and black box tests the gc).

Also stops logging "marked for GC" twice.