### PR TITLE
Added line around interoperability to Downloads page.

### DIFF
--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -28,6 +28,11 @@ description: |-
         which has been signed using <a href="https://www.hashicorp.com/security.html" target="_blank" rel="nofollow noopener noreferrer">HashiCorp's GPG key</a>.
         You can also <a href="https://releases.hashicorp.com/nomad/" target="_blank" rel="nofollow noopener noreferrer">download older versions of Nomad</a> from the releases service.
       </p>
+
+      <p>
+        Nomad works with many popular distributions including Amazon Linux 2, Ubuntu, and RHEL 7.
+      </p>
+
       <p>
       Check out the <a href="https://github.com/hashicorp/nomad/blob/v<%= latest_version %>/CHANGELOG.md">v<%= latest_version %> CHANGELOG</a> for information on the latest release.
       </p>


### PR DESCRIPTION
Added this sentence "Nomad works with many popular distributions including Amazon Linux 2, Ubuntu, and RHEL 7." into the Nomad downloads page.