### PR TITLE
client: Emit TaskEvents when task hooks fail

### DIFF
--- a/client/allocrunner/taskrunner/artifact_hook.go
+++ b/client/allocrunner/taskrunner/artifact_hook.go
@@ -41,9 +41,9 @@ func (h *artifactHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 		//XXX add ctx to GetArtifact to allow cancelling long downloads
 		if err := getter.GetArtifact(req.TaskEnv, artifact, req.TaskDir.Dir); err != nil {
 			wrapped := fmt.Errorf("failed to download artifact %q: %v", artifact.GetterSource, err)
-			h.logger.Debug(wrapped.Error())
-			h.eventEmitter.EmitEvent(structs.NewTaskEvent(structs.TaskArtifactDownloadFailed).SetDownloadError(wrapped))
-			return wrapped
+			herr := NewHookError(wrapped, structs.NewTaskEvent(structs.TaskArtifactDownloadFailed).SetDownloadError(wrapped))
+
+			return herr
 		}
 	}
 

--- a/client/allocrunner/taskrunner/errors.go
+++ b/client/allocrunner/taskrunner/errors.go
@@ -14,15 +14,10 @@ var (
 	ErrTaskNotRunning = errors.New(errTaskNotRunning)
 )
 
-// HookError is an error interface that can be used by a TaskRunner hook to
-// emit custom task events when an error occurs.
-type HookError interface {
-	TaskEvent() *structs.TaskEvent
-	Error() string
-}
-
 // NewHookError returns an implementation of a HookError with an underlying err
 // and a pre-formatted task event.
+// If the taskEvent is nil, then we won't attempt to generate one during error
+// handling.
 func NewHookError(err error, taskEvent *structs.TaskEvent) error {
 	return &hookError{
 		err:       err,
@@ -33,10 +28,6 @@ func NewHookError(err error, taskEvent *structs.TaskEvent) error {
 type hookError struct {
 	taskEvent *structs.TaskEvent
 	err       error
-}
-
-func (h *hookError) TaskEvent() *structs.TaskEvent {
-	return h.taskEvent
 }
 
 func (h *hookError) Error() string {

--- a/client/allocrunner/taskrunner/errors.go
+++ b/client/allocrunner/taskrunner/errors.go
@@ -1,6 +1,10 @@
 package taskrunner
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
 
 const (
 	errTaskNotRunning = "Task not running"
@@ -9,3 +13,32 @@ const (
 var (
 	ErrTaskNotRunning = errors.New(errTaskNotRunning)
 )
+
+// HookError is an error interface that can be used by a TaskRunner hook to
+// emit custom task events when an error occurs.
+type HookError interface {
+	TaskEvent() *structs.TaskEvent
+	Error() string
+}
+
+// NewHookError returns an implementation of a HookError with an underlying err
+// and a pre-formatted task event.
+func NewHookError(err error, taskEvent *structs.TaskEvent) error {
+	return &hookError{
+		err:       err,
+		taskEvent: taskEvent,
+	}
+}
+
+type hookError struct {
+	taskEvent *structs.TaskEvent
+	err       error
+}
+
+func (h *hookError) TaskEvent() *structs.TaskEvent {
+	return h.taskEvent
+}
+
+func (h *hookError) Error() string {
+	return h.err.Error()
+}

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -106,20 +106,18 @@ func (tr *TaskRunner) initHooks() {
 
 func (tr *TaskRunner) emitHookError(err error, hookName string) {
 	var taskEvent *structs.TaskEvent
-	if herr, ok := err.(HookError); ok {
-		taskEvent = herr.TaskEvent()
+	if herr, ok := err.(*hookError); ok {
+		taskEvent = herr.taskEvent
 	} else {
 		message := fmt.Sprintf("%s: %v", hookName, err)
 		taskEvent = structs.NewTaskEvent(structs.TaskHookFailed).SetMessage(message)
 	}
 
 	// The TaskEvent returned by a HookError may be nil if the hook chooses to opt
-	// out of sending a task event on terminal status.
-	if taskEvent == nil {
-		return
+	// out of sending a task event.
+	if taskEvent != nil {
+		tr.EmitEvent(taskEvent)
 	}
-
-	tr.EmitEvent(taskEvent)
 }
 
 // prestart is used to run the runners prestart hooks.

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -104,6 +104,24 @@ func (tr *TaskRunner) initHooks() {
 	}
 }
 
+func (tr *TaskRunner) emitHookError(err error, hookName string) {
+	var taskEvent *structs.TaskEvent
+	if herr, ok := err.(HookError); ok {
+		taskEvent = herr.TaskEvent()
+	} else {
+		message := fmt.Sprintf("%s: %v", hookName, err)
+		taskEvent = structs.NewTaskEvent(structs.TaskHookFailed).SetMessage(message)
+	}
+
+	// The TaskEvent returned by a HookError may be nil if the hook chooses to opt
+	// out of sending a task event on terminal status.
+	if taskEvent == nil {
+		return
+	}
+
+	tr.EmitEvent(taskEvent)
+}
+
 // prestart is used to run the runners prestart hooks.
 func (tr *TaskRunner) prestart() error {
 	// Determine if the allocation is terminaland we should avoid running
@@ -170,6 +188,7 @@ func (tr *TaskRunner) prestart() error {
 		// Run the prestart hook
 		var resp interfaces.TaskPrestartResponse
 		if err := pre.Prestart(tr.killCtx, &req, &resp); err != nil {
+			tr.emitHookError(err, name)
 			return structs.WrapRecoverable(fmt.Sprintf("prestart hook %q failed: %v", name, err), err)
 		}
 
@@ -249,6 +268,7 @@ func (tr *TaskRunner) poststart() error {
 		}
 		var resp interfaces.TaskPoststartResponse
 		if err := post.Poststart(tr.killCtx, &req, &resp); err != nil {
+			tr.emitHookError(err, name)
 			merr.Errors = append(merr.Errors, fmt.Errorf("poststart hook %q failed: %v", name, err))
 		}
 
@@ -291,6 +311,7 @@ func (tr *TaskRunner) exited() error {
 		req := interfaces.TaskExitedRequest{}
 		var resp interfaces.TaskExitedResponse
 		if err := post.Exited(tr.killCtx, &req, &resp); err != nil {
+			tr.emitHookError(err, name)
 			merr.Errors = append(merr.Errors, fmt.Errorf("exited hook %q failed: %v", name, err))
 		}
 
@@ -334,6 +355,7 @@ func (tr *TaskRunner) stop() error {
 		req := interfaces.TaskStopRequest{}
 		var resp interfaces.TaskStopResponse
 		if err := post.Stop(tr.killCtx, &req, &resp); err != nil {
+			tr.emitHookError(err, name)
 			merr.Errors = append(merr.Errors, fmt.Errorf("stop hook %q failed: %v", name, err))
 		}
 
@@ -390,6 +412,7 @@ func (tr *TaskRunner) updateHooks() {
 		// Run the update hook
 		var resp interfaces.TaskUpdateResponse
 		if err := upd.Update(tr.killCtx, &req, &resp); err != nil {
+			tr.emitHookError(err, name)
 			tr.logger.Error("update hook failed", "name", name, "error", err)
 		}
 
@@ -432,6 +455,7 @@ func (tr *TaskRunner) killing() {
 		req := interfaces.TaskKillRequest{}
 		var resp interfaces.TaskKillResponse
 		if err := killHook.Killing(context.Background(), &req, &resp); err != nil {
+			tr.emitHookError(err, name)
 			tr.logger.Error("kill hook failed", "name", name, "error", err)
 		}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5830,6 +5830,9 @@ const (
 
 	// TaskLeaderDead indicates that the leader task within the has finished.
 	TaskLeaderDead = "Leader Task Dead"
+
+	// TaskHookFailed indicates that one of the hooks for a task failed.
+	TaskHookFailed = "Task hook failed"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data


### PR DESCRIPTION
This PR adds a HookError interface that can be used to emit a custom
TaskEvent when a hook fails.
It also provides a simple default implementation of the interface that attaches
a static error and task event. Hooks may implement their own error type,
and return it from this if desired.

If a hook returns a non-HookError, then we automatically generate a
TaskEvent from the error message and the name of the hook, which we then
emit. This allows operators to view the causes of failures without
having to identify and tail client logs.

![image](https://user-images.githubusercontent.com/1330683/50005816-f9c92680-ffab-11e8-87eb-0f534f86da75.png)