### PR TITLE
taskrunner: Use a random suffix for Task Config

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -25,6 +25,7 @@ import (
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/vaultclient"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -690,13 +691,15 @@ func (tr *TaskRunner) persistLocalState() error {
 }
 
 // buildTaskConfig builds a drivers.TaskConfig with an unique ID for the task.
-// The ID is consistently built from the alloc ID, task name and restart attempt.
+// The ID is unique for every invocation, it is built from the alloc ID, task
+// name and 8 random characters.
 func (tr *TaskRunner) buildTaskConfig() *drivers.TaskConfig {
 	task := tr.Task()
 	alloc := tr.Alloc()
+	invocationid := uuid.Generate()[:8]
 
 	return &drivers.TaskConfig{
-		ID:      fmt.Sprintf("%s/%s/%d", alloc.ID, task.Name, tr.restartTracker.GetCount()),
+		ID:      fmt.Sprintf("%s/%s/%s", alloc.ID, task.Name, invocationid),
 		Name:    task.Name,
 		JobName: alloc.Job.Name,
 		Resources: &drivers.Resources{


### PR DESCRIPTION
The RestartCount is not really suitable for use as a source of
uniqueness within task invocations as it is not monotonic, and interacts
with the restart stanza in a users config, so conflates restarts due to
task failures, with restarts due to enviromental changes, such as consul
template or vault secrets changing.

Here we instead use a substring from a uuid, which is more random than
we strictly need, but is nicer than rolling our own random string
generator here.