### PR TITLE
Implement MultiplexV2 RPC handling

### DIFF
--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -179,7 +179,11 @@ func (s *Server) handleMultiplex(conn net.Conn, ctx *RPCContext) {
 
 	conf := yamux.DefaultConfig()
 	conf.LogOutput = s.config.LogOutput
-	server, _ := yamux.Server(conn, conf)
+	server, err := yamux.Server(conn, conf)
+	if err != nil {
+		s.logger.Printf("[ERR] nomad.rpc: multiplex failed to create yamux server: %v", err)
+		return
+	}
 
 	// Update the context to store the yamux session
 	ctx.Session = server
@@ -275,7 +279,11 @@ func (s *Server) handleMultiplexV2(conn net.Conn, ctx *RPCContext) {
 
 	conf := yamux.DefaultConfig()
 	conf.LogOutput = s.config.LogOutput
-	server, _ := yamux.Server(conn, conf)
+	server, err := yamux.Server(conn, conf)
+	if err != nil {
+		s.logger.Printf("[ERR] nomad.rpc: multiplex_v2 failed to create yamux server: %v", err)
+		return
+	}
 
 	// Update the context to store the yamux session
 	ctx.Session = server

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -10,11 +10,13 @@ import (
 
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/helper/pool"
+	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/hashicorp/raft"
+	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -200,4 +202,63 @@ func TestRPC_streamingRpcConn_badMethod(t *testing.T) {
 	require.Nil(conn)
 	require.NotNil(err)
 	require.Contains(err.Error(), "unknown rpc method: \"Bogus\"")
+}
+
+// COMPAT: Remove in 0.10
+// This is a very low level test to assert that the V2 handling works. It is
+// making manual RPC calls since no helpers exist at this point since we are
+// only implementing support for v2 but not using it yet. In the future we can
+// switch the conn pool to establishing v2 connections and we can deprecate this
+// test.
+func TestRPC_handleMultiplexV2(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	s := TestServer(t, nil)
+	defer s.Shutdown()
+	testutil.WaitForLeader(t, s.RPC)
+
+	p1, p2 := net.Pipe()
+	defer p1.Close()
+	defer p2.Close()
+
+	// Start the handler
+	doneCh := make(chan struct{})
+	go func() {
+		s.handleConn(p2, &RPCContext{Conn: p2})
+		close(doneCh)
+	}()
+
+	// Establish the MultiplexV2 connection
+	_, err := p1.Write([]byte{byte(pool.RpcMultiplexV2)})
+	require.Nil(err)
+
+	// Make two streams
+	conf := yamux.DefaultConfig()
+	conf.LogOutput = testlog.NewWriter(t)
+	session, err := yamux.Client(p1, conf)
+	require.Nil(err)
+
+	s1, err := session.Open()
+	require.Nil(err)
+	defer s1.Close()
+
+	s2, err := session.Open()
+	require.Nil(err)
+	defer s2.Close()
+
+	// Make an RPC
+	_, err = s1.Write([]byte{byte(pool.RpcNomad)})
+	require.Nil(err)
+
+	args := &structs.GenericRequest{}
+	var l string
+	err = msgpackrpc.CallWithCodec(pool.NewClientCodec(s1), "Status.Leader", args, &l)
+	require.Nil(err)
+	require.NotEmpty(l)
+
+	// Make a streaming RPC
+	err = s.streamingRpcImpl(s2, "Bogus")
+	require.NotNil(err)
+	require.Contains(err.Error(), "unknown rpc")
+
 }


### PR DESCRIPTION
Implements and tests the V2 multiplexer. This will not be used until
several versions of Nomad have been released to mitigate upgrade
concerns.

Builds on https://github.com/hashicorp/nomad/pull/3842