### PR TITLE
add default update stanza and max_parallel=0 disables deployments

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -751,6 +751,8 @@ func (j *Job) Canonicalize() {
 	}
 	if j.Update != nil {
 		j.Update.Canonicalize()
+	} else if *j.Type == JobTypeService {
+		j.Update = DefaultUpdateStrategy()
 	}
 
 	for _, tg := range j.TaskGroups {

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -108,6 +108,17 @@ func TestJobs_Canonicalize(t *testing.T) {
 				CreateIndex:       uint64ToPtr(0),
 				ModifyIndex:       uint64ToPtr(0),
 				JobModifyIndex:    uint64ToPtr(0),
+				Update: &UpdateStrategy{
+					Stagger:          timeToPtr(30 * time.Second),
+					MaxParallel:      intToPtr(1),
+					HealthCheck:      stringToPtr("checks"),
+					MinHealthyTime:   timeToPtr(10 * time.Second),
+					HealthyDeadline:  timeToPtr(5 * time.Minute),
+					ProgressDeadline: timeToPtr(10 * time.Minute),
+					AutoRevert:       boolToPtr(false),
+					Canary:           intToPtr(0),
+					AutoPromote:      boolToPtr(false),
+				},
 				TaskGroups: []*TaskGroup{
 					{
 						Name:  stringToPtr(""),
@@ -130,6 +141,17 @@ func TestJobs_Canonicalize(t *testing.T) {
 							Delay:         timeToPtr(30 * time.Second),
 							MaxDelay:      timeToPtr(1 * time.Hour),
 							Unlimited:     boolToPtr(true),
+						},
+						Update: &UpdateStrategy{
+							Stagger:          timeToPtr(30 * time.Second),
+							MaxParallel:      intToPtr(1),
+							HealthCheck:      stringToPtr("checks"),
+							MinHealthyTime:   timeToPtr(10 * time.Second),
+							HealthyDeadline:  timeToPtr(5 * time.Minute),
+							ProgressDeadline: timeToPtr(10 * time.Minute),
+							AutoRevert:       boolToPtr(false),
+							Canary:           intToPtr(0),
+							AutoPromote:      boolToPtr(false),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
@@ -179,6 +201,17 @@ func TestJobs_Canonicalize(t *testing.T) {
 				CreateIndex:       uint64ToPtr(0),
 				ModifyIndex:       uint64ToPtr(0),
 				JobModifyIndex:    uint64ToPtr(0),
+				Update: &UpdateStrategy{
+					Stagger:          timeToPtr(30 * time.Second),
+					MaxParallel:      intToPtr(1),
+					HealthCheck:      stringToPtr("checks"),
+					MinHealthyTime:   timeToPtr(10 * time.Second),
+					HealthyDeadline:  timeToPtr(5 * time.Minute),
+					ProgressDeadline: timeToPtr(10 * time.Minute),
+					AutoRevert:       boolToPtr(false),
+					Canary:           intToPtr(0),
+					AutoPromote:      boolToPtr(false),
+				},
 				TaskGroups: []*TaskGroup{
 					{
 						Name:  stringToPtr("bar"),
@@ -201,6 +234,17 @@ func TestJobs_Canonicalize(t *testing.T) {
 							Delay:         timeToPtr(30 * time.Second),
 							MaxDelay:      timeToPtr(1 * time.Hour),
 							Unlimited:     boolToPtr(true),
+						},
+						Update: &UpdateStrategy{
+							Stagger:          timeToPtr(30 * time.Second),
+							MaxParallel:      intToPtr(1),
+							HealthCheck:      stringToPtr("checks"),
+							MinHealthyTime:   timeToPtr(10 * time.Second),
+							HealthyDeadline:  timeToPtr(5 * time.Minute),
+							ProgressDeadline: timeToPtr(10 * time.Minute),
+							AutoRevert:       boolToPtr(false),
+							Canary:           intToPtr(0),
+							AutoPromote:      boolToPtr(false),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -166,6 +166,70 @@ func TestJobs_Canonicalize(t *testing.T) {
 			},
 		},
 		{
+			name: "batch",
+			input: &Job{
+				Type: stringToPtr("batch"),
+				TaskGroups: []*TaskGroup{
+					{
+						Tasks: []*Task{
+							{},
+						},
+					},
+				},
+			},
+			expected: &Job{
+				ID:                stringToPtr(""),
+				Name:              stringToPtr(""),
+				Region:            stringToPtr("global"),
+				Namespace:         stringToPtr(DefaultNamespace),
+				Type:              stringToPtr("batch"),
+				ParentID:          stringToPtr(""),
+				Priority:          intToPtr(50),
+				AllAtOnce:         boolToPtr(false),
+				VaultToken:        stringToPtr(""),
+				Status:            stringToPtr(""),
+				StatusDescription: stringToPtr(""),
+				Stop:              boolToPtr(false),
+				Stable:            boolToPtr(false),
+				Version:           uint64ToPtr(0),
+				CreateIndex:       uint64ToPtr(0),
+				ModifyIndex:       uint64ToPtr(0),
+				JobModifyIndex:    uint64ToPtr(0),
+				TaskGroups: []*TaskGroup{
+					{
+						Name:  stringToPtr(""),
+						Count: intToPtr(1),
+						EphemeralDisk: &EphemeralDisk{
+							Sticky:  boolToPtr(false),
+							Migrate: boolToPtr(false),
+							SizeMB:  intToPtr(300),
+						},
+						RestartPolicy: &RestartPolicy{
+							Delay:    timeToPtr(15 * time.Second),
+							Attempts: intToPtr(3),
+							Interval: timeToPtr(24 * time.Hour),
+							Mode:     stringToPtr("fail"),
+						},
+						ReschedulePolicy: &ReschedulePolicy{
+							Attempts:      intToPtr(1),
+							Interval:      timeToPtr(24 * time.Hour),
+							DelayFunction: stringToPtr("constant"),
+							Delay:         timeToPtr(5 * time.Second),
+							MaxDelay:      timeToPtr(0),
+							Unlimited:     boolToPtr(false),
+						},
+						Tasks: []*Task{
+							{
+								KillTimeout: timeToPtr(5 * time.Second),
+								LogConfig:   DefaultLogConfig(),
+								Resources:   DefaultResources(),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "partial",
 			input: &Job{
 				Name:      stringToPtr("foo"),
@@ -511,6 +575,17 @@ func TestJobs_Canonicalize(t *testing.T) {
 				CreateIndex:       uint64ToPtr(0),
 				ModifyIndex:       uint64ToPtr(0),
 				JobModifyIndex:    uint64ToPtr(0),
+				Update: &UpdateStrategy{
+					Stagger:          timeToPtr(30 * time.Second),
+					MaxParallel:      intToPtr(1),
+					HealthCheck:      stringToPtr("checks"),
+					MinHealthyTime:   timeToPtr(10 * time.Second),
+					HealthyDeadline:  timeToPtr(5 * time.Minute),
+					ProgressDeadline: timeToPtr(10 * time.Minute),
+					AutoRevert:       boolToPtr(false),
+					Canary:           intToPtr(0),
+					AutoPromote:      boolToPtr(false),
+				},
 				Periodic: &PeriodicConfig{
 					Enabled:         boolToPtr(true),
 					Spec:            stringToPtr(""),

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -438,6 +438,8 @@ func (g *TaskGroup) Canonicalize(job *Job) {
 
 	if g.Update != nil {
 		g.Update.Canonicalize()
+	} else if *job.Type == "service" {
+		g.Update = DefaultUpdateStrategy()
 	}
 
 	// Merge the reschedule policy from the job

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -438,8 +438,6 @@ func (g *TaskGroup) Canonicalize(job *Job) {
 
 	if g.Update != nil {
 		g.Update.Canonicalize()
-	} else if *job.Type == "service" {
-		g.Update = DefaultUpdateStrategy()
 	}
 
 	// Merge the reschedule policy from the job

--- a/client/allocrunner/health_hook.go
+++ b/client/allocrunner/health_hook.go
@@ -117,7 +117,7 @@ func (h *allocHealthWatcherHook) init() error {
 
 	// No need to watch allocs for deployments that rely on operators
 	// manually setting health
-	if h.isDeploy && (tg.Update == nil || tg.Update.HealthCheck == structs.UpdateStrategyHealthCheck_Manual) {
+	if h.isDeploy && (tg.Update.IsEmpty() || tg.Update.HealthCheck == structs.UpdateStrategyHealthCheck_Manual) {
 		return nil
 	}
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -641,7 +641,7 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 	// Update has been pushed into the task groups. stagger and max_parallel are
 	// preserved at the job level, but all other values are discarded. The job.Update
 	// api value is merged into TaskGroups already in api.Canonicalize
-	if job.Update != nil {
+	if job.Update != nil && job.Update.MaxParallel != nil && *job.Update.MaxParallel > 0 {
 		j.Update = structs.UpdateStrategy{}
 
 		if job.Update.Stagger != nil {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3970,7 +3970,7 @@ func (u *UpdateStrategy) Validate() error {
 	}
 
 	if u.MaxParallel < 0 {
-		multierror.Append(&mErr, fmt.Errorf("Max parallel can not be less than zero: %d < 1", u.MaxParallel))
+		multierror.Append(&mErr, fmt.Errorf("Max parallel can not be less than zero: %d < 0", u.MaxParallel))
 	}
 	if u.Canary < 0 {
 		multierror.Append(&mErr, fmt.Errorf("Canary count can not be less than zero: %d < 0", u.Canary))

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3640,7 +3640,7 @@ func (j *Job) Stopped() bool {
 // HasUpdateStrategy returns if any task group in the job has an update strategy
 func (j *Job) HasUpdateStrategy() bool {
 	for _, tg := range j.TaskGroups {
-		if tg.Update != nil {
+		if !tg.Update.IsEmpty() {
 			return true
 		}
 	}
@@ -3998,6 +3998,14 @@ func (u *UpdateStrategy) Validate() error {
 	}
 
 	return mErr.ErrorOrNil()
+}
+
+func (u *UpdateStrategy) IsEmpty() bool {
+	if u == nil {
+		return true
+	}
+
+	return u.MaxParallel == 0
 }
 
 // TODO(alexdadgar): Remove once no longer used by the scheduler.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3969,8 +3969,8 @@ func (u *UpdateStrategy) Validate() error {
 		multierror.Append(&mErr, fmt.Errorf("Invalid health check given: %q", u.HealthCheck))
 	}
 
-	if u.MaxParallel < 1 {
-		multierror.Append(&mErr, fmt.Errorf("Max parallel can not be less than one: %d < 1", u.MaxParallel))
+	if u.MaxParallel < 0 {
+		multierror.Append(&mErr, fmt.Errorf("Max parallel can not be less than zero: %d < 1", u.MaxParallel))
 	}
 	if u.Canary < 0 {
 		multierror.Append(&mErr, fmt.Errorf("Canary count can not be less than zero: %d < 0", u.Canary))

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1995,7 +1995,7 @@ func TestAffinity_Validate(t *testing.T) {
 
 func TestUpdateStrategy_Validate(t *testing.T) {
 	u := &UpdateStrategy{
-		MaxParallel:      0,
+		MaxParallel:      -1,
 		HealthCheck:      "foo",
 		MinHealthyTime:   -10,
 		HealthyDeadline:  -15,
@@ -2009,7 +2009,7 @@ func TestUpdateStrategy_Validate(t *testing.T) {
 	if !strings.Contains(mErr.Errors[0].Error(), "Invalid health check given") {
 		t.Fatalf("err: %s", err)
 	}
-	if !strings.Contains(mErr.Errors[1].Error(), "Max parallel can not be less than one") {
+	if !strings.Contains(mErr.Errors[1].Error(), "Max parallel can not be less than zero") {
 		t.Fatalf("err: %s", err)
 	}
 	if !strings.Contains(mErr.Errors[2].Error(), "Canary count can not be less than zero") {

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -331,7 +331,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 	}
 	if !existingDeployment {
 		dstate = &structs.DeploymentState{}
-		if tg.Update != nil && tg.Update.MaxParallel != 0 {
+		if !tg.Update.IsEmpty() {
 			dstate.AutoRevert = tg.Update.AutoRevert
 			dstate.AutoPromote = tg.Update.AutoPromote
 			dstate.ProgressDeadline = tg.Update.ProgressDeadline
@@ -509,7 +509,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 	}
 
 	// Create a new deployment if necessary
-	if !existingDeployment && strategy != nil && dstate.DesiredTotal != 0 && (!hadRunning || updatingSpec) {
+	if !existingDeployment && !strategy.IsEmpty() && dstate.DesiredTotal != 0 && (!hadRunning || updatingSpec) {
 		// A previous group may have made the deployment already
 		if a.deployment == nil {
 			a.deployment = structs.NewDeployment(a.job)
@@ -618,7 +618,7 @@ func (a *allocReconciler) handleGroupCanaries(all allocSet, desiredChanges *stru
 func (a *allocReconciler) computeLimit(group *structs.TaskGroup, untainted, destructive, migrate allocSet, canaryState bool) int {
 	// If there is no update strategy or deployment for the group we can deploy
 	// as many as the group has
-	if group.Update == nil || len(destructive)+len(migrate) == 0 || group.Update.MaxParallel == 0 {
+	if group.Update.IsEmpty() || len(destructive)+len(migrate) == 0 {
 		return group.Count
 	} else if a.deploymentPaused || a.deploymentFailed {
 		// If the deployment is paused or failed, do not create anything else

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -331,7 +331,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 	}
 	if !existingDeployment {
 		dstate = &structs.DeploymentState{}
-		if tg.Update != nil {
+		if tg.Update != nil && tg.Update.MaxParallel != 0 {
 			dstate.AutoRevert = tg.Update.AutoRevert
 			dstate.AutoPromote = tg.Update.AutoPromote
 			dstate.ProgressDeadline = tg.Update.ProgressDeadline

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -618,7 +618,7 @@ func (a *allocReconciler) handleGroupCanaries(all allocSet, desiredChanges *stru
 func (a *allocReconciler) computeLimit(group *structs.TaskGroup, untainted, destructive, migrate allocSet, canaryState bool) int {
 	// If there is no update strategy or deployment for the group we can deploy
 	// as many as the group has
-	if group.Update == nil || len(destructive)+len(migrate) == 0 {
+	if group.Update == nil || len(destructive)+len(migrate) == 0 || group.Update.MaxParallel == 0 {
 		return group.Count
 	} else if a.deploymentPaused || a.deploymentFailed {
 		// If the deployment is paused or failed, do not create anything else

--- a/website/source/docs/job-specification/update.html.md
+++ b/website/source/docs/job-specification/update.html.md
@@ -52,9 +52,11 @@ job "docs" {
 
 ## `update` Parameters
 
-- `max_parallel` `(int: 0)` - Specifies the number of allocations within a task group that can be
+- `max_parallel` `(int: 1)` - Specifies the number of allocations within a task group that can be
   updated at the same time.  The task groups themselves are updated in parallel.
 
+  - `max_parallel = 0` - Specifies that the allocation should use forced updates instead of deployments
+  
 - `health_check` `(string: "checks")` - Specifies the mechanism in which
   allocations health is determined. The potential values are:
 


### PR DESCRIPTION
## Overview
This adds a default update stanza and makes `max_parallel=0` a sentinel value that disables deployments.
* Jobs that do not have an update stanza present in the jobspec will default to a deployment of rolling updates with `max_parallel=1`
  * **Previous behavior** for jobs w/o an update stanza was forced updates
  * Jobs that have an `update` stanza (even an empty one) are not affected
* Jobs with `max_parallel=0` in their update stanza will disable deployments (rolling and canary) explicitly, and make the job do forced updates

## Behavior
### Default update stanza
#### Service jobs have deployments when first submitted
![Screenshot from 2019-08-30 09-43-43](https://user-images.githubusercontent.com/1182129/64037772-55701b80-cb0b-11e9-8a86-4c8518ae390d.png)
#### Service jobs have rolling deployments when you submit a new version of the job
![Screenshot from 2019-08-30 09-44-15](https://user-images.githubusercontent.com/1182129/64037773-55701b80-cb0b-11e9-955b-763857920592.png)

#### Batch jobs have no deployments and still perform destructive updates
![Screenshot from 2019-08-30 09-50-59](https://user-images.githubusercontent.com/1182129/64037943-b8fa4900-cb0b-11e9-9968-2fdc83a3a861.png)

---------------------------------------------------------

### max_parallel=0 disables deployments (i.e. the job will have destructive updates)
![Screenshot from 2019-08-30 09-53-15](https://user-images.githubusercontent.com/1182129/64038073-0c6c9700-cb0c-11e9-9142-4327f47ecc3b.png)
![Screenshot from 2019-08-30 09-52-54](https://user-images.githubusercontent.com/1182129/64038081-1098b480-cb0c-11e9-960d-bf48588bcbba.png)

## Implementation
* we set the default update strategy for a Job, which will get merged into the TaskGroup update strategy at api.Canonicalization in the command/agent
* the place to disable deployments for a job is when the alloc reconciler computes the deployment for the task group

## Todo
* [x] default update stanza
  * [x] update validation
  * [x] update docs with a note that `max_parallel=0` is a sentinel value to indicate forced updates
  * [x] update tests
  * [x] set the default update strategy at Job canonicalization
    * [x] double check w/ team: canonicalization should happen server side in structs#(*Job)Canonicalize?
      - no it should happen in the api#(*Job)Canonicalize which is called from the command/agent, that means we would set the defaults before raft
      - putting it in the structs#Canonicalize would result in surprising behavior, since we expect structs to be not nil
  * [x] test that confirms it's only for service jobs
* [x] max_parallel=0 should disable deployment patterns
  * [x] confirm forced updates
  * [x] confirm no deployments are present
* [x] tests for max_parallel
* [ ] (separate PR) update docs: after an upgrade, a job update (not just job create) will result in an update stanza being added
* [ ] (separate PR) add e2e tests