### PR TITLE
drivers/docker: labels containers with task info

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -859,10 +859,17 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		config.Cmd = driverConfig.Args
 	}
 
-	if len(driverConfig.Labels) > 0 {
-		config.Labels = driverConfig.Labels
-		logger.Debug("applied labels on the container", "labels", config.Labels)
+	config.Labels = map[string]string{
+		"com.hashicorp.nomad.task_id":   task.ID,
+		"com.hashicorp.nomad.task_name": task.Name,
+		"com.hashicorp.nomad.alloc_id":  task.AllocID,
+		"com.hashicorp.nomad.job_name":  task.JobName,
 	}
+
+	for k, v := range driverConfig.Labels {
+		config.Labels[k] = v
+	}
+	logger.Debug("applied labels on the container", "labels", config.Labels)
 
 	config.Env = task.EnvList()
 


### PR DESCRIPTION
Label docker containers with task info (i.e. job/alloc/task id).

Using `com.hashicorp.nomad.` namespace to avoid name clashes with user
labels.

Closes https://github.com/hashicorp/nomad/issues/4781.   This is a less ambitious scope of https://github.com/hashicorp/nomad/pull/4995 - we intend to add a more flexible configurable option in the future, but this seems like a nice change on its own.