### PR TITLE
Populate task event struct with kill timeout

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -499,7 +499,9 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 			continue
 		}
 
-		err := tr.Kill(context.TODO(), structs.NewTaskEvent(structs.TaskKilling))
+		taskEvent := structs.NewTaskEvent(structs.TaskKilling)
+		taskEvent.SetKillTimeout(tr.Task().KillTimeout)
+		err := tr.Kill(context.TODO(), taskEvent)
 		if err != nil && err != taskrunner.ErrTaskNotRunning {
 			ar.logger.Warn("error stopping leader task", "error", err, "task_name", name)
 		}
@@ -519,7 +521,9 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 		wg.Add(1)
 		go func(name string, tr *taskrunner.TaskRunner) {
 			defer wg.Done()
-			err := tr.Kill(context.TODO(), structs.NewTaskEvent(structs.TaskKilling))
+			taskEvent := structs.NewTaskEvent(structs.TaskKilling)
+			taskEvent.SetKillTimeout(tr.Task().KillTimeout)
+			err := tr.Kill(context.TODO(), taskEvent)
 			if err != nil && err != taskrunner.ErrTaskNotRunning {
 				ar.logger.Warn("error stopping task", "error", err, "task_name", name)
 			}

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -107,10 +107,19 @@ func TestAllocRunner_TaskLeader_KillTG(t *testing.T) {
 		}
 
 		found := false
+		killingMsg := ""
 		for _, e := range state1.Events {
 			if e.Type != structs.TaskLeaderDead {
 				found = true
 			}
+			if e.Type == structs.TaskKilling {
+				killingMsg = e.DisplayMessage
+			}
+		}
+		expectedKillingMsg := "Sent interrupt. Waiting 10ms before force killing"
+
+		if killingMsg != expectedKillingMsg {
+			return false, fmt.Errorf("Unexpected task event message - wanted %q. got %q", killingMsg, expectedKillingMsg)
 		}
 
 		if !found {

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -116,14 +116,14 @@ func TestAllocRunner_TaskLeader_KillTG(t *testing.T) {
 				killingMsg = e.DisplayMessage
 			}
 		}
-		expectedKillingMsg := "Sent interrupt. Waiting 10ms before force killing"
-
-		if killingMsg != expectedKillingMsg {
-			return false, fmt.Errorf("Unexpected task event message - wanted %q. got %q", killingMsg, expectedKillingMsg)
-		}
 
 		if !found {
 			return false, fmt.Errorf("Did not find event %v", structs.TaskLeaderDead)
+		}
+
+		expectedKillingMsg := "Sent interrupt. Waiting 10ms before force killing"
+		if killingMsg != expectedKillingMsg {
+			return false, fmt.Errorf("Unexpected task event message - wanted %q. got %q", killingMsg, expectedKillingMsg)
 		}
 
 		// Task Two should be dead


### PR DESCRIPTION
This makes for a nicer task event message when the task is killed

Fixes #5931 