### PR TITLE
vault: protect against empty Vault secret response

### DIFF
--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -630,24 +630,15 @@ func (v *vaultClient) getWrappingFn() func(operation, path string) string {
 // it in the client. If the token is not valid for Nomads purposes an error is
 // returned.
 func (v *vaultClient) parseSelfToken() error {
-	// Get the initial lease duration
-	auth := v.client.Auth().Token()
-	var self *vapi.Secret
-
 	// Try looking up the token using the self endpoint
-	secret, err := auth.LookupSelf()
+	secret, err := v.lookupSelf()
 	if err != nil {
-		// Try looking up our token directly
-		self, err = auth.Lookup(v.client.Token())
-		if err != nil {
-			return fmt.Errorf("failed to lookup Vault periodic token: %v", err)
-		}
+		return err
 	}
-	self = secret
 
 	// Read and parse the fields
 	var data tokenData
-	if err := mapstructure.WeakDecode(self.Data, &data); err != nil {
+	if err := mapstructure.WeakDecode(secret.Data, &data); err != nil {
 		return fmt.Errorf("failed to parse Vault token's data block: %v", err)
 	}
 	root := false
@@ -722,6 +713,29 @@ func (v *vaultClient) parseSelfToken() error {
 	}
 
 	return mErr.ErrorOrNil()
+}
+
+// lookupSelf is a helper function that looks up latest self lease info.
+func (v *vaultClient) lookupSelf() (*vapi.Secret, error) {
+	// Get the initial lease duration
+	auth := v.client.Auth().Token()
+
+	secret, err := auth.LookupSelf()
+	if err == nil && secret != nil && secret.Data != nil {
+		return secret, nil
+	}
+
+	// Try looking up our token directly, even when we get an empty response,
+	// in case of an unexpected event - a true failure would occur in this lookup again
+	secret, err = auth.Lookup(v.client.Token())
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("failed to lookup Vault periodic token: %v", err)
+	case secret == nil || secret.Data == nil:
+		return nil, fmt.Errorf("failed to lookup Vault periodic token: got empty response")
+	default:
+		return secret, nil
+	}
 }
 
 // getRole returns the role name to be used when creating tokens


### PR DESCRIPTION
Fixes #4921

Sadly, we don't have proper mechanism to mock Vault client, so not sure how to best test this.

I inspected the Vault client interactions, specially for cases where returned value is nil even if the error is also nil.  I believe we covered all correctly now:
* [`v.client.Sys().InitStatus()`](https://github.com/hashicorp/nomad/blob/f3853f11daa51336a2d46d883b1aff6feeddc7ec/nomad/vault.go#L427) - the value is non-nil boolean
* [`v.client.Sys().CapabilitiesSelf(path)`](https://github.com/hashicorp/nomad/blob/f3853f11daa51336a2d46d883b1aff6feeddc7ec/nomad/vault.go#L812): Capabilities handles empty bodies in [`hasCapability`](https://github.com/hashicorp/nomad/blob/f3853f11daa51336a2d46d883b1aff6feeddc7ec/vendor/github.com/hashicorp/vault/api/sys_capabilities.go#L43-L45) - also the `nil` array is handled with proper fail-safe default.
* [`v.client.Logical().Read(fmt.Sprintf("auth/token/roles/%s", role))`](https://github.com/hashicorp/nomad/blob/f3853f11daa51336a2d46d883b1aff6feeddc7ec/nomad/vault.go#L834-L840) handles when `rsecret` is nil
