### PR TITLE
Revert "executor: synchronize exitState accesses"

### DIFF
--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -213,8 +212,6 @@ type UniversalExecutor struct {
 	commandCfg *ExecCommand
 
 	exitState     *ProcessState
-	exitStateLock sync.Mutex
-
 	processExited chan interface{}
 
 	// resConCtx is used to track and cleanup additional resources created by
@@ -367,8 +364,6 @@ func (e *UniversalExecutor) Wait(ctx context.Context) (*ProcessState, error) {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-e.processExited:
-		e.exitStateLock.Lock()
-		defer e.exitStateLock.Unlock()
 		return e.exitState, nil
 	}
 }
@@ -383,9 +378,7 @@ func (e *UniversalExecutor) wait() {
 	pid := e.childCmd.Process.Pid
 	err := e.childCmd.Wait()
 	if err == nil {
-		e.exitStateLock.Lock()
 		e.exitState = &ProcessState{Pid: pid, ExitCode: 0, Time: time.Now()}
-		e.exitStateLock.Unlock()
 		return
 	}
 
@@ -411,9 +404,7 @@ func (e *UniversalExecutor) wait() {
 		e.logger.Warn("unexpected Cmd.Wait() error type", "error", err)
 	}
 
-	e.exitStateLock.Lock()
 	e.exitState = &ProcessState{Pid: pid, ExitCode: exitCode, Signal: signal, Time: time.Now()}
-	e.exitStateLock.Unlock()
 }
 
 var (

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -79,9 +78,7 @@ type LibcontainerExecutor struct {
 	container      libcontainer.Container
 	userProc       *libcontainer.Process
 	userProcExited chan interface{}
-
-	exitState     *ProcessState
-	exitStateLock sync.Mutex
+	exitState      *ProcessState
 }
 
 func NewExecutorWithIsolation(logger hclog.Logger) Executor {
@@ -251,8 +248,6 @@ func (l *LibcontainerExecutor) Wait(ctx context.Context) (*ProcessState, error) 
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-l.userProcExited:
-		l.exitStateLock.Lock()
-		defer l.exitStateLock.Unlock()
 		return l.exitState, nil
 	}
 }
@@ -268,10 +263,7 @@ func (l *LibcontainerExecutor) wait() {
 			ps = exitErr.ProcessState
 		} else {
 			l.logger.Error("failed to call wait on user process", "error", err)
-			l.exitStateLock.Lock()
 			l.exitState = &ProcessState{Pid: 0, ExitCode: 1, Time: time.Now()}
-			l.exitStateLock.Unlock()
-
 			return
 		}
 	}
@@ -289,14 +281,12 @@ func (l *LibcontainerExecutor) wait() {
 		}
 	}
 
-	l.exitStateLock.Lock()
 	l.exitState = &ProcessState{
 		Pid:      ps.Pid(),
 		ExitCode: exitCode,
 		Signal:   signal,
 		Time:     time.Now(),
 	}
-	l.exitStateLock.Unlock()
 }
 
 // Shutdown stops all processes started and cleans up any resources


### PR DESCRIPTION
Reverts hashicorp/nomad#5433

Apparently, channel communications can constitute Happens-Before even for proximate variables, so this syncing isn't necessary.

> _The closing of a channel happens before a receive that returns a zero value because the channel is closed._
https://golang.org/ref/mem#tmp_7

