### PR TITLE
nomad: include snapshot index when submitting plans

### DIFF
--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -184,7 +184,7 @@ func (p *planner) snapshotMinIndex(prevPlanResultIndex, planSnapshotIndex uint64
 
 	const timeout = 5 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	snap, err := p.fsm.State().SnapshotAfter(ctx, minIndex)
+	snap, err := p.fsm.State().SnapshotMinIndex(ctx, minIndex)
 	cancel()
 	if err == context.DeadlineExceeded {
 		return nil, fmt.Errorf("timed out after %s waiting for index=%d (previous plan result index=%d; plan snapshot index=%d)",

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -101,7 +101,7 @@ func (s *StateStore) Snapshot() (*StateSnapshot, error) {
 	return snap, nil
 }
 
-// SnapshotAfter is used to create a point in time snapshot where the index is
+// SnapshotMinIndex is used to create a state snapshot where the index is
 // guaranteed to be greater than or equal to the index parameter.
 //
 // Some server operations (such as scheduling) exchange objects via RPC
@@ -111,7 +111,7 @@ func (s *StateStore) Snapshot() (*StateSnapshot, error) {
 //
 // Callers should maintain their own timer metric as the time this method
 // blocks indicates Raft log application latency relative to scheduling.
-func (s *StateStore) SnapshotAfter(ctx context.Context, index uint64) (*StateSnapshot, error) {
+func (s *StateStore) SnapshotMinIndex(ctx context.Context, index uint64) (*StateSnapshot, error) {
 	// Ported from work.go:waitForIndex prior to 0.9
 
 	const backoffBase = 20 * time.Millisecond

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -7138,9 +7138,9 @@ func TestStateSnapshot_DenormalizeAllocationDiffSlice_AllocDoesNotExist(t *testi
 	require.Nil(denormalizedAllocs)
 }
 
-// TestStateStore_SnapshotAfter_OK asserts StateStore.SnapshotAfter blocks
+// TestStateStore_SnapshotMinIndex_OK asserts StateStore.SnapshotMinIndex blocks
 // until the StateStore's latest index is >= the requested index.
-func TestStateStore_SnapshotAfter_OK(t *testing.T) {
+func TestStateStore_SnapshotMinIndex_OK(t *testing.T) {
 	t.Parallel()
 
 	s := testStateStore(t)
@@ -7150,9 +7150,9 @@ func TestStateStore_SnapshotAfter_OK(t *testing.T) {
 	node := mock.Node()
 	require.NoError(t, s.UpsertNode(index+1, node))
 
-	// Assert SnapshotAfter returns immediately if index < latest index
+	// Assert SnapshotMinIndex returns immediately if index < latest index
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
-	snap, err := s.SnapshotAfter(ctx, index)
+	snap, err := s.SnapshotMinIndex(ctx, index)
 	cancel()
 	require.NoError(t, err)
 
@@ -7162,9 +7162,9 @@ func TestStateStore_SnapshotAfter_OK(t *testing.T) {
 		require.Fail(t, "snapshot index should be greater than index")
 	}
 
-	// Assert SnapshotAfter returns immediately if index == latest index
+	// Assert SnapshotMinIndex returns immediately if index == latest index
 	ctx, cancel = context.WithTimeout(context.Background(), 0)
-	snap, err = s.SnapshotAfter(ctx, index+1)
+	snap, err = s.SnapshotMinIndex(ctx, index+1)
 	cancel()
 	require.NoError(t, err)
 
@@ -7172,14 +7172,14 @@ func TestStateStore_SnapshotAfter_OK(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, snapIndex, index+1)
 
-	// Assert SnapshotAfter blocks if index > latest index
+	// Assert SnapshotMinIndex blocks if index > latest index
 	errCh := make(chan error, 1)
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	go func() {
 		defer close(errCh)
 		waitIndex := index + 2
-		snap, err := s.SnapshotAfter(ctx, waitIndex)
+		snap, err := s.SnapshotMinIndex(ctx, waitIndex)
 		if err != nil {
 			errCh <- err
 			return
@@ -7211,23 +7211,23 @@ func TestStateStore_SnapshotAfter_OK(t *testing.T) {
 	case err := <-errCh:
 		require.NoError(t, err)
 	case <-time.After(5 * time.Second):
-		require.Fail(t, "timed out waiting for SnapshotAfter to unblock")
+		require.Fail(t, "timed out waiting for SnapshotMinIndex to unblock")
 	}
 }
 
-// TestStateStore_SnapshotAfter_Timeout asserts StateStore.SnapshotAfter
+// TestStateStore_SnapshotMinIndex_Timeout asserts StateStore.SnapshotMinIndex
 // returns an error if the desired index is not reached within the deadline.
-func TestStateStore_SnapshotAfter_Timeout(t *testing.T) {
+func TestStateStore_SnapshotMinIndex_Timeout(t *testing.T) {
 	t.Parallel()
 
 	s := testStateStore(t)
 	index, err := s.LatestIndex()
 	require.NoError(t, err)
 
-	// Assert SnapshotAfter blocks if index > latest index
+	// Assert SnapshotMinIndex blocks if index > latest index
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	snap, err := s.SnapshotAfter(ctx, index+1)
+	snap, err := s.SnapshotMinIndex(ctx, index+1)
 	require.EqualError(t, err, context.DeadlineExceeded.Error())
 	require.Nil(t, snap)
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8605,6 +8605,11 @@ type Plan struct {
 	// lower priority jobs that are preempted. Preempted allocations are marked
 	// as evicted.
 	NodePreemptions map[string][]*Allocation
+
+	// SnapshotIndex is the Raft index of the snapshot used to create the
+	// Plan. The leader will wait to evaluate the plan until its StateStore
+	// has reached at least this index.
+	SnapshotIndex uint64
 }
 
 // AppendStoppedAlloc marks an allocation to be stopped. The clientStatus of the

--- a/nomad/worker.go
+++ b/nomad/worker.go
@@ -284,6 +284,10 @@ func (w *Worker) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, scheduler.
 	// Add the evaluation token to the plan
 	plan.EvalToken = w.evalToken
 
+	// Add SnapshotIndex to ensure leader's StateStore processes the Plan
+	// at or after the index it was created.
+	plan.SnapshotIndex = w.snapshotIndex
+
 	// Normalize stopped and preempted allocs before RPC
 	normalizePlan := ServersMeetMinimumVersion(w.srv.Members(), MinVersionPlanNormalization, true)
 	if normalizePlan {
@@ -319,7 +323,7 @@ SUBMIT:
 	}
 
 	// Check if a state update is required. This could be required if we
-	// planning based on stale data, which is causing issues. For example, a
+	// planned based on stale data, which is causing issues. For example, a
 	// node failure since the time we've started planning or conflicting task
 	// allocations.
 	var state scheduler.State

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -296,7 +296,7 @@ func TestWorker_waitForIndex(t *testing.T) {
 
 	// Wait for a future index
 	w := &Worker{srv: s1, logger: s1.logger}
-	snap, err := w.snapshotAfter(index+1, time.Second)
+	snap, err := w.snapshotMinIndex(index+1, time.Second)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 
@@ -306,7 +306,7 @@ func TestWorker_waitForIndex(t *testing.T) {
 	// Cause a timeout
 	waitIndex := index + 100
 	timeout := 10 * time.Millisecond
-	snap, err = w.snapshotAfter(index+100, timeout)
+	snap, err = w.snapshotMinIndex(index+100, timeout)
 	require.Nil(t, snap)
 	require.EqualError(t, err,
 		fmt.Sprintf("timed out after %s waiting for index=%d", timeout, waitIndex))


### PR DESCRIPTION
# tl;dr

Ensure leader's state snapshot is at or after `max(previousPlanResultIndex, plan.SnapshotIndex)` when evaluating and applying a plan.

# Background

Workers receive evals, create plans, and submit them to the leader for evaluation and applying. This scheduling pipeline runs concurrent with Raft over RPC between server agents to provide optimistic parallelism. The leader is responsible for evaluating workers' plans by ensuring they do not conflict and then applying them. Since this entire process is concurrent with Raft consensus, certain invariants must be met by the leader to ensure plans are evaluated and applied serially:

1. The leader's state used to evaluate plans must be equal to or newer than the state used to create the plan to ensure all referenced objects exist.
2. The leader's state used to evaluate and apply plans must be after previously applied plans (serialization).

# Implementation

The first invariant is enforced by ensuring the state snapshot used to evaluate plans is >= the snapshot at which the plan was created. (new in 1d670f2)

The second invariant is enforced through 3 mechanisms:

* The previous plan is optimistically applied to the leader's state when evaluating a plan. (pre-existing functionality)
* A Raft barrier is emitted after leader election which among other things ensures the leader's state includes all previously applied plans. (pre-existing functionality)
* The leader's state is at or after the previous plan result's index. (new in f82f2a6)

If either invariant cannot be met the plan fails and the worker must reprocess the evaluation.

# Previous Attempt

The previous attempt in #5411 attempted to enforce the invariants by ensuring the leader's state had caught up to the latest Raft index. It also contained some implementation bugs, but the concept was a valid way to enforce the invariants. However, it suffered from a couple issues:

* Certain Raft log entries, such as Barriers, do not increment any indexes in the state store, so the plan applier could never make progress if the previous log entry was a Barrier.
* Waiting for the leader's state to catch up to Raft's LastIndex, even if possible, could cause unnecessary blocking not required to enforce consistency. As long as the state is at a point to provide the invariants above, it may lag behind Raft's LastIndex without affecting correctness.