### PR TITLE
UI: Jobs requested with the wrong namespace under the right conditions

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -1,5 +1,4 @@
 import { inject as service } from '@ember/service';
-import { assign } from '@ember/polyfills';
 import Watchable from './watchable';
 
 export default Watchable.extend({
@@ -21,12 +20,6 @@ export default Watchable.extend({
         job.Namespace = namespace ? namespace.get('id') : 'default';
       });
       return data;
-    });
-  },
-
-  findRecordSummary(modelName, name, snapshot, namespaceQuery) {
-    return this.ajax(`${this.buildURL(modelName, name, snapshot, 'findRecord')}/summary`, 'GET', {
-      data: assign(this.buildQuery() || {}, namespaceQuery),
     });
   },
 

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -52,18 +52,9 @@ export default Watchable.extend({
     summary: '/summary',
   },
 
-  findAllocations(job) {
-    const url = `${this.buildURL('job', job.get('id'), job, 'findRecord')}/allocations`;
-    return this.ajax(url, 'GET', { data: this.buildQuery() }).then(allocs => {
-      return this.store.pushPayload('allocation', {
-        allocations: allocs,
-      });
-    });
-  },
-
   fetchRawDefinition(job) {
     const url = this.buildURL('job', job.get('id'), job, 'findRecord');
-    return this.ajax(url, 'GET', { data: this.buildQuery() });
+    return this.ajax(url, 'GET');
   },
 
   forcePeriodic(job) {

--- a/ui/app/adapters/node.js
+++ b/ui/app/adapters/node.js
@@ -1,12 +1,3 @@
 import Watchable from './watchable';
 
-export default Watchable.extend({
-  findAllocations(node) {
-    const url = `${this.buildURL('node', node.get('id'), node, 'findRecord')}/allocations`;
-    return this.ajax(url, 'GET').then(allocs => {
-      return this.store.pushPayload('allocation', {
-        allocations: allocs,
-      });
-    });
-  },
-});
+export default Watchable.extend();

--- a/ui/app/utils/properties/watch.js
+++ b/ui/app/utils/properties/watch.js
@@ -3,13 +3,16 @@ import { get } from '@ember/object';
 import RSVP from 'rsvp';
 import { task } from 'ember-concurrency';
 import wait from 'nomad-ui/utils/wait';
+import config from 'nomad-ui/config/environment';
+
+const isEnabled = config.APP.blockingQueries !== false;
 
 export function watchRecord(modelName) {
   return task(function*(id, throttle = 2000) {
     if (typeof id === 'object') {
       id = get(id, 'id');
     }
-    while (!Ember.testing) {
+    while (isEnabled && !Ember.testing) {
       try {
         yield RSVP.all([
           this.get('store').findRecord(modelName, id, {
@@ -32,7 +35,7 @@ export function watchRecord(modelName) {
 
 export function watchRelationship(relationshipName) {
   return task(function*(model, throttle = 2000) {
-    while (!Ember.testing) {
+    while (isEnabled && !Ember.testing) {
       try {
         yield RSVP.all([
           this.get('store')
@@ -54,7 +57,7 @@ export function watchRelationship(relationshipName) {
 
 export function watchAll(modelName) {
   return task(function*(throttle = 2000) {
-    while (!Ember.testing) {
+    while (isEnabled && !Ember.testing) {
       try {
         yield RSVP.all([
           this.get('store').findAll(modelName, { reload: true, adapterOptions: { watch: true } }),

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -19,8 +19,7 @@ module.exports = function(environment) {
     },
 
     APP: {
-      // Here you can pass flags/options to your application instance
-      // when it is created
+      blockingQueries: true,
     },
   };
 

--- a/ui/mirage/factories/allocation.js
+++ b/ui/mirage/factories/allocation.js
@@ -125,6 +125,7 @@ export default Factory.extend({
     );
 
     const job = allocation.jobId ? server.db.jobs.find(allocation.jobId) : pickOne(server.db.jobs);
+    const namespace = allocation.namespace || job.namespace;
     const node = allocation.nodeId
       ? server.db.nodes.find(allocation.nodeId)
       : pickOne(server.db.nodes);
@@ -147,6 +148,7 @@ export default Factory.extend({
     );
 
     allocation.update({
+      namespace,
       jobId: job.id,
       nodeId: node.id,
       taskStateIds: states.mapBy('id'),


### PR DESCRIPTION
When a namespace is set in localStorage and a job with the namespace `default` is requested, the `default` namespace gets overridden by the namespace in localStorage.

**Example:** 
`{ id: 'my-job', namespace: 'default' }` gets requested as 
`/v1/job/my-job?namespace=ns-in-local-storage`

Since the jobs routes set the local storage namespace before fetching any data, the only places this could occur were on clients and allocations. The easiest way to reproduce this bug is:

1. Change namespaces to something other than default
2. Reload the page to ensure the localStorage param is being used from the beginning of the app's life
3. Visit the clients page.
4. Visit individual clients.
5. Observe allocations with "..." as their job/task-group.

Note that namespaces are an enterprise feature so this ui bug only impacted enterprise deployments.