### PR TITLE
Log de-noising

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -172,8 +172,9 @@ func NewAllocRunner(config *Config) (*allocRunner, error) {
 		driverManager:            config.DriverManager,
 	}
 
-	// Create the logger based on the allocation ID
-	ar.logger = config.Logger.Named("alloc_runner").With("alloc_id", alloc.ID)
+	// Create the logger based on the allocation ID. Give it a generic name
+	// to differentiate from client-global log lines at a glance.
+	ar.logger = config.Logger.Named("runner").With("alloc_id", alloc.ID)
 
 	// Create alloc broadcaster
 	ar.allocBroadcaster = cstructs.NewAllocBroadcaster(ar.logger)

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -77,7 +77,9 @@ func (a *allocHealthSetter) SetHealth(healthy, isDeploy bool, trackerTaskEvents 
 
 // initRunnerHooks intializes the runners hooks.
 func (ar *allocRunner) initRunnerHooks() {
-	hookLogger := ar.logger.Named("runner_hook")
+	// Don't add a sublogger as the names get long and have little meaning
+	// to end users. Each hook adds its own name.
+	hookLogger := ar.logger
 
 	// create health setting shim
 	hs := &allocHealthSetter{ar}

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -269,8 +269,8 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		driverManager:       config.DriverManager,
 	}
 
-	// Create the logger based on the allocation ID
-	tr.logger = config.Logger.Named("task_runner").With("task", config.Task.Name)
+	// Add the task name to the logger
+	tr.logger = config.Logger.With("task", config.Task.Name)
 
 	// Pull out the task's resources
 	ares := tr.alloc.AllocatedResources

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -46,7 +46,9 @@ func (h *hookResources) getMounts() []*drivers.MountConfig {
 
 // initHooks intializes the tasks hooks.
 func (tr *TaskRunner) initHooks() {
-	hookLogger := tr.logger.Named("task_hook")
+	// Don't add a sublogger as the names get long and have little meaning
+	// to end users. Each hook adds its own name.
+	hookLogger := tr.logger
 	task := tr.Task()
 
 	tr.logmonHookConfig = newLogMonHookConfig(task.Name, tr.taskDir.LogDir)

--- a/client/pluginmanager/group.go
+++ b/client/pluginmanager/group.go
@@ -91,9 +91,9 @@ func (m *PluginGroup) Shutdown() {
 	m.mLock.Lock()
 	defer m.mLock.Unlock()
 	for i := len(m.managers) - 1; i >= 0; i-- {
-		m.logger.Info("shutting down plugin manager", "plugin-type", m.managers[i].PluginType())
+		m.logger.Debug("shutting down plugin manager", "plugin-type", m.managers[i].PluginType())
 		m.managers[i].Shutdown()
-		m.logger.Info("plugin manager finished", "plugin-type", m.managers[i].PluginType())
+		m.logger.Debug("plugin manager finished", "plugin-type", m.managers[i].PluginType())
 	}
 	m.shutdown = true
 }

--- a/drivers/docker/stats.go
+++ b/drivers/docker/stats.go
@@ -69,6 +69,11 @@ func (h *taskHandle) collectStats(ctx context.Context, ch chan *cstructs.TaskRes
 
 		// Stats blocks until an error has occurred, or doneCh has been closed
 		if err := h.client.Stats(statsOpts); err != nil && err != io.ErrClosedPipe {
+			if ctx.Err() != nil {
+				// Context canceled, exit.
+				return
+			}
+
 			// An error occurred during stats collection, retry with backoff
 			h.logger.Debug("error collecting stats from container", "error", err)
 


### PR DESCRIPTION
Made a quick pass to try to remove some noise from our logs.

* daf4f9a  - squelches logging on context cancellations
* 7be0c03 - moves plugin mgr shutdown messages from INFO to DEBUG as they're not generally useful unless you're debugging plugins or the manager itself
* de7ca5d - is a little more contentious as it removes a bunch of intermediary loggers from the client:

Example old(-) / new(+) log line:
```diff
-2019-01-18T14:28:20.750-0800 [TRACE] client.alloc_runner.task_runner: running poststart hooks: alloc_id=...
+2019-01-18T14:23:54.381-0800 [TRACE] client.runner: running poststart hooks: alloc_id=...
```

TaskRunner log lines can be differentiated from AllocRunner log lines by
the presence of a `task=...` field.