### PR TITLE
Add page titles to filesystem routes

### DIFF
--- a/ui/app/controllers/allocations/allocation/task/fs.js
+++ b/ui/app/controllers/allocations/allocation/task/fs.js
@@ -20,6 +20,16 @@ export default Controller.extend({
   directories: filterBy('directoryEntries', 'IsDir'),
   files: filterBy('directoryEntries', 'IsDir', false),
 
+  pathWithLeadingSlash: computed('path', function() {
+    const path = this.path;
+
+    if (path.startsWith('/')) {
+      return path;
+    } else {
+      return `/${path}`;
+    }
+  }),
+
   sortedDirectoryEntries: computed(
     'directoryEntries.[]',
     'sortProperty',

--- a/ui/app/templates/allocations/allocation/task/fs.hbs
+++ b/ui/app/templates/allocations/allocation/task/fs.hbs
@@ -1,3 +1,4 @@
+{{title pathWithLeadingSlash " -  Task " task.name " filesystem"}}
 {{task-subnav task=task}}
 <section class="section is-closer">
   {{#if task.isRunning}}

--- a/ui/tests/acceptance/task-fs-test.js
+++ b/ui/tests/acceptance/task-fs-test.js
@@ -49,11 +49,21 @@ module('Acceptance | task fs', function(hooks) {
     const paths = ['some-file.log', 'a/deep/path/to/a/file.log', '/', 'Unicode™®'];
 
     const testPath = async filePath => {
+      let pathWithLeadingSlash = filePath;
+
+      if (!pathWithLeadingSlash.startsWith('/')) {
+        pathWithLeadingSlash = `/${filePath}`;
+      }
+
       await FS.visitPath({ id: allocation.id, name: task.name, path: filePath });
       assert.equal(
         currentURL(),
         `/allocations/${allocation.id}/${task.name}/fs/${encodeURIComponent(filePath)}`,
         'No redirect'
+      );
+      assert.equal(
+        document.title,
+        `${pathWithLeadingSlash} - Task ${task.name} filesystem - Nomad`
       );
       assert.equal(FS.breadcrumbsText, `${task.name} ${filePath.replace(/\//g, ' ')}`.trim());
     };


### PR DESCRIPTION
I wish something like Ruby’s `Pathname` were a trivial inclusion 😐