### PR TITLE
Support canary tags for services in Consul

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -1,17 +1,14 @@
 package client
 
 import (
-	"github.com/hashicorp/nomad/client/driver"
-	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/command/agent/consul"
-	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // ConsulServiceAPI is the interface the Nomad Client uses to register and
 // remove services and checks from Consul.
 type ConsulServiceAPI interface {
-	RegisterTask(allocID string, task *structs.Task, restarter consul.TaskRestarter, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error
-	RemoveTask(allocID string, task *structs.Task)
-	UpdateTask(allocID string, existing, newTask *structs.Task, restart consul.TaskRestarter, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error
+	RegisterTask(*consul.TaskServices) error
+	RemoveTask(*consul.TaskServices)
+	UpdateTask(old, newTask *consul.TaskServices) error
 	AllocRegistrations(allocID string) (*consul.AllocRegistration, error)
 }

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/nomad/client/driver"
 	"github.com/hashicorp/nomad/client/getter"
 	"github.com/hashicorp/nomad/client/vaultclient"
+	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/ugorji/go/codec"
 
@@ -1219,7 +1220,8 @@ func (r *TaskRunner) run() {
 				// Remove from consul before killing the task so that traffic
 				// can be rerouted
 				interpTask := interpolateServices(r.envBuilder.Build(), r.task)
-				r.consul.RemoveTask(r.alloc.ID, interpTask)
+				taskServices := consul.NewTaskServices(r.alloc, interpTask, r, nil, nil)
+				r.consul.RemoveTask(taskServices)
 
 				// Delay actually killing the task if configured. See #244
 				if r.task.ShutdownDelay > 0 {
@@ -1275,7 +1277,8 @@ func (r *TaskRunner) run() {
 func (r *TaskRunner) cleanup() {
 	// Remove from Consul
 	interpTask := interpolateServices(r.envBuilder.Build(), r.task)
-	r.consul.RemoveTask(r.alloc.ID, interpTask)
+	taskServices := consul.NewTaskServices(r.alloc, interpTask, r, nil, nil)
+	r.consul.RemoveTask(taskServices)
 
 	drv, err := r.createDriver()
 	if err != nil {
@@ -1339,7 +1342,8 @@ func (r *TaskRunner) shouldRestart() bool {
 
 	// Unregister from Consul while waiting to restart.
 	interpTask := interpolateServices(r.envBuilder.Build(), r.task)
-	r.consul.RemoveTask(r.alloc.ID, interpTask)
+	taskServices := consul.NewTaskServices(r.alloc, interpTask, r, nil, nil)
+	r.consul.RemoveTask(taskServices)
 
 	// Sleep but watch for destroy events.
 	select {
@@ -1498,7 +1502,8 @@ func (r *TaskRunner) registerServices(d driver.Driver, h driver.DriverHandle, n 
 		exec = h
 	}
 	interpolatedTask := interpolateServices(r.envBuilder.Build(), r.task)
-	return r.consul.RegisterTask(r.alloc.ID, interpolatedTask, r, exec, n)
+	taskServices := consul.NewTaskServices(r.alloc, interpolatedTask, r, exec, n)
+	return r.consul.RegisterTask(taskServices)
 }
 
 // interpolateServices interpolates tags in a service and checks with values from the
@@ -1679,7 +1684,7 @@ func (r *TaskRunner) handleUpdate(update *structs.Allocation) error {
 
 		// Update services in Consul
 		newInterpolatedTask := interpolateServices(r.envBuilder.Build(), updatedTask)
-		if err := r.updateServices(drv, r.handle, oldInterpolatedTask, newInterpolatedTask); err != nil {
+		if err := r.updateServices(drv, r.handle, r.alloc, oldInterpolatedTask, update, newInterpolatedTask); err != nil {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("error updating services and checks in Consul: %v", err))
 		}
 	}
@@ -1697,7 +1702,10 @@ func (r *TaskRunner) handleUpdate(update *structs.Allocation) error {
 }
 
 // updateServices and checks with Consul. Tasks must be interpolated!
-func (r *TaskRunner) updateServices(d driver.Driver, h driver.ScriptExecutor, oldTask, newTask *structs.Task) error {
+func (r *TaskRunner) updateServices(d driver.Driver, h driver.ScriptExecutor,
+	oldAlloc *structs.Allocation, oldTask *structs.Task,
+	newAlloc *structs.Allocation, newTask *structs.Task) error {
+
 	var exec driver.ScriptExecutor
 	if d.Abilities().Exec {
 		// Allow set the script executor if the driver supports it
@@ -1706,7 +1714,9 @@ func (r *TaskRunner) updateServices(d driver.Driver, h driver.ScriptExecutor, ol
 	r.driverNetLock.Lock()
 	net := r.driverNet.Copy()
 	r.driverNetLock.Unlock()
-	return r.consul.UpdateTask(r.alloc.ID, oldTask, newTask, r, exec, net)
+	oldTaskServices := consul.NewTaskServices(oldAlloc, oldTask, r, exec, net)
+	newTaskServices := consul.NewTaskServices(newAlloc, newTask, r, exec, net)
+	return r.consul.UpdateTask(oldTaskServices, newTaskServices)
 }
 
 // handleDestroy kills the task handle. In the case that killing fails,

--- a/client/task_runner.go
+++ b/client/task_runner.go
@@ -1219,9 +1219,7 @@ func (r *TaskRunner) run() {
 
 				// Remove from consul before killing the task so that traffic
 				// can be rerouted
-				interpTask := interpolateServices(r.envBuilder.Build(), r.task)
-				taskServices := consul.NewTaskServices(r.alloc, interpTask, r, nil, nil)
-				r.consul.RemoveTask(taskServices)
+				r.removeServices()
 
 				// Delay actually killing the task if configured. See #244
 				if r.task.ShutdownDelay > 0 {
@@ -1276,9 +1274,7 @@ func (r *TaskRunner) run() {
 // stopping. Errors are logged.
 func (r *TaskRunner) cleanup() {
 	// Remove from Consul
-	interpTask := interpolateServices(r.envBuilder.Build(), r.task)
-	taskServices := consul.NewTaskServices(r.alloc, interpTask, r, nil, nil)
-	r.consul.RemoveTask(taskServices)
+	r.removeServices()
 
 	drv, err := r.createDriver()
 	if err != nil {
@@ -1341,9 +1337,7 @@ func (r *TaskRunner) shouldRestart() bool {
 	}
 
 	// Unregister from Consul while waiting to restart.
-	interpTask := interpolateServices(r.envBuilder.Build(), r.task)
-	taskServices := consul.NewTaskServices(r.alloc, interpTask, r, nil, nil)
-	r.consul.RemoveTask(taskServices)
+	r.removeServices()
 
 	// Sleep but watch for destroy events.
 	select {
@@ -1717,6 +1711,20 @@ func (r *TaskRunner) updateServices(d driver.Driver, h driver.ScriptExecutor,
 	oldTaskServices := consul.NewTaskServices(oldAlloc, oldTask, r, exec, net)
 	newTaskServices := consul.NewTaskServices(newAlloc, newTask, r, exec, net)
 	return r.consul.UpdateTask(oldTaskServices, newTaskServices)
+}
+
+// removeServices and checks from Consul. Handles interpolation and deleting
+// Canary=true and Canary=false versions in case Canary=false is set at the
+// same time as the alloc is stopped.
+func (r *TaskRunner) removeServices() {
+	interpTask := interpolateServices(r.envBuilder.Build(), r.task)
+	taskServices := consul.NewTaskServices(r.alloc, interpTask, r, nil, nil)
+	r.consul.RemoveTask(taskServices)
+
+	// Flip Canary and remove again in case canary is getting flipped at
+	// the same time as the alloc is being destroyed
+	taskServices.Canary = !taskServices.Canary
+	r.consul.RemoveTask(taskServices)
 }
 
 // handleDestroy kills the task handle. In the case that killing fails,

--- a/client/task_runner_test.go
+++ b/client/task_runner_test.go
@@ -650,7 +650,7 @@ func TestTaskRunner_UnregisterConsul_Retries(t *testing.T) {
 	defer ctx.Cleanup()
 
 	// Assert it is properly registered and unregistered
-	if expected := 4; len(consul.ops) != expected {
+	if expected := 6; len(consul.ops) != expected {
 		t.Errorf("expected %d consul ops but found: %d", expected, len(consul.ops))
 	}
 	if consul.ops[0].op != "add" {
@@ -659,11 +659,17 @@ func TestTaskRunner_UnregisterConsul_Retries(t *testing.T) {
 	if consul.ops[1].op != "remove" {
 		t.Errorf("expected second op to be remove but found: %q", consul.ops[1].op)
 	}
-	if consul.ops[2].op != "add" {
-		t.Errorf("expected third op to be add but found: %q", consul.ops[2].op)
+	if consul.ops[2].op != "remove" {
+		t.Errorf("expected third op to be remove but found: %q", consul.ops[2].op)
 	}
-	if consul.ops[3].op != "remove" {
-		t.Errorf("expected fourth/final op to be remove but found: %q", consul.ops[3].op)
+	if consul.ops[3].op != "add" {
+		t.Errorf("expected fourth op to be add but found: %q", consul.ops[3].op)
+	}
+	if consul.ops[4].op != "remove" {
+		t.Errorf("expected fifth op to be remove but found: %q", consul.ops[4].op)
+	}
+	if consul.ops[5].op != "remove" {
+		t.Errorf("expected sixth op to be remove but found: %q", consul.ops[5].op)
 	}
 }
 

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -14,7 +14,6 @@ import (
 
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/nomad/client/driver"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -589,11 +588,11 @@ func (c *ServiceClient) RegisterAgent(role string, services []*structs.Service) 
 // serviceRegs creates service registrations, check registrations, and script
 // checks from a service. It returns a service registration object with the
 // service and check IDs populated.
-func (c *ServiceClient) serviceRegs(ops *operations, allocID string, service *structs.Service,
-	task *structs.Task, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) (*ServiceRegistration, error) {
+func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, task *TaskServices) (
+	*ServiceRegistration, error) {
 
 	// Get the services ID
-	id := makeTaskServiceID(allocID, task.Name, service)
+	id := makeTaskServiceID(task.AllocID, task.Name, service, task.Canary)
 	sreg := &ServiceRegistration{
 		serviceID: id,
 		checkIDs:  make(map[string]struct{}, len(service.Checks)),
@@ -606,26 +605,33 @@ func (c *ServiceClient) serviceRegs(ops *operations, allocID string, service *st
 	}
 
 	// Determine the address to advertise based on the mode
-	ip, port, err := getAddress(addrMode, service.PortLabel, task.Resources.Networks, net)
+	ip, port, err := getAddress(addrMode, service.PortLabel, task.Networks, task.DriverNetwork)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get address for service %q: %v", service.Name, err)
+	}
+
+	// Determine whether to use tags or canary_tags
+	var tags []string
+	if task.Canary {
+		tags = make([]string, len(service.CanaryTags))
+		copy(tags, service.CanaryTags)
+	} else {
+		tags = make([]string, len(service.Tags))
+		copy(tags, service.Tags)
 	}
 
 	// Build the Consul Service registration request
 	serviceReg := &api.AgentServiceRegistration{
 		ID:      id,
 		Name:    service.Name,
-		Tags:    make([]string, len(service.Tags)),
+		Tags:    tags,
 		Address: ip,
 		Port:    port,
 	}
-	// copy isn't strictly necessary but can avoid bugs especially
-	// with tests that may reuse Tasks
-	copy(serviceReg.Tags, service.Tags)
 	ops.regServices = append(ops.regServices, serviceReg)
 
 	// Build the check registrations
-	checkIDs, err := c.checkRegs(ops, allocID, id, service, task, exec, net)
+	checkIDs, err := c.checkRegs(ops, id, service, task)
 	if err != nil {
 		return nil, err
 	}
@@ -637,8 +643,8 @@ func (c *ServiceClient) serviceRegs(ops *operations, allocID string, service *st
 
 // checkRegs registers the checks for the given service and returns the
 // registered check ids.
-func (c *ServiceClient) checkRegs(ops *operations, allocID, serviceID string, service *structs.Service,
-	task *structs.Task, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) ([]string, error) {
+func (c *ServiceClient) checkRegs(ops *operations, serviceID string, service *structs.Service,
+	task *TaskServices) ([]string, error) {
 
 	// Fast path
 	numChecks := len(service.Checks)
@@ -651,11 +657,13 @@ func (c *ServiceClient) checkRegs(ops *operations, allocID, serviceID string, se
 		checkID := makeCheckID(serviceID, check)
 		checkIDs = append(checkIDs, checkID)
 		if check.Type == structs.ServiceCheckScript {
-			if exec == nil {
+			if task.DriverExec == nil {
 				return nil, fmt.Errorf("driver doesn't support script checks")
 			}
-			ops.scripts = append(ops.scripts, newScriptCheck(
-				allocID, task.Name, checkID, check, exec, c.client, c.logger, c.shutdownCh))
+
+			sc := newScriptCheck(task.AllocID, task.Name, checkID, check, task.DriverExec,
+				c.client, c.logger, c.shutdownCh)
+			ops.scripts = append(ops.scripts, sc)
 
 			// Skip getAddress for script checks
 			checkReg, err := createCheckReg(serviceID, checkID, check, "", 0)
@@ -679,7 +687,7 @@ func (c *ServiceClient) checkRegs(ops *operations, allocID, serviceID string, se
 			addrMode = structs.AddressModeHost
 		}
 
-		ip, port, err := getAddress(addrMode, portLabel, task.Resources.Networks, net)
+		ip, port, err := getAddress(addrMode, portLabel, task.Networks, task.DriverNetwork)
 		if err != nil {
 			return nil, fmt.Errorf("error getting address for check %q: %v", check.Name, err)
 		}
@@ -700,7 +708,7 @@ func (c *ServiceClient) checkRegs(ops *operations, allocID, serviceID string, se
 // Checks will always use the IP from the Task struct (host's IP).
 //
 // Actual communication with Consul is done asynchronously (see Run).
-func (c *ServiceClient) RegisterTask(allocID string, task *structs.Task, restarter TaskRestarter, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error {
+func (c *ServiceClient) RegisterTask(task *TaskServices) error {
 	// Fast path
 	numServices := len(task.Services)
 	if numServices == 0 {
@@ -712,7 +720,7 @@ func (c *ServiceClient) RegisterTask(allocID string, task *structs.Task, restart
 
 	ops := &operations{}
 	for _, service := range task.Services {
-		sreg, err := c.serviceRegs(ops, allocID, service, task, exec, net)
+		sreg, err := c.serviceRegs(ops, service, task)
 		if err != nil {
 			return err
 		}
@@ -720,18 +728,18 @@ func (c *ServiceClient) RegisterTask(allocID string, task *structs.Task, restart
 	}
 
 	// Add the task to the allocation's registration
-	c.addTaskRegistration(allocID, task.Name, t)
+	c.addTaskRegistration(task.AllocID, task.Name, t)
 
 	c.commit(ops)
 
 	// Start watching checks. Done after service registrations are built
 	// since an error building them could leak watches.
 	for _, service := range task.Services {
-		serviceID := makeTaskServiceID(allocID, task.Name, service)
+		serviceID := makeTaskServiceID(task.AllocID, task.Name, service, task.Canary)
 		for _, check := range service.Checks {
 			if check.TriggersRestarts() {
 				checkID := makeCheckID(serviceID, check)
-				c.checkWatcher.Watch(allocID, task.Name, checkID, check, restarter)
+				c.checkWatcher.Watch(task.AllocID, task.Name, checkID, check, task.Restarter)
 			}
 		}
 	}
@@ -742,19 +750,19 @@ func (c *ServiceClient) RegisterTask(allocID string, task *structs.Task, restart
 // changed.
 //
 // DriverNetwork must not change between invocations for the same allocation.
-func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Task, restarter TaskRestarter, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) error {
+func (c *ServiceClient) UpdateTask(old, newTask *TaskServices) error {
 	ops := &operations{}
 
 	taskReg := new(TaskRegistration)
 	taskReg.Services = make(map[string]*ServiceRegistration, len(newTask.Services))
 
-	existingIDs := make(map[string]*structs.Service, len(existing.Services))
-	for _, s := range existing.Services {
-		existingIDs[makeTaskServiceID(allocID, existing.Name, s)] = s
+	existingIDs := make(map[string]*structs.Service, len(old.Services))
+	for _, s := range old.Services {
+		existingIDs[makeTaskServiceID(old.AllocID, old.Name, s, old.Canary)] = s
 	}
 	newIDs := make(map[string]*structs.Service, len(newTask.Services))
 	for _, s := range newTask.Services {
-		newIDs[makeTaskServiceID(allocID, newTask.Name, s)] = s
+		newIDs[makeTaskServiceID(newTask.AllocID, newTask.Name, s, newTask.Canary)] = s
 	}
 
 	// Loop over existing Service IDs to see if they have been removed or
@@ -802,7 +810,7 @@ func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Ta
 			}
 
 			// New check on an unchanged service; add them now
-			newCheckIDs, err := c.checkRegs(ops, allocID, existingID, newSvc, newTask, exec, net)
+			newCheckIDs, err := c.checkRegs(ops, existingID, newSvc, newTask)
 			if err != nil {
 				return err
 			}
@@ -814,7 +822,7 @@ func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Ta
 
 			// Update all watched checks as CheckRestart fields aren't part of ID
 			if check.TriggersRestarts() {
-				c.checkWatcher.Watch(allocID, newTask.Name, checkID, check, restarter)
+				c.checkWatcher.Watch(newTask.AllocID, newTask.Name, checkID, check, newTask.Restarter)
 			}
 		}
 
@@ -831,7 +839,7 @@ func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Ta
 
 	// Any remaining services should just be enqueued directly
 	for _, newSvc := range newIDs {
-		sreg, err := c.serviceRegs(ops, allocID, newSvc, newTask, exec, net)
+		sreg, err := c.serviceRegs(ops, newSvc, newTask)
 		if err != nil {
 			return err
 		}
@@ -840,18 +848,18 @@ func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Ta
 	}
 
 	// Add the task to the allocation's registration
-	c.addTaskRegistration(allocID, newTask.Name, taskReg)
+	c.addTaskRegistration(newTask.AllocID, newTask.Name, taskReg)
 
 	c.commit(ops)
 
 	// Start watching checks. Done after service registrations are built
 	// since an error building them could leak watches.
 	for _, service := range newIDs {
-		serviceID := makeTaskServiceID(allocID, newTask.Name, service)
+		serviceID := makeTaskServiceID(newTask.AllocID, newTask.Name, service, newTask.Canary)
 		for _, check := range service.Checks {
 			if check.TriggersRestarts() {
 				checkID := makeCheckID(serviceID, check)
-				c.checkWatcher.Watch(allocID, newTask.Name, checkID, check, restarter)
+				c.checkWatcher.Watch(newTask.AllocID, newTask.Name, checkID, check, newTask.Restarter)
 			}
 		}
 	}
@@ -861,11 +869,11 @@ func (c *ServiceClient) UpdateTask(allocID string, existing, newTask *structs.Ta
 // RemoveTask from Consul. Removes all service entries and checks.
 //
 // Actual communication with Consul is done asynchronously (see Run).
-func (c *ServiceClient) RemoveTask(allocID string, task *structs.Task) {
+func (c *ServiceClient) RemoveTask(task *TaskServices) {
 	ops := operations{}
 
 	for _, service := range task.Services {
-		id := makeTaskServiceID(allocID, task.Name, service)
+		id := makeTaskServiceID(task.AllocID, task.Name, service, task.Canary)
 		ops.deregServices = append(ops.deregServices, id)
 
 		for _, check := range service.Checks {
@@ -879,7 +887,7 @@ func (c *ServiceClient) RemoveTask(allocID string, task *structs.Task) {
 	}
 
 	// Remove the task from the alloc's registrations
-	c.removeTaskRegistration(allocID, task.Name)
+	c.removeTaskRegistration(task.AllocID, task.Name)
 
 	// Now add them to the deregistration fields; main Run loop will update
 	c.commit(&ops)
@@ -1023,7 +1031,7 @@ func (c *ServiceClient) removeTaskRegistration(allocID, taskName string) {
 //	Example Client ID: _nomad-client-ggnjpgl7yn7rgmvxzilmpvrzzvrszc7l
 //
 func makeAgentServiceID(role string, service *structs.Service) string {
-	return fmt.Sprintf("%s-%s-%s", nomadServicePrefix, role, service.Hash(role, ""))
+	return fmt.Sprintf("%s-%s-%s", nomadServicePrefix, role, service.Hash(role, "", false))
 }
 
 // makeTaskServiceID creates a unique ID for identifying a task service in
@@ -1031,8 +1039,8 @@ func makeAgentServiceID(role string, service *structs.Service) string {
 // Checks. This allows updates to merely compare IDs.
 //
 //	Example Service ID: _nomad-task-TNM333JKJPM5AK4FAS3VXQLXFDWOF4VH
-func makeTaskServiceID(allocID, taskName string, service *structs.Service) string {
-	return nomadTaskPrefix + service.Hash(allocID, taskName)
+func makeTaskServiceID(allocID, taskName string, service *structs.Service, canary bool) string {
+	return nomadTaskPrefix + service.Hash(allocID, taskName, canary)
 }
 
 // makeCheckID creates a unique ID for a check.

--- a/command/agent/consul/structs.go
+++ b/command/agent/consul/structs.go
@@ -1,0 +1,67 @@
+package consul
+
+import (
+	"github.com/hashicorp/nomad/client/driver"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type TaskServices struct {
+	AllocID string
+
+	// Name of the task
+	Name string
+
+	// Canary indicates whether or not the allocation is a canary
+	Canary bool
+
+	// Restarter allows restarting the task depending on the task's
+	// check_restart stanzas.
+	Restarter TaskRestarter
+
+	// Services and checks to register for the task.
+	Services []*structs.Service
+
+	// Networks from the task's resources stanza.
+	Networks structs.Networks
+
+	// DriverExec is the script executor for the task's driver.
+	DriverExec driver.ScriptExecutor
+
+	// DriverNetwork is the network specified by the driver and may be nil.
+	DriverNetwork *cstructs.DriverNetwork
+}
+
+func NewTaskServices(alloc *structs.Allocation, task *structs.Task, restarter TaskRestarter, exec driver.ScriptExecutor, net *cstructs.DriverNetwork) *TaskServices {
+	ts := TaskServices{
+		AllocID:       alloc.ID,
+		Name:          task.Name,
+		Restarter:     restarter,
+		Services:      task.Services,
+		DriverExec:    exec,
+		DriverNetwork: net,
+	}
+
+	if task.Resources != nil {
+		ts.Networks = task.Resources.Networks
+	}
+
+	if alloc.DeploymentStatus != nil && alloc.DeploymentStatus.Canary {
+		ts.Canary = true
+	}
+
+	return &ts
+}
+
+// Copy method for easing tests
+func (t *TaskServices) Copy() *TaskServices {
+	newTS := new(TaskServices)
+	*newTS = *t
+
+	// Deep copy Services
+	newTS.Services = make([]*structs.Service, len(t.Services))
+	for i := range t.Services {
+		newTS.Services[i] = t.Services[i].Copy()
+	}
+	return newTS
+}

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -1368,6 +1368,10 @@ func TestConsul_CanaryTags(t *testing.T) {
 	for _, service := range ctx.FakeConsul.services {
 		require.NotEqual(canaryTags, service.Tags)
 	}
+
+	ctx.ServiceClient.RemoveTask(ctx.Task)
+	require.NoError(ctx.syncOnce())
+	require.Len(ctx.FakeConsul.services, 0)
 }
 
 // TestIsNomadService asserts the isNomadService helper returns true for Nomad

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/kr/pretty"
@@ -34,19 +35,11 @@ func testLogger() *log.Logger {
 	return log.New(ioutil.Discard, "", 0)
 }
 
-func testTask() *structs.Task {
-	return &structs.Task{
-		Name: "taskname",
-		Resources: &structs.Resources{
-			Networks: []*structs.NetworkResource{
-				{
-					DynamicPorts: []structs.Port{
-						{Label: "x", Value: xPort},
-						{Label: "y", Value: yPort},
-					},
-				},
-			},
-		},
+func testTask() *TaskServices {
+	return &TaskServices{
+		AllocID:   uuid.Generate(),
+		Name:      "taskname",
+		Restarter: &restartRecorder{},
 		Services: []*structs.Service{
 			{
 				Name:      "taskname-service",
@@ -54,7 +47,44 @@ func testTask() *structs.Task {
 				Tags:      []string{"tag1", "tag2"},
 			},
 		},
+		Networks: []*structs.NetworkResource{
+			{
+				DynamicPorts: []structs.Port{
+					{Label: "x", Value: xPort},
+					{Label: "y", Value: yPort},
+				},
+			},
+		},
+		DriverExec: newMockExec(),
 	}
+}
+
+// mockExec implements the ScriptExecutor interface and will use an alternate
+// implementation t.ExecFunc if non-nil.
+type mockExec struct {
+	// Ticked whenever a script is called
+	execs chan int
+
+	// If non-nil will be called by script checks
+	ExecFunc func(ctx context.Context, cmd string, args []string) ([]byte, int, error)
+}
+
+func newMockExec() *mockExec {
+	return &mockExec{
+		execs: make(chan int, 100),
+	}
+}
+
+func (m *mockExec) Exec(ctx context.Context, cmd string, args []string) ([]byte, int, error) {
+	select {
+	case m.execs <- 1:
+	default:
+	}
+	if m.ExecFunc == nil {
+		// Default impl is just "ok"
+		return []byte("ok"), 0, nil
+	}
+	return m.ExecFunc(ctx, cmd, args)
 }
 
 // restartRecorder is a minimal TaskRestarter implementation that simply
@@ -67,33 +97,12 @@ func (r *restartRecorder) Restart(source, reason string, failure bool) {
 	atomic.AddInt64(&r.restarts, 1)
 }
 
-// testFakeCtx contains a fake Consul AgentAPI and implements the Exec
-// interface to allow testing without running Consul.
+// testFakeCtx contains a fake Consul AgentAPI
 type testFakeCtx struct {
 	ServiceClient *ServiceClient
 	FakeConsul    *MockAgent
-	Task          *structs.Task
-	Restarter     *restartRecorder
-
-	// Ticked whenever a script is called
-	execs chan int
-
-	// If non-nil will be called by script checks
-	ExecFunc func(ctx context.Context, cmd string, args []string) ([]byte, int, error)
-}
-
-// Exec implements the ScriptExecutor interface and will use an alternate
-// implementation t.ExecFunc if non-nil.
-func (t *testFakeCtx) Exec(ctx context.Context, cmd string, args []string) ([]byte, int, error) {
-	select {
-	case t.execs <- 1:
-	default:
-	}
-	if t.ExecFunc == nil {
-		// Default impl is just "ok"
-		return []byte("ok"), 0, nil
-	}
-	return t.ExecFunc(ctx, cmd, args)
+	Task          *TaskServices
+	MockExec      *mockExec
 }
 
 var errNoOps = fmt.Errorf("testing error: no pending operations")
@@ -114,20 +123,19 @@ func (t *testFakeCtx) syncOnce() error {
 // A test Task is also provided.
 func setupFake() *testFakeCtx {
 	fc := NewMockAgent()
+	tt := testTask()
 	return &testFakeCtx{
 		ServiceClient: NewServiceClient(fc, testLogger()),
 		FakeConsul:    fc,
-		Task:          testTask(),
-		Restarter:     &restartRecorder{},
-		execs:         make(chan int, 100),
+		Task:          tt,
+		MockExec:      tt.DriverExec.(*mockExec),
 	}
 }
 
 func TestConsul_ChangeTags(t *testing.T) {
 	ctx := setupFake()
 
-	allocID := "allocid"
-	if err := ctx.ServiceClient.RegisterTask(allocID, ctx.Task, ctx.Restarter, nil, nil); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -141,7 +149,7 @@ func TestConsul_ChangeTags(t *testing.T) {
 
 	// Query the allocs registrations and then again when we update. The IDs
 	// should change
-	reg1, err := ctx.ServiceClient.AllocRegistrations(allocID)
+	reg1, err := ctx.ServiceClient.AllocRegistrations(ctx.Task.AllocID)
 	if err != nil {
 		t.Fatalf("Looking up alloc registration failed: %v", err)
 	}
@@ -166,10 +174,9 @@ func TestConsul_ChangeTags(t *testing.T) {
 		}
 	}
 
-	origTask := ctx.Task
-	ctx.Task = testTask()
+	origTask := ctx.Task.Copy()
 	ctx.Task.Services[0].Tags[0] = "newtag"
-	if err := ctx.ServiceClient.UpdateTask("allocid", origTask, ctx.Task, nil, nil, nil); err != nil {
+	if err := ctx.ServiceClient.UpdateTask(origTask, ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 	if err := ctx.syncOnce(); err != nil {
@@ -193,7 +200,7 @@ func TestConsul_ChangeTags(t *testing.T) {
 	}
 
 	// Check again and ensure the IDs changed
-	reg2, err := ctx.ServiceClient.AllocRegistrations(allocID)
+	reg2, err := ctx.ServiceClient.AllocRegistrations(ctx.Task.AllocID)
 	if err != nil {
 		t.Fatalf("Looking up alloc registration failed: %v", err)
 	}
@@ -251,7 +258,7 @@ func TestConsul_ChangePorts(t *testing.T) {
 		},
 	}
 
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -294,8 +301,8 @@ func TestConsul_ChangePorts(t *testing.T) {
 		case "c2":
 			origScriptKey = k
 			select {
-			case <-ctx.execs:
-				if n := len(ctx.execs); n > 0 {
+			case <-ctx.MockExec.execs:
+				if n := len(ctx.MockExec.execs); n > 0 {
 					t.Errorf("expected 1 exec but found: %d", n+1)
 				}
 			case <-time.After(3 * time.Second):
@@ -312,8 +319,7 @@ func TestConsul_ChangePorts(t *testing.T) {
 	}
 
 	// Now update the PortLabel on the Service and Check c3
-	origTask := ctx.Task
-	ctx.Task = testTask()
+	origTask := ctx.Task.Copy()
 	ctx.Task.Services[0].PortLabel = "y"
 	ctx.Task.Services[0].Checks = []*structs.ServiceCheck{
 		{
@@ -339,7 +345,7 @@ func TestConsul_ChangePorts(t *testing.T) {
 			// Removed PortLabel; should default to service's (y)
 		},
 	}
-	if err := ctx.ServiceClient.UpdateTask("allocid", origTask, ctx.Task, nil, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.UpdateTask(origTask, ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 	if err := ctx.syncOnce(); err != nil {
@@ -383,8 +389,8 @@ func TestConsul_ChangePorts(t *testing.T) {
 				t.Errorf("expected key change for %s from %q", v.Name, origScriptKey)
 			}
 			select {
-			case <-ctx.execs:
-				if n := len(ctx.execs); n > 0 {
+			case <-ctx.MockExec.execs:
+				if n := len(ctx.MockExec.execs); n > 0 {
 					t.Errorf("expected 1 exec but found: %d", n+1)
 				}
 			case <-time.After(3 * time.Second):
@@ -420,8 +426,7 @@ func TestConsul_ChangeChecks(t *testing.T) {
 		},
 	}
 
-	allocID := "allocid"
-	if err := ctx.ServiceClient.RegisterTask(allocID, ctx.Task, ctx.Restarter, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -442,7 +447,7 @@ func TestConsul_ChangeChecks(t *testing.T) {
 
 	// Query the allocs registrations and then again when we update. The IDs
 	// should change
-	reg1, err := ctx.ServiceClient.AllocRegistrations(allocID)
+	reg1, err := ctx.ServiceClient.AllocRegistrations(ctx.Task.AllocID)
 	if err != nil {
 		t.Fatalf("Looking up alloc registration failed: %v", err)
 	}
@@ -498,7 +503,7 @@ func TestConsul_ChangeChecks(t *testing.T) {
 			PortLabel: "x",
 		},
 	}
-	if err := ctx.ServiceClient.UpdateTask("allocid", origTask, ctx.Task, nil, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.UpdateTask(origTask, ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -556,7 +561,7 @@ func TestConsul_ChangeChecks(t *testing.T) {
 	}
 
 	// Check again and ensure the IDs changed
-	reg2, err := ctx.ServiceClient.AllocRegistrations(allocID)
+	reg2, err := ctx.ServiceClient.AllocRegistrations(ctx.Task.AllocID)
 	if err != nil {
 		t.Fatalf("Looking up alloc registration failed: %v", err)
 	}
@@ -612,7 +617,7 @@ func TestConsul_ChangeChecks(t *testing.T) {
 			PortLabel: "x",
 		},
 	}
-	if err := ctx.ServiceClient.UpdateTask("allocid", origTask, ctx.Task, nil, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.UpdateTask(origTask, ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 	if err := ctx.syncOnce(); err != nil {
@@ -655,7 +660,7 @@ func TestConsul_RegServices(t *testing.T) {
 		},
 	}
 
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, nil, nil); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -686,7 +691,7 @@ func TestConsul_RegServices(t *testing.T) {
 
 	// Assert the check update is properly formed
 	checkUpd := <-ctx.ServiceClient.checkWatcher.checkUpdateCh
-	if checkUpd.checkRestart.allocID != "allocid" {
+	if checkUpd.checkRestart.allocID != ctx.Task.AllocID {
 		t.Fatalf("expected check's allocid to be %q but found %q", "allocid", checkUpd.checkRestart.allocID)
 	}
 	if expected := 200 * time.Millisecond; checkUpd.checkRestart.timeLimit != expected {
@@ -696,7 +701,7 @@ func TestConsul_RegServices(t *testing.T) {
 	// Make a change which will register a new service
 	ctx.Task.Services[0].Name = "taskname-service2"
 	ctx.Task.Services[0].Tags[0] = "tag3"
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, nil, nil); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -746,7 +751,7 @@ func TestConsul_RegServices(t *testing.T) {
 	}
 
 	// Remove the new task
-	ctx.ServiceClient.RemoveTask("allocid", ctx.Task)
+	ctx.ServiceClient.RemoveTask(ctx.Task)
 	if err := ctx.syncOnce(); err != nil {
 		t.Fatalf("unexpected error syncing task: %v", err)
 	}
@@ -796,7 +801,7 @@ func TestConsul_ShutdownOK(t *testing.T) {
 	go ctx.ServiceClient.Run()
 
 	// Register a task and agent
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -858,7 +863,7 @@ func TestConsul_ShutdownSlow(t *testing.T) {
 
 	// Make Exec slow, but not too slow
 	waiter := make(chan struct{})
-	ctx.ExecFunc = func(ctx context.Context, cmd string, args []string) ([]byte, int, error) {
+	ctx.MockExec.ExecFunc = func(ctx context.Context, cmd string, args []string) ([]byte, int, error) {
 		select {
 		case <-waiter:
 		default:
@@ -874,7 +879,7 @@ func TestConsul_ShutdownSlow(t *testing.T) {
 	go ctx.ServiceClient.Run()
 
 	// Register a task and agent
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -933,7 +938,7 @@ func TestConsul_ShutdownBlocked(t *testing.T) {
 
 	// Make Exec block forever
 	waiter := make(chan struct{})
-	ctx.ExecFunc = func(ctx context.Context, cmd string, args []string) ([]byte, int, error) {
+	ctx.MockExec.ExecFunc = func(ctx context.Context, cmd string, args []string) ([]byte, int, error) {
 		close(waiter)
 		<-block
 		return []byte{}, 0, nil
@@ -945,7 +950,7 @@ func TestConsul_ShutdownBlocked(t *testing.T) {
 	go ctx.ServiceClient.Run()
 
 	// Register a task and agent
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -997,7 +1002,7 @@ func TestConsul_CancelScript(t *testing.T) {
 		},
 	}
 
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -1016,7 +1021,7 @@ func TestConsul_CancelScript(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		select {
-		case <-ctx.execs:
+		case <-ctx.MockExec.execs:
 			// Script ran as expected!
 		case <-time.After(3 * time.Second):
 			t.Fatalf("timed out waiting for script check to run")
@@ -1034,7 +1039,7 @@ func TestConsul_CancelScript(t *testing.T) {
 		},
 	}
 
-	if err := ctx.ServiceClient.UpdateTask("allocid", origTask, ctx.Task, ctx.Restarter, ctx, nil); err != nil {
+	if err := ctx.ServiceClient.UpdateTask(origTask, ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -1053,7 +1058,7 @@ func TestConsul_CancelScript(t *testing.T) {
 
 	// Make sure exec wasn't called again
 	select {
-	case <-ctx.execs:
+	case <-ctx.MockExec.execs:
 		t.Errorf("unexpected execution of script; was goroutine not cancelled?")
 	case <-time.After(100 * time.Millisecond):
 		// No unexpected script execs
@@ -1112,7 +1117,7 @@ func TestConsul_DriverNetwork_AutoUse(t *testing.T) {
 		},
 	}
 
-	net := &cstructs.DriverNetwork{
+	ctx.Task.DriverNetwork = &cstructs.DriverNetwork{
 		PortMap: map[string]int{
 			"x": 8888,
 			"y": 9999,
@@ -1121,7 +1126,7 @@ func TestConsul_DriverNetwork_AutoUse(t *testing.T) {
 		AutoAdvertise: true,
 	}
 
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, ctx, net); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -1137,9 +1142,9 @@ func TestConsul_DriverNetwork_AutoUse(t *testing.T) {
 		switch v.Name {
 		case ctx.Task.Services[0].Name: // x
 			// Since DriverNetwork.AutoAdvertise=true, driver ports should be used
-			if v.Port != net.PortMap["x"] {
+			if v.Port != ctx.Task.DriverNetwork.PortMap["x"] {
 				t.Errorf("expected service %s's port to be %d but found %d",
-					v.Name, net.PortMap["x"], v.Port)
+					v.Name, ctx.Task.DriverNetwork.PortMap["x"], v.Port)
 			}
 			// The order of checks in Consul is not guaranteed to
 			// be the same as their order in the Task definition,
@@ -1167,13 +1172,13 @@ func TestConsul_DriverNetwork_AutoUse(t *testing.T) {
 			}
 		case ctx.Task.Services[1].Name: // y
 			// Service should be container ip:port
-			if v.Address != net.IP {
+			if v.Address != ctx.Task.DriverNetwork.IP {
 				t.Errorf("expected service %s's address to be %s but found %s",
-					v.Name, net.IP, v.Address)
+					v.Name, ctx.Task.DriverNetwork.IP, v.Address)
 			}
-			if v.Port != net.PortMap["y"] {
+			if v.Port != ctx.Task.DriverNetwork.PortMap["y"] {
 				t.Errorf("expected service %s's port to be %d but found %d",
-					v.Name, net.PortMap["x"], v.Port)
+					v.Name, ctx.Task.DriverNetwork.PortMap["x"], v.Port)
 			}
 			// Check should be host ip:port
 			if v.Checks[0].TCP != ":1235" { // yPort
@@ -1215,7 +1220,7 @@ func TestConsul_DriverNetwork_NoAutoUse(t *testing.T) {
 		},
 	}
 
-	net := &cstructs.DriverNetwork{
+	ctx.Task.DriverNetwork = &cstructs.DriverNetwork{
 		PortMap: map[string]int{
 			"x": 8888,
 			"y": 9999,
@@ -1224,7 +1229,7 @@ func TestConsul_DriverNetwork_NoAutoUse(t *testing.T) {
 		AutoAdvertise: false,
 	}
 
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, ctx, net); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
@@ -1246,13 +1251,13 @@ func TestConsul_DriverNetwork_NoAutoUse(t *testing.T) {
 			}
 		case ctx.Task.Services[1].Name: // y + driver mode
 			// Service should be container ip:port
-			if v.Address != net.IP {
+			if v.Address != ctx.Task.DriverNetwork.IP {
 				t.Errorf("expected service %s's address to be %s but found %s",
-					v.Name, net.IP, v.Address)
+					v.Name, ctx.Task.DriverNetwork.IP, v.Address)
 			}
-			if v.Port != net.PortMap["y"] {
+			if v.Port != ctx.Task.DriverNetwork.PortMap["y"] {
 				t.Errorf("expected service %s's port to be %d but found %d",
-					v.Name, net.PortMap["x"], v.Port)
+					v.Name, ctx.Task.DriverNetwork.PortMap["x"], v.Port)
 			}
 		case ctx.Task.Services[2].Name: // y + host mode
 			if v.Port != yPort {
@@ -1278,7 +1283,7 @@ func TestConsul_DriverNetwork_Change(t *testing.T) {
 		},
 	}
 
-	net := &cstructs.DriverNetwork{
+	ctx.Task.DriverNetwork = &cstructs.DriverNetwork{
 		PortMap: map[string]int{
 			"x": 8888,
 			"y": 9999,
@@ -1310,31 +1315,59 @@ func TestConsul_DriverNetwork_Change(t *testing.T) {
 	}
 
 	// Initial service should advertise host port x
-	if err := ctx.ServiceClient.RegisterTask("allocid", ctx.Task, ctx.Restarter, ctx, net); err != nil {
+	if err := ctx.ServiceClient.RegisterTask(ctx.Task); err != nil {
 		t.Fatalf("unexpected error registering task: %v", err)
 	}
 
 	syncAndAssertPort(xPort)
 
 	// UpdateTask to use Host (shouldn't change anything)
-	orig := ctx.Task.Copy()
+	origTask := ctx.Task.Copy()
 	ctx.Task.Services[0].AddressMode = structs.AddressModeHost
 
-	if err := ctx.ServiceClient.UpdateTask("allocid", orig, ctx.Task, ctx.Restarter, ctx, net); err != nil {
+	if err := ctx.ServiceClient.UpdateTask(origTask, ctx.Task); err != nil {
 		t.Fatalf("unexpected error updating task: %v", err)
 	}
 
 	syncAndAssertPort(xPort)
 
 	// UpdateTask to use Driver (*should* change IP and port)
-	orig = ctx.Task.Copy()
+	origTask = ctx.Task.Copy()
 	ctx.Task.Services[0].AddressMode = structs.AddressModeDriver
 
-	if err := ctx.ServiceClient.UpdateTask("allocid", orig, ctx.Task, ctx.Restarter, ctx, net); err != nil {
+	if err := ctx.ServiceClient.UpdateTask(origTask, ctx.Task); err != nil {
 		t.Fatalf("unexpected error updating task: %v", err)
 	}
 
-	syncAndAssertPort(net.PortMap["x"])
+	syncAndAssertPort(ctx.Task.DriverNetwork.PortMap["x"])
+}
+
+// TestConsul_CanaryTags asserts CanaryTags are used when Canary=true
+func TestConsul_CanaryTags(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	ctx := setupFake()
+
+	canaryTags := []string{"tag1", "canary"}
+	ctx.Task.Canary = true
+	ctx.Task.Services[0].CanaryTags = canaryTags
+
+	require.NoError(ctx.ServiceClient.RegisterTask(ctx.Task))
+	require.NoError(ctx.syncOnce())
+	require.Len(ctx.FakeConsul.services, 1)
+	for _, service := range ctx.FakeConsul.services {
+		require.Equal(canaryTags, service.Tags)
+	}
+
+	// Disable canary and assert tags are not the canary tags
+	origTask := ctx.Task.Copy()
+	ctx.Task.Canary = false
+	require.NoError(ctx.ServiceClient.UpdateTask(origTask, ctx.Task))
+	require.NoError(ctx.syncOnce())
+	require.Len(ctx.FakeConsul.services, 1)
+	for _, service := range ctx.FakeConsul.services {
+		require.NotEqual(canaryTags, service.Tags)
+	}
 }
 
 // TestIsNomadService asserts the isNomadService helper returns true for Nomad

--- a/e2e/consul/canary_tags_test.go
+++ b/e2e/consul/canary_tags_test.go
@@ -1,0 +1,161 @@
+package consul_test
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/jobspec"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var integration = flag.Bool("integration", false, "run integration tests")
+
+func TestConsul(t *testing.T) {
+	if !*integration {
+		t.Skip("skipping test in non-integration mode.")
+	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Consul Canary Tags Test")
+}
+
+var _ = Describe("Consul Canary Tags Test", func() {
+
+	var (
+		agent       *consulapi.Agent
+		allocations *api.Allocations
+		deployments *api.Deployments
+		jobs        *api.Jobs
+		system      *api.System
+		job         *api.Job
+		specFile    string
+	)
+
+	BeforeSuite(func() {
+		consulConf := consulapi.DefaultConfig()
+		consulClient, err := consulapi.NewClient(consulConf)
+		Expect(err).ShouldNot(HaveOccurred())
+		agent = consulClient.Agent()
+
+		conf := api.DefaultConfig()
+		client, err := api.NewClient(conf)
+		Expect(err).ShouldNot(HaveOccurred())
+		allocations = client.Allocations()
+		deployments = client.Deployments()
+		jobs = client.Jobs()
+		system = client.System()
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		job, err = jobspec.ParseFile(specFile)
+		Expect(err).ShouldNot(HaveOccurred())
+		job.ID = helper.StringToPtr(*job.ID + uuid.Generate()[22:])
+		resp, _, err := jobs.Register(job, nil)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(resp.EvalID).ShouldNot(BeEmpty())
+	})
+
+	AfterEach(func() {
+		jobs.Deregister(*job.ID, true, nil)
+		system.GarbageCollect()
+	})
+
+	Describe("Consul Canary Tags Test", func() {
+		Context("Canary Tags", func() {
+			BeforeEach(func() {
+				specFile = "input/canary_tags.hcl"
+			})
+
+			It("Should set and unset canary tags", func() {
+
+				// Eventually be running and healthy
+				Eventually(func() []string {
+					deploys, _, err := jobs.Deployments(*job.ID, nil)
+					Expect(err).ShouldNot(HaveOccurred())
+					healthyDeploys := make([]string, 0, len(deploys))
+					for _, d := range deploys {
+						if d.Status == "successful" {
+							healthyDeploys = append(healthyDeploys, d.ID)
+						}
+					}
+					return healthyDeploys
+				}, 5*time.Second, 20*time.Millisecond).Should(HaveLen(1))
+
+				// Start a deployment
+				job.Meta = map[string]string{"version": "2"}
+				resp, _, err := jobs.Register(job, nil)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(resp.EvalID).ShouldNot(BeEmpty())
+
+				// Eventually have a canary
+				var deploys []*api.Deployment
+				Eventually(func() []*api.Deployment {
+					deploys, _, err = jobs.Deployments(*job.ID, nil)
+					Expect(err).ShouldNot(HaveOccurred())
+					return deploys
+				}, 2*time.Second, 20*time.Millisecond).Should(HaveLen(2))
+
+				var deploy *api.Deployment
+				Eventually(func() []string {
+					deploy, _, err = deployments.Info(deploys[0].ID, nil)
+					Expect(err).ShouldNot(HaveOccurred())
+					return deploy.TaskGroups["consul_canary_test"].PlacedCanaries
+				}, 2*time.Second, 20*time.Millisecond).Should(HaveLen(1))
+
+				Eventually(func() bool {
+					allocID := deploy.TaskGroups["consul_canary_test"].PlacedCanaries[0]
+					alloc, _, err := allocations.Info(allocID, nil)
+					Expect(err).ShouldNot(HaveOccurred())
+					return alloc.DeploymentStatus != nil && alloc.DeploymentStatus.Healthy != nil && *alloc.DeploymentStatus.Healthy
+				}, 3*time.Second, 20*time.Millisecond).Should(BeTrue())
+
+				// Check Consul for canary tags
+				Eventually(func() []string {
+					services, err := agent.Services()
+					Expect(err).ShouldNot(HaveOccurred())
+					for _, v := range services {
+						if v.Service == "canarytest" {
+							return v.Tags
+						}
+					}
+					return nil
+				}, 2*time.Second, 20*time.Millisecond).Should(
+					Equal([]string{"foo", "canary"}))
+
+				// Manually promote
+				{
+					resp, _, err := deployments.PromoteAll(deploys[0].ID, nil)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(resp.EvalID).ShouldNot(BeEmpty())
+				}
+
+				// Eventually canary is removed
+				Eventually(func() bool {
+					allocID := deploy.TaskGroups["consul_canary_test"].PlacedCanaries[0]
+					alloc, _, err := allocations.Info(allocID, nil)
+					Expect(err).ShouldNot(HaveOccurred())
+					return alloc.DeploymentStatus.Canary
+				}, 2*time.Second, 20*time.Millisecond).Should(BeFalse())
+
+				// Check Consul canary tags were removed
+				Eventually(func() []string {
+					services, err := agent.Services()
+					Expect(err).ShouldNot(HaveOccurred())
+					for _, v := range services {
+						if v.Service == "canarytest" {
+							return v.Tags
+						}
+					}
+					return nil
+				}, 2*time.Second, 20*time.Millisecond).Should(
+					Equal([]string{"foo", "bar"}))
+			})
+		})
+	})
+})

--- a/e2e/consul/input/canary_tags.hcl
+++ b/e2e/consul/input/canary_tags.hcl
@@ -1,0 +1,36 @@
+job "consul_canary_test" {
+  datacenters = ["dc1"]
+
+  group "consul_canary_test" {
+    count = 2
+
+    task "consul_canary_test" {
+      driver = "mock_driver"
+
+      config {
+        run_for   = "10m"
+        exit_code = 9
+      }
+
+      service {
+        name = "canarytest"
+        tags = ["foo", "bar"]
+        canary_tags = ["foo", "canary"]
+      }
+    }
+
+    update {
+      max_parallel     = 1
+      canary           = 1
+      min_healthy_time = "1s"
+      health_check     = "task_states"
+      auto_revert      = false
+    }
+
+    restart {
+      attempts = 0
+      delay    = "0s"
+      mode     = "fail"
+    }
+  }
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3816,7 +3816,7 @@ func (s *Service) Hash(allocID, taskName string, canary bool) string {
 
 	// Vary ID on whether or not CanaryTags will be used
 	if canary {
-		h.Write([]byte{'1'})
+		h.Write([]byte("Canary"))
 	}
 
 	// Base32 is used for encoding the hash as sha1 hashes can always be

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3800,7 +3800,7 @@ func (s *Service) ValidateName(name string) error {
 
 // Hash returns a base32 encoded hash of a Service's contents excluding checks
 // as they're hashed independently.
-func (s *Service) Hash(allocID, taskName string) string {
+func (s *Service) Hash(allocID, taskName string, canary bool) string {
 	h := sha1.New()
 	io.WriteString(h, allocID)
 	io.WriteString(h, taskName)
@@ -3812,6 +3812,11 @@ func (s *Service) Hash(allocID, taskName string) string {
 	}
 	for _, tag := range s.CanaryTags {
 		io.WriteString(h, tag)
+	}
+
+	// Vary ID on whether or not CanaryTags will be used
+	if canary {
+		h.Write([]byte{'1'})
 	}
 
 	// Base32 is used for encoding the hash as sha1 hashes can always be


### PR DESCRIPTION
Also refactor Consul ServiceClient to take a struct instead of a massive
set of arguments. Meant updating a lot of code but it should be far
easier to extend in the future as you will only need to update a single
struct instead of every single call site.

Adds an e2e test for canary tags.

Fixes https://github.com/hashicorp/nomad/issues/2920