### PR TITLE
Separate BatchJobDeregister evals updates

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -522,7 +522,7 @@ func (n *nomadFSM) applyBatchDeregisterJob(buf []byte, index uint64) interface{}
 		}
 	}
 
-	return n.upsertEvals(index, req.Evals)
+	return nil
 }
 
 // handleJobDeregister is used to deregister a job.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -472,9 +472,6 @@ type JobBatchDeregisterRequest struct {
 	// Jobs is the set of jobs to deregister
 	Jobs map[NamespacedID]*JobDeregisterOptions
 
-	// Evals is the set of evaluations to create.
-	Evals []*Evaluation
-
 	WriteRequest
 }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/4299

There is a race between job purging and job-deregister evaluations
handling that seem to cause completed jobs to re-run unexpectedly when
they are being GCed.

Here, we make `BatchDeregister` behave just like `Deregister`, where we
submit the `job-deregister` evals after `JobBatchDeregisterRequest` is
committed to raft.

Open Questions:
* [ ] How can we test this racey behavior effectively in local/integration tests?
  * I have run this patch with my test environment setup in https://github.com/notnoopci/nomad-0.8.3-job-rerun-bug for over 12 hours, ran ~12k jobs, with ~7k gc invocation and ~211 invocations of BatchDeregister over that period without ever invoking the race and running a batch job multiple times -- while the bug would occur for as little as 15 minutes without this patch.