### PR TITLE
fix: disable swap for executor_linux allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ BUG FIXES:
    space in it on Windows [[GH-3855](https://github.com/hashicorp/nomad/issues/3855)]
  * client/vault: Recognize renewing non-renewable Vault lease as fatal [[GH-3727](https://github.com/hashicorp/nomad/issues/3727)]
  * config: Revert minimum CPU limit back to 20 from 100.
+ * driver/exec: Properly disable swapping [[GH-3958](https://github.com/hashicorp/nomad/issues/3958)]
  * driver/lxc: Cleanup LXC containers after errors on container startup. [[GH-3773](https://github.com/hashicorp/nomad/issues/3773)]
  * ui: Fix ui on non-leaders when ACLs are enabled [[GH-3722](https://github.com/hashicorp/nomad/issues/3722)]
  * ui: Fix requests using client-side certificates in Firefox. [[GH-3728](https://github.com/hashicorp/nomad/pull/3728)]

--- a/client/driver/executor/executor_linux.go
+++ b/client/driver/executor/executor_linux.go
@@ -83,7 +83,8 @@ func (e *UniversalExecutor) configureCgroups(resources *structs.Resources) error
 		// Total amount of memory allowed to consume
 		e.resConCtx.groups.Resources.Memory = int64(resources.MemoryMB * 1024 * 1024)
 		// Disable swap to avoid issues on the machine
-		e.resConCtx.groups.Resources.MemorySwap = int64(-1)
+		var memSwappiness int64 = 0
+		e.resConCtx.groups.Resources.MemorySwappiness = &memSwappiness
 	}
 
 	if resources.CPU < 2 {


### PR DESCRIPTION
    fix: disable swap for executor_linux allocations
    
    A comment in the nomad source code states that swapping for
    executor_linux allocations is disabled but it wasn't.
    
    Nomad wrote -1 to the memsw.limit_in_bytes cgroup file to disable
    swapping.
    This has the following problems:
    
    1.) Writing -1 to the file does not disable swapping. It sets
        the limit for memory and swap to unlimited.
    2.) On common Linux distributions like Ubuntu 16.04 LTS the
        memsw.limit_in_bytes cgroup file does not exist by default.
        The memsw.limit_in_bytes file only exist if the Linux kernel is
        build with CONFIG_MEMCG_SWAP=yes and either
        CONFIG_MEMCG_SWAP_ENABLED=yes or when the kernel parameter
        swapaccount=1 is passed during boot.
        Most Linux distributions disable swap accounting by default because
        of higher memory usage.
        Nomad silently ignores if writing to the memsw.limit_in_bytes file
        fails. The allocation succeeds, no message is logged to notify the
        user.
    
    To ensure that disabling swap works on common Linux kernels, disable
    swapping by writing 0 to the memory.swappiness file.
    Using the memory.swappiness file only requires that the kernel is
    compiled with CONFIG_MEMCG=yes. This is the default in common Linux
    kernels.