### PR TITLE
NOMAD_PORT_<label> regression

### DIFF
--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -786,9 +786,14 @@ func buildUpstreamsEnv(envMap map[string]string, upstreams []structs.ConsulUpstr
 	}
 }
 
-func WithPortMapEnvs(envs map[string]string, ports map[string]int) map[string]string {
+// SetPortMapEnvs sets the PortMap related environment variables on the map
+func SetPortMapEnvs(envs map[string]string, ports map[string]int) map[string]string {
+	if envs == nil {
+		envs = map[string]string{}
+	}
+
 	for portLabel, port := range ports {
-		portEnv := PortPrefix + portLabel
+		portEnv := helper.CleanEnvVar(PortPrefix+portLabel, '_')
 		envs[portEnv] = strconv.Itoa(port)
 	}
 	return envs

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -786,6 +786,14 @@ func buildUpstreamsEnv(envMap map[string]string, upstreams []structs.ConsulUpstr
 	}
 }
 
+func WithPortMapEnvs(envs map[string]string, ports map[string]int) map[string]string {
+	for portLabel, port := range ports {
+		portEnv := PortPrefix + portLabel
+		envs[portEnv] = strconv.Itoa(port)
+	}
+	return envs
+}
+
 // SetHostEnvvars adds the host environment variables to the tasks. The filter
 // parameter can be use to filter host environment from entering the tasks.
 func (b *Builder) SetHostEnvvars(filter []string) *Builder {

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -784,3 +784,23 @@ func TestEnvironment_Upstreams(t *testing.T) {
 	require.Equal(t, "127.0.0.1:1234", env["foo"])
 	require.Equal(t, "1234", env["bar"])
 }
+
+func TestEnvironment_SetPortMapEnvs(t *testing.T) {
+	envs := map[string]string{
+		"foo":            "bar",
+		"NOMAD_PORT_ssh": "2342",
+	}
+	ports := map[string]int{
+		"ssh":  22,
+		"http": 80,
+	}
+
+	envs = SetPortMapEnvs(envs, ports)
+
+	expected := map[string]string{
+		"foo":             "bar",
+		"NOMAD_PORT_ssh":  "22",
+		"NOMAD_PORT_http": "80",
+	}
+	require.Equal(t, expected, envs)
+}

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -967,6 +967,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		logger.Debug("applied labels on the container", "labels", config.Labels)
 	}
 
+	task.Env = taskenv.WithPortMapEnvs(task.Env, driverConfig.PortMap)
 	config.Env = task.EnvList()
 
 	containerName := fmt.Sprintf("%s-%s", strings.Replace(task.Name, "/", "_", -1), task.AllocID)

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -655,6 +655,9 @@ func (d *Driver) containerBinds(task *drivers.TaskConfig, driverConfig *TaskConf
 func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *TaskConfig,
 	imageID string) (docker.CreateContainerOptions, error) {
 
+	// ensure that PortMap variables are populated early on
+	task.Env = taskenv.SetPortMapEnvs(task.Env, driverConfig.PortMap)
+
 	logger := d.logger.With("task_name", task.Name)
 	var c docker.CreateContainerOptions
 	if task.Resources == nil {
@@ -967,7 +970,6 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		logger.Debug("applied labels on the container", "labels", config.Labels)
 	}
 
-	task.Env = taskenv.WithPortMapEnvs(task.Env, driverConfig.PortMap)
 	config.Env = task.EnvList()
 
 	containerName := fmt.Sprintf("%s-%s", strings.Replace(task.Name, "/", "_", -1), task.AllocID)

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/drivers/shared/eventer"
 	"github.com/hashicorp/nomad/drivers/shared/executor"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
@@ -303,6 +304,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	if err := cfg.DecodeDriverConfig(&driverConfig); err != nil {
 		return nil, nil, fmt.Errorf("failed to decode driver config: %v", err)
 	}
+
+	// ensure that PortMap variables are populated early on
+	cfg.Env = taskenv.SetPortMapEnvs(cfg.Env, driverConfig.PortMap)
 
 	handle := drivers.NewTaskHandle(taskHandleVersion)
 	handle.Config = cfg


### PR DESCRIPTION
for https://github.com/hashicorp/nomad/issues/6159

## Behavior
* **In 0.8.*,** we set the port mapping in the task's environment variables.
![Screenshot from 2019-09-03 13-04-10](https://user-images.githubusercontent.com/1182129/64204798-5f678680-ce4b-11e9-87d6-4a654e9e8275.png)
* **In 0.9.0,** we do not override the port environment variables with the port map, so `NOMAD_HOST_PORT_<label>` and `NOMAD_PORT_<label>` are the same.
![Screenshot from 2019-09-03 13-06-03](https://user-images.githubusercontent.com/1182129/64204923-9dfd4100-ce4b-11e9-9900-d8c10dc87740.png)
* **In this fix,** `NOMAD_PORT_<label>` gets set to the correct value from the port mapping, so the behavior matches **0.8.***

## Todo
- [x] docker driver
- [x] ~~rkt driver~~
- [x] qemu driver
- [x] tests


The rkt driver in 0.8 wasn't setting port maps correctly, as it didn't implement `Prestart` driver config part [1]; see qemu[2] implementation for comparison

[1] https://github.com/hashicorp/nomad/blob/v0.8.7/client/driver/rkt.go#L396-L398
[2] https://github.com/hashicorp/nomad/blob/v0.8.7/client/driver/qemu.go#L186-L205