### PR TITLE
docker: allow configuration of docker mounts

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -104,6 +104,18 @@ const (
 	dockerCapsWhitelistConfigOption  = "docker.caps.whitelist"
 	dockerCapsWhitelistConfigDefault = dockerBasicCaps
 
+	// dockerSharedAllocContainerPath is the key for setting the mount point
+	// for the SharedAllocDir
+	dockerSharedAllocContainerPath = "docker.dir.alloc.mount"
+
+	// dockerTaskLocalContainerPath is the key for setting the mount point
+	// for the LocalDir
+	dockerTaskLocalContainerPath = "docker.dir.local.mount"
+
+	// dockerTaskSecretsContainerPath is the key for setting the mount point
+	// for the SecretsDir
+	dockerTaskSecretsContainerPath = "docker.dir.secrets.mount"
+
 	// dockerTimeout is the length of time a request can be outstanding before
 	// it is timed out.
 	dockerTimeout = 5 * time.Minute
@@ -1009,9 +1021,9 @@ func (d *DockerDriver) dockerClients() (*docker.Client, *docker.Client, error) {
 func (d *DockerDriver) containerBinds(driverConfig *DockerDriverConfig, taskDir *allocdir.TaskDir,
 	task *structs.Task) ([]string, error) {
 
-	allocDirBind := fmt.Sprintf("%s:%s", taskDir.SharedAllocDir, allocdir.SharedAllocContainerPath)
-	taskLocalBind := fmt.Sprintf("%s:%s", taskDir.LocalDir, allocdir.TaskLocalContainerPath)
-	secretDirBind := fmt.Sprintf("%s:%s", taskDir.SecretsDir, allocdir.TaskSecretsContainerPath)
+	allocDirBind := fmt.Sprintf("%s:%s", taskDir.SharedAllocDir, d.config.ReadDefault(dockerSharedAllocContainerPath, allocdir.SharedAllocContainerPath))
+	taskLocalBind := fmt.Sprintf("%s:%s", taskDir.LocalDir, d.config.ReadDefault(dockerTaskLocalContainerPath, allocdir.TaskLocalContainerPath))
+	secretDirBind := fmt.Sprintf("%s:%s", taskDir.SecretsDir, d.config.ReadDefault(dockerTaskSecretsContainerPath, allocdir.TaskSecretsContainerPath))
 	binds := []string{allocDirBind, taskLocalBind, secretDirBind}
 
 	volumesEnabled := d.config.ReadBoolDefault(dockerVolumesConfigOption, dockerVolumesConfigDefault)

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -633,6 +633,18 @@ options](/docs/agent/configuration/client.html#options):
   tasks using `cap_add` and `cap_drop` options. Supports the value `"ALL"` as a 
   shortcut for whitelisting all capabilities.
 
+* `docker.dir.alloc.mount`: Defaults to `/alloc`. Changing this allows you to change
+  the mount point inside the container for shared task storage. This can be particularly helpful
+  when implementing a schedular agnostic standard for a shared task storage directory.
+
+* `docker.dir.local.mount`: Defaults to `/local`. Changing this allows you to change
+  the mount point inside the container for local storage. This can be particularly helpful when
+  implementing a schedular agnostic standard for a local storage directory.
+
+* `docker.dir.secrets.mount`: Defaults to `/secrets`. Changing this allows you to change
+  the mount point inside the container for secrets. This can be particularly helpful when
+  implementing a schedular agnostic standard for a secrets directory.
+
 Note: When testing or using the `-dev` flag you can use `DOCKER_HOST`,
 `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` to customize Nomad's behavior. If
 `docker.endpoint` is set Nomad will **only** read client configuration from the


### PR DESCRIPTION
This is fairly critical for those of us coming from previous schedulers and have already established mount points for these concepts. (i.e. [mesos sandbox](http://mesos.apache.org/documentation/latest/sandbox/) )