### PR TITLE
Simplify health_hook locking and test thoroughly

### DIFF
--- a/client/allocrunnerv2/health_hook_test.go
+++ b/client/allocrunnerv2/health_hook_test.go
@@ -6,12 +6,16 @@ import (
 	"testing"
 	"time"
 
+	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/nomad/client/allocrunnerv2/interfaces"
 	"github.com/hashicorp/nomad/client/consul"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,6 +23,12 @@ import (
 var _ interfaces.RunnerPrerunHook = (*allocHealthWatcherHook)(nil)
 var _ interfaces.RunnerUpdateHook = (*allocHealthWatcherHook)(nil)
 var _ interfaces.RunnerDestroyHook = (*allocHealthWatcherHook)(nil)
+
+// allocHealth is emitted to a chan whenever SetHealth is called
+type allocHealth struct {
+	healthy    bool
+	taskEvents map[string]*structs.TaskEvent
+}
 
 // mockHealthSetter implements healthSetter that stores health internally
 type mockHealthSetter struct {
@@ -28,6 +38,17 @@ type mockHealthSetter struct {
 	isDeploy   *bool
 	taskEvents map[string]*structs.TaskEvent
 	mu         sync.Mutex
+
+	healthCh chan allocHealth
+}
+
+// newMockHealthSetter returns a mock HealthSetter that emits all SetHealth
+// calls on a buffered chan. Callers who do need need notifications of health
+// changes may just create the struct directly.
+func newMockHealthSetter() *mockHealthSetter {
+	return &mockHealthSetter{
+		healthCh: make(chan allocHealth, 1),
+	}
 }
 
 func (m *mockHealthSetter) SetHealth(healthy, isDeploy bool, taskEvents map[string]*structs.TaskEvent) {
@@ -38,6 +59,10 @@ func (m *mockHealthSetter) SetHealth(healthy, isDeploy bool, taskEvents map[stri
 	m.healthy = &healthy
 	m.isDeploy = &isDeploy
 	m.taskEvents = taskEvents
+
+	if m.healthCh != nil {
+		m.healthCh <- allocHealth{healthy, taskEvents}
+	}
 }
 
 func (m *mockHealthSetter) ClearHealth() {
@@ -50,6 +75,7 @@ func (m *mockHealthSetter) ClearHealth() {
 	m.taskEvents = nil
 }
 
+// TestHealthHook_PrerunDestroy asserts a health hook does not error if it is run and destroyed.
 func TestHealthHook_PrerunDestroy(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -73,8 +99,192 @@ func TestHealthHook_PrerunDestroy(t *testing.T) {
 	// Prerun
 	require.NoError(prerunh.Prerun(context.Background()))
 
+	// Assert isDeploy is false (other tests peek at isDeploy to determine
+	// if an Update applied)
+	ahw := h.(*allocHealthWatcherHook)
+	ahw.hookLock.Lock()
+	assert.False(t, ahw.isDeploy)
+	ahw.hookLock.Unlock()
+
 	// Destroy
 	require.NoError(destroyh.Destroy())
+}
+
+// TestHealthHook_PrerunUpdateDestroy asserts Updates may be applied concurrently.
+func TestHealthHook_PrerunUpdateDestroy(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	alloc := mock.Alloc()
+
+	b := cstructs.NewAllocBroadcaster()
+	defer b.Close()
+
+	consul := consul.NewMockConsulServiceClient(t)
+	hs := &mockHealthSetter{}
+
+	h := newAllocHealthWatcherHook(testlog.HCLogger(t), alloc.Copy(), hs, b.Listen(), consul).(*allocHealthWatcherHook)
+
+	// Prerun
+	require.NoError(h.Prerun(context.Background()))
+
+	// Update multiple times in a goroutine to mimic Client behavior
+	// (Updates are concurrent with alloc runner but are applied serially).
+	errs := make(chan error, 2)
+	go func() {
+		defer close(errs)
+		for i := 0; i < cap(errs); i++ {
+			alloc.AllocModifyIndex++
+			errs <- h.Update(&interfaces.RunnerUpdateRequest{Alloc: alloc.Copy()})
+		}
+	}()
+
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+
+	// Destroy
+	require.NoError(h.Destroy())
+}
+
+// TestHealthHook_UpdatePrerunDestroy asserts that a hook may have Update
+// called before Prerun.
+func TestHealthHook_UpdatePrerunDestroy(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	alloc := mock.Alloc()
+
+	b := cstructs.NewAllocBroadcaster()
+	defer b.Close()
+
+	consul := consul.NewMockConsulServiceClient(t)
+	hs := &mockHealthSetter{}
+
+	h := newAllocHealthWatcherHook(testlog.HCLogger(t), alloc.Copy(), hs, b.Listen(), consul).(*allocHealthWatcherHook)
+
+	// Set a DeploymentID to cause ClearHealth to be called
+	alloc.DeploymentID = uuid.Generate()
+
+	// Update in a goroutine to mimic Client behavior (Updates are
+	// concurrent with alloc runner).
+	errs := make(chan error, 1)
+	go func(alloc *structs.Allocation) {
+		errs <- h.Update(&interfaces.RunnerUpdateRequest{Alloc: alloc})
+		close(errs)
+	}(alloc.Copy())
+
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+
+	// Prerun should be a noop
+	require.NoError(h.Prerun(context.Background()))
+
+	// Assert that the Update took affect by isDeploy being true
+	h.hookLock.Lock()
+	assert.True(t, h.isDeploy)
+	h.hookLock.Unlock()
+
+	// Destroy
+	require.NoError(h.Destroy())
+}
+
+// TestHealthHook_Destroy asserts that a hook may have only Destroy called.
+func TestHealthHook_Destroy(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	b := cstructs.NewAllocBroadcaster()
+	defer b.Close()
+
+	consul := consul.NewMockConsulServiceClient(t)
+	hs := &mockHealthSetter{}
+
+	h := newAllocHealthWatcherHook(testlog.HCLogger(t), mock.Alloc(), hs, b.Listen(), consul).(*allocHealthWatcherHook)
+
+	// Destroy
+	require.NoError(h.Destroy())
+}
+
+// TestHealthHook_SetHealth asserts SetHealth is called when health status is
+// set. Uses task state and health checks.
+func TestHealthHook_SetHealth(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	alloc := mock.Alloc()
+	alloc.Job.TaskGroups[0].Migrate.MinHealthyTime = 1 // let's speed things up
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+
+	// Synthesize running alloc and tasks
+	alloc.ClientStatus = structs.AllocClientStatusRunning
+	alloc.TaskStates = map[string]*structs.TaskState{
+		task.Name: {
+			State:     structs.TaskStateRunning,
+			StartedAt: time.Now(),
+		},
+	}
+
+	// Make Consul response
+	check := &consulapi.AgentCheck{
+		Name:   task.Services[0].Checks[0].Name,
+		Status: consulapi.HealthPassing,
+	}
+	taskRegs := map[string]*agentconsul.TaskRegistration{
+		task.Name: {
+			Services: map[string]*agentconsul.ServiceRegistration{
+				task.Services[0].Name: {
+					Service: &consulapi.AgentService{
+						ID:      "foo",
+						Service: task.Services[0].Name,
+					},
+					Checks: []*consulapi.AgentCheck{check},
+				},
+			},
+		},
+	}
+
+	b := cstructs.NewAllocBroadcaster()
+	defer b.Close()
+
+	// Don't reply on the first call
+	called := false
+	consul := consul.NewMockConsulServiceClient(t)
+	consul.AllocRegistrationsFn = func(string) (*agentconsul.AllocRegistration, error) {
+		if !called {
+			called = true
+			return nil, nil
+		}
+
+		reg := &agentconsul.AllocRegistration{
+			Tasks: taskRegs,
+		}
+
+		return reg, nil
+	}
+
+	hs := newMockHealthSetter()
+
+	h := newAllocHealthWatcherHook(testlog.HCLogger(t), alloc.Copy(), hs, b.Listen(), consul).(*allocHealthWatcherHook)
+
+	// Prerun
+	require.NoError(h.Prerun(context.Background()))
+
+	// Wait for health to be set (healthy)
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout waiting for health to be set")
+	case health := <-hs.healthCh:
+		require.True(health.healthy)
+
+		// Healthy allocs shouldn't emit task events
+		ev := health.taskEvents[task.Name]
+		require.Nilf(ev, "%#v", health.taskEvents)
+	}
+
+	// Destroy
+	require.NoError(h.Destroy())
 }
 
 // TestHealthHook_SystemNoop asserts that system jobs return the noop tracker.
@@ -105,66 +315,4 @@ func TestHealthHook_BatchNoop(t *testing.T) {
 	// Assert that it's the noop impl
 	_, ok := h.(noopAllocHealthWatcherHook)
 	require.True(t, ok)
-}
-
-// TestHealthHook_WatchSema asserts only one caller can acquire the watchSema
-// lock at once and all other callers are blocked.
-func TestHealthHook_WatchSema(t *testing.T) {
-	t.Parallel()
-
-	s := newWatchSema()
-
-	s.acquire()
-
-	// Second acquire should block
-	acq2 := make(chan struct{})
-	go func() {
-		s.acquire()
-		close(acq2)
-	}()
-
-	select {
-	case <-acq2:
-		t.Fatalf("should not have been able to acquire lock")
-	case <-time.After(33 * time.Millisecond):
-		// Ok! It's blocking!
-	}
-
-	// Release and assert second acquire is now active
-	s.release()
-
-	select {
-	case <-acq2:
-		// Ok! Second acquire unblocked!
-	case <-time.After(33 * time.Millisecond):
-		t.Fatalf("second acquire should not have blocked")
-	}
-
-	// wait() should block until lock is released
-	waitCh := make(chan struct{})
-	go func() {
-		s.wait()
-		close(waitCh)
-	}()
-
-	select {
-	case <-waitCh:
-		t.Fatalf("should not have been able to acquire lock")
-	case <-time.After(33 * time.Millisecond):
-		// Ok! It's blocking!
-	}
-
-	// Release and assert wait() finished
-	s.release()
-
-	select {
-	case <-waitCh:
-		// Ok! wait() unblocked!
-	case <-time.After(33 * time.Millisecond):
-		t.Fatalf("wait should not have blocked")
-	}
-
-	// Assert wait() did not acquire the lock
-	s.acquire()
-	s.release()
 }

--- a/client/consul/consul_testing.go
+++ b/client/consul/consul_testing.go
@@ -31,7 +31,7 @@ func NewMockConsulOp(op, allocID, task string) MockConsulOp {
 // MockConsulServiceClient implements the ConsulServiceAPI interface to record
 // and log task registration/deregistration.
 type MockConsulServiceClient struct {
-	Ops []MockConsulOp
+	ops []MockConsulOp
 	mu  sync.Mutex
 
 	logger log.Logger
@@ -84,4 +84,10 @@ func (m *MockConsulServiceClient) AllocRegistrations(allocID string) (*consul.Al
 	}
 
 	return nil, nil
+}
+
+func (m *MockConsulServiceClient) GetOps() []MockConsulOp {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ops
 }


### PR DESCRIPTION
Use done chan like @dadgar suggested in the original PR... no clue why I didn't do this to begin with as it also behaves better:

If Prerun and Destroy were run quickly the watcher goroutine may never have started: it was indeterminate. The done chan means if Prerun creates a watcher, Destroy will block until it exits. Functionally I think we're safe either way, but determinism is always preferable when possible as it makes reasoning and testing far easier! (Also it's less code!)

Thoroughly test hook as concurrent Update calls make for a tricky concurrency problem. Despite being awfully long they're still mostly unit tests. The watcher just has a *lot* of dependencies to manage. All new tests pass -race