### PR TITLE
UI: Specialized No Leader error page

### DIFF
--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -3,6 +3,7 @@ import { computed, get } from '@ember/object';
 import RESTAdapter from 'ember-data/adapters/rest';
 import codesForError from '../utils/codes-for-error';
 import removeRecord from '../utils/remove-record';
+import { default as NoLeaderError, NO_LEADER } from '../utils/no-leader-error';
 
 export const namespace = 'v1';
 
@@ -20,6 +21,13 @@ export default RESTAdapter.extend({
       };
     }
   }),
+
+  handleResponse(status, headers, payload) {
+    if (status === 500 && payload === NO_LEADER) {
+      return new NoLeaderError();
+    }
+    return this._super(...arguments);
+  },
 
   findAll() {
     return this._super(...arguments).catch(error => {

--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -4,6 +4,7 @@ import { run } from '@ember/runloop';
 import { observer, computed } from '@ember/object';
 import Ember from 'ember';
 import codesForError from '../utils/codes-for-error';
+import NoLeaderError from '../utils/no-leader-error';
 
 export default Controller.extend({
   config: service(),
@@ -35,6 +36,11 @@ export default Controller.extend({
 
   is500: computed('errorCodes.[]', function() {
     return this.get('errorCodes').includes('500');
+  }),
+
+  isNoLeader: computed('error', function() {
+    const error = this.get('error');
+    return error instanceof NoLeaderError;
   }),
 
   throwError: observer('error', function() {

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -4,7 +4,12 @@
 {{else}}
   <div class="error-container">
     <div data-test-error class="error-message">
-      {{#if is500}}
+      {{#if isNoLeader}}
+        <h1 data-test-error-title class="title is-spaced">No Cluster Leader</h1>
+        <p data-test-error-message class="subtitle">
+          The cluster has no leader. <a href="https://www.nomadproject.io/guides/outage.html"> Read about Outage Recovery.</a>
+        </p>
+      {{else if is500}}
         <h1 data-test-error-title class="title is-spaced">Server Error</h1>
         <p data-test-error-message class="subtitle">A server error prevented data from being sent to the client.</p>
       {{else if is404}}

--- a/ui/app/utils/no-leader-error.js
+++ b/ui/app/utils/no-leader-error.js
@@ -1,0 +1,7 @@
+import { AdapterError } from 'ember-data/adapters/errors';
+
+export const NO_LEADER = 'No cluster leader';
+
+export default AdapterError.extend({
+  message: NO_LEADER,
+});

--- a/ui/tests/acceptance/application-errors-test.js
+++ b/ui/tests/acceptance/application-errors-test.js
@@ -52,3 +52,18 @@ test('the 403 error page links to the ACL tokens page', function(assert) {
     );
   });
 });
+
+test('the no leader error state gets its own error message', function(assert) {
+  server.pretender.get('/v1/jobs', () => [500, {}, 'No cluster leader']);
+
+  JobsList.visit();
+
+  andThen(() => {
+    assert.ok(JobsList.error.isPresent, 'An error is shown');
+    assert.equal(
+      JobsList.error.title,
+      'No Cluster Leader',
+      'The error is specifically for the lack of a cluster leader'
+    );
+  });
+});


### PR DESCRIPTION
Before it was just a generic Server Error. Now it identifies the issue and sets the unlucky visitor on the right path to resolve the problem.

![image](https://user-images.githubusercontent.com/174740/43488958-395a5446-94d0-11e8-9b79-1173fefba53d.png)
