### PR TITLE
client/driver/env: interpolate empty optional meta params as empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ IMPROVEMENTS:
  * discovery: Support Consul gRPC health checks. [[GH-4251](https://github.com/hashicorp/nomad/issues/4251)]
  * driver/docker: Add progress monitoring and inactivity detection to docker
    image pulls [[GH-4192](https://github.com/hashicorp/nomad/issues/4192)] 
+ * env: Default interpolation of optional meta fields of parameterized jobs to
+   an empty string rather than the field key. [[GH-3720](https://github.com/hashicorp/nomad/issues/3720)]
 
 ## 0.8.3 (April 27, 2018)
 

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -397,7 +397,23 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 
 	// Set meta
 	combined := alloc.Job.CombinedTaskMeta(alloc.TaskGroup, b.taskName)
-	b.taskMeta = make(map[string]string, len(combined)*2)
+	// taskMetaSize is double to total meta keys to account for given and upper
+	// cased values
+	taskMetaSize := len(combined) * 2
+
+	// if job is parameterized initialize optional meta to empty strings
+	if alloc.Job.IsParameterized() {
+		b.taskMeta = make(map[string]string,
+			taskMetaSize+(len(alloc.Job.ParameterizedJob.MetaOptional)*2))
+
+		for _, k := range alloc.Job.ParameterizedJob.MetaOptional {
+			b.taskMeta[fmt.Sprintf("%s%s", MetaPrefix, strings.ToUpper(k))] = ""
+			b.taskMeta[fmt.Sprintf("%s%s", MetaPrefix, k)] = ""
+		}
+	} else {
+		b.taskMeta = make(map[string]string, taskMetaSize)
+	}
+
 	for k, v := range combined {
 		b.taskMeta[fmt.Sprintf("%s%s", MetaPrefix, strings.ToUpper(k))] = v
 		b.taskMeta[fmt.Sprintf("%s%s", MetaPrefix, k)] = v


### PR DESCRIPTION
fixes #3720