### PR TITLE
Avoid de-registering slowly restored services - attempt 2

### DIFF
--- a/command/agent/consul/client_test.go
+++ b/command/agent/consul/client_test.go
@@ -1,0 +1,28 @@
+package consul
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsul_RemoveStalePendingRemovals(t *testing.T) {
+	now := time.Now()
+	recent := now.Add(-5 * time.Second)
+	c := &ServiceClient{
+		servicesPendingRemoval: map[string]time.Time{
+			"service_superold": now.Add(-24 * time.Hour),
+			"service_recent":   recent,
+		},
+		checksPendingRemoval: map[string]time.Time{
+			"checks_superold": now.Add(-24 * time.Hour),
+			"checks_recent":   recent,
+		},
+	}
+
+	c.removeStalePendingRemovals()
+
+	require.Equal(t, map[string]time.Time{"service_recent": recent}, c.servicesPendingRemoval)
+	require.Equal(t, map[string]time.Time{"checks_recent": recent}, c.checksPendingRemoval)
+}


### PR DESCRIPTION
This is an alternative implementation to #5837 that I didn't like as much.

Here, we attempt to mitigate against this by introducing a delay for deleting
consul services and checks that we didn't explicitly de-registered.  So
if we notice a service not recognized by Nomad yet, delete it after a
delay period (e.g. 5 minutes here), unless it's registered by then.

I believe #5837 is a bit simpler but opening this as draft if folks want to discuss it