### PR TITLE
Fix missing plugin driver capabilities

### DIFF
--- a/plugins/drivers/client.go
+++ b/plugins/drivers/client.go
@@ -55,6 +55,11 @@ func (d *driverPluginClient) Capabilities() (*Capabilities, error) {
 	if resp.Capabilities != nil {
 		caps.SendSignals = resp.Capabilities.SendSignals
 		caps.Exec = resp.Capabilities.Exec
+		caps.MustInitiateNetwork = resp.Capabilities.MustCreateNetwork
+
+		for _, mode := range resp.Capabilities.NetworkIsolationModes {
+			caps.NetIsolationModes = append(caps.NetIsolationModes, netIsolationModeFromProto(mode))
+		}
 
 		switch resp.Capabilities.FsIsolation {
 		case proto.DriverCapabilities_NONE:

--- a/plugins/drivers/testutils/testing_test.go
+++ b/plugins/drivers/testutils/testing_test.go
@@ -259,3 +259,28 @@ func TestBaseDriver_TaskEvents(t *testing.T) {
 	}
 
 }
+
+func TestBaseDriver_Capabilities(t *testing.T) {
+	capabilities := &drivers.Capabilities{
+		NetIsolationModes: []drivers.NetIsolationMode{
+			drivers.NetIsolationModeHost,
+			drivers.NetIsolationModeGroup,
+		},
+		MustInitiateNetwork: true,
+		SendSignals:         true,
+		Exec:                true,
+		FSIsolation:         drivers.FSIsolationNone,
+	}
+	d := &MockDriver{
+		CapabilitiesF: func() (*drivers.Capabilities, error) {
+			return capabilities, nil
+		},
+	}
+
+	harness := NewDriverHarness(t, d)
+	defer harness.Kill()
+
+	caps, err := harness.Capabilities()
+	require.NoError(t, err)
+	require.Equal(t, capabilities, caps)
+}


### PR DESCRIPTION
NetIsolationModes and MustInitiateNetwork were left out of the
driver Capabilities when using an external task driver plugin

Before, with the new test:
```
pouulet@server:~/dev/go/src/github.com/hashicorp/nomad/plugins/drivers/testutils
$ go test -v -run TestBaseDriver_Capabilities .
=== RUN   TestBaseDriver_Capabilities
--- FAIL: TestBaseDriver_Capabilities (0.00s)
    testing_test.go:285:
                Error Trace:    testing_test.go:285
                Error:          Not equal:
                                expected: &drivers.Capabilities{SendSignals:true, Exec:true, FSIsolation:"none", NetIsolationModes:[]drivers.NetIsolationMode{"host", "group"}, MustInitiateNetwork:true}
                                actual  : &drivers.Capabilities{SendSignals:true, Exec:true, FSIsolation:"none", NetIsolationModes:[]drivers.NetIsolationMode(nil), MustInitiateNetwork:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -4,7 +4,4 @@
                                  FSIsolation: (drivers.FSIsolation) (len=4) "none",
                                - NetIsolationModes: ([]drivers.NetIsolationMode) (len=2) {
                                -  (drivers.NetIsolationMode) (len=4) "host",
                                -  (drivers.NetIsolationMode) (len=5) "group"
                                - },
                                - MustInitiateNetwork: (bool) true
                                + NetIsolationModes: ([]drivers.NetIsolationMode) <nil>,
                                + MustInitiateNetwork: (bool) false
                                 })
                Test:           TestBaseDriver_Capabilities
FAIL
FAIL    github.com/hashicorp/nomad/plugins/drivers/testutils    0.007s
```

Same test, with the patch:
```
pouulet@server:~/dev/go/src/github.com/hashicorp/nomad/plugins/drivers/testutils
$ go test -v -run TestBaseDriver_Capabilities .
=== RUN   TestBaseDriver_Capabilities
--- PASS: TestBaseDriver_Capabilities (0.00s)
PASS
ok      github.com/hashicorp/nomad/plugins/drivers/testutils    (cached)
```