### PR TITLE
Add ember-qunit-nice-errors

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -75,6 +75,7 @@
     "ember-moment": "^7.8.1",
     "ember-native-dom-helpers": "^0.5.4",
     "ember-power-select": "^2.2.3",
+    "ember-qunit-nice-errors": "^1.2.0",
     "ember-resolver": "^5.0.1",
     "ember-responsive": "^3.0.0",
     "ember-sinon": "^2.2.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1323,6 +1323,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-types@0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.10.2.tgz#aef76a04fde54634976fc94defaad1a67e2eadb0"
+  integrity sha512-ufWX953VU1eIuWqxS0nRDMYlGyFH+yxln5CsmIHlpzEt3fdYqUnRtsFt0XAsQot8OaVCwFqxT1RiwvtzYjeYeg==
+
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -1415,7 +1420,7 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.3:
+babel-core@^6.10.4, babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.3:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
@@ -4767,6 +4772,16 @@ ember-power-select@^2.2.3:
     ember-text-measurer "^0.5.0"
     ember-truth-helpers "^2.1.0"
 
+ember-qunit-nice-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-qunit-nice-errors/-/ember-qunit-nice-errors-1.2.0.tgz#8db4468fbe761f42bec9adcddfd21efa31237267"
+  integrity sha512-DNvqrS6vSMf7VImW7RjlTbiUnYvyxNNeVMNBVyys7g8hgg/IqbWeXQjKUzeSp/dUbzVi9Fr/8cuLHH7S38DSOA==
+  dependencies:
+    babel-core "^6.10.4"
+    broccoli-persistent-filter "^1.4.3"
+    ember-cli-babel "^6.6.0"
+    recast "^0.13.0"
+
 ember-qunit@^3.5.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.5.3.tgz#bfd0bff8298c78c77e870cca43fe0826e78a0d09"
@@ -5096,7 +5111,7 @@ espree@^5.0.1:
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -9115,6 +9130,16 @@ recast@^0.11.3:
     esprima "~3.1.0"
     private "~0.1.5"
     source-map "~0.5.0"
+
+recast@^0.13.0:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.13.2.tgz#919e7e856d5154f13284142ed1797753c6756137"
+  integrity sha512-Xqo0mKljGUWGUhnkdbODk7oJGFrMcpgKQ9cCyZ4y+G9VfoTKdum8nHbf/SxIdKx5aBSZ29VpVy20bTyt7jyC8w==
+  dependencies:
+    ast-types "0.10.2"
+    esprima "~4.0.0"
+    private "~0.1.5"
+    source-map "~0.6.1"
 
 redent@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This shows the entire assertion that’s failing. This is
especially useful in combination with page objects.

For an assertion like this:
assert.equal(PageLayout.flashMessages.length, 1)

The failure displayed normally is just “failed” with the
expected of 1 and the result of undefined. With this addon,
the expected and result remain the same, but “failed” is
replaced with the text of the assertion.

The typical way to address this is to supply the optional
final argument to the assertion function that customises the
failure message. That still works with this addon, but most
of the time it becomes unnecessary.