### PR TITLE
make purge parameter lowercase

### DIFF
--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -1726,7 +1726,7 @@ The table below shows this endpoint's support for
 - `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
-- `Purge` `(bool: false)` - Specifies that the job should stopped and purged
+- `purge` `(bool: false)` - Specifies that the job should stopped and purged
   immediately. This means the job will not be queryable after being stopped. If
   not set, the job will be purged by the garbage collector.
 


### PR DESCRIPTION
The [purge](https://www.nomadproject.io/api/jobs.html#purge) parameter in the listed parameters for the API endpoint to [stop a job](https://www.nomadproject.io/api/jobs.html#stop-a-job) should be lowercase (as the example we provide in the doc correctly shows)