### PR TITLE
AR Fixes: task leader handling, restoring, state updating, AR.Destroy deadlocks

### DIFF
--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -17,11 +17,11 @@ func TestClient_ACL_resolveTokenValue(t *testing.T) {
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c1 := TestClient(t, func(c *config.Config) {
+	c1, cleanup := TestClient(t, func(c *config.Config) {
 		c.RPCHandler = s1
 		c.ACLEnabled = true
 	})
-	defer c1.Shutdown()
+	defer cleanup()
 
 	// Create a policy / token
 	policy := mock.ACLPolicy()
@@ -66,11 +66,11 @@ func TestClient_ACL_resolvePolicies(t *testing.T) {
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c1 := TestClient(t, func(c *config.Config) {
+	c1, cleanup := TestClient(t, func(c *config.Config) {
 		c.RPCHandler = s1
 		c.ACLEnabled = true
 	})
-	defer c1.Shutdown()
+	defer cleanup()
 
 	// Create a policy / token
 	policy := mock.ACLPolicy()
@@ -106,10 +106,10 @@ func TestClient_ACL_ResolveToken_Disabled(t *testing.T) {
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c1 := TestClient(t, func(c *config.Config) {
+	c1, cleanup := TestClient(t, func(c *config.Config) {
 		c.RPCHandler = s1
 	})
-	defer c1.Shutdown()
+	defer cleanup()
 
 	// Should always get nil when disabled
 	aclObj, err := c1.ResolveToken("blah")
@@ -122,11 +122,11 @@ func TestClient_ACL_ResolveToken(t *testing.T) {
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c1 := TestClient(t, func(c *config.Config) {
+	c1, cleanup := TestClient(t, func(c *config.Config) {
 		c.RPCHandler = s1
 		c.ACLEnabled = true
 	})
-	defer c1.Shutdown()
+	defer cleanup()
 
 	// Create a policy / token
 	policy := mock.ACLPolicy()

--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -16,7 +16,8 @@ import (
 func TestAllocations_GarbageCollectAll(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	client := TestClient(t, nil)
+	client, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	req := &nstructs.NodeSpecificRequest{}
 	var resp nstructs.GenericResponse
@@ -29,11 +30,11 @@ func TestAllocations_GarbageCollectAll_ACL(t *testing.T) {
 	server, addr, root := testACLServer(t, nil)
 	defer server.Shutdown()
 
-	client := TestClient(t, func(c *config.Config) {
+	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer client.Shutdown()
+	defer cleanup()
 
 	// Try request without a token and expect failure
 	{
@@ -79,9 +80,10 @@ func TestAllocations_GarbageCollect(t *testing.T) {
 	t.Skip("missing mock driver plugin implementation")
 	t.Parallel()
 	require := require.New(t)
-	client := TestClient(t, func(c *config.Config) {
+	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.GCDiskUsageThreshold = 100.0
 	})
+	defer cleanup()
 
 	a := mock.Alloc()
 	a.Job.TaskGroups[0].Tasks[0].Driver = "mock_driver"
@@ -122,11 +124,11 @@ func TestAllocations_GarbageCollect_ACL(t *testing.T) {
 	server, addr, root := testACLServer(t, nil)
 	defer server.Shutdown()
 
-	client := TestClient(t, func(c *config.Config) {
+	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer client.Shutdown()
+	defer cleanup()
 
 	// Try request without a token and expect failure
 	{
@@ -178,7 +180,8 @@ func TestAllocations_Stats(t *testing.T) {
 	t.Skip("missing exec driver plugin implementation")
 	t.Parallel()
 	require := require.New(t)
-	client := TestClient(t, nil)
+	client, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	a := mock.Alloc()
 	require.Nil(client.addAlloc(a, ""))
@@ -213,11 +216,11 @@ func TestAllocations_Stats_ACL(t *testing.T) {
 	server, addr, root := testACLServer(t, nil)
 	defer server.Shutdown()
 
-	client := TestClient(t, func(c *config.Config) {
+	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer client.Shutdown()
+	defer cleanup()
 
 	// Try request without a token and expect failure
 	{

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -40,7 +40,6 @@ func (a *allocHealthSetter) SetHealth(healthy, isDeploy bool, trackerTaskEvents 
 	a.ar.stateLock.Unlock()
 
 	// If deployment is unhealthy emit task events explaining why
-	a.ar.tasksLock.RLock()
 	if !healthy && isDeploy {
 		for task, event := range trackerTaskEvents {
 			if tr, ok := a.ar.tasks[task]; ok {
@@ -56,7 +55,6 @@ func (a *allocHealthSetter) SetHealth(healthy, isDeploy bool, trackerTaskEvents 
 	for name, tr := range a.ar.tasks {
 		states[name] = tr.TaskState()
 	}
-	a.ar.tasksLock.RUnlock()
 
 	// Build the client allocation
 	calloc := a.ar.clientAlloc(states)

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -1,48 +1,272 @@
 package allocrunner
 
 import (
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/nomad/client/allocwatcher"
 	"github.com/hashicorp/nomad/client/config"
+	consulapi "github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/state"
+	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/shared/catalog"
 	"github.com/hashicorp/nomad/plugins/shared/loader"
 	"github.com/hashicorp/nomad/plugins/shared/singleton"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+// MockStateUpdater implements the AllocStateHandler interface and records
+// alloc updates.
+type MockStateUpdater struct {
+	Updates []*structs.Allocation
+	mu      sync.Mutex
+}
+
+// AllocStateUpdated implements the AllocStateHandler interface and records an
+// alloc update.
+func (m *MockStateUpdater) AllocStateUpdated(alloc *structs.Allocation) {
+	m.mu.Lock()
+	m.Updates = append(m.Updates, alloc)
+	m.mu.Unlock()
+}
+
+// Last returns a copy of the last alloc (or nil) update. Safe for concurrent
+// access with updates.
+func (m *MockStateUpdater) Last() *structs.Allocation {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := len(m.Updates)
+	if n == 0 {
+		return nil
+	}
+	return m.Updates[n-1].Copy()
+}
+
+// Reset resets the recorded alloc updates.
+func (m *MockStateUpdater) Reset() {
+	m.mu.Lock()
+	m.Updates = nil
+	m.mu.Unlock()
+}
+
+// testAllocRunnerConfig returns a new allocrunner.Config with mocks and noop
+// versions of dependencies.
+func testAllocRunnerConfig(t *testing.T, alloc *structs.Allocation) *Config {
+	logger := testlog.HCLogger(t)
+	return &Config{
+		// Copy the alloc in case the caller edits and reuses it
+		Alloc:                 alloc.Copy(),
+		Logger:                logger,
+		ClientConfig:          config.TestClientConfig(),
+		StateDB:               state.NoopDB{},
+		Consul:                consulapi.NewMockConsulServiceClient(t, logger),
+		Vault:                 vaultclient.NewMockVaultClient(),
+		StateUpdater:          &MockStateUpdater{},
+		PrevAllocWatcher:      allocwatcher.NoopPrevAlloc{},
+		PluginSingletonLoader: &loader.MockCatalog{},
+	}
+}
 
 // TestAllocRunner_AllocState_Initialized asserts that getting TaskStates via
 // AllocState() are initialized even before the AllocRunner has run.
 func TestAllocRunner_AllocState_Initialized(t *testing.T) {
-	t.Skip("missing exec driver plugin implementation")
 	t.Parallel()
 
-	alloc := mock.Alloc()
-	logger := testlog.HCLogger(t)
-
-	conf := &Config{
-		Alloc:                 alloc,
-		Logger:                logger,
-		ClientConfig:          config.TestClientConfig(),
-		StateDB:               state.NoopDB{},
-		Consul:                nil,
-		Vault:                 nil,
-		StateUpdater:          nil,
-		PrevAllocWatcher:      nil,
-		PluginSingletonLoader: &loader.MockCatalog{},
-	}
+	conf := testAllocRunnerConfig(t, mock.Alloc())
 
 	pluginLoader := catalog.TestPluginLoader(t)
-	conf.PluginSingletonLoader = singleton.NewSingletonLoader(logger, pluginLoader)
+	conf.PluginSingletonLoader = singleton.NewSingletonLoader(conf.Logger, pluginLoader)
 	ar, err := NewAllocRunner(conf)
 	require.NoError(t, err)
 
 	allocState := ar.AllocState()
 
 	require.NotNil(t, allocState)
-	require.NotNil(t, allocState.TaskStates[alloc.Job.TaskGroups[0].Tasks[0].Name])
+	require.NotNil(t, allocState.TaskStates[conf.Alloc.Job.TaskGroups[0].Tasks[0].Name])
+}
+
+// TestAllocRunner_TaskLeader_KillTG asserts that when a leader task dies the
+// entire task group is killed.
+func TestAllocRunner_TaskLeader_KillTG(t *testing.T) {
+	t.Parallel()
+
+	alloc := mock.BatchAlloc()
+	alloc.Job.TaskGroups[0].RestartPolicy.Attempts = 0
+
+	// Create two tasks in the task group
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Name = "task1"
+	task.Driver = "mock_driver"
+	task.KillTimeout = 10 * time.Millisecond
+	task.Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+
+	task2 := alloc.Job.TaskGroups[0].Tasks[0].Copy()
+	task2.Name = "task2"
+	task2.Driver = "mock_driver"
+	task2.Leader = true
+	task2.Config = map[string]interface{}{
+		"run_for": "1s",
+	}
+	alloc.Job.TaskGroups[0].Tasks = append(alloc.Job.TaskGroups[0].Tasks, task2)
+	alloc.TaskResources[task2.Name] = task2.Resources
+
+	conf := testAllocRunnerConfig(t, alloc)
+	ar, err := NewAllocRunner(conf)
+	require.NoError(t, err)
+	defer ar.Destroy()
+	go ar.Run()
+
+	// Wait for all tasks to be killed
+	upd := conf.StateUpdater.(*MockStateUpdater)
+	testutil.WaitForResult(func() (bool, error) {
+		last := upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("No updates")
+		}
+		if last.ClientStatus != structs.AllocClientStatusComplete {
+			return false, fmt.Errorf("got status %v; want %v", last.ClientStatus, structs.AllocClientStatusComplete)
+		}
+
+		// Task1 should be killed because Task2 exited
+		state1 := last.TaskStates[task.Name]
+		if state1.State != structs.TaskStateDead {
+			return false, fmt.Errorf("got state %v; want %v", state1.State, structs.TaskStateDead)
+		}
+		if state1.FinishedAt.IsZero() || state1.StartedAt.IsZero() {
+			return false, fmt.Errorf("expected to have a start and finish time")
+		}
+		if len(state1.Events) < 2 {
+			// At least have a received and destroyed
+			return false, fmt.Errorf("Unexpected number of events")
+		}
+
+		found := false
+		for _, e := range state1.Events {
+			if e.Type != structs.TaskLeaderDead {
+				found = true
+			}
+		}
+
+		if !found {
+			return false, fmt.Errorf("Did not find event %v", structs.TaskLeaderDead)
+		}
+
+		// Task Two should be dead
+		state2 := last.TaskStates[task2.Name]
+		if state2.State != structs.TaskStateDead {
+			return false, fmt.Errorf("got state %v; want %v", state2.State, structs.TaskStateDead)
+		}
+		if state2.FinishedAt.IsZero() || state2.StartedAt.IsZero() {
+			return false, fmt.Errorf("expected to have a start and finish time")
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+}
+
+// TestAllocRunner_TaskLeader_StopTG asserts that when stopping an alloc with a
+// leader the leader is stopped before other tasks.
+func TestAllocRunner_TaskLeader_StopTG(t *testing.T) {
+	t.Parallel()
+
+	alloc := mock.Alloc()
+	alloc.Job.TaskGroups[0].RestartPolicy.Attempts = 0
+
+	// Create 3 tasks in the task group
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Name = "follower1"
+	task.Driver = "mock_driver"
+	task.KillTimeout = 10 * time.Millisecond
+	task.Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+
+	task2 := alloc.Job.TaskGroups[0].Tasks[0].Copy()
+	task2.Name = "leader"
+	task2.Driver = "mock_driver"
+	task2.Leader = true
+	task2.KillTimeout = 10 * time.Millisecond
+	task2.Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+
+	task3 := alloc.Job.TaskGroups[0].Tasks[0].Copy()
+	task3.Name = "follower2"
+	task3.Driver = "mock_driver"
+	task3.KillTimeout = 10 * time.Millisecond
+	task3.Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+	alloc.Job.TaskGroups[0].Tasks = append(alloc.Job.TaskGroups[0].Tasks, task2, task3)
+	alloc.TaskResources[task2.Name] = task2.Resources
+
+	conf := testAllocRunnerConfig(t, alloc)
+	ar, err := NewAllocRunner(conf)
+	require.NoError(t, err)
+	defer ar.Destroy()
+	go ar.Run()
+
+	// Wait for tasks to start
+	upd := conf.StateUpdater.(*MockStateUpdater)
+	last := upd.Last()
+	testutil.WaitForResult(func() (bool, error) {
+		last = upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("No updates")
+		}
+		if n := len(last.TaskStates); n != 3 {
+			return false, fmt.Errorf("Not enough task states (want: 3; found %d)", n)
+		}
+		for name, state := range last.TaskStates {
+			if state.State != structs.TaskStateRunning {
+				return false, fmt.Errorf("Task %q is not running yet (it's %q)", name, state.State)
+			}
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Reset updates
+	upd.Reset()
+
+	// Stop alloc
+	update := alloc.Copy()
+	update.DesiredStatus = structs.AllocDesiredStatusStop
+	ar.Update(update)
+
+	// Wait for tasks to stop
+	testutil.WaitForResult(func() (bool, error) {
+		last := upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("No updates")
+		}
+		if last.TaskStates["leader"].FinishedAt.UnixNano() >= last.TaskStates["follower1"].FinishedAt.UnixNano() {
+			return false, fmt.Errorf("expected leader to finish before follower1: %s >= %s",
+				last.TaskStates["leader"].FinishedAt, last.TaskStates["follower1"].FinishedAt)
+		}
+		if last.TaskStates["leader"].FinishedAt.UnixNano() >= last.TaskStates["follower2"].FinishedAt.UnixNano() {
+			return false, fmt.Errorf("expected leader to finish before follower2: %s >= %s",
+				last.TaskStates["leader"].FinishedAt, last.TaskStates["follower2"].FinishedAt)
+		}
+		return true, nil
+	}, func(err error) {
+		last := upd.Last()
+		for name, state := range last.TaskStates {
+			t.Logf("%s: %s", name, state.State)
+		}
+		t.Fatalf("err: %v", err)
+	})
 }
 
 /*

--- a/client/allocrunner/interfaces/runner.go
+++ b/client/allocrunner/interfaces/runner.go
@@ -2,8 +2,6 @@ package interfaces
 
 import (
 	"github.com/hashicorp/nomad/client/allocrunner/state"
-	"github.com/hashicorp/nomad/nomad/structs"
-
 	cstructs "github.com/hashicorp/nomad/client/structs"
 )
 
@@ -24,8 +22,9 @@ type AllocRunner interface {
 
 // TaskStateHandler exposes a handler to be called when a task's state changes
 type TaskStateHandler interface {
-	// TaskStateUpdated is used to emit updated task state
-	TaskStateUpdated(task string, state *structs.TaskState)
+	// TaskStateUpdated is used to notify the alloc runner about task state
+	// changes.
+	TaskStateUpdated()
 }
 
 // AllocStatsReporter gives acess to the latest resource usage from the

--- a/client/allocrunner/taskrunner/state/state.go
+++ b/client/allocrunner/taskrunner/state/state.go
@@ -25,6 +25,23 @@ func NewLocalState() *LocalState {
 	}
 }
 
+// Canonicalize ensures LocalState is in a consistent state by initializing
+// Hooks and ensuring no HookState's are nil. Useful for cleaning unmarshalled
+// state which may be in an unknown state.
+func (s *LocalState) Canonicalize() {
+	if s.Hooks == nil {
+		// Hooks is nil, create it
+		s.Hooks = make(map[string]*HookState)
+	} else {
+		for k, v := range s.Hooks {
+			// Remove invalid nil entries from Hooks map
+			if v == nil {
+				delete(s.Hooks, k)
+			}
+		}
+	}
+}
+
 // Copy should be called with the lock held
 func (s *LocalState) Copy() *LocalState {
 	// Create a copy

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -52,10 +52,11 @@ const (
 )
 
 type TaskRunner struct {
-	// allocID and taskName are immutable so these fields may be accessed
-	// without locks
-	allocID  string
-	taskName string
+	// allocID, taskName, and taskLeader are immutable so these fields may
+	// be accessed without locks
+	allocID    string
+	taskName   string
+	taskLeader bool
 
 	alloc     *structs.Allocation
 	allocLock sync.Mutex
@@ -203,6 +204,7 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		task:                  config.Task,
 		taskDir:               config.TaskDir,
 		taskName:              config.Task.Name,
+		taskLeader:            config.Task.Leader,
 		envBuilder:            envBuilder,
 		consulClient:          config.Consul,
 		vaultClient:           config.VaultClient,
@@ -396,15 +398,6 @@ func (tr *TaskRunner) handleUpdates() {
 		case <-tr.triggerUpdateCh:
 		case <-tr.waitCh:
 			return
-		}
-
-		if tr.Alloc().TerminalStatus() {
-			// Terminal update: kill TaskRunner and let Run execute postrun hooks
-			err := tr.Kill(context.TODO(), structs.NewTaskEvent(structs.TaskKilled))
-			if err != nil {
-				tr.logger.Warn("error stopping task", "error", err)
-			}
-			continue
 		}
 
 		// Non-terminal update; run hooks
@@ -618,6 +611,7 @@ func (tr *TaskRunner) Restore() error {
 // update.
 func (tr *TaskRunner) UpdateState(state string, event *structs.TaskEvent) {
 	tr.logger.Debug("setting task state", "state", state, "event", event.Type)
+
 	// Update the local state
 	stateCopy := tr.setStateLocal(state, event)
 
@@ -698,7 +692,6 @@ func (tr *TaskRunner) setStateLocal(state string, event *structs.TaskEvent) *str
 // logged. Use AppendEvent to simply add a new event.
 func (tr *TaskRunner) EmitEvent(event *structs.TaskEvent) {
 	tr.stateLock.Lock()
-	defer tr.stateLock.Unlock()
 
 	tr.appendEvent(event)
 
@@ -708,8 +701,11 @@ func (tr *TaskRunner) EmitEvent(event *structs.TaskEvent) {
 		tr.logger.Warn("error persisting event", "error", err, "event", event)
 	}
 
+	stateCopy := tr.state.Copy()
+	tr.stateLock.Unlock()
+
 	// Notify the alloc runner of the event
-	tr.stateUpdater.TaskStateUpdated(tr.taskName, tr.state.Copy())
+	tr.stateUpdater.TaskStateUpdated(tr.taskName, stateCopy)
 }
 
 // AppendEvent appends a new TaskEvent to this task's TaskState. The actual

--- a/client/allocrunner/taskrunner/task_runner_getters.go
+++ b/client/allocrunner/taskrunner/task_runner_getters.go
@@ -16,6 +16,11 @@ func (tr *TaskRunner) setAlloc(updated *structs.Allocation) {
 	tr.allocLock.Unlock()
 }
 
+// IsLeader returns true if this task is the leader of its task group.
+func (tr *TaskRunner) IsLeader() bool {
+	return tr.taskLeader
+}
+
 func (tr *TaskRunner) Task() *structs.Task {
 	tr.taskLock.RLock()
 	defer tr.taskLock.RUnlock()

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -101,8 +101,11 @@ func (tr *TaskRunner) prestart() error {
 			TaskEnv: tr.envBuilder.Build(),
 		}
 
+		var origHookState *state.HookState
 		tr.localStateLock.RLock()
-		origHookState := tr.localState.Hooks[name]
+		if tr.localState.Hooks != nil {
+			origHookState = tr.localState.Hooks[name]
+		}
 		tr.localStateLock.RUnlock()
 		if origHookState != nil && origHookState.PrestartDone {
 			tr.logger.Trace("skipping done prestart hook", "name", pre.Name())

--- a/client/client.go
+++ b/client/client.go
@@ -760,6 +760,11 @@ func (c *Client) restoreState() error {
 	var mErr multierror.Error
 	for _, alloc := range allocs {
 
+		//XXX On Restore we give up on watching previous allocs because
+		//    we need the local AllocRunners initialized first. We could
+		//    add a second loop to initialize just the alloc watcher.
+		prevAllocWatcher := allocwatcher.NoopPrevAlloc{}
+
 		c.configLock.RLock()
 		arConf := &allocrunner.Config{
 			Alloc:                 alloc,
@@ -769,6 +774,7 @@ func (c *Client) restoreState() error {
 			StateUpdater:          c,
 			Consul:                c.consulService,
 			Vault:                 c.vaultClient,
+			PrevAllocWatcher:      prevAllocWatcher,
 			PluginLoader:          c.config.PluginLoader,
 			PluginSingletonLoader: c.config.PluginSingletonLoader,
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -805,7 +805,7 @@ func (c *Client) restoreState() error {
 	// All allocs restored successfully, run them!
 	c.allocLock.Lock()
 	for _, ar := range c.allocs {
-		go ar.Run()
+		ar.Run()
 	}
 	c.allocLock.Unlock()
 
@@ -1933,7 +1933,7 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 	// Store the alloc runner.
 	c.allocs[alloc.ID] = ar
 
-	go ar.Run()
+	ar.Run()
 	return nil
 }
 

--- a/client/client_stats_endpoint_test.go
+++ b/client/client_stats_endpoint_test.go
@@ -14,7 +14,8 @@ import (
 func TestClientStats_Stats(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	client := TestClient(t, nil)
+	client, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	req := &nstructs.NodeSpecificRequest{}
 	var resp structs.ClientStatsResponse
@@ -30,11 +31,11 @@ func TestClientStats_Stats_ACL(t *testing.T) {
 	server, addr, root := testACLServer(t, nil)
 	defer server.Shutdown()
 
-	client := TestClient(t, func(c *config.Config) {
+	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer client.Shutdown()
+	defer cleanup()
 
 	// Try request without a token and expect failure
 	{

--- a/client/config/testing.go
+++ b/client/config/testing.go
@@ -1,13 +1,43 @@
 package config
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/mitchellh/go-testing-interface"
 )
 
-// TestClientConfig returns a default client configuration for test clients.
-func TestClientConfig() *Config {
+// TestClientConfig returns a default client configuration for test clients and
+// a cleanup func to remove the state and alloc dirs when finished.
+func TestClientConfig(t testing.T) (*Config, func()) {
 	conf := DefaultConfig()
+
+	// Create a tempdir to hold state and alloc subdirs
+	parent, err := ioutil.TempDir("", "nomadtest")
+	if err != nil {
+		t.Fatalf("error creating client dir: %v", err)
+	}
+	cleanup := func() {
+		os.RemoveAll(parent)
+	}
+
+	allocDir := filepath.Join(parent, "allocs")
+	if err := os.Mkdir(allocDir, 0777); err != nil {
+		cleanup()
+		t.Fatalf("error creating alloc dir: %v", err)
+	}
+	conf.AllocDir = allocDir
+
+	stateDir := filepath.Join(parent, "client")
+	if err := os.Mkdir(stateDir, 0777); err != nil {
+		cleanup()
+		t.Fatalf("error creating alloc dir: %v", err)
+	}
+	conf.StateDir = stateDir
+
 	conf.VaultConfig.Enabled = helper.BoolToPtr(false)
 	conf.DevMode = true
 	conf.Node = &structs.Node{
@@ -19,5 +49,5 @@ func TestClientConfig() *Config {
 	// Loosen GC threshold
 	conf.GCDiskUsageThreshold = 98.0
 	conf.GCInodeUsageThreshold = 98.0
-	return conf
+	return conf, cleanup
 }

--- a/client/fingerprint_manager_test.go
+++ b/client/fingerprint_manager_test.go
@@ -20,10 +20,10 @@ func TestFingerprintManager_Run_MockDriver(t *testing.T) {
 	t.Skip("missing mock driver plugin implementation")
 	t.Parallel()
 	require := require.New(t)
-	testClient := TestClient(t, nil)
+	testClient, cleanup := TestClient(t, nil)
 
 	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -48,10 +48,8 @@ func TestFingerprintManager_Run_MockDriver(t *testing.T) {
 func TestFingerprintManager_Run_ResourcesFingerprint(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	testClient := TestClient(t, nil)
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	testClient, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -76,14 +74,12 @@ func TestFingerprintManager_Run_ResourcesFingerprint(t *testing.T) {
 func TestFingerprintManager_Fingerprint_Run(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"driver.raw_exec.enable": "true",
 		}
 	})
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -109,15 +105,13 @@ func TestFingerprintManager_Fingerprint_Periodic(t *testing.T) {
 	t.Skip("missing mock driver plugin implementation")
 	t.Parallel()
 	require := require.New(t)
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"test.shutdown_periodic_after":    "true",
 			"test.shutdown_periodic_duration": "2",
 		}
 	})
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -172,16 +166,14 @@ func TestFingerprintManager_HealthCheck_Driver(t *testing.T) {
 	t.Skip("missing mock driver plugin implementation")
 	t.Parallel()
 	require := require.New(t)
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"driver.raw_exec.enable":          "1",
 			"test.shutdown_periodic_after":    "true",
 			"test.shutdown_periodic_duration": "2",
 		}
 	})
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -275,15 +267,13 @@ func TestFingerprintManager_HealthCheck_Periodic(t *testing.T) {
 	t.Skip("missing mock driver plugin implementation")
 	t.Parallel()
 	require := require.New(t)
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"test.shutdown_periodic_after":    "true",
 			"test.shutdown_periodic_duration": "2",
 		}
 	})
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -373,15 +363,13 @@ func TestFimgerprintManager_Run_InWhitelist(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"test.shutdown_periodic_after":    "true",
 			"test.shutdown_periodic_duration": "2",
 		}
 	})
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -404,15 +392,13 @@ func TestFimgerprintManager_Run_InWhitelist(t *testing.T) {
 func TestFingerprintManager_Run_InBlacklist(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"fingerprint.whitelist": "  arch,memory,foo,bar	",
 			"fingerprint.blacklist": "  cpu	",
 		}
 	})
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -437,15 +423,13 @@ func TestFingerprintManager_Run_Combination(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"fingerprint.whitelist": "  arch,cpu,memory,foo,bar	",
 			"fingerprint.blacklist": "  memory,nomad	",
 		}
 	})
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -471,15 +455,13 @@ func TestFingerprintManager_Run_Combination(t *testing.T) {
 func TestFingerprintManager_Run_WhitelistDrivers(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"driver.raw_exec.enable": "1",
 			"driver.whitelist": "   raw_exec ,  foo	",
 		}
 	})
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -503,15 +485,13 @@ func TestFingerprintManager_Run_AllDriversBlacklisted(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"driver.raw_exec.enable": "1",
 			"driver.whitelist": "   foo,bar,baz	",
 		}
 	})
-
-	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -538,7 +518,7 @@ func TestFingerprintManager_Run_DriversWhiteListBlacklistCombination(t *testing.
 	t.Parallel()
 	require := require.New(t)
 
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"driver.raw_exec.enable": "1",
 			"driver.whitelist": "   raw_exec,exec,foo,bar,baz	",
@@ -547,7 +527,7 @@ func TestFingerprintManager_Run_DriversWhiteListBlacklistCombination(t *testing.
 	})
 
 	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,
@@ -572,14 +552,14 @@ func TestFingerprintManager_Run_DriverFailure(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"driver.raw_exec.enable": "1",
 		}
 	})
 
 	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	singLoader := testClient.config.PluginSingletonLoader
 
@@ -626,7 +606,7 @@ func TestFingerprintManager_Run_DriversInBlacklist(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	testClient := TestClient(t, func(c *config.Config) {
+	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"driver.raw_exec.enable": "1",
 			"driver.whitelist": "   raw_exec,foo,bar,baz	",
@@ -635,7 +615,7 @@ func TestFingerprintManager_Run_DriversInBlacklist(t *testing.T) {
 	})
 
 	testClient.logger = testlog.HCLogger(t)
-	defer testClient.Shutdown()
+	defer cleanup()
 
 	fm := NewFingerprintManager(
 		testClient.config.PluginSingletonLoader,

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -57,8 +57,8 @@ func TestFS_Stat_NoAlloc(t *testing.T) {
 	require := require.New(t)
 
 	// Start a client
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Make the request with bad allocation id
 	req := &cstructs.FsStatRequest{
@@ -79,8 +79,8 @@ func TestFS_Stat(t *testing.T) {
 	require := require.New(t)
 
 	// Start a client
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Create and add an alloc
 	a := mock.Alloc()
@@ -134,11 +134,11 @@ func TestFS_Stat_ACL(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	client := TestClient(t, func(c *config.Config) {
+	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.ACLEnabled = true
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer client.Shutdown()
+	defer cleanup()
 
 	// Create a bad token
 	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityDeny})
@@ -196,8 +196,8 @@ func TestFS_List_NoAlloc(t *testing.T) {
 	require := require.New(t)
 
 	// Start a client
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Make the request with bad allocation id
 	req := &cstructs.FsListRequest{
@@ -218,8 +218,8 @@ func TestFS_List(t *testing.T) {
 	require := require.New(t)
 
 	// Start a client
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Create and add an alloc
 	a := mock.Alloc()
@@ -273,11 +273,11 @@ func TestFS_List_ACL(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	client := TestClient(t, func(c *config.Config) {
+	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.ACLEnabled = true
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer client.Shutdown()
+	defer cleanup()
 
 	// Create a bad token
 	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityDeny})
@@ -335,8 +335,8 @@ func TestFS_Stream_NoAlloc(t *testing.T) {
 	require := require.New(t)
 
 	// Start a client
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Make the request with bad allocation id
 	req := &cstructs.FsStreamRequest{
@@ -414,11 +414,11 @@ func TestFS_Stream_ACL(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	client := TestClient(t, func(c *config.Config) {
+	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.ACLEnabled = true
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer client.Shutdown()
+	defer cleanup()
 
 	// Create a bad token
 	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityReadFS})
@@ -534,10 +534,10 @@ func TestFS_Stream(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := TestClient(t, func(c *config.Config) {
+	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	expected := "Hello from the other side"
 	job := mock.BatchJob()
@@ -645,10 +645,10 @@ func TestFS_Stream_Follow(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := TestClient(t, func(c *config.Config) {
+	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	expectedBase := "Hello from the other side"
 	repeat := 10
@@ -743,10 +743,10 @@ func TestFS_Stream_Limit(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := TestClient(t, func(c *config.Config) {
+	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	var limit int64 = 5
 	full := "Hello from the other side"
@@ -833,8 +833,8 @@ func TestFS_Logs_NoAlloc(t *testing.T) {
 	require := require.New(t)
 
 	// Start a client
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Make the request with bad allocation id
 	req := &cstructs.FsLogsRequest{
@@ -916,10 +916,10 @@ func TestFS_Logs_TaskPending(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := TestClient(t, func(c *config.Config) {
+	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	job := mock.BatchJob()
 	job.TaskGroups[0].Count = 1
@@ -1024,11 +1024,11 @@ func TestFS_Logs_ACL(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	client := TestClient(t, func(c *config.Config) {
+	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.ACLEnabled = true
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer client.Shutdown()
+	defer cleanup()
 
 	// Create a bad token
 	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityReadFS})
@@ -1145,10 +1145,10 @@ func TestFS_Logs(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := TestClient(t, func(c *config.Config) {
+	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	expected := "Hello from the other side\n"
 	job := mock.BatchJob()
@@ -1247,10 +1247,10 @@ func TestFS_Logs_Follow(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := TestClient(t, func(c *config.Config) {
+	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	expectedBase := "Hello from the other side\n"
 	repeat := 10
@@ -1545,8 +1545,8 @@ func TestFS_findClosest(t *testing.T) {
 func TestFS_streamFile_NoFile(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	ad := tempAllocDir(t)
 	defer os.RemoveAll(ad.AllocDir)
@@ -1565,8 +1565,8 @@ func TestFS_streamFile_NoFile(t *testing.T) {
 func TestFS_streamFile_Modify(t *testing.T) {
 	t.Parallel()
 
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Get a temp alloc dir
 	ad := tempAllocDir(t)
@@ -1634,8 +1634,8 @@ func TestFS_streamFile_Modify(t *testing.T) {
 
 func TestFS_streamFile_Truncate(t *testing.T) {
 	t.Parallel()
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Get a temp alloc dir
 	ad := tempAllocDir(t)
@@ -1739,8 +1739,8 @@ func TestFS_streamFile_Truncate(t *testing.T) {
 func TestFS_streamImpl_Delete(t *testing.T) {
 	t.Parallel()
 
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Get a temp alloc dir
 	ad := tempAllocDir(t)
@@ -1807,8 +1807,8 @@ func TestFS_streamImpl_Delete(t *testing.T) {
 func TestFS_logsImpl_NoFollow(t *testing.T) {
 	t.Parallel()
 
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Get a temp alloc dir and create the log dir
 	ad := tempAllocDir(t)
@@ -1874,8 +1874,8 @@ func TestFS_logsImpl_NoFollow(t *testing.T) {
 func TestFS_logsImpl_Follow(t *testing.T) {
 	t.Parallel()
 
-	c := TestClient(t, nil)
-	defer c.Shutdown()
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
 
 	// Get a temp alloc dir and create the log dir
 	ad := tempAllocDir(t)

--- a/client/rpc_test.go
+++ b/client/rpc_test.go
@@ -19,10 +19,10 @@ func TestRpc_streamingRpcConn_badEndpoint(t *testing.T) {
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c := TestClient(t, func(c *config.Config) {
+	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s1.GetConfig().RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Wait for the client to connect
 	testutil.WaitForResult(func() (bool, error) {
@@ -75,7 +75,7 @@ func TestRpc_streamingRpcConn_badEndpoint_TLS(t *testing.T) {
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c := TestClient(t, func(c *config.Config) {
+	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.Region = "regionFoo"
 		c.Servers = []string{s1.GetConfig().RPCAddr.String()}
 		c.TLSConfig = &sconfig.TLSConfig{
@@ -87,7 +87,7 @@ func TestRpc_streamingRpcConn_badEndpoint_TLS(t *testing.T) {
 			KeyFile:              fookey,
 		}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Wait for the client to connect
 	testutil.WaitForResult(func() (bool, error) {

--- a/client/state/db_test.go
+++ b/client/state/db_test.go
@@ -1,0 +1,169 @@
+package state
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	trstate "github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func setupBoltDB(t *testing.T) (*BoltStateDB, func()) {
+	dir, err := ioutil.TempDir("", "nomadtest")
+	require.NoError(t, err)
+
+	db, err := NewBoltStateDB(dir)
+	if err != nil {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("error removing boltdb dir: %v", err)
+		}
+		t.Fatalf("error creating boltdb: %v", err)
+	}
+
+	cleanup := func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("error closing boltdb: %v", err)
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("error removing boltdb dir: %v", err)
+		}
+	}
+
+	return db.(*BoltStateDB), cleanup
+}
+
+func testDB(t *testing.T, f func(*testing.T, StateDB)) {
+	boltdb, cleanup := setupBoltDB(t)
+	defer cleanup()
+
+	memdb := NewMemDB()
+
+	impls := []StateDB{boltdb, memdb}
+
+	for _, db := range impls {
+		db := db
+		t.Run(db.Name(), func(t *testing.T) {
+			f(t, db)
+		})
+	}
+}
+
+// TestStateDB asserts the behavior of GetAllAllocations, PutAllocation, and
+// DeleteAllocationBucket for all operational StateDB implementations.
+func TestStateDB_Allocations(t *testing.T) {
+	t.Parallel()
+
+	testDB(t, func(t *testing.T, db StateDB) {
+		require := require.New(t)
+
+		// Empty database should return empty non-nil results
+		allocs, errs, err := db.GetAllAllocations()
+		require.NoError(err)
+		require.NotNil(allocs)
+		require.Empty(allocs)
+		require.NotNil(errs)
+		require.Empty(errs)
+
+		// Put allocations
+		alloc1 := mock.Alloc()
+		alloc2 := mock.BatchAlloc()
+		require.NoError(db.PutAllocation(alloc1))
+		require.NoError(db.PutAllocation(alloc2))
+
+		// Retrieve them
+		allocs, errs, err = db.GetAllAllocations()
+		require.NoError(err)
+		require.NotNil(allocs)
+		require.Len(allocs, 2)
+		require.Contains(allocs, alloc1)
+		require.Contains(allocs, alloc2)
+		require.NotNil(errs)
+		require.Empty(errs)
+
+		// Add another
+		alloc3 := mock.SystemAlloc()
+		require.NoError(db.PutAllocation(alloc3))
+		allocs, errs, err = db.GetAllAllocations()
+		require.NoError(err)
+		require.NotNil(allocs)
+		require.Len(allocs, 3)
+		require.Contains(allocs, alloc1)
+		require.Contains(allocs, alloc2)
+		require.Contains(allocs, alloc3)
+		require.NotNil(errs)
+		require.Empty(errs)
+
+		// Deleting a nonexistent alloc is a noop
+		require.NoError(db.DeleteAllocationBucket("asdf"))
+		allocs, errs, err = db.GetAllAllocations()
+		require.NoError(err)
+		require.NotNil(allocs)
+		require.Len(allocs, 3)
+
+		// Delete alloc1
+		require.NoError(db.DeleteAllocationBucket(alloc1.ID))
+		allocs, errs, err = db.GetAllAllocations()
+		require.NoError(err)
+		require.NotNil(allocs)
+		require.Len(allocs, 2)
+		require.Contains(allocs, alloc2)
+		require.Contains(allocs, alloc3)
+		require.NotNil(errs)
+		require.Empty(errs)
+	})
+}
+
+// TestStateDB_TaskState asserts the behavior of task state related StateDB
+// methods.
+func TestStateDB_TaskState(t *testing.T) {
+	t.Parallel()
+
+	testDB(t, func(t *testing.T, db StateDB) {
+		require := require.New(t)
+
+		// Getting nonexistent state should return nils
+		ls, ts, err := db.GetTaskRunnerState("allocid", "taskname")
+		require.NoError(err)
+		require.Nil(ls)
+		require.Nil(ts)
+
+		// Putting TaskState without first putting the allocation should work
+		state := structs.NewTaskState()
+		state.Failed = true // set a non-default value
+		require.NoError(db.PutTaskState("allocid", "taskname", state))
+
+		// Getting should return the available state
+		ls, ts, err = db.GetTaskRunnerState("allocid", "taskname")
+		require.NoError(err)
+		require.Nil(ls)
+		require.Equal(state, ts)
+
+		// Deleting a nonexistent task should not error
+		require.NoError(db.DeleteTaskBucket("adsf", "asdf"))
+		require.NoError(db.DeleteTaskBucket("asllocid", "asdf"))
+
+		// Data should be untouched
+		ls, ts, err = db.GetTaskRunnerState("allocid", "taskname")
+		require.NoError(err)
+		require.Nil(ls)
+		require.Equal(state, ts)
+
+		// Deleting the task should remove the state
+		require.NoError(db.DeleteTaskBucket("allocid", "taskname"))
+		ls, ts, err = db.GetTaskRunnerState("allocid", "taskname")
+		require.NoError(err)
+		require.Nil(ls)
+		require.Nil(ts)
+
+		// Putting LocalState should work just like TaskState
+		origLocalState := trstate.NewLocalState()
+		require.NoError(db.PutTaskRunnerLocalState("allocid", "taskname", origLocalState))
+		ls, ts, err = db.GetTaskRunnerState("allocid", "taskname")
+		require.NoError(err)
+		require.Equal(origLocalState, ls)
+		require.Nil(ts)
+	})
+}

--- a/client/state/interface.go
+++ b/client/state/interface.go
@@ -7,12 +7,41 @@ import (
 
 // StateDB implementations store and load Nomad client state.
 type StateDB interface {
+	// Name of implementation.
+	Name() string
+
+	// GetAllAllocations returns all valid allocations and a map of
+	// allocation IDs to retrieval errors.
+	//
+	// If a single error is returned then both allocations and the map will be nil.
 	GetAllAllocations() ([]*structs.Allocation, map[string]error, error)
+
+	// PulAllocation stores an allocation or returns an error if it could
+	// not be stored.
 	PutAllocation(*structs.Allocation) error
+
+	// GetTaskRunnerState returns the LocalState and TaskState for a
+	// TaskRunner. Either state may be nil if it is not found, but if an
+	// error is encountered only the error will be non-nil.
 	GetTaskRunnerState(allocID, taskName string) (*state.LocalState, *structs.TaskState, error)
-	PutTaskRunnerLocalState(allocID, taskName string, val interface{}) error
+
+	// PutTaskRunnerLocalTask stores the LocalState for a TaskRunner or
+	// returns an error.
+	PutTaskRunnerLocalState(allocID, taskName string, val *state.LocalState) error
+
+	// PutTaskState stores the TaskState for a TaskRunner or returns an
+	// error.
 	PutTaskState(allocID, taskName string, state *structs.TaskState) error
+
+	// DeleteTaskBucket deletes a task's state bucket if it exists. No
+	// error is returned if it does not exist.
 	DeleteTaskBucket(allocID, taskName string) error
+
+	// DeleteAllocationBucket deletes an allocation's state bucket if it
+	// exists. No error is returned if it does not exist.
 	DeleteAllocationBucket(allocID string) error
+
+	// Close the database. Unsafe for further use after calling regardless
+	// of return value.
 	Close() error
 }

--- a/client/state/memdb.go
+++ b/client/state/memdb.go
@@ -1,0 +1,144 @@
+package state
+
+import (
+	"sync"
+
+	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// MemDB implements a StateDB that stores data in memory and should only be
+// used for testing. All methods are safe for concurrent use.
+type MemDB struct {
+	// alloc_id -> value
+	allocs map[string]*structs.Allocation
+
+	// alloc_id -> task_name -> value
+	localTaskState map[string]map[string]*state.LocalState
+	taskState      map[string]map[string]*structs.TaskState
+
+	mu sync.RWMutex
+}
+
+func NewMemDB() *MemDB {
+	return &MemDB{
+		allocs:         make(map[string]*structs.Allocation),
+		localTaskState: make(map[string]map[string]*state.LocalState),
+		taskState:      make(map[string]map[string]*structs.TaskState),
+	}
+}
+
+func (m *MemDB) Name() string {
+	return "memdb"
+}
+
+func (m *MemDB) GetAllAllocations() ([]*structs.Allocation, map[string]error, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	allocs := make([]*structs.Allocation, 0, len(m.allocs))
+	for _, v := range m.allocs {
+		allocs = append(allocs, v)
+	}
+
+	return allocs, map[string]error{}, nil
+}
+
+func (m *MemDB) PutAllocation(alloc *structs.Allocation) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.allocs[alloc.ID] = alloc
+	return nil
+}
+
+func (m *MemDB) GetTaskRunnerState(allocID string, taskName string) (*state.LocalState, *structs.TaskState, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var ls *state.LocalState
+	var ts *structs.TaskState
+
+	// Local Task State
+	allocLocalTS := m.localTaskState[allocID]
+	if len(allocLocalTS) != 0 {
+		ls = allocLocalTS[taskName]
+	}
+
+	// Task State
+	allocTS := m.taskState[allocID]
+	if len(allocTS) != 0 {
+		ts = allocTS[taskName]
+	}
+
+	return ls, ts, nil
+}
+
+func (m *MemDB) PutTaskRunnerLocalState(allocID string, taskName string, val *state.LocalState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if alts, ok := m.localTaskState[allocID]; ok {
+		alts[taskName] = val.Copy()
+		return nil
+	}
+
+	m.localTaskState[allocID] = map[string]*state.LocalState{
+		taskName: val.Copy(),
+	}
+
+	return nil
+}
+
+func (m *MemDB) PutTaskState(allocID string, taskName string, state *structs.TaskState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if ats, ok := m.taskState[allocID]; ok {
+		ats[taskName] = state.Copy()
+		return nil
+	}
+
+	m.taskState[allocID] = map[string]*structs.TaskState{
+		taskName: state.Copy(),
+	}
+
+	return nil
+}
+
+func (m *MemDB) DeleteTaskBucket(allocID, taskName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if ats, ok := m.taskState[allocID]; ok {
+		delete(ats, taskName)
+	}
+
+	if alts, ok := m.localTaskState[allocID]; ok {
+		delete(alts, taskName)
+	}
+
+	return nil
+}
+
+func (m *MemDB) DeleteAllocationBucket(allocID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.allocs, allocID)
+	delete(m.taskState, allocID)
+	delete(m.localTaskState, allocID)
+
+	return nil
+}
+
+func (m *MemDB) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Set everything to nil to blow up on further use
+	m.allocs = nil
+	m.taskState = nil
+	m.localTaskState = nil
+
+	return nil
+}

--- a/client/state/noopdb.go
+++ b/client/state/noopdb.go
@@ -8,6 +8,10 @@ import (
 // NoopDB implements a StateDB that does not persist any data.
 type NoopDB struct{}
 
+func (n NoopDB) Name() string {
+	return "noopdb"
+}
+
 func (n NoopDB) GetAllAllocations() ([]*structs.Allocation, map[string]error, error) {
 	return nil, nil, nil
 }
@@ -20,7 +24,7 @@ func (n NoopDB) GetTaskRunnerState(allocID string, taskName string) (*state.Loca
 	return nil, nil, nil
 }
 
-func (n NoopDB) PutTaskRunnerLocalState(allocID string, taskName string, val interface{}) error {
+func (n NoopDB) PutTaskRunnerLocalState(allocID string, taskName string, val *state.LocalState) error {
 	return nil
 }
 

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -27,8 +27,8 @@ type mockUpdater struct {
 	logger log.Logger
 }
 
-func (m *mockUpdater) TaskStateUpdated(task string, state *structs.TaskState) {
-	m.logger.Named("test.updater").Debug("update", "task", task, "state", state)
+func (m *mockUpdater) TaskStateUpdated() {
+	m.logger.Named("mock.updater").Debug("Update!")
 }
 
 // TODO Fix

--- a/helper/boltdd/boltdd_test.go
+++ b/helper/boltdd/boltdd_test.go
@@ -232,7 +232,9 @@ func TestBucket_Delete(t *testing.T) {
 		require.NoError(err)
 
 		var v []byte
-		require.Error(child.Get(childKey, &v))
+		err = child.Get(childKey, &v)
+		require.Error(err)
+		require.True(IsErrNotFound(err))
 		require.Equal(([]byte)(nil), v)
 
 		require.Nil(child.Bucket(grandchildName1))

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -3,6 +3,7 @@ package nomad
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
@@ -26,10 +27,10 @@ func TestClientAllocations_GarbageCollectAll_Local(t *testing.T) {
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s.connectedNodes()
@@ -188,11 +189,11 @@ func TestClientAllocations_GarbageCollectAll_Remote(t *testing.T) {
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 		c.GCDiskUsageThreshold = 100.0
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s2.connectedNodes()
@@ -268,11 +269,11 @@ func TestClientAllocations_GarbageCollect_Local(t *testing.T) {
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 		c.GCDiskUsageThreshold = 100.0
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -283,7 +284,7 @@ func TestClientAllocations_GarbageCollect_Local(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for": "2s",
+			"run_for": 2 * time.Second,
 		},
 		LogConfig: structs.DefaultLogConfig(),
 		Resources: &structs.Resources{
@@ -417,11 +418,11 @@ func TestClientAllocations_GarbageCollect_Remote(t *testing.T) {
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 		c.GCDiskUsageThreshold = 100.0
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -432,7 +433,7 @@ func TestClientAllocations_GarbageCollect_Remote(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for": "2s",
+			"run_for": 2 * time.Second,
 		},
 		LogConfig: structs.DefaultLogConfig(),
 		Resources: &structs.Resources{
@@ -539,10 +540,10 @@ func TestClientAllocations_Stats_Local(t *testing.T) {
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -553,7 +554,7 @@ func TestClientAllocations_Stats_Local(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for": "2s",
+			"run_for": 2 * time.Second,
 		},
 		LogConfig: structs.DefaultLogConfig(),
 		Resources: &structs.Resources{
@@ -688,10 +689,10 @@ func TestClientAllocations_Stats_Remote(t *testing.T) {
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -702,7 +703,7 @@ func TestClientAllocations_Stats_Remote(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for": "2s",
+			"run_for": 2 * time.Second,
 		},
 		LogConfig: structs.DefaultLogConfig(),
 		Resources: &structs.Resources{

--- a/nomad/client_fs_endpoint_test.go
+++ b/nomad/client_fs_endpoint_test.go
@@ -31,10 +31,10 @@ func TestClientFS_List_Local(t *testing.T) {
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -45,7 +45,7 @@ func TestClientFS_List_Local(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for": "2s",
+			"run_for": 2 * time.Second,
 		},
 		LogConfig: structs.DefaultLogConfig(),
 		Resources: &structs.Resources{
@@ -183,10 +183,10 @@ func TestClientFS_List_Remote(t *testing.T) {
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -197,7 +197,7 @@ func TestClientFS_List_Remote(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for": "2s",
+			"run_for": 2 * time.Second,
 		},
 		LogConfig: structs.DefaultLogConfig(),
 		Resources: &structs.Resources{
@@ -300,10 +300,10 @@ func TestClientFS_Stat_Local(t *testing.T) {
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -314,7 +314,7 @@ func TestClientFS_Stat_Local(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for": "2s",
+			"run_for": 2 * time.Second,
 		},
 		LogConfig: structs.DefaultLogConfig(),
 		Resources: &structs.Resources{
@@ -452,10 +452,10 @@ func TestClientFS_Stat_Remote(t *testing.T) {
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -466,7 +466,7 @@ func TestClientFS_Stat_Remote(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for": "2s",
+			"run_for": 2 * time.Second,
 		},
 		LogConfig: structs.DefaultLogConfig(),
 		Resources: &structs.Resources{
@@ -719,10 +719,10 @@ func TestClientFS_Streaming_Local(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	expected := "Hello from the other side"
@@ -734,7 +734,7 @@ func TestClientFS_Streaming_Local(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for":       "2s",
+			"run_for":       2 * time.Second,
 			"stdout_string": expected,
 		},
 		LogConfig: structs.DefaultLogConfig(),
@@ -851,10 +851,10 @@ func TestClientFS_Streaming_Local_Follow(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	expectedBase := "Hello from the other side"
@@ -868,7 +868,7 @@ func TestClientFS_Streaming_Local_Follow(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for":                "20s",
+			"run_for":                2 * time.Second,
 			"stdout_string":          expectedBase,
 			"stdout_repeat":          repeat,
 			"stdout_repeat_duration": 200 * time.Millisecond,
@@ -995,10 +995,10 @@ func TestClientFS_Streaming_Remote_Server(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	expected := "Hello from the other side"
@@ -1010,7 +1010,7 @@ func TestClientFS_Streaming_Remote_Server(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for":       "2s",
+			"run_for":       2 * time.Second,
 			"stdout_string": expected,
 		},
 		LogConfig: structs.DefaultLogConfig(),
@@ -1141,11 +1141,11 @@ func TestClientFS_Streaming_Remote_Region(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 		c.Region = "two"
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	expected := "Hello from the other side"
@@ -1157,7 +1157,7 @@ func TestClientFS_Streaming_Remote_Region(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for":       "2s",
+			"run_for":       2 * time.Second,
 			"stdout_string": expected,
 		},
 		LogConfig: structs.DefaultLogConfig(),
@@ -1541,10 +1541,10 @@ func TestClientFS_Logs_Local(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	expected := "Hello from the other side"
@@ -1556,7 +1556,7 @@ func TestClientFS_Logs_Local(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for":       "2s",
+			"run_for":       2 * time.Second,
 			"stdout_string": expected,
 		},
 		LogConfig: structs.DefaultLogConfig(),
@@ -1674,10 +1674,10 @@ func TestClientFS_Logs_Local_Follow(t *testing.T) {
 	defer s.Shutdown()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	expectedBase := "Hello from the other side"
@@ -1691,7 +1691,7 @@ func TestClientFS_Logs_Local_Follow(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for":                "20s",
+			"run_for":                20 * time.Second,
 			"stdout_string":          expectedBase,
 			"stdout_repeat":          repeat,
 			"stdout_repeat_duration": 200 * time.Millisecond,
@@ -1819,10 +1819,10 @@ func TestClientFS_Logs_Remote_Server(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	expected := "Hello from the other side"
@@ -1834,7 +1834,7 @@ func TestClientFS_Logs_Remote_Server(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for":       "2s",
+			"run_for":       2 * time.Second,
 			"stdout_string": expected,
 		},
 		LogConfig: structs.DefaultLogConfig(),
@@ -1966,11 +1966,11 @@ func TestClientFS_Logs_Remote_Region(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 		c.Region = "two"
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Force an allocation onto the node
 	expected := "Hello from the other side"
@@ -1982,7 +1982,7 @@ func TestClientFS_Logs_Remote_Region(t *testing.T) {
 		Name:   "web",
 		Driver: "mock_driver",
 		Config: map[string]interface{}{
-			"run_for":       "2s",
+			"run_for":       2 * time.Second,
 			"stdout_string": expected,
 		},
 		LogConfig: structs.DefaultLogConfig(),

--- a/nomad/client_rpc_test.go
+++ b/nomad/client_rpc_test.go
@@ -264,10 +264,10 @@ func TestNodeStreamingRpc_badEndpoint(t *testing.T) {
 	defer s1.Shutdown()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s1.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	// Wait for the client to connect
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/client_stats_endpoint_test.go
+++ b/nomad/client_stats_endpoint_test.go
@@ -25,10 +25,10 @@ func TestClientStats_Stats_Local(t *testing.T) {
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s.connectedNodes()
@@ -183,10 +183,10 @@ func TestClientStats_Stats_Remote(t *testing.T) {
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c := client.TestClient(t, func(c *config.Config) {
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer c.Shutdown()
+	defer cleanup()
 
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s2.connectedNodes()

--- a/nomad/drainer_int_test.go
+++ b/nomad/drainer_int_test.go
@@ -870,7 +870,6 @@ func TestDrainer_AllTypes_Deadline_GarbageCollectedNode(t *testing.T) {
 // Test that transitions to force drain work.
 func TestDrainer_Batch_TransitionToForce(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
 	for _, inf := range []bool{true, false} {
 		name := "Infinite"
@@ -878,6 +877,7 @@ func TestDrainer_Batch_TransitionToForce(t *testing.T) {
 			name = "Deadline"
 		}
 		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
 			s1 := TestServer(t, nil)
 			defer s1.Shutdown()
 			codec := rpcClient(t, s1)
@@ -948,12 +948,12 @@ func TestDrainer_Batch_TransitionToForce(t *testing.T) {
 			// Make sure the batch job isn't affected
 			testutil.AssertUntil(500*time.Millisecond, func() (bool, error) {
 				if err := checkAllocPromoter(errCh); err != nil {
-					return false, err
+					return false, fmt.Errorf("check alloc promoter error: %v", err)
 				}
 
 				allocs, err := state.AllocsByNode(nil, n1.ID)
 				if err != nil {
-					return false, err
+					return false, fmt.Errorf("AllocsByNode error: %v", err)
 				}
 				for _, alloc := range allocs {
 					if alloc.DesiredStatus != structs.AllocDesiredStatusRun {

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -264,7 +264,7 @@ func BatchJob() *structs.Job {
 						Name:   "worker",
 						Driver: "mock_driver",
 						Config: map[string]interface{}{
-							"run_for": "500ms",
+							"run_for": 500 * time.Millisecond,
 						},
 						Env: map[string]string{
 							"FOO": "bar",

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5573,6 +5573,21 @@ type TaskState struct {
 	Events []*TaskEvent
 }
 
+// NewTaskState returns a TaskState initialized in the Pending state.
+func NewTaskState() *TaskState {
+	return &TaskState{
+		State: TaskStatePending,
+	}
+}
+
+// Canonicalize ensures the TaskState has a State set. It should default to
+// Pending.
+func (ts *TaskState) Canonicalize() {
+	if ts.State == "" {
+		ts.State = TaskStatePending
+	}
+}
+
 func (ts *TaskState) Copy() *TaskState {
 	if ts == nil {
 		return nil

--- a/plugins/drivers/task_handle.go
+++ b/plugins/drivers/task_handle.go
@@ -29,6 +29,10 @@ func (h *TaskHandle) GetDriverState(v interface{}) error {
 }
 
 func (h *TaskHandle) Copy() *TaskHandle {
+	if h == nil {
+		return nil
+	}
+
 	handle := new(TaskHandle)
 	*handle = *h
 	handle.Config = h.Config.Copy()


### PR DESCRIPTION
Replacement of #4775 rebased on master post-#4792 merge.

Fixes:
* Fix panic on restore due to nil prev alloc watcher ee06875
* Fix panic when copying a nil TaskHandle 942f1d7
* Port task leader tests from deprecated alloc runner and get them passing (with -race)
* Refactor AR task killing into a single method that kills the leader first
* Fix deadlock in AR.Destroy (see note below)
* Documented and tested state database behavior to make restoring more robust.

### Notable Code Change: AllocRunner.Run

Instead of `go ar.Run()` you should now call `ar.Run()` as `AllocRunner.Run` now creates its own goroutine. This allows it to synchronously mark that it _has run_ so that when `AR.Destroy` is called it knows whether or not to wait for `ar.Run()` to exit.

### Notable Test Change: TestClient Cleanup

Made TestClientConfig and TestClient return a cleanup func to clean up its state and alloc dirs after a test finishes.