### PR TITLE
upgrade machine image for most jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,10 @@ workflows:
       - test-machine:
           name: "test-docker"
           test_packages: "./drivers/docker"
+          # docker is misbehaving in docker-machine-recent image
+          # and we get unexpected failures
+          # e.g. https://circleci.com/gh/hashicorp/nomad/3854
+          executor: go-machine
           <<: *IGNORE_FOR_UI_BRANCHES
       - test-machine:
           name: "test-exec"
@@ -158,7 +162,7 @@ jobs:
           path: /tmp/test-reports
 
   test-machine:
-    executor: go-machine
+    executor: "<< parameters.executor >>"
     parameters:
       test_packages:
         type: string
@@ -166,6 +170,9 @@ jobs:
       exclude_packages:
         type: string
         default: ""
+      executor:
+        type: string
+        default: "go-machine-recent"
     environment:
       <<: *COMMON_ENVS
       GOTEST_PKGS_EXCLUDE: "<< parameters.exclude_packages >>"


### PR DESCRIPTION
Looks like the host unattended upgrades is interferring with chroot
creation.  Here, we upgrade machine image to one without unattended
upgrades misconfigured, across the board except for the `test-docker`
job.

Docker seems to be misbehaving on that image, and we get some unexpected
cgroups errors, e.g. https://circleci.com/gh/hashicorp/nomad/3854 .

Sample recent failures of `test-exec`:

https://circleci.com/gh/hashicorp/nomad/3633
https://circleci.com/gh/hashicorp/nomad/3696
https://circleci.com/gh/hashicorp/nomad/3714
https://circleci.com/gh/hashicorp/nomad/3764
https://circleci.com/gh/hashicorp/nomad/3770
https://circleci.com/gh/hashicorp/nomad/3834