### PR TITLE
UI: Remodel task-group-deployment-summary to properly use PlacedCanaries

### DIFF
--- a/ui/app/models/task-group-deployment-summary.js
+++ b/ui/app/models/task-group-deployment-summary.js
@@ -1,4 +1,4 @@
-import { gt } from '@ember/object/computed';
+import { gt, alias } from '@ember/object/computed';
 import Fragment from 'ember-data-model-fragments/fragment';
 import attr from 'ember-data/attr';
 import { fragmentOwner } from 'ember-data-model-fragments/attributes';
@@ -12,7 +12,11 @@ export default Fragment.extend({
   promoted: attr('boolean'),
   requiresPromotion: gt('desiredCanaries', 0),
 
-  placedCanaries: attr('number'),
+  // The list of canary allocation IDs
+  // hasMany is not supported in fragments
+  placedCanaryAllocations: attr({ defaultValue: () => [] }),
+
+  placedCanaries: alias('placedCanaryAllocations.length'),
   desiredCanaries: attr('number'),
   desiredTotal: attr('number'),
   placedAllocs: attr('number'),

--- a/ui/app/serializers/task-group-deployment-summary.js
+++ b/ui/app/serializers/task-group-deployment-summary.js
@@ -1,0 +1,9 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  normalize(typeHash, hash) {
+    hash.PlacedCanaryAllocations = hash.PlacedCanaries || [];
+    delete hash.PlacedCanaries;
+    return this._super(typeHash, hash);
+  },
+});

--- a/ui/mirage/factories/deployment-task-group-summary.js
+++ b/ui/mirage/factories/deployment-task-group-summary.js
@@ -12,8 +12,12 @@ export default Factory.extend({
     return faker.random.number(Math.floor(this.desiredTotal / 2));
   },
 
+  // PlacedCanaries is an array of allocation IDs. Since the IDs aren't currently
+  // used for associating allocations, any random value will do for now.
   placedCanaries() {
-    return faker.random.number(this.desiredCanaries);
+    return Array(faker.random.number(this.desiredCanaries))
+      .fill(null)
+      .map(() => faker.random.uuid());
   },
 
   placedAllocs() {

--- a/ui/tests/acceptance/job-deployments-test.js
+++ b/ui/tests/acceptance/job-deployments-test.js
@@ -5,7 +5,8 @@ import { test } from 'qunit';
 import moment from 'moment';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 
-const sum = (list, key) => list.reduce((sum, item) => sum + get(item, key), 0);
+const sum = (list, key, getter = a => a) =>
+  list.reduce((sum, item) => sum + getter(get(item, key)), 0);
 
 let job;
 let deployments;
@@ -40,9 +41,7 @@ test('/jobs/:id/deployments should list all job deployments', function(assert) {
   });
 });
 
-test('each deployment mentions the deployment shortId, status, version, and time since it was submitted', function(
-  assert
-) {
+test('each deployment mentions the deployment shortId, status, version, and time since it was submitted', function(assert) {
   visit(`/jobs/${job.id}/deployments`);
 
   andThen(() => {
@@ -82,9 +81,7 @@ test('each deployment mentions the deployment shortId, status, version, and time
   });
 });
 
-test('when the deployment is running and needs promotion, the deployment item says so', function(
-  assert
-) {
+test('when the deployment is running and needs promotion, the deployment item says so', function(assert) {
   // Ensure the deployment needs deployment
   const deployment = sortedDeployments.models[0];
   const taskGroupSummary = deployment.deploymentTaskGroupSummaryIds.map(id =>
@@ -96,7 +93,7 @@ test('when the deployment is running and needs promotion, the deployment item sa
 
   taskGroupSummary.update({
     desiredCanaries: 1,
-    placedCanaries: 0,
+    placedCanaries: [],
     promoted: false,
   });
 
@@ -152,7 +149,7 @@ test('when open, a deployment shows the deployment metrics', function(assert) {
     andThen(() => {
       assert.equal(
         find('[data-test-deployment-metric="canaries"]').textContent.trim(),
-        `${sum(taskGroupSummaries, 'placedCanaries')} / ${sum(
+        `${sum(taskGroupSummaries, 'placedCanaries', a => a.length)} / ${sum(
           taskGroupSummaries,
           'desiredCanaries'
         )}`,
@@ -192,9 +189,7 @@ test('when open, a deployment shows the deployment metrics', function(assert) {
   });
 });
 
-test('when open, a deployment shows a list of all task groups and their respective stats', function(
-  assert
-) {
+test('when open, a deployment shows a list of all task groups and their respective stats', function(assert) {
   visit(`/jobs/${job.id}/deployments`);
 
   andThen(() => {
@@ -241,7 +236,7 @@ test('when open, a deployment shows a list of all task groups and their respecti
       );
       assert.equal(
         taskGroupRow.querySelector('[data-test-deployment-task-group-canaries]').textContent.trim(),
-        `${taskGroup.placedCanaries} / ${taskGroup.desiredCanaries}`,
+        `${taskGroup.placedCanaries.length} / ${taskGroup.desiredCanaries}`,
         'Canaries'
       );
       assert.equal(
@@ -265,9 +260,7 @@ test('when open, a deployment shows a list of all task groups and their respecti
   });
 });
 
-test('when open, a deployment shows a list of all allocations for the deployment', function(
-  assert
-) {
+test('when open, a deployment shows a list of all allocations for the deployment', function(assert) {
   visit(`/jobs/${job.id}/deployments`);
 
   andThen(() => {


### PR DESCRIPTION
PlacedCanaries is a `[]string` of allocation IDs, not an `int`.

The result of the UI getting this wrong was whenever the count of placed canaries was shown, it was 0. Now it uses the length of PlacedCanaries.