### PR TITLE
Hash fields used in task service IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.7.1 (Unreleased)
 
 __BACKWARDS INCOMPATIBILITIES:__
+ * client: The format of service IDs in Consul has changed. If you rely upon
+   Nomad's service IDs (*not* service names; those are stable), you will need
+   to update your code.  [GH-3632]
  * config: Nomad no longer parses Atlas configuration stanzas. Atlas has been
    deprecated since earlier this year. If you have an Atlas stanza in your
    config file it will have to be removed.
@@ -57,6 +60,8 @@ BUG FIXES:
    explicitly [GH-3520]
  * cli: Fix passing Consul address via flags [GH-3504]
  * cli: Fix panic when running `keyring` commands [GH-3509]
+ * client: Fix advertising services with tags that require URL escaping
+   [GH-3632]
  * client: Fix a panic when restoring an allocation with a dead leader task
    [GH-3502]
  * client: Fix service/check updating when just interpolated variables change

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -1023,20 +1023,7 @@ func makeAgentServiceID(role string, service *structs.Service) string {
 //
 //	Example Service ID: _nomad-task-TNM333JKJPM5AK4FAS3VXQLXFDWOF4VH
 func makeTaskServiceID(allocID, taskName string, service *structs.Service) string {
-	h := sha1.New()
-	io.WriteString(h, allocID)
-	io.WriteString(h, taskName)
-	io.WriteString(h, service.Name)
-	io.WriteString(h, service.PortLabel)
-	io.WriteString(h, service.AddressMode)
-	for _, tag := range service.Tags {
-		io.WriteString(h, tag)
-	}
-
-	// Base32 is used for encoding the hash as sha1 hashes can always be
-	// encoded without padding, only 4 bytes larger than base64, and saves
-	// 8 bytes vs hex.
-	return nomadTaskPrefix + base32.StdEncoding.EncodeToString(h.Sum(nil))
+	return nomadTaskPrefix + service.Hash(allocID, taskName)
 }
 
 // makeCheckID creates a unique ID for a check.

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -116,7 +116,12 @@ func TestConsul_Integration(t *testing.T) {
 		{
 			Name:      "httpd2",
 			PortLabel: "http",
-			Tags:      []string{"test", "http2"},
+			Tags: []string{
+				"test",
+				// Use URL-unfriendly tags to test #3620
+				"public-test.ettaviation.com:80/ redirect=302,https://test.ettaviation.com",
+				"public-test.ettaviation.com:443/",
+			},
 		},
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3140,17 +3140,6 @@ func (s *Service) ValidateName(name string) error {
 	return nil
 }
 
-// Hash calculates the hash of the check based on it's content and the service
-// which owns it
-func (s *Service) Hash() string {
-	h := sha1.New()
-	io.WriteString(h, s.Name)
-	io.WriteString(h, strings.Join(s.Tags, ""))
-	io.WriteString(h, s.PortLabel)
-	io.WriteString(h, s.AddressMode)
-	return fmt.Sprintf("%x", h.Sum(nil))
-}
-
 const (
 	// DefaultKillTimeout is the default timeout between signaling a task it
 	// will be killed and killing it.


### PR DESCRIPTION
Fixes #3620

Previously we concatenated tags into task service IDs. This could break
deregistration of tag names that contained double //s like some Fabio
tags.

This change breaks service ID backward compatibility so on upgrade all
users services and checks will be removed and re-added with new IDs.

This change has the side effect of including all service fields in the
ID's hash, so we no longer have to track PortLabel and AddressMode
changes independently.