### PR TITLE
allocs: Add nomad alloc signal command

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"time"
+
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 var (
@@ -101,6 +103,23 @@ type AllocStopResponse struct {
 	EvalID string
 
 	WriteMeta
+}
+
+func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal string) error {
+	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
+	if err != nil {
+		return err
+	}
+
+	req := structs.AllocSignalRequest{
+		AllocID: alloc.ID,
+		Signal:  signal,
+		Task:    task,
+	}
+
+	var resp structs.GenericResponse
+	_, err = nodeClient.putQuery("/v1/client/allocation/"+alloc.ID+"/signal", &req, &resp, q)
+	return err
 }
 
 // Allocation is used for serialization of allocations.

--- a/client/alloc_endpoint.go
+++ b/client/alloc_endpoint.go
@@ -48,6 +48,19 @@ func (a *Allocations) GarbageCollect(args *nstructs.AllocSpecificRequest, reply 
 	return nil
 }
 
+func (a *Allocations) Signal(args *nstructs.AllocSignalRequest, reply *nstructs.GenericResponse) error {
+	defer metrics.MeasureSince([]string{"client", "allocations", "signal"}, time.Now())
+
+	// Check submit job permissions
+	if aclObj, err := a.c.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNsOp(args.Namespace, acl.NamespaceCapabilityAllocLifecycle) {
+		return nstructs.ErrPermissionDenied
+	}
+
+	return a.c.SignalAllocation(args.AllocID, args.Task, args.Signal)
+}
+
 // Restart is used to trigger a restart of an allocation or a subtask on a client.
 func (a *Allocations) Restart(args *nstructs.AllocRestartRequest, reply *nstructs.GenericResponse) error {
 	defer metrics.MeasureSince([]string{"client", "allocations", "restart"}, time.Now())

--- a/client/alloc_endpoint.go
+++ b/client/alloc_endpoint.go
@@ -48,10 +48,11 @@ func (a *Allocations) GarbageCollect(args *nstructs.AllocSpecificRequest, reply 
 	return nil
 }
 
+// Signal is used to send a signal to an allocation's tasks on a client.
 func (a *Allocations) Signal(args *nstructs.AllocSignalRequest, reply *nstructs.GenericResponse) error {
 	defer metrics.MeasureSince([]string{"client", "allocations", "signal"}, time.Now())
 
-	// Check submit job permissions
+	// Check alloc-lifecycle permissions
 	if aclObj, err := a.c.ResolveToken(args.AuthToken); err != nil {
 		return err
 	} else if aclObj != nil && !aclObj.AllowNsOp(args.Namespace, acl.NamespaceCapabilityAllocLifecycle) {

--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -356,14 +356,6 @@ func TestAllocations_Signal_ACL(t *testing.T) {
 	}
 }
 
-func TestAllocations_Signal_Subtask(t *testing.T) {
-	t.Parallel()
-}
-
-func TestAllocations_Signal_EntireAlloc(t *testing.T) {
-	t.Parallel()
-}
-
 func TestAllocations_Stats(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -272,6 +272,98 @@ func TestAllocations_GarbageCollect_ACL(t *testing.T) {
 	}
 }
 
+func TestAllocations_Signal(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := TestClient(t, nil)
+	defer cleanup()
+
+	a := mock.Alloc()
+	require.Nil(t, client.addAlloc(a, ""))
+
+	// Try with bad alloc
+	req := &nstructs.AllocSignalRequest{}
+	var resp nstructs.GenericResponse
+	err := client.ClientRPC("Allocations.Signal", &req, &resp)
+	require.NotNil(t, err)
+	require.True(t, nstructs.IsErrUnknownAllocation(err))
+
+	// Try with good alloc
+	req.AllocID = a.ID
+
+	var resp2 nstructs.GenericResponse
+	err = client.ClientRPC("Allocations.Signal", &req, &resp2)
+
+	require.Error(t, err, "Expected error, got: %s, resp: %#+v", err, resp2)
+	require.Equal(t, "1 error(s) occurred:\n\n* Failed to signal task: web, err: Task not running", err.Error())
+}
+
+func TestAllocations_Signal_ACL(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	server, addr, root := testACLServer(t, nil)
+	defer server.Shutdown()
+
+	client, cleanup := TestClient(t, func(c *config.Config) {
+		c.Servers = []string{addr}
+		c.ACLEnabled = true
+	})
+	defer cleanup()
+
+	// Try request without a token and expect failure
+	{
+		req := &nstructs.AllocSignalRequest{}
+		var resp nstructs.GenericResponse
+		err := client.ClientRPC("Allocations.Signal", &req, &resp)
+		require.NotNil(err)
+		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+	}
+
+	// Try request with an invalid token and expect failure
+	{
+		token := mock.CreatePolicyAndToken(t, server.State(), 1005, "invalid", mock.NodePolicy(acl.PolicyDeny))
+		req := &nstructs.AllocSignalRequest{}
+		req.AuthToken = token.SecretID
+
+		var resp nstructs.GenericResponse
+		err := client.ClientRPC("Allocations.Signal", &req, &resp)
+
+		require.NotNil(err)
+		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+	}
+
+	// Try request with a valid token
+	{
+		token := mock.CreatePolicyAndToken(t, server.State(), 1005, "test-valid",
+			mock.NamespacePolicy(nstructs.DefaultNamespace, "", []string{acl.NamespaceCapabilityAllocLifecycle}))
+		req := &nstructs.AllocSignalRequest{}
+		req.AuthToken = token.SecretID
+		req.Namespace = nstructs.DefaultNamespace
+
+		var resp nstructs.GenericResponse
+		err := client.ClientRPC("Allocations.Signal", &req, &resp)
+		require.True(nstructs.IsErrUnknownAllocation(err))
+	}
+
+	// Try request with a management token
+	{
+		req := &nstructs.AllocSignalRequest{}
+		req.AuthToken = root.SecretID
+
+		var resp nstructs.GenericResponse
+		err := client.ClientRPC("Allocations.Signal", &req, &resp)
+		require.True(nstructs.IsErrUnknownAllocation(err))
+	}
+}
+
+func TestAllocations_Signal_Subtask(t *testing.T) {
+	t.Parallel()
+}
+
+func TestAllocations_Signal_EntireAlloc(t *testing.T) {
+	t.Parallel()
+}
+
 func TestAllocations_Stats(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/client/client.go
+++ b/client/client.go
@@ -128,6 +128,7 @@ type AllocRunner interface {
 	WaitCh() <-chan struct{}
 	DestroyCh() <-chan struct{}
 	ShutdownCh() <-chan struct{}
+	Signal(taskName, signal string) error
 	GetTaskEventHandler(taskName string) drivermanager.EventHandler
 
 	RestartTask(taskName string, taskEvent *structs.TaskEvent) error
@@ -704,6 +705,18 @@ func (c *Client) Stats() map[string]map[string]string {
 		"runtime": hstats.RuntimeStats(),
 	}
 	return stats
+}
+
+// SignalAllocation sends a signal to the tasks within an allocation.
+// If the provided task is empty, then every allocation will be signalled.
+// If a task is provided, then only an exactly matching task will be signalled.
+func (c *Client) SignalAllocation(allocID, task, signal string) error {
+	ar, err := c.getAllocRunner(allocID)
+	if err != nil {
+		return err
+	}
+
+	return ar.Signal(task, signal)
 }
 
 // CollectAllocation garbage collects a single allocation on a node. Returns

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -138,6 +138,8 @@ func (s *HTTPServer) ClientAllocRequest(resp http.ResponseWriter, req *http.Requ
 		return s.allocRestart(allocID, resp, req)
 	case "gc":
 		return s.allocGC(allocID, resp, req)
+	case "signal":
+		return s.allocSignal(allocID, resp, req)
 	}
 
 	return nil, CodedError(404, resourceNotFoundErr)
@@ -253,6 +255,45 @@ func (s *HTTPServer) allocGC(allocID string, resp http.ResponseWriter, req *http
 	}
 
 	return nil, rpcErr
+}
+
+func (s *HTTPServer) allocSignal(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if !(req.Method == "POST" || req.Method == "PUT") {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	// Build the request and parse the ACL token
+	args := structs.AllocSignalRequest{}
+	err := decodeBody(req, &args)
+	if err != nil {
+		return nil, CodedError(400, fmt.Sprintf("Failed to decode body: %v", err))
+	}
+	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
+	args.AllocID = allocID
+
+	// Determine the handler to use
+	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForAlloc(allocID)
+
+	// Make the RPC
+	var reply structs.GenericResponse
+	var rpcErr error
+	if useLocalClient {
+		rpcErr = s.agent.Client().ClientRPC("Allocations.Signal", &args, &reply)
+	} else if useClientRPC {
+		rpcErr = s.agent.Client().RPC("ClientAllocations.Signal", &args, &reply)
+	} else if useServerRPC {
+		rpcErr = s.agent.Server().RPC("ClientAllocations.Signal", &args, &reply)
+	} else {
+		rpcErr = CodedError(400, "No local Node and node_id not provided")
+	}
+
+	if rpcErr != nil {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+			rpcErr = CodedError(404, rpcErr.Error())
+		}
+	}
+
+	return reply, rpcErr
 }
 
 func (s *HTTPServer) allocSnapshot(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -405,6 +405,7 @@ func TestHTTP_AllocStop(t *testing.T) {
 
 		require.NoError(state.UpsertAllocs(1000, []*structs.Allocation{alloc}))
 
+		// Test that the happy path works
 		{
 			// Make the HTTP request
 			req, err := http.NewRequest("POST", "/v1/allocation/"+alloc.ID+"/stop", nil)
@@ -420,6 +421,7 @@ func TestHTTP_AllocStop(t *testing.T) {
 			require.NotEmpty(a.Index, "missing index")
 		}
 
+		// Test that we 404 when the allocid is invalid
 		{
 			// Make the HTTP request
 			req, err := http.NewRequest("POST", "/v1/allocation/"+alloc.ID+"/stop", nil)

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -1,0 +1,122 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+)
+
+type AllocSignalCommand struct {
+	Meta
+}
+
+func (a *AllocSignalCommand) Help() string {
+	helpText := `
+Usage: nomad alloc signal [options] <signal> <allocation> <task>
+
+  signal an existing allocation. This command is used to signal a specific alloc
+  and its subtasks. If no task is provided then all of the allocations subtasks
+  will receive the signal.
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+Signal Specific Options:
+
+  -s
+    Specify the signal that the selected tasks should receive.
+
+  -verbose
+    Show full information.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *AllocSignalCommand) Name() string { return "alloc signal" }
+
+func (c *AllocSignalCommand) Run(args []string) int {
+	var verbose bool
+	var signal string
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&verbose, "verbose", false, "")
+	flags.StringVar(&signal, "s", "SIGKILL", "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we got exactly one alloc
+	args = flags.Args()
+	if len(args) < 1 || len(args) > 2 {
+		c.Ui.Error("This command takes up to two arguments: <alloc-id> <task>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	allocID := args[0]
+
+	// Truncate the id unless full length is requested
+	length := shortId
+	if verbose {
+		length = fullId
+	}
+
+	// Query the allocation info
+	if len(allocID) == 1 {
+		c.Ui.Error(fmt.Sprintf("Alloc ID must contain at least two characters."))
+		return 1
+	}
+
+	allocID = sanitizeUUIDPrefix(allocID)
+
+	var taskName string
+	if len(args) == 2 {
+		taskName = args[1]
+	}
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	allocs, _, err := client.Allocations().PrefixList(allocID)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying allocation: %v", err))
+		return 1
+	}
+
+	if len(allocs) == 0 {
+		c.Ui.Error(fmt.Sprintf("No allocation(s) with prefix or id %q found", allocID))
+		return 1
+	}
+
+	if len(allocs) > 1 {
+		// Format the allocs
+		out := formatAllocListStubs(allocs, verbose, length)
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple allocations\n\n%s", out))
+		return 1
+	}
+
+	// Prefix lookup matched a single allocation
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
+		return 1
+	}
+
+	err = client.Allocations().Signal(alloc, nil, taskName, signal)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error signalling allocation: %s", err))
+		return 1
+	}
+
+	return 0
+}
+
+func (a *AllocSignalCommand) Synopsis() string {
+	return "Signal a running allocation"
+}

--- a/command/alloc_signal_test.go
+++ b/command/alloc_signal_test.go
@@ -1,0 +1,50 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllocSignalCommand_Implements(t *testing.T) {
+	t.Parallel()
+	var _ cli.Command = &AllocSignalCommand{}
+}
+
+func TestAllocSignalCommand_Fails(t *testing.T) {
+	t.Parallel()
+	srv, _, url := testServer(t, false, nil)
+	defer srv.Shutdown()
+
+	require := require.New(t)
+
+	ui := new(cli.MockUi)
+	cmd := &AllocSignalCommand{Meta: Meta{Ui: ui}}
+
+	// Fails on lack of alloc ID
+	require.Equal(1, cmd.Run([]string{}))
+	require.Contains(ui.ErrorWriter.String(), "This command takes up to two arguments")
+	ui.ErrorWriter.Reset()
+
+	// Fails on misuse
+	require.Equal(1, cmd.Run([]string{"some", "bad", "args"}))
+	require.Contains(ui.ErrorWriter.String(), "This command takes up to two arguments")
+	ui.ErrorWriter.Reset()
+
+	// Fails on connection failure
+	require.Equal(1, cmd.Run([]string{"-address=nope", "foobar"}))
+	require.Contains(ui.ErrorWriter.String(), "Error querying allocation")
+	ui.ErrorWriter.Reset()
+
+	// Fails on missing alloc
+	code := cmd.Run([]string{"-address=" + url, "26470238-5CF2-438F-8772-DC67CFB0705C"})
+	require.Equal(1, code)
+	require.Contains(ui.ErrorWriter.String(), "No allocation(s) with prefix or id")
+	ui.ErrorWriter.Reset()
+
+	// Fail on identifier with too few characters
+	require.Equal(1, cmd.Run([]string{"-address=" + url, "2"}))
+	require.Contains(ui.ErrorWriter.String(), "must contain at least two characters.")
+	ui.ErrorWriter.Reset()
+}

--- a/command/commands.go
+++ b/command/commands.go
@@ -145,6 +145,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"alloc signal": func() (cli.Command, error) {
+			return &AllocSignalCommand{
+				Meta: meta,
+			}, nil
+		},
 		"alloc stop": func() (cli.Command, error) {
 			return &AllocStopCommand{
 				Meta: meta,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -741,6 +741,14 @@ type AllocSpecificRequest struct {
 	QueryOptions
 }
 
+// AllocSignalRequest is used to signal a specific allocation
+type AllocSignalRequest struct {
+	AllocID string
+	Task    string
+	Signal  string
+	QueryOptions
+}
+
 // AllocsGetRequest is used to query a set of allocations
 type AllocsGetRequest struct {
 	AllocIDs []string
@@ -6159,6 +6167,11 @@ func (e *TaskEvent) SetExitCode(c int) *TaskEvent {
 func (e *TaskEvent) SetSignal(s int) *TaskEvent {
 	e.Signal = s
 	e.Details["signal"] = fmt.Sprintf("%d", s)
+	return e
+}
+
+func (e *TaskEvent) SetSignalText(s string) *TaskEvent {
+	e.Details["signal"] = s
 	return e
 }
 


### PR DESCRIPTION
This command will be used to send a signal to either a single task within
an allocation, or all of the tasks if <task-name> is omitted. If the sent
signal terminates the allocation, it will be treated as if the allocation
has crashed, rather than as if it was operator-terminated.

Signal validation is currently handled by the driver itself and nomad does
not attempt to restrict or validate them. There is future work to ensure
compatibility of drivers and portability of signal names.