### PR TITLE
Fix docker driver tests

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -433,6 +433,11 @@ func TestDockerDriver_Start_StoppedContainer(t *testing.T) {
 	defer cleanup()
 	copyImage(t, task.TaskDir(), "busybox.tar")
 
+	client := newTestDockerClient(t)
+	imageID, err := d.Impl().(*Driver).loadImage(task, &taskCfg, client)
+	require.NoError(t, err)
+	require.NotEmpty(t, imageID)
+
 	// Create a container of the same name but don't start it. This mimics
 	// the case of dockerd getting restarted and stopping containers while
 	// Nomad is watching them.
@@ -444,12 +449,11 @@ func TestDockerDriver_Start_StoppedContainer(t *testing.T) {
 		},
 	}
 
-	client := newTestDockerClient(t)
 	if _, err := client.CreateContainer(opts); err != nil {
 		t.Fatalf("error creating initial container: %v", err)
 	}
 
-	_, _, err := d.StartTask(task)
+	_, _, err = d.StartTask(task)
 	require.NoError(t, err)
 
 	defer d.DestroyTask(task.ID, true)


### PR DESCRIPTION
Some tests have containers that die almost immediately, and may die
and cleaned up before `driver.WaitUntilStarted` runs.

The causes for container dying seems special for each test:
* TestDockerDriver_Cleanup: `hello-world` image just emits a message and exits immediately
* TestDockerDriver_ForcePull_RepoDigest: the busybox image in `TestDockerDriver_ForcePull_RepoDigest` test didn't support `-p 0` argument
* TestDockerDriver_Entrypoint: with the entrypoint being `/bin/sh -c`, the command needs to be the entire string; otherwise, it ignores the comments

Also for `TestDockerDriver_Start_StoppedContainer` - the busybox isn't always loaded as part of the test setup - so we'd get `driver_test.go:447: error creating initial container: no such image` error.