### PR TITLE
Adding cgroupParent support for all containers started by nomad/docke…

### DIFF
--- a/client/driver/docker.go
+++ b/client/driver/docker.go
@@ -141,6 +141,9 @@ const (
 	// remove containers after the task exits.
 	dockerCleanupContainerConfigOption  = "docker.cleanup.container"
 	dockerCleanupContainerConfigDefault = true
+
+	// dockerCgroupParent is the parent cgroup for all docker containers
+	dockerCgroupParentConfigOption = "docker.cgroup.parent"
 )
 
 type DockerDriver struct {
@@ -1214,6 +1217,10 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 	}
 
 	memLimit := int64(task.Resources.MemoryMB) * 1024 * 1024
+	cgroupParent, ok := d.config.Options[dockerCgroupParentConfigOption]
+	if ok != true {
+		cgroupParent = ""
+	}
 
 	if len(driverConfig.Logging) == 0 {
 		if runtime.GOOS == "darwin" {
@@ -1235,7 +1242,8 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 		// Binds are used to mount a host volume into the container. We mount a
 		// local directory for storage and a shared alloc directory that can be
 		// used to share data between different tasks in the same task group.
-		Binds: binds,
+		Binds:        binds,
+		CgroupParent: cgroupParent,
 
 		VolumeDriver: driverConfig.VolumeDriver,
 
@@ -1281,6 +1289,7 @@ func (d *DockerDriver) createContainerConfig(ctx *ExecContext, task *structs.Tas
 		d.logger.Printf("[DEBUG] driver.docker: using %dms cpu quota and %dms cpu period for %s", hostConfig.CPUQuota, defaultCFSPeriodUS, task.Name)
 	}
 	d.logger.Printf("[DEBUG] driver.docker: binding directories %#v for %s", hostConfig.Binds, task.Name)
+	d.logger.Printf("[DEBUG] driver.docker: using %s cgroup for %s", hostConfig.CgroupParent, task.Name)
 
 	//  set privileged mode
 	hostPrivileged := d.config.ReadBoolDefault(dockerPrivilegedConfigOption, false)

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -161,6 +161,54 @@ func newTestDockerClient(t *testing.T) *docker.Client {
 	return client
 }
 
+func dockerSetupCgroup(t *testing.T, task *structs.Task, cgroup string) (*docker.Client, *DockerHandle, func()) {
+	client := newTestDockerClient(t)
+	return dockerSetupWithClientCgroup(t, task, client, cgroup)
+}
+
+func dockerSetupWithClientCgroup(t *testing.T, task *structs.Task, client *docker.Client, cgroup string) (*docker.Client, *DockerHandle, func()) {
+	t.Helper()
+	tctx := testDockerDriverContexts(t, task)
+	tctx.DriverCtx.config.Options[dockerCgroupParentConfigOption] = cgroup
+	driver := NewDockerDriver(tctx.DriverCtx)
+	copyImage(t, tctx.ExecCtx.TaskDir, "busybox.tar")
+
+	presp, err := driver.Prestart(tctx.ExecCtx, task)
+	if err != nil {
+		if presp != nil && presp.CreatedResources != nil {
+			driver.Cleanup(tctx.ExecCtx, presp.CreatedResources)
+		}
+		tctx.AllocDir.Destroy()
+		t.Fatalf("error in prestart: %v", err)
+	}
+	// Update the exec ctx with the driver network env vars
+	tctx.ExecCtx.TaskEnv = tctx.EnvBuilder.SetDriverNetwork(presp.Network).Build()
+
+	sresp, err := driver.Start(tctx.ExecCtx, task)
+	if err != nil {
+		driver.Cleanup(tctx.ExecCtx, presp.CreatedResources)
+		tctx.AllocDir.Destroy()
+		t.Fatalf("Failed to start driver: %s\nStack\n%s", err, debug.Stack())
+	}
+
+	if sresp.Handle == nil {
+		driver.Cleanup(tctx.ExecCtx, presp.CreatedResources)
+		tctx.AllocDir.Destroy()
+		t.Fatalf("handle is nil\nStack\n%s", debug.Stack())
+	}
+
+	// At runtime this is handled by TaskRunner
+	tctx.ExecCtx.TaskEnv = tctx.EnvBuilder.SetDriverNetwork(sresp.Network).Build()
+
+	cleanup := func() {
+		driver.Cleanup(tctx.ExecCtx, presp.CreatedResources)
+		sresp.Handle.Kill()
+		tctx.AllocDir.Destroy()
+	}
+
+	return client, sresp.Handle.(*DockerHandle), cleanup
+}
+
 // This test should always pass, even if docker daemon is not available
 func TestDockerDriver_Fingerprint(t *testing.T) {
 	if !tu.IsTravis() {
@@ -2472,10 +2520,10 @@ func TestDockerDriver_AdvertiseIPv6Address(t *testing.T) {
 		Name:   "nc-demo",
 		Driver: "docker",
 		Config: map[string]interface{}{
-			"image":                  "busybox",
-			"load":                   "busybox.tar",
-			"command":                "/bin/nc",
-			"args":                   []string{"-l", "127.0.0.1", "-p", "0"},
+			"image":   "busybox",
+			"load":    "busybox.tar",
+			"command": "/bin/nc",
+			"args":    []string{"-l", "127.0.0.1", "-p", "0"},
 			"advertise_ipv6_address": expectedAdvertise,
 		},
 		Resources: &structs.Resources{
@@ -2598,4 +2646,44 @@ func TestDockerDriver_CPUCFSPeriod(t *testing.T) {
 	container, err := client.InspectContainer(handle.ContainerID())
 	assert.Nil(t, err, "Error inspecting container: %v", err)
 	assert.Equal(t, int64(1000000), container.HostConfig.CPUPeriod, "cpu_cfs_period option incorrectly set")
+}
+
+func TestDockerDriver_CgroupParent(t *testing.T) {
+	expected := "scheduler_allocations.slice"
+
+	task := &structs.Task{
+		Name:   "nc-demo",
+		Driver: "docker",
+		Config: map[string]interface{}{
+			"image":        "busybox",
+			"load":         "busybox.tar",
+			"command":      "/bin/nc",
+			"args":         []string{"-l", "127.0.0.1", "-p", "0"},
+			"network_mode": "host",
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 256,
+			CPU:      512,
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+	}
+
+	client, handle, cleanup := dockerSetupCgroup(t, task, expected)
+	defer cleanup()
+
+	waitForExist(t, client, handle)
+
+	container, err := client.InspectContainer(handle.ContainerID())
+	if err != nil {
+
+		t.Fatalf("err: %v", err)
+	}
+
+	actual := container.HostConfig.CgroupParent
+	if actual != expected {
+		t.Fatalf("Got CgroupParent mode %q; want %q", expected, actual)
+	}
 }


### PR DESCRIPTION
…r to share same cgroupParent

This PR adds support for nomad client to start all containers via same cgroup parent when using docker.

Usgae:

In client config part of nomad:

client {
enabled = true
options = {
"docker.cgroup.parent" = "scheduler_allocations.slice"
}
}