### PR TITLE
escapingio: handle stalled readers

### DIFF
--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -265,6 +265,11 @@ func (l *AllocExecCommand) execImpl(client *api.Client, alloc *api.Allocation, t
 			stdin = escapingio.NewReader(stdin, escapeChar[0], func(c byte) bool {
 				switch c {
 				case '.':
+					// need to restore tty state so error reporting here
+					// gets emitted at beginning of line
+					outCleanup()
+					inCleanup()
+
 					stderr.Write([]byte("\nConnection closed\n"))
 					cancelFn()
 					return true
@@ -272,7 +277,6 @@ func (l *AllocExecCommand) execImpl(client *api.Client, alloc *api.Allocation, t
 					return false
 				}
 			})
-
 		}
 	}
 


### PR DESCRIPTION
Handle stalled readers (e.g. network write got stalled), by having
escaping io have a buffer so it looks for escaped characters in the
stream.

This simplifies the implementation considerably, as we can look
for new lines followed by escaped characters directly.

Also, we add a test to ensure that any partial results are flushed to
readers.
