### PR TITLE
drivers: Handle out-of-nomad executor termination

### DIFF
--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -430,11 +430,42 @@ func (d *Driver) WaitTask(ctx context.Context, taskID string) (<-chan *drivers.E
 	return ch, nil
 }
 
+// handleFailedExecutor is called when we receive an unrecoverable error from
+// an executor process.
+//
+// Here we attempt to clean up the orphaned subprocesses before returning the
+// error to the Nomad client to avoid orphaning the process and running duplicate
+// tasks.
+func (d *Driver) handleFailedExecutor(handle *taskHandle) error {
+	// If the pid is unset (0), or is kernel task (1), then we shouldn't try to
+	// look it up and terminate it. This case should never happen, but exists
+	// for extra defensiveness.
+	if handle.pid < 2 {
+		return nil
+	}
+
+	ps, err := os.FindProcess(handle.pid)
+	if err != nil {
+		return fmt.Errorf("Could not find child process (%d): %v", handle.pid, err)
+	}
+
+	err = ps.Kill()
+	if err != nil {
+		return fmt.Errorf("Failed to terminate child process (%d): %v", handle.pid, err)
+	}
+
+	return nil
+}
+
 func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *drivers.ExitResult) {
 	defer close(ch)
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait(ctx)
 	if err != nil {
+		cErr := d.handleFailedExecutor(handle)
+		if cErr != nil {
+			d.logger.Error("Failed to cleanup subprocess", "error", err)
+		}
 		result = &drivers.ExitResult{
 			Err: fmt.Errorf("executor: error waiting on process: %v", err),
 		}

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -585,11 +586,42 @@ func GetAbsolutePath(bin string) (string, error) {
 	return filepath.EvalSymlinks(lp)
 }
 
+// handleFailedExecutor is called when we receive an unrecoverable error from
+// an executor process.
+//
+// Here we attempt to clean up the orphaned subprocesses before returning the
+// error to the Nomad client to avoid orphaning the process and running duplicate
+// tasks.
+func (d *Driver) handleFailedExecutor(handle *taskHandle) error {
+	// If the pid is unset (0), or is kernel task (1), then we shouldn't try to
+	// look it up and terminate it. This case should never happen, but exists
+	// for extra defensiveness.
+	if handle.pid < 2 {
+		return nil
+	}
+
+	ps, err := os.FindProcess(handle.pid)
+	if err != nil {
+		return fmt.Errorf("Could not find child process (%d): %v", handle.pid, err)
+	}
+
+	err = ps.Kill()
+	if err != nil {
+		return fmt.Errorf("Failed to terminate child process (%d): %v", handle.pid, err)
+	}
+
+	return nil
+}
+
 func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *drivers.ExitResult) {
 	defer close(ch)
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait(ctx)
 	if err != nil {
+		cErr := d.handleFailedExecutor(handle)
+		if cErr != nil {
+			d.logger.Error("Failed to cleanup subprocess", "error", err)
+		}
 		result = &drivers.ExitResult{
 			Err: fmt.Errorf("executor: error waiting on process: %v", err),
 		}

--- a/drivers/rawexec/driver.go
+++ b/drivers/rawexec/driver.go
@@ -392,11 +392,42 @@ func (d *Driver) WaitTask(ctx context.Context, taskID string) (<-chan *drivers.E
 	return ch, nil
 }
 
+// handleFailedExecutor is called when we receive an unrecoverable error from
+// an executor process.
+//
+// Here we attempt to clean up the orphaned subprocesses before returning the
+// error to the Nomad client to avoid orphaning the process and running duplicate
+// tasks.
+func (d *Driver) handleFailedExecutor(handle *taskHandle) error {
+	// If the pid is unset (0), or is kernel task (1), then we shouldn't try to
+	// look it up and terminate it. This case should never happen, but exists
+	// for extra defensiveness.
+	if handle.pid < 2 {
+		return nil
+	}
+
+	ps, err := os.FindProcess(handle.pid)
+	if err != nil {
+		return fmt.Errorf("Could not find child process (%d): %v", handle.pid, err)
+	}
+
+	err = ps.Kill()
+	if err != nil {
+		return fmt.Errorf("Failed to terminate child process (%d): %v", handle.pid, err)
+	}
+
+	return nil
+}
+
 func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *drivers.ExitResult) {
 	defer close(ch)
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait(ctx)
 	if err != nil {
+		cErr := d.handleFailedExecutor(handle)
+		if cErr != nil {
+			d.logger.Error("Failed to cleanup subprocess", "error", err)
+		}
 		result = &drivers.ExitResult{
 			Err: fmt.Errorf("executor: error waiting on process: %v", err),
 		}

--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -1046,11 +1046,42 @@ func elide(inBuf bytes.Buffer) string {
 	return tempBuf.String()
 }
 
+// handleFailedExecutor is called when we receive an unrecoverable error from
+// an executor process.
+//
+// Here we attempt to clean up the orphaned subprocesses before returning the
+// error to the Nomad client to avoid orphaning the process and running duplicate
+// tasks.
+func (d *Driver) handleFailedExecutor(handle *taskHandle) error {
+	// If the pid is unset (0), or is kernel task (1), then we shouldn't try to
+	// look it up and terminate it. This case should never happen, but exists
+	// for extra defensiveness.
+	if handle.pid < 2 {
+		return nil
+	}
+
+	ps, err := os.FindProcess(handle.pid)
+	if err != nil {
+		return fmt.Errorf("Could not find child process (%d): %v", handle.pid, err)
+	}
+
+	err = ps.Kill()
+	if err != nil {
+		return fmt.Errorf("Failed to terminate child process (%d): %v", handle.pid, err)
+	}
+
+	return nil
+}
+
 func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *drivers.ExitResult) {
 	defer close(ch)
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait(ctx)
 	if err != nil {
+		cErr := d.handleFailedExecutor(handle)
+		if cErr != nil {
+			d.logger.Error("Failed to cleanup subprocess", "error", err)
+		}
 		result = &drivers.ExitResult{
 			Err: fmt.Errorf("executor: error waiting on process: %v", err),
 		}


### PR DESCRIPTION
This commit adds a new handleFailedExecutor function to drivers that
execute processes via the nomad `executor` supervisor.

This function is invoked during failures in WaitTask to avoid the case where
we will orphan the users application process if the executor process is
killed unexpectedly, as the child may continue to live on.

It does _not_ fix the leak in cases where an executor process dies while the
Task Driver process is down, because in those cases we will need to more
strictly validate the child pid to avoid wrongfully terminating user
processes in high pid churn environments, or after extended client
downtime.

related to #5408