### PR TITLE
README: newer Vault init command

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -46,7 +46,7 @@ $ nomad node-status
 To initialize and unseal Vault, run:
 
 ```bash
-$ vault init -key-shares=1 -key-threshold=1
+$ vault operator init -key-shares=1 -key-threshold=1
 $ vault unseal
 $ export VAULT_TOKEN=[INITIAL_ROOT_TOKEN]
 ```


### PR DESCRIPTION
Got a warning message:

```
WARNING! The "vault init" command is deprecated. Please use "vault operator
init" instead. This command will be removed in Vault 0.11 (or later).
```