### PR TITLE
Fix restart attempts of `restart` stanza in `delay` mode.

### DIFF
--- a/client/allocrunner/taskrunner/restarts/restarts.go
+++ b/client/allocrunner/taskrunner/restarts/restarts.go
@@ -169,8 +169,6 @@ func (r *RestartTracker) GetState() (string, time.Duration) {
 		return structs.TaskNotRestarting, 0
 	}
 
-	r.count++
-
 	// Check if we have entered a new interval.
 	end := r.startTime.Add(r.policy.Interval)
 	now := time.Now()
@@ -178,6 +176,8 @@ func (r *RestartTracker) GetState() (string, time.Duration) {
 		r.count = 0
 		r.startTime = now
 	}
+
+	r.count++
 
 	// Handle restarts due to failures
 	if !r.failure {


### PR DESCRIPTION
```
restart {
  interval = "1m"
  attempts = 2
  delay    = "5s"
  mode     = "delay"
}
```
Imagine constantly failing job with restart policy in mode `delay`, starting from 2nd interval every subsequent one gets one extra restart attempt. Root cause stems from the fact that attempts counter is being reset (line no. 178) just after it was incremented.
```
                                        +
            1st INTERVAL                |          2nd INTERVAL
            all good                    |          one extra restart
                                        |
                                        |
     initial      1st       2nd         |     initial      1st        2nd       3rd
     attempt      restart   restart     |     attempt      restart    restart   EXTRA restart
                                        |
        +           +        +          |         +           +          +          +
        |           |        |          |         |           |          |          |
        |           |        |          |         |           |          |          |
        |           |        |          |         |           |          |          |
        |           |        |          |         |           |          |          |
 +-+----+-----+-----+----+---+---+----------------+-----+-----+-----+----+------+---+----->
   |    t     |          |       |      |       t+60s   |           |           |
   +          +          +       |      |               |           +           +
count=0    count=1    count=2    |      |               |        count=1     count=2
   +          +          +       +      +               +           +           +
                              count=3              count=4
                            stop and wait          but wait! It is
                            for the new            the new interval
                            interval               so reset the counter!
                                                   counter=0
                                                   (line no. 178)
```
If we increment counter after checking if we have entered a new interval we should by fine.