### PR TITLE
[Docs] Improve docs around Consul ACL token

### DIFF
--- a/website/source/docs/agent/configuration/consul.html.md
+++ b/website/source/docs/agent/configuration/consul.html.md
@@ -103,9 +103,9 @@ configuration, Nomad will automatically connect and configure with Consul.
   communicate with the Consul agent.
 
 - `token` `(string: "")` - Specifies the token used to provide a per-request ACL
-  token. This option overrides the Consul Agent's default token (beware that the 
-  Consul Agent's default token is often an anonymous token which by default doesn't
-  allow writes in Consul).
+  token. This option overrides the Consul Agent's default token. If the token is 
+  not set here or on the Consul agent, it will default to Consul's anonymous policy, 
+  which may or may not allow writes.
 
 - `verify_ssl` `(bool: true)`- Specifies if SSL peer verification should be used
   when communicating to the Consul API client over HTTPS

--- a/website/source/docs/agent/configuration/consul.html.md
+++ b/website/source/docs/agent/configuration/consul.html.md
@@ -103,7 +103,9 @@ configuration, Nomad will automatically connect and configure with Consul.
   communicate with the Consul agent.
 
 - `token` `(string: "")` - Specifies the token used to provide a per-request ACL
-  token. This option overrides the Consul Agent's default token.
+  token. This option overrides the Consul Agent's default token (beware that the 
+  Consul Agent's default token is often an anonymous token which by default doesn't
+  allow writes in Consul).
 
 - `verify_ssl` `(bool: true)`- Specifies if SSL peer verification should be used
   when communicating to the Consul API client over HTTPS


### PR DESCRIPTION
If I'm not mistaken the Consul Agent default token is an anonymous token which doesn't allow writes while a Nomad server needs to write to Consul.