### PR TITLE
UI: Keep line charts in their canvases at all times

### DIFF
--- a/ui/app/components/stats-time-series.js
+++ b/ui/app/components/stats-time-series.js
@@ -51,9 +51,17 @@ export default LineChart.extend({
   }),
 
   yScale: computed('data.[]', 'yProp', 'xAxisOffset', function() {
+    const yProp = this.get('yProp');
+    const yValues = (this.get('data') || []).mapBy(yProp);
+
+    let [low, high] = [0, 1];
+    if (yValues.compact().length) {
+      [low, high] = d3Array.extent(yValues);
+    }
+
     return d3Scale
       .scaleLinear()
       .rangeRound([this.get('xAxisOffset'), 10])
-      .domain([0, 1]);
+      .domain([Math.min(0, low), Math.max(1, high)]);
   }),
 });


### PR DESCRIPTION
Today the stat charts y-domain is always bound to 0-1 (0-100%), but due to CPU soft limits (and maybe future other soft limits, who knows), this doesn't always work.

This PR makes 0-1 the default, but will go below 0 and above 1 if the data domain is outside of the 0-1 bounds.