### PR TITLE
Pass service metadata "external-source" for consul UI integration

### DIFF
--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -566,6 +566,10 @@ func (c *ServiceClient) RegisterAgent(role string, services []*structs.Service) 
 			Tags:    service.Tags,
 			Address: host,
 			Port:    port,
+			// This enables the consul UI to show that Nomad registered this service
+			Meta: map[string]string{
+				"external-source": "nomad",
+			},
 		}
 		ops.regServices = append(ops.regServices, serviceReg)
 
@@ -660,6 +664,10 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, t
 		Tags:    tags,
 		Address: ip,
 		Port:    port,
+		// This enables the consul UI to show that Nomad registered this service
+		Meta: map[string]string{
+			"external-source": "nomad",
+		},
 	}
 	ops.regServices = append(ops.regServices, serviceReg)
 


### PR DESCRIPTION
This lets the Consul UI show a little Nomad logo on services that Nomad registers. 

![nomad_source](https://user-images.githubusercontent.com/460133/48637836-79a3a700-e994-11e8-876e-9198466a0c4f.png)
