### PR TITLE
metrics: add namespace label to allocation metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 * api: use region from job hcl when not provided as query parameter in job registration and plan endpoints [[GH-5664](https://github.com/hashicorp/nomad/pull/5664)]
+* metrics: add namespace label as appropriate to metrics [[GH-5847](https://github.com/hashicorp/nomad/issues/5847)]
 
 BUG FIXES:
 

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -362,13 +362,10 @@ func (tr *TaskRunner) initLabels() {
 			Name:  "task",
 			Value: tr.taskName,
 		},
-	}
-
-	if tr.alloc.Namespace != "" {
-		tr.baseLabels = append(tr.baseLabels, metrics.Label{
-			Name: "namespace",
+		{
+			Name:  "namespace",
 			Value: tr.alloc.Namespace,
-		})
+		},
 	}
 
 	if tr.alloc.Job.ParentID != "" {

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -364,6 +364,13 @@ func (tr *TaskRunner) initLabels() {
 		},
 	}
 
+	if tr.alloc.Namespace != "" {
+		tr.baseLabels = append(tr.baseLabels, metrics.Label{
+			Name: "namespace",
+			Value: tr.alloc.Namespace,
+		})
+	}
+
 	if tr.alloc.Job.ParentID != "" {
 		tr.baseLabels = append(tr.baseLabels, metrics.Label{
 			Name:  "parent_id",

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -2037,10 +2037,10 @@ func TestTaskRunner_BaseLabels(t *testing.T) {
 	}
 
 	config, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
+	defer cleanup()
 
 	tr, err := NewTaskRunner(config)
 	require.NoError(err)
-	defer cleanup()
 
 	labels := map[string]string{}
 	for _, e := range tr.baseLabels {

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -2042,30 +2042,13 @@ func TestTaskRunner_BaseLabels(t *testing.T) {
 	require.NoError(err)
 	defer cleanup()
 
-	var foundJob, foundGroup, foundTask, foundAlloc, foundNamespace bool
+	labels := map[string]string{}
 	for _, e := range tr.baseLabels {
-		switch e.Name {
-		case "job":
-			require.Equal(e.Value, alloc.Job.Name)
-			foundJob = true
-		case  "task_group":
-			require.Equal(e.Value, alloc.TaskGroup)
-			foundGroup = true
-		case  "task":
-			require.Equal(e.Value, task.Name)
-			foundTask = true
-		case  "alloc_id":
-			require.Equal(e.Value, alloc.ID)
-			foundAlloc = true
-		case "namespace":
-			require.Equal(e.Value, alloc.Namespace)
-			foundNamespace = true
-		}
+		labels[e.Name] = e.Value
 	}
-	require.True(foundJob)
-	require.True(foundGroup)
-	require.True(foundAlloc)
-	require.True(foundTask)
-	require.True(foundNamespace)
+	require.Equal(alloc.Job.Name, labels["job"])
+	require.Equal(alloc.TaskGroup, labels["task_group"])
+	require.Equal(task.Name, labels["task"])
+	require.Equal(alloc.ID, labels["alloc_id"])
+	require.Equal(alloc.Namespace, labels["namespace"])
 }
-

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -657,6 +657,10 @@ func (s *Server) iterateJobSummaryMetrics(summary *structs.JobSummary) {
 					Name:  "task_group",
 					Value: name,
 				},
+				{
+					Name:  "namespace",
+					Value: summary.Namespace,
+				},
 			}
 
 			if strings.Contains(summary.JobID, "/dispatch-") {


### PR DESCRIPTION
also, add them to job summary metrics. 

the resulting changes (current, in both open-source and enterprise) are: 

resolves #5554 by adding the `namespace` label to all `nomad.client.allocs.*` metrics. in addition to not discriminating by namespace, there was a bug where identical jobs in different namespaces would cause one metric to "shadow" another one.

similarly, added a `namespace` label to all `nomad.nomad.job_summary.*` metrics.