### PR TITLE
Fixed dead link to SWIM paper

### DIFF
--- a/website/source/docs/internals/gossip.html.md
+++ b/website/source/docs/internals/gossip.html.md
@@ -12,7 +12,7 @@ description: |-
 Nomad uses a [gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol)
 to manage membership. This is provided through the use of the [Serf library](https://www.serf.io/).
 The gossip protocol used by Serf is based on
-["SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol"](https://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf),
+["SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol"](https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf),
 with a few minor adaptations. There are more details about [Serf's protocol here](https://www.serf.io/docs/internals/gossip.html).
 
 ~> **Advanced Topic!** This page covers technical details of


### PR DESCRIPTION
The original link to the paper SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol was dead, so I updated it with a working one