### PR TITLE
Update README.md

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,7 +16,7 @@ to bootstrap a local staging environment:
 
 ```bash
 $ git clone git@github.com:hashicorp/nomad.git
-$ cd terraform
+$ cd nomad/terraform
 $ vagrant up && vagrant ssh
 ```
 


### PR DESCRIPTION
git-clone'ing doesn't automatically jump you into the dir, so this doc update fixes a missing step