### PR TITLE
add alicloud example for provisioning nomad cluster

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,6 +27,7 @@ Azure CLI.
 
 - Follow the steps [here](aws/README.md) to provision a cluster on AWS.
 - Follow the steps [here](azure/README.md) to provision a cluster on Azure.
+- Follow the steps [here](alicloud/README.md) to provision a cluster on Alicloud.
 
 Continue with the steps below after a cluster has been provisioned.
 

--- a/terraform/Vagrantfile
+++ b/terraform/Vagrantfile
@@ -51,6 +51,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.synced_folder "aws/", "/home/vagrant/aws", owner: "vagrant", group: "vagrant"
   config.vm.synced_folder "azure/", "/home/vagrant/azure", owner: "vagrant", group: "vagrant"
+  config.vm.synced_folder "alicloud/", "/home/vagrant/alicloud", owner: "vagrant", group: "vagrant"
   config.vm.synced_folder "shared/", "/home/vagrant/shared", owner: "vagrant", group: "vagrant"
   config.vm.synced_folder "examples/", "/home/vagrant/examples", owner: "vagrant", group: "vagrant"
 

--- a/terraform/alicloud/README.md
+++ b/terraform/alicloud/README.md
@@ -1,0 +1,99 @@
+# Provision a Nomad cluster on Alicloud
+
+## Pre-requisites
+
+To get started, create the following:
+
+- Alicloud account
+- [API access keys](https://www.alibabacloud.com/help/doc-detail/29009.htm)
+
+## Set the Alicloud environment variables
+
+Set up service endpoint of your region to prevent TLS timeout error.
+
+[Service endpoint in your region](https://www.alibabacloud.com/help/doc-detail/29008.html?spm=a2c5t.11065259.1996646101.searchclickresult.76165207ngmXar)
+```bash
+$ export ECS_ENDPOINT=[Service endpoint(ecs.us-east-1.aliyuncs.com)] 
+$ export TF_VAR_access_key=[ALICLOUD_ACCESS_KEY]
+$ export TF_VAR_secret_key=[ALICLOUD_SECRET_KEY]
+```
+
+The reason I don't use ALICLOUD_ACCESS_KEY and ALICLOUD_SECRET_KEY is because access_key and secret_key are used in retry_join local variable and you cannot simply access the two ALICLOUD environment variables in the configuration.
+
+The role that holds the key must have the full access to ecs, ram, vpc, eip and kms.
+
+## Build an Alicloud machine image with Packer
+
+Before building a image, you may have not signed up for the alicloud snapshot service first.
+
+[Packer](https://www.packer.io/intro/index.html) is HashiCorp's open source tool 
+for creating identical machine images for multiple platforms from a single 
+source configuration. The Terraform templates included in this repo reference a 
+publicly available Alicloud machine image by default. The  Alicloud machine image can be customized 
+through modifications to the [build configuration script](../shared/scripts/setup.sh) 
+and [packer.json](packer.json).
+
+Use the following command to build the image:
+
+```bash
+$ packer build packer.json
+```
+
+## Provision a cluster with Terraform
+
+`cd` to an environment subdirectory:
+
+```bash
+$ cd env/us-east
+```
+
+Update `terraform.tfvars` with your your Alicloud image ID if you created 
+a custom Alicloud image with packer:
+
+```bash
+region            = "us-east-1"
+image_id          = "ubuntu_16_0402_64_20G_alibase_20180409.vhd"
+instance_type     = "ecs.n4.large"
+server_count      = "3"
+client_count      = "4"
+zone              = "us-east-1a"
+```
+
+Modify the `region`, `instance_type`, `server_count`, and `client_count` variables
+as appropriate. At least one client and one server are required. You can 
+optionally replace the Nomad binary at runtime by adding the `nomad_binary` 
+variable like so:
+
+```bash
+region                  = "us-east-1"
+image_id                = "ubuntu_16_0402_64_20G_alibase_20180409.vhd"
+instance_type           = "ecs.n4.large"
+server_count            = "3"
+client_count            = "4"
+nomad_binary            = "https://releases.hashicorp.com/nomad/0.8.6/nomad_0.8.6_linux_amd64.zip"
+```
+
+Provision the cluster:
+
+```bash
+$ terraform init
+$ terraform get
+$ terraform plan
+$ terraform apply
+```
+
+## Access the cluster
+
+SSH to one of the servers using its public IP:
+
+```bash
+$ ssh -i /path/to/private/key ubuntu@PUBLIC_IP
+```
+
+The infrastructure that is provisioned for this test environment is configured to 
+allow all traffic over port 22. This is obviously not recommended for production 
+deployments.
+
+## Next Steps
+
+Click [here](../README.md#test) for next steps.

--- a/terraform/alicloud/env/us-east/main.tf
+++ b/terraform/alicloud/env/us-east/main.tf
@@ -1,0 +1,131 @@
+variable "access_key" {}
+variable "secret_key" {}
+
+variable "name" {
+  description = "Used to name various infrastructure components"
+  default     = "hashistack"
+}
+
+variable "region" {
+  description = "The Alicloud region to deploy to."
+  default     = "us-east-1"
+}
+
+variable "image_id" {}
+
+variable "instance_type" {}
+
+
+variable "server_count" {
+  description = "The number of servers to provision."
+  default     = "3"
+}
+
+variable "client_count" {
+  description = "The number of clients to provision."
+  default     = "4"
+}
+
+locals {
+  "retry_join" = "provider=aliyun region=${var.region} tag_key=ConsulAutoJoin tag_value=auto-join access_key_id=${var.access_key} access_key_secret=${var.secret_key}"
+}
+
+variable "nomad_binary" {
+  description = "Used to replace the machine image installed Nomad binary."
+  default     = "https://releases.hashicorp.com/nomad/0.8.6/nomad_0.8.6_linux_amd64.zip"
+}
+
+variable "nic_type" {
+  default = "intranet"
+}
+
+variable "internet_charge_type" {
+  default = "PayByTraffic"
+}
+
+variable "internet_max_bandwidth_out" {
+  default = 5
+}
+
+variable "disk_category" {
+  default = "cloud_efficiency"
+}
+
+variable "disk_size" {
+  default = "40"
+}
+
+variable "key_name" {
+  default = "key-pair-from-terraform"
+}
+
+variable "private_key_file" {
+  default = "alicloud_ssh_key.pem"
+}
+
+provider "alicloud" {
+  access_key = "${var.access_key}"
+  secret_key = "${var.secret_key}"
+  region = "${var.region}"
+}
+
+variable "vpc_cidr" {
+  default = "172.16.0.0/12"
+}
+variable "vswitch_cidr" {
+  default = "172.16.0.0/21"
+}
+variable "zone" {
+  default = "us-east-1a"
+}
+
+module "hashistack" {
+  source = "../../modules/hashistack"
+
+  name                       = "${var.name}"
+  region                     = "${var.region}"
+  image_id                   = "${var.image_id}"
+  instance_type              = "${var.instance_type}"
+  server_count               = "${var.server_count}"
+  client_count               = "${var.client_count}"
+  retry_join                 = "${local.retry_join}"
+  nomad_binary               = "${var.nomad_binary}"
+  nic_type                   = "${var.nic_type}"
+  internet_charge_type       = "${var.internet_charge_type}"
+  internet_max_bandwidth_out = "${var.internet_max_bandwidth_out}"
+  disk_category              = "${var.disk_category}"
+  disk_size                  = "${var.disk_size}"
+  key_name                   = "${var.key_name}"
+  private_key_file           = "${var.private_key_file}"
+  vpc_cidr                   = "${var.vpc_cidr}"
+  vswitch_cidr               = "${var.vswitch_cidr}"
+  zone                       = "${var.zone}"
+}
+
+output "IP_Addresses" {
+  value = <<CONFIGURATION
+
+Client public IPs: ${join(", ", module.hashistack.client_public_ips)}
+Server public IPs: ${join(", ", module.hashistack.server_public_ips)}
+
+To connect, add your private key and SSH into any client or server with
+`ssh ubuntu@PUBLIC_IP`. You can test the integrity of the cluster by running:
+
+  $ consul members
+  $ nomad server members
+  $ nomad node status
+
+If you see an error message like the following when running any of the above
+commands, it usually indicates that the configuration script has not finished
+executing:
+
+"Error querying servers: Get http://127.0.0.1:4646/v1/agent/members: dial tcp
+127.0.0.1:4646: getsockopt: connection refused"
+
+Simply wait a few seconds and rerun the command if this occurs.
+
+The Nomad UI can be accessed at http://PUBLIC_IP:4646/ui.
+The Consul UI can be accessed at http://PUBLIC_IP:8500/ui.
+
+CONFIGURATION
+}

--- a/terraform/alicloud/env/us-east/terraform.tfvars
+++ b/terraform/alicloud/env/us-east/terraform.tfvars
@@ -1,0 +1,6 @@
+region            = "us-east-1"
+image_id          = "ubuntu_16_0402_64_20G_alibase_20180409.vhd"
+instance_type     = "ecs.n4.large"
+server_count      = "3"
+client_count      = "4"
+zone              = "us-east-1a"

--- a/terraform/alicloud/env/us-east/user-data-client.sh
+++ b/terraform/alicloud/env/us-east/user-data-client.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+exec > >(sudo tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+sudo bash /ops/shared/scripts/client.sh "alicloud" "${retry_join}" "${nomad_binary}"

--- a/terraform/alicloud/env/us-east/user-data-server.sh
+++ b/terraform/alicloud/env/us-east/user-data-server.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+exec > >(sudo tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+sudo bash /ops/shared/scripts/server.sh "alicloud" "${server_count}" "${retry_join}" "${nomad_binary}"

--- a/terraform/alicloud/modules/hashistack/hashistack.tf
+++ b/terraform/alicloud/modules/hashistack/hashistack.tf
@@ -1,0 +1,272 @@
+variable "name" {}
+variable "region" {}
+variable "image_id" {}
+variable "instance_type" {}
+variable "server_count" {}
+variable "client_count" {}
+variable "retry_join" {}
+variable "nomad_binary" {}
+variable "nic_type" {}
+variable "internet_charge_type" {}
+variable "internet_max_bandwidth_out" {}
+variable "disk_category" {}
+variable "disk_size" {}
+variable "key_name" {}
+variable "private_key_file" {}
+variable "vpc_cidr" {}
+variable "vswitch_cidr" {}
+variable "zone" {}
+
+
+
+
+
+resource "alicloud_vpc" "default" {
+  name       = "tf-vpc"
+  cidr_block = "${var.vpc_cidr}"
+}
+
+resource "alicloud_vswitch" "vsw" {
+  vpc_id            = "${alicloud_vpc.default.id}"
+  cidr_block        = "${var.vswitch_cidr}"
+  availability_zone = "${var.zone}"
+}
+
+resource "alicloud_security_group" "group" {
+  name        = "${var.name}"
+  description = "New security group"
+  vpc_id      = "${alicloud_vpc.default.id}"
+}
+
+resource "alicloud_security_group_rule" "allow_ssh" {
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "${var.nic_type}"
+  policy            = "accept"
+  port_range        = "22/22"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.group.id}"
+  cidr_ip           = "0.0.0.0/0"
+}
+
+resource "alicloud_security_group_rule" "allow_nomad" {
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "${var.nic_type}"
+  policy            = "accept"
+  port_range        = "4646/4646"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.group.id}"
+  cidr_ip           = "0.0.0.0/0"
+}
+
+resource "alicloud_security_group_rule" "allow_consul" {
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "${var.nic_type}"
+  policy            = "accept"
+  port_range        = "8500/8500"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.group.id}"
+  cidr_ip           = "0.0.0.0/0"
+}
+
+resource "alicloud_security_group_rule" "allow_hdfs_namenode_ui" {
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "${var.nic_type}"
+  policy            = "accept"
+  port_range        = "50070/50070"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.group.id}"
+  cidr_ip           = "0.0.0.0/0"
+}
+
+resource "alicloud_security_group_rule" "allow_hdfs_datanode_ui" {
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "${var.nic_type}"
+  policy            = "accept"
+  port_range        = "50075/50075"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.group.id}"
+  cidr_ip           = "0.0.0.0/0"
+}
+
+resource "alicloud_security_group_rule" "allow_spark_history_server_ui" {
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "${var.nic_type}"
+  policy            = "accept"
+  port_range        = "18080/18080"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.group.id}"
+  cidr_ip           = "0.0.0.0/0"
+}
+
+resource "alicloud_security_group_rule" "allow_ingress_all" {
+  type              = "ingress"
+  ip_protocol       = "all"
+  nic_type          = "${var.nic_type}"
+  policy            = "accept"
+  port_range        = "-1/-1"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.group.id}"
+  cidr_ip           = "0.0.0.0/0"
+}
+
+resource "alicloud_security_group_rule" "allow_egress_all" {
+  type              = "egress"
+  ip_protocol       = "all"
+  nic_type          = "${var.nic_type}"
+  policy            = "accept"
+  port_range        = "-1/-1"
+  priority          = 1
+  security_group_id = "${alicloud_security_group.group.id}"
+  cidr_ip           = "0.0.0.0/0"
+}
+
+
+data "template_file" "user_data_server" {
+  template = "${file("${path.root}/user-data-server.sh")}"
+
+  vars {
+    server_count = "${var.server_count}"
+    region       = "${var.region}"
+    retry_join   = "${var.retry_join}"
+    nomad_binary = "${var.nomad_binary}"
+  }
+}
+
+data "template_file" "user_data_client" {
+  template = "${file("${path.root}/user-data-client.sh")}"
+
+  vars {
+    region     = "${var.region}"
+    retry_join = "${var.retry_join}"
+    nomad_binary = "${var.nomad_binary}"
+  }
+}
+
+resource "alicloud_instance" "server" {
+  image_id               = "${var.image_id}"
+  instance_type          = "${var.instance_type}"
+  security_groups        = ["${alicloud_security_group.group.*.id}"]
+  count                  = "${var.server_count}"
+  vswitch_id             = "${alicloud_vswitch.vsw.id}"
+
+  internet_charge_type       = "${var.internet_charge_type}"
+  internet_max_bandwidth_out = "${var.internet_max_bandwidth_out}"
+
+  instance_name   = "${var.name}-server-${count.index}"
+  host_name       = "${var.name}-server-${count.index}"
+  key_name        = "${alicloud_key_pair.key_pair.id}"
+
+  #Instance tags
+  tags {
+    Name           = "${var.name}-server-${count.index}"
+    ConsulAutoJoin = "auto-join"
+  }
+
+  user_data            = "${data.template_file.user_data_server.rendered}"
+}
+
+resource "alicloud_disk" "server_disk" {
+  availability_zone = "${alicloud_instance.server.0.availability_zone}"
+  category          = "${var.disk_category}"
+  size              = "${var.disk_size}"
+  count             = "${var.server_count}"
+}
+
+resource "alicloud_disk_attachment" "server-attachment" {
+  count       = "${var.server_count}"
+  disk_id     = "${element(alicloud_disk.server_disk.*.id, count.index)}"
+  instance_id = "${element(alicloud_instance.server.*.id, count.index)}"
+}
+
+resource "alicloud_instance" "client" {
+  image_id               = "${var.image_id}"
+  instance_type          = "${var.instance_type}"
+  security_groups        = ["${alicloud_security_group.group.*.id}"]
+  count                  = "${var.client_count}"
+  vswitch_id             = "${alicloud_vswitch.vsw.id}"
+  
+  internet_charge_type       = "${var.internet_charge_type}"
+  internet_max_bandwidth_out = "${var.internet_max_bandwidth_out}"
+
+  instance_name   = "${var.name}-client-${count.index}"
+  host_name       = "${var.name}-client-${count.index}"
+  key_name        = "${alicloud_key_pair.key_pair.id}"
+
+  depends_on             = ["alicloud_instance.server"]
+
+  #Instance tags
+  tags {
+    Name           = "${var.name}-client-${count.index}"
+    ConsulAutoJoin = "auto-join"
+  }
+
+  user_data            = "${data.template_file.user_data_client.rendered}"
+}
+
+resource "alicloud_disk" "client_disk" {
+  availability_zone = "${alicloud_instance.client.0.availability_zone}"
+  category          = "${var.disk_category}"
+  size              = "${var.disk_size}"
+  count             = "${var.client_count}"
+}
+
+resource "alicloud_disk_attachment" "client-attachment" {
+  count       = "${var.client_count}"
+  disk_id     = "${element(alicloud_disk.client_disk.*.id, count.index)}"
+  instance_id = "${element(alicloud_instance.client.*.id, count.index)}"
+}
+
+resource "alicloud_ram_role" "instance_role" {
+  name     = "${var.name}-role"
+  services = ["ecs.aliyuncs.com"]
+  force    = true
+}
+
+resource "alicloud_ram_policy" "policy" {
+  name = "auto-discover-cluster"
+
+  statement = [
+    {
+      effect   = "Allow"
+      action   = ["ecs:*"]
+      resource = ["acs:ecs:*:*:*"]
+    }
+  ]
+
+  force = true
+}
+
+resource "alicloud_ram_role_policy_attachment" "role-policy" {
+  policy_name = "${alicloud_ram_policy.policy.name}"
+  role_name   = "${alicloud_ram_role.instance_role.name}"
+  policy_type = "${alicloud_ram_policy.policy.type}"
+}
+
+resource "alicloud_ram_role_attachment" "attach" {
+  role_name    = "${alicloud_ram_role.instance_role.name}"
+  instance_ids = ["${alicloud_instance.server.*.id}", "${alicloud_instance.client.*.id}"]
+}
+
+resource "alicloud_key_pair" "key_pair" {
+  key_name = "${var.key_name}"
+  key_file = "${var.private_key_file}"
+}
+
+resource "alicloud_key_pair_attachment" "key_pair_attachment" {
+  key_name     = "${alicloud_key_pair.key_pair.id}"
+  instance_ids = ["${alicloud_instance.server.*.id}", "${alicloud_instance.client.*.id}"]
+}
+
+output "server_public_ips" {
+  value = ["${alicloud_instance.server.*.public_ip}"]
+}
+
+output "client_public_ips" {
+  value = ["${alicloud_instance.client.*.public_ip}"]
+}

--- a/terraform/alicloud/packer.json
+++ b/terraform/alicloud/packer.json
@@ -1,0 +1,40 @@
+{
+  "variables": {
+    "access_key": "{{env `TF_VAR_access_key`}}",
+    "secret_key": "{{env `TF_VAR_secret_key`}}"
+  },
+  "builders": [{
+    "type": "alicloud-ecs",
+    "access_key":"{{user `access_key`}}",
+    "secret_key":"{{user `secret_key`}}",
+    "region":"us-east-1",
+    "image_name":"hashistack-{{timestamp}}",
+    "source_image":"ubuntu_16_0402_64_20G_alibase_20180409.vhd",
+    "ssh_username":"root",
+    "instance_type":"ecs.n4.large",
+    "io_optimized":"true",
+    "image_force_delete":"true"
+  }],
+  "provisioners":  [
+  {
+    "type": "shell",
+    "inline": [
+      "sudo mkdir /ops",
+      "sudo chmod 777 /ops"
+    ]
+  },
+  {
+    "type": "file",
+    "source": "../shared",
+    "destination": "/ops"
+  },
+  {
+    "type": "file",
+    "source": "../examples",
+    "destination": "/ops"
+  },
+  {
+    "type": "shell",
+    "script": "../shared/scripts/setup.sh"
+  }]
+}

--- a/terraform/shared/config/consul_alicloud.service
+++ b/terraform/shared/config/consul_alicloud.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Consul Agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+Environment=CONSUL_ALLOW_PRIVILEGED_PORTS=true
+ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d" -dns-port="53" -recursor="168.63.129.16"
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/shared/scripts/setup.sh
+++ b/terraform/shared/scripts/setup.sh
@@ -27,8 +27,8 @@ NOMADDIR=/opt/nomad
 HADOOP_VERSION=2.7.6
 
 # Dependencies
-sudo apt-get install -y software-properties-common
 sudo apt-get update
+sudo apt-get install -y software-properties-common
 sudo apt-get install -y unzip tree redis-tools jq curl tmux
 
 # Numpy (for Spark)


### PR DESCRIPTION
- I noticed that there is no example of Alicloud about _provision nomad cluster in the cloud_, which maybe inconvenient for those who are interested in provisioning nomad cluster in Alicloud. So I modified the template based on aws example and added some resources of Alicloud Provider. 
- The full workflow is tested in Alicloud ECS of us-east-1 region.
- The specific steps are in the README file below.

# Provision a Nomad cluster on Alicloud

## Pre-requisites

To get started, create the following:

- Alicloud account
- [API access keys](https://www.alibabacloud.com/help/doc-detail/29009.htm)

## Set the Alicloud environment variables

Set up service endpoint of your region to prevent TLS timeout error.

[Service endpoint in your region](https://www.alibabacloud.com/help/doc-detail/29008.html?spm=a2c5t.11065259.1996646101.searchclickresult.76165207ngmXar)
```bash
$ export ECS_ENDPOINT=[Service endpoint(ecs.us-east-1.aliyuncs.com)] 
$ export TF_VAR_access_key=[ALICLOUD_ACCESS_KEY]
$ export TF_VAR_secret_key=[ALICLOUD_SECRET_KEY]
```

The reason I don't use ALICLOUD_ACCESS_KEY and ALICLOUD_SECRET_KEY is because access_key and secret_key are used in retry_join local variable and you cannot simply access the two ALICLOUD environment variables in the configuration.

The role that holds the key must have the full access to ecs, ram, vpc, eip and kms.

## Build an Alicloud machine image with Packer

Before building a image, you may have not signed up for the alicloud snapshot service first.

[Packer](https://www.packer.io/intro/index.html) is HashiCorp's open source tool 
for creating identical machine images for multiple platforms from a single 
source configuration. The Terraform templates included in this repo reference a 
publicly available Alicloud machine image by default. The  Alicloud machine image can be customized 
through modifications to the [build configuration script](../shared/scripts/setup.sh) 
and [packer.json](packer.json).

Use the following command to build the image:

```bash
$ packer build packer.json
```

## Provision a cluster with Terraform

`cd` to an environment subdirectory:

```bash
$ cd env/us-east
```

Update `terraform.tfvars` with your your Alicloud image ID if you created 
a custom Alicloud image with packer:

```bash
region            = "us-east-1"
image_id          = "ubuntu_16_0402_64_20G_alibase_20180409.vhd"
instance_type     = "ecs.n4.large"
server_count      = "3"
client_count      = "4"
zone              = "us-east-1a"
```

Modify the `region`, `instance_type`, `server_count`, and `client_count` variables
as appropriate. At least one client and one server are required. You can 
optionally replace the Nomad binary at runtime by adding the `nomad_binary` 
variable like so:

```bash
region                  = "us-east-1"
image_id                = "ubuntu_16_0402_64_20G_alibase_20180409.vhd"
instance_type           = "ecs.n4.large"
server_count            = "3"
client_count            = "4"
nomad_binary            = "https://releases.hashicorp.com/nomad/0.8.6/nomad_0.8.6_linux_amd64.zip"
```

Provision the cluster:

```bash
$ terraform init
$ terraform get
$ terraform plan
$ terraform apply
```

## Access the cluster

SSH to one of the servers using its public IP:

```bash
$ ssh -i /path/to/private/key ubuntu@PUBLIC_IP
```

The infrastructure that is provisioned for this test environment is configured to 
allow all traffic over port 22. This is obviously not recommended for production 
deployments.

## Next Steps

Click [here](../README.md#test) for next steps.