### PR TITLE
website: fix example json job

### DIFF
--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -69,7 +69,7 @@ Below is the JSON representation of the job outputted by `$ nomad init`:
                         "TLSSkipVerify": false,
                         "CheckRestart": {
                             "Limit": 3,
-                            "Grace": "30s",
+                            "Grace": 30000000000,
                             "IgnoreWarnings": false
                         }
                     }]
@@ -114,7 +114,7 @@ Below is the JSON representation of the job outputted by `$ nomad init`:
 The example JSON could be submitted as a job using the following:
 
 ```text
-$ curl -XPUT @d example.json http://127.0.0.1:4646/v1/job/example
+$ curl -XPUT -d @example.json http://127.0.0.1:4646/v1/job/example
 {
   "EvalID": "5d6ded54-0b2a-8858-6583-be5f476dec9d",
   "EvalCreateIndex": 12,


### PR DESCRIPTION
Fix example json job so it's submittable: Use an int for duration because we can't use the string syntax for time duration in json.

Also fixes typo in curl example command.

Signed-off-by: Michael McCracken <mikmccra@cisco.com>