### PR TITLE
Improve CPU core detection in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -156,7 +156,7 @@ def suggestedCPUCores()
 	when /darwin/
 		Integer(`sysctl -n hw.ncpu`) / 2
 	when /linux/
-		Integer(`cat /proc/cpuinfo | grep processor | wc -l`) / 2
+		Integer(`grep -c ^processor /proc/cpuinfo`) / 2
 	else
 		2
 	end


### PR DESCRIPTION
Use single `grep` with `^` condition instead of `grep` + `cat` + `wc` (and 2 pipes)