### PR TITLE
Support graceful shutdowns in agent

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -176,7 +176,8 @@ func (ar *allocRunner) WaitCh() <-chan struct{} {
 	return ar.waitCh
 }
 
-// Run is the main goroutine that executes all the tasks.
+// Run the AllocRunner. Starts tasks if the alloc is non-terminal and closes
+// WaitCh when it exits. Should be started in a goroutine.
 func (ar *allocRunner) Run() {
 	// Close the wait channel on return
 	defer close(ar.waitCh)

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -37,7 +37,7 @@ type allocRunner struct {
 	// stateUpdater is used to emit updated alloc state
 	stateUpdater cinterfaces.AllocStateHandler
 
-	// taskStateUpdateCh is ticked whenever task state as changed. Must
+	// taskStateUpdatedCh is ticked whenever task state as changed. Must
 	// have len==1 to allow nonblocking notification of state updates while
 	// the goroutine is already processing a previous update.
 	taskStateUpdatedCh chan struct{}
@@ -62,12 +62,12 @@ type allocRunner struct {
 	// to access.
 	destroyed bool
 
-	// runLaunched is true if Run() has been called. If this is false
-	// Destroy() does not wait on tasks to shutdown as they are not
-	// running. Must acquire destroyedLock to access.
-	runLaunched bool
+	// runnersLaunched is true if TaskRunners were Run. Must acquire
+	// destroyedLock to access.
+	runnersLaunched bool
 
-	// destroyedLock guards destroyed, ran, and serializes Destroy() calls.
+	// destroyedLock guards destroyed, runnersLaunched, and serializes
+	// Shutdown/Destroy calls.
 	destroyedLock sync.Mutex
 
 	// Alloc captures the allocation being run.
@@ -178,38 +178,50 @@ func (ar *allocRunner) WaitCh() <-chan struct{} {
 
 // Run is the main goroutine that executes all the tasks.
 func (ar *allocRunner) Run() {
-	ar.destroyedLock.Lock()
-	defer ar.destroyedLock.Unlock()
+	// Close the wait channel on return
+	defer close(ar.waitCh)
 
-	// Run should not be called after Destroy is called. This is a
-	// programming error.
-	if ar.destroyed {
-		ar.logger.Error("alloc destroyed; cannot run")
-		return
-	}
+	// Start the task state update handler
+	go ar.handleTaskStateUpdates()
 
 	// If an alloc should not be run, ensure any restored task handles are
 	// destroyed and exit to wait for the AR to be GC'd by the client.
 	if !ar.shouldRun() {
 		ar.logger.Debug("not running terminal alloc")
 
-		// Cleanup and sync state
-		states := ar.killTasks()
-
-		// Get the client allocation
-		calloc := ar.clientAlloc(states)
-
-		// Update the server
-		ar.stateUpdater.AllocStateUpdated(calloc)
-
-		// Broadcast client alloc to listeners
-		ar.allocBroadcaster.Send(calloc)
+		// Ensure all tasks are cleaned up
+		ar.killTasks()
 		return
 	}
 
-	// Run! (and mark as having been run to ensure Destroy cleans up properly)
-	ar.runLaunched = true
-	go ar.runImpl()
+	// Mark task runners as being run for Shutdown
+	ar.destroyedLock.Lock()
+	ar.runnersLaunched = true
+	ar.destroyedLock.Unlock()
+
+	// If task update chan has been closed, that means we've been shutdown.
+	select {
+	case <-ar.taskStateUpdateHandlerCh:
+		return
+	default:
+	}
+
+	// Run the prestart hooks
+	if err := ar.prerun(); err != nil {
+		ar.logger.Error("prerun failed", "error", err)
+		goto POST
+	}
+
+	// Run the runners and block until they exit
+	<-ar.runTasks()
+
+POST:
+	// Run the postrun hooks
+	// XXX Equivalent to TR.Poststop hook
+	if err := ar.postrun(); err != nil {
+		ar.logger.Error("postrun failed", "error", err)
+	}
+
 }
 
 // shouldRun returns true if the alloc is in a state that the alloc runner
@@ -234,30 +246,6 @@ func (ar *allocRunner) shouldRun() bool {
 	}
 
 	return true
-}
-
-func (ar *allocRunner) runImpl() {
-	// Close the wait channel on return
-	defer close(ar.waitCh)
-
-	// Start the task state update handler
-	go ar.handleTaskStateUpdates()
-
-	// Run the prestart hooks
-	if err := ar.prerun(); err != nil {
-		ar.logger.Error("prerun failed", "error", err)
-		goto POST
-	}
-
-	// Run the runners and block until they exit
-	<-ar.runTasks()
-
-POST:
-	// Run the postrun hooks
-	// XXX Equivalent to TR.Poststop hook
-	if err := ar.postrun(); err != nil {
-		ar.logger.Error("postrun failed", "error", err)
-	}
 }
 
 // runTasks is used to run the task runners.
@@ -328,7 +316,7 @@ func (ar *allocRunner) TaskStateUpdated() {
 }
 
 // handleTaskStateUpdates must be run in goroutine as it monitors
-// taskStateUpdateCh for task state update notifications and processes task
+// taskStateUpdatedCh for task state update notifications and processes task
 // states.
 //
 // Processing task state updates must be done in a goroutine as it may have to
@@ -340,10 +328,12 @@ func (ar *allocRunner) handleTaskStateUpdates() {
 		select {
 		case <-ar.taskStateUpdatedCh:
 		case <-ar.waitCh:
-			// Tasks have exited, run once more to ensure final
+			// Run has exited, sync once more to ensure final
 			// states are collected.
 			done = true
 		}
+
+		ar.logger.Trace("handling task state update", "done", done)
 
 		// Set with the appropriate event if task runners should be
 		// killed.
@@ -620,12 +610,11 @@ func (ar *allocRunner) Listener() *cstructs.AllocListener {
 // exit (thus closing WaitCh).
 func (ar *allocRunner) Destroy() {
 	ar.destroyedLock.Lock()
+	defer ar.destroyedLock.Unlock()
 	if ar.destroyed {
 		// Only destroy once
-		ar.destroyedLock.Unlock()
 		return
 	}
-	defer ar.destroyedLock.Unlock()
 
 	// Stop any running tasks and persist states in case the client is
 	// shutdown before Destroy finishes.
@@ -633,10 +622,8 @@ func (ar *allocRunner) Destroy() {
 	calloc := ar.clientAlloc(states)
 	ar.stateUpdater.AllocStateUpdated(calloc)
 
-	// Wait for tasks to exit and postrun hooks to finish (if they ran at all)
-	if ar.runLaunched {
-		<-ar.waitCh
-	}
+	// Wait for tasks to exit and postrun hooks to finish
+	<-ar.waitCh
 
 	// Run destroy hooks
 	if err := ar.destroy(); err != nil {
@@ -645,9 +632,7 @@ func (ar *allocRunner) Destroy() {
 
 	// Wait for task state update handler to exit before removing local
 	// state if Run() ran at all.
-	if ar.runLaunched {
-		<-ar.taskStateUpdateHandlerCh
-	}
+	<-ar.taskStateUpdateHandlerCh
 
 	// Cleanup state db
 	if err := ar.stateDB.DeleteAllocationBucket(ar.id); err != nil {
@@ -676,6 +661,43 @@ func (ar *allocRunner) IsDestroyed() bool {
 // This method is safe for calling concurrently with Run().
 func (ar *allocRunner) IsWaiting() bool {
 	return ar.prevAllocWatcher.IsWaiting()
+}
+
+// Shutdown AllocRunner gracefully. Blocks while shutting down all TaskRunners.
+// Tasks are unaffected and may be restored.
+func (ar *allocRunner) Shutdown() {
+	ar.destroyedLock.Lock()
+	defer ar.destroyedLock.Unlock()
+
+	// Destroy is a superset of Shutdown so there's nothing to do if this
+	// has already been destroyed.
+	if ar.destroyed {
+		return
+	}
+
+	ar.logger.Trace("shutting down")
+
+	// Shutdown tasks gracefully if they were run
+	if ar.runnersLaunched {
+		wg := sync.WaitGroup{}
+		for _, tr := range ar.tasks {
+			wg.Add(1)
+			go func(tr *taskrunner.TaskRunner) {
+				tr.Shutdown()
+				wg.Done()
+			}(tr)
+		}
+		wg.Wait()
+	}
+
+	// Wait for Run to exit
+	<-ar.waitCh
+
+	// Run shutdown hooks
+	ar.shutdownHooks()
+
+	// Wait for updater to finish its final run
+	<-ar.taskStateUpdateHandlerCh
 }
 
 // IsMigrating returns true if the alloc runner is migrating data from its

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -241,3 +241,27 @@ func (ar *allocRunner) destroy() error {
 
 	return nil
 }
+
+// shutdownHooks calls graceful shutdown hooks for when the agent is exiting.
+func (ar *allocRunner) shutdownHooks() {
+	for _, hook := range ar.runnerHooks {
+		sh, ok := hook.(interfaces.ShutdownHook)
+		if !ok {
+			continue
+		}
+
+		name := sh.Name()
+		var start time.Time
+		if ar.logger.IsTrace() {
+			start = time.Now()
+			ar.logger.Trace("running shutdown hook", "name", name, "start", start)
+		}
+
+		sh.Shutdown()
+
+		if ar.logger.IsTrace() {
+			end := time.Now()
+			ar.logger.Trace("finished shutdown hooks", "name", name, "end", end, "duration", end.Sub(start))
+		}
+	}
+}

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -124,7 +124,7 @@ func TestAllocRunner_TaskLeader_KillTG(t *testing.T) {
 	ar, err := NewAllocRunner(conf)
 	require.NoError(t, err)
 	defer ar.Destroy()
-	ar.Run()
+	go ar.Run()
 
 	// Wait for all tasks to be killed
 	upd := conf.StateUpdater.(*MockStateUpdater)
@@ -214,7 +214,7 @@ func TestAllocRunner_TaskLeader_StopTG(t *testing.T) {
 	ar, err := NewAllocRunner(conf)
 	require.NoError(t, err)
 	defer ar.Destroy()
-	ar.Run()
+	go ar.Run()
 
 	// Wait for tasks to start
 	upd := conf.StateUpdater.(*MockStateUpdater)
@@ -308,7 +308,6 @@ func TestAllocRunner_TaskLeader_StopRestoredTG(t *testing.T) {
 
 	ar, err := NewAllocRunner(conf)
 	require.NoError(t, err)
-	defer ar.Destroy()
 
 	// Mimic Nomad exiting before the leader stopping is able to stop other tasks.
 	ar.tasks["leader"].UpdateState(structs.TaskStateDead, structs.NewTaskEvent(structs.TaskKilled))

--- a/client/allocrunner/health_hook.go
+++ b/client/allocrunner/health_hook.go
@@ -188,6 +188,11 @@ func (h *allocHealthWatcherHook) Destroy() error {
 	return nil
 }
 
+func (h *allocHealthWatcherHook) Shutdown() {
+	// Same as Destroy
+	h.Destroy()
+}
+
 // watchHealth watches alloc health until it is set, the alloc is stopped, or
 // the context is canceled. watchHealth will be canceled and restarted on
 // Updates so calls are serialized with a lock.

--- a/client/allocrunner/health_hook_test.go
+++ b/client/allocrunner/health_hook_test.go
@@ -23,6 +23,7 @@ import (
 var _ interfaces.RunnerPrerunHook = (*allocHealthWatcherHook)(nil)
 var _ interfaces.RunnerUpdateHook = (*allocHealthWatcherHook)(nil)
 var _ interfaces.RunnerDestroyHook = (*allocHealthWatcherHook)(nil)
+var _ interfaces.ShutdownHook = (*allocHealthWatcherHook)(nil)
 
 // allocHealth is emitted to a chan whenever SetHealth is called
 type allocHealth struct {

--- a/client/allocrunner/interfaces/runner_lifecycle.go
+++ b/client/allocrunner/interfaces/runner_lifecycle.go
@@ -42,3 +42,11 @@ type HookTarget interface {
 	// State retrieves a copy of the target alloc runners state.
 	State() *state.State
 }
+
+// ShutdownHook may be implemented by AllocRunner or TaskRunner hooks and will
+// be called when the agent process is being shutdown gracefully.
+type ShutdownHook interface {
+	RunnerHook
+
+	Shutdown()
+}

--- a/client/allocrunner/taskrunner/stats_hook_test.go
+++ b/client/allocrunner/taskrunner/stats_hook_test.go
@@ -15,6 +15,7 @@ import (
 // Statically assert the stats hook implements the expected interfaces
 var _ interfaces.TaskPoststartHook = (*statsHook)(nil)
 var _ interfaces.TaskExitedHook = (*statsHook)(nil)
+var _ interfaces.ShutdownHook = (*statsHook)(nil)
 
 type mockStatsUpdater struct {
 	// Ch is sent task resource usage updates if not nil

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -303,6 +303,8 @@ func (tr *TaskRunner) initLabels() {
 	}
 }
 
+// Run the TaskRunner. Starts the user's task or reattaches to a restored task.
+// Run closes WaitCh when it exits. Should be started in a goroutine.
 func (tr *TaskRunner) Run() {
 	defer close(tr.waitCh)
 	var result *drivers.ExitResult

--- a/client/allocrunner/taskrunner/task_runner_getters.go
+++ b/client/allocrunner/taskrunner/task_runner_getters.go
@@ -10,10 +10,16 @@ func (tr *TaskRunner) Alloc() *structs.Allocation {
 	return tr.alloc
 }
 
-func (tr *TaskRunner) setAlloc(updated *structs.Allocation) {
+// setAlloc and task on TaskRunner
+func (tr *TaskRunner) setAlloc(updated *structs.Allocation, task *structs.Task) {
 	tr.allocLock.Lock()
+	defer tr.allocLock.Unlock()
+
+	tr.taskLock.Lock()
+	defer tr.taskLock.Unlock()
+
 	tr.alloc = updated
-	tr.allocLock.Unlock()
+	tr.task = task
 }
 
 // IsLeader returns true if this task is the leader of its task group.

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -127,8 +127,7 @@ func TestTaskRunner_Restore_Running(t *testing.T) {
 	})
 
 	// Cause TR to exit without shutting down task
-	origTR.ctxCancel()
-	<-origTR.WaitCh()
+	origTR.Shutdown()
 
 	// Start a new TaskRunner and make sure it does not rerun the task
 	newTR, err := NewTaskRunner(conf)

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -162,6 +162,10 @@ func (h *vaultHook) Stop(ctx context.Context, req *interfaces.TaskStopRequest, r
 	return nil
 }
 
+func (h *vaultHook) Shutdown() {
+	h.cancel()
+}
+
 // run should be called in a go-routine and manages the derivation, renewal and
 // handling of errors with the Vault token. The optional parameter allows
 // setting the initial Vault token. This is useful when the Vault token is

--- a/client/allocrunner/taskrunner/vault_hook_test.go
+++ b/client/allocrunner/taskrunner/vault_hook_test.go
@@ -1,0 +1,8 @@
+package taskrunner
+
+import "github.com/hashicorp/nomad/client/allocrunner/interfaces"
+
+// Statically assert the stats hook implements the expected interfaces
+var _ interfaces.TaskPrestartHook = (*vaultHook)(nil)
+var _ interfaces.TaskStopHook = (*vaultHook)(nil)
+var _ interfaces.ShutdownHook = (*vaultHook)(nil)

--- a/client/client.go
+++ b/client/client.go
@@ -575,15 +575,11 @@ func (c *Client) Shutdown() error {
 		}
 	} else {
 		// In normal mode call shutdown
-		wg := sync.WaitGroup{}
+		arGroup := group{}
 		for _, ar := range c.getAllocRunners() {
-			wg.Add(1)
-			go func(ar AllocRunner) {
-				ar.Shutdown()
-				wg.Done()
-			}(ar)
+			arGroup.Go(ar.Shutdown)
 		}
-		wg.Wait()
+		arGroup.Wait()
 	}
 
 	c.shutdown = true

--- a/client/client.go
+++ b/client/client.go
@@ -1215,10 +1215,10 @@ func (c *Client) registerAndHeartbeat() {
 	c.retryRegisterNode()
 
 	// Start watching changes for node changes
-	c.shutdownGroup.Go(c.watchNodeUpdates)
+	go c.watchNodeUpdates()
 
 	// Start watching for emitting node events
-	c.shutdownGroup.Go(c.watchNodeEvents)
+	go c.watchNodeEvents()
 
 	// Setup the heartbeat timer, for the initial registration
 	// we want to do this quickly. We want to do it extra quickly
@@ -2600,6 +2600,7 @@ type group struct {
 	wg sync.WaitGroup
 }
 
+// Go starts f in a goroutine and must be called before Wait.
 func (g *group) Go(f func()) {
 	g.wg.Add(1)
 	go func() {
@@ -2608,6 +2609,8 @@ func (g *group) Go(f func()) {
 	}()
 }
 
+// Wait for all goroutines to exit. Must be called after all calls to Go
+// complete.
 func (g *group) Wait() {
 	g.wg.Wait()
 }

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -71,6 +71,13 @@ TRY:
 		return nil
 	}
 
+	// If shutting down, exit without logging the error
+	select {
+	case <-c.shutdownCh:
+		return nil
+	default:
+	}
+
 	// Move off to another server, and see if we can retry.
 	c.rpcLogger.Error("error performing RPC to server", "error", rpcErr, "rpc", method, "server", server.Addr)
 	c.servers.NotifyFailedServer(server)


### PR DESCRIPTION
Previously Nomad simply left AR/TR goroutines running when shutting down. Since Nomad must be crashsafe this was not a consistency issue.

In practice though this posed three issues:
1. Tests had no one to mimic shutting down a Client and starting up a new one.
2. Shutdowns could log lots of confusing errors as some components (eg rpc conn pool or state db) were closed while *still in use.*
3. Any crash safety issues we had could be hit *every shutdown.* While I don't think this was the source of any issues, it would be very difficult to know for sure as they're likely racy/nondeterministic.

This PR adds a blocking Shutdown method to ARs and TRs. It also:

* Restores the old AR.Run behavior: AR.Run is always run and should be run in a goroutine. The old path was just extra complexity for no gain.
* Returns an error from the statedb if it's used after close instead of panicking. This matches boltdb's behavior.
* Adds a ShutdownHook to AR & TR to allow hooks to cleanup.