### PR TITLE
task_runner does not set TaskGroupName in TaskConfig

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -797,9 +797,10 @@ func (tr *TaskRunner) buildTaskConfig() *drivers.TaskConfig {
 	env := tr.envBuilder.Build()
 
 	return &drivers.TaskConfig{
-		ID:      fmt.Sprintf("%s/%s/%s", alloc.ID, task.Name, invocationid),
-		Name:    task.Name,
-		JobName: alloc.Job.Name,
+		ID:            fmt.Sprintf("%s/%s/%s", alloc.ID, task.Name, invocationid),
+		Name:          task.Name,
+		JobName:       alloc.Job.Name,
+		TaskGroupName: alloc.TaskGroup,
 		Resources: &drivers.Resources{
 			NomadResources: taskResources,
 			LinuxResources: &drivers.LinuxResources{

--- a/plugins/shared/loader/loader_test.go
+++ b/plugins/shared/loader/loader_test.go
@@ -371,7 +371,7 @@ func TestPluginLoader_External_Config_Bad(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	// Create two plugins
+	// Create a plugin
 	plugins := []string{"mock-device"}
 	pluginVersions := []string{"v0.0.1"}
 	h := newHarness(t, plugins)


### PR DESCRIPTION
Noticed this while working on a driver plugin, will push commit with (one-line) fix after the documenting test fails