### PR TITLE
Deployment adds JobSpecModifyIndex

### DIFF
--- a/api/deployments.go
+++ b/api/deployments.go
@@ -125,17 +125,44 @@ func (d *Deployments) SetAllocHealth(deploymentID string, healthy, unhealthy []s
 
 // Deployment is used to serialize an deployment.
 type Deployment struct {
-	ID                string
-	Namespace         string
-	JobID             string
-	JobVersion        uint64
-	JobModifyIndex    uint64
-	JobCreateIndex    uint64
-	TaskGroups        map[string]*DeploymentState
-	Status            string
+	// ID is a generated UUID for the deployment
+	ID string
+
+	// Namespace is the namespace the deployment is created in
+	Namespace string
+
+	// JobID is the job the deployment is created for
+	JobID string
+
+	// JobVersion is the version of the job at which the deployment is tracking
+	JobVersion uint64
+
+	// JobModifyIndex is the modify index of the job at which the deployment is
+	// tracking. This is the ModifyIndex field on the job.
+	JobModifyIndex uint64
+
+	// JobSpecModifyIndex is the modify index of the job spec at which the
+	// deployment is tracking. This is the JobModifyIndex field on the job.
+	JobSpecModifyIndex uint64
+
+	// JobCreateIndex is the create index of the job which the deployment is
+	// tracking. It is needed so that if the job gets stopped and reran we can
+	// present the correct list of deployments for the job and not old ones.
+	JobCreateIndex uint64
+
+	// TaskGroups is the set of task groups effected by the deployment and their
+	// current deployment status.
+	TaskGroups map[string]*DeploymentState
+
+	// The status of the deployment
+	Status string
+
+	// StatusDescription allows a human readable description of the deployment
+	// status.
 	StatusDescription string
-	CreateIndex       uint64
-	ModifyIndex       uint64
+
+	CreateIndex uint64
+	ModifyIndex uint64
 }
 
 // DeploymentState tracks the state of a deployment for a given task group.

--- a/api/deployments.go
+++ b/api/deployments.go
@@ -137,12 +137,12 @@ type Deployment struct {
 	// JobVersion is the version of the job at which the deployment is tracking
 	JobVersion uint64
 
-	// JobModifyIndex is the modify index of the job at which the deployment is
-	// tracking. This is the ModifyIndex field on the job.
+	// JobModifyIndex is the ModifyIndex of the job which the deployment is
+	// tracking.
 	JobModifyIndex uint64
 
-	// JobSpecModifyIndex is the modify index of the job spec at which the
-	// deployment is tracking. This is the JobModifyIndex field on the job.
+	// JobSpecModifyIndex is the JobModifyIndex of the job which the
+	// deployment is tracking.
 	JobSpecModifyIndex uint64
 
 	// JobCreateIndex is the create index of the job which the deployment is

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5425,8 +5425,13 @@ type Deployment struct {
 	// JobVersion is the version of the job at which the deployment is tracking
 	JobVersion uint64
 
-	// JobModifyIndex is the modify index of the job at which the deployment is tracking
+	// JobModifyIndex is the modify index of the job at which the deployment is
+	// tracking. This is the ModifyIndex field on the job.
 	JobModifyIndex uint64
+
+	// JobSpecModifyIndex is the modify index of the job spec at which the
+	// deployment is tracking. This is the JobModifyIndex field on the job.
+	JobSpecModifyIndex uint64
 
 	// JobCreateIndex is the create index of the job which the deployment is
 	// tracking. It is needed so that if the job gets stopped and reran we can
@@ -5451,15 +5456,16 @@ type Deployment struct {
 // NewDeployment creates a new deployment given the job.
 func NewDeployment(job *Job) *Deployment {
 	return &Deployment{
-		ID:                uuid.Generate(),
-		Namespace:         job.Namespace,
-		JobID:             job.ID,
-		JobVersion:        job.Version,
-		JobModifyIndex:    job.ModifyIndex,
-		JobCreateIndex:    job.CreateIndex,
-		Status:            DeploymentStatusRunning,
-		StatusDescription: DeploymentStatusDescriptionRunning,
-		TaskGroups:        make(map[string]*DeploymentState, len(job.TaskGroups)),
+		ID:                 uuid.Generate(),
+		Namespace:          job.Namespace,
+		JobID:              job.ID,
+		JobVersion:         job.Version,
+		JobModifyIndex:     job.ModifyIndex,
+		JobSpecModifyIndex: job.JobModifyIndex,
+		JobCreateIndex:     job.CreateIndex,
+		Status:             DeploymentStatusRunning,
+		StatusDescription:  DeploymentStatusDescriptionRunning,
+		TaskGroups:         make(map[string]*DeploymentState, len(job.TaskGroups)),
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5425,12 +5425,12 @@ type Deployment struct {
 	// JobVersion is the version of the job at which the deployment is tracking
 	JobVersion uint64
 
-	// JobModifyIndex is the modify index of the job at which the deployment is
-	// tracking. This is the ModifyIndex field on the job.
+	// JobModifyIndex is the ModifyIndex of the job which the deployment is
+	// tracking.
 	JobModifyIndex uint64
 
-	// JobSpecModifyIndex is the modify index of the job spec at which the
-	// deployment is tracking. This is the JobModifyIndex field on the job.
+	// JobSpecModifyIndex is the JobModifyIndex of the job which the
+	// deployment is tracking.
 	JobSpecModifyIndex uint64
 
 	// JobCreateIndex is the create index of the job which the deployment is

--- a/website/source/api/deployments.html.md
+++ b/website/source/api/deployments.html.md
@@ -52,6 +52,7 @@ $ curl \
     "JobID": "example",
     "JobVersion": 1,
     "JobModifyIndex": 17,
+    "JobSpecModifyIndex": 17,
     "JobCreateIndex": 7,
     "TaskGroups": {
       "cache": {
@@ -108,6 +109,7 @@ $ curl \
   "JobID": "example",
   "JobVersion": 1,
   "JobModifyIndex": 17,
+  "JobSpecModifyIndex": 17,
   "JobCreateIndex": 7,
   "TaskGroups": {
     "cache": {


### PR DESCRIPTION
Deployment tracks the Job.JobModifyIndex so that PUTS against /v1/jobs
can be more easily coorelated with the created deployment.

Fixes https://github.com/hashicorp/nomad/issues/4301