### PR TITLE
Read task name off of the state rather than the task

### DIFF
--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -50,7 +50,7 @@
             <tr data-test-task-row={{row.model.task.name}}>
               <td data-test-name>
                 {{#link-to "allocations.allocation.task" row.model.allocation row.model}}
-                  {{row.model.task.name}}
+                  {{row.model.name}}
                 {{/link-to}}
               </td>
               <td data-test-state>{{row.model.state}}</td>


### PR DESCRIPTION
It's possible for the task (derived from the job API response)
to be nil, or have a nil name field.

Using the task state instead ensures a name every time.