### PR TITLE
client: Pass servers contacted ch to allocrunner

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -404,7 +404,7 @@ func (tr *TaskRunner) Run() {
 		case <-tr.shutdownCtx.Done():
 			return
 		case <-tr.serversContactedCh:
-			tr.logger.Trace("server contacted; unblocking waiting task")
+			tr.logger.Info("server contacted; unblocking waiting task")
 		}
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -1016,6 +1016,7 @@ func (c *Client) restoreState() error {
 			PrevAllocMigrator:   prevAllocMigrator,
 			DeviceManager:       c.devicemanager,
 			DriverManager:       c.drivermanager,
+			ServersContactedCh:  c.serversContactedCh,
 		}
 		c.configLock.RUnlock()
 


### PR DESCRIPTION
This fixes an issue where batch and service workloads would never be
restarted due to indefinitely blocking on a nil channel.

It also raises the restoration logging message to `Info` to simplify log
analysis.