### PR TITLE
lxc: cleanup partially configured containers after errors in Start

### DIFF
--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -213,7 +213,7 @@ func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse,
 	sresp, err, errCleanup := d.startWithCleanup(ctx, task)
 	if err != nil {
 		if cleanupErr := errCleanup(); cleanupErr != nil {
-			d.logger.Printf("[ERR] error occured while cleaning up from error in Start: %v", cleanupErr)
+			d.logger.Printf("[ERR] error occurred while cleaning up from error in Start: %v", cleanupErr)
 		}
 	}
 	return sresp, err

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -210,16 +210,16 @@ func (d *LxcDriver) Prestart(*ExecContext, *structs.Task) (*PrestartResponse, er
 
 // Start starts the LXC Driver
 func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse, error) {
-	sresp, err, errCleanup := d.StartWithCleanup(ctx, task)
+	sresp, err, errCleanup := d.startWithCleanup(ctx, task)
 	if err != nil {
 		if cleanupErr := errCleanup(); cleanupErr != nil {
-			d.logger.Printf("[ERR] error occured:\n%v\nwhile cleaning up from error in Start: %v", cleanupErr, err)
+			d.logger.Printf("[ERR] error occured while cleaning up from error in Start: %v", cleanupErr)
 		}
 	}
 	return sresp, err
 }
 
-func (d *LxcDriver) StartWithCleanup(ctx *ExecContext, task *structs.Task) (*StartResponse, error, func() error) {
+func (d *LxcDriver) startWithCleanup(ctx *ExecContext, task *structs.Task) (*StartResponse, error, func() error) {
 	noCleanup := func() error { return nil }
 	var driverConfig LxcDriverConfig
 	if err := mapstructure.WeakDecode(task.Config, &driverConfig); err != nil {
@@ -326,10 +326,7 @@ func (d *LxcDriver) StartWithCleanup(ctx *ExecContext, task *structs.Task) (*Sta
 		if err := c.Stop(); err != nil {
 			return err
 		}
-		if err := c.Destroy(); err != nil {
-			return err
-		}
-		return nil
+		return c.Destroy()
 	}
 
 	// Set the resource limits


### PR DESCRIPTION
_Context_:

A test added in #3687 does not clean up the container it creates.
This is actually a bug in the driver, not the test - there's no way for the test to clean up a partially configured container because Start() doesn't return a handle on error. This PR fixes this.

_Here's the commit comment_:

If there are any errors in container setup after c.Create() in
Start(), the container will be left around, with no way to clean it up
because the handle will not be created or returned from Start.

Added a wrapper that checks for errors and performs appropriate
cleanup. Returning a cleanup function from a wrapped function instead
of just doing the cleanup before returning the error helps to ensure
that future changes that might add or change error exits can't forget
to consider a cleanup function.

Adds a check to the invalid config test case to check that a container
created with an invalid config doesn't get left behind.

