### PR TITLE
Issue #4297: Optional Consul service tags for nomad server and agent services

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -580,7 +580,7 @@ func (a *Agent) setupServer() error {
 		httpServ := &structs.Service{
 			Name:      a.config.Consul.ServerServiceName,
 			PortLabel: a.config.AdvertiseAddrs.HTTP,
-			Tags:      []string{consul.ServiceTagHTTP},
+			Tags:      append(a.config.Consul.Tags, consul.ServiceTagHTTP),
 		}
 		const isServer = true
 		if check := a.agentHTTPCheck(isServer); check != nil {
@@ -589,7 +589,7 @@ func (a *Agent) setupServer() error {
 		rpcServ := &structs.Service{
 			Name:      a.config.Consul.ServerServiceName,
 			PortLabel: a.config.AdvertiseAddrs.RPC,
-			Tags:      []string{consul.ServiceTagRPC},
+			Tags:      append(a.config.Consul.Tags, consul.ServiceTagRPC),
 			Checks: []*structs.ServiceCheck{
 				{
 					Name:      a.config.Consul.ServerRPCCheckName,
@@ -603,7 +603,7 @@ func (a *Agent) setupServer() error {
 		serfServ := &structs.Service{
 			Name:      a.config.Consul.ServerServiceName,
 			PortLabel: a.config.AdvertiseAddrs.Serf,
-			Tags:      []string{consul.ServiceTagSerf},
+			Tags:      append(a.config.Consul.Tags, consul.ServiceTagSerf),
 			Checks: []*structs.ServiceCheck{
 				{
 					Name:      a.config.Consul.ServerSerfCheckName,
@@ -742,7 +742,7 @@ func (a *Agent) setupClient() error {
 		httpServ := &structs.Service{
 			Name:      a.config.Consul.ClientServiceName,
 			PortLabel: a.config.AdvertiseAddrs.HTTP,
-			Tags:      []string{consul.ServiceTagHTTP},
+			Tags:      append(a.config.Consul.Tags, consul.ServiceTagHTTP),
 		}
 		const isServer = false
 		if check := a.agentHTTPCheck(isServer); check != nil {

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -788,6 +788,7 @@ func parseConsulConfig(result **config.ConsulConfig, list *ast.ObjectList) error
 		"server_serf_check_name",
 		"server_rpc_check_name",
 		"ssl",
+                "tags",
 		"timeout",
 		"token",
 		"verify_ssl",

--- a/nomad/structs/config/consul.go
+++ b/nomad/structs/config/consul.go
@@ -43,6 +43,10 @@ type ConsulConfig struct {
 	// to register the client HTTP health check with Consul
 	ClientHTTPCheckName string `mapstructure:"client_http_check_name"`
 
+	// Tags are optional service tags that get registered with the service
+        // in Consul
+	Tags []string `mapstructure:"tags"`
+
 	// AutoAdvertise determines if this Nomad Agent will advertise its
 	// services via Consul.  When true, Nomad Agent will register
 	// services with Consul.
@@ -132,6 +136,7 @@ func (a *ConsulConfig) Merge(b *ConsulConfig) *ConsulConfig {
 	if b.ClientHTTPCheckName != "" {
 		result.ClientHTTPCheckName = b.ClientHTTPCheckName
 	}
+	result.Tags = append(result.Tags, b.Tags...)
 	if b.AutoAdvertise != nil {
 		result.AutoAdvertise = helper.BoolToPtr(*b.AutoAdvertise)
 	}
@@ -226,7 +231,6 @@ func (c *ConsulConfig) ApiConfig() (*consul.Config, error) {
 		}
 		config.Transport.TLSClientConfig = tlsConfig
 	}
-
 	return config, nil
 }
 

--- a/website/source/docs/configuration/consul.html.md
+++ b/website/source/docs/configuration/consul.html.md
@@ -108,6 +108,9 @@ configuring Nomad to talk to Consul via DNS such as consul.service.consul
 - `ssl` `(bool: false)` - Specifies if the transport scheme should use HTTPS to
   communicate with the Consul agent.
 
+- `tags` `(Array["string"]: ""])` - Specifies optional Consul tags to be
+  registered with the Nomad server and agent services.
+
 - `token` `(string: "")` - Specifies the token used to provide a per-request ACL
   token. This option overrides the Consul Agent's default token. If the token is 
   not set here or on the Consul agent, it will default to Consul's anonymous policy, 


### PR DESCRIPTION
Allows specifying optional consul tags in the configuration file e.g. 

```
consul {
  address = "127.0.0.1:8500"
  tags = ["tag-one", "tag-two", "tag-three"]
}
```

This is in addition to the default http, serf and rpc tags.