### PR TITLE
nomad: fix race in BlockedEvals

### DIFF
--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -450,10 +450,10 @@ func (b *BlockedEvals) UnblockQuota(quota string, index uint64) {
 // be enqueued into the eval broker.
 func (b *BlockedEvals) UnblockClassAndQuota(class, quota string, index uint64) {
 	b.l.Lock()
+	defer b.l.Unlock()
 
 	// Do nothing if not enabled
 	if !b.enabled {
-		b.l.Unlock()
 		return
 	}
 
@@ -464,7 +464,6 @@ func (b *BlockedEvals) UnblockClassAndQuota(class, quota string, index uint64) {
 		b.unblockIndexes[quota] = index
 	}
 	b.unblockIndexes[class] = index
-	b.l.Unlock()
 
 	b.capacityChangeCh <- &capacityUpdate{
 		computedClass: class,


### PR DESCRIPTION
We need to capture the chan inside the lock to avoid a race. Concurrent operations on a chan are safe, but concurrent gets+sets on a struct field are not.  The race was:

```
==================
WARNING: DATA RACE
Write at 0x00c00237b770 by goroutine 2373:
  github.com/hashicorp/nomad/nomad.(*BlockedEvals).Flush()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/blocked_evals.go:648 +0x32a
  github.com/hashicorp/nomad/nomad.(*BlockedEvals).SetEnabled()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/blocked_evals.go:149 +0x16f
  github.com/hashicorp/nomad/nomad.(*Server).revokeLeadership()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/leader.go:726 +0x232
  github.com/hashicorp/nomad/nomad.(*Server).leaderLoop.func1()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/leader.go:135 +0x3c
  github.com/hashicorp/nomad/nomad.(*Server).leaderLoop()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/leader.go:167 +0x4dd
  github.com/hashicorp/nomad/nomad.(*Server).monitorLeadership.func1()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/leader.go:76 +0x6c

Previous read at 0x00c00237b770 by goroutine 2012:
  github.com/hashicorp/nomad/nomad.(*BlockedEvals).UnblockClassAndQuota()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/blocked_evals.go:469 +0x1a7
  github.com/hashicorp/nomad/nomad.(*nomadFSM).applyAllocClientUpdate()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/fsm.go:744 +0x961
  github.com/hashicorp/nomad/nomad.(*nomadFSM).Apply()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/fsm.go:209 +0x8aa
  github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft.(*Raft).runFSM.func1()
      /home/schmichael/go/src/github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft/fsm.go:57 +0x3b3
  github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft.(*Raft).runFSM()
      /home/schmichael/go/src/github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft/fsm.go:120 +0x3de
  github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft.(*Raft).runFSM-fm()
      /home/schmichael/go/src/github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft/api.go:506 +0x41
  github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft.(*raftState).goFunc.func1()
      /home/schmichael/go/src/github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft/state.go:146 +0x60

Goroutine 2373 (running) created at:
  github.com/hashicorp/nomad/nomad.(*Server).monitorLeadership()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/leader.go:74 +0x269

Goroutine 2012 (running) created at:
  github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft.(*raftState).goFunc()
      /home/schmichael/go/src/github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft/state.go:144 +0x73
  github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft.NewRaft()
      /home/schmichael/go/src/github.com/hashicorp/nomad/vendor/github.com/hashicorp/raft/api.go:506 +0x1227
  github.com/hashicorp/nomad/nomad.(*Server).setupRaft()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/server.go:1231 +0xbdb
  github.com/hashicorp/nomad/nomad.NewServer()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/server.go:348 +0x11a7
  github.com/hashicorp/nomad/nomad.TestServer()
      /home/schmichael/go/src/github.com/hashicorp/nomad/nomad/testing.go:99 +0xc66
  github.com/hashicorp/nomad/client.TestAlloc_ExecStreaming()
      /home/schmichael/go/src/github.com/hashicorp/nomad/client/alloc_endpoint_test.go:468 +0x9b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162
==================
```