### PR TITLE
tr: Block updates when terminal

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -396,6 +396,13 @@ func (tr *TaskRunner) updateHooks() {
 	// Prepare state needed by Update hooks
 	alloc := tr.Alloc()
 
+	// Prevent update hooks from running in a terminal state. This prevents updates
+	// from running during the shutdown of a task due to e.g vault token renewal.
+	if alloc.TerminalStatus() {
+		tr.logger.Info("Skipping update hooks because allocation is terminal")
+		return
+	}
+
 	// Execute Update hooks
 	for _, hook := range tr.runnerHooks {
 		upd, ok := hook.(interfaces.TaskUpdateHook)


### PR DESCRIPTION
This commit prevents taskrunner update hooks from executing when an allocation
has reached a terminal status.

This fixes a class of race conditions caused by hooks that will trigger further
updates until shutdown is completed. These hooks can cause issues with
e.g consul, whereby they may recieve an update-after-shutdown.

Fixes: #5770