### PR TITLE
Add ability to control Mirage logging via query

### DIFF
--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -14,6 +14,8 @@ export function findLeader(schema) {
 export default function() {
   this.timing = 0; // delay for each request, automatically set to 0 during testing
 
+  this.logging = window.location.search.includes('mirage-logging=true');
+
   this.namespace = 'v1';
   this.trackRequests = Ember.testing;
 


### PR DESCRIPTION
This lets us turn Mirage logging on without editing any
files, which makes it easier to switch between branches.

As discussed [here](https://github.com/hashicorp/nomad/pull/6048#discussion_r311128060)!