### PR TITLE
Cleanup docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ BUG FIXES:
  * client: Job validation now checks that the datacenter field does not contain empty strings [[GH-5665](https://github.com/hashicorp/nomad/pull/5665)]
  * client: Fix network port mapping  related environment variables when running with Nomad 0.8 servers [[GH-5587](https://github.com/hashicorp/nomad/issues/5587)]
  * client: Fix issue with terminal state deployments being modified when allocation subsequently fails [[GH-5645](https://github.com/hashicorp/nomad/issues/5645)]
+ * driver/docker: Fix regression around image GC [[GH-5768](https://github.com/hashicorp/nomad/issues/5768)]
  * metrics: Fixed stale metrics [[GH-5540](https://github.com/hashicorp/nomad/issues/5540)]
  * vault: Fix renewal time to be 1/2 lease duration with jitter [[GH-5479](https://github.com/hashicorp/nomad/issues/5479)]
 

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1109,7 +1109,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 	if err != nil {
 		switch err.(type) {
 		case *docker.NoSuchContainer:
-			h.logger.Error("failed to inspect container state, will proceed with DestroyTask",
+			h.logger.Info("container was removed out of band, will proceed with DestroyTask",
 				"error", err)
 		default:
 			return fmt.Errorf("failed to inspect container state: %v", err)

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1107,24 +1107,30 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 
 	c, err := h.client.InspectContainer(h.containerID)
 	if err != nil {
-		return fmt.Errorf("failed to inspect container state: %v", err)
-	}
-
-	if c.State.Running {
-		if !force {
-			return fmt.Errorf("must call StopTask for the given task before Destroy or set force to true")
-		}
-		if err := h.client.StopContainer(h.containerID, 0); err != nil {
-			h.logger.Warn("failed to stop container during destroy", "error", err)
-		}
-	}
-
-	if h.removeContainerOnExit {
-		if err := h.client.RemoveContainer(docker.RemoveContainerOptions{ID: h.containerID, RemoveVolumes: true, Force: true}); err != nil {
-			h.logger.Error("error removing container", "error", err)
+		switch err.(type) {
+		case *docker.NoSuchContainer:
+			h.logger.Error("failed to inspect container state, will proceed with DestroyTask",
+				"error", err)
+		default:
+			return fmt.Errorf("failed to inspect container state: %v", err)
 		}
 	} else {
-		h.logger.Debug("not removing container due to config")
+		if c.State.Running {
+			if !force {
+				return fmt.Errorf("must call StopTask for the given task before Destroy or set force to true")
+			}
+			if err := h.client.StopContainer(h.containerID, 0); err != nil {
+				h.logger.Warn("failed to stop container during destroy", "error", err)
+			}
+		}
+
+		if h.removeContainerOnExit {
+			if err := h.client.RemoveContainer(docker.RemoveContainerOptions{ID: h.containerID, RemoveVolumes: true, Force: true}); err != nil {
+				h.logger.Error("error removing container", "error", err)
+			}
+		} else {
+			h.logger.Debug("not removing container due to config")
+		}
 	}
 
 	if err := d.cleanupImage(h); err != nil {

--- a/drivers/docker/handle.go
+++ b/drivers/docker/handle.go
@@ -212,15 +212,6 @@ func (h *taskHandle) run() {
 		}
 	}
 
-	// Remove the container
-	if h.removeContainerOnExit == true {
-		if err := h.client.RemoveContainer(docker.RemoveContainerOptions{ID: h.containerID, RemoveVolumes: true, Force: true}); err != nil {
-			h.logger.Error("error removing container", "error", err)
-		}
-	} else {
-		h.logger.Debug("not removing container due to config")
-	}
-
 	// Set the result
 	h.exitResultLock.Lock()
 	h.exitResult = &drivers.ExitResult{

--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -75,7 +75,7 @@ func (h *DriverHarness) Kill() {
 	h.server.Stop()
 }
 
-// MkAllocDir creates a tempory directory and allocdir structure.
+// MkAllocDir creates a temporary directory and allocdir structure.
 // If enableLogs is set to true a logmon instance will be started to write logs
 // to the LogDir of the task
 // A cleanup func is returned and should be defered so as to not leak dirs


### PR DESCRIPTION
Resolves #5659 

Before 0.9, the docker driver would remove the docker container in `run()` after it had finished. After the refactor as a task driver plugin, this code was left in `StartTask()`. However, this was causing `DestroyTask()` to error early when it attempted to inspect the (deleted) container. This early exit was preventing image cleanup from happening.

This change moves the container remove over to `DestroyTask()`, so that it can be inspected and stopped. Tests are added for the image GC.

Update: Also, the process has been hardened to handle cases where the docker image has been removed out-of-band.