### PR TITLE
docker: Fix driver spec

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -189,7 +189,7 @@ var (
 			),
 			"image_delay": hclspec.NewDefault(
 				hclspec.NewAttr("image_delay", "string", false),
-				hclspec.NewLiteral("3m"),
+				hclspec.NewLiteral("\"3m\""),
 			),
 			"container": hclspec.NewDefault(
 				hclspec.NewAttr("container", "bool", false),


### PR DESCRIPTION
hclspec.NewLiteral does not quote its values, which caused `3m` to be
parsed as a nonsensical literal which broke the plugin loader during
initialization. By quoting the value here, it starts correctly.