### PR TITLE
docker: only log missing bridge_ip on initial fingerprint

### DIFF
--- a/drivers/docker/fingerprint.go
+++ b/drivers/docker/fingerprint.go
@@ -113,7 +113,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 			} else {
 				// Docker 17.09.0-ce dropped the Gateway IP from the bridge network
 				// See https://github.com/moby/moby/issues/32648
-				if d.fingerprintSuccessful() {
+				if d.fingerprintSuccess == nil {
 					d.logger.Debug("bridge_ip could not be discovered")
 				}
 			}


### PR DESCRIPTION
Prior to 0.9 we only logged if the bridge_ip could not be discovered if it was the first time the fingerprinter ran. This PR restores that functionality. The problem with the current logic is that, since we aren't failing the fingerprint, checking if it was successful doesn't properly detect flapping causing this log line to hit every iteration on the affected docker daemon. 