### PR TITLE
agent: fix error message on -dev=connect

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -77,6 +77,17 @@ func (c *Command) readConfig() *Config {
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 
 	// Role options
+
+	// Dev mode flags: the stdlib flag package doesn't allow non-bool flags
+	// to be passed an empty value. Although we can workaround this by setting
+	// IsBoolVar on the Value implementation, this results in unclear error
+	// messages. So we manipulate the args directly before passing into the
+	// Parse method.
+	for argIndex, arg := range c.args {
+		if arg == "-dev" || arg == "--dev" {
+			c.args[argIndex] = "-dev=true"
+		}
+	}
 	flags.Var((flaghelper.FuncOptionalStringVar)(func(s string) (err error) {
 		dev, err = newDevModeConfig(s)
 		return err

--- a/helper/flag-helpers/flag.go
+++ b/helper/flag-helpers/flag.go
@@ -65,4 +65,4 @@ type FuncOptionalStringVar func(s string) error
 
 func (f FuncOptionalStringVar) Set(s string) error { return f(s) }
 func (f FuncOptionalStringVar) String() string     { return "" }
-func (f FuncOptionalStringVar) IsBoolFlag() bool   { return true }
+func (f FuncOptionalStringVar) IsBoolFlag() bool   { return false }


### PR DESCRIPTION
The stdlib `flag` package doesn't allow non-bool flags to be passed an empty value. The `-dev=connect` flag was working around this by setting `IsBoolVar` on the `Value` implementation, but this resulted in unclear error messages about an "invalid boolean". To avoid this, we'll manipulate the args directly to set `-dev=true` if the `-dev` flag is present before we parse.