### PR TITLE
Fix RPC tunneling when running both client/server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ BUG FIXES:
    [[GH-4234](https://github.com/hashicorp/nomad/issues/4234)]
  * driver/docker: Fix docker credential helper support [[GH-4266](https://github.com/hashicorp/nomad/issues/4266)]
  * driver/docker: Fix panic when docker client configuration options are invalid [[GH-4303](https://github.com/hashicorp/nomad/issues/4303)]
+ * rpc: Fix RPC tunneling when running both client/server on one machine [[GH-4317](https://github.com/hashicorp/nomad/issues/4317)]
 
 ## 0.8.3 (April 27, 2018)
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -322,7 +322,7 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	conf.Servers = a.config.Client.Servers
 	if a.server != nil {
 		conf.Servers = append(conf.Servers,
-			a.config.Addresses.RPC,
+			a.config.normalizedAddrs.RPC,
 			a.config.AdvertiseAddrs.RPC)
 	}
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -314,9 +314,18 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	if conf == nil {
 		conf = clientconfig.DefaultConfig()
 	}
+
+	// If we are running a server, append both its bind and advertise address so
+	// we are able to at least talk to the local server even if that isn't
+	// configured explicitly. This handles both running server and client on one
+	// host and -dev mode.
+	conf.Servers = a.config.Client.Servers
 	if a.server != nil {
-		conf.RPCHandler = a.server
+		conf.Servers = append(conf.Servers,
+			a.config.Addresses.RPC,
+			a.config.AdvertiseAddrs.RPC)
 	}
+
 	conf.LogOutput = a.logOutput
 	conf.LogLevel = a.config.LogLevel
 	conf.DevMode = a.config.DevMode
@@ -333,7 +342,6 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	if a.config.Client.AllocDir != "" {
 		conf.AllocDir = a.config.Client.AllocDir
 	}
-	conf.Servers = a.config.Client.Servers
 	if a.config.Client.NetworkInterface != "" {
 		conf.NetworkInterface = a.config.Client.NetworkInterface
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -321,6 +321,12 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 	// host and -dev mode.
 	conf.Servers = a.config.Client.Servers
 	if a.server != nil {
+		if a.config.AdvertiseAddrs == nil || a.config.AdvertiseAddrs.RPC == "" {
+			return nil, fmt.Errorf("AdvertiseAddrs is nil or empty")
+		} else if a.config.normalizedAddrs == nil || a.config.normalizedAddrs.RPC == "" {
+			return nil, fmt.Errorf("normalizedAddrs is nil or empty")
+		}
+
 		conf.Servers = append(conf.Servers,
 			a.config.normalizedAddrs.RPC,
 			a.config.AdvertiseAddrs.RPC)

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/structs"
 	sconfig "github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1055,5 +1057,26 @@ func TestServer_ShouldReload_ShouldHandleMultipleChanges(t *testing.T) {
 		require.False(shouldReloadAgent)
 		require.False(shouldReloadHTTP)
 		require.False(shouldReloadRPC)
+	}
+}
+
+func TestAgent_ProxyRPC_Dev(t *testing.T) {
+	t.Parallel()
+	agent := NewTestAgent(t, t.Name(), nil)
+	defer agent.Shutdown()
+
+	id := agent.client.NodeID()
+	req := &structs.NodeSpecificRequest{
+		NodeID: id,
+		QueryOptions: structs.QueryOptions{
+			Region: agent.server.Region(),
+		},
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	var resp cstructs.ClientStatsResponse
+	if err := agent.RPC("ClientStats.Stats", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
 	}
 }

--- a/nomad/client_rpc.go
+++ b/nomad/client_rpc.go
@@ -31,6 +31,9 @@ func (s *Server) getNodeConn(nodeID string) (*nodeConnState, bool) {
 	s.nodeConnsLock.RLock()
 	defer s.nodeConnsLock.RUnlock()
 	conns, ok := s.nodeConns[nodeID]
+	if !ok {
+		return nil, false
+	}
 
 	// Return the latest conn
 	var state *nodeConnState


### PR DESCRIPTION
This PR fixes an issue in which clients running in the same process as the
servers (when configured such that server and client are enabled in the
config), would never be registered in the mapping of the node ID to TCP
connection because the client was issuing RPCs directly in-memory.

Fixes https://github.com/hashicorp/nomad/issues/4203