### PR TITLE
Change misleading boolean example in env stanza coercion section (#4820)

### DIFF
--- a/website/source/docs/job-specification/env.html.md
+++ b/website/source/docs/job-specification/env.html.md
@@ -53,13 +53,14 @@ is preserved.
 
 ```hcl
 env {
-  key = "true"
+  key   = 1.4
+  key   = "1.4"
+  "key" = 1.4
+  "key" = "1.4"
+
   key = true
-
-  "key" = true
-
-  key = 1.4
-  key = "1.4"
+  key = "1"
+  key = 1
 }
 ```
 


### PR DESCRIPTION
### Reference

This PR addresses the misleading example provided in the env stanza about value coercion, as described in #4820 

### Changes

Since the confusion come from `true` being represented as `"1"` by [mapstructure](https://github.com/mitchellh/mapstructure) (as described both in the code and [the godoc](https://godoc.org/github.com/mitchellh/mapstructure#DecoderConfig)), using `true` to enumerate the variation with and without quotes around the key or value is misleading (since in this specific case, the quotes really matter)

The proposed change does the same enumeration with a simple numerical value, and illustrates the coercion of `true` to `"1"` to make it more obvious to any newcomer.

