### PR TITLE
Use a min heap to store top K scoring nodes for placement metrics

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -112,6 +112,14 @@ type AllocationMetric struct {
 	Scores             map[string]float64
 	AllocationTime     time.Duration
 	CoalescedFailures  int
+	ScoreMetaData      map[string][]*NodeScoreMeta
+}
+
+// NodeScoreMeta is used to serialize node scoring metadata
+// displayed in the CLI during verbose mode
+type NodeScoreMeta struct {
+	NodeID string
+	Score  float64
 }
 
 // AllocationListStub is used to return a subset of an allocation

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -224,6 +224,60 @@ func TestAllocStatusCommand_RescheduleInfo(t *testing.T) {
 	require.Regexp(regexp.MustCompile(".*Reschedule Attempts\\s*=\\s*1/2"), out)
 }
 
+func TestAllocStatusCommand_ScoreMetrics(t *testing.T) {
+	t.Parallel()
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	// Wait for a node to be ready
+	testutil.WaitForResult(func() (bool, error) {
+		nodes, _, err := client.Nodes().List(nil)
+		if err != nil {
+			return false, err
+		}
+		for _, node := range nodes {
+			if node.Status == structs.NodeStatusReady {
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("no ready nodes")
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	ui := new(cli.MockUi)
+	cmd := &AllocStatusCommand{Meta: Meta{Ui: ui}}
+	// Test reschedule attempt info
+	require := require.New(t)
+	state := srv.Agent.Server().State()
+	a := mock.Alloc()
+	mockNode1 := mock.Node()
+	mockNode2 := mock.Node()
+	a.Metrics = &structs.AllocMetric{
+		ScoreMetaData: map[string][]*structs.NodeScoreMeta{
+			"binpack": []*structs.NodeScoreMeta{
+				{NodeID: mockNode1.ID, Score: 0.77},
+				{NodeID: mockNode2.ID, Score: 0.75},
+			},
+			"node-affinity": []*structs.NodeScoreMeta{
+				{NodeID: mockNode1.ID, Score: 0.5},
+				{NodeID: mockNode2.ID, Score: 0.33},
+			},
+		},
+	}
+	require.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+
+	if code := cmd.Run([]string{"-address=" + url, "-verbose", a.ID}); code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+	out := ui.OutputWriter.String()
+	require.Contains(out, "Placement Metrics")
+	require.Contains(out, fmt.Sprintf("Scorer %q, Node %q", "binpack", mockNode1.ID))
+	require.Contains(out, fmt.Sprintf("Scorer %q, Node %q", "binpack", mockNode2.ID))
+	require.Contains(out, fmt.Sprintf("Scorer %q, Node %q", "node-affinity", mockNode1.ID))
+	require.Contains(out, fmt.Sprintf("Scorer %q, Node %q", "binpack", mockNode2.ID))
+}
+
 func TestAllocStatusCommand_AutocompleteArgs(t *testing.T) {
 	assert := assert.New(t)
 	t.Parallel()

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -373,8 +373,17 @@ func formatAllocMetrics(metrics *api.AllocationMetric, scores bool, prefix strin
 
 	// Print scores
 	if scores {
-		for name, score := range metrics.Scores {
-			out += fmt.Sprintf("%s* Score %q = %f\n", prefix, name, score)
+		if len(metrics.ScoreMetaData) > 0 {
+			for scorer, scoreMeta := range metrics.ScoreMetaData {
+				for _, nodeScore := range scoreMeta {
+					out += fmt.Sprintf("%s* Scorer %q, Node %q = %f\n", prefix, scorer, nodeScore.NodeID, nodeScore.Score)
+				}
+			}
+		} else {
+			// Backwards compatibility for old allocs
+			for name, score := range metrics.Scores {
+				out += fmt.Sprintf("%s* Score %q = %f\n", prefix, name, score)
+			}
 		}
 	}
 

--- a/helper/lib/score_heap.go
+++ b/helper/lib/score_heap.go
@@ -1,0 +1,63 @@
+package lib
+
+import (
+	"container/heap"
+)
+
+// An HeapItem represents elements being managed in the Score heap
+type HeapItem struct {
+	Value string  // The Value of the item; arbitrary.
+	Score float64 // The Score of the item in the heap
+}
+
+// A ScoreHeap implements heap.Interface and is a min heap
+// that keeps the top K elements by Score. Push can be called
+// with an arbitrary number of values but only the top K are stored
+type ScoreHeap struct {
+	items    []*HeapItem
+	capacity int
+}
+
+func NewScoreHeap(capacity uint32) *ScoreHeap {
+	return &ScoreHeap{capacity: int(capacity)}
+}
+
+func (pq ScoreHeap) Len() int { return len(pq.items) }
+
+func (pq ScoreHeap) Less(i, j int) bool {
+	return pq.items[i].Score < pq.items[j].Score
+}
+
+func (pq ScoreHeap) Swap(i, j int) {
+	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
+}
+
+// Push implements heap.Interface and only stores
+// the top K elements by Score
+func (pq *ScoreHeap) Push(x interface{}) {
+	item := x.(*HeapItem)
+	if len(pq.items) < pq.capacity {
+		pq.items = append(pq.items, item)
+	} else {
+		// Pop the lowest scoring element if this item's Score is
+		// greater than the min Score so far
+		minIndex := 0
+		min := pq.items[minIndex]
+		if item.Score > min.Score {
+			// Replace min and heapify
+			pq.items[minIndex] = item
+			heap.Fix(pq, minIndex)
+		}
+	}
+}
+
+// Push implements heap.Interface and returns the top K scoring
+// elements in increasing order of Score. Callers must reverse the order
+// of returned elements to get the top K scoring elements in descending order
+func (pq *ScoreHeap) Pop() interface{} {
+	old := pq.items
+	n := len(old)
+	item := old[n-1]
+	pq.items = old[0 : n-1]
+	return item
+}

--- a/helper/lib/score_heap_test.go
+++ b/helper/lib/score_heap_test.go
@@ -1,0 +1,79 @@
+package lib
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScoreHeap(t *testing.T) {
+	type testCase struct {
+		desc     string
+		items    map[string]float64
+		expected []*HeapItem
+	}
+
+	cases := []testCase{
+		{
+			desc: "More than K elements",
+			items: map[string]float64{
+				"banana":     3.0,
+				"apple":      2.25,
+				"pear":       2.32,
+				"watermelon": 5.45,
+				"orange":     0.20,
+				"strawberry": 9.03,
+				"blueberry":  0.44,
+				"lemon":      3.9,
+				"cherry":     0.03,
+			},
+			expected: []*HeapItem{
+				{Value: "pear", Score: 2.32},
+				{Value: "banana", Score: 3.0},
+				{Value: "lemon", Score: 3.9},
+				{Value: "watermelon", Score: 5.45},
+				{Value: "strawberry", Score: 9.03},
+			},
+		},
+		{
+			desc: "Less than K elements",
+			items: map[string]float64{
+				"eggplant": 9.0,
+				"okra":     -1.0,
+				"corn":     0.25,
+			},
+			expected: []*HeapItem{
+				{Value: "okra", Score: -1.0},
+				{Value: "corn", Score: 0.25},
+				{Value: "eggplant", Score: 9.0},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			// Create Score heap, push elements into it
+			pq := NewScoreHeap(5)
+			for value, score := range tc.items {
+				heapItem := &HeapItem{
+					Value: value,
+					Score: score,
+				}
+				heap.Push(pq, heapItem)
+			}
+
+			// Take the items out; they arrive in increasing Score order
+			require := require.New(t)
+			require.Equal(len(tc.expected), pq.Len())
+
+			i := 0
+			for pq.Len() > 0 {
+				item := heap.Pop(pq).(*HeapItem)
+				require.Equal(tc.expected[i], item)
+				i++
+			}
+		})
+	}
+
+}

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -221,6 +221,32 @@ func CopySliceAffinities(s []*Affinity) []*Affinity {
 	return c
 }
 
+func CopyNodeScoreMetaMap(m map[string][]*NodeScoreMeta) map[string][]*NodeScoreMeta {
+	l := len(m)
+	if l == 0 {
+		return nil
+	}
+
+	cm := make(map[string][]*NodeScoreMeta, l)
+	for k, v := range m {
+		cm[k] = CopySliceNodeScoreMeta(v)
+	}
+	return cm
+}
+
+func CopySliceNodeScoreMeta(s []*NodeScoreMeta) []*NodeScoreMeta {
+	l := len(s)
+	if l == 0 {
+		return nil
+	}
+
+	c := make([]*NodeScoreMeta, l)
+	for i, v := range s {
+		c[i] = v.Copy()
+	}
+	return c
+}
+
 // VaultPoliciesSet takes the structure returned by VaultPolicies and returns
 // the set of required policies
 func VaultPoliciesSet(policies map[string]map[string]*Vault) []string {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -24,6 +24,9 @@ import (
 
 	"golang.org/x/crypto/blake2b"
 
+	"container/heap"
+	"math"
+
 	"github.com/gorhill/cronexpr"
 	"github.com/hashicorp/consul/api"
 	multierror "github.com/hashicorp/go-multierror"
@@ -31,11 +34,10 @@ import (
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/args"
+	"github.com/hashicorp/nomad/helper/lib"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/mitchellh/copystructure"
 	"github.com/ugorji/go/codec"
-
-	"math"
 
 	hcodec "github.com/hashicorp/go-msgpack/codec"
 )
@@ -133,6 +135,10 @@ const (
 	// MaxRetainedNodeEvents is the maximum number of node events that will be
 	// retained for a single node
 	MaxRetainedNodeEvents = 10
+
+	// MaxRetainedNodeScores is the number of top scoring nodes for which we
+	// retain scoring metadata
+	MaxRetainedNodeScores = 5
 )
 
 // Context defines the scope in which a search for Nomad object operates, and
@@ -6359,7 +6365,15 @@ type AllocMetric struct {
 
 	// Scores is the scores of the final few nodes remaining
 	// for placement. The top score is typically selected.
+	// Deprecated: Replaced by ScoreMetaData in Nomad 0.9
 	Scores map[string]float64
+
+	// ScoreMetaData is a slice of top scoring nodes per scorer
+	ScoreMetaData map[string][]*NodeScoreMeta
+
+	// topScores is used to maintain a heap of the top K scoring nodes per
+	// scorer type
+	topScores map[string]*lib.ScoreHeap
 
 	// AllocationTime is a measure of how long the allocation
 	// attempt took. This can affect performance and SLAs.
@@ -6385,6 +6399,7 @@ func (a *AllocMetric) Copy() *AllocMetric {
 	na.DimensionExhausted = helper.CopyMapStringInt(na.DimensionExhausted)
 	na.QuotaExhausted = helper.CopySliceString(na.QuotaExhausted)
 	na.Scores = helper.CopyMapStringFloat64(na.Scores)
+	na.ScoreMetaData = CopyNodeScoreMetaMap(na.ScoreMetaData)
 	return na
 }
 
@@ -6432,12 +6447,67 @@ func (a *AllocMetric) ExhaustQuota(dimensions []string) {
 	a.QuotaExhausted = append(a.QuotaExhausted, dimensions...)
 }
 
+// ScoreNode is used to gather top K scoring nodes in a heap
 func (a *AllocMetric) ScoreNode(node *Node, name string, score float64) {
-	if a.Scores == nil {
-		a.Scores = make(map[string]float64)
+	if a.topScores == nil {
+		a.topScores = make(map[string]*lib.ScoreHeap)
 	}
-	key := fmt.Sprintf("%s.%s", node.ID, name)
-	a.Scores[key] = score
+	scorerHeap, ok := a.topScores[name]
+	if !ok {
+		scorerHeap = lib.NewScoreHeap(MaxRetainedNodeScores)
+		a.topScores[name] = scorerHeap
+	}
+	heap.Push(scorerHeap, &lib.HeapItem{
+		Value: node.ID,
+		Score: score,
+	})
+}
+
+// PopulateScoreMetaData populates a map of scorer to scoring metadata
+// The map is populated by popping elements from a heap of top K scores
+// maintained per scorer
+func (a *AllocMetric) PopulateScoreMetaData() {
+	if a.ScoreMetaData == nil {
+		a.ScoreMetaData = make(map[string][]*NodeScoreMeta)
+	}
+	if a.topScores != nil && len(a.ScoreMetaData) == 0 {
+		for scorer, scoreHeap := range a.topScores {
+			scoreMeta := make([]*NodeScoreMeta, scoreHeap.Len())
+			i := scoreHeap.Len() - 1
+			// Pop from the heap and store in reverse to get top K
+			// scoring nodes in descending order
+			for scoreHeap.Len() > 0 {
+				item := heap.Pop(scoreHeap).(*lib.HeapItem)
+				scoreMeta[i] = &NodeScoreMeta{
+					NodeID: item.Value,
+					Score:  item.Score,
+				}
+				i--
+			}
+			a.ScoreMetaData[scorer] = scoreMeta
+		}
+	}
+}
+
+// NodeScoreMeta captures scoring meta data derived from
+// different scoring factors. The meta data from top K scores
+// are displayed in the CLI
+type NodeScoreMeta struct {
+	NodeID string
+	Score  float64
+}
+
+func (s *NodeScoreMeta) Copy() *NodeScoreMeta {
+	if s == nil {
+		return nil
+	}
+	ns := new(NodeScoreMeta)
+	*ns = *s
+	return ns
+}
+
+func (s *NodeScoreMeta) String() string {
+	return fmt.Sprintf("%s %v", s.NodeID, s.Score)
 }
 
 // AllocDeploymentStatus captures the status of the allocation as part of the

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -470,6 +470,9 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 			// Store the available nodes by datacenter
 			s.ctx.Metrics().NodesAvailable = byDC
 
+			// Compute top K scoring node metadata
+			s.ctx.Metrics().PopulateScoreMetaData()
+
 			// Set fields based on if we found an allocation option
 			if option != nil {
 				// Create an allocation for this

--- a/scheduler/stack_test.go
+++ b/scheduler/stack_test.go
@@ -295,6 +295,7 @@ func TestServiceStack_Select_BinPack_Overflow(t *testing.T) {
 	stack.SetJob(job)
 	selectOptions := &SelectOptions{}
 	node, _ := stack.Select(job.TaskGroups[0], selectOptions)
+	ctx.Metrics().PopulateScoreMetaData()
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -311,7 +312,7 @@ func TestServiceStack_Select_BinPack_Overflow(t *testing.T) {
 		t.Fatalf("bad: %#v", met)
 	}
 	// Expect two metrics, one with bin packing score and one with normalized score
-	if len(met.Scores) != 2 {
+	if len(met.ScoreMetaData) != 2 {
 		t.Fatalf("bad: %#v", met)
 	}
 }
@@ -517,6 +518,7 @@ func TestSystemStack_Select_BinPack_Overflow(t *testing.T) {
 
 	selectOptions := &SelectOptions{}
 	node, _ := stack.Select(job.TaskGroups[0], selectOptions)
+	ctx.Metrics().PopulateScoreMetaData()
 	if node == nil {
 		t.Fatalf("missing node %#v", ctx.Metrics())
 	}
@@ -533,7 +535,7 @@ func TestSystemStack_Select_BinPack_Overflow(t *testing.T) {
 		t.Fatalf("bad: %#v", met)
 	}
 	// Should have two scores, one from bin packing and one from normalization
-	if len(met.Scores) != 2 {
+	if len(met.ScoreMetaData) != 2 {
 		t.Fatalf("bad: %#v", met)
 	}
 }


### PR DESCRIPTION
This PR changes the placement metrics map which used to store all scored nodes, to only storing the top K nodes per scorer. 

Also includes changes to the CLI, score metrics are grouped by scorer type, like below:

```Placement Metrics
  * Scorer "node-affinity", Node "5f2db925-69d4-e677-d3a9-b166155153c6" = 1.000000
  * Scorer "node-affinity", Node "4ebde21b-daa9-f264-16dd-b6ba88efdd58" = 1.000000
  * Scorer "node-affinity", Node "14ebcc35-34d0-1812-14c9-b4397d603723" = 0.333333
  * Scorer "normalized-score", Node "5f2db925-69d4-e677-d3a9-b166155153c6" = 0.540313
  * Scorer "normalized-score", Node "4ebde21b-daa9-f264-16dd-b6ba88efdd58" = 0.540313
  * Scorer "normalized-score", Node "14ebcc35-34d0-1812-14c9-b4397d603723" = 0.206980
  * Scorer "binpack", Node "5f2db925-69d4-e677-d3a9-b166155153c6" = 0.080626
  * Scorer "binpack", Node "4ebde21b-daa9-f264-16dd-b6ba88efdd58" = 0.080626
  * Scorer "binpack", Node "14ebcc35-34d0-1812-14c9-b4397d603723" = 0.080626
```