### PR TITLE
Add support for docker storage options

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -263,6 +263,7 @@ var (
 		"readonly_rootfs": hclspec.NewAttr("readonly_rootfs", "bool", false),
 		"security_opt":    hclspec.NewAttr("security_opt", "list(string)", false),
 		"shm_size":        hclspec.NewAttr("shm_size", "number", false),
+		"storage_opt":     hclspec.NewBlockAttrs("storage_opt", "string", false),
 		"sysctl":          hclspec.NewBlockAttrs("sysctl", "string", false),
 		"tty":             hclspec.NewAttr("tty", "bool", false),
 		"ulimit":          hclspec.NewBlockAttrs("ulimit", "string", false),
@@ -319,6 +320,7 @@ type TaskConfig struct {
 	ReadonlyRootfs    bool              `codec:"readonly_rootfs"`
 	SecurityOpt       []string          `codec:"security_opt"`
 	ShmSize           int64             `codec:"shm_size"`
+	StorageOpt        map[string]string `codec:"storage_opt"`
 	Sysctl            map[string]string `codec:"sysctl"`
 	TTY               bool              `codec:"tty"`
 	Ulimit            map[string]string `codec:"ulimit"`

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -627,6 +627,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		// used to share data between different tasks in the same task group.
 		Binds: binds,
 
+		StorageOpt:   driverConfig.StorageOpt,
 		VolumeDriver: driverConfig.VolumeDriver,
 
 		PidsLimit: driverConfig.PidsLimit,

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1122,6 +1122,25 @@ func TestDockerDriver_SecurityOpt(t *testing.T) {
 	require.Exactly(t, cfg.SecurityOpt, container.HostConfig.SecurityOpt)
 }
 
+func TestDockerDriver_CreateContainerConfig(t *testing.T) {
+	t.Parallel()
+
+	task, cfg, _ := dockerTask(t)
+	opt := map[string]string{"size": "120G"}
+
+	cfg.StorageOpt = opt
+	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
+
+	dh := dockerDriverHarness(t, nil)
+	driver := dh.Impl().(*Driver)
+
+	c, err := driver.createContainerConfig(task, cfg, "org/repo:0.1")
+	require.NoError(t, err)
+
+	require.Equal(t, "org/repo:0.1", c.Config.Image)
+	require.EqualValues(t, opt, c.HostConfig.StorageOpt)
+}
+
 func TestDockerDriver_Capabilities(t *testing.T) {
 	if !tu.IsTravis() {
 		t.Parallel()

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -227,6 +227,19 @@ The `docker` driver supports the following configuration in the job spec.  Only
 
 * `shm_size` - (Optional) The size (bytes) of /dev/shm for the container.
 
+* `storage_opt` - (Optional) A key-value map of storage options set to the containers on start.
+  This overrides the [host dockerd configuration](https://docs.docker.com/engine/reference/commandline/dockerd/#options-per-storage-driver).
+  For example:
+
+
+    ```hcl
+    config {
+      storage_opt = {
+        size = "40G"
+      }
+    }
+    ```
+
 * `SSL` - (Optional) If this is set to true, Nomad uses SSL to talk to the
   repository. The default value is `true`. **Deprecated as of 0.5.3**
 


### PR DESCRIPTION
Add support for `--storage-opts` flags.

Making this PR targeting https://github.com/hashicorp/nomad/pull/4844 - to ease review, we can merge it into the PR or review it and merge it after the docker plugin PR is merged.