### PR TITLE
Fix usage of RPC bind address versus advertised

### DIFF
--- a/nomad/autopilot.go
+++ b/nomad/autopilot.go
@@ -64,7 +64,7 @@ func (d *AutopilotDelegate) IsServer(m serf.Member) (*autopilot.ServerInfo, erro
 	server := &autopilot.ServerInfo{
 		Name:   m.Name,
 		ID:     parts.ID,
-		Addr:   parts.Addr,
+		Addr:   parts.RPCAddr,
 		Build:  parts.Build,
 		Status: m.Status,
 	}

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -178,10 +178,10 @@ func (n *Node) constructNodeServerInfoResponse(snap *state.StateSnapshot, reply 
 
 	// Reply with config information required for future RPC requests
 	reply.Servers = make([]*structs.NodeServerInfo, 0, len(n.srv.localPeers))
-	for k, v := range n.srv.localPeers {
+	for _, v := range n.srv.localPeers {
 		reply.Servers = append(reply.Servers,
 			&structs.NodeServerInfo{
-				RPCAdvertiseAddr: string(k),
+				RPCAdvertiseAddr: v.RPCAddr.String(),
 				RPCMajorVersion:  int32(v.MajorVersion),
 				RPCMinorVersion:  int32(v.MinorVersion),
 				Datacenter:       v.Datacenter,

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -2,7 +2,6 @@ package nomad
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/hashicorp/consul/agent/consul/autopilot"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -43,8 +42,7 @@ func (op *Operator) RaftGetConfiguration(args *structs.GenericRequest, reply *st
 			continue
 		}
 
-		addr := (&net.TCPAddr{IP: member.Addr, Port: parts.Port}).String()
-		serverMap[raft.ServerAddress(addr)] = member
+		serverMap[raft.ServerAddress(parts.RPCAddr.String())] = member
 	}
 
 	// Fill out the reply.

--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -426,7 +426,7 @@ func (s *Server) forwardLeader(server *serverParts, method string, args interfac
 	if server == nil {
 		return structs.ErrNoLeader
 	}
-	return s.connPool.RPC(s.config.Region, server.Addr, server.MajorVersion, method, args, reply)
+	return s.connPool.RPC(s.config.Region, server.RPCAddr, server.MajorVersion, method, args, reply)
 }
 
 // forwardServer is used to forward an RPC call to a particular server
@@ -457,7 +457,7 @@ func (s *Server) forwardRegion(region, method string, args interface{}, reply in
 
 	// Forward to remote Nomad
 	metrics.IncrCounter([]string{"nomad", "rpc", "cross-region", region}, 1)
-	return s.connPool.RPC(region, server.Addr, server.MajorVersion, method, args, reply)
+	return s.connPool.RPC(region, server.RPCAddr, server.MajorVersion, method, args, reply)
 }
 
 // streamingRpc creates a connection to the given server and conducts the


### PR DESCRIPTION
Fixes a few instances where the bind address of the Server RPC was used
rather than the advertise. The most import, fixed occurence is the
Server's responding with the non-advertise address in the heartbeat.