### PR TITLE
add node.region to interpolation documentation

### DIFF
--- a/website/source/docs/runtime/interpolation.html.md.erb
+++ b/website/source/docs/runtime/interpolation.html.md.erb
@@ -77,6 +77,11 @@ driver.
     <td><tt>9afa5da1-8f39-25a2-48dc-ba31fd7c0023</tt></td>
   </tr>
   <tr>
+    <td><tt>${node.region}</tt></td>
+    <td>Client's region</td>
+    <td><tt>global</tt></td>
+  </tr>
+  <tr>
     <td><tt>${node.datacenter}</tt></td>
     <td>Client's datacenter</td>
     <td><tt>dc1</tt></td>


### PR DESCRIPTION
`node.region` is available for interpolation, but not documented. this PR adds it to the documentation at https://www.nomadproject.io/docs/runtime/interpolation.html#node-variables-

this is related to #6164