### PR TITLE
Bootstrap vagrant development environment with protoc

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -137,6 +137,10 @@ def configureLinuxProvisioners(vmCfg)
 		path: './scripts/vagrant-linux-priv-rkt.sh'
 
 	vmCfg.vm.provision "shell",
+		privileged: true,
+		path: './scripts/vagrant-linux-protoc.sh'
+
+	vmCfg.vm.provision "shell",
 		privileged: false,
 		path: './scripts/vagrant-linux-priv-ui.sh'
 

--- a/scripts/vagrant-linux-protoc.sh
+++ b/scripts/vagrant-linux-protoc.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# set up protoc so that we can use it for protobuf generation
+PROTOC_ZIP=protoc-3.3.0-osx-x86_64.zip
+curl -OL https://github.com/google/protobuf/releases/download/v3.3.0/$PROTOC_ZIP
+sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+rm -f $PROTOC_ZIP
+

--- a/scripts/vagrant-linux-protoc.sh
+++ b/scripts/vagrant-linux-protoc.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # set up protoc so that we can use it for protobuf generation
-PROTOC_ZIP=protoc-3.3.0-linux-x86_64.zip
-curl -OL https://github.com/google/protobuf/releases/download/v3.3.0/$PROTOC_ZIP
+PROTOC_ZIP=protoc-3.6.1-linux-x86_64.zip
+curl -OL https://github.com/google/protobuf/releases/download/v3.6.1/$PROTOC_ZIP
 sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
 rm -f $PROTOC_ZIP
 

--- a/scripts/vagrant-linux-protoc.sh
+++ b/scripts/vagrant-linux-protoc.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # set up protoc so that we can use it for protobuf generation
-PROTOC_ZIP=protoc-3.3.0-osx-x86_64.zip
+PROTOC_ZIP=protoc-3.3.0-linux-x86_64.zip
 curl -OL https://github.com/google/protobuf/releases/download/v3.3.0/$PROTOC_ZIP
 sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
 rm -f $PROTOC_ZIP


### PR DESCRIPTION
We will use protoc for generating protobuf files. See http://google.github.io/proto-lens/installing-protoc.html for reference. 