### PR TITLE
sidecar_task override in connect admission controller

### DIFF
--- a/api/services.go
+++ b/api/services.go
@@ -157,7 +157,7 @@ type SidecarTask struct {
 	Meta          map[string]string
 	KillTimeout   *time.Duration `mapstructure:"kill_timeout"`
 	LogConfig     *LogConfig     `mapstructure:"logs"`
-	ShutdownDelay time.Duration  `mapstructure:"shutdown_delay"`
+	ShutdownDelay *time.Duration `mapstructure:"shutdown_delay"`
 	KillSignal    string         `mapstructure:"kill_signal"`
 }
 

--- a/api/services.go
+++ b/api/services.go
@@ -135,7 +135,7 @@ func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {
 type ConsulConnect struct {
 	Native         bool
 	SidecarService *ConsulSidecarService `mapstructure:"sidecar_service"`
-	SidecarTask    *Task                 `mapstructure:"sidecar_task"`
+	SidecarTask    *SidecarTask          `mapstructure:"sidecar_task"`
 }
 
 // ConsulSidecarService represents a Consul Connect SidecarService jobspec
@@ -143,6 +143,22 @@ type ConsulConnect struct {
 type ConsulSidecarService struct {
 	Port  string
 	Proxy *ConsulProxy
+}
+
+// SidecarTask represents a subset of Task fields that can be set to override
+// the fields of the Task generated for the sidecar
+type SidecarTask struct {
+	Name          string
+	Driver        string
+	User          string
+	Config        map[string]interface{}
+	Env           map[string]string
+	Resources     *Resources
+	Meta          map[string]string
+	KillTimeout   *time.Duration `mapstructure:"kill_timeout"`
+	LogConfig     *LogConfig     `mapstructure:"logs"`
+	ShutdownDelay time.Duration  `mapstructure:"shutdown_delay"`
+	KillSignal    string         `mapstructure:"kill_signal"`
 }
 
 // ConsulProxy represents a Consul Connect sidecar proxy jobspec stanza.

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1084,7 +1084,7 @@ func ApiConsulConnectToStructs(in *api.ConsulConnect) *structs.ConsulConnect {
 	if in.SidecarTask != nil {
 		out.SidecarTask = &structs.SidecarTask{
 			Name:          in.SidecarTask.Name,
-			Driver:        in.SidecarTask.Name,
+			Driver:        in.SidecarTask.Driver,
 			Config:        in.SidecarTask.Config,
 			User:          in.SidecarTask.User,
 			Env:           in.SidecarTask.Env,
@@ -1096,7 +1096,7 @@ func ApiConsulConnectToStructs(in *api.ConsulConnect) *structs.ConsulConnect {
 		}
 
 		if in.SidecarTask.KillTimeout != nil {
-			out.SidecarTask.KillTimeout = *in.SidecarTask.KillTimeout
+			out.SidecarTask.KillTimeout = in.SidecarTask.KillTimeout
 		}
 		if in.SidecarTask.LogConfig != nil {
 			out.SidecarTask.LogConfig = &structs.LogConfig{}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1082,7 +1082,31 @@ func ApiConsulConnectToStructs(in *api.ConsulConnect) *structs.ConsulConnect {
 	}
 
 	if in.SidecarTask != nil {
-		ApiTaskToStructsTask(in.SidecarTask, out.SidecarTask)
+		out.SidecarTask = &structs.SidecarTask{
+			Name:          in.SidecarTask.Name,
+			Driver:        in.SidecarTask.Name,
+			Config:        in.SidecarTask.Config,
+			User:          in.SidecarTask.User,
+			Env:           in.SidecarTask.Env,
+			Resources:     ApiResourcesToStructs(in.SidecarTask.Resources),
+			Meta:          in.SidecarTask.Meta,
+			LogConfig:     &structs.LogConfig{},
+			ShutdownDelay: in.SidecarTask.ShutdownDelay,
+			KillSignal:    in.SidecarTask.KillSignal,
+		}
+
+		if in.SidecarTask.KillTimeout != nil {
+			out.SidecarTask.KillTimeout = *in.SidecarTask.KillTimeout
+		}
+		if in.SidecarTask.LogConfig != nil {
+			out.SidecarTask.LogConfig = &structs.LogConfig{}
+			if in.SidecarTask.LogConfig.MaxFiles != nil {
+				out.SidecarTask.LogConfig.MaxFiles = *in.SidecarTask.LogConfig.MaxFiles
+			}
+			if in.SidecarTask.LogConfig.MaxFileSizeMB != nil {
+				out.SidecarTask.LogConfig.MaxFileSizeMB = *in.SidecarTask.LogConfig.MaxFileSizeMB
+			}
+		}
 	}
 
 	return out

--- a/jobspec/parse_service.go
+++ b/jobspec/parse_service.go
@@ -164,7 +164,7 @@ func parseConnect(co *ast.ObjectItem) (*api.ConsulConnect, error) {
 		return nil, fmt.Errorf("only one 'sidecar_task' block allowed per task")
 	}
 
-	t, err := parseTask(o.Items[0])
+	t, err := parseSidecarTask(o.Items[0])
 	if err != nil {
 		return nil, fmt.Errorf("sidecar_task, %v", err)
 	}
@@ -226,6 +226,54 @@ func parseSidecarService(o *ast.ObjectItem) (*api.ConsulSidecarService, error) {
 	sidecar.Proxy = r
 
 	return &sidecar, nil
+}
+
+func parseSidecarTask(item *ast.ObjectItem) (*api.SidecarTask, error) {
+	// We need this later
+	var listVal *ast.ObjectList
+	if ot, ok := item.Val.(*ast.ObjectType); ok {
+		listVal = ot.List
+	} else {
+		return nil, fmt.Errorf("should be an object")
+	}
+
+	// Check for invalid keys
+	valid := []string{
+		"config",
+		"driver",
+		"env",
+		"kill_timeout",
+		"logs",
+		"meta",
+		"resources",
+		"shutdown_delay",
+		"user",
+		"kill_signal",
+	}
+	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
+		return nil, err
+	}
+
+	task, err := parseTask(item)
+	if err != nil {
+		return nil, err
+	}
+
+	sidecarTask := &api.SidecarTask{
+		Name:          task.Name,
+		Driver:        task.Driver,
+		User:          task.User,
+		Config:        task.Config,
+		Env:           task.Env,
+		Resources:     task.Resources,
+		Meta:          task.Meta,
+		KillTimeout:   task.KillTimeout,
+		LogConfig:     task.LogConfig,
+		ShutdownDelay: task.ShutdownDelay,
+		KillSignal:    task.KillSignal,
+	}
+
+	return sidecarTask, nil
 }
 
 func parseProxy(o *ast.ObjectItem) (*api.ConsulProxy, error) {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -933,6 +933,7 @@ func TestParse(t *testing.T) {
 										Env: map[string]string{
 											"FOO": "abc",
 										},
+										ShutdownDelay: helper.TimeToPtr(5 * time.Second),
 									},
 								},
 							},

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -925,7 +925,7 @@ func TestParse(t *testing.T) {
 											},
 										},
 									},
-									SidecarTask: &api.Task{
+									SidecarTask: &api.SidecarTask{
 										Resources: &api.Resources{
 											CPU:      helper.IntToPtr(500),
 											MemoryMB: helper.IntToPtr(1024),

--- a/jobspec/test-fixtures/tg-network.hcl
+++ b/jobspec/test-fixtures/tg-network.hcl
@@ -34,6 +34,8 @@ job "foo" {
           env {
             FOO = "abc"
           }
+
+          shutdown_delay = "5s"
         }
       }
     }

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -9,11 +9,13 @@ import (
 )
 
 var (
-	// connectSidecarResources is the set of resources used by default for the
-	// Consul Connect sidecar task
-	connectSidecarResources = &structs.Resources{
-		CPU:      250,
-		MemoryMB: 128,
+	// connectSidecarResources returns the set of resources used by default for
+	// the Consul Connect sidecar task
+	connectSidecarResources = func() *structs.Resources {
+		return &structs.Resources{
+			CPU:      250,
+			MemoryMB: 128,
+		}
 	}
 
 	// connectDriverConfig is the driver configuration used by the injected
@@ -30,10 +32,12 @@ var (
 	// the proper Consul version is used that supports the nessicary Connect
 	// features. This includes bootstraping envoy with a unix socket for Consul's
 	// grpc xDS api.
-	connectVersionConstraint = &structs.Constraint{
-		LTarget: "${attr.consul.version}",
-		RTarget: ">= 1.6.0beta1",
-		Operand: "version",
+	connectVersionConstraint = func() *structs.Constraint {
+		return &structs.Constraint{
+			LTarget: "${attr.consul.version}",
+			RTarget: ">= 1.6.0beta1",
+			Operand: "version",
+		}
 	}
 )
 
@@ -147,9 +151,9 @@ func newConnectTask(service *structs.Service) *structs.Task {
 			MaxFiles:      2,
 			MaxFileSizeMB: 2,
 		},
-		Resources: connectSidecarResources.Copy(),
+		Resources: connectSidecarResources(),
 		Constraints: structs.Constraints{
-			connectVersionConstraint,
+			connectVersionConstraint(),
 		},
 	}
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -243,7 +243,7 @@ func TestJobEndpoint_Register_ConnectWithSidecarTask(t *testing.T) {
 	require.Equal("connect-proxy:backend", string(sidecarTask.Kind))
 	require.Equal("connect-proxy-backend", out.TaskGroups[0].Networks[0].DynamicPorts[0].Label)
 
-	// Check that the correct fields were overriden from the sidecar_task stanza
+	// Check that the correct fields were overridden from the sidecar_task stanza
 	require.Equal("test", sidecarTask.Meta["source"])
 	require.Equal(500, sidecarTask.Resources.CPU)
 	require.Equal(connectSidecarResources.MemoryMB, sidecarTask.Resources.MemoryMB)

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -176,6 +176,101 @@ func TestJobEndpoint_Register_Connect(t *testing.T) {
 
 }
 
+func TestJobEndpoint_Register_ConnectWithSidecarTask(t *testing.T) {
+	require := require.New(t)
+	t.Parallel()
+	s1 := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0 // Prevent automatic dequeue
+	})
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	job := mock.Job()
+	job.TaskGroups[0].Networks = structs.Networks{
+		{
+			Mode: "bridge",
+		},
+	}
+	job.TaskGroups[0].Services = []*structs.Service{
+		{
+			Name:      "backend",
+			PortLabel: "8080",
+			Connect: &structs.ConsulConnect{
+				SidecarService: &structs.ConsulSidecarService{},
+				SidecarTask: &structs.SidecarTask{
+					Meta: map[string]string{
+						"source": "test",
+					},
+					Resources: &structs.Resources{
+						CPU: 500,
+					},
+					Config: map[string]interface{}{
+						"labels": map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	req := &structs.JobRegisterRequest{
+		Job: job,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// Fetch the response
+	var resp structs.JobRegisterResponse
+	require.NoError(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
+	require.NotZero(resp.Index)
+
+	// Check for the node in the FSM
+	state := s1.fsm.State()
+	ws := memdb.NewWatchSet()
+	out, err := state.JobByID(ws, job.Namespace, job.ID)
+	require.NoError(err)
+	require.NotNil(out)
+	require.Equal(resp.JobModifyIndex, out.CreateIndex)
+
+	// Check that the sidecar task was injected
+	require.Len(out.TaskGroups[0].Tasks, 2)
+	sidecarTask := out.TaskGroups[0].Tasks[1]
+	require.Equal("connect-proxy-backend", sidecarTask.Name)
+	require.Equal("connect-proxy:backend", string(sidecarTask.Kind))
+	require.Equal("connect-proxy-backend", out.TaskGroups[0].Networks[0].DynamicPorts[0].Label)
+
+	// Check that the correct fields were overriden from the sidecar_task stanza
+	require.Equal("test", sidecarTask.Meta["source"])
+	require.Equal(500, sidecarTask.Resources.CPU)
+	require.Equal(connectSidecarResources.MemoryMB, sidecarTask.Resources.MemoryMB)
+	cfg := connectDriverConfig
+	cfg["labels"] = map[string]interface{}{
+		"foo": "bar",
+	}
+	require.Equal(cfg, sidecarTask.Config)
+
+	// Check that round tripping the job doesn't change the sidecarTask
+	out.Meta["test"] = "abc"
+	req.Job = out
+	require.NoError(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
+	require.NotZero(resp.Index)
+	// Check for the new node in the FSM
+	state = s1.fsm.State()
+	ws = memdb.NewWatchSet()
+	out, err = state.JobByID(ws, job.Namespace, job.ID)
+	require.NoError(err)
+	require.NotNil(out)
+	require.Equal(resp.JobModifyIndex, out.CreateIndex)
+
+	require.Len(out.TaskGroups[0].Tasks, 2)
+	require.Exactly(sidecarTask, out.TaskGroups[0].Tasks[1])
+
+}
+
 func TestJobEndpoint_Register_ACL(t *testing.T) {
 	t.Parallel()
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -246,7 +246,7 @@ func TestJobEndpoint_Register_ConnectWithSidecarTask(t *testing.T) {
 	// Check that the correct fields were overridden from the sidecar_task stanza
 	require.Equal("test", sidecarTask.Meta["source"])
 	require.Equal(500, sidecarTask.Resources.CPU)
-	require.Equal(connectSidecarResources.MemoryMB, sidecarTask.Resources.MemoryMB)
+	require.Equal(connectSidecarResources().MemoryMB, sidecarTask.Resources.MemoryMB)
 	cfg := connectDriverConfig
 	cfg["labels"] = map[string]interface{}{
 		"foo": "bar",

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -629,16 +629,14 @@ type SidecarTask struct {
 
 	// KillTimeout is the time between signaling a task that it will be
 	// killed and killing it.
-	KillTimeout time.Duration
+	KillTimeout *time.Duration
 
 	// LogConfig provides configuration for log rotation
 	LogConfig *LogConfig
 
 	// ShutdownDelay is the duration of the delay between deregistering a
 	// task from Consul and sending it a signal to shutdown. See #2441
-	ShutdownDelay time.Duration
-
-	// The kill signal to use for the task. This is an optional specification,
+	ShutdownDelay *time.Duration
 
 	// KillSignal is the kill signal to use for the task. This is an optional
 	// specification and defaults to SIGINT
@@ -654,6 +652,7 @@ func (t *SidecarTask) Copy() *SidecarTask {
 	nt.Env = helper.CopyMapStringString(nt.Env)
 
 	nt.Resources = nt.Resources.Copy()
+	nt.LogConfig = nt.LogConfig.Copy()
 	nt.Meta = helper.CopyMapStringString(nt.Meta)
 
 	if i, err := copystructure.Copy(nt.Config); err != nil {
@@ -671,6 +670,8 @@ func (t *SidecarTask) MergeIntoTask(task *Task) {
 		task.Name = t.Name
 	}
 
+	// If the driver changes then the driver config can be overwritten.
+	// Otherwise we'll merge the driver config togethe
 	if t.Driver != "" && t.Driver != task.Driver {
 		task.Driver = t.Driver
 		task.Config = t.Config
@@ -708,8 +709,8 @@ func (t *SidecarTask) MergeIntoTask(task *Task) {
 		}
 	}
 
-	if t.KillTimeout != 0 {
-		task.KillTimeout = t.KillTimeout
+	if t.KillTimeout != nil {
+		task.KillTimeout = *t.KillTimeout
 	}
 
 	if t.LogConfig != nil {
@@ -725,8 +726,8 @@ func (t *SidecarTask) MergeIntoTask(task *Task) {
 		}
 	}
 
-	if t.ShutdownDelay != 0 {
-		task.ShutdownDelay = 0
+	if t.ShutdownDelay != nil {
+		task.ShutdownDelay = *t.ShutdownDelay
 	}
 
 	if t.KillSignal != "" {

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -661,6 +661,14 @@ func (t *SidecarTask) Copy() *SidecarTask {
 		nt.Config = i.(map[string]interface{})
 	}
 
+	if t.KillTimeout != nil {
+		nt.KillTimeout = helper.TimeToPtr(*t.KillTimeout)
+	}
+
+	if t.ShutdownDelay != nil {
+		nt.ShutdownDelay = helper.TimeToPtr(*t.ShutdownDelay)
+	}
+
 	return nt
 }
 
@@ -671,7 +679,7 @@ func (t *SidecarTask) MergeIntoTask(task *Task) {
 	}
 
 	// If the driver changes then the driver config can be overwritten.
-	// Otherwise we'll merge the driver config togethe
+	// Otherwise we'll merge the driver config together
 	if t.Driver != "" && t.Driver != task.Driver {
 		task.Driver = t.Driver
 		task.Config = t.Config

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -601,7 +601,7 @@ func (s *ConsulSidecarService) Equals(o *ConsulSidecarService) bool {
 	return s.Proxy.Equals(o.Proxy)
 }
 
-// SidecarTask represents a subset of Task fields that are able to be overriden
+// SidecarTask represents a subset of Task fields that are able to be overridden
 // from the sidecar_task stanza
 type SidecarTask struct {
 	// Name of the task

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -60,3 +60,43 @@ func TestConsulConnect_CopyEquals(t *testing.T) {
 	o.SidecarService.Proxy.Upstreams = nil
 	require.False(t, c.Equals(o))
 }
+
+func TestSidecarTask_MergeIntoTask(t *testing.T) {
+
+	task := MockJob().TaskGroups[0].Tasks[0]
+	sTask := &SidecarTask{
+		Name:   "sidecar",
+		Driver: "sidecar",
+		Config: map[string]interface{}{
+			"foo": "bar",
+		},
+		Resources: &Resources{
+			CPU:      10000,
+			MemoryMB: 10000,
+		},
+		Env: map[string]string{
+			"sidecar": "proxy",
+		},
+	}
+
+	expected := task.Copy()
+	expected.Name = "sidecar"
+	expected.Driver = "sidecar"
+	expected.Config = map[string]interface{}{
+		"foo": "bar",
+	}
+	expected.Resources.CPU = 10000
+	expected.Resources.MemoryMB = 10000
+	expected.Env["sidecar"] = "proxy"
+
+	sTask.MergeIntoTask(task)
+
+	require.Exactly(t, expected, task)
+
+	sTask.Config["abc"] = 123
+	expected.Config["abc"] = 123
+
+	sTask.MergeIntoTask(task)
+	require.Exactly(t, expected, task)
+
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5107,6 +5107,9 @@ type LogConfig struct {
 }
 
 func (l *LogConfig) Copy() *LogConfig {
+	if l == nil {
+		return nil
+	}
 	return &LogConfig{
 		MaxFiles:      l.MaxFiles,
 		MaxFileSizeMB: l.MaxFileSizeMB,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5106,6 +5106,13 @@ type LogConfig struct {
 	MaxFileSizeMB int
 }
 
+func (l *LogConfig) Copy() *LogConfig {
+	return &LogConfig{
+		MaxFiles:      l.MaxFiles,
+		MaxFileSizeMB: l.MaxFileSizeMB,
+	}
+}
+
 // DefaultLogConfig returns the default LogConfig values.
 func DefaultLogConfig() *LogConfig {
 	return &LogConfig{
@@ -5229,6 +5236,7 @@ func (t *Task) Copy() *Task {
 
 	nt.Vault = nt.Vault.Copy()
 	nt.Resources = nt.Resources.Copy()
+	nt.LogConfig = nt.LogConfig.Copy()
 	nt.Meta = helper.CopyMapStringString(nt.Meta)
 	nt.DispatchPayload = nt.DispatchPayload.Copy()
 


### PR DESCRIPTION
This PR implements basic override functionality of the injected Consul Connect sidecar proxy task. Due to the complexities of merging entire Task structs, a subset of fields have been pulled out into a `SidecarTask` struct which can be merged with a `Task`. Merging of map fields such as `Env` and `Meta` are supported. `Config` will be merged unless `Driver` is changed as well at which point `Config` of the sidecar_task replaces the task's field.

closes #6040 