### PR TITLE
docs: Change querystring -> query string

### DIFF
--- a/website/source/api/allocations.html.md
+++ b/website/source/api/allocations.html.md
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")`- Specifies a string to filter allocations on based on
-  an index prefix. This is specified as a querystring parameter.
+  an index prefix. This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/deployments.html.md
+++ b/website/source/api/deployments.html.md
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")`- Specifies a string to filter deployments based on
-  an index prefix. This is specified as a querystring parameter.
+  an index prefix. This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/evaluations.html.md
+++ b/website/source/api/evaluations.html.md
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")`- Specifies a string to filter evaluations on based on
-  an index prefix. This is specified as a querystring parameter.
+  an index prefix. This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")` - Specifies a string to filter jobs on based on
-  an index prefix. This is specified as a querystring parameter.
+  an index prefix. This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/metrics.html.md
+++ b/website/source/api/metrics.html.md
@@ -26,7 +26,7 @@ The table below shows this endpoint's support for
 
 - `format` `(string: "")` - Specifies the metrics format to be other than the
   JSON default. Currently, only `prometheus` is supported as an alternative
-  format. This is specified as a querystring parameter.
+  format. This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/namespaces.html.md
+++ b/website/source/api/namespaces.html.md
@@ -32,7 +32,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")`- Specifies a string to filter namespaces on based on
-  an index prefix. This is specified as a querystring parameter.
+  an index prefix. This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/nodes.html.md
+++ b/website/source/api/nodes.html.md
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")`- Specifies a string to filter nodes on based on an
-  index prefix. This is specified as a querystring parameter.
+  index prefix. This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/operator.html.md
+++ b/website/source/api/operator.html.md
@@ -39,7 +39,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `stale` - Specifies if the cluster should respond without an active leader.
-  This is specified as a querystring parameter.
+  This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/quotas.html.md
+++ b/website/source/api/quotas.html.md
@@ -32,7 +32,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")`- Specifies a string to filter quota specifications on
-  based on an index prefix. This is specified as a querystring parameter.
+  based on an index prefix. This is specified as a query string parameter.
 
 ### Sample Request
 
@@ -228,7 +228,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")`- Specifies a string to filter quota specifications on
-  based on an index prefix. This is specified as a querystring parameter.
+  based on an index prefix. This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/ui.html.md
+++ b/website/source/api/ui.html.md
@@ -23,19 +23,19 @@ This page lists all known jobs in a paginated, searchable, and sortable table.
 ### Parameters
 
 - `namespace` `(string: "")` - Specifies the namespace all jobs should be a member
-  of. This is specified as a querystring parameter. Namespaces are an enterprise feature.
+  of. This is specified as a query string parameter. Namespaces are an enterprise feature.
 
 - `sort` `(string: "")` - Specifies the property the list of jobs should be sorted by.
-  This is specified as a querystring parameter.
+  This is specified as a query string parameter.
 
 - `desc` `(boolean: false)` - Specifies whether or not the sort direction is descending
-  or ascending. This is specified as a querystring parameter.
+  or ascending. This is specified as a query string parameter.
 
 - `search` `(string: "")` - Specifies a regular expression uses to filter the list of
-  visible jobs. This is specified as a querystring parameter.
+  visible jobs. This is specified as a query string parameter.
 
 - `page` `(int: 0)` - Specifies the page in the jobs list that should be visible. This
-  is specified as a querystring parameter.
+  is specified as a query string parameter.
 
 
 ## Job Detail
@@ -74,13 +74,13 @@ based on the type of job.
 ### Parameters
 
 - `sort` `(string: "")` - Specifies the property the list of task groups should be
-  sorted by. This is specified as a querystring parameter.
+  sorted by. This is specified as a query string parameter.
 
 - `desc` `(boolean: false)` - Specifies whether or not the sort direction is descending
-  or ascending. This is specified as a querystring parameter.
+  or ascending. This is specified as a query string parameter.
 
 - `page` `(int: 0)` - Specifies the page in the task groups list that should be visible. This
-  is specified as a querystring parameter.
+  is specified as a query string parameter.
 
 
 ### Job Definition
@@ -133,16 +133,16 @@ allocations.
 ### Parameters
 
 - `sort` `(string: "")` - Specifies the property the list of allocations should be sorted by.
-  This is specified as a querystring parameter.
+  This is specified as a query string parameter.
 
 - `desc` `(boolean: false)` - Specifies whether or not the sort direction is descending
-  or ascending. This is specified as a querystring parameter.
+  or ascending. This is specified as a query string parameter.
 
 - `search` `(string: "")` - Specifies a regular expression uses to filter the list of
-  visible allocations. This is specified as a querystring parameter.
+  visible allocations. This is specified as a query string parameter.
 
 - `page` `(int: 0)` - Specifies the page in the allocations list that should be visible. This
-  is specified as a querystring parameter.
+  is specified as a query string parameter.
 
 
 ## Allocation Detail
@@ -160,10 +160,10 @@ description of the event.
 ### Parameters
 
 - `sort` `(string: "")` - Specifies the property the list of tasks should be sorted by.
-  This is specified as a querystring parameter.
+  This is specified as a query string parameter.
 
 - `desc` `(boolean: false)` - Specifies whether or not the sort direction is descending
-  or ascending. This is specified as a querystring parameter.
+  or ascending. This is specified as a query string parameter.
 
 
 ## Task Detail
@@ -199,16 +199,16 @@ table.
 ### Parameters
 
 - `sort` `(string: "")` - Specifies the property the list of client nodes should be sorted by.
-  This is specified as a querystring parameter.
+  This is specified as a query string parameter.
 
 - `desc` `(boolean: false)` - Specifies whether or not the sort direction is descending
-  or ascending. This is specified as a querystring parameter.
+  or ascending. This is specified as a query string parameter.
 
 - `search` `(string: "")` - Specifies a regular expression uses to filter the list of
-  visible client nodes. This is specified as a querystring parameter.
+  visible client nodes. This is specified as a query string parameter.
 
 - `page` `(int: 0)` - Specifies the page in the client nodes list that should be visible. This
-  is specified as a querystring parameter.
+  is specified as a query string parameter.
 
 
 ## Node Detail
@@ -223,16 +223,16 @@ address, port, datacenter, allocations, and attributes.
 ### Parameters
 
 - `sort` `(string: "")` - Specifies the property the list of allocations should be sorted by.
-  This is specified as a querystring parameter.
+  This is specified as a query string parameter.
 
 - `desc` `(boolean: false)` - Specifies whether or not the sort direction is descending
-  or ascending. This is specified as a querystring parameter.
+  or ascending. This is specified as a query string parameter.
 
 - `search` `(string: "")` - Specifies a regular expression uses to filter the list of
-  visible allocations. This is specified as a querystring parameter.
+  visible allocations. This is specified as a query string parameter.
 
 - `page` `(int: 0)` - Specifies the page in the allocations list that should be visible. This
-  is specified as a querystring parameter.
+  is specified as a query string parameter.
 
 
 ## Servers List
@@ -248,13 +248,13 @@ the leader.
 ### Parameters
 
 - `sort` `(string: "")` - Specifies the property the list of server agents should be sorted by.
-  This is specified as a querystring parameter.
+  This is specified as a query string parameter.
 
 - `desc` `(boolean: false)` - Specifies whether or not the sort direction is descending
-  or ascending. This is specified as a querystring parameter.
+  or ascending. This is specified as a query string parameter.
 
 - `page` `(int: 0)` - Specifies the page in the server agents list that should be visible. This
-  is specified as a querystring parameter.
+  is specified as a query string parameter.
 
 
 ## Server Detail


### PR DESCRIPTION
Submitting for comment: It appears that "query string" is the more commonly used form and aligns with the original RFC text.  