### PR TITLE
Support Device Mounts for Exec/Java Drivers

### DIFF
--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -312,6 +312,11 @@ func (d *AllocDir) UnmountAll() error {
 		if err := dir.unmountSpecialDirs(); err != nil {
 			mErr.Errors = append(mErr.Errors, err)
 		}
+
+		// Unmount any task specific mounts
+		if err := dir.unmountTaskMounts(); err != nil {
+			mErr.Errors = append(mErr.Errors, err)
+		}
 	}
 
 	return mErr.ErrorOrNil()

--- a/client/allocdir/fs_darwin.go
+++ b/client/allocdir/fs_darwin.go
@@ -24,3 +24,14 @@ func createSecretDir(dir string) error {
 func removeSecretDir(dir string) error {
 	return os.RemoveAll(dir)
 }
+
+// bindMount mounts src to dst with support for read only mounting.
+// Assumes that filepath.Dir(dst) exists already
+func bindMount(src, dst string, readOnly bool) error {
+	return syscall.Link(src, dst)
+}
+
+// unmount a bind mount.  If the target is already unmounted, no error is returned
+func unmount(path string) error {
+	return syscall.Unlink(path)
+}

--- a/client/allocdir/fs_freebsd.go
+++ b/client/allocdir/fs_freebsd.go
@@ -24,3 +24,14 @@ func createSecretDir(dir string) error {
 func removeSecretDir(dir string) error {
 	return os.RemoveAll(dir)
 }
+
+// bindMount mounts src to dst with support for read only mounting.
+// Assumes that filepath.Dir(dst) exists already
+func bindMount(src, dst string, readOnly bool) error {
+	return syscall.Link(src, dst)
+}
+
+// unmount a bind mount.  If the target is already unmounted, no error is returned
+func unmount(path string) error {
+	return syscall.Unlink(path)
+}

--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -25,15 +24,15 @@ func linkDir(src, dst string) error {
 		return err
 	}
 
-	return syscall.Mount(src, dst, "", syscall.MS_BIND, "")
+	return unix.Mount(src, dst, "", unix.MS_BIND, "")
 }
 
 // unlinkDir unmounts a bind mounted directory as Linux doesn't support
 // hardlinking directories. If the dir is already unmounted no error is
 // returned.
 func unlinkDir(dir string) error {
-	if err := syscall.Unmount(dir, 0); err != nil {
-		if err != syscall.EINVAL {
+	if err := unix.Unmount(dir, 0); err != nil {
+		if err != unix.EINVAL {
 			return err
 		}
 	}
@@ -56,9 +55,9 @@ func createSecretDir(dir string) error {
 		}
 
 		var flags uintptr
-		flags = syscall.MS_NOEXEC
+		flags = unix.MS_NOEXEC
 		options := fmt.Sprintf("size=%dm", secretDirTmpfsSize)
-		if err := syscall.Mount("tmpfs", dir, "tmpfs", flags, options); err != nil {
+		if err := unix.Mount("tmpfs", dir, "tmpfs", flags, options); err != nil {
 			return os.NewSyscallError("mount", err)
 		}
 
@@ -80,7 +79,7 @@ func removeSecretDir(dir string) error {
 	if unix.Geteuid() == 0 {
 		if err := unlinkDir(dir); err != nil {
 			// Ignore invalid path errors
-			if err != syscall.ENOENT {
+			if err != unix.ENOENT {
 				return os.NewSyscallError("unmount", err)
 			}
 		}

--- a/client/allocdir/fs_linux_test.go
+++ b/client/allocdir/fs_linux_test.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -164,4 +166,229 @@ func TestLinuxUnprivilegedSecretDir(t *testing.T) {
 	if err := removeSecretDir(secretsDir); err != nil {
 		t.Fatalf("error removing nonexistent secrets dir %q: %v", secretsDir, err)
 	}
+}
+
+func TestLinuxRoot_BindMounting_DirRW(t *testing.T) {
+	if unix.Geteuid() != 0 {
+		t.Skip("Must be run as root")
+	}
+
+	tmpdir, err := ioutil.TempDir("", "test-linux-root")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	sourceDir := filepath.Join(tmpdir, "sourcedir")
+	require.NoError(t, os.Mkdir(sourceDir, 0601))
+
+	sampleFileContent := randomBytes(30)
+	err = ioutil.WriteFile(
+		filepath.Join(sourceDir, "testfile"),
+		sampleFileContent,
+		0604)
+	require.NoError(t, err)
+
+	target := filepath.Join(tmpdir, "targetdir-rw")
+	defer unmount(target)
+
+	err = bindMount(sourceDir, target, false)
+	require.NoError(t, err)
+
+	// resulting target has the same permissions
+	fi, err := os.Stat(target)
+	require.NoError(t, err)
+	require.EqualValues(t, os.FileMode(0601), fi.Mode().Perm())
+
+	// can see the file in source reference through mount
+	found, err := ioutil.ReadFile(filepath.Join(target, "testfile"))
+	require.NoError(t, err)
+	require.EqualValues(t, sampleFileContent, found)
+
+	fi, err = os.Stat(filepath.Join(target, "testfile"))
+	require.NoError(t, err)
+	require.EqualValues(t, os.FileMode(0604), fi.Mode().Perm())
+
+	// can modify in target path and work is present through source
+	newFileContent := randomBytes(30)
+	err = ioutil.WriteFile(filepath.Join(target, "newtestfile"),
+		newFileContent,
+		0604)
+	require.NoError(t, err)
+
+	found, err = ioutil.ReadFile(filepath.Join(sourceDir, "newtestfile"))
+	require.NoError(t, err)
+	require.EqualValues(t, newFileContent, found)
+
+	// unmount
+	err = unmount(target)
+	require.NoError(t, err)
+
+	// once unmount, cannot read files through target
+	_, err = ioutil.ReadFile(filepath.Join(target, "testfile"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestLinuxRoot_BindMounting_DirRO(t *testing.T) {
+	if unix.Geteuid() != 0 {
+		t.Skip("Must be run as root")
+	}
+
+	tmpdir, err := ioutil.TempDir("", "test-linux-root")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	sourceDir := filepath.Join(tmpdir, "sourcedir")
+	require.NoError(t, os.Mkdir(sourceDir, 0601))
+
+	sampleFileContent := randomBytes(30)
+	err = ioutil.WriteFile(
+		filepath.Join(sourceDir, "testfile"),
+		sampleFileContent,
+		0604)
+	require.NoError(t, err)
+
+	target := filepath.Join(tmpdir, "targetdir-ro")
+	fmt.Printf("created path %v\n", target)
+	defer unmount(target)
+
+	err = bindMount(sourceDir, target, true)
+	require.NoError(t, err)
+
+	// resulting target has the same permissions
+	fi, err := os.Stat(target)
+	require.NoError(t, err)
+	require.EqualValues(t, os.FileMode(0601), fi.Mode().Perm())
+
+	// can see the file in source reference through mount
+	found, err := ioutil.ReadFile(filepath.Join(target, "testfile"))
+	require.NoError(t, err)
+	require.EqualValues(t, sampleFileContent, found)
+
+	fi, err = os.Stat(filepath.Join(target, "testfile"))
+	require.NoError(t, err)
+	require.EqualValues(t, os.FileMode(0604), fi.Mode().Perm())
+
+	// cannot write to target path
+	err = ioutil.WriteFile(filepath.Join(target, "newtestfile"),
+		randomBytes(30),
+		0604)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read-only file system")
+
+	// unmount
+	err = unmount(target)
+	require.NoError(t, err)
+
+	// once unmount, cannot read files through target
+	_, err = ioutil.ReadFile(filepath.Join(target, "testfile"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestLinuxRoot_BindMounting_FileRW(t *testing.T) {
+	if unix.Geteuid() != 0 {
+		t.Skip("Must be run as root")
+	}
+
+	tmpdir, err := ioutil.TempDir("", "test-linux-root")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	source := filepath.Join(tmpdir, "sourcefile")
+
+	sampleFileContent := randomBytes(30)
+	err = ioutil.WriteFile(source, sampleFileContent, 0604)
+	require.NoError(t, err)
+
+	target := filepath.Join(tmpdir, "sourcefile-rw")
+	defer unmount(target)
+
+	err = bindMount(source, target, false)
+	require.NoError(t, err)
+
+	// resulting target has the same permissions
+	fi, err := os.Stat(target)
+	require.NoError(t, err)
+	require.EqualValues(t, os.FileMode(0604), fi.Mode().Perm())
+
+	// can see the file in source reference through mount
+	found, err := ioutil.ReadFile(target)
+	require.NoError(t, err)
+	require.EqualValues(t, sampleFileContent, found)
+
+	// can modify in target path and work is present through source
+	newFileContent := randomBytes(30)
+	err = ioutil.WriteFile(target,
+		newFileContent,
+		0604)
+	require.NoError(t, err)
+
+	found, err = ioutil.ReadFile(source)
+	require.NoError(t, err)
+	require.EqualValues(t, newFileContent, found)
+
+	// unmount
+	err = unmount(target)
+	require.NoError(t, err)
+
+	// Once unmount, the target should appear empty.
+	// The file may not necessarily be deleted
+	found, _ = ioutil.ReadFile(target)
+	require.Len(t, found, 0)
+}
+
+func TestLinuxRoot_BindMounting_FileRO(t *testing.T) {
+	if unix.Geteuid() != 0 {
+		t.Skip("Must be run as root")
+	}
+
+	tmpdir, err := ioutil.TempDir("", "test-linux-root")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	source := filepath.Join(tmpdir, "sourcefile")
+
+	sampleFileContent := randomBytes(30)
+	err = ioutil.WriteFile(source, sampleFileContent, 0604)
+	require.NoError(t, err)
+
+	target := filepath.Join(tmpdir, "sourcefile-ro")
+	defer unmount(target)
+
+	err = bindMount(source, target, true)
+	require.NoError(t, err)
+
+	// resulting target has the same permissions
+	fi, err := os.Stat(target)
+	require.NoError(t, err)
+	require.EqualValues(t, os.FileMode(0604), fi.Mode().Perm())
+
+	// can see the file in source reference through mount
+	found, err := ioutil.ReadFile(target)
+	require.NoError(t, err)
+	require.EqualValues(t, sampleFileContent, found)
+
+	// can modify in target path and work is present through source
+	err = ioutil.WriteFile(target,
+		randomBytes(30),
+		0604)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read-only file system")
+
+	// unmount
+	err = unmount(target)
+	require.NoError(t, err)
+
+	// Once unmount, the target should appear empty.
+	// The file may not necessarily be deleted
+	found, _ = ioutil.ReadFile(target)
+	require.Len(t, found, 0)
+}
+
+func randomBytes(c int) []byte {
+	b := make([]byte, c)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic("could not generate random bytes")
+	}
+
+	return b
 }

--- a/client/allocdir/fs_solaris.go
+++ b/client/allocdir/fs_solaris.go
@@ -25,3 +25,14 @@ func createSecretDir(dir string) error {
 func removeSecretDir(dir string) error {
 	return os.RemoveAll(dir)
 }
+
+// bindMount mounts src to dst with support for read only mounting.
+// Assumes that filepath.Dir(dst) exists already
+func bindMount(src, dst string, readOnly bool) error {
+	return syscall.Link(src, dst)
+}
+
+// unmount a bind mount.  If the target is already unmounted, no error is returned
+func unmount(path string) error {
+	return syscall.Unlink(path)
+}

--- a/client/allocdir/fs_windows.go
+++ b/client/allocdir/fs_windows.go
@@ -64,3 +64,13 @@ func unmountSpecialDirs(taskDir string) error {
 func getOwner(os.FileInfo) (int, int) {
 	return idUnsupported, idUnsupported
 }
+
+// bindMount does nothing currently
+func bindMount(src, dst string, readOnly bool) error {
+	return nil
+}
+
+// unmount does nothing currently
+func unmount(path string) error {
+	return nil
+}

--- a/client/allocdir/task_dir.go
+++ b/client/allocdir/task_dir.go
@@ -161,6 +161,21 @@ func (t *TaskDir) buildChroot(chrootCreated bool, entries map[string]string) err
 	return nil
 }
 
+// Mount bind-mounts source path from host into dest path inside task directory.
+// This method is not thread safe, and is expected to be called in the task dir
+// preparation goroutine
+func (t *TaskDir) Mount(source, dest string, readonly bool) error {
+	if err := createDir(t.Dir, filepath.Dir(dest)); err != nil {
+		return fmt.Errorf("failed to create destination directory %v: %v", dest, err)
+	}
+
+	return bindMount(source, filepath.Join(t.Dir, dest), readonly)
+}
+
+func (t *TaskDir) Unmount(path string) error {
+	return unmount(filepath.Join(t.Dir, path))
+}
+
 func (t *TaskDir) embedDirs(entries map[string]string) error {
 	subdirs := make(map[string]string)
 	for source, dest := range entries {

--- a/client/allocrunner/taskrunner/device_mount_hook.go
+++ b/client/allocrunner/taskrunner/device_mount_hook.go
@@ -1,0 +1,77 @@
+package taskrunner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+)
+
+type deviceMountHook struct {
+	runner *TaskRunner
+	logger hclog.Logger
+
+	// Stored state to be used by Stop
+	chroot *allocdir.TaskDir
+	mounts []string
+}
+
+func newDeviceMountHook(runner *TaskRunner, logger hclog.Logger) *deviceMountHook {
+	h := &deviceMountHook{
+		runner: runner,
+	}
+	h.logger = logger.Named(h.Name())
+	return h
+}
+
+func (h *deviceMountHook) Name() string {
+	return "device_mounting"
+}
+
+func (h *deviceMountHook) Prestart(ctx context.Context,
+	req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
+
+	// Mount only when task runner is responsible for creating the chroot isolation for task.
+	// Drivers with image based isolation (e.g. docker, qemu) need to mount devices, instead.
+	if h.runner.driverCapabilities.FSIsolation != cstructs.FSIsolationChroot {
+		resp.Done = true
+		return nil
+	}
+
+	h.chroot = h.runner.taskDir
+
+	for _, d := range h.runner.hookResources.getDevices() {
+		readOnly := d.Permissions != "rw"
+		if err := h.chroot.Mount(d.HostPath, d.TaskPath, readOnly); err != nil {
+			return fmt.Errorf("failed to mount device %s: %v", d.TaskPath, err)
+		}
+
+		h.mounts = append(h.mounts, d.TaskPath)
+	}
+
+	for _, d := range h.runner.hookResources.getMounts() {
+		if err := h.chroot.Mount(d.HostPath, d.TaskPath, d.Readonly); err != nil {
+			return fmt.Errorf("failed to mount mount %s: %v", d.TaskPath, err)
+		}
+
+		h.mounts = append(h.mounts, d.TaskPath)
+	}
+
+	return nil
+}
+
+func (h *deviceMountHook) Stop(context.Context, *interfaces.TaskStopRequest, *interfaces.TaskStopResponse) error {
+	var merr multierror.Error
+
+	for _, m := range h.mounts {
+		if err := h.chroot.Unmount(m); err != nil {
+			merr.Errors = append(merr.Errors, fmt.Errorf("failed to unmount %v: %v", m, err))
+		}
+	}
+
+	return merr.ErrorOrNil()
+}

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -64,6 +64,7 @@ func (tr *TaskRunner) initHooks() {
 		newArtifactHook(tr, hookLogger),
 		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, hookLogger),
 		newDeviceHook(tr.devicemanager, hookLogger),
+		newDeviceMountHook(tr, hookLogger),
 	}
 
 	// If Vault is enabled, add the hook


### PR DESCRIPTION
Adds support for device mounting for chroot-based drivers, namely exec and java.

The approach is to add a task dir hook that mounts individual devices and mounts into the chroot environment.

Though, the unmounting happens in the alloc/task dir destruction, rather than in a stop hook, similar to the special devices that get mounted in chroot.  I initially started with using a stop hook; and I'm not sure which approach is actually better.