### PR TITLE
add community section under task drivers and sync name with device plugins

### DIFF
--- a/website/source/docs/drivers/external/index.html.md
+++ b/website/source/docs/drivers/external/index.html.md
@@ -12,7 +12,7 @@ If you have authored a task driver plugin that you believe will be useful to the
 broader Nomad community and you are committed to maintaining the plugin, please
 file a PR to add your plugin to this page.
 
-## Authoring Task Driver Plugins
+## Task Driver Plugins
 
 Nomad has a plugin system for defining task drivers. External task driver
 plugins will have the same user experience as built in drivers. 

--- a/website/source/docs/drivers/external/index.html.md
+++ b/website/source/docs/drivers/external/index.html.md
@@ -1,19 +1,24 @@
 ---
 layout: "docs"
-page_title: "External Plugins"
-sidebar_current: "docs-external-plugins"
+page_title: "Task Driver Plugins: Community Supported"
+sidebar_current: "docs-drivers-community"
 description: |-
-  External plugins allow you easily extend Nomad's functionality and further
-  support customized workloads.
+  A list of community supported Task Driver Plugins.
 ---
 
-# External Plugins
+# Community Supported
 
-Starting with Nomad 0.9, task and device drivers are now pluggable. This gives users the flexibility to introduce their own drivers without having to recompile Nomad. You can view the [plugin stanza][plugin] documentation for examples on how to use the `plugin` stanza in Nomad's client configuration. 
+If you have authored a task driver plugin that you believe will be useful to the
+broader Nomad community and you are committed to maintaining the plugin, please
+file a PR to add your plugin to this page.
 
-Below is a list of external drivers you can use with Nomad:
+## Authoring Task Driver Plugins
+
+Nomad has a plugin system for defining task drivers. External task driver
+plugins will have the same user experience as built in drivers. 
+
+Below is a list of community-supported task drivers you can use with Nomad:
 
 - [LXC][lxc]
 
 [lxc]: /docs/drivers/external/lxc.html 
-[plugin]: /docs/configuration/plugin.html

--- a/website/source/docs/drivers/external/lxc.html.md
+++ b/website/source/docs/drivers/external/lxc.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Drivers: LXC"
-sidebar_current: "docs-external-plugins-lxc"
+sidebar_current: "docs-drivers-community-lxc"
 description: |-
   The LXC task driver is used to run application containers using LXC.
 ---

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -435,6 +435,15 @@
             <a href="/docs/drivers/rkt.html">Rkt</a>
           </li>
 
+          <li<%= sidebar_current("docs-drivers-community") %>>
+            <a href="/docs/drivers/external/index.html"">Community</a>
+            <ul class="nav">
+              <li<%= sidebar_current("docs-drivers-community-lxc") %>>
+                <a href="/docs/drivers/external/lxc.html">LXC</a>
+              </li>
+            </ul>
+          </li>
+
         </ul>
       </li>
 
@@ -446,7 +455,7 @@
           </li>
 
           <li<%= sidebar_current("docs-devices-community") %>>
-            <a href="/docs/devices/community.html">Community Supported</a>
+            <a href="/docs/devices/community.html">Community</a>
           </li>
         </ul>
       </li>
@@ -469,15 +478,6 @@
 
       <li<%= sidebar_current("docs-vault-integration") %>>
         <a href="/docs/vault-integration/index.html">Vault Integration</a>
-      </li>
-
-      <li<%= sidebar_current("docs-external-plugins") %>>
-        <a href="/docs/drivers/external/index.html">External Plugins</a>
-        <ul class="nav">
-          <li<%= sidebar_current("docs-external-plugins-lxc") %>>
-            <a href="/docs/drivers/external/lxc.html">LXC</a>
-          </li>
-        </ul>
       </li>
 
       <hr>


### PR DESCRIPTION
Removing **External Plugins** section from docs.

Adding **Community** bullet to **Task Drivers** section in docs

Changing **Community Supported** in the **Device Plugins** section to **Community**