### PR TITLE
nomad: revert use of SnapshotAfter in planApply

### DIFF
--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -1,7 +1,6 @@
 package nomad
 
 import (
-	"context"
 	"fmt"
 	"runtime"
 	"time"
@@ -100,15 +99,7 @@ func (p *planner) planApply() {
 		// Snapshot the state so that we have a consistent view of the world
 		// if no snapshot is available
 		if waitCh == nil || snap == nil {
-			// Wait up to 5s for raft to catch up. Timing out
-			// causes the eval to be nacked and retried on another
-			// server, so timing out too quickly could cause
-			// greater scheduling latency than if we just waited
-			// longer here.
-			const indexTimeout = 5 * time.Second
-			ctx, cancel := context.WithTimeout(context.Background(), indexTimeout)
-			snap, err = p.fsm.State().SnapshotAfter(ctx, p.raft.LastIndex())
-			cancel()
+			snap, err = p.fsm.State().Snapshot()
 			if err != nil {
 				p.logger.Error("failed to snapshot state", "error", err)
 				pending.respond(nil, err)


### PR DESCRIPTION
Revert plan_apply.go changes from #5411

Since non-Command Raft messages do not update the StateStore index,
SnapshotAfter may unnecessarily block and needlessly fail in idle
clusters where the last Raft message is a non-Command message.

This is trivially reproducible with the dev agent and a job that has 2
tasks, 1 of which fails.

The correct logic would be to SnapshotAfter the previous plan's index to
ensure consistency. New clusters or newly elected leaders will not have
a previous plan, so the index the leader was elected should be used
instead.