### PR TITLE
Shard raft commits

### DIFF
--- a/nomad/drainer/drainer_util.go
+++ b/nomad/drainer/drainer_util.go
@@ -1,0 +1,93 @@
+package drainer
+
+import (
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+var (
+	// maxIdsPerTxn is the maximum number of IDs that can be included in a
+	// single Raft transaction. This is to ensure that the Raft message does not
+	// become too large.
+	maxIdsPerTxn = (1024 * 256) / 36 // 0.25 MB of ids.
+)
+
+// partitionIds takes a set of IDs and returns a partitioned view of them such
+// that no batch would result in an overly large raft transaction.
+func partitionIds(ids []string) [][]string {
+	index := 0
+	total := len(ids)
+	var partitions [][]string
+	for remaining := total - index; remaining > 0; remaining = total - index {
+		if remaining < maxIdsPerTxn {
+			partitions = append(partitions, ids[index:])
+			break
+		} else {
+			partitions = append(partitions, ids[index:index+maxIdsPerTxn])
+			index += maxIdsPerTxn
+		}
+	}
+
+	return partitions
+}
+
+// transistionTuple is used to group desired transistions and evals
+type transistionTuple struct {
+	Transistions map[string]*structs.DesiredTransition
+	Evals        []*structs.Evaluation
+}
+
+// partitionAllocDrain returns a list of alloc transistions and evals to apply
+// in a single raft transaction.This is necessary to ensure that the Raft
+// transaction does not become too large.
+func partitionAllocDrain(transistions map[string]*structs.DesiredTransition,
+	evals []*structs.Evaluation) []*transistionTuple {
+
+	// Determine a stable ordering of the transistioning allocs
+	allocs := make([]string, 0, len(transistions))
+	for id := range transistions {
+		allocs = append(allocs, id)
+	}
+
+	var requests []*transistionTuple
+	submittedEvals, submittedTrans := 0, 0
+	for submittedEvals != len(evals) || submittedTrans != len(transistions) {
+		req := &transistionTuple{
+			Transistions: make(map[string]*structs.DesiredTransition),
+		}
+		requests = append(requests, req)
+		available := maxIdsPerTxn
+
+		// Add the allocs first
+		if remaining := len(allocs) - submittedTrans; remaining > 0 {
+			if remaining <= available {
+				for _, id := range allocs[submittedTrans:] {
+					req.Transistions[id] = transistions[id]
+				}
+				available -= remaining
+				submittedTrans += remaining
+			} else {
+				for _, id := range allocs[submittedTrans : submittedTrans+available] {
+					req.Transistions[id] = transistions[id]
+				}
+				submittedTrans += available
+
+				// Exhausted space so skip adding evals
+				continue
+			}
+
+		}
+
+		// Add the evals
+		if remaining := len(evals) - submittedEvals; remaining > 0 {
+			if remaining <= available {
+				req.Evals = evals[submittedEvals:]
+				submittedEvals += remaining
+			} else {
+				req.Evals = evals[submittedEvals : submittedEvals+available]
+				submittedEvals += available
+			}
+		}
+	}
+
+	return requests
+}

--- a/nomad/drainer/drainer_util_test.go
+++ b/nomad/drainer/drainer_util_test.go
@@ -1,0 +1,54 @@
+package drainer
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDrainer_PartitionAllocDrain(t *testing.T) {
+	// Set the max ids per reap to something lower.
+	old := maxIdsPerTxn
+	defer func() { maxIdsPerTxn = old }()
+	maxIdsPerTxn = 2
+
+	require := require.New(t)
+	transistions := map[string]*structs.DesiredTransition{"a": nil, "b": nil, "c": nil}
+	evals := []*structs.Evaluation{nil, nil, nil}
+	requests := partitionAllocDrain(transistions, evals)
+	require.Len(requests, 3)
+
+	first := requests[0]
+	require.Len(first.Transistions, 2)
+	require.Len(first.Evals, 0)
+
+	second := requests[1]
+	require.Len(second.Transistions, 1)
+	require.Len(second.Evals, 1)
+
+	third := requests[2]
+	require.Len(third.Transistions, 0)
+	require.Len(third.Evals, 2)
+}
+
+func TestDrainer_PartitionIds(t *testing.T) {
+	require := require.New(t)
+
+	// Set the max ids per reap to something lower.
+	old := maxIdsPerTxn
+	defer func() { maxIdsPerTxn = old }()
+	maxIdsPerTxn = 2
+
+	ids := []string{"1", "2", "3", "4", "5"}
+	requests := partitionIds(ids)
+	require.Len(requests, 3)
+	require.Len(requests[0], 2)
+	require.Len(requests[1], 2)
+	require.Len(requests[2], 1)
+	require.Equal(requests[0][0], ids[0])
+	require.Equal(requests[0][1], ids[1])
+	require.Equal(requests[1][0], ids[2])
+	require.Equal(requests[1][1], ids[3])
+	require.Equal(requests[2][0], ids[4])
+}

--- a/nomad/drainer/watch_nodes.go
+++ b/nomad/drainer/watch_nodes.go
@@ -89,7 +89,7 @@ func (n *NodeDrainer) Update(node *structs.Node) {
 	}
 
 	if done {
-		index, err := n.raft.NodeDrainComplete(node.ID)
+		index, err := n.raft.NodesDrainComplete([]string{node.ID})
 		if err != nil {
 			n.logger.Printf("[ERR] nomad.drain: failed to unset drain for node %q: %v", node.ID, err)
 		} else {

--- a/nomad/drainer_shims.go
+++ b/nomad/drainer_shims.go
@@ -8,14 +8,18 @@ type drainerShim struct {
 	s *Server
 }
 
-func (d drainerShim) NodeDrainComplete(nodeID string) (uint64, error) {
-	args := &structs.NodeUpdateDrainRequest{
-		NodeID:       nodeID,
-		Drain:        false,
+func (d drainerShim) NodesDrainComplete(nodes []string) (uint64, error) {
+	args := &structs.BatchNodeUpdateDrainRequest{
+		Updates:      make(map[string]*structs.DrainUpdate, len(nodes)),
 		WriteRequest: structs.WriteRequest{Region: d.s.config.Region},
 	}
 
-	resp, index, err := d.s.raftApply(structs.NodeUpdateDrainRequestType, args)
+	update := &structs.DrainUpdate{}
+	for _, node := range nodes {
+		args.Updates[node] = update
+	}
+
+	resp, index, err := d.s.raftApply(structs.BatchNodeUpdateDrainRequestType, args)
 	return d.convertApplyErrors(resp, index, err)
 }
 

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -267,7 +267,7 @@ func TestFSM_BatchUpdateNodeDrain(t *testing.T) {
 	resp = fsm.Apply(makeLog(buf))
 	require.Nil(resp)
 
-	// Verify we are NOT registered
+	// Verify drain is set
 	ws := memdb.NewWatchSet()
 	node, err = fsm.State().NodeByID(ws, req.Node.ID)
 	require.Nil(err)

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -234,6 +234,47 @@ func TestFSM_UpdateNodeStatus(t *testing.T) {
 	})
 }
 
+func TestFSM_BatchUpdateNodeDrain(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	fsm := testFSM(t)
+
+	node := mock.Node()
+	req := structs.NodeRegisterRequest{
+		Node: node,
+	}
+	buf, err := structs.Encode(structs.NodeRegisterRequestType, req)
+	require.Nil(err)
+
+	resp := fsm.Apply(makeLog(buf))
+	require.Nil(resp)
+
+	strategy := &structs.DrainStrategy{
+		DrainSpec: structs.DrainSpec{
+			Deadline: 10 * time.Second,
+		},
+	}
+	req2 := structs.BatchNodeUpdateDrainRequest{
+		Updates: map[string]*structs.DrainUpdate{
+			node.ID: &structs.DrainUpdate{
+				DrainStrategy: strategy,
+			},
+		},
+	}
+	buf, err = structs.Encode(structs.BatchNodeUpdateDrainRequestType, req2)
+	require.Nil(err)
+
+	resp = fsm.Apply(makeLog(buf))
+	require.Nil(resp)
+
+	// Verify we are NOT registered
+	ws := memdb.NewWatchSet()
+	node, err = fsm.State().NodeByID(ws, req.Node.ID)
+	require.Nil(err)
+	require.True(node.Drain)
+	require.Equal(node.DrainStrategy, strategy)
+}
+
 func TestFSM_UpdateNodeDrain(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -605,12 +605,34 @@ func (s *StateStore) UpdateNodeStatus(index uint64, nodeID, status string) error
 	return nil
 }
 
+// BatchUpdateNodeDrain is used to update the drain of a node set of nodes
+func (s *StateStore) BatchUpdateNodeDrain(index uint64, updates map[string]*structs.DrainUpdate) error {
+	txn := s.db.Txn(true)
+	defer txn.Abort()
+	for node, update := range updates {
+		if err := s.updateNodeDrainImpl(txn, index, node, update.DrainStrategy, update.MarkEligible); err != nil {
+			return err
+		}
+	}
+	txn.Commit()
+	return nil
+}
+
 // UpdateNodeDrain is used to update the drain of a node
 func (s *StateStore) UpdateNodeDrain(index uint64, nodeID string,
 	drain *structs.DrainStrategy, markEligible bool) error {
 
 	txn := s.db.Txn(true)
 	defer txn.Abort()
+	if err := s.updateNodeDrainImpl(txn, index, nodeID, drain, markEligible); err != nil {
+		return err
+	}
+	txn.Commit()
+	return nil
+}
+
+func (s *StateStore) updateNodeDrainImpl(txn *memdb.Txn, index uint64, nodeID string,
+	drain *structs.DrainStrategy, markEligible bool) error {
 
 	// Lookup the node
 	existing, err := txn.First("nodes", "id", nodeID)
@@ -644,7 +666,6 @@ func (s *StateStore) UpdateNodeDrain(index uint64, nodeID string,
 		return fmt.Errorf("index update failed: %v", err)
 	}
 
-	txn.Commit()
 	return nil
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -76,6 +76,7 @@ const (
 	AutopilotRequestType
 	AllocUpdateDesiredTransitionRequestType
 	NodeUpdateEligibilityRequestType
+	BatchNodeUpdateDrainRequestType
 )
 
 const (
@@ -304,6 +305,23 @@ type NodeUpdateDrainRequest struct {
 	// MarkEligible marks the node as eligible if removing the drain strategy.
 	MarkEligible bool
 	WriteRequest
+}
+
+// BatchNodeUpdateDrainRequest is used for updating the drain strategy for a
+// batch of nodes
+type BatchNodeUpdateDrainRequest struct {
+	// Updates is a mapping of nodes to their updated drain strategy
+	Updates map[string]*DrainUpdate
+	WriteRequest
+}
+
+// DrainUpdate is used to update the drain of a node
+type DrainUpdate struct {
+	// DrainStrategy is the new strategy for the node
+	DrainStrategy *DrainStrategy
+
+	// MarkEligible marks the node as eligible if removing the drain strategy.
+	MarkEligible bool
 }
 
 // NodeUpdateEligibilityRequest is used for updating the scheduling	eligibility


### PR DESCRIPTION
Shard requests that involve sets of objects to keep individual raft request sizes small.