### PR TITLE
executor: kill all container processes

### DIFF
--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestMain(m *testing.M) {
@@ -137,7 +138,7 @@ func TestExecDriver_StartWaitStop(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		result := <-ch
-		require.Equal(2, result.Signal)
+		require.Equal(int(unix.SIGINT), result.Signal)
 	}()
 
 	require.NoError(harness.WaitUntilStarted(task.ID, 1*time.Second))
@@ -160,7 +161,71 @@ func TestExecDriver_StartWaitStop(t *testing.T) {
 		status, err := harness.InspectTask(task.ID)
 		require.NoError(err)
 		require.Equal(drivers.TaskStateExited, status.State)
-	case <-time.After(1 * time.Second):
+	case <-time.After(10 * time.Second):
+		require.Fail("timeout waiting for task to shutdown")
+	}
+
+	require.NoError(harness.DestroyTask(task.ID, true))
+}
+
+func TestExecDriver_StartWaitStopKill(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	ctestutils.ExecCompatible(t)
+
+	d := NewExecDriver(testlog.HCLogger(t))
+	harness := drivers.NewDriverHarness(t, d)
+	task := &drivers.TaskConfig{
+		ID:   uuid.Generate(),
+		Name: "test",
+	}
+
+	taskConfig := map[string]interface{}{
+		"command": "/bin/bash",
+		"args":    []string{"-c", "echo hi; sleep 600"},
+	}
+	encodeDriverHelper(require, task, taskConfig)
+
+	cleanup := harness.MkAllocDir(task, false)
+	defer cleanup()
+
+	handle, _, err := harness.StartTask(task)
+	require.NoError(err)
+
+	ch, err := harness.WaitTask(context.Background(), handle.Config.ID)
+	require.NoError(err)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		result := <-ch
+
+		// /bin/bash typically ignores INT, so it will be killed eventually
+		require.Equal(int(unix.SIGKILL), result.Signal)
+	}()
+
+	require.NoError(harness.WaitUntilStarted(task.ID, 1*time.Second))
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := harness.StopTask(task.ID, 2*time.Second, "SIGINT")
+		require.NoError(err)
+	}()
+
+	waitCh := make(chan struct{})
+	go func() {
+		defer close(waitCh)
+		wg.Wait()
+	}()
+
+	select {
+	case <-waitCh:
+		status, err := harness.InspectTask(task.ID)
+		require.NoError(err)
+		require.Equal(drivers.TaskStateExited, status.State)
+	case <-time.After(10 * time.Second):
 		require.Fail("timeout waiting for task to shutdown")
 	}
 

--- a/drivers/java/driver_test.go
+++ b/drivers/java/driver_test.go
@@ -1,11 +1,11 @@
 package java
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"context"
@@ -105,7 +105,7 @@ func TestJavaDriver_Jar_Stop_Wait(t *testing.T) {
 
 	task := basicTask(t, "demo-app", map[string]interface{}{
 		"jar_path":    "demoapp.jar",
-		"args":        []string{"20"},
+		"args":        []string{"600"},
 		"jvm_options": []string{"-Xmx64m", "-Xms32m"},
 	})
 
@@ -120,39 +120,35 @@ func TestJavaDriver_Jar_Stop_Wait(t *testing.T) {
 	ch, err := harness.WaitTask(context.Background(), handle.Config.ID)
 	require.NoError(err)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		result := <-ch
-		require.Equal(2, result.Signal)
-	}()
-
 	require.NoError(harness.WaitUntilStarted(task.ID, 1*time.Second))
 
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
-
 		time.Sleep(10 * time.Millisecond)
-		err := harness.StopTask(task.ID, 2*time.Second, "SIGINT")
-		require.NoError(err)
-	}()
-
-	waitCh := make(chan struct{})
-	go func() {
-		defer close(waitCh)
-		wg.Wait()
+		harness.StopTask(task.ID, 2*time.Second, "SIGINT")
 	}()
 
 	select {
-	case <-waitCh:
-		status, err := harness.InspectTask(task.ID)
-		require.NoError(err)
-		require.Equal(drivers.TaskStateExited, status.State)
-	case <-time.After(5 * time.Second):
+	case result := <-ch:
+		require.False(result.Successful())
+	case <-time.After(10 * time.Second):
 		require.Fail("timeout waiting for task to shutdown")
 	}
+
+	// Ensure that the task is marked as dead, but account
+	// for WaitTask() closing channel before internal state is updated
+	testutil.WaitForResult(func() (bool, error) {
+		status, err := harness.InspectTask(task.ID)
+		if err != nil {
+			return false, fmt.Errorf("inspecting task failed: %v", err)
+		}
+		if status.State != drivers.TaskStateExited {
+			return false, fmt.Errorf("task hasn't exited yet; status: %v", status.State)
+		}
+
+		return true, nil
+	}, func(err error) {
+		require.NoError(err)
+	})
 
 	require.NoError(harness.DestroyTask(task.ID, true))
 }

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -247,7 +247,7 @@ func (l *LibcontainerExecutor) wait() {
 			ps = exitErr.ProcessState
 		} else {
 			l.logger.Error("failed to call wait on user process", "error", err)
-			l.exitState = &ProcessState{Pid: 0, ExitCode: 0, Time: time.Now()}
+			l.exitState = &ProcessState{Pid: 0, ExitCode: -2, Time: time.Now()}
 			return
 		}
 	}
@@ -319,10 +319,10 @@ func (l *LibcontainerExecutor) Shutdown(signal string, grace time.Duration) erro
 		case <-l.userProcExited:
 			return nil
 		case <-time.After(grace):
-			return l.container.Signal(os.Kill, false)
+			return l.container.Signal(os.Kill, true)
 		}
 	} else {
-		return l.container.Signal(os.Kill, false)
+		return l.container.Signal(os.Kill, true)
 	}
 }
 


### PR DESCRIPTION
For drivers using libcontainer executor (i.e. exec and java), kill all container processes after the graceful shutdown grace period.

This fixes a regression from 0.8.6, where the task gets stuck at termination if the kicked process does not terminate on `SIGINT`.  If the parent process is killed with SIGKILL, the child processes are left runner.  `libcontainer` would still consider the container to be running until they die naturally.