### PR TITLE
UI: Run a job from the Web UI

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -59,6 +59,26 @@ export default Watchable.extend({
     const url = this.urlForFindRecord(job.get('id'), 'job');
     return this.ajax(url, 'DELETE');
   },
+
+  parse(spec) {
+    const url = addToPath(this.urlForFindAll('job'), '/parse');
+    return this.ajax(url, 'POST', {
+      data: {
+        JobHCL: spec,
+        Canonicalize: true,
+      },
+    });
+  },
+
+  plan(job) {
+    const url = addToPath(this.urlForFindRecord(job.get('id'), 'job'), '/plan');
+    return this.ajax(url, 'POST', {
+      data: {
+        Job: job.get('_newDefinitionJSON'),
+        Diff: true,
+      },
+    });
+  },
 });
 
 function associateNamespace(url, namespace) {

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -79,6 +79,16 @@ export default Watchable.extend({
       },
     });
   },
+
+  // Running a job doesn't follow REST create semantics so it's easier to
+  // treat it as an action.
+  run(job) {
+    return this.ajax(this.urlForCreateRecord('job'), 'POST', {
+      data: {
+        Job: job.get('_newDefinitionJSON'),
+      },
+    });
+  },
 });
 
 function associateNamespace(url, namespace) {

--- a/ui/app/controllers/jobs/run.js
+++ b/ui/app/controllers/jobs/run.js
@@ -1,0 +1,36 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
+import { task } from 'ember-concurrency';
+
+export default Controller.extend({
+  stage: computed('planOutput', function() {
+    return this.get('planOutput') ? 'plan' : 'editor';
+  }),
+
+  plan: task(function*() {
+    this.cancel();
+
+    try {
+      yield this.get('model').parse();
+    } catch (err) {
+      this.set('parseError', err);
+    }
+
+    try {
+      const planOutput = yield this.get('model').plan();
+      console.log('Heyo!', planOutput);
+      this.set('planOutput', planOutput);
+    } catch (err) {
+      this.set('planError', err);
+      console.log('Uhoh', err);
+    }
+  }).drop(),
+
+  submit: task(function*() {}),
+
+  cancel() {
+    this.set('planOutput', null);
+    this.set('planError', null);
+    this.set('parseError', null);
+  },
+});

--- a/ui/app/controllers/jobs/run.js
+++ b/ui/app/controllers/jobs/run.js
@@ -9,6 +9,8 @@ export default Controller.extend({
   planError: null,
   runError: null,
 
+  planOutput: null,
+
   showPlanMessage: localStorageProperty('nomadMessageJobPlan', true),
   showEditorMessage: localStorageProperty('nomadMessageJobEditor', true),
 
@@ -29,7 +31,7 @@ export default Controller.extend({
 
     try {
       const planOutput = yield this.get('model').plan();
-      this.set('planOutput', planOutput);
+      this.set('planOutput', planOutput.Diff);
     } catch (err) {
       const error = messageFromAdapterError(err) || 'Could not plan job';
       this.set('planError', error);

--- a/ui/app/controllers/jobs/run.js
+++ b/ui/app/controllers/jobs/run.js
@@ -1,46 +1,61 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import { task } from 'ember-concurrency';
-import { qpBuilder } from 'nomad-ui/utils/classes/query-params';
-import { next } from '@ember/runloop';
+import messageFromAdapterError from 'nomad-ui/utils/message-from-adapter-error';
+import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 
 export default Controller.extend({
+  parseError: null,
+  planError: null,
+  runError: null,
+
+  showPlanMessage: localStorageProperty('nomadMessageJobPlan', true),
+  showEditorMessage: localStorageProperty('nomadMessageJobEditor', true),
+
   stage: computed('planOutput', function() {
     return this.get('planOutput') ? 'plan' : 'editor';
   }),
 
   plan: task(function*() {
-    this.cancel();
+    this.reset();
 
     try {
       yield this.get('model').parse();
     } catch (err) {
-      this.set('parseError', err);
+      const error = messageFromAdapterError(err) || 'Could not parse input';
+      this.set('parseError', error);
+      return;
     }
 
     try {
       const planOutput = yield this.get('model').plan();
       this.set('planOutput', planOutput);
     } catch (err) {
-      this.set('planError', err);
+      const error = messageFromAdapterError(err) || 'Could not plan job';
+      this.set('planError', error);
     }
   }).drop(),
 
   submit: task(function*() {
     try {
       yield this.get('model').run();
+
       const id = this.get('model.plainId');
       const namespace = this.get('model.namespace.name') || 'default';
+
+      this.reset();
+
       // navigate to the new job page
       this.transitionToRoute('jobs.job', id, {
         queryParams: { jobNamespace: namespace },
       });
     } catch (err) {
-      this.set('runError', err);
+      const error = messageFromAdapterError(err) || 'Could not submit job';
+      this.set('runError', error);
     }
   }),
 
-  cancel() {
+  reset() {
     this.set('planOutput', null);
     this.set('planError', null);
     this.set('parseError', null);

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -212,7 +212,7 @@ export default Model.extend({
       const json = JSON.parse(definition);
       this.set('_newDefinitionJSON', definition);
       this.setIDByPayload(json);
-      promise = RSVP.Resolve(definition);
+      promise = RSVP.resolve(definition);
     } catch (err) {
       // If the definition is invalid JSON, assume it is HCL. If it is invalid
       // in anyway, the parse endpoint will throw an error.

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -198,6 +198,11 @@ export default Model.extend({
     return this.store.adapterFor('job').plan(this);
   },
 
+  run() {
+    assert('A job must be parsed before ran', this.get('_newDefinitionJSON'));
+    return this.store.adapterFor('job').run(this);
+  },
+
   parse() {
     const definition = this.get('_newDefinition');
     let promise;
@@ -224,8 +229,16 @@ export default Model.extend({
   },
 
   setIDByPayload(payload) {
-    this.set('plainId', payload.Name);
-    this.set('id', JSON.stringify([payload.Name, payload.Namespace || 'default']));
+    const namespace = payload.Namespace || 'default';
+    const id = payload.Name;
+
+    this.set('plainId', id);
+    this.set('id', JSON.stringify([id, namespace]));
+
+    const namespaceRecord = this.store.peekRecord('namespace', namespace);
+    if (namespaceRecord) {
+      this.set('namespace', namespaceRecord);
+    }
   },
 
   statusClass: computed('status', function() {

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -8,6 +8,7 @@ const Router = EmberRouter.extend({
 
 Router.map(function() {
   this.route('jobs', function() {
+    this.route('run');
     this.route('job', { path: '/:job_name' }, function() {
       this.route('task-group', { path: '/:name' });
       this.route('definition');

--- a/ui/app/routes/jobs/run.js
+++ b/ui/app/routes/jobs/run.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   store: service(),
+  system: service(),
 
   breadcrumbs: [
     {
@@ -10,4 +11,16 @@ export default Route.extend({
       args: ['jobs.run'],
     },
   ],
+
+  model() {
+    return this.get('store').createRecord('job', {
+      namespace: this.get('system.activeNamespace'),
+    });
+  },
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.get('model').deleteRecord();
+    }
+  },
 });

--- a/ui/app/routes/jobs/run.js
+++ b/ui/app/routes/jobs/run.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default Route.extend({
+  store: service(),
+
+  breadcrumbs: [
+    {
+      label: 'Run',
+      args: ['jobs.run'],
+    },
+  ],
+});

--- a/ui/app/styles/components/codemirror.scss
+++ b/ui/app/styles/components/codemirror.scss
@@ -4,6 +4,10 @@ $dark-bright: lighten($dark, 15%);
   height: auto;
 }
 
+.CodeMirror-scroll {
+  min-height: 500px;
+}
+
 .cm-s-hashi,
 .cm-s-hashi-read-only {
   &.CodeMirror {

--- a/ui/app/styles/components/codemirror.scss
+++ b/ui/app/styles/components/codemirror.scss
@@ -43,7 +43,7 @@ $dark-bright: lighten($dark, 15%);
   }
 
   span.cm-comment {
-    color: $grey-light;
+    color: $grey;
   }
 
   span.cm-string,

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -1,34 +1,35 @@
 // Utils
-@import "./utils/reset.scss";
-@import "./utils/z-indices";
-@import "./utils/product-colors";
-@import "./utils/bumper";
+@import './utils/reset.scss';
+@import './utils/z-indices';
+@import './utils/product-colors';
+@import './utils/bumper';
+@import './utils/layout';
 
 // Start with Bulma variables as a foundation
-@import "bulma/sass/utilities/initial-variables";
+@import 'bulma/sass/utilities/initial-variables';
 
 // Override variables where appropriate
-@import "./core/variables.scss";
+@import './core/variables.scss';
 
 // Bring in the rest of Bulma
-@import "bulma/bulma";
+@import 'bulma/bulma';
 
 // Override Bulma details where appropriate
-@import "./core/buttons";
-@import "./core/breadcrumb";
-@import "./core/columns";
-@import "./core/forms";
-@import "./core/icon";
-@import "./core/level";
-@import "./core/menu";
-@import "./core/message";
-@import "./core/navbar";
-@import "./core/notification";
-@import "./core/pagination";
-@import "./core/progress";
-@import "./core/section";
-@import "./core/table";
-@import "./core/tabs";
-@import "./core/tag";
-@import "./core/title";
-@import "./core/typography";
+@import './core/buttons';
+@import './core/breadcrumb';
+@import './core/columns';
+@import './core/forms';
+@import './core/icon';
+@import './core/level';
+@import './core/menu';
+@import './core/message';
+@import './core/navbar';
+@import './core/notification';
+@import './core/pagination';
+@import './core/progress';
+@import './core/section';
+@import './core/table';
+@import './core/tabs';
+@import './core/tag';
+@import './core/title';
+@import './core/typography';

--- a/ui/app/styles/utils/layout.scss
+++ b/ui/app/styles/utils/layout.scss
@@ -1,0 +1,3 @@
+.is-associative {
+  margin-top: -0.75em;
+}

--- a/ui/app/templates/components/job-page/parts/recent-allocations.hbs
+++ b/ui/app/templates/components/job-page/parts/recent-allocations.hbs
@@ -2,7 +2,7 @@
   <div class="boxed-section-head">
     Recent Allocations
   </div>
-  <div class="boxed-section-body is-full-bleed">
+  <div class="boxed-section-body {{if job.allocations.length "is-full-bleed"}}">
     {{#if job.allocations.length}}
       {{#list-table
         source=sortedAllocations

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -9,7 +9,7 @@
         </div>
       {{/if}}
       <div class="column is-centered">
-        {{#link-to "jobs.run" class="button is-primary is-pulled-right"}}Run Job{{/link-to}}
+        {{#link-to "jobs.run" data-test-run-job class="button is-primary is-pulled-right"}}Run Job{{/link-to}}
       </div>
     </div>
     {{#list-pagination

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -2,11 +2,16 @@
   {{#if isForbidden}}
     {{partial "partials/forbidden-message"}}
   {{else}}
-    {{#if filteredJobs.length}}
-      <div class="content">
-        <div>{{search-box data-test-jobs-search searchTerm=(mut searchTerm) placeholder="Search jobs..."}}</div>
+    <div class="columns">
+      {{#if filteredJobs.length}}
+        <div class="column">
+          {{search-box data-test-jobs-search searchTerm=(mut searchTerm) placeholder="Search jobs..."}}
+        </div>
+      {{/if}}
+      <div class="column is-centered">
+        {{#link-to "jobs.run" class="button is-primary is-pulled-right"}}Run Job{{/link-to}}
       </div>
-    {{/if}}
+    </div>
     {{#list-pagination
       source=sortedJobs
       size=pageSize

--- a/ui/app/templates/jobs/run.hbs
+++ b/ui/app/templates/jobs/run.hbs
@@ -1,16 +1,37 @@
 <section class="section">
+  {{#if parseError}}
+    <div data-test-parse-error class="notification is-danger">
+      <h3 class="title is-4">Parse Error</h3>
+      <p>{{parseError}}</p>
+    </div>
+  {{/if}}
+  {{#if planError}}
+    <div data-test-plan-error class="notification is-danger">
+      <h3 class="title is-4">Plan Error</h3>
+      <p>{{planError}}</p>
+    </div>
+  {{/if}}
+  {{#if runError}}
+    <div data-test-run-error class="notification is-danger">
+      <h3 class="title is-4">Run Error</h3>
+      <p>{{runError}}</p>
+    </div>
+  {{/if}}
+
   {{#if (eq stage "editor")}}
-    <div class="notification is-info">
-      <div class="columns">
-        <div class="column">
-          <h3 class="title is-4">Run a Job</h3>
-          <p>Paste or author HCL or JSON to submit to your cluster. A plan will be requested before the job is submitted.</p>
-        </div>
-        <div class="column is-centered is-minimum">
-          <button class="button is-info">Okay</button>
+    {{#if showEditorMessage}}
+      <div class="notification is-info">
+        <div class="columns">
+          <div class="column">
+            <h3 class="title is-4">Run a Job</h3>
+            <p>Paste or author HCL or JSON to submit to your cluster. A plan will be requested before the job is submitted.</p>
+          </div>
+          <div class="column is-centered is-minimum">
+            <button class="button is-info" onclick={{toggle-action "showEditorMessage" this}}>Okay</button>
+          </div>
         </div>
       </div>
-    </div>
+    {{/if}}
     <div class="boxed-section">
       <div class="boxed-section-head">
         Job Definition
@@ -33,17 +54,19 @@
   {{/if}}
 
   {{#if (eq stage "plan")}}
-    <div class="notification is-info">
-      <div class="columns">
-        <div class="column">
-          <h3 class="title is-4">Job Plan</h3>
-          <p>This is the impact running this job will have on your cluster.</p>
-        </div>
-        <div class="column is-centered is-minimum">
-          <button class="button is-info">Okay</button>
+    {{#if showPlanMessage}}
+      <div class="notification is-info">
+        <div class="columns">
+          <div class="column">
+            <h3 class="title is-4">Job Plan</h3>
+            <p>This is the impact running this job will have on your cluster.</p>
+          </div>
+          <div class="column is-centered is-minimum">
+            <button class="button is-info" onclick={{toggle-action "showPlanMessage" this}}>Okay</button>
+          </div>
         </div>
       </div>
-    </div>
+    {{/if}}
     <div class="boxed-section">
       <div class="boxed-section-head">Job Plan</div>
       <div class="boxed-section-body is-dark">
@@ -52,7 +75,7 @@
     </div>
     <div class="content is-associative">
       <button class="button is-primary {{if submit.isRunning "is-loading"}}" onclick={{perform submit}}>Submit</button>
-      <button class="button is-light" onclick={{action cancel}}>Cancel</button>
+      <button class="button is-light" onclick={{action reset}}>Cancel</button>
     </div>
   {{/if}}
 </section>

--- a/ui/app/templates/jobs/run.hbs
+++ b/ui/app/templates/jobs/run.hbs
@@ -1,31 +1,58 @@
 <section class="section">
-  <div class="notification is-info">
-    <div class="columns">
-      <div class="column">
-        <h3 class="title is-4">Run a Job</h3>
-        <p>Paste or author HCL or JSON to submit to your cluster. A plan will be requested before the job is submitted.</p>
+  {{#if (eq stage "editor")}}
+    <div class="notification is-info">
+      <div class="columns">
+        <div class="column">
+          <h3 class="title is-4">Run a Job</h3>
+          <p>Paste or author HCL or JSON to submit to your cluster. A plan will be requested before the job is submitted.</p>
+        </div>
+        <div class="column is-centered is-minimum">
+          <button class="button is-info">Okay</button>
+        </div>
       </div>
-      <div class="column is-centered is-minimum">
-        <button class="button is-info">Okay</button>
+    </div>
+    <div class="boxed-section">
+      <div class="boxed-section-head">
+        Job Definition
+      </div>
+      <div class="boxed-section-body is-full-bleed">
+        {{ivy-codemirror
+          value=(or model._newDefinition jobSpec)
+          valueUpdated=(action (mut model._newDefinition))
+          options=(hash
+            mode="javascript"
+            theme="hashi"
+            tabSize=2
+            lineNumbers=true
+          )}}
       </div>
     </div>
-  </div>
-  <div class="boxed-section">
-    <div class="boxed-section-head">
-      Job Definition
+    <div class="content is-associative">
+      <button class="button is-primary {{if plan.isRunning "is-loading"}}" onclick={{perform plan}}>Plan</button>
     </div>
-    <div class="boxed-section-body is-full-bleed">
-      {{ivy-codemirror
-        value=jobSpec
-        options=(hash
-          mode="javascript"
-          theme="hashi"
-          tabSize=2
-          lineNumbers=true
-        )}}
+  {{/if}}
+
+  {{#if (eq stage "plan")}}
+    <div class="notification is-info">
+      <div class="columns">
+        <div class="column">
+          <h3 class="title is-4">Job Plan</h3>
+          <p>This is the impact running this job will have on your cluster.</p>
+        </div>
+        <div class="column is-centered is-minimum">
+          <button class="button is-info">Okay</button>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="content is-associative">
-    <button class="button is-primary">Plan</button>
-  </div>
+    <div class="boxed-section">
+      <div class="boxed-section-head">Job Plan</div>
+      <div class="boxed-section-body is-dark">
+        {{job-diff diff=planOutput.Diff}}
+      </div>
+    </div>
+    <div class="content is-associative">
+      <button class="button is-primary {{if submit.isRunning "is-loading"}}" onclick={{perform submit}}>Submit</button>
+      <button class="button is-light" onclick={{action cancel}}>Cancel</button>
+    </div>
+  {{/if}}
 </section>

--- a/ui/app/templates/jobs/run.hbs
+++ b/ui/app/templates/jobs/run.hbs
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="content is-associative">
-      <button class="button is-primary {{if plan.isRunning "is-loading"}}" onclick={{perform plan}} data-test-plan>Plan</button>
+      <button class="button is-primary {{if plan.isRunning "is-loading"}}" type="button" onclick={{perform plan}} disabled={{or plan.isRunning (not model._newDefinition)}} data-test-plan>Plan</button>
     </div>
   {{/if}}
 
@@ -75,8 +75,8 @@
       </div>
     </div>
     <div class="content is-associative">
-      <button class="button is-primary {{if submit.isRunning "is-loading"}}" onclick={{perform submit}} data-test-run>Run</button>
-      <button class="button is-light" onclick={{action reset}} data-test-cancel>Cancel</button>
+      <button class="button is-primary {{if submit.isRunning "is-loading"}}" type="button" onclick={{perform submit}} disabled={{submit.isRunning}} data-test-run>Run</button>
+      <button class="button is-light" type="button" onclick={{action reset}} data-test-cancel>Cancel</button>
     </div>
   {{/if}}
 </section>

--- a/ui/app/templates/jobs/run.hbs
+++ b/ui/app/templates/jobs/run.hbs
@@ -1,20 +1,20 @@
 <section class="section">
   {{#if parseError}}
     <div data-test-parse-error class="notification is-danger">
-      <h3 class="title is-4">Parse Error</h3>
-      <p>{{parseError}}</p>
+      <h3 class="title is-4" data-test-parse-error-title>Parse Error</h3>
+      <p data-test-parse-error-message>{{parseError}}</p>
     </div>
   {{/if}}
   {{#if planError}}
     <div data-test-plan-error class="notification is-danger">
-      <h3 class="title is-4">Plan Error</h3>
-      <p>{{planError}}</p>
+      <h3 class="title is-4" data-test-plan-error-title>Plan Error</h3>
+      <p data-test-plan-error-message>{{planError}}</p>
     </div>
   {{/if}}
   {{#if runError}}
     <div data-test-run-error class="notification is-danger">
-      <h3 class="title is-4">Run Error</h3>
-      <p>{{runError}}</p>
+      <h3 class="title is-4" data-test-run-error-title>Run Error</h3>
+      <p data-test-run-error-message>{{runError}}</p>
     </div>
   {{/if}}
 
@@ -23,11 +23,11 @@
       <div class="notification is-info">
         <div class="columns">
           <div class="column">
-            <h3 class="title is-4">Run a Job</h3>
-            <p>Paste or author HCL or JSON to submit to your cluster. A plan will be requested before the job is submitted.</p>
+            <h3 class="title is-4" data-test-editor-help-title>Run a Job</h3>
+            <p data-test-editor-help-message>Paste or author HCL or JSON to submit to your cluster. A plan will be requested before the job is submitted.</p>
           </div>
           <div class="column is-centered is-minimum">
-            <button class="button is-info" onclick={{toggle-action "showEditorMessage" this}}>Okay</button>
+            <button class="button is-info" onclick={{toggle-action "showEditorMessage" this}} data-test-editor-help-dismiss>Okay</button>
           </div>
         </div>
       </div>
@@ -38,6 +38,7 @@
       </div>
       <div class="boxed-section-body is-full-bleed">
         {{ivy-codemirror
+          data-test-editor
           value=(or model._newDefinition jobSpec)
           valueUpdated=(action (mut model._newDefinition))
           options=(hash
@@ -49,7 +50,7 @@
       </div>
     </div>
     <div class="content is-associative">
-      <button class="button is-primary {{if plan.isRunning "is-loading"}}" onclick={{perform plan}}>Plan</button>
+      <button class="button is-primary {{if plan.isRunning "is-loading"}}" onclick={{perform plan}} data-test-plan>Plan</button>
     </div>
   {{/if}}
 
@@ -58,11 +59,11 @@
       <div class="notification is-info">
         <div class="columns">
           <div class="column">
-            <h3 class="title is-4">Job Plan</h3>
-            <p>This is the impact running this job will have on your cluster.</p>
+            <h3 class="title is-4" data-test-plan-help-title>Job Plan</h3>
+            <p data-test-plan-help-message>This is the impact running this job will have on your cluster.</p>
           </div>
           <div class="column is-centered is-minimum">
-            <button class="button is-info" onclick={{toggle-action "showPlanMessage" this}}>Okay</button>
+            <button class="button is-info" onclick={{toggle-action "showPlanMessage" this}} data-test-plan-help-dismiss>Okay</button>
           </div>
         </div>
       </div>
@@ -70,12 +71,12 @@
     <div class="boxed-section">
       <div class="boxed-section-head">Job Plan</div>
       <div class="boxed-section-body is-dark">
-        {{job-diff diff=planOutput}}
+        {{job-diff data-test-plan-output diff=planOutput}}
       </div>
     </div>
     <div class="content is-associative">
-      <button class="button is-primary {{if submit.isRunning "is-loading"}}" onclick={{perform submit}}>Submit</button>
-      <button class="button is-light" onclick={{action reset}}>Cancel</button>
+      <button class="button is-primary {{if submit.isRunning "is-loading"}}" onclick={{perform submit}} data-test-run>Run</button>
+      <button class="button is-light" onclick={{action reset}} data-test-cancel>Cancel</button>
     </div>
   {{/if}}
 </section>

--- a/ui/app/templates/jobs/run.hbs
+++ b/ui/app/templates/jobs/run.hbs
@@ -1,0 +1,31 @@
+<section class="section">
+  <div class="notification is-info">
+    <div class="columns">
+      <div class="column">
+        <h3 class="title is-4">Run a Job</h3>
+        <p>Paste or author HCL or JSON to submit to your cluster. A plan will be requested before the job is submitted.</p>
+      </div>
+      <div class="column is-centered is-minimum">
+        <button class="button is-info">Okay</button>
+      </div>
+    </div>
+  </div>
+  <div class="boxed-section">
+    <div class="boxed-section-head">
+      Job Definition
+    </div>
+    <div class="boxed-section-body is-full-bleed">
+      {{ivy-codemirror
+        value=jobSpec
+        options=(hash
+          mode="javascript"
+          theme="hashi"
+          tabSize=2
+          lineNumbers=true
+        )}}
+    </div>
+  </div>
+  <div class="content is-associative">
+    <button class="button is-primary">Plan</button>
+  </div>
+</section>

--- a/ui/app/templates/jobs/run.hbs
+++ b/ui/app/templates/jobs/run.hbs
@@ -70,7 +70,7 @@
     <div class="boxed-section">
       <div class="boxed-section-head">Job Plan</div>
       <div class="boxed-section-body is-dark">
-        {{job-diff diff=planOutput.Diff}}
+        {{job-diff diff=planOutput}}
       </div>
     </div>
     <div class="content is-associative">

--- a/ui/app/utils/message-from-adapter-error.js
+++ b/ui/app/utils/message-from-adapter-error.js
@@ -1,0 +1,6 @@
+// Returns a single string based on the response the adapter received
+export default function messageFromAdapterError(error) {
+  if (error.errors) {
+    return error.errors.mapBy('detail').join('\n\n');
+  }
+}

--- a/ui/app/utils/properties/local-storage.js
+++ b/ui/app/utils/properties/local-storage.js
@@ -1,0 +1,19 @@
+import { computed } from '@ember/object';
+
+// An Ember.Computed property that persists set values in localStorage
+// and will attempt to get its initial value from localStorage before
+// falling back to a default.
+//
+// ex. showTutorial: localStorageProperty('nomadTutorial', true),
+export default function localStorageProperty(localStorageKey, defaultValue) {
+  return computed({
+    get() {
+      const persistedValue = window.localStorage.getItem(localStorageKey);
+      return persistedValue ? JSON.parse(persistedValue) : defaultValue;
+    },
+    set(key, value) {
+      window.localStorage.setItem(localStorageKey, JSON.stringify(value));
+      return value;
+    },
+  });
+}

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -13,7 +13,6 @@ module.exports = function(defaults) {
       paths: ['public/images/icons'],
     },
     codemirror: {
-      themes: ['solarized'],
       modes: ['javascript'],
     },
     funnel: {

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import Response from 'ember-cli-mirage/response';
 import { HOSTS } from './common';
 import { logFrames, logEncode } from './data/logs';
+import { generateDiff } from './factories/job-version';
 
 const { copy } = Ember;
 
@@ -55,6 +56,33 @@ export default function() {
     })
   );
 
+  this.post('/jobs', function({ jobs }, req) {
+    const body = JSON.parse(req.requestBody);
+
+    if (!body.Job) return new Response(400, {}, 'Job is a required field on the request payload');
+
+    return okEmpty();
+  });
+
+  this.post('/jobs/parse', function({ jobs }, req) {
+    const body = JSON.parse(req.requestBody);
+
+    if (!body.JobHCL)
+      return new Response(400, {}, 'JobHCL is a required field on the request payload');
+    if (!body.Canonicalize) return new Response(400, {}, 'Expected Canonicalize to be true');
+
+    return new Response(200, {}, this.serialize(jobs.first()));
+  });
+
+  this.post('/job/:id/plan', function({ jobs }, req) {
+    const body = JSON.parse(req.requestBody);
+
+    if (!body.Job) return new Response(400, {}, 'Job is a required field on the request payload');
+    if (!body.Diff) return new Response(400, {}, 'Expected Diff to be true');
+
+    return new Response(200, {}, JSON.stringify({ Diff: generateDiff(req.params.id) }));
+  });
+
   this.get(
     '/job/:id',
     withBlockingSupport(function({ jobs }, { params, queryParams }) {
@@ -107,8 +135,7 @@ export default function() {
       createAllocations: parent.createAllocations,
     });
 
-    // Return bogus, since the response is normally just eval information
-    return new Response(200, {}, '{}');
+    return okEmpty();
   });
 
   this.delete('/job/:id', function(schema, { params }) {
@@ -275,4 +302,10 @@ function filterKeys(object, ...keys) {
   });
 
   return clone;
+}
+
+// An empty response but not a 204 No Content. This is still a valid JSON
+// response that represents a payload with no worthwhile data.
+function okEmpty() {
+  return new Response(200, {}, '{}');
 }

--- a/ui/mirage/factories/job-version.js
+++ b/ui/mirage/factories/job-version.js
@@ -6,7 +6,7 @@ export default Factory.extend({
   stable: faker.random.boolean,
   submitTime: () => faker.date.past(2 / 365, REF_TIME) * 1000000,
   diff() {
-    return generateDiff(this);
+    return generateDiff(this.jobId);
   },
 
   jobId: null,
@@ -39,10 +39,10 @@ export default Factory.extend({
   },
 });
 
-function generateDiff(version) {
+export function generateDiff(id) {
   return {
     Fields: null,
-    ID: version.jobId,
+    ID: id,
     Objects: null,
     TaskGroups: [
       {

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -8,8 +8,12 @@ const JOB_TYPES = ['service', 'batch', 'system'];
 const JOB_STATUSES = ['pending', 'running', 'dead'];
 
 export default Factory.extend({
-  id: i => `job-${i}`,
-  name: i => `${faker.list.random(...JOB_PREFIXES)()}-${faker.hacker.noun().dasherize()}-${i}`,
+  id: i =>
+    `${faker.list.random(...JOB_PREFIXES)()}-${faker.hacker.noun().dasherize()}-${i}`.toLowerCase(),
+
+  name() {
+    return this.id;
+  },
 
   groupsCount: () => faker.random.number({ min: 1, max: 5 }),
 

--- a/ui/tests/.eslintrc.js
+++ b/ui/tests/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     selectSearch: true,
     removeMultipleOption: true,
     clearSelected: true,
+    getCodeMirrorInstance: true,
   },
   env: {
     embertest: true,

--- a/ui/tests/acceptance/job-run-test.js
+++ b/ui/tests/acceptance/job-run-test.js
@@ -1,0 +1,315 @@
+import { assign } from '@ember/polyfills';
+import { currentURL } from 'ember-native-dom-helpers';
+import { test } from 'qunit';
+import moduleForAcceptance from 'nomad-ui/tests/helpers/module-for-acceptance';
+import JobRun from 'nomad-ui/tests/pages/jobs/run';
+
+const newJobName = 'new-job';
+
+const jsonJob = overrides => {
+  return JSON.stringify(
+    assign(
+      {},
+      {
+        Name: newJobName,
+        Namespace: 'default',
+        Datacenters: ['dc1'],
+        Priority: 50,
+        TaskGroups: {
+          redis: {
+            Tasks: {
+              redis: {
+                Driver: 'docker',
+              },
+            },
+          },
+        },
+      },
+      overrides
+    ),
+    null,
+    2
+  );
+};
+
+const hclJob = () => `
+job "${newJobName}" {
+  namespace = "default"
+  datacenters = ["dc1"]
+
+  task "redis" {
+    driver = "docker"
+  }
+}
+`;
+
+moduleForAcceptance('Acceptance | job run', {
+  beforeEach() {
+    // Required for placing allocations (a result of creating jobs)
+    server.create('node');
+  },
+});
+
+test('visiting /jobs/run', function(assert) {
+  JobRun.visit();
+
+  andThen(() => {
+    assert.equal(currentURL(), '/jobs/run');
+  });
+});
+
+test('the page has an editor and an explanation popup', function(assert) {
+  JobRun.visit();
+
+  andThen(() => {
+    assert.ok(JobRun.editorHelp.isPresent, 'Editor explanation popup is present');
+    assert.ok(JobRun.editor.isPresent, 'Editor is present');
+  });
+});
+
+test('the explanation popup can be dismissed', function(assert) {
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editorHelp.dismiss();
+  });
+
+  andThen(() => {
+    assert.notOk(JobRun.editorHelp.isPresent, 'Editor explanation popup is gone');
+    assert.equal(
+      window.localStorage.nomadMessageJobEditor,
+      'false',
+      'Dismissal is persisted in localStorage'
+    );
+  });
+});
+
+test('the explanation popup is not shown once the dismissal state is set in localStorage', function(assert) {
+  window.localStorage.nomadMessageJobEditor = 'false';
+
+  JobRun.visit();
+
+  andThen(() => {
+    assert.notOk(JobRun.editorHelp.isPresent, 'Editor explanation popup is gone');
+  });
+});
+
+test('submitting a json job skips the parse endpoint', function(assert) {
+  const spec = jsonJob();
+
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editor.fillIn(spec);
+    JobRun.plan();
+  });
+
+  andThen(() => {
+    const requests = server.pretender.handledRequests.mapBy('url');
+    assert.notOk(requests.includes('/v1/jobs/parse'), 'JSON job spec is not parsed');
+    assert.ok(requests.includes(`/v1/job/${newJobName}/plan`), 'JSON job spec is still planned');
+  });
+});
+
+test('submitting an hcl job requires the parse endpoint', function(assert) {
+  const spec = hclJob();
+
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editor.fillIn(spec);
+    JobRun.plan();
+  });
+
+  andThen(() => {
+    const requests = server.pretender.handledRequests.mapBy('url');
+    assert.ok(requests.includes('/v1/jobs/parse'), 'HCL job spec is parsed first');
+    assert.ok(requests.includes(`/v1/job/${newJobName}/plan`), 'HCL job spec is planned');
+    assert.ok(
+      requests.indexOf('/v1/jobs/parse') < requests.indexOf(`/v1/job/${newJobName}/plan`),
+      'Parse comes before Plan'
+    );
+  });
+});
+
+test('when a job is successfully parsed and planned, the plan is shown to the user', function(assert) {
+  const spec = hclJob();
+
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editor.fillIn(spec);
+    JobRun.plan();
+  });
+
+  andThen(() => {
+    assert.ok(JobRun.planOutput, 'The plan is outputted');
+    assert.notOk(JobRun.editor.isPresent, 'The editor is replaced with the plan output');
+    assert.ok(JobRun.planHelp.isPresent, 'The plan explanation popup is shown');
+  });
+});
+
+test('from the plan screen, the cancel button goes back to the editor with the job still in tact', function(assert) {
+  const spec = hclJob();
+
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editor.fillIn(spec);
+    JobRun.plan();
+  });
+
+  andThen(() => {
+    JobRun.cancel();
+  });
+
+  andThen(() => {
+    assert.ok(JobRun.editor.isPresent, 'The editor is shown again');
+    assert.notOk(JobRun.planOutpu, 'The plan is gone');
+    assert.equal(JobRun.editor.contents, spec, 'The spec that was planned is still in the editor');
+  });
+});
+
+test('from the plan screen, the submit button submits the job and redirects to the job overview page', function(assert) {
+  const spec = hclJob();
+
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editor.fillIn(spec);
+    JobRun.plan();
+  });
+
+  andThen(() => {
+    JobRun.run();
+  });
+
+  andThen(() => {
+    assert.equal(
+      currentURL(),
+      `/jobs/${newJobName}`,
+      `Redirected to the job overview page for ${newJobName}`
+    );
+
+    const runRequest = server.pretender.handledRequests.find(
+      req => req.method === 'POST' && req.url === '/v1/jobs'
+    );
+    const planRequest = server.pretender.handledRequests.find(
+      req => req.method === 'POST' && req.url === '/v1/jobs/parse'
+    );
+
+    assert.ok(runRequest, 'A POST request was made to run the new job');
+    assert.deepEqual(
+      JSON.parse(runRequest.requestBody).Job,
+      JSON.parse(planRequest.responseText),
+      'The Job payload parameter is equivalent to the result of the parse request'
+    );
+  });
+});
+
+test('when parse fails, the parse error message is shown', function(assert) {
+  const spec = hclJob();
+
+  const errorMessage = 'Parse Failed!! :o';
+  server.pretender.post('/v1/jobs/parse', () => [400, {}, errorMessage]);
+
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editor.fillIn(spec);
+    JobRun.plan();
+  });
+
+  andThen(() => {
+    assert.notOk(JobRun.planError.isPresent, 'Plan error is not shown');
+    assert.notOk(JobRun.runError.isPresent, 'Run error is not shown');
+
+    assert.ok(JobRun.parseError.isPresent, 'Parse error is shown');
+    assert.equal(
+      JobRun.parseError.message,
+      errorMessage,
+      'The error message from the server is shown in the error in the UI'
+    );
+  });
+});
+
+test('when plan fails, the plan error message is shown', function(assert) {
+  const spec = hclJob();
+
+  const errorMessage = 'Parse Failed!! :o';
+  server.pretender.post(`/v1/job/${newJobName}/plan`, () => [400, {}, errorMessage]);
+
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editor.fillIn(spec);
+    JobRun.plan();
+  });
+
+  andThen(() => {
+    assert.notOk(JobRun.parseError.isPresent, 'Parse error is not shown');
+    assert.notOk(JobRun.runError.isPresent, 'Run error is not shown');
+
+    assert.ok(JobRun.planError.isPresent, 'Plan error is shown');
+    assert.equal(
+      JobRun.planError.message,
+      errorMessage,
+      'The error message from the server is shown in the error in the UI'
+    );
+  });
+});
+
+test('when run fails, the run error message is shown', function(assert) {
+  const spec = hclJob();
+
+  const errorMessage = 'Parse Failed!! :o';
+  server.pretender.post('/v1/jobs', () => [400, {}, errorMessage]);
+
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editor.fillIn(spec);
+    JobRun.plan();
+  });
+
+  andThen(() => {
+    JobRun.run();
+  });
+
+  andThen(() => {
+    assert.notOk(JobRun.planError.isPresent, 'Plan error is not shown');
+    assert.notOk(JobRun.parseError.isPresent, 'Parse error is not shown');
+
+    assert.ok(JobRun.runError.isPresent, 'Run error is shown');
+    assert.equal(
+      JobRun.runError.message,
+      errorMessage,
+      'The error message from the server is shown in the error in the UI'
+    );
+  });
+});
+
+test('when submitting a job to a different namespace, the redirect to the job overview page takes namespace into account', function(assert) {
+  const newNamespace = 'second-namespace';
+
+  server.create('namespace', { id: newNamespace });
+  const spec = jsonJob({ Namespace: newNamespace });
+
+  JobRun.visit();
+
+  andThen(() => {
+    JobRun.editor.fillIn(spec);
+    JobRun.plan();
+  });
+
+  andThen(() => {
+    JobRun.run();
+  });
+  andThen(() => {
+    assert.equal(
+      currentURL(),
+      `/jobs/${newJobName}?namespace=${newNamespace}`,
+      `Redirected to the job overview page for ${newJobName} and switched the namespace to ${newNamespace}`
+    );
+  });
+});

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -69,6 +69,18 @@ test('each job row should link to the corresponding job', function(assert) {
   });
 });
 
+test('the new job button transitions to the new job page', function(assert) {
+  JobsList.visit();
+
+  andThen(() => {
+    JobsList.runJob();
+  });
+
+  andThen(() => {
+    assert.equal(currentURL(), '/jobs/run');
+  });
+});
+
 test('when there are no jobs, there is an empty message', function(assert) {
   JobsList.visit();
 

--- a/ui/tests/helpers/codemirror.js
+++ b/ui/tests/helpers/codemirror.js
@@ -1,0 +1,19 @@
+import { registerHelper } from '@ember/test';
+
+const invariant = (truthy, error) => {
+  if (!truthy) throw new Error(error);
+};
+
+export default function registerCodeMirrorHelpers() {
+  registerHelper('getCodeMirrorInstance', function(app, selector) {
+    const cmService = app.__container__.lookup('service:code-mirror');
+
+    const element = document.querySelector(selector);
+    invariant(element, `Selector ${selector} matched no elements`);
+
+    const cm = cmService.instanceFor(element.id);
+    invariant(cm, `No registered CodeMirror instance for ${selector}`);
+
+    return cm;
+  });
+}

--- a/ui/tests/helpers/start-app.js
+++ b/ui/tests/helpers/start-app.js
@@ -3,8 +3,10 @@ import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
 import registerPowerSelectHelpers from 'ember-power-select/test-support/helpers';
+import registerCodeMirrorHelpers from 'nomad-ui/tests/helpers/codemirror';
 
 registerPowerSelectHelpers();
+registerCodeMirrorHelpers();
 
 export default function startApp(attrs) {
   let attributes = merge({}, config.APP);

--- a/ui/tests/pages/components/error.js
+++ b/ui/tests/pages/components/error.js
@@ -1,0 +1,11 @@
+import { clickable, isPresent, text } from 'ember-cli-page-object';
+
+export default function(selectorBase = 'data-test-error') {
+  return {
+    scope: `[${selectorBase}]`,
+    isPresent: isPresent(),
+    title: text(`[${selectorBase}-title]`),
+    message: text(`[${selectorBase}-message]`),
+    seekHelp: clickable(`[${selectorBase}-message] a`),
+  };
+}

--- a/ui/tests/pages/helpers/codemirror.js
+++ b/ui/tests/pages/helpers/codemirror.js
@@ -1,0 +1,32 @@
+// Like fillable, but for the CodeMirror editor
+//
+// Usage: fillIn: codeFillable('[data-test-editor]')
+//        Page.fillIn(code);
+export function codeFillable(selector) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      return function(code) {
+        const cm = getCodeMirrorInstance(selector);
+        cm.setValue(code);
+        return this;
+      };
+    },
+  };
+}
+
+// Like text, but for the CodeMirror editor
+//
+// Usage: content: code('[data-test-editor]')
+//        Page.code(); // some = [ 'string', 'of', 'code' ]
+export function code(selector) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      const cm = getCodeMirrorInstance(selector);
+      return cm.getValue();
+    },
+  };
+}

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -16,6 +16,8 @@ export default create({
 
   search: fillable('[data-test-jobs-search] input'),
 
+  runJob: clickable('[data-test-run-job]'),
+
   jobs: collection('[data-test-job-row]', {
     id: attribute('data-test-job-row'),
     name: text('[data-test-job-name]'),

--- a/ui/tests/pages/jobs/run.js
+++ b/ui/tests/pages/jobs/run.js
@@ -1,0 +1,38 @@
+import { clickable, create, isPresent, text, visitable } from 'ember-cli-page-object';
+import { codeFillable, code } from 'nomad-ui/tests/pages/helpers/codemirror';
+
+import error from 'nomad-ui/tests/pages/components/error';
+
+export default create({
+  visit: visitable('/jobs/run'),
+
+  planError: error('data-test-plan-error'),
+  parseError: error('data-test-parse-error'),
+  runError: error('data-test-run-error'),
+
+  plan: clickable('[data-test-plan]'),
+  cancel: clickable('[data-test-cancel]'),
+  run: clickable('[data-test-run]'),
+
+  planOutput: text('[data-test-plan-output]'),
+
+  planHelp: {
+    isPresent: isPresent('[data-test-plan-help-title]'),
+    title: text('[data-test-plan-help-title]'),
+    message: text('[data-test-plan-help-message]'),
+    dismiss: clickable('[data-test-plan-help-dismiss]'),
+  },
+
+  editorHelp: {
+    isPresent: isPresent('[data-test-editor-help-title]'),
+    title: text('[data-test-editor-help-title]'),
+    message: text('[data-test-editor-help-message]'),
+    dismiss: clickable('[data-test-editor-help-dismiss]'),
+  },
+
+  editor: {
+    isPresent: isPresent('[data-test-editor]'),
+    contents: code('[data-test-editor]'),
+    fillIn: codeFillable('[data-test-editor]'),
+  },
+});


### PR DESCRIPTION
_This is part of a bigger Web UI Job Writes project_

Sometimes you just wanna paste some code and hit the green button, ya know?

Now you will be able to run a job (either HCL or JSON) from the web ui by clicking the "Run Job" button found on the jobs list page.

### A quick Q&A before screenshots

**Q: Isn't this an Infrastructure as Code anti-pattern?**
A: Strictly speaking, yes! Since the UI isn't wired up to source control, it's absolutely possible for your cluster to get out of sync with your source of truth. However, in certain environments it might be easier to submit jobs via the web ui and still commit the job file changes to source control. More commonly, users may want to run jobs in dev or test clusters where infrastructure as code isn't as important to the organization. We're just giving people options 🙂

**Q: Oooooh, I don't want this. Where's the off button?**
A: Right now the off button is ACLs. Set an anonymous token that only permits read access. Then (without an elevated token) none of this write stuff will work.

**Q: This is great! Will I still get to see a plan? And will I get version diffs and deployments?**
A: Yes and yes. The Web UI and the CLI are built on top of the same APIs, so everything will work as expected.

------------------------------------------------

![image](https://user-images.githubusercontent.com/174740/44242104-cb157d80-a17c-11e8-85c4-5658da889aed.png)

![image](https://user-images.githubusercontent.com/174740/44242183-2a738d80-a17d-11e8-961d-46bc2b0239aa.png)

![image](https://user-images.githubusercontent.com/174740/44242233-5abb2c00-a17d-11e8-8fc7-a46b4380810f.png)

![image](https://user-images.githubusercontent.com/174740/44242250-6e669280-a17d-11e8-9cd3-f24053269e66.png)
