### PR TITLE
Block rpc handling until state store is caught up

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -289,6 +289,8 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 		return err
 	}
 
+	s.setConsistentReadReady()
+
 	return nil
 }
 
@@ -713,6 +715,8 @@ func (s *Server) iterateJobSummaryMetrics(summary *structs.JobSummary) {
 // This is used to cleanup any state that may be specific to a leader.
 func (s *Server) revokeLeadership() error {
 	defer metrics.MeasureSince([]string{"nomad", "leader", "revoke_leadership"}, time.Now())
+
+	s.resetConsistentReadReady()
 
 	// Clear the leader token since we are no longer the leader.
 	s.setLeaderAcl("")

--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -432,7 +432,7 @@ CHECK_LEADER:
 	isLeader, remoteServer := r.getLeader()
 
 	// Handle the case we are the leader
-	if isLeader {
+	if isLeader && r.Server.isReadyForConsistentReads() {
 		return false, nil
 	}
 
@@ -457,7 +457,11 @@ CHECK_LEADER:
 		}
 	}
 
-	// No leader found and hold time exceeded
+	// hold time exceeeded without being ready to respond
+	if isLeader {
+		return true, structs.ErrNotReadyForConsistentReads
+	}
+
 	return true, structs.ErrNoLeader
 }
 

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -74,6 +74,47 @@ func TestRPC_forwardLeader(t *testing.T) {
 	}
 }
 
+func TestRPC_WaitForConsistentReads(t *testing.T) {
+	t.Parallel()
+	s1 := TestServer(t, func(c *Config) {
+		c.RPCHoldTimeout = 20 * time.Millisecond
+	})
+	defer s1.Shutdown()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	isLeader, _ := s1.getLeader()
+	require.True(t, isLeader)
+	require.True(t, s1.isReadyForConsistentReads())
+
+	s1.resetConsistentReadReady()
+	require.False(t, s1.isReadyForConsistentReads())
+
+	codec := rpcClient(t, s1)
+
+	get := &structs.JobListRequest{
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			Namespace: "default",
+		},
+	}
+
+	// check timeout while waiting for consistency
+	var resp structs.JobListResponse
+	err := msgpackrpc.CallWithCodec(codec, "Job.List", get, &resp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), structs.ErrNotReadyForConsistentReads.Error())
+
+	// check we wait and block
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		s1.setConsistentReadReady()
+	}()
+
+	err = msgpackrpc.CallWithCodec(codec, "Job.List", get, &resp)
+	require.NoError(t, err)
+
+}
+
 func TestRPC_forwardRegion(t *testing.T) {
 	t.Parallel()
 	s1 := TestServer(t, nil)

--- a/nomad/structs/errors.go
+++ b/nomad/structs/errors.go
@@ -7,14 +7,15 @@ import (
 )
 
 const (
-	errNoLeader            = "No cluster leader"
-	errNoRegionPath        = "No path to region"
-	errTokenNotFound       = "ACL token not found"
-	errPermissionDenied    = "Permission denied"
-	errNoNodeConn          = "No path to node"
-	errUnknownMethod       = "Unknown rpc method"
-	errUnknownNomadVersion = "Unable to determine Nomad version"
-	errNodeLacksRpc        = "Node does not support RPC; requires 0.8 or later"
+	errNoLeader                   = "No cluster leader"
+	errNotReadyForConsistentReads = "Not ready to serve consistent reads"
+	errNoRegionPath               = "No path to region"
+	errTokenNotFound              = "ACL token not found"
+	errPermissionDenied           = "Permission denied"
+	errNoNodeConn                 = "No path to node"
+	errUnknownMethod              = "Unknown rpc method"
+	errUnknownNomadVersion        = "Unable to determine Nomad version"
+	errNodeLacksRpc               = "Node does not support RPC; requires 0.8 or later"
 
 	// Prefix based errors that are used to check if the error is of a given
 	// type. These errors should be created with the associated constructor.
@@ -26,14 +27,15 @@ const (
 )
 
 var (
-	ErrNoLeader            = errors.New(errNoLeader)
-	ErrNoRegionPath        = errors.New(errNoRegionPath)
-	ErrTokenNotFound       = errors.New(errTokenNotFound)
-	ErrPermissionDenied    = errors.New(errPermissionDenied)
-	ErrNoNodeConn          = errors.New(errNoNodeConn)
-	ErrUnknownMethod       = errors.New(errUnknownMethod)
-	ErrUnknownNomadVersion = errors.New(errUnknownNomadVersion)
-	ErrNodeLacksRpc        = errors.New(errNodeLacksRpc)
+	ErrNoLeader                   = errors.New(errNoLeader)
+	ErrNotReadyForConsistentReads = errors.New(errNotReadyForConsistentReads)
+	ErrNoRegionPath               = errors.New(errNoRegionPath)
+	ErrTokenNotFound              = errors.New(errTokenNotFound)
+	ErrPermissionDenied           = errors.New(errPermissionDenied)
+	ErrNoNodeConn                 = errors.New(errNoNodeConn)
+	ErrUnknownMethod              = errors.New(errUnknownMethod)
+	ErrUnknownNomadVersion        = errors.New(errUnknownNomadVersion)
+	ErrNodeLacksRpc               = errors.New(errNodeLacksRpc)
 )
 
 // IsErrNoLeader returns whether the error is due to there being no leader.


### PR DESCRIPTION
Here, we ensure that when leader only responds to RPC calls when state
store is up to date.  At leadership transition or launch with restored
state, the server local store might not be caught up with latest raft
logs and may return a stale read.

The solution here is to have an RPC consistency read gate, enabled when
`establishLeadership` completes before we respond to RPC calls.
`establishLeadership` is gated by a `raft.Barrier` which ensures that
all prior raft logs have been applied.

Conversely, the gate is disabled when leadership is lost.

This fixes the underlying issue in https://github.com/hashicorp/nomad/pull/5906 .

This is very much inspired by https://github.com/hashicorp/consul/pull/3154/files