### PR TITLE
Fix regression with requiring docker auth email

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1668,15 +1668,16 @@ func TestDockerDriver_AuthFromTaskConfig(t *testing.T) {
 	if !tu.IsCI() {
 		t.Parallel()
 	}
-	testutil.DockerCompatible(t)
 
 	cases := []struct {
 		Auth       DockerAuth
 		AuthConfig *docker.AuthConfiguration
+		Desc       string
 	}{
 		{
 			Auth:       DockerAuth{},
 			AuthConfig: nil,
+			Desc:       "Empty Config",
 		},
 		{
 			Auth: DockerAuth{
@@ -1691,6 +1692,7 @@ func TestDockerDriver_AuthFromTaskConfig(t *testing.T) {
 				Email:         "foo@bar.com",
 				ServerAddress: "www.foobar.com",
 			},
+			Desc: "All fields set",
 		},
 		{
 			Auth: DockerAuth{
@@ -1703,13 +1705,16 @@ func TestDockerDriver_AuthFromTaskConfig(t *testing.T) {
 				Password:      "bar",
 				ServerAddress: "www.foobar.com",
 			},
+			Desc: "Email not set",
 		},
 	}
 
 	for _, c := range cases {
-		act, err := authFromTaskConfig(&TaskConfig{Auth: c.Auth})("test")
-		require.NoError(t, err)
-		require.Exactly(t, c.AuthConfig, act)
+		t.Run(c.Desc, func(t *testing.T) {
+			act, err := authFromTaskConfig(&TaskConfig{Auth: c.Auth})("test")
+			require.NoError(t, err)
+			require.Exactly(t, c.AuthConfig, act)
+		})
 	}
 }
 

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1664,6 +1664,55 @@ func TestDockerDriver_AuthConfiguration(t *testing.T) {
 	}
 }
 
+func TestDockerDriver_AuthFromTaskConfig(t *testing.T) {
+	if !tu.IsCI() {
+		t.Parallel()
+	}
+	testutil.DockerCompatible(t)
+
+	cases := []struct {
+		Auth       DockerAuth
+		AuthConfig *docker.AuthConfiguration
+	}{
+		{
+			Auth:       DockerAuth{},
+			AuthConfig: nil,
+		},
+		{
+			Auth: DockerAuth{
+				Username:   "foo",
+				Password:   "bar",
+				Email:      "foo@bar.com",
+				ServerAddr: "www.foobar.com",
+			},
+			AuthConfig: &docker.AuthConfiguration{
+				Username:      "foo",
+				Password:      "bar",
+				Email:         "foo@bar.com",
+				ServerAddress: "www.foobar.com",
+			},
+		},
+		{
+			Auth: DockerAuth{
+				Username:   "foo",
+				Password:   "bar",
+				ServerAddr: "www.foobar.com",
+			},
+			AuthConfig: &docker.AuthConfiguration{
+				Username:      "foo",
+				Password:      "bar",
+				ServerAddress: "www.foobar.com",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		act, err := authFromTaskConfig(&TaskConfig{Auth: c.Auth})("test")
+		require.NoError(t, err)
+		require.Exactly(t, c.AuthConfig, act)
+	}
+}
+
 func TestDockerDriver_OOMKilled(t *testing.T) {
 	if !tu.IsCI() {
 		t.Parallel()

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -82,7 +82,7 @@ func firstValidAuth(repo string, backends []authBackend) (*docker.AuthConfigurat
 // authFromTaskConfig generates an authBackend for any auth given in the task-configuration
 func authFromTaskConfig(driverConfig *TaskConfig) authBackend {
 	return func(string) (*docker.AuthConfiguration, error) {
-		if len(driverConfig.Auth.Email) == 0 {
+		if len(driverConfig.Auth.Username) == 0 {
 			return nil, nil
 		}
 		return &docker.AuthConfiguration{

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -82,7 +82,8 @@ func firstValidAuth(repo string, backends []authBackend) (*docker.AuthConfigurat
 // authFromTaskConfig generates an authBackend for any auth given in the task-configuration
 func authFromTaskConfig(driverConfig *TaskConfig) authBackend {
 	return func(string) (*docker.AuthConfiguration, error) {
-		if len(driverConfig.Auth.Username) == 0 {
+		// If all auth fields are empty, return
+		if len(driverConfig.Auth.Username) == 0 && len(driverConfig.Auth.Password) == 0 && len(driverConfig.Auth.Email) == 0 && len(driverConfig.Auth.ServerAddr) == 0 {
 			return nil, nil
 		}
 		return &docker.AuthConfiguration{


### PR DESCRIPTION
Fixes #5412 

In 0.8.7 we looked for a overall non empty config. This fixes a bug in 0.9 beta3 where we checked for email being non empty. Instead, this only returns nil if all auth fields are empty.