### PR TITLE
revert change to increase min. CPU resource value from 20 to 100

### DIFF
--- a/api/resources.go
+++ b/api/resources.go
@@ -49,7 +49,7 @@ func DefaultResources() *Resources {
 // IN nomad/structs/structs.go and should be kept in sync.
 func MinResources() *Resources {
 	return &Resources{
-		CPU:      helper.IntToPtr(100),
+		CPU:      helper.IntToPtr(20),
 		MemoryMB: helper.IntToPtr(10),
 		IOPS:     helper.IntToPtr(0),
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1253,7 +1253,7 @@ func DefaultResources() *Resources {
 // api/resources.go and should be kept in sync.
 func MinResources() *Resources {
 	return &Resources{
-		CPU:      100,
+		CPU:      20,
 		MemoryMB: 10,
 		IOPS:     0,
 	}


### PR DESCRIPTION
In the commit 622d3ddb92ea7e656ef831641c02024cb5a5d6d1
"Fixed test and moved constants into standalone func" the minimum CPU
resource value for a job was increased from 100 to 20.

This can break the nomad setup for people that used lower CPU
values and are at the maximum MHz value of the available CPU on a
machine.
Change the minimum back to 20 MHz to ensure downwards compatibility.