### PR TITLE
make root block device size configurable in TF config

### DIFF
--- a/terraform/aws/env/us-east/main.tf
+++ b/terraform/aws/env/us-east/main.tf
@@ -15,6 +15,11 @@ variable "instance_type" {
   default     = "t2.medium"
 }
 
+variable "root_block_device_size" {
+  description = "The volume size of the root block device."
+  default     = 8
+}
+
 variable "key_name" {}
 
 variable "server_count" {
@@ -50,15 +55,16 @@ provider "aws" {
 module "hashistack" {
   source = "../../modules/hashistack"
 
-  name          = "${var.name}"
-  region        = "${var.region}"
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_type}"
-  key_name      = "${var.key_name}"
-  server_count  = "${var.server_count}"
-  client_count  = "${var.client_count}"
-  retry_join    = "${var.retry_join}"
-  nomad_binary  = "${var.nomad_binary}"
+  name                   = "${var.name}"
+  region                 = "${var.region}"
+  ami                    = "${var.ami}"
+  instance_type          = "${var.instance_type}"
+  key_name               = "${var.key_name}"
+  server_count           = "${var.server_count}"
+  client_count           = "${var.client_count}"
+  retry_join             = "${var.retry_join}"
+  nomad_binary           = "${var.nomad_binary}"
+  root_block_device_size = "${var.root_block_device_size}"
 }
 
 output "IP_Addresses" {

--- a/terraform/aws/modules/hashistack/hashistack.tf
+++ b/terraform/aws/modules/hashistack/hashistack.tf
@@ -6,6 +6,7 @@ variable "key_name" {}
 variable "server_count" {}
 variable "client_count" {}
 variable "nomad_binary" {}
+variable "root_block_device_size" {}
 
 variable "retry_join" {
   type = "map"
@@ -129,6 +130,12 @@ resource "aws_instance" "server" {
     map(lookup(var.retry_join, "tag_key"), lookup(var.retry_join, "tag_value"))
   )}"
 
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = "${var.root_block_device_size}"
+    delete_on_termination = "true"
+  }
+
   user_data            = "${data.template_file.user_data_server.rendered}"
   iam_instance_profile = "${aws_iam_instance_profile.instance_profile.name}"
 }
@@ -146,6 +153,12 @@ resource "aws_instance" "client" {
     map("Name", "${var.name}-client-${count.index}"),
     map(lookup(var.retry_join, "tag_key"), lookup(var.retry_join, "tag_value"))
   )}"
+
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = "${var.root_block_device_size}"
+    delete_on_termination = "true"
+  }
 
   ebs_block_device = {
     device_name           = "/dev/xvdd"


### PR DESCRIPTION
Making root block device size on the nodes configurable (this will still default to 8 GB as before if the user doesn't specify anything).

User can now add a line like the following to the *terraform.tfvars* file (https://github.com/hashicorp/nomad/blob/master/terraform/aws/env/us-east/terraform.tfvars):

`root_block_device_size = "20"`