### PR TITLE
taskrunner: Persist environment from hooks

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -218,9 +218,9 @@ func (tr *TaskRunner) prestart() error {
 
 		// Store the environment variables returned by the hook
 		if name == HookNameDevices {
-			tr.envBuilder.SetDeviceHookEnv(name, origHookState.Env)
+			tr.envBuilder.SetDeviceHookEnv(name, resp.Env)
 		} else {
-			tr.envBuilder.SetHookEnv(name, origHookState.Env)
+			tr.envBuilder.SetHookEnv(name, resp.Env)
 		}
 
 		// Store the resources


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/5032 introduced a regression
where the origHookState was used in place of the response from the hook.

This fixes that and the resulting panic