### PR TITLE
docker: pick second network

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -884,7 +884,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		}
 	} else {
 		// TODO add support for more than one network
-		network := task.Resources.NomadResources.Networks[0]
+		network := task.Resources.NomadResources.Networks[1]
 		publishedPorts := map[docker.Port][]docker.PortBinding{}
 		exposedPorts := map[docker.Port]struct{}{}
 


### PR DESCRIPTION
Hi,

I'd like to be able to bind the docker containers to a specific network interface. The demand there #646 is a bit fluffy. I'm, for know, looking for some pointers to continue this investigation.

First blocker, the Networks slice doesn't contain anything but eth0. So the modifications here create a panic :wink:

Thanks,