### PR TITLE
Nomad terraform config for enterprise binaries

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -43,7 +43,7 @@ a custom AMI:
 
 ```bash
 region                  = "us-east-1"
-ami                     = "ami-066a7f2ffac02f833"
+ami                     = "ami-05847887cacd41419"
 instance_type           = "t2.medium"
 key_name                = "KEY_NAME"
 server_count            = "3"
@@ -57,7 +57,7 @@ variable like so:
 
 ```bash
 region                  = "us-east-1"
-ami                     = "ami-066a7f2ffac02f833"
+ami                     = "ami-05847887cacd41419"
 instance_type           = "t2.medium"
 key_name                = "KEY_NAME"
 server_count            = "3"

--- a/terraform/aws/env/us-east/terraform.tfvars
+++ b/terraform/aws/env/us-east/terraform.tfvars
@@ -15,6 +15,13 @@ name = "nomad"
 #  - Typically this is left commented unless necessary. 
 #nomad_binary = "https://releases.hashicorp.com/nomad/0.9.0/nomad_0.9.0_linux_amd64.zip"
 
+# If you are using a binary from a restricted S3 bucket, you will need to use
+# the s3 protocol (see example on next line)
+# nomad_binary = "s3://<your-bucket-name>/your-nomad-binary.zip"
+# NOTE: the instances in environment can read from S3 buckets, but you will need
+# to make sure your bucket has the appropriate policy that allows you to read
+# from it
+
 # `region` ("us-east-1") - sets the AWS region to build your cluster in.
 #region = "us-east-1"
 

--- a/terraform/aws/env/us-east/terraform.tfvars
+++ b/terraform/aws/env/us-east/terraform.tfvars
@@ -28,7 +28,7 @@ name = "nomad"
 # `ami` (required) - The base AMI for the created nodes, This AMI must exist in
 # the requested region for this environment to build properly.
 #  - If it is not provided here, it will be requested interactively.
-ami = "ami-0df3b3ceb1f37291d"
+ami = "ami-05847887cacd41419"
 
 # `server_instance_type` ("t2.medium"), `client_instance_type` ("t2.medium"),
 # `server_count` (3),`client_count` (4) - These options control instance size

--- a/terraform/aws/modules/hashistack/hashistack.tf
+++ b/terraform/aws/modules/hashistack/hashistack.tf
@@ -249,6 +249,7 @@ data "aws_iam_policy_document" "auto_discover_cluster" {
       "ec2:DescribeInstances",
       "ec2:DescribeTags",
       "autoscaling:DescribeAutoScalingGroups",
+      "s3:GetObject",
     ]
 
     resources = ["*"]

--- a/terraform/shared/scripts/client.sh
+++ b/terraform/shared/scripts/client.sh
@@ -31,21 +31,22 @@ sudo systemctl start consul.service
 sleep 10
 
 # AWS CLI
-sudo apt-get install awscli -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip
+sudo pip install awscli
 
 # Nomad
 
 ## Replace existing Nomad binary if remote file exists
 if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
-	curl -L $NOMAD_BINARY > nomad.zip
-	sudo unzip -o nomad.zip -d /usr/local/bin
-	sudo chmod 0755 /usr/local/bin/nomad
-	sudo chown root:root /usr/local/bin/nomad
-elif [[ "aws s3 cp $NOMAD_BINARY nomad.zip --dryrun" ]]; then
-	aws s3 cp $NOMAD_BINARY nomad.zip
-	sudo unzip -o nomad.zip -d /usr/local/bin
-	sudo chmod 0755 /usr/local/bin/nomad
-	sudo chown root:root /usr/local/bin/nomad
+        curl -L $NOMAD_BINARY > nomad.zip
+        sudo unzip -o nomad.zip -d /usr/local/bin
+        sudo chmod 0755 /usr/local/bin/nomad
+        sudo chown root:root /usr/local/bin/nomad
+elif [[ "$(which aws) s3 cp $NOMAD_BINARY nomad.zip --dryrun" ]]; then
+        $(which aws) s3 cp $NOMAD_BINARY nomad.zip
+        sudo unzip -o nomad.zip -d /usr/local/bin
+        sudo chmod 0755 /usr/local/bin/nomad
+        sudo chown root:root /usr/local/bin/nomad
 fi
 
 sudo cp $CONFIGDIR/nomad_client.hcl $NOMADCONFIGDIR/nomad.hcl

--- a/terraform/shared/scripts/client.sh
+++ b/terraform/shared/scripts/client.sh
@@ -30,6 +30,9 @@ sudo cp $CONFIGDIR/consul_$CLOUD.service /etc/systemd/system/consul.service
 sudo systemctl start consul.service
 sleep 10
 
+# AWS CLI
+sudo apt-get install awscli -y
+
 # Nomad
 
 ## Replace existing Nomad binary if remote file exists

--- a/terraform/shared/scripts/client.sh
+++ b/terraform/shared/scripts/client.sh
@@ -34,10 +34,15 @@ sleep 10
 
 ## Replace existing Nomad binary if remote file exists
 if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
-  curl -L $NOMAD_BINARY > nomad.zip
-  sudo unzip -o nomad.zip -d /usr/local/bin
-  sudo chmod 0755 /usr/local/bin/nomad
-  sudo chown root:root /usr/local/bin/nomad
+	curl -L $NOMAD_BINARY > nomad.zip
+	sudo unzip -o nomad.zip -d /usr/local/bin
+	sudo chmod 0755 /usr/local/bin/nomad
+	sudo chown root:root /usr/local/bin/nomad
+elif [[ "aws s3 cp $NOMAD_BINARY nomad.zip --dryrun" ]]; then
+	aws s3 cp $NOMAD_BINARY nomad.zip
+	sudo unzip -o nomad.zip -d /usr/local/bin
+	sudo chmod 0755 /usr/local/bin/nomad
+	sudo chown root:root /usr/local/bin/nomad
 fi
 
 sudo cp $CONFIGDIR/nomad_client.hcl $NOMADCONFIGDIR/nomad.hcl

--- a/terraform/shared/scripts/server.sh
+++ b/terraform/shared/scripts/server.sh
@@ -43,21 +43,22 @@ sudo cp $CONFIGDIR/vault.service /etc/systemd/system/vault.service
 sudo systemctl start vault.service
 
 # AWS CLI
-sudo apt-get install awscli -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip
+sudo pip install awscli
 
 # Nomad
 
 ## Replace existing Nomad binary if remote file exists
 if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
-	curl -L $NOMAD_BINARY > nomad.zip
-	sudo unzip -o nomad.zip -d /usr/local/bin
-	sudo chmod 0755 /usr/local/bin/nomad
-	sudo chown root:root /usr/local/bin/nomad
-elif [[ "aws s3 cp $NOMAD_BINARY nomad.zip --dryrun" ]]; then
-	aws s3 cp $NOMAD_BINARY nomad.zip
-	sudo unzip -o nomad.zip -d /usr/local/bin
-	sudo chmod 0755 /usr/local/bin/nomad
-	sudo chown root:root /usr/local/bin/nomad
+        curl -L $NOMAD_BINARY > nomad.zip
+        sudo unzip -o nomad.zip -d /usr/local/bin
+        sudo chmod 0755 /usr/local/bin/nomad
+        sudo chown root:root /usr/local/bin/nomad
+elif [[ "$(which aws) s3 cp $NOMAD_BINARY nomad.zip --dryrun" ]]; then
+        $(which aws) s3 cp $NOMAD_BINARY nomad.zip
+        sudo unzip -o nomad.zip -d /usr/local/bin
+        sudo chmod 0755 /usr/local/bin/nomad
+        sudo chown root:root /usr/local/bin/nomad
 fi
 
 sed -i "s/SERVER_COUNT/$SERVER_COUNT/g" $CONFIGDIR/nomad.hcl

--- a/terraform/shared/scripts/server.sh
+++ b/terraform/shared/scripts/server.sh
@@ -42,6 +42,9 @@ sudo cp $CONFIGDIR/vault.service /etc/systemd/system/vault.service
 
 sudo systemctl start vault.service
 
+# AWS CLI
+sudo apt-get install awscli -y
+
 # Nomad
 
 ## Replace existing Nomad binary if remote file exists

--- a/terraform/shared/scripts/server.sh
+++ b/terraform/shared/scripts/server.sh
@@ -46,10 +46,15 @@ sudo systemctl start vault.service
 
 ## Replace existing Nomad binary if remote file exists
 if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
-  curl -L $NOMAD_BINARY > nomad.zip
-  sudo unzip -o nomad.zip -d /usr/local/bin
-  sudo chmod 0755 /usr/local/bin/nomad
-  sudo chown root:root /usr/local/bin/nomad
+	curl -L $NOMAD_BINARY > nomad.zip
+	sudo unzip -o nomad.zip -d /usr/local/bin
+	sudo chmod 0755 /usr/local/bin/nomad
+	sudo chown root:root /usr/local/bin/nomad
+elif [[ "aws s3 cp $NOMAD_BINARY nomad.zip --dryrun" ]]; then
+	aws s3 cp $NOMAD_BINARY nomad.zip
+	sudo unzip -o nomad.zip -d /usr/local/bin
+	sudo chmod 0755 /usr/local/bin/nomad
+	sudo chown root:root /usr/local/bin/nomad
 fi
 
 sed -i "s/SERVER_COUNT/$SERVER_COUNT/g" $CONFIGDIR/nomad.hcl


### PR DESCRIPTION
This PR is an attempt as solving the issue of using the terraform config with Nomad enterprise binaries for our team that are in restricted S3 buckets. A user spinning up a cluster in their AWS environment will be able to have the nodes read from S3 buckets that have given their AWS account the permission to do so.

This PR adds S3 GetObject permission to the IAM policy attached to all the nodes and adds some logic in the post-provisioning script when downloading/installing the nomad enterprise binary specified by the user. If this is a normal, open source binary from our website or a publicly accessible s3 bucket, nothing changes for the user. If, however, the user specifies an s3 link to a restricted bucket as a value to the **nomad_binary** variable (example: nomad_binary = "s3://my-bucket/my-enterprise-binary"), this configuration will install that.

Please note: you still have to set up an s3 bucket with an appropriate policy that will allow nodes in the AWS account to read from it, so these nodes will not be able to just read from any bucket in the same (or another) AWS account. See below for an example of how you would need to set up an s3 bucket to let these nodes read from it:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Get object from S3 bucket",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::<your-aws-account>:root"
            },
            "Action": "s3:*",
            "Resource": [
                "arn:aws:s3:::<your-s3-bucket>",
                "arn:aws:s3:::<your-s3-bucket/*>"
            ]
        }
    ]
}
```