### PR TITLE
update preemption tests to use new node resource structs

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2764,14 +2764,6 @@ func (a *AllocatedTaskResources) Subtract(delta *AllocatedTaskResources) {
 
 	a.Cpu.Subtract(&delta.Cpu)
 	a.Memory.Subtract(&delta.Memory)
-
-	for _, n := range delta.Networks {
-		// Find the matching interface by IP or CIDR
-		idx := a.NetIndex(n)
-		if idx != -1 {
-			a.Networks[idx].MBits -= delta.Networks[idx].MBits
-		}
-	}
 }
 
 // AllocatedSharedResources are the set of resources allocated to a task group.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2757,6 +2757,8 @@ func (a *AllocatedTaskResources) Comparable() *ComparableResources {
 	return ret
 }
 
+// Subtract only subtracts CPU and Memory resources. Network utilization
+// is managed separately in NetworkIndex
 func (a *AllocatedTaskResources) Subtract(delta *AllocatedTaskResources) {
 	if delta == nil {
 		return

--- a/scheduler/preemption.go
+++ b/scheduler/preemption.go
@@ -318,9 +318,11 @@ func (p *Preemptor) PreemptForNetwork(networkResourceAsk *structs.NetworkResourc
 	var allocsToPreempt []*structs.Allocation
 	met := false
 	freeBandwidth := 0
+	preemptedDevice := ""
 
 OUTER:
 	for device, currentAllocs := range deviceToAllocs {
+		preemptedDevice = device
 		totalBandwidth := netIdx.AvailBandwidth[device]
 
 		// If the device doesn't have enough total available bandwidth, skip
@@ -411,13 +413,11 @@ OUTER:
 	}
 
 	// Build a resource object with just the network Mbits filled in
-	// Its safe to use the first preempted allocation's network resource
-	// here because all allocations preempted will be from the same device
 	nodeRemainingResources := &structs.ComparableResources{
 		Flattened: structs.AllocatedTaskResources{
 			Networks: []*structs.NetworkResource{
 				{
-					Device: allocsToPreempt[0].Resources.Networks[0].Device,
+					Device: preemptedDevice,
 					MBits:  freeBandwidth,
 				},
 			},

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -243,8 +243,7 @@ OUTER:
 
 					netPreemptions := preemptor.PreemptForNetwork(ask, netIdx)
 					if netPreemptions == nil {
-						iter.ctx.Metrics().ExhaustedNode(option.Node,
-							fmt.Sprintf("unable to meet network resource %v after preemption", ask))
+						iter.ctx.Logger().Named("binpack").Error(fmt.Sprintf("unable to meet network resource %v after preemption", ask))
 						netIdx.Release()
 						continue OUTER
 					}
@@ -261,7 +260,7 @@ OUTER:
 
 					offer, err = netIdx.AssignNetwork(ask)
 					if offer == nil {
-						iter.ctx.Logger().Error(fmt.Sprintf("unexpected error, unable to create offer after preempting:%v", err))
+						iter.ctx.Logger().Named("binpack").Error(fmt.Sprintf("unexpected error, unable to create offer after preempting:%v", err))
 						netIdx.Release()
 						continue OUTER
 					}


### PR DESCRIPTION
This PR fixes preemption unit tests to use the newer node resource structs, doing that surfaced a bug in handling AllocatedTaskResources, it  should not have subtracted network mbits. That's already handled by the network index. 