### PR TITLE
[Allocation Lifecycle] ACL and alloc_signal command

### DIFF
--- a/acl/policy.go
+++ b/acl/policy.go
@@ -28,6 +28,7 @@ const (
 	NamespaceCapabilityDispatchJob      = "dispatch-job"
 	NamespaceCapabilityReadLogs         = "read-logs"
 	NamespaceCapabilityReadFS           = "read-fs"
+	NamespaceCapabilityAllocLifecycle   = "alloc-lifecycle"
 	NamespaceCapabilitySentinelOverride = "sentinel-override"
 )
 
@@ -93,7 +94,7 @@ func isNamespaceCapabilityValid(cap string) bool {
 	switch cap {
 	case NamespaceCapabilityDeny, NamespaceCapabilityListJobs, NamespaceCapabilityReadJob,
 		NamespaceCapabilitySubmitJob, NamespaceCapabilityDispatchJob, NamespaceCapabilityReadLogs,
-		NamespaceCapabilityReadFS:
+		NamespaceCapabilityReadFS, NamespaceCapabilityAllocLifecycle:
 		return true
 	// Separate the enterprise-only capabilities
 	case NamespaceCapabilitySentinelOverride:
@@ -122,6 +123,7 @@ func expandNamespacePolicy(policy string) []string {
 			NamespaceCapabilityDispatchJob,
 			NamespaceCapabilityReadLogs,
 			NamespaceCapabilityReadFS,
+			NamespaceCapabilityAllocLifecycle,
 		}
 	default:
 		return nil

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"time"
+
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 var (
@@ -76,6 +78,23 @@ func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
 
 	var resp struct{}
 	_, err = nodeClient.query("/v1/client/allocation/"+alloc.ID+"/gc", &resp, nil)
+	return err
+}
+
+func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal string) error {
+	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
+	if err != nil {
+		return err
+	}
+
+	req := structs.AllocSignalRequest{
+		AllocID: alloc.ID,
+		Signal:  signal,
+		Task:    task,
+	}
+
+	var resp struct{}
+	_, err = nodeClient.putQuery("/v1/client/allocation/"+alloc.ID+"/signal", &req, &resp, q)
 	return err
 }
 

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -81,10 +81,11 @@ func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
 	return err
 }
 
-func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal string) error {
+func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal string) (
+	*structs.AllocSignalResponse, error) {
 	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req := structs.AllocSignalRequest{
@@ -93,9 +94,9 @@ func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal st
 		Task:    task,
 	}
 
-	var resp struct{}
+	var resp structs.AllocSignalResponse
 	_, err = nodeClient.putQuery("/v1/client/allocation/"+alloc.ID+"/signal", &req, &resp, q)
-	return err
+	return &resp, err
 }
 
 // Allocation is used for serialization of allocations.

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -81,6 +81,17 @@ func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
 	return err
 }
 
+func (a *Allocations) Stop(alloc *Allocation, q *QueryOptions) (*structs.AllocStopResponse, error) {
+	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp structs.AllocStopResponse
+	_, err = nodeClient.putQuery("/v1/allocation/"+alloc.ID+"/stop", nil, &resp, q)
+	return &resp, err
+}
+
 func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal string) (
 	*structs.AllocSignalResponse, error) {
 	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)

--- a/client/alloc_endpoint.go
+++ b/client/alloc_endpoint.go
@@ -48,7 +48,7 @@ func (a *Allocations) GarbageCollect(args *nstructs.AllocSpecificRequest, reply 
 	return nil
 }
 
-func (a *Allocations) Signal(args *nstructs.AllocSignalRequest, reply *nstructs.GenericResponse) error {
+func (a *Allocations) Signal(args *nstructs.AllocSignalRequest, reply *nstructs.AllocSignalResponse) error {
 	defer metrics.MeasureSince([]string{"client", "allocations", "signal"}, time.Now())
 
 	// Check submit job permissions
@@ -58,7 +58,9 @@ func (a *Allocations) Signal(args *nstructs.AllocSignalRequest, reply *nstructs.
 		return nstructs.ErrPermissionDenied
 	}
 
-	return a.c.SignalAllocation(args.AllocID, args.Task, args.Signal)
+	var err error
+	reply.SignalledTasks, err = a.c.SignalAllocation(args.AllocID, args.Task, args.Signal)
+	return err
 }
 
 // Stats is used to collect allocation statistics

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -941,7 +941,7 @@ func (ar *allocRunner) GetTaskEventHandler(taskName string) drivermanager.EventH
 func (ar *allocRunner) Signal(taskName, signal string) error {
 	// TODO(dani): Add new task event
 	event := structs.NewTaskEvent(structs.TaskDriverMessage).
-		SetDriverMessage(fmt.Sprintf("Recieved signal: %s from user", signal))
+		SetDriverMessage(fmt.Sprintf("Received signal: %s from user", signal))
 
 	if taskName != "" {
 		tr, ok := ar.tasks[taskName]

--- a/client/client.go
+++ b/client/client.go
@@ -123,7 +123,7 @@ type AllocRunner interface {
 	WaitCh() <-chan struct{}
 	DestroyCh() <-chan struct{}
 	ShutdownCh() <-chan struct{}
-	Signal(taskName, signal string) error
+	Signal(taskName, signal string) (map[string]string, error)
 	GetTaskEventHandler(taskName string) drivermanager.EventHandler
 }
 
@@ -695,10 +695,10 @@ func (c *Client) Stats() map[string]map[string]string {
 // SignalAllocation sends a signal to the tasks within an allocation.
 // If the provided task is empty, then every allocation will be signalled.
 // If a task is provided, then only an exactly matching task will be signalled.
-func (c *Client) SignalAllocation(allocID, task, signal string) error {
+func (c *Client) SignalAllocation(allocID, task, signal string) (map[string]string, error) {
 	ar, err := c.getAllocRunner(allocID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	return ar.Signal(task, signal)

--- a/client/client.go
+++ b/client/client.go
@@ -123,6 +123,7 @@ type AllocRunner interface {
 	WaitCh() <-chan struct{}
 	DestroyCh() <-chan struct{}
 	ShutdownCh() <-chan struct{}
+	Signal(taskName, signal string) error
 	GetTaskEventHandler(taskName string) drivermanager.EventHandler
 }
 
@@ -689,6 +690,18 @@ func (c *Client) Stats() map[string]map[string]string {
 		"runtime": hstats.RuntimeStats(),
 	}
 	return stats
+}
+
+// SignalAllocation sends a signal to the tasks within an allocation.
+// If the provided task is empty, then every allocation will be signalled.
+// If a task is provided, then only an exactly matching task will be signalled.
+func (c *Client) SignalAllocation(allocID, task, signal string) error {
+	ar, err := c.getAllocRunner(allocID)
+	if err != nil {
+		return err
+	}
+
+	return ar.Signal(task, signal)
 }
 
 // CollectAllocation garbage collects a single allocation on a node. Returns

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -175,7 +175,7 @@ func (s *HTTPServer) allocGC(allocID string, resp http.ResponseWriter, req *http
 }
 
 func (s *HTTPServer) allocSignal(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "POST" {
+	if !(req.Method == "POST" || req.Method == "PUT") {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -192,7 +192,7 @@ func (s *HTTPServer) allocSignal(allocID string, resp http.ResponseWriter, req *
 	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForAlloc(allocID)
 
 	// Make the RPC
-	var reply structs.GenericResponse
+	var reply structs.AllocSignalResponse
 	var rpcErr error
 	if useLocalClient {
 		rpcErr = s.agent.Client().ClientRPC("Allocations.Signal", &args, &reply)
@@ -210,7 +210,7 @@ func (s *HTTPServer) allocSignal(allocID string, resp http.ResponseWriter, req *
 		}
 	}
 
-	return nil, rpcErr
+	return reply, rpcErr
 }
 
 func (s *HTTPServer) allocSnapshot(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -41,7 +41,29 @@ func (s *HTTPServer) AllocsRequest(resp http.ResponseWriter, req *http.Request) 
 }
 
 func (s *HTTPServer) AllocSpecificRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	allocID := strings.TrimPrefix(req.URL.Path, "/v1/allocation/")
+	reqSuffix := strings.TrimPrefix(req.URL.Path, "/v1/allocation/")
+
+	// tokenize the suffix of the path to get the alloc id and find the action
+	// invoked on the alloc id
+	tokens := strings.Split(reqSuffix, "/")
+	if len(tokens) > 2 || len(tokens) < 1 {
+		return nil, CodedError(404, resourceNotFoundErr)
+	}
+	allocID := tokens[0]
+
+	if len(tokens) == 1 {
+		return s.allocGet(allocID, resp, req)
+	}
+
+	switch tokens[1] {
+	case "stop":
+		return s.allocStop(allocID, resp, req)
+	}
+
+	return nil, CodedError(404, resourceNotFoundErr)
+}
+
+func (s *HTTPServer) allocGet(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if req.Method != "GET" {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
@@ -78,8 +100,22 @@ func (s *HTTPServer) AllocSpecificRequest(resp http.ResponseWriter, req *http.Re
 	return alloc, nil
 }
 
-func (s *HTTPServer) ClientAllocRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (s *HTTPServer) allocStop(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if !(req.Method == "POST" || req.Method == "PUT") {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
 
+	transReq := &structs.AllocStopRequest{
+		AllocID: allocID,
+	}
+	s.parseWriteRequest(req, &transReq.WriteRequest)
+
+	var out structs.AllocStopResponse
+	err := s.agent.RPC("Alloc.Stop", &transReq, &out)
+	return out, err
+}
+
+func (s *HTTPServer) ClientAllocRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	reqSuffix := strings.TrimPrefix(req.URL.Path, "/v1/client/allocation/")
 
 	// tokenize the suffix of the path to get the alloc id and find the action

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -108,10 +108,15 @@ func (c *AllocSignalCommand) Run(args []string) int {
 		return 1
 	}
 
-	err = client.Allocations().Signal(alloc, nil, taskName, "sighup")
+	resp, err := client.Allocations().Signal(alloc, nil, taskName, "sighup")
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error signalling allocation: %s", err))
 		return 1
+	}
+
+	// TODO: Pretty print a table
+	for k, v := range resp.SignalledTasks {
+		c.Ui.Output(fmt.Sprintf("%s: %s", k, v))
 	}
 
 	return 0

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -1,0 +1,133 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+)
+
+type AllocSignalCommand struct {
+	Meta
+}
+
+func (a *AllocSignalCommand) Help() string {
+	helpText := `
+Usage: nomad alloc signal [options] <allocation> <task>
+
+  signal an existing allocation. This command is used to signal a specific alloc
+  and its subtasks. If no task is provided then all of the allocations subtasks
+  will recieve the signal.
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+Signal Specific Options:
+
+  -verbose
+    Show full information.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *AllocSignalCommand) Name() string { return "alloc signal" }
+
+func (c *AllocSignalCommand) Run(args []string) int {
+	var verbose bool
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&verbose, "verbose", false, "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we got exactly one alloc
+	args = flags.Args()
+	if len(args) != 1 {
+		c.Ui.Error("This command takes one argument: <alloc-id>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	allocID := args[0]
+
+	// Truncate the id unless full length is requested
+	length := shortId
+	if verbose {
+		length = fullId
+	}
+
+	// Query the allocation info
+	if len(allocID) == 1 {
+		c.Ui.Error(fmt.Sprintf("Alloc ID must contain at least two characters."))
+		return 1
+	}
+
+	allocID = sanitizeUUIDPrefix(allocID)
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	allocs, _, err := client.Allocations().PrefixList(allocID)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying allocation: %v", err))
+		return 1
+	}
+
+	if len(allocs) == 0 {
+		c.Ui.Error(fmt.Sprintf("No allocation(s) with prefix or id %q found", allocID))
+		return 1
+	}
+
+	if len(allocs) > 1 {
+		// Format the allocs
+		out := formatAllocListStubs(allocs, verbose, length)
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple allocations\n\n%s", out))
+		return 1
+	}
+
+	// Prefix lookup matched a single allocation
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
+		return 1
+	}
+
+	// Placeholder - List root dir until we implement RPCs for stopping.
+
+	files, _, err := client.AllocFS().List(alloc, "/", nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error listing alloc dir: %s", err))
+		return 1
+	}
+
+	// Display the file information in a tabular format
+	out := make([]string, len(files)+1)
+	out[0] = "Mode|Size|Modified Time|Name"
+	for i, file := range files {
+		fn := file.Name
+		if file.IsDir {
+			fn = fmt.Sprintf("%s/", fn)
+		}
+		var size string
+		size = fmt.Sprintf("%d", file.Size)
+		out[i+1] = fmt.Sprintf("%s|%s|%s|%s",
+			file.FileMode,
+			size,
+			formatTime(file.ModTime),
+			fn,
+		)
+	}
+	c.Ui.Output(formatList(out))
+
+	return 0
+}
+
+func (a *AllocSignalCommand) Synopsis() string {
+	return "Signal a running allocation"
+}

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -15,7 +15,7 @@ Usage: nomad alloc signal [options] <signal> <allocation> <task>
 
   signal an existing allocation. This command is used to signal a specific alloc
   and its subtasks. If no task is provided then all of the allocations subtasks
-  will recieve the signal.
+  will receive the signal.
 
 General Options:
 
@@ -24,7 +24,7 @@ General Options:
 Signal Specific Options:
 
   -s
-    Specify the signal that the selected tasks should recieve.
+    Specify the signal that the selected tasks should receive.
 
   -verbose
     Show full information.

--- a/command/alloc_signal_test.go
+++ b/command/alloc_signal_test.go
@@ -1,0 +1,12 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestAllocSignalCommand_Implements(t *testing.T) {
+	t.Parallel()
+	var _ cli.Command = &AllocSignalCommand{}
+}

--- a/command/alloc_signal_test.go
+++ b/command/alloc_signal_test.go
@@ -4,9 +4,47 @@ import (
 	"testing"
 
 	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllocSignalCommand_Implements(t *testing.T) {
 	t.Parallel()
 	var _ cli.Command = &AllocSignalCommand{}
+}
+
+func TestAllocSignalCommand_Fails(t *testing.T) {
+	t.Parallel()
+	srv, _, url := testServer(t, false, nil)
+	defer srv.Shutdown()
+
+	require := require.New(t)
+
+	ui := new(cli.MockUi)
+	cmd := &AllocSignalCommand{Meta: Meta{Ui: ui}}
+
+	// Fails on lack of alloc ID
+	require.Equal(1, cmd.Run([]string{}))
+	require.Contains(ui.ErrorWriter.String(), "This command takes up to two arguments")
+	ui.ErrorWriter.Reset()
+
+	// Fails on misuse
+	require.Equal(1, cmd.Run([]string{"some", "bad", "args"}))
+	require.Contains(ui.ErrorWriter.String(), "This command takes up to two arguments")
+	ui.ErrorWriter.Reset()
+
+	// Fails on connection failure
+	require.Equal(1, cmd.Run([]string{"-address=nope", "foobar"}))
+	require.Contains(ui.ErrorWriter.String(), "Error querying allocation")
+	ui.ErrorWriter.Reset()
+
+	// Fails on missing alloc
+	code := cmd.Run([]string{"-address=" + url, "26470238-5CF2-438F-8772-DC67CFB0705C"})
+	require.Equal(1, code)
+	require.Contains(ui.ErrorWriter.String(), "No allocation(s) with prefix or id")
+	ui.ErrorWriter.Reset()
+
+	// Fail on identifier with too few characters
+	require.Equal(1, cmd.Run([]string{"-address=" + url, "2"}))
+	require.Contains(ui.ErrorWriter.String(), "must contain at least two characters.")
+	ui.ErrorWriter.Reset()
 }

--- a/command/alloc_stop.go
+++ b/command/alloc_stop.go
@@ -1,0 +1,149 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+)
+
+type AllocStopCommand struct {
+	Meta
+}
+
+func (a *AllocStopCommand) Help() string {
+	helpText := `
+Usage: nomad alloc stop [options] <allocation>
+Alias: nomad stop
+
+  stop an existing allocation. This command is used to signal a specific alloc
+  to shut down. When the allocation has been shut down, it will then be
+  rescheduled. An interactive monitoring session will display log lines as the
+  allocation completes shutting down. It is safe to exit the monitor early with
+  ctrl-c.
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+Stop Specific Options:
+
+  -kill-timeout <duration>
+    The period of time that the allocation should be allowed to perform a
+    graceful shutdown (default 5s). After this time, the process will recieve a
+    SIGKILL and be forcefully terminated. If set to '0s', then the allocation
+    will be immediately terminated.
+
+  -detach
+    Return immediately instead of entering monitor mode. After the
+    stop command is submitted, a new evaluation ID is printed to the
+    screen, which can be used to examine the rescheduling evaluation using the
+    eval-status command.
+
+  -verbose
+    Show full information.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *AllocStopCommand) Name() string { return "alloc stop" }
+
+func (c *AllocStopCommand) Run(args []string) int {
+	var detach, verbose bool
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&detach, "detach", false, "")
+	flags.BoolVar(&verbose, "verbose", false, "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we got exactly one alloc
+	args = flags.Args()
+	if len(args) != 1 {
+		c.Ui.Error("This command takes one argument: <alloc-id>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	allocID := args[0]
+
+	// Truncate the id unless full length is requested
+	length := shortId
+	if verbose {
+		length = fullId
+	}
+
+	// Query the allocation info
+	if len(allocID) == 1 {
+		c.Ui.Error(fmt.Sprintf("Alloc ID must contain at least two characters."))
+		return 1
+	}
+
+	allocID = sanitizeUUIDPrefix(allocID)
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	allocs, _, err := client.Allocations().PrefixList(allocID)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying allocation: %v", err))
+		return 1
+	}
+
+	if len(allocs) == 0 {
+		c.Ui.Error(fmt.Sprintf("No allocation(s) with prefix or id %q found", allocID))
+		return 1
+	}
+
+	if len(allocs) > 1 {
+		// Format the allocs
+		out := formatAllocListStubs(allocs, verbose, length)
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple allocations\n\n%s", out))
+		return 1
+	}
+
+	// Prefix lookup matched a single allocation
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
+		return 1
+	}
+
+	// Placeholder - List root dir until we implement RPCs for stopping.
+
+	files, _, err := client.AllocFS().List(alloc, "/", nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error listing alloc dir: %s", err))
+		return 1
+	}
+
+	// Display the file information in a tabular format
+	out := make([]string, len(files)+1)
+	out[0] = "Mode|Size|Modified Time|Name"
+	for i, file := range files {
+		fn := file.Name
+		if file.IsDir {
+			fn = fmt.Sprintf("%s/", fn)
+		}
+		var size string
+		size = fmt.Sprintf("%d", file.Size)
+		out[i+1] = fmt.Sprintf("%s|%s|%s|%s",
+			file.FileMode,
+			size,
+			formatTime(file.ModTime),
+			fn,
+		)
+	}
+	c.Ui.Output(formatList(out))
+
+	return 0
+}
+
+func (a *AllocStopCommand) Synopsis() string {
+	return "Stop and reschedule a running allocation"
+}

--- a/command/alloc_stop.go
+++ b/command/alloc_stop.go
@@ -28,7 +28,7 @@ Stop Specific Options:
 
   -kill-timeout <duration>
     The period of time that the allocation should be allowed to perform a
-    graceful shutdown (default 5s). After this time, the process will recieve a
+    graceful shutdown (default 5s). After this time, the process will receive a
     SIGKILL and be forcefully terminated. If set to '0s', then the allocation
     will be immediately terminated.
 

--- a/command/alloc_stop_test.go
+++ b/command/alloc_stop_test.go
@@ -1,0 +1,12 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestAllocStopCommand_Implements(t *testing.T) {
+	t.Parallel()
+	var _ cli.Command = &AllocStopCommand{}
+}

--- a/command/commands.go
+++ b/command/commands.go
@@ -140,6 +140,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"alloc signal": func() (cli.Command, error) {
+			return &AllocSignalCommand{
+				Meta: meta,
+			}, nil
+		},
 		"alloc fs": func() (cli.Command, error) {
 			return &AllocFSCommand{
 				Meta: meta,

--- a/command/commands.go
+++ b/command/commands.go
@@ -140,6 +140,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"alloc stop": func() (cli.Command, error) {
+			return &AllocStopCommand{
+				Meta: meta,
+			}, nil
+		},
 		"alloc signal": func() (cli.Command, error) {
 			return &AllocSignalCommand{
 				Meta: meta,

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -10,6 +10,8 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -203,6 +205,63 @@ func (a *Alloc) GetAllocs(args *structs.AllocsGetRequest,
 		},
 	}
 	return a.srv.blockingRPC(&opts)
+}
+
+func (a *Alloc) Stop(args *structs.AllocStopRequest, reply *structs.AllocStopResponse) error {
+	if done, err := a.srv.forward("Alloc.Stop", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "alloc", "stop"}, time.Now())
+
+	// Check that it is a management token.
+	if aclObj, err := a.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNsOp(args.Namespace, acl.NamespaceCapabilityAllocLifecycle) {
+		return structs.ErrPermissionDenied
+	}
+
+	if args.AllocID == "" {
+		return fmt.Errorf("must provide an alloc id")
+	}
+
+	// TODO: Maybe use blocking query
+	ws := memdb.NewWatchSet()
+	alloc, err := a.srv.State().AllocByID(ws, args.AllocID)
+	if err != nil {
+		return err
+	}
+
+	eval := &structs.Evaluation{
+		ID:             uuid.Generate(),
+		Namespace:      alloc.Namespace,
+		Priority:       alloc.Job.Priority,
+		Type:           alloc.Job.Type,
+		TriggeredBy:    structs.EvalTriggerAllocStop,
+		JobID:          alloc.Job.ID,
+		JobModifyIndex: alloc.Job.ModifyIndex,
+		Status:         structs.EvalStatusPending,
+	}
+
+	transitionReq := &structs.AllocUpdateDesiredTransitionRequest{
+		Evals: []*structs.Evaluation{eval},
+		Allocs: map[string]*structs.DesiredTransition{
+			args.AllocID: &structs.DesiredTransition{
+				Migrate: helper.BoolToPtr(true),
+			},
+		},
+	}
+
+	// Commit this update via Raft
+	_, index, err := a.srv.raftApply(structs.AllocUpdateDesiredTransitionRequestType, transitionReq)
+	if err != nil {
+		a.logger.Error("AllocUpdateDesiredTransitionRequest failed", "error", err)
+		return err
+	}
+
+	// Setup the response
+	reply.Index = index
+	reply.EvalID = eval.ID
+	return nil
 }
 
 // UpdateDesiredTransition is used to update the desired transitions of an

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1116,6 +1116,11 @@ type AllocsGetResponse struct {
 	QueryMeta
 }
 
+type AllocSignalResponse struct {
+	SignalledTasks map[string]string
+	QueryMeta
+}
+
 // JobAllocationsResponse is used to return the allocations for a job
 type JobAllocationsResponse struct {
 	Allocations []*AllocListStub
@@ -6123,6 +6128,11 @@ func (e *TaskEvent) SetExitCode(c int) *TaskEvent {
 func (e *TaskEvent) SetSignal(s int) *TaskEvent {
 	e.Signal = s
 	e.Details["signal"] = fmt.Sprintf("%d", s)
+	return e
+}
+
+func (e *TaskEvent) SetSignalText(s string) *TaskEvent {
+	e.Details["signal"] = s
 	return e
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -705,6 +705,14 @@ type AllocSpecificRequest struct {
 	QueryOptions
 }
 
+// AllocSignalRequest is used to signal a specific allocation
+type AllocSignalRequest struct {
+	AllocID string
+	Task    string
+	Signal  string
+	QueryOptions
+}
+
 // AllocsGetRequest is used to query a set of allocations
 type AllocsGetRequest struct {
 	AllocIDs []string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -694,6 +694,21 @@ type AllocUpdateDesiredTransitionRequest struct {
 	WriteRequest
 }
 
+// AllocStopRequest is used to stop and reschedule a running Allocation.
+type AllocStopRequest struct {
+	AllocID string
+
+	WriteRequest
+}
+
+// AllocStopResponse is the response to an `AllocStopRequest`
+type AllocStopResponse struct {
+	// EvalID is the id of the follow up evalution for the rescheduled alloc.
+	EvalID string
+
+	WriteMeta
+}
+
 // AllocListRequest is used to request a list of allocations
 type AllocListRequest struct {
 	QueryOptions
@@ -7973,6 +7988,7 @@ const (
 	EvalTriggerPeriodicJob       = "periodic-job"
 	EvalTriggerNodeDrain         = "node-drain"
 	EvalTriggerNodeUpdate        = "node-update"
+	EvalTriggerAllocStop         = "alloc-stop"
 	EvalTriggerScheduled         = "scheduled"
 	EvalTriggerRollingUpdate     = "rolling-update"
 	EvalTriggerDeploymentWatcher = "deployment-watcher"

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -127,6 +127,7 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) error {
 	switch eval.TriggeredBy {
 	case structs.EvalTriggerJobRegister, structs.EvalTriggerJobDeregister,
 		structs.EvalTriggerNodeDrain, structs.EvalTriggerNodeUpdate,
+		structs.EvalTriggerAllocStop,
 		structs.EvalTriggerRollingUpdate, structs.EvalTriggerQueuedAllocs,
 		structs.EvalTriggerPeriodicJob, structs.EvalTriggerMaxPlans,
 		structs.EvalTriggerDeploymentWatcher, structs.EvalTriggerRetryFailedAlloc,

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -61,7 +61,7 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) error {
 	switch eval.TriggeredBy {
 	case structs.EvalTriggerJobRegister, structs.EvalTriggerNodeUpdate, structs.EvalTriggerFailedFollowUp,
 		structs.EvalTriggerJobDeregister, structs.EvalTriggerRollingUpdate, structs.EvalTriggerPreemption,
-		structs.EvalTriggerDeploymentWatcher, structs.EvalTriggerNodeDrain:
+		structs.EvalTriggerDeploymentWatcher, structs.EvalTriggerNodeDrain, structs.EvalTriggerAllocStop:
 	default:
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)


### PR DESCRIPTION
This Pull Request adds the new `alloc-lifecycle` ACL, and adds it to the Write coarse grained policy. It also introduces the `nomad alloc signal` command which allows a user to send a signal to an allocation.

### Remaining Work

- [ ] Add a new task event for user-triggered-signalling
- [ ] Finalize UI
- [ ] Testing across drivers