### PR TITLE
Fix driver naming, fingerprint output, races/tests

### DIFF
--- a/drivers/mock/driver.go
+++ b/drivers/mock/driver.go
@@ -110,8 +110,7 @@ type Driver struct {
 
 	shutdownFingerprintTime time.Time
 
-	// logger will log to the plugin output which is usually an 'executor.out'
-	// file located in the root of the TaskDir
+	// logger will log to the Nomad agent
 	logger hclog.Logger
 }
 

--- a/drivers/mock/driver.go
+++ b/drivers/mock/driver.go
@@ -259,11 +259,11 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	attrs := map[string]string{}
 	if !d.shutdownFingerprintTime.IsZero() && time.Now().After(d.shutdownFingerprintTime) {
 		health = drivers.HealthStateUndetected
-		desc = "mock disabled"
+		desc = "disabled"
 	} else {
 		health = drivers.HealthStateHealthy
 		attrs["driver.mock"] = "1"
-		desc = "mock enabled"
+		desc = "ready"
 	}
 
 	return &drivers.Fingerprint{

--- a/drivers/mock/state.go
+++ b/drivers/mock/state.go
@@ -5,21 +5,21 @@ import (
 )
 
 type taskStore struct {
-	store map[string]*mockTaskHandle
+	store map[string]*taskHandle
 	lock  sync.RWMutex
 }
 
 func newTaskStore() *taskStore {
-	return &taskStore{store: map[string]*mockTaskHandle{}}
+	return &taskStore{store: map[string]*taskHandle{}}
 }
 
-func (ts *taskStore) Set(id string, handle *mockTaskHandle) {
+func (ts *taskStore) Set(id string, handle *taskHandle) {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 	ts.store[id] = handle
 }
 
-func (ts *taskStore) Get(id string) (*mockTaskHandle, bool) {
+func (ts *taskStore) Get(id string) (*taskHandle, bool) {
 	ts.lock.RLock()
 	defer ts.lock.RUnlock()
 	t, ok := ts.store[id]

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -37,16 +37,16 @@ const (
 	fingerprintPeriod = 30 * time.Second
 
 	// The key populated in Node Attributes to indicate presence of the Qemu driver
-	qemuDriverAttr        = "driver.qemu"
-	qemuDriverVersionAttr = "driver.qemu.version"
+	driverAttr        = "driver.qemu"
+	driverVersionAttr = "driver.qemu.version"
 
 	// Represents an ACPI shutdown request to the VM (emulates pressing a physical power button)
 	// Reference: https://en.wikibooks.org/wiki/QEMU/Monitor
-	qemuGracefulShutdownMsg = "system_powerdown\n"
-	qemuMonitorSocketName   = "qemu-monitor.sock"
+	gracefulShutdownMsg = "system_powerdown\n"
+	monitorSocketName   = "qemu-monitor.sock"
 
 	// Maximum socket path length prior to qemu 2.10.1
-	qemuLegacyMaxMonitorPathLen = 108
+	legacyMaxMonitorPathLen = 108
 )
 
 var (
@@ -64,7 +64,7 @@ var (
 		Factory: func(l hclog.Logger) interface{} { return NewQemuDriver(l) },
 	}
 
-	reQemuVersion = regexp.MustCompile(`version (\d[\.\d+]+)`)
+	versionRegex = regexp.MustCompile(`version (\d[\.\d+]+)`)
 
 	// Prior to qemu 2.10.1, monitor socket paths are truncated to 108 bytes.
 	// We should consider this if driver.qemu.version is < 2.10.1 and the
@@ -72,7 +72,7 @@ var (
 	//
 	// Relevant fix is here:
 	// https://github.com/qemu/qemu/commit/ad9579aaa16d5b385922d49edac2c96c79bcfb6
-	qemuVersionLongSocketPathFix = semver.New("2.10.1")
+	versionLongSocketPathFix = semver.New("2.10.1")
 
 	// pluginInfo is the response returned for the PluginInfo RPC
 	pluginInfo = &base.PluginInfoResponse{
@@ -103,7 +103,7 @@ var (
 		FSIsolation: cstructs.FSIsolationImage,
 	}
 
-	_ drivers.DriverPlugin = (*QemuDriver)(nil)
+	_ drivers.DriverPlugin = (*Driver)(nil)
 )
 
 // TaskConfig is the driver configuration of a taskConfig within a job
@@ -115,18 +115,18 @@ type TaskConfig struct {
 	GracefulShutdown bool           `codec:"graceful_shutdown"`
 }
 
-// QemuTaskState is the state which is encoded in the handle returned in
-// StartTask. This information is needed to rebuild the taskConfig state and handler
+// TaskState is the state which is encoded in the handle returned in StartTask.
+// This information is needed to rebuild the taskConfig state and handler
 // during recovery.
-type QemuTaskState struct {
+type TaskState struct {
 	ReattachConfig *utils.ReattachConfig
 	TaskConfig     *drivers.TaskConfig
 	Pid            int
 	StartedAt      time.Time
 }
 
-// QemuDriver is a driver for running images via Qemu
-type QemuDriver struct {
+// Driver is a driver for running images via Qemu
+type Driver struct {
 	// eventer is used to handle multiplexing of TaskEvents calls such that an
 	// event can be broadcast to all callers
 	eventer *eventer.Eventer
@@ -145,15 +145,14 @@ type QemuDriver struct {
 	// ctx passed to any subsystems
 	signalShutdown context.CancelFunc
 
-	// logger will log to the plugin output which is usually an 'executor.out'
-	// file located in the root of the TaskDir
+	// logger will log to the Nomad agent
 	logger hclog.Logger
 }
 
 func NewQemuDriver(logger hclog.Logger) drivers.DriverPlugin {
 	ctx, cancel := context.WithCancel(context.Background())
 	logger = logger.Named(pluginName)
-	return &QemuDriver{
+	return &Driver{
 		eventer:        eventer.NewEventer(ctx, logger),
 		tasks:          newTaskStore(),
 		ctx:            ctx,
@@ -162,36 +161,36 @@ func NewQemuDriver(logger hclog.Logger) drivers.DriverPlugin {
 	}
 }
 
-func (d *QemuDriver) PluginInfo() (*base.PluginInfoResponse, error) {
+func (d *Driver) PluginInfo() (*base.PluginInfoResponse, error) {
 	return pluginInfo, nil
 }
 
-func (d *QemuDriver) ConfigSchema() (*hclspec.Spec, error) {
+func (d *Driver) ConfigSchema() (*hclspec.Spec, error) {
 	return configSpec, nil
 }
 
-func (d *QemuDriver) SetConfig(_ []byte, cfg *base.ClientAgentConfig) error {
+func (d *Driver) SetConfig(_ []byte, cfg *base.ClientAgentConfig) error {
 	if cfg != nil {
 		d.nomadConfig = cfg.Driver
 	}
 	return nil
 }
 
-func (d *QemuDriver) TaskConfigSchema() (*hclspec.Spec, error) {
+func (d *Driver) TaskConfigSchema() (*hclspec.Spec, error) {
 	return taskConfigSpec, nil
 }
 
-func (d *QemuDriver) Capabilities() (*drivers.Capabilities, error) {
+func (d *Driver) Capabilities() (*drivers.Capabilities, error) {
 	return capabilities, nil
 }
 
-func (r *QemuDriver) Fingerprint(ctx context.Context) (<-chan *drivers.Fingerprint, error) {
+func (r *Driver) Fingerprint(ctx context.Context) (<-chan *drivers.Fingerprint, error) {
 	ch := make(chan *drivers.Fingerprint)
 	go r.handleFingerprint(ctx, ch)
 	return ch, nil
 }
 
-func (d *QemuDriver) handleFingerprint(ctx context.Context, ch chan *drivers.Fingerprint) {
+func (d *Driver) handleFingerprint(ctx context.Context, ch chan *drivers.Fingerprint) {
 	ticker := time.NewTimer(0)
 	for {
 		select {
@@ -206,7 +205,7 @@ func (d *QemuDriver) handleFingerprint(ctx context.Context, ch chan *drivers.Fin
 	}
 }
 
-func (d *QemuDriver) buildFingerprint() *drivers.Fingerprint {
+func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	fingerprint := &drivers.Fingerprint{
 		Attributes:        map[string]string{},
 		Health:            drivers.HealthStateHealthy,
@@ -229,24 +228,24 @@ func (d *QemuDriver) buildFingerprint() *drivers.Fingerprint {
 	}
 	out := strings.TrimSpace(string(outBytes))
 
-	matches := reQemuVersion.FindStringSubmatch(out)
+	matches := versionRegex.FindStringSubmatch(out)
 	if len(matches) != 2 {
 		fingerprint.Health = drivers.HealthStateUndetected
 		fingerprint.HealthDescription = fmt.Sprintf("failed to parse qemu version from %v", out)
 		return fingerprint
 	}
 	currentQemuVersion := matches[1]
-	fingerprint.Attributes[qemuDriverAttr] = "1"
-	fingerprint.Attributes[qemuDriverVersionAttr] = currentQemuVersion
+	fingerprint.Attributes[driverAttr] = "1"
+	fingerprint.Attributes[driverVersionAttr] = currentQemuVersion
 	return fingerprint
 }
 
-func (d *QemuDriver) RecoverTask(handle *drivers.TaskHandle) error {
+func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 	if handle == nil {
 		return fmt.Errorf("error: handle cannot be nil")
 	}
 
-	var taskState QemuTaskState
+	var taskState TaskState
 	if err := handle.GetDriverState(&taskState); err != nil {
 		d.logger.Error("failed to decode taskConfig state from handle", "error", err, "task_id", handle.Config.ID)
 		return fmt.Errorf("failed to decode taskConfig state from handle: %v", err)
@@ -284,7 +283,7 @@ func (d *QemuDriver) RecoverTask(handle *drivers.TaskHandle) error {
 	return nil
 }
 
-func (d *QemuDriver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstructs.DriverNetwork, error) {
+func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstructs.DriverNetwork, error) {
 	if _, ok := d.tasks.Get(cfg.ID); ok {
 		return nil, nil, fmt.Errorf("taskConfig with ID '%s' already started", cfg.ID)
 	}
@@ -443,7 +442,7 @@ func (d *QemuDriver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *c
 		logger:       d.logger,
 	}
 
-	qemuDriverState := QemuTaskState{
+	qemuDriverState := TaskState{
 		ReattachConfig: utils.ReattachConfigFromGoPlugin(pluginClient.ReattachConfig()),
 		Pid:            ps.Pid,
 		TaskConfig:     cfg,
@@ -469,7 +468,7 @@ func (d *QemuDriver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *c
 	return handle, driverNetwork, nil
 }
 
-func (d *QemuDriver) WaitTask(ctx context.Context, taskID string) (<-chan *drivers.ExitResult, error) {
+func (d *Driver) WaitTask(ctx context.Context, taskID string) (<-chan *drivers.ExitResult, error) {
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return nil, drivers.ErrTaskNotFound
@@ -481,7 +480,7 @@ func (d *QemuDriver) WaitTask(ctx context.Context, taskID string) (<-chan *drive
 	return ch, nil
 }
 
-func (d *QemuDriver) StopTask(taskID string, timeout time.Duration, signal string) error {
+func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) error {
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return drivers.ErrTaskNotFound
@@ -507,7 +506,7 @@ func (d *QemuDriver) StopTask(taskID string, timeout time.Duration, signal strin
 	return nil
 }
 
-func (d *QemuDriver) DestroyTask(taskID string, force bool) error {
+func (d *Driver) DestroyTask(taskID string, force bool) error {
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return drivers.ErrTaskNotFound
@@ -531,7 +530,7 @@ func (d *QemuDriver) DestroyTask(taskID string, force bool) error {
 	return nil
 }
 
-func (d *QemuDriver) InspectTask(taskID string) (*drivers.TaskStatus, error) {
+func (d *Driver) InspectTask(taskID string) (*drivers.TaskStatus, error) {
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return nil, drivers.ErrTaskNotFound
@@ -555,7 +554,7 @@ func (d *QemuDriver) InspectTask(taskID string) (*drivers.TaskStatus, error) {
 	return status, nil
 }
 
-func (d *QemuDriver) TaskStats(taskID string) (*cstructs.TaskResourceUsage, error) {
+func (d *Driver) TaskStats(taskID string) (*cstructs.TaskResourceUsage, error) {
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return nil, drivers.ErrTaskNotFound
@@ -564,15 +563,15 @@ func (d *QemuDriver) TaskStats(taskID string) (*cstructs.TaskResourceUsage, erro
 	return handle.exec.Stats()
 }
 
-func (d *QemuDriver) TaskEvents(ctx context.Context) (<-chan *drivers.TaskEvent, error) {
+func (d *Driver) TaskEvents(ctx context.Context) (<-chan *drivers.TaskEvent, error) {
 	return d.eventer.TaskEvents(ctx)
 }
 
-func (d *QemuDriver) SignalTask(taskID string, signal string) error {
+func (d *Driver) SignalTask(taskID string, signal string) error {
 	return fmt.Errorf("Qemu driver can't signal commands")
 }
 
-func (d *QemuDriver) ExecTask(taskID string, cmdArgs []string, timeout time.Duration) (*drivers.ExecTaskResult, error) {
+func (d *Driver) ExecTask(taskID string, cmdArgs []string, timeout time.Duration) (*drivers.ExecTaskResult, error) {
 	return nil, fmt.Errorf("Qemu driver can't execute commands")
 
 }
@@ -588,7 +587,7 @@ func GetAbsolutePath(bin string) (string, error) {
 	return filepath.EvalSymlinks(lp)
 }
 
-func (d *QemuDriver) handleWait(ctx context.Context, handle *qemuTaskHandle, ch chan *drivers.ExitResult) {
+func (d *Driver) handleWait(ctx context.Context, handle *qemuTaskHandle, ch chan *drivers.ExitResult) {
 	defer close(ch)
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait()
@@ -615,19 +614,19 @@ func (d *QemuDriver) handleWait(ctx context.Context, handle *qemuTaskHandle, ch 
 // present on the host. If it is safe to use, the socket's full path is
 // returned along with a nil error. Otherwise, an empty string is returned
 // along with a descriptive error.
-func (d *QemuDriver) getMonitorPath(dir string, fingerPrint *drivers.Fingerprint) (string, error) {
+func (d *Driver) getMonitorPath(dir string, fingerPrint *drivers.Fingerprint) (string, error) {
 	var longPathSupport bool
-	currentQemuVer := fingerPrint.Attributes[qemuDriverVersionAttr]
+	currentQemuVer := fingerPrint.Attributes[driverVersionAttr]
 	currentQemuSemver := semver.New(currentQemuVer)
-	if currentQemuSemver.LessThan(*qemuVersionLongSocketPathFix) {
+	if currentQemuSemver.LessThan(*versionLongSocketPathFix) {
 		longPathSupport = false
 		d.logger.Debug("long socket paths are not available in this version of QEMU", "version", currentQemuVer)
 	} else {
 		longPathSupport = true
 		d.logger.Debug("long socket paths available in this version of QEMU", "version", currentQemuVer)
 	}
-	fullSocketPath := fmt.Sprintf("%s/%s", dir, qemuMonitorSocketName)
-	if len(fullSocketPath) > qemuLegacyMaxMonitorPathLen && longPathSupport == false {
+	fullSocketPath := fmt.Sprintf("%s/%s", dir, monitorSocketName)
+	if len(fullSocketPath) > legacyMaxMonitorPathLen && longPathSupport == false {
 		return "", fmt.Errorf("monitor path is too long for this version of qemu")
 	}
 	return fullSocketPath, nil
@@ -646,9 +645,9 @@ func sendQemuShutdown(logger hclog.Logger, monitorPath string, userPid int) erro
 	}
 	defer monitorSocket.Close()
 	logger.Debug("sending graceful shutdown command to qemu monitor socket", "monitor_path", monitorPath, "pid", userPid)
-	_, err = monitorSocket.Write([]byte(qemuGracefulShutdownMsg))
+	_, err = monitorSocket.Write([]byte(gracefulShutdownMsg))
 	if err != nil {
-		logger.Warn("failed to send shutdown message", "shutdown message", qemuGracefulShutdownMsg, "monitorPath", monitorPath, "userPid", userPid, "error", err)
+		logger.Warn("failed to send shutdown message", "shutdown message", gracefulShutdownMsg, "monitorPath", monitorPath, "userPid", userPid, "error", err)
 	}
 	return err
 }

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -209,7 +209,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	fingerprint := &drivers.Fingerprint{
 		Attributes:        map[string]string{},
 		Health:            drivers.HealthStateHealthy,
-		HealthDescription: "healthy",
+		HealthDescription: "ready",
 	}
 
 	bin := "qemu-system-x86_64"

--- a/drivers/qemu/driver_test.go
+++ b/drivers/qemu/driver_test.go
@@ -116,20 +116,20 @@ func TestQemuDriver_GetMonitorPathOldQemu(t *testing.T) {
 
 	fingerPrint := &drivers.Fingerprint{
 		Attributes: map[string]string{
-			qemuDriverVersionAttr: "2.0.0",
+			driverVersionAttr: "2.0.0",
 		},
 	}
 	shortPath := strings.Repeat("x", 10)
-	qemuDriver := d.(*QemuDriver)
+	qemuDriver := d.(*Driver)
 	_, err := qemuDriver.getMonitorPath(shortPath, fingerPrint)
 	require.Nil(err)
 
-	longPath := strings.Repeat("x", qemuLegacyMaxMonitorPathLen+100)
+	longPath := strings.Repeat("x", legacyMaxMonitorPathLen+100)
 	_, err = qemuDriver.getMonitorPath(longPath, fingerPrint)
 	require.NotNil(err)
 
 	// Max length includes the '/' separator and socket name
-	maxLengthCount := qemuLegacyMaxMonitorPathLen - len(qemuMonitorSocketName) - 1
+	maxLengthCount := legacyMaxMonitorPathLen - len(monitorSocketName) - 1
 	maxLengthLegacyPath := strings.Repeat("x", maxLengthCount)
 	_, err = qemuDriver.getMonitorPath(maxLengthLegacyPath, fingerPrint)
 	require.Nil(err)
@@ -167,21 +167,21 @@ func TestQemuDriver_GetMonitorPathNewQemu(t *testing.T) {
 
 	fingerPrint := &drivers.Fingerprint{
 		Attributes: map[string]string{
-			qemuDriverVersionAttr: "2.99.99",
+			driverVersionAttr: "2.99.99",
 		},
 	}
 	shortPath := strings.Repeat("x", 10)
-	qemuDriver := d.(*QemuDriver)
+	qemuDriver := d.(*Driver)
 	_, err := qemuDriver.getMonitorPath(shortPath, fingerPrint)
 	require.Nil(err)
 
 	// Should not return an error in this qemu version
-	longPath := strings.Repeat("x", qemuLegacyMaxMonitorPathLen+100)
+	longPath := strings.Repeat("x", legacyMaxMonitorPathLen+100)
 	_, err = qemuDriver.getMonitorPath(longPath, fingerPrint)
 	require.Nil(err)
 
 	// Max length includes the '/' separator and socket name
-	maxLengthCount := qemuLegacyMaxMonitorPathLen - len(qemuMonitorSocketName) - 1
+	maxLengthCount := legacyMaxMonitorPathLen - len(monitorSocketName) - 1
 	maxLengthLegacyPath := strings.Repeat("x", maxLengthCount)
 	_, err = qemuDriver.getMonitorPath(maxLengthLegacyPath, fingerPrint)
 	require.Nil(err)

--- a/drivers/qemu/driver_test.go
+++ b/drivers/qemu/driver_test.go
@@ -124,12 +124,12 @@ func TestQemuDriver_GetMonitorPathOldQemu(t *testing.T) {
 	_, err := qemuDriver.getMonitorPath(shortPath, fingerPrint)
 	require.Nil(err)
 
-	longPath := strings.Repeat("x", legacyMaxMonitorPathLen+100)
+	longPath := strings.Repeat("x", qemuLegacyMaxMonitorPathLen+100)
 	_, err = qemuDriver.getMonitorPath(longPath, fingerPrint)
 	require.NotNil(err)
 
 	// Max length includes the '/' separator and socket name
-	maxLengthCount := legacyMaxMonitorPathLen - len(monitorSocketName) - 1
+	maxLengthCount := qemuLegacyMaxMonitorPathLen - len(qemuMonitorSocketName) - 1
 	maxLengthLegacyPath := strings.Repeat("x", maxLengthCount)
 	_, err = qemuDriver.getMonitorPath(maxLengthLegacyPath, fingerPrint)
 	require.Nil(err)
@@ -176,12 +176,12 @@ func TestQemuDriver_GetMonitorPathNewQemu(t *testing.T) {
 	require.Nil(err)
 
 	// Should not return an error in this qemu version
-	longPath := strings.Repeat("x", legacyMaxMonitorPathLen+100)
+	longPath := strings.Repeat("x", qemuLegacyMaxMonitorPathLen+100)
 	_, err = qemuDriver.getMonitorPath(longPath, fingerPrint)
 	require.Nil(err)
 
 	// Max length includes the '/' separator and socket name
-	maxLengthCount := legacyMaxMonitorPathLen - len(monitorSocketName) - 1
+	maxLengthCount := qemuLegacyMaxMonitorPathLen - len(qemuMonitorSocketName) - 1
 	maxLengthLegacyPath := strings.Repeat("x", maxLengthCount)
 	_, err = qemuDriver.getMonitorPath(maxLengthLegacyPath, fingerPrint)
 	require.Nil(err)

--- a/drivers/qemu/state.go
+++ b/drivers/qemu/state.go
@@ -5,21 +5,21 @@ import (
 )
 
 type taskStore struct {
-	store map[string]*qemuTaskHandle
+	store map[string]*taskHandle
 	lock  sync.RWMutex
 }
 
 func newTaskStore() *taskStore {
-	return &taskStore{store: map[string]*qemuTaskHandle{}}
+	return &taskStore{store: map[string]*taskHandle{}}
 }
 
-func (ts *taskStore) Set(id string, handle *qemuTaskHandle) {
+func (ts *taskStore) Set(id string, handle *taskHandle) {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 	ts.store[id] = handle
 }
 
-func (ts *taskStore) Get(id string) (*qemuTaskHandle, bool) {
+func (ts *taskStore) Get(id string) (*taskHandle, bool) {
 	ts.lock.RLock()
 	defer ts.lock.RUnlock()
 	t, ok := ts.store[id]

--- a/drivers/rawexec/driver.go
+++ b/drivers/rawexec/driver.go
@@ -120,9 +120,6 @@ type Driver struct {
 	// ctx passed to any subsystems
 	signalShutdown context.CancelFunc
 
-	// fingerprintPeriod allows overriding the global fingerprint period
-	fingerprintPeriod time.Duration
-
 	// logger will log to the Nomad agent
 	logger hclog.Logger
 }
@@ -158,77 +155,76 @@ func NewRawExecDriver(logger hclog.Logger) drivers.DriverPlugin {
 	ctx, cancel := context.WithCancel(context.Background())
 	logger = logger.Named(pluginName)
 	return &Driver{
-		eventer:           eventer.NewEventer(ctx, logger),
-		config:            &Config{},
-		tasks:             newTaskStore(),
-		ctx:               ctx,
-		signalShutdown:    cancel,
-		fingerprintPeriod: fingerprintPeriod,
-		logger:            logger,
+		eventer:        eventer.NewEventer(ctx, logger),
+		config:         &Config{},
+		tasks:          newTaskStore(),
+		ctx:            ctx,
+		signalShutdown: cancel,
+		logger:         logger,
 	}
 }
 
-func (r *Driver) PluginInfo() (*base.PluginInfoResponse, error) {
+func (d *Driver) PluginInfo() (*base.PluginInfoResponse, error) {
 	return pluginInfo, nil
 }
 
-func (r *Driver) ConfigSchema() (*hclspec.Spec, error) {
+func (d *Driver) ConfigSchema() (*hclspec.Spec, error) {
 	return configSpec, nil
 }
 
-func (r *Driver) SetConfig(data []byte, cfg *base.ClientAgentConfig) error {
+func (d *Driver) SetConfig(data []byte, cfg *base.ClientAgentConfig) error {
 	var config Config
 	if err := base.MsgPackDecode(data, &config); err != nil {
 		return err
 	}
 
-	r.config = &config
+	d.config = &config
 	if cfg != nil {
-		r.nomadConfig = cfg.Driver
+		d.nomadConfig = cfg.Driver
 	}
 	return nil
 }
 
-func (r *Driver) Shutdown(ctx context.Context) error {
-	r.signalShutdown()
+func (d *Driver) Shutdown(ctx context.Context) error {
+	d.signalShutdown()
 	return nil
 }
 
-func (r *Driver) TaskConfigSchema() (*hclspec.Spec, error) {
+func (d *Driver) TaskConfigSchema() (*hclspec.Spec, error) {
 	return taskConfigSpec, nil
 }
 
-func (r *Driver) Capabilities() (*drivers.Capabilities, error) {
+func (d *Driver) Capabilities() (*drivers.Capabilities, error) {
 	return capabilities, nil
 }
 
-func (r *Driver) Fingerprint(ctx context.Context) (<-chan *drivers.Fingerprint, error) {
+func (d *Driver) Fingerprint(ctx context.Context) (<-chan *drivers.Fingerprint, error) {
 	ch := make(chan *drivers.Fingerprint)
-	go r.handleFingerprint(ctx, ch)
+	go d.handleFingerprint(ctx, ch)
 	return ch, nil
 }
 
-func (r *Driver) handleFingerprint(ctx context.Context, ch chan<- *drivers.Fingerprint) {
+func (d *Driver) handleFingerprint(ctx context.Context, ch chan<- *drivers.Fingerprint) {
 	defer close(ch)
 	ticker := time.NewTimer(0)
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-r.ctx.Done():
+		case <-d.ctx.Done():
 			return
 		case <-ticker.C:
-			ticker.Reset(r.fingerprintPeriod)
-			ch <- r.buildFingerprint()
+			ticker.Reset(fingerprintPeriod)
+			ch <- d.buildFingerprint()
 		}
 	}
 }
 
-func (r *Driver) buildFingerprint() *drivers.Fingerprint {
+func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	var health drivers.HealthState
 	var desc string
 	attrs := map[string]string{}
-	if r.config.Enabled {
+	if d.config.Enabled {
 		health = drivers.HealthStateHealthy
 		desc = "ready"
 		attrs["driver.raw_exec"] = "1"
@@ -244,20 +240,20 @@ func (r *Driver) buildFingerprint() *drivers.Fingerprint {
 	}
 }
 
-func (r *Driver) RecoverTask(handle *drivers.TaskHandle) error {
+func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 	if handle == nil {
 		return fmt.Errorf("error: handle cannot be nil")
 	}
 
 	var taskState TaskState
 	if err := handle.GetDriverState(&taskState); err != nil {
-		r.logger.Error("failed to decode task state from handle", "error", err, "task_id", handle.Config.ID)
+		d.logger.Error("failed to decode task state from handle", "error", err, "task_id", handle.Config.ID)
 		return fmt.Errorf("failed to decode task state from handle: %v", err)
 	}
 
 	plugRC, err := utils.ReattachConfigToGoPlugin(taskState.ReattachConfig)
 	if err != nil {
-		r.logger.Error("failed to build ReattachConfig from task state", "error", err, "task_id", handle.Config.ID)
+		d.logger.Error("failed to build ReattachConfig from task state", "error", err, "task_id", handle.Config.ID)
 		return fmt.Errorf("failed to build ReattachConfig from task state: %v", err)
 	}
 
@@ -267,28 +263,28 @@ func (r *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 
 	exec, pluginClient, err := utils.CreateExecutorWithConfig(pluginConfig, os.Stderr)
 	if err != nil {
-		r.logger.Error("failed to reattach to executor", "error", err, "task_id", handle.Config.ID)
+		d.logger.Error("failed to reattach to executor", "error", err, "task_id", handle.Config.ID)
 		return fmt.Errorf("failed to reattach to executor: %v", err)
 	}
 
-	h := &rawExecTaskHandle{
+	h := &taskHandle{
 		exec:         exec,
 		pid:          taskState.Pid,
 		pluginClient: pluginClient,
-		task:         taskState.TaskConfig,
+		taskConfig:   taskState.TaskConfig,
 		procState:    drivers.TaskStateRunning,
 		startedAt:    taskState.StartedAt,
 		exitResult:   &drivers.ExitResult{},
 	}
 
-	r.tasks.Set(taskState.TaskConfig.ID, h)
+	d.tasks.Set(taskState.TaskConfig.ID, h)
 
 	go h.run()
 	return nil
 }
 
-func (r *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstructs.DriverNetwork, error) {
-	if _, ok := r.tasks.Get(cfg.ID); ok {
+func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstructs.DriverNetwork, error) {
+	if _, ok := d.tasks.Get(cfg.ID); ok {
 		return nil, nil, fmt.Errorf("task with ID %q already started", cfg.ID)
 	}
 
@@ -297,7 +293,7 @@ func (r *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 		return nil, nil, fmt.Errorf("failed to decode driver config: %v", err)
 	}
 
-	r.logger.Info("starting task", "driver_cfg", hclog.Fmt("%+v", driverConfig))
+	d.logger.Info("starting task", "driver_cfg", hclog.Fmt("%+v", driverConfig))
 	handle := drivers.NewTaskHandle(pluginName)
 	handle.Config = cfg
 
@@ -307,7 +303,7 @@ func (r *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 		LogLevel: "debug",
 	}
 
-	exec, pluginClient, err := utils.CreateExecutor(os.Stderr, hclog.Debug, r.nomadConfig, executorConfig)
+	exec, pluginClient, err := utils.CreateExecutor(os.Stderr, hclog.Debug, d.nomadConfig, executorConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create executor: %v", err)
 	}
@@ -317,7 +313,7 @@ func (r *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 		Args:               driverConfig.Args,
 		Env:                cfg.EnvList(),
 		User:               cfg.User,
-		BasicProcessCgroup: !r.config.NoCgroups,
+		BasicProcessCgroup: !d.config.NoCgroups,
 		TaskDir:            cfg.TaskDir().Dir,
 		StdoutPath:         cfg.StdoutPath,
 		StderrPath:         cfg.StderrPath,
@@ -329,14 +325,14 @@ func (r *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 		return nil, nil, fmt.Errorf("failed to launch command with executor: %v", err)
 	}
 
-	h := &rawExecTaskHandle{
+	h := &taskHandle{
 		exec:         exec,
 		pid:          ps.Pid,
 		pluginClient: pluginClient,
-		task:         cfg,
+		taskConfig:   cfg,
 		procState:    drivers.TaskStateRunning,
 		startedAt:    time.Now().Round(time.Millisecond),
-		logger:       r.logger,
+		logger:       d.logger,
 	}
 
 	driverState := TaskState{
@@ -347,30 +343,30 @@ func (r *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 	}
 
 	if err := handle.SetDriverState(&driverState); err != nil {
-		r.logger.Error("failed to start task, error setting driver state", "error", err)
+		d.logger.Error("failed to start task, error setting driver state", "error", err)
 		exec.Shutdown("", 0)
 		pluginClient.Kill()
 		return nil, nil, fmt.Errorf("failed to set driver state: %v", err)
 	}
 
-	r.tasks.Set(cfg.ID, h)
+	d.tasks.Set(cfg.ID, h)
 	go h.run()
 	return handle, nil, nil
 }
 
-func (r *Driver) WaitTask(ctx context.Context, taskID string) (<-chan *drivers.ExitResult, error) {
-	handle, ok := r.tasks.Get(taskID)
+func (d *Driver) WaitTask(ctx context.Context, taskID string) (<-chan *drivers.ExitResult, error) {
+	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return nil, drivers.ErrTaskNotFound
 	}
 
 	ch := make(chan *drivers.ExitResult)
-	go r.handleWait(ctx, handle, ch)
+	go d.handleWait(ctx, handle, ch)
 
 	return ch, nil
 }
 
-func (r *Driver) handleWait(ctx context.Context, handle *rawExecTaskHandle, ch chan *drivers.ExitResult) {
+func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *drivers.ExitResult) {
 	defer close(ch)
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait()
@@ -388,14 +384,14 @@ func (r *Driver) handleWait(ctx context.Context, handle *rawExecTaskHandle, ch c
 	select {
 	case <-ctx.Done():
 		return
-	case <-r.ctx.Done():
+	case <-d.ctx.Done():
 		return
 	case ch <- result:
 	}
 }
 
-func (r *Driver) StopTask(taskID string, timeout time.Duration, signal string) error {
-	handle, ok := r.tasks.Get(taskID)
+func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) error {
+	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return drivers.ErrTaskNotFound
 	}
@@ -410,8 +406,8 @@ func (r *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	return nil
 }
 
-func (r *Driver) DestroyTask(taskID string, force bool) error {
-	handle, ok := r.tasks.Get(taskID)
+func (d *Driver) DestroyTask(taskID string, force bool) error {
+	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return drivers.ErrTaskNotFound
 	}
@@ -430,36 +426,21 @@ func (r *Driver) DestroyTask(taskID string, force bool) error {
 		handle.pluginClient.Kill()
 	}
 
-	r.tasks.Delete(taskID)
+	d.tasks.Delete(taskID)
 	return nil
 }
 
-func (r *Driver) InspectTask(taskID string) (*drivers.TaskStatus, error) {
-	handle, ok := r.tasks.Get(taskID)
+func (d *Driver) InspectTask(taskID string) (*drivers.TaskStatus, error) {
+	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return nil, drivers.ErrTaskNotFound
 	}
 
-	handle.stateLock.RLock()
-	defer handle.stateLock.RUnlock()
-
-	status := &drivers.TaskStatus{
-		ID:          handle.task.ID,
-		Name:        handle.task.Name,
-		State:       handle.procState,
-		StartedAt:   handle.startedAt,
-		CompletedAt: handle.completedAt,
-		ExitResult:  handle.exitResult,
-		DriverAttributes: map[string]string{
-			"pid": strconv.Itoa(handle.pid),
-		},
-	}
-
-	return status, nil
+	return handle.TaskStatus(), nil
 }
 
-func (r *Driver) TaskStats(taskID string) (*cstructs.TaskResourceUsage, error) {
-	handle, ok := r.tasks.Get(taskID)
+func (d *Driver) TaskStats(taskID string) (*cstructs.TaskResourceUsage, error) {
+	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return nil, drivers.ErrTaskNotFound
 	}
@@ -467,29 +448,29 @@ func (r *Driver) TaskStats(taskID string) (*cstructs.TaskResourceUsage, error) {
 	return handle.exec.Stats()
 }
 
-func (r *Driver) TaskEvents(ctx context.Context) (<-chan *drivers.TaskEvent, error) {
-	return r.eventer.TaskEvents(ctx)
+func (d *Driver) TaskEvents(ctx context.Context) (<-chan *drivers.TaskEvent, error) {
+	return d.eventer.TaskEvents(ctx)
 }
 
-func (r *Driver) SignalTask(taskID string, signal string) error {
-	handle, ok := r.tasks.Get(taskID)
+func (d *Driver) SignalTask(taskID string, signal string) error {
+	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return drivers.ErrTaskNotFound
 	}
 
 	sig := os.Interrupt
 	if s, ok := signals.SignalLookup[signal]; ok {
-		r.logger.Warn("signal to send to task unknown, using SIGINT", "signal", signal, "task_id", handle.task.ID)
+		d.logger.Warn("signal to send to task unknown, using SIGINT", "signal", signal, "task_id", handle.taskConfig.ID)
 		sig = s
 	}
 	return handle.exec.Signal(sig)
 }
 
-func (r *Driver) ExecTask(taskID string, cmd []string, timeout time.Duration) (*drivers.ExecTaskResult, error) {
+func (d *Driver) ExecTask(taskID string, cmd []string, timeout time.Duration) (*drivers.ExecTaskResult, error) {
 	if len(cmd) == 0 {
 		return nil, fmt.Errorf("error cmd must have atleast one value")
 	}
-	handle, ok := r.tasks.Get(taskID)
+	handle, ok := d.tasks.Get(taskID)
 	if !ok {
 		return nil, drivers.ErrTaskNotFound
 	}

--- a/drivers/rawexec/handle.go
+++ b/drivers/rawexec/handle.go
@@ -1,6 +1,7 @@
 package rawexec
 
 import (
+	"strconv"
 	"sync"
 	"time"
 
@@ -10,7 +11,7 @@ import (
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
-type rawExecTaskHandle struct {
+type taskHandle struct {
 	exec         executor.Executor
 	pid          int
 	pluginClient *plugin.Client
@@ -19,24 +20,37 @@ type rawExecTaskHandle struct {
 	// stateLock syncs access to all fields below
 	stateLock sync.RWMutex
 
-	task        *drivers.TaskConfig
+	taskConfig  *drivers.TaskConfig
 	procState   drivers.TaskState
 	startedAt   time.Time
 	completedAt time.Time
 	exitResult  *drivers.ExitResult
 }
 
-func (h *rawExecTaskHandle) IsRunning() bool {
+func (h *taskHandle) TaskStatus() *drivers.TaskStatus {
+	h.stateLock.RLock()
+	defer h.stateLock.RUnlock()
+
+	return &drivers.TaskStatus{
+		ID:          h.taskConfig.ID,
+		Name:        h.taskConfig.Name,
+		State:       h.procState,
+		StartedAt:   h.startedAt,
+		CompletedAt: h.completedAt,
+		ExitResult:  h.exitResult,
+		DriverAttributes: map[string]string{
+			"pid": strconv.Itoa(h.pid),
+		},
+	}
+}
+
+func (h *taskHandle) IsRunning() bool {
 	h.stateLock.RLock()
 	defer h.stateLock.RUnlock()
 	return h.procState == drivers.TaskStateRunning
 }
 
-func (h *rawExecTaskHandle) run() {
-
-	// Since run is called immediately after the handle is created this
-	// ensures the exitResult is initialized so we avoid a nil pointer
-	// thus it does not need to be included in the lock.
+func (h *taskHandle) run() {
 	h.stateLock.Lock()
 	if h.exitResult == nil {
 		h.exitResult = &drivers.ExitResult{}

--- a/drivers/rawexec/state.go
+++ b/drivers/rawexec/state.go
@@ -5,21 +5,21 @@ import (
 )
 
 type taskStore struct {
-	store map[string]*rawExecTaskHandle
+	store map[string]*taskHandle
 	lock  sync.RWMutex
 }
 
 func newTaskStore() *taskStore {
-	return &taskStore{store: map[string]*rawExecTaskHandle{}}
+	return &taskStore{store: map[string]*taskHandle{}}
 }
 
-func (ts *taskStore) Set(id string, handle *rawExecTaskHandle) {
+func (ts *taskStore) Set(id string, handle *taskHandle) {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 	ts.store[id] = handle
 }
 
-func (ts *taskStore) Get(id string) (*rawExecTaskHandle, bool) {
+func (ts *taskStore) Get(id string) (*taskHandle, bool) {
 	ts.lock.RLock()
 	defer ts.lock.RUnlock()
 	t, ok := ts.store[id]

--- a/drivers/rkt/driver_test.go
+++ b/drivers/rkt/driver_test.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var _ drivers.DriverPlugin = (*RktDriver)(nil)
+var _ drivers.DriverPlugin = (*Driver)(nil)
 
 func TestRktVersionRegex(t *testing.T) {
 	ctestutil.RktCompatible(t)
@@ -65,13 +65,13 @@ func TestRktDriver_SetConfig(t *testing.T) {
 	var data []byte
 	require.NoError(basePlug.MsgPackEncode(&data, config))
 	require.NoError(harness.SetConfig(data, nil))
-	require.Exactly(config, d.(*RktDriver).config)
+	require.Exactly(config, d.(*Driver).config)
 
 	config.VolumesEnabled = false
 	data = []byte{}
 	require.NoError(basePlug.MsgPackEncode(&data, config))
 	require.NoError(harness.SetConfig(data, nil))
-	require.Exactly(config, d.(*RktDriver).config)
+	require.Exactly(config, d.(*Driver).config)
 
 }
 
@@ -381,7 +381,7 @@ func TestRktDriver_StartWaitRecoverWaitStop(t *testing.T) {
 	originalStatus, err := d.InspectTask(task.ID)
 	require.NoError(err)
 
-	d.(*RktDriver).tasks.Delete(task.ID)
+	d.(*Driver).tasks.Delete(task.ID)
 
 	wg.Wait()
 	require.True(waitDone)

--- a/drivers/rkt/handle.go
+++ b/drivers/rkt/handle.go
@@ -3,6 +3,7 @@
 package rkt
 
 import (
+	"strconv"
 	"sync"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
-type rktTaskHandle struct {
+type taskHandle struct {
 	exec         executor.Executor
 	env          *env.TaskEnv
 	uuid         string
@@ -31,17 +32,30 @@ type rktTaskHandle struct {
 	exitResult  *drivers.ExitResult
 }
 
-func (h *rktTaskHandle) IsRunning() bool {
+func (h *taskHandle) TaskStatus() *drivers.TaskStatus {
+	h.stateLock.RLock()
+	defer h.stateLock.RUnlock()
+
+	return &drivers.TaskStatus{
+		ID:          h.taskConfig.ID,
+		Name:        h.taskConfig.Name,
+		State:       h.procState,
+		StartedAt:   h.startedAt,
+		CompletedAt: h.completedAt,
+		ExitResult:  h.exitResult,
+		DriverAttributes: map[string]string{
+			"pid": strconv.Itoa(h.pid),
+		},
+	}
+}
+
+func (h *taskHandle) IsRunning() bool {
 	h.stateLock.RLock()
 	defer h.stateLock.RUnlock()
 	return h.procState == drivers.TaskStateRunning
 }
 
-func (h *rktTaskHandle) run() {
-
-	// Since run is called immediately after the handle is created this
-	// ensures the exitResult is initialized so we avoid a nil pointer
-	// thus it does not need to be included in the lock
+func (h *taskHandle) run() {
 	h.stateLock.Lock()
 	if h.exitResult == nil {
 		h.exitResult = &drivers.ExitResult{}

--- a/drivers/rkt/handle.go
+++ b/drivers/rkt/handle.go
@@ -32,17 +32,21 @@ type rktTaskHandle struct {
 }
 
 func (h *rktTaskHandle) IsRunning() bool {
+	h.stateLock.RLock()
+	defer h.stateLock.RUnlock()
 	return h.procState == drivers.TaskStateRunning
 }
 
 func (h *rktTaskHandle) run() {
 
-	// since run is called immediately after the handle is created this
+	// Since run is called immediately after the handle is created this
 	// ensures the exitResult is initialized so we avoid a nil pointer
 	// thus it does not need to be included in the lock
+	h.stateLock.Lock()
 	if h.exitResult == nil {
 		h.exitResult = &drivers.ExitResult{}
 	}
+	h.stateLock.Unlock()
 
 	ps, err := h.exec.Wait()
 	h.stateLock.Lock()

--- a/drivers/rkt/state.go
+++ b/drivers/rkt/state.go
@@ -7,21 +7,21 @@ import (
 )
 
 type taskStore struct {
-	store map[string]*rktTaskHandle
+	store map[string]*taskHandle
 	lock  sync.RWMutex
 }
 
 func newTaskStore() *taskStore {
-	return &taskStore{store: map[string]*rktTaskHandle{}}
+	return &taskStore{store: map[string]*taskHandle{}}
 }
 
-func (ts *taskStore) Set(id string, handle *rktTaskHandle) {
+func (ts *taskStore) Set(id string, handle *taskHandle) {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 	ts.store[id] = handle
 }
 
-func (ts *taskStore) Get(id string) (*rktTaskHandle, bool) {
+func (ts *taskStore) Get(id string) (*taskHandle, bool) {
 	ts.lock.RLock()
 	defer ts.lock.RUnlock()
 	t, ok := ts.store[id]

--- a/plugins/base/server.go
+++ b/plugins/base/server.go
@@ -64,9 +64,11 @@ func (b *basePluginServer) SetConfig(ctx context.Context, req *proto.SetConfigRe
 	cfg := nomadConfigFromProto(req.GetNomadConfig())
 	filteredCfg := new(ClientAgentConfig)
 
-	switch info.Type {
-	case PluginTypeDriver:
-		filteredCfg.Driver = cfg.Driver
+	if cfg != nil {
+		switch info.Type {
+		case PluginTypeDriver:
+			filteredCfg.Driver = cfg.Driver
+		}
 	}
 
 	// Set the config

--- a/plugins/drivers/client.go
+++ b/plugins/drivers/client.go
@@ -86,10 +86,10 @@ func (d *driverPluginClient) handleFingerprint(ctx context.Context, ch chan *Fin
 			return
 		}
 		if err != nil {
-			d.logger.Error("error receiving stream from Fingerprint driver RPC", "error", err)
 			select {
 			case <-ctx.Done():
 			case ch <- &Fingerprint{Err: fmt.Errorf("error from RPC stream: %v", err)}:
+				d.logger.Error("error receiving stream from Fingerprint driver RPC", "error", err)
 			}
 			return
 		}

--- a/plugins/shared/catalog/register_linux.go
+++ b/plugins/shared/catalog/register_linux.go
@@ -1,0 +1,10 @@
+package catalog
+
+import "github.com/hashicorp/nomad/drivers/rkt"
+
+// This file is where all builtin plugins should be registered in the catalog.
+// Plugins with build restrictions should be placed in the appropriate
+// register_XXX.go file.
+func init() {
+	RegisterDeferredConfig(rkt.PluginID, rkt.PluginConfig, rkt.PluginLoader)
+}


### PR DESCRIPTION
Sorry for the random assortment of fixes. These were mostly encountered when working on implementing agent restarting (TR.Restore+Driver.RecoverTask), and I wanted to pull them out into their own PR as the agent restarting PR will be pretty complex on its own.

* registered rkt (on linux)
* made all exported (and many internal) driver package names consistent
* made all fingerprint messages consistent (should we use a const)
* fixed a ubiquitous race in driver handles (driver tests pass with `-race` now!)
* fix a comment on the logger that got copy/pasted around
* squelch error log line when Fingerprint gets canceled