### PR TITLE
Fine grained ACLs for Host Volumes

### DIFF
--- a/acl/policy.go
+++ b/acl/policy.go
@@ -45,8 +45,9 @@ const (
 	// combined we take the union of all capabilities. If the deny capability is present, it
 	// takes precedence and overwrites all other capabilities.
 
-	HostVolumeCapabilityDeny  = "deny"
-	HostVolumeCapabilityMount = "mount"
+	HostVolumeCapabilityDeny           = "deny"
+	HostVolumeCapabilityMountReadOnly  = "mount-readonly"
+	HostVolumeCapabilityMountReadWrite = "mount-readwrite"
 )
 
 var (
@@ -160,7 +161,7 @@ func expandNamespacePolicy(policy string) []string {
 
 func isHostVolumeCapabilityValid(cap string) bool {
 	switch cap {
-	case HostVolumeCapabilityDeny, HostVolumeCapabilityMount:
+	case HostVolumeCapabilityDeny, HostVolumeCapabilityMountReadOnly, HostVolumeCapabilityMountReadWrite:
 		return true
 	default:
 		return false
@@ -172,9 +173,9 @@ func expandHostVolumePolicy(policy string) []string {
 	case PolicyDeny:
 		return []string{HostVolumeCapabilityDeny}
 	case PolicyRead:
-		return []string{HostVolumeCapabilityDeny}
+		return []string{HostVolumeCapabilityMountReadOnly}
 	case PolicyWrite:
-		return []string{HostVolumeCapabilityMount}
+		return []string{HostVolumeCapabilityMountReadOnly, HostVolumeCapabilityMountReadWrite}
 	default:
 		return nil
 	}

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -202,7 +202,7 @@ func TestParse(t *testing.T) {
 		{
 			`
 			host_volume "production-tls-*" {
-				capabilities = ["mount"]
+				capabilities = ["mount-readonly"]
 			}
 			`,
 			"",
@@ -212,7 +212,26 @@ func TestParse(t *testing.T) {
 						Name:   "production-tls-*",
 						Policy: "",
 						Capabilities: []string{
-							HostVolumeCapabilityMount,
+							HostVolumeCapabilityMountReadOnly,
+						},
+					},
+				},
+			},
+		},
+		{
+			`
+			host_volume "production-tls-*" {
+				capabilities = ["mount-readwrite"]
+			}
+			`,
+			"",
+			&Policy{
+				HostVolumes: []*HostVolumePolicy{
+					{
+						Name:   "production-tls-*",
+						Policy: "",
+						Capabilities: []string{
+							HostVolumeCapabilityMountReadWrite,
 						},
 					},
 				},
@@ -221,7 +240,7 @@ func TestParse(t *testing.T) {
 		{
 			`
 			host_volume "volume has a space" {
-				capabilities = ["mount"]
+				capabilities = ["mount-readwrite"]
 			}
 			`,
 			"Invalid host volume name",


### PR DESCRIPTION
This PR breaks the mount ACL for Host Volumes into 2 acls, ReadWrite,
and ReadOnly.

The ReadOnly ACL will allow the user to mount a volume only when the
group level volume request explicitly requires a ReadOnly volume.

The ReadWrite ACL will all the user to mount volumes as both ReadOnly
and ReadWrite.