### PR TITLE
Fixes device scheduling unit tests

### DIFF
--- a/scheduler/device.go
+++ b/scheduler/device.go
@@ -3,6 +3,8 @@ package scheduler
 import (
 	"fmt"
 
+	"math"
+
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -76,7 +78,7 @@ func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *struc
 					continue
 				}
 
-				totalWeight += a.Weight
+				totalWeight += math.Abs(a.Weight)
 
 				// Check if satisfied
 				if !checkAttributeAffinity(d.ctx, a.Operand, lVal, rVal) {

--- a/scheduler/device.go
+++ b/scheduler/device.go
@@ -65,6 +65,10 @@ func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *struc
 
 		// Score the choice
 		var choiceScore float64
+
+		// Track the sum of matched affinity weights in a separate variable
+		// We return this if this device had the best score compared to other devices considered
+		var sumMatchedWeights float64
 		if l := len(ask.Affinities); l != 0 {
 			totalWeight := 0.0
 			for _, a := range ask.Affinities {
@@ -85,8 +89,8 @@ func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *struc
 					continue
 				}
 				choiceScore += a.Weight
+				sumMatchedWeights += a.Weight
 			}
-			matchedWeights += choiceScore
 
 			// normalize
 			choiceScore /= totalWeight
@@ -99,6 +103,9 @@ func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *struc
 
 		// Set the new highest score
 		offerScore = choiceScore
+
+		// Set the new sum of matching affinity weights
+		matchedWeights = sumMatchedWeights
 
 		// Build the choice
 		offer = &structs.AllocatedDeviceResource{

--- a/scheduler/device.go
+++ b/scheduler/device.go
@@ -41,7 +41,7 @@ func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *struc
 	// Hold the current best offer
 	var offer *structs.AllocatedDeviceResource
 	var offerScore float64
-
+	var matchedWeights float64
 	// Determine the devices that are feasible based on availability and
 	// constraints
 	for id, devInst := range d.Devices {
@@ -86,6 +86,7 @@ func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *struc
 				}
 				choiceScore += a.Weight
 			}
+			matchedWeights += choiceScore
 
 			// normalize
 			choiceScore /= totalWeight
@@ -124,5 +125,5 @@ func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *struc
 		return nil, 0.0, fmt.Errorf("no devices match request")
 	}
 
-	return offer, offerScore, nil
+	return offer, matchedWeights, nil
 }

--- a/scheduler/device.go
+++ b/scheduler/device.go
@@ -42,6 +42,7 @@ func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *struc
 	var offer *structs.AllocatedDeviceResource
 	var offerScore float64
 	var matchedWeights float64
+
 	// Determine the devices that are feasible based on availability and
 	// constraints
 	for id, devInst := range d.Devices {

--- a/scheduler/device_test.go
+++ b/scheduler/device_test.go
@@ -302,7 +302,6 @@ func TestDeviceAllocator_Allocate_Affinities(t *testing.T) {
 				},
 			},
 			ExpectedDevice: nvidia0,
-			ZeroScore:      true,
 		},
 		{
 			Name: "nvidia/gpu",

--- a/scheduler/device_test.go
+++ b/scheduler/device_test.go
@@ -301,6 +301,7 @@ func TestDeviceAllocator_Allocate_Affinities(t *testing.T) {
 					Weight:  -0.2,
 				},
 			},
+			ZeroScore:      true,
 			ExpectedDevice: nvidia0,
 		},
 		{

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -196,7 +196,7 @@ OUTER:
 		devAllocator.AddAllocs(proposed)
 
 		// Track the affinities of the devices
-		totalDeviceAffinityWeight := 0.0
+		devicesWithAffinities := 0.0
 		deviceAffinityScore := 0.0
 
 		// Assign the resources for each task
@@ -295,9 +295,7 @@ OUTER:
 
 				// Add the scores
 				if len(req.Affinities) != 0 {
-					for _, a := range req.Affinities {
-						totalDeviceAffinityWeight += a.Weight
-					}
+					devicesWithAffinities++
 					deviceAffinityScore += score
 				}
 			}
@@ -352,8 +350,8 @@ OUTER:
 		iter.ctx.Metrics().ScoreNode(option.Node, "binpack", normalizedFit)
 
 		// Score the device affinity
-		if totalDeviceAffinityWeight != 0 {
-			deviceAffinityScore /= totalDeviceAffinityWeight
+		if devicesWithAffinities != 0 {
+			deviceAffinityScore /= float64(devicesWithAffinities)
 			option.Scores = append(option.Scores, deviceAffinityScore)
 			iter.ctx.Metrics().ScoreNode(option.Node, "devices", deviceAffinityScore)
 		}

--- a/scheduler/rank_test.go
+++ b/scheduler/rank_test.go
@@ -607,7 +607,7 @@ func TestBinPackIterator_Devices(t *testing.T) {
 					},
 				},
 			},
-			DeviceScore: 0.9,
+			DeviceScore: 1.0,
 		},
 		{
 			Name: "single request over count, no match",
@@ -784,7 +784,7 @@ func TestBinPackIterator_Devices(t *testing.T) {
 			// Check potential affinity scores
 			if c.DeviceScore != 0.0 {
 				require.Len(out.Scores, 2)
-				require.Equal(out.Scores[1], c.DeviceScore)
+				require.Equal(c.DeviceScore, out.Scores[1])
 			}
 		})
 	}


### PR DESCRIPTION
Also changes the logic for score when there is more than one task
requesting a device. Since inter task affinities are already normalized,
we take the average of the scores across tasks.