### PR TITLE
tests: break out command, command/agent on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,16 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
+      env: GOTEST_PKGS="./command" GOTEST_PKGS_EXCLUDE="./command/agent"
+      <<: *skip_for_ui_branches
+    - os: linux
+      dist: xenial
+      sudo: required
+      env: GOTEST_PKGS="./command/agent"
+      <<: *skip_for_ui_branches
+    - os: linux
+      dist: xenial
+      sudo: required
       env: GOTEST_PKGS="./drivers/docker"
       <<: *skip_for_ui_branches
     - os: linux
@@ -46,7 +56,7 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
-      env: GOTEST_PKGS_EXCLUDE="./api|./client|./drivers/docker|./drivers/exec|./nomad"
+      env: GOTEST_PKGS_EXCLUDE="./api|./client|./command|./command/agent|./drivers/docker|./drivers/exec|./nomad"
       <<: *skip_for_ui_branches
     - os: linux
       dist: xenial


### PR DESCRIPTION
The `command` and `command/agent` packages are taking 5+ minutes on Travis and this contributes to build timeouts. While this doesn't address underlying issues, breaking these out can reduce re-runs until that work is done.