### PR TITLE
Reconciler should consider failed allocs when marking deployment as failed

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -160,6 +160,9 @@ func (a *allocReconciler) Compute() *reconcileResults {
 	// Detect if the deployment is paused
 	if a.deployment != nil {
 		// Detect if any allocs associated with this deploy have failed
+		// Failed allocations could edge trigger an evaluation before the deployment watcher
+		// runs and marks the deploy as failed. This block makes sure that is still
+		// considered a failed deploy
 		failedAllocsInDeploy := false
 		for _, as := range m {
 			for _, alloc := range as {

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -159,8 +159,17 @@ func (a *allocReconciler) Compute() *reconcileResults {
 
 	// Detect if the deployment is paused
 	if a.deployment != nil {
+		// Detect if any allocs associated with this deploy have failed
+		failedAllocsInDeploy := false
+		for _, as := range m {
+			for _, alloc := range as {
+				if alloc.DeploymentID == a.deployment.ID && alloc.ClientStatus == structs.AllocClientStatusFailed {
+					failedAllocsInDeploy = true
+				}
+			}
+		}
 		a.deploymentPaused = a.deployment.Status == structs.DeploymentStatusPaused
-		a.deploymentFailed = a.deployment.Status == structs.DeploymentStatusFailed
+		a.deploymentFailed = a.deployment.Status == structs.DeploymentStatusFailed || failedAllocsInDeploy
 	}
 
 	// Reconcile each group


### PR DESCRIPTION
This PR fixes a race between the reconciler processing an edge triggered eval when `ClientStatusFailed` and the deployment watcher marking the deploy as failed. This race causes the reconciler to create a replacement for the failed allocation when it should not. 

The reconciler should consider allocs with ClientStatusFailed as a failed deployment even if the deployment watcher hasn't marked the deployment yet, to fix this race