### PR TITLE
Tweaked deprecation wording for legacy config

### DIFF
--- a/website/source/docs/drivers/raw_exec.html.md
+++ b/website/source/docs/drivers/raw_exec.html.md
@@ -88,8 +88,8 @@ plugin "raw_exec" {
 }
 ```
 
-Nomad versions before v0.9 use the folowing client configuration. This configuration is also supported in Nomad v0.9.0, but 
-is deprecated in favor of the plugin stanza:
+Nomad versions before v0.9 use the folowing client configuration. This configuration is
+also supported in Nomad v0.9.0, but is deprecated in favor of the plugin stanza:
 
 ```
 client {

--- a/website/source/docs/drivers/raw_exec.html.md
+++ b/website/source/docs/drivers/raw_exec.html.md
@@ -88,8 +88,8 @@ plugin "raw_exec" {
 }
 ```
 
-Prior to Nomad 0.9, the client configuration would look like this (this syntax
-will soon be deprecated):
+Nomad versions before v0.9 use the folowing client configuration. This configuration is also supported in Nomad v0.9.0, but 
+is deprecated in favor of the plugin stanza:
 
 ```
 client {


### PR DESCRIPTION
Made small adjustment to make it clear that 0.8.7 would require the legacy syntax and that the deprecation notice was more about the legacy syntax becoming unsupported at some point after v0.9.0