### PR TITLE
Updated the TensorRT demo to use the official NVIDIA image

### DIFF
--- a/terraform/examples/tensorrt/tensorrt-demo.nomad
+++ b/terraform/examples/tensorrt/tensorrt-demo.nomad
@@ -91,7 +91,7 @@ job "tensorrt" {
       driver = "docker"
 
       config {
-        image = "renaudwastaken/tensorrt-frontend:latest"
+        image = "nvidia/tensorrt-labs:frontend"
         args = [
           "main.py", "${RTSERVER}"
         ]


### PR DESCRIPTION
Hello!

I noticed that the demo was using the tensorRT image that was hosted under my personal dockerhub account. We've moved that image to the official NVIDIA account (nvidia/tensorrt-labs:frontend).

Ultimately this is the same image :
```
nomad git:(master) skopeo inspect docker://nvidia/tensorrt-labs:frontend | jq .Digest
"sha256:c7a9c8b3415416fe3d7e39dc1645df5d40f3df86013261c3e1d635555a4becba"

skopeo inspect docker://renaudwastaken/tensorrt-frontend:latest | jq .Digest
"sha256:c7a9c8b3415416fe3d7e39dc1645df5d40f3df86013261c3e1d635555a4becba
```

Let me know if anything more is needed as this is my first contribution :)