### PR TITLE
E2E: Initial Framework

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -1,0 +1,11 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/e2e/framework"
+)
+
+func RunE2ETests(t *testing.T) {
+	framework.Run(t)
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,11 @@
+package e2e
+
+import (
+	"testing"
+
+	_ "github.com/hashicorp/nomad/e2e/example"
+)
+
+func TestE2E(t *testing.T) {
+	RunE2ETests(t)
+}

--- a/e2e/example/e2e_test.go
+++ b/e2e/example/e2e_test.go
@@ -1,0 +1,17 @@
+package example
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/e2e/framework"
+)
+
+func TestE2E(t *testing.T) {
+	framework.New().AddSuites(&framework.TestSuite{
+		Component:   "simple",
+		CanRunLocal: true,
+		Cases: []framework.TestCase{
+			new(SimpleExampleTestCase),
+		},
+	}).Run(t)
+}

--- a/e2e/example/example.go
+++ b/e2e/example/example.go
@@ -1,0 +1,25 @@
+package example
+
+import (
+	"github.com/hashicorp/nomad/e2e/framework"
+)
+
+func init() {
+	framework.AddSuites(&framework.TestSuite{
+		Component:   "simple",
+		CanRunLocal: true,
+		Cases: []framework.TestCase{
+			new(SimpleExampleTestCase),
+		},
+	})
+}
+
+type SimpleExampleTestCase struct {
+	framework.TC
+}
+
+func (tc *SimpleExampleTestCase) TestExample() {
+	jobs, _, err := tc.Nomad().Jobs().List(nil)
+	tc.NoError(err)
+	tc.Empty(jobs)
+}

--- a/e2e/example/example.go
+++ b/e2e/example/example.go
@@ -18,8 +18,8 @@ type SimpleExampleTestCase struct {
 	framework.TC
 }
 
-func (tc *SimpleExampleTestCase) TestExample() {
+func (tc *SimpleExampleTestCase) TestExample(f *framework.F) {
 	jobs, _, err := tc.Nomad().Jobs().List(nil)
-	tc.NoError(err)
-	tc.Empty(jobs)
+	f.NoError(err)
+	f.Empty(jobs)
 }

--- a/e2e/framework/case.go
+++ b/e2e/framework/case.go
@@ -18,6 +18,10 @@ type TestSuite struct {
 	Constraints Constraints // Environment constraints to follow
 	Parallel    bool        // If true, will run test cases in parallel
 	Slow        bool        // Slow test suites don't run by default
+
+	// API Clients
+	Consul bool
+	Vault  bool
 }
 
 // Constraints that must be satisfied for a TestSuite to run

--- a/e2e/framework/case.go
+++ b/e2e/framework/case.go
@@ -52,7 +52,7 @@ func (c Constraints) matches(env Environment) error {
 
 	for _, t := range c.Tags {
 		if _, ok := env.Tags[t]; !ok {
-			return fmt.Errorf("tags constraint failed, tag '%s' is not included in environment")
+			return fmt.Errorf("tags constraint failed, tag '%s' is not included in environment", t)
 		}
 	}
 	return nil

--- a/e2e/framework/case.go
+++ b/e2e/framework/case.go
@@ -20,6 +20,7 @@ type TestSuite struct {
 	Slow        bool        // Slow test suites don't run by default
 }
 
+// Constraints that must be satisfied for a TestSuite to run
 type Constraints struct {
 	Provider    string   // Cloud provider ex. 'aws', 'azure', 'gcp'
 	OS          string   // Operating system ex. 'windows', 'linux'
@@ -53,7 +54,10 @@ func (c Constraints) matches(env Environment) error {
 	return nil
 }
 
-// TC is the base test case which should be embedded in TestCase implementations
+// TC is the base test case which should be embedded in TestCase implementations.
+// It also embeds testify assertions configured with the current *testing.T
+// context. For more information on assertions:
+// https://godoc.org/github.com/stretchr/testify/assert#Assertions
 type TC struct {
 	*assert.Assertions
 	require *require.Assertions
@@ -75,7 +79,8 @@ func (tc *TC) Prefix() string {
 	return fmt.Sprintf("%s-", tc.cluster.ID)
 }
 
-// Name is the Name of the test cluster.
+// Name returns the name of the test case which is set to the name of the
+// implementing type.
 func (tc *TC) Name() string {
 	return tc.cluster.Name
 }
@@ -90,6 +95,12 @@ func (tc *TC) SetT(t *testing.T) {
 	tc.t = t
 	tc.Assertions = assert.New(t)
 	tc.require = require.New(t)
+}
+
+// Require fetches a require flavor of testify assertions
+// https://godoc.org/github.com/stretchr/testify/require
+func (tc *TC) Require() *require.Assertions {
+	return tc.require
 }
 
 func (tc *TC) setClusterInfo(info *ClusterInfo) {

--- a/e2e/framework/case.go
+++ b/e2e/framework/case.go
@@ -1,0 +1,89 @@
+package framework
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type TestSuite struct {
+	Component string
+
+	CanRunLocal bool
+	Cases       []TestCase
+	Constraints Constraints
+	Parallel    bool
+	Slow        bool
+}
+
+type Constraints struct {
+	CloudProvider string
+	OS            string
+	Arch          string
+	Environment   string
+	Tags          []string
+}
+
+func (c Constraints) matches(env Environment) error {
+	if len(c.CloudProvider) != 0 && c.CloudProvider != env.Provider {
+		return fmt.Errorf("provider constraint does not match environment")
+	}
+
+	if len(c.OS) != 0 && c.OS != env.OS {
+		return fmt.Errorf("os constraint does not match environment")
+	}
+
+	if len(c.Arch) != 0 && c.Arch != env.Arch {
+		return fmt.Errorf("arch constraint does not match environment")
+	}
+
+	if len(c.Environment) != 0 && c.Environment != env.Name {
+		return fmt.Errorf("environment constraint does not match environment name")
+	}
+
+	for _, t := range c.Tags {
+		if _, ok := env.Tags[t]; !ok {
+			return fmt.Errorf("tags constraint failed, tag '%s' is not included in environment")
+		}
+	}
+	return nil
+}
+
+type TC struct {
+	*assert.Assertions
+	require *require.Assertions
+	t       *testing.T
+
+	cluster *ClusterInfo
+	prefix  string
+	name    string
+}
+
+func (tc *TC) Nomad() *api.Client {
+	return tc.cluster.NomadClient
+}
+
+func (tc *TC) Prefix() string {
+	return fmt.Sprintf("%s-", tc.cluster.ID)
+}
+
+func (tc *TC) Name() string {
+	return tc.cluster.Name
+}
+
+func (tc *TC) T() *testing.T {
+	return tc.t
+}
+
+func (tc *TC) SetT(t *testing.T) {
+	tc.t = t
+	tc.Assertions = assert.New(t)
+	tc.require = require.New(t)
+}
+
+func (tc *TC) setClusterInfo(info *ClusterInfo) {
+	tc.cluster = info
+}

--- a/e2e/framework/case.go
+++ b/e2e/framework/case.go
@@ -61,11 +61,11 @@ func (c Constraints) matches(env Environment) error {
 // TC is the base test case which should be embedded in TestCase implementations.
 // It also embeds testify assertions configured with the current *testing.T
 // context. For more information on assertions:
-// https://godoc.org/github.com/stretchr/testify/assert#Assertions
+// https://godoc.org/github.com/stretchr/testify/require#Assertions
 type TC struct {
-	*assert.Assertions
-	require *require.Assertions
-	t       *testing.T
+	*require.Assertions
+	assert *assert.Assertions
+	t      *testing.T
 
 	cluster *ClusterInfo
 	prefix  string
@@ -97,14 +97,14 @@ func (tc *TC) T() *testing.T {
 // SetT sets the current *testing.T context
 func (tc *TC) SetT(t *testing.T) {
 	tc.t = t
-	tc.Assertions = assert.New(t)
-	tc.require = require.New(t)
+	tc.Assertions = require.New(t)
+	tc.assert = assert.New(t)
 }
 
-// Require fetches a require flavor of testify assertions
-// https://godoc.org/github.com/stretchr/testify/require
-func (tc *TC) Require() *require.Assertions {
-	return tc.require
+// Require fetches an assert flavor of testify assertions
+// https://godoc.org/github.com/stretchr/testify/assert
+func (tc *TC) Assert() *assert.Assertions {
+	return tc.assert
 }
 
 func (tc *TC) setClusterInfo(info *ClusterInfo) {

--- a/e2e/framework/case.go
+++ b/e2e/framework/case.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestSuite defines a set of test cases and under what conditions to run them
@@ -59,17 +57,10 @@ func (c Constraints) matches(env Environment) error {
 }
 
 // TC is the base test case which should be embedded in TestCase implementations.
-// It also embeds testify assertions configured with the current *testing.T
-// context. For more information on assertions:
-// https://godoc.org/github.com/stretchr/testify/require#Assertions
 type TC struct {
-	*require.Assertions
-	assert *assert.Assertions
-	t      *testing.T
+	t *testing.T
 
 	cluster *ClusterInfo
-	prefix  string
-	name    string
 }
 
 // Nomad returns a configured nomad api client
@@ -77,34 +68,10 @@ func (tc *TC) Nomad() *api.Client {
 	return tc.cluster.NomadClient
 }
 
-// Prefix will return a test case unique prefix which can be used to scope resources
-// during parallel tests.
-func (tc *TC) Prefix() string {
-	return fmt.Sprintf("%s-", tc.cluster.ID)
-}
-
 // Name returns the name of the test case which is set to the name of the
 // implementing type.
 func (tc *TC) Name() string {
 	return tc.cluster.Name
-}
-
-// T retrieves the current *testing.T context
-func (tc *TC) T() *testing.T {
-	return tc.t
-}
-
-// SetT sets the current *testing.T context
-func (tc *TC) SetT(t *testing.T) {
-	tc.t = t
-	tc.Assertions = require.New(t)
-	tc.assert = assert.New(t)
-}
-
-// Require fetches an assert flavor of testify assertions
-// https://godoc.org/github.com/stretchr/testify/assert
-func (tc *TC) Assert() *assert.Assertions {
-	return tc.assert
 }
 
 func (tc *TC) setClusterInfo(info *ClusterInfo) {

--- a/e2e/framework/context.go
+++ b/e2e/framework/context.go
@@ -23,6 +23,14 @@ func newF(t *testing.T) *F {
 	return newFWithID(uuid.Generate()[:8], t)
 }
 
+func newFFromParent(f *F, t *testing.T) *F {
+	child := newF(t)
+	for k, v := range f.data {
+		child.Set(k, v)
+	}
+	return child
+}
+
 func newFWithID(id string, t *testing.T) *F {
 	ft := &F{
 		id:         id,

--- a/e2e/framework/context.go
+++ b/e2e/framework/context.go
@@ -1,0 +1,61 @@
+package framework
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// F is the framework context that is passed to each test.
+// It is used to access the *testing.T context as well as testify helpers
+type F struct {
+	id string
+	*require.Assertions
+	assert *assert.Assertions
+	t      *testing.T
+
+	data map[interface{}]interface{}
+}
+
+func newF(t *testing.T) *F {
+	return newFWithID(uuid.Generate()[:8], t)
+}
+
+func newFWithID(id string, t *testing.T) *F {
+	ft := &F{
+		id:         id,
+		t:          t,
+		Assertions: require.New(t),
+		assert:     assert.New(t),
+	}
+
+	return ft
+}
+
+// Assert fetches an assert flavor of testify assertions
+// https://godoc.org/github.com/stretchr/testify/assert
+func (f *F) Assert() *assert.Assertions {
+	return f.assert
+}
+
+// T returns the *testing.T context
+func (f *F) T() *testing.T {
+	return f.t
+}
+
+// ID returns the current context ID
+func (f *F) ID() string {
+	return f.id
+}
+
+// Set is used to set arbitrary key/values to pass between before/after and test methods
+func (f *F) Set(key, val interface{}) {
+	f.data[key] = val
+}
+
+// Value retrives values set by the F.Set method
+func (f *F) Value(key interface{}) interface{} {
+	return f.data[key]
+}

--- a/e2e/framework/doc.go
+++ b/e2e/framework/doc.go
@@ -4,5 +4,106 @@ model includes a top level Framework which TestSuites can be added to. TestSuite
 include conditions under which the suite will run and a list of TestCase
 implementations to run. TestCases can be implemented with methods that run
 before/after each and all tests.
+
+Writing Tests
+
+Tests follow a similar patterns as go tests. They are functions that must start
+with 'Test' and instead of a *testing.T argument, they must have a receiver that
+implements the TestCase interface. A crude example as follows:
+
+	// foo_test.go
+	type MyTestCase struct {
+		framework.TC
+	}
+
+	func (tc *MyTestCase) TestMyFoo() {
+		tc.T().Log("bar")
+	}
+
+	func TestCalledFromGoTest(t *testing.T){
+		framework.New().AddSuites(&framework.TestSuite{
+			Component:   "foo",
+			Cases: []framework.TestCase{
+				new(MyTestCase),
+			},
+		}).Run(t)
+	}
+
+Test cases should embed the TC struct which satisfies the TestCase interface.
+Optionally a TestCase can also override the Name() function of TC which returns
+a string to name the test case. By default the name is the name of the struct
+type, which in the above example would be "MyTestCase"
+
+Test cases may also optionally implement additional interfaces to define setup
+and teardown logic:
+
+	BeforeEachStep
+	AfterEachStep
+	BeforeAllSteps
+	AfterAllSteps
+
+The test case struct allows you to setup and teardown state in the struct that
+can be consumed by the tests. For example:
+
+	type ComplexNomadTC struct {
+		framework.TC
+		jobID string
+	}
+
+	func (tc *ComplexNomadTC) BeforeEachStep(){
+		// Do some complex job setup with a unique prefix string
+		jobID, err := doSomeComplexSetup(tc.Nomad(), tc.Prefix())
+		tc.NoError(err)
+		tc.jobID = jobID
+	}
+
+	func (tc *ComplexNomadTC) TestSomeScenario(){
+		doTestThingWithJob(tc.T(), tc.Nomad(), tc.jobID)
+	}
+
+	func (tc *ComplexNomadTC) TestOtherScenario(){
+		doOtherTestThingWithJob(tc.T(), tc.Nomad(), tc.jobID)
+	}
+
+	func (tc *ComplexNomadTC) AfterEachStep(){
+		_, _, err := tc.Nomad().Jobs().Deregister(jobID, true, nil)
+		tc.Require().NoError(err)
+	}
+
+As demonstrated in the previous example, TC also exposes functions that return
+configured api clients including Nomad, Consul and Vault. If Consul or Vault
+are not provisioned their respective getter functions will return nil.
+
+Testify Integration
+
+Test cases expose a T() function to fetch the current *testing.T context.
+While this means the author is able to most other testing libraries,
+github.com/stretch/testify is recommended and integrated into the framework.
+The TC struct also embeds testify assertions that are preconfigured with the
+current testing context. Additionally TC comes with a Require() method that
+yields a testify Require if that flavor is desired.
+
+	func (tc *MyTestCase) TestWithTestify() {
+		err := someErrFunc()
+		tc.NoError(err)
+		// Or tc.Require().NoError(err)
+	}
+
+Parallelism
+
+The test framework honors go test's parallel feature under certain conditions.
+A TestSuite can be created with the Parallel field set to true to enable
+parallel execution of the test cases of the suite. Tests within a test case
+will always be executed sequentially. TC.T() is NOT safe to call from multiple
+gorouties, therefore TC.T().Parallel() should NEVER be called from a test of a
+TestCase
+
+Since test cases have the potential to work with a shared Nomad cluster in parallel
+any resources created or destroyed must be prefixed with a unique identifier for
+each test case. The TC struct exposes a Parallel() function that will return a
+string that is unique with in a test cases, so multiple tests with in the case
+can reliably create unique IDs between tests and setup/teardown. The string
+returned is 8 alpha numeric characters with a '-' appended.
+
 */
 package framework

--- a/e2e/framework/doc.go
+++ b/e2e/framework/doc.go
@@ -1,0 +1,8 @@
+/*
+Package framework implements a model for developing end-to-end test suites. The
+model includes a top level Framework which TestSuites can be added to. TestSuites
+include conditions under which the suite will run and a list of TestCase
+implementations to run. TestCases can be implemented with methods that run
+before/after each and all tests.
+*/
+package framework

--- a/e2e/framework/doc.go
+++ b/e2e/framework/doc.go
@@ -99,7 +99,7 @@ The test framework honors go test's parallel feature under certain conditions.
 A TestSuite can be created with the Parallel field set to true to enable
 parallel execution of the test cases of the suite. Tests within a test case
 will be executed sequentially unless f.T().Parallel() is called. Note that if
-multiple tests are to be executed in parallel, access to TC is note syncronized.
+multiple tests are to be executed in parallel, access to TC is not syncronized.
 The *framework.F offers a way to store state between before/after each method if
 desired.
 

--- a/e2e/framework/doc.go
+++ b/e2e/framework/doc.go
@@ -37,10 +37,10 @@ type, which in the above example would be "MyTestCase"
 Test cases may also optionally implement additional interfaces to define setup
 and teardown logic:
 
-	BeforeEachStep
-	AfterEachStep
-	BeforeAllSteps
-	AfterAllSteps
+	BeforeEachTest
+	AfterEachTest
+	BeforeAllTests
+	AfterAllTests
 
 The test case struct allows you to setup and teardown state in the struct that
 can be consumed by the tests. For example:
@@ -50,7 +50,7 @@ can be consumed by the tests. For example:
 		jobID string
 	}
 
-	func (tc *ComplexNomadTC) BeforeEachStep(){
+	func (tc *ComplexNomadTC) BeforeEach(){
 		// Do some complex job setup with a unique prefix string
 		jobID, err := doSomeComplexSetup(tc.Nomad(), tc.Prefix())
 		tc.NoError(err)
@@ -65,7 +65,7 @@ can be consumed by the tests. For example:
 		doOtherTestThingWithJob(tc.T(), tc.Nomad(), tc.jobID)
 	}
 
-	func (tc *ComplexNomadTC) AfterEachStep(){
+	func (tc *ComplexNomadTC) AfterEach(){
 		_, _, err := tc.Nomad().Jobs().Deregister(jobID, true, nil)
 		tc.Require().NoError(err)
 	}
@@ -95,7 +95,7 @@ The test framework honors go test's parallel feature under certain conditions.
 A TestSuite can be created with the Parallel field set to true to enable
 parallel execution of the test cases of the suite. Tests within a test case
 will always be executed sequentially. TC.T() is NOT safe to call from multiple
-gorouties, therefore TC.T().Parallel() should NEVER be called from a test of a
+goroutines, therefore TC.T().Parallel() should NEVER be called from a test of a
 TestCase
 
 Since test cases have the potential to work with a shared Nomad cluster in parallel

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -8,14 +8,14 @@ import (
 	"testing"
 )
 
-var fEnv = flag.String("nomad.env", "", "name of the environment executing against")
-var fProvider = flag.String("nomad.env.provider", "", "cloud provider for which environment is executing against")
-var fOS = flag.String("nomad.env.os", "", "operating system for which the environment is executing against")
-var fArch = flag.String("nomad.env.arch", "", "cpu architecture for which the environment is executing against")
-var fTags = flag.String("nomad.env.tags", "", "comma delimited list of tags associated with the environment")
-var fLocal = flag.Bool("nomad.local", false, "denotes execution is against a local environment")
-var fSlow = flag.Bool("nomad.slow", false, "toggles execution of slow test suites")
-var fForceAll = flag.Bool("nomad.force", false, "if set, skips all environment checks when filtering test suites")
+var fEnv = flag.String("env", "", "name of the environment executing against")
+var fProvider = flag.String("env.provider", "", "cloud provider for which environment is executing against")
+var fOS = flag.String("env.os", "", "operating system for which the environment is executing against")
+var fArch = flag.String("env.arch", "", "cpu architecture for which the environment is executing against")
+var fTags = flag.String("env.tags", "", "comma delimited list of tags associated with the environment")
+var fLocal = flag.Bool("local", false, "denotes execution is against a local environment")
+var fSlow = flag.Bool("slow", false, "toggles execution of slow test suites")
+var fForceRun = flag.Bool("forceRun", false, "if set, skips all environment checks when filtering test suites")
 
 var pkgFramework = New()
 
@@ -33,11 +33,11 @@ type Framework struct {
 // framework is targeting. During 'go run', these fields are populated by
 // the following flags:
 //
-//		-nomad.env <string>		"name of the environment executing against"
-//		-nomad.env.provider <string>	"cloud provider for which the environment is executing against"
-//		-nomad.env.os <string>		"operating system of environment"
-//		-nomad.env.arch <string>	"cpu architecture of environment"
-//		-nomad.env.tags <string>	"comma delimited list of environment tags"
+//		-env <string>		"name of the environment executing against"
+//		-env.provider <string>	"cloud provider for which the environment is executing against"
+//		-env.os <string>		"operating system of environment"
+//		-env.arch <string>	"cpu architecture of environment"
+//		-env.tags <string>	"comma delimited list of environment tags"
 //
 // These flags are not needed when executing locally
 type Environment struct {
@@ -65,7 +65,7 @@ func New() *Framework {
 		env:         env,
 		isLocalRun:  *fLocal,
 		slow:        *fSlow,
-		force:       *fForceAll,
+		force:       *fForceRun,
 	}
 }
 
@@ -109,7 +109,7 @@ func Run(t *testing.T) {
 // If skip is false and an error is returned, the test suite is failed.
 func (f *Framework) runSuite(t *testing.T, s *TestSuite) (skip bool, err error) {
 
-	// If -nomad.force is set, skip all constraint checks
+	// If -forceRun is set, skip all constraint checks
 	if !f.force {
 		// If this is a local run, check that the suite supports running locally
 		if !s.CanRunLocal && f.isLocalRun {

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -132,7 +132,11 @@ func (f *Framework) runSuite(t *testing.T, s *TestSuite) (skip bool, err error) 
 		name := fmt.Sprintf("%T", c)
 
 		// Each TestCase is provisioned a nomad cluster
-		info, err := f.provisioner.ProvisionCluster(ProvisionerOptions{Name: name})
+		info, err := f.provisioner.ProvisionCluster(ProvisionerOptions{
+			Name:         name,
+			ExpectConsul: s.Consul,
+			ExpectVault:  s.Vault,
+		})
 		if err != nil {
 			return false, fmt.Errorf("could not provision cluster for case: %v", err)
 		}

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -152,14 +152,14 @@ func (f *Framework) runSuite(t *testing.T, s *TestSuite) (skip bool, err error) 
 			}
 
 			// Check if the case includes a before all function
-			if beforeAllSteps, ok := c.(BeforeAllSteps); ok {
-				beforeAllSteps.BeforeAllSteps()
+			if beforeAllTests, ok := c.(BeforeAllTests); ok {
+				beforeAllTests.BeforeAll()
 			}
 
 			// Check if the case includes an after all function at the end
 			defer func() {
-				if afterAllSteps, ok := c.(AfterAllSteps); ok {
-					afterAllSteps.AfterAllSteps()
+				if afterAllTests, ok := c.(AfterAllTests); ok {
+					afterAllTests.AfterAll()
 				}
 			}()
 
@@ -171,21 +171,21 @@ func (f *Framework) runSuite(t *testing.T, s *TestSuite) (skip bool, err error) 
 				if ok := isTestMethod(method.Name); !ok {
 					continue
 				}
-				// Each step is run as its own sub test of the case
+				// Each test is run as its own sub test of the case
 				// Test cases are never parallel
 				t.Run(method.Name, func(t *testing.T) {
 
 					// Since the test function interacts with testing.T through
 					// the test case struct, we need to swap the test context for
-					// the duration of the step.
+					// the duration of the test.
 					parentT := c.T()
 					c.SetT(t)
-					if BeforeEachStep, ok := c.(BeforeEachStep); ok {
-						BeforeEachStep.BeforeEachStep()
+					if BeforeEachTest, ok := c.(BeforeEachTest); ok {
+						BeforeEachTest.BeforeEach()
 					}
 					defer func() {
-						if afterEachStep, ok := c.(AfterEachStep); ok {
-							afterEachStep.AfterEachStep()
+						if afterEachTest, ok := c.(AfterEachTest); ok {
+							afterEachTest.AfterEach()
 						}
 						c.SetT(parentT)
 					}()
@@ -205,6 +205,6 @@ func isTestMethod(m string) bool {
 	if !strings.HasPrefix(m, "Test") {
 		return false
 	}
-	// THINKING: adding flag to target a specific step or step regex?
+	// THINKING: adding flag to target a specific test or test regex?
 	return true
 }

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -131,7 +131,10 @@ func (f *Framework) runSuite(t *testing.T, s *TestSuite) (skip bool, err error) 
 		// The test name is set to the name of the implementing type, including package
 		name := fmt.Sprintf("%T", c)
 
-		// Each TestCase is provisioned a nomad cluster
+		// Each TestCase is provisioned a Nomad cluster to test against.
+		// This varies by the provisioner implementation used, currently
+		// the default behavior is for every Test case to use a single shared
+		// Nomad cluster.
 		info, err := f.provisioner.ProvisionCluster(ProvisionerOptions{
 			Name:         name,
 			ExpectConsul: s.Consul,
@@ -176,7 +179,7 @@ func (f *Framework) runSuite(t *testing.T, s *TestSuite) (skip bool, err error) 
 				// Test cases are never parallel
 				t.Run(method.Name, func(t *testing.T) {
 
-					cF := newF(t)
+					cF := newFFromParent(f, t)
 					if BeforeEachTest, ok := c.(BeforeEachTest); ok {
 						BeforeEachTest.BeforeEach(cF)
 					}

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -1,0 +1,183 @@
+package framework
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+var fProvider = flag.String("nomad.env.provider", "", "cloud provider for which environment is executing against")
+var fEnv = flag.String("nomad.env", "", "name of the environment executing against")
+var fOS = flag.String("nomad.os", "", "operating system for which the environment is executing against")
+var fArch = flag.String("nomad.arch", "", "cpu architecture for which the environment is executing against")
+var fTags = flag.String("nomad.tags", "", "comma delimited list of tags associated with the environment")
+var fLocal = flag.Bool("nomad.local", false, "denotes execution is against a local environment")
+var fSlow = flag.Bool("nomad.slow", false, "toggles execution of slow test suites")
+var fForceAll = flag.Bool("nomad.force", false, "if set, skips all environment checks when filtering test suites")
+
+var pkgFramework = New()
+
+type Framework struct {
+	suites      []*TestSuite
+	provisioner Provisioner
+	env         Environment
+
+	isLocalRun bool
+	slow       bool
+	force      bool
+}
+
+type Environment struct {
+	Name     string
+	Provider string
+	OS       string
+	Arch     string
+	Tags     map[string]struct{}
+}
+
+func New() *Framework {
+	env := Environment{
+		Name:     *fEnv,
+		Provider: *fProvider,
+		OS:       *fOS,
+		Arch:     *fArch,
+		Tags:     map[string]struct{}{},
+	}
+	for _, tag := range strings.Split(*fTags, ",") {
+		env.Tags[tag] = struct{}{}
+	}
+	return &Framework{
+		provisioner: DefaultProvisioner,
+		env:         env,
+		isLocalRun:  *fLocal,
+		slow:        *fSlow,
+		force:       *fForceAll,
+	}
+}
+
+func (f *Framework) AddSuites(s ...*TestSuite) *Framework {
+	f.suites = append(f.suites, s...)
+	return f
+}
+
+func AddSuites(s ...*TestSuite) *Framework {
+	pkgFramework.AddSuites(s...)
+	return pkgFramework
+}
+
+// Run starts the test framework and runs each TestSuite
+func (f *Framework) Run(t *testing.T) {
+	for _, s := range f.suites {
+		t.Run(s.Component, func(t *testing.T) {
+			skip, err := f.runSuite(t, s)
+			if skip {
+				t.Skipf("skipping suite '%s': %v", s.Component, err)
+				return
+			}
+			if err != nil {
+				t.Errorf("error starting suite '%s': %v", s.Component, err)
+			}
+		})
+	}
+
+}
+
+func Run(t *testing.T) {
+	pkgFramework.Run(t)
+}
+
+// runSuite is called from Framework.Run inside of a sub test for each TestSuite
+func (f *Framework) runSuite(t *testing.T, s *TestSuite) (skip bool, err error) {
+
+	if !f.force {
+		// If this is a local run, check that the suite supports running locally
+		if !s.CanRunLocal && f.isLocalRun {
+			return true, fmt.Errorf("local run detected and suite cannot run locally")
+		}
+
+		// Check that constraints are met
+		if err := s.Constraints.matches(f.env); err != nil {
+			return true, fmt.Errorf("constraint failed: %v", err)
+		}
+
+		// Check the slow toggle and if the suite's slow flag is that same
+		if f.slow != s.Slow {
+			return true, fmt.Errorf("framework slow suite configuration is %v but suite is %v", f.slow, s.Slow)
+		}
+	}
+
+	for _, c := range s.Cases {
+		name := fmt.Sprintf("%T", c)
+		// Each TestCase is provisioned a nomad cluster
+		info, err := f.provisioner.ProvisionCluster(ProvisionerOptions{Name: name})
+		if err != nil {
+			return false, fmt.Errorf("could not provision cluster for case: %v", err)
+		}
+		defer f.provisioner.DestroyCluster(info.ID)
+
+		c.setClusterInfo(info)
+		// Each TestCase runs as a subtest of the TestSuite
+		t.Run(c.Name(), func(t *testing.T) {
+			c.SetT(t)
+			// If the TestSuite has Parallel set, all cases run in parallel
+			if s.Parallel {
+				t.Parallel()
+			}
+
+			// Check if the case includes a before all function
+			if beforeAllSteps, ok := c.(BeforeAllSteps); ok {
+				beforeAllSteps.BeforeAllSteps()
+			}
+
+			// Check if the case includes an after all function at the end
+			defer func() {
+				if afterAllSteps, ok := c.(AfterAllSteps); ok {
+					afterAllSteps.AfterAllSteps()
+				}
+			}()
+
+			// Here we need to iterate through the methods of the case to find
+			// ones that at test functions
+			reflectC := reflect.TypeOf(c)
+			for i := 0; i < reflectC.NumMethod(); i++ {
+				method := reflectC.Method(i)
+				if ok, _ := isTestMethod(method.Name); !ok {
+					continue
+				}
+				// Each step is run as its own sub test of the case
+				t.Run(method.Name, func(t *testing.T) {
+
+					// Since the test function interacts with testing.T through
+					// the test case struct, we need to swap the test context for
+					// the duration of the step.
+					parentT := c.T()
+					c.SetT(t)
+					if BeforeEachStep, ok := c.(BeforeEachStep); ok {
+						BeforeEachStep.BeforeEachStep()
+					}
+					defer func() {
+						if afterEachStep, ok := c.(AfterEachStep); ok {
+							afterEachStep.AfterEachStep()
+						}
+						c.SetT(parentT)
+					}()
+					//Call the method
+					method.Func.Call([]reflect.Value{reflect.ValueOf(c)})
+				})
+			}
+		})
+
+	}
+
+	return false, nil
+}
+
+func isTestMethod(m string) (bool, error) {
+	if !strings.HasPrefix(m, "Test") {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/e2e/framework/interfaces.go
+++ b/e2e/framework/interfaces.go
@@ -4,16 +4,13 @@ import (
 	"testing"
 )
 
-// Named exists simply to make sure the Name() method was implemented since it
-// is the only required method implementation of a test case
-type Named interface {
-	Name() string
-}
-
+// TestCase is the interface which an E2E test case implements.
+// It is not meant to be implemented directly, instead the struct should embed
+// the 'framework.TC' struct
 type TestCase interface {
-	Named
 	internalTestCase
 
+	Name() string
 	T() *testing.T
 	SetT(*testing.T)
 }
@@ -22,18 +19,24 @@ type internalTestCase interface {
 	setClusterInfo(*ClusterInfo)
 }
 
+// BeforeAllSteps is used to define a method to be called before the execution
+// of all test steps.
 type BeforeAllSteps interface {
 	BeforeAllSteps()
 }
 
+// AfterAllSteps is used to define a method to be called after the execution of
+// all test steps.
 type AfterAllSteps interface {
 	AfterAllSteps()
 }
 
+// BeforeEachStep is used to define a method to be called before each test step.
 type BeforeEachStep interface {
 	BeforeEachStep()
 }
 
+// AfterEachStep is used to degine a method to be called after each test step.
 type AfterEachStep interface {
 	AfterEachStep()
 }

--- a/e2e/framework/interfaces.go
+++ b/e2e/framework/interfaces.go
@@ -1,0 +1,39 @@
+package framework
+
+import (
+	"testing"
+)
+
+// Named exists simply to make sure the Name() method was implemented since it
+// is the only required method implementation of a test case
+type Named interface {
+	Name() string
+}
+
+type TestCase interface {
+	Named
+	internalTestCase
+
+	T() *testing.T
+	SetT(*testing.T)
+}
+
+type internalTestCase interface {
+	setClusterInfo(*ClusterInfo)
+}
+
+type BeforeAllSteps interface {
+	BeforeAllSteps()
+}
+
+type AfterAllSteps interface {
+	AfterAllSteps()
+}
+
+type BeforeEachStep interface {
+	BeforeEachStep()
+}
+
+type AfterEachStep interface {
+	AfterEachStep()
+}

--- a/e2e/framework/interfaces.go
+++ b/e2e/framework/interfaces.go
@@ -19,24 +19,24 @@ type internalTestCase interface {
 	setClusterInfo(*ClusterInfo)
 }
 
-// BeforeAllSteps is used to define a method to be called before the execution
-// of all test steps.
-type BeforeAllSteps interface {
-	BeforeAllSteps()
+// BeforeAllTests is used to define a method to be called before the execution
+// of all tests.
+type BeforeAllTests interface {
+	BeforeAll()
 }
 
-// AfterAllSteps is used to define a method to be called after the execution of
-// all test steps.
-type AfterAllSteps interface {
-	AfterAllSteps()
+// AfterAllTests is used to define a method to be called after the execution of
+// all tests.
+type AfterAllTests interface {
+	AfterAll()
 }
 
-// BeforeEachStep is used to define a method to be called before each test step.
-type BeforeEachStep interface {
-	BeforeEachStep()
+// BeforeEachTest is used to define a method to be called before each test.
+type BeforeEachTest interface {
+	BeforeEach()
 }
 
-// AfterEachStep is used to degine a method to be called after each test step.
-type AfterEachStep interface {
-	AfterEachStep()
+// AfterEachTest is used to degine a method to be called after each test.
+type AfterEachTest interface {
+	AfterEach()
 }

--- a/e2e/framework/interfaces.go
+++ b/e2e/framework/interfaces.go
@@ -1,9 +1,5 @@
 package framework
 
-import (
-	"testing"
-)
-
 // TestCase is the interface which an E2E test case implements.
 // It is not meant to be implemented directly, instead the struct should embed
 // the 'framework.TC' struct
@@ -11,8 +7,6 @@ type TestCase interface {
 	internalTestCase
 
 	Name() string
-	T() *testing.T
-	SetT(*testing.T)
 }
 
 type internalTestCase interface {
@@ -22,21 +16,21 @@ type internalTestCase interface {
 // BeforeAllTests is used to define a method to be called before the execution
 // of all tests.
 type BeforeAllTests interface {
-	BeforeAll()
+	BeforeAll(*F)
 }
 
 // AfterAllTests is used to define a method to be called after the execution of
 // all tests.
 type AfterAllTests interface {
-	AfterAll()
+	AfterAll(*F)
 }
 
 // BeforeEachTest is used to define a method to be called before each test.
 type BeforeEachTest interface {
-	BeforeEach()
+	BeforeEach(*F)
 }
 
 // AfterEachTest is used to degine a method to be called after each test.
 type AfterEachTest interface {
-	AfterEach()
+	AfterEach(*F)
 }

--- a/e2e/framework/provisioner.go
+++ b/e2e/framework/provisioner.go
@@ -1,0 +1,66 @@
+package framework
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	capi "github.com/hashicorp/consul/api"
+	napi "github.com/hashicorp/nomad/api"
+	vapi "github.com/hashicorp/vault/api"
+)
+
+type ProvisionerOptions struct {
+	Name    string
+	Servers int
+	Clients int
+}
+
+type ClusterInfo struct {
+	ID           string
+	Name         string
+	Servers      []string
+	Clients      []string
+	NomadClient  *napi.Client
+	ConsulClient *capi.Client
+	VaultClient  *vapi.Client
+}
+
+type Provisioner interface {
+	ProvisionCluster(opts ProvisionerOptions) (*ClusterInfo, error)
+	DestroyCluster(clusterID string) error
+}
+
+var DefaultProvisioner Provisioner = new(singleClusterProvisioner)
+
+type singleClusterProvisioner struct{}
+
+func (p *singleClusterProvisioner) ProvisionCluster(opts ProvisionerOptions) (*ClusterInfo, error) {
+	h := md5.New()
+	h.Write([]byte(opts.Name))
+	info := &ClusterInfo{
+		ID:   hex.EncodeToString(h.Sum(nil))[:8],
+		Name: opts.Name,
+	}
+	nomadAddr := os.Getenv("NOMAD_ADDR")
+	if len(nomadAddr) == 0 {
+		return nil, fmt.Errorf("environment variable NOMAD_ADDR not set")
+	}
+
+	nomadConfig := napi.DefaultConfig()
+	nomadConfig.Address = nomadAddr
+	nomadClient, err := napi.NewClient(nomadConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	info.NomadClient = nomadClient
+
+	return info, err
+}
+
+func (p *singleClusterProvisioner) DestroyCluster(_ string) error {
+	//Maybe try to GC things based on id?
+	return nil
+}

--- a/e2e/framework/provisioner.go
+++ b/e2e/framework/provisioner.go
@@ -11,32 +11,37 @@ import (
 	vapi "github.com/hashicorp/vault/api"
 )
 
+// ProvisionerOptions defines options to be given to the Provisioner when calling
+// ProvisionCluster
 type ProvisionerOptions struct {
-	Name    string
-	Servers int
-	Clients int
+	Name         string
+	ExpectConsul bool // If true, fails if a Consul client can't be configured
+	ExpectVault  bool // If true, fails if a Vault client can't be configured
 }
 
 type ClusterInfo struct {
 	ID           string
 	Name         string
-	Servers      []string
-	Clients      []string
 	NomadClient  *napi.Client
 	ConsulClient *capi.Client
 	VaultClient  *vapi.Client
 }
 
+// Provisioner interface is used by the test framework to provision a Nomad
+// cluster for each TestCase
 type Provisioner interface {
 	ProvisionCluster(opts ProvisionerOptions) (*ClusterInfo, error)
 	DestroyCluster(clusterID string) error
 }
 
+// DefaultProvisioner is a noop provisioner that builds clients from environment
+// variables according to the respective client configuration
 var DefaultProvisioner Provisioner = new(singleClusterProvisioner)
 
 type singleClusterProvisioner struct{}
 
 func (p *singleClusterProvisioner) ProvisionCluster(opts ProvisionerOptions) (*ClusterInfo, error) {
+	// Build ID based off given name
 	h := md5.New()
 	h.Write([]byte(opts.Name))
 	info := &ClusterInfo{
@@ -44,10 +49,12 @@ func (p *singleClusterProvisioner) ProvisionCluster(opts ProvisionerOptions) (*C
 		Name: opts.Name,
 	}
 
+	// Nomad client is required
 	if len(os.Getenv("NOMAD_ADDR")) == 0 {
 		return nil, fmt.Errorf("environment variable NOMAD_ADDR not set")
 	}
 
+	// Build Nomad api client
 	nomadClient, err := napi.NewClient(napi.DefaultConfig())
 	if err != nil {
 		return nil, err
@@ -56,18 +63,24 @@ func (p *singleClusterProvisioner) ProvisionCluster(opts ProvisionerOptions) (*C
 
 	if len(os.Getenv(capi.HTTPAddrEnvName)) != 0 {
 		consulClient, err := capi.NewClient(capi.DefaultConfig())
-		if err != nil {
+		if err != nil && opts.ExpectConsul {
 			return nil, err
 		}
 		info.ConsulClient = consulClient
+	} else if opts.ExpectConsul {
+		return nil, fmt.Errorf("consul client expected but environment variable %s not set",
+			capi.HTTPAddrEnvName)
 	}
 
 	if len(os.Getenv(vapi.EnvVaultAddress)) != 0 {
 		vaultClient, err := vapi.NewClient(vapi.DefaultConfig())
-		if err != nil {
+		if err != nil && opts.ExpectVault {
 			return nil, err
 		}
 		info.VaultClient = vaultClient
+	} else if opts.ExpectVault {
+		return nil, fmt.Errorf("vault client expected but environment variable %s not set",
+			vapi.EnvVaultAddress)
 	}
 
 	return info, err

--- a/e2e/framework/provisioner.go
+++ b/e2e/framework/provisioner.go
@@ -49,11 +49,6 @@ func (p *singleClusterProvisioner) ProvisionCluster(opts ProvisionerOptions) (*C
 		Name: opts.Name,
 	}
 
-	// Nomad client is required
-	if len(os.Getenv("NOMAD_ADDR")) == 0 {
-		return nil, fmt.Errorf("environment variable NOMAD_ADDR not set")
-	}
-
 	// Build Nomad api client
 	nomadClient, err := napi.NewClient(napi.DefaultConfig())
 	if err != nil {

--- a/e2e/framework/provisioner.go
+++ b/e2e/framework/provisioner.go
@@ -43,19 +43,32 @@ func (p *singleClusterProvisioner) ProvisionCluster(opts ProvisionerOptions) (*C
 		ID:   hex.EncodeToString(h.Sum(nil))[:8],
 		Name: opts.Name,
 	}
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	if len(nomadAddr) == 0 {
+
+	if len(os.Getenv("NOMAD_ADDR")) == 0 {
 		return nil, fmt.Errorf("environment variable NOMAD_ADDR not set")
 	}
 
-	nomadConfig := napi.DefaultConfig()
-	nomadConfig.Address = nomadAddr
-	nomadClient, err := napi.NewClient(nomadConfig)
+	nomadClient, err := napi.NewClient(napi.DefaultConfig())
 	if err != nil {
 		return nil, err
 	}
-
 	info.NomadClient = nomadClient
+
+	if len(os.Getenv(capi.HTTPAddrEnvName)) != 0 {
+		consulClient, err := capi.NewClient(capi.DefaultConfig())
+		if err != nil {
+			return nil, err
+		}
+		info.ConsulClient = consulClient
+	}
+
+	if len(os.Getenv(vapi.EnvVaultAddress)) != 0 {
+		vaultClient, err := vapi.NewClient(vapi.DefaultConfig())
+		if err != nil {
+			return nil, err
+		}
+		info.VaultClient = vaultClient
+	}
 
 	return info, err
 }

--- a/e2e/framework/provisioner.go
+++ b/e2e/framework/provisioner.go
@@ -1,13 +1,12 @@
 package framework
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"os"
 
 	capi "github.com/hashicorp/consul/api"
 	napi "github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/helper/uuid"
 	vapi "github.com/hashicorp/vault/api"
 )
 
@@ -42,10 +41,8 @@ type singleClusterProvisioner struct{}
 
 func (p *singleClusterProvisioner) ProvisionCluster(opts ProvisionerOptions) (*ClusterInfo, error) {
 	// Build ID based off given name
-	h := md5.New()
-	h.Write([]byte(opts.Name))
 	info := &ClusterInfo{
-		ID:   hex.EncodeToString(h.Sum(nil))[:8],
+		ID:   uuid.Generate()[:8],
 		Name: opts.Name,
 	}
 


### PR DESCRIPTION
Initial work on the e2e framework is complete.

The high level design includes a framework which composed of multiple test suites. Test suites test a particular feature or component and defines conditions under which it should run (for example only on cloud provider X). Each test suite also includes multiple test cases. Test cases are user defined structs that can define setup/teardown logic as well as multiple tests. State can be shared in the struct between setup and test execution. This allows for a common scenario where you wish to setup a complex state within nomad then apply different sets operations to the same original state.

See the included `doc.go` for more in-depth documentation. 