### PR TITLE
Restore some `exec` behavior 

### DIFF
--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -297,11 +297,16 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 		return nil, nil, fmt.Errorf("failed to create executor: %v", err)
 	}
 
+	user := cfg.User
+	if user == "" {
+		user = "nobody"
+	}
+
 	execCmd := &executor.ExecCommand{
 		Cmd:            driverConfig.Command,
 		Args:           driverConfig.Args,
 		Env:            cfg.EnvList(),
-		User:           cfg.User,
+		User:           user,
 		ResourceLimits: true,
 		Resources:      cfg.Resources,
 		TaskDir:        cfg.TaskDir().Dir,

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -328,11 +328,16 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *cstru
 		return nil, nil, fmt.Errorf("failed to create executor: %v", err)
 	}
 
+	user := cfg.User
+	if user == "" {
+		user = "nobody"
+	}
+
 	execCmd := &executor.ExecCommand{
 		Cmd:            absPath,
 		Args:           args,
 		Env:            cfg.EnvList(),
-		User:           cfg.User,
+		User:           user,
 		ResourceLimits: true,
 		Resources:      cfg.Resources,
 		TaskDir:        cfg.TaskDir().Dir,


### PR DESCRIPTION
Restore some 0.8 exec behavior, namely run task as `nobody` by default, and make all host devices available.

It's worth noting that I noticed that now 0.9 exec makes `/sys` available to exec tasks, unlike 0.8.  I have decided to keep mounting /sys as it's not a breaking change and is useful in some cases (e.g. reading cgroups).