### PR TITLE
fix for user-specified auto-join tags

### DIFF
--- a/terraform/aws/env/us-east/main.tf
+++ b/terraform/aws/env/us-east/main.tf
@@ -29,7 +29,13 @@ variable "client_count" {
 
 variable "retry_join" {
   description = "Used by Consul to automatically form a cluster."
-  default     = "provider=aws tag_key=ConsulAutoJoin tag_value=auto-join"
+  type        = "map"
+
+  default = {
+    provider  = "aws"
+    tag_key   = "ConsulAutoJoin"
+    tag_value = "auto-join"
+  }
 }
 
 variable "nomad_binary" {

--- a/terraform/aws/modules/hashistack/hashistack.tf
+++ b/terraform/aws/modules/hashistack/hashistack.tf
@@ -5,8 +5,17 @@ variable "instance_type" {}
 variable "key_name" {}
 variable "server_count" {}
 variable "client_count" {}
-variable "retry_join" {}
 variable "nomad_binary" {}
+
+variable "retry_join" {
+  type = "map"
+
+  default = {
+    provider  = "aws"
+    tag_key   = "ConsulAutoJoin"
+    tag_value = "auto-join"
+  }
+}
 
 data "aws_vpc" "default" {
   default = true
@@ -92,7 +101,7 @@ data "template_file" "user_data_server" {
   vars {
     server_count = "${var.server_count}"
     region       = "${var.region}"
-    retry_join   = "${var.retry_join}"
+    retry_join   = "${chomp(join(" ", formatlist("%s=%s", keys(var.retry_join), values(var.retry_join))))}"
     nomad_binary = "${var.nomad_binary}"
   }
 }
@@ -101,8 +110,8 @@ data "template_file" "user_data_client" {
   template = "${file("${path.root}/user-data-client.sh")}"
 
   vars {
-    region     = "${var.region}"
-    retry_join = "${var.retry_join}"
+    region       = "${var.region}"
+    retry_join   = "${chomp(join(" ", formatlist("%s=%s ", keys(var.retry_join), values(var.retry_join))))}"
     nomad_binary = "${var.nomad_binary}"
   }
 }
@@ -114,11 +123,11 @@ resource "aws_instance" "server" {
   vpc_security_group_ids = ["${aws_security_group.primary.id}"]
   count                  = "${var.server_count}"
 
-  #Instance tags
-  tags {
-    Name           = "${var.name}-server-${count.index}"
-    ConsulAutoJoin = "auto-join"
-  }
+  # instance tags
+  tags = "${merge(
+    map("Name", "${var.name}-server-${count.index}"),
+    map(lookup(var.retry_join, "tag_key"), lookup(var.retry_join, "tag_value"))
+  )}"
 
   user_data            = "${data.template_file.user_data_server.rendered}"
   iam_instance_profile = "${aws_iam_instance_profile.instance_profile.name}"
@@ -132,17 +141,17 @@ resource "aws_instance" "client" {
   count                  = "${var.client_count}"
   depends_on             = ["aws_instance.server"]
 
-  #Instance tags
-  tags {
-    Name           = "${var.name}-client-${count.index}"
-    ConsulAutoJoin = "auto-join"
-  }
+  # instance tags
+  tags = "${merge(
+    map("Name", "${var.name}-client-${count.index}"),
+    map(lookup(var.retry_join, "tag_key"), lookup(var.retry_join, "tag_value"))
+  )}"
 
-  ebs_block_device =  {
-    device_name                 = "/dev/xvdd"
-    volume_type                 = "gp2"
-    volume_size                 = "50"
-    delete_on_termination       = "true"
+  ebs_block_device = {
+    device_name           = "/dev/xvdd"
+    volume_type           = "gp2"
+    volume_size           = "50"
+    delete_on_termination = "true"
   }
 
   user_data            = "${data.template_file.user_data_client.rendered}"


### PR DESCRIPTION
# bugs

1. Previous AWS Terraform code would provision the EC2 instances with a static Consul auto-join key and value regardless of what the user specified with retry_join. This broke Consul auto-join logic.
1. If user relied on default values for retry_join the Consul auto-join logic was correct HOWEVER if there were 2 or more users of the TF code in the same AWS account their Consul clusters would attempt to merge and likely break leader election.

# proposed fix

Changed retry_join paramter to map value and provided defaults which were the same as previous code. Converted to type map due to limitations in the utility functions available in TF < 0.12 for adjusting retry_join to play nicely with formats expected by aws_instance::tags and the bundled user-data scripts. This will have (minor) impact for those using .tfvar or TFE in that they will need to adjust from input format String to input format Map.
