### PR TITLE
[3503] adding consul-address flag to command.go

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -134,6 +134,7 @@ func (c *Command) readConfig() *Config {
 		cmdConfig.Consul.VerifySSL = &b
 		return nil
 	}), "consul-verify-ssl", "")
+        flags.StringVar(&cmdConfig.Consul.Addr, "consul-address", "", "")
 
 	// Vault options
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {


### PR DESCRIPTION
the -consul-address flag while documented, was never actually implemented. This fix is not due to regression, but merely a miss on https://github.com/hashicorp/nomad/pull/3327

Closes #3503 
