### PR TITLE
Port client portion of #4392 to new taskrunner

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -276,6 +277,25 @@ func (tr *TaskRunner) initLabels() {
 			Name:  "task",
 			Value: tr.taskName,
 		},
+	}
+
+	if tr.alloc.Job.ParentID != "" {
+		tr.baseLabels = append(tr.baseLabels, metrics.Label{
+			Name:  "parent_id",
+			Value: tr.alloc.Job.ParentID,
+		})
+		if strings.Contains(tr.alloc.Job.Name, "/dispatch-") {
+			tr.baseLabels = append(tr.baseLabels, metrics.Label{
+				Name:  "dispatch_id",
+				Value: strings.Split(tr.alloc.Job.Name, "/dispatch-")[1],
+			})
+		}
+		if strings.Contains(tr.alloc.Job.Name, "/periodic-") {
+			tr.baseLabels = append(tr.baseLabels, metrics.Label{
+				Name:  "periodic_id",
+				Value: strings.Split(tr.alloc.Job.Name, "/periodic-")[1],
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
PR #4392 was merged to master *after* allocrunnerv2 was branched, so the
client-specific portions must be ported from master to arv2.