### PR TITLE
UI: Read job summary from Jobs.List

### DIFF
--- a/ui/app/components/allocation-row.js
+++ b/ui/app/components/allocation-row.js
@@ -58,6 +58,9 @@ function qualifyJob() {
         job,
         originalJobId: null,
       });
+      if (job.get('isPartial')) {
+        job.reload();
+      }
     } else {
       this.get('store')
         .findRecord('job', allocation.get('originalJobId'))

--- a/ui/app/components/job-row.js
+++ b/ui/app/components/job-row.js
@@ -1,10 +1,8 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { lazyClick } from '../helpers/lazy-click';
-import { watchRelationship } from 'nomad-ui/utils/properties/watch';
-import WithVisibilityDetection from 'nomad-ui/mixins/with-component-visibility-detection';
 
-export default Component.extend(WithVisibilityDetection, {
+export default Component.extend({
   store: service(),
 
   tagName: 'tr',
@@ -17,32 +15,4 @@ export default Component.extend(WithVisibilityDetection, {
   click(event) {
     lazyClick([this.get('onClick'), event]);
   },
-
-  didReceiveAttrs() {
-    // Reload the job in order to get detail information
-    const job = this.get('job');
-    if (job && !job.get('isLoading')) {
-      job.reload().then(() => {
-        this.get('watch').perform(job, 100);
-      });
-    }
-  },
-
-  visibilityHandler() {
-    if (document.hidden) {
-      this.get('watch').cancelAll();
-    } else {
-      const job = this.get('job');
-      if (job && !job.get('isLoading')) {
-        this.get('watch').perform(job, 100);
-      }
-    }
-  },
-
-  willDestroy() {
-    this.get('watch').cancelAll();
-    this._super(...arguments);
-  },
-
-  watch: watchRelationship('summary'),
 });

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -84,6 +84,11 @@ export default Model.extend({
   taskGroups: fragmentArray('task-group', { defaultValue: () => [] }),
   summary: belongsTo('job-summary'),
 
+  // A job model created from the jobs list response will be lacking
+  // task groups. This is an indicator that it needs to be reloaded
+  // if task group information is important.
+  isPartial: equal('taskGroups.length', 0),
+
   // If a job has only been loaded through the list request, the task groups
   // are still unknown. However, the count of task groups is available through
   // the job-summary model which is embedded in the jobs list response.

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -84,6 +84,11 @@ export default Model.extend({
   taskGroups: fragmentArray('task-group', { defaultValue: () => [] }),
   summary: belongsTo('job-summary'),
 
+  // If a job has only been loaded through the list request, the task groups
+  // are still unknown. However, the count of task groups is available through
+  // the job-summary model which is embedded in the jobs list response.
+  taskGroupCount: or('taskGroups.length', 'taskGroupSummaries.length'),
+
   // Alias through to the summary, as if there was no relationship
   taskGroupSummaries: alias('summary.taskGroupSummaries'),
   queuedAllocs: alias('summary.queuedAllocs'),

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -33,6 +33,14 @@ export default ApplicationSerializer.extend({
       hash.ParameterizedJob = true;
     }
 
+    // If the hash contains summary information, push it into the store
+    // as a job-summary model.
+    if (hash.JobSummary) {
+      this.store.pushPayload('job-summary', {
+        'job-summary': [hash.JobSummary],
+      });
+    }
+
     return this._super(typeHash, hash);
   },
 

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -5,8 +5,8 @@
 <td data-test-job-type>{{job.displayType}}</td>
 <td data-test-job-priority>{{job.priority}}</td>
 <td data-test-job-task-groups>
-  {{#if job.taskGroups.length}}
-    {{job.taskGroups.length}}
+  {{#if job.taskGroupCount}}
+    {{job.taskGroupCount}}
   {{else}}
     --
   {{/if}}


### PR DESCRIPTION
This eliminates the n + 1 open connections problem. Now the jobs list page will poll for all updates using only one request.