### PR TITLE
network fingerprinting multiple IPs on the configured network device

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1291,15 +1291,21 @@ func updateNetworks(ns structs.Networks, up structs.Networks, c *config.Config) 
 	if c.NetworkInterface == "" {
 		ns = up
 	} else {
-		// if a network is configured, use only that network
-		// use the fingerprinted data
+		// If a network device is configured, filter up to contain details for only
+		// that device
+		upd := []*structs.NetworkResource{}
 		for _, n := range up {
 			if c.NetworkInterface == n.Device {
-				ns = []*structs.NetworkResource{n}
+				upd = append(upd, n)
 			}
 		}
-		// if not matched, ns has the old data
+		if len(upd) > 0 {
+			ns = upd
+		}
+		// Otherwise, ns has the old data
 	}
+
+	// ns is set, apply the config NetworkSpeed to all
 	if c.NetworkSpeed != 0 {
 		for _, n := range ns {
 			n.MBits = c.NetworkSpeed

--- a/client/client.go
+++ b/client/client.go
@@ -1299,10 +1299,10 @@ func updateNetworks(ns structs.Networks, up structs.Networks, c *config.Config) 
 				upd = append(upd, n)
 			}
 		}
+		// If updates, use them. Otherwise, ns contains the configured interfaces
 		if len(upd) > 0 {
 			ns = upd
 		}
-		// Otherwise, ns has the old data
 	}
 
 	// ns is set, apply the config NetworkSpeed to all


### PR DESCRIPTION
merging network fingerprinting can merge multiple addresses (for, e.g. ipv4 and 6) on the same configured network device