### PR TITLE
structs: validate no tcp checks for connect services

### DIFF
--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -407,6 +407,14 @@ func (s *Service) Validate() error {
 			continue
 		}
 
+		// TCP checks against a Consul Connect enabled service are not supported
+		// due to the service being bound to the loopback interface inside the
+		// network namespace
+		if c.Type == ServiceCheckTCP && s.Connect != nil && s.Connect.SidecarService != nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Check %s invalid: tcp checks are not valid for Connect enabled services", c.Name))
+			continue
+		}
+
 		if err := c.validate(); err != nil {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Check %s invalid: %v", c.Name, err))
 		}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2373,6 +2373,22 @@ func TestInvalidServiceCheck(t *testing.T) {
 	if err := s.Validate(); err != nil {
 		t.Fatalf("un-expected error: %v", err)
 	}
+
+	s = Service{
+		Name: "service-name",
+		Checks: []*ServiceCheck{
+			{
+				Name:     "tcp-check",
+				Type:     ServiceCheckTCP,
+				Interval: 5 * time.Second,
+				Timeout:  2 * time.Second,
+			},
+		},
+		Connect: &ConsulConnect{
+			SidecarService: &ConsulSidecarService{},
+		},
+	}
+	require.Error(t, s.Validate())
 }
 
 func TestDistinctCheckID(t *testing.T) {


### PR DESCRIPTION
Adds a validation that checks for tcp checks with a connect sidecar service configured

fixes #6141 