### PR TITLE
Failed/paused deployments do not block migrations

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -464,24 +464,9 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 		desiredChanges.Ignore += uint64(len(destructive))
 	}
 
-	// Calculate the allowed number of changes and set the desired changes
-	// accordingly.
-	if !a.deploymentFailed && !a.deploymentPaused {
-		desiredChanges.Migrate += uint64(len(migrate))
-	} else {
-		desiredChanges.Stop += uint64(len(migrate))
-	}
-
+	// Migrate all the allocations
+	desiredChanges.Migrate += uint64(len(migrate))
 	for _, alloc := range migrate.nameOrder() {
-		// If the deployment is failed or paused, don't replace it, just mark as stop.
-		if a.deploymentFailed || a.deploymentPaused {
-			a.result.stop = append(a.result.stop, allocStopResult{
-				alloc:             alloc,
-				statusDescription: allocNodeTainted,
-			})
-			continue
-		}
-
 		a.result.stop = append(a.result.stop, allocStopResult{
 			alloc:             alloc,
 			statusDescription: allocMigrating,


### PR DESCRIPTION
This PR changes behavior of the scheduler such that a task group with a
deployment that is failed or paused will not cause the scheduler to skip
migrations.

The reason for this change is that it causes a bad UX when draining
nodes with allocations that are part of a failed/paused deployment.
These operations should not be coupled in any way and this remedies
that.

Prior behavior was still correct, but required either jobs to
transistion to a healthy state or for the node to hit its drain
deadline.