### PR TITLE
UI Dependency Upgrades: Step 6 - Styleguide upgrade and progress

### DIFF
--- a/ui/app/components/distribution-bar.js
+++ b/ui/app/components/distribution-bar.js
@@ -99,7 +99,7 @@ export default Component.extend(WindowResizable, {
       });
 
     slices = slices.merge(slicesEnter);
-    slices.attr('class', d => d.className || `slice-${filteredData.indexOf(d)}`);
+    slices.attr('class', d => d.className || `slice-${_data.indexOf(d)}`);
 
     const setWidth = d => `${width * d.percent - (d.index === sliceCount - 1 || d.index === 0 ? 1 : 2)}px`
     const setOffset = d => `${width * d.offset + (d.index === 0 ? 0 : 1)}px`

--- a/ui/app/components/freestyle/sg-boxed-section.js
+++ b/ui/app/components/freestyle/sg-boxed-section.js
@@ -1,0 +1,27 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  variants: computed(() => [
+    {
+      key: 'Normal',
+      title: 'Normal',
+      slug: '',
+    },
+    {
+      key: 'Info',
+      title: 'Info',
+      slug: 'is-info',
+    },
+    {
+      key: 'Warning',
+      title: 'Warning',
+      slug: 'is-warning',
+    },
+    {
+      key: 'Danger',
+      title: 'Danger',
+      slug: 'is-danger',
+    },
+  ]),
+});

--- a/ui/app/components/freestyle/sg-colors.js
+++ b/ui/app/components/freestyle/sg-colors.js
@@ -1,0 +1,97 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  nomadTheme: computed(() => [
+    {
+      name: 'Primary',
+      base: '#25ba81',
+    },
+    {
+      name: 'Primary Dark',
+      base: '#1d9467',
+    },
+    {
+      name: 'Text',
+      base: '#0a0a0a',
+    },
+    {
+      name: 'Link',
+      base: '#1563ff',
+    },
+    {
+      name: 'Gray',
+      base: '#bbc4d1',
+    },
+    {
+      name: 'Off-white',
+      base: '#f5f5f5',
+    },
+  ]),
+
+  productColors: computed(() => [
+    {
+      name: 'Consul Pink',
+      base: '#ff0087',
+    },
+    {
+      name: 'Consul Pink Dark',
+      base: '#c62a71',
+    },
+    {
+      name: 'Packer Blue',
+      base: '#1daeff',
+    },
+    {
+      name: 'Packer Blue Dark',
+      base: '#1d94dd',
+    },
+    {
+      name: 'Terraform Purple',
+      base: '#5c4ee5',
+    },
+    {
+      name: 'Terraform Purple Dark',
+      base: '#4040b2',
+    },
+    {
+      name: 'Vagrant Blue',
+      base: '#1563ff',
+    },
+    {
+      name: 'Vagrant Blue Dark',
+      base: '#104eb2',
+    },
+    {
+      name: 'Nomad Green',
+      base: '#25ba81',
+    },
+    {
+      name: 'Nomad Green Dark',
+      base: '#1d9467',
+    },
+    {
+      name: 'Nomad Green Darker',
+      base: '#16704d',
+    },
+  ]),
+
+  emotiveColors: computed(() => [
+    {
+      name: 'Success',
+      base: '#23d160',
+    },
+    {
+      name: 'Warning',
+      base: '#fa8e23',
+    },
+    {
+      name: 'Danger',
+      base: '#c84034',
+    },
+    {
+      name: 'Info',
+      base: '#1563ff',
+    },
+  ]),
+});

--- a/ui/app/components/freestyle/sg-distribution-bar-jumbo.js
+++ b/ui/app/components/freestyle/sg-distribution-bar-jumbo.js
@@ -1,0 +1,13 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  distributionBarData: computed(() => {
+    return [
+      { label: 'one', value: 10 },
+      { label: 'two', value: 20 },
+      { label: 'three', value: 0 },
+      { label: 'four', value: 35 },
+    ];
+  }),
+});

--- a/ui/app/components/freestyle/sg-distribution-bar.js
+++ b/ui/app/components/freestyle/sg-distribution-bar.js
@@ -1,0 +1,43 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  timerTicks: 0,
+
+  startTimer: function() {
+    this.set(
+      'timer',
+      setInterval(() => {
+        this.incrementProperty('timerTicks');
+      }, 500)
+    );
+  }.on('init'),
+
+  willDestroy() {
+    clearInterval(this.get('timer'));
+  },
+
+  distributionBarData: computed(() => {
+    return [
+      { label: 'one', value: 10 },
+      { label: 'two', value: 20 },
+      { label: 'three', value: 30 },
+    ];
+  }),
+
+  distributionBarDataWithClasses: computed(() => {
+    return [
+      { label: 'Queued', value: 10, className: 'queued' },
+      { label: 'Complete', value: 20, className: 'complete' },
+      { label: 'Failed', value: 30, className: 'failed' },
+    ];
+  }),
+
+  distributionBarDataRotating: computed('timerTicks', () => {
+    return [
+      { label: 'one', value: Math.round(Math.random() * 50) },
+      { label: 'two', value: Math.round(Math.random() * 50) },
+      { label: 'three', value: Math.round(Math.random() * 50) },
+    ];
+  }),
+});

--- a/ui/app/controllers/freestyle.js
+++ b/ui/app/controllers/freestyle.js
@@ -1,46 +1,6 @@
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
 import FreestyleController from 'ember-freestyle/controllers/freestyle';
 
 export default FreestyleController.extend({
   emberFreestyle: service(),
-
-  timerTicks: 0,
-
-  startTimer: function() {
-    this.set(
-      'timer',
-      setInterval(() => {
-        this.incrementProperty('timerTicks');
-      }, 500)
-    );
-  }.on('init'),
-
-  stopTimer: function() {
-    clearInterval(this.get('timer'));
-  }.on('willDestroy'),
-
-  distributionBarData: computed(() => {
-    return [
-      { label: 'one', value: 10 },
-      { label: 'two', value: 20 },
-      { label: 'three', value: 30 },
-    ];
-  }),
-
-  distributionBarDataWithClasses: computed(() => {
-    return [
-      { label: 'Queued', value: 10, className: 'queued' },
-      { label: 'Complete', value: 20, className: 'complete' },
-      { label: 'Failed', value: 30, className: 'failed' },
-    ];
-  }),
-
-  distributionBarDataRotating: computed('timerTicks', () => {
-    return [
-      { label: 'one', value: Math.round(Math.random() * 50) },
-      { label: 'two', value: Math.round(Math.random() * 50) },
-      { label: 'three', value: Math.round(Math.random() * 50) },
-    ];
-  }),
 });

--- a/ui/app/routes/freestyle.js
+++ b/ui/app/routes/freestyle.js
@@ -1,0 +1,18 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import RSVP from 'rsvp';
+
+export default Route.extend({
+  emberFreestyle: service(),
+
+  beforeModel() {
+    let emberFreestyle = this.get('emberFreestyle');
+
+    return emberFreestyle.ensureHljs().then(() => {
+      return RSVP.all([
+        emberFreestyle.ensureHljsLanguage('handlebars'),
+        emberFreestyle.ensureHljsLanguage('htmlbars'),
+      ]);
+    });
+  },
+});

--- a/ui/app/services/ember-freestyle.js
+++ b/ui/app/services/ember-freestyle.js
@@ -1,5 +1,5 @@
 import EmberFreestyle from 'ember-freestyle/services/ember-freestyle';
 
 export default EmberFreestyle.extend({
-  defaultTheme: 'monokai-sublime',
+  defaultTheme: 'solarized-light',
 });

--- a/ui/app/styles/app.scss
+++ b/ui/app/styles/app.scss
@@ -1,5 +1,8 @@
-@import "./core";
-@import "./components";
-@import "./charts";
+@import './core';
+@import './components';
+@import './charts';
 
-@import "ember-power-select";
+@import 'ember-power-select';
+
+// Only necessary in dev
+@import './styleguide.scss';

--- a/ui/app/styles/styleguide.scss
+++ b/ui/app/styles/styleguide.scss
@@ -1,0 +1,44 @@
+#styleguide {
+  .mock-content {
+    display: flex;
+    height: 250px;
+
+    .mock-image,
+    .mock-copy {
+      height: 100%;
+      width: 100%;
+      margin: 1em;
+    }
+
+    .mock-image {
+      background: linear-gradient(
+          to top right,
+          transparent 0%,
+          transparent 49%,
+          $grey-blue 49%,
+          $grey-blue 51%,
+          transparent 51%,
+          transparent 100%
+        ),
+        linear-gradient(
+          to bottom right,
+          transparent 0%,
+          transparent 49%,
+          $grey-blue 49%,
+          $grey-blue 51%,
+          transparent 51%,
+          transparent 100%
+        );
+    }
+
+    .mock-copy {
+      background: repeating-linear-gradient(
+        to bottom,
+        $grey-blue,
+        $grey-blue 5px,
+        transparent 5px,
+        transparent 14px
+      );
+    }
+  }
+}

--- a/ui/app/templates/components/freestyle/sg-boxed-section.hbs
+++ b/ui/app/templates/components/freestyle/sg-boxed-section.hbs
@@ -1,0 +1,183 @@
+{{#freestyle-collection defaultKey="Normal" as |collection|}}
+  {{#collection.variant key="Normal"}}
+    {{#freestyle-usage "boxed-section-normal-normal" title="Normal Boxed Section"}}
+      <div class="boxed-section">
+        <div class="boxed-section-head">
+          Normal Boxed Section
+        </div>
+        <div class="boxed-section-body">
+          <div class="mock-content">
+            <div class="mock-image"></div>
+            <div class="mock-copy"></div>
+            <div class="mock-copy"></div>
+          </div>
+        </div>
+      </div>
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="Info"}}
+    {{#freestyle-usage "boxed-section-normal-info" title="Info Boxed Section"}}
+      <div class="boxed-section is-info">
+        <div class="boxed-section-head">
+          Normal Boxed Section
+        </div>
+        <div class="boxed-section-body">
+          <div class="mock-content">
+            <div class="mock-image"></div>
+            <div class="mock-copy"></div>
+            <div class="mock-copy"></div>
+          </div>
+        </div>
+      </div>
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="Warning"}}
+    {{#freestyle-usage "boxed-section-normal-warning" title="Warning Boxed Section"}}
+      <div class="boxed-section is-warning">
+        <div class="boxed-section-head">
+          Normal Boxed Section
+        </div>
+        <div class="boxed-section-body">
+          <div class="mock-content">
+            <div class="mock-image"></div>
+            <div class="mock-copy"></div>
+            <div class="mock-copy"></div>
+          </div>
+        </div>
+      </div>
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="Danger"}}
+    {{#freestyle-usage "boxed-section-normal-danger" title="Danger Boxed Section"}}
+      <div class="boxed-section is-danger">
+        <div class="boxed-section-head">
+          Normal Boxed Section
+        </div>
+        <div class="boxed-section-body">
+          <div class="mock-content">
+            <div class="mock-image"></div>
+            <div class="mock-copy"></div>
+            <div class="mock-copy"></div>
+          </div>
+        </div>
+      </div>
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+{{/freestyle-collection}}
+
+{{#freestyle-collection defaultKey="Normal" as |collection|}}
+  {{#each variants as |variant|}}
+    {{#collection.variant key=variant.key}}
+      {{#freestyle-usage "boxed-section-right-hand-normal" title=(concat variant.title "Normal Boxed Section With Right Hand Details")}}
+        <div class="boxed-section {{variant.slug}}">
+          <div class="boxed-section-head">
+            Boxed Section With Right Hand Details
+            <span class="pull-right">{{now interval=1000}}</span>
+          </div>
+          <div class="boxed-section-body">
+            <div class="mock-content">
+              <div class="mock-image"></div>
+              <div class="mock-copy"></div>
+              <div class="mock-copy"></div>
+            </div>
+          </div>
+        </div>
+      {{/freestyle-usage}}
+    {{/collection.variant}}
+  {{/each}}
+{{/freestyle-collection}}
+
+{{#freestyle-collection defaultKey="Normal" as |collection|}}
+  {{#each variants as |variant|}}
+    {{#collection.variant key=variant.key}}
+      {{#freestyle-usage "boxed-section-left-badge-normal" title=(concat variant.title " Normal Boxed Section With Title Decoration")}}
+        <div class="boxed-section {{variant.slug}}">
+          <div class="boxed-section-head">
+            Boxed Section With Title Decoration
+            <span class="badge is-white">7</span>
+          </div>
+          <div class="boxed-section-body">
+            <div class="mock-content">
+              <div class="mock-image"></div>
+              <div class="mock-copy"></div>
+              <div class="mock-copy"></div>
+            </div>
+          </div>
+        </div>
+      {{/freestyle-usage}}
+    {{/collection.variant}}
+  {{/each}}
+{{/freestyle-collection}}
+
+{{#freestyle-collection defaultKey="Normal" as |collection|}}
+  {{#each variants as |variant|}}
+    {{#collection.variant key=variant.key}}
+      {{#freestyle-usage "boxed-section-with-foot-normal" title=(concat variant.title " Boxed Section With Foot")}}
+        <div class="boxed-section {{variant.slug}}">
+          <div class="boxed-section-head">
+            Boxed Section With Large Header
+          </div>
+          <div class="boxed-section-body with-foot">
+            <div class="mock-content">
+              <div class="mock-image"></div>
+              <div class="mock-copy"></div>
+              <div class="mock-copy"></div>
+            </div>
+          </div>
+          <div class="boxed-section-foot">
+            <span>Left-aligned message</span>
+            <a href="#" class="pull-right">Toggle or other action</a>
+          </div>
+        </div>
+      {{/freestyle-usage}}
+    {{/collection.variant}}
+  {{/each}}
+{{/freestyle-collection}}
+
+{{#freestyle-collection defaultKey="Normal" as |collection|}}
+  {{#each variants as |variant|}}
+    {{#collection.variant key=variant.key}}
+      {{#freestyle-usage "boxed-section-with-large-header" title=(concat variant.title " Boxed Section With Large Header")}}
+        <div class="boxed-section {{variant.slug}}">
+          <div class="boxed-section-head">
+            <div class="boxed-section-row">
+              Boxed Section With Large Header
+              <span class="badge is-white is-subtle bumper-left">Status</span>
+            </div>
+            <div class="boxed-section-row">
+              <span class="tag is-outlined">A tag that goes on a second line because it's rather long</span>
+            </div>
+          </div>
+          <div class="boxed-section-body">
+            <div class="mock-content">
+              <div class="mock-image"></div>
+              <div class="mock-copy"></div>
+              <div class="mock-copy"></div>
+            </div>
+          </div>
+        </div>
+      {{/freestyle-usage}}
+    {{/collection.variant}}
+  {{/each}}
+{{/freestyle-collection}}
+
+{{#freestyle-collection defaultKey="Normal" as |collection|}}
+  {{#each variants as |variant|}}
+    {{#collection.variant key=variant.key}}
+      {{#freestyle-usage "boxed-section-with-dark-body" title=(concat variant.title " Boxed Section With Dark Body")}}
+        <div class="boxed-section {{variant.slug}}">
+          <div class="boxed-section-head">
+            Boxed Section With Dark Body
+          </div>
+          <div class="boxed-section-body is-dark">
+            <div class="mock-content">
+              <div class="mock-image"></div>
+              <div class="mock-copy"></div>
+              <div class="mock-copy"></div>
+            </div>
+          </div>
+        </div>
+      {{/freestyle-usage}}
+    {{/collection.variant}}
+  {{/each}}
+{{/freestyle-collection}}

--- a/ui/app/templates/components/freestyle/sg-breadcrumbs.hbs
+++ b/ui/app/templates/components/freestyle/sg-breadcrumbs.hbs
@@ -1,0 +1,33 @@
+{{#freestyle-usage 'breadcrumbs-standard' title='Standard Breadcrumbs'}}
+  <div class="navbar is-secondary">
+    <div class="navbar-item"></div>
+    <nav class="breadcrumb is-large">
+      <li>
+        <a href="#">Topic</a>
+      </li>
+      <li>
+        <a href="#">Sub-topic</a>
+      </li>
+      <li class="is-active">
+        <a href="#">Active Topic</a>
+      </li>
+    </nav>
+  </div>
+{{/freestyle-usage}}
+{{#freestyle-annotation}}
+  Breadcrumbs are only ever used in the secondary nav of the primary header.
+{{/freestyle-annotation}}
+
+{{#freestyle-usage 'breadcrumbs-single' title='Single Breadcrumb'}}
+  <div class="navbar is-secondary">
+    <div class="navbar-item"></div>
+    <nav class="breadcrumb is-large">
+      <li>
+        <a href="#">Topic</a>
+      </li>
+    </nav>
+  </div>
+{{/freestyle-usage}}
+{{#freestyle-annotation}}
+  Breadcrumbs are given a lot of emphasis and often double as a page title. Since they are also global state, they are important for helping a user keep their bearings.
+{{/freestyle-annotation}}

--- a/ui/app/templates/components/freestyle/sg-buttons.hbs
+++ b/ui/app/templates/components/freestyle/sg-buttons.hbs
@@ -1,0 +1,54 @@
+{{#freestyle-collection defaultKey="standard" as |collection|}}
+  {{#collection.variant key="standard"}}
+    {{#freestyle-usage 'buttons-standard' title='Standard Buttons'}}
+      <div class="block">
+        <a class="button">Button</a>
+        <a class="button is-white">White</a>
+        <a class="button is-light">Light</a>
+        <a class="button is-dark">Dark</a>
+        <a class="button is-black">Black</a>
+        <a class="button is-link">Link</a>
+      </div>
+      <div class="block">
+        <a class="button is-primary">Primary</a>
+        <a class="button is-info">Info</a>
+        <a class="button is-success">Success</a>
+        <a class="button is-warning">Warning</a>
+        <a class="button is-danger">Danger</a>
+      </div>
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="outlines"}}
+    {{#freestyle-usage 'buttons-outlines' title='Outline Buttons'}}
+      <div class="block">
+        <a class="button is-outlined">Outlined</a>
+        <a class="button is-primary is-outlined">Primary</a>
+        <a class="button is-info is-outlined">Info</a>
+        <a class="button is-success is-outlined">Success</a>
+        <a class="button is-warning is-outlined">Warning</a>
+        <a class="button is-danger is-outlined is-important">Danger</a>
+      </div>
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="hollow"}}
+    {{#freestyle-usage 'buttons-hollow' title='Hollow Buttons'}}
+      <div class="block" style="background:#25BA81; padding:30px">
+        <a class="button is-primary is-inverted is-outlined">Primary</a>
+        <a class="button is-info is-inverted is-outlined">Info</a>
+        <a class="button is-success is-inverted is-outlined">Success</a>
+        <a class="button is-warning is-inverted is-outlined">Warning</a>
+        <a class="button is-danger is-inverted is-outlined">Danger</a>
+      </div>
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="sizing"}}
+    {{#freestyle-usage 'buttons-sizing' title='Button Sizes'}}
+      <div class="block">
+        <a class="button is-small">Small</a>
+        <a class="button">Normal</a>
+        <a class="button is-medium">Medium</a>
+        <a class="button is-large">Large</a>
+      </div>
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+{{/freestyle-collection}}

--- a/ui/app/templates/components/freestyle/sg-colors.hbs
+++ b/ui/app/templates/components/freestyle/sg-colors.hbs
@@ -1,0 +1,16 @@
+{{#freestyle-usage "colors"}}
+  {{freestyle-palette
+      colorPalette=nomadTheme
+      title="Nomad Theme"
+      description="Accent and neutrals."}}
+
+  {{freestyle-palette
+      colorPalette=productColors
+      title="Product Colors"
+      description="Colors from other HashiCorp products. Often borrowed for alternative accents and color schemes."}}
+
+  {{freestyle-palette
+      colorPalette=emotiveColors
+      title="Emotive Colors"
+      description="Colors used in conjunction with an emotional response."}}
+{{/freestyle-usage}}

--- a/ui/app/templates/components/freestyle/sg-distribution-bar-jumbo.hbs
+++ b/ui/app/templates/components/freestyle/sg-distribution-bar-jumbo.hbs
@@ -1,0 +1,25 @@
+{{#freestyle-usage "jumbo-distribution-bar"}}
+  {{#distribution-bar data=distributionBarData class="split-view" as |chart|}}
+    <ol class="legend">
+      {{#each chart.data as |datum index|}}
+        <li class="{{datum.className}} {{if (eq datum.index chart.activeDatum.index) "is-active"}} {{if (eq datum.value 0) "is-empty"}}">
+          <span class="color-swatch {{if datum.className datum.className (concat "swatch-" index)}}" />
+          <span class="value" data-test-legend-value="{{datum.className}}">{{datum.value}}</span>
+          <span class="label">
+            {{datum.label}}
+          </span>
+        </li>
+      {{/each}}
+    </ol>
+  {{/distribution-bar}}
+{{/freestyle-usage}}
+{{#freestyle-annotation}}
+  <div class="block">
+    A variation of the Distribution Bar component for when the distribution bar is the central component of the page. It's a larger format that requires no interaction to see the data labels and values.
+  </div>
+  <div class="boxed-section">
+    <div class="boxed-section-body is-dark">
+      {{json-viewer json=distributionBarData}}
+    </div>
+  </div>
+{{/freestyle-annotation}}

--- a/ui/app/templates/components/freestyle/sg-distribution-bar.hbs
+++ b/ui/app/templates/components/freestyle/sg-distribution-bar.hbs
@@ -1,0 +1,70 @@
+{{#freestyle-collection as |collection|}}
+  {{#collection.variant key="standard"}}
+    {{#freestyle-usage 'distribution-bar-standard'}}
+      <div class="block" style="height:50px; width:200px;">
+        {{distribution-bar data=distributionBarData}}
+      </div>
+    {{/freestyle-usage}}
+    {{#freestyle-annotation}}
+      <div class="block">
+        The distribution bar chart proportionally show data in a single bar. It includes a tooltip out of the box, assumes the size of the container element, and is designed to be styled with CSS.
+      </div>
+      <div class="boxed-section">
+        <div class="boxed-section-body is-dark">
+          {{json-viewer json=distributionBarData}}
+        </div>
+      </div>
+    {{/freestyle-annotation}}
+  {{/collection.variant}}
+  {{#collection.variant key="with classes"}}
+    {{#freestyle-usage 'distribution-bar-with-classes'}}
+      <div class="block" style="height:50px; width:200px;">
+        {{distribution-bar data=distributionBarDataWithClasses}}
+      </div>
+    {{/freestyle-usage}}
+    {{#freestyle-annotation}}
+      <div class="block">
+        If a datum provides a <code>className</code> property, it will be assigned to the corresponding <code>rect</code> element, allowing for custom colorization.
+      </div>
+      <div class="boxed-section">
+        <div class="boxed-section-body is-dark">
+          {{json-viewer json=distributionBarDataWithClasses}}
+        </div>
+      </div>
+    {{/freestyle-annotation}}
+  {{/collection.variant}}
+  {{#collection.variant key="flexibility"}}
+    {{#freestyle-usage 'distribution-bar-sizing-1'}}
+      <div class="block" style="height:10px; width:600px;">
+        {{distribution-bar data=distributionBarData}}
+      </div>
+    {{/freestyle-usage}}
+    {{#freestyle-usage 'distribution-bar-sizing-2'}}
+      <div class="block" style="height:200px; width:30px;">
+        {{distribution-bar data=distributionBarData}}
+      </div>
+    {{/freestyle-usage}}
+    {{#freestyle-annotation}}
+      <div class="block">
+      Distribution bar assumes the dimensions of the container.
+      </div>
+    {{/freestyle-annotation}}
+  {{/collection.variant}}
+  {{#collection.variant key="live updating"}}
+    {{#freestyle-usage 'distribution-bar-updating'}}
+      <div class="block" style="height:50px; width:600px;">
+        {{distribution-bar data=distributionBarDataRotating}}
+      </div>
+    {{/freestyle-usage}}
+    {{#freestyle-annotation}}
+      <div class="block">
+      Distribution bar animates with data changes.
+      </div>
+      <div class="boxed-section">
+        <div class="boxed-section-body is-dark">
+          {{json-viewer json=distributionBarDataRotating}}
+        </div>
+      </div>
+    {{/freestyle-annotation}}
+  {{/collection.variant}}
+{{/freestyle-collection}}

--- a/ui/app/templates/components/freestyle/sg-font-sizing.hbs
+++ b/ui/app/templates/components/freestyle/sg-font-sizing.hbs
@@ -1,0 +1,14 @@
+{{#freestyle-usage "font-sizing"}}
+  <div class="block">
+    <h1 class="title">Large Title</h1>
+    <p>Some prose to follow the large title. Not necessarily meant for reading.</p>
+  </div>
+  <div class="block">
+    <h2 class="title is-4">Medium Title</h2>
+    <p>Some prose to follow the large title. Not necessarily meant for reading.</p>
+  </div>
+  <div class="block">
+    <h3 class="title is-5">Small Title</h3>
+    <p>Some prose to follow the large title. Not necessarily meant for reading.</p>
+  </div>
+{{/freestyle-usage}}

--- a/ui/app/templates/components/freestyle/sg-font-stacks.hbs
+++ b/ui/app/templates/components/freestyle/sg-font-stacks.hbs
@@ -1,0 +1,52 @@
+{{#freestyle-collection inline=true as |collection|}}
+  {{#collection.variant key="-apple-system"}}
+    {{#freestyle-usage "font-apple-system" title="-apple-system"}}
+      {{freestyle-typeface fontFamily="-apple-system"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="BlinkMacSystemFont"}}
+    {{#freestyle-usage "font-blink-mac-system" title="BlinkMacSystemFont"}}
+      {{freestyle-typeface fontFamily="BlinkMacSystemFont"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="Segoe UI"}}
+    {{#freestyle-usage "font-segoe-ui" title="Segoe UI"}}
+      {{freestyle-typeface fontFamily="Segoe UI"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="Roboto"}}
+    {{#freestyle-usage "font-roboto" title="Roboto"}}
+      {{freestyle-typeface fontFamily="Roboto"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="Oxygen Sans"}}
+    {{#freestyle-usage "font-oxygen-sans" title="Oxygen Sans"}}
+      {{freestyle-typeface fontFamily="Oxygen-Sans"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="Ubuntu"}}
+    {{#freestyle-usage "font-ubuntu" title="Ubuntu"}}
+      {{freestyle-typeface fontFamily="Ubuntu"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="Cantarell"}}
+    {{#freestyle-usage "font-cantarell" title="Cantarell"}}
+      {{freestyle-typeface fontFamily="Cantarell"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="Helvetica Neue"}}
+    {{#freestyle-usage "font-helvetica-neue" title="Helvetica Neue"}}
+      {{freestyle-typeface fontFamily="Helvetica Neue"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="sans-serif"}}
+    {{#freestyle-usage "font-sans-serif" title="sans-serif"}}
+      {{freestyle-typeface fontFamily="sans-serif"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+  {{#collection.variant key="monospace"}}
+    {{#freestyle-usage "font-monospace" title="monospace"}}
+      {{freestyle-typeface fontFamily="monospace"}}
+    {{/freestyle-usage}}
+  {{/collection.variant}}
+{{/freestyle-collection}}

--- a/ui/app/templates/freestyle.hbs
+++ b/ui/app/templates/freestyle.hbs
@@ -18,11 +18,15 @@
       {{#section.subsection name="Boxed section"}}
         {{freestyle/sg-boxed-section}}
       {{/section.subsection}}
+
       {{#section.subsection name="Breadcrumbs"}}
+        {{freestyle/sg-breadcrumbs}}
       {{/section.subsection}}
+
       {{#section.subsection name="Buttons"}}
         {{freestyle/sg-buttons}}
       {{/section.subsection}}
+
       {{#section.subsection name="Diff Viewer"}}
       {{/section.subsection}}
       {{#section.subsection name="Dropdown"}}

--- a/ui/app/templates/freestyle.hbs
+++ b/ui/app/templates/freestyle.hbs
@@ -1,120 +1,70 @@
 <div id="styleguide">
-  {{#freestyle-guide title='Nomad UI'subtitle='Styles and Patterns'}}
-    {{#freestyle-section name='Buttons' as |section|}}
-      {{#freestyle-subsection name='Standard' section=section}}
-        {{#freestyle-usage 'buttons-standard' title='Standard Buttons'}}
-          <div class="block">
-            <a class="button">Button</a>
-            <a class="button is-white">White</a>
-            <a class="button is-light">Light</a>
-            <a class="button is-dark">Dark</a>
-            <a class="button is-black">Black</a>
-            <a class="button is-link">Link</a>
-          </div>
-          <div class="block">
-            <a class="button is-primary">Primary</a>
-            <a class="button is-info">Info</a>
-            <a class="button is-success">Success</a>
-            <a class="button is-warning">Warning</a>
-            <a class="button is-danger">Danger</a>
-          </div>
-        {{/freestyle-usage}}
-      {{/freestyle-subsection}}
+  {{#freestyle-guide title='Nomad UI' subtitle='Styles and Patterns'}}
+    {{#freestyle-section name="Theme" as |section|}}
+      {{#section.subsection name="Font Stacks"}}
+        {{freestyle/sg-font-stacks}}
+      {{/section.subsection}}
 
-      {{#freestyle-subsection name='Outlines' section=section}}
-        {{#freestyle-usage 'buttons-outlines' title='Outline Buttons'}}
-          <div class="block">
-            <a class="button is-outlined">Outlined</a>
-            <a class="button is-primary is-outlined">Primary</a>
-            <a class="button is-info is-outlined">Info</a>
-            <a class="button is-success is-outlined">Success</a>
-            <a class="button is-warning is-outlined">Warning</a>
-            <a class="button is-danger is-outlined is-important">Danger</a>
-          </div>
-        {{/freestyle-usage}}
-      {{/freestyle-subsection}}
+      {{#section.subsection name="Text Sizing"}}
+        {{freestyle/sg-font-sizing}}
+      {{/section.subsection}}
 
-      {{#freestyle-subsection name='Hollow' section=section}}
-        {{#freestyle-usage 'buttons-hollow' title='Hollow Buttons'}}
-          <div class="block" style="background:#25BA81; padding:30px">
-            <a class="button is-primary is-inverted is-outlined">Primary</a>
-            <a class="button is-info is-inverted is-outlined">Info</a>
-            <a class="button is-success is-inverted is-outlined">Success</a>
-            <a class="button is-warning is-inverted is-outlined">Warning</a>
-            <a class="button is-danger is-inverted is-outlined">Danger</a>
-          </div>
-        {{/freestyle-usage}}
-      {{/freestyle-subsection}}
-
-      {{#freestyle-subsection name='Sizing' section=section}}
-        {{#freestyle-usage 'buttons-sizing' title='Button Sizes'}}
-          <div class="block">
-            <a class="button is-small">Small</a>
-            <a class="button">Normal</a>
-            <a class="button is-medium">Medium</a>
-            <a class="button is-large">Large</a>
-          </div>
-        {{/freestyle-usage}}
-      {{/freestyle-subsection}}
+      {{#section.subsection name="Colors"}}
+        {{freestyle/sg-colors}}
+      {{/section.subsection}}
     {{/freestyle-section}}
 
-    {{#freestyle-section name='Distribution Bar' as |section|}}
-      {{#freestyle-subsection name='Standard' section=section}}
-        {{#freestyle-usage 'distribution-bar-standard'}}
-          <div class="block" style="height:50px; width:200px;">
-            {{distribution-bar data=distributionBarData}}
-          </div>
-        {{/freestyle-usage}}
-        {{#freestyle-annotation}}
-          <div class="block">
-            The distribution bar chart proportionally show data in a single bar. It includes a tooltip out of the box, assumes the size of the container element, and is designed to be styled with CSS.
-          </div>
-        {{/freestyle-annotation}}
-      {{/freestyle-subsection}}
-
-      {{#freestyle-subsection name='With Classes' section=section}}
-        {{#freestyle-usage 'distribution-bar-with-classes'}}
-          <div class="block" style="height:50px; width:200px;">
-            {{distribution-bar data=distributionBarDataWithClasses}}
-          </div>
-        {{/freestyle-usage}}
-        {{#freestyle-annotation}}
-          <div class="block">
-            If a datum provides a <code>className</code> property, it will be assigned to the corresponding <code>rect</code> element, allowing for custom colorization.
-          </div>
-        {{/freestyle-annotation}}
-      {{/freestyle-subsection}}
-
-      {{#freestyle-subsection name='Flexible Sizing' section=section}}
-        {{#freestyle-usage 'distribution-bar-sizing-1'}}
-          <div class="block" style="height:10px; width:600px;">
-            {{distribution-bar data=distributionBarData}}
-          </div>
-        {{/freestyle-usage}}
-        {{#freestyle-usage 'distribution-bar-sizing-2'}}
-          <div class="block" style="height:200px; width:30px;">
-            {{distribution-bar data=distributionBarData}}
-          </div>
-        {{/freestyle-usage}}
-        {{#freestyle-annotation}}
-          <div class="block">
-          Distribution bar assumes the dimensions of the container.
-          </div>
-        {{/freestyle-annotation}}
-      {{/freestyle-subsection}}
-
-      {{#freestyle-subsection name='Updating Data' section=section}}
-        {{#freestyle-usage 'distribution-bar-updating'}}
-          <div class="block" style="height:50px; width:600px;">
-            {{distribution-bar data=distributionBarDataRotating}}
-          </div>
-        {{/freestyle-usage}}
-        {{#freestyle-annotation}}
-          <div class="block">
-          Distribution bar animates with data changes.
-          </div>
-        {{/freestyle-annotation}}
-      {{/freestyle-subsection}}
+    {{#freestyle-section name="Components" as |section|}}
+      {{#section.subsection name="Boxed section"}}
+        {{freestyle/sg-boxed-section}}
+      {{/section.subsection}}
+      {{#section.subsection name="Breadcrumbs"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Buttons"}}
+        {{freestyle/sg-buttons}}
+      {{/section.subsection}}
+      {{#section.subsection name="Diff Viewer"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Dropdown"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Event stream"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Gutter navigation"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Header"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Inline definitions"}}
+      {{/section.subsection}}
+      {{#section.subsection name="JSON Viewer"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Log Stream"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Metric"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Page tabs"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Page title"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Search box"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Table"}}
+      {{/section.subsection}}
+      {{#section.subsection name="Table, Configuration"}}
+      {{/section.subsection}}
     {{/freestyle-section}}
-{{/freestyle-guide}}
+
+    {{#freestyle-section name="Charts" as |section|}}
+      {{#section.subsection name="Distribution Bar"}}
+        {{freestyle/sg-distribution-bar}}
+      {{/section.subsection}}
+
+      {{#section.subsection name="Jumbo Distribution Bar"}}
+        {{freestyle/sg-distribution-bar-jumbo}}
+      {{/section.subsection}}
+
+      {{#section.subsection name="Progress Bar"}}
+      {{/section.subsection}}
+    {{/freestyle-section}}
+  {{/freestyle-guide}}
 </div>
+

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
     "ember-data-model-fragments": "^2.14.0",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^3.4.3",
-    "ember-freestyle": "^0.4.1",
+    "ember-freestyle": "~0.6.2",
     "ember-inline-svg": "^0.1.11",
     "ember-load-initializers": "^1.0.0",
     "ember-moment": "^7.5.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3241,24 +3241,20 @@ ember-fetch@^3.4.3:
     node-fetch "^2.0.0-alpha.9"
     whatwg-fetch "^2.0.3"
 
-ember-freestyle@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/ember-freestyle/-/ember-freestyle-0.4.2.tgz#ae1593be2106e4212b319e5474a3f9432fa4e329"
+ember-freestyle@~0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/ember-freestyle/-/ember-freestyle-0.6.2.tgz#c325f96a32b4984b78e00cbd29e6dad23f0b1864"
   dependencies:
     broccoli-flatiron "0.0.0"
-    broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^2.0.0"
-    broccoli-source "^1.1.0"
-    broccoli-stew "^1.2.0"
     broccoli-writer "^0.1.1"
-    ember-cli-babel "^6.0.0"
+    ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^1.3.0"
     ember-cli-sass "^6.1.3"
     ember-cli-showdown "^3.2.1"
     ember-runtime-enumerable-includes-polyfill "^2.0.0"
     es6-promise "^4.1.0"
     glob "^7.1.1"
-    highlight.js "^9.3.0"
 
 ember-get-config@^0.2.2:
   version "0.2.4"
@@ -4559,10 +4555,6 @@ heimdalljs@^0.3.0:
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.3.3.tgz#e92d2c6f77fd46d5bf50b610d28ad31755054d0b"
   dependencies:
     rsvp "~3.2.1"
-
-highlight.js@^9.3.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### UI Dependency Upgrades
  - Step 1: Core Ember and low-risk dependencies
  - Step 2: Switch to Module Imports
  - Step 3: Bulma and Sass upgrades
  - Step 4: Testing upgrades
  - Step 5: Prettier upgrade
  - **Step 6: Styleguide upgrade**

Nomad UI's styleguide is built using [Ember Freestyle](http://ember-freestyle.com/), which has had some recent development. It was also as good a time as any to make progress on the contents of the styleguide.

The navigation now spells out the component inventory of the UI and details more than it used to. Making sure everything is documented and kept up to date will be an ongoing project.

![image](https://user-images.githubusercontent.com/174740/35020419-d413d88e-fae0-11e7-83d3-cd485c8423fc.png)
