### PR TITLE
Shorten docker health timeout

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1041,14 +1041,21 @@ func (d *DockerDriver) dockerClients() (*docker.Client, *docker.Client, error) {
 	}
 
 	var err error
-	client, err = d.newDockerClient(dockerTimeout)
-	if err != nil {
-		return nil, nil, err
+
+	// Onlt initialize the client if it hasn't yet been done
+	if client == nil {
+		client, err = d.newDockerClient(dockerTimeout)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
-	waitClient, err = d.newDockerClient(0 * time.Minute)
-	if err != nil {
-		return nil, nil, err
+	// Only initialize the waitClient if it hasn't yet been done
+	if waitClient == nil {
+		waitClient, err = d.newDockerClient(0 * time.Minute)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	return client, waitClient, nil

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1019,11 +1019,10 @@ func (d *DockerDriver) dockerHealthCheckClient() (*docker.Client, error) {
 		return healthCheckClient, nil
 	}
 
-	newHealthCheckClient, err := d.newDockerClient(dockerHealthCheckTimeout)
+	var err error
+	healthCheckClient, err = d.newDockerClient(dockerHealthCheckTimeout)
 	if err != nil {
 		return nil, err
-	} else {
-		healthCheckClient = newHealthCheckClient
 	}
 
 	return healthCheckClient, nil
@@ -1041,23 +1040,18 @@ func (d *DockerDriver) dockerClients() (*docker.Client, *docker.Client, error) {
 		return client, waitClient, nil
 	}
 
-	var merr multierror.Error
-
-	newClient, err := d.newDockerClient(dockerTimeout)
+	var err error
+	client, err = d.newDockerClient(dockerTimeout)
 	if err != nil {
-		merr.Errors = append(merr.Errors, err)
-	} else {
-		client = newClient
+		return nil, nil, err
 	}
 
-	newWaitClient, err := d.newDockerClient(0 * time.Minute)
+	waitClient, err = d.newDockerClient(0 * time.Minute)
 	if err != nil {
-		merr.Errors = append(merr.Errors, err)
-	} else {
-		waitClient = newWaitClient
+		return nil, nil, err
 	}
 
-	return client, waitClient, merr.ErrorOrNil()
+	return client, waitClient, nil
 }
 
 // newDockerClient creates a new *docker.Client with a configurable timeout


### PR DESCRIPTION
Previous discussion included memoizing the error- I ended up not including this as it seems safer to not do so, and retry after each unsuccessful attempt (i.e, calls to these endpoints could fail for transient reasons) 