### PR TITLE
fix prev node tracking

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -531,7 +531,7 @@ func updateRescheduleTracker(alloc *structs.Allocation, prev *structs.Allocation
 			rescheduleEvents = append(rescheduleEvents, reschedEvent.Copy())
 		}
 	}
-	rescheduleEvent := structs.NewRescheduleEvent(time.Now().UTC().UnixNano(), prev.ID, alloc.NodeID)
+	rescheduleEvent := structs.NewRescheduleEvent(time.Now().UTC().UnixNano(), prev.ID, prev.NodeID)
 	rescheduleEvents = append(rescheduleEvents, rescheduleEvent)
 	alloc.RescheduleTracker = &structs.RescheduleTracker{Events: rescheduleEvents}
 }


### PR DESCRIPTION
Fixes a bug that happened during moving methods around as part of PR #3759 , instead of storing the previous allocation's node ID, incorrectly stored the current allocation's node ID in the reschedule tracker. 
Ive updated the unit test to verify all the contents of the reschedule tracker to catch this. 