### PR TITLE
ci: move docker unix-y test

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -506,34 +506,6 @@ func TestDockerDriver_Start_LoadImage(t *testing.T) {
 
 }
 
-// Tests that images prefixed with "https://" are supported
-func TestDockerDriver_Start_Image_HTTPS(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
-	testutil.DockerCompatible(t)
-
-	taskCfg := TaskConfig{
-		Image: "https://gcr.io/google_containers/pause:0.8.0",
-	}
-	task := &drivers.TaskConfig{
-		ID:        uuid.Generate(),
-		Name:      "pause",
-		AllocID:   uuid.Generate(),
-		Resources: basicResources,
-	}
-	require.NoError(t, task.EncodeConcreteDriverConfig(&taskCfg))
-
-	d := dockerDriverHarness(t, nil)
-	cleanup := d.MkAllocDir(task, true)
-	defer cleanup()
-
-	_, _, err := d.StartTask(task)
-	require.NoError(t, err)
-
-	d.DestroyTask(task.ID, true)
-}
-
 // Tests that starting a task without an image fails
 func TestDockerDriver_Start_NoImage(t *testing.T) {
 	if !tu.IsCI() {


### PR DESCRIPTION
Fix AppVeyor failing builds, by moving docker image url test to run on unix
systems only.  The used paused image is a linux image only, not
available on Windows.