### PR TITLE
Affinity struct, API and parsing

### DIFF
--- a/api/compose_test.go
+++ b/api/compose_test.go
@@ -31,6 +31,7 @@ func TestCompose(t *testing.T) {
 	// Compose a task group
 	grp := NewTaskGroup("grp1", 2).
 		Constrain(NewConstraint("kernel.name", "=", "linux")).
+		AddAffinity(NewAffinity("${node.class}", "=", "large", 50)).
 		SetMeta("foo", "bar").
 		AddTask(task)
 
@@ -70,6 +71,14 @@ func TestCompose(t *testing.T) {
 						LTarget: "kernel.name",
 						RTarget: "linux",
 						Operand: "=",
+					},
+				},
+				Affinities: []*Affinity{
+					{
+						LTarget: "${node.class}",
+						RTarget: "large",
+						Operand: "=",
+						Weight:  50,
 					},
 				},
 				Tasks: []*Task{

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -610,6 +610,7 @@ type Job struct {
 	AllAtOnce         *bool `mapstructure:"all_at_once"`
 	Datacenters       []string
 	Constraints       []*Constraint
+	Affinities        []*Affinity
 	TaskGroups        []*TaskGroup
 	Update            *UpdateStrategy
 	Periodic          *PeriodicConfig
@@ -833,6 +834,12 @@ func (j *Job) AddDatacenter(dc string) *Job {
 // Constrain is used to add a constraint to a job.
 func (j *Job) Constrain(c *Constraint) *Job {
 	j.Constraints = append(j.Constraints, c)
+	return j
+}
+
+// AddAffinity is used to add an affinity to a job.
+func (j *Job) AddAffinity(a *Affinity) *Job {
+	j.Affinities = append(j.Affinities, a)
 	return j
 }
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1332,6 +1332,42 @@ func TestJobs_Constrain(t *testing.T) {
 	}
 }
 
+func TestJobs_AddAffinity(t *testing.T) {
+	t.Parallel()
+	job := &Job{Affinities: nil}
+
+	// Create and add an affinity
+	out := job.AddAffinity(NewAffinity("kernel.version", "=", "4.6", 100))
+	if n := len(job.Affinities); n != 1 {
+		t.Fatalf("expected 1 affinity, got: %d", n)
+	}
+
+	// Check that the job was returned
+	if job != out {
+		t.Fatalf("expect: %#v, got: %#v", job, out)
+	}
+
+	// Adding another affinity preserves the original
+	job.AddAffinity(NewAffinity("${node.datacenter}", "=", "dc2", 50))
+	expect := []*Affinity{
+		{
+			LTarget: "kernel.version",
+			RTarget: "4.6",
+			Operand: "=",
+			Weight:  100,
+		},
+		{
+			LTarget: "${node.datacenter}",
+			RTarget: "dc2",
+			Operand: "=",
+			Weight:  50,
+		},
+	}
+	if !reflect.DeepEqual(job.Affinities, expect) {
+		t.Fatalf("expect: %#v, got: %#v", expect, job.Affinities)
+	}
+}
+
 func TestJobs_Sort(t *testing.T) {
 	t.Parallel()
 	jobs := []*JobListStub{

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -154,7 +154,6 @@ type Affinity struct {
 	RTarget string  // Right-hand target
 	Operand string  // Constraint operand (<=, <, =, !=, >, >=), set_contains_all, set_contains_any
 	Weight  float64 // Weight applied to nodes that match the affinity. Can be negative
-	str     string  // Memoized string
 }
 
 func NewAffinity(LTarget string, Operand string, RTarget string, Weight float64) *Affinity {

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -56,6 +56,42 @@ func TestTaskGroup_Constrain(t *testing.T) {
 	}
 }
 
+func TestTaskGroup_AddAffinity(t *testing.T) {
+	t.Parallel()
+	grp := NewTaskGroup("grp1", 1)
+
+	// Add an affinity to the group
+	out := grp.AddAffinity(NewAffinity("kernel.version", "=", "4.6", 100))
+	if n := len(grp.Affinities); n != 1 {
+		t.Fatalf("expected 1 affinity, got: %d", n)
+	}
+
+	// Check that the group was returned
+	if out != grp {
+		t.Fatalf("expected: %#v, got: %#v", grp, out)
+	}
+
+	// Add a second affinity
+	grp.AddAffinity(NewAffinity("${node.affinity}", "=", "dc2", 50))
+	expect := []*Affinity{
+		{
+			LTarget: "kernel.version",
+			RTarget: "4.6",
+			Operand: "=",
+			Weight:  100,
+		},
+		{
+			LTarget: "${node.affinity}",
+			RTarget: "dc2",
+			Operand: "=",
+			Weight:  50,
+		},
+	}
+	if !reflect.DeepEqual(grp.Affinities, expect) {
+		t.Fatalf("expect: %#v, got: %#v", expect, grp.Constraints)
+	}
+}
+
 func TestTaskGroup_SetMeta(t *testing.T) {
 	t.Parallel()
 	grp := NewTaskGroup("grp1", 1)
@@ -229,6 +265,42 @@ func TestTask_Constrain(t *testing.T) {
 	}
 	if !reflect.DeepEqual(task.Constraints, expect) {
 		t.Fatalf("expect: %#v, got: %#v", expect, task.Constraints)
+	}
+}
+
+func TestTask_AddAffinity(t *testing.T) {
+	t.Parallel()
+	task := NewTask("task1", "exec")
+
+	// Add an affinity to the task
+	out := task.AddAffinity(NewAffinity("kernel.version", "=", "4.6", 100))
+	if n := len(task.Affinities); n != 1 {
+		t.Fatalf("expected 1 affinity, got: %d", n)
+	}
+
+	// Check that the task was returned
+	if out != task {
+		t.Fatalf("expected: %#v, got: %#v", task, out)
+	}
+
+	// Add a second affinity
+	task.AddAffinity(NewAffinity("${node.datacenter}", "=", "dc2", 50))
+	expect := []*Affinity{
+		{
+			LTarget: "kernel.version",
+			RTarget: "4.6",
+			Operand: "=",
+			Weight:  100,
+		},
+		{
+			LTarget: "${node.datacenter}",
+			RTarget: "dc2",
+			Operand: "=",
+			Weight:  50,
+		},
+	}
+	if !reflect.DeepEqual(task.Affinities, expect) {
+		t.Fatalf("expect: %#v, got: %#v", expect, task.Affinities)
 	}
 }
 

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTaskGroup_NewTaskGroup(t *testing.T) {
@@ -274,9 +275,8 @@ func TestTask_AddAffinity(t *testing.T) {
 
 	// Add an affinity to the task
 	out := task.AddAffinity(NewAffinity("kernel.version", "=", "4.6", 100))
-	if n := len(task.Affinities); n != 1 {
-		t.Fatalf("expected 1 affinity, got: %d", n)
-	}
+	require := require.New(t)
+	require.Len(out, 1)
 
 	// Check that the task was returned
 	if out != task {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -616,6 +616,15 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 		}
 	}
 
+	if l := len(job.Affinities); l != 0 {
+		j.Affinities = make([]*structs.Affinity, l)
+		for i, a := range job.Affinities {
+			aff := &structs.Affinity{}
+			ApiAffinityToStructs(a, aff)
+			j.Affinities[i] = aff
+		}
+	}
+
 	// COMPAT: Remove in 0.7.0. Update has been pushed into the task groups
 	if job.Update != nil {
 		j.Update = structs.UpdateStrategy{}
@@ -672,6 +681,15 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 			c := &structs.Constraint{}
 			ApiConstraintToStructs(constraint, c)
 			tg.Constraints[k] = c
+		}
+	}
+
+	if l := len(taskGroup.Affinities); l != 0 {
+		tg.Affinities = make([]*structs.Affinity, l)
+		for k, affinity := range taskGroup.Affinities {
+			a := &structs.Affinity{}
+			ApiAffinityToStructs(affinity, a)
+			tg.Affinities[k] = a
 		}
 	}
 
@@ -751,6 +769,15 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 			c := &structs.Constraint{}
 			ApiConstraintToStructs(constraint, c)
 			structsTask.Constraints[i] = c
+		}
+	}
+
+	if l := len(apiTask.Affinities); l != 0 {
+		structsTask.Affinities = make([]*structs.Affinity, l)
+		for i, a := range apiTask.Affinities {
+			aff := &structs.Affinity{}
+			ApiAffinityToStructs(a, aff)
+			structsTask.Affinities[i] = aff
 		}
 	}
 
@@ -891,4 +918,11 @@ func ApiConstraintToStructs(c1 *api.Constraint, c2 *structs.Constraint) {
 	c2.LTarget = c1.LTarget
 	c2.RTarget = c1.RTarget
 	c2.Operand = c1.Operand
+}
+
+func ApiAffinityToStructs(a1 *api.Affinity, a2 *structs.Affinity) {
+	a2.LTarget = a1.LTarget
+	a2.Operand = a1.Operand
+	a2.RTarget = a1.RTarget
+	a2.Weight = a1.Weight
 }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -619,9 +619,7 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 	if l := len(job.Affinities); l != 0 {
 		j.Affinities = make([]*structs.Affinity, l)
 		for i, a := range job.Affinities {
-			aff := &structs.Affinity{}
-			ApiAffinityToStructs(a, aff)
-			j.Affinities[i] = aff
+			j.Affinities[i] = ApiAffinityToStructs(a)
 		}
 	}
 
@@ -687,9 +685,7 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 	if l := len(taskGroup.Affinities); l != 0 {
 		tg.Affinities = make([]*structs.Affinity, l)
 		for k, affinity := range taskGroup.Affinities {
-			a := &structs.Affinity{}
-			ApiAffinityToStructs(affinity, a)
-			tg.Affinities[k] = a
+			tg.Affinities[k] = ApiAffinityToStructs(affinity)
 		}
 	}
 
@@ -775,9 +771,7 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 	if l := len(apiTask.Affinities); l != 0 {
 		structsTask.Affinities = make([]*structs.Affinity, l)
 		for i, a := range apiTask.Affinities {
-			aff := &structs.Affinity{}
-			ApiAffinityToStructs(a, aff)
-			structsTask.Affinities[i] = aff
+			structsTask.Affinities[i] = ApiAffinityToStructs(a)
 		}
 	}
 
@@ -920,9 +914,11 @@ func ApiConstraintToStructs(c1 *api.Constraint, c2 *structs.Constraint) {
 	c2.Operand = c1.Operand
 }
 
-func ApiAffinityToStructs(a1 *api.Affinity, a2 *structs.Affinity) {
-	a2.LTarget = a1.LTarget
-	a2.Operand = a1.Operand
-	a2.RTarget = a1.RTarget
-	a2.Weight = a1.Weight
+func ApiAffinityToStructs(a1 *api.Affinity) *structs.Affinity {
+	return &structs.Affinity{
+		LTarget: a1.LTarget,
+		Operand: a1.Operand,
+		RTarget: a1.RTarget,
+		Weight:  a1.Weight,
+	}
 }

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1211,6 +1211,14 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 				Operand: "c",
 			},
 		},
+		Affinities: []*api.Affinity{
+			{
+				LTarget: "a",
+				RTarget: "b",
+				Operand: "c",
+				Weight:  50,
+			},
+		},
 		Update: &api.UpdateStrategy{
 			Stagger:          helper.TimeToPtr(1 * time.Second),
 			MaxParallel:      helper.IntToPtr(5),
@@ -1246,6 +1254,14 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						LTarget: "x",
 						RTarget: "y",
 						Operand: "z",
+					},
+				},
+				Affinities: []*api.Affinity{
+					{
+						LTarget: "x",
+						RTarget: "y",
+						Operand: "z",
+						Weight:  100,
 					},
 				},
 				RestartPolicy: &api.RestartPolicy{
@@ -1301,6 +1317,14 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								LTarget: "x",
 								RTarget: "y",
 								Operand: "z",
+							},
+						},
+						Affinities: []*api.Affinity{
+							{
+								LTarget: "a",
+								RTarget: "b",
+								Operand: "c",
+								Weight:  50,
 							},
 						},
 
@@ -1443,6 +1467,14 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 				Operand: "c",
 			},
 		},
+		Affinities: []*structs.Affinity{
+			{
+				LTarget: "a",
+				RTarget: "b",
+				Operand: "c",
+				Weight:  50,
+			},
+		},
 		Update: structs.UpdateStrategy{
 			Stagger:     1 * time.Second,
 			MaxParallel: 5,
@@ -1472,6 +1504,14 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						LTarget: "x",
 						RTarget: "y",
 						Operand: "z",
+					},
+				},
+				Affinities: []*structs.Affinity{
+					{
+						LTarget: "x",
+						RTarget: "y",
+						Operand: "z",
+						Weight:  100,
 					},
 				},
 				RestartPolicy: &structs.RestartPolicy{
@@ -1526,6 +1566,14 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								LTarget: "x",
 								RTarget: "y",
 								Operand: "z",
+							},
+						},
+						Affinities: []*structs.Affinity{
+							{
+								LTarget: "a",
+								RTarget: "b",
+								Operand: "c",
+								Weight:  50,
 							},
 						},
 						Env: map[string]string{

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -601,6 +601,7 @@ func parseAffinities(result *[]*api.Affinity, list *ast.ObjectList) error {
 			"attribute",
 			"operator",
 			"regexp",
+			"set_contains",
 			"set_contains_any",
 			"set_contains_all",
 			"value",
@@ -645,6 +646,12 @@ func parseAffinities(result *[]*api.Affinity, list *ast.ObjectList) error {
 		// to "set_contains_all" and the value to the "RTarget"
 		if affinity, ok := m[structs.AffinitySetContainsAll]; ok {
 			m["Operand"] = structs.AffinitySetContainsAll
+			m["RTarget"] = affinity
+		}
+
+		// set_contains is a synonym of set_contains_all
+		if affinity, ok := m[structs.ConstraintSetContains]; ok {
+			m["Operand"] = structs.ConstraintSetContains
 			m["RTarget"] = affinity
 		}
 

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -637,15 +637,15 @@ func parseAffinities(result *[]*api.Affinity, list *ast.ObjectList) error {
 
 		// If "set_contains_any" is provided, set the operand
 		// to "set_contains_any" and the value to the "RTarget"
-		if affinity, ok := m[structs.AffinitySetContainsAny]; ok {
-			m["Operand"] = structs.AffinitySetContainsAny
+		if affinity, ok := m[structs.ConstraintSetContaintsAny]; ok {
+			m["Operand"] = structs.ConstraintSetContaintsAny
 			m["RTarget"] = affinity
 		}
 
 		// If "set_contains_all" is provided, set the operand
 		// to "set_contains_all" and the value to the "RTarget"
-		if affinity, ok := m[structs.AffinitySetContainsAll]; ok {
-			m["Operand"] = structs.AffinitySetContainsAll
+		if affinity, ok := m[structs.ConstraintSetContainsAll]; ok {
+			m["Operand"] = structs.ConstraintSetContainsAll
 			m["RTarget"] = affinity
 		}
 

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -46,6 +46,15 @@ func TestParse(t *testing.T) {
 					},
 				},
 
+				Affinities: []*api.Affinity{
+					{
+						LTarget: "${meta.team}",
+						RTarget: "mobile",
+						Operand: "=",
+						Weight:  50,
+					},
+				},
+
 				Update: &api.UpdateStrategy{
 					Stagger:          helper.TimeToPtr(60 * time.Second),
 					MaxParallel:      helper.IntToPtr(2),
@@ -82,6 +91,14 @@ func TestParse(t *testing.T) {
 								LTarget: "kernel.os",
 								RTarget: "linux",
 								Operand: "=",
+							},
+						},
+						Affinities: []*api.Affinity{
+							{
+								LTarget: "${node.datacenter}",
+								RTarget: "dc2",
+								Operand: "=",
+								Weight:  100,
 							},
 						},
 						Meta: map[string]string{

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -148,6 +148,14 @@ func TestParse(t *testing.T) {
 										},
 									},
 								},
+								Affinities: []*api.Affinity{
+									{
+										LTarget: "${meta.foo}",
+										RTarget: "bar",
+										Operand: "=",
+										Weight:  25,
+									},
+								},
 								Services: []*api.Service{
 									{
 										Tags:       []string{"foo", "bar"},

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -151,8 +151,8 @@ func TestParse(t *testing.T) {
 								Affinities: []*api.Affinity{
 									{
 										LTarget: "${meta.foo}",
-										RTarget: "bar",
-										Operand: "=",
+										RTarget: "a,b,c",
+										Operand: "set_contains",
 										Weight:  25,
 									},
 								},

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -16,6 +16,13 @@ job "binstore-storagelocker" {
     value     = "windows"
   }
 
+  affinity {
+    attribute = "${meta.team}"
+    value = "mobile"
+    operator = "="
+    weight = 50
+  }
+
   update {
     stagger      = "60s"
     max_parallel = 2
@@ -75,6 +82,14 @@ job "binstore-storagelocker" {
         min_healthy_time = "11s"
         healthy_deadline = "11m"
     }
+
+    affinity {
+      attribute = "${node.datacenter}"
+      value = "dc2"
+      operator = "="
+      weight = 100
+    }
+
 
     task "binstore" {
       driver = "docker"

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -90,11 +90,17 @@ job "binstore-storagelocker" {
       weight = 100
     }
 
-
     task "binstore" {
       driver = "docker"
       user   = "bob"
       leader = true
+
+      affinity {
+        attribute = "${meta.foo}"
+        value = "bar"
+        operator = "="
+        weight = 25
+      }
 
       config {
         image = "hashicorp/binstore"

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -97,8 +97,8 @@ job "binstore-storagelocker" {
 
       affinity {
         attribute = "${meta.foo}"
-        value = "bar"
-        operator = "="
+        value = "a,b,c"
+        operator = "set_contains"
         weight = 25
       }
 

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -228,6 +228,17 @@ func (tg *TaskGroup) Diff(other *TaskGroup, contextual bool) (*TaskGroupDiff, er
 		diff.Objects = append(diff.Objects, conDiff...)
 	}
 
+	// Affinities diff
+	affinitiesDiff := primitiveObjectSetDiff(
+		interfaceSlice(tg.Affinities),
+		interfaceSlice(other.Affinities),
+		[]string{"str"},
+		"Affinity",
+		contextual)
+	if affinitiesDiff != nil {
+		diff.Objects = append(diff.Objects, affinitiesDiff...)
+	}
+
 	// Restart policy diff
 	rDiff := primitiveObjectDiff(tg.RestartPolicy, other.RestartPolicy, nil, "RestartPolicy", contextual)
 	if rDiff != nil {

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -105,6 +105,17 @@ func (j *Job) Diff(other *Job, contextual bool) (*JobDiff, error) {
 		diff.Objects = append(diff.Objects, conDiff...)
 	}
 
+	// Affinities diff
+	affinitiesDiff := primitiveObjectSetDiff(
+		interfaceSlice(j.Affinities),
+		interfaceSlice(other.Affinities),
+		[]string{"str"},
+		"Affinity",
+		contextual)
+	if affinitiesDiff != nil {
+		diff.Objects = append(diff.Objects, affinitiesDiff...)
+	}
+
 	// Task groups diff
 	tgs, err := taskGroupDiffs(j.TaskGroups, other.TaskGroups, contextual)
 	if err != nil {
@@ -396,6 +407,17 @@ func (t *Task) Diff(other *Task, contextual bool) (*TaskDiff, error) {
 		contextual)
 	if conDiff != nil {
 		diff.Objects = append(diff.Objects, conDiff...)
+	}
+
+	// Affinities diff
+	affinitiesDiff := primitiveObjectSetDiff(
+		interfaceSlice(t.Affinities),
+		interfaceSlice(other.Affinities),
+		[]string{"str"},
+		"Affinity",
+		contextual)
+	if affinitiesDiff != nil {
+		diff.Objects = append(diff.Objects, affinitiesDiff...)
 	}
 
 	// Config diff

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -1304,6 +1304,110 @@ func TestTaskGroupDiff(t *testing.T) {
 			},
 		},
 		{
+			// Affinities edited
+			Old: &TaskGroup{
+				Affinities: []*Affinity{
+					{
+						LTarget: "foo",
+						RTarget: "foo",
+						Operand: "foo",
+						Weight:  20,
+						str:     "foo",
+					},
+					{
+						LTarget: "bar",
+						RTarget: "bar",
+						Operand: "bar",
+						Weight:  20,
+						str:     "bar",
+					},
+				},
+			},
+			New: &TaskGroup{
+				Affinities: []*Affinity{
+					{
+						LTarget: "foo",
+						RTarget: "foo",
+						Operand: "foo",
+						Weight:  20,
+						str:     "foo",
+					},
+					{
+						LTarget: "baz",
+						RTarget: "baz",
+						Operand: "baz",
+						Weight:  20,
+						str:     "baz",
+					},
+				},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Affinity",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "LTarget",
+								Old:  "",
+								New:  "baz",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Operand",
+								Old:  "",
+								New:  "baz",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "RTarget",
+								Old:  "",
+								New:  "baz",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Weight",
+								Old:  "",
+								New:  "20",
+							},
+						},
+					},
+					{
+						Type: DiffTypeDeleted,
+						Name: "Affinity",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "LTarget",
+								Old:  "bar",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Operand",
+								Old:  "bar",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "RTarget",
+								Old:  "bar",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Weight",
+								Old:  "20",
+								New:  "",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			// RestartPolicy added
 			Old: &TaskGroup{},
 			New: &TaskGroup{

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -754,6 +754,110 @@ func TestJobDiff(t *testing.T) {
 			},
 		},
 		{
+			// Affinities edited
+			Old: &Job{
+				Affinities: []*Affinity{
+					{
+						LTarget: "foo",
+						RTarget: "foo",
+						Operand: "foo",
+						Weight:  20,
+						str:     "foo",
+					},
+					{
+						LTarget: "bar",
+						RTarget: "bar",
+						Operand: "bar",
+						Weight:  20,
+						str:     "bar",
+					},
+				},
+			},
+			New: &Job{
+				Affinities: []*Affinity{
+					{
+						LTarget: "foo",
+						RTarget: "foo",
+						Operand: "foo",
+						Weight:  20,
+						str:     "foo",
+					},
+					{
+						LTarget: "baz",
+						RTarget: "baz",
+						Operand: "baz",
+						Weight:  20,
+						str:     "baz",
+					},
+				},
+			},
+			Expected: &JobDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Affinity",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "LTarget",
+								Old:  "",
+								New:  "baz",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Operand",
+								Old:  "",
+								New:  "baz",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "RTarget",
+								Old:  "",
+								New:  "baz",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Weight",
+								Old:  "",
+								New:  "20",
+							},
+						},
+					},
+					{
+						Type: DiffTypeDeleted,
+						Name: "Affinity",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "LTarget",
+								Old:  "bar",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Operand",
+								Old:  "bar",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "RTarget",
+								Old:  "bar",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Weight",
+								Old:  "20",
+								New:  "",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			// Task groups edited
 			Old: &Job{
 				TaskGroups: []*TaskGroup{
@@ -2707,6 +2811,110 @@ func TestTaskDiff(t *testing.T) {
 								Type: DiffTypeDeleted,
 								Name: "RTarget",
 								Old:  "bar",
+								New:  "",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Affinities edited",
+			Old: &Task{
+				Affinities: []*Affinity{
+					{
+						LTarget: "foo",
+						RTarget: "foo",
+						Operand: "foo",
+						Weight:  20,
+						str:     "foo",
+					},
+					{
+						LTarget: "bar",
+						RTarget: "bar",
+						Operand: "bar",
+						Weight:  20,
+						str:     "bar",
+					},
+				},
+			},
+			New: &Task{
+				Affinities: []*Affinity{
+					{
+						LTarget: "foo",
+						RTarget: "foo",
+						Operand: "foo",
+						Weight:  20,
+						str:     "foo",
+					},
+					{
+						LTarget: "baz",
+						RTarget: "baz",
+						Operand: "baz",
+						Weight:  20,
+						str:     "baz",
+					},
+				},
+			},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Affinity",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "LTarget",
+								Old:  "",
+								New:  "baz",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Operand",
+								Old:  "",
+								New:  "baz",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "RTarget",
+								Old:  "",
+								New:  "baz",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Weight",
+								Old:  "",
+								New:  "20",
+							},
+						},
+					},
+					{
+						Type: DiffTypeDeleted,
+						Name: "Affinity",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "LTarget",
+								Old:  "bar",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Operand",
+								Old:  "bar",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "RTarget",
+								Old:  "bar",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Weight",
+								Old:  "20",
 								New:  "",
 							},
 						},

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -208,6 +208,19 @@ func CopySliceConstraints(s []*Constraint) []*Constraint {
 	return c
 }
 
+func CopySliceAffinities(s []*Affinity) []*Affinity {
+	l := len(s)
+	if l == 0 {
+		return nil
+	}
+
+	c := make([]*Affinity, l)
+	for i, v := range s {
+		c[i] = v.Copy()
+	}
+	return c
+}
+
 // VaultPoliciesSet takes the structure returned by VaultPolicies and returns
 // the set of required policies
 func VaultPoliciesSet(policies map[string]map[string]*Vault) []string {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2116,6 +2116,7 @@ func (j *Job) Copy() *Job {
 	*nj = *j
 	nj.Datacenters = helper.CopySliceString(nj.Datacenters)
 	nj.Constraints = CopySliceConstraints(nj.Constraints)
+	nj.Affinities = CopySliceAffinities(nj.Affinities)
 
 	if j.TaskGroups != nil {
 		tgs := make([]*TaskGroup, len(nj.TaskGroups))
@@ -4087,6 +4088,7 @@ func (t *Task) Copy() *Task {
 	}
 
 	nt.Constraints = CopySliceConstraints(nt.Constraints)
+	nt.Affinities = CopySliceAffinities(nt.Affinities)
 
 	nt.Vault = nt.Vault.Copy()
 	nt.Resources = nt.Resources.Copy()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2174,7 +2174,7 @@ func (j *Job) Validate() error {
 	}
 	if j.Type == JobTypeSystem {
 		if j.Affinities != nil {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs should not have an affinity stanza"))
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs may not have an affinity stanza"))
 		}
 	} else {
 		for idx, affinity := range j.Affinities {
@@ -3431,7 +3431,7 @@ func (tg *TaskGroup) Validate(j *Job) error {
 	}
 	if j.Type == JobTypeSystem {
 		if tg.Affinities != nil {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs should not have an affinity stanza"))
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs may not have an affinity stanza"))
 		}
 	} else {
 		for idx, affinity := range tg.Affinities {
@@ -4230,7 +4230,7 @@ func (t *Task) Validate(ephemeralDisk *EphemeralDisk, jobType string) error {
 
 	if jobType == JobTypeSystem {
 		if t.Affinities != nil {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs should not have an affinity stanza"))
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs may not have an affinity stanza"))
 		}
 	} else {
 		for idx, affinity := range t.Affinities {
@@ -5217,6 +5217,8 @@ const (
 	ConstraintRegex            = "regexp"
 	ConstraintVersion          = "version"
 	ConstraintSetContains      = "set_contains"
+	ConstraintSetContainsAll   = "set_contains_all"
+	ConstraintSetContaintsAny  = "set_contains_any"
 )
 
 // Constraints are used to restrict placement options.
@@ -5303,11 +5305,6 @@ func (c *Constraint) Validate() error {
 	return mErr.ErrorOrNil()
 }
 
-const (
-	AffinitySetContainsAll = "set_contains_all"
-	AffinitySetContainsAny = "set_contains_any"
-)
-
 // Affinity is used to score placement options based on a weight
 type Affinity struct {
 	LTarget string  // Left-hand target
@@ -5350,7 +5347,7 @@ func (a *Affinity) Validate() error {
 
 	// Perform additional validation based on operand
 	switch a.Operand {
-	case AffinitySetContainsAll, AffinitySetContainsAny, ConstraintSetContains:
+	case ConstraintSetContainsAll, ConstraintSetContaintsAny, ConstraintSetContains:
 		if a.RTarget == "" {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Set contains operators require an RTarget"))
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5305,7 +5305,8 @@ type Affinity struct {
 func (a *Affinity) Equal(o *Affinity) bool {
 	return a.LTarget == o.LTarget &&
 		a.RTarget == o.RTarget &&
-		a.Operand == o.Operand
+		a.Operand == o.Operand &&
+		a.Weight == o.Weight
 }
 
 func (a *Affinity) Copy() *Affinity {
@@ -5333,7 +5334,7 @@ func (a *Affinity) Validate() error {
 
 	// Perform additional validation based on operand
 	switch a.Operand {
-	case AffinitySetContainsAll, AffinitySetContainsAny:
+	case AffinitySetContainsAll, AffinitySetContainsAny, ConstraintSetContains:
 		if a.RTarget == "" {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Set contains operators require an RTarget"))
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2172,11 +2172,16 @@ func (j *Job) Validate() error {
 			mErr.Errors = append(mErr.Errors, outer)
 		}
 	}
-
-	for idx, affinity := range j.Affinities {
-		if err := affinity.Validate(); err != nil {
-			outer := fmt.Errorf("Affinity %d validation failed: %s", idx+1, err)
-			mErr.Errors = append(mErr.Errors, outer)
+	if j.Type == JobTypeSystem {
+		if j.Affinities != nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs should not have an affinity stanza"))
+		}
+	} else {
+		for idx, affinity := range j.Affinities {
+			if err := affinity.Validate(); err != nil {
+				outer := fmt.Errorf("Affinity %d validation failed: %s", idx+1, err)
+				mErr.Errors = append(mErr.Errors, outer)
+			}
 		}
 	}
 
@@ -3424,11 +3429,16 @@ func (tg *TaskGroup) Validate(j *Job) error {
 			mErr.Errors = append(mErr.Errors, outer)
 		}
 	}
-
-	for idx, affinity := range tg.Affinities {
-		if err := affinity.Validate(); err != nil {
-			outer := fmt.Errorf("Affinity %d validation failed: %s", idx+1, err)
-			mErr.Errors = append(mErr.Errors, outer)
+	if j.Type == JobTypeSystem {
+		if tg.Affinities != nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs should not have an affinity stanza"))
+		}
+	} else {
+		for idx, affinity := range tg.Affinities {
+			if err := affinity.Validate(); err != nil {
+				outer := fmt.Errorf("Affinity %d validation failed: %s", idx+1, err)
+				mErr.Errors = append(mErr.Errors, outer)
+			}
 		}
 	}
 
@@ -3528,7 +3538,7 @@ func (tg *TaskGroup) Validate(j *Job) error {
 
 	// Validate the tasks
 	for _, task := range tg.Tasks {
-		if err := task.Validate(tg.EphemeralDisk); err != nil {
+		if err := task.Validate(tg.EphemeralDisk, j.Type); err != nil {
 			outer := fmt.Errorf("Task %s validation failed: %v", task.Name, err)
 			mErr.Errors = append(mErr.Errors, outer)
 		}
@@ -4164,7 +4174,7 @@ func (t *Task) GoString() string {
 }
 
 // Validate is used to sanity check a task
-func (t *Task) Validate(ephemeralDisk *EphemeralDisk) error {
+func (t *Task) Validate(ephemeralDisk *EphemeralDisk, jobType string) error {
 	var mErr multierror.Error
 	if t.Name == "" {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing task name"))
@@ -4218,10 +4228,16 @@ func (t *Task) Validate(ephemeralDisk *EphemeralDisk) error {
 		}
 	}
 
-	for idx, affinity := range t.Affinities {
-		if err := affinity.Validate(); err != nil {
-			outer := fmt.Errorf("Affinity %d validation failed: %s", idx+1, err)
-			mErr.Errors = append(mErr.Errors, outer)
+	if jobType == JobTypeSystem {
+		if t.Affinities != nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs should not have an affinity stanza"))
+		}
+	} else {
+		for idx, affinity := range t.Affinities {
+			if err := affinity.Validate(); err != nil {
+				outer := fmt.Errorf("Affinity %d validation failed: %s", idx+1, err)
+				mErr.Errors = append(mErr.Errors, outer)
+			}
 		}
 	}
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -404,7 +404,7 @@ func TestJob_SystemJob_Validate(t *testing.T) {
 	}}
 	err = j.Validate()
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "System jobs should not have an affinity stanza")
+	require.Contains(t, err.Error(), "System jobs may not have an affinity stanza")
 }
 
 func TestJob_VaultPolicies(t *testing.T) {


### PR DESCRIPTION
This PR adds new struct for modelling affinities, which can be specified at the job/taskgroup/task level similar to constraints. 

This also includes the API layer and parsing for affinities. 