### PR TITLE
Fix error messages for transitioning jobs to/from periodic

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1213,10 +1213,10 @@ func validateJobUpdate(old, new *structs.Job) error {
 
 	// Transitioning to/from periodic is disallowed
 	if old.IsPeriodic() && !new.IsPeriodic() {
-		return fmt.Errorf("cannot update non-periodic job to being periodic")
+		return fmt.Errorf("cannot update periodic job to being non-periodic")
 	}
 	if new.IsPeriodic() && !old.IsPeriodic() {
-		return fmt.Errorf("cannot update periodic job to being non-periodic")
+		return fmt.Errorf("cannot update non-periodic job to being periodic")
 	}
 
 	// Transitioning to/from parameterized is disallowed


### PR DESCRIPTION
The error messages are flipped; when you transition a job from _not_ being periodic to being periodic you get the message "cannot update periodic job to being non-periodic", and vice versa.