### PR TITLE
Set NextEval when making `failed-follow-up` evals

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -531,6 +531,7 @@ func (s *Server) reapFailedEvaluations(stopCh chan struct{}) {
 			followupEvalWait := s.config.EvalFailedFollowupBaselineDelay +
 				time.Duration(rand.Int63n(int64(s.config.EvalFailedFollowupDelayRange)))
 			followupEval := eval.CreateFailedFollowUpEval(followupEvalWait)
+			updateEval.NextEval = followupEval.ID
 
 			// Update via Raft
 			req := structs.EvalUpdateRequest{

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -582,7 +582,9 @@ func TestLeader_ReapFailedEval(t *testing.T) {
 		if out.Status != structs.EvalStatusFailed {
 			return false, fmt.Errorf("got status %v; want %v", out.Status, structs.EvalStatusFailed)
 		}
-
+		if out.NextEval == "" {
+			return false, fmt.Errorf("got empty NextEval")
+		}
 		// See if there is a followup
 		evals, err := state.EvalsByJob(ws, eval.Namespace, eval.JobID)
 		if err != nil {
@@ -601,6 +603,11 @@ func TestLeader_ReapFailedEval(t *testing.T) {
 			if e.Status != structs.EvalStatusPending {
 				return false, fmt.Errorf("follow up eval has status %v; want %v",
 					e.Status, structs.EvalStatusPending)
+			}
+
+			if e.ID != out.NextEval {
+				return false, fmt.Errorf("follow up eval id is %v; orig eval NextEval %v",
+					e.ID, out.NextEval)
 			}
 
 			if e.Wait < s1.config.EvalFailedFollowupBaselineDelay ||

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8024,11 +8024,13 @@ type Evaluation struct {
 	WaitUntil time.Time
 
 	// NextEval is the evaluation ID for the eval created to do a followup.
-	// This is used to support rolling upgrades, where we need a chain of evaluations.
+	// This is used to support rolling upgrades and failed-follow-up evals, where
+	// we need a chain of evaluations.
 	NextEval string
 
 	// PreviousEval is the evaluation ID for the eval creating this one to do a followup.
-	// This is used to support rolling upgrades, where we need a chain of evaluations.
+	// This is used to support rolling upgrades and failed-follow-up evals, where
+	// we need a chain of evaluations.
 	PreviousEval string
 
 	// BlockedEval is the evaluation ID for a created blocked eval. A
@@ -8215,7 +8217,8 @@ func (e *Evaluation) CreateBlockedEval(classEligibility map[string]bool,
 
 // CreateFailedFollowUpEval creates a follow up evaluation when the current one
 // has been marked as failed because it has hit the delivery limit and will not
-// be retried by the eval_broker.
+// be retried by the eval_broker. Callers should copy the created eval's ID to
+// into the old eval's NextEval field.
 func (e *Evaluation) CreateFailedFollowUpEval(wait time.Duration) *Evaluation {
 	return &Evaluation{
 		ID:             uuid.Generate(),


### PR DESCRIPTION
This allows users to locate failed-follow-up evals more easily