### PR TITLE
Add endpoint to fetch stats from all clients at once

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -166,6 +166,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.Handle("/v1/client/fs/", wrapCORS(s.wrap(s.FsRequest)))
 	s.mux.HandleFunc("/v1/client/gc", s.wrap(s.ClientGCRequest))
 	s.mux.Handle("/v1/client/stats", wrapCORS(s.wrap(s.ClientStatsRequest)))
+	s.mux.Handle("/v1/clients/stats", wrapCORS(s.wrap(s.ClientsStatsRequest)))
 	s.mux.Handle("/v1/client/allocation/", wrapCORS(s.wrap(s.ClientAllocRequest)))
 
 	s.mux.HandleFunc("/v1/agent/self", s.wrap(s.AgentSelfRequest))

--- a/command/agent/stats_endpoint.go
+++ b/command/agent/stats_endpoint.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hashicorp/nomad/client/stats"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -45,4 +46,54 @@ func (s *HTTPServer) ClientStatsRequest(resp http.ResponseWriter, req *http.Requ
 	}
 
 	return reply.HostStats, nil
+}
+
+func (s *HTTPServer) ClientsStatsRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	args := structs.NodeListRequest{}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var nodes structs.NodeListResponse
+	if err := s.agent.RPC("Node.List", &args, &nodes); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]*stats.HostStats)
+	for _, node := range nodes.Nodes {
+		args := structs.NodeSpecificRequest{
+			NodeID: node.ID,
+		}
+		s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
+
+		// Determine the handler to use
+		useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(node.ID)
+
+		// Make the RPC
+		var reply cstructs.ClientStatsResponse
+		var rpcErr error
+		if useLocalClient {
+			rpcErr = s.agent.Client().ClientRPC("ClientStats.Stats", &args, &reply)
+		} else if useClientRPC {
+			rpcErr = s.agent.Client().RPC("ClientStats.Stats", &args, &reply)
+		} else if useServerRPC {
+			rpcErr = s.agent.Server().RPC("ClientStats.Stats", &args, &reply)
+		} else {
+			rpcErr = CodedError(400, "No local Node and node_id not provided")
+		}
+
+		if rpcErr != nil {
+			if structs.IsErrNoNodeConn(rpcErr) {
+				rpcErr = CodedError(404, rpcErr.Error())
+			} else if strings.Contains(rpcErr.Error(), "Unknown node") {
+				rpcErr = CodedError(404, rpcErr.Error())
+			}
+
+			return nil, rpcErr
+		}
+
+		out[node.ID] = reply.HostStats
+	}
+
+	return out, nil
 }

--- a/command/node_status_test.go
+++ b/command/node_status_test.go
@@ -107,6 +107,22 @@ func TestNodeStatusCommand_Run(t *testing.T) {
 	}
 	ui.OutputWriter.Reset()
 
+	// Query all nodes stats
+	if code := cmd.Run([]string{"-address=" + url, "-stats"}); code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+	out = ui.OutputWriter.String()
+	if !strings.Contains(out, "CPU") {
+		t.Fatalf("expect to find CPU, got: %s", out)
+	}
+	if !strings.Contains(out, "Memory") {
+		t.Fatalf("expect to find Memory, got: %s", out)
+	}
+	if !strings.Contains(out, "Disk") {
+		t.Fatalf("expect to find Disk, got: %s", out)
+	}
+	ui.OutputWriter.Reset()
+
 	// Query a single node
 	if code := cmd.Run([]string{"-address=" + url, nodeID}); code != 0 {
 		t.Fatalf("expected exit 0, got: %d", code)


### PR DESCRIPTION
This patch adds a new API endpoint to fetch stats from all clients at once. This should be useful for monitoring and alerting, giving a better look at which resources are scarce and which nodes are overloaded. It should also be useful to build dashboards.

I never wrote Go before so this is probably crap, I will make amends as necessary.