### PR TITLE
[RFC] driver/docker: support default container labels

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -201,91 +201,6 @@ var (
 		),
 	})
 
-	// taskConfigSpec is the hcl specification for the driver config section of
-	// a task within a job. It is returned in the TaskConfigSchema RPC
-	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
-		"image":                  hclspec.NewAttr("image", "string", true),
-		"advertise_ipv6_address": hclspec.NewAttr("advertise_ipv6_address", "bool", false),
-		"args":                   hclspec.NewAttr("args", "list(string)", false),
-		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
-			"username":       hclspec.NewAttr("username", "string", false),
-			"password":       hclspec.NewAttr("password", "string", false),
-			"email":          hclspec.NewAttr("email", "string", false),
-			"server_address": hclspec.NewAttr("server_address", "string", false),
-		})),
-		"auth_soft_fail": hclspec.NewAttr("auth_soft_fail", "bool", false),
-		"cap_add":        hclspec.NewAttr("cap_add", "list(string)", false),
-		"cap_drop":       hclspec.NewAttr("cap_drop", "list(string)", false),
-		"command":        hclspec.NewAttr("command", "string", false),
-		"cpu_hard_limit": hclspec.NewAttr("cpu_hard_limit", "bool", false),
-		"cpu_cfs_period": hclspec.NewAttr("cpu_cfs_period", "number", false),
-		"devices": hclspec.NewBlockSet("devices", hclspec.NewObject(map[string]*hclspec.Spec{
-			"host_path":          hclspec.NewAttr("host_path", "string", false),
-			"container_path":     hclspec.NewAttr("container_path", "string", false),
-			"cgroup_permissions": hclspec.NewAttr("cgroup_permissions", "string", false),
-		})),
-		"dns_search_domains": hclspec.NewAttr("dns_search_domains", "list(string)", false),
-		"dns_options":        hclspec.NewAttr("dns_options", "list(string)", false),
-		"dns_servers":        hclspec.NewAttr("dns_servers", "list(string)", false),
-		"entrypoint":         hclspec.NewAttr("entrypoint", "list(string)", false),
-		"extra_hosts":        hclspec.NewAttr("extra_hosts", "list(string)", false),
-		"force_pull":         hclspec.NewAttr("force_pull", "bool", false),
-		"hostname":           hclspec.NewAttr("hostname", "string", false),
-		"interactive":        hclspec.NewAttr("interactive", "bool", false),
-		"ipc_mode":           hclspec.NewAttr("ipc_mode", "string", false),
-		"ipv4_address":       hclspec.NewAttr("ipv4_address", "string", false),
-		"ipv6_address":       hclspec.NewAttr("ipv6_address", "string", false),
-		"labels":             hclspec.NewBlockAttrs("labels", "string", false),
-		"load":               hclspec.NewAttr("load", "string", false),
-		"logging": hclspec.NewBlockSet("logging", hclspec.NewObject(map[string]*hclspec.Spec{
-			"type":   hclspec.NewAttr("type", "string", false),
-			"config": hclspec.NewBlockAttrs("config", "string", false),
-		})),
-		"mac_address": hclspec.NewAttr("mac_address", "string", false),
-		"mounts": hclspec.NewBlockSet("mounts", hclspec.NewObject(map[string]*hclspec.Spec{
-			"type": hclspec.NewDefault(
-				hclspec.NewAttr("type", "string", false),
-				hclspec.NewLiteral("\"volume\""),
-			),
-			"target":   hclspec.NewAttr("target", "string", false),
-			"source":   hclspec.NewAttr("source", "string", false),
-			"readonly": hclspec.NewAttr("readonly", "bool", false),
-			"bind_options": hclspec.NewBlock("bind_options", false, hclspec.NewObject(map[string]*hclspec.Spec{
-				"propagation": hclspec.NewAttr("propagation", "string", false),
-			})),
-			"tmpfs_options": hclspec.NewBlock("tmpfs_options", false, hclspec.NewObject(map[string]*hclspec.Spec{
-				"size": hclspec.NewAttr("size", "number", false),
-				"mode": hclspec.NewAttr("mode", "number", false),
-			})),
-			"volume_options": hclspec.NewBlock("volume_options", false, hclspec.NewObject(map[string]*hclspec.Spec{
-				"no_copy": hclspec.NewAttr("no_copy", "bool", false),
-				"labels":  hclspec.NewBlockAttrs("labels", "string", false),
-				"driver_config": hclspec.NewBlockSet("driver_config", hclspec.NewObject(map[string]*hclspec.Spec{
-					"name":    hclspec.NewAttr("name", "string", false),
-					"options": hclspec.NewBlockAttrs("name", "string", false),
-				})),
-			})),
-		})),
-		"network_aliases": hclspec.NewAttr("network_aliases", "list(string)", false),
-		"network_mode":    hclspec.NewAttr("network_mode", "string", false),
-		"pids_limit":      hclspec.NewAttr("pids_limit", "number", false),
-		"pid_mode":        hclspec.NewAttr("pid_mode", "string", false),
-		"port_map":        hclspec.NewBlockAttrs("port_map", "number", false),
-		"privileged":      hclspec.NewAttr("privileged", "bool", false),
-		"readonly_rootfs": hclspec.NewAttr("readonly_rootfs", "bool", false),
-		"security_opt":    hclspec.NewAttr("security_opt", "list(string)", false),
-		"shm_size":        hclspec.NewAttr("shm_size", "number", false),
-		"storage_opt":     hclspec.NewBlockAttrs("storage_opt", "string", false),
-		"sysctl":          hclspec.NewBlockAttrs("sysctl", "string", false),
-		"tty":             hclspec.NewAttr("tty", "bool", false),
-		"ulimit":          hclspec.NewBlockAttrs("ulimit", "string", false),
-		"uts_mode":        hclspec.NewAttr("uts_mode", "string", false),
-		"userns_mode":     hclspec.NewAttr("userns_mode", "string", false),
-		"volumes":         hclspec.NewAttr("volumes", "list(string)", false),
-		"volume_driver":   hclspec.NewAttr("volume_driver", "string", false),
-		"work_dir":        hclspec.NewAttr("work_dir", "string", false),
-	})
-
 	// capabilities is returned by the Capabilities RPC and indicates what
 	// optional features this driver supports
 	capabilities = &drivers.Capabilities{
@@ -534,9 +449,94 @@ func (d *Driver) SetConfig(data []byte, cfg *base.ClientAgentConfig) error {
 }
 
 func (d *Driver) TaskConfigSchema() (*hclspec.Spec, error) {
-	return taskConfigSpec, nil
+	return d.taskConfigSpec, nil
 }
 
 func (d *Driver) Capabilities() (*drivers.Capabilities, error) {
 	return capabilities, nil
+}
+
+func (d *Driver) updateTaskConfigSpec() {
+	d.taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
+		"image":                  hclspec.NewAttr("image", "string", true),
+		"advertise_ipv6_address": hclspec.NewAttr("advertise_ipv6_address", "bool", false),
+		"args":                   hclspec.NewAttr("args", "list(string)", false),
+		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
+			"username":       hclspec.NewAttr("username", "string", false),
+			"password":       hclspec.NewAttr("password", "string", false),
+			"email":          hclspec.NewAttr("email", "string", false),
+			"server_address": hclspec.NewAttr("server_address", "string", false),
+		})),
+		"auth_soft_fail": hclspec.NewAttr("auth_soft_fail", "bool", false),
+		"cap_add":        hclspec.NewAttr("cap_add", "list(string)", false),
+		"cap_drop":       hclspec.NewAttr("cap_drop", "list(string)", false),
+		"command":        hclspec.NewAttr("command", "string", false),
+		"cpu_hard_limit": hclspec.NewAttr("cpu_hard_limit", "bool", false),
+		"cpu_cfs_period": hclspec.NewAttr("cpu_cfs_period", "number", false),
+		"devices": hclspec.NewBlockSet("devices", hclspec.NewObject(map[string]*hclspec.Spec{
+			"host_path":          hclspec.NewAttr("host_path", "string", false),
+			"container_path":     hclspec.NewAttr("container_path", "string", false),
+			"cgroup_permissions": hclspec.NewAttr("cgroup_permissions", "string", false),
+		})),
+		"dns_search_domains": hclspec.NewAttr("dns_search_domains", "list(string)", false),
+		"dns_options":        hclspec.NewAttr("dns_options", "list(string)", false),
+		"dns_servers":        hclspec.NewAttr("dns_servers", "list(string)", false),
+		"entrypoint":         hclspec.NewAttr("entrypoint", "list(string)", false),
+		"extra_hosts":        hclspec.NewAttr("extra_hosts", "list(string)", false),
+		"force_pull":         hclspec.NewAttr("force_pull", "bool", false),
+		"hostname":           hclspec.NewAttr("hostname", "string", false),
+		"interactive":        hclspec.NewAttr("interactive", "bool", false),
+		"ipc_mode":           hclspec.NewAttr("ipc_mode", "string", false),
+		"ipv4_address":       hclspec.NewAttr("ipv4_address", "string", false),
+		"ipv6_address":       hclspec.NewAttr("ipv6_address", "string", false),
+		"labels":             hclspec.NewBlockAttrs("labels", "string", false),
+		"load":               hclspec.NewAttr("load", "string", false),
+		"logging": hclspec.NewBlockSet("logging", hclspec.NewObject(map[string]*hclspec.Spec{
+			"type":   hclspec.NewAttr("type", "string", false),
+			"config": hclspec.NewBlockAttrs("config", "string", false),
+		})),
+		"mac_address": hclspec.NewAttr("mac_address", "string", false),
+		"mounts": hclspec.NewBlockSet("mounts", hclspec.NewObject(map[string]*hclspec.Spec{
+			"type": hclspec.NewDefault(
+				hclspec.NewAttr("type", "string", false),
+				hclspec.NewLiteral("\"volume\""),
+			),
+			"target":   hclspec.NewAttr("target", "string", false),
+			"source":   hclspec.NewAttr("source", "string", false),
+			"readonly": hclspec.NewAttr("readonly", "bool", false),
+			"bind_options": hclspec.NewBlock("bind_options", false, hclspec.NewObject(map[string]*hclspec.Spec{
+				"propagation": hclspec.NewAttr("propagation", "string", false),
+			})),
+			"tmpfs_options": hclspec.NewBlock("tmpfs_options", false, hclspec.NewObject(map[string]*hclspec.Spec{
+				"size": hclspec.NewAttr("size", "number", false),
+				"mode": hclspec.NewAttr("mode", "number", false),
+			})),
+			"volume_options": hclspec.NewBlock("volume_options", false, hclspec.NewObject(map[string]*hclspec.Spec{
+				"no_copy": hclspec.NewAttr("no_copy", "bool", false),
+				"labels":  hclspec.NewBlockAttrs("labels", "string", false),
+				"driver_config": hclspec.NewBlockSet("driver_config", hclspec.NewObject(map[string]*hclspec.Spec{
+					"name":    hclspec.NewAttr("name", "string", false),
+					"options": hclspec.NewBlockAttrs("name", "string", false),
+				})),
+			})),
+		})),
+		"network_aliases": hclspec.NewAttr("network_aliases", "list(string)", false),
+		"network_mode":    hclspec.NewAttr("network_mode", "string", false),
+		"pids_limit":      hclspec.NewAttr("pids_limit", "number", false),
+		"pid_mode":        hclspec.NewAttr("pid_mode", "string", false),
+		"port_map":        hclspec.NewBlockAttrs("port_map", "number", false),
+		"privileged":      hclspec.NewAttr("privileged", "bool", false),
+		"readonly_rootfs": hclspec.NewAttr("readonly_rootfs", "bool", false),
+		"security_opt":    hclspec.NewAttr("security_opt", "list(string)", false),
+		"shm_size":        hclspec.NewAttr("shm_size", "number", false),
+		"storage_opt":     hclspec.NewBlockAttrs("storage_opt", "string", false),
+		"sysctl":          hclspec.NewBlockAttrs("sysctl", "string", false),
+		"tty":             hclspec.NewAttr("tty", "bool", false),
+		"ulimit":          hclspec.NewBlockAttrs("ulimit", "string", false),
+		"uts_mode":        hclspec.NewAttr("uts_mode", "string", false),
+		"userns_mode":     hclspec.NewAttr("userns_mode", "string", false),
+		"volumes":         hclspec.NewAttr("volumes", "list(string)", false),
+		"volume_driver":   hclspec.NewAttr("volume_driver", "string", false),
+		"work_dir":        hclspec.NewAttr("work_dir", "string", false),
+	})
 }

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -862,10 +862,15 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		config.Cmd = driverConfig.Args
 	}
 
+	labels := map[string]string{}
 	if len(driverConfig.Labels) > 0 {
-		config.Labels = driverConfig.Labels
-		logger.Debug("applied labels on the container", "labels", config.Labels)
+		labels = driverConfig.Labels
 	}
+	for k, v := range driverConfig.Internal.DefaultLabels {
+		labels[k] = v
+	}
+	logger.Debug("applied labels on the container", "labels", labels)
+	config.Labels = labels
 
 	config.Env = task.EnvList()
 

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -605,7 +605,7 @@ func encodeDriverHelper(require *require.Assertions, task *drivers.TaskConfig, t
 	evalCtx := &hcl.EvalContext{
 		Functions: shared.GetStdlibFuncs(),
 	}
-	spec, diag := hclspec.Convert(taskConfigSpec)
+	spec, diag := hclspec.Convert(taskConfigSpec, evalCtx)
 	require.False(diag.HasErrors())
 	taskConfigCtyVal, diag := shared.ParseHclInterface(taskConfig, spec, evalCtx)
 	require.False(diag.HasErrors())

--- a/drivers/java/driver_test.go
+++ b/drivers/java/driver_test.go
@@ -270,7 +270,7 @@ func encodeDriverHelper(t *testing.T, task *drivers.TaskConfig, taskConfig map[s
 	evalCtx := &hcl.EvalContext{
 		Functions: shared.GetStdlibFuncs(),
 	}
-	spec, diag := hclspec.Convert(taskConfigSpec)
+	spec, diag := hclspec.Convert(taskConfigSpec, evalCtx)
 	require.False(t, diag.HasErrors())
 	taskConfigCtyVal, diag := shared.ParseHclInterface(taskConfig, spec, evalCtx)
 	require.Empty(t, diag.Errs())

--- a/drivers/lxc/driver_test.go
+++ b/drivers/lxc/driver_test.go
@@ -263,7 +263,7 @@ func encodeDriverHelper(require *require.Assertions, task *drivers.TaskConfig, t
 	evalCtx := &hcl.EvalContext{
 		Functions: shared.GetStdlibFuncs(),
 	}
-	spec, diag := hclspec.Convert(taskConfigSpec)
+	spec, diag := hclspec.Convert(taskConfigSpec, evalCtx)
 	require.False(diag.HasErrors())
 	taskConfigCtyVal, diag := shared.ParseHclInterface(taskConfig, spec, evalCtx)
 	require.False(diag.HasErrors())

--- a/drivers/qemu/driver_test.go
+++ b/drivers/qemu/driver_test.go
@@ -195,7 +195,7 @@ func encodeDriverHelper(require *require.Assertions, task *drivers.TaskConfig, t
 	evalCtx := &hcl.EvalContext{
 		Functions: shared.GetStdlibFuncs(),
 	}
-	spec, diag := hclspec.Convert(taskConfigSpec)
+	spec, diag := hclspec.Convert(taskConfigSpec, evalCtx)
 	require.False(diag.HasErrors(), diag.Error())
 	taskConfigCtyVal, diag := shared.ParseHclInterface(taskConfig, spec, evalCtx)
 	require.False(diag.HasErrors(), diag.Error())

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -492,7 +492,7 @@ func encodeDriverHelper(require *require.Assertions, task *drivers.TaskConfig, t
 	evalCtx := &hcl.EvalContext{
 		Functions: shared.GetStdlibFuncs(),
 	}
-	spec, diag := hclspec.Convert(taskConfigSpec)
+	spec, diag := hclspec.Convert(taskConfigSpec, evalCtx)
 	require.False(diag.HasErrors())
 	taskConfigCtyVal, diag := shared.ParseHclInterface(taskConfig, spec, evalCtx)
 	require.False(diag.HasErrors())

--- a/drivers/rkt/driver_test.go
+++ b/drivers/rkt/driver_test.go
@@ -829,7 +829,7 @@ func encodeDriverHelper(require *require.Assertions, task *drivers.TaskConfig, t
 	evalCtx := &hcl.EvalContext{
 		Functions: shared.GetStdlibFuncs(),
 	}
-	spec, diag := hclspec.Convert(taskConfigSpec)
+	spec, diag := hclspec.Convert(taskConfigSpec, evalCtx)
 	require.False(diag.HasErrors())
 	taskConfigCtyVal, diag := shared.ParseHclInterface(taskConfig, spec, evalCtx)
 	if diag.HasErrors() {

--- a/plugins/shared/cmd/launcher/command/device.go
+++ b/plugins/shared/cmd/launcher/command/device.go
@@ -176,7 +176,7 @@ func (c *Device) getSpec() (hcldec.Spec, error) {
 	c.logger.Trace("device spec", "spec", hclog.Fmt("% #v", pretty.Formatter(spec)))
 
 	// Convert the schema
-	schema, diag := hclspec.Convert(spec)
+	schema, diag := hclspec.Convert(spec, nil)
 	if diag.HasErrors() {
 		errStr := "failed to convert HCL schema: "
 		for _, err := range diag.Errs() {

--- a/plugins/shared/hclspec/dec_test.go
+++ b/plugins/shared/hclspec/dec_test.go
@@ -20,7 +20,7 @@ func testSpecConversions(t *testing.T, cases []testConversions) {
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			act, diag := Convert(c.Input)
+			act, diag := Convert(c.Input, nil)
 			if diag.HasErrors() {
 				if c.ExpectedError == "" {
 					t.Fatalf("Convert %q failed: %v", c.Name, diag.Error())

--- a/plugins/shared/loader/init.go
+++ b/plugins/shared/loader/init.go
@@ -369,7 +369,7 @@ func (l *PluginLoader) validePluginConfig(id PluginID, info *pluginInfo) error {
 	}
 
 	// Convert the schema to hcl
-	spec, diag := hclspec.Convert(info.configSchema)
+	spec, diag := hclspec.Convert(info.configSchema, configParseCtx)
 	if diag.HasErrors() {
 		multierror.Append(&mErr, diag.Errs()...)
 		return multierror.Prefix(&mErr, "failed converting config schema:")


### PR DESCRIPTION
Support having default_labels to be set on nomad task Docker containers.
It defaults to labeling task_name, alloc_id, and job_name, and users
can override those by setting `default_labels` as a driver config option.

I aimed to support all variable interpolation supported within task
config, including node attributes.  When setting the values in driver
plugin config, one must escape them to avoid them being interpolated
within context the context of the driver plugin rather than task.  So a
driver config may look like:

```hcl
plugin "docker" {
  config {
    default_labels {
      alloc_id = "$${NOMAD_ALLOC_ID}"
      dc = "${{node.datacenter}}"
    }
  }
}
```

The implementation here is interesting.  In affect, Docker driver reserves
an `__internal` hcl block, where it injects the driver plugin default
labels values to be parsed and evaluated by task runner.

The flow of processing is as follows:
1. Driver receives plugin driver config with `default_label`, and it
   stores the value as a json representation (being json compatible)

2. When TaskRunner requests the TaskConfigSchema, docker driver injects
   an `__internal` block with the json representation as default value

3. TaskRunner parses user config along with the `__internal` block and
   sends parsed and interpolated config to Docker driver

4. Docker driver then uses the interpolated values from the `__internal`
   block

The approach is convoluted, but maintains the current Driver interface.
It avoids doing any hcl parsing in the drivers, which my complicate our
full transition to hcl2 and require passing evaluation context (for node
attributes, etc) to driver as well.

Open this PR to solicit review or discuss alternatives before going down this way (by adding tests, etc).