### PR TITLE
devcluster: Add standalone server

### DIFF
--- a/dev/cluster/server-standalone.hcl
+++ b/dev/cluster/server-standalone.hcl
@@ -1,0 +1,15 @@
+# Increase log verbosity
+log_level = "DEBUG"
+
+# Setup data dir
+data_dir = "/tmp/serverstandalone"
+
+# Give the agent a unique name. Defaults to hostname
+name = "serverstandalone"
+
+# Enable the server
+server {
+  enabled = true
+
+  bootstrap_expect = 1
+}


### PR DESCRIPTION
This adds a single-node configuration of a dev cluster, for use when
testing things that require state restoration or multiple clients, but don't
necessarily require a 3+ node cluster.