### PR TITLE
Ease user customizations of Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ nomad_linux_amd64
 nomad_darwin_amd64
 TODO.md
 codecgen-*.generated.go
+GNUMakefile.local
 
 .terraform
 *.tfstate*

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,6 +51,9 @@ ifeq (FreeBSD,$(THIS_OS))
 ALL_TARGETS += freebsd_amd64
 endif
 
+# include per-user customization after all variables are defined
+-include GNUMakefile.local
+
 pkg/darwin_amd64/nomad: $(SOURCE_FILES) ## Build Nomad for darwin/amd64
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_DIRTY := $(if $(shell git status --porcelain),+CHANGES)
 
 GO_LDFLAGS := "-X github.com/hashicorp/nomad/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
-GO_TAGS =
+GO_TAGS ?=
 
 GO_TEST_CMD = $(if $(shell which gotestsum),gotestsum --,go test)
 


### PR DESCRIPTION
Allow users to have makefile customizations in `GNUMakefile.local`.

Allow honoring `GO_TAGS` environment variable if set.  Currently, developers
must set variable as a makefile argument e.g. `make GO_TAGS=ui dev`, and
this allows us to use env-var syntax (e.g. `GO_TAGS=ui make dev`) and
make it convenient to set GO_TAGS globally.
