### PR TITLE
docker: Support Stats on Windows

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -42,10 +42,6 @@ var (
 	// running operations such as waiting on containers and collect stats
 	waitClient *docker.Client
 
-	// The statistics the Docker driver exposes
-	DockerMeasuredMemStats = []string{"RSS", "Cache", "Swap", "Usage", "Max Usage"}
-	DockerMeasuredCpuStats = []string{"Throttled Periods", "Throttled Time", "Percent"}
-
 	// recoverableErrTimeouts returns a recoverable error if the error was due
 	// to timeouts
 	recoverableErrTimeouts = func(err error) error {

--- a/drivers/docker/util/stats_posix.go
+++ b/drivers/docker/util/stats_posix.go
@@ -1,0 +1,53 @@
+// +build !windows
+
+package util
+
+import (
+	"runtime"
+
+	docker "github.com/fsouza/go-dockerclient"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/stats"
+)
+
+var (
+	DockerMeasuredCPUStats = []string{"Throttled Periods", "Throttled Time", "Percent"}
+	DockerMeasuredMemStats = []string{"RSS", "Cache", "Swap", "Usage", "Max Usage"}
+)
+
+func DockerStatsToTaskResourceUsage(s *docker.Stats) *cstructs.TaskResourceUsage {
+	ms := &cstructs.MemoryStats{
+		RSS:      s.MemoryStats.Stats.Rss,
+		Cache:    s.MemoryStats.Stats.Cache,
+		Swap:     s.MemoryStats.Stats.Swap,
+		Usage:    s.MemoryStats.Usage,
+		MaxUsage: s.MemoryStats.MaxUsage,
+		Measured: DockerMeasuredMemStats,
+	}
+
+	cs := &cstructs.CpuStats{
+		ThrottledPeriods: s.CPUStats.ThrottlingData.ThrottledPeriods,
+		ThrottledTime:    s.CPUStats.ThrottlingData.ThrottledTime,
+		Measured:         DockerMeasuredCPUStats,
+	}
+
+	// Calculate percentage
+	cs.Percent = CalculateCPUPercent(
+		s.CPUStats.CPUUsage.TotalUsage, s.PreCPUStats.CPUUsage.TotalUsage,
+		s.CPUStats.SystemCPUUsage, s.PreCPUStats.SystemCPUUsage, runtime.NumCPU())
+	cs.SystemMode = CalculateCPUPercent(
+		s.CPUStats.CPUUsage.UsageInKernelmode, s.PreCPUStats.CPUUsage.UsageInKernelmode,
+		s.CPUStats.CPUUsage.TotalUsage, s.PreCPUStats.CPUUsage.TotalUsage, runtime.NumCPU())
+	cs.UserMode = CalculateCPUPercent(
+		s.CPUStats.CPUUsage.UsageInUsermode, s.PreCPUStats.CPUUsage.UsageInUsermode,
+		s.CPUStats.CPUUsage.TotalUsage, s.PreCPUStats.CPUUsage.TotalUsage, runtime.NumCPU())
+	cs.TotalTicks = (cs.Percent / 100) * stats.TotalTicksAvailable() / float64(runtime.NumCPU())
+
+	return &cstructs.TaskResourceUsage{
+		ResourceUsage: &cstructs.ResourceUsage{
+			MemoryStats: ms,
+			CpuStats:    cs,
+		},
+		Timestamp: s.Read.UTC().UnixNano(),
+	}
+}

--- a/drivers/docker/util/stats_windows.go
+++ b/drivers/docker/util/stats_windows.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"runtime"
+
+	docker "github.com/fsouza/go-dockerclient"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/stats"
+)
+
+var (
+	// The statistics the Docker driver exposes
+	DockerMeasuredCPUStats = []string{"Throttled Periods", "Throttled Time", "Percent"}
+	DockerMeasuredMemStats = []string{"RSS", "Usage", "Max Usage"}
+)
+
+func DockerStatsToTaskResourceUsage(s *docker.Stats) *cstructs.TaskResourceUsage {
+	ms := &cstructs.MemoryStats{
+		RSS:      s.MemoryStats.PrivateWorkingSet,
+		Usage:    s.MemoryStats.Commit,
+		MaxUsage: s.MemoryStats.CommitPeak,
+		Measured: DockerMeasuredMemStats,
+	}
+
+	cpuPercent := 0.0
+
+	// https://github.com/moby/moby/blob/cbb885b07af59225eef12a8159e70d1485616d57/integration-cli/docker_api_stats_test.go#L47-L58
+	// Max number of 100ns intervals between the previous time read and now
+	possIntervals := uint64(s.Read.Sub(s.PreRead).Nanoseconds()) // Start with number of ns intervals
+	possIntervals /= 100                                         // Convert to number of 100ns intervals
+	possIntervals *= uint64(s.NumProcs)                          // Multiple by the number of processors
+
+	// Intervals used
+	intervalsUsed := s.CPUStats.CPUUsage.TotalUsage - s.PreCPUStats.CPUUsage.TotalUsage
+
+	// Percentage avoiding divide-by-zero
+	if possIntervals > 0 {
+		cpuPercent = float64(intervalsUsed) / float64(possIntervals) * 100.0
+	}
+
+	cs := &cstructs.CpuStats{
+		ThrottledPeriods: s.CPUStats.ThrottlingData.ThrottledPeriods,
+		ThrottledTime:    s.CPUStats.ThrottlingData.ThrottledTime,
+		Percent:          cpuPercent,
+		TotalTicks:       (cpuPercent / 100) * stats.TotalTicksAvailable() / float64(runtime.NumCPU()),
+		Measured:         DockerMeasuredCPUStats,
+	}
+
+	return &cstructs.TaskResourceUsage{
+		ResourceUsage: &cstructs.ResourceUsage{
+			MemoryStats: ms,
+			CpuStats:    cs,
+		},
+		Timestamp: s.Read.UTC().UnixNano(),
+	}
+}

--- a/drivers/docker/util/util.go
+++ b/drivers/docker/util/util.go
@@ -1,0 +1,11 @@
+package util
+
+func CalculateCPUPercent(newSample, oldSample, newTotal, oldTotal uint64, cores int) float64 {
+	numerator := newSample - oldSample
+	denom := newTotal - oldTotal
+	if numerator <= 0 || denom <= 0 {
+		return 0.0
+	}
+
+	return (float64(numerator) / float64(denom)) * float64(cores) * 100.0
+}


### PR DESCRIPTION
This PR adds support for fetching container stats on Windows.

This is based on the implementation in the Docker integration tests that
are referenced inline.

![image](https://user-images.githubusercontent.com/1330683/53244361-f5577300-36aa-11e9-8663-dda0f3444864.png)


fixes #2897