### PR TITLE
ci: run seperate build jobs for slower packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,27 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
+      env: GOTEST_PKGS="./api"
+    - os: linux
+      dist: xenial
+      sudo: required
+      env: GOTEST_PKGS="./client"
+    - os: linux
+      dist: xenial
+      sudo: required
+      env: GOTEST_PKGS="./drivers/docker"
+    - os: linux
+      dist: xenial
+      sudo: required
+      env: GOTEST_PKGS="./drivers/exec"
+    - os: linux
+      dist: xenial
+      sudo: required
+      env: GOTEST_PKGS="./nomad"
+    - os: linux
+      dist: xenial
+      sudo: required
+      env: GOTEST_PKGS_EXCLUDE="./api|./client|./drivers/docker|./drivers/exec|./nomad"
     - os: linux
       dist: xenial
       sudo: required

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,6 +10,12 @@ GO_TAGS =
 
 GO_TEST_CMD = $(if $(shell which gotestsum),gotestsum --,go test)
 
+ifeq ($(origin GOTEST_PKGS_EXCLUDE), undefined)
+GOTEST_PKGS ?= "./..."
+else
+GOTEST_PKGS=$(shell go list ./... | sed 's/github.com\/hashicorp\/nomad/./' | egrep -v "^($(GOTEST_PKGS_EXCLUDE))$$")
+endif
+
 default: help
 
 ifeq (,$(findstring $(THIS_OS),Darwin Linux FreeBSD Windows))
@@ -252,7 +258,7 @@ test-nomad: dev ## Run Nomad test suites
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
 		-timeout=15m \
-		./... $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
+		$(GOTEST_PKGS) $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
 	@if [ $(VERBOSE) ] ; then \
 		bash -C "$(PROJECT_ROOT)/scripts/test_check.sh" ; \
 	fi


### PR DESCRIPTION
This PR splits out some of our known long running test packages into their own travis jobs.