### PR TITLE
track next alloc in a new field

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -91,6 +91,7 @@ type Allocation struct {
 	DeploymentID       string
 	DeploymentStatus   *AllocDeploymentStatus
 	PreviousAllocation string
+	NextAllocation     string
 	RescheduleTracker  *RescheduleTracker
 	CreateIndex        uint64
 	ModifyIndex        uint64

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5035,6 +5035,9 @@ type Allocation struct {
 	// PreviousAllocation is the allocation that this allocation is replacing
 	PreviousAllocation string
 
+	// NextAllocation is the allocation that this allocation is being replaced by
+	NextAllocation string
+
 	// DeploymentID identifies an allocation as being created from a
 	// particular deployment
 	DeploymentID string


### PR DESCRIPTION
Adds a new field to track next allocation id, upserted during insertion of a replacement alloc that points to the previous alloc. 