### PR TITLE
AWS sandbox environment upgrade

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,7 +38,7 @@ properly:
 ```bash
 $ consul members
 $ nomad server members
-$ nomad node-status
+$ nomad node status
 ```
 
 ## Unseal the Vault cluster (optional)
@@ -47,7 +47,7 @@ To initialize and unseal Vault, run:
 
 ```bash
 $ vault operator init -key-shares=1 -key-threshold=1
-$ vault unseal
+$ vault operator unseal
 $ export VAULT_TOKEN=[INITIAL_ROOT_TOKEN]
 ```
 

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -43,7 +43,7 @@ a custom AMI:
 
 ```bash
 region                  = "us-east-1"
-ami                     = "ami-ec237c93"
+ami                     = "ami-00bc95fa4b380317b"
 instance_type           = "t2.medium"
 key_name                = "KEY_NAME"
 server_count            = "3"
@@ -57,7 +57,7 @@ variable like so:
 
 ```bash
 region                  = "us-east-1"
-ami                     = "ami-ec237c93"
+ami                     = "ami-00bc95fa4b380317b"
 instance_type           = "t2.medium"
 key_name                = "KEY_NAME"
 server_count            = "3"

--- a/terraform/aws/env/us-east/main.tf
+++ b/terraform/aws/env/us-east/main.tf
@@ -65,8 +65,8 @@ To connect, add your private key and SSH into any client or server with
 `ssh ubuntu@PUBLIC_IP`. You can test the integrity of the cluster by running:
 
   $ consul members
-  $ nomad server-members
-  $ nomad node-status
+  $ nomad server members
+  $ nomad node status
 
 If you see an error message like the following when running any of the above
 commands, it usually indicates that the configuration script has not finished

--- a/terraform/aws/env/us-east/terraform.tfvars
+++ b/terraform/aws/env/us-east/terraform.tfvars
@@ -1,5 +1,5 @@
 region            = "us-east-1"
-ami               = "ami-ec237c93"
+ami               = "ami-00bc95fa4b380317b"
 instance_type     = "t2.medium"
 key_name          = "KEY_NAME"
 server_count      = "3"

--- a/terraform/aws/modules/hashistack/hashistack.tf
+++ b/terraform/aws/modules/hashistack/hashistack.tf
@@ -31,6 +31,14 @@ resource "aws_security_group" "primary" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # Fabio 
+  ingress {
+    from_port   = 9998
+    to_port     = 9999
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   # Consul
   ingress {
     from_port   = 8500

--- a/terraform/shared/scripts/setup.sh
+++ b/terraform/shared/scripts/setup.sh
@@ -19,7 +19,7 @@ VAULTDOWNLOAD=https://releases.hashicorp.com/vault/${VAULTVERSION}/vault_${VAULT
 VAULTCONFIGDIR=/etc/vault.d
 VAULTDIR=/opt/vault
 
-NOMADVERSION=0.8.4
+NOMADVERSION=0.8.6
 NOMADDOWNLOAD=https://releases.hashicorp.com/nomad/${NOMADVERSION}/nomad_${NOMADVERSION}_linux_amd64.zip
 NOMADCONFIGDIR=/etc/nomad.d
 NOMADDIR=/opt/nomad


### PR DESCRIPTION
Bumped up Nomad to 0.8.6, updated deprecated Nomad and Vault commands, and upgraded AMI which fixes a Vault configuration issue (AMI ID has been updated in appropriate README.md files and terraform.tfvars)