### PR TITLE
agent: -dev=connect mode bind to 0.0.0.0

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -740,12 +740,8 @@ func (mode *devModeConfig) networkConfig() error {
 			return fmt.Errorf(errMsg, "could not find public network inteface")
 		}
 		iface := ifAddrs[0].Name
-		addr, err := sockaddr.GetInterfaceIP(iface)
-		if err != nil {
-			return fmt.Errorf(errMsg, "could not find address for public interface")
-		}
 		mode.iface = iface
-		mode.bindAddr = addr
+		mode.bindAddr = "0.0.0.0" // allows CLI to "just work"
 		return nil
 	}
 	mode.bindAddr = "127.0.0.1"


### PR DESCRIPTION
The dev mode flag for connect was binding to the default interface's IP, but this makes for a bad user experience for the CLI which will default to 127.0.0.1. If we bind to 0.0.0.0 instead the CLI will work without further configuration by the user.