### PR TITLE
remove networking from `job init --short` example jobspec

### DIFF
--- a/command/assets/example-short.nomad
+++ b/command/assets/example-short.nomad
@@ -16,24 +16,6 @@ job "example" {
       resources {
         cpu    = 500
         memory = 256
-
-        network {
-          mbits = 10
-          port  "db"  {}
-        }
-      }
-
-      service {
-        name = "redis-cache"
-        tags = ["global", "cache"]
-        port = "db"
-
-        check {
-          name     = "alive"
-          type     = "tcp"
-          interval = "10s"
-          timeout  = "2s"
-        }
       }
     }
   }


### PR DESCRIPTION
It seems standard to remove the networking component from the example jobspec that is produced by `job init --short`. This is an attempt to clean it up for the bare minimum for development.