### PR TITLE
Register exec driver plugin among some fixes

### DIFF
--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -31,11 +31,18 @@ const (
 )
 
 var (
-	// PluginID is the rawexec plugin metadata registered in the plugin
+	// PluginID is the exec plugin metadata registered in the plugin
 	// catalog.
 	PluginID = loader.PluginID{
 		Name:       pluginName,
 		PluginType: base.PluginTypeDriver,
+	}
+
+	// PluginConfig is the exec driver factory function registered in the
+	// plugin catalog.
+	PluginConfig = &loader.InternalPluginConfig{
+		Config:  map[string]interface{}{},
+		Factory: func(l hclog.Logger) interface{} { return NewExecDriver(l) },
 	}
 
 	// pluginInfo is the response returned for the PluginInfo RPC

--- a/plugins/shared/catalog/register.go
+++ b/plugins/shared/catalog/register.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"github.com/hashicorp/nomad/drivers/exec"
 	"github.com/hashicorp/nomad/drivers/qemu"
 	"github.com/hashicorp/nomad/drivers/rawexec"
 )
@@ -10,5 +11,6 @@ import (
 // register_XXX.go file.
 func init() {
 	RegisterDeferredConfig(rawexec.PluginID, rawexec.PluginConfig, rawexec.PluginLoader)
+	Register(exec.PluginID, exec.PluginConfig)
 	Register(qemu.PluginID, qemu.PluginConfig)
 }


### PR DESCRIPTION
Namely, remove the `enabled` configuration flag, as it's specific to
`raw_exec` driver.  Also, pass resource limits to underlying call.