### PR TITLE
 prevent deadlock in deadline timer

### DIFF
--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -417,7 +417,10 @@ FAIL:
 				// deadlocking on the already stopped deadline timer, we only drain the channel if
 				// the previous deadline was not zero.
 				if !prevDeadlineZero && !deadlineTimer.Stop() {
-					<-deadlineTimer.C
+					select {
+					case <-deadlineTimer.C:
+					default:
+					}
 				}
 				deadlineTimer.Reset(next.Sub(time.Now()))
 			}

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -979,6 +979,7 @@ func TestDeploymentWatcher_PromotedCanary_UpdatedAllocs(t *testing.T) {
 	j.TaskGroups[0].Update.MaxParallel = 1
 	j.TaskGroups[0].Update.ProgressDeadline = 50 * time.Millisecond
 	j.Stable = true
+
 	d := mock.Deployment()
 	d.TaskGroups["web"].DesiredTotal = 2
 	d.TaskGroups["web"].DesiredCanaries = 1
@@ -987,6 +988,7 @@ func TestDeploymentWatcher_PromotedCanary_UpdatedAllocs(t *testing.T) {
 	d.JobID = j.ID
 	d.TaskGroups["web"].ProgressDeadline = 50 * time.Millisecond
 	d.TaskGroups["web"].RequireProgressBy = time.Now().Add(50 * time.Millisecond)
+
 	a := mock.Alloc()
 	now := time.Now()
 	a.CreateTime = now.UnixNano()


### PR DESCRIPTION
This PR fixes a deployment watcher deadlock if the deadline timer channel has previously been drained, and a deployment update causes the `RequireProgressBy` value to change. Before this change, we blocked forever on draining the timer channel which will never fire another event. 

I reproduced this with a canary deployment with a short progress deadline (5s). If the deployment is promoted after the progress deadline, and additional allocs are placed by the scheduler, the deployment watcher never sees those and the deployment stays at "running" forever.