### PR TITLE
executor: use file descriptor for process stdout/stderr

### DIFF
--- a/drivers/shared/procio/buffer.go
+++ b/drivers/shared/procio/buffer.go
@@ -1,0 +1,41 @@
+package procio
+
+import (
+	"bytes"
+	"io"
+)
+
+type bufferCloser struct {
+	bytes.Buffer
+}
+
+func (_ *bufferCloser) Close() error { return nil }
+
+type BufferIO struct {
+	out *bufferCloser
+	err *bufferCloser
+}
+
+func NewBufferIO() IO {
+	return &BufferIO{out: &bufferCloser{}, err: &bufferCloser{}}
+}
+
+func (b *BufferIO) Close() error {
+	return nil
+}
+
+func (b *BufferIO) Stdout() io.ReadCloser {
+	return b.out
+}
+
+func (b *BufferIO) Stderr() io.ReadCloser {
+	return b.err
+}
+
+func (b *BufferIO) Set(f SetWritersCB) {
+	f(b.out, b.err)
+}
+
+func (b *BufferIO) Buffers() (out *bytes.Buffer, err *bytes.Buffer) {
+	return &b.out.Buffer, &b.err.Buffer
+}

--- a/drivers/shared/procio/io.go
+++ b/drivers/shared/procio/io.go
@@ -1,0 +1,165 @@
+package procio
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/hashicorp/nomad/client/lib/fifo"
+)
+
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		buffer := make([]byte, 32<<10)
+		return &buffer
+	},
+}
+
+type SetWritersCB func(out, err io.WriteCloser)
+
+// IO is an interface around process IO. Currently this includes stdout and
+// stderr.
+type IO interface {
+	io.Closer
+	Stdout() io.ReadCloser
+	Stderr() io.ReadCloser
+	Set(SetWritersCB)
+}
+
+type IOType string
+
+const (
+	IOTypeEmpty  IOType = ""
+	IOTypeFIFO   IOType = "fifo"
+	IOTypeBuffer IOType = "buffer"
+)
+
+// Stdio is the configuration for where to write standard process output to
+type Stdio struct {
+	IOType IOType
+	Stdout string
+	Stderr string
+}
+
+// IsNull returns true if the stdio is not defined
+func (s Stdio) IsNull() bool {
+	return s.IOType == "" && s.Stdout == "" && s.Stderr == ""
+}
+
+// ProcessIO wraps an IO interface and and sends output to the configured
+// destination
+type ProcessIO struct {
+	io IO
+
+	copyLoop bool
+	stdio    Stdio
+}
+
+func NewProcessIO(stdio Stdio, cb SetWritersCB) (pio *ProcessIO, err error) {
+	pio = &ProcessIO{
+		stdio:    stdio,
+		copyLoop: true,
+	}
+
+	if stdio.IsNull() {
+		i, err := NewNullIO()
+		if err != nil {
+			return nil, err
+		}
+		pio.io = i
+		return pio, nil
+	}
+
+	switch stdio.IOType {
+
+	case IOTypeFIFO, IOTypeEmpty:
+		pio.io, err = NewPipeIO()
+		if err != nil {
+			return nil, err
+		}
+	case IOTypeBuffer:
+		pio.io = NewBufferIO()
+		pio.copyLoop = false
+	}
+	pio.io.Set(cb)
+
+	return pio, nil
+}
+
+func (p *ProcessIO) Close() error {
+	if p.io != nil {
+		return p.io.Close()
+	}
+	return nil
+}
+
+func (p *ProcessIO) IO() IO {
+	return p.io
+}
+
+func (p *ProcessIO) Copy(wg *sync.WaitGroup) error {
+	if !p.copyLoop {
+		return nil
+	}
+
+	if err := copyLoop(p.stdio.Stdout, p.io.Stdout(), wg); err != nil {
+		return fmt.Errorf("failed to start copy loop for process stdout: %v", err)
+	}
+
+	if err := copyLoop(p.stdio.Stderr, p.io.Stderr(), wg); err != nil {
+		return fmt.Errorf("failed to start copy loop for process stderr: %v", err)
+	}
+
+	return nil
+}
+
+func copyLoop(path string, r io.ReadCloser, wg *sync.WaitGroup) error {
+	fw, err := fifo.Open(path)
+	if err != nil {
+		return err
+	}
+
+	wg.Add(1)
+	go func() {
+		p := bufPool.Get().(*[]byte)
+		defer bufPool.Put(p)
+		io.CopyBuffer(fw, r, *p)
+		wg.Done()
+		fw.Close()
+	}()
+
+	return nil
+}
+
+// NewNullIO returns IO setup for /dev/null use
+func NewNullIO() (IO, error) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		return nil, err
+	}
+	return &nullIO{
+		devNull: f,
+	}, nil
+}
+
+type nullIO struct {
+	devNull *os.File
+}
+
+func (n *nullIO) Close() error {
+	n.devNull.Close()
+	return nil
+}
+
+func (n *nullIO) Stdout() io.ReadCloser {
+	return nil
+}
+
+func (n *nullIO) Stderr() io.ReadCloser {
+	return nil
+}
+
+func (n *nullIO) Set(f SetWritersCB) {
+	f(n.devNull, n.devNull)
+}

--- a/drivers/shared/procio/pipe.go
+++ b/drivers/shared/procio/pipe.go
@@ -1,0 +1,97 @@
+package procio
+
+import (
+	"io"
+	"os"
+)
+
+func newPipe() (*pipe, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	return &pipe{
+		r: r,
+		w: w,
+	}, nil
+}
+
+type pipe struct {
+	r *os.File
+	w *os.File
+}
+
+func (p *pipe) Close() error {
+	err := p.w.Close()
+	if rerr := p.r.Close(); err == nil {
+		err = rerr
+	}
+	return err
+}
+
+type pipeIO struct {
+	out *pipe
+	err *pipe
+}
+
+func NewPipeIO() (i IO, err error) {
+
+	var (
+		pipes          []*pipe
+		stdout, stderr *pipe
+	)
+
+	// cleanup in case of an error
+	defer func() {
+		if err != nil {
+			for _, p := range pipes {
+				p.Close()
+			}
+		}
+	}()
+
+	// setup stdout pipe and fifo
+	if stdout, err = newPipe(); err != nil {
+		return nil, err
+	}
+	pipes = append(pipes, stdout)
+
+	// setup stderr pipe and fifo
+	if stderr, err = newPipe(); err != nil {
+		return nil, err
+	}
+	pipes = append(pipes, stderr)
+
+	return &pipeIO{
+		out: stdout,
+		err: stderr,
+	}, nil
+}
+
+func (i *pipeIO) Close() error {
+	var err error
+	for _, p := range []*pipe{
+		i.out,
+		i.err,
+	} {
+		if p != nil {
+			// capture first close error if occurs
+			if closeErr := p.Close(); err == nil {
+				err = closeErr
+			}
+		}
+	}
+	return err
+}
+
+func (i *pipeIO) Stdout() io.ReadCloser {
+	return i.out.r
+}
+
+func (i *pipeIO) Stderr() io.ReadCloser {
+	return i.err.r
+}
+
+func (i *pipeIO) Set(f SetWritersCB) {
+	f(i.out.w, i.err.w)
+}

--- a/drivers/shared/procio/pipe_unix.go
+++ b/drivers/shared/procio/pipe_unix.go
@@ -1,0 +1,3 @@
+// +build !windows
+
+package procio


### PR DESCRIPTION
This PR introduced a new package `procio` which handles process io. In order to fix #5472 a file descriptor should be given to the command instead of an `io.Writer` interface. This way `Command.Wait` will return when the parent process dies instead of waiting for all children to terminate. 

