### PR TITLE
Don't GC running but desired stop allocations

### DIFF
--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -7,7 +7,6 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
-
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler"
@@ -620,6 +619,12 @@ func (c *CoreScheduler) partitionDeploymentReap(deployments []string) []*structs
 func allocGCEligible(a *structs.Allocation, job *structs.Job, gcTime time.Time, thresholdIndex uint64) bool {
 	// Not in a terminal status and old enough
 	if !a.TerminalStatus() || a.ModifyIndex > thresholdIndex {
+		return false
+	}
+
+	// If the allocation is still running on the client we can not garbage
+	// collect it.
+	if a.ClientStatus == structs.AllocClientStatusRunning {
 		return false
 	}
 

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -1973,6 +1973,16 @@ func TestAllocation_GCEligible(t *testing.T) {
 			ShouldGC:       false,
 		},
 		{
+			Desc:           "Don't GC when non terminal on client and job dead",
+			ClientStatus:   structs.AllocClientStatusRunning,
+			DesiredStatus:  structs.AllocDesiredStatusStop,
+			JobStatus:      structs.JobStatusDead,
+			GCTime:         fail,
+			ModifyIndex:    90,
+			ThresholdIndex: 90,
+			ShouldGC:       false,
+		},
+		{
 			Desc:             "GC when terminal but not failed ",
 			ClientStatus:     structs.AllocClientStatusComplete,
 			DesiredStatus:    structs.AllocDesiredStatusRun,


### PR DESCRIPTION
This PR fixes an edge case where we could GC an allocation that was in a
desired stop state but had not terminated yet. This can be hit if the
client hasn't shutdown the allocation yet or if the allocation is still
shutting down (long kill_timeout).

Fixes https://github.com/hashicorp/nomad/issues/4940