### PR TITLE
UI: Use polling instead of streaming for following logs in Safari

### DIFF
--- a/ui/app/utils/classes/poll-logger.js
+++ b/ui/app/utils/classes/poll-logger.js
@@ -30,11 +30,15 @@ export default EmberObject.extend(AbstractLogger, {
 
       if (text) {
         const lines = text.replace(/\}\{/g, '}\n{').split('\n');
-        const frames = lines.map(line => JSON.parse(line));
-        frames.forEach(frame => (frame.Data = window.atob(frame.Data)));
+        const frames = lines
+          .map(line => JSON.parse(line))
+          .filter(frame => frame.Data != null && frame.Offset != null);
 
-        this.set('endOffset', frames[frames.length - 1].Offset);
-        this.get('write')(frames.mapBy('Data').join(''));
+        if (frames.length) {
+          frames.forEach(frame => (frame.Data = window.atob(frame.Data)));
+          this.set('endOffset', frames[frames.length - 1].Offset);
+          this.get('write')(frames.mapBy('Data').join(''));
+        }
       }
 
       yield timeout(interval);

--- a/ui/app/utils/classes/stream-logger.js
+++ b/ui/app/utils/classes/stream-logger.js
@@ -73,5 +73,16 @@ export default EmberObject.extend(AbstractLogger, {
     }
   }),
 }).reopenClass({
-  isSupported: !!window.ReadableStream,
+  isSupported: !!window.ReadableStream && !isSafari(),
 });
+
+// Fetch streaming doesn't work in Safari yet despite all the primitives being in place.
+// Bug: https://bugs.webkit.org/show_bug.cgi?id=185924
+// Until this is fixed, Safari needs to be explicitly targeted for poll-based logging.
+function isSafari() {
+  const oldSafariTest = /constructor/i.test(window.HTMLElement);
+  const newSafariTest = (function(p) {
+    return p.toString() === '[object SafariRemoteNotification]';
+  })(!window['safari'] || (typeof window.safari !== 'undefined' && window.safari.pushNotification));
+  return oldSafariTest || newSafariTest;
+}

--- a/ui/tests/integration/task-log-test.js
+++ b/ui/tests/integration/task-log-test.js
@@ -9,7 +9,7 @@ import { logEncode } from '../../mirage/data/logs';
 const HOST = '1.1.1.1:1111';
 const allowedConnectionTime = 100;
 const commonProps = {
-  interval: 50,
+  interval: 200,
   allocation: {
     id: 'alloc-1',
     node: {


### PR DESCRIPTION
Related WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=185924

Despite having all the requisite primitives and APIs, getting a ReadableStream from a fetch response body in Safari doesn't always work.

For the time being, Safari will instead use the polling-based log watcher, much like IE, Edge, and Firefox use.

I also found a bug in the polling-based log watcher and fixed it.