### PR TITLE
UI: Always show an absolute timestamp tooltip when showing relative dates

### DIFF
--- a/ui/app/helpers/format-date.js
+++ b/ui/app/helpers/format-date.js
@@ -1,0 +1,9 @@
+import moment from 'moment';
+import Helper from '@ember/component/helper';
+
+export function formatTs([date]) {
+  const format = 'MMMM D, YYYY';
+  return moment(date).format(format);
+}
+
+export default Helper.helper(formatTs);

--- a/ui/app/helpers/format-month-ts.js
+++ b/ui/app/helpers/format-month-ts.js
@@ -1,0 +1,9 @@
+import moment from 'moment';
+import Helper from '@ember/component/helper';
+
+export function formatMonthTs([date]) {
+  const format = 'MMM DD HH:mm:ss ZZ';
+  return moment(date).format(format);
+}
+
+export default Helper.helper(formatMonthTs);

--- a/ui/app/helpers/format-ts.js
+++ b/ui/app/helpers/format-ts.js
@@ -1,0 +1,9 @@
+import moment from 'moment';
+import Helper from '@ember/component/helper';
+
+export function formatTs([date]) {
+  const format = "MMM DD, 'YY HH:mm:ss ZZ";
+  return moment(date).format(format);
+}
+
+export default Helper.helper(formatTs);

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -10,12 +10,12 @@
       <span class="label">Task Details</span>
       <span class="pair" data-test-started-at>
         <span class="term">Started At</span>
-        {{moment-format model.startedAt "MM/DD/YY HH:mm:ss"}}
+        {{format-ts model.startedAt}}
       </span>
       {{#if model.finishedAt}}
         <span class="pair">
           <span class="term">Finished At</span>
-          {{moment-format model.finishedAt "MM/DD/YY HH:mm:ss"}}
+          {{format-ts model.finishedAt}}
         </span>
       {{/if}}
       <span class="pair">
@@ -89,7 +89,7 @@
         {{/t.head}}
         {{#t.body as |row|}}
           <tr data-test-task-event>
-            <td data-test-task-event-time>{{moment-format row.model.time "MM/DD/YY HH:mm:ss"}}</td>
+            <td data-test-task-event-time>{{format-ts row.model.time}}</td>
             <td data-test-task-event-type>{{row.model.type}}</td>
             <td data-test-task-event-message>
               {{#if row.model.message}}

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -65,7 +65,7 @@
         {{#if model.drainStrategy.forceDeadline}}
           <span class="pair" data-test-drain-forced-deadline>
             <span class="term">Forced Deadline</span>
-            {{moment-format model.drainStrategy.forceDeadline "MM/DD/YY HH:mm:ss"}}
+            {{format-ts model.drainStrategy.forceDeadline}}
             ({{moment-from-now model.drainStrategy.forceDeadline interval=1000}})
           </span>
         {{/if}}
@@ -159,7 +159,7 @@
         {{/t.head}}
         {{#t.body as |row|}}
           <tr data-test-client-event>
-            <td data-test-client-event-time>{{moment-format row.model.time "MM/DD/YY HH:mm:ss"}}</td>
+            <td data-test-client-event-time>{{format-ts row.model.time}}</td>
             <td data-test-client-event-subsystem>{{row.model.subsystem}}</td>
             <td data-test-client-event-message>
               {{#if row.model.message}}
@@ -204,7 +204,7 @@
               <span class="is-pulled-right">
                 <span class="pair">
                   <span class="term">Last Updated</span>
-                  <span data-test-last-updated class="tooltip" aria-label="{{moment-format a.item.updateTime "MM/DD/YY HH:mm:ss"}}">
+                  <span data-test-last-updated class="tooltip" aria-label="{{format-ts a.item.updateTime}}">
                     {{moment-from-now a.item.updateTime interval=1000}}
                   </span>
                 </span>

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -204,7 +204,9 @@
               <span class="is-pulled-right">
                 <span class="pair">
                   <span class="term">Last Updated</span>
-                  <span data-test-last-updated>{{moment-from-now a.item.updateTime interval=1000}}</span>
+                  <span data-test-last-updated class="tooltip" aria-label="{{moment-format a.item.updateTime "MM/DD/YY HH:mm:ss"}}">
+                    {{moment-from-now a.item.updateTime interval=1000}}
+                  </span>
                 </span>
               </span>
             </div>

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -22,9 +22,9 @@
     {{/link-to}}
   </td>
 {{/if}}
-<td data-test-create-time>{{moment-format allocation.createTime "MM/DD HH:mm:ss"}}</td>
+<td data-test-create-time>{{format-month-ts allocation.createTime}}</td>
 <td data-test-modify-time>
-  <span class="tooltip" aria-label="{{moment-format allocation.modifyTime "MM/DD HH:mm:ss"}}">
+  <span class="tooltip" aria-label="{{format-month-ts allocation.modifyTime}}">
     {{moment-from-now allocation.modifyTime}}
   </span>
 </td>

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -23,7 +23,11 @@
   </td>
 {{/if}}
 <td data-test-create-time>{{moment-format allocation.createTime "MM/DD HH:mm:ss"}}</td>
-<td data-test-modify-time>{{moment-from-now allocation.modifyTime}}</td>
+<td data-test-modify-time>
+  <span class="tooltip" aria-label="{{moment-format allocation.modifyTime "MM/DD HH:mm:ss"}}">
+    {{moment-from-now allocation.modifyTime}}
+  </span>
+</td>
 <td data-test-client-status class="is-one-line">
   <span class="color-swatch {{allocation.clientStatus}}" /> {{allocation.clientStatus}}
 </td>

--- a/ui/app/templates/components/freestyle/sg-inline-definitions.hbs
+++ b/ui/app/templates/components/freestyle/sg-inline-definitions.hbs
@@ -12,7 +12,7 @@
       </span>
       <span class="pair">
         <span class="term">Last Updated</span>
-        <span>{{moment-format (now)}}</span>
+        <span>{{format-ts (now)}}</span>
       </span>
     </div>
   </div>
@@ -31,7 +31,7 @@
       </span>
       <span class="pair">
         <span class="term">Last Updated</span>
-        <span>{{moment-format (now)}}</span>
+        <span>{{format-ts (now)}}</span>
       </span>
     </div>
   </div>
@@ -44,7 +44,7 @@
       </span>
       <span class="pair">
         <span class="term">Last Updated</span>
-        <span>{{moment-format (now)}}</span>
+        <span>{{format-ts (now)}}</span>
       </span>
     </div>
   </div>
@@ -57,7 +57,7 @@
       </span>
       <span class="pair">
         <span class="term">Last Updated</span>
-        <span>{{moment-format (now)}}</span>
+        <span>{{format-ts (now)}}</span>
       </span>
     </div>
   </div>
@@ -70,7 +70,7 @@
       </span>
       <span class="pair">
         <span class="term">Last Updated</span>
-        <span>{{moment-format (now)}}</span>
+        <span>{{format-ts (now)}}</span>
       </span>
     </div>
   </div>

--- a/ui/app/templates/components/freestyle/sg-timeline.hbs
+++ b/ui/app/templates/components/freestyle/sg-timeline.hbs
@@ -1,7 +1,7 @@
 {{#freestyle-usage 'timeline' title="Simple Timeline"}}
   <ol class="timeline">
     <li class="timeline-note">
-      {{moment-format yesterday "MMMM D, YYYY"}}
+      {{format-date yesterday}}
     </li>
     <li class="timeline-object">
       <div class="boxed-section">
@@ -18,7 +18,7 @@
       </div>
     </li>
     <li class="timeline-note">
-      {{moment-format today "MMMM D, YYYY"}}
+      {{format-date today}}
     </li>
     <li class="timeline-object">
       <div class="boxed-section">
@@ -38,7 +38,7 @@
 {{#freestyle-usage 'timeline-intricate' title="Detailed Timeline"}}
   <ol class="timeline">
     <li class="timeline-note">
-      {{moment-format today "MMMM D, YYYY"}}
+      {{format-date today}}
     </li>
     <li class="timeline-object">
       <div class="boxed-section">
@@ -50,7 +50,7 @@
           </span>
           <span class="bumper-left pair is-faded">
             <span class="term">Submitted</span>
-            <span class="tooltip" aria-label="{{moment-format (now) "MM/DD HH:mm:ss"}}">{{moment-from-now (now)}}</span>
+            <span class="tooltip" aria-label="{{format-month-ts (now)}}">{{moment-from-now (now)}}</span>
           </span>
         </div>
       </div>
@@ -65,13 +65,13 @@
           </span>
           <span class="bumper-left pair is-faded">
             <span class="term">Submitted</span>
-            <span>{{moment-format yesterday "MM/DD HH:mm:ss"}}</span>
+            <span>{{format-month-ts yesterday}}</span>
           </span>
         </div>
       </div>
     </li>
     <li class="timeline-note">
-      {{moment-format yesterday "MMMM D, YYYY"}}
+      {{format-date yesterday}}
     </li>
     <li class="timeline-object">
       <div class="boxed-section">
@@ -83,7 +83,7 @@
           </span>
           <span class="bumper-left pair is-faded">
             <span class="term">Submitted</span>
-            <span>{{moment-format yesterday "MM/DD HH:mm:ss"}}</span>
+            <span>{{format-month-ts yesterday}}</span>
           </span>
         </div>
       </div>
@@ -94,7 +94,7 @@
 {{#freestyle-usage 'timeline-toggles' title='Toggling Timeline Objects'}}
   <ol class="timeline">
     <li class="timeline-note">
-      {{moment-format today "MMMM D, YYYY"}}
+      {{format-date today}}
     </li>
     <li class="timeline-object">
       <div class="boxed-section">
@@ -118,7 +118,7 @@
       </div>
     </li>
     <li class="timeline-note">
-      {{moment-format yesterday "MMMM D, YYYY"}}
+      {{format-date yesterday}}
     </li>
     <li class="timeline-object">
       <div class="boxed-section">
@@ -147,7 +147,7 @@
 {{#freestyle-usage 'timeline-emphasis' title='Emphasizing a Timeline Object'}}
   <ol class="timeline">
     <li class="timeline-note">
-      {{moment-format today "MMMM D, YYYY"}}
+      {{format-date today}}
     </li>
     <li class="timeline-object">
       <div class="boxed-section">
@@ -158,7 +158,7 @@
           </span>
           <span class="bumper-left pair is-faded">
             <span class="term">Submitted</span>
-            <span>{{moment-from-now (now)}}</span>
+            <span class="tooltip" aria-label="{{format-ts (now)}}">{{moment-from-now (now)}}</span>
           </span>
         </div>
       </div>
@@ -175,13 +175,13 @@
           </span>
           <span class="bumper-left pair is-faded">
             <span class="term">Submitted</span>
-            <span>{{moment-format yesterday}}</span>
+            <span>{{format-ts yesterday}}</span>
           </span>
         </div>
       </div>
     </li>
     <li class="timeline-note">
-      {{moment-format yesterday "MMMM D, YYYY"}}
+      {{format-date yesterday}}
     </li>
     <li class="timeline-object">
       <div class="boxed-section">
@@ -192,7 +192,7 @@
           </span>
           <span class="bumper-left pair is-faded">
             <span class="term">Submitted</span>
-            <span>{{moment-format yesterday}}</span>
+            <span>{{format-ts yesterday}}</span>
           </span>
         </div>
       </div>

--- a/ui/app/templates/components/freestyle/sg-timeline.hbs
+++ b/ui/app/templates/components/freestyle/sg-timeline.hbs
@@ -50,7 +50,7 @@
           </span>
           <span class="bumper-left pair is-faded">
             <span class="term">Submitted</span>
-            <span>{{moment-from-now (now)}}</span>
+            <span class="tooltip" aria-label="{{moment-format (now) "MM/DD HH:mm:ss"}}">{{moment-from-now (now)}}</span>
           </span>
         </div>
       </div>
@@ -65,7 +65,7 @@
           </span>
           <span class="bumper-left pair is-faded">
             <span class="term">Submitted</span>
-            <span>{{moment-format yesterday}}</span>
+            <span>{{moment-format yesterday "MM/DD HH:mm:ss"}}</span>
           </span>
         </div>
       </div>
@@ -83,7 +83,7 @@
           </span>
           <span class="bumper-left pair is-faded">
             <span class="term">Submitted</span>
-            <span>{{moment-format yesterday}}</span>
+            <span>{{moment-format yesterday "MM/DD HH:mm:ss"}}</span>
           </span>
         </div>
       </div>

--- a/ui/app/templates/components/job-deployment.hbs
+++ b/ui/app/templates/components/job-deployment.hbs
@@ -9,7 +9,7 @@
       <span class="term">Version</span>
       <span class="has-emphasis" data-test-deployment-version>#{{deployment.version.number}}</span>
       <span data-test-deployment-submit-time>|
-        <span class="tooltip" aria-label="{{moment-format deployment.version.submitTime "MM/DD/YY HH:mm:ss"}}">
+        <span class="tooltip" aria-label="{{format-ts deployment.version.submitTime}}">
           {{moment-from-now deployment.version.submitTime}}
         </span>
       </span>

--- a/ui/app/templates/components/job-deployment.hbs
+++ b/ui/app/templates/components/job-deployment.hbs
@@ -8,7 +8,11 @@
     <span class="pair is-faded">
       <span class="term">Version</span>
       <span class="has-emphasis" data-test-deployment-version>#{{deployment.version.number}}</span>
-      <span data-test-deployment-submit-time>| {{moment-from-now deployment.version.submitTime}}</span>
+      <span data-test-deployment-submit-time>|
+        <span class="tooltip" aria-label="{{moment-format deployment.version.submitTime "MM/DD/YY HH:mm:ss"}}">
+          {{moment-from-now deployment.version.submitTime}}
+        </span>
+      </span>
     </span>
     <button data-test-deployment-toggle-details class="button is-light is-compact pull-right" {{action (toggle "isOpen" this)}}>details</button>
  </span>

--- a/ui/app/templates/components/job-deployment/task-groups.hbs
+++ b/ui/app/templates/components/job-deployment/task-groups.hbs
@@ -32,7 +32,7 @@
           <td data-test-deployment-task-group-healthy>{{row.model.healthyAllocs}}</td>
           <td data-test-deployment-task-group-unhealthy>{{row.model.unhealthyAllocs}}</td>
           <td data-test-deployment-task-group-progress-deadline>
-            <span class="nowrap">{{moment-format row.model.requireProgressBy "MM/DD/YY HH:mm:ss"}}</span>
+            <span class="nowrap">{{format-ts row.model.requireProgressBy}}</span>
           </td>
         </tr>
       {{/t.body}}

--- a/ui/app/templates/components/job-deployments-stream.hbs
+++ b/ui/app/templates/components/job-deployments-stream.hbs
@@ -2,7 +2,7 @@
   {{#if record.meta.showDate}}
     <li data-test-deployment-time class="timeline-note">
       {{#if record.deployment.version.submitTime}}
-        {{moment-format record.deployment.version.submitTime "MMMM D, YYYY"}}
+        {{format-date record.deployment.version.submitTime}}
       {{else}}
         Unknown time
       {{/if}}

--- a/ui/app/templates/components/job-page/parts/latest-deployment.hbs
+++ b/ui/app/templates/components/job-page/parts/latest-deployment.hbs
@@ -5,7 +5,7 @@
         {{if job.latestDeployment.isRunning "Active" "Latest"}} Deployment
         <span class="badge is-white {{if job.latestDeployment.isRunning "is-subtle"}} bumper-left" data-test-active-deployment-stat="id">{{job.latestDeployment.shortId}}</span>
         {{#if job.latestDeployment.version.submitTime}}
-          <span class="pull-right submit-time tooltip" data-test-active-deployment-stat="submit-time" aria-label="{{moment-format job.latestDeployment.version.submitTime "MM/DD/YY HH:mm:ss"}}">
+          <span class="pull-right submit-time tooltip" data-test-active-deployment-stat="submit-time" aria-label="{{format-ts job.latestDeployment.version.submitTime}}">
             {{moment-from-now job.latestDeployment.version.submitTime}}
           </span>
         {{/if}}

--- a/ui/app/templates/components/job-page/parts/latest-deployment.hbs
+++ b/ui/app/templates/components/job-page/parts/latest-deployment.hbs
@@ -5,7 +5,9 @@
         {{if job.latestDeployment.isRunning "Active" "Latest"}} Deployment
         <span class="badge is-white {{if job.latestDeployment.isRunning "is-subtle"}} bumper-left" data-test-active-deployment-stat="id">{{job.latestDeployment.shortId}}</span>
         {{#if job.latestDeployment.version.submitTime}}
-          <span class="pull-right submit-time" data-test-active-deployment-stat="submit-time">{{moment-from-now job.latestDeployment.version.submitTime}}</span>
+          <span class="pull-right submit-time tooltip" data-test-active-deployment-stat="submit-time" aria-label="{{moment-format job.latestDeployment.version.submitTime "MM/DD/YY HH:mm:ss"}}">
+            {{moment-from-now job.latestDeployment.version.submitTime}}
+          </span>
         {{/if}}
       </div>
       <div class="boxed-section-row">

--- a/ui/app/templates/components/job-version.hbs
+++ b/ui/app/templates/components/job-version.hbs
@@ -6,7 +6,7 @@
   </span>
   <span class="pair is-faded">
     <span class="term">Submitted</span>
-    <span data-test-version-submit-time class="submit-date">{{moment-format version.submitTime "MM/DD/YY HH:mm:ss"}}</span>
+    <span data-test-version-submit-time class="submit-date">{{format-ts version.submitTime}}</span>
   </span>
   {{#if version.diff}}
     <button class="button is-light is-compact pull-right" {{action "toggleDiff"}}>{{changeCount}} {{pluralize "Change" changeCount}}</button>

--- a/ui/app/templates/components/job-versions-stream.hbs
+++ b/ui/app/templates/components/job-versions-stream.hbs
@@ -1,7 +1,7 @@
 {{#each annotatedVersions key="version.id" as |record|}}
   {{#if record.meta.showDate}}
     <li data-test-version-time class="timeline-note">
-      {{moment-format record.version.submitTime "MMMM D, YYYY"}}
+      {{format-date record.version.submitTime}}
     </li>
   {{/if}}
   <li data-test-version class="timeline-object">

--- a/ui/app/templates/components/reschedule-event-row.hbs
+++ b/ui/app/templates/components/reschedule-event-row.hbs
@@ -2,7 +2,7 @@
   {{#if label}}
     <strong data-test-reschedule-label>{{label}}</strong>
   {{/if}}
-  {{moment-format time "MMMM D, YYYY HH:mm:ss"}}
+  {{format-ts time}}
 </li>
 <li class="timeline-object" data-test-allocation={{allocation.id}}>
   <div class="boxed-section">

--- a/ui/app/templates/components/reschedule-event-timeline.hbs
+++ b/ui/app/templates/components/reschedule-event-timeline.hbs
@@ -13,7 +13,7 @@
   {{#if (and allocation.followUpEvaluation.waitUntil (not allocation.nextAllocation))}}
     <li class="timeline-note" data-test-attempt-notice>
       {{x-icon "clock" class="is-info is-text"}} Nomad will attempt to reschedule
-      <span class="tooltip" aria-label="{{moment-format allocation.followUpEvaluation.waitUntil "MM/DD HH:mm:ss"}}">
+      <span class="tooltip" aria-label="{{format-ts allocation.followUpEvaluation.waitUntil}}">
         {{moment-from-now allocation.followUpEvaluation.waitUntil interval=1000}}
       </span>
     </li>

--- a/ui/app/templates/components/reschedule-event-timeline.hbs
+++ b/ui/app/templates/components/reschedule-event-timeline.hbs
@@ -13,7 +13,9 @@
   {{#if (and allocation.followUpEvaluation.waitUntil (not allocation.nextAllocation))}}
     <li class="timeline-note" data-test-attempt-notice>
       {{x-icon "clock" class="is-info is-text"}} Nomad will attempt to reschedule
-      {{moment-from-now allocation.followUpEvaluation.waitUntil interval=1000}}
+      <span class="tooltip" aria-label="{{moment-format allocation.followUpEvaluation.waitUntil "MM/DD HH:mm:ss"}}">
+        {{moment-from-now allocation.followUpEvaluation.waitUntil interval=1000}}
+      </span>
     </li>
   {{/if}}
   {{reschedule-event-row

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -18,7 +18,7 @@
     <em>No message</em>
   {{/if}}
 </td>
-<td data-test-time>{{moment-format task.events.lastObject.time "MM/DD/YY HH:mm:ss"}}</td>
+<td data-test-time>{{format-ts task.events.lastObject.time}}</td>
 <td data-test-ports>
   <ul>
     {{#with task.resources.networks.firstObject as |network|}}

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -95,7 +95,7 @@ test('each task row should list high-level information for the task', function(a
   assert.equal(taskRow.message, event.displayMessage, 'Event Message');
   assert.equal(
     taskRow.time,
-    moment(event.time / 1000000).format('MM/DD/YY HH:mm:ss'),
+    moment(event.time / 1000000).format("MMM DD, 'YY HH:mm:ss ZZ"),
     'Event Time'
   );
 

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -141,7 +141,7 @@ test('each allocation should have high-level details for the allocation', functi
     assert.equal(allocationRow.shortId, allocation.id.split('-')[0], 'Allocation short ID');
     assert.equal(
       allocationRow.createTime,
-      moment(allocation.createTime / 1000000).format('MM/DD HH:mm:ss'),
+      moment(allocation.createTime / 1000000).format('MMM DD HH:mm:ss ZZ'),
       'Allocation create time'
     );
     assert.equal(
@@ -319,7 +319,11 @@ test('each node event shows basic node event information', function(assert) {
 
   andThen(() => {
     const eventRow = ClientDetail.events.objectAt(0);
-    assert.equal(eventRow.time, moment(event.time).format('MM/DD/YY HH:mm:ss'), 'Event timestamp');
+    assert.equal(
+      eventRow.time,
+      moment(event.time).format("MMM DD, 'YY HH:mm:ss ZZ"),
+      'Event timestamp'
+    );
     assert.equal(eventRow.subsystem, event.subsystem, 'Event subsystem');
     assert.equal(eventRow.message, event.message, 'Event message');
   });
@@ -452,7 +456,7 @@ test('when the node has a drain strategy with a positive deadline, the drain sta
     );
 
     assert.ok(
-      ClientDetail.drain.forcedDeadline.includes(forceDeadline.format('MM/DD/YY HH:mm:ss')),
+      ClientDetail.drain.forcedDeadline.includes(forceDeadline.format("MMM DD, 'YY HH:mm:ss ZZ")),
       'Force deadline is shown as an absolute date'
     );
 

--- a/ui/tests/acceptance/job-deployments-test.js
+++ b/ui/tests/acceptance/job-deployments-test.js
@@ -204,7 +204,7 @@ test('when open, a deployment shows a list of all task groups and their respecti
       assert.equal(taskGroupRow.unhealthy, taskGroup.unhealthyAllocs, 'Unhealthy Allocs');
       assert.equal(
         taskGroupRow.progress,
-        moment(taskGroup.requireProgressBy).format('MM/DD/YY HH:mm:ss'),
+        moment(taskGroup.requireProgressBy).format("MMM DD, 'YY HH:mm:ss ZZ"),
         'Progress By'
       );
     });

--- a/ui/tests/acceptance/job-versions-test.js
+++ b/ui/tests/acceptance/job-versions-test.js
@@ -21,7 +21,9 @@ test('/jobs/:id/versions should list all job versions', function(assert) {
 
 test('each version mentions the version number, the stability, and the submitted time', function(assert) {
   const version = versions.sortBy('submitTime').reverse()[0];
-  const formattedSubmitTime = moment(version.submitTime / 1000000).format('MM/DD/YY HH:mm:ss');
+  const formattedSubmitTime = moment(version.submitTime / 1000000).format(
+    "MMM DD, 'YY HH:mm:ss ZZ"
+  );
   const versionRow = Versions.versions.objectAt(0);
 
   assert.ok(versionRow.text.includes(`Version #${version.version}`), 'Version #');

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -24,7 +24,7 @@ test('/allocation/:id/:task_name should name the task and list high-level task i
   assert.ok(Task.state.includes(task.state), 'Task state');
 
   assert.ok(
-    Task.startedAt.includes(moment(task.startedAt).format('MM/DD/YY HH:mm:ss')),
+    Task.startedAt.includes(moment(task.startedAt).format("MMM DD, 'YY HH:mm:ss ZZ")),
     'Task started at'
   );
 });
@@ -142,7 +142,7 @@ test('each recent event should list the time, type, and description of the event
 
   assert.equal(
     recentEvent.time,
-    moment(event.time / 1000000).format('MM/DD/YY HH:mm:ss'),
+    moment(event.time / 1000000).format("MMM DD, 'YY HH:mm:ss ZZ"),
     'Event timestamp'
   );
   assert.equal(recentEvent.type, event.type, 'Event type');

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -148,7 +148,7 @@ test('each allocation should show basic information about the allocation', funct
     assert.equal(allocationRow.shortId, allocation.id.split('-')[0], 'Allocation short id');
     assert.equal(
       allocationRow.createTime,
-      moment(allocation.createTime / 1000000).format('MM/DD HH:mm:ss'),
+      moment(allocation.createTime / 1000000).format('MMM DD HH:mm:ss ZZ'),
       'Allocation create time'
     );
     assert.equal(

--- a/ui/tests/integration/job-page/parts/latest-deployment-test.js
+++ b/ui/tests/integration/job-page/parts/latest-deployment-test.js
@@ -194,7 +194,7 @@ test('each task group in the expanded task group section shows task group detail
         assert.equal(findForTaskGroup('name').textContent.trim(), task.get('name'));
         assert.equal(
           findForTaskGroup('progress-deadline').textContent.trim(),
-          moment(task.get('requireProgressBy')).format('MM/DD/YY HH:mm:ss')
+          moment(task.get('requireProgressBy')).format("MMM DD, 'YY HH:mm:ss ZZ")
         );
       });
   });


### PR DESCRIPTION
It looks like this:

![image](https://user-images.githubusercontent.com/174740/52036163-3e1f7000-24e1-11e9-9c4b-9dbc3cfb6461.png)
