### PR TITLE
executor: block shutdown on process exiting

### DIFF
--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -469,6 +469,14 @@ func (e *UniversalExecutor) Shutdown(signal string, grace time.Duration) error {
 		proc.Kill()
 	}
 
+	// Wait for process to exit
+	select {
+	case <-e.processExited:
+	case <-time.After(time.Second * 15):
+		e.logger.Warn("process did not exit after 15 seconds")
+		merr.Errors = append(merr.Errors, fmt.Errorf("process did not exit after 15 seconds"))
+	}
+
 	// Prefer killing the process via the resource container.
 	if !(e.commandCfg.ResourceLimits || e.commandCfg.BasicProcessCgroup) {
 		if err := e.cleanupChildProcesses(proc); err != nil && err.Error() != finishedErr {


### PR DESCRIPTION
I wasn't able to reproduce the failure, but it seems as though a race exists between shutting down the executor (which kills the user process) and killing the executor through go-plugin's client api. This had the potential to result in a killed executor and an orphaned user process. 

This PR makes the executor's `Shutdown` func blocking until the user process exits.