### PR TITLE
UI: Use the JobID as the Version ID for mirage job versions

### DIFF
--- a/ui/mirage/factories/job-version.js
+++ b/ui/mirage/factories/job-version.js
@@ -12,6 +12,12 @@ export default Factory.extend({
   jobId: null,
   version: 0,
 
+  // ID is used for record tracking within Mirage,
+  // but Nomad uses the JobID as the version ID.
+  tempVersionId() {
+    return this.job.id;
+  },
+
   // Directive to restrict any related deployments from having a 'running' status
   noActiveDeployment: false,
 

--- a/ui/mirage/serializers/job-version.js
+++ b/ui/mirage/serializers/job-version.js
@@ -16,6 +16,9 @@ export default ApplicationSerializer.extend({
           hash.Diffs.push(version.Diff);
           delete version.Diff;
 
+          // ID is used for record tracking within Mirage,
+          // but Nomad uses the JobID as the version ID.
+          version.ID = version.TempVersionID;
           hash.Versions.push(version);
           return hash;
         },


### PR DESCRIPTION
The Mirage Job Version JSON was not using JobID as the ID property.

The way I fixed this is rather unfortunate, but there is little else that can be done about overriding a mirage record's ID. If anyone knows of something better, please let me know!