### PR TITLE
Improve Kill handling on task runner

### DIFF
--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -78,7 +78,9 @@ func (tr *TaskRunner) Kill(ctx context.Context, event *structs.TaskEvent) error 
 	tr.EmitEvent(event)
 
 	// Check if the Run method has started yet. If it hasn't we return early,
-	// since the task hasn't even started so there is nothing to wait for
+	// since the task hasn't even started so there is nothing to wait for. This
+	// is still correct since the Run method no-op since the kill context has
+	// already been cancelled.
 	if !tr.hasRunLaunched() {
 		return nil
 	}

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
 // Restart a task. Returns immediately if no task is running. Blocks until
 // existing task exits or passed-in context is canceled.
 func (tr *TaskRunner) Restart(ctx context.Context, event *structs.TaskEvent, failure bool) error {
+	tr.logger.Trace("Restart requested", "failure", failure)
+
 	// Grab the handle
 	handle := tr.getDriverHandle()
 
@@ -47,6 +48,8 @@ func (tr *TaskRunner) Restart(ctx context.Context, event *structs.TaskEvent, fai
 }
 
 func (tr *TaskRunner) Signal(event *structs.TaskEvent, s string) error {
+	tr.logger.Trace("Signal requested", "signal", s)
+
 	// Grab the handle
 	handle := tr.getDriverHandle()
 
@@ -65,58 +68,26 @@ func (tr *TaskRunner) Signal(event *structs.TaskEvent, s string) error {
 // Kill a task. Blocks until task exits or context is canceled. State is set to
 // dead.
 func (tr *TaskRunner) Kill(ctx context.Context, event *structs.TaskEvent) error {
+	tr.logger.Trace("Kill requested", "event_type", event.Type, "event_reason", event.KillReason)
+
 	// Cancel the task runner to break out of restart delay or the main run
 	// loop.
 	tr.killCtxCancel()
 
-	// Grab the handle
-	handle := tr.getDriverHandle()
-
-	// Check it is running
-	if handle == nil {
-		return ErrTaskNotRunning
-	}
-
-	// Emit the event since it may take a long time to kill
+	// Emit kill event
 	tr.EmitEvent(event)
 
-	// Run the hooks prior to killing the task
-	tr.killing()
-
-	// Tell the restart tracker that the task has been killed so it doesn't
-	// attempt to restart it.
-	tr.restartTracker.SetKilled()
-
-	// Kill the task using an exponential backoff in-case of failures.
-	killErr := tr.killTask(handle)
-	if killErr != nil {
-		// We couldn't successfully destroy the resource created.
-		tr.logger.Error("failed to kill task. Resources may have been leaked", "error", killErr)
-	}
-
-	// Block until task has exited.
-	waitCh, err := handle.WaitCh(ctx)
-
-	// The error should be nil or TaskNotFound, if it's something else then a
-	// failure in the driver or transport layer occurred
-	if err != nil {
-		if err == drivers.ErrTaskNotFound {
-			return nil
-		}
-		tr.logger.Error("failed to wait on task. Resources may have been leaked", "error", err)
-		return err
+	// Check if the Run method has started yet. If it hasn't we return early,
+	// since the task hasn't even started so there is nothing to wait for
+	if !tr.hasRunLaunched() {
+		return nil
 	}
 
 	select {
-	case <-waitCh:
+	case <-tr.WaitCh():
 	case <-ctx.Done():
+		return ctx.Err()
 	}
 
-	if killErr != nil {
-		return killErr
-	} else if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	return nil
+	return tr.getKillErr()
 }

--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -199,6 +199,8 @@ func (h *serviceHook) getTaskServices() *agentconsul.TaskServices {
 // interpolateServices returns an interpolated copy of services and checks with
 // values from the task's environment.
 func interpolateServices(taskEnv *taskenv.TaskEnv, services []*structs.Service) []*structs.Service {
+	// Guard against not having a valid taskEnv. This can be the case if the
+	// Killing or Exited hook is run before post-run.
 	if taskEnv == nil || len(services) == 0 {
 		return nil
 	}

--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -199,6 +199,10 @@ func (h *serviceHook) getTaskServices() *agentconsul.TaskServices {
 // interpolateServices returns an interpolated copy of services and checks with
 // values from the task's environment.
 func interpolateServices(taskEnv *taskenv.TaskEnv, services []*structs.Service) []*structs.Service {
+	if taskEnv == nil || len(services) == 0 {
+		return nil
+	}
+
 	interpolated := make([]*structs.Service, len(services))
 
 	for i, origService := range services {

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -99,7 +99,7 @@ type TaskRunner struct {
 	// killCtxCancel is called when killing a task.
 	killCtxCancel context.CancelFunc
 
-	// killErr is populatd when killing a task. Access should be done use the
+	// killErr is populated when killing a task. Access should be done use the
 	// getter/setter
 	killErr     error
 	killErrLock sync.Mutex

--- a/client/allocrunner/taskrunner/task_runner_getters.go
+++ b/client/allocrunner/taskrunner/task_runner_getters.go
@@ -85,3 +85,31 @@ func (tr *TaskRunner) clearDriverHandle() {
 	}
 	tr.handle = nil
 }
+
+// setKillErr stores any error that arouse while killing the task
+func (tr *TaskRunner) setKillErr(err error) {
+	tr.killErrLock.Lock()
+	defer tr.killErrLock.Unlock()
+	tr.killErr = err
+}
+
+// getKillErr returns any error that arouse while killing the task
+func (tr *TaskRunner) getKillErr() error {
+	tr.killErrLock.Lock()
+	defer tr.killErrLock.Unlock()
+	return tr.killErr
+}
+
+// setRunLaunched marks the fact that the Run loop has been started
+func (tr *TaskRunner) setRunLaunched() {
+	tr.runLaunchedLock.Lock()
+	defer tr.runLaunchedLock.Unlock()
+	tr.runLaunched = true
+}
+
+// hasRunLaunched returns whether the Run loop has been started
+func (tr *TaskRunner) hasRunLaunched() bool {
+	tr.runLaunchedLock.Lock()
+	defer tr.runLaunchedLock.Unlock()
+	return tr.runLaunched
+}

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -256,7 +256,7 @@ func (tr *TaskRunner) poststart() error {
 
 	// Pass the lazy handle to the hooks so even if the driver exits and we
 	// launch a new one (external plugin), the handle will refresh.
-	lazyHandle := NewLazyHandle(tr.ctx, tr.getDriverHandle, tr.logger)
+	lazyHandle := NewLazyHandle(tr.shutdownCtx, tr.getDriverHandle, tr.logger)
 
 	var merr multierror.Error
 	for _, hook := range tr.runnerHooks {


### PR DESCRIPTION
This PR improves how killing a task is handled. Before the kill function
directly orchestrated the killing and was only valid while the task was
running. The new behavior is to mark the desired state and wait for the
task runner to converge to that state.