### PR TITLE
Update `node-status` verbose command to include node address.

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -151,6 +151,7 @@ type HostDiskStats struct {
 // NodeListStub is a subset of information returned during
 // node list operations.
 type NodeListStub struct {
+	Address           string
 	ID                string
 	Datacenter        string
 	Name              string

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -180,7 +180,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		out[0] = "ID|DC|Name|Class|"
 
 		if c.verbose {
-			out[0] += "Version|"
+			out[0] += "Address|Version|"
 		}
 
 		out[0] += "Drain|Status"
@@ -196,8 +196,8 @@ func (c *NodeStatusCommand) Run(args []string) int {
 				node.Name,
 				node.NodeClass)
 			if c.verbose {
-				out[i+1] += fmt.Sprintf("|%s",
-					node.Version)
+				out[i+1] += fmt.Sprintf("|%s|%s",
+					node.Address, node.Version)
 			}
 			out[i+1] += fmt.Sprintf("|%v|%s",
 				node.Drain,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1172,6 +1172,7 @@ func (n *Node) TerminalStatus() bool {
 // Stub returns a summarized version of the node
 func (n *Node) Stub() *NodeListStub {
 	return &NodeListStub{
+		Address:           n.Attributes["unique.network.ip-address"],
 		ID:                n.ID,
 		Datacenter:        n.Datacenter,
 		Name:              n.Name,
@@ -1188,6 +1189,7 @@ func (n *Node) Stub() *NodeListStub {
 // NodeListStub is used to return a subset of job information
 // for the job list
 type NodeListStub struct {
+	Address           string
 	ID                string
 	Datacenter        string
 	Name              string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1171,8 +1171,11 @@ func (n *Node) TerminalStatus() bool {
 
 // Stub returns a summarized version of the node
 func (n *Node) Stub() *NodeListStub {
+
+	addr, _, _ := net.SplitHostPort(n.HTTPAddr)
+
 	return &NodeListStub{
-		Address:           n.Attributes["unique.network.ip-address"],
+		Address:           addr,
 		ID:                n.ID,
 		Datacenter:        n.Datacenter,
 		Name:              n.Name,


### PR DESCRIPTION
This change updates the `nomad node-status -verbose` command to also include the address of the node. This is helpful for cluster administrators to quickly discover information and access nodes when required.

Test suite:
```
$ make test-nomad
==> Removing old development build...
==> Building pkg/darwin_amd64/nomad with tags nomad_test ...
==> Running Nomad test suites:
PASS
```

The changes were built locally and tested:
```
$ ./jrasell-nomad node-status
ID        DC   Name                             Class   Drain  Status
cb4832d4  dc1  AAABBBB-156498.YYYYYYY.XXXX.net  <none>  false  ready

$ ./jrasell-nomad node-status -verbose
ID                                    DC   Name                             Class   Address    Version    Drain  Status
cb4832d4-9864-05cc-746e-6bdd6f3687d9  dc1  AAABBBB-156498.YYYYYYY.XXXX.net  <none>  127.0.0.1  0.8.0-dev  false  ready
```

Closes #3678 