### PR TITLE
client/driver: docker progress detection and monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ IMPROVEMENTS:
  * command: Add -short option to init command that emits a minimal
    jobspec [[GH-4239](https://github.com/hashicorp/nomad/issues/4239)]
  * discovery: Support Consul gRPC health checks. [[GH-4251](https://github.com/hashicorp/nomad/issues/4251)]
+ * driver/docker: Add progress monitoring and inactivity detection to docker
+   image pulls [[GH-4192](https://github.com/hashicorp/nomad/issues/4192)] 
 
 ## 0.8.3 (April 27, 2018)
 

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -769,7 +769,6 @@ func (d *DockerDriver) getDockerCoordinator(client *docker.Client) (*dockerCoord
 		cleanup:     d.config.ReadBoolDefault(dockerCleanupImageConfigOption, dockerCleanupImageConfigDefault),
 		logger:      d.logger,
 		removeDelay: d.config.ReadDurationDefault(dockerImageRemoveDelayConfigOption, dockerImageRemoveDelayConfigDefault),
-		emitEvent:   d.emitEvent,
 	}
 
 	return GetDockerCoordinator(config), fmt.Sprintf("%s-%s", d.DriverContext.allocID, d.DriverContext.taskName)
@@ -1552,7 +1551,7 @@ func (d *DockerDriver) pullImage(driverConfig *DockerDriverConfig, client *docke
 	d.emitEvent("Downloading image %s:%s", repo, tag)
 	coordinator, callerID := d.getDockerCoordinator(client)
 
-	return coordinator.PullImage(driverConfig.ImageName, authOptions, time.Duration(driverConfig.ImagePullTimeout)*time.Second, callerID)
+	return coordinator.PullImage(driverConfig.ImageName, authOptions, time.Duration(driverConfig.ImagePullTimeout)*time.Second, callerID, d.emitEvent)
 }
 
 // authBackend encapsulates a function that resolves registry credentials.

--- a/client/driver/docker_coordinator_test.go
+++ b/client/driver/docker_coordinator_test.go
@@ -64,7 +64,7 @@ func TestDockerCoordinator_ConcurrentPulls(t *testing.T) {
 	id := ""
 	for i := 0; i < 10; i++ {
 		go func() {
-			id, _ = coordinator.PullImage(image, nil, 0, uuid.Generate())
+			id, _ = coordinator.PullImage(image, nil, 0, uuid.Generate(), nil)
 		}()
 	}
 
@@ -112,7 +112,7 @@ func TestDockerCoordinator_Pull_Remove(t *testing.T) {
 	callerIDs := make([]string, 10, 10)
 	for i := 0; i < 10; i++ {
 		callerIDs[i] = uuid.Generate()
-		id, _ = coordinator.PullImage(image, nil, 0, callerIDs[i])
+		id, _ = coordinator.PullImage(image, nil, 0, callerIDs[i], nil)
 	}
 
 	// Check the reference count
@@ -173,7 +173,7 @@ func TestDockerCoordinator_Remove_Cancel(t *testing.T) {
 	callerID := uuid.Generate()
 
 	// Pull image
-	id, _ := coordinator.PullImage(image, nil, 0, callerID)
+	id, _ := coordinator.PullImage(image, nil, 0, callerID, nil)
 
 	// Check the reference count
 	if references := coordinator.imageRefCount[id]; len(references) != 1 {
@@ -189,7 +189,7 @@ func TestDockerCoordinator_Remove_Cancel(t *testing.T) {
 	}
 
 	// Pull image again within delay
-	id, _ = coordinator.PullImage(image, nil, 0, callerID)
+	id, _ = coordinator.PullImage(image, nil, 0, callerID, nil)
 
 	// Check the reference count
 	if references := coordinator.imageRefCount[id]; len(references) != 1 {
@@ -221,7 +221,7 @@ func TestDockerCoordinator_No_Cleanup(t *testing.T) {
 	callerID := uuid.Generate()
 
 	// Pull image
-	id, _ := coordinator.PullImage(image, nil, 0, callerID)
+	id, _ := coordinator.PullImage(image, nil, 0, callerID, nil)
 
 	// Check the reference count
 	if references := coordinator.imageRefCount[id]; len(references) != 0 {

--- a/client/driver/docker_coordinator_test.go
+++ b/client/driver/docker_coordinator_test.go
@@ -64,7 +64,7 @@ func TestDockerCoordinator_ConcurrentPulls(t *testing.T) {
 	id := ""
 	for i := 0; i < 10; i++ {
 		go func() {
-			id, _ = coordinator.PullImage(image, nil, uuid.Generate())
+			id, _ = coordinator.PullImage(image, nil, 0, uuid.Generate())
 		}()
 	}
 
@@ -112,7 +112,7 @@ func TestDockerCoordinator_Pull_Remove(t *testing.T) {
 	callerIDs := make([]string, 10, 10)
 	for i := 0; i < 10; i++ {
 		callerIDs[i] = uuid.Generate()
-		id, _ = coordinator.PullImage(image, nil, callerIDs[i])
+		id, _ = coordinator.PullImage(image, nil, 0, callerIDs[i])
 	}
 
 	// Check the reference count
@@ -173,7 +173,7 @@ func TestDockerCoordinator_Remove_Cancel(t *testing.T) {
 	callerID := uuid.Generate()
 
 	// Pull image
-	id, _ := coordinator.PullImage(image, nil, callerID)
+	id, _ := coordinator.PullImage(image, nil, 0, callerID)
 
 	// Check the reference count
 	if references := coordinator.imageRefCount[id]; len(references) != 1 {
@@ -189,7 +189,7 @@ func TestDockerCoordinator_Remove_Cancel(t *testing.T) {
 	}
 
 	// Pull image again within delay
-	id, _ = coordinator.PullImage(image, nil, callerID)
+	id, _ = coordinator.PullImage(image, nil, 0, callerID)
 
 	// Check the reference count
 	if references := coordinator.imageRefCount[id]; len(references) != 1 {
@@ -221,7 +221,7 @@ func TestDockerCoordinator_No_Cleanup(t *testing.T) {
 	callerID := uuid.Generate()
 
 	// Pull image
-	id, _ := coordinator.PullImage(image, nil, callerID)
+	id, _ := coordinator.PullImage(image, nil, 0, callerID)
 
 	// Check the reference count
 	if references := coordinator.imageRefCount[id]; len(references) != 0 {

--- a/client/driver/docker_coordinator_test.go
+++ b/client/driver/docker_coordinator_test.go
@@ -64,7 +64,7 @@ func TestDockerCoordinator_ConcurrentPulls(t *testing.T) {
 	id := ""
 	for i := 0; i < 10; i++ {
 		go func() {
-			id, _ = coordinator.PullImage(image, nil, 0, uuid.Generate(), nil)
+			id, _ = coordinator.PullImage(image, nil, uuid.Generate(), nil)
 		}()
 	}
 
@@ -112,7 +112,7 @@ func TestDockerCoordinator_Pull_Remove(t *testing.T) {
 	callerIDs := make([]string, 10, 10)
 	for i := 0; i < 10; i++ {
 		callerIDs[i] = uuid.Generate()
-		id, _ = coordinator.PullImage(image, nil, 0, callerIDs[i], nil)
+		id, _ = coordinator.PullImage(image, nil, callerIDs[i], nil)
 	}
 
 	// Check the reference count
@@ -173,7 +173,7 @@ func TestDockerCoordinator_Remove_Cancel(t *testing.T) {
 	callerID := uuid.Generate()
 
 	// Pull image
-	id, _ := coordinator.PullImage(image, nil, 0, callerID, nil)
+	id, _ := coordinator.PullImage(image, nil, callerID, nil)
 
 	// Check the reference count
 	if references := coordinator.imageRefCount[id]; len(references) != 1 {
@@ -189,7 +189,7 @@ func TestDockerCoordinator_Remove_Cancel(t *testing.T) {
 	}
 
 	// Pull image again within delay
-	id, _ = coordinator.PullImage(image, nil, 0, callerID, nil)
+	id, _ = coordinator.PullImage(image, nil, callerID, nil)
 
 	// Check the reference count
 	if references := coordinator.imageRefCount[id]; len(references) != 1 {
@@ -221,7 +221,7 @@ func TestDockerCoordinator_No_Cleanup(t *testing.T) {
 	callerID := uuid.Generate()
 
 	// Pull image
-	id, _ := coordinator.PullImage(image, nil, 0, callerID, nil)
+	id, _ := coordinator.PullImage(image, nil, callerID, nil)
 
 	// Check the reference count
 	if references := coordinator.imageRefCount[id]; len(references) != 0 {

--- a/client/driver/docker_progress.go
+++ b/client/driver/docker_progress.go
@@ -1,0 +1,259 @@
+package driver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+	units "github.com/docker/go-units"
+)
+
+const (
+	// defaultPullActivityDeadline is the default value set in the imageProgressManager
+	// when newImageProgressManager is called
+	defaultPullActivityDeadline = 2 * time.Minute
+
+	// defaultImageProgressReportInterval is the default value set in the
+	// imageProgressManager when newImageProgressManager is called
+	defaultImageProgressReportInterval = 10 * time.Second
+)
+
+// layerProgress tracks the state and downloaded bytes of a single layer within
+// a docker image
+type layerProgress struct {
+	id           string
+	status       layerProgressStatus
+	currentBytes int64
+	totalBytes   int64
+}
+
+type layerProgressStatus int
+
+const (
+	layerProgressStatusUnknown layerProgressStatus = iota
+	layerProgressStatusStarting
+	layerProgressStatusWaiting
+	layerProgressStatusDownloading
+	layerProgressStatusVerifying
+	layerProgressStatusDownloaded
+	layerProgressStatusExtracting
+	layerProgressStatusComplete
+	layerProgressStatusExists
+)
+
+func lpsFromString(status string) layerProgressStatus {
+	switch status {
+	case "Pulling fs layer":
+		return layerProgressStatusStarting
+	case "Waiting":
+		return layerProgressStatusWaiting
+	case "Downloading":
+		return layerProgressStatusDownloading
+	case "Verifying Checksum":
+		return layerProgressStatusVerifying
+	case "Download complete":
+		return layerProgressStatusDownloaded
+	case "Extracting":
+		return layerProgressStatusExtracting
+	case "Pull complete":
+		return layerProgressStatusComplete
+	case "Already exists":
+		return layerProgressStatusExists
+	default:
+		return layerProgressStatusUnknown
+	}
+}
+
+// imageProgress tracks the status of each child layer as its pulled from a
+// docker image repo
+type imageProgress struct {
+	sync.RWMutex
+	lastMessage *jsonmessage.JSONMessage
+	timestamp   time.Time
+	layers      map[string]*layerProgress
+	pullStart   time.Time
+}
+
+// get returns a status message and the timestamp of the last status update
+func (p *imageProgress) get() (string, time.Time) {
+	p.RLock()
+	defer p.RUnlock()
+
+	if p.lastMessage == nil {
+		return "No progress", p.timestamp
+	}
+
+	var pulled, pulling int
+	for _, l := range p.layers {
+		if l.status == layerProgressStatusDownloading {
+			pulling++
+		} else if l.status > layerProgressStatusVerifying {
+			pulled++
+		}
+	}
+
+	elapsed := time.Now().Sub(p.pullStart)
+	cur := p.currentBytes()
+	total := p.totalBytes()
+	var est int64
+	if cur != 0 {
+		est = (elapsed.Nanoseconds() / cur * total) - elapsed.Nanoseconds()
+	}
+
+	return fmt.Sprintf("Pulled %d/%d (%s/%s) pulling %d layers - est %.1fs remaining",
+		pulled, len(p.layers), units.BytesSize(float64(cur)), units.BytesSize(float64(total)), pulling,
+		time.Duration(est).Seconds()), p.timestamp
+}
+
+// set takes a status message received from the docker engine api during an image
+// pull and updates the status of the coorisponding layer
+func (p *imageProgress) set(msg *jsonmessage.JSONMessage) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.lastMessage = msg
+	p.timestamp = time.Now()
+
+	lps := lpsFromString(msg.Status)
+	if lps == layerProgressStatusUnknown {
+		return
+	}
+
+	layer, ok := p.layers[msg.ID]
+	if !ok {
+		layer = &layerProgress{id: msg.ID}
+		p.layers[msg.ID] = layer
+	}
+	layer.status = lps
+	if msg.Progress != nil && lps == layerProgressStatusDownloading {
+		layer.currentBytes = msg.Progress.Current
+		layer.totalBytes = msg.Progress.Total
+	} else if lps == layerProgressStatusDownloaded {
+		layer.currentBytes = layer.totalBytes
+	}
+}
+
+// currentBytes iterates through all image layers and sums the total of
+// current bytes. The caller is responsible for acquiring a read lock on the
+// imageProgress struct
+func (p *imageProgress) currentBytes() int64 {
+	var b int64
+	for _, l := range p.layers {
+		b += l.currentBytes
+	}
+	return b
+}
+
+// totalBytes iterates through all image layers and sums the total of
+// total bytes. The caller is responsible for acquiring a read lock on the
+// imageProgress struct
+func (p *imageProgress) totalBytes() int64 {
+	var b int64
+	for _, l := range p.layers {
+		b += l.totalBytes
+	}
+	return b
+}
+
+// progressReporterFunc defines the method for handeling inactivity and report
+// events from the imageProgressManager. The image name, current status message,
+// timestamp of last received status update and timestamp of when the pull started
+// are passed in.
+type progressReporterFunc func(image string, msg string, timestamp time.Time, pullStart time.Time)
+
+// imageProgressManager tracks the progress of pulling a docker image from an
+// image repository.
+// It also implemented the io.Writer interface so as to be passed to the docker
+// client pull image method in order to receive status updates from the docker
+// engine api.
+type imageProgressManager struct {
+	imageProgress    *imageProgress
+	image            string
+	activityDeadline time.Duration
+	inactivityFunc   progressReporterFunc
+	reportInterval   time.Duration
+	reporter         progressReporterFunc
+	cancel           context.CancelFunc
+	stopCh           chan struct{}
+	buf              bytes.Buffer
+}
+
+func newImageProgressManager(
+	image string, cancel context.CancelFunc,
+	inactivityFunc, reporter progressReporterFunc) *imageProgressManager {
+
+	return &imageProgressManager{
+		image:            image,
+		activityDeadline: defaultPullActivityDeadline,
+		inactivityFunc:   inactivityFunc,
+		reportInterval:   defaultImageProgressReportInterval,
+		reporter:         reporter,
+		imageProgress: &imageProgress{
+			timestamp: time.Now(),
+			layers:    make(map[string]*layerProgress),
+		},
+		cancel: cancel,
+		stopCh: make(chan struct{}),
+	}
+}
+
+// start intiates the ticker to trigger the inactivity and reporter handlers
+func (pm *imageProgressManager) start() {
+	pm.imageProgress.pullStart = time.Now()
+	go func() {
+		ticker := time.NewTicker(defaultImageProgressReportInterval)
+		for {
+			select {
+			case <-ticker.C:
+				msg, timestamp := pm.imageProgress.get()
+				if time.Now().Sub(timestamp) > pm.activityDeadline {
+					pm.inactivityFunc(pm.image, msg, timestamp, pm.imageProgress.pullStart)
+					pm.cancel()
+					return
+				}
+				pm.reporter(pm.image, msg, timestamp, pm.imageProgress.pullStart)
+			case <-pm.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+func (pm *imageProgressManager) stop() {
+	close(pm.stopCh)
+}
+
+func (pm *imageProgressManager) Write(p []byte) (n int, err error) {
+	n, err = pm.buf.Write(p)
+	var msg jsonmessage.JSONMessage
+
+	for {
+		line, err := pm.buf.ReadBytes('\n')
+		if err == io.EOF {
+			// Partial write of line; push back onto buffer and break until full line
+			pm.buf.Write(line)
+			break
+		}
+		if err != nil {
+			return n, err
+		}
+		err = json.Unmarshal(line, &msg)
+		if err != nil {
+			return n, err
+		}
+
+		if msg.Error != nil {
+			// error received from the docker engine api
+			return n, msg.Error
+		}
+
+		pm.imageProgress.set(&msg)
+	}
+
+	return
+}

--- a/client/driver/docker_progress.go
+++ b/client/driver/docker_progress.go
@@ -21,6 +21,10 @@ const (
 	// dockerImageProgressReportInterval is the default value set in the
 	// imageProgressManager when newImageProgressManager is called
 	dockerImageProgressReportInterval = 10 * time.Second
+
+	// dockerImageSlowProgressReportInterval is the default value set in the
+	// imageProgressManager when newImageProgressManager is called
+	dockerImageSlowProgressReportInterval = 2 * time.Minute
 )
 
 // layerProgress tracks the state and downloaded bytes of a single layer within
@@ -88,11 +92,16 @@ func (p *imageProgress) get() (string, time.Time) {
 		return "No progress", p.timestamp
 	}
 
-	var pulled, pulling int
+	var pulled, pulling, waiting int
 	for _, l := range p.layers {
-		if l.status == layerProgressStatusDownloading {
+		switch {
+		case l.status == layerProgressStatusStarting ||
+			l.status == layerProgressStatusWaiting:
+			waiting++
+		case l.status == layerProgressStatusDownloading ||
+			l.status == layerProgressStatusVerifying:
 			pulling++
-		} else if l.status > layerProgressStatusVerifying {
+		case l.status >= layerProgressStatusDownloaded:
 			pulled++
 		}
 	}
@@ -105,9 +114,9 @@ func (p *imageProgress) get() (string, time.Time) {
 		est = (elapsed.Nanoseconds() / cur * total) - elapsed.Nanoseconds()
 	}
 
-	return fmt.Sprintf("Pulled %d/%d (%s/%s) pulling %d layers - est %.1fs remaining",
-		pulled, len(p.layers), units.BytesSize(float64(cur)), units.BytesSize(float64(total)), pulling,
-		time.Duration(est).Seconds()), p.timestamp
+	return fmt.Sprintf("Pulled %d/%d (%s/%s) layers: %d waiting/%d pulling - est %.1fs remaining",
+		pulled, len(p.layers), units.BytesSize(float64(cur)), units.BytesSize(float64(total)),
+		waiting, pulling, time.Duration(est).Seconds()), p.timestamp
 }
 
 // set takes a status message received from the docker engine api during an image
@@ -160,7 +169,7 @@ func (p *imageProgress) totalBytes() int64 {
 	return b
 }
 
-// progressReporterFunc defines the method for handeling inactivity and report
+// progressReporterFunc defines the method for handling inactivity and report
 // events from the imageProgressManager. The image name, current status message
 // and timestamp of last received status update are passed in.
 type progressReporterFunc func(image string, msg string, timestamp time.Time)
@@ -190,12 +199,13 @@ func newImageProgressManager(
 	inactivityFunc, reporter, slowReporter progressReporterFunc) *imageProgressManager {
 
 	pm := &imageProgressManager{
-		image:            image,
-		activityDeadline: dockerPullActivityDeadline,
-		inactivityFunc:   inactivityFunc,
-		reportInterval:   dockerImageProgressReportInterval,
-		reporter:         reporter,
-		slowReporter:     slowReporter,
+		image:              image,
+		activityDeadline:   dockerPullActivityDeadline,
+		inactivityFunc:     inactivityFunc,
+		reportInterval:     dockerImageProgressReportInterval,
+		reporter:           reporter,
+		slowReportInterval: dockerImageSlowProgressReportInterval,
+		slowReporter:       slowReporter,
 		imageProgress: &imageProgress{
 			timestamp: time.Now(),
 			layers:    make(map[string]*layerProgress),

--- a/client/driver/docker_progress_test.go
+++ b/client/driver/docker_progress_test.go
@@ -1,0 +1,52 @@
+package driver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_DockerImageProgressManager(t *testing.T) {
+
+	pm := &imageProgressManager{
+		imageProgress: &imageProgress{
+			timestamp: time.Now(),
+			layers:    make(map[string]*layerProgress),
+		},
+	}
+
+	_, err := pm.Write([]byte(`{"status":"Pulling from library/golang","id":"1.9.5"}
+{"status":"Pulling fs layer","progressDetail":{},"id":"c73ab1c6897b"}
+{"status":"Pulling fs layer","progressDetail":{},"id":"1ab373b3deae"}
+`))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(pm.imageProgress.layers), "number of layers should be 2")
+
+	cur := pm.imageProgress.currentBytes()
+	require.Zero(t, cur)
+	tot := pm.imageProgress.totalBytes()
+	require.Zero(t, tot)
+
+	_, err = pm.Write([]byte(`{"status":"Pulling fs layer","progress`))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(pm.imageProgress.layers), "number of layers should be 2")
+
+	_, err = pm.Write([]byte(`Detail":{},"id":"b542772b4177"}` + "\n"))
+	require.NoError(t, err)
+	require.Equal(t, 3, len(pm.imageProgress.layers), "number of layers should be 3")
+
+	_, err = pm.Write([]byte(`{"status":"Downloading","progressDetail":{"current":45800,"total":4335495},"progress":"[\u003e                                                  ]   45.8kB/4.335MB","id":"b542772b4177"}
+{"status":"Downloading","progressDetail":{"current":113576,"total":11108010},"progress":"[\u003e                                                  ]  113.6kB/11.11MB","id":"1ab373b3deae"}
+{"status":"Downloading","progressDetail":{"current":694257,"total":4335495},"progress":"[========\u003e                                          ]  694.3kB/4.335MB","id":"b542772b4177"}` + "\n"))
+	require.NoError(t, err)
+	require.Equal(t, 3, len(pm.imageProgress.layers), "number of layers should be 3")
+	require.Equal(t, int64(807833), pm.imageProgress.currentBytes())
+	require.Equal(t, int64(15443505), pm.imageProgress.totalBytes())
+
+	_, err = pm.Write([]byte(`{"status":"Download complete","progressDetail":{},"id":"b542772b4177"}` + "\n"))
+	require.NoError(t, err)
+	require.Equal(t, 3, len(pm.imageProgress.layers), "number of layers should be 3")
+	require.Equal(t, int64(4449071), pm.imageProgress.currentBytes())
+	require.Equal(t, int64(15443505), pm.imageProgress.totalBytes())
+}


### PR DESCRIPTION
This PR aims to add the following enhancements to the docker driver:

* Inactivity timeout which aborts a pull of no progress has been made during a defined period of time
* ~Pull timeout, configured in the jobspec as `image_pull_timeout` which will abort the pull if it does not complete in the configured duration~ *Removed from this PR see b6d2b75*
* Image pull progress logging to client stdout
  * Multiplexed to all allocs pulling the same image. 
* Image pull progress logged to alloc if the pull lasts longer than 2 mins (and subsequent msgs ever 2 mins there after)


Example log:
```
2018/04/24 12:47:12.076066 [DEBUG] driver.docker: image docker.elastic.co/elasticsearch/elasticsearch:6.2.4 pull progress: Pulled 1/6 (106.7 MiB/227.3 MiB) pulling 3 layers - est 11.2s remaining
2018/04/24 12:47:22.076012 [DEBUG] driver.docker: image docker.elastic.co/elasticsearch/elasticsearch:6.2.4 pull progress: Pulled 5/6 (191.4 MiB/227.3 MiB) pulling 1 layers - est 3.6s remaining
2018/04/24 12:47:32.076002 [DEBUG] driver.docker: image docker.elastic.co/elasticsearch/elasticsearch:6.2.4 pull progress: Pulled 6/6 (227.3 MiB/227.3 MiB) pulling 0 layers - est 0.1s remaining
2018/04/24 12:47:33.394116 [DEBUG] driver.docker: docker pull docker.elastic.co/elasticsearch/elasticsearch:6.2.4 succeeded
```