### PR TITLE
ci: Test with Ubuntu 16.04 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,28 +15,28 @@ git:
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       env: ENABLE_RACE=1
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       env: RUN_WEBSITE_TESTS=1 SKIP_NOMAD_TESTS=1
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       env: RUN_UI_TESTS=1 SKIP_NOMAD_TESTS=1
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
     - os: osx
       osx_image: xcode9.1
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       env: RUN_E2E_TESTS=1 SKIP_NOMAD_TESTS=1
   allow_failures:

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -466,8 +466,9 @@ func TestExecDriver_HandlerExec(t *testing.T) {
 		if line == "" {
 			continue
 		}
-		// Skip systemd cgroup
-		if strings.HasPrefix(line, "1:name=systemd") {
+		// Skip systemd and rdma cgroups; rdma was added in most recent kernels and libcontainer/docker
+		// don't isolate them by default.
+		if strings.HasPrefix(line, "1:name=systemd") || strings.Contains(line, ":rdma:") {
 			continue
 		}
 		if !strings.Contains(line, ":/nomad/") {

--- a/scripts/travis-linux.sh
+++ b/scripts/travis-linux.sh
@@ -10,7 +10,7 @@ sudo service docker restart
 # true errors would fail in the apt-get install phase
 apt-get update || true
 
-apt-get install -y liblxc1 lxc-dev lxc shellcheck
+apt-get install -y liblxc1 lxc-dev lxc lxc-templates shellcheck
 apt-get install -y qemu
 bash ./scripts/travis-rkt.sh
 bash ./scripts/travis-consul.sh


### PR DESCRIPTION
Ubuntu 14.04 is very old, is few months away of being EOLed, and has odd interactions between lxc and libcontainer.

This PR makes Ubuntu 16.04 Xenial (which is only 2.5 years old) be the default test environment for builds, and our CI would match our development Vagrant image.