### PR TITLE
divest /api from rest of nomad internal packages

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -183,6 +183,9 @@ check: ## Lint the source code
 	@$(MAKE) proto
 	@if (git status | grep -q .pb.go); then echo the following proto files are out of sync; git status |grep .pb.go; exit 1; fi
 
+	@echo "==> Check API package is isolated from rest"
+	@! go list -f '{{ join .Deps "\n" }}' ./api | grep github.com/hashicorp/nomad/ | grep -v -e /vendor/ -e /nomad/api/
+
 .PHONY: checkscripts
 checkscripts: ## Lint shell scripts
 	@echo "==> Linting scripts..."

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"time"
-
-	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 var (
@@ -111,13 +109,13 @@ func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal st
 		return err
 	}
 
-	req := structs.AllocSignalRequest{
+	req := AllocSignalRequest{
 		AllocID: alloc.ID,
 		Signal:  signal,
 		Task:    task,
 	}
 
-	var resp structs.GenericResponse
+	var resp GenericResponse
 	_, err = nodeClient.putQuery("/v1/client/allocation/"+alloc.ID+"/signal", &req, &resp, q)
 	return err
 }
@@ -293,6 +291,18 @@ func (a Allocation) RescheduleInfo(t time.Time) (int, int) {
 
 type AllocationRestartRequest struct {
 	TaskName string
+}
+
+type AllocSignalRequest struct {
+	AllocID string
+	Task    string
+	Signal  string
+}
+
+// GenericResponse is used to respond to a request where no
+// specific response information is needed.
+type GenericResponse struct {
+	WriteMeta
 }
 
 // RescheduleTracker encapsulates previous reschedule events


### PR DESCRIPTION
The API package needs to be independent from rest of nomad packages, to avoid leaking internal packages and dependencies (e.g. raft, ugorji, etc).

Also add a checker that /api doesn't import internal nomad pkgs as part of CI.

For some context - check https://github.com/hashicorp/nomad/pull/5213 and https://github.com/hashicorp/nomad/pull/5488 .