### PR TITLE
Yishan/website revised resources page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Resources
 -------------------------------
 
 * Website
-  * [www.nomadproject.io](www.nomadproject.io)
+  * [www.nomadproject.io](https://www.nomadproject.io)
 * Mailing List
   * [Google Groups](https://groups.google.com/group/nomad-tool)
 * Webinars

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -11,7 +11,7 @@ description: |-
       <div class="col-md-offset-2 col-md-8">
         <%= inline_svg "logo-hashicorp.svg", height: 120, class: "logo" %>
 
-        <h1>Easily Deploy Applications at Any Scale</h1>
+        <h1>Deploy and Manage Any Containerized, Legacy, or Batch Application</h1>
 
         <a class="button primary" href="/intro/index.html">Get Started</a>
         <a class="button" href="/downloads.html">Download <%= latest_version %></a>
@@ -26,10 +26,9 @@ description: |-
       <div class="col-sm-12">
         <h2>Simple and Lightweight</h2>
         <p class="lead">
-          HashiCorp Nomad is a single binary that schedules applications and services on
-          Linux, Windows, and Mac. It is an open source scheduler that uses a
-          declarative job file for scheduling virtualized, containerized, and
-          standalone applications.
+          Nomad is an easy-to-use, flexible, and performant workload orchestrator that can
+          deploy a mix of microservice, batch, containerized, and non-containerized applications.
+          Nomad is easy to operate and scale and has native Consul and Vault integrations.
         </p>
       </div>
     </div>

--- a/website/source/resources.html.erb
+++ b/website/source/resources.html.erb
@@ -38,33 +38,12 @@ description: |-
   </ul>
 </p>
 <p>
-  <strong>Webinars</strong>
-  <ul>
-    <li><a href="https://www.hashicorp.com/resources/solutions-engineering-hangout-microservices-with-nomad">Running Microservices with Nomad</a></li>
-    <li><a href="https://www.hashicorp.com/resources/se-hangout-running-heterogeneous-apps-nomad">Running Heterogeneous Apps on Nomad</a></li>
-    <li><a href="https://www.hashicorp.com/resources/supporting-multiple-teams-single-nomad-cluster">Supporting Multiple Teams on a Single Nomad Cluster</a></li>
-    <li><a href="https://www.hashicorp.com/resources/move-your-vmware-workloads-nomad">Moving Your Legacy VMWare Workloads to Nomad</a></li>
-    <li><a href="https://www.hashicorp.com/resources/machine-learning-workflows-hashicorp-nomad-apache-spark">Machine Learning Workflows with HashiCorp Nomad & Apache Spark</a></li>
-  </ul>
-</p>
-<p>
   <strong>Bug Tracker</strong>
   <ul>
     <li><a href="https://github.com/hashicorp/nomad/issues">GitHub Issues</a></li>
   </ul>
   Please only use this to report bugs. For general help, please use our mailing list or Gitter.
 </p>
-
-<h2>How to Install Nomad</h2>
-
-<ul>
-  <li><a href="https://www.nomadproject.io/intro/getting-started/install.html">Install Nomad Locally (Sandbox)</a> - via Vagrant</li>
-  <li><a href="https://github.com/hashicorp/nomad/tree/master/terraform">Nomad on AWS & Azure (Sandbox)</a> - via Terraform</li>
-  <li><a href="https://aws.amazon.com/quickstart/architecture/nomad/">Nomad on AWS Quickstart</a> - via CloudFormation</li>
-  <li><a href="https://www.nomadproject.io/guides/operations/deployment-guide.html">Install Nomad for Production</a> - Official HashiCorp Guide</li>
-  <li><a href="https://www.katacoda.com/hashicorp/scenarios/nomad-introduction">Introduction to Nomad (Katacoda)</a> - Interactive Introduction to Nomad</li>
-  <li><a href="https://katacoda.com/hashicorp/scenarios/playground">Nomad Playground (Katacoda)</a> - Online Nomad Playground Environment</li>
-</ul>
 
 <h2>Who Uses Nomad</h2>
 <ul>
@@ -171,6 +150,26 @@ description: |-
 </ul>
 <br>
 <p>...and more!</p>
+
+<h2>Webinars</h2>
+<ul>
+  <li><a href="https://www.hashicorp.com/resources/solutions-engineering-hangout-microservices-with-nomad">Running Microservices with Nomad</a></li>
+  <li><a href="https://www.hashicorp.com/resources/se-hangout-running-heterogeneous-apps-nomad">Running Heterogeneous Apps on Nomad</a></li>
+  <li><a href="https://www.hashicorp.com/resources/supporting-multiple-teams-single-nomad-cluster">Supporting Multiple Teams on a Single Nomad Cluster</a></li>
+  <li><a href="https://www.hashicorp.com/resources/move-your-vmware-workloads-nomad">Moving Your Legacy VMWare Workloads to Nomad</a></li>
+  <li><a href="https://www.hashicorp.com/resources/machine-learning-workflows-hashicorp-nomad-apache-spark">Machine Learning Workflows with HashiCorp Nomad & Apache Spark</a></li>
+</ul>
+
+<h2>How to Install Nomad</h2>
+
+<ul>
+  <li><a href="https://www.nomadproject.io/intro/getting-started/install.html">Install Nomad Locally (Sandbox)</a> - via Vagrant</li>
+  <li><a href="https://github.com/hashicorp/nomad/tree/master/terraform">Nomad on AWS & Azure (Sandbox)</a> - via Terraform</li>
+  <li><a href="https://aws.amazon.com/quickstart/architecture/nomad/">Nomad on AWS Quickstart</a> - via CloudFormation</li>
+  <li><a href="https://www.nomadproject.io/guides/operations/deployment-guide.html">Install Nomad for Production</a> - Official HashiCorp Guide</li>
+  <li><a href="https://www.katacoda.com/hashicorp/scenarios/nomad-introduction">Introduction to Nomad (Katacoda)</a> - Interactive Introduction to Nomad</li>
+  <li><a href="https://katacoda.com/hashicorp/scenarios/playground">Nomad Playground (Katacoda)</a> - Online Nomad Playground Environment</li>
+</ul>
 
 <h2>Integrations</h2>
 

--- a/website/source/resources.html.erb
+++ b/website/source/resources.html.erb
@@ -46,6 +46,7 @@ description: |-
 </p>
 
 <h2>Who Uses Nomad</h2>
+
 <ul>
   <li>CircleCI</li>
     <ul>
@@ -152,6 +153,7 @@ description: |-
 <p>...and more!</p>
 
 <h2>Webinars</h2>
+
 <ul>
   <li><a href="https://www.hashicorp.com/resources/solutions-engineering-hangout-microservices-with-nomad">Running Microservices with Nomad</a></li>
   <li><a href="https://www.hashicorp.com/resources/se-hangout-running-heterogeneous-apps-nomad">Running Heterogeneous Apps on Nomad</a></li>

--- a/website/source/resources.html.erb
+++ b/website/source/resources.html.erb
@@ -8,76 +8,169 @@ description: |-
 <h1>Resources</h1>
 
 <p>
-  Nomad is a widely deployed open source project with a rapidly expanding
-  ecosystem. Numerous resources exist for learning, experimentation and
-  integration with third-party tools.
+  Nomad is widely adopted and used in production by PagerDuty, Target, Citadel,
+  Trivago, SAP, Pandora, Roblox, eBay, Deluxe Entertainment, and more.
+
+  This is a collection of resources for installing Nomad, joining our community,
+  learning Nomad's real world use-cases, or integrating with third-party tools.
 </p>
 
 <h2>Community</h2>
 
 <p>
-  <strong>Gitter:</strong> <a href="https://gitter.im/hashicorp-nomad/Lobby">Nomad Gitter Room</a>
+  <strong>Mailing List</strong>
+  <ul>
+    <li><a href="https://groups.google.com/group/nomad-tool">Nomad Google Group</a>
+</li>
+  </ul>
 </p>
 <p>
-  <strong>IRC:</strong> Use the <a href="https://irc.gitter.im">Gitter IRC bridge</a>
+  <strong>Gitter</strong>
+  <ul>
+    <li><a href="https://gitter.im/hashicorp-nomad/Lobby">Nomad Chat Room</a>
+  </ul>
 </p>
 <p>
-  <strong>Mailing list:</strong>
-  <a href="https://groups.google.com/group/nomad-tool">Nomad Google Group</a>
+  <strong>Community Calls</strong>
+  <ul>
+    <li><a href="https://www.youtube.com/watch?v=OsZeKTP2u98&t=2s">04/03/2019 with Pandora & Q2EBanking</a></li>
+    <li><a href="https://www.youtube.com/watch?v=eSwZwVVTDqw&t=2660s">05/24/2018 with SAP Ariba</a></li>
+  </ul>
 </p>
 <p>
-  <strong>Bug Tracker:</strong>
-  <a href="https://github.com/hashicorp/nomad/issues">Issue tracker
-    on GitHub</a>. Please only use this for reporting bugs. Do not ask
-  for general help here. Use IRC or the mailing list for that.
+  <strong>Webinars</strong>
+  <ul>
+    <li><a href="https://www.hashicorp.com/resources/solutions-engineering-hangout-microservices-with-nomad">Running Microservices with Nomad</a></li>
+    <li><a href="https://www.hashicorp.com/resources/se-hangout-running-heterogeneous-apps-nomad">Running Heterogeneous Apps on Nomad</a></li>
+    <li><a href="https://www.hashicorp.com/resources/supporting-multiple-teams-single-nomad-cluster">Supporting Multiple Teams on a Single Nomad Cluster</a></li>
+    <li><a href="https://www.hashicorp.com/resources/move-your-vmware-workloads-nomad">Moving Your Legacy VMWare Workloads to Nomad</a></li>
+    <li><a href="https://www.hashicorp.com/resources/machine-learning-workflows-hashicorp-nomad-apache-spark">Machine Learning Workflows with HashiCorp Nomad & Apache Spark</a></li>
+  </ul>
+</p>
+<p>
+  <strong>Bug Tracker</strong>
+  <ul>
+    <li><a href="https://github.com/hashicorp/nomad/issues">GitHub Issues</a></li>
+  </ul>
+  Please only use this to report bugs. For general help, please use our mailing list or Gitter.
 </p>
 
-<h2>Videos</h2>
+<h2>How to Install Nomad</h2>
 
 <ul>
-  <li><a href="https://www.hashicorp.com/resources/nomad-vault-circleci-security-scheduling">Nomad and Vault at <strong>CircleCI</strong>: Security and Scheduling are Not Your Core Competencies</a></li>
-  <li><a href="https://www.hashicorp.com/resources/nomad-scaling-target-microservices-across-cloud">Nomad at <strong>Target</strong>: Scaling Microservices Across Public and Private Clouds</a></li>
-  <li><a href="https://www.hashicorp.com/resources/engineering-reliability-expecting-failure-sre-nomad">Engineering reliability by expecting failure: SRE with HashiCorp Nomad</a></li>
-  <li><a href="https://www.hashicorp.com/resources/autoscaling-hashicorp-nomad">Build your own autoscaling feature with HashiCorp Nomad</a></li>
-  <li><a href="https://www.hashicorp.com/resources/jet-walmart-hashicorp-nomad-azure-run-apps">How <strong>Jet.com</strong> uses HashiCorp Nomad on Azure to run its applications</a></li>
-  <li><a href="https://www.hashicorp.com/resources/end-to-end-production-nomad-citadel">End to end production Nomad at <strong>Citadel</strong></a></li>
-  <li><a href="https://www.hashicorp.com/resources/nomad-overview-demo-citadel-use-case">HashiCorp Nomad demo and <strong>Citadel</strong> use case</a></li>
-  <li><a href="https://www.youtube.com/watch?v=lTIvKZHedJQ">Nelson: Multi-region Container Orchestration for HashiCorp Nomad and Lyft Envoy</a></li>
-  <li><a href="https://www.hashicorp.com/resources/elsevier-nomad-container-framework-demo"><strong>Elsevier's</strong> Container Framework with Nomad, Terraform, and Consul</a></li>
-  <li><a href="https://www.hashicorp.com/resources/pagerduty-nomad-journey"><strong>PagerDuty's</strong> Nomadic Journey</a></li>
-  <li><a href="https://www.hashicorp.com/resources/operating-jobs-scale-nomad">Operating jobs at scale with Nomad</a></li>
-  <li><a href="https://www.hashicorp.com/resources/backend-batch-processing-nomad">Backend batch processing with Nomad</a></li>
-</ul>
-
-<h2>Blog Posts</h2>
-
-<ul>
-  <li><a href="https://portworx.com/architects-corner-roblox-runs-platform-70-million-gamers-hashicorp-nomad/">How Roblox runs a platform for 70 million gamers on HashiCorp Nomad and Portworx</a> - Rob Cameron, <strong>Roblox</strong></li>
-  <li><a href="https://tech.trivago.com/2019/01/25/nomad-our-experiences-and-best-practices/">Nomad - our experiences and best practices</a> - Inga Feick, <string>Trivago</strong></li>
-  <li><a href="https://andydote.co.uk/2019/01/28/nomad-rabbitmq-consul-cluster/">RabbitMQ clustering with Consul in Nomad</a> - Andy Dote</li>
-  <li><a href="https://medium.com/@henrikjohansen/cluster-scheduling-systems-for-large-scale-security-operations-351e7886852b">Cluster Scheduling Systems for Large Scale Security Operations</a> - Henrik Johansen</li>
-  <li><a href="https://medium.com/@copyconstruct/schedulers-kubernetes-and-nomad-b0f2e14a896">Cluster Schedulers</a> - Cindy Sridharan</li>
-  <li><a href="https://danielparker.me/nomad/hashicorp/schedulers/nomad/">Playing with Nomad from HashiCorp</a> - Daniel Parker, <strong>Target</strong></li>
-  <li><a href="https://medium.com/@gabrielteles/migrating-from-aws-to-aws-e2bb1bfaa0e0">Migrating from AWS to AWS</a> - Gabriel Teles</li>
-  <li><a href="https://stackshare.io/circleci/how-circleci-processes-4-5-million-builds-per-month">How <strong>CircleCI</strong> Processes 4.5 Million Builds Per Month</a> - Rob Zuber</li>
-  <li><a href="http://timperrett.com/2017/05/13/nomad-with-envoy-and-consul">Envoy with Nomad and Consul</a> - Tim Perrett</li>
-  <li><a href="https://www.hashicorp.com/blog/continuous-deployment-with-nomad-and-terraform">Continuous Deployment with Nomad and Terraform</a> - Nic Jackson</li>
-  <li><a href="https://www.hashicorp.com/blog/running-apache-spark-on-nomad">Running Apache Spark on HashiCorp Nomad</a> - Rob Genova</li>
-  <li><a href="https://www.hashicorp.com/blog/auto-bootstrapping-a-nomad-cluster">Auto-bootstrapping a Nomad Cluster</a> - Nic Jackson</li>
-  <li><a href="https://www.hashicorp.com/blog/replacing-queues-with-nomad-dispatch">Replacing Queues with Nomad Dispatch</a> - Armon Dadgar</li>
-  <li><a href="https://sanderknape.com/2016/08/nomad-consul-multi-datacenter-container-orchestration/">Multi-datacenter Container Orchestration with Nomad and Consul</a> - Sander Knape</li>
- <li><a href="https://www.hashicorp.com/blog/on-demand-container-storage-with-hashicorp-nomad/">On-demand Container Storage with HashiCorp Nomad</a> - Jeff Silberman, <strong>Portworx</strong></li>
-</ul>
-
-<h2>Tools for Provisioning and Experimentation</h2>
-
-<ul>
-  <li><a href="https://registry.terraform.io/search?q=nomad">Terraform Module Registry</a> - Official Nomad modules for AWS, Azure and Google Cloud</li>
-  <li><a href="https://aws.amazon.com/quickstart/architecture/nomad/">HashiCorp Nomad on AWS</a> - AWS Quickstart Guide for Nomad</li>
-  <li><a href="https://github.com/hashicorp/nomad/tree/master/terraform">Nomad Sandbox Environment for AWS and Azure</a> - Easily Provision a Combined Nomad, Consul and Vault Cluster on AWS or Azure</li>
+  <li><a href="https://www.nomadproject.io/intro/getting-started/install.html">Install Nomad Locally (Sandbox)</a> - via Vagrant</li>
+  <li><a href="https://github.com/hashicorp/nomad/tree/master/terraform">Nomad on AWS & Azure (Sandbox)</a> - via Terraform</li>
+  <li><a href="https://aws.amazon.com/quickstart/architecture/nomad/">Nomad on AWS Quickstart</a> - via CloudFormation</li>
+  <li><a href="https://www.nomadproject.io/guides/operations/deployment-guide.html">Install Nomad for Production</a> - Official HashiCorp Guide</li>
   <li><a href="https://www.katacoda.com/hashicorp/scenarios/nomad-introduction">Introduction to Nomad (Katacoda)</a> - Interactive Introduction to Nomad</li>
   <li><a href="https://katacoda.com/hashicorp/scenarios/playground">Nomad Playground (Katacoda)</a> - Online Nomad Playground Environment</li>
 </ul>
+
+<h2>Who Uses Nomad</h2>
+<ul>
+  <li>CircleCI</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/nomad-vault-circleci-security-scheduling">Security & Scheduling are Not Your Core Competencies</a></li>
+    </ul>
+  <li>Citadel</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/end-to-end-production-nomad-citadel">End-to-End Production Nomad at Citadel</a></li>
+      <li><a href="https://www.hashicorp.com/resources/citadel-scaling-hashicorp-nomad-consul">Extreme Scaling with HashiCorp Nomad & Consul</a></li>
+    </ul>
+  <li>Deluxe Entertainment</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/deluxe-hashistack-video-production">How Deluxe Uses the Complete HashiStack for Video Production</a></li>
+    </ul>
+  <li>Jet.com (Walmart)</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/jet-walmart-hashicorp-nomad-azure-run-apps">Driving down costs at Jet.com with HashiCorp Nomad</a></li>
+    </ul>
+  <li>PagerDuty</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/pagerduty-nomad-journey">PagerDuty's Nomadic Journey</a></li>
+    </ul>
+  <li>Pandora</li>
+    <ul>
+      <li><a href="https://www.youtube.com/watch?v=OsZeKTP2u98&t=2s">How Pandora Uses Nomad</a></li>
+    </ul>
+  <li>SAP Ariba</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/nomad-community-call-core-team-sap-ariba">HashiCorp Nomad @ SAP Ariba</a></li>
+    </ul>
+  <li>SeatGeek</li>
+    <ul>
+      <li><a href="https://github.com/seatgeek/nomad-helper">Nomad Helper Tools</a></li>
+    </ul>
+  <li>Spaceflight Industries</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/blog/spaceflight-uses-hashicorp-consul-for-service-discovery-and-real-time-updates-to-their-hub-and-spoke-network-architecture">Spaceflight's Hub-And-Spoke Infrastructure</a></li>
+    </ul>
+  <li>SpotInst</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/blog/spotinst-and-hashicorp-nomad-to-reduce-ec2-costs-fo">SpotInst and HashiCorp Nomad to Reduce EC2 Costs for Users</a></li>
+    </ul>
+  <li>Target</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/nomad-scaling-target-microservices-across-cloud">Nomad at Target: Scaling Microservices Across Public and Private Cloud</a></li>
+      <li><a href="https://danielparker.me/nomad/hashicorp/schedulers/nomad/">Playing with Nomad from HashiCorp</a></li>
+    </ul>
+  <li>Trivago</li>
+    <ul>
+      <li><a href="https://matthias-endler.de/2019/maybe-you-dont-need-kubernetes/">Maybe You Don't Need Kubernetes</a></li>
+      <li><a href="https://tech.trivago.com/2019/01/25/nomad-our-experiences-and-best-practices/">Nomad - Our Experiences and Best Practices</a></li>
+    </ul>
+  <li>Roblox</li>
+    <ul>
+      <li><a href="https://portworx.com/architects-corner-roblox-runs-platform-70-million-gamers-hashicorp-nomad/">How Roblox runs a platform for 70 million gamers on HashiCorp Nomad</a></li>
+    </ul>
+  <li>Oscar Health</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/scalable-ci-oscar-health-insurance-nomad-docker">Scalable CI at Oscar Health with Nomad and Docker</a></li>
+    </ul>
+  <li>eBay</li>
+    <ul>
+      <li><a href="HashiStack at eBay: A Fully Containerized Platform Based on Infrastructure as Code">HashiStack at eBay: A Fully Containerized Platform Based on Infrastructure as Code</a></li>
+    </ul>
+  <li>Joyent</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/autoscaling-hashicorp-nomad">Build Your Own Autoscaling Feature with HashiCorp Nomad</a></li>
+    </ul>
+  <li>Dutch National Police</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/going-cloud-native-at-the-dutch-national-police">Going Cloud-Native at the Dutch National Police</a></li>
+    </ul>
+  <li>N26</li>
+    <ul>
+      <li><a href="https://medium.com/insiden26/tech-at-n26-the-bank-in-the-cloud-e5ff818b528b">Tech at N26 - The Bank in the Cloud</a></li>
+    </ul>
+  <li>Elsevier</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/elsevier-nomad-container-framework-demo">Eslevier’s Container Framework with Nomad, Terraform, and Consul</a></li>
+    </ul>
+  <li>Palantir</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/enterprise-security-hashicorp-stack">Enterprise Security at Palantir with the HashiCorp stack</a></li>
+    </ul>
+  <li>Graymeta</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/backend-batch-processing-nomad">Backend Batch Processing At Scale with Nomad</a></li>
+    </ul>
+  <li>NIH NCBI</li>
+    <ul>
+      <li><a href="https://www.hashicorp.com/resources/ncbi-legacy-migration-hybrid-cloud-consul-nomad">NCBI’s Legacy Migration to Hybrid Cloud with Consul & Nomad</a></li>
+    </ul>
+  <li>Q2EBanking</li>
+    <ul>
+      <li><a href="https://www.youtube.com/watch?v=OsZeKTP2u98&feature=youtu.be&t=1499">Q2's Nomad Use and Overview</a></li>
+    </ul>
+  <li>imgix</li>
+    <ul>
+      <li><a href="https://medium.com/@copyconstruct/schedulers-kubernetes-and-nomad-b0f2e14a896">Cluster Schedulers & Why We Chose Nomad Over Kubernetes</a></li>
+    </ul>
+  <li>Region Syddanmark</li>
+</ul>
+<br>
+<p>...and more!</p>
 
 <h2>Integrations</h2>
 
@@ -103,28 +196,3 @@ description: |-
   <li><a href="https://github.com/jippi/awesome-nomad">jippi/awesome-nomad</a> - A Curated List of Nomad Tools</li>
   <li><a href="https://github.com/jrasell/nomadfiles">jrasell/nomadfiles</a> - A Collection of Nomad Job Files for Deploying Applications</li>
 </ul>
-
-<h2>Trusted By</h2>
-
-<ul>
-  <li>Bownty.com</li>
-  <li>CircleCI</li>
-  <li>Citadel</li>
-  <li>Deluxe Entertainment</li>
-  <li>Elsevier</li>
-  <li>Jet.com</li>
-  <li>Pagerduty</li>
-  <li>Pandora</li>
-  <li>SAP Ariba</li>
-  <li>SeatGeek</li>
-  <li>Spaceflight Industries</li>
-  <li>SpotInst</li>
-  <li>Target</li>
-</ul>
-
-<p>
-<em>
-  <strong>If you would like to have a resource or your company name added to this page, please</strong>
-  <a href="https://github.com/hashicorp/nomad">submit a Pull Request</a>.
-</em>
-</p>


### PR DESCRIPTION
- Updated homepage tagline to "Deploy and Manage Any Containerized, Legacy, or Batch Application"
- Updated homepage boilerplate for consistency with GitHub README
- Reformatted "Community" section for consistency with GitHub README
- Added "Who Uses Nomad" section in consistency with GitHub README
- Rewrote overview description on "Resources" page
- Removed "IRC" section (redundant with Gitter)
- Added "Community Calls" section with links to prior sessions
- Added "Webinar" section with links to prior sessions
- Renamed "Tools for Provisioning & Experimentation" to "How to Install Nomad" section
- Bumped up the "How to Install Nomad" section right below to second on the list "Community"
- Removed "Videos" & "Blog Posts" section in favor of segmentation
- Removed the "Trusted By" section and disclaimer at bottom
- Revised Bug Tracker copy 