### PR TITLE
Make macos/osx builds optional in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ branches:
 
 matrix:
   include:
-
-matrix:
-  include:
     - os: linux
       dist: trusty
       sudo: required
@@ -31,6 +28,9 @@ matrix:
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
     - os: osx
       osx_image: xcode9.1
+  allow_failures:
+    - os: osx
+  fast_finish: true
 
 cache:
   directories:


### PR DESCRIPTION
This is an unfortunate thing to do.

The goal is to never merge code that doesn't have a passing build. 

The problem is between a handful of flaky tests and macos builds having long queue times in Travis, the CI feedback loop is too long to be practical.

This compromise makes the linux build required (must be green to merge) and the osx build optional (we still track successes and failures, they just aren't accounted for in overall success or failure).

We should revisit this once tests pass more consistently and/or once Travis has better osx support.