### PR TITLE
client/driver: use correct repo address when using docker-credential helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ IMPROVEMENTS:
    an empty string rather than the field key. [[GH-3720](https://github.com/hashicorp/nomad/issues/3720)]
 
 BUG FIXES:
- * driver/docker: Fix docker credential helper support [[GH-3818](https://github.com/hashicorp/nomad/issues/3818)] [[GH-4221](https://github.com/hashicorp/nomad/issues/4221)]
+ * driver/docker: Fix docker credential helper support [[GH-4266](https://github.com/hashicorp/nomad/issues/4266)]
 
 ## 0.8.3 (April 27, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ IMPROVEMENTS:
  * env: Default interpolation of optional meta fields of parameterized jobs to
    an empty string rather than the field key. [[GH-3720](https://github.com/hashicorp/nomad/issues/3720)]
 
+BUG FIXES:
+ * driver/docker: Fix docker credential helper support [[GH-3818](https://github.com/hashicorp/nomad/issues/3818)] [[GH-4221](https://github.com/hashicorp/nomad/issues/4221)]
+
 ## 0.8.3 (April 27, 2018)
 
 BUG FIXES:

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -2130,13 +2130,15 @@ func authFromHelper(helperName string) authBackend {
 		helper := dockerAuthHelperPrefix + helperName
 		cmd := exec.Command(helper, "get")
 
-		// Ensure that the HTTPs prefix exists
-		if !strings.HasPrefix(repo, "https://") {
-			repo = fmt.Sprintf("https://%s", repo)
+		repoInfo, err := parseRepositoryInfo(repo)
+		if err != nil {
+			return nil, err
 		}
 
-		cmd.Stdin = strings.NewReader(repo)
+		// Ensure that the HTTPs prefix exists
+		repoAddr := fmt.Sprintf("https://%s", repoInfo.Hostname())
 
+		cmd.Stdin = strings.NewReader(repoAddr)
 		output, err := cmd.Output()
 		if err != nil {
 			switch err.(type) {

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -2130,13 +2130,13 @@ func authFromHelper(helperName string) authBackend {
 		helper := dockerAuthHelperPrefix + helperName
 		cmd := exec.Command(helper, "get")
 
-		repoInfo, err := parseRepositoryInfo(repo)
+		repoParsed, err := reference.ParseNamed(repo)
 		if err != nil {
 			return nil, err
 		}
 
 		// Ensure that the HTTPs prefix exists
-		repoAddr := fmt.Sprintf("https://%s", repoInfo.Hostname())
+		repoAddr := fmt.Sprintf("https://%s", repoParsed.Hostname())
 
 		cmd.Stdin = strings.NewReader(repoAddr)
 		output, err := cmd.Output()

--- a/client/driver/docker_linux_test.go
+++ b/client/driver/docker_linux_test.go
@@ -1,0 +1,41 @@
+package driver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerDriver_authFromHelper(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-docker-driver_authfromhelper")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	helperPayload := "{\"Username\":\"hashi\",\"Secret\":\"nomad\"}"
+	helperContent := []byte(fmt.Sprintf("#!/bin/sh\ncat > %s/helper-$1.out;echo '%s'", dir, helperPayload))
+
+	helperFile := filepath.Join(dir, "docker-credential-testnomad")
+	err = ioutil.WriteFile(helperFile, helperContent, 0777)
+	require.NoError(t, err)
+
+	path := os.Getenv("PATH")
+	os.Setenv("PATH", fmt.Sprintf("%s:%s", path, dir))
+	defer os.Setenv("PATH", path)
+
+	helper := authFromHelper("testnomad")
+	creds, err := helper("registry.local:5000/repo/image")
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	require.Equal(t, "hashi", creds.Username)
+	require.Equal(t, "nomad", creds.Password)
+
+	if _, err := os.Stat(filepath.Join(dir, "helper-get.out")); os.IsNotExist(err) {
+		t.Fatalf("Expected helper-get.out to exist")
+	}
+	content, err := ioutil.ReadFile(filepath.Join(dir, "helper-get.out"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("https://registry.local:5000"), content)
+}

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -2458,33 +2458,3 @@ func TestDockerDriver_AdvertiseIPv6Address(t *testing.T) {
 		t.Fatalf("Got GlobalIPv6address %s want GlobalIPv6address with prefix %s", expectedPrefix, container.NetworkSettings.GlobalIPv6Address)
 	}
 }
-
-func TestDockerDriver_authFromHelper(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-docker-driver_authfromhelper")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	helperPayload := "{\"Username\":\"hashi\",\"Secret\":\"nomad\"}"
-	helperContent := []byte(fmt.Sprintf("#!/bin/sh\ncat > %s/helper-$1.out;echo '%s'", dir, helperPayload))
-
-	helperFile := filepath.Join(dir, "docker-credential-testnomad")
-	err = ioutil.WriteFile(helperFile, helperContent, 0777)
-	require.NoError(t, err)
-
-	path := os.Getenv("PATH")
-	os.Setenv("PATH", fmt.Sprintf("%s:%s", path, dir))
-	defer os.Setenv("PATH", path)
-
-	helper := authFromHelper("testnomad")
-	creds, err := helper("registry.local:5000/repo/image")
-	require.NoError(t, err)
-	require.NotNil(t, creds)
-	require.Equal(t, "hashi", creds.Username)
-	require.Equal(t, "nomad", creds.Password)
-
-	if _, err := os.Stat(filepath.Join(dir, "helper-get.out")); os.IsNotExist(err) {
-		t.Fatalf("Expected helper-get.out to exist")
-	}
-	content, err := ioutil.ReadFile(filepath.Join(dir, "helper-get.out"))
-	require.NoError(t, err)
-	require.Equal(t, []byte("https://registry.local:5000"), content)
-}

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -2458,3 +2458,33 @@ func TestDockerDriver_AdvertiseIPv6Address(t *testing.T) {
 		t.Fatalf("Got GlobalIPv6address %s want GlobalIPv6address with prefix %s", expectedPrefix, container.NetworkSettings.GlobalIPv6Address)
 	}
 }
+
+func TestDockerDriver_authFromHelper(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-docker-driver_authfromhelper")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	helperPayload := "{\"Username\":\"hashi\",\"Secret\":\"nomad\"}"
+	helperContent := []byte(fmt.Sprintf("#!/bin/sh\ncat > %s/helper-$1.out;echo '%s'", dir, helperPayload))
+
+	helperFile := filepath.Join(dir, "docker-credential-testnomad")
+	err = ioutil.WriteFile(helperFile, helperContent, 0777)
+	require.NoError(t, err)
+
+	path := os.Getenv("PATH")
+	os.Setenv("PATH", fmt.Sprintf("%s:%s", path, dir))
+	defer os.Setenv("PATH", path)
+
+	helper := authFromHelper("testnomad")
+	creds, err := helper("registry.local:5000/repo/image")
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	require.Equal(t, "hashi", creds.Username)
+	require.Equal(t, "nomad", creds.Password)
+
+	if _, err := os.Stat(filepath.Join(dir, "helper-get.out")); os.IsNotExist(err) {
+		t.Fatalf("Expected helper-get.out to exist")
+	}
+	content, err := ioutil.ReadFile(filepath.Join(dir, "helper-get.out"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("https://registry.local:5000"), content)
+}


### PR DESCRIPTION
Uses the server address instead of the image repo reference as the input to the docker-credentials helper.

fixes #3818 
fixes #4221 