### PR TITLE
initialize device manager stats interval

### DIFF
--- a/client/devicemanager/manager.go
+++ b/client/devicemanager/manager.go
@@ -118,6 +118,7 @@ func New(c *Config) *manager {
 		loader:           c.Loader,
 		pluginConfig:     c.PluginConfig,
 		updater:          c.Updater,
+		statsInterval:    c.StatsInterval,
 		instances:        make(map[loader.PluginID]*instanceManager),
 		reattachConfigs:  make(map[loader.PluginID]*pstructs.ReattachConfig),
 		fingerprintResCh: make(chan struct{}, 1),


### PR DESCRIPTION
Fixes a bug where we cpu is pigged at 100% due to collecting devices
statistics.  The passed stats interval was ignored, and the default zero
value causes a very tight loop of stats collection.

FWIW, in my testing, it took 2.5-3ms to collect nvidia GPU stats, on a
`g2.2xlarge` ec2 instance.

The stats interval defaults to 1 second and is user configurable.  I
believe this is too frequent as a default, and I may advocate for
reducing it to a value closer to 5s or 10s, but keeping it as is for
now.

Fixes https://github.com/hashicorp/nomad/issues/6057 .