### PR TITLE
Recognize renewing non-renewable Vault lease as fatal

### DIFF
--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -428,6 +428,7 @@ func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 	fatal := false
 	if renewalErr != nil &&
 		(strings.Contains(renewalErr.Error(), "lease not found or lease is not renewable") ||
+			strings.Contains(renewalErr.Error(), "lease is not renewable") ||
 			strings.Contains(renewalErr.Error(), "token not found") ||
 			strings.Contains(renewalErr.Error(), "permission denied")) {
 		fatal = true


### PR DESCRIPTION
Makes Nomad properly recognize all Vault error messages from https://github.com/hashicorp/vault/blob/78adac0a24fbefa644fc775bae70b46482af0ea9/vault/expiration.go#L1295-L1307

Fixes https://github.com/hashicorp/nomad/issues/2832