### PR TITLE
Only show the placement failures section if there is a blocked eval

### DIFF
--- a/ui/app/models/evaluation.js
+++ b/ui/app/models/evaluation.js
@@ -1,4 +1,4 @@
-import { bool } from '@ember/object/computed';
+import { bool, equal } from '@ember/object/computed';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
@@ -15,6 +15,7 @@ export default Model.extend({
   failedTGAllocs: fragmentArray('placement-failure', { defaultValue: () => [] }),
 
   hasPlacementFailures: bool('failedTGAllocs.length'),
+  isBlocked: equal('status', 'blocked'),
 
   // TEMPORARY: https://github.com/emberjs/data/issues/5209
   originalJobId: attr('string'),

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -1,4 +1,4 @@
-import { alias, bool, equal, or } from '@ember/object/computed';
+import { alias, equal, or, and } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
@@ -106,7 +106,13 @@ export default Model.extend({
   evaluations: hasMany('evaluations'),
   namespace: belongsTo('namespace'),
 
-  hasPlacementFailures: bool('latestFailureEvaluation'),
+  hasBlockedEvaluation: computed('evaluations.@each.isBlocked', function() {
+    return this.get('evaluations')
+      .toArray()
+      .some(evaluation => evaluation.get('isBlocked'));
+  }),
+
+  hasPlacementFailures: and('latestFailureEvaluation', 'hasBlockedEvaluation'),
 
   latestEvaluation: computed('evaluations.@each.modifyIndex', 'evaluations.isPending', function() {
     const evaluations = this.get('evaluations');

--- a/ui/mirage/factories/evaluation.js
+++ b/ui/mirage/factories/evaluation.js
@@ -4,7 +4,7 @@ import { provide, pickOne } from '../utils';
 import { DATACENTERS } from '../common';
 
 const EVAL_TYPES = ['system', 'service', 'batch'];
-const EVAL_STATUSES = ['blocked', 'pending', 'complete', 'failed', 'canceled'];
+const EVAL_STATUSES = ['pending', 'complete', 'failed', 'canceled'];
 const EVAL_TRIGGERED_BY = [
   'job-register',
   'job-deregister',
@@ -55,7 +55,7 @@ export default Factory.extend({
   modifyIndex: () => faker.random.number({ min: 10, max: 2000 }),
 
   withPlacementFailures: trait({
-    status: faker.list.random(...EVAL_STATUSES.without('blocked')),
+    status: 'blocked',
     afterCreate(evaluation, server) {
       assignJob(evaluation, server);
       const taskGroups = server.db.taskGroups.where({ jobId: evaluation.jobId });


### PR DESCRIPTION
Fixes #3828 

Placement failures require both an evaluation with placement failures _and_ a blocked evaluation. Blocked evaluations change to "canceled" when a new job is submitted, which is what makes the placement failures message not persist indefinitely. This second condition was missing from the logic in the UI.