### PR TITLE
Set an API http client read timeout through the deadline

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -282,6 +282,8 @@ func (c *Config) SetTimeout(t time.Duration) error {
 			Timeout:   t,
 			KeepAlive: 30 * time.Second,
 		}).DialContext
+
+		c.httpClient.Timeout = t
 	}
 
 	return nil


### PR DESCRIPTION
By setting the transport timeout we are only applying the timeout to the connection establishment. By adding 1 line in which we set the timeout of the http client we are effectively using a context for each request which in turns allows us to set a read timeout.

I had to do this because some calls, under high concurrency, tend to lock forever.

The specific case happened while building a [prometheus nomad exporter](https://github.com/pcarranza/nomad-exporter) and trying to read the node stats, in some hosts the reads lock forever, blocking the scrape completely and making it seem like a target down.

After adding this line to my vendored version of the API the client read fails as expected once the timeout happens.