### PR TITLE
docs: mention support for centos6 is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 __BACKWARDS INCOMPATIBILITIES:__
 
+ * core: Drop support for CentOS/RHEL 6. glibc >= 2.14 is required.
  * core: Switch to structured logging using
    [go-hclog](https://github.com/hashicorp/go-hclog). If you have tooling that
    parses Nomad's logs, the format of logs has changed and your tools may need


### PR DESCRIPTION
From https://groups.google.com/d/topic/nomad-tool/e2Oo06wX_zA/discussion