### PR TITLE
chore: Remove Go Tests from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,46 +20,6 @@ matrix:
   include:
     - os: linux
       dist: xenial
-      sudo: required
-      env: GOTEST_PKGS="./api"
-      <<: *skip_for_ui_branches
-    - os: linux
-      dist: xenial
-      sudo: required
-      env: GOTEST_PKGS="./client"
-      <<: *skip_for_ui_branches
-    - os: linux
-      dist: xenial
-      sudo: required
-      env: GOTEST_PKGS="./command"
-      <<: *skip_for_ui_branches
-    - os: linux
-      dist: xenial
-      sudo: required
-      env: GOTEST_PKGS="./drivers/docker"
-      <<: *skip_for_ui_branches
-    - os: linux
-      dist: xenial
-      sudo: required
-      env: GOTEST_PKGS="./drivers/exec"
-      <<: *skip_for_ui_branches
-    - os: linux
-      dist: xenial
-      sudo: required
-      env: GOTEST_PKGS="./nomad"
-      <<: *skip_for_ui_branches
-    - os: linux
-      dist: xenial
-      sudo: required
-      env: GOTEST_PKGS_EXCLUDE="./api|./client|./command|./drivers/docker|./drivers/exec|./nomad"
-      <<: *skip_for_ui_branches
-    - os: linux
-      dist: xenial
-      sudo: required
-      env: ENABLE_RACE=1
-      <<: *skip_for_ui_branches
-    - os: linux
-      dist: xenial
       sudo: false
       env: RUN_WEBSITE_TESTS=1 SKIP_NOMAD_TESTS=1
       <<: *skip_for_ui_branches


### PR DESCRIPTION
This commit removes the travis tests that duplicate ones ran in
CircleCI.

CircleCI has been significantly more reliable and currently the travis
results are flaky enough that they get mostly ignored.