### PR TITLE
Do not bootstrap with non voters

### DIFF
--- a/nomad/util.go
+++ b/nomad/util.go
@@ -38,6 +38,7 @@ type serverParts struct {
 	Addr         net.Addr
 	RPCAddr      net.Addr
 	Status       serf.MemberStatus
+	NonVoter     bool
 }
 
 func (s *serverParts) String() string {
@@ -117,6 +118,9 @@ func isNomadServer(m serf.Member) (bool, *serverParts) {
 		}
 	}
 
+	// Check if the server is a non voter
+	_, nonVoter := m.Tags["nonvoter"]
+
 	addr := &net.TCPAddr{IP: m.Addr, Port: port}
 	rpcAddr := &net.TCPAddr{IP: rpcIP, Port: port}
 	parts := &serverParts{
@@ -134,6 +138,7 @@ func isNomadServer(m serf.Member) (bool, *serverParts) {
 		Build:        *buildVersion,
 		RaftVersion:  raftVsn,
 		Status:       m.Status,
+		NonVoter:     nonVoter,
 	}
 	return true, parts
 }

--- a/nomad/util_test.go
+++ b/nomad/util_test.go
@@ -25,6 +25,7 @@ func TestIsNomadServer(t *testing.T) {
 			"vsn":      "1",
 			"raft_vsn": "2",
 			"build":    "0.7.0+ent",
+			"nonvoter": "1",
 		},
 	}
 	valid, parts := isNomadServer(m)
@@ -55,6 +56,9 @@ func TestIsNomadServer(t *testing.T) {
 	} else if seg[0] != 0 && seg[1] != 7 && seg[2] != 0 {
 		t.Fatalf("bad: %v", parts.Build)
 	}
+	if !parts.NonVoter {
+		t.Fatalf("should be nonvoter")
+	}
 
 	m.Tags["bootstrap"] = "1"
 	valid, parts = isNomadServer(m)
@@ -73,6 +77,12 @@ func TestIsNomadServer(t *testing.T) {
 	valid, parts = isNomadServer(m)
 	if !valid || parts.Expect != 3 {
 		t.Fatalf("bad: %v", parts.Expect)
+	}
+
+	delete(m.Tags, "nonvoter")
+	valid, parts = isNomadServer(m)
+	if !valid || parts.NonVoter {
+		t.Fatalf("should be a voter")
 	}
 }
 


### PR DESCRIPTION
Fixes an issue a cluster could be bootstrapped by promoting non voting servers
to voters. The fix is to not bootstrap unless bootstrap expect is reached with
voting servers only.