### PR TITLE
Heartbeat improvements and handling failures during establishing leadership

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1131,6 +1131,7 @@ func (c *Client) registerNode() error {
 	// Update the node status to ready after we register.
 	c.configLock.Lock()
 	node.Status = structs.NodeStatusReady
+	c.config.Node.Status = structs.NodeStatusReady
 	c.configLock.Unlock()
 
 	c.logger.Printf("[INFO] client: node registration complete")

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -442,6 +442,7 @@ func (w *deploymentWatcher) createEvalBatched(forIndex uint64) {
 
 	w.outstandingBatch = true
 
+	// TODO this isn't safe on deployment watcher shutdown since timer leaks.
 	time.AfterFunc(perJobEvalBatchPeriod, func() {
 		// Create the eval
 		evalCreateIndex, err := w.createEvaluation(w.getEval())

--- a/nomad/heartbeat.go
+++ b/nomad/heartbeat.go
@@ -67,6 +67,7 @@ func (s *Server) resetHeartbeatTimer(id string) (time.Duration, error) {
 	// check avoids the race in which leadership is lost but a timer is created
 	// on this server since it was servicing an RPC during a leadership loss.
 	if !s.IsLeader() {
+		s.logger.Printf("[DEBUG] nomad.heartbeat: ignoring resetting node %q TTL since this node is not the leader", id)
 		return 0, heartbeatNotLeaderErr
 	}
 
@@ -114,6 +115,7 @@ func (s *Server) invalidateHeartbeat(id string) {
 	// the race in which leadership is lost but a timer is created on this
 	// server since it was servicing an RPC during a leadership loss.
 	if !s.IsLeader() {
+		s.logger.Printf("[DEBUG] nomad.heartbeat: ignoring node %q TTL since this node is not the leader", id)
 		return
 	}
 

--- a/nomad/heartbeat.go
+++ b/nomad/heartbeat.go
@@ -1,12 +1,25 @@
 package nomad
 
 import (
+	"errors"
 	"time"
 
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/lib"
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	// heartbeatNotLeader is the error string returned when the heartbeat request
+	// couldn't be completed since the server is not the leader.
+	heartbeatNotLeader = "failed to reset heartbeat since server is not leader"
+)
+
+var (
+	// heartbeatNotLeaderErr is the error returned when the heartbeat request
+	// couldn't be completed since the server is not the leader.
+	heartbeatNotLeaderErr = errors.New(heartbeatNotLeader)
 )
 
 // initializeHeartbeatTimers is used when a leader is newly elected to create
@@ -50,6 +63,13 @@ func (s *Server) resetHeartbeatTimer(id string) (time.Duration, error) {
 	s.heartbeatTimersLock.Lock()
 	defer s.heartbeatTimersLock.Unlock()
 
+	// Do not create a timer for the node since we are not the leader. This
+	// check avoids the race in which leadership is lost but a timer is created
+	// on this server since it was servicing an RPC during a leadership loss.
+	if !s.IsLeader() {
+		return 0, heartbeatNotLeaderErr
+	}
+
 	// Compute the target TTL value
 	n := len(s.heartbeatTimers)
 	ttl := lib.RateScaledInterval(s.config.MaxHeartbeatsPerSecond, s.config.MinHeartbeatTTL, n)
@@ -89,6 +109,14 @@ func (s *Server) invalidateHeartbeat(id string) {
 	s.heartbeatTimersLock.Lock()
 	delete(s.heartbeatTimers, id)
 	s.heartbeatTimersLock.Unlock()
+
+	// Do not invalidate the node since we are not the leader. This check avoids
+	// the race in which leadership is lost but a timer is created on this
+	// server since it was servicing an RPC during a leadership loss.
+	if !s.IsLeader() {
+		return
+	}
+
 	s.logger.Printf("[WARN] nomad.heartbeat: node '%s' TTL expired", id)
 
 	// Make a request to update the node status

--- a/nomad/heartbeat_test.go
+++ b/nomad/heartbeat_test.go
@@ -271,9 +271,11 @@ func TestHeartbeat_Server_HeartbeatTTL_Failover(t *testing.T) {
 	leader.Shutdown()
 
 	// heartbeatTimers should be cleared on leader shutdown
-	if len(leader.heartbeatTimers) != 0 {
+	testutil.WaitForResult(func() (bool, error) {
+		return len(leader.heartbeatTimers) == 0, nil
+	}, func(err error) {
 		t.Fatalf("heartbeat timers should be empty on the shutdown leader")
-	}
+	})
 
 	// Find the new leader
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -107,8 +107,16 @@ RECONCILE:
 	if !establishedLeader {
 		if err := s.establishLeadership(stopCh); err != nil {
 			s.logger.Printf("[ERR] nomad: failed to establish leadership: %v", err)
+
+			// Immediately revoke leadership since we didn't successfully
+			// establish leadership.
+			if err := s.revokeLeadership(); err != nil {
+				s.logger.Printf("[ERR] nomad: failed to revoke leadership: %v", err)
+			}
+
 			goto WAIT
 		}
+
 		establishedLeader = true
 		defer func() {
 			if err := s.revokeLeadership(); err != nil {

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -157,6 +157,8 @@ WAIT:
 // previously inflight transactions have been committed and that our
 // state is up-to-date.
 func (s *Server) establishLeadership(stopCh chan struct{}) error {
+	defer metrics.MeasureSince([]string{"nomad", "leader", "establish_leadership"}, time.Now())
+
 	// Generate a leader ACL token. This will allow the leader to issue work
 	// that requires a valid ACL token.
 	s.setLeaderAcl(uuid.Generate())
@@ -639,8 +641,7 @@ func (s *Server) publishJobSummaryMetrics(stopCh chan struct{}) {
 // revokeLeadership is invoked once we step down as leader.
 // This is used to cleanup any state that may be specific to a leader.
 func (s *Server) revokeLeadership() error {
-	// TODO put metrics here and on establish leadership that time how long the
-	// whole thing takes so we can detect lock contention or blocking.
+	defer metrics.MeasureSince([]string{"nomad", "leader", "revoke_leadership"}, time.Now())
 
 	// Clear the leader token since we are no longer the leader.
 	s.setLeaderAcl("")

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -639,6 +639,9 @@ func (s *Server) publishJobSummaryMetrics(stopCh chan struct{}) {
 // revokeLeadership is invoked once we step down as leader.
 // This is used to cleanup any state that may be specific to a leader.
 func (s *Server) revokeLeadership() error {
+	// TODO put metrics here and on establish leadership that time how long the
+	// whole thing takes so we can detect lock contention or blocking.
+
 	// Clear the leader token since we are no longer the leader.
 	s.setLeaderAcl("")
 

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLeader_LeftServer(t *testing.T) {
@@ -977,4 +978,20 @@ func TestLeader_RollRaftServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLeader_RevokeLeadership_MultipleTimes(t *testing.T) {
+	s1 := testServer(t, nil)
+	defer s1.Shutdown()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	testutil.WaitForResult(func() (bool, error) {
+		return s1.evalBroker.Enabled(), nil
+	}, func(err error) {
+		t.Fatalf("should have finished establish leader loop")
+	})
+
+	require.Nil(t, s1.revokeLeadership())
+	require.Nil(t, s1.revokeLeadership())
+	require.Nil(t, s1.revokeLeadership())
 }

--- a/vendor/github.com/hashicorp/consul/agent/consul/autopilot/autopilot.go
+++ b/vendor/github.com/hashicorp/consul/agent/consul/autopilot/autopilot.go
@@ -38,8 +38,10 @@ type Autopilot struct {
 	clusterHealth     OperatorHealthReply
 	clusterHealthLock sync.RWMutex
 
+	enabled      bool
 	removeDeadCh chan struct{}
 	shutdownCh   chan struct{}
+	shutdownLock sync.Mutex
 	waitGroup    sync.WaitGroup
 }
 
@@ -62,6 +64,14 @@ func NewAutopilot(logger *log.Logger, delegate Delegate, interval, healthInterva
 }
 
 func (a *Autopilot) Start() {
+	a.shutdownLock.Lock()
+	defer a.shutdownLock.Unlock()
+
+	// Nothing to do
+	if a.enabled {
+		return
+	}
+
 	a.shutdownCh = make(chan struct{})
 	a.waitGroup = sync.WaitGroup{}
 	a.clusterHealth = OperatorHealthReply{}
@@ -69,11 +79,21 @@ func (a *Autopilot) Start() {
 	a.waitGroup.Add(2)
 	go a.run()
 	go a.serverHealthLoop()
+	a.enabled = true
 }
 
 func (a *Autopilot) Stop() {
+	a.shutdownLock.Lock()
+	defer a.shutdownLock.Unlock()
+
+	// Nothing to do
+	if !a.enabled {
+		return
+	}
+
 	close(a.shutdownCh)
 	a.waitGroup.Wait()
+	a.enabled = false
 }
 
 // run periodically looks for nonvoting servers to promote and dead servers to remove.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -123,7 +123,7 @@
 		{"path":"github.com/hashicorp/consul-template/template","checksumSHA1":"N9qobVzScLbTEnGE7MgFnnTbGBw=","revision":"26d029ad37335b3827a9fde5569b2c5e10dcac8f","revisionTime":"2017-10-31T14:25:17Z"},
 		{"path":"github.com/hashicorp/consul-template/version","checksumSHA1":"NB5+D4AuCNV9Bsqh3YFdPi4AJ6U=","revision":"26d029ad37335b3827a9fde5569b2c5e10dcac8f","revisionTime":"2017-10-31T14:25:17Z"},
 		{"path":"github.com/hashicorp/consul-template/watch","checksumSHA1":"b4+Y+02pY2Y5620F9ALzKg8Zmdw=","revision":"26d029ad37335b3827a9fde5569b2c5e10dcac8f","revisionTime":"2017-10-31T14:25:17Z"},
-		{"path":"github.com/hashicorp/consul/agent/consul/autopilot","checksumSHA1":"/nyemJLkxBXKqI9xpLFyTyvOaYY=","revision":"bfeb09983befa337a3b2ebbafb7567913773e40b","revisionTime":"2018-01-23T20:52:17Z"},
+		{"path":"github.com/hashicorp/consul/agent/consul/autopilot","checksumSHA1":"+I7fgoQlrnTUGW5krqNLadWwtjg=","revision":"d1ede2c93dec7b4580e37ef41d24371abab9d9e9","revisionTime":"2018-02-21T18:19:48Z"},
 		{"path":"github.com/hashicorp/consul/api","checksumSHA1":"XLfcIX2qpRr0o26aFMjCOzvw6jo=","revision":"51ea240df8476e02215d53fbfad5838bf0d44d21","revisionTime":"2017-10-16T16:22:40Z"},
 		{"path":"github.com/hashicorp/consul/command/flags","checksumSHA1":"XTQIYV+DPUVRKpVp0+y/78bWH3I=","revision":"d08ab9fd199434e5220276356ecf9617cfec1eb2","revisionTime":"2017-12-18T20:26:35Z"},
 		{"path":"github.com/hashicorp/consul/lib","checksumSHA1":"HGljdtVaqi/e3DgIHymLRLfPYhw=","revision":"bcafded4e60982d0b71e730f0b8564d73cb1d715","revisionTime":"2017-10-31T16:39:15Z"},


### PR DESCRIPTION
The changes in this PR are a result of going through logs of a cluster quickly transition between leaders. As such there are various semi-related fixes:

1. When a client detects a change to the node, register the node in status ready after the initial registration (previously would revert back to initializing until the next heartbeat)
2. If leadership is lost while the deployment watcher is creating an eval, there was no mechanism to no-op the evaluation creation.
3. Guard the heartbeat system from adding timers or invalidating timers when it is not the leader.
4. Revoke leadership if establishing leadership failed. Prior to this, two servers could be "functioning as a leader"!

Fixes https://github.com/hashicorp/nomad/issues/3035
Fixes https://github.com/hashicorp/nomad/issues/3840