### PR TITLE
Add api.DefaultConfigWithClient which allows to specify custom http clients.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-cleanhttp"
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	rootcerts "github.com/hashicorp/go-rootcerts"
 )
 
@@ -199,9 +199,15 @@ func (t *TLSConfig) Copy() *TLSConfig {
 
 // DefaultConfig returns a default configuration for the client
 func DefaultConfig() *Config {
+	return DefaultConfigWithClient(cleanhttp.DefaultClient())
+}
+
+// DefaultConfigWithClient uses the default configuration but with an addition
+// of being able to specify your own http client for connections.
+func DefaultConfigWithClient(client *http.Client) *Config {
 	config := &Config{
 		Address:    "http://127.0.0.1:4646",
-		httpClient: cleanhttp.DefaultClient(),
+		httpClient: client,
 		TLSConfig:  &TLSConfig{},
 	}
 	transport := config.httpClient.Transport.(*http.Transport)


### PR DESCRIPTION
There is no functionality change for existing clients.

This change would allow for better testing of API, especially using [httptest][1] package, which requires that a custom client is provided to capture the requests.

[1]: https://golang.org/pkg/net/http/httptest/