### PR TITLE
B 2117 windows group process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 IMPROVEMENTS:
  * client: Create new process group on process startup. [[GH-3572](https://github.com/hashicorp/nomad/issues/3572)]
 
+BUG FIXES:
+ * driver/exec: Create process group for Windows process and send Ctrl-Break signal on Shutdown [[GH-2117](https://github.com/hashicorp/nomad/issues/2117)]
+
 ## 0.8.0 (April 12, 2018)
 
 __BACKWARDS INCOMPATIBILITIES:__

--- a/client/driver/executor/executor_windows.go
+++ b/client/driver/executor/executor_windows.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+// +build windows
 
 package executor
 
@@ -56,37 +56,56 @@ func (e *UniversalExecutor) setNewProcessGroup() error {
 	if e.cmd.SysProcAttr == nil {
 		e.cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
-	e.cmd.SysProcAttr.Setpgid = true
+	e.cmd.SysProcAttr.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP
 	return nil
 }
 
 // Cleanup any still hanging user processes
 func (e *UniversalExecutor) cleanupChildProcesses(proc *os.Process) error {
-	// If new process group was created upon command execution
-	// we can kill the whole process group now to cleanup any leftovers.
-	if e.cmd.SysProcAttr != nil && e.cmd.SysProcAttr.Setpgid {
-		if err := syscall.Kill(-proc.Pid, syscall.SIGKILL); err != nil && err.Error() != noSuchProcessErr {
-			return err
-		}
+	// We must first verify if the process is still running.
+	// (Windows process often lingered around after being reported as killed).
+	handle, err := syscall.OpenProcess(syscall.PROCESS_TERMINATE|syscall.SYNCHRONIZE|syscall.PROCESS_QUERY_INFORMATION, false, uint32(proc.Pid))
+	if err != nil {
+		return os.NewSyscallError("OpenProcess", err)
+	}
+	defer syscall.CloseHandle(handle)
+
+	result, err := syscall.WaitForSingleObject(syscall.Handle(handle), 0)
+
+	switch result {
+	case syscall.WAIT_OBJECT_0:
 		return nil
-	} else {
+	case syscall.WAIT_TIMEOUT:
+		// Process still running.  Just kill it.
 		return proc.Kill()
+	default:
+		return os.NewSyscallError("WaitForSingleObject", err)
 	}
 }
 
-func (e *UniversalExecutor) shutdownProcess(proc *os.Process) error {
-	// Set default kill signal, as some drivers don't support configurable
-	// signals (such as rkt)
-	var osSignal os.Signal
-	if e.command.TaskKillSignal != nil {
-		osSignal = e.command.TaskKillSignal
-	} else {
-		osSignal = os.Interrupt
+// Send a Ctrl-Break signal for shutting down the process,
+// like in https://golang.org/src/os/signal/signal_windows_test.go
+func sendCtrlBreak(pid int) error {
+	dll, err := syscall.LoadDLL("kernel32.dll")
+	if err != nil {
+		return fmt.Errorf("Error loading kernel32.dll: %v", err)
 	}
+	proc, err := dll.FindProc("GenerateConsoleCtrlEvent")
+	if err != nil {
+		return fmt.Errorf("Cannot find procedure GenerateConsoleCtrlEvent: %v", err)
+	}
+	result, _, err := proc.Call(syscall.CTRL_BREAK_EVENT, uintptr(pid))
+	if result == 0 {
+		return fmt.Errorf("Error sending ctrl-break event: %v", err)
+	}
+	return nil
+}
 
-	if err := proc.Signal(osSignal); err != nil && err.Error() != finishedErr {
+func (e *UniversalExecutor) shutdownProcess(proc *os.Process) error {
+	if err := sendCtrlBreak(proc.Pid); err != nil {
 		return fmt.Errorf("executor.shutdown error: %v", err)
 	}
+	e.logger.Printf("Sent Ctrl-Break to process %v", proc.Pid)
 
 	return nil
 }


### PR DESCRIPTION
This PR is a best attempt to fix #2117. Windows processes never cleanly map to Posix semantic so there is a couple of issues here:
- We currently supposed the process is a console process.  This will allow for the more common case of subprocess handling which are subprocesses launched from a shell script.
- Other signals like Ctrl-C, Ctrl-Close, Ctrl-Terminate aren't handled.  It would required additional config support and testing for correctly mapping them.  As a workaround, it is possible to handle such case by creating a launcher that handle the Ctrl-break and kill its children with the appropriate event.
- I do my best to limit the changes to what's necessary to make it run and build.  The Syslog handling function are however duplicate between the executor_unix.go and executor_windows.go files.  I'm not sure why those functions were in executor_unix.go initially (and why executor_unix.go has so many build targets), but may be they can go back in executor.go.

