### PR TITLE
Change sort arrow to pass through pointer events

### DIFF
--- a/ui/app/styles/core/table.scss
+++ b/ui/app/styles/core/table.scss
@@ -167,6 +167,7 @@
           bottom: 0.75em;
           position: absolute;
           display: block;
+          pointer-events: none;
         }
 
         &.asc::after {


### PR DESCRIPTION
Without this, clicking on the sort arrow didn’t change the
sort direction.