### PR TITLE
Make the built-in UI optional, similar to Consul

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -102,6 +102,7 @@ func (c *Command) readConfig() *Config {
 	flags.StringVar(&cmdConfig.Datacenter, "dc", "", "")
 	flags.StringVar(&cmdConfig.LogLevel, "log-level", "", "")
 	flags.StringVar(&cmdConfig.NodeName, "node", "", "")
+	flags.BoolVar(&cmdConfig.UiEnabled, "ui", false, "")
 
 	// Consul options
 	flags.StringVar(&cmdConfig.Consul.Auth, "consul-auth", "", "")
@@ -916,6 +917,9 @@ General Options (clients and servers):
     dual-role agent (client + server) which is useful for developing
     or testing Nomad. No other configuration is required to start the
     agent in this mode.
+
+  -ui
+    Enables the built-in web UI server and the required HTTP routes.
 
 Server Options:
 

--- a/command/agent/config-test-fixtures/basic.hcl
+++ b/command/agent/config-test-fixtures/basic.hcl
@@ -5,6 +5,7 @@ data_dir = "/tmp/nomad"
 log_level = "ERR"
 bind_addr = "192.168.0.1"
 enable_debug = true
+ui = true
 ports {
 	http = 1234
 	rpc = 2345

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -133,6 +133,10 @@ type Config struct {
 
 	// Autopilot contains the configuration for Autopilot behavior.
 	Autopilot *config.AutopilotConfig `mapstructure:"autopilot"`
+
+	// UiEnabled is used to enable the built-in web user-interface.
+	// Defaults to false.
+	UiEnabled bool `mapstructure:"ui"`
 }
 
 // ClientConfig is configuration specific to the client mode
@@ -569,6 +573,7 @@ func DevConfig() *Config {
 	conf.Telemetry.PrometheusMetrics = true
 	conf.Telemetry.PublishAllocationMetrics = true
 	conf.Telemetry.PublishNodeMetrics = true
+	conf.UiEnabled = true
 
 	return conf
 }
@@ -624,6 +629,7 @@ func DefaultConfig() *Config {
 		Version:            version.GetVersion(),
 		Autopilot:          config.DefaultAutopilotConfig(),
 		DisableUpdateCheck: helper.BoolToPtr(false),
+		UiEnabled:          false,
 	}
 }
 
@@ -798,6 +804,11 @@ func (c *Config) Merge(b *Config) *Config {
 	}
 	for k, v := range b.HTTPAPIResponseHeaders {
 		result.HTTPAPIResponseHeaders[k] = v
+	}
+
+	// Merge UI setting
+	if b.UiEnabled {
+		result.UiEnabled = true
 	}
 
 	return &result

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -100,6 +100,7 @@ func parseConfig(result *Config, list *ast.ObjectList) error {
 		"acl",
 		"sentinel",
 		"autopilot",
+		"ui",
 	}
 	if err := helper.CheckHCLKeys(list, valid); err != nil {
 		return multierror.Prefix(err, "config:")

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -27,6 +27,7 @@ func TestConfig_Parse(t *testing.T) {
 				LogLevel:    "ERR",
 				BindAddr:    "192.168.0.1",
 				EnableDebug: true,
+				UiEnabled: true,
 				Ports: &Ports{
 					HTTP: 1234,
 					RPC:  2345,

--- a/command/agent/stub_asset.go
+++ b/command/agent/stub_asset.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	uiEnabled = false
+	uiBuilt = false
 	stubHTML = `<!DOCTYPE html>
 <html>
 <p>Nomad UI is not available in this binary. To get Nomad UI do one of the following:</p>


### PR DESCRIPTION
In certian environments providing a built-in UI might be undersirable or unallowed.
This commit changes the behavior of Nomad to match Consul, where the
UI is disabled by default and can be explicitly enabled via the
command line flag `-ui` or the configuration setting `ui = true`.

If there is a concern that the UI is now by default disabled (unless you are in `-dev` mode).  I can change the code to support `-no-ui` as an alternative.