### PR TITLE
Change 'CoreOS rkt' to just 'rkt'

### DIFF
--- a/website/source/docs/drivers/rkt.html.md
+++ b/website/source/docs/drivers/rkt.html.md
@@ -10,7 +10,7 @@ description: |-
 
 Name: `rkt`
 
-The `rkt` driver provides an interface for using CoreOS rkt for running
+The `rkt` driver provides an interface for using rkt for running
 application containers.
 
 ## Task Configuration


### PR DESCRIPTION
CoreOS initiated the project but it is now under the CNCF banner and includes many contributors and core maintainers that are not at CoreOS.