### PR TITLE
Skip update checking if DisableUpdateCheck is set to true

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -393,8 +393,9 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer, inmem *metrics
 	}
 	c.httpServer = http
 
-	// Setup update checking
-	if config.DisableUpdateCheck != nil && *config.DisableUpdateCheck {
+	// If DisableUpdateCheck is not enabled, set up update checking
+	// (DisableUpdateCheck is false by default)
+	if config.DisableUpdateCheck != nil && !*config.DisableUpdateCheck {
 		version := config.Version.Version
 		if config.Version.VersionPrerelease != "" {
 			version += fmt.Sprintf("-%s", config.Version.VersionPrerelease)


### PR DESCRIPTION
This fixes a logic bug where if `disable_update_check` was enabled, update checks would be performed. 

By default, `disable_update_check` is false: https://www.nomadproject.io/docs/agent/configuration/index.html#disable_update_check

Fixes #4562