### PR TITLE
client: synchronize access to `ar.alloc`

### DIFF
--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -45,7 +45,7 @@ func (a *allocHealthSetter) SetHealth(healthy, isDeploy bool, trackerTaskEvents 
 	a.ar.stateLock.Lock()
 	a.ar.state.SetDeploymentStatus(time.Now(), healthy)
 	a.ar.persistDeploymentStatus(a.ar.state.DeploymentStatus)
-	terminalDesiredState := a.ar.alloc.ServerTerminalStatus()
+	terminalDesiredState := a.ar.Alloc().ServerTerminalStatus()
 	a.ar.stateLock.Unlock()
 
 	// If deployment is unhealthy emit task events explaining why


### PR DESCRIPTION
`allocRunner.alloc` is protected by `allocRunner.allocLock`, so let's
use `allocRunner.Alloc()` helper function to access it.