### PR TITLE
artifact stanza documentation

### DIFF
--- a/website/source/docs/job-specification/artifact.html.md
+++ b/website/source/docs/job-specification/artifact.html.md
@@ -30,7 +30,7 @@ job "docs" {
     task "server" {
       artifact {
         source      = "https://example.com/file.tar.gz"
-        destination = "/tmp/directory"
+        destination = "local/some-directory"
         options {
           checksum = "md5:df6a4178aec9fbdc1d6d7e3634d1bc33"
         }
@@ -77,18 +77,6 @@ This example downloads the artifact from the provided URL and places it in
 ```hcl
 artifact {
   source = "https://example.com/file.txt"
-}
-```
-
-### Download with Custom Destination
-
-This example downloads the artifact from the provided URL and places it at
-`/tmp/example/file.txt`, as specified by the optional `destination` parameter.
-
-```hcl
-artifact {
-  source      = "https://example.com/file.txt"
-  destination = "/tmp/example"
 }
 ```
 


### PR DESCRIPTION
the artifact stanza documentation had multiple examples (including the one leading the page) where an absolute destination was used for the artifact. this usage is not portable across drivers, so I've removed these usages. at some point in the future, it may be worthwhile pointing out the specific use cases where absolute artifact locations can be made to work, but for the purpose of clarity, this seems better.