### PR TITLE
doc: fix logs size

### DIFF
--- a/website/source/docs/job-specification/logs.html.md
+++ b/website/source/docs/job-specification/logs.html.md
@@ -78,7 +78,7 @@ parameters section above.
 
 This example asks Nomad to retain 3 rotated files for each of `stderr` and
 `stdout`, each a maximum size of 5 MB per file. The minimum disk space this
-would require is 60 MB (3 `stderr` &plus; 3 `stdout` &times; 5 MB &equals; 30 MB).
+would require is 30 MB (3 `stderr` &plus; 3 `stdout` &times; 5 MB &equals; 30 MB).
 
 ```hcl
 logs {


### PR DESCRIPTION
Minor typo in the job logs configuration page.