### PR TITLE
doc: fix tls_cipher_suites type

### DIFF
--- a/website/source/docs/configuration/tls.html.md
+++ b/website/source/docs/configuration/tls.html.md
@@ -59,7 +59,7 @@ the [Encryption Overview Guide](/guides/security/encryption.html).
   complete. This allows the agent to accept both TLS and plaintext traffic.
 
 - `tls_cipher_suites` `string: "")` - Specifies the TLS cipher suites that will
-  be used by the agent, as a comma-separated string. Known insecure ciphers are
+  be used by the agent as a comma-separated string. Known insecure ciphers are
   disabled (3DES and RC4). By default, an agent is configured to use
   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
   TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,

--- a/website/source/docs/configuration/tls.html.md
+++ b/website/source/docs/configuration/tls.html.md
@@ -58,9 +58,9 @@ the [Encryption Overview Guide](/guides/security/encryption.html).
   cluster is being upgraded to TLS, and removed after the migration is
   complete. This allows the agent to accept both TLS and plaintext traffic.
 
-- `tls_cipher_suites` `(array<string>: [])` - Specifies the TLS cipher suites
-  that will be used by the agent. Known insecure ciphers are disabled (3DES and
-  RC4). By default, an agent is configured to use
+- `tls_cipher_suites` `string: "")` - Specifies the TLS cipher suites that will
+  be used by the agent, as a comma-separated string. Known insecure ciphers are
+  disabled (3DES and RC4). By default, an agent is configured to use
   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
   TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
   TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,


### PR DESCRIPTION
tls_cipher_suites only accept a comma-separated string, as evident in:

https://github.com/hashicorp/nomad/blob/0535dfd414214efd14183bf23d1447f679b57af8/nomad/structs/config/tls.go#L61
https://github.com/hashicorp/nomad/blob/d37ed5c193ac8237666b92bd3f3b0b7e0a8ebfd5/helper/tlsutil/config.go#L405