### PR TITLE
Make driver logging less redundant

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -89,9 +89,10 @@ type Driver struct {
 	// gpuRuntime indicates nvidia-docker runtime availability
 	gpuRuntime bool
 
-	// hasFingerprinted is used to store whether we have fingerprinted before
-	hasFingerprinted bool
-	fingerprintLock  sync.Mutex
+	// A tri-state boolean to know if the fingerprinting has happened and
+	// whether it has been successful
+	fingerprintSuccess *bool
+	fingerprintLock    sync.Mutex
 }
 
 // NewDockerDriver returns a docker implementation of a driver plugin

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -88,6 +88,10 @@ type Driver struct {
 
 	// gpuRuntime indicates nvidia-docker runtime availability
 	gpuRuntime bool
+
+	// hasFingerprinted is used to store whether we have fingerprinted before
+	hasFingerprinted bool
+	fingerprintLock  sync.Mutex
 }
 
 // NewDockerDriver returns a docker implementation of a driver plugin

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -92,7 +92,7 @@ type Driver struct {
 	// A tri-state boolean to know if the fingerprinting has happened and
 	// whether it has been successful
 	fingerprintSuccess *bool
-	fingerprintLock    sync.Mutex
+	fingerprintLock    sync.RWMutex
 }
 
 // NewDockerDriver returns a docker implementation of a driver plugin

--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -147,6 +147,14 @@ func (d *Driver) setFingerprintFailure() {
 	d.fingerprintLock.Unlock()
 }
 
+// fingerprintSuccessful returns true if the driver has
+// never fingerprinted or has successfully fingerprinted
+func (d *Driver) fingerprintSuccessful() bool {
+	d.fingerprintLock.Lock()
+	defer d.fingerprintLock.Unlock()
+	return d.fingerprintSuccess == nil || *d.fingerprintSuccess
+}
+
 func (d *Driver) PluginInfo() (*base.PluginInfoResponse, error) {
 	return pluginInfo, nil
 }
@@ -222,7 +230,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	if err != nil {
 		fp.Health = drivers.HealthStateUnhealthy
 		fp.HealthDescription = drivers.NoCgroupMountMessage
-		if d.fingerprintSuccess == nil || *d.fingerprintSuccess {
+		if d.fingerprintSuccessful() {
 			d.logger.Warn(fp.HealthDescription, "error", err)
 		}
 		d.setFingerprintFailure()


### PR DESCRIPTION
Adds a boolean guard so that we don't log the same warning over and over after the initial fingerprint