### PR TITLE
client driver manager

### DIFF
--- a/client/allocrunner/config.go
+++ b/client/allocrunner/config.go
@@ -6,10 +6,10 @@ import (
 	clientconfig "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/interfaces"
+	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
 	cstate "github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/hashicorp/nomad/plugins/shared/loader"
 )
 
 // Config holds the configuration for creating an allocation runner.
@@ -42,10 +42,6 @@ type Config struct {
 	// migrating their ephemeral disk when necessary.
 	PrevAllocWatcher allocwatcher.PrevAllocWatcher
 
-	// PluginLoader is used to load plugins.
-	PluginLoader loader.PluginCatalog
-
-	// PluginSingletonLoader is a plugin loader that will returns singleton
-	// instances of the plugins.
-	PluginSingletonLoader loader.PluginCatalog
+	// DriverManager handles dispensing of driver plugins
+	DriverManager drivermanager.Manager
 }

--- a/client/devicemanager/manager.go
+++ b/client/devicemanager/manager.go
@@ -20,12 +20,6 @@ import (
 
 // Manaager is the interface used to manage device plugins
 type Manager interface {
-	// Run starts the device manager
-	Run()
-
-	// Shutdown shutsdown the manager and all launched plugins
-	Shutdown()
-
 	// Reserve is used to reserve a set of devices
 	Reserve(d *structs.AllocatedDeviceResource) (*device.ContainerReservation, error)
 
@@ -126,6 +120,8 @@ func New(c *Config) *manager {
 		fingerprintResCh: make(chan struct{}, 1),
 	}
 }
+
+func (*manager) PluginType() string { return base.PluginTypeDevice }
 
 // Run starts thed device manager. The manager will shutdown any previously
 // launched plugin and then begin fingerprinting and stats collection on all new

--- a/client/fingerprint_manager.go
+++ b/client/fingerprint_manager.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -11,8 +9,6 @@ import (
 	"github.com/hashicorp/nomad/client/fingerprint"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/hashicorp/nomad/plugins/base"
-	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/loader"
 )
 
@@ -39,10 +35,7 @@ type FingerprintManager struct {
 	// associated node
 	updateNodeAttributes func(*cstructs.FingerprintResponse) *structs.Node
 
-	// updateNodeFromDriver is a callback to the client to update the state of a
-	// specific driver for the node
-	updateNodeFromDriver func(string, *structs.DriverInfo) *structs.Node
-	logger               log.Logger
+	logger log.Logger
 }
 
 // NewFingerprintManager is a constructor that creates and returns an instance
@@ -53,14 +46,12 @@ func NewFingerprintManager(
 	node *structs.Node,
 	shutdownCh chan struct{},
 	updateNodeAttributes func(*cstructs.FingerprintResponse) *structs.Node,
-	updateNodeFromDriver func(string, *structs.DriverInfo) *structs.Node,
 	logger log.Logger) *FingerprintManager {
 
 	return &FingerprintManager{
 		singletonLoader:      singletonLoader,
 		getConfig:            getConfig,
 		updateNodeAttributes: updateNodeAttributes,
-		updateNodeFromDriver: updateNodeFromDriver,
 		node:                 node,
 		shutdownCh:           shutdownCh,
 		logger:               logger.Named("fingerprint_mgr"),
@@ -120,39 +111,6 @@ func (fp *FingerprintManager) Run() error {
 			"skipped_fingerprinters", skippedFingerprints)
 	}
 
-	// Next, set up drivers
-	// Build the white/blacklists of drivers.
-	whitelistDrivers := cfg.ReadStringListToMap("driver.whitelist")
-	whitelistDriversEnabled := len(whitelistDrivers) > 0
-	blacklistDrivers := cfg.ReadStringListToMap("driver.blacklist")
-
-	var availDrivers []string
-	var skippedDrivers []string
-
-	for _, pl := range fp.singletonLoader.Catalog()[base.PluginTypeDriver] {
-		name := pl.Name
-		// Skip fingerprinting drivers that are not in the whitelist if it is
-		// enabled.
-		if _, ok := whitelistDrivers[name]; whitelistDriversEnabled && !ok {
-			skippedDrivers = append(skippedDrivers, name)
-			continue
-		}
-		// Skip fingerprinting drivers that are in the blacklist
-		if _, ok := blacklistDrivers[name]; ok {
-			skippedDrivers = append(skippedDrivers, name)
-			continue
-		}
-
-		availDrivers = append(availDrivers, name)
-	}
-
-	if err := fp.setupDrivers(availDrivers); err != nil {
-		return err
-	}
-
-	if len(skippedDrivers) > 0 {
-		fp.logger.Debug("drivers skipped due to white/blacklist", "skipped_drivers", skippedDrivers)
-	}
 	return nil
 }
 
@@ -186,38 +144,6 @@ func (fm *FingerprintManager) setupFingerprinters(fingerprints []string) error {
 	}
 
 	fm.logger.Debug("detected fingerprints", "node_attrs", appliedFingerprints)
-	return nil
-}
-
-// setupDrivers is used to fingerprint the node to see if these drivers are
-// supported
-func (fm *FingerprintManager) setupDrivers(driverNames []string) error {
-	//TODO(alex,hclog) Update fingerprinters to hclog
-	var availDrivers []string
-	for _, name := range driverNames {
-		// TODO: driver reattach
-		fingerCh, cancel, err := fm.dispenseDriverFingerprint(name)
-		if err != nil {
-			return err
-		}
-
-		finger := <-fingerCh
-
-		// Start a periodic watcher to detect changes to a drivers health and
-		// attributes.
-		go fm.watchDriverFingerprint(fingerCh, name, cancel)
-
-		if fm.logger.IsTrace() {
-			fm.logger.Trace("initial driver fingerprint", "driver", name, "fingerprint", finger)
-		}
-		// Log the fingerprinters which have been applied
-		if finger.Health != drivers.HealthStateUndetected {
-			availDrivers = append(availDrivers, name)
-		}
-		fm.processDriverFingerprint(finger, name)
-	}
-
-	fm.logger.Debug("detected drivers", "drivers", availDrivers)
 	return nil
 }
 
@@ -265,93 +191,4 @@ func (fm *FingerprintManager) fingerprint(name string, f fingerprint.Fingerprint
 	}
 
 	return response.Detected, nil
-}
-
-// watchDrivers facilitates the different periods between fingerprint and
-// health checking a driver
-func (fm *FingerprintManager) watchDriverFingerprint(fpChan <-chan *drivers.Fingerprint, name string, cancel context.CancelFunc) {
-	var backoff time.Duration
-	var retry int
-	for {
-		if backoff > 0 {
-			time.Sleep(backoff)
-		}
-		select {
-		case <-fm.shutdownCh:
-			cancel()
-			return
-		case fp, ok := <-fpChan:
-			if ok && fp.Err == nil {
-				fm.processDriverFingerprint(fp, name)
-				continue
-			}
-			// if the channel is closed attempt to open a new one
-			newFpChan, newCancel, err := fm.dispenseDriverFingerprint(name)
-			if err != nil {
-				fm.logger.Warn("failed to fingerprint driver, retrying in 30s", "error", err, "retry", retry)
-				di := &structs.DriverInfo{
-					Healthy:           false,
-					HealthDescription: "failed to fingerprint driver",
-					UpdateTime:        time.Now(),
-				}
-				if n := fm.updateNodeFromDriver(name, di); n != nil {
-					fm.setNode(n)
-				}
-
-				// Calculate the new backoff
-				backoff = (1 << (2 * uint64(retry))) * driverFPBackoffBaseline
-				if backoff > driverFPBackoffLimit {
-					backoff = driverFPBackoffLimit
-				}
-				retry++
-				continue
-			}
-			cancel()
-			fpChan = newFpChan
-			cancel = newCancel
-
-			// Reset backoff
-			backoff = 0
-			retry = 0
-		}
-	}
-}
-
-// processDriverFringerprint converts a Fingerprint from a driver into a DriverInfo
-// struct and updates the Node with it
-func (fm *FingerprintManager) processDriverFingerprint(fp *drivers.Fingerprint, driverName string) {
-	di := &structs.DriverInfo{
-		Attributes:        fp.Attributes,
-		Detected:          fp.Health != drivers.HealthStateUndetected,
-		Healthy:           fp.Health == drivers.HealthStateHealthy,
-		HealthDescription: fp.HealthDescription,
-		UpdateTime:        time.Now(),
-	}
-	if n := fm.updateNodeFromDriver(driverName, di); n != nil {
-		fm.setNode(n)
-	}
-}
-
-// dispenseDriverFingerprint dispenses a driver plugin for the given driver name
-// and requests a fingerprint channel. The channel and a context cancel function
-// is returned to the caller
-func (fm *FingerprintManager) dispenseDriverFingerprint(driverName string) (<-chan *drivers.Fingerprint, context.CancelFunc, error) {
-	plug, err := fm.singletonLoader.Dispense(driverName, base.PluginTypeDriver, fm.getConfig().NomadPluginConfig(), fm.logger)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	driver, ok := plug.Plugin().(drivers.DriverPlugin)
-	if !ok {
-		return nil, nil, fmt.Errorf("registered driver plugin %q does not implement DriverPlugin interface", driverName)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	fingerCh, err := driver.Fingerprint(ctx)
-	if err != nil {
-		cancel()
-		return nil, nil, err
-	}
-
-	return fingerCh, cancel, nil
 }

--- a/client/pluginmanager/drivermanager/instance.go
+++ b/client/pluginmanager/drivermanager/instance.go
@@ -1,0 +1,442 @@
+package drivermanager
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/base"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/plugins/shared/loader"
+	"github.com/hashicorp/nomad/plugins/shared/singleton"
+)
+
+const (
+	// driverFPBackoffBaseline is the baseline time for exponential backoff while
+	// fingerprinting a driver.
+	driverFPBackoffBaseline = 5 * time.Second
+
+	// driverFPBackoffLimit is the limit of the exponential backoff for fingerprinting
+	// a driver.
+	driverFPBackoffLimit = 2 * time.Minute
+)
+
+// instanceManagerConfig configures a driver instance manager
+type instanceManagerConfig struct {
+	// Logger is the logger used by the driver instance manager
+	Logger log.Logger
+
+	// Ctx is used to shutdown the driver instance manager
+	Ctx context.Context
+
+	// Loader is the plugin loader
+	Loader loader.PluginCatalog
+
+	// StoreReattach is used to store a plugins reattach config
+	StoreReattach StorePluginReattachFn
+
+	// FetchReattach is used to retrieve a plugin's reattach config
+	FetchReattach FetchPluginReattachFn
+
+	// PluginConfig is the config passed to the launched plugins
+	PluginConfig *base.ClientAgentConfig
+
+	// ID is the ID of the plugin being managed
+	ID *loader.PluginID
+
+	// updateNodeFromDriver is the callback used to update the node from fingerprinting
+	UpdateNodeFromDriver UpdateNodeDriverInfoFn
+}
+
+// instanceManager is used to manage a single driver plugin
+type instanceManager struct {
+	// logger is the logger used by the driver instance manager
+	logger log.Logger
+
+	// ctx is used to shutdown the driver manager
+	ctx context.Context
+
+	// cancel is used to shutdown management of this driver plugin
+	cancel context.CancelFunc
+
+	// loader is the plugin loader
+	loader loader.PluginCatalog
+
+	// storeReattach is used to store a plugins reattach config
+	storeReattach StorePluginReattachFn
+
+	// fetchReattach is used to retrieve a plugin's reattach config
+	fetchReattach FetchPluginReattachFn
+
+	// pluginConfig is the config passed to the launched plugins
+	pluginConfig *base.ClientAgentConfig
+
+	// id is the ID of the plugin being managed
+	id *loader.PluginID
+
+	// plugin is the plugin instance being managed
+	plugin loader.PluginInstance
+
+	// driver is the driver plugin being managed
+	driver drivers.DriverPlugin
+
+	// pluginLock locks access to the driver and plugin
+	pluginLock sync.Mutex
+
+	// shutdownLock is used to serialize attempts to shutdown
+	shutdownLock sync.Mutex
+
+	// updateNodeFromDriver is the callback used to update the node from fingerprinting
+	updateNodeFromDriver UpdateNodeDriverInfoFn
+
+	// handlers is the map of taskID to handler funcs
+	handlers     map[string][]EventHandler
+	handlersLock sync.RWMutex
+
+	// firstFingerprintCh is used to trigger that we have successfully
+	// fingerprinted once. It is used to gate launching the stats collection.
+	firstFingerprintCh chan struct{}
+	hasFingerprinted   bool
+
+	// lastHealthState is the last known health fingerprinted by the manager
+	lastHealthState drivers.HealthState
+}
+
+// newInstanceManager returns a new driver instance manager. It is expected that
+// the context passed in the configuration is cancelled in order to shutdown
+// launched goroutines.
+func newInstanceManager(c *instanceManagerConfig) *instanceManager {
+
+	ctx, cancel := context.WithCancel(c.Ctx)
+	i := &instanceManager{
+		logger:               c.Logger.With("driver", c.ID.Name),
+		ctx:                  ctx,
+		cancel:               cancel,
+		loader:               c.Loader,
+		storeReattach:        c.StoreReattach,
+		fetchReattach:        c.FetchReattach,
+		pluginConfig:         c.PluginConfig,
+		id:                   c.ID,
+		updateNodeFromDriver: c.UpdateNodeFromDriver,
+		handlers:             map[string][]EventHandler{},
+		firstFingerprintCh:   make(chan struct{}),
+	}
+
+	go i.run()
+	return i
+}
+
+// WaitForFirstFingerprint waits until either the plugin fingerprints, the
+// passed context is done, or the plugin instance manager is shutdown.
+func (i *instanceManager) WaitForFirstFingerprint(ctx context.Context) {
+	select {
+	case <-i.ctx.Done():
+	case <-ctx.Done():
+	case <-i.firstFingerprintCh:
+	}
+}
+
+// registerEventHandler registers the given handler to run for events with the
+// given taskID
+func (i *instanceManager) registerEventHandler(taskID string, handler EventHandler) {
+	i.handlersLock.Lock()
+	defer i.handlersLock.Unlock()
+	if handlers, ok := i.handlers[taskID]; ok {
+		i.handlers[taskID] = append(handlers, handler)
+	} else {
+		i.handlers[taskID] = []EventHandler{handler}
+	}
+}
+
+// deregisterEventHandler removed the handlers registered for the given taskID
+// and is serlialized so as to not be called concurrently with the registered
+// handler
+func (i *instanceManager) deregisterEventHandler(taskID string) {
+	i.handlersLock.Lock()
+	defer i.handlersLock.Unlock()
+	delete(i.handlers, taskID)
+}
+
+// run is a long lived goroutine that starts the fingerprinting and stats
+// collection goroutine and then shutsdown the plugin on exit.
+func (i *instanceManager) run() {
+	// Dispense once to ensure we are given a valid plugin
+	if _, err := i.dispense(); err != nil {
+		i.logger.Error("dispensing initial plugin failed", "error", err)
+		return
+	}
+
+	// Create a waitgroup to block on shutdown for all created goroutines to
+	// exit
+	var wg sync.WaitGroup
+
+	// Start the fingerprinter
+	wg.Add(1)
+	go func() {
+		i.fingerprint()
+		wg.Done()
+	}()
+
+	// Start event handler
+	wg.Add(1)
+	go func() {
+		i.handleEvents()
+		wg.Done()
+	}()
+
+	// Do a final cleanup
+	wg.Wait()
+	i.cleanup()
+}
+
+// dispense is used to dispense a plugin.
+func (i *instanceManager) dispense() (plugin drivers.DriverPlugin, err error) {
+	i.pluginLock.Lock()
+	defer i.pluginLock.Unlock()
+
+	// See if we already have a running instance
+	if i.plugin != nil && !i.plugin.Exited() {
+		return i.driver, nil
+	}
+
+	var pluginInstance loader.PluginInstance
+
+	if reattach, ok := i.fetchReattach(); ok {
+		// Reattach to existing plugin
+		pluginInstance, err = i.loader.Reattach(i.id.Name, i.id.PluginType, reattach)
+	} else {
+		// Get an instance of the plugin
+		pluginInstance, err = i.loader.Dispense(i.id.Name, i.id.PluginType, i.pluginConfig, i.logger)
+	}
+	if err != nil {
+		// Retry as the error just indicates the singleton has exited
+		if err == singleton.SingletonPluginExited {
+			pluginInstance, err = i.loader.Dispense(i.id.Name, i.id.PluginType, i.pluginConfig, i.logger)
+		}
+
+		// If we still have an error there is a real problem
+		if err != nil {
+			return nil, fmt.Errorf("failed to start plugin: %v", err)
+		}
+	}
+
+	// Convert to a fingerprint plugin
+	driver, ok := pluginInstance.Plugin().(drivers.DriverPlugin)
+	if !ok {
+		pluginInstance.Kill()
+		return nil, fmt.Errorf("plugin loaded does not implement the driver interface")
+	}
+
+	// Store the plugin and driver
+	i.plugin = pluginInstance
+	i.driver = driver
+
+	// Store the reattach config
+	if c, ok := pluginInstance.ReattachConfig(); ok {
+		i.storeReattach(c)
+	}
+
+	return driver, nil
+}
+
+// cleanup shutsdown the plugin
+func (i *instanceManager) cleanup() {
+	i.shutdownLock.Lock()
+	i.pluginLock.Lock()
+	defer i.pluginLock.Unlock()
+	defer i.shutdownLock.Unlock()
+
+	if i.plugin != nil && !i.plugin.Exited() {
+		i.plugin.Kill()
+		i.storeReattach(nil)
+	}
+}
+
+// dispenseFingerprintCh dispenses a driver and makes a Fingerprint RPC call
+// to the driver. The fingerprint chan is returned along with the cancel func
+// for the context used in the RPC. This cancel func should always be called
+// when the caller is finished with the channel.
+func (i *instanceManager) dispenseFingerprintCh() (<-chan *drivers.Fingerprint, context.CancelFunc, error) {
+	driver, err := i.dispense()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx, cancel := context.WithCancel(i.ctx)
+	fingerCh, err := driver.Fingerprint(ctx)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+
+	return fingerCh, cancel, nil
+}
+
+// fingerprint is the main loop for fingerprinting.
+func (i *instanceManager) fingerprint() {
+	fpChan, cancel, err := i.dispenseFingerprintCh()
+	if err != nil {
+		i.logger.Error("failed to dispense driver plugin", "error", err)
+	}
+
+	// backoff and retry used if the RPC is closed by the other end
+	var backoff time.Duration
+	var retry int
+	for {
+		time.Sleep(backoff)
+		select {
+		case <-i.ctx.Done():
+			cancel()
+			return
+		case fp, ok := <-fpChan:
+			if ok {
+				if fp.Err == nil {
+					i.handleFingerprint(fp)
+				} else {
+					i.logger.Warn("recieved fingerprint error from driver", "error", fp.Err)
+					i.handleFingerprintError()
+				}
+				continue
+			}
+
+			// if the channel is closed attempt to open a new one
+			newFpChan, newCancel, err := i.dispenseFingerprintCh()
+			if err != nil {
+				i.logger.Warn("failed to fingerprint driver, retrying in 30s", "error", err, "retry", retry)
+				i.handleFingerprintError()
+
+				// Calculate the new backoff
+				backoff = (1 << (2 * uint64(retry))) * driverFPBackoffBaseline
+				if backoff > driverFPBackoffLimit {
+					backoff = driverFPBackoffLimit
+				}
+				// Increment retry counter
+				retry++
+				continue
+			}
+			cancel()
+			fpChan = newFpChan
+			cancel = newCancel
+
+			// Reset backoff
+			backoff = 0
+			retry = 0
+		}
+	}
+}
+
+// handleFingerprintError is called when an error occured while fingerprinting
+// and will set the driver to unhealthy
+func (i *instanceManager) handleFingerprintError() {
+	di := &structs.DriverInfo{
+		Healthy:           false,
+		HealthDescription: "failed to fingerprint driver",
+		UpdateTime:        time.Now(),
+	}
+	i.updateNodeFromDriver(i.id.Name, di)
+}
+
+// handleFingerprint updates the node with the current fingerprint status
+func (i *instanceManager) handleFingerprint(fp *drivers.Fingerprint) {
+	di := &structs.DriverInfo{
+		Attributes:        fp.Attributes,
+		Detected:          fp.Health != drivers.HealthStateUndetected,
+		Healthy:           fp.Health == drivers.HealthStateHealthy,
+		HealthDescription: fp.HealthDescription,
+		UpdateTime:        time.Now(),
+	}
+	i.updateNodeFromDriver(i.id.Name, di)
+
+	// log detected/undetected state changes after the initial fingerprint
+	if i.hasFingerprinted {
+		if i.lastHealthState != fp.Health {
+			i.logger.Info("driver health state has changed", "previous", i.lastHealthState, "current", fp.Health, "description", fp.HealthDescription)
+		}
+	}
+	i.lastHealthState = fp.Health
+
+	// if this is the first fingerprint, mark that we have received it
+	if !i.hasFingerprinted {
+		if i.logger.IsTrace() {
+			i.logger.Trace("initial driver fingerprint", "fingerprint", fp)
+		}
+		close(i.firstFingerprintCh)
+		i.hasFingerprinted = true
+	}
+}
+
+// dispenseTaskEventsCh dispenses a driver plugin and makes an TaskEvents RPC.
+// The TaskEvent chan and cancel func for the RPC is return. The cancel func must
+// be called by the caller to properly cleanup the context
+func (i *instanceManager) dispenseTaskEventsCh() (<-chan *drivers.TaskEvent, context.CancelFunc, error) {
+	driver, err := i.dispense()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx, cancel := context.WithCancel(i.ctx)
+	eventsCh, err := driver.TaskEvents(ctx)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+
+	return eventsCh, cancel, nil
+}
+
+// handleEvents is the main loop that recieves task events from the driver
+func (i *instanceManager) handleEvents() {
+	eventsCh, cancel, err := i.dispenseTaskEventsCh()
+	if err != nil {
+		i.logger.Error("failed to dispense driver", "error", err)
+	}
+
+	var backoff time.Duration
+	var retry int
+	for {
+		select {
+		case <-i.ctx.Done():
+			cancel()
+			return
+		case ev, ok := <-eventsCh:
+			if ok {
+				i.handleEvent(ev)
+				continue
+			}
+
+			// if the channel is closed attempt to open a new one
+			newEventsChan, newCancel, err := i.dispenseTaskEventsCh()
+			if err != nil {
+				i.logger.Warn("failed to recieve task events, retrying", "error", err, "retry", retry)
+
+				// Calculate the new backoff
+				backoff = (1 << (2 * uint64(retry))) * driverFPBackoffBaseline
+				if backoff > driverFPBackoffLimit {
+					backoff = driverFPBackoffLimit
+				}
+				retry++
+				continue
+			}
+			cancel()
+			eventsCh = newEventsChan
+			cancel = newCancel
+
+			// Reset backoff
+			backoff = 0
+			retry = 0
+
+		}
+	}
+}
+
+// handleEvent looks up the event handler(s) for the event and runs them
+func (i *instanceManager) handleEvent(ev *drivers.TaskEvent) {
+	i.handlersLock.RLock()
+	defer i.handlersLock.RUnlock()
+	for _, handler := range i.handlers[ev.TaskID] {
+		handler(ev)
+	}
+}

--- a/client/pluginmanager/drivermanager/manager.go
+++ b/client/pluginmanager/drivermanager/manager.go
@@ -1,0 +1,286 @@
+package drivermanager
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/base"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/plugins/shared"
+	"github.com/hashicorp/nomad/plugins/shared/loader"
+)
+
+// Manager is the interface used to manage driver plugins
+type Manager interface {
+	RegisterEventHandler(driver, taskID string, handler EventHandler)
+	DeregisterEventHandler(driver, taskID string)
+
+	Dispense(driver string) (drivers.DriverPlugin, error)
+}
+
+// EventHandler can be registered with a Manager to be called for a matching task.
+// The handler should not block execution.
+type EventHandler func(*drivers.TaskEvent)
+
+// StateStorage is used to persist the driver managers state across
+// agent restarts.
+type StateStorage interface {
+	// GetDevicePluginState is used to retrieve the device manager's plugin
+	// state.
+	GetDriverPluginState() (*state.PluginState, error)
+
+	// PutDevicePluginState is used to store the device manager's plugin
+	// state.
+	PutDriverPluginState(state *state.PluginState) error
+}
+
+// UpdateNodeDriverInfoFn is the callback used to update the node from
+// fingerprinting
+type UpdateNodeDriverInfoFn func(string, *structs.DriverInfo) *structs.Node
+
+// StorePluginReattachFn is used to store plugin reattachment configurations.
+type StorePluginReattachFn func(*plugin.ReattachConfig) error
+
+// FetchPluginReattachFn is used to retrieve the stored plugin reattachment
+// configuration.
+type FetchPluginReattachFn func() (*plugin.ReattachConfig, bool)
+
+// Config is used to configure a driver manager
+type Config struct {
+	// Logger is the logger used by the device manager
+	Logger log.Logger
+
+	// Loader is the plugin loader
+	Loader loader.PluginCatalog
+
+	// PluginConfig is the config passed to the launched plugins
+	PluginConfig *base.ClientAgentConfig
+
+	// Updater is used to update the node when driver information changes
+	Updater UpdateNodeDriverInfoFn
+
+	// State is used to manage the device managers state
+	State StateStorage
+
+	// AllowedDrivers if set will only start driver plugins for the given
+	// drivers
+	AllowedDrivers map[string]struct{}
+
+	// BlockedDrivers if set will not allow the given driver plugins to start
+	BlockedDrivers map[string]struct{}
+}
+
+// manager is used to manage a set of driver plugins
+type manager struct {
+	// logger is the logger used by the device manager
+	logger log.Logger
+
+	// state is used to manage the device managers state
+	state StateStorage
+
+	// ctx is used to shutdown the device manager
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// loader is the plugin loader
+	loader loader.PluginCatalog
+
+	// pluginConfig is the config passed to the launched plugins
+	pluginConfig *base.ClientAgentConfig
+
+	// updater is used to update the node when device information changes
+	updater UpdateNodeDriverInfoFn
+
+	// instances is the list of managed devices
+	instances map[string]*instanceManager
+
+	// reattachConfigs stores the plugin reattach configs
+	reattachConfigs    map[loader.PluginID]*shared.ReattachConfig
+	reattachConfigLock sync.Mutex
+
+	// allows/block lists
+	allowedDrivers map[string]struct{}
+	blockedDrivers map[string]struct{}
+}
+
+// New returns a new driver manager
+func New(c *Config) *manager {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &manager{
+		logger:          c.Logger.Named("driver_mgr"),
+		state:           c.State,
+		ctx:             ctx,
+		cancel:          cancel,
+		loader:          c.Loader,
+		pluginConfig:    c.PluginConfig,
+		updater:         c.Updater,
+		instances:       make(map[string]*instanceManager),
+		reattachConfigs: make(map[loader.PluginID]*shared.ReattachConfig),
+		allowedDrivers:  c.AllowedDrivers,
+		blockedDrivers:  c.BlockedDrivers,
+	}
+}
+
+// PluginType returns the type of plugin this mananger mananges
+func (*manager) PluginType() string { return base.PluginTypeDriver }
+
+// Run starts the mananger, initializes driver plugins and blocks until Shutdown
+// is called.
+func (m *manager) Run() {
+	// Load any previous plugin reattach configuration
+	m.loadReattachConfigs()
+
+	// Get driver plugins
+	driversPlugins := m.loader.Catalog()[base.PluginTypeDriver]
+	if len(driversPlugins) == 0 {
+		m.logger.Debug("exiting since there are no driver plugins")
+		m.cancel()
+		return
+	}
+
+	var availDrivers []string
+	var skippedDrivers []string
+	for _, d := range driversPlugins {
+		id := loader.PluginInfoID(d)
+		// Skip drivers that are not in the allowed list if it is set.
+		if _, ok := m.allowedDrivers[id.Name]; len(m.allowedDrivers) > 0 && !ok {
+			skippedDrivers = append(skippedDrivers, id.Name)
+			continue
+		}
+		// Skip fingerprinting drivers that are in the blocked list
+		if _, ok := m.blockedDrivers[id.Name]; ok {
+			skippedDrivers = append(skippedDrivers, id.Name)
+			continue
+		}
+
+		storeFn := func(c *plugin.ReattachConfig) error {
+			id := id
+			return m.storePluginReattachConfig(id, c)
+		}
+		fetchFn := func() (*plugin.ReattachConfig, bool) {
+			id := id
+			return m.fetchPluginReattachConfig(id)
+		}
+
+		instance := newInstanceManager(&instanceManagerConfig{
+			Logger:               m.logger,
+			Ctx:                  m.ctx,
+			Loader:               m.loader,
+			StoreReattach:        storeFn,
+			FetchReattach:        fetchFn,
+			PluginConfig:         m.pluginConfig,
+			ID:                   &id,
+			UpdateNodeFromDriver: m.updater,
+		})
+
+		ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+		instance.WaitForFirstFingerprint(ctx)
+		if instance.lastHealthState != drivers.HealthStateUndetected {
+			availDrivers = append(availDrivers, id.Name)
+		}
+		m.instances[id.Name] = instance
+		cancel()
+	}
+
+	m.logger.Debug("detected drivers", "drivers", availDrivers)
+	if len(skippedDrivers) > 0 {
+		m.logger.Debug("drivers skipped due to allow/block list", "skipped_drivers", skippedDrivers)
+	}
+
+	select {
+	case <-m.ctx.Done():
+	}
+}
+
+// Shutdown cleans up all the plugins
+func (m *manager) Shutdown() {
+	// Cancel the context to stop any requests
+	m.cancel()
+
+	// Go through and shut everything down
+	for _, i := range m.instances {
+		i.cleanup()
+	}
+}
+
+func (m *manager) loadReattachConfigs() error {
+	m.reattachConfigLock.Lock()
+	defer m.reattachConfigLock.Unlock()
+
+	s, err := m.state.GetDriverPluginState()
+	if err != nil {
+		return err
+	}
+
+	if s != nil {
+		for name, c := range s.ReattachConfigs {
+			id := loader.PluginID{
+				PluginType: base.PluginTypeDriver,
+				Name:       name,
+			}
+			m.reattachConfigs[id] = c
+		}
+	}
+	return nil
+}
+
+// storePluginReattachConfig is used as a callback to the instance managers and
+// persists thhe plugin reattach configurations.
+func (m *manager) storePluginReattachConfig(id loader.PluginID, c *plugin.ReattachConfig) error {
+	m.reattachConfigLock.Lock()
+	defer m.reattachConfigLock.Unlock()
+
+	// Store the new reattach config
+	m.reattachConfigs[id] = shared.ReattachConfigFromGoPlugin(c)
+
+	// Persist the state
+	s := &state.PluginState{
+		ReattachConfigs: make(map[string]*shared.ReattachConfig, len(m.reattachConfigs)),
+	}
+
+	for id, c := range m.reattachConfigs {
+		s.ReattachConfigs[id.Name] = c
+	}
+
+	return m.state.PutDriverPluginState(s)
+}
+
+// fetchPluginReattachConfig is used as a callback to the instance managers and
+// retrieves the plugin reattach config. If it has not been stored it will
+// return nil
+func (m *manager) fetchPluginReattachConfig(id loader.PluginID) (*plugin.ReattachConfig, bool) {
+	m.reattachConfigLock.Lock()
+	defer m.reattachConfigLock.Unlock()
+
+	if cfg, ok := m.reattachConfigs[id]; ok {
+		c, err := shared.ReattachConfigToGoPlugin(cfg)
+		if err != nil {
+			m.logger.Warn("failed to read plugin reattach config", "config", cfg, "error", err)
+			return nil, false
+		}
+		return c, true
+	}
+	return nil, false
+}
+
+func (m *manager) RegisterEventHandler(driver, taskID string, handler EventHandler) {
+	m.instances[driver].registerEventHandler(taskID, handler)
+}
+
+func (m *manager) DeregisterEventHandler(driver, taskID string) {
+	m.instances[driver].deregisterEventHandler(taskID)
+}
+
+func (m *manager) Dispense(d string) (drivers.DriverPlugin, error) {
+	if instance, ok := m.instances[d]; ok {
+		return instance.dispense()
+	}
+
+	return nil, fmt.Errorf("driver not found")
+}

--- a/client/pluginmanager/drivermanager/manager_test.go
+++ b/client/pluginmanager/drivermanager/manager_test.go
@@ -1,0 +1,282 @@
+package drivermanager
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/nomad/client/pluginmanager"
+	"github.com/hashicorp/nomad/client/state"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/base"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/plugins/shared/loader"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var _ Manager = (*manager)(nil)
+var _ pluginmanager.PluginManager = (*manager)(nil)
+
+func testSetup(t *testing.T) (chan *drivers.Fingerprint, chan *drivers.TaskEvent, *manager) {
+	fpChan := make(chan *drivers.Fingerprint)
+	evChan := make(chan *drivers.TaskEvent)
+	drv := mockDriver(fpChan, evChan)
+	cat := mockCatalog(map[string]drivers.DriverPlugin{"mock": drv})
+	cfg := &Config{
+		Logger:       testlog.HCLogger(t),
+		Loader:       cat,
+		PluginConfig: nil,
+		Updater:      noopUpdater,
+		State:        state.NoopDB{},
+	}
+
+	mgr := New(cfg)
+	return fpChan, evChan, mgr
+}
+
+func mockDriver(fpChan chan *drivers.Fingerprint, evChan chan *drivers.TaskEvent) drivers.DriverPlugin {
+	return &drivers.MockDriver{
+		FingerprintF: func(ctx context.Context) (<-chan *drivers.Fingerprint, error) {
+			return fpChan, nil
+		},
+		TaskEventsF: func(ctx context.Context) (<-chan *drivers.TaskEvent, error) {
+			return evChan, nil
+		},
+	}
+}
+
+func mockCatalog(drivers map[string]drivers.DriverPlugin) *loader.MockCatalog {
+	cat := map[string][]*base.PluginInfoResponse{
+		base.PluginTypeDriver: []*base.PluginInfoResponse{},
+	}
+	for d := range drivers {
+		cat[base.PluginTypeDriver] = append(cat[base.PluginTypeDriver], &base.PluginInfoResponse{
+			Name: d,
+			Type: base.PluginTypeDriver,
+		})
+	}
+
+	return &loader.MockCatalog{
+		DispenseF: func(name, pluginType string, cfg *base.ClientAgentConfig, logger log.Logger) (loader.PluginInstance, error) {
+			d, ok := drivers[name]
+			if !ok {
+				return nil, fmt.Errorf("driver not found")
+			}
+			return loader.MockBasicExternalPlugin(d), nil
+		},
+		ReattachF: func(name, pluginType string, config *plugin.ReattachConfig) (loader.PluginInstance, error) {
+			d, ok := drivers[name]
+			if !ok {
+				return nil, fmt.Errorf("driver not found")
+			}
+			return loader.MockBasicExternalPlugin(d), nil
+		},
+		CatalogF: func() map[string][]*base.PluginInfoResponse {
+			return cat
+		},
+	}
+}
+
+func mockTaskEvent(taskID string) *drivers.TaskEvent {
+	return &drivers.TaskEvent{
+		TaskID:      taskID,
+		Timestamp:   time.Now(),
+		Annotations: map[string]string{},
+		Message:     "event from " + taskID,
+	}
+}
+
+func noopUpdater(string, *structs.DriverInfo) *structs.Node { return nil }
+
+func TestMananger_FingerPrint(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	fpChan, _, mgr := testSetup(t)
+	var infos []*structs.DriverInfo
+	mgr.updater = func(d string, i *structs.DriverInfo) *structs.Node {
+		infos = append(infos, i)
+		return nil
+	}
+	go mgr.Run()
+	defer mgr.Shutdown()
+	fpChan <- &drivers.Fingerprint{Health: drivers.HealthStateHealthy}
+	testutil.WaitForResult(func() (bool, error) {
+		if len(mgr.instances) != 1 {
+			return false, fmt.Errorf("mananger should have registered an instance")
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err)
+	})
+
+	testutil.WaitForResult(func() (bool, error) {
+		if mgr.instances["mock"].lastHealthState != drivers.HealthStateHealthy {
+			return false, fmt.Errorf("mock instance should be healthy")
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err)
+	})
+
+	fpChan <- &drivers.Fingerprint{
+		Health: drivers.HealthStateUnhealthy,
+	}
+	testutil.WaitForResult(func() (bool, error) {
+		if mgr.instances["mock"].lastHealthState == drivers.HealthStateHealthy {
+			return false, fmt.Errorf("mock instance should be unhealthy")
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err)
+	})
+
+	fpChan <- &drivers.Fingerprint{
+		Health: drivers.HealthStateUndetected,
+	}
+	testutil.WaitForResult(func() (bool, error) {
+		if mgr.instances["mock"].lastHealthState != drivers.HealthStateUndetected {
+			return false, fmt.Errorf("mock instance should be undetected")
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err)
+	})
+
+	require.Len(infos, 3)
+	require.True(infos[0].Healthy)
+	require.True(infos[0].Detected)
+	require.False(infos[1].Healthy)
+	require.True(infos[1].Detected)
+	require.False(infos[2].Healthy)
+	require.False(infos[2].Detected)
+}
+
+func TestMananger_TaskEvents(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	fpChan, evChan, mgr := testSetup(t)
+	go mgr.Run()
+	defer mgr.Shutdown()
+	fpChan <- &drivers.Fingerprint{Health: drivers.HealthStateHealthy}
+	testutil.WaitForResult(func() (bool, error) {
+		if len(mgr.instances) != 1 {
+			return false, fmt.Errorf("mananger should have registered 1 instance")
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err, "instances: %v", mgr.instances)
+	})
+
+	event1 := mockTaskEvent("abc1")
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mgr.RegisterEventHandler("mock", "abc1", func(ev *drivers.TaskEvent) {
+		defer wg.Done()
+		require.Exactly(event1, ev)
+	})
+
+	evChan <- event1
+	wg.Wait()
+}
+
+func TestManager_Run_AllowedDrivers(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	fpChan, _, mgr := testSetup(t)
+	mgr.allowedDrivers = map[string]struct{}{"foo": struct{}{}}
+	go mgr.Run()
+	select {
+	case fpChan <- &drivers.Fingerprint{Health: drivers.HealthStateHealthy}:
+	default:
+	}
+	testutil.AssertUntil(200*time.Millisecond, func() (bool, error) {
+		if len(mgr.instances) > 0 {
+			return false, fmt.Errorf("mananger should have no registered instances")
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err, "instances: %v", mgr.instances)
+	})
+}
+
+func TestManager_Run_BlockedDrivers(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	fpChan, _, mgr := testSetup(t)
+	mgr.blockedDrivers = map[string]struct{}{"mock": struct{}{}}
+	go mgr.Run()
+	select {
+	case fpChan <- &drivers.Fingerprint{Health: drivers.HealthStateHealthy}:
+	default:
+	}
+	testutil.AssertUntil(200*time.Millisecond, func() (bool, error) {
+		if len(mgr.instances) > 0 {
+			return false, fmt.Errorf("mananger should have no registered instances")
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err, "instances: %v", mgr.instances)
+	})
+}
+
+func TestManager_Run_AllowedBlockedDrivers_Combined(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	drvs := map[string]drivers.DriverPlugin{}
+	fpChs := map[string]chan *drivers.Fingerprint{}
+	names := []string{"mock1", "mock2", "mock3", "mock4", "mock5"}
+	for _, d := range names {
+		ch := make(chan *drivers.Fingerprint)
+		drv := mockDriver(ch, nil)
+		drvs[d] = drv
+		fpChs[d] = ch
+	}
+	cat := mockCatalog(drvs)
+	cfg := &Config{
+		Logger:       testlog.HCLogger(t),
+		Loader:       cat,
+		PluginConfig: nil,
+		Updater:      noopUpdater,
+		State:        state.NoopDB{},
+		AllowedDrivers: map[string]struct{}{
+			"mock2": struct{}{},
+			"mock3": struct{}{},
+			"mock4": struct{}{},
+			"foo":   struct{}{},
+		},
+		BlockedDrivers: map[string]struct{}{
+			"mock2": struct{}{},
+			"mock4": struct{}{},
+			"bar":   struct{}{},
+		},
+	}
+	mgr := New(cfg)
+
+	go mgr.Run()
+	for _, d := range names {
+		go func(drv string) {
+			select {
+			case fpChs[drv] <- &drivers.Fingerprint{Health: drivers.HealthStateHealthy}:
+			case <-time.After(200 * time.Millisecond):
+			}
+		}(d)
+	}
+
+	testutil.AssertUntil(200*time.Millisecond, func() (bool, error) {
+		if len(mgr.instances) > 1 {
+			return false, fmt.Errorf("mananger should have 1 registered instances")
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err, "instances: %v", mgr.instances)
+	})
+	require.Len(mgr.instances, 1)
+	_, ok := mgr.instances["mock3"]
+	require.True(ok)
+}

--- a/client/pluginmanager/drivermanager/state/state.go
+++ b/client/pluginmanager/drivermanager/state/state.go
@@ -1,0 +1,11 @@
+package state
+
+import "github.com/hashicorp/nomad/plugins/shared"
+
+// PluginState is used to store the driver managers state across restarts of the
+// agent
+type PluginState struct {
+	// ReattachConfigs are the set of reattach configs for plugin's launched by
+	// the driver manager
+	ReattachConfigs map[string]*shared.ReattachConfig
+}

--- a/client/state/db_test.go
+++ b/client/state/db_test.go
@@ -8,6 +8,7 @@ import (
 
 	trstate "github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	driverstate "github.com/hashicorp/nomad/client/drivermanager/state"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/kr/pretty"
@@ -211,6 +212,31 @@ func TestStateDB_DeviceManager(t *testing.T) {
 
 		// Getting should return the available state
 		ps, err = db.GetDevicePluginState()
+		require.NoError(err)
+		require.NotNil(ps)
+		require.Equal(state, ps)
+	})
+}
+
+// TestStateDB_DriverManager asserts the behavior of device manager state related StateDB
+// methods.
+func TestStateDB_DriverManager(t *testing.T) {
+	t.Parallel()
+
+	testDB(t, func(t *testing.T, db StateDB) {
+		require := require.New(t)
+
+		// Getting nonexistent state should return nils
+		ps, err := db.GetDriverPluginState()
+		require.NoError(err)
+		require.Nil(ps)
+
+		// Putting PluginState should work
+		state := &driverstate.PluginState{}
+		require.NoError(db.PutDriverPluginState(state))
+
+		// Getting should return the available state
+		ps, err = db.GetDriverPluginState()
 		require.NoError(err)
 		require.NotNil(ps)
 		require.Equal(state, ps)

--- a/client/state/interface.go
+++ b/client/state/interface.go
@@ -3,6 +3,7 @@ package state
 import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -49,6 +50,14 @@ type StateDB interface {
 	// PutDevicePluginState is used to store the device manager's plugin
 	// state.
 	PutDevicePluginState(state *dmstate.PluginState) error
+
+	// GetDriverPluginState is used to retrieve the driver manager's plugin
+	// state.
+	GetDriverPluginState() (*driverstate.PluginState, error)
+
+	// PutDriverPluginState is used to store the driver manager's plugin
+	// state.
+	PutDriverPluginState(state *driverstate.PluginState) error
 
 	// Close the database. Unsafe for further use after calling regardless
 	// of return value.

--- a/client/state/memdb.go
+++ b/client/state/memdb.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -20,6 +21,9 @@ type MemDB struct {
 
 	// devicemanager -> plugin-state
 	devManagerPs *dmstate.PluginState
+
+	// drivermanager -> plugin-state
+	driverManagerPs *driverstate.PluginState
 
 	mu sync.RWMutex
 }
@@ -148,6 +152,19 @@ func (m *MemDB) GetDevicePluginState() (*dmstate.PluginState, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.devManagerPs, nil
+}
+
+func (m *MemDB) GetDriverPluginState() (*driverstate.PluginState, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.driverManagerPs, nil
+}
+
+func (m *MemDB) PutDriverPluginState(ps *driverstate.PluginState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.driverManagerPs = ps
+	return nil
 }
 
 func (m *MemDB) Close() error {

--- a/client/state/noopdb.go
+++ b/client/state/noopdb.go
@@ -3,6 +3,7 @@ package state
 import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -46,6 +47,14 @@ func (n NoopDB) PutDevicePluginState(ps *dmstate.PluginState) error {
 }
 
 func (n NoopDB) GetDevicePluginState() (*dmstate.PluginState, error) {
+	return nil, nil
+}
+
+func (n NoopDB) PutDriverPluginState(ps *driverstate.PluginState) error {
+	return nil
+}
+
+func (n NoopDB) GetDriverPluginState() (*driverstate.PluginState, error) {
 	return nil, nil
 }
 

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -18,7 +18,6 @@ func Node() *structs.Node {
 		Attributes: map[string]string{
 			"kernel.name":        "linux",
 			"arch":               "x86",
-			"nomad.version":      "0.5.0",
 			"driver.exec":        "1",
 			"driver.mock_driver": "1",
 		},


### PR DESCRIPTION
This PR implements a driver manager that is started by the client and is responsible for driver life-cycle and storage of plugin reattachment configs. AR/TR no longer need a ref to the plugin loader as the driver manager exposes a `Dispense(driver)` function that handles reattachment.

The manager also handles driver fingerprinting and task event routing. The task runner can register an event handler with the manager to match against a taskID from a specific driver. This is how task events are properly sent to the server with the task state update.

This PR also slightly modifies the device manager to conform to the `PluginManager` interface so is can be started and shutdown as part of the `PluginGroup`.

depends on #4922 