### PR TITLE
Fixing mistake in reschedule doc

### DIFF
--- a/website/source/docs/job-specification/reschedule.html.md
+++ b/website/source/docs/job-specification/reschedule.html.md
@@ -36,7 +36,7 @@ job "docs" {
   group "example" {
     reschedule {
       attempts       = 15
-      interval       = "1hr"
+      interval       = "1h"
       delay          = "30s"
       delay_function = "exponential"
       max_delay      = "120s"
@@ -105,7 +105,7 @@ defaults by job type:
    reschedule {
      delay          = "30s"
      delay_function = "exponential"
-     max_delay      = "1hr"
+     max_delay      = "1h"
      unlimited      = true
    }
     ```


### PR DESCRIPTION
Hey,

There's a mistake in the `reschedule` stanza doc where the interval is set to `1hr` instead of being set to `1h`.

Nomad doesn't understand `1hr` but does understand `1h` so here's a small fix for that part.

Cheers