### PR TITLE
Check allocation's desired state in GC eligibility logic

### DIFF
--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -610,6 +610,12 @@ func allocGCEligible(a *structs.Allocation, job *structs.Job, gcTime time.Time, 
 		return true
 	}
 
+	// If the allocation's desired state is Stop, it can be GCed even if it
+	// has failed and hasn't been rescheduled. This can happen during job updates
+	if a.DesiredStatus == structs.AllocDesiredStatusStop {
+		return true
+	}
+
 	// If the alloc hasn't failed then we don't need to consider it for rescheduling
 	// Rescheduling needs to copy over information from the previous alloc so that it
 	// can enforce the reschedule policy


### PR DESCRIPTION
Fixes #4287

The logic that checks for garbage collection eligibility waits for failed allocs to have a replacement ID if it has an unlimited reschedule policy. However, if a job that has failed allocs is updated to a newer version its desired state is "stop" and the GC logic was not taking that into account, causing it to never be eligible for GC. 