### PR TITLE
Expand drain info for node status command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.8.4 (Unreleased)
 
 IMPROVEMENTS:
+ * cli: Add node drain details to node status [[GH-4247](https://github.com/hashicorp/nomad/issues/4247)]
  * command: add -short option to init command that emits a minimal
    jobspec [[GH-4239](https://github.com/hashicorp/nomad/issues/4239)]
 

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -299,6 +300,26 @@ func nodeDrivers(n *api.Node) []string {
 	return drivers
 }
 
+func formatDrain(n *api.Node) string {
+	if n.DrainStrategy != nil {
+		b := new(strings.Builder)
+		b.WriteString("true")
+
+		if n.DrainStrategy.ForceDeadline.IsZero() {
+			b.WriteString("; no deadline")
+		} else {
+			fmt.Fprintf(b, "; %s deadline", formatTime(n.DrainStrategy.ForceDeadline))
+		}
+
+		if n.DrainStrategy.IgnoreSystemJobs {
+			b.WriteString("; ignoring system jobs")
+		}
+		return b.String()
+	}
+
+	return strconv.FormatBool(n.Drain)
+}
+
 func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 	// Format the header output
 	basic := []string{
@@ -306,7 +327,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		fmt.Sprintf("Name|%s", node.Name),
 		fmt.Sprintf("Class|%s", node.NodeClass),
 		fmt.Sprintf("DC|%s", node.Datacenter),
-		fmt.Sprintf("Drain|%v", node.Drain),
+		fmt.Sprintf("Drain|%v", formatDrain(node)),
 		fmt.Sprintf("Eligibility|%s", node.SchedulingEligibility),
 		fmt.Sprintf("Status|%s", node.Status),
 	}

--- a/command/node_status_test.go
+++ b/command/node_status_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
@@ -249,4 +251,27 @@ func TestNodeStatusCommand_AutocompleteArgs(t *testing.T) {
 	res := predictor.Predict(args)
 	assert.Equal(1, len(res))
 	assert.Equal(nodeID, res[0])
+}
+
+func TestNodeStatusCommand_FormatDrain(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	node := &api.Node{}
+
+	assert.Equal("false", formatDrain(node))
+
+	node.DrainStrategy = &api.DrainStrategy{}
+
+	assert.Equal("true; no deadline", formatDrain(node))
+
+	// formatTime special cases Unix(0, 0), so increment by 1
+	node.DrainStrategy.ForceDeadline = time.Unix(1, 0)
+	t.Logf(node.DrainStrategy.ForceDeadline.String())
+
+	assert.Equal("true; 1970-01-01T00:00:01Z deadline", formatDrain(node))
+
+	node.DrainStrategy.IgnoreSystemJobs = true
+
+	assert.Equal("true; 1970-01-01T00:00:01Z deadline; ignoring system jobs", formatDrain(node))
 }


### PR DESCRIPTION
Prior to this PR `node status` just displayed `Drain = true` or `Drain = false`.

Example of draining node with a deadline and ignoring system jobs:

![image](https://user-images.githubusercontent.com/113362/39553946-efb567be-4e24-11e8-8a13-35b2b35ca899.png)

Example with just a deadline:

![image](https://user-images.githubusercontent.com/113362/39553953-ff408736-4e24-11e8-8cf1-a9b817d2da82.png)

Example with *no* deadline and ignoring system jobs:

![image](https://user-images.githubusercontent.com/113362/39553998-3e6937d2-4e25-11e8-8de9-2183e4133d73.png)

Not draining looks the same (just "false"):

![image](https://user-images.githubusercontent.com/113362/39554048-802b3940-4e25-11e8-9f50-b252f4d7d066.png)
