### PR TITLE
Create evals for system jobs when drain is unset

### DIFF
--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -176,9 +176,9 @@ func TestNodes_ToggleDrain(t *testing.T) {
 	spec := &DrainSpec{
 		Deadline: 10 * time.Second,
 	}
-	wm, err := nodes.UpdateDrain(nodeID, spec, false, nil)
+	drainOut, err := nodes.UpdateDrain(nodeID, spec, false, nil)
 	require.Nil(err)
-	assertWriteMeta(t, wm)
+	assertWriteMeta(t, &drainOut.WriteMeta)
 
 	// Check again
 	out, _, err = nodes.Info(nodeID, nil)
@@ -188,9 +188,9 @@ func TestNodes_ToggleDrain(t *testing.T) {
 	}
 
 	// Toggle off again
-	wm, err = nodes.UpdateDrain(nodeID, nil, true, nil)
+	drainOut, err = nodes.UpdateDrain(nodeID, nil, true, nil)
 	require.Nil(err)
-	assertWriteMeta(t, wm)
+	assertWriteMeta(t, &drainOut.WriteMeta)
 
 	// Check again
 	out, _, err = nodes.Info(nodeID, nil)
@@ -240,11 +240,11 @@ func TestNodes_ToggleEligibility(t *testing.T) {
 	}
 
 	// Toggle it off
-	wm, err := nodes.ToggleEligibility(nodeID, false, nil)
+	eligOut, err := nodes.ToggleEligibility(nodeID, false, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	assertWriteMeta(t, wm)
+	assertWriteMeta(t, &eligOut.WriteMeta)
 
 	// Check again
 	out, _, err = nodes.Info(nodeID, nil)
@@ -256,11 +256,11 @@ func TestNodes_ToggleEligibility(t *testing.T) {
 	}
 
 	// Toggle on
-	wm, err = nodes.ToggleEligibility(nodeID, true, nil)
+	eligOut, err = nodes.ToggleEligibility(nodeID, true, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	assertWriteMeta(t, wm)
+	assertWriteMeta(t, &eligOut.WriteMeta)
 
 	// Check again
 	out, _, err = nodes.Info(nodeID, nil)

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -165,12 +165,12 @@ func (s *HTTPServer) nodeToggleEligibility(resp http.ResponseWriter, req *http.R
 	}
 	s.parseWriteRequest(req, &drainRequest.WriteRequest)
 
-	var out structs.GenericResponse
+	var out structs.NodeEligibilityUpdateResponse
 	if err := s.agent.RPC("Node.UpdateEligibility", &drainRequest, &out); err != nil {
 		return nil, err
 	}
 	setIndex(resp, out.Index)
-	return nil, nil
+	return out, nil
 }
 
 func (s *HTTPServer) nodeQuery(resp http.ResponseWriter, req *http.Request,

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -327,11 +327,15 @@ func TestHTTP_NodeEligible(t *testing.T) {
 		respW := httptest.NewRecorder()
 
 		// Make the request
-		_, err = s.Server.NodeSpecificRequest(respW, req)
+		obj, err := s.Server.NodeSpecificRequest(respW, req)
 		require.Nil(err)
 
 		// Check for the index
 		require.NotZero(respW.HeaderMap.Get("X-Nomad-Index"))
+
+		// Check the response
+		_, ok := obj.(structs.NodeEligibilityUpdateResponse)
+		require.True(ok)
 
 		// Check that the node has been updated
 		state := s.Agent.server.State()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -929,12 +929,17 @@ type NodeUpdateResponse struct {
 // NodeDrainUpdateResponse is used to respond to a node drain update
 type NodeDrainUpdateResponse struct {
 	NodeModifyIndex uint64
-	QueryMeta
-
-	// Deprecated in Nomad 0.8 as an evaluation is not immediately created but
-	// is instead handled by the drainer.
 	EvalIDs         []string
 	EvalCreateIndex uint64
+	WriteMeta
+}
+
+// NodeEligibilityUpdateResponse is used to respond to a node eligibility update
+type NodeEligibilityUpdateResponse struct {
+	NodeModifyIndex uint64
+	EvalIDs         []string
+	EvalCreateIndex uint64
+	WriteMeta
 }
 
 // NodeAllocsResponse is used to return allocs for a single node


### PR DESCRIPTION
This PR creates evals for system jobs when:

* Drain is unset and mark eligible is true
* Eligibility is restored to the node