### PR TITLE
Use consistent casing in the JSON representation of the AllocFileInfo struct

### DIFF
--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -41,7 +41,7 @@ type AllocFileInfo struct {
 	Size        int64
 	FileMode    string
 	ModTime     time.Time
-	ContentType string `json:"contenttype,omitempty"`
+	ContentType string `json:",omitempty"`
 }
 
 // FsListRequest is used to list an allocation's directory.


### PR DESCRIPTION
From `contenttype` to `ContentType`.