### PR TITLE
Add CLI and API support for forcing rescheduling of failed allocs 

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -224,9 +224,14 @@ func (j *Jobs) Deregister(jobID string, purge bool, q *WriteOptions) (string, *W
 }
 
 // ForceEvaluate is used to force-evaluate an existing job.
-func (j *Jobs) ForceEvaluate(jobID string, q *WriteOptions) (string, *WriteMeta, error) {
+func (j *Jobs) ForceEvaluate(jobID string, opts EvalOptions, q *WriteOptions) (string, *WriteMeta, error) {
+	req := &JobEvaluateRequest{
+		JobID:       jobID,
+		EvalOptions: opts,
+	}
+
 	var resp JobRegisterResponse
-	wm, err := j.client.write("/v1/job/"+jobID+"/evaluate", nil, &resp, q)
+	wm, err := j.client.write("/v1/job/"+jobID+"/evaluate", req, &resp, q)
 	if err != nil {
 		return "", nil, err
 	}
@@ -1031,4 +1036,16 @@ type JobStabilityRequest struct {
 type JobStabilityResponse struct {
 	JobModifyIndex uint64
 	WriteMeta
+}
+
+// JobEvaluateRequest is used when we just need to re-evaluate a target job
+type JobEvaluateRequest struct {
+	JobID       string
+	EvalOptions EvalOptions
+	WriteRequest
+}
+
+// EvalOptions is used to encapsulate options when forcing a job evaluation
+type EvalOptions struct {
+	ForceReschedule bool
 }

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1049,7 +1049,7 @@ func TestJobs_ForceEvaluate(t *testing.T) {
 	jobs := c.Jobs()
 
 	// Force-eval on a non-existent job fails
-	_, _, err := jobs.ForceEvaluate("job1", nil)
+	_, _, err := jobs.ForceEvaluate("job1", EvalOptions{}, nil)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("expected not found error, got: %#v", err)
 	}
@@ -1062,7 +1062,7 @@ func TestJobs_ForceEvaluate(t *testing.T) {
 	assertWriteMeta(t, wm)
 
 	// Try force-eval again
-	evalID, wm, err := jobs.ForceEvaluate("job1", nil)
+	evalID, wm, err := jobs.ForceEvaluate("job1", EvalOptions{}, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -90,8 +90,14 @@ func (s *HTTPServer) jobForceEvaluate(resp http.ResponseWriter, req *http.Reques
 	if req.Method != "PUT" && req.Method != "POST" {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
+
+	evalOptions := structs.EvalOptions{}
+	if _, ok := req.URL.Query()["force"]; ok {
+		evalOptions.ForceReschedule = true
+	}
 	args := structs.JobEvaluateRequest{
-		JobID: jobName,
+		JobID:       jobName,
+		EvalOptions: evalOptions,
 	}
 	s.parseWriteRequest(req, &args.WriteRequest)
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -90,14 +90,25 @@ func (s *HTTPServer) jobForceEvaluate(resp http.ResponseWriter, req *http.Reques
 	if req.Method != "PUT" && req.Method != "POST" {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
+	var args structs.JobEvaluateRequest
 
-	evalOptions := structs.EvalOptions{}
-	if _, ok := req.URL.Query()["force"]; ok {
-		evalOptions.ForceReschedule = true
-	}
-	args := structs.JobEvaluateRequest{
-		JobID:       jobName,
-		EvalOptions: evalOptions,
+	// TODO(preetha) remove in 0.9
+	// For backwards compatibility allow using this endpoint without a payload
+	if req.ContentLength == 0 {
+		args = structs.JobEvaluateRequest{
+			JobID: jobName,
+		}
+	} else {
+		if err := decodeBody(req, &args); err != nil {
+			return nil, CodedError(400, err.Error())
+		}
+		if args.JobID == "" {
+			return nil, CodedError(400, "Job ID must be specified")
+		}
+
+		if jobName != "" && args.JobID != jobName {
+			return nil, CodedError(400, "JobID not same as job name")
+		}
 	}
 	s.parseWriteRequest(req, &args.WriteRequest)
 

--- a/command/commands.go
+++ b/command/commands.go
@@ -270,6 +270,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"job eval": func() (cli.Command, error) {
+			return &JobEvalCommand{
+				Meta: meta,
+			}, nil
+		},
 		"job history": func() (cli.Command, error) {
 			return &JobHistoryCommand{
 				Meta: meta,

--- a/command/job_eval.go
+++ b/command/job_eval.go
@@ -1,0 +1,106 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
+)
+
+type JobEvalCommand struct {
+	Meta
+	forceRescheduling bool
+}
+
+func (c *JobEvalCommand) Help() string {
+	helpText := `
+Usage: nomad job eval [options] <job_id>
+
+  Force an evaluation of the provided job id
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+Eval Options:
+
+  -force-reschedule
+    Force reschedule any failed allocations even if they are not currently
+    eligible for rescheduling
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *JobEvalCommand) Synopsis() string {
+	return "Force evaluating a job using its job id"
+}
+
+func (c *JobEvalCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-force-reschedule": complete.PredictNothing,
+		})
+}
+
+func (c *JobEvalCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := c.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
+}
+
+func (c *JobEvalCommand) Name() string { return "eval" }
+
+func (c *JobEvalCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&c.forceRescheduling, "force-reschedule", false, "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we either got no jobs or exactly one.
+	args = flags.Args()
+	if len(args) > 1 {
+		c.Ui.Error("This command takes either no arguments or one: <job>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	if len(args) == 0 {
+		c.Ui.Error("Must provide a job ID")
+		return 1
+	}
+
+	// Call eval end point
+	jobID := args[0]
+
+	opts := api.EvalOptions{
+		ForceReschedule: c.forceRescheduling,
+	}
+	evalId, _, err := client.Jobs().ForceEvaluate(jobID, opts, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error evaluating job: %s", err))
+		return 1
+	}
+	c.Ui.Output(fmt.Sprintf("Created eval ID: %q ", evalId))
+	return 0
+}

--- a/command/job_eval_test.go
+++ b/command/job_eval_test.go
@@ -1,0 +1,65 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobEvalCommand_Implements(t *testing.T) {
+	t.Parallel()
+	var _ cli.Command = &JobEvalCommand{}
+}
+
+func TestJobEvalCommand_Fails(t *testing.T) {
+	t.Parallel()
+	ui := new(cli.MockUi)
+	cmd := &JobEvalCommand{Meta: Meta{Ui: ui}}
+
+	// Fails on misuse
+	if code := cmd.Run([]string{"some", "bad", "args"}); code != 1 {
+		t.Fatalf("expected exit code 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, commandErrorText(cmd)) {
+		t.Fatalf("expected help output, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Fails when job ID is not specified
+	if code := cmd.Run([]string{}); code != 1 {
+		t.Fatalf("expect exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Must provide a job ID") {
+		t.Fatalf("unexpected error: %v", out)
+	}
+	ui.ErrorWriter.Reset()
+
+}
+
+func TestJobEvalCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &JobEvalCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake job
+	state := srv.Agent.Server().State()
+	j := mock.Job()
+	assert.Nil(state.UpsertJob(1000, j))
+
+	prefix := j.ID[:len(j.ID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(j.ID, res[0])
+}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -39,6 +39,13 @@ var (
 		RTarget: ">= 0.6.1",
 		Operand: structs.ConstraintVersion,
 	}
+
+	// allowRescheduleTransition is the transition that allows failed
+	// allocations to be force rescheduled. We create a one off
+	// variable to avoid creating a new object for every request.
+	allowForceRescheduleTransition = &structs.DesiredTransition{
+		ForceReschedule: helper.BoolToPtr(true),
+	}
 )
 
 // Job endpoint is used for job interactions
@@ -538,6 +545,27 @@ func (j *Job) Evaluate(args *structs.JobEvaluateRequest, reply *structs.JobRegis
 		return fmt.Errorf("can't evaluate parameterized job")
 	}
 
+	forceRescheduleAllocs := make(map[string]*structs.DesiredTransition)
+	if args.EvalOptions.ForceReschedule {
+		// Find any failed allocs that could be force rescheduled
+		allocs, err := snap.AllocsByJob(ws, args.RequestNamespace(), args.JobID, false)
+		if err != nil {
+			return err
+		}
+
+		for _, alloc := range allocs {
+			taskGroup := job.LookupTaskGroup(alloc.TaskGroup)
+			// Forcing rescheduling is only allowed if task group has rescheduling enabled
+			if taskGroup != nil && taskGroup.ReschedulePolicy != nil && taskGroup.ReschedulePolicy.Enabled() {
+				continue
+			}
+
+			if alloc.NextAllocation == "" && alloc.ClientStatus == structs.AllocClientStatusFailed {
+				forceRescheduleAllocs[alloc.ID] = allowForceRescheduleTransition
+			}
+		}
+	}
+
 	// Create a new evaluation
 	eval := &structs.Evaluation{
 		ID:             uuid.Generate(),
@@ -549,13 +577,14 @@ func (j *Job) Evaluate(args *structs.JobEvaluateRequest, reply *structs.JobRegis
 		JobModifyIndex: job.ModifyIndex,
 		Status:         structs.EvalStatusPending,
 	}
-	update := &structs.EvalUpdateRequest{
-		Evals:        []*structs.Evaluation{eval},
-		WriteRequest: structs.WriteRequest{Region: args.Region},
-	}
 
-	// Commit this evaluation via Raft
-	_, evalIndex, err := j.srv.raftApply(structs.EvalUpdateRequestType, update)
+	// Create a AllocUpdateDesiredTransitionRequest request with the eval and any forced rescheduled allocs
+	updateTransitionReq := &structs.AllocUpdateDesiredTransitionRequest{
+		Allocs: forceRescheduleAllocs,
+		Evals:  []*structs.Evaluation{eval},
+	}
+	_, evalIndex, err := j.srv.raftApply(structs.AllocUpdateDesiredTransitionRequestType, updateTransitionReq)
+
 	if err != nil {
 		j.srv.logger.Printf("[ERR] nomad.job: Eval create failed: %v", err)
 		return err

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -546,6 +546,7 @@ func (j *Job) Evaluate(args *structs.JobEvaluateRequest, reply *structs.JobRegis
 	}
 
 	forceRescheduleAllocs := make(map[string]*structs.DesiredTransition)
+
 	if args.EvalOptions.ForceReschedule {
 		// Find any failed allocs that could be force rescheduled
 		allocs, err := snap.AllocsByJob(ws, args.RequestNamespace(), args.JobID, false)
@@ -556,7 +557,7 @@ func (j *Job) Evaluate(args *structs.JobEvaluateRequest, reply *structs.JobRegis
 		for _, alloc := range allocs {
 			taskGroup := job.LookupTaskGroup(alloc.TaskGroup)
 			// Forcing rescheduling is only allowed if task group has rescheduling enabled
-			if taskGroup != nil && taskGroup.ReschedulePolicy != nil && taskGroup.ReschedulePolicy.Enabled() {
+			if taskGroup == nil || taskGroup.ReschedulePolicy == nil || !taskGroup.ReschedulePolicy.Enabled() {
 				continue
 			}
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1297,6 +1297,80 @@ func TestJobEndpoint_Evaluate(t *testing.T) {
 	}
 }
 
+func TestJobEndpoint_ForceRescheduleEvaluate(t *testing.T) {
+	require := require.New(t)
+	t.Parallel()
+	s1 := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0 // Prevent automatic dequeue
+	})
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	job := mock.Job()
+	req := &structs.JobRegisterRequest{
+		Job: job,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	var resp structs.JobRegisterResponse
+	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
+	require.Nil(err)
+	require.NotEqual(0, resp.Index)
+
+	state := s1.fsm.State()
+	job, err = state.JobByID(nil, structs.DefaultNamespace, job.ID)
+
+	// Create a failed alloc
+	alloc := mock.Alloc()
+	alloc.Job = job
+	alloc.JobID = job.ID
+	alloc.TaskGroup = job.TaskGroups[0].Name
+	alloc.Namespace = job.Namespace
+	alloc.ClientStatus = structs.AllocClientStatusFailed
+	err = s1.State().UpsertAllocs(resp.Index+1, []*structs.Allocation{alloc})
+	require.Nil(err)
+
+	// Force a re-evaluation
+	reEval := &structs.JobEvaluateRequest{
+		JobID:       job.ID,
+		EvalOptions: structs.EvalOptions{ForceReschedule: true},
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	err = msgpackrpc.CallWithCodec(codec, "Job.Evaluate", reEval, &resp)
+	require.Nil(err)
+	require.NotEqual(0, resp.Index)
+
+	// Lookup the evaluation
+	ws := memdb.NewWatchSet()
+	eval, err := state.EvalByID(ws, resp.EvalID)
+	require.Nil(err)
+	require.NotNil(eval)
+	require.Equal(eval.CreateIndex, resp.EvalCreateIndex)
+	require.Equal(eval.Priority, job.Priority)
+	require.Equal(eval.Type, job.Type)
+	require.Equal(eval.TriggeredBy, structs.EvalTriggerJobRegister)
+	require.Equal(eval.JobID, job.ID)
+	require.Equal(eval.JobModifyIndex, resp.JobModifyIndex)
+	require.Equal(eval.Status, structs.EvalStatusPending)
+
+	// Lookup the alloc, verify DesiredTransition ForceReschedule
+	alloc, err = state.AllocByID(ws, alloc.ID)
+	require.NotNil(alloc)
+	require.Nil(err)
+	require.True(*alloc.DesiredTransition.ForceReschedule)
+}
+
 func TestJobEndpoint_Evaluate_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1325,6 +1325,7 @@ func TestJobEndpoint_ForceRescheduleEvaluate(t *testing.T) {
 
 	state := s1.fsm.State()
 	job, err = state.JobByID(nil, structs.DefaultNamespace, job.ID)
+	require.Nil(err)
 
 	// Create a failed alloc
 	alloc := mock.Alloc()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -470,6 +470,7 @@ type JobEvaluateRequest struct {
 	WriteRequest
 }
 
+// EvalOptions is used to encapsulate options when forcing a job evaluation
 type EvalOptions struct {
 	ForceReschedule bool
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -465,8 +465,13 @@ type JobDeregisterOptions struct {
 
 // JobEvaluateRequest is used when we just need to re-evaluate a target job
 type JobEvaluateRequest struct {
-	JobID string
+	JobID       string
+	EvalOptions EvalOptions
 	WriteRequest
+}
+
+type EvalOptions struct {
+	ForceReschedule bool
 }
 
 // JobSpecificRequest is used when we just need to specify a target job
@@ -2988,13 +2993,17 @@ func (r *ReschedulePolicy) Copy() *ReschedulePolicy {
 	return nrp
 }
 
+func (r *ReschedulePolicy) Enabled() bool {
+	enabled := r != nil && (r.Attempts > 0 || r.Unlimited)
+	return enabled
+}
+
 // Validate uses different criteria to validate the reschedule policy
 // Delay must be a minimum of 5 seconds
 // Delay Ceiling is ignored if Delay Function is "constant"
 // Number of possible attempts is validated, given the interval, delay and delay function
 func (r *ReschedulePolicy) Validate() error {
-	enabled := r != nil && (r.Attempts > 0 || r.Unlimited)
-	if !enabled {
+	if !r.Enabled() {
 		return nil
 	}
 	var mErr multierror.Error
@@ -5608,6 +5617,11 @@ type DesiredTransition struct {
 	// automatically eligible. An example is an allocation that is part of a
 	// deployment.
 	Reschedule *bool
+
+	// ForceReschedule is used to indicate that this allocation must be rescheduled.
+	// This field is only used when operators want to force a placement even if
+	// a failed allocation is not eligible to be rescheduled
+	ForceReschedule *bool
 }
 
 // Merge merges the two desired transitions, preferring the values from the
@@ -5620,6 +5634,10 @@ func (d *DesiredTransition) Merge(o *DesiredTransition) {
 	if o.Reschedule != nil {
 		d.Reschedule = o.Reschedule
 	}
+
+	if o.ForceReschedule != nil {
+		d.ForceReschedule = o.ForceReschedule
+	}
 }
 
 // ShouldMigrate returns whether the transition object dictates a migration.
@@ -5631,6 +5649,15 @@ func (d *DesiredTransition) ShouldMigrate() bool {
 // rescheduling.
 func (d *DesiredTransition) ShouldReschedule() bool {
 	return d.Reschedule != nil && *d.Reschedule
+}
+
+// ShouldForceReschedule returns whether the transition object dictates a
+// forced rescheduling.
+func (d *DesiredTransition) ShouldForceReschedule() bool {
+	if d == nil {
+		return false
+	}
+	return d.ForceReschedule != nil && *d.ForceReschedule
 }
 
 const (

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -4571,7 +4571,7 @@ func TestReconciler_SuccessfulDeploymentWithFailedAllocs_Reschedule(t *testing.T
 	assertPlaceResultsHavePreviousAllocs(t, 10, r.place)
 }
 
-// Tests rescheduling failed service allocations with desired state stop
+// Tests force rescheduling a failed alloc that is past its reschedule limit
 func TestReconciler_ForceReschedule_Service(t *testing.T) {
 	require := require.New(t)
 

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -327,6 +327,11 @@ func updateByReschedulable(alloc *structs.Allocation, now time.Time, evalID stri
 		return
 	}
 
+	// Check if the allocation is marked as it should be force rescheduled
+	if alloc.DesiredTransition.ShouldForceReschedule() {
+		rescheduleNow = true
+	}
+
 	// Reschedule if the eval ID matches the alloc's followup evalID or if its close to its reschedule time
 	rescheduleTime, eligible := alloc.NextRescheduleTime()
 	if eligible && (alloc.FollowupEvalID == evalID || rescheduleTime.Sub(now) <= rescheduleWindowSize) {


### PR DESCRIPTION
This PR changes the /job/<jobid>/evaluate end point to support specifying a json payload `EvalOptions`. Setting `ForceReschedule` to true will reschedule any failed allocs irrespective of their reschedule eligibility at the time of calling the endpoint. 

If the job does not have rescheduling enabled, setting `ForceReschedule` is a no-op. 

Also added a new CLI `nomad job eval <jobid>` to allow operators to easily force an evaluation without needing to run/register the job with full job hcl. To force an evaluation from the CLI, operators can run `nomad job eval -force-reschedule`