### PR TITLE
Fix Website Docs for Periodic jobs TimeZone

### DIFF
--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -198,7 +198,7 @@ The `Job` object supports the following keys:
     - `Enabled` - `Enabled` determines whether the periodic job will spawn child
     jobs.
 
-    - `time_zone` - Specifies the time zone to evaluate the next launch interval
+    - `TimeZone` - Specifies the time zone to evaluate the next launch interval
       against. This is useful when wanting to account for day light savings in
       various time zones. The time zone must be parsable by Golang's
       [LoadLocation](https://golang.org/pkg/time/#LoadLocation). The default is
@@ -222,7 +222,8 @@ The `Job` object supports the following keys:
     ```json
     {
       "Periodic": {
-          "Spec": "*/15 - *"
+          "Spec": "*/15 - *",
+          "TimeZone": "Europe/Berlin",
           "SpecType": "cron",
           "Enabled": true,
           "ProhibitOverlap": true


### PR DESCRIPTION
Was looking into https://www.nomadproject.io/api/json-jobs.html#time_zone and became not sure that the correct parameter name used non-camel-case notation.
Checked with `nomad run -output test.hlc` where the input was:
```
job "docs" {
  periodic {
    enabled          = true
    cron             = "*/15 * * * * *"
    prohibit_overlap = true
    time_zone        = "Europe/Berlin"
  }
}
```
The output has camel-case TimeZone:
```
{
    "Job": {
        .................
        "Periodic": {
            "Enabled": true,
            "Spec": "*/15 * * * * *",
            "SpecType": "cron",
            "ProhibitOverlap": true,
            "TimeZone": "Europe/Berlin"
        },
        .................
    }
}
```