### PR TITLE
use go1.11 in windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,19 @@ install:
   - cmd: docker info
   - cmd: docker run --rm dantoml/busybox-windows:08012019 echo hi there
 
+  - cmd: |
+      cd C:\go
+      del /F/Q/S *.* > NUL
+      cd %APPVEYOR_BUILD_FOLDER%
+      rmdir /Q/S C:\go
+
+  # install go 1.11.11 to match version used for cutting a release
+  - cmd: |
+      mkdir c:\go
+      appveyor DownloadFile "https://dl.google.com/go/go1.11.11.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
+      
+  - ps: Expand-Archive $Env:TEMP\go.zip -DestinationPath C:\
+
   - cmd: set PATH=%GOBIN%;c:\go\bin;%PATH%
   - cmd: echo %Path%
   - cmd: go version


### PR DESCRIPTION
Ensure we use the go 1.11.11, the one used for Vagrant/release scripts/etc, so we can catch issues like https://github.com/hashicorp/nomad/pull/5990 

Branched off before fix was merged and CI is failing indeed as expected in https://ci.appveyor.com/project/hashicorp/nomad/builds/26169078 .