### PR TITLE
tests: partial revert of splitting-out command pkg tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,7 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
-      env: GOTEST_PKGS="./command" GOTEST_PKGS_EXCLUDE="./command/agent"
-      <<: *skip_for_ui_branches
-    - os: linux
-      dist: xenial
-      sudo: required
-      env: GOTEST_PKGS="./command/agent"
+      env: GOTEST_PKGS="./command"
       <<: *skip_for_ui_branches
     - os: linux
       dist: xenial
@@ -56,7 +51,7 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
-      env: GOTEST_PKGS_EXCLUDE="./api|./client|./command|./command/agent|./drivers/docker|./drivers/exec|./nomad"
+      env: GOTEST_PKGS_EXCLUDE="./api|./client|./command|./drivers/docker|./drivers/exec|./nomad"
       <<: *skip_for_ui_branches
     - os: linux
       dist: xenial


### PR DESCRIPTION
GOTEST_PKG_EXCLUDE overrides GOTEST_PKG entirely, so having both in the same test run isn't supported and results in a whole lot of extra tests being run.

Partially reverts https://github.com/hashicorp/nomad/pull/6094
See https://travis-ci.org/hashicorp/nomad/jobs/569816502 for an example of this going wrong.