### PR TITLE
Fix typo in cap_add whitelisting

### DIFF
--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -329,7 +329,7 @@ The `docker` driver supports the following configuration in the job spec.  Only
 * `cap_add` - (Optional) A list of Linux capabilities as strings to pass directly to
   [`--cap-add`](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
   Effective capabilities (computed from `cap_add` and `cap_drop`) have to match the configured whitelist.
-  The whitelist can be customized using the `docker.cap.whitelist` key in the client node's configuration.
+  The whitelist can be customized using the `docker.caps.whitelist` key in the client node's configuration.
   For example:
 
 


### PR DESCRIPTION
I got bitten by this today, the correct config option is `docker.caps.whitelist` when the documentation mentions `docker.cap.whitelist`