### PR TITLE
UI: Promote canary

### DIFF
--- a/ui/app/adapters/deployment.js
+++ b/ui/app/adapters/deployment.js
@@ -1,0 +1,29 @@
+import Watchable from './watchable';
+
+export default Watchable.extend({
+  promote(deployment) {
+    const id = deployment.get('id');
+    const url = urlForAction(this.urlForFindRecord(id, 'deployment'), '/promote');
+    return this.ajax(url, 'POST', {
+      data: {
+        DeploymentId: id,
+        All: true,
+      },
+    });
+  },
+});
+
+// The deployment action API endpoints all end with the ID
+// /deployment/:action/:deployment_id instead of /deployment/:deployment_id/:action
+function urlForAction(url, extension = '') {
+  const [path, params] = url.split('?');
+  const pathParts = path.split('/');
+  const idPart = pathParts.pop();
+  let newUrl = `${pathParts.join('/')}${extension}/${idPart}`;
+
+  if (params) {
+    newUrl += `?${params}`;
+  }
+
+  return newUrl;
+}

--- a/ui/app/components/job-page/parts/latest-deployment.js
+++ b/ui/app/components/job-page/parts/latest-deployment.js
@@ -1,8 +1,27 @@
 import Component from '@ember/component';
+import { task } from 'ember-concurrency';
+import messageFromAdapterError from 'nomad-ui/utils/message-from-adapter-error';
 
 export default Component.extend({
   job: null,
   tagName: '',
 
+  handleError() {},
+
   isShowingDeploymentDetails: false,
+
+  promote: task(function*() {
+    try {
+      yield this.get('job.latestDeployment.content').promote();
+    } catch (err) {
+      let message = messageFromAdapterError(err);
+      if (!message || message === 'Forbidden') {
+        message = 'Your ACL token does not grant permission to promote deployments.';
+      }
+      this.get('handleError')({
+        title: 'Could Not Promote Deployment',
+        description: message,
+      });
+    }
+  }),
 });

--- a/ui/app/models/deployment.js
+++ b/ui/app/models/deployment.js
@@ -1,5 +1,6 @@
 import { alias, equal } from '@ember/object/computed';
 import { computed } from '@ember/object';
+import { assert } from '@ember/debug';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
@@ -58,4 +59,9 @@ export default Model.extend({
 
     return classMap[this.get('status')] || 'is-dark';
   }),
+
+  promote() {
+    assert('A deployment needs to requirePromotion to be promoted', this.get('requiresPromotion'));
+    return this.store.adapterFor('deployment').promote(this);
+  },
 });

--- a/ui/app/templates/components/job-page/parts/latest-deployment.hbs
+++ b/ui/app/templates/components/job-page/parts/latest-deployment.hbs
@@ -14,6 +14,7 @@
         </span>
         {{#if job.latestDeployment.requiresPromotion}}
           <button
+            data-test-promote-canary
             type="button"
             class="button is-warning is-small pull-right {{if promote.isRunning "is-loading"}}"
             disabled={{promote.isRunning}}

--- a/ui/app/templates/components/job-page/parts/latest-deployment.hbs
+++ b/ui/app/templates/components/job-page/parts/latest-deployment.hbs
@@ -13,7 +13,11 @@
           {{job.latestDeployment.status}}
         </span>
         {{#if job.latestDeployment.requiresPromotion}}
-          <span class="tag bumper-left is-warning no-text-transform">Deployment is running but requires promotion</span>
+          <button
+            type="button"
+            class="button is-warning is-small pull-right {{if promote.isRunning "is-loading"}}"
+            disabled={{promote.isRunning}}
+            onclick={{perform promote}}>Promote Canary</button>
         {{/if}}
       </div>
     </div>

--- a/ui/app/templates/components/job-page/service.hbs
+++ b/ui/app/templates/components/job-page/service.hbs
@@ -17,7 +17,7 @@
 
   {{job-page/parts/placement-failures job=job}}
 
-  {{job-page/parts/latest-deployment job=job}}
+  {{job-page/parts/latest-deployment job=job handleError=(action "handleError")}}
 
   {{job-page/parts/task-groups
     job=job

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -162,6 +162,9 @@ export default function() {
   });
 
   this.get('/deployment/:id');
+  this.post('/deployment/promote/:id', function() {
+    return new Response(204, {}, '');
+  });
 
   this.get('/job/:id/evaluations', function({ evaluations }, { params }) {
     return this.serialize(evaluations.where({ jobId: params.id }));

--- a/ui/mirage/factories/deployment-task-group-summary.js
+++ b/ui/mirage/factories/deployment-task-group-summary.js
@@ -8,6 +8,8 @@ export default Factory.extend({
   autoRevert: () => Math.random() > 0.5,
   promoted: () => Math.random() > 0.5,
 
+  requiresPromotion: false,
+
   requireProgressBy: () => faker.date.past(0.5 / 365, REF_TIME),
 
   desiredTotal: faker.random.number({ min: 1, max: 10 }),

--- a/ui/mirage/factories/deployment.js
+++ b/ui/mirage/factories/deployment.js
@@ -27,6 +27,8 @@ export default Factory.extend({
       server.create('deployment-task-group-summary', {
         deployment,
         name: server.db.taskGroups.find(id).name,
+        desiredCanaries: 1,
+        promoted: false,
       })
     );
 


### PR DESCRIPTION
_This is parter of a larger UI Job Writes project #4600_

The UI has always shown deployments. Part of this has been informing you when a deployment needs promotion. Now instead of hopping over to a CLI to do the promotion, you can just click a button.

![promote-canary](https://user-images.githubusercontent.com/174740/44612307-477f1080-a7bc-11e8-85eb-e0231655b45c.gif)
