### PR TITLE
Always populate task dir environment variables

### DIFF
--- a/client/allocrunner/taskrunner/task_dir_hook.go
+++ b/client/allocrunner/taskrunner/task_dir_hook.go
@@ -42,8 +42,8 @@ func (h *taskDirHook) Name() string {
 }
 
 func (h *taskDirHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
+	fsi := h.runner.driverCapabilities.FSIsolation
 	if v, ok := req.HookData[TaskDirHookIsDoneDataKey]; ok && v == "true" {
-		fsi := h.runner.driverCapabilities.FSIsolation
 		setEnvvars(h.runner.envBuilder, fsi, h.runner.taskDir, h.runner.clientConfig)
 		resp.HookData = map[string]string{
 			TaskDirHookIsDoneDataKey: "true",
@@ -61,7 +61,6 @@ func (h *taskDirHook) Prestart(ctx context.Context, req *interfaces.TaskPrestart
 	h.runner.EmitEvent(structs.NewTaskEvent(structs.TaskSetup).SetMessage(structs.TaskBuildingTaskDir))
 
 	// Build the task directory structure
-	fsi := h.runner.driverCapabilities.FSIsolation
 	err := h.runner.taskDir.Build(fsi == drivers.FSIsolationChroot, chroot)
 	if err != nil {
 		return err

--- a/client/state/08types.go
+++ b/client/state/08types.go
@@ -83,7 +83,11 @@ func (t *taskRunnerState08) Upgrade(allocID, taskName string) (*state.LocalState
 
 	// Upgrade task dir state
 	ls.Hooks["task_dir"] = &state.HookState{
-		PrestartDone: t.TaskDirBuilt,
+		Data: map[string]string{
+			// "is_done" is equivalent to task_dir_hook.TaskDirHookIsDoneKey
+			// Does not import to avoid import cycle
+			"is_done": fmt.Sprintf("%v", t.TaskDirBuilt),
+		},
 	}
 
 	// Upgrade dispatch payload state


### PR DESCRIPTION
Fixes an issue where if a task was restarted after restating the client,
the task dir environment variables would not be populated. This PR fixes
this for both upgrades from 0.8.X and for normal 0.9 restarts.