### PR TITLE
Document new Consul checks name config params and CLI flags.

### DIFF
--- a/website/source/docs/agent/configuration/consul.html.md
+++ b/website/source/docs/agent/configuration/consul.html.md
@@ -76,11 +76,23 @@ configuration, Nomad will automatically connect and configure with Consul.
 - `client_service_name` `(string: "nomad-client")` - Specifies the name of the
   service in Consul for the Nomad clients.
 
+- `client_http_check_name` `(string: "Nomad Client HTTP Check")` - Specifies the
+  HTTP health check name in Consul for the Nomad clients.
+
 - `key_file` `(string: "")` - Specifies the path to the private key used for
   Consul communication. If this is set then you need to also set `cert_file`.
 
 - `server_service_name` `(string: "nomad")` - Specifies the name of the service
   in Consul for the Nomad servers.
+
+- `server_http_check_name` `(string: "Nomad Server HTTP Check")` - Specifies the
+  HTTP health check name in Consul for the Nomad servers.
+
+-  `server_serf_check_name` `(string: "Nomad Server Serf Check")` - Specifies
+  the Serf health check name in Consul for the Nomad servers.
+
+-  `server_rpc_check_name` `(string: "Nomad Server RPC Check")` - Specifies
+  the RPC health check name in Consul for the Nomad servers.
 
 - `server_auto_join` `(bool: true)` - Specifies if the Nomad servers should
   automatically discover and join other Nomad servers by searching for the

--- a/website/source/docs/commands/agent.html.md.erb
+++ b/website/source/docs/commands/agent.html.md.erb
@@ -40,8 +40,12 @@ via CLI arguments. The `agent` command accepts the following arguments:
 * `-consul-checks-use-advertise`: Equivalent to the [checks_use_advertise](/docs/agent/configuration/consul.html#checks_use_advertise) config option.
 * `-consul-client-auto-join`: Equivalent to the [client_auto_join](/docs/agent/configuration/consul.html#client_auto_join) config option.
 * `-consul-client-service-name=<name>`: Equivalent to the [client_service_name](/docs/agent/configuration/consul.html#client_service_name) config option.
+* `-consul-client-http-check-name=<name>`: Equivalent to the [client_http_check_name](/docs/agent/configuration/consul.html#client_http_check_name) config option.
 * `-consul-key-file=<path>`: Equivalent to the [key_file](/docs/agent/configuration/consul.html#key_file) config option.
 * `-consul-server-service-name=<name>`: Equivalent to the [server_service_name](/docs/agent/configuration/consul.html#server_service_name) config option.
+* `-consul-server-http-check-name=<name>`: Equivalent to the [server_http_check_name](/docs/agent/configuration/consul.html#server_http_check_name) config option.
+* `-consul-server-serf-check-name=<name>`: Equivalent to the [server_serf_check_name](/docs/agent/configuration/consul.html#server_serf_check_name) config option.
+* `-consul-server-rpc-check-name=<name>`: Equivalent to the [server_rpc_check_name](/docs/agent/configuration/consul.html#server_rpc_check_name) config option.
 * `-consul-server-auto-join`: Equivalent to the [server_auto_join](/docs/agent/configuration/consul.html#server_auto_join) config option.
 * `-consul-ssl`: Equivalent to the [ssl](/docs/agent/configuration/consul.html#ssl) config option.
 * `-consul-token=<token>`: Equivalent to the [token](/docs/agent/configuration/consul.html#token) config option.


### PR DESCRIPTION
This update adds website documentation for the Consul check name parameters added within [GH-4003](https://github.com/hashicorp/nomad/pull/4003).

Closes #4018