### PR TITLE
Remove invalid gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-*.qcow2 filter=lfs diff=lfs merge=lfs -text
+# Do not add existing client/drivers/test-resources/qemu/* files to LFS.
+# Adding existing files to LFS requires rewriting history back to the point
+# those files were added.


### PR DESCRIPTION
alpine.qcow2 is *not* tracked by LFS so the attribute will cause an
error. Remove the attribute and add a note to make sure no one tries to
track existing files again.