### PR TITLE
Remove transition animation from sort arrows

### DIFF
--- a/ui/app/styles/components/fs-explorer.scss
+++ b/ui/app/styles/components/fs-explorer.scss
@@ -18,7 +18,8 @@
     }
   }
 
-  a {
+  .breadcrumb a,
+  tbody a {
     position: relative;
 
     // This is adapted from Bulma’s .button.is-loading::after


### PR DESCRIPTION
It may be an Ember bug: in some circumstances, the
ember-transitioning-in class was persisting in table
sort links even after the transition completed. This
changes the transition animations to be targeted only
for breadcrumbs and directory links.

Here’s a GIF of the problem this fixes:

![animated-leftover-smaller](https://user-images.githubusercontent.com/43280/62387151-77cc4480-b51f-11e9-8950-393f663c442d.gif)

The `ember-transitioning-in` being left over is strange, but we wouldn’t want transition animations on the sort arrows, regardless.