### PR TITLE
Dropped loglevel for AWS fingerprinter env reads

### DIFF
--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -108,7 +108,7 @@ func (f *EnvAWSFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) 
 	for k, unique := range keys {
 		res, err := client.Get(metadataURL + k)
 		if res.StatusCode != http.StatusOK {
-			f.logger.Printf("[INFO]: fingerprint.env_aws: Could not read value for attribute %q", k)
+			f.logger.Printf("[DEBUG]: fingerprint.env_aws: Could not read value for attribute %q", k)
 			continue
 		}
 		if err != nil {

--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -108,7 +108,7 @@ func (f *EnvAWSFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) 
 	for k, unique := range keys {
 		res, err := client.Get(metadataURL + k)
 		if res.StatusCode != http.StatusOK {
-			f.logger.Printf("[WARN]: fingerprint.env_aws: Could not read value for attribute %q", k)
+			f.logger.Printf("[INFO]: fingerprint.env_aws: Could not read value for attribute %q", k)
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
Certain environments use WARN for serious logging; however, nodes can be created which will lack  some of the fingerprinted keys (public-ipv4 and public-hostname specifically).  Setting log level to INFO seems more consistent with this eventuality.