### PR TITLE
CLI info on delayed rescheduling

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -303,7 +303,8 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 	return formatKV(basic), nil
 }
 
-// lookupEvalTime returns a human
+// futureEvalTimePretty returns when the eval is eligible to reschedule
+// relative to current time, based on the WaitUntil field
 func futureEvalTimePretty(evalID string, client *api.Client) string {
 	evaluation, _, err := client.Evaluations().Info(evalID, nil)
 	// Eval time is not a critical output,

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -283,6 +283,13 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 		basic = append(basic,
 			fmt.Sprintf("Replacement Alloc ID|%s", limit(alloc.NextAllocation, uuidLength)))
 	}
+	if alloc.FollowupEvalID != "" {
+		nextEvalTime := futureEvalTimePretty(alloc.FollowupEvalID, client)
+		if nextEvalTime != "" {
+			basic = append(basic,
+				fmt.Sprintf("Reschedule Eligibility|%s", nextEvalTime))
+		}
+	}
 
 	if verbose {
 		basic = append(basic,
@@ -294,6 +301,17 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 	}
 
 	return formatKV(basic), nil
+}
+
+// lookupEvalTime returns a human
+func futureEvalTimePretty(evalID string, client *api.Client) string {
+	evaluation, _, err := client.Evaluations().Info(evalID, nil)
+	// Eval time is not a critical output,
+	// don't return it on errors, if its not set or already in the past
+	if err != nil || evaluation.WaitUntil.IsZero() || time.Now().After(evaluation.WaitUntil) {
+		return ""
+	}
+	return prettyTimeDiff(evaluation.WaitUntil, time.Now())
 }
 
 // outputTaskDetails prints task details for each task in the allocation,

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -103,7 +103,15 @@ func prettyTimeDiff(first, second time.Time) string {
 	second = second.Round(time.Second)
 
 	// calculate time difference in seconds
-	d := second.Sub(first)
+	var d time.Duration
+	messageSuffix := "ago"
+	if second.Equal(first) || second.After(first) {
+		d = second.Sub(first)
+	} else {
+		d = first.Sub(second)
+		messageSuffix = "from now"
+	}
+
 	u := uint64(d.Seconds())
 
 	var buf [32]byte
@@ -183,9 +191,9 @@ func prettyTimeDiff(first, second time.Time) string {
 		end = indexes[num_periods-3]
 	}
 	if start == end { //edge case when time difference is less than a second
-		return "0s ago"
+		return "0s " + messageSuffix
 	} else {
-		return string(buf[start:end]) + " ago"
+		return string(buf[start:end]) + " " + messageSuffix
 	}
 
 }

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -310,6 +310,7 @@ func TestPrettyTimeDiff(t *testing.T) {
 		{now, now.Add(-60 * time.Minute), "1h ago"},
 		{now, now.Add(-80 * time.Minute), "1h20m ago"},
 		{now, now.Add(-6 * time.Hour), "6h ago"},
+		{now.Add(-6 * time.Hour), now, "6h from now"},
 		{now, now.Add(-22165 * time.Second), "6h9m ago"},
 		{now, now.Add(-100 * time.Hour), "4d4h ago"},
 		{now, now.Add(-438000 * time.Minute), "10mo4d ago"},


### PR DESCRIPTION
Show when an allocation is eligible to be rescheduled in the CLI if there's a followup eval id

Builds on top of #3928 