### PR TITLE
Implement client state restoring

### DIFF
--- a/client/allocrunnerv2/alloc_runner.go
+++ b/client/allocrunnerv2/alloc_runner.go
@@ -196,8 +196,9 @@ func (ar *allocRunner) Alloc() *structs.Allocation {
 //    *and* within Run -- *and* Updates are applid within Run -- we may be able to
 //    skip quite a bit of locking? maybe?
 func (ar *allocRunner) SaveState() error {
+	// XXX Do we move this to the client
 	return ar.stateDB.Update(func(tx *bolt.Tx) error {
-		//XXX Track EvalID to only write alloc on change?
+		//XXX Track AllocModifyIndex to only write alloc on change?
 		// Write the allocation
 		return clientstate.PutAllocation(tx, ar.Alloc())
 	})

--- a/client/allocrunnerv2/alloc_runner.go
+++ b/client/allocrunnerv2/alloc_runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunnerv2/state"
 	"github.com/hashicorp/nomad/client/allocrunnerv2/taskrunner"
 	"github.com/hashicorp/nomad/client/config"
+	clientstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -57,12 +58,18 @@ type allocRunner struct {
 }
 
 // NewAllocRunner returns a new allocation runner.
-func NewAllocRunner(config *Config) *allocRunner {
+func NewAllocRunner(config *Config) (*allocRunner, error) {
+	alloc := config.Alloc
+	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
+	if tg == nil {
+		return nil, fmt.Errorf("failed to lookup task group %q", alloc.TaskGroup)
+	}
+
 	ar := &allocRunner{
+		alloc:        alloc,
 		clientConfig: config.ClientConfig,
 		vaultClient:  config.Vault,
-		alloc:        config.Alloc,
-		tasks:        make(map[string]*taskrunner.TaskRunner),
+		tasks:        make(map[string]*taskrunner.TaskRunner, len(tg.Tasks)),
 		waitCh:       make(chan struct{}),
 		updateCh:     make(chan *structs.Allocation),
 		stateDB:      config.StateDB,
@@ -70,15 +77,44 @@ func NewAllocRunner(config *Config) *allocRunner {
 
 	// Create alloc dir
 	//XXX update AllocDir to hc log
-	ar.allocDir = allocdir.NewAllocDir(nil, filepath.Join(config.ClientConfig.AllocDir, config.Alloc.ID))
+	ar.allocDir = allocdir.NewAllocDir(nil, filepath.Join(config.ClientConfig.AllocDir, alloc.ID))
 
 	// Create the logger based on the allocation ID
-	ar.logger = config.Logger.With("alloc_id", config.Alloc.ID)
+	ar.logger = config.Logger.With("alloc_id", alloc.ID)
 
 	// Initialize the runners hooks.
 	ar.initRunnerHooks()
 
-	return ar
+	// Create the TaskRunners
+	if err := ar.initTaskRunners(tg.Tasks); err != nil {
+		return nil, err
+	}
+
+	return ar, nil
+}
+
+// initTaskRunners creates task runners but does *not* run them.
+func (ar *allocRunner) initTaskRunners(tasks []*structs.Task) error {
+	for _, task := range tasks {
+		config := &taskrunner.Config{
+			Alloc:        ar.alloc,
+			ClientConfig: ar.clientConfig,
+			Task:         task,
+			TaskDir:      ar.allocDir.NewTaskDir(task.Name),
+			Logger:       ar.logger,
+			StateDB:      ar.stateDB,
+			VaultClient:  ar.vaultClient,
+		}
+
+		// Create, but do not Run, the task runner
+		tr, err := taskrunner.NewTaskRunner(config)
+		if err != nil {
+			return fmt.Errorf("failed creating runner for task %q: %v", task.Name, err)
+		}
+
+		ar.tasks[task.Name] = tr
+	}
+	return nil
 }
 
 func (ar *allocRunner) WaitCh() <-chan struct{} {
@@ -91,7 +127,6 @@ func (ar *allocRunner) Run() {
 	// Close the wait channel
 	defer close(ar.waitCh)
 
-	var err error
 	var taskWaitCh <-chan struct{}
 
 	// Run the prestart hooks
@@ -102,10 +137,7 @@ func (ar *allocRunner) Run() {
 	}
 
 	// Run the runners
-	taskWaitCh, err = ar.runImpl()
-	if err != nil {
-		ar.logger.Error("starting tasks failed", "error", err)
-	}
+	taskWaitCh = ar.runImpl()
 
 	for {
 		select {
@@ -130,20 +162,9 @@ POST:
 }
 
 // runImpl is used to run the runners.
-func (ar *allocRunner) runImpl() (<-chan struct{}, error) {
-	// Grab the task group
-	alloc := ar.Alloc()
-	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
-	if tg == nil {
-		// XXX Fail and exit
-		ar.logger.Error("failed to lookup task group", "task_group", alloc.TaskGroup)
-		return nil, fmt.Errorf("failed to lookup task group %q", alloc.TaskGroup)
-	}
-
-	for _, task := range tg.Tasks {
-		if err := ar.runTask(alloc, task); err != nil {
-			return nil, err
-		}
+func (ar *allocRunner) runImpl() <-chan struct{} {
+	for _, task := range ar.tasks {
+		go task.Run()
 	}
 
 	// Return a combined WaitCh that is closed when all task runners have
@@ -156,32 +177,7 @@ func (ar *allocRunner) runImpl() (<-chan struct{}, error) {
 		}
 	}()
 
-	return waitCh, nil
-}
-
-// runTask is used to run a task.
-func (ar *allocRunner) runTask(alloc *structs.Allocation, task *structs.Task) error {
-	// Create the runner
-	config := &taskrunner.Config{
-		Alloc:        alloc,
-		ClientConfig: ar.clientConfig,
-		Task:         task,
-		TaskDir:      ar.allocDir.NewTaskDir(task.Name),
-		Logger:       ar.logger,
-		StateDB:      ar.stateDB,
-		VaultClient:  ar.vaultClient,
-	}
-	tr, err := taskrunner.NewTaskRunner(config)
-	if err != nil {
-		return err
-	}
-
-	// Start the runner
-	go tr.Run()
-
-	// Store the runner
-	ar.tasks[task.Name] = tr
-	return nil
+	return waitCh
 }
 
 // Alloc returns the current allocation being run by this runner.
@@ -193,9 +189,29 @@ func (ar *allocRunner) Alloc() *structs.Allocation {
 }
 
 // SaveState does all the state related stuff. Who knows. FIXME
-//XXX
+//XXX do we need to do periodic syncing? if Saving is only called *before* Run
+//    *and* within Run -- *and* Updates are applid within Run -- we may be able to
+//    skip quite a bit of locking? maybe?
 func (ar *allocRunner) SaveState() error {
-	return nil
+	return ar.stateDB.Update(func(tx *bolt.Tx) error {
+		//XXX Track EvalID to only write alloc on change?
+		// Write the allocation
+		return clientstate.PutAllocation(tx, ar.Alloc())
+	})
+}
+
+// Restore state from database. Must be called after NewAllocRunner but before
+// Run.
+func (ar *allocRunner) Restore() error {
+	return ar.stateDB.View(func(tx *bolt.Tx) error {
+		// Restore task runners
+		for _, tr := range ar.tasks {
+			if err := tr.Restore(tx); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // Update the running allocation with a new version received from the server.

--- a/client/allocrunnerv2/alloc_runner.go
+++ b/client/allocrunnerv2/alloc_runner.go
@@ -1,6 +1,7 @@
 package allocrunnerv2
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -139,10 +140,12 @@ func (ar *allocRunner) Run() {
 	// Run the runners
 	taskWaitCh = ar.runImpl()
 
+MAIN:
 	for {
 		select {
 		case <-taskWaitCh:
 			// TaskRunners have all exited
+			break MAIN
 		case updated := <-ar.updateCh:
 			// Updated alloc received
 			//XXX Update hooks
@@ -231,6 +234,10 @@ func (ar *allocRunner) Update(update *structs.Allocation) {
 //XXX TODO
 func (ar *allocRunner) Destroy() {
 	//TODO
+
+	for _, tr := range ar.tasks {
+		tr.Kill(context.Background(), structs.NewTaskEvent(structs.TaskKilled))
+	}
 }
 
 // IsDestroyed returns true if the alloc runner has been destroyed (stopped and

--- a/client/allocrunnerv2/alloc_runner_test.go
+++ b/client/allocrunnerv2/alloc_runner_test.go
@@ -1,5 +1,7 @@
 package allocrunnerv2
 
+/*
+
 import (
 	"testing"
 
@@ -82,3 +84,4 @@ func TestAllocRunner_Postrun_Basic(t *testing.T) {
 	require.True(post.run)
 	require.False(pre.run)
 }
+*/

--- a/client/allocrunnerv2/taskrunner/artifact_hook.go
+++ b/client/allocrunnerv2/taskrunner/artifact_hook.go
@@ -30,15 +30,14 @@ func (*artifactHook) Name() string {
 }
 
 func (h *artifactHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
-	h.eventEmitter.SetState(structs.TaskStatePending, structs.NewTaskEvent(structs.TaskDownloadingArtifacts))
+	h.eventEmitter.EmitEvent(structs.NewTaskEvent(structs.TaskDownloadingArtifacts))
 
 	for _, artifact := range req.Task.Artifacts {
 		//XXX add ctx to GetArtifact to allow cancelling long downloads
 		if err := getter.GetArtifact(req.TaskEnv, artifact, req.TaskDir); err != nil {
 			wrapped := fmt.Errorf("failed to download artifact %q: %v", artifact.GetterSource, err)
 			h.logger.Debug(wrapped.Error())
-			h.eventEmitter.SetState(structs.TaskStatePending,
-				structs.NewTaskEvent(structs.TaskArtifactDownloadFailed).SetDownloadError(wrapped))
+			h.eventEmitter.EmitEvent(structs.NewTaskEvent(structs.TaskArtifactDownloadFailed).SetDownloadError(wrapped))
 			return wrapped
 		}
 	}

--- a/client/allocrunnerv2/taskrunner/interfaces/events.go
+++ b/client/allocrunnerv2/taskrunner/interfaces/events.go
@@ -3,6 +3,5 @@ package interfaces
 import "github.com/hashicorp/nomad/nomad/structs"
 
 type EventEmitter interface {
-	SetState(state string, event *structs.TaskEvent)
 	EmitEvent(event *structs.TaskEvent)
 }

--- a/client/allocrunnerv2/taskrunner/state/state.go
+++ b/client/allocrunnerv2/taskrunner/state/state.go
@@ -5,6 +5,13 @@ import (
 	"github.com/hashicorp/nomad/helper"
 )
 
+var (
+	// taskRunnerStateAllKey holds all the task runners state. At the moment
+	// there is no need to split it
+	//XXX refactor out of client/state and taskrunner
+	taskRunnerStateAllKey = []byte("simple-all")
+)
+
 // LocalState is Task state which is persisted for use when restarting Nomad
 // agents.
 type LocalState struct {

--- a/client/allocrunnerv2/taskrunner/state/state.go
+++ b/client/allocrunnerv2/taskrunner/state/state.go
@@ -5,13 +5,6 @@ import (
 	"github.com/hashicorp/nomad/helper"
 )
 
-var (
-	// taskRunnerStateAllKey holds all the task runners state. At the moment
-	// there is no need to split it
-	//XXX refactor out of client/state and taskrunner
-	taskRunnerStateAllKey = []byte("simple-all")
-)
-
 // LocalState is Task state which is persisted for use when restarting Nomad
 // agents.
 type LocalState struct {
@@ -48,7 +41,7 @@ type HookState struct {
 	// Prestart is true if the hook has run Prestart successfully and does
 	// not need to run again
 	PrestartDone bool
-	Data       map[string]string
+	Data         map[string]string
 }
 
 func (h *HookState) Copy() *HookState {

--- a/client/allocrunnerv2/taskrunner/task_dir_hook.go
+++ b/client/allocrunnerv2/taskrunner/task_dir_hook.go
@@ -35,7 +35,7 @@ func (h *taskDirHook) Prestart(ctx context.Context, req *interfaces.TaskPrestart
 	}
 
 	// Emit the event that we are going to be building the task directory
-	h.runner.SetState("", structs.NewTaskEvent(structs.TaskSetup).SetMessage(structs.TaskBuildingTaskDir))
+	h.runner.EmitEvent(structs.NewTaskEvent(structs.TaskSetup).SetMessage(structs.TaskBuildingTaskDir))
 
 	// Build the task directory structure
 	fsi := h.runner.driver.FSIsolation()

--- a/client/allocrunnerv2/taskrunner/task_runner.go
+++ b/client/allocrunnerv2/taskrunner/task_runner.go
@@ -507,7 +507,7 @@ func (tr *TaskRunner) SetState(state string, event *structs.TaskEvent) {
 	taskState := tr.state
 
 	//XXX REMOVE ME AFTER TESTING
-	if state != "" {
+	if state == "" {
 		panic("SetState must not be called with an empty state")
 	}
 

--- a/client/allocrunnerv2/taskrunner/task_runner.go
+++ b/client/allocrunnerv2/taskrunner/task_runner.go
@@ -473,6 +473,10 @@ func (tr *TaskRunner) persistLocalState() error {
 	})
 }
 
+// XXX If the objects don't exists since the client shutdown before the task
+// runner ever saved state, then we should treat it as a new task runner and not
+// return an error
+//
 // Restore task runner state. Called by AllocRunner.Restore after NewTaskRunner
 // but before Run so no locks need to be acquired.
 func (tr *TaskRunner) Restore(tx *bolt.Tx) error {
@@ -495,6 +499,10 @@ func (tr *TaskRunner) Restore(tx *bolt.Tx) error {
 		return fmt.Errorf("failed to read task state: %v", err)
 	}
 	tr.state = &ts
+
+	// XXX if driver has task {
+	// tr.restoreDriver()
+	// }
 
 	return nil
 }

--- a/client/allocrunnerv2/taskrunner/task_runner_hooks.go
+++ b/client/allocrunnerv2/taskrunner/task_runner_hooks.go
@@ -124,8 +124,9 @@ func (tr *TaskRunner) prestart() error {
 			}
 			tr.localStateLock.Unlock()
 
-			// Persist local state if the hook state has changed
+			// Store and persist local state if the hook state has changed
 			if !hookState.Equal(origHookState) {
+				tr.localState.Hooks[name] = hookState
 				if err := tr.persistLocalState(); err != nil {
 					return err
 				}

--- a/client/client.go
+++ b/client/client.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	consulApi "github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/servers"
-	"github.com/hashicorp/nomad/client/state"
+	clientstate "github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/stats"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/vaultclient"
@@ -109,6 +109,8 @@ type AllocRunner interface {
 	SaveState() error
 	Update(*structs.Allocation)
 	Alloc() *structs.Allocation
+	Restore() error
+	Run()
 }
 
 // Client is used to implement the client interaction with Nomad. Clients
@@ -721,6 +723,7 @@ func (c *Client) restoreState() error {
 		return nil
 	}
 
+	//XXX REMOVED! make a note in backward compat / upgrading doc
 	// COMPAT: Remove in 0.7.0
 	// 0.6.0 transitioned from individual state files to a single bolt-db.
 	// The upgrade path is to:
@@ -728,74 +731,72 @@ func (c *Client) restoreState() error {
 	//   If so, restore from that and delete old state
 	// Restore using state database
 
-	// Allocs holds the IDs of the allocations being restored
-	var allocs []string
-
-	// Upgrading tracks whether this is a pre 0.6.0 upgrade path
-	var upgrading bool
-
-	// Scan the directory
-	allocDir := filepath.Join(c.config.StateDir, "alloc")
-	list, err := ioutil.ReadDir(allocDir)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to list alloc state: %v", err)
-	} else if err == nil && len(list) != 0 {
-		upgrading = true
-		for _, entry := range list {
-			allocs = append(allocs, entry.Name())
-		}
-	} else {
-		// Normal path
-		err := c.stateDB.View(func(tx *bolt.Tx) error {
-			allocs, err = state.GetAllAllocationIDs(tx)
-			if err != nil {
-				return fmt.Errorf("failed to list allocations: %v", err)
-			}
-			return nil
-		})
+	// Restore allocations
+	var allocs []*structs.Allocation
+	var err error
+	err = c.stateDB.View(func(tx *bolt.Tx) error {
+		allocs, err = clientstate.GetAllAllocations(tx)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to list allocations: %v", err)
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// Load each alloc back
 	var mErr multierror.Error
-	for _, id := range allocs {
-		alloc := &structs.Allocation{ID: id}
-
-		// don't worry about blocking/migrating when restoring
-		watcher := allocrunner.NoopPrevAlloc{}
+	for _, alloc := range allocs {
+		//XXX FIXME create a root logger
+		logger := hclog.New(&hclog.LoggerOptions{
+			Name:       "nomad",
+			Level:      hclog.LevelFromString(c.configCopy.LogLevel),
+			TimeFormat: time.RFC3339,
+		})
 
 		c.configLock.RLock()
-		ar := allocrunner.NewAllocRunner(c.logger, c.configCopy.Copy(), c.stateDB, c.updateAllocStatus, alloc, c.vaultClient, c.consulService, watcher)
+		arConf := &allocrunnerv2.Config{
+			Alloc:        alloc,
+			Logger:       logger,
+			ClientConfig: c.config,
+			StateDB:      c.stateDB,
+		}
 		c.configLock.RUnlock()
 
+		ar, err := allocrunnerv2.NewAllocRunner(arConf)
+		if err != nil {
+			c.logger.Printf("[ERR] client: failed to create alloc %q: %v", alloc.ID, err)
+			mErr.Errors = append(mErr.Errors, err)
+			continue
+		}
+
+		// Restore state
+		if err := ar.Restore(); err != nil {
+			c.logger.Printf("[ERR] client: failed to restore alloc %q: %v", alloc.ID, err)
+			mErr.Errors = append(mErr.Errors, err)
+			continue
+		}
+
+		//XXX is this locking necessary?
 		c.allocLock.Lock()
-		c.allocs[id] = ar
+		c.allocs[alloc.ID] = ar
 		c.allocLock.Unlock()
-
-		if err := ar.RestoreState(); err != nil {
-			c.logger.Printf("[ERR] client: failed to restore state for alloc %q: %v", id, err)
-			mErr.Errors = append(mErr.Errors, err)
-		} else {
-			go ar.Run()
-
-			if upgrading {
-				if err := ar.SaveState(); err != nil {
-					c.logger.Printf("[WARN] client: initial save state for alloc %q failed: %v", id, err)
-				}
-			}
-		}
 	}
 
-	// Delete all the entries
-	if upgrading {
-		if err := os.RemoveAll(allocDir); err != nil {
-			mErr.Errors = append(mErr.Errors, err)
-		}
+	// Don't run any allocs if there were any failures
+	//XXX removing this check would switch from all-or-nothing restores to
+	//    best-effort. went with all-or-nothing for now
+	if err := mErr.ErrorOrNil(); err != nil {
+		return err
 	}
 
-	return mErr.ErrorOrNil()
+	// All allocs restored successfully, run them!
+	for _, ar := range c.allocs {
+		go ar.Run()
+	}
+
+	return nil
 }
 
 // saveState is used to snapshot our state into the data dir.
@@ -1949,10 +1950,11 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 	// The long term fix is to pass in the config and node separately and then
 	// we don't have to do a copy.
 	//ar := allocrunner.NewAllocRunner(c.logger, c.configCopy.Copy(), c.stateDB, c.updateAllocStatus, alloc, c.vaultClient, c.consulService, prevAlloc)
-	//XXX FIXME
+	//XXX FIXME create a root logger
 	logger := hclog.New(&hclog.LoggerOptions{
-		Name:  "nomad",
-		Level: hclog.LevelFromString(c.configCopy.LogLevel),
+		Name:       "nomad",
+		Level:      hclog.LevelFromString(c.configCopy.LogLevel),
+		TimeFormat: time.RFC3339,
 	})
 
 	c.configLock.RLock()
@@ -1965,12 +1967,15 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 	}
 	c.configLock.RUnlock()
 
-	ar := allocrunnerv2.NewAllocRunner(arConf)
+	ar, err := allocrunnerv2.NewAllocRunner(arConf)
+	if err != nil {
+		return err
+	}
 
 	// Store the alloc runner.
 	c.allocs[alloc.ID] = ar
 
-	//XXX(schmichael) Why do we do this?
+	// Initialize local state
 	if err := ar.SaveState(); err != nil {
 		c.logger.Printf("[WARN] client: initial save state for alloc %q failed: %v", alloc.ID, err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -792,9 +792,11 @@ func (c *Client) restoreState() error {
 	}
 
 	// All allocs restored successfully, run them!
+	c.allocLock.Lock()
 	for _, ar := range c.allocs {
 		go ar.Run()
 	}
+	c.allocLock.Unlock()
 
 	return nil
 }

--- a/vendor/github.com/hashicorp/go-hclog/README.md
+++ b/vendor/github.com/hashicorp/go-hclog/README.md
@@ -10,8 +10,7 @@ interface for use in development and production environments.
 It provides logging levels that provide decreased output based upon the
 desired amount of output, unlike the standard library `log` package.
 
-It does not provide `Printf` style logging, only key/value logging that is
-exposed as arguments to the logging functions for simplicity.
+It provides `Printf` style logging of values via `hclog.Fmt()`.
 
 It provides a human readable output mode for use in development as well as
 JSON output mode for production.
@@ -99,6 +98,17 @@ requestLogger.Info("we are transporting a request")
 
 This allows sub Loggers to be context specific without having to thread that
 into all the callers.
+
+### Using `hclog.Fmt()`
+
+```go
+var int totalBandwidth = 200
+appLogger.Info("total bandwidth exceeded", "bandwidth", hclog.Fmt("%d GB/s", totalBandwidth))
+```
+
+```text
+... [INFO ] my-app: total bandwidth exceeded: bandwidth="200 GB/s"
+```
 
 ### Use this with code that uses the standard library logger
 

--- a/vendor/github.com/hashicorp/go-hclog/int.go
+++ b/vendor/github.com/hashicorp/go-hclog/int.go
@@ -2,14 +2,17 @@ package hclog
 
 import (
 	"bufio"
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -39,28 +42,40 @@ func New(opts *LoggerOptions) Logger {
 		level = DefaultLevel
 	}
 
-	return &intLogger{
-		m:      new(sync.Mutex),
-		json:   opts.JSONFormat,
-		caller: opts.IncludeLocation,
-		name:   opts.Name,
-		w:      bufio.NewWriter(output),
-		level:  level,
+	mtx := opts.Mutex
+	if mtx == nil {
+		mtx = new(sync.Mutex)
 	}
+
+	ret := &intLogger{
+		m:          mtx,
+		json:       opts.JSONFormat,
+		caller:     opts.IncludeLocation,
+		name:       opts.Name,
+		timeFormat: TimeFormat,
+		w:          bufio.NewWriter(output),
+		level:      new(int32),
+	}
+	if opts.TimeFormat != "" {
+		ret.timeFormat = opts.TimeFormat
+	}
+	atomic.StoreInt32(ret.level, int32(level))
+	return ret
 }
 
 // The internal logger implementation. Internal in that it is defined entirely
 // by this package.
 type intLogger struct {
-	json   bool
-	caller bool
-	name   string
+	json       bool
+	caller     bool
+	name       string
+	timeFormat string
 
 	// this is a pointer so that it's shared by any derived loggers, since
 	// those derived loggers share the bufio.Writer as well.
 	m     *sync.Mutex
 	w     *bufio.Writer
-	level Level
+	level *int32
 
 	implied []interface{}
 }
@@ -75,7 +90,7 @@ const TimeFormat = "2006-01-02T15:04:05.000Z0700"
 // Log a message and a set of key/value pairs if the given level is at
 // or more severe that the threshold configured in the Logger.
 func (z *intLogger) Log(level Level, msg string, args ...interface{}) {
-	if level < z.level {
+	if level < Level(atomic.LoadInt32(z.level)) {
 		return
 	}
 
@@ -126,7 +141,7 @@ func trimCallerPath(path string) string {
 
 // Non-JSON logging format function
 func (z *intLogger) log(t time.Time, level Level, msg string, args ...interface{}) {
-	z.w.WriteString(t.Format(TimeFormat))
+	z.w.WriteString(t.Format(z.timeFormat))
 	z.w.WriteByte(' ')
 
 	s, ok := _levelToBracket[level]
@@ -202,6 +217,8 @@ func (z *intLogger) log(t time.Time, level Level, msg string, args ...interface{
 			case CapturedStacktrace:
 				stacktrace = st
 				continue FOR
+			case Format:
+				val = fmt.Sprintf(st[0].(string), st[1:]...)
 			default:
 				val = fmt.Sprintf("%v", st)
 			}
@@ -262,6 +279,8 @@ func (z *intLogger) logJson(t time.Time, level Level, msg string, args ...interf
 		}
 	}
 
+	args = append(z.implied, args...)
+
 	if args != nil && len(args) > 0 {
 		if len(args)%2 != 0 {
 			cs, ok := args[len(args)-1].(CapturedStacktrace)
@@ -279,7 +298,22 @@ func (z *intLogger) logJson(t time.Time, level Level, msg string, args ...interf
 				// without injecting into logs...
 				continue
 			}
-			vals[args[i].(string)] = args[i+1]
+			val := args[i+1]
+			switch sv := val.(type) {
+			case error:
+				// Check if val is of type error. If error type doesn't
+				// implement json.Marshaler or encoding.TextMarshaler
+				// then set val to err.Error() so that it gets marshaled
+				switch sv.(type) {
+				case json.Marshaler, encoding.TextMarshaler:
+				default:
+					val = sv.Error()
+				}
+			case Format:
+				val = fmt.Sprintf(sv[0].(string), sv[1:]...)
+			}
+
+			vals[args[i].(string)] = val
 		}
 	}
 
@@ -316,36 +350,66 @@ func (z *intLogger) Error(msg string, args ...interface{}) {
 
 // Indicate that the logger would emit TRACE level logs
 func (z *intLogger) IsTrace() bool {
-	return z.level == Trace
+	return Level(atomic.LoadInt32(z.level)) == Trace
 }
 
 // Indicate that the logger would emit DEBUG level logs
 func (z *intLogger) IsDebug() bool {
-	return z.level <= Debug
+	return Level(atomic.LoadInt32(z.level)) <= Debug
 }
 
 // Indicate that the logger would emit INFO level logs
 func (z *intLogger) IsInfo() bool {
-	return z.level <= Info
+	return Level(atomic.LoadInt32(z.level)) <= Info
 }
 
 // Indicate that the logger would emit WARN level logs
 func (z *intLogger) IsWarn() bool {
-	return z.level <= Warn
+	return Level(atomic.LoadInt32(z.level)) <= Warn
 }
 
 // Indicate that the logger would emit ERROR level logs
 func (z *intLogger) IsError() bool {
-	return z.level <= Error
+	return Level(atomic.LoadInt32(z.level)) <= Error
 }
 
 // Return a sub-Logger for which every emitted log message will contain
 // the given key/value pairs. This is used to create a context specific
 // Logger.
 func (z *intLogger) With(args ...interface{}) Logger {
+	if len(args)%2 != 0 {
+		panic("With() call requires paired arguments")
+	}
+
 	var nz intLogger = *z
 
-	nz.implied = append(nz.implied, args...)
+	result := make(map[string]interface{}, len(z.implied)+len(args))
+	keys := make([]string, 0, len(z.implied)+len(args))
+
+	// Read existing args, store map and key for consistent sorting
+	for i := 0; i < len(z.implied); i += 2 {
+		key := z.implied[i].(string)
+		keys = append(keys, key)
+		result[key] = z.implied[i+1]
+	}
+	// Read new args, store map and key for consistent sorting
+	for i := 0; i < len(args); i += 2 {
+		key := args[i].(string)
+		_, exists := result[key]
+		if !exists {
+			keys = append(keys, key)
+		}
+		result[key] = args[i+1]
+	}
+
+	// Sort keys to be consistent
+	sort.Strings(keys)
+
+	nz.implied = make([]interface{}, 0, len(z.implied)+len(args))
+	for _, k := range keys {
+		nz.implied = append(nz.implied, k)
+		nz.implied = append(nz.implied, result[k])
+	}
 
 	return &nz
 }
@@ -357,6 +421,8 @@ func (z *intLogger) Named(name string) Logger {
 
 	if nz.name != "" {
 		nz.name = nz.name + "." + name
+	} else {
+		nz.name = name
 	}
 
 	return &nz
@@ -371,6 +437,12 @@ func (z *intLogger) ResetNamed(name string) Logger {
 	nz.name = name
 
 	return &nz
+}
+
+// Update the logging level on-the-fly. This will affect all subloggers as
+// well.
+func (z *intLogger) SetLevel(level Level) {
+	atomic.StoreInt32(z.level, int32(level))
 }
 
 // Create a *log.Logger that will send it's data through this Logger. This

--- a/vendor/github.com/hashicorp/go-hclog/log.go
+++ b/vendor/github.com/hashicorp/go-hclog/log.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 )
 
 var (
@@ -12,7 +13,7 @@ var (
 	DefaultLevel  = Info
 )
 
-type Level int
+type Level int32
 
 const (
 	// This is a special level used to indicate that no level has been
@@ -35,6 +36,18 @@ const (
 	// For information about unrecoverable events.
 	Error Level = 5
 )
+
+// When processing a value of this type, the logger automatically treats the first
+// argument as a Printf formatting string and passes the rest as the values to be
+// formatted. For example: L.Info(Fmt{"%d beans/day", beans}). This is a simple
+// convience type for when formatting is required.
+type Format []interface{}
+
+// Fmt returns a Format type. This is a convience function for creating a Format
+// type.
+func Fmt(str string, args ...interface{}) Format {
+	return append(Format{str}, args...)
+}
 
 // LevelFromString returns a Level type for the named log level, or "NoLevel" if
 // the level string is invalid. This facilitates setting the log level via
@@ -108,6 +121,10 @@ type Logger interface {
 	// the current name as well.
 	ResetNamed(name string) Logger
 
+	// Updates the level. This should affect all sub-loggers as well. If an
+	// implementation cannot update the level on the fly, it should no-op.
+	SetLevel(level Level)
+
 	// Return a value that conforms to the stdlib log.Logger interface
 	StandardLogger(opts *StandardLoggerOptions) *log.Logger
 }
@@ -130,9 +147,15 @@ type LoggerOptions struct {
 	// Where to write the logs to. Defaults to os.Stdout if nil
 	Output io.Writer
 
+	// An optional mutex pointer in case Output is shared
+	Mutex *sync.Mutex
+
 	// Control if the output should be in JSON.
 	JSONFormat bool
 
-	// Intclude file and line information in each log line
+	// Include file and line information in each log line
 	IncludeLocation bool
+
+	// The time format to use instead of the default
+	TimeFormat string
 }

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -1,0 +1,47 @@
+package hclog
+
+import (
+	"io/ioutil"
+	"log"
+)
+
+// NewNullLogger instantiates a Logger for which all calls
+// will succeed without doing anything.
+// Useful for testing purposes.
+func NewNullLogger() Logger {
+	return &nullLogger{}
+}
+
+type nullLogger struct{}
+
+func (l *nullLogger) Trace(msg string, args ...interface{}) {}
+
+func (l *nullLogger) Debug(msg string, args ...interface{}) {}
+
+func (l *nullLogger) Info(msg string, args ...interface{}) {}
+
+func (l *nullLogger) Warn(msg string, args ...interface{}) {}
+
+func (l *nullLogger) Error(msg string, args ...interface{}) {}
+
+func (l *nullLogger) IsTrace() bool { return false }
+
+func (l *nullLogger) IsDebug() bool { return false }
+
+func (l *nullLogger) IsInfo() bool { return false }
+
+func (l *nullLogger) IsWarn() bool { return false }
+
+func (l *nullLogger) IsError() bool { return false }
+
+func (l *nullLogger) With(args ...interface{}) Logger { return l }
+
+func (l *nullLogger) Named(name string) Logger { return l }
+
+func (l *nullLogger) ResetNamed(name string) Logger { return l }
+
+func (l *nullLogger) SetLevel(level Level) {}
+
+func (l *nullLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
+	return log.New(ioutil.Discard, "", log.LstdFlags)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -150,7 +150,7 @@
 		{"path":"github.com/hashicorp/go-envparse","checksumSHA1":"FKmqR4DC3nCXtnT9pe02z5CLNWo=","revision":"310ca1881b22af3522e3a8638c0b426629886196","revisionTime":"2018-01-19T21:58:41Z"},
 		{"path":"github.com/hashicorp/go-getter","checksumSHA1":"uGH6AI982csQJoRPsSooK7FoWqo=","revision":"3f60ec5cfbb2a39731571b9ddae54b303bb0a969","revisionTime":"2018-04-25T22:41:30Z"},
 		{"path":"github.com/hashicorp/go-getter/helper/url","checksumSHA1":"9J+kDr29yDrwsdu2ULzewmqGjpA=","revision":"b345bfcec894fb7ff3fdf9b21baf2f56ea423d98","revisionTime":"2018-04-10T17:49:45Z"},
-		{"path":"github.com/hashicorp/go-hclog","checksumSHA1":"miVF4/7JP0lRwZvFJGKwZWk7aAQ=","revision":"b4e5765d1e5f00a0550911084f45f8214b5b83b9","revisionTime":"2017-07-16T17:45:23Z"},
+		{"path":"github.com/hashicorp/go-hclog","checksumSHA1":"dOP7kCX3dACHc9mU79826N411QA=","revision":"ff2cf002a8dd750586d91dddd4470c341f981fe1","revisionTime":"2018-07-09T16:53:50Z"},
 		{"path":"github.com/hashicorp/go-immutable-radix","checksumSHA1":"Cas2nprG6pWzf05A2F/OlnjUu2Y=","revision":"8aac2701530899b64bdea735a1de8da899815220","revisionTime":"2017-07-25T22:12:15Z"},
 		{"path":"github.com/hashicorp/go-memdb","checksumSHA1":"FMAvwDar2bQyYAW4XMFhAt0J5xA=","revision":"20ff6434c1cc49b80963d45bf5c6aa89c78d8d57","revisionTime":"2017-08-31T20:15:40Z"},
 		{"path":"github.com/hashicorp/go-msgpack/codec","revision":"fa3f63826f7c23912c15263591e65d54d080b458"},


### PR DESCRIPTION
## Design

Implement all-or-nothing alloc restoration: no goroutines or sideeffects occur until all restoring is complete. Either all ARs and TRs are started or none of them are (and this is easily changed to a best effort).

Restoring calls NewAR -> Restore -> Run

0. Client loads allocs
1. NewAR now calls NewTR
2. AR.Restore calls TR.Restore
3. AR.Run calls TR.Run

## Outstanding items

* Only partially backward compatible at this point
* No AR state saved/restore
* I'm not entirely happy with the mess of state funcs/structs spread across client/state, ar/state, and tr/state. Something to refactor.
