### PR TITLE
tests: fix rkt command environment

### DIFF
--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -661,10 +661,13 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 		Args:           runArgs,
 		ResourceLimits: true,
 		Resources:      cfg.Resources,
-		Env:            cfg.EnvList(),
-		TaskDir:        cfg.TaskDir().Dir,
-		StdoutPath:     cfg.StdoutPath,
-		StderrPath:     cfg.StderrPath,
+
+		// Use rktEnv, the environment needed for running rkt, not the task env
+		Env: rktEnv.List(),
+
+		TaskDir:    cfg.TaskDir().Dir,
+		StdoutPath: cfg.StdoutPath,
+		StderrPath: cfg.StderrPath,
 	}
 	ps, err := execImpl.Launch(execCmd)
 	if err != nil {


### PR DESCRIPTION
The environment variables needed for envoking `rkt` command line
should include host PATH (to access `iptables`).

Given that the command runs outside the VM, untrusted task environment
variables should NOT be honored here.

We do this already with `rkt`, but the change is quite subtle to miss
when refactoring.