### PR TITLE
Move Operating a Job from /docs/ to /guides/

### DIFF
--- a/website/redirects.txt
+++ b/website/redirects.txt
@@ -41,15 +41,15 @@
 
 # Docs
 /docs/agent/config.html                       /docs/agent/configuration/index.html
-/docs/jobops                                  /docs/operating-a-job/index.html
-/docs/jobops/                                 /docs/operating-a-job/index.html
-/docs/jobops/index.html                       /docs/operating-a-job/index.html
-/docs/jobops/taskconfig.html                  /docs/operating-a-job/configuring-tasks.html
-/docs/jobops/inspecting.html                  /docs/operating-a-job/inspecting-state.html
-/docs/jobops/resources.html                   /docs/operating-a-job/resource-utilization.html
+/docs/jobops                                  /guides/operating-a-job/index.html
+/docs/jobops/                                 /guides/operating-a-job/index.html
+/docs/jobops/index.html                       /guides/operating-a-job/index.html
+/docs/jobops/taskconfig.html                  /guides/operating-a-job/configuring-tasks.html
+/docs/jobops/inspecting.html                  /guides/operating-a-job/inspecting-state.html
+/docs/jobops/resources.html                   /guides/operating-a-job/resource-utilization.html
+/docs/jobops/logs.html                        /guides/operating-a-job/accessing-logs.html
+/docs/jobops/updating.html                    /guides/operating-a-job/update-strategies/index.html
 /docs/jobops/servicediscovery.html            /docs/service-discovery/index.html
-/docs/jobops/logs.html                        /docs/operating-a-job/accessing-logs.html
-/docs/jobops/updating.html                    /docs/operating-a-job/update-strategies/index.html
 /docs/jobspec                                 /docs/job-specification/index.html
 /docs/jobspec/                                /docs/job-specification/index.html
 /docs/jobspec/index.html                      /docs/job-specification/index.html
@@ -84,6 +84,30 @@
 /docs/commands/server-force-leave.html        /docs/commands/server/force-leave.html
 /docs/commands/server-join.html               /docs/commands/server/join.html
 /docs/commands/server-members.html            /docs/commands/server/members.html
+
+# Moved /docs/operating-a-job/ -> /guides/operating-a-job/
+/docs/operating-a-job                           /guides/operating-a-job/index.html
+/docs/operating-a-job/                          /guides/operating-a-job/index.html
+/docs/operating-a-job/index.html                /guides/operating-a-job/index.html
+/docs/operating-a-job/accessing-logs.html       /guides/operating-a-job/accessing-logs.html
+/docs/operating-a-job/inspecting-state.html     /guides/operating-a-job/inspecting-state.html
+/docs/operating-a-job/resource-utilization.html /guides/operating-a-job/resource-utilization.html
+/docs/operating-a-job/configuring-tasks.html    /guides/operating-a-job/configuring-tasks.html
+/docs/operating-a-job/submitting-jobs.html      /guides/operating-a-job/submitting-jobs.html
+
+/docs/operating-a-job/failure-handling-strategies                    /guides/operating-a-job/failure-handling-strategies/index.html
+/docs/operating-a-job/failure-handling-strategies/                   /guides/operating-a-job/failure-handling-strategies/index.html
+/docs/operating-a-job/failure-handling-strategies/index.html         /guides/operating-a-job/failure-handling-strategies/index.html
+/docs/operating-a-job/failure-handling-strategies/check-restart.html /guides/operating-a-job/failure-handling-strategies/check-restart.html
+/docs/operating-a-job/failure-handling-strategies/reschedule.html    /guides/operating-a-job/failure-handling-strategies/reschedule.html
+/docs/operating-a-job/failure-handling-strategies/restart.html       /guides/operating-a-job/failure-handling-strategies/restart.html
+
+/docs/operating-a-job/update-strategies                                        /guides/operating-a-job/update-strategies/index.html
+/docs/operating-a-job/update-strategies/                                       /guides/operating-a-job/update-strategies/index.html
+/docs/operating-a-job/update-strategies/index.html                             /guides/operating-a-job/update-strategies/index.html
+/docs/operating-a-job/update-strategies/blue-green-and-canary-deployments.html /guides/operating-a-job/update-strategies/blue-green-and-canary-deployments.html
+/docs/operating-a-job/update-strategies/handling-signals.html                  /guides/operating-a-job/update-strategies/handling-signals.html
+/docs/operating-a-job/update-strategies/rolling-upgrades.html                  /guides/operating-a-job/update-strategies/rolling-upgrades.html
 
 
 # API

--- a/website/source/guides/operating-a-job/accessing-logs.html.md
+++ b/website/source/guides/operating-a-job/accessing-logs.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Accessing Logs - Operating a Job"
-sidebar_current: "docs-operating-a-job-accessing-logs"
+sidebar_current: "guides-operating-a-job-accessing-logs"
 description: |-
   Nomad provides a top-level mechanism for viewing application logs and data
   files via the command line interface. This section discusses the nomad alloc
@@ -19,7 +19,7 @@ as simple as possible, Nomad provides:
 - API for programatic [log access](/api/client.html#stream-logs)
 
 This section will utilize the job named "docs" from the [previous
-sections](/docs/operating-a-job/submitting-jobs.html), but these operations
+sections](/guides/operating-a-job/submitting-jobs.html), but these operations
 and command largely apply to all jobs in Nomad.
 
 As a reminder, here is the output of the run command from the previous example:

--- a/website/source/guides/operating-a-job/configuring-tasks.html.md
+++ b/website/source/guides/operating-a-job/configuring-tasks.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Configuring Tasks - Operating a Job"
-sidebar_current: "docs-operating-a-job-configuring-tasks"
+sidebar_current: "guides-operating-a-job-configuring-tasks"
 description: |-
   Most applications require some kind of configuration. Whether the
   configuration is provided via the command line, environment variables, or a

--- a/website/source/guides/operating-a-job/failure-handling-strategies/check-restart.html.md
+++ b/website/source/guides/operating-a-job/failure-handling-strategies/check-restart.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Check Restart Stanza - Operating a Job"
-sidebar_current: "docs-operating-a-job-failure-handling-strategies-check-restart"
+sidebar_current: "guides-operating-a-job-failure-handling-strategies-check-restart"
 description: |-
   Nomad can restart tasks if they have a failing health check based on
   configuration specified in the `check_restart` stanza. Restarts are done locally on the node

--- a/website/source/guides/operating-a-job/failure-handling-strategies/index.html.md
+++ b/website/source/guides/operating-a-job/failure-handling-strategies/index.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Handling Failures - Operating a Job"
-sidebar_current: "docs-operating-a-job-failure-handling-strategies"
+sidebar_current: "guides-operating-a-job-failure-handling-strategies"
 description: |-
   This section describes features in Nomad that automate recovering from failed tasks.
 ---
@@ -20,6 +20,6 @@ Nomad provides configurable options to enable recovering failed tasks to avoid d
 try to restart a failed task on the node it is running on, and also try to reschedule it on another node.
 Please see one of the guides below or use the navigation on the left for details on each option:
 
-1. [Local Restarts](/docs/operating-a-job/failure-handling-strategies/restart.html)
-1. [Check Restarts](/docs/operating-a-job/failure-handling-strategies/check-restart.html)
-1. [Rescheduling](/docs/operating-a-job/failure-handling-strategies/reschedule.html)
+1. [Local Restarts](/guides/operating-a-job/failure-handling-strategies/restart.html)
+1. [Check Restarts](/guides/operating-a-job/failure-handling-strategies/check-restart.html)
+1. [Rescheduling](/guides/operating-a-job/failure-handling-strategies/reschedule.html)

--- a/website/source/guides/operating-a-job/failure-handling-strategies/reschedule.html.md
+++ b/website/source/guides/operating-a-job/failure-handling-strategies/reschedule.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Reschedule Stanza - Operating a Job"
-sidebar_current: "docs-operating-a-job-failure-handling-strategies-reschedule"
+sidebar_current: "guides-operating-a-job-failure-handling-strategies-reschedule"
 description: |-
   Nomad can reschedule failing tasks after any local restart attempts have been
   exhausted. This is useful to recover from failures stemming from problems in the node

--- a/website/source/guides/operating-a-job/failure-handling-strategies/restart.html.md
+++ b/website/source/guides/operating-a-job/failure-handling-strategies/restart.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Restart Stanza - Operating a Job"
-sidebar_current: "docs-operating-a-job-failure-handling-strategies-local-restarts"
+sidebar_current: "guides-operating-a-job-failure-handling-strategies-local-restarts"
 description: |-
   Nomad can restart a task on the node it is running on to recover from
   failures. Task restarts can be configured to be limited by number of attempts within

--- a/website/source/guides/operating-a-job/index.html.md
+++ b/website/source/guides/operating-a-job/index.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Operating a Job"
-sidebar_current: "docs-operating-a-job"
+sidebar_current: "guides-operating-a-job"
 description: |-
   Learn how to operate a Nomad Job.
 ---

--- a/website/source/guides/operating-a-job/inspecting-state.html.md
+++ b/website/source/guides/operating-a-job/inspecting-state.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Inspecting State - Operating a Job"
-sidebar_current: "docs-operating-a-job-inspecting-state"
+sidebar_current: "guides-operating-a-job-inspecting-state"
 description: |-
   Nomad exposes a number of tools and techniques for inspecting a running job.
   This is helpful in ensuring the job started successfully. Additionally, it
@@ -17,7 +17,7 @@ indicate the job is actually running. To verify the job is running, we need to
 inspect its state.
 
 This section will utilize the job named "docs" from the [previous
-sections](/docs/operating-a-job/submitting-jobs.html), but these operations
+sections](/guides/operating-a-job/submitting-jobs.html), but these operations
 and command largely apply to all jobs in Nomad.
 
 ## Job Status
@@ -198,7 +198,7 @@ Time                   Type        Description
 ```
 
 To debug these failures, we will need to utilize the "logs" command, which is
-discussed in the [accessing logs](/docs/operating-a-job/accessing-logs.html)
+discussed in the [accessing logs](/guides/operating-a-job/accessing-logs.html)
 section of this documentation.
 
 For more information on the `alloc status` command, please see the [CLI

--- a/website/source/guides/operating-a-job/resource-utilization.html.md
+++ b/website/source/guides/operating-a-job/resource-utilization.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Resource Utilization - Operating a Job"
-sidebar_current: "docs-operating-a-job-resource-utilization"
+sidebar_current: "guides-operating-a-job-resource-utilization"
 description: |-
   Nomad supports reporting detailed job statistics and resource utilization
   metrics for most task drivers. This section describes the ways to inspect a
@@ -16,7 +16,7 @@ interface for seeing resource utilization is the `alloc status` command with the
 `-stats` flag.
 
 This section will utilize the job named "docs" from the [previous
-sections](/docs/operating-a-job/submitting-jobs.html), but these operations
+sections](/guides/operating-a-job/submitting-jobs.html), but these operations
 and command largely apply to all jobs in Nomad.
 
 As a reminder, here is the output of the run command from the previous example:

--- a/website/source/guides/operating-a-job/submitting-jobs.html.md
+++ b/website/source/guides/operating-a-job/submitting-jobs.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Submitting Jobs - Operating a Job"
-sidebar_current: "docs-operating-a-job-submitting-jobs"
+sidebar_current: "guides-operating-a-job-submitting-jobs"
 description: |-
   The job file is the unit of work in Nomad. Upon authoring, the job file is
   submitted to the server for evaluation and scheduling. This section discusses
@@ -110,7 +110,7 @@ $ nomad job run docs.nomad
 
 Now that the job is scheduled, it may or may not be running. We need to inspect
 the allocation status and logs to make sure the job started correctly. The next
-section on [inspecting state](/docs/operating-a-job/inspecting-state.html)
+section on [inspecting state](/guides/operating-a-job/inspecting-state.html)
 details ways to examine this job's state.
 
 ## Updating the Job
@@ -169,4 +169,4 @@ nomad job run -check-index 131 docs.nomad
 
 For more details on advanced job updating strategies such as canary builds and
 build-green deployments, please see the documentation on [job update
-strategies](/docs/operating-a-job/update-strategies/index.html).
+strategies](/guides/operating-a-job/update-strategies/index.html).

--- a/website/source/guides/operating-a-job/update-strategies/blue-green-and-canary-deployments.html.md
+++ b/website/source/guides/operating-a-job/update-strategies/blue-green-and-canary-deployments.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Blue/Green & Canary Deployments - Operating a Job"
-sidebar_current: "docs-operating-a-job-updating-blue-green-deployments"
+sidebar_current: "guides-operating-a-job-updating-blue-green-deployments"
 description: |-
   Nomad has built-in support for doing blue/green and canary deployments to more
   safely update existing applications and services.
@@ -10,7 +10,7 @@ description: |-
 # Blue/Green &amp; Canary Deployments
 
 Sometimes [rolling
-upgrades](/docs/operating-a-job/update-strategies/rolling-upgrades.html) do not
+upgrades](/guides/operating-a-job/update-strategies/rolling-upgrades.html) do not
 offer the required flexibility for updating an application in production. Often
 organizations prefer to put a "canary" build into production or utilize a
 technique known as a "blue/green" deployment to ensure a safe application

--- a/website/source/guides/operating-a-job/update-strategies/handling-signals.html.md
+++ b/website/source/guides/operating-a-job/update-strategies/handling-signals.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Handling Signals - Operating a Job"
-sidebar_current: "docs-operating-a-job-updating-handling-signals"
+sidebar_current: "guides-operating-a-job-updating-handling-signals"
 description: |-
   Well-behaved applications expose a way to perform cleanup prior to exiting.
   Nomad can optionally send a configurable signal to applications before

--- a/website/source/guides/operating-a-job/update-strategies/index.html.md
+++ b/website/source/guides/operating-a-job/update-strategies/index.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Update Strategies - Operating a Job"
-sidebar_current: "docs-operating-a-job-updating"
+sidebar_current: "guides-operating-a-job-updating"
 description: |-
   This section describes common patterns for updating already-running jobs
   including rolling upgrades, blue/green deployments, and canary builds. Nomad
@@ -20,6 +20,6 @@ Nomad.
 
 Please see one of the guides below or use the navigation on the left:
 
-1. [Rolling Upgrades](/docs/operating-a-job/update-strategies/rolling-upgrades.html)
-1. [Blue/Green &amp; Canary Deployments](/docs/operating-a-job/update-strategies/blue-green-and-canary-deployments.html)
-1. [Handling Signals](/docs/operating-a-job/update-strategies/handling-signals.html)
+1. [Rolling Upgrades](/guides/operating-a-job/update-strategies/rolling-upgrades.html)
+1. [Blue/Green &amp; Canary Deployments](/guides/operating-a-job/update-strategies/blue-green-and-canary-deployments.html)
+1. [Handling Signals](/guides/operating-a-job/update-strategies/handling-signals.html)

--- a/website/source/guides/operating-a-job/update-strategies/rolling-upgrades.html.md
+++ b/website/source/guides/operating-a-job/update-strategies/rolling-upgrades.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "docs"
+layout: "guides"
 page_title: "Rolling Upgrades - Operating a Job"
-sidebar_current: "docs-operating-a-job-updating-rolling-upgrades"
+sidebar_current: "guides-operating-a-job-updating-rolling-upgrades"
 description: |-
   In order to update a service while reducing downtime, Nomad provides a
   built-in mechanism for rolling upgrades. Rolling upgrades incrementally

--- a/website/source/guides/spark/monitoring.html.md
+++ b/website/source/guides/spark/monitoring.html.md
@@ -127,9 +127,9 @@ $ spark-submit \
 
 Nomad clients collect the `stderr` and `stdout` of running tasks. The CLI or the
  HTTP API can be used to inspect logs, as documented in 
-[Accessing Logs](https://www.nomadproject.io/docs/operating-a-job/accessing-logs.html).
+[Accessing Logs](https://www.nomadproject.io/guides/operating-a-job/accessing-logs.html).
 In cluster mode, the `stderr` and `stdout` of the `driver` application can be 
-accessed in the same way. The [Log Shipper Pattern](https://www.nomadproject.io/docs/operating-a-job/accessing-logs.html#log-shipper-pattern) uses sidecar tasks to forward logs to a central location. This
+accessed in the same way. The [Log Shipper Pattern](https://www.nomadproject.io/guides/operating-a-job/accessing-logs.html#log-shipper-pattern) uses sidecar tasks to forward logs to a central location. This
 can be done using a job template as follows:
 
 ```hcl

--- a/website/source/intro/getting-started/next-steps.html.md
+++ b/website/source/intro/getting-started/next-steps.html.md
@@ -21,7 +21,7 @@ We recommend exploring the following resources as next steps.
   * [Creating a Cluster](/guides/cluster/bootstrapping.html) - Additional details on
     creating a production worthy Nomad Cluster.
 
-  * [Operating a Job](/docs/operating-a-job/index.html) - Additional details on how to
+  * [Operating a Job](/guides/operating-a-job/index.html) - Additional details on how to
     run a job in production.
 
   * [Example Terraform configuration](https://github.com/hashicorp/nomad/tree/master/terraform) - 

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -100,55 +100,6 @@
         <a href="/docs/vault-integration/index.html">Vault Integration</a>
       </li>
 
-      <li<%= sidebar_current("docs-operating-a-job") %>>
-        <a href="/docs/operating-a-job/index.html">Operating a Job</a>
-        <ul class="nav">
-          <li<%= sidebar_current("docs-operating-a-job-configuring-tasks") %>>
-            <a href="/docs/operating-a-job/configuring-tasks.html">Configuring Tasks</a>
-          </li>
-          <li<%= sidebar_current("docs-operating-a-job-submitting-jobs") %>>
-            <a href="/docs/operating-a-job/submitting-jobs.html">Submitting Jobs</a>
-          </li>
-          <li<%= sidebar_current("docs-operating-a-job-inspecting-state") %>>
-            <a href="/docs/operating-a-job/inspecting-state.html">Inspecting State</a>
-          </li>
-          <li<%= sidebar_current("docs-operating-a-job-accessing-logs") %>>
-            <a href="/docs/operating-a-job/accessing-logs.html">Accessing Logs</a>
-          </li>
-          <li<%= sidebar_current("docs-operating-a-job-resource-utilization") %>>
-            <a href="/docs/operating-a-job/resource-utilization.html">Resource Utilization</a>
-          </li>
-          <li<%= sidebar_current("docs-operating-a-job-updating") %>>
-            <a href="/docs/operating-a-job/update-strategies/index.html">Update Strategies</a>
-            <ul class="nav">
-              <li<%= sidebar_current("docs-operating-a-job-updating-rolling-upgrades") %>>
-                <a href="/docs/operating-a-job/update-strategies/rolling-upgrades.html">Rolling Upgrades</a>
-              </li>
-              <li<%= sidebar_current("docs-operating-a-job-updating-blue-green-deployments") %>>
-                <a href="/docs/operating-a-job/update-strategies/blue-green-and-canary-deployments.html">Blue/Green &amp; Canary</a>
-              </li>
-              <li<%= sidebar_current("docs-operating-a-job-updating-handling-signals") %>>
-                <a href="/docs/operating-a-job/update-strategies/handling-signals.html">Handling Signals</a>
-              </li>
-            </ul>
-          </li>
-           <li<%= sidebar_current("docs-operating-a-job-failure-handling-strategies") %>>
-                      <a href="/docs/operating-a-job/failure-handling-strategies/index.html">Failure Recovery Strategies</a>
-                      <ul class="nav">
-                        <li<%= sidebar_current("docs-operating-a-job-failure-handling-strategies-local-restarts") %>>
-                          <a href="/docs/operating-a-job/failure-handling-strategies/restart.html">Local Restarts</a>
-                        </li>
-                        <li<%= sidebar_current("docs-operating-a-job-failure-handling-strategies-check-restart") %>>
-                          <a href="/docs/operating-a-job/failure-handling-strategies/check-restart.html">Check Restarts</a>
-                        </li>
-                        <li<%= sidebar_current("docs-operating-a-job-failure-handling-strategies-reschedule") %>>
-                          <a href="/docs/operating-a-job/failure-handling-strategies/reschedule.html">Rescheduling</a>
-                        </li>
-                      </ul>
-                    </li>
-        </ul>
-      </li>
-
       <li<%= sidebar_current("docs-drivers") %>>
         <a href="/docs/drivers/index.html">Drivers</a>
         <ul class="nav">

--- a/website/source/layouts/guides.erb
+++ b/website/source/layouts/guides.erb
@@ -65,6 +65,55 @@
         <a href="/guides/namespaces.html">Namespaces</a>
       </li>
 
+      <li<%= sidebar_current("guides-operating-a-job") %>>
+        <a href="/guides/operating-a-job/index.html">Operating a Job</a>
+        <ul class="nav">
+          <li<%= sidebar_current("guides-operating-a-job-configuring-tasks") %>>
+            <a href="/guides/operating-a-job/configuring-tasks.html">Configuring Tasks</a>
+          </li>
+          <li<%= sidebar_current("guides-operating-a-job-submitting-jobs") %>>
+            <a href="/guides/operating-a-job/submitting-jobs.html">Submitting Jobs</a>
+          </li>
+          <li<%= sidebar_current("guides-operating-a-job-inspecting-state") %>>
+            <a href="/guides/operating-a-job/inspecting-state.html">Inspecting State</a>
+          </li>
+          <li<%= sidebar_current("guides-operating-a-job-accessing-logs") %>>
+            <a href="/guides/operating-a-job/accessing-logs.html">Accessing Logs</a>
+          </li>
+          <li<%= sidebar_current("guides-operating-a-job-resource-utilization") %>>
+            <a href="/guides/operating-a-job/resource-utilization.html">Resource Utilization</a>
+          </li>
+          <li<%= sidebar_current("guides-operating-a-job-updating") %>>
+            <a href="/guides/operating-a-job/update-strategies/index.html">Update Strategies</a>
+            <ul class="nav">
+              <li<%= sidebar_current("guides-operating-a-job-updating-rolling-upgrades") %>>
+                <a href="/guides/operating-a-job/update-strategies/rolling-upgrades.html">Rolling Upgrades</a>
+              </li>
+              <li<%= sidebar_current("guides-operating-a-job-updating-blue-green-deployments") %>>
+                <a href="/guides/operating-a-job/update-strategies/blue-green-and-canary-deployments.html">Blue/Green &amp; Canary</a>
+              </li>
+              <li<%= sidebar_current("guides-operating-a-job-updating-handling-signals") %>>
+                <a href="/guides/operating-a-job/update-strategies/handling-signals.html">Handling Signals</a>
+              </li>
+            </ul>
+          </li>
+           <li<%= sidebar_current("guides-operating-a-job-failure-handling-strategies") %>>
+                      <a href="/guides/operating-a-job/failure-handling-strategies/index.html">Failure Recovery Strategies</a>
+                      <ul class="nav">
+                        <li<%= sidebar_current("guides-operating-a-job-failure-handling-strategies-local-restarts") %>>
+                          <a href="/guides/operating-a-job/failure-handling-strategies/restart.html">Local Restarts</a>
+                        </li>
+                        <li<%= sidebar_current("guides-operating-a-job-failure-handling-strategies-check-restart") %>>
+                          <a href="/guides/operating-a-job/failure-handling-strategies/check-restart.html">Check Restarts</a>
+                        </li>
+                        <li<%= sidebar_current("guides-operating-a-job-failure-handling-strategies-reschedule") %>>
+                          <a href="/guides/operating-a-job/failure-handling-strategies/reschedule.html">Rescheduling</a>
+                        </li>
+                      </ul>
+                    </li>
+        </ul>
+      </li>
+
       <li<%= sidebar_current("guides-outage-recovery") %>>
         <a href="/guides/outage.html">Outage Recovery</a>
       </li>


### PR DESCRIPTION
Add redirects from /docs/ -> /guides/ and update old redirects to point
to the new location.