### PR TITLE
Publishing metrics for job summary

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -233,6 +233,9 @@ func convertServerConfig(agentConfig *Config, logOutput io.Writer) (*nomad.Confi
 	// Set the TLS config
 	conf.TLSConfig = agentConfig.TLSConfig
 
+	// Setup telemetry related config
+	conf.StatsCollectionInterval = agentConfig.Telemetry.collectionInterval
+
 	return conf, nil
 }
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -235,6 +235,8 @@ func convertServerConfig(agentConfig *Config, logOutput io.Writer) (*nomad.Confi
 
 	// Setup telemetry related config
 	conf.StatsCollectionInterval = agentConfig.Telemetry.collectionInterval
+	conf.DisableTaggedMetrics = agentConfig.Telemetry.DisableTaggedMetrics
+	conf.BackwardsCompatibleMetrics = agentConfig.Telemetry.BackwardsCompatibleMetrics
 
 	return conf, nil
 }

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -245,6 +245,10 @@ type Config struct {
 
 	// SentinelConfig is this Agent's Sentinel configuration
 	SentinelConfig *config.SentinelConfig
+
+	// StatsCollectionInterval is the interval at which the Nomad server
+	// publishes metrics which are periodic in nature like updating gauges
+	StatsCollectionInterval time.Duration
 }
 
 // CheckVersion is used to check if the ProtocolVersion is valid

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -307,6 +307,7 @@ func DefaultConfig() *Config {
 		TLSConfig:                        &config.TLSConfig{},
 		ReplicationBackoff:               30 * time.Second,
 		SentinelGCInterval:               30 * time.Second,
+		StatsCollectionInterval:          1 * time.Minute,
 	}
 
 	// Enable all known schedulers by default

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -249,6 +249,14 @@ type Config struct {
 	// StatsCollectionInterval is the interval at which the Nomad server
 	// publishes metrics which are periodic in nature like updating gauges
 	StatsCollectionInterval time.Duration
+
+	// DisableTaggedMetrics determines whether metrics will be displayed via a
+	// key/value/tag format, or simply a key/value format
+	DisableTaggedMetrics bool
+
+	// BackwardsCompatibleMetrics determines whether to show methods of
+	// displaying metrics for older verions, or to only show the new format
+	BackwardsCompatibleMetrics bool
 }
 
 // CheckVersion is used to check if the ProtocolVersion is valid

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -555,12 +555,38 @@ func (s *Server) publishJobSummaryMetrics(stopCh chan struct{}) {
 				}
 				summary := raw.(*structs.JobSummary)
 				for name, tgSummary := range summary.Summary {
-					metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "queued"}, float32(tgSummary.Queued))
-					metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "complete"}, float32(tgSummary.Complete))
-					metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "failed"}, float32(tgSummary.Failed))
-					metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "running"}, float32(tgSummary.Running))
-					metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "starting"}, float32(tgSummary.Starting))
-					metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "lost"}, float32(tgSummary.Lost))
+					if !s.config.DisableTaggedMetrics {
+						labels := []metrics.Label{
+							{
+								Name:  "job",
+								Value: summary.JobID,
+							},
+							{
+								Name:  "task_group",
+								Value: name,
+							},
+						}
+						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "queued"},
+							float32(tgSummary.Queued), labels)
+						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "complete"},
+							float32(tgSummary.Complete), labels)
+						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "failed"},
+							float32(tgSummary.Failed), labels)
+						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "running"},
+							float32(tgSummary.Running), labels)
+						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "starting"},
+							float32(tgSummary.Starting), labels)
+						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "lost"},
+							float32(tgSummary.Lost), labels)
+					}
+					if s.config.BackwardsCompatibleMetrics {
+						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "queued"}, float32(tgSummary.Queued))
+						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "complete"}, float32(tgSummary.Complete))
+						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "failed"}, float32(tgSummary.Failed))
+						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "running"}, float32(tgSummary.Running))
+						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "starting"}, float32(tgSummary.Starting))
+						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "lost"}, float32(tgSummary.Lost))
+					}
 				}
 			}
 			timer.Reset(s.config.StatsCollectionInterval)


### PR DESCRIPTION
Fixes #3465 

Publishing the job metrics in the leader node since they need to be published only from one of the servers.

Going to add docs, and related things once the implementation looks good to folks.

@dadgar @chelseakomlo 