### PR TITLE
Converts ANSI terminal codes to HTML in logs

### DIFF
--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -18,5 +18,5 @@
   </span>
 </div>
 <div data-test-log-box class="boxed-section-body is-dark is-full-bleed">
-  <pre data-test-log-cli class="cli-window"><code>{{logger.output}}</code></pre>
+  <pre data-test-log-cli class="cli-window"><code>{{{logger.output}}}</code></pre>
 </div>

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -18,5 +18,5 @@
   </span>
 </div>
 <div data-test-log-box class="boxed-section-body is-dark is-full-bleed">
-  <pre data-test-log-cli class="cli-window"><code>{{{logger.output}}}</code></pre>
+  <pre data-test-log-cli class="cli-window"><code>{{logger.output}}</code></pre>
 </div>

--- a/ui/app/utils/classes/log.js
+++ b/ui/app/utils/classes/log.js
@@ -7,6 +7,7 @@ import queryString from 'query-string';
 import { task } from 'ember-concurrency';
 import StreamLogger from 'nomad-ui/utils/classes/stream-logger';
 import PollLogger from 'nomad-ui/utils/classes/poll-logger';
+import Anser from 'anser';
 
 const MAX_OUTPUT_LENGTH = 50000;
 
@@ -37,7 +38,8 @@ const Log = EmberObject.extend(Evented, {
   // The top or bottom of the log, depending on whether
   // the logPointer is pointed at head or tail
   output: computed('logPointer', 'head', 'tail', function() {
-    return this.logPointer === 'head' ? this.head : this.tail;
+    let logs = this.logPointer === 'head' ? this.head : this.tail;
+    return Anser.ansiToHtml(logs);
   }),
 
   init() {

--- a/ui/app/utils/classes/log.js
+++ b/ui/app/utils/classes/log.js
@@ -1,5 +1,6 @@
 import { alias } from '@ember/object/computed';
 import { assert } from '@ember/debug';
+import { htmlSafe } from '@ember/template';
 import Evented from '@ember/object/evented';
 import EmberObject, { computed } from '@ember/object';
 import { assign } from '@ember/polyfills';
@@ -39,7 +40,8 @@ const Log = EmberObject.extend(Evented, {
   // the logPointer is pointed at head or tail
   output: computed('logPointer', 'head', 'tail', function() {
     let logs = this.logPointer === 'head' ? this.head : this.tail;
-    return Anser.ansiToHtml(logs);
+    let colouredLogs = Anser.ansiToHtml(logs);
+    return htmlSafe(colouredLogs);
   }),
 
   init() {

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,6 +25,7 @@
     "'app/styles/**/*.*'": ["prettier --write", "git add"]
   },
   "devDependencies": {
+    "anser": "^1.4.8",
     "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",

--- a/ui/tests/unit/utils/log-test.js
+++ b/ui/tests/unit/utils/log-test.js
@@ -100,9 +100,9 @@ module('Unit | Util | Log', function(hooks) {
     });
 
     await settled();
-    assert.ok(log.get('output').endsWith(truncationMessage), 'Truncation message is shown');
+    assert.ok(log.get('output').toString().endsWith(truncationMessage), 'Truncation message is shown');
     assert.equal(
-      log.get('output').length,
+      log.get('output').toString().length,
       50000 + truncationMessage.length,
       'Output is truncated the appropriate amount'
     );

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1129,6 +1129,11 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+anser@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.8.tgz#19a3bfc5f0e31c49efaea38f58fd0d136597f2a3"
+  integrity sha512-tVHucTCKIt9VRrpQKzPtOlwm/3AmyQ7J+QE29ixFnvuE2hm83utEVrN7jJapYkHV6hI0HOHkEX9TOMCzHtwvuA==
+
 ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"


### PR DESCRIPTION
Haven't tested Windows, but might address #5603

Before:
<img width="917" alt="Screenshot 2019-04-27 at 15 53 40" src="https://user-images.githubusercontent.com/625787/56851274-146dbd80-6905-11e9-91ec-5766795688de.png">
After:
<img width="994" alt="Screenshot 2019-04-27 at 15 53 04" src="https://user-images.githubusercontent.com/625787/56851275-1768ae00-6905-11e9-94ff-155dcadb86ca.png">