### PR TITLE
Use eval broker lock when reading/modifying delay heap

### DIFF
--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -777,14 +777,14 @@ func (b *EvalBroker) runDelayedEvalsWatcher(ctx context.Context) {
 // nextDelayedEval returns the next delayed eval to launch and when it should be enqueued.
 // This peeks at the heap to return the top. If the heap is empty, this returns nil and zero time.
 func (b *EvalBroker) nextDelayedEval() (*structs.Evaluation, time.Time) {
-	b.l.Lock()
+	b.l.RLock()
 	// If there is nothing wait for an update.
 	if b.delayHeap.Length() == 0 {
-		b.l.Unlock()
+		b.l.RUnlock()
 		return nil, time.Time{}
 	}
 	nextEval := b.delayHeap.Peek()
-	b.l.Unlock()
+	b.l.RUnlock()
 	if nextEval == nil {
 		return nil, time.Time{}
 	}

--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -763,8 +763,8 @@ func (b *EvalBroker) runDelayedEvalsWatcher(ctx context.Context) {
 			return
 		case <-timerChannel:
 			// remove from the heap since we can enqueue it now
-			b.delayHeap.Remove(&evalWrapper{eval})
 			b.l.Lock()
+			b.delayHeap.Remove(&evalWrapper{eval})
 			b.stats.TotalWaiting -= 1
 			b.enqueueLocked(eval, eval.Type)
 			b.l.Unlock()
@@ -777,12 +777,14 @@ func (b *EvalBroker) runDelayedEvalsWatcher(ctx context.Context) {
 // nextDelayedEval returns the next delayed eval to launch and when it should be enqueued.
 // This peeks at the heap to return the top. If the heap is empty, this returns nil and zero time.
 func (b *EvalBroker) nextDelayedEval() (*structs.Evaluation, time.Time) {
+	b.l.Lock()
 	// If there is nothing wait for an update.
 	if b.delayHeap.Length() == 0 {
+		b.l.Unlock()
 		return nil, time.Time{}
 	}
 	nextEval := b.delayHeap.Peek()
-
+	b.l.Unlock()
 	if nextEval == nil {
 		return nil, time.Time{}
 	}


### PR DESCRIPTION
Fixes #4607 

runDelayedEvalsWatcher attempted to read and write from the delay heap it uses without synchronization. This caused a panic due to the race mentioned in #4607. This PR uses the existing eval broker mutex to synchronize access.