### PR TITLE
Logger backed by *testing.T

### DIFF
--- a/helper/testlog/testlog.go
+++ b/helper/testlog/testlog.go
@@ -1,0 +1,40 @@
+// Package testlog creates a *log.Logger backed by testing.T to ease logging in
+// tests.
+package testlog
+
+import (
+	"io"
+	"log"
+)
+
+// Logger is the methods of testing.T (or testing.B) needed by the test
+// logger.
+type Logger interface {
+	Logf(format string, args ...interface{})
+}
+
+// writer implements io.Writer on top of a Logger.
+type writer struct {
+	t Logger
+}
+
+// Write to an underlying Logger. Never returns an error.
+func (w *writer) Write(p []byte) (n int, err error) {
+	w.t.Logf(string(p))
+	return len(p), nil
+}
+
+// NewWriter creates a new io.Writer backed by a Logger.
+func NewWriter(t Logger) io.Writer {
+	return &writer{t}
+}
+
+// NewLog returns a new test logger. See https://golang.org/pkg/log/#New
+func NewLog(t Logger, prefix string, flag int) *log.Logger {
+	return log.New(&writer{t}, prefix, flag)
+}
+
+// New logger with "TEST" prefix and the Lmicroseconds flag.
+func New(t Logger) *log.Logger {
+	return NewLog(t, "TEST ", log.Lmicroseconds)
+}

--- a/helper/testlog/testlog.go
+++ b/helper/testlog/testlog.go
@@ -1,5 +1,6 @@
-// Package testlog creates a *log.Logger backed by testing.T to ease logging in
-// tests.
+// Package testlog creates a *log.Logger backed by *testing.T to ease logging
+// in tests. This allows logs from components being tested to only be printed
+// if the test fails (or the verbose flag is specified).
 package testlog
 
 import (
@@ -7,15 +8,15 @@ import (
 	"log"
 )
 
-// Logger is the methods of testing.T (or testing.B) needed by the test
+// LogPrinter is the methods of testing.T (or testing.B) needed by the test
 // logger.
-type Logger interface {
+type LogPrinter interface {
 	Logf(format string, args ...interface{})
 }
 
 // writer implements io.Writer on top of a Logger.
 type writer struct {
-	t Logger
+	t LogPrinter
 }
 
 // Write to an underlying Logger. Never returns an error.
@@ -25,16 +26,21 @@ func (w *writer) Write(p []byte) (n int, err error) {
 }
 
 // NewWriter creates a new io.Writer backed by a Logger.
-func NewWriter(t Logger) io.Writer {
+func NewWriter(t LogPrinter) io.Writer {
 	return &writer{t}
 }
 
-// NewLog returns a new test logger. See https://golang.org/pkg/log/#New
-func NewLog(t Logger, prefix string, flag int) *log.Logger {
+// New returns a new test logger. See https://golang.org/pkg/log/#New
+func New(t LogPrinter, prefix string, flag int) *log.Logger {
 	return log.New(&writer{t}, prefix, flag)
 }
 
-// New logger with "TEST" prefix and the Lmicroseconds flag.
-func New(t Logger) *log.Logger {
-	return NewLog(t, "TEST ", log.Lmicroseconds)
+// WithPrefix returns a new test logger with the Lmicroseconds flag set.
+func WithPrefix(t LogPrinter, prefix string) *log.Logger {
+	return New(t, prefix, log.Lmicroseconds)
+}
+
+// NewLog logger with "TEST" prefix and the Lmicroseconds flag.
+func Logger(t LogPrinter) *log.Logger {
+	return WithPrefix(t, "TEST ")
 }


### PR DESCRIPTION
For capturing log output in tests and only displaying them on failure.

Pulled out of #3241