### PR TITLE
connect: add unix socket to proxy grpc for envoy

### DIFF
--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -63,7 +63,7 @@ var (
 
 	// AllocGRPCSocket is the path relative to the task dir root for the
 	// unix socket connected to Consul's gRPC endpoint.
-	AllocGRPCSocket = filepath.Join(TmpDirName, "consul_grpc.sock")
+	AllocGRPCSocket = filepath.Join(SharedAllocName, TmpDirName, "consul_grpc.sock")
 )
 
 // AllocDir allows creating, destroying, and accessing an allocation's

--- a/client/allocdir/testing.go
+++ b/client/allocdir/testing.go
@@ -1,0 +1,37 @@
+package allocdir
+
+import (
+	"io/ioutil"
+	"os"
+
+	hclog "github.com/hashicorp/go-hclog"
+	testing "github.com/mitchellh/go-testing-interface"
+)
+
+// TestAllocDir returns a built alloc dir in a temporary directory and cleanup
+// func.
+func TestAllocDir(t testing.T, l hclog.Logger, prefix string) (*AllocDir, func()) {
+	dir, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		t.Fatalf("Couldn't create temp dir: %v", err)
+	}
+
+	allocDir := NewAllocDir(l, dir)
+
+	cleanup := func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("error cleaning up alloc dir %q: %v", prefix, err)
+		}
+
+		if err := allocDir.Destroy(); err != nil {
+			t.Logf("error cleaning up alloc dir %q: %v", prefix, err)
+		}
+	}
+
+	if err := allocDir.Build(); err != nil {
+		cleanup()
+		t.Fatalf("error building alloc dir %q: %v", prefix, err)
+	}
+
+	return allocDir, cleanup
+}

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -115,13 +115,15 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 
 	// Create the alloc directory hook. This is run first to ensure the
 	// directory path exists for other hooks.
+	alloc := ar.Alloc()
 	ar.runnerHooks = []interfaces.RunnerHook{
 		newAllocDirHook(hookLogger, ar.allocDir),
 		newUpstreamAllocsHook(hookLogger, ar.prevAllocWatcher),
 		newDiskMigrationHook(hookLogger, ar.prevAllocMigrator, ar.allocDir),
-		newAllocHealthWatcherHook(hookLogger, ar.Alloc(), hs, ar.Listener(), ar.consulClient),
-		newNetworkHook(hookLogger, ns, ar.Alloc(), nm, nc),
-		newGroupServiceHook(hookLogger, ar.Alloc(), ar.consulClient),
+		newAllocHealthWatcherHook(hookLogger, alloc, hs, ar.Listener(), ar.consulClient),
+		newNetworkHook(hookLogger, ns, alloc, nm, nc),
+		newGroupServiceHook(hookLogger, alloc, ar.consulClient),
+		newConsulSockHook(hookLogger, alloc, ar.allocDir, config.ConsulConfig),
 	}
 
 	return nil

--- a/client/allocrunner/consulsock_hook.go
+++ b/client/allocrunner/consulsock_hook.go
@@ -1,0 +1,319 @@
+package allocrunner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/nomad/structs/config"
+)
+
+// consulSockHook creates Unix sockets to allow communication from inside a
+// netns to Consul.
+//
+// Noop for allocations without a group Connect stanza.
+type consulSockHook struct {
+	alloc *structs.Allocation
+
+	proxy *sockProxy
+
+	// mu synchronizes group & cancel as they may be mutated and accessed
+	// concurrently via Prerun, Update, Postrun.
+	mu sync.Mutex
+
+	logger hclog.Logger
+}
+
+func newConsulSockHook(logger hclog.Logger, alloc *structs.Allocation, allocDir *allocdir.AllocDir, config *config.ConsulConfig) *consulSockHook {
+	h := &consulSockHook{
+		alloc: alloc,
+		proxy: newSockProxy(logger, allocDir, config),
+	}
+	h.logger = logger.Named(h.Name())
+	return h
+}
+
+func (consulSockHook) Name() string {
+	return "consul_socket"
+}
+
+// shouldRun returns true if the Unix socket should be created and proxied.
+// Requires the mutex to be held.
+func (h *consulSockHook) shouldRun() bool {
+	tg := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup)
+	for _, s := range tg.Services {
+		if s.Connect != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (h *consulSockHook) Prerun() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if !h.shouldRun() {
+		return nil
+	}
+
+	return h.proxy.run(h.alloc)
+}
+
+// Update creates a gRPC socket file and proxy if there are any Connect
+// services.
+func (h *consulSockHook) Update(req *interfaces.RunnerUpdateRequest) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.alloc = req.Alloc
+
+	if !h.shouldRun() {
+		return nil
+	}
+
+	return h.proxy.run(h.alloc)
+}
+
+func (h *consulSockHook) Postrun() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if err := h.proxy.stop(); err != nil {
+		// Only log failures to stop proxies. Worst case scenario is a
+		// small goroutine leak.
+		h.logger.Debug("error stopping Consul proxy", "error", err)
+	}
+	return nil
+}
+
+type sockProxy struct {
+	allocDir *allocdir.AllocDir
+	config   *config.ConsulConfig
+
+	ctx     context.Context
+	cancel  func()
+	doneCh  chan struct{}
+	runOnce bool
+
+	logger hclog.Logger
+}
+
+func newSockProxy(logger hclog.Logger, allocDir *allocdir.AllocDir, config *config.ConsulConfig) *sockProxy {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &sockProxy{
+		allocDir: allocDir,
+		config:   config,
+		ctx:      ctx,
+		cancel:   cancel,
+		doneCh:   make(chan struct{}),
+		logger:   logger,
+	}
+}
+
+// run socket proxy if allocation requires it, it isn't already running, and it
+// hasn't been told to stop.
+//
+// NOT safe for concurrent use.
+func (s *sockProxy) run(alloc *structs.Allocation) error {
+	// Only run once.
+	if s.runOnce {
+		return nil
+	}
+
+	// Only run once. Never restart.
+	select {
+	case <-s.doneCh:
+		s.logger.Trace("socket proxy already shutdown; exiting")
+		return nil
+	case <-s.ctx.Done():
+		s.logger.Trace("socket proxy already done; exiting")
+		return nil
+	default:
+	}
+
+	destAddr := s.config.GRPCAddr
+	if destAddr == "" {
+		// No GRPCAddr defined. Use Addr but replace port with the gRPC
+		// default of 8502.
+		host, _, err := net.SplitHostPort(s.config.Addr)
+		if err != nil {
+			return fmt.Errorf("error parsing Consul address %q: %v",
+				s.config.Addr, err)
+		}
+
+		destAddr = net.JoinHostPort(host, "8502")
+	}
+
+	hostGRPCSockPath := filepath.Join(s.allocDir.AllocDir, allocdir.AllocGRPCSocket)
+	listener, err := net.Listen("unix", hostGRPCSockPath)
+	if err != nil {
+		return fmt.Errorf("unable to create unix socket for Consul gRPC endpoint: %v", err)
+	}
+
+	// The gRPC socket should be usable by all users in case a task is
+	// running as an unprivileged user.  Unix does not allow setting domain
+	// socket permissions when creating the file, so we must manually call
+	// chmod afterwards.
+	// https://github.com/golang/go/issues/11822
+	if err := os.Chmod(hostGRPCSockPath, os.ModePerm); err != nil {
+		return fmt.Errorf("unable to set permissions on unix socket for Consul gRPC endpoint: %v", err)
+	}
+
+	go func() {
+		proxy(s.ctx, s.logger, destAddr, listener)
+		s.cancel()
+		close(s.doneCh)
+	}()
+
+	s.runOnce = true
+	return nil
+}
+
+// stop the proxy and blocks until the proxy has stopped. Returns an error if
+// the proxy does not exit in a timely fashion.
+func (s *sockProxy) stop() error {
+	s.cancel()
+
+	// If proxy was never run, don't wait for anything to shutdown.
+	if !s.runOnce {
+		return nil
+	}
+
+	select {
+	case <-s.doneCh:
+		return nil
+	case <-time.After(3 * time.Second):
+		return fmt.Errorf("timed out waiting for proxy to exit")
+	}
+}
+
+// Proxy between a listener and dest
+func proxy(ctx context.Context, logger hclog.Logger, dest string, l net.Listener) {
+	// Wait for all connections to be done before exiting to prevent
+	// goroutine leaks.
+	wg := sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		// Must cancel context and close listener before waiting
+		cancel()
+		l.Close()
+		wg.Wait()
+	}()
+
+	// Close Accept() when context is cancelled
+	go func() {
+		<-ctx.Done()
+		l.Close()
+	}()
+
+	for ctx.Err() == nil {
+		conn, err := l.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				// Accept errors during shutdown are to be expected
+				return
+			}
+			logger.Error("error in grpc proxy; shutting down proxy", "error", err, "dest", dest)
+			return
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			proxyConn(ctx, logger, dest, conn)
+		}()
+	}
+}
+
+// proxyConn proxies between an existing net.Conn and a destination address. If
+// the destAddr starts with "unix://" it is treated as a path to a unix socket.
+// Otherwise it is treated as a host for a TCP connection.
+//
+// When the context is cancelled proxyConn blocks until all goroutines shutdown
+// to prevent leaks.
+func proxyConn(ctx context.Context, logger hclog.Logger, destAddr string, conn net.Conn) {
+	// Close the connection when we're done with it.
+	defer conn.Close()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Detect unix sockets
+	network := "tcp"
+	const unixPrefix = "unix://"
+	if strings.HasPrefix(destAddr, unixPrefix) {
+		network = "unix"
+		destAddr = destAddr[len(unixPrefix):]
+	}
+
+	dialer := &net.Dialer{}
+	dest, err := dialer.DialContext(ctx, network, destAddr)
+	if err == context.Canceled || err == context.DeadlineExceeded {
+		logger.Trace("proxy exiting gracefully", "error", err, "dest", destAddr,
+			"src_local", conn.LocalAddr(), "src_remote", conn.RemoteAddr())
+		return
+	}
+	if err != nil {
+		logger.Error("error connecting to grpc", "error", err, "dest", destAddr)
+		return
+	}
+
+	// Wait for goroutines to exit before exiting to prevent leaking.
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
+	// socket -> gRPC
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		n, err := io.Copy(dest, conn)
+		if ctx.Err() == nil && err != nil {
+			logger.Error("error proxying to Consul", "error", err, "dest", destAddr,
+				"src_local", conn.LocalAddr(), "src_remote", conn.RemoteAddr(),
+				"bytes", n,
+			)
+			return
+		}
+		logger.Trace("proxy to Consul complete",
+			"src_local", conn.LocalAddr(), "src_remote", conn.RemoteAddr(),
+			"bytes", n,
+		)
+	}()
+
+	// gRPC -> socket
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		n, err := io.Copy(conn, dest)
+		if ctx.Err() == nil && err != nil {
+			logger.Trace("error proxying from Consul", "error", err, "dest", destAddr,
+				"src_local", conn.LocalAddr(), "src_remote", conn.RemoteAddr(),
+				"bytes", n,
+			)
+			return
+		}
+		logger.Trace("proxy from Consul complete",
+			"src_local", conn.LocalAddr(), "src_remote", conn.RemoteAddr(),
+			"bytes", n,
+		)
+	}()
+
+	// When cancelled close connections to break out of copies goroutines.
+	<-ctx.Done()
+	conn.Close()
+	dest.Close()
+}

--- a/client/allocrunner/consulsock_hook.go
+++ b/client/allocrunner/consulsock_hook.go
@@ -281,7 +281,7 @@ func proxyConn(ctx context.Context, logger hclog.Logger, destAddr string, conn n
 		defer cancel()
 		n, err := io.Copy(dest, conn)
 		if ctx.Err() == nil && err != nil {
-			logger.Error("error proxying to Consul", "error", err, "dest", destAddr,
+			logger.Warn("error proxying to Consul", "error", err, "dest", destAddr,
 				"src_local", conn.LocalAddr(), "src_remote", conn.RemoteAddr(),
 				"bytes", n,
 			)
@@ -300,7 +300,7 @@ func proxyConn(ctx context.Context, logger hclog.Logger, destAddr string, conn n
 		defer cancel()
 		n, err := io.Copy(conn, dest)
 		if ctx.Err() == nil && err != nil {
-			logger.Trace("error proxying from Consul", "error", err, "dest", destAddr,
+			logger.Warn("error proxying from Consul", "error", err, "dest", destAddr,
 				"src_local", conn.LocalAddr(), "src_remote", conn.RemoteAddr(),
 				"bytes", n,
 			)

--- a/client/allocrunner/consulsock_hook.go
+++ b/client/allocrunner/consulsock_hook.go
@@ -43,7 +43,7 @@ func newConsulSockHook(logger hclog.Logger, alloc *structs.Allocation, allocDir 
 	return h
 }
 
-func (consulSockHook) Name() string {
+func (*consulSockHook) Name() string {
 	return "consul_socket"
 }
 

--- a/client/allocrunner/consulsock_hook_test.go
+++ b/client/allocrunner/consulsock_hook_test.go
@@ -1,0 +1,275 @@
+package allocrunner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConsulSockHook_PrerunPostrun_Ok asserts that a proxy is started when the
+// Consul unix socket hook's Prerun method is called and stopped with the
+// Postrun method is called.
+func TestConsulSockHook_PrerunPostrun_Ok(t *testing.T) {
+	t.Parallel()
+
+	// As of Consul 1.6.0 the test server does not support the gRPC
+	// endpoint so we have to fake it.
+	fakeConsul, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer fakeConsul.Close()
+	consulConfig := &config.ConsulConfig{
+		GRPCAddr: fakeConsul.Addr().String(),
+	}
+
+	alloc := mock.ConnectAlloc()
+
+	logger := testlog.HCLogger(t)
+
+	allocDir, cleanup := allocdir.TestAllocDir(t, logger, "EnvoyBootstrap")
+	defer cleanup()
+
+	// Start the unix socket proxy
+	h := newConsulSockHook(logger, alloc, allocDir, consulConfig)
+	require.NoError(t, h.Prerun())
+
+	gRPCSock := filepath.Join(allocDir.AllocDir, allocdir.AllocGRPCSocket)
+	envoyConn, err := net.Dial("unix", gRPCSock)
+	require.NoError(t, err)
+
+	// Write to Consul to ensure data is proxied out of the netns
+	input := bytes.Repeat([]byte{'X'}, 5*1024)
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := envoyConn.Write(input)
+		errCh <- err
+	}()
+
+	// Accept the connection from the netns
+	consulConn, err := fakeConsul.Accept()
+	require.NoError(t, err)
+	defer consulConn.Close()
+
+	output := make([]byte, len(input))
+	_, err = consulConn.Read(output)
+	require.NoError(t, err)
+	require.NoError(t, <-errCh)
+	require.Equal(t, input, output)
+
+	// Read from Consul to ensure data is proxied into the netns
+	input = bytes.Repeat([]byte{'Y'}, 5*1024)
+	go func() {
+		_, err := consulConn.Write(input)
+		errCh <- err
+	}()
+
+	_, err = envoyConn.Read(output)
+	require.NoError(t, err)
+	require.NoError(t, <-errCh)
+	require.Equal(t, input, output)
+
+	// Stop the unix socket proxy
+	require.NoError(t, h.Postrun())
+
+	// Consul reads should error
+	n, err := consulConn.Read(output)
+	require.Error(t, err)
+	require.Zero(t, n)
+
+	// Envoy reads and writes should error
+	n, err = envoyConn.Write(input)
+	require.Error(t, err)
+	require.Zero(t, n)
+	n, err = envoyConn.Read(output)
+	require.Error(t, err)
+	require.Zero(t, n)
+}
+
+// TestConsulSockHook_Prerun_Error asserts that invalid Consul addresses cause
+// Prerun to return an error if the alloc requires a grpc proxy.
+func TestConsulSockHook_Prerun_Error(t *testing.T) {
+	t.Parallel()
+
+	logger := testlog.HCLogger(t)
+
+	allocDir, cleanup := allocdir.TestAllocDir(t, logger, "EnvoyBootstrap")
+	defer cleanup()
+
+	// A config without an Addr or GRPCAddr is invalid.
+	consulConfig := &config.ConsulConfig{}
+
+	alloc := mock.Alloc()
+	connectAlloc := mock.ConnectAlloc()
+
+	{
+		// An alloc without a Connect proxy sidecar should not return
+		// an error.
+		h := newConsulSockHook(logger, alloc, allocDir, consulConfig)
+		require.NoError(t, h.Prerun())
+
+		// Postrun should be a noop
+		require.NoError(t, h.Postrun())
+	}
+
+	{
+		// An alloc *with* a Connect proxy sidecar *should* return an error
+		// when Consul is not configured.
+		h := newConsulSockHook(logger, connectAlloc, allocDir, consulConfig)
+		require.Error(t, h.Prerun())
+
+		// Postrun should be a noop
+		require.NoError(t, h.Postrun())
+	}
+
+	{
+		// Updating an alloc without a sidecar to have a sidecar should
+		// error when the sidecar is added.
+		h := newConsulSockHook(logger, alloc, allocDir, consulConfig)
+		require.NoError(t, h.Prerun())
+
+		req := &interfaces.RunnerUpdateRequest{
+			Alloc: connectAlloc,
+		}
+		require.Error(t, h.Update(req))
+
+		// Postrun should be a noop
+		require.NoError(t, h.Postrun())
+	}
+}
+
+// TestConsulSockHook_proxy_Unix asserts that the destination can be a unix
+// socket path.
+func TestConsulSockHook_proxy_Unix(t *testing.T) {
+	t.Parallel()
+
+	dir, err := ioutil.TempDir("", "nomadtest_proxy_Unix")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+
+	// Setup fake listener that would be inside the netns (normally a unix
+	// socket, but it doesn't matter for this test).
+	src, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer src.Close()
+
+	// Setup fake listener that would be Consul outside the netns. Use a
+	// socket as Consul may be configured to listen on a unix socket.
+	destFn := filepath.Join(dir, "fakeconsul.sock")
+	dest, err := net.Listen("unix", destFn)
+	require.NoError(t, err)
+	defer dest.Close()
+
+	// Collect errors (must have len > goroutines)
+	errCh := make(chan error, 10)
+
+	// Block until completion
+	wg := sync.WaitGroup{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		proxy(ctx, testlog.HCLogger(t), "unix://"+destFn, src)
+	}()
+
+	// Fake Envoy
+	// Connect and write to the src (netns) side of the proxy; then read
+	// and exit.
+	wg.Add(1)
+	go func() {
+		defer func() {
+			// Cancel after final read has completed (or an error
+			// has occurred)
+			cancel()
+
+			wg.Done()
+		}()
+
+		addr := src.Addr()
+		conn, err := net.Dial(addr.Network(), addr.String())
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		defer conn.Close()
+
+		if _, err := conn.Write([]byte{'X'}); err != nil {
+			errCh <- err
+			return
+		}
+
+		recv := make([]byte, 1)
+		if _, err := conn.Read(recv); err != nil {
+			errCh <- err
+			return
+		}
+
+		if expected := byte('Y'); recv[0] != expected {
+			errCh <- fmt.Errorf("expected %q but received: %q", expected, recv[0])
+			return
+		}
+	}()
+
+	// Fake Consul on a unix socket
+	// Listen, receive 1 byte, write a response, and exit
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		conn, err := dest.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		// Close listener now. No more connections expected.
+		if err := dest.Close(); err != nil {
+			errCh <- err
+			return
+		}
+
+		defer conn.Close()
+
+		recv := make([]byte, 1)
+		if _, err := conn.Read(recv); err != nil {
+			errCh <- err
+			return
+		}
+
+		if expected := byte('X'); recv[0] != expected {
+			errCh <- fmt.Errorf("expected %q but received: %q", expected, recv[0])
+			return
+		}
+
+		if _, err := conn.Write([]byte{'Y'}); err != nil {
+			errCh <- err
+			return
+		}
+	}()
+
+	// Wait for goroutines to complete
+	wg.Wait()
+
+	// Make sure no errors occurred
+	for len(errCh) > 0 {
+		assert.NoError(t, <-errCh)
+	}
+}

--- a/client/allocrunner/groupservice_hook_test.go
+++ b/client/allocrunner/groupservice_hook_test.go
@@ -45,30 +45,7 @@ func TestGroupServiceHook_NoGroupServices(t *testing.T) {
 func TestGroupServiceHook_GroupServices(t *testing.T) {
 	t.Parallel()
 
-	alloc := mock.Alloc()
-	alloc.AllocatedResources.Shared.Networks = []*structs.NetworkResource{
-		{
-			Mode: "bridge",
-			IP:   "10.0.0.1",
-			DynamicPorts: []structs.Port{
-				{
-					Label: "connect-proxy-testconnect",
-					Value: 9999,
-					To:    9998,
-				},
-			},
-		},
-	}
-	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
-	tg.Services = []*structs.Service{
-		{
-			Name:      "testconnect",
-			PortLabel: "9999",
-			Connect: &structs.ConsulConnect{
-				SidecarService: &structs.ConsulSidecarService{},
-			},
-		},
-	}
+	alloc := mock.ConnectAlloc()
 	logger := testlog.HCLogger(t)
 	consulClient := consul.NewMockConsulServiceClient(t, logger)
 

--- a/client/allocrunner/taskrunner/envoybootstrap_hook.go
+++ b/client/allocrunner/taskrunner/envoybootstrap_hook.go
@@ -72,9 +72,9 @@ func (h *envoyBootstrapHook) Prestart(ctx context.Context, req *interfaces.TaskP
 
 	h.logger.Debug("bootstrapping Connect proxy sidecar", "task", req.Task.Name, "service", serviceName)
 
-	//TODO(schmichael) relies on GRPCSocket being created
-	//TODO(schmichael) unnecessasry if the sidecar is running on the host netns
-	grpcAddr := "unix://" + filepath.Join(allocdir.SharedAllocName, allocdir.AllocGRPCSocket)
+	//TODO Should connect directly to Consul if the sidecar is running on
+	//     the host netns.
+	grpcAddr := "unix://" + allocdir.AllocGRPCSocket
 
 	// Envoy bootstrap configuration may contain a Consul token, so write
 	// it to the secrets directory like Vault tokens.

--- a/client/allocrunner/taskrunner/envoybootstrap_hook_test.go
+++ b/client/allocrunner/taskrunner/envoybootstrap_hook_test.go
@@ -12,8 +12,10 @@ import (
 	consultest "github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/testutil"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
+	"github.com/hashicorp/nomad/helper/args"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -73,14 +75,8 @@ func TestTaskRunner_EnvoyBootstrapHook_Ok(t *testing.T) {
 
 	logger := testlog.HCLogger(t)
 
-	tmpAllocDir, err := ioutil.TempDir("", "EnvoyBootstrapHookTest")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpAllocDir)
-
-	allocDir := allocdir.NewAllocDir(testlog.HCLogger(t), tmpAllocDir)
-	defer allocDir.Destroy()
+	allocDir, cleanup := allocdir.TestAllocDir(t, logger, "EnvoyBootstrap")
+	defer cleanup()
 
 	// Register Group Services
 	consulConfig := consulapi.DefaultConfig()
@@ -108,7 +104,11 @@ func TestTaskRunner_EnvoyBootstrapHook_Ok(t *testing.T) {
 	// Assert it is Done
 	require.True(t, resp.Done)
 
-	f, err := os.Open(filepath.Join(req.TaskDir.SecretsDir, "envoy_bootstrap.json"))
+	// Ensure the default path matches
+	env := map[string]string{
+		taskenv.SecretsDir: req.TaskDir.SecretsDir,
+	}
+	f, err := os.Open(args.ReplaceEnv(structs.EnvoyBootstrapPath, env))
 	require.NoError(t, err)
 	defer f.Close()
 
@@ -123,14 +123,8 @@ func TestTaskRunner_EnvoyBootstrapHook_Noop(t *testing.T) {
 	t.Parallel()
 	logger := testlog.HCLogger(t)
 
-	tmpAllocDir, err := ioutil.TempDir("", "EnvoyBootstrapHookTest")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpAllocDir)
-
-	allocDir := allocdir.NewAllocDir(testlog.HCLogger(t), tmpAllocDir)
-	defer allocDir.Destroy()
+	allocDir, cleanup := allocdir.TestAllocDir(t, logger, "EnvoyBootstrap")
+	defer cleanup()
 
 	alloc := mock.Alloc()
 	task := alloc.Job.LookupTaskGroup(alloc.TaskGroup).Tasks[0]
@@ -153,7 +147,7 @@ func TestTaskRunner_EnvoyBootstrapHook_Noop(t *testing.T) {
 	require.True(t, resp.Done)
 
 	// Assert no file was written
-	_, err = os.Open(filepath.Join(req.TaskDir.SecretsDir, "envoy_bootstrap.json"))
+	_, err := os.Open(filepath.Join(req.TaskDir.SecretsDir, "envoy_bootstrap.json"))
 	require.Error(t, err)
 	require.True(t, os.IsNotExist(err))
 }
@@ -209,14 +203,8 @@ func TestTaskRunner_EnvoyBootstrapHook_RecoverableError(t *testing.T) {
 
 	logger := testlog.HCLogger(t)
 
-	tmpAllocDir, err := ioutil.TempDir("", "EnvoyBootstrapHookTest")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpAllocDir)
-
-	allocDir := allocdir.NewAllocDir(testlog.HCLogger(t), tmpAllocDir)
-	defer allocDir.Destroy()
+	allocDir, cleanup := allocdir.TestAllocDir(t, logger, "EnvoyBootstrap")
+	defer cleanup()
 
 	// Unlike the successful test above, do NOT register the group services
 	// yet. This should cause a recoverable error similar to if Consul was

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -23,7 +23,7 @@ var (
 	connectDriverConfig = map[string]interface{}{
 		"image": "${meta.connect.sidecar_image}",
 		"args": []interface{}{
-			"-c", "${NOMAD_TASK_DIR}/bootstrap.json",
+			"-c", structs.EnvoyBootstrapPath,
 			"-l", "${meta.connect.log_level}",
 		},
 	}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -381,6 +381,22 @@ func MaxParallelJob() *structs.Job {
 	return job
 }
 
+// ConnectJob adds a Connect proxy sidecar group service to mock.Job.
+func ConnectJob() *structs.Job {
+	job := Job()
+	tg := job.TaskGroups[0]
+	tg.Services = []*structs.Service{
+		{
+			Name:      "testconnect",
+			PortLabel: "9999",
+			Connect: &structs.ConsulConnect{
+				SidecarService: &structs.ConsulSidecarService{},
+			},
+		},
+	}
+	return job
+}
+
 func BatchJob() *structs.Job {
 	job := &structs.Job{
 		Region:      "global",
@@ -622,6 +638,26 @@ func Alloc() *structs.Allocation {
 		ClientStatus:  structs.AllocClientStatusPending,
 	}
 	alloc.JobID = alloc.Job.ID
+	return alloc
+}
+
+// ConnectJob adds a Connect proxy sidecar group service to mock.Alloc.
+func ConnectAlloc() *structs.Allocation {
+	alloc := Alloc()
+	alloc.Job = ConnectJob()
+	alloc.AllocatedResources.Shared.Networks = []*structs.NetworkResource{
+		{
+			Mode: "bridge",
+			IP:   "10.0.0.1",
+			DynamicPorts: []structs.Port{
+				{
+					Label: "connect-proxy-testconnect",
+					Value: 9999,
+					To:    9999,
+				},
+			},
+		},
+	}
 	return alloc
 }
 

--- a/nomad/structs/config/consul.go
+++ b/nomad/structs/config/consul.go
@@ -61,6 +61,9 @@ type ConsulConfig struct {
 	// Uses Consul's default and env var.
 	Addr string `hcl:"address"`
 
+	// GRPCAddr is the gRPC endpoint address of the local Consul agent
+	GRPCAddr string `hcl:"grpc_address"`
+
 	// Timeout is used by Consul HTTP Client
 	Timeout    time.Duration
 	TimeoutHCL string `hcl:"timeout" json:"-"`
@@ -160,6 +163,9 @@ func (a *ConsulConfig) Merge(b *ConsulConfig) *ConsulConfig {
 	}
 	if b.Addr != "" {
 		result.Addr = b.Addr
+	}
+	if b.GRPCAddr != "" {
+		result.GRPCAddr = b.GRPCAddr
 	}
 	if b.Timeout != 0 {
 		result.Timeout = b.Timeout

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -19,6 +19,8 @@ import (
 )
 
 const (
+	EnvoyBootstrapPath = "${NOMAD_SECRETS_DIR}/envoy_bootstrap.json"
+
 	ServiceCheckHTTP   = "http"
 	ServiceCheckTCP    = "tcp"
 	ServiceCheckScript = "script"


### PR DESCRIPTION
Fixes #6124

Implement a L4 proxy from a unix socket inside a network namespace to
Consul's gRPC endpoint on the host. This allows Envoy to connect to
Consul's xDS configuration API.