### PR TITLE
UI: Faceted search on the jobs list page

### DIFF
--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -28,6 +28,33 @@ export default Controller.extend(Sortable, Searchable, {
   fuzzySearchProps: computed(() => ['name']),
   fuzzySearchEnabled: true,
 
+  facetOptionsType: computed(() => [
+    { key: 'batch', label: 'Batch' },
+    { key: 'parameterized', label: 'Parameterized' },
+    { key: 'periodic', label: 'Periodic' },
+    { key: 'service', label: 'Service' },
+    { key: 'system', label: 'System' },
+  ]),
+
+  facetOptionsStatus: computed(() => [
+    { key: 'pending', label: 'Pending' },
+    { key: 'running', label: 'Running' },
+    { key: 'dead', label: 'Dead' },
+  ]),
+
+  facetOptionsDatacenter: computed('model.[]', function() {
+    return [{ key: 'dc1', label: 'dc1' }];
+  }),
+
+  facetOptionsPrefix: computed('model.[]', function() {
+    return [{ key: 'atlas-', label: 'atlas-' }];
+  }),
+
+  facetSelectionType: computed(() => []),
+  facetSelectionStatus: computed(() => []),
+  facetSelectionDatacenter: computed(() => []),
+  facetSelectionPrefix: computed(() => []),
+
   /**
     Filtered jobs are those that match the selected namespace and aren't children
     of periodic or parameterized jobs.

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -110,6 +110,40 @@ export default Controller.extend(Sortable, Searchable, {
       .filter(job => !job.get('parent.content'));
   }),
 
+  filteredJobs: computed(
+    'visibleJobs.[]',
+    'facetSelectionType',
+    'facetSelectionStatus',
+    'facetSelectionDatacenter',
+    'facetSelectionPrefix',
+    function() {
+      const {
+        facetSelectionType: types,
+        facetSelectionStatus: statuses,
+        facetSelectionDatacenter: datacenters,
+        facetSelectionPrefix: prefixes,
+      } = this.getProperties(
+        'facetSelectionType',
+        'facetSelectionStatus',
+        'facetSelectionDatacenter',
+        'facetSelectionPrefix'
+      );
+
+      // A job must match ALL filter facets, but it can match ANY selection within a facet
+      // Always return early to prevent unnecessary facet predicates.
+      return this.get('visibleJobs').filter(job => {
+        if (types.length && !types.includes(job.get('displayType'))) return false;
+        if (statuses.length && !statuses.includes(job.get('status'))) return false;
+        if (datacenters.length && !job.get('datacenters').find(dc => datacenters.includes(dc)))
+          return false;
+        const name = job.get('name');
+        if (prefixes.length && !prefixes.find(prefix => name.startsWith(prefix))) return false;
+
+        return true;
+      });
+    }
+  ),
+
   listToSort: alias('filteredJobs'),
   listToSearch: alias('listSorted'),
   sortedJobs: alias('listSearched'),

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -51,6 +51,16 @@ export default Controller.extend(Sortable, Searchable, {
   fuzzySearchProps: computed(() => ['name']),
   fuzzySearchEnabled: true,
 
+  qpType: '',
+  qpStatus: '',
+  qpDatacenter: '',
+  qpPrefix: '',
+
+  selectionType: qpSelection('qpType'),
+  selectionStatus: qpSelection('qpStatus'),
+  selectionDatacenter: qpSelection('qpDatacenter'),
+  selectionPrefix: qpSelection('qpPrefix'),
+
   optionsType: computed(() => [
     { key: 'batch', label: 'Batch' },
     { key: 'parameterized', label: 'Parameterized' },
@@ -125,18 +135,8 @@ export default Controller.extend(Sortable, Searchable, {
     }));
   }),
 
-  qpType: '',
-  qpStatus: '',
-  qpDatacenter: '',
-  qpPrefix: '',
-
-  selectionType: qpSelection('qpType'),
-  selectionStatus: qpSelection('qpStatus'),
-  selectionDatacenter: qpSelection('qpDatacenter'),
-  selectionPrefix: qpSelection('qpPrefix'),
-
   /**
-    Filtered jobs are those that match the selected namespace and aren't children
+    Visible jobs are those that match the selected namespace and aren't children
     of periodic or parameterized jobs.
   */
   visibleJobs: computed('model.[]', 'model.@each.parent', function() {

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -173,12 +173,22 @@ export default Controller.extend(Sortable, Searchable, {
       // A job must match ALL filter facets, but it can match ANY selection within a facet
       // Always return early to prevent unnecessary facet predicates.
       return this.get('visibleJobs').filter(job => {
-        if (types.length && !types.includes(job.get('displayType'))) return false;
-        if (statuses.length && !statuses.includes(job.get('status'))) return false;
-        if (datacenters.length && !job.get('datacenters').find(dc => datacenters.includes(dc)))
+        if (types.length && !types.includes(job.get('displayType'))) {
           return false;
+        }
+
+        if (statuses.length && !statuses.includes(job.get('status'))) {
+          return false;
+        }
+
+        if (datacenters.length && !job.get('datacenters').find(dc => datacenters.includes(dc))) {
+          return false;
+        }
+
         const name = job.get('name');
-        if (prefixes.length && !prefixes.find(prefix => name.startsWith(prefix))) return false;
+        if (prefixes.length && !prefixes.find(prefix => name.startsWith(prefix))) {
+          return false;
+        }
 
         return true;
       });

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -19,7 +19,7 @@ const qpDeserialize = str => {
   }
 };
 
-const selectionFromQP = qpKey =>
+const qpSelection = qpKey =>
   computed(qpKey, function() {
     return qpDeserialize(this.get(qpKey));
   });
@@ -51,7 +51,7 @@ export default Controller.extend(Sortable, Searchable, {
   fuzzySearchProps: computed(() => ['name']),
   fuzzySearchEnabled: true,
 
-  facetOptionsType: computed(() => [
+  optionsType: computed(() => [
     { key: 'batch', label: 'Batch' },
     { key: 'parameterized', label: 'Parameterized' },
     { key: 'periodic', label: 'Periodic' },
@@ -59,13 +59,13 @@ export default Controller.extend(Sortable, Searchable, {
     { key: 'system', label: 'System' },
   ]),
 
-  facetOptionsStatus: computed(() => [
+  optionsStatus: computed(() => [
     { key: 'pending', label: 'Pending' },
     { key: 'running', label: 'Running' },
     { key: 'dead', label: 'Dead' },
   ]),
 
-  facetOptionsDatacenter: computed('visibleJobs.[]', function() {
+  optionsDatacenter: computed('visibleJobs.[]', function() {
     const flatten = (acc, val) => acc.concat(val);
     const allDatacenters = new Set(
       this.get('visibleJobs')
@@ -78,14 +78,14 @@ export default Controller.extend(Sortable, Searchable, {
     scheduleOnce('actions', () => {
       this.set(
         'qpDatacenter',
-        qpSerialize(intersection(availableDatacenters, this.get('facetSelectionDatacenter')))
+        qpSerialize(intersection(availableDatacenters, this.get('selectionDatacenter')))
       );
     });
 
     return availableDatacenters.sort().map(dc => ({ key: dc, label: dc }));
   }),
 
-  facetOptionsPrefix: computed('visibleJobs.[]', function() {
+  optionsPrefix: computed('visibleJobs.[]', function() {
     // A prefix is defined as the start of a job name up to the first - or .
     // ex: mktg-analytics -> mktg, ds.supermodel.classifier -> ds
     const hasPrefix = /.[-._]/;
@@ -114,7 +114,7 @@ export default Controller.extend(Sortable, Searchable, {
     scheduleOnce('actions', () => {
       this.set(
         'qpPrefix',
-        qpSerialize(intersection(availablePrefixes, this.get('facetSelectionPrefix')))
+        qpSerialize(intersection(availablePrefixes, this.get('selectionPrefix')))
       );
     });
 
@@ -130,10 +130,10 @@ export default Controller.extend(Sortable, Searchable, {
   qpDatacenter: '',
   qpPrefix: '',
 
-  facetSelectionType: selectionFromQP('qpType'),
-  facetSelectionStatus: selectionFromQP('qpStatus'),
-  facetSelectionDatacenter: selectionFromQP('qpDatacenter'),
-  facetSelectionPrefix: selectionFromQP('qpPrefix'),
+  selectionType: qpSelection('qpType'),
+  selectionStatus: qpSelection('qpStatus'),
+  selectionDatacenter: qpSelection('qpDatacenter'),
+  selectionPrefix: qpSelection('qpPrefix'),
 
   /**
     Filtered jobs are those that match the selected namespace and aren't children
@@ -153,21 +153,21 @@ export default Controller.extend(Sortable, Searchable, {
 
   filteredJobs: computed(
     'visibleJobs.[]',
-    'facetSelectionType',
-    'facetSelectionStatus',
-    'facetSelectionDatacenter',
-    'facetSelectionPrefix',
+    'selectionType',
+    'selectionStatus',
+    'selectionDatacenter',
+    'selectionPrefix',
     function() {
       const {
-        facetSelectionType: types,
-        facetSelectionStatus: statuses,
-        facetSelectionDatacenter: datacenters,
-        facetSelectionPrefix: prefixes,
+        selectionType: types,
+        selectionStatus: statuses,
+        selectionDatacenter: datacenters,
+        selectionPrefix: prefixes,
       } = this.getProperties(
-        'facetSelectionType',
-        'facetSelectionStatus',
-        'facetSelectionDatacenter',
-        'facetSelectionPrefix'
+        'selectionType',
+        'selectionStatus',
+        'selectionDatacenter',
+        'selectionPrefix'
       );
 
       // A job must match ALL filter facets, but it can match ANY selection within a facet

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -119,13 +119,10 @@ export default Controller.extend(Sortable, Searchable, {
     });
 
     // Sort, format, and include the count in the label
-    return prefixes
-      .sortBy('prefix')
-      .reverse()
-      .map(name => ({
-        key: name.prefix,
-        label: `${name.prefix} (${name.count})`,
-      }));
+    return prefixes.sortBy('prefix').map(name => ({
+      key: name.prefix,
+      label: `${name.prefix} (${name.count})`,
+    }));
   }),
 
   qpType: '',

--- a/ui/app/styles/components/dropdown.scss
+++ b/ui/app/styles/components/dropdown.scss
@@ -142,4 +142,10 @@
       }
     }
   }
+
+  .dropdown-empty {
+    display: block;
+    padding: 8px 12px;
+    color: $grey-light;
+  }
 }

--- a/ui/app/templates/components/multi-select-dropdown.hbs
+++ b/ui/app/templates/components/multi-select-dropdown.hbs
@@ -28,6 +28,8 @@
             {{option.label}}
           </label>
         </li>
+      {{else}}
+        <em data-test-dropdown-empty class="dropdown-empty">No options</em>
       {{/each}}
     </ul>
   {{/dd.content}}

--- a/ui/app/templates/components/multi-select-dropdown.hbs
+++ b/ui/app/templates/components/multi-select-dropdown.hbs
@@ -18,7 +18,7 @@
   {{#dd.content class="dropdown-options"}}
     <ul role="listbox" data-test-dropdown-options>
       {{#each options key="key" as |option|}}
-        <li data-test-dropdown-option class="dropdown-option" tabindex="1" onkeydown={{action "traverseList" option}}>
+        <li data-test-dropdown-option={{option.key}} class="dropdown-option" tabindex="1" onkeydown={{action "traverseList" option}}>
           <label>
             <input
               type="checkbox"

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -4,7 +4,7 @@
   {{else}}
     <div class="columns">
       {{#if filteredJobs.length}}
-        <div class="column">
+        <div class="column is-one-third">
           {{search-box
             data-test-jobs-search
             searchTerm=(mut searchTerm)
@@ -13,7 +13,31 @@
         </div>
       {{/if}}
       <div class="column is-centered">
-        {{#link-to "jobs.run" data-test-run-job class="button is-primary is-pulled-right"}}Run Job{{/link-to}}
+        <div class="button-bar is-pulled-right">
+          {{multi-select-dropdown
+            label="Type"
+            options=facetOptionsType
+            selection=facetSelectionType
+            onSelect=(action (mut facetSelectionType))}}
+          {{multi-select-dropdown
+            label="Status"
+            options=facetOptionsStatus
+            selection=facetSelectionStatus
+            onSelect=(action (mut facetSelectionStatus))}}
+          {{multi-select-dropdown
+            label="Datacenter"
+            options=facetOptionsDatacenter
+            selection=facetSelectionDatacenter
+            onSelect=(action (mut facetSelectionDatacenter))}}
+          {{multi-select-dropdown
+            label="Prefix"
+            options=facetOptionsPrefix
+            selection=facetSelectionPrefix
+            onSelect=(action (mut facetSelectionPrefix))}}
+        </div>
+      </div>
+      <div class="column is-minimum is-centered">
+        {{#link-to "jobs.run" data-test-run-job class="button is-primary"}}Run Job{{/link-to}}
       </div>
     </div>
     {{#list-pagination

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -15,21 +15,25 @@
       <div class="column is-centered">
         <div class="button-bar is-pulled-right">
           {{multi-select-dropdown
+            data-test-type-facet
             label="Type"
             options=facetOptionsType
             selection=facetSelectionType
             onSelect=(action setFacetQueryParam "qpType")}}
           {{multi-select-dropdown
+            data-test-status-facet
             label="Status"
             options=facetOptionsStatus
             selection=facetSelectionStatus
             onSelect=(action setFacetQueryParam "qpStatus")}}
           {{multi-select-dropdown
+            data-test-datacenter-facet
             label="Datacenter"
             options=facetOptionsDatacenter
             selection=facetSelectionDatacenter
             onSelect=(action setFacetQueryParam "qpDatacenter")}}
           {{multi-select-dropdown
+            data-test-prefix-facet
             label="Prefix"
             options=facetOptionsPrefix
             selection=facetSelectionPrefix
@@ -76,10 +80,15 @@
       </div>
     {{else}}
       <div data-test-empty-jobs-list class="empty-message">
-        {{#if (eq filteredJobs.length 0)}}
+        {{#if (eq visibleJobs.length 0)}}
           <h3 data-test-empty-jobs-list-headline class="empty-message-headline">No Jobs</h3>
           <p class="empty-message-body">
             The cluster is currently empty.
+          </p>
+        {{else if (eq filteredJobs.length 0)}}
+          <h3 data-test-empty-jobs-list-headline class="empty-message-headline">No Matches</h3>
+          <p class="empty-message-body">
+            No jobs match your current filter selection.
           </p>
         {{else if searchTerm}}
           <h3 data-test-empty-jobs-list-headline class="empty-message-headline">No Matches</h3>

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -17,26 +17,26 @@
           {{multi-select-dropdown
             data-test-type-facet
             label="Type"
-            options=facetOptionsType
-            selection=facetSelectionType
+            options=optionsType
+            selection=selectionType
             onSelect=(action setFacetQueryParam "qpType")}}
           {{multi-select-dropdown
             data-test-status-facet
             label="Status"
-            options=facetOptionsStatus
-            selection=facetSelectionStatus
+            options=optionsStatus
+            selection=selectionStatus
             onSelect=(action setFacetQueryParam "qpStatus")}}
           {{multi-select-dropdown
             data-test-datacenter-facet
             label="Datacenter"
-            options=facetOptionsDatacenter
-            selection=facetSelectionDatacenter
+            options=optionsDatacenter
+            selection=selectionDatacenter
             onSelect=(action setFacetQueryParam "qpDatacenter")}}
           {{multi-select-dropdown
             data-test-prefix-facet
             label="Prefix"
-            options=facetOptionsPrefix
-            selection=facetSelectionPrefix
+            options=optionsPrefix
+            selection=selectionPrefix
             onSelect=(action setFacetQueryParam "qpPrefix")}}
         </div>
       </div>

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -18,22 +18,22 @@
             label="Type"
             options=facetOptionsType
             selection=facetSelectionType
-            onSelect=(action (mut facetSelectionType))}}
+            onSelect=(action setFacetQueryParam "qpType")}}
           {{multi-select-dropdown
             label="Status"
             options=facetOptionsStatus
             selection=facetSelectionStatus
-            onSelect=(action (mut facetSelectionStatus))}}
+            onSelect=(action setFacetQueryParam "qpStatus")}}
           {{multi-select-dropdown
             label="Datacenter"
             options=facetOptionsDatacenter
             selection=facetSelectionDatacenter
-            onSelect=(action (mut facetSelectionDatacenter))}}
+            onSelect=(action setFacetQueryParam "qpDatacenter")}}
           {{multi-select-dropdown
             label="Prefix"
             options=facetOptionsPrefix
             selection=facetSelectionPrefix
-            onSelect=(action (mut facetSelectionPrefix))}}
+            onSelect=(action setFacetQueryParam "qpPrefix")}}
         </div>
       </div>
       <div class="column is-minimum is-centered">

--- a/ui/tests/integration/multi-select-dropdown-test.js
+++ b/ui/tests/integration/multi-select-dropdown-test.js
@@ -297,3 +297,15 @@ test('pressing ESC when the options list is open closes the list and returns foc
     'The trigger has focus'
   );
 });
+
+test('when there are no list options, an empty message is shown', function(assert) {
+  const props = commonProperties();
+  props.options = [];
+  this.setProperties(props);
+  this.render(commonTemplate);
+
+  click('[data-test-dropdown-trigger]');
+  assert.ok(find('[data-test-dropdown-options]'), 'The dropdown is still shown');
+  assert.ok(find('[data-test-dropdown-empty]'), 'The empty state is shown');
+  assert.notOk(find('[data-test-dropdown-option]'), 'No options are shown');
+});

--- a/ui/tests/pages/components/facet.js
+++ b/ui/tests/pages/components/facet.js
@@ -1,0 +1,17 @@
+import { isPresent, clickable, collection, text, attribute } from 'ember-cli-page-object';
+
+export default scope => ({
+  scope,
+
+  isPresent: isPresent(),
+
+  toggle: clickable('[data-test-dropdown-trigger]'),
+
+  options: collection('[data-test-dropdown-option]', {
+    testContainer: '#ember-testing',
+    resetScope: true,
+    label: text(),
+    key: attribute('data-test-dropdown-option'),
+    toggle: clickable('label'),
+  }),
+});

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -9,6 +9,8 @@ import {
   visitable,
 } from 'ember-cli-page-object';
 
+import facet from 'nomad-ui/tests/pages/components/facet';
+
 export default create({
   pageSize: 10,
 
@@ -54,5 +56,12 @@ export default create({
     options: collection('.ember-power-select-option', {
       label: text(),
     }),
+  },
+
+  facets: {
+    type: facet('[data-test-type-facet]'),
+    status: facet('[data-test-status-facet]'),
+    datacenter: facet('[data-test-datacenter-facet]'),
+    prefix: facet('[data-test-prefix-facet]'),
   },
 });


### PR DESCRIPTION
_This is part two of three for faceted search in the Nomad UI: #5235_

![image](https://user-images.githubusercontent.com/174740/51702047-a3e29800-1fc7-11e9-855e-ecc9aae996b7.png)

Faceted search on the Jobs page introduces four quick filter options for finding jobs.

1. **Type:** Batch, Parameterized, Periodic, Service, or System
2. **Status:** Pending, Running, or Dead
3. **Datacener:** A dynamically built list for filtering jobs by which datacenters they are allowed to run in
4. **Prefix:** An experimental facet that dynamically builds a list based on common job name prefixes (beginning of name up to first `-`, `_`, or `.`)

Facet selections are persisted in query params in order to be shareable and bookmarkable.