### PR TITLE
add formatting for hcl parsing error messages

### DIFF
--- a/helper/pluginutils/hclutils/testing.go
+++ b/helper/pluginutils/hclutils/testing.go
@@ -70,7 +70,8 @@ func (b *HCLParser) parse(t *testing.T, config, out interface{}) {
 	decSpec, diags := hclspecutils.Convert(b.spec)
 	require.Empty(t, diags)
 
-	ctyValue, diag, _ := ParseHclInterface(config, decSpec, b.vars)
+	ctyValue, diag, errs := ParseHclInterface(config, decSpec, b.vars)
+	require.Nil(t, errs)
 	require.Empty(t, diag)
 
 	// encode

--- a/helper/pluginutils/hclutils/testing.go
+++ b/helper/pluginutils/hclutils/testing.go
@@ -70,7 +70,7 @@ func (b *HCLParser) parse(t *testing.T, config, out interface{}) {
 	decSpec, diags := hclspecutils.Convert(b.spec)
 	require.Empty(t, diags)
 
-	ctyValue, diag := ParseHclInterface(config, decSpec, b.vars)
+	ctyValue, diag, _ := ParseHclInterface(config, decSpec, b.vars)
 	require.Empty(t, diag)
 
 	// encode

--- a/helper/pluginutils/hclutils/util.go
+++ b/helper/pluginutils/hclutils/util.go
@@ -2,6 +2,7 @@ package hclutils
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/hcl2/hcl"
@@ -17,7 +18,7 @@ import (
 // ParseHclInterface is used to convert an interface value representing a hcl2
 // body and return the interpolated value. Vars may be nil if there are no
 // variables to interpolate.
-func ParseHclInterface(val interface{}, spec hcldec.Spec, vars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+func ParseHclInterface(val interface{}, spec hcldec.Spec, vars map[string]cty.Value) (cty.Value, hcl.Diagnostics, []error) {
 	evalCtx := &hcl.EvalContext{
 		Variables: vars,
 		Functions: GetStdlibFuncs(),
@@ -29,27 +30,29 @@ func ParseHclInterface(val interface{}, spec hcldec.Spec, vars map[string]cty.Va
 	err := enc.Encode(val)
 	if err != nil {
 		// Convert to a hcl diagnostics message
-		return cty.NilVal, hcl.Diagnostics([]*hcl.Diagnostic{
-			{
+		errorMessage := fmt.Sprintf("Label encoding failed: %v", err)
+		return cty.NilVal,
+			hcl.Diagnostics([]*hcl.Diagnostic{{
 				Severity: hcl.DiagError,
-				Summary:  "Failed to JSON encode value",
-				Detail:   fmt.Sprintf("JSON encoding failed: %v", err),
-			}})
+				Summary:  "Failed to encode label value",
+				Detail:   errorMessage,
+			}}),
+			[]error{errors.New(errorMessage)}
 	}
 
 	// Parse the json as hcl2
 	hclFile, diag := hjson.Parse(buf.Bytes(), "")
 	if diag.HasErrors() {
-		return cty.NilVal, diag
+		return cty.NilVal, diag, formattedDiagnosticErrors(diag)
 	}
 
 	value, decDiag := hcldec.Decode(hclFile.Body, spec, evalCtx)
 	diag = diag.Extend(decDiag)
 	if diag.HasErrors() {
-		return cty.NilVal, diag
+		return cty.NilVal, diag, formattedDiagnosticErrors(diag)
 	}
 
-	return value, diag
+	return value, diag, nil
 }
 
 // GetStdlibFuncs returns the set of stdlib functions.
@@ -71,4 +74,16 @@ func GetStdlibFuncs() map[string]function.Function {
 		"substr":     stdlib.SubstrFunc,
 		"upper":      stdlib.UpperFunc,
 	}
+}
+
+func formattedDiagnosticErrors(diag hcl.Diagnostics) []error {
+	var errs []error
+	for _, d := range diag {
+		if d.Summary == "Extraneous JSON object property" {
+			d.Summary = "Invalid label"
+		}
+		err := errors.New(fmt.Sprintf("%s: %s", d.Summary, d.Detail))
+		errs = append(errs, err)
+	}
+	return errs
 }

--- a/helper/pluginutils/hclutils/util.go
+++ b/helper/pluginutils/hclutils/util.go
@@ -76,6 +76,9 @@ func GetStdlibFuncs() map[string]function.Function {
 	}
 }
 
+// TODO: update hcl2 library with better diagnostics formatting for streamed configs
+// - should be arbitrary labels not JSON https://github.com/hashicorp/hcl2/blob/4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52/hcl/json/structure.go#L66
+// - should not print diagnostic subject https://github.com/hashicorp/hcl2/blob/4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52/hcl/diagnostic.go#L77
 func formattedDiagnosticErrors(diag hcl.Diagnostics) []error {
 	var errs []error
 	for _, d := range diag {

--- a/helper/pluginutils/hclutils/util_test.go
+++ b/helper/pluginutils/hclutils/util_test.go
@@ -497,11 +497,45 @@ func TestParseUnknown(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			inter := hclutils.HclConfigToInterface(t, c.hcl)
 
-			ctyValue, diag, _ := hclutils.ParseHclInterface(inter, cSpec, vars)
+			ctyValue, diag, errs := hclutils.ParseHclInterface(inter, cSpec, vars)
 			t.Logf("parsed: %# v", pretty.Formatter(ctyValue))
 
+			require.NotNil(t, errs)
 			require.True(t, diag.HasErrors())
-			require.Contains(t, diag.Errs()[0].Error(), "no variable named")
+			require.Contains(t, errs[0].Error(), "no variable named")
+		})
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	dockerDriver := new(docker.Driver)
+	dockerSpec, err := dockerDriver.TaskConfigSchema()
+	require.NoError(t, err)
+	spec, diags := hclspecutils.Convert(dockerSpec)
+	require.False(t, diags.HasErrors())
+
+	cases := []struct {
+		name string
+		hcl  string
+	}{
+		{
+			"invalid_field",
+			`config { image = "redis:3.2" bad_key = "whatever"}`,
+		},
+	}
+
+	vars := map[string]cty.Value{}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			inter := hclutils.HclConfigToInterface(t, c.hcl)
+
+			ctyValue, diag, errs := hclutils.ParseHclInterface(inter, spec, vars)
+			t.Logf("parsed: %# v", pretty.Formatter(ctyValue))
+
+			require.NotNil(t, errs)
+			require.True(t, diag.HasErrors())
+			require.Contains(t, errs[0].Error(), "Invalid label")
 		})
 	}
 }

--- a/helper/pluginutils/hclutils/util_test.go
+++ b/helper/pluginutils/hclutils/util_test.go
@@ -358,9 +358,9 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Logf("Val: % #v", pretty.Formatter(c.config))
 			// Parse the interface
-			ctyValue, diag := hclutils.ParseHclInterface(c.config, c.spec, c.vars)
+			ctyValue, diag, errs := hclutils.ParseHclInterface(c.config, c.spec, c.vars)
 			if diag.HasErrors() {
-				for _, err := range diag.Errs() {
+				for _, err := range errs {
 					t.Error(err)
 				}
 				t.FailNow()
@@ -497,7 +497,7 @@ func TestParseUnknown(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			inter := hclutils.HclConfigToInterface(t, c.hcl)
 
-			ctyValue, diag := hclutils.ParseHclInterface(inter, cSpec, vars)
+			ctyValue, diag, _ := hclutils.ParseHclInterface(inter, cSpec, vars)
 			t.Logf("parsed: %# v", pretty.Formatter(ctyValue))
 
 			require.True(t, diag.HasErrors())

--- a/helper/pluginutils/loader/init.go
+++ b/helper/pluginutils/loader/init.go
@@ -457,10 +457,11 @@ func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) error
 	}
 
 	// Parse the config using the spec
-	val, diag := hclutils.ParseHclInterface(info.config, spec, nil)
+	val, diag, diagErrs := hclutils.ParseHclInterface(info.config, spec, nil)
 	if diag.HasErrors() {
-		multierror.Append(&mErr, diag.Errs()...)
-		return multierror.Prefix(&mErr, "failed parsing config:")
+		multierror.Append(&mErr, diagErrs...)
+		return multierror.Prefix(&mErr, "failed to parse config")
+
 	}
 
 	// Marshal the value

--- a/helper/pluginutils/loader/init.go
+++ b/helper/pluginutils/loader/init.go
@@ -460,7 +460,7 @@ func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) error
 	val, diag, diagErrs := hclutils.ParseHclInterface(info.config, spec, nil)
 	if diag.HasErrors() {
 		multierror.Append(&mErr, diagErrs...)
-		return multierror.Prefix(&mErr, "failed to parse config")
+		return multierror.Prefix(&mErr, "failed to parse config: ")
 
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5937,15 +5937,15 @@ const (
 	TaskSetupFailure = "Setup Failure"
 
 	// TaskDriveFailure indicates that the task could not be started due to a
-	// failure in the driver.
+	// failure in the driver. TaskDriverFailure is considered Recoverable.
 	TaskDriverFailure = "Driver Failure"
 
 	// TaskReceived signals that the task has been pulled by the client at the
 	// given timestamp.
 	TaskReceived = "Received"
 
-	// TaskFailedValidation indicates the task was invalid and as such was not
-	// run.
+	// TaskFailedValidation indicates the task was invalid and as such was not run.
+	// TaskFailedValidation is not considered Recoverable.
 	TaskFailedValidation = "Failed Validation"
 
 	// TaskStarted signals that the task was started and its timestamp can be

--- a/plugins/shared/cmd/launcher/command/device.go
+++ b/plugins/shared/cmd/launcher/command/device.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-multierror"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
+	multierror "github.com/hashicorp/go-multierror"
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
@@ -199,7 +199,7 @@ func (c *Device) setConfig(spec hcldec.Spec, apiVersion string, config []byte, n
 
 	val, diag, diagErrs := hclutils.ParseHclInterface(configVal, spec, nil)
 	if diag.HasErrors() {
-		return multierror.Append(errors.New("failed to parse config"), diagErrs...)
+		return multierror.Append(errors.New("failed to parse config: "), diagErrs...)
 	}
 	c.logger.Trace("parsed hcl config", "config", hclog.Fmt("% #v", pretty.Formatter(val)))
 


### PR DESCRIPTION
## Overview
Clean up error messages produced by hcl2 library
## Behavior
### Before (error messages had these weird numbers in them)
#### `nomad agent -dev` logs
![Screenshot from 2019-07-17 10-40-24](https://user-images.githubusercontent.com/1182129/61397712-5ad91580-a87f-11e9-8c5c-4234ecf7df08.png)


---------------------------

#### `nomad alloc status` command
![Screenshot from 2019-07-17 10-21-48](https://user-images.githubusercontent.com/1182129/61396535-ca013a80-a87c-11e9-99be-ffba7dde433d.png)

--------------------------------

### After (removed weird numbers and make message about invalid labels, not JSON)
#### `nomad agent -dev` logs
![Screenshot from 2019-07-17 10-41-07](https://user-images.githubusercontent.com/1182129/61397769-7512f380-a87f-11e9-888d-a25e020f36da.png)


----------------------------

#### `nomad alloc status` command
![Screenshot from 2019-07-19 10-02-54](https://user-images.githubusercontent.com/1182129/61552358-702f7a80-aa0c-11e9-916b-31c4b1e6050f.png)


## Implementation
* added private method to helper/pluginutils/hclutils/utils.go for hcl diagnostics error message formatting
  - it constructs an error from the diagnostic summary and detail
  - it ignores the diagnostic subject, which is just garbage "file line numbers" constructed from streamed bytes
  - if it finds a diagnostic that matches "Extraneous JSON label..." it creates an error with a nicer message
  - **future work:** submit pull request to hcl2 library with better error messages
* also changed where the task event emission for an error happens
  - moved it inside runDriver (was formerly in `MAIN:` in `run()`)
  - added task events for each error
  - config parsing errors emit TaskFailedValidation event
  - this appears to remove the "failed to parse config" logs that were added to `nomad alloc status` results when the event was TaskDriverFailure, so I might need to look into that more if we want to preserve that behavior