### PR TITLE
docs: mention env var changes in upgrade docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ __BACKWARDS INCOMPATIBILITIES:__
    attempts/time interval values have been changed to enable faster server side rescheduling. See
    [restart stanza](https://www.nomadproject.io/docs/job-specification/restart.html) for more information.
  * jobspec: Removed compatibility code that migrated pre Nomad 0.6.0 Update stanza syntax. All job spec files should be using update stanza fields introduced in 0.7.0 [[GH-3979](https://github.com/hashicorp/nomad/pull/3979/files)]
+ * client: Periods (`.`) are no longer replaced with underscores (`_`) in
+   environment variables as many applications rely on periods in environment
+   variable names. [[GH-3760](https://github.com/hashicorp/nomad/issues/3760)]
 
 IMPROVEMENTS:
  * core: Servers can now service client HTTP endpoints [[GH-3892](https://github.com/hashicorp/nomad/issues/3892)]

--- a/website/source/docs/upgrade/upgrade-specific.html.md
+++ b/website/source/docs/upgrade/upgrade-specific.html.md
@@ -17,7 +17,7 @@ standard upgrade flow.
 
 ## Nomad 0.8.0
 
-#### Raft Protocol Version Compatibility
+### Raft Protocol Version Compatibility
 
 When upgrading to Nomad 0.8.0 from a version lower than 0.7.0, users will need to
 set the [`-raft-protocol`](/docs/agent/options.html#_raft_protocol) option to 1 in
@@ -50,6 +50,30 @@ Raft Protocol versions supported by each Consul version:
 
 In order to enable all [Autopilot](/guides/cluster/autopilot.html) features, all servers
 in a Nomad cluster must be running with Raft protocol version 3 or later.
+
+### Periods in Environment Variable Names No Longer Escaped
+
+*Applications which expect periods in environment variable names to be replaced
+with underscores must be updated.*
+
+In Nomad 0.7 periods (`.`) in environment variables names were replaced with an
+underscore in both the [`env`](/docs/job-specification/env.html) and
+[`template`](/docs/job-specification/template.html) stanzas.
+
+In Nomad 0.8 periods are *not* replaced and will be included in environment
+variables verbatim.
+
+For example the following stanza:
+
+```text
+env {
+  registry.consul.addr = "${NOMAD_IP_http}:8500"
+}
+```
+
+In Nomad 0.7 would be exposed to the task as
+`registry_consul_addr=127.0.0.1:8500`. In Nomad 0.8 it will now appear exactly
+as specified: `registry.consul.addr=127.0.0.1:8500`.
 
 ## Nomad 0.6.0
 


### PR DESCRIPTION
Mention the changes from #3760 in the upgrade docs as applications
expecting underscores will break.

![image](https://user-images.githubusercontent.com/113362/38267651-f9f02c60-3730-11e8-9104-689d937262d1.png)
