### PR TITLE
Fix a website link under `Runtime Environment`

### DIFF
--- a/website/source/docs/runtime/_envvars.html.md.erb
+++ b/website/source/docs/runtime/_envvars.html.md.erb
@@ -102,7 +102,7 @@
     <td><tt>NOMAD&lowbar;HOST&lowbar;PORT&lowbar;&lt;label&gt;</tt></td>
     <td>
       Port on the host for the port <tt>label</tt>. See
-      [here](/docs/job-specification/network.html#mapped&lowbar;ports) for more
+      [here](/docs/job-specification/network.html#port) for more
       information.
     </td>
   </tr>

--- a/website/source/docs/runtime/_envvars.html.md.erb
+++ b/website/source/docs/runtime/_envvars.html.md.erb
@@ -102,7 +102,7 @@
     <td><tt>NOMAD&lowbar;HOST&lowbar;PORT&lowbar;&lt;label&gt;</tt></td>
     <td>
       Port on the host for the port <tt>label</tt>. See
-      [here](/docs/job-specification/network.html#port) for more
+      [here](/docs/job-specification/network.html#mapped-ports) for more
       information.
     </td>
   </tr>


### PR DESCRIPTION
### Steps to reproduce:

1. Navigate to https://www.nomadproject.io/docs/runtime/environment.html
2. Under the `Network-related Variables` there is a `NOMAD_HOST_PORT_<label>` variable, click on the `here` link.
3. It navigates to https://www.nomadproject.io/docs/job-specification/network.html#mapped&lowbar;ports
4. It should navigate to https://www.nomadproject.io/docs/job-specification/network.html#port