### PR TITLE
nomad: fix panic when no node conn found

### DIFF
--- a/nomad/client_fs_endpoint.go
+++ b/nomad/client_fs_endpoint.go
@@ -292,6 +292,7 @@ func (f *FileSystem) stream(conn io.ReadWriteCloser) {
 				code = helper.Int64ToPtr(404)
 			}
 			f.handleStreamResultError(err, code, encoder)
+			return
 		}
 
 		// Get a connection to the server


### PR DESCRIPTION
A missing return would cause a panic when a server could find no route
to a client.