### PR TITLE
Metric prefix filtering

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -298,6 +298,7 @@ func convertServerConfig(agentConfig *Config, logOutput io.Writer) (*nomad.Confi
 	// Setup telemetry related config
 	conf.StatsCollectionInterval = agentConfig.Telemetry.collectionInterval
 	conf.DisableTaggedMetrics = agentConfig.Telemetry.DisableTaggedMetrics
+	conf.DisableDispatchedJobSummaryMetrics = agentConfig.Telemetry.DisableDispatchedJobSummaryMetrics
 	conf.BackwardsCompatibleMetrics = agentConfig.Telemetry.BackwardsCompatibleMetrics
 
 	return conf, nil

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -820,6 +820,10 @@ func (c *Command) setupTelemetry(config *Config) (*metrics.InmemSink, error) {
 	metricsConf.AllowedPrefixes = allowedPrefixes
 	metricsConf.BlockedPrefixes = blockedPrefixes
 
+	if telConfig.FilterDefault != nil {
+		metricsConf.FilterDefault = *telConfig.FilterDefault
+	}
+
 	// Configure the statsite sink
 	var fanout metrics.FanoutSink
 	if telConfig.StatsiteAddr != "" {

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -812,6 +812,14 @@ func (c *Command) setupTelemetry(config *Config) (*metrics.InmemSink, error) {
 		metricsConf.EnableHostname = true
 	}
 
+	allowedPrefixes, blockedPrefixes, err := telConfig.PrefixFilters()
+	if err != nil {
+		return inm, err
+	}
+
+	metricsConf.AllowedPrefixes = allowedPrefixes
+	metricsConf.BlockedPrefixes = blockedPrefixes
+
 	// Configure the statsite sink
 	var fanout metrics.FanoutSink
 	if telConfig.StatsiteAddr != "" {
@@ -895,6 +903,7 @@ func (c *Command) setupTelemetry(config *Config) (*metrics.InmemSink, error) {
 		metricsConf.EnableHostname = false
 		metrics.NewGlobal(metricsConf, inm)
 	}
+
 	return inm, nil
 }
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -434,6 +434,15 @@ type Telemetry struct {
 	// key/value structure as done in older versions of Nomad
 	BackwardsCompatibleMetrics bool `mapstructure:"backwards_compatible_metrics"`
 
+	// PrefixFilter allows for filtering out metrics from being collected
+	PrefixFilter []string `mapstructure:"prefix_filter"`
+
+	// DisableDispatchedJobSummaryMetrics allows for ignore dispatched jobs when
+	// publishing Job summary metrics. This is useful in environment that produce
+	// high numbers of single count dispatch jobs as the metrics for each take up
+	// a small memory overhead.
+	DisableDispatchedJobSummaryMetrics bool `mapstructure:"disable_dispatched_job_summary_metrics"`
+
 	// Circonus: see https://github.com/circonus-labs/circonus-gometrics
 	// for more details on the various configuration options.
 	// Valid configuration combinations:
@@ -504,6 +513,24 @@ type Telemetry struct {
 	// (e.g. a specific geo location or datacenter, dc:sfo)
 	// Default: none
 	CirconusBrokerSelectTag string `mapstructure:"circonus_broker_select_tag"`
+}
+
+// PrefixFilters parses the PrefixFilter field and returns a list of allowed and blocked filters
+func (t *Telemetry) PrefixFilters() (allowed, blocked []string, err error) {
+	for _, rule := range t.PrefixFilter {
+		if rule == "" {
+			continue
+		}
+		switch rule[0] {
+		case '+':
+			allowed = append(allowed, rule[1:])
+		case '-':
+			blocked = append(blocked, rule[1:])
+		default:
+			return nil, nil, fmt.Errorf("Filter rule must begin with either '+' or '-': %q", rule)
+		}
+	}
+	return allowed, blocked, nil
 }
 
 // Ports encapsulates the various ports we bind to for network services. If any
@@ -1321,6 +1348,14 @@ func (a *Telemetry) Merge(b *Telemetry) *Telemetry {
 
 	if b.BackwardsCompatibleMetrics {
 		result.BackwardsCompatibleMetrics = b.BackwardsCompatibleMetrics
+	}
+
+	if b.PrefixFilter != nil {
+		result.PrefixFilter = b.PrefixFilter
+	}
+
+	if b.DisableDispatchedJobSummaryMetrics {
+		result.DisableDispatchedJobSummaryMetrics = b.DisableDispatchedJobSummaryMetrics
 	}
 
 	return &result

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -437,6 +437,10 @@ type Telemetry struct {
 	// PrefixFilter allows for filtering out metrics from being collected
 	PrefixFilter []string `mapstructure:"prefix_filter"`
 
+	// FilterDefault controls whether to allow metrics that have not been specified
+	// by the filter
+	FilterDefault *bool `mapstructure:"filter_default"`
+
 	// DisableDispatchedJobSummaryMetrics allows for ignore dispatched jobs when
 	// publishing Job summary metrics. This is useful in environment that produce
 	// high numbers of single count dispatch jobs as the metrics for each take up
@@ -1352,6 +1356,10 @@ func (a *Telemetry) Merge(b *Telemetry) *Telemetry {
 
 	if b.PrefixFilter != nil {
 		result.PrefixFilter = b.PrefixFilter
+	}
+
+	if b.FilterDefault != nil {
+		result.FilterDefault = b.FilterDefault
 	}
 
 	if b.DisableDispatchedJobSummaryMetrics {

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -725,6 +725,7 @@ func parseTelemetry(result **Telemetry, list *ast.ObjectList) error {
 		"disable_tagged_metrics",
 		"backwards_compatible_metrics",
 		"prefix_filter",
+		"filter_default",
 		"disable_dispatched_job_summary_metrics",
 	}
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -724,6 +724,8 @@ func parseTelemetry(result **Telemetry, list *ast.ObjectList) error {
 		"circonus_broker_select_tag",
 		"disable_tagged_metrics",
 		"backwards_compatible_metrics",
+		"prefix_filter",
+		"disable_dispatched_job_summary_metrics",
 	}
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 		return err

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -274,6 +274,10 @@ type Config struct {
 	// key/value/tag format, or simply a key/value format
 	DisableTaggedMetrics bool
 
+	// DisableDispatchedJobSummaryMetrics allows for ignore dispatched jobs when
+	// publishing Job summary metrics
+	DisableDispatchedJobSummaryMetrics bool
+
 	// BackwardsCompatibleMetrics determines whether to show methods of
 	// displaying metrics for older versions, or to only show the new format
 	BackwardsCompatibleMetrics bool

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -613,7 +613,11 @@ func (s *Server) publishJobSummaryMetrics(stopCh chan struct{}) {
 					break
 				}
 				summary := raw.(*structs.JobSummary)
-				if s.config.DisableDispatchedJobSummaryMetrics && summary.Dispatched {
+				job, err := state.JobByID(ws, summary.Namespace, summary.JobID)
+				if err != nil {
+					s.logger.Printf("[ERR] nomad: failed to lookup job for summary: %v", err)
+				}
+				if s.config.DisableDispatchedJobSummaryMetrics && job.Dispatched {
 					continue
 				}
 				s.iterateJobSummaryMetrics(summary)

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -613,12 +613,15 @@ func (s *Server) publishJobSummaryMetrics(stopCh chan struct{}) {
 					break
 				}
 				summary := raw.(*structs.JobSummary)
-				job, err := state.JobByID(ws, summary.Namespace, summary.JobID)
-				if err != nil {
-					s.logger.Printf("[ERR] nomad: failed to lookup job for summary: %v", err)
-				}
-				if s.config.DisableDispatchedJobSummaryMetrics && job.Dispatched {
-					continue
+				if s.config.DisableDispatchedJobSummaryMetrics {
+					job, err := state.JobByID(ws, summary.Namespace, summary.JobID)
+					if err != nil {
+						s.logger.Printf("[ERR] nomad: failed to lookup job for summary: %v", err)
+						continue
+					}
+					if job.Dispatched {
+						continue
+					}
 				}
 				s.iterateJobSummaryMetrics(summary)
 			}

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -613,41 +613,48 @@ func (s *Server) publishJobSummaryMetrics(stopCh chan struct{}) {
 					break
 				}
 				summary := raw.(*structs.JobSummary)
-				for name, tgSummary := range summary.Summary {
-					if !s.config.DisableTaggedMetrics {
-						labels := []metrics.Label{
-							{
-								Name:  "job",
-								Value: summary.JobID,
-							},
-							{
-								Name:  "task_group",
-								Value: name,
-							},
-						}
-						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "queued"},
-							float32(tgSummary.Queued), labels)
-						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "complete"},
-							float32(tgSummary.Complete), labels)
-						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "failed"},
-							float32(tgSummary.Failed), labels)
-						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "running"},
-							float32(tgSummary.Running), labels)
-						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "starting"},
-							float32(tgSummary.Starting), labels)
-						metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "lost"},
-							float32(tgSummary.Lost), labels)
-					}
-					if s.config.BackwardsCompatibleMetrics {
-						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "queued"}, float32(tgSummary.Queued))
-						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "complete"}, float32(tgSummary.Complete))
-						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "failed"}, float32(tgSummary.Failed))
-						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "running"}, float32(tgSummary.Running))
-						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "starting"}, float32(tgSummary.Starting))
-						metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "lost"}, float32(tgSummary.Lost))
-					}
+				if s.config.DisableDispatchedJobSummaryMetrics && summary.Dispatched {
+					continue
 				}
+				s.iterateJobSummaryMetrics(summary)
 			}
+		}
+	}
+}
+
+func (s *Server) iterateJobSummaryMetrics(summary *structs.JobSummary) {
+	for name, tgSummary := range summary.Summary {
+		if !s.config.DisableTaggedMetrics {
+			labels := []metrics.Label{
+				{
+					Name:  "job",
+					Value: summary.JobID,
+				},
+				{
+					Name:  "task_group",
+					Value: name,
+				},
+			}
+			metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "queued"},
+				float32(tgSummary.Queued), labels)
+			metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "complete"},
+				float32(tgSummary.Complete), labels)
+			metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "failed"},
+				float32(tgSummary.Failed), labels)
+			metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "running"},
+				float32(tgSummary.Running), labels)
+			metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "starting"},
+				float32(tgSummary.Starting), labels)
+			metrics.SetGaugeWithLabels([]string{"nomad", "job_summary", "lost"},
+				float32(tgSummary.Lost), labels)
+		}
+		if s.config.BackwardsCompatibleMetrics {
+			metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "queued"}, float32(tgSummary.Queued))
+			metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "complete"}, float32(tgSummary.Complete))
+			metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "failed"}, float32(tgSummary.Failed))
+			metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "running"}, float32(tgSummary.Running))
+			metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "starting"}, float32(tgSummary.Starting))
+			metrics.SetGauge([]string{"nomad", "job_summary", summary.JobID, name, "lost"}, float32(tgSummary.Lost))
 		}
 	}
 }

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3022,10 +3022,9 @@ func (s *StateStore) ReconcileJobSummaries(index uint64) error {
 
 		// Create a job summary for the job
 		summary := &structs.JobSummary{
-			JobID:      job.ID,
-			Namespace:  job.Namespace,
-			Summary:    make(map[string]structs.TaskGroupSummary),
-			Dispatched: job.Dispatched,
+			JobID:     job.ID,
+			Namespace: job.Namespace,
+			Summary:   make(map[string]structs.TaskGroupSummary),
 		}
 		for _, tg := range job.TaskGroups {
 			summary.Summary[tg.Name] = structs.TaskGroupSummary{}
@@ -3322,7 +3321,6 @@ func (s *StateStore) updateSummaryWithJob(index uint64, job *structs.Job,
 			Summary:     make(map[string]structs.TaskGroupSummary),
 			Children:    new(structs.JobChildrenSummary),
 			CreateIndex: index,
-			Dispatched:  job.Dispatched,
 		}
 		hasSummaryChanged = true
 	}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3022,9 +3022,10 @@ func (s *StateStore) ReconcileJobSummaries(index uint64) error {
 
 		// Create a job summary for the job
 		summary := &structs.JobSummary{
-			JobID:     job.ID,
-			Namespace: job.Namespace,
-			Summary:   make(map[string]structs.TaskGroupSummary),
+			JobID:      job.ID,
+			Namespace:  job.Namespace,
+			Summary:    make(map[string]structs.TaskGroupSummary),
+			Dispatched: job.Dispatched,
 		}
 		for _, tg := range job.TaskGroups {
 			summary.Summary[tg.Name] = structs.TaskGroupSummary{}
@@ -3321,6 +3322,7 @@ func (s *StateStore) updateSummaryWithJob(index uint64, job *structs.Job,
 			Summary:     make(map[string]structs.TaskGroupSummary),
 			Children:    new(structs.JobChildrenSummary),
 			CreateIndex: index,
+			Dispatched:  job.Dispatched,
 		}
 		hasSummaryChanged = true
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1574,13 +1574,13 @@ func (n *Node) Stub() *NodeListStub {
 	addr, _, _ := net.SplitHostPort(n.HTTPAddr)
 
 	return &NodeListStub{
-		Address:    addr,
-		ID:         n.ID,
-		Datacenter: n.Datacenter,
-		Name:       n.Name,
-		NodeClass:  n.NodeClass,
-		Version:    n.Attributes["nomad.version"],
-		Drain:      n.Drain,
+		Address:               addr,
+		ID:                    n.ID,
+		Datacenter:            n.Datacenter,
+		Name:                  n.Name,
+		NodeClass:             n.NodeClass,
+		Version:               n.Attributes["nomad.version"],
+		Drain:                 n.Drain,
 		SchedulingEligibility: n.SchedulingEligibility,
 		Status:                n.Status,
 		StatusDescription:     n.StatusDescription,
@@ -2481,6 +2481,9 @@ type JobSummary struct {
 
 	// Children contains a summary for the children of this job.
 	Children *JobChildrenSummary
+
+	// Dispatched is true if this job is dispatched from a parameterized job
+	Dispatched bool
 
 	// Raft Indexes
 	CreateIndex uint64

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2482,9 +2482,6 @@ type JobSummary struct {
 	// Children contains a summary for the children of this job.
 	Children *JobChildrenSummary
 
-	// Dispatched is true if this job is dispatched from a parameterized job
-	Dispatched bool
-
 	// Raft Indexes
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/website/source/docs/agent/configuration/telemetry.html.md
+++ b/website/source/docs/agent/configuration/telemetry.html.md
@@ -70,7 +70,26 @@ The following options are available on all telemetry configurations.
   0.7. Note that this option is used to transition monitoring to tagged
   metrics and will eventually be deprecated.
 
+- `prefix_filter` `(list: [])` - This is a list of filter rules to apply for
+  allowing/blocking metrics by prefix. A leading "<b>+</b>" will enable any
+  metrics with the given prefix, and a leading "<b>-</b>" will block them. If
+  there is overlap between two rules, the more specific rule will take
+  precedence. Blocking will take priority if the same prefix is listed multiple
+  times. 
 
+```javascript
+  [
+    "-nomad.raft",
+    "+nomad.raft.apply",
+    "-nomad.memberlist",
+  ]
+```
+
+- `disable_dispatched_job_summary_metrics` `(bool: false)` - Specifies if Nomad
+  should ignore jobs dispatched from a parameterized job when publishing job
+  summary statistics. Since each job has a small memory overhead for tracking
+  summary statistics, it is sometimes desired to trade these statistics for
+  more memory when dispatching high volumes of jobs.
 
 ### `statsite`
 

--- a/website/source/docs/agent/configuration/telemetry.html.md
+++ b/website/source/docs/agent/configuration/telemetry.html.md
@@ -64,11 +64,15 @@ The following options are available on all telemetry configurations.
   only be added to tagged metrics. Note that this option is used to transition
   monitoring to tagged metrics and will eventually be deprecated.
 
-
 - `disable_tagged_metrics` `(bool: false)` - Specifies if Nomad should not emit
   tagged metrics and only emit metrics compatible with versions below Nomad
   0.7. Note that this option is used to transition monitoring to tagged
   metrics and will eventually be deprecated.
+
+- `filter_default` `(bool: true)` - This controls whether to allow metrics that
+  have not been specified by the filter. Defaults to true, which will allow all
+  metrics when no filters are provided. When set to false with no filters, no
+  metrics will be sent.
 
 - `prefix_filter` `(list: [])` - This is a list of filter rules to apply for
   allowing/blocking metrics by prefix. A leading "<b>+</b>" will enable any


### PR DESCRIPTION
This PR introduces three new options to the `telemetry` config block:
* `filter_default` - This controls whether to allow metrics that have not been specified by the filter. Modeled after the [option in Consul](https://www.consul.io/docs/agent/options.html#telemetry-filter_default)
* `prefix_filter` - This is modeled after the [option in Consul](https://www.consul.io/docs/agent/options.html#telemetry-prefix_filter) for defining prefixes to include and exclude from metrics
* `disable_dispatched_job_summary_metrics` - This long winded option disables registration of job_summary metrics entirely if the job has been dispatched from a parameterized job. #4422 Explains why you might want this. Additionally if you are dispatching a high volume of jobs you can reclaim the memory overhead used by summary stats tracking of each job for scheduling. This can be significant in large deployments.

fixes #4864 