### PR TITLE
UI: Make tests faster

### DIFF
--- a/ui/mirage/factories/allocation.js
+++ b/ui/mirage/factories/allocation.js
@@ -26,6 +26,9 @@ export default Factory.extend({
   clientStatus: faker.list.random(...CLIENT_STATUSES),
   desiredStatus: faker.list.random(...DESIRED_STATUSES),
 
+  // When true, doesn't create any resources, state, or events
+  shallow: false,
+
   withTaskWithPorts: trait({
     afterCreate(allocation, server) {
       const taskGroup = server.db.taskGroups.findBy({ name: allocation.taskGroup });
@@ -101,6 +104,7 @@ export default Factory.extend({
           rescheduleAttempts: Math.max(attempts, 0),
           rescheduleSuccess: allocation.rescheduleSuccess,
           previousAllocation: allocation.id,
+          shallow: allocation.shallow,
           clientStatus: 'failed',
           rescheduleTracker,
           followupEvalId: server.create('evaluation', {
@@ -111,6 +115,7 @@ export default Factory.extend({
         nextAllocation = server.create('allocation', {
           previousAllocation: allocation.id,
           clientStatus: allocation.rescheduleSuccess ? 'running' : 'failed',
+          shallow: allocation.shallow,
           rescheduleTracker,
         });
       }
@@ -138,35 +143,42 @@ export default Factory.extend({
       ? server.db.taskGroups.findBy({ name: allocation.taskGroup })
       : pickOne(server.db.taskGroups.where({ jobId: job.id }));
 
-    const states = taskGroup.taskIds.map(id =>
-      server.create('task-state', {
-        allocation,
-        name: server.db.tasks.find(id).name,
-      })
-    );
-
-    const resources = taskGroup.taskIds.map(id =>
-      server.create('task-resource', {
-        allocation,
-        name: server.db.tasks.find(id).name,
-      })
-    );
-
     allocation.update({
       namespace,
       jobId: job.id,
       nodeId: node.id,
-      taskStateIds: allocation.clientStatus === 'pending' ? [] : states.mapBy('id'),
-      taskResourceIds: allocation.clientStatus === 'pending' ? [] : resources.mapBy('id'),
+      taskStateIds: [],
+      taskResourceIds: [],
       taskGroup: taskGroup.name,
       name: allocation.name || `${taskGroup.name}.[${faker.random.number(10)}]`,
     });
 
-    // Each allocation has a corresponding allocation stats running on some client.
-    // Create that record, even though it's not a relationship.
-    server.create('client-allocation-stat', {
-      id: allocation.id,
-      _taskNames: states.mapBy('name'),
-    });
+    if (!allocation.shallow) {
+      const states = taskGroup.taskIds.map(id =>
+        server.create('task-state', {
+          allocation,
+          name: server.db.tasks.find(id).name,
+        })
+      );
+
+      const resources = taskGroup.taskIds.map(id =>
+        server.create('task-resource', {
+          allocation,
+          name: server.db.tasks.find(id).name,
+        })
+      );
+
+      allocation.update({
+        taskStateIds: allocation.clientStatus === 'pending' ? [] : states.mapBy('id'),
+        taskResourceIds: allocation.clientStatus === 'pending' ? [] : resources.mapBy('id'),
+      });
+
+      // Each allocation has a corresponding allocation stats running on some client.
+      // Create that record, even though it's not a relationship.
+      server.create('client-allocation-stat', {
+        id: allocation.id,
+        _taskNames: states.mapBy('name'),
+      });
+    }
   },
 });

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -15,7 +15,7 @@ export default Factory.extend({
     return this.id;
   },
 
-  groupsCount: () => faker.random.number({ min: 1, max: 3 }),
+  groupsCount: () => faker.random.number({ min: 1, max: 2 }),
 
   region: () => 'global',
   type: faker.list.random(...JOB_TYPES),
@@ -27,7 +27,7 @@ export default Factory.extend({
     faker.list.random(...DATACENTERS)
   ),
 
-  childrenCount: () => faker.random.number({ min: 1, max: 3 }),
+  childrenCount: () => faker.random.number({ min: 1, max: 2 }),
 
   periodic: trait({
     type: 'batch',
@@ -98,6 +98,9 @@ export default Factory.extend({
   // When true, allocations for this job will fail and reschedule, randomly succeeding or not
   withRescheduling: false,
 
+  // When true, only task groups and allocations are made
+  shallow: false,
+
   afterCreate(job, server) {
     if (!job.namespaceId) {
       const namespace = server.db.namespaces.length ? pickOne(server.db.namespaces).id : null;
@@ -115,6 +118,7 @@ export default Factory.extend({
       job,
       createAllocations: job.createAllocations,
       withRescheduling: job.withRescheduling,
+      shallow: job.shallow,
     });
 
     job.update({
@@ -150,32 +154,34 @@ export default Factory.extend({
         });
     }
 
-    const knownEvaluationProperties = {
-      job,
-      namespace: job.namespace,
-    };
-    server.createList(
-      'evaluation',
-      faker.random.number({ min: 1, max: 5 }),
-      knownEvaluationProperties
-    );
-    if (!job.noFailedPlacements) {
+    if (!job.shallow) {
+      const knownEvaluationProperties = {
+        job,
+        namespace: job.namespace,
+      };
       server.createList(
         'evaluation',
-        faker.random.number(3),
-        'withPlacementFailures',
+        faker.random.number({ min: 1, max: 5 }),
         knownEvaluationProperties
       );
-    }
+      if (!job.noFailedPlacements) {
+        server.createList(
+          'evaluation',
+          faker.random.number(3),
+          'withPlacementFailures',
+          knownEvaluationProperties
+        );
+      }
 
-    if (job.failedPlacements) {
-      server.create(
-        'evaluation',
-        'withPlacementFailures',
-        assign(knownEvaluationProperties, {
-          modifyIndex: 4000,
-        })
-      );
+      if (job.failedPlacements) {
+        server.create(
+          'evaluation',
+          'withPlacementFailures',
+          assign(knownEvaluationProperties, {
+            modifyIndex: 4000,
+          })
+        );
+      }
     }
 
     if (job.periodic) {
@@ -185,6 +191,7 @@ export default Factory.extend({
         namespaceId: job.namespaceId,
         namespace: job.namespace,
         createAllocations: job.createAllocations,
+        shallow: job.shallow,
       });
     }
 
@@ -195,6 +202,7 @@ export default Factory.extend({
         namespaceId: job.namespaceId,
         namespace: job.namespace,
         createAllocations: job.createAllocations,
+        shallow: job.shallow,
       });
     }
   },

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -15,7 +15,7 @@ export default Factory.extend({
     return this.id;
   },
 
-  groupsCount: () => faker.random.number({ min: 1, max: 5 }),
+  groupsCount: () => faker.random.number({ min: 1, max: 3 }),
 
   region: () => 'global',
   type: faker.list.random(...JOB_TYPES),
@@ -27,7 +27,7 @@ export default Factory.extend({
     faker.list.random(...DATACENTERS)
   ),
 
-  childrenCount: () => faker.random.number({ min: 1, max: 5 }),
+  childrenCount: () => faker.random.number({ min: 1, max: 3 }),
 
   periodic: trait({
     type: 'batch',
@@ -137,7 +137,7 @@ export default Factory.extend({
     });
 
     if (!job.noDeployments) {
-      Array(faker.random.number({ min: 1, max: 10 }))
+      Array(faker.random.number({ min: 1, max: 3 }))
         .fill(null)
         .map((_, index) => {
           return server.create('job-version', {

--- a/ui/mirage/factories/task-group.js
+++ b/ui/mirage/factories/task-group.js
@@ -4,7 +4,7 @@ const DISK_RESERVATIONS = [200, 500, 1000, 2000, 5000, 10000, 100000];
 
 export default Factory.extend({
   name: id => `${faker.hacker.noun().dasherize()}-g-${id}`,
-  count: () => faker.random.number({ min: 1, max: 4 }),
+  count: () => faker.random.number({ min: 1, max: 2 }),
 
   ephemeralDisk: () => ({
     Sticky: faker.random.boolean(),
@@ -20,14 +20,22 @@ export default Factory.extend({
   // and reschedule, creating reschedule events.
   withRescheduling: false,
 
+  // When true, only creates allocations
+  shallow: false,
+
   afterCreate(group, server) {
-    const tasks = server.createList('task', group.count, {
-      taskGroup: group,
-    });
+    let taskIds = [];
+
+    if (!group.shallow) {
+      const tasks = server.createList('task', group.count, {
+        taskGroup: group,
+      });
+      taskIds = tasks.mapBy('id');
+    }
 
     group.update({
-      taskIds: tasks.mapBy('id'),
-      task_ids: tasks.mapBy('id'),
+      taskIds: taskIds,
+      task_ids: taskIds,
     });
 
     if (group.createAllocations) {

--- a/ui/mirage/factories/task-state.js
+++ b/ui/mirage/factories/task-state.js
@@ -17,7 +17,7 @@ export default Factory.extend({
   afterCreate(state, server) {
     const props = [
       'task-event',
-      faker.random.number({ min: 1, max: 10 }),
+      faker.random.number({ min: 1, max: 3 }),
       {
         taskStateId: state.id,
       },

--- a/ui/tests/acceptance/job-allocations-test.js
+++ b/ui/tests/acceptance/job-allocations-test.js
@@ -13,6 +13,7 @@ const makeSearchAllocations = server => {
     .map((_, index) => {
       server.create('allocation', {
         id: index < 5 ? `ffffff-dddddd-${index}` : `111111-222222-${index}`,
+        shallow: true,
       });
     });
 };
@@ -28,7 +29,7 @@ module('Acceptance | job allocations', function(hooks) {
   });
 
   test('lists all allocations for the job', async function(assert) {
-    server.createList('allocation', Allocations.pageSize - 1);
+    server.createList('allocation', Allocations.pageSize - 1, { shallow: true });
     allocations = server.schema.allocations.where({ jobId: job.id }).models;
 
     await Allocations.visit({ id: job.id });

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -8,26 +8,26 @@ import JobDetail from 'nomad-ui/tests/pages/jobs/detail';
 import JobsList from 'nomad-ui/tests/pages/jobs/list';
 
 moduleForJob('Acceptance | job detail (batch)', 'allocations', () =>
-  server.create('job', { type: 'batch' })
+  server.create('job', { type: 'batch', shallow: true })
 );
 moduleForJob('Acceptance | job detail (system)', 'allocations', () =>
-  server.create('job', { type: 'system' })
+  server.create('job', { type: 'system', shallow: true })
 );
 moduleForJob('Acceptance | job detail (periodic)', 'children', () =>
-  server.create('job', 'periodic')
+  server.create('job', 'periodic', { shallow: true })
 );
 
 moduleForJob('Acceptance | job detail (parameterized)', 'children', () =>
-  server.create('job', 'parameterized')
+  server.create('job', 'parameterized', { shallow: true })
 );
 
 moduleForJob('Acceptance | job detail (periodic child)', 'allocations', () => {
-  const parent = server.create('job', 'periodic');
+  const parent = server.create('job', 'periodic', { childrenCount: 1, shallow: true });
   return server.db.jobs.where({ parentId: parent.id })[0];
 });
 
 moduleForJob('Acceptance | job detail (parameterized child)', 'allocations', () => {
-  const parent = server.create('job', 'parameterized');
+  const parent = server.create('job', 'parameterized', { childrenCount: 1, shallow: true });
   return server.db.jobs.where({ parentId: parent.id })[0];
 });
 

--- a/ui/tests/acceptance/namespaces-test.js
+++ b/ui/tests/acceptance/namespaces-test.js
@@ -11,7 +11,7 @@ module('Acceptance | namespaces (disabled)', function(hooks) {
   hooks.beforeEach(function() {
     server.create('agent');
     server.create('node');
-    server.createList('job', 5);
+    server.createList('job', 5, { createAllocations: false });
   });
 
   test('the namespace switcher is not in the gutter menu', async function(assert) {

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -15,7 +15,7 @@ module('Acceptance | regions (only one)', function(hooks) {
   hooks.beforeEach(function() {
     server.create('agent');
     server.create('node');
-    server.createList('job', 5);
+    server.createList('job', 2, { createAllocations: false, noDeployments: true });
   });
 
   test('when there is only one region, the region switcher is not shown in the nav bar', async function(assert) {
@@ -68,7 +68,8 @@ module('Acceptance | regions (many)', function(hooks) {
   hooks.beforeEach(function() {
     server.create('agent');
     server.create('node');
-    server.createList('job', 5);
+    server.createList('job', 2, { createAllocations: false, noDeployments: true });
+    server.create('allocation');
     server.create('region', { id: 'global' });
     server.create('region', { id: 'region-2' });
   });


### PR DESCRIPTION
I have long had a hunch that my free and wild use of [Mirage]() has causing poor test performance, so I did some (a lot) of investigating and managed to make the UI test suite 3x faster with a relatively small PR.

**Before**
![ember-test-avg-summary](https://user-images.githubusercontent.com/174740/56050363-8be5ff00-5d00-11e9-8d62-4645c62fef9d.png)

**After**
<img width="1070" alt="Screen Shot 2019-04-11 at 8 06 59 PM" src="https://user-images.githubusercontent.com/174740/56050378-97d1c100-5d00-11e9-94ae-c74d9e587306.png">