### PR TITLE
tests: run docker tests in macOS out of box

### DIFF
--- a/drivers/docker/driver_darwin_test.go
+++ b/drivers/docker/driver_darwin_test.go
@@ -1,0 +1,26 @@
+package docker
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestMain is a hacky test entrypoint to set temp directory to a path that can
+// be mounted into Docker containers on macOS without needing dev performing
+// special setup.
+//
+// macOS sets tempdir as `/var`, which Docker does not whitelist as a path that
+// can be bind-mounted.
+func TestMain(m *testing.M) {
+	tmpdir := fmt.Sprintf("/tmp/nomad-docker-tests-%d", time.Now().Unix())
+
+	defer os.Setenv("TMPDIR", os.Getenv("TMPDIR"))
+	os.Setenv("TMPDIR", tmpdir)
+
+	os.MkdirAll(tmpdir, 0700)
+	defer os.RemoveAll(tmpdir)
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Use `/tmp` as temporary directory for docker driver tests, so tests can
run out of the box without any intervention.

macOS sets tempdir as `/var`, which Docker does not whitelist as a path
that can be bind-mounted.