### PR TITLE
Fix and speedup rkt tests

### DIFF
--- a/client/driver/driver_test.go
+++ b/client/driver/driver_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/nomad/client/driver/env"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/testtask"
-	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -112,11 +111,13 @@ type testContext struct {
 func testDriverContexts(t *testing.T, task *structs.Task) *testContext {
 	cfg := testConfig(t)
 	cfg.Node = mock.Node()
-	allocDir := allocdir.NewAllocDir(testlog.Logger(t), filepath.Join(cfg.AllocDir, uuid.Generate()))
+	alloc := mock.Alloc()
+	alloc.NodeID = cfg.Node.ID
+
+	allocDir := allocdir.NewAllocDir(testlog.Logger(t), filepath.Join(cfg.AllocDir, alloc.ID))
 	if err := allocDir.Build(); err != nil {
 		t.Fatalf("AllocDir.Build() failed: %v", err)
 	}
-	alloc := mock.Alloc()
 
 	// Build a temp driver so we can call FSIsolation and build the task dir
 	tmpdrv, err := NewDriver(task.Driver, NewEmptyDriverContext())

--- a/client/driver/rkt.go
+++ b/client/driver/rkt.go
@@ -699,9 +699,12 @@ func (d *RktDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse,
 	}
 	go h.run()
 
-	// Only return a driver network if *not* using host networking
+	// Do not attempt to retrieve driver network if one won't exist:
+	//  - "host" means the container itself has no networking metadata
+	//  - "none" means no network is configured
+	// https://coreos.com/rkt/docs/latest/networking/overview.html#no-loopback-only-networking
 	var driverNetwork *cstructs.DriverNetwork
-	if network != "host" {
+	if network != "host" && network != "none" {
 		d.logger.Printf("[DEBUG] driver.rkt: retrieving network information for pod %q (UUID: %s) for task %q", img, uuid, d.taskName)
 		driverNetwork, err = rktGetDriverNetwork(uuid, driverConfig.PortMap, d.logger)
 		if err != nil && !pluginClient.Exited() {

--- a/client/driver/rkt_test.go
+++ b/client/driver/rkt_test.go
@@ -277,7 +277,7 @@ func TestRktDriver_Start_Wait_AllocDir(t *testing.T) {
 		Name:   "rkttest_alpine",
 		Driver: "rkt",
 		Config: map[string]interface{}{
-			"image":   "docker://redis:4-alpine",
+			"image":   "docker://redis:3.2-alpine",
 			"command": "/bin/sh",
 			"args": []string{
 				"-c",
@@ -343,7 +343,7 @@ func TestRktDriver_UserGroup(t *testing.T) {
 		Driver: "rkt",
 		User:   "nobody",
 		Config: map[string]interface{}{
-			"image":   "docker://redis:4-alpine",
+			"image":   "docker://redis:3.2-alpine",
 			"group":   "nogroup",
 			"command": "sleep",
 			"args":    []string{"9000"},
@@ -467,7 +467,7 @@ func TestRktDriver_PortMapping(t *testing.T) {
 		Name:   "redis",
 		Driver: "rkt",
 		Config: map[string]interface{}{
-			"image": "docker://redis:4-alpine",
+			"image": "docker://redis:3.2-alpine",
 			"port_map": []map[string]string{
 				{
 					"main": "6379-tcp",
@@ -536,7 +536,7 @@ func TestRktDriver_PortsMapping_Host(t *testing.T) {
 		Name:   "redis",
 		Driver: "rkt",
 		Config: map[string]interface{}{
-			"image": "docker://redis:4-alpine",
+			"image": "docker://redis:3.2-alpine",
 			"net":   []string{"host"},
 		},
 		LogConfig: &structs.LogConfig{


### PR DESCRIPTION
Fixed and sped up rkt tests (70s :arrow_right: 10s).

I standardized on alpine redis where possible as it's about 1/4 the size of the Debian image and still has `ps` which is awfully useful for tests.

Tiny code change to skip looking up networking information if `net=none` is specified. Can't imagine anyone is using that in prod, but if they are this will remove a bunch of ugly errors from their logs.

See individual commits for details.