### PR TITLE
Run test with verbose mode and log to a file

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -236,6 +236,7 @@ test-nomad: dev ## Run Nomad test suites
 	@echo "Exit code: $$(cat exit-code)" >> test.log
 	@grep -A1 -- '--- FAIL:' test.log || true
 	@grep '^FAIL' test.log || true
+	@grep -A10 'panic' test.log || true
 	@test "$$TRAVIS" == "true" && cat test.log || true
 	@if [ "$$(cat exit-code)" == "0" ] ; then echo "PASS" ; exit 0 ; else exit 1 ; fi
 


### PR DESCRIPTION
This makes nomad tests more similar to Consul. With verbose mode you get more detail on failed tests, especially if they also have log statements. All test output is logged to a file and failed tests are highlighted at the end of the run, making it easy to see what failed. 