### PR TITLE
drivers/docker: rename logging `type` to `driver`

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -256,6 +256,7 @@ var (
 		"load":               hclspec.NewAttr("load", "string", false),
 		"logging": hclspec.NewBlock("logging", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"type":   hclspec.NewAttr("type", "string", false),
+			"driver": hclspec.NewAttr("driver", "string", false),
 			"config": hclspec.NewAttr("config", "list(map(string))", false),
 		})),
 		"mac_address": hclspec.NewAttr("mac_address", "string", false),
@@ -397,6 +398,7 @@ func (d DockerDevice) toDockerDevice() (docker.Device, error) {
 
 type DockerLogging struct {
 	Type   string             `codec:"type"`
+	Driver string             `codec:"driver"`
 	Config hclutils.MapStrStr `codec:"config"`
 }
 

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -181,7 +181,8 @@ config {
   }
   load = "/tmp/image.tar.gz"
   logging {
-    type = "json-file"
+    driver = "json-file-driver"
+    type   = "json-file"
     config {
       "max-file" = "3"
       "max-size" = "10m"
@@ -308,7 +309,8 @@ config {
 		},
 		LoadImage: "/tmp/image.tar.gz",
 		Logging: DockerLogging{
-			Type: "json-file",
+			Driver: "json-file-driver",
+			Type:   "json-file",
 			Config: map[string]string{
 				"max-file": "3",
 				"max-size": "10m",

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -706,9 +706,9 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		hostConfig.MemorySwap = task.Resources.LinuxResources.MemoryLimitBytes // MemorySwap is memory + swap.
 	}
 
-	loggingDriver := driverConfig.Logging.Driver
+	loggingDriver := driverConfig.Logging.Type
 	if loggingDriver == "" {
-		loggingDriver = driverConfig.Logging.Type
+		loggingDriver = driverConfig.Logging.Driver
 	}
 
 	hostConfig.LogConfig = docker.LogConfig{

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -706,8 +706,13 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		hostConfig.MemorySwap = task.Resources.LinuxResources.MemoryLimitBytes // MemorySwap is memory + swap.
 	}
 
+	loggingDriver := driverConfig.Logging.Driver
+	if loggingDriver == "" {
+		loggingDriver = driverConfig.Logging.Type
+	}
+
 	hostConfig.LogConfig = docker.LogConfig{
-		Type:   driverConfig.Logging.Type,
+		Type:   loggingDriver,
 		Config: driverConfig.Logging.Config,
 	}
 


### PR DESCRIPTION
Docker uses the term logging `driver` in its public documentations: in
`docker` daemon config[1], `docker run` arguments [2] and in docker compose file[3].
Interestingly, docker used `type` in its API [4] instead of everywhere
else.

It's unfortunate that Nomad used `type` modeling after the Docker API
rather than the user facing documents.  Nomad using `type` feels very
non-user friendly as it's disconnected from how Docker markets the flag
and shows internal representation instead.

Here, we rectify the situation by introducing `driver` field and
prefering it over `type` in logging.

Doing it here in a backward compatible manner, and will update docs with `driver` field once 0.9 final ships.

[1] https://docs.docker.com/config/containers/logging/configure/
[2] https://docs.docker.com/engine/reference/run/#logging-drivers---log-driver
[3] https://docs.docker.com/compose/compose-file/#logging
[4] https://docs.docker.com/engine/api/v1.39/#operation/ContainerCreate