### PR TITLE
Unset drain when final batch allocs finish

### DIFF
--- a/nomad/drainer/draining_node.go
+++ b/nomad/drainer/draining_node.go
@@ -119,8 +119,9 @@ func (n *drainingNode) RemainingAllocs() ([]*structs.Allocation, error) {
 	return drain, nil
 }
 
-// RunningServices returns the set of service jobs on the node.
-func (n *drainingNode) RunningServices() ([]structs.NamespacedID, error) {
+// DrainingJobs returns the set of jobs on the node that can block a drain.
+// These include batch and service jobs.
+func (n *drainingNode) DrainingJobs() ([]structs.NamespacedID, error) {
 	n.l.RLock()
 	defer n.l.RUnlock()
 
@@ -133,7 +134,7 @@ func (n *drainingNode) RunningServices() ([]structs.NamespacedID, error) {
 	jobIDs := make(map[structs.NamespacedID]struct{})
 	var jobs []structs.NamespacedID
 	for _, alloc := range allocs {
-		if alloc.TerminalStatus() || alloc.Job.Type != structs.JobTypeService {
+		if alloc.TerminalStatus() || alloc.Job.Type == structs.JobTypeSystem {
 			continue
 		}
 

--- a/nomad/drainer/draining_node_test.go
+++ b/nomad/drainer/draining_node_test.go
@@ -46,9 +46,9 @@ func assertDrainingNode(t *testing.T, dn *drainingNode, isDone bool, remaining, 
 	require.Nil(t, err)
 	assert.Len(t, allocs, remaining, "RemainingAllocs mismatch")
 
-	jobs, err := dn.RunningServices()
+	jobs, err := dn.DrainingJobs()
 	require.Nil(t, err)
-	assert.Len(t, jobs, running, "RunningServices mismatch")
+	assert.Len(t, jobs, running, "DrainingJobs mismatch")
 }
 
 func TestDrainingNode_Table(t *testing.T) {
@@ -70,7 +70,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			name:      "Batch",
 			isDone:    false,
 			remaining: 1,
-			running:   0,
+			running:   1,
 			setup: func(t *testing.T, dn *drainingNode) {
 				alloc := mock.BatchAlloc()
 				alloc.NodeID = dn.node.ID
@@ -128,7 +128,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			name:      "ServiceTerminal",
 			isDone:    false,
 			remaining: 2,
-			running:   0,
+			running:   1,
 			setup: func(t *testing.T, dn *drainingNode) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
@@ -146,7 +146,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			name:      "AllTerminalButBatch",
 			isDone:    false,
 			remaining: 1,
-			running:   0,
+			running:   1,
 			setup: func(t *testing.T, dn *drainingNode) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
@@ -184,7 +184,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			name:      "HalfTerminal",
 			isDone:    false,
 			remaining: 3,
-			running:   1,
+			running:   2,
 			setup: func(t *testing.T, dn *drainingNode) {
 				allocs := []*structs.Allocation{
 					mock.Alloc(),

--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -304,6 +304,9 @@ type handleTaskGroupTestCase struct {
 	// Name of test
 	Name string
 
+	// Batch uses a batch job and alloc
+	Batch bool
+
 	// Expectations
 	ExpectedDrained  int
 	ExpectedMigrated int
@@ -394,8 +397,34 @@ func TestHandeTaskGroup_Table(t *testing.T) {
 			},
 		},
 		{
+			// One already drained, other allocs on non-draining node and healthy
+			Name:             "OneAlreadyDrainedBatched",
+			Batch:            true,
+			ExpectedDrained:  0,
+			ExpectedMigrated: 1,
+			ExpectedDone:     true,
+			AddAlloc: func(i int, a *structs.Allocation, drainingID, runningID string) {
+				if i == 0 {
+					a.DesiredStatus = structs.AllocDesiredStatusStop
+					return
+				}
+				a.NodeID = runningID
+			},
+		},
+		{
 			// All allocs are terminl, nothing to be drained
 			Name:             "AllMigrating",
+			ExpectedDrained:  0,
+			ExpectedMigrated: 10,
+			ExpectedDone:     true,
+			AddAlloc: func(i int, a *structs.Allocation, drainingID, runningID string) {
+				a.DesiredStatus = structs.AllocDesiredStatusStop
+			},
+		},
+		{
+			// All allocs are terminl, nothing to be drained
+			Name:             "AllMigratingBatch",
+			Batch:            true,
 			ExpectedDrained:  0,
 			ExpectedMigrated: 10,
 			ExpectedDone:     true,
@@ -522,6 +551,9 @@ func testHandleTaskGroup(t *testing.T, tc handleTaskGroupTestCase) {
 	drainingNode, runningNode := testNodes(t, state)
 
 	job := mock.Job()
+	if tc.Batch {
+		job = mock.BatchJob()
+	}
 	job.TaskGroups[0].Count = 10
 	if tc.Count > 0 {
 		job.TaskGroups[0].Count = tc.Count
@@ -534,6 +566,9 @@ func testHandleTaskGroup(t *testing.T, tc handleTaskGroupTestCase) {
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
 		a := mock.Alloc()
+		if tc.Batch {
+			a = mock.BatchAlloc()
+		}
 		a.JobID = job.ID
 		a.Job = job
 		a.TaskGroup = job.TaskGroups[0].Name
@@ -554,7 +589,7 @@ func testHandleTaskGroup(t *testing.T, tc handleTaskGroupTestCase) {
 	require.Nil(err)
 
 	res := newJobResult()
-	require.Nil(handleTaskGroup(snap, false, job.TaskGroups[0], allocs, 102, res))
+	require.Nil(handleTaskGroup(snap, tc.Batch, job.TaskGroups[0], allocs, 102, res))
 	assert.Lenf(res.drain, tc.ExpectedDrained, "Drain expected %d but found: %d",
 		tc.ExpectedDrained, len(res.drain))
 	assert.Lenf(res.migrated, tc.ExpectedMigrated, "Migrate expected %d but found: %d",
@@ -603,7 +638,7 @@ func TestHandleTaskGroup_Migrations(t *testing.T) {
 	snap, err := state.Snapshot()
 	require.Nil(err)
 
-	// Handle before and after indexes
+	// Handle before and after indexes as both service and batch
 	res := newJobResult()
 	require.Nil(handleTaskGroup(snap, false, job.TaskGroups[0], allocs, 101, res))
 	require.Empty(res.drain)
@@ -611,7 +646,19 @@ func TestHandleTaskGroup_Migrations(t *testing.T) {
 	require.True(res.done)
 
 	res = newJobResult()
+	require.Nil(handleTaskGroup(snap, true, job.TaskGroups[0], allocs, 101, res))
+	require.Empty(res.drain)
+	require.Len(res.migrated, 10)
+	require.True(res.done)
+
+	res = newJobResult()
 	require.Nil(handleTaskGroup(snap, false, job.TaskGroups[0], allocs, 103, res))
+	require.Empty(res.drain)
+	require.Empty(res.migrated)
+	require.True(res.done)
+
+	res = newJobResult()
+	require.Nil(handleTaskGroup(snap, true, job.TaskGroups[0], allocs, 103, res))
 	require.Empty(res.drain)
 	require.Empty(res.migrated)
 	require.True(res.done)

--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -554,7 +554,7 @@ func testHandleTaskGroup(t *testing.T, tc handleTaskGroupTestCase) {
 	require.Nil(err)
 
 	res := newJobResult()
-	require.Nil(handleTaskGroup(snap, job.TaskGroups[0], allocs, 102, res))
+	require.Nil(handleTaskGroup(snap, false, job.TaskGroups[0], allocs, 102, res))
 	assert.Lenf(res.drain, tc.ExpectedDrained, "Drain expected %d but found: %d",
 		tc.ExpectedDrained, len(res.drain))
 	assert.Lenf(res.migrated, tc.ExpectedMigrated, "Migrate expected %d but found: %d",
@@ -605,13 +605,13 @@ func TestHandleTaskGroup_Migrations(t *testing.T) {
 
 	// Handle before and after indexes
 	res := newJobResult()
-	require.Nil(handleTaskGroup(snap, job.TaskGroups[0], allocs, 101, res))
+	require.Nil(handleTaskGroup(snap, false, job.TaskGroups[0], allocs, 101, res))
 	require.Empty(res.drain)
 	require.Len(res.migrated, 10)
 	require.True(res.done)
 
 	res = newJobResult()
-	require.Nil(handleTaskGroup(snap, job.TaskGroups[0], allocs, 103, res))
+	require.Nil(handleTaskGroup(snap, false, job.TaskGroups[0], allocs, 103, res))
 	require.Empty(res.drain)
 	require.Empty(res.migrated)
 	require.True(res.done)

--- a/nomad/drainer/watch_nodes.go
+++ b/nomad/drainer/watch_nodes.go
@@ -68,12 +68,12 @@ func (n *NodeDrainer) Update(node *structs.Node) {
 
 	// TODO Test this
 	// Register interest in the draining jobs.
-	jobs, err := draining.RunningServices()
+	jobs, err := draining.DrainingJobs()
 	if err != nil {
-		n.logger.Printf("[ERR] nomad.drain: error retrieving services on node %q: %v", node.ID, err)
+		n.logger.Printf("[ERR] nomad.drain: error retrieving draining jobs on node %q: %v", node.ID, err)
 		return
 	}
-	n.logger.Printf("[TRACE] nomad.drain: node %q has %d services on it", node.ID, len(jobs))
+	n.logger.Printf("[TRACE] nomad.drain: node %q has %d draining jobs on it", node.ID, len(jobs))
 	n.jobWatcher.RegisterJobs(jobs)
 
 	// TODO Test at this layer as well that a node drain on a node without

--- a/nomad/drainer_int_test.go
+++ b/nomad/drainer_int_test.go
@@ -609,7 +609,7 @@ func TestDrainer_AllTypes_NoDeadline(t *testing.T) {
 		new.ClientStatus = structs.AllocClientStatusComplete
 		updates = append(updates, new)
 	}
-	require.Nil(state.UpsertAllocs(1000, updates))
+	require.Nil(state.UpdateAllocsFromClient(1000, updates))
 
 	// Check that the node drain is removed
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/drainer_int_test.go
+++ b/nomad/drainer_int_test.go
@@ -478,3 +478,158 @@ func TestDrainer_AllTypes_Deadline(t *testing.T) {
 	}
 	require.True(serviceMax < batchMax)
 }
+
+// Test that drain is unset when batch jobs naturally finish
+func TestDrainer_AllTypes_NoDeadline(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	s1 := TestServer(t, nil)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create two nodes, registering the second later
+	n1, n2 := mock.Node(), mock.Node()
+	nodeReg := &structs.NodeRegisterRequest{
+		Node:         n1,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var nodeResp structs.NodeUpdateResponse
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Node.Register", nodeReg, &nodeResp))
+
+	// Create a service job that runs on just one
+	job := mock.Job()
+	job.TaskGroups[0].Count = 2
+	req := &structs.JobRegisterRequest{
+		Job: job,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	var resp structs.JobRegisterResponse
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
+	require.NotZero(resp.Index)
+
+	// Create a system job
+	sysjob := mock.SystemJob()
+	req = &structs.JobRegisterRequest{
+		Job: sysjob,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
+	require.NotZero(resp.Index)
+
+	// Create a batch job
+	bjob := mock.BatchJob()
+	bjob.TaskGroups[0].Count = 2
+	req = &structs.JobRegisterRequest{
+		Job: bjob,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
+	require.NotZero(resp.Index)
+
+	// Wait for the allocations to be placed
+	state := s1.State()
+	testutil.WaitForResult(func() (bool, error) {
+		allocs, err := state.AllocsByNode(nil, n1.ID)
+		if err != nil {
+			return false, err
+		}
+		return len(allocs) == 5, fmt.Errorf("got %d allocs", len(allocs))
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Create the second node
+	nodeReg = &structs.NodeRegisterRequest{
+		Node:         n2,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Node.Register", nodeReg, &nodeResp))
+
+	// Drain the node
+	drainReq := &structs.NodeUpdateDrainRequest{
+		NodeID: n1.ID,
+		DrainStrategy: &structs.DrainStrategy{
+			DrainSpec: structs.DrainSpec{
+				Deadline: 0 * time.Second, // Infinite
+			},
+		},
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var drainResp structs.NodeDrainUpdateResponse
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Node.UpdateDrain", drainReq, &drainResp))
+
+	// Wait for the allocs to be replaced
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go allocPromoter(t, ctx, state, codec, n1.ID, s1.logger)
+	go allocPromoter(t, ctx, state, codec, n2.ID, s1.logger)
+
+	// Wait for the service allocs to be stopped on the draining node
+	testutil.WaitForResult(func() (bool, error) {
+		allocs, err := state.AllocsByJob(nil, job.Namespace, job.ID, false)
+		if err != nil {
+			return false, err
+		}
+		for _, alloc := range allocs {
+			if alloc.NodeID != n1.ID {
+				continue
+			}
+			if alloc.DesiredStatus != structs.AllocDesiredStatusStop {
+				return false, fmt.Errorf("got desired status %v", alloc.DesiredStatus)
+			}
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Mark the batch allocations as finished
+	allocs, err := state.AllocsByJob(nil, job.Namespace, bjob.ID, false)
+	require.Nil(err)
+
+	var updates []*structs.Allocation
+	for _, alloc := range allocs {
+		new := alloc.Copy()
+		new.ClientStatus = structs.AllocClientStatusComplete
+		updates = append(updates, new)
+	}
+	require.Nil(state.UpsertAllocs(1000, updates))
+
+	// Check that the node drain is removed
+	testutil.WaitForResult(func() (bool, error) {
+		node, err := state.NodeByID(nil, n1.ID)
+		if err != nil {
+			return false, err
+		}
+		return node.DrainStrategy == nil, fmt.Errorf("has drain strategy still set")
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Wait for the service allocations to be placed on the other node
+	testutil.WaitForResult(func() (bool, error) {
+		allocs, err := state.AllocsByNode(nil, n2.ID)
+		if err != nil {
+			return false, err
+		}
+		return len(allocs) == 3, fmt.Errorf("got %d allocs", len(allocs))
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+}


### PR DESCRIPTION
This PR fixes a bug in which drains weren't marked as complete when batch
allocs finished before their deadline.