### PR TITLE
Don't emit task events after alloc is in a terminal DesiredState 

### DIFF
--- a/client/allochealth/tracker.go
+++ b/client/allochealth/tracker.go
@@ -146,7 +146,7 @@ func (t *Tracker) TaskEvents() map[string]*structs.TaskEvent {
 	defer t.l.Unlock()
 
 	// Nothing to do since the failure wasn't task related
-	if t.allocFailed {
+	if t.allocFailed || t.alloc.TerminalStatus() {
 		return nil
 	}
 

--- a/client/allochealth/tracker.go
+++ b/client/allochealth/tracker.go
@@ -146,7 +146,7 @@ func (t *Tracker) TaskEvents() map[string]*structs.TaskEvent {
 	defer t.l.Unlock()
 
 	// Nothing to do since the failure wasn't task related
-	if t.allocFailed || t.alloc.TerminalStatus() {
+	if t.allocFailed {
 		return nil
 	}
 

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -46,10 +46,11 @@ func (a *allocHealthSetter) SetHealth(healthy, isDeploy bool, trackerTaskEvents 
 	a.ar.stateLock.Lock()
 	a.ar.state.SetDeploymentStatus(time.Now(), healthy)
 	a.ar.persistDeploymentStatus(a.ar.state.DeploymentStatus)
+	isTerminal := a.ar.alloc.TerminalStatus()
 	a.ar.stateLock.Unlock()
 
 	// If deployment is unhealthy emit task events explaining why
-	if !healthy && isDeploy {
+	if !healthy && isDeploy && !isTerminal {
 		for task, event := range trackerTaskEvents {
 			if tr, ok := a.ar.tasks[task]; ok {
 				// Append but don't emit event since the server

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -46,11 +46,11 @@ func (a *allocHealthSetter) SetHealth(healthy, isDeploy bool, trackerTaskEvents 
 	a.ar.stateLock.Lock()
 	a.ar.state.SetDeploymentStatus(time.Now(), healthy)
 	a.ar.persistDeploymentStatus(a.ar.state.DeploymentStatus)
-	isTerminal := a.ar.alloc.TerminalStatus()
+	terminalDesiredState := a.ar.alloc.ServerTerminalStatus()
 	a.ar.stateLock.Unlock()
 
 	// If deployment is unhealthy emit task events explaining why
-	if !healthy && isDeploy && !isTerminal {
+	if !healthy && isDeploy && !terminalDesiredState {
 		for task, event := range trackerTaskEvents {
 			if tr, ok := a.ar.tasks[task]; ok {
 				// Append but don't emit event since the server

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7288,13 +7288,17 @@ func (a *Allocation) copyImpl(job bool) *Allocation {
 func (a *Allocation) TerminalStatus() bool {
 	// First check the desired state and if that isn't terminal, check client
 	// state.
+	return a.ServerTerminalStatus() || a.ClientTerminalStatus()
+}
+
+// ServerTerminalStatus returns true if the desired state of the allocation is terminal
+func (a *Allocation) ServerTerminalStatus() bool {
 	switch a.DesiredStatus {
 	case AllocDesiredStatusStop, AllocDesiredStatusEvict:
 		return true
 	default:
+		return false
 	}
-
-	return a.ClientTerminalStatus()
 }
 
 // ClientTerminalStatus returns if the client status is terminal and will no longer transition


### PR DESCRIPTION
This fixes a bug with task events where we were emitted unhealthy task events after the alloc's DesiredState changed to stop. 