### PR TITLE
Removed text between command and output

### DIFF
--- a/website/source/docs/operating-a-job/inspecting-state.html.md
+++ b/website/source/docs/operating-a-job/inspecting-state.html.md
@@ -25,13 +25,8 @@ and command largely apply to all jobs in Nomad.
 After a job is submitted, you can query the status of that job using the job
 status command:
 
-```shell
-$ nomad job status
-```
-
-Here is some sample output:
-
 ```text
+$ nomad job status
 ID    Type     Priority  Status
 docs  service  50        running
 ```
@@ -40,13 +35,8 @@ At a high level, we can see that our job is currently running, but what does
 "running" actually mean. By supplying the name of a job to the job status
 command, we can ask Nomad for more detailed job information:
 
-```shell
-$ nomad job status docs
-```
-
-Here is some sample output
-
 ```text
+$ nomad job status docs
 ID          = docs
 Name        = docs
 Type        = service
@@ -192,7 +182,7 @@ Unfortunately not all failures are as easily debuggable. If the `alloc-status`
 command shows many restarts, there is likely an application-level issue during
 start up. For example:
 
-```
+```text
 $ nomad alloc-status 04d9627d
 # ...
 

--- a/website/source/docs/operating-a-job/submitting-jobs.html.md
+++ b/website/source/docs/operating-a-job/submitting-jobs.html.md
@@ -69,13 +69,8 @@ Once the job file is authored, we need to plan out the changes. The `nomad plan`
 command invokes a dry-run of the scheduler and inform us of which scheduling
 decisions would take place.
 
-```shell
-$ nomad plan docs.nomad
-```
-
-The resulting output will look like:
-
 ```text
+$ nomad plan docs.nomad
 + Job: "docs"
 + Task Group: "example" (1 create)
   + Task: "server" (forces create)
@@ -104,13 +99,8 @@ this job. This is done via the `nomad run` command. We can optionally supply
 the modify index provided to us by the plan command to ensure no changes to this
 job have taken place between our plan and now.
 
-```shell
-$ nomad run docs.nomad
-```
-
-The resulting output will look like:
-
 ```text
+$ nomad run docs.nomad
 ==> Monitoring evaluation "0d159869"
     Evaluation triggered by job "docs"
     Allocation "5cbf23a1" created: node "1e1aa1e0", group "example"

--- a/website/source/docs/operating-a-job/update-strategies/rolling-upgrades.html.md
+++ b/website/source/docs/operating-a-job/update-strategies/rolling-upgrades.html.md
@@ -92,11 +92,6 @@ this output to confirm it is correct:
 
 ```text
 $ nomad plan geo-api-server.nomad
-```
-
-Here is some sample output:
-
-```text
 +/- Job: "geo-api-server"
 +/- Task Group: "api-server" (2 create/destroy update, 4 ignore)
   +/- Task: "server" (forces create/destroy update)


### PR DESCRIPTION
Removed some low-value text between the example command and the sample output.