### PR TITLE
Only create deployment if job changes or no allocs

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -366,6 +366,11 @@ func (s *GenericScheduler) computeJobAllocs() error {
 		s.ctx.Plan().AppendAlloc(update)
 	}
 
+	// Handle the annotation updates
+	for _, update := range results.annotationUpdates {
+		s.ctx.Plan().AppendAlloc(update)
+	}
+
 	// Nothing remaining to do if placement is not required
 	if len(results.place)+len(results.destructiveUpdate) == 0 {
 		if !s.job.Stopped() {

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -367,7 +367,7 @@ func (s *GenericScheduler) computeJobAllocs() error {
 	}
 
 	// Handle the annotation updates
-	for _, update := range results.annotationUpdates {
+	for _, update := range results.attributeUpdates {
 		s.ctx.Plan().AppendAlloc(update)
 	}
 

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -95,9 +95,9 @@ type reconcileResults struct {
 	// stop is the set of allocations to stop
 	stop []allocStopResult
 
-	// annotationUpdates are updates to the allocation that are not from a
+	// attributeUpdates are updates to the allocation that are not from a
 	// jobspec change.
-	annotationUpdates map[string]*structs.Allocation
+	attributeUpdates map[string]*structs.Allocation
 
 	// desiredTGUpdates captures the desired set of changes to make for each
 	// task group.
@@ -875,8 +875,8 @@ func (a *allocReconciler) handleDelayedReschedules(rescheduleLater []*delayedRes
 	a.result.desiredFollowupEvals[tgName] = evals
 
 	// Initialize the annotations
-	if len(allocIDToFollowupEvalID) != 0 && a.result.annotationUpdates == nil {
-		a.result.annotationUpdates = make(map[string]*structs.Allocation)
+	if len(allocIDToFollowupEvalID) != 0 && a.result.attributeUpdates == nil {
+		a.result.attributeUpdates = make(map[string]*structs.Allocation)
 	}
 
 	// Create in-place updates for every alloc ID that needs to be updated with its follow up eval ID
@@ -884,6 +884,6 @@ func (a *allocReconciler) handleDelayedReschedules(rescheduleLater []*delayedRes
 		existingAlloc := all[allocID]
 		updatedAlloc := existingAlloc.Copy()
 		updatedAlloc.FollowupEvalID = evalID
-		a.result.annotationUpdates[updatedAlloc.ID] = updatedAlloc
+		a.result.attributeUpdates[updatedAlloc.ID] = updatedAlloc
 	}
 }

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -114,8 +114,7 @@ func allocUpdateFnDestructive(*structs.Allocation, *structs.Job, *structs.TaskGr
 
 func allocUpdateFnInplace(existing *structs.Allocation, _ *structs.Job, newTG *structs.TaskGroup) (bool, bool, *structs.Allocation) {
 	// Create a shallow copy
-	newAlloc := new(structs.Allocation)
-	*newAlloc = *existing
+	newAlloc := existing.CopySkipJob()
 	newAlloc.TaskResources = make(map[string]*structs.Resources)
 
 	// Use the new task resources but keep the network from the old
@@ -289,6 +288,14 @@ func stopResultsToNames(stop []allocStopResult) []string {
 	return names
 }
 
+func annotationsToNames(annotations map[string]*structs.Allocation) []string {
+	names := make([]string, 0, len(annotations))
+	for _, a := range annotations {
+		names = append(names, a.Name)
+	}
+	return names
+}
+
 func allocsToNames(allocs []*structs.Allocation) []string {
 	names := make([]string, 0, len(allocs))
 	for _, a := range allocs {
@@ -303,6 +310,7 @@ type resultExpectation struct {
 	place             int
 	destructive       int
 	inplace           int
+	annotations       int
 	stop              int
 	desiredTGUpdates  map[string]*structs.DesiredUpdates
 }
@@ -333,6 +341,9 @@ func assertResults(t *testing.T, r *reconcileResults, exp *resultExpectation) {
 	}
 	if l := len(r.inplaceUpdate); l != exp.inplace {
 		t.Fatalf("Expected %d inplaceUpdate; got %d", exp.inplace, l)
+	}
+	if l := len(r.annotationUpdates); l != exp.annotations {
+		t.Fatalf("Expected %d annotations; got %d", exp.annotations, l)
 	}
 	if l := len(r.stop); l != exp.stop {
 		t.Fatalf("Expected %d stops; got %d", exp.stop, l)
@@ -1208,14 +1219,17 @@ func TestReconciler_MultiTG(t *testing.T) {
 // Tests delayed rescheduling of failed batch allocations
 func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 	require := require.New(t)
+
 	// Set desired 4
 	job := mock.Job()
 	job.TaskGroups[0].Count = 4
 	now := time.Now()
+
 	// Set up reschedule policy
 	delayDur := 15 * time.Second
 	job.TaskGroups[0].ReschedulePolicy = &structs.ReschedulePolicy{Attempts: 3, Interval: 24 * time.Hour, Delay: delayDur, DelayFunction: "linear"}
 	tgName := job.TaskGroups[0].Name
+
 	// Create 6 existing allocations - 2 running, 1 complete and 3 failed
 	var allocs []*structs.Allocation
 	for i := 0; i < 6; i++ {
@@ -1227,6 +1241,7 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 		allocs = append(allocs, alloc)
 		alloc.ClientStatus = structs.AllocClientStatusRunning
 	}
+
 	// Mark 3 as failed with restart tracking info
 	allocs[0].ClientStatus = structs.AllocClientStatusFailed
 	allocs[0].NextAllocation = allocs[1].ID
@@ -1252,6 +1267,7 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 			PrevNodeID:  uuid.Generate(),
 		},
 	}}
+
 	// Mark one as complete
 	allocs[5].ClientStatus = structs.AllocClientStatusComplete
 
@@ -1259,7 +1275,6 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 	r := reconciler.Compute()
 
 	// Two reschedule attempts were already made, one more can be made at a future time
-
 	// Verify that the follow up eval has the expected waitUntil time
 	evals := r.desiredFollowupEvals[tgName]
 	require.NotNil(evals)
@@ -1271,7 +1286,8 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 		createDeployment:  nil,
 		deploymentUpdates: nil,
 		place:             0,
-		inplace:           1,
+		inplace:           0,
+		annotations:       1,
 		stop:              0,
 		desiredTGUpdates: map[string]*structs.DesiredUpdates{
 			job.TaskGroups[0].Name: {
@@ -1281,23 +1297,31 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 			},
 		},
 	})
-	assertNamesHaveIndexes(t, intRange(2, 2), allocsToNames(r.inplaceUpdate))
-	// verify that the followup evalID field is set correctly
-	r.inplaceUpdate[0].EvalID = evals[0].ID
+	assertNamesHaveIndexes(t, intRange(2, 2), annotationsToNames(r.annotationUpdates))
+
+	// Verify that the followup evalID field is set correctly
+	var annotated *structs.Allocation
+	for _, a := range r.annotationUpdates {
+		annotated = a
+	}
+	require.Equal(evals[0].ID, annotated.FollowupEvalID)
 }
 
 // Tests delayed rescheduling of failed batch allocations and batching of allocs
 // with fail times that are close together
 func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 	require := require.New(t)
+
 	// Set desired 4
 	job := mock.Job()
 	job.TaskGroups[0].Count = 10
 	now := time.Now()
+
 	// Set up reschedule policy
 	delayDur := 15 * time.Second
 	job.TaskGroups[0].ReschedulePolicy = &structs.ReschedulePolicy{Attempts: 3, Interval: 24 * time.Hour, Delay: delayDur, DelayFunction: "linear"}
 	tgName := job.TaskGroups[0].Name
+
 	// Create 10 existing allocations
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -1309,6 +1333,7 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 		allocs = append(allocs, alloc)
 		alloc.ClientStatus = structs.AllocClientStatusRunning
 	}
+
 	// Mark 5 as failed with fail times very close together
 	for i := 0; i < 5; i++ {
 		allocs[i].ClientStatus = structs.AllocClientStatusFailed
@@ -1343,7 +1368,8 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 		createDeployment:  nil,
 		deploymentUpdates: nil,
 		place:             0,
-		inplace:           7,
+		inplace:           0,
+		annotations:       7,
 		stop:              0,
 		desiredTGUpdates: map[string]*structs.DesiredUpdates{
 			job.TaskGroups[0].Name: {
@@ -1353,9 +1379,10 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 			},
 		},
 	})
-	assertNamesHaveIndexes(t, intRange(0, 6), allocsToNames(r.inplaceUpdate))
-	// verify that the followup evalID field is set correctly
-	for _, alloc := range r.inplaceUpdate {
+	assertNamesHaveIndexes(t, intRange(0, 6), annotationsToNames(r.annotationUpdates))
+
+	// Verify that the followup evalID field is set correctly
+	for _, alloc := range r.annotationUpdates {
 		if allocNameToIndex(alloc.Name) < 5 {
 			require.Equal(evals[0].ID, alloc.FollowupEvalID)
 		} else if allocNameToIndex(alloc.Name) < 7 {
@@ -1447,11 +1474,13 @@ func TestReconciler_RescheduleNow_Batch(t *testing.T) {
 // Tests rescheduling failed service allocations with desired state stop
 func TestReconciler_RescheduleLater_Service(t *testing.T) {
 	require := require.New(t)
+
 	// Set desired 5
 	job := mock.Job()
 	job.TaskGroups[0].Count = 5
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
+
 	// Set up reschedule policy
 	delayDur := 15 * time.Second
 	job.TaskGroups[0].ReschedulePolicy = &structs.ReschedulePolicy{Attempts: 1, Interval: 24 * time.Hour, Delay: delayDur, MaxDelay: 1 * time.Hour}
@@ -1467,8 +1496,10 @@ func TestReconciler_RescheduleLater_Service(t *testing.T) {
 		allocs = append(allocs, alloc)
 		alloc.ClientStatus = structs.AllocClientStatusRunning
 	}
+
 	// Mark two as failed
 	allocs[0].ClientStatus = structs.AllocClientStatusFailed
+
 	// Mark one of them as already rescheduled once
 	allocs[0].RescheduleTracker = &structs.RescheduleTracker{Events: []*structs.RescheduleEvent{
 		{RescheduleTime: time.Now().Add(-1 * time.Hour).UTC().UnixNano(),
@@ -1498,7 +1529,8 @@ func TestReconciler_RescheduleLater_Service(t *testing.T) {
 		createDeployment:  nil,
 		deploymentUpdates: nil,
 		place:             1,
-		inplace:           1,
+		inplace:           0,
+		annotations:       1,
 		stop:              0,
 		desiredTGUpdates: map[string]*structs.DesiredUpdates{
 			job.TaskGroups[0].Name: {
@@ -1510,9 +1542,14 @@ func TestReconciler_RescheduleLater_Service(t *testing.T) {
 	})
 
 	assertNamesHaveIndexes(t, intRange(4, 4), placeResultsToNames(r.place))
-	assertNamesHaveIndexes(t, intRange(1, 1), allocsToNames(r.inplaceUpdate))
-	// verify that the followup evalID field is set correctly
-	r.inplaceUpdate[0].EvalID = evals[0].ID
+	assertNamesHaveIndexes(t, intRange(1, 1), annotationsToNames(r.annotationUpdates))
+
+	// Verify that the followup evalID field is set correctly
+	var annotated *structs.Allocation
+	for _, a := range r.annotationUpdates {
+		annotated = a
+	}
+	require.Equal(evals[0].ID, annotated.FollowupEvalID)
 }
 
 // Tests rescheduling failed service allocations with desired state stop
@@ -1856,14 +1893,16 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Destructive(t *testing.T) {
 
 // Tests the reconciler creates a deployment for inplace updates
 func TestReconciler_CreateDeployment_RollingUpgrade_Inplace(t *testing.T) {
-	job := mock.Job()
+	jobOld := mock.Job()
+	job := jobOld.Copy()
+	job.Version++
 	job.TaskGroups[0].Update = noCanaryUpdate
 
 	// Create 10 allocations from the old job
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
 		alloc := mock.Alloc()
-		alloc.Job = job
+		alloc.Job = jobOld
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -1276,8 +1276,8 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 		desiredTGUpdates: map[string]*structs.DesiredUpdates{
 			job.TaskGroups[0].Name: {
 				Place:         0,
-				InPlaceUpdate: 1,
-				Ignore:        3,
+				InPlaceUpdate: 0,
+				Ignore:        4,
 			},
 		},
 	})
@@ -1348,8 +1348,8 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 		desiredTGUpdates: map[string]*structs.DesiredUpdates{
 			job.TaskGroups[0].Name: {
 				Place:         0,
-				InPlaceUpdate: 7,
-				Ignore:        3,
+				InPlaceUpdate: 0,
+				Ignore:        10,
 			},
 		},
 	})
@@ -1503,8 +1503,8 @@ func TestReconciler_RescheduleLater_Service(t *testing.T) {
 		desiredTGUpdates: map[string]*structs.DesiredUpdates{
 			job.TaskGroups[0].Name: {
 				Place:         1,
-				InPlaceUpdate: 1,
-				Ignore:        3,
+				InPlaceUpdate: 0,
+				Ignore:        4,
 			},
 		},
 	})


### PR DESCRIPTION
This PR makes it so deployments are only created if there are no allocations
for the given job version or when the specification has changed. Fixes an issue
where rescheduling would always create a deployment.