### PR TITLE
implement nomad exec for rkt

### DIFF
--- a/command/node_config.go
+++ b/command/node_config.go
@@ -82,7 +82,7 @@ func (c *NodeConfigCommand) Run(args []string) int {
 	if updateServers {
 		// Get the server addresses
 		if len(args) == 0 {
-			c.Ui.Error("If the '-update-servers' flag is set, atleast one server argument must be provided")
+			c.Ui.Error("If the '-update-servers' flag is set, at least one server argument must be provided")
 			c.Ui.Error(commandErrorText(c))
 			return 1
 		}

--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -506,7 +506,7 @@ func (d *Driver) SignalTask(taskID string, signal string) error {
 
 func (d *Driver) ExecTask(taskID string, cmd []string, timeout time.Duration) (*drivers.ExecTaskResult, error) {
 	if len(cmd) == 0 {
-		return nil, fmt.Errorf("error cmd must have atleast one value")
+		return nil, fmt.Errorf("error cmd must have at least one value")
 	}
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {
@@ -540,7 +540,7 @@ func (d *Driver) ExecTaskStreamingRaw(ctx context.Context,
 	stream drivers.ExecTaskStream) error {
 
 	if len(command) == 0 {
-		return fmt.Errorf("error cmd must have atleast one value")
+		return fmt.Errorf("error cmd must have at least one value")
 	}
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -563,7 +563,7 @@ func (d *Driver) ExecTaskStreamingRaw(ctx context.Context,
 	stream drivers.ExecTaskStream) error {
 
 	if len(command) == 0 {
-		return fmt.Errorf("error cmd must have atleast one value")
+		return fmt.Errorf("error cmd must have at least one value")
 	}
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {

--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -863,7 +863,7 @@ func (d *Driver) SignalTask(taskID string, signal string) error {
 
 func (d *Driver) ExecTask(taskID string, cmdArgs []string, timeout time.Duration) (*drivers.ExecTaskResult, error) {
 	if len(cmdArgs) == 0 {
-		return nil, fmt.Errorf("error cmd must have atleast one value")
+		return nil, fmt.Errorf("error cmd must have at least one value")
 	}
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {
@@ -900,7 +900,7 @@ func (d *Driver) ExecTaskStreamingRaw(ctx context.Context,
 	stream drivers.ExecTaskStream) error {
 
 	if len(command) == 0 {
-		return fmt.Errorf("error cmd must have atleast one value")
+		return fmt.Errorf("error cmd must have at least one value")
 	}
 	handle, ok := d.tasks.Get(taskID)
 	if !ok {


### PR DESCRIPTION
Implement the streaming exec handler for the rkt driver, by invoking `rkt enter` command.

Sequel to #5632 and #5634