### PR TITLE
batch node deregistration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
  * core: Removed deprecated upgrade path code pertaining to older versions of Nomad [[GH-5894](https://github.com/hashicorp/nomad/issues/5894)]
+ * core: Deregister nodes in batches rather than one at a time [[GH-5784](https://github.com/hashicorp/nomad/pull/5784)
  * client: Improved task event display message to include kill time out [[GH-5943](https://github.com/hashicorp/nomad/issues/5943)]
  * api: Used region from job hcl when not provided as query parameter in job registration and plan endpoints [[GH-5664](https://github.com/hashicorp/nomad/pull/5664)]
  * api: Inferred content type of file in alloc filesystem stat endpoint [[GH-5907](https://github.com/hashicorp/nomad/issues/5907)]

--- a/contributing/checklist-rpc-endpoint.md
+++ b/contributing/checklist-rpc-endpoint.md
@@ -4,7 +4,9 @@ Prefer adding a new message to changing any existing RPC messages.
 
 ## Code
 
-* [ ] `Request` struct and `RequestType` constant in `nomad/structs/structs.go`
+* [ ] `Request` struct and `*RequestType` constant in
+      `nomad/structs/structs.go`. Append the constant, old constant
+      values must remain unchanged
 * [ ] In `nomad/fsm.go`, add a dispatch case to the switch statement in `Apply`
   * `*nomadFSM` method to decode the request and call the state method
 * [ ] State method for modifying objects in a `Txn` in `nomad/state/state_store.go`

--- a/contributing/checklist-rpc-endpoint.md
+++ b/contributing/checklist-rpc-endpoint.md
@@ -1,0 +1,27 @@
+# New RPC Endpoint Checklist
+
+Prefer adding a new message to changing any existing RPC messages.
+
+## Code
+
+* [ ] `Request` struct and `RequestType` constant in `nomad/structs/structs.go`
+* [ ] In `nomad/fsm.go`, add a dispatch case to the switch statement in `Apply`
+  * `*nomadFSM` method to decode the request and call the state method
+* [ ] State method for modifying objects in a `Txn` in `nomad/state/state_store.go`
+  * `nomad/state/state_store_test.go`
+* [ ] Handler for the request in `nomad/foo_endpoint.go`
+  * RPCs are resolved by matching the method name for bound structs
+	[net/rpc](https://golang.org/pkg/net/rpc/)
+* Wrapper for the HTTP request in `command/agent/foo_endpoint.go`
+  * Backwards compatibility requires a new endpoint, an upgraded
+    client or server may be forwarding this request to an old server,
+    without support for the new RPC
+  * RPCs triggered by an internal process may not need support
+* [ ] `nomad/core_sched.go` sends many RPCs
+  * `ServersMeetMinimumVersion` asserts that the server cluster is
+    upgraded, so use this to gaurd sending the new RPC, else send the old RPC
+  * Version must match the actual release version!
+
+## Docs
+
+* [ ] Changelog

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -509,7 +509,7 @@ func (c *CoreScheduler) nodeReap(eval *structs.Evaluation, nodeIDs []string) err
 
 	// Call to the leader to issue the reap
 	for _, ids := range partitionAll(maxIdsPerReap, nodeIDs) {
-		req := structs.NodeDeregisterBatchRequest{
+		req := structs.NodeBatchDeregisterRequest{
 			NodeIDs: ids,
 			WriteRequest: structs.WriteRequest{
 				Region:    c.srv.config.Region,
@@ -517,7 +517,7 @@ func (c *CoreScheduler) nodeReap(eval *structs.Evaluation, nodeIDs []string) err
 			},
 		}
 		var resp structs.NodeUpdateResponse
-		if err := c.srv.RPC("Node.DeregisterBatch", &req, &resp); err != nil {
+		if err := c.srv.RPC("Node.BatchDeregister", &req, &resp); err != nil {
 			c.logger.Error("node reap failed", "node_ids", ids, "error", err)
 			return err
 		}

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -487,7 +487,7 @@ OUTER:
 }
 
 func (c *CoreScheduler) nodeReap(eval *structs.Evaluation, nodeIDs []string) error {
-	// For old clusters, send single deregistration messages
+	// For old clusters, send single deregistration messages COMPAT(0.11)
 	minVersionBatchNodeDeregister := version.Must(version.NewVersion("0.9.4"))
 	if !ServersMeetMinimumVersion(c.srv.Members(), minVersionBatchNodeDeregister, true) {
 		for _, id := range nodeIDs {

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -484,9 +484,9 @@ OUTER:
 	c.logger.Debug("node GC found eligible nodes", "nodes", len(gcNode))
 
 	// Call to the leader to issue the reap
-	for _, nodeID := range gcNode {
+	for _, ids := range partitionAll(maxIdsPerReap, gcNode) {
 		req := structs.NodeDeregisterRequest{
-			NodeID: nodeID,
+			NodeIDs: ids,
 			WriteRequest: structs.WriteRequest{
 				Region:    c.srv.config.Region,
 				AuthToken: eval.LeaderACL,
@@ -494,7 +494,7 @@ OUTER:
 		}
 		var resp structs.NodeUpdateResponse
 		if err := c.srv.RPC("Node.Deregister", &req, &resp); err != nil {
-			c.logger.Error("node reap failed", "node_id", nodeID, "error", err)
+			c.logger.Error("node reap failed", "node_ids", ids, "error", err)
 			return err
 		}
 	}

--- a/nomad/drainer/watch_nodes_test.go
+++ b/nomad/drainer/watch_nodes_test.go
@@ -126,7 +126,7 @@ func TestNodeDrainWatcher_Remove_Nonexistent(t *testing.T) {
 	require.Equal(n, tracked[n.ID])
 
 	// Delete the node
-	require.Nil(state.DeleteNode(101, n.ID))
+	require.Nil(state.DeleteNode(101, []string{n.ID}))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 2, nil
 	}, func(err error) {

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -296,7 +296,7 @@ func (n *nomadFSM) applyDeregisterNode(buf []byte, index uint64) interface{} {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.DeleteNode(index, req.NodeID); err != nil {
+	if err := n.state.DeleteNode(index, req.NodeIDs); err != nil {
 		n.logger.Error("DeleteNode failed", "error", err)
 		return err
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -297,14 +297,14 @@ func (n *nomadFSM) applyDeregisterNode(buf []byte, index uint64) interface{} {
 	}
 
 	// Messages pre 0.9.3 use a single NodeID
-	var ids []string
+	var nodeIDs []string
 	if len(req.NodeIDs) == 0 {
-		ids = []string{req.NodeID}
+		nodeIDs = append(nodeIDs, req.NodeID)
 	} else {
-		ids = req.NodeIDs
+		nodeIDs = req.NodeIDs
 	}
 
-	if err := n.state.DeleteNode(index, ids); err != nil {
+	if err := n.state.DeleteNode(index, nodeIDs); err != nil {
 		n.logger.Error("DeleteNode failed", "error", err)
 		return err
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -300,6 +300,8 @@ func (n *nomadFSM) applyDeregisterNode(buf []byte, index uint64) interface{} {
 	var nodeIDs []string
 	if len(req.NodeIDs) == 0 {
 		nodeIDs = append(nodeIDs, req.NodeID)
+	} else if req.NodeID != "" {
+		return fmt.Errorf("invalid request: set NodeIDs instead of NodeID")
 	} else {
 		nodeIDs = req.NodeIDs
 	}
@@ -308,6 +310,7 @@ func (n *nomadFSM) applyDeregisterNode(buf []byte, index uint64) interface{} {
 		n.logger.Error("DeleteNode failed", "error", err)
 		return err
 	}
+
 	return nil
 }
 

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -191,8 +191,6 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyUpsertNode(buf[1:], log.Index)
 	case structs.NodeDeregisterRequestType:
 		return n.applyDeregisterNode(buf[1:], log.Index)
-	case structs.NodeDeregisterBatchRequestType:
-		return n.applyDeregisterNodeBatch(buf[1:], log.Index)
 	case structs.NodeUpdateStatusRequestType:
 		return n.applyStatusUpdate(buf[1:], log.Index)
 	case structs.NodeUpdateDrainRequestType:
@@ -251,6 +249,8 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyBatchDrainUpdate(buf[1:], log.Index)
 	case structs.SchedulerConfigRequestType:
 		return n.applySchedulerConfigUpdate(buf[1:], log.Index)
+	case structs.NodeDeregisterBatchRequestType:
+		return n.applyDeregisterNodeBatch(buf[1:], log.Index)
 	}
 
 	// Check enterprise only message types.

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -296,7 +296,15 @@ func (n *nomadFSM) applyDeregisterNode(buf []byte, index uint64) interface{} {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.DeleteNode(index, req.NodeIDs); err != nil {
+	// Messages pre 0.9.3 use a single NodeID
+	var ids []string
+	if len(req.NodeIDs) == 0 {
+		ids = []string{req.NodeID}
+	} else {
+		ids = req.NodeIDs
+	}
+
+	if err := n.state.DeleteNode(index, ids); err != nil {
 		n.logger.Error("DeleteNode failed", "error", err)
 		return err
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -307,7 +307,7 @@ func (n *nomadFSM) applyDeregisterNode(buf []byte, index uint64) interface{} {
 }
 
 func (n *nomadFSM) applyDeregisterNodeBatch(buf []byte, index uint64) interface{} {
-	defer metrics.MeasureSince([]string{"nomad", "fsm", "deregister_node"}, time.Now())
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "batch_deregister_node"}, time.Now())
 	var req structs.NodeDeregisterBatchRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -249,7 +249,7 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyBatchDrainUpdate(buf[1:], log.Index)
 	case structs.SchedulerConfigRequestType:
 		return n.applySchedulerConfigUpdate(buf[1:], log.Index)
-	case structs.NodeDeregisterBatchRequestType:
+	case structs.NodeBatchDeregisterRequestType:
 		return n.applyDeregisterNodeBatch(buf[1:], log.Index)
 	}
 
@@ -308,7 +308,7 @@ func (n *nomadFSM) applyDeregisterNode(buf []byte, index uint64) interface{} {
 
 func (n *nomadFSM) applyDeregisterNodeBatch(buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "batch_deregister_node"}, time.Now())
-	var req structs.NodeDeregisterBatchRequest
+	var req structs.NodeBatchDeregisterRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -224,10 +224,10 @@ func TestFSM_DeregisterNode(t *testing.T) {
 		t.Fatalf("resp: %v", resp)
 	}
 
-	req2 := structs.NodeDeregisterRequest{
+	req2 := structs.NodeDeregisterBatchRequest{
 		NodeIDs: []string{node.ID},
 	}
-	buf, err = structs.Encode(structs.NodeDeregisterRequestType, req2)
+	buf, err = structs.Encode(structs.NodeDeregisterBatchRequestType, req2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -224,10 +224,10 @@ func TestFSM_DeregisterNode(t *testing.T) {
 		t.Fatalf("resp: %v", resp)
 	}
 
-	req2 := structs.NodeDeregisterBatchRequest{
+	req2 := structs.NodeBatchDeregisterRequest{
 		NodeIDs: []string{node.ID},
 	}
-	buf, err = structs.Encode(structs.NodeDeregisterBatchRequestType, req2)
+	buf, err = structs.Encode(structs.NodeBatchDeregisterRequestType, req2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -225,7 +225,7 @@ func TestFSM_DeregisterNode(t *testing.T) {
 	}
 
 	req2 := structs.NodeDeregisterRequest{
-		NodeID: node.ID,
+		NodeIDs: []string{node.ID},
 	}
 	buf, err = structs.Encode(structs.NodeDeregisterRequestType, req2)
 	if err != nil {

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -269,6 +269,8 @@ func (n *Node) Deregister(args *structs.NodeDeregisterRequest, reply *structs.No
 		nodeIDs = append(nodeIDs, args.NodeID)
 	} else if args.NodeID != "" {
 		return fmt.Errorf("use only NodeIDs, the NodeID field is deprecated")
+	} else {
+		nodeIDs = args.NodeIDs
 	}
 
 	// Open state handles

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -247,7 +247,7 @@ func (n *Node) constructNodeServerInfoResponse(snap *state.StateSnapshot, reply 
 
 // Deregister is the deprecated single deregistration endpoint
 func (n *Node) Deregister(args *structs.NodeDeregisterRequest, reply *structs.NodeUpdateResponse) error {
-	return n.DeregisterBatch(&structs.NodeDeregisterBatchRequest{
+	return n.DeregisterBatch(&structs.NodeBatchDeregisterRequest{
 		NodeIDs:      []string{args.NodeID},
 		WriteRequest: args.WriteRequest,
 	}, reply)
@@ -255,8 +255,8 @@ func (n *Node) Deregister(args *structs.NodeDeregisterRequest, reply *structs.No
 
 // DeregisterBatch is used to remove client nodes from the cluster. If a client should just
 // be made unavailable for scheduling, a status update is preferred.
-func (n *Node) DeregisterBatch(args *structs.NodeDeregisterBatchRequest, reply *structs.NodeUpdateResponse) error {
-	if done, err := n.srv.forward("Node.DeregisterBatch", args, args, reply); done {
+func (n *Node) DeregisterBatch(args *structs.NodeBatchDeregisterRequest, reply *structs.NodeUpdateResponse) error {
+	if done, err := n.srv.forward("Node.BatchDeregister", args, args, reply); done {
 		return err
 	}
 	defer metrics.MeasureSince([]string{"nomad", "client", "deregister"}, time.Now())
@@ -294,7 +294,7 @@ func (n *Node) DeregisterBatch(args *structs.NodeDeregisterBatchRequest, reply *
 
 	// Commit this update to Raft, before we clear the heartbeatTimer so that failure
 	// leaves the node running
-	_, index, err := n.srv.raftApply(structs.NodeDeregisterBatchRequestType, args)
+	_, index, err := n.srv.raftApply(structs.NodeBatchDeregisterRequestType, args)
 	if err != nil {
 		n.logger.Error("deregister failed", "error", err)
 		return err

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -223,7 +223,7 @@ func TestClientEndpoint_Deregister(t *testing.T) {
 
 	// Deregister
 	dereg := &structs.NodeDeregisterRequest{
-		NodeID:       node.ID,
+		NodeIDs:      []string{node.ID},
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	var resp2 structs.GenericResponse
@@ -270,7 +270,7 @@ func TestClientEndpoint_Deregister_ACL(t *testing.T) {
 
 	// Deregister without any token and expect it to fail
 	dereg := &structs.NodeDeregisterRequest{
-		NodeID:       node.ID,
+		NodeIDs:      []string{node.ID},
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	var resp structs.GenericResponse
@@ -296,7 +296,7 @@ func TestClientEndpoint_Deregister_ACL(t *testing.T) {
 
 	// Deregister with an invalid token.
 	dereg1 := &structs.NodeDeregisterRequest{
-		NodeID:       node1.ID,
+		NodeIDs:      []string{node1.ID},
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	dereg1.AuthToken = invalidToken.SecretID
@@ -345,7 +345,7 @@ func TestClientEndpoint_Deregister_Vault(t *testing.T) {
 
 	// Deregister
 	dereg := &structs.NodeDeregisterRequest{
-		NodeID:       node.ID,
+		NodeIDs:      []string{node.ID},
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	var resp2 structs.GenericResponse
@@ -1447,7 +1447,7 @@ func TestClientEndpoint_GetNode_Blocking(t *testing.T) {
 
 	// Node delete triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.DeleteNode(400, node2.ID); err != nil {
+		if err := state.DeleteNode(400, []string{node2.ID}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -2714,7 +2714,7 @@ func TestClientEndpoint_ListNodes_Blocking(t *testing.T) {
 
 	// Node delete triggers watches.
 	time.AfterFunc(100*time.Millisecond, func() {
-		errCh <- state.DeleteNode(50, node.ID)
+		errCh <- state.DeleteNode(50, []string{node.ID})
 	})
 
 	req.MinQueryIndex = 45

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -270,18 +270,18 @@ func TestClientEndpoint_Deregister_ACL(t *testing.T) {
 	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid", mock.NodePolicy(acl.PolicyRead))
 
 	// Deregister without any token and expect it to fail
-	dereg := &structs.NodeDeregisterBatchRequest{
+	dereg := &structs.NodeBatchDeregisterRequest{
 		NodeIDs:      []string{node.ID},
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	var resp structs.GenericResponse
-	if err := msgpackrpc.CallWithCodec(codec, "Node.DeregisterBatch", dereg, &resp); err == nil {
+	if err := msgpackrpc.CallWithCodec(codec, "Node.BatchDeregister", dereg, &resp); err == nil {
 		t.Fatalf("node de-register succeeded")
 	}
 
 	// Deregister with a valid token
 	dereg.AuthToken = validToken.SecretID
-	if err := msgpackrpc.CallWithCodec(codec, "Node.DeregisterBatch", dereg, &resp); err != nil {
+	if err := msgpackrpc.CallWithCodec(codec, "Node.BatchDeregister", dereg, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -296,18 +296,18 @@ func TestClientEndpoint_Deregister_ACL(t *testing.T) {
 	}
 
 	// Deregister with an invalid token.
-	dereg1 := &structs.NodeDeregisterBatchRequest{
+	dereg1 := &structs.NodeBatchDeregisterRequest{
 		NodeIDs:      []string{node1.ID},
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	dereg1.AuthToken = invalidToken.SecretID
-	if err := msgpackrpc.CallWithCodec(codec, "Node.DeregisterBatch", dereg1, &resp); err == nil {
+	if err := msgpackrpc.CallWithCodec(codec, "Node.BatchDeregister", dereg1, &resp); err == nil {
 		t.Fatalf("rpc should not have succeeded")
 	}
 
 	// Try with a root token
 	dereg1.AuthToken = root.SecretID
-	if err := msgpackrpc.CallWithCodec(codec, "Node.DeregisterBatch", dereg1, &resp); err != nil {
+	if err := msgpackrpc.CallWithCodec(codec, "Node.BatchDeregister", dereg1, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 }
@@ -345,12 +345,12 @@ func TestClientEndpoint_Deregister_Vault(t *testing.T) {
 	state.UpsertVaultAccessor(100, []*structs.VaultAccessor{va1, va2})
 
 	// Deregister
-	dereg := &structs.NodeDeregisterBatchRequest{
+	dereg := &structs.NodeBatchDeregisterRequest{
 		NodeIDs:      []string{node.ID},
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	var resp2 structs.GenericResponse
-	if err := msgpackrpc.CallWithCodec(codec, "Node.DeregisterBatch", dereg, &resp2); err != nil {
+	if err := msgpackrpc.CallWithCodec(codec, "Node.BatchDeregister", dereg, &resp2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if resp2.Index == 0 {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -684,18 +684,18 @@ func (s *StateStore) DeleteNode(index uint64, nodes []string) error {
 	for _, nodeID := range nodes {
 		existing, err := txn.First("nodes", "id", nodeID)
 		if err != nil {
-			return fmt.Errorf("node lookup failed: %v", err)
+			return fmt.Errorf("node lookup failed: %s: %v", nodeID, err)
 		}
 		if existing == nil {
-			return fmt.Errorf("node not found")
+			return fmt.Errorf("node not found: %s", nodeID)
 		}
 
 		// Delete the node
 		if err := txn.Delete("nodes", existing); err != nil {
-			return fmt.Errorf("node delete failed: %v", err)
+			return fmt.Errorf("node delete failed: %s: %v", nodeID, err)
 		}
 		if err := txn.Insert("index", &IndexEntry{"nodes", index}); err != nil {
-			return fmt.Errorf("index update failed: %v", err)
+			return fmt.Errorf("index update failed: %s: %v", nodeID, err)
 		}
 	}
 	txn.Commit()

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -677,28 +677,27 @@ func (s *StateStore) UpsertNode(index uint64, node *structs.Node) error {
 	return nil
 }
 
-// DeleteNode is used to deregister a node
-func (s *StateStore) DeleteNode(index uint64, nodeID string) error {
+// DeleteNode deregisters a batch of nodes
+func (s *StateStore) DeleteNode(index uint64, nodes []string) error {
 	txn := s.db.Txn(true)
 	defer txn.Abort()
+	for _, nodeID := range nodes {
+		existing, err := txn.First("nodes", "id", nodeID)
+		if err != nil {
+			return fmt.Errorf("node lookup failed: %v", err)
+		}
+		if existing == nil {
+			return fmt.Errorf("node not found")
+		}
 
-	// Lookup the node
-	existing, err := txn.First("nodes", "id", nodeID)
-	if err != nil {
-		return fmt.Errorf("node lookup failed: %v", err)
+		// Delete the node
+		if err := txn.Delete("nodes", existing); err != nil {
+			return fmt.Errorf("node delete failed: %v", err)
+		}
+		if err := txn.Insert("index", &IndexEntry{"nodes", index}); err != nil {
+			return fmt.Errorf("index update failed: %v", err)
+		}
 	}
-	if existing == nil {
-		return fmt.Errorf("node not found")
-	}
-
-	// Delete the node
-	if err := txn.Delete("nodes", existing); err != nil {
-		return fmt.Errorf("node delete failed: %v", err)
-	}
-	if err := txn.Insert("index", &IndexEntry{"nodes", index}); err != nil {
-		return fmt.Errorf("index update failed: %v", err)
-	}
-
 	txn.Commit()
 	return nil
 }

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -680,7 +680,7 @@ func (s *StateStore) UpsertNode(index uint64, node *structs.Node) error {
 // DeleteNode deregisters a batch of nodes
 func (s *StateStore) DeleteNode(index uint64, nodes []string) error {
 	if len(nodes) == 0 {
-		return nil
+		return fmt.Errorf("node ids missing")
 	}
 
 	txn := s.db.Txn(true)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -822,7 +822,7 @@ func TestStateStore_DeleteNode_Node(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	err = state.DeleteNode(1001, node.ID)
+	err = state.DeleteNode(1001, []string{node.ID})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -316,9 +316,9 @@ type NodeRegisterRequest struct {
 }
 
 // NodeDeregisterRequest is used for Node.Deregister endpoint
-// to deregister a node as being a schedulable entity.
+// to deregister a batch of nodes from being schedulable entities.
 type NodeDeregisterRequest struct {
-	NodeID string
+	NodeIDs []string
 	WriteRequest
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -83,7 +83,7 @@ const (
 	NodeUpdateEligibilityRequestType
 	BatchNodeUpdateDrainRequestType
 	SchedulerConfigRequestType
-	NodeDeregisterBatchRequestType
+	NodeBatchDeregisterRequestType
 )
 
 const (
@@ -324,9 +324,9 @@ type NodeDeregisterRequest struct {
 	WriteRequest
 }
 
-// NodeDeregisterBatchRequest is used for Node.DeregisterBatch endpoint
+// NodeBatchDeregisterRequest is used for Node.BatchDeregister endpoint
 // to deregister a batch of nodes from being schedulable entities.
-type NodeDeregisterBatchRequest struct {
+type NodeBatchDeregisterRequest struct {
 	NodeIDs []string
 	WriteRequest
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -54,7 +54,6 @@ type MessageType uint8
 const (
 	NodeRegisterRequestType MessageType = iota
 	NodeDeregisterRequestType
-	NodeDeregisterBatchRequestType // QUESTION does iota make it important to append this list?
 	NodeUpdateStatusRequestType
 	NodeUpdateDrainRequestType
 	JobRegisterRequestType
@@ -84,6 +83,7 @@ const (
 	NodeUpdateEligibilityRequestType
 	BatchNodeUpdateDrainRequestType
 	SchedulerConfigRequestType
+	NodeDeregisterBatchRequestType
 )
 
 const (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -317,8 +317,7 @@ type NodeRegisterRequest struct {
 }
 
 // NodeDeregisterRequest is used for Node.Deregister endpoint
-// to deregister a batch of nodes from being schedulable entities.
-// Deprecated in 0.9.3
+// to deregister a node as being a schedulable entity.
 type NodeDeregisterRequest struct {
 	NodeID string
 	WriteRequest

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -318,6 +318,7 @@ type NodeRegisterRequest struct {
 // NodeDeregisterRequest is used for Node.Deregister endpoint
 // to deregister a batch of nodes from being schedulable entities.
 type NodeDeregisterRequest struct {
+	NodeID  string // Deprecated in 0.9.3
 	NodeIDs []string
 	WriteRequest
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -54,6 +54,7 @@ type MessageType uint8
 const (
 	NodeRegisterRequestType MessageType = iota
 	NodeDeregisterRequestType
+	NodeDeregisterBatchRequestType // QUESTION does iota make it important to append this list?
 	NodeUpdateStatusRequestType
 	NodeUpdateDrainRequestType
 	JobRegisterRequestType
@@ -317,8 +318,15 @@ type NodeRegisterRequest struct {
 
 // NodeDeregisterRequest is used for Node.Deregister endpoint
 // to deregister a batch of nodes from being schedulable entities.
+// Deprecated in 0.9.3
 type NodeDeregisterRequest struct {
-	NodeID  string // Deprecated in 0.9.3
+	NodeID string
+	WriteRequest
+}
+
+// NodeDeregisterBatchRequest is used for Node.DeregisterBatch endpoint
+// to deregister a batch of nodes from being schedulable entities.
+type NodeDeregisterBatchRequest struct {
 	NodeIDs []string
 	WriteRequest
 }

--- a/nomad/util.go
+++ b/nomad/util.go
@@ -196,6 +196,34 @@ func shuffleStrings(list []string) {
 	}
 }
 
+// partitionAll splits a slice of strings into a slice of slices of strings, each with a max
+// size of `size`. All entries from the original slice are preserved. The last slice may be
+// smaller than `size`. The input slice is unmodified
+func partitionAll(size int, xs []string) [][]string {
+	out := make([][]string, 0)
+	if size < 1 {
+		return append(out, xs)
+	}
+
+	got, part, i, j := 0, 0, 0, 0
+	for got < len(xs) {
+		i = size * part
+		j = minInt(size*(part+1), len(xs))
+		out = append(out, xs[i:j])
+		part = part + 1
+		got = j
+	}
+
+	return out
+}
+
+func minInt(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
 // maxUint64 returns the maximum value
 func maxUint64(inputs ...uint64) uint64 {
 	l := len(inputs)

--- a/nomad/util.go
+++ b/nomad/util.go
@@ -200,28 +200,21 @@ func shuffleStrings(list []string) {
 // size of `size`. All entries from the original slice are preserved. The last slice may be
 // smaller than `size`. The input slice is unmodified
 func partitionAll(size int, xs []string) [][]string {
-	out := make([][]string, 0)
 	if size < 1 {
-		return append(out, xs)
+		return [][]string{xs}
 	}
 
-	got, part, i, j := 0, 0, 0, 0
-	for got < len(xs) {
-		i = size * part
-		j = minInt(size*(part+1), len(xs))
+	out := [][]string{}
+
+	for i := 0; i < len(xs); i += size {
+		j := i + size
+		if j > len(xs) {
+			j = len(xs)
+		}
 		out = append(out, xs[i:j])
-		part = part + 1
-		got = j
 	}
 
 	return out
-}
-
-func minInt(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
 }
 
 // maxUint64 returns the maximum value

--- a/nomad/util_test.go
+++ b/nomad/util_test.go
@@ -8,6 +8,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/serf/serf"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsNomadServer(t *testing.T) {
@@ -228,6 +229,21 @@ func TestShuffleStrings(t *testing.T) {
 	if reflect.DeepEqual(inp, orig) {
 		t.Fatalf("shuffle failed")
 	}
+}
+
+func Test_partitionAll(t *testing.T) {
+	xs := []string{"a", "b", "c", "d", "e", "f"}
+	// evenly divisible
+	require.Equal(t, [][]string{{"a", "b"}, {"c", "d"}, {"e", "f"}}, partitionAll(2, xs))
+	require.Equal(t, [][]string{{"a", "b", "c"}, {"d", "e", "f"}}, partitionAll(3, xs))
+	// whole thing fits int the last part
+	require.Equal(t, [][]string{{"a", "b", "c", "d", "e", "f"}}, partitionAll(7, xs))
+	// odd remainder
+	require.Equal(t, [][]string{{"a", "b", "c", "d"}, {"e", "f"}}, partitionAll(4, xs))
+	// zero size
+	require.Equal(t, [][]string{{"a", "b", "c", "d", "e", "f"}}, partitionAll(0, xs))
+	// one size
+	require.Equal(t, [][]string{{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}}, partitionAll(1, xs))
 }
 
 func TestMaxUint64(t *testing.T) {


### PR DESCRIPTION
Change node deregistration to operate on a batch of node is, partitioned into `maxIdsPerReap` slices. The user-facing API submits a batch of 1.

* [ ] Changelog