### PR TITLE
tests: fix rkt tests

### DIFF
--- a/command/integration_test.go
+++ b/command/integration_test.go
@@ -23,7 +23,7 @@ func TestIntegration_Command_NomadInit(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	{
-		cmd := exec.Command("nomad", "init")
+		cmd := exec.Command("nomad", "job", "init")
 		cmd.Dir = tmpDir
 		if err := cmd.Run(); err != nil {
 			t.Fatalf("error running init: %v", err)
@@ -31,7 +31,7 @@ func TestIntegration_Command_NomadInit(t *testing.T) {
 	}
 
 	{
-		cmd := exec.Command("nomad", "validate", "example.nomad")
+		cmd := exec.Command("nomad", "job", "validate", "example.nomad")
 		cmd.Dir = tmpDir
 		cmd.Env = []string{`NOMAD_ADDR=http://127.0.0.1:0`}
 		if err := cmd.Run(); err != nil {
@@ -52,13 +52,13 @@ func TestIntegration_Command_RoundTripJob(t *testing.T) {
 	defer srv.Shutdown()
 
 	{
-		cmd := exec.Command("nomad", "init")
+		cmd := exec.Command("nomad", "job", "init")
 		cmd.Dir = tmpDir
 		assert.Nil(cmd.Run())
 	}
 
 	{
-		cmd := exec.Command("nomad", "run", "example.nomad")
+		cmd := exec.Command("nomad", "job", "run", "example.nomad")
 		cmd.Dir = tmpDir
 		cmd.Env = []string{fmt.Sprintf("NOMAD_ADDR=%s", url)}
 		err := cmd.Run()
@@ -68,7 +68,7 @@ func TestIntegration_Command_RoundTripJob(t *testing.T) {
 	}
 
 	{
-		cmd := exec.Command("nomad", "inspect", "example")
+		cmd := exec.Command("nomad", "job", "inspect", "example")
 		cmd.Dir = tmpDir
 		cmd.Env = []string{fmt.Sprintf("NOMAD_ADDR=%s", url)}
 		out, err := cmd.Output()
@@ -83,4 +83,13 @@ func TestIntegration_Command_RoundTripJob(t *testing.T) {
 		assert.Nil(err)
 		assert.NotZero(resp.EvalID)
 	}
+
+	{
+		cmd := exec.Command("nomad", "job", "stop", "example")
+		cmd.Dir = tmpDir
+		cmd.Env = []string{fmt.Sprintf("NOMAD_ADDR=%s", url)}
+		_, err := cmd.Output()
+		assert.Nil(err)
+	}
+
 }

--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -652,7 +652,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 			MemoryMB: int(drivers.BytesToMB(cfg.Resources.LinuxResources.MemoryLimitBytes)),
 			DiskMB:   cfg.Resources.NomadResources.DiskMB,
 		},
-		Env:        cfg.EnvList(),
+		Env:        rktEnv.List(),
 		TaskDir:    cfg.TaskDir().Dir,
 		StdoutPath: cfg.StdoutPath,
 		StderrPath: cfg.StderrPath,

--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -125,7 +125,7 @@ var (
 	capabilities = &drivers.Capabilities{
 		SendSignals: true,
 		Exec:        true,
-		FSIsolation: cstructs.FSIsolationChroot,
+		FSIsolation: cstructs.FSIsolationImage,
 	}
 
 	reRktVersion  = regexp.MustCompile(`rkt [vV]ersion[:]? (\d[.\d]+)`)


### PR DESCRIPTION
Fix rkt tests by marking the isolation level as image and ensuring that PATH env-var is properly set.

With a rider change related to managing integration tests and attempting to stop process as well.