### PR TITLE
bump go-discover to fix Azure provider `vendor.json` file

### DIFF
--- a/vendor/github.com/hashicorp/go-discover/provider/azure/azure_discover.go
+++ b/vendor/github.com/hashicorp/go-discover/provider/azure/azure_discover.go
@@ -13,7 +13,13 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 )
 
-type Provider struct{}
+type Provider struct {
+	userAgent string
+}
+
+func (p *Provider) SetUserAgent(s string) {
+	p.userAgent = s
+}
 
 func (p *Provider) Help() string {
 	return `Microsoft Azure:
@@ -78,9 +84,12 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 
 	// Setup the client using autorest; followed the structure from Terraform
 	vmnet := network.NewInterfacesClient(subscriptionID)
-	vmnet.Client.UserAgent = "Hashicorp-Consul"
 	vmnet.Sender = autorest.CreateSender(autorest.WithLogging(l))
 	vmnet.Authorizer = autorest.NewBearerAuthorizer(sbt)
+
+	if p.userAgent != "" {
+		vmnet.Client.UserAgent = p.userAgent
+	}
 
 	if tagName != "" && tagValue != "" && resourceGroup == "" && vmScaleSet == "" {
 		l.Printf("[DEBUG] discover-azure: using tag method. tag_name: %s, tag_value: %s", tagName, tagValue)

--- a/vendor/github.com/hashicorp/go-discover/provider/azure/vendor/vendor.json
+++ b/vendor/github.com/hashicorp/go-discover/provider/azure/vendor/vendor.json
@@ -13,7 +13,7 @@
 		{"path":"github.com/Azure/go-autorest/autorest/to","checksumSHA1":"SbBb2GcJNm5GjuPKGL2777QywR4=","revision":"5cdef8c5dbd65369ef90f1b8d7ea2b7348ffc862","revisionTime":"2018-04-27T22:46:30Z"},
 		{"path":"github.com/Azure/go-autorest/autorest/validation","checksumSHA1":"5UH4IFIB/98iowPCzzVs4M4MXiQ=","revision":"5cdef8c5dbd65369ef90f1b8d7ea2b7348ffc862","revisionTime":"2018-04-27T22:46:30Z"},
 		{"path":"github.com/dgrijalva/jwt-go","checksumSHA1":"+TKtBzv23ywvmmqRiGEjUba4YmI=","revision":"dbeaa9332f19a944acb5736b4456cfcc02140e29","revisionTime":"2017-10-19T21:57:19Z"},
-		{"path":"github.com/hashicorp/go-discover/provider/azure","checksumSHA1":"F8qQlAbbXZWigahcusD+1FOgXuU=","revision":"c7c0eb3fc6b6f8024c39cb24f3fe254a72595dd4","revisionTime":"2018-04-27T00:43:23Z"},
+		{"path":"github.com/hashicorp/go-discover/provider/azure","checksumSHA1":"F8qQlAbbXZWigahcusD+1FOgXuU=","revision":"c7c0eb3fc6b6f8024c39cb24f3fe254a72595dd4","revisionTime":"2018-04-27T00:43:23Z"}
 	],
 	"rootPath": "github.com/hashicorp/go-discover/provider/azure"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -140,7 +140,7 @@
 		{"path":"github.com/hashicorp/go-discover","checksumSHA1":"CnY2iYK47tGA9wsFMfH04PpmSoI=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z"},
 		{"path":"github.com/hashicorp/go-discover/provider/aliyun","checksumSHA1":"ZmU/47XUGUQpFP6E8T6Tl8QKszI=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
 		{"path":"github.com/hashicorp/go-discover/provider/aws","checksumSHA1":"Vit45xRjrJ6h7IGJndrBjodVUAE=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/azure","checksumSHA1":"YKDBKFABvt6MSjdwPsafMA6VdJw=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
+		{"path":"github.com/hashicorp/go-discover/provider/azure","checksumSHA1":"dMU80T10KQFZNqpBBjzf7ymFNBw=","revision":"266744fed5f15e5d4488269b2c29b66e25783f6f","revisionTime":"2018-05-21T21:57:50Z","tree":true},
 		{"path":"github.com/hashicorp/go-discover/provider/digitalocean","checksumSHA1":"qoy/euk2dwrONYMUsaAPznHHpxQ=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
 		{"path":"github.com/hashicorp/go-discover/provider/gce","checksumSHA1":"tnKls5vtzpNQAj7b987N4i81HvY=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
 		{"path":"github.com/hashicorp/go-discover/provider/os","checksumSHA1":"LZwn9B00AjulYRCKapmJWFAamoo=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},


### PR DESCRIPTION
Pulling https://github.com/hashicorp/go-discover/pull/39/files in to allow FOSSA to check transitive dependencies properly. Previously,  `vendor/github.com/hashicorp/go-discover/provider/azure/vendor/vendor.json` had invalid json. 