### PR TITLE
stale allocation data leads to incorrect (and even negative) metrics

### DIFF
--- a/client/allocrunner/state/state.go
+++ b/client/allocrunner/state/state.go
@@ -59,3 +59,13 @@ func (s *State) Copy() *State {
 		TaskStates:        taskStates,
 	}
 }
+
+// ClientTerminalStatus returns if the client status is terminal and will no longer transition
+func (a *State) ClientTerminalStatus() bool {
+	switch a.ClientStatus {
+	case structs.AllocClientStatusComplete, structs.AllocClientStatusFailed, structs.AllocClientStatusLost:
+		return true
+	default:
+		return false
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -2713,7 +2713,7 @@ func (c *Client) getAllocatedResources(selfNode *structs.Node) *structs.Comparab
 	allocatedDeviceMbits := make(map[string]int)
 	for _, ar := range c.getAllocRunners() {
 		alloc := ar.Alloc()
-		if ar.Alloc().ServerTerminalStatus() || ar.AllocState().ClientTerminalStatus() {
+		if alloc.ServerTerminalStatus() || ar.AllocState().ClientTerminalStatus() {
 			continue
 		}
 


### PR DESCRIPTION
client: was not using up-to-date client state in determining which alloc count towards allocated resources

this is the second issue where using `AllocRunner.Alloc()` instead of `AllocRunner.AllocState()` meant that the `ClientState` had the wrong data. @schmichael [previously noted](https://github.com/hashicorp/nomad/pull/5541#pullrequestreview-227352591) how nefarious this is, that we should look for a solution. i haven't done anything to address the underlying issue with this PR; I've just made the simplest fix to correct the metrics calculation. in fact, the call to `AllocState()` may be a little more expensive than is necessary for this; we only need to know whether the allocation is still resident.

fixes #5570 