### PR TITLE
Close unclosed backtick in docs

### DIFF
--- a/website/source/api/search.html.md
+++ b/website/source/api/search.html.md
@@ -15,7 +15,7 @@ Additionally, a prefix can be searched for within every context.
 
 | Method  | Path                         | Produces                   |
 | ------- | ---------------------------- | -------------------------- |
-| `POST`  | `/v1/search                  | `application/json`         |
+| `POST`  | `/v1/search`                 | `application/json`         |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries) and


### PR DESCRIPTION
Hi, I noticed that one of the table cells in this page was not using the monospace font because the close backtick is missing: https://www.nomadproject.io/api/search.html