### PR TITLE
UI: Account for the search icon within the is-compact modifier

### DIFF
--- a/ui/app/styles/components/search-box.scss
+++ b/ui/app/styles/components/search-box.scss
@@ -68,8 +68,13 @@
     width: 100%;
   }
 
-  input {
+  input,
+  .input {
     width: 100%;
     padding: 0.4em 1.75em 0.4em 2.25em;
+
+    &.is-compact {
+      padding: 0.25em 0.75em 0.25em 2.25em;
+    }
   }
 }


### PR DESCRIPTION
This has been impacting the task-group and client-detail page ever since the magnifying glass icon was introduced along with faceted search.

**Before...**
<img width="465" alt="Screen Shot 2019-06-27 at 12 31 54 PM" src="https://user-images.githubusercontent.com/174740/60295139-d9254600-98d7-11e9-890a-c5d0e71ee337.png">

**After...**
<img width="501" alt="Screen Shot 2019-06-27 at 12 31 33 PM" src="https://user-images.githubusercontent.com/174740/60295147-df1b2700-98d7-11e9-859b-b8b9785aea1f.png">
