### PR TITLE
drivers: restore port_map old json support

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -292,7 +292,7 @@ var (
 		"readonly_rootfs": hclspec.NewAttr("readonly_rootfs", "bool", false),
 		"security_opt":    hclspec.NewAttr("security_opt", "list(string)", false),
 		"shm_size":        hclspec.NewAttr("shm_size", "number", false),
-		"storage_opt":     hclspec.NewAttr("storage_opt", "list(map(string))", false),
+		"storage_opt":     hclspec.NewBlockAttrs("storage_opt", "string", false),
 		"sysctl":          hclspec.NewAttr("sysctl", "list(map(string))", false),
 		"tty":             hclspec.NewAttr("tty", "bool", false),
 		"ulimit":          hclspec.NewAttr("ulimit", "list(map(string))", false),
@@ -349,7 +349,7 @@ type TaskConfig struct {
 	ReadonlyRootfs    bool               `codec:"readonly_rootfs"`
 	SecurityOpt       []string           `codec:"security_opt"`
 	ShmSize           int64              `codec:"shm_size"`
-	StorageOpt        hclutils.MapStrStr `codec:"storage_opt"`
+	StorageOpt        map[string]string  `codec:"storage_opt"`
 	Sysctl            hclutils.MapStrStr `codec:"sysctl"`
 	TTY               bool               `codec:"tty"`
 	Ulimit            hclutils.MapStrStr `codec:"ulimit"`

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -16,6 +16,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/drivers/shared/eventer"
 	"github.com/hashicorp/nomad/drivers/shared/executor"
+	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -90,7 +91,7 @@ var (
 		"accelerator":       hclspec.NewAttr("accelerator", "string", false),
 		"graceful_shutdown": hclspec.NewAttr("graceful_shutdown", "bool", false),
 		"args":              hclspec.NewAttr("args", "list(string)", false),
-		"port_map":          hclspec.NewBlockAttrs("port_map", "number", false),
+		"port_map":          hclspec.NewAttr("port_map", "list(map(number))", false),
 	})
 
 	// capabilities is returned by the Capabilities RPC and indicates what
@@ -106,11 +107,11 @@ var (
 
 // TaskConfig is the driver configuration of a taskConfig within a job
 type TaskConfig struct {
-	ImagePath        string         `codec:"image_path"`
-	Accelerator      string         `codec:"accelerator"`
-	Args             []string       `codec:"args"`     // extra arguments to qemu executable
-	PortMap          map[string]int `codec:"port_map"` // A map of host port and the port name defined in the image manifest file
-	GracefulShutdown bool           `codec:"graceful_shutdown"`
+	ImagePath        string             `codec:"image_path"`
+	Accelerator      string             `codec:"accelerator"`
+	Args             []string           `codec:"args"`     // extra arguments to qemu executable
+	PortMap          hclutils.MapStrInt `codec:"port_map"` // A map of host port and the port name defined in the image manifest file
+	GracefulShutdown bool               `codec:"graceful_shutdown"`
 }
 
 // TaskState is the state which is encoded in the handle returned in StartTask.

--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/nomad/drivers/shared/eventer"
 	"github.com/hashicorp/nomad/drivers/shared/executor"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -110,7 +111,7 @@ var (
 		"dns_servers":        hclspec.NewAttr("dns_servers", "list(string)", false),
 		"dns_search_domains": hclspec.NewAttr("dns_search_domains", "list(string)", false),
 		"net":                hclspec.NewAttr("net", "list(string)", false),
-		"port_map":           hclspec.NewBlockAttrs("port_map", "string", false),
+		"port_map":           hclspec.NewAttr("port_map", "list(map(string))", false),
 		"volumes":            hclspec.NewAttr("volumes", "list(string)", false),
 		"insecure_options":   hclspec.NewAttr("insecure_options", "list(string)", false),
 		"no_overlay":         hclspec.NewAttr("no_overlay", "bool", false),
@@ -140,16 +141,16 @@ type Config struct {
 
 // TaskConfig is the driver configuration of a taskConfig within a job
 type TaskConfig struct {
-	ImageName        string            `codec:"image"`
-	Command          string            `codec:"command"`
-	Args             []string          `codec:"args"`
-	TrustPrefix      string            `codec:"trust_prefix"`
-	DNSServers       []string          `codec:"dns_servers"`        // DNS Server for containers
-	DNSSearchDomains []string          `codec:"dns_search_domains"` // DNS Search domains for containers
-	Net              []string          `codec:"net"`                // Networks for the containers
-	PortMap          map[string]string `codec:"port_map"`           // A map of host port and the port name defined in the image manifest file
-	Volumes          []string          `codec:"volumes"`            // Host-Volumes to mount in, syntax: /path/to/host/directory:/destination/path/in/container[:readOnly]
-	InsecureOptions  []string          `codec:"insecure_options"`   // list of args for --insecure-options
+	ImageName        string             `codec:"image"`
+	Command          string             `codec:"command"`
+	Args             []string           `codec:"args"`
+	TrustPrefix      string             `codec:"trust_prefix"`
+	DNSServers       []string           `codec:"dns_servers"`        // DNS Server for containers
+	DNSSearchDomains []string           `codec:"dns_search_domains"` // DNS Search domains for containers
+	Net              []string           `codec:"net"`                // Networks for the containers
+	PortMap          hclutils.MapStrStr `codec:"port_map"`           // A map of host port and the port name defined in the image manifest file
+	Volumes          []string           `codec:"volumes"`            // Host-Volumes to mount in, syntax: /path/to/host/directory:/destination/path/in/container[:readOnly]
+	InsecureOptions  []string           `codec:"insecure_options"`   // list of args for --insecure-options
 
 	NoOverlay bool   `codec:"no_overlay"` // disable overlayfs for rkt run
 	Debug     bool   `codec:"debug"`      // Enable debug option for rkt command

--- a/helper/pluginutils/hclutils/types.go
+++ b/helper/pluginutils/hclutils/types.go
@@ -1,0 +1,51 @@
+package hclutils
+
+import (
+	"github.com/ugorji/go/codec"
+)
+
+// MapStrInt is a wrapper for map[string]int that handles
+// deserialization from different hcl2 json representation
+// that were supported in Nomad 0.8
+type MapStrInt map[string]int
+
+func (s *MapStrInt) CodecEncodeSelf(enc *codec.Encoder) {
+	v := []map[string]int{*s}
+	enc.MustEncode(v)
+}
+
+func (s *MapStrInt) CodecDecodeSelf(dec *codec.Decoder) {
+	ms := []map[string]int{}
+	dec.MustDecode(&ms)
+
+	r := map[string]int{}
+	for _, m := range ms {
+		for k, v := range m {
+			r[k] = v
+		}
+	}
+	*s = r
+}
+
+// MapStrStr is a wrapper for map[string]string that handles
+// deserialization from different hcl2 json representation
+// that were supported in Nomad 0.8
+type MapStrStr map[string]string
+
+func (s *MapStrStr) CodecEncodeSelf(enc *codec.Encoder) {
+	v := []map[string]string{*s}
+	enc.MustEncode(v)
+}
+
+func (s *MapStrStr) CodecDecodeSelf(dec *codec.Decoder) {
+	ms := []map[string]string{}
+	dec.MustDecode(&ms)
+
+	r := map[string]string{}
+	for _, m := range ms {
+		for k, v := range m {
+			r[k] = v
+		}
+	}
+	*s = r
+}

--- a/helper/pluginutils/hclutils/types_test.go
+++ b/helper/pluginutils/hclutils/types_test.go
@@ -1,0 +1,139 @@
+package hclutils_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
+	"github.com/hashicorp/nomad/plugins/shared/hclspec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapStrInt_JsonArrays(t *testing.T) {
+	spec := hclspec.NewObject(map[string]*hclspec.Spec{
+		"port_map": hclspec.NewAttr("port_map", "list(map(number))", false),
+	})
+
+	type PidMapTaskConfig struct {
+		PortMap hclutils.MapStrInt `codec:"port_map"`
+	}
+
+	parser := hclutils.NewConfigParser(spec)
+
+	expected := PidMapTaskConfig{
+		PortMap: map[string]int{
+			"http":  80,
+			"https": 443,
+			"ssh":   25,
+		},
+	}
+
+	t.Run("hcl case", func(t *testing.T) {
+		config := `
+config {
+  port_map {
+    http  = 80
+    https = 443
+    ssh   = 25
+  }
+}`
+		// Test decoding
+		var tc PidMapTaskConfig
+		parser.ParseHCL(t, config, &tc)
+
+		require.EqualValues(t, expected, tc)
+
+	})
+	jsonCases := []struct {
+		name string
+		json string
+	}{
+		{
+			"array of map entries",
+			`{"Config": {"port_map": [{"http": 80}, {"https": 443}, {"ssh": 25}]}}`,
+		},
+		{
+			"array with one map",
+			`{"Config": {"port_map": [{"http": 80, "https": 443, "ssh": 25}]}}`,
+		},
+		{
+			"array of maps",
+			`{"Config": {"port_map": [{"http": 80, "https": 443}, {"ssh": 25}]}}`,
+		},
+	}
+
+	for _, c := range jsonCases {
+		t.Run("json:"+c.name, func(t *testing.T) {
+			// Test decoding
+			var tc PidMapTaskConfig
+			parser.ParseJson(t, c.json, &tc)
+
+			require.EqualValues(t, expected, tc)
+
+		})
+	}
+}
+
+func TestMapStrStr_JsonArrays(t *testing.T) {
+	spec := hclspec.NewObject(map[string]*hclspec.Spec{
+		"port_map": hclspec.NewAttr("port_map", "list(map(string))", false),
+	})
+
+	type PidMapTaskConfig struct {
+		PortMap hclutils.MapStrStr `codec:"port_map"`
+	}
+
+	parser := hclutils.NewConfigParser(spec)
+
+	expected := PidMapTaskConfig{
+		PortMap: map[string]string{
+			"http":  "80",
+			"https": "443",
+			"ssh":   "25",
+		},
+	}
+
+	t.Run("hcl case", func(t *testing.T) {
+		config := `
+config {
+  port_map {
+    http  = "80"
+    https = "443"
+    ssh   = "25"
+  }
+}`
+		// Test decoding
+		var tc PidMapTaskConfig
+		parser.ParseHCL(t, config, &tc)
+
+		require.EqualValues(t, expected, tc)
+
+	})
+	jsonCases := []struct {
+		name string
+		json string
+	}{
+		{
+			"array of map entries",
+			`{"Config": {"port_map": [{"http": "80"}, {"https": "443"}, {"ssh": "25"}]}}`,
+		},
+		{
+			"array with one map",
+			`{"Config": {"port_map": [{"http": "80", "https": "443", "ssh": "25"}]}}`,
+		},
+		{
+			"array of maps",
+			`{"Config": {"port_map": [{"http": "80", "https": "443"}, {"ssh": "25"}]}}`,
+		},
+	}
+
+	for _, c := range jsonCases {
+		t.Run("json:"+c.name, func(t *testing.T) {
+			// Test decoding
+			var tc PidMapTaskConfig
+			parser.ParseJson(t, c.json, &tc)
+
+			require.EqualValues(t, expected, tc)
+
+		})
+	}
+}


### PR DESCRIPTION
drivers: restore port_map old json support

This ensures that `port_map` along with other block like attribute
declarations (e.g. ulimit, labels, etc) can handle various hcl and json
syntax that was supported in 0.8.

In 0.8.7, the following declarations are effectively equivalent:

```
// hcl block
port_map {
  http = 80
  https = 443
}

// hcl assignment
port_map = {
  http  = 80
  https = 443
}

// json single element array of map (default in API response)
{"port_map": [{"http": 80, "https": 443}]}

// json array of individual maps (supported accidentally iiuc)
{"port_map: [{"http": 80}, {"https": 443}]}
```

We achieve compatbility by using `NewAttr("...", "list(map(string))",
false)` to be serialized to a `map[string]string` wrapper, instead of using
`BlockAttrs` declaration.  The wrapper merges the list of maps
automatically, to ease driver development.

This approach is closer to how v0.8.7 implemented the fields [1][2], and
despite its verbosity, seems to perserve 0.8.7 behavior in hcl2.

This is only required for built-in types that have backward
compatibility constraints.  External drivers should use `BlockAttrs`
instead, as they see fit.

[1] https://github.com/hashicorp/nomad/blob/v0.8.7/client/driver/docker.go#L216
[2] https://github.com/hashicorp/nomad/blob/v0.8.7/client/driver/docker.go#L698-L700