### PR TITLE
driver/docker: use default network mode

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -882,8 +882,8 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 			hostConfig.NetworkMode = netMode
 		} else {
 			// docker default
-			logger.Debug("networking mode not specified; using default", "network_mode", defaultNetworkMode)
-			hostConfig.NetworkMode = defaultNetworkMode
+			logger.Debug("networking mode not specified; using default")
+			hostConfig.NetworkMode = "default"
 		}
 	}
 

--- a/drivers/docker/driver_default.go
+++ b/drivers/docker/driver_default.go
@@ -7,11 +7,6 @@ import (
 	"github.com/moby/moby/daemon/caps"
 )
 
-const (
-	// Setting default network mode for non-windows OS as bridge
-	defaultNetworkMode = "bridge"
-)
-
 func getPortBinding(ip string, port string) []docker.PortBinding {
 	return []docker.PortBinding{{HostIP: ip, HostPort: port}}
 }

--- a/drivers/docker/driver_windows.go
+++ b/drivers/docker/driver_windows.go
@@ -2,11 +2,6 @@ package docker
 
 import docker "github.com/fsouza/go-dockerclient"
 
-const (
-	// Default network mode for windows containers is nat
-	defaultNetworkMode = "nat"
-)
-
 //Currently Windows containers don't support host ip in port binding.
 func getPortBinding(ip string, port string) []docker.PortBinding {
 	return []docker.PortBinding{{HostIP: "", HostPort: port}}


### PR DESCRIPTION
fallback to docker default network mode instead of explicit bridge for linux
or nat for windows