### PR TITLE
Retry validating token from vault till success

### DIFF
--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -423,7 +423,7 @@ OUTER:
 				}
 				initStatus = true
 			}
-			// Retry parsing the token till success
+			// Retry validating the token till success
 			if err := v.parseSelfToken(); err != nil {
 				v.logger.Printf("[ERR] vault: failed to validate self token/role. Retrying in %v: %v", v.config.ConnectionRetryIntv, err)
 				retryTimer.Reset(v.config.ConnectionRetryIntv)

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -429,7 +429,7 @@ OUTER:
 				retryTimer.Reset(v.config.ConnectionRetryIntv)
 				v.l.Lock()
 				v.connEstablished = true
-				v.connEstablishedErr = fmt.Errorf("Connection to Vault failed: %v", err)
+				v.connEstablishedErr = fmt.Errorf("Nomad Server failed to establish connections to Vault: %v", err)
 				v.l.Unlock()
 				continue OUTER
 			}

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"math/rand"
 	"regexp"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -424,23 +423,15 @@ OUTER:
 				}
 				initStatus = true
 			}
-			// Retrieve our token, validate it and parse the lease duration
+			// Retry parsing the token till success
 			if err := v.parseSelfToken(); err != nil {
-				// Retry if vault is sealed
-				//TODO(preetha) : is there a nicer way to figure out whether vault is sealed
-				if strings.Contains(err.Error(), "is sealed") {
-					v.logger.Printf("[ERR] vault: failed to validate self token/role. Retrying in %v: %v", v.config.ConnectionRetryIntv, err)
-					retryTimer.Reset(v.config.ConnectionRetryIntv)
-					continue OUTER
-				} else {
-					// Irrecoverable error so we return
-					v.logger.Printf("[ERR] vault: failed to validate self token/role and not retrying: %v", err)
-					v.l.Lock()
-					v.connEstablished = false
-					v.connEstablishedErr = err
-					v.l.Unlock()
-					return
-				}
+				v.logger.Printf("[ERR] vault: failed to validate self token/role. Retrying in %v: %v", v.config.ConnectionRetryIntv, err)
+				retryTimer.Reset(v.config.ConnectionRetryIntv)
+				v.l.Lock()
+				v.connEstablished = true
+				v.connEstablishedErr = fmt.Errorf("Connection to Vault failed: %v", err)
+				v.l.Unlock()
+				continue OUTER
 			}
 			break OUTER
 		}
@@ -855,8 +846,8 @@ func (v *vaultClient) CreateToken(ctx context.Context, a *structs.Allocation, ta
 	// Check if we have established a connection with Vault
 	if established, err := v.ConnectionEstablished(); !established && err == nil {
 		return nil, structs.NewRecoverableError(fmt.Errorf("Connection to Vault has not been established"), true)
-	} else if !established {
-		return nil, fmt.Errorf("Connection to Vault failed: %v", err)
+	} else if err != nil {
+		return nil, err
 	}
 
 	// Track how long the request takes
@@ -933,8 +924,8 @@ func (v *vaultClient) LookupToken(ctx context.Context, token string) (*vapi.Secr
 	// Check if we have established a connection with Vault
 	if established, err := v.ConnectionEstablished(); !established && err == nil {
 		return nil, structs.NewRecoverableError(fmt.Errorf("Connection to Vault has not been established"), true)
-	} else if !established {
-		return nil, fmt.Errorf("Connection to Vault failed: %v", err)
+	} else if err != nil {
+		return nil, err
 	}
 
 	// Track how long the request takes
@@ -1052,8 +1043,8 @@ func (v *vaultClient) parallelRevoke(ctx context.Context, accessors []*structs.V
 	// Check if we have established a connection with Vault
 	if established, err := v.ConnectionEstablished(); !established && err == nil {
 		return structs.NewRecoverableError(fmt.Errorf("Connection to Vault has not been established"), true)
-	} else if !established {
-		return fmt.Errorf("Connection to Vault failed: %v", err)
+	} else if err != nil {
+		return err
 	}
 
 	g, pCtx := errgroup.WithContext(ctx)

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -260,8 +260,8 @@ func TestVaultClient_ValidateRole(t *testing.T) {
 	var connErr error
 	testutil.WaitForResult(func() (bool, error) {
 		conn, connErr = client.ConnectionEstablished()
-		if conn {
-			return false, fmt.Errorf("Should not connect")
+		if !conn {
+			return false, fmt.Errorf("Should connect")
 		}
 
 		if connErr == nil {
@@ -303,8 +303,8 @@ func TestVaultClient_ValidateRole_NonExistant(t *testing.T) {
 	var connErr error
 	testutil.WaitForResult(func() (bool, error) {
 		conn, connErr = client.ConnectionEstablished()
-		if conn {
-			return false, fmt.Errorf("Should not connect")
+		if !conn {
+			return false, fmt.Errorf("Should connect")
 		}
 
 		if connErr == nil {
@@ -351,8 +351,8 @@ func TestVaultClient_ValidateToken(t *testing.T) {
 	var connErr error
 	testutil.WaitForResult(func() (bool, error) {
 		conn, connErr = client.ConnectionEstablished()
-		if conn {
-			return false, fmt.Errorf("Should not connect")
+		if !conn {
+			return false, fmt.Errorf("Should connect")
 		}
 
 		if connErr == nil {
@@ -967,10 +967,9 @@ func TestVaultClient_CreateToken_Role_InvalidToken(t *testing.T) {
 
 	testutil.WaitForResult(func() (bool, error) {
 		established, err := client.ConnectionEstablished()
-		if established {
-			return false, fmt.Errorf("Shouldn't establish")
+		if !established {
+			return false, fmt.Errorf("Should establish")
 		}
-
 		return err != nil, nil
 	}, func(err error) {
 		t.Fatalf("Connection not established")


### PR DESCRIPTION
Fixes #3786 

Also consolidates error message definition into one place, and changes error handling logic to separate connection establishment from token validation errors