### PR TITLE
UI: Replace the adapter cancellation methods with a cancellation token system

### DIFF
--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -1,4 +1,4 @@
-import { get, computed } from '@ember/object';
+import { get } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import { inject as service } from '@ember/service';
 import queryString from 'query-string';
@@ -9,50 +9,22 @@ export default ApplicationAdapter.extend({
   watchList: service(),
   store: service(),
 
-  xhrs: computed(function() {
-    return {
-      list: {},
-      track(key, xhr) {
-        if (this.list[key]) {
-          this.list[key].push(xhr);
-        } else {
-          this.list[key] = [xhr];
-        }
-      },
-      cancel(key) {
-        while (this.list[key] && this.list[key].length) {
-          this.remove(key, this.list[key][0]);
-        }
-      },
-      remove(key, xhr) {
-        if (this.list[key]) {
-          xhr.abort();
-          this.list[key].removeObject(xhr);
-        }
-      },
-    };
-  }),
-
-  ajaxOptions() {
+  ajaxOptions(url, type, options) {
     const ajaxOptions = this._super(...arguments);
-    const key = this.xhrKey(...arguments);
+    const cancellationToken = (options || {}).cancellationToken;
+    if (cancellationToken) {
+      delete options.cancellationToken;
 
-    const previousBeforeSend = ajaxOptions.beforeSend;
-    ajaxOptions.beforeSend = function(jqXHR) {
-      if (previousBeforeSend) {
-        previousBeforeSend(...arguments);
-      }
-      this.xhrs.track(key, jqXHR);
-      jqXHR.always(() => {
-        this.xhrs.remove(key, jqXHR);
-      });
-    };
+      const previousBeforeSend = ajaxOptions.beforeSend;
+      ajaxOptions.beforeSend = function(jqXHR) {
+        cancellationToken.capture(jqXHR);
+        if (previousBeforeSend) {
+          previousBeforeSend(...arguments);
+        }
+      };
+    }
 
     return ajaxOptions;
-  },
-
-  xhrKey(url, method /* options */) {
-    return `${method} ${url}`;
   },
 
   findAll(store, type, sinceToken, snapshotRecordArray, additionalParams = {}) {
@@ -63,7 +35,9 @@ export default ApplicationAdapter.extend({
       params.index = this.watchList.getIndexFor(url);
     }
 
+    const cancellationToken = get(snapshotRecordArray || {}, 'adapterOptions.cancellationToken');
     return this.ajax(url, 'GET', {
+      cancellationToken,
       data: params,
     });
   },
@@ -76,7 +50,9 @@ export default ApplicationAdapter.extend({
       params.index = this.watchList.getIndexFor(url);
     }
 
+    const cancellationToken = get(snapshot || {}, 'adapterOptions.cancellationToken');
     return this.ajax(url, 'GET', {
+      cancellationToken,
       data: params,
     }).catch(error => {
       if (error instanceof AbortError) {
@@ -86,7 +62,8 @@ export default ApplicationAdapter.extend({
     });
   },
 
-  reloadRelationship(model, relationshipName, watch = false) {
+  reloadRelationship(model, relationshipName, options = { watch: false, cancellationToken: null }) {
+    const { watch, cancellationToken } = options;
     const relationship = model.relationshipFor(relationshipName);
     if (relationship.kind !== 'belongsTo' && relationship.kind !== 'hasMany') {
       throw new Error(
@@ -110,6 +87,7 @@ export default ApplicationAdapter.extend({
       }
 
       return this.ajax(url, 'GET', {
+        cancellationToken,
         data: params,
       }).then(
         json => {
@@ -142,40 +120,5 @@ export default ApplicationAdapter.extend({
     }
 
     return this._super(...arguments);
-  },
-
-  cancelFindRecord(modelName, id) {
-    if (!modelName || id == null) {
-      return;
-    }
-    const url = this.urlForFindRecord(id, modelName);
-    this.xhrs.cancel(`GET ${url}`);
-  },
-
-  cancelFindAll(modelName) {
-    if (!modelName) {
-      return;
-    }
-    let url = this.urlForFindAll(modelName);
-    const params = queryString.stringify(this.buildQuery());
-    if (params) {
-      url = `${url}?${params}`;
-    }
-    this.xhrs.cancel(`GET ${url}`);
-  },
-
-  cancelReloadRelationship(model, relationshipName) {
-    if (!model || !relationshipName) {
-      return;
-    }
-    const relationship = model.relationshipFor(relationshipName);
-    if (relationship.kind !== 'belongsTo' && relationship.kind !== 'hasMany') {
-      throw new Error(
-        `${relationship.key} must be a belongsTo or hasMany, instead it was ${relationship.kind}`
-      );
-    } else {
-      const url = model[relationship.kind](relationship.key).link();
-      this.xhrs.cancel(`GET ${url}`);
-    }
   },
 });

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -11,13 +11,13 @@ export default ApplicationAdapter.extend({
 
   ajaxOptions(url, type, options) {
     const ajaxOptions = this._super(...arguments);
-    const cancellationToken = (options || {}).cancellationToken;
-    if (cancellationToken) {
-      delete options.cancellationToken;
+    const abortToken = (options || {}).abortToken;
+    if (abortToken) {
+      delete options.abortToken;
 
       const previousBeforeSend = ajaxOptions.beforeSend;
       ajaxOptions.beforeSend = function(jqXHR) {
-        cancellationToken.capture(jqXHR);
+        abortToken.capture(jqXHR);
         if (previousBeforeSend) {
           previousBeforeSend(...arguments);
         }
@@ -35,9 +35,9 @@ export default ApplicationAdapter.extend({
       params.index = this.watchList.getIndexFor(url);
     }
 
-    const cancellationToken = get(snapshotRecordArray || {}, 'adapterOptions.cancellationToken');
+    const abortToken = get(snapshotRecordArray || {}, 'adapterOptions.abortToken');
     return this.ajax(url, 'GET', {
-      cancellationToken,
+      abortToken,
       data: params,
     });
   },
@@ -50,9 +50,9 @@ export default ApplicationAdapter.extend({
       params.index = this.watchList.getIndexFor(url);
     }
 
-    const cancellationToken = get(snapshot || {}, 'adapterOptions.cancellationToken');
+    const abortToken = get(snapshot || {}, 'adapterOptions.abortToken');
     return this.ajax(url, 'GET', {
-      cancellationToken,
+      abortToken,
       data: params,
     }).catch(error => {
       if (error instanceof AbortError) {
@@ -62,8 +62,8 @@ export default ApplicationAdapter.extend({
     });
   },
 
-  reloadRelationship(model, relationshipName, options = { watch: false, cancellationToken: null }) {
-    const { watch, cancellationToken } = options;
+  reloadRelationship(model, relationshipName, options = { watch: false, abortToken: null }) {
+    const { watch, abortToken } = options;
     const relationship = model.relationshipFor(relationshipName);
     if (relationship.kind !== 'belongsTo' && relationship.kind !== 'hasMany') {
       throw new Error(
@@ -87,7 +87,7 @@ export default ApplicationAdapter.extend({
       }
 
       return this.ajax(url, 'GET', {
-        cancellationToken,
+        abortToken,
         data: params,
       }).then(
         json => {

--- a/ui/app/utils/classes/xhr-token.js
+++ b/ui/app/utils/classes/xhr-token.js
@@ -1,0 +1,11 @@
+export default class XHRToken {
+  capture(xhr) {
+    this._xhr = xhr;
+  }
+
+  abort() {
+    if (this._xhr) {
+      this._xhr.abort();
+    }
+  }
+}

--- a/ui/app/utils/properties/watch.js
+++ b/ui/app/utils/properties/watch.js
@@ -19,7 +19,7 @@ export function watchRecord(modelName) {
         yield RSVP.all([
           this.store.findRecord(modelName, id, {
             reload: true,
-            adapterOptions: { watch: true, cancellationToken: token },
+            adapterOptions: { watch: true, abortToken: token },
           }),
           wait(throttle),
         ]);
@@ -41,7 +41,7 @@ export function watchRelationship(relationshipName) {
         yield RSVP.all([
           this.store
             .adapterFor(model.constructor.modelName)
-            .reloadRelationship(model, relationshipName, { watch: true, cancellationToken: token }),
+            .reloadRelationship(model, relationshipName, { watch: true, abortToken: token }),
           wait(throttle),
         ]);
       } catch (e) {
@@ -62,7 +62,7 @@ export function watchAll(modelName) {
         yield RSVP.all([
           this.store.findAll(modelName, {
             reload: true,
-            adapterOptions: { watch: true, cancellationToken: token },
+            adapterOptions: { watch: true, abortToken: token },
           }),
           wait(throttle),
         ]);

--- a/ui/tests/unit/adapters/job-test.js
+++ b/ui/tests/unit/adapters/job-test.js
@@ -233,7 +233,7 @@ module('Unit | Adapter | Job', function(hooks) {
     const plainId = 'job-1';
     const mockModel = makeMockModel(plainId);
 
-    this.subject().reloadRelationship(mockModel, 'summary', true);
+    this.subject().reloadRelationship(mockModel, 'summary', { watch: true });
     assert.equal(
       pretender.handledRequests[0].url,
       '/v1/job/job-1/summary?index=1',
@@ -241,7 +241,7 @@ module('Unit | Adapter | Job', function(hooks) {
     );
 
     await settled();
-    this.subject().reloadRelationship(mockModel, 'summary', true);
+    this.subject().reloadRelationship(mockModel, 'summary', { watch: true });
     assert.equal(
       pretender.handledRequests[1].url,
       '/v1/job/job-1/summary?index=2',
@@ -260,7 +260,7 @@ module('Unit | Adapter | Job', function(hooks) {
     this.subject()
       .findAll(null, { modelName: 'job' }, null, {
         reload: true,
-        adapterOptions: { watch: true, cancellationToken: token },
+        adapterOptions: { watch: true, abortToken: token },
       })
       .catch(() => {});
 
@@ -287,7 +287,7 @@ module('Unit | Adapter | Job', function(hooks) {
 
     this.subject().findRecord(null, { modelName: 'job' }, jobId, {
       reload: true,
-      adapterOptions: { watch: true, cancellationToken: token },
+      adapterOptions: { watch: true, abortToken: token },
     });
 
     const { request: xhr } = pretender.requestReferences[0];
@@ -311,7 +311,7 @@ module('Unit | Adapter | Job', function(hooks) {
     const mockModel = makeMockModel(plainId);
     pretender.get('/v1/job/:id/summary', () => [200, {}, '{}'], true);
 
-    this.subject().reloadRelationship(mockModel, 'summary', true, token);
+    this.subject().reloadRelationship(mockModel, 'summary', { watch: true, abortToken: token });
 
     const { request: xhr } = pretender.requestReferences[0];
     assert.equal(xhr.status, 0, 'Request is still pending');
@@ -337,12 +337,12 @@ module('Unit | Adapter | Job', function(hooks) {
 
     this.subject().findRecord(null, { modelName: 'job' }, jobId, {
       reload: true,
-      adapterOptions: { watch: true, cancellationToken: token1 },
+      adapterOptions: { watch: true, abortToken: token1 },
     });
 
     this.subject().findRecord(null, { modelName: 'job' }, jobId, {
       reload: true,
-      adapterOptions: { watch: true, cancellationToken: token2 },
+      adapterOptions: { watch: true, abortToken: token2 },
     });
 
     const { request: xhr } = pretender.requestReferences[0];


### PR DESCRIPTION
This replaces the way that XHR cancellation happens throughout the app.

### Before

Cancellation was handled by adapters. Adapters would track all the XHRs and exposed methods that took adapter-like arguments (model name and ID). The cancel method would then look up the XHRs in the registry and abort them.

This had one major issue: there was no discerning between two requests to an identical endpoint.

This may seem like an edge case, but it's oddly easy to end up in this situation. If Page 1 is watching record A and then the app transitioning to Page 2 that tries to load record A in the model hook, the order of events goes:

1. Request to record A is made (watchRecord)
2. Page transition
3. Request to record A is made (model hook)
4. Cancellation for record A is made
5. Both requests are aborted
6. Model hook throws an error due to an empty response (AbortError)

### After

XHRTokens are created at the point where watch requests are made. The XHRToken is more or less an empty object. The XHRToken is passed along to the adapter watch/find methods. The Adapter assigns the XHR to the token. Now the find/watch callsite has a reference to the XHR and can be responsible for cancellation.

Now cancellation is per _request_ rather than per _url_ and our problems go away.

This approach takes inspiration from [axios](https://github.com/axios/axios#cancellation).