### PR TITLE
UI: Unlink record relationships before unloading them from the store

### DIFF
--- a/ui/app/serializers/application.js
+++ b/ui/app/serializers/application.js
@@ -2,6 +2,7 @@ import { copy } from '@ember/object/internals';
 import { get } from '@ember/object';
 import { makeArray } from '@ember/array';
 import JSONSerializer from 'ember-data/serializers/json';
+import removeRecord from '../utils/remove-record';
 
 export default JSONSerializer.extend({
   primaryKey: 'ID',
@@ -59,7 +60,7 @@ export default JSONSerializer.extend({
       .forEach(old => {
         const newRecord = newRecords.find(record => get(record, 'id') === get(old, 'id'));
         if (!newRecord) {
-          store.unloadRecord(old);
+          removeRecord(store, old);
         } else {
           newRecords.removeObject(newRecord);
         }

--- a/ui/app/utils/remove-record.js
+++ b/ui/app/utils/remove-record.js
@@ -1,0 +1,27 @@
+// Unlinks a record from all its relationships and unloads it from
+// the store.
+export default function removeRecord(store, record) {
+  // Collect relationship property names and types
+  const relationshipMeta = [];
+  record.eachRelationship((key, { kind }) => {
+    relationshipMeta.push({ key, kind });
+  });
+
+  // Push an update to this record with the relationships nulled out.
+  // This unlinks the relationship from the models that aren't about to
+  // be unloaded.
+  store.push({
+    data: {
+      id: record.get('id'),
+      type: record.constructor.modelName,
+      relationships: relationshipMeta.reduce((hash, rel) => {
+        hash[rel.key] = { data: rel.kind === 'hasMany' ? [] : null };
+        return hash;
+      }, {}),
+    },
+  });
+
+  // Now that the record has no attachments, it can be safely unloaded
+  // from the store.
+  store.unloadRecord(record);
+}


### PR DESCRIPTION
When simply unloading a record, references to the record are
maintained by the internal relationship state of related models.
This causes refetching and duplicate models local to that relationship
state.