### PR TITLE
dev: bump vagrant consul version to match CI

### DIFF
--- a/scripts/travis-consul.sh
+++ b/scripts/travis-consul.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-VERSION="1.6.0-rc1"
+VERSION="1.6.0"
 OS="linux"
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     OS="darwin"
@@ -15,7 +15,7 @@ function install_consul() {
 			return
 		fi
 	fi
-	
+
 	wget -q -O /tmp/consul.zip ${DOWNLOAD}
 
 	unzip -d /tmp /tmp/consul.zip

--- a/scripts/vagrant-linux-priv-consul.sh
+++ b/scripts/vagrant-linux-priv-consul.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-VERSION=1.0.7
+VERSION="1.6.0-rc1"
 DOWNLOAD=https://releases.hashicorp.com/consul/${VERSION}/consul_${VERSION}_linux_amd64.zip
 
 function install_consul() {
@@ -11,7 +11,7 @@ function install_consul() {
 			return
 		fi
 	fi
-	
+
 	wget -q -O /tmp/consul.zip ${DOWNLOAD}
 
 	unzip -d /tmp /tmp/consul.zip

--- a/scripts/vagrant-linux-priv-consul.sh
+++ b/scripts/vagrant-linux-priv-consul.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-VERSION="1.6.0-rc1"
+VERSION="1.6.0"
 DOWNLOAD=https://releases.hashicorp.com/consul/${VERSION}/consul_${VERSION}_linux_amd64.zip
 
 function install_consul() {


### PR DESCRIPTION
In https://github.com/hashicorp/nomad/pull/6157 we bumped the required version of Consul for CI, but we need to bump it in Vagrant as well to have parity in local development.