### PR TITLE
Update "Nomad vs. Other Software" navigation order and reflect 10k node cluster sizes.

### DIFF
--- a/website/source/intro/vs/kubernetes.html.md
+++ b/website/source/intro/vs/kubernetes.html.md
@@ -35,6 +35,6 @@ into a single system. By default, Nomad is distributed, highly available,
 and operationally simple.
 
 Kubernetes documentation states they can support clusters greater than 5,000 nodes
-and they support a multi-AZ/multi-region configuration. Nomad has been tested
-on clusters up to 5,000 nodes, but is expected to work on much larger clusters as
-well. Nomad also supports multi-datacenter and multi-region configurations.
+and they support a multi-AZ/multi-region configuration. Nomad has been proven to scale 
+to cluster sizes that exceed 10,000 nodes in real-world production environments. Nomad 
+also natively supports multi-datacenter and multi-region configurations.

--- a/website/source/layouts/intro.erb
+++ b/website/source/layouts/intro.erb
@@ -12,33 +12,34 @@
       <li<%= sidebar_current("vs-other") %>>
         <a href="/intro/vs/index.html">Nomad vs. Other Software</a>
         <ul class="nav">
-          <li<%= sidebar_current("vs-other-ecs") %>>
-            <a href="/intro/vs/ecs.html">AWS ECS</a>
-                      </li>
-
-          <li<%= sidebar_current("vs-other-swarm") %>>
-            <a href="/intro/vs/swarm.html">Docker Swarm</a>
-                      </li>
-
-          <li<%= sidebar_current("vs-other-htcondor") %>>
-            <a href="/intro/vs/htcondor.html">HTCondor</a>
-                      </li>
 
           <li<%= sidebar_current("vs-other-kubernetes") %>>
             <a href="/intro/vs/kubernetes.html">Kubernetes</a>
                       </li>
 
           <li<%= sidebar_current("vs-other-mesos") %>>
-            <a href="/intro/vs/mesos.html">Mesos with Aurora, Marathon, etc</a>
+            <a href="/intro/vs/mesos.html">Mesos with Frameworks</a>
                       </li>
+
+          <li<%= sidebar_current("vs-other-swarm") %>>
+            <a href="/intro/vs/swarm.html">Docker Swarm</a>
+                      </li>
+
+          <li<%= sidebar_current("vs-other-ecs") %>>
+            <a href="/intro/vs/ecs.html">AWS ECS</a>
+                      </li>
+
+          <li<%= sidebar_current("vs-other-yarn") %>>
+            <a href="/intro/vs/yarn.html">Hadoop YARN</a>
+          </li>
 
           <li<%= sidebar_current("vs-other-terraform") %>>
             <a href="/intro/vs/terraform.html">Terraform</a>
           </li>
 
-          <li<%= sidebar_current("vs-other-yarn") %>>
-            <a href="/intro/vs/yarn.html">Hadoop YARN</a>
-          </li>
+          <li<%= sidebar_current("vs-other-htcondor") %>>
+            <a href="/intro/vs/htcondor.html">HTCondor</a>
+                      </li>
 
           <li<%= sidebar_current("vs-other-custom") %>>
             <a href="/intro/vs/custom.html">Custom Solutions</a>

--- a/website/source/layouts/intro.erb
+++ b/website/source/layouts/intro.erb
@@ -13,6 +13,22 @@
         <a href="/intro/vs/index.html">Nomad vs. Other Software</a>
         <ul class="nav">
 
+          <li<%= sidebar_current("vs-other-ecs") %>>
+            <a href="/intro/vs/ecs.html">AWS ECS</a>
+                      </li>
+
+          <li<%= sidebar_current("vs-other-swarm") %>>
+            <a href="/intro/vs/swarm.html">Docker Swarm</a>
+                      </li>
+
+          <li<%= sidebar_current("vs-other-yarn") %>>
+            <a href="/intro/vs/yarn.html">Hadoop YARN</a>
+          </li>
+
+          <li<%= sidebar_current("vs-other-htcondor") %>>
+            <a href="/intro/vs/htcondor.html">HTCondor</a>
+                      </li>
+
           <li<%= sidebar_current("vs-other-kubernetes") %>>
             <a href="/intro/vs/kubernetes.html">Kubernetes</a>
                       </li>
@@ -21,29 +37,14 @@
             <a href="/intro/vs/mesos.html">Mesos with Frameworks</a>
                       </li>
 
-          <li<%= sidebar_current("vs-other-swarm") %>>
-            <a href="/intro/vs/swarm.html">Docker Swarm</a>
-                      </li>
-
-          <li<%= sidebar_current("vs-other-ecs") %>>
-            <a href="/intro/vs/ecs.html">AWS ECS</a>
-                      </li>
-
-          <li<%= sidebar_current("vs-other-yarn") %>>
-            <a href="/intro/vs/yarn.html">Hadoop YARN</a>
-          </li>
-
           <li<%= sidebar_current("vs-other-terraform") %>>
             <a href="/intro/vs/terraform.html">Terraform</a>
           </li>
 
-          <li<%= sidebar_current("vs-other-htcondor") %>>
-            <a href="/intro/vs/htcondor.html">HTCondor</a>
-                      </li>
-
           <li<%= sidebar_current("vs-other-custom") %>>
             <a href="/intro/vs/custom.html">Custom Solutions</a>
           </li>
+
         </ul>
       </li>
 


### PR DESCRIPTION
Re-order "Nomad vs. Other Software" section navigation by relevance. Update Kubernetes page to reflect 10k node cluster sizes in production.