### PR TITLE
Reconcile child summaries correctly

### DIFF
--- a/dev/cluster/client1.hcl
+++ b/dev/cluster/client1.hcl
@@ -10,9 +10,6 @@ name = "client1"
 # Enable the client
 client {
   enabled = true
-  options = {
-   "driver.raw_exec.enable" = "1"
-  }
   server_join {
     retry_join = ["127.0.0.1:4647", "127.0.0.1:5647", "127.0.0.1:6647"]
   }

--- a/dev/cluster/client1.hcl
+++ b/dev/cluster/client1.hcl
@@ -10,7 +10,9 @@ name = "client1"
 # Enable the client
 client {
   enabled = true
-
+  options = {
+   "driver.raw_exec.enable" = "1"
+  }
   server_join {
     retry_join = ["127.0.0.1:4647", "127.0.0.1:5647", "127.0.0.1:6647"]
   }

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1403,7 +1403,7 @@ func (n *nomadFSM) reconcileQueuedAllocations(index uint64) error {
 		job := rawJob.(*structs.Job)
 
 		// Nothing to do for queued allocations if the job is a parent periodic/parameterized job
-		if job.ParentID == "" && (job.Periodic != nil || job.ParameterizedJob != nil) {
+		if job.IsParameterized() || job.IsPeriodic() {
 			continue
 		}
 		planner := &scheduler.Harness{

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1401,6 +1401,11 @@ func (n *nomadFSM) reconcileQueuedAllocations(index uint64) error {
 			break
 		}
 		job := rawJob.(*structs.Job)
+
+		// Nothing to do for queued allocations if the job is a parent periodic/parameterized job
+		if job.ParentID == "" && (job.Periodic != nil || job.ParameterizedJob != nil) {
+			continue
+		}
 		planner := &scheduler.Harness{
 			State: &snap.StateStore,
 		}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -6,12 +6,13 @@ import (
 	"sort"
 	"time"
 
+	"reflect"
+
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"reflect"
 )
 
 // Txn is a transaction against a state store.

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3057,8 +3057,7 @@ func (s *StateStore) ReconcileJobSummaries(index uint64) error {
 		}
 		job := rawJob.(*structs.Job)
 
-		if (job.ParameterizedJob != nil || job.Periodic != nil) && job.ParentID == "" {
-
+		if job.IsParameterized() || job.IsPeriodic() {
 			// COMPAT: Remove after 0.11
 
 			// The following block of code fixes incorrect child summaries due to a bug


### PR DESCRIPTION
This PR fixes a long standing bug that affects parameterized/periodic jobs when reconciling job summaries. 

The `Children` field was being overridden to empty, and the `Summary` field values were incorrect, prior to this fix. After this fix, a leader election or using the reconcile summaries endpoint should fix the summaries to be accurate. 

Fixes #3886 