### PR TITLE
Skip upto a configurable amount of nodes based on a score threshold

### DIFF
--- a/scheduler/select.go
+++ b/scheduler/select.go
@@ -21,6 +21,7 @@ func NewLimitIterator(ctx Context, source RankIterator, limit int, scoreThreshol
 		limit:          limit,
 		maxSkip:        maxSkip,
 		scoreThreshold: scoreThreshold,
+		skippedNodes:   make([]*RankedNode, 0, limit+maxSkip),
 	}
 	return iter
 }

--- a/scheduler/select.go
+++ b/scheduler/select.go
@@ -3,18 +3,24 @@ package scheduler
 // LimitIterator is a RankIterator used to limit the number of options
 // that are returned before we artificially end the stream.
 type LimitIterator struct {
-	ctx    Context
-	source RankIterator
-	limit  int
-	seen   int
+	ctx              Context
+	source           RankIterator
+	limit            int
+	maxSkip          int
+	scoreThreshold   float64
+	seen             int
+	skippedNodes     []*RankedNode
+	skippedNodeIndex int
 }
 
 // NewLimitIterator is returns a LimitIterator with a fixed limit of returned options
-func NewLimitIterator(ctx Context, source RankIterator, limit int) *LimitIterator {
+func NewLimitIterator(ctx Context, source RankIterator, limit int, scoreThreshold float64, maxSkip int) *LimitIterator {
 	iter := &LimitIterator{
-		ctx:    ctx,
-		source: source,
-		limit:  limit,
+		ctx:            ctx,
+		source:         source,
+		limit:          limit,
+		maxSkip:        maxSkip,
+		scoreThreshold: scoreThreshold,
 	}
 	return iter
 }
@@ -27,19 +33,41 @@ func (iter *LimitIterator) Next() *RankedNode {
 	if iter.seen == iter.limit {
 		return nil
 	}
-
-	option := iter.source.Next()
+	option := iter.nextOption()
 	if option == nil {
 		return nil
 	}
 
+	if len(iter.skippedNodes) < iter.maxSkip {
+		// Try skipping ahead up to maxSkip to find an option with score lesser than the threshold
+		for option != nil && option.Score <= iter.scoreThreshold && len(iter.skippedNodes) < iter.maxSkip {
+			iter.skippedNodes = append(iter.skippedNodes, option)
+			option = iter.source.Next()
+		}
+	}
 	iter.seen += 1
+	if option == nil { // Didn't find anything, so use the skipped nodes instead
+		return iter.nextOption()
+	}
 	return option
+}
+
+// nextOption uses the iterator's list of skipped nodes if the source iterator is exhausted
+func (iter *LimitIterator) nextOption() *RankedNode {
+	sourceOption := iter.source.Next()
+	if sourceOption == nil && iter.skippedNodeIndex < len(iter.skippedNodes) {
+		skippedOption := iter.skippedNodes[iter.skippedNodeIndex]
+		iter.skippedNodeIndex += 1
+		return skippedOption
+	}
+	return sourceOption
 }
 
 func (iter *LimitIterator) Reset() {
 	iter.source.Reset()
 	iter.seen = 0
+	iter.skippedNodes = nil
+	iter.skippedNodeIndex = 0
 }
 
 // MaxScoreIterator is a RankIterator used to return only a single result

--- a/scheduler/select.go
+++ b/scheduler/select.go
@@ -13,7 +13,9 @@ type LimitIterator struct {
 	skippedNodeIndex int
 }
 
-// NewLimitIterator is returns a LimitIterator with a fixed limit of returned options
+// NewLimitIterator returns a LimitIterator with a fixed limit of returned options.
+// Up to maxSkip options whose score is below scoreThreshold are skipped
+// if there are additional options available in the source iterator
 func NewLimitIterator(ctx Context, source RankIterator, limit int, scoreThreshold float64, maxSkip int) *LimitIterator {
 	iter := &LimitIterator{
 		ctx:            ctx,
@@ -21,7 +23,7 @@ func NewLimitIterator(ctx Context, source RankIterator, limit int, scoreThreshol
 		limit:          limit,
 		maxSkip:        maxSkip,
 		scoreThreshold: scoreThreshold,
-		skippedNodes:   make([]*RankedNode, 0, limit+maxSkip),
+		skippedNodes:   make([]*RankedNode, 0, maxSkip),
 	}
 	return iter
 }
@@ -67,7 +69,7 @@ func (iter *LimitIterator) nextOption() *RankedNode {
 func (iter *LimitIterator) Reset() {
 	iter.source.Reset()
 	iter.seen = 0
-	iter.skippedNodes = nil
+	iter.skippedNodes = make([]*RankedNode, 0, iter.maxSkip)
 	iter.skippedNodeIndex = 0
 }
 

--- a/scheduler/select_test.go
+++ b/scheduler/select_test.go
@@ -64,7 +64,7 @@ func TestLimitIterator_ScoreThreshold(t *testing.T) {
 	}
 
 	var nodes []*structs.Node
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		nodes = append(nodes, mock.Node())
 	}
 
@@ -269,6 +269,32 @@ func TestLimitIterator_ScoreThreshold(t *testing.T) {
 			threshold: -1,
 			limit:     2,
 			maxSkip:   2,
+		},
+		{
+			desc: "maxSkip is more than available nodes",
+			nodes: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -2,
+				},
+				{
+					Node:  nodes[1],
+					Score: 1,
+				},
+			},
+			expectedOut: []*RankedNode{
+				{
+					Node:  nodes[1],
+					Score: 1,
+				},
+				{
+					Node:  nodes[0],
+					Score: -2,
+				},
+			},
+			threshold: -1,
+			limit:     2,
+			maxSkip:   10,
 		},
 	}
 

--- a/scheduler/select_test.go
+++ b/scheduler/select_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLimitIterator(t *testing.T) {
@@ -24,7 +26,7 @@ func TestLimitIterator(t *testing.T) {
 	}
 	static := NewStaticRankIterator(ctx, nodes)
 
-	limit := NewLimitIterator(ctx, static, 1)
+	limit := NewLimitIterator(ctx, static, 1, 0, 2)
 	limit.SetLimit(2)
 
 	out := collectRanked(limit)
@@ -48,6 +50,244 @@ func TestLimitIterator(t *testing.T) {
 	if out[0] != nodes[2] && out[1] != nodes[0] {
 		t.Fatalf("bad: %v", out)
 	}
+}
+
+func TestLimitIterator_ScoreThreshold(t *testing.T) {
+	_, ctx := testContext(t)
+	type testCase struct {
+		desc        string
+		nodes       []*RankedNode
+		expectedOut []*RankedNode
+		threshold   float64
+		limit       int
+		maxSkip     int
+	}
+
+	var nodes []*structs.Node
+	for i := 0; i < 10; i++ {
+		nodes = append(nodes, mock.Node())
+	}
+
+	testCases := []testCase{
+		{
+			desc: "Skips one low scoring node",
+			nodes: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+				{
+					Node:  nodes[1],
+					Score: 2,
+				},
+				{
+					Node:  nodes[2],
+					Score: 3,
+				},
+			},
+			expectedOut: []*RankedNode{
+				{
+					Node:  nodes[1],
+					Score: 2,
+				},
+				{
+					Node:  nodes[2],
+					Score: 3,
+				},
+			},
+			threshold: -1,
+			limit:     2,
+			maxSkip:   2,
+		},
+		{
+			desc: "Skips maxSkip scoring nodes",
+			nodes: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+				{
+					Node:  nodes[1],
+					Score: -2,
+				},
+				{
+					Node:  nodes[2],
+					Score: 3,
+				},
+				{
+					Node:  nodes[3],
+					Score: 4,
+				},
+			},
+			expectedOut: []*RankedNode{
+				{
+					Node:  nodes[2],
+					Score: 3,
+				},
+				{
+					Node:  nodes[3],
+					Score: 4,
+				},
+			},
+			threshold: -1,
+			limit:     2,
+			maxSkip:   2,
+		},
+		{
+			desc: "maxSkip limit reached",
+			nodes: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+				{
+					Node:  nodes[1],
+					Score: -6,
+				},
+				{
+					Node:  nodes[2],
+					Score: -3,
+				},
+				{
+					Node:  nodes[3],
+					Score: -4,
+				},
+			},
+			expectedOut: []*RankedNode{
+				{
+					Node:  nodes[2],
+					Score: -3,
+				},
+				{
+					Node:  nodes[3],
+					Score: -4,
+				},
+			},
+			threshold: -1,
+			limit:     2,
+			maxSkip:   2,
+		},
+		{
+			desc: "draw both from skipped nodes",
+			nodes: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+				{
+					Node:  nodes[1],
+					Score: -6,
+				},
+			},
+			expectedOut: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+				{
+					Node:  nodes[1],
+					Score: -6,
+				},
+			},
+			threshold: -1,
+			limit:     2,
+			maxSkip:   2,
+		}, {
+			desc: "one node above threshold, one skipped node",
+			nodes: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+				{
+					Node:  nodes[1],
+					Score: 5,
+				},
+			},
+			expectedOut: []*RankedNode{
+				{
+					Node:  nodes[1],
+					Score: 5,
+				},
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+			},
+			threshold: -1,
+			limit:     2,
+			maxSkip:   2,
+		},
+		{
+			desc: "low scoring nodes interspersed",
+			nodes: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+				{
+					Node:  nodes[1],
+					Score: 5,
+				},
+				{
+					Node:  nodes[2],
+					Score: -2,
+				},
+				{
+					Node:  nodes[3],
+					Score: 2,
+				},
+			},
+			expectedOut: []*RankedNode{
+				{
+					Node:  nodes[1],
+					Score: 5,
+				},
+				{
+					Node:  nodes[3],
+					Score: 2,
+				},
+			},
+			threshold: -1,
+			limit:     2,
+			maxSkip:   2,
+		},
+		{
+			desc: "only one node, score below threshold",
+			nodes: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+			},
+			expectedOut: []*RankedNode{
+				{
+					Node:  nodes[0],
+					Score: -1,
+				},
+			},
+			threshold: -1,
+			limit:     2,
+			maxSkip:   2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			static := NewStaticRankIterator(ctx, tc.nodes)
+
+			limit := NewLimitIterator(ctx, static, 1, 0, 2)
+			limit.SetLimit(2)
+			out := collectRanked(limit)
+			require := require.New(t)
+			require.Equal(tc.expectedOut, out)
+
+			limit.Reset()
+			require.Equal(0, limit.skippedNodeIndex)
+			require.Equal(0, len(limit.skippedNodes))
+		})
+	}
+
 }
 
 func TestMaxScoreIterator(t *testing.T) {

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -22,7 +22,8 @@ const (
 	previousFailedAllocNodePenalty = 50.0
 
 	// skipScoreThreshold is a threshold used in the limit iterator to skip nodes
-	// that have a score lower than this.
+	// that have a score lower than this. -10 is the highest possible score for a
+	// node with penalty (based on batchJobAntiAffinityPenalty)
 	skipScoreThreshold = -10.0
 
 	// maxSkip limits the number of nodes that can be skipped in the limit iterator

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -22,9 +22,8 @@ const (
 	previousFailedAllocNodePenalty = 50.0
 
 	// skipScoreThreshold is a threshold used in the limit iterator to skip nodes
-	// that have a score lower than this. This threshold ensures skipping nodes
-	// that have more than one anti affinity penalty (job and node) applied to them
-	skipScoreThreshold = -250.0
+	// that have a score lower than this.
+	skipScoreThreshold = -10.0
 
 	// maxSkip limits the number of nodes that can be skipped in the limit iterator
 	maxSkip = 3


### PR DESCRIPTION
This PR modifies the limit iterator to take a score thresold and a max skip limit. Any nodes below the threshold are skipped. If the source iterator is exhausted then skipped nodes are returned in order. 

Using this will allow the scheduler to ignore nodes with an anti-affinity penalty within a reasonable limit (based on what maxSkip is set to). 