### PR TITLE
Update golang to 1.12.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ executors:
   go:
     working_directory: /go/src/github.com/hashicorp/nomad
     docker:
-      - image: hashicorpnomad/ci-build-image:20190812
+      - image: hashicorpnomad/ci-build-image:20190823
   go-machine:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     machine:
@@ -243,7 +243,7 @@ commands:
     parameters:
       version:
         type: string
-        default: "1.12.7"
+        default: "1.12.9"
     steps:
       - run:
           name: install golang << parameters.version >>

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.12.7
+FROM circleci/golang:1.12.9
 ENV PROTOC_VERSION 3.6.1
 ENV VAULT_VERSION 1.1.0
 ENV CONSUL_VERSION 1.4.0
@@ -7,11 +7,6 @@ RUN sudo apt-get update \
     && sudo apt-get -y upgrade \
     && sudo apt-get install -y unzip \
     && sudo rm -rf /var/lib/apt/lists/*
-
-## Add the git repo and run bootstrap to install CI dependencies, then remove
-## the extra checkout to save image size.
-COPY . /tmp/build
-RUN cd /tmp/build && sudo chown -R $(whoami) /tmp/build && make bootstrap && rm -rf /tmp/build
 
 RUN wget -q -O /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
     && unzip /tmp/protoc.zip -d /tmp/protoc3 \
@@ -27,4 +22,10 @@ RUN wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSI
 RUN wget -q -O /tmp/consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip \
     && sudo unzip -d /usr/local/bin /tmp/consul.zip \
     && rm -rf /tmp/consul*
+
+## Add the git repo and run bootstrap to install CI dependencies, then remove
+## the extra checkout to save image size.
+COPY GNUmakefile /tmp/build/GNUmakefile
+COPY scripts /tmp/build/scripts
+RUN cd /tmp/build && sudo chown -R $(whoami) /tmp/build && make deps lint-deps && rm -rf /tmp/build
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -382,7 +382,8 @@ ui-screenshots-local:
 	@cd scripts/screenshots/src && SCREENSHOTS_DIR="../screenshots" node index.js
 
 .PHONY: ci-image
+ci-image: IMAGE_TAG=$(shell date +%Y%m%d)
 ci-image:
-	@echo "==> Building CI Image hashicorpnomad/ci-build-image:$(date %Y%m%d)"
-	@docker build . -f Dockerfile.ci -t hashicorpnomad/ci-build-image:$(date %Y%m%d)
-	@echo "To push the image, run `docker push -t hashicorpnomad/ci-build-image:$(date %Y%m%d)"
+	@echo "==> Building CI Image hashicorpnomad/ci-build-image:$(IMAGE_TAG)"
+	@docker build . -f Dockerfile.ci -t hashicorpnomad/ci-build-image:$(IMAGE_TAG)
+	@echo "To push the image, run 'docker push -t hashicorpnomad/ci-build-image:$(IMAGE_TAG)'"

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Who Uses Nomad
 Contributing to Nomad
 --------------------
 
-If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.11.11+ is *required*).
+If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.12.9+ is *required*).
 
 See the [`contributing`](contributing/) directory for more developer documentation.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,10 +23,10 @@ install:
       cd %APPVEYOR_BUILD_FOLDER%
       rmdir /Q/S C:\go
 
-  # install go 1.11.11 to match version used for cutting a release
+  # install go 1.12.9 to match version used for cutting a release
   - cmd: |
       mkdir c:\go
-      appveyor DownloadFile "https://dl.google.com/go/go1.11.11.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
+      appveyor DownloadFile "https://dl.google.com/go/go1.12.9.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
       
   - ps: Expand-Archive $Env:TEMP\go.zip -DestinationPath C:\
 

--- a/scripts/release/mac-remote-build
+++ b/scripts/release/mac-remote-build
@@ -56,7 +56,7 @@ REPO_PATH="${TMP_WORKSPACE}/gopath/src/github.com/hashicorp/nomad"
 mkdir -p "${TMP_WORKSPACE}/tmp"
 
 install_go() {
-  local go_version="1.11.11"
+  local go_version="1.12.9"
   local download=
 
   download="https://storage.googleapis.com/golang/go${go_version}.darwin-amd64.tar.gz"

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function install_go() {
-	local go_version=1.11.11
+	local go_version=1.12.9
 	local download=
 
 	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"


### PR DESCRIPTION
Upgrading to use 1.12.9 for nomad 0.10, as 1.12.9 the latest golang release.  We may consider 1.13 if released before nomad 0.10 is out.