### PR TITLE
API docs: /client/gc returns text/plain, not json

### DIFF
--- a/website/source/api/client.html.md
+++ b/website/source/api/client.html.md
@@ -569,7 +569,7 @@ the Nomad client whose allocations should be garbage collected.
 
 | Method | Path                         | Produces                   |
 | ------ | ---------------------------- | -------------------------- |
-| `GET`  | `/client/gc`                 | `application/json`         |
+| `GET`  | `/client/gc`                 | `text/plain`               |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and


### PR DESCRIPTION
```
curl -v http://127.0.0.1:4646/v1/client/gc
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 4646 (#0)
> GET /v1/client/gc HTTP/1.1
> Host: 127.0.0.1:4646
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Vary: Accept-Encoding
< Date: Thu, 23 Nov 2017 18:11:32 GMT
< Content-Length: 0
< Content-Type: text/plain; charset=utf-8
```