### PR TITLE
UI: Service job breadcrumbs + errant open connections

### DIFF
--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -10,7 +10,27 @@ export default ApplicationAdapter.extend({
   store: service(),
 
   xhrs: computed(function() {
-    return {};
+    return {
+      list: {},
+      track(key, xhr) {
+        if (this.list[key]) {
+          this.list[key].push(xhr);
+        } else {
+          this.list[key] = [xhr];
+        }
+      },
+      cancel(key) {
+        while (this.list[key] && this.list[key].length) {
+          this.remove(key, this.list[key][0]);
+        }
+      },
+      remove(key, xhr) {
+        if (this.list[key]) {
+          xhr.abort();
+          this.list[key].removeObject(xhr);
+        }
+      },
+    };
   }),
 
   ajaxOptions() {
@@ -22,9 +42,9 @@ export default ApplicationAdapter.extend({
       if (previousBeforeSend) {
         previousBeforeSend(...arguments);
       }
-      this.get('xhrs')[key] = jqXHR;
+      this.get('xhrs').track(key, jqXHR);
       jqXHR.always(() => {
-        delete this.get('xhrs')[key];
+        this.get('xhrs').remove(key, jqXHR);
       });
     };
 
@@ -127,10 +147,7 @@ export default ApplicationAdapter.extend({
       return;
     }
     const url = this.urlForFindRecord(id, modelName);
-    const xhr = this.get('xhrs')[url];
-    if (xhr) {
-      xhr.abort();
-    }
+    this.get('xhrs').cancel(url);
   },
 
   cancelFindAll(modelName) {
@@ -142,10 +159,7 @@ export default ApplicationAdapter.extend({
     if (params) {
       url = `${url}?${params}`;
     }
-    const xhr = this.get('xhrs')[url];
-    if (xhr) {
-      xhr.abort();
-    }
+    this.get('xhrs').cancel(url);
   },
 
   cancelReloadRelationship(model, relationshipName) {
@@ -159,10 +173,7 @@ export default ApplicationAdapter.extend({
       );
     } else {
       const url = model[relationship.kind](relationship.key).link();
-      const xhr = this.get('xhrs')[url];
-      if (xhr) {
-        xhr.abort();
-      }
+      this.get('xhrs').cancel(url);
     }
   },
 });

--- a/ui/app/components/job-page/system.js
+++ b/ui/app/components/job-page/system.js
@@ -1,0 +1,3 @@
+import AbstractJobPage from './abstract';
+
+export default AbstractJobPage.extend();


### PR DESCRIPTION
1. The job detail page for service jobs once again have a breadcrumb trail
2. Open connections are no longer left open in the void when a new request with the same URL is made.