### PR TITLE
tests: no t.Parallel() in table driven tests

### DIFF
--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -79,7 +79,6 @@ func TestExecutor_Start_Invalid(pt *testing.T) {
 	invalid := "/bin/foobar"
 	for name, factory := range executorFactories {
 		pt.Run(name, func(t *testing.T) {
-			t.Parallel()
 			require := require.New(t)
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = invalid
@@ -98,7 +97,6 @@ func TestExecutor_Start_Wait_Failure_Code(pt *testing.T) {
 	pt.Parallel()
 	for name, factory := range executorFactories {
 		pt.Run(name, func(t *testing.T) {
-			t.Parallel()
 			require := require.New(t)
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = "/bin/date"
@@ -121,7 +119,6 @@ func TestExecutor_Start_Wait(pt *testing.T) {
 	pt.Parallel()
 	for name, factory := range executorFactories {
 		pt.Run(name, func(t *testing.T) {
-			t.Parallel()
 			require := require.New(t)
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = "/bin/echo"
@@ -157,7 +154,6 @@ func TestExecutor_WaitExitSignal(pt *testing.T) {
 	pt.Parallel()
 	for name, factory := range executorFactories {
 		pt.Run(name, func(t *testing.T) {
-			t.Parallel()
 			require := require.New(t)
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = "/bin/sleep"
@@ -191,7 +187,6 @@ func TestExecutor_Start_Kill(pt *testing.T) {
 	pt.Parallel()
 	for name, factory := range executorFactories {
 		pt.Run(name, func(t *testing.T) {
-			t.Parallel()
 			require := require.New(t)
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = "/bin/sleep"


### PR DESCRIPTION
When `t.Parallel()` is used inside a `t.Run()` sub-set, the closure
doesn't behave as expected, and some cases effectively get skipped.
More details can be found in https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721

FWIW, the executor tests are currently failing consistently with this change, as libcontainer expects a rootfs with `/bin/{echo|date|date}` to be present but we construct an empty chroot now.

~~Also, a minor change to get `TestFingerprintManager_Run_Combination` test passing.~~