### PR TITLE
api: add follow param to file stream endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
  * agent: allow the job GC interval to be configured [[GH-5978](https://github.com/hashicorp/nomad/issues/5978)]
+ * api: add follow parameter to file streaming endpoint to support older browsers [[GH-6049](https://github.com/hashicorp/nomad/issues/6049)]
 
 ## 0.9.5 (Unreleased)
 
@@ -46,7 +47,7 @@ BUG FIXES:
  * driver: Fixed an issue preventing external driver plugins from launching executor process [[GH-5726](https://github.com/hashicorp/nomad/issues/5726)]
  * driver/docker: Fixed a bug mounting relative paths on Windows [[GH-5811](https://github.com/hashicorp/nomad/issues/5811)]
  * driver/exec: Upgraded libcontainer dependency to avoid zombie `runc:[1:CHILD]]` processes [[GH-5851](https://github.com/hashicorp/nomad/issues/5851)]
- * metrics: Added metrics for raft and state store indexes. [[GH-5841](https://github.com/hashicorp/nomad/issues/5841)] 
+ * metrics: Added metrics for raft and state store indexes. [[GH-5841](https://github.com/hashicorp/nomad/issues/5841)]
  * metrics: Upgrade prometheus client to avoid label conflicts [[GH-5850](https://github.com/hashicorp/nomad/issues/5850)]
  * ui: Fixed ability to click sort arrow to change sort direction [[GH-5833](https://github.com/hashicorp/nomad/pull/5833)]
 
@@ -1629,4 +1630,3 @@ BUG FIXES:
 ## 0.1.0 (September 28, 2015)
 
   * Initial release
-

--- a/website/source/api/client.html.md
+++ b/website/source/api/client.html.md
@@ -9,7 +9,7 @@ description: |-
 
 # Client HTTP API
 
-The `/client` endpoints are used to interact with the Nomad clients. 
+The `/client` endpoints are used to interact with the Nomad clients.
 
 Since Nomad 0.8.0, both a client and server can handle client endpoints. This is
 particularly useful for when a direct connection to a client is not possible due
@@ -362,6 +362,8 @@ The table below shows this endpoint's support for
 
 - `path` `(string: "/")` - Specifies the path of the file to read, relative to
   the root of the allocation directory.
+
+- `follow` `(bool: true)`- Specifies whether to tail the file.
 
 - `offset` `(int: <required>)` - Specifies the byte offset from where content
   will be read.


### PR DESCRIPTION
The `/v1/client/fs/stream endpoint` supports tailing a file by writing chunks out as they come in. But not all browsers [support streams](https://caniuse.com/#feat=streams) (ex IE11) so we need to be able to tail a file without streaming.

The fs stream and logs endpoint use the same implementation for filesystem streaming under the hood, but the fs stream always passes the `follow` parameter set to true. This adds the same toggle to the fs stream endpoint that we have for logs. It defaults to true for backwards compatibility.

