### PR TITLE
executor: fix Windows blocking on pipe close

### DIFF
--- a/client/driver/executor/executor_windows.go
+++ b/client/driver/executor/executor_windows.go
@@ -63,7 +63,7 @@ func (e *UniversalExecutor) shutdownProcess(proc *os.Process) error {
 	if err := sendCtrlBreak(proc.Pid); err != nil {
 		return fmt.Errorf("executor.shutdown error: %v", err)
 	}
-	e.logger.Printf("Sent Ctrl-Break to process %v", proc.Pid)
+	e.logger.Printf("[INFO] executor: sent Ctrl-Break to process %v", proc.Pid)
 
 	return nil
 }


### PR DESCRIPTION
Sending the Ctrl-Break signal to PowerShell <6 causes it to drop into
debug mode. Closing its output pipe at that point will block
indefinitely and prevent the process from being killed by Nomad.

See the upstream powershell issue for details:
https://github.com/PowerShell/PowerShell/issues/4254

Sample executor logging when the blocking behavior is hit:

```
2018/06/08 21:56:32.242562 [INFO] executor: launching command powershell.exe -Command echo Hello; sleep 1000000
2018/06/08 21:56:43.063844 [INFO] executor: sent Ctrl-Break to process 8044
2018/06/08 21:56:52.068681 [WARN] executor: timed out waiting for read-side of process output pipe to close
2018/06/08 21:56:56.070628 [WARN] executor: timed out waiting for read-side of process output pipe to close
```

And the process is force killed properly.

This PR fixes a bug introduced by the combination of #4153, #4336, and PowerShell/Powershell#4254