### PR TITLE
docs: fix links in task job specification

### DIFF
--- a/website/source/docs/job-specification/task.html.md
+++ b/website/source/docs/job-specification/task.html.md
@@ -196,6 +196,7 @@ task "server" {
 [resources]: /docs/job-specification/resources.html "Nomad resources Job Specification"
 [logs]: /docs/job-specification/logs.html "Nomad logs Job Specification"
 [service]: /guides/operations/consul-integration/index.html#service-discovery/index.html "Nomad Service Discovery"
+[vault]: /docs/job-specification/vault.html "Nomad vault Job Specification"
 [exec]: /docs/drivers/exec.html "Nomad exec Driver"
 [java]: /docs/drivers/java.html "Nomad Java Driver"
 [Docker]: /docs/drivers/docker.html "Nomad Docker Driver"

--- a/website/source/docs/job-specification/task.html.md
+++ b/website/source/docs/job-specification/task.html.md
@@ -161,7 +161,7 @@ task "server" {
 ### Service Discovery
 
 This example creates a service in Consul. To read more about service discovery
-in Nomad, please see the [Nomad service discovery documentation][service].
+in Nomad, please see the [Nomad service discovery documentation][service_discovery].
 
 ```hcl
 task "server" {
@@ -195,12 +195,13 @@ task "server" {
 [meta]: /docs/job-specification/meta.html "Nomad meta Job Specification"
 [resources]: /docs/job-specification/resources.html "Nomad resources Job Specification"
 [logs]: /docs/job-specification/logs.html "Nomad logs Job Specification"
-[service]: /guides/operations/consul-integration/index.html#service-discovery/index.html "Nomad Service Discovery"
+[service]: /docs/job-specification/service.html "Nomad service Job Specification"
 [vault]: /docs/job-specification/vault.html "Nomad vault Job Specification"
 [exec]: /docs/drivers/exec.html "Nomad exec Driver"
 [java]: /docs/drivers/java.html "Nomad Java Driver"
 [Docker]: /docs/drivers/docker.html "Nomad Docker Driver"
 [rkt]: /docs/drivers/rkt.html "Nomad rkt Driver"
+[service_discovery]: /guides/operations/consul-integration/index.html#service-discovery/index.html "Nomad Service Discovery"
 [template]: /docs/job-specification/template.html "Nomad template Job Specification"
 [user_drivers]: /docs/configuration/client.html#_quot_user_checked_drivers_quot_
 [user_blacklist]: /docs/configuration/client.html#_quot_user_blacklist_quot_


### PR DESCRIPTION
### What was the issue

- The `vault` task parameter hadn't any link set
- The `service` task parameter has the same target than the service discovery documentation (e.g. https://www.nomadproject.io/docs/job-specification/service.html  versus https://www.nomadproject.io/guides/operations/consul-integration/index.html#service-discovery/index.html )

### What changes

- link to the Vault job spec documentation has been added
- the service link targets have been split in `[service]` and `[service_discovery]` to keep it unchanged for the service discovery example, but fix the link in the task parameter list for the `service (Service: nil)` entry

### Open question (potential changes?)

As I tried to fix the links, I wasn't sure if any convention existed for the link references:

The list looks like alphabetically ordered, but not exactly. 
It's not by apparition ordering either (e.g. max_kill wouldn't be at the end)

Therefore I wasn't sure where to put the links. Any guidance or suggestion to improve this is welcome.
