### PR TITLE
update API docs for /regions endpoint

### DIFF
--- a/website/source/api/regions.html.md
+++ b/website/source/api/regions.html.md
@@ -14,7 +14,7 @@ The `/regions` endpoints list all known regions.
 
 | Method | Path                         | Produces                   |
 | ------ | ---------------------------- | -------------------------- |
-| `GET`  | `/status/regions`            | `application/json`         |
+| `GET`  | `/regions`                   | `application/json`         |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and
@@ -28,7 +28,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://nomad.rocks/v1/status/regions
+    https://nomad.rocks/v1/regions
 ```
 
 ### Sample Response


### PR DESCRIPTION
Hello!

I noticed that the Regions endpoint documentation shows `/status/regions`. I believe it is just `/regions`