### PR TITLE
HostVolumes: Include volume info in nomad node status

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -436,6 +436,13 @@ type DriverInfo struct {
 	UpdateTime        time.Time
 }
 
+// HostVolumeInfo is used to return metadata about a given HostVolume.
+type HostVolumeInfo struct {
+	Source   string
+	ReadOnly bool
+	Hidden   bool
+}
+
 // Node is used to deserialize a node entry.
 type Node struct {
 	ID                    string
@@ -459,6 +466,7 @@ type Node struct {
 	StatusUpdatedAt       int64
 	Events                []*NodeEvent
 	Drivers               map[string]*DriverInfo
+	HostVolumes           map[string]*HostVolumeInfo
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -301,7 +301,7 @@ func nodeDrivers(n *api.Node) []string {
 
 func nodeVolumeNames(n *api.Node) []string {
 	var volumes []string
-	for name, _ := range n.HostVolumes {
+	for name := range n.HostVolumes {
 		volumes = append(volumes, name)
 	}
 
@@ -346,88 +346,104 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		basic = append(basic, fmt.Sprintf("Host Volumes|%s", strings.Join(nodeVolumeNames(node), ",")))
 		basic = append(basic, fmt.Sprintf("Drivers|%s", strings.Join(nodeDrivers(node), ",")))
 		c.Ui.Output(c.Colorize().Color(formatKV(basic)))
-	} else {
-		// Get the host stats
-		hostStats, nodeStatsErr := client.Nodes().Stats(node.ID, nil)
-		if nodeStatsErr != nil {
-			c.Ui.Output("")
-			c.Ui.Error(fmt.Sprintf("error fetching node stats: %v", nodeStatsErr))
-		}
-		if hostStats != nil {
-			uptime := time.Duration(hostStats.Uptime * uint64(time.Second))
-			basic = append(basic, fmt.Sprintf("Uptime|%s", uptime.String()))
-		}
 
-		// Emit the volume info
-		if !c.verbose {
-			basic = append(basic, fmt.Sprintf("Host Volumes|%s", strings.Join(nodeVolumeNames(node), ",")))
-		}
-
-		// Emit the driver info
-		if !c.verbose {
-			driverStatus := fmt.Sprintf("Driver Status| %s", c.outputTruncatedNodeDriverInfo(node))
-			basic = append(basic, driverStatus)
-		}
-
-		c.Ui.Output(c.Colorize().Color(formatKV(basic)))
-
-		if c.verbose {
-			c.outputNodeVolumeInfo(node)
-			c.outputNodeDriverInfo(node)
-		}
-
-		// Emit node events
-		c.outputNodeStatusEvents(node)
-
-		// Get list of running allocations on the node
-		runningAllocs, err := getRunningAllocs(client, node.ID)
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error querying node for running allocations: %s", err))
+		// Output alloc info
+		if err := c.outputAllocInfo(client, node); err != nil {
+			c.Ui.Error(fmt.Sprintf("%s", err))
 			return 1
 		}
 
-		allocatedResources := getAllocatedResources(client, runningAllocs, node)
-		c.Ui.Output(c.Colorize().Color("\n[bold]Allocated Resources[reset]"))
-		c.Ui.Output(formatList(allocatedResources))
+		return 0
+	}
 
-		actualResources, err := getActualResources(client, runningAllocs, node)
-		if err == nil {
-			c.Ui.Output(c.Colorize().Color("\n[bold]Allocation Resource Utilization[reset]"))
-			c.Ui.Output(formatList(actualResources))
-		}
+	// Get the host stats
+	hostStats, nodeStatsErr := client.Nodes().Stats(node.ID, nil)
+	if nodeStatsErr != nil {
+		c.Ui.Output("")
+		c.Ui.Error(fmt.Sprintf("error fetching node stats: %v", nodeStatsErr))
+	}
+	if hostStats != nil {
+		uptime := time.Duration(hostStats.Uptime * uint64(time.Second))
+		basic = append(basic, fmt.Sprintf("Uptime|%s", uptime.String()))
+	}
 
-		hostResources, err := getHostResources(hostStats, node)
-		if err != nil {
-			c.Ui.Output("")
-			c.Ui.Error(fmt.Sprintf("error fetching node stats: %v", err))
-		}
-		if err == nil {
-			c.Ui.Output(c.Colorize().Color("\n[bold]Host Resource Utilization[reset]"))
-			c.Ui.Output(formatList(hostResources))
-		}
+	// When we're not running in verbose mode, then also include host volumes and
+	// driver info in the basic output
+	if !c.verbose {
+		basic = append(basic, fmt.Sprintf("Host Volumes|%s", strings.Join(nodeVolumeNames(node), ",")))
 
-		if err == nil && node.NodeResources != nil && len(node.NodeResources.Devices) > 0 {
-			c.Ui.Output(c.Colorize().Color("\n[bold]Device Resource Utilization[reset]"))
-			c.Ui.Output(formatList(getDeviceResourcesForNode(hostStats.DeviceStats, node)))
-		}
-		if hostStats != nil && c.stats {
-			c.Ui.Output(c.Colorize().Color("\n[bold]CPU Stats[reset]"))
-			c.printCpuStats(hostStats)
-			c.Ui.Output(c.Colorize().Color("\n[bold]Memory Stats[reset]"))
-			c.printMemoryStats(hostStats)
-			c.Ui.Output(c.Colorize().Color("\n[bold]Disk Stats[reset]"))
-			c.printDiskStats(hostStats)
-			if len(hostStats.DeviceStats) > 0 {
-				c.Ui.Output(c.Colorize().Color("\n[bold]Device Stats[reset]"))
-				printDeviceStats(c.Ui, hostStats.DeviceStats)
-			}
+		driverStatus := fmt.Sprintf("Driver Status| %s", c.outputTruncatedNodeDriverInfo(node))
+		basic = append(basic, driverStatus)
+	}
+
+	// Output the basic info
+	c.Ui.Output(c.Colorize().Color(formatKV(basic)))
+
+	// If we're running in verbose mode, include full host volume and driver info
+	if c.verbose {
+		c.outputNodeVolumeInfo(node)
+		c.outputNodeDriverInfo(node)
+	}
+
+	// Emit node events
+	c.outputNodeStatusEvents(node)
+
+	// Get list of running allocations on the node
+	runningAllocs, err := getRunningAllocs(client, node.ID)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying node for running allocations: %s", err))
+		return 1
+	}
+
+	allocatedResources := getAllocatedResources(client, runningAllocs, node)
+	c.Ui.Output(c.Colorize().Color("\n[bold]Allocated Resources[reset]"))
+	c.Ui.Output(formatList(allocatedResources))
+
+	actualResources, err := getActualResources(client, runningAllocs, node)
+	if err == nil {
+		c.Ui.Output(c.Colorize().Color("\n[bold]Allocation Resource Utilization[reset]"))
+		c.Ui.Output(formatList(actualResources))
+	}
+
+	hostResources, err := getHostResources(hostStats, node)
+	if err != nil {
+		c.Ui.Output("")
+		c.Ui.Error(fmt.Sprintf("error fetching node stats: %v", err))
+	}
+	if err == nil {
+		c.Ui.Output(c.Colorize().Color("\n[bold]Host Resource Utilization[reset]"))
+		c.Ui.Output(formatList(hostResources))
+	}
+
+	if err == nil && node.NodeResources != nil && len(node.NodeResources.Devices) > 0 {
+		c.Ui.Output(c.Colorize().Color("\n[bold]Device Resource Utilization[reset]"))
+		c.Ui.Output(formatList(getDeviceResourcesForNode(hostStats.DeviceStats, node)))
+	}
+	if hostStats != nil && c.stats {
+		c.Ui.Output(c.Colorize().Color("\n[bold]CPU Stats[reset]"))
+		c.printCpuStats(hostStats)
+		c.Ui.Output(c.Colorize().Color("\n[bold]Memory Stats[reset]"))
+		c.printMemoryStats(hostStats)
+		c.Ui.Output(c.Colorize().Color("\n[bold]Disk Stats[reset]"))
+		c.printDiskStats(hostStats)
+		if len(hostStats.DeviceStats) > 0 {
+			c.Ui.Output(c.Colorize().Color("\n[bold]Device Stats[reset]"))
+			printDeviceStats(c.Ui, hostStats.DeviceStats)
 		}
 	}
 
+	if err := c.outputAllocInfo(client, node); err != nil {
+		c.Ui.Error(fmt.Sprintf("%s", err))
+		return 1
+	}
+
+	return 0
+}
+
+func (c *NodeStatusCommand) outputAllocInfo(client *api.Client, node *api.Node) error {
 	nodeAllocs, _, err := client.Nodes().Allocations(node.ID, nil)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error querying node allocations: %s", err))
-		return 1
+		return fmt.Errorf("Error querying node allocations: %s", err)
 	}
 
 	c.Ui.Output(c.Colorize().Color("\n[bold]Allocations[reset]"))
@@ -438,8 +454,8 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		c.formatDeviceAttributes(node)
 		c.formatMeta(node)
 	}
-	return 0
 
+	return nil
 }
 
 func (c *NodeStatusCommand) outputTruncatedNodeDriverInfo(node *api.Node) string {


### PR DESCRIPTION
NOTE: When #5923 is merged into `f-host-volumes`, this PR should be targeted against `f-host-volumes`

## Short Output

```
$ nomad node status -self -short
ID           = 964f7030
Name         = mew
Class        = <none>
DC           = dc1
Drain        = false
Eligibility  = eligible
Status       = ready
Host Volumes = tmp-dir
Drivers      = docker,mock_driver,raw_exec

Allocations
No allocations placed
```

## Verbose Output
```
ID          = 964f7030-9882-a359-7965-2bd432fbdd96
Name        = mew
Class       = <none>
DC          = dc1
Drain       = false
Eligibility = eligible
Status      = ready
Uptime      = 168h8m18s

Host Volumes
Name     ReadOnly  Hidden  Source
tmp-dir  false     false   /tmp

Drivers
Driver       Detected  Healthy  Message                  Time
docker       true      true     Healthy                  2019-07-25T15:30:20+02:00
exec         false     false    Driver must run as root  2019-07-25T15:30:20+02:00
java         false     false    Driver must run as root  2019-07-25T15:30:20+02:00
mock_driver  true      true     Healthy                  2019-07-25T15:30:20+02:00
qemu         false     false    <none>                   2019-07-25T15:30:20+02:00
raw_exec     true      true     Healthy                  2019-07-25T15:30:20+02:00
rkt          false     false    Driver must run as root  2019-07-25T15:30:20+02:00

Node Events
Time                       Subsystem  Message          Details
2019-07-25T15:30:20+02:00  Cluster    Node registered  <none>

Allocated Resources
CPU          Memory      Disk
0/32000 MHz  0 B/15 GiB  0 B/7.5 GiB

Allocation Resource Utilization
CPU          Memory
0/32000 MHz  0 B/15 GiB

Host Resource Utilization
CPU            Memory         Disk
516/32000 MHz  11 GiB/15 GiB  (tmpfs)

Allocations
No allocations placed

Attributes
{{omitted}}

Meta
```