### PR TITLE
Clarify defaults and behaviour of mode = fail in restart stanza in documentation

### DIFF
--- a/website/source/docs/job-specification/restart.html.md
+++ b/website/source/docs/job-specification/restart.html.md
@@ -47,7 +47,7 @@ job "docs" {
   controlled by `mode`. This is specified using a label suffix like "30s" or
   "1h". Defaults vary by job type, see below for more information.
 
-- `mode` `(string: "delay")` - Controls the behavior when the task fails more
+- `mode` `(string: "fail")` - Controls the behavior when the task fails more
   than `attempts` times in an interval. For a detailed explanation of these
   values and their behavior, please see the [mode values section](#mode-values).
 
@@ -95,4 +95,5 @@ restart {
 
 - `"fail"` - Instructs the scheduler to not attempt to restart the task on
   failure. This mode is useful for non-idempotent jobs which are unlikely to
-  succeed after a few failures.
+  succeed after a few failures. Failed jobs will be restarted according to
+  the [`reschedule`](/docs/job-specification/reschedule.html) stanza.


### PR DESCRIPTION
The Nomad changelog says that the default value the `restart` stanza's `mode` attribute is `mode = "fail"` as of 0.8. However one place (that I believe) documents the default value, [the value in parentheses beside the documented behaviour of the `mode` attribute](https://www.nomadproject.io/docs/job-specification/restart.html#mode), still claims the old default value of `"delayed"`. This PR updates that.

Also, the effect of setting `mode = "fail"` was not clear to me by reading the docs for it on [the restart page](https://www.nomadproject.io/docs/job-specification/restart.html#quot-fail-quot-). I only understood it after I read the [_guide_](https://www.nomadproject.io/guides/operating-a-job/failure-handling-strategies/restart.html) for job restarts. So I tried to clarify the behaviour in the `restart` docs. If what I proposed is not correct but is still worth clarifying in the docs, let me know.