### PR TITLE
consul: fix script checks exiting after 1 run

### DIFF
--- a/command/agent/consul/script.go
+++ b/command/agent/consul/script.go
@@ -97,7 +97,6 @@ func (s *scriptCheck) run() *scriptHandle {
 			switch err {
 			case context.Canceled:
 				// check removed during execution; exit
-				cancel()
 				return
 			case context.DeadlineExceeded:
 				metrics.IncrCounter([]string{"client", "consul", "script_timeouts"}, 1)
@@ -111,9 +110,6 @@ func (s *scriptCheck) run() *scriptHandle {
 				// failures
 				s.logger.Warn("check timed out", "timeout", s.check.Timeout)
 			}
-
-			// cleanup context
-			cancel()
 
 			state := api.HealthCritical
 			switch code {

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -777,10 +777,6 @@ func TestConsul_RegServices(t *testing.T) {
 // TestConsul_ShutdownOK tests the ok path for the shutdown logic in
 // ServiceClient.
 func TestConsul_ShutdownOK(t *testing.T) {
-	// FIXME: This test is failing now because checks are called once only
-	// not sure what changed
-	t.Skip("FIXME: unexpected failing test")
-
 	require := require.New(t)
 	ctx := setupFake(t)
 
@@ -832,7 +828,7 @@ func TestConsul_ShutdownOK(t *testing.T) {
 		t.Fatalf("expected 1 checkTTL entry but found: %d", n)
 	}
 	for _, v := range ctx.FakeConsul.checkTTLs {
-		require.Equalf(2, v, "expected 2 updates but foud %d", v)
+		require.Equalf(2, v, "expected 2 updates but found %d", v)
 	}
 	for _, v := range ctx.FakeConsul.checks {
 		if v.Status != "passing" {


### PR DESCRIPTION
Fixes a regression caused in d335a82859ca2177bc6deda0c2c85b559daf2db3

The removal of the inner context made the remaining cancels cancel the
outer context and cause script checks to exit prematurely.