### PR TITLE
driver/docker: convert host bind path to os native

### DIFF
--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -236,9 +236,9 @@ func parseVolumeSpecWindows(volBind string) (hostPath string, containerPath stri
 	if len(parts) < 2 {
 		return "", "", "", fmt.Errorf("not <src>:<destination> format")
 	}
-
-	// for nomad to be OS agnostic the host mount path with forward or backward slash
-	// we then convert the slashes to OS specific slash in the agent side
+        
+	// In order to be OS agnostic, the host mount path should support either forward or backward slash.
+        // These will later to converted to OS specific slash in the agent side
 	hostPath = filepath.FromSlash(parts[0])
 	containerPath = parts[1]
 

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -237,7 +237,7 @@ func parseVolumeSpecWindows(volBind string) (hostPath string, containerPath stri
 		return "", "", "", fmt.Errorf("not <src>:<destination> format")
 	}
 
-	hostPath = parts[0]
+	hostPath = filepath.FromSlash(parts[0])
 	containerPath = parts[1]
 
 	if len(parts) > 2 {

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -236,9 +236,10 @@ func parseVolumeSpecWindows(volBind string) (hostPath string, containerPath stri
 	if len(parts) < 2 {
 		return "", "", "", fmt.Errorf("not <src>:<destination> format")
 	}
-        
-	// In order to be OS agnostic, the host mount path should support either forward or backward slash.
-        // These will later to converted to OS specific slash in the agent side
+
+	// Convert host mount path separators to match the host OS's separator
+	// so that relative paths are supported cross-platform regardless of
+	// what slash is used in the jobspec.
 	hostPath = filepath.FromSlash(parts[0])
 	containerPath = parts[1]
 

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -237,6 +237,8 @@ func parseVolumeSpecWindows(volBind string) (hostPath string, containerPath stri
 		return "", "", "", fmt.Errorf("not <src>:<destination> format")
 	}
 
+	// for nomad to be OS agnostic the host mount path with forward or backward slash
+	// we then convert the slashes to OS specific slash in the agent side
 	hostPath = filepath.FromSlash(parts[0])
 	containerPath = parts[1]
 


### PR DESCRIPTION
relative mounting can be specified using backslashes or forward slashes.
so no prior knowledge of host OS is needed for relative volumes mounting