### PR TITLE
taskrunner: Return the restart delay correctly

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -457,7 +457,7 @@ func (tr *TaskRunner) shouldRestart() (bool, time.Duration) {
 	case structs.TaskRestarting:
 		tr.logger.Info("restarting task", "reason", reason, "delay", when)
 		tr.UpdateState(structs.TaskStatePending, structs.NewTaskEvent(structs.TaskRestarting).SetRestartDelay(when).SetRestartReason(reason))
-		return true, 0
+		return true, when
 	default:
 		tr.logger.Error("restart tracker returned unknown state", "state", state)
 		return true, when


### PR DESCRIPTION
We were incorrectly returning a 0 duration to the taskrunner when
determining when a task should restart. This would cause tasks to be
restarted immediately, ignoring the restart {} stanza in a users
configuration.

This commit causes us to return the restart duration to the task runner
so it may correctly delay further execution.

It looks like these code branches have no real tests, and I'm not sure how to write one for it. I'm open to suggestions though.

Repro Steps
============

1) `$ nomad agent -dev`
2) Create the following as test-case.nomad
```hcl
job "sleep" {
  datacenters = ["dc1"]
  type = "batch"

  group "test" {
    count = 1
    task "test" {
      driver = "raw_exec"
      config {
        command = "sleep"
        args = ["5000"]
      }
    }
  }
}
```

3) `$ nomad run test-case.nomad`
4) Extract the alloc id from `$ nomad status sleep`
5) `$ pkill sleep`
6) `$ nomad status $alloc-id`
7) Observe the task events and see that the job was correctly delayed.