### PR TITLE
raw_exec: be defensive when disabled

### DIFF
--- a/drivers/rawexec/driver.go
+++ b/drivers/rawexec/driver.go
@@ -47,6 +47,8 @@ var (
 		Config:  map[string]interface{}{},
 		Factory: func(l hclog.Logger) interface{} { return NewRawExecDriver(l) },
 	}
+
+	errDisabledDriver = fmt.Errorf("raw_exec is disabled")
 )
 
 // PluginLoader maps pre-0.9 client driver options to post-0.9 plugin options.
@@ -307,6 +309,10 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 }
 
 func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drivers.DriverNetwork, error) {
+	if !d.config.Enabled {
+		return nil, nil, errDisabledDriver
+	}
+
 	if _, ok := d.tasks.Get(cfg.ID); ok {
 		return nil, nil, fmt.Errorf("task with ID %q already started", cfg.ID)
 	}

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -32,6 +32,12 @@ func TestMain(m *testing.M) {
 	}
 }
 
+func newEnabledRawExecDriver(t *testing.T) *Driver {
+	d := NewRawExecDriver(testlog.HCLogger(t)).(*Driver)
+	d.config.Enabled = true
+	return d
+}
+
 func TestRawExecDriver_SetConfig(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -73,7 +79,7 @@ func TestRawExecDriver_Fingerprint(t *testing.T) {
 	fingerprintTest := func(config *Config, expected *drivers.Fingerprint) func(t *testing.T) {
 		return func(t *testing.T) {
 			require := require.New(t)
-			d := NewRawExecDriver(testlog.HCLogger(t)).(*Driver)
+			d := newEnabledRawExecDriver(t)
 			harness := dtestutil.NewDriverHarness(t, d)
 			defer harness.Kill()
 
@@ -133,7 +139,7 @@ func TestRawExecDriver_StartWait(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
+	d := newEnabledRawExecDriver(t)
 	harness := dtestutil.NewDriverHarness(t, d)
 	defer harness.Kill()
 	task := &drivers.TaskConfig{
@@ -175,12 +181,12 @@ func TestRawExecDriver_StartWaitRecoverWaitStop(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
+	d := newEnabledRawExecDriver(t)
 	harness := dtestutil.NewDriverHarness(t, d)
 	defer harness.Kill()
 
 	// Disable cgroups so test works without root
-	config := &Config{NoCgroups: true}
+	config := &Config{NoCgroups: true, Enabled: true}
 	var data []byte
 	require.NoError(basePlug.MsgPackEncode(&data, config))
 	bconfig := &basePlug.Config{PluginConfig: data}
@@ -219,7 +225,7 @@ func TestRawExecDriver_StartWaitRecoverWaitStop(t *testing.T) {
 	originalStatus, err := d.InspectTask(task.ID)
 	require.NoError(err)
 
-	d.(*Driver).tasks.Delete(task.ID)
+	d.tasks.Delete(task.ID)
 
 	wg.Wait()
 	require.True(waitDone)
@@ -258,7 +264,7 @@ func TestRawExecDriver_Start_Wait_AllocDir(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
+	d := newEnabledRawExecDriver(t)
 	harness := dtestutil.NewDriverHarness(t, d)
 	defer harness.Kill()
 
@@ -313,7 +319,7 @@ func TestRawExecDriver_Start_Kill_Wait_Cgroup(t *testing.T) {
 	require := require.New(t)
 	pidFile := "pid"
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
+	d := newEnabledRawExecDriver(t)
 	harness := dtestutil.NewDriverHarness(t, d)
 	defer harness.Kill()
 
@@ -403,7 +409,7 @@ func TestRawExecDriver_Exec(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
+	d := newEnabledRawExecDriver(t)
 	harness := dtestutil.NewDriverHarness(t, d)
 	defer harness.Kill()
 
@@ -476,8 +482,8 @@ func TestRawExecDriver_Disabled(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
-	d.(*Driver).config.Enabled = false
+	d := newEnabledRawExecDriver(t)
+	d.config.Enabled = false
 
 	harness := dtestutil.NewDriverHarness(t, d)
 	defer harness.Kill()

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -471,3 +471,23 @@ config {
 
 	require.EqualValues(t, expected, tc)
 }
+
+func TestRawExecDriver_Disabled(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	d := NewRawExecDriver(testlog.HCLogger(t))
+	d.(*Driver).config.Enabled = false
+
+	harness := dtestutil.NewDriverHarness(t, d)
+	defer harness.Kill()
+	task := &drivers.TaskConfig{
+		ID:   uuid.Generate(),
+		Name: "test",
+	}
+
+	handle, _, err := harness.StartTask(task)
+	require.Error(err)
+	require.Contains(err.Error(), errDisabledDriver.Error())
+	require.Nil(handle)
+}

--- a/drivers/rawexec/driver_unix_test.go
+++ b/drivers/rawexec/driver_unix_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/testtask"
 	"github.com/hashicorp/nomad/helper/uuid"
 	basePlug "github.com/hashicorp/nomad/plugins/base"
@@ -31,7 +30,7 @@ func TestRawExecDriver_User(t *testing.T) {
 	}
 	require := require.New(t)
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
+	d := newEnabledRawExecDriver(t)
 	harness := dtestutil.NewDriverHarness(t, d)
 
 	task := &drivers.TaskConfig{
@@ -63,7 +62,7 @@ func TestRawExecDriver_Signal(t *testing.T) {
 	}
 	require := require.New(t)
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
+	d := newEnabledRawExecDriver(t)
 	harness := dtestutil.NewDriverHarness(t, d)
 
 	task := &drivers.TaskConfig{
@@ -134,12 +133,12 @@ func TestRawExecDriver_StartWaitStop(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
+	d := newEnabledRawExecDriver(t)
 	harness := dtestutil.NewDriverHarness(t, d)
 	defer harness.Kill()
 
 	// Disable cgroups so test works without root
-	config := &Config{NoCgroups: true}
+	config := &Config{NoCgroups: true, Enabled: true}
 	var data []byte
 	require.NoError(basePlug.MsgPackEncode(&data, config))
 	bconfig := &basePlug.Config{PluginConfig: data}
@@ -204,7 +203,7 @@ func TestRawExec_ExecTaskStreaming(t *testing.T) {
 	}
 	require := require.New(t)
 
-	d := NewRawExecDriver(testlog.HCLogger(t))
+	d := newEnabledRawExecDriver(t)
 	harness := dtestutil.NewDriverHarness(t, d)
 	defer harness.Kill()
 

--- a/helper/pluginutils/catalog/testing.go
+++ b/helper/pluginutils/catalog/testing.go
@@ -10,7 +10,15 @@ import (
 
 // TestPluginLoader returns a plugin loader populated only with internal plugins
 func TestPluginLoader(t testing.T) loader.PluginCatalog {
-	return TestPluginLoaderWithOptions(t, "", nil, nil)
+	driverConfigs := []*config.PluginConfig{
+		{
+			Name: "raw_exec",
+			Config: map[string]interface{}{
+				"enabled": true,
+			},
+		},
+	}
+	return TestPluginLoaderWithOptions(t, "", nil, driverConfigs)
 }
 
 // TestPluginLoaderWithOptions allows configuring the plugin loader fully.


### PR DESCRIPTION
Ensure that no raw_exec task can run on a client where it's disabled,
even if a flaw lead to client being assigned a raw_exec task
unexpectedly.