### PR TITLE
Basic Support for Swap

### DIFF
--- a/api/resources.go
+++ b/api/resources.go
@@ -72,7 +72,7 @@ func (r *Resources) Merge(other *Resources) {
 	if other.MemoryMB != nil {
 		r.MemoryMB = other.MemoryMB
 	}
-    if other.SwapMB != nil {
+	if other.SwapMB != nil {
 		r.SwapMB = other.SwapMB
 	}
 	if other.DiskMB != nil {

--- a/api/resources.go
+++ b/api/resources.go
@@ -7,6 +7,7 @@ import "github.com/hashicorp/nomad/helper"
 type Resources struct {
 	CPU      *int
 	MemoryMB *int `mapstructure:"memory"`
+	SwapMB   *int `mapstructure:"swap"`
 	DiskMB   *int `mapstructure:"disk"`
 	IOPS     *int
 	Networks []*NetworkResource
@@ -21,6 +22,9 @@ func (r *Resources) Canonicalize() {
 	}
 	if r.MemoryMB == nil {
 		r.MemoryMB = defaultResources.MemoryMB
+	}
+	if r.SwapMB == nil {
+		r.SwapMB = defaultResources.SwapMB
 	}
 	if r.IOPS == nil {
 		r.IOPS = defaultResources.IOPS
@@ -38,6 +42,7 @@ func DefaultResources() *Resources {
 	return &Resources{
 		CPU:      helper.IntToPtr(100),
 		MemoryMB: helper.IntToPtr(300),
+		SwapMB:   helper.IntToPtr(0),
 		IOPS:     helper.IntToPtr(0),
 	}
 }
@@ -51,6 +56,7 @@ func MinResources() *Resources {
 	return &Resources{
 		CPU:      helper.IntToPtr(20),
 		MemoryMB: helper.IntToPtr(10),
+		SwapMB:   helper.IntToPtr(0),
 		IOPS:     helper.IntToPtr(0),
 	}
 }
@@ -65,6 +71,9 @@ func (r *Resources) Merge(other *Resources) {
 	}
 	if other.MemoryMB != nil {
 		r.MemoryMB = other.MemoryMB
+	}
+    if other.SwapMB != nil {
+		r.SwapMB = other.SwapMB
 	}
 	if other.DiskMB != nil {
 		r.DiskMB = other.DiskMB

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1192,6 +1192,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 		hostConfig.MemorySwap = 0
 		hostConfig.MemorySwappiness = -1
 	} else {
+		hostConfig.MemorySwappiness = 1
 		hostConfig.MemorySwap = memLimit + swapLimit // MemorySwap is memory + swap.
 	}
 

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1150,7 +1150,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 	}
 
 	memLimit := int64(task.Resources.MemoryMB) * 1024 * 1024
-	swapLimit := int64(task.Resources.MemoryMB) * 1024 * 1024
+	swapLimit := int64(task.Resources.SwapMB) * 1024 * 1024
 
 	if len(driverConfig.Logging) == 0 {
 		if runtime.GOOS == "darwin" {

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1150,6 +1150,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 	}
 
 	memLimit := int64(task.Resources.MemoryMB) * 1024 * 1024
+	swapLimit := int64(task.Resources.MemoryMB) * 1024 * 1024
 
 	if len(driverConfig.Logging) == 0 {
 		if runtime.GOOS == "darwin" {
@@ -1191,7 +1192,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 		hostConfig.MemorySwap = 0
 		hostConfig.MemorySwappiness = -1
 	} else {
-		hostConfig.MemorySwap = memLimit // MemorySwap is memory + swap.
+		hostConfig.MemorySwap = memLimit + swapLimit // MemorySwap is memory + swap.
 	}
 
 	if len(driverConfig.Logging) != 0 {

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -335,6 +335,10 @@ func (d *LxcDriver) startWithCleanup(ctx *ExecContext, task *structs.Task) (*Sta
 	if err := c.SetMemoryLimit(lxc.ByteSize(task.Resources.MemoryMB) * lxc.MB); err != nil {
 		return nil, fmt.Errorf("unable to set memory limits: %v", err), stopAndDestroyCleanup
 	}
+	if err := c.SetMemorySwapLimit(lxc.ByteSize(task.Resources.MemoryMB) +
+                                   lxc.ByteSize(task.Resources.SwapMB)* lxc.MB); err != nil {
+		return nil, fmt.Errorf("unable to set memory limits: %v", err)
+	}
 	if err := c.SetCgroupItem("cpu.shares", strconv.Itoa(task.Resources.CPU)); err != nil {
 		return nil, fmt.Errorf("unable to set cpu shares: %v", err), stopAndDestroyCleanup
 	}

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -336,7 +336,7 @@ func (d *LxcDriver) startWithCleanup(ctx *ExecContext, task *structs.Task) (*Sta
 		return nil, fmt.Errorf("unable to set memory limits: %v", err), stopAndDestroyCleanup
 	}
 	if err := c.SetMemorySwapLimit(lxc.ByteSize(task.Resources.MemoryMB) +
-                                   lxc.ByteSize(task.Resources.SwapMB)* lxc.MB); err != nil {
+		lxc.ByteSize(task.Resources.SwapMB)*lxc.MB); err != nil {
 		return nil, fmt.Errorf("unable to set memory limits: %v", err)
 	}
 	if err := c.SetCgroupItem("cpu.shares", strconv.Itoa(task.Resources.CPU)); err != nil {

--- a/client/fingerprint/fingerprint.go
+++ b/client/fingerprint/fingerprint.go
@@ -38,6 +38,7 @@ var (
 		"nomad":   NewNomadFingerprint,
 		"signal":  NewSignalFingerprint,
 		"storage": NewStorageFingerprint,
+		"swap":    NewSwapFingerprint,
 		"vault":   NewVaultFingerprint,
 	}
 

--- a/client/fingerprint/swap.go
+++ b/client/fingerprint/swap.go
@@ -1,0 +1,43 @@
+package fingerprint
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shirou/gopsutil/mem"
+)
+
+// SwapFingerprint is used to fingerprint the available swap on the node
+type SwapFingerprint struct {
+	StaticFingerprinter
+	logger *log.Logger
+}
+
+// NewSwapFingerprint is used to create a Memory fingerprint
+func NewSwapFingerprint(logger *log.Logger) Fingerprint {
+	f := &SwapFingerprint{
+		logger: logger,
+	}
+	return f
+}
+
+func (f *SwapFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) (bool, error) {
+	swapInfo, err := mem.SwapMemory()
+	if err != nil {
+		f.logger.Printf("[WARN] Error reading swap information: %s", err)
+		return false, err
+	}
+
+	if swapInfo.Total > 0 {
+		node.Attributes["swap.total"] = fmt.Sprintf("%d", swapInfo.Total)
+
+		if node.Resources == nil {
+			node.Resources = &structs.Resources{}
+		}
+		node.Resources.SwapMB = int(swapInfo.Total / 1024 / 1024)
+    }
+
+	return true, nil
+}

--- a/client/fingerprint/swap.go
+++ b/client/fingerprint/swap.go
@@ -31,7 +31,7 @@ func (f *SwapFingerprint) Fingerprint(cfg *config.Config, node *structs.Node) (b
 	}
 
 	if swapInfo.Total > 0 {
-		node.Attributes["swap.total"] = fmt.Sprintf("%d", swapInfo.Total)
+		node.Attributes["swap.totalbytes"] = fmt.Sprintf("%d", swapInfo.Total)
 
 		if node.Resources == nil {
 			node.Resources = &structs.Resources{}

--- a/client/fingerprint/swap_test.go
+++ b/client/fingerprint/swap_test.go
@@ -1,0 +1,32 @@
+package fingerprint
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func TestSwapFingerprint(t *testing.T) {
+	f := NewSwapFingerprint(testLogger())
+	node := &structs.Node{
+		Attributes: make(map[string]string),
+	}
+	ok, err := f.Fingerprint(&config.Config{}, node)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("should apply")
+	}
+
+	assertNodeAttributeContains(t, node, "swap.totalbytes")
+
+	if node.Resources == nil {
+		t.Fatalf("Node Resources was nil")
+	}
+	if node.Resources.SwapMB == 0 {
+		t.Errorf("Expected node.Resources.SwapMB to be non-zero")
+	}
+
+}

--- a/client/fingerprint/swap_test.go
+++ b/client/fingerprint/swap_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/client/config"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -12,15 +13,16 @@ func TestSwapFingerprint(t *testing.T) {
 	node := &structs.Node{
 		Attributes: make(map[string]string),
 	}
-	ok, err := f.Fingerprint(&config.Config{}, node)
+	request := &cstructs.FingerprintRequest{Config: &config.Config{}, Node: node}
+
+	var response cstructs.FingerprintResponse
+
+	err := f.Fingerprint(request, &response)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if !ok {
-		t.Fatalf("should apply")
-	}
 
-	assertNodeAttributeContains(t, node, "swap.totalbytes")
+	assertNodeAttributeContains(t, response.Attributes, "swap.totalbytes")
 
 	if node.Resources == nil {
 		t.Fatalf("Node Resources was nil")

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -475,6 +475,7 @@ type AdvertiseAddrs struct {
 type Resources struct {
 	CPU                 int    `mapstructure:"cpu"`
 	MemoryMB            int    `mapstructure:"memory"`
+	SwapMB              int    `mapstructure:"swap"`
 	DiskMB              int    `mapstructure:"disk"`
 	IOPS                int    `mapstructure:"iops"`
 	ReservedPorts       string `mapstructure:"reserved_ports"`
@@ -1309,6 +1310,9 @@ func (r *Resources) Merge(b *Resources) *Resources {
 	}
 	if b.MemoryMB != 0 {
 		result.MemoryMB = b.MemoryMB
+	}
+	if b.SwapMB != 0 {
+		result.SwapMB = b.SwapMB
 	}
 	if b.DiskMB != 0 {
 		result.DiskMB = b.DiskMB

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -472,7 +472,7 @@ func parseReserved(result **Resources, list *ast.ObjectList) error {
 	valid := []string{
 		"cpu",
 		"memory",
-        "swap",
+		"swap",
 		"disk",
 		"iops",
 		"reserved_ports",

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -472,6 +472,7 @@ func parseReserved(result **Resources, list *ast.ObjectList) error {
 	valid := []string{
 		"cpu",
 		"memory",
+        "swap",
 		"disk",
 		"iops",
 		"reserved_ports",

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -753,6 +753,7 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 	structsTask.Resources = &structs.Resources{
 		CPU:      *apiTask.Resources.CPU,
 		MemoryMB: *apiTask.Resources.MemoryMB,
+		SwapMB:   *apiTask.Resources.SwapMB,
 		IOPS:     *apiTask.Resources.IOPS,
 	}
 

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -496,7 +496,7 @@ func (c *AllocStatusCommand) outputTaskResources(alloc *api.Allocation, task str
 		}
 	}
 	var resourcesOutput []string
-	resourcesOutput = append(resourcesOutput, "CPU|Memory|Disk|IOPS|Addresses")
+	resourcesOutput = append(resourcesOutput, "CPU|Memory|Swap|Disk|IOPS|Addresses")
 	firstAddr := ""
 	if len(addr) > 0 {
 		firstAddr = addr[0]
@@ -505,6 +505,7 @@ func (c *AllocStatusCommand) outputTaskResources(alloc *api.Allocation, task str
 	// Display the rolled up stats. If possible prefer the live statistics
 	cpuUsage := strconv.Itoa(*resource.CPU)
 	memUsage := humanize.IBytes(uint64(*resource.MemoryMB * bytesPerMegabyte))
+	swapUsage := humanize.IBytes(uint64(*resource.SwapMB * bytesPerMegabyte))
 	if stats != nil {
 		if ru, ok := stats.Tasks[task]; ok && ru != nil && ru.ResourceUsage != nil {
 			if cs := ru.ResourceUsage.CpuStats; cs != nil {
@@ -512,17 +513,19 @@ func (c *AllocStatusCommand) outputTaskResources(alloc *api.Allocation, task str
 			}
 			if ms := ru.ResourceUsage.MemoryStats; ms != nil {
 				memUsage = fmt.Sprintf("%v/%v", humanize.IBytes(ms.RSS), memUsage)
+				swapUsage = fmt.Sprintf("%v/%v", humanize.IBytes(ms.Swap), swapUsage)
 			}
 		}
 	}
-	resourcesOutput = append(resourcesOutput, fmt.Sprintf("%v MHz|%v|%v|%v|%v",
+	resourcesOutput = append(resourcesOutput, fmt.Sprintf("%v MHz|%v|%v|%v|%v|%v",
 		cpuUsage,
 		memUsage,
+		swapUsage,
 		humanize.IBytes(uint64(*alloc.Resources.DiskMB*bytesPerMegabyte)),
 		*resource.IOPS,
 		firstAddr))
 	for i := 1; i < len(addr); i++ {
-		resourcesOutput = append(resourcesOutput, fmt.Sprintf("||||%v", addr[i]))
+		resourcesOutput = append(resourcesOutput, fmt.Sprintf("|||||%v", addr[i]))
 	}
 	c.Ui.Output(formatListWithSpaces(resourcesOutput))
 

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -1199,6 +1199,7 @@ func parseResources(result *api.Resources, list *ast.ObjectList) error {
 		"iops",
 		"disk",
 		"memory",
+        "swap",
 		"network",
 	}
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -1199,7 +1199,7 @@ func parseResources(result *api.Resources, list *ast.ObjectList) error {
 		"iops",
 		"disk",
 		"memory",
-        "swap",
+		"swap",
 		"network",
 	}
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -225,6 +225,7 @@ func TestParse(t *testing.T) {
 								Resources: &api.Resources{
 									CPU:      helper.IntToPtr(500),
 									MemoryMB: helper.IntToPtr(128),
+									SwapMB:   helper.IntToPtr(0),
 									IOPS:     helper.IntToPtr(30),
 								},
 								Constraints: []*api.Constraint{

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -155,6 +155,7 @@ func TestParse(t *testing.T) {
 								},
 								Resources: &api.Resources{
 									CPU:      helper.IntToPtr(500),
+									SwapMB:   helper.IntToPtr(512),
 									MemoryMB: helper.IntToPtr(128),
 									Networks: []*api.NetworkResource{
 										{
@@ -224,8 +225,8 @@ func TestParse(t *testing.T) {
 								},
 								Resources: &api.Resources{
 									CPU:      helper.IntToPtr(500),
+									SwapMB:   helper.IntToPtr(512),
 									MemoryMB: helper.IntToPtr(128),
-									SwapMB:   helper.IntToPtr(0),
 									IOPS:     helper.IntToPtr(30),
 								},
 								Constraints: []*api.Constraint{

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -17,13 +17,13 @@ job "binstore-storagelocker" {
   }
 
   update {
-    stagger      = "60s"
-    max_parallel = 2
-    health_check = "manual"
+    stagger          = "60s"
+    max_parallel     = 2
+    health_check     = "manual"
     min_healthy_time = "10s"
     healthy_deadline = "10m"
-    auto_revert = true
-    canary = 1
+    auto_revert      = true
+    canary           = 1
   }
 
   task "outside" {
@@ -49,22 +49,22 @@ job "binstore-storagelocker" {
     }
 
     reschedule {
-       attempts = 5
-       interval = "12h"
+      attempts = 5
+      interval = "12h"
     }
 
     ephemeral_disk {
-        sticky = true
-        size = 150
+      sticky = true
+      size   = 150
     }
 
     update {
-        max_parallel = 3
-        health_check = "checks"
-        min_healthy_time = "1s"
-        healthy_deadline = "1m"
-        auto_revert = false
-        canary = 2
+      max_parallel     = 3
+      health_check     = "checks"
+      min_healthy_time = "1s"
+      healthy_deadline = "1m"
+      auto_revert      = false
+      canary           = 2
     }
 
     migrate {
@@ -109,8 +109,8 @@ job "binstore-storagelocker" {
           port     = "admin"
 
           check_restart {
-            limit = 3
-            grace = "10s"
+            limit           = 3
+            grace           = "10s"
             ignore_warnings = true
           }
         }
@@ -119,6 +119,7 @@ job "binstore-storagelocker" {
       resources {
         cpu    = 500
         memory = 128
+        swap   = 512
 
         network {
           mbits = "100"
@@ -135,14 +136,11 @@ job "binstore-storagelocker" {
             static = 3
           }
 
-          port "http" {
-          }
+          port "http" {}
 
-          port "https" {
-          }
+          port "https" {}
 
-          port "admin" {
-          }
+          port "admin" {}
         }
       }
 
@@ -159,9 +157,9 @@ job "binstore-storagelocker" {
       }
 
       artifact {
-        source = "http://bar.com/artifact"
+        source      = "http://bar.com/artifact"
         destination = "test/foo/"
-        mode = "file"
+        mode        = "file"
 
         options {
           checksum = "md5:ff1cc0d3432dad54d607c1505fb7245c"
@@ -173,20 +171,20 @@ job "binstore-storagelocker" {
       }
 
       template {
-        source = "foo"
-        destination = "foo"
-        change_mode = "foo"
+        source        = "foo"
+        destination   = "foo"
+        change_mode   = "foo"
         change_signal = "foo"
-        splay = "10s"
-        env = true
-        vault_grace = "33s"
+        splay         = "10s"
+        env           = true
+        vault_grace   = "33s"
       }
 
       template {
-        source = "bar"
-        destination = "bar"
-        perms = "777"
-        left_delimiter = "--"
+        source          = "bar"
+        destination     = "bar"
+        perms           = "777"
+        left_delimiter  = "--"
         right_delimiter = "__"
       }
     }
@@ -200,6 +198,7 @@ job "binstore-storagelocker" {
 
       resources {
         cpu    = 500
+        swap   = 512
         memory = 128
         iops   = 30
       }
@@ -210,9 +209,9 @@ job "binstore-storagelocker" {
       }
 
       vault {
-        policies = ["foo", "bar"]
-        env = false
-        change_mode = "signal"
+        policies      = ["foo", "bar"]
+        env           = false
+        change_mode   = "signal"
         change_signal = "SIGUSR1"
       }
     }

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2827,6 +2827,7 @@ func TestTaskDiff(t *testing.T) {
 					MemoryMB: 100,
 					DiskMB:   100,
 					IOPS:     100,
+					SwapMB:   100,
 				},
 			},
 			New: &Task{
@@ -2835,6 +2836,7 @@ func TestTaskDiff(t *testing.T) {
 					MemoryMB: 200,
 					DiskMB:   200,
 					IOPS:     200,
+					SwapMB:   200,
 				},
 			},
 			Expected: &TaskDiff{
@@ -2868,6 +2870,12 @@ func TestTaskDiff(t *testing.T) {
 								Old:  "100",
 								New:  "200",
 							},
+							{
+								Type: DiffTypeEdited,
+								Name: "SwapMB",
+								Old:  "100",
+								New:  "200",
+							},
 						},
 					},
 				},
@@ -2882,6 +2890,7 @@ func TestTaskDiff(t *testing.T) {
 					MemoryMB: 100,
 					DiskMB:   100,
 					IOPS:     100,
+					SwapMB:   100,
 				},
 			},
 			New: &Task{
@@ -2890,6 +2899,7 @@ func TestTaskDiff(t *testing.T) {
 					MemoryMB: 100,
 					DiskMB:   200,
 					IOPS:     100,
+					SwapMB:   100,
 				},
 			},
 			Expected: &TaskDiff{
@@ -2920,6 +2930,12 @@ func TestTaskDiff(t *testing.T) {
 							{
 								Type: DiffTypeNone,
 								Name: "MemoryMB",
+								Old:  "100",
+								New:  "100",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "SwapMB",
 								Old:  "100",
 								New:  "100",
 							},

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1597,7 +1597,7 @@ func (r *Resources) Merge(other *Resources) {
 	if other.MemoryMB != 0 {
 		r.MemoryMB = other.MemoryMB
 	}
-    if other.SwapMB != 0 {
+	if other.SwapMB != 0 {
 		r.SwapMB = other.SwapMB
 	}
 	if other.DiskMB != 0 {
@@ -1635,7 +1635,7 @@ func (r *Resources) MeetsMinResources() error {
 	if r.MemoryMB < minResources.MemoryMB {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("minimum MemoryMB value is %d; got %d", minResources.MemoryMB, r.MemoryMB))
 	}
-    if r.SwapMB < minResources.SwapMB {
+	if r.SwapMB < minResources.SwapMB {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("minimum SwapMB value is %d; got %d", minResources.SwapMB, r.SwapMB))
 	}
 	if r.IOPS < minResources.IOPS {
@@ -1687,7 +1687,7 @@ func (r *Resources) Superset(other *Resources) (bool, string) {
 	if r.MemoryMB < other.MemoryMB {
 		return false, "memory"
 	}
-    if r.SwapMB < other.SwapMB {
+	if r.SwapMB < other.SwapMB {
 		return false, "swap"
 	}
 	if r.DiskMB < other.DiskMB {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1547,6 +1547,7 @@ func (ns Networks) Port(label string) (string, int) {
 type Resources struct {
 	CPU      int
 	MemoryMB int
+	SwapMB   int
 	DiskMB   int
 	IOPS     int
 	Networks Networks
@@ -1564,6 +1565,7 @@ func DefaultResources() *Resources {
 	return &Resources{
 		CPU:      100,
 		MemoryMB: 300,
+		SwapMB:   0,
 		IOPS:     0,
 	}
 }
@@ -1577,6 +1579,7 @@ func MinResources() *Resources {
 	return &Resources{
 		CPU:      20,
 		MemoryMB: 10,
+		SwapMB:   0,
 		IOPS:     0,
 	}
 }
@@ -1593,6 +1596,9 @@ func (r *Resources) Merge(other *Resources) {
 	}
 	if other.MemoryMB != 0 {
 		r.MemoryMB = other.MemoryMB
+	}
+    if other.SwapMB != 0 {
+		r.SwapMB = other.SwapMB
 	}
 	if other.DiskMB != 0 {
 		r.DiskMB = other.DiskMB
@@ -1628,6 +1634,9 @@ func (r *Resources) MeetsMinResources() error {
 	}
 	if r.MemoryMB < minResources.MemoryMB {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("minimum MemoryMB value is %d; got %d", minResources.MemoryMB, r.MemoryMB))
+	}
+    if r.SwapMB < minResources.SwapMB {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("minimum SwapMB value is %d; got %d", minResources.SwapMB, r.SwapMB))
 	}
 	if r.IOPS < minResources.IOPS {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("minimum IOPS value is %d; got %d", minResources.IOPS, r.IOPS))
@@ -1678,6 +1687,9 @@ func (r *Resources) Superset(other *Resources) (bool, string) {
 	if r.MemoryMB < other.MemoryMB {
 		return false, "memory"
 	}
+    if r.SwapMB < other.SwapMB {
+		return false, "swap"
+	}
 	if r.DiskMB < other.DiskMB {
 		return false, "disk"
 	}
@@ -1696,6 +1708,7 @@ func (r *Resources) Add(delta *Resources) error {
 	r.CPU += delta.CPU
 	r.MemoryMB += delta.MemoryMB
 	r.DiskMB += delta.DiskMB
+	r.SwapMB += delta.SwapMB
 	r.IOPS += delta.IOPS
 
 	for _, n := range delta.Networks {

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -409,6 +409,8 @@ func tasksUpdated(jobA, jobB *structs.Job, taskGroup string) bool {
 			return true
 		} else if ar.MemoryMB != br.MemoryMB {
 			return true
+		} else if ar.SwapMB != br.SwapMB {
+			return true
 		} else if ar.IOPS != br.IOPS {
 			return true
 		}


### PR DESCRIPTION
This PR adds basic support to make Swap space a schedulable resource. While especially in cloud environments swap usage can be tricky since the performance can vary a lot. However, for some cases that process very ununiform data (especially batch workload), swap is often needed to not over-provision Memory to a great extent that then never ends up being used. At @Marketcircle, we are using a fork of Nomad with those changes.

*There are no changes to the documentation yet, and also the metric collection is not finalized.*

The main change is that "Swap" is a schedulable resource and can be defined in the resources of a task.

```
      resources = {
        memory = 2048
        cpu    = 1750
        swap   = 2048
}
```

Nodes do get fingerprinted for available swap space and the docker and lxc schedulers have been updated to enforce the limit.
