### PR TITLE
Preemption for system jobs

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -67,36 +67,38 @@ func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
 
 // Allocation is used for serialization of allocations.
 type Allocation struct {
-	ID                 string
-	Namespace          string
-	EvalID             string
-	Name               string
-	NodeID             string
-	JobID              string
-	Job                *Job
-	TaskGroup          string
-	Resources          *Resources
-	TaskResources      map[string]*Resources
-	AllocatedResources *AllocatedResources
-	Services           map[string]string
-	Metrics            *AllocationMetric
-	DesiredStatus      string
-	DesiredDescription string
-	DesiredTransition  DesiredTransition
-	ClientStatus       string
-	ClientDescription  string
-	TaskStates         map[string]*TaskState
-	DeploymentID       string
-	DeploymentStatus   *AllocDeploymentStatus
-	FollowupEvalID     string
-	PreviousAllocation string
-	NextAllocation     string
-	RescheduleTracker  *RescheduleTracker
-	CreateIndex        uint64
-	ModifyIndex        uint64
-	AllocModifyIndex   uint64
-	CreateTime         int64
-	ModifyTime         int64
+	ID                    string
+	Namespace             string
+	EvalID                string
+	Name                  string
+	NodeID                string
+	JobID                 string
+	Job                   *Job
+	TaskGroup             string
+	Resources             *Resources
+	TaskResources         map[string]*Resources
+	AllocatedResources    *AllocatedResources
+	Services              map[string]string
+	Metrics               *AllocationMetric
+	DesiredStatus         string
+	DesiredDescription    string
+	DesiredTransition     DesiredTransition
+	ClientStatus          string
+	ClientDescription     string
+	TaskStates            map[string]*TaskState
+	DeploymentID          string
+	DeploymentStatus      *AllocDeploymentStatus
+	FollowupEvalID        string
+	PreviousAllocation    string
+	NextAllocation        string
+	RescheduleTracker     *RescheduleTracker
+	PreemptedAllocations  []string
+	PreemptedByAllocation string
+	CreateIndex           uint64
+	ModifyIndex           uint64
+	AllocModifyIndex      uint64
+	CreateTime            int64
+	ModifyTime            int64
 }
 
 // AllocationMetric is used to deserialize allocation metrics.

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1013,6 +1013,7 @@ type ObjectDiff struct {
 
 type PlanAnnotations struct {
 	DesiredTGUpdates map[string]*DesiredUpdates
+	PreemptedAllocs  []*AllocationListStub
 }
 
 type DesiredUpdates struct {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1024,6 +1024,7 @@ type DesiredUpdates struct {
 	InPlaceUpdate     uint64
 	DestructiveUpdate uint64
 	Canary            uint64
+	Evict             uint64
 }
 
 type JobDispatchRequest struct {

--- a/api/operator.go
+++ b/api/operator.go
@@ -110,13 +110,18 @@ func (op *Operator) RaftRemovePeerByID(id string, q *WriteOptions) error {
 }
 
 type SchedulerConfiguration struct {
-	// EnablePreemption specifies whether to enable eviction of lower
+	// PreemptionConfig specifies whether to enable eviction of lower
 	// priority jobs to place higher priority jobs.
-	EnablePreemption bool
+	PreemptionConfig PreemptionConfig
 
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+// PreemptionConfig specifies whether preemption is enabled based on scheduler type
+type PreemptionConfig struct {
+	SystemSchedulerEnabled bool
 }
 
 // SchedulerGetConfiguration is used to query the current Scheduler configuration.

--- a/api/operator_test.go
+++ b/api/operator_test.go
@@ -3,6 +3,9 @@ package api
 import (
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/testutil/retry"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOperator_RaftGetConfiguration(t *testing.T) {
@@ -49,5 +52,68 @@ func TestOperator_RaftRemovePeerByID(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(),
 		"id \"nope\" was not found in the Raft configuration") {
 		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAPI_OperatorSchedulerGetSetConfiguration(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+
+	operator := c.Operator()
+	var config *SchedulerConfiguration
+	retry.Run(t, func(r *retry.R) {
+		var err error
+		config, _, err = operator.SchedulerGetConfiguration(nil)
+		r.Check(err)
+	})
+	require.False(config.EnablePreemption)
+
+	// Change a config setting
+	newConf := &SchedulerConfiguration{EnablePreemption: true}
+	_, err := operator.SchedulerSetConfiguration(newConf, nil)
+	require.Nil(err)
+
+	config, _, err = operator.SchedulerGetConfiguration(nil)
+	require.Nil(err)
+	require.True(config.EnablePreemption)
+}
+
+func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+
+	operator := c.Operator()
+	var config *SchedulerConfiguration
+	retry.Run(t, func(r *retry.R) {
+		var err error
+		config, _, err = operator.SchedulerGetConfiguration(nil)
+		r.Check(err)
+	})
+	require.False(config.EnablePreemption)
+
+	// Pass an invalid ModifyIndex
+	{
+		newConf := &SchedulerConfiguration{
+			EnablePreemption: true,
+			ModifyIndex:      config.ModifyIndex - 1,
+		}
+		resp, _, err := operator.SchedulerCASConfiguration(newConf, nil)
+		require.Nil(err)
+		require.False(resp)
+	}
+
+	// Pass a valid ModifyIndex
+	{
+		newConf := &SchedulerConfiguration{
+			EnablePreemption: true,
+			ModifyIndex:      config.ModifyIndex,
+		}
+		resp, _, err := operator.SchedulerCASConfiguration(newConf, nil)
+		require.Nil(err)
+		require.True(resp)
 	}
 }

--- a/api/operator_test.go
+++ b/api/operator_test.go
@@ -68,16 +68,16 @@ func TestAPI_OperatorSchedulerGetSetConfiguration(t *testing.T) {
 		config, _, err = operator.SchedulerGetConfiguration(nil)
 		r.Check(err)
 	})
-	require.False(config.EnablePreemption)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
 
 	// Change a config setting
-	newConf := &SchedulerConfiguration{EnablePreemption: true}
+	newConf := &SchedulerConfiguration{PreemptionConfig: PreemptionConfig{SystemSchedulerEnabled: false}}
 	_, err := operator.SchedulerSetConfiguration(newConf, nil)
 	require.Nil(err)
 
 	config, _, err = operator.SchedulerGetConfiguration(nil)
 	require.Nil(err)
-	require.True(config.EnablePreemption)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
 }
 
 func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
@@ -93,12 +93,12 @@ func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
 		config, _, err = operator.SchedulerGetConfiguration(nil)
 		r.Check(err)
 	})
-	require.False(config.EnablePreemption)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
 
 	// Pass an invalid ModifyIndex
 	{
 		newConf := &SchedulerConfiguration{
-			EnablePreemption: true,
+			PreemptionConfig: PreemptionConfig{SystemSchedulerEnabled: false},
 			ModifyIndex:      config.ModifyIndex - 1,
 		}
 		resp, _, err := operator.SchedulerCASConfiguration(newConf, nil)
@@ -109,7 +109,7 @@ func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
 	// Pass a valid ModifyIndex
 	{
 		newConf := &SchedulerConfiguration{
-			EnablePreemption: true,
+			PreemptionConfig: PreemptionConfig{SystemSchedulerEnabled: false},
 			ModifyIndex:      config.ModifyIndex,
 		}
 		resp, _, err := operator.SchedulerCASConfiguration(newConf, nil)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -194,6 +194,8 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/system/gc", s.wrap(s.GarbageCollectRequest))
 	s.mux.HandleFunc("/v1/system/reconcile/summaries", s.wrap(s.ReconcileJobSummaries))
 
+	s.mux.HandleFunc("/v1/operator/scheduler/config", s.wrap(s.OperatorSchedulerConfiguration))
+
 	if uiEnabled {
 		s.mux.Handle("/ui/", http.StripPrefix("/ui/", handleUI(http.FileServer(&UIAssetWrapper{FileSystem: assetFS()}))))
 	} else {

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -226,7 +226,7 @@ func (s *HTTPServer) OperatorSchedulerConfiguration(resp http.ResponseWriter, re
 		}
 
 		out := api.SchedulerConfiguration{
-			EnablePreemption: reply.EnablePreemption,
+			PreemptionConfig: api.PreemptionConfig{SystemSchedulerEnabled: reply.PreemptionConfig.SystemSchedulerEnabled},
 			CreateIndex:      reply.CreateIndex,
 			ModifyIndex:      reply.ModifyIndex,
 		}
@@ -239,11 +239,11 @@ func (s *HTTPServer) OperatorSchedulerConfiguration(resp http.ResponseWriter, re
 
 		var conf api.SchedulerConfiguration
 		if err := decodeBody(req, &conf); err != nil {
-			return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("Error parsing autopilot config: %v", err))
+			return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("Error parsing scheduler config: %v", err))
 		}
 
 		args.Config = structs.SchedulerConfiguration{
-			EnablePreemption: conf.EnablePreemption,
+			PreemptionConfig: structs.PreemptionConfig{SystemSchedulerEnabled: conf.PreemptionConfig.SystemSchedulerEnabled},
 		}
 
 		// Check for cas value

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -813,7 +813,7 @@ func (n *nomadFSM) applyPlanResults(buf []byte, index uint64) interface{} {
 		n.logger.Error("ApplyPlan failed", "error", err)
 		return err
 	}
-
+	n.handleUpsertedEvals(req.PreemptionEvals)
 	return nil
 }
 

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2835,7 +2835,9 @@ func TestFSM_SchedulerConfig(t *testing.T) {
 	// Set the autopilot config using a request.
 	req := structs.SchedulerSetConfigRequest{
 		Config: structs.SchedulerConfiguration{
-			EnablePreemption: true,
+			PreemptionConfig: structs.PreemptionConfig{
+				SystemSchedulerEnabled: true,
+			},
 		},
 	}
 	buf, err := structs.Encode(structs.SchedulerConfigRequestType, req)
@@ -2850,11 +2852,11 @@ func TestFSM_SchedulerConfig(t *testing.T) {
 	_, config, err := fsm.state.SchedulerConfig()
 	require.Nil(err)
 
-	require.Equal(config.EnablePreemption, req.Config.EnablePreemption)
+	require.Equal(config.PreemptionConfig.SystemSchedulerEnabled, req.Config.PreemptionConfig.SystemSchedulerEnabled)
 
 	// Now use CAS and provide an old index
 	req.CAS = true
-	req.Config.EnablePreemption = false
+	req.Config.PreemptionConfig = structs.PreemptionConfig{SystemSchedulerEnabled: false}
 	req.Config.ModifyIndex = config.ModifyIndex - 1
 	buf, err = structs.Encode(structs.SchedulerConfigRequestType, req)
 	require.Nil(err)
@@ -2867,5 +2869,5 @@ func TestFSM_SchedulerConfig(t *testing.T) {
 	_, config, err = fsm.state.SchedulerConfig()
 	require.Nil(err)
 	// Verify that preemption is still enabled
-	require.True(config.EnablePreemption)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
 }

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1246,7 +1246,7 @@ func (s *Server) getOrCreateSchedulerConfig() *structs.SchedulerConfiguration {
 		return config
 	}
 
-	config = &structs.SchedulerConfiguration{EnablePreemption: false}
+	config = &structs.SchedulerConfiguration{PreemptionConfig: structs.PreemptionConfig{SystemSchedulerEnabled: true}}
 	req := structs.SchedulerSetConfigRequest{Config: *config}
 	if _, _, err = s.raftApply(structs.SchedulerConfigRequestType, req); err != nil {
 		s.logger.Named("core").Error("failed to initialize config", "error", err)

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -204,10 +204,8 @@ func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap
 
 	var evals []*structs.Evaluation
 	for preemptedJobID, _ := range preemptedJobIDs {
-		job, _ := p.State().JobByID(nil, preemptedJobID.Namespace, preemptedJobID.ID) // TODO Fix me
+		job, _ := p.State().JobByID(nil, preemptedJobID.Namespace, preemptedJobID.ID)
 		if job != nil {
-			//TODO(preetha): This eval is missing class eligibility related fields
-			// need to figure out how to set them per job
 			eval := &structs.Evaluation{
 				ID:          uuid.Generate(),
 				Namespace:   job.Namespace,

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -203,7 +203,7 @@ func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap
 	}
 
 	var evals []*structs.Evaluation
-	for preemptedJobID, _ := range preemptedJobIDs {
+	for preemptedJobID := range preemptedJobIDs {
 		job, _ := p.State().JobByID(nil, preemptedJobID.Namespace, preemptedJobID.ID)
 		if job != nil {
 			eval := &structs.Evaluation{

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -44,6 +44,7 @@ func init() {
 		aclPolicyTableSchema,
 		aclTokenTableSchema,
 		autopilotConfigTableSchema,
+		schedulerConfigTableSchema,
 	}...)
 }
 
@@ -594,6 +595,24 @@ func aclTokenTableSchema() *memdb.TableSchema {
 				Unique:       false,
 				Indexer: &memdb.FieldSetIndex{
 					Field: "Global",
+				},
+			},
+		},
+	}
+}
+
+// schedulerConfigTableSchema returns the MemDB schema for the scheduler config table.
+// This table is used to store configuration options for the scheduler
+func schedulerConfigTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "scheduler_config",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": {
+				Name:         "id",
+				AllowMissing: true,
+				Unique:       true,
+				Indexer: &memdb.ConditionalIndex{
+					Conditional: func(obj interface{}) (bool, error) { return true, nil },
 				},
 			},
 		},

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -218,7 +218,6 @@ func (s *StateStore) UpsertPlanResults(index uint64, results *structs.ApplyPlanR
 		}
 	}
 
-	// TODO(preetha) do a pass to group by jobid
 	// Prepare preempted allocs in the plan results for update
 	for _, preemptedAlloc := range results.NodePreemptions {
 		// Look for existing alloc
@@ -229,7 +228,7 @@ func (s *StateStore) UpsertPlanResults(index uint64, results *structs.ApplyPlanR
 
 		// Nothing to do if this does not exist
 		if existing == nil {
-			return nil
+			continue
 		}
 		exist := existing.(*structs.Allocation)
 
@@ -248,7 +247,6 @@ func (s *StateStore) UpsertPlanResults(index uint64, results *structs.ApplyPlanR
 	}
 
 	// Upsert followup evals for allocs that were preempted
-
 	for _, eval := range results.PreemptionEvals {
 		if err := s.nestedUpsertEval(txn, index, eval); err != nil {
 			return err

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -119,3 +119,26 @@ type AutopilotConfig struct {
 	CreateIndex uint64
 	ModifyIndex uint64
 }
+
+type SchedulerConfiguration struct {
+	// EnablePreemption specifies whether to enable eviction of lower
+	// priority jobs to place higher priority jobs.
+	EnablePreemption bool
+
+	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// SchedulerSetConfigRequest is used by the Operator endpoint to update the
+// current Scheduler configuration of the cluster.
+type SchedulerSetConfigRequest struct {
+	// Config is the new Scheduler configuration to use.
+	Config SchedulerConfiguration
+
+	// CAS controls whether to use check-and-set semantics for this request.
+	CAS bool
+
+	// WriteRequest holds the ACL token to go along with this request.
+	WriteRequest
+}

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -121,13 +121,19 @@ type AutopilotConfig struct {
 }
 
 type SchedulerConfiguration struct {
-	// EnablePreemption specifies whether to enable eviction of lower
+	// PreemptionConfig specifies whether to enable eviction of lower
 	// priority jobs to place higher priority jobs.
-	EnablePreemption bool
+	PreemptionConfig PreemptionConfig
 
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+// PreemptionConfig specifies whether preemption is enabled based on scheduler type
+type PreemptionConfig struct {
+	// SystemSchedulerEnabled specifies if preemption is enabled for system jobs
+	SystemSchedulerEnabled bool
 }
 
 // SchedulerSetConfigRequest is used by the Operator endpoint to update the

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8214,6 +8214,14 @@ func (p *Plan) IsNoOp() bool {
 		len(p.DeploymentUpdates) == 0
 }
 
+// PreemptedAllocs is used to store information about a set of allocations
+// for the same job that get preempted as part of placing allocations for the
+// job in the plan.
+
+// Preempted allocs represents a map from jobid to allocations
+// to be preempted
+type PreemptedAllocs map[*NamespacedID][]*Allocation
+
 // PlanResult is the result of a plan submitted to the leader.
 type PlanResult struct {
 	// NodeUpdate contains all the updates that were committed.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -643,6 +643,15 @@ type ApplyPlanResultsRequest struct {
 	// processed many times, potentially making state updates, without the state of
 	// the evaluation itself being updated.
 	EvalID string
+
+	// NodePreemptions is a map from node id to a set of allocations from other
+	// lower priority jobs that are preempted. Preempted allocations are marked
+	// as stopped.
+	NodePreemptions []*Allocation
+
+	// PreemptionEvals is a slice of follow up evals for jobs whose allocations
+	// have been preempted to place allocs in this plan
+	PreemptionEvals []*Evaluation
 }
 
 // AllocUpdateRequest is used to submit changes to allocations, either
@@ -1871,6 +1880,29 @@ func (r *Resources) Add(delta *Resources) error {
 			r.Networks = append(r.Networks, n.Copy())
 		} else {
 			r.Networks[idx].Add(n)
+		}
+	}
+	return nil
+}
+
+// Subtract removes the resources of the delta to this, potentially
+// returning an error if not possible.
+func (r *Resources) Subtract(delta *Resources) error {
+	if delta == nil {
+		return nil
+	}
+	r.CPU -= delta.CPU
+	r.MemoryMB -= delta.MemoryMB
+	r.DiskMB -= delta.DiskMB
+	r.IOPS -= delta.IOPS
+
+	for _, n := range delta.Networks {
+		// Find the matching interface by IP or CIDR
+		idx := r.NetIndex(n)
+		if idx == -1 {
+			r.Networks = append(r.Networks, n.Copy())
+		} else {
+			r.Networks[idx].MBits -= delta.Networks[idx].MBits
 		}
 	}
 	return nil
@@ -7025,6 +7057,14 @@ type Allocation struct {
 	// that can be rescheduled in the future
 	FollowupEvalID string
 
+	// PreemptedAllocations captures IDs of any allocations that were preempted
+	// in order to place this allocation
+	PreemptedAllocations []string
+
+	// PreemptedByAllocation tracks the alloc ID of the allocation that caused this allocation
+	// to stop running because it got preempted
+	PreemptedByAllocation string
+
 	// Raft Indexes
 	CreateIndex uint64
 	ModifyIndex uint64
@@ -7099,6 +7139,7 @@ func (a *Allocation) copyImpl(job bool) *Allocation {
 	}
 
 	na.RescheduleTracker = a.RescheduleTracker.Copy()
+	na.PreemptedAllocations = helper.CopySliceString(a.PreemptedAllocations)
 	return na
 }
 
@@ -7743,6 +7784,7 @@ const (
 	EvalTriggerMaxPlans          = "max-plan-attempts"
 	EvalTriggerRetryFailedAlloc  = "alloc-failure"
 	EvalTriggerQueuedAllocs      = "queued-allocs"
+	EvalTriggerPreemption        = "preempted"
 )
 
 const (
@@ -7968,11 +8010,12 @@ func (e *Evaluation) ShouldBlock() bool {
 // for a given Job
 func (e *Evaluation) MakePlan(j *Job) *Plan {
 	p := &Plan{
-		EvalID:         e.ID,
-		Priority:       e.Priority,
-		Job:            j,
-		NodeUpdate:     make(map[string][]*Allocation),
-		NodeAllocation: make(map[string][]*Allocation),
+		EvalID:          e.ID,
+		Priority:        e.Priority,
+		Job:             j,
+		NodeUpdate:      make(map[string][]*Allocation),
+		NodeAllocation:  make(map[string][]*Allocation),
+		NodePreemptions: make(map[string][]*Allocation),
 	}
 	if j != nil {
 		p.AllAtOnce = j.AllAtOnce
@@ -8085,6 +8128,11 @@ type Plan struct {
 	// deployments. This allows the scheduler to cancel any unneeded deployment
 	// because the job is stopped or the update block is removed.
 	DeploymentUpdates []*DeploymentStatusUpdate
+
+	// NodePreemptions is a map from node id to a set of allocations from other
+	// lower priority jobs that are preempted. Preempted allocations are marked
+	// as evicted.
+	NodePreemptions map[string][]*Allocation
 }
 
 // AppendUpdate marks the allocation for eviction. The clientStatus of the
@@ -8115,6 +8163,27 @@ func (p *Plan) AppendUpdate(alloc *Allocation, desiredStatus, desiredDesc, clien
 	node := alloc.NodeID
 	existing := p.NodeUpdate[node]
 	p.NodeUpdate[node] = append(existing, newAlloc)
+}
+
+func (p *Plan) AppendPreemptedAlloc(alloc *Allocation, desiredStatus, preemptingAllocID string) {
+	newAlloc := new(Allocation)
+	*newAlloc = *alloc
+	// Normalize the job
+	newAlloc.Job = nil
+
+	// Strip the resources as it can be rebuilt.
+	newAlloc.Resources = nil
+
+	newAlloc.DesiredStatus = desiredStatus
+	newAlloc.PreemptedByAllocation = preemptingAllocID
+
+	desiredDesc := fmt.Sprintf("Preempted by alloc ID %v", preemptingAllocID)
+	newAlloc.DesiredDescription = desiredDesc
+
+	node := alloc.NodeID
+	// Append this alloc to slice for this node
+	existing := p.NodePreemptions[node]
+	p.NodePreemptions[node] = append(existing, newAlloc)
 }
 
 func (p *Plan) PopUpdate(alloc *Allocation) {
@@ -8148,6 +8217,14 @@ func (p *Plan) IsNoOp() bool {
 		len(p.DeploymentUpdates) == 0
 }
 
+// PreemptedAllocs is used to store information about a set of allocations
+// for the same job that get preempted as part of placing allocations for the
+// job in the plan.
+
+// Preempted allocs represents a map from jobid to allocations
+// to be preempted
+type PreemptedAllocs map[*NamespacedID][]*Allocation
+
 // PlanResult is the result of a plan submitted to the leader.
 type PlanResult struct {
 	// NodeUpdate contains all the updates that were committed.
@@ -8161,6 +8238,11 @@ type PlanResult struct {
 
 	// DeploymentUpdates is the set of deployment updates that were committed.
 	DeploymentUpdates []*DeploymentStatusUpdate
+
+	// NodePreemptions is a map from node id to a set of allocations from other
+	// lower priority jobs that are preempted. Preempted allocations are marked
+	// as stopped.
+	NodePreemptions map[string][]*Allocation
 
 	// RefreshIndex is the index the worker should refresh state up to.
 	// This allows all evictions and allocations to be materialized.
@@ -8198,6 +8280,8 @@ func (p *PlanResult) FullCommit(plan *Plan) (bool, int, int) {
 type PlanAnnotations struct {
 	// DesiredTGUpdates is the set of desired updates per task group.
 	DesiredTGUpdates map[string]*DesiredUpdates
+	// PreemptedAllocs is the set of allocations to be preempted to make the placement successful.
+	PreemptedAllocs []*AllocListStub
 }
 
 // DesiredUpdates is the set of changes the scheduler would like to make given

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8284,6 +8284,7 @@ type DesiredUpdates struct {
 	InPlaceUpdate     uint64
 	DestructiveUpdate uint64
 	Canary            uint64
+	Evict             uint64
 }
 
 func (d *DesiredUpdates) GoString() string {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7781,7 +7781,7 @@ const (
 	EvalTriggerMaxPlans          = "max-plan-attempts"
 	EvalTriggerRetryFailedAlloc  = "alloc-failure"
 	EvalTriggerQueuedAllocs      = "queued-allocs"
-	EvalTriggerPreemption        = "preempted"
+	EvalTriggerPreemption        = "preemption"
 )
 
 const (
@@ -8162,20 +8162,22 @@ func (p *Plan) AppendUpdate(alloc *Allocation, desiredStatus, desiredDesc, clien
 	p.NodeUpdate[node] = append(existing, newAlloc)
 }
 
+// AppendPreemptedAlloc is used to append an allocation that's being preempted to the plan.
+// To minimize the size of the plan, this only sets a minimal set of fields in the allocation
 func (p *Plan) AppendPreemptedAlloc(alloc *Allocation, desiredStatus, preemptingAllocID string) {
-	newAlloc := new(Allocation)
-	*newAlloc = *alloc
-	// Normalize the job
-	newAlloc.Job = nil
-
-	// Strip the resources as it can be rebuilt.
-	newAlloc.Resources = nil
-
+	newAlloc := &Allocation{}
+	newAlloc.ID = alloc.ID
+	newAlloc.JobID = alloc.JobID
+	newAlloc.Namespace = alloc.Namespace
 	newAlloc.DesiredStatus = desiredStatus
 	newAlloc.PreemptedByAllocation = preemptingAllocID
 
 	desiredDesc := fmt.Sprintf("Preempted by alloc ID %v", preemptingAllocID)
 	newAlloc.DesiredDescription = desiredDesc
+
+	// TaskResources are needed by the plan applier to check if allocations fit
+	// after removing preempted allocations
+	newAlloc.TaskResources = alloc.TaskResources
 
 	node := alloc.NodeID
 	// Append this alloc to slice for this node

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -644,9 +644,8 @@ type ApplyPlanResultsRequest struct {
 	// the evaluation itself being updated.
 	EvalID string
 
-	// NodePreemptions is a map from node id to a set of allocations from other
-	// lower priority jobs that are preempted. Preempted allocations are marked
-	// as stopped.
+	// NodePreemptions is a slice of allocations from other lower priority jobs
+	// that are preempted. Preempted allocations are marked as evicted.
 	NodePreemptions []*Allocation
 
 	// PreemptionEvals is a slice of follow up evals for jobs whose allocations
@@ -1899,9 +1898,7 @@ func (r *Resources) Subtract(delta *Resources) error {
 	for _, n := range delta.Networks {
 		// Find the matching interface by IP or CIDR
 		idx := r.NetIndex(n)
-		if idx == -1 {
-			r.Networks = append(r.Networks, n.Copy())
-		} else {
+		if idx != -1 {
 			r.Networks[idx].MBits -= delta.Networks[idx].MBits
 		}
 	}
@@ -8217,14 +8214,6 @@ func (p *Plan) IsNoOp() bool {
 		len(p.DeploymentUpdates) == 0
 }
 
-// PreemptedAllocs is used to store information about a set of allocations
-// for the same job that get preempted as part of placing allocations for the
-// job in the plan.
-
-// Preempted allocs represents a map from jobid to allocations
-// to be preempted
-type PreemptedAllocs map[*NamespacedID][]*Allocation
-
 // PlanResult is the result of a plan submitted to the leader.
 type PlanResult struct {
 	// NodeUpdate contains all the updates that were committed.
@@ -8280,6 +8269,7 @@ func (p *PlanResult) FullCommit(plan *Plan) (bool, int, int) {
 type PlanAnnotations struct {
 	// DesiredTGUpdates is the set of desired updates per task group.
 	DesiredTGUpdates map[string]*DesiredUpdates
+
 	// PreemptedAllocs is the set of allocations to be preempted to make the placement successful.
 	PreemptedAllocs []*AllocListStub
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -81,6 +81,7 @@ const (
 	AllocUpdateDesiredTransitionRequestType
 	NodeUpdateEligibilityRequestType
 	BatchNodeUpdateDrainRequestType
+	SchedulerConfigRequestType
 )
 
 const (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7416,6 +7416,37 @@ func (a *Allocation) ComparableResources() *ComparableResources {
 	}
 }
 
+// COMPAT(0.11): Remove in 0.11
+// CompatibleNetworkResources returns network resources on the allocation
+// by reading AllocatedResources which are populated starting in 0.9 and
+// falling back to pre 0.9 fields (Resources/TaskResources) if set
+func (a *Allocation) CompatibleNetworkResources() []*NetworkResource {
+	var ret []*NetworkResource
+	// Alloc already has 0.9+ behavior
+	if a.AllocatedResources != nil {
+		var comparableResources *ComparableResources
+		for _, taskResource := range a.AllocatedResources.Tasks {
+			if comparableResources == nil {
+				comparableResources = taskResource.Comparable()
+			} else {
+				comparableResources.Add(taskResource.Comparable())
+			}
+		}
+		ret = comparableResources.Flattened.Networks
+	} else if a.Resources != nil {
+		// Alloc has pre 0.9 total resources
+		ret = a.Resources.Networks
+	} else if a.TaskResources != nil {
+		// Alloc has pre 0.9 task resources
+		resources := new(Resources)
+		for _, taskResource := range a.TaskResources {
+			resources.Add(taskResource)
+		}
+		ret = resources.Networks
+	}
+	return ret
+}
+
 // LookupTask by name from the Allocation. Returns nil if the Job is not set, the
 // TaskGroup does not exist, or the task name cannot be found.
 func (a *Allocation) LookupTask(name string) *Task {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1869,6 +1869,58 @@ func TestResource_Add_Network(t *testing.T) {
 	}
 }
 
+func TestResource_Subtract(t *testing.T) {
+	r1 := &Resources{
+		CPU:      2000,
+		MemoryMB: 2048,
+		DiskMB:   10000,
+		IOPS:     100,
+		Networks: []*NetworkResource{
+			{
+				CIDR:          "10.0.0.0/8",
+				MBits:         100,
+				ReservedPorts: []Port{{"ssh", 22}},
+			},
+		},
+	}
+	r2 := &Resources{
+		CPU:      1000,
+		MemoryMB: 1024,
+		DiskMB:   5000,
+		IOPS:     50,
+		Networks: []*NetworkResource{
+			{
+				IP:            "10.0.0.1",
+				MBits:         20,
+				ReservedPorts: []Port{{"web", 80}},
+			},
+		},
+	}
+
+	err := r1.Subtract(r2)
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+
+	expect := &Resources{
+		CPU:      1000,
+		MemoryMB: 1024,
+		DiskMB:   5000,
+		IOPS:     50,
+		Networks: []*NetworkResource{
+			{
+				CIDR:          "10.0.0.0/8",
+				MBits:         80,
+				ReservedPorts: []Port{{"ssh", 22}},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(expect.Networks, r1.Networks) {
+		t.Fatalf("bad: %#v %#v", expect, r1)
+	}
+}
+
 func TestEncodeDecode(t *testing.T) {
 	type FooRequest struct {
 		Foo string

--- a/scheduler/context.go
+++ b/scheduler/context.go
@@ -123,6 +123,12 @@ func (e *EvalContext) ProposedAllocs(nodeID string) ([]*structs.Allocation, erro
 		proposed = structs.RemoveAllocs(existingAlloc, update)
 	}
 
+	// Remove any allocs that are being preempted
+	nodePreemptedAllocs := e.plan.NodePreemptions[nodeID]
+	if len(nodePreemptedAllocs) > 0 {
+		proposed = structs.RemoveAllocs(existingAlloc, nodePreemptedAllocs)
+	}
+
 	// We create an index of the existing allocations so that if an inplace
 	// update occurs, we do not double count and we override the old allocation.
 	proposedIDs := make(map[string]*structs.Allocation, len(proposed))

--- a/scheduler/context_test.go
+++ b/scheduler/context_test.go
@@ -14,8 +14,9 @@ import (
 func testContext(t testing.TB) (*state.StateStore, *EvalContext) {
 	state := state.TestStateStore(t)
 	plan := &structs.Plan{
-		NodeUpdate:     make(map[string][]*structs.Allocation),
-		NodeAllocation: make(map[string][]*structs.Allocation),
+		NodeUpdate:      make(map[string][]*structs.Allocation),
+		NodeAllocation:  make(map[string][]*structs.Allocation),
+		NodePreemptions: make(map[string][]*structs.Allocation),
 	}
 
 	logger := testlog.HCLogger(t)

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -130,7 +130,8 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) error {
 		structs.EvalTriggerRollingUpdate, structs.EvalTriggerQueuedAllocs,
 		structs.EvalTriggerPeriodicJob, structs.EvalTriggerMaxPlans,
 		structs.EvalTriggerDeploymentWatcher, structs.EvalTriggerRetryFailedAlloc,
-		structs.EvalTriggerFailedFollowUp:
+		structs.EvalTriggerFailedFollowUp,
+		structs.EvalTriggerPreemption:
 	default:
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)

--- a/scheduler/preemption.go
+++ b/scheduler/preemption.go
@@ -1,0 +1,437 @@
+package scheduler
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// maxParallelPenalty is a score penalty applied to allocations to mitigate against
+// too many allocations of the same job being preempted. This penalty is applied after the
+// number of allocations being preempted exceeds max_parallel value in the job's migrate stanza
+const maxParallelPenalty = 50.0
+
+type PreemptionType uint8
+
+const (
+	NetworkResource PreemptionType = iota
+	CPUMemoryDiskIOPS
+)
+
+// resourceDistance returns how close the resource is to the resource being asked for
+// It is calculated by first computing a relative fraction and then measuring how close
+// that is to the origin coordinate. Lower values are better
+func resourceDistance(resource *structs.Resources, resourceAsk *structs.Resources) float64 {
+	memoryCoord, cpuCoord, iopsCoord, diskMBCoord := 0.0, 0.0, 0.0, 0.0
+	if resourceAsk.MemoryMB > 0 {
+		memoryCoord = float64(resourceAsk.MemoryMB-resource.MemoryMB) / float64(resourceAsk.MemoryMB)
+	}
+	if resourceAsk.CPU > 0 {
+		cpuCoord = float64(resourceAsk.CPU-resource.CPU) / float64(resourceAsk.CPU)
+	}
+	if resourceAsk.IOPS > 0 {
+		iopsCoord = float64(resourceAsk.IOPS-resource.IOPS) / float64(resourceAsk.IOPS)
+	}
+	if resourceAsk.DiskMB > 0 {
+		diskMBCoord = float64(resourceAsk.DiskMB-resource.DiskMB) / float64(resourceAsk.DiskMB)
+	}
+
+	originDist := math.Sqrt(
+		math.Pow(memoryCoord, 2) +
+			math.Pow(cpuCoord, 2) +
+			math.Pow(iopsCoord, 2) +
+			math.Pow(diskMBCoord, 2))
+	return originDist
+}
+
+// networkResourceDistance returns distance based on network megabits
+func networkResourceDistance(resource *structs.Resources, resourceAsk *structs.Resources) float64 {
+	networkCoord := math.MaxFloat64
+	if len(resourceAsk.Networks) > 0 && resourceAsk.Networks[0].MBits > 0 {
+		networkCoord = float64(resourceAsk.Networks[0].MBits-resource.Networks[0].MBits) / float64(resourceAsk.Networks[0].MBits)
+	}
+
+	originDist := math.Sqrt(
+		math.Pow(networkCoord, 2))
+	return originDist
+}
+
+// getPreemptionScore is used to calculate a score (lower is better) based on the distance between
+// the needed resource and requirements. A penalty is added when the choice already has some existing
+// allocations in the plan that are being preempted.
+func getPreemptionScore(resource *structs.Resources, resourceAsk *structs.Resources, preemptionType PreemptionType, maxParallel int, numPreemptedAllocs int) float64 {
+	maxParallelScorePenalty := 0.0
+	if maxParallel > 0 && numPreemptedAllocs >= maxParallel {
+		maxParallelScorePenalty = float64((numPreemptedAllocs+1)-maxParallel) * maxParallelPenalty
+	}
+	switch preemptionType {
+	case NetworkResource:
+		return networkResourceDistance(resource, resourceAsk) + maxParallelScorePenalty
+	case CPUMemoryDiskIOPS:
+		return resourceDistance(resource, resourceAsk) + maxParallelScorePenalty
+	}
+	panic(fmt.Errorf("Unknown preemption type:%v", preemptionType))
+}
+
+// findPreemptibleAllocationsForTaskGroup computes a list of allocations to preempt to accommodate
+// the resources asked for. Only allocs with a job priority < 10 of jobPriority are considered
+// This method is used after network resource needs have already been met.
+func findPreemptibleAllocationsForTaskGroup(jobPriority int, current []*structs.Allocation, resourceAsk *structs.Resources, node *structs.Node, currentPreemptions []*structs.Allocation) []*structs.Allocation {
+	resourcesNeeded := resourceAsk.Copy()
+	allocsByPriority := filterAndGroupPreemptibleAllocs(jobPriority, current)
+	var bestAllocs []*structs.Allocation
+	allRequirementsMet := false
+	var preemptedResources *structs.Resources
+
+	//TODO(preetha): should add some debug logging
+
+	nodeRemainingResources := node.Resources.Copy()
+
+	// Initialize nodeRemainingResources with the remaining resources
+	// after accounting for reserved resources and all allocations
+
+	// Subtract the reserved resources of the node
+	if node.Reserved != nil {
+		nodeRemainingResources.Subtract(node.Reserved)
+	}
+
+	// Subtract current allocations
+	for _, alloc := range current {
+		nodeRemainingResources.Subtract(alloc.Resources)
+	}
+
+	// Iterate over allocations grouped by priority to find preemptible allocations
+	for _, allocGrp := range allocsByPriority {
+		for len(allocGrp.allocs) > 0 && !allRequirementsMet {
+			closestAllocIndex := -1
+			bestDistance := math.MaxFloat64
+			// find the alloc with the closest distance
+			for index, alloc := range allocGrp.allocs {
+				currentPreemptionCount := computeCurrentPreemptions(alloc, currentPreemptions)
+				maxParallel := 0
+				tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
+				if tg != nil && tg.Migrate != nil {
+					maxParallel = tg.Migrate.MaxParallel
+				}
+				distance := getPreemptionScore(alloc.Resources, resourcesNeeded, CPUMemoryDiskIOPS, maxParallel, currentPreemptionCount)
+				if distance < bestDistance {
+					bestDistance = distance
+					closestAllocIndex = index
+				}
+			}
+			closestAlloc := allocGrp.allocs[closestAllocIndex]
+
+			if preemptedResources == nil {
+				preemptedResources = closestAlloc.Resources.Copy()
+			} else {
+				preemptedResources.Add(closestAlloc.Resources)
+			}
+			availableResources := preemptedResources.Copy()
+			availableResources.Add(nodeRemainingResources)
+
+			allRequirementsMet = meetsNonNetworkRequirements(availableResources, resourceAsk)
+			bestAllocs = append(bestAllocs, closestAlloc)
+
+			allocGrp.allocs[closestAllocIndex] = allocGrp.allocs[len(allocGrp.allocs)-1]
+			allocGrp.allocs = allocGrp.allocs[:len(allocGrp.allocs)-1]
+			resourcesNeeded.Subtract(closestAlloc.Resources)
+		}
+		if allRequirementsMet {
+			break
+		}
+	}
+
+	// Early return if all allocs examined and requirements were not met
+	if !allRequirementsMet {
+		return nil
+	}
+
+	// We do another pass to eliminate unnecessary preemptions
+	// This filters out allocs whose resources are already covered by another alloc
+	filteredBestAllocs := eliminateSuperSetAllocations(bestAllocs, resourceAsk, nodeRemainingResources, resourceDistance, meetsNonNetworkRequirements)
+	return filteredBestAllocs
+
+}
+
+// computeCurrentPreemptions counts the number of other allocations being preempted that match the job and task group of
+// the alloc under consideration. This is used as a scoring factor to minimize too many allocs of the same job being preempted at once
+func computeCurrentPreemptions(currentAlloc *structs.Allocation, currentPreemptions []*structs.Allocation) int {
+	numCurrentPreemptionsForJob := 0
+	for _, alloc := range currentPreemptions {
+		if alloc.JobID == currentAlloc.JobID && alloc.Namespace == currentAlloc.Namespace && alloc.TaskGroup == currentAlloc.TaskGroup {
+			numCurrentPreemptionsForJob++
+		}
+	}
+	return numCurrentPreemptionsForJob
+}
+
+// meetsNonNetworkRequirements checks if the first resource meets or exceeds the second resource's requirements
+// This intentionally ignores network requirements, those are handled by meetsNetworkRequirements
+func meetsNonNetworkRequirements(first *structs.Resources, second *structs.Resources) bool {
+	if first.CPU < second.CPU {
+		return false
+	}
+	if first.MemoryMB < second.MemoryMB {
+		return false
+	}
+	if first.DiskMB < second.DiskMB {
+		return false
+	}
+	if first.IOPS < second.IOPS {
+		return false
+	}
+	return true
+}
+
+// meetsNetworkRequirements checks if the first resource meets or exceeds the second resource's network MBits requirements
+func meetsNetworkRequirements(first *structs.Resources, second *structs.Resources) bool {
+	if len(first.Networks) == 0 || len(second.Networks) == 0 {
+		return false
+	}
+	return first.Networks[0].MBits >= second.Networks[0].MBits
+}
+
+type groupedAllocs struct {
+	priority int
+	allocs   []*structs.Allocation
+}
+
+func filterAndGroupPreemptibleAllocs(jobPriority int, current []*structs.Allocation) []*groupedAllocs {
+	allocsByPriority := make(map[int][]*structs.Allocation)
+	for _, alloc := range current {
+		// Why is alloc.Job even nil though?
+		if alloc.Job == nil {
+			continue
+		}
+
+		// Skip allocs whose priority is within a delta of 10
+		// This also skips any allocs of the current job
+		// for which we are attempting preemption
+		if jobPriority-alloc.Job.Priority < 10 {
+			continue
+		}
+		grpAllocs, ok := allocsByPriority[alloc.Job.Priority]
+		if !ok {
+			grpAllocs = make([]*structs.Allocation, 0)
+		}
+		grpAllocs = append(grpAllocs, alloc)
+		allocsByPriority[alloc.Job.Priority] = grpAllocs
+	}
+
+	var groupedSortedAllocs []*groupedAllocs
+	for priority, allocs := range allocsByPriority {
+		groupedSortedAllocs = append(groupedSortedAllocs, &groupedAllocs{
+			priority: priority,
+			allocs:   allocs})
+	}
+
+	// Sort by priority
+	sort.Slice(groupedSortedAllocs, func(i, j int) bool {
+		return groupedSortedAllocs[i].priority < groupedSortedAllocs[j].priority
+	})
+
+	return groupedSortedAllocs
+}
+
+type distanceFn func(first *structs.Resources, second *structs.Resources) float64
+
+type meetsRequirementsFn func(first *structs.Resources, second *structs.Resources) bool
+
+func eliminateSuperSetAllocations(bestAllocs []*structs.Allocation, resourceAsk *structs.Resources,
+	nodeRemainingResources *structs.Resources, distanceFunc distanceFn, reqFunc meetsRequirementsFn) []*structs.Allocation {
+	// Sort by distance reversed to surface any superset allocs first
+	sort.Slice(bestAllocs, func(i, j int) bool {
+		distance1 := distanceFunc(bestAllocs[i].Resources, resourceAsk)
+		distance2 := distanceFunc(bestAllocs[j].Resources, resourceAsk)
+		return distance1 > distance2
+	})
+
+	var preemptedResources *structs.Resources
+	var filteredBestAllocs []*structs.Allocation
+
+	// Do another pass to eliminate allocations that are a superset of other allocations
+	// in the preemption set
+	for _, alloc := range bestAllocs {
+		if preemptedResources == nil {
+			preemptedResources = alloc.Resources
+		} else {
+			preemptedResources.Add(alloc.Resources)
+		}
+		filteredBestAllocs = append(filteredBestAllocs, alloc)
+		availableResources := preemptedResources.Copy()
+		availableResources.Add(nodeRemainingResources)
+
+		requirementsMet := reqFunc(availableResources, resourceAsk)
+		if requirementsMet {
+			break
+		}
+	}
+	return filteredBestAllocs
+}
+
+// preemptForNetworkResourceAsk tries to find allocations to preempt to meet network resources.
+// this needs to consider network resources at the task level and for the same task it should
+// only preempt allocations that share the same network device
+func preemptForNetworkResourceAsk(jobPriority int, currentAllocs []*structs.Allocation, resourceAsk *structs.Resources,
+	netIdx *structs.NetworkIndex, currentPreemptions []*structs.Allocation) []*structs.Allocation {
+
+	// Early return if there are no current allocs
+	if len(currentAllocs) == 0 {
+		return nil
+	}
+
+	networkResourceAsk := resourceAsk.Networks[0]
+	deviceToAllocs := make(map[string][]*structs.Allocation)
+	MbitsNeeded := networkResourceAsk.MBits
+	reservedPortsNeeded := networkResourceAsk.ReservedPorts
+
+	// Create a map from each device to allocs
+	// We do this because to place a task we have to be able to
+	// preempt allocations that are using the same device.
+	//
+	// This step also filters out high priority allocations and allocations
+	// that are not using any network resources
+	for _, alloc := range currentAllocs {
+		if alloc.Job == nil {
+			continue
+		}
+
+		if jobPriority-alloc.Job.Priority < 10 {
+			continue
+		}
+		if len(alloc.Resources.Networks) > 0 {
+			device := alloc.Resources.Networks[0].Device
+			allocsForDevice := deviceToAllocs[device]
+			allocsForDevice = append(allocsForDevice, alloc)
+			deviceToAllocs[device] = allocsForDevice
+		}
+	}
+
+	// If no existing allocations use network resources, return early
+	if len(deviceToAllocs) == 0 {
+		return nil
+	}
+
+	var allocsToPreempt []*structs.Allocation
+
+	met := false
+	freeBandwidth := 0
+
+	for device, currentAllocs := range deviceToAllocs {
+		totalBandwidth := netIdx.AvailBandwidth[device]
+		// If the device doesn't have enough total available bandwidth, skip
+		if totalBandwidth < MbitsNeeded {
+			continue
+		}
+
+		// Track how much existing free bandwidth we have before preemption
+		freeBandwidth = totalBandwidth - netIdx.UsedBandwidth[device]
+
+		preemptedBandwidth := 0
+
+		// Reset allocsToPreempt since we don't want to preempt across devices for the same task
+		allocsToPreempt = nil
+
+		// Build map from used reserved ports to allocation
+		usedPortToAlloc := make(map[int]*structs.Allocation)
+
+		// First try to satisfy needed reserved ports
+		if len(reservedPortsNeeded) > 0 {
+			for _, alloc := range currentAllocs {
+				for _, tr := range alloc.TaskResources {
+					reservedPorts := tr.Networks[0].ReservedPorts
+					for _, p := range reservedPorts {
+						usedPortToAlloc[p.Value] = alloc
+					}
+				}
+			}
+
+			// Look for allocs that are using reserved ports needed
+			for _, port := range reservedPortsNeeded {
+				alloc, ok := usedPortToAlloc[port.Value]
+				if ok {
+					preemptedBandwidth += alloc.Resources.Networks[0].MBits
+					allocsToPreempt = append(allocsToPreempt, alloc)
+				}
+			}
+
+			// Remove allocs that were preempted to satisfy reserved ports
+			currentAllocs = structs.RemoveAllocs(currentAllocs, allocsToPreempt)
+		}
+
+		// If bandwidth requirements have been met, stop
+		if preemptedBandwidth+freeBandwidth >= MbitsNeeded {
+			met = true
+			break
+		}
+
+		// Split by priority
+		allocsByPriority := filterAndGroupPreemptibleAllocs(jobPriority, currentAllocs)
+
+		for _, allocsGrp := range allocsByPriority {
+			allocs := allocsGrp.allocs
+
+			// Sort by distance function that takes into account needed MBits
+			// as well as penalty for preempting an allocation
+			// whose task group already has existing preemptions
+			sort.Slice(allocs, func(i, j int) bool {
+				firstAlloc := allocs[i]
+				currentPreemptionCount1 := computeCurrentPreemptions(firstAlloc, currentPreemptions)
+
+				// Look up configured maxParallel value for these allocation's task groups
+				var maxParallel1, maxParallel2 int
+				tg1 := allocs[i].Job.LookupTaskGroup(allocs[i].TaskGroup)
+				if tg1 != nil && tg1.Migrate != nil {
+					maxParallel1 = tg1.Migrate.MaxParallel
+				}
+				distance1 := getPreemptionScore(allocs[i].Resources, resourceAsk, NetworkResource, maxParallel1, currentPreemptionCount1)
+
+				secondAlloc := allocs[j]
+				currentPreemptionCount2 := computeCurrentPreemptions(secondAlloc, currentPreemptions)
+				tg2 := secondAlloc.Job.LookupTaskGroup(secondAlloc.TaskGroup)
+				if tg2 != nil && tg2.Migrate != nil {
+					maxParallel2 = tg2.Migrate.MaxParallel
+				}
+				distance2 := getPreemptionScore(secondAlloc.Resources, resourceAsk, NetworkResource, maxParallel2, currentPreemptionCount2)
+
+				return distance1 < distance2
+			})
+
+			for _, alloc := range allocs {
+				preemptedBandwidth += alloc.Resources.Networks[0].MBits
+				allocsToPreempt = append(allocsToPreempt, alloc)
+				if preemptedBandwidth+freeBandwidth >= MbitsNeeded {
+					met = true
+					break
+				}
+			}
+			if met {
+				break
+			}
+		}
+		if met {
+			break
+		}
+	}
+	if len(allocsToPreempt) == 0 {
+		return nil
+	}
+
+	// Build a resource object with just the network Mbits filled in
+	// Its safe to use the first preempted allocation's network resource
+	// here because all allocations preempted will be from the same device
+	nodeRemainingResources := &structs.Resources{
+		Networks: []*structs.NetworkResource{
+			{
+				Device: allocsToPreempt[0].Resources.Networks[0].Device,
+				MBits:  freeBandwidth,
+			},
+		},
+	}
+
+	// Do a final pass to eliminate any superset allocations
+	filteredBestAllocs := eliminateSuperSetAllocations(allocsToPreempt, resourceAsk, nodeRemainingResources, networkResourceDistance, meetsNetworkRequirements)
+	return filteredBestAllocs
+}

--- a/scheduler/preemption.go
+++ b/scheduler/preemption.go
@@ -363,7 +363,6 @@ func preemptForNetworkResourceAsk(jobPriority int, currentAllocs []*structs.Allo
 
 		// If bandwidth requirements have been met, stop
 		if preemptedBandwidth+freeBandwidth >= MbitsNeeded {
-			met = true
 			break
 		}
 
@@ -407,10 +406,12 @@ func preemptForNetworkResourceAsk(jobPriority int, currentAllocs []*structs.Allo
 					break
 				}
 			}
+			// If we met bandwidth needs we can break out of loop that's iterating by priority within a device
 			if met {
 				break
 			}
 		}
+		// If we met bandwidth needs we can break out of loop that's iterating by allocs sharing the same network device
 		if met {
 			break
 		}

--- a/scheduler/preemption.go
+++ b/scheduler/preemption.go
@@ -1,7 +1,6 @@
 package scheduler
 
 import (
-	"fmt"
 	"math"
 	"sort"
 
@@ -13,44 +12,52 @@ import (
 // number of allocations being preempted exceeds max_parallel value in the job's migrate stanza
 const maxParallelPenalty = 50.0
 
-type PreemptionType uint8
-
-const (
-	NetworkResource PreemptionType = iota
-	CPUMemoryDiskIOPS
-)
-
-// resourceDistance returns how close the resource is to the resource being asked for
-// It is calculated by first computing a relative fraction and then measuring how close
-// that is to the origin coordinate. Lower values are better
-func resourceDistance(resource *structs.Resources, resourceAsk *structs.Resources) float64 {
-	memoryCoord, cpuCoord, iopsCoord, diskMBCoord := 0.0, 0.0, 0.0, 0.0
-	if resourceAsk.MemoryMB > 0 {
-		memoryCoord = float64(resourceAsk.MemoryMB-resource.MemoryMB) / float64(resourceAsk.MemoryMB)
+func basicResourceDistance(resourceAsk *structs.ComparableResources, resourceUsed *structs.ComparableResources) float64 {
+	memoryCoord, cpuCoord, diskMBCoord := 0.0, 0.0, 0.0
+	if resourceAsk.Flattened.Memory.MemoryMB > 0 {
+		memoryCoord = (float64(resourceAsk.Flattened.Memory.MemoryMB) - float64(resourceUsed.Flattened.Memory.MemoryMB)) / float64(resourceAsk.Flattened.Memory.MemoryMB)
 	}
-	if resourceAsk.CPU > 0 {
-		cpuCoord = float64(resourceAsk.CPU-resource.CPU) / float64(resourceAsk.CPU)
+	if resourceAsk.Flattened.Cpu.CpuShares > 0 {
+		cpuCoord = (float64(resourceAsk.Flattened.Cpu.CpuShares) - float64(resourceUsed.Flattened.Cpu.CpuShares)) / float64(resourceAsk.Flattened.Cpu.CpuShares)
 	}
-	if resourceAsk.IOPS > 0 {
-		iopsCoord = float64(resourceAsk.IOPS-resource.IOPS) / float64(resourceAsk.IOPS)
+	if resourceAsk.Shared.DiskMB > 0 {
+		diskMBCoord = (float64(resourceAsk.Shared.DiskMB) - float64(resourceUsed.Shared.DiskMB)) / float64(resourceAsk.Shared.DiskMB)
 	}
-	if resourceAsk.DiskMB > 0 {
-		diskMBCoord = float64(resourceAsk.DiskMB-resource.DiskMB) / float64(resourceAsk.DiskMB)
-	}
-
 	originDist := math.Sqrt(
 		math.Pow(memoryCoord, 2) +
 			math.Pow(cpuCoord, 2) +
-			math.Pow(iopsCoord, 2) +
 			math.Pow(diskMBCoord, 2))
 	return originDist
 }
 
+// getPreemptionScoreForTaskGroupResources is used to calculate a score (lower is better) based on the distance between
+// the needed resource and requirements. A penalty is added when the choice already has some existing
+// allocations in the plan that are being preempted.
+func getPreemptionScoreForTaskGroupResources(resourceAsk *structs.ComparableResources, resourceUsed *structs.ComparableResources, maxParallel int, numPreemptedAllocs int) float64 {
+	maxParallelScorePenalty := 0.0
+	if maxParallel > 0 && numPreemptedAllocs >= maxParallel {
+		maxParallelScorePenalty = float64((numPreemptedAllocs+1)-maxParallel) * maxParallelPenalty
+	}
+	return basicResourceDistance(resourceAsk, resourceUsed) + maxParallelScorePenalty
+}
+
+// getPreemptionScoreForNetwork is similar to getPreemptionScoreForTaskGroupResources but only uses network mbits to calculate a preemption score
+func getPreemptionScoreForNetwork(resourceUsed *structs.NetworkResource, resourceNeeded *structs.NetworkResource, maxParallel int, numPreemptedAllocs int) float64 {
+	if resourceUsed == nil || resourceNeeded == nil {
+		return math.MaxFloat64
+	}
+	maxParallelScorePenalty := 0.0
+	if maxParallel > 0 && numPreemptedAllocs >= maxParallel {
+		maxParallelScorePenalty = float64((numPreemptedAllocs+1)-maxParallel) * maxParallelPenalty
+	}
+	return networkResourceDistance(resourceUsed, resourceNeeded) + maxParallelScorePenalty
+}
+
 // networkResourceDistance returns distance based on network megabits
-func networkResourceDistance(resource *structs.Resources, resourceAsk *structs.Resources) float64 {
+func networkResourceDistance(resourceUsed *structs.NetworkResource, resourceNeeded *structs.NetworkResource) float64 {
 	networkCoord := math.MaxFloat64
-	if len(resourceAsk.Networks) > 0 && resourceAsk.Networks[0].MBits > 0 {
-		networkCoord = float64(resourceAsk.Networks[0].MBits-resource.Networks[0].MBits) / float64(resourceAsk.Networks[0].MBits)
+	if resourceUsed != nil && resourceNeeded != nil {
+		networkCoord = float64(resourceNeeded.MBits-resourceUsed.MBits) / float64(resourceNeeded.MBits)
 	}
 
 	originDist := math.Sqrt(
@@ -58,48 +65,31 @@ func networkResourceDistance(resource *structs.Resources, resourceAsk *structs.R
 	return originDist
 }
 
-// getPreemptionScore is used to calculate a score (lower is better) based on the distance between
-// the needed resource and requirements. A penalty is added when the choice already has some existing
-// allocations in the plan that are being preempted.
-func getPreemptionScore(resource *structs.Resources, resourceAsk *structs.Resources, preemptionType PreemptionType, maxParallel int, numPreemptedAllocs int) float64 {
-	maxParallelScorePenalty := 0.0
-	if maxParallel > 0 && numPreemptedAllocs >= maxParallel {
-		maxParallelScorePenalty = float64((numPreemptedAllocs+1)-maxParallel) * maxParallelPenalty
-	}
-	switch preemptionType {
-	case NetworkResource:
-		return networkResourceDistance(resource, resourceAsk) + maxParallelScorePenalty
-	case CPUMemoryDiskIOPS:
-		return resourceDistance(resource, resourceAsk) + maxParallelScorePenalty
-	}
-	panic(fmt.Errorf("Unknown preemption type:%v", preemptionType))
-}
-
 // findPreemptibleAllocationsForTaskGroup computes a list of allocations to preempt to accommodate
 // the resources asked for. Only allocs with a job priority < 10 of jobPriority are considered
 // This method is used after network resource needs have already been met.
-func findPreemptibleAllocationsForTaskGroup(jobPriority int, current []*structs.Allocation, resourceAsk *structs.Resources, node *structs.Node, currentPreemptions []*structs.Allocation) []*structs.Allocation {
-	resourcesNeeded := resourceAsk.Copy()
+func findPreemptibleAllocationsForTaskGroup(jobPriority int, current []*structs.Allocation, resourceAsk *structs.AllocatedResources, node *structs.Node, currentPreemptions []*structs.Allocation) []*structs.Allocation {
+	resourcesNeeded := resourceAsk.Comparable()
 	allocsByPriority := filterAndGroupPreemptibleAllocs(jobPriority, current)
 	var bestAllocs []*structs.Allocation
 	allRequirementsMet := false
-	var preemptedResources *structs.Resources
+	var preemptedResources *structs.ComparableResources
 
 	//TODO(preetha): should add some debug logging
 
-	nodeRemainingResources := node.Resources.Copy()
+	nodeRemainingResources := node.ComparableResources()
 
 	// Initialize nodeRemainingResources with the remaining resources
 	// after accounting for reserved resources and all allocations
 
 	// Subtract the reserved resources of the node
-	if node.Reserved != nil {
-		nodeRemainingResources.Subtract(node.Reserved)
+	if node.ComparableReservedResources() != nil {
+		nodeRemainingResources.Subtract(node.ComparableReservedResources())
 	}
 
 	// Subtract current allocations
 	for _, alloc := range current {
-		nodeRemainingResources.Subtract(alloc.Resources)
+		nodeRemainingResources.Subtract(alloc.ComparableResources())
 	}
 
 	// Iterate over allocations grouped by priority to find preemptible allocations
@@ -115,7 +105,7 @@ func findPreemptibleAllocationsForTaskGroup(jobPriority int, current []*structs.
 				if tg != nil && tg.Migrate != nil {
 					maxParallel = tg.Migrate.MaxParallel
 				}
-				distance := getPreemptionScore(alloc.Resources, resourcesNeeded, CPUMemoryDiskIOPS, maxParallel, currentPreemptionCount)
+				distance := getPreemptionScoreForTaskGroupResources(resourcesNeeded, alloc.ComparableResources(), maxParallel, currentPreemptionCount)
 				if distance < bestDistance {
 					bestDistance = distance
 					closestAllocIndex = index
@@ -124,19 +114,22 @@ func findPreemptibleAllocationsForTaskGroup(jobPriority int, current []*structs.
 			closestAlloc := allocGrp.allocs[closestAllocIndex]
 
 			if preemptedResources == nil {
-				preemptedResources = closestAlloc.Resources.Copy()
+				preemptedResources = closestAlloc.ComparableResources()
 			} else {
-				preemptedResources.Add(closestAlloc.Resources)
+				preemptedResources.Add(closestAlloc.ComparableResources())
 			}
 			availableResources := preemptedResources.Copy()
 			availableResources.Add(nodeRemainingResources)
 
-			allRequirementsMet = meetsNonNetworkRequirements(availableResources, resourceAsk)
+			// This step needs the original resources asked for as the second arg, can't use the running total
+			allRequirementsMet = meetsNonNetworkRequirements(availableResources, resourceAsk.Comparable())
 			bestAllocs = append(bestAllocs, closestAlloc)
 
 			allocGrp.allocs[closestAllocIndex] = allocGrp.allocs[len(allocGrp.allocs)-1]
 			allocGrp.allocs = allocGrp.allocs[:len(allocGrp.allocs)-1]
-			resourcesNeeded.Subtract(closestAlloc.Resources)
+
+			// this is the remaining total of resources needed
+			resourcesNeeded.Subtract(closestAlloc.ComparableResources())
 		}
 		if allRequirementsMet {
 			break
@@ -148,9 +141,18 @@ func findPreemptibleAllocationsForTaskGroup(jobPriority int, current []*structs.
 		return nil
 	}
 
+	resourcesNeeded = resourceAsk.Comparable()
 	// We do another pass to eliminate unnecessary preemptions
 	// This filters out allocs whose resources are already covered by another alloc
-	filteredBestAllocs := eliminateSuperSetAllocations(bestAllocs, resourceAsk, nodeRemainingResources, resourceDistance, meetsNonNetworkRequirements)
+
+	// Sort bestAllocs by distance descending (without penalty)
+	sort.Slice(bestAllocs, func(i, j int) bool {
+		distance1 := basicResourceDistance(resourcesNeeded, bestAllocs[i].ComparableResources())
+		distance2 := basicResourceDistance(resourcesNeeded, bestAllocs[j].ComparableResources())
+		return distance1 > distance2
+	})
+
+	filteredBestAllocs := eliminateSuperSetAllocationsForTaskGroup(bestAllocs, nodeRemainingResources, resourcesNeeded)
 	return filteredBestAllocs
 
 }
@@ -169,28 +171,25 @@ func computeCurrentPreemptions(currentAlloc *structs.Allocation, currentPreempti
 
 // meetsNonNetworkRequirements checks if the first resource meets or exceeds the second resource's requirements
 // This intentionally ignores network requirements, those are handled by meetsNetworkRequirements
-func meetsNonNetworkRequirements(first *structs.Resources, second *structs.Resources) bool {
-	if first.CPU < second.CPU {
+func meetsNonNetworkRequirements(first *structs.ComparableResources, second *structs.ComparableResources) bool {
+	if first.Flattened.Cpu.CpuShares < second.Flattened.Cpu.CpuShares {
 		return false
 	}
-	if first.MemoryMB < second.MemoryMB {
+	if first.Flattened.Memory.MemoryMB < second.Flattened.Memory.MemoryMB {
 		return false
 	}
-	if first.DiskMB < second.DiskMB {
-		return false
-	}
-	if first.IOPS < second.IOPS {
+	if first.Shared.DiskMB < second.Shared.DiskMB {
 		return false
 	}
 	return true
 }
 
 // meetsNetworkRequirements checks if the first resource meets or exceeds the second resource's network MBits requirements
-func meetsNetworkRequirements(first *structs.Resources, second *structs.Resources) bool {
-	if len(first.Networks) == 0 || len(second.Networks) == 0 {
+func meetsNetworkRequirements(firstMbits int, secondMbits int) bool {
+	if firstMbits == 0 || secondMbits == 0 {
 		return false
 	}
-	return first.Networks[0].MBits >= second.Networks[0].MBits
+	return firstMbits >= secondMbits
 }
 
 type groupedAllocs struct {
@@ -235,35 +234,52 @@ func filterAndGroupPreemptibleAllocs(jobPriority int, current []*structs.Allocat
 	return groupedSortedAllocs
 }
 
-type distanceFn func(first *structs.Resources, second *structs.Resources) float64
+func eliminateSuperSetAllocationsForTaskGroup(bestAllocs []*structs.Allocation,
+	nodeRemainingResources *structs.ComparableResources,
+	resourceAsk *structs.ComparableResources) []*structs.Allocation {
 
-type meetsRequirementsFn func(first *structs.Resources, second *structs.Resources) bool
-
-func eliminateSuperSetAllocations(bestAllocs []*structs.Allocation, resourceAsk *structs.Resources,
-	nodeRemainingResources *structs.Resources, distanceFunc distanceFn, reqFunc meetsRequirementsFn) []*structs.Allocation {
-	// Sort by distance reversed to surface any superset allocs first
-	sort.Slice(bestAllocs, func(i, j int) bool {
-		distance1 := distanceFunc(bestAllocs[i].Resources, resourceAsk)
-		distance2 := distanceFunc(bestAllocs[j].Resources, resourceAsk)
-		return distance1 > distance2
-	})
-
-	var preemptedResources *structs.Resources
+	var preemptedResources *structs.ComparableResources
 	var filteredBestAllocs []*structs.Allocation
 
 	// Do another pass to eliminate allocations that are a superset of other allocations
 	// in the preemption set
 	for _, alloc := range bestAllocs {
 		if preemptedResources == nil {
-			preemptedResources = alloc.Resources
+			preemptedResources = alloc.ComparableResources().Copy()
 		} else {
-			preemptedResources.Add(alloc.Resources)
+			preemptedResources.Add(alloc.ComparableResources().Copy())
 		}
 		filteredBestAllocs = append(filteredBestAllocs, alloc)
 		availableResources := preemptedResources.Copy()
 		availableResources.Add(nodeRemainingResources)
 
-		requirementsMet := reqFunc(availableResources, resourceAsk)
+		requirementsMet, _ := availableResources.Superset(resourceAsk)
+		if requirementsMet {
+			break
+		}
+	}
+	return filteredBestAllocs
+}
+
+func eliminateSuperSetAllocationsForNetwork(bestAllocs []*structs.Allocation, networkResourcesAsk *structs.NetworkResource,
+	nodeRemainingResources *structs.ComparableResources) []*structs.Allocation {
+
+	var preemptedResources *structs.ComparableResources
+	var filteredBestAllocs []*structs.Allocation
+
+	// Do another pass to eliminate allocations that are a superset of other allocations
+	// in the preemption set
+	for _, alloc := range bestAllocs {
+		if preemptedResources == nil {
+			preemptedResources = alloc.ComparableResources().Copy()
+		} else {
+			preemptedResources.Add(alloc.ComparableResources().Copy())
+		}
+		filteredBestAllocs = append(filteredBestAllocs, alloc)
+		availableResources := preemptedResources.Copy()
+		availableResources.Add(nodeRemainingResources)
+
+		requirementsMet := meetsNetworkRequirements(availableResources.Flattened.Networks[0].MBits, networkResourcesAsk.MBits)
 		if requirementsMet {
 			break
 		}
@@ -274,7 +290,7 @@ func eliminateSuperSetAllocations(bestAllocs []*structs.Allocation, resourceAsk 
 // preemptForNetworkResourceAsk tries to find allocations to preempt to meet network resources.
 // this needs to consider network resources at the task level and for the same task it should
 // only preempt allocations that share the same network device
-func preemptForNetworkResourceAsk(jobPriority int, currentAllocs []*structs.Allocation, resourceAsk *structs.Resources,
+func preemptForNetworkResourceAsk(jobPriority int, currentAllocs []*structs.Allocation, networkResourceAsk *structs.NetworkResource,
 	netIdx *structs.NetworkIndex, currentPreemptions []*structs.Allocation) []*structs.Allocation {
 
 	// Early return if there are no current allocs
@@ -282,7 +298,6 @@ func preemptForNetworkResourceAsk(jobPriority int, currentAllocs []*structs.Allo
 		return nil
 	}
 
-	networkResourceAsk := resourceAsk.Networks[0]
 	deviceToAllocs := make(map[string][]*structs.Allocation)
 	MbitsNeeded := networkResourceAsk.MBits
 	reservedPortsNeeded := networkResourceAsk.ReservedPorts
@@ -301,8 +316,9 @@ func preemptForNetworkResourceAsk(jobPriority int, currentAllocs []*structs.Allo
 		if jobPriority-alloc.Job.Priority < 10 {
 			continue
 		}
-		if len(alloc.Resources.Networks) > 0 {
-			device := alloc.Resources.Networks[0].Device
+		networks := alloc.CompatibleNetworkResources()
+		if len(networks) > 0 {
+			device := networks[0].Device
 			allocsForDevice := deviceToAllocs[device]
 			allocsForDevice = append(allocsForDevice, alloc)
 			deviceToAllocs[device] = allocsForDevice
@@ -376,26 +392,7 @@ func preemptForNetworkResourceAsk(jobPriority int, currentAllocs []*structs.Allo
 			// as well as penalty for preempting an allocation
 			// whose task group already has existing preemptions
 			sort.Slice(allocs, func(i, j int) bool {
-				firstAlloc := allocs[i]
-				currentPreemptionCount1 := computeCurrentPreemptions(firstAlloc, currentPreemptions)
-
-				// Look up configured maxParallel value for these allocation's task groups
-				var maxParallel1, maxParallel2 int
-				tg1 := allocs[i].Job.LookupTaskGroup(allocs[i].TaskGroup)
-				if tg1 != nil && tg1.Migrate != nil {
-					maxParallel1 = tg1.Migrate.MaxParallel
-				}
-				distance1 := getPreemptionScore(allocs[i].Resources, resourceAsk, NetworkResource, maxParallel1, currentPreemptionCount1)
-
-				secondAlloc := allocs[j]
-				currentPreemptionCount2 := computeCurrentPreemptions(secondAlloc, currentPreemptions)
-				tg2 := secondAlloc.Job.LookupTaskGroup(secondAlloc.TaskGroup)
-				if tg2 != nil && tg2.Migrate != nil {
-					maxParallel2 = tg2.Migrate.MaxParallel
-				}
-				distance2 := getPreemptionScore(secondAlloc.Resources, resourceAsk, NetworkResource, maxParallel2, currentPreemptionCount2)
-
-				return distance1 < distance2
+				return distanceComparatorForNetwork(allocs, currentPreemptions, networkResourceAsk, i, j)
 			})
 
 			for _, alloc := range allocs {
@@ -423,16 +420,77 @@ func preemptForNetworkResourceAsk(jobPriority int, currentAllocs []*structs.Allo
 	// Build a resource object with just the network Mbits filled in
 	// Its safe to use the first preempted allocation's network resource
 	// here because all allocations preempted will be from the same device
-	nodeRemainingResources := &structs.Resources{
-		Networks: []*structs.NetworkResource{
-			{
-				Device: allocsToPreempt[0].Resources.Networks[0].Device,
-				MBits:  freeBandwidth,
+	nodeRemainingResources := &structs.ComparableResources{
+		Flattened: structs.AllocatedTaskResources{
+			Networks: []*structs.NetworkResource{
+				{
+					Device: allocsToPreempt[0].Resources.Networks[0].Device,
+					MBits:  freeBandwidth,
+				},
 			},
 		},
 	}
 
+	// Sort by distance reversed to surface any superset allocs first
+	// This sort only looks at mbits because we should still not prefer
+	// allocs that have a maxParallel penalty
+	sort.Slice(allocsToPreempt, func(i, j int) bool {
+		firstAlloc := allocsToPreempt[i]
+		secondAlloc := allocsToPreempt[j]
+
+		firstAllocNetworks := firstAlloc.ComparableResources().Flattened.Networks
+		var firstAllocNetResourceUsed *structs.NetworkResource
+		if len(firstAllocNetworks) > 0 {
+			firstAllocNetResourceUsed = firstAllocNetworks[0]
+		}
+
+		secondAllocNetworks := secondAlloc.ComparableResources().Flattened.Networks
+		var secondAllocNetResourceUsed *structs.NetworkResource
+		if len(secondAllocNetworks) > 0 {
+			secondAllocNetResourceUsed = secondAllocNetworks[0]
+		}
+
+		distance1 := networkResourceDistance(firstAllocNetResourceUsed, networkResourceAsk)
+		distance2 := networkResourceDistance(secondAllocNetResourceUsed, networkResourceAsk)
+		return distance1 > distance2
+	})
+
 	// Do a final pass to eliminate any superset allocations
-	filteredBestAllocs := eliminateSuperSetAllocations(allocsToPreempt, resourceAsk, nodeRemainingResources, networkResourceDistance, meetsNetworkRequirements)
+	filteredBestAllocs := eliminateSuperSetAllocationsForNetwork(allocsToPreempt, networkResourceAsk, nodeRemainingResources)
 	return filteredBestAllocs
+}
+
+func distanceComparatorForNetwork(allocs []*structs.Allocation, currentPreemptions []*structs.Allocation, networkResourceAsk *structs.NetworkResource, i int, j int) bool {
+	firstAlloc := allocs[i]
+	currentPreemptionCount1 := computeCurrentPreemptions(firstAlloc, currentPreemptions)
+	// Look up configured maxParallel value for these allocation's task groups
+	var maxParallel1, maxParallel2 int
+	tg1 := allocs[i].Job.LookupTaskGroup(firstAlloc.TaskGroup)
+	if tg1 != nil && tg1.Migrate != nil {
+		maxParallel1 = tg1.Migrate.MaxParallel
+	}
+	// Dereference network usage on first alloc if its there
+	firstAllocNetworks := firstAlloc.CompatibleNetworkResources()
+	var firstAllocNetResourceUsed *structs.NetworkResource
+	if len(firstAllocNetworks) > 0 {
+		firstAllocNetResourceUsed = firstAllocNetworks[0]
+	}
+
+	distance1 := getPreemptionScoreForNetwork(firstAllocNetResourceUsed, networkResourceAsk, maxParallel1, currentPreemptionCount1)
+
+	secondAlloc := allocs[j]
+	currentPreemptionCount2 := computeCurrentPreemptions(secondAlloc, currentPreemptions)
+	tg2 := secondAlloc.Job.LookupTaskGroup(secondAlloc.TaskGroup)
+	if tg2 != nil && tg2.Migrate != nil {
+		maxParallel2 = tg2.Migrate.MaxParallel
+	}
+	// Dereference network usage on first alloc if its there
+	secondAllocNetworks := secondAlloc.CompatibleNetworkResources()
+	var secondAllocNetResourceUsed *structs.NetworkResource
+	if len(secondAllocNetworks) > 0 {
+		secondAllocNetResourceUsed = secondAllocNetworks[0]
+	}
+
+	distance2 := getPreemptionScoreForNetwork(secondAllocNetResourceUsed, networkResourceAsk, maxParallel2, currentPreemptionCount2)
+	return distance1 < distance2
 }

--- a/scheduler/preemption.go
+++ b/scheduler/preemption.go
@@ -122,7 +122,8 @@ func findPreemptibleAllocationsForTaskGroup(jobPriority int, current []*structs.
 			availableResources.Add(nodeRemainingResources)
 
 			// This step needs the original resources asked for as the second arg, can't use the running total
-			allRequirementsMet = meetsNonNetworkRequirements(availableResources, resourceAsk.Comparable())
+			allRequirementsMet, _ = availableResources.Superset(resourceAsk.Comparable())
+
 			bestAllocs = append(bestAllocs, closestAlloc)
 
 			allocGrp.allocs[closestAllocIndex] = allocGrp.allocs[len(allocGrp.allocs)-1]
@@ -167,21 +168,6 @@ func computeCurrentPreemptions(currentAlloc *structs.Allocation, currentPreempti
 		}
 	}
 	return numCurrentPreemptionsForJob
-}
-
-// meetsNonNetworkRequirements checks if the first resource meets or exceeds the second resource's requirements
-// This intentionally ignores network requirements, those are handled by meetsNetworkRequirements
-func meetsNonNetworkRequirements(first *structs.ComparableResources, second *structs.ComparableResources) bool {
-	if first.Flattened.Cpu.CpuShares < second.Flattened.Cpu.CpuShares {
-		return false
-	}
-	if first.Flattened.Memory.MemoryMB < second.Flattened.Memory.MemoryMB {
-		return false
-	}
-	if first.Shared.DiskMB < second.Shared.DiskMB {
-		return false
-	}
-	return true
 }
 
 // meetsNetworkRequirements checks if the first resource meets or exceeds the second resource's network MBits requirements

--- a/scheduler/preemption_test.go
+++ b/scheduler/preemption_test.go
@@ -1,0 +1,789 @@
+package scheduler
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceDistance(t *testing.T) {
+	resourceAsk := &structs.Resources{
+		CPU:      2048,
+		MemoryMB: 512,
+		IOPS:     300,
+		DiskMB:   4096,
+		Networks: []*structs.NetworkResource{
+			{
+				Device: "eth0",
+				MBits:  1024,
+			},
+		},
+	}
+
+	type testCase struct {
+		allocResource    *structs.Resources
+		expectedDistance string
+	}
+
+	testCases := []*testCase{
+		{
+			&structs.Resources{
+				CPU:      2048,
+				MemoryMB: 512,
+				IOPS:     300,
+				DiskMB:   4096,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						MBits:  1024,
+					},
+				},
+			},
+			"0.000",
+		},
+		{
+			&structs.Resources{
+				CPU:      1024,
+				MemoryMB: 400,
+				IOPS:     200,
+				DiskMB:   1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						MBits:  1024,
+					},
+				},
+			},
+			"0.986",
+		},
+		{
+			&structs.Resources{
+				CPU:      1024,
+				MemoryMB: 200,
+				IOPS:     200,
+				DiskMB:   1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						MBits:  512,
+					},
+				},
+			},
+			"1.138",
+		},
+		{
+			&structs.Resources{
+				CPU:      8192,
+				MemoryMB: 200,
+				IOPS:     200,
+				DiskMB:   1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						MBits:  512,
+					},
+				},
+			},
+			"3.169",
+		},
+		{
+			&structs.Resources{
+				CPU:      2048,
+				MemoryMB: 500,
+				IOPS:     300,
+				DiskMB:   4096,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						MBits:  1024,
+					},
+				},
+			},
+			"0.023",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			require := require.New(t)
+			require.Equal(tc.expectedDistance, fmt.Sprintf("%3.3f", resourceDistance(tc.allocResource, resourceAsk)))
+		})
+
+	}
+
+}
+
+func TestPreemption(t *testing.T) {
+	type testCase struct {
+		desc                 string
+		currentAllocations   []*structs.Allocation
+		nodeReservedCapacity *structs.Resources
+		nodeCapacity         *structs.Resources
+		resourceAsk          *structs.Resources
+		jobPriority          int
+		currentPreemptions   []*structs.Allocation
+		preemptedAllocIDs    map[string]struct{}
+	}
+
+	highPrioJob := mock.Job()
+	highPrioJob.Priority = 100
+
+	lowPrioJob := mock.Job()
+	lowPrioJob.Priority = 30
+
+	lowPrioJob2 := mock.Job()
+	lowPrioJob2.Priority = 30
+
+	// Create some persistent alloc ids to use in test cases
+	allocIDs := []string{uuid.Generate(), uuid.Generate(), uuid.Generate(), uuid.Generate(), uuid.Generate()}
+
+	nodeResources := &structs.Resources{
+		CPU:      4000,
+		MemoryMB: 8192,
+		DiskMB:   100 * 1024,
+		IOPS:     150,
+		Networks: []*structs.NetworkResource{
+			{
+				Device: "eth0",
+				CIDR:   "192.168.0.100/32",
+				MBits:  1000,
+			},
+		},
+	}
+	reservedNodeResources := &structs.Resources{
+		CPU:      100,
+		MemoryMB: 256,
+		DiskMB:   4 * 1024,
+		Networks: []*structs.NetworkResource{
+			{
+				Device:        "eth0",
+				IP:            "192.168.0.100",
+				ReservedPorts: []structs.Port{{Label: "ssh", Value: 22}},
+				MBits:         1,
+			},
+		},
+	}
+
+	testCases := []testCase{
+		{
+			desc: "No preemption because existing allocs are not low priority",
+			currentAllocations: []*structs.Allocation{
+				createAlloc(allocIDs[0], highPrioJob, &structs.Resources{
+					CPU:      3200,
+					MemoryMB: 7256,
+					DiskMB:   4 * 1024,
+					IOPS:     150,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  50,
+						},
+					},
+				})},
+			nodeReservedCapacity: reservedNodeResources,
+			nodeCapacity:         nodeResources,
+			jobPriority:          100,
+			resourceAsk: &structs.Resources{
+				CPU:      100,
+				MemoryMB: 256,
+				DiskMB:   4 * 1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device:        "eth0",
+						IP:            "192.168.0.100",
+						ReservedPorts: []structs.Port{{Label: "ssh", Value: 22}},
+						MBits:         1,
+					},
+				},
+			},
+		},
+		{
+			desc: "Preempting low priority allocs not enough to meet resource ask",
+			currentAllocations: []*structs.Allocation{
+				createAlloc(allocIDs[0], lowPrioJob, &structs.Resources{
+					CPU:      3200,
+					MemoryMB: 7256,
+					DiskMB:   4 * 1024,
+					IOPS:     150,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  50,
+						},
+					},
+				})},
+			nodeReservedCapacity: reservedNodeResources,
+			nodeCapacity:         nodeResources,
+			jobPriority:          100,
+			resourceAsk: &structs.Resources{
+				CPU:      4000,
+				MemoryMB: 8192,
+				DiskMB:   4 * 1024,
+				IOPS:     300,
+				Networks: []*structs.NetworkResource{
+					{
+						Device:        "eth0",
+						IP:            "192.168.0.100",
+						ReservedPorts: []structs.Port{{Label: "ssh", Value: 22}},
+						MBits:         1,
+					},
+				},
+			},
+		},
+		{
+			desc: "Combination of high/low priority allocs, without static ports",
+			currentAllocations: []*structs.Allocation{
+				createAlloc(allocIDs[0], highPrioJob, &structs.Resources{
+					CPU:      2800,
+					MemoryMB: 2256,
+					DiskMB:   4 * 1024,
+					IOPS:     150,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  150,
+						},
+					},
+				}),
+				createAlloc(allocIDs[1], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.200",
+							MBits:  500,
+						},
+					},
+				}),
+				createAlloc(allocIDs[2], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  300,
+						},
+					},
+				}),
+				createAlloc(allocIDs[3], lowPrioJob, &structs.Resources{
+					CPU:      700,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+				}),
+			},
+			nodeReservedCapacity: reservedNodeResources,
+			nodeCapacity:         nodeResources,
+			jobPriority:          100,
+			resourceAsk: &structs.Resources{
+				CPU:      1100,
+				MemoryMB: 1000,
+				DiskMB:   25 * 1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						IP:     "192.168.0.100",
+						MBits:  840,
+					},
+				},
+			},
+			preemptedAllocIDs: map[string]struct{}{
+				allocIDs[1]: {},
+				allocIDs[2]: {},
+				allocIDs[3]: {},
+			},
+		}, {
+			desc: "Preemption needed for all resources except network",
+			currentAllocations: []*structs.Allocation{
+				createAlloc(allocIDs[0], highPrioJob, &structs.Resources{
+					CPU:      2800,
+					MemoryMB: 2256,
+					DiskMB:   40 * 1024,
+					IOPS:     100,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  150,
+						},
+					},
+				}),
+				createAlloc(allocIDs[1], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.200",
+							MBits:  50,
+						},
+					},
+				}),
+				createAlloc(allocIDs[2], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 512,
+					DiskMB:   25 * 1024,
+				}),
+				createAlloc(allocIDs[3], lowPrioJob, &structs.Resources{
+					CPU:      700,
+					MemoryMB: 276,
+					DiskMB:   20 * 1024,
+				}),
+			},
+			nodeReservedCapacity: reservedNodeResources,
+			nodeCapacity:         nodeResources,
+			jobPriority:          100,
+			resourceAsk: &structs.Resources{
+				CPU:      1000,
+				MemoryMB: 3000,
+				DiskMB:   50 * 1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						IP:     "192.168.0.100",
+						MBits:  50,
+					},
+				},
+			},
+			preemptedAllocIDs: map[string]struct{}{
+				allocIDs[1]: {},
+				allocIDs[2]: {},
+				allocIDs[3]: {},
+			},
+		},
+		{
+			desc: "Only one low priority alloc needs to be preempted",
+			currentAllocations: []*structs.Allocation{
+				createAlloc(allocIDs[0], highPrioJob, &structs.Resources{
+					CPU:      1200,
+					MemoryMB: 2256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  150,
+						},
+					},
+				}),
+				createAlloc(allocIDs[1], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     10,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  500,
+						},
+					},
+				}),
+				createAlloc(allocIDs[2], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     10,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.200",
+							MBits:  300,
+						},
+					},
+				}),
+			},
+			nodeReservedCapacity: reservedNodeResources,
+			nodeCapacity:         nodeResources,
+			jobPriority:          100,
+			resourceAsk: &structs.Resources{
+				CPU:      300,
+				MemoryMB: 500,
+				DiskMB:   5 * 1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						IP:     "192.168.0.100",
+						MBits:  320,
+					},
+				},
+			},
+			preemptedAllocIDs: map[string]struct{}{
+				allocIDs[2]: {},
+			},
+		},
+		{
+			desc: "one alloc meets static port need, another meets remaining mbits needed",
+			currentAllocations: []*structs.Allocation{
+				createAlloc(allocIDs[0], highPrioJob, &structs.Resources{
+					CPU:      1200,
+					MemoryMB: 2256,
+					DiskMB:   4 * 1024,
+					IOPS:     150,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  150,
+						},
+					},
+				}),
+				createAlloc(allocIDs[1], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.200",
+							MBits:  500,
+							ReservedPorts: []structs.Port{
+								{
+									Label: "db",
+									Value: 88,
+								},
+							},
+						},
+					},
+				}),
+				createAlloc(allocIDs[2], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  200,
+						},
+					},
+				}),
+			},
+			nodeReservedCapacity: reservedNodeResources,
+			nodeCapacity:         nodeResources,
+			jobPriority:          100,
+			resourceAsk: &structs.Resources{
+				CPU:      2700,
+				MemoryMB: 1000,
+				DiskMB:   25 * 1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						IP:     "192.168.0.100",
+						MBits:  800,
+						ReservedPorts: []structs.Port{
+							{
+								Label: "db",
+								Value: 88,
+							},
+						},
+					},
+				},
+			},
+			preemptedAllocIDs: map[string]struct{}{
+				allocIDs[1]: {},
+				allocIDs[2]: {},
+			},
+		},
+		{
+			desc: "alloc that meets static port need also meets other needds",
+			currentAllocations: []*structs.Allocation{
+				createAlloc(allocIDs[0], highPrioJob, &structs.Resources{
+					CPU:      1200,
+					MemoryMB: 2256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  150,
+						},
+					},
+				}),
+				createAlloc(allocIDs[1], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.200",
+							MBits:  600,
+							ReservedPorts: []structs.Port{
+								{
+									Label: "db",
+									Value: 88,
+								},
+							},
+						},
+					},
+				}),
+				createAlloc(allocIDs[2], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  100,
+						},
+					},
+				}),
+			},
+			nodeReservedCapacity: reservedNodeResources,
+			nodeCapacity:         nodeResources,
+			jobPriority:          100,
+			resourceAsk: &structs.Resources{
+				CPU:      600,
+				MemoryMB: 1000,
+				DiskMB:   25 * 1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						IP:     "192.168.0.100",
+						MBits:  700,
+						ReservedPorts: []structs.Port{
+							{
+								Label: "db",
+								Value: 88,
+							},
+						},
+					},
+				},
+			},
+			preemptedAllocIDs: map[string]struct{}{
+				allocIDs[1]: {},
+			},
+		},
+		{
+			desc: "alloc from job that has existing evictions not chosen for preemption",
+			currentAllocations: []*structs.Allocation{
+				createAlloc(allocIDs[0], highPrioJob, &structs.Resources{
+					CPU:      1200,
+					MemoryMB: 2256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  150,
+						},
+					},
+				}),
+				createAlloc(allocIDs[1], lowPrioJob, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     10,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.200",
+							MBits:  500,
+						},
+					},
+				}),
+				createAlloc(allocIDs[2], lowPrioJob2, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     10,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  300,
+						},
+					},
+				}),
+			},
+			nodeReservedCapacity: reservedNodeResources,
+			nodeCapacity:         nodeResources,
+			jobPriority:          100,
+			resourceAsk: &structs.Resources{
+				CPU:      300,
+				MemoryMB: 500,
+				DiskMB:   5 * 1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						IP:     "192.168.0.100",
+						MBits:  320,
+					},
+				},
+			},
+			currentPreemptions: []*structs.Allocation{
+				createAlloc(allocIDs[4], lowPrioJob2, &structs.Resources{
+					CPU:      200,
+					MemoryMB: 256,
+					DiskMB:   4 * 1024,
+					IOPS:     10,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  300,
+						},
+					},
+				}),
+			},
+			preemptedAllocIDs: map[string]struct{}{
+				allocIDs[1]: {},
+			},
+		},
+		// This test case exercises the code path for a final filtering step that tries to
+		// minimize the number of preemptible allocations
+		{
+			desc: "Filter out allocs whose resource usage superset is also in the preemption list",
+			currentAllocations: []*structs.Allocation{
+				createAlloc(allocIDs[0], highPrioJob, &structs.Resources{
+					CPU:      1800,
+					MemoryMB: 2256,
+					DiskMB:   4 * 1024,
+					IOPS:     50,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  150,
+						},
+					},
+				}),
+				createAlloc(allocIDs[1], lowPrioJob, &structs.Resources{
+					CPU:      1500,
+					MemoryMB: 256,
+					DiskMB:   5 * 1024,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.100",
+							MBits:  100,
+						},
+					},
+				}),
+				createAlloc(allocIDs[2], lowPrioJob, &structs.Resources{
+					CPU:      600,
+					MemoryMB: 256,
+					DiskMB:   5 * 1024,
+					Networks: []*structs.NetworkResource{
+						{
+							Device: "eth0",
+							IP:     "192.168.0.200",
+							MBits:  300,
+						},
+					},
+				}),
+			},
+			nodeReservedCapacity: reservedNodeResources,
+			nodeCapacity:         nodeResources,
+			jobPriority:          100,
+			resourceAsk: &structs.Resources{
+				CPU:      1000,
+				MemoryMB: 256,
+				DiskMB:   5 * 1024,
+				Networks: []*structs.NetworkResource{
+					{
+						Device: "eth0",
+						IP:     "192.168.0.100",
+						MBits:  50,
+					},
+				},
+			},
+			preemptedAllocIDs: map[string]struct{}{
+				allocIDs[1]: {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			node := mock.Node()
+			node.Resources = tc.nodeCapacity
+			node.Reserved = tc.nodeReservedCapacity
+
+			state, ctx := testContext(t)
+			nodes := []*RankedNode{
+				{
+					Node: node,
+				},
+			}
+			state.UpsertNode(1000, node)
+			for _, alloc := range tc.currentAllocations {
+				alloc.NodeID = node.ID
+			}
+			require := require.New(t)
+			err := state.UpsertAllocs(1001, tc.currentAllocations)
+			require.Nil(err)
+			if tc.currentPreemptions != nil {
+				ctx.plan.NodePreemptions[node.ID] = tc.currentPreemptions
+			}
+			static := NewStaticRankIterator(ctx, nodes)
+			binPackIter := NewBinPackIterator(ctx, static, true, tc.jobPriority)
+
+			taskGroup := &structs.TaskGroup{
+				EphemeralDisk: &structs.EphemeralDisk{},
+				Tasks: []*structs.Task{
+					{
+						Name:      "web",
+						Resources: tc.resourceAsk,
+					},
+				},
+			}
+			binPackIter.SetTaskGroup(taskGroup)
+			option := binPackIter.Next()
+			if tc.preemptedAllocIDs == nil {
+				require.Nil(option)
+			} else {
+				require.NotNil(option)
+				preemptedAllocs := option.PreemptedAllocs
+				require.Equal(len(tc.preemptedAllocIDs), len(preemptedAllocs))
+				for _, alloc := range preemptedAllocs {
+					_, ok := tc.preemptedAllocIDs[alloc.ID]
+					require.True(ok)
+				}
+			}
+		})
+	}
+}
+
+// helper method to create allocations with given jobs and resources
+func createAlloc(id string, job *structs.Job, resource *structs.Resources) *structs.Allocation {
+	alloc := &structs.Allocation{
+		ID:    id,
+		Job:   job,
+		JobID: job.ID,
+		TaskResources: map[string]*structs.Resources{
+			"web": resource,
+		},
+		Resources:     resource,
+		Namespace:     structs.DefaultNamespace,
+		EvalID:        uuid.Generate(),
+		DesiredStatus: structs.AllocDesiredStatusRun,
+		ClientStatus:  structs.AllocClientStatusRunning,
+		TaskGroup:     "web",
+	}
+	return alloc
+}

--- a/scheduler/preemption_test.go
+++ b/scheduler/preemption_test.go
@@ -754,9 +754,7 @@ func TestPreemption(t *testing.T) {
 			}
 			require := require.New(t)
 			err := state.UpsertAllocs(1001, tc.currentAllocations)
-			for _, alloc := range tc.currentAllocations {
-				fmt.Println(alloc.ID)
-			}
+
 			require.Nil(err)
 			if tc.currentPreemptions != nil {
 				ctx.plan.NodePreemptions[node.ID] = tc.currentPreemptions
@@ -782,7 +780,6 @@ func TestPreemption(t *testing.T) {
 				require.NotNil(option)
 				preemptedAllocs := option.PreemptedAllocs
 				require.Equal(len(tc.preemptedAllocIDs), len(preemptedAllocs))
-				fmt.Println(preemptedAllocs[0].ID)
 				for _, alloc := range preemptedAllocs {
 					_, ok := tc.preemptedAllocIDs[alloc.ID]
 					require.True(ok)

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -234,7 +234,7 @@ OUTER:
 					}
 
 					// Look for preemptible allocations to satisfy the network resource for this task
-					preemptedAllocsForTaskNetwork := preemptForNetworkResourceAsk(iter.priority, proposed, taskResources, netIdx, currentPreemptions)
+					preemptedAllocsForTaskNetwork := preemptForNetworkResourceAsk(iter.priority, proposed, ask, netIdx, currentPreemptions)
 					if preemptedAllocsForTaskNetwork == nil {
 						iter.ctx.Metrics().ExhaustedNode(option.Node,
 							fmt.Sprintf("unable to meet network resource %v after preemption", ask))

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -88,6 +88,9 @@ type State interface {
 	// LatestDeploymentByJobID returns the latest deployment matching the given
 	// job ID
 	LatestDeploymentByJobID(ws memdb.WatchSet, namespace, jobID string) (*structs.Deployment, error)
+
+	// SchedulerConfig returns config options for the scheduler
+	SchedulerConfig() (uint64, *structs.SchedulerConfiguration, error)
 }
 
 // Planner interface is used to submit a task allocation plan.

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -287,9 +287,9 @@ func NewSystemStack(ctx Context) *SystemStack {
 	// by a particular task group. Enable eviction as system jobs are high
 	// priority.
 	_, schedConfig, _ := s.ctx.State().SchedulerConfig()
-	enablePreemption := false
+	enablePreemption := true
 	if schedConfig != nil {
-		enablePreemption = schedConfig.EnablePreemption
+		enablePreemption = schedConfig.PreemptionConfig.SystemSchedulerEnabled
 	}
 	s.binPack = NewBinPackIterator(ctx, rankSource, enablePreemption, 0)
 

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSystemSched_JobRegister(t *testing.T) {
@@ -218,7 +221,7 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 		JobID:       job1.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	noErr(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	noErr(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval1}))
 
 	// Process the evaluation
 	if err := h1.Process(NewSystemScheduler, eval1); err != nil {
@@ -274,15 +277,31 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	noErr(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	noErr(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval1}))
 	// Process the evaluation
 	if err := h.Process(NewSystemScheduler, eval1); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Ensure that we have one allocation queued from the system job eval
+	// System scheduler will preempt the service job and would have placed eval1
+	require := require.New(t)
+
+	newPlan := h.Plans[1]
+	require.Len(newPlan.NodeAllocation, 1)
+	require.Len(newPlan.NodePreemptions, 1)
+
+	for _, allocList := range newPlan.NodeAllocation {
+		require.Len(allocList, 1)
+		require.Equal(job.ID, allocList[0].JobID)
+	}
+
+	for _, allocList := range newPlan.NodePreemptions {
+		require.Len(allocList, 1)
+		require.Equal(svcJob.ID, allocList[0].JobID)
+	}
+	// Ensure that we have no queued allocations on the second eval
 	queued := h.Evals[1].QueuedAllocations["web"]
-	if queued != 1 {
+	if queued != 0 {
 		t.Fatalf("expected: %v, actual: %v", 1, queued)
 	}
 }
@@ -1528,4 +1547,323 @@ func TestSystemSched_QueuedAllocsMultTG(t *testing.T) {
 	}
 
 	h.AssertEvalStatus(t, structs.EvalStatusComplete)
+}
+
+func TestSystemSched_Preemption(t *testing.T) {
+	h := NewHarness(t)
+
+	// Create nodes
+	var nodes []*structs.Node
+	for i := 0; i < 2; i++ {
+		node := mock.Node()
+		node.Resources = &structs.Resources{
+			CPU:      3072,
+			MemoryMB: 5034,
+			DiskMB:   20 * 1024,
+			IOPS:     150,
+			Networks: []*structs.NetworkResource{
+				{
+					Device: "eth0",
+					CIDR:   "192.168.0.100/32",
+					MBits:  1000,
+				},
+			},
+		}
+		noErr(t, h.State.UpsertNode(h.NextIndex(), node))
+		nodes = append(nodes, node)
+	}
+
+	// Create some low priority batch jobs and allocations for them
+	// One job uses a reserved port
+	job1 := mock.BatchJob()
+	job1.Type = structs.JobTypeBatch
+	job1.Priority = 20
+	job1.TaskGroups[0].Tasks[0].Resources = &structs.Resources{
+		CPU:      512,
+		MemoryMB: 1024,
+		Networks: []*structs.NetworkResource{
+			{
+				MBits: 200,
+				ReservedPorts: []structs.Port{
+					{
+						Label: "web",
+						Value: 80,
+					},
+				},
+			},
+		},
+	}
+
+	alloc1 := mock.Alloc()
+	alloc1.Job = job1
+	alloc1.JobID = job1.ID
+	alloc1.NodeID = nodes[0].ID
+	alloc1.Name = "my-job[0]"
+	alloc1.TaskGroup = job1.TaskGroups[0].Name
+	alloc1.Resources = &structs.Resources{
+		CPU:      512,
+		MemoryMB: 1024,
+		DiskMB:   5 * 1024,
+		Networks: []*structs.NetworkResource{
+			{
+				Device: "eth0",
+				MBits:  200,
+				ReservedPorts: []structs.Port{
+					{
+						Label: "web",
+						Value: 80,
+					},
+				},
+			},
+		},
+	}
+	alloc1.TaskResources = map[string]*structs.Resources{
+		"web": {
+			CPU:      512,
+			MemoryMB: 1024,
+			DiskMB:   5 * 1024,
+			Networks: []*structs.NetworkResource{
+				{
+					Device: "eth0",
+					MBits:  200,
+					ReservedPorts: []structs.Port{
+						{
+							Label: "web",
+							Value: 80,
+						},
+					},
+				},
+			},
+		},
+	}
+	noErr(t, h.State.UpsertJob(h.NextIndex(), job1))
+
+	job2 := mock.BatchJob()
+	job2.Type = structs.JobTypeBatch
+	job2.Priority = 20
+	job2.TaskGroups[0].Tasks[0].Resources = &structs.Resources{
+		CPU:      512,
+		MemoryMB: 1024,
+		Networks: []*structs.NetworkResource{
+			{
+				MBits: 200,
+			},
+		},
+	}
+
+	alloc2 := mock.Alloc()
+	alloc2.Job = job2
+	alloc2.JobID = job2.ID
+	alloc2.NodeID = nodes[0].ID
+	alloc2.Name = "my-job[2]"
+	alloc2.TaskGroup = job2.TaskGroups[0].Name
+	alloc2.Resources = &structs.Resources{
+		CPU:      512,
+		MemoryMB: 1024,
+		DiskMB:   5 * 1024,
+		Networks: []*structs.NetworkResource{
+			{
+				Device: "eth0",
+				MBits:  200,
+			},
+		},
+	}
+	alloc2.TaskResources = map[string]*structs.Resources{
+		"web": {
+			CPU:      512,
+			MemoryMB: 1024,
+			DiskMB:   5 * 1024,
+			Networks: []*structs.NetworkResource{
+				{
+					Device: "eth0",
+					MBits:  200,
+				},
+			},
+		},
+	}
+	noErr(t, h.State.UpsertJob(h.NextIndex(), job2))
+
+	job3 := mock.Job()
+	job3.Type = structs.JobTypeBatch
+	job3.Priority = 40
+	job3.TaskGroups[0].Tasks[0].Resources = &structs.Resources{
+		CPU:      1024,
+		MemoryMB: 2048,
+		Networks: []*structs.NetworkResource{
+			{
+				Device: "eth0",
+				MBits:  400,
+			},
+		},
+	}
+
+	alloc3 := mock.Alloc()
+	alloc3.Job = job3
+	alloc3.JobID = job3.ID
+	alloc3.NodeID = nodes[0].ID
+	alloc3.Name = "my-job[0]"
+	alloc3.TaskGroup = job3.TaskGroups[0].Name
+	alloc3.Resources = &structs.Resources{
+		CPU:      1024,
+		MemoryMB: 25,
+		DiskMB:   5 * 1024,
+		Networks: []*structs.NetworkResource{
+			{
+				Device: "eth0",
+				MBits:  400,
+			},
+		},
+	}
+	alloc3.TaskResources = map[string]*structs.Resources{
+		"web": {
+			CPU:      1024,
+			MemoryMB: 25,
+			DiskMB:   5 * 1024,
+			Networks: []*structs.NetworkResource{
+				{
+					Device: "eth0",
+					MBits:  400,
+				},
+			},
+		},
+	}
+	noErr(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc1, alloc2, alloc3}))
+
+	// Create a high priority job and allocs for it
+	// These allocs should not be preempted
+
+	job4 := mock.BatchJob()
+	job4.Type = structs.JobTypeBatch
+	job4.Priority = 100
+	job4.TaskGroups[0].Tasks[0].Resources = &structs.Resources{
+		CPU:      1024,
+		MemoryMB: 2048,
+		Networks: []*structs.NetworkResource{
+			{
+				MBits: 100,
+			},
+		},
+	}
+
+	alloc4 := mock.Alloc()
+	alloc4.Job = job4
+	alloc4.JobID = job4.ID
+	alloc4.NodeID = nodes[0].ID
+	alloc4.Name = "my-job4[0]"
+	alloc4.TaskGroup = job4.TaskGroups[0].Name
+	alloc4.Resources = &structs.Resources{
+		CPU:      1024,
+		MemoryMB: 2048,
+		DiskMB:   2 * 1024,
+		Networks: []*structs.NetworkResource{
+			{
+				Device: "eth0",
+				MBits:  100,
+			},
+		},
+	}
+	alloc4.TaskResources = map[string]*structs.Resources{
+		"web": {
+			CPU:      1024,
+			MemoryMB: 2048,
+			DiskMB:   2 * 1024,
+			Networks: []*structs.NetworkResource{
+				{
+					Device: "eth0",
+					MBits:  100,
+				},
+			},
+		},
+	}
+	noErr(t, h.State.UpsertJob(h.NextIndex(), job4))
+	noErr(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc4}))
+
+	// Create a system job such that it would need to preempt both allocs to succeed
+	job := mock.SystemJob()
+	job.TaskGroups[0].Tasks[0].Resources = &structs.Resources{
+		CPU:      1948,
+		MemoryMB: 256,
+		Networks: []*structs.NetworkResource{
+			{
+				MBits:        800,
+				DynamicPorts: []structs.Port{{Label: "http"}},
+			},
+		},
+	}
+	noErr(t, h.State.UpsertJob(h.NextIndex(), job))
+
+	// Create a mock evaluation to register the job
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	noErr(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+
+	// Process the evaluation
+	err := h.Process(NewSystemScheduler, eval)
+	require := require.New(t)
+	require.Nil(err)
+
+	// Ensure a single plan
+	require.Equal(1, len(h.Plans))
+	plan := h.Plans[0]
+
+	// Ensure the plan doesn't have annotations.
+	require.Nil(plan.Annotations)
+
+	// Ensure the plan allocated on both nodes
+	var planned []*structs.Allocation
+	preemptingAllocId := ""
+	require.Equal(2, len(plan.NodeAllocation))
+
+	// The alloc that got placed on node 1 is the preemptor
+	for _, allocList := range plan.NodeAllocation {
+		planned = append(planned, allocList...)
+		for _, alloc := range allocList {
+			if alloc.NodeID == nodes[0].ID {
+				preemptingAllocId = alloc.ID
+			}
+		}
+	}
+
+	// Lookup the allocations by JobID
+	ws := memdb.NewWatchSet()
+	out, err := h.State.AllocsByJob(ws, job.Namespace, job.ID, false)
+	noErr(t, err)
+
+	// Ensure all allocations placed
+	require.Equal(2, len(out))
+
+	// Verify that one node has preempted allocs
+	require.NotNil(plan.NodePreemptions[nodes[0].ID])
+	preemptedAllocs := plan.NodePreemptions[nodes[0].ID]
+
+	// Verify that three jobs have preempted allocs
+	require.Equal(3, len(preemptedAllocs))
+
+	expectedPreemptedJobIDs := []string{job1.ID, job2.ID, job3.ID}
+
+	// We expect job1, job2 and job3 to have preempted allocations
+	// job4 should not have any allocs preempted
+	for _, alloc := range preemptedAllocs {
+		require.Contains(expectedPreemptedJobIDs, alloc.JobID)
+	}
+	// Look up the preempted allocs by job ID
+	ws = memdb.NewWatchSet()
+
+	for _, jobId := range expectedPreemptedJobIDs {
+		out, err = h.State.AllocsByJob(ws, structs.DefaultNamespace, jobId, false)
+		noErr(t, err)
+		for _, alloc := range out {
+			require.Equal(structs.AllocDesiredStatusEvict, alloc.DesiredStatus)
+			require.Equal(fmt.Sprintf("Preempted by alloc ID %v", preemptingAllocId), alloc.DesiredDescription)
+		}
+	}
+
+	h.AssertEvalStatus(t, structs.EvalStatusComplete)
+
 }

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -242,6 +242,9 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 	node := mock.Node()
 	noErr(t, h.State.UpsertNode(h.NextIndex(), node))
 
+	// Enable Preemption
+	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{EnablePreemption: true})
+
 	// Create a service job which consumes most of the system resources
 	svcJob := mock.Job()
 	svcJob.TaskGroups[0].Count = 1
@@ -1572,6 +1575,9 @@ func TestSystemSched_Preemption(t *testing.T) {
 		noErr(t, h.State.UpsertNode(h.NextIndex(), node))
 		nodes = append(nodes, node)
 	}
+
+	// Enable Preemption
+	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{EnablePreemption: true})
 
 	// Create some low priority batch jobs and allocations for them
 	// One job uses a reserved port

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -243,7 +243,11 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 	noErr(t, h.State.UpsertNode(h.NextIndex(), node))
 
 	// Enable Preemption
-	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{EnablePreemption: true})
+	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{
+		PreemptionConfig: structs.PreemptionConfig{
+			SystemSchedulerEnabled: true,
+		},
+	})
 
 	// Create a service job which consumes most of the system resources
 	svcJob := mock.Job()
@@ -1577,7 +1581,11 @@ func TestSystemSched_Preemption(t *testing.T) {
 	}
 
 	// Enable Preemption
-	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{EnablePreemption: true})
+	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{
+		PreemptionConfig: structs.PreemptionConfig{
+			SystemSchedulerEnabled: true,
+		},
+	})
 
 	// Create some low priority batch jobs and allocations for them
 	// One job uses a reserved port

--- a/scheduler/testing.go
+++ b/scheduler/testing.go
@@ -96,6 +96,7 @@ func (h *Harness) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, State, er
 	result := new(structs.PlanResult)
 	result.NodeUpdate = plan.NodeUpdate
 	result.NodeAllocation = plan.NodeAllocation
+	result.NodePreemptions = plan.NodePreemptions
 	result.AllocIndex = index
 
 	// Flatten evicts and allocs
@@ -116,6 +117,18 @@ func (h *Harness) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, State, er
 		}
 	}
 
+	// Set create and modify time for preempted allocs and flatten them
+	var preemptedAllocs []*structs.Allocation
+	for _, preemptions := range result.NodePreemptions {
+		for _, alloc := range preemptions {
+			if alloc.CreateTime == 0 {
+				alloc.CreateTime = now
+			}
+			alloc.ModifyTime = now
+			preemptedAllocs = append(preemptedAllocs, alloc)
+		}
+	}
+
 	// Setup the update request
 	req := structs.ApplyPlanResultsRequest{
 		AllocUpdateRequest: structs.AllocUpdateRequest{
@@ -125,6 +138,7 @@ func (h *Harness) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, State, er
 		Deployment:        plan.Deployment,
 		DeploymentUpdates: plan.DeploymentUpdates,
 		EvalID:            plan.EvalID,
+		NodePreemptions:   preemptedAllocs,
 	}
 
 	// Apply the full plan


### PR DESCRIPTION
This PR brings in prior work from PR #4710, rebased to master and modifying all the internal comparison logic to use the new `ComparableResources` struct. 