### PR TITLE
UI: Guard against the line chart element already being destroyed

### DIFF
--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -325,9 +325,11 @@ export default Component.extend(WindowResizable, {
   },
 
   mountD3Elements() {
-    d3.select(this.element.querySelector('.x-axis')).call(this.get('xAxis'));
-    d3.select(this.element.querySelector('.y-axis')).call(this.get('yAxis'));
-    d3.select(this.element.querySelector('.y-gridlines')).call(this.get('yGridlines'));
+    if (!this.get('isDestroyed') && !this.get('isDestroying')) {
+      d3.select(this.element.querySelector('.x-axis')).call(this.get('xAxis'));
+      d3.select(this.element.querySelector('.y-axis')).call(this.get('yAxis'));
+      d3.select(this.element.querySelector('.y-gridlines')).call(this.get('yGridlines'));
+    }
   },
 
   windowResizeHandler() {


### PR DESCRIPTION
Since DOM code is in a run.next, it's possible that between the DOM
code being queued and running the element is destroyed. So the DOM
code needs to guard against this using the isDestroyed API.