### PR TITLE
Specify docker name in driver health messages

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1070,6 +1070,7 @@ func (c *Client) updateNodeFromDriver(name string, fingerprint, health *structs.
 						Subsystem: "Driver",
 						Message:   health.HealthDescription,
 						Timestamp: time.Now(),
+						Details:   map[string]string{"driver": name},
 					}
 					c.triggerNodeEvent(event)
 				}

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -447,7 +447,7 @@ func formatEventMessage(message, driverName string) string {
 		return message
 	}
 
-	return fmt.Sprintf("Driver: %s, Message: %s", driverName, message)
+	return fmt.Sprintf("Driver: %s, %s", driverName, message)
 }
 
 func formatEventDetails(details map[string]string) string {

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -431,7 +431,7 @@ func (c *NodeStatusCommand) outputNodeEvent(events []*api.NodeEvent) {
 	for i, event := range events {
 		timestamp := formatTime(event.Timestamp)
 		subsystem := event.Subsystem
-		msg := event.Message
+		msg := formatEventMessage(event.Message, event.Details["driver"])
 		if c.verbose {
 			details := formatEventDetails(event.Details)
 			nodeEvents[size-i] = fmt.Sprintf("%s|%s|%s|%s", timestamp, subsystem, msg, details)
@@ -440,6 +440,14 @@ func (c *NodeStatusCommand) outputNodeEvent(events []*api.NodeEvent) {
 		}
 	}
 	c.Ui.Output(formatList(nodeEvents))
+}
+
+func formatEventMessage(message, driverName string) string {
+	if driverName == "" {
+		return message
+	}
+
+	return fmt.Sprintf("Driver: %s, Message: %s", driverName, message)
 }
 
 func formatEventDetails(details map[string]string) string {


### PR DESCRIPTION
Driver health messages should specify which driver the message is referring to. 