### PR TITLE
client: update driver info on new driver fingerprint

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1154,7 +1154,6 @@ func (c *Client) updateNodeFromDriver(name string, info *structs.DriverInfo) *st
 	if !hadDriver {
 		// If the driver info has not yet been set, do that here
 		hasChanged = true
-		c.config.Node.Drivers[name] = info
 		for attrName, newVal := range info.Attributes {
 			c.config.Node.Attributes[attrName] = newVal
 		}
@@ -1163,11 +1162,11 @@ func (c *Client) updateNodeFromDriver(name string, info *structs.DriverInfo) *st
 		// The driver info has already been set, fix it up
 		if oldVal.Detected != info.Detected {
 			hasChanged = true
-			c.config.Node.Drivers[name].Detected = info.Detected
 		}
 
 		if oldVal.Healthy != info.Healthy || oldVal.HealthDescription != info.HealthDescription {
 			hasChanged = true
+
 			if info.HealthDescription != "" {
 				event := &structs.NodeEvent{
 					Subsystem: "Driver",
@@ -1186,6 +1185,7 @@ func (c *Client) updateNodeFromDriver(name string, info *structs.DriverInfo) *st
 			}
 
 			hasChanged = true
+
 			if newVal == "" {
 				delete(c.config.Node.Attributes, attrName)
 			} else {
@@ -1205,6 +1205,7 @@ func (c *Client) updateNodeFromDriver(name string, info *structs.DriverInfo) *st
 	}
 
 	if hasChanged {
+		c.config.Node.Drivers[name] = info
 		c.config.Node.Drivers[name].UpdateTime = time.Now()
 		c.updateNodeLocked()
 	}


### PR DESCRIPTION
Fixes a bug where a driver health and attributes are never updated from
their initial status.  If a driver started unhealthy, it may never go
into a healthy status.