### PR TITLE
Prevent checkwatcher from deadlocking from too many check restarts

### DIFF
--- a/client/allocrunner/alloc_runner_unix_test.go
+++ b/client/allocrunner/alloc_runner_unix_test.go
@@ -114,11 +114,11 @@ func TestAllocRunner_Restore_RunningTerminal(t *testing.T) {
 	require.Error(t, logmonProc.Signal(syscall.Signal(0)))
 
 	// Assert consul was cleaned up:
-	//   2 removals (canary+noncanary) during prekill
-	//   2 removals (canary+noncanary) during exited
-	//   2 removals (canary+noncanary) during stop
+	//   1 removal during prekill
+	//   1 removal during exited
+	//   1 removal during stop
 	consulOps := conf2.Consul.(*consul.MockConsulServiceClient).GetOps()
-	require.Len(t, consulOps, 6)
+	require.Len(t, consulOps, 3)
 	for _, op := range consulOps {
 		require.Equal(t, "remove", op.Op)
 	}

--- a/client/allocrunner/interfaces/task_lifecycle.go
+++ b/client/allocrunner/interfaces/task_lifecycle.go
@@ -123,7 +123,10 @@ type TaskPoststartHook interface {
 	Poststart(context.Context, *TaskPoststartRequest, *TaskPoststartResponse) error
 }
 
-type TaskPreKillRequest struct{}
+type TaskPreKillRequest struct{
+	// True if the alloc is being killed due to a healthcheck failure
+	IsFailure bool
+}
 type TaskPreKillResponse struct{}
 
 type TaskPreKillHook interface {

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -23,7 +23,7 @@ func (tr *TaskRunner) Restart(ctx context.Context, event *structs.TaskEvent, fai
 	tr.EmitEvent(event)
 
 	// Run the pre-kill hooks prior to restarting the task
-	tr.preKill()
+	tr.preKill(failure)
 
 	// Tell the restart tracker that a restart triggered the exit
 	tr.restartTracker.SetRestartTriggered(failure)

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -799,7 +799,7 @@ func (tr *TaskRunner) initDriver() error {
 // runner killErr value.
 func (tr *TaskRunner) handleKill() *drivers.ExitResult {
 	// Run the pre killing hooks
-	tr.preKill()
+	tr.preKill(false)
 
 	// Tell the restart tracker that the task has been killed so it doesn't
 	// attempt to restart it.

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -438,7 +438,7 @@ func (tr *TaskRunner) updateHooks() {
 // preKill is used to run the runners preKill hooks
 // preKill hooks contain logic that must be executed before
 // a task is killed or restarted
-func (tr *TaskRunner) preKill() {
+func (tr *TaskRunner) preKill(isFailure bool) {
 	if tr.logger.IsTrace() {
 		start := time.Now()
 		tr.logger.Trace("running pre kill hooks", "start", start)
@@ -464,7 +464,9 @@ func (tr *TaskRunner) preKill() {
 		}
 
 		// Run the pre kill hook
-		req := interfaces.TaskPreKillRequest{}
+		req := interfaces.TaskPreKillRequest{
+			IsFailure: isFailure,
+		}
 		var resp interfaces.TaskPreKillResponse
 		if err := killHook.PreKilling(context.Background(), &req, &resp); err != nil {
 			tr.emitHookError(err, name)

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1991,25 +1991,22 @@ func TestTaskRunner_UnregisterConsul_Retries(t *testing.T) {
 
 	consul := conf.Consul.(*consulapi.MockConsulServiceClient)
 	consulOps := consul.GetOps()
-	require.Len(t, consulOps, 8)
+	require.Len(t, consulOps, 5)
 
 	// Initial add
 	require.Equal(t, "add", consulOps[0].Op)
 
-	// Removing canary and non-canary entries on first exit
+	// Removing on first exit
 	require.Equal(t, "remove", consulOps[1].Op)
-	require.Equal(t, "remove", consulOps[2].Op)
 
 	// Second add on retry
-	require.Equal(t, "add", consulOps[3].Op)
+	require.Equal(t, "add", consulOps[2].Op)
 
-	// Removing canary and non-canary entries on retry
+	// Removing on retry
+	require.Equal(t, "remove", consulOps[3].Op)
+
+	// Removing on stop
 	require.Equal(t, "remove", consulOps[4].Op)
-	require.Equal(t, "remove", consulOps[5].Op)
-
-	// Removing canary and non-canary entries on stop
-	require.Equal(t, "remove", consulOps[6].Op)
-	require.Equal(t, "remove", consulOps[7].Op)
 }
 
 // testWaitForTaskToStart waits for the task to be running or fails the test

--- a/client/consul/consul.go
+++ b/client/consul/consul.go
@@ -8,7 +8,7 @@ import (
 // remove services and checks from Consul.
 type ConsulServiceAPI interface {
 	RegisterTask(*consul.TaskServices) error
-	RemoveTask(*consul.TaskServices)
+	RemoveTask(*consul.TaskServices, bool)
 	UpdateTask(old, newTask *consul.TaskServices) error
 	AllocRegistrations(allocID string) (*consul.AllocRegistration, error)
 }

--- a/client/consul/consul_testing.go
+++ b/client/consul/consul_testing.go
@@ -70,7 +70,7 @@ func (m *MockConsulServiceClient) RegisterTask(task *consul.TaskServices) error 
 	return nil
 }
 
-func (m *MockConsulServiceClient) RemoveTask(task *consul.TaskServices) {
+func (m *MockConsulServiceClient) RemoveTask(task *consul.TaskServices, isFailure bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.logger.Trace("RemoveTask", "alloc_id", task.AllocID, "task", task.Name,

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -941,7 +941,7 @@ func (c *ServiceClient) UpdateTask(old, newTask *TaskServices) error {
 // RemoveTask from Consul. Removes all service entries and checks.
 //
 // Actual communication with Consul is done asynchronously (see Run).
-func (c *ServiceClient) RemoveTask(task *TaskServices) {
+func (c *ServiceClient) RemoveTask(task *TaskServices, isFailure bool) {
 	ops := operations{}
 
 	for _, service := range task.Services {
@@ -952,7 +952,8 @@ func (c *ServiceClient) RemoveTask(task *TaskServices) {
 			cid := makeCheckID(id, check)
 			ops.deregChecks = append(ops.deregChecks, cid)
 
-			if check.TriggersRestarts() {
+			// Task restarts due to healthcheck failures will have their checks removed by the check watcher
+			if check.TriggersRestarts() && !isFailure {
 				c.checkWatcher.Unwatch(cid)
 			}
 		}

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -636,7 +636,7 @@ func TestConsul_RegServices(t *testing.T) {
 	}
 
 	// Remove the new task
-	ctx.ServiceClient.RemoveTask(ctx.Task)
+	ctx.ServiceClient.RemoveTask(ctx.Task, false)
 	if err := ctx.syncOnce(); err != nil {
 		t.Fatalf("unexpected error syncing task: %v", err)
 	}
@@ -1258,7 +1258,7 @@ func TestConsul_CanaryTags(t *testing.T) {
 		require.NotEqual(canaryTags, service.Tags)
 	}
 
-	ctx.ServiceClient.RemoveTask(ctx.Task)
+	ctx.ServiceClient.RemoveTask(ctx.Task, false)
 	require.NoError(ctx.syncOnce())
 	require.Len(ctx.FakeConsul.services, 0)
 }
@@ -1291,7 +1291,7 @@ func TestConsul_CanaryTags_NoTags(t *testing.T) {
 		require.Equal(tags, service.Tags)
 	}
 
-	ctx.ServiceClient.RemoveTask(ctx.Task)
+	ctx.ServiceClient.RemoveTask(ctx.Task, false)
 	require.NoError(ctx.syncOnce())
 	require.Len(ctx.FakeConsul.services, 0)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/5395

Each time the consul check watcher runs its main loop, it has three
choices: 1. update watched checks, 2. check & restart failed allocs,
or 3. exit. Updating watched checks drains `checkUpdateCh`; restarts
synchronously fill `checkUpdateCh`. If too many checks require a
restart during the main loop, the `checkUpdateCh` channel will become
full and block. Once this happens, the channel cannot be drained, and
the check watcher deadlocks.

A check restart travels through several functions, so here's a simplified
view of the run loop:

```
while {
  dequeueUpdates from w.checkUpdateCh {
    ...
  }
  checkTimer {
  for all check watches {
    restart if unhealthy via apply()
      -> apply() calls Restart()
        -> Restart() calls preKill()
          -> preKill() calls PreKilling() hook
            -> PreKilling() hook calls deregister()
              -> deregister() calls RemoveTask()
                -> RemoveTask() calls Unwatch()
                  -> Unwatch() pushes messages into w.checkUpdateCh
                     // deadlock if channel is full before we exit the check watch for loop
  }
}
```

To fix this, we will pass along along a bool to the prekill hook
indicating that the restart is due to a check restart so that during
task deregistration, we do not attempt to insert messages into the
`checkUpdateCh` channel. These checks are removed by the check watcher
once the task runner's Restart function returns anyway.

Here's a job file to help test for the deadlock:

```hcl
job "example" {
  datacenters = ["dc1"]

  group "cache" {
    count = 7

    restart {
      attempts = 10
      interval = "5m"
      delay = "10s"
      mode = "delay"
    }

    task "redis" {
      driver = "docker"

      shutdown_delay = "10s"

      config {
        image = "redis:3.2"
        port_map {
          db = 6379
        }
      }

      resources {
        cpu    = 100
        memory = 32
        network {
          mbits = 10
          port "db" {}
        }
      }

      service {
        name = "redis-cache"
        tags = ["global", "cache"]
        port = "db"
        check {
          type = "script"
          command = "false"
          interval = "2s"
          timeout = "1s"
          check_restart = {
            limit = 3
            grace = "10s"
          }
        }
      }
    }
  }
}
```

A `count` of 7 is overkill but it helps speed things up. The job has
an intentionally faulty healthcheck. Run the job against a single node
using the 0.9.3 agent and then walk away for 5 minutes. The check
watcher should be deadlocked, and attempting to stop the job or drain
the node will fail/block. The same job file with this PR's changes
should be able to restart to its heart's content.

Additionally, the deregister function no longer removes consul tasks
twice. It used to do this when canary tasks had a different generated
consul ID, but this is no longer the case, and the second task removal
is unnecessary, only generating errors in nomad and consul logs. While
this itself does not cause deadlocking, it helped to speed up the
check watcher's deadlocking when it was present by inserting twice as
many messages into the channel.

A final addition: alloc restarts due to check restarts will no longer
wait through the shutdown delay. Unhealthy allocations should probably
just be restarted right away, and the use of the shutdown delay in the
prekill hook is probably an unintentional change due to the giant 0.9
refactor and alloc lifecycle changes.

Tests have been adjusted to account for this where I could find them.

I don't really write golang so I apologize if there are better or more
idiomatic approaches to this sort of change. Same goes for tests
because I am definitely lost when it comes to the testing apparatus on
a giant golang project like this.