### PR TITLE
Fix formatting of allocation score metrics

### DIFF
--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -247,7 +247,7 @@ func TestAllocStatusCommand_ScoreMetrics(t *testing.T) {
 
 	ui := new(cli.MockUi)
 	cmd := &AllocStatusCommand{Meta: Meta{Ui: ui}}
-	// Test reschedule attempt info
+	// Test node metrics
 	require := require.New(t)
 	state := srv.Agent.Server().State()
 	a := mock.Alloc()
@@ -280,7 +280,7 @@ func TestAllocStatusCommand_ScoreMetrics(t *testing.T) {
 	require.Contains(out, "Placement Metrics")
 	require.Contains(out, mockNode1.ID)
 	require.Contains(out, mockNode2.ID)
-	require.Contains(out, "Final Score")
+	require.Contains(out, "final score")
 }
 
 func TestAllocStatusCommand_AutocompleteArgs(t *testing.T) {

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -375,21 +375,23 @@ func formatAllocMetrics(metrics *api.AllocationMetric, scores bool, prefix strin
 	if scores {
 		if len(metrics.ScoreMetaData) > 0 {
 			scoreOutput := make([]string, len(metrics.ScoreMetaData)+1)
-
+			var scorerNames []string
 			for i, scoreMeta := range metrics.ScoreMetaData {
 				// Add header as first row
 				if i == 0 {
 					scoreOutput[0] = "Node|"
 					for scorerName := range scoreMeta.Scores {
 						scoreOutput[0] += fmt.Sprintf("%v|", scorerName)
+						scorerNames = append(scorerNames, scorerName)
 					}
-					scoreOutput[0] += "Final Score"
+					scoreOutput[0] += "final score"
 				}
 				scoreOutput[i+1] = fmt.Sprintf("%v|", scoreMeta.NodeID)
-				for _, scoreVal := range scoreMeta.Scores {
-					scoreOutput[i+1] += fmt.Sprintf("%v|", scoreVal)
+				for _, scorerName := range scorerNames {
+					scoreVal := scoreMeta.Scores[scorerName]
+					scoreOutput[i+1] += fmt.Sprintf("%.3g|", scoreVal)
 				}
-				scoreOutput[i+1] += fmt.Sprintf("%v", scoreMeta.NormScore)
+				scoreOutput[i+1] += fmt.Sprintf("%.3g", scoreMeta.NormScore)
 			}
 			out += formatList(scoreOutput)
 		} else {

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -319,6 +319,8 @@ func (iter *JobAntiAffinityIterator) Next() *RankedNode {
 			scorePenalty := -1 * float64(collisions+1) / float64(iter.desiredCount)
 			option.Scores = append(option.Scores, scorePenalty)
 			iter.ctx.Metrics().ScoreNode(option.Node, "job-anti-affinity", scorePenalty)
+		} else {
+			iter.ctx.Metrics().ScoreNode(option.Node, "job-anti-affinity", 0)
 		}
 		return option
 	}
@@ -362,6 +364,8 @@ func (iter *NodeReschedulingPenaltyIterator) Next() *RankedNode {
 		if ok {
 			option.Scores = append(option.Scores, -1)
 			iter.ctx.Metrics().ScoreNode(option.Node, "node-reschedule-penalty", -1)
+		} else {
+			iter.ctx.Metrics().ScoreNode(option.Node, "node-reschedule-penalty", 0)
 		}
 		return option
 	}
@@ -428,6 +432,7 @@ func (iter *NodeAffinityIterator) Next() *RankedNode {
 		return nil
 	}
 	if !iter.hasAffinities() {
+		iter.ctx.Metrics().ScoreNode(option.Node, "node-affinity", 0)
 		return option
 	}
 	// TODO(preetha): we should calculate normalized weights once and reuse it here


### PR DESCRIPTION
fixes a CLI display issue when score metrics do not contain all scoring factors. This PR addresses that by using a default value of zero. It also cleans up the display to use three digits of precision. 