### PR TITLE
Bug fix auto revert

### DIFF
--- a/e2e/rescheduling/input/rescheduling_maxp_autorevert.hcl
+++ b/e2e/rescheduling/input/rescheduling_maxp_autorevert.hcl
@@ -10,15 +10,16 @@ job "demo3" {
 
       config {
         command = "bash"
-        args    = ["-c", "sleep 5000"]
+        args    = ["-c", "sleep 15000"]
       }
     }
 
     update {
       max_parallel     = 1
       min_healthy_time = "1s"
-      healthy_deadline = "1m"
       auto_revert      = true
+      healthy_deadline = "2s"
+      progress_deadline = "3s"
     }
 
     restart {

--- a/e2e/rescheduling/server_side_restarts_test.go
+++ b/e2e/rescheduling/server_side_restarts_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Server Side Restart Tests", func() {
 
 		})
 
-		Context("Reschedule with canary and auto revert ", func() {
+		Context("Reschedule with canary, auto revert with short progress deadline ", func() {
 			BeforeEach(func() {
 				specFile = "input/rescheduling_canary_autorevert.hcl"
 			})
@@ -230,11 +230,10 @@ var _ = Describe("Server Side Restart Tests", func() {
 				// Wait for the revert
 				Eventually(allocStatuses, 3*time.Second, time.Second).Should(
 					ConsistOf([]string{"failed", "failed", "failed", "running", "running", "running"}))
-
 				// Verify new deployment and its status
 				// There should be one successful, one failed, and one more successful (after revert)
 				time.Sleep(5 * time.Second) //TODO(preetha) figure out why this wasn't working with ginkgo constructs
-				Eventually(deploymentStatus(), 2*time.Second, time.Second).Should(
+				Eventually(deploymentStatus(), 5*time.Second, time.Second).Should(
 					ConsistOf(structs.DeploymentStatusSuccessful, structs.DeploymentStatusFailed, structs.DeploymentStatusSuccessful))
 			})
 
@@ -273,7 +272,7 @@ var _ = Describe("Server Side Restart Tests", func() {
 
 		})
 
-		Context("Reschedule with max parallel and auto revert true ", func() {
+		Context("Reschedule with max parallel, auto revert true and short progress deadline", func() {
 			BeforeEach(func() {
 				specFile = "input/rescheduling_maxp_autorevert.hcl"
 			})
@@ -292,7 +291,7 @@ var _ = Describe("Server Side Restart Tests", func() {
 				Eventually(allocStatusesRescheduled, 2*time.Second, time.Second).Should(BeEmpty())
 
 				// Wait for the revert
-				Eventually(allocStatuses, 3*time.Second, time.Second).Should(
+				Eventually(allocStatuses, 5*time.Second, time.Second).Should(
 					ConsistOf([]string{"complete", "failed", "running", "running", "running"}))
 
 				// Verify new deployment and its status

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3339,9 +3339,11 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 
 	// Update the progress deadline
 	if pd := state.ProgressDeadline; pd != 0 {
-		// If we are the first placed allocation start the progress deadline.
+		// If we are the first placed allocation for the deployment start the progress deadline.
 		if placed != 0 && state.RequireProgressBy.IsZero() {
-			state.RequireProgressBy = time.Unix(0, alloc.CreateTime).Add(pd)
+			// Use modify time instead of create time becasue we may in-place
+			// update the allocation to be part of a new deployment.
+			state.RequireProgressBy = time.Unix(0, alloc.ModifyTime).Add(pd)
 		} else if healthy != 0 {
 			if d := alloc.DeploymentStatus.Timestamp.Add(pd); d.After(state.RequireProgressBy) {
 				state.RequireProgressBy = d


### PR DESCRIPTION
Fix a bug in the deployment watcher changes to support progress deadline - if its an auto revert the progress deadline still used the create time and incorrectly marked the deployment as failed.