### PR TITLE
Add jrasell/sherpa to resource page and remove Replicator.

### DIFF
--- a/website/source/resources.html.erb
+++ b/website/source/resources.html.erb
@@ -169,7 +169,7 @@ description: |-
   <li><a href="https://apache.github.io/incubator-heron/docs/operators/deployment/schedulers/nomad/">Apache Heron Nomad Integration</a> - Realtime, Distributed Stream Processing on Nomad</li>
   <li><a href="https://github.com/jet/nomad-service-alerter"><strong>Jet.com</strong> Nomad Service Alerter</a> - Alerting for your Nomad services</li>
   <li><a href="https://getnelson.github.io/nelson/">Nelson</a> - Automated, Multi-region Container Deployment with HashiCorp Nomad</li>
-  <li><a href="https://github.com/elsevier-core-engineering/replicator"><strong>Elsevier</strong> Replicator</a> - Automated Cluster and Job Scaling For HashiCorp Nomad</li>
+  <li><a href="https://github.com/jrasell/sherpa">Sherpa</a> - A job scaler for HashiCorp Nomad that aims to be highly flexible so it can support a wide range of architectures and budgets</li>
   <li><a href="https://github.com/jrasell/levant">Levant</a> - An open source templating and deployment tool for HashiCorp Nomad jobs</li>
   <li><a href="https://github.com/underarmour/libra"><strong>Under Armour</strong> Libra</a> - A Nomad Auto Scaler</li>
   <li><a href="https://docs.datadoghq.com/integrations/nomad">Datadog Nomad Integration</a> - Monitor Nomad Clusters with Datadog</li>


### PR DESCRIPTION
Adds jrasell/sherpa to the resources page under the Integrations
section.

Replicator is no longer being maintained or has been under active
development for well over a year. I have therefore removed this
from the resources page.