### PR TITLE
UI: The initial index qp value should be 1, not 0

### DIFF
--- a/ui/app/services/watch-list.js
+++ b/ui/app/services/watch-list.js
@@ -14,7 +14,7 @@ export default Service.extend({
   },
 
   getIndexFor(url) {
-    return list[url] || 0;
+    return list[url] || 1;
   },
 
   setIndexFor(url, value) {

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -26,7 +26,7 @@ export default function() {
       const response = fn.apply(this, arguments);
 
       // Get and increment the appropriate index
-      nomadIndices[url] || (nomadIndices[url] = 1);
+      nomadIndices[url] || (nomadIndices[url] = 2);
       const index = nomadIndices[url];
       nomadIndices[url]++;
 

--- a/ui/tests/unit/adapters/job-test.js
+++ b/ui/tests/unit/adapters/job-test.js
@@ -103,7 +103,7 @@ test('findAll can be watched', function(assert) {
   );
   assert.equal(
     pretender.handledRequests[1].url,
-    '/v1/jobs?index=0',
+    '/v1/jobs?index=1',
     'Second request is a blocking request for jobs'
   );
 
@@ -111,7 +111,7 @@ test('findAll can be watched', function(assert) {
     request();
     assert.equal(
       pretender.handledRequests[2].url,
-      '/v1/jobs?index=1',
+      '/v1/jobs?index=2',
       'Third request is a blocking request with an incremented index param'
     );
 
@@ -137,7 +137,7 @@ test('findRecord can be watched', function(assert) {
   );
   assert.equal(
     pretender.handledRequests[1].url,
-    '/v1/job/job-1?index=0',
+    '/v1/job/job-1?index=1',
     'Second request is a blocking request for job-1'
   );
 
@@ -145,7 +145,7 @@ test('findRecord can be watched', function(assert) {
     request();
     assert.equal(
       pretender.handledRequests[2].url,
-      '/v1/job/job-1?index=1',
+      '/v1/job/job-1?index=2',
       'Third request is a blocking request with an incremented index param'
     );
 
@@ -174,7 +174,7 @@ test('relationship reloads can be watched', function(assert) {
   this.subject().reloadRelationship(mockModel, 'summary', true);
   assert.equal(
     pretender.handledRequests[0].url,
-    '/v1/job/job-1/summary?index=0',
+    '/v1/job/job-1/summary?index=1',
     'First request is a blocking request for job-1 summary relationship'
   );
 
@@ -182,7 +182,7 @@ test('relationship reloads can be watched', function(assert) {
     this.subject().reloadRelationship(mockModel, 'summary', true);
     assert.equal(
       pretender.handledRequests[1].url,
-      '/v1/job/job-1/summary?index=1',
+      '/v1/job/job-1/summary?index=2',
       'Second request is a blocking request with an incremented index param'
     );
   });


### PR DESCRIPTION
A query param of `index=0` operates as if the query param isn't present. Instead, 1 should be the value, which will make the request block even when there is nothing to respond with yet.