### PR TITLE
Allocs already in terminal state do not need to be updated in the reconciler

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -272,6 +272,7 @@ func (a *allocReconciler) cancelDeployments() {
 // handleStop marks all allocations to be stopped, handling the lost case
 func (a *allocReconciler) handleStop(m allocMatrix) {
 	for group, as := range m {
+		as = filterByTerminal(as)
 		untainted, migrate, lost := as.filterByTainted(a.taintedNodes)
 		a.markStop(untainted, "", allocNotNeeded)
 		a.markStop(migrate, "", allocNotNeeded)


### PR DESCRIPTION
This PR fixes a bug in the reconciler around handling stopping allocations when a job is purged/stopped. 

Even if allocs in that job were already terminal, the reconciler was incorrectly and unnecessarily marking them as stopped again causing unnecessary allocation updates. 

