### PR TITLE
Fix erroneous metrics link + code block typo on the metrics page

### DIFF
--- a/website/source/api/metrics.html.md
+++ b/website/source/api/metrics.html.md
@@ -12,7 +12,7 @@ The `/metrics` endpoint returns metrics for the current Nomad process.
 
 | Method  | Path            | Produces                   |
 | ------- | --------------- | -------------------------- |
-| `GET`   | `/v1/metrics    | `application/json`         |
+| `GET`   | `/v1/metrics`   | `application/json`         |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and

--- a/website/source/guides/nomad-metrics.html.md
+++ b/website/source/guides/nomad-metrics.html.md
@@ -25,7 +25,7 @@ as [Prometheus](https://prometheus.io/), [Grafana](https://grafana.com/),
 [Graphite](https://graphiteapp.org/), [DataDog](https://www.datadoghq.com/),
 and [Circonus](https://www.circonus.com ).
 
-See Nomad's [Metrics API](/api/metrics.html.md) for more information on how
+See Nomad's [Metrics API](/api/metrics.html) for more information on how
 data can be exposed for other metrics tools as well.
 
 ## Setting up metrics


### PR DESCRIPTION
Noticed a 404 link whilst reading up on some docs, also fixed a md code block typo while I was there.