### PR TITLE
release: skip check step when cutting release

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -234,7 +234,7 @@ dev: vendorfmt changelogfmt ## Build for the current development platform
 
 .PHONY: prerelease
 prerelease: GO_TAGS=ui release
-prerelease: check generate-all ember-dist static-assets ## Generate all the static assets for a Nomad release
+prerelease: generate-all ember-dist static-assets ## Generate all the static assets for a Nomad release
 
 .PHONY: release
 release: GO_TAGS=ui release

--- a/scripts/release/Makefile.linux
+++ b/scripts/release/Makefile.linux
@@ -15,7 +15,7 @@ RELEASE_TARGET = release
 
 build_releases:
 	@echo "======>> installing dependencies"
-	$(MAKE) bootstrap
+	$(MAKE) deps
 
 	@echo "======>> pre-releasing"
 	$(MAKE) $(PRERELEASE_TARGET)


### PR DESCRIPTION
`make check` runs very intensive linters that slow and seem to behave
differently on different machines.

Linting is still a part of our CI and we shouldn't be cutting a release
when CI isn't green anyway.

Closes #5447