### PR TITLE
alloc-lifecycle: Fix restart with empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BUG FIXES:
 * core: Fixed a panic that may occur when preempting jobs for network resources [[GH-5794](https://github.com/hashicorp/nomad/issues/5794)]
 * core: Fixed a config parsing issue when client metadata contains a boolean value [[GH-5802](https://github.com/hashicorp/nomad/issues/5802)]
 * core: Fixed a config parsing issue where consul, vault, and autopilot stanzas break when using a config directory [[GH-5817](https://github.com/hashicorp/nomad/issues/5817)]
+* api: Allow sumitting alloc restart requests with an empty body [[GH-5823](https://github.com/hashicorp/nomad/pull/5823)]
 * client: Fixed an issue where task restart attempts is not honored properly [[GH-5737](https://github.com/hashicorp/nomad/issues/5737)]
 * client: Fixed a panic that occurs when a 0.9.2 client is running with 0.8 nomad servers [[GH-5812](https://github.com/hashicorp/nomad/issues/5812)]
 

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -202,7 +202,7 @@ func (s *HTTPServer) allocRestart(allocID string, resp http.ResponseWriter, req 
 		TaskName string
 	}
 	err := json.NewDecoder(req.Body).Decode(&reqBody)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return nil, err
 	}
 	if reqBody.TaskName != "" {


### PR DESCRIPTION
Currently when you submit a manual request to the alloc lifecycle API
with a version of Curl that will submit empty bodies, the alloc restart
api will fail with an EOF error.

This behaviour is undesired, as it is reasonable to not submit a body at
all when restarting an entire allocation rather than an individual task.

This fixes it by ignoring EOF (not unexpected EOF) errors and treating
them as entire task restarts.