### PR TITLE
Add Client Metadata API

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -26,6 +26,9 @@ const (
 	// ErrInvalidMethod is used if the HTTP method is not supported
 	ErrInvalidMethod = "Invalid method"
 
+	// ErrUnprocessibleBody is used if the HTTP body could not be decoded.
+	ErrUnprocessibleBody = "Unprocessible body"
+
 	// ErrEntOnly is the error returned if accessing an enterprise only
 	// endpoint
 	ErrEntOnly = "Nomad Enterprise only endpoint"

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -2,6 +2,7 @@ package nomad
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -47,6 +48,8 @@ const (
 	// reregistered by the heartbeat.
 	NodeHeartbeatEventReregistered = "Node reregistered by heartbeat"
 )
+
+var errNodeNotFound = errors.New("node not found")
 
 // Node endpoint is used for client interactions
 type Node struct {
@@ -276,7 +279,7 @@ func (n *Node) Deregister(args *structs.NodeDeregisterRequest, reply *structs.No
 		return err
 	}
 	if node == nil {
-		return fmt.Errorf("node not found")
+		return errNodeNotFound
 	}
 
 	// Commit this update via Raft
@@ -354,7 +357,7 @@ func (n *Node) UpdateStatus(args *structs.NodeUpdateStatusRequest, reply *struct
 		return err
 	}
 	if node == nil {
-		return fmt.Errorf("node not found")
+		return errNodeNotFound
 	}
 
 	// We have a valid node connection, so add the mapping to cache the
@@ -481,7 +484,7 @@ func (n *Node) UpdateDrain(args *structs.NodeUpdateDrainRequest,
 		return err
 	}
 	if node == nil {
-		return fmt.Errorf("node not found")
+		return errNodeNotFound
 	}
 
 	// COMPAT: Remove in 0.9. Attempt to upgrade the request if it is of the old
@@ -576,7 +579,7 @@ func (n *Node) UpdateEligibility(args *structs.NodeUpdateEligibilityRequest,
 		return err
 	}
 	if node == nil {
-		return fmt.Errorf("node not found")
+		return errNodeNotFound
 	}
 
 	if node.DrainStrategy != nil && args.Eligibility == structs.NodeSchedulingEligible {
@@ -659,7 +662,7 @@ func (n *Node) Evaluate(args *structs.NodeEvaluateRequest, reply *structs.NodeUp
 		return err
 	}
 	if node == nil {
-		return fmt.Errorf("node not found")
+		return errNodeNotFound
 	}
 
 	// Create the evaluation

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -330,6 +330,13 @@ func (n *Node) UpdateMetadata(args *structs.NodePatchMetadataRequest, reply *str
 	}
 	defer metrics.MeasureSince([]string{"nomad", "client", "update_metadata"}, time.Now())
 
+	// Check node write permissions
+	if aclObj, err := n.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeWrite() {
+		return structs.ErrPermissionDenied
+	}
+
 	// Verify the arguments
 	if args.NodeID == "" {
 		return fmt.Errorf("missing node ID for client metadata update")
@@ -373,6 +380,13 @@ func (n *Node) ReplaceMetadata(args *structs.NodeReplaceMetadataRequest, reply *
 		return err
 	}
 	defer metrics.MeasureSince([]string{"nomad", "client", "replace_metadata"}, time.Now())
+
+	// Check node write permissions
+	if aclObj, err := n.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeWrite() {
+		return structs.ErrPermissionDenied
+	}
 
 	// Verify the arguments
 	if args.NodeID == "" {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -712,7 +712,7 @@ func (s *StateStore) UpdateNodeMetadata(index uint64, nodeID string, upserts map
 	// Update the metadata in the copy
 	for k, v := range upserts {
 		if _, ok := copyNode.Meta[k]; ok {
-			s.logger.Info("overwiting metadata value for key:", k)
+			s.logger.Info("overwriting node metadata", "node", nodeID, "key", k)
 		}
 		copyNode.Meta[k] = v
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -54,6 +54,8 @@ const (
 	NodeRegisterRequestType MessageType = iota
 	NodeDeregisterRequestType
 	NodeUpdateStatusRequestType
+	NodePatchMetadataRequestType
+	NodeReplaceMetadataRequestType
 	NodeUpdateDrainRequestType
 	JobRegisterRequestType
 	JobDeregisterRequestType
@@ -345,6 +347,36 @@ type NodeServerInfo struct {
 type NodeUpdateStatusRequest struct {
 	NodeID    string
 	Status    string
+	NodeEvent *NodeEvent
+	WriteRequest
+}
+
+// NodePatchMetadataRequest is used for adding or removing metadata keys for
+// a given client node.
+type NodePatchMetadataRequest struct {
+	NodeID string
+
+	// Upserts is a mapping of new or updated metadata keys to their values
+	Upserts map[string]string
+
+	// Deletes is a slice of metadata keys that should be removed.
+	Deletes []string
+
+	NodeEvent *NodeEvent
+	WriteRequest
+}
+
+// NodeReplaceMetadataRequest is used for doing a wholesale replacement of
+// metadata on a client node.
+type NodeReplaceMetadataRequest struct {
+	NodeID   string
+	Metadata map[string]string
+
+	// ModifyIndex stores the modify indexes of this configuration.
+	ModifyIndex uint64
+	// CAS controls whether to use check-and-set semantics for this request.
+	CAS bool
+
 	NodeEvent *NodeEvent
 	WriteRequest
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1010,6 +1010,13 @@ type NodeUpdateResponse struct {
 	QueryMeta
 }
 
+// NodeMetadataUpdateResponse is used to respond to a node metadata update
+type NodeMetadataUpdateResponse struct {
+	NodeModifyIndex uint64
+	Updated         bool
+	WriteMeta
+}
+
 // NodeDrainUpdateResponse is used to respond to a node drain update
 type NodeDrainUpdateResponse struct {
 	NodeModifyIndex uint64

--- a/website/source/api/nodes.html.md
+++ b/website/source/api/nodes.html.md
@@ -755,6 +755,91 @@ $ curl \
 
 ```
 
+## Set Metadata
+
+This endpoint replaces the metadata of the node. Updating metadata will not
+trigger new evaluations of existing allocations on the node.
+
+| Method  | Path                         | Produces                   |
+| ------- | ---------------------------- | -------------------------- |
+| `PUT` | `/v1/node/:node_id/metadata` | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries) and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | ACL Required       |
+| ---------------- | ------------------ |
+| `NO`             | `node:write`       |
+
+### Parameters
+
+- `:node_id` `(string: <required>)`- Specifies the UUID of the node. This must
+  be the full UUID, not the short 8-character one. This is specified as part of
+  the path.
+
+- `Metadata` `(object: <required>)` - A map of string key, values that the node
+  metadata should be set to. This is provided as part of the body.
+
+- `cas` `(int: <optional>)` - If provided, the update will be applied with a
+   a Check-And-Set operation. The update will only happen if the given index
+   matches the `ModifyIndex` of the Node when the update is being applied. The
+   `Updated` parameter in the response will be `false` if the update could not
+   be applied.
+
+### Sample Request
+
+```bash
+curl -X PUT localhost:4646/v1/node/e7205a5c-345c-8066-a095-6cb77092f0aa/metadata \
+  -d '{"Metadata": {"key":"value"}}' | jq
+{
+  "Index": 24,
+  "NodeModifyIndex": 24,
+  "Updated": true
+}
+```
+
+## Update Metadata
+
+This endpoint replaces the metadata of the node. Updating metadata will not
+trigger new evaluations of existing allocations on the node.
+
+| Method  | Path                         | Produces                   |
+| ------- | ---------------------------- | -------------------------- |
+| `PATCH` | `/v1/node/:node_id/metadata` | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries) and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | ACL Required       |
+| ---------------- | ------------------ |
+| `NO`             | `node:write`       |
+
+### Parameters
+
+- `:node_id` `(string: <required>)`- Specifies the UUID of the node. This must
+  be the full UUID, not the short 8-character one. This is specified as part of
+  the path.
+
+- `Upserts` `(object: <optional>)` - A map of string key, values that the node
+  metadata should have inserted or updated. This is provided as part of the body.
+
+- `Deletes` `(array: <optional>)` - An array of string keys that the node
+  metadata should have removed. This is provided as part of the body.
+
+### Sample Request
+
+```bash
+curl -X PUT localhost:4646/v1/node/e7205a5c-345c-8066-a095-6cb77092f0aa/metadata \
+  -d '{"Upserts": {"key":"value"}, "Deletes": ["some-other-key"]}' | jq
+{
+  "Index": 25,
+  "NodeModifyIndex": 25,
+  "Updated": true
+}
+```
+
 ## Drain Node
 
 This endpoint toggles the drain mode of the node. When draining is enabled, no


### PR DESCRIPTION
This PR adds the API and necessary underlying machinery to dynamically
update the metadata associated with a Client.

This will enable third-party tools to update client metadata based on dynamic
factors (such as the locality of volumes), for use with Affinites and
Constraints.

## PATCH /v1/node/nodeid/metadata

The API exposes `Upserts` and `Deletes` rather than a wholesale map
replacement as it is intended for multiple tools to write against the
API, and it allows greater concurrency with less risk of tools racing
against each other.

Example Usage:

```
[nomad(f-client-metadata)] $ curl -X PATCH localhost:4646/v1/node/e7205a5c-345c-8066-a095-6cb77092f0aa/metadata -d "{\"Upserts\": {\"key\":\"value\"}}" | jq
{
  "Index": 22,
  "NodeModifyIndex": 22,
  "Updated": true
}
[nomad(f-client-metadata)] $ curl -X PATCH localhost:4646/v1/node/e7205a5c-345c-8066-a095-6cb77092f0aa/metadata -d "{\"Upserts\": {\"foo\":\"bar\"}}" | jq
{
  "Index": 23,
  "NodeModifyIndex": 23,
  "Updated": true
}
[nomad(f-client-metadata)] $ curl localhost:4646/v1/node/e7205a5c-345c-8066-a095-6cb77092f0aa | jq '.Meta'
{
  "key": "value",
  "foo": "bar",
}
```

## PUT /v1/node/nodeid/metadata

This API exposes a wholesale replacement and optionally allows the use of compare-and-set semantics using the node ModifyIndex. While being more flexible, it is more complicated when used in e.g simple bash scripts.

Example Usage:

```
[nomad(f-client-metadata)] $ curl -X PUT localhost:4646/v1/node/e7205a5c-345c-8066-a095-6cb77092f0aa/metadata -d "{\"Metadata\": {\"key\":\"value\"}}" | jq
{
  "Index": 24,
  "NodeModifyIndex": 24,
  "Updated": true
}
[nomad(f-client-metadata)] $ curl localhost:4646/v1/node/e7205a5c-345c-8066-a095-6cb77092f0aa | jq '.Meta'
{
  "key": "value"
}
```