### PR TITLE
UI: Dependency upgrades - Use ember modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ git:
 branches:
   only:
     - master
+    - f-ui-upgrade-deps
 
 matrix:
   include:

--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -1,15 +1,14 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { computed, get } from '@ember/object';
 import RESTAdapter from 'ember-data/adapters/rest';
 import codesForError from '../utils/codes-for-error';
-
-const { get, computed, inject } = Ember;
 
 export const namespace = 'v1';
 
 export default RESTAdapter.extend({
   namespace,
 
-  token: inject.service(),
+  token: service(),
 
   headers: computed('token.secret', function() {
     const token = this.get('token.secret');

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import RSVP from 'rsvp';
+import { assign } from '@ember/polyfills';
 import ApplicationAdapter from './application';
 
-const { RSVP, inject, assign } = Ember;
-
 export default ApplicationAdapter.extend({
-  system: inject.service(),
+  system: service(),
 
   shouldReloadAll: () => true,
 

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
 import { default as ApplicationAdapter, namespace } from './application';
 
-const { inject } = Ember;
-
 export default ApplicationAdapter.extend({
-  store: inject.service(),
+  store: service(),
 
   namespace: namespace + '/acl',
 

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -1,3 +1,4 @@
+import Application from '@ember/application';
 import Ember from 'ember';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
@@ -7,10 +8,10 @@ let App;
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver
+  Resolver,
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -1,12 +1,9 @@
 import Application from '@ember/application';
-import Ember from 'ember';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 let App;
-
-Ember.MODEL_FACTORY_INJECTIONS = true;
 
 App = Application.extend({
   modulePrefix: config.modulePrefix,

--- a/ui/app/components/allocation-row.js
+++ b/ui/app/components/allocation-row.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+import { run } from '@ember/runloop';
 import { lazyClick } from '../helpers/lazy-click';
 
-const { Component, inject, run } = Ember;
-
 export default Component.extend({
-  store: inject.service(),
+  store: service(),
 
   tagName: 'tr',
 

--- a/ui/app/components/allocation-status-bar.js
+++ b/ui/app/components/allocation-status-bar.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
 import DistributionBar from './distribution-bar';
-
-const { computed } = Ember;
 
 export default DistributionBar.extend({
   layoutName: 'components/distribution-bar',

--- a/ui/app/components/attributes-section.js
+++ b/ui/app/components/attributes-section.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Component } = Ember;
+import Component from '@ember/component';
 
 export default Component.extend({
   tagName: '',

--- a/ui/app/components/client-node-row.js
+++ b/ui/app/components/client-node-row.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import { lazyClick } from '../helpers/lazy-click';
-
-const { Component } = Ember;
 
 export default Component.extend({
   tagName: 'tr',

--- a/ui/app/components/distribution-bar.js
+++ b/ui/app/components/distribution-bar.js
@@ -1,10 +1,13 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { run } from '@ember/runloop';
+import { assign } from '@ember/polyfills';
+import { guidFor } from '@ember/object/internals';
 import d3 from 'npm:d3-selection';
 import 'npm:d3-transition';
 import WindowResizable from '../mixins/window-resizable';
 import styleStringProperty from '../utils/properties/style-string';
 
-const { Component, computed, run, assign, guidFor } = Ember;
 const sumAggregate = (total, val) => total + val;
 
 export default Component.extend(WindowResizable, {

--- a/ui/app/components/gutter-menu.js
+++ b/ui/app/components/gutter-menu.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
-
-const { Component, inject, computed } = Ember;
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
-  system: inject.service(),
+  system: service(),
 
   sortedNamespaces: computed('system.namespaces.@each.name', function() {
     const namespaces = this.get('system.namespaces').toArray() || [];

--- a/ui/app/components/job-deployment.js
+++ b/ui/app/components/job-deployment.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Component } = Ember;
+import Component from '@ember/component';
 
 export default Component.extend({
   classNames: ['job-deployment', 'boxed-section'],

--- a/ui/app/components/job-deployment/deployment-metrics.js
+++ b/ui/app/components/job-deployment/deployment-metrics.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Component } = Ember;
+import Component from '@ember/component';
 
 export default Component.extend({
   tagName: '',

--- a/ui/app/components/job-deployments-stream.js
+++ b/ui/app/components/job-deployments-stream.js
@@ -1,7 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 import moment from 'moment';
-
-const { Component, computed } = Ember;
 
 export default Component.extend({
   tagName: 'ol',

--- a/ui/app/components/job-diff-fields-and-objects.js
+++ b/ui/app/components/job-diff-fields-and-objects.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Component } = Ember;
+import Component from '@ember/component';
 
 export default Component.extend({
   tagName: '',

--- a/ui/app/components/job-diff.js
+++ b/ui/app/components/job-diff.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Component, computed } = Ember;
+import { equal } from '@ember/object/computed';
+import Component from '@ember/component';
 
 export default Component.extend({
   classNames: ['job-diff'],
@@ -10,7 +9,7 @@ export default Component.extend({
 
   verbose: true,
 
-  isEdited: computed.equal('diff.Type', 'Edited'),
-  isAdded: computed.equal('diff.Type', 'Added'),
-  isDeleted: computed.equal('diff.Type', 'Deleted'),
+  isEdited: equal('diff.Type', 'Edited'),
+  isAdded: equal('diff.Type', 'Added'),
+  isDeleted: equal('diff.Type', 'Deleted'),
 });

--- a/ui/app/components/job-row.js
+++ b/ui/app/components/job-row.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import { lazyClick } from '../helpers/lazy-click';
-
-const { Component } = Ember;
 
 export default Component.extend({
   tagName: 'tr',

--- a/ui/app/components/job-version.js
+++ b/ui/app/components/job-version.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Component, computed } = Ember;
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 const changeTypes = ['Added', 'Deleted', 'Edited'];
 

--- a/ui/app/components/job-versions-stream.js
+++ b/ui/app/components/job-versions-stream.js
@@ -1,7 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 import moment from 'moment';
-
-const { Component, computed } = Ember;
 
 export default Component.extend({
   tagName: 'ol',

--- a/ui/app/components/json-viewer.js
+++ b/ui/app/components/json-viewer.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { run } from '@ember/runloop';
 import JSONFormatterPkg from 'npm:json-formatter-js';
-
-const { Component, computed, run } = Ember;
 
 // json-formatter-js is packaged in a funny way that ember-cli-browserify
 // doesn't unwrap properly.

--- a/ui/app/components/list-pagination.js
+++ b/ui/app/components/list-pagination.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Component, computed } = Ember;
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   source: computed(() => []),
@@ -31,9 +30,11 @@ export default Component.extend({
     const lowerBound = Math.max(1, page - spread);
     const upperBound = Math.min(lastPage, page + spread) + 1;
 
-    return Array(upperBound - lowerBound).fill(null).map((_, index) => ({
-      pageNumber: lowerBound + index,
-    }));
+    return Array(upperBound - lowerBound)
+      .fill(null)
+      .map((_, index) => ({
+        pageNumber: lowerBound + index,
+      }));
   }),
 
   list: computed('source.[]', 'page', 'size', function() {

--- a/ui/app/components/list-pagination/list-pager.js
+++ b/ui/app/components/list-pagination/list-pager.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Component } = Ember;
+import Component from '@ember/component';
 
 export default Component.extend({
   tagName: '',

--- a/ui/app/components/list-table.js
+++ b/ui/app/components/list-table.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Component, computed } = Ember;
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   tagName: 'table',

--- a/ui/app/components/list-table/sort-by.js
+++ b/ui/app/components/list-table/sort-by.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Component, computed } = Ember;
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   tagName: 'th',

--- a/ui/app/components/list-table/table-body.js
+++ b/ui/app/components/list-table/table-body.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Component } = Ember;
+import Component from '@ember/component';
 
 export default Component.extend({
   tagName: 'tbody',

--- a/ui/app/components/list-table/table-head.js
+++ b/ui/app/components/list-table/table-head.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Component } = Ember;
+import Component from '@ember/component';
 
 export default Component.extend({
   tagName: 'thead',

--- a/ui/app/components/search-box.js
+++ b/ui/app/components/search-box.js
@@ -1,13 +1,13 @@
-import Ember from 'ember';
-
-const { Component, computed, run } = Ember;
+import { reads } from '@ember/object/computed';
+import Component from '@ember/component';
+import { run } from '@ember/runloop';
 
 export default Component.extend({
   // Passed to the component (mutable)
   searchTerm: null,
 
   // Used as a debounce buffer
-  _searchTerm: computed.reads('searchTerm'),
+  _searchTerm: reads('searchTerm'),
 
   // Used to throttle sets to searchTerm
   debounce: 150,

--- a/ui/app/components/server-agent-row.js
+++ b/ui/app/components/server-agent-row.js
@@ -1,14 +1,15 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { alias } from '@ember/object/computed';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { lazyClick } from '../helpers/lazy-click';
-
-const { Component, inject, computed } = Ember;
 
 export default Component.extend({
   // TODO Switch back to the router service once the service behaves more like Route
   // https://github.com/emberjs/ember.js/issues/15801
   // router: inject.service('router'),
-  _router: inject.service('-routing'),
-  router: computed.alias('_router.router'),
+  _router: service('-routing'),
+  router: alias('_router.router'),
 
   tagName: 'tr',
   classNames: ['server-agent-row', 'is-interactive'],

--- a/ui/app/components/task-group-row.js
+++ b/ui/app/components/task-group-row.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import { lazyClick } from '../helpers/lazy-click';
-
-const { Component } = Ember;
 
 export default Component.extend({
   tagName: 'tr',

--- a/ui/app/components/task-log.js
+++ b/ui/app/components/task-log.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { run } from '@ember/runloop';
 import { task } from 'ember-concurrency';
 import { logger } from 'nomad-ui/utils/classes/log';
 import WindowResizable from 'nomad-ui/mixins/window-resizable';
 
-const { Component, computed, inject, run } = Ember;
-
 export default Component.extend(WindowResizable, {
-  token: inject.service(),
+  token: service(),
 
   classNames: ['boxed-section', 'task-log'],
 

--- a/ui/app/controllers/allocations/allocation.js
+++ b/ui/app/controllers/allocations/allocation.js
@@ -1,5 +1,3 @@
-import Ember from 'ember';
-
-const { Controller } = Ember;
+import Controller from '@ember/controller';
 
 export default Controller.extend({});

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -1,7 +1,6 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import Controller from '@ember/controller';
 import Sortable from 'nomad-ui/mixins/sortable';
-
-const { Controller, computed } = Ember;
 
 export default Controller.extend(Sortable, {
   queryParams: {
@@ -12,6 +11,6 @@ export default Controller.extend(Sortable, {
   sortProperty: 'name',
   sortDescending: false,
 
-  listToSort: computed.alias('model.states'),
-  sortedStates: computed.alias('listSorted'),
+  listToSort: alias('model.states'),
+  sortedStates: alias('listSorted'),
 });

--- a/ui/app/controllers/allocations/allocation/task/index.js
+++ b/ui/app/controllers/allocations/allocation/task/index.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
-
-const { Controller, computed } = Ember;
+import { alias } from '@ember/object/computed';
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 
 export default Controller.extend({
-  network: computed.alias('model.resources.networks.firstObject'),
+  network: alias('model.resources.networks.firstObject'),
   ports: computed('network.reservedPorts.[]', 'network.dynamicPorts.[]', function() {
     return (this.get('network.reservedPorts') || [])
       .map(port => ({

--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -1,10 +1,12 @@
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+import { run } from '@ember/runloop';
+import { observer, computed } from '@ember/object';
 import Ember from 'ember';
 import codesForError from '../utils/codes-for-error';
 
-const { Controller, computed, inject, run, observer } = Ember;
-
 export default Controller.extend({
-  config: inject.service(),
+  config: service(),
 
   error: null,
 

--- a/ui/app/controllers/clients.js
+++ b/ui/app/controllers/clients.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Controller } = Ember;
+import Controller from '@ember/controller';
 
 export default Controller.extend({
   isForbidden: false,

--- a/ui/app/controllers/clients/client.js
+++ b/ui/app/controllers/clients/client.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 import Sortable from 'nomad-ui/mixins/sortable';
 import Searchable from 'nomad-ui/mixins/searchable';
-
-const { Controller, computed } = Ember;
 
 export default Controller.extend(Sortable, Searchable, {
   queryParams: {
@@ -20,9 +20,9 @@ export default Controller.extend(Sortable, Searchable, {
 
   searchProps: computed(() => ['shortId', 'name']),
 
-  listToSort: computed.alias('model.allocations'),
-  listToSearch: computed.alias('listSorted'),
-  sortedAllocations: computed.alias('listSearched'),
+  listToSort: alias('model.allocations'),
+  listToSearch: alias('listSorted'),
+  sortedAllocations: alias('listSearched'),
 
   actions: {
     gotoAllocation(allocation) {

--- a/ui/app/controllers/clients/index.js
+++ b/ui/app/controllers/clients/index.js
@@ -1,14 +1,14 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import Controller, { inject as controller } from '@ember/controller';
+import { computed } from '@ember/object';
 import Sortable from 'nomad-ui/mixins/sortable';
 import Searchable from 'nomad-ui/mixins/searchable';
 
-const { Controller, computed, inject } = Ember;
-
 export default Controller.extend(Sortable, Searchable, {
-  clientsController: inject.controller('clients'),
+  clientsController: controller('clients'),
 
-  nodes: computed.alias('model.nodes'),
-  agents: computed.alias('model.agents'),
+  nodes: alias('model.nodes'),
+  agents: alias('model.agents'),
 
   queryParams: {
     currentPage: 'page',
@@ -25,11 +25,11 @@ export default Controller.extend(Sortable, Searchable, {
 
   searchProps: computed(() => ['id', 'name', 'datacenter']),
 
-  listToSort: computed.alias('nodes'),
-  listToSearch: computed.alias('listSorted'),
-  sortedNodes: computed.alias('listSearched'),
+  listToSort: alias('nodes'),
+  listToSearch: alias('listSorted'),
+  sortedNodes: alias('listSearched'),
 
-  isForbidden: computed.alias('clientsController.isForbidden'),
+  isForbidden: alias('clientsController.isForbidden'),
 
   actions: {
     gotoNode(node) {

--- a/ui/app/controllers/freestyle.js
+++ b/ui/app/controllers/freestyle.js
@@ -1,10 +1,9 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import FreestyleController from 'ember-freestyle/controllers/freestyle';
 
-const { inject, computed } = Ember;
-
 export default FreestyleController.extend({
-  emberFreestyle: inject.service(),
+  emberFreestyle: service(),
 
   timerTicks: 0,
 

--- a/ui/app/controllers/jobs.js
+++ b/ui/app/controllers/jobs.js
@@ -1,9 +1,10 @@
-import Ember from 'ember';
-
-const { Controller, inject, observer, run } = Ember;
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+import { observer } from '@ember/object';
+import { run } from '@ember/runloop';
 
 export default Controller.extend({
-  system: inject.service(),
+  system: service(),
 
   queryParams: {
     jobNamespace: 'namespace',

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -1,18 +1,19 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { alias, filterBy } from '@ember/object/computed';
+import Controller, { inject as controller } from '@ember/controller';
+import { computed } from '@ember/object';
 import Sortable from 'nomad-ui/mixins/sortable';
 import Searchable from 'nomad-ui/mixins/searchable';
 
-const { Controller, computed, inject } = Ember;
-
 export default Controller.extend(Sortable, Searchable, {
-  system: inject.service(),
-  jobsController: inject.controller('jobs'),
+  system: service(),
+  jobsController: controller('jobs'),
 
-  isForbidden: computed.alias('jobsController.isForbidden'),
+  isForbidden: alias('jobsController.isForbidden'),
 
-  pendingJobs: computed.filterBy('model', 'status', 'pending'),
-  runningJobs: computed.filterBy('model', 'status', 'running'),
-  deadJobs: computed.filterBy('model', 'status', 'dead'),
+  pendingJobs: filterBy('model', 'status', 'pending'),
+  runningJobs: filterBy('model', 'status', 'running'),
+  deadJobs: filterBy('model', 'status', 'dead'),
 
   queryParams: {
     currentPage: 'page',
@@ -42,9 +43,9 @@ export default Controller.extend(Sortable, Searchable, {
     }
   ),
 
-  listToSort: computed.alias('filteredJobs'),
-  listToSearch: computed.alias('listSorted'),
-  sortedJobs: computed.alias('listSearched'),
+  listToSort: alias('filteredJobs'),
+  listToSearch: alias('listSorted'),
+  sortedJobs: alias('listSearched'),
 
   isShowingDeploymentDetails: false,
 

--- a/ui/app/controllers/jobs/job.js
+++ b/ui/app/controllers/jobs/job.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Controller, computed } = Ember;
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 
 export default Controller.extend({
   breadcrumbs: computed('model.{name,id}', function() {

--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -1,12 +1,11 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import Controller, { inject as controller } from '@ember/controller';
 import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 
-const { Controller, computed, inject } = Ember;
-
 export default Controller.extend(WithNamespaceResetting, {
-  jobController: inject.controller('jobs.job'),
+  jobController: controller('jobs.job'),
 
-  job: computed.alias('model.job'),
+  job: alias('model.job'),
 
-  breadcrumbs: computed.alias('jobController.breadcrumbs'),
+  breadcrumbs: alias('jobController.breadcrumbs'),
 });

--- a/ui/app/controllers/jobs/job/deployments.js
+++ b/ui/app/controllers/jobs/job/deployments.js
@@ -1,13 +1,12 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import Controller, { inject as controller } from '@ember/controller';
 import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 
-const { Controller, computed, inject } = Ember;
-
 export default Controller.extend(WithNamespaceResetting, {
-  jobController: inject.controller('jobs.job'),
+  jobController: controller('jobs.job'),
 
-  job: computed.alias('model'),
-  deployments: computed.alias('model.deployments'),
+  job: alias('model'),
+  deployments: alias('model.deployments'),
 
-  breadcrumbs: computed.alias('jobController.breadcrumbs'),
+  breadcrumbs: alias('jobController.breadcrumbs'),
 });

--- a/ui/app/controllers/jobs/job/index.js
+++ b/ui/app/controllers/jobs/job/index.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { alias } from '@ember/object/computed';
+import Controller, { inject as controller } from '@ember/controller';
+import { computed } from '@ember/object';
 import Sortable from 'nomad-ui/mixins/sortable';
 import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 
-const { Controller, computed, inject } = Ember;
-
 export default Controller.extend(Sortable, WithNamespaceResetting, {
-  system: inject.service(),
-  jobController: inject.controller('jobs.job'),
+  system: service(),
+  jobController: controller('jobs.job'),
 
   queryParams: {
     currentPage: 'page',
@@ -20,15 +21,15 @@ export default Controller.extend(Sortable, WithNamespaceResetting, {
   sortProperty: 'name',
   sortDescending: false,
 
-  breadcrumbs: computed.alias('jobController.breadcrumbs'),
-  job: computed.alias('model'),
+  breadcrumbs: alias('jobController.breadcrumbs'),
+  job: alias('model'),
 
   taskGroups: computed('model.taskGroups.[]', function() {
     return this.get('model.taskGroups') || [];
   }),
 
-  listToSort: computed.alias('taskGroups'),
-  sortedTaskGroups: computed.alias('listSorted'),
+  listToSort: alias('taskGroups'),
+  sortedTaskGroups: alias('listSorted'),
 
   sortedEvaluations: computed('model.evaluations.@each.modifyIndex', function() {
     return (this.get('model.evaluations') || []).sortBy('modifyIndex').reverse();

--- a/ui/app/controllers/jobs/job/loading.js
+++ b/ui/app/controllers/jobs/job/loading.js
@@ -1,8 +1,7 @@
-import Ember from 'ember';
-
-const { Controller, computed, inject } = Ember;
+import { alias } from '@ember/object/computed';
+import Controller, { inject as controller } from '@ember/controller';
 
 export default Controller.extend({
-  jobController: inject.controller('jobs.job'),
-  breadcrumbs: computed.alias('jobController.breadcrumbs'),
+  jobController: controller('jobs.job'),
+  breadcrumbs: alias('jobController.breadcrumbs'),
 });

--- a/ui/app/controllers/jobs/job/task-group.js
+++ b/ui/app/controllers/jobs/job/task-group.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import Controller, { inject as controller } from '@ember/controller';
+import { computed } from '@ember/object';
 import Sortable from 'nomad-ui/mixins/sortable';
 import Searchable from 'nomad-ui/mixins/searchable';
 import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 
-const { Controller, computed, inject } = Ember;
-
 export default Controller.extend(Sortable, Searchable, WithNamespaceResetting, {
-  jobController: inject.controller('jobs.job'),
+  jobController: controller('jobs.job'),
 
   queryParams: {
     currentPage: 'page',
@@ -27,9 +27,9 @@ export default Controller.extend(Sortable, Searchable, WithNamespaceResetting, {
     return this.get('model.allocations') || [];
   }),
 
-  listToSort: computed.alias('allocations'),
-  listToSearch: computed.alias('listSorted'),
-  sortedAllocations: computed.alias('listSearched'),
+  listToSort: alias('allocations'),
+  listToSearch: alias('listSorted'),
+  sortedAllocations: alias('listSearched'),
 
   breadcrumbs: computed('jobController.breadcrumbs.[]', 'model.{name}', function() {
     return this.get('jobController.breadcrumbs').concat([

--- a/ui/app/controllers/jobs/job/versions.js
+++ b/ui/app/controllers/jobs/job/versions.js
@@ -1,13 +1,12 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import Controller, { inject as controller } from '@ember/controller';
 import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 
-const { Controller, computed, inject } = Ember;
-
 export default Controller.extend(WithNamespaceResetting, {
-  jobController: inject.controller('jobs.job'),
+  jobController: controller('jobs.job'),
 
-  job: computed.alias('model'),
-  versions: computed.alias('model.versions'),
+  job: alias('model'),
+  versions: alias('model.versions'),
 
-  breadcrumbs: computed.alias('jobController.breadcrumbs'),
+  breadcrumbs: alias('jobController.breadcrumbs'),
 });

--- a/ui/app/controllers/servers.js
+++ b/ui/app/controllers/servers.js
@@ -1,11 +1,10 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import Controller from '@ember/controller';
 import Sortable from 'nomad-ui/mixins/sortable';
 
-const { Controller, computed } = Ember;
-
 export default Controller.extend(Sortable, {
-  nodes: computed.alias('model.nodes'),
-  agents: computed.alias('model.agents'),
+  nodes: alias('model.nodes'),
+  agents: alias('model.agents'),
 
   queryParams: {
     currentPage: 'page',
@@ -21,6 +20,6 @@ export default Controller.extend(Sortable, {
 
   isForbidden: false,
 
-  listToSort: computed.alias('agents'),
-  sortedAgents: computed.alias('listSorted'),
+  listToSort: alias('agents'),
+  sortedAgents: alias('listSorted'),
 });

--- a/ui/app/controllers/servers/index.js
+++ b/ui/app/controllers/servers/index.js
@@ -1,8 +1,7 @@
-import Ember from 'ember';
-
-const { Controller, computed, inject } = Ember;
+import { alias } from '@ember/object/computed';
+import Controller, { inject as controller } from '@ember/controller';
 
 export default Controller.extend({
-  serversController: inject.controller('servers'),
-  isForbidden: computed.alias('serversController.isForbidden'),
+  serversController: controller('servers'),
+  isForbidden: alias('serversController.isForbidden'),
 });

--- a/ui/app/controllers/servers/server.js
+++ b/ui/app/controllers/servers/server.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Controller, computed } = Ember;
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 
 export default Controller.extend({
   activeTab: 'tags',

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
-
-const { Controller, inject, computed, getOwner } = Ember;
+import { inject as service } from '@ember/service';
+import { reads } from '@ember/object/computed';
+import Controller from '@ember/controller';
+import { getOwner } from '@ember/application';
 
 export default Controller.extend({
-  token: inject.service(),
-  store: inject.service(),
+  token: service(),
+  store: service(),
 
-  secret: computed.reads('token.secret'),
+  secret: reads('token.secret'),
 
   tokenIsValid: false,
   tokenIsInvalid: false,

--- a/ui/app/helpers/css-class.js
+++ b/ui/app/helpers/css-class.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 /**
  * CSS Class
@@ -12,4 +12,4 @@ export function cssClass([updateType]) {
   return updateType.replace(/\//g, '-').dasherize();
 }
 
-export default Ember.Helper.helper(cssClass);
+export default helper(cssClass);

--- a/ui/app/helpers/format-bytes.js
+++ b/ui/app/helpers/format-bytes.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Helper } = Ember;
+import Helper from '@ember/component/helper';
 
 const UNITS = ['Bytes', 'KiB', 'MiB'];
 

--- a/ui/app/helpers/format-percentage.js
+++ b/ui/app/helpers/format-percentage.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 /**
  * Percentage Calculator
@@ -35,4 +35,4 @@ function safeNumber(value) {
   return isNaN(value) ? 0 : +value;
 }
 
-export default Ember.Helper.helper(formatPercentage);
+export default helper(formatPercentage);

--- a/ui/app/helpers/is-object.js
+++ b/ui/app/helpers/is-object.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Helper } = Ember;
+import Helper from '@ember/component/helper';
 
 export function isObject([value]) {
   const isObject = !Array.isArray(value) && value !== null && typeof value === 'object';

--- a/ui/app/helpers/lazy-click.js
+++ b/ui/app/helpers/lazy-click.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Helper, $ } = Ember;
+import Helper from '@ember/component/helper';
+import $ from 'jquery';
 
 /**
  * Lazy Click Event

--- a/ui/app/helpers/pluralize.js
+++ b/ui/app/helpers/pluralize.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Helper } = Ember;
+import Helper from '@ember/component/helper';
 
 export function pluralize([term, count]) {
   return count === 1 ? term : term.pluralize();

--- a/ui/app/helpers/x-icon.js
+++ b/ui/app/helpers/x-icon.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 import { inlineSvg } from 'ember-inline-svg/helpers/inline-svg';
 
 // Generated at compile-time by ember-inline-svg
@@ -18,4 +18,4 @@ export function xIcon(params, options) {
   return inlineSvg(SVGs, name, { class: classes });
 }
 
-export default Ember.Helper.helper(xIcon);
+export default helper(xIcon);

--- a/ui/app/mixins/searchable.js
+++ b/ui/app/mixins/searchable.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Mixin, computed, get } = Ember;
+import Mixin from '@ember/object/mixin';
+import { get, computed } from '@ember/object';
 
 /**
   Searchable mixin

--- a/ui/app/mixins/sortable.js
+++ b/ui/app/mixins/sortable.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Mixin, computed } = Ember;
+import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
 
 /**
   Sortable mixin

--- a/ui/app/mixins/window-resizable.js
+++ b/ui/app/mixins/window-resizable.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import Mixin from '@ember/object/mixin';
+import { run } from '@ember/runloop';
+import $ from 'jquery';
 
-const { run, $ } = Ember;
-
-export default Ember.Mixin.create({
+export default Mixin.create({
   setupWindowResize: function() {
     run.scheduleOnce('afterRender', this, () => {
       this.set('_windowResizeHandler', this.get('windowResizeHandler').bind(this));

--- a/ui/app/mixins/with-forbidden-state.js
+++ b/ui/app/mixins/with-forbidden-state.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Mixin } = Ember;
+import Mixin from '@ember/object/mixin';
 
 export default Mixin.create({
   setupController(controller) {

--- a/ui/app/mixins/with-model-error-handling.js
+++ b/ui/app/mixins/with-model-error-handling.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import Mixin from '@ember/object/mixin';
 import notifyError from 'nomad-ui/utils/notify-error';
-
-const { Mixin } = Ember;
 
 export default Mixin.create({
   model() {

--- a/ui/app/mixins/with-namespace-resetting.js
+++ b/ui/app/mixins/with-namespace-resetting.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
-
-const { Mixin, inject } = Ember;
+import { inject as controller } from '@ember/controller';
+import { inject as service } from '@ember/service';
+import Mixin from '@ember/object/mixin';
 
 export default Mixin.create({
-  system: inject.service(),
-  jobsController: inject.controller('jobs'),
+  system: service(),
+  jobsController: controller('jobs'),
 
   actions: {
     gotoJobs(namespace) {

--- a/ui/app/models/agent.js
+++ b/ui/app/models/agent.js
@@ -1,11 +1,10 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 
-const { computed, inject } = Ember;
-
 export default Model.extend({
-  system: inject.service(),
+  system: service(),
 
   name: attr('string'),
   address: attr('string'),

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -1,4 +1,7 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { readOnly } from '@ember/object/computed';
+import { computed } from '@ember/object';
+import RSVP from 'rsvp';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
@@ -6,8 +9,6 @@ import { fragment, fragmentArray } from 'ember-data-model-fragments/attributes';
 import PromiseObject from '../utils/classes/promise-object';
 import timeout from '../utils/timeout';
 import shortUUIDProperty from '../utils/properties/short-uuid';
-
-const { computed, RSVP, inject } = Ember;
 
 const STATUS_ORDER = {
   pending: 1,
@@ -18,7 +19,7 @@ const STATUS_ORDER = {
 };
 
 export default Model.extend({
-  token: inject.service(),
+  token: service(),
 
   shortId: shortUUIDProperty('id'),
   job: belongsTo('job'),
@@ -56,7 +57,7 @@ export default Model.extend({
     return taskGroups && taskGroups.findBy('name', this.get('taskGroupName'));
   }),
 
-  memoryUsed: computed.readOnly('stats.ResourceUsage.MemoryStats.RSS'),
+  memoryUsed: readOnly('stats.ResourceUsage.MemoryStats.RSS'),
   cpuUsed: computed('stats.ResourceUsage.CpuStats.TotalTicks', function() {
     return Math.floor(this.get('stats.ResourceUsage.CpuStats.TotalTicks') || 0);
   }),

--- a/ui/app/models/deployment.js
+++ b/ui/app/models/deployment.js
@@ -1,12 +1,11 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import { computed } from '@ember/object';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 import { fragmentArray } from 'ember-data-model-fragments/attributes';
 import shortUUIDProperty from '../utils/properties/short-uuid';
 import sumAggregation from '../utils/properties/sum-aggregation';
-
-const { computed } = Ember;
 
 export default Model.extend({
   shortId: shortUUIDProperty('id'),
@@ -35,7 +34,7 @@ export default Model.extend({
   }),
 
   // Dependent keys can only go one level past an @each so an alias is needed
-  versionSubmitTime: computed.alias('version.submitTime'),
+  versionSubmitTime: alias('version.submitTime'),
 
   placedCanaries: sumAggregation('taskGroupSummaries', 'placedCanaries'),
   desiredCanaries: sumAggregation('taskGroupSummaries', 'desiredCanaries'),

--- a/ui/app/models/evaluation.js
+++ b/ui/app/models/evaluation.js
@@ -1,11 +1,9 @@
-import Ember from 'ember';
+import { bool } from '@ember/object/computed';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
 import { fragmentArray } from 'ember-data-model-fragments/attributes';
 import shortUUIDProperty from '../utils/properties/short-uuid';
-
-const { computed } = Ember;
 
 export default Model.extend({
   shortId: shortUUIDProperty('id'),
@@ -16,7 +14,7 @@ export default Model.extend({
   statusDescription: attr('string'),
   failedTGAllocs: fragmentArray('placement-failure', { defaultValue: () => [] }),
 
-  hasPlacementFailures: computed.bool('failedTGAllocs.length'),
+  hasPlacementFailures: bool('failedTGAllocs.length'),
 
   // TEMPORARY: https://github.com/emberjs/data/issues/5209
   originalJobId: attr('string'),

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -1,11 +1,10 @@
-import Ember from 'ember';
+import { collect, sum, bool, equal } from '@ember/object/computed';
+import { computed } from '@ember/object';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 import { fragmentArray } from 'ember-data-model-fragments/attributes';
 import sumAggregation from '../utils/properties/sum-aggregation';
-
-const { computed } = Ember;
 
 export default Model.extend({
   region: attr('string'),
@@ -35,7 +34,7 @@ export default Model.extend({
   failedAllocs: sumAggregation('taskGroupSummaries', 'failedAllocs'),
   lostAllocs: sumAggregation('taskGroupSummaries', 'lostAllocs'),
 
-  allocsList: computed.collect(
+  allocsList: collect(
     'queuedAllocs',
     'startingAllocs',
     'runningAllocs',
@@ -44,7 +43,7 @@ export default Model.extend({
     'lostAllocs'
   ),
 
-  totalAllocs: computed.sum('allocsList'),
+  totalAllocs: sum('allocsList'),
 
   pendingChildren: attr('number'),
   runningChildren: attr('number'),
@@ -56,7 +55,7 @@ export default Model.extend({
   evaluations: hasMany('evaluations'),
   namespace: belongsTo('namespace'),
 
-  hasPlacementFailures: computed.bool('latestFailureEvaluation'),
+  hasPlacementFailures: bool('latestFailureEvaluation'),
 
   latestEvaluation: computed('evaluations.@each.modifyIndex', 'evaluations.isPending', function() {
     const evaluations = this.get('evaluations');
@@ -82,7 +81,7 @@ export default Model.extend({
     }
   ),
 
-  supportsDeployments: computed.equal('type', 'service'),
+  supportsDeployments: equal('type', 'service'),
 
   runningDeployment: computed('deployments.@each.status', function() {
     return this.get('deployments').findBy('status', 'running');

--- a/ui/app/models/namespace.js
+++ b/ui/app/models/namespace.js
@@ -1,11 +1,9 @@
-import Ember from 'ember';
+import { readOnly } from '@ember/object/computed';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 
-const { computed } = Ember;
-
 export default Model.extend({
-  name: computed.readOnly('id'),
+  name: readOnly('id'),
   hash: attr('string'),
   description: attr('string'),
 });

--- a/ui/app/models/node-attributes.js
+++ b/ui/app/models/node-attributes.js
@@ -1,9 +1,8 @@
-import Ember from 'ember';
+import { get, computed } from '@ember/object';
 import attr from 'ember-data/attr';
 import Fragment from 'ember-data-model-fragments/fragment';
 import flat from 'npm:flat';
 
-const { computed, get } = Ember;
 const { unflatten } = flat;
 
 export default Fragment.extend({
@@ -12,10 +11,12 @@ export default Fragment.extend({
   attributesStructured: computed('attributes', function() {
     // `unflatten` doesn't sort keys before unflattening, so manual preprocessing is necessary.
     const original = this.get('attributes');
-    const attrs = Object.keys(original).sort().reduce((obj, key) => {
-      obj[key] = original[key];
-      return obj;
-    }, {});
+    const attrs = Object.keys(original)
+      .sort()
+      .reduce((obj, key) => {
+        obj[key] = original[key];
+        return obj;
+      }, {});
     return unflatten(attrs, { overwrite: true });
   }),
 

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -1,12 +1,10 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { hasMany } from 'ember-data/relationships';
 import { fragment } from 'ember-data-model-fragments/attributes';
 import shortUUIDProperty from '../utils/properties/short-uuid';
 import ipParts from '../utils/ip-parts';
-
-const { computed } = Ember;
 
 export default Model.extend({
   // Available from list response

--- a/ui/app/models/task-event.js
+++ b/ui/app/models/task-event.js
@@ -1,10 +1,9 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
 import Fragment from 'ember-data-model-fragments/fragment';
 import attr from 'ember-data/attr';
 import { fragmentOwner } from 'ember-data-model-fragments/attributes';
 import moment from 'moment';
 
-const { computed } = Ember;
 const displayProps = [
   'message',
   'validationError',

--- a/ui/app/models/task-group-deployment-summary.js
+++ b/ui/app/models/task-group-deployment-summary.js
@@ -1,9 +1,7 @@
-import Ember from 'ember';
+import { gt } from '@ember/object/computed';
 import Fragment from 'ember-data-model-fragments/fragment';
 import attr from 'ember-data/attr';
 import { fragmentOwner } from 'ember-data-model-fragments/attributes';
-
-const { computed } = Ember;
 
 export default Fragment.extend({
   deployment: fragmentOwner(),
@@ -12,7 +10,7 @@ export default Fragment.extend({
 
   autoRevert: attr('boolean'),
   promoted: attr('boolean'),
-  requiresPromotion: computed.gt('desiredCanaries', 0),
+  requiresPromotion: gt('desiredCanaries', 0),
 
   placedCanaries: attr('number'),
   desiredCanaries: attr('number'),

--- a/ui/app/models/task-group-summary.js
+++ b/ui/app/models/task-group-summary.js
@@ -1,9 +1,7 @@
-import Ember from 'ember';
+import { collect, sum } from '@ember/object/computed';
 import Fragment from 'ember-data-model-fragments/fragment';
 import attr from 'ember-data/attr';
 import { fragmentOwner } from 'ember-data-model-fragments/attributes';
-
-const { computed } = Ember;
 
 export default Fragment.extend({
   job: fragmentOwner(),
@@ -16,7 +14,7 @@ export default Fragment.extend({
   failedAllocs: attr('number'),
   lostAllocs: attr('number'),
 
-  allocsList: computed.collect(
+  allocsList: collect(
     'queuedAllocs',
     'startingAllocs',
     'runningAllocs',
@@ -25,5 +23,5 @@ export default Fragment.extend({
     'lostAllocs'
   ),
 
-  totalAllocs: computed.sum('allocsList'),
+  totalAllocs: sum('allocsList'),
 });

--- a/ui/app/models/task-group.js
+++ b/ui/app/models/task-group.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
 import Fragment from 'ember-data-model-fragments/fragment';
 import attr from 'ember-data/attr';
 import { fragmentOwner, fragmentArray } from 'ember-data-model-fragments/attributes';
 import sumAggregation from '../utils/properties/sum-aggregation';
-
-const { computed } = Ember;
 
 export default Fragment.extend({
   job: fragmentOwner(),

--- a/ui/app/models/task-state.js
+++ b/ui/app/models/task-state.js
@@ -1,9 +1,8 @@
-import Ember from 'ember';
+import { none } from '@ember/object/computed';
+import { computed } from '@ember/object';
 import Fragment from 'ember-data-model-fragments/fragment';
 import attr from 'ember-data/attr';
 import { fragment, fragmentOwner, fragmentArray } from 'ember-data-model-fragments/attributes';
-
-const { computed } = Ember;
 
 export default Fragment.extend({
   name: attr('string'),
@@ -12,7 +11,7 @@ export default Fragment.extend({
   finishedAt: attr('date'),
   failed: attr('boolean'),
 
-  isActive: computed.none('finishedAt'),
+  isActive: none('finishedAt'),
 
   allocation: fragmentOwner(),
   task: computed('allocation.taskGroup.tasks.[]', function() {

--- a/ui/app/models/token.js
+++ b/ui/app/models/token.js
@@ -1,9 +1,7 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { hasMany } from 'ember-data/relationships';
-
-const { computed } = Ember;
 
 export default Model.extend({
   secret: attr('string'),
@@ -14,5 +12,5 @@ export default Model.extend({
   policies: hasMany('policy'),
   policyNames: attr(),
 
-  accessor: computed.alias('id'),
+  accessor: alias('id'),
 });

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL,
 });

--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import WithModelErrorHandling from 'nomad-ui/mixins/with-model-error-handling';
-
-const { Route } = Ember;
 
 export default Route.extend(WithModelErrorHandling);

--- a/ui/app/routes/allocations/allocation/task.js
+++ b/ui/app/routes/allocations/allocation/task.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
-
-const { Route, inject, Error: EmberError } = Ember;
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+import EmberError from '@ember/error';
 
 export default Route.extend({
-  store: inject.service(),
+  store: service(),
 
   model({ name }) {
     const allocation = this.modelFor('allocations.allocation');

--- a/ui/app/routes/allocations/allocation/task/logs.js
+++ b/ui/app/routes/allocations/allocation/task/logs.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Route } = Ember;
+import Route from '@ember/routing/route';
 
 export default Route.extend({
   model() {

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -1,9 +1,8 @@
-import Ember from 'ember';
-
-const { Route, inject } = Ember;
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 
 export default Route.extend({
-  config: inject.service(),
+  config: service(),
 
   resetController(controller, isExiting) {
     if (isExiting) {

--- a/ui/app/routes/clients.js
+++ b/ui/app/routes/clients.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+import RSVP from 'rsvp';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
 import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 
-const { Route, inject, RSVP } = Ember;
-
 export default Route.extend(WithForbiddenState, {
-  store: inject.service(),
-  system: inject.service(),
+  store: service(),
+  system: service(),
 
   beforeModel() {
     return this.get('system.leader');

--- a/ui/app/routes/clients/client.js
+++ b/ui/app/routes/clients/client.js
@@ -1,10 +1,9 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import notifyError from 'nomad-ui/utils/notify-error';
 
-const { Route, inject } = Ember;
-
 export default Route.extend({
-  store: inject.service(),
+  store: service(),
 
   model() {
     return this._super(...arguments).catch(notifyError(this));

--- a/ui/app/routes/index.js
+++ b/ui/app/routes/index.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Route } = Ember;
+import Route from '@ember/routing/route';
 
 export default Route.extend({
   redirect() {

--- a/ui/app/routes/jobs.js
+++ b/ui/app/routes/jobs.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+import { run } from '@ember/runloop';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
 import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 
-const { Route, inject, run } = Ember;
-
 export default Route.extend(WithForbiddenState, {
-  system: inject.service(),
-  store: inject.service(),
+  system: service(),
+  store: service(),
 
   beforeModel() {
     return this.get('system.namespaces');

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Route } = Ember;
+import Route from '@ember/routing/route';
 
 export default Route.extend({
   actions: {

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+import RSVP from 'rsvp';
 import notifyError from 'nomad-ui/utils/notify-error';
 
-const { Route, RSVP, inject } = Ember;
-
 export default Route.extend({
-  store: inject.service(),
+  store: service(),
 
   serialize(model) {
     return { job_name: model.get('plainId') };

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Route } = Ember;
+import Route from '@ember/routing/route';
 
 export default Route.extend({
   model() {

--- a/ui/app/routes/jobs/job/deployments.js
+++ b/ui/app/routes/jobs/job/deployments.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Route, RSVP } = Ember;
+import Route from '@ember/routing/route';
+import RSVP from 'rsvp';
 
 export default Route.extend({
   model() {

--- a/ui/app/routes/jobs/job/task-group.js
+++ b/ui/app/routes/jobs/job/task-group.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Route } = Ember;
+import Route from '@ember/routing/route';
 
 export default Route.extend({
   model({ name }) {

--- a/ui/app/routes/jobs/job/versions.js
+++ b/ui/app/routes/jobs/job/versions.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { Route } = Ember;
+import Route from '@ember/routing/route';
 
 export default Route.extend({
   model() {

--- a/ui/app/routes/not-found.js
+++ b/ui/app/routes/not-found.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { Route, Error: EmberError } = Ember;
+import Route from '@ember/routing/route';
+import EmberError from '@ember/error';
 
 export default Route.extend({
   model() {

--- a/ui/app/routes/servers.js
+++ b/ui/app/routes/servers.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+import RSVP from 'rsvp';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
 import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 
-const { Route, inject, RSVP } = Ember;
-
 export default Route.extend(WithForbiddenState, {
-  store: inject.service(),
-  system: inject.service(),
+  store: service(),
+  system: service(),
 
   beforeModel() {
     return this.get('system.leader');

--- a/ui/app/routes/servers/server.js
+++ b/ui/app/routes/servers/server.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import WithModelErrorHandling from 'nomad-ui/mixins/with-model-error-handling';
-
-const { Route } = Ember;
 
 export default Route.extend(WithModelErrorHandling);

--- a/ui/app/serializers/allocation.js
+++ b/ui/app/serializers/allocation.js
@@ -1,10 +1,9 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 import ApplicationSerializer from './application';
 
-const { get, inject } = Ember;
-
 export default ApplicationSerializer.extend({
-  system: inject.service(),
+  system: service(),
 
   attrs: {
     taskGroupName: 'TaskGroup',

--- a/ui/app/serializers/application.js
+++ b/ui/app/serializers/application.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import { makeArray } from '@ember/array';
 import JSONSerializer from 'ember-data/serializers/json';
-
-const { makeArray } = Ember;
 
 export default JSONSerializer.extend({
   primaryKey: 'ID',

--- a/ui/app/serializers/deployment.js
+++ b/ui/app/serializers/deployment.js
@@ -1,7 +1,6 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { assign } from '@ember/polyfills';
 import ApplicationSerializer from './application';
-
-const { get, assign } = Ember;
 
 export default ApplicationSerializer.extend({
   attrs: {

--- a/ui/app/serializers/evaluation.js
+++ b/ui/app/serializers/evaluation.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
+import { assign } from '@ember/polyfills';
 import ApplicationSerializer from './application';
 
-const { inject, get, assign } = Ember;
-
 export default ApplicationSerializer.extend({
-  system: inject.service(),
+  system: service(),
 
   normalize(typeHash, hash) {
     hash.FailedTGAllocs = Object.keys(hash.FailedTGAllocs || {}).map(key => {

--- a/ui/app/serializers/job-version.js
+++ b/ui/app/serializers/job-version.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import { assign } from '@ember/polyfills';
 import ApplicationSerializer from './application';
-
-const { assign } = Ember;
 
 export default ApplicationSerializer.extend({
   attrs: {

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -1,8 +1,7 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { assign } from '@ember/polyfills';
 import ApplicationSerializer from './application';
 import queryString from 'npm:query-string';
-
-const { get, assign } = Ember;
 
 export default ApplicationSerializer.extend({
   attrs: {

--- a/ui/app/serializers/node.js
+++ b/ui/app/serializers/node.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
 import ApplicationSerializer from './application';
 
-const { inject } = Ember;
-
 export default ApplicationSerializer.extend({
-  config: inject.service(),
+  config: service(),
 
   attrs: {
     httpAddr: 'HTTPAddr',

--- a/ui/app/serializers/task-group.js
+++ b/ui/app/serializers/task-group.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import { copy } from '@ember/object/internals';
 import ApplicationSerializer from './application';
-
-const { copy } = Ember;
 
 export default ApplicationSerializer.extend({
   normalize(typeHash, hash) {

--- a/ui/app/serializers/token.js
+++ b/ui/app/serializers/token.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import { copy } from '@ember/object/internals';
 import ApplicationSerializer from './application';
-
-const { copy } = Ember;
 
 export default ApplicationSerializer.extend({
   primaryKey: 'AccessorID',

--- a/ui/app/services/config.js
+++ b/ui/app/services/config.js
@@ -1,14 +1,14 @@
-import Ember from 'ember';
+import { equal } from '@ember/object/computed';
+import Service from '@ember/service';
+import { get } from '@ember/object';
 import config from '../config/environment';
-
-const { Service, get, computed } = Ember;
 
 export default Service.extend({
   unknownProperty(path) {
     return get(config, path);
   },
 
-  isDev: computed.equal('environment', 'development'),
-  isProd: computed.equal('environment', 'production'),
-  isTest: computed.equal('environment', 'test'),
+  isDev: equal('environment', 'development'),
+  isProd: equal('environment', 'production'),
+  isTest: equal('environment', 'test'),
 });

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -1,12 +1,11 @@
-import Ember from 'ember';
+import Service, { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import PromiseObject from '../utils/classes/promise-object';
 import { namespace } from '../adapters/application';
 
-const { Service, computed, inject } = Ember;
-
 export default Service.extend({
-  token: inject.service(),
-  store: inject.service(),
+  token: service(),
+  store: service(),
 
   leader: computed(function() {
     const token = this.get('token');

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Service from '@ember/service';
+import { computed } from '@ember/object';
+import { assign } from '@ember/polyfills';
 import fetch from 'nomad-ui/utils/fetch';
-
-const { Service, computed, assign } = Ember;
 
 export default Service.extend({
   secret: computed({

--- a/ui/app/utils/classes/abstract-logger.js
+++ b/ui/app/utils/classes/abstract-logger.js
@@ -1,16 +1,16 @@
-import Ember from 'ember';
+import { assert } from '@ember/debug';
+import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
+import { assign } from '@ember/polyfills';
 import queryString from 'npm:query-string';
 
-const { Mixin, computed, assign } = Ember;
 const MAX_OUTPUT_LENGTH = 50000;
 
 export default Mixin.create({
   url: '',
   params: computed(() => ({})),
   logFetch() {
-    Ember.assert(
-      'Loggers need a logFetch method, which should have an interface like window.fetch'
-    );
+    assert('Loggers need a logFetch method, which should have an interface like window.fetch');
   },
 
   endOffset: null,

--- a/ui/app/utils/classes/log.js
+++ b/ui/app/utils/classes/log.js
@@ -1,10 +1,12 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import { assert } from '@ember/debug';
+import Evented from '@ember/object/evented';
+import EmberObject, { computed } from '@ember/object';
+import { assign } from '@ember/polyfills';
 import queryString from 'npm:query-string';
 import { task } from 'ember-concurrency';
 import StreamLogger from 'nomad-ui/utils/classes/stream-logger';
 import PollLogger from 'nomad-ui/utils/classes/poll-logger';
-
-const { Object: EmberObject, Evented, computed, assign } = Ember;
 
 const MAX_OUTPUT_LENGTH = 50000;
 
@@ -14,14 +16,12 @@ const Log = EmberObject.extend(Evented, {
   url: '',
   params: computed(() => ({})),
   logFetch() {
-    Ember.assert(
-      'Log objects need a logFetch method, which should have an interface like window.fetch'
-    );
+    assert('Log objects need a logFetch method, which should have an interface like window.fetch');
   },
 
   // Read-only state
 
-  isStreaming: computed.alias('logStreamer.poll.isRunning'),
+  isStreaming: alias('logStreamer.poll.isRunning'),
   logPointer: null,
   logStreamer: null,
 

--- a/ui/app/utils/classes/poll-logger.js
+++ b/ui/app/utils/classes/poll-logger.js
@@ -1,8 +1,6 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
 import AbstractLogger from './abstract-logger';
-
-const { Object: EmberObject } = Ember;
 
 export default EmberObject.extend(AbstractLogger, {
   interval: 1000,

--- a/ui/app/utils/classes/promise-object.js
+++ b/ui/app/utils/classes/promise-object.js
@@ -1,5 +1,4 @@
-import Ember from 'ember';
-
-const { ObjectProxy, PromiseProxyMixin } = Ember;
+import ObjectProxy from '@ember/object/proxy';
+import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 
 export default ObjectProxy.extend(PromiseProxyMixin);

--- a/ui/app/utils/classes/stream-logger.js
+++ b/ui/app/utils/classes/stream-logger.js
@@ -1,9 +1,7 @@
-import Ember from 'ember';
+import EmberObject, { computed } from '@ember/object';
 import { task } from 'ember-concurrency';
 import TextDecoder from 'nomad-ui/utils/classes/text-decoder';
 import AbstractLogger from './abstract-logger';
-
-const { Object: EmberObject, computed } = Ember;
 
 export default EmberObject.extend(AbstractLogger, {
   reader: null,

--- a/ui/app/utils/properties/short-uuid.js
+++ b/ui/app/utils/properties/short-uuid.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { computed } = Ember;
+import { computed } from '@ember/object';
 
 // An Ember.Computed property for taking the first segment
 // of a uuid.

--- a/ui/app/utils/properties/style-string.js
+++ b/ui/app/utils/properties/style-string.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { computed } = Ember;
+import { computed } from '@ember/object';
 
 // An Ember.Computed property for transforming an object into an
 // html compatible style attribute

--- a/ui/app/utils/properties/sum-aggregation.js
+++ b/ui/app/utils/properties/sum-aggregation.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { computed } = Ember;
+import { computed } from '@ember/object';
 
 // An Ember.Computed property for summating all properties from a
 // set of objects.
@@ -9,6 +7,8 @@ const { computed } = Ember;
 //     sum: sumAggregationProperty('list', 'foo') // 4
 export default function sumAggregationProperty(listKey, propKey) {
   return computed(`${listKey}.@each.${propKey}`, function() {
-    return this.get(listKey).mapBy(propKey).reduce((sum, count) => sum + count, 0);
+    return this.get(listKey)
+      .mapBy(propKey)
+      .reduce((sum, count) => sum + count, 0);
   });
 }

--- a/ui/app/utils/timeout.js
+++ b/ui/app/utils/timeout.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { RSVP } = Ember;
+import RSVP from 'rsvp';
 
 // An always failing promise used to race against other promises
 export default function timeout(duration) {

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { click, findAll, currentURL, find, visit } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 import moment from 'moment';
-
-const { $ } = Ember;
 
 let job;
 let node;

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -1,11 +1,9 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { click, find, findAll, currentURL, visit } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 import { formatBytes } from 'nomad-ui/helpers/format-bytes';
 import moment from 'moment';
-
-const { $ } = Ember;
 
 let node;
 

--- a/ui/tests/acceptance/job-deployments-test.js
+++ b/ui/tests/acceptance/job-deployments-test.js
@@ -1,10 +1,10 @@
+import { get } from '@ember/object';
+import $ from 'jquery';
 import { click, findAll, find, visit } from 'ember-native-dom-helpers';
-import Ember from 'ember';
 import { test } from 'qunit';
 import moment from 'moment';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 
-const { get, $ } = Ember;
 const sum = (list, key) => list.reduce((sum, item) => sum + get(item, key), 0);
 
 let job;

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -1,10 +1,10 @@
+import { get } from '@ember/object';
+import $ from 'jquery';
 import { click, findAll, currentURL, find, visit } from 'ember-native-dom-helpers';
-import Ember from 'ember';
 import moment from 'moment';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 
-const { get, $ } = Ember;
 const sum = (list, key) => list.reduce((sum, item) => sum + get(item, key), 0);
 
 let job;

--- a/ui/tests/acceptance/job-versions-test.js
+++ b/ui/tests/acceptance/job-versions-test.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { findAll, visit } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 import moment from 'moment';
-
-const { $ } = Ember;
 
 let job;
 let versions;

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -1,9 +1,7 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { click, find, findAll, currentURL, visit, fillIn } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
-
-const { $ } = Ember;
 
 moduleForAcceptance('Acceptance | jobs list', {
   beforeEach() {

--- a/ui/tests/acceptance/nodes-list-test.js
+++ b/ui/tests/acceptance/nodes-list-test.js
@@ -1,11 +1,9 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { click, find, findAll, currentURL, visit } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 import { findLeader } from '../../mirage/config';
 import ipParts from 'nomad-ui/utils/ip-parts';
-
-const { $ } = Ember;
 
 function minimumSetup() {
   server.createList('node', 1);

--- a/ui/tests/acceptance/server-detail-test.js
+++ b/ui/tests/acceptance/server-detail-test.js
@@ -1,9 +1,7 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { find, findAll, currentURL, visit } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
-
-const { $ } = Ember;
 
 let agent;
 

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -1,11 +1,9 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { click, findAll, currentURL, find, visit } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 import moment from 'moment';
 import ipParts from 'nomad-ui/utils/ip-parts';
-
-const { $ } = Ember;
 
 let allocation;
 let task;

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -1,11 +1,9 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { click, find, findAll, fillIn, currentURL, visit } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 import { formatBytes } from 'nomad-ui/helpers/format-bytes';
 import moment from 'moment';
-
-const { $ } = Ember;
 
 let job;
 let taskGroup;

--- a/ui/tests/acceptance/task-logs-test.js
+++ b/ui/tests/acceptance/task-logs-test.js
@@ -1,9 +1,7 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { find } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
-
-const { run } = Ember;
 
 let allocation;
 let task;

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -1,9 +1,7 @@
+import $ from 'jquery';
 import { find, findAll, fillIn, click, visit } from 'ember-native-dom-helpers';
-import Ember from 'ember';
 import { test, skip } from 'ember-qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
-
-const { $ } = Ember;
 
 let job;
 let node;

--- a/ui/tests/helpers/destroy-app.js
+++ b/ui/tests/helpers/destroy-app.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
   if (window.server) {
     window.server.shutdown();
   }

--- a/ui/tests/helpers/module-for-acceptance.js
+++ b/ui/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,7 @@
+import { Promise } from 'rsvp';
 import { module } from 'qunit';
-import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/ui/tests/helpers/module-for-serializer.js
+++ b/ui/tests/helpers/module-for-serializer.js
@@ -1,8 +1,6 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
 import { moduleForModel } from 'ember-qunit';
 import { initialize as fragmentSerializerInitializer } from 'nomad-ui/initializers/fragment-serializer';
-
-const { getOwner } = Ember;
 
 export default function(modelName, description, options = { needs: [] }) {
   // moduleForModel correctly wires up #Serializer.store,

--- a/ui/tests/helpers/start-app.js
+++ b/ui/tests/helpers/start-app.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
 import registerPowerSelectHelpers from '../../tests/helpers/ember-power-select';
@@ -6,10 +7,10 @@ import registerPowerSelectHelpers from '../../tests/helpers/ember-power-select';
 registerPowerSelectHelpers();
 
 export default function startApp(attrs) {
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  return Ember.run(() => {
+  return run(() => {
     let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/ui/tests/integration/task-log-test.js
+++ b/ui/tests/integration/task-log-test.js
@@ -1,12 +1,10 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { test, moduleForComponent } from 'ember-qunit';
 import wait from 'ember-test-helpers/wait';
 import { find, click } from 'ember-native-dom-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Pretender from 'pretender';
 import { logEncode } from '../../mirage/data/logs';
-
-const { run } = Ember;
 
 const HOST = '1.1.1.1:1111';
 const commonProps = {

--- a/ui/tests/unit/mixins/searchable-test.js
+++ b/ui/tests/unit/mixins/searchable-test.js
@@ -1,15 +1,15 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import { getOwner } from '@ember/application';
+import EmberObject, { computed } from '@ember/object';
 import { moduleFor, test } from 'ember-qunit';
 import Searchable from 'nomad-ui/mixins/searchable';
 
-const { getOwner, computed } = Ember;
-
 moduleFor('mixin:searchable', 'Unit | Mixin | Searchable', {
   subject() {
-    const SearchableObject = Ember.Object.extend(Searchable, {
+    const SearchableObject = EmberObject.extend(Searchable, {
       source: null,
       searchProps: computed(() => ['id', 'name']),
-      listToSearch: computed.alias('source'),
+      listToSearch: alias('source'),
     });
 
     this.register('test-container:searchable-object', SearchableObject);

--- a/ui/tests/unit/models/task-group-test.js
+++ b/ui/tests/unit/models/task-group-test.js
@@ -1,7 +1,6 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
 import { moduleForModel, test } from 'ember-qunit';
 
-const { get } = Ember;
 const sum = (list, key) => list.reduce((sum, item) => sum + get(item, key), 0);
 
 moduleForModel('task-group', 'Unit | Model | task-group', {

--- a/ui/tests/unit/utils/log-test.js
+++ b/ui/tests/unit/utils/log-test.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import RSVP from 'rsvp';
+import { run } from '@ember/runloop';
 import sinon from 'sinon';
 import wait from 'ember-test-helpers/wait';
 import { module, test } from 'ember-qunit';
 import _Log from 'nomad-ui/utils/classes/log';
-
-const { Object: EmberObject, RSVP, run } = Ember;
 
 let startSpy, stopSpy, initSpy, fetchSpy;
 


### PR DESCRIPTION
### UI Dependency Upgrades
  - Step 1: Core Ember and low-risk dependencies
  - **Step 2: Switch to Module Imports**
  - Step 3: Bulma and Sass upgrades
  - Step 4: Testing upgrades
  - Step 5: Prettier upgrade
  - Step 6: Styleguide upgrade

Changes the UI codebase from importing the Ember global to importing from Ember modules. The changeset was [generated with tooling](https://github.com/ember-cli/ember-modules-codemod).