### PR TITLE
Recover from any possible io error when invoking Write on FileRotator

### DIFF
--- a/client/logmon/logging/rotator.go
+++ b/client/logmon/logging/rotator.go
@@ -145,6 +145,12 @@ func (f *FileRotator) Write(p []byte) (n int, err error) {
 		f.currentWr += int64(n)
 		if err != nil {
 			f.logger.Error("error writing to file", "err", err)
+
+			// As bufio writer does not automatically recover in case of any
+			// io error, we need to recover from it manually resetting the
+			// writter.
+			f.createOrResetBuffer()
+
 			return
 		}
 	}


### PR DESCRIPTION
As of now, FileRotator uses bufio.Write under the hood to write data to
configured output file. Due to the way how bufio handles any occurred io
error - saves it into `err` variable never resetting it automatically -
any operation like `Write`, `Flush` etc will become a no-op, returning the very same,
saved error (eg. Out of disk space) even when the problem is fixed (eg. disk
space is available again).

That automatically means that FileRotator will stop writing any logs,
reporting the same error over and over again, even if it's no longer
valid.

This PR fixes it by resetting the bufio Writer, which resets any errors
and tries to write requested data.