### PR TITLE
Allow controlling the stop signal for drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ __BACKWARDS INCOMPATIBILITIES:__
 IMPROVEMENTS:
  * core: Allow operators to reload TLS certificate and key files via SIGHUP
    [GH-3479]
+ * core:  allow configurable stop signals for a task, when drivers support
+   sending stop signals. [GH-1755]
  * core: Allow agents to be run in `rpc_upgrade_mode` when migrating a cluster
    to TLS rather than changing `heartbeat_grace`
  * api: Allocations now track and return modify time in addition to create time
@@ -30,7 +32,6 @@ IMPROVEMENTS:
  * driver/docker: Adds support for `ulimit` and `sysctl` options [GH-3568]
  * driver/docker: Adds support for StopTimeout (set to the same value as
    kill_timeout [GH-3601]
- * driver/exec:  allow controlling the stop signal in exec/raw_exec [GH-1755]
  * driver/rkt: Add support for passing through user [GH-3612]
  * driver/qemu: Support graceful shutdowns on unix platforms [GH-3411]
  * template: Updated to consul template 0.19.4 [GH-3543]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ IMPROVEMENTS:
  * driver/docker: Adds support for `ulimit` and `sysctl` options [GH-3568]
  * driver/docker: Adds support for StopTimeout (set to the same value as
    kill_timeout [GH-3601]
+ * driver/exec:  allow controlling the stop signal in exec/raw_exec [GH-1755]
  * driver/rkt: Add support for passing through user [GH-3612]
  * driver/qemu: Support graceful shutdowns on unix platforms [GH-3411]
  * template: Updated to consul template 0.19.4 [GH-3543]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ __BACKWARDS INCOMPATIBILITIES:__
 IMPROVEMENTS:
  * core: Allow operators to reload TLS certificate and key files via SIGHUP
    [GH-3479]
- * core:  allow configurable stop signals for a task, when drivers support
-   sending stop signals. [GH-1755]
+ * core: Allow configurable stop signals for a task, when drivers support
+   sending stop signals [GH-1755]
  * core: Allow agents to be run in `rpc_upgrade_mode` when migrating a cluster
    to TLS rather than changing `heartbeat_grace`
  * api: Allocations now track and return modify time in addition to create time

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -370,7 +370,7 @@ type Task struct {
 	DispatchPayload *DispatchPayloadConfig
 	Leader          bool
 	ShutdownDelay   time.Duration `mapstructure:"shutdown_delay"`
-	KillSignal      string
+	KillSignal      string        `mapstructure:"kill_signal"`
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -370,6 +370,7 @@ type Task struct {
 	DispatchPayload *DispatchPayloadConfig
 	Leader          bool
 	ShutdownDelay   time.Duration `mapstructure:"shutdown_delay"`
+	KillSignal      string
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -160,6 +160,7 @@ type DockerVolumeDriverConfig struct {
 	Options []map[string]string `mapstructure:"options"`
 }
 
+// DockerDriverConfig defines the user specified config block in a jobspec
 type DockerDriverConfig struct {
 	ImageName        string              `mapstructure:"image"`              // Container's Image Name
 	LoadImage        string              `mapstructure:"load"`               // LoadImage is a path to an image archive file
@@ -201,7 +202,6 @@ type DockerDriverConfig struct {
 	MacAddress       string              `mapstructure:"mac_address"`        // Pin mac address to container
 	SecurityOpt      []string            `mapstructure:"security_opt"`       // Flags to pass directly to security-opt
 	Devices          []DockerDevice      `mapstructure:"devices"`            // To allow mounting USB or other serial control devices
-	StopSignal       string              `mapstructure:"stop_signal"`        // allow passing through a specific stop signal
 }
 
 func sliceMergeUlimit(ulimitsRaw map[string]string) ([]docker.ULimit, error) {
@@ -1046,6 +1046,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 		return c, err
 	}
 
+	// create the config block that will later be consumed by go-dockerclient
 	config := &docker.Config{
 		Image:       d.imageID,
 		Hostname:    driverConfig.Hostname,
@@ -1055,7 +1056,6 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 		StopTimeout: int(task.KillTimeout.Seconds()),
 	}
 
-	// Set the stop signal for the docker container.
 	if task.KillSignal != "" {
 		config.StopSignal = task.KillSignal
 	}

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1054,10 +1054,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 		Tty:         driverConfig.TTY,
 		OpenStdin:   driverConfig.Interactive,
 		StopTimeout: int(task.KillTimeout.Seconds()),
-	}
-
-	if task.KillSignal != "" {
-		config.StopSignal = task.KillSignal
+		StopSignal:  task.KillSignal,
 	}
 
 	if driverConfig.WorkDir != "" {

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -2045,3 +2045,85 @@ func TestDockerDriver_Device_Success(t *testing.T) {
 	assert.Equal(t, expectedDevice, container.HostConfig.Devices[0], "Incorrect device ")
 
 }
+
+func TestDockerDriver_Kill(t *testing.T) {
+	assert := assert.New(t)
+	if !tu.IsTravis() {
+		t.Parallel()
+	}
+	if !testutil.DockerIsConnected(t) {
+		t.Skip("Docker not connected")
+	}
+
+	// Tasks started with a signal that is not supported should error
+	{
+		task := &structs.Task{
+			Name:       "nc-demo",
+			Driver:     "docker",
+			KillSignal: "ABCDEF",
+			Config: map[string]interface{}{
+				"load":    "busybox.tar",
+				"image":   "busybox",
+				"command": "/bin/nc",
+				"args":    []string{"-l", "127.0.0.1", "-p", "0"},
+			},
+			LogConfig: &structs.LogConfig{
+				MaxFiles:      10,
+				MaxFileSizeMB: 10,
+			},
+			Resources: basicResources,
+		}
+
+		ctx := testDockerDriverContexts(t, task)
+		defer ctx.AllocDir.Destroy()
+		d := NewDockerDriver(ctx.DriverCtx)
+		copyImage(t, ctx.ExecCtx.TaskDir, "busybox.tar")
+
+		_, err := d.Prestart(ctx.ExecCtx, task)
+		if err != nil {
+			t.Fatalf("error in prestart: %v", err)
+		}
+
+		_, err = d.Start(ctx.ExecCtx, task)
+		assert.NotNil(err)
+	}
+
+	// Tasks started with a signal that is not supported should not error
+	{
+		task := &structs.Task{
+			Name:       "nc-demo",
+			Driver:     "docker",
+			KillSignal: "SIGQUIT",
+			Config: map[string]interface{}{
+				"load":    "busybox.tar",
+				"image":   "busybox",
+				"command": "/bin/nc",
+				"args":    []string{"-l", "127.0.0.1", "-p", "0"},
+			},
+			LogConfig: &structs.LogConfig{
+				MaxFiles:      10,
+				MaxFileSizeMB: 10,
+			},
+			Resources: basicResources,
+		}
+
+		ctx := testDockerDriverContexts(t, task)
+		defer ctx.AllocDir.Destroy()
+		d := NewDockerDriver(ctx.DriverCtx)
+		copyImage(t, ctx.ExecCtx.TaskDir, "busybox.tar")
+
+		_, err := d.Prestart(ctx.ExecCtx, task)
+		if err != nil {
+			t.Fatalf("error in prestart: %v", err)
+		}
+
+		resp, err := d.Start(ctx.ExecCtx, task)
+		assert.Nil(err)
+		assert.NotNil(resp.Handle)
+
+		handle := resp.Handle.(*DockerHandle)
+		waitForExist(t, client, handle)
+		err = handle.Kill()
+		assert.Nil(err)
+	}
+}

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -31,8 +31,9 @@ type ExecDriver struct {
 }
 
 type ExecDriverConfig struct {
-	Command string   `mapstructure:"command"`
-	Args    []string `mapstructure:"args"`
+	Command    string   `mapstructure:"command"`
+	Args       []string `mapstructure:"args"`
+	KillSignal string   `mapstructure:"kill_signal"`
 }
 
 // execHandle is returned from Start/Open as a handle to the PID
@@ -66,6 +67,9 @@ func (d *ExecDriver) Validate(config map[string]interface{}) error {
 			},
 			"args": {
 				Type: fields.TypeArray,
+			},
+			"kill_signal": {
+				Type: fields.TypeString,
 			},
 		},
 	}
@@ -132,6 +136,7 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 	execCmd := &executor.ExecCommand{
 		Cmd:            command,
 		Args:           driverConfig.Args,
+		KillSignal:     driverConfig.KillSignal,
 		FSIsolation:    true,
 		ResourceLimits: true,
 		User:           getExecutorUser(task),

--- a/client/driver/exec.go
+++ b/client/driver/exec.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/hashicorp/consul-template/signals"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/allocdir"
@@ -130,12 +129,9 @@ func (d *ExecDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 		return nil, fmt.Errorf("failed to set executor context: %v", err)
 	}
 
-	var taskKillSignal os.Signal
-	if task.KillSignal != "" {
-		taskKillSignal = signals.SignalLookup[task.KillSignal]
-		if taskKillSignal == nil {
-			return nil, fmt.Errorf("Signal %s is not supported", task.KillSignal)
-		}
+	taskKillSignal, err := getTaskKillSignal(task.KillSignal)
+	if err != nil {
+		return nil, err
 	}
 
 	execCmd := &executor.ExecCommand{

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -500,7 +500,16 @@ func (e *UniversalExecutor) ShutDown() error {
 		return nil
 	}
 
-	if err = proc.Signal(e.command.TaskKillSignal); err != nil && err.Error() != finishedErr {
+	// Set default kill signal, as some drivers don't support configurable
+	// signals (such as rkt)
+	var osSignal os.Signal
+	if e.command.TaskKillSignal != nil {
+		osSignal = e.command.TaskKillSignal
+	} else {
+		osSignal = os.Interrupt
+	}
+
+	if err = proc.Signal(osSignal); err != nil && err.Error() != finishedErr {
 		return fmt.Errorf("executor.shutdown error: %v", err)
 	}
 

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -98,7 +98,8 @@ type ExecCommand struct {
 	// Args is the args of the command that the user wants to run.
 	Args []string
 
-	KillSignal string
+	// TaskKillSignal is an optional field which signal to kill the process
+	TaskKillSignal os.Signal
 
 	// FSIsolation determines whether the command would be run in a chroot.
 	FSIsolation bool
@@ -483,21 +484,6 @@ func (e *UniversalExecutor) Exit() error {
 	return merr.ErrorOrNil()
 }
 
-// Look to see if the user has specified a kill command. If non has been
-// specified, default to SIGQUIT.
-func getMatchingSyscall(sys string) syscall.Signal {
-	switch sys {
-	case "SIGINT":
-		return syscall.SIGINT
-	case "SIGUSR1":
-		return syscall.SIGUSR1
-	case "SIGUSR2":
-		return syscall.SIGUSR2
-	default:
-		return syscall.SIGQUIT
-	}
-}
-
 // Shutdown sends an interrupt signal to the user process
 func (e *UniversalExecutor) ShutDown() error {
 	if e.cmd.Process == nil {
@@ -514,14 +500,14 @@ func (e *UniversalExecutor) ShutDown() error {
 		return nil
 	}
 
-	var killErr error
-	if e.command.KillSignal != "" {
-		sys := getMatchingSyscall(e.command.KillSignal)
-		killErr = syscall.Kill(e.cmd.Process.Pid, sys)
+	var osSignal os.Signal
+	if e.command.TaskKillSignal != nil {
+		osSignal = e.command.TaskKillSignal
 	} else {
-		killErr = proc.Signal(os.Interrupt)
+		osSignal = os.Interrupt
 	}
-	if killErr != nil && killErr.Error() != finishedErr {
+
+	if err = proc.Signal(osSignal); err != nil && err.Error() != finishedErr {
 		return fmt.Errorf("executor.shutdown error: %v", err)
 	}
 

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -500,14 +500,7 @@ func (e *UniversalExecutor) ShutDown() error {
 		return nil
 	}
 
-	var osSignal os.Signal
-	if e.command.TaskKillSignal != nil {
-		osSignal = e.command.TaskKillSignal
-	} else {
-		osSignal = os.Interrupt
-	}
-
-	if err = proc.Signal(osSignal); err != nil && err.Error() != finishedErr {
+	if err = proc.Signal(e.command.TaskKillSignal); err != nil && err.Error() != finishedErr {
 		return fmt.Errorf("executor.shutdown error: %v", err)
 	}
 

--- a/client/driver/java.go
+++ b/client/driver/java.go
@@ -265,12 +265,18 @@ func (d *JavaDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse
 		return nil, err
 	}
 
+	taskKillSignal, err := getTaskKillSignal(task.KillSignal)
+	if err != nil {
+		return nil, err
+	}
+
 	execCmd := &executor.ExecCommand{
 		Cmd:            absPath,
 		Args:           args,
 		FSIsolation:    true,
 		ResourceLimits: true,
 		User:           getExecutorUser(task),
+		TaskKillSignal: taskKillSignal,
 	}
 	ps, err := execIntf.LaunchCmd(execCmd)
 	if err != nil {

--- a/client/driver/raw_exec.go
+++ b/client/driver/raw_exec.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/hashicorp/consul-template/signals"
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
@@ -145,12 +144,9 @@ func (d *RawExecDriver) Start(ctx *ExecContext, task *structs.Task) (*StartRespo
 		return nil, fmt.Errorf("failed to set executor context: %v", err)
 	}
 
-	var taskKillSignal os.Signal
-	if task.KillSignal != "" {
-		taskKillSignal = signals.SignalLookup[task.KillSignal]
-		if taskKillSignal == nil {
-			return nil, fmt.Errorf("Signal %s is not supported", task.KillSignal)
-		}
+	taskKillSignal, err := getTaskKillSignal(task.KillSignal)
+	if err != nil {
+		return nil, err
 	}
 
 	execCmd := &executor.ExecCommand{

--- a/client/driver/utils.go
+++ b/client/driver/utils.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/consul-template/signals"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/allocdir"
@@ -203,4 +204,18 @@ func SetEnvvars(envBuilder *env.Builder, fsi cstructs.FSIsolation, taskDir *allo
 		filter := strings.Split(conf.ReadDefault("env.blacklist", config.DefaultEnvBlacklist), ",")
 		envBuilder.SetHostEnvvars(filter)
 	}
+}
+
+// getTaskKillSignal looks up the signal specified for the task if it has been
+// specified. If it is not supported on the platform, returns an error.
+func getTaskKillSignal(signal string) (os.Signal, error) {
+	if signal == "" {
+		return nil, nil
+	}
+
+	taskKillSignal := signals.SignalLookup[signal]
+	if taskKillSignal == nil {
+		return nil, fmt.Errorf("Signal %s is not supported", signal)
+	}
+	return taskKillSignal, nil
 }

--- a/client/driver/utils.go
+++ b/client/driver/utils.go
@@ -210,12 +210,13 @@ func SetEnvvars(envBuilder *env.Builder, fsi cstructs.FSIsolation, taskDir *allo
 // specified. If it is not supported on the platform, returns an error.
 func getTaskKillSignal(signal string) (os.Signal, error) {
 	if signal == "" {
-		return nil, nil
+		return os.Interrupt, nil
 	}
 
 	taskKillSignal := signals.SignalLookup[signal]
 	if taskKillSignal == nil {
 		return nil, fmt.Errorf("Signal %s is not supported", signal)
 	}
+
 	return taskKillSignal, nil
 }

--- a/client/driver/utils_test.go
+++ b/client/driver/utils_test.go
@@ -1,8 +1,13 @@
 package driver
 
 import (
+	"os"
+	"runtime"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDriver_KillTimeout(t *testing.T) {
@@ -19,5 +24,35 @@ func TestDriver_KillTimeout(t *testing.T) {
 
 	if actual := GetKillTimeout(input, max); expected != actual {
 		t.Fatalf("KillTimeout() returned %v; want %v", actual, expected)
+	}
+}
+
+func TestDriver_getTaskKillSignal(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux only test")
+	}
+
+	// Test that the default is SIGINT
+	{
+		sig, err := getTaskKillSignal("")
+		assert.Nil(err)
+		assert.Equal(sig, os.Interrupt)
+	}
+
+	// Test that unsupported signals return an error
+	{
+		_, err := getTaskKillSignal("ABCDEF")
+		assert.NotNil(err)
+		assert.Contains(err.Error(), "Signal ABCDEF is not supported")
+	}
+
+	// Test that supported signals return that signal
+	{
+		sig, err := getTaskKillSignal("SIGKILL")
+		assert.Nil(err)
+		assert.Equal(sig, syscall.SIGKILL)
 	}
 }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -666,6 +666,8 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 	}
 }
 
+// ApiTaskToStructsTask is a copy and type conversion between the API
+// representation of a task from a struct representation of a task.
 func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 	structsTask.Name = apiTask.Name
 	structsTask.Driver = apiTask.Driver
@@ -676,6 +678,7 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 	structsTask.Meta = apiTask.Meta
 	structsTask.KillTimeout = *apiTask.KillTimeout
 	structsTask.ShutdownDelay = apiTask.ShutdownDelay
+	structsTask.KillSignal = apiTask.KillSignal
 
 	if l := len(apiTask.Constraints); l != 0 {
 		structsTask.Constraints = make([]*structs.Constraint, l)

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1260,6 +1260,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 							"lol": "code",
 						},
 						KillTimeout: helper.TimeToPtr(10 * time.Second),
+						KillSignal:  "SIGQUIT",
 						LogConfig: &api.LogConfig{
 							MaxFiles:      helper.IntToPtr(10),
 							MaxFileSizeMB: helper.IntToPtr(100),
@@ -1455,6 +1456,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 							"lol": "code",
 						},
 						KillTimeout: 10 * time.Second,
+						KillSignal:  "SIGQUIT",
 						LogConfig: &structs.LogConfig{
 							MaxFiles:      10,
 							MaxFileSizeMB: 100,

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -625,12 +625,6 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 			Result:           &t,
 		})
 
-		// this needs to be manually assigned
-		killsig := m["kill_signal"]
-		if killsig != nil {
-			t.KillSignal = killsig.(string)
-		}
-
 		if err != nil {
 			return err
 		}

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -591,6 +591,7 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 			"template",
 			"user",
 			"vault",
+			"kill_signal",
 		}
 		if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("'%s' ->", n))
@@ -623,6 +624,13 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 			WeaklyTypedInput: true,
 			Result:           &t,
 		})
+
+		// this needs to be manually assigned
+		killsig := m["kill_signal"]
+		if killsig != nil {
+			t.KillSignal = killsig.(string)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -563,17 +563,16 @@ func TestParse(t *testing.T) {
 		{
 			"job-with-kill-signal.hcl",
 			&api.Job{
-				ID:   helper.StringToPtr("example"),
-				Name: helper.StringToPtr("example"),
-
+				ID:   helper.StringToPtr("foo"),
+				Name: helper.StringToPtr("foo"),
 				TaskGroups: []*api.TaskGroup{
 					{
-						Name: helper.StringToPtr("webservice"),
+						Name: helper.StringToPtr("bar"),
 						Tasks: []*api.Task{
 							{
-								Name:       "webservice",
+								Name:       "bar",
 								Driver:     "docker",
-								KillSignal: "SIGINT",
+								KillSignal: "SIGQUIT",
 								Config: map[string]interface{}{
 									"image": "hashicorp/image",
 								},

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -559,6 +559,30 @@ func TestParse(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"job-with-kill-signal.hcl",
+			&api.Job{
+				ID:   helper.StringToPtr("example"),
+				Name: helper.StringToPtr("example"),
+
+				TaskGroups: []*api.TaskGroup{
+					{
+						Name: helper.StringToPtr("webservice"),
+						Tasks: []*api.Task{
+							{
+								Name:       "webservice",
+								Driver:     "docker",
+								KillSignal: "SIGINT",
+								Config: map[string]interface{}{
+									"image": "hashicorp/image",
+								},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -202,7 +202,8 @@ func TestParse(t *testing.T) {
 										RightDelim: helper.StringToPtr("__"),
 									},
 								},
-								Leader: true,
+								Leader:     true,
+								KillSignal: "",
 							},
 							{
 								Name:   "storagelocker",

--- a/jobspec/test-fixtures/job-with-kill-signal.hcl
+++ b/jobspec/test-fixtures/job-with-kill-signal.hcl
@@ -1,0 +1,12 @@
+job "example" {
+    task "webservice" {
+      kill_signal = "SIGINT"
+        driver = "docker"
+        config
+        {
+          image =  "hashicorp/image"
+        }
+    }
+
+}
+

--- a/jobspec/test-fixtures/job-with-kill-signal.hcl
+++ b/jobspec/test-fixtures/job-with-kill-signal.hcl
@@ -1,12 +1,10 @@
-job "example" {
-    task "webservice" {
-      kill_signal = "SIGINT"
-        driver = "docker"
-        config
-        {
-          image =  "hashicorp/image"
-        }
+job "foo" {
+  task "bar" {
+    driver = "docker"
+    kill_signal = "SIGQUIT"
+
+    config {
+      image = "hashicorp/image"
     }
-
+  }
 }
-

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -3760,9 +3760,8 @@ func TestJobEndpoint_ValidateJob_KillSignal(t *testing.T) {
 		job.TaskGroups[0].Tasks[0].KillSignal = "SIGINT"
 
 		err, warnings := validateJob(job)
-		if err == nil || !strings.Contains(err.Error(), "support sending signals") {
-			t.Fatalf("Expected signal feasibility error; got %v", err)
-		}
+		assert.NotNil(err)
+		assert.True(strings.Contains(err.Error(), "support sending signals"))
 		assert.Nil(warnings)
 	}
 
@@ -3773,9 +3772,7 @@ func TestJobEndpoint_ValidateJob_KillSignal(t *testing.T) {
 		job.TaskGroups[0].Tasks[0].KillSignal = "SIGINT"
 
 		err, warnings := validateJob(job)
-		if err != nil {
-			t.Fatalf("Expected error to be nil; got %v", err.Error())
-		}
+		assert.Nil(err)
 		assert.Nil(warnings)
 	}
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3228,7 +3228,9 @@ type Task struct {
 	ShutdownDelay time.Duration
 
 	// The kill signal to use for the task. This is an optional specification,
-	// and if not set, the driver will default to SIGINT
+
+	// KillSignal is the kill signal to use for the task. This is an optional
+	// specification and defaults to SIGINT
 	KillSignal string
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1978,6 +1978,11 @@ func (j *Job) RequiredSignals() map[string]map[string][]string {
 				taskSignals[task.Vault.ChangeSignal] = struct{}{}
 			}
 
+			// If a user has specified a KillSignal, add it to required signals
+			if task.KillSignal != "" {
+				taskSignals[task.KillSignal] = struct{}{}
+			}
+
 			// Check if any template change mode uses signals
 			for _, t := range task.Templates {
 				if t.ChangeMode != TemplateChangeModeSignal {
@@ -3221,6 +3226,10 @@ type Task struct {
 	// ShutdownDelay is the duration of the delay between deregistering a
 	// task from Consul and sending it a signal to shutdown. See #2441
 	ShutdownDelay time.Duration
+
+	// The kill signal to use for the task. This is an optional specification,
+	// and if not set, the driver will default to SIGINT
+	KillSignal string
 }
 
 func (t *Task) Copy() *Task {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -806,6 +806,26 @@ func TestJob_RequiredSignals(t *testing.T) {
 		},
 	}
 
+	j2 := &Job{
+		TaskGroups: []*TaskGroup{
+			{
+				Name: "foo",
+				Tasks: []*Task{
+					{
+						Name:       "t1",
+						KillSignal: "SIGQUIT",
+					},
+				},
+			},
+		},
+	}
+
+	e2 := map[string]map[string][]string{
+		"foo": {
+			"t1": {"SIGQUIT"},
+		},
+	}
+
 	cases := []struct {
 		Job      *Job
 		Expected map[string]map[string][]string
@@ -817,6 +837,10 @@ func TestJob_RequiredSignals(t *testing.T) {
 		{
 			Job:      j1,
 			Expected: e1,
+		},
+		{
+			Job:      j2,
+			Expected: e2,
 		},
 	}
 

--- a/website/source/docs/job-specification/task.html.md
+++ b/website/source/docs/job-specification/task.html.md
@@ -54,6 +54,11 @@ job "docs" {
   [`max_kill_timeout`][max_kill] on the agent running the task, which has a
   default value of 30 seconds.
 
+- `kill_signal` `(string)` - Specifies a configurable kill signal for a task,
+  where the default is SIGINT. Note tha this is only supported for drivers
+  which accept sending signals (currently docker, exec, raw_exec, and java
+  drivers).
+
 - `leader` `(bool: false)` - Specifies whether the task is the leader task of
   the task group. If set to true, when the leader task completes, all other
   tasks within the task group will be gracefully shutdown.

--- a/website/source/docs/job-specification/task.html.md
+++ b/website/source/docs/job-specification/task.html.md
@@ -55,8 +55,8 @@ job "docs" {
   default value of 30 seconds.
 
 - `kill_signal` `(string)` - Specifies a configurable kill signal for a task,
-  where the default is SIGINT. Note tha this is only supported for drivers
-  which accept sending signals (currently docker, exec, raw_exec, and java
+  where the default is SIGINT. Note that this is only supported for drivers
+  which accept sending signals (currently Docker, exec, raw_exec, and Java
   drivers).
 
 - `leader` `(bool: false)` - Specifies whether the task is the leader task of


### PR DESCRIPTION
See initial issue: https://github.com/hashicorp/nomad/issues/1755

This feature is only supported by drivers which accept signals.

This excludes rkt- we first need this PR to merge before extending support: https://github.com/rkt/rkt/pull/3732