### PR TITLE
Fix the CPU Information error message

### DIFF
--- a/helper/stats/cpu.go
+++ b/helper/stats/cpu.go
@@ -29,7 +29,7 @@ func Init() error {
 
 		var cpuInfo []cpu.InfoStat
 		if cpuInfo, err = cpu.Info(); err != nil {
-			merrs = multierror.Append(merrs, fmt.Errorf("Unable to obtain CPU information: %v", initErr))
+			merrs = multierror.Append(merrs, fmt.Errorf("Unable to obtain CPU information: %v", err))
 		}
 
 		for _, cpu := range cpuInfo {


### PR DESCRIPTION
The version of gopsutil included with the current Nomad version introduces a 3-second timeout that could come up as an error here; however, we are outputting the wrong variable and eating the error.