### PR TITLE
rpc: only attempt NodeRpc for nodes>=0.8

### DIFF
--- a/nomad/client_alloc_endpoint.go
+++ b/nomad/client_alloc_endpoint.go
@@ -2,7 +2,6 @@ package nomad
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
@@ -48,16 +47,8 @@ func (a *ClientAllocations) GarbageCollectAll(args *structs.NodeSpecificRequest,
 		return err
 	}
 
-	node, err := snap.NodeByID(nil, args.NodeID)
+	_, err = getNodeForRpc(snap, args.NodeID)
 	if err != nil {
-		return err
-	}
-
-	if node == nil {
-		return fmt.Errorf("Unknown node %q", args.NodeID)
-	}
-
-	if err := nodeSupportsRpc(node); err != nil {
 		return err
 	}
 
@@ -112,16 +103,8 @@ func (a *ClientAllocations) GarbageCollect(args *structs.AllocSpecificRequest, r
 	}
 
 	// Make sure Node is valid and new enough to support RPC
-	node, err := snap.NodeByID(nil, alloc.NodeID)
+	_, err = getNodeForRpc(snap, alloc.NodeID)
 	if err != nil {
-		return err
-	}
-
-	if node == nil {
-		return fmt.Errorf("Unknown node %q", alloc.NodeID)
-	}
-
-	if err := nodeSupportsRpc(node); err != nil {
 		return err
 	}
 
@@ -176,16 +159,8 @@ func (a *ClientAllocations) Stats(args *cstructs.AllocStatsRequest, reply *cstru
 	}
 
 	// Make sure Node is valid and new enough to support RPC
-	node, err := snap.NodeByID(nil, alloc.NodeID)
+	_, err = getNodeForRpc(snap, alloc.NodeID)
 	if err != nil {
-		return err
-	}
-
-	if node == nil {
-		return fmt.Errorf("Unknown node %q", alloc.NodeID)
-	}
-
-	if err := nodeSupportsRpc(node); err != nil {
 		return err
 	}
 

--- a/nomad/client_fs_endpoint.go
+++ b/nomad/client_fs_endpoint.go
@@ -132,16 +132,8 @@ func (f *FileSystem) List(args *cstructs.FsListRequest, reply *cstructs.FsListRe
 	}
 
 	// Make sure Node is valid and new enough to support RPC
-	node, err := snap.NodeByID(nil, alloc.NodeID)
+	_, err = getNodeForRpc(snap, alloc.NodeID)
 	if err != nil {
-		return err
-	}
-
-	if node == nil {
-		return fmt.Errorf("Unknown node %q", alloc.NodeID)
-	}
-
-	if err := nodeSupportsRpc(node); err != nil {
 		return err
 	}
 
@@ -195,16 +187,8 @@ func (f *FileSystem) Stat(args *cstructs.FsStatRequest, reply *cstructs.FsStatRe
 	}
 
 	// Make sure Node is valid and new enough to support RPC
-	node, err := snap.NodeByID(nil, alloc.NodeID)
+	_, err = getNodeForRpc(snap, alloc.NodeID)
 	if err != nil {
-		return err
-	}
-
-	if node == nil {
-		return fmt.Errorf("Unknown node %q", alloc.NodeID)
-	}
-
-	if err := nodeSupportsRpc(node); err != nil {
 		return err
 	}
 

--- a/nomad/client_rpc.go
+++ b/nomad/client_rpc.go
@@ -9,7 +9,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/helper/pool"
-	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/yamux"
 	"github.com/ugorji/go/codec"
@@ -237,18 +236,7 @@ func NodeStreamingRpc(session *yamux.Session, method string) (net.Conn, error) {
 // findNodeConnAndForward is a helper for finding the server with a connection
 // to the given node and forwarding the RPC to the correct server. This does not
 // work for streaming RPCs.
-func findNodeConnAndForward(srv *Server, snap *state.StateSnapshot,
-	nodeID, method string, args, reply interface{}) error {
-
-	node, err := snap.NodeByID(nil, nodeID)
-	if err != nil {
-		return err
-	}
-
-	if node == nil {
-		return fmt.Errorf("Unknown node %q", nodeID)
-	}
-
+func findNodeConnAndForward(srv *Server, nodeID, method string, args, reply interface{}) error {
 	// Determine the Server that has a connection to the node.
 	srvWithConn, err := srv.serverWithNodeConn(nodeID, srv.Region())
 	if err != nil {

--- a/nomad/client_stats_endpoint.go
+++ b/nomad/client_stats_endpoint.go
@@ -2,7 +2,6 @@ package nomad
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
@@ -46,17 +45,9 @@ func (s *ClientStats) Stats(args *nstructs.NodeSpecificRequest, reply *structs.C
 		return err
 	}
 
-	node, err := snap.NodeByID(nil, args.NodeID)
-	if err != nil {
-		return err
-	}
-
-	if node == nil {
-		return fmt.Errorf("Unknown node %q", args.NodeID)
-	}
-
 	// Make sure Node is new enough to support RPC
-	if err := nodeSupportsRpc(node); err != nil {
+	_, err = getNodeForRpc(snap, args.NodeID)
+	if err != nil {
 		return err
 	}
 

--- a/nomad/structs/errors.go
+++ b/nomad/structs/errors.go
@@ -7,12 +7,14 @@ import (
 )
 
 const (
-	errNoLeader         = "No cluster leader"
-	errNoRegionPath     = "No path to region"
-	errTokenNotFound    = "ACL token not found"
-	errPermissionDenied = "Permission denied"
-	errNoNodeConn       = "No path to node"
-	errUnknownMethod    = "Unknown rpc method"
+	errNoLeader            = "No cluster leader"
+	errNoRegionPath        = "No path to region"
+	errTokenNotFound       = "ACL token not found"
+	errPermissionDenied    = "Permission denied"
+	errNoNodeConn          = "No path to node"
+	errUnknownMethod       = "Unknown rpc method"
+	errUnknownNomadVersion = "Unable to determine Nomad version"
+	errNodeLacksRpc        = "Node does not support RPC; requires 0.8 or later"
 
 	// Prefix based errors that are used to check if the error is of a given
 	// type. These errors should be created with the associated constructor.
@@ -24,12 +26,14 @@ const (
 )
 
 var (
-	ErrNoLeader         = errors.New(errNoLeader)
-	ErrNoRegionPath     = errors.New(errNoRegionPath)
-	ErrTokenNotFound    = errors.New(errTokenNotFound)
-	ErrPermissionDenied = errors.New(errPermissionDenied)
-	ErrNoNodeConn       = errors.New(errNoNodeConn)
-	ErrUnknownMethod    = errors.New(errUnknownMethod)
+	ErrNoLeader            = errors.New(errNoLeader)
+	ErrNoRegionPath        = errors.New(errNoRegionPath)
+	ErrTokenNotFound       = errors.New(errTokenNotFound)
+	ErrPermissionDenied    = errors.New(errPermissionDenied)
+	ErrNoNodeConn          = errors.New(errNoNodeConn)
+	ErrUnknownMethod       = errors.New(errUnknownMethod)
+	ErrUnknownNomadVersion = errors.New(errUnknownNomadVersion)
+	ErrNodeLacksRpc        = errors.New(errNodeLacksRpc)
 )
 
 // IsErrNoLeader returns whether the error is due to there being no leader.
@@ -123,4 +127,16 @@ func IsErrUnknownEvaluation(err error) bool {
 // deployment.
 func IsErrUnknownDeployment(err error) bool {
 	return err != nil && strings.Contains(err.Error(), ErrUnknownDeploymentPrefix)
+}
+
+// IsErrUnknownNomadVersion returns whether the error is due to Nomad being
+// unable to determine the version of a node.
+func IsErrUnknownNomadVersion(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errUnknownNomadVersion)
+}
+
+// IsErrNodeLacksRpc returns whether error is due to a Nomad server being
+// unable to connect to a client node because the client is too old (pre-v0.8).
+func IsErrNodeLacksRpc(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errNodeLacksRpc)
 }

--- a/nomad/util.go
+++ b/nomad/util.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/serf/serf"
 )
 
@@ -200,4 +201,25 @@ func maxUint64(inputs ...uint64) uint64 {
 		}
 	}
 	return max
+}
+
+var minRpcVersion = version.Must(version.NewVersion("0.8.0-rc1"))
+
+// nodeSupportsRpc returns a non-nil error if a Node does not support RPC.
+func nodeSupportsRpc(node *structs.Node) error {
+	rawNodeVer, ok := node.Attributes["nomad.version"]
+	if !ok {
+		return structs.ErrUnknownNomadVersion
+	}
+
+	nodeVer, err := version.NewVersion(rawNodeVer)
+	if err != nil {
+		return structs.ErrUnknownNomadVersion
+	}
+
+	if nodeVer.LessThan(minRpcVersion) {
+		return structs.ErrNodeLacksRpc
+	}
+
+	return nil
 }

--- a/nomad/util.go
+++ b/nomad/util.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/serf/serf"
 )
@@ -203,7 +204,26 @@ func maxUint64(inputs ...uint64) uint64 {
 	return max
 }
 
-var minRpcVersion = version.Must(version.NewVersion("0.8.0-rc1"))
+// getNodeForRpc returns a Node struct if the Node supports Node RPC. Otherwise
+// an error is returned.
+func getNodeForRpc(snap *state.StateSnapshot, nodeID string) (*structs.Node, error) {
+	node, err := snap.NodeByID(nil, nodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	if node == nil {
+		return nil, fmt.Errorf("Unknown node %q", nodeID)
+	}
+
+	if err := nodeSupportsRpc(node); err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+var minNodeVersionSupportingRPC = version.Must(version.NewVersion("0.8.0-rc1"))
 
 // nodeSupportsRpc returns a non-nil error if a Node does not support RPC.
 func nodeSupportsRpc(node *structs.Node) error {
@@ -217,7 +237,7 @@ func nodeSupportsRpc(node *structs.Node) error {
 		return structs.ErrUnknownNomadVersion
 	}
 
-	if nodeVer.LessThan(minRpcVersion) {
+	if nodeVer.LessThan(minNodeVersionSupportingRPC) {
 		return structs.ErrNodeLacksRpc
 	}
 

--- a/website/source/docs/upgrade/upgrade-specific.html.md
+++ b/website/source/docs/upgrade/upgrade-specific.html.md
@@ -75,6 +75,15 @@ In Nomad 0.7 would be exposed to the task as
 `registry_consul_addr=127.0.0.1:8500`. In Nomad 0.8 it will now appear exactly
 as specified: `registry.consul.addr=127.0.0.1:8500`.
 
+### Client APIs Unavailable on Older Nodes
+
+Because Nomad 0.8 uses a new RPC mechanism to route node-specific APIs like
+[`nomad alloc fs`](/docs/commands/alloc/fs.html) through servers to the node,
+0.8 CLIs are incompatible using these commands on clients older than 0.8.
+
+To access these commands on older clients either continue to use a pre-0.8
+version of the CLI, or upgrade all clients to 0.8.
+
 ## Nomad 0.6.0
 
 ### Default `advertise` address changes


### PR DESCRIPTION
Attempting NodeRpc (or streaming node rpc) for clients that do not
support it causes it to hang indefinitely because while the TCP
connection exists, the client will never respond.

CLI output:
```
$ nomad fs 2e redis
Unexpected response code: 500 (Node does not support RPC; requires 0.8 or later)

$ ./nomad status 2e
ID                  = 2ecebc3d
Eval ID             = a81ef2c8
Name                = example.cache[3]
Node ID             = cce8fb56
...

Couldn't retrieve stats (HINT: ensure Client.Advertise.HTTP is set): Unexpected response code: 500 (Node does not support RPC; requires 0.8 or later)

Task "redis" is "running"
Task Resources
CPU      Memory   Disk     IOPS  Addresses
...
```