### PR TITLE
RFC: Setup probot/stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,34 @@
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 30
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+# We don't close any issue that is an enhancement or confirmed bug, but issues waiting for reproduction
+# cases and questions tend to get outdated.
+exemptLabels:
+  - "enhancement"
+  - "bug"
+
+# Label to use when marking as stale
+staleLabel: "waiting-reply"
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: |
+  Hey there
+
+  Since this issue hasn't had any activity in a while - we're going to automatically close it in 30 days. If you're still seeing this issue with the latest version of Nomad, please respond here and we'll keep this open and take another look at this.
+
+  Thanks!
+
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: >
+  This issue will be auto-closed because there hasn't been any activity for a few months.
+  Feel free to [open a new one](https://github.com/hashicorp/nomad/issues/new) if you still experience this problem :+1:
+# Limit to only `issues`
+only: issues


### PR DESCRIPTION
Post Merge Actions:
- Install the probot Stale app on the repository ([app](Configure the
GitHub App))

Link to source/docs: https://github.com/probot/stale

We recently discussed potentially setting up a GitHub App for pruning
old issues and managing cases where we never recieve a reply.

This is a first draft at a GitHub Probot configuration for managing those issues
with a long enough cycle time that it shouldn't catch cases where there is
active discussion, and it'll ignore anything we've explicitly called out an
`enhancement` or `bug`, but will prompt people for a response if
we're `waiting-reply` etc.