### PR TITLE
remove mac logs caveat

### DIFF
--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -769,21 +769,6 @@ need a higher degree of isolation between processes for security or other
 reasons, it is recommended to use full virtualization like
 [QEMU](/docs/drivers/qemu.html).
 
-## Docker for Mac Caveats
-
-Docker for Mac runs Docker inside a small VM and then allows access to parts of
-the host filesystem into that VM. At present, nomad uses a syslog server bound to
-a Unix socket within a path that both the host and the VM can access to forward
-log messages back to nomad. But at present, Docker For Mac does not work for
-Unix domain sockets (https://github.com/docker/for-mac/issues/483) in one of
-these shared paths.
-
-As a result, using nomad with the docker driver on OS X/macOS will work, but no
-logs will be available to nomad. Users must use the native docker facilities to
-examine the logs of any jobs running under docker.
-
-In the future, we will resolve this issue, one way or another.
-
 ## Docker for Windows Caveats
 
 Docker for Windows only supports running Windows containers. Because Docker for


### PR DESCRIPTION
Grepping for this particular caveat only showed it to be in the docker driver section.