### PR TITLE
Never respond with an empty object from the adapter

### DIFF
--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -80,7 +80,7 @@ export default ApplicationAdapter.extend({
       data: params,
     }).catch(error => {
       if (error instanceof AbortError) {
-        return {};
+        return;
       }
       throw error;
     });


### PR DESCRIPTION
In production builds only, this will slip into the local store
as a record with no ID, which makes for all sorts of bad news.