### PR TITLE
Check if driver handle is nil before execing

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1347,7 +1347,12 @@ func appendTaskEvent(state *structs.TaskState, event *structs.TaskEvent, capacit
 }
 
 func (tr *TaskRunner) TaskExecHandler() drivermanager.TaskExecHandler {
-	return tr.getDriverHandle().ExecStreaming
+	// Check it is running
+	handle := tr.getDriverHandle()
+	if handle == nil {
+		return nil
+	}
+	return handle.ExecStreaming
 }
 
 func (tr *TaskRunner) DriverCapabilities() (*drivers.Capabilities, error) {


### PR DESCRIPTION
Defend against tr.getDriverHandle being nil.  Exec handler checks if
task is running, but it may be stopped between check and driver handler
fetching.

Returning here is safe as caller treats `nil` as a running check.  The relevent callsite is https://github.com/hashicorp/nomad/blob/9ef22a4805002624a791fc676b00fb5b379db991/client/alloc_endpoint.go#L229-L251 .

Fixes #6063