### PR TITLE
taskrunner: emit TaskReceived event

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -309,6 +309,9 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 	// Initialize base labels
 	tr.initLabels()
 
+	// Initialize initial task received event
+	tr.appendEvent(structs.NewTaskEvent(structs.TaskReceived))
+
 	return tr, nil
 }
 


### PR DESCRIPTION
Preserve pre-0.9, where task runner emits `Received: Task received by
client` event on task runner creation.