### PR TITLE
docker: Terminate dockerlogger

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1019,15 +1019,8 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 		return fmt.Errorf("must call StopTask for the given task before Destroy or set force to true")
 	}
 
-	defer h.dloggerPluginClient.Kill()
-
 	if err := h.client.StopContainer(h.containerID, 0); err != nil {
 		h.logger.Warn("failed to stop container during destroy", "error", err)
-	}
-
-	if err := h.dlogger.Stop(); err != nil {
-		h.logger.Error("failed to stop docker logger process during destroy",
-			"error", err, "logger_pid", h.dloggerPluginClient.ReattachConfig().Pid)
 	}
 
 	if err := d.cleanupImage(h); err != nil {

--- a/drivers/docker/handle.go
+++ b/drivers/docker/handle.go
@@ -156,7 +156,17 @@ func (h *taskHandle) Kill(killTimeout time.Duration, signal os.Signal) error {
 	return nil
 }
 
+func (h *taskHandle) shutdownLogger() {
+	if err := h.dlogger.Stop(); err != nil {
+		h.logger.Error("failed to stop docker logger process during StopTask",
+			"error", err, "logger_pid", h.dloggerPluginClient.ReattachConfig().Pid)
+	}
+	h.dloggerPluginClient.Kill()
+}
+
 func (h *taskHandle) run() {
+	defer h.shutdownLogger()
+
 	exitCode, werr := h.waitClient.WaitContainer(h.containerID)
 	if werr != nil {
 		h.logger.Error("failed to wait for container; already terminated")


### PR DESCRIPTION
Previously, we did not attempt to stop Docker Logger processes until
DestroyTask, which means that under many circumstances, we will never
successfully close the plugin client.

This commit terminates the plugin process when `run` terminates, or when
`DestroyTask` is called.

Steps to repro:

```
$ nomad agent -dev
$ nomad init
$ nomad run example.nomad
$ nomad stop example
$ ps aux | grep nomad # See docker_logger process running
$ signal the dev agent
$ ps aux | grep nomad # See docker_logger process running
```