### PR TITLE
Codegen codec helpers for all nomad structs

### DIFF
--- a/nomad/structs/generate.sh
+++ b/nomad/structs/generate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-FILES="$(ls *[!_test].go | tr '\n' ' ')"
+FILES="$(ls ./*.go | grep -v -e _test.go -e .generated.go | tr '\n' ' ')"
 codecgen -d 100 -o structs.generated.go ${FILES}

--- a/scripts/install-codecgen.sh
+++ b/scripts/install-codecgen.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Match entry in vendor.json
-GIT_TAG="v1.1.2"
+GIT_TAG="0053ebfd9d0ee06ccefbfe17072021e1d4acebee"
 echo "Installing codec/codecgen@${GIT_TAG} ..."
 
 # Either fetch in existing git repo or use go get to clone


### PR DESCRIPTION
`ls *[!_test].go` was ignoring any file that ends with `s.go` (or any of the letter inside `[]`), including `structs.go`!

Also ensure that the ugorji/go codec library version matches the codec generation file format.  I have confirmed that we get the same autogenerated code for our structs under v1.1.2 and the other version, so we don't risk introducing incompatibility changes.  Here, we downgrade codecgen binary to match library, but intend to follow up to find a more appropriate recent version of ugorji/go library to use that maintains serialization format binary compatibility.

Here is my script to confirm that v0.9.1 structs are the same (you can follow it on this branch HEAD to confirm that generated code is the same on master).

```
$ git checkout v0.9.1
HEAD is now at 23c4597db Release v0.9.1
$ git status
HEAD detached at v0.9.1
nothing to commit, working tree clean
$
$ # checking with v1.1.2 codegen
$ pushd ~/go/src/github.com/ugorji/go/codec/codecgen && git checkout v1.1.2 && go install . && popd
~/go/src/github.com/ugorji/go/codec/codecgen ~/go/src/github.com/hashicorp/nomad
Previous HEAD position was 0053ebf codec: codecgen: gen.go: move stripVendor to a function that is kept in sync
HEAD is now at 8fd0f8d codec: set go.mod to require github.com/ugorji/go v1.1.2
~/go/src/github.com/hashicorp/nomad
$ rm -rf ./nomad/structs/structs.generated.go ./client/structs/structs.generated.go
$ make generate-all
--> Running go generate...
--> Generating proto bindings...
$ git status
HEAD detached at v0.9.1
nothing to commit, working tree clean
$
$
$ # yay no changes - now try again with 0053ebf
$ pushd ~/go/src/github.com/ugorji/go/codec/codecgen && git checkout 0053ebfd9d0ee06ccefbfe17072021e1d4acebee && go install . && popd
~/go/src/github.com/ugorji/go/codec/codecgen ~/go/src/github.com/hashicorp/nomad
Previous HEAD position was 8fd0f8d codec: set go.mod to require github.com/ugorji/go v1.1.2
HEAD is now at 0053ebf codec: codecgen: gen.go: move stripVendor to a function that is kept in sync
~/go/src/github.com/hashicorp/nomad
$ rm -rf ./nomad/structs/structs.generated.go ./client/structs/structs.generated.go
$ make generate-all
--> Running go generate...
--> Generating proto bindings...
$ git status
HEAD detached at v0.9.1
nothing to commit, working tree clean
```