### PR TITLE
UI: Use localStorage instead of sessionStorage to store ACL tokens

### DIFF
--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -9,13 +9,13 @@ export default Service.extend({
 
   secret: computed({
     get() {
-      return window.sessionStorage.nomadTokenSecret;
+      return window.localStorage.nomadTokenSecret;
     },
     set(key, value) {
       if (value == null) {
-        window.sessionStorage.removeItem('nomadTokenSecret');
+        window.localStorage.removeItem('nomadTokenSecret');
       } else {
-        window.sessionStorage.nomadTokenSecret = value;
+        window.localStorage.nomadTokenSecret = value;
       }
 
       return value;

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -8,7 +8,7 @@
         <div class="columns">
           <div class="column">
             <h3 class="title is-4">Token Storage</h3>
-            <p>To protect Secret IDs, tokens are stored client-side in <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage">session storage</a>. Your ACL token is automatically cleared from storage upon closing your browser window. You can also manually clear your token instead.</p>
+            <p>Tokens are stored client-side in <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage">local storage</a>. This will persist your token across sessions. You can manually clear your token here.</p>
           </div>
           <div class="column is-centered is-minimum">
             <button class="button is-info" {{action "clearTokenProperties"}}>Clear Token</button>

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -21,18 +21,18 @@ moduleForAcceptance('Acceptance | tokens', {
   },
 });
 
-test('the token form sets the token in session storage', function(assert) {
+test('the token form sets the token in local storage', function(assert) {
   const { secretId } = managementToken;
 
   Tokens.visit();
 
   andThen(() => {
-    assert.ok(window.sessionStorage.nomadTokenSecret == null, 'No token secret set');
+    assert.ok(window.localStorage.nomadTokenSecret == null, 'No token secret set');
 
     Tokens.secret(secretId).submit();
 
     andThen(() => {
-      assert.equal(window.sessionStorage.nomadTokenSecret, secretId, 'Token secret was set');
+      assert.equal(window.localStorage.nomadTokenSecret, secretId, 'Token secret was set');
     });
   });
 });
@@ -91,7 +91,7 @@ test('an error message is shown when authenticating a token fails', function(ass
 
     andThen(() => {
       assert.ok(
-        window.sessionStorage.nomadTokenSecret == null,
+        window.localStorage.nomadTokenSecret == null,
         'Token secret is discarded on failure'
       );
       assert.ok(Tokens.errorMessage, 'Token error message is shown');

--- a/ui/tests/helpers/module-for-acceptance.js
+++ b/ui/tests/helpers/module-for-acceptance.js
@@ -6,10 +6,7 @@ import destroyApp from '../helpers/destroy-app';
 export default function(name, options = {}) {
   module(name, {
     beforeEach() {
-      // Clear session storage (a side effect of token storage)
-      window.sessionStorage.clear();
-
-      // Also clear local storage (a side effect of namespaces and regions)
+      // Also clear local storage (a side effect of namespaces, regions, and tokens)
       window.localStorage.clear();
 
       this.application = startApp();


### PR DESCRIPTION
This makes setting a token persist across sessions, which makes things like clicking links (particularly deep links), and refreshing work as expected.