### PR TITLE
lxc: move lxc log file out of container-visible alloc dir

### DIFF
--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -253,7 +253,7 @@ func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse,
 	}
 	c.SetLogLevel(logLevel)
 
-	logFile := filepath.Join(ctx.TaskDir.LogDir, fmt.Sprintf("%v-lxc.log", task.Name))
+	logFile := filepath.Join(ctx.TaskDir.Dir, fmt.Sprintf("%v-lxc.log", task.Name))
 	c.SetLogFile(logFile)
 
 	options := lxc.TemplateOptions{


### PR DESCRIPTION
The LXC runtime's log file is currently written to TaskDir.LogDir,
which is mounted as alloc/logs inside the containers in the task
group.

This file is not intended to be visible to containers, and depending
on the log level, may have information about the host that a container
should not be allowed to see.

Is there any reason it needs to be in this dir?

Also, I'm open to other places it should go instead.
