### PR TITLE
UI: Warn uncaught exceptions to console

### DIFF
--- a/ui/DEVELOPMENT_MODE.md
+++ b/ui/DEVELOPMENT_MODE.md
@@ -1,0 +1,42 @@
+## Running the Web UI in development mode against a production Nomad cluster
+
+:warning: **Running the Web UI in development mode is only necessary when debugging
+issues. Unless you are debugging an issue, please only use the Web UI contained
+in the Nomad binary.** :warning:
+
+The production Web UI concatenates and minifies JavaScript and CSS. This can make errors
+cryptic or useless. In development mode, files are as expected and stack traces are useful.
+
+Debugging Web UI issues with the Web UI in development mode is done in three steps:
+
+  1. Cloning the Nomad Repo
+  2. Setting up your environment (or using Vagrant)
+  3. Serving the Web UI locally while proxying to the production Nomad cluster
+
+### Cloning the Nomad Repo
+
+The Web UI is part of the same repo as Nomad itself. Clone the repo
+[using Github](https://help.github.com/articles/cloning-a-repository/).
+
+### Setting up your environment
+
+The [Web UI README](README.md) includes a list of software prerequisites and instructions
+for running the UI locally or with the Vagrant VM.
+
+### Serving the Web UI locally while proxying to the production Nomad cluster
+
+Serving the Web UI is done with a single command in the `/ui` directory.
+
+  - **Local:** `ember serve`
+  - **Vagrant:** `ember serve --watch polling --port 4201`
+
+However, this will use the [Mirage fixtures](http://www.ember-cli-mirage.com/) as a backend.
+To use your own Nomad cluster as a backend, use the proxy option.
+
+  - **Local:** `ember serve --proxy https://demo.nomadproject.io`
+  - **Vagrant:** `ember serve --watch polling --port 4201 --proxy https://demo.nomadproject.io`
+
+The Web UI will now be accessible from your host machine.
+
+  - **Local:** [http://localhost:4200](http://localhost:4200)
+  - **Vagrant:** [http://localhost:4201](http://localhost:4201)

--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -33,6 +33,11 @@ export default Controller.extend({
       run.next(() => {
         throw this.get('error');
       });
+    } else {
+      run.next(() => {
+        // eslint-disable-next-line
+        console.warn('UNRECOVERABLE ERROR:', this.get('error'));
+      });
     }
   }),
 });


### PR DESCRIPTION
The UI currently gracefully handles runtime exceptions, but it doesn't do much in the way of saying what, why, or how.

Now in the event of the gray screen of death, a stack trace is warned to the developer console.
![image](https://user-images.githubusercontent.com/174740/33680382-4d4ab0dc-da76-11e7-8938-3c0ede5d52cd.png)

However, production stack traces aren't very helpful, so I also wrote a short guide on how to run the UI in dev mode from source while proxying to a different Nomad cluster.