### PR TITLE
Formatting and Typo fixes for Getting Started pages

### DIFF
--- a/website/source/intro/getting-started/jobs.html.md
+++ b/website/source/intro/getting-started/jobs.html.md
@@ -90,7 +90,7 @@ An allocation represents an instance of Task Group placed on a node. To inspect
 an allocation we use the [`alloc status` command](/docs/commands/alloc/status.html):
 
 ```text
-$ nomad alloc status 8ba85cef 
+$ nomad alloc status 8ba85cef
 ID                  = 8ba85cef
 Eval ID             = 13ebb66d
 Name                = example.cache[0]
@@ -129,7 +129,7 @@ We can see that Nomad reports the state of the allocation as well as its
 current resource usage. By supplying the `-stats` flag, more detailed resource
 usage statistics will be reported.
 
-To see the logs of a task, we can use the [logs command](/docs/commands/alloc/logs.html):
+To see the logs of a task, we can use the [`logs` command](/docs/commands/alloc/logs.html):
 
 ```text
 $ nomad alloc logs 8ba85cef redis
@@ -256,9 +256,9 @@ changed, another user has modified the job and the plan's results are
 potentially invalid.
 ```
 
-The plan output shows us that one allocation will be updated and that the other 
-two will be ignored. This is due to the `max_parallel` setting in the `update` 
-stanza, which is set to 1 to instruct Nomad to perform only a single change at 
+The plan output shows us that one allocation will be updated and that the other
+two will be ignored. This is due to the `max_parallel` setting in the `update`
+stanza, which is set to 1 to instruct Nomad to perform only a single change at
 a time.
 
 Once ready, use `run` to push the updated specification:

--- a/website/source/intro/getting-started/running.html.md
+++ b/website/source/intro/getting-started/running.html.md
@@ -134,11 +134,11 @@ replication continues to be attempted until the node recovers. Nomad will
 automatically try to reconnect to _failed_ nodes, allowing it to recover from
 certain network conditions, while _left_ nodes are no longer contacted.
 
-If an agent is operating as a server, [leave_on_terminate](/docs/agent/configuration/index.html#leave_on_terminate) should only
-be set if the server will never rejoin the cluster again. The default value of `false` for 'leave_on_terminate` and `leave_on_interrupt`
+If an agent is operating as a server, [`leave_on_terminate`](/docs/agent/configuration/index.html#leave_on_terminate) should only
+be set if the server will never rejoin the cluster again. The default value of `false` for `leave_on_terminate` and `leave_on_interrupt`
 work well for most scenarios. If Nomad servers are part of an auto scaling group where new servers are brought up to replace
 failed servers, using graceful leave avoids causing a potential availability outage affecting the [consensus protocol](/docs/internals/consensus.html).
-As of of Nomad 0.8, Nomad includes Autopilot which automatically removes failed or dead servers. This allows the operator to skip setting leave_on_terminate
+As of Nomad 0.8, Nomad includes Autopilot which automatically removes failed or dead servers. This allows the operator to skip setting `leave_on_terminate`
 
 If a server does forcefully exit and will not be returning into service, the
 [`server force-leave` command](/docs/commands/server/force-leave.html) should


### PR DESCRIPTION
Was running through the getting started pages again on nomadproject.io and noticed some typos.