### PR TITLE
UI: XHR keys need to include the method as well

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -49,9 +49,9 @@ export default Watchable.extend({
   xhrKey(url, method, options = {}) {
     const namespace = options.data && options.data.namespace;
     if (namespace) {
-      return `${url}?namespace=${namespace}`;
+      return `${method} ${url}?namespace=${namespace}`;
     }
-    return url;
+    return `${method} ${url}`;
   },
 
   relationshipFallbackLinks: {

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -51,8 +51,8 @@ export default ApplicationAdapter.extend({
     return ajaxOptions;
   },
 
-  xhrKey(url /* method, options */) {
-    return url;
+  xhrKey(url, method /* options */) {
+    return `${method} ${url}`;
   },
 
   findAll(store, type, sinceToken, snapshotRecordArray, additionalParams = {}) {


### PR DESCRIPTION
The URL alone doesn't guarantee uniqueness. This caused a bug where stopping a job (`DELETE /v1/job/:id`) and reading a job (`GET /v1/job/:id`) could abort one another.