### PR TITLE
allocrunner: Close updates routine correctly

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -652,7 +652,7 @@ func (ar *allocRunner) handleAllocUpdates() {
 		case update := <-ar.allocUpdatedCh:
 			ar.handleAllocUpdate(update)
 		case <-ar.waitCh:
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
This stops us from leaking goroutines into loops on shutdown.