### PR TITLE
Implemented bind mount type; added tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,20 @@ git:
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       env: RUN_UI_TESTS=1 SKIP_NOMAD_TESTS=1
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
     - os: osx
       osx_image: xcode9.1
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       env: RUN_E2E_TESTS=1 SKIP_NOMAD_TESTS=1
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,20 @@ git:
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: trusty
       sudo: required
     - os: linux
-      dist: xenial
+      dist: trusty
       sudo: false
       env: RUN_UI_TESTS=1 SKIP_NOMAD_TESTS=1
     - os: linux
-      dist: xenial
+      dist: trusty
       sudo: false
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
     - os: osx
       osx_image: xcode9.1
     - os: linux
-      dist: xenial
+      dist: trusty
       sudo: required
       env: RUN_E2E_TESTS=1 SKIP_NOMAD_TESTS=1
   allow_failures:

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -2130,7 +2130,7 @@ func setupDockerBindMount(t *testing.T, cfg *config.Config, hostpath string) (*s
 	}
 
 	// Build alloc and task directory structure
-	allocDir := allocdir.NewAllocDir(testlog.Logger(t), filepath.Join(cfg.AllocDir, uuid.Generate()))
+	allocDir := allocdir.NewAllocDir(testLogger(), filepath.Join(cfg.AllocDir, uuid.Generate()))
 	if err := allocDir.Build(); err != nil {
 		t.Fatalf("failed to build alloc dir: %v", err)
 	}
@@ -2143,11 +2143,11 @@ func setupDockerBindMount(t *testing.T, cfg *config.Config, hostpath string) (*s
 
 	// Setup driver
 	alloc := mock.Alloc()
-	logger := testlog.Logger(t)
+	logger := testLogger()
 	emitter := func(m string, args ...interface{}) {
 		logger.Printf("[EVENT] "+m, args...)
 	}
-	driverCtx := NewDriverContext(alloc.Job.Name, alloc.TaskGroup, task.Name, alloc.ID, cfg, cfg.Node, testlog.Logger(t), emitter)
+	driverCtx := NewDriverContext(alloc.Job.Name, alloc.TaskGroup, task.Name, alloc.ID, cfg, cfg.Node, testLogger(), emitter)
 	driver := NewDockerDriver(driverCtx)
 
 	// Setup execCtx

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -634,7 +634,7 @@ func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
 		if !res.Successful() {
 			t.Fatalf("err: %v", res)
 		}
-	case <-time.After(time.Duration(tu.TestMultiplier()*5) * time.Second):
+	case <-time.After(time.Duration(tu.TestMultiplier()*10) * time.Second):
 		t.Fatalf("timeout")
 	}
 
@@ -1890,7 +1890,7 @@ func TestDockerDriver_VolumesEnabled(t *testing.T) {
 	}
 }
 
-func TestDockerDriver_Mounts(t *testing.T) {
+func TestDockerDriver_VolumeMounts(t *testing.T) {
 	if !tu.IsTravis() {
 		t.Parallel()
 	}
@@ -1899,6 +1899,7 @@ func TestDockerDriver_Mounts(t *testing.T) {
 	}
 
 	goodMount := map[string]interface{}{
+		"type":   "volume",
 		"target": "/nomad",
 		"volume_options": []interface{}{
 			map[string]interface{}{
@@ -1937,10 +1938,26 @@ func TestDockerDriver_Mounts(t *testing.T) {
 			Mounts: []interface{}{goodMount, goodMount, goodMount},
 		},
 		{
-			Name:  "multiple volume options",
-			Error: "Only one volume_options stanza allowed",
+			Name:  "bind_options in bind mount error",
+			Error: "bind_options invalid on \"volume\" mount type",
 			Mounts: []interface{}{
 				map[string]interface{}{
+					"type":   "volume",
+					"target": "/nomad",
+					"bind_options": []interface{}{
+						map[string]interface{}{
+							"propagation": "shared",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:  "multiple volume options",
+			Error: "only one volume_options stanza allowed",
+			Mounts: []interface{}{
+				map[string]interface{}{
+					"type":   "volume",
 					"target": "/nomad",
 					"volume_options": []interface{}{
 						map[string]interface{}{
@@ -1966,6 +1983,7 @@ func TestDockerDriver_Mounts(t *testing.T) {
 			Error: "volume driver config may only be specified once",
 			Mounts: []interface{}{
 				map[string]interface{}{
+					"type":   "volume",
 					"target": "/nomad",
 					"volume_options": []interface{}{
 						map[string]interface{}{
@@ -1987,6 +2005,7 @@ func TestDockerDriver_Mounts(t *testing.T) {
 			Error: "labels may only be",
 			Mounts: []interface{}{
 				map[string]interface{}{
+					"type":   "volume",
 					"target": "/nomad",
 					"volume_options": []interface{}{
 						map[string]interface{}{
@@ -2004,6 +2023,7 @@ func TestDockerDriver_Mounts(t *testing.T) {
 			Error: "driver options may only",
 			Mounts: []interface{}{
 				map[string]interface{}{
+					"type":   "volume",
 					"target": "/nomad",
 					"volume_options": []interface{}{
 						map[string]interface{}{
@@ -2020,6 +2040,308 @@ func TestDockerDriver_Mounts(t *testing.T) {
 									},
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	task := &structs.Task{
+		Name:   "redis-demo",
+		Driver: "docker",
+		Config: map[string]interface{}{
+			"image":   "busybox",
+			"load":    "busybox.tar",
+			"command": "/bin/sleep",
+			"args":    []string{"10000"},
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 256,
+			CPU:      512,
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			// Build the task
+			task.Config["mounts"] = c.Mounts
+
+			ctx := testDockerDriverContexts(t, task)
+			driver := NewDockerDriver(ctx.DriverCtx)
+			copyImage(t, ctx.ExecCtx.TaskDir, "busybox.tar")
+			defer ctx.AllocDir.Destroy()
+
+			_, err := driver.Prestart(ctx.ExecCtx, task)
+			if err == nil && c.Error != "" {
+				t.Fatalf("expected error: %v", c.Error)
+			} else if err != nil {
+				if c.Error == "" {
+					t.Fatalf("unexpected error in prestart: %v", err)
+				} else if !strings.Contains(err.Error(), c.Error) {
+					t.Fatalf("expected error %q; got %v", c.Error, err)
+				}
+			}
+		})
+	}
+}
+
+func setupDockerBindMount(t *testing.T, cfg *config.Config, hostpath string) (*structs.Task, Driver, *ExecContext, string, func()) {
+	if !testutil.DockerIsConnected(t) {
+		t.Skip("Docker not connected")
+	}
+
+	randfn := fmt.Sprintf("test-%d", rand.Int())
+	hostfile := filepath.Join(hostpath, randfn)
+	containerPath := "/mnt/vol"
+	containerFile := filepath.Join(containerPath, randfn)
+
+	task := &structs.Task{
+		Name:   "ls",
+		Driver: "docker",
+		Config: map[string]interface{}{
+			"image":   "busybox",
+			"load":    "busybox.tar",
+			"command": "touch",
+			"args":    []string{containerFile},
+			"mounts": []interface{}{
+				map[string]interface{}{
+					"readonly": "false",
+					"source":   hostpath,
+					"target":   containerPath,
+					"type":     "bind",
+					"bind_options": []interface{}{
+						map[string]interface{}{
+							"propagation": "shared",
+						},
+					},
+				},
+			},
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: basicResources,
+	}
+
+	// Build alloc and task directory structure
+	allocDir := allocdir.NewAllocDir(testlog.Logger(t), filepath.Join(cfg.AllocDir, uuid.Generate()))
+	if err := allocDir.Build(); err != nil {
+		t.Fatalf("failed to build alloc dir: %v", err)
+	}
+	taskDir := allocDir.NewTaskDir(task.Name)
+	if err := taskDir.Build(false, nil, cstructs.FSIsolationImage); err != nil {
+		allocDir.Destroy()
+		t.Fatalf("failed to build task dir: %v", err)
+	}
+	copyImage(t, taskDir, "busybox.tar")
+
+	// Setup driver
+	alloc := mock.Alloc()
+	logger := testlog.Logger(t)
+	emitter := func(m string, args ...interface{}) {
+		logger.Printf("[EVENT] "+m, args...)
+	}
+	driverCtx := NewDriverContext(alloc.Job.Name, alloc.TaskGroup, task.Name, alloc.ID, cfg, cfg.Node, testlog.Logger(t), emitter)
+	driver := NewDockerDriver(driverCtx)
+
+	// Setup execCtx
+	envBuilder := env.NewBuilder(cfg.Node, alloc, task, cfg.Region)
+	SetEnvvars(envBuilder, driver.FSIsolation(), taskDir, cfg)
+	execCtx := NewExecContext(taskDir, envBuilder.Build())
+
+	// Setup cleanup function
+	cleanup := func() {
+		allocDir.Destroy()
+		if filepath.IsAbs(hostpath) {
+			os.RemoveAll(hostpath)
+		}
+	}
+	return task, driver, execCtx, hostfile, cleanup
+}
+
+func TestDockerDriver_BindMount_VolumesDisabled(t *testing.T) {
+	if !tu.IsTravis() {
+		t.Parallel()
+	}
+	if !testutil.DockerIsConnected(t) {
+		t.Skip("Docker not connected")
+	}
+
+	cfg := testConfig(t)
+	cfg.Options = map[string]string{
+		dockerVolumesConfigOption: "false",
+		"docker.cleanup.image":    "false",
+	}
+
+	{
+		tmpvol, err := ioutil.TempDir("", "nomadtest_docker_volumesdisabled")
+		if err != nil {
+			t.Fatalf("error creating temporary dir: %v", err)
+		}
+
+		task, driver, execCtx, _, cleanup := setupDockerBindMount(t, cfg, tmpvol)
+		defer cleanup()
+
+		_, err = driver.Prestart(execCtx, task)
+		if err != nil {
+			t.Fatalf("error in prestart: %v", err)
+		}
+		if _, err := driver.Start(execCtx, task); err == nil {
+			t.Fatalf("Started driver successfully when volumes should have been disabled.")
+		}
+	}
+
+	// Relative paths should still be allowed
+	{
+		task, driver, execCtx, fn, cleanup := setupDockerBindMount(t, cfg, ".")
+		defer cleanup()
+
+		_, err := driver.Prestart(execCtx, task)
+		if err != nil {
+			t.Fatalf("error in prestart: %v", err)
+		}
+		resp, err := driver.Start(execCtx, task)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer resp.Handle.Kill()
+
+		select {
+		case res := <-resp.Handle.WaitCh():
+			if !res.Successful() {
+				t.Fatalf("unexpected err: %v", res)
+			}
+		case <-time.After(time.Duration(tu.TestMultiplier()*10) * time.Second):
+			t.Fatalf("timeout")
+		}
+
+		if _, err := ioutil.ReadFile(filepath.Join(execCtx.TaskDir.Dir, fn)); err != nil {
+			t.Fatalf("unexpected error reading %s: %v", fn, err)
+		}
+	}
+}
+
+func TestDockerDriver_BindMount_VolumesEnabled(t *testing.T) {
+	if !tu.IsTravis() {
+		t.Parallel()
+	}
+	if !testutil.DockerIsConnected(t) {
+		t.Skip("Docker not connected")
+	}
+
+	cfg := testConfig(t)
+
+	tmpvol, err := ioutil.TempDir("", "nomadtest_docker_volumesenabled")
+	if err != nil {
+		t.Fatalf("error creating temporary dir: %v", err)
+	}
+
+	// Evaluate symlinks so it works on MacOS
+	tmpvol, err = filepath.EvalSymlinks(tmpvol)
+	if err != nil {
+		t.Fatalf("error evaluating symlinks: %v", err)
+	}
+
+	task, driver, execCtx, hostpath, cleanup := setupDockerBindMount(t, cfg, tmpvol)
+	defer cleanup()
+
+	_, err = driver.Prestart(execCtx, task)
+	if err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := driver.Start(execCtx, task)
+	if err != nil {
+		t.Fatalf("Failed to start docker driver: %v", err)
+	}
+	defer resp.Handle.Kill()
+
+	select {
+	case res := <-resp.Handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("unexpected err: %v", res)
+		}
+	case <-time.After(time.Duration(tu.TestMultiplier()*10) * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	if _, err := ioutil.ReadFile(hostpath); err != nil {
+		t.Fatalf("unexpected error reading %s: %v", hostpath, err)
+	}
+}
+
+func TestDockerDriver_BindMount(t *testing.T) {
+	if !tu.IsTravis() {
+		t.Parallel()
+	}
+	if !testutil.DockerIsConnected(t) {
+		t.Skip("Docker not connected")
+	}
+
+	goodMount := map[string]interface{}{
+		"type":   "bind",
+		"target": "/nomad",
+		"bind_options": []interface{}{
+			map[string]interface{}{
+				"propagation": "shared",
+			},
+		},
+		"readonly": true,
+		"source":   "test",
+	}
+
+	cases := []struct {
+		Name   string
+		Mounts []interface{}
+		Error  string
+	}{
+		{
+			Name:   "good-one",
+			Error:  "",
+			Mounts: []interface{}{goodMount},
+		},
+		{
+			Name:   "good-many",
+			Error:  "",
+			Mounts: []interface{}{goodMount, goodMount, goodMount},
+		},
+		{
+			Name:  "volume_options in bind mount error",
+			Error: "volume_options invalid on \"bind\" mount type",
+			Mounts: []interface{}{
+				map[string]interface{}{
+					"type":   "bind",
+					"target": "/nomad",
+					"volume_options": []interface{}{
+						map[string]interface{}{
+							"driver_config": []interface{}{
+								map[string]interface{}{
+									"name": "local",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:  "multiple bind options",
+			Error: "only one bind_options stanza allowed",
+			Mounts: []interface{}{
+				map[string]interface{}{
+					"type":   "bind",
+					"target": "/nomad",
+					"bind_options": []interface{}{
+						map[string]interface{}{
+							"propagation": "shared",
+						},
+						map[string]interface{}{
+							"propagation": "shared",
 						},
 					},
 				},

--- a/client/driver/docker_test.go
+++ b/client/driver/docker_test.go
@@ -2166,7 +2166,9 @@ func setupDockerBindMount(t *testing.T, cfg *config.Config, hostpath string) (*s
 }
 
 func TestDockerDriver_BindMount_VolumesDisabled(t *testing.T) {
-	if !tu.IsTravis() {
+	if tu.IsTravis() {
+		t.Skip("Need to upgrade to Ubuntu 16.04+")
+	} else {
 		t.Parallel()
 	}
 	if !testutil.DockerIsConnected(t) {
@@ -2228,7 +2230,9 @@ func TestDockerDriver_BindMount_VolumesDisabled(t *testing.T) {
 }
 
 func TestDockerDriver_BindMount_VolumesEnabled(t *testing.T) {
-	if !tu.IsTravis() {
+	if tu.IsTravis() {
+		t.Skip("Need to upgrade to Ubuntu 16.04+")
+	} else {
 		t.Parallel()
 	}
 	if !testutil.DockerIsConnected(t) {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1574,13 +1574,13 @@ func (n *Node) Stub() *NodeListStub {
 	addr, _, _ := net.SplitHostPort(n.HTTPAddr)
 
 	return &NodeListStub{
-		Address:               addr,
-		ID:                    n.ID,
-		Datacenter:            n.Datacenter,
-		Name:                  n.Name,
-		NodeClass:             n.NodeClass,
-		Version:               n.Attributes["nomad.version"],
-		Drain:                 n.Drain,
+		Address:    addr,
+		ID:         n.ID,
+		Datacenter: n.Datacenter,
+		Name:       n.Name,
+		NodeClass:  n.NodeClass,
+		Version:    n.Attributes["nomad.version"],
+		Drain:      n.Drain,
 		SchedulingEligibility: n.SchedulingEligibility,
 		Status:                n.Status,
 		StatusDescription:     n.StatusDescription,


### PR DESCRIPTION
Implemented the `bind` mount type. This will allow Windows users to mount absolute paths.  This is #4761 squashed and patched onto release-087 base