### PR TITLE
UI: Add CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
             - v1-deps-{{ .Branch }}-
             - v1-deps-
       - run:
-          name: Yarn Install
+          name: yarn install
           command: cd ui && yarn install
       - save_cache:
           key: v1-deps-{{ .Branch }}-{{ checksum "ui/yarn.lock" }}
@@ -190,13 +190,13 @@ jobs:
             - ./ui/node_modules
       - run: export PATH="$HOME/.yarn/bin:$PATH"
       - run:
-          name: Run JS Lint
+          name: lint:js
           command: cd ui && yarn run lint:js
       - run:
-          name: Run HBS Lint
+          name: lint:hbs
           command: cd ui && yarn run lint:hbs
       - run:
-          name: Run Tests
+          name: Ember tests
           command: cd ui && yarn test
 
   build-website:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,14 +96,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - v1-deps-{{ .Branch }}-{{ checksum "ui/yarn.lock" }}
             - v1-deps-{{ .Branch }}-
             - v1-deps-
       - run:
           name: Yarn Install
           command: cd ui && yarn install
       - save_cache:
-          key: v1-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: v1-deps-{{ .Branch }}-{{ checksum "ui/yarn.lock" }}
           paths:
             - ./ui/node_modules
       - run: export PATH="$HOME/.yarn/bin:$PATH"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,20 +75,19 @@ jobs:
           JOBS: 2
     steps:
       - checkout
-      - run: cd ui
       - run:
           name: Yarn Install
-          command: yarn install
+          command: cd ui && yarn install
       - run: export PATH="$HOME/.yarn/bin:$PATH"
       - run:
           name: Run JS Lint
-          command: yarn run lint:js
+          command: cd ui && yarn run lint:js
       - run:
           name: Run HBS Lint
-          command: yarn run lint:hbs
+          command: cd ui && yarn run lint:hbs
       - run:
           name: Run Tests
-          command: yarn test
+          command: cd ui && yarn test
 
   build-deps-image:
     executor: docker-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,7 @@ jobs:
     docker:
       - image: circleci/node:10-browsers
         environment:
+          # See https://git.io/vdao3 for details.
           JOBS: 2
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,9 +94,18 @@ jobs:
           JOBS: 2
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - v1-deps-{{ .Branch }}-
+            - v1-deps-
       - run:
           name: Yarn Install
           command: cd ui && yarn install
+      - save_cache:
+          key: v1-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - ./ui/node_modules
       - run: export PATH="$HOME/.yarn/bin:$PATH"
       - run:
           name: Run JS Lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ jobs:
           key: v1-deps-{{ checksum "ui/yarn.lock" }}
           paths:
             - ./ui/node_modules
-      - run: export PATH="$HOME/.yarn/bin:$PATH"
       - run:
           name: lint:js
           command: cd ui && yarn run lint:js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ workflows:
       #     filters:
       #       branches:
       #         only: dani/circleci
+  
+  ui:
+    jobs:
+      - all-ui # to decompose later
 
   website:
     jobs:
@@ -64,6 +68,27 @@ executors:
     machine: true # TODO: Find latest docker image id
 
 jobs:
+  all-ui:
+    docker:
+      - image: circleci/node:10-browsers
+        environment:
+          JOBS: 2
+    steps:
+      - checkout
+      - run:
+        name: Yarn Install
+        command: yarn install
+      - run: export PATH="$HOME/.yarn/bin:$PATH"
+      - run
+        name: Run JS Lint
+        command: yarn run lint:js
+      - run
+        name: Run HBS Lint
+        command: yarn run lint:hbs
+      - run
+        name: Run Tests
+        command: yarn test
+
   build-deps-image:
     executor: docker-builder
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,68 +5,53 @@ references:
     GOMAXPROCS: 1
     NOMAD_SLOW_TEST: 1
     GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
+  ignore_for_ui_branches: &IGNORE_FOR_UI_BRANCHES
+    filters:
+      branches:
+        ignore: /^.-ui\b.*/
+
 
 workflows:
   build-test:
     jobs:
       - lint:
-        filters:
-          branches:
-            ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       - test-machine:
           name: "test-client"
           test_packages: "./client/..."
-          filters:
-            branches:
-              ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       - test-machine:
           name: "test-nomad"
           test_packages: "./nomad/..."
-          filters:
-            branches:
-              ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       - test-machine:
           # API Tests run in a VM rather than container due to the FS tests
           # requiring `mount` priviliges.
           name: "test-api"
           test_packages: "./api/..."
-          filters:
-            branches:
-              ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       - test-container:
           name: "test-devices"
           test_packages: "./devices/..."
-          filters:
-            branches:
-              ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       - test-machine:
           name: "test-other"
           exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/rkt|./drivers/shared/executor|./nomad|./devices"
-          filters:
-            branches:
-              ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       - test-machine:
           name: "test-docker"
           test_packages: "./drivers/docker"
-          filters:
-            branches:
-              ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       - test-machine:
           name: "test-exec"
           test_packages: "./drivers/exec"
-          filters:
-            branches:
-              ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       - test-machine:
           name: "test-shared-exec"
           test_packages: "./drivers/shared/executor"
-          filters:
-            branches:
-              ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       - test-rkt:
-          filters:
-            branches:
-              ignore: /^.-ui\b.*/
+          <<: *IGNORE_FOR_UI_BRANCHES
       # - build-deps-image:
       #     context: dani-test
       #     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,19 +52,15 @@ workflows:
           <<: *IGNORE_FOR_UI_BRANCHES
       - test-rkt:
           <<: *IGNORE_FOR_UI_BRANCHES
+      - test-ui:
+          filters:
+            branches:
+              only: /^.-ui\b.*/
       # - build-deps-image:
       #     context: dani-test
       #     filters:
       #       branches:
       #         only: dani/circleci
-
-  
-  ui:
-    jobs:
-      - test-ui:
-          filters:
-            branches:
-              only: /^.-ui\b.*/
 
   website:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,43 +9,77 @@ references:
 workflows:
   build-test:
     jobs:
-      - lint
+      - lint:
+        filters:
+          branches:
+            ignore: /^.-ui\b/
       - test-machine:
           name: "test-client"
           test_packages: "./client/..."
+          filters:
+            branches:
+              ignore: /^.-ui\b/
       - test-machine:
           name: "test-nomad"
           test_packages: "./nomad/..."
+          filters:
+            branches:
+              ignore: /^.-ui\b/
       - test-machine:
           # API Tests run in a VM rather than container due to the FS tests
           # requiring `mount` priviliges.
           name: "test-api"
           test_packages: "./api/..."
+          filters:
+            branches:
+              ignore: /^.-ui\b/
       - test-container:
           name: "test-devices"
           test_packages: "./devices/..."
+          filters:
+            branches:
+              ignore: /^.-ui\b/
       - test-machine:
           name: "test-other"
           exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/rkt|./drivers/shared/executor|./nomad|./devices"
+          filters:
+            branches:
+              ignore: /^.-ui\b/
       - test-machine:
           name: "test-docker"
           test_packages: "./drivers/docker"
+          filters:
+            branches:
+              ignore: /^.-ui\b/
       - test-machine:
           name: "test-exec"
           test_packages: "./drivers/exec"
+          filters:
+            branches:
+              ignore: /^.-ui\b/
       - test-machine:
           name: "test-shared-exec"
           test_packages: "./drivers/shared/executor"
-      - test-rkt
+          filters:
+            branches:
+              ignore: /^.-ui\b/
+      - test-rkt:
+          filters:
+            branches:
+              ignore: /^.-ui\b/
       # - build-deps-image:
       #     context: dani-test
       #     filters:
       #       branches:
       #         only: dani/circleci
+
   
   ui:
     jobs:
-      - all-ui # to decompose later
+      - all-ui: # to decompose later
+          filters:
+            branches:
+              only: /^.-ui\b/
 
   website:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ references:
 workflows:
   build-test:
     jobs:
-      - lint:
+      - lint-go:
           <<: *IGNORE_FOR_UI_BRANCHES
       - test-machine:
           name: "test-client"
@@ -87,7 +87,7 @@ jobs:
       - run: docker build -t hashicorpnomad/ci-build-image:$CIRCLE_SHA1 . -f ./Dockerfile.ci
       - run: docker push hashicorpnomad/ci-build-image:$CIRCLE_SHA1
 
-  lint:
+  lint-go:
     executor: go
     environment:
       GOPATH: /go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,14 +179,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-deps-{{ .Branch }}-{{ checksum "ui/yarn.lock" }}
-            - v1-deps-{{ .Branch }}-
+            - v1-deps-{{ checksum "ui/yarn.lock" }}
             - v1-deps-
       - run:
           name: yarn install
           command: cd ui && yarn install
       - save_cache:
-          key: v1-deps-{{ .Branch }}-{{ checksum "ui/yarn.lock" }}
+          key: v1-deps-{{ checksum "ui/yarn.lock" }}
           paths:
             - ./ui/node_modules
       - run: export PATH="$HOME/.yarn/bin:$PATH"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,19 +12,19 @@ workflows:
       - lint:
         filters:
           branches:
-            ignore: /^.-ui\b/
+            ignore: /^.-ui\b.*/
       - test-machine:
           name: "test-client"
           test_packages: "./client/..."
           filters:
             branches:
-              ignore: /^.-ui\b/
+              ignore: /^.-ui\b.*/
       - test-machine:
           name: "test-nomad"
           test_packages: "./nomad/..."
           filters:
             branches:
-              ignore: /^.-ui\b/
+              ignore: /^.-ui\b.*/
       - test-machine:
           # API Tests run in a VM rather than container due to the FS tests
           # requiring `mount` priviliges.
@@ -32,41 +32,41 @@ workflows:
           test_packages: "./api/..."
           filters:
             branches:
-              ignore: /^.-ui\b/
+              ignore: /^.-ui\b.*/
       - test-container:
           name: "test-devices"
           test_packages: "./devices/..."
           filters:
             branches:
-              ignore: /^.-ui\b/
+              ignore: /^.-ui\b.*/
       - test-machine:
           name: "test-other"
           exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/rkt|./drivers/shared/executor|./nomad|./devices"
           filters:
             branches:
-              ignore: /^.-ui\b/
+              ignore: /^.-ui\b.*/
       - test-machine:
           name: "test-docker"
           test_packages: "./drivers/docker"
           filters:
             branches:
-              ignore: /^.-ui\b/
+              ignore: /^.-ui\b.*/
       - test-machine:
           name: "test-exec"
           test_packages: "./drivers/exec"
           filters:
             branches:
-              ignore: /^.-ui\b/
+              ignore: /^.-ui\b.*/
       - test-machine:
           name: "test-shared-exec"
           test_packages: "./drivers/shared/executor"
           filters:
             branches:
-              ignore: /^.-ui\b/
+              ignore: /^.-ui\b.*/
       - test-rkt:
           filters:
             branches:
-              ignore: /^.-ui\b/
+              ignore: /^.-ui\b.*/
       # - build-deps-image:
       #     context: dani-test
       #     filters:
@@ -79,7 +79,7 @@ workflows:
       - all-ui: # to decompose later
           filters:
             branches:
-              only: /^.-ui\b/
+              only: /^.-ui\b.*/
 
   website:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ workflows:
   
   ui:
     jobs:
-      - all-ui: # to decompose later
+      - test-ui:
           filters:
             branches:
               only: /^.-ui\b.*/
@@ -87,36 +87,6 @@ executors:
     machine: true # TODO: Find latest docker image id
 
 jobs:
-  all-ui:
-    docker:
-      - image: circleci/node:10-browsers
-        environment:
-          JOBS: 2
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-deps-{{ .Branch }}-{{ checksum "ui/yarn.lock" }}
-            - v1-deps-{{ .Branch }}-
-            - v1-deps-
-      - run:
-          name: Yarn Install
-          command: cd ui && yarn install
-      - save_cache:
-          key: v1-deps-{{ .Branch }}-{{ checksum "ui/yarn.lock" }}
-          paths:
-            - ./ui/node_modules
-      - run: export PATH="$HOME/.yarn/bin:$PATH"
-      - run:
-          name: Run JS Lint
-          command: cd ui && yarn run lint:js
-      - run:
-          name: Run HBS Lint
-          command: cd ui && yarn run lint:hbs
-      - run:
-          name: Run Tests
-          command: cd ui && yarn test
-
   build-deps-image:
     executor: docker-builder
     steps:
@@ -206,6 +176,35 @@ jobs:
           path: /tmp/test-reports
       - store_artifacts:
           path: /tmp/test-reports
+  test-ui:
+    docker:
+      - image: circleci/node:10-browsers
+        environment:
+          JOBS: 2
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-deps-{{ .Branch }}-{{ checksum "ui/yarn.lock" }}
+            - v1-deps-{{ .Branch }}-
+            - v1-deps-
+      - run:
+          name: Yarn Install
+          command: cd ui && yarn install
+      - save_cache:
+          key: v1-deps-{{ .Branch }}-{{ checksum "ui/yarn.lock" }}
+          paths:
+            - ./ui/node_modules
+      - run: export PATH="$HOME/.yarn/bin:$PATH"
+      - run:
+          name: Run JS Lint
+          command: cd ui && yarn run lint:js
+      - run:
+          name: Run HBS Lint
+          command: cd ui && yarn run lint:hbs
+      - run:
+          name: Run Tests
+          command: cd ui && yarn test
 
   build-website:
     # setting the working_directory along with the checkout path allows us to not have

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,18 +76,18 @@ jobs:
     steps:
       - checkout
       - run:
-        name: Yarn Install
-        command: yarn install
+          name: Yarn Install
+          command: yarn install
       - run: export PATH="$HOME/.yarn/bin:$PATH"
-      - run
-        name: Run JS Lint
-        command: yarn run lint:js
-      - run
-        name: Run HBS Lint
-        command: yarn run lint:hbs
-      - run
-        name: Run Tests
-        command: yarn test
+      - run:
+          name: Run JS Lint
+          command: yarn run lint:js
+      - run:
+          name: Run HBS Lint
+          command: yarn run lint:hbs
+      - run:
+          name: Run Tests
+          command: yarn test
 
   build-deps-image:
     executor: docker-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
           JOBS: 2
     steps:
       - checkout
+      - run: cd ui
       - run:
           name: Yarn Install
           command: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,7 @@ workflows:
           <<: *IGNORE_FOR_UI_BRANCHES
       - test-rkt:
           <<: *IGNORE_FOR_UI_BRANCHES
-      - test-ui:
-          filters:
-            branches:
-              only: /^.-ui\b.*/
+      - test-ui
       # - build-deps-image:
       #     context: dani-test
       #     filters:


### PR DESCRIPTION
This adds a job to test the UI on CircleCI, including the sort of branch
pattern-matching from #5839, so `.-ui/` branches only have that job
and not the non-UI ones.

I considered having an entire workflow for UI, which could have separate
jobs for linting vs Ember tests, but the lint commands take so little time
that it didn’t seem worth it.

There’s no use of nvm to change the Node version as the Docker image
is what controls that. It’s annoying to have to update the version in multiple
places, but probably infrequent.