### PR TITLE
Add support for nomad task emitting stdout/stderr with file suffix

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -610,8 +610,9 @@ func (g *TaskGroup) AddSpread(s *Spread) *TaskGroup {
 
 // LogConfig provides configuration for log rotation
 type LogConfig struct {
-	MaxFiles      *int `mapstructure:"max_files"`
-	MaxFileSizeMB *int `mapstructure:"max_file_size"`
+	MaxFiles      *int    `mapstructure:"max_files"`
+	MaxFileSizeMB *int    `mapstructure:"max_file_size"`
+	Suffix        *string `mapstructure:"suffix"`
 }
 
 func DefaultLogConfig() *LogConfig {

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -65,6 +65,7 @@ func dockerTask(t *testing.T) (*structs.Task, int, int) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 256,
@@ -313,6 +314,7 @@ func TestDockerDriver_StartOpen_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -370,6 +372,7 @@ func TestDockerDriver_Start_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 	}
 
@@ -419,6 +422,7 @@ func TestDockerDriver_Start_StoppedContainer(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      1,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 	}
 
@@ -486,6 +490,7 @@ func TestDockerDriver_Start_LoadImage(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 256,
@@ -554,6 +559,7 @@ func TestDockerDriver_Start_BadPull_Recoverable(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 256,
@@ -607,6 +613,7 @@ func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 256,
@@ -670,6 +677,7 @@ func TestDockerDriver_Start_Kill_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -715,6 +723,7 @@ func TestDockerDriver_Start_KillTimeout(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources:   basicResources,
 		KillTimeout: timeout,
@@ -913,6 +922,7 @@ func TestDockerDriver_NetworkMode_Host(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 	}
 
@@ -971,6 +981,7 @@ func TestDockerDriver_NetworkAliases_Bridge(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 	}
 
@@ -1565,6 +1576,7 @@ func TestDockerDriver_User(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 	}
 
@@ -1616,6 +1628,7 @@ func TestDockerDriver_CleanupContainer(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 	}
 
@@ -1667,6 +1680,7 @@ func TestDockerDriver_Stats(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -1726,6 +1740,7 @@ func setupDockerVolumes(t *testing.T, cfg *config.Config, hostpath string) (*str
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -2044,6 +2059,7 @@ func TestDockerDriver_Mounts(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 	}
 
@@ -2215,6 +2231,7 @@ func TestDockerDriver_OOMKilled(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			CPU:      250,
@@ -2377,6 +2394,7 @@ func TestDockerDriver_Kill(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -2485,6 +2503,7 @@ func TestDockerDriver_AdvertiseIPv6Address(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 	}
 

--- a/client/driver/docker_unix_test.go
+++ b/client/driver/docker_unix_test.go
@@ -39,6 +39,7 @@ func TestDockerDriver_Signal(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 	}
 

--- a/client/driver/exec_test.go
+++ b/client/driver/exec_test.go
@@ -95,6 +95,7 @@ func TestExecDriver_StartOpen_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -139,6 +140,7 @@ func TestExecDriver_Start_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -193,6 +195,7 @@ func TestExecDriver_Start_Wait_AllocDir(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -246,6 +249,7 @@ func TestExecDriver_Start_Kill_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources:   basicResources,
 		KillTimeout: 10 * time.Second,
@@ -298,6 +302,7 @@ func TestExecDriverUser(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources:   basicResources,
 		KillTimeout: 10 * time.Second,
@@ -338,6 +343,7 @@ func TestExecDriver_HandlerExec(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}

--- a/client/driver/exec_unix_test.go
+++ b/client/driver/exec_unix_test.go
@@ -33,6 +33,7 @@ func TestExecDriver_KillUserPid_OnPluginReconnectFailure(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -105,6 +106,7 @@ func TestExecDriver_Signal(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources:   basicResources,
 		KillTimeout: 10 * time.Second,

--- a/client/driver/executor/executor.go
+++ b/client/driver/executor/executor.go
@@ -359,7 +359,7 @@ func (e *UniversalExecutor) configureLoggers() error {
 	logFileSize := int64(e.ctx.Task.LogConfig.MaxFileSizeMB * 1024 * 1024)
 	if e.lro == nil {
 		lro, err := logging.NewFileRotator(e.ctx.LogDir, fmt.Sprintf("%v.stdout", e.ctx.Task.Name),
-			e.ctx.Task.LogConfig.MaxFiles, logFileSize, e.logger)
+			e.ctx.Task.LogConfig.Suffix, e.ctx.Task.LogConfig.MaxFiles, logFileSize, e.logger)
 		if err != nil {
 			return fmt.Errorf("error creating new stdout log file for %q: %v", e.ctx.Task.Name, err)
 		}
@@ -373,7 +373,7 @@ func (e *UniversalExecutor) configureLoggers() error {
 
 	if e.lre == nil {
 		lre, err := logging.NewFileRotator(e.ctx.LogDir, fmt.Sprintf("%v.stderr", e.ctx.Task.Name),
-			e.ctx.Task.LogConfig.MaxFiles, logFileSize, e.logger)
+			e.ctx.Task.LogConfig.Suffix, e.ctx.Task.LogConfig.MaxFiles, logFileSize, e.logger)
 		if err != nil {
 			return fmt.Errorf("error creating new stderr log file for %q: %v", e.ctx.Task.Name, err)
 		}

--- a/client/driver/executor/executor_linux_test.go
+++ b/client/driver/executor/executor_linux_test.go
@@ -149,6 +149,7 @@ func TestExecutor_ClientCleanup(t *testing.T) {
 	ctx, allocDir := testExecutorContextWithChroot(t)
 	ctx.Task.LogConfig.MaxFiles = 1
 	ctx.Task.LogConfig.MaxFileSizeMB = 300
+	ctx.Task.LogConfig.Suffix = ""
 	defer allocDir.Destroy()
 
 	executor := NewExecutor(testlog.Logger(t))

--- a/client/driver/java_test.go
+++ b/client/driver/java_test.go
@@ -95,6 +95,7 @@ func TestJavaDriver_StartOpen_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -151,6 +152,7 @@ func TestJavaDriver_Start_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -217,6 +219,7 @@ func TestJavaDriver_Start_Kill_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -283,6 +286,7 @@ func TestJavaDriver_Signal(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -352,6 +356,7 @@ func TestJavaDriver_User(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -394,6 +399,7 @@ func TestJavaDriver_Start_Wait_Class(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -464,6 +470,7 @@ func TestJavaDriver_Start_Kill(t *testing.T) {
 			LogConfig: &structs.LogConfig{
 				MaxFiles:      10,
 				MaxFileSizeMB: 10,
+				Suffix:        "",
 			},
 			Resources: basicResources,
 		}
@@ -501,6 +508,7 @@ func TestJavaDriver_Start_Kill(t *testing.T) {
 			LogConfig: &structs.LogConfig{
 				MaxFiles:      10,
 				MaxFileSizeMB: 10,
+				Suffix:        "",
 			},
 			Resources: basicResources,
 		}

--- a/client/driver/logging/rotator.go
+++ b/client/driver/logging/rotator.go
@@ -39,6 +39,7 @@ type FileRotator struct {
 
 	path             string // path is the path on the file system where the rotated set of files are opened
 	baseFileName     string // baseFileName is the base file name of the rotated files
+	fileSuffix		 string // fileSuffix is the file name suffix of the rorated Files
 	logFileIdx       int    // logFileIdx is the current index of the rotated files
 	oldestLogFileIdx int    // oldestLogFileIdx is the index of the oldest log file in a path
 
@@ -57,7 +58,7 @@ type FileRotator struct {
 }
 
 // NewFileRotator returns a new file rotator
-func NewFileRotator(path string, baseFile string, maxFiles int,
+func NewFileRotator(path string, baseFile string, suffix string, maxFiles int,
 	fileSize int64, logger *log.Logger) (*FileRotator, error) {
 	rotator := &FileRotator{
 		MaxFiles: maxFiles,
@@ -65,6 +66,7 @@ func NewFileRotator(path string, baseFile string, maxFiles int,
 
 		path:         path,
 		baseFileName: baseFile,
+		fileSuffix:   suffix,
 
 		flushTicker: time.NewTicker(bufferFlushDuration),
 		logger:      logger,

--- a/client/driver/logging/universal_collector.go
+++ b/client/driver/logging/universal_collector.go
@@ -93,7 +93,7 @@ func (s *SyslogCollector) LaunchCollector(ctx *LogCollectorContext) (*SyslogColl
 	//FIXME There's an easier way to get this
 	logdir := ctx.AllocDir.TaskDirs[ctx.TaskName].LogDir
 	lro, err := NewFileRotator(logdir, fmt.Sprintf("%v.stdout", ctx.TaskName),
-		ctx.LogConfig.MaxFiles, logFileSize, s.logger)
+		ctx.LogConfig.Suffix, ctx.LogConfig.MaxFiles, logFileSize, s.logger)
 
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func (s *SyslogCollector) LaunchCollector(ctx *LogCollectorContext) (*SyslogColl
 	s.lro = lro
 
 	lre, err := NewFileRotator(logdir, fmt.Sprintf("%v.stderr", ctx.TaskName),
-		ctx.LogConfig.MaxFiles, logFileSize, s.logger)
+		ctx.LogConfig.Suffix, ctx.LogConfig.MaxFiles, logFileSize, s.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/client/driver/mock_driver.go
+++ b/client/driver/mock_driver.go
@@ -442,7 +442,7 @@ func (h *mockDriverHandle) handleLogging() {
 	// Setup a log rotator
 	logFileSize := int64(h.task.LogConfig.MaxFileSizeMB * 1024 * 1024)
 	lro, err := logging.NewFileRotator(h.ctx.TaskDir.LogDir, fmt.Sprintf("%v.stdout", h.taskName),
-		h.task.LogConfig.MaxFiles, logFileSize, h.logger)
+		h.task.LogConfig.Suffix, h.task.LogConfig.MaxFiles, logFileSize, h.logger)
 	if err != nil {
 		h.exitErr = err
 		close(h.doneCh)

--- a/client/driver/qemu_test.go
+++ b/client/driver/qemu_test.go
@@ -87,6 +87,7 @@ func TestQemuDriver_StartOpen_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			CPU:      500,
@@ -166,6 +167,7 @@ func TestQemuDriver_GracefulShutdown(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			CPU:      1000,
@@ -297,6 +299,7 @@ func TestQemuDriverUser(t *testing.T) {
 			LogConfig: &structs.LogConfig{
 				MaxFiles:      10,
 				MaxFileSizeMB: 10,
+				Suffix:        "",
 			},
 			Resources: &structs.Resources{
 				CPU:      500,
@@ -325,6 +328,7 @@ func TestQemuDriverUser(t *testing.T) {
 			LogConfig: &structs.LogConfig{
 				MaxFiles:      10,
 				MaxFileSizeMB: 10,
+				Suffix:        "",
 			},
 			Resources: &structs.Resources{
 				CPU:      500,
@@ -378,6 +382,7 @@ func TestQemuDriverGetMonitorPathOldQemu(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			CPU:      500,
@@ -437,6 +442,7 @@ func TestQemuDriverGetMonitorPathNewQemu(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			CPU:      500,

--- a/client/driver/raw_exec_test.go
+++ b/client/driver/raw_exec_test.go
@@ -78,6 +78,7 @@ func TestRawExecDriver_StartOpen_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -125,6 +126,7 @@ func TestRawExecDriver_Start_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -176,6 +178,7 @@ func TestRawExecDriver_Start_Wait_AllocDir(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -227,6 +230,7 @@ func TestRawExecDriver_Start_Kill_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -282,6 +286,7 @@ func TestRawExecDriver_Start_Kill_Wait_Cgroup(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 		User:      "root",
@@ -372,6 +377,7 @@ func TestRawExecDriver_HandlerExec(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}

--- a/client/driver/raw_exec_unix_test.go
+++ b/client/driver/raw_exec_unix_test.go
@@ -32,6 +32,7 @@ func TestRawExecDriver_User(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: basicResources,
 	}
@@ -67,6 +68,7 @@ func TestRawExecDriver_Signal(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources:   basicResources,
 		KillTimeout: 10 * time.Second,

--- a/client/driver/rkt_test.go
+++ b/client/driver/rkt_test.go
@@ -99,6 +99,7 @@ func TestRktDriver_Start_DNS(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 128,
@@ -150,6 +151,7 @@ func TestRktDriver_Start_Wait(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 128,
@@ -222,6 +224,7 @@ func TestRktDriver_Start_Wait_Skip_Trust(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 128,
@@ -289,6 +292,7 @@ func TestRktDriver_Start_Wait_AllocDir(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 128,
@@ -351,6 +355,7 @@ func TestRktDriver_UserGroup(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 128,
@@ -407,6 +412,7 @@ func TestRktTrustPrefix(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 128,
@@ -478,6 +484,7 @@ func TestRktDriver_PortMapping(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 256,
@@ -542,6 +549,7 @@ func TestRktDriver_PortsMapping_Host(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 256,
@@ -605,6 +613,7 @@ func TestRktDriver_HandlerExec(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 128,
@@ -677,6 +686,7 @@ func TestRktDriver_Stats(t *testing.T) {
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      10,
 			MaxFileSizeMB: 10,
+			Suffix:        "",
 		},
 		Resources: &structs.Resources{
 			MemoryMB: 128,

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -873,6 +873,7 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 	structsTask.LogConfig = &structs.LogConfig{
 		MaxFiles:      *apiTask.LogConfig.MaxFiles,
 		MaxFileSizeMB: *apiTask.LogConfig.MaxFileSizeMB,
+		Suffix:        *apiTask.LogConfig.Suffix,
 	}
 
 	if l := len(apiTask.Artifacts); l != 0 {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1425,6 +1425,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						LogConfig: &api.LogConfig{
 							MaxFiles:      helper.IntToPtr(10),
 							MaxFileSizeMB: helper.IntToPtr(100),
+							Suffix:        helper.StringToPtr(""),
 						},
 						Artifacts: []*api.TaskArtifact{
 							{
@@ -1699,6 +1700,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						LogConfig: &structs.LogConfig{
 							MaxFiles:      10,
 							MaxFileSizeMB: 100,
+							Suffix:        "",
 						},
 						Artifacts: []*structs.TaskArtifact{
 							{
@@ -1840,6 +1842,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						LogConfig: &api.LogConfig{
 							MaxFiles:      helper.IntToPtr(10),
 							MaxFileSizeMB: helper.IntToPtr(100),
+							Suffix:        helper.StringToPtr(""),
 						},
 						Artifacts: []*api.TaskArtifact{
 							{
@@ -1958,6 +1961,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						LogConfig: &structs.LogConfig{
 							MaxFiles:      10,
 							MaxFileSizeMB: 100,
+							Suffix:        "",
 						},
 						Artifacts: []*structs.TaskArtifact{
 							{

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -34,6 +34,7 @@ func testJob(jobID string) *api.Job {
 		SetLogConfig(&api.LogConfig{
 			MaxFiles:      helper.IntToPtr(1),
 			MaxFileSizeMB: helper.IntToPtr(2),
+			Suffix:        helper.StringToPtr(""),
 		})
 
 	group := api.NewTaskGroup("group1", 1).

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -236,6 +236,7 @@ func TestParse(t *testing.T) {
 								LogConfig: &api.LogConfig{
 									MaxFiles:      helper.IntToPtr(14),
 									MaxFileSizeMB: helper.IntToPtr(101),
+									Suffix:        helper.StringToPtr(""),
 								},
 								Artifacts: []*api.TaskArtifact{
 									{

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2929,6 +2929,7 @@ func TestTaskDiff(t *testing.T) {
 				LogConfig: &LogConfig{
 					MaxFiles:      1,
 					MaxFileSizeMB: 10,
+					Suffix:        ".suffix",
 				},
 			},
 			Expected: &TaskDiff{
@@ -2950,7 +2951,12 @@ func TestTaskDiff(t *testing.T) {
 								Old:  "",
 								New:  "1",
 							},
-						},
+							{
+								Type: DiffTypeAdded,
+								Name: "Suffix",
+								Old:  "",
+								New:  ".suffix",
+							},						},
 					},
 				},
 			},
@@ -2961,6 +2967,7 @@ func TestTaskDiff(t *testing.T) {
 				LogConfig: &LogConfig{
 					MaxFiles:      1,
 					MaxFileSizeMB: 10,
+					Suffix:        ".suffix",
 				},
 			},
 			New: &Task{},
@@ -2983,6 +2990,12 @@ func TestTaskDiff(t *testing.T) {
 								Old:  "1",
 								New:  "",
 							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Suffix",
+								Old:  ".suffix",
+								New:  "",
+							},
 						},
 					},
 				},
@@ -2994,12 +3007,14 @@ func TestTaskDiff(t *testing.T) {
 				LogConfig: &LogConfig{
 					MaxFiles:      1,
 					MaxFileSizeMB: 10,
+					Suffix:        ".first",
 				},
 			},
 			New: &Task{
 				LogConfig: &LogConfig{
 					MaxFiles:      2,
 					MaxFileSizeMB: 20,
+					Suffix:        ".second",
 				},
 			},
 			Expected: &TaskDiff{
@@ -3021,6 +3036,12 @@ func TestTaskDiff(t *testing.T) {
 								Old:  "1",
 								New:  "2",
 							},
+							{
+								Type: DiffTypeEdited,
+								Name: "Suffix",
+								Old:  ".first",
+								New:  ".second",
+							},
 						},
 					},
 				},
@@ -3033,12 +3054,14 @@ func TestTaskDiff(t *testing.T) {
 				LogConfig: &LogConfig{
 					MaxFiles:      1,
 					MaxFileSizeMB: 10,
+					Suffix:        ".first",
 				},
 			},
 			New: &Task{
 				LogConfig: &LogConfig{
 					MaxFiles:      1,
 					MaxFileSizeMB: 20,
+					Suffix:        ".second",
 				},
 			},
 			Expected: &TaskDiff{
@@ -3059,6 +3082,12 @@ func TestTaskDiff(t *testing.T) {
 								Name: "MaxFiles",
 								Old:  "1",
 								New:  "1",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Suffix",
+								Old:  ".first",
+								New:  ".second",
 							},
 						},
 					},

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4030,6 +4030,7 @@ const (
 type LogConfig struct {
 	MaxFiles      int
 	MaxFileSizeMB int
+	Suffix        string
 }
 
 // DefaultLogConfig returns the default LogConfig values.
@@ -4037,6 +4038,7 @@ func DefaultLogConfig() *LogConfig {
 	return &LogConfig{
 		MaxFiles:      10,
 		MaxFileSizeMB: 10,
+		Suffix:        "",
 	}
 }
 

--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -725,6 +725,8 @@ The `LogConfig` object configures the log rotation policy for a task's `stdout` 
 - `MaxFileSizeMB` - The size of each rotated file. The size is specified in
   `MB`.
 
+- `Suffix` - an additional suffix for stdout/stderr e.g. `task.stdout.0<<Suffix>>`
+
 If the amount of disk resource requested for the task is less than the total
 amount of disk space needed to retain the rotated set of files, Nomad will return
 a validation error when a job is submitted.
@@ -733,14 +735,16 @@ a validation error when a job is submitted.
 {
   "LogConfig": {
     "MaxFiles": 3,
-    "MaxFileSizeMB": 10
+    "MaxFileSizeMB": 10,
+    "Suffix": ".json"
   }
 }
 ```
 
 In the above example we have asked Nomad to retain 3 rotated files for both
 `stderr` and `stdout` and size of each file is 10 MB. The minimum disk space that
-would be required for the task would be 60 MB.
+would be required for the task would be 60 MB. And each file will be appended with
+`.json` extension
 
 ### Artifact
 


### PR DESCRIPTION
There are different type of log structures in a multi-service architecture. Some of them are json based, others are CRLF delimited with specific structures. When you apply global log forwarders such as data dog, filebeast, splunk and such, in the configuration you define the different formats and some inclusion / exclusion regex pattern. Its a recommended practice today to simply use stdout and stderr to emit logs and avoid task/process based log rotations, thus move it to the infrastructure level and use pipe it in.

This proposal is to add a file suffix/extension to the normal stdout/stderr log rotate facility nomad has to simplify the inclusion/exclusion pattern. In my usage I am simply going to append `.json` or `.nlog` or other extensions which can be easily communicated to the forwarding engine and not simply rely on the task name.