### PR TITLE
structs for reschedule policy and reschedule tracker 

### DIFF
--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -234,6 +234,12 @@ func (tg *TaskGroup) Diff(other *TaskGroup, contextual bool) (*TaskGroupDiff, er
 		diff.Objects = append(diff.Objects, rDiff)
 	}
 
+	// Reschedule policy diff
+	reschedDiff := primitiveObjectDiff(tg.ReschedulePolicy, other.ReschedulePolicy, nil, "ReschedulePolicy", contextual)
+	if reschedDiff != nil {
+		diff.Objects = append(diff.Objects, reschedDiff)
+	}
+
 	// EphemeralDisk diff
 	diskDiff := primitiveObjectDiff(tg.EphemeralDisk, other.EphemeralDisk, nil, "EphemeralDisk", contextual)
 	if diskDiff != nil {

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -1495,6 +1495,148 @@ func TestTaskGroupDiff(t *testing.T) {
 			},
 		},
 		{
+			// ReschedulePolicy added
+			Old: &TaskGroup{},
+			New: &TaskGroup{
+				ReschedulePolicy: &ReschedulePolicy{
+					Attempts: 1,
+					Interval: 15 * time.Second,
+				},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "ReschedulePolicy",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "Attempts",
+								Old:  "",
+								New:  "1",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Interval",
+								Old:  "",
+								New:  "15000000000",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// ReschedulePolicy deleted
+			Old: &TaskGroup{
+				ReschedulePolicy: &ReschedulePolicy{
+					Attempts: 1,
+					Interval: 15 * time.Second,
+				},
+			},
+			New: &TaskGroup{},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeDeleted,
+						Name: "ReschedulePolicy",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "Attempts",
+								Old:  "1",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Interval",
+								Old:  "15000000000",
+								New:  "",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// ReschedulePolicy edited
+			Old: &TaskGroup{
+				ReschedulePolicy: &ReschedulePolicy{
+					Attempts: 1,
+					Interval: 1 * time.Second,
+				},
+			},
+			New: &TaskGroup{
+				ReschedulePolicy: &ReschedulePolicy{
+					Attempts: 2,
+					Interval: 2 * time.Second,
+				},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "ReschedulePolicy",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "Attempts",
+								Old:  "1",
+								New:  "2",
+							},
+							{
+								Type: DiffTypeEdited,
+								Name: "Interval",
+								Old:  "1000000000",
+								New:  "2000000000",
+							},
+						},
+					},
+				},
+			},
+		}, {
+			// ReschedulePolicy edited with context
+			Contextual: true,
+			Old: &TaskGroup{
+				ReschedulePolicy: &ReschedulePolicy{
+					Attempts: 1,
+					Interval: 1 * time.Second,
+				},
+			},
+			New: &TaskGroup{
+				ReschedulePolicy: &ReschedulePolicy{
+					Attempts: 1,
+					Interval: 2 * time.Second,
+				},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "ReschedulePolicy",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeNone,
+								Name: "Attempts",
+								Old:  "1",
+								New:  "1",
+							},
+							{
+								Type: DiffTypeEdited,
+								Name: "Interval",
+								Old:  "1000000000",
+								New:  "2000000000",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			// Update strategy deleted
 			Old: &TaskGroup{
 				Update: &UpdateStrategy{

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2514,6 +2514,17 @@ var (
 	}
 )
 
+var (
+	defaultServiceJobReschedulePolicy = ReschedulePolicy{
+		Attempts: 2,
+		Interval: 1 * time.Hour,
+	}
+	defaultBatchJobReschedulePolicy = ReschedulePolicy{
+		Attempts: 1,
+		Interval: 24 * time.Hour,
+	}
+)
+
 const (
 	// RestartPolicyModeDelay causes an artificial delay till the next interval is
 	// reached when the specified attempts have been reached in the interval.
@@ -2592,6 +2603,54 @@ func NewRestartPolicy(jobType string) *RestartPolicy {
 	return nil
 }
 
+const ReschedulePolicyMinInterval = 15 * time.Second
+
+// ReschedulePolicy configures how Tasks are rescheduled  when they crash or fail.
+type ReschedulePolicy struct {
+	// Attempts limits the number of rescheduling attempts that can occur in an interval.
+	Attempts int
+
+	// Interval is a duration in which we can limit the number of reschedule attempts.
+	Interval time.Duration
+
+	//TODO delay
+}
+
+func (r *ReschedulePolicy) Copy() *ReschedulePolicy {
+	if r == nil {
+		return nil
+	}
+	nrp := new(ReschedulePolicy)
+	*nrp = *r
+	return nrp
+}
+
+func (r *ReschedulePolicy) Validate() error {
+	var mErr multierror.Error
+	// Check for ambiguous/confusing settings
+	if r.Attempts < 0 {
+		multierror.Append(&mErr, fmt.Errorf("Attempts must be >= 0 (got %v)", r.Attempts))
+	}
+
+	if r.Interval.Nanoseconds() < ReschedulePolicyMinInterval.Nanoseconds() {
+		multierror.Append(&mErr, fmt.Errorf("Interval cannot be less than %v (got %v)", RestartPolicyMinInterval, r.Interval))
+	}
+
+	return mErr.ErrorOrNil()
+}
+
+func NewReshedulePolicy(jobType string) *ReschedulePolicy {
+	switch jobType {
+	case JobTypeService, JobTypeSystem:
+		rp := defaultServiceJobReschedulePolicy
+		return &rp
+	case JobTypeBatch:
+		rp := defaultBatchJobReschedulePolicy
+		return &rp
+	}
+	return nil
+}
+
 // TaskGroup is an atomic unit of placement. Each task group belongs to
 // a job and may contain any number of tasks. A task group support running
 // in many replicas using the same configuration..
@@ -2622,6 +2681,9 @@ type TaskGroup struct {
 	// Meta is used to associate arbitrary metadata with this
 	// task group. This is opaque to Nomad.
 	Meta map[string]string
+
+	// ReschedulePolicy
+	ReschedulePolicy *ReschedulePolicy
 }
 
 func (tg *TaskGroup) Copy() *TaskGroup {
@@ -2633,6 +2695,7 @@ func (tg *TaskGroup) Copy() *TaskGroup {
 	ntg.Update = ntg.Update.Copy()
 	ntg.Constraints = CopySliceConstraints(ntg.Constraints)
 	ntg.RestartPolicy = ntg.RestartPolicy.Copy()
+	ntg.ReschedulePolicy = ntg.ReschedulePolicy.Copy()
 
 	if tg.Tasks != nil {
 		tasks := make([]*Task, len(ntg.Tasks))
@@ -2661,6 +2724,10 @@ func (tg *TaskGroup) Canonicalize(job *Job) {
 	// Set the default restart policy.
 	if tg.RestartPolicy == nil {
 		tg.RestartPolicy = NewRestartPolicy(job.Type)
+	}
+
+	if tg.ReschedulePolicy == nil {
+		tg.ReschedulePolicy = NewReshedulePolicy(job.Type)
 	}
 
 	// Set a default ephemeral disk object if the user has not requested for one
@@ -2711,6 +2778,14 @@ func (tg *TaskGroup) Validate(j *Job) error {
 		}
 	} else {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("Task Group %v should have a restart policy", tg.Name))
+	}
+
+	if tg.ReschedulePolicy != nil {
+		if err := tg.ReschedulePolicy.Validate(); err != nil {
+			mErr.Errors = append(mErr.Errors, err)
+		}
+	} else {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("Task Group %v should have a reschedule policy", tg.Name))
 	}
 
 	if tg.EphemeralDisk != nil {
@@ -4836,6 +4911,26 @@ type DeploymentStatusUpdate struct {
 	StatusDescription string
 }
 
+type RescheduleTracker struct {
+	// RescheduleTime is the timestamp of a reschedule attempt
+	RescheduleTime int64
+
+	// PrevAllocID is the ID of the previous allocation being restarted
+	PrevAllocID string
+
+	// PrevNodeID is the node ID of the previous allocation
+	PrevNodeID string
+}
+
+func (rt *RescheduleTracker) Copy() *RescheduleTracker {
+	if rt == nil {
+		return nil
+	}
+	copy := new(RescheduleTracker)
+	*copy = *rt
+	return copy
+}
+
 const (
 	AllocDesiredStatusRun   = "run"   // Allocation should run
 	AllocDesiredStatusStop  = "stop"  // Allocation should stop
@@ -4931,6 +5026,9 @@ type Allocation struct {
 
 	// ModifyTime is the time the allocation was last updated.
 	ModifyTime int64
+
+	// RescheduleTrackers captures details of previous reschedule attempts of the allocation
+	RescheduleTrackers []*RescheduleTracker
 }
 
 // Index returns the index of the allocation. If the allocation is from a task
@@ -4988,6 +5086,13 @@ func (a *Allocation) copyImpl(job bool) *Allocation {
 		}
 		na.TaskStates = ts
 	}
+
+	if a.RescheduleTrackers != nil {
+		var rescheduleTrackers []*RescheduleTracker
+		for _, tracker := range a.RescheduleTrackers {
+			rescheduleTrackers = append(rescheduleTrackers, tracker.Copy())
+		}
+	}
 	return na
 }
 
@@ -5008,6 +5113,44 @@ func (a *Allocation) TerminalStatus() bool {
 	default:
 		return false
 	}
+}
+
+// ShouldReschedule returns if the allocation is eligible to be rescheduled according
+// to its status and ReschedulePolicy
+func (a *Allocation) ShouldReschedule(reschedulePolicy *ReschedulePolicy) bool {
+	// First check the desired state
+	switch a.DesiredStatus {
+	case AllocDesiredStatusStop, AllocDesiredStatusEvict:
+		return false
+	default:
+	}
+	if reschedulePolicy == nil {
+		return false
+	}
+	switch a.ClientStatus {
+	case AllocClientStatusFailed:
+		return a.rescheduleEligible(reschedulePolicy.Interval, reschedulePolicy.Attempts)
+	default:
+		return false
+	}
+}
+
+func (a *Allocation) rescheduleEligible(interval time.Duration, attempts int) bool {
+	if attempts == 0 {
+		return false
+	}
+	if a.RescheduleTrackers == nil && attempts > 0 {
+		return true
+	}
+	attempted := 0
+	for j := len(a.RescheduleTrackers) - 1; j >= 0; j-- {
+		lastAttempt := a.RescheduleTrackers[j].RescheduleTime
+		timeDiff := time.Now().UTC().UnixNano() - lastAttempt
+		if timeDiff < interval.Nanoseconds() {
+			attempted += 1
+		}
+	}
+	return attempted < attempts
 }
 
 // Terminated returns if the allocation is in a terminal state on a client.
@@ -5033,7 +5176,7 @@ func (a *Allocation) RanSuccessfully() bool {
 		return false
 	}
 
-	// Check to see if all the tasks finised successfully in the allocation
+	// Check to see if all the tasks finished successfully in the allocation
 	allSuccess := true
 	for _, state := range a.TaskStates {
 		allSuccess = allSuccess && state.Successful()
@@ -5319,6 +5462,7 @@ const (
 	EvalTriggerDeploymentWatcher = "deployment-watcher"
 	EvalTriggerFailedFollowUp    = "failed-follow-up"
 	EvalTriggerMaxPlans          = "max-plan-attempts"
+	EvalTriggerRetryFailedAlloc  = "replacing-after-failure"
 )
 
 const (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2515,11 +2515,11 @@ var (
 )
 
 var (
-	defaultServiceJobReschedulePolicy = ReschedulePolicy{
+	DefaultServiceJobReschedulePolicy = ReschedulePolicy{
 		Attempts: 2,
 		Interval: 1 * time.Hour,
 	}
-	defaultBatchJobReschedulePolicy = ReschedulePolicy{
+	DefaultBatchJobReschedulePolicy = ReschedulePolicy{
 		Attempts: 1,
 		Interval: 24 * time.Hour,
 	}
@@ -2626,26 +2626,25 @@ func (r *ReschedulePolicy) Copy() *ReschedulePolicy {
 }
 
 func (r *ReschedulePolicy) Validate() error {
-	var mErr multierror.Error
-	// Check for ambiguous/confusing settings
-	if r.Attempts < 0 {
-		multierror.Append(&mErr, fmt.Errorf("Attempts must be >= 0 (got %v)", r.Attempts))
-	}
+	if r != nil && r.Attempts > 0 {
+		var mErr multierror.Error
+		// Check for ambiguous/confusing settings
+		if r.Interval.Nanoseconds() < ReschedulePolicyMinInterval.Nanoseconds() {
+			multierror.Append(&mErr, fmt.Errorf("Interval cannot be less than %v (got %v)", RestartPolicyMinInterval, r.Interval))
+		}
 
-	if r.Interval.Nanoseconds() < ReschedulePolicyMinInterval.Nanoseconds() {
-		multierror.Append(&mErr, fmt.Errorf("Interval cannot be less than %v (got %v)", RestartPolicyMinInterval, r.Interval))
+		return mErr.ErrorOrNil()
 	}
-
-	return mErr.ErrorOrNil()
+	return nil
 }
 
 func NewReshedulePolicy(jobType string) *ReschedulePolicy {
 	switch jobType {
-	case JobTypeService, JobTypeSystem:
-		rp := defaultServiceJobReschedulePolicy
+	case JobTypeService:
+		rp := DefaultServiceJobReschedulePolicy
 		return &rp
 	case JobTypeBatch:
-		rp := defaultBatchJobReschedulePolicy
+		rp := DefaultBatchJobReschedulePolicy
 		return &rp
 	}
 	return nil
@@ -4912,7 +4911,13 @@ type DeploymentStatusUpdate struct {
 	StatusDescription string
 }
 
+// RescheduleTracker encapsulates previous reschedule events
 type RescheduleTracker struct {
+	Events []*RescheduleEvent
+}
+
+// RescheduleEvent is used to keep track of previous attempts at rescheduling an allocation
+type RescheduleEvent struct {
 	// RescheduleTime is the timestamp of a reschedule attempt
 	RescheduleTime int64
 
@@ -4923,11 +4928,11 @@ type RescheduleTracker struct {
 	PrevNodeID string
 }
 
-func (rt *RescheduleTracker) Copy() *RescheduleTracker {
+func (rt *RescheduleEvent) Copy() *RescheduleEvent {
 	if rt == nil {
 		return nil
 	}
-	copy := new(RescheduleTracker)
+	copy := new(RescheduleEvent)
 	*copy = *rt
 	return copy
 }
@@ -5029,7 +5034,7 @@ type Allocation struct {
 	ModifyTime int64
 
 	// RescheduleTrackers captures details of previous reschedule attempts of the allocation
-	RescheduleTrackers []*RescheduleTracker
+	RescheduleTracker *RescheduleTracker
 }
 
 // Index returns the index of the allocation. If the allocation is from a task
@@ -5088,9 +5093,9 @@ func (a *Allocation) copyImpl(job bool) *Allocation {
 		na.TaskStates = ts
 	}
 
-	if a.RescheduleTrackers != nil {
-		var rescheduleTrackers []*RescheduleTracker
-		for _, tracker := range a.RescheduleTrackers {
+	if a.RescheduleTracker != nil {
+		var rescheduleTrackers []*RescheduleEvent
+		for _, tracker := range a.RescheduleTracker.Events {
 			rescheduleTrackers = append(rescheduleTrackers, tracker.Copy())
 		}
 	}
@@ -5117,8 +5122,8 @@ func (a *Allocation) TerminalStatus() bool {
 }
 
 // ShouldReschedule returns if the allocation is eligible to be rescheduled according
-// to its status and ReschedulePolicy
-func (a *Allocation) ShouldReschedule(reschedulePolicy *ReschedulePolicy) bool {
+// to its status and ReschedulePolicy given its failure time
+func (a *Allocation) ShouldReschedule(reschedulePolicy *ReschedulePolicy, failTime time.Time) bool {
 	// First check the desired state
 	switch a.DesiredStatus {
 	case AllocDesiredStatusStop, AllocDesiredStatusEvict:
@@ -5127,7 +5132,7 @@ func (a *Allocation) ShouldReschedule(reschedulePolicy *ReschedulePolicy) bool {
 	}
 	switch a.ClientStatus {
 	case AllocClientStatusFailed:
-		return a.RescheduleEligible(reschedulePolicy)
+		return a.RescheduleEligible(reschedulePolicy, failTime)
 	default:
 		return false
 	}
@@ -5135,7 +5140,7 @@ func (a *Allocation) ShouldReschedule(reschedulePolicy *ReschedulePolicy) bool {
 
 // RescheduleEligible returns if the allocation is eligible to be rescheduled according
 // to its ReschedulePolicy and the current state of its reschedule trackers
-func (a *Allocation) RescheduleEligible(reschedulePolicy *ReschedulePolicy) bool {
+func (a *Allocation) RescheduleEligible(reschedulePolicy *ReschedulePolicy, failTime time.Time) bool {
 	if reschedulePolicy == nil {
 		return false
 	}
@@ -5145,13 +5150,13 @@ func (a *Allocation) RescheduleEligible(reschedulePolicy *ReschedulePolicy) bool
 	if attempts == 0 {
 		return false
 	}
-	if a.RescheduleTrackers == nil && attempts > 0 {
+	if (a.RescheduleTracker == nil || len(a.RescheduleTracker.Events) == 0) && attempts > 0 {
 		return true
 	}
 	attempted := 0
-	for j := len(a.RescheduleTrackers) - 1; j >= 0; j-- {
-		lastAttempt := a.RescheduleTrackers[j].RescheduleTime
-		timeDiff := time.Now().UTC().UnixNano() - lastAttempt
+	for j := len(a.RescheduleTracker.Events) - 1; j >= 0; j-- {
+		lastAttempt := a.RescheduleTracker.Events[j].RescheduleTime
+		timeDiff := failTime.UTC().UnixNano() - lastAttempt
 		if timeDiff < interval.Nanoseconds() {
 			attempted += 1
 		}
@@ -5468,7 +5473,7 @@ const (
 	EvalTriggerDeploymentWatcher = "deployment-watcher"
 	EvalTriggerFailedFollowUp    = "failed-follow-up"
 	EvalTriggerMaxPlans          = "max-plan-attempts"
-	EvalTriggerRetryFailedAlloc  = "replacing-after-failure"
+	EvalTriggerRetryFailedAlloc  = "alloc-failure"
 )
 
 const (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2682,7 +2682,8 @@ type TaskGroup struct {
 	// task group. This is opaque to Nomad.
 	Meta map[string]string
 
-	// ReschedulePolicy
+	// ReschedulePolicy is used to configure how the scheduler should
+	// retry failed allocations.
 	ReschedulePolicy *ReschedulePolicy
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4916,6 +4916,20 @@ type RescheduleTracker struct {
 	Events []*RescheduleEvent
 }
 
+func (rt *RescheduleTracker) Copy() *RescheduleTracker {
+	if rt == nil {
+		return nil
+	}
+	nt := &RescheduleTracker{}
+	*nt = *rt
+	rescheduleEvents := make([]*RescheduleEvent, 0, len(rt.Events))
+	for _, tracker := range rt.Events {
+		rescheduleEvents = append(rescheduleEvents, tracker.Copy())
+	}
+	nt.Events = rescheduleEvents
+	return nt
+}
+
 // RescheduleEvent is used to keep track of previous attempts at rescheduling an allocation
 type RescheduleEvent struct {
 	// RescheduleTime is the timestamp of a reschedule attempt
@@ -4928,12 +4942,12 @@ type RescheduleEvent struct {
 	PrevNodeID string
 }
 
-func (rt *RescheduleEvent) Copy() *RescheduleEvent {
-	if rt == nil {
+func (re *RescheduleEvent) Copy() *RescheduleEvent {
+	if re == nil {
 		return nil
 	}
 	copy := new(RescheduleEvent)
-	*copy = *rt
+	*copy = *re
 	return copy
 }
 
@@ -5093,12 +5107,7 @@ func (a *Allocation) copyImpl(job bool) *Allocation {
 		na.TaskStates = ts
 	}
 
-	if a.RescheduleTracker != nil {
-		var rescheduleTrackers []*RescheduleEvent
-		for _, tracker := range a.RescheduleTracker.Events {
-			rescheduleTrackers = append(rescheduleTrackers, tracker.Copy())
-		}
-	}
+	na.RescheduleTracker = a.RescheduleTracker.Copy()
 	return na
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5125,18 +5125,23 @@ func (a *Allocation) ShouldReschedule(reschedulePolicy *ReschedulePolicy) bool {
 		return false
 	default:
 	}
-	if reschedulePolicy == nil {
-		return false
-	}
 	switch a.ClientStatus {
 	case AllocClientStatusFailed:
-		return a.rescheduleEligible(reschedulePolicy.Interval, reschedulePolicy.Attempts)
+		return a.RescheduleEligible(reschedulePolicy)
 	default:
 		return false
 	}
 }
 
-func (a *Allocation) rescheduleEligible(interval time.Duration, attempts int) bool {
+// RescheduleEligible returns if the allocation is eligible to be rescheduled according
+// to its ReschedulePolicy and the current state of its reschedule trackers
+func (a *Allocation) RescheduleEligible(reschedulePolicy *ReschedulePolicy) bool {
+	if reschedulePolicy == nil {
+		return false
+	}
+	attempts := reschedulePolicy.Attempts
+	interval := reschedulePolicy.Interval
+
 	if attempts == 0 {
 		return false
 	}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2313,16 +2313,28 @@ func TestReschedulePolicy_Validate(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			ReschedulePolicy: &ReschedulePolicy{1, 5 * time.Minute},
-			err:              nil,
+			ReschedulePolicy: &ReschedulePolicy{
+				Attempts: 0,
+				Interval: 0 * time.Second},
+			err: nil,
 		},
 		{
-			ReschedulePolicy: &ReschedulePolicy{-1, 5 * time.Minute},
-			err:              nil,
+			ReschedulePolicy: &ReschedulePolicy{
+				Attempts: 1,
+				Interval: 5 * time.Minute},
+			err: nil,
 		},
 		{
-			ReschedulePolicy: &ReschedulePolicy{1, 1 * time.Second},
-			err:              fmt.Errorf("Interval cannot be less than %v (got %v)", RestartPolicyMinInterval, time.Second),
+			ReschedulePolicy: &ReschedulePolicy{
+				Attempts: -1,
+				Interval: 5 * time.Minute},
+			err: nil,
+		},
+		{
+			ReschedulePolicy: &ReschedulePolicy{
+				Attempts: 1,
+				Interval: 1 * time.Second},
+			err: fmt.Errorf("Interval cannot be less than %v (got %v)", RestartPolicyMinInterval, time.Second),
 		},
 	}
 
@@ -2599,6 +2611,14 @@ func TestAllocation_ShouldReschedule(t *testing.T) {
 			DesiredStatus:    AllocDesiredStatusRun,
 			FailTime:         fail,
 			ReschedulePolicy: nil,
+			ShouldReschedule: false,
+		},
+		{
+			Desc:             "Disabled recheduling",
+			ClientStatus:     AllocClientStatusFailed,
+			DesiredStatus:    AllocDesiredStatusRun,
+			FailTime:         fail,
+			ReschedulePolicy: &ReschedulePolicy{0, 1 * time.Minute},
 			ShouldReschedule: false,
 		},
 		{

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2684,6 +2684,28 @@ func TestAllocation_ShouldReschedule(t *testing.T) {
 	}
 }
 
+func TestRescheduleTracker_Copy(t *testing.T) {
+	type testCase struct {
+		original *RescheduleTracker
+		expected *RescheduleTracker
+	}
+
+	cases := []testCase{
+		{nil, nil},
+		{&RescheduleTracker{Events: []*RescheduleEvent{
+			{2, "12", "12"},
+		}}, &RescheduleTracker{Events: []*RescheduleEvent{
+			{2, "12", "12"},
+		}}},
+	}
+
+	for _, tc := range cases {
+		if got := tc.original.Copy(); !reflect.DeepEqual(got, tc.expected) {
+			t.Fatalf("expected %v but got %v", *tc.expected, *got)
+		}
+	}
+}
+
 func TestVault_Validate(t *testing.T) {
 	v := &Vault{
 		Env:        true,

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -189,10 +189,11 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:          "foo",
-						Count:         2,
-						RestartPolicy: NewRestartPolicy(JobTypeService),
-						EphemeralDisk: DefaultEphemeralDisk(),
+						Name:             "foo",
+						Count:            2,
+						RestartPolicy:    NewRestartPolicy(JobTypeService),
+						ReschedulePolicy: NewReshedulePolicy(JobTypeService),
+						EphemeralDisk:    DefaultEphemeralDisk(),
 						Update: &UpdateStrategy{
 							Stagger:         30 * time.Second,
 							MaxParallel:     2,
@@ -229,10 +230,11 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 				Update:    UpdateStrategy{},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:          "foo",
-						Count:         2,
-						RestartPolicy: NewRestartPolicy(JobTypeBatch),
-						EphemeralDisk: DefaultEphemeralDisk(),
+						Name:             "foo",
+						Count:            2,
+						RestartPolicy:    NewRestartPolicy(JobTypeBatch),
+						ReschedulePolicy: NewReshedulePolicy(JobTypeBatch),
+						EphemeralDisk:    DefaultEphemeralDisk(),
 					},
 				},
 			},
@@ -272,10 +274,11 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 				Update:    UpdateStrategy{},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:          "foo",
-						Count:         2,
-						RestartPolicy: NewRestartPolicy(JobTypeBatch),
-						EphemeralDisk: DefaultEphemeralDisk(),
+						Name:             "foo",
+						Count:            2,
+						RestartPolicy:    NewRestartPolicy(JobTypeBatch),
+						ReschedulePolicy: NewReshedulePolicy(JobTypeBatch),
+						EphemeralDisk:    DefaultEphemeralDisk(),
 					},
 				},
 			},
@@ -321,10 +324,11 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:          "foo",
-						Count:         2,
-						RestartPolicy: NewRestartPolicy(JobTypeService),
-						EphemeralDisk: DefaultEphemeralDisk(),
+						Name:             "foo",
+						Count:            2,
+						RestartPolicy:    NewRestartPolicy(JobTypeService),
+						ReschedulePolicy: NewReshedulePolicy(JobTypeService),
+						EphemeralDisk:    DefaultEphemeralDisk(),
 						Update: &UpdateStrategy{
 							Stagger:         2 * time.Second,
 							MaxParallel:     2,
@@ -363,10 +367,11 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:          "foo",
-						Count:         2,
-						RestartPolicy: NewRestartPolicy(JobTypeService),
-						EphemeralDisk: DefaultEphemeralDisk(),
+						Name:             "foo",
+						Count:            2,
+						RestartPolicy:    NewRestartPolicy(JobTypeService),
+						ReschedulePolicy: NewReshedulePolicy(JobTypeService),
+						EphemeralDisk:    DefaultEphemeralDisk(),
 						Update: &UpdateStrategy{
 							Stagger:         30 * time.Second,
 							MaxParallel:     2,
@@ -414,10 +419,11 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:          "foo",
-						Count:         2,
-						RestartPolicy: NewRestartPolicy(JobTypeService),
-						EphemeralDisk: DefaultEphemeralDisk(),
+						Name:             "foo",
+						Count:            2,
+						RestartPolicy:    NewRestartPolicy(JobTypeService),
+						ReschedulePolicy: NewReshedulePolicy(JobTypeService),
+						EphemeralDisk:    DefaultEphemeralDisk(),
 						Update: &UpdateStrategy{
 							Stagger:         30 * time.Second,
 							MaxParallel:     1,
@@ -429,10 +435,11 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 						},
 					},
 					{
-						Name:          "bar",
-						Count:         14,
-						RestartPolicy: NewRestartPolicy(JobTypeService),
-						EphemeralDisk: DefaultEphemeralDisk(),
+						Name:             "bar",
+						Count:            14,
+						RestartPolicy:    NewRestartPolicy(JobTypeService),
+						ReschedulePolicy: NewReshedulePolicy(JobTypeService),
+						EphemeralDisk:    DefaultEphemeralDisk(),
 						Update: &UpdateStrategy{
 							Stagger:         30 * time.Second,
 							MaxParallel:     1,
@@ -444,10 +451,11 @@ func TestJob_Canonicalize_Update(t *testing.T) {
 						},
 					},
 					{
-						Name:          "foo",
-						Count:         26,
-						EphemeralDisk: DefaultEphemeralDisk(),
-						RestartPolicy: NewRestartPolicy(JobTypeService),
+						Name:             "foo",
+						Count:            26,
+						EphemeralDisk:    DefaultEphemeralDisk(),
+						RestartPolicy:    NewRestartPolicy(JobTypeService),
+						ReschedulePolicy: NewReshedulePolicy(JobTypeService),
 						Update: &UpdateStrategy{
 							Stagger:         30 * time.Second,
 							MaxParallel:     3,
@@ -559,6 +567,10 @@ func testJob() *Job {
 					Attempts: 3,
 					Interval: 10 * time.Minute,
 					Delay:    1 * time.Minute,
+				},
+				ReschedulePolicy: &ReschedulePolicy{
+					Interval: 5 * time.Minute,
+					Attempts: 10,
 				},
 				Tasks: []*Task{
 					{
@@ -914,6 +926,10 @@ func TestTaskGroup_Validate(t *testing.T) {
 			Attempts: 10,
 			Mode:     RestartPolicyModeDelay,
 		},
+		ReschedulePolicy: &ReschedulePolicy{
+			Interval: 5 * time.Minute,
+			Attempts: 5,
+		},
 	}
 	err := tg.Validate(j)
 	mErr := err.(*multierror.Error)
@@ -993,6 +1009,10 @@ func TestTaskGroup_Validate(t *testing.T) {
 			Delay:    10 * time.Second,
 			Attempts: 10,
 			Mode:     RestartPolicyModeDelay,
+		},
+		ReschedulePolicy: &ReschedulePolicy{
+			Interval: 5 * time.Minute,
+			Attempts: 10,
 		},
 	}
 
@@ -2285,6 +2305,38 @@ func TestRestartPolicy_Validate(t *testing.T) {
 	}
 }
 
+func TestReschedulePolicy_Validate(t *testing.T) {
+	type testCase struct {
+		ReschedulePolicy *ReschedulePolicy
+		err              error
+	}
+
+	testCases := []testCase{
+		{
+			ReschedulePolicy: &ReschedulePolicy{1, 5 * time.Minute},
+			err:              nil,
+		},
+		{
+			ReschedulePolicy: &ReschedulePolicy{-1, 5 * time.Minute},
+			err:              fmt.Errorf("Attempts must be >= 0 (got -1)"),
+		},
+		{
+			ReschedulePolicy: &ReschedulePolicy{1, 1 * time.Second},
+			err:              fmt.Errorf("Interval cannot be less than %v (got %v)", RestartPolicyMinInterval, time.Second),
+		},
+	}
+
+	assert := assert.New(t)
+
+	for _, tc := range testCases {
+		if tc.err != nil {
+			assert.Contains(tc.ReschedulePolicy.Validate().Error(), tc.err.Error())
+		} else {
+			assert.Nil(tc.err)
+		}
+	}
+}
+
 func TestAllocation_Index(t *testing.T) {
 	a1 := Allocation{
 		Name:      "example.cache[1]",
@@ -2508,6 +2560,115 @@ func TestAllocation_Terminated(t *testing.T) {
 		if alloc.Terminated() != state.Terminated {
 			t.Fatalf("expected: %v, actual: %v", state.Terminated, alloc.Terminated())
 		}
+	}
+}
+
+func TestAllocation_ShouldReschedule(t *testing.T) {
+	type testCase struct {
+		Desc               string
+		ClientStatus       string
+		DesiredStatus      string
+		ReschedulePolicy   *ReschedulePolicy
+		RescheduleTrackers []*RescheduleTracker
+		ShouldReschedule   bool
+	}
+
+	harness := []testCase{
+		{
+			Desc:             "Reschedule when desired state is stop",
+			ClientStatus:     AllocClientStatusPending,
+			DesiredStatus:    AllocDesiredStatusStop,
+			ReschedulePolicy: nil,
+			ShouldReschedule: false,
+		},
+		{
+			Desc:             "Reschedule when client status is complete",
+			ClientStatus:     AllocClientStatusComplete,
+			DesiredStatus:    AllocDesiredStatusRun,
+			ReschedulePolicy: nil,
+			ShouldReschedule: false,
+		},
+		{
+			Desc:             "Reschedule with nil reschedule policy",
+			ClientStatus:     AllocClientStatusFailed,
+			DesiredStatus:    AllocDesiredStatusRun,
+			ReschedulePolicy: nil,
+			ShouldReschedule: false,
+		},
+		{
+			Desc:             "Reschedule when client status is complete",
+			ClientStatus:     AllocClientStatusComplete,
+			DesiredStatus:    AllocDesiredStatusRun,
+			ReschedulePolicy: nil,
+			ShouldReschedule: false,
+		},
+		{
+			Desc:             "Reschedule with policy when client status complete",
+			ClientStatus:     AllocClientStatusComplete,
+			DesiredStatus:    AllocDesiredStatusRun,
+			ReschedulePolicy: &ReschedulePolicy{1, 1 * time.Minute},
+			ShouldReschedule: false,
+		},
+		{
+			Desc:             "Reschedule with no previous attempts",
+			ClientStatus:     AllocClientStatusFailed,
+			DesiredStatus:    AllocDesiredStatusRun,
+			ReschedulePolicy: &ReschedulePolicy{1, 1 * time.Minute},
+			ShouldReschedule: true,
+		},
+		{
+			Desc:             "Reschedule with leftover attempts",
+			ClientStatus:     AllocClientStatusFailed,
+			DesiredStatus:    AllocDesiredStatusRun,
+			ReschedulePolicy: &ReschedulePolicy{2, 5 * time.Minute},
+			RescheduleTrackers: []*RescheduleTracker{
+				{
+					RescheduleTime: time.Now().Add(-1 * time.Minute).UTC().UnixNano(),
+				},
+			},
+			ShouldReschedule: true,
+		},
+		{
+			Desc:             "Reschedule with too old previous attempts",
+			ClientStatus:     AllocClientStatusFailed,
+			DesiredStatus:    AllocDesiredStatusRun,
+			ReschedulePolicy: &ReschedulePolicy{1, 5 * time.Minute},
+			RescheduleTrackers: []*RescheduleTracker{
+				{
+					RescheduleTime: time.Now().Add(-6 * time.Minute).UTC().UnixNano(),
+				},
+			},
+			ShouldReschedule: true,
+		},
+		{
+			Desc:             "Reschedule with no leftover attempts",
+			ClientStatus:     AllocClientStatusFailed,
+			DesiredStatus:    AllocDesiredStatusRun,
+			ReschedulePolicy: &ReschedulePolicy{2, 5 * time.Minute},
+			RescheduleTrackers: []*RescheduleTracker{
+				{
+					RescheduleTime: time.Now().Add(-3 * time.Minute).UTC().UnixNano(),
+				},
+				{
+					RescheduleTime: time.Now().Add(-4 * time.Minute).UTC().UnixNano(),
+				},
+			},
+			ShouldReschedule: false,
+		},
+	}
+
+	for _, state := range harness {
+		alloc := Allocation{}
+		alloc.DesiredStatus = state.DesiredStatus
+		alloc.ClientStatus = state.ClientStatus
+		alloc.RescheduleTrackers = state.RescheduleTrackers
+
+		t.Run(state.Desc, func(t *testing.T) {
+			if got := alloc.ShouldReschedule(state.ReschedulePolicy); got != state.ShouldReschedule {
+				t.Fatalf("expected %v but got %v", state.ShouldReschedule, got)
+			}
+		})
+
 	}
 }
 


### PR DESCRIPTION
This PR adds a new config struct for rescheduling, and new alloc field `RescheduleTracker`. Also adds a method to determine when an allocation is eligible to be rescheduled, and unit tests.  