### PR TITLE
Fix bug with determining when agent is a client

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -958,7 +958,11 @@ func (a *Agent) setupConsul(consulConfig *config.ConsulConfig) error {
 	a.consulCatalog = client.Catalog()
 
 	// Create Consul Service client for service advertisement and checks.
-	a.consulService = consul.NewServiceClient(client.Agent(), a.logger, a.Client() != nil)
+	isClient := false
+	if a.config.Client != nil && a.config.Client.Enabled {
+		isClient = true
+	}
+	a.consulService = consul.NewServiceClient(client.Agent(), a.logger, isClient)
 
 	// Run the Consul service client's sync'ing main loop
 	go a.consulService.Run()


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/hashicorp/nomad/pull/4365 that sets a boolean flag
when the agent is a client. It incorrectly checked state before initializing
the client. This leads to Nomad clients not deregistering any services registered
in Consul after allocs are destroyed

Fixes #4376