### PR TITLE
clientconfig: Fix parsing multiple host volumes

### DIFF
--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -141,6 +141,7 @@ func extraKeys(c *Config) error {
 	// Remove HostVolume extra keys
 	for _, hv := range c.Client.HostVolumes {
 		removeEqualFold(&c.Client.ExtraKeysHCL, hv.Name)
+		removeEqualFold(&c.Client.ExtraKeysHCL, "host_volume")
 	}
 
 	for _, k := range []string{"enabled_schedulers", "start_join", "retry_join", "server_join"} {


### PR DESCRIPTION
I'm not sure why this fixes the problem, but it does fix a problem that was blocking multiple host_volume parses. It's cloned from the way plugin parsing works.