### PR TITLE
agent: add optional param to -dev flag for connect

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -413,7 +413,7 @@ func TestAgent_HTTPCheckPath(t *testing.T) {
 	t.Parallel()
 	// Agent.agentHTTPCheck only needs a config and logger
 	a := &Agent{
-		config: DevConfig(),
+		config: DevConfig(nil),
 		logger: testlog.HCLogger(t),
 	}
 	if err := a.config.normalizeAddrs(); err != nil {

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1172,7 +1172,8 @@ General Options (clients and servers):
 
     -dev=connect
       Start the agent in development mode, but bind to a public network
-      interface rather than localhost for Consul Connect testing.
+      interface rather than localhost for using Consul Connect. This
+      mode is supported only on Linux as root.
 
 Server Options:
 

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -56,7 +56,7 @@ type Command struct {
 }
 
 func (c *Command) readConfig() *Config {
-	var dev bool
+	var dev *devModeConfig
 	var configPath []string
 	var servers string
 	var meta []string
@@ -77,7 +77,10 @@ func (c *Command) readConfig() *Config {
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 
 	// Role options
-	flags.BoolVar(&dev, "dev", false, "")
+	flags.Var((flaghelper.FuncOptionalStringVar)(func(s string) (err error) {
+		dev, err = newDevModeConfig(s)
+		return err
+	}), "dev", "")
 	flags.BoolVar(&cmdConfig.Server.Enabled, "server", false, "")
 	flags.BoolVar(&cmdConfig.Client.Enabled, "client", false, "")
 
@@ -204,8 +207,8 @@ func (c *Command) readConfig() *Config {
 
 	// Load the configuration
 	var config *Config
-	if dev {
-		config = DevConfig()
+	if dev != nil {
+		config = DevConfig(dev)
 	} else {
 		config = DefaultConfig()
 	}
@@ -1164,7 +1167,12 @@ General Options (clients and servers):
     Start the agent in development mode. This enables a pre-configured
     dual-role agent (client + server) which is useful for developing
     or testing Nomad. No other configuration is required to start the
-    agent in this mode.
+    agent in this mode, but you may pass an optional comma-separated
+    list of mode configurations:
+
+    -dev=connect
+      Start the agent in development mode, but bind to a public network
+      interface rather than localhost for Consul Connect testing.
 
 Server Options:
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -617,6 +619,60 @@ func TestConfig_Listener(t *testing.T) {
 	want = fmt.Sprintf("0.0.0.0:%d", ports[1])
 	if addr := ln.Addr().String(); addr != want {
 		t.Fatalf("expected %q, got: %q", want, addr)
+	}
+}
+
+func TestConfig_DevModeFlag(t *testing.T) {
+	cases := []struct {
+		flag        string
+		expected    *devModeConfig
+		expectedErr string
+	}{}
+	if runtime.GOOS != "linux" {
+		cases = []struct {
+			flag        string
+			expected    *devModeConfig
+			expectedErr string
+		}{
+			{"", nil, ""},
+			{"true", &devModeConfig{defaultMode: true, connectMode: false}, ""},
+			{"true,connect", nil, "-dev=connect is only supported on linux"},
+			{"connect", nil, "-dev=connect is only supported on linux"},
+			{"xxx", nil, "invalid -dev flag"},
+		}
+	}
+	if runtime.GOOS == "linux" {
+		cases = []struct {
+			flag        string
+			expected    *devModeConfig
+			expectedErr string
+		}{
+			{"", nil, ""},
+			{"true", &devModeConfig{defaultMode: true, connectMode: false}, ""},
+			{"true,connect", &devModeConfig{defaultMode: true, connectMode: true}, ""},
+			{"connect", &devModeConfig{defaultMode: false, connectMode: true}, ""},
+			{"xxx", nil, "invalid -dev flag"},
+		}
+	}
+	for _, c := range cases {
+		t.Run(c.flag, func(t *testing.T) {
+			mode, err := newDevModeConfig(c.flag)
+			if err != nil && c.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err != nil && !strings.Contains(err.Error(), c.expectedErr) {
+				t.Fatalf("expected %s; got %v", c.expectedErr, err)
+			}
+			if mode == nil && c.expected != nil {
+				t.Fatalf("expected %+v but got nil", c.expected)
+			}
+			if mode != nil {
+				if c.expected.defaultMode != mode.defaultMode ||
+					c.expected.connectMode != mode.connectMode {
+					t.Fatalf("expected %+v, got %+v", c.expected, mode)
+				}
+			}
+		})
 	}
 }
 

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -311,7 +311,7 @@ func (a *TestAgent) pickRandomPorts(c *Config) {
 // TestConfig returns a unique default configuration for testing an
 // agent.
 func (a *TestAgent) config() *Config {
-	conf := DevConfig()
+	conf := DevConfig(nil)
 
 	// Customize the server configuration
 	config := nomad.DefaultConfig()

--- a/helper/flag-helpers/flag.go
+++ b/helper/flag-helpers/flag.go
@@ -58,3 +58,11 @@ func (f FuncDurationVar) Set(s string) error {
 }
 func (f FuncDurationVar) String() string   { return "" }
 func (f FuncDurationVar) IsBoolFlag() bool { return false }
+
+// FuncOptionalStringVar is a flag that accepts a function which it
+// calls on the optional string given by the user.
+type FuncOptionalStringVar func(s string) error
+
+func (f FuncOptionalStringVar) Set(s string) error { return f(s) }
+func (f FuncOptionalStringVar) String() string     { return "" }
+func (f FuncOptionalStringVar) IsBoolFlag() bool   { return true }

--- a/website/source/docs/commands/agent.html.md.erb
+++ b/website/source/docs/commands/agent.html.md.erb
@@ -14,7 +14,7 @@ or server functionality, including exposing interfaces for client consumption
 and running jobs.
 
 Due to the power and flexibility of this command, the Nomad agent is documented
-in its own section. See the [Nomad Agent](/guides/install/production/nomad-agent.html) 
+in its own section. See the [Nomad Agent](/guides/install/production/nomad-agent.html)
 guide and the [Configuration](/docs/configuration/index.html) documentation section for
 more information on how to use this command and the options it has.
 
@@ -55,7 +55,12 @@ via CLI arguments. The `agent` command accepts the following arguments:
 * `-dc=<datacenter>`: Equivalent to the [datacenter](#datacenter) config option.
 * `-dev`: Start the agent in development mode. This enables a pre-configured
   dual-role agent (client + server) which is useful for developing or testing
-  Nomad. No other configuration is required to start the agent in this mode.
+  Nomad. No other configuration is required to start the agent in this mode,
+  but you may pass an optional comma-separated list of mode configurations:
+
+  `-dev=connect`: Start the agent in development mode, but bind to a public network
+  interface rather than localhost for Consul Connect testing.
+
 * `-encrypt`: Set the Serf encryption key. See the [Encryption Overview](/guides/security/encryption.html) for more details.
 * `-join=<address>`: Address of another agent to join upon starting up. This can
   be specified multiple times to specify multiple agents to join.
@@ -102,8 +107,8 @@ via CLI arguments. The `agent` command accepts the following arguments:
 * `vault-cert-file=<path>`: The path to the certificate for Vault communication.
 * `vault-key-file=<path>`: The path to the private key for Vault communication.
 * `vault-namespace=<namespace>`: The Vault namespace used for the integration.
-  Required for servers and clients. Overrides the Vault namespace read from the 
-  VAULT_NAMESPACE environment variable.  
+  Required for servers and clients. Overrides the Vault namespace read from the
+  VAULT_NAMESPACE environment variable.
 * `vault-tls-skip-verify`: A boolean that determines whether to skip SSL
   certificate verification.
 * `vault-tls-server-name=<name>`: Used to set the SNI host when connecting to

--- a/website/source/docs/commands/agent.html.md.erb
+++ b/website/source/docs/commands/agent.html.md.erb
@@ -58,8 +58,9 @@ via CLI arguments. The `agent` command accepts the following arguments:
   Nomad. No other configuration is required to start the agent in this mode,
   but you may pass an optional comma-separated list of mode configurations:
 
-  `-dev=connect`: Start the agent in development mode, but bind to a public network
-  interface rather than localhost for Consul Connect testing.
+  `-dev=connect`: Start the agent in development mode, but bind to a public
+  network interface rather than localhost for using Consul Connect. This mode
+  is supported only on Linux as root.
 
 * `-encrypt`: Set the Serf encryption key. See the [Encryption Overview](/guides/security/encryption.html) for more details.
 * `-join=<address>`: Address of another agent to join upon starting up. This can


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/6117

Consul Connect must route traffic between network namespaces through a public interface (i.e. not localhost). In order to support testing in dev mode, users needed to manually set the interface which doesn't make for a smooth experience.

This commit adds a facility for adding optional parameters to the `nomad agent -dev` flag and uses it to add a `-dev=connect` flag that binds to a public interface on the host.

---

@schmichael @nickethier I've got this up as a draft PR because I've got a couple of minor design questions:
* For the time being I've opted not to make the `devModeConfig` a public type that we can thread throughout the codebase. There are a dozen or so places where we check `if config.DevMode` which we'd need to update if we turned that bool into a struct, and with only one use case that we can handle locally I feel like it doesn't make sense to do this (at least not yet).
* #6117 suggests that we need the interface and doesn't mention the address, but I think we'll end up needing the address as well or we'd end up needing to use `0.0.0.0` on the interface we find.
* Also, we're binding to the "first" interface which is probably fine for most cases?
* ~(Obviously I still need to add docs as well but I wanted to make sure the design was pinned down first.)~ Done in 959a10f
