### PR TITLE
config meta parsing

### DIFF
--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -478,12 +478,10 @@ func TestConfig_ParsePanic(t *testing.T) {
 // structure should not be unexpected
 func TestConfig_ParseSliceExtra(t *testing.T) {
 	c, err := ParseConfigFile("./testdata/config-slices.json")
-	if err != nil {
-		t.Fatalf("parse error: %s\n", err)
-	}
+	require.NoError(t, err)
 
 	opt := map[string]string{"o0": "foo", "o1": "bar"}
-	meta := map[string]string{"m0": "foo", "m1": "bar"}
+	meta := map[string]string{"m0": "foo", "m1": "bar", "m2": "true", "m3": "1.2"}
 	env := map[string]string{"e0": "baz"}
 	srv := []string{"foo", "bar"}
 
@@ -497,9 +495,7 @@ func TestConfig_ParseSliceExtra(t *testing.T) {
 
 	// the alt format is also accepted by hcl as valid config data
 	c, err = ParseConfigFile("./testdata/config-slices-alt.json")
-	if err != nil {
-		t.Fatalf("parse error: %s\n", err)
-	}
+	require.NoError(t, err)
 
 	require.EqualValues(t, opt, c.Client.Options)
 	require.EqualValues(t, meta, c.Client.Meta)
@@ -511,9 +507,7 @@ func TestConfig_ParseSliceExtra(t *testing.T) {
 
 	// small files keep more extra keys than large ones
 	_, err = ParseConfigFile("./testdata/obj-len-one-server.json")
-	if err != nil {
-		t.Fatalf("parse error: %s\n", err)
-	}
+	require.NoError(t, err)
 }
 
 var sample0 = &Config{

--- a/command/agent/testdata/config-slices-alt.json
+++ b/command/agent/testdata/config-slices-alt.json
@@ -9,7 +9,9 @@
 			"meta": [
 				{
 					"m0": "foo",
-					"m1": "bar"
+					"m1": "bar",
+					"m2": true,
+					"m3": 1.2
 				}
 			],
 			"options": [

--- a/command/agent/testdata/config-slices.json
+++ b/command/agent/testdata/config-slices.json
@@ -6,7 +6,9 @@
 		},
 		"meta": {
 			"m0": "foo",
-			"m1": "bar"
+			"m1": "bar",
+			"m2": true,
+			"m3": 1.2
 		},
 		"chroot_env": {
 			"e0": "baz"

--- a/vendor/github.com/hashicorp/hcl/decoder.go
+++ b/vendor/github.com/hashicorp/hcl/decoder.go
@@ -535,7 +535,7 @@ func (d *decoder) decodeString(name string, node ast.Node, result reflect.Value)
 	switch n := node.(type) {
 	case *ast.LiteralType:
 		switch n.Token.Type {
-		case token.NUMBER:
+		case token.NUMBER, token.FLOAT, token.BOOL:
 			result.Set(reflect.ValueOf(n.Token.Text).Convert(result.Type()))
 			return nil
 		case token.STRING, token.HEREDOC:

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -208,7 +208,7 @@
 		{"path":"github.com/hashicorp/go-version","checksumSHA1":"r0pj5dMHCghpaQZ3f1BRGoKiSWw=","revision":"b5a281d3160aa11950a6182bd9a9dc2cb1e02d50","revisionTime":"2018-08-24T00:43:55Z"},
 		{"path":"github.com/hashicorp/golang-lru","checksumSHA1":"d9PxF1XQGLMJZRct2R8qVM/eYlE=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4","revisionTime":"2016-02-07T21:47:19Z"},
 		{"path":"github.com/hashicorp/golang-lru/simplelru","checksumSHA1":"2nOpYjx8Sn57bqlZq17yM4YJuM4=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"},
-		{"path":"github.com/hashicorp/hcl","checksumSHA1":"bPPNuq11pA/YSJzwxS0163WnhCo=","revision":"99e2f22d1c94b272184d97dd9d252866409100ab","revisionTime":"2019-04-30T13:52:23Z"},
+		{"path":"github.com/hashicorp/hcl","checksumSHA1":"vgGv8zuy7q8c5LBAFO1fnnQRRgE=","revision":"1804807358d86424faacbb42f50f0c04303cef11","revisionTime":"2019-06-10T16:16:27Z"},
 		{"path":"github.com/hashicorp/hcl/hcl/ast","checksumSHA1":"XQmjDva9JCGGkIecOgwtBEMCJhU=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
 		{"path":"github.com/hashicorp/hcl/hcl/parser","checksumSHA1":"croNloscHsjX87X+4/cKOURf1EY=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
 		{"path":"github.com/hashicorp/hcl/hcl/scanner","checksumSHA1":"lgR7PSAZ0RtvAc9OCtCnNsF/x8g=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},


### PR DESCRIPTION
configuration string parsing should accept boolean and numeric inputs. The fix for this is in HCL, https://github.com/hashicorp/hcl/pull/277