### PR TITLE
Add rpc_upgrade_mode as config option for TLS upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 IMPROVEMENTS:
  * api: Allocations now track and return modify time in addition to create time.
+ * core: Allow agents to be run in `rpc_upgrade_mode` when migrating a cluster
+   to TLS rather than changing `heartbeat_grace`.
 
 BUG FIXES:
-
 
 ## 0.7 (Unreleased)
 

--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -152,6 +152,7 @@ tls {
     ca_file = "foo"
     cert_file = "bar"
     key_file = "pipe"
+    rpc_upgrade_mode = true
     verify_https_client = true
 }
 sentinel {

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -771,6 +771,7 @@ func parseTLSConfig(result **config.TLSConfig, list *ast.ObjectList) error {
 		"http",
 		"rpc",
 		"verify_server_hostname",
+		"rpc_upgrade_mode",
 		"ca_file",
 		"cert_file",
 		"key_file",

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -172,6 +172,7 @@ func TestConfig_Parse(t *testing.T) {
 					CAFile:               "foo",
 					CertFile:             "bar",
 					KeyFile:              "pipe",
+					RPCUpgradeMode:       true,
 					VerifyHTTPSClient:    true,
 				},
 				HTTPAPIResponseHeaders: map[string]string{

--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -100,9 +100,11 @@ func (s *Server) handleConn(conn net.Conn, isTLS bool) {
 
 	// Enforce TLS if EnableRPC is set
 	if s.config.TLSConfig.EnableRPC && !isTLS && RPCType(buf[0]) != rpcTLS {
-		s.logger.Printf("[WARN] nomad.rpc: Non-TLS connection attempted with RequireTLS set")
-		conn.Close()
-		return
+		if !s.config.TLSConfig.RPCUpgradeMode {
+			s.logger.Printf("[WARN] nomad.rpc: Non-TLS connection attempted with RequireTLS set")
+			conn.Close()
+			return
+		}
 	}
 
 	// Switch on the byte

--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -101,7 +101,7 @@ func (s *Server) handleConn(conn net.Conn, isTLS bool) {
 	// Enforce TLS if EnableRPC is set
 	if s.config.TLSConfig.EnableRPC && !isTLS && RPCType(buf[0]) != rpcTLS {
 		if !s.config.TLSConfig.RPCUpgradeMode {
-			s.logger.Printf("[WARN] nomad.rpc: Non-TLS connection attempted with RequireTLS set")
+			s.logger.Printf("[WARN] nomad.rpc: Non-TLS connection attempted from %s with RequireTLS set", conn.RemoteAddr().String())
 			conn.Close()
 			return
 		}

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -3,10 +3,17 @@ package nomad
 import (
 	"net"
 	"net/rpc"
+	"os"
+	"path"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 // rpcClient is a test helper method to return a ClientCodec to use to make rpc
@@ -83,4 +90,85 @@ func TestRPC_forwardRegion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+}
+
+func TestRPC_PlaintextRPCSucceedsWhenInUpgradeMode(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	const (
+		cafile  = "../helper/tlsutil/testdata/ca.pem"
+		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
+		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
+	)
+	dir := tmpDir(t)
+	defer os.RemoveAll(dir)
+
+	s1 := testServer(t, func(c *Config) {
+		c.DataDir = path.Join(dir, "node1")
+		c.TLSConfig = &config.TLSConfig{
+			EnableRPC:            true,
+			VerifyServerHostname: true,
+			CAFile:               cafile,
+			CertFile:             foocert,
+			KeyFile:              fookey,
+			RPCUpgradeMode:       true,
+		}
+	})
+	defer s1.Shutdown()
+
+	codec := rpcClient(t, s1)
+
+	// Create the register request
+	node := mock.Node()
+	req := &structs.NodeRegisterRequest{
+		Node:         node,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "Node.Register", req, &resp)
+	assert.Nil(err)
+
+	// Check that heartbeatTimers has the heartbeat ID
+	_, ok := s1.heartbeatTimers[node.ID]
+	assert.True(ok)
+}
+
+func TestRPC_PlaintextRPCFailsWhenNotInUpgradeMode(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	const (
+		cafile  = "../helper/tlsutil/testdata/ca.pem"
+		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
+		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
+	)
+	dir := tmpDir(t)
+	defer os.RemoveAll(dir)
+
+	s1 := testServer(t, func(c *Config) {
+		c.DataDir = path.Join(dir, "node1")
+		c.TLSConfig = &config.TLSConfig{
+			EnableRPC:            true,
+			VerifyServerHostname: true,
+			CAFile:               cafile,
+			CertFile:             foocert,
+			KeyFile:              fookey,
+		}
+	})
+	defer s1.Shutdown()
+
+	codec := rpcClient(t, s1)
+
+	node := mock.Node()
+	req := &structs.NodeRegisterRequest{
+		Node:         node,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "Node.Register", req, &resp)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "connection reset by peer")
 }

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/net-rpc-msgpackrpc"
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -170,5 +170,4 @@ func TestRPC_PlaintextRPCFailsWhenNotInUpgradeMode(t *testing.T) {
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "Node.Register", req, &resp)
 	assert.NotNil(err)
-	assert.Contains(err.Error(), "connection reset by peer")
 }

--- a/nomad/structs/config/tls.go
+++ b/nomad/structs/config/tls.go
@@ -29,7 +29,7 @@ type TLSConfig struct {
 	// Must be provided to serve TLS connections.
 	KeyFile string `mapstructure:"key_file"`
 
-	// RPCUpgradeMode should be enabled when a cluster ie being upgraded
+	// RPCUpgradeMode should be enabled when a cluster is being upgraded
 	// to TLS. Allows servers to accept both plaintext and TLS connections and
 	// should only be a temporary state.
 	RPCUpgradeMode bool `mapstructure:"rpc_upgrade_mode"`

--- a/nomad/structs/config/tls.go
+++ b/nomad/structs/config/tls.go
@@ -29,6 +29,11 @@ type TLSConfig struct {
 	// Must be provided to serve TLS connections.
 	KeyFile string `mapstructure:"key_file"`
 
+	// RPCUpgradeMode should be enabled when a cluster ie being upgraded
+	// to TLS. Allows servers to accept both plaintext and TLS connections and
+	// should only be a temporary state.
+	RPCUpgradeMode bool `mapstructure:"rpc_upgrade_mode"`
+
 	// Verify connections to the HTTPS API
 	VerifyHTTPSClient bool `mapstructure:"verify_https_client"`
 }

--- a/website/source/docs/agent/configuration/tls.html.md
+++ b/website/source/docs/agent/configuration/tls.html.md
@@ -54,6 +54,10 @@ the [Agent's Gossip and RPC Encryption](/docs/agent/encryption.html).
   a Nomad client makes the client use TLS for making RPC requests to the Nomad
   servers.
 
+- `rpc_upgrade_mode` `(bool: false)` - This option should be used only when the
+  cluster is being upgraded to TLS, and removed after the migration is
+  complete. This allows the agent to accept both TLS and plaintext traffic.
+
 - `verify_https_client` `(bool: false)` - Specifies agents should require
   client certificates for all incoming HTTPS requests. The client certificates
   must be signed by the same CA as Nomad.


### PR DESCRIPTION
Allows for a better operator experience when upgrading to TLS. 

Considerations: 
- Are the tests in rpc_test.go the best possible, or is there another RPC call that would be better for this test case?
- Should documentation be part of this PR or a separate PR? We should update https://www.nomadproject.io/guides/securing-nomad.html#switching-an-existing-cluster-to-tls
