### PR TITLE
Test fix races

### DIFF
--- a/client/gc_test.go
+++ b/client/gc_test.go
@@ -30,7 +30,7 @@ func gcConfig() *GCConfig {
 // runners to be terminal
 func exitAllocRunner(runners ...AllocRunner) {
 	for _, ar := range runners {
-		terminalAlloc := ar.Alloc()
+		terminalAlloc := ar.Alloc().Copy()
 		terminalAlloc.DesiredStatus = structs.AllocDesiredStatusStop
 		ar.Update(terminalAlloc)
 	}

--- a/client/pluginmanager/drivermanager/manager.go
+++ b/client/pluginmanager/drivermanager/manager.go
@@ -242,6 +242,7 @@ func (m *manager) waitForFirstFingerprint(ctx context.Context, cancel context.Ca
 		return
 	}
 
+	var mu sync.Mutex
 	var availDrivers []string
 	var wg sync.WaitGroup
 
@@ -253,7 +254,9 @@ func (m *manager) waitForFirstFingerprint(ctx context.Context, cancel context.Ca
 			defer wg.Done()
 			instance.WaitForFirstFingerprint(ctx)
 			if instance.getLastHealth() != drivers.HealthStateUndetected {
+				mu.Lock()
 				availDrivers = append(availDrivers, name)
+				mu.Unlock()
 			}
 		}(n, i)
 	}

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -399,6 +399,8 @@ func TestLeader_PeriodicDispatcher_Restore_Adds(t *testing.T) {
 
 	// Check that the new leader is tracking the periodic job only
 	testutil.WaitForResult(func() (bool, error) {
+		leader.periodicDispatcher.l.Lock()
+		defer leader.periodicDispatcher.l.Unlock()
 		if _, tracked := leader.periodicDispatcher.tracked[tuplePeriodic]; !tracked {
 			return false, fmt.Errorf("periodic job not tracked")
 		}

--- a/nomad/periodic.go
+++ b/nomad/periodic.go
@@ -173,7 +173,7 @@ func (p *PeriodicDispatch) SetEnabled(enabled bool) {
 		// If we are transitioning from disabled to enabled, run the daemon.
 		ctx, cancel := context.WithCancel(context.Background())
 		p.stopFn = cancel
-		go p.run(ctx)
+		go p.run(ctx, p.updateCh)
 	}
 }
 
@@ -320,7 +320,7 @@ func (p *PeriodicDispatch) shouldRun() bool {
 
 // run is a long-lived function that waits till a job's periodic spec is met and
 // then creates an evaluation to run the job.
-func (p *PeriodicDispatch) run(ctx context.Context) {
+func (p *PeriodicDispatch) run(ctx context.Context, updateCh <-chan struct{}) {
 	var launchCh <-chan time.Time
 	for p.shouldRun() {
 		job, launch := p.nextLaunch()
@@ -335,7 +335,7 @@ func (p *PeriodicDispatch) run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-p.updateCh:
+		case <-updateCh:
 			continue
 		case <-launchCh:
 			p.dispatch(job, launch)

--- a/nomad/periodic_endpoint_test.go
+++ b/nomad/periodic_endpoint_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	memdb "github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/net-rpc-msgpackrpc"
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -120,8 +120,9 @@ func TestPeriodicEndpoint_Force_ACL(t *testing.T) {
 		ws := memdb.NewWatchSet()
 		eval, err := state.EvalByID(ws, resp.EvalID)
 		assert.Nil(err)
-		assert.NotNil(eval)
-		assert.Equal(eval.CreateIndex, resp.EvalCreateIndex)
+		if assert.NotNil(eval) {
+			assert.Equal(eval.CreateIndex, resp.EvalCreateIndex)
+		}
 	}
 
 	// Fetch the response with management token
@@ -135,8 +136,9 @@ func TestPeriodicEndpoint_Force_ACL(t *testing.T) {
 		ws := memdb.NewWatchSet()
 		eval, err := state.EvalByID(ws, resp.EvalID)
 		assert.Nil(err)
-		assert.NotNil(eval)
-		assert.Equal(eval.CreateIndex, resp.EvalCreateIndex)
+		if assert.NotNil(eval) {
+			assert.Equal(eval.CreateIndex, resp.EvalCreateIndex)
+		}
 	}
 }
 


### PR DESCRIPTION
These race fixes make quite a few more tests in `nomad/` race free (although not nearly all), and you can now run the dev agent with `-race` enabled build. (You could run a dev agent with a `-race` enabled build before, but it would hit a race on shutdown.)

The general SetEnabled pattern we use for server daemons is hard to make race free as `SetEnabled(false)` reinitializes most/all struct fields while `SetEnabled(true)` starts goroutines that access them. So you could end up with an execution history:

1. d.SetEnabled(true) -> starts g1 with access to `d.ch` (v1)
2. d.SetEnabled(false) -> cancel g1, reinitialize `d.ch` (v2)
   * This is a race as there's nothing ensuring g1 exits before attempting to reread `d.ch` (v2) which is being changed concurrently
3. d.SetEnabled(true) -> starts g2 with access to `d.ch` (v2)

If this happens quickly enough there could be 2 goroutines both receiving from `d.ch` (v2). While this is ~infinitely unlikely to happen at runtime due to at least milliseconds elapsing between two `SetEnabled(true)` calls, it does make tests that want to manually enable/disable daemons timing dependent.

I solved this by passing `d.ch` on the stack so in the example above `g1` would receive `d.ch` (v1) as an argument and would never attempt to access `d.ch` (v2) on daemon struct `d` directly.