### PR TITLE
docker: log that a container has been killed by the OOM killer

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1613,7 +1613,7 @@ func (h *DockerHandle) run() {
 	if ierr != nil {
 		h.logger.Printf("[ERR] driver.docker: failed to inspect container %s: %v", h.containerID, ierr)
 	} else if container.State.OOMKilled {
-		werr = fmt.Errorf("Docker container killed by OOM killer")
+		werr = fmt.Errorf("OOM Killed")
 	}
 
 	close(h.doneCh)

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1609,6 +1609,13 @@ func (h *DockerHandle) run() {
 		werr = fmt.Errorf("Docker container exited with non-zero exit code: %d", exitCode)
 	}
 
+	container, ierr := h.waitClient.InspectContainer(h.containerID)
+	if ierr != nil {
+		h.logger.Printf("[ERR] driver.docker: failed to inspect container %s: %v", h.containerID, ierr)
+	} else if container.State.OOMKilled {
+		werr = fmt.Errorf("Docker container killed by OOM killer")
+	}
+
 	close(h.doneCh)
 
 	// Shutdown the syslog collector

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1793,7 +1793,7 @@ func TestDockerDriver_OOMKilled(t *testing.T) {
 			t.Fatalf("expected error, but container exited successfull")
 		}
 
-		if !strings.Contains(res.Err.Error(), "killed by OOM killer") {
+		if res.Err.Error() != "OOM Killed" {
 			t.Fatalf("not killed by OOM killer: %s", res.Err)
 		}
 


### PR DESCRIPTION
Docker has out of the box support for notification when a container has been killed by the OOM killer.

Fix: #2203 (at least for Docker tasks)