### PR TITLE
Changed Superset to only return the resource name

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1339,16 +1339,16 @@ func (r *Resources) NetIndex(n *NetworkResource) int {
 // should be used for that.
 func (r *Resources) Superset(other *Resources) (bool, string) {
 	if r.CPU < other.CPU {
-		return false, "cpu exhausted"
+		return false, "cpu"
 	}
 	if r.MemoryMB < other.MemoryMB {
-		return false, "memory exhausted"
+		return false, "memory"
 	}
 	if r.DiskMB < other.DiskMB {
-		return false, "disk exhausted"
+		return false, "disk"
 	}
 	if r.IOPS < other.IOPS {
-		return false, "iops exhausted"
+		return false, "iops"
 	}
 	return true, ""
 }

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -1477,7 +1477,7 @@ $ curl \
       "NodesExhausted": 1,
       "ClassExhausted": null,
       "DimensionExhausted": {
-        "cpu exhausted": 1
+        "cpu": 1
       }
     }
   },

--- a/website/source/docs/commands/job/status.html.md.erb
+++ b/website/source/docs/commands/job/status.html.md.erb
@@ -177,7 +177,7 @@ cache       1       0         4        0       0         0
 Placement Failure
 Task Group "cache":
   * Resources exhausted on 1 nodes
-  * Dimension "cpu exhausted" exhausted on 1 nodes
+  * Dimension "cpu" exhausted on 1 nodes
 
 Latest Deployment
 ID          = bb4b2fb1

--- a/website/source/docs/commands/plan.html.md.erb
+++ b/website/source/docs/commands/plan.html.md.erb
@@ -103,7 +103,7 @@ Scheduler dry-run:
 - WARNING: Failed to place all allocations.
   Task Group "cache" (failed to place 3 allocations):
     * Resources exhausted on 1 nodes
-    * Dimension "cpu exhausted" exhausted on 1 nodes
+    * Dimension "cpu" exhausted on 1 nodes
 
 Job Modify Index: 15
 To submit the job with version verification run:

--- a/website/source/docs/operating-a-job/inspecting-state.html.md
+++ b/website/source/docs/operating-a-job/inspecting-state.html.md
@@ -98,7 +98,7 @@ ID        Priority  Triggered By  Status    Placement Failures
 Placement Failure
 Task Group "example":
   * Resources exhausted on 1 nodes
-  * Dimension "cpu exhausted" exhausted on 1 nodes
+  * Dimension "cpu" exhausted on 1 nodes
 
 Allocations
 ID        Eval ID   Node ID   Task Group  Desired  Status   Created At
@@ -135,7 +135,7 @@ Placement Failures = true
 Failed Placements
 Task Group "example" (failed to place 3 allocations):
   * Resources exhausted on 1 nodes
-  * Dimension "cpu exhausted" exhausted on 1 nodes
+  * Dimension "cpu" exhausted on 1 nodes
 
 Evaluation "5744eb15" waiting for additional capacity to place remainder
 ```


### PR DESCRIPTION
The Superset method on Resources used to return a string in the format of “[resource name] exhausted”.
This was leading to the output in plan/create job API DimensionExhausted to return keys like
```
"DimensionExhausted": {"cpu exhausted": 1}
```
This was not anywhere documented, however, one of the examples on the website showed it like this.

The other side effect of this is that the CLI formats the strings from the name of the key leading to output like
```
* Dimension "cpu exhausted" exhausted on 1 nodes
```

This PR changes the behaviour of to just return the name of the exhausted resource.
`"DimensionExhausted": {"cpu exhausted": 1}` is a much clearer API, and `Dimension "cpu" exhausted on 1 nodes` seems more correct as well.