### PR TITLE
api: Fix definition of HostVolumeInfo

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -438,7 +438,7 @@ type DriverInfo struct {
 
 // HostVolumeInfo is used to return metadata about a given HostVolume.
 type HostVolumeInfo struct {
-	Source   string
+	Path     string
 	ReadOnly bool
 	Hidden   bool
 }

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -490,7 +490,7 @@ func (c *NodeStatusCommand) outputNodeVolumeInfo(node *api.Node) {
 
 	for _, volName := range names {
 		info := node.HostVolumes[volName]
-		output = append(output, fmt.Sprintf("%s|%v|%v|%s", volName, info.ReadOnly, info.Hidden, info.Source))
+		output = append(output, fmt.Sprintf("%s|%v|%v|%s", volName, info.ReadOnly, info.Hidden, info.Path))
 	}
 	c.Ui.Output(formatList(output))
 }


### PR DESCRIPTION
When I renamed Source -> Path for HostVolumeConfiguration, I missed also
updating the API package. This fixes that.