### PR TITLE
 Add tooling for OSX builds into vagrant box

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ THIS_OS := $(shell uname)
 GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_DIRTY := $(if $(shell git status --porcelain),+CHANGES)
 
-GO_LDFLAGS := "-X github.com/hashicorp/nomad/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
+GO_LDFLAGS := -X github.com/hashicorp/nomad/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)
 GO_TAGS =
 
 default: help
@@ -81,7 +81,7 @@ pkg/freebsd_amd64/nomad: $(SOURCE_FILES) ## Build Nomad for freebsd/amd64
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=freebsd GOARCH=amd64 \
 		go build \
-		-ldflags $(GO_LDFLAGS) \
+		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_TAGS)" \
 		-o "$@"
 
@@ -89,7 +89,7 @@ pkg/linux_386/nomad: $(SOURCE_FILES) ## Build Nomad for linux/386
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=linux GOARCH=386 \
 		go build \
-		-ldflags $(GO_LDFLAGS) \
+		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_TAGS)" \
 		-o "$@"
 
@@ -97,7 +97,7 @@ pkg/linux_amd64/nomad: $(SOURCE_FILES) ## Build Nomad for linux/amd64
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
 		go build \
-		-ldflags $(GO_LDFLAGS) \
+		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_TAGS)" \
 		-o "$@"
 
@@ -105,7 +105,7 @@ pkg/linux_arm/nomad: $(SOURCE_FILES) ## Build Nomad for linux/arm
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=linux GOARCH=arm CC=arm-linux-gnueabihf-gcc-5 \
 		go build \
-		-ldflags $(GO_LDFLAGS) \
+		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_TAGS)" \
 		-o "$@"
 
@@ -113,7 +113,7 @@ pkg/linux_arm64/nomad: $(SOURCE_FILES) ## Build Nomad for linux/arm64
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc-5 \
 		go build \
-		-ldflags $(GO_LDFLAGS) \
+		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_TAGS)" \
 		-o "$@"
 
@@ -126,7 +126,7 @@ pkg/windows_386/nomad: $(SOURCE_FILES) ## Build Nomad for windows/386
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=windows GOARCH=386 \
 		go build \
-		-ldflags $(GO_LDFLAGS) \
+		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_TAGS)" \
 		-o "$@.exe"
 
@@ -134,7 +134,7 @@ pkg/windows_amd64/nomad: $(SOURCE_FILES) ## Build Nomad for windows/amd64
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=windows GOARCH=amd64 \
 		go build \
-		-ldflags $(GO_LDFLAGS) \
+		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_TAGS)" \
 		-o "$@.exe"
 
@@ -142,7 +142,7 @@ pkg/linux_amd64-lxc/nomad: $(SOURCE_FILES) ## Build Nomad+LXC for linux/amd64
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
 		go build \
-		-ldflags $(GO_LDFLAGS) \
+		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_TAGS) lxc" \
 		-o "$@"
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ THIS_OS := $(shell uname)
 GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_DIRTY := $(if $(shell git status --porcelain),+CHANGES)
 
-GO_LDFLAGS := -X github.com/hashicorp/nomad/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)
+GO_LDFLAGS := "-X github.com/hashicorp/nomad/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
 GO_TAGS =
 
 default: help

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -121,6 +121,10 @@ def configureLinuxProvisioners(vmCfg)
 		path: './scripts/vagrant-linux-priv-rkt.sh'
 
 	vmCfg.vm.provision "shell",
+		privileged: true,
+		path: './scripts/vagrant-linux-priv-osx-cross.sh'
+
+	vmCfg.vm.provision "shell",
 		privileged: false,
 		path: './scripts/vagrant-linux-priv-ui.sh'
 

--- a/scripts/vagrant-linux-priv-osx-cross.sh
+++ b/scripts/vagrant-linux-priv-osx-cross.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Borrowed from https://github.com/docker/golang-cross
+#
+# Install dependencies required to cross compile osx, then cleanup
+#
+# TODO: this should be a separate build stage when CI supports it
+
+
+set -eu -o pipefail
+
+PKG_DEPS="patch xz-utils clang"
+
+apt-get update -qq
+time apt-get install -y -q $PKG_DEPS
+
+OSX_SDK=MacOSX10.11.sdk
+OSX_CROSS_COMMIT=a9317c18a3a457ca0a657f08cc4d0d43c6cf8953
+OSXCROSS_PATH="/osxcross"
+
+echo "Cloning osxcross"
+time git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH
+cd $OSXCROSS_PATH
+git checkout -q $OSX_CROSS_COMMIT
+
+echo "Downloading OSX SDK"
+time curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz \
+    -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz"
+
+echo "Building osxcross"
+UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh > /dev/null
+
+if ! grep 'PATH="$PATH:/osxcross/target/bin"' /home/vagrant/.profile ; then
+	echo "Adding to path in .profile"
+	echo 'PATH="$PATH:/osxcross/target/bin"' >> /home/vagrant/.profile
+fi


### PR DESCRIPTION
This will allow the creation of Darwin builds on the Linux development vagrant box.

**Resources**

* [DockerHub: dockercore/golang-cross](https://hub.docker.com/r/dockercore/golang-cross/)
* [GitHub: docker/golang-cross](https://github.com/docker/golang-cross)
* [GitHub: tpoechtrager/osxcross](https://github.com/tpoechtrager/osxcross)

