### PR TITLE
add HasHealth helper for nil checks

### DIFF
--- a/client/alloc_runner_health_watcher.go
+++ b/client/alloc_runner_health_watcher.go
@@ -39,7 +39,7 @@ func (r *AllocRunner) watchHealth(ctx context.Context) {
 	}
 
 	// No need to watch health as it's already set
-	if alloc.DeploymentStatus.IsHealthy() || alloc.DeploymentStatus.IsUnhealthy() {
+	if alloc.DeploymentStatus.HasHealth() {
 		return
 	}
 

--- a/client/alloc_runner_test.go
+++ b/client/alloc_runner_test.go
@@ -136,7 +136,7 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_BadStart(t *testing.T) {
 		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
+		if !last.DeploymentStatus.HasHealth() {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if *last.DeploymentStatus.Healthy {
 			return false, fmt.Errorf("want deployment status unhealthy; got healthy")
@@ -186,7 +186,7 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_Deadline(t *testing.T) {
 		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
+		if !last.DeploymentStatus.HasHealth() {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if *last.DeploymentStatus.Healthy {
 			return false, fmt.Errorf("want deployment status unhealthy; got healthy")
@@ -240,7 +240,7 @@ func TestAllocRunner_DeploymentHealth_Healthy_NoChecks(t *testing.T) {
 		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
+		if !last.DeploymentStatus.HasHealth() {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if !*last.DeploymentStatus.Healthy {
 			return false, fmt.Errorf("want deployment status healthy; got unhealthy")
@@ -330,7 +330,7 @@ func TestAllocRunner_DeploymentHealth_Healthy_Checks(t *testing.T) {
 		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
+		if !last.DeploymentStatus.HasHealth() {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if !*last.DeploymentStatus.Healthy {
 			return false, fmt.Errorf("want deployment status healthy; got unhealthy")
@@ -396,7 +396,7 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_Checks(t *testing.T) {
 		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
+		if !last.DeploymentStatus.HasHealth() {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if *last.DeploymentStatus.Healthy {
 			return false, fmt.Errorf("want deployment status unhealthy; got healthy")
@@ -443,7 +443,7 @@ func TestAllocRunner_DeploymentHealth_Healthy_UpdatedDeployment(t *testing.T) {
 		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
+		if !last.DeploymentStatus.HasHealth() {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if !*last.DeploymentStatus.Healthy {
 			return false, fmt.Errorf("want deployment status healthy; got unhealthy")
@@ -464,7 +464,7 @@ func TestAllocRunner_DeploymentHealth_Healthy_UpdatedDeployment(t *testing.T) {
 		if newCount <= oldCount {
 			return false, fmt.Errorf("No new updates")
 		}
-		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
+		if !last.DeploymentStatus.HasHealth() {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if !*last.DeploymentStatus.Healthy {
 			return false, fmt.Errorf("want deployment status healthy; got unhealthy")
@@ -505,7 +505,7 @@ func TestAllocRunner_DeploymentHealth_Healthy_Migration(t *testing.T) {
 		if last == nil {
 			return false, fmt.Errorf("No updates")
 		}
-		if last.DeploymentStatus == nil || last.DeploymentStatus.Healthy == nil {
+		if !last.DeploymentStatus.HasHealth() {
 			return false, fmt.Errorf("want deployment status unhealthy; got unset")
 		} else if !*last.DeploymentStatus.Healthy {
 			return false, fmt.Errorf("want deployment status healthy; got unhealthy")

--- a/nomad/drainer/watch_jobs.go
+++ b/nomad/drainer/watch_jobs.go
@@ -365,9 +365,7 @@ func handleTaskGroup(snap *state.StateSnapshot, tg *structs.TaskGroup,
 
 		// If the alloc is running and has its deployment status set, it is
 		// considered healthy from a migration standpoint.
-		if !alloc.TerminalStatus() &&
-			alloc.DeploymentStatus != nil &&
-			alloc.DeploymentStatus.Healthy != nil {
+		if !alloc.TerminalStatus() && alloc.DeploymentStatus.HasHealth() {
 			healthy++
 		}
 

--- a/nomad/drainer_int_test.go
+++ b/nomad/drainer_int_test.go
@@ -42,7 +42,7 @@ func allocPromoter(t *testing.T, ctx context.Context,
 				continue
 			}
 
-			if alloc.DeploymentStatus != nil && alloc.DeploymentStatus.Healthy != nil {
+			if alloc.DeploymentStatus.HasHealth() {
 				continue
 			}
 			newAlloc := alloc.Copy()

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3246,8 +3246,8 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 
 	// If there was no existing allocation, this is a placement and we increment
 	// the placement
-	existingHealthSet := existing != nil && existing.DeploymentStatus != nil && existing.DeploymentStatus.Healthy != nil
-	allocHealthSet := alloc.DeploymentStatus != nil && alloc.DeploymentStatus.Healthy != nil
+	existingHealthSet := existing != nil && existing.DeploymentStatus.HasHealth()
+	allocHealthSet := alloc.DeploymentStatus.HasHealth()
 	if existing == nil || existing.DeploymentID != alloc.DeploymentID {
 		placed++
 	} else if !existingHealthSet && allocHealthSet {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6080,6 +6080,11 @@ type AllocDeploymentStatus struct {
 	ModifyIndex uint64
 }
 
+// HasHealth returns true if the allocation has its health set.
+func (a *AllocDeploymentStatus) HasHealth() bool {
+	return a != nil && a.Healthy != nil
+}
+
 // IsHealthy returns if the allocation is marked as healthy as part of a
 // deployment
 func (a *AllocDeploymentStatus) IsHealthy() bool {


### PR DESCRIPTION
We performed the DeploymentStatus nil checks a couple different ways, so
hopefully this helper will consoldiate them and make it more clear what
the code is doing.

Or if it doesn't I can just throw this patch away. nbd