### PR TITLE
Emit first node event after initialization on health status change

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1063,8 +1063,10 @@ func (c *Client) updateNodeFromDriver(name string, fingerprint, health *structs.
 			} else {
 				hasChanged = true
 
-				// Only emit an event if the health status has changed, not if we are
-				// simply updating a node on startup
+				// Only emit an event if the health status has changed after node
+				// initial startup (the health description will not get populated until
+				// a health check has run; the initial status is equal to whether the
+				// node is detected or not).
 				if health.Healthy != oldVal.Healthy && health.HealthDescription != "" {
 					event := &structs.NodeEvent{
 						Subsystem: "Driver",

--- a/client/client.go
+++ b/client/client.go
@@ -1065,7 +1065,7 @@ func (c *Client) updateNodeFromDriver(name string, fingerprint, health *structs.
 
 				// Only emit an event if the health status has changed, not if we are
 				// simply updating a node on startup
-				if health.Healthy != oldVal.Healthy && oldVal.HealthDescription != "" {
+				if health.Healthy != oldVal.Healthy && health.HealthDescription != "" {
 					event := &structs.NodeEvent{
 						Subsystem: "Driver",
 						Message:   health.HealthDescription,


### PR DESCRIPTION
Fixes a bug where the first node event would not be emitted. This ensures that only events where the health status has changed, and are not the status created on client initialization, will be emitted. 