### PR TITLE
Skip tests that require root when not root

### DIFF
--- a/client/driver/lxc_test.go
+++ b/client/driver/lxc_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/client/config"
+	ctestutil "github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	lxc "gopkg.in/lxc/go-lxc.v2"
@@ -61,6 +62,7 @@ func TestLxcDriver_Start_Wait(t *testing.T) {
 	if !lxcPresent(t) {
 		t.Skip("lxc not present")
 	}
+	ctestutil.RequireRoot(t)
 
 	task := &structs.Task{
 		Name:   "foo",
@@ -137,6 +139,7 @@ func TestLxcDriver_Open_Wait(t *testing.T) {
 	if !lxcPresent(t) {
 		t.Skip("lxc not present")
 	}
+	ctestutil.RequireRoot(t)
 
 	task := &structs.Task{
 		Name:   "foo",

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -127,6 +127,7 @@ func TestQemuDriver_GracefulShutdown(t *testing.T) {
 		t.Parallel()
 	}
 	ctestutils.QemuCompatible(t)
+	ctestutils.RequireRoot(t)
 	task := &structs.Task{
 		Name:   "linux",
 		Driver: "qemu",

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -7,6 +7,13 @@ import (
 	"testing"
 )
 
+// RequireRoot skips tests unless running on a Unix as root.
+func RequireRoot(t *testing.T) {
+	if syscall.Geteuid() != 0 {
+		t.Skip("Must run as root on Unix")
+	}
+}
+
 func ExecCompatible(t *testing.T) {
 	if runtime.GOOS != "linux" || syscall.Geteuid() != 0 {
 		t.Skip("Test only available running as root on linux")


### PR DESCRIPTION
Also skip Chown on allocdir migration on Windows and when non-root.
Windows doesn't support it, and it will always fail as a non-root user.