### PR TITLE
nomad: disable service+batch preemption by default

### DIFF
--- a/command/agent/operator_endpoint_test.go
+++ b/command/agent/operator_endpoint_test.go
@@ -271,9 +271,11 @@ func TestOperator_SchedulerGetConfiguration(t *testing.T) {
 		require.Equal(200, resp.Code)
 		out, ok := obj.(structs.SchedulerConfigurationResponse)
 		require.True(ok)
+
+		// Only system jobs can preempt other jobs by default.
 		require.True(out.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
-		require.True(out.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
-		require.True(out.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
+		require.False(out.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
+		require.False(out.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
 	})
 }
 

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -48,8 +48,8 @@ var minSchedulerConfigVersion = version.Must(version.NewVersion("0.9.0"))
 var defaultSchedulerConfig = &structs.SchedulerConfiguration{
 	PreemptionConfig: structs.PreemptionConfig{
 		SystemSchedulerEnabled:  true,
-		BatchSchedulerEnabled:   true,
-		ServiceSchedulerEnabled: true,
+		BatchSchedulerEnabled:   false,
+		ServiceSchedulerEnabled: false,
 	},
 }
 

--- a/website/source/api/operator.html.md
+++ b/website/source/api/operator.html.md
@@ -364,8 +364,8 @@ $ curl \
     "ModifyIndex": 5,
     "PreemptionConfig": {
       "SystemSchedulerEnabled": true,
-      "BatchSchedulerEnabled": true,
-      "ServiceSchedulerEnabled": true,
+      "BatchSchedulerEnabled": false,
+      "ServiceSchedulerEnabled": false
     }
   }
 }
@@ -381,10 +381,10 @@ $ curl \
   - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for various schedulers.
          - `SystemSchedulerEnabled` `(bool: true)` - Specifies whether preemption for system jobs is enabled. Note that
          this defaults to true.
-         - `BatchSchedulerEnabled` <sup>0.9.2</sup> `(bool: true)` (Enterprise Only) - Specifies whether preemption for batch jobs is enabled. Note that
-         this defaults to true.
-         - `ServiceSchedulerEnabled` <sup>0.9.2</sup> `(bool: true)` (Enterprise Only) - Specifies whether preemption for service jobs is enabled. Note that
-         this defaults to true.
+         - `BatchSchedulerEnabled` <sup>0.9.2</sup> `(bool: false)` (Enterprise Only) - Specifies whether preemption for batch jobs is enabled. Note that
+         this defaults to false and must be explicitly enabled.
+         - `ServiceSchedulerEnabled` <sup>0.9.2</sup> `(bool: false)` (Enterprise Only) - Specifies whether preemption for service jobs is enabled. Note that
+         this defaults to false and must be explicitly enabled.
   - `CreateIndex` - The Raft index at which the config was created.
   - `ModifyIndex` - The Raft index at which the config was modified.
 
@@ -415,9 +415,9 @@ The table below shows this endpoint's support for
 ```json
 {
   "PreemptionConfig": {
-    "SystemSchedulerEnabled": false,
+    "SystemSchedulerEnabled": true,
     "BatchSchedulerEnabled": false,
-    "ServiceSchedulerEnabled": true,
+    "ServiceSchedulerEnabled": true
   }
 }
 ```
@@ -425,7 +425,7 @@ The table below shows this endpoint's support for
 - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for various schedulers.
  - `SystemSchedulerEnabled` `(bool: true)` - Specifies whether preemption for system jobs is enabled. Note that
          if this is set to true, then system jobs can preempt any other jobs.
- - `BatchSchedulerEnabled` <sup>0.9.2</sup> `(bool: true)` (Enterprise Only) - Specifies whether preemption for batch jobs is enabled. Note that
+ - `BatchSchedulerEnabled` <sup>0.9.2</sup> `(bool: false)` (Enterprise Only) - Specifies whether preemption for batch jobs is enabled. Note that
          if this is set to true, then batch jobs can preempt any other jobs.
- - `ServiceSchedulerEnabled` <sup>0.9.2</sup> `(bool: true)` (Enterprise Only) - Specifies whether preemption for service jobs is enabled. Note that
+ - `ServiceSchedulerEnabled` <sup>0.9.2</sup> `(bool: false)` (Enterprise Only) - Specifies whether preemption for service jobs is enabled. Note that
          if this is set to true, then service jobs can preempt any other jobs.


### PR DESCRIPTION
Enterprise only.

Disable preemption for service and batch jobs by default.

Maintain backward compatibility in a x.y.Z release. Consider switching
the default for new clusters in the future.

Approximately follows #5628

Manually tested upgrade path from 0.9.1:

- System scheduler setting is preserved
- Server and Batch default to false.