### PR TITLE
Consul Catalog Integration Fixes

### DIFF
--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -513,7 +513,7 @@ func (c *ServiceClient) sync() error {
 		// Nomad managed checks if this is not a client agent.
 		// This is to prevent server agents from removing checks
 		// registered by client agents
-		if !isNomadService(check.ServiceID) || !c.isClientAgent {
+		if !isNomadService(check.ServiceID) || !c.isClientAgent || !isNomadCheck(check.CheckID) {
 			// Service not managed by Nomad, skip
 			continue
 		}
@@ -1180,6 +1180,12 @@ func createCheckReg(serviceID, checkID string, check *structs.ServiceCheck, host
 		return nil, fmt.Errorf("check type %+q not valid", check.Type)
 	}
 	return &chkReg, nil
+}
+
+// isNomadCheck returns true if the ID matches the pattern of a Nomad managed
+// check.
+func isNomadCheck(id string) bool {
+	return strings.HasPrefix(id, nomadCheckPrefix)
 }
 
 // isNomadService returns true if the ID matches the pattern of a Nomad managed

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -1116,6 +1116,8 @@ func makeTaskServiceID(allocID, taskName string, service *structs.Service, canar
 }
 
 // makeCheckID creates a unique ID for a check.
+//
+//  Example Check ID: _nomad-check-434ae42f9a57c5705344974ac38de2aee0ee089d
 func makeCheckID(serviceID string, check *structs.ServiceCheck) string {
 	return fmt.Sprintf("%s%s", nomadCheckPrefix, check.Hash(serviceID))
 }


### PR DESCRIPTION
fixes #4566 
fixes #4537

The current implementation of Service Registration uses a hash of the nomad-internal state of a service to register it with Consul, this means that any update to the service invalidates this name and we then de-register, and recreate the service in Consul.

While this behavior slightly simplifies reasoning about service registration, this becomes problematic when we add consul health checks to a service. When the service is re-registered, so are the checks, which default to failing for at least one check period. This causes issues when a canary is promoted, as the old, stable allocs are immediately stopped, and the new ones updated, which causes a consul registration cycle and takes your service offline for one health check period.

This pull request introduces `v3` of the Nomad-Consul integration style that moves back to having a stable identifier for a service, and registers updates based on changes to the internal struct state and remote state.

## Notes

* There is currently a UX issue in Consul that means that when you update a Service's tags, its Checks will still return the ones they were registered against, however this does not effect the functionality of Consul or Nomad (https://github.com/hashicorp/consul/issues/5631).

* There is an outstanding Nomad bug where the consul reconciler races against task restoration on a host, which means when restarting or updating a client, services will be removed from consul and re-registered, causing a 1-health-check-period status flap. This PR does not attempt to solve that bug as it will require a larger refactor of the client startup flow to be reliable, thus this PR does not attempt to handle older registrations outside of removing them as expected.