### PR TITLE
Fix panic when reschedule policy for allocation can't be looked up

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6293,6 +6293,10 @@ func (a *Allocation) NextRescheduleTime() (time.Time, bool) {
 // It is calculated according to the delay function and previous reschedule attempts.
 func (a *Allocation) NextDelay() time.Duration {
 	policy := a.ReschedulePolicy()
+	// Can be nil if the task group was updated to remove its reschedule policy
+	if policy == nil {
+		return 0
+	}
 	delayDur := policy.Delay
 	if a.RescheduleTracker == nil || a.RescheduleTracker.Events == nil || len(a.RescheduleTracker.Events) == 0 {
 		return delayDur

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2942,6 +2942,12 @@ func TestAllocation_NextDelay(t *testing.T) {
 			expectedRescheduleEligible: false,
 		},
 		{
+			desc:                       "Allocation has no reschedule policy",
+			alloc:                      &Allocation{},
+			expectedRescheduleTime:     time.Time{},
+			expectedRescheduleEligible: false,
+		},
+		{
 			desc: "Allocation lacks task state",
 			reschedulePolicy: &ReschedulePolicy{
 				DelayFunction: "constant",
@@ -3385,7 +3391,9 @@ func TestAllocation_NextDelay(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			require := require.New(t)
 			j := testJob()
-			j.TaskGroups[0].ReschedulePolicy = tc.reschedulePolicy
+			if tc.reschedulePolicy != nil {
+				j.TaskGroups[0].ReschedulePolicy = tc.reschedulePolicy
+			}
 			tc.alloc.Job = j
 			tc.alloc.TaskGroup = j.TaskGroups[0].Name
 			reschedTime, allowed := tc.alloc.NextRescheduleTime()


### PR DESCRIPTION
Fixes #4560 

Fixes a nil panic when reschedule policy is nil