### PR TITLE
Generic handling of server region errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ BUG FIXES:
  * core: Fix an issue in which multiple servers could be acting as a leader. A
    prominent side-effect being nodes TTLing incorrectly [[GH-3890](https://github.com/hashicorp/nomad/issues/3890)]
  * core: Fix an issue where jobs with the same name in a different namespace were not being blocked correctly [[GH-3972](https://github.com/hashicorp/nomad/issues/3972)]
+ * cli: server member command handles failure to retrieve leader in remote
+   regions [[GH-4087](https://github.com/hashicorp/nomad/issues/4087)]
  * client: Support IP detection of wireless interfaces on Windows [[GH-4011](https://github.com/hashicorp/nomad/issues/4011)]
  * client: Migrated ephemeral_disk's maintain directory permissions [[GH-3723](https://github.com/hashicorp/nomad/issues/3723)]
  * client: Always advertise driver IP when in driver address mode [[GH-3682](https://github.com/hashicorp/nomad/issues/3682)]


### PR DESCRIPTION
Does not early exit of errors and instead collects all and displays a warning message:

```
nomad server members
Name            Address         Port  Status  Leader  Protocol  Build      Datacenter  Region
server2.foo     192.168.18.171  5658  alive   false   2         0.8.0-dev  dc1         foo
server1.global  192.168.18.171  4648  alive   true    2         0.8.0-dev  dc1         global

Error determining leaders: 1 error(s) occurred:

* Region "foo": Unexpected response code: 500 (rpc error: failed to get conn: dial tcp 192.168.18.171:5657: connect: connection refused)
```