### PR TITLE
Corrected vault address and port in client/server hcl

### DIFF
--- a/terraform/shared/config/nomad.hcl
+++ b/terraform/shared/config/nomad.hcl
@@ -13,7 +13,7 @@ consul {
 
 vault {
   enabled = false
-  address = "vault.service.consul"
+  address = "http://active.vault.service.consul:8200"
   task_token_ttl = "1h"
   create_from_role = "nomad-cluster"
   token = ""

--- a/terraform/shared/config/nomad_client.hcl
+++ b/terraform/shared/config/nomad_client.hcl
@@ -16,5 +16,5 @@ consul {
 
 vault {
   enabled = true
-  address = "vault.service.consul"
+  address = "http://active.vault.service.consul:8200"
 }


### PR DESCRIPTION
According to the [`vault` Stanza page](https://www.nomadproject.io/docs/configuration/vault.html):
>This must include the protocol, host/ip, and port given in the format protocol://host:port.