### PR TITLE
Fix output of 'nomad deployment fail' with no arg

### DIFF
--- a/command/deployment_fail.go
+++ b/command/deployment_fail.go
@@ -79,10 +79,10 @@ func (c *DeploymentFailCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Check that we got no arguments
+	// Check that we got one argument
 	args = flags.Args()
 	if l := len(args); l != 1 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error("This command takes one argument: <deployment id>")
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}


### PR DESCRIPTION
The error text from the `deployment fail` command is incorrect.

```
$ nomad deployment fail
This command takes no arguments
For additional help try 'nomad deployment fail -help'
$ nomad deployment fail -help
Usage: nomad deployment fail [options] <deployment id>
```
