### PR TITLE
jobs tests were sending invalid jobs

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -238,9 +238,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Driver: "docker",
 								Config: map[string]interface{}{
 									"image": "redis:3.2",
-									"port_map": map[string]int{
+									"port_map": []map[string]int{{
 										"db": 6379,
-									},
+									}},
 								},
 								Resources: &Resources{
 									CPU:      helper.IntToPtr(500),
@@ -347,9 +347,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Driver: "docker",
 								Config: map[string]interface{}{
 									"image": "redis:3.2",
-									"port_map": map[string]int{
+									"port_map": []map[string]int{{
 										"db": 6379,
-									},
+									}},
 								},
 								Resources: &Resources{
 									CPU:      helper.IntToPtr(500),


### PR DESCRIPTION
The only docs for the golang api seem to be the tests, and the tests were generating invalid jobs if you ran them against a real server. Portmap should be an array of maps