### PR TITLE
UI: Bundle o' bug fixes

### DIFF
--- a/ui/app/adapters/job-summary.js
+++ b/ui/app/adapters/job-summary.js
@@ -1,0 +1,12 @@
+import Watchable from './watchable';
+
+export default Watchable.extend({
+  urlForFindRecord(id, type, hash) {
+    const [name, namespace] = JSON.parse(id);
+    let url = this._super(name, 'job', hash) + '/summary';
+    if (namespace && namespace !== 'default') {
+      url += `?namespace=${namespace}`;
+    }
+    return url;
+  },
+});

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -116,6 +116,9 @@ export default ApplicationAdapter.extend({
   },
 
   cancelFindRecord(modelName, id) {
+    if (!modelName || id == null) {
+      return;
+    }
     const url = this.urlForFindRecord(id, modelName);
     const xhr = this.get('xhrs')[url];
     if (xhr) {
@@ -124,6 +127,9 @@ export default ApplicationAdapter.extend({
   },
 
   cancelFindAll(modelName) {
+    if (!modelName) {
+      return;
+    }
     const xhr = this.get('xhrs')[this.urlForFindAll(modelName)];
     if (xhr) {
       xhr.abort();
@@ -131,6 +137,9 @@ export default ApplicationAdapter.extend({
   },
 
   cancelReloadRelationship(model, relationshipName) {
+    if (!model || !relationshipName) {
+      return;
+    }
     const relationship = model.relationshipFor(relationshipName);
     if (relationship.kind !== 'belongsTo' && relationship.kind !== 'hasMany') {
       throw new Error(

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -53,7 +53,7 @@ export default Controller.extend(Sortable, Searchable, {
 
   actions: {
     gotoJob(job) {
-      this.transitionToRoute('jobs.job', job);
+      this.transitionToRoute('jobs.job', job.get('plainId'));
     },
 
     refresh() {

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -106,7 +106,7 @@ export default Model.extend({
   pendingChildren: alias('summary.pendingChildren'),
   runningChildren: alias('summary.runningChildren'),
   deadChildren: alias('summary.deadChildren'),
-  totalChildren: alias('summary.childrenList'),
+  totalChildren: alias('summary.totalChildren'),
 
   version: attr('number'),
 

--- a/ui/app/routes/jobs/job/index.js
+++ b/ui/app/routes/jobs/job/index.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { collect } from '@ember/object/computed';
-import { watchRecord, watchRelationship } from 'nomad-ui/utils/properties/watch';
+import { watchRecord, watchRelationship, watchAll } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
 
 export default Route.extend(WithWatchers, {
@@ -13,13 +13,15 @@ export default Route.extend(WithWatchers, {
       summary: this.get('watchSummary').perform(model),
       evaluations: this.get('watchEvaluations').perform(model),
       deployments: model.get('supportsDeployments') && this.get('watchDeployments').perform(model),
+      list: model.get('hasChildren') && this.get('watchAll').perform(),
     });
   },
 
   watch: watchRecord('job'),
+  watchAll: watchAll('job'),
   watchSummary: watchRelationship('summary'),
   watchEvaluations: watchRelationship('evaluations'),
   watchDeployments: watchRelationship('deployments'),
 
-  watchers: collect('watch', 'watchSummary', 'watchEvaluations', 'watchDeployments'),
+  watchers: collect('watch', 'watchAll', 'watchSummary', 'watchEvaluations', 'watchDeployments'),
 });

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -21,6 +21,10 @@ export default ApplicationSerializer.extend({
       hash.ParentID = JSON.stringify([hash.ParentID, hash.NamespaceID || 'default']);
     }
 
+    // Job Summary is always at /:job-id/summary, but since it can also come from
+    // the job list, it's better for Ember Data to be linked by ID association.
+    hash.SummaryID = hash.ID;
+
     // Periodic is a boolean on list and an object on single
     if (hash.Periodic instanceof Object) {
       hash.PeriodicDetails = hash.Periodic;
@@ -55,11 +59,6 @@ export default ApplicationSerializer.extend({
       .split('?');
 
     return assign(this._super(...arguments), {
-      summary: {
-        links: {
-          related: buildURL(`${jobURL}/summary`, { namespace: namespace }),
-        },
-      },
       allocations: {
         links: {
           related: buildURL(`${jobURL}/allocations`, { namespace: namespace }),

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -1,4 +1,4 @@
-<td data-test-job-name>{{#link-to "jobs.job" job class="is-primary"}}{{job.name}}{{/link-to}}</td>
+<td data-test-job-name>{{#link-to "jobs.job" job.plainId class="is-primary"}}{{job.name}}{{/link-to}}</td>
 <td data-test-job-status>
   <span class="tag {{job.statusClass}}">{{job.status}}</span>
 </td>

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -14,7 +14,11 @@
 <td data-test-job-allocations>
   <div class="inline-chart">
     {{#if job.hasChildren}}
-      {{children-status-bar job=job isNarrow=true}}
+      {{#if (gt job.totalChildren 0)}}
+        {{children-status-bar job=job isNarrow=true}}
+      {{else}}
+        <em class="is-faded">No Children</em>
+      {{/if}}
     {{else}}
       {{allocation-status-bar allocationContainer=job isNarrow=true}}
     {{/if}}


### PR DESCRIPTION
1. `v1/jobs` needs to be watched on periodic and parameterized job pages to poll child job updates
2. Periodic and parameterized job showed an Array.toString instead of the actual total child count
3. Requests that were canceled with no arguments (happens on a job detail page when the job in undefined) were throwing errors
4. Inter-linking to job detail pages bypassed authorization checking
5. `v1/job/:id/summary` was still required due to a manual relationship being set in the adapter