### PR TITLE
UI: Remove superfluous test attributes

### DIFF
--- a/ui/app/templates/allocations/allocation/task/fs.hbs
+++ b/ui/app/templates/allocations/allocation/task/fs.hbs
@@ -45,7 +45,7 @@
             <tbody>
               <tr data-test-entry>
                 <td colspan="3">
-                  <span data-test-empty-icon>{{x-icon "alert-circle-outline"}}</span>
+                  {{x-icon "alert-circle-outline"}}
                   <span class="name" data-test-name>Directory is empty</span>
                 </td>
               </tr>

--- a/ui/app/templates/components/fs-directory-entry.hbs
+++ b/ui/app/templates/components/fs-directory-entry.hbs
@@ -2,9 +2,9 @@
   <td>
     {{#link-to "allocations.allocation.task.fs" task.allocation task pathToEntry activeClass="is-active"}}
       {{#if entry.IsDir}}
-        <span data-test-directory-icon>{{x-icon "folder-outline"}}</span>
+        {{x-icon "folder-outline"}}
       {{else}}
-        <span data-test-file-icon>{{x-icon "file-outline"}}</span>
+        {{x-icon "file-outline"}}
       {{/if}}
 
       <span class="name" data-test-name>{{entry.Name}}</span>

--- a/ui/tests/pages/allocations/task/fs.js
+++ b/ui/tests/pages/allocations/task/fs.js
@@ -28,9 +28,9 @@ export default create({
   directoryEntries: collection('[data-test-entry]', {
     name: text('[data-test-name]'),
 
-    isFile: isPresent('[data-test-file-icon]'),
-    isDirectory: isPresent('[data-test-directory-icon]'),
-    isEmpty: isPresent('[data-test-empty-icon]'),
+    isFile: isPresent('.icon-is-file-outline'),
+    isDirectory: isPresent('.icon-is-folder-outline'),
+    isEmpty: isPresent('.icon-is-alert-circle-outline'),
 
     size: text('[data-test-size]'),
     lastModified: text('[data-test-last-modified]'),


### PR DESCRIPTION
I found while working on #5926 that x-icon already adds
assertion-compatible selectors, so these wrappers are
unnecessary.