### PR TITLE
docs: fix job json example

### DIFF
--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -189,9 +189,9 @@ The table below shows this endpoint's support for
                 "Attempts": 10,
                 "Delay": 30000000000,
                 "DelayFunction": "exponential",
-                "Interval": 0,
+                "Interval": 36000000000000,
                 "MaxDelay": 3600000000000,
-                "Unlimited": true
+                "Unlimited": false
             },
             "EphemeralDisk": {
                 "SizeMB": 300
@@ -213,7 +213,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request POST \
-    --data @my-job.nomad \
+    --data @my-job.json \
     https://localhost:4646/v1/jobs
 ```
 


### PR DESCRIPTION
The internal needs to be long enough to accomodate the attempts.

Also, clarify that the input should be a json file rather than an hcl
`.nomad` one.


Without these changes, I get the following error:

```
$ curl     --request POST     --data @/tmp/payload-orig.json     http://localhost:4646/v1/jobs; echo
1 error(s) occurred:

* Task group cache validation failed: 1 error(s) occurred:

* 3 error(s) occurred:

* Interval must be a non zero value if Attempts > 0
* Reschedule Policy with Attempts = 10, Interval = 0s, and Unlimited = true is ambiguous
* If Attempts >0, Unlimited cannot also be set to true
```