### PR TITLE
Add support for consul EnableTagOverride

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -364,14 +364,14 @@ type ServiceCheck struct {
 
 // The Service model represents a Consul service definition
 type Service struct {
-	Id           string
-	Name         string
-	Tags         []string
-	CanaryTags   []string `mapstructure:"canary_tags"`
-	PortLabel    string   `mapstructure:"port"`
-	AddressMode  string   `mapstructure:"address_mode"`
-	Checks       []ServiceCheck
-	CheckRestart *CheckRestart `mapstructure:"check_restart"`
+	Id                string
+	Name              string
+	Tags              []string
+	CanaryTags        []string `mapstructure:"canary_tags"`
+	PortLabel         string   `mapstructure:"port"`
+	AddressMode       string   `mapstructure:"address_mode"`
+	Checks            []ServiceCheck
+	CheckRestart      *CheckRestart `mapstructure:"check_restart"`
 	EnableTagOverride bool
 }
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -372,6 +372,7 @@ type Service struct {
 	AddressMode  string   `mapstructure:"address_mode"`
 	Checks       []ServiceCheck
 	CheckRestart *CheckRestart `mapstructure:"check_restart"`
+	EnableTagOverride bool
 }
 
 func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -695,6 +695,7 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, t
 		Meta: map[string]string{
 			"external-source": "nomad",
 		},
+		EnableTagOverride: service.EnableTagOverride,
 	}
 	ops.regServices = append(ops.regServices, serviceReg)
 

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -94,6 +94,7 @@ func agentServiceUpdateRequired(reg *api.AgentServiceRegistration, svc *api.Agen
 		reg.Port == svc.Port &&
 		reg.Address == svc.Address &&
 		reg.Name == svc.Service &&
+		reg.EnableTagOverride == svc.EnableTagOverride &&
 		reflect.DeepEqual(reg.Tags, svc.Tags))
 }
 
@@ -597,6 +598,7 @@ func (c *ServiceClient) RegisterAgent(role string, services []*structs.Service) 
 			Meta: map[string]string{
 				"external-source": "nomad",
 			},
+			EnableTagOverride: service.EnableTagOverride,
 		}
 		ops.regServices = append(ops.regServices, serviceReg)
 
@@ -1111,9 +1113,9 @@ func makeAgentServiceID(role string, service *structs.Service) string {
 // Consul. All structs.Service fields are included in the ID's hash except
 // Checks. This allows updates to merely compare IDs.
 //
-//	Example Service ID: _nomad-task-b4e61df9-b095-d64e-f241-23860da1375f-redis-http
+//	Example Service ID: _nomad-task-b4e61df9-b095-d64e-f241-23860da1375f-redis-http-false
 func makeTaskServiceID(allocID, taskName string, service *structs.Service, canary bool) string {
-	return fmt.Sprintf("%s%s-%s-%s", nomadTaskPrefix, allocID, taskName, service.Name)
+	return fmt.Sprintf("%s%s-%s-%s-%t", nomadTaskPrefix, allocID, taskName, service.Name, service.EnableTagOverride)
 }
 
 // makeCheckID creates a unique ID for a check.

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -98,6 +98,13 @@ func agentServiceUpdateRequired(reg *api.AgentServiceRegistration, svc *api.Agen
 		reflect.DeepEqual(reg.Tags, svc.Tags))
 }
 
+// Replace with Consul tags
+func replaceServiceTagsWithConsulTags(reg *api.AgentServiceRegistration, svc *api.AgentService) {
+	if svc != nil {
+		copy(reg.Tags, svc.Tags)
+	}
+}
+
 // operations are submitted to the main loop via commit() for synchronizing
 // with Consul.
 type operations struct {
@@ -486,6 +493,11 @@ func (c *ServiceClient) sync() error {
 		existingSvc, ok := consulServices[id]
 
 		if ok {
+			if locals.EnableTagOverride {
+				// if EnableTagOverride is set, then we want to keep the tags updated by external services
+				replaceServiceTagsWithConsulTags(locals, existingSvc)
+			}
+
 			// There is an existing registration of this service in Consul, so here
 			// we validate to see if the service has been invalidated to see if it
 			// should be updated.

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -1296,6 +1296,36 @@ func TestConsul_CanaryTags_NoTags(t *testing.T) {
 	require.Len(ctx.FakeConsul.services, 0)
 }
 
+// TestConsul_EnableTagOverrideEnabled asserts EnableTagOverride is set when EnableTagOverride=true
+func TestConsul_EnableTagOverrideEnabled(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	ctx := setupFake(t)
+
+	ctx.Task.Services[0].EnableTagOverride = true
+
+	require.NoError(ctx.ServiceClient.RegisterTask(ctx.Task))
+	require.NoError(ctx.syncOnce())
+	require.Len(ctx.FakeConsul.services, 1)
+	for _, service := range ctx.FakeConsul.services {
+		require.Equal(true, service.EnableTagOverride)
+	}
+}
+
+// TestConsul_EnableTagOverrideIsDisabledByDefault asserts EnableTagOverride is disabled by default
+func TestConsul_EnableTagOverrideIsDisabledByDefault(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	ctx := setupFake(t)
+
+	require.NoError(ctx.ServiceClient.RegisterTask(ctx.Task))
+	require.NoError(ctx.syncOnce())
+	require.Len(ctx.FakeConsul.services, 1)
+	for _, service := range ctx.FakeConsul.services {
+		require.Equal(false, service.EnableTagOverride)
+	}
+}
+
 // TestConsul_PeriodicSync asserts that Nomad periodically reconciles with
 // Consul.
 func TestConsul_PeriodicSync(t *testing.T) {

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -177,7 +177,6 @@ func TestConsul_ChangeEnableTagOverride(t *testing.T) {
 	require.NotNil(reg1, "Unexpected nil alloc registration")
 	require.Equal(1, reg1.NumServices())
 
-
 	for _, v := range ctx.FakeConsul.services {
 		require.Equal(false, v.EnableTagOverride)
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -763,11 +763,12 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 		structsTask.Services = make([]*structs.Service, l)
 		for i, service := range apiTask.Services {
 			structsTask.Services[i] = &structs.Service{
-				Name:        service.Name,
-				PortLabel:   service.PortLabel,
-				Tags:        service.Tags,
-				CanaryTags:  service.CanaryTags,
-				AddressMode: service.AddressMode,
+				Name:              service.Name,
+				PortLabel:         service.PortLabel,
+				Tags:              service.Tags,
+				CanaryTags:        service.CanaryTags,
+				AddressMode:       service.AddressMode,
+				EnableTagOverride: service.EnableTagOverride,
 			}
 
 			if l := len(service.Checks); l != 0 {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1398,6 +1398,11 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 									},
 								},
 							},
+							{
+								Id:                "id_serviceB",
+								Name:              "serviceB",
+								EnableTagOverride: true,
+							},
 						},
 						Resources: &api.Resources{
 							CPU:      helper.IntToPtr(100),
@@ -1697,6 +1702,11 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 										},
 									},
 								},
+							},
+							{
+								Name:              "serviceB",
+								EnableTagOverride: true,
+								AddressMode:       "auto",
 							},
 						},
 						Resources: &structs.Resources{

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3951,6 +3951,12 @@ func TestTaskDiff(t *testing.T) {
 						Fields: []*FieldDiff{
 							{
 								Type: DiffTypeAdded,
+								Name: "EnableTagOverride",
+								Old:  "",
+								New:  "false",
+							},
+							{
+								Type: DiffTypeAdded,
 								Name: "Name",
 								Old:  "",
 								New:  "bam",
@@ -3967,6 +3973,12 @@ func TestTaskDiff(t *testing.T) {
 						Type: DiffTypeDeleted,
 						Name: "Service",
 						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "EnableTagOverride",
+								Old:  "false",
+								New:  "",
+							},
 							{
 								Type: DiffTypeDeleted,
 								Name: "Name",
@@ -4015,6 +4027,12 @@ func TestTaskDiff(t *testing.T) {
 								Type: DiffTypeAdded,
 								Name: "AddressMode",
 								New:  "driver",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "EnableTagOverride",
+								Old:  "false",
+								New:  "false",
 							},
 							{
 								Type: DiffTypeNone,
@@ -4112,6 +4130,12 @@ func TestTaskDiff(t *testing.T) {
 							{
 								Type: DiffTypeNone,
 								Name: "AddressMode",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "EnableTagOverride",
+								Old:  "false",
+								New:  "false",
 							},
 							{
 								Type: DiffTypeNone,
@@ -4446,6 +4470,12 @@ func TestTaskDiff(t *testing.T) {
 								Name: "AddressMode",
 								Old:  "",
 								New:  "",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "EnableTagOverride",
+								Old:  "false",
+								New:  "false",
 							},
 							{
 								Type: DiffTypeNone,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5113,10 +5113,10 @@ type Service struct {
 	// this service.
 	AddressMode string
 
-	Tags       []string        // List of tags for the service
-	CanaryTags []string        // List of tags for the service when it is a canary
-	Checks     []*ServiceCheck // List of checks associated with the service
-	EnableTagOverride bool	   // Allow external agents to change the tags for a service
+	Tags              []string        // List of tags for the service
+	CanaryTags        []string        // List of tags for the service when it is a canary
+	Checks            []*ServiceCheck // List of checks associated with the service
+	EnableTagOverride bool            // Allow external agents to change the tags for a service
 }
 
 func (s *Service) Copy() *Service {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5116,6 +5116,7 @@ type Service struct {
 	Tags       []string        // List of tags for the service
 	CanaryTags []string        // List of tags for the service when it is a canary
 	Checks     []*ServiceCheck // List of checks associated with the service
+	EnableTagOverride bool	   // Allow external agents to change the tags for a service
 }
 
 func (s *Service) Copy() *Service {


### PR DESCRIPTION
At the moment the Consul's EnableTagOverride flag not being set by Nomad, so the default(false) is always used. In certain cases it is useful for services outside Nomad to update the tags of the Consul services, however for that to happen EnableTagOverride has to be set to true.
This change enables setting EnableTagOverride at a service level.
An older request describing this can be found here #2057