### PR TITLE
Update community.html.erb to include Levant.

### DIFF
--- a/website/source/community.html.erb
+++ b/website/source/community.html.erb
@@ -38,6 +38,7 @@ description: |-
   <li><a href="https://github.com/iverberk/nomad-ui">nomad-ui</a> - Nomad UI is a simple to deploy, web based UI for interacting with Nomad</li>
   <li><a href="https://github.com/iverberk/jenkins-nomad">nomad-jenkins</a> - This project uses Nomad to provision new Jenkins build slaves based on workload</li>
   <li><a href="https://github.com/elsevier-core-engineering/replicator">replicator</a> - Replicator is a fast and highly concurrent Go daemon that provides dynamic scaling of Nomad jobs and worker nodes</li>
+  <li><a href="https://github.com/jrasell/levant">levant</a> - Levant is an open source templating and deployment tool that provides realtime feedback and detailed failure messages upon deployment issues</li>
 </ul>
 
 <em>


### PR DESCRIPTION
This change requests that Levant be added to the Nomad community page. Levant is an open source templating and deployment tool for HashiCorp Nomad jobs that provides realtime feedback and detailed failure messages upon deployment issues. Further details about Levant can be seen on the [jrasell/levant](https://github.com/jrasell/levant) GitHub page.