### PR TITLE
Edge trigger rescheduling when ClientStatusFailed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1304,6 +1304,8 @@ func (c *Client) updateAllocStatus(alloc *structs.Allocation) {
 	// send the fields that are updatable by the client.
 	stripped := new(structs.Allocation)
 	stripped.ID = alloc.ID
+	stripped.JobID = alloc.JobID
+	stripped.Namespace = alloc.Namespace
 	stripped.NodeID = c.NodeID()
 	stripped.TaskStates = alloc.TaskStates
 	stripped.ClientStatus = alloc.ClientStatus

--- a/client/client.go
+++ b/client/client.go
@@ -1304,8 +1304,6 @@ func (c *Client) updateAllocStatus(alloc *structs.Allocation) {
 	// send the fields that are updatable by the client.
 	stripped := new(structs.Allocation)
 	stripped.ID = alloc.ID
-	stripped.JobID = alloc.JobID
-	stripped.Namespace = alloc.Namespace
 	stripped.NodeID = c.NodeID()
 	stripped.TaskStates = alloc.TaskStates
 	stripped.ClientStatus = alloc.ClientStatus

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -586,7 +586,7 @@ func (n *nomadFSM) applyAllocClientUpdate(buf []byte, index uint64) interface{} 
 	// Update any evals
 	if len(req.Evals) > 0 {
 		if err := n.upsertEvals(index, req.Evals); err != nil {
-			n.logger.Printf("[ERR] nomad.fsm: UpdateAllocFromClient failed: %v", err)
+			n.logger.Printf("[ERR] nomad.fsm: applyAllocClientUpdate failed to update evaluations: %v", err)
 			return err
 		}
 	}

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -826,11 +826,11 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 	}
 
 	// Update modified timestamp for client initiated allocation updates
-	now := time.Now().UTC().UnixNano()
+	now := time.Now()
 	var evals []*structs.Evaluation
 
 	for _, alloc := range args.Alloc {
-		alloc.ModifyTime = now
+		alloc.ModifyTime = now.UTC().UnixNano()
 
 		// Add an evaluation if this is a failed alloc that is eligible for rescheduling
 		if alloc.ClientStatus == structs.AllocClientStatusFailed {
@@ -846,7 +846,7 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 			// Only create evaluations if this is an existing alloc and eligible as per its task group's ReschedulePolicy
 			if existingAlloc, _ := n.srv.State().AllocByID(ws, alloc.ID); existingAlloc != nil {
 				taskGroup := job.LookupTaskGroup(existingAlloc.TaskGroup)
-				if taskGroup != nil && existingAlloc.RescheduleEligible(taskGroup.ReschedulePolicy) {
+				if taskGroup != nil && existingAlloc.RescheduleEligible(taskGroup.ReschedulePolicy, now) {
 					eval := &structs.Evaluation{
 						ID:          uuid.Generate(),
 						Namespace:   alloc.Namespace,

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -840,11 +840,11 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 			if existingAlloc, _ := n.srv.State().AllocByID(nil, alloc.ID); existingAlloc != nil {
 				job, err := n.srv.State().JobByID(nil, existingAlloc.Namespace, existingAlloc.JobID)
 				if err != nil {
-					n.srv.logger.Printf("[WARN] nomad.client: UpdateAlloc unable to find job ID %q :%v", existingAlloc.JobID, err)
+					n.srv.logger.Printf("[ERR] nomad.client: UpdateAlloc unable to find job ID %q :%v", existingAlloc.JobID, err)
 					continue
 				}
 				if job == nil {
-					n.srv.logger.Printf("[WARN] nomad.client: UpdateAlloc unable to find job ID %q", existingAlloc.JobID)
+					n.srv.logger.Printf("[DEBUG] nomad.client: UpdateAlloc unable to find job ID %q", existingAlloc.JobID)
 					continue
 				}
 				taskGroup := job.LookupTaskGroup(existingAlloc.TaskGroup)

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -844,7 +844,7 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 					continue
 				}
 				if job == nil {
-					n.srv.logger.Printf("[ERR] nomad.client: UpdateAlloc unable to find job ID %q", existingAlloc.JobID)
+					n.srv.logger.Printf("[WARN] nomad.client: UpdateAlloc unable to find job ID %q", existingAlloc.JobID)
 					continue
 				}
 				taskGroup := job.LookupTaskGroup(existingAlloc.TaskGroup)

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1662,12 +1662,20 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Inject fake evaluations
+	// Inject fake allocations
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
 	state := s1.fsm.State()
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
 	err := state.UpsertAllocs(100, []*structs.Allocation{alloc})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Inject mock job
+	job := mock.Job()
+	job.ID = alloc.JobID
+	err = state.UpsertJob(101, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1747,7 +1755,7 @@ func TestClientEndpoint_BatchUpdate(t *testing.T) {
 	// Call to do the batch update
 	bf := NewBatchFuture()
 	endpoint := s1.endpoints.Node
-	endpoint.batchUpdate(bf, []*structs.Allocation{clientAlloc})
+	endpoint.batchUpdate(bf, []*structs.Allocation{clientAlloc}, nil)
 	if err := bf.Wait(); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1803,6 +1811,14 @@ func TestClientEndpoint_UpdateAlloc_Vault(t *testing.T) {
 	va.NodeID = node.ID
 	va.AllocID = alloc.ID
 	if err := state.UpsertVaultAccessor(101, []*structs.VaultAccessor{va}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Inject mock job
+	job := mock.Job()
+	job.ID = alloc.JobID
+	err := state.UpsertJob(101, job)
+	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1708,11 +1708,18 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	assert.Equal(structs.AllocClientStatusFailed, out.ClientStatus)
 	assert.True(out.ModifyTime > 0)
 
-	// Lookup evals, should have created one
+	// Assert that one eval with TriggeredBy EvalTriggerRetryFailedAlloc exists
 	evaluations, err := state.EvalsByJob(ws, job.Namespace, job.ID)
 	assert.Nil(err)
-	assert.Equal(1, len(evaluations))
-	assert.Equal(structs.EvalTriggerRetryFailedAlloc, evaluations[0].TriggeredBy)
+	assert.True(len(evaluations) != 0)
+	found := false
+	for _, resultEval := range evaluations {
+		if resultEval.TriggeredBy == structs.EvalTriggerRetryFailedAlloc {
+			found = true
+		}
+	}
+	assert.True(found, "Should create an eval for failed alloc")
+
 }
 
 func TestClientEndpoint_BatchUpdate(t *testing.T) {

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad/testutil"
 	vapi "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientEndpoint_Register(t *testing.T) {
@@ -1649,6 +1650,7 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
+	require := require.New(t)
 
 	// Create the register request
 	node := mock.Node()
@@ -1667,16 +1669,17 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	// Inject mock job
 	job := mock.Job()
 	err := state.UpsertJob(101, job)
-	assert.Nil(err)
+	require.Nil(err)
 
 	// Inject fake allocations
 	alloc := mock.Alloc()
 	alloc.JobID = job.ID
 	alloc.NodeID = node.ID
-	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
+	err = state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
+	require.Nil(err)
 	alloc.TaskGroup = job.TaskGroups[0].Name
 	err = state.UpsertAllocs(100, []*structs.Allocation{alloc})
-	assert.Nil(err)
+	require.Nil(err)
 
 	// Attempt update
 	clientAlloc := new(structs.Allocation)

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1649,7 +1649,6 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
-	assert := assert.New(t)
 	require := require.New(t)
 
 	// Create the register request
@@ -1694,8 +1693,8 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	var resp2 structs.NodeAllocsResponse
 	start := time.Now()
 	err = msgpackrpc.CallWithCodec(codec, "Node.UpdateAlloc", update, &resp2)
-	assert.Nil(err)
-	assert.NotEqual(0, resp2.Index)
+	require.Nil(err)
+	require.NotEqual(0, resp2.Index)
 
 	if diff := time.Since(start); diff < batchUpdateInterval {
 		t.Fatalf("too fast: %v", diff)
@@ -1704,21 +1703,21 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	// Lookup the alloc
 	ws := memdb.NewWatchSet()
 	out, err := state.AllocByID(ws, alloc.ID)
-	assert.Nil(err)
-	assert.Equal(structs.AllocClientStatusFailed, out.ClientStatus)
-	assert.True(out.ModifyTime > 0)
+	require.Nil(err)
+	require.Equal(structs.AllocClientStatusFailed, out.ClientStatus)
+	require.True(out.ModifyTime > 0)
 
 	// Assert that one eval with TriggeredBy EvalTriggerRetryFailedAlloc exists
 	evaluations, err := state.EvalsByJob(ws, job.Namespace, job.ID)
-	assert.Nil(err)
-	assert.True(len(evaluations) != 0)
+	require.Nil(err)
+	require.True(len(evaluations) != 0)
 	found := false
 	for _, resultEval := range evaluations {
 		if resultEval.TriggeredBy == structs.EvalTriggerRetryFailedAlloc {
 			found = true
 		}
 	}
-	assert.True(found, "Should create an eval for failed alloc")
+	require.True(found, "Should create an eval for failed alloc")
 
 }
 

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -393,7 +393,7 @@ func correctDeploymentCanaries(result *structs.PlanResult) {
 	}
 }
 
-// evaluateNodePlan is used to evalute the plan for a single node,
+// evaluateNodePlan is used to evaluate the plan for a single node,
 // returning if the plan is valid or if an error is encountered
 func evaluateNodePlan(snap *state.StateSnapshot, plan *structs.Plan, nodeID string) (bool, string, error) {
 	// If this is an evict-only plan, it always 'fits' since we are removing things.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -532,6 +532,10 @@ type AllocUpdateRequest struct {
 	// Alloc is the list of new allocations to assign
 	Alloc []*Allocation
 
+	// Evals is the list of new evaluations to create
+	// Evals are valid only when used in the Raft RPC
+	Evals []*Evaluation
+
 	// Job is the shared parent job of the allocations.
 	// It is pulled out since it is common to reduce payload size.
 	Job *Job


### PR DESCRIPTION
This PR modifies the UpdateAlloc endpoint and corresponding fsm apply step to create an evaluation to trigger rescheduling

Builds on top of PR #3757 and PR #3759 

 