### PR TITLE
show preemptions in nomad plan CLI

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -133,8 +133,10 @@ type AllocationListStub struct {
 	ID                 string
 	EvalID             string
 	Name               string
+	Namespace          string
 	NodeID             string
 	JobID              string
+	JobType            string
 	JobVersion         uint64
 	TaskGroup          string
 	DesiredStatus      string

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -20,6 +20,7 @@ When running the job with the check-index flag, the job will only be run if the
 server side version matches the job modify index returned. If the index has
 changed, another user has modified the job and the plan's results are
 potentially invalid.`
+	preemptionShowByJobIdThreshold = 10
 )
 
 type JobPlanCommand struct {
@@ -173,9 +174,72 @@ func (c *JobPlanCommand) Run(args []string) int {
 			c.Colorize().Color(fmt.Sprintf("[bold][yellow]Job Warnings:\n%s[reset]\n", resp.Warnings)))
 	}
 
+	// Print preemptions if there are any
+	if resp.Annotations != nil && len(resp.Annotations.PreemptedAllocs) > 0 {
+		c.addPreemptions(resp)
+	}
+
 	// Print the job index info
 	c.Ui.Output(c.Colorize().Color(formatJobModifyIndex(resp.JobModifyIndex, path)))
 	return getExitCode(resp)
+}
+
+// addPreemptions shows details about preempted allocations
+func (c *JobPlanCommand) addPreemptions(resp *api.JobPlanResponse) {
+	c.Ui.Output(c.Colorize().Color("[bold][yellow]Preemptions:\n[reset]"))
+	if len(resp.Annotations.PreemptedAllocs) < preemptionShowByJobIdThreshold {
+		var allocs []string
+		allocs = append(allocs, fmt.Sprintf("Alloc ID|Job ID|Task Group"))
+		for _, alloc := range resp.Annotations.PreemptedAllocs {
+			allocs = append(allocs, fmt.Sprintf("%s|%s|%s", alloc.ID, alloc.JobID, alloc.TaskGroup))
+		}
+		c.Ui.Output(formatList(allocs))
+	} else {
+		// Display in a summary format if the list is too large
+		// Group by job type and job ids
+		allocDetails := make(map[string]map[namespaceIdPair]int)
+		numJobs := 0
+		for _, alloc := range resp.Annotations.PreemptedAllocs {
+			id := namespaceIdPair{alloc.JobID, alloc.Namespace}
+			countMap := allocDetails[alloc.JobType]
+			if countMap == nil {
+				countMap = make(map[namespaceIdPair]int)
+			}
+			cnt, ok := countMap[id]
+			if !ok {
+				// First time we are seeing this job, increment counter
+				numJobs++
+			}
+			countMap[id] = cnt + 1
+			allocDetails[alloc.JobType] = countMap
+		}
+		var output []string
+		// Show counts grouped by job ID if its less than a threshold
+		if numJobs < preemptionShowByJobIdThreshold {
+			output = append(output, fmt.Sprintf("Job ID|Namespace|Job Type|Preemptions"))
+			for jobType, jobCounts := range allocDetails {
+				for jobId, count := range jobCounts {
+					output = append(output, fmt.Sprintf("%s|%s|%s|%d", jobId.id, jobId.namespace, jobType, count))
+				}
+			}
+		} else {
+			// Show counts grouped by job type
+			output = append(output, fmt.Sprintf("Job Type|Preemptions"))
+			for jobType, jobCounts := range allocDetails {
+				total := 0
+				for _, count := range jobCounts {
+					total += count
+				}
+				output = append(output, fmt.Sprintf("%s|%d", jobType, total))
+			}
+		}
+		c.Ui.Output(formatList(output))
+	}
+}
+
+type namespaceIdPair struct {
+	id        string
+	namespace string
 }
 
 // getExitCode returns 0:

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -20,7 +20,10 @@ When running the job with the check-index flag, the job will only be run if the
 server side version matches the job modify index returned. If the index has
 changed, another user has modified the job and the plan's results are
 potentially invalid.`
-	preemptionShowByJobIdThreshold = 10
+
+	// preemptionDisplayThreshold is an upper bound used to limit and summarize
+	// the details of preempted jobs in the output
+	preemptionDisplayThreshold = 10
 )
 
 type JobPlanCommand struct {
@@ -187,7 +190,7 @@ func (c *JobPlanCommand) Run(args []string) int {
 // addPreemptions shows details about preempted allocations
 func (c *JobPlanCommand) addPreemptions(resp *api.JobPlanResponse) {
 	c.Ui.Output(c.Colorize().Color("[bold][yellow]Preemptions:\n[reset]"))
-	if len(resp.Annotations.PreemptedAllocs) < preemptionShowByJobIdThreshold {
+	if len(resp.Annotations.PreemptedAllocs) < preemptionDisplayThreshold {
 		var allocs []string
 		allocs = append(allocs, fmt.Sprintf("Alloc ID|Job ID|Task Group"))
 		for _, alloc := range resp.Annotations.PreemptedAllocs {
@@ -213,9 +216,10 @@ func (c *JobPlanCommand) addPreemptions(resp *api.JobPlanResponse) {
 			countMap[id] = cnt + 1
 			allocDetails[alloc.JobType] = countMap
 		}
-		var output []string
+
 		// Show counts grouped by job ID if its less than a threshold
-		if numJobs < preemptionShowByJobIdThreshold {
+		var output []string
+		if numJobs < preemptionDisplayThreshold {
 			output = append(output, fmt.Sprintf("Job ID|Namespace|Job Type|Preemptions"))
 			for jobType, jobCounts := range allocDetails {
 				for jobId, count := range jobCounts {

--- a/command/job_plan_test.go
+++ b/command/job_plan_test.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
-
-	"strconv"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
-	require2 "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPlanCommand_Implements(t *testing.T) {
@@ -178,7 +177,7 @@ func TestPlanCommad_Preemptions(t *testing.T) {
 	t.Parallel()
 	ui := new(cli.MockUi)
 	cmd := &JobPlanCommand{Meta: Meta{Ui: ui}}
-	require := require2.New(t)
+	require := require.New(t)
 
 	// Only one preempted alloc
 	resp1 := &api.JobPlanResponse{

--- a/command/job_plan_test.go
+++ b/command/job_plan_test.go
@@ -225,7 +225,7 @@ func TestPlanCommad_Preemptions(t *testing.T) {
 
 	// More than 10 unique job IDs
 	preemptedAllocs = make([]*api.AllocationListStub, 0)
-	job_type := "batch"
+	var job_type string
 	for i := 0; i < 20; i++ {
 		job_id := "job" + strconv.Itoa(i)
 		if i%2 == 0 {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7538,8 +7538,10 @@ func (a *Allocation) Stub() *AllocListStub {
 		ID:                 a.ID,
 		EvalID:             a.EvalID,
 		Name:               a.Name,
+		Namespace:          a.Namespace,
 		NodeID:             a.NodeID,
 		JobID:              a.JobID,
+		JobType:            a.Job.Type,
 		JobVersion:         a.Job.Version,
 		TaskGroup:          a.TaskGroup,
 		DesiredStatus:      a.DesiredStatus,
@@ -7563,8 +7565,10 @@ type AllocListStub struct {
 	ID                 string
 	EvalID             string
 	Name               string
+	Namespace          string
 	NodeID             string
 	JobID              string
+	JobType            string
 	JobVersion         uint64
 	TaskGroup          string
 	DesiredStatus      string


### PR DESCRIPTION
This PR augments the output of `nomad plan` with info about preemptions. 

It uses a tiered approach to make sure the CLI doesn't show every single allocid if there are many preemptions. Instead, it groups things and shows summary counts. 

There are three cases:

### 1 - Number of preempted allocations less than 10
```
Alloc ID  Job ID  Task Group
alloc1    jobID1  test
alloc2    jobID2  test2
```

### 2 - Number of unique jobids amongst all preemptions less than 10
```
Job ID  Namespace  Job Type  Preemptions
job0    test1       batch        3
job1    test2       batch        3
job2    test3       service      3
job3    test4       batch        3
```

### 3 - Number of unique jobids amongst all preemptions greater than 10
```
Job Type  Preemptions
batch     10
service   20
```
Builds on top of #4794, which should be merged first. 