### PR TITLE
vendor: fix blake2b on non-amd64 archs

### DIFF
--- a/vendor/golang.org/x/crypto/blake2b/blake2b_ref.go
+++ b/vendor/golang.org/x/crypto/blake2b/blake2b_ref.go
@@ -1,0 +1,11 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !amd64 appengine gccgo
+
+package blake2b
+
+func hashBlocks(h *[8]uint64, c *[2]uint64, flag uint64, blocks []byte) {
+	hashBlocksGeneric(h, c, flag, blocks)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,6 +1,6 @@
 {
 	"comment": "",
-	"ignore": "test appengine",
+	"ignore": "test",
 	"package": [
 		{"path":"context","revision":""},
 		{"path":"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2015-06-15/network","checksumSHA1":"Fs6Gcl0nhC0FJ6MsB+Ck7r4huYo=","revision":"767429fcb996dad413936d682c28301e6739bade","revisionTime":"2018-05-01T22:35:11Z"},
@@ -320,7 +320,7 @@
 		{"path":"github.com/zclconf/go-cty/cty/json","checksumSHA1":"1ApmO+Q33+Oem/3f6BU6sztJWNc=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
 		{"path":"github.com/zclconf/go-cty/cty/set","checksumSHA1":"y5Sk+n6SOspFj8mlyb8swr4DMIs=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
 		{"path":"go4.org/errorutil","checksumSHA1":"PMr/a5kcnC4toJtVwWhlU5E4tJY=","revision":"034d17a462f7b2dcd1a4a73553ec5357ff6e6c6e","revisionTime":"2017-05-24T23:16:39Z"},
-		{"path":"golang.org/x/crypto/blake2b","checksumSHA1":"iBXpCGzDbbbm0sWfaOY3aKDJ31U=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
+		{"path":"golang.org/x/crypto/blake2b","checksumSHA1":"ejjxT0+wDWWncfh0Rt3lSH4IbXQ=","revision":"de0752318171da717af4ce24d0a2e8626afaeb11","revisionTime":"2018-08-08T16:52:45Z"},
 		{"path":"golang.org/x/crypto/ssh/terminal","checksumSHA1":"BGm8lKZmvJbf/YOJLeL1rw2WVjA=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
 		{"path":"golang.org/x/net/context","checksumSHA1":"9jjO5GjLa0XF/nfWihF02RoH4qc=","revision":"30db96677b74e24b967e23f911eb3364fc61a011","revisionTime":"2016-05-25T13:11:03Z"},
 		{"path":"golang.org/x/net/context/ctxhttp","checksumSHA1":"WHc3uByvGaMcnSoI21fhzYgbOgg=","revision":"f09c4662a0bd6bd8943ac7b4931e185df9471da4","revisionTime":"2016-09-24T00:10:04Z"},


### PR DESCRIPTION
The blake2b package only includes an asm implementation for amd64. Other
architectures use a generic Go implementation. Unfortunately appengine
is one of those architectures and we explicitly ignore appengine when
vendoring because it is an unsupported platform for Nomad.

Commit 925ec07a4 started ignoring appengine to help trim down the vendor
package. We now need to include appengine again - despite not building
for it - just to avoid accidently breaking other archs we do support.