### PR TITLE
Fix executable check on windows

### DIFF
--- a/helper/pluginutils/loader/filter_windows.go
+++ b/helper/pluginutils/loader/filter_windows.go
@@ -9,7 +9,7 @@ import (
 
 // On windows, an executable can be any file with any extension. To avoid
 // introspecting the file, here we skip executability checks on windows systems
-// and simply check for the convention of an `exe` extension.
+// and simply check for the convention of an `.exe` extension.
 func executable(path string, s os.FileInfo) bool {
-	return filepath.Ext(path) == "exe"
+	return filepath.Ext(path) == ".exe"
 }


### PR DESCRIPTION
path/filepath.Ext(path) returns the '.' with the extension