### PR TITLE
drivers/exec: Restore 0.8 capabilities

### DIFF
--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -475,6 +475,7 @@ func TestExecDriver_DevicesAndMounts(t *testing.T) {
 	task := &drivers.TaskConfig{
 		ID:         uuid.Generate(),
 		Name:       "test",
+		User:       "root", // need permission to read mounts paths
 		Resources:  testResources,
 		StdoutPath: filepath.Join(tmpDir, "task-stdout"),
 		StderrPath: filepath.Join(tmpDir, "task-stderr"),

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -553,12 +553,20 @@ func configureCapabilities(cfg *lconfigs.Config, command *ExecCommand) error {
 	// TODO: allow better control of these
 	// use capabilities list as prior to adopting libcontainer in 0.9
 	allCaps := supportedCaps()
-	cfg.Capabilities = &lconfigs.Capabilities{
-		Bounding:    allCaps,
-		Permitted:   nil,
-		Inheritable: nil,
-		Ambient:     nil,
-		Effective:   nil,
+
+	// match capabilities used in Nomad 0.8
+	if command.User == "root" {
+		cfg.Capabilities = &lconfigs.Capabilities{
+			Bounding:    allCaps,
+			Permitted:   allCaps,
+			Effective:   allCaps,
+			Ambient:     nil,
+			Inheritable: nil,
+		}
+	} else {
+		cfg.Capabilities = &lconfigs.Capabilities{
+			Bounding: allCaps,
+		}
 	}
 
 	return nil

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -249,7 +249,7 @@ func TestExecutor_Capabilities(t *testing.T) {
 	defer allocDir.Destroy()
 
 	execCmd.ResourceLimits = true
-	execCmd.Cmd = "/bin/sh"
+	execCmd.Cmd = "/bin/bash"
 	execCmd.Args = []string{"-c", "cat /proc/$$/cmdline"}
 
 	executor := NewExecutorWithIsolation(testlog.HCLogger(t))

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -473,7 +473,7 @@ func setupRootfsBinary(t *testing.T, rootfs, path string) {
 	t.Helper()
 
 	dst := filepath.Join(rootfs, path)
-	err := os.MkdirAll(filepath.Dir(dst), 666)
+	err := os.MkdirAll(filepath.Dir(dst), 0755)
 	require.NoError(t, err)
 
 	src := filepath.Join(


### PR DESCRIPTION
Nomad 0.9 incidentally set effective capabilities that is higher than
what's expected of a `nobody` process, and what's set in 0.8.

This change restores the capabilities to ones used in Nomad 0.8.

The capabilities impact is non-trivial.  Some operations (e.g. mount/shutdown) seems to check for effective uid so by default `nobody` user wouldn't be doing much damage.  On the other hand, other operations seem to succeed, e.g. binding to privileged ports as nobody.

Some capabilities are dangerous: CAP_DAC_OVERRIDE allowed processes to read and manipulate any accessible paths bypassing file permission checks.  Restoring proper permisisons, unmasked two tests that didn't have permissions set correctly.