### PR TITLE
Restore precommit linting

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -21,8 +21,8 @@
     }
   },
   "lint-staged": {
-    "'{app,tests,config,lib,mirage}/**/*.js'": ["prettier --write", "git add"],
-    "'app/styles/**/*.*'": ["prettier --write", "git add"]
+    "{app,tests,config,lib,mirage}/**/*.js": ["prettier --write", "git add"],
+    "app/styles/**/*.*": ["prettier --write", "git add"]
   },
   "devDependencies": {
     "anser": "^1.4.8",


### PR DESCRIPTION
The two pairs of quotes were causing no files to match.