### PR TITLE
Docker: Fix logging config parsing

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -11,7 +11,6 @@ import (
 	metrics "github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hcldec"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
@@ -620,12 +619,7 @@ func (tr *TaskRunner) runDriver() error {
 		tr.logger.Warn("some environment variables not available for rendering", "keys", strings.Join(keys, ", "))
 	}
 
-	evalCtx := &hcl.EvalContext{
-		Variables: vars,
-		Functions: hclutils.GetStdlibFuncs(),
-	}
-
-	val, diag := hclutils.ParseHclInterface(tr.task.Config, tr.taskSchema, evalCtx)
+	val, diag := hclutils.ParseHclInterface(tr.task.Config, tr.taskSchema, vars)
 	if diag.HasErrors() {
 		return multierror.Append(errors.New("failed to parse config"), diag.Errs()...)
 	}

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -533,8 +533,11 @@ func (c *ServiceClient) sync() error {
 		}
 	}
 
-	c.logger.Debug("sync complete", "registered_services", sreg, "deregistered_services", sdereg,
-		"registered_checks", creg, "deregistered_checks", cdereg)
+	// Only log if something was actually synced
+	if sreg > 0 || sdereg > 0 || creg > 0 || cdereg > 0 {
+		c.logger.Debug("sync complete", "registered_services", sreg, "deregistered_services", sdereg,
+			"registered_checks", creg, "deregistered_checks", cdereg)
+	}
 	return nil
 }
 

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -253,7 +253,7 @@ var (
 		"ipv6_address":       hclspec.NewAttr("ipv6_address", "string", false),
 		"labels":             hclspec.NewBlockAttrs("labels", "string", false),
 		"load":               hclspec.NewAttr("load", "string", false),
-		"logging": hclspec.NewBlockSet("logging", hclspec.NewObject(map[string]*hclspec.Spec{
+		"logging": hclspec.NewBlock("logging", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"type":   hclspec.NewAttr("type", "string", false),
 			"config": hclspec.NewBlockAttrs("config", "string", false),
 		})),

--- a/helper/pluginutils/hclutils/util.go
+++ b/helper/pluginutils/hclutils/util.go
@@ -15,8 +15,14 @@ import (
 )
 
 // ParseHclInterface is used to convert an interface value representing a hcl2
-// body and return the interpolated value.
-func ParseHclInterface(val interface{}, spec hcldec.Spec, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+// body and return the interpolated value. Vars may be nil if there are no
+// variables to interpolate.
+func ParseHclInterface(val interface{}, spec hcldec.Spec, vars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+	evalCtx := &hcl.EvalContext{
+		Variables: vars,
+		Functions: GetStdlibFuncs(),
+	}
+
 	// Encode to json
 	var buf bytes.Buffer
 	enc := codec.NewEncoder(&buf, structs.JsonHandle)
@@ -37,7 +43,7 @@ func ParseHclInterface(val interface{}, spec hcldec.Spec, ctx *hcl.EvalContext) 
 		return cty.NilVal, diag
 	}
 
-	value, decDiag := hcldec.Decode(hclFile.Body, spec, ctx)
+	value, decDiag := hcldec.Decode(hclFile.Body, spec, evalCtx)
 	diag = diag.Extend(decDiag)
 	if diag.HasErrors() {
 		return cty.NilVal, diag

--- a/helper/pluginutils/hclutils/util_test.go
+++ b/helper/pluginutils/hclutils/util_test.go
@@ -356,6 +356,8 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 						"tag": "driver-test",
 					},
 				},
+				Devices: []docker.DockerDevice{},
+				Mounts:  []docker.DockerMount{},
 			},
 			expectedType: &docker.TaskConfig{},
 		},

--- a/helper/pluginutils/loader/init.go
+++ b/helper/pluginutils/loader/init.go
@@ -10,20 +10,11 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	plugin "github.com/hashicorp/go-plugin"
 	version "github.com/hashicorp/go-version"
-	hcl2 "github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclspecutils"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/zclconf/go-cty/cty/msgpack"
-)
-
-var (
-	// configParseCtx is the context used to parse a plugin's configuration
-	// stanza
-	configParseCtx = &hcl2.EvalContext{
-		Functions: hclutils.GetStdlibFuncs(),
-	}
 )
 
 // validateConfig returns whether or not the configuration is valid
@@ -466,7 +457,7 @@ func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) error
 	}
 
 	// Parse the config using the spec
-	val, diag := hclutils.ParseHclInterface(info.config, spec, configParseCtx)
+	val, diag := hclutils.ParseHclInterface(info.config, spec, nil)
 	if diag.HasErrors() {
 		multierror.Append(&mErr, diag.Errs()...)
 		return multierror.Prefix(&mErr, "failed parsing config:")

--- a/plugins/shared/cmd/launcher/command/device.go
+++ b/plugins/shared/cmd/launcher/command/device.go
@@ -14,7 +14,6 @@ import (
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
-	hcl2 "github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hcldec"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclspecutils"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
@@ -197,11 +196,7 @@ func (c *Device) setConfig(spec hcldec.Spec, apiVersion string, config []byte, n
 
 	c.logger.Trace("raw hcl config", "config", hclog.Fmt("% #v", pretty.Formatter(configVal)))
 
-	ctx := &hcl2.EvalContext{
-		Functions: hclutils.GetStdlibFuncs(),
-	}
-
-	val, diag := hclutils.ParseHclInterface(configVal, spec, ctx)
+	val, diag := hclutils.ParseHclInterface(configVal, spec, nil)
 	if diag.HasErrors() {
 		errStr := "failed to parse config"
 		for _, err := range diag.Errs() {


### PR DESCRIPTION
0.9.0beta2 bug in parsing Docker `logging` configs reported in: https://groups.google.com/d/topic/nomad-tool/B3Uo6Kns2BI/discussion

The fix was to switch the `logging` spec from a `NewBlockSet` to a `NewBlock`.

PR also includes:

* 08864d5 - hijacked existing test that didn't seem very valid to test this bug.
  * @nickethier Does hijacking this test here seem appropriate or should this live in the Docker driver itself? I think we need a lot more tests of this style (task config parsing), so it'd be nice to figure out a _Right Way_ of doing it.
* 645c8c4 - debug log line to allow timing alloc update application
* 3e52a6a - stops some periodic consul logging if nothing was actually changed
* 1d17fbc - small api simplification while tracking down bug

Linux AMD64 build:
[nomad-linux_amd64-5a8d9552.gz](https://github.com/hashicorp/nomad/files/2829463/nomad-linux_amd64-5a8d9552.gz)
