### PR TITLE
Scheduler and reconciler changes to support rescheduling

### DIFF
--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -91,6 +91,10 @@ func Job() *structs.Job {
 					Delay:    1 * time.Minute,
 					Mode:     structs.RestartPolicyModeDelay,
 				},
+				ReschedulePolicy: &structs.ReschedulePolicy{
+					Attempts: 2,
+					Interval: 10 * time.Minute,
+				},
 				Tasks: []*structs.Task{
 					{
 						Name:   "web",

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4942,6 +4942,12 @@ type RescheduleEvent struct {
 	PrevNodeID string
 }
 
+func NewRescheduleEvent(rescheduleTime int64, prevAllocID string, prevNodeID string) *RescheduleEvent {
+	return &RescheduleEvent{RescheduleTime: rescheduleTime,
+		PrevAllocID: prevAllocID,
+		PrevNodeID:  prevNodeID}
+}
+
 func (re *RescheduleEvent) Copy() *RescheduleEvent {
 	if re == nil {
 		return nil

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -438,9 +438,9 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 			if prevAllocation != nil {
 				var penaltyNodes []string
 				penaltyNodes = append(penaltyNodes, prevAllocation.NodeID)
-				if prevAllocation.RescheduleTrackers != nil {
-					for _, reschedTracker := range prevAllocation.RescheduleTrackers {
-						penaltyNodes = append(penaltyNodes, reschedTracker.PrevNodeID)
+				if prevAllocation.RescheduleTracker != nil {
+					for _, reschedEvent := range prevAllocation.RescheduleTracker.Events {
+						penaltyNodes = append(penaltyNodes, reschedEvent.PrevNodeID)
 					}
 				}
 				selectOptions.PenaltyNodeIDs = penaltyNodes
@@ -482,14 +482,14 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 				// set the record the older allocation id so that they are chained
 				if prev := prevAllocation; prev != nil {
 					alloc.PreviousAllocation = prev.ID
-					var rescheduleTrackers []*structs.RescheduleTracker
-					if prev.RescheduleTrackers != nil {
-						for _, reschedInfo := range prev.RescheduleTrackers {
-							rescheduleTrackers = append(rescheduleTrackers, reschedInfo.Copy())
+					var rescheduleEvents []*structs.RescheduleEvent
+					if prev.RescheduleTracker != nil {
+						for _, reschedEvent := range prev.RescheduleTracker.Events {
+							rescheduleEvents = append(rescheduleEvents, reschedEvent.Copy())
 						}
 					}
-					rescheduleTrackers = append(rescheduleTrackers, &structs.RescheduleTracker{RescheduleTime: time.Now().UTC().UnixNano(), PrevAllocID: prev.ID, PrevNodeID: alloc.NodeID})
-					alloc.RescheduleTrackers = rescheduleTrackers
+					rescheduleEvents = append(rescheduleEvents, &structs.RescheduleEvent{RescheduleTime: time.Now().UTC().UnixNano(), PrevAllocID: prev.ID, PrevNodeID: alloc.NodeID})
+					alloc.RescheduleTracker = &structs.RescheduleTracker{Events: rescheduleEvents}
 				}
 
 				// If we are placing a canary and we found a match, add the canary

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -466,7 +466,7 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 				// set the record the older allocation id so that they are chained
 				if prevAllocation != nil {
 					alloc.PreviousAllocation = prevAllocation.ID
-					if tg.ReschedulePolicy != nil && tg.ReschedulePolicy.Attempts > 0 {
+					if missing.Reschedule() {
 						updateRescheduleTracker(alloc, prevAllocation)
 					}
 				}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -2788,8 +2788,8 @@ func TestServiceSched_Reschedule_Once(t *testing.T) {
 		}
 	}
 	assert.Equal(failedAllocID, newAlloc.PreviousAllocation)
-	assert.Equal(1, len(newAlloc.RescheduleTrackers))
-	assert.Equal(failedAllocID, newAlloc.RescheduleTrackers[0].PrevAllocID)
+	assert.Equal(1, len(newAlloc.RescheduleTracker.Events))
+	assert.Equal(failedAllocID, newAlloc.RescheduleTracker.Events[0].PrevAllocID)
 
 	// Mark this alloc as failed again, should not get rescheduled
 	newAlloc.ClientStatus = structs.AllocClientStatusFailed
@@ -2890,14 +2890,13 @@ func TestServiceSched_Reschedule_Multiple(t *testing.T) {
 		var pendingAllocs []*structs.Allocation
 		fmt.Println("Iteration: ", i)
 		for _, alloc := range out {
-			fmt.Println(alloc.ID, alloc.ClientStatus, len(alloc.RescheduleTrackers), alloc.PreviousAllocation)
 			if alloc.ClientStatus == structs.AllocClientStatusPending {
 				pendingAllocs = append(pendingAllocs, alloc)
 			}
 		}
 		assert.Equal(1, len(pendingAllocs))
 		newAlloc := pendingAllocs[0]
-		assert.Equal(expectedNumReschedTrackers, len(newAlloc.RescheduleTrackers))
+		assert.Equal(expectedNumReschedTrackers, len(newAlloc.RescheduleTracker.Events))
 
 		// Mark this alloc as failed again
 		newAlloc.ClientStatus = structs.AllocClientStatusFailed

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -2888,7 +2888,6 @@ func TestServiceSched_Reschedule_Multiple(t *testing.T) {
 
 		// Find the new alloc with ClientStatusPending
 		var pendingAllocs []*structs.Allocation
-		fmt.Println("Iteration: ", i)
 		for _, alloc := range out {
 			if alloc.ClientStatus == structs.AllocClientStatusPending {
 				pendingAllocs = append(pendingAllocs, alloc)

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -304,3 +304,52 @@ func (iter *JobAntiAffinityIterator) Next() *RankedNode {
 func (iter *JobAntiAffinityIterator) Reset() {
 	iter.source.Reset()
 }
+
+// NodeAntiAffinityIterator is used to apply a penalty to
+// a node that had a previous failed allocation for the same job.
+// This is used when attempting to reschedule a failed alloc
+type NodeAntiAffinityIterator struct {
+	ctx          Context
+	source       RankIterator
+	penalty      float64
+	penaltyNodes map[string]struct{}
+}
+
+// NewNodeAntiAffinityIterator is used to create a NodeAntiAffinityIterator that
+// applies the given penalty for placement onto nodes in penaltyNodes
+func NewNodeAntiAffinityIterator(ctx Context, source RankIterator, penalty float64) *NodeAntiAffinityIterator {
+	iter := &NodeAntiAffinityIterator{
+		ctx:     ctx,
+		source:  source,
+		penalty: penalty,
+	}
+	return iter
+}
+
+func (iter *NodeAntiAffinityIterator) SetPenaltyNodes(nodes []string) {
+	penaltyNodes := make(map[string]struct{})
+	for _, node := range nodes {
+		penaltyNodes[node] = struct{}{}
+	}
+	iter.penaltyNodes = penaltyNodes
+}
+
+func (iter *NodeAntiAffinityIterator) Next() *RankedNode {
+	for {
+		option := iter.source.Next()
+		if option == nil {
+			return nil
+		}
+
+		_, ok := iter.penaltyNodes[option.Node.ID]
+		if ok {
+			option.Score -= iter.penalty
+			iter.ctx.Metrics().ScoreNode(option.Node, "node-anti-affinity", iter.penalty)
+		}
+		return option
+	}
+}
+
+func (iter *NodeAntiAffinityIterator) Reset() {
+	iter.source.Reset()
+}

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -326,11 +326,7 @@ func NewNodeAntiAffinityIterator(ctx Context, source RankIterator, penalty float
 	return iter
 }
 
-func (iter *NodeAntiAffinityIterator) SetPenaltyNodes(nodes []string) {
-	penaltyNodes := make(map[string]struct{})
-	for _, node := range nodes {
-		penaltyNodes[node] = struct{}{}
-	}
+func (iter *NodeAntiAffinityIterator) SetPenaltyNodes(penaltyNodes map[string]struct{}) {
 	iter.penaltyNodes = penaltyNodes
 }
 
@@ -351,5 +347,6 @@ func (iter *NodeAntiAffinityIterator) Next() *RankedNode {
 }
 
 func (iter *NodeAntiAffinityIterator) Reset() {
+	iter.penaltyNodes = make(map[string]struct{})
 	iter.source.Reset()
 }

--- a/scheduler/rank_test.go
+++ b/scheduler/rank_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
 )
 
 func TestFeasibleRankIterator(t *testing.T) {
@@ -451,15 +451,16 @@ func TestNodeAntiAffinity_PenaltyNodes(t *testing.T) {
 	static := NewStaticRankIterator(ctx, nodes)
 
 	nodeAntiAffIter := NewNodeAntiAffinityIterator(ctx, static, 50.0)
-	nodeAntiAffIter.SetPenaltyNodes([]string{node1.ID})
+	nodeAntiAffIter.SetPenaltyNodes(map[string]struct{}{node1.ID: {}})
 
 	out := collectRanked(nodeAntiAffIter)
-	assert := assert.New(t)
-	assert.Equal(2, len(out))
-	assert.Equal(node1.ID, out[0].Node.ID)
-	assert.Equal(-50.0, out[0].Score)
 
-	assert.Equal(node2.ID, out[1].Node.ID)
-	assert.Equal(0.0, out[1].Score)
+	require := require.New(t)
+	require.Equal(2, len(out))
+	require.Equal(node1.ID, out[0].Node.ID)
+	require.Equal(-50.0, out[0].Score)
+
+	require.Equal(node2.ID, out[1].Node.ID)
+	require.Equal(0.0, out[1].Score)
 
 }

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -620,7 +620,7 @@ func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
 		return nil
 	}
 	var place []allocPlaceResult
-	// add rescheduled alloc placement results
+	// Add rescheduled placement results
 	for _, alloc := range reschedule {
 		place = append(place, allocPlaceResult{
 			name:          alloc.Name,
@@ -632,7 +632,7 @@ func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
 			break
 		}
 	}
-	// add remaining
+	// Add remaining placement results
 	if existing < group.Count {
 		for _, name := range nameIndex.Next(uint(group.Count - existing)) {
 			place = append(place, allocPlaceResult{

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -628,6 +628,7 @@ func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
 			name:          alloc.Name,
 			taskGroup:     group,
 			previousAlloc: alloc,
+			reschedule:    true,
 		})
 		existing += 1
 		if existing == group.Count {

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -673,11 +673,7 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 
 	// Filter out any terminal allocations from the untainted set
 	// This is so that we don't try to mark them as stopped redundantly
-	for id, alloc := range untainted {
-		if alloc.TerminalStatus() {
-			delete(untainted, id)
-		}
-	}
+	untainted = filterByTerminal(untainted)
 
 	// Prefer stopping any alloc that has the same name as the canaries if we
 	// are promoted

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -266,7 +266,7 @@ func (a allocSet) filterByRescheduleable(isBatch bool, reschedulePolicy *structs
 		}
 	}
 	// Delete these from rescheduleable allocs
-	for allocId, _ := range rescheduledPrevAllocs {
+	for allocId := range rescheduledPrevAllocs {
 		delete(reschedule, allocId)
 	}
 	return

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -28,6 +28,9 @@ type placementResult interface {
 	// PreviousAllocation returns the previous allocation
 	PreviousAllocation() *structs.Allocation
 
+	// Reschedule returns whether the placement was rescheduling a failed allocation
+	Reschedule() bool
+
 	// StopPreviousAlloc returns whether the previous allocation should be
 	// stopped and if so the status description.
 	StopPreviousAlloc() (bool, string)
@@ -47,12 +50,14 @@ type allocPlaceResult struct {
 	canary        bool
 	taskGroup     *structs.TaskGroup
 	previousAlloc *structs.Allocation
+	reschedule    bool
 }
 
 func (a allocPlaceResult) TaskGroup() *structs.TaskGroup           { return a.taskGroup }
 func (a allocPlaceResult) Name() string                            { return a.name }
 func (a allocPlaceResult) Canary() bool                            { return a.canary }
 func (a allocPlaceResult) PreviousAllocation() *structs.Allocation { return a.previousAlloc }
+func (a allocPlaceResult) Reschedule() bool                        { return a.reschedule }
 func (a allocPlaceResult) StopPreviousAlloc() (bool, string)       { return false, "" }
 
 // allocDestructiveResult contains the information required to do a destructive
@@ -69,6 +74,7 @@ func (a allocDestructiveResult) TaskGroup() *structs.TaskGroup           { retur
 func (a allocDestructiveResult) Name() string                            { return a.placeName }
 func (a allocDestructiveResult) Canary() bool                            { return false }
 func (a allocDestructiveResult) PreviousAllocation() *structs.Allocation { return a.stopAlloc }
+func (a allocDestructiveResult) Reschedule() bool                        { return false }
 func (a allocDestructiveResult) StopPreviousAlloc() (bool, string) {
 	return true, a.stopStatusDescription
 }

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -36,7 +36,7 @@ type Stack interface {
 }
 
 type SelectOptions struct {
-	PenaltyNodeIDs []string
+	PenaltyNodeIDs map[string]struct{}
 	PreferredNodes []*structs.Node
 }
 
@@ -198,8 +198,6 @@ func (s *GenericStack) Select(tg *structs.TaskGroup, options *SelectOptions) (*R
 	s.binPack.SetTaskGroup(tg)
 	if options != nil {
 		s.nodeAntiAff.SetPenaltyNodes(options.PenaltyNodeIDs)
-	} else {
-		s.nodeAntiAff.SetPenaltyNodes(nil)
 	}
 
 	if contextual, ok := s.quota.(ContextualIterator); ok {

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -172,13 +172,14 @@ func (s *GenericStack) Select(tg *structs.TaskGroup, options *SelectOptions) (*R
 	if options != nil && len(options.PreferredNodes) > 0 {
 		originalNodes := s.source.nodes
 		s.source.SetNodes(options.PreferredNodes)
-		options.PreferredNodes = nil
-		if option, resources := s.Select(tg, options); option != nil {
+		optionsNew := *options
+		optionsNew.PreferredNodes = nil
+		if option, resources := s.Select(tg, &optionsNew); option != nil {
 			s.source.SetNodes(originalNodes)
 			return option, resources
 		}
 		s.source.SetNodes(originalNodes)
-		return s.Select(tg, options)
+		return s.Select(tg, &optionsNew)
 	}
 
 	// Reset the max selector and context

--- a/scheduler/stack_test.go
+++ b/scheduler/stack_test.go
@@ -47,8 +47,9 @@ func benchmarkServiceStack_MetaKeyConstraint(b *testing.B, key string, numNodes,
 	stack.SetJob(job)
 
 	b.ResetTimer()
+	selectOptions := &SelectOptions{}
 	for i := 0; i < b.N; i++ {
-		stack.Select(job.TaskGroups[0])
+		stack.Select(job.TaskGroups[0], selectOptions)
 	}
 }
 
@@ -104,7 +105,8 @@ func TestServiceStack_Select_Size(t *testing.T) {
 
 	job := mock.Job()
 	stack.SetJob(job)
-	node, size := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	node, size := stack.Select(job.TaskGroups[0], selectOptions)
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -138,7 +140,8 @@ func TestServiceStack_Select_PreferringNodes(t *testing.T) {
 
 	// Create a preferred node
 	preferredNode := mock.Node()
-	option, _ := stack.SelectPreferringNodes(job.TaskGroups[0], []*structs.Node{preferredNode})
+	selectOptions := &SelectOptions{PreferredNodes: []*structs.Node{preferredNode}}
+	option, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	if option == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -151,7 +154,8 @@ func TestServiceStack_Select_PreferringNodes(t *testing.T) {
 	preferredNode1 := preferredNode.Copy()
 	preferredNode1.Attributes["kernel.name"] = "windows"
 	preferredNode1.ComputeClass()
-	option, _ = stack.SelectPreferringNodes(job.TaskGroups[0], []*structs.Node{preferredNode1})
+	selectOptions = &SelectOptions{PreferredNodes: []*structs.Node{preferredNode1}}
+	option, _ = stack.Select(job.TaskGroups[0], selectOptions)
 	if option == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -174,7 +178,8 @@ func TestServiceStack_Select_MetricsReset(t *testing.T) {
 
 	job := mock.Job()
 	stack.SetJob(job)
-	n1, _ := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	n1, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	m1 := ctx.Metrics()
 	if n1 == nil {
 		t.Fatalf("missing node %#v", m1)
@@ -184,7 +189,7 @@ func TestServiceStack_Select_MetricsReset(t *testing.T) {
 		t.Fatalf("should only be 2")
 	}
 
-	n2, _ := stack.Select(job.TaskGroups[0])
+	n2, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	m2 := ctx.Metrics()
 	if n2 == nil {
 		t.Fatalf("missing node %#v", m2)
@@ -215,7 +220,8 @@ func TestServiceStack_Select_DriverFilter(t *testing.T) {
 	job.TaskGroups[0].Tasks[0].Driver = "foo"
 	stack.SetJob(job)
 
-	node, _ := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	node, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -243,8 +249,8 @@ func TestServiceStack_Select_ConstraintFilter(t *testing.T) {
 	job := mock.Job()
 	job.Constraints[0].RTarget = "freebsd"
 	stack.SetJob(job)
-
-	node, _ := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	node, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -280,8 +286,8 @@ func TestServiceStack_Select_BinPack_Overflow(t *testing.T) {
 
 	job := mock.Job()
 	stack.SetJob(job)
-
-	node, _ := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	node, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -347,7 +353,8 @@ func TestSystemStack_Select_Size(t *testing.T) {
 
 	job := mock.Job()
 	stack.SetJob(job)
-	node, size := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	node, size := stack.Select(job.TaskGroups[0], selectOptions)
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -381,7 +388,8 @@ func TestSystemStack_Select_MetricsReset(t *testing.T) {
 
 	job := mock.Job()
 	stack.SetJob(job)
-	n1, _ := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	n1, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	m1 := ctx.Metrics()
 	if n1 == nil {
 		t.Fatalf("missing node %#v", m1)
@@ -391,7 +399,7 @@ func TestSystemStack_Select_MetricsReset(t *testing.T) {
 		t.Fatalf("should only be 1")
 	}
 
-	n2, _ := stack.Select(job.TaskGroups[0])
+	n2, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	m2 := ctx.Metrics()
 	if n2 == nil {
 		t.Fatalf("missing node %#v", m2)
@@ -418,7 +426,8 @@ func TestSystemStack_Select_DriverFilter(t *testing.T) {
 	job.TaskGroups[0].Tasks[0].Driver = "foo"
 	stack.SetJob(job)
 
-	node, _ := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	node, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -435,7 +444,7 @@ func TestSystemStack_Select_DriverFilter(t *testing.T) {
 	stack = NewSystemStack(ctx)
 	stack.SetNodes(nodes)
 	stack.SetJob(job)
-	node, _ = stack.Select(job.TaskGroups[0])
+	node, _ = stack.Select(job.TaskGroups[0], selectOptions)
 	if node != nil {
 		t.Fatalf("node not filtered %#v", node)
 	}
@@ -460,7 +469,8 @@ func TestSystemStack_Select_ConstraintFilter(t *testing.T) {
 	job.Constraints[0].RTarget = "freebsd"
 	stack.SetJob(job)
 
-	node, _ := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	node, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -497,7 +507,8 @@ func TestSystemStack_Select_BinPack_Overflow(t *testing.T) {
 	job := mock.Job()
 	stack.SetJob(job)
 
-	node, _ := stack.Select(job.TaskGroups[0])
+	selectOptions := &SelectOptions{}
+	node, _ := stack.Select(job.TaskGroups[0], selectOptions)
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -275,7 +275,7 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 		s.stack.SetNodes(nodes)
 
 		// Attempt to match the task group
-		option, _ := s.stack.Select(missing.TaskGroup)
+		option, _ := s.stack.Select(missing.TaskGroup, nil)
 
 		if option == nil {
 			// If nodes were filtered because of constraint mismatches and we

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -511,7 +511,7 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 			allocInPlace, "")
 
 		// Attempt to match the task group
-		option, _ := stack.Select(update.TaskGroup)
+		option, _ := stack.Select(update.TaskGroup, nil) // This select only looks at one node so we don't pass any node weight options
 
 		// Pop the allocation
 		ctx.Plan().PopUpdate(update.Alloc)
@@ -722,7 +722,7 @@ func updateNonTerminalAllocsToLost(plan *structs.Plan, tainted map[string]*struc
 // genericAllocUpdateFn is a factory for the scheduler to create an allocUpdateType
 // function to be passed into the reconciler. The factory takes objects that
 // exist only in the scheduler context and returns a function that can be used
-// by the reconciler to make decsions about how to update an allocation. The
+// by the reconciler to make decisions about how to update an allocation. The
 // factory allows the reconciler to be unaware of how to determine the type of
 // update necessary and can minimize the set of objects it is exposed to.
 func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateType {
@@ -767,7 +767,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateTy
 		ctx.Plan().AppendUpdate(existing, structs.AllocDesiredStatusStop, allocInPlace, "")
 
 		// Attempt to match the task group
-		option, _ := stack.Select(newTG)
+		option, _ := stack.Select(newTG, nil) // This select only looks at one node so we don't pass any node weight options
 
 		// Pop the allocation
 		ctx.Plan().PopUpdate(existing)

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -511,7 +511,7 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 			allocInPlace, "")
 
 		// Attempt to match the task group
-		option, _ := stack.Select(update.TaskGroup, nil) // This select only looks at one node so we don't pass any node weight options
+		option, _ := stack.Select(update.TaskGroup, nil) // This select only looks at one node so we don't pass selectOptions
 
 		// Pop the allocation
 		ctx.Plan().PopUpdate(update.Alloc)
@@ -767,7 +767,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateTy
 		ctx.Plan().AppendUpdate(existing, structs.AllocDesiredStatusStop, allocInPlace, "")
 
 		// Attempt to match the task group
-		option, _ := stack.Select(newTG, nil) // This select only looks at one node so we don't pass any node weight options
+		option, _ := stack.Select(newTG, nil) // This select only looks at one node so we don't pass selectOptions
 
 		// Pop the allocation
 		ctx.Plan().PopUpdate(existing)


### PR DESCRIPTION
This PR builds on top of PR #3757 to add support for rescheduling failed allocs using a rescheduling tracker. Other changes: 

- Stack's select interface now takes an options struct that contains preferred nodes and penalized nodes. This makes it easier to add other selection options in the future 
- Deletes method for handling preferred nodes and pushes that into the stack's Select implementation
- New anti-affinity iterator that adds a penalty for previous nodes from failed allocs when computing replacements 