### PR TITLE
nomad: handle edge case where node drain event shouldn't be emitted

### DIFF
--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -504,6 +504,8 @@ func (n *Node) UpdateDrain(args *structs.NodeUpdateDrainRequest,
 		args.NodeEvent.SetMessage(NodeDrainEventDrainUpdated)
 	} else if node.DrainStrategy != nil && args.DrainStrategy == nil {
 		args.NodeEvent.SetMessage(NodeDrainEventDrainDisabled)
+	} else {
+		args.NodeEvent = nil
 	}
 
 	// Commit this update via Raft

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -921,6 +921,7 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 	// Check for updated node in the FSM
 	ws = memdb.NewWatchSet()
 	out, err = state.NodeByID(ws, node.ID)
+	require.NoError(err)
 	require.Len(out.Events, 3)
 	require.Equal(NodeDrainEventDrainDisabled, out.Events[2].Message)
 
@@ -929,6 +930,7 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 	require.Nil(msgpackrpc.CallWithCodec(codec, "Node.UpdateDrain", dereg, &resp3))
 	ws = memdb.NewWatchSet()
 	out, err = state.NodeByID(ws, node.ID)
+	require.NoError(err)
 	require.Len(out.Events, 3)
 }
 

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -917,6 +917,19 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 	require.NotZero(resp3.Index)
 	require.NotZero(resp3.EvalCreateIndex)
 	require.Len(resp3.EvalIDs, 1)
+
+	// Check for updated node in the FSM
+	ws = memdb.NewWatchSet()
+	out, err = state.NodeByID(ws, node.ID)
+	require.Len(out.Events, 3)
+	require.Equal(NodeDrainEventDrainDisabled, out.Events[2].Message)
+
+	// Check that calling UpdateDrain with the same DrainStrategy does not emit
+	// a node event.
+	require.Nil(msgpackrpc.CallWithCodec(codec, "Node.UpdateDrain", dereg, &resp3))
+	ws = memdb.NewWatchSet()
+	out, err = state.NodeByID(ws, node.ID)
+	require.Len(out.Events, 3)
 }
 
 func TestClientEndpoint_UpdateDrain_ACL(t *testing.T) {


### PR DESCRIPTION
If `nomad node drain -disable` is sent after the client has fully drained an empty node event is emitted as such:

```
2018-06-05T15:43:43-04:00  Drain      <none>
2018-06-05T15:43:09-04:00  Drain      Node drain complete
2018-06-05T15:43:09-04:00  Drain      Node drain strategy set
2018-06-05T15:42:42-04:00  Cluster    Node registered
```