### PR TITLE
schedulers: check all drivers on node

### DIFF
--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -15,6 +15,16 @@ func Node() *structs.Node {
 		SecretID:   uuid.Generate(),
 		Datacenter: "dc1",
 		Name:       "foobar",
+		Drivers: map[string]*structs.DriverInfo{
+			"exec": {
+				Detected: true,
+				Healthy:  true,
+			},
+			"mock_driver": {
+				Detected: true,
+				Healthy:  true,
+			},
+		},
 		Attributes: map[string]string{
 			"kernel.name":        "linux",
 			"arch":               "x86",

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -245,6 +245,7 @@ func (c *DriverChecker) hasDrivers(option *structs.Node) bool {
 			return false
 		}
 	}
+
 	return true
 }
 

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -227,7 +227,11 @@ func (c *DriverChecker) hasDrivers(option *structs.Node) bool {
 				return false
 			}
 
-			return driverInfo.Detected && driverInfo.Healthy
+			if driverInfo.Detected && driverInfo.Healthy {
+				continue
+			} else {
+				return false
+			}
 		}
 
 		value, ok := option.Attributes[driverStr]

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -236,13 +236,66 @@ func TestHostVolumeChecker_ReadOnly(t *testing.T) {
 	}
 }
 
-func TestDriverChecker(t *testing.T) {
+func TestDriverChecker_DriverInfo(t *testing.T) {
+	_, ctx := testContext(t)
+	nodes := []*structs.Node{
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+	}
+	nodes[0].Drivers["foo"] = &structs.DriverInfo{
+		Detected: true,
+		Healthy:  true,
+	}
+	nodes[1].Drivers["foo"] = &structs.DriverInfo{
+		Detected: true,
+		Healthy:  false,
+	}
+	nodes[2].Drivers["foo"] = &structs.DriverInfo{
+		Detected: false,
+		Healthy:  false,
+	}
+
+	drivers := map[string]struct{}{
+		"exec": {},
+		"foo":  {},
+	}
+	checker := NewDriverChecker(ctx, drivers)
+	cases := []struct {
+		Node   *structs.Node
+		Result bool
+	}{
+		{
+			Node:   nodes[0],
+			Result: true,
+		},
+		{
+			Node:   nodes[1],
+			Result: false,
+		},
+		{
+			Node:   nodes[2],
+			Result: false,
+		},
+	}
+
+	for i, c := range cases {
+		if act := checker.Feasible(c.Node); act != c.Result {
+			t.Fatalf("case(%d) failed: got %v; want %v", i, act, c.Result)
+		}
+	}
+}
+func TestDriverChecker_Compatibility(t *testing.T) {
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
 		mock.Node(),
 		mock.Node(),
 		mock.Node(),
+	}
+	for _, n := range nodes {
+		// force compatibility mode
+		n.Drivers = nil
 	}
 	nodes[0].Attributes["driver.foo"] = "1"
 	nodes[1].Attributes["driver.foo"] = "0"


### PR DESCRIPTION
When checking driver feasability for an alloc with multiple drivers, we
must check that all drivers are detected and healthy.

Nomad 0.9 and 0.8 have a bug where we may check a single driver only,
but which driver is dependent on map traversal order, which is
unspecified in golang spec.
