### PR TITLE
Nomad TLS with Vault

### DIFF
--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -14,11 +14,9 @@ description: |-
 You can use [Consul Template][consul-template] in your Nomad cluster to
 integrate with Vault's [PKI Secrets Engine][pki-engine] to generate and renew
 dynamic X.509 certificates. By using this method, you enable each node to have a
-unique certificate, eliminating sharing and the accompanying pain of revocation
-and rollover. You can also keep certificate TTLs relatively short which makes
-situations where you have to revoke certificates less likely. This in turn
-allows you to safely and securely scale your cluster while using mutual TLS
-(mTLS).
+unique certificate with a relatively short ttl. This feature, along with
+automatic certificate rotation, allows you to safely and securely scale your
+cluster while using mutual TLS (mTLS).
 
 ## Reference Material
 

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -150,7 +150,7 @@ $ vault write -field=certificate pki/root/generate/internal \
     common_name="global.nomad" ttl=87600h > CA_cert.crt
 ```
 
-### Step 4: Generate the Intermediate CA and CSR
+### Step 5: Generate the Intermediate CA and CSR
 
 Enable the PKI secrets engine at the pki_int path:
 
@@ -172,7 +172,7 @@ $ vault write -format=json pki_int/intermediate/generate/internal \
     ttl="43800h" | jq -r '.data.csr' > pki_intermediate.csr
 ```
 
-### Step 5: Sign the CSR and Configure Intermediate CA Certificate
+### Step 6: Sign the CSR and Configure Intermediate CA Certificate
 
 Sign the intermediate CA CSR with the root certificate and save the generated
 certificate as `intermediate.cert.pem`:
@@ -190,7 +190,7 @@ back into Vault:
 vault write pki_int/intermediate/set-signed certificate=@intermediate.cert.pem
 ```
 
-### Step 6: Create a Role
+### Step 7: Create a Role
 
 A role is a logical name that maps to a policy used to generate credentials. In
 our example, it will allow you to use [configuration
@@ -211,7 +211,7 @@ You should see the following output if the command you issues was successful:
 Success! Data written to: pki_int/roles/nomad-cluster
 ```
 
-### Step 7: Create a Policy to Access the Role Endpoint
+### Step 8: Create a Policy to Access the Role Endpoint
 
 Recall from [Step 1](#step-1-initialize-vault-server) that we generated a root
 token that we used to log in to Vault. Although we could use that token in our
@@ -237,7 +237,7 @@ $ vault policy write tls-policy tls-policy.hcl
 Success! Uploaded policy: tls-policy
 ```
 
-### Step 8: Generate a Token based on `tls-policy`
+### Step 9: Generate a Token based on `tls-policy`
 
 Create a token based on `tls-policy` with the following command:
 
@@ -261,7 +261,7 @@ policies             ["default" "tls-policy"]
 
 Make a note of this token as you will need it in the upcoming steps.
 
-### Step 9: Configure Consul Template on All Nodes
+### Step 10: Configure Consul Template on All Nodes
 
 If you are using the AWS environment provided in this guide, you already have
 [Consul Template][consul-template-github] installed on all nodes. If you are
@@ -339,7 +339,7 @@ concern. The recommended approach is to securely introduce this token to Consul
 Template. To learn how to accomplish this, see [Secure
 Introduction][secure-introduction].
 
-### Step 10: Create Templates
+### Step 11: Create Templates
 
 The following are the templates used by the configuration file we specified in
 the previous step:
@@ -417,7 +417,7 @@ word `client`:
 {{ end }}
 ```
 
-### Step 10: Start the Consul Template Service
+### Step 12: Start the Consul Template Service
 
 Once you have written the individual templates to the `source` locations you
 specified in each of the template stanzas in [Step
@@ -436,7 +436,7 @@ $ ls /opt/nomad/certs/
 agent.crt  agent.key  ca.crt  cli.crt  cli.key
 ```
 
-### Step 11: Configure Nomad to Use TLS
+### Step 13: Configure Nomad to Use TLS
 
 Add the following [tls stanza][nomad-tls-stanza] to your Nomad agent
 configuration file (located at `/etc/nomad.d/nomad.hcl` in this example):

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -501,7 +501,7 @@ Add the following [tls stanza][nomad-tls-stanza] to the configuration of all
 Nomad agents (servers and clients) in the cluster (configuration file located at
 `/etc/nomad.d/nomad.hcl` in this example):
 
-```
+```hcl
 tls {
   http = true
   rpc  = true
@@ -514,11 +514,29 @@ tls {
   verify_https_client    = true
 }
 ```
-Reload Nomad's configuration:
+
+Additionally, ensure the [`rpc_upgrade_mode`][rpc-upgrade-mode] option is set to
+`true` on your server nodes (this is to ensure the Nomad servers will accept
+both TLS and non-TLS connections during the upgrade):
+
+```hcl
+rpc_upgrade_mode       = true
+```
+Reload Nomad's configuration on all nodes:
 
 ```shell
 $ systemctl reload nomad
 ```
+Once Nomad has been reloaded on all Nodes, go back to your server nodes and
+change the `rpc_upgrade_mode` option to false (or remove the line since the
+option defaults to false) so that your Nomad servers will only accept TLS
+connections:
+
+```hcl
+rpc_upgrade_mode       = false
+```
+You will need to reload Nomad on your servers after changing this setting. You
+can read more about RPC Upgrade Mode [here][rpc-upgrade].
 
 If you run `nomad status`, you will now receive the following error:
 
@@ -607,6 +625,8 @@ restart nomad`.
 [policies]: https://www.vaultproject.io/docs/concepts/policies.html#policies
 [pki-engine]: https://www.vaultproject.io/docs/secrets/pki/index.html
 [repo]: https://github.com/hashicorp/nomad/tree/master/terraform
+[rpc-upgrade-mode]: /docs/configuration/tls.html#rpc_upgrade_mode
+[rpc-upgrade]: /guides/security/securing-nomad.html#rpc-upgrade-mode-for-nomad-servers
 [seal]: https://www.vaultproject.io/docs/concepts/seal.html
 [secure-introduction]: https://learn.hashicorp.com/vault/identity-access-management/iam-secure-intro
 [token]: https://www.vaultproject.io/docs/concepts/tokens.html

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -30,10 +30,10 @@ cluster while using mutual TLS (mTLS).
 
 ## Challenge
 
-Secure your Nomad cluster with mTLS. Configure a root and intermediate CA in
-Vault and ensure (with the help of Consul Template) that you are periodically
-renewing your X.509 certificates on all nodes to maintain a healthy cluster
-state.
+Secure your existing Nomad cluster with mTLS. Configure a root and intermediate
+CA in Vault and ensure (with the help of Consul Template) that you are
+periodically renewing your X.509 certificates on all nodes to maintain a healthy
+cluster state.
 
 ## Solution
 

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -285,22 +285,60 @@ Your `consul-template.hcl` configuration file should look similar to the
 following (you will need to provide this to each node in the cluster):
 
 ```
+# This denotes the start of the configuration section for Vault. All values
+# contained in this section pertain to Vault.
 vault {
+  # This is the address of the Vault leader. The protocol (http(s)) portion
+  # of the address is required.
   address      = "http://active.vault.service.consul:8200"
+
+  # This value can also be specified via the environment variable VAULT_TOKEN.
   token        = "s.xafiYzh7MCMotHLu2d35hepR"
+
+  # This should also be less than or around 1/3 of your TTL for a predictable
+  # behaviour. See https://github.com/hashicorp/vault/issues/3414
   grace        = "1s"
+
+  # This tells Consul Template that the provided token is actually a wrapped
+  # token that should be unwrapped using Vault's cubbyhole response wrapping
+  # before being used. Please see Vault's cubbyhole response wrapping
+  # documentation for more information.
   unwrap_token = false
+
+  # This option tells Consul Template to automatically renew the Vault token
+  # given. If you are unfamiliar with Vault's architecture, Vault requires
+  # tokens be renewed at some regular interval or they will be revoked. Consul
+  # Template will automatically renew the token at half the lease duration of
+  # the token. The default value is true, but this option can be disabled if
+  # you want to renew the Vault token using an out-of-band process.
   renew_token  = true
 }
 
+# This block defines the configuration for connecting to a syslog server for
+# logging.
 syslog {
   enabled  = true
+
+  # This is the name of the syslog facility to log to.
   facility = "LOCAL5"
 }
 
+# This block defines the configuration for a template. Unlike other blocks,
+# this block may be specified multiple times to configure multiple templates.
+# It is also possible to configure templates via the CLI directly.
 template {
+  # This is the source file on disk to use as the input template. This is often
+  # called the "Consul Template template". This option is required if not using
+  # the `contents` option.
   source      = "/opt/nomad/templates/agent.crt.tpl"
+
+  # This is the destination path on disk where the source template will render.
+  # If the parent directories do not exist, Consul Template will attempt to
+  # create them, unless create_dest_dirs is false.
   destination = "/opt/nomad/certs/agent.crt"
+
+  # This is the optional command to run when the template is rendered. The
+  # command will only run if the resulting template changes. 
   command     = "pkill -SIGHUP nomad"
 }
 

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -125,7 +125,7 @@ again. Future Vault requests will automatically use this token.
 
 ### Step 4: Generate the Root CA
 
-Enable the [PKI secrets engine][pki-engine] at the pki path:
+Enable the [PKI secrets engine][pki-engine] at the `pki` path:
 
 ```shell
 $ vault secrets enable pki
@@ -152,7 +152,7 @@ $ vault write -field=certificate pki/root/generate/internal \
 
 ### Step 5: Generate the Intermediate CA and CSR
 
-Enable the PKI secrets engine at the pki_int path:
+Enable the PKI secrets engine at the `pki_int` path:
 
 ```shell
 $ vault secrets enable -path=pki_int pki

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -171,7 +171,7 @@ $ vault write -format=json pki_int/intermediate/generate/internal \
     ttl="43800h" | jq -r '.data.csr' > pki_intermediate.csr
 ```
 
-### Step 5: Sign the Intermediate CA CSR 
+### Step 5: Sign the CSR and Configure Intermediate CA Certificate
 
 Sign the intermediate CA CSR with the root certificate and save the generated
 certificate as `intermediate.cert.pem`:
@@ -189,12 +189,229 @@ back into Vault:
 vault write pki_int/intermediate/set-signed certificate=@intermediate.cert.pem
 ```
 
+### Step 6: Create a Role
+
+A role is a logical name that maps to a policy used to generate credentials. In
+our example, it will allow you to use [configuration
+parameters][config-parameters] that specify certificate common names, designate
+alternate names, and enable subdomains along with a few other key settings.
+
+Create a role named `nomad-cluster` that specifies the allowed domains, enables
+you to create certificates for subdomains, and generates certificates with a TTL
+of 86400 seconds (24 hours).
+
+```
+$ vault write pki_int/roles/nomad-cluster allowed_domains=global.nomad \
+    allow_subdomains=true max_ttl=86400s generate_lease=true
+```
+You should see the following output if the command you issues was successful:
+
+```
+Success! Data written to: pki_int/roles/nomad-cluster
+```
+
+### Step 7: Create a Policy to Access the Role Endpoint
+
+Recall from [Step 1](#step-1-initialize-vault-server) that we generated a root
+token that we used to log in to Vault. Although we could use that token in our
+next steps to generate our TLS certs, the recommended security approach is to
+create a new token based on a specific policy with limited privileges.
+
+Create a policy file named `tls-policy.hcl` and provide it the following
+contents:
+
+```
+path "pki_int/issue/nomad-cluster" {
+  capabilities = ["update"]
+}
+```
+Note that we have are specifying the `update` [capability][capability] on the
+path `pki_int/issue/nomad-cluster`. All other privileges will be denied. You can
+read more about Vault policies [here][policies].
+
+Write the policy we just created into Vault:
+
+```
+$ vault policy write tls-policy tls-policy.hcl
+Success! Uploaded policy: tls-policy
+```
+
+### Step 8: Generate a Token based on `tls-policy`
+
+Create a token based on `tls-policy` with the following command:
+
+```
+$ vault token create -policy="tls-policy" -ttl=24h
+```
+
+If the command is successful, you will see output similar to the following:
+
+```shell
+Key                  Value
+---                  -----
+token                s.xafiYzh7MCMotHLu2d35hepR
+token_accessor       9vj7q5nnF53JAcTyxvccpAZK
+token_duration       24h
+token_renewable      true
+token_policies       ["default" "tls-policy"]
+identity_policies    []
+policies             ["default" "tls-policy"]
+```
+
+### Step 9: Configure Consul Template on All Nodes
+
+If you are using the AWS environment provided in this guide, you already have
+[Consul Template][consul-template-github] installed on all nodes. If you are
+using your own environment, please make sure Consul Template is installed. You
+can download it [here][ct-download].
+
+Provide the token you created in [Step
+8](#step-8-generate-a-token-based-on-tls-policy) to the Consul Template
+configuration file located at `/etc/consul-template.d/consul-template.hcl`. You
+will also need to specify the [template stanza][ct-template-stanza] so you can
+render each of the following on the node at the specified location from the
+provided templates (the actual templates will be provided in the next step):
+
+* Node certificate
+* Node private key
+* CA public certificate
+
+Your `consul-template.hcl` configuration file should look similar to the
+following (you will need to do this on each node in the cluster):
+
+```
+vault {
+  address      = "http://active.vault.service.consul:8200"
+  token        = "s.xafiYzh7MCMotHLu2d35hepR"
+  grace        = "1s"
+  unwrap_token = false
+  renew_token  = true
+}
+
+syslog {
+  enabled  = true
+  facility = "LOCAL5"
+}
+
+template {
+  source      = "/opt/nomad/templates/agent.crt.tpl"
+  destination = "/opt/nomad/certs/agent.crt"
+  command     = "pkill -SIGHUP nomad"
+}
+
+template {
+  source      = "/opt/nomad/templates/agent.key.tpl"
+  destination = "/opt/nomad/certs/agent.key"
+  command     = "pkill -SIGHUP nomad"
+}
+
+template {
+  source      = "/opt/nomad/templates/ca.crt.tpl"
+  destination = "/opt/nomad/certs/ca.crt"
+  command     = "pkill -SIGHUP nomad"
+}
+```
+You may change the `source` and `destination` options in your
+configuration to a location you prefer. This environment assumes you have
+created a `templates` and `certs` directory in `/opt/nomad`.
+
+!> Note: we have hard coded the token we created into the Consul Template
+configuration file. Although we can avoid this by assigning it to the
+environment variable `VAULT_TOKEN`, this approach is still a security concern.
+We need to securely introduce this token to Consul Template. To learn how to
+accomplish this, see [Secure Introduction][secure-introduction].
+
+### Step 10: Create Templates
+
+The following are the templates used by the configuration file we specified in
+the previous step:
+
+**For Nomad Servers**:
+
+*agent.crt.tpl*:
+
+```
+{{ with secret "pki_int/issue/nomad-cluster" "common_name=server.global.nomad" "ttl=24h" "alt_names=localhost" "ip_sans=127.0.0.1"}}
+{{ .Data.certificate }}
+{{ end }}
+```
+
+*agent.key.tpl*:
+
+```
+{{ with secret "pki_int/issue/nomad-cluster" "common_name=server.global.nomad" "ttl=24h" "alt_names=localhost" "ip_sans=127.0.0.1"}}
+{{ .Data.private_key }}
+{{ end }}
+```
+
+*ca.crt.tpl*:
+
+```
+{{ with secret "pki_int/issue/nomad-cluster" "common_name=server.global.nomad" "ttl=24h"}}
+{{ .Data.issuing_ca }}
+{{ end }}
+```
+
+**For Nomad Clients**:
+
+Replace the word `server` in the `common_name` option in each template with the
+word `client`:
+
+*agent.crt.tpl*:
+
+```
+{{ with secret "pki_int/issue/nomad-cluster" "common_name=client.global.nomad" "ttl=24h" "alt_names=localhost" "ip_sans=127.0.0.1"}}
+{{ .Data.certificate }}
+{{ end }}
+```
+
+*agent.key.tpl*:
+
+```
+{{ with secret "pki_int/issue/nomad-cluster" "common_name=client.global.nomad" "ttl=24h" "alt_names=localhost" "ip_sans=127.0.0.1"}}
+{{ .Data.private_key }}
+{{ end }}
+```
+
+*ca.crt.tpl*:
+
+```
+{{ with secret "pki_int/issue/nomad-cluster" "common_name=client.global.nomad" "ttl=24h"}}
+{{ .Data.issuing_ca }}
+{{ end }}
+```
+
+### Step 10: Start the Consul Template Service
+
+Once you have written the individual templates to the `source` locations you
+specified in each of the template stanzas in [Step
+9](#step-9-configure-consul-template-on-all-nodes), you may start the Consul
+Template service on each node:
+
+```shell
+$ sudo systemctl start consul-template
+```
+You can quickly confirm the appropriate certs and private keys were generated in
+the `destination` directory you specified in your Consul Template configuration
+by listing them out:
+
+```
+$ ls /opt/nomad/certs/
+agent.crt  agent.key  ca.crt
+```
+
+[capability]: https://www.vaultproject.io/docs/concepts/policies.html#capabilities
+[config-parameters]: https://www.vaultproject.io/api/secret/pki/index.html#parameters-8
 [consul-template]: https://www.consul.io/docs/guides/consul-template.html
 [consul-template-github]: https://github.com/hashicorp/consul-template
+[ct-download]: https://releases.hashicorp.com/consul-template/
+[ct-template-stanza]: https://github.com/hashicorp/consul-template#configuration-file-format
 [login]: https://www.vaultproject.io/docs/commands/login.html
+[policies]: https://www.vaultproject.io/docs/concepts/policies.html#policies
 [pki-engine]: https://www.vaultproject.io/docs/secrets/pki/index.html
 [repo]: https://github.com/hashicorp/nomad/tree/master/terraform
 [seal]: https://www.vaultproject.io/docs/concepts/seal.html
+[secure-introduction]: https://learn.hashicorp.com/vault/identity-access-management/iam-secure-intro
 [token]: https://www.vaultproject.io/docs/concepts/tokens.html
 [vault-ca-learn]: https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine
 [vault-ra]: https://learn.hashicorp.com/vault/operations/ops-reference-architecture

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -1,0 +1,200 @@
+---
+layout: "guides"
+page_title: "Vault PKI Secrets Engine Integration"
+sidebar_current: "guides-security-vault-pki"
+description: |-
+  Securing Nomad's cluster communication with TLS is important for both
+  security and easing operations. Nomad can use mutual TLS (mTLS) for
+  authenticating for all HTTP and RPC communication. This guide will leverage
+  Vault's PKI secrets engine to accomplish this task.
+---
+
+# Vault PKI Secrets Engine Integration
+
+You can use [Consul Template][consul-template] in your Nomad cluster to
+integrate with Vault's [PKI Secrets Engine][pki-engine] to generate and renew
+dynamic X.509 certificates. By using this method, you enable each node to have a
+unique certificate, eliminating sharing and the accompanying pain of revocation
+and rollover. You can also keep certificate TTLs relatively short which makes
+situations where you have to revoke certificates less likely. This in turn
+allows you to safely and securely scale your cluster while using mutual TLS
+(mTLS).
+
+## Reference Material
+
+- [Vault PKI Secrets Engine][pki-engine]
+- [Consul Template][consul-template-github]
+- [Build Your Own Certificate Authority (CA)][vault-ca-learn]
+
+## Estimated Time to Complete
+
+25 minutes
+
+## Challenge
+
+Secure your Nomad cluster with mTLS. Configure a root and intermediate CA in
+Vault and ensure (with the help of Consul Template) that you are periodically
+renewing your X.509 certificates on all nodes to maintain a healthy cluster
+state.
+
+## Solution
+
+Enable TLS in your Nomad cluster configuration. Additionally, configure Consul
+Template on all nodes along with the appropriate templates to communicate with
+Vault and ensure all nodes are dynamically generating/renewing their X.509
+certificates.
+
+## Prerequisites
+
+To perform the tasks described in this guide, you need to have a Nomad
+environment with Consul and Vault installed. You can use this [repo][repo] to
+easily provision a sandbox environment. This guide will assume a cluster with
+one server node and three client nodes.
+
+~> **Please Note:** This guide is for demo purposes and is only using a single
+Nomad server with a Vault server configured alongside it. In a production
+cluster, 3 or 5 Nomad server nodes are recommended along with a separate Vault
+cluster. Please see [Vault Reference Architecture][vault-ra] to learn how to
+securely deploy a Vault cluster.
+
+## Steps
+
+### Step 1: Initialize Vault Server
+
+Run the following command to initialize Vault server and receive an
+[unseal][seal] key and initial root [token][token] (if you are running the
+environment provided in this guide, the Vault server is co-located with the
+Nomad server). Be sure to note the unseal key and initial root token as you will
+need these two pieces of information.
+
+```shell
+$ vault operator init -key-shares=1 -key-threshold=1
+```
+
+The `vault operator init` command above creates a single Vault unseal key for
+convenience. For a production environment, it is recommended that you create at
+least five unseal key shares and securely distribute them to independent
+operators. The `vault operator init` command defaults to five key shares and a
+key threshold of three. If you provisioned more than one server, the others will
+become standby nodes but should still be unsealed.
+
+### Step 2: Unseal Vault
+
+Run the following command and then provide your unseal key to Vault.
+
+```shell
+$ vault operator unseal
+```
+The output of unsealing Vault will look similar to the following:
+
+```shell
+Key                    Value
+---                    -----
+Seal Type              shamir
+Initialized            true
+Sealed                 false
+Total Shares           1
+Threshold              1
+Version                1.0.3
+Cluster Name           vault-cluster-d1b6513f
+Cluster ID             87d6d13f-4b92-60ce-1f70-41a66412b0f1
+HA Enabled             true
+HA Cluster             n/a
+HA Mode                standby
+Active Node Address    <none>
+```
+
+### Step 3: Log in to Vault
+
+Use the [login][login] command to authenticate yourself against Vault using the
+initial root token you received earlier. You will need to authenticate to run
+the necessary commands to write policies, create roles, and configure your root
+and intermediate CAs.
+
+```shell
+$ vault login <your initial root token>
+```
+If your login is successful, you will see output similar to what is shown below:
+
+```shell
+Success! You are now authenticated. The token information displayed below
+is already stored in the token helper. You do NOT need to run "vault login"
+again. Future Vault requests will automatically use this token.
+...
+```
+
+### Step 4: Generate the Root CA
+
+Enable the pki secrets engine at the pki path:
+
+```shell
+$ vault secrets enable pki
+```
+
+Tune the pki secrets engine to issue certificates with a maximum time-to-live
+(TTL) of 87600 hours:
+
+```shell
+$ vault secrets tune -max-lease-ttl=87600h pki
+```
+* Please note: we are using a common and recommended pattern which is to have
+  one mount act as the root CA and to use this CA only to sign intermediate CA
+  CSRs from other PKI secrets engines (which we will create in the next few
+  steps).
+
+Generate the root certificate and save the certificate as `CA_cert.crt`:
+
+```shell
+$ vault write -field=certificate pki/root/generate/internal \
+    common_name="global.nomad" ttl=87600h > CA_cert.crt
+```
+
+### Step 4: Generate the Intermediate CA and CSR
+
+Enable the pki secrets engine at the pki_int path:
+
+```shell
+$ vault secrets enable -path=pki_int pki
+```
+
+Tune the pki_int secrets engine to issue certificates with a maximum
+time-to-live (TTL) of 43800 hours:
+
+```shell
+$ vault secrets tune -max-lease-ttl=43800h pki_int
+```
+Generate a CSR from your intermediate CA and save it as `pki_intermediate.csr`:
+
+```shell
+$ vault write -format=json pki_int/intermediate/generate/internal \
+    common_name="global.nomad Intermediate Authority" \
+    ttl="43800h" | jq -r '.data.csr' > pki_intermediate.csr
+```
+
+### Step 5: Sign the Intermediate CA CSR 
+
+Sign the intermediate CA CSR with the root certificate and save the generated
+certificate as `intermediate.cert.pem`:
+
+```shell
+$ vault write -format=json pki/root/sign-intermediate \
+    csr=@pki_intermediate.csr format=pem_bundle \
+    ttl="43800h" | jq -r '.data.certificate' > intermediate.cert.pem
+```
+
+Once the CSR is signed and the root CA returns a certificate, it can be imported
+back into Vault:
+
+```shell
+vault write pki_int/intermediate/set-signed certificate=@intermediate.cert.pem
+```
+
+[consul-template]: https://www.consul.io/docs/guides/consul-template.html
+[consul-template-github]: https://github.com/hashicorp/consul-template
+[login]: https://www.vaultproject.io/docs/commands/login.html
+[pki-engine]: https://www.vaultproject.io/docs/secrets/pki/index.html
+[repo]: https://github.com/hashicorp/nomad/tree/master/terraform
+[seal]: https://www.vaultproject.io/docs/concepts/seal.html
+[token]: https://www.vaultproject.io/docs/concepts/tokens.html
+[vault-ca-learn]: https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine
+[vault-ra]: https://learn.hashicorp.com/vault/operations/ops-reference-architecture

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -357,7 +357,7 @@ using your own environment, please make sure Consul Template is installed. You
 can download it [here][ct-download].
 
 Provide the token you created in [Step
-8](#step-8-generate-a-token-based-on-tls-policy) to the Consul Template
+9](#step-9-generate-a-token-based-on-tls-policy) to the Consul Template
 configuration file located at `/etc/consul-template.d/consul-template.hcl`. You
 will also need to specify the [template stanza][ct-template-stanza] so you can
 render each of the following on your nodes at the specified location from the

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -354,6 +354,8 @@ template {
   command     = "pkill -SIGHUP nomad"
 }
 
+# The following template stanzas are for the CLI certs
+
 template {
   source      = "/opt/nomad/templates/cli.crt.tpl"
   destination = "/opt/nomad/certs/cli.crt"

--- a/website/source/guides/security/vault-pki-integration.html.md
+++ b/website/source/guides/security/vault-pki-integration.html.md
@@ -527,7 +527,7 @@ Reload Nomad's configuration on all nodes:
 ```shell
 $ systemctl reload nomad
 ```
-Once Nomad has been reloaded on all Nodes, go back to your server nodes and
+Once Nomad has been reloaded on all nodes, go back to your server nodes and
 change the `rpc_upgrade_mode` option to false (or remove the line since the
 option defaults to false) so that your Nomad servers will only accept TLS
 connections:

--- a/website/source/layouts/guides.erb
+++ b/website/source/layouts/guides.erb
@@ -176,6 +176,11 @@
             <a href="/guides/security/securing-nomad.html">Securing Nomad with TLS</a>
           </li>
 
+          </li>
+          <li<%= sidebar_current("guides-security-vault-pki") %>>
+            <a href="/guides/security/vault-pki-integration.html">Vault PKI Secrets Engine Integration</a>
+          </li>
+
           <li<%= sidebar_current("guides-security-acl") %>>
             <a href="/guides/security/acl.html">Access Control</a>
           </li>


### PR DESCRIPTION
This guide describes how to set up mTLS in a Nomad cluster with the help of Vault and Consul Template.

Particularly interested on any feedback on how to handle the shared key for encrypted gossip communication between servers (this is the last section and basically copies the section provided in https://www.nomadproject.io/guides/security/securing-nomad.html).