### PR TITLE
Fix panic on every run of the keyring command.

### DIFF
--- a/command/keyring.go
+++ b/command/keyring.go
@@ -68,7 +68,7 @@ func (c *KeyringCommand) AutocompleteArgs() complete.Predictor {
 }
 
 func (c *KeyringCommand) Run(args []string) int {
-	var installKey, useKey, removeKey, token string
+	var installKey, useKey, removeKey string
 	var listKeys bool
 
 	flags := c.Meta.FlagSet("keys", FlagSetClient)
@@ -78,7 +78,6 @@ func (c *KeyringCommand) Run(args []string) int {
 	flags.StringVar(&useKey, "use", "", "use key")
 	flags.StringVar(&removeKey, "remove", "", "remove key")
 	flags.BoolVar(&listKeys, "list", false, "list keys")
-	flags.StringVar(&token, "token", "", "acl token")
 
 	if err := flags.Parse(args); err != nil {
 		return 1


### PR DESCRIPTION
This change removes the flag token declaration within keyring.go which caused a flag redefined panic on every command run as the token flag is specified in the command meta.

The change has been built and tested locally by running the compiled binary:
```
$ nomad-local agent -dev -encrypt=<REDACTED>
```

The local running instance was then queried using the compiled binary:
```
$ nomad-local keyring  -list
==> Gathering installed encryption keys...
Key
<REDACTED>
```

Running the command without any parameters also now results in the usage being correctly printed to the console:
```
$ nomad keyring
Usage: nomad keyring [options]

  Manages encryption keys used for gossip messages between Nomad servers. Gossip
  encryption is optional. When enabled, this command may be used to examine
  active encryption keys in the cluster, add new keys, and remove old ones. When
  combined, this functionality provides the ability to perform key rotation
  cluster-wide, without disrupting the cluster.

  All operations performed by this command can only be run against server nodes.

  All variations of the keyring command return 0 if all nodes reply and there
  are no errors. If any node fails to reply or reports failure, the exit code
  will be 1.

General Options:
``` 


Coses #3508 