### PR TITLE
Remove non-UI jobs for branches starting with .-ui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./nomad"
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: linux
       dist: xenial
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,42 +18,42 @@ matrix:
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./api"
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./client"
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/docker"
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/exec"
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./nomad"
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS_EXCLUDE="./api|./client|./drivers/docker|./drivers/exec|./nomad"
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: linux
       dist: xenial
       sudo: required
       env: ENABLE_RACE=1
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: linux
       dist: xenial
       sudo: false
       env: RUN_WEBSITE_TESTS=1 SKIP_NOMAD_TESTS=1
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: linux
       dist: xenial
       sudo: false
@@ -62,15 +62,15 @@ matrix:
       dist: xenial
       sudo: false
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: osx
       osx_image: xcode9.1
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
     - os: linux
       dist: xenial
       sudo: required
       env: RUN_E2E_TESTS=1 SKIP_NOMAD_TESTS=1
-      if: NOT branch =~ /^.-ui/
+      if: NOT branch =~ /^.-ui\b/
   allow_failures:
     # Allow osx to fail as its flaky
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,48 +12,51 @@ addons:
 git:
   depth: 300
 
+_skip_for_ui_branches: &skip_for_ui_branches
+  if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+
 matrix:
   include:
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./api"
-      &skip-for-ui-branches if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./client"
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/docker"
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/exec"
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./nomad"
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS_EXCLUDE="./api|./client|./drivers/docker|./drivers/exec|./nomad"
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
       sudo: required
       env: ENABLE_RACE=1
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
       sudo: false
       env: RUN_WEBSITE_TESTS=1 SKIP_NOMAD_TESTS=1
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
       sudo: false
@@ -62,15 +65,15 @@ matrix:
       dist: xenial
       sudo: false
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
     - os: osx
       osx_image: xcode9.1
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
       sudo: required
       env: RUN_E2E_TESTS=1 SKIP_NOMAD_TESTS=1
-      <<: *skip-for-ui-branches
+      <<: *skip_for_ui_branches
   allow_failures:
     # Allow osx to fail as its flaky
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,22 +18,22 @@ matrix:
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./api"
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./client"
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/docker"
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/exec"
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: linux
       dist: xenial
       sudo: required
@@ -43,17 +43,17 @@ matrix:
       dist: xenial
       sudo: required
       env: GOTEST_PKGS_EXCLUDE="./api|./client|./drivers/docker|./drivers/exec|./nomad"
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: ENABLE_RACE=1
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: linux
       dist: xenial
       sudo: false
       env: RUN_WEBSITE_TESTS=1 SKIP_NOMAD_TESTS=1
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: linux
       dist: xenial
       sudo: false
@@ -62,15 +62,15 @@ matrix:
       dist: xenial
       sudo: false
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: osx
       osx_image: xcode9.1
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: RUN_E2E_TESTS=1 SKIP_NOMAD_TESTS=1
-      if: NOT branch =~ /^.-ui\b/
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
   allow_failures:
     # Allow osx to fail as its flaky
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,34 +18,42 @@ matrix:
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./api"
+      if: NOT branch =~ /^.-ui/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./client"
+      if: NOT branch =~ /^.-ui/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/docker"
+      if: NOT branch =~ /^.-ui/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/exec"
+      if: NOT branch =~ /^.-ui/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./nomad"
+      if: NOT branch =~ /^.-ui/
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS_EXCLUDE="./api|./client|./drivers/docker|./drivers/exec|./nomad"
+      if: NOT branch =~ /^.-ui/
     - os: linux
       dist: xenial
       sudo: required
       env: ENABLE_RACE=1
+      if: NOT branch =~ /^.-ui/
     - os: linux
       dist: xenial
       sudo: false
       env: RUN_WEBSITE_TESTS=1 SKIP_NOMAD_TESTS=1
+      if: NOT branch =~ /^.-ui/
     - os: linux
       dist: xenial
       sudo: false
@@ -54,12 +62,15 @@ matrix:
       dist: xenial
       sudo: false
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
+      if: NOT branch =~ /^.-ui/
     - os: osx
       osx_image: xcode9.1
+      if: NOT branch =~ /^.-ui/
     - os: linux
       dist: xenial
       sudo: required
       env: RUN_E2E_TESTS=1 SKIP_NOMAD_TESTS=1
+      if: NOT branch =~ /^.-ui/
   allow_failures:
     # Allow osx to fail as its flaky
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,42 +18,42 @@ matrix:
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./api"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./client"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/docker"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/exec"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./nomad"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS_EXCLUDE="./api|./client|./drivers/docker|./drivers/exec|./nomad"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: ENABLE_RACE=1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: false
       env: RUN_WEBSITE_TESTS=1 SKIP_NOMAD_TESTS=1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: false
@@ -62,15 +62,15 @@ matrix:
       dist: xenial
       sudo: false
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: osx
       osx_image: xcode9.1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: RUN_E2E_TESTS=1 SKIP_NOMAD_TESTS=1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.ui\b/)
+      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
   allow_failures:
     # Allow osx to fail as its flaky
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,42 +18,42 @@ matrix:
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./api"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      &skip-for-ui-branches if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./client"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/docker"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./drivers/exec"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS="./nomad"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
     - os: linux
       dist: xenial
       sudo: required
       env: GOTEST_PKGS_EXCLUDE="./api|./client|./drivers/docker|./drivers/exec|./nomad"
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
     - os: linux
       dist: xenial
       sudo: required
       env: ENABLE_RACE=1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
     - os: linux
       dist: xenial
       sudo: false
       env: RUN_WEBSITE_TESTS=1 SKIP_NOMAD_TESTS=1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
     - os: linux
       dist: xenial
       sudo: false
@@ -62,15 +62,15 @@ matrix:
       dist: xenial
       sudo: false
       env: RUN_STATIC_CHECKS=1 SKIP_NOMAD_TESTS=1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
     - os: osx
       osx_image: xcode9.1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
     - os: linux
       dist: xenial
       sudo: required
       env: RUN_E2E_TESTS=1 SKIP_NOMAD_TESTS=1
-      if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
+      <<: *skip-for-ui-branches
   allow_failures:
     # Allow osx to fail as its flaky
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 git:
   depth: 300
 
+# This skips non-UI jobs for UI-only branches with names like f-ui/whatever or b-ui/something.
 _skip_for_ui_branches: &skip_for_ui_branches
   if: (type = push AND NOT branch =~ /^.-ui\b/) OR (type = pull_request AND NOT head_branch =~ /^.-ui\b/)
 


### PR DESCRIPTION
This change would mean that UI-specific branches would only have a single-job build on Travis CI. This saves some wasted concurrency and spares us seeing spurious test failures.

[This build](https://travis-ci.org/hashicorp/nomad/builds/545460448) is an example; notice that the URL is to a `build` but since there’s only one job, it shows directly rather than showing a job matrix.

This implementation requires trust that the branch hasn’t made any changes outside `ui/`. If there’s interest, I could look into causing the job to fail if any non-UI changes have been made.

One possible improvement would be to extract the conditional so it’s only specified once and then included in the different non-UI job specifications. It’s easily accomplished with an [anchor](https://camel.readthedocs.io/en/latest/yamlref.html#anchors) if people prefer that.