### PR TITLE
Error if TLS Certificate signature algorithm isn't supported in cipher suites

### DIFF
--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -844,7 +844,7 @@ func parseTLSConfig(result **config.TLSConfig, list *ast.ObjectList) error {
 		return err
 	}
 
-	if _, err := tlsutil.ParseCiphers(tlsConfig.TLSCipherSuites); err != nil {
+	if _, err := tlsutil.ParseCiphers(&tlsConfig); err != nil {
 		return err
 	}
 

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -286,7 +286,19 @@ func TestConfig_Parse(t *testing.T) {
 			if (err != nil) != tc.Err {
 				t.Fatalf("file: %s\n\n%s", tc.File, err)
 			}
-			require.EqualValues(actual, tc.Result)
+
+			//panic(fmt.Sprintf("first: %+v \n second: %+v", actual.TLSConfig, tc.Result.TLSConfig))
+			require.EqualValues(removeHelperAttributes(actual), tc.Result)
 		})
 	}
+}
+
+// In order to compare the Config struct after parsing, and from generating what
+// is expected in the test, we need to remove helper attributes that are
+// instantiated in the process of parsing the configuration
+func removeHelperAttributes(c *Config) *Config {
+	if c.TLSConfig != nil {
+		c.TLSConfig.KeyLoader = nil
+	}
+	return c
 }

--- a/helper/tlsutil/config.go
+++ b/helper/tlsutil/config.go
@@ -448,25 +448,24 @@ func ParseCiphers(tlsConfig *config.TLSConfig) ([]uint16, error) {
 		var supportedSignatureAlgorithm algorithmStringRepr
 
 		tlsCert := keyLoader.GetCertificate()
-		if tlsCert != nil {
-			// Determine what type of signature algorithm is being used by typecasting
-			// the certificate's private key
-			privKey := tlsCert.PrivateKey
-			switch privKey.(type) {
-			case *rsa.PrivateKey:
-				supportedSignatureAlgorithm = rsaStringRepr
-			case *ecdsa.PrivateKey:
-				supportedSignatureAlgorithm = ecdsaStringRepr
-			default:
-				return []uint16{}, fmt.Errorf("Unsupported signature algorithm %T; RSA and ECDSA only are supported.", privKey)
-			}
 
-			for _, cipher := range parsedCiphers {
-				if supportedCipherSignatures[cipher] == supportedSignatureAlgorithm {
-					// Positive case, return the matched cipher suites as the signature
-					// algorithm is also supported
-					return suites, nil
-				}
+		// Determine what type of signature algorithm is being used by typecasting
+		// the certificate's private key
+		privKey := tlsCert.PrivateKey
+		switch privKey.(type) {
+		case *rsa.PrivateKey:
+			supportedSignatureAlgorithm = rsaStringRepr
+		case *ecdsa.PrivateKey:
+			supportedSignatureAlgorithm = ecdsaStringRepr
+		default:
+			return []uint16{}, fmt.Errorf("Unsupported signature algorithm %T; RSA and ECDSA only are supported.", privKey)
+		}
+
+		for _, cipher := range parsedCiphers {
+			if supportedCipherSignatures[cipher] == supportedSignatureAlgorithm {
+				// Positive case, return the matched cipher suites as the signature
+				// algorithm is also supported
+				return suites, nil
 			}
 		}
 

--- a/helper/tlsutil/config.go
+++ b/helper/tlsutil/config.go
@@ -463,7 +463,7 @@ func ParseCiphers(tlsConfig *config.TLSConfig) ([]uint16, error) {
 		// Negative case, if this is reached it means that none of the specified
 		// cipher suites signature algorithms match the signature algorithm
 		// for the certificate.
-		return []uint16{}, fmt.Errorf("Specified cipher suites don't support the certificate signature algorithm, consider adding more cipher suites to match this signature algorithm.")
+		return []uint16{}, fmt.Errorf("Specified cipher suites don't support the certificate signature algorithm %s, consider adding more cipher suites to match this signature algorithm.", supportedSignatureAlgorithm)
 	}
 
 	// Default in case this function is called but TLS is not actually configured

--- a/helper/tlsutil/config.go
+++ b/helper/tlsutil/config.go
@@ -43,11 +43,14 @@ var supportedTLSCiphers = map[string]uint16{
 	"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 }
 
+// algorithmStringRepr is the string representation of a signing algorithm
 type algorithmStringRepr string
 
 var rsaStringRepr algorithmStringRepr = "RSA"
 var ecdsaStringRepr algorithmStringRepr = "ECDSA"
 
+// supportedCipherSignatures is the supported cipher suites with their
+// corresponding signature algorithm
 var supportedCipherSignatures = map[string]algorithmStringRepr{
 	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    rsaStringRepr,
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  ecdsaStringRepr,

--- a/helper/tlsutil/config.go
+++ b/helper/tlsutil/config.go
@@ -125,7 +125,7 @@ type Config struct {
 }
 
 func NewTLSConfiguration(newConf *config.TLSConfig, verifyIncoming, verifyOutgoing bool) (*Config, error) {
-	ciphers, err := ParseCiphers(newConf.TLSCipherSuites)
+	ciphers, err := ParseCiphers(newConf)
 	if err != nil {
 		return nil, err
 	}
@@ -385,17 +385,17 @@ func (c *Config) IncomingTLSConfig() (*tls.Config, error) {
 
 // ParseCiphers parses ciphersuites from the comma-separated string into
 // recognized slice
-func ParseCiphers(cipherStr string) ([]uint16, error) {
+func ParseCiphers(tlsConfig *config.TLSConfig) ([]uint16, error) {
 	suites := []uint16{}
 
-	cipherStr = strings.TrimSpace(cipherStr)
+	cipherStr := strings.TrimSpace(tlsConfig.TLSCipherSuites)
 
 	var ciphers []string
 	if cipherStr == "" {
 		ciphers = defaultTLSCiphers
 
 	} else {
-		ciphers = strings.Split(cipherStr, ",")
+		ciphers = strings.Split(tlsConfig.TLSCipherSuites, ",")
 	}
 	for _, cipher := range ciphers {
 		c, ok := supportedTLSCiphers[cipher]

--- a/helper/tlsutil/config.go
+++ b/helper/tlsutil/config.go
@@ -43,17 +43,17 @@ var supportedTLSCiphers = map[string]uint16{
 	"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 }
 
-// algorithmStringRepr is the string representation of a signing algorithm
-type algorithmStringRepr string
+// signatureAlgorithm is the string representation of a signing algorithm
+type signatureAlgorithm string
 
 const (
-	rsaStringRepr   algorithmStringRepr = "RSA"
-	ecdsaStringRepr algorithmStringRepr = "ECDSA"
+	rsaStringRepr   signatureAlgorithm = "RSA"
+	ecdsaStringRepr signatureAlgorithm = "ECDSA"
 )
 
 // supportedCipherSignatures is the supported cipher suites with their
 // corresponding signature algorithm
-var supportedCipherSignatures = map[string]algorithmStringRepr{
+var supportedCipherSignatures = map[string]signatureAlgorithm{
 	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    rsaStringRepr,
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  ecdsaStringRepr,
 	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   rsaStringRepr,
@@ -475,7 +475,7 @@ func ParseCiphers(tlsConfig *config.TLSConfig) ([]uint16, error) {
 // This is determined by examining the type of the certificate's public key,
 // as Golang doesn't expose a more straightforward  API which returns this
 // type
-func getSignatureAlgorithm(tlsCert *tls.Certificate) (algorithmStringRepr, error) {
+func getSignatureAlgorithm(tlsCert *tls.Certificate) (signatureAlgorithm, error) {
 	privKey := tlsCert.PrivateKey
 	switch privKey.(type) {
 	case *rsa.PrivateKey:

--- a/helper/tlsutil/config.go
+++ b/helper/tlsutil/config.go
@@ -46,8 +46,10 @@ var supportedTLSCiphers = map[string]uint16{
 // algorithmStringRepr is the string representation of a signing algorithm
 type algorithmStringRepr string
 
-var rsaStringRepr algorithmStringRepr = "RSA"
-var ecdsaStringRepr algorithmStringRepr = "ECDSA"
+const (
+	rsaStringRepr   algorithmStringRepr = "RSA"
+	ecdsaStringRepr algorithmStringRepr = "ECDSA"
+)
 
 // supportedCipherSignatures is the supported cipher suites with their
 // corresponding signature algorithm

--- a/helper/tlsutil/config.go
+++ b/helper/tlsutil/config.go
@@ -41,6 +41,61 @@ var supportedTLSCiphers = map[string]uint16{
 	"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 }
 
+var rsa string = "RSA"
+var ecdsa string = "ECDSA"
+
+var supportedCipherSignatures = map[string]string{
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    rsa,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  ecdsa,
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   rsa,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": ecdsa,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   rsa,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": ecdsa,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   rsa,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      rsa,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": ecdsa,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    ecdsa,
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      rsa,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    ecdsa,
+	"TLS_RSA_WITH_AES_128_GCM_SHA256":         rsa,
+	"TLS_RSA_WITH_AES_256_GCM_SHA384":         rsa,
+	"TLS_RSA_WITH_AES_128_CBC_SHA256":         rsa,
+	"TLS_RSA_WITH_AES_128_CBC_SHA":            rsa,
+	"TLS_RSA_WITH_AES_256_CBC_SHA":            rsa,
+}
+
+var signatureAlgorithmMapping = map[x509.SignatureAlgorithm]string{
+	x509.MD2WithRSA:       rsa,
+	x509.MD5WithRSA:       rsa,
+	x509.SHA1WithRSA:      rsa,
+	x509.SHA256WithRSA:    rsa,
+	x509.SHA384WithRSA:    rsa,
+	x509.SHA512WithRSA:    rsa,
+	x509.ECDSAWithSHA1:    ecdsa,
+	x509.ECDSAWithSHA256:  ecdsa,
+	x509.ECDSAWithSHA384:  ecdsa,
+	x509.ECDSAWithSHA512:  ecdsa,
+	x509.SHA256WithRSAPSS: rsa,
+	x509.SHA384WithRSAPSS: rsa,
+	x509.SHA512WithRSAPSS: rsa,
+}
+
+func cipherSuitesSupportSignatureAlgorithm(supportedSignature x509.SignatureAlgorithm, supportedCipherSuites []string) (bool, error) {
+	supportedSignatureAlgorithm, ok := signatureAlgorithmMapping[supportedSignature]
+	if !ok {
+		return false, fmt.Errorf("Unsupported signature scheme: %s", supportedSignature.String())
+	}
+
+	for _, cipher := range supportedCipherSuites {
+		cipherSupportedAlg := supportedCipherSignatures[cipher]
+		if supportedSignatureAlgorithm == cipherSupportedAlg {
+			return true, nil
+		}
+	}
+
+	return false, fmt.Errorf("Specified cipher suites don't support %s, consider adding more cipher suites with this signature algorithm.", supportedSignatureAlgorithm)
+}
+
 // defaultTLSCiphers are the TLS Ciphers that are supported by default
 var defaultTLSCiphers = []string{
 	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",

--- a/helper/tlsutil/config.go
+++ b/helper/tlsutil/config.go
@@ -43,10 +43,12 @@ var supportedTLSCiphers = map[string]uint16{
 	"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 }
 
-var rsaStringRepr string = "RSA"
-var ecdsaStringRepr string = "ECDSA"
+type algorithmStringRepr string
 
-var supportedCipherSignatures = map[string]string{
+var rsaStringRepr algorithmStringRepr = "RSA"
+var ecdsaStringRepr algorithmStringRepr = "ECDSA"
+
+var supportedCipherSignatures = map[string]algorithmStringRepr{
 	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    rsaStringRepr,
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  ecdsaStringRepr,
 	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   rsaStringRepr,
@@ -440,7 +442,7 @@ func ParseCiphers(tlsConfig *config.TLSConfig) ([]uint16, error) {
 	keyLoader.LoadKeyPair(tlsConfig.CertFile, tlsConfig.KeyFile)
 
 	if keyLoader.GetCertificate() != nil {
-		var supportedSignatureAlgorithm string
+		var supportedSignatureAlgorithm algorithmStringRepr
 
 		tlsCert := keyLoader.GetCertificate()
 		if tlsCert != nil {

--- a/helper/tlsutil/config_test.go
+++ b/helper/tlsutil/config_test.go
@@ -647,25 +647,27 @@ func TestConfig_IncomingTLS_TLSCipherSuites(t *testing.T) {
 func TestConfig_ParseCiphers_Valid(t *testing.T) {
 	require := require.New(t)
 
-	validCiphers := strings.Join([]string{
-		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
-		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-		"TLS_RSA_WITH_AES_128_GCM_SHA256",
-		"TLS_RSA_WITH_AES_256_GCM_SHA384",
-		"TLS_RSA_WITH_AES_128_CBC_SHA256",
-		"TLS_RSA_WITH_AES_128_CBC_SHA",
-		"TLS_RSA_WITH_AES_256_CBC_SHA",
-	}, ",")
+	tlsConfig := &config.TLSConfig{
+		TLSCipherSuites: strings.Join([]string{
+			"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+			"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+			"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+			"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+			"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+			"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+			"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+			"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+			"TLS_RSA_WITH_AES_128_GCM_SHA256",
+			"TLS_RSA_WITH_AES_256_GCM_SHA384",
+			"TLS_RSA_WITH_AES_128_CBC_SHA256",
+			"TLS_RSA_WITH_AES_128_CBC_SHA",
+			"TLS_RSA_WITH_AES_256_CBC_SHA",
+		}, ","),
+	}
 
 	expectedCiphers := []uint16{
 		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
@@ -687,7 +689,7 @@ func TestConfig_ParseCiphers_Valid(t *testing.T) {
 		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 	}
 
-	parsedCiphers, err := ParseCiphers(validCiphers)
+	parsedCiphers, err := ParseCiphers(tlsConfig)
 	require.Nil(err)
 	require.Equal(parsedCiphers, expectedCiphers)
 }
@@ -708,7 +710,8 @@ func TestConfig_ParseCiphers_Default(t *testing.T) {
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	}
 
-	parsedCiphers, err := ParseCiphers("")
+	empty := &config.TLSConfig{}
+	parsedCiphers, err := ParseCiphers(empty)
 	require.Nil(err)
 	require.Equal(parsedCiphers, expectedCiphers)
 }
@@ -722,7 +725,10 @@ func TestConfig_ParseCiphers_Invalid(t *testing.T) {
 	}
 
 	for _, cipher := range invalidCiphers {
-		parsedCiphers, err := ParseCiphers(cipher)
+		tlsConfig := &config.TLSConfig{
+			TLSCipherSuites: cipher,
+		}
+		parsedCiphers, err := ParseCiphers(tlsConfig)
 		require.NotNil(err)
 		require.Equal(fmt.Sprintf("unsupported TLS cipher %q", cipher), err.Error())
 		require.Equal(0, len(parsedCiphers))

--- a/nomad/structs/config/tls.go
+++ b/nomad/structs/config/tls.go
@@ -97,6 +97,12 @@ func (k *KeyLoader) LoadKeyPair(certFile, keyFile string) (*tls.Certificate, err
 	return k.certificate, nil
 }
 
+func (k *KeyLoader) GetCertificate() *tls.Certificate {
+	k.cacheLock.Lock()
+	defer k.cacheLock.Unlock()
+	return k.certificate
+}
+
 // GetOutgoingCertificate fetches the currently-loaded certificate when
 // accepting a TLS connection. This currently does not consider information in
 // the ClientHello and only returns the certificate that was last loaded.


### PR DESCRIPTION
This fixes a usability issue where a user can specify a set of cipher suites where the TLS Certificate might have a different signing algorithm. This provides a error to the operator when starting the agent and only allows for the agent to bootstrap if there is a common signing algorithm between the certificate and the agent's cipher suite. 
