### PR TITLE
nomad/command: fix strings.Contains args order

### DIFF
--- a/command/job_init_test.go
+++ b/command/job_init_test.go
@@ -81,7 +81,7 @@ func TestInitCommand_defaultJob(t *testing.T) {
 	// Ensure the job file is always written with spaces instead of tabs. Since
 	// the default job file is embedded in the go file, it's easy for tabs to
 	// slip in.
-	if strings.Contains("\t", defaultJob) {
+	if strings.Contains(defaultJob, "\t") {
 		t.Error("default job contains tab character - please convert to spaces")
 	}
 }


### PR DESCRIPTION
Swapped call args order to meet the expected behavior.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>