### PR TITLE
Fix for panic when submitting non-existent version for job history CLI command

### DIFF
--- a/command/job_history.go
+++ b/command/job_history.go
@@ -249,7 +249,7 @@ func (c *JobHistoryCommand) formatJobVersions(versions []*api.Job, diffs []*api.
 
 func (c *JobHistoryCommand) formatJobVersion(job *api.Job, diff *api.JobDiff, nextVersion uint64, full bool) error {
 	if job == nil {
-		return fmt.Errorf("Error printing job history for non-existant job or job version")
+		return fmt.Errorf("Error printing job history for non-existing job or job version")
 	}
 
 	basic := []string{

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -248,6 +248,10 @@ func (c *JobHistoryCommand) formatJobVersions(versions []*api.Job, diffs []*api.
 }
 
 func (c *JobHistoryCommand) formatJobVersion(job *api.Job, diff *api.JobDiff, nextVersion uint64, full bool) error {
+	if job == nil {
+		return fmt.Errorf("Error printing job history for non-existant job or job version")
+	}
+
 	basic := []string{
 		fmt.Sprintf("Version|%d", *job.Version),
 		fmt.Sprintf("Stable|%v", *job.Stable),


### PR DESCRIPTION
Fixes a panic where running `nomad job history -full -version=500 example` would result in: 

```
panic: runtime error: invalid memory address or nil pointer dereference                                  
[signal SIGSEGV: segmentation violation code=0x1 addr=0x100 pc=0x15834a5]                                

goroutine 1 [running]:    
github.com/hashicorp/nomad/command.(*JobHistoryCommand).formatJobVersion(0xc420319a20, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0)
        /opt/gopath/src/github.com/hashicorp/nomad/command/job_history.go:252 +0x45                      
github.com/hashicorp/nomad/command.(*JobHistoryCommand).Run(0xc420319a20, 0xc4200c6030, 0x3, 0x3, 0xc4200a9000)
        /opt/gopath/src/github.com/hashicorp/nomad/command/job_history.go:185 +0xc1d                     
github.com/hashicorp/nomad/vendor/github.com/mitchellh/cli.(*CLI).Run(0xc4202f83c0, 0xc4202f83c0, 0xc42026d4e0, 0x10)
        /opt/gopath/src/github.com/hashicorp/nomad/vendor/github.com/mitchellh/cli/cli.go:255 +0x1eb     
main.RunCustom(0xc4200c6010, 0x5, 0x5, 0xc4204d3f68)                                                     
        /opt/gopath/src/github.com/hashicorp/nomad/main.go:127 +0x4b4                                    
main.Run(0xc4200c6010, 0x5, 0x5, 0xc420098058)      
        /opt/gopath/src/github.com/hashicorp/nomad/main.go:72 +0x3f                                      
main.main()               
        /opt/gopath/src/github.com/hashicorp/nomad/main.go:68 +0x63 
```

Fixes https://github.com/hashicorp/nomad/issues/4542