### PR TITLE
UI: Fixed flaky client-detail test

### DIFF
--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -25,8 +25,14 @@ module('Acceptance | client detail', function(hooks) {
     // Related models
     server.create('agent');
     server.create('job', { createAllocations: false });
-    server.createList('allocation', 3, { nodeId: node.id, clientStatus: 'running' });
-    server.create('allocation', 'preempted', { nodeId: node.id, clientStatus: 'running' });
+    server.createList('allocation', 3);
+    server.create('allocation', 'preempted');
+
+    // Force all allocations into the running state so now allocation rows are missing
+    // CPU/Mem runtime metrics
+    server.schema.allocations.all().models.forEach(allocation => {
+      allocation.update({ clientStatus: 'running' });
+    });
   });
 
   test('/clients/:id should have a breadcrumb trail linking back to clients', async function(assert) {


### PR DESCRIPTION
Since one allocation is preempted, the alloc factory creates a new alloc
that wasn't guaranteed to be running. When it is the first alloc row in
the table, then the alloc row detail test fails because non-running
allocs don't have metrics. The fix was to manually update all the alloc
clientStatuses.

Test flakiness introduced in #5594 