### PR TITLE
Fix dispatched optional meta correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ IMPROVEMENTS:
    image pulls [[GH-4192](https://github.com/hashicorp/nomad/issues/4192)]
  * driver/raw_exec: Use cgroups to manage process tree for precise cleanup of
    launched processes [[GH-4350](https://github.com/hashicorp/nomad/issues/4350)]
+ * env: Default interpolation of optional meta fields of parameterized jobs to
+   an empty string rather than the field key. [[GH-3720](https://github.com/hashicorp/nomad/issues/3720)]
  * ui: Show node drain, node eligibility, and node drain strategy information in the Client list and Client detail pages [[GH-4353](https://github.com/hashicorp/nomad/issues/4353)]
  * ui: Show reschedule-event information for allocations that were server-side rescheduled [[GH-4254](https://github.com/hashicorp/nomad/issues/4254)]
  * ui: Show the running deployment Progress Deadlines on the Job Detail Page [[GH-4388](https://github.com/hashicorp/nomad/issues/4388)]

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -614,6 +614,7 @@ type Job struct {
 	Update            *UpdateStrategy
 	Periodic          *PeriodicConfig
 	ParameterizedJob  *ParameterizedJobConfig
+	Dispatched        bool
 	Payload           []byte
 	Reschedule        *ReschedulePolicy
 	Migrate           *MigrateStrategy
@@ -636,7 +637,7 @@ func (j *Job) IsPeriodic() bool {
 
 // IsParameterized returns whether a job is parameterized job.
 func (j *Job) IsParameterized() bool {
-	return j.ParameterizedJob != nil
+	return j.ParameterizedJob != nil && !j.Dispatched
 }
 
 func (j *Job) Canonicalize() {

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -397,7 +397,23 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 
 	// Set meta
 	combined := alloc.Job.CombinedTaskMeta(alloc.TaskGroup, b.taskName)
-	b.taskMeta = make(map[string]string, len(combined)*2)
+	// taskMetaSize is double to total meta keys to account for given and upper
+	// cased values
+	taskMetaSize := len(combined) * 2
+
+	// if job is parameterized initialize optional meta to empty strings
+	if alloc.Job.IsParameterized() {
+		b.taskMeta = make(map[string]string,
+			taskMetaSize+(len(alloc.Job.ParameterizedJob.MetaOptional)*2))
+
+		for _, k := range alloc.Job.ParameterizedJob.MetaOptional {
+			b.taskMeta[fmt.Sprintf("%s%s", MetaPrefix, strings.ToUpper(k))] = ""
+			b.taskMeta[fmt.Sprintf("%s%s", MetaPrefix, k)] = ""
+		}
+	} else {
+		b.taskMeta = make(map[string]string, taskMetaSize)
+	}
+
 	for k, v := range combined {
 		b.taskMeta[fmt.Sprintf("%s%s", MetaPrefix, strings.ToUpper(k))] = v
 		b.taskMeta[fmt.Sprintf("%s%s", MetaPrefix, k)] = v

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -403,8 +403,8 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 
 	// if job is parameterized initialize optional meta to empty strings
 	if alloc.Job.Dispatched {
-		b.taskMeta = make(map[string]string,
-			taskMetaSize+(len(alloc.Job.ParameterizedJob.MetaOptional)*2))
+		optionalMetaCount := len(alloc.Job.ParameterizedJob.MetaOptional)
+		b.taskMeta = make(map[string]string, taskMetaSize+optionalMetaCount*2)
 
 		for _, k := range alloc.Job.ParameterizedJob.MetaOptional {
 			b.taskMeta[fmt.Sprintf("%s%s", MetaPrefix, strings.ToUpper(k))] = ""

--- a/client/driver/env/env.go
+++ b/client/driver/env/env.go
@@ -402,7 +402,7 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 	taskMetaSize := len(combined) * 2
 
 	// if job is parameterized initialize optional meta to empty strings
-	if alloc.Job.IsParameterized() {
+	if alloc.Job.Dispatched {
 		b.taskMeta = make(map[string]string,
 			taskMetaSize+(len(alloc.Job.ParameterizedJob.MetaOptional)*2))
 

--- a/client/driver/env/env_test.go
+++ b/client/driver/env/env_test.go
@@ -382,6 +382,7 @@ func TestEnvironment_InterpolateEmptyOptionalMeta(t *testing.T) {
 	a.Job.ParameterizedJob = &structs.ParameterizedJobConfig{
 		MetaOptional: []string{"metaopt1", "metaopt2"},
 	}
+	a.Job.Dispatched = true
 	task := a.Job.TaskGroups[0].Tasks[0]
 	task.Meta = map[string]string{"metaopt1": "metaopt1val"}
 	env := NewBuilder(mock.Node(), a, task, "global").Build()

--- a/client/driver/env/env_test.go
+++ b/client/driver/env/env_test.go
@@ -378,6 +378,7 @@ func TestEnvironment_UpdateTask(t *testing.T) {
 // job, if an optional meta field is not set, it will get interpolated as an
 // empty string.
 func TestEnvironment_InterpolateEmptyOptionalMeta(t *testing.T) {
+	require := require.New(t)
 	a := mock.Alloc()
 	a.Job.ParameterizedJob = &structs.ParameterizedJobConfig{
 		MetaOptional: []string{"metaopt1", "metaopt2"},
@@ -386,6 +387,6 @@ func TestEnvironment_InterpolateEmptyOptionalMeta(t *testing.T) {
 	task := a.Job.TaskGroups[0].Tasks[0]
 	task.Meta = map[string]string{"metaopt1": "metaopt1val"}
 	env := NewBuilder(mock.Node(), a, task, "global").Build()
-	require.Equal(t, "metaopt1val", env.ReplaceEnv("${NOMAD_META_metaopt1}"))
-	require.Empty(t, env.ReplaceEnv("${NOMAD_META_metaopt2}"))
+	require.Equal("metaopt1val", env.ReplaceEnv("${NOMAD_META_metaopt1}"))
+	require.Empty(env.ReplaceEnv("${NOMAD_META_metaopt2}"))
 }

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1325,6 +1325,7 @@ func validateJob(job *structs.Job) (invalid, warnings error) {
 
 // validateJobUpdate ensures updates to a job are valid.
 func validateJobUpdate(old, new *structs.Job) error {
+	// Validate Dispatch not set on new Jobs
 	if old == nil {
 		if new.Dispatched {
 			return fmt.Errorf("job can't be submitted with 'Dispatched' set")
@@ -1407,7 +1408,6 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 
 	// Derive the child job and commit it via Raft
 	dispatchJob := parameterizedJob.Copy()
-	dispatchJob.ParameterizedJob = nil
 	dispatchJob.ID = structs.DispatchedID(parameterizedJob.ID, time.Now())
 	dispatchJob.ParentID = parameterizedJob.ID
 	dispatchJob.Name = dispatchJob.ID

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -4384,6 +4384,12 @@ func TestJobEndpoint_Dispatch(t *testing.T) {
 				if !out.Dispatched {
 					t.Fatal("expected dispatched job")
 				}
+				if out.IsParameterized() {
+					t.Fatal("dispatched job should not be parameterized")
+				}
+				if out.ParameterizedJob == nil {
+					t.Fatal("parameter job config should exist")
+				}
 
 				if tc.noEval {
 					return

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -458,6 +458,33 @@ func TestJobEndpoint_Register_ParameterizedJob(t *testing.T) {
 	}
 }
 
+func TestJobEndpoint_Register_Dispatched(t *testing.T) {
+	t.Parallel()
+	s1 := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0 // Prevent automatic dequeue
+	})
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request with a job with 'Dispatch' set to true
+	job := mock.Job()
+	job.Dispatched = true
+	req := &structs.JobRegisterRequest{
+		Job: job,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	var resp structs.JobRegisterResponse
+	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
+	if err == nil || !strings.Contains(err.Error(), "'Dispatched' is read-only") {
+		t.Fatalf("expected dispatch read-only error: %v", err)
+	}
+}
 func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 	t.Parallel()
 	s1 := TestServer(t, func(c *Config) {
@@ -3959,6 +3986,7 @@ func TestJobEndpoint_ValidateJob_KillSignal(t *testing.T) {
 
 func TestJobEndpoint_ValidateJobUpdate(t *testing.T) {
 	t.Parallel()
+	require := require.New(t)
 	old := mock.Job()
 	new := mock.Job()
 
@@ -3988,6 +4016,16 @@ func TestJobEndpoint_ValidateJobUpdate(t *testing.T) {
 	} else {
 		t.Log(err)
 	}
+
+	new = mock.Job()
+	new.Dispatched = true
+	require.Error(validateJobUpdate(old, new),
+		"expected err when setting new job to dispatched")
+	require.Error(validateJobUpdate(nil, new),
+		"expected err when setting new job to dispatched")
+	require.Error(validateJobUpdate(new, old),
+		"expected err when setting dispatched to false")
+	require.NoError(validateJobUpdate(nil, old))
 }
 
 func TestJobEndpoint_ValidateJobUpdate_ACL(t *testing.T) {
@@ -4342,6 +4380,9 @@ func TestJobEndpoint_Dispatch(t *testing.T) {
 				}
 				if out.ParentID != tc.parameterizedJob.ID {
 					t.Fatalf("bad parent ID")
+				}
+				if !out.Dispatched {
+					t.Fatal("expected dispatched job")
 				}
 
 				if tc.noEval {

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -460,6 +460,7 @@ func TestJobEndpoint_Register_ParameterizedJob(t *testing.T) {
 
 func TestJobEndpoint_Register_Dispatched(t *testing.T) {
 	t.Parallel()
+	require := require.New(t)
 	s1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
@@ -481,9 +482,8 @@ func TestJobEndpoint_Register_Dispatched(t *testing.T) {
 	// Fetch the response
 	var resp structs.JobRegisterResponse
 	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
-	if err == nil || !strings.Contains(err.Error(), "'Dispatched' is read-only") {
-		t.Fatalf("expected dispatch read-only error: %v", err)
-	}
+	require.Error(err)
+	require.Contains(err.Error(), "job can't be submitted with 'Dispatched'")
 }
 func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 	t.Parallel()

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -152,6 +152,12 @@ func TestJobDiff(t *testing.T) {
 					},
 					{
 						Type: DiffTypeDeleted,
+						Name: "Dispatched",
+						Old:  "false",
+						New:  "",
+					},
+					{
+						Type: DiffTypeDeleted,
 						Name: "Meta[foo]",
 						Old:  "bar",
 						New:  "",
@@ -212,6 +218,12 @@ func TestJobDiff(t *testing.T) {
 						Name: "AllAtOnce",
 						Old:  "",
 						New:  "true",
+					},
+					{
+						Type: DiffTypeAdded,
+						Name: "Dispatched",
+						Old:  "",
+						New:  "false",
 					},
 					{
 						Type: DiffTypeAdded,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2018,6 +2018,10 @@ type Job struct {
 	// for dispatching.
 	ParameterizedJob *ParameterizedJobConfig
 
+	// Dispatched is used to identify if the Job has been dispatched from a
+	// parameterized job.
+	Dispatched bool
+
 	// Payload is the payload supplied when the job was dispatched.
 	Payload []byte
 
@@ -2328,7 +2332,7 @@ func (j *Job) IsPeriodicActive() bool {
 
 // IsParameterized returns whether a job is parameterized job.
 func (j *Job) IsParameterized() bool {
-	return j.ParameterizedJob != nil
+	return j.ParameterizedJob != nil && !j.Dispatched
 }
 
 // VaultPolicies returns the set of Vault policies per task group, per task


### PR DESCRIPTION
This fixes a bug in PR #4262 due to the fact that dispatched jobs never return true for `job.IsParameterized` thus missing the logic implemented in the PR. The fix was to add a new `Dispatched` field to the `Job` struct which is set when a new job is dispatched and not allowed to be mutated from the api.

fixes #3720 