### PR TITLE
UI: Allocation lifecycle

### DIFF
--- a/ui/app/adapters/allocation.js
+++ b/ui/app/adapters/allocation.js
@@ -1,3 +1,22 @@
 import Watchable from './watchable';
+import addToPath from 'nomad-ui/utils/add-to-path';
 
-export default Watchable.extend();
+export default Watchable.extend({
+  stop: adapterAction('/stop'),
+  restart: adapterAction((adapter, allocation) => {
+    const prefix = `${adapter.host || '/'}${adapter.urlPrefix()}`;
+    return `${prefix}/client/allocation/${allocation.id}/restart`;
+  }, 'PUT'),
+});
+
+function adapterAction(path, verb = 'POST') {
+  return function(allocation) {
+    let url;
+    if (typeof path === 'function') {
+      url = path(this, allocation);
+    } else {
+      url = addToPath(this.urlForFindRecord(allocation.id, 'allocation'), path);
+    }
+    return this.ajax(url, verb);
+  };
+}

--- a/ui/app/adapters/allocation.js
+++ b/ui/app/adapters/allocation.js
@@ -3,20 +3,19 @@ import addToPath from 'nomad-ui/utils/add-to-path';
 
 export default Watchable.extend({
   stop: adapterAction('/stop'),
-  restart: adapterAction((adapter, allocation) => {
-    const prefix = `${adapter.host || '/'}${adapter.urlPrefix()}`;
-    return `${prefix}/client/allocation/${allocation.id}/restart`;
-  }, 'PUT'),
+
+  restart(allocation, taskName) {
+    const prefix = `${this.host || '/'}${this.urlPrefix()}`;
+    const url = `${prefix}/client/allocation/${allocation.id}/restart`;
+    return this.ajax(url, 'PUT', {
+      data: taskName && { TaskName: taskName },
+    });
+  },
 });
 
 function adapterAction(path, verb = 'POST') {
   return function(allocation) {
-    let url;
-    if (typeof path === 'function') {
-      url = path(this, allocation);
-    } else {
-      url = addToPath(this.urlForFindRecord(allocation.id, 'allocation'), path);
-    }
+    const url = addToPath(this.urlForFindRecord(allocation.id, 'allocation'), path);
     return this.ajax(url, verb);
   };
 }

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -1,5 +1,6 @@
 import { inject as service } from '@ember/service';
 import Watchable from './watchable';
+import addToPath from 'nomad-ui/utils/add-to-path';
 
 export default Watchable.extend({
   system: service(),
@@ -117,15 +118,4 @@ function associateNamespace(url, namespace) {
     url += `?namespace=${namespace}`;
   }
   return url;
-}
-
-function addToPath(url, extension = '') {
-  const [path, params] = url.split('?');
-  let newUrl = `${path}${extension}`;
-
-  if (params) {
-    newUrl += `?${params}`;
-  }
-
-  return newUrl;
 }

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -52,7 +52,7 @@ export default Controller.extend(Sortable, {
     } catch (err) {
       this.set('error', {
         title: 'Could Not Stop Allocation',
-        description: 'Your ACL token does not grant allocation lifecyle permissions.',
+        description: 'Your ACL token does not grant allocation lifecycle permissions.',
       });
     }
   }),
@@ -63,7 +63,7 @@ export default Controller.extend(Sortable, {
     } catch (err) {
       this.set('error', {
         title: 'Could Not Restart Allocation',
-        description: 'Your ACL token does not grant allocation lifecyle permissions.',
+        description: 'Your ACL token does not grant allocation lifecycle permissions.',
       });
     }
   }),

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -1,6 +1,8 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
+import { task } from 'ember-concurrency';
 import Sortable from 'nomad-ui/mixins/sortable';
 import { lazyClick } from 'nomad-ui/helpers/lazy-click';
 
@@ -20,6 +22,40 @@ export default Controller.extend(Sortable, {
 
   // Set in the route
   preempter: null,
+
+  error: computed(() => {
+    // { title, description }
+    return null;
+  }),
+
+  onDismiss() {
+    this.set('error', null);
+  },
+
+  stopAllocation: task(function*() {
+    try {
+      yield this.model.stop();
+      // Eagerly update the allocation clientStatus to avoid flickering
+      this.model.set('clientStatus', 'complete');
+    } catch (err) {
+      this.set('error', {
+        title: 'Could Not Stop Allocation',
+        description: 'Your ACL token does not grant allocation lifecyle permissions.',
+      });
+    }
+  }),
+
+  restartAllocation: task(function*() {
+    try {
+      yield this.model.restart();
+    } catch (err) {
+      console.log('oops', err);
+      this.set('error', {
+        title: 'Could Not Stop Allocation',
+        description: 'Your ACL token does not grant allocation lifecyle permissions.',
+      });
+    }
+  }),
 
   actions: {
     gotoTask(allocation, task) {

--- a/ui/app/controllers/allocations/allocation/task/index.js
+++ b/ui/app/controllers/allocations/allocation/task/index.js
@@ -35,10 +35,9 @@ export default Controller.extend({
     try {
       yield this.model.restart();
     } catch (err) {
-      console.log('OOPs', err);
       this.set('error', {
         title: 'Could Not Restart Task',
-        description: 'Your ACL token does not grant allocation lifecyle permissions.',
+        description: 'Your ACL token does not grant allocation lifecycle permissions.',
       });
     }
   }),

--- a/ui/app/controllers/allocations/allocation/task/index.js
+++ b/ui/app/controllers/allocations/allocation/task/index.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
+import { task } from 'ember-concurrency';
 
 export default Controller.extend({
   network: alias('model.resources.networks.firstObject'),
@@ -19,5 +20,26 @@ export default Controller.extend({
         }))
       )
       .sortBy('name');
+  }),
+
+  error: computed(() => {
+    // { title, description }
+    return null;
+  }),
+
+  onDismiss() {
+    this.set('error', null);
+  },
+
+  restartTask: task(function*() {
+    try {
+      yield this.model.restart();
+    } catch (err) {
+      console.log('OOPs', err);
+      this.set('error', {
+        title: 'Could Not Restart Task',
+        description: 'Your ACL token does not grant allocation lifecyle permissions.',
+      });
+    }
   }),
 });

--- a/ui/app/mixins/with-watchers.js
+++ b/ui/app/mixins/with-watchers.js
@@ -33,7 +33,7 @@ export default Mixin.create(WithVisibilityDetection, {
   actions: {
     willTransition(transition) {
       // Don't cancel watchers if transitioning into a sub-route
-      if (!transition.intent.name.startsWith(this.routeName)) {
+      if (!transition.intent.name || !transition.intent.name.startsWith(this.routeName)) {
         this.cancelAllWatchers();
       }
 

--- a/ui/app/mixins/with-watchers.js
+++ b/ui/app/mixins/with-watchers.js
@@ -31,8 +31,11 @@ export default Mixin.create(WithVisibilityDetection, {
   },
 
   actions: {
-    willTransition() {
-      this.cancelAllWatchers();
+    willTransition(transition) {
+      // Don't cancel watchers if transitioning into a sub-route
+      if (!transition.intent.name.startsWith(this.routeName)) {
+        this.cancelAllWatchers();
+      }
 
       // Bubble the action up to the application route
       return true;

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -104,7 +104,7 @@ export default Model.extend({
     return this.store.adapterFor('allocation').stop(this);
   },
 
-  restart() {
-    return this.store.adapterFor('allocation').restart(this);
+  restart(taskName) {
+    return this.store.adapterFor('allocation').restart(this, taskName);
   },
 });

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -99,4 +99,12 @@ export default Model.extend({
       );
     }
   ),
+
+  stop() {
+    return this.store.adapterFor('allocation').stop(this);
+  },
+
+  restart() {
+    return this.store.adapterFor('allocation').restart(this);
+  },
 });

--- a/ui/app/models/task-state.js
+++ b/ui/app/models/task-state.js
@@ -43,4 +43,8 @@ export default Fragment.extend({
 
     return classMap[this.state] || 'is-dark';
   }),
+
+  restart() {
+    return this.allocation.restart(this.name);
+  },
 });

--- a/ui/app/routes/allocations/allocation/index.js
+++ b/ui/app/routes/allocations/allocation/index.js
@@ -10,4 +10,10 @@ export default Route.extend({
 
     return this._super(...arguments);
   },
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.watchNext.cancelAll();
+    }
+  },
 });

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -4,4 +4,8 @@
   &.is-6 {
     margin-bottom: 0.5rem;
   }
+
+  &.with-headroom {
+    margin-top: 1rem;
+  }
 }

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -1,8 +1,42 @@
 <section class="section">
-  <h1 data-test-title class="title">
+  {{#if error}}
+    <div class="notification is-danger">
+      <div class="columns">
+        <div class="column">
+          <h3 data-test-error-title class="title is-4">{{error.title}}</h3>
+          <p data-test-error-body>{{error.description}}</p>
+        </div>
+        <div class="column is-centered is-minimum">
+          <button data-test-error-close class="button is-danger" onclick={{action onDismiss}}>Okay</button>
+        </div>
+      </div>
+    </div>
+  {{/if}}
+
+  <h1 data-test-title class="title with-headroom">
     Allocation {{model.name}}
     <span class="bumper-left tag {{model.statusClass}}">{{model.clientStatus}}</span>
     <span class="tag is-hollow is-small no-text-transform">{{model.id}}</span>
+    {{#if model.isRunning}}
+      {{two-step-button
+        data-test-stop
+        idleText="Stop"
+        cancelText="Cancel"
+        confirmText="Yes, Stop"
+        confirmationMessage="Are you sure? This will reschedule the allocation on a different client."
+        awaitingConfirmation=stopAllocation.isRunning
+        disabled=(or stopAllocation.isRunning restartAllocation.isRunning)
+        onConfirm=(perform stopAllocation)}}
+      {{two-step-button
+        data-test-restart
+        idleText="Restart"
+        cancelText="Cancel"
+        confirmText="Yes, Restart"
+        confirmationMessage="Are you sure? This will restart the allocation in-place."
+        awaitingConfirmation=restartAllocation.isRunning
+        disabled=(or stopAllocation.isRunning restartAllocation.isRunning)
+        onConfirm=(perform restartAllocation)}}
+    {{/if}}
   </h1>
 
   <div class="boxed-section is-small">

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -1,13 +1,13 @@
 <section class="section">
   {{#if error}}
-    <div class="notification is-danger">
+    <div data-test-inline-error class="notification is-danger">
       <div class="columns">
         <div class="column">
-          <h3 data-test-error-title class="title is-4">{{error.title}}</h3>
-          <p data-test-error-body>{{error.description}}</p>
+          <h3 data-test-inline-error-title class="title is-4">{{error.title}}</h3>
+          <p data-test-inline-error-body>{{error.description}}</p>
         </div>
         <div class="column is-centered is-minimum">
-          <button data-test-error-close class="button is-danger" onclick={{action onDismiss}}>Okay</button>
+          <button data-test-inline-error-close class="button is-danger" onclick={{action onDismiss}}>Okay</button>
         </div>
       </div>
     </div>

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -1,8 +1,33 @@
 {{partial "allocations/allocation/task/subnav"}}
 <section class="section">
+  {{#if error}}
+    <div class="notification is-danger">
+      <div class="columns">
+        <div class="column">
+          <h3 data-test-error-title class="title is-4">{{error.title}}</h3>
+          <p data-test-error-body>{{error.description}}</p>
+        </div>
+        <div class="column is-centered is-minimum">
+          <button data-test-error-close class="button is-danger" onclick={{action onDismiss}}>Okay</button>
+        </div>
+      </div>
+    </div>
+  {{/if}}
+
   <h1 class="title" data-test-title>
     {{model.name}}
     <span class="bumper-left tag {{model.stateClass}}" data-test-state>{{model.state}}</span>
+    {{#if model.isRunning}}
+      {{two-step-button
+        data-test-restart
+        idleText="Restart"
+        cancelText="Cancel"
+        confirmText="Yes, Restart"
+        confirmationMessage="Are you sure? This will restart the task in-place."
+        awaitingConfirmation=restartTask.isRunning
+        disabled=restartTask.isRunning
+        onConfirm=(perform restartTask)}}
+    {{/if}}
   </h1>
 
   <div class="boxed-section is-small">

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -1,14 +1,14 @@
 {{partial "allocations/allocation/task/subnav"}}
 <section class="section">
   {{#if error}}
-    <div class="notification is-danger">
+    <div data-test-inline-error class="notification is-danger">
       <div class="columns">
         <div class="column">
-          <h3 data-test-error-title class="title is-4">{{error.title}}</h3>
-          <p data-test-error-body>{{error.description}}</p>
+          <h3 data-test-inline-error-title class="title is-4">{{error.title}}</h3>
+          <p data-test-inline-error-body>{{error.description}}</p>
         </div>
         <div class="column is-centered is-minimum">
-          <button data-test-error-close class="button is-danger" onclick={{action onDismiss}}>Okay</button>
+          <button data-test-inline-error-close class="button is-danger" onclick={{action onDismiss}}>Okay</button>
         </div>
       </div>
     </div>

--- a/ui/app/templates/components/two-step-button.hbs
+++ b/ui/app/templates/components/two-step-button.hbs
@@ -1,5 +1,10 @@
 {{#if isIdle}}
-  <button data-test-idle-button type="button" class="button is-danger is-outlined is-important is-small" onclick={{action "promptForConfirmation"}}>
+  <button
+    data-test-idle-button
+    type="button"
+    class="button is-danger is-outlined is-important is-small"
+    disabled={{disabled}}
+    onclick={{action "promptForConfirmation"}}>
     {{idleText}}
   </button>
 {{else if isPendingConfirmation}}

--- a/ui/app/utils/add-to-path.js
+++ b/ui/app/utils/add-to-path.js
@@ -1,0 +1,11 @@
+// Adds a string to the end of a URL path while being mindful of query params
+export default function addToPath(url, extension = '') {
+  const [path, params] = url.split('?');
+  let newUrl = `${path}${extension}`;
+
+  if (params) {
+    newUrl += `?${params}`;
+  }
+
+  return newUrl;
+}

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -200,6 +200,10 @@ export default function() {
 
   this.get('/allocation/:id');
 
+  this.post('/allocation/:id/stop', function() {
+    return new Response(204, {}, '');
+  });
+
   this.get('/namespaces', function({ namespaces }) {
     const records = namespaces.all();
 
@@ -301,6 +305,10 @@ export default function() {
   };
 
   // Client requests are available on the server and the client
+  this.put('/client/allocation/:id/restart', function() {
+    return new Response(204, {}, '');
+  });
+
   this.get('/client/allocation/:id/stats', clientAllocationStatsHandler);
   this.get('/client/fs/logs/:allocation_id', clientAllocationLog);
 

--- a/ui/tests/integration/two-step-button-test.js
+++ b/ui/tests/integration/two-step-button-test.js
@@ -14,6 +14,7 @@ module('Integration | Component | two step button', function(hooks) {
     confirmText: 'Confirm Action',
     confirmationMessage: 'Are you certain',
     awaitingConfirmation: false,
+    disabled: false,
     onConfirm: sinon.spy(),
     onCancel: sinon.spy(),
   });
@@ -25,6 +26,7 @@ module('Integration | Component | two step button', function(hooks) {
       confirmText=confirmText
       confirmationMessage=confirmationMessage
       awaitingConfirmation=awaitingConfirmation
+      disabled=disabled
       onConfirm=onConfirm
       onCancel=onCancel}}
   `;
@@ -134,5 +136,69 @@ module('Integration | Component | two step button', function(hooks) {
         'The confirm button is in a loading state'
       );
     });
+  });
+
+  test('when in the prompt state, clicking outside will reset state back to idle', async function(assert) {
+    const props = commonProperties();
+    this.setProperties(props);
+    await render(commonTemplate);
+
+    click('[data-test-idle-button]');
+    await settled();
+
+    assert.ok(find('[data-test-cancel-button]'), 'In the prompt state');
+
+    click(document.body);
+    await settled();
+
+    assert.ok(find('[data-test-idle-button]'), 'Back in the idle state');
+  });
+
+  test('when in the prompt state, clicking inside will not reset state back to idle', async function(assert) {
+    const props = commonProperties();
+    this.setProperties(props);
+    await render(commonTemplate);
+
+    click('[data-test-idle-button]');
+    await settled();
+
+    assert.ok(find('[data-test-cancel-button]'), 'In the prompt state');
+
+    click('[data-test-confirmation-message]');
+    await settled();
+
+    assert.notOk(find('[data-test-idle-button]'), 'Still in the prompt state');
+  });
+
+  test('when awaitingConfirmation is true, clicking outside does nothing', async function(assert) {
+    const props = commonProperties();
+    props.awaitingConfirmation = true;
+    this.setProperties(props);
+    await render(commonTemplate);
+
+    click('[data-test-idle-button]');
+    await settled();
+
+    assert.ok(find('[data-test-cancel-button]'), 'In the prompt state');
+
+    click(document.body);
+    await settled();
+
+    assert.notOk(find('[data-test-idle-button]'), 'Still in the prompt state');
+  });
+
+  test('when disabled is true, the idle button is disabled', async function(assert) {
+    const props = commonProperties();
+    props.disabled = true;
+    this.setProperties(props);
+    await render(commonTemplate);
+
+    assert.ok(
+      find('[data-test-idle-button]').hasAttribute('disabled'),
+      'The idle button is disabled'
+    );
+
+    click('[data-test-idle-button]');
+    assert.ok(find('[data-test-idle-button]'), 'Still in the idle state after clicking');
   });
 });

--- a/ui/tests/integration/two-step-button-test.js
+++ b/ui/tests/integration/two-step-button-test.js
@@ -4,6 +4,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { create } from 'ember-cli-page-object';
+import twoStepButton from 'nomad-ui/tests/pages/components/two-step-button';
+
+const TwoStepButton = create(twoStepButton());
 
 module('Integration | Component | two step button', function(hooks) {
   setupRenderingTest(hooks);
@@ -37,11 +41,7 @@ module('Integration | Component | two step button', function(hooks) {
     await render(commonTemplate);
 
     assert.ok(find('[data-test-idle-button]'), 'Idle button is rendered');
-    assert.equal(
-      find('[data-test-idle-button]').textContent.trim(),
-      props.idleText,
-      'Button is labeled correctly'
-    );
+    assert.equal(TwoStepButton.idleText, props.idleText, 'Button is labeled correctly');
 
     assert.notOk(find('[data-test-cancel-button]'), 'No cancel button yet');
     assert.notOk(find('[data-test-confirm-button]'), 'No confirm button yet');
@@ -53,25 +53,17 @@ module('Integration | Component | two step button', function(hooks) {
     this.setProperties(props);
     await render(commonTemplate);
 
-    click('[data-test-idle-button]');
+    TwoStepButton.idle();
 
     return settled().then(() => {
       assert.ok(find('[data-test-cancel-button]'), 'Cancel button is rendered');
-      assert.equal(
-        find('[data-test-cancel-button]').textContent.trim(),
-        props.cancelText,
-        'Button is labeled correctly'
-      );
+      assert.equal(TwoStepButton.cancelText, props.cancelText, 'Button is labeled correctly');
 
       assert.ok(find('[data-test-confirm-button]'), 'Confirm button is rendered');
-      assert.equal(
-        find('[data-test-confirm-button]').textContent.trim(),
-        props.confirmText,
-        'Button is labeled correctly'
-      );
+      assert.equal(TwoStepButton.confirmText, props.confirmText, 'Button is labeled correctly');
 
       assert.equal(
-        find('[data-test-confirmation-message]').textContent.trim(),
+        TwoStepButton.confirmationMessage,
         props.confirmationMessage,
         'Confirmation message is shown'
       );
@@ -85,10 +77,10 @@ module('Integration | Component | two step button', function(hooks) {
     this.setProperties(props);
     await render(commonTemplate);
 
-    click('[data-test-idle-button]');
+    TwoStepButton.idle();
 
     return settled().then(() => {
-      click('[data-test-cancel-button]');
+      TwoStepButton.cancel();
 
       return settled().then(() => {
         assert.ok(props.onCancel.calledOnce, 'The onCancel hook fired');
@@ -102,10 +94,10 @@ module('Integration | Component | two step button', function(hooks) {
     this.setProperties(props);
     await render(commonTemplate);
 
-    click('[data-test-idle-button]');
+    TwoStepButton.idle();
 
     return settled().then(() => {
-      click('[data-test-confirm-button]');
+      TwoStepButton.confirm();
 
       return settled().then(() => {
         assert.ok(props.onConfirm.calledOnce, 'The onConfirm hook fired');
@@ -120,21 +112,12 @@ module('Integration | Component | two step button', function(hooks) {
     this.setProperties(props);
     await render(commonTemplate);
 
-    click('[data-test-idle-button]');
+    TwoStepButton.idle();
 
     return settled().then(() => {
-      assert.ok(
-        find('[data-test-cancel-button]').hasAttribute('disabled'),
-        'The cancel button is disabled'
-      );
-      assert.ok(
-        find('[data-test-confirm-button]').hasAttribute('disabled'),
-        'The confirm button is disabled'
-      );
-      assert.ok(
-        find('[data-test-confirm-button]').classList.contains('is-loading'),
-        'The confirm button is in a loading state'
-      );
+      assert.ok(TwoStepButton.cancelIsDisabled, 'The cancel button is disabled');
+      assert.ok(TwoStepButton.confirmIsDisabled, 'The confirm button is disabled');
+      assert.ok(TwoStepButton.isRunning, 'The confirm button is in a loading state');
     });
   });
 
@@ -143,7 +126,7 @@ module('Integration | Component | two step button', function(hooks) {
     this.setProperties(props);
     await render(commonTemplate);
 
-    click('[data-test-idle-button]');
+    TwoStepButton.idle();
     await settled();
 
     assert.ok(find('[data-test-cancel-button]'), 'In the prompt state');
@@ -159,7 +142,7 @@ module('Integration | Component | two step button', function(hooks) {
     this.setProperties(props);
     await render(commonTemplate);
 
-    click('[data-test-idle-button]');
+    TwoStepButton.idle();
     await settled();
 
     assert.ok(find('[data-test-cancel-button]'), 'In the prompt state');
@@ -176,7 +159,7 @@ module('Integration | Component | two step button', function(hooks) {
     this.setProperties(props);
     await render(commonTemplate);
 
-    click('[data-test-idle-button]');
+    TwoStepButton.idle();
     await settled();
 
     assert.ok(find('[data-test-cancel-button]'), 'In the prompt state');
@@ -193,12 +176,9 @@ module('Integration | Component | two step button', function(hooks) {
     this.setProperties(props);
     await render(commonTemplate);
 
-    assert.ok(
-      find('[data-test-idle-button]').hasAttribute('disabled'),
-      'The idle button is disabled'
-    );
+    assert.ok(TwoStepButton.isDisabled, 'The idle button is disabled');
 
-    click('[data-test-idle-button]');
+    TwoStepButton.idle();
     assert.ok(find('[data-test-idle-button]'), 'Still in the idle state after clicking');
   });
 });

--- a/ui/tests/pages/allocations/detail.js
+++ b/ui/tests/pages/allocations/detail.js
@@ -9,11 +9,15 @@ import {
 } from 'ember-cli-page-object';
 
 import allocations from 'nomad-ui/tests/pages/components/allocations';
+import twoStepButton from 'nomad-ui/tests/pages/components/two-step-button';
 
 export default create({
   visit: visitable('/allocations/:id'),
 
   title: text('[data-test-title]'),
+
+  stop: twoStepButton('[data-test-stop]'),
+  restart: twoStepButton('[data-test-restart]'),
 
   details: {
     scope: '[data-test-allocation-details]',
@@ -76,5 +80,12 @@ export default create({
     title: text('[data-test-error-title]'),
     message: text('[data-test-error-message]'),
     seekHelp: clickable('[data-test-error-message] a'),
+  },
+
+  inlineError: {
+    isShown: isPresent('[data-test-inline-error]'),
+    title: text('[data-test-inline-error-title]'),
+    message: text('[data-test-inline-error-body]'),
+    dismiss: clickable('[data-test-inline-error-close]'),
   },
 });

--- a/ui/tests/pages/allocations/task/detail.js
+++ b/ui/tests/pages/allocations/task/detail.js
@@ -8,12 +8,16 @@ import {
   visitable,
 } from 'ember-cli-page-object';
 
+import twoStepButton from 'nomad-ui/tests/pages/components/two-step-button';
+
 export default create({
   visit: visitable('/allocations/:id/:name'),
 
   title: text('[data-test-title]'),
   state: text('[data-test-state]'),
   startedAt: text('[data-test-started-at]'),
+
+  restart: twoStepButton('[data-test-restart]'),
 
   breadcrumbs: collection('[data-test-breadcrumb]', {
     id: attribute('data-test-breadcrumb'),
@@ -50,5 +54,12 @@ export default create({
     title: text('[data-test-error-title]'),
     message: text('[data-test-error-message]'),
     seekHelp: clickable('[data-test-error-message] a'),
+  },
+
+  inlineError: {
+    isShown: isPresent('[data-test-inline-error]'),
+    title: text('[data-test-inline-error-title]'),
+    message: text('[data-test-inline-error-body]'),
+    dismiss: clickable('[data-test-inline-error-close]'),
   },
 });

--- a/ui/tests/pages/components/two-step-button.js
+++ b/ui/tests/pages/components/two-step-button.js
@@ -1,0 +1,14 @@
+import { attribute, clickable, hasClass, isPresent } from 'ember-cli-page-object';
+
+export default scope => ({
+  scope,
+
+  isPresent: isPresent(),
+
+  idle: clickable('[data-test-idle-button]'),
+  confirm: clickable('[data-test-confirm-button]'),
+  cancel: clickable('[data-test-cancel-button]'),
+
+  isRunning: hasClass('is-loading', '[data-test-confirm-button]'),
+  isDisabled: attribute('disabled', '[data-test-idle-button]'),
+});

--- a/ui/tests/pages/components/two-step-button.js
+++ b/ui/tests/pages/components/two-step-button.js
@@ -1,4 +1,4 @@
-import { attribute, clickable, hasClass, isPresent } from 'ember-cli-page-object';
+import { attribute, clickable, hasClass, isPresent, text } from 'ember-cli-page-object';
 
 export default scope => ({
   scope,
@@ -11,4 +11,12 @@ export default scope => ({
 
   isRunning: hasClass('is-loading', '[data-test-confirm-button]'),
   isDisabled: attribute('disabled', '[data-test-idle-button]'),
+
+  cancelIsDisabled: attribute('disabled', '[data-test-cancel-button]'),
+  confirmIsDisabled: attribute('disabled', '[data-test-confirm-button]'),
+
+  idleText: text('[data-test-idle-button]'),
+  cancelText: text('[data-test-cancel-button]'),
+  confirmText: text('[data-test-confirm-button]'),
+  confirmationMessage: text('[data-test-confirmation-message]'),
 });

--- a/ui/tests/unit/adapters/allocation-test.js
+++ b/ui/tests/unit/adapters/allocation-test.js
@@ -1,0 +1,78 @@
+import { settled } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { startMirage } from 'nomad-ui/initializers/ember-cli-mirage';
+
+module('Unit | Adapter | Allocation', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(async function() {
+    this.store = this.owner.lookup('service:store');
+    this.subject = () => this.store.adapterFor('allocation');
+
+    this.server = startMirage();
+
+    this.server.create('namespace');
+    this.server.create('node');
+    this.server.create('job', { createAllocations: false });
+    this.server.create('allocation', { id: 'alloc-1' });
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
+  test('`stop` makes the correct API call', async function(assert) {
+    const { pretender } = this.server;
+    const allocationId = 'alloc-1';
+
+    const allocation = await this.store.findRecord('allocation', allocationId);
+    pretender.handledRequests.length = 0;
+
+    await this.subject().stop(allocation);
+    const req = pretender.handledRequests[0];
+    assert.equal(
+      `${req.method} ${req.url}`,
+      `POST /v1/allocation/${allocationId}/stop`,
+      `POST /v1/allocation/${allocationId}/stop`
+    );
+  });
+
+  test('`restart` makes the correct API call', async function(assert) {
+    const { pretender } = this.server;
+    const allocationId = 'alloc-1';
+
+    const allocation = await this.store.findRecord('allocation', allocationId);
+    pretender.handledRequests.length = 0;
+
+    await this.subject().restart(allocation);
+    const req = pretender.handledRequests[0];
+    assert.equal(
+      `${req.method} ${req.url}`,
+      `PUT /v1/client/allocation/${allocationId}/restart`,
+      `PUT /v1/client/allocation/${allocationId}/restart`
+    );
+  });
+
+  test('`restart` takes an optional task name and makes the correct API call', async function(assert) {
+    const { pretender } = this.server;
+    const allocationId = 'alloc-1';
+    const taskName = 'task-name';
+
+    const allocation = await this.store.findRecord('allocation', allocationId);
+    pretender.handledRequests.length = 0;
+
+    await this.subject().restart(allocation, taskName);
+    const req = pretender.handledRequests[0];
+    assert.equal(
+      `${req.method} ${req.url}`,
+      `PUT /v1/client/allocation/${allocationId}/restart`,
+      `PUT /v1/client/allocation/${allocationId}/restart`
+    );
+    assert.deepEqual(
+      JSON.parse(req.requestBody),
+      { TaskName: taskName },
+      'Request body is correct'
+    );
+  });
+});

--- a/ui/tests/unit/adapters/allocation-test.js
+++ b/ui/tests/unit/adapters/allocation-test.js
@@ -1,4 +1,3 @@
-import { settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { startMirage } from 'nomad-ui/initializers/ember-cli-mirage';

--- a/ui/tests/unit/utils/add-to-path-test.js
+++ b/ui/tests/unit/utils/add-to-path-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import addToPath from 'nomad-ui/utils/add-to-path';
+
+const testCases = [
+  {
+    name: 'Only domain',
+    in: ['https://domain.com', '/path'],
+    out: 'https://domain.com/path',
+  },
+  {
+    name: 'Deep path',
+    in: ['https://domain.com/a/path', '/to/nowhere'],
+    out: 'https://domain.com/a/path/to/nowhere',
+  },
+  {
+    name: 'With Query Params',
+    in: ['https://domain.com?interesting=development', '/this-is-an'],
+    out: 'https://domain.com/this-is-an?interesting=development',
+  },
+];
+
+module('Unit | Util | addToPath', function() {
+  testCases.forEach(testCase => {
+    test(testCase.name, function(assert) {
+      assert.equal(
+        addToPath.apply(null, testCase.in),
+        testCase.out,
+        `[${testCase.in.join(', ')}] => ${testCase.out}`
+      );
+    });
+  });
+});


### PR DESCRIPTION
UI support for allocation stop and restart and task restart.

Integrates with blocking queries to give live-updating of task restarts, including task events, as well as allocation stop, including rescheduled allocation client status.

![image](https://user-images.githubusercontent.com/174740/58060009-464cfb00-7b24-11e9-8f7f-7ffd77e0d647.png)
_Stop and restart buttons on the allocation detail page_

![image](https://user-images.githubusercontent.com/174740/58060037-51079000-7b24-11e9-8098-4a70d4f524f1.png)
_Confirmation text for stopping_

![image](https://user-images.githubusercontent.com/174740/58060043-5a90f800-7b24-11e9-82f1-8f692970d24e.png)
_After stopping an allocation, the reschedule events lead to the new allocation._

![image](https://user-images.githubusercontent.com/174740/58060049-62e93300-7b24-11e9-9c05-aae4a68cefa2.png)
_Confirmation text for restarting_

![image](https://user-images.githubusercontent.com/174740/58060099-84e2b580-7b24-11e9-847d-16ce79d6b463.png)
_Restart button and task events on the task detail page_