### PR TITLE
Allow compiling without nvidia integration

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -18,7 +18,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/taskenv"
-	"github.com/hashicorp/nomad/devices/gpu/nvidia"
 	"github.com/hashicorp/nomad/drivers/docker/docklog"
 	"github.com/hashicorp/nomad/drivers/shared/eventer"
 	nstructs "github.com/hashicorp/nomad/nomad/structs"
@@ -56,6 +55,9 @@ var (
 	// taskHandleVersion is the version of task handle which this driver sets
 	// and understands how to decode driver state
 	taskHandleVersion = 1
+
+	// Nvidia-container-runtime environment variable names
+	nvidiaVisibleDevices = "NVIDIA_VISIBLE_DEVICES"
 )
 
 type Driver struct {
@@ -684,7 +686,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		PidsLimit: driverConfig.PidsLimit,
 	}
 
-	if _, ok := task.DeviceEnv[nvidia.NvidiaVisibleDevices]; ok {
+	if _, ok := task.DeviceEnv[nvidiaVisibleDevices]; ok {
 		if !d.gpuRuntime {
 			return c, fmt.Errorf("requested docker-runtime %q was not found", d.config.GPURuntimeName)
 		}

--- a/helper/pluginutils/catalog/register_nvidia_linux.go
+++ b/helper/pluginutils/catalog/register_nvidia_linux.go
@@ -1,12 +1,14 @@
+// +build !nonvidia
+
 package catalog
 
 import (
-	"github.com/hashicorp/nomad/drivers/rkt"
+	"github.com/hashicorp/nomad/devices/gpu/nvidia"
 )
 
 // This file is where all builtin plugins should be registered in the catalog.
 // Plugins with build restrictions should be placed in the appropriate
 // register_XXX.go file.
 func init() {
-	RegisterDeferredConfig(rkt.PluginID, rkt.PluginConfig, rkt.PluginLoader)
+	Register(nvidia.PluginID, nvidia.PluginConfig)
 }


### PR DESCRIPTION
nvidia library use of dynamic library seems to conflict with alpine and
musl based OSes.  This adds a `nonvidia` tag to allow compiling nomad
for alpine images.

The nomad releases currently only support glibc based OS environments,
so we default to compiling with nvidia.

Fixes #5535