### PR TITLE
Always add core scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,9 @@ BUG FIXES:
  * client: Improve auto-detection of network interface when interface name has a
    space in it on Windows [[GH-3855](https://github.com/hashicorp/nomad/issues/3855)]
  * client/vault: Recognize renewing non-renewable Vault lease as fatal [[GH-3727](https://github.com/hashicorp/nomad/issues/3727)]
- * config: Revert minimum CPU limit back to 20 from 100.
+ * config: Revert minimum CPU limit back to 20 from 100 [[GH-3706](https://github.com/hashicorp/nomad/issues/3706)]
+ * config: Always add core scheduler to enabled schedulers and add invalid
+   EnabledScheduler detection [[GH-3978](https://github.com/hashicorp/nomad/issues/3978)]
  * driver/exec: Properly disable swapping [[GH-3958](https://github.com/hashicorp/nomad/issues/3958)]
  * driver/lxc: Cleanup LXC containers after errors on container startup. [[GH-3773](https://github.com/hashicorp/nomad/issues/3773)]
  * ui: Fix ui on non-leaders when ACLs are enabled [[GH-3722](https://github.com/hashicorp/nomad/issues/3722)]

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -149,7 +149,20 @@ func convertServerConfig(agentConfig *Config, logOutput io.Writer) (*nomad.Confi
 		conf.NumSchedulers = agentConfig.Server.NumSchedulers
 	}
 	if len(agentConfig.Server.EnabledSchedulers) != 0 {
-		conf.EnabledSchedulers = agentConfig.Server.EnabledSchedulers
+		// Convert to a set and require the core scheduler
+		set := make(map[string]struct{}, 4)
+		set[structs.JobTypeCore] = struct{}{}
+		for _, sched := range agentConfig.Server.EnabledSchedulers {
+			set[sched] = struct{}{}
+		}
+
+		schedulers := make([]string, 0, len(set))
+		for k := range set {
+			schedulers = append(schedulers, k)
+		}
+
+		conf.EnabledSchedulers = schedulers
+
 	}
 	if agentConfig.ACL.Enabled {
 		conf.ACLEnabled = true

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1193,6 +1193,18 @@ func (s *Server) setupWorkers() error {
 		return nil
 	}
 
+	// Check if the core scheduler is not enabled
+	found := false
+	for _, scheduler := range s.config.EnabledSchedulers {
+		if scheduler == structs.JobTypeCore {
+			found = true
+			break
+		}
+	}
+	if !found {
+		panic(fmt.Sprintf("invalid configuration: %q scheduler not enabled", structs.JobTypeCore))
+	}
+
 	// Start the workers
 	for i := 0; i < s.config.NumSchedulers; i++ {
 		if w, err := NewWorker(s); err != nil {


### PR DESCRIPTION
This PR causes the core scheduler to always be enabled and also adds error
checking to detect the core scheduler missing (programmer error) and users
adding invalid scheduler types.

Fixes https://github.com/hashicorp/nomad/issues/3658