### PR TITLE
UI: Defer showing alloc addresses until the node is loaded

### DIFF
--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -65,15 +65,23 @@
               <td data-test-ports>
                 <ul>
                   {{#each row.model.resources.networks.firstObject.reservedPorts as |port|}}
-                    <li>
+                    <li data-test-port>
                       <strong>{{port.Label}}:</strong>
-                      <a href="http://{{row.model.allocation.node.address}}:{{port.Value}}" target="_blank">{{row.model.allocation.node.address}}:{{port.Value}}</a>
+                      {{#if row.model.allocation.node.address}}
+                        <a href="http://{{row.model.allocation.node.address}}:{{port.Value}}" target="_blank">{{row.model.allocation.node.address}}:{{port.Value}}</a>
+                      {{else}}
+                        ...
+                      {{/if}}
                     </li>
                   {{/each}}
                   {{#each row.model.resources.networks.firstObject.dynamicPorts as |port|}}
                     <li>
                       <strong>{{port.Label}}:</strong>
-                      <a href="http://{{row.model.allocation.node.address}}:{{port.Value}}" target="_blank">{{row.model.allocation.node.address}}:{{port.Value}}</a>
+                      {{#if row.model.allocation.node.address}}
+                        <a href="http://{{row.model.allocation.node.address}}:{{port.Value}}" target="_blank">{{row.model.allocation.node.address}}:{{port.Value}}</a>
+                      {{else}}
+                        ...
+                      {{/if}}
                     </li>
                   {{/each}}
                 </ul>


### PR DESCRIPTION
**Before:** Allocations would list all addresses by joining `undefined` and the port. This resulted in broken links that would open a blank tab.

**After:** Allocations will show the nonintrusive `...` loading state until the node the alloc is running on is loaded. This guarantees a legitimate URL.