### PR TITLE
Update node-drain logging message to be clearer for operators.

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -209,7 +209,7 @@ func (n *Nodes) monitorDrainNode(ctx context.Context, nodeID string, index uint6
 		}
 
 		if node.DrainStrategy == nil {
-			msg := Messagef(MonitorMsgLevelInfo, "Node %q drain complete", nodeID)
+			msg := Messagef(MonitorMsgLevelInfo, "Node %q has marked all allocations for migration", nodeID)
 			select {
 			case nodeCh <- msg:
 			case <-ctx.Done():

--- a/command/node_drain_test.go
+++ b/command/node_drain_test.go
@@ -222,7 +222,7 @@ func TestNodeDrainCommand_Monitor(t *testing.T) {
 	out := outBuf.String()
 	t.Logf("Output:\n%s", out)
 
-	require.Contains(out, "drain complete")
+	require.Contains(out, "marked all allocations for migration")
 	for _, a := range allocs {
 		if *a.Job.Type == "system" {
 			if strings.Contains(out, a.ID) {


### PR DESCRIPTION
This change updates the console log message when performing a node
drain and particulary when a node has marked all allocs for
migration. Previously it logged 'drain complete' which was a little
confusing to operators as the node is not drained at this point.

Closes #4183