### PR TITLE
`memory` default is 10, not 300

### DIFF
--- a/api/resources.go
+++ b/api/resources.go
@@ -17,7 +17,7 @@ func (r *Resources) Canonicalize() {
 		r.CPU = helper.IntToPtr(100)
 	}
 	if r.MemoryMB == nil {
-		r.MemoryMB = helper.IntToPtr(10)
+		r.MemoryMB = helper.IntToPtr(300)
 	}
 	if r.IOPS == nil {
 		r.IOPS = helper.IntToPtr(0)

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -186,7 +186,7 @@ func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {
 
 	s.CheckRestart.Canonicalize()
 
-	// Canonicalize CheckRestart on Checks and merge Service.CheckRestart
+	// Canonicallize CheckRestart on Checks and merge Service.CheckRestart
 	// into each check.
 	for _, c := range s.Checks {
 		c.CheckRestart.Canonicalize()
@@ -373,8 +373,13 @@ type Task struct {
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
-	min := MinResources()
-	t.Resources.Canonicalize()
+	if t.Resources == nil {
+		var r Resources
+		r.Canonicalize() 
+		t.Resources = &r
+	} else {
+		t.Resources.Canonicalize()
+	}
 
 	if t.KillTimeout == nil {
 		t.KillTimeout = helper.TimeToPtr(5 * time.Second)

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -186,7 +186,7 @@ func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {
 
 	s.CheckRestart.Canonicalize()
 
-	// Canonicallize CheckRestart on Checks and merge Service.CheckRestart
+	// Canonicalize CheckRestart on Checks and merge Service.CheckRestart
 	// into each check.
 	for _, c := range s.Checks {
 		c.CheckRestart.Canonicalize()
@@ -374,9 +374,7 @@ type Task struct {
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
 	min := MinResources()
-	min.Merge(t.Resources)
-	min.Canonicalize()
-	t.Resources = min
+	t.Resources.Canonicalize()
 
 	if t.KillTimeout == nil {
 		t.KillTimeout = helper.TimeToPtr(5 * time.Second)

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -374,13 +374,9 @@ type Task struct {
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
 	if t.Resources == nil {
-		var r Resources
-		r.Canonicalize() 
-		t.Resources = &r
-	} else {
-		t.Resources.Canonicalize()
+		t.Resources = &Resources{}
 	}
-
+	t.Resources.Canonicalize()
 	if t.KillTimeout == nil {
 		t.KillTimeout = helper.TimeToPtr(5 * time.Second)
 	}

--- a/website/source/docs/job-specification/resources.html.md
+++ b/website/source/docs/job-specification/resources.html.md
@@ -49,7 +49,7 @@ job "docs" {
 - `iops` `(int: 0)` - Specifies the number of IOPS required given as a weight
   between 0-1000.
 
-- `memory` `(int: 10)` - Specifies the memory required in MB
+- `memory` `(int: 300)` - Specifies the memory required in MB
 
 - `network` <code>([Network][]: <required>)</code> - Specifies the network
   requirements, including static and dynamic port allocations.

--- a/website/source/docs/job-specification/resources.html.md
+++ b/website/source/docs/job-specification/resources.html.md
@@ -49,7 +49,7 @@ job "docs" {
 - `iops` `(int: 0)` - Specifies the number of IOPS required given as a weight
   between 0-1000.
 
-- `memory` `(int: 300)` - Specifies the memory required in MB
+- `memory` `(int: 10)` - Specifies the memory required in MB
 
 - `network` <code>([Network][]: <required>)</code> - Specifies the network
   requirements, including static and dynamic port allocations.


### PR DESCRIPTION
Verified by creating sample job and removing memory from resources

```
Task "redis" is "running"
Task Resources
CPU        Memory          Disk     IOPS  Addresses
3/100 MHz  976 KiB/10 MiB  300 MiB  0     db: **.**.**.**:20824
```