### PR TITLE
HCL to JSON api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.8.1 (Unreleased)
 
 IMPROVEMENTS:
+ * api: Add /v1/jobs/parse api endpoint for rendering HCL jobs files as JSON [[GH-2782](https://github.com/hashicorp/nomad/issues/2782)]
  * client: Create new process group on process startup. [[GH-3572](https://github.com/hashicorp/nomad/issues/3572)]
 
 ## 0.8.0 (April 12, 2018)

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -36,9 +36,22 @@ type Jobs struct {
 	client *Client
 }
 
+type JobsParseRequest struct {
+	JobHCL string
+}
+
 // Jobs returns a handle on the jobs endpoints.
 func (c *Client) Jobs() *Jobs {
 	return &Jobs{client: c}
+}
+
+// Parse is used to convert the HCL repesentation of a Job to JSON server side
+// To parse the HCL client side see package github.com/hashicorp/nomad/jobspec
+func (j *Jobs) Parse(jobHCL string) (*Job, error) {
+	var job *Job
+	req := &JobsParseRequest{JobHCL: jobHCL}
+	_, err := j.client.write("/v1/jobs/parse", req, job, nil)
+	return job, err
 }
 
 func (j *Jobs) Validate(job *Job, q *WriteOptions) (*JobValidateResponse, *WriteMeta, error) {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -36,8 +36,13 @@ type Jobs struct {
 	client *Client
 }
 
+// JobsParseRequest is used for arguments of the /vi/jobs/parse endpoint
 type JobsParseRequest struct {
+	//JobHCL is an hcl jobspec
 	JobHCL string
+	//Canonicalize is a flag as to if the server should return default values
+	//for unset fields
+	Canonicalize bool
 }
 
 // Jobs returns a handle on the jobs endpoints.

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -38,11 +38,11 @@ type Jobs struct {
 
 // JobsParseRequest is used for arguments of the /vi/jobs/parse endpoint
 type JobsParseRequest struct {
-	//JobHCL is an hcl jobspec
+	// JobHCL is an hcl jobspec
 	JobHCL string
 
-	//Canonicalize is a flag as to if the server should return default values
-	//for unset fields
+	// Canonicalize is a flag as to if the server should return default values
+	// for unset fields
 	Canonicalize bool
 }
 
@@ -53,7 +53,7 @@ func (c *Client) Jobs() *Jobs {
 
 // Parse is used to convert the HCL repesentation of a Job to JSON server side.
 // To parse the HCL client side see package github.com/hashicorp/nomad/jobspec
-func (j *Jobs) Parse(jobHCL string, canonicalize bool) (*Job, error) {
+func (j *Jobs) ParseHCL(jobHCL string, canonicalize bool) (*Job, error) {
 	var job Job
 	req := &JobsParseRequest{
 		JobHCL:       jobHCL,

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -40,6 +40,7 @@ type Jobs struct {
 type JobsParseRequest struct {
 	//JobHCL is an hcl jobspec
 	JobHCL string
+
 	//Canonicalize is a flag as to if the server should return default values
 	//for unset fields
 	Canonicalize bool
@@ -50,13 +51,16 @@ func (c *Client) Jobs() *Jobs {
 	return &Jobs{client: c}
 }
 
-// Parse is used to convert the HCL repesentation of a Job to JSON server side
+// Parse is used to convert the HCL repesentation of a Job to JSON server side.
 // To parse the HCL client side see package github.com/hashicorp/nomad/jobspec
-func (j *Jobs) Parse(jobHCL string) (*Job, error) {
-	var job *Job
-	req := &JobsParseRequest{JobHCL: jobHCL}
-	_, err := j.client.write("/v1/jobs/parse", req, job, nil)
-	return job, err
+func (j *Jobs) Parse(jobHCL string, canonicalize bool) (*Job, error) {
+	var job Job
+	req := &JobsParseRequest{
+		JobHCL:       jobHCL,
+		Canonicalize: canonicalize,
+	}
+	_, err := j.client.write("/v1/jobs/parse", req, &job, nil)
+	return &job, err
 }
 
 func (j *Jobs) Validate(job *Job, q *WriteOptions) (*JobValidateResponse, *WriteMeta, error) {

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -54,7 +54,7 @@ func TestJobs_Parse(t *testing.T) {
 
 	jobs := c.Jobs()
 
-	checkJob := func(job *Job, expected string) {
+	checkJob := func(job *Job, expectedRegion string) {
 		if job == nil {
 			t.Fatal("job should not be nil")
 		}
@@ -62,22 +62,22 @@ func TestJobs_Parse(t *testing.T) {
 		region := job.Region
 
 		if region == nil {
-			if expected != "" {
-				t.Fatalf("expected job region to be '%s' but was unset", expected)
+			if expectedRegion != "" {
+				t.Fatalf("expected job region to be '%s' but was unset", expectedRegion)
 			}
 		} else {
-			if expected != *region {
-				t.Fatalf("expected job region '%s', but got '%s'", expected, *region)
+			if expectedRegion != *region {
+				t.Fatalf("expected job region '%s', but got '%s'", expectedRegion, *region)
 			}
 		}
 	}
-	job, err := jobs.Parse(mock.HCL(), true)
+	job, err := jobs.ParseHCL(mock.HCL(), true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	checkJob(job, "global")
 
-	job, err = jobs.Parse(mock.HCL(), false)
+	job, err = jobs.ParseHCL(mock.HCL(), false)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -47,6 +47,43 @@ func TestJobs_Register(t *testing.T) {
 	}
 }
 
+func TestJobs_Parse(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+
+	jobs := c.Jobs()
+
+	checkJob := func(job *Job, expected string) {
+		if job == nil {
+			t.Fatal("job should not be nil")
+		}
+
+		region := job.Region
+
+		if region == nil {
+			if expected != "" {
+				t.Fatalf("expected job region to be '%s' but was unset", expected)
+			}
+		} else {
+			if expected != *region {
+				t.Fatalf("expected job region '%s', but got '%s'", expected, *region)
+			}
+		}
+	}
+	job, err := jobs.Parse(mock.HCL(), true)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	checkJob(job, "global")
+
+	job, err = jobs.Parse(mock.HCL(), false)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	checkJob(job, "")
+}
+
 func TestJobs_Validate(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t, nil, nil)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -143,6 +143,7 @@ func (s *HTTPServer) Shutdown() {
 // registerHandlers is used to attach our handlers to the mux
 func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/jobs", s.wrap(s.JobsRequest))
+	s.mux.HandleFunc("/v1/jobs/parse", s.wrap(s.JobsParseRequest))
 	s.mux.HandleFunc("/v1/job/", s.wrap(s.JobSpecificRequest))
 
 	s.mux.HandleFunc("/v1/nodes", s.wrap(s.NodesRequest))

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -565,6 +565,9 @@ func (s *HTTPServer) JobsParseRequest(resp http.ResponseWriter, req *http.Reques
 		return nil, CodedError(400, err.Error())
 	}
 
+	if args.Canonicalize {
+		jobStruct.Canonicalize()
+	}
 	return jobStruct, nil
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -298,9 +298,9 @@ func TestHTTP_JobsParse(t *testing.T) {
 		}
 
 		if job.Datacenters == nil ||
-			*job.Datacenters[0] != expected.Datacenters[0] {
+			job.Datacenters[0] != expected.Datacenters[0] {
 			t.Fatalf("job datacenters is '%s', expected '%s'",
-				*job.Datacenters[0], expected.Datacenters[0])
+				job.Datacenters[0], expected.Datacenters[0])
 		}
 	})
 }

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -276,7 +276,7 @@ func TestHTTP_JobsParse(t *testing.T) {
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {
 		buf := encodeReq(api.JobsParseRequest{JobHCL: mock.HCL()})
-		req, err := http.NewRequest("POST", "/v1/jobs/render", buf)
+		req, err := http.NewRequest("POST", "/v1/jobs/parse", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -63,6 +63,38 @@ func Node() *structs.Node {
 	return node
 }
 
+func HCL() string {
+	return `job "my-job" {
+	datacenters = ["dc1"]
+	type = "service"
+	constraint {
+		attribute = "${attr.kernel.name}"
+		value = "linux"
+	}
+
+	group "web" {
+		count = 10
+		restart {
+			attempts = 3
+			interval = "10m"
+			delay = "1m"
+			mode = "delay"
+		}
+		task "web" {
+			driver = "exec"
+			config {
+				command = "/bin/date"
+			}
+			resources {
+				cpu = 500
+				memory = 256
+			}
+		}
+	}
+}
+`
+}
+
 func Job() *structs.Job {
 	job := &structs.Job{
 		Region:      "global",

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -231,6 +231,75 @@ $ curl \
 }
 ```
 
+## Parse Job
+
+This endpoint will parse an hcl jobspec and produce the equivalent json encoded
+job.
+
+| Method | Path                      | Produces                   |
+| ------ | ------------------------- | -------------------------- |
+| `POST` | `/v1/jobs/parse`          | `application/json`         |
+
+### Parameters
+
+- `JobHCL` `(string: <required>)` - Specifies the HCL definition of the job
+  encoded in a JSON string.
+- `Canonicalize` `(bool: false)` - Flag to enable setting any unset fields to
+  their default values.
+
+## Sample Payload
+
+```json
+{
+    "JobHCL":"job \"example\" { type = \"service\" group \"cache\" {} }",
+    "Canonicalize": true
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request POST \
+    --data '{"Canonicalize": true, "JobHCL": "job \"my-job\" {}"}' \
+    https://localhost:4646/v1/jobs/parse
+```
+
+### Sample Response
+
+```json
+{
+    "AllAtOnce": false,
+    "Constraints": null,
+    "CreateIndex": 0,
+    "Datacenters": null,
+    "ID": "my-job",
+    "JobModifyIndex": 0,
+    "Meta": null,
+    "Migrate": null,
+    "ModifyIndex": 0,
+    "Name": "my-job",
+    "Namespace": "default",
+    "ParameterizedJob": null,
+    "ParentID": "",
+    "Payload": null,
+    "Periodic": null,
+    "Priority": 50,
+    "Region": "global",
+    "Reschedule": null,
+    "Stable": false,
+    "Status": "",
+    "StatusDescription": "",
+    "Stop": false,
+    "SubmitTime": null,
+    "TaskGroups": null,
+    "Type": "service",
+    "Update": null,
+    "VaultToken": "",
+    "Version": 0
+}
+```
+
 ## Read Job
 
 This endpoint reads information about a single job for its specification and

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -246,7 +246,7 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | ACL Required |
 | ---------------- | ------------ |
-| `NO`             | `NONE`       |
+| `NO`             | `none`       |
 
 ### Parameters
 

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -233,7 +233,7 @@ $ curl \
 
 ## Parse Job
 
-This endpoint will parse an hcl jobspec and produce the equivalent json encoded
+This endpoint will parse a HCL jobspec and produce the equivalent JSON encoded
 job.
 
 | Method | Path                      | Produces                   |

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -240,6 +240,14 @@ job.
 | ------ | ------------------------- | -------------------------- |
 | `POST` | `/v1/jobs/parse`          | `application/json`         |
 
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries) and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `NONE`       |
+
 ### Parameters
 
 - `JobHCL` `(string: <required>)` - Specifies the HCL definition of the job


### PR DESCRIPTION
The parse endpoint accepts a hcl jobspec body within a json object
and returns the parsed json object for the job. This allows users to
register jobs with the nomad json api without specifically needing
a nomad binary to parse their hcl encoded jobspec file.

Fixes #2782