### PR TITLE
Fix bug related to high cpu usage

### DIFF
--- a/client/allocrunner/taskrunner/stats_hook.go
+++ b/client/allocrunner/taskrunner/stats_hook.go
@@ -143,12 +143,8 @@ func (h *statsHook) collectResourceUsageStats(ctx context.Context, handle interf
 			// Update stats on TaskRunner and emit them
 			h.updater.UpdateStats(ru)
 
-		default:
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
+		case <-ctx.Done():
+			return
 		}
 	}
 }


### PR DESCRIPTION
After some refactoring that changed the purpose of a context in the stats hook, I missed changing the select statement. This caused a for loop to tight loop.