### PR TITLE
Support StopTimeout for Docker tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ IMPROVEMENTS:
  * driver/docker: Adds support for adding host device to container via
    `--device` [GH-2938]
  * driver/docker: Adds support for `ulimit` and `sysctl` options [GH-3568]
+ * driver/docker: Adds support for StopTimeout (set to the same value as
+   kill_timeout [GH-3601]
  * driver/qemu: Support graceful shutdowns on unix platforms [GH-3411]
  * template: Updated to consul template 0.19.4 [GH-3543]
  * core/enterprise: Return 501 status code in Nomad Pro for Premium end points

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1047,11 +1047,12 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 	}
 
 	config := &docker.Config{
-		Image:     d.imageID,
-		Hostname:  driverConfig.Hostname,
-		User:      task.User,
-		Tty:       driverConfig.TTY,
-		OpenStdin: driverConfig.Interactive,
+		Image:       d.imageID,
+		Hostname:    driverConfig.Hostname,
+		User:        task.User,
+		Tty:         driverConfig.TTY,
+		OpenStdin:   driverConfig.Interactive,
+		StopTimeout: int(task.KillTimeout),
 	}
 
 	if driverConfig.WorkDir != "" {

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1052,7 +1052,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 		User:        task.User,
 		Tty:         driverConfig.TTY,
 		OpenStdin:   driverConfig.Interactive,
-		StopTimeout: int(task.KillTimeout),
+		StopTimeout: int(task.KillTimeout.Seconds()),
 	}
 
 	if driverConfig.WorkDir != "" {

--- a/vendor/github.com/fsouza/go-dockerclient/container.go
+++ b/vendor/github.com/fsouza/go-dockerclient/container.go
@@ -300,6 +300,7 @@ type Config struct {
 	ExposedPorts      map[Port]struct{}   `json:"ExposedPorts,omitempty" yaml:"ExposedPorts,omitempty" toml:"ExposedPorts,omitempty"`
 	PublishService    string              `json:"PublishService,omitempty" yaml:"PublishService,omitempty" toml:"PublishService,omitempty"`
 	StopSignal        string              `json:"StopSignal,omitempty" yaml:"StopSignal,omitempty" toml:"StopSignal,omitempty"`
+	StopTimeout       int                 `json:"StopTimeout,omitempty" yaml:"StopTimeout,omitempty" toml:"StopTimeout,omitempty"`
 	Env               []string            `json:"Env,omitempty" yaml:"Env,omitempty" toml:"Env,omitempty"`
 	Cmd               []string            `json:"Cmd" yaml:"Cmd" toml:"Cmd"`
 	Healthcheck       *HealthConfig       `json:"Healthcheck,omitempty" yaml:"Healthcheck,omitempty" toml:"Healthcheck,omitempty"`

--- a/vendor/github.com/fsouza/go-dockerclient/network.go
+++ b/vendor/github.com/fsouza/go-dockerclient/network.go
@@ -112,7 +112,7 @@ func (c *Client) NetworkInfo(id string) (*Network, error) {
 type CreateNetworkOptions struct {
 	Name           string                 `json:"Name" yaml:"Name" toml:"Name"`
 	Driver         string                 `json:"Driver" yaml:"Driver" toml:"Driver"`
-	IPAM           IPAMOptions            `json:"IPAM" yaml:"IPAM" toml:"IPAM"`
+	IPAM           *IPAMOptions           `json:"IPAM,omitempty" yaml:"IPAM" toml:"IPAM"`
 	Options        map[string]interface{} `json:"Options" yaml:"Options" toml:"Options"`
 	Labels         map[string]string      `json:"Labels" yaml:"Labels" toml:"Labels"`
 	CheckDuplicate bool                   `json:"CheckDuplicate" yaml:"CheckDuplicate" toml:"CheckDuplicate"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -561,10 +561,10 @@
 			"revisionTime": "2016-07-19T20:45:16Z"
 		},
 		{
-			"checksumSHA1": "Fo+DksVXnYQULqol7d07WDAtSMg=",
+			"checksumSHA1": "E+wmSQrc/BXzgITrbNAbUzljoiM=",
 			"path": "github.com/fsouza/go-dockerclient",
-			"revision": "f06d891e0d0f000caf614fa8c670985434ae2df2",
-			"revisionTime": "2017-11-14T14:45:54Z"
+			"revision": "5ffdfff51ec0eba739b1039e65ba3625ef25f7c0",
+			"revisionTime": "2017-11-23T03:37:03Z"
 		},
 		{
 			"comment": "v1.8.5-2-g6ec4abd",


### PR DESCRIPTION
This PR does the following: 
- Updates github.com/fsouza/go-dockerclient
- Allows StopTimeout for docker tasks to be set to kill_timeout

Fixes https://github.com/hashicorp/nomad/issues/3544