### PR TITLE
change to testing utilities to fix rkt tests

### DIFF
--- a/plugins/drivers/testing.go
+++ b/plugins/drivers/testing.go
@@ -117,9 +117,9 @@ func (h *DriverHarness) MkAllocDir(t *TaskConfig, enableLogs bool) func() {
 
 	taskEnv := taskBuilder.Build()
 	if t.Env == nil {
-		t.Env = taskEnv.All()
+		t.Env = taskEnv.Map()
 	} else {
-		for k, v := range taskEnv.All() {
+		for k, v := range taskEnv.Map() {
 			if _, ok := t.Env[k]; !ok {
 				t.Env[k] = v
 			}


### PR DESCRIPTION
in MkAllocDir, do not update TaskConfig with All() from the task builder, just with Env()
This was polluting the task environment variables with node attributes and causing failures in the rkt tests, which do not tolerate periods in environment variables.

Local testing does not indicate any new test failures in the Docker driver.

resolves NMD-1172