### PR TITLE
UI: Node drain and eligibility

### DIFF
--- a/ui/app/helpers/format-duration.js
+++ b/ui/app/helpers/format-duration.js
@@ -1,0 +1,8 @@
+import Helper from '@ember/component/helper';
+import formatDuration from '../utils/format-duration';
+
+function formatDurationHelper([duration], { units }) {
+  return formatDuration(duration, units);
+}
+
+export default Helper.helper(formatDurationHelper);

--- a/ui/app/models/drain-strategy.js
+++ b/ui/app/models/drain-strategy.js
@@ -1,0 +1,12 @@
+import { lt, equal } from '@ember/object/computed';
+import attr from 'ember-data/attr';
+import Fragment from 'ember-data-model-fragments/fragment';
+
+export default Fragment.extend({
+  deadline: attr('number'),
+  forceDeadline: attr('date'),
+  ignoreSystemJobs: attr('boolean'),
+
+  isForced: lt('deadline', 0),
+  hasNoDeadline: equal('deadline', 0),
+});

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -25,6 +25,7 @@ export default Model.extend({
   meta: fragment('node-attributes'),
   resources: fragment('resources'),
   reserved: fragment('resources'),
+  drainStrategy: fragment('drain-strategy'),
 
   isEligible: equal('schedulingEligibility', 'eligible'),
 

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -56,4 +56,10 @@ export default Model.extend({
   unhealthyDriverNames: computed('unhealthyDrivers.@each.name', function() {
     return this.get('unhealthyDrivers').mapBy('name');
   }),
+
+  // A status attribute that includes states not included in node status.
+  // Useful for coloring and sorting nodes
+  compositeStatus: computed('status', 'isEligible', function() {
+    return this.get('isEligible') ? this.get('status') : 'ineligible';
+  }),
 });

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -1,4 +1,5 @@
 import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { hasMany } from 'ember-data/relationships';
@@ -11,6 +12,7 @@ export default Model.extend({
   name: attr('string'),
   datacenter: attr('string'),
   isDraining: attr('boolean'),
+  schedulingEligibility: attr('string'),
   status: attr('string'),
   statusDescription: attr('string'),
   shortId: shortUUIDProperty('id'),
@@ -23,6 +25,8 @@ export default Model.extend({
   meta: fragment('node-attributes'),
   resources: fragment('resources'),
   reserved: fragment('resources'),
+
+  isEligible: equal('schedulingEligibility', 'eligible'),
 
   address: computed('httpAddr', function() {
     return ipParts(this.get('httpAddr')).address;

--- a/ui/app/serializers/drain-strategy.js
+++ b/ui/app/serializers/drain-strategy.js
@@ -1,0 +1,13 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  normalize(typeHash, hash) {
+    // TODO API: finishedAt is always marshaled as a date even when unset.
+    // To simplify things, unset it here when it's the empty date value.
+    if (hash.ForceDeadline === '0001-01-01T00:00:00Z') {
+      hash.ForceDeadline = null;
+    }
+
+    return this._super(typeHash, hash);
+  },
+});

--- a/ui/app/serializers/node.js
+++ b/ui/app/serializers/node.js
@@ -7,6 +7,7 @@ export default ApplicationSerializer.extend({
   config: service(),
 
   attrs: {
+    isDraining: 'Drain',
     httpAddr: 'HTTPAddr',
   },
 

--- a/ui/app/styles/components/node-status-light.scss
+++ b/ui/app/styles/components/node-status-light.scss
@@ -26,4 +26,8 @@ $size: 0.75em;
       darken($grey-lighter, 25%) 6px
     );
   }
+
+  &.ineligible {
+    background: $warning;
+  }
 }

--- a/ui/app/styles/components/status-text.scss
+++ b/ui/app/styles/components/status-text.scss
@@ -1,4 +1,6 @@
 .status-text {
+  font-weight: $weight-semibold;
+
   &.node-ready {
     color: $nomad-green-dark;
   }
@@ -9,5 +11,14 @@
 
   &.node-initializing {
     color: $grey;
+  }
+
+  @each $name, $pair in $colors {
+    $color: nth($pair, 1);
+    $color-invert: nth($pair, 2);
+
+    &.is-#{$name} {
+      color: $color;
+    }
   }
 }

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -9,7 +9,7 @@
 {{#gutter-menu class="page-body"}}
   <section class="section">
     <h1 data-test-title class="title">
-      <span data-test-node-status="{{model.status}}" class="node-status-light {{model.status}}"></span>
+      <span data-test-node-status="{{model.compositeStatus}}" class="node-status-light {{model.compositeStatus}}"></span>
       {{or model.name model.shortId}}
       <span class="tag is-hollow is-small no-text-transform">{{model.id}}</span>
     </h1>

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -61,7 +61,7 @@
       <div class="boxed-section is-small is-info">
         <div class="boxed-section-body inline-definitions">
           <span class="label">Drain Strategy</span>
-          <span class="pair">
+          <span class="pair" data-test-drain-deadline>
             <span class="term">Deadline</span>
             {{#if model.drainStrategy.isForced}}
               <span class="badge is-danger">Forced Drain</span>
@@ -72,13 +72,13 @@
             {{/if}}
           </span>
           {{#if model.drainStrategy.forceDeadline}}
-            <span class="pair">
+            <span class="pair" data-test-drain-forced-deadline>
               <span class="term">Forced Deadline</span>
               {{moment-format model.drainStrategy.forceDeadline "MM/DD/YY HH:mm:ss"}}
               ({{moment-from-now model.drainStrategy.forceDeadline interval=1000}})
             </span>
           {{/if}}
-          <span class="pair">
+          <span class="pair" data-test-drain-ignore-system-jobs>
             <span class="term">Ignore System Jobs?</span>
             {{if model.drainStrategy.ignoreSystemJobs "Yes" "No"}}
           </span>

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -57,6 +57,35 @@
       </div>
     </div>
 
+    {{#if model.drainStrategy}}
+      <div class="boxed-section is-small is-info">
+        <div class="boxed-section-body inline-definitions">
+          <span class="label">Drain Strategy</span>
+          <span class="pair">
+            <span class="term">Deadline</span>
+            {{#if model.drainStrategy.isForced}}
+              <span class="badge is-danger">Forced Drain</span>
+            {{else if model.drainStrategy.hasNoDeadline}}
+              No deadline
+            {{else}}
+              {{format-duration model.drainStrategy.deadline}}
+            {{/if}}
+          </span>
+          {{#if model.drainStrategy.forceDeadline}}
+            <span class="pair">
+              <span class="term">Forced Deadline</span>
+              {{moment-format model.drainStrategy.forceDeadline "MM/DD/YY HH:mm:ss"}}
+              ({{moment-from-now model.drainStrategy.forceDeadline interval=1000}})
+            </span>
+          {{/if}}
+          <span class="pair">
+            <span class="term">Ignore System Jobs?</span>
+            {{if model.drainStrategy.ignoreSystemJobs "Yes" "No"}}
+          </span>
+        </div>
+      </div>
+    {{/if}}
+
     <div class="boxed-section">
       <div class="boxed-section-head">
         <div>Allocations <span class="badge is-white">{{model.allocations.length}}</span></div>

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -25,6 +25,22 @@
           <span class="term">Address</span>
           {{model.httpAddr}}
         </span>
+        <span class="pair" data-test-draining>
+          <span class="term">Draining</span>
+          {{#if model.isDraining}}
+            <span class="status-text is-info">true</span>
+          {{else}}
+            false
+          {{/if}}
+        </span>
+        <span class="pair" data-test-eligibility>
+          <span class="term">Eligibility</span>
+          {{#if model.isEligible}}
+            {{model.schedulingEligibility}}
+          {{else}}
+            <span class="status-text is-warning">{{model.schedulingEligibility}}</span>
+          {{/if}}
+        </span>
         <span class="pair" data-test-datacenter-definition>
           <span class="term">Datacenter</span>
           {{model.datacenter}}

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -27,8 +27,9 @@
             {{#t.sort-by prop="id"}}ID{{/t.sort-by}}
             {{#t.sort-by class="is-200px is-truncatable" prop="name"}}Name{{/t.sort-by}}
             {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
+            {{#t.sort-by prop="isDraining"}}Drain{{/t.sort-by}}
+            {{#t.sort-by prop="schedulingEligibility"}}Eligibility{{/t.sort-by}}
             <th>Address</th>
-            <th>Port</th>
             {{#t.sort-by prop="datacenter"}}Datacenter{{/t.sort-by}}
             <th># Allocs</th>
           {{/t.head}}

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -8,8 +8,9 @@
 <td data-test-client-id>{{#link-to "clients.client" node.id class="is-primary"}}{{node.shortId}}{{/link-to}}</td>
 <td data-test-client-name class="is-200px is-truncatable" title="{{node.name}}">{{node.name}}</td>
 <td data-test-client-status>{{node.status}}</td>
-<td data-test-client-address>{{node.address}}</td>
-<td data-test-client-port>{{node.port}}</td>
+<td data-test-client-drain>{{if node.isDraining "true" "false"}}</td>
+<td data-test-client-eligibility>{{node.schedulingEligibility}}</td>
+<td data-test-client-address>{{node.httpAddr}}</td>
 <td data-test-client-datacenter>{{node.datacenter}}</td>
 <td data-test-client-allocations>
   {{#if node.allocations.isPending}}

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -8,8 +8,20 @@
 <td data-test-client-id>{{#link-to "clients.client" node.id class="is-primary"}}{{node.shortId}}{{/link-to}}</td>
 <td data-test-client-name class="is-200px is-truncatable" title="{{node.name}}">{{node.name}}</td>
 <td data-test-client-status>{{node.status}}</td>
-<td data-test-client-drain>{{if node.isDraining "true" "false"}}</td>
-<td data-test-client-eligibility>{{node.schedulingEligibility}}</td>
+<td data-test-client-drain>
+  {{#if node.isDraining}}
+    <span class="status-text is-info">true</span>
+  {{else}}
+    false
+  {{/if}}
+</td>
+<td data-test-client-eligibility>
+  {{#if node.isEligible}}
+    {{node.schedulingEligibility}}
+  {{else}}
+    <span class="status-text is-warning">{{node.schedulingEligibility}}</span>
+  {{/if}}
+</td>
 <td data-test-client-address>{{node.httpAddr}}</td>
 <td data-test-client-datacenter>{{node.datacenter}}</td>
 <td data-test-client-allocations>

--- a/ui/app/utils/format-duration.js
+++ b/ui/app/utils/format-duration.js
@@ -1,0 +1,47 @@
+import moment from 'moment';
+
+const allUnits = [
+  { name: 'years', suffix: 'year', inMoment: true, pluralizable: true },
+  { name: 'months', suffix: 'month', inMoment: true, pluralizable: true },
+  { name: 'days', suffix: 'day', inMoment: true, pluralizable: true },
+  { name: 'hours', suffix: 'h', inMoment: true, pluralizable: false },
+  { name: 'minutes', suffix: 'm', inMoment: true, pluralizable: false },
+  { name: 'seconds', suffix: 's', inMoment: true, pluralizable: false },
+  { name: 'milliseconds', suffix: 'ms', inMoment: true, pluralizable: false },
+  { name: 'microseconds', suffix: 'µs', inMoment: false, pluralizable: false },
+  { name: 'nanoseconds', suffix: 'ns', inMoment: false, pluralizable: false },
+];
+
+export default function formatDuration(duration = 0, units = 'ns') {
+  const durationParts = {};
+
+  if (units === 'ns') {
+    durationParts.nanoseconds = duration % 1000;
+    durationParts.microseconds = Math.floor((duration % 1000000) / 1000);
+    duration = Math.floor(duration / 1000000);
+  } else if (units === 'mms') {
+    durationParts.microseconds = duration % 1000;
+    duration = Math.floor(duration / 1000);
+  }
+
+  const momentDuration = moment.duration(duration, ['ns', 'mms'].includes(units) ? 'ms' : units);
+
+  allUnits
+    .filterBy('inMoment')
+    .mapBy('name')
+    .forEach(unit => {
+      durationParts[unit] = momentDuration[unit]();
+    });
+
+  const displayParts = allUnits.reduce((parts, unitType) => {
+    if (durationParts[unitType.name]) {
+      const count = durationParts[unitType.name];
+      const suffix =
+        count === 1 || !unitType.pluralizable ? unitType.suffix : unitType.suffix.pluralize();
+      parts.push(`${count}${unitType.pluralizable ? ' ' : ''}${suffix}`);
+    }
+    return parts;
+  }, []);
+
+  return displayParts.join(' ');
+}

--- a/ui/mirage/factories/node.js
+++ b/ui/mirage/factories/node.js
@@ -41,6 +41,26 @@ export default Factory.extend({
     },
   }),
 
+  forcedDraining: trait({
+    drain: true,
+    schedulingEligibility: 'ineligible',
+    drainStrategy: {
+      Deadline: -1,
+      ForceDeadline: '0001-01-01T00:00:00Z',
+      IgnoreSystemJobs: faker.random.boolean(),
+    },
+  }),
+
+  noDeadlineDraining: trait({
+    drain: true,
+    schedulingEligibility: 'ineligible',
+    drainStrategy: {
+      Deadline: 0,
+      ForceDeadline: '0001-01-01T00:00:00Z',
+      IgnoreSystemJobs: faker.random.boolean(),
+    },
+  }),
+
   drainStrategy: null,
 
   drivers: makeDrivers,

--- a/ui/tests/acceptance/nodes-list-test.js
+++ b/ui/tests/acceptance/nodes-list-test.js
@@ -2,7 +2,6 @@ import { click, find, findAll, currentURL, visit } from 'ember-native-dom-helper
 import { test } from 'qunit';
 import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
 import { findLeader } from '../../mirage/config';
-import ipParts from 'nomad-ui/utils/ip-parts';
 
 function minimumSetup() {
   server.createList('node', 1);
@@ -47,7 +46,6 @@ test('each client record should show high-level info of the client', function(as
   andThen(() => {
     const nodeRow = find('[data-test-client-node-row]');
     const allocations = server.db.allocations.where({ nodeId: node.id });
-    const { address, port } = ipParts(node.httpAddr);
 
     assert.equal(
       nodeRow.querySelector('[data-test-client-id]').textContent.trim(),
@@ -65,11 +63,19 @@ test('each client record should show high-level info of the client', function(as
       'Status'
     );
     assert.equal(
-      nodeRow.querySelector('[data-test-client-address]').textContent.trim(),
-      address,
-      'Address'
+      nodeRow.querySelector('[data-test-client-drain]').textContent.trim(),
+      node.drain + '',
+      'Draining'
     );
-    assert.equal(nodeRow.querySelector('[data-test-client-port]').textContent.trim(), port, 'Port');
+    assert.equal(
+      nodeRow.querySelector('[data-test-client-eligibility]').textContent.trim(),
+      node.schedulingEligibility,
+      'Eligibility'
+    );
+    assert.equal(
+      nodeRow.querySelector('[data-test-client-address]').textContent.trim(),
+      node.httpAddr
+    );
     assert.equal(
       nodeRow.querySelector('[data-test-client-datacenter]').textContent.trim(),
       node.datacenter,
@@ -108,9 +114,7 @@ test('when there are no clients, there is an empty message', function(assert) {
   });
 });
 
-test('when there are clients, but no matches for a search term, there is an empty message', function(
-  assert
-) {
+test('when there are clients, but no matches for a search term, there is an empty message', function(assert) {
   server.createList('agent', 1);
   server.create('node', { name: 'node' });
 
@@ -126,9 +130,7 @@ test('when there are clients, but no matches for a search term, there is an empt
   });
 });
 
-test('when accessing clients is forbidden, show a message with a link to the tokens page', function(
-  assert
-) {
+test('when accessing clients is forbidden, show a message with a link to the tokens page', function(assert) {
   server.create('agent');
   server.create('node', { name: 'node' });
   server.pretender.get('/v1/nodes', () => [403, {}, null]);
@@ -236,9 +238,7 @@ test('each server should link to the server detail page', function(assert) {
   });
 });
 
-test('when accessing servers is forbidden, show a message with a link to the tokens page', function(
-  assert
-) {
+test('when accessing servers is forbidden, show a message with a link to the tokens page', function(assert) {
   server.create('agent');
   server.pretender.get('/v1/agent/members', () => [403, {}, null]);
 

--- a/ui/tests/unit/utils/format-duration-test.js
+++ b/ui/tests/unit/utils/format-duration-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'ember-qunit';
+import formatDuration from 'nomad-ui/utils/format-duration';
+
+module('Unit | Util | formatDuration');
+
+test('When all units have values, all units are displayed', function(assert) {
+  const expectation = '39 years 1 month 13 days 23h 31m 30s 987ms 654µs 400ns';
+  assert.equal(formatDuration(1234567890987654321), expectation, expectation);
+});
+
+test('Any unit without values gets dropped from the display', function(assert) {
+  const expectation = '14 days 6h 56m 890ms 980µs';
+  assert.equal(formatDuration(1234560890980000), expectation, expectation);
+});
+
+test('The units option allows for units coarser than nanoseconds', function(assert) {
+  const expectation1 = '1s 200ms';
+  const expectation2 = '20m';
+  const expectation3 = '1 month 1 day';
+  assert.equal(formatDuration(1200, 'ms'), expectation1, expectation1);
+  assert.equal(formatDuration(1200, 's'), expectation2, expectation2);
+  assert.equal(formatDuration(32, 'd'), expectation3, expectation3);
+});

--- a/ui/tests/unit/utils/format-duration-test.js
+++ b/ui/tests/unit/utils/format-duration-test.js
@@ -21,3 +21,8 @@ test('The units option allows for units coarser than nanoseconds', function(asse
   assert.equal(formatDuration(1200, 's'), expectation2, expectation2);
   assert.equal(formatDuration(32, 'd'), expectation3, expectation3);
 });
+
+test('When duration is 0, 0 is shown in terms of the units provided to the function', function(assert) {
+  assert.equal(formatDuration(0), '0ns', 'formatDuration(0) -> 0ns');
+  assert.equal(formatDuration(0, 'year'), '0 years', 'formatDuration(0, "year") -> 0 years');
+});


### PR DESCRIPTION
**Changes to clients list:**
  1. Address and Port columns are now merged
  2. New drain column with blue text when a node is draining
  3. New eligibility column with orange text when a node is ineligible for scheduling

**Changes to client detail:**
  1. New orange status light when a node is ineligible for scheduling
  2. Drain and eligibility status in the Client Details information strip
  3. New Drain information strip when a node is draining, includes states for
      1. Drain with a deadline
      2. Drain with no deadline
      3. Forced drain

_Clients list with a client that is draining_
<img width="1229" alt="screen shot 2018-05-30 at 12 44 09 am" src="https://user-images.githubusercontent.com/174740/40740196-06d29ce4-63fd-11e8-9289-ebfcc256eb34.png">

_Client detail for a client that is draining with a deadline_
<img width="1220" alt="screen shot 2018-05-30 at 12 50 03 am" src="https://user-images.githubusercontent.com/174740/40740217-12daafea-63fd-11e8-9d4c-2d37b6a8980c.png">

_Client detail for client that is force-draining (rare to see given the nature of a forced drain)_
<img width="1216" alt="screen shot 2018-05-30 at 11 24 28 am" src="https://user-images.githubusercontent.com/174740/40740264-3c4c487a-63fd-11e8-9b09-665c2b864d24.png">
