### PR TITLE
Add a -race enabled build to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
       sudo: required
     - os: linux
       dist: trusty
+      sudo: required
+      env: ENABLE_RACE=1
+    - os: linux
+      dist: trusty
       sudo: false
       env: RUN_UI_TESTS=1 SKIP_NOMAD_TESTS=1
     - os: linux
@@ -28,7 +32,10 @@ matrix:
     - os: osx
       osx_image: xcode9.1
   allow_failures:
+    # Allow osx to fail as its flaky
     - os: osx
+    #FIXME Allow race enabled builds to fail for now.
+    - env: ENABLE_RACE=1
   fast_finish: true
 
 before_install:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -244,10 +244,11 @@ test: ## Run the Nomad test suite and/or the Nomad UI test suite
 .PHONY: test-nomad
 test-nomad: dev ## Run Nomad test suites
 	@echo "==> Running Nomad test suites:"
-	@go test $(if $(VERBOSE),-v) \
-			-cover \
-			-timeout=900s \
-			-tags="$(if $(HAS_LXC),lxc)" ./... $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
+	$(if $(ENABLE_RACE),GORACE="strip_path_prefix=$(GOPATH)/src") go test \
+		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
+		-cover \
+		-timeout=900s \
+		-tags="$(if $(HAS_LXC),lxc)" ./... $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
 	@if [ $(VERBOSE) ] ; then \
 		bash -C "$(PROJECT_ROOT)/scripts/test_check.sh" ; \
 	fi


### PR DESCRIPTION
Allow it to fail for now with the goal of making it the default build in
the future.

Thanks to @jippi for calling attention to this in #4608. We should have added this build a long time ago so we could be race-free by now, but better late than never!

(If I get the `.travis.yml` right on the first try I'm giving myself a :cookie:)