### PR TITLE
Add output copy timeout for cmd.Wait()

### DIFF
--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -614,8 +614,31 @@ func cmdWait(c *exec.Cmd) (*os.ProcessState, error) {
 		return state, err
 	}
 
+	// wait for output to be copied with a grace period
+	waitOnCmdOutput(c, 5*time.Second)
+
 	if !state.Success() {
 		return state, &exec.ExitError{ProcessState: state}
 	}
 	return state, nil
+}
+
+func waitOnCmdOutput(c *exec.Cmd, timeout time.Duration) error {
+	_, isStdoutFile := c.Stdout.(*os.File)
+	_, isStderrFile := c.Stderr.(*os.File)
+	if isStdoutFile && isStderrFile {
+		return nil
+	}
+
+	ch := make(chan error)
+	go func() {
+		ch <- c.Wait()
+	}()
+
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("cmd timedout while copying output")
+	}
 }

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -624,12 +624,6 @@ func cmdWait(c *exec.Cmd) (*os.ProcessState, error) {
 }
 
 func waitOnCmdOutput(c *exec.Cmd, timeout time.Duration) error {
-	_, isStdoutFile := c.Stdout.(*os.File)
-	_, isStderrFile := c.Stderr.(*os.File)
-	if isStdoutFile && isStderrFile {
-		return nil
-	}
-
 	ch := make(chan error)
 	go func() {
 		ch <- c.Wait()

--- a/vendor/github.com/opencontainers/runc/libcontainer/process_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/process_linux.go
@@ -589,12 +589,6 @@ func cmdWait(c *exec.Cmd) (*os.ProcessState, error) {
 }
 
 func waitOnCmdOutput(c *exec.Cmd, timeout time.Duration) error {
-	_, isStdoutFile := c.Stdout.(*os.File)
-	_, isStderrFile := c.Stderr.(*os.File)
-	if isStdoutFile && isStderrFile {
-		return nil
-	}
-
 	ch := make(chan error)
 	go func() {
 		ch <- c.Wait()


### PR DESCRIPTION
Alternative hacky competing implementation to #5483 to fix #5472.

The ultimate issue is that `cmd.Wait()` blocks indefinitely until `Std{out|err}`are closed, which happens when all children are killed not just the executor init process.

Here, we use `cmd.Wait()` alternative implementation that blocks until process dies and then waits for some seconds to clean output.

This is meant as a draft PR illustrating the approach for dicsussion; before merging, we'll have the following:
* [ ] clean up function names and document the need for them
* [ ] update libcontainer fork and vendor, rather than modify the vendored files in place.