### PR TITLE
Provide ARMv6l binaries

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,7 +34,8 @@ endif
 
 ALL_TARGETS += linux_386 \
 	linux_amd64 \
-	linux_arm \
+	linux_armel \
+	linux_armhf \
 	linux_arm64 \
 	windows_386 \
 	windows_amd64
@@ -83,9 +84,17 @@ pkg/linux_amd64/nomad: $(SOURCE_FILES) ## Build Nomad for linux/amd64
 		-tags "$(GO_TAGS)" \
 		-o "$@"
 
-pkg/linux_arm/nomad: $(SOURCE_FILES) ## Build Nomad for linux/arm
+pkg/linux_armel/nomad: $(SOURCE_FILES) ## Build Nomad for linux/armel (Pi 1, Zero)
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
-	@CGO_ENABLED=1 GOOS=linux GOARCH=arm CC=arm-linux-gnueabihf-gcc-5 \
+	@CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=6 CC=arm-linux-gnueabi-gcc-5 \
+		go build \
+		-ldflags $(GO_LDFLAGS) \
+		-tags "$(GO_TAGS)" \
+		-o "$@"
+
+pkg/linux_armhf/nomad: $(SOURCE_FILES) ## Build Nomad for linux/armhf (Pi 2, 3)
+	@echo "==> Building $@ with tags $(GO_TAGS)..."
+	@CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc-5 \
 		go build \
 		-ldflags $(GO_LDFLAGS) \
 		-tags "$(GO_TAGS)" \

--- a/scripts/vagrant-linux-priv-config.sh
+++ b/scripts/vagrant-linux-priv-config.sh
@@ -37,9 +37,12 @@ apt-get install -y \
 # Install ARM build utilities
 apt-get install -y \
 	binutils-aarch64-linux-gnu \
+	binutils-arm-linux-gnueabi \
 	binutils-arm-linux-gnueabihf \
 	gcc-5-aarch64-linux-gnu \
+	gcc-5-arm-linux-gnueabi \
 	gcc-5-arm-linux-gnueabihf \
+	gcc-5-multilib-arm-linux-gnueabi \
 	gcc-5-multilib-arm-linux-gnueabihf
 
 # Install Windows build utilities


### PR DESCRIPTION
ARM is a quite popular for small computing clusters, and an interesting
pet project to try Nomad on.

Unfortunately, the current ARM builds don't run on Raspberry Pi's 1,
Zero or Zero W as it is compiled with some operations not available
there.

When executing the current binary, you receive this message:

```
Illegal instruction (core dumped)
```

The difference is caused by the version of the ARM instructions are
available on each version of the Pi.

| Version     | Compiler arch              |
|-------------+----------------------------|
| Pi v1, Zero | armel, floating point (v6) |
| Pi v2, v3   | armhf, floating point (v7) |

Fortunately, cross-compiling using Go is not so troublesome. It is possible to
produce an executable using the non-hf version of `gcc`.

This commit introduces a new `make` target for armel binaries. It renames the
previous one so it is clear the difference between artifacts versions.

A couple of extra compilation dependencies are needed on the build machine.

Tested `armel` o a Pi Zero W 1.3 and Pi 3, which executes, but there are not yet
any jobs running. The `armel` binary should work on all Raspberry Pi models,
while the `armhf` only works on Pi 2/3 and it is optimized.

Fixes #2517