### PR TITLE
fix system sched constraint errors

### DIFF
--- a/dev/cluster/client2.hcl
+++ b/dev/cluster/client2.hcl
@@ -10,9 +10,17 @@ name = "client2"
 # Enable the client
 client {
   enabled = true
-
   server_join {
     retry_join = ["127.0.0.1:4647", "127.0.0.1:5647", "127.0.0.1:6647"]
+  }
+  meta {
+    tag = "foo"
+  }
+}
+
+plugin "raw_exec" {
+  config {
+    enabled = true
   }
 }
 

--- a/dev/cluster/client3.hcl
+++ b/dev/cluster/client3.hcl
@@ -2,10 +2,10 @@
 log_level = "DEBUG"
 
 # Setup data dir
-data_dir = "/tmp/client1"
+data_dir = "/tmp/client3"
 
 # Give the agent a unique name. Defaults to hostname
-name = "client1"
+name = "client3"
 
 # Enable the client
 client {
@@ -14,7 +14,7 @@ client {
     retry_join = ["127.0.0.1:4647", "127.0.0.1:5647", "127.0.0.1:6647"]
   }
   meta {
-    tag = "foo"
+    tag = "bar"
   }
 }
 
@@ -25,5 +25,5 @@ plugin "raw_exec" {
 }
 
 ports {
-  http = 7646
+  http = 9646
 }

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -1314,13 +1314,20 @@ func TestSystemSched_Queued_With_Constraints(t *testing.T) {
 func TestSystemSched_ConstraintErrors(t *testing.T) {
 	h := NewHarness(t)
 
+	var node *structs.Node
 	// Register some nodes
-	for _, tag := range []string{"aaaaaa", "foo", "foo"} {
-		node := mock.Node()
+	// the tag "aaaaaa" is hashed so that the nodes are processed
+	// in an order other than good, good, bad
+	for _, tag := range []string{"aaaaaa", "foo", "foo", "foo"} {
+		node = mock.Node()
 		node.Meta["tag"] = tag
 		node.ComputeClass()
 		require.Nil(t, h.State.UpsertNode(h.NextIndex(), node))
 	}
+
+	// Mark the last node as ineligible
+	node.SchedulingEligibility = structs.NodeSchedulingIneligible
+	// node.ComputeClass() // should only need to be updated at registration?
 
 	// Make a job with a partially matching constraint
 	job := mock.SystemJob()

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -1327,9 +1327,8 @@ func TestSystemSched_ConstraintErrors(t *testing.T) {
 
 	// Mark the last node as ineligible
 	node.SchedulingEligibility = structs.NodeSchedulingIneligible
-	// node.ComputeClass() // should only need to be updated at registration?
 
-	// Make a job with a partially matching constraint
+	// Make a job with a constraint that matches a subset of the nodes
 	job := mock.SystemJob()
 	job.Constraints = append(job.Constraints,
 		&structs.Constraint{


### PR DESCRIPTION
Fix the system scheduler so that filtered nodes are not reported to the user as failures.
Fixes #2381 and #5169 