### PR TITLE
logmon fixes

### DIFF
--- a/client/allocrunner/taskrunner/logmon_hook_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_test.go
@@ -1,7 +1,102 @@
 package taskrunner
 
-import "github.com/hashicorp/nomad/client/allocrunner/interfaces"
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+
+	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/stretchr/testify/require"
+)
 
 // Statically assert the logmon hook implements the expected interfaces
 var _ interfaces.TaskPrestartHook = (*logmonHook)(nil)
 var _ interfaces.TaskStopHook = (*logmonHook)(nil)
+
+// TestTaskRunner_LogmonHook_LoadReattach unit tests loading logmon reattach
+// config from persisted hook state.
+func TestTaskRunner_LogmonHook_LoadReattach(t *testing.T) {
+	t.Parallel()
+
+	// No hook data should return nothing
+	cfg, err := reattachConfigFromHookData(nil)
+	require.Nil(t, cfg)
+	require.NoError(t, err)
+
+	// Hook data without the appropriate key should return nothing
+	cfg, err = reattachConfigFromHookData(map[string]string{"foo": "bar"})
+	require.Nil(t, cfg)
+	require.NoError(t, err)
+
+	// Create a realistic reattach config and roundtrip it
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	orig := &plugin.ReattachConfig{
+		Protocol: plugin.ProtocolGRPC,
+		Addr:     addr,
+		Pid:      4,
+	}
+	origJSON, err := json.Marshal(pstructs.ReattachConfigFromGoPlugin(orig))
+	require.NoError(t, err)
+
+	cfg, err = reattachConfigFromHookData(map[string]string{
+		logmonReattachKey: string(origJSON),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, orig, cfg)
+}
+
+// TestTaskRunner_LogmonHook_StartStop asserts that a new logmon is created the
+// first time Prestart is called, reattached to on subsequent restarts, and
+// killed on Stop.
+func TestTaskRunner_LogmonHook_StartStop(t *testing.T) {
+	t.Parallel()
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+
+	dir, err := ioutil.TempDir("", "nomadtest")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+
+	hookConf := newLogMonHookConfig(task.Name, dir)
+	hook := newLogMonHook(hookConf, testlog.HCLogger(t))
+
+	req := interfaces.TaskPrestartRequest{
+		Task: task,
+	}
+	resp := interfaces.TaskPrestartResponse{}
+
+	// First prestart should set reattach key but never be Done as it needs
+	// to rerun on agent restarts to reattach.
+	require.NoError(t, hook.Prestart(context.Background(), &req, &resp))
+	defer hook.Stop(context.Background(), nil, nil)
+
+	require.False(t, resp.Done)
+	origHookData := resp.HookData[logmonReattachKey]
+	require.NotEmpty(t, origHookData)
+
+	// Running prestart again should effectively noop as it reattaches to
+	// the running logmon.
+	req.HookData = map[string]string{
+		logmonReattachKey: origHookData,
+	}
+	require.NoError(t, hook.Prestart(context.Background(), &req, &resp))
+	require.False(t, resp.Done)
+	origHookData = resp.HookData[logmonReattachKey]
+	require.Equal(t, origHookData, req.HookData[logmonReattachKey])
+
+	// Running stop should shutdown logmon
+	require.NoError(t, hook.Stop(context.Background(), nil, nil))
+}

--- a/client/allocrunner/taskrunner/logmon_hook_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_test.go
@@ -1,18 +1,24 @@
+// +build !windows
+
 package taskrunner
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
+	"syscall"
 	"testing"
 
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,6 +102,75 @@ func TestTaskRunner_LogmonHook_StartStop(t *testing.T) {
 	require.False(t, resp.Done)
 	origHookData = resp.HookData[logmonReattachKey]
 	require.Equal(t, origHookData, req.HookData[logmonReattachKey])
+
+	// Running stop should shutdown logmon
+	require.NoError(t, hook.Stop(context.Background(), nil, nil))
+}
+
+// TestTaskRunner_LogmonHook_StartCrashStop simulates logmon crashing while the
+// Nomad client is restarting and asserts failing to reattach to logmon causes
+// a recoverable error (task restart).
+func TestTaskRunner_LogmonHook_StartCrashStop(t *testing.T) {
+	t.Parallel()
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+
+	dir, err := ioutil.TempDir("", "nomadtest")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+
+	hookConf := newLogMonHookConfig(task.Name, dir)
+	hook := newLogMonHook(hookConf, testlog.HCLogger(t))
+
+	req := interfaces.TaskPrestartRequest{
+		Task: task,
+	}
+	resp := interfaces.TaskPrestartResponse{}
+
+	// First start
+	require.NoError(t, hook.Prestart(context.Background(), &req, &resp))
+	defer hook.Stop(context.Background(), nil, nil)
+
+	origHookData := resp.HookData[logmonReattachKey]
+	require.NotEmpty(t, origHookData)
+
+	// Pluck PID out of reattach synthesize a crash
+	reattach := struct {
+		Pid int
+	}{}
+	require.NoError(t, json.Unmarshal([]byte(origHookData), &reattach))
+	pid := reattach.Pid
+	require.NotZero(t, pid)
+
+	proc, _ := os.FindProcess(pid)
+
+	// Assert logmon is running
+	require.NoError(t, proc.Signal(syscall.Signal(0)))
+
+	// Kill it
+	require.NoError(t, proc.Signal(os.Kill))
+
+	// Since signals are asynchronous wait for the process to die
+	testutil.WaitForResult(func() (bool, error) {
+		err := proc.Signal(syscall.Signal(0))
+		return err != nil, fmt.Errorf("pid %d still running", pid)
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
+	// Running prestart again should return a recoverable error with no
+	// reattach config to cause the task to be restarted with a new logmon.
+	req.HookData = map[string]string{
+		logmonReattachKey: origHookData,
+	}
+	resp = interfaces.TaskPrestartResponse{}
+	err = hook.Prestart(context.Background(), &req, &resp)
+	require.Error(t, err)
+	require.True(t, structs.IsRecoverable(err))
+	require.Empty(t, resp.HookData)
 
 	// Running stop should shutdown logmon
 	require.NoError(t, hook.Stop(context.Background(), nil, nil))

--- a/client/allocrunner/taskrunner/logmon_hook_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_test.go
@@ -1,24 +1,18 @@
-// +build !windows
-
 package taskrunner
 
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
-	"syscall"
 	"testing"
 
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
-	"github.com/hashicorp/nomad/nomad/structs"
 	pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
-	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -102,75 +96,6 @@ func TestTaskRunner_LogmonHook_StartStop(t *testing.T) {
 	require.False(t, resp.Done)
 	origHookData = resp.HookData[logmonReattachKey]
 	require.Equal(t, origHookData, req.HookData[logmonReattachKey])
-
-	// Running stop should shutdown logmon
-	require.NoError(t, hook.Stop(context.Background(), nil, nil))
-}
-
-// TestTaskRunner_LogmonHook_StartCrashStop simulates logmon crashing while the
-// Nomad client is restarting and asserts failing to reattach to logmon causes
-// a recoverable error (task restart).
-func TestTaskRunner_LogmonHook_StartCrashStop(t *testing.T) {
-	t.Parallel()
-
-	alloc := mock.BatchAlloc()
-	task := alloc.Job.TaskGroups[0].Tasks[0]
-
-	dir, err := ioutil.TempDir("", "nomadtest")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
-
-	hookConf := newLogMonHookConfig(task.Name, dir)
-	hook := newLogMonHook(hookConf, testlog.HCLogger(t))
-
-	req := interfaces.TaskPrestartRequest{
-		Task: task,
-	}
-	resp := interfaces.TaskPrestartResponse{}
-
-	// First start
-	require.NoError(t, hook.Prestart(context.Background(), &req, &resp))
-	defer hook.Stop(context.Background(), nil, nil)
-
-	origHookData := resp.HookData[logmonReattachKey]
-	require.NotEmpty(t, origHookData)
-
-	// Pluck PID out of reattach synthesize a crash
-	reattach := struct {
-		Pid int
-	}{}
-	require.NoError(t, json.Unmarshal([]byte(origHookData), &reattach))
-	pid := reattach.Pid
-	require.NotZero(t, pid)
-
-	proc, _ := os.FindProcess(pid)
-
-	// Assert logmon is running
-	require.NoError(t, proc.Signal(syscall.Signal(0)))
-
-	// Kill it
-	require.NoError(t, proc.Signal(os.Kill))
-
-	// Since signals are asynchronous wait for the process to die
-	testutil.WaitForResult(func() (bool, error) {
-		err := proc.Signal(syscall.Signal(0))
-		return err != nil, fmt.Errorf("pid %d still running", pid)
-	}, func(err error) {
-		require.NoError(t, err)
-	})
-
-	// Running prestart again should return a recoverable error with no
-	// reattach config to cause the task to be restarted with a new logmon.
-	req.HookData = map[string]string{
-		logmonReattachKey: origHookData,
-	}
-	resp = interfaces.TaskPrestartResponse{}
-	err = hook.Prestart(context.Background(), &req, &resp)
-	require.Error(t, err)
-	require.True(t, structs.IsRecoverable(err))
-	require.Empty(t, resp.HookData)
 
 	// Running stop should shutdown logmon
 	require.NoError(t, hook.Stop(context.Background(), nil, nil))

--- a/client/allocrunner/taskrunner/logmon_hook_unix_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_unix_test.go
@@ -1,0 +1,89 @@
+// +build !windows
+
+package taskrunner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTaskRunner_LogmonHook_StartCrashStop simulates logmon crashing while the
+// Nomad client is restarting and asserts failing to reattach to logmon causes
+// a recoverable error (task restart).
+func TestTaskRunner_LogmonHook_StartCrashStop(t *testing.T) {
+	t.Parallel()
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+
+	dir, err := ioutil.TempDir("", "nomadtest")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+
+	hookConf := newLogMonHookConfig(task.Name, dir)
+	hook := newLogMonHook(hookConf, testlog.HCLogger(t))
+
+	req := interfaces.TaskPrestartRequest{
+		Task: task,
+	}
+	resp := interfaces.TaskPrestartResponse{}
+
+	// First start
+	require.NoError(t, hook.Prestart(context.Background(), &req, &resp))
+	defer hook.Stop(context.Background(), nil, nil)
+
+	origHookData := resp.HookData[logmonReattachKey]
+	require.NotEmpty(t, origHookData)
+
+	// Pluck PID out of reattach synthesize a crash
+	reattach := struct {
+		Pid int
+	}{}
+	require.NoError(t, json.Unmarshal([]byte(origHookData), &reattach))
+	pid := reattach.Pid
+	require.NotZero(t, pid)
+
+	proc, _ := os.FindProcess(pid)
+
+	// Assert logmon is running
+	require.NoError(t, proc.Signal(syscall.Signal(0)))
+
+	// Kill it
+	require.NoError(t, proc.Signal(os.Kill))
+
+	// Since signals are asynchronous wait for the process to die
+	testutil.WaitForResult(func() (bool, error) {
+		err := proc.Signal(syscall.Signal(0))
+		return err != nil, fmt.Errorf("pid %d still running", pid)
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
+	// Running prestart again should return a recoverable error with no
+	// reattach config to cause the task to be restarted with a new logmon.
+	req.HookData = map[string]string{
+		logmonReattachKey: origHookData,
+	}
+	resp = interfaces.TaskPrestartResponse{}
+	err = hook.Prestart(context.Background(), &req, &resp)
+	require.Error(t, err)
+	require.True(t, structs.IsRecoverable(err))
+	require.Empty(t, resp.HookData)
+
+	// Running stop should shutdown logmon
+	require.NoError(t, hook.Stop(context.Background(), nil, nil))
+}

--- a/client/pluginmanager/drivermanager/instance.go
+++ b/client/pluginmanager/drivermanager/instance.go
@@ -371,7 +371,7 @@ func (i *instanceManager) handleFingerprint(fp *drivers.Fingerprint) {
 
 	// if this is the first fingerprint, mark that we have received it
 	if !i.hasFingerprinted {
-		i.logger.Trace("initial driver fingerprint", "fingerprint", fp)
+		i.logger.Debug("initial driver fingerprint", "health", fp.Health, "description", fp.HealthDescription)
 		close(i.firstFingerprintCh)
 		i.hasFingerprinted = true
 	}

--- a/drivers/shared/executor/client.go
+++ b/drivers/shared/executor/client.go
@@ -118,6 +118,11 @@ func (c *grpcExecutorClient) handleStats(ctx context.Context, stream proto.Execu
 	defer close(ch)
 	for {
 		resp, err := stream.Recv()
+		if ctx.Err() != nil {
+			// Context canceled; exit gracefully
+			return
+		}
+
 		if err != nil {
 			if err != io.EOF {
 				c.logger.Error("error receiving stream from Stats executor RPC, closing stream", "error", err)

--- a/plugins/drivers/client.go
+++ b/plugins/drivers/client.go
@@ -282,6 +282,11 @@ func (d *driverPluginClient) handleStats(ctx context.Context, ch chan<- *cstruct
 	defer close(ch)
 	for {
 		resp, err := stream.Recv()
+		if ctx.Err() != nil {
+			// Context canceled; exit gracefully
+			return
+		}
+
 		if err != nil {
 			if err != io.EOF {
 				d.logger.Error("error receiving stream from TaskStats driver RPC, closing stream", "error", err)


### PR DESCRIPTION
Commits have details on individual items, but to summarize:

There were multiple bugs preventing logmon reattaching from ever working:

1. Reattach unmarshalling always returned an error because you can't unmarshal into a nil pointer.
2. The hook data wasn't being saved because it was put on the request struct, not the response struct.
3. The plugin configuration should only have reattach *or* a command set. Not both.
4. Setting Done=true meant the hook was never re-run on agent restart so reattaching was never attempted.

That's d44a7b6. The other 2 commits contain log fixes.

There's still a potential leak (logmon state isn't crash safe), but the fix is quite a bit more involved so I moved it to another branch.