### PR TITLE
Fix bug in plan applier introduced in PR-5602

### DIFF
--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -396,6 +396,8 @@ func TestStateStore_UpsertPlanResults_PreemptedAllocs(t *testing.T) {
 	require.NoError(err)
 	require.Equal(preempted.DesiredStatus, structs.AllocDesiredStatusEvict)
 	require.Equal(preempted.DesiredDescription, fmt.Sprintf("Preempted by alloc ID %v", alloc.ID))
+	require.Equal(preempted.Job.ID, preemptedAlloc.Job.ID)
+	require.Equal(preempted.Job, preemptedAlloc.Job)
 
 	// Verify eval for preempted job
 	preemptedJobEval, err := state.EvalByID(ws, eval2.ID)


### PR DESCRIPTION
This fixes a bug in the state store during plan apply. When
denormalizing preempted allocations it incorrectly set the preemptor's
job during the update. This eventually causes a panic downstream in the
client because of associating the wrong job with the preempted allocation. 

Added a test assertion that failed before and passes after this fix