### PR TITLE
Always advertise driver IP when in driver mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ BUG FIXES:
  * core: Fix an issue in which batch jobs with queued placements and lost
    allocations could result in improper placement counts [[GH-3717](https://github.com/hashicorp/nomad/issues/3717)]
  * client: Migrated ephemeral_disk's maintain directory permissions [[GH-3723](https://github.com/hashicorp/nomad/issues/3723)]
+ * client: Always advertise driver IP when in driver address mode [[GH-3682](https://github.com/hashicorp/nomad/issues/3682)]
  * client/vault: Recognize renewing non-renewable Vault lease as fatal [[GH-3727](https://github.com/hashicorp/nomad/issues/3727)]
  * config: Revert minimum CPU limit back to 20 from 100.
  * ui: Fix ui on non-leaders when ACLs are enabled [[GH-3722](https://github.com/hashicorp/nomad/issues/3722)]

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -820,9 +820,6 @@ func (d *DockerDriver) Start(ctx *ExecContext, task *structs.Task) (*StartRespon
 
 	// Detect container address
 	ip, autoUse := d.detectIP(container)
-	if ip == "" {
-		d.logger.Printf("[DEBUG] driver.docker: task %s could not detect a container IP", d.taskName)
-	}
 
 	// Create a response with the driver handle and container network metadata
 	resp := &StartResponse{
@@ -863,11 +860,6 @@ func (d *DockerDriver) detectIP(c *docker.Container) (string, bool) {
 		// Linux, nat on Windows)
 		if name != "bridge" && name != "nat" {
 			auto = true
-			d.logger.Printf("[INFO] driver.docker: task %s auto-advertising detected IP %s on network %q",
-				d.taskName, ip, name)
-		} else {
-			d.logger.Printf("[DEBUG] driver.docker task %s detect IP %s on network %q but not auto-advertising",
-				d.taskName, ip, name)
 		}
 
 		break

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1446,13 +1446,13 @@ func (r *TaskRunner) startTask() error {
 			r.logger.Printf("[INFO] client: alloc %s task %s auto-advertising detected IP %s",
 				r.alloc.ID, r.task.Name, sresp.Network.IP)
 		} else {
-			r.logger.Printf("[DEBUG] client: alloc %s task %s detected IP %s but not auto-advertising",
+			r.logger.Printf("[TRACE] client: alloc %s task %s detected IP %s but not auto-advertising",
 				r.alloc.ID, r.task.Name, sresp.Network.IP)
 		}
 	}
 
 	if sresp.Network == nil || sresp.Network.IP == "" {
-		r.logger.Printf("[DEBUG] client: alloc %s task %s could not detect a driver IP", r.alloc.ID, r.task.Name)
+		r.logger.Printf("[TRACE] client: alloc %s task %s could not detect a driver IP", r.alloc.ID, r.task.Name)
 	}
 
 	// Update environment with the network defined by the driver's Start method.

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1440,6 +1440,21 @@ func (r *TaskRunner) startTask() error {
 
 	}
 
+	// Log driver network information
+	if sresp.Network != nil && sresp.Network.IP != "" {
+		if sresp.Network.AutoAdvertise {
+			r.logger.Printf("[INFO] client: alloc %s task %s auto-advertising detected IP %s",
+				r.alloc.ID, r.task.Name, sresp.Network.IP)
+		} else {
+			r.logger.Printf("[DEBUG] client: alloc %s task %s detected IP %s but not auto-advertising",
+				r.alloc.ID, r.task.Name, sresp.Network.IP)
+		}
+	}
+
+	if sresp.Network == nil || sresp.Network.IP == "" {
+		r.logger.Printf("[DEBUG] client: alloc %s task %s could not detect a driver IP", r.alloc.ID, r.task.Name)
+	}
+
 	// Update environment with the network defined by the driver's Start method.
 	r.envBuilder.SetDriverNetwork(sresp.Network)
 

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -1098,11 +1098,6 @@ func isOldNomadService(id string) bool {
 // label is specified (an empty value), zero values are returned because no
 // address could be resolved.
 func getAddress(addrMode, portLabel string, networks structs.Networks, driverNet *cstructs.DriverNetwork) (string, int, error) {
-	// No port label specified, no address can be assembled
-	if portLabel == "" {
-		return "", 0, nil
-	}
-
 	switch addrMode {
 	case structs.AddressModeAuto:
 		if driverNet.Advertise() {
@@ -1112,6 +1107,18 @@ func getAddress(addrMode, portLabel string, networks structs.Networks, driverNet
 		}
 		return getAddress(addrMode, portLabel, networks, driverNet)
 	case structs.AddressModeHost:
+		if portLabel == "" {
+			if len(networks) != 1 {
+				// If no networks are specified return zero
+				// values. Consul will advertise the host IP
+				// with no port. This is the pre-0.7.1 behavior
+				// some people rely on.
+				return "", 0, nil
+			}
+
+			return networks[0].IP, 0, nil
+		}
+
 		// Default path: use host ip:port
 		ip, port := networks.Port(portLabel)
 		if ip == "" && port <= 0 {
@@ -1123,6 +1130,11 @@ func getAddress(addrMode, portLabel string, networks structs.Networks, driverNet
 		// Require a driver network if driver address mode is used
 		if driverNet == nil {
 			return "", 0, fmt.Errorf(`cannot use address_mode="driver": no driver network exists`)
+		}
+
+		// If no port label is specified just return the IP
+		if portLabel == "" {
+			return driverNet.IP, 0, nil
 		}
 
 		// If the port is a label, use the driver's port (not the host's)

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -1145,10 +1145,13 @@ func getAddress(addrMode, portLabel string, networks structs.Networks, driverNet
 		// If port isn't a label, try to parse it as a literal port number
 		port, err := strconv.Atoi(portLabel)
 		if err != nil {
-			return "", 0, fmt.Errorf("invalid port %q: %v", portLabel, err)
+			// Don't include Atoi error message as user likely
+			// never intended it to be a numeric and it creates a
+			// confusing error message
+			return "", 0, fmt.Errorf("invalid port label %q: port labels in driver address_mode must be numeric or in the driver's port map", portLabel)
 		}
 		if port <= 0 {
-			return "", 0, fmt.Errorf("invalid port: %q: port 0 is invalid", portLabel)
+			return "", 0, fmt.Errorf("invalid port: %q: port must be >0", portLabel)
 		}
 
 		return driverNet.IP, port, nil

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -1571,7 +1571,7 @@ func TestGetAddress(t *testing.T) {
 		},
 		{
 			Name:       "NoPort_AutoMode",
-			Mode:       structs.AddressModeHost,
+			Mode:       structs.AddressModeAuto,
 			ExpectedIP: HostIP,
 		},
 		{

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -1468,6 +1468,7 @@ func TestGetAddress(t *testing.T) {
 		ExpectedPort int
 		ExpectedErr  string
 	}{
+		// Valid Configurations
 		{
 			Name:      "ExampleService",
 			Mode:      structs.AddressModeAuto,
@@ -1529,6 +1530,8 @@ func TestGetAddress(t *testing.T) {
 			ExpectedIP:   "10.1.2.3",
 			ExpectedPort: 7890,
 		},
+
+		// Invalid Configurations
 		{
 			Name:        "DriverWithoutNetwork",
 			Mode:        structs.AddressModeDriver,


### PR DESCRIPTION
Fixes #3681

When in driver address mode Nomad should always advertise the driver's IP
in Consul even when no network exists. This matches the 0.6 behavior.

When in host address mode Nomad advertises the alloc's network's IP if
one exists. Otherwise it lets Consul determine the IP.

I also added some much needed logging around Docker's network discovery.

Binaries from d1e2833

[linux_amd64.zip](https://github.com/hashicorp/nomad/files/1627884/linux_amd64.zip)
[windows_amd64.zip](https://github.com/hashicorp/nomad/files/1627888/windows_amd64.zip)

**Old**
~Binaries from 9a1cb46 which include #3680:~

~[linux_amd64.zip](https://github.com/hashicorp/nomad/files/1577453/linux_amd64.zip)~
~[windows_amd64.zip](https://github.com/hashicorp/nomad/files/1577454/windows_amd64.zip)~

 ~Binaries from cd2e712:~

~[linux_amd64.zip](https://github.com/hashicorp/nomad/files/1577325/linux_amd64.zip)~
~[windows_amd64.zip](https://github.com/hashicorp/nomad/files/1577330/windows_amd64.zip)~

  