### PR TITLE
Fix kill timeout exceeding 5m on Docker driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ IMPROVEMENTS:
 
 BUG FIXES:
  * core: Reset queued allocation summary to zero when job stopped [[GH-4414](https://github.com/hashicorp/nomad/issues/4414)]
+ * driver/docker: Fix kill timeout not being respected when timeout is over five
+   minutes [[GH-4599](https://github.com/hashicorp/nomad/issues/4599)]
 
 ## 0.8.4 (June 11, 2018)
 

--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -1913,7 +1913,7 @@ func (h *DockerHandle) Signal(s os.Signal) error {
 // Kill is used to terminate the task. This uses `docker stop -t killTimeout`
 func (h *DockerHandle) Kill() error {
 	// Stop the container
-	err := h.client.StopContainer(h.containerID, uint(h.killTimeout.Seconds()))
+	err := h.waitClient.StopContainer(h.containerID, uint(h.killTimeout.Seconds()))
 	if err != nil {
 		h.executor.Exit()
 		h.pluginClient.Kill()


### PR DESCRIPTION
Fixes an issue where the Docker API client would timeout before the kill
timeout was hit.

/cc @ryanuber 