### PR TITLE
chown $GOPATH for vagrant user

### DIFF
--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -21,6 +21,7 @@ install_go
 	
 # Ensure that the GOPATH tree is owned by vagrant:vagrant
 mkdir -p /opt/gopath
+chown -R vagrant:vagrant /opt/gopath
 
 # Ensure Go is on PATH
 if [ ! -e /usr/bin/go ] ; then


### PR DESCRIPTION
Without this you get:

```
==> linux: ==> Updating build dependencies...
==> linux: go get -u github.com/kardianos/govendor
==> linux: package github.com/kardianos/govendor: mkdir /opt/gopath/src/github.com/kardianos/: permission denied
==> linux: GNUmakefile:141: recipe for target 'deps' failed
```