### PR TITLE
vault: fix race in accessor revocations

### DIFF
--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -311,6 +311,8 @@ func (v *vaultClient) SetActive(active bool) {
 func (v *vaultClient) flush() {
 	v.l.Lock()
 	defer v.l.Unlock()
+	v.revLock.Lock()
+	defer v.revLock.Unlock()
 
 	v.client = nil
 	v.clientSys = nil


### PR DESCRIPTION
vaultClient.flush must acquire `revLock` before setting `revoking`. Expand diff down a bit to see the field.