### PR TITLE
UI: Make task rows clickable.

### DIFF
--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -1,6 +1,7 @@
 import { alias } from '@ember/object/computed';
 import Controller, { inject as controller } from '@ember/controller';
 import Sortable from 'nomad-ui/mixins/sortable';
+import { lazyClick } from 'nomad-ui/helpers/lazy-click';
 
 export default Controller.extend(Sortable, {
   allocationController: controller('allocations.allocation'),
@@ -17,4 +18,14 @@ export default Controller.extend(Sortable, {
 
   listToSort: alias('model.states'),
   sortedStates: alias('listSorted'),
+
+  actions: {
+    gotoTask(allocation, task) {
+      this.transitionToRoute('allocations.allocation.task', task);
+    },
+
+    taskClick(allocation, task, event) {
+      lazyClick([() => this.send('gotoTask', allocation, task), event]);
+    },
+  },
 });

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -48,7 +48,10 @@
             <th>Addresses</th>
           {{/t.head}}
           {{#t.body as |row|}}
-            <tr data-test-task-row={{row.model.task.name}}>
+            <tr
+              data-test-task-row={{row.model.task.name}}
+              onclick={{action "taskClick" row.model.allocation row.model}}
+              class="is-interactive">
               <td class="is-narrow">
                 {{#if (not row.model.driverStatus.healthy)}}
                   <span data-test-icon="unhealthy-driver" class="tooltip text-center" aria-label="{{row.model.driver}} is unhealthy">

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -137,6 +137,36 @@ test('each task row should list high-level information for the task', function(a
   });
 });
 
+test('each task row should link to the task detail page', function(assert) {
+  const task = server.db.taskStates.where({ allocationId: allocation.id }).sortBy('name')[0];
+
+  click('[data-test-task-row] [data-test-name] a');
+
+  andThen(() => {
+    assert.equal(
+      currentURL(),
+      `/allocations/${allocation.id}/${task.name}`,
+      'Task name in task row links to task detail'
+    );
+  });
+
+  andThen(() => {
+    visit(`/allocations/${allocation.id}`);
+  });
+
+  andThen(() => {
+    click('[data-test-task-row]');
+  });
+
+  andThen(() => {
+    assert.equal(
+      currentURL(),
+      `/allocations/${allocation.id}/${task.name}`,
+      'Task row links to task detail'
+    );
+  });
+});
+
 test('tasks with an unhealthy driver have a warning icon', function(assert) {
   assert.ok(find('[data-test-task-row] [data-test-icon="unhealthy-driver"]'), 'Warning is shown');
 });


### PR DESCRIPTION
Right now they are the only tables where the entire row isn't a
click-target to drill into the detail page.

Sidenote: Not sure what I was thinking when I implemented `lazyClick` the way I did. It isn't actually being used as a helper anywhere, and since it expects an event, I don't see how it would ever work as a helper. Since I'm trying to get this in for 0.8.4, I turned a blind eye to it for the time being.