### PR TITLE
UI: Use native fetch in production when available

### DIFF
--- a/ui/app/utils/fetch.js
+++ b/ui/app/utils/fetch.js
@@ -4,7 +4,11 @@ import config from '../config/environment';
 
 // The ember-fetch polyfill does not provide streaming
 // Additionally, Mirage/Pretender does not support fetch
-const mirageEnabled = config['ember-cli-mirage'] && config['ember-cli-mirage'].enabled !== false;
+const mirageEnabled =
+  config.environment !== 'production' &&
+  config['ember-cli-mirage'] &&
+  config['ember-cli-mirage'].enabled !== false;
+
 const fetchToUse = Ember.testing || mirageEnabled ? fetch : window.fetch || fetch;
 
 export default fetchToUse;


### PR DESCRIPTION
Tests and Mirage won't work with native fetch and the existing checks weren't enough to ensure native fetch was used in prod. Since it's only relevant for log streaming in cases where the browser has native stream reading, it went unnoticed.