### PR TITLE
client/metrics: fixed bad metrics 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2638,7 +2638,7 @@ func (c *Client) emitClientMetrics() {
 	// Emit allocation metrics
 	blocked, migrating, pending, running, terminal := 0, 0, 0, 0, 0
 	for _, ar := range c.getAllocRunners() {
-		switch ar.Alloc().ClientStatus {
+		switch ar.AllocState().ClientStatus {
 		case structs.AllocClientStatusPending:
 			switch {
 			case ar.IsWaiting():


### PR DESCRIPTION
resolves #5540: modified metrics calculation to use (updated) client copy of the allocation instead of (un-updated) server copy