### PR TITLE
Fix Vault template test for v2 secret backend

### DIFF
--- a/scripts/travis-vault.sh
+++ b/scripts/travis-vault.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-VERSION=0.8.3
+VERSION=0.10.2
 OS="linux"
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     OS="darwin"

--- a/scripts/vagrant-linux-priv-vault.sh
+++ b/scripts/vagrant-linux-priv-vault.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-VERSION=0.10.0
+VERSION=0.10.2
 DOWNLOAD=https://releases.hashicorp.com/vault/${VERSION}/vault_${VERSION}_linux_amd64.zip
 
 function install_vault() {


### PR DESCRIPTION
Vault now has a versioned secret backend so our unit tests fail on the dev
Vault server when used with 0.10.x+ Vault instances.