### PR TITLE
Standardize driver health description messages for all drivers

### DIFF
--- a/drivers/docker/fingerprint.go
+++ b/drivers/docker/fingerprint.go
@@ -34,14 +34,14 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	fp := &drivers.Fingerprint{
 		Attributes:        map[string]*pstructs.Attribute{},
 		Health:            drivers.HealthStateHealthy,
-		HealthDescription: "healthy",
+		HealthDescription: drivers.DriverHealthy,
 	}
 	client, _, err := d.dockerClients()
 	if err != nil {
 		d.logger.Info("failed to initialize client", "error", err)
 		return &drivers.Fingerprint{
 			Health:            drivers.HealthStateUndetected,
-			HealthDescription: "failed to initialize docker client",
+			HealthDescription: "Failed to initialize docker client",
 		}
 	}
 
@@ -50,7 +50,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 		d.logger.Debug("could not connect to docker daemon", "endpoint", client.Endpoint(), "error", err)
 		return &drivers.Fingerprint{
 			Health:            drivers.HealthStateUnhealthy,
-			HealthDescription: "failed to connect to docker daemon",
+			HealthDescription: "Failed to connect to docker daemon",
 		}
 	}
 

--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -189,7 +189,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	fp := &drivers.Fingerprint{
 		Attributes:        map[string]*pstructs.Attribute{},
 		Health:            drivers.HealthStateHealthy,
-		HealthDescription: "healthy",
+		HealthDescription: drivers.DriverHealthy,
 	}
 
 	if !utils.IsUnixRoot() {
@@ -201,14 +201,14 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	mount, err := fingerprint.FindCgroupMountpointDir()
 	if err != nil {
 		fp.Health = drivers.HealthStateUnhealthy
-		fp.HealthDescription = "failed to discover cgroup mount point"
+		fp.HealthDescription = drivers.NoCgroupMountMessage
 		d.logger.Warn(fp.HealthDescription, "error", err)
 		return fp
 	}
 
 	if mount == "" {
 		fp.Health = drivers.HealthStateUnhealthy
-		fp.HealthDescription = "requires cgroup"
+		fp.HealthDescription = drivers.CgroupMountEmpty
 		return fp
 	}
 

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -196,7 +196,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	fp := &drivers.Fingerprint{
 		Attributes:        map[string]*pstructs.Attribute{},
 		Health:            drivers.HealthStateHealthy,
-		HealthDescription: "healthy",
+		HealthDescription: drivers.DriverHealthy,
 	}
 
 	if runtime.GOOS == "linux" {
@@ -210,14 +210,14 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 		mount, err := fingerprint.FindCgroupMountpointDir()
 		if err != nil {
 			fp.Health = drivers.HealthStateUnhealthy
-			fp.HealthDescription = "failed to discover cgroup mount point"
+			fp.HealthDescription = drivers.NoCgroupMountMessage
 			d.logger.Warn(fp.HealthDescription, "error", err)
 			return fp
 		}
 
 		if mount == "" {
 			fp.Health = drivers.HealthStateUnhealthy
-			fp.HealthDescription = "cgroups are unavailable"
+			fp.HealthDescription = drivers.CgroupMountEmpty
 			return fp
 		}
 	}

--- a/drivers/mock/driver.go
+++ b/drivers/mock/driver.go
@@ -279,7 +279,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	} else {
 		health = drivers.HealthStateHealthy
 		attrs["driver.mock"] = pstructs.NewBoolAttribute(true)
-		desc = "ready"
+		desc = drivers.DriverHealthy
 	}
 
 	return &drivers.Fingerprint{

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -207,7 +207,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	fingerprint := &drivers.Fingerprint{
 		Attributes:        map[string]*pstructs.Attribute{},
 		Health:            drivers.HealthStateHealthy,
-		HealthDescription: "ready",
+		HealthDescription: drivers.DriverHealthy,
 	}
 
 	bin := "qemu-system-x86_64"
@@ -229,7 +229,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	matches := versionRegex.FindStringSubmatch(out)
 	if len(matches) != 2 {
 		fingerprint.Health = drivers.HealthStateUndetected
-		fingerprint.HealthDescription = fmt.Sprintf("failed to parse qemu version from %v", out)
+		fingerprint.HealthDescription = fmt.Sprintf("Failed to parse qemu version from %v", out)
 		return fingerprint
 	}
 	currentQemuVersion := matches[1]

--- a/drivers/rawexec/driver.go
+++ b/drivers/rawexec/driver.go
@@ -230,7 +230,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	attrs := map[string]*pstructs.Attribute{}
 	if d.config.Enabled {
 		health = drivers.HealthStateHealthy
-		desc = "ready"
+		desc = drivers.DriverHealthy
 		attrs["driver.raw_exec"] = pstructs.NewBoolAttribute(true)
 	} else {
 		health = drivers.HealthStateUndetected

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -121,7 +121,7 @@ func TestRawExecDriver_Fingerprint(t *testing.T) {
 			Expected: drivers.Fingerprint{
 				Attributes:        map[string]*pstructs.Attribute{"driver.raw_exec": pstructs.NewBoolAttribute(true)},
 				Health:            drivers.HealthStateHealthy,
-				HealthDescription: "ready",
+				HealthDescription: drivers.DriverHealthy,
 			},
 		},
 	}

--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -265,7 +265,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	fingerprint := &drivers.Fingerprint{
 		Attributes:        map[string]*pstructs.Attribute{},
 		Health:            drivers.HealthStateHealthy,
-		HealthDescription: "ready",
+		HealthDescription: drivers.DriverHealthy,
 	}
 
 	// Only enable if we are root
@@ -278,7 +278,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	outBytes, err := exec.Command(rktCmd, "version").Output()
 	if err != nil {
 		fingerprint.Health = drivers.HealthStateUndetected
-		fingerprint.HealthDescription = fmt.Sprintf("failed to executor %s version: %v", rktCmd, err)
+		fingerprint.HealthDescription = fmt.Sprintf("Failed to execute %s version: %v", rktCmd, err)
 		return fingerprint
 	}
 	out := strings.TrimSpace(string(outBytes))
@@ -287,7 +287,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	appcMatches := reAppcVersion.FindStringSubmatch(out)
 	if len(rktMatches) != 2 || len(appcMatches) != 2 {
 		fingerprint.Health = drivers.HealthStateUndetected
-		fingerprint.HealthDescription = "unable to parse rkt version string"
+		fingerprint.HealthDescription = "Unable to parse rkt version string"
 		return fingerprint
 	}
 
@@ -296,7 +296,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	if currentVersion.LessThan(minVersion) {
 		// Do not allow ancient rkt versions
 		fingerprint.Health = drivers.HealthStateUndetected
-		fingerprint.HealthDescription = fmt.Sprintf("unsuported rkt version %s", currentVersion)
+		fingerprint.HealthDescription = fmt.Sprintf("Unsuported rkt version %s", currentVersion)
 		return fingerprint
 	}
 

--- a/plugins/drivers/driver.go
+++ b/plugins/drivers/driver.go
@@ -18,6 +18,8 @@ import (
 	"github.com/zclconf/go-cty/cty/msgpack"
 )
 
+const DriverHealthy = "Healthy"
+
 // DriverPlugin is the interface with drivers will implement. It is also
 // implemented by a plugin client which proxies the calls to go-plugin. See
 // the proto/driver.proto file for detailed information about each RPC and

--- a/plugins/drivers/errors.go
+++ b/plugins/drivers/errors.go
@@ -5,3 +5,7 @@ import "fmt"
 var ErrTaskNotFound = fmt.Errorf("task not found for given id")
 
 var DriverRequiresRootMessage = "Driver must run as root"
+
+var NoCgroupMountMessage = "Failed to discover cgroup mount point"
+
+var CgroupMountEmpty = "Cgroup mount point unavailable"


### PR DESCRIPTION
Use same description for driver health indicator across all internal drivers, and capitalize other error messages for consistency