### PR TITLE
Rename TaskKillHook to TaskPreKillHook to more closely match usage

### DIFF
--- a/client/allocrunner/interfaces/task_lifecycle.go
+++ b/client/allocrunner/interfaces/task_lifecycle.go
@@ -117,11 +117,11 @@ type TaskPoststartHook interface {
 type TaskKillRequest struct{}
 type TaskKillResponse struct{}
 
-type TaskKillHook interface {
+type TaskPreKillHook interface {
 	TaskHook
 
-	// Killing is called when a task is going to be Killed or Restarted.
-	Killing(context.Context, *TaskKillRequest, *TaskKillResponse) error
+	// PreKilling is called right before a task is going to be killed or restarted.
+	PreKilling(context.Context, *TaskKillRequest, *TaskKillResponse) error
 }
 
 type TaskExitedRequest struct{}

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -22,8 +22,8 @@ func (tr *TaskRunner) Restart(ctx context.Context, event *structs.TaskEvent, fai
 	// Emit the event since it may take a long time to kill
 	tr.EmitEvent(event)
 
-	// Run the hooks prior to restarting the task
-	tr.killing()
+	// Run the pre-kill hooks prior to restarting the task
+	tr.preKill()
 
 	// Tell the restart tracker that a restart triggered the exit
 	tr.restartTracker.SetRestartTriggered(failure)

--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -200,7 +200,7 @@ func (h *serviceHook) getTaskServices() *agentconsul.TaskServices {
 // values from the task's environment.
 func interpolateServices(taskEnv *taskenv.TaskEnv, services []*structs.Service) []*structs.Service {
 	// Guard against not having a valid taskEnv. This can be the case if the
-	// Killing or Exited hook is run before post-run.
+	// PreKilling or Exited hook is run before post-run.
 	if taskEnv == nil || len(services) == 0 {
 		return nil
 	}

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -706,8 +706,8 @@ func (tr *TaskRunner) initDriver() error {
 // handleKill is used to handle the a request to kill a task. It will store any
 // error in the task runner killErr value.
 func (tr *TaskRunner) handleKill() {
-	// Run the hooks prior to killing the task
-	tr.killing()
+	// Run the pre killing hooks
+	tr.preKill()
 
 	// Tell the restart tracker that the task has been killed so it doesn't
 	// attempt to restart it.

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -437,8 +437,10 @@ func (tr *TaskRunner) updateHooks() {
 	}
 }
 
-// killing is used to run the runners kill hooks.
-func (tr *TaskRunner) killing() {
+// preKill is used to run the runners preKill hooks
+// preKill hooks contain logic that must be executed before
+// a task is killed or restarted
+func (tr *TaskRunner) preKill() {
 	if tr.logger.IsTrace() {
 		start := time.Now()
 		tr.logger.Trace("running kill hooks", "start", start)
@@ -449,24 +451,24 @@ func (tr *TaskRunner) killing() {
 	}
 
 	for _, hook := range tr.runnerHooks {
-		killHook, ok := hook.(interfaces.TaskKillHook)
+		killHook, ok := hook.(interfaces.TaskPreKillHook)
 		if !ok {
 			continue
 		}
 
 		name := killHook.Name()
 
-		// Time the update hook
+		// Time the pre kill hook
 		var start time.Time
 		if tr.logger.IsTrace() {
 			start = time.Now()
 			tr.logger.Trace("running kill hook", "name", name, "start", start)
 		}
 
-		// Run the kill hook
+		// Run the pre kill hook
 		req := interfaces.TaskKillRequest{}
 		var resp interfaces.TaskKillResponse
-		if err := killHook.Killing(context.Background(), &req, &resp); err != nil {
+		if err := killHook.PreKilling(context.Background(), &req, &resp); err != nil {
 			tr.emitHookError(err, name)
 			tr.logger.Error("kill hook failed", "name", name, "error", err)
 		}


### PR DESCRIPTION
Also added and fixed some comments because this is a subtle distinction 