### PR TITLE
delayed rescheduling

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -86,6 +86,7 @@ type Allocation struct {
 	TaskStates         map[string]*TaskState
 	DeploymentID       string
 	DeploymentStatus   *AllocDeploymentStatus
+	FollowupEvalID     string
 	PreviousAllocation string
 	NextAllocation     string
 	RescheduleTracker  *RescheduleTracker
@@ -129,6 +130,7 @@ type AllocationListStub struct {
 	TaskStates         map[string]*TaskState
 	DeploymentStatus   *AllocDeploymentStatus
 	RescheduleTracker  *RescheduleTracker
+	FollowupEvalID     string
 	CreateIndex        uint64
 	ModifyIndex        uint64
 	CreateTime         int64

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -446,6 +446,10 @@ func parseReschedulePolicy(final **api.ReschedulePolicy, list *ast.ObjectList) e
 	valid := []string{
 		"attempts",
 		"interval",
+		"unlimited",
+		"delay",
+		"delay_ceiling",
+		"delay_function",
 	}
 	if err := helper.CheckHCLKeys(obj.Val, valid); err != nil {
 		return err

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -679,8 +679,42 @@ func TestParse(t *testing.T) {
 				Type:        helper.StringToPtr("batch"),
 				Datacenters: []string{"dc1"},
 				Reschedule: &api.ReschedulePolicy{
-					Attempts: helper.IntToPtr(15),
-					Interval: helper.TimeToPtr(30 * time.Minute),
+					Attempts:      helper.IntToPtr(15),
+					Interval:      helper.TimeToPtr(30 * time.Minute),
+					DelayFunction: helper.StringToPtr("linear"),
+					Delay:         helper.TimeToPtr(10 * time.Second),
+				},
+				TaskGroups: []*api.TaskGroup{
+					{
+						Name:  helper.StringToPtr("bar"),
+						Count: helper.IntToPtr(3),
+						Tasks: []*api.Task{
+							{
+								Name:   "bar",
+								Driver: "raw_exec",
+								Config: map[string]interface{}{
+									"command": "bash",
+									"args":    []interface{}{"-c", "echo hi"},
+								},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"reschedule-job-unlimited.hcl",
+			&api.Job{
+				ID:          helper.StringToPtr("foo"),
+				Name:        helper.StringToPtr("foo"),
+				Type:        helper.StringToPtr("batch"),
+				Datacenters: []string{"dc1"},
+				Reschedule: &api.ReschedulePolicy{
+					DelayFunction: helper.StringToPtr("exponential"),
+					Delay:         helper.TimeToPtr(10 * time.Second),
+					DelayCeiling:  helper.TimeToPtr(120 * time.Second),
+					Unlimited:     helper.BoolToPtr(true),
 				},
 				TaskGroups: []*api.TaskGroup{
 					{

--- a/jobspec/test-fixtures/reschedule-job-unlimited.hcl
+++ b/jobspec/test-fixtures/reschedule-job-unlimited.hcl
@@ -2,10 +2,10 @@ job "foo" {
   datacenters = ["dc1"]
   type = "batch"
   reschedule {
-      attempts = 15
-      interval = "30m"
-      delay = "10s",
-      delay_function = "linear"
+    delay = "10s",
+    delay_function = "exponential"
+    delay_ceiling="120s"
+    unlimited = true
   }
   group "bar" {
     count = 3

--- a/lib/delay_heap.go
+++ b/lib/delay_heap.go
@@ -1,4 +1,4 @@
-package delayheap
+package lib
 
 import (
 	"container/heap"

--- a/lib/delay_heap_test.go
+++ b/lib/delay_heap_test.go
@@ -1,4 +1,4 @@
-package delayheap
+package lib
 
 import (
 	"testing"

--- a/nomad/delayheap/delay_heap.go
+++ b/nomad/delayheap/delay_heap.go
@@ -1,0 +1,166 @@
+package delayheap
+
+import (
+	"container/heap"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// DelayHeap wraps a heap and gives operations other than Push/Pop.
+// The inner heap is sorted by the time in the WaitUntil field of DelayHeapNode
+type DelayHeap struct {
+	index map[structs.NamespacedID]*DelayHeapNode
+	heap  delayedHeapImp
+}
+
+type HeapNode interface {
+	Data() interface{}
+	ID() string
+	Namespace() string
+}
+
+// DelayHeapNode encapsulates the node stored in DelayHeap
+// WaitUntil is used as the sorting criteria
+type DelayHeapNode struct {
+	// Node is the data object stored in the delay heap
+	Node HeapNode
+	// WaitUntil is the time delay associated with the node
+	// Objects in the heap are sorted by WaitUntil
+	WaitUntil time.Time
+
+	index int
+}
+
+type delayedHeapImp []*DelayHeapNode
+
+func (h delayedHeapImp) Len() int {
+	return len(h)
+}
+
+func (h delayedHeapImp) Less(i, j int) bool {
+	// Two zero times should return false.
+	// Otherwise, zero is "greater" than any other time.
+	// (To sort it at the end of the list.)
+	// Sort such that zero times are at the end of the list.
+	iZero, jZero := h[i].WaitUntil.IsZero(), h[j].WaitUntil.IsZero()
+	if iZero && jZero {
+		return false
+	} else if iZero {
+		return false
+	} else if jZero {
+		return true
+	}
+
+	return h[i].WaitUntil.Before(h[j].WaitUntil)
+}
+
+func (h delayedHeapImp) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+
+func (h *delayedHeapImp) Push(x interface{}) {
+	node := x.(*DelayHeapNode)
+	n := len(*h)
+	node.index = n
+	*h = append(*h, node)
+}
+
+func (h *delayedHeapImp) Pop() interface{} {
+	old := *h
+	n := len(old)
+	node := old[n-1]
+	node.index = -1 // for safety
+	*h = old[0 : n-1]
+	return node
+}
+
+func NewDelayHeap() *DelayHeap {
+	return &DelayHeap{
+		index: make(map[structs.NamespacedID]*DelayHeapNode),
+		heap:  make(delayedHeapImp, 0),
+	}
+}
+
+func (p *DelayHeap) Push(dataNode HeapNode, next time.Time) error {
+	tuple := structs.NamespacedID{
+		ID:        dataNode.ID(),
+		Namespace: dataNode.Namespace(),
+	}
+	if _, ok := p.index[tuple]; ok {
+		return fmt.Errorf("node %q (%s) already exists", dataNode.ID(), dataNode.Namespace())
+	}
+
+	delayHeapNode := &DelayHeapNode{dataNode, next, 0}
+	p.index[tuple] = delayHeapNode
+	heap.Push(&p.heap, delayHeapNode)
+	return nil
+}
+
+func (p *DelayHeap) Pop() *DelayHeapNode {
+	if len(p.heap) == 0 {
+		return nil
+	}
+
+	delayHeapNode := heap.Pop(&p.heap).(*DelayHeapNode)
+	tuple := structs.NamespacedID{
+		ID:        delayHeapNode.Node.ID(),
+		Namespace: delayHeapNode.Node.Namespace(),
+	}
+	delete(p.index, tuple)
+	return delayHeapNode
+}
+
+func (p *DelayHeap) Peek() *DelayHeapNode {
+	if len(p.heap) == 0 {
+		return nil
+	}
+
+	return p.heap[0]
+}
+
+func (p *DelayHeap) Contains(heapNode HeapNode) bool {
+	tuple := structs.NamespacedID{
+		ID:        heapNode.ID(),
+		Namespace: heapNode.Namespace(),
+	}
+	_, ok := p.index[tuple]
+	return ok
+}
+
+func (p *DelayHeap) Update(heapNode HeapNode, waitUntil time.Time) error {
+	tuple := structs.NamespacedID{
+		ID:        heapNode.ID(),
+		Namespace: heapNode.Namespace(),
+	}
+	if existingHeapNode, ok := p.index[tuple]; ok {
+		// Need to update the job as well because its spec can change.
+		existingHeapNode.Node = heapNode
+		existingHeapNode.WaitUntil = waitUntil
+		heap.Fix(&p.heap, existingHeapNode.index)
+		return nil
+	}
+
+	return fmt.Errorf("heap doesn't contain object with ID %q (%s)", heapNode.ID(), heapNode.Namespace())
+}
+
+func (p *DelayHeap) Remove(heapNode HeapNode) error {
+	tuple := structs.NamespacedID{
+		ID:        heapNode.ID(),
+		Namespace: heapNode.Namespace(),
+	}
+	if node, ok := p.index[tuple]; ok {
+		heap.Remove(&p.heap, node.index)
+		delete(p.index, tuple)
+		return nil
+	}
+
+	return fmt.Errorf("heap doesn't contain object with ID %q (%s)", heapNode.ID(), heapNode.Namespace())
+}
+
+func (p *DelayHeap) Length() int {
+	return len(p.heap)
+}

--- a/nomad/delayheap/delay_heap_test.go
+++ b/nomad/delayheap/delay_heap_test.go
@@ -1,0 +1,115 @@
+package delayheap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// HeapNodeImpl satisfies the HeapNode interface
+type heapNodeImpl struct {
+	dataObject interface{}
+	id         string
+	namespace  string
+}
+
+func (d *heapNodeImpl) Data() interface{} {
+	return d.dataObject
+}
+
+func (d *heapNodeImpl) ID() string {
+	return d.id
+}
+
+func (d *heapNodeImpl) Namespace() string {
+	return d.namespace
+}
+
+func TestDelayHeap_PushPop(t *testing.T) {
+	delayHeap := NewDelayHeap()
+	now := time.Now()
+	require := require.New(t)
+	// a dummy type to use as the inner object in the heap
+	type myObj struct {
+		a int
+		b string
+	}
+	dataNode1 := &heapNodeImpl{
+		dataObject: &myObj{a: 0, b: "hey"},
+		id:         "101",
+		namespace:  "default",
+	}
+	delayHeap.Push(dataNode1, now.Add(-10*time.Minute))
+
+	dataNode2 := &heapNodeImpl{
+		dataObject: &myObj{a: 0, b: "hey"},
+		id:         "102",
+		namespace:  "default",
+	}
+	delayHeap.Push(dataNode2, now.Add(10*time.Minute))
+
+	dataNode3 := &heapNodeImpl{
+		dataObject: &myObj{a: 0, b: "hey"},
+		id:         "103",
+		namespace:  "default",
+	}
+	delayHeap.Push(dataNode3, now.Add(-15*time.Second))
+
+	dataNode4 := &heapNodeImpl{
+		dataObject: &myObj{a: 0, b: "hey"},
+		id:         "101",
+		namespace:  "test-namespace",
+	}
+	delayHeap.Push(dataNode4, now.Add(2*time.Hour))
+
+	expectedWaitTimes := []time.Time{now.Add(-10 * time.Minute), now.Add(-15 * time.Second), now.Add(10 * time.Minute), now.Add(2 * time.Hour)}
+	entries := getHeapEntries(delayHeap, now)
+	for i, entry := range entries {
+		require.Equal(expectedWaitTimes[i], entry.WaitUntil)
+	}
+
+}
+
+func TestDelayHeap_Update(t *testing.T) {
+	delayHeap := NewDelayHeap()
+	now := time.Now()
+	require := require.New(t)
+	// a dummy type to use as the inner object in the heap
+	type myObj struct {
+		a int
+		b string
+	}
+	dataNode1 := &heapNodeImpl{
+		dataObject: &myObj{a: 0, b: "hey"},
+		id:         "101",
+		namespace:  "default",
+	}
+	delayHeap.Push(dataNode1, now.Add(-10*time.Minute))
+
+	dataNode2 := &heapNodeImpl{
+		dataObject: &myObj{a: 0, b: "hey"},
+		id:         "102",
+		namespace:  "default",
+	}
+	delayHeap.Push(dataNode2, now.Add(10*time.Minute))
+	delayHeap.Update(dataNode1, now.Add(20*time.Minute))
+
+	expectedWaitTimes := []time.Time{now.Add(10 * time.Minute), now.Add(20 * time.Minute)}
+	expectedIdOrder := []string{"102", "101"}
+	entries := getHeapEntries(delayHeap, now)
+	for i, entry := range entries {
+		require.Equal(expectedWaitTimes[i], entry.WaitUntil)
+		require.Equal(expectedIdOrder[i], entry.Node.ID())
+	}
+
+}
+
+func getHeapEntries(delayHeap *DelayHeap, now time.Time) []*DelayHeapNode {
+	var entries []*DelayHeapNode
+	for node := delayHeap.Pop(); node != nil; {
+		entries = append(entries, node)
+		node = delayHeap.Pop()
+	}
+	return entries
+}

--- a/nomad/delayheap/delay_heap_test.go
+++ b/nomad/delayheap/delay_heap_test.go
@@ -105,8 +105,8 @@ func TestDelayHeap_Update(t *testing.T) {
 
 }
 
-func getHeapEntries(delayHeap *DelayHeap, now time.Time) []*DelayHeapNode {
-	var entries []*DelayHeapNode
+func getHeapEntries(delayHeap *DelayHeap, now time.Time) []*delayHeapNode {
+	var entries []*delayHeapNode
 	for node := delayHeap.Pop(); node != nil; {
 		entries = append(entries, node)
 		node = delayHeap.Pop()

--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/nomad/helper/uuid"
-	"github.com/hashicorp/nomad/nomad/delayheap"
+	"github.com/hashicorp/nomad/lib"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -86,7 +86,7 @@ type EvalBroker struct {
 
 	// delayHeap is a heap used to track incoming evaluations that are
 	// not eligible to enqueue until their WaitTime
-	delayHeap *delayheap.DelayHeap
+	delayHeap *lib.DelayHeap
 
 	// delayedEvalsUpdateCh is used to trigger notifications for updates
 	// to the delayHeap
@@ -142,7 +142,7 @@ func NewEvalBroker(timeout, initialNackDelay, subsequentNackDelay time.Duration,
 		timeWait:             make(map[string]*time.Timer),
 		initialNackDelay:     initialNackDelay,
 		subsequentNackDelay:  subsequentNackDelay,
-		delayHeap:            delayheap.NewDelayHeap(),
+		delayHeap:            lib.NewDelayHeap(),
 		delayedEvalsUpdateCh: make(chan struct{}, 1),
 	}
 	b.stats.ByScheduler = make(map[string]*SchedulerStats)
@@ -717,7 +717,7 @@ func (b *EvalBroker) flush() {
 	b.ready = make(map[string]PendingEvaluations)
 	b.unack = make(map[string]*unackEval)
 	b.timeWait = make(map[string]*time.Timer)
-	b.delayHeap = delayheap.NewDelayHeap()
+	b.delayHeap = lib.NewDelayHeap()
 }
 
 // evalWrapper satisfies the HeapNode interface

--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -8,8 +8,11 @@ import (
 	"sync"
 	"time"
 
+	"context"
+
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/delayheap"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -77,7 +80,19 @@ type EvalBroker struct {
 	// timeWait has evaluations that are waiting for time to elapse
 	timeWait map[string]*time.Timer
 
-	// initialNackDelay is the delay applied before reenqueuing a
+	// delayedEvalCancelFunc is used to stop the long running go routine
+	// that processes delayed evaluations
+	delayedEvalCancelFunc context.CancelFunc
+
+	// delayHeap is a heap used to track incoming evaluations that are
+	// not eligible to enqueue until their WaitTime
+	delayHeap *delayheap.DelayHeap
+
+	// delayedEvalsUpdateCh is used to trigger notifications for updates
+	// to the delayHeap
+	delayedEvalsUpdateCh chan struct{}
+
+	// initialNackDelay is the delay applied before re-enqueuing a
 	// Nacked evaluation for the first time.
 	initialNackDelay time.Duration
 
@@ -105,7 +120,7 @@ type PendingEvaluations []*structs.Evaluation
 // with the timeout used for messages that are not acknowledged before we
 // assume a Nack and attempt to redeliver as well as the deliveryLimit
 // which prevents a failing eval from being endlessly delivered. The
-// initialNackDelay is the delay before making a Nacked evalution available
+// initialNackDelay is the delay before making a Nacked evaluation available
 // again for the first Nack and subsequentNackDelay is the compounding delay
 // after the first Nack.
 func NewEvalBroker(timeout, initialNackDelay, subsequentNackDelay time.Duration, deliveryLimit int) (*EvalBroker, error) {
@@ -113,22 +128,25 @@ func NewEvalBroker(timeout, initialNackDelay, subsequentNackDelay time.Duration,
 		return nil, fmt.Errorf("timeout cannot be negative")
 	}
 	b := &EvalBroker{
-		nackTimeout:         timeout,
-		deliveryLimit:       deliveryLimit,
-		enabled:             false,
-		stats:               new(BrokerStats),
-		evals:               make(map[string]int),
-		jobEvals:            make(map[structs.NamespacedID]string),
-		blocked:             make(map[string]PendingEvaluations),
-		ready:               make(map[string]PendingEvaluations),
-		unack:               make(map[string]*unackEval),
-		waiting:             make(map[string]chan struct{}),
-		requeue:             make(map[string]*structs.Evaluation),
-		timeWait:            make(map[string]*time.Timer),
-		initialNackDelay:    initialNackDelay,
-		subsequentNackDelay: subsequentNackDelay,
+		nackTimeout:          timeout,
+		deliveryLimit:        deliveryLimit,
+		enabled:              false,
+		stats:                new(BrokerStats),
+		evals:                make(map[string]int),
+		jobEvals:             make(map[structs.NamespacedID]string),
+		blocked:              make(map[string]PendingEvaluations),
+		ready:                make(map[string]PendingEvaluations),
+		unack:                make(map[string]*unackEval),
+		waiting:              make(map[string]chan struct{}),
+		requeue:              make(map[string]*structs.Evaluation),
+		timeWait:             make(map[string]*time.Timer),
+		initialNackDelay:     initialNackDelay,
+		subsequentNackDelay:  subsequentNackDelay,
+		delayHeap:            delayheap.NewDelayHeap(),
+		delayedEvalsUpdateCh: make(chan struct{}, 1),
 	}
 	b.stats.ByScheduler = make(map[string]*SchedulerStats)
+
 	return b, nil
 }
 
@@ -144,6 +162,10 @@ func (b *EvalBroker) Enabled() bool {
 func (b *EvalBroker) SetEnabled(enabled bool) {
 	b.l.Lock()
 	b.enabled = enabled
+	// start the go routine for delayed evals
+	ctx, cancel := context.WithCancel(context.Background())
+	b.delayedEvalCancelFunc = cancel
+	go b.runDelayedEvalsWatcher(ctx)
 	b.l.Unlock()
 	if !enabled {
 		b.Flush()
@@ -203,6 +225,16 @@ func (b *EvalBroker) processEnqueue(eval *structs.Evaluation, token string) {
 	// Check if we need to enforce a wait
 	if eval.Wait > 0 {
 		b.processWaitingEnqueue(eval)
+		return
+	}
+
+	if !eval.WaitUntil.IsZero() {
+		b.delayHeap.Push(&evalWrapper{eval}, eval.WaitUntil)
+		// Signal an update.
+		select {
+		case b.delayedEvalsUpdateCh <- struct{}{}:
+		default:
+		}
 		return
 	}
 
@@ -663,6 +695,12 @@ func (b *EvalBroker) Flush() {
 		wait.Stop()
 	}
 
+	// Cancel the delayed evaluations goroutine
+	b.delayedEvalCancelFunc()
+
+	// Clear out the update channel for delayed evaluations
+	b.delayedEvalsUpdateCh = make(chan struct{}, 1)
+
 	// Reset the broker
 	b.stats.TotalReady = 0
 	b.stats.TotalUnacked = 0
@@ -675,6 +713,66 @@ func (b *EvalBroker) Flush() {
 	b.ready = make(map[string]PendingEvaluations)
 	b.unack = make(map[string]*unackEval)
 	b.timeWait = make(map[string]*time.Timer)
+	b.delayHeap = delayheap.NewDelayHeap()
+}
+
+// evalWrapper satisfies the HeapNode interface
+type evalWrapper struct {
+	eval *structs.Evaluation
+}
+
+func (d *evalWrapper) Data() interface{} {
+	return d.eval
+}
+
+func (d *evalWrapper) ID() string {
+	return d.eval.ID
+}
+
+func (d *evalWrapper) Namespace() string {
+	return d.eval.Namespace
+}
+
+// runDelayedEvalsWatcher is a long-lived function that waits till a job's periodic spec is met and
+// then creates an evaluation to run the job.
+func (b *EvalBroker) runDelayedEvalsWatcher(ctx context.Context) {
+	var timerChannel <-chan time.Time
+	for b.enabled {
+		eval, waitUntil := b.nextDelayedEval()
+		if waitUntil.IsZero() {
+			timerChannel = nil
+		} else {
+			launchDur := waitUntil.Sub(time.Now().UTC())
+			timerChannel = time.After(launchDur)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-timerChannel:
+			// remove from the heap since we can enqueue it now
+			b.delayHeap.Remove(&evalWrapper{eval})
+			b.enqueueLocked(eval, eval.Type)
+		case <-b.delayedEvalsUpdateCh:
+			continue
+		}
+	}
+}
+
+// nextDelayedEval returns the next delayed eval to launch and when it should be enqueued.
+// This peeks at the heap to return the top.
+func (b *EvalBroker) nextDelayedEval() (*structs.Evaluation, time.Time) {
+	// If there is nothing wait for an update.
+	if b.delayHeap.Length() == 0 {
+		return nil, time.Time{}
+	}
+	nextEval := b.delayHeap.Peek()
+
+	if nextEval == nil {
+		return nil, time.Time{}
+	}
+	eval := nextEval.Node.Data().(*structs.Evaluation)
+	return eval, nextEval.WaitUntil
 }
 
 // Stats is used to query the state of the broker

--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -775,7 +775,7 @@ func (b *EvalBroker) runDelayedEvalsWatcher(ctx context.Context) {
 }
 
 // nextDelayedEval returns the next delayed eval to launch and when it should be enqueued.
-// This peeks at the heap to return the top.
+// This peeks at the heap to return the top. If the heap is empty, this returns nil and zero time.
 func (b *EvalBroker) nextDelayedEval() (*structs.Evaluation, time.Time) {
 	// If there is nothing wait for an update.
 	if b.delayHeap.Length() == 0 {

--- a/nomad/eval_broker_test.go
+++ b/nomad/eval_broker_test.go
@@ -1141,7 +1141,7 @@ func TestEvalBroker_Wait(t *testing.T) {
 	}
 }
 
-// Ensure fairness between schedulers
+// Ensure that delayed evaluations work as expected
 func TestEvalBroker_WaitUntil(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -1166,7 +1166,7 @@ func TestEvalBroker_WaitUntil(t *testing.T) {
 	eval3.WaitUntil = now.Add(20 * time.Millisecond)
 	eval3.CreateIndex = 1
 	b.Enqueue(eval3)
-
+	require.Equal(3, b.stats.TotalWaiting)
 	// sleep enough for two evals to be ready
 	time.Sleep(200 * time.Millisecond)
 
@@ -1184,6 +1184,7 @@ func TestEvalBroker_WaitUntil(t *testing.T) {
 	out, _, err = b.Dequeue(defaultSched, 2*time.Second)
 	require.Nil(err)
 	require.Equal(eval1, out)
+	require.Equal(0, b.stats.TotalWaiting)
 }
 
 // Ensure that priority is taken into account when enqueueing many evaluations.

--- a/nomad/eval_broker_test.go
+++ b/nomad/eval_broker_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -1138,6 +1139,51 @@ func TestEvalBroker_Wait(t *testing.T) {
 	if out != eval {
 		t.Fatalf("bad : %#v", out)
 	}
+}
+
+// Ensure fairness between schedulers
+func TestEvalBroker_WaitUntil(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	b := testBroker(t, 0)
+	b.SetEnabled(true)
+
+	now := time.Now()
+	// Create a few of evals with WaitUntil set
+	eval1 := mock.Eval()
+	eval1.WaitUntil = now.Add(1 * time.Second)
+	eval1.CreateIndex = 1
+	b.Enqueue(eval1)
+
+	eval2 := mock.Eval()
+	eval2.WaitUntil = now.Add(100 * time.Millisecond)
+	// set CreateIndex to use as a tie breaker when eval2
+	// and eval3 are both in the pending evals heap
+	eval2.CreateIndex = 2
+	b.Enqueue(eval2)
+
+	eval3 := mock.Eval()
+	eval3.WaitUntil = now.Add(20 * time.Millisecond)
+	eval3.CreateIndex = 1
+	b.Enqueue(eval3)
+
+	// sleep enough for two evals to be ready
+	time.Sleep(200 * time.Millisecond)
+
+	// first dequeue should return eval3
+	out, _, err := b.Dequeue(defaultSched, time.Second)
+	require.Nil(err)
+	require.Equal(eval3, out)
+
+	// second dequeue should return eval2
+	out, _, err = b.Dequeue(defaultSched, time.Second)
+	require.Nil(err)
+	require.Equal(eval2, out)
+
+	// third dequeue should return eval1
+	out, _, err = b.Dequeue(defaultSched, 2*time.Second)
+	require.Nil(err)
+	require.Equal(eval1, out)
 }
 
 // Ensure that priority is taken into account when enqueueing many evaluations.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2708,7 +2708,7 @@ func (r *ReschedulePolicy) Validate() error {
 
 	}
 
-	//Validate Interval and other delay parameters if attempts are limited
+	// Validate Interval and other delay parameters if attempts are limited
 	if !r.Unlimited {
 		if r.Interval.Nanoseconds() < ReschedulePolicyMinInterval.Nanoseconds() {
 			multierror.Append(&mErr, fmt.Errorf("Interval cannot be less than %v (got %v)", ReschedulePolicyMinInterval, r.Interval))

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5385,7 +5385,7 @@ func (a *Allocation) LastEventTime() time.Time {
 	return lastEventTime
 }
 
-// NextRescheduleTime returns a time delta after which the allocation is eligible to be rescheduled
+// NextRescheduleTime returns a time on or after which the allocation is eligible to be rescheduled,
 // and whether the next reschedule time is within policy's interval if the policy doesn't allow unlimited reschedules
 func (a *Allocation) NextRescheduleTime(reschedulePolicy *ReschedulePolicy) (time.Time, bool) {
 	failTime := a.LastEventTime()
@@ -5410,6 +5410,8 @@ func (a *Allocation) NextRescheduleTime(reschedulePolicy *ReschedulePolicy) (tim
 	return nextRescheduleTime, rescheduleEligible
 }
 
+// NextDelay returns a duration after which the allocation can be rescheduled.
+// It is calculated according to the delay function and previous reschedule attempts.
 func (a *Allocation) NextDelay(policy *ReschedulePolicy) time.Duration {
 	delayDur := policy.Delay
 	if a.RescheduleTracker == nil || a.RescheduleTracker.Events == nil || len(a.RescheduleTracker.Events) == 0 {
@@ -5437,13 +5439,13 @@ func (a *Allocation) NextDelay(policy *ReschedulePolicy) time.Duration {
 	if policy.DelayCeiling > 0 && delayDur > policy.DelayCeiling {
 		delayDur = policy.DelayCeiling
 		// check if delay needs to be reset
-		if len(a.RescheduleTracker.Events) > 0 {
-			lastRescheduleEvent := a.RescheduleTracker.Events[len(a.RescheduleTracker.Events)-1]
-			timeDiff := a.LastEventTime().UTC().UnixNano() - lastRescheduleEvent.RescheduleTime
-			if timeDiff > delayDur.Nanoseconds() {
-				delayDur = policy.Delay
-			}
+
+		lastRescheduleEvent := a.RescheduleTracker.Events[len(a.RescheduleTracker.Events)-1]
+		timeDiff := a.LastEventTime().UTC().UnixNano() - lastRescheduleEvent.RescheduleTime
+		if timeDiff > delayDur.Nanoseconds() {
+			delayDur = policy.Delay
 		}
+
 	}
 
 	return delayDur
@@ -5553,12 +5555,11 @@ type AllocListStub struct {
 	ClientDescription  string
 	TaskStates         map[string]*TaskState
 	DeploymentStatus   *AllocDeploymentStatus
-
-	FollowupEvalID string
-	CreateIndex    uint64
-	ModifyIndex    uint64
-	CreateTime     int64
-	ModifyTime     int64
+	FollowupEvalID     string
+	CreateIndex        uint64
+	ModifyIndex        uint64
+	CreateTime         int64
+	ModifyTime         int64
 }
 
 // SetEventDisplayMessage populates the display message if its not already set,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2656,7 +2656,8 @@ type ReschedulePolicy struct {
 	// DelayCeiling is an upper bound on the delay.
 	DelayCeiling time.Duration
 
-	// Unlimited allows rescheduling attempts until they succeed
+	// Unlimited allows infinite rescheduling attempts. Only allowed when delay is set
+	// between reschedule attempts.
 	Unlimited bool
 }
 
@@ -2707,7 +2708,7 @@ func (r *ReschedulePolicy) Validate() error {
 
 	}
 
-	// Validate Interval and other delay parameters if attempts are limited
+	//Validate Interval and other delay parameters if attempts are limited
 	if !r.Unlimited {
 		if r.Interval.Nanoseconds() < ReschedulePolicyMinInterval.Nanoseconds() {
 			multierror.Append(&mErr, fmt.Errorf("Interval cannot be less than %v (got %v)", ReschedulePolicyMinInterval, r.Interval))
@@ -5120,12 +5121,16 @@ type RescheduleEvent struct {
 
 	// PrevNodeID is the node ID of the previous allocation
 	PrevNodeID string
+
+	// Delay is the reschedule delay associated with the attempt
+	Delay time.Duration
 }
 
-func NewRescheduleEvent(rescheduleTime int64, prevAllocID string, prevNodeID string) *RescheduleEvent {
+func NewRescheduleEvent(rescheduleTime int64, prevAllocID string, prevNodeID string, delay time.Duration) *RescheduleEvent {
 	return &RescheduleEvent{RescheduleTime: rescheduleTime,
 		PrevAllocID: prevAllocID,
-		PrevNodeID:  prevNodeID}
+		PrevNodeID:  prevNodeID,
+		Delay:       delay}
 }
 
 func (re *RescheduleEvent) Copy() *RescheduleEvent {
@@ -5221,6 +5226,13 @@ type Allocation struct {
 	// given deployment
 	DeploymentStatus *AllocDeploymentStatus
 
+	// RescheduleTrackers captures details of previous reschedule attempts of the allocation
+	RescheduleTracker *RescheduleTracker
+
+	// FollowupEvalID captures a follow up evaluation created to handle a failed allocation
+	// that can be rescheduled in the future
+	FollowupEvalID string
+
 	// Raft Indexes
 	CreateIndex uint64
 	ModifyIndex uint64
@@ -5235,9 +5247,6 @@ type Allocation struct {
 
 	// ModifyTime is the time the allocation was last updated.
 	ModifyTime int64
-
-	// RescheduleTrackers captures details of previous reschedule attempts of the allocation
-	RescheduleTracker *RescheduleTracker
 }
 
 // Index returns the index of the allocation. If the allocation is from a task
@@ -5344,11 +5353,11 @@ func (a *Allocation) RescheduleEligible(reschedulePolicy *ReschedulePolicy, fail
 	}
 	attempts := reschedulePolicy.Attempts
 	interval := reschedulePolicy.Interval
-
-	if attempts == 0 {
+	enabled := attempts > 0 || reschedulePolicy.Unlimited
+	if !enabled {
 		return false
 	}
-	if (a.RescheduleTracker == nil || len(a.RescheduleTracker.Events) == 0) && attempts > 0 {
+	if (a.RescheduleTracker == nil || len(a.RescheduleTracker.Events) == 0) && attempts > 0 || reschedulePolicy.Unlimited {
 		return true
 	}
 	attempted := 0
@@ -5360,6 +5369,84 @@ func (a *Allocation) RescheduleEligible(reschedulePolicy *ReschedulePolicy, fail
 		}
 	}
 	return attempted < attempts
+}
+
+// LastEventTime is the time of the last task event in the allocation.
+// It is used to determine allocation failure time.
+func (a *Allocation) LastEventTime() time.Time {
+	var lastEventTime time.Time
+	if a.TaskStates != nil {
+		for _, e := range a.TaskStates {
+			if lastEventTime.IsZero() || e.FinishedAt.After(lastEventTime) {
+				lastEventTime = e.FinishedAt
+			}
+		}
+	}
+	return lastEventTime
+}
+
+// NextRescheduleTime returns a time delta after which the allocation is eligible to be rescheduled
+// and whether the next reschedule time is within policy's interval if the policy doesn't allow unlimited reschedules
+func (a *Allocation) NextRescheduleTime(reschedulePolicy *ReschedulePolicy) (time.Time, bool) {
+	failTime := a.LastEventTime()
+	if a.ClientStatus != AllocClientStatusFailed || failTime.IsZero() {
+		return time.Time{}, false
+	}
+	nextDelay := a.NextDelay(reschedulePolicy)
+	nextRescheduleTime := failTime.Add(nextDelay)
+	rescheduleEligible := reschedulePolicy.Unlimited || (reschedulePolicy.Attempts > 0 && a.RescheduleTracker == nil)
+	if reschedulePolicy.Attempts > 0 && a.RescheduleTracker != nil && a.RescheduleTracker.Events != nil {
+		// Check for eligibility based on the interval if max attempts is set
+		attempted := 0
+		for j := len(a.RescheduleTracker.Events) - 1; j >= 0; j-- {
+			lastAttempt := a.RescheduleTracker.Events[j].RescheduleTime
+			timeDiff := failTime.UTC().UnixNano() - lastAttempt
+			if timeDiff < reschedulePolicy.Interval.Nanoseconds() {
+				attempted += 1
+			}
+		}
+		rescheduleEligible = attempted < reschedulePolicy.Attempts && nextDelay < reschedulePolicy.Interval
+	}
+	return nextRescheduleTime, rescheduleEligible
+}
+
+func (a *Allocation) NextDelay(policy *ReschedulePolicy) time.Duration {
+	delayDur := policy.Delay
+	if a.RescheduleTracker == nil || a.RescheduleTracker.Events == nil || len(a.RescheduleTracker.Events) == 0 {
+		return delayDur
+	}
+	events := a.RescheduleTracker.Events
+	switch policy.DelayFunction {
+	case "exponential":
+		delayDur = a.RescheduleTracker.Events[len(a.RescheduleTracker.Events)-1].Delay * 2
+	case "fibonacci":
+		if len(events) >= 2 {
+			fibN1Delay := events[len(events)-1].Delay
+			fibN2Delay := events[len(events)-2].Delay
+			// Handle reset of delay ceiling which should cause
+			// a new series to start
+			if fibN2Delay == policy.DelayCeiling && fibN1Delay == policy.Delay {
+				delayDur = fibN1Delay
+			} else {
+				delayDur = fibN1Delay + fibN2Delay
+			}
+		}
+	default:
+		return delayDur
+	}
+	if policy.DelayCeiling > 0 && delayDur > policy.DelayCeiling {
+		delayDur = policy.DelayCeiling
+		// check if delay needs to be reset
+		if len(a.RescheduleTracker.Events) > 0 {
+			lastRescheduleEvent := a.RescheduleTracker.Events[len(a.RescheduleTracker.Events)-1]
+			timeDiff := a.LastEventTime().UTC().UnixNano() - lastRescheduleEvent.RescheduleTime
+			if timeDiff > delayDur.Nanoseconds() {
+				delayDur = policy.Delay
+			}
+		}
+	}
+
+	return delayDur
 }
 
 // Terminated returns if the allocation is in a terminal state on a client.
@@ -5466,10 +5553,12 @@ type AllocListStub struct {
 	ClientDescription  string
 	TaskStates         map[string]*TaskState
 	DeploymentStatus   *AllocDeploymentStatus
-	CreateIndex        uint64
-	ModifyIndex        uint64
-	CreateTime         int64
-	ModifyTime         int64
+
+	FollowupEvalID string
+	CreateIndex    uint64
+	ModifyIndex    uint64
+	CreateTime     int64
+	ModifyTime     int64
 }
 
 // SetEventDisplayMessage populates the display message if its not already set,
@@ -5751,8 +5840,13 @@ type Evaluation struct {
 	StatusDescription string
 
 	// Wait is a minimum wait time for running the eval. This is used to
-	// support a rolling upgrade.
+	// support a rolling upgrade in versions prior to 0.7.0
+	// Deprecated
 	Wait time.Duration
+
+	// WaitUntil is the time when this eval should be run. This is used to
+	// supported delayed rescheduling of failed allocations
+	WaitUntil time.Time
 
 	// NextEval is the evaluation ID for the eval created to do a followup.
 	// This is used to support rolling upgrades, where we need a chain of evaluations.

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -3476,7 +3476,11 @@ func TestAllocation_NextDelay(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			require := require.New(t)
-			reschedTime, allowed := tc.alloc.NextRescheduleTime(tc.reschedulePolicy)
+			j := testJob()
+			j.TaskGroups[0].ReschedulePolicy = tc.reschedulePolicy
+			tc.alloc.Job = j
+			tc.alloc.TaskGroup = j.TaskGroups[0].Name
+			reschedTime, allowed := tc.alloc.NextRescheduleTime()
 			require.Equal(tc.expectedRescheduleEligible, allowed)
 			require.Equal(tc.expectedRescheduleTime, reschedTime)
 		})

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -429,6 +429,9 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 	// Update the set of placement nodes
 	s.stack.SetNodes(nodes)
 
+	// Capture current time to use as the start time for any rescheduled allocations
+	now := time.Now()
+
 	// Have to handle destructive changes first as we need to discount their
 	// resources. To understand this imagine the resources were reduced and the
 	// count was scaled up.
@@ -491,7 +494,6 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 				// If the new allocation is replacing an older allocation then we
 				// set the record the older allocation id so that they are chained
 				if prevAllocation != nil {
-					now := time.Now()
 					alloc.PreviousAllocation = prevAllocation.ID
 					if missing.IsRescheduling() {
 						updateRescheduleTracker(alloc, prevAllocation, now)

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -494,7 +494,7 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 					now := time.Now()
 					alloc.PreviousAllocation = prevAllocation.ID
 					if missing.IsRescheduling() {
-						updateRescheduleTracker(alloc, prevAllocation, tg.ReschedulePolicy, now)
+						updateRescheduleTracker(alloc, prevAllocation, now)
 					}
 				}
 
@@ -551,7 +551,8 @@ func getSelectOptions(prevAllocation *structs.Allocation, preferredNode *structs
 }
 
 // updateRescheduleTracker carries over previous restart attempts and adds the most recent restart
-func updateRescheduleTracker(alloc *structs.Allocation, prev *structs.Allocation, reschedPolicy *structs.ReschedulePolicy, now time.Time) {
+func updateRescheduleTracker(alloc *structs.Allocation, prev *structs.Allocation, now time.Time) {
+	reschedPolicy := prev.ReschedulePolicy()
 	var rescheduleEvents []*structs.RescheduleEvent
 	if prev.RescheduleTracker != nil {
 		var interval time.Duration
@@ -580,7 +581,7 @@ func updateRescheduleTracker(alloc *structs.Allocation, prev *structs.Allocation
 			}
 		}
 	}
-	nextDelay := prev.NextDelay(reschedPolicy)
+	nextDelay := prev.NextDelay()
 	rescheduleEvent := structs.NewRescheduleEvent(now.UnixNano(), prev.ID, prev.NodeID, nextDelay)
 	rescheduleEvents = append(rescheduleEvents, rescheduleEvent)
 	alloc.RescheduleTracker = &structs.RescheduleTracker{Events: rescheduleEvents}

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -76,7 +76,7 @@ type GenericScheduler struct {
 	ctx        *EvalContext
 	stack      *GenericStack
 
-	// Deprecated, was used in pre Nomad 0.7 rolling update stanza
+	// Deprecated, was used in pre Nomad 0.7 rolling update stanza and in node draining prior to Nomad 0.8
 	followupEvalWait time.Duration
 	nextEval         *structs.Evaluation
 	followUpEvals    []*structs.Evaluation

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -2715,7 +2715,7 @@ func TestServiceSched_RetryLimit(t *testing.T) {
 	h.AssertEvalStatus(t, structs.EvalStatusFailed)
 }
 
-func TestServiceSched_Reschedule_Once(t *testing.T) {
+func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -2730,9 +2730,15 @@ func TestServiceSched_Reschedule_Once(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 2
 	job.TaskGroups[0].ReschedulePolicy = &structs.ReschedulePolicy{
-		Attempts: 1,
-		Interval: 15 * time.Minute,
+		Attempts:      1,
+		Interval:      15 * time.Minute,
+		Delay:         5 * time.Second,
+		DelayCeiling:  1 * time.Minute,
+		DelayFunction: "linear",
 	}
+	tgName := job.TaskGroups[0].Name
+	now := time.Now()
+
 	noErr(t, h.State.UpsertJob(h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
@@ -2746,6 +2752,9 @@ func TestServiceSched_Reschedule_Once(t *testing.T) {
 	}
 	// Mark one of the allocations as failed
 	allocs[1].ClientStatus = structs.AllocClientStatusFailed
+	allocs[1].TaskStates = map[string]*structs.TaskState{tgName: {State: "dead",
+		StartedAt:  now.Add(-1 * time.Hour),
+		FinishedAt: now.Add(-10 * time.Second)}}
 	failedAllocID := allocs[1].ID
 	successAllocID := allocs[0].ID
 
@@ -2817,7 +2826,96 @@ func TestServiceSched_Reschedule_Once(t *testing.T) {
 
 }
 
-func TestServiceSched_Reschedule_Multiple(t *testing.T) {
+// Tests that alloc reschedulable at a future time creates a follow up eval
+func TestServiceSched_Reschedule_Later(t *testing.T) {
+	h := NewHarness(t)
+	require := require.New(t)
+	// Create some nodes
+	var nodes []*structs.Node
+	for i := 0; i < 10; i++ {
+		node := mock.Node()
+		nodes = append(nodes, node)
+		noErr(t, h.State.UpsertNode(h.NextIndex(), node))
+	}
+
+	// Generate a fake job with allocations and an update policy.
+	job := mock.Job()
+	job.TaskGroups[0].Count = 2
+	delayDuration := 15 * time.Second
+	job.TaskGroups[0].ReschedulePolicy = &structs.ReschedulePolicy{
+		Attempts:      1,
+		Interval:      15 * time.Minute,
+		Delay:         delayDuration,
+		DelayCeiling:  1 * time.Minute,
+		DelayFunction: "linear",
+	}
+	tgName := job.TaskGroups[0].Name
+	now := time.Now()
+
+	noErr(t, h.State.UpsertJob(h.NextIndex(), job))
+
+	var allocs []*structs.Allocation
+	for i := 0; i < 2; i++ {
+		alloc := mock.Alloc()
+		alloc.Job = job
+		alloc.JobID = job.ID
+		alloc.NodeID = nodes[i].ID
+		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
+		allocs = append(allocs, alloc)
+	}
+	// Mark one of the allocations as failed
+	allocs[1].ClientStatus = structs.AllocClientStatusFailed
+	allocs[1].TaskStates = map[string]*structs.TaskState{tgName: {State: "dead",
+		StartedAt:  now.Add(-1 * time.Hour),
+		FinishedAt: now}}
+	failedAllocID := allocs[1].ID
+
+	noErr(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+
+	// Create a mock evaluation
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    50,
+		TriggeredBy: structs.EvalTriggerNodeUpdate,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	noErr(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+
+	// Process the evaluation
+	err := h.Process(NewServiceScheduler, eval)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure multiple plans
+	if len(h.Plans) == 0 {
+		t.Fatalf("bad: %#v", h.Plans)
+	}
+
+	// Lookup the allocations by JobID
+	ws := memdb.NewWatchSet()
+	out, err := h.State.AllocsByJob(ws, job.Namespace, job.ID, false)
+	noErr(t, err)
+
+	// Verify no new allocs were created
+	require.Equal(2, len(out))
+
+	// Verify follow up eval was created for the failed alloc
+	alloc, err := h.State.AllocByID(ws, failedAllocID)
+	require.Nil(err)
+	require.NotEmpty(alloc.FollowupEvalID)
+
+	// Ensure there is a follow up eval.
+	if len(h.CreateEvals) != 1 || h.CreateEvals[0].Status != structs.EvalStatusPending {
+		t.Fatalf("bad: %#v", h.CreateEvals)
+	}
+	followupEval := h.CreateEvals[0]
+	require.Equal(now.Add(delayDuration), followupEval.WaitUntil)
+}
+
+func TestServiceSched_Reschedule_MultipleNow(t *testing.T) {
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -2833,9 +2931,14 @@ func TestServiceSched_Reschedule_Multiple(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 2
 	job.TaskGroups[0].ReschedulePolicy = &structs.ReschedulePolicy{
-		Attempts: maxRestartAttempts,
-		Interval: 30 * time.Minute,
+		Attempts:      maxRestartAttempts,
+		Interval:      30 * time.Minute,
+		Delay:         5 * time.Second,
+		DelayFunction: "linear",
 	}
+	tgName := job.TaskGroups[0].Name
+	now := time.Now()
+
 	noErr(t, h.State.UpsertJob(h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
@@ -2850,6 +2953,9 @@ func TestServiceSched_Reschedule_Multiple(t *testing.T) {
 	}
 	// Mark one of the allocations as failed
 	allocs[1].ClientStatus = structs.AllocClientStatusFailed
+	allocs[1].TaskStates = map[string]*structs.TaskState{tgName: {State: "dead",
+		StartedAt:  now.Add(-1 * time.Hour),
+		FinishedAt: now.Add(-10 * time.Second)}}
 
 	noErr(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
 
@@ -2915,6 +3021,9 @@ func TestServiceSched_Reschedule_Multiple(t *testing.T) {
 
 		// Mark this alloc as failed again
 		newAlloc.ClientStatus = structs.AllocClientStatusFailed
+		newAlloc.TaskStates = map[string]*structs.TaskState{tgName: {State: "dead",
+			StartedAt:  now.Add(-12 * time.Second),
+			FinishedAt: now.Add(-10 * time.Second)}}
 
 		failedAllocId = newAlloc.ID
 		failedNodeID = newAlloc.NodeID
@@ -2944,6 +3053,136 @@ func TestServiceSched_Reschedule_Multiple(t *testing.T) {
 	out, err := h.State.AllocsByJob(ws, job.Namespace, job.ID, false)
 	noErr(t, err)
 	assert.Equal(5, len(out)) // 2 original, plus 3 reschedule attempts
+}
+
+// Tests that old reschedule attempts are pruned
+func TestServiceSched_Reschedule_PruneEvents(t *testing.T) {
+	h := NewHarness(t)
+
+	// Create some nodes
+	var nodes []*structs.Node
+	for i := 0; i < 10; i++ {
+		node := mock.Node()
+		nodes = append(nodes, node)
+		noErr(t, h.State.UpsertNode(h.NextIndex(), node))
+	}
+
+	// Generate a fake job with allocations and an update policy.
+	job := mock.Job()
+	job.TaskGroups[0].Count = 2
+	job.TaskGroups[0].ReschedulePolicy = &structs.ReschedulePolicy{
+		DelayFunction: "exponential",
+		DelayCeiling:  1 * time.Hour,
+		Delay:         5 * time.Second,
+		Unlimited:     true,
+	}
+	noErr(t, h.State.UpsertJob(h.NextIndex(), job))
+
+	var allocs []*structs.Allocation
+	for i := 0; i < 2; i++ {
+		alloc := mock.Alloc()
+		alloc.Job = job
+		alloc.JobID = job.ID
+		alloc.NodeID = nodes[i].ID
+		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
+		allocs = append(allocs, alloc)
+	}
+	now := time.Now()
+	// Mark allocations as failed with restart info
+	allocs[1].TaskStates = map[string]*structs.TaskState{job.TaskGroups[0].Name: {State: "dead",
+		StartedAt:  now.Add(-1 * time.Hour),
+		FinishedAt: now.Add(-15 * time.Minute)}}
+	allocs[1].ClientStatus = structs.AllocClientStatusFailed
+
+	allocs[1].RescheduleTracker = &structs.RescheduleTracker{
+		Events: []*structs.RescheduleEvent{
+			{RescheduleTime: now.Add(-1 * time.Hour).UTC().UnixNano(),
+				PrevAllocID: uuid.Generate(),
+				PrevNodeID:  uuid.Generate(),
+				Delay:       5 * time.Second,
+			},
+			{RescheduleTime: now.Add(-40 * time.Minute).UTC().UnixNano(),
+				PrevAllocID: allocs[0].ID,
+				PrevNodeID:  uuid.Generate(),
+				Delay:       10 * time.Second,
+			},
+			{RescheduleTime: now.Add(-30 * time.Minute).UTC().UnixNano(),
+				PrevAllocID: allocs[0].ID,
+				PrevNodeID:  uuid.Generate(),
+				Delay:       20 * time.Second,
+			},
+			{RescheduleTime: now.Add(-20 * time.Minute).UTC().UnixNano(),
+				PrevAllocID: allocs[0].ID,
+				PrevNodeID:  uuid.Generate(),
+				Delay:       40 * time.Second,
+			},
+			{RescheduleTime: now.Add(-10 * time.Minute).UTC().UnixNano(),
+				PrevAllocID: allocs[0].ID,
+				PrevNodeID:  uuid.Generate(),
+				Delay:       80 * time.Second,
+			},
+			{RescheduleTime: now.Add(-3 * time.Minute).UTC().UnixNano(),
+				PrevAllocID: allocs[0].ID,
+				PrevNodeID:  uuid.Generate(),
+				Delay:       160 * time.Second,
+			},
+		},
+	}
+	expectedFirstRescheduleEvent := allocs[1].RescheduleTracker.Events[1]
+	expectedDelay := 320 * time.Second
+	failedAllocID := allocs[1].ID
+	successAllocID := allocs[0].ID
+
+	noErr(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+
+	// Create a mock evaluation
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    50,
+		TriggeredBy: structs.EvalTriggerNodeUpdate,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	noErr(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+
+	// Process the evaluation
+	err := h.Process(NewServiceScheduler, eval)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure multiple plans
+	if len(h.Plans) == 0 {
+		t.Fatalf("bad: %#v", h.Plans)
+	}
+
+	// Lookup the allocations by JobID
+	ws := memdb.NewWatchSet()
+	out, err := h.State.AllocsByJob(ws, job.Namespace, job.ID, false)
+	noErr(t, err)
+
+	// Verify that one new allocation got created with its restart tracker info
+	assert := assert.New(t)
+	assert.Equal(3, len(out))
+	var newAlloc *structs.Allocation
+	for _, alloc := range out {
+		if alloc.ID != successAllocID && alloc.ID != failedAllocID {
+			newAlloc = alloc
+		}
+	}
+
+	assert.Equal(failedAllocID, newAlloc.PreviousAllocation)
+	// Verify that the new alloc copied the last 5 reschedule attempts
+	assert.Equal(6, len(newAlloc.RescheduleTracker.Events))
+	assert.Equal(expectedFirstRescheduleEvent, newAlloc.RescheduleTracker.Events[0])
+
+	mostRecentRescheduleEvent := newAlloc.RescheduleTracker.Events[5]
+	// Verify that the failed alloc ID is in the most recent reschedule event
+	assert.Equal(failedAllocID, mostRecentRescheduleEvent.PrevAllocID)
+	// Verify that the delay value was captured correctly
+	assert.Equal(expectedDelay, mostRecentRescheduleEvent.Delay)
+
 }
 
 // Tests that deployments with failed allocs don't result in placements
@@ -3079,6 +3318,9 @@ func TestBatchSched_Run_FailedAlloc(t *testing.T) {
 	job.TaskGroups[0].Count = 1
 	noErr(t, h.State.UpsertJob(h.NextIndex(), job))
 
+	tgName := job.TaskGroups[0].Name
+	now := time.Now()
+
 	// Create a failed alloc
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -3086,6 +3328,9 @@ func TestBatchSched_Run_FailedAlloc(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.Name = "my-job.web[0]"
 	alloc.ClientStatus = structs.AllocClientStatusFailed
+	alloc.TaskStates = map[string]*structs.TaskState{tgName: {State: "dead",
+		StartedAt:  now.Add(-1 * time.Hour),
+		FinishedAt: now.Add(-10 * time.Second)}}
 	noErr(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to register the job
@@ -3231,6 +3476,9 @@ func TestBatchSched_Run_FailedAllocQueuedAllocations(t *testing.T) {
 	job.TaskGroups[0].Count = 1
 	noErr(t, h.State.UpsertJob(h.NextIndex(), job))
 
+	tgName := job.TaskGroups[0].Name
+	now := time.Now()
+
 	// Create a failed alloc
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -3238,6 +3486,9 @@ func TestBatchSched_Run_FailedAllocQueuedAllocations(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.Name = "my-job.web[0]"
 	alloc.ClientStatus = structs.AllocClientStatusFailed
+	alloc.TaskStates = map[string]*structs.TaskState{tgName: {State: "dead",
+		StartedAt:  now.Add(-1 * time.Hour),
+		FinishedAt: now.Add(-10 * time.Second)}}
 	noErr(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to register the job
@@ -3962,4 +4213,233 @@ func TestServiceSched_CancelDeployment_NewerJob(t *testing.T) {
 	}
 
 	h.AssertEvalStatus(t, structs.EvalStatusComplete)
+}
+
+// Various table driven tests for carry forward
+// of past reschedule events
+func Test_updateRescheduleTracker(t *testing.T) {
+
+	t1 := time.Now().UTC()
+	alloc := mock.Alloc()
+	prevAlloc := mock.Alloc()
+
+	type testCase struct {
+		desc                     string
+		prevAllocEvents          []*structs.RescheduleEvent
+		reschedPolicy            *structs.ReschedulePolicy
+		expectedRescheduleEvents []*structs.RescheduleEvent
+		reschedTime              time.Time
+	}
+
+	testCases := []testCase{
+		{
+			desc:                     "No past events",
+			prevAllocEvents:          nil,
+			reschedPolicy:            &structs.ReschedulePolicy{Unlimited: false, Interval: 24 * time.Hour, Attempts: 2, Delay: 5 * time.Second},
+			reschedTime:              t1,
+			expectedRescheduleEvents: []*structs.RescheduleEvent{{t1.UnixNano(), prevAlloc.ID, prevAlloc.NodeID, 5 * time.Second}},
+		},
+		{
+			desc: "one past event, linear delay",
+			prevAllocEvents: []*structs.RescheduleEvent{
+				{RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID: prevAlloc.ID,
+					PrevNodeID:  prevAlloc.NodeID,
+					Delay:       5 * time.Second}},
+			reschedPolicy: &structs.ReschedulePolicy{Unlimited: false, Interval: 24 * time.Hour, Attempts: 2, Delay: 5 * time.Second},
+			reschedTime:   t1,
+			expectedRescheduleEvents: []*structs.RescheduleEvent{
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          5 * time.Second,
+				},
+				{
+					RescheduleTime: t1.UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          5 * time.Second,
+				},
+			},
+		},
+		{
+			desc: "one past event, fibonacci delay",
+			prevAllocEvents: []*structs.RescheduleEvent{
+				{RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID: prevAlloc.ID,
+					PrevNodeID:  prevAlloc.NodeID,
+					Delay:       5 * time.Second}},
+			reschedPolicy: &structs.ReschedulePolicy{Unlimited: false, Interval: 24 * time.Hour, Attempts: 2, Delay: 5 * time.Second, DelayFunction: "fibonacci", DelayCeiling: 60 * time.Second},
+			reschedTime:   t1,
+			expectedRescheduleEvents: []*structs.RescheduleEvent{
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          5 * time.Second,
+				},
+				{
+					RescheduleTime: t1.UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          5 * time.Second,
+				},
+			},
+		},
+		{
+			desc: "eight past events, fibonacci delay, unlimited",
+			prevAllocEvents: []*structs.RescheduleEvent{
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          5 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          5 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          10 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          15 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          25 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          40 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          65 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          105 * time.Second,
+				},
+			},
+			reschedPolicy: &structs.ReschedulePolicy{Unlimited: true, Delay: 5 * time.Second, DelayFunction: "fibonacci", DelayCeiling: 240 * time.Second},
+			reschedTime:   t1,
+			expectedRescheduleEvents: []*structs.RescheduleEvent{
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          15 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          25 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          40 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          65 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          105 * time.Second,
+				},
+				{
+					RescheduleTime: t1.UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          170 * time.Second,
+				},
+			},
+		},
+		{
+			desc: " old attempts past interval, exponential delay, limited",
+			prevAllocEvents: []*structs.RescheduleEvent{
+				{
+					RescheduleTime: t1.Add(-2 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          5 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          10 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-30 * time.Minute).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          20 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-10 * time.Minute).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          40 * time.Second,
+				},
+			},
+			reschedPolicy: &structs.ReschedulePolicy{Unlimited: false, Interval: 1 * time.Hour, Attempts: 5, Delay: 5 * time.Second, DelayFunction: "exponential", DelayCeiling: 240 * time.Second},
+			reschedTime:   t1,
+			expectedRescheduleEvents: []*structs.RescheduleEvent{
+				{
+					RescheduleTime: t1.Add(-30 * time.Minute).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          20 * time.Second,
+				},
+				{
+					RescheduleTime: t1.Add(-10 * time.Minute).UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          40 * time.Second,
+				},
+				{
+					RescheduleTime: t1.UnixNano(),
+					PrevAllocID:    prevAlloc.ID,
+					PrevNodeID:     prevAlloc.NodeID,
+					Delay:          80 * time.Second,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require := require.New(t)
+			prevAlloc.RescheduleTracker = &structs.RescheduleTracker{Events: tc.prevAllocEvents}
+			updateRescheduleTracker(alloc, prevAlloc, tc.reschedPolicy, tc.reschedTime)
+			require.Equal(tc.expectedRescheduleEvents, alloc.RescheduleTracker.Events)
+		})
+	}
+
 }

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -4390,7 +4390,7 @@ func Test_updateRescheduleTracker(t *testing.T) {
 					Delay:          5 * time.Second,
 				},
 				{
-					RescheduleTime: t1.Add(-1 * time.Hour).UnixNano(),
+					RescheduleTime: t1.Add(-70 * time.Minute).UnixNano(),
 					PrevAllocID:    prevAlloc.ID,
 					PrevNodeID:     prevAlloc.NodeID,
 					Delay:          10 * time.Second,

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -4437,7 +4437,8 @@ func Test_updateRescheduleTracker(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			require := require.New(t)
 			prevAlloc.RescheduleTracker = &structs.RescheduleTracker{Events: tc.prevAllocEvents}
-			updateRescheduleTracker(alloc, prevAlloc, tc.reschedPolicy, tc.reschedTime)
+			prevAlloc.Job.LookupTaskGroup(prevAlloc.TaskGroup).ReschedulePolicy = tc.reschedPolicy
+			updateRescheduleTracker(alloc, prevAlloc, tc.reschedTime)
 			require.Equal(tc.expectedRescheduleEvents, alloc.RescheduleTracker.Events)
 		})
 	}

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -844,16 +844,29 @@ func (a *allocReconciler) handleDelayedReschedules(rescheduleLater []*delayedRes
 	})
 
 	var evals []*structs.Evaluation
-	var allocIDs []string
 	nextReschedTime := rescheduleLater[0].rescheduleTime
 	allocIDToFollowupEvalID := make(map[string]string, len(rescheduleLater))
+	// Create a new eval for the first batch
+	eval := &structs.Evaluation{
+		ID:             uuid.Generate(),
+		Namespace:      a.job.Namespace,
+		Priority:       a.job.Priority,
+		Type:           a.job.Type,
+		TriggeredBy:    structs.EvalTriggerRetryFailedAlloc,
+		JobID:          a.job.ID,
+		JobModifyIndex: a.job.ModifyIndex,
+		Status:         structs.EvalStatusPending,
+		WaitUntil:      nextReschedTime,
+	}
+	evals = append(evals, eval)
 	for _, allocReschedInfo := range rescheduleLater {
-		if allocReschedInfo.rescheduleTime.UTC().UnixNano()-nextReschedTime.UTC().UnixNano() < batchedFailedAllocWindowSize.Nanoseconds() {
-			// add to batch
-			allocIDs = append(allocIDs, allocReschedInfo.allocID)
+		if allocReschedInfo.rescheduleTime.Sub(nextReschedTime) < batchedFailedAllocWindowSize {
+			allocIDToFollowupEvalID[allocReschedInfo.allocID] = eval.ID
 		} else {
-			// create a new eval for the previous batch
-			eval := &structs.Evaluation{
+			// Start a new batch
+			nextReschedTime = allocReschedInfo.rescheduleTime
+			// Create a new eval for the new batch
+			eval = &structs.Evaluation{
 				ID:             uuid.Generate(),
 				Namespace:      a.job.Namespace,
 				Priority:       a.job.Priority,
@@ -865,37 +878,14 @@ func (a *allocReconciler) handleDelayedReschedules(rescheduleLater []*delayedRes
 				WaitUntil:      nextReschedTime,
 			}
 			evals = append(evals, eval)
-			for _, allocID := range allocIDs {
-				allocIDToFollowupEvalID[allocID] = eval.ID
-			}
-			nextReschedTime = allocReschedInfo.rescheduleTime
-			// clear out this batch and start it again
-			allocIDs = nil
-			allocIDs = append(allocIDs, allocReschedInfo.allocID)
-		}
-	}
-	// Deal with the last batch
-	if len(allocIDs) > 0 {
-		eval := &structs.Evaluation{
-			ID:             uuid.Generate(),
-			Namespace:      a.job.Namespace,
-			Priority:       a.job.Priority,
-			Type:           a.job.Type,
-			TriggeredBy:    structs.EvalTriggerRetryFailedAlloc,
-			JobID:          a.job.ID,
-			JobModifyIndex: a.job.ModifyIndex,
-			Status:         structs.EvalStatusPending,
-			WaitUntil:      nextReschedTime,
-		}
-		evals = append(evals, eval)
-		for _, allocID := range allocIDs {
-			allocIDToFollowupEvalID[allocID] = eval.ID
+			// Set the evalID for the first alloc in this new batch
+			allocIDToFollowupEvalID[allocReschedInfo.allocID] = eval.ID
 		}
 	}
 
 	a.result.desiredFollowupEvals[tgName] = evals
 
-	// create inplace updates for every alloc ID that needs to be updated with its follow up eval ID
+	// Create in-place updates for every alloc ID that needs to be updated with its follow up eval ID
 	rescheduleLaterAllocs := make(map[string]*structs.Allocation)
 	for allocID, evalID := range allocIDToFollowupEvalID {
 		existingAlloc := all[allocID]

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -12,6 +12,12 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+const (
+	// batchedFailedAllocWindowSize is the window size used
+	// to batch up failed allocations before creating an eval
+	batchedFailedAllocWindowSize = 5 * time.Second
+)
+
 // allocUpdateType takes an existing allocation and a new job definition and
 // returns whether the allocation can ignore the change, requires a destructive
 // update, or can be inplace updated. If it can be inplace updated, an updated
@@ -290,8 +296,6 @@ func (a *allocReconciler) markStop(allocs allocSet, clientStatus, statusDescript
 	}
 }
 
-const batchedFailedAllocWindowSize = 5 * time.Second
-
 // computeGroup reconciles state for a particular task group. It returns whether
 // the deployment it is for is complete with regards to the task group.
 func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
@@ -343,7 +347,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 	untainted, rescheduleNow, rescheduleLater := untainted.filterByRescheduleable(a.batch, tg.ReschedulePolicy)
 
 	// Create batched follow up evaluations for allocations that are reschedulable later
-	rescheduleLaterAllocs := make(map[string]*structs.Allocation)
+	var rescheduleLaterAllocs map[string]*structs.Allocation
 	if len(rescheduleLater) > 0 {
 		rescheduleLaterAllocs = a.handleDelayedReschedules(rescheduleLater, all, tg.Name)
 	}
@@ -830,6 +834,9 @@ func (a *allocReconciler) computeUpdates(group *structs.TaskGroup, untainted, re
 
 	return
 }
+
+// handleDelayedReschedules creates batched followup evaluations with the WaitUntil field set
+// for allocations that are eligible to be rescheduled later
 func (a *allocReconciler) handleDelayedReschedules(rescheduleLater []*delayedRescheduleInfo, all allocSet, tgName string) allocSet {
 	// Sort by time
 	sort.Slice(rescheduleLater, func(i, j int) bool {

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -344,7 +344,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 	untainted, migrate, lost := all.filterByTainted(a.taintedNodes)
 
 	// Determine what set of terminal allocations need to be rescheduled
-	untainted, rescheduleNow, rescheduleLater := untainted.filterByRescheduleable(a.batch, tg.ReschedulePolicy)
+	untainted, rescheduleNow, rescheduleLater := untainted.filterByRescheduleable(a.batch)
 
 	// Create batched follow up evaluations for allocations that are reschedulable later
 	var rescheduleLaterAllocs map[string]*structs.Allocation

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -252,11 +252,11 @@ func (a allocSet) filterByRescheduleable(isBatch bool, reschedulePolicy *structs
 			default:
 			}
 			if alloc.NextAllocation == "" {
-				//ignore allocs that have already been rescheduled
+				// Ignore allocs that have already been rescheduled
 				isUntainted, eligibleNow, eligibleLater, rescheduleTime = updateByReschedulable(alloc, reschedulePolicy, now, true)
 			}
 		} else {
-			//ignore allocs that have already been rescheduled
+			// Ignore allocs that have already been rescheduled
 			if alloc.NextAllocation == "" {
 				isUntainted, eligibleNow, eligibleLater, rescheduleTime = updateByReschedulable(alloc, reschedulePolicy, now, false)
 			}
@@ -278,12 +278,12 @@ func (a allocSet) filterByRescheduleable(isBatch bool, reschedulePolicy *structs
 func updateByReschedulable(alloc *structs.Allocation, reschedulePolicy *structs.ReschedulePolicy, now time.Time, batch bool) (untainted, rescheduleNow, rescheduleLater bool, rescheduleTime time.Time) {
 	shouldAllow := true
 	if !batch {
-		// for service type jobs we ignore allocs whose desired state is stop/evict
+		// For service type jobs we ignore allocs whose desired state is stop/evict
 		// everything else is either rescheduleable or untainted
 		shouldAllow = alloc.DesiredStatus != structs.AllocDesiredStatusStop && alloc.DesiredStatus != structs.AllocDesiredStatusEvict
 	}
 	rescheduleTime, eligible := alloc.NextRescheduleTime(reschedulePolicy)
-	// we consider a time difference of less than 5 seconds to be eligible
+	// We consider a time difference of less than 5 seconds to be eligible
 	// because we collapse allocations that failed within 5 seconds into a single evaluation
 	if eligible && now.After(rescheduleTime) {
 		rescheduleNow = true

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -283,10 +283,9 @@ func updateByReschedulable(alloc *structs.Allocation, reschedulePolicy *structs.
 		shouldAllow = alloc.DesiredStatus != structs.AllocDesiredStatusStop && alloc.DesiredStatus != structs.AllocDesiredStatusEvict
 	}
 	rescheduleTime, eligible := alloc.NextRescheduleTime(reschedulePolicy)
-	timeDiff := rescheduleTime.UTC().UnixNano() - now.UTC().UnixNano()
 	// we consider a time difference of less than 5 seconds to be eligible
 	// because we collapse allocations that failed within 5 seconds into a single evaluation
-	if eligible && timeDiff < batchedFailedAllocWindowSize.Nanoseconds() {
+	if eligible && now.After(rescheduleTime) {
 		rescheduleNow = true
 	} else if shouldAllow {
 		untainted = true


### PR DESCRIPTION
Scheduler and reconciler changes 

Helper methods to determine next delay time and unit tests 

new delay heap to track delayed evaluations (needs a bit more iteration on the interface for it). It used in the eval broker, and can be extended later to have the periodic scheduler also use it. 

