### PR TITLE
docker: Avoid leaking containers during Reattach

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -199,16 +199,16 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 
 		h.dlogger, h.dloggerPluginClient, err = d.setupNewDockerLogger(container, handle.Config, time.Now())
 		if err != nil {
-			// TODO(dani): FIXME: Here we will leak the users container. Simply removing
-			//                    the container here will cause a user restart-stanza
-			//                    based cycle.
+			if err := client.StopContainer(handleState.ContainerID, 0); err != nil {
+				d.logger.Warn("failed to stop container during cleanup", "container_id", handleState.ContainerID, "error", err)
+			}
 			return fmt.Errorf("failed to setup replacement docker logger: %v", err)
 		}
 
 		if err := handle.SetDriverState(h.buildState()); err != nil {
-			// TODO(dani): FIXME: Here we will leak the users container. Simply removing
-			//                    the container here will cause a user restart-stanza
-			//                    based cycle.
+			if err := client.StopContainer(handleState.ContainerID, 0); err != nil {
+				d.logger.Warn("failed to stop container during cleanup", "container_id", handleState.ContainerID, "error", err)
+			}
 			return fmt.Errorf("failed to store driver state: %v", err)
 		}
 	}


### PR DESCRIPTION
Currently if a docker_logger cannot be reattached to, we will leak the
container that was being used. This is problematic if e.g using static
ports as it means you can never recover your task, or if a service is
expensive to run and will then be running without supervision.

Not sure if this is the right approach to cleaning this up yet, filing
this PR primarily for discussion.

Related to #5296