### PR TITLE
test: fix flaky garbage collect test

### DIFF
--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
 
@@ -196,7 +197,19 @@ func TestClientAllocations_GarbageCollectAll_Remote(t *testing.T) {
 
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s2.connectedNodes()
-		return len(nodes) == 1, nil
+		if len(nodes) != 1 {
+			return false, fmt.Errorf("should have 1 client. found %d", len(nodes))
+		}
+		req := &structs.NodeSpecificRequest{
+			NodeID:       c.NodeID(),
+			QueryOptions: structs.QueryOptions{Region: "global"},
+		}
+		resp := structs.SingleNodeResponse{}
+		if err := msgpackrpc.CallWithCodec(codec, "Node.GetNode", req, &resp); err != nil {
+			return false, err
+		}
+		return resp.Node != nil && resp.Node.Status == structs.NodeStatusReady, fmt.Errorf(
+			"expected ready but found %s", pretty.Sprint(resp.Node))
 	}, func(err error) {
 		t.Fatalf("should have a clients")
 	})


### PR DESCRIPTION
This seems to fix TestClientAllocations_GarbageCollectAll_Remote being
flaky.

This test confuses me. It joins 2 servers, but then goes out of its way
to make sure the test client only interacts with one. There are not
enough comments for me to figure out the precise assertions this test is
trying to make.

A good old fashioned wait-for-the-client-to-register seems to fix the
flakiness though. The error was that the node could not be found, so
this makes some sense. However, lots of other tests seem to use the same
"wait for node" logic and don't appear to be flaky, so who knows why
waiting fixes this one.

Passes with -race.