### PR TITLE
drivers: pass logger through driver plugin client

### DIFF
--- a/helper/pluginutils/loader/loader.go
+++ b/helper/pluginutils/loader/loader.go
@@ -205,7 +205,7 @@ func (l *PluginLoader) dispensePlugin(
 
 	client := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig:  base.Handshake,
-		Plugins:          getPluginMap(pluginType),
+		Plugins:          getPluginMap(pluginType, logger),
 		Cmd:              pluginCmd,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		Logger:           logger,
@@ -259,7 +259,7 @@ func (l *PluginLoader) dispensePlugin(
 }
 
 // getPluginMap returns a plugin map based on the type of plugin being launched.
-func getPluginMap(pluginType string) map[string]plugin.Plugin {
+func getPluginMap(pluginType string, logger log.Logger) map[string]plugin.Plugin {
 	pmap := map[string]plugin.Plugin{
 		base.PluginTypeBase: &base.PluginBase{},
 	}
@@ -268,7 +268,7 @@ func getPluginMap(pluginType string) map[string]plugin.Plugin {
 	case base.PluginTypeDevice:
 		pmap[base.PluginTypeDevice] = &device.PluginDevice{}
 	case base.PluginTypeDriver:
-		pmap[base.PluginTypeDriver] = &drivers.PluginDriver{}
+		pmap[base.PluginTypeDriver] = drivers.NewDriverPlugin(nil, logger)
 	}
 
 	return pmap

--- a/plugins/drivers/plugin.go
+++ b/plugins/drivers/plugin.go
@@ -11,6 +11,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+var _ plugin.GRPCPlugin = &PluginDriver{}
+
 // PluginDriver wraps a DriverPlugin and implements go-plugins GRPCPlugin
 // interface to expose the the interface over gRPC
 type PluginDriver struct {
@@ -19,7 +21,7 @@ type PluginDriver struct {
 	logger hclog.Logger
 }
 
-func NewDriverPlugin(d DriverPlugin, logger hclog.Logger) plugin.GRPCPlugin {
+func NewDriverPlugin(d DriverPlugin, logger hclog.Logger) *PluginDriver {
 	return &PluginDriver{
 		impl:   d,
 		logger: logger,

--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -43,7 +43,7 @@ func (d *DriverHarness) Impl() drivers.DriverPlugin {
 func NewDriverHarness(t testing.T, d drivers.DriverPlugin) *DriverHarness {
 	logger := testlog.HCLogger(t).Named("driver_harness")
 
-	pd := drivers.NewDriverPlugin(d, logger).(*drivers.PluginDriver)
+	pd := drivers.NewDriverPlugin(d, logger)
 
 	client, server := plugin.TestPluginGRPCConn(t,
 		map[string]plugin.Plugin{


### PR DESCRIPTION
This fixes a panic whenever driver plugin attempts to log a message.