### PR TITLE
Vault API Client Tweaks

### DIFF
--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -156,6 +157,10 @@ func NewVaultClient(config *config.VaultConfig, logger hclog.Logger, tokenDerive
 		logger.Error("error creating vault client", "error", err)
 		return nil, err
 	}
+
+	client.SetHeaders(http.Header{
+		"User-Agent": []string{"HashiCorp/nomad"},
+	})
 
 	c.client = client
 

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -160,7 +160,7 @@ func NewVaultClient(config *config.VaultConfig, logger hclog.Logger, tokenDerive
 	}
 
 	client.SetHeaders(http.Header{
-		"User-Agent": []string{"HashiCorp/nomad"},
+		"User-Agent": []string{"hashicorp/nomad"},
 	})
 
 	c.client = client

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1433,6 +1433,7 @@ func (s *Server) Stats() map[string]map[string]string {
 		"raft":    s.raft.Stats(),
 		"serf":    s.serf.Stats(),
 		"runtime": stats.RuntimeStats(),
+		"vault":   s.vault.Stats(),
 	}
 
 	return stats

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -515,11 +515,11 @@ func (v *vaultClient) renewalLoop() {
 // nextBackoff returns the delay for the next auto renew interval, in seconds.
 // Returns negative value if past expiration
 //
-// It should increaes the amount of backoff each time, with the following rules:
+// It should increase the amount of backoff each time, with the following rules:
 //
 // * If we have an existing authentication that is going to expire,
 // never back off more than half of the amount of time remaining
-// until expiration (with 1s floor)
+// until expiration (with 5s floor)
 // * Never back off more than 30 seconds multiplied by a random
 // value between 1 and 2
 // * Use randomness so that many clients won't keep hitting Vault
@@ -531,8 +531,6 @@ func nextBackoff(backoff float64, expiry time.Time) float64 {
 	}
 
 	switch {
-	case backoff < 5:
-		backoff = 5
 	case backoff >= 24:
 		backoff = 30
 	default:
@@ -546,9 +544,8 @@ func nextBackoff(backoff float64, expiry time.Time) float64 {
 		backoff = maxBackoff.Seconds()
 	}
 
-	// avoid hammering Vault
-	if backoff < 1 {
-		backoff = 1
+	if backoff < 5 {
+		backoff = 5
 	}
 
 	return backoff

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -209,10 +209,6 @@ type vaultClient struct {
 	tomb   *tomb.Tomb
 	logger log.Logger
 
-	// stats stores the stats
-	stats     *VaultStats
-	statsLock sync.RWMutex
-
 	// l is used to lock the configuration aspects of the client such that
 	// multiple callers can't cause conflicting config updates
 	l sync.Mutex
@@ -236,7 +232,6 @@ func NewVaultClient(c *config.VaultConfig, logger log.Logger, purgeFn PurgeVault
 		revoking: make(map[*structs.VaultAccessor]time.Time),
 		purgeFn:  purgeFn,
 		tomb:     &tomb.Tomb{},
-		stats:    new(VaultStats),
 	}
 
 	if v.config.IsEnabled() {
@@ -1052,13 +1047,11 @@ func (v *vaultClient) RevokeTokens(ctx context.Context, accessors []*structs.Vau
 // time.
 func (v *vaultClient) storeForRevocation(accessors []*structs.VaultAccessor) {
 	v.revLock.Lock()
-	v.statsLock.Lock()
+
 	now := time.Now()
 	for _, a := range accessors {
 		v.revoking[a] = now.Add(time.Duration(a.CreationTTL) * time.Second)
 	}
-	v.stats.TrackedForRevoke = len(v.revoking)
-	v.statsLock.Unlock()
 	v.revLock.Unlock()
 }
 
@@ -1179,12 +1172,9 @@ func (v *vaultClient) revokeDaemon() {
 
 			// Can delete from the tracked list now that we have purged
 			v.revLock.Lock()
-			v.statsLock.Lock()
 			for _, va := range revoking {
 				delete(v.revoking, va)
 			}
-			v.stats.TrackedForRevoke = len(v.revoking)
-			v.statsLock.Unlock()
 			v.revLock.Unlock()
 
 		}
@@ -1221,11 +1211,9 @@ func (v *vaultClient) Stats() *VaultStats {
 	// Allocate a new stats struct
 	stats := new(VaultStats)
 
-	v.statsLock.RLock()
-	defer v.statsLock.RUnlock()
-
-	// Copy all the stats
-	stats.TrackedForRevoke = v.stats.TrackedForRevoke
+	v.revLock.Lock()
+	stats.TrackedForRevoke = len(v.revoking)
+	v.revLock.Unlock()
 
 	return stats
 }

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -560,7 +560,7 @@ func (v *vaultClient) renew() error {
 	// Attempt to renew the token
 	secret, err := v.auth.RenewSelf(v.tokenData.CreationTTL)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to renew the vault token: %v", err)
 	}
 	if secret == nil {
 		// It's possible for RenewSelf to return (nil, nil) if the
@@ -914,6 +914,7 @@ func (v *vaultClient) CreateToken(ctx context.Context, a *structs.Allocation, ta
 
 	// Determine whether it is unrecoverable
 	if err != nil {
+		err = fmt.Errorf("failed to create an alloc vault token: %v", err)
 		if structs.VaultUnrecoverableError.MatchString(err.Error()) {
 			return secret, err
 		}

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -583,15 +583,15 @@ func (v *vaultClient) renew() (bool, error) {
 	// Attempt to renew the token
 	secret, err := v.auth.RenewSelf(v.tokenData.CreationTTL)
 	if err != nil {
-
 		// Check if there is a permission denied
 		recoverable := !structs.VaultUnrecoverableError.MatchString(err.Error())
 		return recoverable, fmt.Errorf("failed to renew the vault token: %v", err)
 	}
+
 	if secret == nil {
 		// It's possible for RenewSelf to return (nil, nil) if the
 		// response body from Vault is empty.
-		return fmt.Errorf("renewal failed: empty response from vault")
+		return true, fmt.Errorf("renewal failed: empty response from vault")
 	}
 
 	// these treated as transient errors, where can keep renewing

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -1221,7 +1221,7 @@ func (v *vaultClient) Stats() map[string]string {
 
 	return map[string]string{
 		"tracked_for_revoked": strconv.Itoa(stat.TrackedForRevoke),
-		"token_ttl":           stat.TokenTTL.String(),
+		"token_ttl":           stat.TokenTTL.Round(time.Second).String(),
 		"token_expire_time":   expireTimeStr,
 	}
 }

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -210,7 +210,7 @@ type vaultClient struct {
 	// childTTL is the TTL for child tokens.
 	childTTL string
 
-	// currentExpiration is the time the current tokean lease expires
+	// currentExpiration is the time the current token lease expires
 	currentExpiration time.Time
 
 	tomb   *tomb.Tomb

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -127,7 +127,7 @@ type VaultClient interface {
 	Running() bool
 
 	// Stats returns the Vault clients statistics
-	Stats() *VaultStats
+	Stats() map[string]string
 
 	// EmitStats emits that clients statistics at the given period until stopCh
 	// is called.
@@ -1223,7 +1223,7 @@ func (v *vaultClient) EmitStats(period time.Duration, stopCh chan struct{}) {
 	for {
 		select {
 		case <-time.After(period):
-			stats := v.Stats()
+			stats := v.stats()
 			metrics.SetGauge([]string{"nomad", "vault", "distributed_tokens_revoking"}, float32(stats.TrackedForRevoke))
 		case <-stopCh:
 			return

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -1285,8 +1285,8 @@ func TestVaultClient_nextBackoff(t *testing.T) {
 	// some edge cases
 	t.Run("close to expiry", func(t *testing.T) {
 		b := nextBackoff(20, time.Now().Add(1100*time.Millisecond))
-		if !(1.0 <= b && b <= 3) {
-			t.Fatalf("Expected backoff within [1, 3] but found %v", b)
+		if b != 5.0 {
+			t.Fatalf("Expected backoff is 5 but found %v", b)
 		}
 	})
 

--- a/nomad/vault_testing.go
+++ b/nomad/vault_testing.go
@@ -139,5 +139,5 @@ func (v *TestVaultClient) Stop()                                                
 func (v *TestVaultClient) SetActive(enabled bool)                               {}
 func (v *TestVaultClient) SetConfig(config *config.VaultConfig) error           { return nil }
 func (v *TestVaultClient) Running() bool                                        { return true }
-func (v *TestVaultClient) Stats() *VaultStats                                   { return new(VaultStats) }
+func (v *TestVaultClient) Stats() map[string]string                             { return map[string]string{} }
 func (v *TestVaultClient) EmitStats(period time.Duration, stopCh chan struct{}) {}


### PR DESCRIPTION
Some tweaks for Vault Client Token renewal:

* Passing a UserAgent header when calling Vault
* Increment counter for vault renewal errors
* As token vault expiry approaches, set 1s floor for delay