### PR TITLE
Node access is done using locked Node copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ BUG FIXES:
    [GH_-3452]
  * client: Fix lock contention that could cause a node to miss a heartbeat and
    be marked as down [GH-3195]
+ * client: Fix data race that could lead to concurrent map read/writes during
+   hearbeating and fingerprinting [GH-3461]
  * driver/docker: Fix docker user specified syslogging [GH-3184]
  * driver/docker: Fix issue where CPU usage statistics were artificially high
    [GH-3229]

--- a/client/client.go
+++ b/client/client.go
@@ -501,7 +501,7 @@ func (c *Client) CollectAllAllocs() error {
 func (c *Client) Node() *structs.Node {
 	c.configLock.RLock()
 	defer c.configLock.RUnlock()
-	return c.config.Node
+	return c.configCopy.Node
 }
 
 // StatsReporter exposes the various APIs related resource usage of a Nomad

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -222,7 +222,7 @@ func TestClient_HasNodeChanged(t *testing.T) {
 	c := testClient(t, nil)
 	defer c.Shutdown()
 
-	node := c.Node()
+	node := c.config.Node
 	attrHash, err := hashstructure.Hash(node.Attributes, nil)
 	if err != nil {
 		c.logger.Printf("[DEBUG] client: unable to calculate node attributes hash: %v", err)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/3454

Reliably reproduced the data race before by having a fingerprinter
change the nodes attributes every millisecond and syncing at the same
rate. With fix, did not ever panic. Further, running before and after with race
detector shows the data race is gone.