### PR TITLE
docs: add lots of links to plugin guide

### DIFF
--- a/website/source/docs/devices/community.html.md
+++ b/website/source/docs/devices/community.html.md
@@ -15,5 +15,8 @@ file a PR to add your plugin to this page.
 ## Authoring Device Plugins
 
 Nomad has a plugin system for defining device drivers. External device plugins
-will have the same user experience as built in drivers. For details on authoring
-a device plugin, please refer to the plugin authoring guide.
+will have the same user experience as built in drivers. For details on
+authoring a device plugin, please refer to the [plugin authoring
+guide][plugin_guide].
+
+[plugin_guide]: /docs/internals/plugins/index.html

--- a/website/source/docs/devices/index.html.md
+++ b/website/source/docs/devices/index.html.md
@@ -18,3 +18,8 @@ The list of supported device plugins is provided on the left of this page.
 Each device plugin documents its configuration and installation requirements,
 the attributes it fingerprints, and the environment variables it exposes to
 tasks.
+
+For details on authoring a device plugin, please refer to the [plugin authoring
+guide][plugin_guide].
+
+[plugin_guide]: /docs/internals/plugins/index.html

--- a/website/source/docs/drivers/external/index.html.md
+++ b/website/source/docs/drivers/external/index.html.md
@@ -12,6 +12,9 @@ If you have authored a task driver plugin that you believe will be useful to the
 broader Nomad community and you are committed to maintaining the plugin, please
 file a PR to add your plugin to this page.
 
+For details on authoring a task driver plugin, please refer to the [plugin
+authoring guide][plugin_guide].
+
 ## Task Driver Plugins
 
 Nomad has a plugin system for defining task drivers. External task driver
@@ -23,4 +26,5 @@ Below is a list of community-supported task drivers you can use with Nomad:
 - [Singularity][singularity]
 
 [lxc]: /docs/drivers/external/lxc.html
+[plugin_guide]: /docs/internals/plugins/index.html
 [singularity]: /docs/drivers/external/singularity.html

--- a/website/source/docs/drivers/index.html.md
+++ b/website/source/docs/drivers/index.html.md
@@ -26,11 +26,9 @@ task driver documents the configuration available in a [job
 specification](/docs/job-specification/index.html), the environments it can be
 used in, and the resource isolation mechanisms available.
 
-Nomad strives to mask the details of running a task from users and instead
-provides a clean abstraction. It is possible for the same task to be executed
-with different isolation levels depending on the client running the task. The
-goal is to use the strictest isolation available and gracefully degrade
-protections where necessary.
+For details on authoring a task driver plugin, please refer to the [plugin
+authoring guide][plugin_guide].
 
 [plugin]: /docs/configuration/plugin.html
 [docker_plugin]: /docs/drivers/docker.html#client-requirements
+[plugin_guide]: /docs/internals/plugins/index.html


### PR DESCRIPTION
Add links to plugin guide because its buried under Docs -> Internal. At
least one user couldn't find it:

https://groups.google.com/d/msg/nomad-tool/5sR8MTGZFrM/8bOExpcJAgAJ

Link from:
 - Devices index
 - Devices community page
 - Drivers index
 - Drivers community page

I erred on the side of over-linking because it's just a single concise
sentence and I'd hate for people to struggle finding the guide.

Also remove some very old (4 years!) and confusing docs from the driver
index page.