### PR TITLE
test: require root for linux devmode test

### DIFF
--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/lib/freeport"
+	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -642,6 +643,7 @@ func TestConfig_DevModeFlag(t *testing.T) {
 		}
 	}
 	if runtime.GOOS == "linux" {
+		testutil.RequireRoot(t)
 		cases = []struct {
 			flag        string
 			expected    *devModeConfig


### PR DESCRIPTION
@schmichael pointed out that we need to add `testutil.RequireRoot(t)` to tests that require root to avoid failures like this when running tests locally, which was resulting in the following error when running unit tests under Linux w/o root:

```
config_test.go:661: unexpected error: -dev=connect uses network namespaces and is only supported for root.
```

---

After the fix, testing on Linux w/o root:
```
vagrant@linux:/opt/gopath/src/github.com/hashicorp/nomad$ go test -v ./command/agent -run TestConfig_DevModeFlag
=== RUN   TestConfig_DevModeFlag
--- SKIP: TestConfig_DevModeFlag (0.00s)
    driver_compatible.go:16: Must run as root on Unix
PASS
ok      github.com/hashicorp/nomad/command/agent        0.064s
```

vs macOS:
```
 go test -v ./command/agent -run TestConfig_DevModeFlag
=== RUN   TestConfig_DevModeFlag
=== RUN   TestConfig_DevModeFlag/#00
=== RUN   TestConfig_DevModeFlag/true
=== RUN   TestConfig_DevModeFlag/true,connect
=== RUN   TestConfig_DevModeFlag/connect
=== RUN   TestConfig_DevModeFlag/xxx
--- PASS: TestConfig_DevModeFlag (0.00s)
    --- PASS: TestConfig_DevModeFlag/#00 (0.00s)
    --- PASS: TestConfig_DevModeFlag/true (0.00s)
    --- PASS: TestConfig_DevModeFlag/true,connect (0.00s)
    --- PASS: TestConfig_DevModeFlag/connect (0.00s)
    --- PASS: TestConfig_DevModeFlag/xxx (0.00s)
PASS
ok      github.com/hashicorp/nomad/command/agent        0.710s
```