### PR TITLE
UI: Reattach resources to stats trackers in the event they were destroyed

### DIFF
--- a/ui/app/services/stats-trackers-registry.js
+++ b/ui/app/services/stats-trackers-registry.js
@@ -11,6 +11,9 @@ import AllocationStatsTracker from 'nomad-ui/utils/classes/allocation-stats-trac
 const MAX_STAT_TRACKERS = 10;
 let registry;
 
+const exists = (tracker, prop) =>
+  tracker.get(prop) && !tracker.get(prop).isDestroyed && !tracker.get(prop).isDestroying;
+
 export default Service.extend({
   token: service(),
 
@@ -30,12 +33,16 @@ export default Service.extend({
 
     const type = resource && resource.constructor.modelName;
     const key = `${type}:${resource.get('id')}`;
-
-    const cachedTracker = registry.get(key);
-    if (cachedTracker) return cachedTracker;
-
     const Constructor = type === 'node' ? NodeStatsTracker : AllocationStatsTracker;
     const resourceProp = type === 'node' ? 'node' : 'allocation';
+
+    const cachedTracker = registry.get(key);
+    if (cachedTracker) {
+      // It's possible for the resource on a cachedTracker to have been
+      // deleted. Rebind it if that's the case.
+      if (!exists(cachedTracker, resourceProp)) cachedTracker.set(resourceProp, resource);
+      return cachedTracker;
+    }
 
     const tracker = Constructor.create({
       fetch: url => this.get('token').authorizedRequest(url),


### PR DESCRIPTION
When a stats tracker gets created, it gets assigned a node or allocation to poll stats for. Then it is cached so the data can be retrieved later.

It's currently possible that the resource attached to a stats tracker is unloaded/destroyed, resulting in a half-working state. In this state, stats fetching still works, since the allocation/node ID remains the same, but the resource reservation amount (denominator) will be undefined, resulting in 0% utilization.

To prevent this from happening, whenever a stats tracker is looked up (which is always done by resource object) the resource used in the lookup may be reattached to the tracker object.