### PR TITLE
cli: display group ports and address in alloc status command output

### DIFF
--- a/api/resources.go
+++ b/api/resources.go
@@ -99,13 +99,20 @@ type NetworkResource struct {
 	MBits         *int
 	ReservedPorts []Port
 	DynamicPorts  []Port
-	Services      []*Service
 }
 
 func (n *NetworkResource) Canonicalize() {
 	if n.MBits == nil {
 		n.MBits = intToPtr(10)
 	}
+}
+
+func (n *NetworkResource) HasPorts() bool {
+	if n == nil {
+		return false
+	}
+
+	return len(n.ReservedPorts)+len(n.DynamicPorts) > 0
 }
 
 // NodeDeviceResource captures a set of devices sharing a common

--- a/nomad/structs/network.go
+++ b/nomad/structs/network.go
@@ -286,6 +286,7 @@ func (idx *NetworkIndex) AssignNetwork(ask *NetworkResource) (out *NetworkResour
 
 		// Create the offer
 		offer := &NetworkResource{
+			Mode:          ask.Mode,
 			Device:        n.Device,
 			IP:            ipStr,
 			MBits:         ask.MBits,
@@ -312,6 +313,12 @@ func (idx *NetworkIndex) AssignNetwork(ask *NetworkResource) (out *NetworkResour
 	BUILD_OFFER:
 		for i, port := range dynPorts {
 			offer.DynamicPorts[i].Value = port
+
+			// This syntax allows you to set the mapped to port to the same port
+			// allocated by the scheduler on the host.
+			if offer.DynamicPorts[i].To == -1 {
+				offer.DynamicPorts[i].To = port
+			}
 		}
 
 		// Stop, we have an offer!


### PR DESCRIPTION
Adds a table of group ports and addressing with port mapping if set. The table is only shown if a group network is defined and atleast one port exists.

fixes #6188 

Ex.
![image](https://dl.nick.sh/screenshots/2019-08-22-11-54-08_558x515.png)
