### PR TITLE
UI: Make sure the code element within a cli-window takes the full height

### DIFF
--- a/ui/app/styles/components/cli-window.scss
+++ b/ui/app/styles/components/cli-window.scss
@@ -5,6 +5,10 @@
   height: 500px;
   overflow: auto;
 
+  code {
+    height: 100%;
+  }
+
   .is-light {
     color: $text;
   }


### PR DESCRIPTION
Fixes this problem:

![image](https://user-images.githubusercontent.com/174740/33686785-d6f98da8-da8a-11e7-9837-b882dbbdeff1.png)
