### PR TITLE
RPC Advertise used exclusively for Clients

### DIFF
--- a/api/operator_autopilot_test.go
+++ b/api/operator_autopilot_test.go
@@ -82,16 +82,20 @@ func TestAPI_OperatorAutopilotServerHealth(t *testing.T) {
 	defer s.Stop()
 
 	operator := c.Operator()
-	retry.Run(t, func(r *retry.R) {
+	testutil.WaitForResult(func() (bool, error) {
 		out, _, err := operator.AutopilotServerHealth(nil)
 		if err != nil {
-			r.Fatalf("err: %v", err)
+			return false, err
 		}
 
 		if len(out.Servers) != 1 ||
 			!out.Servers[0].Healthy ||
 			out.Servers[0].Name != fmt.Sprintf("%s.global", s.Config.NodeName) {
-			r.Fatalf("bad: %v", out)
+			return false, fmt.Errorf("%v", out)
 		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
 	})
 }

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -229,7 +229,7 @@ func convertServerConfig(agentConfig *Config, logOutput io.Writer) (*nomad.Confi
 	// address that all servers should be able to communicate over RPC with.
 	serverAddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(serfAddr.IP.String(), fmt.Sprintf("%d", rpcAddr.Port)))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse Serf advertise address %q: %v", agentConfig.AdvertiseAddrs.Serf, err)
+		return nil, fmt.Errorf("Failed to resolve Serf advertise address %q: %v", agentConfig.AdvertiseAddrs.Serf, err)
 	}
 
 	conf.SerfConfig.MemberlistConfig.AdvertiseAddr = serfAddr.IP.String()

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -224,9 +224,18 @@ func convertServerConfig(agentConfig *Config, logOutput io.Writer) (*nomad.Confi
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse Serf advertise address %q: %v", agentConfig.AdvertiseAddrs.Serf, err)
 	}
-	conf.RPCAdvertise = rpcAddr
+
+	// Server address is the serf advertise address and rpc port. This is the
+	// address that all servers should be able to communicate over RPC with.
+	serverAddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(serfAddr.IP.String(), fmt.Sprintf("%d", rpcAddr.Port)))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse Serf advertise address %q: %v", agentConfig.AdvertiseAddrs.Serf, err)
+	}
+
 	conf.SerfConfig.MemberlistConfig.AdvertiseAddr = serfAddr.IP.String()
 	conf.SerfConfig.MemberlistConfig.AdvertisePort = serfAddr.Port
+	conf.ClientRPCAdvertise = rpcAddr
+	conf.ServerRPCAdvertise = serverAddr
 
 	// Set up gc threshold and heartbeat grace period
 	if gcThreshold := agentConfig.Server.NodeGCThreshold; gcThreshold != "" {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -36,6 +36,7 @@ func TestAgent_ServerConfig(t *testing.T) {
 	t.Parallel()
 	conf := DefaultConfig()
 	conf.DevMode = true // allow localhost for advertise addrs
+	conf.Server.Enabled = true
 	a := &Agent{config: conf}
 
 	conf.AdvertiseAddrs.Serf = "127.0.0.1:4000"

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -81,7 +81,7 @@ type Config struct {
 	// by the other servers and clients
 	RPCAddr *net.TCPAddr
 
-	// ClientRPCAdvertise is the address that is advertised to other nodes for
+	// ClientRPCAdvertise is the address that is advertised to client nodes for
 	// the RPC endpoint. This can differ from the RPC address, if for example
 	// the RPCAddr is unspecified "0.0.0.0:4646", but this address must be
 	// reachable

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -81,11 +81,17 @@ type Config struct {
 	// by the other servers and clients
 	RPCAddr *net.TCPAddr
 
-	// RPCAdvertise is the address that is advertised to other nodes for
+	// ClientRPCAdvertise is the address that is advertised to other nodes for
 	// the RPC endpoint. This can differ from the RPC address, if for example
 	// the RPCAddr is unspecified "0.0.0.0:4646", but this address must be
 	// reachable
-	RPCAdvertise *net.TCPAddr
+	ClientRPCAdvertise *net.TCPAddr
+
+	// ServerRPCAdvertise is the address that is advertised to other servers for
+	// the RPC endpoint. This can differ from the RPC address, if for example
+	// the RPCAddr is unspecified "0.0.0.0:4646", but this address must be
+	// reachable
+	ServerRPCAdvertise *net.TCPAddr
 
 	// RaftConfig is the configuration used for Raft in the local DC
 	RaftConfig *raft.Config

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -178,10 +178,10 @@ func (n *Node) constructNodeServerInfoResponse(snap *state.StateSnapshot, reply 
 
 	// Reply with config information required for future RPC requests
 	reply.Servers = make([]*structs.NodeServerInfo, 0, len(n.srv.localPeers))
-	for k, v := range n.srv.localPeers {
+	for _, v := range n.srv.localPeers {
 		reply.Servers = append(reply.Servers,
 			&structs.NodeServerInfo{
-				RPCAdvertiseAddr: string(k),
+				RPCAdvertiseAddr: v.RPCAddr.String(),
 				RPCMajorVersion:  int32(v.MajorVersion),
 				RPCMinorVersion:  int32(v.MinorVersion),
 				Datacenter:       v.Datacenter,

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -2,6 +2,7 @@ package nomad
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
@@ -703,6 +704,45 @@ func TestClientEndpoint_UpdateStatus_HeartbeatOnly(t *testing.T) {
 	if ttl < s1.config.MinHeartbeatTTL || ttl > 2*s1.config.MinHeartbeatTTL {
 		t.Fatalf("bad: %#v", ttl)
 	}
+}
+
+func TestClientEndpoint_UpdateStatus_HeartbeatOnly_Advertise(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	advAddr := "127.0.1.1:1234"
+	adv, err := net.ResolveTCPAddr("tcp", advAddr)
+	require.Nil(err)
+
+	s1 := TestServer(t, func(c *Config) {
+		c.ClientRPCAdvertise = adv
+	})
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	node := mock.Node()
+	reg := &structs.NodeRegisterRequest{
+		Node:         node,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	// Fetch the response
+	var resp structs.NodeUpdateResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Node.Register", reg, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check for heartbeat interval
+	ttl := resp.HeartbeatTTL
+	if ttl < s1.config.MinHeartbeatTTL || ttl > 2*s1.config.MinHeartbeatTTL {
+		t.Fatalf("bad: %#v", ttl)
+	}
+
+	// Check for heartbeat servers
+	require.Len(resp.Servers, 1)
+	require.Equal(resp.Servers[0].RPCAdvertiseAddr, advAddr)
 }
 
 func TestClientEndpoint_UpdateDrain(t *testing.T) {

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -424,6 +424,7 @@ func TestServer_InvalidSchedulers(t *testing.T) {
 	config := DefaultConfig()
 	config.DevMode = true
 	config.LogOutput = testlog.NewWriter(t)
+	config.SerfConfig.MemberlistConfig.BindAddr = "127.0.0.1"
 	logger := log.New(config.LogOutput, "", log.LstdFlags)
 	catalog := consul.NewMockCatalog(logger)
 

--- a/nomad/stats_fetcher.go
+++ b/nomad/stats_fetcher.go
@@ -42,7 +42,7 @@ func NewStatsFetcher(logger *log.Logger, pool *pool.ConnPool, region string) *St
 func (f *StatsFetcher) fetch(server *serverParts, replyCh chan *autopilot.ServerStats) {
 	var args struct{}
 	var reply autopilot.ServerStats
-	err := f.pool.RPC(f.region, server.RPCAddr, server.MajorVersion, "Status.RaftStats", &args, &reply)
+	err := f.pool.RPC(f.region, server.Addr, server.MajorVersion, "Status.RaftStats", &args, &reply)
 	if err != nil {
 		f.logger.Printf("[WARN] nomad: error getting server health from %q: %v",
 			server.Name, err)

--- a/website/source/docs/agent/configuration/index.html.md
+++ b/website/source/docs/agent/configuration/index.html.md
@@ -37,13 +37,12 @@ Here is an example Nomad agent configuration that runs in both client and server
 mode.
 
 ```hcl
-bind_addr = "0.0.0.0" # the default
-
 data_dir  = "/var/lib/nomad"
 
+bind_addr = "0.0.0.0" # the default
+
 advertise {
-  # Defaults to the node's hostname. If the hostname resolves to a loopback
-  # address you must manually configure advertise addresses.
+  # Defaults to the first private IP address.
   http = "1.2.3.4"
   rpc  = "1.2.3.4"
   serf = "1.2.3.4:5648" # non-default ports may be specified
@@ -97,7 +96,9 @@ testing.
   configurations such as NAT. This configuration is optional, and defaults to
   the bind address of the specific network service if it is not provided. Any
   values configured in this stanza take precedence over the default
-  [bind_addr](#bind_addr). If the bind address is `0.0.0.0` then the first
+  [bind_addr](#bind_addr).
+    
+    If the bind address is `0.0.0.0` then the address 
   private IP found is advertised. You may advertise an alternate port as well.
   The values support [go-sockaddr/template format][go-sockaddr/template].
 
@@ -105,12 +106,14 @@ testing.
     reachable by all the nodes from which end users are going to use the Nomad
     CLI tools.
 
-  - `rpc` - The address to advertise for the RPC interface. This address should
-    be reachable by all of the agents in the cluster.
+  - `rpc` - The address advertised to Nomad client nodes. This allows
+    advertising a different RPC address than is used by Nomad Servers such that
+    the clients can connect to the Nomad servers if they are behind a NAT.
 
   - `serf` - The address advertised for the gossip layer. This address must be
     reachable from all server nodes. It is not required that clients can reach
-    this address.
+    this address. Nomad servers will communicate to each other over RPC using
+    the advertised Serf IP and advertised RPC Port.
 
 - `bind_addr` `(string: "0.0.0.0")` - Specifies which address the Nomad
   agent should bind to for network services, including the HTTP interface as


### PR DESCRIPTION
This PR fixes mixed usage of the `advertise.Serf` and `advertise.RPC` fields for the server configuration. Now the advertised serf address is used for all server communication and the advertised RPC address is only used by Nomad clients. 

All Nomad servers should be able to resolve the advertised Serf address and dial the advertised RPC port. 

Fixes https://github.com/hashicorp/nomad/issues/3813