### PR TITLE
executor/linux: make chroot binary paths absolute

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1054,6 +1054,85 @@ func TestTaskRunner_DeriveToken_Unrecoverable(t *testing.T) {
 	require.True(t, state.Events[2].FailsTask)
 }
 
+// TestTaskRunner_Download_ChrootExec asserts that downloaded artifacts may be
+// executed in a chroot.
+func TestTaskRunner_Download_ChrootExec(t *testing.T) {
+	t.Parallel()
+	ctestutil.ExecCompatible(t)
+
+	ts := httptest.NewServer(http.FileServer(http.Dir(filepath.Dir("."))))
+	defer ts.Close()
+
+	// Create a task that downloads a script and executes it.
+	alloc := mock.BatchAlloc()
+	alloc.Job.TaskGroups[0].RestartPolicy = &structs.RestartPolicy{}
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "exec"
+	task.Config = map[string]interface{}{
+		"command": "noop.sh",
+	}
+	task.Artifacts = []*structs.TaskArtifact{
+		{
+			GetterSource: fmt.Sprintf("%s/testdata/noop.sh", ts.URL),
+			GetterMode:   "file",
+			RelativeDest: "noop.sh",
+		},
+	}
+
+	tr, _, cleanup := runTestTaskRunner(t, alloc, task.Name)
+	defer cleanup()
+
+	// Wait for task to run and exit
+	select {
+	case <-tr.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		require.Fail(t, "timed out waiting for task runner to exit")
+	}
+
+	state := tr.TaskState()
+	require.Equal(t, structs.TaskStateDead, state.State)
+	require.False(t, state.Failed)
+}
+
+// TestTaskRunner_Download_Exec asserts that downloaded artifacts may be
+// executed in a driver without filesystem isolation.
+func TestTaskRunner_Download_RawExec(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.FileServer(http.Dir(filepath.Dir("."))))
+	defer ts.Close()
+
+	// Create a task that downloads a script and executes it.
+	alloc := mock.BatchAlloc()
+	alloc.Job.TaskGroups[0].RestartPolicy = &structs.RestartPolicy{}
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "raw_exec"
+	task.Config = map[string]interface{}{
+		"command": "noop.sh",
+	}
+	task.Artifacts = []*structs.TaskArtifact{
+		{
+			GetterSource: fmt.Sprintf("%s/testdata/noop.sh", ts.URL),
+			GetterMode:   "file",
+			RelativeDest: "noop.sh",
+		},
+	}
+
+	tr, _, cleanup := runTestTaskRunner(t, alloc, task.Name)
+	defer cleanup()
+
+	// Wait for task to run and exit
+	select {
+	case <-tr.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		require.Fail(t, "timed out waiting for task runner to exit")
+	}
+
+	state := tr.TaskState()
+	require.Equal(t, structs.TaskStateDead, state.State)
+	require.False(t, state.Failed)
+}
+
 // TestTaskRunner_Download_List asserts that multiple artificats are downloaded
 // before a task is run.
 func TestTaskRunner_Download_List(t *testing.T) {

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1085,7 +1085,7 @@ func TestTaskRunner_Download_ChrootExec(t *testing.T) {
 	// Wait for task to run and exit
 	select {
 	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*30) * time.Second):
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
 		require.Fail(t, "timed out waiting for task runner to exit")
 	}
 

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1085,7 +1085,7 @@ func TestTaskRunner_Download_ChrootExec(t *testing.T) {
 	// Wait for task to run and exit
 	select {
 	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+	case <-time.After(time.Duration(testutil.TestMultiplier()*30) * time.Second):
 		require.Fail(t, "timed out waiting for task runner to exit")
 	}
 

--- a/client/allocrunner/taskrunner/testdata/noop.sh
+++ b/client/allocrunner/taskrunner/testdata/noop.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "ok"

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -163,7 +163,10 @@ func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, erro
 	}
 
 	// Turn relative-to-chroot path into absolute path to avoid
-	// libcontainer trying to resolve the binary using $PATH
+	// libcontainer trying to resolve the binary using $PATH.
+	// Do *not* use filepath.Join as it will translate ".."s returned by
+	// filepath.Rel. Prepending "/" will cause the path to be rooted in the
+	// chroot which is the desired behavior.
 	path = "/" + rel
 
 	combined := append([]string{path}, command.Args...)

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -162,15 +162,9 @@ func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, erro
 		return nil, fmt.Errorf("failed to determine relative path base=%q target=%q: %v", command.TaskDir, path, err)
 	}
 
-	// filepath.Rel will only return leading dots if the path escapes the
-	// TaskDir
-	if strings.HasPrefix(rel, "..") {
-		return nil, fmt.Errorf("command path %q escapes task dir %q", path, command.TaskDir)
-	}
-
 	// Turn relative-to-chroot path into absolute path to avoid
 	// libcontainer trying to resolve the binary using $PATH
-	path = filepath.Join("/", rel)
+	path = "/" + rel
 
 	combined := append([]string{path}, command.Args...)
 	stdout, err := command.Stdout()

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -162,9 +162,15 @@ func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, erro
 		return nil, fmt.Errorf("failed to determine relative path base=%q target=%q: %v", command.TaskDir, path, err)
 	}
 
+	// filepath.Rel will only return leading dots if the path escapes the
+	// TaskDir
+	if strings.HasPrefix(rel, "..") {
+		return nil, fmt.Errorf("command path %q escapes task dir %q", path, command.TaskDir)
+	}
+
 	// Turn relative-to-chroot path into absolute path to avoid
 	// libcontainer trying to resolve the binary using $PATH
-	path = "/" + rel
+	path = filepath.Join("/", rel)
 
 	combined := append([]string{path}, command.Args...)
 	stdout, err := command.Stdout()

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -161,7 +161,10 @@ func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine relative path base=%q target=%q: %v", command.TaskDir, path, err)
 	}
-	path = rel
+
+	// Turn relative-to-chroot path into absolute path to avoid
+	// libcontainer trying to resolve the binary using $PATH
+	path = "/" + rel
 
 	combined := append([]string{path}, command.Args...)
 	stdout, err := command.Stdout()


### PR DESCRIPTION
Avoid libcontainer.Process trying to lookup the binary via $PATH as the
executor has already found where the binary is located.