### PR TITLE
Change clients/jobs facets to always right-align

### DIFF
--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -3,14 +3,14 @@
     {{partial "partials/forbidden-message"}}
   {{else}}
     <div class="toolbar">
-      {{#if nodes.length}}
-        <div class="toolbar-item">
+      <div class="toolbar-item">
+        {{#if nodes.length}}
           {{search-box
             searchTerm=(mut searchTerm)
             onChange=(action resetPagination)
             placeholder="Search clients..."}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </div>
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
           {{multi-select-dropdown

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -3,15 +3,15 @@
     {{partial "partials/forbidden-message"}}
   {{else}}
     <div class="toolbar">
-      {{#if visibleJobs.length}}
-        <div class="toolbar-item">
+      <div class="toolbar-item">
+        {{#if visibleJobs.length}}
           {{search-box
             data-test-jobs-search
             searchTerm=(mut searchTerm)
             onChange=(action resetPagination)
             placeholder="Search jobs..."}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </div>
       {{#if (media "isMobile")}}
         <div class="toolbar-item is-right-aligned">
           {{#link-to "jobs.run" data-test-run-job class="button is-primary"}}Run Job{{/link-to}}


### PR DESCRIPTION
This changes the templates so the element that contains
the search box is always present, instead hiding only
the box itself when there’s nothing to search. Keeping
the empty element lets it take up its flexbox space so
the facets will no longer be in the centre.