### PR TITLE
Update 404 page to match other HashiCorp sites

### DIFF
--- a/website/source/404.html.erb
+++ b/website/source/404.html.erb
@@ -1,5 +1,0 @@
----
-noindex: true
----
-
-<h2>Page Not Found</h2>

--- a/website/source/404.html.md
+++ b/website/source/404.html.md
@@ -1,0 +1,14 @@
+---
+layout: "inner"
+page_title: "Not Found"
+noindex: true
+description: |-
+  Page not found!
+---
+
+# Page Not Found
+
+Sorry, the page you tried to visit does not exist. This could be our fault,
+and if so we will fix that up right away.
+
+Please go back to get back on track.


### PR DESCRIPTION
I noticed that Terraform, Vault, Consul, Vagrant, and Packer all have the same 404 page. Nomad was the only exception. This PR syncs Nomad's 404 page with the other products.