### PR TITLE
ci: ignore background ping errors

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -5,7 +5,7 @@ export PING_SLEEP=60
 bash -c "while true; do echo \$(date) - building ...; sleep $PING_SLEEP; done" &
 PING_LOOP_PID=$!
 
-trap 'kill ${PING_LOOP_PID}' EXIT HUP INT QUIT TERM
+trap 'kill ${PING_LOOP_PID} || true' EXIT HUP INT QUIT TERM
 
 if [ "$RUN_STATIC_CHECKS" ]; then
     make check
@@ -17,5 +17,6 @@ fi
 NOMAD_SLOW_TEST=1 make test
 TEST_OUTPUT=$?
 
-kill $PING_LOOP_PID
+kill $PING_LOOP_PID || true
+
 exit $TEST_OUTPUT


### PR DESCRIPTION
If the background ping process dies before somehow, e.g. https://travis-ci.org/hashicorp/nomad/jobs/486050357, let's not fail the job.