### PR TITLE
job region defaults to node region

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -453,8 +453,8 @@ func (c *Client) getNodeClientImpl(nodeID string, timeout time.Duration, q *Quer
 		// If the client is configured for a particular region use that
 		region = c.config.Region
 	default:
-		// No region information is given so use the default.
-		region = "global"
+		// No region information is given so use GlobalRegion as the default.
+		region = GlobalRegion
 	}
 
 	// Get an API client for the node

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -26,9 +26,11 @@ const (
 	// DefaultNamespace is the default namespace.
 	DefaultNamespace = "default"
 
-	// GlobalRegion is a sentinel region value that users may specify
-	// to indicate the job should be run on the region of the node
-	// that the job was submitted to
+	// For Job configuration, GlobalRegion is a sentinel region value
+	// that users may specify to indicate the job should be run on
+	// the region of the node that the job was submitted to.
+	// For Client configuration, if no region information is given,
+	// the client node will default to be part of the GlobalRegion.
 	GlobalRegion = "global"
 )
 

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -25,6 +25,11 @@ const (
 
 	// DefaultNamespace is the default namespace.
 	DefaultNamespace = "default"
+
+	// GlobalRegion is a sentinel region value that users may specify
+	// to indicate the job should be run on the region of the node
+	// that the job was submitted to
+	GlobalRegion = "global"
 )
 
 const (
@@ -704,7 +709,7 @@ func (j *Job) Canonicalize() {
 		j.Stop = boolToPtr(false)
 	}
 	if j.Region == nil {
-		j.Region = stringToPtr("global")
+		j.Region = stringToPtr(GlobalRegion)
 	}
 	if j.Namespace == nil {
 		j.Namespace = stringToPtr("default")

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -704,7 +704,7 @@ func (j *Job) Canonicalize() {
 		j.Stop = boolToPtr(false)
 	}
 	if j.Region == nil {
-		j.Region = stringToPtr("global")
+		j.Region = stringToPtr("")
 	}
 	if j.Namespace == nil {
 		j.Namespace = stringToPtr("default")

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -704,7 +704,7 @@ func (j *Job) Canonicalize() {
 		j.Stop = boolToPtr(false)
 	}
 	if j.Region == nil {
-		j.Region = stringToPtr("")
+		j.Region = stringToPtr("global")
 	}
 	if j.Namespace == nil {
 		j.Namespace = stringToPtr("default")

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -147,7 +147,7 @@ func (s *HTTPServer) jobPlan(resp http.ResponseWriter, req *http.Request,
 	}
 	// If 'global' region is specified or if no region is given,
 	// default to region of the node you're submitting to
-	if args.Job.Region == nil || *args.Job.Region == "" || *args.Job.Region == "global" {
+	if args.Job.Region == nil || *args.Job.Region == "" || *args.Job.Region == api.GlobalRegion {
 		args.Job.Region = &s.agent.config.Region
 	}
 
@@ -396,7 +396,7 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 	}
 	// If 'global' region is specified or if no region is given,
 	// default to region of the node you're submitting to
-	if args.Job.Region == nil || *args.Job.Region == "" || *args.Job.Region == "global" {
+	if args.Job.Region == nil || *args.Job.Region == "" || *args.Job.Region == api.GlobalRegion {
 		args.Job.Region = &s.agent.config.Region
 	}
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -147,8 +147,7 @@ func (s *HTTPServer) jobPlan(resp http.ResponseWriter, req *http.Request,
 	}
 	// If 'global' region is specified or if no region is given,
 	// default to region of the node you're submitting to
-	if args.Job.Region == helper.StringToPtr("global") ||
-		args.Job.Region == helper.StringToPtr("") || args.Job.Region == nil {
+	if args.Job.Region == nil || *args.Job.Region == "" || *args.Job.Region == "global" {
 		args.Job.Region = &s.agent.config.Region
 	}
 
@@ -397,8 +396,7 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 	}
 	// If 'global' region is specified or if no region is given,
 	// default to region of the node you're submitting to
-	if args.Job.Region == helper.StringToPtr("global") ||
-		args.Job.Region == helper.StringToPtr("") || args.Job.Region == nil {
+	if args.Job.Region == nil || *args.Job.Region == "" || *args.Job.Region == "global" {
 		args.Job.Region = &s.agent.config.Region
 	}
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -141,12 +141,17 @@ func (s *HTTPServer) jobPlan(resp http.ResponseWriter, req *http.Request,
 		return nil, CodedError(400, "Job ID does not match")
 	}
 
-	// Http region takes precedence over hcl region
+	// Region in http request query param takes precedence over region in job hcl config
 	if args.WriteRequest.Region != "" {
 		args.Job.Region = helper.StringToPtr(args.WriteRequest.Region)
 	}
+	// If 'global' region is specified or if no region is given,
+	// default to region of the node you're submitting to
+	if args.Job.Region == helper.StringToPtr("global") ||
+		args.Job.Region == helper.StringToPtr("") || args.Job.Region == nil {
+		args.Job.Region = &s.agent.config.Region
+	}
 
-	// If no region given, region is canonicalized to 'global'
 	sJob := ApiJobToStructJob(args.Job)
 
 	planReq := structs.JobPlanRequest{
@@ -157,6 +162,8 @@ func (s *HTTPServer) jobPlan(resp http.ResponseWriter, req *http.Request,
 			Region: sJob.Region,
 		},
 	}
+	// parseWriteRequest overrides Namespace, Region and AuthToken
+	// based on values from the original http request
 	s.parseWriteRequest(req, &planReq.WriteRequest)
 	planReq.Namespace = sJob.Namespace
 
@@ -384,17 +391,18 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 		return nil, CodedError(400, "Job ID does not match name")
 	}
 
-	// Region in api request query param takes precedence over region in job config
+	// Region in http request query param takes precedence over region in job hcl config
 	if args.WriteRequest.Region != "" {
 		args.Job.Region = helper.StringToPtr(args.WriteRequest.Region)
 	}
+	// If 'global' region is specified or if no region is given,
+	// default to region of the node you're submitting to
+	if args.Job.Region == helper.StringToPtr("global") ||
+		args.Job.Region == helper.StringToPtr("") || args.Job.Region == nil {
+		args.Job.Region = &s.agent.config.Region
+	}
 
 	sJob := ApiJobToStructJob(args.Job)
-
-	// If no region given, defaults to region of the node
-	if sJob.Region == "" {
-		sJob.Region = s.agent.config.Region
-	}
 
 	regReq := structs.JobRegisterRequest{
 		Job:            sJob,
@@ -406,6 +414,8 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 			AuthToken: args.WriteRequest.SecretID,
 		},
 	}
+	// parseWriteRequest overrides Namespace, Region and AuthToken
+	// based on values from the original http request
 	s.parseWriteRequest(req, &regReq.WriteRequest)
 	regReq.Namespace = sJob.Namespace
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -384,13 +384,17 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 		return nil, CodedError(400, "Job ID does not match name")
 	}
 
-	// Http region takes precedence over hcl region
+	// Region in api request query param takes precedence over region in job config
 	if args.WriteRequest.Region != "" {
 		args.Job.Region = helper.StringToPtr(args.WriteRequest.Region)
 	}
 
-	// If no region given, region is canonicalized to 'global'
 	sJob := ApiJobToStructJob(args.Job)
+
+	// If no region given, defaults to region of the node
+	if sJob.Region == "" {
+		sJob.Region = s.agent.config.Region
+	}
 
 	regReq := structs.JobRegisterRequest{
 		Job:            sJob,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -493,10 +493,16 @@ func TestHTTP_JobUpdateRegion(t *testing.T) {
 			ExpectedRegion: "north-america",
 		},
 		{
-			Name:           "falls back to default if no region is provided",
+			Name:           "defaults to node region global if no region is provided",
 			ConfigRegion:   "",
 			APIRegion:      "",
 			ExpectedRegion: "global",
+		},
+		{
+			Name:           "defaults to node region not-global if no region is provided",
+			ConfigRegion:   "",
+			APIRegion:      "",
+			ExpectedRegion: "not-global",
 		},
 	}
 


### PR DESCRIPTION
## Overview

PR https://github.com/hashicorp/nomad/pull/5664 changed behavior to default to a region called "global", when it should default to the region of the node it's submitting the job to.

## Behavior
Hcl Region := Region specified in the Job hcl config
Http Region := Region specified as a `region` query parameter in the http request to the command agent (so either via a script or usually a command line argument)
### Http Region takes precedence over Hcl Region
| http | hcl | result |
|---|---|---|
| A | B | A |
| A | nil | A |
| nil | B | B |

### "global" Region value defaults to region of the node you're submitting to
| http | hcl | result |
|---|---|---|
| "some other region value" | "nil" | "some other region value" |
| nil | "some region other value" | "some region other value"  |
| "some other region value" | "global" | "some other region value" |
| "global" | "some region other value" | "global" --> node region |
| "global" | "global" | "global" --> node region |
| "global" | nil | "global" --> node region |
| nil | "global" | "global" --> node region |
| nil | nil | default --> node region |

## Implementation
While working on PR https://github.com/hashicorp/nomad/pull/5664 we discovered that the Hcl region gets saved but ignored, as downstream RPC calls only reference the region provided in the WriteRequest in the JobRegisterRequest, which used to come from the Http Region. This means that the Job state and the JobRegisterRequest regions became decoupled, which I fixed in previous PR.

However, that actually broke the correct behavior because there is further canonicalization that happens to the WriteRequest, which sets Region to the node region if not present:
https://github.com/hashicorp/nomad/blob/master/command/agent/job_endpoint.go#L405
https://github.com/hashicorp/nomad/blob/master/command/agent/http.go#L472
https://github.com/hashicorp/nomad/blob/master/command/agent/http.go#L431-L438
(thus, if Http Region is nil, but a user set "global" in the Hcl, the Hcl "global" value would get saved but ignored and the actual Region value for the job would get configured to the node region)

## Discussion
* what is a "global" region?
  - if you create a cluster with no region specified, it creates a literal region called "global"
* if a user explicitly asks for "global" region, where should the job go?
  - to the region of the node you're submitting to
* where is the appropriate place to have the Job region value default to the node region?
  - in jobUpdate before ApiToJobStruct canonicalization or parseWriteRequest happens