### PR TITLE
Accept vault token for job revert

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,7 +26,7 @@ var (
 	ClientConnTimeout = 1 * time.Second
 )
 
-// QueryOptions are used to parameterize a query
+// QueryOptions are used to parametrize a query
 type QueryOptions struct {
 	// Providing a datacenter overwrites the region provided
 	// by the Config
@@ -57,7 +57,7 @@ type QueryOptions struct {
 	AuthToken string
 }
 
-// WriteOptions are used to parameterize a write
+// WriteOptions are used to parametrize a write
 type WriteOptions struct {
 	// Providing a datacenter overwrites the region provided
 	// by the Config

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -321,13 +321,14 @@ func (j *Jobs) Dispatch(jobID string, meta map[string]string,
 // enforceVersion is set, the job is only reverted if the current version is at
 // the passed version.
 func (j *Jobs) Revert(jobID string, version uint64, enforcePriorVersion *uint64,
-	q *WriteOptions) (*JobRegisterResponse, *WriteMeta, error) {
+	q *WriteOptions, vaultToken string) (*JobRegisterResponse, *WriteMeta, error) {
 
 	var resp JobRegisterResponse
 	req := &JobRevertRequest{
 		JobID:               jobID,
 		JobVersion:          version,
 		EnforcePriorVersion: enforcePriorVersion,
+		VaultToken:          vaultToken,
 	}
 	wm, err := j.client.write("/v1/job/"+jobID+"/revert", req, &resp, q)
 	if err != nil {
@@ -929,6 +930,12 @@ type JobRevertRequest struct {
 	// EnforcePriorVersion if set will enforce that the job is at the given
 	// version before reverting.
 	EnforcePriorVersion *uint64
+
+	// VaultToken is the Vault token that proves the submitter of the job revert
+	// has access to any Vault policies specified in the targeted job version. This
+	// field is only used to transfer the token and is not stored after the Job
+	// revert.
+	VaultToken string `json:",omitempty"`
 
 	WriteRequest
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -933,7 +933,7 @@ type JobRevertRequest struct {
 
 	// VaultToken is the Vault token that proves the submitter of the job revert
 	// has access to any Vault policies specified in the targeted job version. This
-	// field is only used to transfer the token and is not stored after the Job
+	// field is only used to authorize the revert and is not stored after the Job
 	// revert.
 	VaultToken string `json:",omitempty"`
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -755,13 +755,13 @@ func TestJobs_Revert(t *testing.T) {
 	assertWriteMeta(t, wm)
 
 	// Fail revert at incorrect enforce
-	_, _, err = jobs.Revert(*job.ID, 0, uint64ToPtr(10), nil)
+	_, _, err = jobs.Revert(*job.ID, 0, uint64ToPtr(10), nil, "")
 	if err == nil || !strings.Contains(err.Error(), "enforcing version") {
 		t.Fatalf("expected enforcement error: %v", err)
 	}
 
 	// Works at correct index
-	revertResp, wm, err := jobs.Revert(*job.ID, 0, uint64ToPtr(1), nil)
+	revertResp, wm, err := jobs.Revert(*job.ID, 0, uint64ToPtr(1), nil, "")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/nomad/api/contexts"
@@ -32,6 +33,10 @@ Revert Options:
 
   -verbose
     Display full information.
+
+  -vault-token 
+   The Vault token used to verify that the caller has access to the Vault 
+   policies i the targeted version of the job.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -67,11 +72,13 @@ func (c *JobRevertCommand) Name() string { return "job revert" }
 
 func (c *JobRevertCommand) Run(args []string) int {
 	var detach, verbose bool
+	var vaultToken string
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&detach, "detach", false, "")
 	flags.BoolVar(&verbose, "verbose", false, "")
+	flags.StringVar(&vaultToken, "vault-token", "", "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -96,6 +103,12 @@ func (c *JobRevertCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
 		return 1
+	}
+
+	// Parse the Vault token
+	if vaultToken == "" {
+		// Check the environment variable
+		vaultToken = os.Getenv("VAULT_TOKEN")
 	}
 
 	jobID := args[0]
@@ -125,7 +138,7 @@ func (c *JobRevertCommand) Run(args []string) int {
 	}
 
 	// Prefix lookup matched a single job
-	resp, _, err := client.Jobs().Revert(jobs[0].ID, revertVersion, nil, nil)
+	resp, _, err := client.Jobs().Revert(jobs[0].ID, revertVersion, nil, nil, vaultToken)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s", err))
 		return 1

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -31,12 +31,12 @@ Revert Options:
     the evaluation ID will be printed to the screen, which can be used to
     examine the evaluation using the eval-status command.
 
-  -verbose
-    Display full information.
-
   -vault-token 
    The Vault token used to verify that the caller has access to the Vault 
    policies i the targeted version of the job.
+
+  -verbose
+    Display full information.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -441,8 +441,10 @@ func (j *Job) Revert(args *structs.JobRevertRequest, reply *structs.JobRegisterR
 	}
 
 	// Build the register request
+	revJob := jobV.Copy()
+	revJob.VaultToken = args.VaultToken
 	reg := &structs.JobRegisterRequest{
-		Job:          jobV.Copy(),
+		Job:          revJob,
 		WriteRequest: args.WriteRequest,
 	}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -442,6 +442,7 @@ func (j *Job) Revert(args *structs.JobRevertRequest, reply *structs.JobRegisterR
 
 	// Build the register request
 	revJob := jobV.Copy()
+	// Use Vault Token from revert request to perform registration of reverted job.
 	revJob.VaultToken = args.VaultToken
 	reg := &structs.JobRegisterRequest{
 		Job:          revJob,

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1114,6 +1114,8 @@ func TestJobEndpoint_Revert_Vault_NoToken(t *testing.T) {
 	}
 }
 
+// TestJobEndpoint_Revert_Vault_Policies asserts that job revert uses the
+// revert request's Vault token when authorizing policies.
 func TestJobEndpoint_Revert_Vault_Policies(t *testing.T) {
 	t.Parallel()
 	s1 := TestServer(t, func(c *Config) {

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1017,6 +1017,215 @@ func TestJobEndpoint_Revert(t *testing.T) {
 	}
 }
 
+func TestJobEndpoint_Revert_Vault_NoToken(t *testing.T) {
+	t.Parallel()
+	s1 := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0 // Prevent automatic dequeue
+	})
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Enable vault
+	tr, f := true, false
+	s1.config.VaultConfig.Enabled = &tr
+	s1.config.VaultConfig.AllowUnauthenticated = &f
+
+	// Replace the Vault Client on the server
+	tvc := &TestVaultClient{}
+	s1.vault = tvc
+
+	// Add three tokens: one that allows the requesting policy, one that does
+	// not and one that returns an error
+	policy := "foo"
+
+	goodToken := uuid.Generate()
+	goodPolicies := []string{"foo", "bar", "baz"}
+	tvc.SetLookupTokenAllowedPolicies(goodToken, goodPolicies)
+
+	// Create the initial register request
+	job := mock.Job()
+	job.VaultToken = goodToken
+	job.Priority = 100
+	job.TaskGroups[0].Tasks[0].Vault = &structs.Vault{
+		Policies:   []string{policy},
+		ChangeMode: structs.VaultChangeModeRestart,
+	}
+	req := &structs.JobRegisterRequest{
+		Job: job,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	var resp structs.JobRegisterResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Reregister again to get another version
+	job2 := job.Copy()
+	job2.Priority = 1
+	req = &structs.JobRegisterRequest{
+		Job: job2,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	if err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	revertReq := &structs.JobRevertRequest{
+		JobID:      job.ID,
+		JobVersion: 1,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	err := msgpackrpc.CallWithCodec(codec, "Job.Revert", revertReq, &resp)
+	if err == nil || !strings.Contains(err.Error(), "current version") {
+		t.Fatalf("expected current version err: %v", err)
+	}
+
+	// Create revert request and enforcing it be at version 1
+	revertReq = &structs.JobRevertRequest{
+		JobID:               job.ID,
+		JobVersion:          0,
+		EnforcePriorVersion: helper.Uint64ToPtr(1),
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	err = msgpackrpc.CallWithCodec(codec, "Job.Revert", revertReq, &resp)
+	if err == nil || !strings.Contains(err.Error(), "missing Vault Token") {
+		t.Fatalf("expected Vault not enabled error: %v", err)
+	}
+}
+
+func TestJobEndpoint_Revert_Vault_Policies(t *testing.T) {
+	t.Parallel()
+	s1 := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0 // Prevent automatic dequeue
+	})
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Enable vault
+	tr, f := true, false
+	s1.config.VaultConfig.Enabled = &tr
+	s1.config.VaultConfig.AllowUnauthenticated = &f
+
+	// Replace the Vault Client on the server
+	tvc := &TestVaultClient{}
+	s1.vault = tvc
+
+	// Add three tokens: one that allows the requesting policy, one that does
+	// not and one that returns an error
+	policy := "foo"
+
+	badToken := uuid.Generate()
+	badPolicies := []string{"a", "b", "c"}
+	tvc.SetLookupTokenAllowedPolicies(badToken, badPolicies)
+
+	registerGoodToken := uuid.Generate()
+	goodPolicies := []string{"foo", "bar", "baz"}
+	tvc.SetLookupTokenAllowedPolicies(registerGoodToken, goodPolicies)
+
+	revertGoodToken := uuid.Generate()
+	revertGoodPolicies := []string{"foo", "bar_revert", "baz_revert"}
+	tvc.SetLookupTokenAllowedPolicies(revertGoodToken, revertGoodPolicies)
+
+	rootToken := uuid.Generate()
+	rootPolicies := []string{"root"}
+	tvc.SetLookupTokenAllowedPolicies(rootToken, rootPolicies)
+
+	errToken := uuid.Generate()
+	expectedErr := fmt.Errorf("return errors from vault")
+	tvc.SetLookupTokenError(errToken, expectedErr)
+
+	// Create the initial register request
+	job := mock.Job()
+	job.VaultToken = registerGoodToken
+	job.Priority = 100
+	job.TaskGroups[0].Tasks[0].Vault = &structs.Vault{
+		Policies:   []string{policy},
+		ChangeMode: structs.VaultChangeModeRestart,
+	}
+	req := &structs.JobRegisterRequest{
+		Job: job,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	var resp structs.JobRegisterResponse
+	if err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Reregister again to get another version
+	job2 := job.Copy()
+	job2.Priority = 1
+	req = &structs.JobRegisterRequest{
+		Job: job2,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	if err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Create the revert request with the bad Vault token
+	revertReq := &structs.JobRevertRequest{
+		JobID:      job.ID,
+		JobVersion: 0,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+		VaultToken: badToken,
+	}
+
+	// Fetch the response
+	err := msgpackrpc.CallWithCodec(codec, "Job.Revert", revertReq, &resp)
+	if err == nil || !strings.Contains(err.Error(),
+		"doesn't allow access to the following policies: "+policy) {
+		t.Fatalf("expected permission denied error: %v", err)
+	}
+
+	// Use the err token
+	revertReq.VaultToken = errToken
+	err = msgpackrpc.CallWithCodec(codec, "Job.Revert", revertReq, &resp)
+	if err == nil || !strings.Contains(err.Error(), expectedErr.Error()) {
+		t.Fatalf("expected permission denied error: %v", err)
+	}
+
+	// Use a good token
+	revertReq.VaultToken = revertGoodToken
+	if err := msgpackrpc.CallWithCodec(codec, "Job.Revert", revertReq, &resp); err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+}
+
 func TestJobEndpoint_Revert_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -1030,7 +1239,7 @@ func TestJobEndpoint_Revert_ACL(t *testing.T) {
 	state := s1.fsm.State()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	// Create the job
+	// Create the jobs
 	job := mock.Job()
 	err := state.UpsertJob(300, job)
 	require.Nil(err)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -560,6 +560,12 @@ type JobRevertRequest struct {
 	// version before reverting.
 	EnforcePriorVersion *uint64
 
+	// VaultToken is the Vault token that proves the submitter of the job revert
+	// has access to any Vault policies specified in the targeted job version. This
+	// field is only used to transfer the token and is not stored after the Job
+	// revert.
+	VaultToken string
+
 	WriteRequest
 }
 

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -1295,6 +1295,9 @@ The table below shows this endpoint's support for
   job's version. This is checked and acts as a check-and-set value before
   reverting to the specified job.
 
+- `VaultToken` `(string: "")` - Optional value specifying the [vault token](/docs/commands/job/revert.html)
+  used for Vault [policy authentication checking](/docs/configuration/vault.html#allow_unauthenticated).
+
 ### Sample Payload
 
 ```json

--- a/website/source/docs/commands/job/revert.html.md.erb
+++ b/website/source/docs/commands/job/revert.html.md.erb
@@ -12,6 +12,14 @@ The `job revert` command is used to revert a job to a prior version of the
 job. The available versions to revert to can be found using [`job
 history`](/docs/commands/job/history.html) command.
 
+The revert command will use a vault token with the following preference:
+first the `-vault-token` flag, then the `$VAULT_TOKEN` environment variable.
+Because the vault token used to [run](/docs/commands/job/run.html) the targeted
+job version was not persisted, it must be provided to revert if the targeted
+job version includes Vault policies and the Nomad servers were
+[configured](/docs/configuration/vault.html#allow_unauthenticated)
+to require authentication.
+
 ## Usage
 
 ```
@@ -30,6 +38,10 @@ to revert to.
 * `-detach`: Return immediately instead of monitoring. A new evaluation ID
   will be output, which can be used to examine the evaluation using the
   [eval status](/docs/commands/eval-status.html) command
+
+* `-vault-token`: If set, the passed Vault token is sent along with the revert request
+  to the Nomad servers. This overrides the token found in the $VAULT_TOKEN environment
+  variable.
 
 * `-verbose`: Show full information.
 

--- a/website/source/docs/commands/job/revert.html.md.erb
+++ b/website/source/docs/commands/job/revert.html.md.erb
@@ -12,7 +12,7 @@ The `job revert` command is used to revert a job to a prior version of the
 job. The available versions to revert to can be found using [`job
 history`](/docs/commands/job/history.html) command.
 
-The revert command will use a vault token with the following preference:
+The revert command will use a Vault token with the following preference:
 first the `-vault-token` flag, then the `$VAULT_TOKEN` environment variable.
 Because the vault token used to [run](/docs/commands/job/run.html) the targeted
 job version was not persisted, it must be provided to revert if the targeted

--- a/website/source/docs/commands/job/run.html.md.erb
+++ b/website/source/docs/commands/job/run.html.md.erb
@@ -68,7 +68,7 @@ precedence, going from highest to lowest: the `-vault-token` flag, the
 
 * `-vault-token`: If set, the passed Vault token is stored in the job before
   sending to the Nomad servers. This allows passing the Vault token without
-  storing it in the job file. This overrides the token found in $VAULT_TOKEN
+  storing it in the job file. This overrides the token found in the $VAULT_TOKEN
   environment variable and that found in the job.
 
 * `-verbose`: Show full information.


### PR DESCRIPTION
Consider `-vault-token` or `VAULT_TOKEN` on `nomad job revert ...`. Resolves #4555 

This was straightforward, plumbing all the way from the CLI through the HTTP API and to the RPC endpoints. The vault token is passed through the HTTP API in the JobRevertRequest body, instead of a header as originally discussed, because there wasn't a general way to get it in as a header without replumbing a lot of the (generic) http request work.