### PR TITLE
B fix missing ref in docs

### DIFF
--- a/website/source/docs/job-specification/group.html.md
+++ b/website/source/docs/job-specification/group.html.md
@@ -45,6 +45,14 @@ job "docs" {
 - `meta` <code>([Meta][]: nil)</code> - Specifies a key-value map that annotates
   with user-defined metadata.
 
+- `migrate` <code>([Migrate][]: nil)</code> - Specifies the group strategy for
+  migrating off of draining nodes. Only service jobs with a count greater than
+  1 support migrate stanzas.
+
+- `reschedule` <code>([Reschedule][]: nil)</code> - Allows to specify a
+  rescheduling strategy. Nomad will then attempt to schedule the task on another
+  node if any of the group allocation statuses become "failed".
+
 - `restart` <code>([Restart][]: nil)</code> - Specifies the restart policy for
   all tasks in this group. If omitted, a default policy exists for each job
   type, which can be found in the [restart stanza documentation][restart].
@@ -112,5 +120,7 @@ group "example" {
 [constraint]: /docs/job-specification/constraint.html "Nomad constraint Job Specification"
 [ephemeraldisk]: /docs/job-specification/ephemeral_disk.html "Nomad ephemeral_disk Job Specification"
 [meta]: /docs/job-specification/meta.html "Nomad meta Job Specification"
+[migrate]: /docs/job-specification/migrate.html "Nomad migrate Job Specification"
+[reschedule]: /docs/job-specification/reschedule.html "Nomad reschedule Job Specification"
 [restart]: /docs/job-specification/restart.html "Nomad restart Job Specification"
 [vault]: /docs/job-specification/vault.html "Nomad vault Job Specification"

--- a/website/source/docs/job-specification/job.html.md
+++ b/website/source/docs/job-specification/job.html.md
@@ -85,6 +85,10 @@ job "docs" {
 - `meta` <code>([Meta][]: nil)</code> - Specifies a key-value map that annotates
   with user-defined metadata.
 
+- `migrate` <code>([Migrate][]: nil)</code> - Specifies the groups strategy for
+  migrating off of draining nodes. If omitted, a default migration strategy is
+  applied. Only service jobs with a count greater than 1 support migrate stanzas.
+
 - `namespace` `(string: "default")` - The namespace in which to execute the job.
   Values other than default are not allowed in non-Enterprise versions of Nomad.
 
@@ -99,6 +103,10 @@ job "docs" {
   inclusively, with a larger value corresponding to a higher priority.
 
 - `region` `(string: "global")` - The region in which to execute the job.
+
+- `reschedule` <code>([Reschedule][]: nil)</code> - Allows to specify a
+  rescheduling strategy. Nomad will then attempt to schedule the task on another
+  node if any of its allocation statuses become "failed".
 
 - `type` `(string: "service")` - Specifies the  [Nomad scheduler][scheduler] to
   use. Nomad provides the `service`, `system` and `batch` schedulers.
@@ -218,8 +226,10 @@ $ VAULT_TOKEN="..." nomad job run example.nomad
 [constraint]: /docs/job-specification/constraint.html "Nomad constraint Job Specification"
 [group]: /docs/job-specification/group.html "Nomad group Job Specification"
 [meta]: /docs/job-specification/meta.html "Nomad meta Job Specification"
+[migrate]: /docs/job-specification/migrate.html "Nomad migrate Job Specification"
 [parameterized]: /docs/job-specification/parameterized.html "Nomad parameterized Job Specification"
 [periodic]: /docs/job-specification/periodic.html "Nomad periodic Job Specification"
+[reschedule]: /docs/job-specification/reschedule.html "Nomad reschedule Job Specification"
 [task]: /docs/job-specification/task.html "Nomad task Job Specification"
 [update]: /docs/job-specification/update.html "Nomad update Job Specification"
 [vault]: /docs/job-specification/vault.html "Nomad vault Job Specification"

--- a/website/source/docs/runtime/interpolation.html.md.erb
+++ b/website/source/docs/runtime/interpolation.html.md.erb
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Variable Interpolation"
-sidebar_current: "docs-runtime-interpolation"
+sidebar_current: "docs-variable-interpolation"
 description: |-
   Learn about the Nomad's interpolation and interpreted variables.
 ---


### PR DESCRIPTION
As I ramp up using Nomad (and am loving it so far!), I spend _a lot_ of time in the docs.
Doing so I spot a few glitches here and there. Even if it's a small contribution, I hope it might help to improve the onboarding of other newcomers (starting with my teammates)

## What changes

### Variable Interpolation sidebar fix
In the docs sidebar, the `Variable Interpolation` ( https://www.nomadproject.io/docs/runtime/interpolation.html ) was never in 'active' (green) state. This is is not a big deal, but confused me a few times (and that's the kind of visual glitches that goes unnoticed for a while, then stands out once you notice them).

### Missing migrate and reschedule references in `job` and `group` specs

From the [reschedule](https://www.nomadproject.io/docs/job-specification/reschedule.html) and [migrate](https://www.nomadproject.io/docs/job-specification/migrate.html) docs, we can use them in both the job and group stanza. 
But in the job and group docs, we don't find those references (like we have for all the other ones). this made me (and probably others) overlooked those reschedule and migrate declarations. 

