### PR TITLE
acl: Add alloc-lifecycle namespace capability

### DIFF
--- a/acl/policy.go
+++ b/acl/policy.go
@@ -28,6 +28,7 @@ const (
 	NamespaceCapabilityDispatchJob      = "dispatch-job"
 	NamespaceCapabilityReadLogs         = "read-logs"
 	NamespaceCapabilityReadFS           = "read-fs"
+	NamespaceCapabilityAllocLifecycle   = "alloc-lifecycle"
 	NamespaceCapabilitySentinelOverride = "sentinel-override"
 )
 
@@ -93,7 +94,7 @@ func isNamespaceCapabilityValid(cap string) bool {
 	switch cap {
 	case NamespaceCapabilityDeny, NamespaceCapabilityListJobs, NamespaceCapabilityReadJob,
 		NamespaceCapabilitySubmitJob, NamespaceCapabilityDispatchJob, NamespaceCapabilityReadLogs,
-		NamespaceCapabilityReadFS:
+		NamespaceCapabilityReadFS, NamespaceCapabilityAllocLifecycle:
 		return true
 	// Separate the enterprise-only capabilities
 	case NamespaceCapabilitySentinelOverride:
@@ -122,6 +123,7 @@ func expandNamespacePolicy(policy string) []string {
 			NamespaceCapabilityDispatchJob,
 			NamespaceCapabilityReadLogs,
 			NamespaceCapabilityReadFS,
+			NamespaceCapabilityAllocLifecycle,
 		}
 	default:
 		return nil

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -80,6 +80,7 @@ func TestParse(t *testing.T) {
 							NamespaceCapabilityDispatchJob,
 							NamespaceCapabilityReadLogs,
 							NamespaceCapabilityReadFS,
+							NamespaceCapabilityAllocLifecycle,
 						},
 					},
 					{


### PR DESCRIPTION
This capability will gate access to features that allow interacting with an allocations running state, for example, signalling, stopping, and rescheduling specific allocations.

It is added to the `write` coarse grained policy for a Namespace.