### PR TITLE
Move telemetry content stable website

### DIFF
--- a/website/source/docs/configuration/telemetry.html.md
+++ b/website/source/docs/configuration/telemetry.html.md
@@ -31,7 +31,7 @@ telemetry {
 
 This section of the documentation only covers the configuration options for
 `telemetry` stanza. To understand the architecture and metrics themselves,
-please see the [Telemetry guide](/guides/operations/monitoring/telemetry.html).
+please see the [Telemetry guide](/docs/telemetry/index.html).
 
 ## `telemetry` Parameters
 

--- a/website/source/docs/telemetry/index.html.md
+++ b/website/source/docs/telemetry/index.html.md
@@ -1,7 +1,7 @@
 ---
-layout: "guides"
+layout: "docs"
 page_title: "Telemetry"
-sidebar_current: "guides-operations-monitoring-telemetry"
+sidebar_current: "docs-telemetry"
 description: |-
   Learn about the telemetry data available in Nomad.
 ---

--- a/website/source/guides/operating-a-job/resource-utilization.html.md
+++ b/website/source/guides/operating-a-job/resource-utilization.html.md
@@ -83,7 +83,7 @@ While single point in time resource usage measurements are useful, it is often
 more useful to graph resource usage over time to better understand and estimate
 resource usage. Nomad supports outputting resource data to statsite and statsd
 and is the recommended way of monitoring resources. For more information about
-outputting telemetry see the [Telemetry Guide](/guides/operations/monitoring/telemetry.html).
+outputting telemetry see the [Telemetry Guide](/docs/telemetry/index.html).
 
 For more advanced use cases, the resource usage data is also accessible via the
 client's HTTP API. See the documentation of the Client's [allocation HTTP

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -433,6 +433,10 @@
         <a href="/docs/runtime/environment.html">Runtime Environment</a>
       </li>
       
+      <li<%= sidebar_current("docs-telemetry") %>>
+        <a href="/docs/telemetry/index.html">Telemetry</a>
+      </li>
+
       <li<%= sidebar_current("docs-variable-interpolation") %>>
         <a href="/docs/runtime/interpolation.html">Variable Interpolation</a>
       </li>


### PR DESCRIPTION
Merged into master. Takes a page about telemetry that wasn't visible in master and gives it its own place in the docs section. This move goes along with https://github.com/hashicorp/nomad/pull/4929
