### PR TITLE
Adding tests for killing task without grace

### DIFF
--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -393,6 +393,8 @@ func setupRootfsBinary(t *testing.T, rootfs, path string) {
 	require.NoError(t, err)
 }
 
+// TestExecutor_Start_Kill_Immediately_NoGrace asserts that executors shutdown
+// immediately when sent a kill signal with no grace period.
 func TestExecutor_Start_Kill_Immediately_NoGrace(pt *testing.T) {
 	pt.Parallel()
 	for name, factory := range executorFactories {

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	tu "github.com/hashicorp/nomad/testutil"
 	ps "github.com/mitchellh/go-ps"
@@ -25,9 +26,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var executorFactories = map[string]func(hclog.Logger) Executor{}
-var universalFactory = func(l hclog.Logger) Executor {
-	return NewExecutor(l)
+var executorFactories = map[string]executorFactory{}
+
+type executorFactory struct {
+	new              func(hclog.Logger) Executor
+	configureExecCmd func(*testing.T, *ExecCommand)
+}
+
+var universalFactory = executorFactory{
+	new:              NewExecutor,
+	configureExecCmd: func(*testing.T, *ExecCommand) {},
 }
 
 func init() {
@@ -55,11 +63,21 @@ func testExecutorCommand(t *testing.T) (*ExecCommand, *allocdir.AllocDir) {
 		Env:     taskEnv.List(),
 		TaskDir: td.Dir,
 		Resources: &drivers.Resources{
-			NomadResources: alloc.AllocatedResources.Tasks[task.Name],
+			NomadResources: &structs.AllocatedTaskResources{
+				Cpu: structs.AllocatedCpuResources{
+					CpuShares: 500,
+				},
+				Memory: structs.AllocatedMemoryResources{
+					MemoryMB: 256,
+				},
+			},
+			LinuxResources: &drivers.LinuxResources{
+				CPUShares:        500,
+				MemoryLimitBytes: 256 * 1024 * 1024,
+			},
 		},
 	}
 
-	setupRootfs(t, td.Dir)
 	configureTLogging(cmd)
 	return cmd, allocDir
 }
@@ -84,8 +102,9 @@ func TestExecutor_Start_Invalid(pt *testing.T) {
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = invalid
 			execCmd.Args = []string{"1"}
+			factory.configureExecCmd(t, execCmd)
 			defer allocDir.Destroy()
-			executor := factory(testlog.HCLogger(t))
+			executor := factory.new(testlog.HCLogger(t))
 			defer executor.Shutdown("", 0)
 
 			_, err := executor.Launch(execCmd)
@@ -102,8 +121,9 @@ func TestExecutor_Start_Wait_Failure_Code(pt *testing.T) {
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = "/bin/date"
 			execCmd.Args = []string{"fail"}
+			factory.configureExecCmd(t, execCmd)
 			defer allocDir.Destroy()
-			executor := factory(testlog.HCLogger(t))
+			executor := factory.new(testlog.HCLogger(t))
 			defer executor.Shutdown("", 0)
 
 			ps, err := executor.Launch(execCmd)
@@ -124,9 +144,10 @@ func TestExecutor_Start_Wait(pt *testing.T) {
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = "/bin/echo"
 			execCmd.Args = []string{"hello world"}
+			factory.configureExecCmd(t, execCmd)
 
 			defer allocDir.Destroy()
-			executor := factory(testlog.HCLogger(t))
+			executor := factory.new(testlog.HCLogger(t))
 			defer executor.Shutdown("", 0)
 
 			ps, err := executor.Launch(execCmd)
@@ -162,8 +183,10 @@ func TestExecutor_WaitExitSignal(pt *testing.T) {
 			execCmd.Cmd = "/bin/sleep"
 			execCmd.Args = []string{"10000"}
 			execCmd.ResourceLimits = true
+			factory.configureExecCmd(t, execCmd)
+
 			defer allocDir.Destroy()
-			executor := factory(testlog.HCLogger(t))
+			executor := factory.new(testlog.HCLogger(t))
 			defer executor.Shutdown("", 0)
 
 			ps, err := executor.Launch(execCmd)
@@ -213,8 +236,10 @@ func TestExecutor_Start_Kill(pt *testing.T) {
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = "/bin/sleep"
 			execCmd.Args = []string{"10"}
+			factory.configureExecCmd(t, execCmd)
+
 			defer allocDir.Destroy()
-			executor := factory(testlog.HCLogger(t))
+			executor := factory.new(testlog.HCLogger(t))
 			defer executor.Shutdown("", 0)
 
 			ps, err := executor.Launch(execCmd)
@@ -376,8 +401,9 @@ func TestExecutor_Start_Kill_Immediately_NoGrace(pt *testing.T) {
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = "/bin/sleep"
 			execCmd.Args = []string{"100"}
+			factory.configureExecCmd(t, execCmd)
 			defer allocDir.Destroy()
-			executor := factory(testlog.HCLogger(t))
+			executor := factory.new(testlog.HCLogger(t))
 			defer executor.Shutdown("", 0)
 
 			ps, err := executor.Launch(execCmd)
@@ -410,8 +436,9 @@ func TestExecutor_Start_Kill_Immediately_WithGrace(pt *testing.T) {
 			execCmd, allocDir := testExecutorCommand(t)
 			execCmd.Cmd = "/bin/sleep"
 			execCmd.Args = []string{"100"}
+			factory.configureExecCmd(t, execCmd)
 			defer allocDir.Destroy()
-			executor := factory(testlog.HCLogger(t))
+			executor := factory.new(testlog.HCLogger(t))
 			defer executor.Shutdown("", 0)
 
 			ps, err := executor.Launch(execCmd)


### PR DESCRIPTION
Added a test for executor waiting while shutting down.

While digging into potential Wait races, I noticed that killing a task in tests didn't terminate process properly, e.g. `TestExecutor_Start_Kill_Immediately_NoGrace/LibcontainerExecutor` in https://travis-ci.org/hashicorp/nomad/jobs/511484378 .

Upon inspection, the issue seems that libcontainer executor command needs to be configured with `ResourceLimits` set to `true` for shutdown to operate well.  In production code, this is always the case but not in tests.

Here, we ensure that `ResourceLimits` is always `true` in tests.

A follow up after 0.9 is to make libcontainer executor works properly even when `ResourceLimits` is set to false.  We can do this by ensuring that devices cgroup is always created in addition to freezer, as libcontainer uses `devices` cgroup to determine cgroup processes: https://github.com/hashicorp/nomad/blob/4ca6cda6c1077474a3cde93c9b7ed5ac374eec35/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go#L288 .
