### PR TITLE
Check for nil for RPC listener; prevent double closing of listener channel 

### DIFF
--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -64,6 +64,7 @@ type RPCContext struct {
 
 // listen is used to listen for incoming RPC connections
 func (s *Server) listen(ctx context.Context) {
+	defer close(s.listenerCh)
 	for {
 		select {
 		case <-ctx.Done():

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -476,7 +476,16 @@ func (s *Server) reloadTLSConnections(newTLSConfig *config.TLSConfig) error {
 	s.connPool.ReloadTLS(tlsWrap)
 
 	// reinitialize our rpc listener
-	s.rpcListener.Close()
+	if s.rpcListener == nil {
+		s.logger.Println("Unable to reload configuration due to uninitialized rpc listner")
+		return nil
+	}
+
+	if err := s.rpcListener.Close(); err != nil {
+		s.logger.Printf("[ERR] nomad: Unable to close rpc listener %s", err)
+		return err
+	}
+
 	<-s.listenerCh
 	s.startRPCListener()
 

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -487,13 +487,16 @@ func (s *Server) reloadTLSConnections(newTLSConfig *config.TLSConfig) error {
 	}
 
 	<-s.listenerCh
-	s.startRPCListener()
 
 	listener, err := s.createRPCListener()
 	if err != nil {
 		listener.Close()
 		return err
 	}
+
+	// Ensure that the listener exists before potentially closing it after the
+	// context for the nomad listener has exited
+	s.startRPCListener()
 
 	// Close and reload existing Raft connections
 	wrapper := tlsutil.RegionSpecificWrapper(s.config.Region, tlsWrap)


### PR DESCRIPTION
TODO: test all TLS upgrade/downgrade cases