### PR TITLE
Add CircleCI Configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,4 +240,5 @@ commands:
               unset GOTEST_PKGS
             fi
 
+            sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make generate-structs
             sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make test-nomad

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,23 +221,12 @@ commands:
             && rm -rf /tmp/consul*
 
   install-protoc:
-    parameters:
-      version:
-        type: string
-        default: 3.6.1
     steps:
       - run:
           name: install protoc
           command: |
             sudo rm -rf /usr/bin/protoc
-
-            wget -q -O /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v<< parameters.version >>/protoc-<< parameters.version >>-linux-x86_64.zip \
-                && unzip /tmp/protoc.zip -d /tmp/protoc3 \
-                && sudo mv /tmp/protoc3/bin/* /usr/local/bin/ \
-                && sudo mv /tmp/protoc3/include/* /usr/local/include/ \
-                && sudo ln -s /usr/local/bin/protoc /usr/bin/protoc \
-                && rm -rf /tmp/protoc*
-
+            sudo ./scripts/vagrant-linux-priv-protoc.sh
 
   run-tests:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,8 +162,6 @@ jobs:
             unset GOTEST_PKGS
           fi
 
-          env
-
           sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make test-nomad
       - store_test_results:
           path: /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,129 @@
-version: 2
+version: 2.1
+
+executors:
+  go:
+    working_directory: ~/go/src/github.com/hashicorp/nomad
+    docker:
+      - image: dantoml/nomad-build-image:e8d69b1e8
+  go-machine:
+    working_directory: ~/go/src/github.com/hashicorp/nomad
+    machine:
+      image: circleci/classic:201808-01
+  docker-builder:
+    working_directory: ~/go/src/github.com/hashicorp/nomad
+    machine: true # TODO: Find latest docker image id
+
 jobs:
+  build-deps-image:
+    executor: docker-builder
+    steps:
+      - checkout
+      - run: docker pull dantoml/nomad-build-image:latest || true
+      - run: docker build -t dantoml/nomad-build-image:$CIRCLE_SHA1 ./.circleci/build-images/go
+      - run: docker push dantoml/nomad-build-image:$CIRCLE_SHA1
+
+  lint:
+    executor: go
+    environment:
+      GOPATH: /home/circleci/go
+    steps:
+      - checkout
+      - run: make check
+
+  test-container:
+    executor: go
+    parameters:
+      test_packages:
+        type: string
+        default: ""
+      exclude_packages:
+        type: string
+        default: ""
+    environment:
+      GOTEST_PKGS: "<< parameters.test_packages >>"
+      GOTEST_PKGS_EXCLUDE: "<< parameters.exclude_packages >>"
+      GOPATH: /home/circleci/go
+      GOTESTSUM_JUNITFILE: /tmp/results.xml
+      GOMAXPROCS: 1
+      NOMAD_SLOW_TEST: 1
+    steps:
+      - checkout
+      - run: |
+          if [ -z $GOTEST_PKGS_EXCLUDE ];
+          then
+            unset GOTEST_PKGS_EXCLUDE
+          else
+            unset GOTEST_PKGS
+          fi
+          make test-nomad
+      - store_test_results:
+          path: /tmp
+
+  test-machine:
+    executor: go-machine
+    parameters:
+      test_packages:
+        type: string
+        default: ""
+      exclude_packages:
+        type: string
+        default: ""
+    environment:
+      GOTEST_PKGS_EXCLUDE: "<< parameters.exclude_packages >>"
+      GOTEST_PKGS: "<< parameters.test_packages >>"
+      GOTESTSUM_JUNITFILE: /tmp/results.xml
+      GOPATH: /home/circleci/go
+      GOVERSION: 1.11.5
+      PROTOC_VERSION: 3.6.1
+      GOMAXPROCS: 1
+      NOMAD_SLOW_TEST: 1
+    steps:
+      - checkout
+      - run:
+          name: install go
+          command: |
+            sudo rm -rf /usr/local/go
+            wget https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
+      - run:
+          name: install protoc
+          command: |
+            sudo rm -rf /usr/bin/protoc
+
+            wget -q -O /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
+                && unzip /tmp/protoc.zip -d /tmp/protoc3 \
+                && sudo mv /tmp/protoc3/bin/* /usr/local/bin/ \
+                && sudo mv /tmp/protoc3/include/* /usr/local/include/ \
+                && sudo ln -s /usr/local/bin/protoc /usr/bin/protoc \
+                && rm -rf /tmp/protoc*
+      - run:
+          name: Install Vault/Consul
+          command: |
+            export VAULT_VERSION="1.1.0"
+            export CONSUL_VERSION="1.4.0"
+
+            wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip \
+            && sudo unzip -d /usr/local/bin /tmp/vault.zip \
+            && rm -rf /tmp/vault*
+
+            wget -q -O /tmp/consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip \
+            && sudo unzip -d /usr/local/bin /tmp/consul.zip \
+            && rm -rf /tmp/consul*
+      - run: PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make bootstrap
+      - run: |
+          if [ -z $GOTEST_PKGS_EXCLUDE ];
+          then
+            unset GOTEST_PKGS_EXCLUDE
+          else
+            unset GOTEST_PKGS
+          fi
+
+          env
+
+          sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make test-nomad
+      - store_test_results:
+          path: /tmp
+
   build-website:
     # setting the working_directory along with the checkout path allows us to not have
     # to cd into the website/ directory for commands
@@ -33,7 +157,39 @@ jobs:
           command: ./scripts/deploy.sh
 
 workflows:
-  version: 2
+  build-test:
+    jobs:
+      - lint
+      - test-machine:
+          name: "test-client"
+          test_packages: "./client/..."
+      - test-machine:
+          name: "test-nomad"
+          test_packages: "./nomad/..."
+      - test-container:
+          name: "test-api"
+          test_packages: "./api/..."
+      - test-container:
+          name: "test-devices"
+          test_packages: "./devices/..."
+      - test-machine:
+          name: "test-other"
+          exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/shared/executor|./nomad|./devices"
+      - test-machine:
+          name: "test-docker"
+          test_packages: "./drivers/docker"
+      - test-machine:
+          name: "test-exec"
+          test_packages: "./drivers/exec"
+      - test-machine:
+          name: "test-shared-exec"
+          test_packages: "./drivers/shared/executor"
+      # - build-deps-image:
+      #     context: dani-test
+      #     filters:
+      #       branches:
+      #         only: dani/circleci
+
   website:
     jobs:
       - build-website:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,50 @@ jobs:
       - store_test_results:
           path: /tmp
 
+  test-rkt:
+    executor: go-machine
+    environment:
+      GOTEST_PKGS: "./drivers/rkt"
+      GOTESTSUM_JUNITFILE: /tmp/results.xml
+      GOPATH: /home/circleci/go
+      GOVERSION: 1.12.1
+      PROTOC_VERSION: 3.6.1
+      GOMAXPROCS: 1
+      NOMAD_SLOW_TEST: 1
+      RKT_VERSION: 1.29.0
+    steps:
+      - checkout
+      - run:
+          name: install go
+          command: |
+            sudo rm -rf /usr/local/go
+            wget https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
+      - run:
+          name: install protoc
+          command: |
+            sudo rm -rf /usr/bin/protoc
+            wget -q -O /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
+                && unzip /tmp/protoc.zip -d /tmp/protoc3 \
+                && sudo mv /tmp/protoc3/bin/* /usr/local/bin/ \
+                && sudo mv /tmp/protoc3/include/* /usr/local/include/ \
+                && sudo ln -s /usr/local/bin/protoc /usr/bin/protoc \
+                && rm -rf /tmp/protoc*
+
+      - run:
+          name: install rkt
+          command: |
+            gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+            wget https://github.com/rkt/rkt/releases/download/v$RKT_VERSION/rkt_$RKT_VERSION-1_amd64.deb
+            wget https://github.com/rkt/rkt/releases/download/v$RKT_VERSION/rkt_$RKT_VERSION-1_amd64.deb.asc
+            gpg --verify rkt_$RKT_VERSION-1_amd64.deb.asc
+            sudo dpkg -i rkt_$RKT_VERSION-1_amd64.deb
+      - run: PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make bootstrap
+      - run: |
+          sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make test-nomad
+      - store_test_results:
+          path: /tmp
+
   test-machine:
     executor: go-machine
     parameters:
@@ -174,7 +218,7 @@ workflows:
           test_packages: "./devices/..."
       - test-machine:
           name: "test-other"
-          exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/shared/executor|./nomad|./devices"
+          exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/rkt|./drivers/shared/executor|./nomad|./devices"
       - test-machine:
           name: "test-docker"
           test_packages: "./drivers/docker"
@@ -184,6 +228,7 @@ workflows:
       - test-machine:
           name: "test-shared-exec"
           test_packages: "./drivers/shared/executor"
+      - test-rkt
       # - build-deps-image:
       #     context: dani-test
       #     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,49 @@
 version: 2.1
 
+references:
+  GO_VERSION: &GOVERSION 1.12.1
+workflows:
+  build-test:
+    jobs:
+      - lint
+      - test-machine:
+          name: "test-client"
+          test_packages: "./client/..."
+      - test-machine:
+          name: "test-nomad"
+          test_packages: "./nomad/..."
+      - test-container:
+          name: "test-api"
+          test_packages: "./api/..."
+      - test-container:
+          name: "test-devices"
+          test_packages: "./devices/..."
+      - test-machine:
+          name: "test-other"
+          exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/rkt|./drivers/shared/executor|./nomad|./devices"
+      - test-machine:
+          name: "test-docker"
+          test_packages: "./drivers/docker"
+      - test-machine:
+          name: "test-exec"
+          test_packages: "./drivers/exec"
+      - test-machine:
+          name: "test-shared-exec"
+          test_packages: "./drivers/shared/executor"
+      - test-rkt
+      # - build-deps-image:
+      #     context: dani-test
+      #     filters:
+      #       branches:
+      #         only: dani/circleci
+
+  website:
+    jobs:
+      - build-website:
+          context: static-sites
+          filters:
+            branches:
+              only: stable-website
 executors:
   go:
     working_directory: ~/go/src/github.com/hashicorp/nomad
@@ -48,14 +92,7 @@ jobs:
       NOMAD_SLOW_TEST: 1
     steps:
       - checkout
-      - run: |
-          if [ -z $GOTEST_PKGS_EXCLUDE ];
-          then
-            unset GOTEST_PKGS_EXCLUDE
-          else
-            unset GOTEST_PKGS
-          fi
-          make test-nomad
+      - run-tests
       - store_test_results:
           path: /tmp
 
@@ -65,8 +102,7 @@ jobs:
       GOTEST_PKGS: "./drivers/rkt"
       GOTESTSUM_JUNITFILE: /tmp/results.xml
       GOPATH: /home/circleci/go
-      GOVERSION: 1.12.1
-      PROTOC_VERSION: 3.6.1
+      GOVERSION: *GOVERSION
       GOMAXPROCS: 1
       NOMAD_SLOW_TEST: 1
       RKT_VERSION: 1.29.0
@@ -78,17 +114,7 @@ jobs:
             sudo rm -rf /usr/local/go
             wget https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
             sudo tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
-      - run:
-          name: install protoc
-          command: |
-            sudo rm -rf /usr/bin/protoc
-            wget -q -O /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
-                && unzip /tmp/protoc.zip -d /tmp/protoc3 \
-                && sudo mv /tmp/protoc3/bin/* /usr/local/bin/ \
-                && sudo mv /tmp/protoc3/include/* /usr/local/include/ \
-                && sudo ln -s /usr/local/bin/protoc /usr/bin/protoc \
-                && rm -rf /tmp/protoc*
-
+      - install-protoc
       - run:
           name: install rkt
           command: |
@@ -98,8 +124,7 @@ jobs:
             gpg --verify rkt_$RKT_VERSION-1_amd64.deb.asc
             sudo dpkg -i rkt_$RKT_VERSION-1_amd64.deb
       - run: PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make bootstrap
-      - run: |
-          sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make test-nomad
+      - run-tests
       - store_test_results:
           path: /tmp
 
@@ -117,8 +142,7 @@ jobs:
       GOTEST_PKGS: "<< parameters.test_packages >>"
       GOTESTSUM_JUNITFILE: /tmp/results.xml
       GOPATH: /home/circleci/go
-      GOVERSION: 1.11.5
-      PROTOC_VERSION: 3.6.1
+      GOVERSION: *GOVERSION
       GOMAXPROCS: 1
       NOMAD_SLOW_TEST: 1
     steps:
@@ -129,40 +153,11 @@ jobs:
             sudo rm -rf /usr/local/go
             wget https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
             sudo tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
-      - run:
-          name: install protoc
-          command: |
-            sudo rm -rf /usr/bin/protoc
-
-            wget -q -O /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
-                && unzip /tmp/protoc.zip -d /tmp/protoc3 \
-                && sudo mv /tmp/protoc3/bin/* /usr/local/bin/ \
-                && sudo mv /tmp/protoc3/include/* /usr/local/include/ \
-                && sudo ln -s /usr/local/bin/protoc /usr/bin/protoc \
-                && rm -rf /tmp/protoc*
-      - run:
-          name: Install Vault/Consul
-          command: |
-            export VAULT_VERSION="1.1.0"
-            export CONSUL_VERSION="1.4.0"
-
-            wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip \
-            && sudo unzip -d /usr/local/bin /tmp/vault.zip \
-            && rm -rf /tmp/vault*
-
-            wget -q -O /tmp/consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip \
-            && sudo unzip -d /usr/local/bin /tmp/consul.zip \
-            && rm -rf /tmp/consul*
+      - install-protoc
+      - install-consul
+      - install-vault
       - run: PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make bootstrap
-      - run: |
-          if [ -z $GOTEST_PKGS_EXCLUDE ];
-          then
-            unset GOTEST_PKGS_EXCLUDE
-          else
-            unset GOTEST_PKGS
-          fi
-
-          sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make test-nomad
+      - run-tests
       - store_test_results:
           path: /tmp
 
@@ -198,45 +193,62 @@ jobs:
           name: website deploy
           command: ./scripts/deploy.sh
 
-workflows:
-  build-test:
-    jobs:
-      - lint
-      - test-machine:
-          name: "test-client"
-          test_packages: "./client/..."
-      - test-machine:
-          name: "test-nomad"
-          test_packages: "./nomad/..."
-      - test-container:
-          name: "test-api"
-          test_packages: "./api/..."
-      - test-container:
-          name: "test-devices"
-          test_packages: "./devices/..."
-      - test-machine:
-          name: "test-other"
-          exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/rkt|./drivers/shared/executor|./nomad|./devices"
-      - test-machine:
-          name: "test-docker"
-          test_packages: "./drivers/docker"
-      - test-machine:
-          name: "test-exec"
-          test_packages: "./drivers/exec"
-      - test-machine:
-          name: "test-shared-exec"
-          test_packages: "./drivers/shared/executor"
-      - test-rkt
-      # - build-deps-image:
-      #     context: dani-test
-      #     filters:
-      #       branches:
-      #         only: dani/circleci
+commands:
+  install-vault:
+    parameters:
+      version:
+        type: string
+        default: 1.0.0
+    steps:
+      - run:
+          name: Install Vault << parameters.version >>
+          command: |
+            wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/<< parameters.version >>/vault_<< parameters.version>>_linux_amd64.zip \
+            && sudo unzip -d /usr/local/bin /tmp/vault.zip \
+            && rm -rf /tmp/vault*
 
-  website:
-    jobs:
-      - build-website:
-          context: static-sites
-          filters:
-            branches:
-              only: stable-website
+  install-consul:
+    parameters:
+      version:
+        type: string
+        default: 1.0.0
+    steps:
+      - run:
+          name: Install Consul << parameters.version >>
+          command: |
+            wget -q -O /tmp/consul.zip https://releases.hashicorp.com/consul/<< parameters.version >>/consul_<< parameters.version >>_linux_amd64.zip \
+            && sudo unzip -d /usr/local/bin /tmp/consul.zip \
+            && rm -rf /tmp/consul*
+
+  install-protoc:
+    parameters:
+      version:
+        type: string
+        default: 3.6.1
+    steps:
+      - run:
+          name: install protoc
+          command: |
+            sudo rm -rf /usr/bin/protoc
+
+            wget -q -O /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v<< parameters.version >>/protoc-<< parameters.version >>-linux-x86_64.zip \
+                && unzip /tmp/protoc.zip -d /tmp/protoc3 \
+                && sudo mv /tmp/protoc3/bin/* /usr/local/bin/ \
+                && sudo mv /tmp/protoc3/include/* /usr/local/include/ \
+                && sudo ln -s /usr/local/bin/protoc /usr/bin/protoc \
+                && rm -rf /tmp/protoc*
+
+
+  run-tests:
+    steps:
+      - run:
+          name: Running Nomad Tests
+          command: |
+            if [ -z $GOTEST_PKGS_EXCLUDE ];
+            then
+              unset GOTEST_PKGS_EXCLUDE
+            else
+              unset GOTEST_PKGS
+            fi
+
+            sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make test-nomad

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,9 @@ workflows:
       - test-machine:
           name: "test-nomad"
           test_packages: "./nomad/..."
-      - test-container:
+      - test-machine:
+          # API Tests run in a VM rather than container due to the FS tests
+          # requiring `mount` priviliges.
           name: "test-api"
           test_packages: "./api/..."
       - test-container:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  GO_VERSION: &GOVERSION 1.12.1
+  GO_VERSION: &GOVERSION 1.12.7
 workflows:
   build-test:
     jobs:
@@ -48,7 +48,7 @@ executors:
   go:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     docker:
-      - image: dantoml/nomad-build-image:e8d69b1e8
+      - image: hashicorpnomad/ci-build-image:20190812
   go-machine:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     machine:
@@ -62,9 +62,8 @@ jobs:
     executor: docker-builder
     steps:
       - checkout
-      - run: docker pull dantoml/nomad-build-image:latest || true
-      - run: docker build -t dantoml/nomad-build-image:$CIRCLE_SHA1 ./.circleci/build-images/go
-      - run: docker push dantoml/nomad-build-image:$CIRCLE_SHA1
+      - run: docker build -t hashicorpnomad/ci-build-image:$CIRCLE_SHA1 . -f ./Dockerfile.ci
+      - run: docker push hashicorpnomad/ci-build-image:$CIRCLE_SHA1
 
   lint:
     executor: go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
               only: stable-website
 executors:
   go:
-    working_directory: ~/go/src/github.com/hashicorp/nomad
+    working_directory: /go/src/github.com/hashicorp/nomad
     docker:
       - image: hashicorpnomad/ci-build-image:20190812
   go-machine:
@@ -68,7 +68,7 @@ jobs:
   lint:
     executor: go
     environment:
-      GOPATH: /home/circleci/go
+      GOPATH: /go
     steps:
       - checkout
       - run: make check
@@ -85,7 +85,7 @@ jobs:
     environment:
       GOTEST_PKGS: "<< parameters.test_packages >>"
       GOTEST_PKGS_EXCLUDE: "<< parameters.exclude_packages >>"
-      GOPATH: /home/circleci/go
+      GOPATH: /go
       GOTESTSUM_JUNITFILE: /tmp/results.xml
       GOMAXPROCS: 1
       NOMAD_SLOW_TEST: 1

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,32 @@
+FROM circleci/golang:1.11.5
+ENV PROTOC_VERSION 3.6.1
+ENV VAULT_VERSION 1.1.0
+ENV CONSUL_VERSION 1.4.0
+
+RUN sudo apt-get update \
+    && sudo apt-get -y upgrade \
+    && sudo apt-get install -y unzip \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+COPY GNUmakefile ./
+COPY ./scripts/ ./scripts/
+
+RUN make bootstrap \
+      && rm GNUmakefile \
+      && sudo rm -rf scripts
+
+RUN wget -q -O /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
+    && unzip /tmp/protoc.zip -d /tmp/protoc3 \
+    && sudo mv /tmp/protoc3/bin/* /usr/local/bin/ \
+    && sudo mv /tmp/protoc3/include/* /usr/local/include/ \
+    && sudo ln -s /usr/local/bin/protoc /usr/bin/protoc \
+    && rm -rf /tmp/protoc*
+
+RUN wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip \
+    && sudo unzip -d /usr/local/bin /tmp/vault.zip \
+    && rm -rf /tmp/vault*
+
+RUN wget -q -O /tmp/consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip \
+    && sudo unzip -d /usr/local/bin /tmp/consul.zip \
+    && rm -rf /tmp/consul*
+

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.11.5
+FROM circleci/golang:1.12.7
 ENV PROTOC_VERSION 3.6.1
 ENV VAULT_VERSION 1.1.0
 ENV CONSUL_VERSION 1.4.0
@@ -8,12 +8,10 @@ RUN sudo apt-get update \
     && sudo apt-get install -y unzip \
     && sudo rm -rf /var/lib/apt/lists/*
 
-COPY GNUmakefile ./
-COPY ./scripts/ ./scripts/
-
-RUN make bootstrap \
-      && rm GNUmakefile \
-      && sudo rm -rf scripts
+## Add the git repo and run bootstrap to install CI dependencies, then remove
+## the extra checkout to save image size.
+COPY . /tmp/build
+RUN cd /tmp/build && sudo chown -R $(whoami) /tmp/build && make bootstrap && rm -rf /tmp/build
 
 RUN wget -q -O /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
     && unzip /tmp/protoc.zip -d /tmp/protoc3 \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,11 @@ endif
 # On Linux we build for Linux and Windows
 ifeq (Linux,$(THIS_OS))
 
-VERBOSE="true"
+ifeq ($(CI),true)
+	$(info Running in a CI environment, verbose mode is disabled)
+else
+	VERBOSE="true"
+endif
 
 
 ALL_TARGETS += linux_386 \
@@ -270,7 +274,10 @@ test-nomad: dev ## Run Nomad test suites
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
 		-timeout=15m \
-		$(GOTEST_PKGS)
+		$(GOTEST_PKGS) $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
+	@if [ $(VERBOSE) ] ; then \
+		bash -C "$(PROJECT_ROOT)/scripts/test_check.sh" ; \
+	fi
 
 .PHONY: e2e-test
 e2e-test: dev ## Run the Nomad e2e test suite

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,11 +25,7 @@ endif
 # On Linux we build for Linux and Windows
 ifeq (Linux,$(THIS_OS))
 
-ifeq ($(TRAVIS),true)
-$(info Running in Travis, verbose mode is disabled)
-else
 VERBOSE="true"
-endif
 
 
 ALL_TARGETS += linux_386 \
@@ -274,10 +270,7 @@ test-nomad: dev ## Run Nomad test suites
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
 		-timeout=15m \
-		$(GOTEST_PKGS) $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
-	@if [ $(VERBOSE) ] ; then \
-		bash -C "$(PROJECT_ROOT)/scripts/test_check.sh" ; \
-	fi
+		$(GOTEST_PKGS)
 
 .PHONY: e2e-test
 e2e-test: dev ## Run the Nomad e2e test suite

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -356,6 +356,7 @@ help: ## Display this usage information
 	@echo "This host will build the following targets if 'make release' is invoked:"
 	@echo $(ALL_TARGETS) | sed 's/^/    /'
 
+.PHONY: ui-screenshots
 ui-screenshots:
 	@echo "==> Collecting UI screenshots..."
 	# Build the screenshots image if it doesn't exist yet
@@ -367,6 +368,14 @@ ui-screenshots:
 		--volume "$(shell pwd)/scripts/screenshots/screenshots:/screenshots" \
 		nomad-ui-screenshots
 
+.PHONY: ui-screenshots-local
 ui-screenshots-local:
 	@echo "==> Collecting UI screenshots (local)..."
 	@cd scripts/screenshots/src && SCREENSHOTS_DIR="../screenshots" node index.js
+
+.PHONY: ci-image
+ci-image:
+	@echo "==> Building CI Image hashicorpnomad/ci-build-image:$(date %Y%m%d)"
+	@docker build . -f Dockerfile.ci -t hashicorpnomad/ci-build-image:$(date %Y%m%d)
+	@echo "To push the image, run `docker push -t hashicorpnomad/ci-build-image:$(date %Y%m%d)"
+


### PR DESCRIPTION
This PR introduces a basic configuration for testing Nomad on CircleCI.

We have to use the Machine executor in various places due to running
into memory limits during compilation, and issues with CPU related to
golang NumCPUs ignoring cgroup limits. This is also required in
environments where we need a full root user for things like Docker
daemons or running `exec` tests.

I'd like to run CircleCI and Travis in parallel for a couple of weeks
to get an idea of flakiness and to find any issues before migrating
completely.