### PR TITLE
take NodeID from url in api for node eligibility

### DIFF
--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -166,6 +166,10 @@ func (s *HTTPServer) nodeToggleEligibility(resp http.ResponseWriter, req *http.R
 	if err := decodeBody(req, &eligibilityRequest); err != nil {
 		return nil, CodedError(400, err.Error())
 	}
+	if eligibilityRequest.NodeID == "" {
+		eligibilityRequest.NodeID = nodeID
+	}
+
 	s.parseWriteRequest(req, &eligibilityRequest.WriteRequest)
 
 	var out structs.NodeEligibilityUpdateResponse

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -370,13 +370,12 @@ func TestHTTP_NodeEligible(t *testing.T) {
 		var resp structs.NodeUpdateResponse
 		require.Nil(s.Agent.RPC("Node.Register", &args, &resp))
 
-		drainReq := api.NodeUpdateEligibilityRequest{
-			NodeID:      node.ID,
+		eligibilityReq := api.NodeUpdateEligibilityRequest{
 			Eligibility: structs.NodeSchedulingIneligible,
 		}
 
 		// Make the HTTP request
-		buf := encodeReq(drainReq)
+		buf := encodeReq(eligibilityReq)
 		req, err := http.NewRequest("POST", "/v1/node/"+node.ID+"/eligibility", buf)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
@@ -399,8 +398,8 @@ func TestHTTP_NodeEligible(t *testing.T) {
 		require.Equal(structs.NodeSchedulingIneligible, out.SchedulingEligibility)
 
 		// Make the HTTP request to set something invalid
-		drainReq.Eligibility = "foo"
-		buf = encodeReq(drainReq)
+		eligibilityReq.Eligibility = "foo"
+		buf = encodeReq(eligibilityReq)
 		req, err = http.NewRequest("POST", "/v1/node/"+node.ID+"/eligibility", buf)
 		require.Nil(err)
 		respW = httptest.NewRecorder()


### PR DESCRIPTION
I tried to turn some nodes ineligible for scheduling using Nomad API and faced an inconsistency between documentation and API code.
 
[Documentation suggests]( https://www.nomadproject.io/api/nodes.html#toggle-node-eligibility), that I should send a POST request to `/v1/node/:node_id/eligibility` in order to toggle a specific node. 

Meanwhile, API is expecting to take NodeID from a POST/PUT payload, ignoring a URL parameter.

Since all other endpoints are taking NodeID from URL, it looks like documentation is correct here. I synced test with documentation. As am not sure, what behavior should be in case of ids in URL and payload are different, so I kept backward compatibility by giving priority to the payload.

WDYT?
