### PR TITLE
Report alloc device statistics in API and CLI

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -37,6 +37,7 @@ type CpuStats struct {
 type ResourceUsage struct {
 	MemoryStats *MemoryStats
 	CpuStats    *CpuStats
+	DeviceStats []*DeviceGroupStats
 }
 
 // TaskResourceUsage holds aggregated resource usage of all processes in a Task

--- a/client/allocrunner/config.go
+++ b/client/allocrunner/config.go
@@ -35,6 +35,9 @@ type Config struct {
 	// StateUpdater is used to emit updated task state
 	StateUpdater interfaces.AllocStateHandler
 
+	// deviceStatsReporter is used to lookup resource usage for alloc devices
+	DeviceStatsReporter interfaces.DeviceStatsReporter
+
 	// PrevAllocWatcher handles waiting on previous allocations and
 	// migrating their ephemeral disk when necessary.
 	PrevAllocWatcher allocwatcher.PrevAllocWatcher

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -886,7 +886,7 @@ func (tr *TaskRunner) LatestResourceUsage() *cstructs.TaskResourceUsage {
 
 	// Look up device statistics lazily when fetched, as currently we do not emit any stats for them yet
 	if ru != nil && tr.deviceStatsReporter != nil {
-		deviceResources := tr.Alloc().AllocatedResources.Tasks[tr.Task().Name].Devices
+		deviceResources := tr.Alloc().AllocatedResources.Tasks[tr.taskName].Devices
 		ru.ResourceUsage.DeviceStats = tr.deviceStatsReporter.LatestDeviceResourceStats(deviceResources)
 	}
 	return ru

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/driver/env"
+	cinterfaces "github.com/hashicorp/nomad/client/interfaces"
 	cstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/vaultclient"
@@ -161,6 +162,9 @@ type TaskRunner struct {
 	resourceUsage     *cstructs.TaskResourceUsage
 	resourceUsageLock sync.Mutex
 
+	// deviceStatsReporter is used to lookup resource usage for alloc devices
+	deviceStatsReporter cinterfaces.DeviceStatsReporter
+
 	// PluginSingletonLoader is a plugin loader that will returns singleton
 	// instances of the plugins.
 	pluginSingletonLoader loader.PluginCatalog
@@ -182,6 +186,9 @@ type Config struct {
 
 	// StateUpdater is used to emit updated task state
 	StateUpdater interfaces.TaskStateHandler
+
+	// deviceStatsReporter is used to lookup resource usage for alloc devices
+	DeviceStatsReporter cinterfaces.DeviceStatsReporter
 
 	// PluginSingletonLoader is a plugin loader that will returns singleton
 	// instances of the plugins.
@@ -224,6 +231,7 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		localState:            state.NewLocalState(),
 		stateDB:               config.StateDB,
 		stateUpdater:          config.StateUpdater,
+		deviceStatsReporter:   config.DeviceStatsReporter,
 		killCtx:               killCtx,
 		killCtxCancel:         killCancel,
 		ctx:                   trCtx,
@@ -875,6 +883,12 @@ func (tr *TaskRunner) LatestResourceUsage() *cstructs.TaskResourceUsage {
 	tr.resourceUsageLock.Lock()
 	ru := tr.resourceUsage
 	tr.resourceUsageLock.Unlock()
+
+	// Look up device statistics lazily when fetched, as currently we do not emit any stats for them yet
+	if ru != nil && tr.deviceStatsReporter != nil {
+		deviceResources := tr.Alloc().AllocatedResources.Tasks[tr.Task().Name].Devices
+		ru.ResourceUsage.DeviceStats = tr.deviceStatsReporter.LatestDeviceResourceStats(deviceResources)
+	}
 	return ru
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/nomad/plugins/device"
-
 	metrics "github.com/armon/go-metrics"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -42,6 +40,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	nconfig "github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/hashicorp/nomad/plugins/device"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/shirou/gopsutil/host"
 )

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/client/config"
 	consulApi "github.com/hashicorp/nomad/client/consul"
@@ -1184,5 +1182,5 @@ func TestClient_computeAllocatedDeviceStats(t *testing.T) {
 		},
 	}
 
-	require.EqualValues(t, expected, result)
+	assert.EqualValues(t, expected, result)
 }

--- a/client/interfaces/client.go
+++ b/client/interfaces/client.go
@@ -1,6 +1,9 @@
 package interfaces
 
-import "github.com/hashicorp/nomad/nomad/structs"
+import (
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/device"
+)
 
 type Client interface {
 	AllocStateHandler
@@ -11,4 +14,10 @@ type AllocStateHandler interface {
 	// AllocStateUpdated is used to emit an updated allocation. This allocation
 	// is stripped to only include client settable fields.
 	AllocStateUpdated(alloc *structs.Allocation)
+}
+
+// DeviceStatsReporter gives access to the latest resource usage
+// for devices
+type DeviceStatsReporter interface {
+	LatestDeviceResourceStats([]*structs.AllocatedDeviceResource) []*device.DeviceGroupStats
 }

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/stats"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/device"
 )
 
 // RpcError is used for serializing errors with a potential error code
@@ -215,11 +216,13 @@ func (cs *CpuStats) Add(other *CpuStats) {
 type ResourceUsage struct {
 	MemoryStats *MemoryStats
 	CpuStats    *CpuStats
+	DeviceStats []*device.DeviceGroupStats
 }
 
 func (ru *ResourceUsage) Add(other *ResourceUsage) {
 	ru.MemoryStats.Add(other.MemoryStats)
 	ru.CpuStats.Add(other.CpuStats)
+	ru.DeviceStats = append(ru.DeviceStats, other.DeviceStats...)
 }
 
 // TaskResourceUsage holds aggregated resource usage of all processes in a Task

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -525,6 +525,7 @@ func (c *AllocStatusCommand) outputTaskResources(alloc *api.Allocation, task str
 
 	if len(deviceStats) > 0 {
 		c.Ui.Output("")
+		c.Ui.Output("Device Stats")
 		c.Ui.Output(formatList(getDeviceResources(deviceStats)))
 	}
 

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -606,6 +606,7 @@ func (c *AllocStatusCommand) outputVerboseResourceUsage(task string, resourceUsa
 	}
 
 	if len(deviceStats) > 0 {
+		c.Ui.Output("")
 		c.Ui.Output("Device Stats")
 
 		printDeviceStats(c.Ui, deviceStats)

--- a/command/helper_stats.go
+++ b/command/helper_stats.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/mitchellh/cli"
 )
 
 func deviceQualifiedID(vendor, typ, name, id string) string {
@@ -18,10 +19,10 @@ func deviceQualifiedID(vendor, typ, name, id string) string {
 	return p + "[" + id + "]"
 }
 
-func buildDeviceStatsSummaryMap(host *api.HostStats) map[string]*api.StatValue {
+func buildDeviceStatsSummaryMap(deviceGroupStats []*api.DeviceGroupStats) map[string]*api.StatValue {
 	r := map[string]*api.StatValue{}
 
-	for _, dg := range host.DeviceStats {
+	for _, dg := range deviceGroupStats {
 		for id, stats := range dg.InstanceStats {
 			k := deviceQualifiedID(dg.Vendor, dg.Type, dg.Name, id)
 			r[k] = stats.Summary
@@ -42,5 +43,44 @@ func formatDeviceStats(stat *api.StatObject, keyPrefix string, result *[]string)
 
 	for k, o := range stat.Nested {
 		formatDeviceStats(o, keyPrefix+k, result)
+	}
+}
+
+// getDeviceResources returns a list of devices and their statistics summary
+func getDeviceResourcesForNode(deviceGroupStats []*api.DeviceGroupStats, node *api.Node) []string {
+	statsSummaryMap := buildDeviceStatsSummaryMap(deviceGroupStats)
+
+	devices := []string{}
+	for _, dg := range node.NodeResources.Devices {
+		for _, inst := range dg.Instances {
+			id := deviceQualifiedID(dg.Vendor, dg.Type, dg.Name, inst.ID)
+			statStr := ""
+			if stats, ok := statsSummaryMap[id]; ok && stats != nil {
+				statStr = stats.String()
+			}
+
+			devices = append(devices, fmt.Sprintf("%v|%v", id, statStr))
+		}
+	}
+
+	return devices
+}
+
+func printDeviceStats(ui cli.Ui, deviceGroupStats []*api.DeviceGroupStats) {
+	isFirst := true
+	for _, dg := range deviceGroupStats {
+		for id, dinst := range dg.InstanceStats {
+			if !isFirst {
+				ui.Output("\n")
+			}
+			isFirst = false
+
+			qid := deviceQualifiedID(dg.Vendor, dg.Type, dg.Name, id)
+			attrs := make([]string, 1, len(dinst.Stats.Attributes)+1)
+			attrs[0] = fmt.Sprintf("Device|%s", qid)
+			formatDeviceStats(dinst.Stats, "", &attrs)
+
+			ui.Output(formatKV(attrs))
+		}
 	}
 }

--- a/command/helper_stats.go
+++ b/command/helper_stats.go
@@ -84,7 +84,7 @@ func printDeviceStats(ui cli.Ui, deviceGroupStats []*api.DeviceGroupStats) {
 	for _, dg := range deviceGroupStats {
 		for id, dinst := range dg.InstanceStats {
 			if !isFirst {
-				ui.Output("\n")
+				ui.Output("")
 			}
 			isFirst = false
 

--- a/command/helper_stats.go
+++ b/command/helper_stats.go
@@ -46,7 +46,8 @@ func formatDeviceStats(stat *api.StatObject, keyPrefix string, result *[]string)
 	}
 }
 
-// getDeviceResources returns a list of devices and their statistics summary
+// getDeviceResourcesForNode returns a list of devices and their statistics summary
+// and tracks devices without statistics
 func getDeviceResourcesForNode(deviceGroupStats []*api.DeviceGroupStats, node *api.Node) []string {
 	statsSummaryMap := buildDeviceStatsSummaryMap(deviceGroupStats)
 
@@ -64,6 +65,18 @@ func getDeviceResourcesForNode(deviceGroupStats []*api.DeviceGroupStats, node *a
 	}
 
 	return devices
+}
+
+// getDeviceResources returns alist of devices and their statistics summary
+func getDeviceResources(deviceGroupStats []*api.DeviceGroupStats) []string {
+	statsSummaryMap := buildDeviceStatsSummaryMap(deviceGroupStats)
+
+	result := make([]string, 0, len(statsSummaryMap))
+	for id, stats := range statsSummaryMap {
+		result = append(result, id+"|"+stats.String())
+	}
+
+	return result
 }
 
 func printDeviceStats(ui cli.Ui, deviceGroupStats []*api.DeviceGroupStats) {

--- a/command/helper_stats_test.go
+++ b/command/helper_stats_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
@@ -83,6 +82,7 @@ func TestFormatDeviceStats(t *testing.T) {
 
 	stat := &api.StatObject{
 		Attributes: map[string]*api.StatValue{
+			"a0": statValue("va0"),
 			"k0": statValue("v0"),
 		},
 		Nested: map[string]*api.StatObject{
@@ -108,22 +108,21 @@ func TestFormatDeviceStats(t *testing.T) {
 		},
 	}
 
-	result := []string{"preseedkey|pressededvalue"}
-	formatDeviceStats(stat, "", &result)
+	result := formatDeviceStats("TestDeviceID", stat)
 
-	// check array is appended only
-	require.Equal(t, "preseedkey|pressededvalue", result[0])
+	// check that device id always appears first
+	require.Equal(t, "Device|TestDeviceID", result[0])
 
 	// check rest of values
-	sort.Strings(result)
 	expected := []string{
+		"Device|TestDeviceID",
+		"a0|va0",
 		"k0|v0",
 		"nested1.k1_0|v1_0",
 		"nested1.k1_1|v1_1",
 		"nested1.nested1_1.k11_0|v11_0",
 		"nested1.nested1_1.k11_1|v11_1",
 		"nested2.k2|v2",
-		"preseedkey|pressededvalue",
 	}
 
 	require.Equal(t, expected, result)
@@ -191,7 +190,6 @@ func TestNodeStatusCommand_GetDeviceResourcesForNode(t *testing.T) {
 	}
 
 	formattedDevices := getDeviceResourcesForNode(hostDeviceStats, node)
-	sort.Strings(formattedDevices)
 	expected := []string{
 		"vendor1/type1/name1[id1]|stat1",
 		"vendor1/type1/name1[id2]|2",
@@ -240,7 +238,6 @@ func TestNodeStatusCommand_GetDeviceResources(t *testing.T) {
 	}
 
 	formattedDevices := getDeviceResources(hostDeviceStats)
-	sort.Strings(formattedDevices)
 	expected := []string{
 		"vendor1/type1/name1[id1]|stat1",
 		"vendor1/type1/name1[id2]|2",

--- a/command/helper_stats_test.go
+++ b/command/helper_stats_test.go
@@ -201,3 +201,52 @@ func TestNodeStatusCommand_GetDeviceResourcesForNode(t *testing.T) {
 
 	assert.Equal(t, expected, formattedDevices)
 }
+
+func TestNodeStatusCommand_GetDeviceResources(t *testing.T) {
+	hostDeviceStats := []*api.DeviceGroupStats{
+		{
+			Vendor: "vendor1",
+			Type:   "type1",
+			Name:   "name1",
+			InstanceStats: map[string]*api.DeviceStats{
+				"id1": {
+					Summary: &api.StatValue{
+						StringVal: helper.StringToPtr("stat1"),
+					},
+				},
+				"id2": {
+					Summary: &api.StatValue{
+						IntNumeratorVal: helper.Int64ToPtr(2),
+					},
+				},
+			},
+		},
+		{
+			Vendor: "vendor2",
+			Type:   "type2",
+			InstanceStats: map[string]*api.DeviceStats{
+				"id1": {
+					Summary: &api.StatValue{
+						StringVal: helper.StringToPtr("stat3"),
+					},
+				},
+				"id2": {
+					Summary: &api.StatValue{
+						IntNumeratorVal: helper.Int64ToPtr(4),
+					},
+				},
+			},
+		},
+	}
+
+	formattedDevices := getDeviceResources(hostDeviceStats)
+	sort.Strings(formattedDevices)
+	expected := []string{
+		"vendor1/type1/name1[id1]|stat1",
+		"vendor1/type1/name1[id2]|2",
+		"vendor2/type2[id1]|stat3",
+		"vendor2/type2[id2]|4",
+	}
+
+	assert.Equal(t, expected, formattedDevices)
+}

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -392,7 +392,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 
 		if err == nil && len(node.NodeResources.Devices) > 0 {
 			c.Ui.Output(c.Colorize().Color("\n[bold]Device Resource Utilization[reset]"))
-			c.Ui.Output(formatList(getDeviceResources(hostStats, node)))
+			c.Ui.Output(formatList(getDeviceResourcesForNode(hostStats.DeviceStats, node)))
 		}
 		if hostStats != nil && c.stats {
 			c.Ui.Output(c.Colorize().Color("\n[bold]CPU Stats[reset]"))
@@ -403,7 +403,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 			c.printDiskStats(hostStats)
 			if len(hostStats.DeviceStats) > 0 {
 				c.Ui.Output(c.Colorize().Color("\n[bold]Device Stats[reset]"))
-				c.printDeviceStats(hostStats)
+				printDeviceStats(c.Ui, hostStats.DeviceStats)
 			}
 		}
 	}
@@ -590,25 +590,6 @@ func (c *NodeStatusCommand) printDiskStats(hostStats *api.HostStats) {
 	}
 }
 
-func (c *NodeStatusCommand) printDeviceStats(hostStats *api.HostStats) {
-	isFirst := true
-	for _, dg := range hostStats.DeviceStats {
-		for id, dinst := range dg.InstanceStats {
-			if !isFirst {
-				c.Ui.Output("\n")
-			}
-			isFirst = false
-
-			qid := deviceQualifiedID(dg.Vendor, dg.Type, dg.Name, id)
-			attrs := make([]string, 1, len(dinst.Stats.Attributes)+1)
-			attrs[0] = fmt.Sprintf("Device|%s", qid)
-			formatDeviceStats(dinst.Stats, "", &attrs)
-
-			c.Ui.Output(formatKV(attrs))
-		}
-	}
-}
-
 // getRunningAllocs returns a slice of allocation id's running on the node
 func getRunningAllocs(client *api.Client, nodeID string) ([]*api.Allocation, error) {
 	var allocs []*api.Allocation
@@ -742,26 +723,6 @@ func getHostResources(hostStats *api.HostStats, node *api.Node) ([]string, error
 		)
 	}
 	return resources, nil
-}
-
-// getDeviceResources returns a list of devices and their statistics summary
-func getDeviceResources(hostStats *api.HostStats, node *api.Node) []string {
-	statsSummaryMap := buildDeviceStatsSummaryMap(hostStats)
-
-	devices := []string{}
-	for _, dg := range node.NodeResources.Devices {
-		for _, inst := range dg.Instances {
-			id := deviceQualifiedID(dg.Vendor, dg.Type, dg.Name, inst.ID)
-			statStr := ""
-			if stats, ok := statsSummaryMap[id]; ok && stats != nil {
-				statStr = stats.String()
-			}
-
-			devices = append(devices, fmt.Sprintf("%v|%v", id, statStr))
-		}
-	}
-
-	return devices
 }
 
 // formatNodeStubList is used to return a table format of a list of node stubs.

--- a/command/node_status_test.go
+++ b/command/node_status_test.go
@@ -2,14 +2,12 @@ package command
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/command/agent"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
@@ -277,79 +275,4 @@ func TestNodeStatusCommand_FormatDrain(t *testing.T) {
 
 	node.DrainStrategy.IgnoreSystemJobs = true
 	assert.Equal("true; 1970-01-01T00:00:01Z deadline; ignoring system jobs", formatDrain(node))
-}
-
-func TestNodeStatusCommand_GetDeviceResources(t *testing.T) {
-	hostStats := &api.HostStats{
-		DeviceStats: []*api.DeviceGroupStats{
-			{
-				Vendor: "vendor1",
-				Type:   "type1",
-				Name:   "name1",
-				InstanceStats: map[string]*api.DeviceStats{
-					"id1": {
-						Summary: &api.StatValue{
-							StringVal: helper.StringToPtr("stat1"),
-						},
-					},
-					"id2": {
-						Summary: &api.StatValue{
-							IntNumeratorVal: helper.Int64ToPtr(2),
-						},
-					},
-				},
-			},
-			{
-				Vendor: "vendor2",
-				Type:   "type2",
-				InstanceStats: map[string]*api.DeviceStats{
-					"id1": {
-						Summary: &api.StatValue{
-							StringVal: helper.StringToPtr("stat3"),
-						},
-					},
-					"id2": {
-						Summary: &api.StatValue{
-							IntNumeratorVal: helper.Int64ToPtr(4),
-						},
-					},
-				},
-			},
-		},
-	}
-
-	node := &api.Node{
-		NodeResources: &api.NodeResources{
-			Devices: []*api.NodeDeviceResource{
-				{
-					Vendor: "vendor2",
-					Type:   "type2",
-					Instances: []*api.NodeDevice{
-						{ID: "id1"},
-						{ID: "id2"},
-					},
-				},
-				{
-					Vendor: "vendor1",
-					Type:   "type1",
-					Name:   "name1",
-					Instances: []*api.NodeDevice{
-						{ID: "id1"},
-						{ID: "id2"},
-					},
-				},
-			},
-		},
-	}
-
-	formattedDevices := getDeviceResources(hostStats, node)
-	sort.Strings(formattedDevices)
-	expected := []string{
-		"vendor1/type1/name1[id1]|stat1",
-		"vendor1/type1/name1[id2]|2",
-		"vendor2/type2[id1]|stat3",
-		"vendor2/type2[id2]|4",
-	}
-
-	assert.Equal(t, expected, formattedDevices)
 }


### PR DESCRIPTION
In the task status, it uses the same format as `nomad node` CLI.

This change makes few compromises:

* Looks up the devices associated with tasks at look up time.  Given
that `nomad alloc status` is called rarely generally (compared to stats
telemetry and general job reporting), it seems fine.  However, the
lookup overhead grows bounded by number of `tasks x total-host-devices`,
which can be significant.

* `client.Client` performs the task devices->statistics lookup.  It
passes self to alloc/task runners so they can look up the device statistics
allocated to them.
  * Currently alloc/task runners are responsible for constructing the
entire RPC response for stats
  * The alternatives for making task runners device statistics aware
don't seem appealing (e.g. having task runners contain reference to hostStats)

* On the alloc aggregation resource usage, I did a naive merging of task device statistics.
  * Personally, I question the value of such aggregation, compared to
costs of struct duplication and bloating the response - but opted to be
consistent in the API.
  * With naive concatination, device instances from a single device group used by separate tasks in the alloc, would be aggregated in two separate device group statistics.
