### PR TITLE
drivers/exec: use an independent name=systemd cgroup path

### DIFF
--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -434,8 +434,8 @@ func TestExecDriver_HandlerExec(t *testing.T) {
 		if line == "" {
 			continue
 		}
-		// Skip systemd and rdma cgroups; rdma was added in most recent kernels and libcontainer/docker
-		// don't isolate them by default.
+		// Skip rdma subsystem; rdma was added in most recent kernels and libcontainer/docker
+		// don't isolate it by default.
 		if strings.Contains(line, ":rdma:") {
 			continue
 		}

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -436,7 +436,7 @@ func TestExecDriver_HandlerExec(t *testing.T) {
 		}
 		// Skip systemd and rdma cgroups; rdma was added in most recent kernels and libcontainer/docker
 		// don't isolate them by default.
-		if strings.HasPrefix(line, "1:name=systemd") || strings.Contains(line, ":rdma:") {
+		if strings.Contains(line, ":rdma:") {
 			continue
 		}
 		if !strings.Contains(line, ":/nomad/") {

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -684,7 +684,7 @@ func configureCgroups(cfg *lconfigs.Config, command *ExecCommand) error {
 	}
 
 	id := uuid.Generate()
-	cfg.Cgroups.Path = filepath.Join(defaultCgroupParent, id)
+	cfg.Cgroups.Path = filepath.Join("/", defaultCgroupParent, id)
 
 	if command.Resources == nil || command.Resources.NomadResources == nil {
 		return nil

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -203,8 +203,8 @@ func TestExecutor_CgroupPaths(t *testing.T) {
 				continue
 			}
 
-			// Skip systemd and rdma cgroups; rdma was added in most recent kernels and libcontainer/docker
-			// don't isolate them by default.
+			// Skip rdma subsystem; rdma was added in most recent kernels and libcontainer/docker
+			// don't isolate it by default.
 			if strings.Contains(line, ":rdma:") {
 				continue
 			}


### PR DESCRIPTION
We aim for containers to be part of a new cgroups hierarchy independent
from nomad agent.  However, we've been setting a relative path as
libcontainer `cfg.Cgroups.Path`, which makes libcontainer concatinate
the executor process cgroup with passed cgroup, as set in [1].

By setting an absolute path, we ensure that all cgroups subsystem
(including `name=systemd` get a dedicated one).  This matches behavior
in Nomad 0.8, and behavior of how Docker and OCI sets CgroupsPath[2]

Fixes #5736

[1] https://github.com/hashicorp/nomad/blob/d7edf9b2e42348865908735996359c7869fb16b5/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go#L326-L340
[2] https://github.com/moby/moby/blob/238f8eaa31aa74be843c81703fabf774863ec30c/vendor/github.com/containerd/containerd/oci/spec.go#L229