### PR TITLE
Default restart interval is 30m

### DIFF
--- a/website/source/docs/job-specification/restart.html.md
+++ b/website/source/docs/job-specification/restart.html.md
@@ -71,7 +71,7 @@ defaults by job type:
 
     ```hcl
     restart {
-      interval = "1m"
+      interval = "30m"
       attempts = 2
       delay    = "15s"
       mode     = "fail"


### PR DESCRIPTION
Commit d4337d25c31a076ef877608eaec167c5af4a1be4 changed the default restart interval from 15s to 30m. This change was not reflected in the documentation.