### PR TITLE
client: wait for batched driver updates before registering nodes

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1468,13 +1468,7 @@ func (c *Client) watchNodeEvents() {
 	// batchEvents stores events that have yet to be published
 	var batchEvents []*structs.NodeEvent
 
-	// Create and drain the timer
-	timer := time.NewTimer(0)
-	timer.Stop()
-	select {
-	case <-timer.C:
-	default:
-	}
+	timer := stoppedTimer()
 	defer timer.Stop()
 
 	for {
@@ -1930,7 +1924,8 @@ func (c *Client) updateNodeLocked() {
 // it will update the client node copy and re-register the node.
 func (c *Client) watchNodeUpdates() {
 	var hasChanged bool
-	timer := time.NewTimer(c.retryIntv(nodeUpdateRetryIntv))
+
+	timer := stoppedTimer()
 	defer timer.Stop()
 
 	for {

--- a/client/client.go
+++ b/client/client.go
@@ -428,7 +428,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulServic
 	select {
 	case <-c.Ready():
 	case <-time.After(batchFirstFingerprintsProcessingGrace):
-		logger.Warn("batched fingerprint, registering node with registered so far")
+		logger.Warn("batch fingerprint operation timed out; proceeding to register with fingerprinted plugins so far")
 	}
 
 	// Restore the state

--- a/client/node_updater.go
+++ b/client/node_updater.go
@@ -14,7 +14,7 @@ import (
 var (
 	// batchFirstFingerprintsTimeout is the maximum amount of time to wait for
 	// initial fingerprinting to complete before sending a batched Node update
-	batchFirstFingerprintsTimeout = 5 * time.Second
+	batchFirstFingerprintsTimeout = 50 * time.Second
 )
 
 // batchFirstFingerprints waits for the first fingerprint response from all

--- a/client/util.go
+++ b/client/util.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"math/rand"
+	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -62,4 +63,14 @@ func shuffleStrings(list []string) {
 		j := rand.Intn(i + 1)
 		list[i], list[j] = list[j], list[i]
 	}
+}
+
+// stoppedTimer returns a timer that's stopped and wouldn't fire until
+// it's reset
+func stoppedTimer() *time.Timer {
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	return timer
 }


### PR DESCRIPTION
Here we retain 0.8.7 behavior of waiting for driver fingerprints before
registering a node, with some timeout.  This is needed for system jobs,
as system job scheduling for node occur at node registration, and the
race might mean that a system job may not get placed on the node because
of missing drivers.

The timeout isn't strictly necessary, but raising it to 1 minute as it's
closer to indefinitely blocked than 1 second.  We need to keep the value
high enough to capture as much drivers/devices, but low enough that
doesn't risk blocking too long due to misbehaving plugin.

Fixes #5579

While digging here, I made few changes that would have helped me debug the problem quicker:
* Removed `watchNodeUpdates()` almost immediately after `registerAndHeartbeat()` calls `retryRegisterNode()`, well after 5 seconds.
* ensure that `detected drivers` show their status and don't mistake nonfingerprinted drivers as available ones.