### PR TITLE
UI: Proper task group breadcrumb on the allocation pages

### DIFF
--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -24,7 +24,7 @@ export default Route.extend(WithWatchers, {
           model.get('job'),
           model.get('taskGroupName'),
           qpBuilder({
-            jobNamespace: model.get('namespace.name') || 'default',
+            jobNamespace: model.get('job.namespace.name') || 'default',
           }),
         ],
       },

--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -14,18 +14,20 @@ export default Route.extend(WithWatchers, {
   // Allocation breadcrumbs extend from job / task group breadcrumbs
   // even though the route structure does not.
   breadcrumbs(model) {
+    const jobQueryParams = qpBuilder({
+      jobNamespace: model.get('job.namespace.name') || 'default',
+    });
+
     return [
-      { label: 'Jobs', args: ['jobs.index'] },
+      { label: 'Jobs', args: ['jobs.index', jobQueryParams] },
       ...jobCrumbs(model.get('job')),
       {
         label: model.get('taskGroupName'),
         args: [
           'jobs.job.task-group',
-          model.get('job'),
+          model.get('job.plainId'),
           model.get('taskGroupName'),
-          qpBuilder({
-            jobNamespace: model.get('job.namespace.name') || 'default',
-          }),
+          jobQueryParams,
         ],
       },
       {

--- a/ui/app/routes/jobs/job/task-group.js
+++ b/ui/app/routes/jobs/job/task-group.js
@@ -12,6 +12,7 @@ export default Route.extend(WithWatchers, {
         label: model.get('name'),
         args: [
           'jobs.job.task-group',
+          model.get('job'),
           model.get('name'),
           qpBuilder({ jobNamespace: model.get('job.namespace.name') || 'default' }),
         ],

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -113,7 +113,7 @@ export default Service.extend({
 
       // If the namespace in localStorage is no longer in the cluster, it needs to
       // be cleared from localStorage
-      this.set('activeNamespace', null);
+      window.localStorage.removeItem('nomadActiveNamespace');
       return this.get('namespaces').findBy('id', 'default');
     },
     set(key, value) {


### PR DESCRIPTION
The breadcrumb was missing the namespace query param which led to errors being thrown when using the breadcrumb on a non-default namespace.

Only impacts enterprise, since namespaces are an enterprise feature.