### PR TITLE
Add fingerprint manager to manage fingerprinting node

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -236,9 +236,10 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulServic
 			defer c.configLock.Unlock()
 			return c.config
 		},
-		node:   c.config.Node,
-		client: c,
-		logger: c.logger,
+		node:       c.config.Node,
+		updateNode: c.updateNodeFromFingerprint,
+		shutdownCh: c.shutdownCh,
+		logger:     c.logger,
 	}
 
 	// Fingerprint the node
@@ -960,7 +961,7 @@ func (c *Client) fingerprint(fingerprintManager *FingerprintManager) error {
 		availableFingerprints = append(availableFingerprints, name)
 	}
 
-	if err := fingerprintManager.SetupFingerprints(availableFingerprints); err != nil {
+	if err := fingerprintManager.SetupFingerprinters(availableFingerprints); err != nil {
 		return err
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -210,9 +210,8 @@ func TestClient_RPC_Passthrough(t *testing.T) {
 func TestClient_Fingerprint(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	if _, ok := driver.BuiltinDrivers["mock_driver"]; !ok {
-		t.Skip(`test requires mock_driver; run with "-tags nomad_test"`)
-	}
+
+	driver.CheckForMockDriver(t)
 
 	c := testClient(t, nil)
 	defer c.Shutdown()
@@ -257,9 +256,7 @@ func TestClient_HasNodeChanged(t *testing.T) {
 }
 
 func TestClient_Fingerprint_Periodic(t *testing.T) {
-	if _, ok := driver.BuiltinDrivers["mock_driver"]; !ok {
-		t.Skip(`test requires mock_driver; run with "-tags nomad_test"`)
-	}
+	driver.CheckForMockDriver(t)
 	t.Parallel()
 
 	// these constants are only defined when nomad_test is enabled, so these fail

--- a/client/driver/testing.go
+++ b/client/driver/testing.go
@@ -1,0 +1,13 @@
+package driver
+
+import (
+	"testing"
+)
+
+// CheckForMockDriver is a test helper that ensures the mock driver is enabled.
+// If not, it skips the current test.
+func CheckForMockDriver(t *testing.T) {
+	if _, ok := BuiltinDrivers["mock_driver"]; !ok {
+		t.Skip(`test requires mock_driver; run with "-tags nomad_test"`)
+	}
+}

--- a/client/fingerprint_manager.go
+++ b/client/fingerprint_manager.go
@@ -20,20 +20,36 @@ type FingerprintManager struct {
 
 	// updateNode is a callback to the client to update the state of its
 	// associated node
-	updateNode func(*cstructs.FingerprintResponse)
+	updateNode func(*cstructs.FingerprintResponse) *structs.Node
 	logger     *log.Logger
+}
+
+// NewFingerprintManager is a constructor that creates and returns an instance
+// of FingerprintManager
+func NewFingerprintManager(getConfig func() *config.Config,
+	node *structs.Node,
+	shutdownCh chan struct{},
+	updateNode func(*cstructs.FingerprintResponse) *structs.Node,
+	logger *log.Logger) *FingerprintManager {
+	return &FingerprintManager{
+		getConfig:  getConfig,
+		updateNode: updateNode,
+		node:       node,
+		shutdownCh: shutdownCh,
+		logger:     logger,
+	}
 }
 
 // run runs each fingerprinter individually on an ongoing basis
 func (fm *FingerprintManager) run(f fingerprint.Fingerprint, period time.Duration, name string) {
-	fm.logger.Printf("[DEBUG] fingerprint_manager: fingerprinting %s every %v", name, period)
+	fm.logger.Printf("[DEBUG] client.fingerprint_manager: fingerprinting %s every %v", name, period)
 
 	for {
 		select {
 		case <-time.After(period):
 			_, err := fm.fingerprint(name, f)
 			if err != nil {
-				fm.logger.Printf("[DEBUG] fingerprint_manager: periodic fingerprinting for %v failed: %+v", name, err)
+				fm.logger.Printf("[DEBUG] client.fingerprint_manager: periodic fingerprinting for %v failed: %+v", name, err)
 				continue
 			}
 
@@ -45,7 +61,7 @@ func (fm *FingerprintManager) run(f fingerprint.Fingerprint, period time.Duratio
 
 // setupDrivers is used to fingerprint the node to see if these drivers are
 // supported
-func (fm *FingerprintManager) SetupDrivers(drivers []string) error {
+func (fm *FingerprintManager) setupDrivers(drivers []string) error {
 	var availDrivers []string
 	driverCtx := driver.NewDriverContext("", "", fm.getConfig(), fm.node, fm.logger, nil)
 	for _, name := range drivers {
@@ -57,7 +73,7 @@ func (fm *FingerprintManager) SetupDrivers(drivers []string) error {
 
 		detected, err := fm.fingerprint(name, d)
 		if err != nil {
-			fm.logger.Printf("[DEBUG] fingerprint_manager: fingerprinting for %v failed: %+v", name, err)
+			fm.logger.Printf("[DEBUG] client.fingerprint_manager: fingerprinting for %v failed: %+v", name, err)
 			return err
 		}
 
@@ -72,8 +88,7 @@ func (fm *FingerprintManager) SetupDrivers(drivers []string) error {
 		}
 	}
 
-	fm.logger.Printf("[DEBUG] fingerprint_manager: available drivers %v", availDrivers)
-
+	fm.logger.Printf("[DEBUG] client.fingerprint_manager: detected drivers %v", availDrivers)
 	return nil
 }
 
@@ -83,25 +98,27 @@ func (fm *FingerprintManager) SetupDrivers(drivers []string) error {
 func (fm *FingerprintManager) fingerprint(name string, f fingerprint.Fingerprint) (bool, error) {
 	request := &cstructs.FingerprintRequest{Config: fm.getConfig(), Node: fm.node}
 	var response cstructs.FingerprintResponse
-	err := f.Fingerprint(request, &response)
-	if err != nil {
+	if err := f.Fingerprint(request, &response); err != nil {
 		return false, err
 	}
 
-	fm.updateNode(&response)
+	if node := fm.updateNode(&response); node != nil {
+		fm.node = node
+	}
+
 	return response.Detected, nil
 }
 
 // setupFingerprints is used to fingerprint the node to see if these attributes are
 // supported
-func (fm *FingerprintManager) SetupFingerprinters(fingerprints []string) error {
+func (fm *FingerprintManager) setupFingerprinters(fingerprints []string) error {
 	var appliedFingerprints []string
 
 	for _, name := range fingerprints {
 		f, err := fingerprint.NewFingerprint(name, fm.logger)
 
 		if err != nil {
-			fm.logger.Printf("[DEBUG] fingerprint_manager: fingerprinting for %v failed: %+v", name, err)
+			fm.logger.Printf("[DEBUG] client.fingerprint_manager: fingerprinting for %v failed: %+v", name, err)
 			return err
 		}
 
@@ -121,6 +138,75 @@ func (fm *FingerprintManager) SetupFingerprinters(fingerprints []string) error {
 		}
 	}
 
-	fm.logger.Printf("[DEBUG] fingerprint_manager: applied fingerprints %v", appliedFingerprints)
+	fm.logger.Printf("[DEBUG] client.fingerprint_manager: detected fingerprints %v", appliedFingerprints)
+	return nil
+}
+
+func (fp *FingerprintManager) Run() error {
+	// first, set up all fingerprints
+	cfg := fp.getConfig()
+	whitelistFingerprints := cfg.ReadStringListToMap("fingerprint.whitelist")
+	whitelistFingerprintsEnabled := len(whitelistFingerprints) > 0
+	blacklistFingerprints := cfg.ReadStringListToMap("fingerprint.blacklist")
+
+	fp.logger.Printf("[DEBUG] client.fingerprint_manager: built-in fingerprints: %v", fingerprint.BuiltinFingerprints())
+
+	var availableFingerprints []string
+	var skippedFingerprints []string
+	for _, name := range fingerprint.BuiltinFingerprints() {
+		// Skip modules that are not in the whitelist if it is enabled.
+		if _, ok := whitelistFingerprints[name]; whitelistFingerprintsEnabled && !ok {
+			skippedFingerprints = append(skippedFingerprints, name)
+			continue
+		}
+		// Skip modules that are in the blacklist
+		if _, ok := blacklistFingerprints[name]; ok {
+			skippedFingerprints = append(skippedFingerprints, name)
+			continue
+		}
+
+		availableFingerprints = append(availableFingerprints, name)
+	}
+
+	if err := fp.setupFingerprinters(availableFingerprints); err != nil {
+		return err
+	}
+
+	if len(skippedFingerprints) != 0 {
+		fp.logger.Printf("[DEBUG] client.fingerprint_manager: fingerprint modules skipped due to white/blacklist: %v", skippedFingerprints)
+	}
+
+	// next, set up drivers
+	// Build the white/blacklists of drivers.
+	whitelistDrivers := cfg.ReadStringListToMap("driver.whitelist")
+	whitelistDriversEnabled := len(whitelistDrivers) > 0
+	blacklistDrivers := cfg.ReadStringListToMap("driver.blacklist")
+
+	var availDrivers []string
+	var skippedDrivers []string
+
+	for name := range driver.BuiltinDrivers {
+		// Skip fingerprinting drivers that are not in the whitelist if it is
+		// enabled.
+		if _, ok := whitelistDrivers[name]; whitelistDriversEnabled && !ok {
+			skippedDrivers = append(skippedDrivers, name)
+			continue
+		}
+		// Skip fingerprinting drivers that are in the blacklist
+		if _, ok := blacklistDrivers[name]; ok {
+			skippedDrivers = append(skippedDrivers, name)
+			continue
+		}
+
+		availDrivers = append(availDrivers, name)
+	}
+
+	if err := fp.setupDrivers(availDrivers); err != nil {
+		return err
+	}
+
+	if len(skippedDrivers) > 0 {
+		fp.logger.Printf("[DEBUG] client.fingerprint_manager: drivers skipped due to white/blacklist: %v", skippedDrivers)
+	}
 	return nil
 }

--- a/client/fingerprint_manager.go
+++ b/client/fingerprint_manager.go
@@ -1,0 +1,122 @@
+package client
+
+import (
+	"log"
+	"time"
+
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/client/driver"
+	"github.com/hashicorp/nomad/client/fingerprint"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// FingerprintManager runs a client fingerprinters on a continuous basis, and
+// updates the client when the node has changed
+type FingerprintManager struct {
+	getConfig func() *config.Config
+	node      *structs.Node
+	client    *Client
+	logger    *log.Logger
+}
+
+// run runs each fingerprinter individually on an ongoing basis
+func (fm *FingerprintManager) run(f fingerprint.Fingerprint, period time.Duration, name string) {
+	fm.logger.Printf("[DEBUG] fingerprint_manager: fingerprinting %s every %v", name, period)
+
+	for {
+		select {
+		case <-time.After(period):
+			_, err := fm.fingerprint(name, f)
+			if err != nil {
+				fm.logger.Printf("[DEBUG] fingerprint_manager: periodic fingerprinting for %v failed: %+v", name, err)
+				continue
+			}
+
+		case <-fm.client.shutdownCh:
+			return
+		}
+	}
+}
+
+// setupDrivers is used to fingerprint the node to see if these drivers are
+// supported
+func (fm *FingerprintManager) SetupDrivers(drivers []string) error {
+	var availDrivers []string
+	driverCtx := driver.NewDriverContext("", "", fm.getConfig(), fm.node, fm.logger, nil)
+	for _, name := range drivers {
+
+		d, err := driver.NewDriver(name, driverCtx)
+		if err != nil {
+			return err
+		}
+
+		detected, err := fm.fingerprint(name, d)
+		if err != nil {
+			fm.logger.Printf("[DEBUG] fingerprint_manager: fingerprinting for %v failed: %+v", name, err)
+			return err
+		}
+
+		// log the fingerprinters which have been applied
+		if detected {
+			availDrivers = append(availDrivers, name)
+		}
+
+		p, period := d.Periodic()
+		if p {
+			go fm.run(d, period, name)
+		}
+	}
+
+	fm.logger.Printf("[DEBUG] fingerprint_manager: available drivers %v", availDrivers)
+
+	return nil
+}
+
+// fingerprint does an initial fingerprint of the client. If the fingerprinter
+// is meant to be run continuously, a process is launched ro perform this
+// fingerprint on an ongoing basis in the background.
+func (fm *FingerprintManager) fingerprint(name string, f fingerprint.Fingerprint) (bool, error) {
+	request := &cstructs.FingerprintRequest{Config: fm.getConfig(), Node: fm.node}
+	var response cstructs.FingerprintResponse
+	err := f.Fingerprint(request, &response)
+	if err != nil {
+		return false, err
+	}
+
+	fm.client.updateNodeFromFingerprint(&response)
+	return response.Detected, nil
+}
+
+// setupDrivers is used to fingerprint the node to see if these attributes are
+// supported
+func (fm *FingerprintManager) SetupFingerprints(fingerprints []string) error {
+	var appliedFingerprints []string
+
+	for _, name := range fingerprints {
+		f, err := fingerprint.NewFingerprint(name, fm.logger)
+
+		if err != nil {
+			fm.logger.Printf("[DEBUG] fingerprint_manager: fingerprinting for %v failed: %+v", name, err)
+			return err
+		}
+
+		detected, err := fm.fingerprint(name, f)
+		if err != nil {
+			return err
+		}
+
+		// log the fingerprinters which have been applied
+		if detected {
+			appliedFingerprints = append(appliedFingerprints, name)
+		}
+
+		p, period := f.Periodic()
+		if p {
+			go fm.run(f, period, name)
+		}
+	}
+
+	fm.logger.Printf("[DEBUG] fingerprint_manager: applied fingerprints %v", appliedFingerprints)
+	return nil
+}

--- a/client/fingerprint_manager_test.go
+++ b/client/fingerprint_manager_test.go
@@ -13,9 +13,7 @@ import (
 )
 
 func TestFingerprintManager_Run_MockDriver(t *testing.T) {
-	if _, ok := driver.BuiltinDrivers["mock_driver"]; !ok {
-		t.Skip(`test requires mock_driver; run with "-tags nomad_test"`)
-	}
+	driver.CheckForMockDriver(t)
 	t.Parallel()
 	require := require.New(t)
 

--- a/client/fingerprint_manager_test.go
+++ b/client/fingerprint_manager_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// test that the driver manager updates a node when its attributes change
-func TestFingerprintManager_Fingerprint_MockDriver(t *testing.T) {
+func TestFingerprintManager_Run_MockDriver(t *testing.T) {
 	if _, ok := driver.BuiltinDrivers["mock_driver"]; !ok {
 		t.Skip(`test requires mock_driver; run with "-tags nomad_test"`)
 	}
@@ -23,69 +22,64 @@ func TestFingerprintManager_Fingerprint_MockDriver(t *testing.T) {
 	node := &structs.Node{
 		Attributes: make(map[string]string, 0),
 	}
-	mockConfig := &config.Config{
-		Node: node,
-	}
 
-	var resp *cstructs.FingerprintResponse
-	updateNode := func(r *cstructs.FingerprintResponse) {
-		resp = r
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
 	}
-
+	conf := config.DefaultConfig()
 	getConfig := func() *config.Config {
-		return mockConfig
+		return conf
 	}
 
-	fm := FingerprintManager{
-		getConfig:  getConfig,
-		node:       node,
-		updateNode: updateNode,
-		logger:     testLogger(),
-	}
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		make(chan struct{}),
+		updateNode,
+		testLogger(),
+	)
 
-	// test setting up a mock driver
-	drivers := []string{"mock_driver"}
-	err := fm.SetupDrivers(drivers)
+	err := fm.Run()
 	require.Nil(err)
-
-	require.NotEqual("", resp.Attributes["driver.mock_driver"])
+	require.NotEqual("", node.Attributes["driver.mock_driver"])
 }
 
-func TestFingerprintManager_Fingerprint_RawExec(t *testing.T) {
+func TestFingerprintManager_Fingerprint_Run(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
 	node := &structs.Node{
 		Attributes: make(map[string]string, 0),
 	}
-	mockConfig := &config.Config{
-		Node: node,
-		Options: map[string]string{
-			"driver.raw_exec.enable": "true",
-		},
-	}
-	var resp *cstructs.FingerprintResponse
-	updateNode := func(r *cstructs.FingerprintResponse) {
-		resp = r
-	}
 
+	conf := config.DefaultConfig()
+	conf.Options = map[string]string{"driver.raw_exec.enable": "true"}
 	getConfig := func() *config.Config {
-		return mockConfig
+		return conf
 	}
 
-	fm := FingerprintManager{
-		getConfig:  getConfig,
-		node:       node,
-		updateNode: updateNode,
-		logger:     testLogger(),
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
 	}
 
-	// test setting up a mock driver
-	drivers := []string{"raw_exec"}
-	err := fm.SetupDrivers(drivers)
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		make(chan struct{}),
+		updateNode,
+		testLogger(),
+	)
+
+	err := fm.Run()
 	require.Nil(err)
 
-	require.NotEqual("", resp.Attributes["driver.raw_exec"])
+	require.NotEqual("", node.Attributes["driver.raw_exec"])
 }
 
 func TestFingerprintManager_Fingerprint_Periodic(t *testing.T) {
@@ -95,20 +89,19 @@ func TestFingerprintManager_Fingerprint_Periodic(t *testing.T) {
 	node := &structs.Node{
 		Attributes: make(map[string]string, 0),
 	}
-	var resp *cstructs.FingerprintResponse
-	updateNode := func(r *cstructs.FingerprintResponse) {
-		resp = r
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
 	}
-	mockConfig := &config.Config{
-		Node: node,
-		Options: map[string]string{
-			"test.shutdown_periodic_after":    "true",
-			"test.shutdown_periodic_duration": "3",
-		},
+	conf := config.DefaultConfig()
+	conf.Options = map[string]string{
+		"test.shutdown_periodic_after":    "true",
+		"test.shutdown_periodic_duration": "3",
 	}
-
 	getConfig := func() *config.Config {
-		return mockConfig
+		return conf
 	}
 
 	shutdownCh := make(chan struct{})
@@ -116,22 +109,20 @@ func TestFingerprintManager_Fingerprint_Periodic(t *testing.T) {
 		close(shutdownCh)
 	})()
 
-	fm := FingerprintManager{
-		getConfig:  getConfig,
-		node:       node,
-		updateNode: updateNode,
-		shutdownCh: shutdownCh,
-		logger:     testLogger(),
-	}
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		shutdownCh,
+		updateNode,
+		testLogger(),
+	)
 
-	// test setting up a mock driver
-	drivers := []string{"mock_driver"}
-	err := fm.SetupDrivers(drivers)
+	err := fm.Run()
 	require.Nil(err)
 
 	// Ensure the mock driver is registered on the client
 	testutil.WaitForResult(func() (bool, error) {
-		mockDriverStatus := resp.Attributes["driver.mock_driver"]
+		mockDriverStatus := node.Attributes["driver.mock_driver"]
 		if mockDriverStatus == "" {
 			return false, fmt.Errorf("mock driver attribute should be set on the client")
 		}
@@ -142,7 +133,7 @@ func TestFingerprintManager_Fingerprint_Periodic(t *testing.T) {
 
 	// Ensure that the client fingerprinter eventually removes this attribute
 	testutil.WaitForResult(func() (bool, error) {
-		mockDriverStatus := resp.Attributes["driver.mock_driver"]
+		mockDriverStatus := node.Attributes["driver.mock_driver"]
 		if mockDriverStatus != "" {
 			return false, fmt.Errorf("mock driver attribute should not be set on the client")
 		}
@@ -150,4 +141,289 @@ func TestFingerprintManager_Fingerprint_Periodic(t *testing.T) {
 	}, func(err error) {
 		t.Fatalf("err: %v", err)
 	})
+}
+
+func TestFimgerprintManager_Run_InWhitelist(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
+	}
+	conf := config.DefaultConfig()
+	conf.Options = map[string]string{"fingerprint.whitelist": "  arch,cpu,memory,network,storage,foo,bar	"}
+	getConfig := func() *config.Config {
+		return conf
+	}
+
+	shutdownCh := make(chan struct{})
+	defer (func() {
+		close(shutdownCh)
+	})()
+
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		shutdownCh,
+		updateNode,
+		testLogger(),
+	)
+
+	err := fm.Run()
+	require.Nil(err)
+	require.NotEqual(node.Attributes["cpu.frequency"], "")
+}
+
+func TestFimgerprintManager_Run_InBlacklist(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
+	}
+	conf := config.DefaultConfig()
+	conf.Options = map[string]string{"fingerprint.whitelist": "  arch,memory,foo,bar	"}
+	conf.Options = map[string]string{"fingerprint.blacklist": "  cpu	"}
+	getConfig := func() *config.Config {
+		return conf
+	}
+
+	shutdownCh := make(chan struct{})
+	defer (func() {
+		close(shutdownCh)
+	})()
+
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		shutdownCh,
+		updateNode,
+		testLogger(),
+	)
+
+	err := fm.Run()
+	require.Nil(err)
+	require.Equal(node.Attributes["cpu.frequency"], "")
+	require.NotEqual(node.Attributes["memory.totalbytes"], "")
+}
+
+func TestFimgerprintManager_Run_Combination(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
+	}
+	conf := config.DefaultConfig()
+	conf.Options = map[string]string{"fingerprint.whitelist": "  arch,cpu,memory,foo,bar	"}
+	conf.Options = map[string]string{"fingerprint.blacklist": "  memory,nomad	"}
+	getConfig := func() *config.Config {
+		return conf
+	}
+
+	shutdownCh := make(chan struct{})
+	defer (func() {
+		close(shutdownCh)
+	})()
+
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		shutdownCh,
+		updateNode,
+		testLogger(),
+	)
+
+	err := fm.Run()
+	require.Nil(err)
+	require.NotEqual(node.Attributes["cpu.frequency"], "")
+	require.NotEqual(node.Attributes["cpu.arch"], "")
+	require.Equal(node.Attributes["memory.totalbytes"], "")
+	require.Equal(node.Attributes["nomad.version"], "")
+}
+
+func TestFimgerprintManager_Run_WhitelistDrivers(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
+	}
+	conf := config.DefaultConfig()
+	conf.Options = map[string]string{
+		"driver.raw_exec.enable": "1",
+		"driver.whitelist": "   raw_exec ,  foo	",
+	}
+	getConfig := func() *config.Config {
+		return conf
+	}
+
+	shutdownCh := make(chan struct{})
+	defer (func() {
+		close(shutdownCh)
+	})()
+
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		shutdownCh,
+		updateNode,
+		testLogger(),
+	)
+
+	err := fm.Run()
+	require.Nil(err)
+	require.NotEqual(node.Attributes["driver.raw_exec"], "")
+}
+
+func TestFimgerprintManager_Run_AllDriversBlacklisted(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
+	}
+	conf := config.DefaultConfig()
+	conf.Options = map[string]string{
+		"driver.whitelist": "   foo,bar,baz	",
+	}
+	getConfig := func() *config.Config {
+		return conf
+	}
+
+	shutdownCh := make(chan struct{})
+	defer (func() {
+		close(shutdownCh)
+	})()
+
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		shutdownCh,
+		updateNode,
+		testLogger(),
+	)
+
+	err := fm.Run()
+	require.Nil(err)
+	require.Equal(node.Attributes["driver.raw_exec"], "")
+	require.Equal(node.Attributes["driver.exec"], "")
+	require.Equal(node.Attributes["driver.docker"], "")
+}
+
+func TestFimgerprintManager_Run_DriversWhiteListBlacklistCombination(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
+	}
+	conf := config.DefaultConfig()
+	conf.Options = map[string]string{
+		"driver.raw_exec.enable": "1",
+		"driver.whitelist": "   raw_exec,exec,foo,bar,baz	",
+		"driver.blacklist": "   exec,foo,bar,baz	",
+	}
+	getConfig := func() *config.Config {
+		return conf
+	}
+
+	shutdownCh := make(chan struct{})
+	defer (func() {
+		close(shutdownCh)
+	})()
+
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		shutdownCh,
+		updateNode,
+		testLogger(),
+	)
+
+	err := fm.Run()
+	require.Nil(err)
+	require.NotEqual(node.Attributes["driver.raw_exec"], "")
+	require.Equal(node.Attributes["driver.exec"], "")
+	require.Equal(node.Attributes["foo"], "")
+	require.Equal(node.Attributes["bar"], "")
+	require.Equal(node.Attributes["baz"], "")
+}
+
+func TestFimgerprintManager_Run_DriversInBlacklist(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	updateNode := func(r *cstructs.FingerprintResponse) *structs.Node {
+		for k, v := range r.Attributes {
+			node.Attributes[k] = v
+		}
+		return node
+	}
+	conf := config.DefaultConfig()
+	conf.Options = map[string]string{
+		"driver.raw_exec.enable": "1",
+		"driver.whitelist": "   raw_exec,foo,bar,baz	",
+		"driver.blacklist": "   exec,foo,bar,baz	",
+	}
+	getConfig := func() *config.Config {
+		return conf
+	}
+
+	shutdownCh := make(chan struct{})
+	defer (func() {
+		close(shutdownCh)
+	})()
+
+	fm := NewFingerprintManager(
+		getConfig,
+		node,
+		shutdownCh,
+		updateNode,
+		testLogger(),
+	)
+
+	err := fm.Run()
+	require.Nil(err)
+	require.NotEqual(node.Attributes["driver.raw_exec"], "")
+	require.Equal(node.Attributes["driver.exec"], "")
 }

--- a/client/fingerprint_manager_test.go
+++ b/client/fingerprint_manager_test.go
@@ -1,0 +1,139 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/client/driver"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// test that the driver manager updates a node when its attributes change
+func TestFingerprintManager_Fingerprint_MockDriver(t *testing.T) {
+	if _, ok := driver.BuiltinDrivers["mock_driver"]; !ok {
+		t.Skip(`test requires mock_driver; run with "-tags nomad_test"`)
+	}
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	mockConfig := &config.Config{
+		Node: node,
+	}
+	c := &Client{
+		config: mockConfig,
+	}
+	getConfig := func() *config.Config {
+		return mockConfig
+	}
+
+	fm := FingerprintManager{
+		getConfig: getConfig,
+		node:      node,
+		client:    c,
+		logger:    testLogger(),
+	}
+
+	// test setting up a mock driver
+	drivers := []string{"mock_driver"}
+	err := fm.SetupDrivers(drivers)
+	require.Nil(err)
+
+	require.NotEqual("", node.Attributes["driver.mock_driver"])
+}
+
+func TestFingerprintManager_Fingerprint_RawExec(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	mockConfig := &config.Config{
+		Node: node,
+		Options: map[string]string{
+			"driver.raw_exec.enable": "true",
+		},
+	}
+	c := &Client{
+		config: mockConfig,
+	}
+	getConfig := func() *config.Config {
+		return mockConfig
+	}
+
+	fm := FingerprintManager{
+		getConfig: getConfig,
+		node:      node,
+		client:    c,
+		logger:    testLogger(),
+	}
+
+	// test setting up a mock driver
+	drivers := []string{"raw_exec"}
+	err := fm.SetupDrivers(drivers)
+	require.Nil(err)
+
+	require.NotEqual("", node.Attributes["driver.raw_exec"])
+}
+
+func TestFingerprintManager_Fingerprint_Periodic(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	node := &structs.Node{
+		Attributes: make(map[string]string, 0),
+	}
+	mockConfig := &config.Config{
+		Node: node,
+		Options: map[string]string{
+			"test.shutdown_periodic_after":    "true",
+			"test.shutdown_periodic_duration": "3",
+		},
+	}
+	c := &Client{
+		config: mockConfig,
+	}
+	getConfig := func() *config.Config {
+		return mockConfig
+	}
+
+	fm := FingerprintManager{
+		getConfig: getConfig,
+		node:      node,
+		client:    c,
+		logger:    testLogger(),
+	}
+
+	// test setting up a mock driver
+	drivers := []string{"mock_driver"}
+	err := fm.SetupDrivers(drivers)
+	require.Nil(err)
+
+	// Ensure the mock driver is registered on the client
+	testutil.WaitForResult(func() (bool, error) {
+		mockDriverStatus := node.Attributes["driver.mock_driver"]
+		if mockDriverStatus == "" {
+			return false, fmt.Errorf("mock driver attribute should be set on the client")
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Ensure that the client fingerprinter eventually removes this attribute
+	testutil.WaitForResult(func() (bool, error) {
+		mockDriverStatus := node.Attributes["driver.mock_driver"]
+		if mockDriverStatus != "" {
+			return false, fmt.Errorf("mock driver attribute should not be set on the client")
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+}


### PR DESCRIPTION
In the future, the fingerprint manager will later also be responsible for updating the node status of a healthy/unhealthy driver. 

Considerations: 
- Should the fingerprint manager be responsible for updating the Node or should that stay in the client? 