### PR TITLE
Add NodeName to the alloc/job status outputs.

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -72,6 +72,7 @@ type Allocation struct {
 	EvalID             string
 	Name               string
 	NodeID             string
+	NodeName           string
 	JobID              string
 	Job                *Job
 	TaskGroup          string
@@ -121,6 +122,7 @@ type AllocationListStub struct {
 	EvalID             string
 	Name               string
 	NodeID             string
+	NodeName           string
 	JobID              string
 	JobVersion         uint64
 	TaskGroup          string

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -234,6 +234,7 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 		fmt.Sprintf("Eval ID|%s", limit(alloc.EvalID, uuidLength)),
 		fmt.Sprintf("Name|%s", alloc.Name),
 		fmt.Sprintf("Node ID|%s", limit(alloc.NodeID, uuidLength)),
+		fmt.Sprintf("Node Name|%s", alloc.NodeName),
 		fmt.Sprintf("Job ID|%s", alloc.JobID),
 		fmt.Sprintf("Job Version|%d", getVersion(alloc.Job)),
 		fmt.Sprintf("Client Status|%s", alloc.ClientStatus),

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -413,12 +413,13 @@ func formatAllocListStubs(stubs []*api.AllocationListStub, verbose bool, uuidLen
 
 	allocs := make([]string, len(stubs)+1)
 	if verbose {
-		allocs[0] = "ID|Eval ID|Node ID|Task Group|Version|Desired|Status|Created|Modified"
+		allocs[0] = "ID|Eval ID|Node ID|Node Name|Task Group|Version|Desired|Status|Created|Modified"
 		for i, alloc := range stubs {
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%d|%s|%s|%s|%s",
+			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.EvalID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
+				alloc.NodeName,
 				alloc.TaskGroup,
 				alloc.JobVersion,
 				alloc.DesiredStatus,
@@ -427,14 +428,15 @@ func formatAllocListStubs(stubs []*api.AllocationListStub, verbose bool, uuidLen
 				formatUnixNanoTime(alloc.ModifyTime))
 		}
 	} else {
-		allocs[0] = "ID|Node ID|Task Group|Version|Desired|Status|Created|Modified"
+		allocs[0] = "ID|Node ID|Node Name|Task Group|Version|Desired|Status|Created|Modified"
 		for i, alloc := range stubs {
 			now := time.Now()
 			createTimePretty := prettyTimeDiff(time.Unix(0, alloc.CreateTime), now)
 			modTimePretty := prettyTimeDiff(time.Unix(0, alloc.ModifyTime), now)
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%s",
+			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
+				alloc.NodeName,
 				alloc.TaskGroup,
 				alloc.JobVersion,
 				alloc.DesiredStatus,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5751,6 +5751,9 @@ type Allocation struct {
 	// NodeID is the node this is being placed on
 	NodeID string
 
+	// NodeName is the name of the node this is being placed on.
+	NodeName string
+
 	// Job is the parent job of the task group being allocated.
 	// This is copied at allocation time to avoid issues if the job
 	// definition is updated.
@@ -6132,6 +6135,7 @@ func (a *Allocation) Stub() *AllocListStub {
 		EvalID:             a.EvalID,
 		Name:               a.Name,
 		NodeID:             a.NodeID,
+		NodeName:           a.NodeName,
 		JobID:              a.JobID,
 		JobVersion:         a.Job.Version,
 		TaskGroup:          a.TaskGroup,
@@ -6157,6 +6161,7 @@ type AllocListStub struct {
 	EvalID             string
 	Name               string
 	NodeID             string
+	NodeName           string
 	JobID              string
 	JobVersion         uint64
 	TaskGroup          string

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -482,6 +482,7 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 					TaskGroup:     tg.Name,
 					Metrics:       s.ctx.Metrics(),
 					NodeID:        option.Node.ID,
+					NodeName:      option.Node.Name,
 					DeploymentID:  deploymentID,
 					TaskResources: option.TaskResources,
 					DesiredStatus: structs.AllocDesiredStatusRun,

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -316,6 +316,7 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 				TaskGroup:     missing.TaskGroup.Name,
 				Metrics:       s.ctx.Metrics(),
 				NodeID:        option.Node.ID,
+				NodeName:      option.Node.Name,
 				TaskResources: option.TaskResources,
 				DesiredStatus: structs.AllocDesiredStatusRun,
 				ClientStatus:  structs.AllocClientStatusPending,


### PR DESCRIPTION
Currently when operators need to log onto a machine where an alloc
is running they will need to perform both an alloc/job status
call and then a call to discover the node name from the node list.

This updates both the job status and alloc status output to include
the node name within the information to make operator use easier.

Closes #2359
Closes #1180

Output Examples:
```shell
$ jrasell-nomad job status example

Allocations
ID        Node ID   Node Name                        Task Group  Version  Desired  Status   Created  Modified
e4ea34e6  55d16017  XXXXXXX-XXXXXX.xxxxxxx.xxxx.xxx  cache       0        run      running  8s ago   7s ago
```

```shell
$ jrasell-nomad alloc status e4ea34e6

ID                  = e4ea34e6
Eval ID             = 23fef345
Name                = example.cache[0]
Node ID             = 55d16017
Node Name           = XXXXXXX-XXXXXX.xxxxxxx.xxxx.xxx
```