### PR TITLE
Check if drain alloc node exists

### DIFF
--- a/nomad/drainer/watch_jobs.go
+++ b/nomad/drainer/watch_jobs.go
@@ -351,6 +351,10 @@ func handleTaskGroup(snap *state.StateSnapshot, batch bool, tg *structs.TaskGrou
 			if err != nil {
 				return err
 			}
+			// If the node doesn't exist, move on
+			if node == nil {
+				continue
+			}
 
 			onDrainingNode = node.DrainStrategy != nil
 			drainingNodes[node.ID] = onDrainingNode


### PR DESCRIPTION
Ref #4207. 

There seems to be some initialization state where on start, if an alloc is on a draining node that no longer exists, Nomad servers will panic. Checking if the node still exists here will allow Nomad servers to start up.