### PR TITLE
driver/docker: pull image with digest

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -2183,16 +2183,17 @@ type createContainerClient interface {
 
 func parseDockerImage(image string) (repo, tag string) {
 	repo, tag = docker.ParseRepositoryTag(image)
-	if tag == "" {
-		if i := strings.IndexRune(image, '@'); i > -1 { // Has digest (@sha256:...)
-			// when pulling images with a digest, the repository contains the sha hash, and the tag is empty
-			// see: https://github.com/fsouza/go-dockerclient/blob/master/image_test.go#L471
-			repo = image
-		} else {
-			tag = "latest"
-		}
+	if tag != "" {
+		return repo, tag
 	}
-	return
+	if i := strings.IndexRune(image, '@'); i > -1 { // Has digest (@sha256:...)
+		// when pulling images with a digest, the repository contains the sha hash, and the tag is empty
+		// see: https://github.com/fsouza/go-dockerclient/blob/master/image_test.go#L471
+		repo = image
+	} else {
+		tag = "latest"
+	}
+	return repo, tag
 }
 
 func dockerImageRef(repo string, tag string) string {

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1500,10 +1500,7 @@ func (d *DockerDriver) Periodic() (bool, time.Duration) {
 // loading it from the file system
 func (d *DockerDriver) createImage(driverConfig *DockerDriverConfig, client *docker.Client, taskDir *allocdir.TaskDir) (string, error) {
 	image := driverConfig.ImageName
-	repo, tag := docker.ParseRepositoryTag(image)
-	if tag == "" {
-		tag = "latest"
-	}
+	repo, tag := parseDockerImage(image)
 
 	coordinator, callerID := d.getDockerCoordinator(client)
 
@@ -1511,7 +1508,7 @@ func (d *DockerDriver) createImage(driverConfig *DockerDriverConfig, client *doc
 	// is "latest", or ForcePull is set, we have to check for a new version every time so we don't
 	// bother to check and cache the id here. We'll download first, then cache.
 	if driverConfig.ForcePull {
-		d.logger.Printf("[DEBUG] driver.docker: force pull image '%s:%s' instead of inspecting local", repo, tag)
+		d.logger.Printf("[DEBUG] driver.docker: force pull image '%s' instead of inspecting local", dockerImageRef(repo, tag))
 	} else if tag != "latest" {
 		if dockerImage, _ := client.InspectImage(image); dockerImage != nil {
 			// Image exists so just increment its reference count
@@ -1544,7 +1541,7 @@ func (d *DockerDriver) pullImage(driverConfig *DockerDriverConfig, client *docke
 		d.logger.Printf("[DEBUG] driver.docker: did not find docker auth for repo %q", repo)
 	}
 
-	d.emitEvent("Downloading image %s:%s", repo, tag)
+	d.emitEvent("Downloading image %s", dockerImageRef(repo, tag))
 	coordinator, callerID := d.getDockerCoordinator(client)
 
 	return coordinator.PullImage(driverConfig.ImageName, authOptions, callerID, d.emitEvent)
@@ -2182,4 +2179,25 @@ type createContainerClient interface {
 	InspectContainer(id string) (*docker.Container, error)
 	ListContainers(docker.ListContainersOptions) ([]docker.APIContainers, error)
 	RemoveContainer(opts docker.RemoveContainerOptions) error
+}
+
+func parseDockerImage(image string) (repo, tag string) {
+	repo, tag = docker.ParseRepositoryTag(image)
+	if tag == "" {
+		if i := strings.IndexRune(image, '@'); i > -1 { // Has digest (@sha256:...)
+			// when pulling images with a digest, the repository contains the sha hash, and the tag is empty
+			// see: https://github.com/fsouza/go-dockerclient/blob/master/image_test.go#L471
+			repo = image
+		} else {
+			tag = "latest"
+		}
+	}
+	return
+}
+
+func dockerImageRef(repo string, tag string) string {
+	if tag == "" {
+		return repo
+	}
+	return fmt.Sprintf("%s:%s", repo, tag)
 }

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1092,6 +1092,30 @@ func TestDockerDriver_ForcePull(t *testing.T) {
 	}
 }
 
+func TestDockerDriver_ForcePull_RepoDigest(t *testing.T) {
+	if !tu.IsTravis() {
+		t.Parallel()
+	}
+	if !testutil.DockerIsConnected(t) {
+		t.Skip("Docker not connected")
+	}
+
+	task, _, _ := dockerTask(t)
+	task.Config["load"] = ""
+	task.Config["image"] = "library/busybox@sha256:58ac43b2cc92c687a32c8be6278e50a063579655fe3090125dcb2af0ff9e1a64"
+	task.Config["force_pull"] = "true"
+
+	client, handle, cleanup := dockerSetup(t, task)
+	defer cleanup()
+
+	waitForExist(t, client, handle)
+
+	_, err := client.InspectContainer(handle.ContainerID())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
 func TestDockerDriver_SecurityOpt(t *testing.T) {
 	if !tu.IsTravis() {
 		t.Parallel()
@@ -2456,5 +2480,29 @@ func TestDockerDriver_AdvertiseIPv6Address(t *testing.T) {
 
 	if !strings.HasPrefix(container.NetworkSettings.GlobalIPv6Address, expectedPrefix) {
 		t.Fatalf("Got GlobalIPv6address %s want GlobalIPv6address with prefix %s", expectedPrefix, container.NetworkSettings.GlobalIPv6Address)
+	}
+}
+
+func TestParseDockerImage(t *testing.T) {
+	tests := []struct {
+		Image string
+		Repo  string
+		Tag   string
+	}{
+		{"library/hello-world:1.0", "library/hello-world", "1.0"},
+		{"library/hello-world", "library/hello-world", "latest"},
+		{"library/hello-world:latest", "library/hello-world", "latest"},
+		{"library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", "library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", ""},
+	}
+	for _, test := range tests {
+		t.Run(test.Image, func(t *testing.T) {
+			repo, tag := parseDockerImage(test.Image)
+			if repo != test.Repo {
+				t.Errorf("expected repo '%s' but got '%s'", test.Repo, repo)
+			}
+			if repo != test.Repo {
+				t.Errorf("expected tag '%s' but got '%s'", test.Tag, tag)
+			}
+		})
 	}
 }

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -2497,12 +2497,8 @@ func TestParseDockerImage(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Image, func(t *testing.T) {
 			repo, tag := parseDockerImage(test.Image)
-			if repo != test.Repo {
-				t.Errorf("expected repo '%s' but got '%s'", test.Repo, repo)
-			}
-			if repo != test.Repo {
-				t.Errorf("expected tag '%s' but got '%s'", test.Tag, tag)
-			}
+			require.Equal(t, test.Repo, repo)
+			require.Equal(t, test.Tag, tag)
 		})
 	}
 }

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -2502,3 +2502,21 @@ func TestParseDockerImage(t *testing.T) {
 		})
 	}
 }
+
+func TestDockerImageRef(t *testing.T) {
+	tests := []struct {
+		Image string
+		Repo  string
+		Tag   string
+	}{
+		{"library/hello-world:1.0", "library/hello-world", "1.0"},
+		{"library/hello-world:latest", "library/hello-world", "latest"},
+		{"library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", "library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", ""},
+	}
+	for _, test := range tests {
+		t.Run(test.Image, func(t *testing.T) {
+			image := dockerImageRef(test.Repo, test.Tag)
+			require.Equal(t, test.Image, image)
+		})
+	}
+}

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -1103,6 +1103,7 @@ func TestDockerDriver_ForcePull_RepoDigest(t *testing.T) {
 	task, _, _ := dockerTask(t)
 	task.Config["load"] = ""
 	task.Config["image"] = "library/busybox@sha256:58ac43b2cc92c687a32c8be6278e50a063579655fe3090125dcb2af0ff9e1a64"
+	localDigest := "sha256:8ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7"
 	task.Config["force_pull"] = "true"
 
 	client, handle, cleanup := dockerSetup(t, task)
@@ -1110,10 +1111,9 @@ func TestDockerDriver_ForcePull_RepoDigest(t *testing.T) {
 
 	waitForExist(t, client, handle)
 
-	_, err := client.InspectContainer(handle.ContainerID())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	container, err := client.InspectContainer(handle.ContainerID())
+	require.NoError(t, err)
+	require.Equal(t, localDigest, container.Image)
 }
 
 func TestDockerDriver_SecurityOpt(t *testing.T) {


### PR DESCRIPTION
Fixes #4290 
Fixes #4211 

Add digest support to the docker driver image config. This commit
factors out some common code to print the repo:tag (dockerImageRef) for
events/logs as well as parsing the image to retreive the repo,tag
(parseDockerImage) so that the results are consistent/sane for both
repo:tag and repo@sha256:... references.

When pulling an image with a digest, the tag is blank and the repo
contains the digest. See:
https://github.com/fsouza/go-dockerclient/blob/master/image_test.go#L471