### PR TITLE
client: Give a copy of clientconfig to allocrunner

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -867,7 +867,7 @@ func (c *Client) restoreState() error {
 		arConf := &allocrunner.Config{
 			Alloc:                 alloc,
 			Logger:                c.logger,
-			ClientConfig:          c.config,
+			ClientConfig:          c.configCopy,
 			StateDB:               c.stateDB,
 			StateUpdater:          c,
 			DeviceStatsReporter:   c,
@@ -2059,7 +2059,7 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 	arConf := &allocrunner.Config{
 		Alloc:                 alloc,
 		Logger:                c.logger,
-		ClientConfig:          c.config,
+		ClientConfig:          c.configCopy,
 		StateDB:               c.stateDB,
 		Consul:                c.consulService,
 		Vault:                 c.vaultClient,


### PR DESCRIPTION
Currently, there is a race condition between creating a taskrunner, and
updating node attributes via fingerprinting.

This is because the taskenv builder will try to iterate over the
clientconfig.Node.Attributes map, which can be concurrently updated by
the fingerprinting process, thus causing a panic.

This fixes that by providing a copy of the clientconfg to the
allocrunner inside the Read lock during config creation.

We could alternatively move the initialization process inside the config
lock, but that seems unnecessarily expensive, as afaik the allocrunner
does not depend on any future updated values, and has no way to safely
syncronize access to those resources.