### PR TITLE
make: always honor GO_TAGS in dev

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -236,7 +236,7 @@ dev: vendorfmt changelogfmt ## Build for the current development platform
 	@rm -f $(GOPATH)/bin/nomad
 	@$(MAKE) --no-print-directory \
 		$(DEV_TARGET) \
-		GO_TAGS="$(NOMAD_UI_TAG)"
+		GO_TAGS="$(GO_TAGS) $(NOMAD_UI_TAG)"
 	@mkdir -p $(PROJECT_ROOT)/bin
 	@mkdir -p $(GOPATH)/bin
 	@cp $(PROJECT_ROOT)/$(DEV_TARGET) $(PROJECT_ROOT)/bin/


### PR DESCRIPTION
Our build scripts pass `$(GO_TAGS)` to `-tags` go compile flags, except
for `make dev`, where `$(NOMAD_UI_TAG)` is used.  This change ensures
`make dev` is inline with the rest of makefile targets.

I use the flag primarily to enable the nomad ui using the committed
compiled assets without regenerating them, as I find using stale ui
satisfactory most of the time.

Readers of this PR may find https://github.com/hashicorp/nomad/pull/5427 relevant in setting some historical context.