### PR TITLE
Fix incorrect deletion of node conn

### DIFF
--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -287,7 +288,7 @@ func TestNodes_GC(t *testing.T) {
 
 	err := nodes.GC(uuid.Generate(), nil)
 	require.NotNil(err)
-	require.Contains(err.Error(), "Unknown node")
+	require.True(structs.IsErrUnknownNode(err))
 }
 
 func TestNodes_GcAlloc(t *testing.T) {
@@ -299,5 +300,5 @@ func TestNodes_GcAlloc(t *testing.T) {
 
 	err := nodes.GcAlloc(uuid.Generate(), nil)
 	require.NotNil(err)
-	require.Contains(err.Error(), "unknown allocation")
+	require.True(structs.IsErrUnknownAllocation(err))
 }

--- a/nomad/client_rpc_test.go
+++ b/nomad/client_rpc_test.go
@@ -56,9 +56,19 @@ func TestServer_removeNodeConn_differentAddrs(t *testing.T) {
 	s1.addNodeConn(ctx2)
 	require.Len(s1.connectedNodes(), 1)
 
+	// Check that the value is the second conn.
+	state, ok := s1.getNodeConn(nodeID)
+	require.True(ok)
+	require.Equal(state.Ctx.Conn.LocalAddr().String(), w2.name)
+
 	// Delete the first
 	s1.removeNodeConn(ctx1)
 	require.Len(s1.connectedNodes(), 1)
+
+	// Check that the value is the second conn.
+	state, ok = s1.getNodeConn(nodeID)
+	require.True(ok)
+	require.Equal(state.Ctx.Conn.LocalAddr().String(), w2.name)
 
 	// Delete the second
 	s1.removeNodeConn(ctx2)


### PR DESCRIPTION
This PR fixes an issue where if the client has multiple connections to a
server, a single connection closing would cause the routing to the node
to be lost.