### PR TITLE
Use user provided image name to launch container

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -178,7 +178,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *struc
 		return nil, nil, err
 	}
 
-	containerCfg, err := d.createContainerConfig(cfg, &driverConfig, id)
+	containerCfg, err := d.createContainerConfig(cfg, &driverConfig, driverConfig.Image)
 	if err != nil {
 		d.logger.Error("failed to create container configuration", "image_name", driverConfig.Image,
 			"image_id", id, "error", err)


### PR DESCRIPTION
This allows the container to be tagged with a user friendly image name
(e.g. `redis:3.2`) rather than the image ID (e.g.
`sha256:87856cc39862cec77541d68382e4867d7ccb29a85a17221446c857ddaebca916`).

Useful for human debugging, as well as some debugging and image scanning
tools.

This risks two bad changes:
1. Discrepancy in image resolution between docker and Nomad's image
loader.
  * I checked the image creation paths in Nomad, and noticed that we
either pulled the image or inspect the image with the user provided
name.

2. A race in image tagging where the tag is modified between image
loading and container creation.
  * I, personally, don't think this case is cause for concern, as it is
analogous to the task running a bit later.  As long as the image is
still present, creating the container should be good.

Closes https://github.com/hashicorp/nomad/issues/2624