### PR TITLE
remove Index field from EmitNodeEventsResponse

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1282,7 +1282,6 @@ type EmitNodeEventsRequest struct {
 // EmitNodeEventsResponse is a response to the client about the status of
 // the node event source update.
 type EmitNodeEventsResponse struct {
-	Index uint64
 	WriteMeta
 }
 


### PR DESCRIPTION
`Index` is already included as part of `WriteMeta` embedding.

This is a backward compatible change: Clients never read the field; and
Server refernces to `EmitNodeEventsResponse.Index` would be using the
value in `WriteMeta`, which is consistent with other response structs.