### PR TITLE
Fix navigation via clicking recent allocation row

### DIFF
--- a/ui/app/components/job-page/parts/recent-allocations.js
+++ b/ui/app/components/job-page/parts/recent-allocations.js
@@ -1,9 +1,12 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import PromiseArray from 'nomad-ui/utils/classes/promise-array';
 
 export default Component.extend({
   classNames: ['boxed-section'],
+
+  router: service(),
 
   sortProperty: 'modifyIndex',
   sortDescending: true,
@@ -20,7 +23,7 @@ export default Component.extend({
 
   actions: {
     gotoAllocation(allocation) {
-      this.transitionToRoute('allocations.allocation', allocation);
+      this.router.transitionTo('allocations.allocation', allocation.id);
     },
   },
 });

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -54,6 +54,19 @@ export default function moduleForJob(title, context, jobFactory, additionalTests
         assert.ok(JobDetail.allocationsSummary, 'Allocations are shown in the summary section');
         assert.notOk(JobDetail.childrenSummary, 'Children are not shown in the summary section');
       });
+
+      test('clicking in an allocation row navigates to that allocation', async function(assert) {
+        const allocationRow = JobDetail.allocations[0];
+        const allocationId = allocationRow.id;
+
+        await allocationRow.visitRow();
+
+        assert.equal(
+          currentURL(),
+          `/allocations/${allocationId}`,
+          'Allocation row links to allocation detail'
+        );
+      });
     }
 
     if (context === 'children') {

--- a/ui/tests/pages/components/allocations.js
+++ b/ui/tests/pages/components/allocations.js
@@ -19,6 +19,7 @@ export default function(selector = '[data-test-allocation]', propKey = 'allocati
       rescheduled: isPresent('[data-test-indicators] [data-test-icon="reschedule"]'),
 
       visit: clickable('[data-test-short-id] a'),
+      visitRow: clickable(),
       visitJob: clickable('[data-test-job]'),
       visitClient: clickable('[data-test-client] a'),
     }),


### PR DESCRIPTION
I noticed that the allocation row from job overview had the pointer cursor but clicking outside the allocation id didn’t actually do anything. It looks like the action was written for a controller context, so I changed it to use the router service. I also added `.id` to the transition call because without it I was getting `You didn't provide enough string/numeric parameters to satisfy all of the dynamic segments for route`. Maybe this is because the router definition is looking for `allocation_id`, but I didn’t want to get into changing that.

I added a test, which ended up being a set of tests, because of the `moduleForJob` extraction. You can see it failing [here](https://travis-ci.org/hashicorp/nomad/builds/568972555#L472-L483) (linking to a set of lines in `travis-web` appears to be broken 😞) before I committed the fix.