### PR TITLE
DriverContext: Add the TaskGroup and the Job name

### DIFF
--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -225,7 +225,7 @@ func TestDockerDriver_Fingerprint_Bridge(t *testing.T) {
 
 	conf := testConfig(t)
 	conf.Node = mock.Node()
-	dd := NewDockerDriver(NewDriverContext("", "", conf, conf.Node, testLogger(), nil))
+	dd := NewDockerDriver(NewDriverContext("", "", "", "", conf, conf.Node, testLogger(), nil))
 
 	request := &cstructs.FingerprintRequest{Config: conf, Node: conf.Node}
 	var response cstructs.FingerprintResponse
@@ -277,7 +277,7 @@ func TestDockerDriver_Check_DockerHealthStatus(t *testing.T) {
 
 	conf := testConfig(t)
 	conf.Node = mock.Node()
-	dd := NewDockerDriver(NewDriverContext("", "", conf, conf.Node, testLogger(), nil))
+	dd := NewDockerDriver(NewDriverContext("", "", "", "", conf, conf.Node, testLogger(), nil))
 
 	request := &cstructs.HealthCheckRequest{}
 	var response cstructs.HealthCheckResponse
@@ -1667,7 +1667,7 @@ func setupDockerVolumes(t *testing.T, cfg *config.Config, hostpath string) (*str
 	emitter := func(m string, args ...interface{}) {
 		logger.Printf("[EVENT] "+m, args...)
 	}
-	driverCtx := NewDriverContext(task.Name, alloc.ID, cfg, cfg.Node, testLogger(), emitter)
+	driverCtx := NewDriverContext(alloc.Job.Name, alloc.TaskGroup, task.Name, alloc.ID, cfg, cfg.Node, testLogger(), emitter)
 	driver := NewDockerDriver(driverCtx)
 
 	// Setup execCtx

--- a/client/driver/driver.go
+++ b/client/driver/driver.go
@@ -259,11 +259,13 @@ type LogEventFn func(message string, args ...interface{})
 // node attributes into a Driver without having to change the Driver interface
 // each time we do it. Used in conjunction with Factory, above.
 type DriverContext struct {
-	taskName string
-	allocID  string
-	config   *config.Config
-	logger   *log.Logger
-	node     *structs.Node
+	jobName       string
+	taskGroupName string
+	taskName      string
+	allocID       string
+	config        *config.Config
+	logger        *log.Logger
+	node          *structs.Node
 
 	emitEvent LogEventFn
 }
@@ -278,15 +280,18 @@ func NewEmptyDriverContext() *DriverContext {
 // This enables other packages to create DriverContexts but keeps the fields
 // private to the driver. If we want to change this later we can gorename all of
 // the fields in DriverContext.
-func NewDriverContext(taskName, allocID string, config *config.Config, node *structs.Node,
+func NewDriverContext(jobName, taskGroupName, taskName, allocID string,
+	config *config.Config, node *structs.Node,
 	logger *log.Logger, eventEmitter LogEventFn) *DriverContext {
 	return &DriverContext{
-		taskName:  taskName,
-		allocID:   allocID,
-		config:    config,
-		node:      node,
-		logger:    logger,
-		emitEvent: eventEmitter,
+		jobName:       jobName,
+		taskGroupName: taskGroupName,
+		taskName:      taskName,
+		allocID:       allocID,
+		config:        config,
+		node:          node,
+		logger:        logger,
+		emitEvent:     eventEmitter,
 	}
 }
 

--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -145,7 +145,7 @@ func testDriverContexts(t *testing.T, task *structs.Task) *testContext {
 	emitter := func(m string, args ...interface{}) {
 		logger.Printf("[EVENT] "+m, args...)
 	}
-	driverCtx := NewDriverContext(task.Name, alloc.ID, cfg, cfg.Node, logger, emitter)
+	driverCtx := NewDriverContext(alloc.Job.Name, alloc.TaskGroup, task.Name, alloc.ID, cfg, cfg.Node, logger, emitter)
 
 	return &testContext{allocDir, driverCtx, execCtx, eb}
 }

--- a/client/fingerprint_manager.go
+++ b/client/fingerprint_manager.go
@@ -173,7 +173,7 @@ func (fm *FingerprintManager) setupFingerprinters(fingerprints []string) error {
 // supported
 func (fm *FingerprintManager) setupDrivers(drivers []string) error {
 	var availDrivers []string
-	driverCtx := driver.NewDriverContext("", "", fm.getConfig(), fm.getNode(), fm.logger, nil)
+	driverCtx := driver.NewDriverContext("", "", "", "", fm.getConfig(), fm.getNode(), fm.logger, nil)
 	for _, name := range drivers {
 
 		d, err := driver.NewDriver(name, driverCtx)

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -563,7 +563,7 @@ func (r *TaskRunner) createDriver() (driver.Driver, error) {
 		r.setState(structs.TaskStatePending, structs.NewTaskEvent(structs.TaskDriverMessage).SetDriverMessage(msg), false)
 	}
 
-	driverCtx := driver.NewDriverContext(r.task.Name, r.alloc.ID, r.config, r.config.Node, r.logger, eventEmitter)
+	driverCtx := driver.NewDriverContext(r.alloc.Job.Name, r.alloc.TaskGroup, r.task.Name, r.alloc.ID, r.config, r.config.Node, r.logger, eventEmitter)
 	d, err := driver.NewDriver(r.task.Driver, driverCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create driver '%s' for alloc %s: %v",


### PR DESCRIPTION
Adding this fields to the DriverContext object, will allow us to pass
them to the drivers.

An use case for this, will be to emit tagged metrics in the drivers,
which contain all relevant information:
- Job
- TaskGroup
- Task
- ...

For more context, see the following discussion: https://github.com/hashicorp/nomad/pull/4185#discussion_r182974636