### PR TITLE
Implement spreading allocations based on a target node attribute

### DIFF
--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -221,6 +221,32 @@ func CopySliceAffinities(s []*Affinity) []*Affinity {
 	return c
 }
 
+func CopySliceSpreads(s []*Spread) []*Spread {
+	l := len(s)
+	if l == 0 {
+		return nil
+	}
+
+	c := make([]*Spread, l)
+	for i, v := range s {
+		c[i] = v.Copy()
+	}
+	return c
+}
+
+func CopySliceSpreadTarget(s []*SpreadTarget) []*SpreadTarget {
+	l := len(s)
+	if l == 0 {
+		return nil
+	}
+
+	c := make([]*SpreadTarget, l)
+	for i, v := range s {
+		c[i] = v.Copy()
+	}
+	return c
+}
+
 // VaultPoliciesSet takes the structure returned by VaultPolicies and returns
 // the set of required policies
 func VaultPoliciesSet(policies map[string]map[string]*Vault) []string {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2189,6 +2189,13 @@ func (j *Job) Validate() error {
 		}
 	}
 
+	for idx, spread := range j.Spreads {
+		if err := spread.Validate(); err != nil {
+			outer := fmt.Errorf("Spread %d validation failed: %s", idx+1, err)
+			mErr.Errors = append(mErr.Errors, outer)
+		}
+	}
+
 	// Check for duplicate task groups
 	taskGroups := make(map[string]int)
 	for idx, tg := range j.TaskGroups {
@@ -3457,6 +3464,13 @@ func (tg *TaskGroup) Validate(j *Job) error {
 		}
 	} else {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("Task Group %v should have a restart policy", tg.Name))
+	}
+
+	for idx, spread := range tg.Spreads {
+		if err := spread.Validate(); err != nil {
+			outer := fmt.Errorf("Spread %d validation failed: %s", idx+1, err)
+			mErr.Errors = append(mErr.Errors, outer)
+		}
 	}
 
 	if j.Type == JobTypeSystem {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5423,12 +5423,16 @@ func (a *Affinity) Validate() error {
 type Spread struct {
 	// Attribute is the node attribute used as the spread criteria
 	Attribute string
+
 	// Weight is the relative weight of this spread, useful when there are multiple
 	// spread and affinities
 	Weight int
+
 	// SpreadTarget is used to describe desired percentages for each attribute value
 	SpreadTarget []*SpreadTarget
-	str          string
+
+	// Memoized string representation
+	str string
 }
 
 func (s *Spread) Copy() *Spread {
@@ -5485,9 +5489,12 @@ func (s *Spread) Validate() error {
 type SpreadTarget struct {
 	// Value is a single attribute value, like "dc1"
 	Value string
+
 	// Percent is the desired percentage of allocs
 	Percent uint32
-	str     string
+
+	// Memoized string representation
+	str string
 }
 
 func (s *SpreadTarget) Copy() *SpreadTarget {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5484,8 +5484,7 @@ func (s *Spread) Validate() error {
 	return mErr.ErrorOrNil()
 }
 
-// SpreadTarget is used to specify desired percentages
-// for each attribute value
+// SpreadTarget is used to specify desired percentages for each attribute value
 type SpreadTarget struct {
 	// Value is a single attribute value, like "dc1"
 	Value string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5431,7 +5431,7 @@ func (s *Spread) String() string {
 	if s.str != "" {
 		return s.str
 	}
-	s.str = fmt.Sprintf("%s %s %v", s.Attribute, s.Weight, s.SpreadTarget)
+	s.str = fmt.Sprintf("%s %s %v", s.Attribute, s.SpreadTarget, s.Weight)
 	return s.str
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2191,7 +2191,7 @@ func (j *Job) Validate() error {
 
 	if j.Type == JobTypeSystem {
 		if j.Spreads != nil {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs may not have a s stanza"))
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("System jobs may not have a spread stanza"))
 		}
 	} else {
 		for idx, spread := range j.Spreads {
@@ -5479,7 +5479,7 @@ func (s *Spread) Validate() error {
 		sumPercent += target.Percent
 	}
 	if sumPercent > 100 {
-		mErr.Errors = append(mErr.Errors, errors.New("Sum of spread target percentages must not be greater than 100"))
+		mErr.Errors = append(mErr.Errors, errors.New(fmt.Sprintf("Sum of spread target percentages must not be greater than 100%%; got %d%%", sumPercent)))
 	}
 	return mErr.ErrorOrNil()
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -3926,3 +3926,91 @@ func TestNode_Copy(t *testing.T) {
 	require.Equal(node.DrainStrategy, node2.DrainStrategy)
 	require.Equal(node.Drivers, node2.Drivers)
 }
+
+func TestSpread_Validate(t *testing.T) {
+	type tc struct {
+		spread *Spread
+		err    error
+		name   string
+	}
+
+	testCases := []tc{
+		{
+			spread: &Spread{},
+			err:    fmt.Errorf("Missing spread attribute"),
+			name:   "empty spread",
+		},
+		{
+			spread: &Spread{
+				Attribute: "${node.datacenter}",
+				Weight:    -1,
+			},
+			err:  fmt.Errorf("Spread stanza must have a positive weight from 0 to 100"),
+			name: "Invalid weight",
+		},
+		{
+			spread: &Spread{
+				Attribute: "${node.datacenter}",
+				Weight:    200,
+			},
+			err:  fmt.Errorf("Spread stanza must have a positive weight from 0 to 100"),
+			name: "Invalid weight",
+		},
+		{
+			spread: &Spread{
+				Attribute: "${node.datacenter}",
+				Weight:    50,
+			},
+			err:  fmt.Errorf("Atleast one spread target value must be specified"),
+			name: "No spread targets",
+		},
+		{
+			spread: &Spread{
+				Attribute: "${node.datacenter}",
+				Weight:    50,
+				SpreadTarget: []*SpreadTarget{
+					{
+						Value:   "dc1",
+						Percent: 25,
+					},
+					{
+						Value:   "dc1",
+						Percent: 50,
+					},
+				},
+			},
+			err:  fmt.Errorf("Spread target value \"dc1\" already defined"),
+			name: "No spread targets",
+		},
+		{
+			spread: &Spread{
+				Attribute: "${node.datacenter}",
+				Weight:    50,
+				SpreadTarget: []*SpreadTarget{
+					{
+						Value:   "dc1",
+						Percent: 25,
+					},
+					{
+						Value:   "dc2",
+						Percent: 50,
+					},
+				},
+			},
+			err:  nil,
+			name: "Valid spread",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spread.Validate()
+			if tc.err != nil {
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), tc.err.Error())
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -4004,7 +4004,7 @@ func TestSpread_Validate(t *testing.T) {
 					},
 				},
 			},
-			err:  fmt.Errorf("Sum of spread target percentages must not be greater than 100"),
+			err:  fmt.Errorf("Sum of spread target percentages must not be greater than 100%%; got %d%%", 150),
 			name: "Invalid percentages",
 		},
 		{

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -604,10 +604,104 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 
 // Test job registration with spread configured
 func TestServiceSched_Spread(t *testing.T) {
-	h := NewHarness(t)
 	assert := assert.New(t)
 
-	// Create a job that uses spread over data center
+	start := uint32(100)
+	step := uint32(10)
+
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("%d%% in dc1", start)
+		t.Run(name, func(t *testing.T) {
+			h := NewHarness(t)
+			remaining := uint32(100 - start)
+			// Create a job that uses spread over data center
+			job := mock.Job()
+			job.Datacenters = []string{"dc1", "dc2"}
+			job.TaskGroups[0].Count = 10
+			job.TaskGroups[0].Spreads = append(job.TaskGroups[0].Spreads,
+				&structs.Spread{
+					Attribute: "${node.datacenter}",
+					Weight:    100,
+					SpreadTarget: []*structs.SpreadTarget{
+						{
+							Value:   "dc1",
+							Percent: start,
+						},
+						{
+							Value:   "dc2",
+							Percent: remaining,
+						},
+					},
+				})
+			assert.Nil(h.State.UpsertJob(h.NextIndex(), job), "UpsertJob")
+			// Create some nodes, half in dc2
+			var nodes []*structs.Node
+			nodeMap := make(map[string]*structs.Node)
+			for i := 0; i < 10; i++ {
+				node := mock.Node()
+				if i%2 == 0 {
+					node.Datacenter = "dc2"
+				}
+				nodes = append(nodes, node)
+				assert.Nil(h.State.UpsertNode(h.NextIndex(), node), "UpsertNode")
+				nodeMap[node.ID] = node
+			}
+
+			// Create a mock evaluation to register the job
+			eval := &structs.Evaluation{
+				Namespace:   structs.DefaultNamespace,
+				ID:          uuid.Generate(),
+				Priority:    job.Priority,
+				TriggeredBy: structs.EvalTriggerJobRegister,
+				JobID:       job.ID,
+				Status:      structs.EvalStatusPending,
+			}
+			noErr(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+
+			// Process the evaluation
+			assert.Nil(h.Process(NewServiceScheduler, eval), "Process")
+
+			// Ensure a single plan
+			assert.Len(h.Plans, 1, "Number of plans")
+			plan := h.Plans[0]
+
+			// Ensure the plan doesn't have annotations.
+			assert.Nil(plan.Annotations, "Plan.Annotations")
+
+			// Ensure the eval hasn't spawned blocked eval
+			assert.Len(h.CreateEvals, 0, "Created Evals")
+
+			// Ensure the plan allocated
+			var planned []*structs.Allocation
+			dcAllocsMap := make(map[string]int)
+			for nodeId, allocList := range plan.NodeAllocation {
+				planned = append(planned, allocList...)
+				dc := nodeMap[nodeId].Datacenter
+				c := dcAllocsMap[dc]
+				c += len(allocList)
+				dcAllocsMap[dc] = c
+			}
+			assert.Len(planned, 10, "Planned Allocations")
+
+			expectedCounts := make(map[string]int)
+			expectedCounts["dc1"] = 10 - i
+			if i > 0 {
+				expectedCounts["dc2"] = i
+			}
+			require.Equal(t, expectedCounts, dcAllocsMap)
+
+			h.AssertEvalStatus(t, structs.EvalStatusComplete)
+		})
+		start = start - step
+	}
+}
+
+// Test job registration with even spread across dc
+func TestServiceSched_EvenSpread(t *testing.T) {
+	assert := assert.New(t)
+
+	h := NewHarness(t)
+	// Create a job that uses even spread over data center
 	job := mock.Job()
 	job.Datacenters = []string{"dc1", "dc2"}
 	job.TaskGroups[0].Count = 10
@@ -615,23 +709,12 @@ func TestServiceSched_Spread(t *testing.T) {
 		&structs.Spread{
 			Attribute: "${node.datacenter}",
 			Weight:    100,
-			SpreadTarget: []*structs.SpreadTarget{
-				{
-					Value:   "dc1",
-					Percent: 70,
-				},
-				{
-					Value:   "dc2",
-					Percent: 30,
-				},
-			},
 		})
 	assert.Nil(h.State.UpsertJob(h.NextIndex(), job), "UpsertJob")
-
 	// Create some nodes, half in dc2
 	var nodes []*structs.Node
 	nodeMap := make(map[string]*structs.Node)
-	for i := 0; i < 6; i++ {
+	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		if i%2 == 0 {
 			node.Datacenter = "dc2"
@@ -677,9 +760,11 @@ func TestServiceSched_Spread(t *testing.T) {
 	}
 	assert.Len(planned, 10, "Planned Allocations")
 
+	// Expect even split allocs across datacenter
 	expectedCounts := make(map[string]int)
-	expectedCounts["dc1"] = 7
-	expectedCounts["dc2"] = 3
+	expectedCounts["dc1"] = 5
+	expectedCounts["dc2"] = 5
+
 	require.Equal(t, expectedCounts, dcAllocsMap)
 
 	h.AssertEvalStatus(t, structs.EvalStatusComplete)

--- a/scheduler/propertyset.go
+++ b/scheduler/propertyset.go
@@ -75,7 +75,7 @@ func (p *propertySet) SetTGConstraint(constraint *structs.Constraint, taskGroup 
 
 // setConstraint is a shared helper for setting a job or task group constraint.
 func (p *propertySet) setConstraint(constraint *structs.Constraint, taskGroup string) {
-	allowedCount := uint64(0)
+	var allowedCount uint64
 	// Determine the number of allowed allocations with the property.
 	if v := constraint.RTarget; v != "" {
 		c, err := strconv.ParseUint(v, 10, 64)

--- a/scheduler/propertyset.go
+++ b/scheduler/propertyset.go
@@ -234,9 +234,15 @@ func (p *propertySet) UsedCount(option *structs.Node, tg string) (string, string
 	if !ok {
 		return nValue, fmt.Sprintf("missing property %q", p.targetAttribute), 0
 	}
+	combinedUse := p.GetCombinedUseMap()
+	usedCount := combinedUse[nValue]
+	return nValue, "", usedCount
+}
 
-	// combine the counts of how many times the property has been used by
-	// existing and proposed allocations
+// GetCombinedUseMap counts how many times the property has been used by
+// existing and proposed allocations. It also takes into account any stopped
+// allocations
+func (p *propertySet) GetCombinedUseMap() map[string]uint64 {
 	combinedUse := make(map[string]uint64, helper.IntMax(len(p.existingValues), len(p.proposedValues)))
 	for _, usedValues := range []map[string]uint64{p.existingValues, p.proposedValues} {
 		for propertyValue, usedCount := range usedValues {
@@ -259,9 +265,7 @@ func (p *propertySet) UsedCount(option *structs.Node, tg string) (string, string
 			combinedUse[propertyValue] = 0
 		}
 	}
-
-	usedCount := combinedUse[nValue]
-	return nValue, "", usedCount
+	return combinedUse
 }
 
 // filterAllocs filters a set of allocations to just be those that are running

--- a/scheduler/propertyset.go
+++ b/scheduler/propertyset.go
@@ -60,7 +60,7 @@ func NewPropertySet(ctx Context, job *structs.Job) *propertySet {
 	return p
 }
 
-// SetJobConstraintAttribute is used to parameterize the property set for a
+// SetJobConstraint is used to parameterize the property set for a
 // distinct_property constraint set at the job level.
 func (p *propertySet) SetJobConstraint(constraint *structs.Constraint) {
 	p.setConstraint(constraint, "")
@@ -89,18 +89,18 @@ func (p *propertySet) setConstraint(constraint *structs.Constraint, taskGroup st
 	} else {
 		allowedCount = 1
 	}
-	p.setPropertySetInner(constraint.LTarget, allowedCount, taskGroup)
+	p.setTargetAttributeWithCount(constraint.LTarget, allowedCount, taskGroup)
 }
 
 // SetTargetAttribute is used to populate this property set without also storing allowed count
 // This is used when evaluating spread stanzas
 func (p *propertySet) SetTargetAttribute(targetAttribute string, taskGroup string) {
-	p.setPropertySetInner(targetAttribute, 0, taskGroup)
+	p.setTargetAttributeWithCount(targetAttribute, 0, taskGroup)
 }
 
-// setConstraint is a shared helper for setting a job or task group attribute and allowedCount
+// setTargetAttributeWithCount is a shared helper for setting a job or task group attribute and allowedCount
 // allowedCount can be zero when this is used in evaluating spread stanzas
-func (p *propertySet) setPropertySetInner(targetAttribute string, allowedCount uint64, taskGroup string) {
+func (p *propertySet) setTargetAttributeWithCount(targetAttribute string, allowedCount uint64, taskGroup string) {
 	// Store that this is for a task group
 	if taskGroup != "" {
 		p.taskGroup = taskGroup
@@ -113,7 +113,7 @@ func (p *propertySet) setPropertySetInner(targetAttribute string, allowedCount u
 
 	// Determine the number of existing allocations that are using a property
 	// value
-	p.populateExisting(targetAttribute)
+	p.populateExisting()
 
 	// Populate the proposed when setting the constraint. We do this because
 	// when detecting if we can inplace update an allocation we stage an
@@ -124,7 +124,7 @@ func (p *propertySet) setPropertySetInner(targetAttribute string, allowedCount u
 
 // populateExisting is a helper shared when setting the constraint to populate
 // the existing values.
-func (p *propertySet) populateExisting(targetAttribute string) {
+func (p *propertySet) populateExisting() {
 	// Retrieve all previously placed allocations
 	ws := memdb.NewWatchSet()
 	allocs, err := p.ctx.State().AllocsByJob(ws, p.namespace, p.jobID, false)

--- a/scheduler/spread.go
+++ b/scheduler/spread.go
@@ -5,9 +5,9 @@ import (
 )
 
 const (
-	// ImplicitTarget is used to represent any remaining attribute values
+	// implicitTarget is used to represent any remaining attribute values
 	// when target percentages don't add up to 100
-	ImplicitTarget = "*"
+	implicitTarget = "*"
 )
 
 // SpreadIterator is used to spread allocations across a specified attribute
@@ -139,7 +139,7 @@ func (iter *SpreadIterator) Next() *RankedNode {
 				desiredCount, ok := spreadDetails.desiredCounts[nValue]
 				if !ok {
 					// See if there is an implicit target
-					desiredCount, ok = spreadDetails.desiredCounts[ImplicitTarget]
+					desiredCount, ok = spreadDetails.desiredCounts[implicitTarget]
 					if !ok {
 						// The desired count for this attribute is zero if it gets here
 						// so use the maximum possible penalty for this node
@@ -241,7 +241,7 @@ func (iter *SpreadIterator) computeSpreadInfo(tg *structs.TaskGroup) {
 		// Account for remaining count only if there is any spread targets
 		if sumDesiredCounts > 0 && sumDesiredCounts < float64(totalCount) {
 			remainingCount := float64(totalCount) - sumDesiredCounts
-			si.desiredCounts[ImplicitTarget] = remainingCount
+			si.desiredCounts[implicitTarget] = remainingCount
 		}
 		spreadInfos[spread.Attribute] = si
 		iter.sumSpreadWeights += spread.Weight

--- a/scheduler/spread.go
+++ b/scheduler/spread.go
@@ -1,0 +1,155 @@
+package scheduler
+
+import (
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// SpreadIterator is used to spread allocations across a specified attribute
+// according to preset weights
+type SpreadIterator struct {
+	ctx               Context
+	source            RankIterator
+	job               *structs.Job
+	tg                *structs.TaskGroup
+	jobSpreads        []*structs.Spread
+	tgSpreadInfo      map[string]spreadAttributeMap
+	sumSpreadWeights  int
+	hasSpread         bool
+	groupPropertySets map[string][]*propertySet
+}
+
+type spreadAttributeMap map[string]*spreadInfo
+
+type spreadInfo struct {
+	sumWeight     uint32
+	weight        int
+	desiredCounts map[string]float64
+}
+
+func NewSpreadIterator(ctx Context, source RankIterator) *SpreadIterator {
+	iter := &SpreadIterator{
+		ctx:               ctx,
+		source:            source,
+		groupPropertySets: make(map[string][]*propertySet),
+		tgSpreadInfo:      make(map[string]spreadAttributeMap),
+	}
+	return iter
+}
+
+func (iter *SpreadIterator) Reset() {
+	iter.source.Reset()
+	for _, sets := range iter.groupPropertySets {
+		for _, ps := range sets {
+			ps.PopulateProposed()
+		}
+	}
+}
+
+func (iter *SpreadIterator) SetJob(job *structs.Job) {
+	iter.job = job
+	if job.Spreads != nil {
+		iter.jobSpreads = job.Spreads
+	}
+}
+
+func (iter *SpreadIterator) SetTaskGroup(tg *structs.TaskGroup) {
+	iter.tg = tg
+
+	// Build the property set at the taskgroup level
+	if _, ok := iter.groupPropertySets[tg.Name]; !ok {
+		// First add property sets that are at the job level for this task group
+		for _, spread := range iter.jobSpreads {
+			pset := NewPropertySet(iter.ctx, iter.job)
+			pset.SetTargetAttribute(spread.Attribute, tg.Name)
+			iter.groupPropertySets[tg.Name] = append(iter.groupPropertySets[tg.Name], pset)
+		}
+
+		// Include property sets at the task group level
+		for _, spread := range tg.Spreads {
+			pset := NewPropertySet(iter.ctx, iter.job)
+			pset.SetTargetAttribute(spread.Attribute, tg.Name)
+			iter.groupPropertySets[tg.Name] = append(iter.groupPropertySets[tg.Name], pset)
+		}
+	}
+
+	// Check if there is a distinct property
+	iter.hasSpread = len(iter.groupPropertySets[tg.Name]) != 0
+
+	// Build tgSpreadInfo at the task group level
+	if _, ok := iter.tgSpreadInfo[tg.Name]; !ok {
+		iter.computeSpreadInfo(tg)
+	}
+
+}
+
+func (iter *SpreadIterator) hasSpreads() bool {
+	return iter.hasSpread
+}
+
+func (iter *SpreadIterator) Next() *RankedNode {
+	for {
+		option := iter.source.Next()
+
+		// Hot path if there is nothing to check
+		if option == nil || !iter.hasSpreads() {
+			return option
+		}
+
+		tgName := iter.tg.Name
+		propertySets := iter.groupPropertySets[tgName]
+		// Iterate over each spread attribute's property set and add a weighted score
+		totalSpreadScore := 0.0
+		for _, pset := range propertySets {
+			nValue, errorMsg, usedCount := pset.UsedCount(option.Node, tgName)
+			if errorMsg != "" {
+				// Skip if there was errors in resolving this attribute to compute used counts
+				continue
+			}
+			spreadAttributeMap := iter.tgSpreadInfo[tgName]
+			spreadDetails := spreadAttributeMap[pset.targetAttribute]
+			// Get the desired count
+			desiredCount, ok := spreadDetails.desiredCounts[nValue]
+			if !ok {
+				// Warn about missing ratio
+				iter.ctx.Logger().Printf("[WARN] sched: missing desired distribution percentage for attribute value %v in spread stanza for job %v", nValue, iter.job.ID)
+				continue
+			}
+			if float64(usedCount) < desiredCount {
+				// Calculate the relative weight of this specific spread attribute
+				spreadWeight := float64(spreadDetails.weight) / float64(iter.sumSpreadWeights)
+				// Score Boost is proportional the difference between current and desired count
+				// It is multiplied with the spread weight to account for cases where the job has
+				// more than one spread attribute
+				scoreBoost := ((desiredCount - float64(usedCount)) / desiredCount) * spreadWeight
+				totalSpreadScore += scoreBoost
+			}
+		}
+
+		if totalSpreadScore != 0.0 {
+			option.Scores = append(option.Scores, totalSpreadScore)
+			iter.ctx.Metrics().ScoreNode(option.Node, "allocation-spread", totalSpreadScore)
+		}
+		return option
+	}
+}
+
+// computeSpreadInfo computes and stores percentages and total values
+// from all spreads that apply to a specific task group
+func (iter *SpreadIterator) computeSpreadInfo(tg *structs.TaskGroup) {
+	spreadInfos := make(spreadAttributeMap, len(tg.Spreads))
+	totalCount := tg.Count
+	for _, spread := range tg.Spreads {
+		sumWeight := uint32(0)
+		for _, st := range spread.SpreadTarget {
+			sumWeight += st.Percent
+		}
+		si := &spreadInfo{sumWeight: sumWeight, weight: spread.Weight, desiredCounts: make(map[string]float64)}
+		for _, st := range spread.SpreadTarget {
+			desiredCount := (float64(st.Percent) / float64(sumWeight)) * float64(totalCount)
+			si.desiredCounts[st.Value] = desiredCount
+		}
+		spreadInfos[spread.Attribute] = si
+		iter.sumSpreadWeights += spread.Weight
+	}
+	iter.tgSpreadInfo[tg.Name] = spreadInfos
+}

--- a/scheduler/spread.go
+++ b/scheduler/spread.go
@@ -135,6 +135,7 @@ func (iter *SpreadIterator) Next() *RankedNode {
 						// The desired count for this attribute is zero if it gets here
 						// so use the maximum possible penalty for this node
 						totalSpreadScore += -1.0
+						continue
 					}
 				}
 
@@ -191,22 +192,18 @@ func evenSpreadScoreBoost(pset *propertySet, option *structs.Node) float64 {
 		delta := int(minCount - currentAttributeCount)
 		deltaBoost = float64(delta) / float64(minCount)
 	}
-	if currentAttributeCount < minCount {
-		// positive boost for attributes with min count
-		return deltaBoost
-	} else if currentAttributeCount > minCount {
-		// Negative boost if attribute count is greater than minimum
+	if currentAttributeCount != minCount {
+		// Boost based on delta between current and min
 		return deltaBoost
 	} else {
-		// When min and current value are the same we return the maximum
-		// possible boost or penalty
 		if minCount == maxCount {
 			// Maximum possible penalty when the distribution is even
 			return -1.0
 		} else {
-			// Maximum possible boost when there is another attribute with
-			// more allocations
-			return 1.0
+			// Penalty based on delta from max value
+			delta := int(maxCount - minCount)
+			deltaBoost = float64(delta) / float64(minCount)
+			return deltaBoost
 		}
 	}
 }

--- a/scheduler/spread.go
+++ b/scheduler/spread.go
@@ -202,7 +202,7 @@ func evenSpreadScoreBoost(pset *propertySet, option *structs.Node) float64 {
 	}
 
 	// calculate boost based on delta between the current and the minimum
-	deltaBoost := 1.0
+	var deltaBoost float64
 	if minCount == 0 {
 		deltaBoost = -1.0
 	} else {

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -1,0 +1,249 @@
+package scheduler
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpreadIterator_SingleAttribute(t *testing.T) {
+	state, ctx := testContext(t)
+	dcs := []string{"dc1", "dc2", "dc1", "dc1"}
+	var nodes []*RankedNode
+
+	// Add these nodes to the state store
+	for i, dc := range dcs {
+		node := mock.Node()
+		node.Datacenter = dc
+		if err := state.UpsertNode(uint64(100+i), node); err != nil {
+			t.Fatalf("failed to upsert node: %v", err)
+		}
+		nodes = append(nodes, &RankedNode{Node: node})
+	}
+
+	static := NewStaticRankIterator(ctx, nodes)
+
+	job := mock.Job()
+	tg := job.TaskGroups[0]
+	job.TaskGroups[0].Count = 5
+	// add allocs to nodes in dc1
+	upserting := []*structs.Allocation{
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
+			NodeID:    nodes[0].Node.ID,
+		},
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
+			NodeID:    nodes[2].Node.ID,
+		},
+	}
+
+	if err := state.UpsertAllocs(1000, upserting); err != nil {
+		t.Fatalf("failed to UpsertAllocs: %v", err)
+	}
+
+	spread := &structs.Spread{
+		Weight:    100,
+		Attribute: "${node.datacenter}",
+		SpreadTarget: []*structs.SpreadTarget{
+			{
+				Value:   "dc1",
+				Percent: 80,
+			},
+			{
+				Value:   "dc2",
+				Percent: 20,
+			},
+		},
+	}
+	tg.Spreads = []*structs.Spread{spread}
+	spreadIter := NewSpreadIterator(ctx, static)
+	spreadIter.SetJob(job)
+	spreadIter.SetTaskGroup(tg)
+
+	scoreNorm := NewScoreNormalizationIterator(ctx, spreadIter)
+
+	out := collectRanked(scoreNorm)
+
+	// Expect nodes in dc1 with existing allocs to get a boost
+	// Boost should be ((desiredCount-actual)/expected)*spreadWeight
+	// For this test, that becomes dc1 = ((4-2)/4 ) = 0.5, and dc2=(1-0)/1
+	expectedScores := map[string]float64{
+		"dc1": 0.5,
+		"dc2": 1.0,
+	}
+	for _, rn := range out {
+		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
+	}
+
+	// Update the plan to add more allocs to nodes in dc1
+	// After this step there are enough allocs to meet the desired count in dc1
+	ctx.plan.NodeAllocation[nodes[0].Node.ID] = []*structs.Allocation{
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			NodeID:    nodes[0].Node.ID,
+		},
+		// Should be ignored as it is a different job.
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: "bbb",
+			JobID:     "ignore 2",
+			Job:       job,
+			ID:        uuid.Generate(),
+			NodeID:    nodes[0].Node.ID,
+		},
+	}
+	ctx.plan.NodeAllocation[nodes[3].Node.ID] = []*structs.Allocation{
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			NodeID:    nodes[3].Node.ID,
+		},
+	}
+
+	// Reset the scores
+	for _, node := range nodes {
+		node.Scores = nil
+		node.FinalScore = 0
+	}
+	static = NewStaticRankIterator(ctx, nodes)
+	spreadIter = NewSpreadIterator(ctx, static)
+	spreadIter.SetJob(job)
+	spreadIter.SetTaskGroup(tg)
+	scoreNorm = NewScoreNormalizationIterator(ctx, spreadIter)
+	out = collectRanked(scoreNorm)
+
+	// Expect nodes in dc2 with existing allocs to get a boost
+	// DC1 nodes are not boosted because there are enough allocs to meet
+	// the desired count
+	expectedScores = map[string]float64{
+		"dc1": 0,
+		"dc2": 1.0,
+	}
+	for _, rn := range out {
+		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
+	}
+}
+
+func TestSpreadIterator_MultipleAttributes(t *testing.T) {
+	state, ctx := testContext(t)
+	dcs := []string{"dc1", "dc2", "dc1", "dc1"}
+	rack := []string{"r1", "r1", "r2", "r2"}
+	var nodes []*RankedNode
+
+	// Add these nodes to the state store
+	for i, dc := range dcs {
+		node := mock.Node()
+		node.Datacenter = dc
+		node.Meta["rack"] = rack[i]
+		if err := state.UpsertNode(uint64(100+i), node); err != nil {
+			t.Fatalf("failed to upsert node: %v", err)
+		}
+		nodes = append(nodes, &RankedNode{Node: node})
+	}
+
+	static := NewStaticRankIterator(ctx, nodes)
+
+	job := mock.Job()
+	tg := job.TaskGroups[0]
+	job.TaskGroups[0].Count = 5
+	// add allocs to nodes in dc1
+	upserting := []*structs.Allocation{
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
+			NodeID:    nodes[0].Node.ID,
+		},
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			EvalID:    uuid.Generate(),
+			NodeID:    nodes[2].Node.ID,
+		},
+	}
+
+	if err := state.UpsertAllocs(1000, upserting); err != nil {
+		t.Fatalf("failed to UpsertAllocs: %v", err)
+	}
+
+	spread1 := &structs.Spread{
+		Weight:    100,
+		Attribute: "${node.datacenter}",
+		SpreadTarget: []*structs.SpreadTarget{
+			{
+				Value:   "dc1",
+				Percent: 60,
+			},
+			{
+				Value:   "dc2",
+				Percent: 40,
+			},
+		},
+	}
+
+	spread2 := &structs.Spread{
+		Weight:    50,
+		Attribute: "${meta.rack}",
+		SpreadTarget: []*structs.SpreadTarget{
+			{
+				Value:   "r1",
+				Percent: 40,
+			},
+			{
+				Value:   "r2",
+				Percent: 60,
+			},
+		},
+	}
+
+	tg.Spreads = []*structs.Spread{spread1, spread2}
+	spreadIter := NewSpreadIterator(ctx, static)
+	spreadIter.SetJob(job)
+	spreadIter.SetTaskGroup(tg)
+
+	scoreNorm := NewScoreNormalizationIterator(ctx, spreadIter)
+
+	out := collectRanked(scoreNorm)
+
+	// Score come from combining two different spread factors
+	// Second node should have the highest score because it has no allocs and its in dc2/r1
+	expectedScores := map[string]float64{
+		nodes[0].Node.ID: 0.389,
+		nodes[1].Node.ID: 0.833,
+		nodes[2].Node.ID: 0.444,
+		nodes[3].Node.ID: 0.444,
+	}
+	for _, rn := range out {
+		require.Equal(t, fmt.Sprintf("%.3f", expectedScores[rn.Node.ID]), fmt.Sprintf("%.3f", rn.FinalScore))
+	}
+
+}

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -245,3 +245,189 @@ func TestSpreadIterator_MultipleAttributes(t *testing.T) {
 	}
 
 }
+
+func TestSpreadIterator_EvenSpread(t *testing.T) {
+	state, ctx := testContext(t)
+	dcs := []string{"dc1", "dc2", "dc1", "dc2", "dc1", "dc2", "dc2", "dc1", "dc1", "dc1"}
+	var nodes []*RankedNode
+
+	// Add these nodes to the state store
+	for i, dc := range dcs {
+		node := mock.Node()
+		node.Datacenter = dc
+		if err := state.UpsertNode(uint64(100+i), node); err != nil {
+			t.Fatalf("failed to upsert node: %v", err)
+		}
+		nodes = append(nodes, &RankedNode{Node: node})
+	}
+
+	static := NewStaticRankIterator(ctx, nodes)
+	job := mock.Job()
+	tg := job.TaskGroups[0]
+	job.TaskGroups[0].Count = 10
+
+	// Configure even spread across node.datacenter
+	spread := &structs.Spread{
+		Weight:    100,
+		Attribute: "${node.datacenter}",
+	}
+	tg.Spreads = []*structs.Spread{spread}
+	spreadIter := NewSpreadIterator(ctx, static)
+	spreadIter.SetJob(job)
+	spreadIter.SetTaskGroup(tg)
+
+	scoreNorm := NewScoreNormalizationIterator(ctx, spreadIter)
+
+	out := collectRanked(scoreNorm)
+
+	// Nothing placed so both dc nodes get 0 as the score
+	expectedScores := map[string]float64{
+		"dc1": 0,
+		"dc2": 0,
+	}
+	for _, rn := range out {
+		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
+	}
+
+	// Update the plan to add allocs to nodes in dc1
+	// After this step dc2 nodes should get boosted
+	ctx.plan.NodeAllocation[nodes[0].Node.ID] = []*structs.Allocation{
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			NodeID:    nodes[0].Node.ID,
+		},
+	}
+	ctx.plan.NodeAllocation[nodes[2].Node.ID] = []*structs.Allocation{
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			NodeID:    nodes[2].Node.ID,
+		},
+	}
+
+	// Reset the scores
+	for _, node := range nodes {
+		node.Scores = nil
+		node.FinalScore = 0
+	}
+	static = NewStaticRankIterator(ctx, nodes)
+	spreadIter = NewSpreadIterator(ctx, static)
+	spreadIter.SetJob(job)
+	spreadIter.SetTaskGroup(tg)
+	scoreNorm = NewScoreNormalizationIterator(ctx, spreadIter)
+	out = collectRanked(scoreNorm)
+
+	// Expect nodes in dc2 with existing allocs to get a boost
+	// dc1 nodes are penalized because they have allocs
+	expectedScores = map[string]float64{
+		"dc1": -0.5,
+		"dc2": 0.01,
+	}
+	for _, rn := range out {
+		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
+	}
+
+	// Update the plan to add more allocs to nodes in dc2
+	// After this step dc1 nodes should get boosted
+	ctx.plan.NodeAllocation[nodes[1].Node.ID] = []*structs.Allocation{
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			NodeID:    nodes[1].Node.ID,
+		},
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			NodeID:    nodes[1].Node.ID,
+		},
+	}
+	ctx.plan.NodeAllocation[nodes[3].Node.ID] = []*structs.Allocation{
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			NodeID:    nodes[3].Node.ID,
+		},
+	}
+
+	// Reset the scores
+	for _, node := range nodes {
+		node.Scores = nil
+		node.FinalScore = 0
+	}
+	static = NewStaticRankIterator(ctx, nodes)
+	spreadIter = NewSpreadIterator(ctx, static)
+	spreadIter.SetJob(job)
+	spreadIter.SetTaskGroup(tg)
+	scoreNorm = NewScoreNormalizationIterator(ctx, spreadIter)
+	out = collectRanked(scoreNorm)
+
+	// Expect nodes in dc2 to be penalized because there are 3 allocs there now
+	// dc1 nodes are boosted because that has 2 allocs
+	expectedScores = map[string]float64{
+		"dc1": 0.01,
+		"dc2": -0.5,
+	}
+	for _, rn := range out {
+		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
+	}
+
+	// Add another node in dc3
+	node := mock.Node()
+	node.Datacenter = "dc3"
+	if err := state.UpsertNode(uint64(1111), node); err != nil {
+		t.Fatalf("failed to upsert node: %v", err)
+	}
+	nodes = append(nodes, &RankedNode{Node: node})
+
+	// Add another alloc to dc1, now its count matches dc2
+	ctx.plan.NodeAllocation[nodes[4].Node.ID] = []*structs.Allocation{
+		{
+			Namespace: structs.DefaultNamespace,
+			TaskGroup: tg.Name,
+			JobID:     job.ID,
+			Job:       job,
+			ID:        uuid.Generate(),
+			NodeID:    nodes[4].Node.ID,
+		},
+	}
+
+	// Reset scores
+	for _, node := range nodes {
+		node.Scores = nil
+		node.FinalScore = 0
+	}
+	static = NewStaticRankIterator(ctx, nodes)
+	spreadIter = NewSpreadIterator(ctx, static)
+	spreadIter.SetJob(job)
+	spreadIter.SetTaskGroup(tg)
+	scoreNorm = NewScoreNormalizationIterator(ctx, spreadIter)
+	out = collectRanked(scoreNorm)
+
+	// Expect dc1 and dc2 to be penalized because they have 3 allocs
+	// dc3 should get a boost because it has 0 allocs
+	expectedScores = map[string]float64{
+		"dc1": -0.5,
+		"dc2": -0.5,
+		"dc3": 0.01,
+	}
+	for _, rn := range out {
+		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
+	}
+
+}

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -286,7 +286,7 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 		"dc2": 0,
 	}
 	for _, rn := range out {
-		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
+		require.Equal(t, fmt.Sprintf("%.3f", expectedScores[rn.Node.Datacenter]), fmt.Sprintf("%.3f", rn.FinalScore))
 	}
 
 	// Update the plan to add allocs to nodes in dc1
@@ -380,11 +380,11 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 	// Expect nodes in dc2 to be penalized because there are 3 allocs there now
 	// dc1 nodes are boosted because that has 2 allocs
 	expectedScores = map[string]float64{
-		"dc1": 1,
+		"dc1": 0.5,
 		"dc2": -0.5,
 	}
 	for _, rn := range out {
-		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
+		require.Equal(t, fmt.Sprintf("%3.3f", expectedScores[rn.Node.Datacenter]), fmt.Sprintf("%3.3f", rn.FinalScore))
 	}
 
 	// Add another node in dc3
@@ -427,7 +427,7 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 		"dc3": 1,
 	}
 	for _, rn := range out {
-		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
+		require.Equal(t, fmt.Sprintf("%.3f", expectedScores[rn.Node.Datacenter]), fmt.Sprintf("%.3f", rn.FinalScore))
 	}
 
 }

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -57,6 +57,8 @@ func TestSpreadIterator_SingleAttribute(t *testing.T) {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
+	// Create spread target of 80% in dc1
+	// Implicitly, this means 20% in dc2
 	spread := &structs.Spread{
 		Weight:    100,
 		Attribute: "${node.datacenter}",
@@ -64,10 +66,6 @@ func TestSpreadIterator_SingleAttribute(t *testing.T) {
 			{
 				Value:   "dc1",
 				Percent: 80,
-			},
-			{
-				Value:   "dc2",
-				Percent: 20,
 			},
 		},
 	}

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -327,8 +327,8 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 	// Expect nodes in dc2 with existing allocs to get a boost
 	// dc1 nodes are penalized because they have allocs
 	expectedScores = map[string]float64{
-		"dc1": -0.5,
-		"dc2": 0.01,
+		"dc1": -1,
+		"dc2": 1,
 	}
 	for _, rn := range out {
 		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)
@@ -380,7 +380,7 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 	// Expect nodes in dc2 to be penalized because there are 3 allocs there now
 	// dc1 nodes are boosted because that has 2 allocs
 	expectedScores = map[string]float64{
-		"dc1": 0.01,
+		"dc1": 1,
 		"dc2": -0.5,
 	}
 	for _, rn := range out {
@@ -422,9 +422,9 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 	// Expect dc1 and dc2 to be penalized because they have 3 allocs
 	// dc3 should get a boost because it has 0 allocs
 	expectedScores = map[string]float64{
-		"dc1": -0.5,
-		"dc2": -0.5,
-		"dc3": 0.01,
+		"dc1": -1,
+		"dc2": -1,
+		"dc3": 1,
 	}
 	for _, rn := range out {
 		require.Equal(t, expectedScores[rn.Node.Datacenter], rn.FinalScore)


### PR DESCRIPTION
This PR implements support for spreading allocations across a given target node attribute (datacenter, rack etc) in the scheduler.

Spread can be configured at the task group level, or inherited from the job for all task groups. Spread can be combined with affinities, and given weights.  

Builds on top of #4513 and #4512, note to reviewers - its easier if you review this after those two PRs have been merged (should happen sometime this week). 

Open questions: 
* Allowing empty spread targets - should that infer available values for the attribute (eg, dc) at schedule time and then assume even split across all? 
* Interpretation of the "percent" field in each spread target, currently its normalized by dividing by the sum across all targets. This means if there is a single target with a spread percentage of 50, it really means it gets 100% of all allocations. We can make the tradeoff of requiring explicit configuration (ie enforcing that the percentages must add up to 100%)  instead of doing normalization, to avoid this issue