### PR TITLE
[WIP] Client Metadata API

### DIFF
--- a/client/client_metadata_endpoint.go
+++ b/client/client_metadata_endpoint.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/nomad/client/structs"
+	nstructs "github.com/hashicorp/nomad/nomad/structs"
+)
+
+// ClientMetadata endpoint is used for manipulating metadata for a client
+type ClientMetadata struct {
+	c *Client
+}
+
+// Metadata is used to retrieve the Clients metadata.
+func (m *ClientMetadata) Metadata(args *nstructs.NodeSpecificRequest, reply *structs.ClientMetadataResponse) error {
+	defer metrics.MeasureSince([]string{"client", "client_metadata", "metadata"}, time.Now())
+
+	// Check node write permissions
+	if aclObj, err := m.c.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeRead() {
+		return nstructs.ErrPermissionDenied
+	}
+
+	meta := m.c.Node().Meta
+	if meta == nil {
+		meta = make(map[string]string)
+	}
+
+	reply.Metadata = meta
+	reply.Index = m.c.Node().ModifyIndex
+
+	return nil
+}
+
+// UpdateMetadata is used to partially update the Clients metadata.
+func (m *ClientMetadata) UpdateMetadata(req *structs.ClientMetadataUpdateRequest, reply *structs.ClientMetadataUpdateResponse) error {
+	defer metrics.MeasureSince([]string{"client", "client_metadata", "update_metadata"}, time.Now())
+
+	// Check node write permissions
+	if aclObj, err := m.c.ResolveToken(req.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeWrite() {
+		return nstructs.ErrPermissionDenied
+	}
+
+	_, updated := m.c.updateNodeMetadata(req)
+	reply.Updated = updated
+
+	return nil
+}
+
+// ReplaceMetadata is used to entirely overwrite the Clients metadata.
+func (m *ClientMetadata) ReplaceMetadata(req *structs.ClientMetadataReplaceRequest, reply *structs.ClientMetadataUpdateResponse) error {
+	defer metrics.MeasureSince([]string{"client", "client_metadata", "replace_metadata"}, time.Now())
+
+	// Check node write permissions
+	if aclObj, err := m.c.ResolveToken(req.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeWrite() {
+		return nstructs.ErrPermissionDenied
+	}
+
+	m.c.replaceNodeMetadata(req)
+	reply.Updated = true
+
+	return nil
+}

--- a/client/client_metadata_endpoint_test.go
+++ b/client/client_metadata_endpoint_test.go
@@ -1,0 +1,234 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/mock"
+	nstructs "github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientMetadata_Metadata(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client, cleanup := TestClient(t, nil)
+	defer cleanup()
+
+	req := &nstructs.NodeSpecificRequest{}
+	var resp structs.ClientMetadataResponse
+	require.Nil(client.ClientRPC("ClientMetadata.Metadata", &req, &resp))
+	require.NotNil(resp.Metadata)
+}
+
+func TestClientMetadata_Metadata_ACL(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	server, addr, root := testACLServer(t, nil)
+	defer server.Shutdown()
+
+	client, cleanup := TestClient(t, func(c *config.Config) {
+		c.Servers = []string{addr}
+		c.ACLEnabled = true
+	})
+	defer cleanup()
+
+	// Try request without a token and expect failure
+	{
+		req := &nstructs.NodeSpecificRequest{}
+		var resp structs.ClientMetadataResponse
+		err := client.ClientRPC("ClientMetadata.Metadata", &req, &resp)
+		require.NotNil(err)
+		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+	}
+
+	// Try request with an invalid token and expect failure
+	{
+		token := mock.CreatePolicyAndToken(t, server.State(), 1005, "invalid", mock.NodePolicy(acl.PolicyDeny))
+		req := &nstructs.NodeSpecificRequest{}
+		req.AuthToken = token.SecretID
+
+		var resp structs.ClientMetadataResponse
+		err := client.ClientRPC("ClientMetadata.Metadata", &req, &resp)
+
+		require.NotNil(err)
+		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+	}
+
+	// Try request with a valid token
+	{
+		token := mock.CreatePolicyAndToken(t, server.State(), 1007, "valid", mock.NodePolicy(acl.PolicyRead))
+		req := &nstructs.NodeSpecificRequest{}
+		req.AuthToken = token.SecretID
+
+		var resp structs.ClientMetadataResponse
+		err := client.ClientRPC("ClientMetadata.Metadata", &req, &resp)
+
+		require.Nil(err)
+		require.NotNil(resp.Metadata)
+	}
+
+	// Try request with a management token
+	{
+		req := &nstructs.NodeSpecificRequest{}
+		req.AuthToken = root.SecretID
+
+		var resp structs.ClientMetadataResponse
+		err := client.ClientRPC("ClientMetadata.Metadata", &req, &resp)
+
+		require.Nil(err)
+		require.NotNil(resp.Metadata)
+	}
+}
+
+func TestClientMetadata_UpdateMetadata(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client, cleanup := TestClient(t, nil)
+	defer cleanup()
+
+	req := &structs.ClientMetadataUpdateRequest{
+		Updates: map[string]string{
+			"SomeKey": "Value",
+		},
+	}
+	var resp structs.ClientMetadataUpdateResponse
+	require.Nil(client.ClientRPC("ClientMetadata.UpdateMetadata", &req, &resp))
+	require.True(resp.Updated)
+	require.Equal(client.configCopy.Node.Meta["SomeKey"], "Value")
+}
+
+func TestClientMetadata_UpdateMetadata_ACL(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	server, addr, root := testACLServer(t, nil)
+	defer server.Shutdown()
+
+	client, cleanup := TestClient(t, func(c *config.Config) {
+		c.Servers = []string{addr}
+		c.ACLEnabled = true
+	})
+	defer cleanup()
+
+	// Try request without a token and expect failure
+	{
+		req := &structs.ClientMetadataUpdateRequest{}
+		var resp structs.ClientMetadataUpdateResponse
+		err := client.ClientRPC("ClientMetadata.UpdateMetadata", &req, &resp)
+		require.NotNil(err)
+		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+	}
+
+	// Try request with an invalid token and expect failure
+	{
+		token := mock.CreatePolicyAndToken(t, server.State(), 1005, "invalid", mock.NodePolicy(acl.PolicyRead))
+		req := &structs.ClientMetadataUpdateRequest{}
+		req.AuthToken = token.SecretID
+
+		var resp structs.ClientMetadataUpdateResponse
+		err := client.ClientRPC("ClientMetadata.UpdateMetadata", &req, &resp)
+
+		require.NotNil(err)
+		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+	}
+
+	// Try request with a valid write token
+	{
+		token := mock.CreatePolicyAndToken(t, server.State(), 1007, "valid", mock.NodePolicy(acl.PolicyWrite))
+		req := &structs.ClientMetadataUpdateRequest{}
+		req.AuthToken = token.SecretID
+
+		var resp structs.ClientMetadataUpdateResponse
+		err := client.ClientRPC("ClientMetadata.UpdateMetadata", &req, &resp)
+
+		require.Nil(err)
+	}
+
+	// Try request with a management token
+	{
+		req := &structs.ClientMetadataUpdateRequest{}
+		req.AuthToken = root.SecretID
+
+		var resp structs.ClientMetadataUpdateResponse
+		err := client.ClientRPC("ClientMetadata.UpdateMetadata", &req, &resp)
+
+		require.Nil(err)
+	}
+}
+
+func TestClientMetadata_ReplaceMetadata(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client, cleanup := TestClient(t, nil)
+	defer cleanup()
+
+	meta := map[string]string{"foo": "bar", "boo": "baz"}
+
+	req := &structs.ClientMetadataReplaceRequest{
+		Metadata: meta,
+	}
+	var resp structs.ClientMetadataUpdateResponse
+	require.Nil(client.ClientRPC("ClientMetadata.ReplaceMetadata", &req, &resp))
+	require.True(resp.Updated)
+	require.Equal(client.configCopy.Node.Meta, meta)
+}
+
+func TestClientMetadata_ReplaceMetadata_ACL(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	server, addr, root := testACLServer(t, nil)
+	defer server.Shutdown()
+
+	client, cleanup := TestClient(t, func(c *config.Config) {
+		c.Servers = []string{addr}
+		c.ACLEnabled = true
+	})
+	defer cleanup()
+
+	// Try request without a token and expect failure
+	{
+		req := &structs.ClientMetadataReplaceRequest{}
+		var resp structs.ClientMetadataUpdateResponse
+		err := client.ClientRPC("ClientMetadata.ReplaceMetadata", &req, &resp)
+		require.NotNil(err)
+		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+	}
+
+	// Try request with an invalid token and expect failure
+	{
+		token := mock.CreatePolicyAndToken(t, server.State(), 1005, "invalid", mock.NodePolicy(acl.PolicyRead))
+		req := &structs.ClientMetadataReplaceRequest{}
+		req.AuthToken = token.SecretID
+
+		var resp structs.ClientMetadataUpdateResponse
+		err := client.ClientRPC("ClientMetadata.ReplaceMetadata", &req, &resp)
+
+		require.NotNil(err)
+		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+	}
+
+	// Try request with a valid write token
+	{
+		token := mock.CreatePolicyAndToken(t, server.State(), 1007, "valid", mock.NodePolicy(acl.PolicyWrite))
+		req := &structs.ClientMetadataReplaceRequest{}
+		req.AuthToken = token.SecretID
+
+		var resp structs.ClientMetadataUpdateResponse
+		err := client.ClientRPC("ClientMetadata.ReplaceMetadata", &req, &resp)
+
+		require.Nil(err)
+	}
+
+	// Try request with a management token
+	{
+		req := &structs.ClientMetadataReplaceRequest{}
+		req.AuthToken = root.SecretID
+
+		var resp structs.ClientMetadataUpdateResponse
+		err := client.ClientRPC("ClientMetadata.ReplaceMetadata", &req, &resp)
+
+		require.Nil(err)
+	}
+}

--- a/client/config/meta.go
+++ b/client/config/meta.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/structs"
+)
+
+func uniqueKeys(maps ...map[string]string) []string {
+	var keys []string
+	seen := make(map[string]bool)
+
+	for _, m := range maps {
+		for k := range m {
+			if _, ok := seen[k]; ok {
+				continue
+			}
+
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+
+	return keys
+}
+
+// ApplyMetadataDiff takes a meta map, and a slice of diffs, and returns the
+// result of applying the diffs to the map.
+// The input meta map will win all conflicts. This allows operators to easily
+// overrule API updated configuration when updating client agents.
+func ApplyMetadataDiff(logger hclog.Logger, m map[string]string, diffs []*structs.MetadataDiff) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+
+	for _, entry := range diffs {
+		mVal, mContains := m[entry.Key]
+
+		switch entry.Type {
+		case structs.MetadataDiffTypeAdd:
+			// If the config now contains the given key, it takes precedent over the
+			// previous new value.
+			if mContains {
+				continue
+			}
+
+			// The original map still doesn't contain this key, so we insert it.
+			out[entry.Key] = entry.To
+
+		case structs.MetadataDiffTypeRemove:
+			// Entry has updated in config, so we take the new value. Otherwise we do
+			// nothing.
+			if !mContains || entry.From != mVal {
+				continue
+			}
+
+			delete(out, entry.Key)
+
+		case structs.MetadataDiffTypeUpdate:
+			// The value has been _updated_ in the config, so we take the new value.
+			if mContains && mVal != entry.From {
+				continue
+			}
+
+			// The value has been removed from config, so we drop the value
+			if !mContains {
+				continue
+			}
+
+			// The valuehas not changed so we apply the diff value instead.
+			out[entry.Key] = entry.To
+
+		default:
+			logger.Error("Cannot apply metadata diff", "type", entry.Type, "key", entry.Key, "from", entry.From, "to", entry.To)
+		}
+	}
+
+	return out
+}
+
+// ComputeMetadataDiff takes two client meta maps and returns the diff between
+// them. The diff is not guaranteed to be returned in a stable order.
+func ComputeMetadataDiff(original, current map[string]string) []*structs.MetadataDiff {
+	diff := make([]*structs.MetadataDiff, 0)
+
+	keys := uniqueKeys(original, current)
+	for _, key := range keys {
+		cVal, inCurrent := current[key]
+		oVal, inOriginal := original[key]
+
+		if inCurrent && inOriginal {
+			if oVal == cVal {
+				continue // No diff
+			}
+
+			// Updated value
+			diff = append(diff, &structs.MetadataDiff{
+				Type: structs.MetadataDiffTypeUpdate,
+				Key:  key,
+				From: oVal,
+				To:   cVal,
+			})
+		} else if inCurrent && !inOriginal {
+			// New Key
+			diff = append(diff, &structs.MetadataDiff{
+				Type: structs.MetadataDiffTypeAdd,
+				Key:  key,
+				To:   cVal,
+			})
+
+		} else if !inCurrent && inOriginal {
+			// Removed Key
+			diff = append(diff, &structs.MetadataDiff{
+				Type: structs.MetadataDiffTypeRemove,
+				Key:  key,
+				From: oVal,
+			})
+		}
+	}
+
+	return diff
+}

--- a/client/config/meta_test.go
+++ b/client/config/meta_test.go
@@ -1,0 +1,263 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/client/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeMetadataDiff(t *testing.T) {
+	cases := []struct {
+		Name         string
+		Base         map[string]string
+		Target       map[string]string
+		ExpectedDiff []*structs.MetadataDiff
+	}{
+		{
+			Name: "Basic Add",
+			Base: map[string]string{},
+			Target: map[string]string{
+				"Foo": "bar",
+			},
+			ExpectedDiff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeAdd,
+					Key:  "Foo",
+					To:   "bar",
+				},
+			},
+		},
+		{
+			Name: "Basic Remove",
+			Base: map[string]string{
+				"Foo": "bar",
+			},
+			Target: map[string]string{},
+			ExpectedDiff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeRemove,
+					Key:  "Foo",
+					From: "bar",
+				},
+			},
+		},
+		{
+			Name: "Basic Update",
+			Base: map[string]string{
+				"Foo": "bar",
+			},
+			Target: map[string]string{
+				"Foo": "baz",
+			},
+			ExpectedDiff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeUpdate,
+					Key:  "Foo",
+					From: "bar",
+					To:   "baz",
+				},
+			},
+		},
+		{
+			Name: "Basic No-op",
+			Base: map[string]string{
+				"Foo": "bar",
+			},
+			Target: map[string]string{
+				"Foo": "bar",
+			},
+			ExpectedDiff: []*structs.MetadataDiff{},
+		},
+		{
+			Name: "Complex",
+			Base: map[string]string{
+				"Foo":  "bar",
+				"biz":  "baz",
+				"fizz": "buzz",
+			},
+			Target: map[string]string{
+				"Foo": "bar",
+				"biz": "boz",
+			},
+			ExpectedDiff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeUpdate,
+					Key:  "biz",
+					From: "baz",
+					To:   "boz",
+				},
+				{
+					Type: structs.MetadataDiffTypeRemove,
+					Key:  "fizz",
+					From: "buzz",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			diff := ComputeMetadataDiff(tc.Base, tc.Target)
+			require.NotNil(diff)
+			require.Equal(tc.ExpectedDiff, diff)
+		})
+	}
+}
+
+func TestApplyMetadataDiff(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Base   map[string]string
+		Target map[string]string
+		Diff   []*structs.MetadataDiff
+	}{
+		{
+			Name: "Basic Add",
+			Base: map[string]string{},
+			Target: map[string]string{
+				"Foo": "bar",
+			},
+			Diff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeAdd,
+					Key:  "Foo",
+					To:   "bar",
+				},
+			},
+		},
+		{
+			Name: "Basic Remove",
+			Base: map[string]string{
+				"Foo": "bar",
+			},
+			Target: map[string]string{},
+			Diff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeRemove,
+					Key:  "Foo",
+					From: "bar",
+				},
+			},
+		},
+		{
+			Name: "Basic Update",
+			Base: map[string]string{
+				"Foo": "bar",
+			},
+			Target: map[string]string{
+				"Foo": "baz",
+			},
+			Diff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeUpdate,
+					Key:  "Foo",
+					From: "bar",
+					To:   "baz",
+				},
+			},
+		},
+		{
+			Name: "Basic No-op",
+			Base: map[string]string{
+				"Foo": "bar",
+			},
+			Target: map[string]string{
+				"Foo": "bar",
+			},
+			Diff: []*structs.MetadataDiff{},
+		},
+		{
+			Name: "Complex",
+			Base: map[string]string{
+				"Foo":  "bar",
+				"biz":  "baz",
+				"fizz": "buzz",
+			},
+			Target: map[string]string{
+				"Foo": "bar",
+				"biz": "boz",
+			},
+			Diff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeUpdate,
+					Key:  "biz",
+					From: "baz",
+					To:   "boz",
+				},
+				{
+					Type: structs.MetadataDiffTypeRemove,
+					Key:  "fizz",
+					From: "buzz",
+				},
+			},
+		},
+		{
+			Name: "Skipped Update",
+			Base: map[string]string{
+				"foo": "bar",
+			},
+			Target: map[string]string{
+				"foo": "bar",
+			},
+			Diff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeUpdate,
+					Key:  "now-removed",
+					From: "biz",
+					To:   "boz",
+				},
+				{
+					Type: structs.MetadataDiffTypeUpdate,
+					Key:  "foo",
+					From: "buzz",
+					To:   "overruled by updated config",
+				},
+			},
+		},
+		{
+			Name: "Skipped Delete",
+			Base: map[string]string{
+				"foo": "bar",
+			},
+			Target: map[string]string{
+				"foo": "bar",
+			},
+			Diff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeRemove,
+					Key:  "foo",
+					From: "overruled-by-updated-value",
+				},
+			},
+		},
+		{
+			Name: "Skipped Addition",
+			Base: map[string]string{
+				"foo": "bar",
+			},
+			Target: map[string]string{
+				"foo": "bar",
+			},
+			Diff: []*structs.MetadataDiff{
+				{
+					Type: structs.MetadataDiffTypeAdd,
+					Key:  "foo",
+					To:   "overruled-by-updated-value",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			result := ApplyMetadataDiff(nil, tc.Base, tc.Diff)
+			require.NotNil(result)
+			require.Equal(tc.Target, result)
+		})
+	}
+}

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -20,9 +20,10 @@ import (
 
 // rpcEndpoints holds the RPC endpoints
 type rpcEndpoints struct {
-	ClientStats *ClientStats
-	FileSystem  *FileSystem
-	Allocations *Allocations
+	ClientStats    *ClientStats
+	ClientMetadata *ClientMetadata
+	FileSystem     *FileSystem
+	Allocations    *Allocations
 }
 
 // ClientRPC is used to make a local, client only RPC call
@@ -216,6 +217,7 @@ func (c *Client) streamingRpcConn(server *servers.Server, method string) (net.Co
 func (c *Client) setupClientRpc() {
 	// Initialize the RPC handlers
 	c.endpoints.ClientStats = &ClientStats{c}
+	c.endpoints.ClientMetadata = &ClientMetadata{c}
 	c.endpoints.FileSystem = NewFileSystemEndpoint(c)
 	c.endpoints.Allocations = &Allocations{c}
 
@@ -232,6 +234,7 @@ func (c *Client) setupClientRpc() {
 func (c *Client) setupClientRpcServer(server *rpc.Server) {
 	// Register the endpoints
 	server.Register(c.endpoints.ClientStats)
+	server.Register(c.endpoints.ClientMetadata)
 	server.Register(c.endpoints.FileSystem)
 	server.Register(c.endpoints.Allocations)
 }

--- a/client/state/db_test.go
+++ b/client/state/db_test.go
@@ -9,6 +9,7 @@ import (
 	trstate "github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -241,6 +242,29 @@ func TestStateDB_DriverManager(t *testing.T) {
 		require.NoError(err)
 		require.NotNil(ps)
 		require.Equal(state, ps)
+	})
+}
+
+func TestStateDB_MetadataConfiguration(t *testing.T) {
+	t.Parallel()
+
+	testDB(t, func(t *testing.T, db StateDB) {
+		require := require.New(t)
+
+		// Get nonexistent state returns nil
+		cfg, err := db.GetMetadataConfiguration()
+		require.NoError(err)
+		require.Nil(cfg)
+
+		// Setting state should not return an error
+		config := &cstructs.MetadataConfiguration{}
+		require.NoError(db.PutMetadataConfiguration(config))
+
+		// Getting should return the state
+		cfg, err = db.GetMetadataConfiguration()
+		require.NoError(err)
+		require.NotNil(cfg)
+		require.Equal(config, cfg)
 	})
 }
 

--- a/client/state/errdb.go
+++ b/client/state/errdb.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -74,6 +75,14 @@ func (m *ErrDB) GetDriverPluginState() (*driverstate.PluginState, error) {
 }
 
 func (m *ErrDB) PutDriverPluginState(ps *driverstate.PluginState) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) GetMetadataConfiguration() (*cstructs.MetadataConfiguration, error) {
+	return nil, fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) PutMetadataConfiguration(*cstructs.MetadataConfiguration) error {
 	return fmt.Errorf("Error!")
 }
 

--- a/client/state/interface.go
+++ b/client/state/interface.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -68,6 +69,14 @@ type StateDB interface {
 	// PutDriverPluginState is used to store the driver manager's plugin
 	// state.
 	PutDriverPluginState(state *driverstate.PluginState) error
+
+	// GetMetadataConfiguration is used to retrieve the metadata configuration
+	// diff that should be applied when restarting a client.
+	GetMetadataConfiguration() (*cstructs.MetadataConfiguration, error)
+
+	// PutMetadataConfiguration is used to store the metadata configuration
+	// diff that should be applied when restarting a client.
+	PutMetadataConfiguration(*cstructs.MetadataConfiguration) error
 
 	// Close the database. Unsafe for further use after calling regardless
 	// of return value.

--- a/client/state/memdb.go
+++ b/client/state/memdb.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -27,6 +28,8 @@ type MemDB struct {
 
 	// drivermanager -> plugin-state
 	driverManagerPs *driverstate.PluginState
+
+	metadataCfg *cstructs.MetadataConfiguration
 
 	mu sync.RWMutex
 }
@@ -185,6 +188,20 @@ func (m *MemDB) PutDriverPluginState(ps *driverstate.PluginState) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.driverManagerPs = ps
+	return nil
+}
+
+func (m *MemDB) GetMetadataConfiguration() (*cstructs.MetadataConfiguration, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.metadataCfg, nil
+}
+
+func (m *MemDB) PutMetadataConfiguration(cfg *cstructs.MetadataConfiguration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.metadataCfg = cfg
 	return nil
 }
 

--- a/client/state/noopdb.go
+++ b/client/state/noopdb.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -68,6 +69,14 @@ func (n NoopDB) PutDriverPluginState(ps *driverstate.PluginState) error {
 
 func (n NoopDB) GetDriverPluginState() (*driverstate.PluginState, error) {
 	return nil, nil
+}
+
+func (n NoopDB) GetMetadataConfiguration() (*cstructs.MetadataConfiguration, error) {
+	return nil, nil
+}
+
+func (n NoopDB) PutMetadataConfiguration(*cstructs.MetadataConfiguration) error {
+	return nil
 }
 
 func (n NoopDB) Close() error {

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -43,7 +43,9 @@ type ClientMetadataUpdateRequest struct {
 	// node meta
 	Updates map[string]string
 
-	structs.NodeSpecificRequest
+	NodeID   string
+	SecretID string
+
 	structs.WriteRequest
 }
 
@@ -52,7 +54,9 @@ type ClientMetadataUpdateRequest struct {
 type ClientMetadataReplaceRequest struct {
 	Metadata map[string]string
 
-	structs.NodeSpecificRequest
+	NodeID   string
+	SecretID string
+
 	structs.WriteRequest
 }
 

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -28,6 +28,42 @@ func (r *RpcError) Error() string {
 	return r.Message
 }
 
+// ClientMetadataResponse is used to return a node's metadata.
+type ClientMetadataResponse struct {
+	Metadata map[string]string
+
+	structs.QueryMeta
+}
+
+// ClientMetadataUpdateRequest is used to partially update the metadata
+// associated with the node.
+type ClientMetadataUpdateRequest struct {
+	// Updates is a mapping of new or updated metadata keys to their values
+	// if the value for a key is an empty string, the key will be deleted from
+	// node meta
+	Updates map[string]string
+
+	structs.NodeSpecificRequest
+	structs.WriteRequest
+}
+
+// ClientMetadataReplaceRequest is used to replace the metadata associated with
+// the node.
+type ClientMetadataReplaceRequest struct {
+	Metadata map[string]string
+
+	structs.NodeSpecificRequest
+	structs.WriteRequest
+}
+
+// ClientMetadataUpdateResponse is used to return the result of a request to
+// update or replace a client's metadata.
+type ClientMetadataUpdateResponse struct {
+	Updated bool
+
+	structs.WriteMeta
+}
+
 // ClientStatsResponse is used to return statistics about a node.
 type ClientStatsResponse struct {
 	HostStats *stats.HostStats

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -311,6 +311,26 @@ func joinStringSet(s1, s2 []string) []string {
 	return j
 }
 
+type MetadataDiffType uint8
+
+const (
+	MetadataDiffTypeNone MetadataDiffType = iota
+	MetadataDiffTypeAdd
+	MetadataDiffTypeUpdate
+	MetadataDiffTypeRemove
+)
+
+type MetadataDiff struct {
+	Type MetadataDiffType
+	Key  string
+	From string
+	To   string
+}
+
+type MetadataConfiguration struct {
+	Diff []*MetadataDiff
+}
+
 // HealthCheckRequest is the request type for a type that fulfils the Health
 // Check interface
 type HealthCheckRequest struct{}

--- a/command/agent/client_meta_endpoint.go
+++ b/command/agent/client_meta_endpoint.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"fmt"
+	"net/http"
+
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func (s *HTTPServer) ClientMetaRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Get the requested Node ID
+	requestedNode := req.URL.Query().Get("node_id")
+
+	switch req.Method {
+	case "GET":
+		{
+			return s.clientMetaGetCurrent(resp, req, requestedNode)
+		}
+	case "PUT":
+		{
+			return s.clientMetaReplace(resp, req, requestedNode)
+		}
+	case "PATCH":
+		{
+			return s.clientMetaUpdate(resp, req, requestedNode)
+		}
+	default:
+		return nil, CodedError(405, fmt.Sprintf("Unsupported http method (%s)", req.Method))
+	}
+}
+
+func (s *HTTPServer) clientMetaGetCurrent(resp http.ResponseWriter, req *http.Request, nodeID string) (interface{}, error) {
+	// Build the request and parse the ACL token
+	args := structs.NodeSpecificRequest{
+		NodeID: nodeID,
+	}
+	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
+
+	// Determine the handler to use
+	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(nodeID)
+
+	// Make the RPC
+	var reply cstructs.ClientMetadataResponse
+	var rpcErr error
+	if useLocalClient {
+		rpcErr = s.agent.Client().ClientRPC("ClientMetadata.Metadata", &args, &reply)
+	} else if useClientRPC {
+		rpcErr = s.agent.Client().RPC("ClientMeta.Get", &args, &reply)
+	} else if useServerRPC {
+		rpcErr = s.agent.Server().RPC("ClientMeta.Get", &args, &reply)
+	} else {
+		rpcErr = CodedError(400, "No local Node and node_id not provided")
+	}
+
+	if rpcErr != nil {
+		if structs.IsErrNoNodeConn(rpcErr) {
+			rpcErr = CodedError(404, rpcErr.Error())
+		}
+	}
+
+	return &reply, rpcErr
+}
+
+func (s *HTTPServer) clientMetaReplace(resp http.ResponseWriter, req *http.Request, nodeID string) (interface{}, error) {
+	args := cstructs.ClientMetadataReplaceRequest{
+		NodeID: nodeID,
+	}
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	err := decodeBody(req, &args)
+	if err != nil {
+		return nil, CodedError(400, fmt.Sprintf("Failed to decode body: %v", err))
+	}
+
+	// Determine the handler to use
+	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(nodeID)
+
+	// Make the RPC
+	var reply cstructs.ClientMetadataUpdateResponse
+	var rpcErr error
+	if useLocalClient {
+		rpcErr = s.agent.Client().ClientRPC("ClientMetadata.ReplaceMetadata", &args, &reply)
+	} else if useClientRPC {
+		rpcErr = s.agent.Client().RPC("ClientMeta.Put", &args, &reply)
+	} else if useServerRPC {
+		rpcErr = s.agent.Server().RPC("ClientMeta.Put", &args, &reply)
+	} else {
+		rpcErr = CodedError(400, "No local Node and node_id not provided")
+	}
+
+	if rpcErr != nil {
+		if structs.IsErrNoNodeConn(rpcErr) {
+			rpcErr = CodedError(404, rpcErr.Error())
+		}
+	}
+
+	return &reply, rpcErr
+}
+
+func (s *HTTPServer) clientMetaUpdate(resp http.ResponseWriter, req *http.Request, nodeID string) (interface{}, error) {
+	args := cstructs.ClientMetadataUpdateRequest{
+		NodeID: nodeID,
+	}
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	err := decodeBody(req, &args)
+	if err != nil {
+		return nil, CodedError(400, fmt.Sprintf("Failed to decode body: %v", err))
+	}
+
+	// Determine the handler to use
+	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(nodeID)
+
+	// Make the RPC
+	var reply cstructs.ClientMetadataUpdateResponse
+	var rpcErr error
+	if useLocalClient {
+		rpcErr = s.agent.Client().ClientRPC("ClientMetadata.UpdateMetadata", &args, &reply)
+	} else if useClientRPC {
+		rpcErr = s.agent.Client().RPC("ClientMeta.Patch", &args, &reply)
+	} else if useServerRPC {
+		rpcErr = s.agent.Server().RPC("ClientMeta.Patch", &args, &reply)
+	} else {
+		rpcErr = CodedError(400, "No local Node and node_id not provided")
+	}
+
+	if rpcErr != nil {
+		if structs.IsErrNoNodeConn(rpcErr) {
+			rpcErr = CodedError(404, rpcErr.Error())
+		}
+	}
+
+	return &reply, rpcErr
+}

--- a/command/agent/client_meta_endpoint_test.go
+++ b/command/agent/client_meta_endpoint_test.go
@@ -1,0 +1,345 @@
+package agent
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/nomad/acl"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTP_ClientMetaGetCurrent(t *testing.T) {
+	require := require.New(t)
+	path := "/v1/client/meta"
+	httpTest(t,
+		func(c *Config) {
+			c.Client.Meta = map[string]string{
+				"Foo": "bar",
+			}
+		},
+		func(s *TestAgent) {
+			// Local node, local resp
+			{
+				req, err := http.NewRequest("GET", path, nil)
+				require.NoError(err)
+
+				respW := httptest.NewRecorder()
+				reply, err := s.Server.ClientMetaRequest(respW, req)
+				require.NoError(err)
+				require.NotNil(reply)
+			}
+
+			// no client, server resp
+
+			{
+				c := s.client
+				s.client = nil
+
+				testutil.WaitForResult(func() (bool, error) {
+					n, err := s.server.State().NodeByID(nil, c.NodeID())
+					if err != nil {
+						return false, err
+					}
+					return n != nil, nil
+				}, func(err error) {
+					require.NoError(err)
+				})
+
+				req, err := http.NewRequest("GET", fmt.Sprintf("%s?node_id=%s", path, c.NodeID()), nil)
+				require.NoError(err)
+
+				respW := httptest.NewRecorder()
+				reply, err := s.Server.ClientMetaRequest(respW, req)
+				require.NoError(err)
+				require.NotNil(reply)
+
+				s.client = c
+			}
+		})
+}
+
+func TestHTTP_ClientMetaGetCurrent_ACL(t *testing.T) {
+	require := require.New(t)
+	path := "/v1/client/meta?node_id=invalid"
+
+	httpACLTest(t, nil, func(s *TestAgent) {
+		state := s.Agent.server.State()
+
+		// Make the HTTP request
+		req, err := http.NewRequest("GET", path, nil)
+		require.NoError(err)
+
+		// Try request without a token and expect failure
+		{
+			respW := httptest.NewRecorder()
+			_, err := s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+		}
+
+		// Try request with an invalid token and expect failure
+		{
+			respW := httptest.NewRecorder()
+			token := mock.CreatePolicyAndToken(t, state, 1005, "invalid", mock.NodePolicy(acl.PolicyDeny))
+			setToken(req, token)
+			_, err := s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+		}
+
+		// Try request with a valid token
+		// Still returns an error because the node does not exist
+		{
+			respW := httptest.NewRecorder()
+			token := mock.CreatePolicyAndToken(t, state, 1007, "valid", mock.NodePolicy(acl.PolicyRead))
+			setToken(req, token)
+			_, err := s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Contains(err.Error(), "node lookup failed:")
+		}
+
+		// Try request with a management token
+		// Still returns an error because the node does not exist
+		{
+			respW := httptest.NewRecorder()
+			setToken(req, s.RootToken)
+			_, err := s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Contains(err.Error(), "node lookup failed:")
+		}
+	})
+}
+
+func TestHTTP_ClientMetaUpdate(t *testing.T) {
+	require := require.New(t)
+	path := "/v1/client/meta"
+	httpTest(t,
+		func(c *Config) {
+			c.Client.Meta = map[string]string{
+				"Foo": "bar",
+			}
+		},
+		func(s *TestAgent) {
+			// Local node, local resp
+			{
+				body := bytes.NewBuffer([]byte("{\"updates\": {\"newkey\": \"foo\"}}\n"))
+				req, err := http.NewRequest("PATCH", path, body)
+				require.NoError(err)
+
+				respW := httptest.NewRecorder()
+				reply, err := s.Server.ClientMetaRequest(respW, req)
+				require.NoError(err)
+				require.True(reply.(*cstructs.ClientMetadataUpdateResponse).Updated)
+			}
+
+			// no client, server resp
+
+			{
+				c := s.client
+				s.client = nil
+
+				testutil.WaitForResult(func() (bool, error) {
+					n, err := s.server.State().NodeByID(nil, c.NodeID())
+					if err != nil {
+						return false, err
+					}
+					return n != nil, nil
+				}, func(err error) {
+					require.NoError(err)
+				})
+
+				body := bytes.NewBuffer([]byte("{\"updates\": {\"newkey\": \"foo2\"}}\n"))
+				req, err := http.NewRequest("PATCH", fmt.Sprintf("%s?node_id=%s", path, c.NodeID()), body)
+				require.NoError(err)
+
+				respW := httptest.NewRecorder()
+				reply, err := s.Server.ClientMetaRequest(respW, req)
+				require.NoError(err)
+				require.NotNil(reply)
+				require.True(reply.(*cstructs.ClientMetadataUpdateResponse).Updated)
+
+				s.client = c
+			}
+		})
+}
+
+func TestHTTP_ClientMetaUpdate_ACL(t *testing.T) {
+	require := require.New(t)
+	path := "/v1/client/meta?node_id=invalid"
+
+	httpACLTest(t, nil, func(s *TestAgent) {
+		state := s.Agent.server.State()
+
+		// Try request without a token and expect failure
+		{
+			respW := httptest.NewRecorder()
+			body := bytes.NewBuffer([]byte("{}\n"))
+			req, err := http.NewRequest("PATCH", path, body)
+			require.NoError(err)
+			_, err = s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+		}
+
+		// Try request with an invalid token and expect failure
+		{
+			respW := httptest.NewRecorder()
+			body := bytes.NewBuffer([]byte("{}\n"))
+			req, err := http.NewRequest("PATCH", path, body)
+			require.NoError(err)
+			token := mock.CreatePolicyAndToken(t, state, 1005, "invalid", mock.NodePolicy(acl.PolicyDeny))
+			setToken(req, token)
+			_, err = s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+		}
+
+		// Try request with a valid token
+		// Still returns an error because the node does not exist
+		{
+			respW := httptest.NewRecorder()
+			body := bytes.NewBuffer([]byte("{}\n"))
+			req, err := http.NewRequest("PATCH", path, body)
+			require.NoError(err)
+			token := mock.CreatePolicyAndToken(t, state, 1007, "valid", mock.NodePolicy(acl.PolicyWrite))
+			setToken(req, token)
+			_, err = s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Contains(err.Error(), "missing Updates")
+		}
+
+		// Try request with a management token
+		// Still returns an error because the node does not exist
+		{
+			respW := httptest.NewRecorder()
+			body := bytes.NewBuffer([]byte("{}\n"))
+			req, err := http.NewRequest("PATCH", path, body)
+			require.NoError(err)
+			setToken(req, s.RootToken)
+			_, err = s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Contains(err.Error(), "missing Updates")
+		}
+	})
+}
+
+func TestHTTP_ClientMetaReplace(t *testing.T) {
+	require := require.New(t)
+	path := "/v1/client/meta"
+	httpTest(t,
+		func(c *Config) {
+			c.Client.Meta = map[string]string{
+				"Foo": "bar",
+			}
+		},
+		func(s *TestAgent) {
+			// Local node, local resp
+			{
+				body := bytes.NewBuffer([]byte("{}\n"))
+				req, err := http.NewRequest("PUT", path, body)
+				require.NoError(err)
+
+				respW := httptest.NewRecorder()
+				reply, err := s.Server.ClientMetaRequest(respW, req)
+				require.NoError(err)
+				require.True(reply.(*cstructs.ClientMetadataUpdateResponse).Updated)
+			}
+
+			// no client, server resp
+
+			{
+				c := s.client
+				s.client = nil
+
+				testutil.WaitForResult(func() (bool, error) {
+					n, err := s.server.State().NodeByID(nil, c.NodeID())
+					if err != nil {
+						return false, err
+					}
+					return n != nil, nil
+				}, func(err error) {
+					require.NoError(err)
+				})
+
+				body := bytes.NewBuffer([]byte("{\"metadata\": {}}\n"))
+				req, err := http.NewRequest("PUT", fmt.Sprintf("%s?node_id=%s", path, c.NodeID()), body)
+				require.NoError(err)
+
+				respW := httptest.NewRecorder()
+				reply, err := s.Server.ClientMetaRequest(respW, req)
+				require.NoError(err)
+				require.NotNil(reply)
+
+				s.client = c
+			}
+		})
+}
+
+func TestHTTP_ClientMetaReplace_ACL(t *testing.T) {
+	require := require.New(t)
+	path := "/v1/client/meta?node_id=invalid"
+
+	httpACLTest(t, nil, func(s *TestAgent) {
+		state := s.Agent.server.State()
+
+		// Make the HTTP request
+
+		// Try request without a token and expect failure
+		{
+			respW := httptest.NewRecorder()
+			body := bytes.NewBuffer([]byte("{}"))
+			req, err := http.NewRequest("PUT", path, body)
+			require.NoError(err)
+			_, err = s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+		}
+
+		// Try request with an invalid token and expect failure
+		{
+			respW := httptest.NewRecorder()
+			body := bytes.NewBuffer([]byte("{}"))
+			req, err := http.NewRequest("PUT", path, body)
+			require.NoError(err)
+			token := mock.CreatePolicyAndToken(t, state, 1005, "invalid", mock.NodePolicy(acl.PolicyDeny))
+			setToken(req, token)
+			_, err = s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+		}
+
+		// Try request with a valid token
+		// Still returns an error because the node does not exist
+		{
+			respW := httptest.NewRecorder()
+			body := bytes.NewBuffer([]byte("{}"))
+			req, err := http.NewRequest("PUT", path, body)
+			require.NoError(err)
+			token := mock.CreatePolicyAndToken(t, state, 1007, "valid", mock.NodePolicy(acl.PolicyWrite))
+			setToken(req, token)
+			_, err = s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Contains(err.Error(), "missing Metadata")
+		}
+
+		// Try request with a management token
+		// Still returns an error because the node does not exist
+		{
+			respW := httptest.NewRecorder()
+			body := bytes.NewBuffer([]byte("{}"))
+			req, err := http.NewRequest("PUT", path, body)
+			require.NoError(err)
+			setToken(req, s.RootToken)
+			_, err = s.Server.ClientMetaRequest(respW, req)
+			require.NotNil(err)
+			require.Contains(err.Error(), "missing Metadata")
+		}
+	})
+}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -166,6 +166,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/client/gc", s.wrap(s.ClientGCRequest))
 	s.mux.Handle("/v1/client/stats", wrapCORS(s.wrap(s.ClientStatsRequest)))
 	s.mux.Handle("/v1/client/allocation/", wrapCORS(s.wrap(s.ClientAllocRequest)))
+	s.mux.HandleFunc("/v1/client/meta", s.wrap(s.ClientMetaRequest))
 
 	s.mux.HandleFunc("/v1/agent/self", s.wrap(s.AgentSelfRequest))
 	s.mux.HandleFunc("/v1/agent/join", s.wrap(s.AgentJoinRequest))

--- a/nomad/client_meta_endpoint.go
+++ b/nomad/client_meta_endpoint.go
@@ -1,0 +1,151 @@
+package nomad
+
+import (
+	"errors"
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	hclog "github.com/hashicorp/go-hclog"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// Meta endpoints are used to access and modify node metadata.
+type ClientMeta struct {
+	srv    *Server
+	logger hclog.Logger
+}
+
+// Get is used to retrieve the current metadata for a given Node. It retreives
+// the metadata from the Node directly, rather than from a Server.
+func (m *ClientMeta) Get(args *structs.NodeSpecificRequest, reply *cstructs.ClientMetadataResponse) error {
+	// We only allow stale reads since the only potentially stale information is
+	// the Node registration and the cost is fairly high for adding another hope
+	// in the forwarding chain.
+	args.QueryOptions.AllowStale = true
+
+	// Potentially forward to a different region.
+	if done, err := m.srv.forward("ClientMeta.Get", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "client_metadata", "get"}, time.Now())
+
+	if aclObj, err := m.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeRead() {
+		return structs.ErrPermissionDenied
+	}
+
+	// Verify the arguments.
+	if args.NodeID == "" {
+		return errors.New("missing NodeID")
+	}
+
+	// Make sure Node is valid and new enough to support RPC
+	snap, err := m.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	_, err = getNodeForRpc(snap, args.NodeID)
+	if err != nil {
+		return err
+	}
+
+	// Get the connection to the client
+	state, ok := m.srv.getNodeConn(args.NodeID)
+	if !ok {
+		return findNodeConnAndForward(m.srv, args.NodeID, "ClientMeta.Get", args, reply)
+	}
+
+	// Make the RPC
+	return NodeRpc(state.Session, "ClientMetadata.Metadata", args, reply)
+}
+
+// Put is used to replace the metadata for a given Node.
+func (m *ClientMeta) Put(args *cstructs.ClientMetadataReplaceRequest, reply *cstructs.ClientMetadataUpdateResponse) error {
+	// Potentially forward to a different region.
+	if done, err := m.srv.forward("ClientMeta.Put", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "client_metadata", "put"}, time.Now())
+
+	if aclObj, err := m.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeWrite() {
+		return structs.ErrPermissionDenied
+	}
+
+	// Verify the arguments.
+	if args.NodeID == "" {
+		return errors.New("missing NodeID")
+	}
+
+	if args.Metadata == nil {
+		return errors.New("missing Metadata")
+	}
+
+	// Make sure Node is valid and new enough to support RPC
+	snap, err := m.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	_, err = getNodeForRpc(snap, args.NodeID)
+	if err != nil {
+		return err
+	}
+
+	// Get the connection to the client
+	state, ok := m.srv.getNodeConn(args.NodeID)
+	if !ok {
+		return findNodeConnAndForward(m.srv, args.NodeID, "ClientMeta.Put", args, reply)
+	}
+
+	// Make the RPC
+	return NodeRpc(state.Session, "ClientMetadata.ReplaceMetadata", args, reply)
+}
+
+// Patch is used to partilly update the metadata for a given Node.
+func (m *ClientMeta) Patch(args *cstructs.ClientMetadataUpdateRequest, reply *cstructs.ClientMetadataUpdateResponse) error {
+	// Potentially forward to a different region.
+	if done, err := m.srv.forward("ClientMeta.Patch", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "client_metadata", "patch"}, time.Now())
+
+	if aclObj, err := m.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeRead() {
+		return structs.ErrPermissionDenied
+	}
+
+	// Verify the arguments.
+	if args.NodeID == "" {
+		return errors.New("missing NodeID")
+	}
+
+	if args.Updates == nil {
+		return errors.New("missing Updates")
+	}
+
+	// Make sure Node is valid and new enough to support RPC
+	snap, err := m.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	_, err = getNodeForRpc(snap, args.NodeID)
+	if err != nil {
+		return err
+	}
+
+	// Get the connection to the client
+	state, ok := m.srv.getNodeConn(args.NodeID)
+	if !ok {
+		return findNodeConnAndForward(m.srv, args.NodeID, "ClientMeta.Patch", args, reply)
+	}
+
+	// Make the RPC
+	return NodeRpc(state.Session, "ClientMetadata.UpdateMetadata", args, reply)
+}

--- a/nomad/client_meta_endpoint_test.go
+++ b/nomad/client_meta_endpoint_test.go
@@ -1,0 +1,325 @@
+package nomad
+
+import (
+	"testing"
+
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/client"
+	"github.com/hashicorp/nomad/client/config"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientMeta_Get(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Start a server and client
+	s := TestServer(t, nil)
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
+		c.Servers = []string{s.config.RPCAddr.String()}
+	})
+	defer cleanup()
+
+	testutil.WaitForResult(func() (bool, error) {
+		nodes := s.connectedNodes()
+		return len(nodes) == 1, nil
+	}, func(err error) {
+		require.Fail("should have a client")
+	})
+
+	// Make the request without having a node-id
+	req := &structs.NodeSpecificRequest{
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+
+	// Fetch the response
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientMeta.Get", req, &resp)
+	require.NotNil(err)
+	require.Equal(err.Error(), "missing NodeID")
+
+	// Fetch the response setting the node id
+	req.NodeID = c.NodeID()
+	var resp2 cstructs.ClientMetadataResponse
+	err = msgpackrpc.CallWithCodec(codec, "ClientMeta.Get", req, &resp2)
+	require.Nil(err)
+	require.NotNil(resp2.Metadata)
+}
+
+func TestClientMeta_Get_ACL(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Start a server
+	s, root := TestACLServer(t, nil)
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	// Create a bad token
+	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityReadFS})
+	tokenBad := mock.CreatePolicyAndToken(t, s.State(), 1005, "invalid", policyBad)
+
+	policyGood := mock.NodePolicy(acl.PolicyRead)
+	tokenGood := mock.CreatePolicyAndToken(t, s.State(), 1009, "valid2", policyGood)
+
+	cases := []struct {
+		Name          string
+		Token         string
+		ExpectedError string
+	}{
+		{
+			Name:          "bad token",
+			Token:         tokenBad.SecretID,
+			ExpectedError: structs.ErrPermissionDenied.Error(),
+		},
+		{
+			Name:          "good token",
+			Token:         tokenGood.SecretID,
+			ExpectedError: "Unknown node",
+		},
+		{
+			Name:          "root token",
+			Token:         root.SecretID,
+			ExpectedError: "Unknown node",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+
+			// Make the request without having a node-id
+			req := &structs.NodeSpecificRequest{
+				NodeID: uuid.Generate(),
+				QueryOptions: structs.QueryOptions{
+					AuthToken: c.Token,
+					Region:    "global",
+				},
+			}
+
+			// Fetch the response
+			var resp structs.GenericResponse
+			err := msgpackrpc.CallWithCodec(codec, "ClientMeta.Get", req, &resp)
+			require.NotNil(err)
+			require.Contains(err.Error(), c.ExpectedError)
+		})
+	}
+}
+
+func TestClientMeta_Put(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Start a server and client
+	s := TestServer(t, nil)
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
+		c.Servers = []string{s.config.RPCAddr.String()}
+	})
+	defer cleanup()
+
+	testutil.WaitForResult(func() (bool, error) {
+		nodes := s.connectedNodes()
+		return len(nodes) == 1, nil
+	}, func(err error) {
+		require.Fail("should have a client")
+	})
+
+	// Make the request without having a node-id
+	req := &cstructs.ClientMetadataReplaceRequest{
+		Metadata: map[string]string{
+			"Some": "Meta",
+		},
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	// Fetch the response
+	var resp cstructs.ClientMetadataUpdateResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientMeta.Put", req, &resp)
+	require.NotNil(err)
+	require.Equal(err.Error(), "missing NodeID")
+
+	// Fetch the response setting the node id
+	req.NodeID = c.NodeID()
+	var resp2 cstructs.ClientMetadataUpdateResponse
+	err = msgpackrpc.CallWithCodec(codec, "ClientMeta.Put", req, &resp2)
+	require.Nil(err)
+	require.True(resp2.Updated)
+}
+
+func TestClientMeta_Put_ACL(t *testing.T) {
+	require := require.New(t)
+
+	// Start a server
+	s, root := TestACLServer(t, nil)
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	// Create a bad token
+	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityReadFS})
+	tokenBad := mock.CreatePolicyAndToken(t, s.State(), 1005, "invalid", policyBad)
+
+	policyGood := mock.NodePolicy(acl.PolicyWrite)
+	tokenGood := mock.CreatePolicyAndToken(t, s.State(), 1009, "valid2", policyGood)
+
+	cases := []struct {
+		Name          string
+		Token         string
+		ExpectedError string
+	}{
+		{
+			Name:          "bad token",
+			Token:         tokenBad.SecretID,
+			ExpectedError: structs.ErrPermissionDenied.Error(),
+		},
+		{
+			Name:          "good token",
+			Token:         tokenGood.SecretID,
+			ExpectedError: "Unknown node",
+		},
+		{
+			Name:          "root token",
+			Token:         root.SecretID,
+			ExpectedError: "Unknown node",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+
+			// Make the request without having a node-id
+			req := &cstructs.ClientMetadataReplaceRequest{
+				Metadata: map[string]string{"foo": "bar"},
+				NodeID:   uuid.Generate(),
+				WriteRequest: structs.WriteRequest{
+					AuthToken: c.Token,
+					Region:    "global",
+				},
+			}
+
+			// Fetch the response
+			var resp cstructs.ClientMetadataUpdateResponse
+			err := msgpackrpc.CallWithCodec(codec, "ClientMeta.Put", req, &resp)
+			require.NotNil(err)
+			require.Contains(err.Error(), c.ExpectedError)
+		})
+	}
+}
+
+func TestClientMeta_Patch(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Start a server and client
+	s := TestServer(t, nil)
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	c, cleanup := client.TestClient(t, func(c *config.Config) {
+		c.Servers = []string{s.config.RPCAddr.String()}
+	})
+	defer cleanup()
+
+	testutil.WaitForResult(func() (bool, error) {
+		nodes := s.connectedNodes()
+		return len(nodes) == 1, nil
+	}, func(err error) {
+		require.Fail("should have a client")
+	})
+
+	// Make the request without having a node-id
+	req := &cstructs.ClientMetadataUpdateRequest{
+		Updates: map[string]string{
+			"Some": "Meta",
+		},
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	// Fetch the response
+	var resp cstructs.ClientMetadataUpdateResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientMeta.Patch", req, &resp)
+	require.NotNil(err)
+	require.Equal(err.Error(), "missing NodeID")
+
+	// Fetch the response setting the node id
+	req.NodeID = c.NodeID()
+	var resp2 cstructs.ClientMetadataUpdateResponse
+	err = msgpackrpc.CallWithCodec(codec, "ClientMeta.Patch", req, &resp2)
+	require.Nil(err)
+	require.True(resp2.Updated)
+}
+
+func TestClientMeta_Patch_ACL(t *testing.T) {
+	require := require.New(t)
+
+	// Start a server
+	s, root := TestACLServer(t, nil)
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	// Create a bad token
+	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityReadFS})
+	tokenBad := mock.CreatePolicyAndToken(t, s.State(), 1005, "invalid", policyBad)
+
+	policyGood := mock.NodePolicy(acl.PolicyWrite)
+	tokenGood := mock.CreatePolicyAndToken(t, s.State(), 1009, "valid2", policyGood)
+
+	cases := []struct {
+		Name          string
+		Token         string
+		ExpectedError string
+	}{
+		{
+			Name:          "bad token",
+			Token:         tokenBad.SecretID,
+			ExpectedError: structs.ErrPermissionDenied.Error(),
+		},
+		{
+			Name:          "good token",
+			Token:         tokenGood.SecretID,
+			ExpectedError: "Unknown node",
+		},
+		{
+			Name:          "root token",
+			Token:         root.SecretID,
+			ExpectedError: "Unknown node",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+
+			// Make the request without having a node-id
+			req := &cstructs.ClientMetadataUpdateRequest{
+				Updates: map[string]string{"foo": "bar"},
+				NodeID:  uuid.Generate(),
+				WriteRequest: structs.WriteRequest{
+					AuthToken: c.Token,
+					Region:    "global",
+				},
+			}
+
+			// Fetch the response
+			var resp cstructs.ClientMetadataUpdateResponse
+			err := msgpackrpc.CallWithCodec(codec, "ClientMeta.Patch", req, &resp)
+			require.NotNil(err)
+			require.Contains(err.Error(), c.ExpectedError)
+		})
+	}
+}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -246,6 +246,7 @@ type endpoints struct {
 	ClientStats       *ClientStats
 	FileSystem        *FileSystem
 	ClientAllocations *ClientAllocations
+	ClientMeta        *ClientMeta
 }
 
 // NewServer is used to construct a new Nomad server from the
@@ -1027,6 +1028,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 		// Client endpoints
 		s.staticEndpoints.ClientStats = &ClientStats{srv: s, logger: s.logger.Named("client_stats")}
 		s.staticEndpoints.ClientAllocations = &ClientAllocations{srv: s, logger: s.logger.Named("client_allocs")}
+		s.staticEndpoints.ClientMeta = &ClientMeta{srv: s, logger: s.logger.Named("client_meta")}
 
 		// Streaming endpoints
 		s.staticEndpoints.FileSystem = &FileSystem{srv: s, logger: s.logger.Named("client_fs")}
@@ -1049,6 +1051,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 	s.staticEndpoints.Enterprise.Register(server)
 	server.Register(s.staticEndpoints.ClientStats)
 	server.Register(s.staticEndpoints.ClientAllocations)
+	server.Register(s.staticEndpoints.ClientMeta)
 	server.Register(s.staticEndpoints.FileSystem)
 
 	// Create new dynamic endpoints and add them to the RPC server.


### PR DESCRIPTION
## Summary

Nomad allows users to specify a map of metadata that can be associated with a
client. This metadata can then be interpolated in a job configuration, used for
scheduling decisions (as part of constraints, affinities, and spread), and is
displayed in the web ui.

This metadata is currently static, specified via the client configuration file,
and registered with the server during the initial connection, and _re-sent_ when
node updates propagate to the server.

This adds a _client_ api endpoint that allows users to dynamically update this
metadata, and maintains the client as the source of truth for metadata.

## Remaining Work

- Store and apply metadata diffs
- Docs (will file a seperate PR for these post-merge, and prior to the
release of 9.1)