### PR TITLE
Support ARMv6 for 32bit ARM build

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -85,7 +85,7 @@ pkg/linux_amd64/nomad: $(SOURCE_FILES) ## Build Nomad for linux/amd64
 
 pkg/linux_arm/nomad: $(SOURCE_FILES) ## Build Nomad for linux/arm
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
-	@CGO_ENABLED=1 GOOS=linux GOARCH=arm CC=arm-linux-gnueabihf-gcc-5 \
+	@CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=6 CC=arm-linux-gnueabihf-gcc-5 \
 		go build \
 		-ldflags $(GO_LDFLAGS) \
 		-tags "$(GO_TAGS)" \


### PR DESCRIPTION
A test build for anyone with a 32bit ARM machine:
[nomad.gz](https://github.com/hashicorp/nomad/files/1683761/nomad.gz)

Fix via https://github.com/hashicorp/nomad/issues/2517#issuecomment-360987079