### PR TITLE
remove redirects for vault-integration docs

### DIFF
--- a/website/redirects.txt
+++ b/website/redirects.txt
@@ -143,9 +143,6 @@
 /docs/service-discovery                       /guides/operations/consul-integration/index.html
 /docs/service-discovery/                      /guides/operations/consul-integration/index.html
 /docs/service-discovery/index.html            /guides/operations/consul-integration/index.html
-/docs/vault-integration                       /guides/operations/vault-integration/index.html
-/docs/vault-integration/                      /guides/operations/vault-integration/index.html
-/docs/vault-integration/index.html            /guides/operations/vault-integration/index.html
 
 # API
 /docs/http/index.html                   /api/index.html


### PR DESCRIPTION
We now have vault-integration content in the docs section and a new vault-integration guide in the guides section, but everything was being directed to the new content. Removed the appropriate redirects to make sure both pages are accessible.