### PR TITLE
drivers/docker: fix image name handleing when prefixed with https://

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -231,6 +231,15 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("failed to decode driver config: %v", err)
 	}
 
+	if driverConfig.Image == "" {
+		return nil, nil, fmt.Errorf("image name required for docker driver")
+	}
+
+	// Remove any http
+	if strings.HasPrefix(driverConfig.Image, "https://") {
+		driverConfig.Image = strings.Replace(driverConfig.Image, "https://", "", 1)
+	}
+
 	handle := drivers.NewTaskHandle(taskHandleVersion)
 	handle.Config = cfg
 

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -506,6 +506,64 @@ func TestDockerDriver_Start_LoadImage(t *testing.T) {
 
 }
 
+// Tests that images prefixed with "https://" are supported
+func TestDockerDriver_Start_Image_HTTPS(t *testing.T) {
+	if !tu.IsCI() {
+		t.Parallel()
+	}
+	testutil.DockerCompatible(t)
+
+	taskCfg := TaskConfig{
+		Image: "https://gcr.io/google_containers/pause:0.8.0",
+	}
+	task := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "pause",
+		AllocID:   uuid.Generate(),
+		Resources: basicResources,
+	}
+	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
+
+	d := dockerDriverHarness(t, nil)
+	cleanup := d.MkAllocDir(task, true)
+	defer cleanup()
+
+	_, _, err := d.StartTask(task)
+	require.NoError(t, err)
+
+	d.DestroyTask(task.ID, true)
+}
+
+// Tests that starting a task without an image fails
+func TestDockerDriver_Start_NoImage(t *testing.T) {
+	if !tu.IsCI() {
+		t.Parallel()
+	}
+	testutil.DockerCompatible(t)
+
+	taskCfg := TaskConfig{
+		Command: "echo",
+		Args:    []string{"foo"},
+	}
+	task := &drivers.TaskConfig{
+		ID:        uuid.Generate(),
+		Name:      "echo",
+		AllocID:   uuid.Generate(),
+		Resources: basicResources,
+	}
+	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
+
+	d := dockerDriverHarness(t, nil)
+	cleanup := d.MkAllocDir(task, false)
+	defer cleanup()
+
+	_, _, err := d.StartTask(task)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "image name required")
+
+	d.DestroyTask(task.ID, true)
+}
+
 func TestDockerDriver_Start_BadPull_Recoverable(t *testing.T) {
 	if !tu.IsCI() {
 		t.Parallel()


### PR DESCRIPTION
In 0.8, `https://` was striped from the image name during config parsing. This logic was missed during the migration to driver plugins which resulted in images prefixed with `https://` to fail.

fixes #5517 