### PR TITLE
link-local addresses can be fingerprinted

### DIFF
--- a/website/source/docs/configuration/client.html.md
+++ b/website/source/docs/configuration/client.html.md
@@ -64,9 +64,13 @@ driver) but will be removed in a future release.
 - `network_interface` `(string: varied)` - Specifies the name of the interface
   to force network fingerprinting on. When run in dev mode, this defaults to the
   loopback interface. When not in dev mode, the interface attached to the
-  default route is used. All IP addresses except those scoped local for IPV6 on
-  the chosen interface are fingerprinted. The scheduler chooses from those IP
+  default route is used. The scheduler chooses from these fingerprinted IP 
   addresses when allocating ports for tasks.
+
+    Nomad will prefer non-local IP addresses.  If no non-local IP addresses are
+  found, Nomad will fingerprint link-local IPv6 addresses based on the 
+  [`"fingerprint.network.disallow_link_local"`](#quot-fingerprint-network-disallow_link_local-quot-)
+  setting.
 
 - `network_speed` `(int: 0)` - Specifies an override for the network link speed.
   This value, if set, overrides any detected or defaulted link speed. Most

--- a/website/source/docs/configuration/client.html.md
+++ b/website/source/docs/configuration/client.html.md
@@ -67,10 +67,10 @@ driver) but will be removed in a future release.
   default route is used. The scheduler chooses from these fingerprinted IP 
   addresses when allocating ports for tasks.
 
-    Nomad will prefer non-local IP addresses.  If no non-local IP addresses are
-  found, Nomad will fingerprint link-local IPv6 addresses based on the 
-  [`"fingerprint.network.disallow_link_local"`](#quot-fingerprint-network-disallow_link_local-quot-)
-  setting.
+    If no non-local IP addresses are found, Nomad could fingerprint link-local IPv6
+    addresses depending on the client's
+    [`"fingerprint.network.disallow_link_local"`](#quot-fingerprint-network-disallow_link_local-quot-)
+    configuration value.
 
 - `network_speed` `(int: 0)` - Specifies an override for the network link speed.
   This value, if set, overrides any detected or defaulted link speed. Most


### PR DESCRIPTION
Added note to document that link-local addresses can be fingerprinted in
cases where no routable address can be found.  Crosslinked to
`"fingerprint.network.disallow_link_local"` because they are somewhat
related and it is documented at a reasonable distance from this setting.

https://github.com/hashicorp/nomad/blob/83a75b310d60b6e9f3c6ca6d43c0a5ee104ef3fd/client/fingerprint/network.go#L157-L172