### PR TITLE
Use specific url prefix for metrics test

### DIFF
--- a/e2e/metrics/input/helloworld.nomad
+++ b/e2e/metrics/input/helloworld.nomad
@@ -35,7 +35,7 @@ job "hello" {
 
       service {
         name = "hello"
-        tags = ["urlprefix-/"]
+        tags = ["urlprefix-hello/"]
         port = "web"
         check {
           name     = "alive"


### PR DESCRIPTION
Some fixes to the metrics end to end test setup. 