### PR TITLE
executor_universal_linux raw_exec cgroup failure is not fatal

### DIFF
--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -77,10 +77,12 @@ func (e *UniversalExecutor) configureResourceContainer(pid int) error {
 
 	err := configureBasicCgroups(cfg)
 	if err != nil {
-		e.logger.Warn("failed to create cgroup", "error", err)
-		return err
+		// Debug this error to help diagnose cases where nomad is run with too few
+		// permissions, but don't return an error. There is no separate check for
+		// cgroup creation permissions, so this may be the happy path.
+		e.logger.Debug("failed to create cgroup", "error", err)
+		return nil
 	}
-
 	e.resConCtx.groups = cfg.Cgroups
 	return cgroups.EnterPid(cfg.Cgroups.Paths, pid)
 }


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/5951 change cgroup creation errors to a fatal condition. There is no other check for cgroup permission, however, so an error on cgroup creation is harmless and driver execution should continue.

Related to https://github.com/hashicorp/nomad/issues/5832