### PR TITLE
ar: fix bridge networking port mapping when port.To is unset

### DIFF
--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -101,6 +101,9 @@ func getPortMapping(alloc *structs.Allocation) []*portMapping {
 	ports := []*portMapping{}
 	for _, network := range alloc.AllocatedResources.Shared.Networks {
 		for _, port := range append(network.DynamicPorts, network.ReservedPorts...) {
+			if port.To < 1 {
+				continue
+			}
 			for _, proto := range []string{"tcp", "udp"} {
 				ports = append(ports, &portMapping{
 					Host:      port.Value,


### PR DESCRIPTION
Fixes a bug where the ar network hook would fail if a port without `To` was defined.