### PR TITLE
Support custom Consul config for TestServer

### DIFF
--- a/testutil/server.go
+++ b/testutil/server.go
@@ -34,6 +34,7 @@ type TestServerConfig struct {
 	Region            string        `json:"region,omitempty"`
 	DisableCheckpoint bool          `json:"disable_update_check"`
 	LogLevel          string        `json:"log_level,omitempty"`
+	Consul            *Consul       `json:"consul,omitempty"`
 	AdvertiseAddrs    *Advertise    `json:"advertise,omitempty"`
 	Ports             *PortsConfig  `json:"ports,omitempty"`
 	Server            *ServerConfig `json:"server,omitempty"`
@@ -42,6 +43,13 @@ type TestServerConfig struct {
 	ACL               *ACLConfig    `json:"acl,omitempty"`
 	DevMode           bool          `json:"-"`
 	Stdout, Stderr    io.Writer     `json:"-"`
+}
+
+// Consul is used to configure the communication with Consul
+type Consul struct {
+	Address string `json:"address,omitempty"`
+	Auth    string `json:"auth,omitempty"`
+	Token   string `json:"token,omitempty"`
 }
 
 // Advertise is used to configure the addresses to advertise


### PR DESCRIPTION
Adds a Consul field to `TestServerConfig` that allows passing in non-default values for e.g. consul address.

This will allow the TestServer to integrate with [Consul's TestServer](https://github.com/hashicorp/consul/tree/master/testutil), allowing side-effect free integration tests.

This is especially useful if said tests happen to run on a machine that is running a Consul agent on the default :8500 port and we don't want our tests to register services using this agent.

The field is omitted if empty, so is backwards compatible.