### PR TITLE
ci: Use more recent base machine executor image for test-rkt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,13 @@ executors:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     machine: true # TODO: Find latest docker image id
 
+  # uses a more recent image with unattended upgrades disabled properly
+  # but seems to break docker builds
+  go-machine-recent:
+    working_directory: ~/go/src/github.com/hashicorp/nomad
+    machine:
+      image: ubuntu-1604:201903-01
+
 jobs:
   build-deps-image:
     executor: docker-builder
@@ -103,7 +110,7 @@ jobs:
           path: /tmp/test-reports
 
   test-rkt:
-    executor: go-machine
+    executor: go-machine-recent
     environment:
       <<: *COMMON_ENVS
       GOTEST_PKGS: "./drivers/rkt"


### PR DESCRIPTION
This fixes a frequent failure in `test-rkt` jobs where dpkg installation
fails.

The image used currently, circleci/classic:201808-01, has unattended
upgrades enabled accidentally, which runs on every build.  This means
that tools get modified unexpectedly during builds, and apt-get commands
may fail as the unattended upgrade is holding package database lock.

This updates `test-rkt` job only because the new image breaks
`test-docker` job (e.g. https://circleci.com/gh/hashicorp/nomad/2641 ),
and I punted on investigating test-docker for another day.