### PR TITLE
client: always mark exited sys/svc allocs as failed

### DIFF
--- a/client/restarts.go
+++ b/client/restarts.go
@@ -127,10 +127,15 @@ func (r *RestartTracker) GetState() (string, time.Duration) {
 	// Hot path if no attempts are expected
 	if r.policy.Attempts == 0 {
 		r.reason = ReasonNoRestartsAllowed
-		if r.waitRes != nil && r.waitRes.Successful() {
+
+		// If the task does not restart on a successful exit code and
+		// the exit code was successful: terminate.
+		if !r.onSuccess && r.waitRes != nil && r.waitRes.Successful() {
 			return structs.TaskTerminated, 0
 		}
 
+		// Task restarts even on a successful exit code but no restarts
+		// allowed.
 		return structs.TaskNotRestarting, 0
 	}
 


### PR DESCRIPTION
When restarts.attempts=0 was set in a jobspec a system or service alloc
that exited with 0 status would be marked as `completed` instead of
`failed`. Since system and service jobs are intended to run until
stopped or updated, they should always be marked as failed when they
exit even in cases where the exit code is 0.