### PR TITLE
Add support in nomad for supporting raft 3 protocol peers.json

### DIFF
--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1169,7 +1169,12 @@ func (s *Server) setupRaft() error {
 			}
 		} else if _, err := os.Stat(peersFile); err == nil {
 			s.logger.Info("found peers.json file, recovering Raft configuration...")
-			configuration, err := raft.ReadPeersJSON(peersFile)
+			var configuration raft.Configuration
+			if s.config.RaftConfig.ProtocolVersion < 3 {
+				configuration, err = raft.ReadPeersJSON(peersFile)
+			} else {
+				configuration, err = raft.ReadConfigJSON(peersFile)
+			}
 			if err != nil {
 				return fmt.Errorf("recovery failed to parse peers.json: %v", err)
 			}


### PR DESCRIPTION
Seeing the following error while following https://www.nomadproject.io/guides/operations/outage.html for raft protocol 3.

nomad: failed to start Raft: recovery failed to parse peers.json: json: cannot unmarshal object into Go value of type string

This PR fixes the above issue.