### PR TITLE
add log rotation to docker driver log defaults

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -740,6 +740,15 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		Config: driverConfig.Logging.Config,
 	}
 
+	if hostConfig.LogConfig.Type == "" && hostConfig.LogConfig.Config == nil {
+		logger.Trace("no docker log driver provided, defaulting to json-file")
+		hostConfig.LogConfig.Type = "json-file"
+		hostConfig.LogConfig.Config = map[string]string{
+			"max-file": "2",
+			"max-size": "2m",
+		}
+	}
+
 	logger.Debug("configured resources", "memory", hostConfig.Memory,
 		"cpu_shares", hostConfig.CPUShares, "cpu_quota", hostConfig.CPUQuota,
 		"cpu_period", hostConfig.CPUPeriod)

--- a/website/source/docs/drivers/docker.html.md
+++ b/website/source/docs/drivers/docker.html.md
@@ -166,8 +166,8 @@ The `docker` driver supports the following configuration in the job spec.  Only
     }
     ```
 
-* `logging` - (Optional) A key-value map of Docker logging options. The default
-  value is `syslog`.
+* `logging` - (Optional) A key-value map of Docker logging options. 
+    Defaults to `json-file` with log rotation (`max-file=2` and `max-size=2m`).
 
     ```hcl
     config {


### PR DESCRIPTION
## Overview
* Nomad uses Docker log defaults if no user log configuration provided
* Docker log driver defaults to `json-file` with no log rotation, which will make logs grow infinitely
* **This adds log rotation to the default Docker logging**

## Behavior
* rotate docker logs with `max-file=2` and `max-size=2m` by default
* "by default" = only add log rotation if no user config provided (neither log Type nor log Config is set)

## Implementation
* https://docs.docker.com/config/containers/logging/configure/

