### PR TITLE
Consul service meta

### DIFF
--- a/api/services.go
+++ b/api/services.go
@@ -106,6 +106,7 @@ type Service struct {
 	Checks       []ServiceCheck
 	CheckRestart *CheckRestart `mapstructure:"check_restart"`
 	Connect      *ConsulConnect
+	Meta         map[string]string
 }
 
 // Canonicalize the Service by ensuring its name and address mode are set. Task

--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -252,6 +252,15 @@ func interpolateServices(taskEnv *taskenv.TaskEnv, services []*structs.Service) 
 		service.PortLabel = taskEnv.ReplaceEnv(service.PortLabel)
 		service.Tags = taskEnv.ParseAndReplace(service.Tags)
 		service.CanaryTags = taskEnv.ParseAndReplace(service.CanaryTags)
+
+		if len(service.Meta) > 0 {
+			meta := make(map[string]string, len(service.Meta))
+			for k, v := range service.Meta {
+				meta[k] = taskEnv.ReplaceEnv(v)
+			}
+			service.Meta = meta
+		}
+
 		interpolated[i] = service
 	}
 

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -728,10 +728,7 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, t
 		return nil, fmt.Errorf("invalid Consul Connect configuration for service %q: %v", service.Name, err)
 	}
 
-	meta := make(map[string]string, len(service.Meta))
-	for k, v := range service.Meta {
-		meta[k] = v
-	}
+	meta := helper.CopyMapStringString(service.Meta)
 
 	// This enables the consul UI to show that Nomad registered this service
 	meta["external-source"] = "nomad"

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -728,7 +728,10 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, t
 		return nil, fmt.Errorf("invalid Consul Connect configuration for service %q: %v", service.Name, err)
 	}
 
-	meta := helper.CopyMapStringString(service.Meta)
+	meta := make(map[string]string, len(service.Meta))
+	for k, v := range service.Meta {
+		meta[k] = v
+	}
 
 	// This enables the consul UI to show that Nomad registered this service
 	meta["external-source"] = "nomad"

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -728,6 +728,14 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, t
 		return nil, fmt.Errorf("invalid Consul Connect configuration for service %q: %v", service.Name, err)
 	}
 
+	meta := make(map[string]string, len(service.Meta))
+	for k, v := range service.Meta {
+		meta[k] = v
+	}
+
+	// This enables the consul UI to show that Nomad registered this service
+	meta["external-source"] = "nomad"
+
 	// Build the Consul Service registration request
 	serviceReg := &api.AgentServiceRegistration{
 		ID:      id,
@@ -735,10 +743,7 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, t
 		Tags:    tags,
 		Address: ip,
 		Port:    port,
-		// This enables the consul UI to show that Nomad registered this service
-		Meta: map[string]string{
-			"external-source": "nomad",
-		},
+		Meta:    meta,
 		Connect: connect, // will be nil if no Connect stanza
 	}
 	ops.regServices = append(ops.regServices, serviceReg)

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -828,7 +828,7 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 				Tags:        service.Tags,
 				CanaryTags:  service.CanaryTags,
 				AddressMode: service.AddressMode,
-				Meta:        service.Meta,
+				Meta:        helper.CopyMapStringString(service.Meta),
 			}
 
 			if l := len(service.Checks); l != 0 {
@@ -1006,7 +1006,7 @@ func ApiServicesToStructs(in []*api.Service) []*structs.Service {
 			Tags:        s.Tags,
 			CanaryTags:  s.CanaryTags,
 			AddressMode: s.AddressMode,
-			Meta:        s.Meta,
+			Meta:        helper.CopyMapStringString(s.Meta),
 		}
 
 		if l := len(s.Checks); l != 0 {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -828,6 +828,7 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 				Tags:        service.Tags,
 				CanaryTags:  service.CanaryTags,
 				AddressMode: service.AddressMode,
+				Meta:        service.Meta,
 			}
 
 			if l := len(service.Checks); l != 0 {
@@ -1005,6 +1006,7 @@ func ApiServicesToStructs(in []*api.Service) []*structs.Service {
 			Tags:        s.Tags,
 			CanaryTags:  s.CanaryTags,
 			AddressMode: s.AddressMode,
+			Meta:        s.Meta,
 		}
 
 		if l := len(s.Checks); l != 0 {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1508,7 +1508,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						CanaryTags: []string{"d", "e"},
 						PortLabel:  "1234",
 						Meta: map[string]string{
-							"foo": "bar",
+							"servicemeta": "foobar",
 						},
 						CheckRestart: &api.CheckRestart{
 							Limit: 4,
@@ -1574,6 +1574,9 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								Tags:       []string{"1", "2"},
 								CanaryTags: []string{"3", "4"},
 								PortLabel:  "foo",
+								Meta: map[string]string{
+									"servicemeta": "foobar",
+								},
 								CheckRestart: &api.CheckRestart{
 									Limit: 4,
 									Grace: helper.TimeToPtr(11 * time.Second),
@@ -1849,7 +1852,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						PortLabel:   "1234",
 						AddressMode: "auto",
 						Meta: map[string]string{
-							"foo": "bar",
+							"servicemeta": "foobar",
 						},
 						Checks: []*structs.ServiceCheck{
 							{
@@ -1911,7 +1914,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								PortLabel:   "foo",
 								AddressMode: "auto",
 								Meta: map[string]string{
-									"foo": "bar",
+									"servicemeta": "foobar",
 								},
 								Checks: []*structs.ServiceCheck{
 									{

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1507,6 +1507,9 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						Tags:       []string{"a", "b"},
 						CanaryTags: []string{"d", "e"},
 						PortLabel:  "1234",
+						Meta: map[string]string{
+							"foo": "bar",
+						},
 						CheckRestart: &api.CheckRestart{
 							Limit: 4,
 							Grace: helper.TimeToPtr(11 * time.Second),
@@ -1845,6 +1848,9 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						CanaryTags:  []string{"d", "e"},
 						PortLabel:   "1234",
 						AddressMode: "auto",
+						Meta: map[string]string{
+							"foo": "bar",
+						},
 						Checks: []*structs.ServiceCheck{
 							{
 								Name:          "bar",
@@ -1904,6 +1910,9 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								CanaryTags:  []string{"3", "4"},
 								PortLabel:   "foo",
 								AddressMode: "auto",
+								Meta: map[string]string{
+									"foo": "bar",
+								},
 								Checks: []*structs.ServiceCheck{
 									{
 										Name:          "bar",

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -787,8 +787,8 @@ func TestParse(t *testing.T) {
 		{
 			"service-meta.hcl",
 			&api.Job{
-				ID:   helper.StringToPtr("service_check_meta"),
-				Name: helper.StringToPtr("service_check_meta"),
+				ID:   helper.StringToPtr("service_meta"),
+				Name: helper.StringToPtr("service_meta"),
 				Type: helper.StringToPtr("service"),
 				TaskGroups: []*api.TaskGroup{
 					{

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -785,6 +785,33 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"service-meta.hcl",
+			&api.Job{
+				ID:   helper.StringToPtr("service_check_meta"),
+				Name: helper.StringToPtr("service_check_meta"),
+				Type: helper.StringToPtr("service"),
+				TaskGroups: []*api.TaskGroup{
+					{
+						Name: helper.StringToPtr("group"),
+						Tasks: []*api.Task{
+							{
+								Name: "task",
+								Services: []*api.Service{
+									{
+										Name: "http-service",
+										Meta: map[string]string{
+											"foo": "bar",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
 			"reschedule-job.hcl",
 			&api.Job{
 				ID:          helper.StringToPtr("foo"),

--- a/jobspec/test-fixtures/service-meta.hcl
+++ b/jobspec/test-fixtures/service-meta.hcl
@@ -1,11 +1,9 @@
-job "check_meta" {
+job "service_meta" {
     type = "service"
     group "group" {
-        count = 1
-
         task "task" {
           service {
-            port = "http"
+            name = "http-service"
             meta {
                 foo = "bar"
             }

--- a/jobspec/test-fixtures/service-meta.hcl
+++ b/jobspec/test-fixtures/service-meta.hcl
@@ -1,0 +1,16 @@
+job "check_meta" {
+    type = "service"
+    group "group" {
+        count = 1
+
+        task "task" {
+          service {
+            port = "http"
+            meta {
+                foo = "bar"
+            }
+          }
+        }
+    }
+}
+

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -461,9 +461,8 @@ func (s *Service) Hash(allocID, taskName string, canary bool) string {
 	for _, tag := range s.CanaryTags {
 		io.WriteString(h, tag)
 	}
-	for k, v := range s.Meta {
-		io.WriteString(h, k)
-		io.WriteString(h, v)
+	if len(s.Meta) > 0 {
+		fmt.Fprintf(h, "%v", s.Meta)
 	}
 
 	// Vary ID on whether or not CanaryTags will be used

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -146,6 +146,9 @@ The table below shows this endpoint's support for
                         "global",
                         "cache"
                     ],
+                    "Meta": {
+                      "meta": "for my service"
+                    },
                     "PortLabel": "db",
                     "AddressMode": "",
                     "Checks": [{

--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -56,6 +56,9 @@ Below is the JSON representation of the job outputted by `$ nomad init`:
                         "global",
                         "cache"
                     ],
+                    "Meta": {
+                      "meta": "for my service",
+                    },
                     "PortLabel": "db",
                     "AddressMode": "",
                     "Checks": [{
@@ -400,6 +403,9 @@ The `Task` object supports the following keys:
 
      - `Tags`: A list of string tags associated with this Service. String
        interpolation is supported in tags.
+      
+     - `Meta`: A key-value map that annotates the Consul service with
+       user-defined metadata. String interpolation is supported in meta.
 
      - `CanaryTags`: A list of string tags associated with this Service while it
        is a canary. Once the canary is promoted, the registered tags will be

--- a/website/source/docs/job-specification/service.html.md
+++ b/website/source/docs/job-specification/service.html.md
@@ -33,6 +33,10 @@ job "docs" {
 
         port = "db"
 
+        meta {
+          meta = "for your service"
+        }
+
         check {
           type     = "tcp"
           port     = "db"
@@ -135,6 +139,9 @@ does not automatically enable service discovery.
     implemented for Docker and rkt.
 
   - `host` - Use the host IP and port.
+  
+- `meta` <code>([Meta][]: nil)</code> - Specifies a key-value map that annotates
+  the Consul service with user-defined metadata.
 
 ### `check` Parameters
 


### PR DESCRIPTION
This fixes #4300, it adds a `meta` field to the service stanza in the job spec. It's then sent along when registering the service.

I've added the meta data to the `Hash` function as well as the `Equals` function for the `Service` struct. Not sure if that's desirable, I assumed it was.

I believe I've followed most steps in the contributing document, except I'm not sure what to do about the changelog. Happy to fix that up though.