### PR TITLE
Update CLI to use ISO_8601 time format.

### DIFF
--- a/command/helpers.go
+++ b/command/helpers.go
@@ -59,7 +59,8 @@ func formatTime(t time.Time) string {
 		// It's more confusing to display the UNIX epoch or a zero value than nothing
 		return ""
 	}
-	return t.Format("01/02/06 15:04:05 MST")
+	// Return ISO_8601 time format GH-3806
+	return t.Format("2006-01-02T15:04:05Z07:00")
 }
 
 // formatUnixNanoTime is a helper for formatting time for output.


### PR DESCRIPTION
This change updates the formatTime CLI helper function to return an ISO_8601 time format which will make CLI time usage more consistent and easier. Previously the time format was in US style format which was somewhat confusing to non US users.

This has been tested locally:

```
./jrasell-nomad job history example
Version     = 0
Stable      = true
Submit Date = 2018-01-30T08:32:29Z
```

```
./jrasell-nomad alloc-status f1bab94a |grep 'Started At' 
Started At     = 2018-01-30T08:32:30Z
```

Closes #3806