### PR TITLE
drivers/docker: enforce volumes.enabled

### DIFF
--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/cli/cli/config/configfile"
@@ -199,4 +200,21 @@ func validateCgroupPermission(s string) bool {
 	}
 
 	return true
+}
+
+// expandPath returns the absolute path of dir, relative to base if dir is relative path.
+// base is expected to be an absolute path
+func expandPath(base, dir string) string {
+	if filepath.IsAbs(dir) {
+		return filepath.Clean(dir)
+	}
+
+	return filepath.Clean(filepath.Join(base, dir))
+}
+
+// isParentPath returns true if path is a child or decendant of parent path.
+// Both inputes need to be absolute paths.
+func isParentPath(parent, path string) bool {
+	rel, err := filepath.Rel(parent, path)
+	return err == nil && !strings.HasPrefix(rel, "..")
 }

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -212,8 +212,8 @@ func expandPath(base, dir string) string {
 	return filepath.Clean(filepath.Join(base, dir))
 }
 
-// isParentPath returns true if path is a child or decendant of parent path.
-// Both inputes need to be absolute paths.
+// isParentPath returns true if path is a child or a descendant of parent path.
+// Both inputs need to be absolute paths.
 func isParentPath(parent, path string) bool {
 	rel, err := filepath.Rel(parent, path)
 	return err == nil && !strings.HasPrefix(rel, "..")

--- a/drivers/docker/utils_test.go
+++ b/drivers/docker/utils_test.go
@@ -35,3 +35,38 @@ func TestValidateCgroupPermission(t *testing.T) {
 	}
 
 }
+
+func TestExpandPath(t *testing.T) {
+	cases := []struct {
+		base     string
+		target   string
+		expected string
+	}{
+		{"/tmp/alloc/task", "/home/user", "/home/user"},
+		{"/tmp/alloc/task", "/home/user/..", "/home"},
+
+		{"/tmp/alloc/task", ".", "/tmp/alloc/task"},
+		{"/tmp/alloc/task", "..", "/tmp/alloc"},
+
+		{"/tmp/alloc/task", "d1/d2", "/tmp/alloc/task/d1/d2"},
+		{"/tmp/alloc/task", "../d1/d2", "/tmp/alloc/d1/d2"},
+		{"/tmp/alloc/task", "../../d1/d2", "/tmp/d1/d2"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.expected, func(t *testing.T) {
+			require.Equal(t, c.expected, expandPath(c.base, c.target))
+		})
+	}
+}
+
+func TestIsParentPath(t *testing.T) {
+	require.True(t, isParentPath("/a/b/c", "/a/b/c"))
+	require.True(t, isParentPath("/a/b/c", "/a/b/c/d"))
+	require.True(t, isParentPath("/a/b/c", "/a/b/c/d/e"))
+
+	require.False(t, isParentPath("/a/b/c", "/a/b/d"))
+	require.False(t, isParentPath("/a/b/c", "/a/b/cd"))
+	require.False(t, isParentPath("/a/b/c", "/a/d/c"))
+	require.False(t, isParentPath("/a/b/c", "/d/e/c"))
+}


### PR DESCRIPTION
When volumes.enable flag is off in Docker driver, disable all mounts of
paths outside alloc dir.