### PR TITLE
Add missing token option for nomad run command

### DIFF
--- a/website/source/docs/commands/_general_options.html.md
+++ b/website/source/docs/commands/_general_options.html.md
@@ -26,3 +26,6 @@
 
 - `-tls-skip-verify`: Do not verify TLS certificate. This is highly not
   recommended. Verification will also be skipped if `NOMAD_SKIP_VERIFY` is set.
+  
+- `-token`: The SecretID of an ACL token to use to authenticate API requests with.
+  Overrides the `NOMAD_TOKEN` environment variable if set.


### PR DESCRIPTION
I noticed that the documentation regarding the `nomad run` command didn't have the `-token` command listed. I added the option info text verbatim from `nomad run -h`.