### PR TITLE
[wip] devices: Downsample stats collection every 10s

### DIFF
--- a/plugins/shared/cmd/launcher/command/device.go
+++ b/plugins/shared/cmd/launcher/command/device.go
@@ -344,7 +344,7 @@ func (c *Device) replOutput(ctx context.Context, startFingerprint, startStats <-
 			c.Ui.Output(fmt.Sprintf("> fingerprint: % #v", pretty.Formatter(resp)))
 		case ctx := <-startStats:
 			var err error
-			stats, err = c.dev.Stats(ctx, 1*time.Second)
+			stats, err = c.dev.Stats(ctx, 10*time.Second)
 			if err != nil {
 				c.Ui.Error(fmt.Sprintf("stats: %s", err))
 				os.Exit(1)


### PR DESCRIPTION
Most nomad stats are collected at 10second intervals, this does the same
for device plugins, as collecting stats for especially nvidia devices is
expensive, and a 1s interval is excessive.

fixes #6057, although we may wish to have a follow up ticket for
optimising stats collection in the nvidia driver