### PR TITLE
fix flaky test by allowing for call invocation overhead

### DIFF
--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -886,9 +886,10 @@ func TestConsul_ShutdownSlow(t *testing.T) {
 		t.Errorf("unexpected error shutting down client: %v", err)
 	}
 
-	// Shutdown time should have taken: 1s <= shutdown <= 3s
+	// Shutdown time should have taken: ~1s <= shutdown <= 3s
+	// actual timing might be less than 1s, to account for shutdown invocation overhead
 	shutdownTime := time.Now().Sub(preShutdown)
-	if shutdownTime < time.Second || shutdownTime > ctx.ServiceClient.shutdownWait {
+	if shutdownTime < 900*time.Millisecond || shutdownTime > ctx.ServiceClient.shutdownWait {
 		t.Errorf("expected shutdown to take >1s and <%s but took: %s", ctx.ServiceClient.shutdownWait, shutdownTime)
 	}
 


### PR DESCRIPTION
Noticed this in few builds, e.g.:

https://travis-ci.org/hashicorp/nomad/jobs/525716356
https://travis-ci.org/hashicorp/nomad/jobs/529852028
https://travis-ci.org/hashicorp/nomad/jobs/527599410
https://travis-ci.org/hashicorp/nomad/jobs/525474780
https://travis-ci.org/hashicorp/nomad/jobs/528883311
https://travis-ci.org/hashicorp/nomad/jobs/526579271
https://travis-ci.org/hashicorp/nomad/jobs/527916905
https://travis-ci.org/hashicorp/nomad/jobs/527367107
