### PR TITLE
Freebsd vagrant fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,9 +49,10 @@ Vagrant.configure(2) do |config|
 	config.vm.define "freebsd", autostart: false, primary: false do |vmCfg|
 		vmCfg.vm.box = FREEBSD_BASE_BOX
 		vmCfg.vm.hostname = "freebsd"
+		vmCfg.ssh.shell = "sh"
 		vmCfg = configureProviders vmCfg,
 			cpus: suggestedCPUCores()
-
+		vmCfg.vm.network "private_network", type: "dhcp"
 		vmCfg.vm.synced_folder '.',
 			'/opt/gopath/src/github.com/hashicorp/nomad',
 			type: "nfs",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 #
 
 LINUX_BASE_BOX = "bento/ubuntu-16.04"
-FREEBSD_BASE_BOX = "jen20/FreeBSD-11.1-RELEASE"
+FREEBSD_BASE_BOX = "freebsd/FreeBSD-11.2-STABLE"
 
 Vagrant.configure(2) do |config|
 	# Compilation and development boxes

--- a/scripts/vagrant-freebsd-priv-config.sh
+++ b/scripts/vagrant-freebsd-priv-config.sh
@@ -17,7 +17,7 @@ EOT
 pkg update
 
 pkg install -y \
-       editors/vim-lite \
+       editors/vim-tiny \
        devel/git \
        devel/gmake \
        lang/go \


### PR DESCRIPTION
## Description

Changes that allow `FreeBSD` vagrant box comes up as expected.

## Previous Behavior

* `vim-lite` not an actual pkg name in freebsd resulting in the following during provisioning:
```
Updating FreeBSD repository catalogue...                              
FreeBSD repository is up to date.                                           
All repositories are up to date.                                           
Updating FreeBSD repository catalogue...                                    
FreeBSD repository is up to date.                                       
All repositories are up to date.                                     
pkg: No packages available to install matching 'vim-lite' have been found in the repositories
```

* Using 11.1 which was [EOL in September 2018](https://lists.freebsd.org/pipermail/freebsd-announce/2018-September/001842.html) and is causing an issue with libraries required by the latest `bash` version:
```
freebsd: Running provisioner: shell...                                    
    freebsd: Running: /var/folders/vf/0kcj5h414gq093t3xk0jmm_r0000gp/T/vagrant-shell20190314-39410-7amiuy.sh
    freebsd: Shared object "libdl.so.1" not found, required by "bash"         
    freebsd: Shared object "libdl.so.1" not found, required by "bash"               
    freebsd: Shared object "libdl.so.1" not found, required by "bash"                       
    freebsd: GNUmakefile:22: *** Building Nomad is currently only supported on Darwin and Linux..  Stop.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

* NFS sharing needs to have networking setup to use `host dhcp` after running `vagrant up`. [See related issue](https://github.com/hashicorp/vagrant/issues/9063):
```
NFS requires a host-only network to be created.
Please add a host-only network to the machine (with either DHCP or a
static IP) for NFS to work.
```
* Moving to latest `11.2-STABLE` box doesnt have `bash` out of the box:
```
The configured shell (config.ssh.shell) is invalid and unable
to properly execute commands. The most common cause for this is
using a shell that is unavailable on the system. Please verify
you're using the full path to the shell and that the shell is
executable by the SSH user.
```

## New Behavior

* provisioning script now uses `vim-tiny`
* Moving to latest `11.2-STABLE` box
* Networking set to explicitly be `private_network` of type `dhcp` for NFS share to work
* Set shell to `sh` by default for freebsd box

## Testing

`vagrant up freebsd` now provisions a box as intended without errors

## Version info
Host OS:
```
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.13.2
BuildVersion:   17C205
```

Vagrant:
```
$ vagrant --version
Vagrant 2.2.3
```
Virtualbox:
```
$ vboxmanage --version
6.0.4r128413
```