### PR TITLE
Show info about rescheduling attempts in alloc status CLI

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -171,14 +171,15 @@ func (a Allocation) RescheduleInfo(t time.Time) (int, int) {
 			reschedulePolicy = tg.ReschedulePolicy
 		}
 	}
-	var availableAttempts int
-	var interval time.Duration
-	if reschedulePolicy != nil {
-		availableAttempts = *reschedulePolicy.Attempts
-		interval = *reschedulePolicy.Interval
+	if reschedulePolicy == nil {
+		return 0, 0
 	}
+	availableAttempts := *reschedulePolicy.Attempts
+	interval := *reschedulePolicy.Interval
+	attempted := 0
+
+	// Loop over reschedule tracker to find attempts within the restart policy's interval
 	if a.RescheduleTracker != nil && availableAttempts > 0 && interval > 0 {
-		attempted := 0
 		for j := len(a.RescheduleTracker.Events) - 1; j >= 0; j-- {
 			lastAttempt := a.RescheduleTracker.Events[j].RescheduleTime
 			timeDiff := t.UTC().UnixNano() - lastAttempt
@@ -186,9 +187,8 @@ func (a Allocation) RescheduleInfo(t time.Time) (int, int) {
 				attempted += 1
 			}
 		}
-		return attempted, availableAttempts
 	}
-	return 0, availableAttempts
+	return attempted, availableAttempts
 }
 
 // RescheduleTracker encapsulates previous reschedule events

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -4,6 +4,12 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"time"
+
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllocations_List(t *testing.T) {
@@ -118,4 +124,118 @@ func TestAllocations_CreateIndexSort(t *testing.T) {
 	if !reflect.DeepEqual(allocs, expect) {
 		t.Fatalf("\n\n%#v\n\n%#v", allocs, expect)
 	}
+}
+
+func TestAllocations_RescheduleInfo(t *testing.T) {
+	t.Parallel()
+	// Create a job, task group and alloc
+	job := &Job{
+		Name:      helper.StringToPtr("foo"),
+		Namespace: helper.StringToPtr(DefaultNamespace),
+		ID:        helper.StringToPtr("bar"),
+		ParentID:  helper.StringToPtr("lol"),
+		TaskGroups: []*TaskGroup{
+			{
+				Name: helper.StringToPtr("bar"),
+				Tasks: []*Task{
+					{
+						Name: "task1",
+					},
+				},
+			},
+		},
+	}
+	job.Canonicalize()
+
+	alloc := &Allocation{
+		ID:        uuid.Generate(),
+		Namespace: DefaultNamespace,
+		EvalID:    uuid.Generate(),
+		Name:      "foo-bar[1]",
+		NodeID:    uuid.Generate(),
+		TaskGroup: *job.TaskGroups[0].Name,
+		JobID:     *job.ID,
+		Job:       job,
+	}
+
+	type testCase struct {
+		desc              string
+		reschedulePolicy  *ReschedulePolicy
+		rescheduleTracker *RescheduleTracker
+		time              time.Time
+		expAttempted      int
+		expTotal          int
+	}
+
+	testCases := []testCase{
+		{
+			desc:         "no reschedule policy",
+			expAttempted: 0,
+			expTotal:     0,
+		},
+		{
+			desc: "no reschedule events",
+			reschedulePolicy: &ReschedulePolicy{
+				Attempts: helper.IntToPtr(3),
+				Interval: helper.TimeToPtr(15 * time.Minute),
+			},
+			expAttempted: 0,
+			expTotal:     3,
+		},
+		{
+			desc: "all reschedule events within interval",
+			reschedulePolicy: &ReschedulePolicy{
+				Attempts: helper.IntToPtr(3),
+				Interval: helper.TimeToPtr(15 * time.Minute),
+			},
+			time: time.Now(),
+			rescheduleTracker: &RescheduleTracker{
+				Events: []*RescheduleEvent{
+					{
+						RescheduleTime: time.Now().Add(-5 * time.Minute).UTC().UnixNano(),
+					},
+				},
+			},
+			expAttempted: 1,
+			expTotal:     3,
+		},
+		{
+			desc: "some reschedule events outside interval",
+			reschedulePolicy: &ReschedulePolicy{
+				Attempts: helper.IntToPtr(3),
+				Interval: helper.TimeToPtr(15 * time.Minute),
+			},
+			time: time.Now(),
+			rescheduleTracker: &RescheduleTracker{
+				Events: []*RescheduleEvent{
+					{
+						RescheduleTime: time.Now().Add(-45 * time.Minute).UTC().UnixNano(),
+					},
+					{
+						RescheduleTime: time.Now().Add(-30 * time.Minute).UTC().UnixNano(),
+					},
+					{
+						RescheduleTime: time.Now().Add(-10 * time.Minute).UTC().UnixNano(),
+					},
+					{
+						RescheduleTime: time.Now().Add(-5 * time.Minute).UTC().UnixNano(),
+					},
+				},
+			},
+			expAttempted: 2,
+			expTotal:     3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require := require.New(t)
+			alloc.RescheduleTracker = tc.rescheduleTracker
+			job.TaskGroups[0].ReschedulePolicy = tc.reschedulePolicy
+			attempted, total := alloc.RescheduleInfo(tc.time)
+			require.Equal(tc.expAttempted, attempted)
+			require.Equal(tc.expTotal, total)
+		})
+	}
+
 }

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -274,6 +274,11 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 		}
 	}
 
+	if alloc.NextAllocation != "" {
+		basic = append(basic,
+			fmt.Sprintf("Rescheduled Alloc ID|%s", limit(alloc.NextAllocation, uuidLength)))
+	}
+
 	if verbose {
 		basic = append(basic,
 			fmt.Sprintf("Evaluated Nodes|%d", alloc.Metrics.NodesEvaluated),
@@ -281,6 +286,10 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 			fmt.Sprintf("Exhausted Nodes|%d", alloc.Metrics.NodesExhausted),
 			fmt.Sprintf("Allocation Time|%s", alloc.Metrics.AllocationTime),
 			fmt.Sprintf("Failures|%d", alloc.Metrics.CoalescedFailures))
+		if alloc.RescheduleTracker != nil && len(alloc.RescheduleTracker.Events) > 0 {
+			basic = append(basic,
+				fmt.Sprintf("Previous Reschedule Attempts|%d", len(alloc.RescheduleTracker.Events)))
+		}
 	}
 
 	return formatKV(basic), nil

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -287,8 +287,9 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 			fmt.Sprintf("Allocation Time|%s", alloc.Metrics.AllocationTime),
 			fmt.Sprintf("Failures|%d", alloc.Metrics.CoalescedFailures))
 		if alloc.RescheduleTracker != nil && len(alloc.RescheduleTracker.Events) > 0 {
-			basic = append(basic,
-				fmt.Sprintf("Previous Reschedule Attempts|%d", len(alloc.RescheduleTracker.Events)))
+			attempts, total := alloc.RescheduleInfo(time.Unix(0, alloc.ModifyTime))
+			reschedInfo := fmt.Sprintf("Remaining Reschedule Attempts|%d/%d", attempts, total)
+			basic = append(basic, reschedInfo)
 		}
 	}
 

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -274,6 +274,11 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 		}
 	}
 
+	if alloc.RescheduleTracker != nil && len(alloc.RescheduleTracker.Events) > 0 {
+		attempts, total := alloc.RescheduleInfo(time.Unix(0, alloc.ModifyTime))
+		reschedInfo := fmt.Sprintf("Reschedule Attempts|%d/%d", attempts, total)
+		basic = append(basic, reschedInfo)
+	}
 	if alloc.NextAllocation != "" {
 		basic = append(basic,
 			fmt.Sprintf("Rescheduled Alloc ID|%s", limit(alloc.NextAllocation, uuidLength)))
@@ -286,11 +291,6 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 			fmt.Sprintf("Exhausted Nodes|%d", alloc.Metrics.NodesExhausted),
 			fmt.Sprintf("Allocation Time|%s", alloc.Metrics.AllocationTime),
 			fmt.Sprintf("Failures|%d", alloc.Metrics.CoalescedFailures))
-		if alloc.RescheduleTracker != nil && len(alloc.RescheduleTracker.Events) > 0 {
-			attempts, total := alloc.RescheduleInfo(time.Unix(0, alloc.ModifyTime))
-			reschedInfo := fmt.Sprintf("Remaining Reschedule Attempts|%d/%d", attempts, total)
-			basic = append(basic, reschedInfo)
-		}
 	}
 
 	return formatKV(basic), nil

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -281,7 +281,7 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 	}
 	if alloc.NextAllocation != "" {
 		basic = append(basic,
-			fmt.Sprintf("Rescheduled Alloc ID|%s", limit(alloc.NextAllocation, uuidLength)))
+			fmt.Sprintf("Replacement Alloc ID|%s", limit(alloc.NextAllocation, uuidLength)))
 	}
 
 	if verbose {

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -183,12 +183,7 @@ func TestAllocStatusCommand_Run(t *testing.T) {
 	a.RescheduleTracker = &structs.RescheduleTracker{
 		Events: []*structs.RescheduleEvent{
 			{
-				RescheduleTime: time.Now().Add(-5 * time.Minute).UTC().UnixNano(),
-				PrevAllocID:    uuid.Generate(),
-				PrevNodeID:     uuid.Generate(),
-			},
-			{
-				RescheduleTime: time.Now().Add(-5 * time.Minute).UTC().UnixNano(),
+				RescheduleTime: time.Now().Add(-2 * time.Minute).UTC().UnixNano(),
 				PrevAllocID:    uuid.Generate(),
 				PrevNodeID:     uuid.Generate(),
 			},
@@ -206,7 +201,7 @@ func TestAllocStatusCommand_Run(t *testing.T) {
 		t.Fatalf("expected exit 0, got: %d", code)
 	}
 	out = ui.OutputWriter.String()
-	require.Contains(out, "Previous Reschedule Attempts")
+	require.Contains(out, "Remaining Reschedule Attempts = 1/2")
 
 }
 

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -196,12 +196,7 @@ func TestAllocStatusCommand_Run(t *testing.T) {
 	}
 	out = ui.OutputWriter.String()
 	require.Contains(out, "Rescheduled Alloc ID")
-
-	if code := cmd.Run([]string{"-address=" + url, "-verbose", a.ID}); code != 0 {
-		t.Fatalf("expected exit 0, got: %d", code)
-	}
-	out = ui.OutputWriter.String()
-	require.Contains(out, "Remaining Reschedule Attempts = 1/2")
+	require.Contains(out, "Reschedule Attempts = 1/2")
 
 }
 

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -2,9 +2,9 @@ package command
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
-
 	"time"
 
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -196,7 +196,7 @@ func TestAllocStatusCommand_Run(t *testing.T) {
 	}
 	out = ui.OutputWriter.String()
 	require.Contains(out, "Rescheduled Alloc ID")
-	require.Contains(out, "Reschedule Attempts = 1/2")
+	require.Regexp(regexp.MustCompile(".*Reschedule Attempts\\s*=\\s*1/2"), out)
 
 }
 


### PR DESCRIPTION
Shows the rescheduled allocation's ID in all modes

In verbose modes, also shows attempts vs total, relative to the alloc's modify time. 