### PR TITLE
Move current telemetry page to docs

### DIFF
--- a/website/source/docs/telemetry/index.html.md
+++ b/website/source/docs/telemetry/index.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "guides"
+layout: "docs"
 page_title: "Telemetry"
-sidebar_current: "guides-operations-monitoring-telemetry"
+sidebar_current: "docs-telemetry"
 description: |-
   Learn about the telemetry data available in Nomad.
 ---

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -436,6 +436,10 @@
         <a href="/docs/runtime/environment.html">Runtime Environment</a>
       </li>
       
+      <li<%= sidebar_current("docs-telemetry") %>>
+        <a href="/docs/telemetry/index.html">Telemetry</a>
+      </li>
+
       <li<%= sidebar_current("docs-variable-interpolation") %>>
         <a href="/docs/runtime/interpolation.html">Variable Interpolation</a>
       </li>


### PR DESCRIPTION
The telemetry docs page is present in the master branch in the guides section but invisible because it is not listed in any navigation menu. Moving this content to the docs section and giving it visibility by adding it in the navigation bar.