### PR TITLE
UI: Switch the stop button style to look mildly dangerous

### DIFF
--- a/ui/app/templates/components/two-step-button.hbs
+++ b/ui/app/templates/components/two-step-button.hbs
@@ -1,5 +1,5 @@
 {{#if isIdle}}
-  <button data-test-idle-button type="button" class="button is-warning is-small is-inline" onclick={{action "promptForConfirmation"}}>
+  <button data-test-idle-button type="button" class="button is-danger is-outlined is-important is-small is-inline" onclick={{action "promptForConfirmation"}}>
     {{idleText}}
   </button>
 {{else if isPendingConfirmation}}


### PR DESCRIPTION
This helps add a tone of seriousness to the button without grabbing too much attention. It also nicely separates the stop button from the force launch button.

<img width="411" alt="screen shot 2018-05-25 at 11 56 11 am" src="https://user-images.githubusercontent.com/174740/40561669-dffc8d70-6012-11e8-897b-7032ac7b88fd.png">
<img width="541" alt="screen shot 2018-05-25 at 11 56 02 am" src="https://user-images.githubusercontent.com/174740/40561676-e44965c4-6012-11e8-9623-78aee40183ae.png">
