### PR TITLE
build: use GOARM=6 for hf

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -85,7 +85,7 @@ pkg/linux_amd64/nomad: $(SOURCE_FILES) ## Build Nomad for linux/amd64
 
 pkg/linux_arm/nomad: $(SOURCE_FILES) ## Build Nomad for linux/arm
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
-	@CGO_ENABLED=1 GOOS=linux GOARCH=arm CC=arm-linux-gnueabihf-gcc-5 \
+	@CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=6 CC=arm-linux-gnueabihf-gcc-5 \
 		go build \
 		-ldflags $(GO_LDFLAGS) \
 		-tags "$(GO_TAGS)" \


### PR DESCRIPTION
**TODO** Needs testing.

Since we're already compiling against HF CGO libs there's no reason not
to compile Go for HF.