### PR TITLE
tests: disable upgrade e2e tests

### DIFF
--- a/e2e/nomad09upgrade/upgrade.go
+++ b/e2e/nomad09upgrade/upgrade.go
@@ -187,6 +187,11 @@ func (n *nomadAgent) Nomad() (*api.Client, error) {
 
 // BeforeAll downloads all of the desired nomad versions to test against
 func (tc *UpgradePathTC) BeforeAll(f *framework.F) {
+	// Upgrade tests currently fail because the nomad binary isn't found by
+	// discover.NomadExecutable().  Ensure that nomad binary is available
+	// and discoverable and enable this test
+	f.T().Skip("upgrade tests are expected to fail.  TODO: Fix")
+
 	bin, err := discover.NomadExecutable()
 	f.NoError(err)
 	tc.bin = bin


### PR DESCRIPTION
Upgrade e2e tests are failing and we haven't had bandwith to fix yet.
Having them fail makes it easy for us to miss other failures and
regressions.

As such, skip the upgrade e2e tests until we fix them.