### PR TITLE
Docker labels: allow var interpolation

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1269,7 +1269,11 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 	}
 
 	if len(driverConfig.Labels) > 0 {
-		config.Labels = driverConfig.Labels
+		renderedLabels := make(map[string]string, len(driverConfig.Labels))
+		for k, v := range driverConfig.Labels {
+			renderedLabels[k] = ctx.TaskEnv.ReplaceEnv(v)
+		}
+		config.Labels = renderedLabels
 		d.logger.Printf("[DEBUG] driver.docker: applied labels on the container: %+v", config.Labels)
 	}
 


### PR DESCRIPTION
  When using for example cAdvisor it is very convenient to be able to
  assign custom labels coming from the environment.
  Example:
    We use the ${NOMAD_ALLOC_INDEX} to assign a partition to a node but
    in our Prometheus metrics there's no way to identify containers by
    partition.