### PR TITLE
docker: report unhealthy in unsupported Windows

### DIFF
--- a/drivers/docker/fingerprint_test.go
+++ b/drivers/docker/fingerprint_test.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	tu "github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDockerDriver_FingersprintHealth asserts that docker reports healthy
+// whenever Docker is supported.  In particular.
+//
+// In Linux CI and AppVeyor Windows environment, it should be enabled.
+func TestDockerDriver_FingerprintHealth(t *testing.T) {
+	if !tu.IsCI() {
+		t.Parallel()
+	}
+	testutil.DockerCompatible(t)
+
+	d := NewDockerDriver(testlog.HCLogger(t)).(*Driver)
+
+	fp := d.buildFingerprint()
+	require.Equal(t, drivers.HealthStateHealthy, fp.Health)
+}

--- a/drivers/docker/fingerprint_test.go
+++ b/drivers/docker/fingerprint_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDockerDriver_FingersprintHealth asserts that docker reports healthy
-// whenever Docker is supported.  In particular.
+// TestDockerDriver_FingerprintHealth asserts that docker reports healthy
+// whenever Docker is supported.
 //
 // In Linux CI and AppVeyor Windows environment, it should be enabled.
 func TestDockerDriver_FingerprintHealth(t *testing.T) {


### PR DESCRIPTION
On Windows, Nomad only supports Windows containers, so report as
unhealthy otherwise.