### PR TITLE
Fix task/logmon leak after crash

### DIFF
--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -110,8 +110,6 @@ func (ar *allocRunner) prerun() error {
 			continue
 		}
 
-		//TODO Check hook state
-
 		name := pre.Name()
 		var start time.Time
 		if ar.logger.IsTrace() {
@@ -123,11 +121,9 @@ func (ar *allocRunner) prerun() error {
 			return fmt.Errorf("pre-run hook %q failed: %v", name, err)
 		}
 
-		//TODO Persist hook state locally
-
 		if ar.logger.IsTrace() {
 			end := time.Now()
-			ar.logger.Trace("finished pre-run hooks", "name", name, "end", end, "duration", end.Sub(start))
+			ar.logger.Trace("finished pre-run hook", "name", name, "end", end, "duration", end.Sub(start))
 		}
 	}
 

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -1,7 +1,6 @@
 package allocrunner
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -117,7 +116,7 @@ func (ar *allocRunner) prerun() error {
 			ar.logger.Trace("running pre-run hook", "name", name, "start", start)
 		}
 
-		if err := pre.Prerun(context.TODO()); err != nil {
+		if err := pre.Prerun(); err != nil {
 			return fmt.Errorf("pre-run hook %q failed: %v", name, err)
 		}
 

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -265,7 +265,7 @@ func TestAllocRunner_TaskLeader_StopRestoredTG(t *testing.T) {
 	defer cleanup()
 
 	// Use a memory backed statedb
-	conf.StateDB = state.NewMemDB()
+	conf.StateDB = state.NewMemDB(conf.Logger)
 
 	ar, err := NewAllocRunner(conf)
 	require.NoError(t, err)
@@ -579,7 +579,7 @@ func TestAllocRunner_Destroy(t *testing.T) {
 	defer cleanup()
 
 	// Use a MemDB to assert alloc state gets cleaned up
-	conf.StateDB = state.NewMemDB()
+	conf.StateDB = state.NewMemDB(conf.Logger)
 
 	ar, err := NewAllocRunner(conf)
 	require.NoError(t, err)

--- a/client/allocrunner/alloc_runner_unix_test.go
+++ b/client/allocrunner/alloc_runner_unix_test.go
@@ -1,0 +1,114 @@
+// +build !windows
+
+package allocrunner
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/client/state"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAllocRunner_Restore_RunningTerminal asserts that restoring a terminal
+// alloc with a running task properly kills the running the task. This is meant
+// to simulate a Nomad agent crash after receiving an updated alloc with
+// DesiredStatus=Stop, persisting the update, but crashing before terminating
+// the task.
+func TestAllocRunner_Restore_RunningTerminal(t *testing.T) {
+	t.Parallel()
+
+	// 1. Run task
+	// 2. Shutdown alloc runner
+	// 3. Set alloc.desiredstatus=false
+	// 4. Start new alloc runner
+	// 5. Assert task and logmon are cleaned up
+
+	alloc := mock.Alloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{
+		"run_for": "1h",
+	}
+
+	conf, cleanup := testAllocRunnerConfig(t, alloc.Copy())
+	defer cleanup()
+
+	// Maintain state for subsequent run
+	conf.StateDB = state.NewMemDB(conf.Logger)
+
+	// Start and wait for task to be running
+	ar, err := NewAllocRunner(conf)
+	require.NoError(t, err)
+	go ar.Run()
+	defer destroy(ar)
+
+	testutil.WaitForResult(func() (bool, error) {
+		s := ar.AllocState()
+		return s.ClientStatus == structs.AllocClientStatusRunning, fmt.Errorf("expected running, got %s", s.ClientStatus)
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
+	// Shutdown the AR and manually change the state to mimic a crash where
+	// a stopped alloc update is received, but Nomad crashes before
+	// stopping the alloc.
+	ar.Shutdown()
+	select {
+	case <-ar.ShutdownCh():
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "AR took too long to exit")
+	}
+
+	// Assert logmon is still running. This is a super ugly hack that pulls
+	// logmon's PID out of its reattach config, but it does properly ensure
+	// logmon gets cleaned up.
+	ls, _, err := conf.StateDB.GetTaskRunnerState(alloc.ID, task.Name)
+	require.NoError(t, err)
+	require.NotNil(t, ls)
+
+	logmonReattach := struct {
+		Pid int
+	}{}
+	err = json.Unmarshal([]byte(ls.Hooks["logmon"].Data["reattach_config"]), &logmonReattach)
+	require.NoError(t, err)
+
+	logmonProc, _ := os.FindProcess(logmonReattach.Pid)
+	require.NoError(t, logmonProc.Signal(syscall.Signal(0)))
+
+	// Fake alloc terminal during Restore()
+	alloc.DesiredStatus = structs.AllocDesiredStatusStop
+	alloc.ModifyIndex++
+	alloc.AllocModifyIndex++
+
+	// Start a new alloc runner and assert it gets stopped
+	conf2, cleanup2 := testAllocRunnerConfig(t, alloc)
+	defer cleanup2()
+
+	// Use original statedb to maintain hook state
+	conf2.StateDB = conf.StateDB
+
+	// Restore, start, and wait for task to be killed
+	ar2, err := NewAllocRunner(conf2)
+	require.NoError(t, err)
+
+	require.NoError(t, ar2.Restore())
+
+	go ar2.Run()
+	defer destroy(ar2)
+
+	select {
+	case <-ar2.WaitCh():
+	case <-time.After(30 * time.Second):
+	}
+
+	// Assert logmon was cleaned up
+	require.Error(t, logmonProc.Signal(syscall.Signal(0)))
+}

--- a/client/allocrunner/allocdir_hook.go
+++ b/client/allocrunner/allocdir_hook.go
@@ -1,8 +1,6 @@
 package allocrunner
 
 import (
-	"context"
-
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocdir"
 )
@@ -26,7 +24,7 @@ func (h *allocDirHook) Name() string {
 	return "alloc_dir"
 }
 
-func (h *allocDirHook) Prerun(context.Context) error {
+func (h *allocDirHook) Prerun() error {
 	return h.allocDir.Build()
 }
 

--- a/client/allocrunner/health_hook.go
+++ b/client/allocrunner/health_hook.go
@@ -142,7 +142,7 @@ func (h *allocHealthWatcherHook) init() error {
 	return nil
 }
 
-func (h *allocHealthWatcherHook) Prerun(context.Context) error {
+func (h *allocHealthWatcherHook) Prerun() error {
 	h.hookLock.Lock()
 	defer h.hookLock.Unlock()
 

--- a/client/allocrunner/health_hook_test.go
+++ b/client/allocrunner/health_hook_test.go
@@ -1,7 +1,6 @@
 package allocrunner
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -107,7 +106,7 @@ func TestHealthHook_PrerunPostrun(t *testing.T) {
 	require.True(ok)
 
 	// Prerun
-	require.NoError(prerunh.Prerun(context.Background()))
+	require.NoError(prerunh.Prerun())
 
 	// Assert isDeploy is false (other tests peek at isDeploy to determine
 	// if an Update applied)
@@ -137,7 +136,7 @@ func TestHealthHook_PrerunUpdatePostrun(t *testing.T) {
 	h := newAllocHealthWatcherHook(logger, alloc.Copy(), hs, b.Listen(), consul).(*allocHealthWatcherHook)
 
 	// Prerun
-	require.NoError(h.Prerun(context.Background()))
+	require.NoError(h.Prerun())
 
 	// Update multiple times in a goroutine to mimic Client behavior
 	// (Updates are concurrent with alloc runner but are applied serially).
@@ -191,7 +190,7 @@ func TestHealthHook_UpdatePrerunPostrun(t *testing.T) {
 	}
 
 	// Prerun should be a noop
-	require.NoError(h.Prerun(context.Background()))
+	require.NoError(h.Prerun())
 
 	// Assert that the Update took affect by isDeploy being true
 	h.hookLock.Lock()
@@ -283,7 +282,7 @@ func TestHealthHook_SetHealth(t *testing.T) {
 	h := newAllocHealthWatcherHook(logger, alloc.Copy(), hs, b.Listen(), consul).(*allocHealthWatcherHook)
 
 	// Prerun
-	require.NoError(h.Prerun(context.Background()))
+	require.NoError(h.Prerun())
 
 	// Wait for health to be set (healthy)
 	select {

--- a/client/allocrunner/interfaces/runner_lifecycle.go
+++ b/client/allocrunner/interfaces/runner_lifecycle.go
@@ -12,21 +12,34 @@ type RunnerHook interface {
 	Name() string
 }
 
+// RunnerPrerunHooks are executed before calling TaskRunner.Run for
+// non-terminal allocations. Terminal allocations do *not* call prerun.
 type RunnerPrerunHook interface {
 	RunnerHook
 	Prerun(context.Context) error
 }
 
+// RunnerPostrunHooks are executed after calling TaskRunner.Run, even for
+// terminal allocations. Therefore Postrun hooks must be safe to call without
+// first calling Prerun hooks.
 type RunnerPostrunHook interface {
 	RunnerHook
 	Postrun() error
 }
 
+// RunnerDestroyHooks are executed after AllocRunner.Run has exited and must
+// make a best effort cleanup allocation resources. Destroy hooks must be safe
+// to call without first calling Prerun.
 type RunnerDestroyHook interface {
 	RunnerHook
 	Destroy() error
 }
 
+// RunnerUpdateHooks are executed when an allocation update is received from
+// the server. Update is called concurrently with AllocRunner execution and
+// therefore must be safe for concurrent access with other hook methods. Calls
+// to Update are serialized so allocaiton updates will always be processed in
+// order.
 type RunnerUpdateHook interface {
 	RunnerHook
 	Update(*RunnerUpdateRequest) error

--- a/client/allocrunner/interfaces/runner_lifecycle.go
+++ b/client/allocrunner/interfaces/runner_lifecycle.go
@@ -1,9 +1,6 @@
 package interfaces
 
 import (
-	"context"
-
-	"github.com/hashicorp/nomad/client/allocrunner/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -16,7 +13,7 @@ type RunnerHook interface {
 // non-terminal allocations. Terminal allocations do *not* call prerun.
 type RunnerPrerunHook interface {
 	RunnerHook
-	Prerun(context.Context) error
+	Prerun() error
 }
 
 // RunnerPostrunHooks are executed after calling TaskRunner.Run, even for
@@ -47,13 +44,6 @@ type RunnerUpdateHook interface {
 
 type RunnerUpdateRequest struct {
 	Alloc *structs.Allocation
-}
-
-// XXX Not sure yet
-type RunnerHookFactory func(target HookTarget) (RunnerHook, error)
-type HookTarget interface {
-	// State retrieves a copy of the target alloc runners state.
-	State() *state.State
 }
 
 // ShutdownHook may be implemented by AllocRunner or TaskRunner hooks and will

--- a/client/allocrunner/interfaces/task_lifecycle.go
+++ b/client/allocrunner/interfaces/task_lifecycle.go
@@ -88,6 +88,8 @@ type TaskPrestartHook interface {
 
 	// Prestart is called before the task is started including after every
 	// restart. Prestart is not called if the allocation is terminal.
+	//
+	// The context is cancelled if the task is killed.
 	Prestart(context.Context, *TaskPrestartRequest, *TaskPrestartResponse) error
 }
 
@@ -116,6 +118,8 @@ type TaskPoststartHook interface {
 
 	// Poststart is called after the task has started. Poststart is not
 	// called if the allocation is terminal.
+	//
+	// The context is cancelled if the task is killed.
 	Poststart(context.Context, *TaskPoststartRequest, *TaskPoststartResponse) error
 }
 
@@ -139,6 +143,8 @@ type TaskExitedHook interface {
 
 	// Exited is called after a task exits and may or may not be restarted.
 	// Prestart may or may not have been called.
+	//
+	// The context is cancelled if the task is killed.
 	Exited(context.Context, *TaskExitedRequest, *TaskExitedResponse) error
 }
 
@@ -156,6 +162,13 @@ type TaskUpdateResponse struct{}
 
 type TaskUpdateHook interface {
 	TaskHook
+
+	// Update is called when the servers have updated the Allocation for
+	// this task. Updates are concurrent with all other task hooks and
+	// therefore hooks that implement this interface must be completely
+	// safe for concurrent access.
+	//
+	// The context is cancelled if the task is killed.
 	Update(context.Context, *TaskUpdateRequest, *TaskUpdateResponse) error
 }
 
@@ -176,6 +189,7 @@ type TaskStopHook interface {
 	// Therefore it may be called even when prestart and the other hooks
 	// have not.
 	//
-	// Stop hooks must be idempotent.
+	// Stop hooks must be idempotent. The context is cancelled if the task
+	// is killed.
 	Stop(context.Context, *TaskStopRequest, *TaskStopResponse) error
 }

--- a/client/allocrunner/interfaces/task_lifecycle.go
+++ b/client/allocrunner/interfaces/task_lifecycle.go
@@ -87,7 +87,7 @@ type TaskPrestartHook interface {
 	TaskHook
 
 	// Prestart is called before the task is started including after every
-	// restart.
+	// restart. Prestart is not called if the allocation is terminal.
 	Prestart(context.Context, *TaskPrestartRequest, *TaskPrestartResponse) error
 }
 
@@ -114,7 +114,8 @@ type TaskPoststartResponse struct{}
 type TaskPoststartHook interface {
 	TaskHook
 
-	// Poststart is called after the task has started.
+	// Poststart is called after the task has started. Poststart is not
+	// called if the allocation is terminal.
 	Poststart(context.Context, *TaskPoststartRequest, *TaskPoststartResponse) error
 }
 
@@ -125,7 +126,8 @@ type TaskPreKillHook interface {
 	TaskHook
 
 	// PreKilling is called right before a task is going to be killed or
-	// restarted. They are called concurrently with TaskRunner.Run.
+	// restarted. They are called concurrently with TaskRunner.Run and may
+	// be called without Prestart being called.
 	PreKilling(context.Context, *TaskPreKillRequest, *TaskPreKillResponse) error
 }
 
@@ -136,6 +138,7 @@ type TaskExitedHook interface {
 	TaskHook
 
 	// Exited is called after a task exits and may or may not be restarted.
+	// Prestart may or may not have been called.
 	Exited(context.Context, *TaskExitedRequest, *TaskExitedResponse) error
 }
 

--- a/client/allocrunner/migrate_hook.go
+++ b/client/allocrunner/migrate_hook.go
@@ -30,7 +30,9 @@ func (h *diskMigrationHook) Name() string {
 	return "migrate_disk"
 }
 
-func (h *diskMigrationHook) Prerun(ctx context.Context) error {
+func (h *diskMigrationHook) Prerun() error {
+	ctx := context.TODO()
+
 	// Wait for a previous alloc - if any - to terminate
 	if err := h.allocWatcher.Wait(ctx); err != nil {
 		return err

--- a/client/allocrunner/taskrunner/artifact_hook.go
+++ b/client/allocrunner/taskrunner/artifact_hook.go
@@ -37,16 +37,16 @@ func (h *artifactHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 		return nil
 	}
 
-	// Initialize HookData to store download progress
-	resp.HookData = make(map[string]string, len(req.Task.Artifacts))
+	// Initialize hook state to store download progress
+	resp.State = make(map[string]string, len(req.Task.Artifacts))
 
 	h.eventEmitter.EmitEvent(structs.NewTaskEvent(structs.TaskDownloadingArtifacts))
 
 	for _, artifact := range req.Task.Artifacts {
 		aid := artifact.Hash()
-		if req.HookData[aid] != "" {
+		if req.PreviousState[aid] != "" {
 			h.logger.Trace("skipping already downloaded artifact", "artifact", artifact.GetterSource)
-			resp.HookData[aid] = req.HookData[aid]
+			resp.State[aid] = req.PreviousState[aid]
 			continue
 		}
 
@@ -65,7 +65,7 @@ func (h *artifactHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 		// Mark artifact as downloaded to avoid re-downloading due to
 		// retries caused by subsequent artifacts failing. Any
 		// non-empty value works.
-		resp.HookData[aid] = "1"
+		resp.State[aid] = "1"
 	}
 
 	resp.Done = true

--- a/client/allocrunner/taskrunner/logmon_hook.go
+++ b/client/allocrunner/taskrunner/logmon_hook.go
@@ -95,7 +95,7 @@ func reattachConfigFromHookData(data map[string]string) (*plugin.ReattachConfig,
 func (h *logmonHook) Prestart(ctx context.Context,
 	req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
 
-	reattachConfig, err := reattachConfigFromHookData(req.HookData)
+	reattachConfig, err := reattachConfigFromHookData(req.PreviousState)
 	if err != nil {
 		h.logger.Error("failed to load reattach config", "error", err)
 		return err
@@ -131,11 +131,20 @@ func (h *logmonHook) Prestart(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	resp.HookData = map[string]string{logmonReattachKey: string(jsonCfg)}
+	resp.State = map[string]string{logmonReattachKey: string(jsonCfg)}
 	return nil
 }
 
-func (h *logmonHook) Stop(context.Context, *interfaces.TaskStopRequest, *interfaces.TaskStopResponse) error {
+func (h *logmonHook) Stop(_ context.Context, req *interfaces.TaskStopRequest, _ *interfaces.TaskStopResponse) error {
+
+	// It's possible that Stop was called without calling Prestart on agent
+	// restarts. Attempt to reattach to an existing logmon.
+	if h.logmon == nil || h.logmonPluginClient == nil {
+		if err := h.reattach(req); err != nil {
+			h.logger.Debug("error reattaching to logmon when stopping")
+		}
+	}
+
 	if h.logmon != nil {
 		h.logmon.Stop()
 	}
@@ -144,4 +153,19 @@ func (h *logmonHook) Stop(context.Context, *interfaces.TaskStopRequest, *interfa
 	}
 
 	return nil
+}
+
+// reattach to a running logmon if possible. Will not start a new logmon.
+func (h *logmonHook) reattach(req *interfaces.TaskStopRequest) error {
+	reattachConfig, err := reattachConfigFromHookData(req.ExistingState)
+	if err != nil {
+		return err
+	}
+
+	// Give up if there's no reattach config
+	if reattachConfig == nil {
+		return nil
+	}
+
+	return h.launchLogMon(reattachConfig)
 }

--- a/client/allocrunner/taskrunner/logmon_hook.go
+++ b/client/allocrunner/taskrunner/logmon_hook.go
@@ -141,7 +141,7 @@ func (h *logmonHook) Stop(_ context.Context, req *interfaces.TaskStopRequest, _ 
 	// restarts. Attempt to reattach to an existing logmon.
 	if h.logmon == nil || h.logmonPluginClient == nil {
 		if err := h.reattach(req); err != nil {
-			h.logger.Debug("error reattaching to logmon when stopping")
+			h.logger.Trace("error reattaching to logmon when stopping", "error", err)
 		}
 	}
 

--- a/client/allocrunner/taskrunner/logmon_hook_unix_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_unix_test.go
@@ -46,7 +46,7 @@ func TestTaskRunner_LogmonHook_StartCrashStop(t *testing.T) {
 	require.NoError(t, hook.Prestart(context.Background(), &req, &resp))
 	defer hook.Stop(context.Background(), nil, nil)
 
-	origHookData := resp.HookData[logmonReattachKey]
+	origHookData := resp.State[logmonReattachKey]
 	require.NotEmpty(t, origHookData)
 
 	// Pluck PID out of reattach synthesize a crash
@@ -75,14 +75,14 @@ func TestTaskRunner_LogmonHook_StartCrashStop(t *testing.T) {
 
 	// Running prestart again should return a recoverable error with no
 	// reattach config to cause the task to be restarted with a new logmon.
-	req.HookData = map[string]string{
+	req.PreviousState = map[string]string{
 		logmonReattachKey: origHookData,
 	}
 	resp = interfaces.TaskPrestartResponse{}
 	err = hook.Prestart(context.Background(), &req, &resp)
 	require.Error(t, err)
 	require.True(t, structs.IsRecoverable(err))
-	require.Empty(t, resp.HookData)
+	require.Empty(t, resp.State)
 
 	// Running stop should shutdown logmon
 	require.NoError(t, hook.Stop(context.Background(), nil, nil))

--- a/client/allocrunner/taskrunner/state/state.go
+++ b/client/allocrunner/taskrunner/state/state.go
@@ -83,8 +83,8 @@ func (h *HookState) Copy() *HookState {
 
 	c := new(HookState)
 	*c = *h
-	c.Data = helper.CopyMapStringString(c.Data)
-	c.Env = helper.CopyMapStringString(c.Env)
+	c.Data = helper.CopyMapStringString(h.Data)
+	c.Env = helper.CopyMapStringString(h.Env)
 	return c
 }
 

--- a/client/allocrunner/taskrunner/state/state.go
+++ b/client/allocrunner/taskrunner/state/state.go
@@ -41,8 +41,12 @@ func (s *LocalState) Canonicalize() {
 	}
 }
 
-// Copy should be called with the lock held
+// Copy LocalState. Returns nil if nil.
 func (s *LocalState) Copy() *LocalState {
+	if s == nil {
+		return nil
+	}
+
 	// Create a copy
 	c := &LocalState{
 		Hooks:         make(map[string]*HookState, len(s.Hooks)),
@@ -50,7 +54,7 @@ func (s *LocalState) Copy() *LocalState {
 		TaskHandle:    s.TaskHandle.Copy(),
 	}
 
-	// Copy the hooks
+	// Copy the hook state
 	for h, state := range s.Hooks {
 		c.Hooks[h] = state.Copy()
 	}
@@ -71,7 +75,12 @@ type HookState struct {
 	Env map[string]string
 }
 
+// Copy HookState. Returns nil if its nil.
 func (h *HookState) Copy() *HookState {
+	if h == nil {
+		return nil
+	}
+
 	c := new(HookState)
 	*c = *h
 	c.Data = helper.CopyMapStringString(c.Data)

--- a/client/allocrunner/taskrunner/task_dir_hook.go
+++ b/client/allocrunner/taskrunner/task_dir_hook.go
@@ -43,9 +43,9 @@ func (h *taskDirHook) Name() string {
 
 func (h *taskDirHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
 	fsi := h.runner.driverCapabilities.FSIsolation
-	if v, ok := req.HookData[TaskDirHookIsDoneDataKey]; ok && v == "true" {
+	if v, ok := req.PreviousState[TaskDirHookIsDoneDataKey]; ok && v == "true" {
 		setEnvvars(h.runner.envBuilder, fsi, h.runner.taskDir, h.runner.clientConfig)
-		resp.HookData = map[string]string{
+		resp.State = map[string]string{
 			TaskDirHookIsDoneDataKey: "true",
 		}
 		return nil
@@ -68,7 +68,7 @@ func (h *taskDirHook) Prestart(ctx context.Context, req *interfaces.TaskPrestart
 
 	// Update the environment variables based on the built task directory
 	setEnvvars(h.runner.envBuilder, fsi, h.runner.taskDir, h.runner.clientConfig)
-	resp.HookData = map[string]string{
+	resp.State = map[string]string{
 		TaskDirHookIsDoneDataKey: "true",
 	}
 	return nil

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -391,10 +391,9 @@ func (tr *TaskRunner) Run() {
 	go tr.handleUpdates()
 
 MAIN:
-	for {
+	for !tr.Alloc().TerminalStatus() {
 		select {
 		case <-tr.killCtx.Done():
-			tr.handleKill()
 			break MAIN
 		case <-tr.shutdownCtx.Done():
 			// TaskRunner was told to exit immediately
@@ -411,7 +410,6 @@ MAIN:
 
 		select {
 		case <-tr.killCtx.Done():
-			tr.handleKill()
 			break MAIN
 		case <-tr.shutdownCtx.Done():
 			// TaskRunner was told to exit immediately
@@ -483,12 +481,19 @@ MAIN:
 		case <-time.After(restartDelay):
 		case <-tr.killCtx.Done():
 			tr.logger.Trace("task killed between restarts", "delay", restartDelay)
-			tr.handleKill()
 			break MAIN
 		case <-tr.shutdownCtx.Done():
 			// TaskRunner was told to exit immediately
+			tr.logger.Trace("gracefully shutting down during restart delay")
 			return
 		}
+	}
+
+	// Ensure handle is cleaned up. Restore could have recovered a task
+	// that should be terminal, so if the handle still exists we should
+	// kill it here.
+	if tr.getDriverHandle() != nil {
+		tr.handleKill()
 	}
 
 	// Mark the task as dead
@@ -709,8 +714,8 @@ func (tr *TaskRunner) initDriver() error {
 }
 
 // handleKill is used to handle the a request to kill a task. It will return
-//// the handle exit result if one is available and store any error in the task
-//// runner killErr value.
+// the handle exit result if one is available and store any error in the task
+// runner killErr value.
 func (tr *TaskRunner) handleKill() *drivers.ExitResult {
 	// Run the pre killing hooks
 	tr.preKill()
@@ -1039,9 +1044,9 @@ func (tr *TaskRunner) WaitCh() <-chan struct{} {
 }
 
 // Update the running allocation with a new version received from the server.
-// Calls Update hooks asynchronously with Run().
+// Calls Update hooks asynchronously with Run.
 //
-// This method is safe for calling concurrently with Run() and does not modify
+// This method is safe for calling concurrently with Run and does not modify
 // the passed in allocation.
 func (tr *TaskRunner) Update(update *structs.Allocation) {
 	task := update.LookupTask(tr.taskName)

--- a/client/allocrunner/taskrunner/task_runner_getters.go
+++ b/client/allocrunner/taskrunner/task_runner_getters.go
@@ -1,6 +1,7 @@
 package taskrunner
 
 import (
+	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -112,4 +113,17 @@ func (tr *TaskRunner) hasRunLaunched() bool {
 	tr.runLaunchedLock.Lock()
 	defer tr.runLaunchedLock.Unlock()
 	return tr.runLaunched
+}
+
+// hookState returns the state for the given hook or nil if no state is
+// persisted for the hook.
+func (tr *TaskRunner) hookState(name string) *state.HookState {
+	tr.stateLock.RLock()
+	defer tr.stateLock.RUnlock()
+
+	var s *state.HookState
+	if tr.localState.Hooks != nil {
+		s = tr.localState.Hooks[name].Copy()
+	}
+	return s
 }

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -137,7 +137,7 @@ func TestTaskRunner_Restore_Running(t *testing.T) {
 		"run_for": "2s",
 	}
 	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
-	conf.StateDB = cstate.NewMemDB() // "persist" state between task runners
+	conf.StateDB = cstate.NewMemDB(conf.Logger) // "persist" state between task runners
 	defer cleanup()
 
 	// Run the first TaskRunner
@@ -235,7 +235,7 @@ func TestTaskRunner_DevicePropogation(t *testing.T) {
 	tRes.Devices = append(tRes.Devices, &structs.AllocatedDeviceResource{Type: "mock"})
 
 	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
-	conf.StateDB = cstate.NewMemDB() // "persist" state between task runners
+	conf.StateDB = cstate.NewMemDB(conf.Logger) // "persist" state between task runners
 	defer cleanup()
 
 	// Setup the devicemanager
@@ -323,7 +323,7 @@ func TestTaskRunner_Restore_HookEnv(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
-	conf.StateDB = cstate.NewMemDB() // "persist" state between prestart calls
+	conf.StateDB = cstate.NewMemDB(conf.Logger) // "persist" state between prestart calls
 	defer cleanup()
 
 	tr, err := NewTaskRunner(conf)
@@ -368,7 +368,7 @@ func TestTaskRunner_RecoverFromDriverExiting(t *testing.T) {
 	}
 
 	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
-	conf.StateDB = cstate.NewMemDB() // "persist" state between prestart calls
+	conf.StateDB = cstate.NewMemDB(conf.Logger) // "persist" state between prestart calls
 	defer cleanup()
 
 	tr, err := NewTaskRunner(conf)

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1546,11 +1546,18 @@ func TestTaskRunner_UnregisterConsul_Retries(t *testing.T) {
 	consul := conf.Consul.(*consulapi.MockConsulServiceClient)
 	consulOps := consul.GetOps()
 	require.Len(t, consulOps, 6)
-	// pattern: add followed by two removals
+
+	// Initial add
 	require.Equal(t, "add", consulOps[0].Op)
+
+	// Removing canary and non-canary entries on first exit
 	require.Equal(t, "remove", consulOps[1].Op)
 	require.Equal(t, "remove", consulOps[2].Op)
+
+	// Second add on retry
 	require.Equal(t, "add", consulOps[3].Op)
+
+	// Removing canary and non-canary entries on retry
 	require.Equal(t, "remove", consulOps[4].Op)
 	require.Equal(t, "remove", consulOps[5].Op)
 }

--- a/client/allocrunner/upstream_allocs_hook.go
+++ b/client/allocrunner/upstream_allocs_hook.go
@@ -26,7 +26,7 @@ func (h *upstreamAllocsHook) Name() string {
 	return "await_previous_allocations"
 }
 
-func (h *upstreamAllocsHook) Prerun(ctx context.Context) error {
+func (h *upstreamAllocsHook) Prerun() error {
 	// Wait for a previous alloc - if any - to terminate
-	return h.allocWatcher.Wait(ctx)
+	return h.allocWatcher.Wait(context.Background())
 }

--- a/client/devicemanager/manager_test.go
+++ b/client/devicemanager/manager_test.go
@@ -119,11 +119,12 @@ func baseTestConfig(t *testing.T) (
 	mc := &loader.MockCatalog{}
 
 	// Create the config
+	logger := testlog.HCLogger(t)
 	config = &Config{
-		Logger:        testlog.HCLogger(t),
+		Logger:        logger,
 		PluginConfig:  &base.AgentConfig{},
 		StatsInterval: 100 * time.Millisecond,
-		State:         state.NewMemDB(),
+		State:         state.NewMemDB(logger),
 		Updater:       updateFn,
 		Loader:        mc,
 	}

--- a/client/state/db_test.go
+++ b/client/state/db_test.go
@@ -44,7 +44,7 @@ func testDB(t *testing.T, f func(*testing.T, StateDB)) {
 	boltdb, cleanup := setupBoltStateDB(t)
 	defer cleanup()
 
-	memdb := NewMemDB()
+	memdb := NewMemDB(testlog.HCLogger(t))
 
 	impls := []StateDB{boltdb, memdb}
 

--- a/client/state/memdb.go
+++ b/client/state/memdb.go
@@ -3,6 +3,7 @@ package state
 import (
 	"sync"
 
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
@@ -28,15 +29,19 @@ type MemDB struct {
 	// drivermanager -> plugin-state
 	driverManagerPs *driverstate.PluginState
 
+	logger hclog.Logger
+
 	mu sync.RWMutex
 }
 
-func NewMemDB() *MemDB {
+func NewMemDB(logger hclog.Logger) *MemDB {
+	logger = logger.Named("memdb")
 	return &MemDB{
 		allocs:         make(map[string]*structs.Allocation),
 		deployStatus:   make(map[string]*structs.AllocDeploymentStatus),
 		localTaskState: make(map[string]map[string]*state.LocalState),
 		taskState:      make(map[string]map[string]*structs.TaskState),
+		logger:         logger,
 	}
 }
 


### PR DESCRIPTION
The primary goal of this PR is to fix the following:

1. Alloc runs
2. Client receives alloc update with DesiredStatus=Stop _and persists it_
3. Client crashes before stopping tasks and their log daemons
4. On client restart the tasks and log daemons would be leaked

There's 3 major parts:

1. AR.Run *always* calls TR.Run -- even for terminal allocs.
   * We went back and forth on this behavior, and I think this is optimal. It makes AR & TR easier to reason about (New is always called, Restore is called on restart, Run is always called).
2. TR.Run detects if the alloc is terminal and cleans up.
3. Stop hooks (like logmon) now receive hook state in order to know what state needs cleaning up.