### PR TITLE
vault: fix panic by checking for nil secret

### DIFF
--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -547,6 +547,11 @@ func (v *vaultClient) renew() error {
 	if err != nil {
 		return err
 	}
+	if secret == nil {
+		// It's possible for RenewSelf to return (nil, nil) if the
+		// response body from Vault is empty.
+		return fmt.Errorf("renewal failed: empty response from vault")
+	}
 
 	auth := secret.Auth
 	if auth == nil {


### PR DESCRIPTION
Vault's RenewSelf(...) API may return (nil, nil). We failed to check if
secret was nil before attempting to use it.

RenewSelf:
https://github.com/hashicorp/vault/blob/e3eee5b4fb386418d10b6a248252ec6e2e05d980/api/auth_token.go#L138-L155

Calls ParseSecret:
https://github.com/hashicorp/vault/blob/e3eee5b4fb386418d10b6a248252ec6e2e05d980/api/secret.go#L309-L311

If anyone has an idea on how to test this I didn't see any options. We
use a real Vault service, so there's no opportunity to mock the
response.