### PR TITLE
Fix double restart counting for templates

### DIFF
--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -441,7 +441,7 @@ func (tm *TaskTemplateManager) handleTemplateRerenders(allRenderedTime time.Time
 
 				if restart {
 					tm.config.Lifecycle.Restart(context.Background(),
-						structs.NewTaskEvent(structs.TaskRestarting).
+						structs.NewTaskEvent(structs.TaskRestartSignal).
 							SetDisplayMessage("Template with change_mode restart re-rendered"), false)
 				} else if len(signals) != 0 {
 					var mErr multierror.Error

--- a/e2e/consultemplate/consultemplate.go
+++ b/e2e/consultemplate/consultemplate.go
@@ -96,7 +96,7 @@ func (tc *ConsulTemplateTest) TestUpdatesRestartTasks(f *framework.F) {
 			}
 			first := allocs[0]
 			return first.TaskStates["test"].Restarts
-		}, 5*time.Second, time.Second).Should(Equal(count), "Incorrect restart count")
+		}, 10*time.Second, time.Second).Should(Equal(count), "Incorrect restart count")
 	}
 
 	// Wrap in retry to wait until placement
@@ -132,10 +132,7 @@ func (tc *ConsulTemplateTest) TestUpdatesRestartTasks(f *framework.F) {
 	require.Nil(err)
 
 	// Wrap in retry to wait until restart
-	// TODO(dani): FIXME: This restart counter should only be 1. This is
-	//                    likely an accounting bug in restart tracking from
-	//                    template hooks.
-	waitForRestartCount(2)
+	waitForRestartCount(1)
 }
 
 func (tc *ConsulTemplateTest) AfterEach(f *framework.F) {


### PR DESCRIPTION
This PR fixes an issue where template restarts would count twice since
it was emitting a restarting event.