### PR TITLE
Correct Windows plugin restart when Reattach info is stale

### DIFF
--- a/vendor/github.com/hashicorp/go-plugin/client.go
+++ b/vendor/github.com/hashicorp/go-plugin/client.go
@@ -780,7 +780,10 @@ func (c *Client) reattach() (net.Addr, error) {
 	// Verify the process still exists. If not, then it is an error
 	p, err := os.FindProcess(c.config.Reattach.Pid)
 	if err != nil {
-		return nil, err
+		// On Unix systems, FindProcess never returns an error.
+		// On Windows, for non-existent pids it returns:
+		// os.SyscallError - 'OpenProcess: the paremter is incorrect'
+		return nil, ErrProcessNotFound
 	}
 
 	// Attempt to connect to the addr since on Unix systems FindProcess


### PR DESCRIPTION
The Reattach info Nomad stores can get stale, whereby the pid no
longer refers to a live process.

This has happened to me regularly (but not always) when
troubleshooting plugin initialization and handshaking as I'm
frequently starting and killing nomad.

On Windows, when the go-plugin code calls FindProcess with a stale
pid, the following error is always returned:
os.SyscallError - 'OpenProcess: the paremter is incorrect'

On Unix systems, FindProcess never returns an error, at least as
presently defined in the go source code.

In order for Nomad to recognize this condition we need to bubble up
the ErrProcesNotFound error, with which we can then futher propogate
the SingletonPluginExited error from singleton.go.

With these changes in place, whenever a stale pid is found in the
Reattach info, Nomad now properly restarts the plugin exe.