### PR TITLE
Remove trailing dot on drain message to ensure better consistency.

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -335,7 +335,7 @@ func (n *Nodes) monitorDrainAllocs(ctx context.Context, nodeID string, ignoreSys
 
 		// Exit if all allocs are terminal
 		if runningAllocs == 0 {
-			msg := Messagef(MonitorMsgLevelInfo, "All allocations on node %q have stopped.", nodeID)
+			msg := Messagef(MonitorMsgLevelInfo, "All allocations on node %q have stopped", nodeID)
 			select {
 			case allocCh <- msg:
 			case <-ctx.Done():


### PR DESCRIPTION
I am currently working on a tool which includes drain functionality and noticed that this is the only message to end with a dot. This is therefore a very small change to ensure additional consistency in the messages exposed by Nomad when performing a Nomad drain.