### PR TITLE
cli: remove outdated hints

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -196,7 +196,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		if statsErr != nil {
 			c.Ui.Output("")
 			if statsErr != api.NodeDownErr {
-				c.Ui.Error(fmt.Sprintf("Couldn't retrieve stats (HINT: ensure Client.Advertise.HTTP is set): %v", statsErr))
+				c.Ui.Error(fmt.Sprintf("Couldn't retrieve stats: %v", statsErr))
 			} else {
 				c.Ui.Output("Omitting resource statistics since the node is down.")
 			}

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -316,7 +316,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		hostStats, nodeStatsErr := client.Nodes().Stats(node.ID, nil)
 		if nodeStatsErr != nil {
 			c.Ui.Output("")
-			c.Ui.Error(fmt.Sprintf("error fetching node stats (HINT: ensure Client.Advertise.HTTP is set): %v", nodeStatsErr))
+			c.Ui.Error(fmt.Sprintf("error fetching node stats: %v", nodeStatsErr))
 		}
 		if hostStats != nil {
 			uptime := time.Duration(hostStats.Uptime * uint64(time.Second))
@@ -358,7 +358,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		hostResources, err := getHostResources(hostStats, node)
 		if err != nil {
 			c.Ui.Output("")
-			c.Ui.Error(fmt.Sprintf("error fetching node stats (HINT: ensure Client.Advertise.HTTP is set): %v", err))
+			c.Ui.Error(fmt.Sprintf("error fetching node stats: %v", err))
 		}
 		if err == nil {
 			c.Ui.Output(c.Colorize().Color("\n[bold]Host Resource Utilization[reset]"))


### PR DESCRIPTION
Hints no longer apply in the 0.8 Node RPC world.