### PR TITLE
Make sure that task group has a deployment state before using it

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -525,10 +525,11 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 	// Final check to see if the deployment is complete is to ensure everything
 	// is healthy
 	if deploymentComplete && a.deployment != nil {
-		dstate := a.deployment.TaskGroups[group]
-		if dstate.HealthyAllocs < helper.IntMax(dstate.DesiredTotal, dstate.DesiredCanaries) || // Make sure we have enough healthy allocs
-			(dstate.DesiredCanaries > 0 && !dstate.Promoted) { // Make sure we are promoted if we have canaries
-			deploymentComplete = false
+		if dstate, ok := a.deployment.TaskGroups[group]; ok {
+			if dstate.HealthyAllocs < helper.IntMax(dstate.DesiredTotal, dstate.DesiredCanaries) || // Make sure we have enough healthy allocs
+				(dstate.DesiredCanaries > 0 && !dstate.Promoted) { // Make sure we are promoted if we have canaries
+				deploymentComplete = false
+			}
 		}
 	}
 


### PR DESCRIPTION
This adds a check before using deployment state from the deployment for a specific task group in the reconciler

I saw similar checks in the [deployment watcher]( https://github.com/hashicorp/nomad/blob/2d940564088a0f00dc4c1e87860ffd0630d4ecf9/nomad/deploymentwatcher/deployment_watcher.go#L512) and [here too]( https://github.com/hashicorp/nomad/blob/2d940564088a0f00dc4c1e87860ffd0630d4ecf9/nomad/deploymentwatcher/deployment_watcher.go#L183) but the reconciler did not do this. 