### PR TITLE
rpc accept loop: added backoff on logging

### DIFF
--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -49,8 +49,8 @@ const (
 
 type rpcHandler struct {
 	*Server
-	logger   log.Logger
-	gologger *golog.Logger
+	logger          log.Logger
+	gologger        *golog.Logger
 	acceptLoopDelay time.Duration
 }
 
@@ -102,7 +102,7 @@ func (r *rpcHandler) listen(ctx context.Context) {
 			r.handleAcceptErr(err, ctx)
 			continue
 		}
-		// No error, reset delay loop
+		// No error, reset loop delay
 		r.acceptLoopDelay = 0
 
 		go r.handleConn(ctx, conn, &RPCContext{Conn: conn})
@@ -113,7 +113,7 @@ func (r *rpcHandler) listen(ctx context.Context) {
 // Sleep to avoid spamming the log, with a maximum delay according to whether or not the error is temporary
 func (r *rpcHandler) handleAcceptErr(err error, ctx context.Context) {
 	const baseAcceptLoopDelay = 5 * time.Millisecond
-	const maxAcceptLoopDelay  = 5 * time.Second
+	const maxAcceptLoopDelay = 5 * time.Second
 	const maxAcceptLoopDelayTemporaryError = 1 * time.Second
 
 	if r.acceptLoopDelay == 0 {

--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -133,7 +133,7 @@ func (r *rpcHandler) handleAcceptErr(err error, ctx context.Context) {
 	r.logger.Error("failed to accept RPC conn", "error", err, "delay", r.acceptLoopDelay)
 	select {
 	case <-ctx.Done():
-	case <-time.After(maxAcceptLoopDelay):
+	case <-time.After(r.acceptLoopDelay):
 	}
 }
 

--- a/vendor/github.com/hashicorp/memberlist/Makefile
+++ b/vendor/github.com/hashicorp/memberlist/Makefile
@@ -1,3 +1,5 @@
+DEPS := $(shell go list -f '{{range .Imports}}{{.}} {{end}}' ./...)
+
 test: subnet
 	go test ./...
 
@@ -11,4 +13,8 @@ cov:
 	gocov test github.com/hashicorp/memberlist | gocov-html > /tmp/coverage.html
 	open /tmp/coverage.html
 
-.PNONY: test cov integ
+deps:
+	go get -t -d -v ./...
+	echo $(DEPS) | xargs -n1 go get -d
+
+.PHONY: test cov integ

--- a/vendor/github.com/hashicorp/memberlist/README.md
+++ b/vendor/github.com/hashicorp/memberlist/README.md
@@ -1,4 +1,4 @@
-# memberlist [![GoDoc](https://godoc.org/github.com/hashicorp/memberlist?status.png)](https://godoc.org/github.com/hashicorp/memberlist)
+# memberlist [![GoDoc](https://godoc.org/github.com/hashicorp/memberlist?status.png)](https://godoc.org/github.com/hashicorp/memberlist) [![Build Status](https://travis-ci.org/hashicorp/memberlist.svg?branch=master)](https://travis-ci.org/hashicorp/memberlist)
 
 memberlist is a [Go](http://www.golang.org) library that manages cluster
 membership and member failure detection using a gossip based protocol.
@@ -22,6 +22,8 @@ Please check your installation with:
 ```
 go version
 ```
+
+Run `make deps` to fetch dependencies before building
 
 ## Usage
 
@@ -63,82 +65,11 @@ For complete documentation, see the associated [Godoc](http://godoc.org/github.c
 
 ## Protocol
 
-memberlist is based on ["SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol"](http://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf),
-with a few minor adaptations, mostly to increase propagation speed and
+memberlist is based on ["SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol"](http://ieeexplore.ieee.org/document/1028914/). However, we extend the protocol in a number of ways:
+
+* Several extensions are made to increase propagation speed and
 convergence rate.
+* Another set of extensions, that we call Lifeguard, are made to make memberlist more robust in the presence of slow message processing (due to factors such as CPU starvation, and network delay or loss).
 
-A high level overview of the memberlist protocol (based on SWIM) is
-described below, but for details please read the full
-[SWIM paper](http://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf)
-followed by the memberlist source. We welcome any questions related
+For details on all of these extensions, please read our paper "[Lifeguard : SWIM-ing with Situational Awareness](https://arxiv.org/abs/1707.00788)", along with the memberlist source.  We welcome any questions related
 to the protocol on our issue tracker.
-
-### Protocol Description
-
-memberlist begins by joining an existing cluster or starting a new
-cluster. If starting a new cluster, additional nodes are expected to join
-it. New nodes in an existing cluster must be given the address of at
-least one existing member in order to join the cluster. The new member
-does a full state sync with the existing member over TCP and begins gossiping its
-existence to the cluster.
-
-Gossip is done over UDP with a configurable but fixed fanout and interval.
-This ensures that network usage is constant with regards to number of nodes, as opposed to
-exponential growth that can occur with traditional heartbeat mechanisms.
-Complete state exchanges with a random node are done periodically over
-TCP, but much less often than gossip messages. This increases the likelihood
-that the membership list converges properly since the full state is exchanged
-and merged. The interval between full state exchanges is configurable or can
-be disabled entirely.
-
-Failure detection is done by periodic random probing using a configurable interval.
-If the node fails to ack within a reasonable time (typically some multiple
-of RTT), then an indirect probe as well as a direct TCP probe are attempted. An
-indirect probe asks a configurable number of random nodes to probe the same node,
-in case there are network issues causing our own node to fail the probe. The direct
-TCP probe is used to help identify the common situation where networking is
-misconfigured to allow TCP but not UDP. Without the TCP probe, a UDP-isolated node
-would think all other nodes were suspect and could cause churn in the cluster when
-it attempts a TCP-based state exchange with another node. It is not desirable to
-operate with only TCP connectivity because convergence will be much slower, but it
-is enabled so that memberlist can detect this situation and alert operators.
-
-If both our probe, the indirect probes, and the direct TCP probe fail within a
-configurable time, then the node is marked "suspicious" and this knowledge is
-gossiped to the cluster. A suspicious node is still considered a member of
-cluster. If the suspect member of the cluster does not dispute the suspicion
-within a configurable period of time, the node is finally considered dead,
-and this state is then gossiped to the cluster.
-
-This is a brief and incomplete description of the protocol. For a better idea,
-please read the
-[SWIM paper](http://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf)
-in its entirety, along with the memberlist source code.
-
-### Changes from SWIM
-
-As mentioned earlier, the memberlist protocol is based on SWIM but includes
-minor changes, mostly to increase propagation speed and convergence rates.
-
-The changes from SWIM are noted here:
-
-* memberlist does a full state sync over TCP periodically. SWIM only propagates
-  changes over gossip. While both eventually reach convergence, the full state
-  sync increases the likelihood that nodes are fully converged more quickly,
-  at the expense of more bandwidth usage. This feature can be totally disabled
-  if you wish.
-
-* memberlist has a dedicated gossip layer separate from the failure detection
-  protocol. SWIM only piggybacks gossip messages on top of probe/ack messages.
-  memberlist also piggybacks gossip messages on top of probe/ack messages, but
-  also will periodically send out dedicated gossip messages on their own. This
-  feature lets you have a higher gossip rate (for example once per 200ms)
-  and a slower failure detection rate (such as once per second), resulting
-  in overall faster convergence rates and data propagation speeds. This feature
-  can be totally disabed as well, if you wish.
-
-* memberlist stores around the state of dead nodes for a set amount of time,
-  so that when full syncs are requested, the requester also receives information
-  about dead nodes. Because SWIM doesn't do full syncs, SWIM deletes dead node
-  state immediately upon learning that the node is dead. This change again helps
-  the cluster converge more quickly.

--- a/vendor/github.com/hashicorp/memberlist/delegate.go
+++ b/vendor/github.com/hashicorp/memberlist/delegate.go
@@ -12,7 +12,7 @@ type Delegate interface {
 	// NotifyMsg is called when a user-data message is received.
 	// Care should be taken that this method does not block, since doing
 	// so would block the entire UDP packet receive loop. Additionally, the byte
-	// slice may be modified after the call returns, so it should be copied if needed.
+	// slice may be modified after the call returns, so it should be copied if needed
 	NotifyMsg([]byte)
 
 	// GetBroadcasts is called when user data messages can be broadcast.

--- a/vendor/github.com/hashicorp/memberlist/mock_transport.go
+++ b/vendor/github.com/hashicorp/memberlist/mock_transport.go
@@ -1,0 +1,121 @@
+package memberlist
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+)
+
+// MockNetwork is used as a factory that produces MockTransport instances which
+// are uniquely addressed and wired up to talk to each other.
+type MockNetwork struct {
+	transports map[string]*MockTransport
+	port       int
+}
+
+// NewTransport returns a new MockTransport with a unique address, wired up to
+// talk to the other transports in the MockNetwork.
+func (n *MockNetwork) NewTransport() *MockTransport {
+	n.port += 1
+	addr := fmt.Sprintf("127.0.0.1:%d", n.port)
+	transport := &MockTransport{
+		net:      n,
+		addr:     &MockAddress{addr},
+		packetCh: make(chan *Packet),
+		streamCh: make(chan net.Conn),
+	}
+
+	if n.transports == nil {
+		n.transports = make(map[string]*MockTransport)
+	}
+	n.transports[addr] = transport
+	return transport
+}
+
+// MockAddress is a wrapper which adds the net.Addr interface to our mock
+// address scheme.
+type MockAddress struct {
+	addr string
+}
+
+// See net.Addr.
+func (a *MockAddress) Network() string {
+	return "mock"
+}
+
+// See net.Addr.
+func (a *MockAddress) String() string {
+	return a.addr
+}
+
+// MockTransport directly plumbs messages to other transports its MockNetwork.
+type MockTransport struct {
+	net      *MockNetwork
+	addr     *MockAddress
+	packetCh chan *Packet
+	streamCh chan net.Conn
+}
+
+// See Transport.
+func (t *MockTransport) FinalAdvertiseAddr(string, int) (net.IP, int, error) {
+	host, portStr, err := net.SplitHostPort(t.addr.String())
+	if err != nil {
+		return nil, 0, err
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, 0, fmt.Errorf("Failed to parse IP %q", host)
+	}
+
+	port, err := strconv.ParseInt(portStr, 10, 16)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return ip, int(port), nil
+}
+
+// See Transport.
+func (t *MockTransport) WriteTo(b []byte, addr string) (time.Time, error) {
+	dest, ok := t.net.transports[addr]
+	if !ok {
+		return time.Time{}, fmt.Errorf("No route to %q", addr)
+	}
+
+	now := time.Now()
+	dest.packetCh <- &Packet{
+		Buf:       b,
+		From:      t.addr,
+		Timestamp: now,
+	}
+	return now, nil
+}
+
+// See Transport.
+func (t *MockTransport) PacketCh() <-chan *Packet {
+	return t.packetCh
+}
+
+// See Transport.
+func (t *MockTransport) DialTimeout(addr string, timeout time.Duration) (net.Conn, error) {
+	dest, ok := t.net.transports[addr]
+	if !ok {
+		return nil, fmt.Errorf("No route to %q", addr)
+	}
+
+	p1, p2 := net.Pipe()
+	dest.streamCh <- p1
+	return p2, nil
+}
+
+// See Transport.
+func (t *MockTransport) StreamCh() <-chan net.Conn {
+	return t.streamCh
+}
+
+// See Transport.
+func (t *MockTransport) Shutdown() error {
+	return nil
+}

--- a/vendor/github.com/hashicorp/memberlist/net.go
+++ b/vendor/github.com/hashicorp/memberlist/net.go
@@ -8,9 +8,10 @@ import (
 	"hash/crc32"
 	"io"
 	"net"
+	"sync/atomic"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/go-msgpack/codec"
 )
 
@@ -55,6 +56,7 @@ const (
 	encryptMsg
 	nackRespMsg
 	hasCrcMsg
+	errMsg
 )
 
 // compressionType is used to specify the compression algorithm
@@ -68,11 +70,10 @@ const (
 	MetaMaxSize            = 512 // Maximum size for node meta data
 	compoundHeaderOverhead = 2   // Assumed header overhead
 	compoundOverhead       = 2   // Assumed overhead per entry in compoundHeader
-	udpBufSize             = 65536
-	udpRecvBuf             = 2 * 1024 * 1024
 	userMsgOverhead        = 1
 	blockingWarning        = 10 * time.Millisecond // Warn if a UDP packet takes this long to process
-	maxPushStateBytes      = 10 * 1024 * 1024
+	maxPushStateBytes      = 20 * 1024 * 1024
+	maxPushPullRequests    = 128 // Maximum number of concurrent push/pull requests
 )
 
 // ping request sent directly to node
@@ -105,6 +106,11 @@ type ackResp struct {
 // that the indirect ping attempt happened but didn't succeed.
 type nackResp struct {
 	SeqNo uint32
+}
+
+// err response is sent to relay the error from the remote end
+type errResp struct {
+	Error string
 }
 
 // suspect is broadcast when we suspect a node is dead
@@ -185,46 +191,45 @@ func (m *Memberlist) encryptionVersion() encryptionVersion {
 	}
 }
 
-// setUDPRecvBuf is used to resize the UDP receive window. The function
-// attempts to set the read buffer to `udpRecvBuf` but backs off until
-// the read buffer can be set.
-func setUDPRecvBuf(c *net.UDPConn) {
-	size := udpRecvBuf
+// streamListen is a long running goroutine that pulls incoming streams from the
+// transport and hands them off for processing.
+func (m *Memberlist) streamListen() {
 	for {
-		if err := c.SetReadBuffer(size); err == nil {
-			break
+		select {
+		case conn := <-m.transport.StreamCh():
+			go m.handleConn(conn)
+
+		case <-m.shutdownCh:
+			return
 		}
-		size = size / 2
 	}
 }
 
-// tcpListen listens for and handles incoming connections
-func (m *Memberlist) tcpListen() {
-	for {
-		conn, err := m.tcpListener.AcceptTCP()
-		if err != nil {
-			if m.shutdown {
-				break
-			}
-			m.logger.Printf("[ERR] memberlist: Error accepting TCP connection: %s", err)
-			continue
-		}
-		go m.handleConn(conn)
-	}
-}
-
-// handleConn handles a single incoming TCP connection
-func (m *Memberlist) handleConn(conn *net.TCPConn) {
-	m.logger.Printf("[DEBUG] memberlist: TCP connection %s", LogConn(conn))
+// handleConn handles a single incoming stream connection from the transport.
+func (m *Memberlist) handleConn(conn net.Conn) {
+	m.logger.Printf("[DEBUG] memberlist: Stream connection %s", LogConn(conn))
 
 	defer conn.Close()
 	metrics.IncrCounter([]string{"memberlist", "tcp", "accept"}, 1)
 
 	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
-	msgType, bufConn, dec, err := m.readTCP(conn)
+	msgType, bufConn, dec, err := m.readStream(conn)
 	if err != nil {
 		if err != io.EOF {
 			m.logger.Printf("[ERR] memberlist: failed to receive: %s %s", err, LogConn(conn))
+
+			resp := errResp{err.Error()}
+			out, err := encode(errMsg, &resp)
+			if err != nil {
+				m.logger.Printf("[ERR] memberlist: Failed to encode error response: %s", err)
+				return
+			}
+
+			err = m.rawSendMsgStream(conn, out.Bytes())
+			if err != nil {
+				m.logger.Printf("[ERR] memberlist: Failed to send error: %s %s", err, LogConn(conn))
+				return
+			}
 		}
 		return
 	}
@@ -235,6 +240,16 @@ func (m *Memberlist) handleConn(conn *net.TCPConn) {
 			m.logger.Printf("[ERR] memberlist: Failed to receive user message: %s %s", err, LogConn(conn))
 		}
 	case pushPullMsg:
+		// Increment counter of pending push/pulls
+		numConcurrent := atomic.AddUint32(&m.pushPullReq, 1)
+		defer atomic.AddUint32(&m.pushPullReq, ^uint32(0))
+
+		// Check if we have too many open push/pull requests
+		if numConcurrent >= maxPushPullRequests {
+			m.logger.Printf("[ERR] memberlist: Too many pending push/pull requests")
+			return
+		}
+
 		join, remoteNodes, userState, err := m.readRemoteState(bufConn, dec)
 		if err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to read remote state: %s %s", err, LogConn(conn))
@@ -253,7 +268,7 @@ func (m *Memberlist) handleConn(conn *net.TCPConn) {
 	case pingMsg:
 		var p ping
 		if err := dec.Decode(&p); err != nil {
-			m.logger.Printf("[ERR] memberlist: Failed to decode TCP ping: %s %s", err, LogConn(conn))
+			m.logger.Printf("[ERR] memberlist: Failed to decode ping: %s %s", err, LogConn(conn))
 			return
 		}
 
@@ -265,13 +280,13 @@ func (m *Memberlist) handleConn(conn *net.TCPConn) {
 		ack := ackResp{p.SeqNo, nil}
 		out, err := encode(ackRespMsg, &ack)
 		if err != nil {
-			m.logger.Printf("[ERR] memberlist: Failed to encode TCP ack: %s", err)
+			m.logger.Printf("[ERR] memberlist: Failed to encode ack: %s", err)
 			return
 		}
 
-		err = m.rawSendMsgTCP(conn, out.Bytes())
+		err = m.rawSendMsgStream(conn, out.Bytes())
 		if err != nil {
-			m.logger.Printf("[ERR] memberlist: Failed to send TCP ack: %s %s", err, LogConn(conn))
+			m.logger.Printf("[ERR] memberlist: Failed to send ack: %s %s", err, LogConn(conn))
 			return
 		}
 	default:
@@ -279,49 +294,17 @@ func (m *Memberlist) handleConn(conn *net.TCPConn) {
 	}
 }
 
-// udpListen listens for and handles incoming UDP packets
-func (m *Memberlist) udpListen() {
-	var n int
-	var addr net.Addr
-	var err error
-	var lastPacket time.Time
+// packetListen is a long running goroutine that pulls packets out of the
+// transport and hands them off for processing.
+func (m *Memberlist) packetListen() {
 	for {
-		// Do a check for potentially blocking operations
-		if !lastPacket.IsZero() && time.Now().Sub(lastPacket) > blockingWarning {
-			diff := time.Now().Sub(lastPacket)
-			m.logger.Printf(
-				"[DEBUG] memberlist: Potential blocking operation. Last command took %v",
-				diff)
+		select {
+		case packet := <-m.transport.PacketCh():
+			m.ingestPacket(packet.Buf, packet.From, packet.Timestamp)
+
+		case <-m.shutdownCh:
+			return
 		}
-
-		// Create a new buffer
-		// TODO: Use Sync.Pool eventually
-		buf := make([]byte, udpBufSize)
-
-		// Read a packet
-		n, addr, err = m.udpListener.ReadFrom(buf)
-		if err != nil {
-			if m.shutdown {
-				break
-			}
-			m.logger.Printf("[ERR] memberlist: Error reading UDP packet: %s", err)
-			continue
-		}
-
-		// Capture the reception time of the packet as close to the
-		// system calls as possible.
-		lastPacket = time.Now()
-
-		// Check the length
-		if n < 1 {
-			m.logger.Printf("[ERR] memberlist: UDP packet too short (%d bytes) %s",
-				len(buf), LogAddress(addr))
-			continue
-		}
-
-		// Ingest this packet
-		metrics.IncrCounter([]string{"memberlist", "udp", "received"}, float32(n))
-		m.ingestPacket(buf[:n], addr, lastPacket)
 	}
 }
 
@@ -331,8 +314,13 @@ func (m *Memberlist) ingestPacket(buf []byte, from net.Addr, timestamp time.Time
 		// Decrypt the payload
 		plain, err := decryptPayload(m.config.Keyring.GetKeys(), buf, nil)
 		if err != nil {
-			m.logger.Printf("[ERR] memberlist: Decrypt packet failed: %v %s", err, LogAddress(from))
-			return
+			if !m.config.GossipVerifyIncoming {
+				// Treat the message as plaintext
+				plain = buf
+			} else {
+				m.logger.Printf("[ERR] memberlist: Decrypt packet failed: %v %s", err, LogAddress(from))
+				return
+			}
 		}
 
 		// Continue processing the plaintext buffer
@@ -381,39 +369,77 @@ func (m *Memberlist) handleCommand(buf []byte, from net.Addr, timestamp time.Tim
 	case deadMsg:
 		fallthrough
 	case userMsg:
+		// Determine the message queue, prioritize alive
+		queue := m.lowPriorityMsgQueue
+		if msgType == aliveMsg {
+			queue = m.highPriorityMsgQueue
+		}
+
+		// Check for overflow and append if not full
+		m.msgQueueLock.Lock()
+		if queue.Len() >= m.config.HandoffQueueDepth {
+			m.logger.Printf("[WARN] memberlist: handler queue full, dropping message (%d) %s", msgType, LogAddress(from))
+		} else {
+			queue.PushBack(msgHandoff{msgType, buf, from})
+		}
+		m.msgQueueLock.Unlock()
+
+		// Notify of pending message
 		select {
-		case m.handoff <- msgHandoff{msgType, buf, from}:
+		case m.handoffCh <- struct{}{}:
 		default:
-			m.logger.Printf("[WARN] memberlist: UDP handler queue full, dropping message (%d) %s", msgType, LogAddress(from))
 		}
 
 	default:
-		m.logger.Printf("[ERR] memberlist: UDP msg type (%d) not supported %s", msgType, LogAddress(from))
+		m.logger.Printf("[ERR] memberlist: msg type (%d) not supported %s", msgType, LogAddress(from))
 	}
 }
 
-// udpHandler processes messages received over UDP, but is decoupled
-// from the listener to avoid blocking the listener which may cause
-// ping/ack messages to be delayed.
-func (m *Memberlist) udpHandler() {
+// getNextMessage returns the next message to process in priority order, using LIFO
+func (m *Memberlist) getNextMessage() (msgHandoff, bool) {
+	m.msgQueueLock.Lock()
+	defer m.msgQueueLock.Unlock()
+
+	if el := m.highPriorityMsgQueue.Back(); el != nil {
+		m.highPriorityMsgQueue.Remove(el)
+		msg := el.Value.(msgHandoff)
+		return msg, true
+	} else if el := m.lowPriorityMsgQueue.Back(); el != nil {
+		m.lowPriorityMsgQueue.Remove(el)
+		msg := el.Value.(msgHandoff)
+		return msg, true
+	}
+	return msgHandoff{}, false
+}
+
+// packetHandler is a long running goroutine that processes messages received
+// over the packet interface, but is decoupled from the listener to avoid
+// blocking the listener which may cause ping/ack messages to be delayed.
+func (m *Memberlist) packetHandler() {
 	for {
 		select {
-		case msg := <-m.handoff:
-			msgType := msg.msgType
-			buf := msg.buf
-			from := msg.from
+		case <-m.handoffCh:
+			for {
+				msg, ok := m.getNextMessage()
+				if !ok {
+					break
+				}
+				msgType := msg.msgType
+				buf := msg.buf
+				from := msg.from
 
-			switch msgType {
-			case suspectMsg:
-				m.handleSuspect(buf, from)
-			case aliveMsg:
-				m.handleAlive(buf, from)
-			case deadMsg:
-				m.handleDead(buf, from)
-			case userMsg:
-				m.handleUser(buf, from)
-			default:
-				m.logger.Printf("[ERR] memberlist: UDP msg type (%d) not supported %s (handler)", msgType, LogAddress(from))
+				switch msgType {
+				case suspectMsg:
+					m.handleSuspect(buf, from)
+				case aliveMsg:
+					m.handleAlive(buf, from)
+				case deadMsg:
+					m.handleDead(buf, from)
+				case userMsg:
+					m.handleUser(buf, from)
+				default:
+					m.logger.Printf("[ERR] memberlist: Message type (%d) not supported %s (packet handler)", msgType, LogAddress(from))
+				}
 			}
 
 		case <-m.shutdownCh:
@@ -457,7 +483,7 @@ func (m *Memberlist) handlePing(buf []byte, from net.Addr) {
 	if m.config.Ping != nil {
 		ack.Payload = m.config.Ping.AckPayload()
 	}
-	if err := m.encodeAndSendMsg(from, ackRespMsg, &ack); err != nil {
+	if err := m.encodeAndSendMsg(from.String(), ackRespMsg, &ack); err != nil {
 		m.logger.Printf("[ERR] memberlist: Failed to send ack: %s %s", err, LogAddress(from))
 	}
 }
@@ -478,7 +504,6 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	// Send a ping to the correct host.
 	localSeqNo := m.nextSeqNo()
 	ping := ping{SeqNo: localSeqNo, Node: ind.Node}
-	destAddr := &net.UDPAddr{IP: ind.Target, Port: int(ind.Port)}
 
 	// Setup a response handler to relay the ack
 	cancelCh := make(chan struct{})
@@ -488,14 +513,15 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 
 		// Forward the ack back to the requestor.
 		ack := ackResp{ind.SeqNo, nil}
-		if err := m.encodeAndSendMsg(from, ackRespMsg, &ack); err != nil {
+		if err := m.encodeAndSendMsg(from.String(), ackRespMsg, &ack); err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to forward ack: %s %s", err, LogAddress(from))
 		}
 	}
 	m.setAckHandler(localSeqNo, respHandler, m.config.ProbeTimeout)
 
 	// Send the ping.
-	if err := m.encodeAndSendMsg(destAddr, pingMsg, &ping); err != nil {
+	addr := joinHostPort(net.IP(ind.Target).String(), ind.Port)
+	if err := m.encodeAndSendMsg(addr, pingMsg, &ping); err != nil {
 		m.logger.Printf("[ERR] memberlist: Failed to send ping: %s %s", err, LogAddress(from))
 	}
 
@@ -507,7 +533,7 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 				return
 			case <-time.After(m.config.ProbeTimeout):
 				nack := nackResp{ind.SeqNo}
-				if err := m.encodeAndSendMsg(from, nackRespMsg, &nack); err != nil {
+				if err := m.encodeAndSendMsg(from.String(), nackRespMsg, &nack); err != nil {
 					m.logger.Printf("[ERR] memberlist: Failed to send nack: %s %s", err, LogAddress(from))
 				}
 			}
@@ -589,30 +615,30 @@ func (m *Memberlist) handleCompressed(buf []byte, from net.Addr, timestamp time.
 }
 
 // encodeAndSendMsg is used to combine the encoding and sending steps
-func (m *Memberlist) encodeAndSendMsg(to net.Addr, msgType messageType, msg interface{}) error {
+func (m *Memberlist) encodeAndSendMsg(addr string, msgType messageType, msg interface{}) error {
 	out, err := encode(msgType, msg)
 	if err != nil {
 		return err
 	}
-	if err := m.sendMsg(to, out.Bytes()); err != nil {
+	if err := m.sendMsg(addr, out.Bytes()); err != nil {
 		return err
 	}
 	return nil
 }
 
-// sendMsg is used to send a UDP message to another host. It will opportunistically
-// create a compoundMsg and piggy back other broadcasts
-func (m *Memberlist) sendMsg(to net.Addr, msg []byte) error {
+// sendMsg is used to send a message via packet to another host. It will
+// opportunistically create a compoundMsg and piggy back other broadcasts.
+func (m *Memberlist) sendMsg(addr string, msg []byte) error {
 	// Check if we can piggy back any messages
 	bytesAvail := m.config.UDPBufferSize - len(msg) - compoundHeaderOverhead
-	if m.config.EncryptionEnabled() {
+	if m.config.EncryptionEnabled() && m.config.GossipVerifyOutgoing {
 		bytesAvail -= encryptOverhead(m.encryptionVersion())
 	}
 	extra := m.getBroadcasts(compoundOverhead, bytesAvail)
 
 	// Fast path if nothing to piggypack
 	if len(extra) == 0 {
-		return m.rawSendMsgUDP(to, nil, msg)
+		return m.rawSendMsgPacket(addr, nil, msg)
 	}
 
 	// Join all the messages
@@ -624,11 +650,12 @@ func (m *Memberlist) sendMsg(to net.Addr, msg []byte) error {
 	compound := makeCompoundMessage(msgs)
 
 	// Send the message
-	return m.rawSendMsgUDP(to, nil, compound.Bytes())
+	return m.rawSendMsgPacket(addr, nil, compound.Bytes())
 }
 
-// rawSendMsgUDP is used to send a UDP message to another host without modification
-func (m *Memberlist) rawSendMsgUDP(addr net.Addr, node *Node, msg []byte) error {
+// rawSendMsgPacket is used to send message via packet to another host without
+// modification, other than compression or encryption if enabled.
+func (m *Memberlist) rawSendMsgPacket(addr string, node *Node, msg []byte) error {
 	// Check if we have compression enabled
 	if m.config.EnableCompression {
 		buf, err := compressPayload(msg)
@@ -644,9 +671,9 @@ func (m *Memberlist) rawSendMsgUDP(addr net.Addr, node *Node, msg []byte) error 
 
 	// Try to look up the destination node
 	if node == nil {
-		toAddr, _, err := net.SplitHostPort(addr.String())
+		toAddr, _, err := net.SplitHostPort(addr)
 		if err != nil {
-			m.logger.Printf("[ERR] memberlist: Failed to parse address %q: %v", addr.String(), err)
+			m.logger.Printf("[ERR] memberlist: Failed to parse address %q: %v", addr, err)
 			return err
 		}
 		m.nodeLock.RLock()
@@ -668,7 +695,7 @@ func (m *Memberlist) rawSendMsgUDP(addr net.Addr, node *Node, msg []byte) error 
 	}
 
 	// Check if we have encryption enabled
-	if m.config.EncryptionEnabled() {
+	if m.config.EncryptionEnabled() && m.config.GossipVerifyOutgoing {
 		// Encrypt the payload
 		var buf bytes.Buffer
 		primaryKey := m.config.Keyring.GetPrimaryKey()
@@ -681,12 +708,13 @@ func (m *Memberlist) rawSendMsgUDP(addr net.Addr, node *Node, msg []byte) error 
 	}
 
 	metrics.IncrCounter([]string{"memberlist", "udp", "sent"}, float32(len(msg)))
-	_, err := m.udpListener.WriteTo(msg, addr)
+	_, err := m.transport.WriteTo(msg, addr)
 	return err
 }
 
-// rawSendMsgTCP is used to send a TCP message to another host without modification
-func (m *Memberlist) rawSendMsgTCP(conn net.Conn, sendBuf []byte) error {
+// rawSendMsgStream is used to stream a message to another host without
+// modification, other than applying compression and encryption if enabled.
+func (m *Memberlist) rawSendMsgStream(conn net.Conn, sendBuf []byte) error {
 	// Check if compresion is enabled
 	if m.config.EnableCompression {
 		compBuf, err := compressPayload(sendBuf)
@@ -698,7 +726,7 @@ func (m *Memberlist) rawSendMsgTCP(conn net.Conn, sendBuf []byte) error {
 	}
 
 	// Check if encryption is enabled
-	if m.config.EncryptionEnabled() {
+	if m.config.EncryptionEnabled() && m.config.GossipVerifyOutgoing {
 		crypt, err := m.encryptLocalState(sendBuf)
 		if err != nil {
 			m.logger.Printf("[ERROR] memberlist: Failed to encrypt local state: %v", err)
@@ -719,43 +747,36 @@ func (m *Memberlist) rawSendMsgTCP(conn net.Conn, sendBuf []byte) error {
 	return nil
 }
 
-// sendTCPUserMsg is used to send a TCP userMsg to another host
-func (m *Memberlist) sendTCPUserMsg(to net.Addr, sendBuf []byte) error {
-	dialer := net.Dialer{Timeout: m.config.TCPTimeout}
-	conn, err := dialer.Dial("tcp", to.String())
+// sendUserMsg is used to stream a user message to another host.
+func (m *Memberlist) sendUserMsg(addr string, sendBuf []byte) error {
+	conn, err := m.transport.DialTimeout(addr, m.config.TCPTimeout)
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
 
 	bufConn := bytes.NewBuffer(nil)
-
 	if err := bufConn.WriteByte(byte(userMsg)); err != nil {
 		return err
 	}
 
-	// Send our node state
 	header := userMsgHeader{UserMsgLen: len(sendBuf)}
 	hd := codec.MsgpackHandle{}
 	enc := codec.NewEncoder(bufConn, &hd)
-
 	if err := enc.Encode(&header); err != nil {
 		return err
 	}
-
 	if _, err := bufConn.Write(sendBuf); err != nil {
 		return err
 	}
-
-	return m.rawSendMsgTCP(conn, bufConn.Bytes())
+	return m.rawSendMsgStream(conn, bufConn.Bytes())
 }
 
-// sendAndReceiveState is used to initiate a push/pull over TCP with a remote node
-func (m *Memberlist) sendAndReceiveState(addr []byte, port uint16, join bool) ([]pushNodeState, []byte, error) {
+// sendAndReceiveState is used to initiate a push/pull over a stream with a
+// remote host.
+func (m *Memberlist) sendAndReceiveState(addr string, join bool) ([]pushNodeState, []byte, error) {
 	// Attempt to connect
-	dialer := net.Dialer{Timeout: m.config.TCPTimeout}
-	dest := net.TCPAddr{IP: addr, Port: int(port)}
-	conn, err := dialer.Dial("tcp", dest.String())
+	conn, err := m.transport.DialTimeout(addr, m.config.TCPTimeout)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -769,9 +790,17 @@ func (m *Memberlist) sendAndReceiveState(addr []byte, port uint16, join bool) ([
 	}
 
 	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
-	msgType, bufConn, dec, err := m.readTCP(conn)
+	msgType, bufConn, dec, err := m.readStream(conn)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if msgType == errMsg {
+		var resp errResp
+		if err := dec.Decode(&resp); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, fmt.Errorf("remote error: %v", resp.Error)
 	}
 
 	// Quit if not push/pull
@@ -785,7 +814,7 @@ func (m *Memberlist) sendAndReceiveState(addr []byte, port uint16, join bool) ([
 	return remoteNodes, userState, err
 }
 
-// sendLocalState is invoked to send our local state over a tcp connection
+// sendLocalState is invoked to send our local state over a stream connection.
 func (m *Memberlist) sendLocalState(conn net.Conn, join bool) error {
 	// Setup a deadline
 	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
@@ -843,7 +872,7 @@ func (m *Memberlist) sendLocalState(conn net.Conn, join bool) error {
 	}
 
 	// Get the send buffer
-	return m.rawSendMsgTCP(conn, bufConn.Bytes())
+	return m.rawSendMsgStream(conn, bufConn.Bytes())
 }
 
 // encryptLocalState is used to help encrypt local state before sending
@@ -901,9 +930,9 @@ func (m *Memberlist) decryptRemoteState(bufConn io.Reader) ([]byte, error) {
 	return decryptPayload(keys, cipherBytes, dataBytes)
 }
 
-// readTCP is used to read the start of a TCP stream.
-// it decrypts and decompresses the stream if necessary
-func (m *Memberlist) readTCP(conn net.Conn) (messageType, io.Reader, *codec.Decoder, error) {
+// readStream is used to read from a stream connection, decrypting and
+// decompressing the stream if necessary.
+func (m *Memberlist) readStream(conn net.Conn) (messageType, io.Reader, *codec.Decoder, error) {
 	// Created a buffered reader
 	var bufConn io.Reader = bufio.NewReader(conn)
 
@@ -929,7 +958,7 @@ func (m *Memberlist) readTCP(conn net.Conn) (messageType, io.Reader, *codec.Deco
 		// Reset message type and bufConn
 		msgType = messageType(plain[0])
 		bufConn = bytes.NewReader(plain[1:])
-	} else if m.config.EncryptionEnabled() {
+	} else if m.config.EncryptionEnabled() && m.config.GossipVerifyIncoming {
 		return 0, nil, nil,
 			fmt.Errorf("Encryption is configured but remote state is not encrypted")
 	}
@@ -1044,7 +1073,7 @@ func (m *Memberlist) mergeRemoteState(join bool, remoteNodes []pushNodeState, us
 	return nil
 }
 
-// readUserMsg is used to decode a userMsg from a TCP stream
+// readUserMsg is used to decode a userMsg from a stream.
 func (m *Memberlist) readUserMsg(bufConn io.Reader, dec *codec.Decoder) error {
 	// Read the user message header
 	var header userMsgHeader
@@ -1075,13 +1104,12 @@ func (m *Memberlist) readUserMsg(bufConn io.Reader, dec *codec.Decoder) error {
 	return nil
 }
 
-// sendPingAndWaitForAck makes a TCP connection to the given address, sends
+// sendPingAndWaitForAck makes a stream connection to the given address, sends
 // a ping, and waits for an ack. All of this is done as a series of blocking
 // operations, given the deadline. The bool return parameter is true if we
 // we able to round trip a ping to the other node.
-func (m *Memberlist) sendPingAndWaitForAck(destAddr net.Addr, ping ping, deadline time.Time) (bool, error) {
-	dialer := net.Dialer{Deadline: deadline}
-	conn, err := dialer.Dial("tcp", destAddr.String())
+func (m *Memberlist) sendPingAndWaitForAck(addr string, ping ping, deadline time.Time) (bool, error) {
+	conn, err := m.transport.DialTimeout(addr, deadline.Sub(time.Now()))
 	if err != nil {
 		// If the node is actually dead we expect this to fail, so we
 		// shouldn't spam the logs with it. After this point, errors
@@ -1097,17 +1125,17 @@ func (m *Memberlist) sendPingAndWaitForAck(destAddr net.Addr, ping ping, deadlin
 		return false, err
 	}
 
-	if err = m.rawSendMsgTCP(conn, out.Bytes()); err != nil {
+	if err = m.rawSendMsgStream(conn, out.Bytes()); err != nil {
 		return false, err
 	}
 
-	msgType, _, dec, err := m.readTCP(conn)
+	msgType, _, dec, err := m.readStream(conn)
 	if err != nil {
 		return false, err
 	}
 
 	if msgType != ackRespMsg {
-		return false, fmt.Errorf("Unexpected msgType (%d) from TCP ping %s", msgType, LogConn(conn))
+		return false, fmt.Errorf("Unexpected msgType (%d) from ping %s", msgType, LogConn(conn))
 	}
 
 	var ack ackResp
@@ -1116,7 +1144,7 @@ func (m *Memberlist) sendPingAndWaitForAck(destAddr net.Addr, ping ping, deadlin
 	}
 
 	if ack.SeqNo != ping.SeqNo {
-		return false, fmt.Errorf("Sequence number from ack (%d) doesn't match ping (%d) from TCP ping %s", ack.SeqNo, ping.SeqNo, LogConn(conn))
+		return false, fmt.Errorf("Sequence number from ack (%d) doesn't match ping (%d)", ack.SeqNo, ping.SeqNo)
 	}
 
 	return true, nil

--- a/vendor/github.com/hashicorp/memberlist/net_transport.go
+++ b/vendor/github.com/hashicorp/memberlist/net_transport.go
@@ -1,0 +1,289 @@
+package memberlist
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/armon/go-metrics"
+	sockaddr "github.com/hashicorp/go-sockaddr"
+)
+
+const (
+	// udpPacketBufSize is used to buffer incoming packets during read
+	// operations.
+	udpPacketBufSize = 65536
+
+	// udpRecvBufSize is a large buffer size that we attempt to set UDP
+	// sockets to in order to handle a large volume of messages.
+	udpRecvBufSize = 2 * 1024 * 1024
+)
+
+// NetTransportConfig is used to configure a net transport.
+type NetTransportConfig struct {
+	// BindAddrs is a list of addresses to bind to for both TCP and UDP
+	// communications.
+	BindAddrs []string
+
+	// BindPort is the port to listen on, for each address above.
+	BindPort int
+
+	// Logger is a logger for operator messages.
+	Logger *log.Logger
+}
+
+// NetTransport is a Transport implementation that uses connectionless UDP for
+// packet operations, and ad-hoc TCP connections for stream operations.
+type NetTransport struct {
+	config       *NetTransportConfig
+	packetCh     chan *Packet
+	streamCh     chan net.Conn
+	logger       *log.Logger
+	wg           sync.WaitGroup
+	tcpListeners []*net.TCPListener
+	udpListeners []*net.UDPConn
+	shutdown     int32
+}
+
+// NewNetTransport returns a net transport with the given configuration. On
+// success all the network listeners will be created and listening.
+func NewNetTransport(config *NetTransportConfig) (*NetTransport, error) {
+	// If we reject the empty list outright we can assume that there's at
+	// least one listener of each type later during operation.
+	if len(config.BindAddrs) == 0 {
+		return nil, fmt.Errorf("At least one bind address is required")
+	}
+
+	// Build out the new transport.
+	var ok bool
+	t := NetTransport{
+		config:   config,
+		packetCh: make(chan *Packet),
+		streamCh: make(chan net.Conn),
+		logger:   config.Logger,
+	}
+
+	// Clean up listeners if there's an error.
+	defer func() {
+		if !ok {
+			t.Shutdown()
+		}
+	}()
+
+	// Build all the TCP and UDP listeners.
+	port := config.BindPort
+	for _, addr := range config.BindAddrs {
+		ip := net.ParseIP(addr)
+
+		tcpAddr := &net.TCPAddr{IP: ip, Port: port}
+		tcpLn, err := net.ListenTCP("tcp", tcpAddr)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to start TCP listener on %q port %d: %v", addr, port, err)
+		}
+		t.tcpListeners = append(t.tcpListeners, tcpLn)
+
+		// If the config port given was zero, use the first TCP listener
+		// to pick an available port and then apply that to everything
+		// else.
+		if port == 0 {
+			port = tcpLn.Addr().(*net.TCPAddr).Port
+		}
+
+		udpAddr := &net.UDPAddr{IP: ip, Port: port}
+		udpLn, err := net.ListenUDP("udp", udpAddr)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to start UDP listener on %q port %d: %v", addr, port, err)
+		}
+		if err := setUDPRecvBuf(udpLn); err != nil {
+			return nil, fmt.Errorf("Failed to resize UDP buffer: %v", err)
+		}
+		t.udpListeners = append(t.udpListeners, udpLn)
+	}
+
+	// Fire them up now that we've been able to create them all.
+	for i := 0; i < len(config.BindAddrs); i++ {
+		t.wg.Add(2)
+		go t.tcpListen(t.tcpListeners[i])
+		go t.udpListen(t.udpListeners[i])
+	}
+
+	ok = true
+	return &t, nil
+}
+
+// GetAutoBindPort returns the bind port that was automatically given by the
+// kernel, if a bind port of 0 was given.
+func (t *NetTransport) GetAutoBindPort() int {
+	// We made sure there's at least one TCP listener, and that one's
+	// port was applied to all the others for the dynamic bind case.
+	return t.tcpListeners[0].Addr().(*net.TCPAddr).Port
+}
+
+// See Transport.
+func (t *NetTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, error) {
+	var advertiseAddr net.IP
+	var advertisePort int
+	if ip != "" {
+		// If they've supplied an address, use that.
+		advertiseAddr = net.ParseIP(ip)
+		if advertiseAddr == nil {
+			return nil, 0, fmt.Errorf("Failed to parse advertise address %q", ip)
+		}
+
+		// Ensure IPv4 conversion if necessary.
+		if ip4 := advertiseAddr.To4(); ip4 != nil {
+			advertiseAddr = ip4
+		}
+		advertisePort = port
+	} else {
+		if t.config.BindAddrs[0] == "0.0.0.0" {
+			// Otherwise, if we're not bound to a specific IP, let's
+			// use a suitable private IP address.
+			var err error
+			ip, err = sockaddr.GetPrivateIP()
+			if err != nil {
+				return nil, 0, fmt.Errorf("Failed to get interface addresses: %v", err)
+			}
+			if ip == "" {
+				return nil, 0, fmt.Errorf("No private IP address found, and explicit IP not provided")
+			}
+
+			advertiseAddr = net.ParseIP(ip)
+			if advertiseAddr == nil {
+				return nil, 0, fmt.Errorf("Failed to parse advertise address: %q", ip)
+			}
+		} else {
+			// Use the IP that we're bound to, based on the first
+			// TCP listener, which we already ensure is there.
+			advertiseAddr = t.tcpListeners[0].Addr().(*net.TCPAddr).IP
+		}
+
+		// Use the port we are bound to.
+		advertisePort = t.GetAutoBindPort()
+	}
+
+	return advertiseAddr, advertisePort, nil
+}
+
+// See Transport.
+func (t *NetTransport) WriteTo(b []byte, addr string) (time.Time, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	// We made sure there's at least one UDP listener, so just use the
+	// packet sending interface on the first one. Take the time after the
+	// write call comes back, which will underestimate the time a little,
+	// but help account for any delays before the write occurs.
+	_, err = t.udpListeners[0].WriteTo(b, udpAddr)
+	return time.Now(), err
+}
+
+// See Transport.
+func (t *NetTransport) PacketCh() <-chan *Packet {
+	return t.packetCh
+}
+
+// See Transport.
+func (t *NetTransport) DialTimeout(addr string, timeout time.Duration) (net.Conn, error) {
+	dialer := net.Dialer{Timeout: timeout}
+	return dialer.Dial("tcp", addr)
+}
+
+// See Transport.
+func (t *NetTransport) StreamCh() <-chan net.Conn {
+	return t.streamCh
+}
+
+// See Transport.
+func (t *NetTransport) Shutdown() error {
+	// This will avoid log spam about errors when we shut down.
+	atomic.StoreInt32(&t.shutdown, 1)
+
+	// Rip through all the connections and shut them down.
+	for _, conn := range t.tcpListeners {
+		conn.Close()
+	}
+	for _, conn := range t.udpListeners {
+		conn.Close()
+	}
+
+	// Block until all the listener threads have died.
+	t.wg.Wait()
+	return nil
+}
+
+// tcpListen is a long running goroutine that accepts incoming TCP connections
+// and hands them off to the stream channel.
+func (t *NetTransport) tcpListen(tcpLn *net.TCPListener) {
+	defer t.wg.Done()
+	for {
+		conn, err := tcpLn.AcceptTCP()
+		if err != nil {
+			if s := atomic.LoadInt32(&t.shutdown); s == 1 {
+				break
+			}
+
+			t.logger.Printf("[ERR] memberlist: Error accepting TCP connection: %v", err)
+			continue
+		}
+
+		t.streamCh <- conn
+	}
+}
+
+// udpListen is a long running goroutine that accepts incoming UDP packets and
+// hands them off to the packet channel.
+func (t *NetTransport) udpListen(udpLn *net.UDPConn) {
+	defer t.wg.Done()
+	for {
+		// Do a blocking read into a fresh buffer. Grab a time stamp as
+		// close as possible to the I/O.
+		buf := make([]byte, udpPacketBufSize)
+		n, addr, err := udpLn.ReadFrom(buf)
+		ts := time.Now()
+		if err != nil {
+			if s := atomic.LoadInt32(&t.shutdown); s == 1 {
+				break
+			}
+
+			t.logger.Printf("[ERR] memberlist: Error reading UDP packet: %v", err)
+			continue
+		}
+
+		// Check the length - it needs to have at least one byte to be a
+		// proper message.
+		if n < 1 {
+			t.logger.Printf("[ERR] memberlist: UDP packet too short (%d bytes) %s",
+				len(buf), LogAddress(addr))
+			continue
+		}
+
+		// Ingest the packet.
+		metrics.IncrCounter([]string{"memberlist", "udp", "received"}, float32(n))
+		t.packetCh <- &Packet{
+			Buf:       buf[:n],
+			From:      addr,
+			Timestamp: ts,
+		}
+	}
+}
+
+// setUDPRecvBuf is used to resize the UDP receive window. The function
+// attempts to set the read buffer to `udpRecvBuf` but backs off until
+// the read buffer can be set.
+func setUDPRecvBuf(c *net.UDPConn) error {
+	size := udpRecvBufSize
+	var err error
+	for size > 0 {
+		if err = c.SetReadBuffer(size); err == nil {
+			return nil
+		}
+		size = size / 2
+	}
+	return err
+}

--- a/vendor/github.com/hashicorp/memberlist/queue.go
+++ b/vendor/github.com/hashicorp/memberlist/queue.go
@@ -27,6 +27,26 @@ type limitedBroadcast struct {
 	transmits int // Number of transmissions attempted.
 	b         Broadcast
 }
+
+// for testing; emits in transmit order if reverse=false
+func (q *TransmitLimitedQueue) orderedView(reverse bool) []*limitedBroadcast {
+	q.Lock()
+	defer q.Unlock()
+
+	out := make([]*limitedBroadcast, 0, len(q.bcQueue))
+	if reverse {
+		for i := 0; i < len(q.bcQueue); i++ {
+			out = append(out, q.bcQueue[i])
+		}
+	} else {
+		for i := len(q.bcQueue) - 1; i >= 0; i-- {
+			out = append(out, q.bcQueue[i])
+		}
+	}
+
+	return out
+}
+
 type limitedBroadcasts []*limitedBroadcast
 
 // Broadcast is something that can be broadcasted via gossip to

--- a/vendor/github.com/hashicorp/memberlist/suspicion.go
+++ b/vendor/github.com/hashicorp/memberlist/suspicion.go
@@ -117,7 +117,7 @@ func (s *suspicion) Confirm(from string) bool {
 	// stop the timer then we will call the timeout function directly from
 	// here.
 	n := atomic.AddInt32(&s.n, 1)
-	elapsed := time.Now().Sub(s.start)
+	elapsed := time.Since(s.start)
 	remaining := remainingSuspicionTime(n, s.k, elapsed, s.min, s.max)
 	if s.timer.Stop() {
 		if remaining > 0 {

--- a/vendor/github.com/hashicorp/memberlist/tag.sh
+++ b/vendor/github.com/hashicorp/memberlist/tag.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# The version must be supplied from the environment. Do not include the
+# leading "v".
+if [ -z $VERSION ]; then
+    echo "Please specify a version."
+    exit 1
+fi
+
+# Generate the tag.
+echo "==> Tagging version $VERSION..."
+git commit --allow-empty -a --gpg-sign=348FFC4C -m "Release v$VERSION"
+git tag -a -m "Version $VERSION" -s -u 348FFC4C "v${VERSION}" master
+
+exit 0

--- a/vendor/github.com/hashicorp/memberlist/transport.go
+++ b/vendor/github.com/hashicorp/memberlist/transport.go
@@ -1,0 +1,65 @@
+package memberlist
+
+import (
+	"net"
+	"time"
+)
+
+// Packet is used to provide some metadata about incoming packets from peers
+// over a packet connection, as well as the packet payload.
+type Packet struct {
+	// Buf has the raw contents of the packet.
+	Buf []byte
+
+	// From has the address of the peer. This is an actual net.Addr so we
+	// can expose some concrete details about incoming packets.
+	From net.Addr
+
+	// Timestamp is the time when the packet was received. This should be
+	// taken as close as possible to the actual receipt time to help make an
+	// accurate RTT measurement during probes.
+	Timestamp time.Time
+}
+
+// Transport is used to abstract over communicating with other peers. The packet
+// interface is assumed to be best-effort and the stream interface is assumed to
+// be reliable.
+type Transport interface {
+	// FinalAdvertiseAddr is given the user's configured values (which
+	// might be empty) and returns the desired IP and port to advertise to
+	// the rest of the cluster.
+	FinalAdvertiseAddr(ip string, port int) (net.IP, int, error)
+
+	// WriteTo is a packet-oriented interface that fires off the given
+	// payload to the given address in a connectionless fashion. This should
+	// return a time stamp that's as close as possible to when the packet
+	// was transmitted to help make accurate RTT measurements during probes.
+	//
+	// This is similar to net.PacketConn, though we didn't want to expose
+	// that full set of required methods to keep assumptions about the
+	// underlying plumbing to a minimum. We also treat the address here as a
+	// string, similar to Dial, so it's network neutral, so this usually is
+	// in the form of "host:port".
+	WriteTo(b []byte, addr string) (time.Time, error)
+
+	// PacketCh returns a channel that can be read to receive incoming
+	// packets from other peers. How this is set up for listening is left as
+	// an exercise for the concrete transport implementations.
+	PacketCh() <-chan *Packet
+
+	// DialTimeout is used to create a connection that allows us to perform
+	// two-way communication with a peer. This is generally more expensive
+	// than packet connections so is used for more infrequent operations
+	// such as anti-entropy or fallback probes if the packet-oriented probe
+	// failed.
+	DialTimeout(addr string, timeout time.Duration) (net.Conn, error)
+
+	// StreamCh returns a channel that can be read to handle incoming stream
+	// connections from other peers. How this is set up for listening is
+	// left as an exercise for the concrete transport implementations.
+	StreamCh() <-chan net.Conn
+
+	// Shutdown is called when memberlist is shutting down; this gives the
+	// transport a chance to clean up any listeners.
+	Shutdown() error
+}

--- a/vendor/github.com/hashicorp/memberlist/util.go
+++ b/vendor/github.com/hashicorp/memberlist/util.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"math"
 	"math/rand"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -76,10 +78,9 @@ func retransmitLimit(retransmitMult, n int) int {
 // shuffleNodes randomly shuffles the input nodes using the Fisher-Yates shuffle
 func shuffleNodes(nodes []*nodeState) {
 	n := len(nodes)
-	for i := n - 1; i > 0; i-- {
-		j := rand.Intn(i + 1)
+	rand.Shuffle(n, func(i, j int) {
 		nodes[i], nodes[j] = nodes[j], nodes[i]
-	}
+	})
 }
 
 // pushPushScale is used to scale the time interval at which push/pull
@@ -215,20 +216,6 @@ func decodeCompoundMessage(buf []byte) (trunc int, parts [][]byte, err error) {
 	return
 }
 
-// Given a string of the form "host", "host:port",
-// "ipv6::addr" or "[ipv6::address]:port",
-// return true if the string includes a port.
-func hasPort(s string) bool {
-	last := strings.LastIndex(s, ":")
-	if last == -1 {
-		return false
-	}
-	if s[0] == '[' {
-		return s[last-1] == ']'
-	}
-	return strings.Index(s, ":") == last
-}
-
 // compressPayload takes an opaque input buffer, compresses it
 // and wraps it in a compress{} message that is encoded.
 func compressPayload(inp []byte) (*bytes.Buffer, error) {
@@ -285,4 +272,38 @@ func decompressBuffer(c *compress) ([]byte, error) {
 
 	// Return the uncompressed bytes
 	return b.Bytes(), nil
+}
+
+// joinHostPort returns the host:port form of an address, for use with a
+// transport.
+func joinHostPort(host string, port uint16) string {
+	return net.JoinHostPort(host, strconv.Itoa(int(port)))
+}
+
+// hasPort is given a string of the form "host", "host:port", "ipv6::address",
+// or "[ipv6::address]:port", and returns true if the string includes a port.
+func hasPort(s string) bool {
+	// IPv6 address in brackets.
+	if strings.LastIndex(s, "[") == 0 {
+		return strings.LastIndex(s, ":") > strings.LastIndex(s, "]")
+	}
+
+	// Otherwise the presence of a single colon determines if there's a port
+	// since IPv6 addresses outside of brackets (count > 1) can't have a
+	// port.
+	return strings.Count(s, ":") == 1
+}
+
+// ensurePort makes sure the given string has a port number on it, otherwise it
+// appends the given port as a default.
+func ensurePort(s string, port int) string {
+	if hasPort(s) {
+		return s
+	}
+
+	// If this is an IPv6 address, the join call will add another set of
+	// brackets, so we have to trim before we add the default port.
+	s = strings.Trim(s, "[]")
+	s = net.JoinHostPort(s, strconv.Itoa(port))
+	return s
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -216,7 +216,7 @@
 		{"path":"github.com/hashicorp/hcl2/hcldec","checksumSHA1":"wQ3hLj4s+5jN6LePSpT0XTTvdXA=","revision":"6743a2254ba3d642b7d3a0be506259a0842819ac","revisionTime":"2018-08-10T01:10:00Z"},
 		{"path":"github.com/hashicorp/hcl2/hclparse","checksumSHA1":"IzmftuG99BqNhbFGhxZaGwtiMtM=","revision":"6743a2254ba3d642b7d3a0be506259a0842819ac","revisionTime":"2018-08-10T01:10:00Z"},
 		{"path":"github.com/hashicorp/logutils","checksumSHA1":"vt+P9D2yWDO3gdvdgCzwqunlhxU=","revision":"0dc08b1671f34c4250ce212759ebd880f743d883"},
-		{"path":"github.com/hashicorp/memberlist","checksumSHA1":"1zk7IeGClUqBo+Phsx89p7fQ/rQ=","revision":"23ad4b7d7b38496cd64c241dfd4c60b7794c254a","revisionTime":"2017-02-08T21:15:06Z"},
+		{"path":"github.com/hashicorp/memberlist","checksumSHA1":"pd6KJd+33bGQ6oc+2X+ZvqgSAGI=","revision":"2072f3a3ff4b7b3d830be77678d5d4b978362bc4","revisionTime":"2018-10-22T22:19:44Z"},
 		{"path":"github.com/hashicorp/net-rpc-msgpackrpc","checksumSHA1":"qnlqWJYV81ENr61SZk9c65R1mDo=","revision":"a14192a58a694c123d8fe5481d4a4727d6ae82f3"},
 		{"path":"github.com/hashicorp/raft","checksumSHA1":"zkA9uvbj1BdlveyqXpVTh1N6ers=","revision":"077966dbc90f342107eb723ec52fdb0463ec789b","revisionTime":"2018-01-17T20:29:25Z","version":"master","versionExact":"master"},
 		{"path":"github.com/hashicorp/raft-boltdb","checksumSHA1":"QAxukkv54/iIvLfsUP6IK4R0m/A=","revision":"d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee","revisionTime":"2015-02-01T20:08:39Z"},


### PR DESCRIPTION
see NMD-1173 or https://github.com/hashicorp/nomad/issues/3686#issuecomment-442177451

adds throttling to error logging on the Accept() loop in the RPC listener, to prevent from overloading the disk in case some problem (out of file handles, out of memory) causes a tight loop

this change is also needed in memberlist