### PR TITLE
Make tests running on Travis not be verbose

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,3 @@
-
 SHELL = bash
 PROJECT_ROOT := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 THIS_OS := $(shell uname)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -28,8 +28,6 @@ else
 VERBOSE="true"
 endif
 
-print-%  : ; @echo $* = $($*)
-
 
 ALL_TARGETS += linux_386 \
 	linux_amd64 \

--- a/scripts/test_check.sh
+++ b/scripts/test_check.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+echo "Exit code: $(cat exit-code)" >> test.log; 
+grep -A10 'panic: test timed out' test.log || true; 
+grep -A1 -- '--- SKIP:' test.log || true; 
+grep -A1 -- '--- FAIL:' test.log || true; 
+grep '^FAIL' test.log || true;
+exit_code=`cat exit-code`
+echo $exit_code 
+if [ ${exit_code} == "0" ]; then echo "PASS" ; exit 0 ; else echo "TESTS FAILED"; exit 1 ; fi 
+


### PR DESCRIPTION
Running without the TRAVIS env var set still retains verbose logs and prints out a list of failed tests