### PR TITLE
Vagrant optional

### DIFF
--- a/website/source/guides/install/quickstart/index.html.md
+++ b/website/source/guides/install/quickstart/index.html.md
@@ -3,18 +3,23 @@ layout: "guides"
 page_title: "Installing Nomad for QuickStart"
 sidebar_current: "guides-install-quickstart"
 description: |-
-  Learn how to install Nomad for sandbox.
+  Learn how to install Nomad locally or in a sandbox.
 ---
 #Quickstart
 
-This page lists multiple methods to installing Nomad in a sandbox environment.  
+This page lists multiple methods to installing Nomad locally or in a sandbox
+environment.  
 
-These installations are designed to get you started with Nomad easily and should be used only for experimentation purposes.  If you are looking to install Nomad in production, please refer to our [Production Installation](/guides/install/production/index.html) guide here.
+These installations are designed to get you started with Nomad easily and should
+be used only for experimentation purposes.  If you are looking to install Nomad
+in production, please refer to our [Production
+Installation](/guides/install/production/index.html) guide here.
 
 ##Local
 Install Nomad on your local machine.
 
-* [Vagrant](/intro/getting-started/install.html)
+* [Installing the Pre-compiled Binary][installing-binary]
+* [Installing Nomad with Vagrant][vagrant-environment]
 
 ##Cloud
 Install Nomad on the public cloud.
@@ -30,3 +35,6 @@ Experiment with Nomad in your browser via KataCoda's interactive learning platfo
 
 * [Introduction to Nomad](https://www.katacoda.com/hashicorp/scenarios/nomad-introduction)
 * [Nomad Playground](https://katacoda.com/hashicorp/scenarios/playground)
+
+[installing-binary]: /guides/install/index.html#precompiled-binaries
+[vagrant-environment]: /intro/getting-started/install.html#vagrant-setup-optional-

--- a/website/source/intro/getting-started/install.html.md
+++ b/website/source/intro/getting-started/install.html.md
@@ -8,16 +8,21 @@ description: |-
 
 # Install Nomad
 
-To simplify the getting started experience, we will be working in a Vagrant
-environment. Create a new directory, and download [this
+To simplify the getting started experience, you can download the pre-compiled
+binary and run it directly (see the instructions [here][binary-instructions]) or
+you can optionally work in a Vagrant environment (detailed in the following
+section).
+
+## Vagrant Setup (Optional)
+
+Note: To use the Vagrant Setup first install Vagrant following these
+[instructions][install-instructions].
+
+Create a new directory, and download [this
 `Vagrantfile`](https://raw.githubusercontent.com/hashicorp/nomad/master/demo/vagrant/Vagrantfile).
 
-## Vagrant Setup
-
-Note: To use the Vagrant Setup first install Vagrant following these instructions: https://www.vagrantup.com/docs/installation/
-
-Once you have created a new directory and downloaded the `Vagrantfile`
-you must create the virtual machine:
+Once you have created a new directory and downloaded the `Vagrantfile` you must
+create the virtual machine:
 
 ```shell
 $ vagrant up
@@ -82,4 +87,6 @@ re-create it.
 
 Vagrant is running and Nomad is installed. Let's [start Nomad](/intro/getting-started/running.html)!
 
+[binary-instructions]: /guides/install/index.html#precompiled-binaries
 [destroy]: https://www.vagrantup.com/docs/cli/destroy.html
+[install-instructions]: https://www.vagrantup.com/docs/installation/

--- a/website/source/intro/getting-started/install.html.md
+++ b/website/source/intro/getting-started/install.html.md
@@ -85,7 +85,7 @@ re-create it.
 
 ## Next Steps
 
-Vagrant is running and Nomad is installed. Let's [start Nomad](/intro/getting-started/running.html)!
+Nomad is installed. Let's [start Nomad](/intro/getting-started/running.html)!
 
 [binary-instructions]: /guides/install/index.html#precompiled-binaries
 [destroy]: https://www.vagrantup.com/docs/cli/destroy.html

--- a/website/source/intro/getting-started/running.html.md
+++ b/website/source/intro/getting-started/running.html.md
@@ -27,7 +27,7 @@ job configurations or prototype interactions. It should _**not**_ be used in
 production as it does not persist state.
 
 ```text
-vagrant@nomad:~$ sudo nomad agent -dev
+$ sudo nomad agent -dev
 
 ==> Starting Nomad agent...
 ==> Nomad agent configuration:
@@ -78,9 +78,6 @@ If you run [`nomad node status`](/docs/commands/node/status.html) in another
 terminal, you can see the registered nodes of the Nomad cluster:
 
 ```text
-$ vagrant ssh
-...
-
 $ nomad node status
 ID        DC   Name   Class   Drain  Eligibility  Status
 171a583b  dc1  nomad  <none>  false  eligible     ready


### PR DESCRIPTION
Changing Quick Start and Getting Started sections by adding info on installing Nomad directly and making Vagrant optional. The user can decide which method they want to use.