### PR TITLE
remove unnecessary logging in rkt driver fingerprint method

### DIFF
--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -270,7 +270,6 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 
 	// Only enable if we are root
 	if syscall.Geteuid() != 0 {
-		d.logger.Debug("must run as root user, disabling")
 		fingerprint.Health = drivers.HealthStateUndetected
 		fingerprint.HealthDescription = drivers.DriverRequiresRootMessage
 		return fingerprint
@@ -298,8 +297,6 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 		// Do not allow ancient rkt versions
 		fingerprint.Health = drivers.HealthStateUndetected
 		fingerprint.HealthDescription = fmt.Sprintf("unsuported rkt version %s", currentVersion)
-		d.logger.Warn("unsupported rkt version please upgrade to >= "+minVersion.String(),
-			"rkt_version", currentVersion)
 		return fingerprint
 	}
 


### PR DESCRIPTION
Nomad client already logs the same messages based on the fingerprint method's results. 