### PR TITLE
Populate DisplayMessage in various http endpoints 

### DIFF
--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -34,6 +34,9 @@ func (s *HTTPServer) AllocsRequest(resp http.ResponseWriter, req *http.Request) 
 	if out.Allocations == nil {
 		out.Allocations = make([]*structs.AllocListStub, 0)
 	}
+	for _, alloc := range out.Allocations {
+		alloc.SetEventDisplayMessages()
+	}
 	return out.Allocations, nil
 }
 
@@ -70,6 +73,7 @@ func (s *HTTPServer) AllocSpecificRequest(resp http.ResponseWriter, req *http.Re
 		alloc = alloc.Copy()
 		alloc.Job.Payload = decoded
 	}
+	alloc.SetEventDisplayMessages()
 
 	return alloc, nil
 }

--- a/command/agent/deployment_endpoint.go
+++ b/command/agent/deployment_endpoint.go
@@ -166,6 +166,9 @@ func (s *HTTPServer) deploymentAllocations(resp http.ResponseWriter, req *http.R
 	if out.Allocations == nil {
 		out.Allocations = make([]*structs.AllocListStub, 0)
 	}
+	for _, alloc := range out.Allocations {
+		alloc.SetEventDisplayMessages()
+	}
 	return out.Allocations, nil
 }
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -217,6 +217,9 @@ func (s *HTTPServer) jobAllocations(resp http.ResponseWriter, req *http.Request,
 	if out.Allocations == nil {
 		out.Allocations = make([]*structs.AllocListStub, 0)
 	}
+	for _, alloc := range out.Allocations {
+		alloc.SetEventDisplayMessages()
+	}
 	return out.Allocations, nil
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -646,6 +646,13 @@ func TestHTTP_JobAllocations(t *testing.T) {
 		}
 
 		// Directly manipulate the state
+		expectedDisplayMsg := "test message"
+		testEvent := structs.NewTaskEvent("test event").SetMessage(expectedDisplayMsg)
+		var events []*structs.TaskEvent
+		events = append(events, testEvent)
+		taskState := &structs.TaskState{Events: events}
+		alloc1.TaskStates = make(map[string]*structs.TaskState)
+		alloc1.TaskStates["test"] = taskState
 		state := s.Agent.server.State()
 		err := state.UpsertAllocs(1000, []*structs.Allocation{alloc1})
 		if err != nil {
@@ -670,6 +677,8 @@ func TestHTTP_JobAllocations(t *testing.T) {
 		if len(allocs) != 1 && allocs[0].ID != alloc1.ID {
 			t.Fatalf("bad: %v", allocs)
 		}
+		displayMsg := allocs[0].TaskStates["test"].Events[0].DisplayMessage
+		assert.Equal(t, expectedDisplayMsg, displayMsg)
 
 		// Check for the index
 		if respW.HeaderMap.Get("X-Nomad-Index") == "" {

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -89,6 +89,9 @@ func (s *HTTPServer) nodeAllocations(resp http.ResponseWriter, req *http.Request
 	if out.Allocs == nil {
 		out.Allocs = make([]*structs.Allocation, 0)
 	}
+	for _, alloc := range out.Allocs {
+		alloc.SetEventDisplayMessages()
+	}
 	return out.Allocs, nil
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4919,6 +4919,12 @@ func (a *Allocation) ShouldMigrate() bool {
 	return true
 }
 
+// SetEventDisplayMessage populates the display message if its not already set
+// this is to handle old allocations that don't have it, and this method will be removed in a future release
+func (a *Allocation) SetEventDisplayMessages() {
+	setDisplayMsg(a.TaskStates)
+}
+
 // Stub returns a list stub for the allocation
 func (a *Allocation) Stub() *AllocListStub {
 	return &AllocListStub{
@@ -4961,6 +4967,22 @@ type AllocListStub struct {
 	ModifyIndex        uint64
 	CreateTime         int64
 	ModifyTime         int64
+}
+
+// SetEventDisplayMessage populates the display message if its not already set
+// this is a temporary fix to handle old allocations that don't have display message populated, and this method will be removed in a future release
+func (a *AllocListStub) SetEventDisplayMessages() {
+	setDisplayMsg(a.TaskStates)
+}
+
+func setDisplayMsg(taskStates map[string]*TaskState) {
+	if taskStates != nil {
+		for _, taskState := range taskStates {
+			for _, event := range taskState.Events {
+				event.PopulateEventDisplayMessage()
+			}
+		}
+	}
 }
 
 // AllocMetric is used to track various metrics while attempting

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4919,8 +4919,9 @@ func (a *Allocation) ShouldMigrate() bool {
 	return true
 }
 
-// SetEventDisplayMessage populates the display message if its not already set
-// this is to handle old allocations that don't have it, and this method will be removed in a future release
+// SetEventDisplayMessage populates the display message if its not already set,
+// a temporary fix to handle old allocations that don't have it.
+// This method will be removed in a future release.
 func (a *Allocation) SetEventDisplayMessages() {
 	setDisplayMsg(a.TaskStates)
 }
@@ -4969,8 +4970,9 @@ type AllocListStub struct {
 	ModifyTime         int64
 }
 
-// SetEventDisplayMessage populates the display message if its not already set
-// this is a temporary fix to handle old allocations that don't have display message populated, and this method will be removed in a future release
+// SetEventDisplayMessage populates the display message if its not already set,
+// a temporary fix to handle old allocations that don't have it.
+// This method will be removed in a future release.
 func (a *AllocListStub) SetEventDisplayMessages() {
 	setDisplayMsg(a.TaskStates)
 }


### PR DESCRIPTION
This makes old allocation events also have DisplayMessage set for the UI and CLI to read without needing backwards compatible code.