### PR TITLE
Use Tags when CanaryTags isn't specified

### DIFF
--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -626,7 +626,7 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, t
 
 	// Determine whether to use tags or canary_tags
 	var tags []string
-	if task.Canary {
+	if task.Canary && len(service.CanaryTags) > 0 {
 		tags = make([]string, len(service.CanaryTags))
 		copy(tags, service.CanaryTags)
 	} else {

--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -383,6 +383,11 @@ The `Task` object supports the following keys:
      - `Tags`: A list of string tags associated with this Service. String
        interpolation is supported in tags.
 
+     - `CanaryTags`: A list of string tags associated with this Service while it
+       is a canary. Once the canary is promoted, the registered tags will be
+       updated to the set defined in the `Tags` field. String interpolation is
+       supported in tags.
+
      - `PortLabel`: `PortLabel` is an optional string and is used to associate
        a port with the service.  If specified, the port label must match one
        defined in the resources block.  This could be a label of either a

--- a/website/source/docs/job-specification/service.html.md
+++ b/website/source/docs/job-specification/service.html.md
@@ -112,6 +112,12 @@ does not automatically enable service discovery.
   this service. If this is not supplied, no tags will be assigned to the service
   when it is registered.
 
+- `canary_tags` `(array<string>: [])` - Specifies the list of tags to associate with
+  this service when the service is part of an allocation that is currently a
+  canary. Once the canary is promoted, the registered tags will be updated to
+  those specified in the `tags` parameter. If this is not supplied, the
+  registered tags will be equal to that of the `tags parameter.
+
 - `address_mode` `(string: "auto")` - Specifies what address (host or
   driver-specific) this service should advertise.  This setting is supported in
   Docker since Nomad 0.6 and rkt since Nomad 0.7. See [below for


### PR DESCRIPTION
This PR fixes a bug where we weren't defaulting to `tags` when
`canary_tags` was empty and adds documentation.