### PR TITLE
Add exclusion of UI branches for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,10 @@ image: Visual Studio 2017
 
 clone_folder: c:\gopath\src\github.com\hashicorp\nomad
 
+branches:
+  except:
+    - /^.-ui\b/
+
 environment:
   GOPATH: c:\gopath
   GOBIN: c:\gopath\bin


### PR DESCRIPTION
As with #5839 on Travis CI, this skips AppVeyor for UI branches.