### PR TITLE
auto promote canaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ IMPROVEMENTS:
  * core: Add node name to output of `nomad node status` command in verbose mode [[GH-5224](https://github.com/hashicorp/nomad/pull/5224)]
  * core: Reduce the size of the raft transaction for plans by only sending fields updated by the plan applier [[GH-5602](https://github.com/hashicorp/nomad/pull/5602)]
  * api: Support configuring `http.Client` used by golang `api` package [[GH-5275](https://github.com/hashicorp/nomad/pull/5275)]
+ * core: Add job update `auto_promote` flag, which causes deployments to promote themselves when all canaries become healthy [[GH-5719](https://github.com/hashicorp/nomad/pull/5719)]
  * api: Add preemption related fields to API results that return an allocation list. [[GH-5580](https://github.com/hashicorp/nomad/pull/5580)]
  * api: Add additional config options to scheduler configuration endpoint to disable preemption [[GH-5628](https://github.com/hashicorp/nomad/issues/5628)]
  * client: Reduce unnecessary lost nodes on server failure [[GH-5654](https://github.com/hashicorp/nomad/issues/5654)]

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -375,14 +375,15 @@ type UpdateStrategy struct {
 	MinHealthyTime   *time.Duration `mapstructure:"min_healthy_time"`
 	HealthyDeadline  *time.Duration `mapstructure:"healthy_deadline"`
 	ProgressDeadline *time.Duration `mapstructure:"progress_deadline"`
+	Canary           *int           `mapstructure:"canary"`
 	AutoRevert       *bool          `mapstructure:"auto_revert"`
 	AutoPromote      *bool          `mapstructure:"auto_promote"`
-	Canary           *int           `mapstructure:"canary"`
 }
 
 // DefaultUpdateStrategy provides a baseline that can be used to upgrade
 // jobs with the old policy or for populating field defaults.
 func DefaultUpdateStrategy() *UpdateStrategy {
+	// boolPtr fields are omitted to avoid masking an unconfigured nil
 	return &UpdateStrategy{
 		Stagger:          timeToPtr(30 * time.Second),
 		MaxParallel:      intToPtr(1),
@@ -392,7 +393,6 @@ func DefaultUpdateStrategy() *UpdateStrategy {
 		ProgressDeadline: timeToPtr(10 * time.Minute),
 		AutoRevert:       boolToPtr(false),
 		Canary:           intToPtr(0),
-		AutoPromote:      boolToPtr(false),
 	}
 }
 
@@ -487,6 +487,8 @@ func (u *UpdateStrategy) Merge(o *UpdateStrategy) {
 func (u *UpdateStrategy) Canonicalize() {
 	d := DefaultUpdateStrategy()
 
+	// boolPtr fields are omitted to avoid masking an unconfigured nil
+
 	if u.MaxParallel == nil {
 		u.MaxParallel = d.MaxParallel
 	}
@@ -517,10 +519,6 @@ func (u *UpdateStrategy) Canonicalize() {
 
 	if u.Canary == nil {
 		u.Canary = d.Canary
-	}
-
-	if u.AutoPromote == nil {
-		u.AutoPromote = d.AutoPromote
 	}
 }
 

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -376,6 +376,7 @@ type UpdateStrategy struct {
 	HealthyDeadline  *time.Duration `mapstructure:"healthy_deadline"`
 	ProgressDeadline *time.Duration `mapstructure:"progress_deadline"`
 	AutoRevert       *bool          `mapstructure:"auto_revert"`
+	AutoPromote      *bool          `mapstructure:"auto_promote"`
 	Canary           *int           `mapstructure:"canary"`
 }
 
@@ -433,6 +434,10 @@ func (u *UpdateStrategy) Copy() *UpdateStrategy {
 		copy.Canary = intToPtr(*u.Canary)
 	}
 
+	if u.AutoPromote != nil {
+		copy.AutoPromote = boolToPtr(*u.AutoPromote)
+	}
+
 	return copy
 }
 
@@ -471,6 +476,10 @@ func (u *UpdateStrategy) Merge(o *UpdateStrategy) {
 
 	if o.Canary != nil {
 		u.Canary = intToPtr(*o.Canary)
+	}
+
+	if o.AutoPromote != nil {
+		u.AutoPromote = boolToPtr(*o.AutoPromote)
 	}
 }
 

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -392,6 +392,7 @@ func DefaultUpdateStrategy() *UpdateStrategy {
 		ProgressDeadline: timeToPtr(10 * time.Minute),
 		AutoRevert:       boolToPtr(false),
 		Canary:           intToPtr(0),
+		AutoPromote:      boolToPtr(false),
 	}
 }
 
@@ -516,6 +517,10 @@ func (u *UpdateStrategy) Canonicalize() {
 
 	if u.Canary == nil {
 		u.Canary = d.Canary
+	}
+
+	if u.AutoPromote == nil {
+		u.AutoPromote = d.AutoPromote
 	}
 }
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -323,7 +323,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 					ProgressDeadline: timeToPtr(10 * time.Minute),
 					AutoRevert:       boolToPtr(false),
 					Canary:           intToPtr(0),
-					AutoPromote:      boolToPtr(false),
+					AutoPromote:      nil,
 				},
 				TaskGroups: []*TaskGroup{
 					{
@@ -358,7 +358,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 							ProgressDeadline: timeToPtr(10 * time.Minute),
 							AutoRevert:       boolToPtr(false),
 							Canary:           intToPtr(0),
-							AutoPromote:      boolToPtr(false),
+							AutoPromote:      nil,
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -323,6 +323,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 					ProgressDeadline: timeToPtr(10 * time.Minute),
 					AutoRevert:       boolToPtr(false),
 					Canary:           intToPtr(0),
+					AutoPromote:      boolToPtr(false),
 				},
 				TaskGroups: []*TaskGroup{
 					{
@@ -357,6 +358,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 							ProgressDeadline: timeToPtr(10 * time.Minute),
 							AutoRevert:       boolToPtr(false),
 							Canary:           intToPtr(0),
+							AutoPromote:      boolToPtr(false),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
@@ -486,6 +488,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 					ProgressDeadline: timeToPtr(7 * time.Minute),
 					AutoRevert:       boolToPtr(false),
 					Canary:           intToPtr(0),
+					AutoPromote:      boolToPtr(false),
 				},
 				TaskGroups: []*TaskGroup{
 					{
@@ -497,6 +500,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 							MinHealthyTime: timeToPtr(1 * time.Second),
 							AutoRevert:     boolToPtr(true),
 							Canary:         intToPtr(1),
+							AutoPromote:    boolToPtr(true),
 						},
 						Tasks: []*Task{
 							{
@@ -541,6 +545,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 					ProgressDeadline: timeToPtr(7 * time.Minute),
 					AutoRevert:       boolToPtr(false),
 					Canary:           intToPtr(0),
+					AutoPromote:      boolToPtr(false),
 				},
 				TaskGroups: []*TaskGroup{
 					{
@@ -574,6 +579,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 							ProgressDeadline: timeToPtr(7 * time.Minute),
 							AutoRevert:       boolToPtr(true),
 							Canary:           intToPtr(1),
+							AutoPromote:      boolToPtr(true),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
@@ -616,6 +622,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 							ProgressDeadline: timeToPtr(7 * time.Minute),
 							AutoRevert:       boolToPtr(false),
 							Canary:           intToPtr(0),
+							AutoPromote:      boolToPtr(false),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -504,6 +504,7 @@ func NewTaskGroup(name string, count int) *TaskGroup {
 	}
 }
 
+// Canonicalize sets defaults and merges settings that should be inherited from the job
 func (g *TaskGroup) Canonicalize(job *Job) {
 	if g.Name == nil {
 		g.Name = stringToPtr("")

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -374,6 +374,7 @@ func TestTaskGroup_Canonicalize_Update(t *testing.T) {
 		ID: stringToPtr("test"),
 		Update: &UpdateStrategy{
 			AutoRevert:       boolToPtr(false),
+			AutoPromote:      boolToPtr(false),
 			Canary:           intToPtr(0),
 			HealthCheck:      stringToPtr(""),
 			HealthyDeadline:  timeToPtr(0),

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -611,7 +611,9 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 		Affinities:  ApiAffinitiesToStructs(job.Affinities),
 	}
 
-	// COMPAT: Remove in 0.7.0. Update has been pushed into the task groups
+	// Update has been pushed into the task groups. stagger and max_parallel are
+	// preserved at the job level, but all other values are discarded. The job.Update
+	// api value is merged into TaskGroups already in api.Canonicalize
 	if job.Update != nil {
 		j.Update = structs.UpdateStrategy{}
 
@@ -718,9 +720,16 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 			MinHealthyTime:   *taskGroup.Update.MinHealthyTime,
 			HealthyDeadline:  *taskGroup.Update.HealthyDeadline,
 			ProgressDeadline: *taskGroup.Update.ProgressDeadline,
-			AutoRevert:       *taskGroup.Update.AutoRevert,
-			AutoPromote:      *taskGroup.Update.AutoPromote,
 			Canary:           *taskGroup.Update.Canary,
+		}
+
+		// boolPtr fields may be nil, others will have pointers to default values via Canonicalize
+		if taskGroup.Update.AutoRevert != nil {
+			tg.Update.AutoRevert = *taskGroup.Update.AutoRevert
+		}
+
+		if taskGroup.Update.AutoPromote != nil {
+			tg.Update.AutoPromote = *taskGroup.Update.AutoPromote
 		}
 	}
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -719,6 +719,7 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 			HealthyDeadline:  *taskGroup.Update.HealthyDeadline,
 			ProgressDeadline: *taskGroup.Update.ProgressDeadline,
 			AutoRevert:       *taskGroup.Update.AutoRevert,
+			AutoPromote:      *taskGroup.Update.AutoPromote,
 			Canary:           *taskGroup.Update.Canary,
 		}
 	}

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1624,6 +1624,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 					HealthyDeadline:  5 * time.Minute,
 					ProgressDeadline: 5 * time.Minute,
 					AutoRevert:       true,
+					AutoPromote:      false,
 					Canary:           1,
 				},
 				Meta: map[string]string{

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,7 +15,7 @@ You'll need AWS credentials (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) to
 
 Running
 ===========
-After completing the provisioning step above, you should see CLI output showing the IP addresses of Nomad client machines. To run the tests, set the NOMAD_ADDR variable to one of the client IPs.
+After completing the provisioning step above, you should see CLI output showing the IP addresses of Nomad client machines. To run the tests, set the NOMAD_ADDR variable to `http://[client IP]:4646/`
 
 ```
 $ NOMAD_ADDR=<> NOMAD_E2E=1 go test -v

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -18,5 +18,5 @@ Running
 After completing the provisioning step above, you should see CLI output showing the IP addresses of Nomad client machines. To run the tests, set the NOMAD_ADDR variable to one of the client IPs.
 
 ```
-$ NOMAD_ADDR=<> $NOMAD_E2E=1 go test -v
+$ NOMAD_ADDR=<> NOMAD_E2E=1 go test -v
 ```

--- a/e2e/deployment/deployment.go
+++ b/e2e/deployment/deployment.go
@@ -73,6 +73,7 @@ func (tc *DeploymentTest) AfterEach(f *framework.F) {
 	for _, id := range tc.jobIds {
 		jobs.Deregister(id, true, nil)
 	}
+	tc.jobIds = []string{}
 	// Garbage collect
 	nomadClient.System().GarbageCollect()
 }

--- a/e2e/deployment/deployment.go
+++ b/e2e/deployment/deployment.go
@@ -60,6 +60,8 @@ func (tc *DeploymentTest) TestDeploymentAutoPromote(f *framework.F) {
 
 	// Deployment is eventually running
 	e2eutil.WaitForDeployment(t, nomadClient, deploy.ID, run, structs.DeploymentStatusDescriptionRunning)
+
+	deploy, _, _ = nomadClient.Deployments().Info(deploy.ID, nil)
 	require.Equal(t, run, deploy.Status)
 	require.Equal(t, structs.DeploymentStatusDescriptionRunning, deploy.StatusDescription)
 }

--- a/e2e/deployment/deployment.go
+++ b/e2e/deployment/deployment.go
@@ -1,0 +1,76 @@
+package deployment
+
+import (
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/e2e/framework"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/helper/uuid"
+)
+
+type DeploymentTest struct {
+	framework.TC
+	jobIds []string
+}
+
+func init() {
+	framework.AddSuites(&framework.TestSuite{
+		Component:   "Deployment",
+		CanRunLocal: true,
+		Cases: []framework.TestCase{
+			new(DeploymentTest),
+		},
+	})
+}
+
+func (tc *DeploymentTest) BeforeAll(f *framework.F) {
+	// Ensure cluster has leader before running tests
+	e2eutil.WaitForLeader(f.T(), tc.Nomad())
+	e2eutil.WaitForNodesReady(f.T(), tc.Nomad(), 4)
+}
+
+func (tc *DeploymentTest) TestDeploymentAutoPromote(f *framework.F) {
+	t := f.T()
+	nomadClient := tc.Nomad()
+	uuid := uuid.Generate()
+	jobId := "deployment" + uuid[0:8]
+	tc.jobIds = append(tc.jobIds, jobId)
+	e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "deployment/input/deployment_auto0.nomad", jobId)
+
+	// Upgrade
+	e2eutil.RegisterAllocs(t, nomadClient, "deployment/input/deployment_auto1.nomad", jobId)
+	var deploy *api.Deployment
+	ds, _, err := nomadClient.Deployments().List(nil)
+	require.NoError(t, err)
+
+	// Find the deployment
+	for _, d := range ds {
+		if d.JobID == jobId {
+			deploy = d
+			break
+		}
+	}
+
+	// Deployment is auto pending the upgrade of "two" which has a longer time to health
+	run := structs.DeploymentStatusRunning
+	require.Equal(t, run, deploy.Status)
+	require.Equal(t, structs.DeploymentStatusDescriptionRunningAutoPromotion, deploy.StatusDescription)
+
+	// Deployment is eventually running
+	e2eutil.WaitForDeployment(t, nomadClient, deploy.ID, run, structs.DeploymentStatusDescriptionRunning)
+	require.Equal(t, run, deploy.Status)
+	require.Equal(t, structs.DeploymentStatusDescriptionRunning, deploy.StatusDescription)
+}
+
+func (tc *DeploymentTest) AfterEach(f *framework.F) {
+	nomadClient := tc.Nomad()
+	jobs := nomadClient.Jobs()
+	// Stop all jobs in test
+	for _, id := range tc.jobIds {
+		jobs.Deregister(id, true, nil)
+	}
+	// Garbage collect
+	nomadClient.System().GarbageCollect()
+}

--- a/e2e/deployment/input/deployment_auto0.nomad
+++ b/e2e/deployment/input/deployment_auto0.nomad
@@ -32,7 +32,7 @@ job "deployment_auto.nomad" {
       max_parallel = 2
       auto_promote = true
       canary = 2
-      min_healthy_time = "5s"
+      min_healthy_time = "2s"
     }
 
     task "two" {

--- a/e2e/deployment/input/deployment_auto0.nomad
+++ b/e2e/deployment/input/deployment_auto0.nomad
@@ -15,6 +15,7 @@ job "deployment_auto.nomad" {
 
       config {
 	command = "/bin/sleep"
+	# change args to update the job, the only changes
 	args = ["1000000"]
       }
 
@@ -40,7 +41,8 @@ job "deployment_auto.nomad" {
 
       config {
 	command = "/bin/sleep"
-	args = ["200000"]
+	# change args to update the job, the only changes
+	args = ["2000000"]
       }
 
       resources {

--- a/e2e/deployment/input/deployment_auto0.nomad
+++ b/e2e/deployment/input/deployment_auto0.nomad
@@ -1,0 +1,52 @@
+job "deployment_auto.nomad" {
+  datacenters = ["dc1"]
+
+  group "one" {
+    count = 3
+
+    update {
+      max_parallel = 3
+      auto_promote = true
+      canary = 2
+    }
+
+    task "one" {
+      driver = "raw_exec"
+
+      config {
+	command = "/bin/sleep"
+	args = ["1000000"]
+      }
+
+      resources {
+	cpu    = 20
+	memory = 20
+      }
+    }
+  }
+
+  group "two" {
+    count = 3
+
+    update {
+      max_parallel = 2
+      auto_promote = true
+      canary = 2
+      min_healthy_time = "5s"
+    }
+
+    task "two" {
+      driver = "raw_exec"
+
+      config {
+	command = "/bin/sleep"
+	args = ["200000"]
+      }
+
+      resources {
+	cpu    = 20
+	memory = 20
+      }
+    }
+  }
+}

--- a/e2e/deployment/input/deployment_auto1.nomad
+++ b/e2e/deployment/input/deployment_auto1.nomad
@@ -32,7 +32,7 @@ job "deployment_auto.nomad" {
       max_parallel = 2
       auto_promote = true
       canary = 2
-      min_healthy_time = "5s"
+      min_healthy_time = "2s"
     }
 
     task "two" {

--- a/e2e/deployment/input/deployment_auto1.nomad
+++ b/e2e/deployment/input/deployment_auto1.nomad
@@ -15,6 +15,7 @@ job "deployment_auto.nomad" {
 
       config {
 	command = "/bin/sleep"
+	# change args to update the job, the only changes
 	args = ["1000001"]
       }
 
@@ -40,7 +41,8 @@ job "deployment_auto.nomad" {
 
       config {
 	command = "/bin/sleep"
-	args = ["200001"]
+	# change args to update the job, the only changes
+	args = ["2000001"]
       }
 
       resources {

--- a/e2e/deployment/input/deployment_auto1.nomad
+++ b/e2e/deployment/input/deployment_auto1.nomad
@@ -1,0 +1,52 @@
+job "deployment_auto.nomad" {
+  datacenters = ["dc1"]
+
+  group "one" {
+    count = 3
+
+    update {
+      max_parallel = 3
+      auto_promote = true
+      canary = 2
+    }
+
+    task "one" {
+      driver = "raw_exec"
+
+      config {
+	command = "/bin/sleep"
+	args = ["1000001"]
+      }
+
+      resources {
+	cpu    = 20
+	memory = 20
+      }
+    }
+  }
+
+  group "two" {
+    count = 3
+
+    update {
+      max_parallel = 2
+      auto_promote = true
+      canary = 2
+      min_healthy_time = "5s"
+    }
+
+    task "two" {
+      driver = "raw_exec"
+
+      config {
+	command = "/bin/sleep"
+	args = ["200001"]
+      }
+
+      resources {
+	cpu    = 20
+	memory = 20
+      }
+    }
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/hashicorp/nomad/e2e/clientstate"
 	_ "github.com/hashicorp/nomad/e2e/consul"
 	_ "github.com/hashicorp/nomad/e2e/consultemplate"
+	_ "github.com/hashicorp/nomad/e2e/deployment"
 	_ "github.com/hashicorp/nomad/e2e/example"
 	_ "github.com/hashicorp/nomad/e2e/nomad09upgrade"
 	_ "github.com/hashicorp/nomad/e2e/nomadexec"

--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -130,6 +130,6 @@ func WaitForDeployment(t *testing.T, nomadClient *api.Client, deployID string, s
 		)
 
 	}, func(err error) {
-		t.Fatalf("failed to wait on alloc: %v", err)
+		t.Fatalf("failed to wait on deployment: %v", err)
 	})
 }

--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -54,14 +54,12 @@ func WaitForNodesReady(t *testing.T, nomadClient *api.Client, nodes int) {
 	})
 }
 
-func RegisterAndWaitForAllocs(t *testing.T, nomadClient *api.Client, jobFile string, jobID string) []*api.AllocationListStub {
+func RegisterAllocs(t *testing.T, nomadClient *api.Client, jobFile string, jobID string) []*api.AllocationListStub {
 	// Parse job
 	job, err := jobspec.ParseFile(jobFile)
 	require := require.New(t)
 	require.Nil(err)
 	job.ID = helper.StringToPtr(jobID)
-
-	g := NewGomegaWithT(t)
 
 	// Register job
 	jobs := nomadClient.Jobs()
@@ -75,15 +73,26 @@ func RegisterAndWaitForAllocs(t *testing.T, nomadClient *api.Client, jobFile str
 		require.NoError(err)
 	})
 
+	allocs, _, _ := jobs.Allocations(jobID, false, nil)
+	return allocs
+}
+
+func RegisterAndWaitForAllocs(t *testing.T, nomadClient *api.Client, jobFile string, jobID string) []*api.AllocationListStub {
+	// Parse job
+	require := require.New(t)
+	allocs := RegisterAllocs(t, nomadClient, jobFile, jobID)
+	g := NewGomegaWithT(t)
+	jobs := nomadClient.Jobs()
+
 	// Wrap in retry to wait until placement
 	g.Eventually(func() []*api.AllocationListStub {
 		// Look for allocations
-		allocs, _, _ := jobs.Allocations(*job.ID, false, nil)
+		allocs, _, _ := jobs.Allocations(jobID, false, nil)
 		return allocs
 	}, 30*time.Second, time.Second).ShouldNot(BeEmpty())
 
-	allocs, _, err := jobs.Allocations(*job.ID, false, nil)
-	require.Nil(err)
+	allocs, _, err := jobs.Allocations(jobID, false, nil)
+	require.NoError(err)
 	return allocs
 }
 
@@ -96,6 +105,24 @@ func WaitForAllocRunning(t *testing.T, nomadClient *api.Client, allocID string) 
 		}
 
 		return alloc.ClientStatus == structs.AllocClientStatusRunning, fmt.Errorf("expected status running, but was: %s", alloc.ClientStatus)
+	}, func(err error) {
+		t.Fatalf("failed to wait on alloc: %v", err)
+	})
+}
+
+func WaitForDeployment(t *testing.T, nomadClient *api.Client, deployID string, status string, statusDesc string) {
+	testutil.WaitForResultRetries(retries, func() (bool, error) {
+		time.Sleep(time.Millisecond * 100)
+		deploy, _, err := nomadClient.Deployments().Info(deployID, nil)
+		if err != nil {
+			return false, err
+		}
+
+		if deploy.Status == status && deploy.StatusDescription == statusDesc {
+			return true, nil
+		}
+		return false, fmt.Errorf("expected status %s \"%s\", but got: %s \"%s\"", deploy.Status, deploy.StatusDescription)
+
 	}, func(err error) {
 		t.Fatalf("failed to wait on alloc: %v", err)
 	})

--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -121,7 +121,12 @@ func WaitForDeployment(t *testing.T, nomadClient *api.Client, deployID string, s
 		if deploy.Status == status && deploy.StatusDescription == statusDesc {
 			return true, nil
 		}
-		return false, fmt.Errorf("expected status %s \"%s\", but got: %s \"%s\"", deploy.Status, deploy.StatusDescription)
+		return false, fmt.Errorf("expected status %s \"%s\", but got: %s \"%s\"",
+			deploy.Status,
+			deploy.StatusDescription,
+			status,
+			statusDesc,
+		)
 
 	}, func(err error) {
 		t.Fatalf("failed to wait on alloc: %v", err)

--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -78,11 +78,12 @@ func RegisterAllocs(t *testing.T, nomadClient *api.Client, jobFile string, jobID
 }
 
 func RegisterAndWaitForAllocs(t *testing.T, nomadClient *api.Client, jobFile string, jobID string) []*api.AllocationListStub {
-	// Parse job
 	require := require.New(t)
-	allocs := RegisterAllocs(t, nomadClient, jobFile, jobID)
 	g := NewGomegaWithT(t)
 	jobs := nomadClient.Jobs()
+
+	// Start allocations
+	RegisterAllocs(t, nomadClient, jobFile, jobID)
 
 	// Wrap in retry to wait until placement
 	g.Eventually(func() []*api.AllocationListStub {

--- a/e2e/terraform/README.md
+++ b/e2e/terraform/README.md
@@ -10,7 +10,7 @@ Use [envchain](https://github.com/sorah/envchain) to store your AWS credentials.
 
 ```
 $ cd e2e/terraform/
-$ envchain nomadaws TF_VAR_nomad_sha=<nomad_sha> terraform apply
+$ TF_VAR_nomad_sha=<nomad_sha> envchain nomadaws terraform apply
 ```
 
 After this step, you should have a nomad client address to point the end to end tests in the `e2e` folder to.

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -1594,7 +1594,6 @@ func parseUpdate(result **api.UpdateStrategy, list *ast.ObjectList) error {
 
 	// Check for invalid keys
 	valid := []string{
-		// COMPAT: Remove in 0.7.0. Stagger is deprecated in 0.6.0.
 		"stagger",
 		"max_parallel",
 		"health_check",

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -1602,6 +1602,7 @@ func parseUpdate(result **api.UpdateStrategy, list *ast.ObjectList) error {
 		"healthy_deadline",
 		"progress_deadline",
 		"auto_revert",
+		"auto_promote",
 		"canary",
 	}
 	if err := helper.CheckHCLKeys(o.Val, valid); err != nil {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -79,6 +79,7 @@ func TestParse(t *testing.T) {
 					HealthyDeadline:  helper.TimeToPtr(10 * time.Minute),
 					ProgressDeadline: helper.TimeToPtr(10 * time.Minute),
 					AutoRevert:       helper.BoolToPtr(true),
+					AutoPromote:      helper.BoolToPtr(true),
 					Canary:           helper.IntToPtr(1),
 				},
 
@@ -163,6 +164,7 @@ func TestParse(t *testing.T) {
 							HealthyDeadline:  helper.TimeToPtr(1 * time.Minute),
 							ProgressDeadline: helper.TimeToPtr(1 * time.Minute),
 							AutoRevert:       helper.BoolToPtr(false),
+							AutoPromote:      helper.BoolToPtr(false),
 							Canary:           helper.IntToPtr(2),
 						},
 						Migrate: &api.MigrateStrategy{

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -42,6 +42,7 @@ job "binstore-storagelocker" {
     healthy_deadline = "10m"
     progress_deadline = "10m"
     auto_revert = true
+    auto_promote = true
     canary = 1
   }
 
@@ -84,6 +85,7 @@ job "binstore-storagelocker" {
         healthy_deadline = "1m"
         progress_deadline = "1m"
         auto_revert = false
+        auto_promote = false
         canary = 2
     }
 

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -597,9 +597,6 @@ func (w *deploymentWatcher) handleAllocUpdate(allocs []*structs.AllocListStub) (
 		// We need to create an eval so the job can progress.
 		if alloc.DeploymentStatus.IsHealthy() && alloc.DeploymentStatus.ModifyIndex > latestEval {
 			res.createEval = true
-			if alloc.DeploymentStatus.IsCanary() {
-				dstate.HealthyCanaries += 1
-			}
 		}
 
 		// If the group is using a progress deadline, we don't have to do anything.

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -511,7 +511,10 @@ FAIL:
 			}
 
 			// If permitted, automatically promote this canary deployment
-			w.autoPromoteDeployment(updates.allocs)
+			err = w.autoPromoteDeployment(updates.allocs)
+			if err != nil {
+				w.logger.Error("failed to auto promote deployment", "error", err)
+			}
 
 			// Create an eval to push the deployment along
 			if res.createEval || len(res.allowReplacements) != 0 {

--- a/nomad/deploymentwatcher/deployments_watcher.go
+++ b/nomad/deploymentwatcher/deployments_watcher.go
@@ -221,7 +221,7 @@ func (w *Watcher) add(d *structs.Deployment) error {
 }
 
 // addLocked adds a deployment to the watch list and should only be called when
-// locked.
+// locked. Creating the deploymentWatcher starts a go routine to .watch() it
 func (w *Watcher) addLocked(d *structs.Deployment) (*deploymentWatcher, error) {
 	// Not enabled so no-op
 	if !w.enabled {

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -594,7 +594,7 @@ func TestWatcher_AutoPromoteDeployment(t *testing.T) {
 		func() (bool, error) {
 			ds, _ := m.state.DeploymentsByJobID(ws, j.Namespace, j.ID, true)
 			d = ds[0]
-			return 2 == d.TaskGroups["web"].HealthyCanaries, nil
+			return 2 == d.TaskGroups["web"].HealthyAllocs, nil
 		},
 		func(err error) { require.NoError(t, err) },
 	)

--- a/nomad/deploymentwatcher/doc.go
+++ b/nomad/deploymentwatcher/doc.go
@@ -1,0 +1,7 @@
+// deploymentwatcher creates and tracks Deployments, which hold meta data describing the
+// process of upgrading a running job to a new set of Allocations. This encompasses settings
+// for canary deployments and blue/green rollouts.
+//
+// - The watcher is only enabled on the active raft leader.
+// - func (w *deploymentWatcher) watch() is the main deploymentWatcher process
+package deploymentwatcher

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2942,7 +2942,7 @@ func (s *StateStore) UpdateDeploymentPromotion(index uint64, req *structs.ApplyD
 		}
 	}
 
-	// For each promotable allocation remoce the canary field
+	// For each promotable allocation remove the canary field
 	for _, alloc := range promotable {
 		promoted := alloc.Copy()
 		promoted.DeploymentStatus.Canary = false

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -57,8 +57,7 @@ type JobDiff struct {
 // diffable. If contextual diff is enabled, objects within the job will contain
 // field information even if unchanged.
 func (j *Job) Diff(other *Job, contextual bool) (*JobDiff, error) {
-	// COMPAT: Remove "Update" in 0.7.0. Update pushed down to task groups
-	// in 0.6.0
+	// See agent.ApiJobToStructJob Update is a default for TaskGroups
 	diff := &JobDiff{Type: DiffTypeNone}
 	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
 	filter := []string{"ID", "Status", "StatusDescription", "Version", "Stable", "CreateIndex",

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -1979,6 +1979,12 @@ func TestTaskGroupDiff(t *testing.T) {
 						Fields: []*FieldDiff{
 							{
 								Type: DiffTypeDeleted,
+								Name: "AutoPromote",
+								Old:  "false",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
 								Name: "AutoRevert",
 								Old:  "true",
 								New:  "",
@@ -2035,6 +2041,12 @@ func TestTaskGroupDiff(t *testing.T) {
 						Fields: []*FieldDiff{
 							{
 								Type: DiffTypeAdded,
+								Name: "AutoPromote",
+								Old:  "",
+								New:  "false",
+							},
+							{
+								Type: DiffTypeAdded,
 								Name: "AutoRevert",
 								Old:  "",
 								New:  "true",
@@ -2084,6 +2096,7 @@ func TestTaskGroupDiff(t *testing.T) {
 					HealthyDeadline:  30 * time.Second,
 					ProgressDeadline: 29 * time.Second,
 					AutoRevert:       true,
+					AutoPromote:      true,
 					Canary:           2,
 				},
 			},
@@ -2095,6 +2108,7 @@ func TestTaskGroupDiff(t *testing.T) {
 					HealthyDeadline:  31 * time.Second,
 					ProgressDeadline: 32 * time.Second,
 					AutoRevert:       false,
+					AutoPromote:      false,
 					Canary:           1,
 				},
 			},
@@ -2105,6 +2119,12 @@ func TestTaskGroupDiff(t *testing.T) {
 						Type: DiffTypeEdited,
 						Name: "Update",
 						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "AutoPromote",
+								Old:  "true",
+								New:  "false",
+							},
 							{
 								Type: DiffTypeEdited,
 								Name: "AutoRevert",
@@ -2163,6 +2183,7 @@ func TestTaskGroupDiff(t *testing.T) {
 					HealthyDeadline:  30 * time.Second,
 					ProgressDeadline: 30 * time.Second,
 					AutoRevert:       true,
+					AutoPromote:      true,
 					Canary:           2,
 				},
 			},
@@ -2174,6 +2195,7 @@ func TestTaskGroupDiff(t *testing.T) {
 					HealthyDeadline:  30 * time.Second,
 					ProgressDeadline: 30 * time.Second,
 					AutoRevert:       true,
+					AutoPromote:      true,
 					Canary:           2,
 				},
 			},
@@ -2184,6 +2206,12 @@ func TestTaskGroupDiff(t *testing.T) {
 						Type: DiffTypeEdited,
 						Name: "Update",
 						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeNone,
+								Name: "AutoPromote",
+								Old:  "true",
+								New:  "true",
+							},
 							{
 								Type: DiffTypeNone,
 								Name: "AutoRevert",

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7012,6 +7012,8 @@ const (
 	DeploymentStatusSuccessful = "successful"
 	DeploymentStatusCancelled  = "cancelled"
 
+	// TODO Statuses and Descriptions do not match 1:1 and we sometimes use the Description as a status flag
+
 	// DeploymentStatusDescriptions are the various descriptions of the states a
 	// deployment can be in.
 	DeploymentStatusDescriptionRunning               = "Deployment is running"

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3231,7 +3231,8 @@ type Job struct {
 	// to run. Each task group is an atomic unit of scheduling and placement.
 	TaskGroups []*TaskGroup
 
-	// COMPAT: Remove in 0.7.0. Stagger is deprecated in 0.6.0.
+	// See agent.ApiJobToStructJob
+	// Update provides defaults for the TaskGroup Update stanzas
 	Update UpdateStrategy
 
 	// Periodic is used to define the interval the job is run at.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3488,7 +3488,7 @@ func (j *Job) Warnings() error {
 			outer := fmt.Errorf("Group %q has warnings: %v", tg.Name, err)
 			mErr.Errors = append(mErr.Errors, outer)
 		}
-		if tg.Update.AutoPromote {
+		if tg.Update != nil && tg.Update.AutoPromote {
 			ap += 1
 		}
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7002,7 +7002,7 @@ const (
 	// DeploymentStatusDescriptions are the various descriptions of the states a
 	// deployment can be in.
 	DeploymentStatusDescriptionRunning               = "Deployment is running"
-	DeploymentStatusDescriptionRunningNeedsPromotion = "Deployment is running but requires promotion"
+	DeploymentStatusDescriptionRunningNeedsPromotion = "Deployment is running but requires manual promotion"
 	DeploymentStatusDescriptionRunningAutoPromotion  = "Deployment is running pending automatic promotion"
 	DeploymentStatusDescriptionPaused                = "Deployment is paused"
 	DeploymentStatusDescriptionSuccessful            = "Deployment completed successfully"

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3880,6 +3880,9 @@ func (u *UpdateStrategy) Validate() error {
 	if u.Canary < 0 {
 		multierror.Append(&mErr, fmt.Errorf("Canary count can not be less than zero: %d < 0", u.Canary))
 	}
+	if u.Canary == 0 && u.AutoPromote {
+		multierror.Append(&mErr, fmt.Errorf("Auto Promote requires a Canary count greater than zero"))
+	}
 	if u.MinHealthyTime < 0 {
 		multierror.Append(&mErr, fmt.Errorf("Minimum healthy time may not be less than zero: %v", u.MinHealthyTime))
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7003,6 +7003,7 @@ const (
 	// deployment can be in.
 	DeploymentStatusDescriptionRunning               = "Deployment is running"
 	DeploymentStatusDescriptionRunningNeedsPromotion = "Deployment is running but requires promotion"
+	DeploymentStatusDescriptionRunningAutoPromotion  = "Deployment is running pending automatic promotion"
 	DeploymentStatusDescriptionPaused                = "Deployment is paused"
 	DeploymentStatusDescriptionSuccessful            = "Deployment completed successfully"
 	DeploymentStatusDescriptionStoppedJob            = "Cancelled because job is stopped"
@@ -7147,6 +7148,19 @@ func (d *Deployment) RequiresPromotion() bool {
 	}
 	for _, group := range d.TaskGroups {
 		if group.DesiredCanaries > 0 && !group.Promoted {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAutoPromote determines if any taskgroup is marked auto_promote
+func (d *Deployment) HasAutoPromote() bool {
+	if d == nil || len(d.TaskGroups) == 0 || d.Status != DeploymentStatusRunning {
+		return false
+	}
+	for _, group := range d.TaskGroups {
+		if group.AutoPromote {
 			return true
 		}
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3804,6 +3804,7 @@ var (
 		HealthyDeadline:  5 * time.Minute,
 		ProgressDeadline: 10 * time.Minute,
 		AutoRevert:       false,
+		AutoPromote:      false,
 		Canary:           0,
 	}
 )
@@ -3841,6 +3842,10 @@ type UpdateStrategy struct {
 	// allocations, there should be an attempt to auto-revert the job to a
 	// stable version.
 	AutoRevert bool
+
+	// AutoPromote declares that the deployment should be promoted when all canaries are
+	// healthy
+	AutoPromote bool
 
 	// Canary is the number of canaries to deploy when a change to the task
 	// group is detected.
@@ -7162,6 +7167,10 @@ type DeploymentState struct {
 	// reverted on failure
 	AutoRevert bool
 
+	// AutoPromote marks promotion triggered automatically by healthy canaries
+	// copied from TaskGroup UpdateStrategy in scheduler.reconcile
+	AutoPromote bool
+
 	// ProgressDeadline is the deadline by which an allocation must transition
 	// to healthy before the deployment is considered failed.
 	ProgressDeadline time.Duration
@@ -7202,6 +7211,7 @@ func (d *DeploymentState) GoString() string {
 	base += fmt.Sprintf("\n\tHealthy: %d", d.HealthyAllocs)
 	base += fmt.Sprintf("\n\tUnhealthy: %d", d.UnhealthyAllocs)
 	base += fmt.Sprintf("\n\tAutoRevert: %v", d.AutoRevert)
+	base += fmt.Sprintf("\n\tAutoPromote: %v", d.AutoPromote)
 	return base
 }
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -144,6 +144,25 @@ func TestJob_Warnings(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:     "AutoPromote mixed TaskGroups",
+			Expected: []string{"auto_promote must be true for all groups"},
+			Job: &Job{
+				Type: JobTypeService,
+				TaskGroups: []*TaskGroup{
+					{
+						Update: &UpdateStrategy{
+							AutoPromote: true,
+						},
+					},
+					{
+						Update: &UpdateStrategy{
+							AutoPromote: false,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -218,7 +218,11 @@ func (a *allocReconciler) Compute() *reconcileResults {
 	// Set the description of a created deployment
 	if d := a.result.deployment; d != nil {
 		if d.RequiresPromotion() {
-			d.StatusDescription = structs.DeploymentStatusDescriptionRunningNeedsPromotion
+			if d.HasAutoPromote() {
+				d.StatusDescription = structs.DeploymentStatusDescriptionRunningAutoPromotion
+			} else {
+				d.StatusDescription = structs.DeploymentStatusDescriptionRunningNeedsPromotion
+			}
 		}
 	}
 

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -327,6 +327,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 		dstate = &structs.DeploymentState{}
 		if tg.Update != nil {
 			dstate.AutoRevert = tg.Update.AutoRevert
+			dstate.AutoPromote = tg.Update.AutoPromote
 			dstate.ProgressDeadline = tg.Update.ProgressDeadline
 		}
 	}

--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -691,6 +691,9 @@ determined. The potential values are:
   they can be promoted which unblocks a rolling update of the remaining
   allocations at a rate of `max_parallel`.
 
+- `AutoPromote` - Specifies if the job should automatically promote to
+  the new deployment if all canaries become healthy.
+
 - `Stagger` - Specifies the delay between migrating allocations off nodes marked
   for draining.
 
@@ -704,6 +707,7 @@ An example `Update` block:
         "MinHealthyTime": 15000000000,
         "HealthyDeadline": 180000000000,
         "AutoRevert": false,
+        "AutoPromote": false,
         "Canary": 1
   }
 }

--- a/website/source/docs/job-specification/update.html.md
+++ b/website/source/docs/job-specification/update.html.md
@@ -94,7 +94,9 @@ job "docs" {
   allocations as part of its deployment were marked healthy.
 
 - `auto_promote` `(bool: false)` - Specifies if the job should auto-promote to the
-  canary version when all canaries become healthy.
+  canary version when all canaries become healthy during a deployment. Defaults to
+  false which means canaries must be manually updated with the `nomad deployment promote`
+  command.
 
 - `canary` `(int: 0)` - Specifies that changes to the job that would result in
   destructive updates should create the specified number of canaries without

--- a/website/source/docs/job-specification/update.html.md
+++ b/website/source/docs/job-specification/update.html.md
@@ -37,6 +37,7 @@ job "docs" {
     healthy_deadline  = "5m"
     progress_deadline = "10m"
     auto_revert       = true
+	auto_promote      = true
     canary            = 1
     stagger           = "30s"
   }
@@ -91,6 +92,9 @@ job "docs" {
 - `auto_revert` `(bool: false)` - Specifies if the job should auto-revert to the
   last stable job on deployment failure. A job is marked as stable if all the
   allocations as part of its deployment were marked healthy.
+
+- `auto_promote` `(bool: false)` - Specifies if the job should auto-promote to the
+  canary version when all canaries become healthy.
 
 - `canary` `(int: 0)` - Specifies that changes to the job that would result in
   destructive updates should create the specified number of canaries without

--- a/website/source/docs/job-specification/update.html.md
+++ b/website/source/docs/job-specification/update.html.md
@@ -37,7 +37,7 @@ job "docs" {
     healthy_deadline  = "5m"
     progress_deadline = "10m"
     auto_revert       = true
-	auto_promote      = true
+    auto_promote      = true
     canary            = 1
     stagger           = "30s"
   }

--- a/website/source/guides/operating-a-job/update-strategies/blue-green-and-canary-deployments.html.md
+++ b/website/source/guides/operating-a-job/update-strategies/blue-green-and-canary-deployments.html.md
@@ -45,6 +45,7 @@ job "docs" {
       min_healthy_time = "30s"
       healthy_deadline = "10m"
       auto_revert      = true
+      auto_promote     = false
     }
 
     task "api-server" {
@@ -305,6 +306,7 @@ job "docs" {
       min_healthy_time = "30s"
       healthy_deadline = "10m"
       auto_revert      = true
+      auto_promote     = false
     }
 
     task "api-server" {


### PR DESCRIPTION
Add a new configuration option, auto_promote, that causes deployments with healthy canary allocations to be promoted automatically. This fixes https://github.com/hashicorp/nomad/issues/3636