### PR TITLE
Show a section on upcoming delayed evaluations when applicable

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -648,6 +648,16 @@ func (j *Job) Canonicalize() {
 	}
 }
 
+// LookupTaskGroup finds a task group by name
+func (j *Job) LookupTaskGroup(name string) *TaskGroup {
+	for _, tg := range j.TaskGroups {
+		if *tg.Name == name {
+			return tg
+		}
+	}
+	return nil
+}
+
 // JobSummary summarizes the state of the allocations of a job
 type JobSummary struct {
 	JobID     string

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -132,6 +132,17 @@ func (r *ReschedulePolicy) Copy() *ReschedulePolicy {
 	return nrp
 }
 
+func (p *ReschedulePolicy) String() string {
+	if p == nil {
+		return ""
+	}
+	if *p.Unlimited {
+		return fmt.Sprintf("unlimited with %v delay, max_delay = %v", *p.DelayFunction, *p.MaxDelay)
+	} else {
+		return fmt.Sprintf("%v in %v with %v delay, max_delay = %v", *p.Attempts, *p.Interval, *p.DelayFunction, *p.MaxDelay)
+	}
+}
+
 // CheckRestart describes if and when a task should be restarted based on
 // failing health checks.
 type CheckRestart struct {

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -138,9 +138,8 @@ func (p *ReschedulePolicy) String() string {
 	}
 	if *p.Unlimited {
 		return fmt.Sprintf("unlimited with %v delay, max_delay = %v", *p.DelayFunction, *p.MaxDelay)
-	} else {
-		return fmt.Sprintf("%v in %v with %v delay, max_delay = %v", *p.Attempts, *p.Interval, *p.DelayFunction, *p.MaxDelay)
 	}
+	return fmt.Sprintf("%v in %v with %v delay, max_delay = %v", *p.Attempts, *p.Interval, *p.DelayFunction, *p.MaxDelay)
 }
 
 // CheckRestart describes if and when a task should be restarted based on

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -593,7 +593,7 @@ func (c *JobStatusCommand) outputReschedulingEvals(client *api.Client, job *api.
 	}
 	// Only show this section if there is pending evals
 	delayedEvalInfos = append(delayedEvalInfos, evalDetails...)
-	c.Ui.Output(c.Colorize().Color("\n[bold]Future Rescheduling Evaluations[reset]"))
+	c.Ui.Output(c.Colorize().Color("\n[bold]Future Rescheduling Attempts[reset]"))
 	c.Ui.Output(formatList(delayedEvalInfos))
 	return nil
 }

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -566,7 +566,7 @@ func (c *JobStatusCommand) outputReschedulingEvals(client *api.Client, allocList
 	var delayedEvalInfos []string
 
 	taskGroups := make([]string, 0, len(followUpEvalIds))
-	for taskGroup, _ := range followUpEvalIds {
+	for taskGroup := range followUpEvalIds {
 		taskGroups = append(taskGroups, taskGroup)
 	}
 	sort.Strings(taskGroups)

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -1,15 +1,20 @@
 package command
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJobStatusCommand_Implements(t *testing.T) {
@@ -274,6 +279,59 @@ func TestJobStatusCommand_WithAccessPolicy(t *testing.T) {
 	if !strings.Contains(out, *j.ID) {
 		t.Fatalf("should contain full identifiers, got %s", out)
 	}
+}
+
+func TestJobStatusCommand_RescheduleEvals(t *testing.T) {
+	t.Parallel()
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	// Wait for a node to be ready
+	testutil.WaitForResult(func() (bool, error) {
+		nodes, _, err := client.Nodes().List(nil)
+		if err != nil {
+			return false, err
+		}
+		for _, node := range nodes {
+			if node.Status == structs.NodeStatusReady {
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("no ready nodes")
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	ui := new(cli.MockUi)
+	cmd := &JobStatusCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	require := require.New(t)
+	state := srv.Agent.Server().State()
+
+	// Create state store objects for job, alloc and followup eval with a future WaitUntil value
+	j := mock.Job()
+	require.Nil(state.UpsertJob(900, j))
+
+	e := mock.Eval()
+	e.WaitUntil = time.Now().Add(1 * time.Hour)
+	require.Nil(state.UpsertEvals(902, []*structs.Evaluation{e}))
+	a := mock.Alloc()
+	a.Job = j
+	a.JobID = j.ID
+	a.TaskGroup = j.TaskGroups[0].Name
+	a.FollowupEvalID = e.ID
+	a.Metrics = &structs.AllocMetric{}
+	a.DesiredStatus = structs.AllocDesiredStatusRun
+	a.ClientStatus = structs.AllocClientStatusRunning
+	require.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+
+	// Query jobs with prefix match
+	if code := cmd.Run([]string{"-address=" + url, j.ID}); code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+	out := ui.OutputWriter.String()
+	require.Contains(out, "Upcoming Evaluations")
+	require.Contains(out, e.ID)
 }
 
 func waitForSuccess(ui cli.Ui, client *api.Client, length int, t *testing.T, evalId string) int {

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -330,7 +330,7 @@ func TestJobStatusCommand_RescheduleEvals(t *testing.T) {
 		t.Fatalf("expected exit 0, got: %d", code)
 	}
 	out := ui.OutputWriter.String()
-	require.Contains(out, "Upcoming Evaluations")
+	require.Contains(out, "Future Rescheduling Evaluations")
 	require.Contains(out, e.ID[:8])
 }
 

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -331,7 +331,7 @@ func TestJobStatusCommand_RescheduleEvals(t *testing.T) {
 	}
 	out := ui.OutputWriter.String()
 	require.Contains(out, "Upcoming Evaluations")
-	require.Contains(out, e.ID)
+	require.Contains(out, e.ID[:8])
 }
 
 func waitForSuccess(ui cli.Ui, client *api.Client, length int, t *testing.T, evalId string) int {

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -330,7 +330,7 @@ func TestJobStatusCommand_RescheduleEvals(t *testing.T) {
 		t.Fatalf("expected exit 0, got: %d", code)
 	}
 	out := ui.OutputWriter.String()
-	require.Contains(out, "Future Rescheduling Evaluations")
+	require.Contains(out, "Future Rescheduling Attempts")
 	require.Contains(out, e.ID[:8])
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5690,6 +5690,7 @@ func (a *Allocation) Stub() *AllocListStub {
 		ClientDescription:  a.ClientDescription,
 		TaskStates:         a.TaskStates,
 		DeploymentStatus:   a.DeploymentStatus,
+		FollowupEvalID:     a.FollowupEvalID,
 		CreateIndex:        a.CreateIndex,
 		ModifyIndex:        a.ModifyIndex,
 		CreateTime:         a.CreateTime,


### PR DESCRIPTION
Sample output
-------------------

```
preetha@preetha-work ~/go/src/github.com/hashicorp/nomad-oss (f-show-rescheduling-cli-job-status) $nomad job status test
ID            = test2
Name          = test2
Submit Date   = 2018-03-19T21:39:14-05:00
Type          = service
Priority      = 50
Datacenters   = dc1
Status        = pending
Periodic      = false
Parameterized = false

Summary
Task Group  Queued  Starting  Running  Failed  Complete  Lost
t2          0       0         0        6       0         0

Upcoming Evaluations
Task Group  Reschedule Policy                                     Eval ID   Eval Time
t2          unlimited with exponential delay, max_delay = 1h0m0s  2ffc80af  25s from now


Allocations
ID        Node ID   Task Group  Version  Desired  Status  Created  Modified
73d56651  fd4203ab  t2          0        run      failed  18s ago  18s ago
a214bfea  fd4203ab  t2          0        run      failed  18s ago  18s ago
e0a9148c  fd4203ab  t2          0        run      failed  19s ago  18s ago
...
```