### PR TITLE
Scheduler config API 

### DIFF
--- a/api/operator.go
+++ b/api/operator.go
@@ -110,13 +110,18 @@ func (op *Operator) RaftRemovePeerByID(id string, q *WriteOptions) error {
 }
 
 type SchedulerConfiguration struct {
-	// EnablePreemption specifies whether to enable eviction of lower
+	// PreemptionConfig specifies whether to enable eviction of lower
 	// priority jobs to place higher priority jobs.
-	EnablePreemption bool
+	PreemptionConfig PreemptionConfig
 
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+// PreemptionConfig specifies whether preemption is enabled based on scheduler type
+type PreemptionConfig struct {
+	SystemSchedulerEnabled bool
 }
 
 // SchedulerGetConfiguration is used to query the current Scheduler configuration.

--- a/api/operator_test.go
+++ b/api/operator_test.go
@@ -3,6 +3,9 @@ package api
 import (
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/testutil/retry"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOperator_RaftGetConfiguration(t *testing.T) {
@@ -49,5 +52,68 @@ func TestOperator_RaftRemovePeerByID(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(),
 		"id \"nope\" was not found in the Raft configuration") {
 		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAPI_OperatorSchedulerGetSetConfiguration(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+
+	operator := c.Operator()
+	var config *SchedulerConfiguration
+	retry.Run(t, func(r *retry.R) {
+		var err error
+		config, _, err = operator.SchedulerGetConfiguration(nil)
+		r.Check(err)
+	})
+	require.False(config.EnablePreemption)
+
+	// Change a config setting
+	newConf := &SchedulerConfiguration{EnablePreemption: true}
+	_, err := operator.SchedulerSetConfiguration(newConf, nil)
+	require.Nil(err)
+
+	config, _, err = operator.SchedulerGetConfiguration(nil)
+	require.Nil(err)
+	require.True(config.EnablePreemption)
+}
+
+func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+
+	operator := c.Operator()
+	var config *SchedulerConfiguration
+	retry.Run(t, func(r *retry.R) {
+		var err error
+		config, _, err = operator.SchedulerGetConfiguration(nil)
+		r.Check(err)
+	})
+	require.False(config.EnablePreemption)
+
+	// Pass an invalid ModifyIndex
+	{
+		newConf := &SchedulerConfiguration{
+			EnablePreemption: true,
+			ModifyIndex:      config.ModifyIndex - 1,
+		}
+		resp, _, err := operator.SchedulerCASConfiguration(newConf, nil)
+		require.Nil(err)
+		require.False(resp)
+	}
+
+	// Pass a valid ModifyIndex
+	{
+		newConf := &SchedulerConfiguration{
+			EnablePreemption: true,
+			ModifyIndex:      config.ModifyIndex,
+		}
+		resp, _, err := operator.SchedulerCASConfiguration(newConf, nil)
+		require.Nil(err)
+		require.True(resp)
 	}
 }

--- a/api/operator_test.go
+++ b/api/operator_test.go
@@ -68,16 +68,16 @@ func TestAPI_OperatorSchedulerGetSetConfiguration(t *testing.T) {
 		config, _, err = operator.SchedulerGetConfiguration(nil)
 		r.Check(err)
 	})
-	require.False(config.EnablePreemption)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
 
 	// Change a config setting
-	newConf := &SchedulerConfiguration{EnablePreemption: true}
+	newConf := &SchedulerConfiguration{PreemptionConfig: PreemptionConfig{SystemSchedulerEnabled: false}}
 	_, err := operator.SchedulerSetConfiguration(newConf, nil)
 	require.Nil(err)
 
 	config, _, err = operator.SchedulerGetConfiguration(nil)
 	require.Nil(err)
-	require.True(config.EnablePreemption)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
 }
 
 func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
@@ -93,12 +93,12 @@ func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
 		config, _, err = operator.SchedulerGetConfiguration(nil)
 		r.Check(err)
 	})
-	require.False(config.EnablePreemption)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
 
 	// Pass an invalid ModifyIndex
 	{
 		newConf := &SchedulerConfiguration{
-			EnablePreemption: true,
+			PreemptionConfig: PreemptionConfig{SystemSchedulerEnabled: false},
 			ModifyIndex:      config.ModifyIndex - 1,
 		}
 		resp, _, err := operator.SchedulerCASConfiguration(newConf, nil)
@@ -109,7 +109,7 @@ func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
 	// Pass a valid ModifyIndex
 	{
 		newConf := &SchedulerConfiguration{
-			EnablePreemption: true,
+			PreemptionConfig: PreemptionConfig{SystemSchedulerEnabled: false},
 			ModifyIndex:      config.ModifyIndex,
 		}
 		resp, _, err := operator.SchedulerCASConfiguration(newConf, nil)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -194,6 +194,8 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/system/gc", s.wrap(s.GarbageCollectRequest))
 	s.mux.HandleFunc("/v1/system/reconcile/summaries", s.wrap(s.ReconcileJobSummaries))
 
+	s.mux.HandleFunc("/v1/operator/scheduler/config", s.wrap(s.OperatorSchedulerConfiguration))
+
 	if uiEnabled {
 		s.mux.Handle("/ui/", http.StripPrefix("/ui/", handleUI(http.FileServer(&UIAssetWrapper{FileSystem: assetFS()}))))
 	} else {

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -226,7 +226,7 @@ func (s *HTTPServer) OperatorSchedulerConfiguration(resp http.ResponseWriter, re
 		}
 
 		out := api.SchedulerConfiguration{
-			EnablePreemption: reply.EnablePreemption,
+			PreemptionConfig: api.PreemptionConfig{SystemSchedulerEnabled: reply.PreemptionConfig.SystemSchedulerEnabled},
 			CreateIndex:      reply.CreateIndex,
 			ModifyIndex:      reply.ModifyIndex,
 		}
@@ -239,11 +239,11 @@ func (s *HTTPServer) OperatorSchedulerConfiguration(resp http.ResponseWriter, re
 
 		var conf api.SchedulerConfiguration
 		if err := decodeBody(req, &conf); err != nil {
-			return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("Error parsing autopilot config: %v", err))
+			return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("Error parsing scheduler config: %v", err))
 		}
 
 		args.Config = structs.SchedulerConfiguration{
-			EnablePreemption: conf.EnablePreemption,
+			PreemptionConfig: structs.PreemptionConfig{SystemSchedulerEnabled: conf.PreemptionConfig.SystemSchedulerEnabled},
 		}
 
 		// Check for cas value

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -247,6 +247,8 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyNodeEligibilityUpdate(buf[1:], log.Index)
 	case structs.BatchNodeUpdateDrainRequestType:
 		return n.applyBatchDrainUpdate(buf[1:], log.Index)
+	case structs.SchedulerConfigRequestType:
+		return n.applySchedulerConfigUpdate(buf[1:], log.Index)
 	}
 
 	// Check enterprise only message types.
@@ -1838,6 +1840,23 @@ func (s *nomadSnapshot) persistACLTokens(sink raft.SnapshotSink,
 		}
 	}
 	return nil
+}
+
+func (n *nomadFSM) applySchedulerConfigUpdate(buf []byte, index uint64) interface{} {
+	var req structs.SchedulerSetConfigRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "scheduler-config"}, time.Now())
+
+	if req.CAS {
+		act, err := n.state.SchedulerCASConfig(index, req.Config.ModifyIndex, &req.Config)
+		if err != nil {
+			return err
+		}
+		return act
+	}
+	return n.state.SchedulerSetConfig(index, &req.Config)
 }
 
 // Release is a no-op, as we just need to GC the pointer

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2832,7 +2832,9 @@ func TestFSM_SchedulerConfig(t *testing.T) {
 	// Set the autopilot config using a request.
 	req := structs.SchedulerSetConfigRequest{
 		Config: structs.SchedulerConfiguration{
-			EnablePreemption: true,
+			PreemptionConfig: structs.PreemptionConfig{
+				SystemSchedulerEnabled: true,
+			},
 		},
 	}
 	buf, err := structs.Encode(structs.SchedulerConfigRequestType, req)
@@ -2847,11 +2849,11 @@ func TestFSM_SchedulerConfig(t *testing.T) {
 	_, config, err := fsm.state.SchedulerConfig()
 	require.Nil(err)
 
-	require.Equal(config.EnablePreemption, req.Config.EnablePreemption)
+	require.Equal(config.PreemptionConfig.SystemSchedulerEnabled, req.Config.PreemptionConfig.SystemSchedulerEnabled)
 
 	// Now use CAS and provide an old index
 	req.CAS = true
-	req.Config.EnablePreemption = false
+	req.Config.PreemptionConfig = structs.PreemptionConfig{SystemSchedulerEnabled: false}
 	req.Config.ModifyIndex = config.ModifyIndex - 1
 	buf, err = structs.Encode(structs.SchedulerConfigRequestType, req)
 	require.Nil(err)
@@ -2864,5 +2866,5 @@ func TestFSM_SchedulerConfig(t *testing.T) {
 	_, config, err = fsm.state.SchedulerConfig()
 	require.Nil(err)
 	// Verify that preemption is still enabled
-	require.True(config.EnablePreemption)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
 }

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2822,3 +2822,47 @@ func TestFSM_Autopilot(t *testing.T) {
 		t.Fatalf("bad: %v", config.CleanupDeadServers)
 	}
 }
+
+func TestFSM_SchedulerConfig(t *testing.T) {
+	t.Parallel()
+	fsm := testFSM(t)
+
+	require := require.New(t)
+
+	// Set the autopilot config using a request.
+	req := structs.SchedulerSetConfigRequest{
+		Config: structs.SchedulerConfiguration{
+			EnablePreemption: true,
+		},
+	}
+	buf, err := structs.Encode(structs.SchedulerConfigRequestType, req)
+	require.Nil(err)
+
+	resp := fsm.Apply(makeLog(buf))
+	if _, ok := resp.(error); ok {
+		t.Fatalf("bad: %v", resp)
+	}
+
+	// Verify key is set directly in the state store.
+	_, config, err := fsm.state.SchedulerConfig()
+	require.Nil(err)
+
+	require.Equal(config.EnablePreemption, req.Config.EnablePreemption)
+
+	// Now use CAS and provide an old index
+	req.CAS = true
+	req.Config.EnablePreemption = false
+	req.Config.ModifyIndex = config.ModifyIndex - 1
+	buf, err = structs.Encode(structs.SchedulerConfigRequestType, req)
+	require.Nil(err)
+
+	resp = fsm.Apply(makeLog(buf))
+	if _, ok := resp.(error); ok {
+		t.Fatalf("bad: %v", resp)
+	}
+
+	_, config, err = fsm.state.SchedulerConfig()
+	require.Nil(err)
+	// Verify that preemption is still enabled
+	require.True(config.EnablePreemption)
+}

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1246,7 +1246,7 @@ func (s *Server) getOrCreateSchedulerConfig() *structs.SchedulerConfiguration {
 		return config
 	}
 
-	config = &structs.SchedulerConfiguration{EnablePreemption: false}
+	config = &structs.SchedulerConfiguration{PreemptionConfig: structs.PreemptionConfig{SystemSchedulerEnabled: true}}
 	req := structs.SchedulerSetConfigRequest{Config: *config}
 	if _, _, err = s.raftApply(structs.SchedulerConfigRequestType, req); err != nil {
 		s.logger.Named("core").Error("failed to initialize config", "error", err)

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -44,6 +44,7 @@ func init() {
 		aclPolicyTableSchema,
 		aclTokenTableSchema,
 		autopilotConfigTableSchema,
+		schedulerConfigTableSchema,
 	}...)
 }
 
@@ -594,6 +595,24 @@ func aclTokenTableSchema() *memdb.TableSchema {
 				Unique:       false,
 				Indexer: &memdb.FieldSetIndex{
 					Field: "Global",
+				},
+			},
+		},
+	}
+}
+
+// schedulerConfigTableSchema returns the MemDB schema for the scheduler config table.
+// This table is used to store configuration options for the scheduler
+func schedulerConfigTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "scheduler_config",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": {
+				Name:         "id",
+				AllowMissing: true,
+				Unique:       true,
+				Indexer: &memdb.ConditionalIndex{
+					Conditional: func(obj interface{}) (bool, error) { return true, nil },
 				},
 			},
 		},

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4017,3 +4017,81 @@ func (r *StateRestore) addEphemeralDiskToTaskGroups(job *structs.Job) {
 		}
 	}
 }
+
+// SchedulerConfig is used to get the current Scheduler configuration.
+func (s *StateStore) SchedulerConfig() (uint64, *structs.SchedulerConfiguration, error) {
+	tx := s.db.Txn(false)
+	defer tx.Abort()
+
+	// Get the scheduler config
+	c, err := tx.First("scheduler_config", "id")
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed scheduler config lookup: %s", err)
+	}
+
+	config, ok := c.(*structs.SchedulerConfiguration)
+	if !ok {
+		return 0, nil, nil
+	}
+
+	return config.ModifyIndex, config, nil
+}
+
+// SchedulerSetConfig is used to set the current Scheduler configuration.
+func (s *StateStore) SchedulerSetConfig(idx uint64, config *structs.SchedulerConfiguration) error {
+	tx := s.db.Txn(true)
+	defer tx.Abort()
+
+	s.schedulerSetConfigTxn(idx, tx, config)
+
+	tx.Commit()
+	return nil
+}
+
+// SchedulerCASConfig is used to try updating the scheduler configuration with a
+// given Raft index. If the CAS index specified is not equal to the last observed index
+// for the config, then the call is a noop,
+func (s *StateStore) SchedulerCASConfig(idx, cidx uint64, config *structs.SchedulerConfiguration) (bool, error) {
+	tx := s.db.Txn(true)
+	defer tx.Abort()
+
+	// Check for an existing config
+	existing, err := tx.First("scheduler_config", "id")
+	if err != nil {
+		return false, fmt.Errorf("failed scheduler config lookup: %s", err)
+	}
+
+	// If the existing index does not match the provided CAS
+	// index arg, then we shouldn't update anything and can safely
+	// return early here.
+	e, ok := existing.(*structs.SchedulerConfiguration)
+	if !ok || e.ModifyIndex != cidx {
+		return false, nil
+	}
+
+	s.schedulerSetConfigTxn(idx, tx, config)
+
+	tx.Commit()
+	return true, nil
+}
+
+func (s *StateStore) schedulerSetConfigTxn(idx uint64, tx *memdb.Txn, config *structs.SchedulerConfiguration) error {
+	// Check for an existing config
+	existing, err := tx.First("scheduler_config", "id")
+	if err != nil {
+		return fmt.Errorf("failed scheduler config lookup: %s", err)
+	}
+
+	// Set the indexes.
+	if existing != nil {
+		config.CreateIndex = existing.(*structs.SchedulerConfiguration).CreateIndex
+	} else {
+		config.CreateIndex = idx
+	}
+	config.ModifyIndex = idx
+
+	if err := tx.Insert("scheduler_config", config); err != nil {
+		return fmt.Errorf("failed updating scheduler config: %s", err)
+	}
+	return nil
+}

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -119,3 +119,26 @@ type AutopilotConfig struct {
 	CreateIndex uint64
 	ModifyIndex uint64
 }
+
+type SchedulerConfiguration struct {
+	// EnablePreemption specifies whether to enable eviction of lower
+	// priority jobs to place higher priority jobs.
+	EnablePreemption bool
+
+	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// SchedulerSetConfigRequest is used by the Operator endpoint to update the
+// current Scheduler configuration of the cluster.
+type SchedulerSetConfigRequest struct {
+	// Config is the new Scheduler configuration to use.
+	Config SchedulerConfiguration
+
+	// CAS controls whether to use check-and-set semantics for this request.
+	CAS bool
+
+	// WriteRequest holds the ACL token to go along with this request.
+	WriteRequest
+}

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -121,13 +121,19 @@ type AutopilotConfig struct {
 }
 
 type SchedulerConfiguration struct {
-	// EnablePreemption specifies whether to enable eviction of lower
+	// PreemptionConfig specifies whether to enable eviction of lower
 	// priority jobs to place higher priority jobs.
-	EnablePreemption bool
+	PreemptionConfig PreemptionConfig
 
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+// PreemptionConfig specifies whether preemption is enabled based on scheduler type
+type PreemptionConfig struct {
+	// SystemSchedulerEnabled specifies if preemption is enabled for system jobs
+	SystemSchedulerEnabled bool
 }
 
 // SchedulerSetConfigRequest is used by the Operator endpoint to update the

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -83,6 +83,7 @@ const (
 	AllocUpdateDesiredTransitionRequestType
 	NodeUpdateEligibilityRequestType
 	BatchNodeUpdateDrainRequestType
+	SchedulerConfigRequestType
 )
 
 const (

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -88,6 +88,9 @@ type State interface {
 	// LatestDeploymentByJobID returns the latest deployment matching the given
 	// job ID
 	LatestDeploymentByJobID(ws memdb.WatchSet, namespace, jobID string) (*structs.Deployment, error)
+
+	// SchedulerConfig returns config options for the scheduler
+	SchedulerConfig() (uint64, *structs.SchedulerConfiguration, error)
 }
 
 // Planner interface is used to submit a task allocation plan.

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -283,9 +283,9 @@ func NewSystemStack(ctx Context) *SystemStack {
 	// by a particular task group. Enable eviction as system jobs are high
 	// priority.
 	_, schedConfig, _ := s.ctx.State().SchedulerConfig()
-	enablePreemption := false
+	enablePreemption := true
 	if schedConfig != nil {
-		enablePreemption = schedConfig.EnablePreemption
+		enablePreemption = schedConfig.PreemptionConfig.SystemSchedulerEnabled
 	}
 	s.binPack = NewBinPackIterator(ctx, rankSource, enablePreemption, 0)
 

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -105,10 +105,9 @@ func NewGenericStack(batch bool, ctx Context) *GenericStack {
 	rankSource := NewFeasibleRankIterator(ctx, s.distinctPropertyConstraint)
 
 	// Apply the bin packing, this depends on the resources needed
-	// by a particular task group. Only enable eviction for the service
-	// scheduler as that logic is expensive.
-	evict := !batch
-	s.binPack = NewBinPackIterator(ctx, rankSource, evict, 0)
+	// by a particular task group.
+
+	s.binPack = NewBinPackIterator(ctx, rankSource, false, 0)
 
 	// Apply the job anti-affinity iterator. This is to avoid placing
 	// multiple allocations on the same node for this job.
@@ -283,7 +282,12 @@ func NewSystemStack(ctx Context) *SystemStack {
 	// Apply the bin packing, this depends on the resources needed
 	// by a particular task group. Enable eviction as system jobs are high
 	// priority.
-	s.binPack = NewBinPackIterator(ctx, rankSource, true, 0)
+	_, schedConfig, _ := s.ctx.State().SchedulerConfig()
+	enablePreemption := false
+	if schedConfig != nil {
+		enablePreemption = schedConfig.EnablePreemption
+	}
+	s.binPack = NewBinPackIterator(ctx, rankSource, enablePreemption, 0)
 
 	// Apply score normalization
 	s.scoreNorm = NewScoreNormalizationIterator(ctx, s.binPack)

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -242,6 +242,9 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 	node := mock.Node()
 	noErr(t, h.State.UpsertNode(h.NextIndex(), node))
 
+	// Enable Preemption
+	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{EnablePreemption: true})
+
 	// Create a service job which consumes most of the system resources
 	svcJob := mock.Job()
 	svcJob.TaskGroups[0].Count = 1
@@ -1572,6 +1575,9 @@ func TestSystemSched_Preemption(t *testing.T) {
 		noErr(t, h.State.UpsertNode(h.NextIndex(), node))
 		nodes = append(nodes, node)
 	}
+
+	// Enable Preemption
+	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{EnablePreemption: true})
 
 	// Create some low priority batch jobs and allocations for them
 	// One job uses a reserved port

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -243,7 +243,11 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 	noErr(t, h.State.UpsertNode(h.NextIndex(), node))
 
 	// Enable Preemption
-	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{EnablePreemption: true})
+	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{
+		PreemptionConfig: structs.PreemptionConfig{
+			SystemSchedulerEnabled: true,
+		},
+	})
 
 	// Create a service job which consumes most of the system resources
 	svcJob := mock.Job()
@@ -1577,7 +1581,11 @@ func TestSystemSched_Preemption(t *testing.T) {
 	}
 
 	// Enable Preemption
-	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{EnablePreemption: true})
+	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{
+		PreemptionConfig: structs.PreemptionConfig{
+			SystemSchedulerEnabled: true,
+		},
+	})
 
 	// Create some low priority batch jobs and allocations for them
 	// One job uses a reserved port


### PR DESCRIPTION
Adds new state store table, raft operation and API support for scheduler configuration. Scheduler configs are per cluster (region), and the initial use case is to enable/disable preemption. 

This PR also includes wiring up reading the config in the system scheduler.