### PR TITLE
Remove unnecessary locking and serverlist syncing in heartbeats

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2427,26 +2427,6 @@ DISCOLOOP:
 
 	consulLogger.Info("discovered following servers", "servers", nomadServers)
 
-	// Check if the list of servers discovered is identical to the list we already have
-	// If so, we don't need to reset the server list unnecessarily
-	knownServers := make(map[string]struct{})
-	serverList := c.servers.GetServers()
-	for _, s := range serverList {
-		knownServers[s.Addr.String()] = struct{}{}
-	}
-
-	allFound := true
-	for _, s := range nomadServers {
-		_, known := knownServers[s.Addr.String()]
-		if !known {
-			allFound = false
-			break
-		}
-	}
-	if allFound && len(nomadServers) == len(serverList) {
-		c.logger.Info("Not replacing server list, current server list is identical to servers discovered in Consul")
-		return nil
-	}
 	// Fire the retry trigger if we have updated the set of servers.
 	if c.servers.SetServers(nomadServers) {
 		// Start rebalancing

--- a/client/client.go
+++ b/client/client.go
@@ -315,6 +315,9 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulServic
 	// Initialize the server manager
 	c.servers = servers.New(c.logger, c.shutdownCh, c)
 
+	// Start server manager rebalancing go routine
+	go c.servers.Start()
+
 	// Initialize the client
 	if err := c.init(); err != nil {
 		return nil, fmt.Errorf("failed to initialize client: %v", err)
@@ -1345,7 +1348,6 @@ func (c *Client) registerAndHeartbeat() {
 		case <-c.shutdownCh:
 			return
 		}
-
 		if err := c.updateNodeStatus(); err != nil {
 			// The servers have changed such that this node has not been
 			// registered before
@@ -2342,13 +2344,6 @@ func (c *Client) consulDiscovery() {
 func (c *Client) consulDiscoveryImpl() error {
 	consulLogger := c.logger.Named("consul")
 
-	// Acquire heartbeat lock to prevent heartbeat from running
-	// concurrently with discovery. Concurrent execution is safe, however
-	// discovery is usually triggered when heartbeating has failed so
-	// there's no point in allowing it.
-	c.heartbeatLock.Lock()
-	defer c.heartbeatLock.Unlock()
-
 	dcs, err := c.consulCatalog.Datacenters()
 	if err != nil {
 		return fmt.Errorf("client.consul: unable to query Consul datacenters: %v", err)
@@ -2432,6 +2427,26 @@ DISCOLOOP:
 
 	consulLogger.Info("discovered following servers", "servers", nomadServers)
 
+	// Check if the list of servers discovered is identical to the list we already have
+	// If so, we don't need to reset the server list unnecessarily
+	knownServers := make(map[string]struct{})
+	serverList := c.servers.GetServers()
+	for _, s := range serverList {
+		knownServers[s.Addr.String()] = struct{}{}
+	}
+
+	allFound := true
+	for _, s := range nomadServers {
+		_, known := knownServers[s.Addr.String()]
+		if !known {
+			allFound = false
+			break
+		}
+	}
+	if allFound && len(nomadServers) == len(serverList) {
+		c.logger.Info("Not replacing server list, current server list is identical to servers discovered in Consul")
+		return nil
+	}
 	// Fire the retry trigger if we have updated the set of servers.
 	if c.servers.SetServers(nomadServers) {
 		// Start rebalancing

--- a/client/servers/manager.go
+++ b/client/servers/manager.go
@@ -204,7 +204,7 @@ func (m *Manager) SetServers(servers Servers) bool {
 	// Determine if they are equal
 	equal := m.serversAreEqual(servers)
 
-	// If server list is equal don't change the list and return immediatly
+	// If server list is equal don't change the list and return immediately
 	// This prevents unnecessary shuffling of a failed server that was moved to the
 	// bottom of the list
 	if equal {

--- a/client/servers/manager_test.go
+++ b/client/servers/manager_test.go
@@ -74,6 +74,11 @@ func TestServers_SetServers(t *testing.T) {
 	require.False(m.SetServers([]*servers.Server{s1, s2}))
 	after := m.GetServers()
 	require.Equal(before, after)
+
+	// Send a shuffled list, verify original order doesn't change
+	require.False(m.SetServers([]*servers.Server{s2, s1}))
+	afterShuffledInput := m.GetServers()
+	require.Equal(after, afterShuffledInput)
 }
 
 func TestServers_FindServer(t *testing.T) {

--- a/client/servers/manager_test.go
+++ b/client/servers/manager_test.go
@@ -66,6 +66,14 @@ func TestServers_SetServers(t *testing.T) {
 	require.True(m.SetServers([]*servers.Server{s1}))
 	require.Equal(1, m.NumServers())
 	require.Len(m.GetServers(), 1)
+
+	// Test that the list of servers does not get shuffled
+	// as a side effect when incoming list is equal
+	require.True(m.SetServers([]*servers.Server{s1, s2}))
+	before := m.GetServers()
+	require.False(m.SetServers([]*servers.Server{s1, s2}))
+	after := m.GetServers()
+	require.Equal(before, after)
 }
 
 func TestServers_FindServer(t *testing.T) {

--- a/dev/cluster/client1.hcl
+++ b/dev/cluster/client1.hcl
@@ -7,6 +7,9 @@ data_dir = "/tmp/client1"
 # Give the agent a unique name. Defaults to hostname
 name = "client1"
 
+# Enable debugging
+enable_debug = true
+
 # Enable the client
 client {
   enabled = true

--- a/dev/cluster/client2.hcl
+++ b/dev/cluster/client2.hcl
@@ -7,6 +7,9 @@ data_dir = "/tmp/client2"
 # Give the agent a unique name. Defaults to hostname
 name = "client2"
 
+# Enable debugging
+enable_debug = true
+
 # Enable the client
 client {
   enabled = true

--- a/dev/cluster/client3.hcl
+++ b/dev/cluster/client3.hcl
@@ -7,6 +7,9 @@ data_dir = "/tmp/client3"
 # Give the agent a unique name. Defaults to hostname
 name = "client3"
 
+# Enable debugging
+enable_debug = true
+
 # Enable the client
 client {
   enabled = true

--- a/dev/cluster/server1.hcl
+++ b/dev/cluster/server1.hcl
@@ -16,5 +16,5 @@ server {
   }
 
   # Self-elect, should be 3 or 5 for production
-  bootstrap_expect = 1
+  bootstrap_expect = 3
 }

--- a/dev/cluster/server1.hcl
+++ b/dev/cluster/server1.hcl
@@ -16,5 +16,5 @@ server {
   }
 
   # Self-elect, should be 3 or 5 for production
-  bootstrap_expect = 3
+  bootstrap_expect = 1
 }


### PR DESCRIPTION
This removes an unnecessary shared lock between discovery and heartbeating
which was causing heartbeats to be missed upon retries when a single server
fails. Also made a drive by fix to call the periodic server shuffler goroutine. 

I took some of the approach in #4688, but have kept the triggerDiscovery logic upon failure with the change that the server list is not retouched if the discovered servers are same as existing servers. 

Fixes #4666

Prior to this change, running a three server cluster where one of the servers is arbitrarily paused caused many unnecessary reschedule events due the clients being considered lost. With this change, I see a dramatic difference, with the caveat that if a server is paused when a client is about to send its hearbeat and there's not enough grace period left for it to retry another server, it will still be considered a missed heartbeat. 