### PR TITLE
docker: restore pre-0.9 container names

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -925,7 +925,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 
 	config.Env = task.EnvList()
 
-	containerName := strings.Replace(task.ID, "/", "_", -1)
+	containerName := fmt.Sprintf("%s-%s", strings.Replace(task.Name, "/", "_", -1), task.AllocID)
 	logger.Debug("setting container name", "container_name", containerName)
 
 	var networkingConfig *docker.NetworkingConfig

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -79,6 +79,7 @@ func dockerTask(t *testing.T) (*drivers.TaskConfig, *TaskConfig, []int) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "redis-demo",
+		AllocID:   uuid.Generate(),
 		DeviceEnv: make(map[string]string),
 		Resources: &drivers.Resources{
 			NomadResources: &structs.AllocatedTaskResources{
@@ -326,6 +327,7 @@ func TestDockerDriver_Start_Wait(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "nc-demo",
+		AllocID:   uuid.Generate(),
 		Resources: basicResources,
 	}
 	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
@@ -361,6 +363,7 @@ func TestDockerDriver_Start_WaitFinish(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "nc-demo",
+		AllocID:   uuid.Generate(),
 		Resources: basicResources,
 	}
 	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
@@ -403,6 +406,7 @@ func TestDockerDriver_Start_StoppedContainer(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "nc-demo",
+		AllocID:   uuid.Generate(),
 		Resources: basicResources,
 	}
 	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
@@ -462,6 +466,7 @@ func TestDockerDriver_Start_LoadImage(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "busybox-demo",
+		AllocID:   uuid.Generate(),
 		Resources: basicResources,
 	}
 	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
@@ -517,6 +522,7 @@ func TestDockerDriver_Start_BadPull_Recoverable(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "busybox-demo",
+		AllocID:   uuid.Generate(),
 		Resources: basicResources,
 	}
 	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
@@ -560,6 +566,7 @@ func TestDockerDriver_Start_Wait_AllocDir(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "busybox-demo",
+		AllocID:   uuid.Generate(),
 		Resources: basicResources,
 	}
 	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
@@ -609,6 +616,7 @@ func TestDockerDriver_Start_Kill_Wait(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "busybox-demo",
+		AllocID:   uuid.Generate(),
 		Resources: basicResources,
 	}
 	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
@@ -661,6 +669,7 @@ func TestDockerDriver_Start_KillTimeout(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "busybox-demo",
+		AllocID:   uuid.Generate(),
 		Resources: basicResources,
 	}
 	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
@@ -928,6 +937,10 @@ func TestDockerDriver_CreateContainerConfig(t *testing.T) {
 
 	require.Equal(t, "org/repo:0.1", c.Config.Image)
 	require.EqualValues(t, opt, c.HostConfig.StorageOpt)
+
+	// Container name should be /<task_name>-<alloc_id> for backward compat
+	containerName := fmt.Sprintf("%s-%s", strings.Replace(task.Name, "/", "_", -1), task.AllocID)
+	require.Equal(t, containerName, c.Name)
 }
 
 func TestDockerDriver_CreateContainerConfig_Logging(t *testing.T) {
@@ -1422,6 +1435,7 @@ func setupDockerVolumes(t *testing.T, cfg map[string]interface{}, hostpath strin
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "ls",
+		AllocID:   uuid.Generate(),
 		Env:       map[string]string{"VOL_PATH": containerPath},
 		Resources: basicResources,
 	}
@@ -1732,6 +1746,7 @@ func TestDockerDriver_OOMKilled(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),
 		Name:      "oom-killed",
+		AllocID:   uuid.Generate(),
 		Resources: basicResources,
 	}
 	task.Resources.LinuxResources.MemoryLimitBytes = 10 * 1024 * 1024


### PR DESCRIPTION
As far as I can tell Nomad itself does not use the container name after
container creation, so this should be safe.

OP: https://groups.google.com/d/topic/nomad-tool/kYkyERfVRXE/discussion
v0.8.7 code: https://github.com/hashicorp/nomad/blob/v0.8.7/client/driver/docker.go#L1530-L1531