### PR TITLE
Update template.html.md Vault template example

### DIFF
--- a/website/source/docs/job-specification/template.html.md
+++ b/website/source/docs/job-specification/template.html.md
@@ -191,7 +191,7 @@ template {
 
 # Empty lines are also ignored
 LOG_LEVEL="{{key "service/geo-api/log-verbosity"}}"
-API_KEY="{{with secret "secret/geo-api-key"}}{{.Data.key}}{{end}}"
+API_KEY="{{with secret "secret/geo-api-key"}}{{.Data.value}}{{end}}"
 EOH
 
   destination = "secrets/file.env"


### PR DESCRIPTION
The change updates the Vault example within the Environment Variables section to use the `.value` notation rather than the `.key` notation. This is because the example is calling a specific secret key and populating an env var with this; meaning the value of the secret is required over the value.