### PR TITLE
modified the Docker TweakCapabilities function

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1205,7 +1205,7 @@ func TestDockerDriver_Capabilities(t *testing.T) {
 		{
 			Name:       "restrictive-whitelist-add-forbidden",
 			CapAdd:     []string{"net_admin", "mknod"},
-			CapDrop:    []string{"all"},
+			CapDrop:    []string{"mknod"},
 			Whitelist:  "fowner,mknod",
 			StartError: "net_admin",
 		},


### PR DESCRIPTION
I have updated the [`TweakCapabilities`](https://github.com/hashicorp/nomad/blob/master/vendor/github.com/moby/moby/daemon/caps/utils_unix.go#L84) function to use what I believe is a more intuitive implementation from the user's perspective. As I mentioned in [this Nomad plugin MR](https://github.com/jenkinsci/nomad-plugin/pull/53), I feel that users should be able to add capabilities to a Docker container by simply whitelisting them in the Nomad config file and passing them to `cap_add`.

As it stands, however, the logic of the `TweakCapabilities` function for Docker does not deliver this behaviour. Rather, these two steps alone yield the following Docker driver error in the Nomad agent:
```
Docker driver doesn't have the following caps whitelisted on this Nomad agent: [list of all basic capabilities minus those whitelisted]
```
This is because the function currently defines 'tweaking' the capabilities as:
1. starting with the [basic Docker-defined capabilities](https://github.com/hashicorp/nomad/blob/master/drivers/docker/config.go#L40)
2. removing those explicitly dropped by the user
3. adding any additional capabilities explicitly added by the user

The code then takes the resulting list, denoted [`effectiveCaps`](https://github.com/hashicorp/nomad/blob/66674116dc361078725f0f52732741180c628b6f/drivers/docker/driver_default.go#L27), and validates against the user-defined whitelist.

If the user doesn't drop the remaining capabilities, step 2 doesn't happen and the result of `TweakCapabilities` is essentially just the entire basic Docker-defined capability list. But, of course, the user hasn't _whitelisted_ the entire basic capability list (nor should they have to)...and the Docker driver throws the aforementioned error. 

My proposed approach is to _only add capabilities to `effectiveCaps` which have been explicitly added by the user and not explicitly dropped_; I feel this approach is simpler, more intuitive and ultimately more conducive to delivering user-expected behaviour.