### PR TITLE
UI: Fix intermittent test failure "cannot read property name of undefined"

### DIFF
--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -194,7 +194,7 @@ moduleForAcceptance('Acceptance | task detail (no addresses)', {
     server.create('agent');
     server.create('node');
     server.create('job');
-    allocation = server.create('allocation', 'withoutTaskWithPorts');
+    allocation = server.create('allocation', 'withoutTaskWithPorts', { clientStatus: 'running' });
     task = server.db.taskStates.where({ allocationId: allocation.id })[0];
 
     Task.visit({ id: allocation.id, name: task.name });


### PR DESCRIPTION
Introduced by #4860.

Now that the mock allocations no longer create tasks when they aren't in a running state, allocations need to be created in a running state rather than a random state. The original PR addressed this but missed a spot.