### PR TITLE
Fix returned EOF error when calling Nodes GC/GcAlloc API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -930,8 +931,16 @@ func parseWriteMeta(resp *http.Response, q *WriteMeta) error {
 
 // decodeBody is used to JSON decode a body
 func decodeBody(resp *http.Response, out interface{}) error {
-	dec := json.NewDecoder(resp.Body)
-	return dec.Decode(out)
+	switch resp.ContentLength {
+	case 0:
+		if out == nil {
+			return nil
+		}
+		return errors.New("Got 0 byte response with non-nil decode object")
+	default:
+		dec := json.NewDecoder(resp.Body)
+		return dec.Decode(out)
+	}
 }
 
 // encodeBody is used to encode a request body

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -413,17 +413,15 @@ func (n *Nodes) Stats(nodeID string, q *QueryOptions) (*HostStats, error) {
 }
 
 func (n *Nodes) GC(nodeID string, q *QueryOptions) error {
-	var resp struct{}
 	path := fmt.Sprintf("/v1/client/gc?node_id=%s", nodeID)
-	_, err := n.client.query(path, &resp, q)
+	_, err := n.client.query(path, nil, q)
 	return err
 }
 
 // TODO Add tests
 func (n *Nodes) GcAlloc(allocID string, q *QueryOptions) error {
-	var resp struct{}
 	path := fmt.Sprintf("/v1/client/allocation/%s/gc", allocID)
-	_, err := n.client.query(path, &resp, q)
+	_, err := n.client.query(path, nil, q)
 	return err
 }
 


### PR DESCRIPTION
Internally Nomad returns a http.NoBody when calling nodes GC, therefore attempting to decode the body results in an EOF error returned to the user. This fix updates the decodeBody function to check both the response content length and the passed out object.

The following code snippet can be used to locally test:

```go
package main

import (
	"fmt"

	"github.com/hashicorp/nomad/api"
)

func main() {
	nomadClient, _ := api.NewClient(api.DefaultConfig())
	nodeSelf, _ := nomadClient.Agent().Self()
	fmt.Println(nomadClient.Nodes().GC(nodeSelf.Stats["client"]["node_id"], nil))
}
```

Closes #5506 #5994 