### PR TITLE
Re-enable client and java skipped tests

### DIFF
--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -77,7 +77,6 @@ func TestAllocations_GarbageCollectAll_ACL(t *testing.T) {
 }
 
 func TestAllocations_GarbageCollect(t *testing.T) {
-	t.Skip("missing mock driver plugin implementation")
 	t.Parallel()
 	require := require.New(t)
 	client, cleanup := TestClient(t, func(c *config.Config) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -655,7 +655,6 @@ func TestClient_Init(t *testing.T) {
 }
 
 func TestClient_BlockedAllocations(t *testing.T) {
-	t.Skip("missing mock driver plugin implementation")
 	t.Parallel()
 	s1, _ := testServer(t, nil)
 	defer s1.Shutdown()
@@ -691,7 +690,6 @@ func TestClient_BlockedAllocations(t *testing.T) {
 		"run_for":     "100s",
 		"exit_code":   0,
 		"exit_signal": 0,
-		"exit_err":    "",
 	}
 
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -318,8 +318,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 
 	pluginLogFile := filepath.Join(cfg.TaskDir().Dir, "executor.out")
 	executorConfig := &executor.ExecutorConfig{
-		LogFile:  pluginLogFile,
-		LogLevel: "debug",
+		LogFile:     pluginLogFile,
+		LogLevel:    "debug",
+		FSIsolation: capabilities.FSIsolation == drivers.FSIsolationChroot,
 	}
 
 	exec, pluginClient, err := executor.CreateExecutor(os.Stderr, hclog.Debug, d.nomadConfig, executorConfig)

--- a/drivers/java/utils.go
+++ b/drivers/java/utils.go
@@ -29,6 +29,10 @@ func parseJavaVersionOutput(infoString string) (version, runtime, vm string, err
 	infoString = strings.TrimSpace(infoString)
 
 	lines := strings.Split(infoString, "\n")
+	if strings.Contains(lines[0], "Picked up _JAVA_OPTIONS") {
+		lines = lines[1:]
+	}
+
 	if len(lines) != 3 {
 		return "", "", "", fmt.Errorf("unexpected java version info output, expected 3 lines but got: %v", infoString)
 	}

--- a/drivers/java/utils_test.go
+++ b/drivers/java/utils_test.go
@@ -38,6 +38,16 @@ func TestDriver_parseJavaVersionOutput(t *testing.T) {
 			"OpenJDK 64-Bit Server VM 18.9 (build 11.0.1+13, mixed mode)",
 		},
 		{
+			"OpenJDK",
+			`Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m
+			openjdk version "11.0.1" 2018-10-16
+			OpenJDK Runtime Environment 18.9 (build 11.0.1+13)
+			OpenJDK 64-Bit Server VM 18.9 (build 11.0.1+13, mixed mode)`,
+			"11.0.1",
+			"OpenJDK Runtime Environment 18.9 (build 11.0.1+13)",
+			"OpenJDK 64-Bit Server VM 18.9 (build 11.0.1+13, mixed mode)",
+		},
+		{
 			"IcedTea",
 			`java version "1.6.0_36"
 			 OpenJDK Runtime Environment (IcedTea6 1.13.8) (6b36-1.13.8-0ubuntu1~12.04)

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -123,7 +123,7 @@ func WaitForRunning(t testing.T, rpc rpcFn, job *structs.Job) []*structs.AllocLi
 		}
 
 		for _, alloc := range resp.Allocations {
-			if alloc.ClientStatus != structs.AllocClientStatusRunning {
+			if alloc.ClientStatus == structs.AllocClientStatusPending {
 				return false, fmt.Errorf("alloc not running: id=%v tg=%v status=%v",
 					alloc.ID, alloc.TaskGroup, alloc.ClientStatus)
 			}

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -87,8 +88,7 @@ func WaitForLeader(t testing.T, rpc rpcFn) {
 	})
 }
 
-// WaitForRunning runs a job and blocks until all allocs are out of pending.
-func WaitForRunning(t testing.T, rpc rpcFn, job *structs.Job) []*structs.AllocListStub {
+func RegisterJob(t testing.T, rpc rpcFn, job *structs.Job) {
 	WaitForResult(func() (bool, error) {
 		args := &structs.JobRegisterRequest{}
 		args.Job = job
@@ -101,6 +101,11 @@ func WaitForRunning(t testing.T, rpc rpcFn, job *structs.Job) []*structs.AllocLi
 	})
 
 	t.Logf("Job %q registered", job.ID)
+}
+
+// WaitForRunning runs a job and blocks until all allocs are out of pending.
+func WaitForRunning(t testing.T, rpc rpcFn, job *structs.Job) []*structs.AllocListStub {
+	RegisterJob(t, rpc, job)
 
 	var resp structs.JobAllocationsResponse
 
@@ -126,7 +131,7 @@ func WaitForRunning(t testing.T, rpc rpcFn, job *structs.Job) []*structs.AllocLi
 
 		return true, nil
 	}, func(err error) {
-		t.Fatalf("job not running: %v", err)
+		require.NoError(t, err)
 	})
 
 	return resp.Allocations


### PR DESCRIPTION
Re-enabled client that were skipped during the big refactor, and java tests that were accidentally skipped.

This fixes two java driver issues:
* Handles case where `_JAVA_OPTIONS` is set - previously setting this env-var causes an additional unexpected line in `java -version`, causing client to treat java as missing.
* Handles execution isolation properly - on linux, it should run with libcontainer.