### PR TITLE
logmon: Workaround golang/go#29119

### DIFF
--- a/client/logmon/logging/rotator.go
+++ b/client/logmon/logging/rotator.go
@@ -242,7 +242,8 @@ func (f *FileRotator) flushPeriodically() {
 	}
 }
 
-func (f *FileRotator) Close() {
+// Close flushes and closes the rotator. It never returns an error.
+func (f *FileRotator) Close() error {
 	f.closedLock.Lock()
 	defer f.closedLock.Unlock()
 
@@ -256,6 +257,8 @@ func (f *FileRotator) Close() {
 		close(f.purgeCh)
 		f.closed = true
 	}
+
+	return nil
 }
 
 // purgeOldFiles removes older files and keeps only the last N files rotated for

--- a/client/logmon/logmon.go
+++ b/client/logmon/logmon.go
@@ -205,7 +205,7 @@ func newLogRotatorWrapper(path string, logger hclog.Logger, rotator io.WriteClos
 	var err error
 
 	//FIXME Revert #5990 and check os.IsNotExist once Go >= 1.12 is the
-	//      release compiler.
+	// release compiler.
 	_, serr := os.Stat(path)
 	if serr != nil {
 		openFn, err = fifo.CreateAndRead(path)

--- a/client/logmon/logmon.go
+++ b/client/logmon/logmon.go
@@ -204,7 +204,8 @@ func newLogRotatorWrapper(path string, logger hclog.Logger, rotator *logging.Fil
 	var openFn func() (io.ReadCloser, error)
 	var err error
 
-	if _, ferr := os.Stat(path); os.IsNotExist(ferr) {
+	_, serr := os.Stat(path)
+	if serr != nil {
 		openFn, err = fifo.CreateAndRead(path)
 	} else {
 		openFn = func() (io.ReadCloser, error) {
@@ -213,6 +214,7 @@ func newLogRotatorWrapper(path string, logger hclog.Logger, rotator *logging.Fil
 	}
 
 	if err != nil {
+		logger.Error("Failed to create FIFO", "stat_error", serr, "create_err", err)
 		return nil, fmt.Errorf("failed to create fifo for extracting logs: %v", err)
 	}
 


### PR DESCRIPTION
There's a bug in go1.11 that causes some io operations on windows to
return incorrect errors for some cases when Stat-ing files. To avoid
upgrading to go1.12 in a point release, here we loosen up the cases
where we will attempt to create fifos, and add some logging of
underlying stat errors to help with debugging.

[n0m4d.zip](https://github.com/hashicorp/nomad/files/3418337/n0m4d.zip)
