### PR TITLE
docker: Delete Task on Destroy

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1019,6 +1019,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 	}
 
 	defer h.dloggerPluginClient.Kill()
+
 	if err := h.client.StopContainer(h.containerID, 0); err != nil {
 		h.logger.Warn("failed to stop container during destroy", "error", err)
 	}
@@ -1033,6 +1034,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 			"error", err)
 	}
 
+	d.tasks.Delete(taskID)
 	return nil
 }
 


### PR DESCRIPTION
Currently the docker driver does not remove tasks from its state map
when destroying the task, which leads to issues when restarting tasks in
place, and leaks expired handles over time.