### PR TITLE
fingerprinting: Stop setting "Node.Resources"

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -498,15 +498,15 @@ type NodeReservedResources struct {
 }
 
 type NodeReservedCpuResources struct {
-	CpuShares uint64
+	CpuShares int64
 }
 
 type NodeReservedMemoryResources struct {
-	MemoryMB uint64
+	MemoryMB int64
 }
 
 type NodeReservedDiskResources struct {
-	DiskMB uint64
+	DiskMB int64
 }
 
 type NodeReservedNetworkResources struct {

--- a/client/client.go
+++ b/client/client.go
@@ -1343,20 +1343,6 @@ func (c *Client) updateNodeFromFingerprint(response *fingerprint.FingerprintResp
 		}
 	}
 
-	// COMPAT(0.10): Remove in 0.10
-	// update the response networks with the config
-	// if we still have node changes, merge them
-	if response.Resources != nil {
-		response.Resources.Networks = updateNetworks(
-			c.config.Node.Resources.Networks,
-			response.Resources.Networks,
-			c.config)
-		if !c.config.Node.Resources.Equals(response.Resources) {
-			c.config.Node.Resources.Merge(response.Resources)
-			nodeHasChanged = true
-		}
-	}
-
 	// update the response networks with the config
 	// if we still have node changes, merge them
 	if response.NodeResources != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -2789,7 +2789,7 @@ func (c *Client) emitClientMetrics() {
 func (c *Client) getAllocatedResources(selfNode *structs.Node) *structs.ComparableResources {
 	// Unfortunately the allocs only have IP so we need to match them to the
 	// device
-	cidrToDevice := make(map[*net.IPNet]string, len(selfNode.Resources.Networks))
+	cidrToDevice := make(map[*net.IPNet]string, len(selfNode.NodeResources.Networks))
 	for _, n := range selfNode.NodeResources.Networks {
 		_, ipnet, err := net.ParseCIDR(n.CIDR)
 		if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1261,15 +1261,9 @@ func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
 			Cpu:      structs.NodeCpuResources{CpuShares: 123},
 			Networks: []*structs.NetworkResource{{Device: "any-interface"}},
 		},
-		Resources: &structs.Resources{
-			CPU:      80,
-			Networks: []*structs.NetworkResource{{Device: "any-interface"}},
-		},
 	})
 	assert.Equal(t, int64(123), client.config.Node.NodeResources.Cpu.CpuShares)
 	assert.Equal(t, "any-interface", client.config.Node.NodeResources.Networks[0].Device)
-	assert.Equal(t, 80, client.config.Node.Resources.CPU)
-	assert.Equal(t, "any-interface", client.config.Node.Resources.Networks[0].Device)
 
 	// Client with network interface configured keeps the config
 	// setting on update
@@ -1279,7 +1273,6 @@ func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
 		c.Node.Name = name
 		// Node is already a mock.Node, with a device
 		c.Node.NodeResources.Networks[0].Device = dev
-		c.Node.Resources.Networks = c.Node.NodeResources.Networks
 	})
 	defer cleanup()
 	client.updateNodeFromFingerprint(&fingerprint.FingerprintResponse{
@@ -1290,10 +1283,6 @@ func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
 				{Device: dev, MBits: 20},
 			},
 		},
-		Resources: &structs.Resources{
-			CPU:      80,
-			Networks: []*structs.NetworkResource{{Device: "any-interface"}},
-		},
 	})
 	assert.Equal(t, int64(123), client.config.Node.NodeResources.Cpu.CpuShares)
 	// only the configured device is kept
@@ -1301,8 +1290,6 @@ func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
 	assert.Equal(t, dev, client.config.Node.NodeResources.Networks[0].Device)
 	// network speed updates to the configured network are kept
 	assert.Equal(t, 20, client.config.Node.NodeResources.Networks[0].MBits)
-	assert.Equal(t, 80, client.config.Node.Resources.CPU)
-	assert.Equal(t, dev, client.config.Node.Resources.Networks[0].Device)
 
 	// Network speed is applied to all NetworkResources
 	client.config.NetworkInterface = ""
@@ -1311,10 +1298,6 @@ func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
 		NodeResources: &structs.NodeResources{
 			Cpu:      structs.NodeCpuResources{CpuShares: 123},
 			Networks: []*structs.NetworkResource{{Device: "any-interface", MBits: 20}},
-		},
-		Resources: &structs.Resources{
-			CPU:      80,
-			Networks: []*structs.NetworkResource{{Device: "any-interface"}},
 		},
 	})
 	assert.Equal(t, "any-interface", client.config.Node.NodeResources.Networks[0].Device)
@@ -1337,7 +1320,6 @@ func Test_UpdateNodeFromFingerprintMultiIP(t *testing.T) {
 	client, cleanup := TestClient(t, func(c *config.Config) {
 		c.NetworkInterface = dev
 		c.Node.NodeResources.Networks[0].Device = dev
-		c.Node.Resources.Networks = c.Node.NodeResources.Networks
 	})
 	defer cleanup()
 

--- a/client/fingerprint/cpu.go
+++ b/client/fingerprint/cpu.go
@@ -23,11 +23,6 @@ func NewCPUFingerprint(logger log.Logger) Fingerprint {
 func (f *CPUFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintResponse) error {
 	cfg := req.Config
 	setResourcesCPU := func(totalCompute int) {
-		// COMPAT(0.10): Remove in 0.10
-		resp.Resources = &structs.Resources{
-			CPU: totalCompute,
-		}
-
 		resp.NodeResources = &structs.NodeResources{
 			Cpu: structs.NodeCpuResources{
 				CpuShares: int64(totalCompute),

--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -147,13 +147,11 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 	} else if throughput == 0 {
 		// Failed to determine speed. Check if the network fingerprint got it
 		found := false
-		if request.Node.Resources != nil && len(request.Node.Resources.Networks) > 0 {
-			for _, n := range request.Node.Resources.Networks {
-				if n.IP == newNetwork.IP {
-					throughput = n.MBits
-					found = true
-					break
-				}
+		if request.Node.NodeResources.Networks != nil && len(request.Node.NodeResources.Networks) > 0 {
+			for _, n := range request.Node.NodeResources.Networks {
+				throughput = n.MBits
+				found = true
+				break
 			}
 		}
 

--- a/client/fingerprint/memory.go
+++ b/client/fingerprint/memory.go
@@ -43,11 +43,6 @@ func (f *MemoryFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpri
 	if totalMemory > 0 {
 		resp.AddAttribute("memory.totalbytes", fmt.Sprintf("%d", totalMemory))
 
-		// COMPAT(0.10): Remove in 0.10
-		resp.Resources = &structs.Resources{
-			MemoryMB: totalMemory / bytesInMB,
-		}
-
 		resp.NodeResources = &structs.NodeResources{
 			Memory: structs.NodeMemoryResources{
 				MemoryMB: int64(totalMemory / bytesInMB),

--- a/client/fingerprint/memory_test.go
+++ b/client/fingerprint/memory_test.go
@@ -25,13 +25,8 @@ func TestMemoryFingerprint(t *testing.T) {
 
 	assertNodeAttributeContains(t, response.Attributes, "memory.totalbytes")
 
-	if response.Resources == nil {
-		t.Fatalf("response resources should not be nil")
-	}
-
-	// COMPAT(0.10): Remove in 0.10
-	if response.Resources.MemoryMB == 0 {
-		t.Fatalf("Expected node.Resources.MemoryMB to be non-zero")
+	if response.NodeResources == nil {
+		t.Fatalf("response noderesources should not be nil")
 	}
 
 	if response.NodeResources.Memory.MemoryMB == 0 {
@@ -55,7 +50,6 @@ func TestMemoryFingerprint_Override(t *testing.T) {
 
 	assertNodeAttributeContains(t, response.Attributes, "memory.totalbytes")
 	require := require.New(t)
-	require.NotNil(response.Resources)
-	require.Equal(response.Resources.MemoryMB, memoryMB)
+	require.NotNil(response.NodeResources)
 	require.EqualValues(response.NodeResources.Memory.MemoryMB, memoryMB)
 }

--- a/client/fingerprint/network.go
+++ b/client/fingerprint/network.go
@@ -96,11 +96,6 @@ func (f *NetworkFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpr
 		return err
 	}
 
-	// COMPAT(0.10): Remove in 0.10
-	resp.Resources = &structs.Resources{
-		Networks: nwResources,
-	}
-
 	resp.NodeResources = &structs.NodeResources{
 		Networks: nwResources,
 	}

--- a/client/fingerprint/network_test.go
+++ b/client/fingerprint/network_test.go
@@ -214,12 +214,12 @@ func TestNetworkFingerprint_basic(t *testing.T) {
 		t.Fatalf("Bad IP match: %s", ip)
 	}
 
-	if response.Resources == nil || len(response.Resources.Networks) == 0 {
+	if response.NodeResources == nil || len(response.NodeResources.Networks) == 0 {
 		t.Fatal("Expected to find Network Resources")
 	}
 
 	// Test at least the first Network Resource
-	net := response.Resources.Networks[0]
+	net := response.NodeResources.Networks[0]
 	if net.IP == "" {
 		t.Fatal("Expected Network Resource to not be empty")
 	}
@@ -288,12 +288,12 @@ func TestNetworkFingerPrint_default_device(t *testing.T) {
 		t.Fatalf("Bad IP match: %s", ip)
 	}
 
-	if response.Resources == nil || len(response.Resources.Networks) == 0 {
+	if response.NodeResources == nil || len(response.NodeResources.Networks) == 0 {
 		t.Fatal("Expected to find Network Resources")
 	}
 
 	// Test at least the first Network Resource
-	net := response.Resources.Networks[0]
+	net := response.NodeResources.Networks[0]
 	if net.IP == "" {
 		t.Fatal("Expected Network Resource to not be empty")
 	}
@@ -335,12 +335,12 @@ func TestNetworkFingerPrint_LinkLocal_Allowed(t *testing.T) {
 		t.Fatalf("Bad IP match: %s", ip)
 	}
 
-	if response.Resources == nil || len(response.Resources.Networks) == 0 {
+	if response.NodeResources == nil || len(response.NodeResources.Networks) == 0 {
 		t.Fatal("Expected to find Network Resources")
 	}
 
 	// Test at least the first Network Resource
-	net := response.Resources.Networks[0]
+	net := response.NodeResources.Networks[0]
 	if net.IP == "" {
 		t.Fatal("Expected Network Resource to not be empty")
 	}
@@ -386,12 +386,12 @@ func TestNetworkFingerPrint_LinkLocal_Allowed_MixedIntf(t *testing.T) {
 		t.Fatalf("Bad IP match: %s", ip)
 	}
 
-	if response.Resources == nil || len(response.Resources.Networks) == 0 {
+	if response.NodeResources == nil || len(response.NodeResources.Networks) == 0 {
 		t.Fatal("Expected to find Network Resources")
 	}
 
 	// Test at least the first Network Resource
-	net := response.Resources.Networks[0]
+	net := response.NodeResources.Networks[0]
 	if net.IP == "" {
 		t.Fatal("Expected Network Resource to not be empty")
 	}

--- a/client/fingerprint/storage.go
+++ b/client/fingerprint/storage.go
@@ -46,10 +46,6 @@ func (f *StorageFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpr
 	resp.AddAttribute("unique.storage.bytesfree", strconv.FormatUint(free, 10))
 
 	// set the disk size for the response
-	// COMPAT(0.10): Remove in 0.10
-	resp.Resources = &structs.Resources{
-		DiskMB: int(free / bytesPerMegabyte),
-	}
 	resp.NodeResources = &structs.NodeResources{
 		Disk: structs.NodeDiskResources{
 			DiskMB: int64(free / bytesPerMegabyte),

--- a/client/fingerprint/storage_test.go
+++ b/client/fingerprint/storage_test.go
@@ -37,14 +37,6 @@ func TestStorageFingerprint(t *testing.T) {
 		t.Fatalf("unique.storage.bytesfree %d is larger than unique.storage.bytestotal %d", free, total)
 	}
 
-	// COMPAT(0.10): Remove in 0.10
-	if response.Resources == nil {
-		t.Fatalf("Node Resources was nil")
-	}
-	if response.Resources.DiskMB == 0 {
-		t.Errorf("Expected node.Resources.DiskMB to be non-zero")
-	}
-
 	if response.NodeResources == nil || response.NodeResources.Disk.DiskMB == 0 {
 		t.Errorf("Expected node.Resources.DiskMB to be non-zero")
 	}

--- a/client/fingerprint/structs.go
+++ b/client/fingerprint/structs.go
@@ -17,7 +17,6 @@ type FingerprintRequest struct {
 type FingerprintResponse struct {
 	Attributes    map[string]string
 	Links         map[string]string
-	Resources     *structs.Resources // COMPAT(0.10): Remove in 0.10
 	NodeResources *structs.NodeResources
 
 	// Detected is a boolean indicating whether the fingerprinter detected

--- a/client/fingerprint_manager_test.go
+++ b/client/fingerprint_manager_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFingerprintManager_Run_ResourcesFingerprint(t *testing.T) {
+func TestFingerprintManager_Run_NodeResourcesFingerprint(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	testClient, cleanup := TestClient(t, nil)
@@ -27,9 +27,9 @@ func TestFingerprintManager_Run_ResourcesFingerprint(t *testing.T) {
 
 	node := testClient.config.Node
 
-	require.NotEqual(0, node.Resources.CPU)
-	require.NotEqual(0, node.Resources.MemoryMB)
-	require.NotZero(node.Resources.DiskMB)
+	require.NotEqual(0, node.NodeResources.Cpu.CpuShares)
+	require.NotEqual(0, node.NodeResources.Memory.MemoryMB)
+	require.NotZero(node.NodeResources.Disk.DiskMB)
 }
 
 func TestFimgerprintManager_Run_InWhitelist(t *testing.T) {

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -717,14 +717,16 @@ func getAllocatedResources(client *api.Client, runningAllocs []*api.Allocation, 
 func computeNodeTotalResources(node *api.Node) api.Resources {
 	total := api.Resources{}
 
-	r := node.Resources
-	res := node.Reserved
+	r := node.NodeResources
+	res := node.ReservedResources
 	if res == nil {
-		res = &api.Resources{}
+		res = &api.NodeReservedResources{}
 	}
-	total.CPU = helper.IntToPtr(*r.CPU - *res.CPU)
-	total.MemoryMB = helper.IntToPtr(*r.MemoryMB - *res.MemoryMB)
-	total.DiskMB = helper.IntToPtr(*r.DiskMB - *res.DiskMB)
+
+	total.CPU = helper.IntToPtr(int(r.Cpu.CpuShares - res.Cpu.CpuShares))
+	total.MemoryMB = helper.IntToPtr(int(r.Memory.MemoryMB - res.Memory.MemoryMB))
+	total.DiskMB = helper.IntToPtr(int(r.Disk.DiskMB - res.Disk.DiskMB))
+
 	return total
 }
 
@@ -782,7 +784,7 @@ func getHostResources(hostStats *api.HostStats, node *api.Node) ([]string, error
 	if physical {
 		resources[1] = fmt.Sprintf("%v/%d MHz|%s/%s|%s/%s",
 			math.Floor(hostStats.CPUTicksConsumed),
-			*node.Resources.CPU,
+			node.NodeResources.Cpu.CpuShares,
 			humanize.IBytes(hostStats.Memory.Used),
 			humanize.IBytes(hostStats.Memory.Total),
 			humanize.IBytes(diskUsed),
@@ -793,7 +795,7 @@ func getHostResources(hostStats *api.HostStats, node *api.Node) ([]string, error
 		// since nomad doesn't collect the stats data.
 		resources[1] = fmt.Sprintf("%v/%d MHz|%s/%s|(%s)",
 			math.Floor(hostStats.CPUTicksConsumed),
-			*node.Resources.CPU,
+			node.NodeResources.Cpu.CpuShares,
 			humanize.IBytes(hostStats.Memory.Used),
 			humanize.IBytes(hostStats.Memory.Total),
 			storageDevice,

--- a/command/node_status_test.go
+++ b/command/node_status_test.go
@@ -78,6 +78,8 @@ func TestNodeStatusCommand_Run(t *testing.T) {
 	})
 	defer srv.Shutdown()
 
+	testutil.WaitForLeader(t, srv.RPC)
+
 	ui := new(cli.MockUi)
 	cmd := &NodeStatusCommand{Meta: Meta{Ui: ui}}
 


### PR DESCRIPTION
This PR removes the remaining client side and CLI usages of nomad `node.Resources` in favour of `node.NodeResources`. The struct definition and some server backwards compatibility handling still exists, namely in the form of `ComparableResources()`, as these are tagged for 0.11 rather than 0.10.