### PR TITLE
Fix Consul Service PreKill Hook

### DIFF
--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -140,7 +140,7 @@ func (h *serviceHook) Update(ctx context.Context, req *interfaces.TaskUpdateRequ
 	return h.consul.UpdateTask(oldTaskServices, newTaskServices)
 }
 
-func (h *serviceHook) Killing(ctx context.Context, req *interfaces.TaskPreKillRequest, resp *interfaces.TaskPreKillResponse) error {
+func (h *serviceHook) PreKilling(ctx context.Context, req *interfaces.TaskPreKillRequest, resp *interfaces.TaskPreKillResponse) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 

--- a/client/allocrunner/taskrunner/service_hook_test.go
+++ b/client/allocrunner/taskrunner/service_hook_test.go
@@ -3,10 +3,17 @@ package taskrunner
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/require"
 )
+
+// Statically assert the stats hook implements the expected interfaces
+var _ interfaces.TaskPoststartHook = (*serviceHook)(nil)
+var _ interfaces.TaskExitedHook = (*serviceHook)(nil)
+var _ interfaces.TaskPreKillHook = (*serviceHook)(nil)
+var _ interfaces.TaskUpdateHook = (*serviceHook)(nil)
 
 // TestTaskRunner_ServiceHook_InterpolateServices asserts that all service
 // and check fields are properly interpolated.

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -462,7 +462,7 @@ func (tr *TaskRunner) preKill() {
 		var start time.Time
 		if tr.logger.IsTrace() {
 			start = time.Now()
-			tr.logger.Trace("running kill hook", "name", name, "start", start)
+			tr.logger.Trace("running prekill hook", "name", name, "start", start)
 		}
 
 		// Run the pre kill hook
@@ -470,14 +470,14 @@ func (tr *TaskRunner) preKill() {
 		var resp interfaces.TaskPreKillResponse
 		if err := killHook.PreKilling(context.Background(), &req, &resp); err != nil {
 			tr.emitHookError(err, name)
-			tr.logger.Error("kill hook failed", "name", name, "error", err)
+			tr.logger.Error("prekill hook failed", "name", name, "error", err)
 		}
 
 		// No need to persist as TaskKillResponse is currently empty
 
 		if tr.logger.IsTrace() {
 			end := time.Now()
-			tr.logger.Trace("finished kill hook", "name", name, "end", end, "duration", end.Sub(start))
+			tr.logger.Trace("finished prekill hook", "name", name, "end", end, "duration", end.Sub(start))
 		}
 	}
 }

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -835,7 +835,7 @@ func TestTaskRunner_BlockForVault(t *testing.T) {
 	// Check the token was revoked
 	testutil.WaitForResult(func() (bool, error) {
 		if len(vaultClient.StoppedTokens()) != 1 {
-			return false, fmt.Errorf("Expected a stopped token: %v", vaultClient.StoppedTokens())
+			return false, fmt.Errorf("Expected a stopped token %q but found: %v", token, vaultClient.StoppedTokens())
 		}
 
 		if a := vaultClient.StoppedTokens()[0]; a != token {

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -468,7 +468,7 @@ func TestTaskRunner_ShutdownDelay(t *testing.T) {
 	}
 
 	// No shutdown escape hatch for this delay, so don't set it too high
-	task.ShutdownDelay = 500 * time.Duration(testutil.TestMultiplier()) * time.Millisecond
+	task.ShutdownDelay = 1000 * time.Duration(testutil.TestMultiplier()) * time.Millisecond
 
 	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
 	defer cleanup()

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -817,7 +817,7 @@ func TestTaskRunner_BlockForVault(t *testing.T) {
 	// with 0 sleeping.
 	select {
 	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+	case <-time.After(15 * time.Second * time.Duration(testutil.TestMultiplier())):
 		require.Fail(t, "timed out waiting for batch task to exit")
 	}
 

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -767,6 +767,83 @@ func TestTaskRunner_CheckWatcher_Restart(t *testing.T) {
 	require.True(t, state.Failed, pretty.Sprint(state))
 }
 
+// TestTaskRunner_BlockForVault asserts tasks do not start until a vault token
+// is derived.
+func TestTaskRunner_BlockForVault(t *testing.T) {
+	t.Parallel()
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Config = map[string]interface{}{
+		"run_for": "0s",
+	}
+	task.Vault = &structs.Vault{Policies: []string{"default"}}
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
+	defer cleanup()
+
+	// Control when we get a Vault token
+	token := "1234"
+	waitCh := make(chan struct{})
+	handler := func(*structs.Allocation, []string) (map[string]string, error) {
+		<-waitCh
+		return map[string]string{task.Name: token}, nil
+	}
+	vaultClient := conf.Vault.(*vaultclient.MockVaultClient)
+	vaultClient.DeriveTokenFn = handler
+
+	tr, err := NewTaskRunner(conf)
+	require.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+
+	// Assert TR blocks on vault token (does *not* exit)
+	select {
+	case <-tr.WaitCh():
+		require.Fail(t, "tr exited before vault unblocked")
+	case <-time.After(1 * time.Second):
+	}
+
+	// Assert task state is still Pending
+	require.Equal(t, structs.TaskStatePending, tr.TaskState().State)
+
+	// Unblock vault token
+	close(waitCh)
+
+	// TR should exit now that it's unblocked by vault as its a batch job
+	// with 0 sleeping.
+	select {
+	case <-tr.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		require.Fail(t, "timed out waiting for batch task to exit")
+	}
+
+	// Assert task exited successfully
+	finalState := tr.TaskState()
+	require.Equal(t, structs.TaskStateDead, finalState.State)
+	require.False(t, finalState.Failed)
+
+	// Check that the token is on disk
+	tokenPath := filepath.Join(conf.TaskDir.SecretsDir, vaultTokenFile)
+	data, err := ioutil.ReadFile(tokenPath)
+	require.NoError(t, err)
+	require.Equal(t, token, string(data))
+
+	// Check the token was revoked
+	testutil.WaitForResult(func() (bool, error) {
+		if len(vaultClient.StoppedTokens()) != 1 {
+			return false, fmt.Errorf("Expected a stopped token: %v", vaultClient.StoppedTokens())
+		}
+
+		if a := vaultClient.StoppedTokens()[0]; a != token {
+			return false, fmt.Errorf("got stopped token %q; want %q", a, token)
+		}
+		return true, nil
+	}, func(err error) {
+		require.Fail(t, err.Error())
+	})
+}
+
 // testWaitForTaskToStart waits for the task to be running or fails the test
 func testWaitForTaskToStart(t *testing.T, tr *TaskRunner) {
 	testutil.WaitForResult(func() (bool, error) {


### PR DESCRIPTION
...and port a bunch of tests from 0.8. All passing with `-race` enabled.