### PR TITLE
docker: fix send after close panic in stats

### DIFF
--- a/drivers/docker/stats.go
+++ b/drivers/docker/stats.go
@@ -25,7 +25,7 @@ const (
 )
 
 // usageSender wraps a TaskResourceUsage chan such that it supports concurrent
-// sending and closing.
+// sending and closing, and backpressures by dropping events if necessary.
 type usageSender struct {
 	closed bool
 	destCh chan<- *structs.TaskResourceUsage

--- a/drivers/docker/stats.go
+++ b/drivers/docker/stats.go
@@ -32,9 +32,9 @@ type usageSender struct {
 	mu     sync.Mutex
 }
 
-// newDestChPair returns a destCh that supports concurrent sending and closing,
-// and the receiver end of the chan.
-func newDestChPair() (*usageSender, <-chan *structs.TaskResourceUsage) {
+// newStatsChanPipe returns a chan wrapped in a struct that supports concurrent
+// sending and closing, and the receiver end of the chan.
+func newStatsChanPipe() (*usageSender, <-chan *structs.TaskResourceUsage) {
 	destCh := make(chan *cstructs.TaskResourceUsage, 1)
 	return &usageSender{
 		destCh: destCh,
@@ -82,7 +82,7 @@ func (h *taskHandle) Stats(ctx context.Context, interval time.Duration) (<-chan 
 	default:
 	}
 
-	destCh, recvCh := newDestChPair()
+	destCh, recvCh := newStatsChanPipe()
 	go h.collectStats(ctx, destCh, interval)
 	return recvCh, nil
 }

--- a/drivers/docker/stats_test.go
+++ b/drivers/docker/stats_test.go
@@ -17,7 +17,7 @@ func TestDriver_DockerStatsCollector(t *testing.T) {
 	require := require.New(t)
 	src := make(chan *docker.Stats)
 	defer close(src)
-	dst, recvCh := newDestChPair()
+	dst, recvCh := newStatsChanPipe()
 	defer dst.close()
 	stats := &docker.Stats{}
 	stats.CPUStats.ThrottlingData.Periods = 10
@@ -72,7 +72,7 @@ func TestDriver_DockerUsageSender(t *testing.T) {
 	// sample payload
 	res := &cstructs.TaskResourceUsage{}
 
-	destCh, recvCh := newDestChPair()
+	destCh, recvCh := newStatsChanPipe()
 
 	// Sending should never fail
 	destCh.send(res)

--- a/drivers/docker/stats_test.go
+++ b/drivers/docker/stats_test.go
@@ -2,20 +2,23 @@ package docker
 
 import (
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/hashicorp/nomad/plugins/drivers"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDriver_DockerStatsCollector(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	src := make(chan *docker.Stats)
 	defer close(src)
-	dst := make(chan *drivers.TaskResourceUsage)
-	defer close(dst)
+	dst, recvCh := newDestChPair()
+	defer dst.close()
 	stats := &docker.Stats{}
 	stats.CPUStats.ThrottlingData.Periods = 10
 	stats.CPUStats.ThrottlingData.ThrottledPeriods = 10
@@ -39,7 +42,7 @@ func TestDriver_DockerStatsCollector(t *testing.T) {
 	}
 
 	select {
-	case ru := <-dst:
+	case ru := <-recvCh:
 		if runtime.GOOS != "windows" {
 			require.Equal(stats.MemoryStats.Stats.Rss, ru.ResourceUsage.MemoryStats.RSS)
 			require.Equal(stats.MemoryStats.Stats.Cache, ru.ResourceUsage.MemoryStats.Cache)
@@ -59,4 +62,67 @@ func TestDriver_DockerStatsCollector(t *testing.T) {
 	case <-time.After(time.Second):
 		require.Fail("receiving stats should not block here")
 	}
+}
+
+// TestDriver_DockerUsageSender asserts that the TaskResourceUsage chan wrapper
+// supports closing and sending on a chan from concurrent goroutines.
+func TestDriver_DockerUsageSender(t *testing.T) {
+	t.Parallel()
+
+	// sample payload
+	res := &cstructs.TaskResourceUsage{}
+
+	destCh, recvCh := newDestChPair()
+
+	// Sending should never fail
+	destCh.send(res)
+	destCh.send(res)
+	destCh.send(res)
+
+	// Clear chan
+	<-recvCh
+
+	// Send and close concurrently to let the race detector help us out
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+
+	// Sender
+	go func() {
+		destCh.send(res)
+		wg.Done()
+	}()
+
+	// Closer
+	go func() {
+		destCh.close()
+		wg.Done()
+	}()
+
+	// Clear recv chan
+	go func() {
+		for range recvCh {
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	// Assert closed
+	destCh.mu.Lock()
+	closed := destCh.closed
+	destCh.mu.Unlock()
+	require.True(t, closed)
+
+	select {
+	case _, ok := <-recvCh:
+		require.False(t, ok)
+	default:
+		require.Fail(t, "expect recvCh to be closed")
+	}
+
+	// Assert sending and closing never fails
+	destCh.send(res)
+	destCh.close()
+	destCh.close()
+	destCh.send(res)
 }


### PR DESCRIPTION
destCh was being written to by one goroutine and closed by another
goroutine. This panic occurred in Travis:

```
=== FAIL: drivers/docker TestDockerCoordinator_ConcurrentPulls (117.66s)
=== PAUSE TestDockerCoordinator_ConcurrentPulls
=== CONT  TestDockerCoordinator_ConcurrentPulls

panic: send on closed channel

goroutine 5358 [running]:
github.com/hashicorp/nomad/drivers/docker.dockerStatsCollector(0xc0003a4a20, 0xc0003a49c0, 0x3b9aca00)
	/home/travis/gopath/src/github.com/hashicorp/nomad/drivers/docker/stats.go:108 +0x167

created by
github.com/hashicorp/nomad/drivers/docker.TestDriver_DockerStatsCollector
	/home/travis/gopath/src/github.com/hashicorp/nomad/drivers/docker/stats_test.go:33 +0x1ab
```

The 2 ways to fix this kind of error are to either (1) add extra
coordination around multiple goroutines writing to a chan or (2) make it
so only one goroutines writes to a chan.

I implemented (2) first as it's simpler, but @notnoop pointed out since
the same destCh is reused in the stats loop there's now a double close
panic possible!

So this implements (1) by adding a *usageSender struct for handling
concurrent senders and closing.