### PR TITLE
UI: Fix the missing pixels issue with distribution-bar

### DIFF
--- a/ui/app/components/distribution-bar.js
+++ b/ui/app/components/distribution-bar.js
@@ -117,7 +117,14 @@ export default Component.extend(WindowResizable, {
 
     this.set('slices', slices);
 
-    const setWidth = d => `${width * d.percent - (d.index === sliceCount - 1 || d.index === 0 ? 1 : 2)}px`;
+    const setWidth = d => {
+      // Remove a pixel from either side of the slice
+      let modifier = 2;
+      if (d.index === 0) modifier--; // But not the left side
+      if (d.index === sliceCount - 1) modifier--; // But not the right side
+
+      return `${width * d.percent - modifier}px`;
+    };
     const setOffset = d => `${width * d.offset + (d.index === 0 ? 0 : 1)}px`;
 
     let hoverTargets = slices.selectAll('.target').data(d => [d]);

--- a/ui/app/components/distribution-bar.js
+++ b/ui/app/components/distribution-bar.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed, observer } from '@ember/object';
+import { computed, observer, set } from '@ember/object';
 import { run } from '@ember/runloop';
 import { assign } from '@ember/polyfills';
 import { guidFor, copy } from '@ember/object/internals';
@@ -76,6 +76,9 @@ export default Component.extend(WindowResizable, {
     const { chart, _data, isNarrow } = this.getProperties('chart', '_data', 'isNarrow');
     const width = this.$('svg').width();
     const filteredData = _data.filter(d => d.value > 0);
+    filteredData.forEach((d, index) => {
+      set(d, 'index', index);
+    });
 
     let slices = chart.select('.bars').selectAll('g').data(filteredData, d => d.label);
     let sliceCount = filteredData.length;
@@ -114,8 +117,8 @@ export default Component.extend(WindowResizable, {
 
     this.set('slices', slices);
 
-    const setWidth = d => `${width * d.percent - (d.index === sliceCount - 1 || d.index === 0 ? 1 : 2)}px`
-    const setOffset = d => `${width * d.offset + (d.index === 0 ? 0 : 1)}px`
+    const setWidth = d => `${width * d.percent - (d.index === sliceCount - 1 || d.index === 0 ? 1 : 2)}px`;
+    const setOffset = d => `${width * d.offset + (d.index === 0 ? 0 : 1)}px`;
 
     let hoverTargets = slices.selectAll('.target').data(d => [d]);
     hoverTargets.enter()

--- a/ui/app/components/freestyle/sg-distribution-bar.js
+++ b/ui/app/components/freestyle/sg-distribution-bar.js
@@ -17,6 +17,10 @@ export default Component.extend({
     clearInterval(this.get('timer'));
   },
 
+  distributionBarDatum: computed(() => {
+    return [{ label: 'one', value: 10 }];
+  }),
+
   distributionBarData: computed(() => {
     return [
       { label: 'one', value: 10 },

--- a/ui/app/templates/components/freestyle/sg-distribution-bar.hbs
+++ b/ui/app/templates/components/freestyle/sg-distribution-bar.hbs
@@ -67,4 +67,11 @@
       </div>
     {{/freestyle-annotation}}
   {{/collection.variant}}
+  {{#collection.variant key="single bar"}}
+    {{#freestyle-usage 'distribution-bar-single'}}
+      <div class="block" style="height:50px; width:600px;">
+        {{distribution-bar data=distributionBarDatum}}
+      </div>
+    {{/freestyle-usage}}
+  {{/collection.variant}}
 {{/freestyle-collection}}


### PR DESCRIPTION
These two pixels have been a thorn in my side for a long time.

This fixes two bugs that amount to the same missing pixel issue:
  1. Subtraction based on index was using the wrong index due to slices being filtered out when they have a value of 0.
  2. Subtracting 1 instead of 2 when a slice is both the first and last slice in the set.

Here are some very subtle before and after screenshots:

### Bug 1: A missing pixel on the right side due to wrong indices

**before**
<img width="1210" alt="screen shot 2018-07-12 at 4 43 46 pm" src="https://user-images.githubusercontent.com/174740/42665203-742e2cdc-85f3-11e8-9317-792bd6e3f577.png">

**after**
![image](https://user-images.githubusercontent.com/174740/42665214-85493002-85f3-11e8-84fb-5ee7ea8d4263.png)

### Bug 2: A missing pixel on either side due to subtracting only 1 instead of 2.

**before**
<img width="1209" alt="screen shot 2018-07-12 at 4 40 22 pm" src="https://user-images.githubusercontent.com/174740/42665235-9ec3fdf0-85f3-11e8-9374-faf57ba0efcb.png">

**after**
<img width="1211" alt="screen shot 2018-07-12 at 4 40 37 pm" src="https://user-images.githubusercontent.com/174740/42665247-a7509348-85f3-11e8-810e-b688c9f44617.png">
