### PR TITLE
vault namespaces: inject VAULT_NAMESPACE alongside VAULT_TOKEN

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_getters.go
+++ b/client/allocrunner/taskrunner/task_runner_getters.go
@@ -57,7 +57,7 @@ func (tr *TaskRunner) setVaultToken(token string) {
 	tr.vaultToken = token
 
 	// Update the task's environment
-	tr.envBuilder.SetVaultToken(token, tr.task.Vault.Env)
+	tr.envBuilder.SetVaultToken(token, tr.clientConfig.VaultConfig.Namespace, tr.task.Vault.Env)
 }
 
 // getDriverHandle returns a driver handle.

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -85,6 +85,9 @@ const (
 
 	// VaultToken is the environment variable for passing the Vault token
 	VaultToken = "VAULT_TOKEN"
+
+	// VaultNamespace is the environment variable for passing the Vault namespace, if applicable
+	VaultNamespace = "VAULT_NAMESPACE"
 )
 
 // The node values that can be interpreted.
@@ -305,6 +308,7 @@ type Builder struct {
 	allocName        string
 	groupName        string
 	vaultToken       string
+	vaultNamespace   string
 	injectVaultToken bool
 	jobName          string
 
@@ -421,6 +425,11 @@ func (b *Builder) Build() *TaskEnv {
 	// Build the Vault Token
 	if b.injectVaultToken && b.vaultToken != "" {
 		envMap[VaultToken] = b.vaultToken
+	}
+
+	// Build the Vault Namespace
+	if b.injectVaultToken && b.vaultNamespace != "" {
+		envMap[VaultNamespace] = b.vaultNamespace
 	}
 
 	// Copy task meta
@@ -753,9 +762,10 @@ func (b *Builder) SetTemplateEnv(m map[string]string) *Builder {
 	return b
 }
 
-func (b *Builder) SetVaultToken(token string, inject bool) *Builder {
+func (b *Builder) SetVaultToken(token, namespace string, inject bool) *Builder {
 	b.mu.Lock()
 	b.vaultToken = token
+	b.vaultNamespace = namespace
 	b.injectVaultToken = inject
 	b.mu.Unlock()
 	return b

--- a/website/source/docs/job-specification/vault.html.md
+++ b/website/source/docs/job-specification/vault.html.md
@@ -47,8 +47,10 @@ job "docs" {
 ```
 
 The Nomad client will make the Vault token available to the task by writing it
-to the secret directory at `secrets/vault_token` and by injecting a VAULT_TOKEN
-environment variable.
+to the secret directory at `secrets/vault_token` and by injecting a `VAULT_TOKEN`
+environment variable. If the Nomad cluster is [configured](http://localhost:4567/docs/configuration/vault.html#namespace)
+to use [Vault Namespaces](https://www.vaultproject.io/docs/enterprise/namespaces/index.html), 
+a `VAULT_NAMESPACE` environment variable will be injected whenever `VAULT_TOKEN` is.
 
 If Nomad is unable to renew the Vault token (perhaps due to a Vault outage or
 network error), the client will attempt to retrieve a new Vault token. If successful, the
@@ -71,8 +73,8 @@ with Vault as well.
   string like `"SIGUSR1"` or `"SIGINT"`. This option is required if the
   `change_mode` is `signal`.
 
-- `env` `(bool: true)` - Specifies if the `VAULT_TOKEN` environment variable
-  should be set when starting the task.
+- `env` `(bool: true)` - Specifies if the `VAULT_TOKEN` and `VAULT_NAMESPACE`
+  environment variables should be set when starting the task.
 
 - `policies` `(array<string>: [])` - Specifies the set of Vault policies that
   the task requires. The Nomad client will retrieve a Vault token that is


### PR DESCRIPTION
finishing up the feature discussed during the PR of the initial Vault Namespace integration: 
https://github.com/hashicorp/nomad/pull/5520#pullrequestreview-223304323

My thinking is that you only need the VAULT_NAMESPACE if you're talking to vault, i.e., if you have a VAULT_TOKEN. So I've tied this into the existing logic wherein VAULT_TOKEN is injected (optionally) into the environment.

