### PR TITLE
README: use newer command

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -37,7 +37,7 @@ properly:
 
 ```bash
 $ consul members
-$ nomad server-members
+$ nomad server members
 $ nomad node-status
 ```
 


### PR DESCRIPTION
Got a warning message:

```
WARNING! The "nomad server-members" command is deprecated. Please use "nomad
server members" instead. This command will be removed in Nomad 0.10 (or
later).
```