### PR TITLE
docker: Return undetected before first detection

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -99,6 +99,11 @@ type Driver struct {
 	// whether it has been successful
 	fingerprintSuccess *bool
 	fingerprintLock    sync.RWMutex
+
+	// A boolean to know if the docker driver has ever been correctly detected
+	// for use during fingerprinting.
+	detected     bool
+	detectedLock sync.RWMutex
 }
 
 // NewDockerDriver returns a docker implementation of a driver plugin


### PR DESCRIPTION
Preview: https://asciinema.org/a/229631

fixes #5320

This causes the docker driver to return undetected before the daemon is available, for a better experience when hosts do not have docker installed.
After the first detection it then returns unhealthy if it subsequently goes away.

sidenote:
It appears that we do keep fingerprinting drivers if they return undetected, which I did not think was the case.