### PR TITLE
Fix deadlock in previous alloc watcher by emitting last alloc update

### DIFF
--- a/client/allochealth/tracker.go
+++ b/client/allochealth/tracker.go
@@ -289,7 +289,7 @@ func (t *Tracker) watchTaskEvents() {
 		select {
 		case <-t.ctx.Done():
 			return
-		case newAlloc, ok := <-t.allocUpdates.Ch:
+		case newAlloc, ok := <-t.allocUpdates.Ch():
 			if !ok {
 				return
 			}

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -128,13 +128,15 @@ func NewAllocRunner(config *Config) (*allocRunner, error) {
 		taskStateUpdatedCh:       make(chan struct{}, 1),
 		taskStateUpdateHandlerCh: make(chan struct{}),
 		deviceStatsReporter:      config.DeviceStatsReporter,
-		allocBroadcaster:         cstructs.NewAllocBroadcaster(),
 		prevAllocWatcher:         config.PrevAllocWatcher,
 		pluginSingletonLoader:    config.PluginSingletonLoader,
 	}
 
 	// Create the logger based on the allocation ID
 	ar.logger = config.Logger.Named("alloc_runner").With("alloc_id", alloc.ID)
+
+	// Create alloc broadcaster
+	ar.allocBroadcaster = cstructs.NewAllocBroadcaster(ar.logger)
 
 	// Create alloc dir
 	ar.allocDir = allocdir.NewAllocDir(ar.logger, filepath.Join(config.ClientConfig.AllocDir, alloc.ID))

--- a/client/allocrunner/health_hook_test.go
+++ b/client/allocrunner/health_hook_test.go
@@ -81,10 +81,10 @@ func TestHealthHook_PrerunDestroy(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	b := cstructs.NewAllocBroadcaster()
-	defer b.Close()
-
 	logger := testlog.HCLogger(t)
+
+	b := cstructs.NewAllocBroadcaster(logger)
+	defer b.Close()
 
 	consul := consul.NewMockConsulServiceClient(t, logger)
 	hs := &mockHealthSetter{}
@@ -120,10 +120,10 @@ func TestHealthHook_PrerunUpdateDestroy(t *testing.T) {
 
 	alloc := mock.Alloc()
 
-	b := cstructs.NewAllocBroadcaster()
+	logger := testlog.HCLogger(t)
+	b := cstructs.NewAllocBroadcaster(logger)
 	defer b.Close()
 
-	logger := testlog.HCLogger(t)
 	consul := consul.NewMockConsulServiceClient(t, logger)
 	hs := &mockHealthSetter{}
 
@@ -159,10 +159,10 @@ func TestHealthHook_UpdatePrerunDestroy(t *testing.T) {
 
 	alloc := mock.Alloc()
 
-	b := cstructs.NewAllocBroadcaster()
+	logger := testlog.HCLogger(t)
+	b := cstructs.NewAllocBroadcaster(logger)
 	defer b.Close()
 
-	logger := testlog.HCLogger(t)
 	consul := consul.NewMockConsulServiceClient(t, logger)
 	hs := &mockHealthSetter{}
 
@@ -200,10 +200,10 @@ func TestHealthHook_Destroy(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	b := cstructs.NewAllocBroadcaster()
+	logger := testlog.HCLogger(t)
+	b := cstructs.NewAllocBroadcaster(logger)
 	defer b.Close()
 
-	logger := testlog.HCLogger(t)
 	consul := consul.NewMockConsulServiceClient(t, logger)
 	hs := &mockHealthSetter{}
 
@@ -251,10 +251,9 @@ func TestHealthHook_SetHealth(t *testing.T) {
 		},
 	}
 
-	b := cstructs.NewAllocBroadcaster()
-	defer b.Close()
-
 	logger := testlog.HCLogger(t)
+	b := cstructs.NewAllocBroadcaster(logger)
+	defer b.Close()
 
 	// Don't reply on the first call
 	called := false

--- a/client/allocwatcher/alloc_watcher.go
+++ b/client/allocwatcher/alloc_watcher.go
@@ -190,11 +190,13 @@ func (p *localPrevAlloc) Wait(ctx context.Context) error {
 
 	defer p.prevListener.Close()
 
+	//TODO Check p.aloc.Terminated() here
+
 	// Block until previous alloc exits
 	p.logger.Debug("waiting for previous alloc to terminate")
 	for {
 		select {
-		case prevAlloc, ok := <-p.prevListener.Ch:
+		case prevAlloc, ok := <-p.prevListener.Ch():
 			if !ok || prevAlloc.Terminated() {
 				return nil
 			}

--- a/client/allocwatcher/alloc_watcher.go
+++ b/client/allocwatcher/alloc_watcher.go
@@ -190,7 +190,12 @@ func (p *localPrevAlloc) Wait(ctx context.Context) error {
 
 	defer p.prevListener.Close()
 
-	//TODO Check p.aloc.Terminated() here
+	// Don't bother blocking for updates from the previous alloc if it has
+	// already terminated.
+	if p.prevStatus.Terminated() {
+		p.logger.Trace("previous allocation already terminated")
+		return nil
+	}
 
 	// Block until previous alloc exits
 	p.logger.Debug("waiting for previous alloc to terminate")

--- a/client/allocwatcher/alloc_watcher_test.go
+++ b/client/allocwatcher/alloc_watcher_test.go
@@ -45,7 +45,7 @@ func newFakeAllocRunner(t *testing.T, logger hclog.Logger) *fakeAllocRunner {
 	return &fakeAllocRunner{
 		alloc:       alloc,
 		AllocDir:    allocdir.NewAllocDir(logger, path),
-		Broadcaster: cstructs.NewAllocBroadcaster(),
+		Broadcaster: cstructs.NewAllocBroadcaster(logger),
 	}
 }
 

--- a/client/structs/broadcaster.go
+++ b/client/structs/broadcaster.go
@@ -135,14 +135,14 @@ func (b *AllocBroadcaster) Listen() *AllocListener {
 
 	ch := make(chan *structs.Allocation, listenerCap)
 
-	// Broadcaster is already closed, close this listener
-	if b.closed {
-		close(ch)
-	}
-
 	// Send last update if there was one
 	if b.last != nil {
 		ch <- b.last
+	}
+
+	// Broadcaster is already closed, close this listener
+	if b.closed {
+		close(ch)
 	}
 
 	b.listeners[b.nextId] = ch

--- a/client/structs/broadcaster.go
+++ b/client/structs/broadcaster.go
@@ -140,7 +140,8 @@ func (b *AllocBroadcaster) Listen() *AllocListener {
 		ch <- b.last
 	}
 
-	// Broadcaster is already closed, close this listener
+	// Broadcaster is already closed, close this listener. Must be done
+	// after the last update was sent.
 	if b.closed {
 		close(ch)
 	}

--- a/client/structs/broadcaster.go
+++ b/client/structs/broadcaster.go
@@ -25,7 +25,7 @@ var ErrAllocBroadcasterClosed = errors.New("alloc broadcaster closed")
 type AllocBroadcaster struct {
 	mu sync.Mutex
 
-	// listeners is a map of unique ids to listener chans. laziliy
+	// listeners is a map of unique ids to listener chans. lazily
 	// initialized on first listen
 	listeners map[int]chan *structs.Allocation
 

--- a/client/structs/broadcaster_test.go
+++ b/client/structs/broadcaster_test.go
@@ -181,7 +181,7 @@ func TestAllocBroadcaster_PrimeListener(t *testing.T) {
 	case recv := <-l.Ch():
 		require.Equal(t, alloc, recv)
 	case <-time.After(10 * time.Millisecond):
-		t.Fatalf("expected to recieve initial value")
+		t.Fatalf("expected to receive initial value")
 	}
 }
 
@@ -207,7 +207,7 @@ func TestAllocBroadcaster_Closed(t *testing.T) {
 	case recv := <-l.Ch():
 		require.Equal(t, alloc, recv)
 	case <-time.After(10 * time.Millisecond):
-		t.Fatalf("expected to recieve initial value")
+		t.Fatalf("expected to receive initial value")
 	}
 
 	// Ch should now be closed.


### PR DESCRIPTION
Fixes a deadlock where the allocwatcher would block forever waiting for
an update from a terminal alloc.

Made the broadcaster easier to debug as well.

Relies on #4883 