### PR TITLE
structs: add taskgroup networks and services to plan diffs

### DIFF
--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2433,6 +2433,451 @@ func TestTaskGroupDiff(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			// TaskGroup Services edited
+			Contextual: true,
+			Old: &TaskGroup{
+				Services: []*Service{
+					{
+						Name: "foo",
+						Checks: []*ServiceCheck{
+							{
+								Name:     "foo",
+								Type:     "http",
+								Command:  "foo",
+								Args:     []string{"foo"},
+								Path:     "foo",
+								Protocol: "http",
+								Interval: 1 * time.Second,
+								Timeout:  1 * time.Second,
+							},
+						},
+						Connect: &ConsulConnect{
+							SidecarTask: &SidecarTask{
+								Name:   "sidecar",
+								Driver: "docker",
+								Env: map[string]string{
+									"FOO": "BAR",
+								},
+								Config: map[string]interface{}{
+									"foo": "baz",
+								},
+							},
+						},
+					},
+				},
+			},
+
+			New: &TaskGroup{
+				Services: []*Service{
+					{
+						Name: "foo",
+						Checks: []*ServiceCheck{
+							{
+								Name:     "foo",
+								Type:     "tcp",
+								Command:  "bar",
+								Path:     "bar",
+								Protocol: "tcp",
+								Interval: 2 * time.Second,
+								Timeout:  2 * time.Second,
+								Header: map[string][]string{
+									"Foo": {"baz"},
+								},
+							},
+						},
+						Connect: &ConsulConnect{
+							SidecarService: &ConsulSidecarService{
+								Port: "http",
+								Proxy: &ConsulProxy{
+									Upstreams: []ConsulUpstream{
+										{
+											DestinationName: "foo",
+											LocalBindPort:   8000,
+										},
+									},
+									Config: map[string]interface{}{
+										"foo": "qux",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Service",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeNone,
+								Name: "AddressMode",
+								Old:  "",
+								New:  "",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Name",
+								Old:  "foo",
+								New:  "foo",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "PortLabel",
+								Old:  "",
+								New:  "",
+							},
+						},
+						Objects: []*ObjectDiff{
+
+							{
+								Type: DiffTypeEdited,
+								Name: "Check",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeNone,
+										Name: "AddressMode",
+										Old:  "",
+										New:  "",
+									},
+									{
+										Type: DiffTypeEdited,
+										Name: "Command",
+										Old:  "foo",
+										New:  "bar",
+									},
+									{
+										Type: DiffTypeNone,
+										Name: "GRPCService",
+										Old:  "",
+										New:  "",
+									},
+									{
+										Type: DiffTypeNone,
+										Name: "GRPCUseTLS",
+										Old:  "false",
+										New:  "false",
+									},
+									{
+										Type: DiffTypeNone,
+										Name: "InitialStatus",
+										Old:  "",
+										New:  "",
+									},
+									{
+										Type: DiffTypeEdited,
+										Name: "Interval",
+										Old:  "1000000000",
+										New:  "2000000000",
+									},
+									{
+										Type: DiffTypeNone,
+										Name: "Method",
+										Old:  "",
+										New:  "",
+									},
+									{
+										Type: DiffTypeNone,
+										Name: "Name",
+										Old:  "foo",
+										New:  "foo",
+									},
+									{
+										Type: DiffTypeEdited,
+										Name: "Path",
+										Old:  "foo",
+										New:  "bar",
+									},
+									{
+										Type: DiffTypeNone,
+										Name: "PortLabel",
+										Old:  "",
+										New:  "",
+									},
+									{
+										Type: DiffTypeEdited,
+										Name: "Protocol",
+										Old:  "http",
+										New:  "tcp",
+									},
+									{
+										Type: DiffTypeNone,
+										Name: "TLSSkipVerify",
+										Old:  "false",
+										New:  "false",
+									},
+									{
+										Type: DiffTypeNone,
+										Name: "TaskName",
+										Old:  "",
+										New:  "",
+									},
+									{
+										Type: DiffTypeEdited,
+										Name: "Timeout",
+										Old:  "1000000000",
+										New:  "2000000000",
+									},
+									{
+										Type: DiffTypeEdited,
+										Name: "Type",
+										Old:  "http",
+										New:  "tcp",
+									},
+								},
+								Objects: []*ObjectDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "Header",
+										Fields: []*FieldDiff{
+											{
+												Type: DiffTypeAdded,
+												Name: "Foo[0]",
+												Old:  "",
+												New:  "baz",
+											},
+										},
+									},
+								},
+							},
+
+							{
+								Type: DiffTypeEdited,
+								Name: "ConsulConnect",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeNone,
+										Name: "Native",
+										Old:  "false",
+										New:  "false",
+									},
+								},
+								Objects: []*ObjectDiff{
+
+									{
+										Type: DiffTypeAdded,
+										Name: "SidecarService",
+										Fields: []*FieldDiff{
+											{
+												Type: DiffTypeAdded,
+												Name: "Port",
+												Old:  "",
+												New:  "http",
+											},
+										},
+										Objects: []*ObjectDiff{
+											{
+												Type: DiffTypeAdded,
+												Name: "ConsulProxy",
+												Objects: []*ObjectDiff{
+													{
+														Type: DiffTypeAdded,
+														Name: "ConsulUpstreams",
+														Fields: []*FieldDiff{
+															{
+																Type: DiffTypeAdded,
+																Name: "DestinationName",
+																Old:  "",
+																New:  "foo",
+															},
+															{
+																Type: DiffTypeAdded,
+																Name: "LocalBindPort",
+																Old:  "",
+																New:  "8000",
+															},
+														},
+													},
+													{
+														Type: DiffTypeAdded,
+														Name: "Config",
+														Fields: []*FieldDiff{
+															{
+																Type: DiffTypeAdded,
+																Name: "foo",
+																Old:  "",
+																New:  "qux",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										Type: DiffTypeDeleted,
+										Name: "SidecarTask",
+										Fields: []*FieldDiff{
+											{
+												Type: DiffTypeDeleted,
+												Name: "Driver",
+												Old:  "docker",
+												New:  "",
+											},
+											{
+												Type: DiffTypeDeleted,
+												Name: "Env[FOO]",
+												Old:  "BAR",
+												New:  "",
+											},
+											{
+												Type: DiffTypeDeleted,
+												Name: "Name",
+												Old:  "sidecar",
+												New:  "",
+											},
+										},
+										Objects: []*ObjectDiff{
+											{
+												Type: DiffTypeDeleted,
+												Name: "Config",
+												Fields: []*FieldDiff{
+													{
+														Type: DiffTypeDeleted,
+														Name: "foo",
+														Old:  "baz",
+														New:  "",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// TaskGroup Networks edited
+			Contextual: true,
+			Old: &TaskGroup{
+				Networks: Networks{
+					{
+						Device: "foo",
+						CIDR:   "foo",
+						IP:     "foo",
+						MBits:  100,
+						ReservedPorts: []Port{
+							{
+								Label: "foo",
+								Value: 80,
+							},
+						},
+					},
+				},
+			},
+			New: &TaskGroup{
+				Networks: Networks{
+					{
+						Device: "bar",
+						CIDR:   "bar",
+						IP:     "bar",
+						MBits:  200,
+						DynamicPorts: []Port{
+							{
+								Label: "bar",
+								To:    8081,
+							},
+						},
+					},
+				},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Network",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "MBits",
+								Old:  "",
+								New:  "200",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Mode",
+								Old:  "",
+								New:  "",
+							},
+						},
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "Dynamic Port",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "Label",
+										Old:  "",
+										New:  "bar",
+									},
+									{
+										Type: DiffTypeAdded,
+										Name: "To",
+										Old:  "",
+										New:  "8081",
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: DiffTypeDeleted,
+						Name: "Network",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "MBits",
+								Old:  "100",
+								New:  "",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Mode",
+								Old:  "",
+								New:  "",
+							},
+						},
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "Static Port",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeDeleted,
+										Name: "Label",
+										Old:  "foo",
+										New:  "",
+									},
+									{
+										Type: DiffTypeDeleted,
+										Name: "To",
+										Old:  "0",
+										New:  "",
+									},
+									{
+										Type: DiffTypeDeleted,
+										Name: "Value",
+										Old:  "80",
+										New:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		{
 			// Tasks edited
 			Old: &TaskGroup{
@@ -4158,6 +4603,57 @@ func TestTaskDiff(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			Name: "Service with Connect",
+			Old: &Task{
+				Services: []*Service{
+					{
+						Name: "foo",
+					},
+				},
+			},
+			New: &Task{
+				Services: []*Service{
+					{
+						Name: "foo",
+						Connect: &ConsulConnect{
+							SidecarService: &ConsulSidecarService{},
+						},
+					},
+				},
+			},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Service",
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "ConsulConnect",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "Native",
+										Old:  "",
+										New:  "false",
+									},
+								},
+								Objects: []*ObjectDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "SidecarService",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
 		{
 			Name: "Service Checks edited",
 			Old: &Task{


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/6139

Adds a check for differences in `job.Diff` so that task group networks and services show up in the job plan outputs.

---

In addition to the unit test cases, I tested this by running a dev build on this branch and planning the Consul connect demo (the output of `nomad init -connect -short`) with `nomad plan -verbose`.

<details><summary>Plan output</summary>

```
+ Job: "countdash"
+ AllAtOnce:  "false"
+ Dispatched: "false"
+ Name:       "countdash"
+ Namespace:  "default"
+ Priority:   "50"
+ Region:     "global"
+ Stop:       "false"
+ Type:       "service"
+ Datacenters {
  + Datacenters: "dc1"
  }
+ Task Group: "api" (1 create)
  + Count: "1" (forces create)
  + RestartPolicy {
    + Attempts: "2"
    + Delay:    "15000000000"
    + Interval: "1800000000000"
    + Mode:     "fail"
    }
  + ReschedulePolicy {
    + Attempts:      "0"
    + Delay:         "30000000000"
    + DelayFunction: "exponential"
    + Interval:      "0"
    + MaxDelay:      "3600000000000"
    + Unlimited:     "true"
    }
  + EphemeralDisk {
    + Migrate: "false"
    + SizeMB:  "300"
    + Sticky:  "false"
    }
  + Network {
    + MBits: "10"
    + Mode:  "bridge"
    + Dynamic Port {
      + Label: "connect-proxy-count-api"
      + To:    "-1"
      }
    }
  + Service {
    + AddressMode: "auto"
    + Name:        "count-api"
    + PortLabel:   "9001"
    }
  + Task: "connect-proxy-count-api" (forces create)
    + Driver:        "docker"
    + KillTimeout:   "5000000000"
    + Kind:          "connect-proxy:count-api"
    + Leader:        "false"
    + ShutdownDelay: "5000000000"
    + Constraint {
      + LTarget: "${attr.consul.version}"
      + Operand: "version"
      + RTarget: ">= 1.6.0beta1"
      }
    + Config {
      + args[0]: "-c"
      + args[1]: "${NOMAD_TASK_DIR}/bootstrap.json"
      + args[2]: "-l"
      + args[3]: "${meta.connect.log_level}"
      + image:   "${meta.connect.sidecar_image}"
      }
    + Resources {
      + CPU:      "250"
      + DiskMB:   "0"
      + IOPS:     "0"
      + MemoryMB: "128"
      }
    + LogConfig {
      + MaxFileSizeMB: "2"
      + MaxFiles:      "2"
      }
  + Task: "web" (forces create)
    + Driver:        "docker"
    + KillTimeout:   "5000000000"
    + Leader:        "false"
    + ShutdownDelay: "0"
    + Config {
      + image: "hashicorpnomad/counter-api:v1"
      }
    + Resources {
      + CPU:      "100"
      + DiskMB:   "0"
      + IOPS:     "0"
      + MemoryMB: "300"
      }
    + LogConfig {
      + MaxFileSizeMB: "10"
      + MaxFiles:      "10"
      }

+ Task Group: "dashboard" (1 create)
  + Count: "1" (forces create)
  + RestartPolicy {
    + Attempts: "2"
    + Delay:    "15000000000"
    + Interval: "1800000000000"
    + Mode:     "fail"
    }
  + ReschedulePolicy {
    + Attempts:      "0"
    + Delay:         "30000000000"
    + DelayFunction: "exponential"
    + Interval:      "0"
    + MaxDelay:      "3600000000000"
    + Unlimited:     "true"
    }
  + EphemeralDisk {
    + Migrate: "false"
    + SizeMB:  "300"
    + Sticky:  "false"
    }
  + Network {
    + MBits: "10"
    + Mode:  "bridge"
    + Static Port {
      + Label: "http"
      + To:    "9002"
      + Value: "9002"
      }
    + Dynamic Port {
      + Label: "connect-proxy-count-dashboard"
      + To:    "-1"
      }
    }
  + Service {
    + AddressMode: "auto"
    + Name:        "count-dashboard"
    + PortLabel:   "9002"
    }
  + Task: "connect-proxy-count-dashboard" (forces create)
    + Driver:        "docker"
    + KillTimeout:   "5000000000"
    + Kind:          "connect-proxy:count-dashboard"
    + Leader:        "false"
    + ShutdownDelay: "5000000000"
    + Constraint {
      + LTarget: "${attr.consul.version}"
      + Operand: "version"
      + RTarget: ">= 1.6.0beta1"
      }
    + Config {
      + args[0]: "-c"
      + args[1]: "${NOMAD_TASK_DIR}/bootstrap.json"
      + args[2]: "-l"
      + args[3]: "${meta.connect.log_level}"
      + image:   "${meta.connect.sidecar_image}"
      }
    + Resources {
      + CPU:      "250"
      + DiskMB:   "0"
      + IOPS:     "0"
      + MemoryMB: "128"
      }
    + LogConfig {
      + MaxFileSizeMB: "2"
      + MaxFiles:      "2"
      }
  + Task: "dashboard" (forces create)
    + Driver:                    "docker"
    + Env[COUNTING_SERVICE_URL]: "http://${NOMAD_UPSTREAM_ADDR_count_api}"
    + KillTimeout:               "5000000000"
    + Leader:                    "false"
    + ShutdownDelay:             "0"
    + Config {
      + image: "hashicorpnomad/counter-dashboard:v1"
      }
    + Resources {
      + CPU:      "100"
      + DiskMB:   "0"
      + IOPS:     "0"
      + MemoryMB: "300"
      }
    + LogConfig {
      + MaxFileSizeMB: "10"
      + MaxFiles:      "10"
      }

Scheduler dry-run:
- WARNING: Failed to place all allocations.
  Task Group "api" (failed to place 1 allocation):
    * Constraint "${attr.consul.version} version >= 1.6.0beta1" filtered 1 nodes

  Task Group "dashboard" (failed to place 1 allocation):
    * Constraint "${attr.consul.version} version >= 1.6.0beta1" filtered 1 nodes

Job Modify Index: 0
To submit the job with version verification run:

nomad job run -check-index 0 /Users/tim/tmp/connect.nomad

When running the job with the check-index flag, the job will only be run if the
server side version matches the job modify index returned. If the index has
changed, another user has modified the job and the plan's results are
potentially invalid.
```

</details>
