### PR TITLE
client/logmon: restart log collection correctly when a task is restarted

### DIFF
--- a/client/allocrunner/taskrunner/logmon_hook.go
+++ b/client/allocrunner/taskrunner/logmon_hook.go
@@ -101,7 +101,7 @@ func (h *logmonHook) Prestart(ctx context.Context,
 	var reattachConfig *plugin.ReattachConfig
 	var err error
 
-	// If the task was restarted then the logmon process is still running and just
+	// If the task was restarted and the logmon process is still running logmon
 	// needs the start RPC called again to open the fifo
 	if !h.exited || h.logmonPluginClient == nil || h.logmonPluginClient.Exited() {
 		reattachConfig, err = reattachConfigFromHookData(req.PreviousState)

--- a/client/allocrunner/taskrunner/logmon_hook_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_test.go
@@ -19,6 +19,7 @@ import (
 
 // Statically assert the logmon hook implements the expected interfaces
 var _ interfaces.TaskPrestartHook = (*logmonHook)(nil)
+var _ interfaces.TaskExitedHook = (*logmonHook)(nil)
 var _ interfaces.TaskStopHook = (*logmonHook)(nil)
 
 // TestTaskRunner_LogmonHook_LoadReattach unit tests loading logmon reattach

--- a/client/allocrunner/taskrunner/logmon_hook_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_test.go
@@ -19,7 +19,6 @@ import (
 
 // Statically assert the logmon hook implements the expected interfaces
 var _ interfaces.TaskPrestartHook = (*logmonHook)(nil)
-var _ interfaces.TaskExitedHook = (*logmonHook)(nil)
 var _ interfaces.TaskStopHook = (*logmonHook)(nil)
 
 // TestTaskRunner_LogmonHook_LoadReattach unit tests loading logmon reattach

--- a/client/logmon/logmon.go
+++ b/client/logmon/logmon.go
@@ -59,6 +59,12 @@ type logmonImpl struct {
 }
 
 func (l *logmonImpl) Start(cfg *LogConfig) error {
+	// Start can be called multiple times, and should restart the task logger
+	// in such cases
+	if l.tl != nil {
+		l.tl.Close()
+	}
+
 	tl, err := NewTaskLogger(cfg, l.logger)
 	if err != nil {
 		return err

--- a/client/logmon/logmon_test.go
+++ b/client/logmon/logmon_test.go
@@ -1,0 +1,120 @@
+package logmon
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/client/lib/fifo"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogmon_Start_rotate(t *testing.T) {
+	require := require.New(t)
+	dir, err := ioutil.TempDir("", "nomadtest")
+	require.NoError(err)
+	defer os.RemoveAll(dir)
+	stdoutLog := "stdout"
+	stdoutFifoPath := filepath.Join(dir, "stdout.fifo")
+	stderrLog := "stderr"
+	stderrFifoPath := filepath.Join(dir, "stderr.fifo")
+
+	cfg := &LogConfig{
+		LogDir:        dir,
+		StdoutLogFile: stdoutLog,
+		StdoutFifo:    stdoutFifoPath,
+		StderrLogFile: stderrLog,
+		StderrFifo:    stderrFifoPath,
+		MaxFiles:      2,
+		MaxFileSizeMB: 1,
+	}
+
+	lm := NewLogMon(testlog.HCLogger(t))
+	require.NoError(lm.Start(cfg))
+
+	stdout, err := fifo.Open(stdoutFifoPath)
+	require.NoError(err)
+
+	// Write enough bytes such that the log is rotated
+	bytes1MB := make([]byte, 1024*1024)
+	_, err = rand.Read(bytes1MB)
+	require.NoError(err)
+
+	io.Copy(stdout, bytes.NewBuffer(bytes1MB))
+
+	time.Sleep(200 * time.Millisecond)
+	_, err = os.Stat(filepath.Join(dir, "stdout.0"))
+	require.NoError(err)
+	_, err = os.Stat(filepath.Join(dir, "stdout.1"))
+	require.NoError(err)
+
+	require.NoError(lm.Stop())
+}
+
+func TestLogmon_Start_restart(t *testing.T) {
+	require := require.New(t)
+	dir, err := ioutil.TempDir("", "nomadtest")
+	require.NoError(err)
+	defer os.RemoveAll(dir)
+	stdoutLog := "stdout"
+	stdoutFifoPath := filepath.Join(dir, "stdout.fifo")
+	stderrLog := "stderr"
+	stderrFifoPath := filepath.Join(dir, "stderr.fifo")
+
+	cfg := &LogConfig{
+		LogDir:        dir,
+		StdoutLogFile: stdoutLog,
+		StdoutFifo:    stdoutFifoPath,
+		StderrLogFile: stderrLog,
+		StderrFifo:    stderrFifoPath,
+		MaxFiles:      2,
+		MaxFileSizeMB: 1,
+	}
+
+	lm := NewLogMon(testlog.HCLogger(t))
+	impl, ok := lm.(*logmonImpl)
+	require.True(ok)
+	require.NoError(lm.Start(cfg))
+
+	stdout, err := fifo.Open(stdoutFifoPath)
+	require.NoError(err)
+	stderr, err := fifo.Open(stderrFifoPath)
+	require.NoError(err)
+
+	// Write a string and assert it was written to the file
+	io.Copy(stdout, bytes.NewBufferString("test\n"))
+	time.Sleep(200 * time.Millisecond)
+	raw, err := ioutil.ReadFile(filepath.Join(dir, "stdout.0"))
+	require.NoError(err)
+	require.Equal("test\n", string(raw))
+	require.True(impl.tl.IsRunning())
+
+	// Close stdout and assert that logmon no longer writes to the file
+	require.NoError(stdout.Close())
+	require.NoError(stderr.Close())
+
+	stdout, err = fifo.Open(stdoutFifoPath)
+	require.NoError(err)
+	stderr, err = fifo.Open(stderrFifoPath)
+	require.NoError(err)
+	require.False(impl.tl.IsRunning())
+	io.Copy(stdout, bytes.NewBufferString("te"))
+	time.Sleep(200 * time.Millisecond)
+	raw, err = ioutil.ReadFile(filepath.Join(dir, "stdout.0"))
+	require.NoError(err)
+	require.Equal("test\n", string(raw))
+
+	// Start logmon again and assert that it appended to the file
+	require.NoError(lm.Start(cfg))
+	io.Copy(stdout, bytes.NewBufferString("st\n"))
+	time.Sleep(200 * time.Millisecond)
+	raw, err = ioutil.ReadFile(filepath.Join(dir, "stdout.0"))
+	require.NoError(err)
+	require.Equal("test\ntest\n", string(raw))
+}

--- a/client/logmon/logmon_test.go
+++ b/client/logmon/logmon_test.go
@@ -120,7 +120,6 @@ func TestLogmon_Start_restart(t *testing.T) {
 	require.NoError(err)
 	stderr, err = fifo.Open(stderrFifoPath)
 	require.NoError(err)
-	require.False(impl.tl.IsRunning())
 	_, err = stdout.Write([]byte("te"))
 	require.NoError(err)
 	testutil.WaitForResult(func() (bool, error) {
@@ -132,6 +131,7 @@ func TestLogmon_Start_restart(t *testing.T) {
 	}, func(err error) {
 		require.NoError(err)
 	})
+	require.False(impl.tl.IsRunning())
 
 	// Start logmon again and assert that it appended to the file
 	require.NoError(lm.Start(cfg))

--- a/client/logmon/logmon_test.go
+++ b/client/logmon/logmon_test.go
@@ -116,12 +116,20 @@ func TestLogmon_Start_restart(t *testing.T) {
 	require.NoError(stdout.Close())
 	require.NoError(stderr.Close())
 
+	testutil.WaitForResult(func() (bool, error) {
+		return !impl.tl.IsRunning(), fmt.Errorf("logmon is still running")
+	}, func(err error) {
+		require.NoError(err)
+	})
+
 	stdout, err = fifo.Open(stdoutFifoPath)
 	require.NoError(err)
 	stderr, err = fifo.Open(stderrFifoPath)
 	require.NoError(err)
+
 	_, err = stdout.Write([]byte("te"))
 	require.NoError(err)
+
 	testutil.WaitForResult(func() (bool, error) {
 		raw, err := ioutil.ReadFile(filepath.Join(dir, "stdout.0"))
 		if err != nil {
@@ -131,10 +139,15 @@ func TestLogmon_Start_restart(t *testing.T) {
 	}, func(err error) {
 		require.NoError(err)
 	})
-	require.False(impl.tl.IsRunning())
 
 	// Start logmon again and assert that it appended to the file
 	require.NoError(lm.Start(cfg))
+
+	stdout, err = fifo.Open(stdoutFifoPath)
+	require.NoError(err)
+	stderr, err = fifo.Open(stderrFifoPath)
+	require.NoError(err)
+
 	_, err = stdout.Write([]byte("st\n"))
 	require.NoError(err)
 	testutil.WaitForResult(func() (bool, error) {
@@ -142,7 +155,9 @@ func TestLogmon_Start_restart(t *testing.T) {
 		if err != nil {
 			return false, err
 		}
-		return "test\ntest\n" == string(raw), fmt.Errorf("unexpected stdout %q", string(raw))
+
+		expected := "test\ntest\n" == string(raw)
+		return expected, fmt.Errorf("unexpected stdout %q", string(raw))
 	}, func(err error) {
 		require.NoError(err)
 	})


### PR DESCRIPTION
This PR will restart logmon's log collection during task restarts.