### PR TITLE
client: simplify kill logic

### DIFF
--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -77,14 +77,6 @@ func (tr *TaskRunner) Kill(ctx context.Context, event *structs.TaskEvent) error 
 	// Emit kill event
 	tr.EmitEvent(event)
 
-	// Check if the Run method has started yet. If it hasn't we return early,
-	// since the task hasn't even started so there is nothing to wait for. This
-	// is still correct since the Run method no-op since the kill context has
-	// already been cancelled.
-	if !tr.hasRunLaunched() {
-		return nil
-	}
-
 	select {
 	case <-tr.WaitCh():
 	case <-ctx.Done():

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -190,11 +190,6 @@ type TaskRunner struct {
 	// handlers
 	driverManager drivermanager.Manager
 
-	// runLaunched marks whether the Run goroutine has been started. It should
-	// be accessed via helpers
-	runLaunched     bool
-	runLaunchedLock sync.Mutex
-
 	// maxEvents is the capacity of the TaskEvents on the TaskState.
 	// Defaults to defaultMaxEvents but overrideable for testing.
 	maxEvents int
@@ -378,10 +373,6 @@ func (tr *TaskRunner) initLabels() {
 // Run the TaskRunner. Starts the user's task or reattaches to a restored task.
 // Run closes WaitCh when it exits. Should be started in a goroutine.
 func (tr *TaskRunner) Run() {
-	// Mark that the run routine has been launched so that other functions can
-	// decide to use the wait channel or not.
-	tr.setRunLaunched()
-
 	defer close(tr.waitCh)
 	var result *drivers.ExitResult
 

--- a/client/allocrunner/taskrunner/task_runner_getters.go
+++ b/client/allocrunner/taskrunner/task_runner_getters.go
@@ -101,20 +101,6 @@ func (tr *TaskRunner) getKillErr() error {
 	return tr.killErr
 }
 
-// setRunLaunched marks the fact that the Run loop has been started
-func (tr *TaskRunner) setRunLaunched() {
-	tr.runLaunchedLock.Lock()
-	defer tr.runLaunchedLock.Unlock()
-	tr.runLaunched = true
-}
-
-// hasRunLaunched returns whether the Run loop has been started
-func (tr *TaskRunner) hasRunLaunched() bool {
-	tr.runLaunchedLock.Lock()
-	defer tr.runLaunchedLock.Unlock()
-	return tr.runLaunched
-}
-
 // hookState returns the state for the given hook or nil if no state is
 // persisted for the hook.
 func (tr *TaskRunner) hookState(name string) *state.HookState {


### PR DESCRIPTION
Remove runLaunched tracking as Run is *always* called for killable
TaskRunners. TaskRunners which fail before Run can be called (during
NewTaskRunner or Restore) are not killable as they're never added to the
client's alloc map.