### PR TITLE
Nomad client Authentication

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -52,6 +52,7 @@ type ACL struct {
 	wildcardNamespaces *iradix.Tree
 
 	agent    string
+	nodeRPC  string
 	node     string
 	operator string
 	quota    string
@@ -134,6 +135,9 @@ func NewACL(management bool, policies []*Policy) (*ACL, error) {
 		}
 		if policy.Node != nil {
 			acl.node = maxPrivilege(acl.node, policy.Node.Policy)
+		}
+		if policy.NodeRPC != nil {
+			acl.nodeRPC = maxPrivilege(acl.nodeRPC, policy.NodeRPC.Policy)
 		}
 		if policy.Operator != nil {
 			acl.operator = maxPrivilege(acl.operator, policy.Operator.Policy)
@@ -310,6 +314,32 @@ func (a *ACL) AllowNodeWrite() bool {
 	case a.management:
 		return true
 	case a.node == PolicyWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+// AllowNodeRead checks if read operations are allowed for a node
+func (a *ACL) AllowNodeRPCRead() bool {
+	switch {
+	case a.management:
+		return true
+	case a.nodeRPC == PolicyWrite:
+		return true
+	case a.nodeRPC == PolicyRead:
+		return true
+	default:
+		return false
+	}
+}
+
+// AllowNodeWrite checks if write operations are allowed for a node
+func (a *ACL) AllowNodeRPCWrite() bool {
+	switch {
+	case a.management:
+		return true
+	case a.nodeRPC == PolicyWrite:
 		return true
 	default:
 		return false

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -81,6 +81,8 @@ func TestACLManagement(t *testing.T) {
 	assert.True(acl.AllowAgentWrite())
 	assert.True(acl.AllowNodeRead())
 	assert.True(acl.AllowNodeWrite())
+	assert.True(acl.AllowNodeRPCRead())
+	assert.True(acl.AllowNodeRPCWrite())
 	assert.True(acl.AllowOperatorRead())
 	assert.True(acl.AllowOperatorWrite())
 	assert.True(acl.AllowQuotaRead())
@@ -113,6 +115,8 @@ func TestACLMerge(t *testing.T) {
 	assert.True(acl.AllowAgentWrite())
 	assert.True(acl.AllowNodeRead())
 	assert.True(acl.AllowNodeWrite())
+	assert.True(acl.AllowNodeRPCRead())
+	assert.True(acl.AllowNodeRPCWrite())
 	assert.True(acl.AllowOperatorRead())
 	assert.True(acl.AllowOperatorWrite())
 	assert.True(acl.AllowQuotaRead())
@@ -137,6 +141,8 @@ func TestACLMerge(t *testing.T) {
 	assert.False(acl.AllowAgentWrite())
 	assert.True(acl.AllowNodeRead())
 	assert.False(acl.AllowNodeWrite())
+	assert.True(acl.AllowNodeRPCRead())
+	assert.False(acl.AllowNodeRPCWrite())
 	assert.True(acl.AllowOperatorRead())
 	assert.False(acl.AllowOperatorWrite())
 	assert.True(acl.AllowQuotaRead())
@@ -161,6 +167,8 @@ func TestACLMerge(t *testing.T) {
 	assert.False(acl.AllowAgentWrite())
 	assert.False(acl.AllowNodeRead())
 	assert.False(acl.AllowNodeWrite())
+	assert.False(acl.AllowNodeRPCRead())
+	assert.False(acl.AllowNodeRPCWrite())
 	assert.False(acl.AllowOperatorRead())
 	assert.False(acl.AllowOperatorWrite())
 	assert.False(acl.AllowQuotaRead())
@@ -175,6 +183,9 @@ agent {
 	policy = "read"
 }
 node {
+	policy = "read"
+}
+noderpc {
 	policy = "read"
 }
 operator {
@@ -195,6 +206,9 @@ agent {
 node {
 	policy = "write"
 }
+noderpc {
+	policy = "write"
+}
 operator {
 	policy = "write"
 }
@@ -211,6 +225,9 @@ agent {
 	policy = "deny"
 }
 node {
+	policy = "deny"
+}
+noderpc {
 	policy = "deny"
 }
 operator {

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -43,6 +43,7 @@ type Policy struct {
 	Namespaces []*NamespacePolicy `hcl:"namespace,expand"`
 	Agent      *AgentPolicy       `hcl:"agent"`
 	Node       *NodePolicy        `hcl:"node"`
+	NodeRPC    *NodeRPCPolicy     `hcl:"noderpc"`
 	Operator   *OperatorPolicy    `hcl:"operator"`
 	Quota      *QuotaPolicy       `hcl:"quota"`
 	Raw        string             `hcl:"-"`
@@ -54,6 +55,7 @@ func (p *Policy) IsEmpty() bool {
 	return len(p.Namespaces) == 0 &&
 		p.Agent == nil &&
 		p.Node == nil &&
+		p.NodeRPC == nil &&
 		p.Operator == nil &&
 		p.Quota == nil
 }
@@ -70,6 +72,10 @@ type AgentPolicy struct {
 }
 
 type NodePolicy struct {
+	Policy string
+}
+
+type NodeRPCPolicy struct {
 	Policy string
 }
 
@@ -184,6 +190,10 @@ func Parse(rules string) (*Policy, error) {
 
 	if p.Node != nil && !isPolicyValid(p.Node.Policy) {
 		return nil, fmt.Errorf("Invalid node policy: %#v", p.Node)
+	}
+
+	if p.NodeRPC != nil && !isPolicyValid(p.NodeRPC.Policy) {
+		return nil, fmt.Errorf("Invalid nodeRPC policy: %#v", p.Node)
 	}
 
 	if p.Operator != nil && !isPolicyValid(p.Operator.Policy) {

--- a/client/client.go
+++ b/client/client.go
@@ -1505,8 +1505,11 @@ func (c *Client) submitNodeEvents(events []*structs.NodeEvent) error {
 		nodeID: events,
 	}
 	req := structs.EmitNodeEventsRequest{
-		NodeEvents:   nodeEvents,
-		WriteRequest: structs.WriteRequest{Region: c.Region()},
+		NodeEvents: nodeEvents,
+		WriteRequest: structs.WriteRequest{
+			Region:    c.Region(),
+			AuthToken: c.AuthToken(),
+		},
 	}
 	var resp structs.EmitNodeEventsResponse
 	if err := c.RPC("Node.EmitEvents", &req, &resp); err != nil {
@@ -1588,8 +1591,11 @@ func (c *Client) retryRegisterNode() {
 func (c *Client) registerNode() error {
 	node := c.Node()
 	req := structs.NodeRegisterRequest{
-		Node:         node,
-		WriteRequest: structs.WriteRequest{Region: c.Region()},
+		Node: node,
+		WriteRequest: structs.WriteRequest{
+			Region:    c.Region(),
+			AuthToken: c.AuthToken(),
+		},
 	}
 	var resp structs.NodeUpdateResponse
 	if err := c.RPC("Node.Register", &req, &resp); err != nil {
@@ -1618,9 +1624,12 @@ func (c *Client) registerNode() error {
 func (c *Client) updateNodeStatus() error {
 	start := time.Now()
 	req := structs.NodeUpdateStatusRequest{
-		NodeID:       c.NodeID(),
-		Status:       structs.NodeStatusReady,
-		WriteRequest: structs.WriteRequest{Region: c.Region()},
+		NodeID: c.NodeID(),
+		Status: structs.NodeStatusReady,
+		WriteRequest: structs.WriteRequest{
+			Region:    c.Region(),
+			AuthToken: c.AuthToken(),
+		},
 	}
 	var resp structs.NodeUpdateResponse
 	if err := c.RPC("Node.UpdateStatus", &req, &resp); err != nil {
@@ -1747,8 +1756,11 @@ func (c *Client) allocSync() {
 
 			// Send to server.
 			args := structs.AllocUpdateRequest{
-				Alloc:        sync,
-				WriteRequest: structs.WriteRequest{Region: c.Region()},
+				Alloc: sync,
+				WriteRequest: structs.WriteRequest{
+					Region:    c.Region(),
+					AuthToken: c.AuthToken(),
+				},
 			}
 
 			var resp structs.GenericResponse

--- a/client/client.go
+++ b/client/client.go
@@ -640,6 +640,11 @@ func (c *Client) secretNodeID() string {
 	return c.config.Node.SecretID
 }
 
+// AuthToken returns the ACL token for client RPC authentication
+func (c *Client) AuthToken() string {
+	return c.config.Node.Token
+}
+
 // RPCMajorVersion returns the structs.ApiMajorVersion supported by the
 // client.
 func (c *Client) RPCMajorVersion() int {

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -188,6 +188,9 @@ type Config struct {
 	// ACLEnabled controls if ACL enforcement and management is enabled.
 	ACLEnabled bool
 
+	// ACLEnforceNode controls if ACL enforcement on node rpc is enabled.
+	ACLEnforceNode bool
+
 	// ACLTokenTTL is how long we cache token values for
 	ACLTokenTTL time.Duration
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -471,6 +471,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	conf.Node.Name = agentConfig.NodeName
 	conf.Node.Meta = agentConfig.Client.Meta
 	conf.Node.NodeClass = agentConfig.Client.NodeClass
+	conf.Node.Token = agentConfig.Client.Token
 
 	// Set up the HTTP advertise address
 	conf.Node.HTTPAddr = agentConfig.AdvertiseAddrs.HTTP

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -192,6 +192,9 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	if agentConfig.ACL.Enabled {
 		conf.ACLEnabled = true
 	}
+	if agentConfig.ACL.EnforceNode {
+		conf.ACLEnforceNode = true
+	}
 	if agentConfig.ACL.ReplicationToken != "" {
 		conf.ReplicationToken = agentConfig.ACL.ReplicationToken
 	}
@@ -528,6 +531,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 
 	// Setup the ACLs
 	conf.ACLEnabled = agentConfig.ACL.Enabled
+	conf.ACLEnforceNode = agentConfig.ACL.EnforceNode
 	conf.ACLTokenTTL = agentConfig.ACL.TokenTTL
 	conf.ACLPolicyTTL = agentConfig.ACL.PolicyTTL
 

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -70,6 +70,9 @@ func TestAgent_ServerConfig(t *testing.T) {
 	if !out.ACLEnabled {
 		t.Fatalf("ACL not enabled")
 	}
+	if out.ACLEnforceNode {
+		t.Fatalf("ACLEnforceNode should be disabled by default")
+	}
 
 	// Assert addresses weren't changed
 	if addr := conf.AdvertiseAddrs.RPC; addr != "127.0.0.1:4001" {

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -98,6 +98,7 @@ func (c *Command) readConfig() *Config {
 	flags.StringVar(&cmdConfig.Client.StateDir, "state-dir", "", "")
 	flags.StringVar(&cmdConfig.Client.AllocDir, "alloc-dir", "", "")
 	flags.StringVar(&cmdConfig.Client.NodeClass, "node-class", "", "")
+	flags.StringVar(&cmdConfig.Client.Token, "token", "", "")
 	flags.StringVar(&servers, "servers", "", "")
 	flags.Var((*flaghelper.StringFlag)(&meta), "meta", "")
 	flags.StringVar(&cmdConfig.Client.NetworkInterface, "network-interface", "", "")
@@ -1227,6 +1228,9 @@ Client Options:
   -node-class
     Mark this node as a member of a node-class. This can be used to label
     similar node types.
+
+  -token
+    The SecretID of an ACL token to use to authenticate RPC requests with server
 
   -meta
     User specified metadata to associated with the node. Each instance of -meta

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -254,6 +254,9 @@ type ACLConfig struct {
 	// Enabled controls if we are enforce and manage ACLs
 	Enabled bool `hcl:"enabled"`
 
+	// Enabled controls if we are enforce ACL on nodes
+	EnforceNode bool `hcl:"enforce_node"`
+
 	// TokenTTL controls how long we cache ACL tokens. This controls
 	// how stale they can be when we are enforcing policies. Defaults
 	// to "30s". Reducing this impacts performance by forcing more
@@ -706,9 +709,10 @@ func DefaultConfig() *Config {
 			},
 		},
 		ACL: &ACLConfig{
-			Enabled:   false,
-			TokenTTL:  30 * time.Second,
-			PolicyTTL: 30 * time.Second,
+			Enabled:     false,
+			EnforceNode: false,
+			TokenTTL:    30 * time.Second,
+			PolicyTTL:   30 * time.Second,
 		},
 		SyslogFacility: "LOCAL0",
 		Telemetry: &Telemetry{
@@ -1086,6 +1090,9 @@ func (a *ACLConfig) Merge(b *ACLConfig) *ACLConfig {
 
 	if b.Enabled {
 		result.Enabled = true
+	}
+	if b.EnforceNode {
+		result.EnforceNode = false
 	}
 	if b.TokenTTL != 0 {
 		result.TokenTTL = b.TokenTTL

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1098,7 +1098,7 @@ func (a *ACLConfig) Merge(b *ACLConfig) *ACLConfig {
 		result.Enabled = true
 	}
 	if b.EnforceNode {
-		result.EnforceNode = false
+		result.EnforceNode = true
 	}
 	if b.TokenTTL != 0 {
 		result.TokenTTL = b.TokenTTL

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -172,6 +172,9 @@ type ClientConfig struct {
 	// NodeClass is used to group the node by class
 	NodeClass string `hcl:"node_class"`
 
+	// The SecretID of an ACL token to use to authenticate RPC requests
+	Token string `mapstructure:"token"`
+
 	// Options is used for configuration of nomad internals,
 	// like fingerprinters and drivers. The format is:
 	//
@@ -256,6 +259,9 @@ type ACLConfig struct {
 
 	// Enabled controls if we are enforce ACL on nodes
 	EnforceNode bool `hcl:"enforce_node"`
+
+	// Node HCL token
+	Token string `hcl:"token" json:"-"`
 
 	// TokenTTL controls how long we cache ACL tokens. This controls
 	// how stale they can be when we are enforcing policies. Defaults
@@ -1223,6 +1229,9 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 	if b.NodeClass != "" {
 		result.NodeClass = b.NodeClass
+	}
+	if b.Token != "" {
+		result.Token = b.Token
 	}
 	if b.NetworkInterface != "" {
 		result.NetworkInterface = b.NetworkInterface

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -119,6 +119,7 @@ var basicConfig = &Config{
 	},
 	ACL: &ACLConfig{
 		Enabled:          true,
+		EnforceNode:      true,
 		TokenTTL:         60 * time.Second,
 		TokenTTLHCL:      "60s",
 		PolicyTTL:        60 * time.Second,

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -120,6 +120,7 @@ var basicConfig = &Config{
 	ACL: &ACLConfig{
 		Enabled:          true,
 		EnforceNode:      true,
+		Token:            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		TokenTTL:         60 * time.Second,
 		TokenTTLHCL:      "60s",
 		PolicyTTL:        60 * time.Second,

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -118,6 +118,7 @@ func TestConfig_Merge(t *testing.T) {
 		},
 		ACL: &ACLConfig{
 			Enabled:          true,
+			EnforceNode:      false,
 			TokenTTL:         60 * time.Second,
 			PolicyTTL:        60 * time.Second,
 			ReplicationToken: "foo",

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -287,6 +287,7 @@ func TestConfig_Merge(t *testing.T) {
 		},
 		ACL: &ACLConfig{
 			Enabled:          true,
+			EnforceNode:      true,
 			TokenTTL:         20 * time.Second,
 			PolicyTTL:        20 * time.Second,
 			ReplicationToken: "foobar",

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -126,6 +126,7 @@ server {
 
 acl {
   enabled           = true
+	enforce_node      = true
   token_ttl         = "60s"
   policy_ttl        = "60s"
   replication_token = "foobar"

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -127,6 +127,7 @@ server {
 acl {
   enabled           = true
 	enforce_node      = true
+	token             = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
   token_ttl         = "60s"
   policy_ttl        = "60s"
   replication_token = "foobar"

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -2,6 +2,7 @@
   "acl": [
     {
       "enabled": true,
+      "enforce_node": true,
       "policy_ttl": "60s",
       "replication_token": "foobar",
       "token_ttl": "60s"

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -3,6 +3,7 @@
     {
       "enabled": true,
       "enforce_node": true,
+      "token": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
       "policy_ttl": "60s",
       "replication_token": "foobar",
       "token_ttl": "60s"

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -258,6 +258,9 @@ type Config struct {
 	// ACLEnabled controls if ACL enforcement and management is enabled.
 	ACLEnabled bool
 
+	// ACLEnforceNode controls if ACL enforced on node endpoints
+	ACLEnforceNode bool
+
 	// ReplicationBackoff is how much we backoff when replication errors.
 	// This is a tunable knob for testing primarily.
 	ReplicationBackoff time.Duration

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1542,6 +1542,9 @@ type Node struct {
 	// together for the purpose of determining scheduling pressure.
 	NodeClass string
 
+	// The SecretID of an ACL token to use to authenticate RPC requests
+	Token string
+
 	// ComputedClass is a unique id that identifies nodes with a common set of
 	// attributes and capabilities.
 	ComputedClass string


### PR DESCRIPTION
We allow external customers to connect to our nomad servers, but we would like to have a measure of control who is allowed to connect to the cluster, similar to existing ACL authorization.
This is somewhat an extension of #227 

This PR extends the existing ACL to cover node register endpoint

- `enforce_node` in ACL stanza enables the ACL enforcement on nomad clients(false by default)
- New policy type `noderpc:write` is needed for the client to connect
- Flag `token` used to pass ACL secret token to the client
