### PR TITLE
Move server health loop into autopilot leader actions

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1186,7 +1186,6 @@ func (s *Server) getOrCreateAutopilotConfig() *autopilot.Config {
 	}
 
 	if !ServersMeetMinimumVersion(s.Members(), minAutopilotVersion) {
-		s.logger.Printf("[INFO] autopilot: version %v", s.Members()[0].Tags)
 		s.logger.Printf("[WARN] autopilot: can't initialize until all servers are >= %s", minAutopilotVersion.String())
 		return nil
 	}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -352,9 +352,6 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, logger *log.Logg
 	// Emit metrics
 	go s.heartbeatStats()
 
-	// Start the server health checking.
-	go s.autopilot.ServerHealthLoop(s.shutdownCh)
-
 	// Start enterprise background workers
 	s.startEnterpriseBackground()
 

--- a/vendor/github.com/hashicorp/consul/agent/consul/autopilot/autopilot.go
+++ b/vendor/github.com/hashicorp/consul/agent/consul/autopilot/autopilot.go
@@ -64,9 +64,11 @@ func NewAutopilot(logger *log.Logger, delegate Delegate, interval, healthInterva
 func (a *Autopilot) Start() {
 	a.shutdownCh = make(chan struct{})
 	a.waitGroup = sync.WaitGroup{}
-	a.waitGroup.Add(1)
+	a.clusterHealth = OperatorHealthReply{}
 
+	a.waitGroup.Add(2)
 	go a.run()
+	go a.serverHealthLoop()
 }
 
 func (a *Autopilot) Stop() {
@@ -299,15 +301,17 @@ func (a *Autopilot) handlePromotions(promotions []raft.Server) error {
 	return nil
 }
 
-// ServerHealthLoop monitors the health of the servers in the cluster
-func (a *Autopilot) ServerHealthLoop(shutdownCh <-chan struct{}) {
+// serverHealthLoop monitors the health of the servers in the cluster
+func (a *Autopilot) serverHealthLoop() {
+	defer a.waitGroup.Done()
+
 	// Monitor server health until shutdown
 	ticker := time.NewTicker(a.healthInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-shutdownCh:
+		case <-a.shutdownCh:
 			return
 		case <-ticker.C:
 			if err := a.updateClusterHealth(); err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -123,7 +123,7 @@
 		{"path":"github.com/hashicorp/consul-template/template","checksumSHA1":"N9qobVzScLbTEnGE7MgFnnTbGBw=","revision":"26d029ad37335b3827a9fde5569b2c5e10dcac8f","revisionTime":"2017-10-31T14:25:17Z"},
 		{"path":"github.com/hashicorp/consul-template/version","checksumSHA1":"NB5+D4AuCNV9Bsqh3YFdPi4AJ6U=","revision":"26d029ad37335b3827a9fde5569b2c5e10dcac8f","revisionTime":"2017-10-31T14:25:17Z"},
 		{"path":"github.com/hashicorp/consul-template/watch","checksumSHA1":"b4+Y+02pY2Y5620F9ALzKg8Zmdw=","revision":"26d029ad37335b3827a9fde5569b2c5e10dcac8f","revisionTime":"2017-10-31T14:25:17Z"},
-		{"path":"github.com/hashicorp/consul/agent/consul/autopilot","checksumSHA1":"B2Y0S6Iq6ADURuXOGB7v79gU9WU=","revision":"d08ab9fd199434e5220276356ecf9617cfec1eb2","revisionTime":"2017-12-18T20:26:35Z"},
+		{"path":"github.com/hashicorp/consul/agent/consul/autopilot","checksumSHA1":"/nyemJLkxBXKqI9xpLFyTyvOaYY=","revision":"bfeb09983befa337a3b2ebbafb7567913773e40b","revisionTime":"2018-01-23T20:52:17Z"},
 		{"path":"github.com/hashicorp/consul/api","checksumSHA1":"XLfcIX2qpRr0o26aFMjCOzvw6jo=","revision":"51ea240df8476e02215d53fbfad5838bf0d44d21","revisionTime":"2017-10-16T16:22:40Z"},
 		{"path":"github.com/hashicorp/consul/command/flags","checksumSHA1":"XTQIYV+DPUVRKpVp0+y/78bWH3I=","revision":"d08ab9fd199434e5220276356ecf9617cfec1eb2","revisionTime":"2017-12-18T20:26:35Z"},
 		{"path":"github.com/hashicorp/consul/lib","checksumSHA1":"HGljdtVaqi/e3DgIHymLRLfPYhw=","revision":"bcafded4e60982d0b71e730f0b8564d73cb1d715","revisionTime":"2017-10-31T16:39:15Z"},


### PR DESCRIPTION
This pulls in a change from Consul to fix an error message appearing while nodes were waiting to bootstrap, as a result of the autopilot refactor:
```
[ERR] autopilot: failed to initialize config: node is not the leader
```
