### PR TITLE
TF config enable services

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -43,7 +43,7 @@ a custom AMI:
 
 ```bash
 region                  = "us-east-1"
-ami                     = "ami-090a41df9e193a506"
+ami                     = "ami-09730698a875f6abd"
 instance_type           = "t2.medium"
 key_name                = "KEY_NAME"
 server_count            = "3"
@@ -57,7 +57,7 @@ variable like so:
 
 ```bash
 region                  = "us-east-1"
-ami                     = "ami-090a41df9e193a506"
+ami                     = "ami-09730698a875f6abd"
 instance_type           = "t2.medium"
 key_name                = "KEY_NAME"
 server_count            = "3"

--- a/terraform/aws/env/us-east/terraform.tfvars
+++ b/terraform/aws/env/us-east/terraform.tfvars
@@ -21,7 +21,7 @@ name = "nomad"
 # `ami` (required) - The base AMI for the created nodes, This AMI must exist in
 # the requested region for this environment to build properly.
 #  - If it is not provided here, it will be requested interactively.
-ami = "ami-090a41df9e193a506"
+ami = "ami-09730698a875f6abd"
 
 # `server_instance_type` ("t2.medium"), `client_instance_type` ("t2.medium"),
 # `server_count` (3),`client_count` (4) - These options control instance size

--- a/terraform/shared/scripts/client.sh
+++ b/terraform/shared/scripts/client.sh
@@ -27,6 +27,7 @@ sed -i "s/RETRY_JOIN/$RETRY_JOIN/g" $CONFIGDIR/consul_client.json
 sudo cp $CONFIGDIR/consul_client.json $CONSULCONFIGDIR/consul.json
 sudo cp $CONFIGDIR/consul_$CLOUD.service /etc/systemd/system/consul.service
 
+sudo systemctl enable consul.service
 sudo systemctl start consul.service
 sleep 10
 
@@ -43,6 +44,7 @@ fi
 sudo cp $CONFIGDIR/nomad_client.hcl $NOMADCONFIGDIR/nomad.hcl
 sudo cp $CONFIGDIR/nomad.service /etc/systemd/system/nomad.service
 
+sudo systemctl enable nomad.service
 sudo systemctl start nomad.service
 sleep 10
 export NOMAD_ADDR=http://$IP_ADDRESS:4646

--- a/terraform/shared/scripts/server.sh
+++ b/terraform/shared/scripts/server.sh
@@ -30,6 +30,7 @@ sed -i "s/RETRY_JOIN/$RETRY_JOIN/g" $CONFIGDIR/consul.json
 sudo cp $CONFIGDIR/consul.json $CONSULCONFIGDIR
 sudo cp $CONFIGDIR/consul_$CLOUD.service /etc/systemd/system/consul.service
 
+sudo systemctl enable consul.service
 sudo systemctl start consul.service
 sleep 10
 export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500
@@ -40,6 +41,7 @@ sed -i "s/IP_ADDRESS/$IP_ADDRESS/g" $CONFIGDIR/vault.hcl
 sudo cp $CONFIGDIR/vault.hcl $VAULTCONFIGDIR
 sudo cp $CONFIGDIR/vault.service /etc/systemd/system/vault.service
 
+sudo systemctl enable vault.service
 sudo systemctl start vault.service
 
 # Nomad
@@ -56,6 +58,7 @@ sed -i "s/SERVER_COUNT/$SERVER_COUNT/g" $CONFIGDIR/nomad.hcl
 sudo cp $CONFIGDIR/nomad.hcl $NOMADCONFIGDIR
 sudo cp $CONFIGDIR/nomad.service /etc/systemd/system/nomad.service
 
+sudo systemctl enable nomad.service
 sudo systemctl start nomad.service
 sleep 10
 export NOMAD_ADDR=http://$IP_ADDRESS:4646


### PR DESCRIPTION
Enabling Nomad, Consul services (server and client) and Vault service (server) to make persistent after reboot.