### PR TITLE
cli: remove info color on monitored output

### DIFF
--- a/command/monitor.go
+++ b/command/monitor.go
@@ -68,6 +68,15 @@ type monitor struct {
 // write output information to the provided ui. The length parameter determines
 // the number of characters for identifiers in the ui.
 func newMonitor(ui cli.Ui, client *api.Client, length int) *monitor {
+	if colorUi, ok := ui.(*cli.ColoredUi); ok {
+		// Disable Info color for monitored output
+		ui = &cli.ColoredUi{
+			ErrorColor: colorUi.ErrorColor,
+			WarnColor:  colorUi.WarnColor,
+			InfoColor:  cli.UiColorNone,
+			Ui:         colorUi.Ui,
+		}
+	}
 	mon := &monitor{
 		ui: &cli.PrefixedUi{
 			InfoPrefix:   "==> ",


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/113362/38156231-4769f0c8-3431-11e8-9ebf-0704e7c1c8b6.png)

**After:**

![image](https://user-images.githubusercontent.com/113362/38156238-5793dfa4-3431-11e8-89b8-f391eff6ac02.png)
