### PR TITLE
Add name variable to AWS Terraform configs

### DIFF
--- a/terraform/aws/env/us-east/main.tf
+++ b/terraform/aws/env/us-east/main.tf
@@ -1,3 +1,8 @@
+variable "name" {
+  description = "Used to name various infrastructure components"
+  default     = "hashistack"
+}
+
 variable "region" {
   description = "The AWS region to deploy to."
   default     = "us-east-1"
@@ -39,6 +44,7 @@ provider "aws" {
 module "hashistack" {
   source = "../../modules/hashistack"
 
+  name          = "${var.name}"
   region        = "${var.region}"
   ami           = "${var.ami}"
   instance_type = "${var.instance_type}"

--- a/terraform/aws/modules/hashistack/hashistack.tf
+++ b/terraform/aws/modules/hashistack/hashistack.tf
@@ -1,3 +1,4 @@
+variable "name" {}
 variable "region" {}
 variable "ami" {}
 variable "instance_type" {}
@@ -11,8 +12,8 @@ data "aws_vpc" "default" {
   default = true
 }
 
-resource "aws_security_group" "hashistack" {
-  name   = "hashistack"
+resource "aws_security_group" "primary" {
+  name   = "${var.name}"
   vpc_id = "${data.aws_vpc.default.id}"
 
   ingress {
@@ -102,12 +103,12 @@ resource "aws_instance" "server" {
   ami                    = "${var.ami}"
   instance_type          = "${var.instance_type}"
   key_name               = "${var.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.hashistack.id}"]
+  vpc_security_group_ids = ["${aws_security_group.primary.id}"]
   count                  = "${var.server_count}"
 
   #Instance tags
   tags {
-    Name           = "hashistack-server-${count.index}"
+    Name           = "${var.name}-server-${count.index}"
     ConsulAutoJoin = "auto-join"
   }
 
@@ -119,13 +120,13 @@ resource "aws_instance" "client" {
   ami                    = "${var.ami}"
   instance_type          = "${var.instance_type}"
   key_name               = "${var.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.hashistack.id}"]
+  vpc_security_group_ids = ["${aws_security_group.primary.id}"]
   count                  = "${var.client_count}"
   depends_on             = ["aws_instance.server"]
 
   #Instance tags
   tags {
-    Name           = "hashistack-client-${count.index}"
+    Name           = "${var.name}-client-${count.index}"
     ConsulAutoJoin = "auto-join"
   }
 
@@ -141,12 +142,12 @@ resource "aws_instance" "client" {
 }
 
 resource "aws_iam_instance_profile" "instance_profile" {
-  name_prefix = "hashistack"
+  name_prefix = "${var.name}"
   role        = "${aws_iam_role.instance_role.name}"
 }
 
 resource "aws_iam_role" "instance_role" {
-  name_prefix        = "hashistack"
+  name_prefix        = "${var.name}"
   assume_role_policy = "${data.aws_iam_policy_document.instance_role.json}"
 }
 


### PR DESCRIPTION
This enables you to avoid naming conflicts when standing up two sets of infrastructure side-by-side. 