### PR TITLE
Update garbage collection logic to make sure allocs with pending evals are not GCed

### DIFF
--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -1816,7 +1816,7 @@ func TestAllocation_GCEligible(t *testing.T) {
 
 	harness := []testCase{
 		{
-			Desc:           "GC when non terminal",
+			Desc:           "Don't GC when non terminal",
 			ClientStatus:   structs.AllocClientStatusPending,
 			DesiredStatus:  structs.AllocDesiredStatusRun,
 			GCTime:         fail,
@@ -1825,7 +1825,7 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ShouldGC:       false,
 		},
 		{
-			Desc:           "GC when non terminal and job stopped",
+			Desc:           "Don't GC when non terminal and job stopped",
 			ClientStatus:   structs.AllocClientStatusPending,
 			DesiredStatus:  structs.AllocDesiredStatusRun,
 			JobStop:        true,
@@ -1835,7 +1835,7 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ShouldGC:       false,
 		},
 		{
-			Desc:           "GC when non terminal and job dead",
+			Desc:           "Don't GC when non terminal and job dead",
 			ClientStatus:   structs.AllocClientStatusPending,
 			DesiredStatus:  structs.AllocDesiredStatusRun,
 			JobStatus:      structs.JobStatusDead,
@@ -1849,13 +1849,13 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ClientStatus:     structs.AllocClientStatusComplete,
 			DesiredStatus:    structs.AllocDesiredStatusRun,
 			GCTime:           fail,
-			ModifyIndex:      100,
+			ModifyIndex:      90,
 			ThresholdIndex:   90,
 			ReschedulePolicy: nil,
-			ShouldGC:         false,
+			ShouldGC:         true,
 		},
 		{
-			Desc:             "GC when threshold not met",
+			Desc:             "Don't GC when threshold not met",
 			ClientStatus:     structs.AllocClientStatusComplete,
 			DesiredStatus:    structs.AllocDesiredStatusStop,
 			GCTime:           fail,
@@ -1885,7 +1885,7 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ShouldGC:         true,
 		},
 		{
-			Desc:             "GC with no previous attempts",
+			Desc:             "Don't GC when no previous reschedule attempts",
 			ClientStatus:     structs.AllocClientStatusFailed,
 			DesiredStatus:    structs.AllocDesiredStatusRun,
 			GCTime:           fail,
@@ -1895,7 +1895,7 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ShouldGC:         false,
 		},
 		{
-			Desc:             "GC with prev reschedule attempt within interval",
+			Desc:             "Don't GC when prev reschedule attempt within interval",
 			ClientStatus:     structs.AllocClientStatusFailed,
 			DesiredStatus:    structs.AllocDesiredStatusRun,
 			ReschedulePolicy: &structs.ReschedulePolicy{Attempts: 2, Interval: 30 * time.Minute},
@@ -1940,7 +1940,7 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ShouldGC:    true,
 		},
 		{
-			Desc:             "GC when next alloc id is not set and unlimited restarts",
+			Desc:             "Don't GC when next alloc id is not set and unlimited restarts",
 			ClientStatus:     structs.AllocClientStatusFailed,
 			DesiredStatus:    structs.AllocDesiredStatusRun,
 			GCTime:           fail,
@@ -2001,7 +2001,7 @@ func TestAllocation_GCEligible(t *testing.T) {
 			if got := allocGCEligible(alloc, job, tc.GCTime, tc.ThresholdIndex); got != tc.ShouldGC {
 				t.Fatalf("expected %v but got %v", tc.ShouldGC, got)
 			}
-		}
+		})
 
 	}
 

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -1798,10 +1798,10 @@ func TestCoreScheduler_PartitionJobReap(t *testing.T) {
 func TestAllocation_GCEligible(t *testing.T) {
 	type testCase struct {
 		Desc               string
-		GCTime             time.Time
 		ClientStatus       string
 		DesiredStatus      string
 		JobStatus          string
+		FollowupEvalStatus string
 		JobStop            bool
 		ModifyIndex        uint64
 		NextAllocID        string
@@ -1818,7 +1818,6 @@ func TestAllocation_GCEligible(t *testing.T) {
 			Desc:           "GC when non terminal",
 			ClientStatus:   structs.AllocClientStatusPending,
 			DesiredStatus:  structs.AllocDesiredStatusRun,
-			GCTime:         fail,
 			ModifyIndex:    90,
 			ThresholdIndex: 90,
 			ShouldGC:       false,
@@ -1828,7 +1827,6 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ClientStatus:   structs.AllocClientStatusPending,
 			DesiredStatus:  structs.AllocDesiredStatusRun,
 			JobStop:        true,
-			GCTime:         fail,
 			ModifyIndex:    90,
 			ThresholdIndex: 90,
 			ShouldGC:       false,
@@ -1838,7 +1836,6 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ClientStatus:   structs.AllocClientStatusPending,
 			DesiredStatus:  structs.AllocDesiredStatusRun,
 			JobStatus:      structs.JobStatusDead,
-			GCTime:         fail,
 			ModifyIndex:    90,
 			ThresholdIndex: 90,
 			ShouldGC:       false,
@@ -1847,7 +1844,6 @@ func TestAllocation_GCEligible(t *testing.T) {
 			Desc:             "GC when threshold not met",
 			ClientStatus:     structs.AllocClientStatusComplete,
 			DesiredStatus:    structs.AllocDesiredStatusStop,
-			GCTime:           fail,
 			ModifyIndex:      100,
 			ThresholdIndex:   90,
 			ReschedulePolicy: nil,
@@ -1857,40 +1853,38 @@ func TestAllocation_GCEligible(t *testing.T) {
 			Desc:             "GC when no reschedule policy",
 			ClientStatus:     structs.AllocClientStatusFailed,
 			DesiredStatus:    structs.AllocDesiredStatusRun,
-			GCTime:           fail,
 			ReschedulePolicy: nil,
 			ModifyIndex:      90,
 			ThresholdIndex:   90,
 			ShouldGC:         true,
 		},
 		{
-			Desc:             "GC when empty policy",
+			Desc:             "GC with empty reschedule policy",
 			ClientStatus:     structs.AllocClientStatusFailed,
 			DesiredStatus:    structs.AllocDesiredStatusRun,
-			GCTime:           fail,
-			ReschedulePolicy: &structs.ReschedulePolicy{Attempts: 0, Interval: 0 * time.Minute},
+			ReschedulePolicy: &structs.ReschedulePolicy{Attempts: 0, Interval: 0 * time.Minute, Unlimited: false},
 			ModifyIndex:      90,
 			ThresholdIndex:   90,
 			ShouldGC:         true,
 		},
 		{
-			Desc:             "GC with no previous attempts",
-			ClientStatus:     structs.AllocClientStatusFailed,
-			DesiredStatus:    structs.AllocDesiredStatusRun,
-			GCTime:           fail,
-			ModifyIndex:      90,
-			ThresholdIndex:   90,
-			ReschedulePolicy: &structs.ReschedulePolicy{Attempts: 1, Interval: 1 * time.Minute},
-			ShouldGC:         false,
+			Desc:               "GC with pending followup eval",
+			ClientStatus:       structs.AllocClientStatusFailed,
+			DesiredStatus:      structs.AllocDesiredStatusRun,
+			FollowupEvalStatus: structs.EvalStatusPending,
+			ModifyIndex:        90,
+			ThresholdIndex:     90,
+			ReschedulePolicy:   &structs.ReschedulePolicy{Attempts: 1, Interval: 1 * time.Minute},
+			ShouldGC:           false,
 		},
 		{
-			Desc:             "GC with prev reschedule attempt within interval",
-			ClientStatus:     structs.AllocClientStatusFailed,
-			DesiredStatus:    structs.AllocDesiredStatusRun,
-			ReschedulePolicy: &structs.ReschedulePolicy{Attempts: 2, Interval: 30 * time.Minute},
-			GCTime:           fail,
-			ModifyIndex:      90,
-			ThresholdIndex:   90,
+			Desc:               "GC with blocked followup eval",
+			ClientStatus:       structs.AllocClientStatusFailed,
+			DesiredStatus:      structs.AllocDesiredStatusRun,
+			ReschedulePolicy:   &structs.ReschedulePolicy{Attempts: 2, Interval: 30 * time.Minute},
+			FollowupEvalStatus: structs.EvalStatusBlocked,
+			ModifyIndex:        90,
+			ThresholdIndex:     90,
 			RescheduleTrackers: []*structs.RescheduleEvent{
 				{
 					RescheduleTime: fail.Add(-5 * time.Minute).UTC().UnixNano(),
@@ -1899,11 +1893,11 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ShouldGC: false,
 		},
 		{
-			Desc:             "GC with prev reschedule attempt outside interval",
-			ClientStatus:     structs.AllocClientStatusFailed,
-			DesiredStatus:    structs.AllocDesiredStatusRun,
-			GCTime:           fail,
-			ReschedulePolicy: &structs.ReschedulePolicy{Attempts: 5, Interval: 30 * time.Minute},
+			Desc:               "GC with complete followup eval",
+			ClientStatus:       structs.AllocClientStatusFailed,
+			DesiredStatus:      structs.AllocDesiredStatusRun,
+			FollowupEvalStatus: structs.EvalStatusComplete,
+			ReschedulePolicy:   &structs.ReschedulePolicy{Attempts: 5, Interval: 30 * time.Minute},
 			RescheduleTrackers: []*structs.RescheduleEvent{
 				{
 					RescheduleTime: fail.Add(-45 * time.Minute).UTC().UnixNano(),
@@ -1918,21 +1912,14 @@ func TestAllocation_GCEligible(t *testing.T) {
 			Desc:             "GC when next alloc id is set",
 			ClientStatus:     structs.AllocClientStatusFailed,
 			DesiredStatus:    structs.AllocDesiredStatusRun,
-			GCTime:           fail,
 			ReschedulePolicy: &structs.ReschedulePolicy{Attempts: 5, Interval: 30 * time.Minute},
-			RescheduleTrackers: []*structs.RescheduleEvent{
-				{
-					RescheduleTime: fail.Add(-3 * time.Minute).UTC().UnixNano(),
-				},
-			},
-			NextAllocID: uuid.Generate(),
-			ShouldGC:    true,
+			NextAllocID:      uuid.Generate(),
+			ShouldGC:         true,
 		},
 		{
 			Desc:             "GC when job is stopped",
 			ClientStatus:     structs.AllocClientStatusFailed,
 			DesiredStatus:    structs.AllocDesiredStatusRun,
-			GCTime:           fail,
 			ReschedulePolicy: &structs.ReschedulePolicy{Attempts: 5, Interval: 30 * time.Minute},
 			RescheduleTrackers: []*structs.RescheduleEvent{
 				{
@@ -1946,7 +1933,6 @@ func TestAllocation_GCEligible(t *testing.T) {
 			Desc:             "GC when job status is dead",
 			ClientStatus:     structs.AllocClientStatusFailed,
 			DesiredStatus:    structs.AllocDesiredStatusRun,
-			GCTime:           fail,
 			ReschedulePolicy: &structs.ReschedulePolicy{Attempts: 5, Interval: 30 * time.Minute},
 			RescheduleTrackers: []*structs.RescheduleEvent{
 				{
@@ -1965,6 +1951,13 @@ func TestAllocation_GCEligible(t *testing.T) {
 		alloc.ClientStatus = tc.ClientStatus
 		alloc.RescheduleTracker = &structs.RescheduleTracker{Events: tc.RescheduleTrackers}
 		alloc.NextAllocation = tc.NextAllocID
+		var followupEval *structs.Evaluation
+
+		if tc.FollowupEvalStatus != "" {
+			followupEval = mock.Eval()
+			followupEval.Status = tc.FollowupEvalStatus
+		}
+
 		job := mock.Job()
 		alloc.TaskGroup = job.TaskGroups[0].Name
 		job.TaskGroups[0].ReschedulePolicy = tc.ReschedulePolicy
@@ -1974,7 +1967,7 @@ func TestAllocation_GCEligible(t *testing.T) {
 		job.Stop = tc.JobStop
 
 		t.Run(tc.Desc, func(t *testing.T) {
-			if got := allocGCEligible(alloc, job, tc.GCTime, tc.ThresholdIndex); got != tc.ShouldGC {
+			if got := allocGCEligible(alloc, job, followupEval, tc.ThresholdIndex); got != tc.ShouldGC {
 				t.Fatalf("expected %v but got %v", tc.ShouldGC, got)
 			}
 		})
@@ -1985,5 +1978,5 @@ func TestAllocation_GCEligible(t *testing.T) {
 	require := require.New(t)
 	alloc := mock.Alloc()
 	alloc.ClientStatus = structs.AllocClientStatusComplete
-	require.True(allocGCEligible(alloc, nil, time.Now(), 1000))
+	require.True(allocGCEligible(alloc, nil, nil, 1000))
 }


### PR DESCRIPTION
This PR simplifies the GC logic as well. We used to read information in the reschedule tracker to make sure we don't GC any allocations that have recent reschedule events within their time interval. Instead, with this PR we look at if it has a NextAllocation field (that implies it has already been rescheduled) or has a pending eval (from the FollowupEvalID field which is created as soon as a failure causes the allocation to get updated). if there's a pending eval we won't GC it.