### PR TITLE
Driver health UX improvements

### DIFF
--- a/command/node_status.go
+++ b/command/node_status.go
@@ -468,7 +468,7 @@ func formatEventSubsystem(subsystem, driverName string) string {
 func formatEventDetails(details map[string]string) string {
 	output := make([]string, 0, len(details))
 	for k, v := range details {
-		output = append(output, fmt.Sprintf("%s: %s, ", k, v))
+		output = append(output, fmt.Sprintf("%s: %s ", k, v))
 	}
 	return strings.Join(output, ", ")
 }


### PR DESCRIPTION
The resulting output is:

`nomad node-status -self`
```
Drivers                   
qemu rkt docker (unhealthy) exec raw_exec java  
```
and

`nomad node-status --verbose -self`
```
Drivers                                             
Driver    Detected  Healthy  Message                        Time
docker    false     false    Driver docker is not detected  2018-04-03T17:35:20Z
exec      true      true     <none>                         2018-04-03T17:32:20Z
java      true      true     <none>                         2018-04-03T17:32:20Z
qemu      true      true     <none>                         2018-04-03T17:32:20Z
raw_exec  true      true     <none>                         2018-04-03T17:32:20Z
rkt       true      true     <none>                         2018-04-03T17:32:20Z
```
