### PR TITLE
Initial support for Host Volumes

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -500,6 +500,21 @@ func (m *MigrateStrategy) Copy() *MigrateStrategy {
 	return nm
 }
 
+type Volume struct {
+	Name     string
+	Type     string
+	ReadOnly bool `mapstructure:"read_only"`
+	Hidden   bool
+
+	Config map[string]interface{}
+}
+
+type VolumeMount struct {
+	Volume      string
+	Destination string
+	ReadOnly    bool `mapstructure:"read_only"`
+}
+
 // TaskGroup is the unit of scheduling.
 type TaskGroup struct {
 	Name             *string
@@ -508,6 +523,7 @@ type TaskGroup struct {
 	Affinities       []*Affinity
 	Tasks            []*Task
 	Spreads          []*Spread
+	Volumes          map[string]*Volume
 	RestartPolicy    *RestartPolicy
 	ReschedulePolicy *ReschedulePolicy
 	EphemeralDisk    *EphemeralDisk
@@ -715,6 +731,7 @@ type Task struct {
 	Vault           *Vault
 	Templates       []*Template
 	DispatchPayload *DispatchPayloadConfig
+	VolumeMounts    []*VolumeMount
 	Leader          bool
 	ShutdownDelay   time.Duration `mapstructure:"shutdown_delay"`
 	KillSignal      string        `mapstructure:"kill_signal"`

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -61,6 +61,7 @@ func (tr *TaskRunner) initHooks() {
 		newTaskDirHook(tr, hookLogger),
 		newLogMonHook(tr.logmonHookConfig, hookLogger),
 		newDispatchHook(tr.Alloc(), hookLogger),
+		newVolumeHook(tr, hookLogger),
 		newArtifactHook(tr, hookLogger),
 		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, hookLogger),
 		newDeviceHook(tr.devicemanager, hookLogger),

--- a/client/allocrunner/taskrunner/volume_hook.go
+++ b/client/allocrunner/taskrunner/volume_hook.go
@@ -78,7 +78,7 @@ func (h *volumeHook) hostVolumeMountConfigurations(taskMounts []*structs.VolumeM
 		}
 
 		mcfg := &drivers.MountConfig{
-			HostPath: hostVolume.Source,
+			HostPath: hostVolume.Path,
 			TaskPath: m.Destination,
 			Readonly: hostVolume.ReadOnly || req.ReadOnly || m.ReadOnly,
 		}

--- a/client/allocrunner/taskrunner/volume_hook.go
+++ b/client/allocrunner/taskrunner/volume_hook.go
@@ -1,0 +1,123 @@
+package taskrunner
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/hashicorp/go-hclog"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+type volumeHook struct {
+	alloc  *structs.Allocation
+	runner *TaskRunner
+	logger log.Logger
+}
+
+func newVolumeHook(runner *TaskRunner, logger log.Logger) *volumeHook {
+	h := &volumeHook{
+		alloc:  runner.Alloc(),
+		runner: runner,
+	}
+	h.logger = logger.Named(h.Name())
+	return h
+}
+
+func (*volumeHook) Name() string {
+	return "volumes"
+}
+
+func validateHostVolumes(requested map[string]*structs.VolumeRequest, client map[string]*structs.ClientHostVolumeConfig) error {
+	var result error
+
+	for n, req := range requested {
+		if req.Volume.Type != "host" {
+			continue
+		}
+
+		cfg, err := structs.ParseHostVolumeConfig(req.Config)
+		if err != nil {
+			result = multierror.Append(result, fmt.Errorf("failed to parse config for %s: %v", n, err))
+		}
+
+		_, ok := client[cfg.Source]
+		if !ok {
+			result = multierror.Append(result, fmt.Errorf("missing %s", cfg.Source))
+		}
+	}
+
+	return result
+}
+
+func (h *volumeHook) hostVolumeMountConfigurations(vmounts []*structs.VolumeMount, volumes map[string]*structs.VolumeRequest, client map[string]*structs.ClientHostVolumeConfig) ([]*drivers.MountConfig, error) {
+	var mounts []*drivers.MountConfig
+	for _, m := range vmounts {
+		req, ok := volumes[m.Volume]
+		if !ok {
+			// Should never happen unless we misvalidated on job submission
+			return nil, fmt.Errorf("No group volume declaration found named: %s", m.Volume)
+		}
+
+		cfg, err := structs.ParseHostVolumeConfig(req.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse config for %s: %v", m.Volume, err)
+		}
+
+		hostVolume, ok := client[cfg.Source]
+		if !ok {
+			// Should never happen, but unless the client volumes were mutated during
+			// the execution of this hook.
+			return nil, fmt.Errorf("No host volume named: %s", cfg.Source)
+		}
+
+		mcfg := &drivers.MountConfig{
+			HostPath: hostVolume.Source,
+			TaskPath: m.Destination,
+			Readonly: hostVolume.ReadOnly || req.Volume.ReadOnly || m.ReadOnly,
+		}
+		mounts = append(mounts, mcfg)
+	}
+
+	return mounts, nil
+}
+
+func (h *volumeHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
+	volumes := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup).Volumes
+	mounts := h.runner.hookResources.getMounts()
+
+	hostVolumes := h.runner.clientConfig.Node.HostVolumes
+
+	// Always validate volumes to ensure that we do not allow volumes to be used
+	// if a host is restarted and loses the host volume configuration.
+	if err := validateHostVolumes(volumes, hostVolumes); err != nil {
+		h.logger.Error("Requested Host Volume does not exist", "existing", hostVolumes, "requested", volumes)
+		return fmt.Errorf("host volume validation error: %v", err)
+	}
+
+	requestedMounts, err := h.hostVolumeMountConfigurations(req.Task.VolumeMounts, volumes, hostVolumes)
+	if err != nil {
+		h.logger.Error("Failed to generate volume mounts", "error", err)
+		return err
+	}
+
+	// Because this hook is also ran on restores, we only add mounts that do not
+	// already exist. Although this loop is somewhat expensive, there are only
+	// a small number of mounts that exist within most individual tasks. We may
+	// want to revisit this using a `hookdata` param to be "mount only once"
+REQUESTED:
+	for _, m := range requestedMounts {
+		for _, em := range mounts {
+			if em.IsEqual(m) {
+				continue REQUESTED
+			}
+		}
+
+		mounts = append(mounts, m)
+	}
+
+	h.runner.hookResources.setMounts(mounts)
+	return nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -1266,6 +1266,16 @@ func (c *Client) setupNode() error {
 	if node.Name == "" {
 		node.Name, _ = os.Hostname()
 	}
+	// TODO(dani): Fingerprint these to handle volumes that don't exist/have bad perms.
+	if node.HostVolumes == nil {
+		if l := len(c.config.HostVolumes); l != 0 {
+			node.HostVolumes = make(map[string]*structs.ClientHostVolumeConfig, l)
+			for k, v := range c.config.HostVolumes {
+				node.HostVolumes[k] = v.Copy()
+			}
+		}
+	}
+
 	if node.Name == "" {
 		node.Name = node.ID
 	}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -246,6 +246,9 @@ type Config struct {
 	// AutoFetchCNIDir is the destination dir to use when auto doanloading CNI plugins.
 	// This directory will be appended to the CNIPath so it is searched last
 	AutoFetchCNIDir string
+
+	// HostVolumes is the set of configured host volumes
+	HostVolumes map[string]*structs.ClientHostVolumeConfig
 }
 
 func (c *Config) Copy() *Config {
@@ -254,6 +257,7 @@ func (c *Config) Copy() *Config {
 	nc.Node = nc.Node.Copy()
 	nc.Servers = helper.CopySliceString(nc.Servers)
 	nc.Options = helper.CopyMapStringString(nc.Options)
+	nc.HostVolumes = structs.CopyMapStringClientHostVolumeConfig(nc.HostVolumes)
 	nc.ConsulConfig = c.ConsulConfig.Copy()
 	nc.VaultConfig = c.VaultConfig.Copy()
 	return nc

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -470,6 +470,12 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	conf.ClientMinPort = uint(agentConfig.Client.ClientMinPort)
 	conf.DisableRemoteExec = agentConfig.Client.DisableRemoteExec
 
+	hvMap := make(map[string]*structs.ClientHostVolumeConfig, len(agentConfig.Client.HostVolumes))
+	for _, v := range agentConfig.Client.HostVolumes {
+		hvMap[v.Name] = v
+	}
+	conf.HostVolumes = hvMap
+
 	// Setup the node
 	conf.Node = new(structs.Node)
 	conf.Node.Datacenter = agentConfig.Datacenter

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1338,11 +1338,7 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 
 	if len(a.HostVolumes) == 0 && len(b.HostVolumes) != 0 {
-		cc := make([]*structs.ClientHostVolumeConfig, len(b.HostVolumes))
-		for k, v := range b.HostVolumes {
-			cc[k] = v.Copy()
-		}
-		result.HostVolumes = cc
+		result.HostVolumes = structs.CopySliceClientHostVolumeConfig(b.HostVolumes)
 	} else if len(b.HostVolumes) != 0 {
 		result.HostVolumes = structs.HostVolumeSliceMerge(a.HostVolumes, b.HostVolumes)
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -245,6 +245,10 @@ type ClientConfig struct {
 	// ServerJoin contains information that is used to attempt to join servers
 	ServerJoin *ServerJoin `hcl:"server_join"`
 
+	// HostVolumes contains information about the volumes an operator has made
+	// available to jobs running on this node.
+	HostVolumes []*structs.ClientHostVolumeConfig `hcl:"host_volume"`
+
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 
@@ -1331,6 +1335,16 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 
 	if b.ServerJoin != nil {
 		result.ServerJoin = result.ServerJoin.Merge(b.ServerJoin)
+	}
+
+	if len(a.HostVolumes) == 0 && len(b.HostVolumes) != 0 {
+		cc := make([]*structs.ClientHostVolumeConfig, len(b.HostVolumes))
+		for k, v := range b.HostVolumes {
+			cc[k] = v.Copy()
+		}
+		result.HostVolumes = cc
+	} else if len(b.HostVolumes) != 0 {
+		result.HostVolumes = structs.HostVolumeSliceMerge(a.HostVolumes, b.HostVolumes)
 	}
 
 	return &result

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -138,6 +138,11 @@ func extraKeys(c *Config) error {
 	// stats is an unused key, continue to silently ignore it
 	removeEqualFold(&c.Client.ExtraKeysHCL, "stats")
 
+	// Remove HostVolume extra keys
+	for _, hv := range c.Client.HostVolumes {
+		removeEqualFold(&c.Client.ExtraKeysHCL, hv.Name)
+	}
+
 	for _, k := range []string{"enabled_schedulers", "start_join", "retry_join", "server_join"} {
 		removeEqualFold(&c.ExtraKeysHCL, k)
 		removeEqualFold(&c.ExtraKeysHCL, "server")

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -83,7 +83,7 @@ var basicConfig = &Config{
 		NoHostUUID:            helper.BoolToPtr(false),
 		DisableRemoteExec:     true,
 		HostVolumes: []*structs.ClientHostVolumeConfig{
-			{Name: "tmp", Source: "/tmp"},
+			{Name: "tmp", Path: "/tmp"},
 		},
 	},
 	Server: &ServerConfig{

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/stretchr/testify/require"
 )
@@ -81,6 +82,9 @@ var basicConfig = &Config{
 		GCMaxAllocs:           50,
 		NoHostUUID:            helper.BoolToPtr(false),
 		DisableRemoteExec:     true,
+		HostVolumes: []*structs.ClientHostVolumeConfig{
+			{Name: "tmp", Source: "/tmp"},
+		},
 	},
 	Server: &ServerConfig{
 		Enabled:                true,

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -737,7 +737,7 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 				continue
 			}
 
-			vol := &structs.Volume{
+			vol := &structs.VolumeRequest{
 				Name:     v.Name,
 				Type:     v.Type,
 				ReadOnly: v.ReadOnly,
@@ -745,10 +745,7 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 				Config:   v.Config,
 			}
 
-			tg.Volumes[k] = &structs.VolumeRequest{
-				Volume: vol,
-				Config: v.Config,
-			}
+			tg.Volumes[k] = vol
 		}
 	}
 

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -91,7 +91,7 @@ client {
   disable_remote_exec      = true
 
   host_volume "tmp" {
-    source = "/tmp"
+    path = "/tmp"
   }
 }
 

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -89,6 +89,10 @@ client {
   gc_max_allocs            = 50
   no_host_uuid             = false
   disable_remote_exec      = true
+
+  host_volume "tmp" {
+    source = "/tmp"
+  }
 }
 
 server {

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -55,7 +55,7 @@
         {
           "tmp": [
             {
-              "source": "/tmp"
+              "path": "/tmp"
             }
           ]
         }

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -44,12 +44,22 @@
       "client_max_port": 2000,
       "client_min_port": 1000,
       "cpu_total_compute": 4444,
+      "disable_remote_exec": true,
       "enabled": true,
       "gc_disk_usage_threshold": 82,
       "gc_inode_usage_threshold": 91,
       "gc_interval": "6s",
       "gc_max_allocs": 50,
       "gc_parallel_destroys": 6,
+      "host_volume": [
+        {
+          "tmp": [
+            {
+              "source": "/tmp"
+            }
+          ]
+        }
+      ],
       "max_kill_timeout": "10s",
       "meta": [
         {
@@ -60,7 +70,6 @@
       "network_interface": "eth0",
       "network_speed": 100,
       "no_host_uuid": false,
-      "disable_remote_exec": true,
       "node_class": "linux-medium-64bit",
       "options": [
         {
@@ -137,25 +146,39 @@
   "log_json": true,
   "log_level": "ERR",
   "name": "my-web",
-  "plugin": {
-    "docker": {
-      "args": [
-        "foo",
-        "bar"
-      ],
-      "config": {
-        "foo": "bar",
-        "nested": {
-          "bam": 2
+  "plugin": [
+    {
+      "docker": [
+        {
+          "args": [
+            "foo",
+            "bar"
+          ],
+          "config": [
+            {
+              "foo": "bar",
+              "nested": [
+                {
+                  "bam": 2
+                }
+              ]
+            }
+          ]
         }
-      }
+      ]
     },
-    "exec": {
-      "config": {
-          "foo": true
+    {
+      "exec": [
+        {
+          "config": [
+            {
+              "foo": true
+            }
+          ]
         }
+      ]
     }
-  },
+  ],
   "plugin_dir": "/tmp/nomad-plugins",
   "ports": [
     {

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -316,6 +316,7 @@ func parseGroups(result *api.Job, list *ast.ObjectList) error {
 			"spread",
 			"network",
 			"service",
+			"volume",
 		}
 		if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("'%s' ->", n))
@@ -337,6 +338,7 @@ func parseGroups(result *api.Job, list *ast.ObjectList) error {
 		delete(m, "spread")
 		delete(m, "network")
 		delete(m, "service")
+		delete(m, "volume")
 
 		// Build the group with the basic decode
 		var g api.TaskGroup
@@ -424,6 +426,12 @@ func parseGroups(result *api.Job, list *ast.ObjectList) error {
 			}
 		}
 
+		// Parse any volume declarations
+		if o := listVal.Filter("volume"); len(o.Items) > 0 {
+			if err := parseVolumes(&g.Volumes, o); err != nil {
+				return multierror.Prefix(err, "volume ->")
+			}
+		}
 		// Parse tasks
 		if o := listVal.Filter("task"); len(o.Items) > 0 {
 			if err := parseTasks(*result.Name, *g.Name, &g.Tasks, o); err != nil {
@@ -460,6 +468,101 @@ func parseGroups(result *api.Job, list *ast.ObjectList) error {
 	}
 
 	result.TaskGroups = append(result.TaskGroups, collection...)
+	return nil
+}
+
+func parseVolumes(out *map[string]*api.Volume, list *ast.ObjectList) error {
+	volumes := make(map[string]*api.Volume, len(list.Items))
+
+	for _, item := range list.Items {
+		n := item.Keys[0].Token.Value().(string)
+		valid := []string{
+			"type",
+			"read_only",
+			"hidden",
+			"config",
+		}
+		if err := helper.CheckHCLKeys(item.Val, valid); err != nil {
+			return err
+		}
+
+		var m map[string]interface{}
+		if err := hcl.DecodeObject(&m, item.Val); err != nil {
+			return err
+		}
+
+		// TODO(dani): FIXME: this is gross but we don't have ObjectList.Filter here
+		var cfg map[string]interface{}
+		if cfgI, ok := m["config"]; ok {
+			cfgL, ok := cfgI.([]map[string]interface{})
+			if !ok {
+				return fmt.Errorf("Incorrect `config` type, expected map")
+			}
+
+			if len(cfgL) != 1 {
+				return fmt.Errorf("Expected single `config`, found %d", len(cfgL))
+			}
+
+			cfg = cfgL[0]
+		}
+		delete(m, "config")
+
+		var result api.Volume
+		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			WeaklyTypedInput: true,
+			Result:           &result,
+		})
+		if err != nil {
+			return err
+		}
+		if err := dec.Decode(m); err != nil {
+			return err
+		}
+
+		result.Name = n
+		result.Config = cfg
+
+		volumes[n] = &result
+	}
+
+	*out = volumes
+	return nil
+}
+
+func parseVolumeMounts(out *[]*api.VolumeMount, list *ast.ObjectList) error {
+	mounts := make([]*api.VolumeMount, len(list.Items))
+
+	for i, item := range list.Items {
+		valid := []string{
+			"volume",
+			"read_only",
+			"destination",
+		}
+		if err := helper.CheckHCLKeys(item.Val, valid); err != nil {
+			return err
+		}
+
+		var m map[string]interface{}
+		if err := hcl.DecodeObject(&m, item.Val); err != nil {
+			return err
+		}
+
+		var result api.VolumeMount
+		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			WeaklyTypedInput: true,
+			Result:           &result,
+		})
+		if err != nil {
+			return err
+		}
+		if err := dec.Decode(m); err != nil {
+			return err
+		}
+
+		mounts[i] = &result
+	}
+
+	*out = mounts
 	return nil
 }
 
@@ -892,6 +995,7 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 			"user",
 			"vault",
 			"kill_signal",
+			"volume_mount",
 		}
 		if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("'%s' ->", n))
@@ -913,6 +1017,7 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 		delete(m, "service")
 		delete(m, "template")
 		delete(m, "vault")
+		delete(m, "volume_mount")
 
 		// Build the task
 		var t api.Task
@@ -992,6 +1097,14 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 				if err := mapstructure.WeakDecode(m, &t.Meta); err != nil {
 					return err
 				}
+			}
+		}
+
+		// Parse volume mounts
+		if o := listVal.Filter("volume_mount"); len(o.Items) > 0 {
+			if err := parseVolumeMounts(&t.VolumeMounts, o); err != nil {
+				return multierror.Prefix(err, fmt.Sprintf(
+					"'%s', volume_mount ->", n))
 			}
 		}
 

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -86,6 +86,7 @@ func TestParse(t *testing.T) {
 				TaskGroups: []*api.TaskGroup{
 					{
 						Name: helper.StringToPtr("outside"),
+
 						Tasks: []*api.Task{
 							{
 								Name:   "outside",
@@ -108,6 +109,13 @@ func TestParse(t *testing.T) {
 								LTarget: "kernel.os",
 								RTarget: "linux",
 								Operand: "=",
+							},
+						},
+
+						Volumes: map[string]*api.Volume{
+							"foo": {
+								Name: "foo",
+								Type: "host",
 							},
 						},
 						Affinities: []*api.Affinity{
@@ -184,6 +192,12 @@ func TestParse(t *testing.T) {
 										{
 											"FOO": "bar",
 										},
+									},
+								},
+								VolumeMounts: []*api.VolumeMount{
+									{
+										Volume:      "foo",
+										Destination: "/mnt/foo",
 									},
 								},
 								Affinities: []*api.Affinity{

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -63,6 +63,10 @@ job "binstore-storagelocker" {
   group "binsl" {
     count = 5
 
+    volume "foo" {
+      type = "host"
+    }
+
     restart {
       attempts = 5
       interval = "10m"
@@ -140,6 +144,11 @@ job "binstore-storagelocker" {
         labels {
           FOO = "bar"
         }
+      }
+
+      volume_mount {
+        volume      = "foo"
+        destination = "/mnt/foo"
       }
 
       logs {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4885,9 +4885,9 @@ func (tg *TaskGroup) Validate(j *Job) error {
 
 	// Validate the Host Volumes
 	for name, decl := range tg.Volumes {
-		if decl.Volume.Type != VolumeTypeHost {
+		if decl.Type != VolumeTypeHost {
 			// TODO: Remove this error when adding new volume types
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("Volume %s has unrecognised type %s", name, decl.Volume.Type))
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Volume %s has unrecognised type %s", name, decl.Type))
 			continue
 		}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1578,6 +1578,9 @@ type Node struct {
 	// Drivers is a map of driver names to current driver information
 	Drivers map[string]*DriverInfo
 
+	// HostVolumes is a map of host volume names to their configuration
+	HostVolumes map[string]*ClientHostVolumeConfig
+
 	// Raft Indexes
 	CreateIndex uint64
 	ModifyIndex uint64
@@ -1622,6 +1625,7 @@ func (n *Node) Copy() *Node {
 	nn.Events = copyNodeEvents(n.Events)
 	nn.DrainStrategy = nn.DrainStrategy.Copy()
 	nn.Drivers = copyNodeDrivers(n.Drivers)
+	nn.HostVolumes = copyNodeHostVolumes(n.HostVolumes)
 	return nn
 }
 
@@ -1650,6 +1654,21 @@ func copyNodeDrivers(drivers map[string]*DriverInfo) map[string]*DriverInfo {
 	for driver, info := range drivers {
 		c[driver] = info.Copy()
 	}
+	return c
+}
+
+// copyNodeHostVolumes is a helper to copy a map of string to Volume
+func copyNodeHostVolumes(volumes map[string]*ClientHostVolumeConfig) map[string]*ClientHostVolumeConfig {
+	l := len(volumes)
+	if l == 0 {
+		return nil
+	}
+
+	c := make(map[string]*ClientHostVolumeConfig, l)
+	for volume, v := range volumes {
+		c[volume] = v.Copy()
+	}
+
 	return c
 }
 
@@ -4659,6 +4678,9 @@ type TaskGroup struct {
 
 	// Services this group provides
 	Services []*Service
+
+	// Volumes is a map of volumes that have been requested by the task group.
+	Volumes map[string]*VolumeRequest
 }
 
 func (tg *TaskGroup) Copy() *TaskGroup {
@@ -4673,6 +4695,7 @@ func (tg *TaskGroup) Copy() *TaskGroup {
 	ntg.ReschedulePolicy = ntg.ReschedulePolicy.Copy()
 	ntg.Affinities = CopySliceAffinities(ntg.Affinities)
 	ntg.Spreads = CopySliceSpreads(ntg.Spreads)
+	ntg.Volumes = CopyMapVolumeRequest(ntg.Volumes)
 
 	// Copy the network objects
 	if tg.Networks != nil {
@@ -4860,6 +4883,25 @@ func (tg *TaskGroup) Validate(j *Job) error {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("Only one task may be marked as leader"))
 	}
 
+	// Validate the Host Volumes
+	for name, decl := range tg.Volumes {
+		if decl.Volume.Type != VolumeTypeHost {
+			// TODO: Remove this error when adding new volume types
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Volume %s has unrecognised type %s", name, decl.Volume.Type))
+			continue
+		}
+
+		cfg, err := ParseHostVolumeConfig(decl.Config)
+		if err != nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Volume %s has unparseable config: %v", name, err))
+			continue
+		}
+
+		if cfg.Source == "" {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Volume %s has an empty source", name))
+		}
+	}
+
 	// Validate task group and task network resources
 	if err := tg.validateNetworks(); err != nil {
 		outer := fmt.Errorf("Task group network validation failed: %v", err)
@@ -4868,6 +4910,19 @@ func (tg *TaskGroup) Validate(j *Job) error {
 
 	// Validate the tasks
 	for _, task := range tg.Tasks {
+		// Validate the task does not reference undefined volume mounts
+		for i, mnt := range task.VolumeMounts {
+			if mnt.Volume == "" {
+				mErr.Errors = append(mErr.Errors, fmt.Errorf("Task %s has a volume mount (%d) referencing an empty volume", task.Name, i))
+				continue
+			}
+
+			if _, ok := tg.Volumes[mnt.Volume]; !ok {
+				mErr.Errors = append(mErr.Errors, fmt.Errorf("Task %s has a volume mount (%d) referencing undefined volume %s", task.Name, i, mnt.Volume))
+				continue
+			}
+		}
+
 		if err := task.Validate(tg.EphemeralDisk, j.Type); err != nil {
 			outer := fmt.Errorf("Task %s validation failed: %v", task.Name, err)
 			mErr.Errors = append(mErr.Errors, outer)
@@ -5616,6 +5671,10 @@ type Task struct {
 	// task from Consul and sending it a signal to shutdown. See #2441
 	ShutdownDelay time.Duration
 
+	// VolumeMounts is a list of Volume name <-> mount configurations that will be
+	// attached to this task.
+	VolumeMounts []*VolumeMount
+
 	// The kill signal to use for the task. This is an optional specification,
 
 	// KillSignal is the kill signal to use for the task. This is an optional
@@ -5641,6 +5700,7 @@ func (t *Task) Copy() *Task {
 
 	nt.Constraints = CopySliceConstraints(nt.Constraints)
 	nt.Affinities = CopySliceAffinities(nt.Affinities)
+	nt.VolumeMounts = CopySliceVolumeMount(nt.VolumeMounts)
 
 	nt.Vault = nt.Vault.Copy()
 	nt.Resources = nt.Resources.Copy()

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -872,9 +872,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 	tg = &TaskGroup{
 		Volumes: map[string]*VolumeRequest{
 			"foo": {
-				Volume: &Volume{
-					Type: "nothost",
-				},
+				Type: "nothost",
 				Config: map[string]interface{}{
 					"sOuRcE": "foo",
 				},
@@ -893,10 +891,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 	tg = &TaskGroup{
 		Volumes: map[string]*VolumeRequest{
 			"foo": {
-				Volume: &Volume{
-					Type: "host",
-				},
-				Config: nil,
+				Type: "host",
 			},
 		},
 		Tasks: []*Task{
@@ -912,10 +907,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 	tg = &TaskGroup{
 		Volumes: map[string]*VolumeRequest{
 			"foo": {
-				Volume: &Volume{
-					Type: "host",
-				},
-				Config: nil,
+				Type: "host",
 			},
 		},
 		Tasks: []*Task{

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -868,6 +868,83 @@ func TestTaskGroup_Validate(t *testing.T) {
 	err = tg.Validate(j)
 	require.Contains(t, err.Error(), "Port label http already in use")
 	require.Contains(t, err.Error(), "Port mapped to 80 already in use")
+
+	tg = &TaskGroup{
+		Volumes: map[string]*VolumeRequest{
+			"foo": {
+				Volume: &Volume{
+					Type: "nothost",
+				},
+				Config: map[string]interface{}{
+					"sOuRcE": "foo",
+				},
+			},
+		},
+		Tasks: []*Task{
+			{
+				Name:      "task-a",
+				Resources: &Resources{},
+			},
+		},
+	}
+	err = tg.Validate(&Job{})
+	require.Contains(t, err.Error(), `Volume foo has unrecognised type nothost`)
+
+	tg = &TaskGroup{
+		Volumes: map[string]*VolumeRequest{
+			"foo": {
+				Volume: &Volume{
+					Type: "host",
+				},
+				Config: nil,
+			},
+		},
+		Tasks: []*Task{
+			{
+				Name:      "task-a",
+				Resources: &Resources{},
+			},
+		},
+	}
+	err = tg.Validate(&Job{})
+	require.Contains(t, err.Error(), `Volume foo has an empty source`)
+
+	tg = &TaskGroup{
+		Volumes: map[string]*VolumeRequest{
+			"foo": {
+				Volume: &Volume{
+					Type: "host",
+				},
+				Config: nil,
+			},
+		},
+		Tasks: []*Task{
+			{
+				Name:      "task-a",
+				Resources: &Resources{},
+				VolumeMounts: []*VolumeMount{
+					{
+						Volume: "",
+					},
+				},
+			},
+			{
+				Name:      "task-b",
+				Resources: &Resources{},
+				VolumeMounts: []*VolumeMount{
+					{
+						Volume: "foob",
+					},
+				},
+			},
+		},
+	}
+	err = tg.Validate(&Job{})
+	expected = `Task task-a has a volume mount (0) referencing an empty volume`
+	require.Contains(t, err.Error(), expected)
+
+	expected = `Task task-b has a volume mount (0) referencing undefined volume foob`
+	require.Contains(t, err.Error(), expected)
 }
 
 func TestTask_Validate(t *testing.T) {

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -12,7 +12,7 @@ const (
 // ClientHostVolumeConfig is used to configure access to host paths on a Nomad Client
 type ClientHostVolumeConfig struct {
 	Name     string `hcl:",key"`
-	Source   string `hcl:"source"`
+	Path     string `hcl:"path"`
 	ReadOnly bool   `hcl:"read_only"`
 	Hidden   bool   `hcl:"hidden"`
 }

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -1,0 +1,188 @@
+package structs
+
+import (
+	"github.com/mitchellh/copystructure"
+	"github.com/mitchellh/mapstructure"
+)
+
+const (
+	VolumeTypeHost = "host"
+)
+
+// ClientHostVolumeConfig is used to configure access to host paths on a Nomad Client
+type ClientHostVolumeConfig struct {
+	Name     string `hcl:",key"`
+	Source   string `hcl:"source"`
+	ReadOnly bool   `hcl:"read_only"`
+	Hidden   bool   `hcl:"hidden"`
+}
+
+func (p *ClientHostVolumeConfig) Copy() *ClientHostVolumeConfig {
+	if p == nil {
+		return nil
+	}
+
+	c := new(ClientHostVolumeConfig)
+	*c = *p
+	return c
+}
+
+func CopyMapStringClientHostVolumeConfig(m map[string]*ClientHostVolumeConfig) map[string]*ClientHostVolumeConfig {
+	if m == nil {
+		return nil
+	}
+
+	nm := make(map[string]*ClientHostVolumeConfig, len(m))
+	for k, v := range m {
+		nm[k] = v.Copy()
+	}
+
+	return nm
+}
+
+func HostVolumeSliceMerge(a, b []*ClientHostVolumeConfig) []*ClientHostVolumeConfig {
+	n := make([]*ClientHostVolumeConfig, len(a))
+	seenKeys := make(map[string]struct{}, len(a))
+
+	for k, v := range a {
+		if _, ok := seenKeys[v.Name]; ok {
+			continue
+		}
+		n[k] = v.Copy()
+		seenKeys[v.Name] = struct{}{}
+	}
+	for k, v := range b {
+		if _, ok := seenKeys[v.Name]; ok {
+			continue
+		}
+		n[k] = v.Copy()
+		seenKeys[v.Name] = struct{}{}
+	}
+
+	return n
+}
+
+// HostVolumeConfig is the struct that is expected inside the `config` section
+// of a `host` type volume.
+type HostVolumeConfig struct {
+	// Source is the name of the desired HostVolume.
+	Source string
+}
+
+func (h *HostVolumeConfig) Copy() *HostVolumeConfig {
+	if h == nil {
+		return nil
+	}
+	nh := new(HostVolumeConfig)
+	*nh = *h
+	return nh
+}
+
+// Volume is a representation of a storage volume that a TaskGroup wishes to use.
+type Volume struct {
+	Name     string
+	Type     string
+	ReadOnly bool
+	Hidden   bool
+
+	Config map[string]interface{}
+}
+
+func (v *Volume) Copy() *Volume {
+	if v == nil {
+		return nil
+	}
+	nv := new(Volume)
+	*nv = *v
+
+	if i, err := copystructure.Copy(nv.Config); err != nil {
+		panic(err.Error())
+	} else {
+		nv.Config = i.(map[string]interface{})
+	}
+
+	return nv
+}
+
+func CopyMapVolumes(s map[string]*Volume) map[string]*Volume {
+	if s == nil {
+		return nil
+	}
+
+	l := len(s)
+	c := make(map[string]*Volume, l)
+	for k, v := range s {
+		c[k] = v.Copy()
+	}
+	return c
+}
+
+// VolumeMount is ...
+type VolumeMount struct {
+	Volume      string
+	Destination string
+	ReadOnly    bool
+}
+
+func (v *VolumeMount) Copy() *VolumeMount {
+	if v == nil {
+		return nil
+	}
+
+	nv := new(VolumeMount)
+	*nv = *v
+	return nv
+}
+
+func CopySliceVolumeMount(s []*VolumeMount) []*VolumeMount {
+	l := len(s)
+	if l == 0 {
+		return nil
+	}
+
+	c := make([]*VolumeMount, l)
+	for i, v := range s {
+		c[i] = v.Copy()
+	}
+	return c
+}
+
+type VolumeRequest struct {
+	Volume *Volume
+	Config map[string]interface{}
+}
+
+func (h *VolumeRequest) Copy() *VolumeRequest {
+	if h == nil {
+		return nil
+	}
+
+	c := new(VolumeRequest)
+	c.Volume = h.Volume.Copy()
+	if i, err := copystructure.Copy(h.Config); err != nil {
+		panic(err.Error())
+	} else {
+		c.Config = i.(map[string]interface{})
+	}
+	return c
+}
+
+func CopyMapVolumeRequest(m map[string]*VolumeRequest) map[string]*VolumeRequest {
+	if m == nil {
+		return nil
+	}
+
+	l := len(m)
+	c := make(map[string]*VolumeRequest, l)
+	for k, v := range m {
+		c[k] = v.Copy()
+	}
+	return c
+}
+
+func ParseHostVolumeConfig(m map[string]interface{}) (*HostVolumeConfig, error) {
+	var c HostVolumeConfig
+	err := mapstructure.Decode(m, &c)
+
+	return &c, err
+}

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -130,7 +130,8 @@ func CopyMapVolumeRequest(s map[string]*VolumeRequest) map[string]*VolumeRequest
 	return c
 }
 
-// VolumeMount is ...
+// VolumeMount represents the relationship between a destination path in a task
+// and the task group volume that should be mounted there.
 type VolumeMount struct {
 	Volume      string
 	Destination string

--- a/plugins/drivers/driver.go
+++ b/plugins/drivers/driver.go
@@ -362,6 +362,12 @@ type MountConfig struct {
 	Readonly bool
 }
 
+func (m *MountConfig) IsEqual(o *MountConfig) bool {
+	return m.TaskPath == o.TaskPath &&
+		m.HostPath == o.HostPath &&
+		m.Readonly == o.Readonly
+}
+
 func (m *MountConfig) Copy() *MountConfig {
 	if m == nil {
 		return nil

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -117,7 +117,7 @@ func (h *HostVolumeChecker) SetVolumes(volumes map[string]*structs.VolumeRequest
 	// Convert the map from map[DesiredName]Request to map[Source][]Request to improve
 	// lookup performance. Also filter non-host volumes.
 	for _, req := range volumes {
-		if req.Volume.Type != "host" {
+		if req.Volume.Type != structs.VolumeTypeHost {
 			continue
 		}
 

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -109,15 +109,15 @@ func TestHostVolumeChecker(t *testing.T) {
 
 	volumes := map[string]*structs.VolumeRequest{
 		"foo": {
-			Volume: &structs.Volume{Type: "host"},
+			Type:   "host",
 			Config: map[string]interface{}{"source": "foo"},
 		},
 		"bar": {
-			Volume: &structs.Volume{Type: "host"},
+			Type:   "host",
 			Config: map[string]interface{}{"source": "bar"},
 		},
 		"baz": {
-			Volume: &structs.Volume{Type: "nothost"},
+			Type:   "nothost",
 			Config: map[string]interface{}{"source": "baz"},
 		},
 	}

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -81,6 +81,88 @@ func TestRandomIterator(t *testing.T) {
 	}
 }
 
+func TestHostVolumeChecker(t *testing.T) {
+	_, ctx := testContext(t)
+	nodes := []*structs.Node{
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+	}
+	nodes[1].HostVolumes = map[string]*structs.ClientHostVolumeConfig{"foo": {Name: "foo"}}
+	nodes[2].HostVolumes = map[string]*structs.ClientHostVolumeConfig{
+		"foo": {},
+		"bar": {},
+	}
+	nodes[3].HostVolumes = map[string]*structs.ClientHostVolumeConfig{
+		"foo": {},
+		"bar": {},
+	}
+	nodes[4].HostVolumes = map[string]*structs.ClientHostVolumeConfig{
+		"foo": {},
+		"baz": {},
+	}
+
+	noVolumes := map[string]*structs.VolumeRequest{}
+
+	volumes := map[string]*structs.VolumeRequest{
+		"foo": {
+			Volume: &structs.Volume{Type: "host"},
+			Config: map[string]interface{}{"source": "foo"},
+		},
+		"bar": {
+			Volume: &structs.Volume{Type: "host"},
+			Config: map[string]interface{}{"source": "bar"},
+		},
+		"baz": {
+			Volume: &structs.Volume{Type: "nothost"},
+			Config: map[string]interface{}{"source": "baz"},
+		},
+	}
+
+	checker := NewHostVolumeChecker(ctx)
+	cases := []struct {
+		Node             *structs.Node
+		RequestedVolumes map[string]*structs.VolumeRequest
+		Result           bool
+	}{
+		{ // Nil Volumes, some requested
+			Node:             nodes[0],
+			RequestedVolumes: volumes,
+			Result:           false,
+		},
+		{ // Mismatched set of volumes
+			Node:             nodes[1],
+			RequestedVolumes: volumes,
+			Result:           false,
+		},
+		{ // Happy Path
+			Node:             nodes[2],
+			RequestedVolumes: volumes,
+			Result:           true,
+		},
+		{ // No Volumes requested or available
+			Node:             nodes[3],
+			RequestedVolumes: noVolumes,
+			Result:           true,
+		},
+		{ // No Volumes requested, some available
+			Node:             nodes[4],
+			RequestedVolumes: noVolumes,
+			Result:           true,
+		},
+	}
+
+	for i, c := range cases {
+		checker.SetVolumes(c.RequestedVolumes)
+		if act := checker.Feasible(c.Node); act != c.Result {
+			t.Fatalf("case(%d) failed: got %v; want %v", i, act, c.Result)
+		}
+	}
+}
+
 func TestDriverChecker(t *testing.T) {
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{

--- a/scheduler/stack_oss.go
+++ b/scheduler/stack_oss.go
@@ -31,12 +31,15 @@ func NewGenericStack(batch bool, ctx Context) *GenericStack {
 	// Filter on task group devices
 	s.taskGroupDevices = NewDeviceChecker(ctx)
 
+	// Filter on task group host volumes
+	s.taskGroupHostVolumes = NewHostVolumeChecker(ctx)
+
 	// Create the feasibility wrapper which wraps all feasibility checks in
 	// which feasibility checking can be skipped if the computed node class has
 	// previously been marked as eligible or ineligible. Generally this will be
 	// checks that only needs to examine the single node to determine feasibility.
 	jobs := []FeasibilityChecker{s.jobConstraint}
-	tgs := []FeasibilityChecker{s.taskGroupDrivers, s.taskGroupConstraint, s.taskGroupDevices}
+	tgs := []FeasibilityChecker{s.taskGroupDrivers, s.taskGroupConstraint, s.taskGroupHostVolumes, s.taskGroupDevices}
 	s.wrappedChecks = NewFeasibilityWrapper(ctx, s.quota, jobs, tgs)
 
 	// Filter on distinct host constraints.


### PR DESCRIPTION
This is the minimum viable work for #5377.

Subsequent PRs to the f-host-volumes branch will include support for features like getting volume status from the API, further improvements to driver support, validating volumes on client start, etc.

## Example Client Config

```hcl
client {
  host_volume "tmp-dir" {
    path = "/tmp"
  }
}
```

## Example Jobspec

```hcl
job "example" {
  datacenters = ["dc1"]

  type = "service"

  group "cache" {
    count = 1

    volume "tmp" {
      type = "host"

      config {
        source = "tmp-dir"
      }
    }

    task "redis" {
      driver = "docker"

      config {
        image = "redis"
      }

      volume_mount {
        volume           = "tmp"
        destination      = "/tmp"
      }

      resources {
        cpu    = 500 # 500 MHz
        memory = 256 # 256MB

        network {
          mbits = 10
          port  "db"  {}
        }
      }
    }
  }
}
```