### PR TITLE
Node drain orchestrator

### DIFF
--- a/nomad/drainer_int_test.go
+++ b/nomad/drainer_int_test.go
@@ -1,0 +1,188 @@
+package nomad
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/rpc"
+	"testing"
+	"time"
+
+	memdb "github.com/hashicorp/go-memdb"
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func allocPromoter(t *testing.T, ctx context.Context,
+	state *state.StateStore, codec rpc.ClientCodec, nodeID string,
+	logger *log.Logger) {
+	t.Helper()
+
+	nindex := uint64(1)
+	for {
+		allocs, index, err := getNodeAllocs(ctx, state, nodeID, nindex)
+		if err != nil {
+			if err == context.Canceled {
+				return
+			}
+
+			t.Fatalf("failed to get node allocs: %v", err)
+		}
+		nindex = index
+
+		// For each alloc that doesn't have its deployment status set, set it
+		var updates []*structs.Allocation
+		for _, alloc := range allocs {
+			if alloc.DeploymentStatus != nil && alloc.DeploymentStatus.Healthy != nil {
+				continue
+			}
+
+			newAlloc := alloc.Copy()
+			newAlloc.DeploymentStatus = &structs.AllocDeploymentStatus{
+				Healthy: helper.BoolToPtr(true),
+			}
+			updates = append(updates, newAlloc)
+			logger.Printf("Marked deployment health for alloc %q", alloc.ID)
+		}
+
+		if len(updates) == 0 {
+			continue
+		}
+
+		// Send the update
+		req := &structs.AllocUpdateRequest{
+			Alloc:        updates,
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		var resp structs.NodeAllocsResponse
+		require.Nil(t, msgpackrpc.CallWithCodec(codec, "Node.UpdateAlloc", req, &resp))
+	}
+}
+
+func getNodeAllocs(ctx context.Context, state *state.StateStore, nodeID string, index uint64) ([]*structs.Allocation, uint64, error) {
+	resp, index, err := state.BlockingQuery(getNodeAllocsImpl(nodeID), index, ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	return resp.([]*structs.Allocation), index, nil
+}
+
+func getNodeAllocsImpl(nodeID string) func(ws memdb.WatchSet, state *state.StateStore) (interface{}, uint64, error) {
+	return func(ws memdb.WatchSet, state *state.StateStore) (interface{}, uint64, error) {
+		// Capture all the allocations
+		allocs, err := state.AllocsByNode(ws, nodeID)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		// Use the last index that affected the jobs table
+		index, err := state.Index("allocs")
+		if err != nil {
+			return nil, index, err
+		}
+
+		return allocs, index, nil
+	}
+}
+
+func TestDrainer_Simple_ServiceOnly(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	s1 := TestServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create two nodes
+	n1, n2 := mock.Node(), mock.Node()
+	nodeReg := &structs.NodeRegisterRequest{
+		Node:         n1,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var nodeResp structs.NodeUpdateResponse
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Node.Register", nodeReg, &nodeResp))
+
+	// Create a job that runs on just one
+	job := mock.Job()
+	job.TaskGroups[0].Count = 2
+	req := &structs.JobRegisterRequest{
+		Job: job,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	var resp structs.JobRegisterResponse
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
+	require.NotZero(resp.Index)
+
+	// Wait for the two allocations to be placed
+	state := s1.State()
+	testutil.WaitForResult(func() (bool, error) {
+		allocs, err := state.AllocsByJob(nil, job.Namespace, job.ID, false)
+		if err != nil {
+			return false, err
+		}
+		return len(allocs) == 2, fmt.Errorf("got %d allocs", len(allocs))
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Create the second node
+	nodeReg = &structs.NodeRegisterRequest{
+		Node:         n2,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Node.Register", nodeReg, &nodeResp))
+
+	// Drain the first node
+	drainReq := &structs.NodeUpdateDrainRequest{
+		NodeID: n1.ID,
+		DrainStrategy: &structs.DrainStrategy{
+			DrainSpec: structs.DrainSpec{
+				Deadline: 10 * time.Minute,
+			},
+		},
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var drainResp structs.NodeDrainUpdateResponse
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Node.UpdateDrain", drainReq, &drainResp))
+
+	// Wait for the allocs to be replaced
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go allocPromoter(t, ctx, state, codec, n1.ID, s1.logger)
+	go allocPromoter(t, ctx, state, codec, n2.ID, s1.logger)
+
+	testutil.WaitForResult(func() (bool, error) {
+		allocs, err := state.AllocsByNode(nil, n2.ID)
+		if err != nil {
+			return false, err
+		}
+		return len(allocs) == 2, fmt.Errorf("got %d allocs", len(allocs))
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Check that the node drain is removed
+	testutil.WaitForResult(func() (bool, error) {
+		node, err := state.NodeByID(nil, n1.ID)
+		if err != nil {
+			return false, err
+		}
+		return node.DrainStrategy == nil, fmt.Errorf("has drain strategy still set")
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+}

--- a/nomad/drainer_shims.go
+++ b/nomad/drainer_shims.go
@@ -8,38 +8,36 @@ type drainerShim struct {
 	s *Server
 }
 
-func (d drainerShim) NodeDrainComplete(nodeID string) error {
+func (d drainerShim) NodeDrainComplete(nodeID string) (uint64, error) {
 	args := &structs.NodeUpdateDrainRequest{
 		NodeID:       nodeID,
 		Drain:        false,
 		WriteRequest: structs.WriteRequest{Region: d.s.config.Region},
 	}
 
-	resp, _, err := d.s.raftApply(structs.NodeUpdateDrainRequestType, args)
-	return d.convertApplyErrors(resp, err)
+	resp, index, err := d.s.raftApply(structs.NodeUpdateDrainRequestType, args)
+	return d.convertApplyErrors(resp, index, err)
 }
 
-func (d drainerShim) AllocUpdateDesiredTransition(allocs map[string]*structs.DesiredTransition, evals []*structs.Evaluation) error {
+func (d drainerShim) AllocUpdateDesiredTransition(allocs map[string]*structs.DesiredTransition, evals []*structs.Evaluation) (uint64, error) {
 	args := &structs.AllocUpdateDesiredTransitionRequest{
 		Allocs:       allocs,
 		Evals:        evals,
 		WriteRequest: structs.WriteRequest{Region: d.s.config.Region},
 	}
-	resp, _, err := d.s.raftApply(structs.AllocUpdateDesiredTransitionRequestType, args)
-	return d.convertApplyErrors(resp, err)
+	resp, index, err := d.s.raftApply(structs.AllocUpdateDesiredTransitionRequestType, args)
+	return d.convertApplyErrors(resp, index, err)
 }
 
 // convertApplyErrors parses the results of a raftApply and returns the index at
 // which it was applied and any error that occurred. Raft Apply returns two
 // separate errors, Raft library errors and user returned errors from the FSM.
 // This helper, joins the errors by inspecting the applyResponse for an error.
-//
-// Similar to deployment watcher's convertApplyErrors
-func (d drainerShim) convertApplyErrors(applyResp interface{}, err error) error {
+func (d drainerShim) convertApplyErrors(applyResp interface{}, index uint64, err error) (uint64, error) {
 	if applyResp != nil {
 		if fsmErr, ok := applyResp.(error); ok && fsmErr != nil {
-			return fsmErr
+			return index, fsmErr
 		}
 	}
-	return err
+	return index, err
 }

--- a/nomad/drainerv2/drain_heap.go
+++ b/nomad/drainerv2/drain_heap.go
@@ -1,20 +1,173 @@
 package drainerv2
 
 import (
+	"context"
+	"sync"
 	"time"
-
-	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+// DrainDeadlineNotifier allows batch notification of nodes that have reached
+// their drain deadline.
 type DrainDeadlineNotifier interface {
-	NextBatch() <-chan []*structs.Node
+	// NextBatch returns the next batch of nodes that have reached their
+	// deadline.
+	NextBatch() <-chan []string
+
+	// Remove removes the given node from being tracked for a deadline.
 	Remove(nodeID string)
+
+	// Watch marks the given node for being watched for its deadline.
 	Watch(nodeID string, deadline time.Time)
 }
 
+// TODO Make any of what I just wrote true :) Initially it is just a simple
+// implementation.
+
+// deadlineHeap implements the DrainDeadlineNotifier and is backed by a min-heap
+// to efficiently determine the next deadlining node. It also supports
+// coalescing several deadlines into a single emission.
 type deadlineHeap struct {
+	ctx            context.Context
+	coalesceWindow time.Duration
+	batch          chan []string
+	nodes          map[string]time.Time
+	trigger        chan string
+	l              sync.RWMutex
 }
 
-func (d *deadlineHeap) NextBatch() <-chan []structs.Node        { return nil }
-func (d *deadlineHeap) Remove(nodeID string)                    {}
-func (d *deadlineHeap) Watch(nodeID string, deadline time.Time) {}
+// NewDeadlineHeap returns a new deadline heap that coalesces for the given
+// duration and will stop watching when the passed context is cancelled.
+func NewDeadlineHeap(ctx context.Context, coalesceWindow time.Duration) *deadlineHeap {
+	d := &deadlineHeap{
+		ctx:            ctx,
+		coalesceWindow: coalesceWindow,
+		batch:          make(chan []string, 4),
+		nodes:          make(map[string]time.Time, 64),
+		trigger:        make(chan string, 4),
+	}
+
+	go d.watch()
+	return d
+}
+
+func (d *deadlineHeap) watch() {
+	timer := time.NewTimer(0 * time.Millisecond)
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+
+	var nextDeadline time.Time
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-timer.C:
+			if nextDeadline.IsZero() {
+				continue
+			}
+
+			d.l.Lock()
+			var batch []string
+			for nodeID, nodeDeadline := range d.nodes {
+				if !nodeDeadline.After(nextDeadline) {
+					batch = append(batch, nodeID)
+				}
+			}
+
+			// If there is nothing exit early
+			if len(batch) == 0 {
+				d.l.Unlock()
+				goto CALC
+			}
+
+			// Send the batch
+			select {
+			case d.batch <- batch:
+			case <-d.ctx.Done():
+				d.l.Unlock()
+				return
+			}
+
+			// Clean up the nodes
+			for _, nodeID := range batch {
+				delete(d.nodes, nodeID)
+			}
+			d.l.Unlock()
+		case <-d.trigger:
+		}
+
+	CALC:
+		deadline, ok := d.calculateNextDeadline()
+		if !ok {
+			continue
+		}
+
+		if !deadline.Equal(nextDeadline) {
+			timer.Reset(deadline.Sub(time.Now()))
+			nextDeadline = deadline
+		}
+	}
+}
+
+// calculateNextDeadline returns the next deadline in which to scan for
+// deadlined nodes. It applies the coalesce window.
+func (d *deadlineHeap) calculateNextDeadline() (time.Time, bool) {
+	d.l.Lock()
+	defer d.l.Unlock()
+
+	if len(d.nodes) == 0 {
+		return time.Time{}, false
+	}
+
+	// Calculate the new timer value
+	var deadline time.Time
+	for _, v := range d.nodes {
+		if deadline.IsZero() || v.Before(deadline) {
+			deadline = v
+		}
+	}
+
+	var maxWithinWindow time.Time
+	coalescedDeadline := deadline.Add(d.coalesceWindow)
+	for _, nodeDeadline := range d.nodes {
+		if nodeDeadline.Before(coalescedDeadline) {
+			if maxWithinWindow.IsZero() || nodeDeadline.After(maxWithinWindow) {
+				maxWithinWindow = nodeDeadline
+			}
+		}
+	}
+
+	return maxWithinWindow, true
+}
+
+// NextBatch returns the next batch of nodes to be drained.
+func (d *deadlineHeap) NextBatch() <-chan []string {
+	return d.batch
+}
+
+func (d *deadlineHeap) Remove(nodeID string) {
+	d.l.Lock()
+	defer d.l.Unlock()
+	delete(d.nodes, nodeID)
+
+	select {
+	case d.trigger <- nodeID:
+	default:
+	}
+}
+
+func (d *deadlineHeap) Watch(nodeID string, deadline time.Time) {
+	d.l.Lock()
+	defer d.l.Unlock()
+	d.nodes[nodeID] = deadline
+
+	select {
+	case d.trigger <- nodeID:
+	default:
+	}
+}

--- a/nomad/drainerv2/drain_heap.go
+++ b/nomad/drainerv2/drain_heap.go
@@ -1,0 +1,20 @@
+package drainerv2
+
+import (
+	"time"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type DrainDeadlineNotifier interface {
+	NextBatch() <-chan []*structs.Node
+	Remove(nodeID string)
+	Watch(nodeID string, deadline time.Time)
+}
+
+type deadlineHeap struct {
+}
+
+func (d *deadlineHeap) NextBatch() <-chan []structs.Node        { return nil }
+func (d *deadlineHeap) Remove(nodeID string)                    {}
+func (d *deadlineHeap) Watch(nodeID string, deadline time.Time) {}

--- a/nomad/drainerv2/drain_heap_test.go
+++ b/nomad/drainerv2/drain_heap_test.go
@@ -1,0 +1,149 @@
+package drainerv2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeadlineHeap_Interface(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	h := NewDeadlineHeap(context.Background(), 1*time.Second)
+	require.Implements((*DrainDeadlineNotifier)(nil), h)
+}
+
+func TestDeadlineHeap_WatchAndGet(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	h := NewDeadlineHeap(context.Background(), 1*time.Second)
+
+	now := time.Now()
+	nodeID := "1"
+	wait := 10 * time.Millisecond
+	deadline := now.Add(wait)
+	h.Watch(nodeID, deadline)
+
+	var batch []string
+	select {
+	case batch = <-h.NextBatch():
+	case <-time.After(2 * wait):
+		t.Fatal("timeout")
+	}
+
+	require.Len(batch, 1)
+	require.Equal(nodeID, batch[0])
+}
+
+func TestDeadlineHeap_WatchThenUpdateAndGet(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	h := NewDeadlineHeap(context.Background(), 1*time.Second)
+
+	now := time.Now()
+	nodeID := "1"
+	wait := 10 * time.Millisecond
+	deadline := now.Add(wait)
+
+	// Initially watch way in the future
+	h.Watch(nodeID, now.Add(24*time.Hour))
+
+	// Rewatch
+	h.Watch(nodeID, deadline)
+
+	var batch []string
+	select {
+	case batch = <-h.NextBatch():
+	case <-time.After(2 * wait):
+		t.Fatal("timeout")
+	}
+
+	require.Len(batch, 1)
+	require.Equal(nodeID, batch[0])
+}
+
+func TestDeadlineHeap_MultiwatchAndDelete(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	h := NewDeadlineHeap(context.Background(), 1*time.Second)
+
+	now := time.Now()
+	wait := 50 * time.Millisecond
+	deadline := now.Add(wait)
+
+	nodeID1 := "1"
+	nodeID2 := "2"
+	h.Watch(nodeID1, deadline)
+	h.Watch(nodeID2, deadline)
+
+	time.Sleep(1 * time.Millisecond)
+	h.Remove(nodeID2)
+
+	var batch []string
+	select {
+	case batch = <-h.NextBatch():
+	case <-time.After(2 * wait):
+		t.Fatal("timeout")
+	}
+
+	require.Len(batch, 1)
+	require.Equal(nodeID1, batch[0])
+}
+
+func TestDeadlineHeap_WatchCoalesce(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	h := NewDeadlineHeap(context.Background(), 250*time.Millisecond)
+
+	now := time.Now()
+
+	group1 := map[string]time.Time{
+		"1": now.Add(5 * time.Millisecond),
+		"2": now.Add(10 * time.Millisecond),
+		"3": now.Add(20 * time.Millisecond),
+		"4": now.Add(100 * time.Millisecond),
+	}
+
+	group2 := map[string]time.Time{
+		"10": now.Add(355 * time.Millisecond),
+		"11": now.Add(360 * time.Millisecond),
+	}
+
+	for _, g := range []map[string]time.Time{group1, group2} {
+		for n, d := range g {
+			h.Watch(n, d)
+		}
+	}
+
+	var batch []string
+	select {
+	case batch = <-h.NextBatch():
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	require.Len(batch, len(group1))
+	for nodeID := range group1 {
+		require.Contains(batch, nodeID)
+	}
+	batch = nil
+
+	select {
+	case batch = <-h.NextBatch():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	require.Len(batch, len(group2))
+	for nodeID := range group2 {
+		require.Contains(batch, nodeID)
+	}
+
+	select {
+	case <-h.NextBatch():
+		t.Fatal("unexpected batch")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/nomad/drainerv2/drain_interfaces.go
+++ b/nomad/drainerv2/drain_interfaces.go
@@ -1,0 +1,1 @@
+package drainerv2

--- a/nomad/drainerv2/drain_interfaces.go
+++ b/nomad/drainerv2/drain_interfaces.go
@@ -1,1 +1,0 @@
-package drainerv2

--- a/nomad/drainerv2/drain_testing.go
+++ b/nomad/drainerv2/drain_testing.go
@@ -1,0 +1,46 @@
+package drainerv2
+
+import (
+	"sync"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type MockNodeTrackerEvent struct {
+	NodeUpdate *structs.Node
+	NodeRemove string
+}
+
+type MockNodeTracker struct {
+	Nodes  map[string]*structs.Node
+	Events []*MockNodeTrackerEvent
+	sync.Mutex
+}
+
+func NewMockNodeTracker() *MockNodeTracker {
+	return &MockNodeTracker{
+		Nodes:  make(map[string]*structs.Node),
+		Events: make([]*MockNodeTrackerEvent, 0, 16),
+	}
+}
+
+func (m *MockNodeTracker) Tracking(nodeID string) (*structs.Node, bool) {
+	m.Lock()
+	defer m.Unlock()
+	n, ok := m.Nodes[nodeID]
+	return n, ok
+}
+
+func (m *MockNodeTracker) Remove(nodeID string) {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.Nodes, nodeID)
+	m.Events = append(m.Events, &MockNodeTrackerEvent{NodeRemove: nodeID})
+}
+
+func (m *MockNodeTracker) Update(node *structs.Node) {
+	m.Lock()
+	defer m.Unlock()
+	m.Nodes[node.ID] = node
+	m.Events = append(m.Events, &MockNodeTrackerEvent{NodeUpdate: node})
+}

--- a/nomad/drainerv2/drain_testing.go
+++ b/nomad/drainerv2/drain_testing.go
@@ -24,11 +24,10 @@ func NewMockNodeTracker() *MockNodeTracker {
 	}
 }
 
-func (m *MockNodeTracker) Tracking(nodeID string) (*structs.Node, bool) {
+func (m *MockNodeTracker) TrackedNodes() map[string]*structs.Node {
 	m.Lock()
 	defer m.Unlock()
-	n, ok := m.Nodes[nodeID]
-	return n, ok
+	return m.Nodes
 }
 
 func (m *MockNodeTracker) Remove(nodeID string) {

--- a/nomad/drainerv2/drainer.go
+++ b/nomad/drainerv2/drainer.go
@@ -159,7 +159,7 @@ func (n *NodeDrainer) SetEnabled(enabled bool, state *state.StateStore) {
 
 	// If we are starting now, launch the watch daemon
 	if enabled && !wasEnabled {
-		n.run(n.ctx)
+		go n.run(n.ctx)
 	}
 }
 

--- a/nomad/drainerv2/drainer.go
+++ b/nomad/drainerv2/drainer.go
@@ -124,7 +124,7 @@ type NodeDrainer struct {
 	// nodes is the set of draining nodes
 	nodes map[string]*drainingNode
 
-	// nodeWatcher watches for nodes to transistion in and out of drain state.
+	// nodeWatcher watches for nodes to transition in and out of drain state.
 	nodeWatcher DrainingNodeWatcher
 	nodeFactory DrainingNodeWatcherFactory
 
@@ -158,7 +158,7 @@ type NodeDrainer struct {
 
 // NewNodeDrainer returns a new new node drainer. The node drainer is
 // responsible for marking allocations on draining nodes with a desired
-// migration transistion, updating the drain strategy on nodes when they are
+// migration transition, updating the drain strategy on nodes when they are
 // complete and creating evaluations for the system to react to these changes.
 func NewNodeDrainer(c *NodeDrainerConfig) *NodeDrainer {
 	return &NodeDrainer{
@@ -254,10 +254,9 @@ func (n *NodeDrainer) handleDeadlinedNodes(nodes []string) {
 }
 
 // handleJobAllocDrain handles marking a set of allocations as having a desired
-// transistion to drain. The handler blocks till the changes to the allocation
-// have occured.
+// transition to drain. The handler blocks till the changes to the allocation
+// have occurred.
 func (n *NodeDrainer) handleJobAllocDrain(req *DrainRequest) {
-	// This should be syncronous
 	index, err := n.batchDrainAllocs(req.Allocs)
 	req.Resp.Respond(index, err)
 }
@@ -342,17 +341,17 @@ func (n *NodeDrainer) batchDrainAllocs(allocs []*structs.Allocation) (uint64, er
 	return future.Index(), nil
 }
 
-// drainAllocs is a non batch, marking of the desired transistion to migrate for
+// drainAllocs is a non batch, marking of the desired transition to migrate for
 // the set of allocations. It will also create the necessary evaluations for the
 // affected jobs.
 func (n *NodeDrainer) drainAllocs(future *structs.BatchFuture, allocs []*structs.Allocation) {
 	// TODO(alex) This should shard to limit the size of the transaction.
 
-	// Compute the effected jobs and make the transistion map
+	// Compute the effected jobs and make the transition map
 	jobs := make(map[string]*structs.Allocation, 4)
-	transistions := make(map[string]*structs.DesiredTransition, len(allocs))
+	transitions := make(map[string]*structs.DesiredTransition, len(allocs))
 	for _, alloc := range allocs {
-		transistions[alloc.ID] = &structs.DesiredTransition{
+		transitions[alloc.ID] = &structs.DesiredTransition{
 			Migrate: helper.BoolToPtr(true),
 		}
 		jobs[alloc.JobID] = alloc
@@ -372,6 +371,6 @@ func (n *NodeDrainer) drainAllocs(future *structs.BatchFuture, allocs []*structs
 	}
 
 	// Commit this update via Raft
-	index, err := n.raft.AllocUpdateDesiredTransition(transistions, evals)
+	index, err := n.raft.AllocUpdateDesiredTransition(transitions, evals)
 	future.Respond(index, err)
 }

--- a/nomad/drainerv2/drainer.go
+++ b/nomad/drainerv2/drainer.go
@@ -1,0 +1,167 @@
+package drainerv2
+
+import (
+	"context"
+	"log"
+	"sync"
+
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"golang.org/x/time/rate"
+)
+
+const (
+	// LimitStateQueriesPerSecond is the number of state queries allowed per
+	// second
+	LimitStateQueriesPerSecond = 100.0
+)
+
+// RaftApplier contains methods for applying the raft requests required by the
+// NodeDrainer.
+type RaftApplier interface {
+	AllocUpdateDesiredTransition(allocs map[string]*structs.DesiredTransition, evals []*structs.Evaluation) error
+	NodeDrainComplete(nodeID string) error
+}
+
+type AllocDrainer interface {
+	drain(allocs []*structs.Allocation)
+}
+
+type DrainingJobWatcherFactory func(context.Context, *rate.Limiter, AllocDrainer) DrainingJobWatcher
+type DrainingNodeWatcherFactory func(context.Context, *rate.Limiter, AllocDrainer) DrainingNodeWatcher
+type DrainDeadlineNotifierFactory func(context.Context) DrainDeadlineNotifier
+
+type NodeDrainerConfig struct {
+	Logger                *log.Logger
+	Raft                  RaftApplier
+	JobFactory            DrainingJobWatcherFactory
+	NodeFactory           DrainingNodeWatcherFactory
+	DrainDeadlineFactory  DrainDeadlineNotifierFactory
+	StateQueriesPerSecond float64
+}
+
+type NodeDrainer struct {
+	enabled bool
+	logger  *log.Logger
+
+	// nodes is the set of draining nodes
+	nodes map[string]*drainingNode
+
+	// doneNodeCh is used to signal that a node is done draining
+	doneNodeCh chan string
+
+	nodeWatcher DrainingNodeWatcher
+	nodeFactory DrainingNodeWatcherFactory
+
+	jobWatcher DrainingJobWatcher
+	jobFactory DrainingJobWatcherFactory
+
+	deadlineNotifier        DrainDeadlineNotifier
+	deadlineNotifierFactory DrainDeadlineNotifierFactory
+
+	// state is the state that is watched for state changes.
+	state *state.StateStore
+
+	// queryLimiter is used to limit the rate of blocking queries
+	queryLimiter *rate.Limiter
+
+	// raft is a shim around the raft messages necessary for draining
+	raft RaftApplier
+
+	// ctx and exitFn are used to cancel the watcher
+	ctx    context.Context
+	exitFn context.CancelFunc
+
+	l sync.RWMutex
+}
+
+func NewNodeDrainer(c *NodeDrainerConfig) *NodeDrainer {
+	return &NodeDrainer{
+		raft:                    c.Raft,
+		logger:                  c.Logger,
+		jobFactory:              c.JobFactory,
+		nodeFactory:             c.NodeFactory,
+		deadlineNotifierFactory: c.DrainDeadlineFactory,
+		queryLimiter:            rate.NewLimiter(rate.Limit(c.StateQueriesPerSecond), 100),
+	}
+}
+
+// SetEnabled will start or stop the node draining goroutine depending on the
+// enabled boolean.
+func (n *NodeDrainer) SetEnabled(enabled bool, state *state.StateStore) {
+	n.l.Lock()
+	defer n.l.Unlock()
+
+	wasEnabled := n.enabled
+	n.enabled = enabled
+
+	if state != nil {
+		n.state = state
+	}
+
+	// Flush the state to create the necessary objects
+	n.flush()
+
+	// If we are starting now, launch the watch daemon
+	if enabled && !wasEnabled {
+		n.run(n.ctx)
+	}
+}
+
+// flush is used to clear the state of the watcher
+func (n *NodeDrainer) flush() {
+	// Kill everything associated with the watcher
+	if n.exitFn != nil {
+		n.exitFn()
+	}
+
+	n.ctx, n.exitFn = context.WithCancel(context.Background())
+	n.jobWatcher = n.jobFactory(n.ctx, n.queryLimiter, n)
+	n.nodeWatcher = n.nodeFactory(n.ctx, n.queryLimiter, n)
+	n.deadlineNotifier = n.deadlineNotifierFactory(n.ctx)
+	n.nodes = make(map[string]*drainingNode, 32)
+	n.doneNodeCh = make(chan string, 4)
+}
+
+func (n *NodeDrainer) run(ctx context.Context) {
+	for {
+		select {
+		case <-n.ctx.Done():
+			return
+		case nodes := <-n.deadlineNotifier.NextBatch():
+			n.handleDeadlinedNodes(nodes)
+		case nodes := <-n.nodeWatcher.Transistioning():
+			n.handleNodeDrainTransistion(nodes)
+		case allocs := <-n.jobWatcher.Drain():
+			n.handleJobAllocDrain(allocs)
+		case node := <-n.doneNodeCh:
+			n.handleDoneNode(node)
+		}
+	}
+}
+
+func (n *NodeDrainer) handleDeadlinedNodes(nodes []*structs.Node) {
+	// TODO
+}
+
+func (n *NodeDrainer) handleNodeDrainTransistion(nodes []*structs.Node) {
+	// TODO
+}
+
+func (n *NodeDrainer) handleJobAllocDrain(allocs []*structs.Allocation) {
+	// TODO
+
+	// TODO Call check on the appropriate nodes when the final allocs
+	// transistion to stop so we have a place to determine with the node
+	// is done and the final drain of system allocs
+	// TODO This probably requires changing the interface such that it
+	// returns replaced allocs as well.
+}
+
+func (n *NodeDrainer) handleDoneNode(nodeID string) {
+	// TODO
+}
+
+func (n *NodeDrainer) drain(allocs []*structs.Allocation) {
+	// TODO
+}

--- a/nomad/drainerv2/drainer.go
+++ b/nomad/drainerv2/drainer.go
@@ -140,7 +140,7 @@ func (n *NodeDrainer) run(ctx context.Context) {
 	}
 }
 
-func (n *NodeDrainer) handleDeadlinedNodes(nodes []*structs.Node) {
+func (n *NodeDrainer) handleDeadlinedNodes(nodes []string) {
 	// TODO
 }
 

--- a/nomad/drainerv2/draining_node.go
+++ b/nomad/drainerv2/draining_node.go
@@ -81,6 +81,7 @@ func (n *drainingNode) IsDone() (bool, error) {
 	return true, nil
 }
 
+// TODO test that we return the right thing given the strategies
 // DeadlineAllocs returns the set of allocations that should be drained given a
 // node is at its deadline
 func (n *drainingNode) DeadlineAllocs() ([]*structs.Allocation, error) {

--- a/nomad/drainerv2/draining_node.go
+++ b/nomad/drainerv2/draining_node.go
@@ -1,0 +1,65 @@
+package drainerv2
+
+import (
+	"sync"
+	"time"
+
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// TODO make this an interface and then I can optimize the infinite case by
+// using a singleton object
+
+type drainCoordinator interface {
+	done(nodeID string)
+}
+
+func (n *NodeDrainer) nodeDone(nodeID string) {
+	select {
+	case <-n.ctx.Done():
+	case n.doneNodeCh <- nodeID:
+	}
+}
+
+type drainingNode struct {
+	coordinator drainCoordinator
+	state       *state.StateStore
+	node        *structs.Node
+	l           sync.RWMutex
+}
+
+func NewDrainingNode(node *structs.Node, state *state.StateStore, coordinator drainCoordinator) *drainingNode {
+	return &drainingNode{
+		coordinator: coordinator,
+		state:       state,
+		node:        node,
+	}
+}
+
+func (n *drainingNode) Update(node *structs.Node) {
+	n.l.Lock()
+	defer n.l.Unlock()
+	n.node = node
+}
+
+// DeadlineTime returns if the node has a deadline and if so what it is
+func (n *drainingNode) DeadlineTime() (bool, time.Time) {
+	n.l.RLock()
+	defer n.l.RUnlock()
+
+	// Should never happen
+	if n.node == nil || n.node.DrainStrategy == nil {
+		return false, time.Time{}
+	}
+
+	return n.node.DrainStrategy.DeadlineTime()
+}
+
+// DeadlineAllocs returns the set of allocations that should be drained given a
+// node is at its deadline
+func (n *drainingNode) DeadlineAllocs() ([]*structs.Allocation, error) {
+	n.l.RLock()
+	defer n.l.RUnlock()
+	return nil, nil
+}

--- a/nomad/drainerv2/draining_node.go
+++ b/nomad/drainerv2/draining_node.go
@@ -12,7 +12,7 @@ import (
 // using a singleton object
 
 type drainCoordinator interface {
-	done(nodeID string)
+	nodeDone(nodeID string)
 }
 
 func (n *NodeDrainer) nodeDone(nodeID string) {
@@ -35,6 +35,12 @@ func NewDrainingNode(node *structs.Node, state *state.StateStore, coordinator dr
 		state:       state,
 		node:        node,
 	}
+}
+
+func (n *drainingNode) GetNode() *structs.Node {
+	n.l.Lock()
+	defer n.l.Unlock()
+	return n.node
 }
 
 func (n *drainingNode) Update(node *structs.Node) {

--- a/nomad/drainerv2/watch_jobs.go
+++ b/nomad/drainerv2/watch_jobs.go
@@ -1,8 +1,417 @@
 package drainerv2
 
-import "github.com/hashicorp/nomad/nomad/structs"
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
 
+	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"golang.org/x/time/rate"
+)
+
+// DrainingJobWatcher is the interface for watching a job drain
 type DrainingJobWatcher interface {
+	// RegisterJob is used to start watching a draining job
 	RegisterJob(jobID, namespace string)
+
+	// TODO This should probably be a drain future such that we can block the
+	// next loop till the raft apply happens such that we don't emit the same
+	// drain many times. We would get the applied index back and block till
+	// then.
+	// Drain is used to emit allocations that should be drained.
 	Drain() <-chan []*structs.Allocation
+
+	// Migrated is allocations for draining jobs that have transistioned to
+	// stop. There is no guarantee that duplicates won't be published.
+	Migrated() <-chan []*structs.Allocation
+}
+
+// drainingJobWatcher is used to watch draining jobs and emit events when
+// draining allocations have replacements
+type drainingJobWatcher struct {
+	ctx    context.Context
+	logger *log.Logger
+
+	// state is the state that is watched for state changes.
+	state *state.StateStore
+
+	// limiter is used to limit the rate of blocking queries
+	limiter *rate.Limiter
+
+	// jobs is the set of tracked jobs.
+	jobs map[structs.JobNs]struct{}
+
+	// queryCtx is used to cancel a blocking query.
+	queryCtx    context.Context
+	queryCancel context.CancelFunc
+
+	// drainCh and migratedCh are used to emit allocations
+	drainCh    chan []*structs.Allocation
+	migratedCh chan []*structs.Allocation
+
+	l sync.RWMutex
+}
+
+// NewDrainingJobWatcher returns a new job watcher. The caller is expected to
+// cancel the context to clean up the drainer.
+func NewDrainingJobWatcher(ctx context.Context, limiter *rate.Limiter, state *state.StateStore, logger *log.Logger) *drainingJobWatcher {
+
+	// Create a context that can cancel the blocking query so that when a new
+	// job gets registered it is handled.
+	queryCtx, queryCancel := context.WithCancel(ctx)
+
+	w := &drainingJobWatcher{
+		ctx:         ctx,
+		queryCtx:    queryCtx,
+		queryCancel: queryCancel,
+		limiter:     limiter,
+		logger:      logger,
+		state:       state,
+		jobs:        make(map[structs.JobNs]struct{}, 64),
+		drainCh:     make(chan []*structs.Allocation, 8),
+		migratedCh:  make(chan []*structs.Allocation, 8),
+	}
+
+	go w.watch()
+	return w
+}
+
+// RegisterJob marks the given job as draining and adds it to being watched.
+func (w *drainingJobWatcher) RegisterJob(jobID, namespace string) {
+	w.l.Lock()
+	defer w.l.Unlock()
+
+	jns := structs.JobNs{
+		ID:        jobID,
+		Namespace: namespace,
+	}
+	if _, ok := w.jobs[jns]; ok {
+		return
+	}
+
+	// Add the job and cancel the context
+	w.jobs[jns] = struct{}{}
+	w.queryCancel()
+
+	// Create a new query context
+	w.queryCtx, w.queryCancel = context.WithCancel(w.ctx)
+}
+
+// Drain returns the channel that emits allocations to drain.
+func (w *drainingJobWatcher) Drain() <-chan []*structs.Allocation {
+	return w.drainCh
+}
+
+// Migrated returns the channel that emits allocations for draining jobs that
+// have been migrated.
+func (w *drainingJobWatcher) Migrated() <-chan []*structs.Allocation {
+	return w.migratedCh
+}
+
+// deregisterJob removes the job from being watched.
+func (w *drainingJobWatcher) deregisterJob(jobID, namespace string) {
+	w.l.Lock()
+	defer w.l.Unlock()
+	jns := structs.JobNs{
+		ID:        jobID,
+		Namespace: namespace,
+	}
+	delete(w.jobs, jns)
+	w.logger.Printf("[TRACE] nomad.drain.job_watcher: deregistering job %v", jns)
+}
+
+// watch is the long lived watching routine that detects job drain changes.
+func (w *drainingJobWatcher) watch() {
+	jindex := uint64(1)
+	for {
+		w.logger.Printf("[TRACE] nomad.drain.job_watcher: getting job allocs at index %d", jindex)
+		jobAllocs, index, err := w.getJobAllocs(w.getQueryCtx(), jindex)
+		if err != nil {
+			if err == context.Canceled {
+				// Determine if it is a cancel or a shutdown
+				select {
+				case <-w.ctx.Done():
+					w.logger.Printf("[TRACE] nomad.drain.job_watcher: shutting down")
+					return
+				default:
+					// The query context was cancelled
+					continue
+				}
+			}
+
+			w.logger.Printf("[ERR] nomad.drain.job_watcher: error watching job allocs updates at index %d: %v", jindex, err)
+			select {
+			case <-w.ctx.Done():
+				w.logger.Printf("[TRACE] nomad.drain.job_watcher: shutting down")
+				return
+			case <-time.After(stateReadErrorDelay):
+				continue
+			}
+		}
+
+		// update index for next run
+		lastHandled := jindex
+		jindex = index
+
+		// Snapshot the state store
+		snap, err := w.state.Snapshot()
+		if err != nil {
+			w.logger.Printf("[WARN] nomad.drain.job_watcher: failed to snapshot statestore: %v", err)
+			continue
+		}
+
+		currentJobs := w.drainingJobs()
+		var allDrain, allMigrated []*structs.Allocation
+		for job, allocs := range jobAllocs {
+			// Check if the job is still registered
+			if _, ok := currentJobs[job]; !ok {
+				continue
+			}
+
+			w.logger.Printf("[TRACE] nomad.drain.job_watcher: handling job %v", job)
+
+			// Lookup the job
+			job, err := w.state.JobByID(nil, job.Namespace, job.ID)
+			if err != nil {
+				w.logger.Printf("[WARN] nomad.drain.job_watcher: failed to lookup job %v: %v", job, err)
+				continue
+			}
+
+			// Ignore all non-service jobs
+			if job.Type != structs.JobTypeService {
+				w.deregisterJob(job.ID, job.Namespace)
+				continue
+			}
+
+			result, err := handleJob(snap, job, allocs, lastHandled)
+			if err != nil {
+				w.logger.Printf("[ERR] nomad.drain.job_watcher: handling drain for job %v failed: %v", job, err)
+				continue
+			}
+
+			allDrain = append(allDrain, result.drain...)
+			allMigrated = append(allMigrated, result.migrated...)
+
+			// Stop tracking this job
+			if result.done {
+				w.deregisterJob(job.ID, job.Namespace)
+			}
+		}
+
+		if allDrain != nil {
+			select {
+			case w.drainCh <- allDrain:
+			case <-w.ctx.Done():
+				w.logger.Printf("[TRACE] nomad.drain.job_watcher: shutting down")
+				return
+			}
+		}
+
+		if allMigrated != nil {
+			select {
+			case w.migratedCh <- allMigrated:
+			case <-w.ctx.Done():
+				w.logger.Printf("[TRACE] nomad.drain.job_watcher: shutting down")
+				return
+			}
+		}
+	}
+}
+
+// jobResult is the set of actions to take for a draining job given its current
+// state.
+type jobResult struct {
+	// drain is the set of allocations to emit for draining.
+	drain []*structs.Allocation
+
+	// migrated is the set of allocations to emit as migrated
+	migrated []*structs.Allocation
+
+	// done marks whether the job has been fully drained.
+	done bool
+}
+
+// newJobResult returns an initialized jobResult
+func newJobResult() *jobResult {
+	return &jobResult{
+		done: true,
+	}
+}
+
+// handleJob takes the state of a draining job and returns the desired actions.
+func handleJob(snap *state.StateSnapshot, job *structs.Job, allocs []*structs.Allocation, lastHandledIndex uint64) (*jobResult, error) {
+	r := newJobResult()
+	taskGroups := make(map[string]*structs.TaskGroup, len(job.TaskGroups))
+	for _, tg := range job.TaskGroups {
+		if tg.Migrate != nil {
+			// TODO handle the upgrade path
+			// Only capture the groups that have a migrate strategy
+			taskGroups[tg.Name] = tg
+		}
+	}
+
+	// Sort the allocations by TG
+	tgAllocs := make(map[string][]*structs.Allocation, len(taskGroups))
+	for _, alloc := range allocs {
+		if _, ok := taskGroups[alloc.TaskGroup]; !ok {
+			continue
+		}
+
+		tgAllocs[alloc.TaskGroup] = append(tgAllocs[alloc.TaskGroup], alloc)
+	}
+
+	for name, tg := range taskGroups {
+		allocs := tgAllocs[name]
+		if err := handleTaskGroup(snap, tg, allocs, lastHandledIndex, r); err != nil {
+			return nil, fmt.Errorf("drain for task group %q failed: %v", name, err)
+		}
+	}
+
+	return r, nil
+}
+
+// handleTaskGroup takes the state of a draining task group and computes the desired actions.
+func handleTaskGroup(snap *state.StateSnapshot, tg *structs.TaskGroup,
+	allocs []*structs.Allocation, lastHandledIndex uint64, result *jobResult) error {
+
+	// Determine how many allocations can be drained
+	drainingNodes := make(map[string]bool, 4)
+	healthy := 0
+	remainingDrainingAlloc := false
+	var drainable []*structs.Allocation
+
+	for _, alloc := range allocs {
+		// Check if the alloc is on a draining node.
+		onDrainingNode, ok := drainingNodes[alloc.NodeID]
+		if !ok {
+			// Look up the node
+			node, err := snap.NodeByID(nil, alloc.NodeID)
+			if err != nil {
+				return err
+			}
+
+			onDrainingNode = node.DrainStrategy != nil
+			drainingNodes[node.ID] = onDrainingNode
+		}
+
+		// Check if the alloc should be considered migrated. A migrated
+		// allocation is one that is terminal, is on a draining
+		// allocation, and has only happened since our last handled index to
+		// avoid emitting many duplicate migrate events.
+		if alloc.TerminalStatus() &&
+			onDrainingNode &&
+			alloc.ModifyIndex > lastHandledIndex {
+			result.migrated = append(result.migrated, alloc)
+			continue
+		}
+
+		// If the alloc is running and has its deployment status set, it is
+		// considered healthy from a migration standpoint.
+		if !alloc.TerminalStatus() &&
+			alloc.DeploymentStatus != nil &&
+			alloc.DeploymentStatus.Healthy != nil {
+			healthy++
+		}
+
+		// An alloc can't be considered for migration if:
+		// - It isn't on a draining node
+		// - It is already terminal
+		// - It has already been marked for draining
+		if !onDrainingNode || alloc.TerminalStatus() || alloc.DesiredTransition.ShouldMigrate() {
+			continue
+		}
+
+		// This alloc is drainable, so capture it and the fact that the job
+		// isn't done draining yet.
+		remainingDrainingAlloc = true
+		drainable = append(drainable, alloc)
+	}
+
+	// Update the done status
+	if remainingDrainingAlloc {
+		result.done = false
+	}
+
+	// Determine how many we can drain
+	thresholdCount := tg.Count - tg.Migrate.MaxParallel
+	numToDrain := healthy - thresholdCount
+	numToDrain = helper.IntMin(len(drainable), numToDrain)
+	if numToDrain <= 0 {
+		return nil
+	}
+
+	result.drain = append(result.drain, drainable[0:numToDrain]...)
+	return nil
+}
+
+// getJobAllocs returns all allocations for draining jobs
+func (w *drainingJobWatcher) getJobAllocs(ctx context.Context, minIndex uint64) (map[structs.JobNs][]*structs.Allocation, uint64, error) {
+	if err := w.limiter.Wait(ctx); err != nil {
+		return nil, 0, err
+	}
+
+	resp, index, err := w.state.BlockingQuery(w.getJobAllocsImpl, minIndex, ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return resp.(map[structs.JobNs][]*structs.Allocation), index, nil
+}
+
+// getJobAllocsImpl returns a map of draining jobs to their allocations.
+func (w *drainingJobWatcher) getJobAllocsImpl(ws memdb.WatchSet, state *state.StateStore) (interface{}, uint64, error) {
+	index, err := state.Index("allocs")
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Capture the draining jobs.
+	draining := w.drainingJobs()
+	l := len(draining)
+	if l == 0 {
+		return nil, index, nil
+	}
+
+	// Capture the allocs for each draining job.
+	resp := make(map[structs.JobNs][]*structs.Allocation, l)
+	for jns := range draining {
+		allocs, err := state.AllocsByJob(ws, jns.Namespace, jns.ID, false)
+		if err != nil {
+			return nil, index, err
+		}
+
+		resp[jns] = allocs
+	}
+
+	return resp, index, nil
+}
+
+// drainingJobs captures the set of draining jobs.
+func (w *drainingJobWatcher) drainingJobs() map[structs.JobNs]struct{} {
+	w.l.RLock()
+	defer w.l.RUnlock()
+
+	l := len(w.jobs)
+	if l == 0 {
+		return nil
+	}
+
+	draining := make(map[structs.JobNs]struct{}, l)
+	for k := range w.jobs {
+		draining[k] = struct{}{}
+	}
+
+	return draining
+}
+
+// getQueryCtx is a helper for getting the query context.
+func (w *drainingJobWatcher) getQueryCtx() context.Context {
+	w.l.RLock()
+	defer w.l.RUnlock()
+	return w.queryCtx
 }

--- a/nomad/drainerv2/watch_jobs.go
+++ b/nomad/drainerv2/watch_jobs.go
@@ -322,6 +322,7 @@ func handleTaskGroup(snap *state.StateSnapshot, tg *structs.TaskGroup,
 	var drainable []*structs.Allocation
 
 	for _, alloc := range allocs {
+		// TODO Remove at the end/when no more bugs
 		fmt.Printf("--- Looking at alloc %q\n", alloc.ID)
 
 		// Check if the alloc is on a draining node.

--- a/nomad/drainerv2/watch_jobs.go
+++ b/nomad/drainerv2/watch_jobs.go
@@ -81,8 +81,8 @@ func NewDrainingJobWatcher(ctx context.Context, limiter *rate.Limiter, state *st
 		logger:      logger,
 		state:       state,
 		jobs:        make(map[structs.JobNs]struct{}, 64),
-		drainCh:     make(chan *DrainRequest, 8),
-		migratedCh:  make(chan []*structs.Allocation, 8),
+		drainCh:     make(chan *DrainRequest),
+		migratedCh:  make(chan []*structs.Allocation),
 	}
 
 	go w.watch()

--- a/nomad/drainerv2/watch_jobs.go
+++ b/nomad/drainerv2/watch_jobs.go
@@ -1,0 +1,8 @@
+package drainerv2
+
+import "github.com/hashicorp/nomad/nomad/structs"
+
+type DrainingJobWatcher interface {
+	RegisterJob(jobID, namespace string)
+	Drain() <-chan []*structs.Allocation
+}

--- a/nomad/drainerv2/watch_jobs.go
+++ b/nomad/drainerv2/watch_jobs.go
@@ -34,7 +34,7 @@ type DrainingJobWatcher interface {
 	// Drain is used to emit allocations that should be drained.
 	Drain() <-chan *DrainRequest
 
-	// Migrated is allocations for draining jobs that have transistioned to
+	// Migrated is allocations for draining jobs that have transitioned to
 	// stop. There is no guarantee that duplicates won't be published.
 	Migrated() <-chan []*structs.Allocation
 }
@@ -224,7 +224,7 @@ func (w *drainingJobWatcher) watch() {
 				return
 			}
 
-			// Wait for the request to be commited
+			// Wait for the request to be committed
 			select {
 			case <-req.Resp.WaitCh():
 			case <-w.ctx.Done():
@@ -234,7 +234,7 @@ func (w *drainingJobWatcher) watch() {
 
 			// See if it successfully committed
 			if err := req.Resp.Error(); err != nil {
-				w.logger.Printf("[ERR] nomad.drain.job_watcher: failed to transistion allocations: %v", err)
+				w.logger.Printf("[ERR] nomad.drain.job_watcher: failed to transition allocations: %v", err)
 			}
 
 			// Wait until the new index

--- a/nomad/drainerv2/watch_jobs_test.go
+++ b/nomad/drainerv2/watch_jobs_test.go
@@ -1,0 +1,372 @@
+package drainerv2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func testDrainingJobWatcher(t *testing.T) (*drainingJobWatcher, *state.StateStore) {
+	t.Helper()
+
+	state := state.TestStateStore(t)
+	limiter := rate.NewLimiter(100.0, 100)
+	logger := testlog.Logger(t)
+	w := NewDrainingJobWatcher(context.Background(), limiter, state, logger)
+	return w, state
+}
+
+func TestDrainingJobWatcher_Interface(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	w, _ := testDrainingJobWatcher(t)
+	require.Implements((*DrainingJobWatcher)(nil), w)
+}
+
+// DrainingJobWatcher tests:
+// TODO Test that several jobs allocation changes get batched
+// TODO Test that jobs are deregistered when they have no more to migrate
+// TODO Test that the watcher gets triggered on alloc changes
+// TODO Test that the watcher cancels its query when a new job is registered
+
+func TestHandleTaskGroup_AllDone(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Create a non-draining node
+	state := state.TestStateStore(t)
+	n := mock.Node()
+	require.Nil(state.UpsertNode(100, n))
+
+	job := mock.Job()
+	require.Nil(state.UpsertJob(101, job))
+
+	// Create 10 running allocs on the healthy node
+	var allocs []*structs.Allocation
+	for i := 0; i < 10; i++ {
+		a := mock.Alloc()
+		a.Job = job
+		a.TaskGroup = job.TaskGroups[0].Name
+		a.NodeID = n.ID
+		a.DeploymentStatus = &structs.AllocDeploymentStatus{
+			Healthy: helper.BoolToPtr(false),
+		}
+		allocs = append(allocs, a)
+	}
+	require.Nil(state.UpsertAllocs(102, allocs))
+
+	snap, err := state.Snapshot()
+	require.Nil(err)
+
+	res := &jobResult{}
+	require.Nil(handleTaskGroup(snap, job.TaskGroups[0], allocs, 101, res))
+	require.Empty(res.drain)
+	require.Empty(res.migrated)
+	require.True(res.done)
+}
+
+func TestHandleTaskGroup_AllOnDrainingNodes(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// The loop value sets the max parallel for the drain strategy
+	for i := 1; i < 8; i++ {
+		// Create a draining node
+		state := state.TestStateStore(t)
+		n := mock.Node()
+		n.DrainStrategy = &structs.DrainStrategy{
+			DrainSpec: structs.DrainSpec{
+				Deadline: 5 * time.Minute,
+			},
+			ForceDeadline: time.Now().Add(1 * time.Minute),
+		}
+		require.Nil(state.UpsertNode(100, n))
+
+		job := mock.Job()
+		job.TaskGroups[0].Migrate.MaxParallel = i
+		require.Nil(state.UpsertJob(101, job))
+
+		// Create 10 running allocs on the draining node
+		var allocs []*structs.Allocation
+		for i := 0; i < 10; i++ {
+			a := mock.Alloc()
+			a.Job = job
+			a.TaskGroup = job.TaskGroups[0].Name
+			a.NodeID = n.ID
+			a.DeploymentStatus = &structs.AllocDeploymentStatus{
+				Healthy: helper.BoolToPtr(false),
+			}
+			allocs = append(allocs, a)
+		}
+		require.Nil(state.UpsertAllocs(102, allocs))
+
+		snap, err := state.Snapshot()
+		require.Nil(err)
+
+		res := &jobResult{}
+		require.Nil(handleTaskGroup(snap, job.TaskGroups[0], allocs, 101, res))
+		require.Len(res.drain, i)
+		require.Empty(res.migrated)
+		require.False(res.done)
+	}
+}
+
+func TestHandleTaskGroup_MixedHealth(t *testing.T) {
+	cases := []struct {
+		maxParallel        int
+		drainingNodeAllocs int
+		healthSet          int
+		healthUnset        int
+		expectedDrain      int
+		expectedMigrated   int
+		expectedDone       bool
+	}{
+		{
+			maxParallel:        2,
+			drainingNodeAllocs: 10,
+			healthSet:          0,
+			healthUnset:        0,
+			expectedDrain:      2,
+			expectedMigrated:   0,
+			expectedDone:       false,
+		},
+		{
+			maxParallel:        2,
+			drainingNodeAllocs: 9,
+			healthSet:          0,
+			healthUnset:        0,
+			expectedDrain:      1,
+			expectedMigrated:   1,
+			expectedDone:       false,
+		},
+		{
+			maxParallel:        5,
+			drainingNodeAllocs: 9,
+			healthSet:          0,
+			healthUnset:        0,
+			expectedDrain:      4,
+			expectedMigrated:   1,
+			expectedDone:       false,
+		},
+		{
+			maxParallel:        2,
+			drainingNodeAllocs: 5,
+			healthSet:          2,
+			healthUnset:        0,
+			expectedDrain:      0,
+			expectedMigrated:   5,
+			expectedDone:       false,
+		},
+		{
+			maxParallel:        2,
+			drainingNodeAllocs: 5,
+			healthSet:          3,
+			healthUnset:        0,
+			expectedDrain:      0,
+			expectedMigrated:   5,
+			expectedDone:       false,
+		},
+		{
+			maxParallel:        2,
+			drainingNodeAllocs: 5,
+			healthSet:          4,
+			healthUnset:        0,
+			expectedDrain:      1,
+			expectedMigrated:   5,
+			expectedDone:       false,
+		},
+		{
+			maxParallel:        2,
+			drainingNodeAllocs: 5,
+			healthSet:          4,
+			healthUnset:        1,
+			expectedDrain:      1,
+			expectedMigrated:   5,
+			expectedDone:       false,
+		},
+		{
+			maxParallel:        1,
+			drainingNodeAllocs: 5,
+			healthSet:          4,
+			healthUnset:        1,
+			expectedDrain:      0,
+			expectedMigrated:   5,
+			expectedDone:       false,
+		},
+		{
+			maxParallel:        3,
+			drainingNodeAllocs: 5,
+			healthSet:          3,
+			healthUnset:        0,
+			expectedDrain:      1,
+			expectedMigrated:   5,
+			expectedDone:       false,
+		},
+		{
+			maxParallel:        3,
+			drainingNodeAllocs: 0,
+			healthSet:          10,
+			healthUnset:        0,
+			expectedDrain:      0,
+			expectedMigrated:   10,
+			expectedDone:       true,
+		},
+		{
+			// Is the case where deadline is hit and all 10 are just marked
+			// stopped. We should detect the job as done.
+			maxParallel:        3,
+			drainingNodeAllocs: 0,
+			healthSet:          0,
+			healthUnset:        0,
+			expectedDrain:      0,
+			expectedMigrated:   10,
+			expectedDone:       true,
+		},
+	}
+
+	for cnum, c := range cases {
+		t.Run(fmt.Sprintf("%d", cnum), func(t *testing.T) {
+			require := require.New(t)
+
+			// Create a draining node
+			state := state.TestStateStore(t)
+
+			drainingNode := mock.Node()
+			drainingNode.DrainStrategy = &structs.DrainStrategy{
+				DrainSpec: structs.DrainSpec{
+					Deadline: 5 * time.Minute,
+				},
+				ForceDeadline: time.Now().Add(1 * time.Minute),
+			}
+			require.Nil(state.UpsertNode(100, drainingNode))
+
+			healthyNode := mock.Node()
+			require.Nil(state.UpsertNode(101, healthyNode))
+
+			job := mock.Job()
+			job.TaskGroups[0].Migrate.MaxParallel = c.maxParallel
+			require.Nil(state.UpsertJob(101, job))
+
+			// Create running allocs on the draining node with health set
+			var allocs []*structs.Allocation
+			for i := 0; i < c.drainingNodeAllocs; i++ {
+				a := mock.Alloc()
+				a.Job = job
+				a.TaskGroup = job.TaskGroups[0].Name
+				a.NodeID = drainingNode.ID
+				a.DeploymentStatus = &structs.AllocDeploymentStatus{
+					Healthy: helper.BoolToPtr(false),
+				}
+				allocs = append(allocs, a)
+			}
+
+			// Create stopped allocs on the draining node
+			for i := 10 - c.drainingNodeAllocs; i > 0; i-- {
+				a := mock.Alloc()
+				a.Job = job
+				a.TaskGroup = job.TaskGroups[0].Name
+				a.NodeID = drainingNode.ID
+				a.DeploymentStatus = &structs.AllocDeploymentStatus{
+					Healthy: helper.BoolToPtr(false),
+				}
+				a.DesiredStatus = structs.AllocDesiredStatusStop
+				allocs = append(allocs, a)
+			}
+
+			// Create allocs on the healthy node with health set
+			for i := 0; i < c.healthSet; i++ {
+				a := mock.Alloc()
+				a.Job = job
+				a.TaskGroup = job.TaskGroups[0].Name
+				a.NodeID = healthyNode.ID
+				a.DeploymentStatus = &structs.AllocDeploymentStatus{
+					Healthy: helper.BoolToPtr(false),
+				}
+				allocs = append(allocs, a)
+			}
+
+			// Create allocs on the healthy node with health not set
+			for i := 0; i < c.healthUnset; i++ {
+				a := mock.Alloc()
+				a.Job = job
+				a.TaskGroup = job.TaskGroups[0].Name
+				a.NodeID = healthyNode.ID
+				allocs = append(allocs, a)
+			}
+			require.Nil(state.UpsertAllocs(103, allocs))
+
+			snap, err := state.Snapshot()
+			require.Nil(err)
+
+			res := &jobResult{}
+			require.Nil(handleTaskGroup(snap, job.TaskGroups[0], allocs, 101, res))
+			require.Len(res.drain, c.expectedDrain)
+			require.Len(res.migrated, c.expectedMigrated)
+			require.Equal(c.expectedDone, res.done)
+		})
+	}
+}
+
+func TestHandleTaskGroup_Migrations(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Create a draining node
+	state := state.TestStateStore(t)
+	n := mock.Node()
+	n.DrainStrategy = &structs.DrainStrategy{
+		DrainSpec: structs.DrainSpec{
+			Deadline: 5 * time.Minute,
+		},
+		ForceDeadline: time.Now().Add(1 * time.Minute),
+	}
+	require.Nil(state.UpsertNode(100, n))
+
+	job := mock.Job()
+	require.Nil(state.UpsertJob(101, job))
+
+	// Create 10 done allocs
+	var allocs []*structs.Allocation
+	for i := 0; i < 10; i++ {
+		a := mock.Alloc()
+		a.Job = job
+		a.TaskGroup = job.TaskGroups[0].Name
+		a.NodeID = n.ID
+		a.DeploymentStatus = &structs.AllocDeploymentStatus{
+			Healthy: helper.BoolToPtr(false),
+		}
+
+		if i%2 == 0 {
+			a.DesiredStatus = structs.AllocDesiredStatusStop
+		} else {
+			a.ClientStatus = structs.AllocClientStatusFailed
+		}
+		allocs = append(allocs, a)
+	}
+	require.Nil(state.UpsertAllocs(102, allocs))
+
+	snap, err := state.Snapshot()
+	require.Nil(err)
+
+	// Handle before and after indexes
+	res := &jobResult{}
+	require.Nil(handleTaskGroup(snap, job.TaskGroups[0], allocs, 101, res))
+	require.Empty(res.drain)
+	require.Len(res.migrated, 10)
+	require.True(res.done)
+
+	res = &jobResult{}
+	require.Nil(handleTaskGroup(snap, job.TaskGroups[0], allocs, 103, res))
+	require.Empty(res.drain)
+	require.Empty(res.migrated)
+	require.True(res.done)
+}

--- a/nomad/drainerv2/watch_nodes.go
+++ b/nomad/drainerv2/watch_nodes.go
@@ -50,7 +50,7 @@ func (n *NodeDrainer) Update(node *structs.Node) {
 
 	draining, ok := n.nodes[node.ID]
 	if !ok {
-		n.nodes[node.ID] = NewDrainingNode(node, n.state, n)
+		n.nodes[node.ID] = NewDrainingNode(node, n.state)
 		return
 	}
 
@@ -61,9 +61,6 @@ func (n *NodeDrainer) Update(node *structs.Node) {
 	if inf, deadline := node.DrainStrategy.DeadlineTime(); !inf {
 		n.deadlineNotifier.Watch(node.ID, deadline)
 	} else {
-		// TODO think about handling any race that may occur. I believe it is
-		// totally fine as long as the handlers are locked.
-
 		// There is an infinite deadline so it shouldn't be tracked for
 		// deadlining
 		n.deadlineNotifier.Remove(node.ID)

--- a/nomad/drainerv2/watch_nodes.go
+++ b/nomad/drainerv2/watch_nodes.go
@@ -1,0 +1,7 @@
+package drainerv2
+
+import "github.com/hashicorp/nomad/nomad/structs"
+
+type DrainingNodeWatcher interface {
+	Transistioning() <-chan []*structs.Node
+}

--- a/nomad/drainerv2/watch_nodes.go
+++ b/nomad/drainerv2/watch_nodes.go
@@ -1,7 +1,178 @@
 package drainerv2
 
-import "github.com/hashicorp/nomad/nomad/structs"
+import (
+	"context"
+	"log"
+	"time"
 
-type DrainingNodeWatcher interface {
-	Transistioning() <-chan []*structs.Node
+	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"golang.org/x/time/rate"
+)
+
+// DrainingNodeWatcher is the interface for watching for draining nodes.
+type DrainingNodeWatcher interface{}
+
+// Tracking returns the whether the node is being tracked and if so the copy of
+// the node object that is tracked.
+func (n *NodeDrainer) Tracking(nodeID string) (*structs.Node, bool) {
+	n.l.RLock()
+	defer n.l.RUnlock()
+
+	draining, ok := n.nodes[nodeID]
+	if !ok {
+		return nil, false
+	}
+
+	return draining.GetNode(), true
+}
+
+// Remove removes the given node from being tracked
+func (n *NodeDrainer) Remove(nodeID string) {
+	n.l.Lock()
+	defer n.l.Unlock()
+	delete(n.nodes, nodeID)
+}
+
+// Update updates the node, either updating the tracked version or starting to
+// track the node.
+func (n *NodeDrainer) Update(node *structs.Node) {
+	n.l.Lock()
+	defer n.l.Unlock()
+
+	if node == nil {
+		return
+	}
+
+	draining, ok := n.nodes[node.ID]
+	if !ok {
+		n.nodes[node.ID] = NewDrainingNode(node, n.state, n)
+		return
+	}
+
+	draining.Update(node)
+}
+
+// nodeDrainWatcher is used to watch nodes that are entering, leaving or
+// changing their drain strategy.
+type nodeDrainWatcher struct {
+	ctx    context.Context
+	logger *log.Logger
+
+	// state is the state that is watched for state changes.
+	state *state.StateStore
+
+	// limiter is used to limit the rate of blocking queries
+	limiter *rate.Limiter
+
+	// tracker is the object that is tracking the nodes and provides us with the
+	// needed callbacks
+	tracker NodeTracker
+}
+
+// NewNodeDrainWatcher returns a new node drain watcher.
+func NewNodeDrainWatcher(ctx context.Context, limiter *rate.Limiter, state *state.StateStore, logger *log.Logger, tracker NodeTracker) *nodeDrainWatcher {
+	w := &nodeDrainWatcher{
+		ctx:     ctx,
+		limiter: limiter,
+		logger:  logger,
+		tracker: tracker,
+		state:   state,
+	}
+
+	go w.watch()
+	return w
+}
+
+// watch is the long lived watching routine that detects node changes.
+func (w *nodeDrainWatcher) watch() {
+	nindex := uint64(1)
+	for {
+		w.logger.Printf("[TRACE] nomad.drain.node_watcher: getting nodes at index %d", nindex)
+		nodes, index, err := w.getNodes(nindex)
+		if err != nil {
+			if err == context.Canceled {
+				w.logger.Printf("[TRACE] nomad.drain.node_watcher: shutting down")
+				return
+			}
+
+			w.logger.Printf("[ERR] nomad.drain.node_watcher: error watching node updates at index %d: %v", nindex, err)
+			select {
+			case <-w.ctx.Done():
+				w.logger.Printf("[TRACE] nomad.drain.node_watcher: shutting down")
+				return
+			case <-time.After(stateReadErrorDelay):
+				continue
+			}
+		}
+
+		// update index for next run
+		nindex = index
+
+		for _, node := range nodes {
+			newDraining := node.DrainStrategy != nil
+			currentNode, tracked := w.tracker.Tracking(node.ID)
+
+			switch {
+			// If the node is tracked but not draining, untrack
+			case tracked && !newDraining:
+				w.logger.Printf("[TRACE] nomad.drain.node_watcher: tracked node %q is no longer draining", node.ID)
+				w.tracker.Remove(node.ID)
+
+				// If the node is not being tracked but is draining, track
+			case !tracked && newDraining:
+				w.logger.Printf("[TRACE] nomad.drain.node_watcher: untracked node %q is draining", node.ID)
+				w.tracker.Update(node)
+
+				// If the node is being tracked but has changed, update:
+			case tracked && newDraining && !currentNode.DrainStrategy.Equal(node.DrainStrategy):
+				w.logger.Printf("[TRACE] nomad.drain.node_watcher: tracked node %q has updated drain", node.ID)
+				w.tracker.Update(node)
+			default:
+				w.logger.Printf("[TRACE] nomad.drain.node_watcher: node %q at index %v: tracked %v, draining %v", node.ID, node.ModifyIndex, tracked, newDraining)
+			}
+		}
+	}
+}
+
+// getNodes returns all nodes blocking until the nodes are after the given index.
+func (w *nodeDrainWatcher) getNodes(minIndex uint64) ([]*structs.Node, uint64, error) {
+	if err := w.limiter.Wait(w.ctx); err != nil {
+		return nil, 0, err
+	}
+
+	resp, index, err := w.state.BlockingQuery(w.getNodesImpl, minIndex, w.ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return resp.([]*structs.Node), index, nil
+}
+
+// getNodesImpl is used to get nodes from the state store, returning the set of
+// nodes and the given index.
+func (w *nodeDrainWatcher) getNodesImpl(ws memdb.WatchSet, state *state.StateStore) (interface{}, uint64, error) {
+	iter, err := state.Nodes(ws)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	index, err := state.Index("nodes")
+	if err != nil {
+		return nil, 0, err
+	}
+
+	resp := make([]*structs.Node, 0, 64)
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+
+		node := raw.(*structs.Node)
+		resp = append(resp, node)
+	}
+
+	return resp, index, nil
 }

--- a/nomad/drainerv2/watch_nodes.go
+++ b/nomad/drainerv2/watch_nodes.go
@@ -78,6 +78,8 @@ func (n *NodeDrainer) Update(node *structs.Node) {
 		n.jobWatcher.RegisterJob(job)
 	}
 
+	// TODO Test at this layer as well that a node drain on a node without
+	// allocs immediately gets unmarked as draining
 	// Check if the node is done such that if an operator drains a node with
 	// nothing on it we unset drain
 	done, err := draining.IsDone()
@@ -176,6 +178,8 @@ func (w *nodeDrainWatcher) watch() {
 			default:
 				w.logger.Printf("[TRACE] nomad.drain.node_watcher: node %q at index %v: tracked %v, draining %v", nodeID, node.ModifyIndex, tracked, newDraining)
 			}
+
+			// TODO(schmichael) handle the case of a lost node
 		}
 
 		for nodeID := range tracked {

--- a/nomad/drainerv2/watch_nodes_test.go
+++ b/nomad/drainerv2/watch_nodes_test.go
@@ -1,0 +1,153 @@
+package drainerv2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func testNodeDrainWatcher(t *testing.T) (*nodeDrainWatcher, *state.StateStore, *MockNodeTracker) {
+	t.Helper()
+
+	sconfig := &state.StateStoreConfig{
+		LogOutput: testlog.NewWriter(t),
+		Region:    "global",
+	}
+	state, err := state.NewStateStore(sconfig)
+	if err != nil {
+		t.Fatalf("failed to create state store: %v", err)
+	}
+
+	limiter := rate.NewLimiter(100.0, 100)
+	logger := testlog.Logger(t)
+	m := NewMockNodeTracker()
+	w := NewNodeDrainWatcher(context.Background(), limiter, state, logger, m)
+	return w, state, m
+}
+
+func TestNodeDrainWatcher_Interface(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	w, _, _ := testNodeDrainWatcher(t)
+	require.Implements((*DrainingNodeWatcher)(nil), w)
+}
+
+func TestNodeDrainWatcher_AddDraining(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	_, state, m := testNodeDrainWatcher(t)
+
+	// Create two nodes, one draining and one not draining
+	n1, n2 := mock.Node(), mock.Node()
+	n2.DrainStrategy = &structs.DrainStrategy{
+		DrainSpec: structs.DrainSpec{
+			Deadline: time.Hour,
+		},
+		ForceDeadline: time.Now().Add(time.Hour),
+	}
+
+	require.Nil(state.UpsertNode(100, n1))
+	require.Nil(state.UpsertNode(101, n2))
+
+	testutil.WaitForResult(func() (bool, error) {
+		return len(m.Events) == 1, nil
+	}, func(err error) {
+		t.Fatal("No node drain events")
+	})
+
+	_, ok1 := m.Tracking(n1.ID)
+	out2, ok2 := m.Tracking(n2.ID)
+	require.False(ok1)
+	require.True(ok2)
+	require.Equal(n2, out2)
+
+}
+
+func TestNodeDrainWatcher_Remove(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	_, state, m := testNodeDrainWatcher(t)
+
+	// Create a draining node
+	n := mock.Node()
+	n.DrainStrategy = &structs.DrainStrategy{
+		DrainSpec: structs.DrainSpec{
+			Deadline: time.Hour,
+		},
+		ForceDeadline: time.Now().Add(time.Hour),
+	}
+
+	// Wait for it to be tracked
+	require.Nil(state.UpsertNode(100, n))
+	testutil.WaitForResult(func() (bool, error) {
+		return len(m.Events) == 1, nil
+	}, func(err error) {
+		t.Fatal("No node drain events")
+	})
+
+	out, ok := m.Tracking(n.ID)
+	require.True(ok)
+	require.Equal(n, out)
+
+	// Change the node to be not draining and wait for it to be untracked
+	require.Nil(state.UpdateNodeDrain(101, n.ID, nil))
+	testutil.WaitForResult(func() (bool, error) {
+		return len(m.Events) == 2, nil
+	}, func(err error) {
+		t.Fatal("No new node drain events")
+	})
+
+	_, ok = m.Tracking(n.ID)
+	require.False(ok)
+}
+
+func TestNodeDrainWatcher_Update(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	_, state, m := testNodeDrainWatcher(t)
+
+	// Create a draining node
+	n := mock.Node()
+	n.DrainStrategy = &structs.DrainStrategy{
+		DrainSpec: structs.DrainSpec{
+			Deadline: time.Hour,
+		},
+		ForceDeadline: time.Now().Add(time.Hour),
+	}
+
+	// Wait for it to be tracked
+	require.Nil(state.UpsertNode(100, n))
+	testutil.WaitForResult(func() (bool, error) {
+		return len(m.Events) == 1, nil
+	}, func(err error) {
+		t.Fatal("No node drain events")
+	})
+
+	out, ok := m.Tracking(n.ID)
+	require.True(ok)
+	require.Equal(n, out)
+
+	// Change the node to have a new spec
+	s2 := n.DrainStrategy.Copy()
+	s2.Deadline += time.Hour
+	require.Nil(state.UpdateNodeDrain(101, n.ID, s2))
+
+	// Wait for it to be updated
+	testutil.WaitForResult(func() (bool, error) {
+		return len(m.Events) == 2, nil
+	}, func(err error) {
+		t.Fatal("No new node drain events")
+	})
+
+	out, ok = m.Tracking(n.ID)
+	require.True(ok)
+	require.Equal(out.DrainStrategy, s2)
+}

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1887,7 +1887,7 @@ func TestClientEndpoint_BatchUpdate(t *testing.T) {
 	clientAlloc.ClientStatus = structs.AllocClientStatusFailed
 
 	// Call to do the batch update
-	bf := NewBatchFuture()
+	bf := structs.NewBatchFuture()
 	endpoint := s1.staticEndpoints.Node
 	endpoint.batchUpdate(bf, []*structs.Allocation{clientAlloc}, nil)
 	if err := bf.Wait(); err != nil {
@@ -2450,34 +2450,6 @@ func TestClientEndpoint_ListNodes_Blocking(t *testing.T) {
 	}
 	if len(resp4.Nodes) != 0 {
 		t.Fatalf("bad: %#v", resp4.Nodes)
-	}
-}
-
-func TestBatchFuture(t *testing.T) {
-	t.Parallel()
-	bf := NewBatchFuture()
-
-	// Async respond to the future
-	expect := fmt.Errorf("testing")
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		bf.Respond(1000, expect)
-	}()
-
-	// Block for the result
-	start := time.Now()
-	err := bf.Wait()
-	diff := time.Since(start)
-	if diff < 5*time.Millisecond {
-		t.Fatalf("too fast")
-	}
-
-	// Check the results
-	if err != expect {
-		t.Fatalf("bad: %s", err)
-	}
-	if bf.Index() != 1000 {
-		t.Fatalf("bad: %d", bf.Index())
 	}
 }
 

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/nomad/helper/stats"
 	"github.com/hashicorp/nomad/helper/tlsutil"
 	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
-	"github.com/hashicorp/nomad/nomad/drainer"
+	"github.com/hashicorp/nomad/nomad/drainerv2"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -168,7 +168,7 @@ type Server struct {
 	deploymentWatcher *deploymentwatcher.Watcher
 
 	// nodeDrainer is used to drain allocations from nodes.
-	nodeDrainer *drainer.NodeDrainer
+	nodeDrainer *drainerv2.NodeDrainer
 
 	// evalBroker is used to manage the in-progress evaluations
 	// that are waiting to be brokered to a sub-scheduler
@@ -884,10 +884,18 @@ func (s *Server) setupDeploymentWatcher() error {
 // setupNodeDrainer creates a node drainer which will be enabled when a server
 // becomes a leader.
 func (s *Server) setupNodeDrainer() {
-	// create a shim around raft requests
+	// Create a shim around Raft requests
 	shim := drainerShim{s}
-	s.nodeDrainer = drainer.NewNodeDrainer(s.logger, s.shutdownCh, shim)
-	go s.nodeDrainer.Run()
+	c := &drainerv2.NodeDrainerConfig{
+		Logger:                s.logger,
+		Raft:                  shim,
+		JobFactory:            drainerv2.GetDrainingJobWatcher,
+		NodeFactory:           drainerv2.GetNodeWatcherFactory(),
+		DrainDeadlineFactory:  drainerv2.GetDeadlineNotifier,
+		StateQueriesPerSecond: drainerv2.LimitStateQueriesPerSecond,
+		BatchUpdateInterval:   drainerv2.BatchUpdateInterval,
+	}
+	s.nodeDrainer = drainerv2.NewNodeDrainer(c)
 }
 
 // setupVaultClient is used to set up the Vault API client.

--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -1,14 +1,13 @@
 package state
 
 import (
-	"os"
-
+	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/mitchellh/go-testing-interface"
 )
 
 func TestStateStore(t testing.T) *StateStore {
 	config := &StateStoreConfig{
-		LogOutput: os.Stderr,
+		LogOutput: testlog.NewWriter(t),
 		Region:    "global",
 	}
 	state, err := NewStateStore(config)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6640,3 +6640,45 @@ type ACLTokenUpsertResponse struct {
 	Tokens []*ACLToken
 	WriteMeta
 }
+
+// BatchFuture is used to wait on a batch update to complete
+type BatchFuture struct {
+	doneCh chan struct{}
+	err    error
+	index  uint64
+}
+
+// NewBatchFuture creates a new batch future
+func NewBatchFuture() *BatchFuture {
+	return &BatchFuture{
+		doneCh: make(chan struct{}),
+	}
+}
+
+// Wait is used to block for the future to complete and returns the error
+func (b *BatchFuture) Wait() error {
+	<-b.doneCh
+	return b.err
+}
+
+// WaitCh is used to block for the future to complete
+func (b *BatchFuture) WaitCh() <-chan struct{} {
+	return b.doneCh
+}
+
+// Error is used to return the error of the batch, only after Wait()
+func (b *BatchFuture) Error() error {
+	return b.err
+}
+
+// Index is used to return the index of the batch, only after Wait()
+func (b *BatchFuture) Index() uint64 {
+	return b.index
+}
+
+// Respond is used to unblock the future
+func (b *BatchFuture) Respond(index uint64, err error) {
+	b.index = index
+	b.err = err
+	close(b.doneCh)
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1621,6 +1621,26 @@ func (n *NetworkResource) PortLabels() map[string]int {
 	return labelValues
 }
 
+// JobNs is a Job.ID and Namespace tuple
+type JobNs struct {
+	ID, Namespace string
+}
+
+func NewJobNs(namespace, id string) *JobNs {
+	return &JobNs{
+		ID:        id,
+		Namespace: namespace,
+	}
+}
+
+func (j *JobNs) String() string {
+	if j == nil {
+		return "<nil, nil>"
+	}
+
+	return fmt.Sprintf("<ns: %q, id: %q>", j.Namespace, j.ID)
+}
+
 const (
 	// JobTypeNomad is reserved for internal system tasks and is
 	// always handled by the CoreScheduler.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1626,18 +1626,14 @@ type JobNs struct {
 	ID, Namespace string
 }
 
-func NewJobNs(namespace, id string) *JobNs {
-	return &JobNs{
+func NewJobNs(namespace, id string) JobNs {
+	return JobNs{
 		ID:        id,
 		Namespace: namespace,
 	}
 }
 
-func (j *JobNs) String() string {
-	if j == nil {
-		return "<nil, nil>"
-	}
-
+func (j JobNs) String() string {
 	return fmt.Sprintf("<ns: %q, id: %q>", j.Namespace, j.ID)
 }
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -3104,3 +3104,31 @@ func TestTaskEventPopulate(t *testing.T) {
 		}
 	}
 }
+
+func TestBatchFuture(t *testing.T) {
+	t.Parallel()
+	bf := NewBatchFuture()
+
+	// Async respond to the future
+	expect := fmt.Errorf("testing")
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		bf.Respond(1000, expect)
+	}()
+
+	// Block for the result
+	start := time.Now()
+	err := bf.Wait()
+	diff := time.Since(start)
+	if diff < 5*time.Millisecond {
+		t.Fatalf("too fast")
+	}
+
+	// Check the results
+	if err != expect {
+		t.Fatalf("bad: %s", err)
+	}
+	if bf.Index() != 1000 {
+		t.Fatalf("bad: %d", bf.Index())
+	}
+}

--- a/nomad/worker.go
+++ b/nomad/worker.go
@@ -327,7 +327,7 @@ SUBMIT:
 		}
 		return nil, nil, err
 	} else {
-		w.logger.Printf("[DEBUG] worker: submitted plan for evaluation %s", plan.EvalID)
+		w.logger.Printf("[DEBUG] worker: submitted plan at index %d for evaluation %s", resp.Index, plan.EvalID)
 		w.backoffReset()
 	}
 


### PR DESCRIPTION
This PR introduces a new node drain orchestrator to drain allocations off of nodes while attempting to minimize service down time.