### PR TITLE
Do not wrap errors from StartTask as that loses Recoverable

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -656,7 +656,9 @@ func (tr *TaskRunner) runDriver() error {
 				return fmt.Errorf("failed to start task after driver exited unexpectedly: %v", err)
 			}
 		} else {
-			return fmt.Errorf("driver start failed: %v", err)
+			// Do *NOT* wrap the error here without maintaining
+			// whether or not is Recoverable.
+			return err
 		}
 	}
 


### PR DESCRIPTION
Fixes a regression caused by losing the Recoverable information on an error by wrapping it (who needs subclassing?).

Also ports a few tests from 0.8.