### PR TITLE
acl: Add HostVolume ACLs

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -51,6 +51,13 @@ type ACL struct {
 	// We use an iradix for the purposes of ordered iteration.
 	wildcardNamespaces *iradix.Tree
 
+	// hostVolumes maps a named host volume to a capabilitySet
+	hostVolumes *iradix.Tree
+
+	// wildcardHostVolumes maps a glob pattern of host volume names to a capabilitySet
+	// We use an iradix for the purposes of ordered iteration.
+	wildcardHostVolumes *iradix.Tree
+
 	agent    string
 	node     string
 	operator string
@@ -83,6 +90,8 @@ func NewACL(management bool, policies []*Policy) (*ACL, error) {
 	acl := &ACL{}
 	nsTxn := iradix.New().Txn()
 	wnsTxn := iradix.New().Txn()
+	hvTxn := iradix.New().Txn()
+	whvTxn := iradix.New().Txn()
 
 	for _, policy := range policies {
 	NAMESPACES:
@@ -128,6 +137,49 @@ func NewACL(management bool, policies []*Policy) (*ACL, error) {
 			}
 		}
 
+	HOSTVOLUMES:
+		for _, hv := range policy.HostVolumes {
+			// Should the volume be matched using a glob?
+			globDefinition := strings.Contains(hv.Name, "*")
+
+			// Check for existing capabilities
+			var capabilities capabilitySet
+
+			if globDefinition {
+				raw, ok := whvTxn.Get([]byte(hv.Name))
+				if ok {
+					capabilities = raw.(capabilitySet)
+				} else {
+					capabilities = make(capabilitySet)
+					whvTxn.Insert([]byte(hv.Name), capabilities)
+				}
+			} else {
+				raw, ok := hvTxn.Get([]byte(hv.Name))
+				if ok {
+					capabilities = raw.(capabilitySet)
+				} else {
+					capabilities = make(capabilitySet)
+					hvTxn.Insert([]byte(hv.Name), capabilities)
+				}
+			}
+
+			// Deny always takes precedence
+			if capabilities.Check(HostVolumeCapabilityDeny) {
+				continue
+			}
+
+			// Add in all the capabilities
+			for _, cap := range hv.Capabilities {
+				if cap == HostVolumeCapabilityDeny {
+					// Overwrite any existing capabilities
+					capabilities.Clear()
+					capabilities.Set(HostVolumeCapabilityDeny)
+					continue HOSTVOLUMES
+				}
+				capabilities.Set(cap)
+			}
+		}
+
 		// Take the maximum privilege for agent, node, and operator
 		if policy.Agent != nil {
 			acl.agent = maxPrivilege(acl.agent, policy.Agent.Policy)
@@ -146,6 +198,9 @@ func NewACL(management bool, policies []*Policy) (*ACL, error) {
 	// Finalize the namespaces
 	acl.namespaces = nsTxn.Commit()
 	acl.wildcardNamespaces = wnsTxn.Commit()
+	acl.hostVolumes = hvTxn.Commit()
+	acl.wildcardHostVolumes = whvTxn.Commit()
+
 	return acl, nil
 }
 
@@ -162,7 +217,7 @@ func (a *ACL) AllowNamespaceOperation(ns string, op string) bool {
 	}
 
 	// Check for a matching capability set
-	capabilities, ok := a.matchingCapabilitySet(ns)
+	capabilities, ok := a.matchingNamespaceCapabilitySet(ns)
 	if !ok {
 		return false
 	}
@@ -179,7 +234,7 @@ func (a *ACL) AllowNamespace(ns string) bool {
 	}
 
 	// Check for a matching capability set
-	capabilities, ok := a.matchingCapabilitySet(ns)
+	capabilities, ok := a.matchingNamespaceCapabilitySet(ns)
 	if !ok {
 		return false
 	}
@@ -192,12 +247,50 @@ func (a *ACL) AllowNamespace(ns string) bool {
 	return !capabilities.Check(PolicyDeny)
 }
 
-// matchingCapabilitySet looks for a capabilitySet that matches the namespace,
+// AllowHostVolumeOperation checks if a given operation is allowed for a host volume
+func (a *ACL) AllowHostVolumeOperation(hv string, op string) bool {
+	// Hot path management tokens
+	if a.management {
+		return true
+	}
+
+	// Check for a matching capability set
+	capabilities, ok := a.matchingHostVolumeCapabilitySet(hv)
+	if !ok {
+		return false
+	}
+
+	// Check if the capability has been granted
+	return capabilities.Check(op)
+}
+
+// AllowHostVolume checks if any operations are allowed for a HostVolume
+func (a *ACL) AllowHostVolume(ns string) bool {
+	// Hot path management tokens
+	if a.management {
+		return true
+	}
+
+	// Check for a matching capability set
+	capabilities, ok := a.matchingHostVolumeCapabilitySet(ns)
+	if !ok {
+		return false
+	}
+
+	// Check if the capability has been granted
+	if len(capabilities) == 0 {
+		return false
+	}
+
+	return !capabilities.Check(PolicyDeny)
+}
+
+// matchingNamespaceCapabilitySet looks for a capabilitySet that matches the namespace,
 // if no concrete definitions are found, then we return the closest matching
 // glob.
 // The closest matching glob is the one that has the smallest character
 // difference between the namespace and the glob.
-func (a *ACL) matchingCapabilitySet(ns string) (capabilitySet, bool) {
+func (a *ACL) matchingNamespaceCapabilitySet(ns string) (capabilitySet, bool) {
 	// Check for a concrete matching capability set
 	raw, ok := a.namespaces.Get([]byte(ns))
 	if ok {
@@ -205,18 +298,34 @@ func (a *ACL) matchingCapabilitySet(ns string) (capabilitySet, bool) {
 	}
 
 	// We didn't find a concrete match, so lets try and evaluate globs.
-	return a.findClosestMatchingGlob(ns)
+	return a.findClosestMatchingGlob(a.wildcardNamespaces, ns)
+}
+
+// matchingHostVolumeCapabilitySet looks for a capabilitySet that matches the host volume name,
+// if no concrete definitions are found, then we return the closest matching
+// glob.
+// The closest matching glob is the one that has the smallest character
+// difference between the volume name and the glob.
+func (a *ACL) matchingHostVolumeCapabilitySet(name string) (capabilitySet, bool) {
+	// Check for a concrete matching capability set
+	raw, ok := a.hostVolumes.Get([]byte(name))
+	if ok {
+		return raw.(capabilitySet), true
+	}
+
+	// We didn't find a concrete match, so lets try and evaluate globs.
+	return a.findClosestMatchingGlob(a.wildcardHostVolumes, name)
 }
 
 type matchingGlob struct {
-	ns            string
+	name          string
 	difference    int
 	capabilitySet capabilitySet
 }
 
-func (a *ACL) findClosestMatchingGlob(ns string) (capabilitySet, bool) {
+func (a *ACL) findClosestMatchingGlob(radix *iradix.Tree, ns string) (capabilitySet, bool) {
 	// First, find all globs that match.
-	matchingGlobs := a.findAllMatchingWildcards(ns)
+	matchingGlobs := findAllMatchingWildcards(radix, ns)
 
 	// If none match, let's return.
 	if len(matchingGlobs) == 0 {
@@ -238,19 +347,19 @@ func (a *ACL) findClosestMatchingGlob(ns string) (capabilitySet, bool) {
 	return matchingGlobs[0].capabilitySet, true
 }
 
-func (a *ACL) findAllMatchingWildcards(ns string) []matchingGlob {
+func findAllMatchingWildcards(radix *iradix.Tree, name string) []matchingGlob {
 	var matches []matchingGlob
 
-	nsLen := len(ns)
+	nsLen := len(name)
 
-	a.wildcardNamespaces.Root().Walk(func(bk []byte, iv interface{}) bool {
+	radix.Root().Walk(func(bk []byte, iv interface{}) bool {
 		k := string(bk)
 		v := iv.(capabilitySet)
 
-		isMatch := glob.Glob(k, ns)
+		isMatch := glob.Glob(k, name)
 		if isMatch {
 			pair := matchingGlob{
-				ns:            k,
+				name:          k,
 				difference:    nsLen - len(k) + strings.Count(k, glob.GLOB),
 				capabilitySet: v,
 			}

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -199,6 +199,34 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			`
+			host_volume "production-tls-*" {
+				capabilities = ["mount"]
+			}
+			`,
+			"",
+			&Policy{
+				HostVolumes: []*HostVolumePolicy{
+					{
+						Name:   "production-tls-*",
+						Policy: "",
+						Capabilities: []string{
+							HostVolumeCapabilityMount,
+						},
+					},
+				},
+			},
+		},
+		{
+			`
+			host_volume "volume has a space" {
+				capabilities = ["mount"]
+			}
+			`,
+			"Invalid host volume name",
+			nil,
+		},
 	}
 
 	for idx, tc := range tcases {

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -38,6 +38,26 @@ func NamespacePolicy(namespace string, policy string, capabilities []string) str
 	return policyHCL
 }
 
+// HostVolumePolicy is a helper for generating the policy hcl for a given
+// host-volume. Either policy or capabilities may be nil but not both.
+func HostVolumePolicy(vol string, policy string, capabilities []string) string {
+	policyHCL := fmt.Sprintf("host_volume %q {", vol)
+	if policy != "" {
+		policyHCL += fmt.Sprintf("\n\tpolicy = %q", policy)
+	}
+	if len(capabilities) != 0 {
+		for i, s := range capabilities {
+			if !strings.HasPrefix(s, "\"") {
+				capabilities[i] = strconv.Quote(s)
+			}
+		}
+
+		policyHCL += fmt.Sprintf("\n\tcapabilities = [%v]", strings.Join(capabilities, ","))
+	}
+	policyHCL += "\n}"
+	return policyHCL
+}
+
 // AgentPolicy is a helper for generating the hcl for a given agent policy.
 func AgentPolicy(policy string) string {
 	return fmt.Sprintf("agent {\n\tpolicy = %q\n}\n", policy)


### PR DESCRIPTION
This adds an initial implementation of ACLs for HostVolumes.

Because HostVolumes are a cluster-wide resource, they cannot be tied to
a namespace, thus here we allow similar wildcard definitions based on
their names, tied to a set of capabilities.

Initially, the only available capabilities are deny, or mount. These
will be extended to allow read-fs, mount-readonly and
similar capabilities.