### PR TITLE
Fix log streaming and TaskRunner exit handling

### DIFF
--- a/client/allocrunnerv2/alloc_runner_test.go
+++ b/client/allocrunnerv2/alloc_runner_test.go
@@ -1,5 +1,43 @@
 package allocrunnerv2
 
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/client/state"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAllocRunner_AllocState_Initialized asserts that getting TaskStates via
+// AllocState() are initialized even before the AllocRunner has run.
+func TestAllocRunner_AllocState_Initialized(t *testing.T) {
+	t.Parallel()
+
+	alloc := mock.Alloc()
+	logger := testlog.HCLogger(t)
+
+	conf := &Config{
+		Alloc:            alloc,
+		Logger:           logger,
+		ClientConfig:     config.TestClientConfig(),
+		StateDB:          state.NoopDB{},
+		Consul:           nil,
+		Vault:            nil,
+		StateUpdater:     nil,
+		PrevAllocWatcher: nil,
+	}
+
+	ar, err := NewAllocRunner(conf)
+	require.NoError(t, err)
+
+	allocState := ar.AllocState()
+
+	require.NotNil(t, allocState)
+	require.NotNil(t, allocState.TaskStates[alloc.Job.TaskGroups[0].Tasks[0].Name])
+}
+
 /*
 
 import (

--- a/client/allocrunnerv2/state/state.go
+++ b/client/allocrunnerv2/state/state.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-// XXX Why its own package?
 // State captures the state of the allocation runner.
 type State struct {
 	// ClientStatus captures the overall state of the allocation
@@ -18,6 +17,9 @@ type State struct {
 
 	// DeploymentStatus captures the status of the deployment
 	DeploymentStatus *structs.AllocDeploymentStatus
+
+	// TaskStates is a snapshot of task states.
+	TaskStates map[string]*structs.TaskState
 }
 
 // SetDeploymentStatus is a helper for updating the client-controlled
@@ -42,4 +44,18 @@ func (s *State) ClearDeploymentStatus() {
 
 	s.DeploymentStatus.Healthy = nil
 	s.DeploymentStatus.Timestamp = time.Time{}
+}
+
+// Copy returns a deep copy of State.
+func (s *State) Copy() *State {
+	taskStates := make(map[string]*structs.TaskState, len(s.TaskStates))
+	for k, v := range s.TaskStates {
+		taskStates[k] = v.Copy()
+	}
+	return &State{
+		ClientStatus:      s.ClientStatus,
+		ClientDescription: s.ClientDescription,
+		DeploymentStatus:  s.DeploymentStatus.Copy(),
+		TaskStates:        taskStates,
+	}
 }

--- a/client/allocrunnerv2/taskrunner/handleproxy.go
+++ b/client/allocrunnerv2/taskrunner/handleproxy.go
@@ -1,0 +1,57 @@
+package taskrunner
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hashicorp/nomad/client/driver/structs"
+)
+
+// handleResult multiplexes a single WaitResult to multiple waiters. Useful
+// because DriverHandle.WaitCh is closed after it returns a single WaitResult.
+type handleResult struct {
+	doneCh <-chan struct{}
+
+	result *structs.WaitResult
+	mu     sync.RWMutex
+}
+
+func newHandleResult(waitCh <-chan *structs.WaitResult) *handleResult {
+	doneCh := make(chan struct{})
+
+	h := &handleResult{
+		doneCh: doneCh,
+	}
+
+	go func() {
+		// Wait for result
+		res := <-waitCh
+
+		// Set result
+		h.mu.Lock()
+		h.result = res
+		h.mu.Unlock()
+
+		// Notify waiters
+		close(doneCh)
+
+	}()
+
+	return h
+}
+
+// Wait blocks until a task's result is available or the passed-in context is
+// canceled. Safe for concurrent callers.
+func (h *handleResult) Wait(ctx context.Context) *structs.WaitResult {
+	// Block until done or canceled
+	select {
+	case <-h.doneCh:
+	case <-ctx.Done():
+	}
+
+	h.mu.RLock()
+	res := h.result
+	h.mu.RUnlock()
+
+	return res
+}

--- a/client/allocrunnerv2/taskrunner/handleproxy_test.go
+++ b/client/allocrunnerv2/taskrunner/handleproxy_test.go
@@ -1,0 +1,76 @@
+package taskrunner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/client/driver/structs"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleResult_Wait_Result asserts multiple waiters on a handleResult all
+// receive the wait result.
+func TestHandleResult_Wait_Result(t *testing.T) {
+	t.Parallel()
+
+	waitCh := make(chan *structs.WaitResult)
+	h := newHandleResult(waitCh)
+
+	outCh1 := make(chan *structs.WaitResult)
+	outCh2 := make(chan *structs.WaitResult)
+
+	// Create two recievers
+	go func() {
+		outCh1 <- h.Wait(context.Background())
+	}()
+	go func() {
+		outCh2 <- h.Wait(context.Background())
+	}()
+
+	// Send a single result
+	go func() {
+		waitCh <- &structs.WaitResult{ExitCode: 1}
+	}()
+
+	// Assert both receivers got the result
+	assert := func(outCh chan *structs.WaitResult) {
+		select {
+		case result := <-outCh:
+			require.NotNil(t, result)
+			require.Equal(t, 1, result.ExitCode)
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for result")
+		}
+	}
+
+	assert(outCh1)
+	assert(outCh2)
+}
+
+// TestHandleResult_Wait_Cancel asserts that canceling the context unblocks the
+// waiter.
+func TestHandleResult_Wait_Cancel(t *testing.T) {
+	t.Parallel()
+
+	waitCh := make(chan *structs.WaitResult)
+	h := newHandleResult(waitCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	outCh := make(chan *structs.WaitResult)
+
+	go func() {
+		outCh <- h.Wait(ctx)
+	}()
+
+	// Cancelling the context should unblock the Wait
+	cancel()
+
+	// Assert the result is nil
+	select {
+	case result := <-outCh:
+		require.Nil(t, result)
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for result")
+	}
+}

--- a/client/allocrunnerv2/taskrunner/task_runner.go
+++ b/client/allocrunnerv2/taskrunner/task_runner.go
@@ -177,17 +177,16 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 	)
 
 	tr := &TaskRunner{
-		alloc:        config.Alloc,
-		allocID:      config.Alloc.ID,
-		clientConfig: config.ClientConfig,
-		task:         config.Task,
-		taskDir:      config.TaskDir,
-		taskName:     config.Task.Name,
-		envBuilder:   envBuilder,
-		consulClient: config.Consul,
-		vaultClient:  config.VaultClient,
-		//XXX Make a Copy to avoid races?
-		state:           config.Alloc.TaskStates[config.Task.Name],
+		alloc:           config.Alloc,
+		allocID:         config.Alloc.ID,
+		clientConfig:    config.ClientConfig,
+		task:            config.Task,
+		taskDir:         config.TaskDir,
+		taskName:        config.Task.Name,
+		envBuilder:      envBuilder,
+		consulClient:    config.Consul,
+		vaultClient:     config.VaultClient,
+		state:           config.Alloc.TaskStates[config.Task.Name].Copy(),
 		localState:      config.LocalState,
 		stateDB:         config.StateDB,
 		stateUpdater:    config.StateUpdater,

--- a/client/allocrunnerv2/taskrunner/task_runner.go
+++ b/client/allocrunnerv2/taskrunner/task_runner.go
@@ -96,9 +96,14 @@ type TaskRunner struct {
 	// driver is the driver for the task.
 	driver driver.Driver
 
-	handle       driver.DriverHandle // the handle to the running driver
-	handleResult *handleResult       // proxy for handle results
-	handleLock   sync.Mutex
+	// handleLock guards access to handle and handleResult
+	handleLock sync.Mutex
+
+	// handle to the running driver
+	handle driver.DriverHandle
+
+	// handleResult proxies wait results from drivers
+	handleResult *handleResult
 
 	// task is the task being run
 	task     *structs.Task

--- a/client/allocrunnerv2/taskrunner/task_runner_getters.go
+++ b/client/allocrunnerv2/taskrunner/task_runner_getters.go
@@ -49,20 +49,25 @@ func (tr *TaskRunner) setVaultToken(token string) {
 	tr.envBuilder.SetVaultToken(token, tr.task.Vault.Env)
 }
 
-func (tr *TaskRunner) getDriverHandle() driver.DriverHandle {
+// getDriverHandle returns a driver handle and its result proxy. Use the
+// result proxy instead of the handle's WaitCh.
+func (tr *TaskRunner) getDriverHandle() (driver.DriverHandle, *handleResult) {
 	tr.handleLock.Lock()
 	defer tr.handleLock.Unlock()
-	return tr.handle
+	return tr.handle, tr.handleResult
 }
 
+// setDriverHanlde sets the driver handle and creates a new result proxy.
 func (tr *TaskRunner) setDriverHandle(handle driver.DriverHandle) {
 	tr.handleLock.Lock()
 	defer tr.handleLock.Unlock()
 	tr.handle = handle
+	tr.handleResult = newHandleResult(handle.WaitCh())
 }
 
 func (tr *TaskRunner) clearDriverHandle() {
 	tr.handleLock.Lock()
 	defer tr.handleLock.Unlock()
 	tr.handle = nil
+	tr.handleResult = nil
 }

--- a/client/allocrunnerv2/taskrunner/task_runner_hooks.go
+++ b/client/allocrunnerv2/taskrunner/task_runner_hooks.go
@@ -168,7 +168,7 @@ func (tr *TaskRunner) poststart() error {
 		}()
 	}
 
-	handle := tr.getDriverHandle()
+	handle, _ := tr.getDriverHandle()
 	net := handle.Network()
 
 	var merr multierror.Error

--- a/client/allocrunnerv2/taskrunner/task_runner_hooks.go
+++ b/client/allocrunnerv2/taskrunner/task_runner_hooks.go
@@ -69,8 +69,6 @@ func (tr *TaskRunner) initHooks() {
 
 // prestart is used to run the runners prestart hooks.
 func (tr *TaskRunner) prestart() error {
-	//XXX is this necessary? maybe we should have a generic cancelletion
-	//    method instead of peeking into the alloc
 	// Determine if the allocation is terminaland we should avoid running
 	// prestart hooks.
 	alloc := tr.Alloc()
@@ -391,48 +389,3 @@ func (tr *TaskRunner) kill() {
 		}
 	}
 }
-
-/*
-TR Hooks:
-
-> @schmichael
-Task Validate:
-Require:  Client config, task definiton
-Return: error
-Implement: Prestart
-
-> DONE
-Task Dir Build:
-Requires: Folder structure, driver isolation, client config
-Return env, error
-Implement: Prestart
-
-> @alex
-Vault: Task, RPC to talk to server to derive token, Node SecretID
-Return vault token (Call a setter), error, env
-Implement: Prestart
-
-> @alex
-Consul Template:
-Require: Task, alloc directory, way to signal/restart task, updates when vault token changes
-Return env, error
-Implement: Prestart and Update (for new Vault token) and Destroy
-
-> @schmichael
-Consul Service Reg:
-Require: Task, interpolation/ENV
-Return: error
-Implement: Poststart, Update, Kill, Exited
-
-> @alex
-Dispatch Payload:
-Require: Alloc
-Return error
-Implement: Prestart
-
-> @schmichael
-Artifacts:
-Require: Folder structure, task, interpolation/ENV
-Return: error
-Implement: Prestart
-*/

--- a/client/client.go
+++ b/client/client.go
@@ -18,6 +18,7 @@ import (
 	consulapi "github.com/hashicorp/consul/api"
 	hclog "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
+	arstate "github.com/hashicorp/nomad/client/allocrunnerv2/state"
 	consulApi "github.com/hashicorp/nomad/client/consul"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	hstats "github.com/hashicorp/nomad/helper/stats"
@@ -103,6 +104,7 @@ type ClientStatsReporter interface {
 //TODO Create via factory to allow testing Client with mock AllocRunners.
 type AllocRunner interface {
 	Alloc() *structs.Allocation
+	AllocState() *arstate.State
 	Destroy()
 	GetAllocDir() *allocdir.AllocDir
 	IsDestroyed() bool
@@ -640,8 +642,9 @@ func (c *Client) GetAllocFS(allocID string) (allocdir.AllocDirFS, error) {
 	return ar.GetAllocDir(), nil
 }
 
-// GetClientAlloc returns the allocation from the client
-func (c *Client) GetClientAlloc(allocID string) (*structs.Allocation, error) {
+// GetAllocState returns a copy of an allocation's state on this client. It
+// returns either an AllocState or an unknown allocation error.
+func (c *Client) GetAllocState(allocID string) (*arstate.State, error) {
 	c.allocLock.RLock()
 	ar, ok := c.allocs[allocID]
 	c.allocLock.RUnlock()
@@ -649,7 +652,7 @@ func (c *Client) GetClientAlloc(allocID string) (*structs.Allocation, error) {
 		return nil, structs.NewErrUnknownAllocation(allocID)
 	}
 
-	return ar.Alloc(), nil
+	return ar.AllocState(), nil
 }
 
 // GetServers returns the list of nomad servers this client is aware of.

--- a/client/client.go
+++ b/client/client.go
@@ -642,12 +642,14 @@ func (c *Client) GetAllocFS(allocID string) (allocdir.AllocDirFS, error) {
 
 // GetClientAlloc returns the allocation from the client
 func (c *Client) GetClientAlloc(allocID string) (*structs.Allocation, error) {
-	all := c.allAllocs()
-	alloc, ok := all[allocID]
+	c.allocLock.RLock()
+	ar, ok := c.allocs[allocID]
+	c.allocLock.RUnlock()
 	if !ok {
 		return nil, structs.NewErrUnknownAllocation(allocID)
 	}
-	return alloc, nil
+
+	return ar.Alloc(), nil
 }
 
 // GetServers returns the list of nomad servers this client is aware of.
@@ -2549,7 +2551,7 @@ func (c *Client) getAllocatedResources(selfNode *structs.Node) *structs.Resource
 func (c *Client) allAllocs() map[string]*structs.Allocation {
 	ars := c.getAllocRunners()
 	allocs := make(map[string]*structs.Allocation, len(ars))
-	for _, ar := range c.getAllocRunners() {
+	for _, ar := range ars {
 		a := ar.Alloc()
 		allocs[a.ID] = a
 	}

--- a/client/config/testing.go
+++ b/client/config/testing.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// TestClientConfig returns a default client configuration for test clients.
+func TestClientConfig() *Config {
+	conf := DefaultConfig()
+	conf.VaultConfig.Enabled = helper.BoolToPtr(false)
+	conf.DevMode = true
+	conf.Node = &structs.Node{
+		Reserved: &structs.Resources{
+			DiskMB: 0,
+		},
+	}
+
+	// Loosen GC threshold
+	conf.GCDiskUsageThreshold = 98.0
+	conf.GCInodeUsageThreshold = 98.0
+	return conf
+}

--- a/client/driver/mock_driver.go
+++ b/client/driver/mock_driver.go
@@ -45,7 +45,8 @@ type MockDriverConfig struct {
 	// StartErrRecoverable marks the error returned is recoverable
 	StartErrRecoverable bool `mapstructure:"start_error_recoverable"`
 
-	// StartBlockFor specifies a duration in which to block before returning
+	// StartBlockFor specifies a duration in which to block Start before
+	// returning. Useful for testing the behavior of tasks in pending.
 	StartBlockFor time.Duration `mapstructure:"start_block_for"`
 
 	// KillAfter is the duration after which the mock driver indicates the task

--- a/client/driver/mock_driver.go
+++ b/client/driver/mock_driver.go
@@ -415,6 +415,8 @@ func (h *mockDriverHandle) Stats() (*cstructs.TaskResourceUsage, error) {
 // run waits for the configured amount of time and then indicates the task has
 // terminated
 func (h *mockDriverHandle) run() {
+	defer close(h.waitCh)
+
 	// Setup logging output
 	if h.stdoutString != "" {
 		go h.handleLogging()

--- a/client/fs_endpoint.go
+++ b/client/fs_endpoint.go
@@ -836,6 +836,9 @@ func logIndexes(entries []*cstructs.AllocFileInfo, task, logType string) (indexT
 	return indexTupleArray(indexes), nil
 }
 
+// notFoundErr is returned when a log is requested but cannot be found.
+// Implements agent.HTTPCodedError but does not reference it to avoid circular
+// imports.
 type notFoundErr struct {
 	taskName string
 	logType  string

--- a/client/fs_endpoint.go
+++ b/client/fs_endpoint.go
@@ -276,6 +276,15 @@ OUTER:
 			break OUTER
 		case frame, ok := <-frames:
 			if !ok {
+				// frame may have been closed when an error
+				// occurred. Check once more for an error.
+				select {
+				case streamErr = <-errCh:
+					// There was a pending error!
+				default:
+					// No error, continue on
+				}
+
 				break OUTER
 			}
 

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -32,7 +32,7 @@ import (
 // tempAllocDir returns a new alloc dir that is rooted in a temp dir. The caller
 // should destroy the temp dir.
 func tempAllocDir(t testing.TB) *allocdir.AllocDir {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := ioutil.TempDir("", "nomadtest")
 	if err != nil {
 		t.Fatalf("TempDir() failed: %v", err)
 	}
@@ -536,68 +536,21 @@ func TestFS_Stream(t *testing.T) {
 	})
 	defer c.Shutdown()
 
-	// Force an allocation onto the node
 	expected := "Hello from the other side"
-	a := mock.Alloc()
-	a.Job.Type = structs.JobTypeBatch
-	a.NodeID = c.NodeID()
-	a.Job.TaskGroups[0].Count = 1
-	a.Job.TaskGroups[0].Tasks[0] = &structs.Task{
-		Name:   "web",
-		Driver: "mock_driver",
-		Config: map[string]interface{}{
-			"run_for":       "2s",
-			"stdout_string": expected,
-		},
-		LogConfig: structs.DefaultLogConfig(),
-		Resources: &structs.Resources{
-			CPU:      500,
-			MemoryMB: 256,
-		},
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for":       "2s",
+		"stdout_string": expected,
 	}
 
-	// Wait for the client to connect
-	testutil.WaitForResult(func() (bool, error) {
-		node, err := s.State().NodeByID(nil, c.NodeID())
-		if err != nil {
-			return false, err
-		}
-		if node == nil {
-			return false, fmt.Errorf("unknown node")
-		}
-
-		return node.Status == structs.NodeStatusReady, fmt.Errorf("bad node status")
-	}, func(err error) {
-		t.Fatal(err)
-	})
-
-	// Upsert the allocation
-	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
-
-	// Wait for the client to run the allocation
-	testutil.WaitForResult(func() (bool, error) {
-		alloc, err := state.AllocByID(nil, a.ID)
-		if err != nil {
-			return false, err
-		}
-		if alloc == nil {
-			return false, fmt.Errorf("unknown alloc")
-		}
-		if alloc.ClientStatus != structs.AllocClientStatusComplete {
-			return false, fmt.Errorf("alloc client status: %v", alloc.ClientStatus)
-		}
-
-		return true, nil
-	}, func(err error) {
-		t.Fatalf("Alloc on node %q not finished: %v", c.NodeID(), err)
-	})
+	// Wait for alloc to be running
+	alloc := testutil.WaitForRunning(t, s.RPC, job)[0]
 
 	// Make the request
 	req := &cstructs.FsStreamRequest{
-		AllocID:      a.ID,
-		Path:         "alloc/logs/web.stdout.0",
+		AllocID:      alloc.ID,
+		Path:         "alloc/logs/worker.stdout.0",
 		PlainText:    true,
 		QueryOptions: structs.QueryOptions{Region: "global"},
 	}
@@ -693,72 +646,25 @@ func TestFS_Stream_Follow(t *testing.T) {
 	})
 	defer c.Shutdown()
 
-	// Force an allocation onto the node
 	expectedBase := "Hello from the other side"
 	repeat := 10
 
-	a := mock.Alloc()
-	a.Job.Type = structs.JobTypeBatch
-	a.NodeID = c.NodeID()
-	a.Job.TaskGroups[0].Count = 1
-	a.Job.TaskGroups[0].Tasks[0] = &structs.Task{
-		Name:   "web",
-		Driver: "mock_driver",
-		Config: map[string]interface{}{
-			"run_for":                "20s",
-			"stdout_string":          expectedBase,
-			"stdout_repeat":          repeat,
-			"stdout_repeat_duration": 200 * time.Millisecond,
-		},
-		LogConfig: structs.DefaultLogConfig(),
-		Resources: &structs.Resources{
-			CPU:      500,
-			MemoryMB: 256,
-		},
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for":                "20s",
+		"stdout_string":          expectedBase,
+		"stdout_repeat":          repeat,
+		"stdout_repeat_duration": 200 * time.Millisecond,
 	}
 
-	// Wait for the client to connect
-	testutil.WaitForResult(func() (bool, error) {
-		node, err := s.State().NodeByID(nil, c.NodeID())
-		if err != nil {
-			return false, err
-		}
-		if node == nil {
-			return false, fmt.Errorf("unknown node")
-		}
-
-		return node.Status == structs.NodeStatusReady, fmt.Errorf("bad node status")
-	}, func(err error) {
-		t.Fatal(err)
-	})
-
-	// Upsert the allocation
-	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
-
-	// Wait for the client to run the allocation
-	testutil.WaitForResult(func() (bool, error) {
-		alloc, err := state.AllocByID(nil, a.ID)
-		if err != nil {
-			return false, err
-		}
-		if alloc == nil {
-			return false, fmt.Errorf("unknown alloc")
-		}
-		if alloc.ClientStatus != structs.AllocClientStatusRunning {
-			return false, fmt.Errorf("alloc client status: %v", alloc.ClientStatus)
-		}
-
-		return true, nil
-	}, func(err error) {
-		t.Fatalf("Alloc on node %q not running: %v", c.NodeID(), err)
-	})
+	// Wait for alloc to be running
+	alloc := testutil.WaitForRunning(t, s.RPC, job)[0]
 
 	// Make the request
 	req := &cstructs.FsStreamRequest{
-		AllocID:      a.ID,
-		Path:         "alloc/logs/web.stdout.0",
+		AllocID:      alloc.ID,
+		Path:         "alloc/logs/worker.stdout.0",
 		PlainText:    true,
 		Follow:       true,
 		QueryOptions: structs.QueryOptions{Region: "global"},
@@ -837,69 +743,22 @@ func TestFS_Stream_Limit(t *testing.T) {
 	})
 	defer c.Shutdown()
 
-	// Force an allocation onto the node
 	var limit int64 = 5
 	full := "Hello from the other side"
 	expected := full[:limit]
-	a := mock.Alloc()
-	a.Job.Type = structs.JobTypeBatch
-	a.NodeID = c.NodeID()
-	a.Job.TaskGroups[0].Count = 1
-	a.Job.TaskGroups[0].Tasks[0] = &structs.Task{
-		Name:   "web",
-		Driver: "mock_driver",
-		Config: map[string]interface{}{
-			"run_for":       "2s",
-			"stdout_string": full,
-		},
-		LogConfig: structs.DefaultLogConfig(),
-		Resources: &structs.Resources{
-			CPU:      500,
-			MemoryMB: 256,
-		},
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for":       "2s",
+		"stdout_string": full,
 	}
 
-	// Wait for the client to connect
-	testutil.WaitForResult(func() (bool, error) {
-		node, err := s.State().NodeByID(nil, c.NodeID())
-		if err != nil {
-			return false, err
-		}
-		if node == nil {
-			return false, fmt.Errorf("unknown node")
-		}
-
-		return node.Status == structs.NodeStatusReady, fmt.Errorf("bad node status")
-	}, func(err error) {
-		t.Fatal(err)
-	})
-
-	// Upsert the allocation
-	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
-
-	// Wait for the client to run the allocation
-	testutil.WaitForResult(func() (bool, error) {
-		alloc, err := state.AllocByID(nil, a.ID)
-		if err != nil {
-			return false, err
-		}
-		if alloc == nil {
-			return false, fmt.Errorf("unknown alloc")
-		}
-		if alloc.ClientStatus != structs.AllocClientStatusComplete {
-			return false, fmt.Errorf("alloc client status: %v", alloc.ClientStatus)
-		}
-
-		return true, nil
-	}, func(err error) {
-		t.Fatalf("Alloc on node %q not finished: %v", c.NodeID(), err)
-	})
+	// Wait for alloc to be running
+	alloc := testutil.WaitForRunning(t, s.RPC, job)[0]
 
 	// Make the request
 	req := &cstructs.FsStreamRequest{
-		AllocID:      a.ID,
+		AllocID:      alloc.ID,
 		Path:         "alloc/logs/web.stdout.0",
 		PlainText:    true,
 		Limit:        limit,
@@ -1040,6 +899,116 @@ OUTER:
 	}
 }
 
+// TestFS_Logs_TaskPending asserts that trying to stream logs for tasks which
+// have not started returns a 404 error.
+func TestFS_Logs_TaskPending(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Start a server and client
+	s := nomad.TestServer(t, nil)
+	defer s.Shutdown()
+	testutil.WaitForLeader(t, s.RPC)
+
+	c := TestClient(t, func(c *config.Config) {
+		c.Servers = []string{s.GetConfig().RPCAddr.String()}
+	})
+	defer c.Shutdown()
+
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"start_block_for": "4s",
+	}
+
+	// Register job
+	args := &structs.JobRegisterRequest{}
+	args.Job = job
+	args.WriteRequest.Region = "global"
+	var jobResp structs.JobRegisterResponse
+	require.NoError(s.RPC("Job.Register", args, &jobResp))
+
+	// Get the allocation ID
+	var allocID string
+	testutil.WaitForResult(func() (bool, error) {
+		args := structs.AllocListRequest{}
+		args.Region = "global"
+		resp := structs.AllocListResponse{}
+		if err := s.RPC("Alloc.List", &args, &resp); err != nil {
+			return false, err
+		}
+
+		if len(resp.Allocations) != 1 {
+			return false, fmt.Errorf("expected 1 alloc, found %d", len(resp.Allocations))
+		}
+
+		allocID = resp.Allocations[0].ID
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("error getting alloc id: %v", err)
+	})
+
+	// Make the request
+	req := &cstructs.FsLogsRequest{
+		AllocID:      allocID,
+		Task:         job.TaskGroups[0].Tasks[0].Name,
+		LogType:      "stdout",
+		Origin:       "start",
+		PlainText:    true,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+
+	// Get the handler
+	handler, err := c.StreamingRpcHandler("FileSystem.Logs")
+	require.Nil(err)
+
+	// Create a pipe
+	p1, p2 := net.Pipe()
+	defer p1.Close()
+	defer p2.Close()
+
+	errCh := make(chan error)
+	streamMsg := make(chan *cstructs.StreamErrWrapper)
+
+	// Start the handler
+	go handler(p2)
+
+	// Start the decoder
+	go func() {
+		decoder := codec.NewDecoder(p1, structs.MsgpackHandle)
+		for {
+			var msg cstructs.StreamErrWrapper
+			if err := decoder.Decode(&msg); err != nil {
+				if err == io.EOF || strings.Contains(err.Error(), "closed") {
+					return
+				}
+				errCh <- fmt.Errorf("error decoding: %v", err)
+			}
+
+			streamMsg <- &msg
+		}
+	}()
+
+	// Send the request
+	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
+	require.Nil(encoder.Encode(req))
+
+	for {
+		select {
+		case <-time.After(3 * time.Second):
+			t.Fatal("timeout")
+		case err := <-errCh:
+			t.Fatalf("unexpected stream error: %v", err)
+		case msg := <-streamMsg:
+			require.NotNil(msg.Error)
+			require.NotNil(msg.Error.Code)
+			require.EqualValues(404, *msg.Error.Code)
+			require.Contains(msg.Error.Message, "not started")
+			return
+		}
+	}
+}
+
 func TestFS_Logs_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -1174,7 +1143,6 @@ func TestFS_Logs(t *testing.T) {
 	})
 	defer c.Shutdown()
 
-	// Force an allocation onto the node
 	expected := "Hello from the other side\n"
 	job := mock.BatchJob()
 	job.TaskGroups[0].Count = 1
@@ -1182,21 +1150,6 @@ func TestFS_Logs(t *testing.T) {
 		"run_for":       "2s",
 		"stdout_string": expected,
 	}
-
-	// Wait for the client to connect
-	testutil.WaitForResult(func() (bool, error) {
-		node, err := s.State().NodeByID(nil, c.NodeID())
-		if err != nil {
-			return false, err
-		}
-		if node == nil {
-			return false, fmt.Errorf("unknown node")
-		}
-
-		return node.Status == structs.NodeStatusReady, fmt.Errorf("bad node status")
-	}, func(err error) {
-		t.Fatal(err)
-	})
 
 	// Wait for client to be running job
 	testutil.WaitForRunning(t, s.RPC, job)
@@ -1291,7 +1244,6 @@ func TestFS_Logs_Follow(t *testing.T) {
 	})
 	defer c.Shutdown()
 
-	// Force an allocation onto the node
 	expectedBase := "Hello from the other side\n"
 	repeat := 10
 
@@ -1305,19 +1257,11 @@ func TestFS_Logs_Follow(t *testing.T) {
 	}
 
 	// Wait for client to be running job
-	testutil.WaitForRunning(t, s.RPC, job)
-
-	// Get the allocation ID
-	args := structs.AllocListRequest{}
-	args.Region = "global"
-	resp := structs.AllocListResponse{}
-	require.NoError(s.RPC("Alloc.List", &args, &resp))
-	require.Len(resp.Allocations, 1)
-	allocID := resp.Allocations[0].ID
+	alloc := testutil.WaitForRunning(t, s.RPC, job)[0]
 
 	// Make the request
 	req := &cstructs.FsLogsRequest{
-		AllocID:      allocID,
+		AllocID:      alloc.ID,
 		Task:         job.TaskGroups[0].Tasks[0].Name,
 		LogType:      "stdout",
 		Origin:       "start",

--- a/client/state/noopdb.go
+++ b/client/state/noopdb.go
@@ -5,36 +5,37 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-type noopDB struct{}
+// NoopDB implements a StateDB that does not persist any data.
+type NoopDB struct{}
 
-func (n noopDB) GetAllAllocations() ([]*structs.Allocation, map[string]error, error) {
+func (n NoopDB) GetAllAllocations() ([]*structs.Allocation, map[string]error, error) {
 	return nil, nil, nil
 }
 
-func (n noopDB) PutAllocation(*structs.Allocation) error {
+func (n NoopDB) PutAllocation(*structs.Allocation) error {
 	return nil
 }
 
-func (n noopDB) GetTaskRunnerState(allocID string, taskName string) (*state.LocalState, *structs.TaskState, error) {
+func (n NoopDB) GetTaskRunnerState(allocID string, taskName string) (*state.LocalState, *structs.TaskState, error) {
 	return nil, nil, nil
 }
 
-func (n noopDB) PutTaskRunnerLocalState(allocID string, taskName string, val interface{}) error {
+func (n NoopDB) PutTaskRunnerLocalState(allocID string, taskName string, val interface{}) error {
 	return nil
 }
 
-func (n noopDB) PutTaskState(allocID string, taskName string, state *structs.TaskState) error {
+func (n NoopDB) PutTaskState(allocID string, taskName string, state *structs.TaskState) error {
 	return nil
 }
 
-func (n noopDB) DeleteTaskBucket(allocID, taskName string) error {
+func (n NoopDB) DeleteTaskBucket(allocID, taskName string) error {
 	return nil
 }
 
-func (n noopDB) DeleteAllocationBucket(allocID string) error {
+func (n NoopDB) DeleteAllocationBucket(allocID string) error {
 	return nil
 }
 
-func (n noopDB) Close() error {
+func (n NoopDB) Close() error {
 	return nil
 }

--- a/client/state/state_database.go
+++ b/client/state/state_database.go
@@ -46,7 +46,7 @@ func GetStateDBFactory(devMode bool) NewStateDBFunc {
 	// Return a noop state db implementation when in debug mode
 	if devMode {
 		return func(string) (StateDB, error) {
-			return noopDB{}, nil
+			return NoopDB{}, nil
 		}
 	}
 

--- a/client/testing.go
+++ b/client/testing.go
@@ -5,9 +5,6 @@ import (
 	consulApi "github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/fingerprint"
 	"github.com/hashicorp/nomad/command/agent/consul"
-	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/helper/testlog"
-	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/shared/catalog"
 	"github.com/hashicorp/nomad/plugins/shared/singleton"
 	"github.com/mitchellh/go-testing-interface"
@@ -15,22 +12,10 @@ import (
 
 // TestClient creates an in-memory client for testing purposes.
 func TestClient(t testing.T, cb func(c *config.Config)) *Client {
-	conf := config.DefaultConfig()
-	logger := testlog.HCLogger(t)
-	conf.Logger = logger
-	conf.VaultConfig.Enabled = helper.BoolToPtr(false)
-	conf.DevMode = true
-	conf.Node = &structs.Node{
-		Reserved: &structs.Resources{
-			DiskMB: 0,
-		},
-	}
+	conf := config.TestClientConfig()
 
-	// Loosen GC threshold
-	conf.GCDiskUsageThreshold = 98.0
-	conf.GCInodeUsageThreshold = 98.0
-
-	// Tighten the fingerprinter timeouts
+	// Tighten the fingerprinter timeouts (must be done in client package
+	// to avoid circular dependencies)
 	if conf.Options == nil {
 		conf.Options = make(map[string]string)
 	}

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -453,7 +453,7 @@ func TestHTTP_AllocSnapshot_Atomic(t *testing.T) {
 
 		// Wait for the client to run it
 		testutil.WaitForResult(func() (bool, error) {
-			if _, err := s.client.GetClientAlloc(alloc.ID); err != nil {
+			if _, err := s.client.GetAllocState(alloc.ID); err != nil {
 				return false, err
 			}
 

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -145,25 +145,22 @@ func TestHTTP_FS_ReadAt_MissingParams(t *testing.T) {
 	require := require.New(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		req, err := http.NewRequest("GET", "/v1/client/fs/readat/", nil)
-		require.Nil(err)
-		respW := httptest.NewRecorder()
+		require.NoError(err)
 
-		_, err = s.Server.FileReadAtRequest(respW, req)
-		require.NotNil(err)
+		_, err = s.Server.FileReadAtRequest(httptest.NewRecorder(), req)
+		require.Error(err)
 
 		req, err = http.NewRequest("GET", "/v1/client/fs/readat/foo", nil)
-		require.Nil(err)
-		respW = httptest.NewRecorder()
+		require.NoError(err)
 
-		_, err = s.Server.FileReadAtRequest(respW, req)
-		require.NotNil(err)
+		_, err = s.Server.FileReadAtRequest(httptest.NewRecorder(), req)
+		require.Error(err)
 
 		req, err = http.NewRequest("GET", "/v1/client/fs/readat/foo?path=/path/to/file", nil)
-		require.Nil(err)
-		respW = httptest.NewRecorder()
+		require.NoError(err)
 
-		_, err = s.Server.FileReadAtRequest(respW, req)
-		require.NotNil(err)
+		_, err = s.Server.FileReadAtRequest(httptest.NewRecorder(), req)
+		require.Error(err)
 	})
 }
 
@@ -398,7 +395,7 @@ func TestHTTP_FS_Logs(t *testing.T) {
 		p, _ := io.Pipe()
 		req, err := http.NewRequest("GET", path, p)
 		require.Nil(err)
-		respW := httptest.NewRecorder()
+		respW := testutil.NewResponseRecorder()
 		go func() {
 			_, err = s.Server.Logs(respW, req)
 			require.Nil(err)
@@ -406,7 +403,7 @@ func TestHTTP_FS_Logs(t *testing.T) {
 
 		out := ""
 		testutil.WaitForResult(func() (bool, error) {
-			output, err := ioutil.ReadAll(respW.Body)
+			output, err := ioutil.ReadAll(respW)
 			if err != nil {
 				return false, err
 			}
@@ -436,7 +433,7 @@ func TestHTTP_FS_Logs_Follow(t *testing.T) {
 		p, _ := io.Pipe()
 		req, err := http.NewRequest("GET", path, p)
 		require.Nil(err)
-		respW := httptest.NewRecorder()
+		respW := testutil.NewResponseRecorder()
 		errCh := make(chan error)
 		go func() {
 			_, err := s.Server.Logs(respW, req)
@@ -445,7 +442,7 @@ func TestHTTP_FS_Logs_Follow(t *testing.T) {
 
 		out := ""
 		testutil.WaitForResult(func() (bool, error) {
-			output, err := ioutil.ReadAll(respW.Body)
+			output, err := ioutil.ReadAll(respW)
 			if err != nil {
 				return false, err
 			}

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -211,37 +211,46 @@ func TestHTTP_FS_Stream_MissingParams(t *testing.T) {
 	})
 }
 
+// TestHTTP_FS_Logs_MissingParams asserts proper error codes and messages are
+// returned for incorrect parameters (eg missing tasks).
 func TestHTTP_FS_Logs_MissingParams(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	httpTest(t, nil, func(s *TestAgent) {
+		// AllocID Not Present
 		req, err := http.NewRequest("GET", "/v1/client/fs/logs/", nil)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 
-		_, err = s.Server.Logs(respW, req)
-		require.EqualError(err, allocIDNotPresentErr.Error())
+		s.Server.mux.ServeHTTP(respW, req)
+		require.Equal(respW.Body.String(), allocIDNotPresentErr.Error())
+		require.Equal(500, respW.Code) // 500 for backward compat
 
+		// Task Not Present
 		req, err = http.NewRequest("GET", "/v1/client/fs/logs/foo", nil)
 		require.Nil(err)
 		respW = httptest.NewRecorder()
 
-		_, err = s.Server.Logs(respW, req)
-		require.EqualError(err, taskNotPresentErr.Error())
+		s.Server.mux.ServeHTTP(respW, req)
+		require.Equal(respW.Body.String(), taskNotPresentErr.Error())
+		require.Equal(500, respW.Code) // 500 for backward compat
 
+		// Log Type Not Present
 		req, err = http.NewRequest("GET", "/v1/client/fs/logs/foo?task=foo", nil)
 		require.Nil(err)
 		respW = httptest.NewRecorder()
 
-		_, err = s.Server.Logs(respW, req)
-		require.EqualError(err, logTypeNotPresentErr.Error())
+		s.Server.mux.ServeHTTP(respW, req)
+		require.Equal(respW.Body.String(), logTypeNotPresentErr.Error())
+		require.Equal(500, respW.Code) // 500 for backward compat
 
+		// Ok
 		req, err = http.NewRequest("GET", "/v1/client/fs/logs/foo?task=foo&type=stdout", nil)
 		require.Nil(err)
 		respW = httptest.NewRecorder()
 
-		_, err = s.Server.Logs(respW, req)
-		require.Nil(err)
+		s.Server.mux.ServeHTTP(respW, req)
+		require.Equal(200, respW.Code)
 	})
 }
 

--- a/command/agent/helpers.go
+++ b/command/agent/helpers.go
@@ -12,7 +12,7 @@ func (s *HTTPServer) rpcHandlerForAlloc(allocID string) (localClient, remoteClie
 	if c != nil {
 		// If there is an error it means that the client doesn't have the
 		// allocation so we can't use the local client
-		_, err := c.GetClientAlloc(allocID)
+		_, err := c.GetAllocState(allocID)
 		if err == nil {
 			localAlloc = true
 		}

--- a/testutil/responsewriter.go
+++ b/testutil/responsewriter.go
@@ -1,0 +1,76 @@
+package testutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+)
+
+// assert ResponseRecorder implements the http.ResponseWriter interface
+var _ http.ResponseWriter = (*ResponseRecorder)(nil)
+
+// ResponseRecorder implements a ResponseWriter which can be written to and
+// read from concurrently. For use in testing streaming APIs where
+// httptest.ResponseRecorder is unsafe for concurrent access. Uses
+// httptest.ResponseRecorder internally and exposes most of the functionality.
+type ResponseRecorder struct {
+	rr *httptest.ResponseRecorder
+	mu sync.Mutex
+}
+
+func NewResponseRecorder() *ResponseRecorder {
+	return &ResponseRecorder{
+		rr: httptest.NewRecorder(),
+	}
+}
+
+// Flush sets Flushed=true.
+func (r *ResponseRecorder) Flush() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rr.Flush()
+}
+
+// Flushed returns true if Flush has been called.
+func (r *ResponseRecorder) Flushed() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rr.Flushed
+}
+
+// Header returns the response headers. Readers should call HeaderMap() to
+// avoid races due to the server concurrently mutating headers.
+func (r *ResponseRecorder) Header() http.Header {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rr.Header()
+}
+
+// HeaderMap returns the HTTP headers written before WriteHeader was called.
+func (r *ResponseRecorder) HeaderMap() http.Header {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rr.HeaderMap
+}
+
+// Write to the underlying response buffer. Safe to call concurrent with Read.
+func (r *ResponseRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rr.Body.Write(p)
+}
+
+// WriteHeader sets the response code and freezes the headers returned by
+// HeaderMap. Safe to call concurrent with Read and HeaderMap.
+func (r *ResponseRecorder) WriteHeader(statusCode int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rr.WriteHeader(statusCode)
+}
+
+// Read available response bytes. Safe to call concurrently with Write().
+func (r *ResponseRecorder) Read(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rr.Body.Read(p)
+}

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -87,42 +87,40 @@ func WaitForLeader(t testing.T, rpc rpcFn) {
 	})
 }
 
-// WaitForRunning runs a job and blocks until it is running.
-func WaitForRunning(t testing.T, rpc rpcFn, job *structs.Job) {
-	registered := false
+// WaitForRunning runs a job and blocks until all allocs are out of pending.
+func WaitForRunning(t testing.T, rpc rpcFn, job *structs.Job) []*structs.AllocListStub {
 	WaitForResult(func() (bool, error) {
-		if !registered {
-			args := &structs.JobRegisterRequest{}
-			args.Job = job
-			args.WriteRequest.Region = "global"
-			var jobResp structs.JobRegisterResponse
-			err := rpc("Job.Register", args, &jobResp)
-			if err != nil {
-				return false, fmt.Errorf("Job.Register error: %v", err)
-			}
+		args := &structs.JobRegisterRequest{}
+		args.Job = job
+		args.WriteRequest.Region = "global"
+		var jobResp structs.JobRegisterResponse
+		err := rpc("Job.Register", args, &jobResp)
+		return err == nil, fmt.Errorf("Job.Register error: %v", err)
+	}, func(err error) {
+		t.Fatalf("error registering job: %v", err)
+	})
 
-			// Only register once
-			registered = true
-		}
+	t.Logf("Job %q registered", job.ID)
 
-		args := &structs.JobSummaryRequest{}
+	var resp structs.JobAllocationsResponse
+
+	WaitForResult(func() (bool, error) {
+		args := &structs.JobSpecificRequest{}
 		args.JobID = job.ID
 		args.QueryOptions.Region = "global"
-		var resp structs.JobSummaryResponse
-		err := rpc("Job.Summary", args, &resp)
+		err := rpc("Job.Allocations", args, &resp)
 		if err != nil {
-			return false, fmt.Errorf("Job.Summary error: %v", err)
+			return false, fmt.Errorf("Job.Allocations error: %v", err)
 		}
 
-		tgs := len(job.TaskGroups)
-		summaries := len(resp.JobSummary.Summary)
-		if tgs != summaries {
-			return false, fmt.Errorf("task_groups=%d summaries=%d", tgs, summaries)
+		if len(resp.Allocations) == 0 {
+			return false, fmt.Errorf("0 allocations")
 		}
 
-		for tg, summary := range resp.JobSummary.Summary {
-			if summary.Running == 0 {
-				return false, fmt.Errorf("task_group=%s %#v", tg, resp.JobSummary.Summary)
+		for _, alloc := range resp.Allocations {
+			if alloc.ClientStatus != structs.AllocClientStatusRunning {
+				return false, fmt.Errorf("alloc not running: id=%v tg=%v status=%v",
+					alloc.ID, alloc.TaskGroup, alloc.ClientStatus)
 			}
 		}
 
@@ -130,4 +128,6 @@ func WaitForRunning(t testing.T, rpc rpcFn, job *structs.Job) {
 	}, func(err error) {
 		t.Fatalf("job not running: %v", err)
 	})
+
+	return resp.Allocations
 }


### PR DESCRIPTION
Depends on #4695 

Fixing log streaming was relatively easy. However in order to fix log streaming tests I had to fix TaskRunner's exit handling. There was a race in TaskRunner's exit handling where multiple receivers raced to receive the WaitResult from `handle.WaitCh()`. Depending on who won TaskRunner could deadlock or not update the server state.

The handle proxy is a bit ugly but allows all receivers to view the WaitResult. Destroying a TaskRunner should work more reliably as well because TR.Kill wasn't cancelling TR's context. The behavior of TR's context is very subtle which is unfortunate. More direct testing of TaskRunner's lifecycle handling is necessary, but this PR is already covering too many disparate areas.