### PR TITLE
add non-empty string validation for datacenters

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3382,6 +3382,12 @@ func (j *Job) Validate() error {
 	}
 	if len(j.Datacenters) == 0 {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing job datacenters"))
+	} else {
+		for _, v := range j.Datacenters {
+			if v == "" {
+				mErr.Errors = append(mErr.Errors, errors.New("Job datacenter must be non-empty string"))
+			}
+		}
 	}
 	if len(j.TaskGroups) == 0 {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing job task groups"))

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -110,6 +110,16 @@ func TestJob_Validate(t *testing.T) {
 	if !strings.Contains(mErr.Errors[2].Error(), "Task group web validation failed") {
 		t.Fatalf("err: %s", err)
 	}
+
+	// test for empty datacenters
+	j = &Job{
+		Datacenters: []string{""},
+	}
+	err = j.Validate()
+	mErr = err.(*multierror.Error)
+	if !strings.Contains(mErr.Error(), "datacenter must be non-empty string") {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestJob_Warnings(t *testing.T) {


### PR DESCRIPTION
## Overview
Currently the command agent accepts jobs with empty-string datacenters

## Implementation
Add empty-string check to job validation in `nomad/structs/structs.go`

## TODO
- [ ] ~clean up tests (--> parameterize job validation tests?)~ parameterization not necessary for these tests