### PR TITLE
UI: Show deployment deadlines everywhere

### DIFF
--- a/ui/app/templates/components/job-deployment/task-groups.hbs
+++ b/ui/app/templates/components/job-deployment/task-groups.hbs
@@ -14,9 +14,7 @@
         <th>Allocs</th>
         <th>Healthy Allocs</th>
         <th>Unhealthy Allocs</th>
-        {{#if inProgress}}
-          <th>Progress Deadline</th>
-        {{/if}}
+        <th>Progress Deadline</th>
       {{/t.head}}
       {{#t.body as |row|}}
         <tr data-test-deployment-task-group>
@@ -33,11 +31,9 @@
           <td data-test-deployment-task-group-allocs>{{row.model.placedAllocs}} / {{row.model.desiredTotal}}</td>
           <td data-test-deployment-task-group-healthy>{{row.model.healthyAllocs}}</td>
           <td data-test-deployment-task-group-unhealthy>{{row.model.unhealthyAllocs}}</td>
-          {{#if inProgress}}
-            <td data-test-deployment-task-group-progress-deadline>
-              <span class="nowrap">{{moment-format row.model.requireProgressBy "MM/DD/YY HH:mm:ss"}}</span>
-            </td>
-          {{/if}}
+          <td data-test-deployment-task-group-progress-deadline>
+            <span class="nowrap">{{moment-format row.model.requireProgressBy "MM/DD/YY HH:mm:ss"}}</span>
+          </td>
         </tr>
       {{/t.body}}
     {{/list-table}}

--- a/ui/app/templates/components/job-page/parts/running-deployment.hbs
+++ b/ui/app/templates/components/job-page/parts/running-deployment.hbs
@@ -19,7 +19,7 @@
       {{#job-deployment-details deployment=job.runningDeployment as |d|}}
         {{d.metrics}}
         {{#if isShowingDeploymentDetails}}
-          {{d.taskGroups inProgress=true}}
+          {{d.taskGroups}}
           {{d.allocations}}
         {{/if}}
       {{/job-deployment-details}}

--- a/ui/tests/acceptance/job-deployments-test.js
+++ b/ui/tests/acceptance/job-deployments-test.js
@@ -202,6 +202,11 @@ test('when open, a deployment shows a list of all task groups and their respecti
       );
       assert.equal(taskGroupRow.healthy, taskGroup.healthyAllocs, 'Healthy Allocs');
       assert.equal(taskGroupRow.unhealthy, taskGroup.unhealthyAllocs, 'Unhealthy Allocs');
+      assert.equal(
+        taskGroupRow.progress,
+        moment(taskGroup.requireProgressBy).format('MM/DD/YY HH:mm:ss'),
+        'Progress By'
+      );
     });
   });
 });

--- a/ui/tests/pages/jobs/job/deployments.js
+++ b/ui/tests/pages/jobs/job/deployments.js
@@ -43,6 +43,7 @@ export default create({
       allocs: text('[data-test-deployment-task-group-allocs]'),
       healthy: text('[data-test-deployment-task-group-healthy]'),
       unhealthy: text('[data-test-deployment-task-group-unhealthy]'),
+      progress: text('[data-test-deployment-task-group-progress-deadline]'),
     }),
 
     hasAllocations: isPresent('[data-test-deployment-allocations]'),


### PR DESCRIPTION
This was already being shown on the running deployment shown on Job Overview. Now it's everywhere for consistency.

![image](https://user-images.githubusercontent.com/174740/42843615-84eb34f4-89c5-11e8-8fe7-e27517c131ca.png)
