### PR TITLE
agent: global logger should use the same flags

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -81,6 +81,9 @@ func NewAgent(config *Config, logOutput io.Writer, inmem *metrics.InmemSink) (*A
 		InmemSink:  inmem,
 	}
 
+	// Global logger should match internal logger as much as possible
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+
 	if err := a.setupConsul(config.Consul); err != nil {
 		return nil, fmt.Errorf("Failed to initialize Consul client: %v", err)
 	}


### PR DESCRIPTION
Prior to this change logs from the global logger only used seconds:

```
2018/06/06 18:25:58 http: TLS handshake error from ...
```

After this change they properly use the microseconds flag:

```
2018/06/06 18:39:50.702447 http: TLS handshake error ...
```

They still lack a log level unfortunately.