### PR TITLE
fix bug with node eligibility staying disabled even after drain is disabled

### DIFF
--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -498,9 +498,7 @@ func (n *Node) UpdateDrain(args *structs.NodeUpdateDrainRequest,
 
 	// Construct the node event
 	args.NodeEvent = structs.NewNodeEvent().SetSubsystem(structs.NodeEventSubsystemDrain)
-	if node.DrainStrategy == nil && args.DrainStrategy == nil {
-		return nil // Nothing to do
-	} else if node.DrainStrategy == nil && args.DrainStrategy != nil {
+	if node.DrainStrategy == nil && args.DrainStrategy != nil {
 		args.NodeEvent.SetMessage(NodeDrainEventDrainSet)
 	} else if node.DrainStrategy != nil && args.DrainStrategy != nil {
 		args.NodeEvent.SetMessage(NodeDrainEventDrainUpdated)


### PR DESCRIPTION
fix bug where disabling a node drain when there is no drain strategy set causes scheduling eligibility to stay ineligible due to an early return.

Fixes test failure `TestNodes_ToggleDrain` in master