### PR TITLE
UI: Extraneous deployment watcher

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -292,7 +292,7 @@ test-ui: ## Run Nomad UI test suite
 .PHONY: ember-dist
 ember-dist: ## Build the static UI assets from source
 	@echo "--> Installing JavaScript assets"
-	@cd ui && yarn install
+	@cd ui && yarn install --silent
 	@cd ui && npm rebuild node-sass
 	@echo "--> Building Ember application"
 	@cd ui && npm run build

--- a/ui/app/routes/jobs/job/index.js
+++ b/ui/app/routes/jobs/job/index.js
@@ -5,11 +5,14 @@ import WithWatchers from 'nomad-ui/mixins/with-watchers';
 
 export default Route.extend(WithWatchers, {
   startWatchers(controller, model) {
+    if (!model) {
+      return;
+    }
     controller.set('watchers', {
       model: this.get('watch').perform(model),
       summary: this.get('watchSummary').perform(model),
       evaluations: this.get('watchEvaluations').perform(model),
-      deployments: this.get('watchDeployments').perform(model),
+      deployments: model.get('supportsDeployments') && this.get('watchDeployments').perform(model),
     });
   },
 


### PR DESCRIPTION
Watching deployments should only happen on jobs that support deployments (currently only service jobs).