### PR TITLE
client/net: nil panic when logging nil result

### DIFF
--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -156,12 +156,12 @@ func (b *bridgeNetworkConfigurator) Setup(alloc *structs.Allocation, spec *drive
 	// in one of them to fail. This rety attempts to overcome any
 	const retry = 3
 	for attempt := 1; ; attempt++ {
-		result, err := b.cniConfig.AddNetworkList(b.ctx, netconf, b.runtimeConf(alloc, spec))
+		_, err := b.cniConfig.AddNetworkList(b.ctx, netconf, b.runtimeConf(alloc, spec))
 		if err == nil {
 			break
 		}
 
-		b.logger.Warn("failed to configure bridge network", "err", err, "result", result.String(), "attempt", attempt)
+		b.logger.Warn("failed to configure bridge network", "err", err, "attempt", attempt)
 		if attempt == retry {
 			return err
 		}


### PR DESCRIPTION
Removing result from the log line as it is always nil when
AddNetworkList returns an error.