### PR TITLE
Make server side error messages from vault more clearer

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1754,11 +1754,11 @@ func (c *Client) deriveToken(alloc *structs.Allocation, taskNames []string, vcli
 	var resp structs.DeriveVaultTokenResponse
 	if err := c.RPC("Node.DeriveVaultToken", &req, &resp); err != nil {
 		c.logger.Printf("[ERR] client.vault: DeriveVaultToken RPC failed: %v", err)
-		return nil, fmt.Errorf("DeriveVaultToken RPC failed: %v", err)
+		return nil, structs.NewWrappedServerError(resp.Error)
 	}
 	if resp.Error != nil {
 		c.logger.Printf("[ERR] client.vault: failed to derive vault tokens: %v", resp.Error)
-		return nil, resp.Error
+		return nil, structs.NewWrappedServerError(resp.Error)
 	}
 	if resp.Tasks == nil {
 		c.logger.Printf("[ERR] client.vault: failed to derive vault token: invalid response")

--- a/client/client.go
+++ b/client/client.go
@@ -1754,7 +1754,7 @@ func (c *Client) deriveToken(alloc *structs.Allocation, taskNames []string, vcli
 	var resp structs.DeriveVaultTokenResponse
 	if err := c.RPC("Node.DeriveVaultToken", &req, &resp); err != nil {
 		c.logger.Printf("[ERR] client.vault: DeriveVaultToken RPC failed: %v", err)
-		return nil, structs.NewWrappedServerError(resp.Error)
+		return nil, structs.NewWrappedServerError(err)
 	}
 	if resp.Error != nil {
 		c.logger.Printf("[ERR] client.vault: failed to derive vault tokens: %v", resp.Error)

--- a/client/client.go
+++ b/client/client.go
@@ -1754,7 +1754,7 @@ func (c *Client) deriveToken(alloc *structs.Allocation, taskNames []string, vcli
 	var resp structs.DeriveVaultTokenResponse
 	if err := c.RPC("Node.DeriveVaultToken", &req, &resp); err != nil {
 		c.logger.Printf("[ERR] client.vault: DeriveVaultToken RPC failed: %v", err)
-		return nil, structs.NewWrappedServerError(err)
+		return nil, fmt.Errorf("DeriveVaultToken RPC failed: %v", err)
 	}
 	if resp.Error != nil {
 		c.logger.Printf("[ERR] client.vault: failed to derive vault tokens: %v", resp.Error)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -854,6 +854,13 @@ func (r *TaskRunner) deriveVaultToken() (token string, exit bool) {
 			return tokens[r.task.Name], false
 		}
 
+		// Check if this is a server side error
+		if structs.IsServerSide(err) {
+			r.logger.Printf("[ERR] client: failed to derive Vault token for task %v on alloc %q: %v",
+				r.task.Name, r.alloc.ID, err)
+			r.Kill("vault", fmt.Sprintf("server error in deriving vault token: %v", err), true)
+			return "", true
+		}
 		// Check if we can't recover from the error
 		if !structs.IsRecoverable(err) {
 			r.logger.Printf("[ERR] client: failed to derive Vault token for task %v on alloc %q: %v",

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -858,7 +858,7 @@ func (r *TaskRunner) deriveVaultToken() (token string, exit bool) {
 		if structs.IsServerSide(err) {
 			r.logger.Printf("[ERR] client: failed to derive Vault token for task %v on alloc %q: %v",
 				r.task.Name, r.alloc.ID, err)
-			r.Kill("vault", fmt.Sprintf("server error in deriving vault token: %v", err), true)
+			r.Kill("vault", fmt.Sprintf("server error deriving vault token: %v", err), true)
 			return "", true
 		}
 		// Check if we can't recover from the error

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1143,10 +1143,10 @@ func (n *Node) DeriveVaultToken(args *structs.DeriveVaultTokenRequest,
 		if e == nil {
 			return
 		}
-		re, ok := e.(structs.Recoverable)
+		re, ok := e.(*structs.RecoverableError)
 		if ok {
-			// No need to wrap if error already implements Recoverable
-			reply.Error = re.(*structs.RecoverableError)
+			// No need to wrap if error is already a RecoverableError
+			reply.Error = re
 		} else {
 			reply.Error = structs.NewRecoverableError(e, recoverable).(*structs.RecoverableError)
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6137,7 +6137,7 @@ func IsRecoverable(e error) bool {
 // WrappedServerError wraps an error and satisfies
 // both the Recoverable and the ServerSideError interfaces
 type WrappedServerError struct {
-	Err         error
+	Err error
 }
 
 // NewWrappedServerError is used to create a wrapped server side error
@@ -6160,7 +6160,7 @@ func (r *WrappedServerError) IsServerSide() bool {
 }
 
 // ServerSideError is an interface for errors to implement to indicate
-// errors occuring after the request makes it to a server
+// errors occurring after the request makes it to a server
 type ServerSideError interface {
 	error
 	IsServerSide() bool

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6159,8 +6159,8 @@ func (r *WrappedServerError) IsServerSide() bool {
 	return true
 }
 
-// Recoverable is an interface for errors to implement to indicate whether or
-// not they are fatal or recoverable.
+// ServerSideError is an interface for errors to implement to indicate
+// errors occuring after the request makes it to a server
 type ServerSideError interface {
 	error
 	IsServerSide() bool

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4189,7 +4189,7 @@ func (event *TaskEvent) PopulateEventDisplayMessage() {
 		}
 	case TaskKilling:
 		if event.KillReason != "" {
-			desc = fmt.Sprintf("Killing task: %v", event.KillReason)
+			desc = event.KillReason
 		} else if event.KillTimeout != 0 {
 			desc = fmt.Sprintf("Sent interrupt. Waiting %v before force killing", event.KillTimeout)
 		} else {
@@ -6130,6 +6130,47 @@ type Recoverable interface {
 func IsRecoverable(e error) bool {
 	if re, ok := e.(Recoverable); ok {
 		return re.IsRecoverable()
+	}
+	return false
+}
+
+// WrappedServerError wraps an error and satisfies
+// both the Recoverable and the ServerSideError interfaces
+type WrappedServerError struct {
+	Err         error
+}
+
+// NewWrappedServerError is used to create a wrapped server side error
+func NewWrappedServerError(e error) error {
+	return &WrappedServerError{
+		Err: e,
+	}
+}
+
+func (r *WrappedServerError) IsRecoverable() bool {
+	return IsRecoverable(r.Err)
+}
+
+func (r *WrappedServerError) Error() string {
+	return r.Err.Error()
+}
+
+func (r *WrappedServerError) IsServerSide() bool {
+	return true
+}
+
+// Recoverable is an interface for errors to implement to indicate whether or
+// not they are fatal or recoverable.
+type ServerSideError interface {
+	error
+	IsServerSide() bool
+}
+
+// IsServerSide returns true if error is a wrapped
+// server side error
+func IsServerSide(e error) bool {
+	if se, ok := e.(ServerSideError); ok {
+		return se.IsServerSide()
 	}
 	return false
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -3077,7 +3077,7 @@ func TestTaskEventPopulate(t *testing.T) {
 		{NewTaskEvent(TaskRestarting).SetRestartDelay(2 * time.Second).SetRestartReason(ReasonWithinPolicy), "Task restarting in 2s"},
 		{NewTaskEvent(TaskRestarting).SetRestartReason("Chaos Monkey did it"), "Chaos Monkey did it - Task restarting in 0s"},
 		{NewTaskEvent(TaskKilling), "Sent interrupt"},
-		{NewTaskEvent(TaskKilling).SetKillReason("Its time for you to die"), "Killing task: Its time for you to die"},
+		{NewTaskEvent(TaskKilling).SetKillReason("Its time for you to die"), "Its time for you to die"},
 		{NewTaskEvent(TaskKilling).SetKillTimeout(1 * time.Second), "Sent interrupt. Waiting 1s before force killing"},
 		{NewTaskEvent(TaskTerminated).SetExitCode(-1).SetSignal(3), "Exit Code: -1, Signal: 3"},
 		{NewTaskEvent(TaskTerminated).SetMessage("Goodbye"), "Exit Code: 0, Exit Message: \"Goodbye\""},


### PR DESCRIPTION
_new code_
```
Recent Events:
Time                       Type             Description
2018-03-13T17:05:21-05:00  Alloc Unhealthy  Unhealthy because of failed task
2018-03-13T17:05:21-05:00  Killing          vault: server error in deriving vault token: Nomad Server failed to establish connections to Vault: failed to lookup Vault periodic token: Error making API request.

URL: POST http://127.0.0.1:8200/v1/auth/token/looku
Code: 503. Errors:

* Vault is sealed
2018-03-13T17:05:21-05:00  Task Setup       Building Task Directory
```

_master_
```
Recent Events:
Time                       Type             Description
2018-03-12T16:50:04-05:00  Alloc Unhealthy  Unhealthy because of failed task
2018-03-12T16:50:04-05:00  Killing          Killing task: vault: failed to derive token: failed to create token for task "redis" on alloc "259d25ad-f17d-03bf-691a-95ebb9050479": Nomad Server failed to establish connections to Vault: failed to lookup Vault periodic token: Error making API request.

URL: POST http://127.0.0.1:8200/v1/auth/token/lookup
Code: 503. Errors:

* Vault is sealed
2018-03-12T16:50:04-05:00  Task Setup       Building Task Directory
..
```