### PR TITLE
drivers/exec: Support devices mounts

### DIFF
--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -308,6 +308,8 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 		TaskDir:        cfg.TaskDir().Dir,
 		StdoutPath:     cfg.StdoutPath,
 		StderrPath:     cfg.StderrPath,
+		Mounts:         cfg.Mounts,
+		Devices:        cfg.Devices,
 	}
 
 	ps, err := exec.Launch(execCmd)

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -490,6 +490,97 @@ func TestExecDriver_HandlerExec(t *testing.T) {
 	require.NoError(harness.DestroyTask(task.ID, true))
 }
 
+func TestExecDriver_DevicesAndMounts(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	ctestutils.ExecCompatible(t)
+
+	tmpDir, err := ioutil.TempDir("", "exec_binds_mounts")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("from-host"), 600)
+	require.NoError(err)
+
+	d := NewExecDriver(testlog.HCLogger(t))
+	harness := dtestutil.NewDriverHarness(t, d)
+	task := &drivers.TaskConfig{
+		ID:         uuid.Generate(),
+		Name:       "test",
+		StdoutPath: filepath.Join(tmpDir, "task-stdout"),
+		StderrPath: filepath.Join(tmpDir, "task-stderr"),
+		Devices: []*drivers.DeviceConfig{
+			{
+				TaskPath:    "/dev/inserted-random",
+				HostPath:    "/dev/random",
+				Permissions: "rw",
+			},
+		},
+		Mounts: []*drivers.MountConfig{
+			{
+				TaskPath: "/tmp/task-path-rw",
+				HostPath: tmpDir,
+				Readonly: false,
+			},
+			{
+				TaskPath: "/tmp/task-path-ro",
+				HostPath: tmpDir,
+				Readonly: true,
+			},
+		},
+	}
+
+	require.NoError(ioutil.WriteFile(task.StdoutPath, []byte{}, 660))
+	require.NoError(ioutil.WriteFile(task.StderrPath, []byte{}, 660))
+
+	taskConfig := map[string]interface{}{
+		"command": "/bin/bash",
+		"args": []string{"-c", `
+export LANG=en.UTF-8
+echo "mounted device /inserted-random: $(stat -c '%t:%T' /dev/inserted-random)"
+echo "reading from ro path: $(cat /tmp/task-path-ro/testfile)"
+echo "reading from rw path: $(cat /tmp/task-path-rw/testfile)"
+touch /tmp/task-path-rw/testfile && echo 'overwriting file in rw succeeded'
+touch /tmp/task-path-rw/testfile-from-rw && echo from-exec >  /tmp/task-path-rw/testfile-from-rw && echo 'writing new file in rw succeeded'
+touch /tmp/task-path-ro/testfile && echo 'overwriting file in ro succeeded'
+touch /tmp/task-path-ro/testfile-from-ro && echo from-exec >  /tmp/task-path-ro/testfile-from-ro && echo 'writing new file in ro succeeded'
+exit 0
+`},
+	}
+	encodeDriverHelper(require, task, taskConfig)
+
+	cleanup := harness.MkAllocDir(task, false)
+	defer cleanup()
+
+	handle, _, err := harness.StartTask(task)
+	require.NoError(err)
+
+	ch, err := harness.WaitTask(context.Background(), handle.Config.ID)
+	require.NoError(err)
+	result := <-ch
+	require.NoError(harness.DestroyTask(task.ID, true))
+
+	stdout, err := ioutil.ReadFile(task.StdoutPath)
+	require.NoError(err)
+	require.Equal(`mounted device /inserted-random: 1:8
+reading from ro path: from-host
+reading from rw path: from-host
+overwriting file in rw succeeded
+writing new file in rw succeeded`, strings.TrimSpace(string(stdout)))
+
+	stderr, err := ioutil.ReadFile(task.StderrPath)
+	require.NoError(err)
+	require.Equal(`touch: cannot touch '/tmp/task-path-ro/testfile': Read-only file system
+touch: cannot touch '/tmp/task-path-ro/testfile-from-ro': Read-only file system`, strings.TrimSpace(string(stderr)))
+
+	// testing exit code last so we can inspect output first
+	require.Zero(result.ExitCode)
+
+	fromRWContent, err := ioutil.ReadFile(filepath.Join(tmpDir, "testfile-from-rw"))
+	require.NoError(err)
+	require.Equal("from-exec", strings.TrimSpace(string(fromRWContent)))
+}
+
 func encodeDriverHelper(require *require.Assertions, task *drivers.TaskConfig, taskConfig map[string]interface{}) {
 	evalCtx := &hcl.EvalContext{
 		Functions: shared.GetStdlibFuncs(),

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -344,6 +344,8 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 		TaskDir:    cfg.TaskDir().Dir,
 		StdoutPath: cfg.StdoutPath,
 		StderrPath: cfg.StderrPath,
+		Mounts:     cfg.Mounts,
+		Devices:    cfg.Devices,
 	}
 
 	ps, err := exec.Launch(execCmd)

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/nomad/client/stats"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	shelpers "github.com/hashicorp/nomad/helper/stats"
+	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
 const (
@@ -120,6 +121,12 @@ type ExecCommand struct {
 	// doesn't enforce resource limits. To enforce limits, set ResourceLimits.
 	// Using the cgroup does allow more precise cleanup of processes.
 	BasicProcessCgroup bool
+
+	// Mounts are the host paths to be be made available inside rootfs
+	Mounts []*drivers.MountConfig
+
+	// Devices are the the device nodes to be created in isolation environment
+	Devices []*drivers.DeviceConfig
 }
 
 type nopCloser struct {

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -17,8 +17,11 @@ import (
 	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/plugins/drivers"
 	tu "github.com/hashicorp/nomad/testutil"
+	lconfigs "github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func init() {
@@ -193,4 +196,67 @@ func TestExecutor_ClientCleanup(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	output1 := execCmd.stdout.(*bufferCloser).String()
 	require.Equal(len(output), len(output1))
+}
+
+func TestExecutor_cmdDevices(t *testing.T) {
+	input := []*drivers.DeviceConfig{
+		{
+			HostPath:    "/dev/null",
+			TaskPath:    "/task/dev/null",
+			Permissions: "rwm",
+		},
+	}
+
+	expected := &lconfigs.Device{
+		Path:        "/task/dev/null",
+		Type:        99,
+		Major:       1,
+		Minor:       3,
+		Permissions: "rwm",
+	}
+
+	found, err := cmdDevices(input)
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+
+	// ignore file permission and ownership
+	// as they are host specific potentially
+	d := found[0]
+	d.FileMode = 0
+	d.Uid = 0
+	d.Gid = 0
+
+	require.EqualValues(t, expected, d)
+}
+
+func TestExecutor_cmdMounts(t *testing.T) {
+	input := []*drivers.MountConfig{
+		{
+			HostPath: "/host/path-ro",
+			TaskPath: "/task/path-ro",
+			Readonly: true,
+		},
+		{
+			HostPath: "/host/path-rw",
+			TaskPath: "/task/path-rw",
+			Readonly: false,
+		},
+	}
+
+	expected := []*lconfigs.Mount{
+		{
+			Source:      "/host/path-ro",
+			Destination: "/task/path-ro",
+			Flags:       unix.MS_BIND | unix.MS_RDONLY,
+			Device:      "bind",
+		},
+		{
+			Source:      "/host/path-rw",
+			Destination: "/task/path-rw",
+			Flags:       unix.MS_BIND,
+			Device:      "bind",
+		},
+	}
+
+	require.EqualValues(t, expected, cmdMounts(input))
 }


### PR DESCRIPTION
Similar to https://github.com/hashicorp/nomad/pull/4933 - but makes task mounts and devices (injected through device plugins) available in exec and java drivers.

It uses libcontainer support for mounting and configuring device cgroups; unlike the earlier attempt made in https://github.com/hashicorp/nomad/pull/4941 .