### PR TITLE
api: Update policy endpoint to permit anonymous access

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -220,34 +220,32 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 	}
 
 	// If the policy is the anonymous one, anyone can get it
-	if args.Name != "anonymous" {
-		// If it is not a management token determine if it can get this policy
-		mgt := acl.IsManagement()
-		if !mgt {
-			snap, err := a.srv.fsm.State().Snapshot()
-			if err != nil {
-				return err
-			}
+	// If it is not a management token determine if it can get this policy
+	mgt := acl.IsManagement()
+	if !mgt && args.Name != "anonymous" {
+		snap, err := a.srv.fsm.State().Snapshot()
+		if err != nil {
+			return err
+		}
 
-			token, err := snap.ACLTokenBySecretID(nil, args.AuthToken)
-			if err != nil {
-				return err
-			}
-			if token == nil {
-				return structs.ErrTokenNotFound
-			}
+		token, err := snap.ACLTokenBySecretID(nil, args.AuthToken)
+		if err != nil {
+			return err
+		}
+		if token == nil {
+			return structs.ErrTokenNotFound
+		}
 
-			found := false
-			for _, p := range token.Policies {
-				if p == args.Name {
-					found = true
-					break
-				}
+		found := false
+		for _, p := range token.Policies {
+			if p == args.Name {
+				found = true
+				break
 			}
+		}
 
-			if !found {
-				return structs.ErrPermissionDenied
-			}
+		if !found {
+			return structs.ErrPermissionDenied
 		}
 	}
 

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -219,32 +219,35 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 		return structs.ErrPermissionDenied
 	}
 
-	// If it is not a management token determine if it can get this policy
-	mgt := acl.IsManagement()
-	if !mgt {
-		snap, err := a.srv.fsm.State().Snapshot()
-		if err != nil {
-			return err
-		}
-
-		token, err := snap.ACLTokenBySecretID(nil, args.AuthToken)
-		if err != nil {
-			return err
-		}
-		if token == nil {
-			return structs.ErrTokenNotFound
-		}
-
-		found := false
-		for _, p := range token.Policies {
-			if p == args.Name {
-				found = true
-				break
+	// If the policy is the anonymous one, anyone can get it
+	if args.Name != "anonymous" {
+		// If it is not a management token determine if it can get this policy
+		mgt := acl.IsManagement()
+		if !mgt {
+			snap, err := a.srv.fsm.State().Snapshot()
+			if err != nil {
+				return err
 			}
-		}
 
-		if !found {
-			return structs.ErrPermissionDenied
+			token, err := snap.ACLTokenBySecretID(nil, args.AuthToken)
+			if err != nil {
+				return err
+			}
+			if token == nil {
+				return structs.ErrTokenNotFound
+			}
+
+			found := false
+			for _, p := range token.Policies {
+				if p == args.Name {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return structs.ErrPermissionDenied
+			}
 		}
 	}
 

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestACLEndpoint_GetPolicy(t *testing.T) {
@@ -84,7 +85,7 @@ func TestACLEndpoint_GetPolicy(t *testing.T) {
 	}
 	var resp3 structs.SingleACLPolicyResponse
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.GetPolicy", get, &resp3); err != nil {
-		t.Fatalf("err: %v", err)
+		require.NoError(t, err)
 	}
 	assert.EqualValues(t, 1001, resp3.Index)
 	assert.Equal(t, anonymousPolicy, resp3.Policy)


### PR DESCRIPTION
This is another change that would better support #5944, alongside #6017: permitting the fetching of the `anonymous` policy without a token. It seems sensible that users without a token should be able to see the policy that determines their permissions, but the current implementation errors because it’s unable to parse the (non-existent) token. Without this, the “Run Job” button can’t be conditionally enabled when a UI user has no token.
