### PR TITLE
[Docs] Make clear Nomad requires leases in Vault for rendering certificates using the template stanza

### DIFF
--- a/website/source/docs/job-specification/template.html.md
+++ b/website/source/docs/job-specification/template.html.md
@@ -242,7 +242,7 @@ EOH
 }
 ```
 
-Make sure you set `generate_lease=true` on the `pki/issue/foo` role in Vault's PKI backend. Otherwise the template stanze will frequently render a new certificate (approximately every minute) which is probably not what you want.
+Make sure you set `generate_lease=true` on the `pki/issue/foo` role in Vault's PKI backend. Otherwise the template stanza will frequently render a new certificate (approximately every minute) which is probably not what you want.
 
 ### Vault KV API v1
 

--- a/website/source/docs/job-specification/template.html.md
+++ b/website/source/docs/job-specification/template.html.md
@@ -242,6 +242,8 @@ EOH
 }
 ```
 
+Make sure you set `generate_lease=true` on the `pki/issue/foo` role in Vault's PKI backend. Otherwise the template stanze will frequently render a new certificate (approximately every minute) which is probably not what you want.
+
 ### Vault KV API v1
 
 Under Vault KV API v1, paths start with `secret/`, and the response returns the


### PR DESCRIPTION
I've posted this in the Nomad gitter:

> Anyone using Nomad with Vault for generating certs on-the-fly using the template stanza? I've got it fully working but one thing that took some time debugging was that Nomad kept rendering the template for my certs every minute (over-and-over again).
>
> I've checked the ttl settings on multiple levels, tweaked the vault_grace setting in the template stanza but no luck. Turns out: if I set generate_lease=true on the Vault role it works fine.
> 
> So basically my conclusion is: Nomad with Vault for PKI doesn't really work without generating leases. Anyone else encountered this? Checking because it might be worthwhile to document it.

And the response I've got says enough:

> James Rasell okt. 12 15:59
> @rkettelerij I use Vault extensively for short TTL certs and came across that also which took me a little time to figure out. I would certainly +1 any docs on this

and

> Justin Persaud okt. 13 15:26
> @rkettelerij yeah, definitely bit us before too, same exact case with generate_lease. in our case, our consul backend was overloaded by the time we found out and had to remediate

So here's a small doc change to help future users.