### PR TITLE
Changed "til" to "until"

### DIFF
--- a/api/fs.go
+++ b/api/fs.go
@@ -360,7 +360,7 @@ func NewFrameReader(frames <-chan *StreamFrame, errCh <-chan error, cancelCh cha
 }
 
 // SetUnblockTime sets the time to unblock and return zero bytes read. If the
-// duration is unset or is zero or less, the read will block til data is read.
+// duration is unset or is zero or less, the read will block until data is read.
 func (f *FrameReader) SetUnblockTime(d time.Duration) {
 	f.unblockTime = d
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -410,7 +410,7 @@ func TestClient_UpdateAllocStatus(t *testing.T) {
 	})
 	defer c1.Shutdown()
 
-	// Wait til the node is ready
+	// Wait until the node is ready
 	waitTilNodeReady(c1, t)
 
 	job := mock.Job()
@@ -461,7 +461,7 @@ func TestClient_WatchAllocs(t *testing.T) {
 	})
 	defer c1.Shutdown()
 
-	// Wait til the node is ready
+	// Wait until the node is ready
 	waitTilNodeReady(c1, t)
 
 	// Create mock allocations
@@ -557,7 +557,7 @@ func TestClient_SaveRestoreState(t *testing.T) {
 	})
 	defer c1.Shutdown()
 
-	// Wait til the node is ready
+	// Wait until the node is ready
 	waitTilNodeReady(c1, t)
 
 	// Create mock allocations

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -1519,7 +1519,7 @@ func TestCoreScheduler_JobGC_Parameterized(t *testing.T) {
 	}
 }
 
-// This test ensures periodic jobs don't get GCd til they are stopped
+// This test ensures periodic jobs don't get GCd until they are stopped
 func TestCoreScheduler_JobGC_Periodic(t *testing.T) {
 	t.Parallel()
 

--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -205,7 +205,7 @@ func (b *EvalBroker) EnqueueAll(evals map[*structs.Evaluation]string) {
 
 // processEnqueue deduplicates evals and either enqueue immediately or enforce
 // the evals wait time. If the token is passed, and the evaluation ID is
-// outstanding, the evaluation is blocked til an Ack/Nack is received.
+// outstanding, the evaluation is blocked until an Ack/Nack is received.
 // processEnqueue must be called with the lock held.
 func (b *EvalBroker) processEnqueue(eval *structs.Evaluation, token string) {
 	// Check if already enqueued

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -395,7 +395,7 @@ func (v *vaultClient) buildClient() error {
 }
 
 // establishConnection is used to make first contact with Vault. This should be
-// called in a go-routine since the connection is retried til the Vault Client
+// called in a go-routine since the connection is retried until the Vault Client
 // is stopped or the connection is successfully made at which point the renew
 // loop is started.
 func (v *vaultClient) establishConnection() {
@@ -1000,7 +1000,7 @@ func (v *vaultClient) RevokeTokens(ctx context.Context, accessors []*structs.Vau
 			return nil
 		}
 
-		v.logger.Printf("[WARN] vault: failed to revoke tokens. Will reattempt til TTL: %v", err)
+		v.logger.Printf("[WARN] vault: failed to revoke tokens. Will reattempt until TTL: %v", err)
 		v.storeForRevocation(accessors)
 		return nil
 	} else if !committed {

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -136,7 +136,7 @@ when retrieving metrics using the above described signals.
   <tr>
     <td>`nomad.broker.total_blocked`</td>
     <td>
-        Evaluations that are blocked til an existing evaluation for the same job
+        Evaluations that are blocked until an existing evaluation for the same job
         completes
     </td>
     <td># of evaluations</td>


### PR DESCRIPTION
Should be "till" or "until"; chose "until" because it has no homophones.  Primarily impacts comments, but does hit docs and one error line