### PR TITLE
Run Docker tests in Windows AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,10 @@ environment:
   GOMAXPROCS: 1
 
 install:
+  # do basic docker smoke test, and pull image in preparation for tests
+  - cmd: docker info
+  - cmd: docker run --rm dantoml/busybox-windows:08012019 echo hi there
+
   - cmd: set PATH=%GOBIN%;c:\go\bin;%PATH%
   - cmd: echo %Path%
   - cmd: go version
@@ -31,10 +35,12 @@ install:
 build_script:
   - cmd: |
       set PATH=%GOPATH%/bin;%PATH%
-      mkdir -p $GOPATH\bin
-      go build -o $GOPATH\bin\nomad
-# test_script:
-#   - cmd: gotestsum -f short-verbose --junitfile results.xml
+      go build -o %GOPATH%\bin\nomad.exe
+test_script:
+  # only test docker driver tests for now
+  - cmd:
+      gotestsum --junitfile results.xml
+           github.com/hashicorp/nomad/drivers/docker
 # on_finish:
 #   - ps: |
 #       Push-AppveyorArtifact (Resolve-Path .\results.xml)

--- a/client/testutil/docker.go
+++ b/client/testutil/docker.go
@@ -16,6 +16,10 @@ func DockerIsConnected(t *testing.T) bool {
 		return runtime.GOOS == "linux"
 	}
 
+	if testutil.IsAppVeyor() {
+		return runtime.GOOS == "windows"
+	}
+
 	client, err := docker.NewClientFromEnv()
 	if err != nil {
 		return false

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -45,7 +45,7 @@ func TestDockerDriver_authFromHelper(t *testing.T) {
 }
 
 func TestDockerDriver_PidsLimit(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -651,6 +651,11 @@ func TestDockerDriver_Start_KillTimeout(t *testing.T) {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows Docker does not support SIGUSR1")
+	}
+
 	timeout := 2 * time.Second
 	taskCfg := newTaskConfig("", []string{"sleep", "10"})
 	task := &drivers.TaskConfig{
@@ -1140,6 +1145,9 @@ func TestDockerDriver_MACAddress(t *testing.T) {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows docker does not support setting MacAddress")
+	}
 
 	task, cfg, _ := dockerTask(t)
 	cfg.MacAddress = "00:16:3e:00:00:00"
@@ -1455,6 +1463,12 @@ func TestDockerDriver_VolumesEnabled(t *testing.T) {
 	}
 	testutil.DockerCompatible(t)
 
+	if runtime.GOOS == "windows" {
+		// Nomad assumes : as the delimiter between host:path container, but Windows uses it for
+		// drive paths (e.g. `C:\Users...`).  Lookup volume syntax for windows and update test
+		t.Skip("TODO: Windows volume sharing doesn't work")
+	}
+
 	tmpvol, err := ioutil.TempDir("", "nomadtest_docker_volumesenabled")
 	require.NoError(t, err)
 
@@ -1610,6 +1624,10 @@ func TestDockerDriver_OOMKilled(t *testing.T) {
 	}
 	testutil.DockerCompatible(t)
 
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support OOM Killer")
+	}
+
 	taskCfg := newTaskConfig("", []string{"sh", "-c", `sleep 2 && x=a && while true; do x="$x$x"; done`})
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
@@ -1759,6 +1777,10 @@ func TestDockerDriver_ReadonlyRootfs(t *testing.T) {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows Docker does not support root filesystem in read-only mode")
+	}
 
 	task, cfg, _ := dockerTask(t)
 	cfg.ReadonlyRootfs = true

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -190,7 +190,7 @@ func newTestDockerClient(t *testing.T) *docker.Client {
 /*
 // This test should always pass, even if docker daemon is not available
 func TestDockerDriver_Fingerprint(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 
@@ -231,7 +231,7 @@ func TestDockerDriver_Fingerprint(t *testing.T) {
 // TestDockerDriver_Fingerprint_Bridge asserts that if Docker is running we set
 // the bridge network's IP as a node attribute. See #2785
 func TestDockerDriver_Fingerprint_Bridge(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -281,7 +281,7 @@ func TestDockerDriver_Fingerprint_Bridge(t *testing.T) {
 }
 
 func TestDockerDriver_Check_DockerHealthStatus(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -317,7 +317,7 @@ func TestDockerDriver_Check_DockerHealthStatus(t *testing.T) {
 }*/
 
 func TestDockerDriver_Start_Wait(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -352,7 +352,7 @@ func TestDockerDriver_Start_Wait(t *testing.T) {
 }
 
 func TestDockerDriver_Start_WaitFinish(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -394,7 +394,7 @@ func TestDockerDriver_Start_WaitFinish(t *testing.T) {
 //
 // See https://github.com/hashicorp/nomad/issues/3419
 func TestDockerDriver_Start_StoppedContainer(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -453,7 +453,7 @@ func TestDockerDriver_Start_StoppedContainer(t *testing.T) {
 }
 
 func TestDockerDriver_Start_LoadImage(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -502,7 +502,7 @@ func TestDockerDriver_Start_LoadImage(t *testing.T) {
 }
 
 func TestDockerDriver_Start_BadPull_Recoverable(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -538,7 +538,7 @@ func TestDockerDriver_Start_BadPull_Recoverable(t *testing.T) {
 }
 
 func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	// This test requires that the alloc dir be mounted into docker as a volume.
@@ -600,7 +600,7 @@ func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
 }
 
 func TestDockerDriver_Start_Kill_Wait(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -647,7 +647,7 @@ func TestDockerDriver_Start_Kill_Wait(t *testing.T) {
 }
 
 func TestDockerDriver_Start_KillTimeout(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -701,7 +701,7 @@ func TestDockerDriver_StartN(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows Docker does not support SIGINT")
 	}
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -748,7 +748,7 @@ func TestDockerDriver_StartNVersions(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipped on windows, we don't have image variants available")
 	}
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -810,7 +810,7 @@ func TestDockerDriver_StartNVersions(t *testing.T) {
 }
 
 func TestDockerDriver_Labels(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -838,7 +838,7 @@ func TestDockerDriver_Labels(t *testing.T) {
 }
 
 func TestDockerDriver_ForcePull(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -863,7 +863,7 @@ func TestDockerDriver_ForcePull_RepoDigest(t *testing.T) {
 		t.Skip("TODO: Skipped digest test on Windows")
 	}
 
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -890,7 +890,7 @@ func TestDockerDriver_SecurityOpt(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows does not support seccomp")
 	}
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -931,7 +931,7 @@ func TestDockerDriver_CreateContainerConfig(t *testing.T) {
 }
 
 func TestDockerDriver_CreateContainerConfigWithRuntimes(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	if !testutil.DockerIsConnected(t) {
@@ -1006,7 +1006,7 @@ func TestDockerDriver_CreateContainerConfigWithRuntimes(t *testing.T) {
 }
 
 func TestDockerDriver_Capabilities(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1116,7 +1116,7 @@ func TestDockerDriver_Capabilities(t *testing.T) {
 }
 
 func TestDockerDriver_DNS(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1141,7 +1141,7 @@ func TestDockerDriver_DNS(t *testing.T) {
 }
 
 func TestDockerDriver_MACAddress(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1164,7 +1164,7 @@ func TestDockerDriver_MACAddress(t *testing.T) {
 }
 
 func TestDockerWorkDir(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1192,7 +1192,7 @@ func inSlice(needle string, haystack []string) bool {
 }
 
 func TestDockerDriver_PortsNoMap(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1235,7 +1235,7 @@ func TestDockerDriver_PortsNoMap(t *testing.T) {
 }
 
 func TestDockerDriver_PortsMapping(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1282,7 +1282,7 @@ func TestDockerDriver_PortsMapping(t *testing.T) {
 }
 
 func TestDockerDriver_CleanupContainer(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1317,7 +1317,7 @@ func TestDockerDriver_CleanupContainer(t *testing.T) {
 }
 
 func TestDockerDriver_Stats(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1390,7 +1390,7 @@ func setupDockerVolumes(t *testing.T, cfg map[string]interface{}, hostpath strin
 }
 
 func TestDockerDriver_VolumesDisabled(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1458,7 +1458,7 @@ func TestDockerDriver_VolumesDisabled(t *testing.T) {
 }
 
 func TestDockerDriver_VolumesEnabled(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1500,7 +1500,7 @@ func TestDockerDriver_VolumesEnabled(t *testing.T) {
 }
 
 func TestDockerDriver_Mounts(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1568,7 +1568,7 @@ func TestDockerDriver_Mounts(t *testing.T) {
 }
 
 func TestDockerDriver_AuthConfiguration(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1619,7 +1619,7 @@ func TestDockerDriver_AuthConfiguration(t *testing.T) {
 }
 
 func TestDockerDriver_OOMKilled(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1669,7 +1669,7 @@ func TestDockerDriver_OOMKilled(t *testing.T) {
 }
 
 func TestDockerDriver_Devices_IsInvalidConfig(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1708,7 +1708,7 @@ func TestDockerDriver_Devices_IsInvalidConfig(t *testing.T) {
 }
 
 func TestDockerDriver_Device_Success(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1747,7 +1747,7 @@ func TestDockerDriver_Device_Success(t *testing.T) {
 }
 
 func TestDockerDriver_Entrypoint(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1773,7 +1773,7 @@ func TestDockerDriver_Entrypoint(t *testing.T) {
 }
 
 func TestDockerDriver_ReadonlyRootfs(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -1816,7 +1816,7 @@ func (fakeDockerClient) RemoveContainer(opts docker.RemoveContainerOptions) erro
 // TestDockerDriver_VolumeError asserts volume related errors when creating a
 // container are recoverable.
 func TestDockerDriver_VolumeError(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 
@@ -1830,7 +1830,7 @@ func TestDockerDriver_VolumeError(t *testing.T) {
 }
 
 func TestDockerDriver_AdvertiseIPv6Address(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)

--- a/drivers/docker/driver_unix_test.go
+++ b/drivers/docker/driver_unix_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestDockerDriver_User(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -51,7 +51,7 @@ func TestDockerDriver_User(t *testing.T) {
 }
 
 func TestDockerDriver_NetworkAliases_Bridge(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -100,7 +100,7 @@ func TestDockerDriver_NetworkAliases_Bridge(t *testing.T) {
 }
 
 func TestDockerDriver_NetworkMode_Host(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
@@ -144,7 +144,7 @@ func TestDockerDriver_NetworkMode_Host(t *testing.T) {
 }
 
 func TestDockerDriver_CPUCFSPeriod(t *testing.T) {
-	if !tu.IsTravis() {
+	if !tu.IsCI() {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -47,7 +47,7 @@ var testResources = &drivers.Resources{
 }
 
 func TestExecDriver_Fingerprint_NonLinux(t *testing.T) {
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 	require := require.New(t)

--- a/drivers/java/driver_test.go
+++ b/drivers/java/driver_test.go
@@ -34,7 +34,7 @@ func javaCompatible(t *testing.T) {
 
 func TestJavaDriver_Fingerprint(t *testing.T) {
 	javaCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -56,7 +56,7 @@ func TestJavaDriver_Fingerprint(t *testing.T) {
 
 func TestJavaDriver_Jar_Start_Wait(t *testing.T) {
 	javaCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -96,7 +96,7 @@ func TestJavaDriver_Jar_Start_Wait(t *testing.T) {
 
 func TestJavaDriver_Jar_Stop_Wait(t *testing.T) {
 	javaCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -157,7 +157,7 @@ func TestJavaDriver_Jar_Stop_Wait(t *testing.T) {
 
 func TestJavaDriver_Class_Start_Wait(t *testing.T) {
 	javaCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 

--- a/drivers/qemu/driver_test.go
+++ b/drivers/qemu/driver_test.go
@@ -27,7 +27,7 @@ import (
 // Verifies starting a qemu image and stopping it
 func TestQemuDriver_Start_Wait_Stop(t *testing.T) {
 	ctestutil.QemuCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -89,7 +89,7 @@ func TestQemuDriver_Start_Wait_Stop(t *testing.T) {
 // Verifies monitor socket path for old qemu
 func TestQemuDriver_GetMonitorPathOldQemu(t *testing.T) {
 	ctestutil.QemuCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -144,7 +144,7 @@ func TestQemuDriver_GetMonitorPathOldQemu(t *testing.T) {
 // Verifies monitor socket path for new qemu version
 func TestQemuDriver_GetMonitorPathNewQemu(t *testing.T) {
 	ctestutil.QemuCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -224,7 +224,7 @@ func copyFile(src, dst string, t *testing.T) {
 // Verifies starting a qemu image and stopping it
 func TestQemuDriver_User(t *testing.T) {
 	ctestutil.QemuCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -281,7 +281,7 @@ func TestQemuDriver_User(t *testing.T) {
 // TODO(preetha) this test needs random sleeps to pass
 func TestQemuDriver_Stats(t *testing.T) {
 	ctestutil.QemuCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -359,7 +359,7 @@ func TestQemuDriver_Fingerprint(t *testing.T) {
 	require := require.New(t)
 
 	ctestutil.QemuCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -369,8 +369,8 @@ func TestRawExecDriver_Start_Kill_Wait_Cgroup(t *testing.T) {
 		time.Sleep(1 * time.Second)
 		err := harness.StopTask(task.ID, 0, "")
 
-		// Can't rely on the ordering between wait and kill on travis...
-		if !testutil.IsTravis() {
+		// Can't rely on the ordering between wait and kill on CI/travis...
+		if !testutil.IsCI() {
 			require.NoError(err)
 		}
 	}()

--- a/drivers/rkt/driver_test.go
+++ b/drivers/rkt/driver_test.go
@@ -77,7 +77,7 @@ func TestRktDriver_SetConfig(t *testing.T) {
 // Also verifies sending sigterm correctly stops the driver instance
 func TestRktDriver_Start_Wait_Stop_DNS(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -160,7 +160,7 @@ func TestRktDriver_Start_Wait_Stop_DNS(t *testing.T) {
 // Verifies waiting on task to exit cleanly
 func TestRktDriver_Start_Wait_Stop(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -218,7 +218,7 @@ func TestRktDriver_Start_Wait_Stop(t *testing.T) {
 // Verifies that skipping trust_prefix works
 func TestRktDriver_Start_Wait_Skip_Trust(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -276,7 +276,7 @@ func TestRktDriver_Start_Wait_Skip_Trust(t *testing.T) {
 // Verifies that an invalid trust prefix returns expected error
 func TestRktDriver_InvalidTrustPrefix(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -330,7 +330,7 @@ func TestRktDriver_InvalidTrustPrefix(t *testing.T) {
 // to remove the task and then reattaches to it
 func TestRktDriver_StartWaitRecoverWaitStop(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -424,7 +424,7 @@ func TestRktDriver_StartWaitRecoverWaitStop(t *testing.T) {
 // some data to it from inside the container
 func TestRktDriver_Start_Wait_Volume(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -509,7 +509,7 @@ func TestRktDriver_Start_Wait_Volume(t *testing.T) {
 // some data to it from inside the container
 func TestRktDriver_Start_Wait_TaskMounts(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -648,7 +648,7 @@ func TestRktDriver_PortMapping(t *testing.T) {
 // It verifies that running ps inside the container shows the expected user and group
 func TestRktDriver_UserGroup(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -715,7 +715,7 @@ func TestRktDriver_UserGroup(t *testing.T) {
 //  Verifies executing both correct and incorrect commands inside the container
 func TestRktDriver_Exec(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 
@@ -796,7 +796,7 @@ func TestRktDriver_Exec(t *testing.T) {
 // TODO(preetha) figure out why stats are zero
 func TestRktDriver_Stats(t *testing.T) {
 	ctestutil.RktCompatible(t)
-	if !testutil.IsTravis() {
+	if !testutil.IsCI() {
 		t.Parallel()
 	}
 

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -10,12 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	// TravisRunEnv is an environment variable that is set if being run by
-	// Travis.
-	TravisRunEnv = "CI"
-)
-
 type testFn func() (bool, error)
 type errorFn func(error)
 
@@ -69,8 +63,18 @@ func Timeout(original time.Duration) time.Duration {
 	return original * time.Duration(TestMultiplier())
 }
 
+func IsCI() bool {
+	_, ok := os.LookupEnv("CI")
+	return ok
+}
+
 func IsTravis() bool {
-	_, ok := os.LookupEnv(TravisRunEnv)
+	_, ok := os.LookupEnv("TRAVIS")
+	return ok
+}
+
+func IsAppVeyor() bool {
+	_, ok := os.LookupEnv("APPVEYOR")
 	return ok
 }
 

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -51,7 +51,7 @@ func AssertUntil(until time.Duration, test testFn, error errorFn) {
 // TestMultiplier returns a multiplier for retries and waits given environment
 // the tests are being run under.
 func TestMultiplier() int64 {
-	if IsTravis() {
+	if IsCI() {
 		return 4
 	}
 


### PR DESCRIPTION
Start running Docker tests in Windows CI environment, AppVeyor.

The build takes ~5 minutes, e.g. https://ci.appveyor.com/project/hashicorp/nomad/builds/22513699 ; and we can start expanding scope of tests overtime.

It's better to review the changes commit by commit - as the last changeset is quite incidental.