### PR TITLE
drivers: Shutdown eventer correctly

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1039,6 +1039,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 	}
 
 	d.tasks.Delete(taskID)
+	d.signalShutdown()
 	return nil
 }
 

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -480,6 +480,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 	}
 
 	d.tasks.Delete(taskID)
+	d.signalShutdown()
 	return nil
 }
 

--- a/drivers/mock/driver.go
+++ b/drivers/mock/driver.go
@@ -453,6 +453,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 	}
 
 	d.tasks.Delete(taskID)
+	d.signalShutdown()
 	return nil
 }
 

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -535,6 +535,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 	}
 
 	d.tasks.Delete(taskID)
+	d.signalShutdown()
 	return nil
 }
 

--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -780,6 +780,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 	}
 
 	d.tasks.Delete(taskID)
+	d.signalShutdown()
 	return nil
 }
 


### PR DESCRIPTION
Currently not all drivers shutdown their eventer context when tearing
destroying a task. This causes us to leak goroutines for every task.

This commit ensures that all drivers call the shutdwon function during
DestroyTask