### PR TITLE
UX improvments to driver health checks

### DIFF
--- a/client/fingerprint_manager_test.go
+++ b/client/fingerprint_manager_test.go
@@ -290,6 +290,14 @@ func TestFingerprintManager_HealthCheck_Driver(t *testing.T) {
 	}, func(err error) {
 		t.Fatalf("err: %v", err)
 	})
+
+	// Ensure that we don't duplicate health check information on the driver
+	// health information
+	fm.nodeLock.Lock()
+	node := fm.node
+	fm.nodeLock.Unlock()
+	mockDriverAttributes := node.Drivers["mock_driver"].Attributes
+	require.Equal(mockDriverAttributes["driver.mock_driver"], "")
 }
 
 func TestFingerprintManager_HealthCheck_Periodic(t *testing.T) {


### PR DESCRIPTION
- Driver info attributes should retain the "driver." prefix
- Driver info attributes should not contain the "driver.{name}=1" attribute, as this is indicated by the healthy boolean on driver info. 