### PR TITLE
Bump hadoop version to 2.7.7 to fix setup error

### DIFF
--- a/terraform/shared/scripts/setup.sh
+++ b/terraform/shared/scripts/setup.sh
@@ -29,7 +29,7 @@ CONSULTEMPLATEDOWNLOAD=https://releases.hashicorp.com/consul-template/${CONSULTE
 CONSULTEMPLATECONFIGDIR=/etc/consul-template.d
 CONSULTEMPLATEDIR=/opt/consul-template
 
-HADOOP_VERSION=2.7.6
+HADOOP_VERSION=2.7.7
 
 # Dependencies
 sudo apt-get install -y software-properties-common


### PR DESCRIPTION
The Hadoop 2.7.6 artifact no longer exists and causes Packer to fail when building an image.

Bumping the version to 2.7.7 to fix the issue.