### PR TITLE
Add test for Segment's `el` object

### DIFF
--- a/website/source/assets/javascripts/analytics.js
+++ b/website/source/assets/javascripts/analytics.js
@@ -1,6 +1,6 @@
 document.addEventListener('turbolinks:load', function() {
   analytics.page()
-  
+  if (typeof el !== 'undefined') {
     var m = el.href.match(/nomad_(.*?)_(.*?)_(.*?)\.zip/)
     return {
       event: 'Download',
@@ -11,5 +11,6 @@ document.addEventListener('turbolinks:load', function() {
       architecture: m[3],
       product: 'nomad'
     }
-  })
+  }
 })
+


### PR DESCRIPTION
This can be prevented from being present because an adblocker.  I tested
with ghostery locally.  When erroring, the user sees the page render, go completely white, and then draw again