### PR TITLE
UI: Polling Step 3 - Close connections when tabbing away

### DIFF
--- a/ui/app/components/client-node-row.js
+++ b/ui/app/components/client-node-row.js
@@ -2,8 +2,9 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { lazyClick } from '../helpers/lazy-click';
 import { watchRelationship } from 'nomad-ui/utils/properties/watch';
+import WithVisibilityDetection from 'nomad-ui/mixins/with-component-visibility-detection';
 
-export default Component.extend({
+export default Component.extend(WithVisibilityDetection, {
   store: service(),
 
   tagName: 'tr',
@@ -24,6 +25,17 @@ export default Component.extend({
       node.reload().then(() => {
         this.get('watch').perform(node, 100);
       });
+    }
+  },
+
+  visibilityHandler() {
+    if (!document.visible) {
+      this.get('watch').cancelAll();
+    } else {
+      const node = this.get('node');
+      if (node) {
+        this.get('watch').perform(node, 100);
+      }
     }
   },
 

--- a/ui/app/components/client-node-row.js
+++ b/ui/app/components/client-node-row.js
@@ -29,7 +29,7 @@ export default Component.extend(WithVisibilityDetection, {
   },
 
   visibilityHandler() {
-    if (!document.visible) {
+    if (document.hidden) {
       this.get('watch').cancelAll();
     } else {
       const node = this.get('node');

--- a/ui/app/components/job-row.js
+++ b/ui/app/components/job-row.js
@@ -29,7 +29,7 @@ export default Component.extend(WithVisibilityDetection, {
   },
 
   visibilityHandler() {
-    if (!document.visible) {
+    if (document.hidden) {
       this.get('watch').cancelAll();
     } else {
       const job = this.get('job');

--- a/ui/app/components/job-row.js
+++ b/ui/app/components/job-row.js
@@ -2,8 +2,9 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { lazyClick } from '../helpers/lazy-click';
 import { watchRelationship } from 'nomad-ui/utils/properties/watch';
+import WithVisibilityDetection from 'nomad-ui/mixins/with-component-visibility-detection';
 
-export default Component.extend({
+export default Component.extend(WithVisibilityDetection, {
   store: service(),
 
   tagName: 'tr',
@@ -24,6 +25,17 @@ export default Component.extend({
       job.reload().then(() => {
         this.get('watch').perform(job, 100);
       });
+    }
+  },
+
+  visibilityHandler() {
+    if (!document.visible) {
+      this.get('watch').cancelAll();
+    } else {
+      const job = this.get('job');
+      if (job && !job.get('isLoading')) {
+        this.get('watch').perform(job, 100);
+      }
     }
   },
 

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -37,7 +37,7 @@ export default Controller.extend(Sortable, Searchable, {
     'system.namespaces.length',
     function() {
       const hasNamespaces = this.get('system.namespaces.length');
-      const activeNamespace = this.get('system.activeNamespace.id');
+      const activeNamespace = this.get('system.activeNamespace.id') || 'default';
 
       return this.get('model')
         .filter(job => !hasNamespaces || job.get('namespace.id') === activeNamespace)

--- a/ui/app/mixins/window-resizable.js
+++ b/ui/app/mixins/window-resizable.js
@@ -1,8 +1,13 @@
 import Mixin from '@ember/object/mixin';
 import { run } from '@ember/runloop';
+import { assert } from '@ember/debug';
 import $ from 'jquery';
 
 export default Mixin.create({
+  windowResizeHandler() {
+    assert('windowResizeHandler needs to be overridden in the Component', false);
+  },
+
   setupWindowResize: function() {
     run.scheduleOnce('afterRender', this, () => {
       this.set('_windowResizeHandler', this.get('windowResizeHandler').bind(this));

--- a/ui/app/mixins/with-component-visibility-detection.js
+++ b/ui/app/mixins/with-component-visibility-detection.js
@@ -1,0 +1,12 @@
+import Mixin from '@ember/object/mixin';
+
+export default Mixin.create({
+  setupDocumentVisibility: function() {
+    this.set('_visibilityHandler', this.get('visibilityHandler').bind(this));
+    document.addEventListener('visibilitychange', this.get('_visibilityHandler'));
+  }.on('init'),
+
+  removeDocumentVisibility: function() {
+    document.removeEventListener('visibilitychange', this.get('_visibilityHandler'));
+  }.on('willDestroy'),
+});

--- a/ui/app/mixins/with-component-visibility-detection.js
+++ b/ui/app/mixins/with-component-visibility-detection.js
@@ -1,6 +1,11 @@
 import Mixin from '@ember/object/mixin';
+import { assert } from '@ember/debug';
 
 export default Mixin.create({
+  visibilityHandler() {
+    assert('visibilityHandler needs to be overridden in the Component', false);
+  },
+
   setupDocumentVisibility: function() {
     this.set('_visibilityHandler', this.get('visibilityHandler').bind(this));
     document.addEventListener('visibilitychange', this.get('_visibilityHandler'));

--- a/ui/app/mixins/with-route-visibility-detection.js
+++ b/ui/app/mixins/with-route-visibility-detection.js
@@ -1,0 +1,12 @@
+import Mixin from '@ember/object/mixin';
+
+export default Mixin.create({
+  setupDocumentVisibility: function() {
+    this.set('_visibilityHandler', this.get('visibilityHandler').bind(this));
+    document.addEventListener('visibilitychange', this.get('_visibilityHandler'));
+  }.on('activate'),
+
+  removeDocumentVisibility: function() {
+    document.removeEventListener('visibilitychange', this.get('_visibilityHandler'));
+  }.on('deactivate'),
+});

--- a/ui/app/mixins/with-route-visibility-detection.js
+++ b/ui/app/mixins/with-route-visibility-detection.js
@@ -1,6 +1,11 @@
 import Mixin from '@ember/object/mixin';
+import { assert } from '@ember/debug';
 
 export default Mixin.create({
+  visibilityHandler() {
+    assert('visibilityHandler needs to be overridden in the Route', false);
+  },
+
   setupDocumentVisibility: function() {
     this.set('_visibilityHandler', this.get('visibilityHandler').bind(this));
     document.addEventListener('visibilitychange', this.get('_visibilityHandler'));

--- a/ui/app/mixins/with-watchers.js
+++ b/ui/app/mixins/with-watchers.js
@@ -23,7 +23,7 @@ export default Mixin.create(WithVisibilityDetection, {
   },
 
   visibilityHandler() {
-    if (!document.visible) {
+    if (document.hidden) {
       this.cancelAllWatchers();
     } else {
       this.startWatchers(this.controller, this.controller.get('model'));

--- a/ui/app/mixins/with-watchers.js
+++ b/ui/app/mixins/with-watchers.js
@@ -1,16 +1,38 @@
 import Mixin from '@ember/object/mixin';
 import { computed } from '@ember/object';
 import { assert } from '@ember/debug';
+import WithVisibilityDetection from './with-route-visibility-detection';
 
-export default Mixin.create({
+export default Mixin.create(WithVisibilityDetection, {
   watchers: computed(() => []),
+
+  cancelAllWatchers() {
+    this.get('watchers').forEach(watcher => {
+      assert('Watchers must be Ember Concurrency Tasks.', !!watcher.cancelAll);
+      watcher.cancelAll();
+    });
+  },
+
+  startWatchers() {
+    assert('startWatchers needs to be overridden in the Route', false);
+  },
+
+  setupController() {
+    this.startWatchers(...arguments);
+    return this._super(...arguments);
+  },
+
+  visibilityHandler() {
+    if (!document.visible) {
+      this.cancelAllWatchers();
+    } else {
+      this.startWatchers(this.controller, this.controller.get('model'));
+    }
+  },
 
   actions: {
     willTransition() {
-      this.get('watchers').forEach(watcher => {
-        assert('Watchers must be Ember Concurrency Tasks.', !!watcher.cancelAll);
-        watcher.cancelAll();
-      });
+      this.cancelAllWatchers();
     },
   },
 });

--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -5,9 +5,8 @@ import { watchRecord } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
 
 export default Route.extend(WithModelErrorHandling, WithWatchers, {
-  setupController(controller, model) {
+  startWatchers(controller, model) {
     controller.set('watcher', this.get('watch').perform(model));
-    return this._super(...arguments);
   },
 
   watch: watchRecord('allocation'),

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -1,5 +1,6 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { AbortError } from 'ember-data/adapters/errors';
 
 export default Route.extend({
   config: service(),
@@ -22,7 +23,9 @@ export default Route.extend({
     },
 
     error(error) {
-      this.controllerFor('application').set('error', error);
+      if (!(error instanceof AbortError)) {
+        this.controllerFor('application').set('error', error);
+      }
     },
   },
 });

--- a/ui/app/routes/clients/client.js
+++ b/ui/app/routes/clients/client.js
@@ -19,10 +19,9 @@ export default Route.extend(WithWatchers, {
     return model && model.get('allocations');
   },
 
-  setupController(controller, model) {
+  startWatchers(controller, model) {
     controller.set('watchModel', this.get('watch').perform(model));
     controller.set('watchAllocations', this.get('watchAllocations').perform(model));
-    return this._super(...arguments);
   },
 
   watch: watchRecord('node'),

--- a/ui/app/routes/clients/index.js
+++ b/ui/app/routes/clients/index.js
@@ -4,9 +4,8 @@ import { watchAll } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
 
 export default Route.extend(WithWatchers, {
-  setupController(controller) {
+  startWatchers(controller) {
     controller.set('watcher', this.get('watch').perform());
-    return this._super(...arguments);
   },
 
   watch: watchAll('node'),

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -4,9 +4,8 @@ import { watchAll } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
 
 export default Route.extend(WithWatchers, {
-  setupController(controller) {
+  startWatchers(controller) {
     controller.set('modelWatch', this.get('watch').perform());
-    return this._super(...arguments);
   },
 
   watch: watchAll('job'),

--- a/ui/app/routes/jobs/job/deployments.js
+++ b/ui/app/routes/jobs/job/deployments.js
@@ -10,10 +10,9 @@ export default Route.extend(WithWatchers, {
     return RSVP.all([job.get('deployments'), job.get('versions')]).then(() => job);
   },
 
-  setupController(controller, model) {
+  startWatchers(controller, model) {
     controller.set('watchDeployments', this.get('watchDeployments').perform(model));
     controller.set('watchVersions', this.get('watchVersions').perform(model));
-    return this._super(...arguments);
   },
 
   watchDeployments: watchRelationship('deployments'),

--- a/ui/app/routes/jobs/job/index.js
+++ b/ui/app/routes/jobs/job/index.js
@@ -4,15 +4,13 @@ import { watchRecord, watchRelationship } from 'nomad-ui/utils/properties/watch'
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
 
 export default Route.extend(WithWatchers, {
-  setupController(controller, model) {
+  startWatchers(controller, model) {
     controller.set('watchers', {
       model: this.get('watch').perform(model),
       summary: this.get('watchSummary').perform(model),
       evaluations: this.get('watchEvaluations').perform(model),
       deployments: this.get('watchDeployments').perform(model),
     });
-
-    return this._super(...arguments);
   },
 
   watch: watchRecord('job'),

--- a/ui/app/routes/jobs/job/task-group.js
+++ b/ui/app/routes/jobs/job/task-group.js
@@ -19,14 +19,13 @@ export default Route.extend(WithWatchers, {
       });
   },
 
-  setupController(controller, model) {
+  startWatchers(controller, model) {
     const job = model.get('job');
     controller.set('watchers', {
       job: this.get('watchJob').perform(job),
       summary: this.get('watchSummary').perform(job),
       allocations: this.get('watchAllocations').perform(job),
     });
-    return this._super(...arguments);
   },
 
   watchJob: watchRecord('job'),

--- a/ui/app/routes/jobs/job/versions.js
+++ b/ui/app/routes/jobs/job/versions.js
@@ -9,9 +9,8 @@ export default Route.extend(WithWatchers, {
     return job.get('versions').then(() => job);
   },
 
-  setupController(controller, model) {
+  startWatchers(controller, model) {
     controller.set('watcher', this.get('watchVersions').perform(model));
-    return this._super(...arguments);
   },
 
   watchVersions: watchRelationship('versions'),

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -113,6 +113,7 @@ export default Factory.extend({
     const jobSummary = server.create('job-summary', hasChildren ? 'withChildren' : 'withSummary', {
       groupNames: groups.mapBy('name'),
       job,
+      job_id: job.id,
       namespace: job.namespace,
     });
 


### PR DESCRIPTION
Since browsers only support ~6 open connections to the same host at once, it's important to eagerly close connections to allow other tabs to resolve requests.

**Example problem scenario:**
1. Visit `/clients` in Tab A
2. `/clients` has n + 1 connections, 1 for the nodes list and n for the allocations of each node
3. Open a client in a new tab (Tab B)
4. Tab B is in a perpetual loading state because Tab A has already hit the maximum allowed open connections for the nomad server host

**Solved problem scenario:**
1. Visit `/clients` in Tab A
2. `/clients` has n + 1 connections, 1 for the nodes list and n for the allocations of each node
3. Open a client in a new tab (Tab B)
4. Once Tab B is active, the n + 1 connections in Tab A are all aborted
4. Tab B loads immediately because there are currently 0 open connections to the nomad server host