### PR TITLE
driver/exec: use dedicated /dev mount

### DIFF
--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -519,10 +519,9 @@ func configureIsolation(cfg *lconfigs.Config, command *ExecCommand) error {
 
 	cfg.Mounts = []*lconfigs.Mount{
 		{
-			Source:      "/dev",
+			Source:      "dev",
 			Destination: "/dev",
-			Device:      "bind",
-			Flags:       syscall.MS_BIND | syscall.MS_RDONLY | syscall.MS_NOEXEC,
+			Device:      "devtmpfs",
 		},
 		{
 			Source:      "proc",


### PR DESCRIPTION
Use a dedicated /dev mount so we can inject more devices if necessary,
and avoid allowing a container to contaminate host /dev.

Follow up to https://github.com/hashicorp/nomad/pull/5143