### PR TITLE
lookup executables inside chroot

### DIFF
--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -102,7 +102,7 @@ func TestExecDriver_StartWait(t *testing.T) {
 	}
 
 	tc := &TaskConfig{
-		Command: "echo",
+		Command: "cat",
 		Args:    []string{"/proc/self/cgroup"},
 	}
 	require.NoError(task.EncodeConcreteDriverConfig(&tc))

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -102,7 +102,7 @@ func TestExecDriver_StartWait(t *testing.T) {
 	}
 
 	tc := &TaskConfig{
-		Command: "cat",
+		Command: "echo",
 		Args:    []string{"/proc/self/cgroup"},
 	}
 	require.NoError(task.EncodeConcreteDriverConfig(&tc))

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -579,47 +579,6 @@ func lookupBin(taskDir string, bin string) (string, error) {
 	return "", fmt.Errorf("binary %q could not be found", bin)
 }
 
-// lookupTaskBin finds the file in:
-// taskDir/local, taskDir, PATH search inside taskDir
-// and returns an absolute path
-func lookupTaskBin(taskDir string, bin string) (string, error) {
-	// Check in the local directory
-	localDir := filepath.Join(taskDir, allocdir.TaskLocal)
-	local := filepath.Join(localDir, bin)
-	if _, err := os.Stat(local); err == nil {
-		return local, nil
-	}
-
-	// Check at the root of the task's directory
-	root := filepath.Join(taskDir, bin)
-	if _, err := os.Stat(root); err == nil {
-		return root, nil
-	}
-
-	// Check the host PATH anchored inside the taskDir
-	if !strings.Contains(bin, "/") {
-		envPath := os.Getenv("PATH")
-		for _, dir := range filepath.SplitList(envPath) {
-			if dir == "" {
-				// match unix shell behavior, empty path element == .
-				dir = "."
-			}
-			for _, root := range []string{localDir, taskDir} {
-				path := filepath.Join(root, dir, bin)
-				f, err := os.Stat(path)
-				if err != nil {
-					continue
-				}
-				if m := f.Mode(); !m.IsDir() {
-					return path, nil
-				}
-			}
-		}
-	}
-
-	return "", fmt.Errorf("file %s not found under path %s", bin, taskDir)
-}
-
 // makeExecutable makes the given file executable for root,group,others.
 func makeExecutable(binPath string) error {
 	if runtime.GOOS == "windows" {

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -248,7 +248,7 @@ func (e *UniversalExecutor) Version() (*ExecutorVersion, error) {
 // Launch launches the main process and returns its state. It also
 // configures an applies isolation on certain platforms.
 func (e *UniversalExecutor) Launch(command *ExecCommand) (*ProcessState, error) {
-	e.logger.Debug("launch prep", "command", command.Cmd, "args", strings.Join(command.Args, " "))
+	e.logger.Trace("preparing to launch command", "command", command.Cmd, "args", strings.Join(command.Args, " "))
 
 	e.commandCfg = command
 

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -248,7 +248,7 @@ func (e *UniversalExecutor) Version() (*ExecutorVersion, error) {
 // Launch launches the main process and returns its state. It also
 // configures an applies isolation on certain platforms.
 func (e *UniversalExecutor) Launch(command *ExecCommand) (*ProcessState, error) {
-	e.logger.Debug("launching command", "command", command.Cmd, "args", strings.Join(command.Args, " "))
+	e.logger.Debug("launch prep", "command", command.Cmd, "args", strings.Join(command.Args, " "))
 
 	e.commandCfg = command
 
@@ -303,6 +303,7 @@ func (e *UniversalExecutor) Launch(command *ExecCommand) (*ProcessState, error) 
 	e.childCmd.Env = e.commandCfg.Env
 
 	// Start the process
+	e.logger.Debug("launching", "command", command.Cmd, "args", strings.Join(command.Args, " "))
 	if err := e.childCmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start command path=%q --- args=%q: %v", path, e.childCmd.Args, err)
 	}

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -98,7 +98,7 @@ func NewExecutorWithIsolation(logger hclog.Logger) Executor {
 
 // Launch creates a new container in libcontainer and starts a new process with it
 func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, error) {
-	l.logger.Debug("launch prep", "command", command.Cmd, "args", strings.Join(command.Args, " "))
+	l.logger.Trace("preparing to launch command", "command", command.Cmd, "args", strings.Join(command.Args, " "))
 
 	if command.Resources == nil {
 		command.Resources = &drivers.Resources{

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -97,7 +97,7 @@ func NewExecutorWithIsolation(logger hclog.Logger) Executor {
 
 // Launch creates a new container in libcontainer and starts a new process with it
 func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, error) {
-	l.logger.Debug("launching command", "command", command.Cmd, "args", strings.Join(command.Args, " "))
+	l.logger.Debug("launch prep", "command", command.Cmd, "args", strings.Join(command.Args, " "))
 
 	if command.Resources == nil {
 		command.Resources = &drivers.Resources{
@@ -176,6 +176,8 @@ func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, erro
 	if err != nil {
 		return nil, err
 	}
+
+	l.logger.Debug("launching", "command", command.Cmd, "args", strings.Join(command.Args, " "))
 
 	// the task process will be started by the container
 	process := &libcontainer.Process{

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -143,7 +143,7 @@ func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, erro
 	l.container = container
 
 	// Look up the binary path and make it executable
-	absPath, err := lookupTaskBin(command.TaskDir, command.Cmd)
+	absPath, err := lookupTaskBin(command)
 
 	if err != nil {
 		return nil, err
@@ -774,7 +774,10 @@ func cmdMounts(mounts []*drivers.MountConfig) []*lconfigs.Mount {
 
 // lookupTaskBin finds the file `bin` in taskDir/local, taskDir in that order, then performs
 // a PATH search inside taskDir. It returns an absolute path. See also executor.lookupBin
-func lookupTaskBin(taskDir string, bin string) (string, error) {
+func lookupTaskBin(command *ExecCommand) (string, error) {
+	taskDir := command.TaskDir
+	bin := command.Cmd
+
 	// Check in the local directory
 	localDir := filepath.Join(taskDir, allocdir.TaskLocal)
 	local := filepath.Join(localDir, bin)
@@ -788,10 +791,17 @@ func lookupTaskBin(taskDir string, bin string) (string, error) {
 		return root, nil
 	}
 
+	// Find the PATH
+	path := "/usr/local/bin:/usr/bin:/bin"
+	for _, e := range command.Env {
+		if strings.HasPrefix("PATH=", e) {
+			path = e[5:]
+		}
+	}
+
 	// Check the host PATH anchored inside the taskDir
 	if !strings.Contains(bin, "/") {
-		envPath := os.Getenv("PATH")
-		for _, dir := range filepath.SplitList(envPath) {
+		for _, dir := range filepath.SplitList(path) {
 			if dir == "" {
 				// match unix shell behavior, empty path element == .
 				dir = "."

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -142,7 +142,8 @@ func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, erro
 	l.container = container
 
 	// Look up the binary path and make it executable
-	absPath, err := lookupBin(command.TaskDir, command.Cmd)
+	absPath, err := lookupTaskBin(command.TaskDir, command.Cmd)
+
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,7 @@ func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, erro
 
 	path := absPath
 
-	// Determine the path to run as it may have to be relative to the chroot.
+	// Ensure that the path is contained in the chroot, and find it relative to the container
 	rel, err := filepath.Rel(command.TaskDir, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine relative path base=%q target=%q: %v", command.TaskDir, path, err)

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -170,6 +170,9 @@ func TestUniversalExecutor_LookupTaskBin(t *testing.T) {
 	require.Nil(err)
 	defer os.Remove(tmpDir)
 
+	// Create the command
+	cmd := &ExecCommand{Env: []string{"PATH=/bin"}, TaskDir: tmpDir}
+
 	// Make a foo subdir
 	os.MkdirAll(filepath.Join(tmpDir, "foo"), 0700)
 
@@ -179,7 +182,8 @@ func TestUniversalExecutor_LookupTaskBin(t *testing.T) {
 	require.NoError(err)
 
 	// Lookout with an absolute path to the binary
-	_, err = lookupTaskBin(tmpDir, "/foo/tmp.txt")
+	cmd.Cmd = "/foo/tmp.txt"
+	_, err = lookupTaskBin(cmd)
 	require.NoError(err)
 
 	// Write a file under local subdir
@@ -188,11 +192,13 @@ func TestUniversalExecutor_LookupTaskBin(t *testing.T) {
 	ioutil.WriteFile(filePath2, []byte{1, 2}, os.ModeAppend)
 
 	// Lookup with file name, should find the one we wrote above
-	_, err = lookupTaskBin(tmpDir, "tmp.txt")
+	cmd.Cmd = "tmp.txt"
+	_, err = lookupTaskBin(cmd)
 	require.NoError(err)
 
 	// Lookup a host absolute path
-	_, err = lookupTaskBin(tmpDir, "/bin/sh")
+	cmd.Cmd = "/bin/sh"
+	_, err = lookupTaskBin(cmd)
 	require.Error(err)
 }
 

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -48,6 +48,7 @@ func testExecutorCommandWithChroot(t *testing.T) *testExecCmd {
 		"/lib64":            "/lib64",
 		"/usr/lib":          "/usr/lib",
 		"/bin/ls":           "/bin/ls",
+		"/bin/cat":          "/bin/cat",
 		"/bin/echo":         "/bin/echo",
 		"/bin/bash":         "/bin/bash",
 		"/bin/sleep":        "/bin/sleep",

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -179,6 +179,22 @@ func TestExecutor_EscapeContainer(t *testing.T) {
 	_, err := executor.Launch(execCmd)
 	require.Error(err)
 	require.Regexp("^file /bin/kill not found under path", err)
+
+	// Bare files are looked up using the system path, inside the container
+	allocDir.Destroy()
+	testExecCmd = testExecutorCommandWithChroot(t)
+	execCmd, allocDir = testExecCmd.command, testExecCmd.allocDir
+	execCmd.Cmd = "kill"
+	_, err = executor.Launch(execCmd)
+	require.Error(err)
+	require.Regexp("^file kill not found under path", err)
+
+	allocDir.Destroy()
+	testExecCmd = testExecutorCommandWithChroot(t)
+	execCmd, allocDir = testExecCmd.command, testExecCmd.allocDir
+	execCmd.Cmd = "echo"
+	_, err = executor.Launch(execCmd)
+	require.NoError(err)
 }
 
 func TestExecutor_ClientCleanup(t *testing.T) {

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -161,6 +161,41 @@ ld.so.conf.d/`
 	}, func(err error) { t.Error(err) })
 }
 
+func TestUniversalExecutor_LookupTaskBin(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Create a temp dir
+	tmpDir, err := ioutil.TempDir("", "")
+	require.Nil(err)
+	defer os.Remove(tmpDir)
+
+	// Make a foo subdir
+	os.MkdirAll(filepath.Join(tmpDir, "foo"), 0700)
+
+	// Write a file under foo
+	filePath := filepath.Join(tmpDir, "foo", "tmp.txt")
+	err = ioutil.WriteFile(filePath, []byte{1, 2}, os.ModeAppend)
+	require.NoError(err)
+
+	// Lookout with an absolute path to the binary
+	_, err = lookupTaskBin(tmpDir, "/foo/tmp.txt")
+	require.NoError(err)
+
+	// Write a file under local subdir
+	os.MkdirAll(filepath.Join(tmpDir, "local"), 0700)
+	filePath2 := filepath.Join(tmpDir, "local", "tmp.txt")
+	ioutil.WriteFile(filePath2, []byte{1, 2}, os.ModeAppend)
+
+	// Lookup with file name, should find the one we wrote above
+	_, err = lookupTaskBin(tmpDir, "tmp.txt")
+	require.NoError(err)
+
+	// Lookup a host absolute path
+	_, err = lookupTaskBin(tmpDir, "/bin/sh")
+	require.Error(err)
+}
+
 // Exec Launch looks for the binary only inside the chroot
 func TestExecutor_EscapeContainer(t *testing.T) {
 	t.Parallel()

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	tu "github.com/hashicorp/nomad/testutil"
+	"github.com/kr/pretty"
 	ps "github.com/mitchellh/go-ps"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -415,8 +416,15 @@ func TestUniversalExecutor_LookupPath(t *testing.T) {
 	err = ioutil.WriteFile(filePath, []byte{1, 2}, os.ModeAppend)
 	require.Nil(err)
 
+	pretty.Log(tmpDir)
+	pretty.Log(filePath)
+
 	// Lookup with full path to binary
 	_, err = lookupBin("dummy", filePath)
+	require.Nil(err)
+
+	// Lookout with an absolute path to the binary
+	_, err = lookupBin(tmpDir, "/foo/tmp.txt")
 	require.Nil(err)
 
 	// Write a file under local subdir
@@ -436,6 +444,13 @@ func TestUniversalExecutor_LookupPath(t *testing.T) {
 	_, err = lookupBin(tmpDir, "tmp.txt")
 	require.Nil(err)
 
+	// Lookup a host path
+	_, err = lookupBin(tmpDir, "/bin/sh")
+	require.Error(err)
+
+	// Lookup a host path via $PATH
+	_, err = lookupBin(tmpDir, "sh")
+	require.Error(err)
 }
 
 // setupRoootfs setups the rootfs for libcontainer executor

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -452,41 +452,6 @@ func TestUniversalExecutor_LookupPath(t *testing.T) {
 	require.NoError(err)
 }
 
-func TestUniversalExecutor_LookupTaskBin(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
-
-	// Create a temp dir
-	tmpDir, err := ioutil.TempDir("", "")
-	require.Nil(err)
-	defer os.Remove(tmpDir)
-
-	// Make a foo subdir
-	os.MkdirAll(filepath.Join(tmpDir, "foo"), 0700)
-
-	// Write a file under foo
-	filePath := filepath.Join(tmpDir, "foo", "tmp.txt")
-	err = ioutil.WriteFile(filePath, []byte{1, 2}, os.ModeAppend)
-	require.NoError(err)
-
-	// Lookout with an absolute path to the binary
-	_, err = lookupTaskBin(tmpDir, "/foo/tmp.txt")
-	require.NoError(err)
-
-	// Write a file under local subdir
-	os.MkdirAll(filepath.Join(tmpDir, "local"), 0700)
-	filePath2 := filepath.Join(tmpDir, "local", "tmp.txt")
-	ioutil.WriteFile(filePath2, []byte{1, 2}, os.ModeAppend)
-
-	// Lookup with file name, should find the one we wrote above
-	_, err = lookupTaskBin(tmpDir, "tmp.txt")
-	require.NoError(err)
-
-	// Lookup a host absolute path
-	_, err = lookupTaskBin(tmpDir, "/bin/sh")
-	require.Error(err)
-}
-
 // setupRoootfs setups the rootfs for libcontainer executor
 // It uses busybox to make some binaries available - somewhat cheaper
 // than mounting the underlying host filesystem


### PR DESCRIPTION
When we're using a container, lookup the binary inside the chroot directory we've prepared rather than falling back to the host filesystem