### PR TITLE
Include "Docker" in the client driver health event message

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -586,7 +586,7 @@ func (d *DockerDriver) HealthCheck(req *cstructs.HealthCheckRequest, resp *cstru
 
 	d.logger.Printf("[TRACE] driver.docker: docker driver is available and is responsive to `docker ps`")
 	dinfo.Healthy = true
-	dinfo.HealthDescription = "Driver is available and responsive"
+	dinfo.HealthDescription = "Docker driver is available and responsive"
 	resp.AddDriverInfo("docker", dinfo)
 	return nil
 }


### PR DESCRIPTION
Otherwise it reads as "Driver: driver is available and responsive"