### PR TITLE
Upgrade to Golang 1.11.3

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -148,8 +148,8 @@ deps:  ## Install build and development dependencies
 	@echo "==> Updating build dependencies..."
 	go get -u github.com/kardianos/govendor
 	go get -u github.com/ugorji/go/codec/codecgen
-	go get -u github.com/hashicorp/go-bindata/...
-	go get -u github.com/elazarl/go-bindata-assetfs/...
+	go get -u github.com/hashicorp/go-bindata/go-bindata
+	go get -u github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs
 	go get -u github.com/a8m/tree/cmd/tree
 	go get -u github.com/magiconair/vendorfmt/cmd/vendorfmt
 	go get -u github.com/golang/protobuf/protoc-gen-go

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function install_go() {
-	local go_version=1.11
+	local go_version=1.11.3
 	local download=
 
 	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"


### PR DESCRIPTION
Also workaround a regression in 1.11.3

> We are aware of a functionality regression in "go get" when executed in GOPATH mode on an import path pattern containing "..." (e.g., "go get github.com/golang/pkg/..."), when downloading packages not already present in the GOPATH workspace. This is issue golang.org/issue/29241. It will be resolved in the next minor patch releases, Go 1.11.4 and Go 1.10.7, which we plan to release soon. We apologize for any disruption.
https://groups.google.com/forum/#!topic/golang-announce/Kw31K8G7Fi0