### PR TITLE
Add default value "3m" to image_delay, making it consistent with docs.

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -187,7 +187,10 @@ var (
 				hclspec.NewAttr("image", "bool", false),
 				hclspec.NewLiteral("true"),
 			),
-			"image_delay": hclspec.NewAttr("image_delay", "string", false),
+			"image_delay": hclspec.NewDefault(
+				hclspec.NewAttr("image_delay", "string", false),
+				hclspec.NewLiteral("3m"),
+			),
 			"container": hclspec.NewDefault(
 				hclspec.NewAttr("container", "bool", false),
 				hclspec.NewLiteral("true"),


### PR DESCRIPTION
Currently, `image_delay` defaults to 0, causing nomad client to delete docker images the moment they become unused.

This is not the expected behavior according to docs:

https://www.nomadproject.io/docs/drivers/docker.html#image_delay
