### PR TITLE
UI: Drop timezones from timestamps

### DIFF
--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -56,7 +56,7 @@
                   <em>No message</em>
                 {{/if}}
               </td>
-              <td>{{moment-format row.model.events.lastObject.time "MM/DD/YY HH:mm:ss [UTC]"}}</td>
+              <td>{{moment-format row.model.events.lastObject.time "MM/DD/YY HH:mm:ss"}}</td>
               <td>
                 <ul>
                   {{#each row.model.resources.networks.firstObject.reservedPorts as |port|}}

--- a/ui/app/templates/components/job-version.hbs
+++ b/ui/app/templates/components/job-version.hbs
@@ -6,7 +6,7 @@
   </span>
   <span class="pair is-faded version-submit-date">
     <span class="term">Submitted</span>
-    <span class="submit-date">{{moment-format version.submitTime "MM/DD/YY HH:mm:ss [UTC]"}}</span>
+    <span class="submit-date">{{moment-format version.submitTime "MM/DD/YY HH:mm:ss"}}</span>
   </span>
   {{#if version.diff}}
     <button class="button is-light is-compact pull-right" {{action "toggleDiff"}}>{{changeCount}} {{pluralize "Change" changeCount}}</button>

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -106,7 +106,7 @@ test('each task row should list high-level information for the task', function(a
       .find('td:eq(3)')
       .text()
       .trim(),
-    moment(event.time / 1000000).format('MM/DD/YY HH:mm:ss [UTC]'),
+    moment(event.time / 1000000).format('MM/DD/YY HH:mm:ss'),
     'Event Time'
   );
 

--- a/ui/tests/acceptance/job-versions-test.js
+++ b/ui/tests/acceptance/job-versions-test.js
@@ -40,7 +40,7 @@ test('each version mentions the version number, the stability, and the submitted
   );
   assert.equal(
     versionRow.find('.version-submit-date .submit-date').text(),
-    moment(version.submitTime / 1000000).format('MM/DD/YY HH:mm:ss [UTC]'),
+    moment(version.submitTime / 1000000).format('MM/DD/YY HH:mm:ss'),
     'Submit time'
   );
 });


### PR DESCRIPTION
All timestamps are displayed in the user's local timezone. In a perfect world, the timezone abbreviations would also be shown to be extra clear. In that same perfect world, JavaScript has a reasonable Date lib. 