### PR TITLE
Fix for rpc_upgrade_mode

### DIFF
--- a/nomad/structs/config/tls.go
+++ b/nomad/structs/config/tls.go
@@ -166,5 +166,8 @@ func (t *TLSConfig) Merge(b *TLSConfig) *TLSConfig {
 	if b.VerifyHTTPSClient {
 		result.VerifyHTTPSClient = true
 	}
+	if b.RPCUpgradeMode {
+		result.RPCUpgradeMode = true
+	}
 	return result
 }

--- a/nomad/structs/config/tls_test.go
+++ b/nomad/structs/config/tls_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTLSConfig_Merge(t *testing.T) {
+	assert := assert.New(t)
+	a := &TLSConfig{
+		CAFile:   "test-ca-file",
+		CertFile: "test-cert-file",
+	}
+
+	b := &TLSConfig{
+		EnableHTTP:           true,
+		EnableRPC:            true,
+		VerifyServerHostname: true,
+		CAFile:               "test-ca-file-2",
+		CertFile:             "test-cert-file-2",
+		RPCUpgradeMode:       true,
+	}
+
+	new := a.Merge(b)
+	assert.Equal(b, new)
+}


### PR DESCRIPTION
The RPCUpgradeMode field was not included in the Merge() function for a TLSConfig