### PR TITLE
fix nil pointer in fingerprinting AWS env leading to crash

### DIFF
--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -106,10 +106,6 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 	}
 	for k, unique := range keys {
 		res, err := client.Get(metadataURL + k)
-		if res.StatusCode != http.StatusOK {
-			f.logger.Debug("could not read attribute value", "attribute", k)
-			continue
-		}
 		if err != nil {
 			// if it's a URL error, assume we're not in an AWS environment
 			// TODO: better way to detect AWS? Check xen virtualization?
@@ -118,6 +114,9 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 			}
 			// not sure what other errors it would return
 			return err
+		} else if res.StatusCode != http.StatusOK {
+			f.logger.Debug("could not read attribute value", "attribute", k)
+			continue
 		}
 		resp, err := ioutil.ReadAll(res.Body)
 		res.Body.Close()


### PR DESCRIPTION
  HTTP Client returns a nil response if an error has occured. We first
  need to check for an error before being able to check the HTTP response
  code.