### PR TITLE
Fix reconciler bug with deployment not being created

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -500,7 +500,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 	updatingSpec := len(destructive) != 0 || len(a.result.inplaceUpdate) != 0
 	hadRunning := false
 	for _, alloc := range all {
-		if alloc.Job.Version == a.job.Version {
+		if alloc.Job.Version == a.job.Version && alloc.Job.CreateIndex == a.job.CreateIndex {
 			hadRunning = true
 			break
 		}

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -2537,6 +2537,52 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Inplace(t *testing.T) {
 	})
 }
 
+// Tests the reconciler creates a deployment when the job has a newer create index
+func TestReconciler_CreateDeployment_NewerCreateIndex(t *testing.T) {
+	jobOld := mock.Job()
+	job := jobOld.Copy()
+	job.TaskGroups[0].Update = noCanaryUpdate
+	job.CreateIndex = 100
+
+	// Create 5 allocations from the old job
+	var allocs []*structs.Allocation
+	for i := 0; i < 5; i++ {
+		alloc := mock.Alloc()
+		alloc.Job = jobOld
+		alloc.JobID = jobOld.ID
+		alloc.NodeID = uuid.Generate()
+		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		alloc.TaskGroup = job.TaskGroups[0].Name
+		allocs = append(allocs, alloc)
+	}
+
+	reconciler := NewAllocReconciler(testLogger(), allocUpdateFnIgnore, false, job.ID, job, nil, allocs, nil, "")
+	r := reconciler.Compute()
+
+	d := structs.NewDeployment(job)
+	d.TaskGroups[job.TaskGroups[0].Name] = &structs.DeploymentState{
+		DesiredTotal: 5,
+	}
+
+	// Assert the correct results
+	assertResults(t, r, &resultExpectation{
+		createDeployment:  d,
+		deploymentUpdates: nil,
+		place:             5,
+		destructive:       0,
+		inplace:           0,
+		stop:              0,
+		desiredTGUpdates: map[string]*structs.DesiredUpdates{
+			job.TaskGroups[0].Name: {
+				InPlaceUpdate:     0,
+				Ignore:            5,
+				Place:             5,
+				DestructiveUpdate: 0,
+			},
+		},
+	})
+}
+
 // Tests the reconciler doesn't creates a deployment if there are no changes
 func TestReconciler_DontCreateDeployment_NoChanges(t *testing.T) {
 	job := mock.Job()

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -2542,7 +2542,7 @@ func TestReconciler_CreateDeployment_NewerCreateIndex(t *testing.T) {
 	jobOld := mock.Job()
 	job := jobOld.Copy()
 	job.TaskGroups[0].Update = noCanaryUpdate
-	job.CreateIndex = 100
+	job.CreateIndex += 100
 
 	// Create 5 allocations from the old job
 	var allocs []*structs.Allocation


### PR DESCRIPTION
This fixes an issue where if a job is purged and resubmitted Nomad does not create
a new deployment. Adds unit test that failed before this fix