### PR TITLE
Handle client initialization errors when adding/restoring allocs

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -628,6 +628,15 @@ func getClientStatus(taskStates map[string]*structs.TaskState) (status, descript
 	return "", ""
 }
 
+// SetClientStatus is a helper for forcing a specific client
+// status on the alloc runner. This is used during restore errors
+// when the task state can't be restored.
+func (ar *allocRunner) SetClientStatus(clientStatus string) {
+	ar.stateLock.Lock()
+	defer ar.stateLock.Unlock()
+	ar.state.ClientStatus = clientStatus
+}
+
 // AllocState returns a copy of allocation state including a snapshot of task
 // states.
 func (ar *allocRunner) AllocState() *state.State {

--- a/client/client.go
+++ b/client/client.go
@@ -1987,9 +1987,14 @@ func makeFailedAlloc(add *structs.Allocation, err error) *structs.Allocation {
 	}
 
 	failTime := time.Now()
-	stripped.DeploymentStatus = &structs.AllocDeploymentStatus{
-		Healthy:   helper.BoolToPtr(false),
-		Timestamp: failTime,
+	if add.DeploymentStatus.HasHealth() {
+		// Never change deployment health once it has been set
+		stripped.DeploymentStatus = add.DeploymentStatus.Copy()
+	} else {
+		stripped.DeploymentStatus = &structs.AllocDeploymentStatus{
+			Healthy:   helper.BoolToPtr(false),
+			Timestamp: failTime,
+		}
 	}
 
 	taskGroup := add.Job.LookupTaskGroup(add.TaskGroup)

--- a/client/client.go
+++ b/client/client.go
@@ -2013,7 +2013,13 @@ func (c *Client) removeAlloc(allocID string) {
 
 	ar, ok := c.allocs[allocID]
 	if !ok {
-		c.logger.Warn("cannot remove alloc", "alloc_id", allocID, "error", "alloc not found")
+		if _, ok := c.invalidAllocs[allocID]; ok {
+			// Removing from invalid allocs map if present
+			delete(c.invalidAllocs, allocID)
+		} else {
+			// Alloc is unknown, log a warning.
+			c.logger.Warn("cannot remove nonexistent alloc", "alloc_id", allocID, "error", "alloc not found")
+		}
 		return
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -967,9 +967,6 @@ func (c *Client) restoreState() error {
 		if err := ar.Restore(); err != nil {
 			c.logger.Error("error restoring alloc", "error", err, "alloc_id", alloc.ID)
 			mErr.Errors = append(mErr.Errors, err)
-			// Mark alloc as failed so server can handle this
-			failed := makeFailedAlloc(alloc, err)
-			c.allocUpdates <- failed
 			//TODO Cleanup allocrunner
 			continue
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -1977,7 +1977,7 @@ func makeFailedAlloc(add *structs.Allocation, err error) *structs.Allocation {
 	stripped.ID = add.ID
 	stripped.NodeID = add.NodeID
 	stripped.ClientStatus = structs.AllocClientStatusFailed
-	stripped.ClientDescription = fmt.Sprintf("Unable to add allocation due to err: %v", err)
+	stripped.ClientDescription = fmt.Sprintf("Unable to add allocation due to error: %v", err)
 
 	// Copy task states if it exists in the original allocation
 	if add.TaskStates != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -702,7 +702,7 @@ func TestClient_RestoreError(t *testing.T) {
 
 	// This stateDB returns errors for all methods called by restore
 	stateDBFunc := func(hclog.Logger, string) (cstate.StateDB, error) {
-		return &cstate.ErrDB{[]*structs.Allocation{alloc1}}, nil
+		return &cstate.ErrDB{Allocs: []*structs.Allocation{alloc1}}, nil
 	}
 	c1.config.StateDBFactory = stateDBFunc
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -26,7 +26,11 @@ import (
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/state"
+	cstate "github.com/hashicorp/nomad/client/state"
 	ctestutil "github.com/hashicorp/nomad/client/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 func testACLServer(t *testing.T, cb func(*nomad.Config)) (*nomad.Server, string, *structs.ACLToken) {
@@ -599,7 +603,8 @@ func TestClient_SaveRestoreState(t *testing.T) {
 	c1.config.Logger = logger
 	catalog := consul.NewMockCatalog(logger)
 	mockService := consulApi.NewMockConsulServiceClient(t, logger)
-	c2, err := NewClient(c1.config, catalog, mockService)
+	statedbFunc := cstate.GetStateDBFactory(c1.config.DevMode)
+	c2, err := NewClient(c1.config, catalog, mockService, statedbFunc)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -630,6 +635,96 @@ func TestClient_SaveRestoreState(t *testing.T) {
 	}
 }
 
+func TestClient_RestoreError(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	s1, _ := testServer(t, nil)
+	defer s1.Shutdown()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1, cleanup := TestClient(t, func(c *config.Config) {
+		c.DevMode = false
+		c.RPCHandler = s1
+	})
+	defer cleanup()
+
+	// Wait until the node is ready
+	waitTilNodeReady(c1, t)
+
+	// Create mock allocations
+	job := mock.Job()
+	alloc1 := mock.Alloc()
+	alloc1.NodeID = c1.Node().ID
+	alloc1.Job = job
+	alloc1.JobID = job.ID
+	alloc1.Job.TaskGroups[0].Tasks[0].Driver = "mock_driver"
+	alloc1.Job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+	alloc1.ClientStatus = structs.AllocClientStatusRunning
+
+	state := s1.State()
+	err := state.UpsertJob(100, job)
+	require.Nil(err)
+
+	err = state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID))
+	require.Nil(err)
+
+	err = state.UpsertAllocs(102, []*structs.Allocation{alloc1})
+	require.Nil(err)
+
+	// Allocations should get registered
+	testutil.WaitForResult(func() (bool, error) {
+		c1.allocLock.RLock()
+		ar := c1.allocs[alloc1.ID]
+		c1.allocLock.RUnlock()
+		if ar == nil {
+			return false, fmt.Errorf("nil alloc runner")
+		}
+		if ar.Alloc().ClientStatus != structs.AllocClientStatusRunning {
+			return false, fmt.Errorf("client status: got %v; want %v", ar.Alloc().ClientStatus, structs.AllocClientStatusRunning)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Shutdown the client, saves state
+	if err := c1.Shutdown(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Create a new client with a stateDB implementation that errors
+	logger := testlog.HCLogger(t)
+	c1.config.Logger = logger
+	catalog := consul.NewMockCatalog(logger)
+	mockService := consulApi.NewMockConsulServiceClient(t, logger)
+
+	// This stateDB returns errors for all methods called by restore
+	statedbFunc := func(hclog.Logger, string) (cstate.StateDB, error) {
+		return &cstate.ErrDB{[]*structs.Allocation{alloc1}}, nil
+	}
+
+	c2, err := NewClient(c1.config, catalog, mockService, statedbFunc)
+	require.Nil(err)
+	defer c2.Shutdown()
+
+	// Ensure the allocation has been marked as failed on the server
+	testutil.WaitForResult(func() (bool, error) {
+		alloc, err := s1.State().AllocByID(nil, alloc1.ID)
+		require.Nil(err)
+		failed := alloc.ClientStatus == structs.AllocClientStatusFailed
+		if !failed {
+			return false, fmt.Errorf("Expected failed client status, but got %v", alloc.ClientStatus)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+}
+
 func TestClient_Init(t *testing.T) {
 	t.Parallel()
 	dir, err := ioutil.TempDir("", "nomad")
@@ -645,7 +740,8 @@ func TestClient_Init(t *testing.T) {
 		},
 		logger: testlog.HCLogger(t),
 	}
-	if err := client.init(); err != nil {
+	stateDBFunc := state.GetStateDBFactory(true)
+	if err := client.init(stateDBFunc); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -720,7 +720,7 @@ func TestClient_RestoreError(t *testing.T) {
 		}
 		return true, nil
 	}, func(err error) {
-		t.Fatalf("err: %v", err)
+		require.NoError(err)
 	})
 
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -725,6 +725,76 @@ func TestClient_RestoreError(t *testing.T) {
 
 }
 
+func TestClient_AddAllocError(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	s1, _ := testServer(t, nil)
+	defer s1.Shutdown()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1, cleanup := TestClient(t, func(c *config.Config) {
+		c.DevMode = false
+		c.RPCHandler = s1
+	})
+	defer cleanup()
+
+	// Wait until the node is ready
+	waitTilNodeReady(c1, t)
+
+	// Create mock allocation with invalid task group name
+	job := mock.Job()
+	alloc1 := mock.Alloc()
+	alloc1.NodeID = c1.Node().ID
+	alloc1.Job = job
+	alloc1.JobID = job.ID
+	alloc1.Job.TaskGroups[0].Tasks[0].Driver = "mock_driver"
+	alloc1.Job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+	alloc1.ClientStatus = structs.AllocClientStatusPending
+
+	state := s1.State()
+	err := state.UpsertJob(100, job)
+	require.Nil(err)
+
+	err = state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID))
+	require.Nil(err)
+
+	err = state.UpsertAllocs(102, []*structs.Allocation{alloc1})
+	require.Nil(err)
+
+	// Manipulate state store alloc to make its task group invalid
+	stateStoreAlloc, _ := s1.State().AllocByID(nil, alloc1.ID)
+	stateStoreAlloc.TaskGroup = "invalid"
+
+	// Ensure the allocation has been marked as invalid and failed on the server
+	testutil.WaitForResult(func() (bool, error) {
+		c1.allocLock.RLock()
+		ar := c1.allocs[alloc1.ID]
+		_, isInvalid := c1.invalidAllocs[alloc1.ID]
+		c1.allocLock.RUnlock()
+		if ar != nil {
+			return false, fmt.Errorf("expected nil alloc runner")
+		}
+		if !isInvalid {
+			return false, fmt.Errorf("expected alloc to be marked as invalid")
+		}
+		// Make the task group name valid again so that the client update to mark it failed works
+		stateStoreAlloc.TaskGroup = "web"
+		alloc, err := s1.State().AllocByID(nil, alloc1.ID)
+		require.Nil(err)
+		failed := alloc.ClientStatus == structs.AllocClientStatusFailed
+		if !failed {
+			return false, fmt.Errorf("Expected failed client status, but got %v", alloc.ClientStatus)
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err)
+	})
+
+}
+
 func TestClient_Init(t *testing.T) {
 	t.Parallel()
 	dir, err := ioutil.TempDir("", "nomad")

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -214,6 +215,9 @@ type Config struct {
 	// PluginSingletonLoader is a plugin loader that will returns singleton
 	// instances of the plugins.
 	PluginSingletonLoader loader.PluginCatalog
+
+	// StateDBFactory is used to override stateDB implementations,
+	StateDBFactory state.NewStateDBFunc
 }
 
 func (c *Config) Copy() *Config {

--- a/client/state/errdb.go
+++ b/client/state/errdb.go
@@ -1,0 +1,81 @@
+package state
+
+import (
+	"fmt"
+	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
+	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// ErrDB implements a StateDB that returns errors on restore methods, used for testing
+type ErrDB struct {
+	// Allocs is a preset slice of allocations used in GetAllAllocations
+	Allocs []*structs.Allocation
+}
+
+func (m *ErrDB) Name() string {
+	return "errdb"
+}
+
+func (m *ErrDB) Upgrade() error {
+	return nil
+}
+
+func (m *ErrDB) GetAllAllocations() ([]*structs.Allocation, map[string]error, error) {
+	return m.Allocs, nil, nil
+}
+
+func (m *ErrDB) PutAllocation(alloc *structs.Allocation) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) GetDeploymentStatus(allocID string) (*structs.AllocDeploymentStatus, error) {
+	return nil, fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) PutDeploymentStatus(allocID string, ds *structs.AllocDeploymentStatus) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) GetTaskRunnerState(allocID string, taskName string) (*state.LocalState, *structs.TaskState, error) {
+	return nil, nil, fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) PutTaskRunnerLocalState(allocID string, taskName string, val *state.LocalState) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) PutTaskState(allocID string, taskName string, state *structs.TaskState) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) DeleteTaskBucket(allocID, taskName string) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) DeleteAllocationBucket(allocID string) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) PutDevicePluginState(ps *dmstate.PluginState) error {
+	return fmt.Errorf("Error!")
+}
+
+// GetDevicePluginState stores the device manager's plugin state or returns an
+// error.
+func (m *ErrDB) GetDevicePluginState() (*dmstate.PluginState, error) {
+	return nil, fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) GetDriverPluginState() (*driverstate.PluginState, error) {
+	return nil, fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) PutDriverPluginState(ps *driverstate.PluginState) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) Close() error {
+	return fmt.Errorf("Error!")
+}

--- a/client/state/errdb.go
+++ b/client/state/errdb.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"

--- a/client/testing.go
+++ b/client/testing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	consulApi "github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/fingerprint"
+	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/plugins/shared/catalog"
@@ -21,6 +22,13 @@ import (
 // and removed in the returned cleanup function. If they are overridden in the
 // callback then the caller still must run the returned cleanup func.
 func TestClient(t testing.T, cb func(c *config.Config)) (*Client, func() error) {
+	return TestClientWithCustomStateDB(t, cb, nil)
+}
+
+// TestClientWithCustomStateDB creates an in-memory client for testing purposes
+// where the state DB factory can be overridden. It is used in tests that
+// simulate state restore failures
+func TestClientWithCustomStateDB(t testing.T, cb func(c *config.Config), stateDBFunc state.NewStateDBFunc) (*Client, func() error) {
 	conf, cleanup := config.TestClientConfig(t)
 
 	// Tighten the fingerprinter timeouts (must be done in client package
@@ -46,7 +54,10 @@ func TestClient(t testing.T, cb func(c *config.Config)) (*Client, func() error) 
 	}
 	catalog := consul.NewMockCatalog(logger)
 	mockService := consulApi.NewMockConsulServiceClient(t, logger)
-	client, err := NewClient(conf, catalog, mockService)
+	if stateDBFunc == nil {
+		stateDBFunc = state.GetStateDBFactory(conf.DevMode)
+	}
+	client, err := NewClient(conf, catalog, mockService, stateDBFunc)
 	if err != nil {
 		cleanup()
 		t.Fatalf("err: %v", err)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -731,8 +731,11 @@ func (a *Agent) setupClient() error {
 			return err
 		}
 	}
-	statedbFactory := state.GetStateDBFactory(conf.DevMode)
-	client, err := client.NewClient(conf, a.consulCatalog, a.consulService, statedbFactory)
+	if conf.StateDBFactory == nil {
+		conf.StateDBFactory = state.GetStateDBFactory(conf.DevMode)
+	}
+
+	client, err := client.NewClient(conf, a.consulCatalog, a.consulService)
 	if err != nil {
 		return fmt.Errorf("client setup failed: %v", err)
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -21,6 +21,7 @@ import (
 	uuidparse "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/nomad/client"
 	clientconfig "github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad"
@@ -730,8 +731,8 @@ func (a *Agent) setupClient() error {
 			return err
 		}
 	}
-
-	client, err := client.NewClient(conf, a.consulCatalog, a.consulService)
+	statedbFactory := state.GetStateDBFactory(conf.DevMode)
+	client, err := client.NewClient(conf, a.consulCatalog, a.consulService, statedbFactory)
 	if err != nil {
 		return fmt.Errorf("client setup failed: %v", err)
 	}


### PR DESCRIPTION
Handle errors when restore fails or adding allocs fail (due to taskrunner/allocrunner initialization errors) by marking alloc as failed so it can be rescheduled. 

Includes a unit test for restore failure handling. 