### PR TITLE
Fix consul download url in Vagrant demo

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -17,7 +17,7 @@ cd /tmp/
 curl -sSL https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip -o nomad.zip
 
 echo "Fetching Consul..."
-curl -sSL https://releases.hashicorp.com/consul/1.0.0/consul_1.0.7_linux_amd64.zip > consul.zip
+curl -sSL https://releases.hashicorp.com/consul/1.0.7/consul_1.0.7_linux_amd64.zip > consul.zip
 
 echo "Installing Nomad..."
 unzip nomad.zip


### PR DESCRIPTION
This issue was introduced in 07cbe23b8c5bc23a4290a577909f1731de81dc7c

```
$ curl -I https://releases.hashicorp.com/consul/1.0.0/consul_1.0.7_linux_amd64.zip
curl: (22) The requested URL returned error: 403 Forbidden

$ curl -I https://releases.hashicorp.com/consul/1.0.7/consul_1.0.7_linux_amd64.zip
HTTP/1.1 200 OK
Cache-Control: max-age=31536000, stale-white-revalidate=86400,
stale-if-error=604800, public
Content-Disposition: attachment
Last-Modified: Fri, 13 Apr 2018 17:21:08 GMT
ETag: "c5ed9baed01b2b3e52a7ecb9850cecc6"
Content-Type: application/zip
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: sameorigin
Content-Length: 12317246
Accept-Ranges: bytes
Date: Mon, 16 Apr 2018 07:04:47 GMT
Connection: keep-alive
```