### PR TITLE
Configurable TLS cipher suites and versions; disallow weak ciphers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ IMPROVEMENTS:
    image pulls [[GH-4192](https://github.com/hashicorp/nomad/issues/4192)] 
  * env: Default interpolation of optional meta fields of parameterized jobs to
    an empty string rather than the field key. [[GH-3720](https://github.com/hashicorp/nomad/issues/3720)]
+ * core: Add the option for operators to configure TLS versions and allowed
+   cipher suites. Default is a subset of safe ciphers and TLS 1.2 [[GH-4269](https://github.com/hashicorp/nomad/pull/4269)]
  * core: Add a new [progress_deadline](https://www.nomadproject.io/docs/job-specification/update.html#progress_deadline) parameter to
    support rescheduling failed allocations during a deployment. This allows operators to specify a configurable deadline before which
    a deployment should see healthy allocations [[GH-4259](https://github.com/hashicorp/nomad/issues/4259)]

--- a/client/client.go
+++ b/client/client.go
@@ -399,11 +399,16 @@ func (c *Client) init() error {
 func (c *Client) reloadTLSConnections(newConfig *nconfig.TLSConfig) error {
 	var tlsWrap tlsutil.RegionWrapper
 	if newConfig != nil && newConfig.EnableRPC {
-		tw, err := tlsutil.NewTLSConfiguration(newConfig).OutgoingTLSWrapper()
+		tw, err := tlsutil.NewTLSConfiguration(newConfig)
 		if err != nil {
 			return err
 		}
-		tlsWrap = tw
+
+		twWrap, err := tw.OutgoingTLSWrapper()
+		if err != nil {
+			return err
+		}
+		tlsWrap = twWrap
 	}
 
 	// Store the new tls wrapper.

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -762,6 +762,7 @@ func parseTLSConfig(result **config.TLSConfig, list *ast.ObjectList) error {
 		"key_file",
 		"verify_https_client",
 		"tls_cipher_suites",
+		"tls_min_version",
 	}
 
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
@@ -779,6 +780,10 @@ func parseTLSConfig(result **config.TLSConfig, list *ast.ObjectList) error {
 	}
 
 	if _, err := tlsutil.ParseCiphers(tlsConfig.TLSCipherSuites); err != nil {
+		return err
+	}
+
+	if _, err := tlsutil.ParseMinVersion(tlsConfig.TLSMinVersion); err != nil {
 		return err
 	}
 

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/tlsutil"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/mitchellh/mapstructure"
 )
@@ -760,6 +761,7 @@ func parseTLSConfig(result **config.TLSConfig, list *ast.ObjectList) error {
 		"cert_file",
 		"key_file",
 		"verify_https_client",
+		"tls_cipher_suites",
 	}
 
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
@@ -773,6 +775,10 @@ func parseTLSConfig(result **config.TLSConfig, list *ast.ObjectList) error {
 
 	var tlsConfig config.TLSConfig
 	if err := mapstructure.WeakDecode(m, &tlsConfig); err != nil {
+		return err
+	}
+
+	if _, err := tlsutil.ParseCiphers(tlsConfig.TLSCipherSuites); err != nil {
 		return err
 	}
 

--- a/helper/tlsutil/config_test.go
+++ b/helper/tlsutil/config_test.go
@@ -491,7 +491,43 @@ func TestConfig_ParseCiphers_Invalid(t *testing.T) {
 	for _, cipher := range invalidCiphers {
 		parsedCiphers, err := ParseCiphers(cipher)
 		require.NotNil(err)
-		require.Equal(fmt.Sprintf("unsupported cipher %q", cipher), err.Error())
+		require.Equal(fmt.Sprintf("unsupported TLS cipher %q", cipher), err.Error())
 		require.Equal(0, len(parsedCiphers))
+	}
+}
+
+func TestConfig_ParseMinVersion_Valid(t *testing.T) {
+	require := require.New(t)
+
+	validVersions := []string{"tls10",
+		"tls11",
+		"tls12",
+	}
+
+	expected := map[string]uint16{
+		"tls10": tls.VersionTLS10,
+		"tls11": tls.VersionTLS11,
+		"tls12": tls.VersionTLS12,
+	}
+
+	for _, version := range validVersions {
+		parsedVersion, err := ParseMinVersion(version)
+		require.Nil(err)
+		require.Equal(expected[version], parsedVersion)
+	}
+}
+
+func TestConfig_ParseMinVersion_Invalid(t *testing.T) {
+	require := require.New(t)
+
+	invalidVersions := []string{"tls13",
+		"tls15",
+	}
+
+	for _, version := range invalidVersions {
+		parsedVersion, err := ParseMinVersion(version)
+		require.NotNil(err)
+		require.Equal(fmt.Sprintf("unsupported TLS version %q", version), err.Error())
+		require.Equal(uint16(0), parsedVersion)
 	}
 }

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -450,7 +450,11 @@ func (s *Server) reloadTLSConnections(newTLSConfig *config.TLSConfig) error {
 		return fmt.Errorf("can't reload uninitialized RPC listener")
 	}
 
-	tlsConf := tlsutil.NewTLSConfiguration(newTLSConfig)
+	tlsConf, err := tlsutil.NewTLSConfiguration(newTLSConfig)
+	if err != nil {
+		return err
+	}
+
 	incomingTLS, tlsWrap, err := getTLSConf(newTLSConfig.EnableRPC, tlsConf)
 	if err != nil {
 		s.logger.Printf("[ERR] nomad: unable to reset TLS context %s", err)

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -452,6 +452,7 @@ func (s *Server) reloadTLSConnections(newTLSConfig *config.TLSConfig) error {
 
 	tlsConf, err := tlsutil.NewTLSConfiguration(newTLSConfig)
 	if err != nil {
+		s.logger.Printf("[ERR] nomad: unable to create TLS configuration %s", err)
 		return err
 	}
 

--- a/nomad/structs/config/tls.go
+++ b/nomad/structs/config/tls.go
@@ -59,6 +59,10 @@ type TLSConfig struct {
 	// TLSCipherSuites are operator-defined ciphers to be used in Nomad TLS
 	// connections
 	TLSCipherSuites string `mapstructure:"tls_cipher_suites"`
+
+	// TLSMinVersion is used to set the minimum TLS version used for TLS
+	// connections. Should be either "tls10", "tls11", or "tls12".
+	TLSMinVersion string `mapstructure:"tls_min_version"`
 }
 
 type KeyLoader struct {
@@ -150,6 +154,9 @@ func (t *TLSConfig) Copy() *TLSConfig {
 	new.KeyFile = t.KeyFile
 	new.RPCUpgradeMode = t.RPCUpgradeMode
 	new.VerifyHTTPSClient = t.VerifyHTTPSClient
+
+	new.TLSCipherSuites = t.TLSCipherSuites
+	new.TLSMinVersion = t.TLSMinVersion
 
 	new.SetChecksum()
 

--- a/nomad/structs/config/tls.go
+++ b/nomad/structs/config/tls.go
@@ -55,6 +55,10 @@ type TLSConfig struct {
 	// Checksum is a MD5 hash of the certificate CA File, Certificate file, and
 	// key file.
 	Checksum string
+
+	// TLSCipherSuites are operator-defined ciphers to be used in Nomad TLS
+	// connections
+	TLSCipherSuites string `mapstructure:"tls_cipher_suites"`
 }
 
 type KeyLoader struct {

--- a/nomad/structs/config/tls_test.go
+++ b/nomad/structs/config/tls_test.go
@@ -171,9 +171,10 @@ func TestTLS_Copy(t *testing.T) {
 		fookey  = "../../../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
 	a := &TLSConfig{
-		CAFile:   cafile,
-		CertFile: foocert,
-		KeyFile:  fookey,
+		CAFile:          cafile,
+		CertFile:        foocert,
+		KeyFile:         fookey,
+		TLSCipherSuites: "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
 	}
 	a.SetChecksum()
 

--- a/website/source/docs/agent/configuration/tls.html.md
+++ b/website/source/docs/agent/configuration/tls.html.md
@@ -64,6 +64,9 @@ the [Agent's Gossip and RPC Encryption](/docs/agent/encryption.html).
   TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, and
   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.
 
+- `tls_min_version` - Specifies the minimum supported version of TLS. Accepted
+  values are "tls10", "tls11", "tls12". Defaults to TLS 1.2.
+
 - `verify_https_client` `(bool: false)` - Specifies agents should require
   client certificates for all incoming HTTPS requests. The client certificates
   must be signed by the same CA as Nomad.

--- a/website/source/docs/agent/configuration/tls.html.md
+++ b/website/source/docs/agent/configuration/tls.html.md
@@ -58,6 +58,12 @@ the [Agent's Gossip and RPC Encryption](/docs/agent/encryption.html).
   cluster is being upgraded to TLS, and removed after the migration is
   complete. This allows the agent to accept both TLS and plaintext traffic.
 
+- `tls_cipher_suites` - Specifies the TLS cipher suites that will be used by
+  the agent. Known insecure ciphers are disabled (3DES and RC4). By default,
+  an agent is configured to use TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+  TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, and
+  TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.
+
 - `verify_https_client` `(bool: false)` - Specifies agents should require
   client certificates for all incoming HTTPS requests. The client certificates
   must be signed by the same CA as Nomad.


### PR DESCRIPTION
By default, TLS 1.2 and a subset of safe ciphers are allowed. If operators want to enable TLS 1.0 and unsafe ciphers, this can be done via the agent configuration. 
