### PR TITLE
Version clarification for /metrics API endpoint

### DIFF
--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -15,7 +15,7 @@ second interval and are retained for one minute.
 This data can be accessed via an HTTP endpoint or via sending a signal to the
 Nomad process.
 
-Via HTTP, this data is available at `/metrics`. See
+Via HTTP, as of Nomad version 0.7, this data is available at `/metrics`. See
 [Metrics](/api/metrics.html) for more information.
 
 


### PR DESCRIPTION
Added clarification to telemetry doc that  API endpoint is available only as of version 0.7 of Nomad. 

Users encountered "404" error when trying to use this endpoint on earlier versions. 

