### PR TITLE
Raft and state store indexes as metrics

### DIFF
--- a/nomad/server.go
+++ b/nomad/server.go
@@ -412,7 +412,7 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI) (*Server, error)
 	go s.heartbeatStats()
 
 	// Emit raft and state store metrics
-	go s.EmitRaftStats(time.Second, s.shutdownCh)
+	go s.EmitRaftStats(10*time.Second, s.shutdownCh)
 
 	// Start enterprise background workers
 	s.startEnterpriseBackground()

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1454,13 +1454,13 @@ func (s *Server) Stats() map[string]map[string]string {
 	return stats
 }
 
-// EmitRaftStats is used to export metrics about the blocked eval tracker while enabled
+// EmitRaftStats is used to export metrics about raft indexes and state store snapshot index
 func (s *Server) EmitRaftStats(period time.Duration, stopCh <-chan struct{}) {
 	for {
 		select {
 		case <-time.After(period):
-			commitIndex := s.raft.LastIndex()
-			metrics.SetGauge([]string{"raft", "commitIndex"}, float32(commitIndex))
+			lastIndex := s.raft.LastIndex()
+			metrics.SetGauge([]string{"raft", "lastIndex"}, float32(lastIndex))
 			appliedIndex := s.raft.AppliedIndex()
 			metrics.SetGauge([]string{"raft", "appliedIndex"}, float32(appliedIndex))
 			stateStoreSnapshotIndex, err := s.State().LatestIndex()

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/agent/consul/autopilot"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -409,6 +410,9 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI) (*Server, error)
 
 	// Emit metrics
 	go s.heartbeatStats()
+
+	// Emit raft and state store metrics
+	go s.EmitRaftStats(time.Second, s.shutdownCh)
 
 	// Start enterprise background workers
 	s.startEnterpriseBackground()
@@ -1448,6 +1452,27 @@ func (s *Server) Stats() map[string]map[string]string {
 	}
 
 	return stats
+}
+
+// EmitRaftStats is used to export metrics about the blocked eval tracker while enabled
+func (s *Server) EmitRaftStats(period time.Duration, stopCh <-chan struct{}) {
+	for {
+		select {
+		case <-time.After(period):
+			commitIndex := s.raft.LastIndex()
+			metrics.SetGauge([]string{"raft", "commitIndex"}, float32(commitIndex))
+			appliedIndex := s.raft.AppliedIndex()
+			metrics.SetGauge([]string{"raft", "appliedIndex"}, float32(appliedIndex))
+			stateStoreSnapshotIndex, err := s.State().LatestIndex()
+			if err != nil {
+				s.logger.Warn("Unable to read snapshot index from statestore, metric will not be emitted", "error", err)
+			} else {
+				metrics.SetGauge([]string{"state", "snapshotIndex"}, float32(stateStoreSnapshotIndex))
+			}
+		case <-stopCh:
+			return
+		}
+	}
 }
 
 // Region returns the region of the server

--- a/website/source/docs/telemetry/index.html.md
+++ b/website/source/docs/telemetry/index.html.md
@@ -110,6 +110,18 @@ when retrieving metrics using the above described signals.
     <td>Counter</td>
   </tr>
   <tr>
+    <td>`nomad.raft.lastIndex`</td>
+    <td>Index of the last log</td>
+    <td>Sequence number</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
+    <td>`nomad.raft.appliedIndex`</td>
+    <td>Index of the last applied log</td>
+    <td>Sequence number</td>
+    <td>Gauge</td>
+  </tr>
+  <tr>
     <td>`nomad.raft.replication.appendEntries`</td>
     <td>Raft transaction commit time</td>
     <td>ms / Raft Log Append</td>
@@ -166,6 +178,12 @@ when retrieving metrics using the above described signals.
     </td>
     <td>ms / Plan Evaluation</td>
     <td>Timer</td>
+  </tr>
+  <tr>
+   <td>`nomad.state.snapshotIndex`</td>
+   <td>Latest index in the server's in memory state store</td>
+   <td>Sequence number</td>
+   <td>Gauge</td>
   </tr>
   <tr>
     <td>`nomad.worker.invoke_scheduler.<type>`</td>

--- a/website/source/docs/telemetry/index.html.md
+++ b/website/source/docs/telemetry/index.html.md
@@ -111,13 +111,13 @@ when retrieving metrics using the above described signals.
   </tr>
   <tr>
     <td>`nomad.raft.lastIndex`</td>
-    <td>Index of the last log</td>
+    <td>Index of the <a href="https://godoc.org/github.com/hashicorp/raft#Raft.LastIndex">last log in stable storage</a></td>
     <td>Sequence number</td>
     <td>Gauge</td>
   </tr>
   <tr>
     <td>`nomad.raft.appliedIndex`</td>
-    <td>Index of the last applied log</td>
+    <td>Index of the <a href="https://godoc.org/github.com/hashicorp/raft#Raft.AppliedIndex">last applied log</a></td>
     <td>Sequence number</td>
     <td>Gauge</td>
   </tr>


### PR DESCRIPTION
This PR makes every server emit raft commit and apply indexes, and the state store's latest index as metrics