### PR TITLE
Handle exact namespace match properly when also matched as prefix

### DIFF
--- a/command/namespace_inspect.go
+++ b/command/namespace_inspect.go
@@ -71,20 +71,16 @@ func (c *NamespaceInspectCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Do a prefix lookup
+	// Do a prefix lookup; No matches is returned as an error state.
 	ns, possible, err := getNamespace(client.Namespaces(), name)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving namespaces: %s", err))
 		return 1
 	}
 
-	if len(possible) > 1 {
-		if possible[0].Name == name {
-			ns = possible[0]
-		} else {
-			c.Ui.Error(fmt.Sprintf("Prefix matched multiple namespaces\n\n%s", formatNamespaces(possible)))
-			return 1
-		}
+	if ns == nil && possible != nil {
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple namespaces\n\n%s", formatNamespaces(possible)))
+		return 1
 	}
 
 	out, err := Format(len(tmpl) == 0, tmpl, ns)

--- a/command/namespace_inspect.go
+++ b/command/namespace_inspect.go
@@ -78,9 +78,13 @@ func (c *NamespaceInspectCommand) Run(args []string) int {
 		return 1
 	}
 
-	if len(possible) != 0 {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple namespaces\n\n%s", formatNamespaces(possible)))
-		return 1
+	if len(possible) > 1 {
+		if possible[0].Name == name {
+			ns = possible[0]
+		} else {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple namespaces\n\n%s", formatNamespaces(possible)))
+			return 1
+		}
 	}
 
 	out, err := Format(len(tmpl) == 0, tmpl, ns)

--- a/command/namespace_inspect.go
+++ b/command/namespace_inspect.go
@@ -71,14 +71,14 @@ func (c *NamespaceInspectCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Do a prefix lookup; No matches is returned as an error state.
+	// Do a prefix lookup
 	ns, possible, err := getNamespace(client.Namespaces(), name)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving namespaces: %s", err))
 		return 1
 	}
 
-	if ns == nil && possible != nil {
+	if len(possible) != 0 {
 		c.Ui.Error(fmt.Sprintf("Prefix matched multiple namespaces\n\n%s", formatNamespaces(possible)))
 		return 1
 	}

--- a/command/namespace_inspect_test.go
+++ b/command/namespace_inspect_test.go
@@ -113,13 +113,24 @@ func TestNamespaceInspectCommand_NamespaceMatchesPrefix(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Create a foo namespace
-	ns = &api.Namespace{Name: "foo"}
+	ns2 := &api.Namespace{Name: "foo"}
+	_, err = client.Namespaces().Register(ns2, nil)
+	assert.Nil(t, err)
+
+	// Adding a NS after to prevent sort from creating
+	// false successes
+	ns = &api.Namespace{Name: "fooBaz"}
 	_, err = client.Namespaces().Register(ns, nil)
 	assert.Nil(t, err)
 
 	// Check status on namespace
-	code := cmd.Run([]string{"-address=" + url, ns.Name})
+	code := cmd.Run([]string{"-address=" + url, ns2.Name})
 	if code != 0 {
 		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
+	}
+	// Check to ensure we got the proper foo
+	out := ui.OutputWriter.String()
+	if !strings.Contains(out, "= foo\n") {
+		t.Fatalf("expected namespace foo, got: %s", out)
 	}
 }

--- a/command/namespace_inspect_test.go
+++ b/command/namespace_inspect_test.go
@@ -92,3 +92,34 @@ func TestNamespaceInspectCommand_AutocompleteArgs(t *testing.T) {
 	assert.Equal(1, len(res))
 	assert.Equal(ns.Name, res[0])
 }
+
+// This test should demonstrate the behavior of a namespace
+// and prefix collision.  In that case, the Namespace status
+// command should pull the matching namespace rather than
+// displaying the multiple match error
+func TestNamespaceInspectCommand_NamespaceMatchesPrefix(t *testing.T) {
+	t.Parallel()
+
+	// Create a server
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &NamespaceInspectCommand{Meta: Meta{Ui: ui}}
+
+	// Create a namespace that uses foo as a prefix
+	ns := &api.Namespace{Name: "fooBar"}
+	_, err := client.Namespaces().Register(ns, nil)
+	assert.Nil(t, err)
+
+	// Create a foo namespace
+	ns = &api.Namespace{Name: "foo"}
+	_, err = client.Namespaces().Register(ns, nil)
+	assert.Nil(t, err)
+
+	// Check status on namespace
+	code := cmd.Run([]string{"-address=" + url, ns.Name})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
+	}
+}

--- a/command/namespace_status.go
+++ b/command/namespace_status.go
@@ -68,9 +68,13 @@ func (c *NamespaceStatusCommand) Run(args []string) int {
 		return 1
 	}
 
-	if len(possible) != 0 {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple namespaces\n\n%s", formatNamespaces(possible)))
-		return 1
+	if len(possible) > 1 {
+		if possible[0].Name == name {
+			ns = possible[0]
+		} else {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple namespaces\n\n%s", formatNamespaces(possible)))
+			return 1
+		}
 	}
 
 	c.Ui.Output(formatNamespaceBasics(ns))

--- a/command/namespace_status.go
+++ b/command/namespace_status.go
@@ -61,20 +61,16 @@ func (c *NamespaceStatusCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Do a prefix lookup
+	// Do a prefix lookup; No matches is returned as an error state.
 	ns, possible, err := getNamespace(client.Namespaces(), name)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving namespaces: %s", err))
 		return 1
 	}
 
-	if len(possible) > 1 {
-		if possible[0].Name == name {
-			ns = possible[0]
-		} else {
-			c.Ui.Error(fmt.Sprintf("Prefix matched multiple namespaces\n\n%s", formatNamespaces(possible)))
-			return 1
-		}
+	if ns == nil && possible != nil {
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple namespaces\n\n%s", formatNamespaces(possible)))
+		return 1
 	}
 
 	c.Ui.Output(formatNamespaceBasics(ns))
@@ -118,6 +114,14 @@ func formatNamespaceBasics(ns *api.Namespace) string {
 	return formatKV(basic)
 }
 
+// getNamespace returns three values:
+// * an exact match, if found
+// * the fuzzy matches, if found
+// * any error
+//
+// In the case that the fuzzy match finds one and only one
+// possibility, it will return it as though it was an exact
+// match.
 func getNamespace(client *api.Namespaces, ns string) (match *api.Namespace, possible []*api.Namespace, err error) {
 	// Do a prefix lookup
 	namespaces, _, err := client.PrefixList(ns, nil)
@@ -131,6 +135,8 @@ func getNamespace(client *api.Namespaces, ns string) (match *api.Namespace, poss
 		return nil, nil, fmt.Errorf("Namespace %q matched no namespaces", ns)
 	case l == 1:
 		return namespaces[0], nil, nil
+	case l > 1 && ns == namespaces[0].Name:
+		return namespaces[0], namespaces[1:], nil
 	default:
 		return nil, namespaces, nil
 	}

--- a/command/namespace_status_test.go
+++ b/command/namespace_status_test.go
@@ -133,3 +133,35 @@ func TestNamespaceStatusCommand_AutocompleteArgs(t *testing.T) {
 	assert.Equal(1, len(res))
 	assert.Equal(ns.Name, res[0])
 }
+
+// This test should demonstrate the behavior of a namespace
+// and prefix collision.  In that case, the Namespace status
+// command should pull the matching namespace rather than
+// displaying the multiple match error
+func TestNamespaceStatusCommand_NamespaceMatchesPrefix(t *testing.T) {
+	t.Parallel()
+
+	// Create a server
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &NamespaceStatusCommand{Meta: Meta{Ui: ui}}
+
+	// Create a namespace that uses foo as a prefix
+	ns := &api.Namespace{Name: "fooBar"}
+	_, err := client.Namespaces().Register(ns, nil)
+	assert.Nil(t, err)
+
+	// Create a foo namespace
+	ns = &api.Namespace{Name: "foo"}
+	_, err = client.Namespaces().Register(ns, nil)
+	assert.Nil(t, err)
+
+	// Check status on namespace
+	code := cmd.Run([]string{"-address=" + url, ns.Name})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
+	}
+
+}

--- a/command/namespace_status_test.go
+++ b/command/namespace_status_test.go
@@ -163,5 +163,4 @@ func TestNamespaceStatusCommand_NamespaceMatchesPrefix(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
 	}
-
 }

--- a/command/namespace_status_test.go
+++ b/command/namespace_status_test.go
@@ -154,13 +154,24 @@ func TestNamespaceStatusCommand_NamespaceMatchesPrefix(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Create a foo namespace
-	ns = &api.Namespace{Name: "foo"}
+	ns2 := &api.Namespace{Name: "foo"}
+	_, err = client.Namespaces().Register(ns2, nil)
+	assert.Nil(t, err)
+
+	// Adding a NS after to prevent sort from creating
+	// false successes
+	ns = &api.Namespace{Name: "fooBaz"}
 	_, err = client.Namespaces().Register(ns, nil)
 	assert.Nil(t, err)
 
 	// Check status on namespace
-	code := cmd.Run([]string{"-address=" + url, ns.Name})
+	code := cmd.Run([]string{"-address=" + url, ns2.Name})
 	if code != 0 {
 		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
+	}
+	// Check to ensure we got the proper foo
+	out := ui.OutputWriter.String()
+	if !strings.Contains(out, "= foo\n") {
+		t.Fatalf("expected namespace foo, got: %s", out)
 	}
 }

--- a/website/source/api/client.html.md
+++ b/website/source/api/client.html.md
@@ -569,7 +569,7 @@ the Nomad client whose allocations should be garbage collected.
 
 | Method | Path                         | Produces                   |
 | ------ | ---------------------------- | -------------------------- |
-| `GET`  | `/client/gc`                 | `application/json`         |
+| `GET`  | `/client/gc`                 | `text/plain`               |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and

--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -198,7 +198,7 @@ The `Job` object supports the following keys:
     - `Enabled` - `Enabled` determines whether the periodic job will spawn child
     jobs.
 
-    - `time_zone` - Specifies the time zone to evaluate the next launch interval
+    - `TimeZone` - Specifies the time zone to evaluate the next launch interval
       against. This is useful when wanting to account for day light savings in
       various time zones. The time zone must be parsable by Golang's
       [LoadLocation](https://golang.org/pkg/time/#LoadLocation). The default is
@@ -222,7 +222,8 @@ The `Job` object supports the following keys:
     ```json
     {
       "Periodic": {
-          "Spec": "*/15 - *"
+          "Spec": "*/15 - *",
+          "TimeZone": "Europe/Berlin",
           "SpecType": "cron",
           "Enabled": true,
           "ProhibitOverlap": true

--- a/website/source/api/regions.html.md
+++ b/website/source/api/regions.html.md
@@ -14,7 +14,7 @@ The `/regions` endpoints list all known regions.
 
 | Method | Path                         | Produces                   |
 | ------ | ---------------------------- | -------------------------- |
-| `GET`  | `/status/regions`            | `application/json`         |
+| `GET`  | `/regions`                   | `application/json`         |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and
@@ -28,7 +28,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://nomad.rocks/v1/status/regions
+    https://nomad.rocks/v1/regions
 ```
 
 ### Sample Response


### PR DESCRIPTION
This fixes an issue with the `nomad namespace inspect` and `nomad namespace status` commands failing to run for namespaces whose names are the start of another namespace's name: for example, foo and foobar.  If the argument matches the first possibility returned by prefix exactly, that namespace will be targetted.  If no exact match occurs, the behavior is unchanged.