### PR TITLE
e2e: filter default AMI by OS

### DIFF
--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -63,6 +63,12 @@ data "aws_ami" "main" {
     name   = "name"
     values = ["nomad-e2e-*"]
   }
+
+  filter {
+    name   = "tag:OS"
+    values = ["Ubuntu"]
+  }
+
 }
 
 output "servers" {

--- a/e2e/terraform/packer.json
+++ b/e2e/terraform/packer.json
@@ -6,7 +6,10 @@
     "instance_type": "t2.medium",
     "ssh_username": "ubuntu",
     "ami_name": "nomad-e2e-{{timestamp}}",
-    "ami_groups": ["all"]
+    "ami_groups": ["all"],
+    "tags": {
+      "OS": "Ubuntu"
+    }
   }],
   "provisioners":  [
   {


### PR DESCRIPTION
Add an OS tag to Packer builds of our e2e test AMIs and then filters by this in Terraform.

(I've also hand-tagged the most recent AMI so we can use it immediately in nightly e2e once this is merged rather than waiting for the next AMI to be baked.)