### PR TITLE
Issue #4649: Remove the systemd process and threads limit

### DIFF
--- a/dist/systemd/nomad.service
+++ b/dist/systemd/nomad.service
@@ -19,6 +19,7 @@ RestartSec=2
 StartLimitBurst=3
 StartLimitIntervalSec=10
 LimitNOFILE=65536
+TasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd limits the number of process and threads you can create within the cgroup it creates for a given service. This is especially limiting if you have a high number of keys Nomad watches from Consul.

Fixes #4649