### PR TITLE
Monitor drains from CLI by default but allow detaching

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -213,3 +213,8 @@ type DesiredTransition struct {
 	// migrated to another node.
 	Migrate *bool
 }
+
+// ShouldMigrate returns whether the transition object dictates a migration.
+func (d DesiredTransition) ShouldMigrate() bool {
+	return d.Migrate != nil && *d.Migrate
+}

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -239,3 +239,10 @@ func TestAllocations_RescheduleInfo(t *testing.T) {
 	}
 
 }
+
+func TestAllocations_ShouldMigrate(t *testing.T) {
+	t.Parallel()
+	require.True(t, DesiredTransition{Migrate: helper.BoolToPtr(true)}.ShouldMigrate())
+	require.False(t, DesiredTransition{}.ShouldMigrate())
+	require.False(t, DesiredTransition{Migrate: helper.BoolToPtr(false)}.ShouldMigrate())
+}

--- a/command/node_drain_test.go
+++ b/command/node_drain_test.go
@@ -4,16 +4,187 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/command/agent"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNodeDrainCommand_Implements(t *testing.T) {
 	t.Parallel()
 	var _ cli.Command = &NodeDrainCommand{}
+}
+
+func TestNodeDrainCommand_Detach(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	server, client, url := testServer(t, true, func(c *agent.Config) {
+		c.NodeName = "drain_detach_node"
+	})
+	defer server.Shutdown()
+
+	// Wait for a node to appear
+	var nodeID string
+	testutil.WaitForResult(func() (bool, error) {
+		nodes, _, err := client.Nodes().List(nil)
+		if err != nil {
+			return false, err
+		}
+		if len(nodes) == 0 {
+			return false, fmt.Errorf("missing node")
+		}
+		nodeID = nodes[0].ID
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+
+	// Register a job to create an alloc to drain that will block draining
+	job := &api.Job{
+		ID:          helper.StringToPtr("mock_service"),
+		Name:        helper.StringToPtr("mock_service"),
+		Datacenters: []string{"dc1"},
+		TaskGroups: []*api.TaskGroup{
+			{
+				Name: helper.StringToPtr("mock_group"),
+				Tasks: []*api.Task{
+					{
+						Name:   "mock_task",
+						Driver: "mock_driver",
+						Config: map[string]interface{}{
+							"run_for":    "10m",
+							"exit_after": "10m",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, _, err := client.Jobs().Register(job, nil)
+	require.Nil(err)
+
+	testutil.WaitForResult(func() (bool, error) {
+		allocs, _, err := client.Nodes().Allocations(nodeID, nil)
+		if err != nil {
+			return false, err
+		}
+		return len(allocs) > 0, fmt.Errorf("no allocs")
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	ui := new(cli.MockUi)
+	cmd := &NodeDrainCommand{Meta: Meta{Ui: ui}}
+	if code := cmd.Run([]string{"-address=" + url, "-self", "-enable", "-detach"}); code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+
+	out := ui.OutputWriter.String()
+	expected := "drain strategy set"
+	require.Contains(out, expected)
+
+	node, _, err := client.Nodes().Info(nodeID, nil)
+	require.Nil(err)
+	require.NotNil(node.DrainStrategy)
+}
+
+func TestNodeDrainCommand_Monitor(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	server, client, url := testServer(t, true, func(c *agent.Config) {
+		c.NodeName = "drain_monitor_node"
+	})
+	defer server.Shutdown()
+
+	// Wait for a node to appear
+	var nodeID string
+	testutil.WaitForResult(func() (bool, error) {
+		nodes, _, err := client.Nodes().List(nil)
+		if err != nil {
+			return false, err
+		}
+		if len(nodes) == 0 {
+			return false, fmt.Errorf("missing node")
+		}
+		nodeID = nodes[0].ID
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+
+	// Register a job to create an alloc to drain
+	count := 3
+	job := &api.Job{
+		ID:          helper.StringToPtr("mock_service"),
+		Name:        helper.StringToPtr("mock_service"),
+		Datacenters: []string{"dc1"},
+		TaskGroups: []*api.TaskGroup{
+			{
+				Name:  helper.StringToPtr("mock_group"),
+				Count: &count,
+				Migrate: &api.MigrateStrategy{
+					MaxParallel:     helper.IntToPtr(1),
+					HealthCheck:     helper.StringToPtr("task_states"),
+					MinHealthyTime:  helper.TimeToPtr(10 * time.Millisecond),
+					HealthyDeadline: helper.TimeToPtr(5 * time.Minute),
+				},
+				Tasks: []*api.Task{
+					{
+						Name:   "mock_task",
+						Driver: "mock_driver",
+						Config: map[string]interface{}{
+							"run_for": "10m",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, _, err := client.Jobs().Register(job, nil)
+	require.Nil(err)
+
+	var allocs []*api.Allocation
+	testutil.WaitForResult(func() (bool, error) {
+		allocs, _, err = client.Nodes().Allocations(nodeID, nil)
+		if err != nil {
+			return false, err
+		}
+		if len(allocs) != count {
+			return false, fmt.Errorf("number of allocs %d != count (%d)", len(allocs), count)
+		}
+		for _, a := range allocs {
+			if a.ClientStatus != "running" {
+				return false, fmt.Errorf("alloc %q still not running: %s", a.ID, a.ClientStatus)
+			}
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	ui := new(cli.MockUi)
+	cmd := &NodeDrainCommand{Meta: Meta{Ui: ui}}
+	args := []string{"-address=" + url, "-self", "-enable", "-deadline", "1s"}
+	t.Logf("Running: %v", args)
+	if code := cmd.Run(args); code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+
+	out := ui.OutputWriter.String()
+	t.Logf("Output:\n%s", out)
+
+	require.Contains(out, "drain complete")
+	for _, a := range allocs {
+		require.Contains(out, fmt.Sprintf("Alloc %q draining", a.ID))
+	}
 }
 
 func TestNodeDrainCommand_Fails(t *testing.T) {

--- a/command/node_drain_test.go
+++ b/command/node_drain_test.go
@@ -183,6 +183,7 @@ func TestNodeDrainCommand_Monitor(t *testing.T) {
 
 	require.Contains(out, "drain complete")
 	for _, a := range allocs {
+		require.Contains(out, fmt.Sprintf("Alloc %q marked for migration", a.ID))
 		require.Contains(out, fmt.Sprintf("Alloc %q draining", a.ID))
 	}
 }

--- a/command/node_eligibility_test.go
+++ b/command/node_eligibility_test.go
@@ -37,8 +37,9 @@ func TestNodeEligibilityCommand_Fails(t *testing.T) {
 	if code := cmd.Run([]string{"-address=nope", "-enable", "12345678-abcd-efab-cdef-123456789abc"}); code != 1 {
 		t.Fatalf("expected exit code 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error toggling") {
-		t.Fatalf("expected failed toggle error, got: %s", out)
+	expected := "Error updating scheduling eligibility"
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, expected) {
+		t.Fatalf("expected %q, got: %s", expected, out)
 	}
 	ui.ErrorWriter.Reset()
 


### PR DESCRIPTION
Output from 5c4ffd4:

```
                Node "274a087e-9bbb-8f84-b415-7d607d364ef6" drain strategy set
                Alloc "2de59faf-f100-fb4f-0732-6fe17acbba9b" marked for migration
                Alloc "2de59faf-f100-fb4f-0732-6fe17acbba9b" draining
                Alloc "2de59faf-f100-fb4f-0732-6fe17acbba9b" status running -> complete
                Alloc "5453a2a3-dbd2-cac3-5927-bf98cac33447" marked for migration
                Alloc "ecc4720b-1736-4a95-3ab6-f7b77d209bf3" marked for migration
                Alloc "5453a2a3-dbd2-cac3-5927-bf98cac33447" draining
                Alloc "ecc4720b-1736-4a95-3ab6-f7b77d209bf3" draining
                Alloc "5453a2a3-dbd2-cac3-5927-bf98cac33447" status running -> complete
                Alloc "ecc4720b-1736-4a95-3ab6-f7b77d209bf3" status running -> complete
                Node "274a087e-9bbb-8f84-b415-7d607d364ef6" drain complete
```

Original output from 8b7b42c:

```
Node "41b74037-5310-ad9f-a368-3bcc78fb723f" drain strategy set
Alloc "114e6f07-60a6-bd43-8967-a1822174def5" draining
Alloc "114e6f07-60a6-bd43-8967-a1822174def5" status running -> complete
Alloc "39f14533-ec8c-654c-f719-d265e5385eff" draining
Alloc "4d5c1f00-7662-a2fa-54db-73812370989d" draining
Node "41b74037-5310-ad9f-a368-3bcc78fb723f" drain complete
```