### PR TITLE
Increment Hadoop 2.7 version for Terraform environment

### DIFF
--- a/terraform/shared/scripts/setup.sh
+++ b/terraform/shared/scripts/setup.sh
@@ -24,7 +24,7 @@ NOMADDOWNLOAD=https://releases.hashicorp.com/nomad/${NOMADVERSION}/nomad_${NOMAD
 NOMADCONFIGDIR=/etc/nomad.d
 NOMADDIR=/opt/nomad
 
-HADOOP_VERSION=2.7.5
+HADOOP_VERSION=2.7.6
 
 # Dependencies
 sudo apt-get install -y software-properties-common


### PR DESCRIPTION
I was getting 404's on the 2.7.5 link after the release of 2.7.6