### PR TITLE
ar: refactor network bridge config to use go-cni lib

### DIFF
--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -111,7 +111,10 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 	}
 
 	// create network configurator
-	nc := newNetworkConfigurator(hookLogger, ar.Alloc(), config)
+	nc, err := newNetworkConfigurator(hookLogger, ar.Alloc(), config)
+	if err != nil {
+		return fmt.Errorf("failed to initialize network configurator: %v", err)
+	}
 
 	// Create the alloc directory hook. This is run first to ensure the
 	// directory path exists for other hooks.

--- a/client/allocrunner/network_hook.go
+++ b/client/allocrunner/network_hook.go
@@ -1,6 +1,7 @@
 package allocrunner
 
 import (
+	"context"
 	"fmt"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -70,7 +71,7 @@ func (h *networkHook) Prerun() error {
 		h.setter.SetNetworkIsolation(spec)
 	}
 
-	if err := h.networkConfigurator.Setup(h.alloc, spec); err != nil {
+	if err := h.networkConfigurator.Setup(context.Background(), h.alloc, spec); err != nil {
 		return fmt.Errorf("failed to configure networking for alloc: %v", err)
 	}
 	return nil
@@ -81,7 +82,7 @@ func (h *networkHook) Postrun() error {
 		return nil
 	}
 
-	if err := h.networkConfigurator.Teardown(h.alloc, h.spec); err != nil {
+	if err := h.networkConfigurator.Teardown(context.Background(), h.alloc, h.spec); err != nil {
 		h.logger.Error("failed to cleanup network for allocation, resources may have leaked", "alloc", h.alloc.ID, "error", err)
 	}
 	return h.manager.DestroyNetwork(h.alloc.ID, h.spec)

--- a/client/allocrunner/network_hook.go
+++ b/client/allocrunner/network_hook.go
@@ -71,7 +71,7 @@ func (h *networkHook) Prerun() error {
 		h.setter.SetNetworkIsolation(spec)
 	}
 
-	if err := h.networkConfigurator.Setup(context.Background(), h.alloc, spec); err != nil {
+	if err := h.networkConfigurator.Setup(context.TODO(), h.alloc, spec); err != nil {
 		return fmt.Errorf("failed to configure networking for alloc: %v", err)
 	}
 	return nil
@@ -82,7 +82,7 @@ func (h *networkHook) Postrun() error {
 		return nil
 	}
 
-	if err := h.networkConfigurator.Teardown(context.Background(), h.alloc, h.spec); err != nil {
+	if err := h.networkConfigurator.Teardown(context.TODO(), h.alloc, h.spec); err != nil {
 		h.logger.Error("failed to cleanup network for allocation, resources may have leaked", "alloc", h.alloc.ID, "error", err)
 	}
 	return h.manager.DestroyNetwork(h.alloc.ID, h.spec)

--- a/client/allocrunner/network_manager_linux.go
+++ b/client/allocrunner/network_manager_linux.go
@@ -1,7 +1,6 @@
 package allocrunner
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -122,18 +121,18 @@ func netModeToIsolationMode(netMode string) drivers.NetIsolationMode {
 	}
 }
 
-func newNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, config *clientconfig.Config) NetworkConfigurator {
+func newNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, config *clientconfig.Config) (NetworkConfigurator, error) {
 	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
 
 	// Check if network stanza is given
 	if len(tg.Networks) == 0 {
-		return &hostNetworkConfigurator{}
+		return &hostNetworkConfigurator{}, nil
 	}
 
 	switch strings.ToLower(tg.Networks[0].Mode) {
 	case "bridge":
-		return newBridgeNetworkConfigurator(log, context.Background(), config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.CNIPath)
+		return newBridgeNetworkConfigurator(log, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.CNIPath)
 	default:
-		return &hostNetworkConfigurator{}
+		return &hostNetworkConfigurator{}, nil
 	}
 }

--- a/client/allocrunner/network_manager_nonlinux.go
+++ b/client/allocrunner/network_manager_nonlinux.go
@@ -15,6 +15,6 @@ func newNetworkManager(alloc *structs.Allocation, driverManager drivermanager.Ma
 	return nil, nil
 }
 
-func newNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, config *clientconfig.Config) NetworkConfigurator {
-	return &hostNetworkConfigurator{}
+func newNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, config *clientconfig.Config) (NetworkConfigurator, error) {
+	return &hostNetworkConfigurator{}, nil
 }

--- a/client/allocrunner/networking.go
+++ b/client/allocrunner/networking.go
@@ -1,6 +1,8 @@
 package allocrunner
 
 import (
+	"context"
+
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
@@ -8,8 +10,8 @@ import (
 // NetworkConfigurator sets up and tears down the interfaces, routes, firewall
 // rules, etc for the configured networking mode of the allocation.
 type NetworkConfigurator interface {
-	Setup(*structs.Allocation, *drivers.NetworkIsolationSpec) error
-	Teardown(*structs.Allocation, *drivers.NetworkIsolationSpec) error
+	Setup(context.Context, *structs.Allocation, *drivers.NetworkIsolationSpec) error
+	Teardown(context.Context, *structs.Allocation, *drivers.NetworkIsolationSpec) error
 }
 
 // hostNetworkConfigurator is a noop implementation of a NetworkConfigurator for
@@ -17,9 +19,9 @@ type NetworkConfigurator interface {
 // require further configuration
 type hostNetworkConfigurator struct{}
 
-func (h *hostNetworkConfigurator) Setup(*structs.Allocation, *drivers.NetworkIsolationSpec) error {
+func (h *hostNetworkConfigurator) Setup(context.Context, *structs.Allocation, *drivers.NetworkIsolationSpec) error {
 	return nil
 }
-func (h *hostNetworkConfigurator) Teardown(*structs.Allocation, *drivers.NetworkIsolationSpec) error {
+func (h *hostNetworkConfigurator) Teardown(context.Context, *structs.Allocation, *drivers.NetworkIsolationSpec) error {
 	return nil
 }

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -150,7 +150,7 @@ func (b *bridgeNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Al
 		return fmt.Errorf("failed to initialize table forwarding rules: %v", err)
 	}
 
-	if err := b.cni.Load(cni.WithConfListBytes([]byte(b.buildNomadNetConfig()))); err != nil {
+	if err := b.cni.Load(cni.WithConfListBytes(b.buildNomadNetConfig())); err != nil {
 		return err
 	}
 

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -150,7 +150,7 @@ func (b *bridgeNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Al
 		return fmt.Errorf("failed to initialize table forwarding rules: %v", err)
 	}
 
-	if err := b.cni.Load(cni.WithConfList([]byte(b.buildNomadNetConfig()))); err != nil {
+	if err := b.cni.Load(cni.WithConfListBytes([]byte(b.buildNomadNetConfig()))); err != nil {
 		return err
 	}
 

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -30,7 +30,7 @@ const (
 
 	// bridgeNetworkAllocIfPrefix is the prefix that is used for the interface
 	// name created inside of the alloc network which is connected to the bridge
-	bridgeNetworkAllocIfPrefix = "eth0"
+	bridgeNetworkAllocIfPrefix = "eth"
 
 	// defaultNomadAllocSubnet is the subnet to use for host local ip address
 	// allocation when not specified by the client

--- a/vendor/github.com/containerd/go-cni/LICENSE
+++ b/vendor/github.com/containerd/go-cni/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/containerd/go-cni/README.md
+++ b/vendor/github.com/containerd/go-cni/README.md
@@ -1,0 +1,60 @@
+[![Build Status](https://travis-ci.org/containerd/go-cni.svg?branch=master)](https://travis-ci.org/containerd/go-cni)
+
+# go-cni
+
+A generic CNI library to provide APIs for CNI plugin interactions. The library provides APIs to:
+
+- Load CNI network config from different sources
+- Setup networks for container namespace
+- Remove networks from container namespace
+- Query status of CNI network plugin initialization
+
+go-cni aims to support plugins that implement [Container Network Interface](https://github.com/containernetworking/cni)
+
+## Usage
+```go
+func main() {
+	id := "123456"
+	netns := "/proc/9999/ns/net"
+	defaultIfName := "eth0"
+	// Initialize library
+	l = gocni.New(gocni.WithMinNetworkCount(2),
+		gocni.WithPluginConfDir("/etc/mycni/net.d"),
+		gocni.WithPluginDir([]string{"/opt/mycni/bin", "/opt/cni/bin"}),
+		gocni.WithDefaultIfName(defaultIfName))
+
+	// Load the cni configuration
+	err:= l.Load(gocni.WithLoNetwork, gocni.WithDefaultConf)
+        if err != nil{
+		log.Errorf("failed to load cni configuration: %v", err)
+		return
+	}
+
+	// Setup network for namespace.
+	labels := map[string]string{
+		"K8S_POD_NAMESPACE":          "namespace1",
+		"K8S_POD_NAME":               "pod1",
+		"K8S_POD_INFRA_CONTAINER_ID": id,
+	}
+	result, err := l.Setup(id, netns, gocni.WithLabels(labels))
+	if err != nil {
+		log.Errorf("failed to setup network for namespace %q: %v",id, err)
+		return
+	}
+
+	// Get IP of the default interface
+	IP := result.Interfaces[defaultIfName].IPConfigs[0].IP.String()
+	fmt.Printf("IP of the default interface %s:%s", defaultIfName, IP)
+}
+```
+
+## Project details
+
+The go-cni is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/vendor/github.com/containerd/go-cni/README.md
+++ b/vendor/github.com/containerd/go-cni/README.md
@@ -4,7 +4,7 @@
 
 A generic CNI library to provide APIs for CNI plugin interactions. The library provides APIs to:
 
-- Load CNI network config from different sources
+- Load CNI network config from different sources  
 - Setup networks for container namespace
 - Remove networks from container namespace
 - Query status of CNI network plugin initialization
@@ -22,14 +22,14 @@ func main() {
 		gocni.WithPluginConfDir("/etc/mycni/net.d"),
 		gocni.WithPluginDir([]string{"/opt/mycni/bin", "/opt/cni/bin"}),
 		gocni.WithDefaultIfName(defaultIfName))
-
+	
 	// Load the cni configuration
 	err:= l.Load(gocni.WithLoNetwork, gocni.WithDefaultConf)
         if err != nil{
 		log.Errorf("failed to load cni configuration: %v", err)
-		return
+		return 
 	}
-
+	
 	// Setup network for namespace.
 	labels := map[string]string{
 		"K8S_POD_NAMESPACE":          "namespace1",
@@ -39,9 +39,9 @@ func main() {
 	result, err := l.Setup(id, netns, gocni.WithLabels(labels))
 	if err != nil {
 		log.Errorf("failed to setup network for namespace %q: %v",id, err)
-		return
+		return 
 	}
-
+	
 	// Get IP of the default interface
 	IP := result.Interfaces[defaultIfName].IPConfigs[0].IP.String()
 	fmt.Printf("IP of the default interface %s:%s", defaultIfName, IP)

--- a/vendor/github.com/containerd/go-cni/cni.go
+++ b/vendor/github.com/containerd/go-cni/cni.go
@@ -1,0 +1,220 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	cnilibrary "github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/pkg/errors"
+)
+
+type CNI interface {
+	// Setup setup the network for the namespace
+	Setup(ctx context.Context, id string, path string, opts ...NamespaceOpts) (*CNIResult, error)
+	// Remove tears down the network of the namespace.
+	Remove(ctx context.Context, id string, path string, opts ...NamespaceOpts) error
+	// Load loads the cni network config
+	Load(opts ...CNIOpt) error
+	// Status checks the status of the cni initialization
+	Status() error
+	// GetConfig returns a copy of the CNI plugin configurations as parsed by CNI
+	GetConfig() *ConfigResult
+}
+
+type ConfigResult struct {
+	PluginDirs       []string
+	PluginConfDir    string
+	PluginMaxConfNum int
+	Prefix           string
+	Networks         []*ConfNetwork
+}
+
+type ConfNetwork struct {
+	Config *NetworkConfList
+	IFName string
+}
+
+// NetworkConfList is a source bytes to string version of cnilibrary.NetworkConfigList
+type NetworkConfList struct {
+	Name       string
+	CNIVersion string
+	Plugins    []*NetworkConf
+	Source     string
+}
+
+// NetworkConf is a source bytes to string conversion of cnilibrary.NetworkConfig
+type NetworkConf struct {
+	Network *types.NetConf
+	Source  string
+}
+
+type libcni struct {
+	config
+
+	cniConfig    cnilibrary.CNI
+	networkCount int // minimum network plugin configurations needed to initialize cni
+	networks     []*Network
+	sync.RWMutex
+}
+
+func defaultCNIConfig() *libcni {
+	return &libcni{
+		config: config{
+			pluginDirs:       []string{DefaultCNIDir},
+			pluginConfDir:    DefaultNetDir,
+			pluginMaxConfNum: DefaultMaxConfNum,
+			prefix:           DefaultPrefix,
+		},
+		cniConfig: &cnilibrary.CNIConfig{
+			Path: []string{DefaultCNIDir},
+		},
+		networkCount: 1,
+	}
+}
+
+// New creates a new libcni instance.
+func New(config ...CNIOpt) (CNI, error) {
+	cni := defaultCNIConfig()
+	var err error
+	for _, c := range config {
+		if err = c(cni); err != nil {
+			return nil, err
+		}
+	}
+	return cni, nil
+}
+
+// Load loads the latest config from cni config files.
+func (c *libcni) Load(opts ...CNIOpt) error {
+	var err error
+	c.Lock()
+	defer c.Unlock()
+	// Reset the networks on a load operation to ensure
+	// config happens on a clean slate
+	c.reset()
+
+	for _, o := range opts {
+		if err = o(c); err != nil {
+			return errors.Wrapf(ErrLoad, fmt.Sprintf("cni config load failed: %v", err))
+		}
+	}
+	return nil
+}
+
+// Status returns the status of CNI initialization.
+func (c *libcni) Status() error {
+	c.RLock()
+	defer c.RUnlock()
+	if len(c.networks) < c.networkCount {
+		return ErrCNINotInitialized
+	}
+	return nil
+}
+
+// Networks returns all the configured networks.
+// NOTE: Caller MUST NOT modify anything in the returned array.
+func (c *libcni) Networks() []*Network {
+	c.RLock()
+	defer c.RUnlock()
+	return append([]*Network{}, c.networks...)
+}
+
+// Setup setups the network in the namespace
+func (c *libcni) Setup(ctx context.Context, id string, path string, opts ...NamespaceOpts) (*CNIResult, error) {
+	if err := c.Status(); err != nil {
+		return nil, err
+	}
+	ns, err := newNamespace(id, path, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var results []*current.Result
+	for _, network := range c.Networks() {
+		r, err := network.Attach(ctx, ns)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, r)
+	}
+	return c.GetCNIResultFromResults(results)
+}
+
+// Remove removes the network config from the namespace
+func (c *libcni) Remove(ctx context.Context, id string, path string, opts ...NamespaceOpts) error {
+	if err := c.Status(); err != nil {
+		return err
+	}
+	ns, err := newNamespace(id, path, opts...)
+	if err != nil {
+		return err
+	}
+	for _, network := range c.Networks() {
+		if err := network.Remove(ctx, ns); err != nil {
+			// Based on CNI spec v0.7.0, empty network namespace is allowed to
+			// do best effort cleanup. However, it is not handled consistently
+			// right now:
+			// https://github.com/containernetworking/plugins/issues/210
+			// TODO(random-liu): Remove the error handling when the issue is
+			// fixed and the CNI spec v0.6.0 support is deprecated.
+			if path == "" && strings.Contains(err.Error(), "no such file or directory") {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// GetConfig returns a copy of the CNI plugin configurations as parsed by CNI
+func (c *libcni) GetConfig() *ConfigResult {
+	c.RLock()
+	defer c.RUnlock()
+	r := &ConfigResult{
+		PluginDirs:       c.config.pluginDirs,
+		PluginConfDir:    c.config.pluginConfDir,
+		PluginMaxConfNum: c.config.pluginMaxConfNum,
+		Prefix:           c.config.prefix,
+	}
+	for _, network := range c.networks {
+		conf := &NetworkConfList{
+			Name:       network.config.Name,
+			CNIVersion: network.config.CNIVersion,
+			Source:     string(network.config.Bytes),
+		}
+		for _, plugin := range network.config.Plugins {
+			conf.Plugins = append(conf.Plugins, &NetworkConf{
+				Network: plugin.Network,
+				Source:  string(plugin.Bytes),
+			})
+		}
+		r.Networks = append(r.Networks, &ConfNetwork{
+			Config: conf,
+			IFName: network.ifName,
+		})
+	}
+	return r
+}
+
+func (c *libcni) reset() {
+	c.networks = nil
+}

--- a/vendor/github.com/containerd/go-cni/errors.go
+++ b/vendor/github.com/containerd/go-cni/errors.go
@@ -1,0 +1,55 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+import (
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrCNINotInitialized = errors.New("cni plugin not initialized")
+	ErrInvalidConfig     = errors.New("invalid cni config")
+	ErrNotFound          = errors.New("not found")
+	ErrRead              = errors.New("failed to read config file")
+	ErrInvalidResult     = errors.New("invalid result")
+	ErrLoad              = errors.New("failed to load cni config")
+)
+
+// IsCNINotInitialized returns true if the error is due to cni config not being initialized
+func IsCNINotInitialized(err error) bool {
+	return errors.Cause(err) == ErrCNINotInitialized
+}
+
+// IsInvalidConfig returns true if the error is invalid cni config
+func IsInvalidConfig(err error) bool {
+	return errors.Cause(err) == ErrInvalidConfig
+}
+
+// IsNotFound returns true if the error is due to a missing config or result
+func IsNotFound(err error) bool {
+	return errors.Cause(err) == ErrNotFound
+}
+
+// IsReadFailure return true if the error is a config read failure
+func IsReadFailure(err error) bool {
+	return errors.Cause(err) == ErrRead
+}
+
+// IsInvalidResult return true if the error is due to invalid cni result
+func IsInvalidResult(err error) bool {
+	return errors.Cause(err) == ErrInvalidResult
+}

--- a/vendor/github.com/containerd/go-cni/helper.go
+++ b/vendor/github.com/containerd/go-cni/helper.go
@@ -1,0 +1,41 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+import (
+	"fmt"
+
+	"github.com/containernetworking/cni/pkg/types/current"
+)
+
+func validateInterfaceConfig(ipConf *current.IPConfig, ifs int) error {
+	if ipConf == nil {
+		return fmt.Errorf("invalid IP configuration (nil)")
+	}
+	if ipConf.Interface != nil && *ipConf.Interface > ifs {
+		return fmt.Errorf("invalid IP configuration (interface number %d is > number of interfaces %d)", *ipConf.Interface, ifs)
+	}
+	return nil
+}
+
+func getIfName(prefix string, i int) string {
+	return fmt.Sprintf("%s%d", prefix, i)
+}
+
+func defaultInterface(prefix string) string {
+	return getIfName(prefix, 0)
+}

--- a/vendor/github.com/containerd/go-cni/namespace.go
+++ b/vendor/github.com/containerd/go-cni/namespace.go
@@ -1,0 +1,77 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+import (
+	"context"
+
+	cnilibrary "github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/types/current"
+)
+
+type Network struct {
+	cni    cnilibrary.CNI
+	config *cnilibrary.NetworkConfigList
+	ifName string
+}
+
+func (n *Network) Attach(ctx context.Context, ns *Namespace) (*current.Result, error) {
+	r, err := n.cni.AddNetworkList(ctx, n.config, ns.config(n.ifName))
+	if err != nil {
+		return nil, err
+	}
+	return current.NewResultFromResult(r)
+}
+
+func (n *Network) Remove(ctx context.Context, ns *Namespace) error {
+	return n.cni.DelNetworkList(ctx, n.config, ns.config(n.ifName))
+}
+
+type Namespace struct {
+	id             string
+	path           string
+	capabilityArgs map[string]interface{}
+	args           map[string]string
+}
+
+func newNamespace(id, path string, opts ...NamespaceOpts) (*Namespace, error) {
+	ns := &Namespace{
+		id:             id,
+		path:           path,
+		capabilityArgs: make(map[string]interface{}),
+		args:           make(map[string]string),
+	}
+	for _, o := range opts {
+		if err := o(ns); err != nil {
+			return nil, err
+		}
+	}
+	return ns, nil
+}
+
+func (ns *Namespace) config(ifName string) *cnilibrary.RuntimeConf {
+	c := &cnilibrary.RuntimeConf{
+		ContainerID: ns.id,
+		NetNS:       ns.path,
+		IfName:      ifName,
+	}
+	for k, v := range ns.args {
+		c.Args = append(c.Args, [2]string{k, v})
+	}
+	c.CapabilityArgs = ns.capabilityArgs
+	return c
+}

--- a/vendor/github.com/containerd/go-cni/namespace_opts.go
+++ b/vendor/github.com/containerd/go-cni/namespace_opts.go
@@ -1,0 +1,75 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+type NamespaceOpts func(s *Namespace) error
+
+// Capabilities
+func WithCapabilityPortMap(portMapping []PortMapping) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.capabilityArgs["portMappings"] = portMapping
+		return nil
+	}
+}
+
+func WithCapabilityIPRanges(ipRanges []IPRanges) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.capabilityArgs["ipRanges"] = ipRanges
+		return nil
+	}
+}
+
+// WithCapabilityBandWitdh adds support for traffic shaping:
+// https://github.com/heptio/cni-plugins/tree/master/plugins/meta/bandwidth
+func WithCapabilityBandWidth(bandWidth BandWidth) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.capabilityArgs["bandwidth"] = bandWidth
+		return nil
+	}
+}
+
+// WithCapabilityDNS adds support for dns
+func WithCapabilityDNS(dns DNS) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.capabilityArgs["dns"] = dns
+		return nil
+	}
+}
+
+func WithCapability(name string, capability interface{}) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.capabilityArgs[name] = capability
+		return nil
+	}
+}
+
+// Args
+func WithLabels(labels map[string]string) NamespaceOpts {
+	return func(c *Namespace) error {
+		for k, v := range labels {
+			c.args[k] = v
+		}
+		return nil
+	}
+}
+
+func WithArgs(k, v string) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.args[k] = v
+		return nil
+	}
+}

--- a/vendor/github.com/containerd/go-cni/opts.go
+++ b/vendor/github.com/containerd/go-cni/opts.go
@@ -142,9 +142,9 @@ func WithConfFile(fileName string) CNIOpt {
 	}
 }
 
-// WithConfList can be used to load network config list directly
+// WithConfListBytes can be used to load network config list directly
 // from byte
-func WithConfList(bytes []byte) CNIOpt {
+func WithConfListBytes(bytes []byte) CNIOpt {
 	return func(c *libcni) error {
 		confList, err := cnilibrary.ConfListFromBytes(bytes)
 		if err != nil {

--- a/vendor/github.com/containerd/go-cni/opts.go
+++ b/vendor/github.com/containerd/go-cni/opts.go
@@ -1,0 +1,263 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+import (
+	"sort"
+	"strings"
+
+	cnilibrary "github.com/containernetworking/cni/libcni"
+	"github.com/pkg/errors"
+)
+
+type CNIOpt func(c *libcni) error
+
+// WithInterfacePrefix sets the prefix for network interfaces
+// e.g. eth or wlan
+func WithInterfacePrefix(prefix string) CNIOpt {
+	return func(c *libcni) error {
+		c.prefix = prefix
+		return nil
+	}
+}
+
+// WithPluginDir can be used to set the locations of
+// the cni plugin binaries
+func WithPluginDir(dirs []string) CNIOpt {
+	return func(c *libcni) error {
+		c.pluginDirs = dirs
+		c.cniConfig = &cnilibrary.CNIConfig{Path: dirs}
+		return nil
+	}
+}
+
+// WithPluginConfDir can be used to configure the
+// cni configuration directory.
+func WithPluginConfDir(dir string) CNIOpt {
+	return func(c *libcni) error {
+		c.pluginConfDir = dir
+		return nil
+	}
+}
+
+// WithPluginMaxConfNum can be used to configure the
+// max cni plugin config file num.
+func WithPluginMaxConfNum(max int) CNIOpt {
+	return func(c *libcni) error {
+		c.pluginMaxConfNum = max
+		return nil
+	}
+}
+
+// WithMinNetworkCount can be used to configure the
+// minimum networks to be configured and initialized
+// for the status to report success. By default its 1.
+func WithMinNetworkCount(count int) CNIOpt {
+	return func(c *libcni) error {
+		c.networkCount = count
+		return nil
+	}
+}
+
+// WithLoNetwork can be used to load the loopback
+// network config.
+func WithLoNetwork(c *libcni) error {
+	loConfig, _ := cnilibrary.ConfListFromBytes([]byte(`{
+"cniVersion": "0.3.1",
+"name": "cni-loopback",
+"plugins": [{
+  "type": "loopback"
+}]
+}`))
+
+	c.networks = append(c.networks, &Network{
+		cni:    c.cniConfig,
+		config: loConfig,
+		ifName: "lo",
+	})
+	return nil
+}
+
+// WithConf can be used to load config directly
+// from byte.
+func WithConf(bytes []byte) CNIOpt {
+	return WithConfIndex(bytes, 0)
+}
+
+// WithConfIndex can be used to load config directly
+// from byte and set the interface name's index.
+func WithConfIndex(bytes []byte, index int) CNIOpt {
+	return func(c *libcni) error {
+		conf, err := cnilibrary.ConfFromBytes(bytes)
+		if err != nil {
+			return err
+		}
+		confList, err := cnilibrary.ConfListFromConf(conf)
+		if err != nil {
+			return err
+		}
+		c.networks = append(c.networks, &Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, index),
+		})
+		return nil
+	}
+}
+
+// WithConfFile can be used to load network config
+// from an .conf file. Supported with absolute fileName
+// with path only.
+func WithConfFile(fileName string) CNIOpt {
+	return func(c *libcni) error {
+		conf, err := cnilibrary.ConfFromFile(fileName)
+		if err != nil {
+			return err
+		}
+		// upconvert to conf list
+		confList, err := cnilibrary.ConfListFromConf(conf)
+		if err != nil {
+			return err
+		}
+		c.networks = append(c.networks, &Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, 0),
+		})
+		return nil
+	}
+}
+
+// WithConfList can be used to load network config list directly
+// from byte
+func WithConfList(bytes []byte) CNIOpt {
+	return func(c *libcni) error {
+		confList, err := cnilibrary.ConfListFromBytes(bytes)
+		if err != nil {
+			return err
+		}
+		i := len(c.networks)
+		c.networks = append(c.networks, &Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, i),
+		})
+		return nil
+	}
+}
+
+// WithConfListFile can be used to load network config
+// from an .conflist file. Supported with absolute fileName
+// with path only.
+func WithConfListFile(fileName string) CNIOpt {
+	return func(c *libcni) error {
+		confList, err := cnilibrary.ConfListFromFile(fileName)
+		if err != nil {
+			return err
+		}
+		i := len(c.networks)
+		c.networks = append(c.networks, &Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, i),
+		})
+		return nil
+	}
+}
+
+// WithDefaultConf can be used to detect the default network
+// config file from the configured cni config directory and load
+// it.
+// Since the CNI spec does not specify a way to detect default networks,
+// the convention chosen is - the first network configuration in the sorted
+// list of network conf files as the default network.
+func WithDefaultConf(c *libcni) error {
+	return loadFromConfDir(c, c.pluginMaxConfNum)
+}
+
+// WithAllConf can be used to detect all network config
+// files from the configured cni config directory and load
+// them.
+func WithAllConf(c *libcni) error {
+	return loadFromConfDir(c, 0)
+}
+
+// loadFromConfDir detects network config files from the
+// configured cni config directory and load them. max is
+// the maximum network config to load (max i<= 0 means no limit).
+func loadFromConfDir(c *libcni, max int) error {
+	files, err := cnilibrary.ConfFiles(c.pluginConfDir, []string{".conf", ".conflist", ".json"})
+	switch {
+	case err != nil:
+		return errors.Wrapf(ErrRead, "failed to read config file: %v", err)
+	case len(files) == 0:
+		return errors.Wrapf(ErrCNINotInitialized, "no network config found in %s", c.pluginConfDir)
+	}
+
+	// files contains the network config files associated with cni network.
+	// Use lexicographical way as a defined order for network config files.
+	sort.Strings(files)
+	// Since the CNI spec does not specify a way to detect default networks,
+	// the convention chosen is - the first network configuration in the sorted
+	// list of network conf files as the default network and choose the default
+	// interface provided during init as the network interface for this default
+	// network. For every other network use a generated interface id.
+	i := 0
+	var networks []*Network
+	for _, confFile := range files {
+		var confList *cnilibrary.NetworkConfigList
+		if strings.HasSuffix(confFile, ".conflist") {
+			confList, err = cnilibrary.ConfListFromFile(confFile)
+			if err != nil {
+				return errors.Wrapf(ErrInvalidConfig, "failed to load CNI config list file %s: %v", confFile, err)
+			}
+		} else {
+			conf, err := cnilibrary.ConfFromFile(confFile)
+			if err != nil {
+				return errors.Wrapf(ErrInvalidConfig, "failed to load CNI config file %s: %v", confFile, err)
+			}
+			// Ensure the config has a "type" so we know what plugin to run.
+			// Also catches the case where somebody put a conflist into a conf file.
+			if conf.Network.Type == "" {
+				return errors.Wrapf(ErrInvalidConfig, "network type not found in %s", confFile)
+			}
+
+			confList, err = cnilibrary.ConfListFromConf(conf)
+			if err != nil {
+				return errors.Wrapf(ErrInvalidConfig, "failed to convert CNI config file %s to CNI config list: %v", confFile, err)
+			}
+		}
+		if len(confList.Plugins) == 0 {
+			return errors.Wrapf(ErrInvalidConfig, "CNI config list in config file %s has no networks, skipping", confFile)
+
+		}
+		networks = append(networks, &Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, i),
+		})
+		i++
+		if i == max {
+			break
+		}
+	}
+	if len(networks) == 0 {
+		return errors.Wrapf(ErrCNINotInitialized, "no valid networks found in %s", c.pluginDirs)
+	}
+	c.networks = append(c.networks, networks...)
+	return nil
+}

--- a/vendor/github.com/containerd/go-cni/result.go
+++ b/vendor/github.com/containerd/go-cni/result.go
@@ -1,0 +1,106 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+import (
+	"net"
+
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/pkg/errors"
+)
+
+type IPConfig struct {
+	IP      net.IP
+	Gateway net.IP
+}
+
+type CNIResult struct {
+	Interfaces map[string]*Config
+	DNS        []types.DNS
+	Routes     []*types.Route
+}
+
+type Config struct {
+	IPConfigs []*IPConfig
+	Mac       string
+	Sandbox   string
+}
+
+// GetCNIResultFromResults returns a structured data containing the
+// interface configuration for each of the interfaces created in the namespace.
+// Conforms with
+// Result:
+// a) Interfaces list. Depending on the plugin, this can include the sandbox
+// (eg, container or hypervisor) interface name and/or the host interface
+// name, the hardware addresses of each interface, and details about the
+// sandbox (if any) the interface is in.
+// b) IP configuration assigned to each  interface. The IPv4 and/or IPv6 addresses,
+// gateways, and routes assigned to sandbox and/or host interfaces.
+// c) DNS information. Dictionary that includes DNS information for nameservers,
+// domain, search domains and options.
+func (c *libcni) GetCNIResultFromResults(results []*current.Result) (*CNIResult, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	r := &CNIResult{
+		Interfaces: make(map[string]*Config),
+	}
+
+	// Plugins may not need to return Interfaces in result if
+	// if there are no multiple interfaces created. In that case
+	// all configs should be applied against default interface
+	r.Interfaces[defaultInterface(c.prefix)] = &Config{}
+
+	// Walk through all the results
+	for _, result := range results {
+		// Walk through all the interface in each result
+		for _, intf := range result.Interfaces {
+			r.Interfaces[intf.Name] = &Config{
+				Mac:     intf.Mac,
+				Sandbox: intf.Sandbox,
+			}
+		}
+		// Walk through all the IPs in the result and attach it to corresponding
+		// interfaces
+		for _, ipConf := range result.IPs {
+			if err := validateInterfaceConfig(ipConf, len(result.Interfaces)); err != nil {
+				return nil, errors.Wrapf(ErrInvalidResult, "invalid interface config: %v", err)
+			}
+			name := c.getInterfaceName(result.Interfaces, ipConf)
+			r.Interfaces[name].IPConfigs = append(r.Interfaces[name].IPConfigs,
+				&IPConfig{IP: ipConf.Address.IP, Gateway: ipConf.Gateway})
+		}
+		r.DNS = append(r.DNS, result.DNS)
+		r.Routes = append(r.Routes, result.Routes...)
+	}
+	if _, ok := r.Interfaces[defaultInterface(c.prefix)]; !ok {
+		return nil, errors.Wrapf(ErrNotFound, "default network not found for: %s", defaultInterface(c.prefix))
+	}
+	return r, nil
+}
+
+// getInterfaceName returns the interface name if the plugins
+// return the result with associated interfaces. If interface
+// is not present then default interface name is used
+func (c *libcni) getInterfaceName(interfaces []*current.Interface,
+	ipConf *current.IPConfig) string {
+	if ipConf.Interface != nil {
+		return interfaces[*ipConf.Interface].Name
+	}
+	return defaultInterface(c.prefix)
+}

--- a/vendor/github.com/containerd/go-cni/testutils.go
+++ b/vendor/github.com/containerd/go-cni/testutils.go
@@ -1,0 +1,78 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func makeTmpDir(prefix string) (string, error) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), prefix)
+	if err != nil {
+		return "", err
+	}
+	return tmpDir, nil
+}
+
+func makeFakeCNIConfig(t *testing.T) (string, string) {
+	cniDir, err := makeTmpDir("fakecni")
+	if err != nil {
+		t.Fatalf("Failed to create plugin config dir: %v", err)
+	}
+
+	cniConfDir := path.Join(cniDir, "net.d")
+	err = os.MkdirAll(cniConfDir, 0777)
+	if err != nil {
+		t.Fatalf("Failed to create network config dir: %v", err)
+	}
+
+	networkConfig1 := path.Join(cniConfDir, "mocknetwork1.conf")
+	f1, err := os.Create(networkConfig1)
+	if err != nil {
+		t.Fatalf("Failed to create network config %v: %v", f1, err)
+	}
+	networkConfig2 := path.Join(cniConfDir, "mocknetwork2.conf")
+	f2, err := os.Create(networkConfig2)
+	if err != nil {
+		t.Fatalf("Failed to create network config %v: %v", f2, err)
+	}
+
+	cfg1 := fmt.Sprintf(`{ "name": "%s", "type": "%s", "capabilities": {"portMappings": true}  }`, "plugin1", "fakecni")
+	_, err = f1.WriteString(cfg1)
+	if err != nil {
+		t.Fatalf("Failed to write network config file %v: %v", f1, err)
+	}
+	f1.Close()
+	cfg2 := fmt.Sprintf(`{ "name": "%s", "type": "%s", "capabilities": {"portMappings": true}  }`, "plugin2", "fakecni")
+	_, err = f2.WriteString(cfg2)
+	if err != nil {
+		t.Fatalf("Failed to write network config file %v: %v", f2, err)
+	}
+	f2.Close()
+	return cniDir, cniConfDir
+}
+
+func tearDownCNIConfig(t *testing.T, confDir string) {
+	err := os.RemoveAll(confDir)
+	if err != nil {
+		t.Fatalf("Failed to cleanup CNI configs: %v", err)
+	}
+}

--- a/vendor/github.com/containerd/go-cni/types.go
+++ b/vendor/github.com/containerd/go-cni/types.go
@@ -1,0 +1,65 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+const (
+	CNIPluginName        = "cni"
+	DefaultNetDir        = "/etc/cni/net.d"
+	DefaultCNIDir        = "/opt/cni/bin"
+	DefaultMaxConfNum    = 1
+	VendorCNIDirTemplate = "%s/opt/%s/bin"
+	DefaultPrefix        = "eth"
+)
+
+type config struct {
+	pluginDirs       []string
+	pluginConfDir    string
+	pluginMaxConfNum int
+	prefix           string
+}
+
+type PortMapping struct {
+	HostPort      int32
+	ContainerPort int32
+	Protocol      string
+	HostIP        string
+}
+
+type IPRanges struct {
+	Subnet     string
+	RangeStart string
+	RangeEnd   string
+	Gateway    string
+}
+
+// BandWidth defines the ingress/egress rate and burst limits
+type BandWidth struct {
+	IngressRate  uint64
+	IngressBurst uint64
+	EgressRate   uint64
+	EgressBurst  uint64
+}
+
+// DNS defines the dns config
+type DNS struct {
+	// List of DNS servers of the cluster.
+	Servers []string
+	// List of DNS search domains of the cluster.
+	Searches []string
+	// List of DNS options.
+	Options []string
+}

--- a/vendor/github.com/containerd/go-cni/vendor.conf
+++ b/vendor/github.com/containerd/go-cni/vendor.conf
@@ -1,0 +1,6 @@
+github.com/stretchr/testify b89eecf5ca5db6d3ba60b237ffe3df7bafb7662f
+github.com/davecgh/go-spew 8991bc29aa16c548c550c7ff78260e27b9ab7c73
+github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2
+github.com/stretchr/objx 8a3f7159479fbc75b30357fbc48f380b7320f08e
+github.com/containernetworking/cni v0.7.1
+github.com/pkg/errors v0.8.0

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2,508 +2,3127 @@
 	"comment": "",
 	"ignore": "test",
 	"package": [
-		{"path":"cloud.google.com/go/compute/metadata","checksumSHA1":"b1KgRkWqz0RmrEBK6IJ8kOJva6w=","revision":"4bdb329835f9d945a6dad7b2ed60534497faa857","revisionTime":"2019-08-08T17:09:53Z"},
-		{"path":"cloud.google.com/go/iam","checksumSHA1":"+S/9jBntS1iHZwxkR64vsy97Gh8=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
-		{"path":"cloud.google.com/go/internal","checksumSHA1":"JfGXEtr79UaxukcL05IERkjYm/g=","revision":"f6872d26e2099733e489f2322a878213384f731a","revisionTime":"2019-08-26T22:18:59Z"},
-		{"path":"cloud.google.com/go/internal/optional","checksumSHA1":"wQ4uGuRwMb24vG16pPQDOOCPkFo=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
-		{"path":"cloud.google.com/go/internal/trace","checksumSHA1":"jHOn3QLqvr1luNqyOg24/BXLrsM=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
-		{"path":"cloud.google.com/go/internal/version","checksumSHA1":"CRid/VCcJ3Vfwg/R/gbmzcHVOwQ=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
-		{"path":"cloud.google.com/go/storage","checksumSHA1":"bZ1XULD+TbAPpn8b6+5dMaWWcqs=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
-		{"path":"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2015-06-15/network","checksumSHA1":"Fs6Gcl0nhC0FJ6MsB+Ck7r4huYo=","revision":"767429fcb996dad413936d682c28301e6739bade","revisionTime":"2018-05-01T22:35:11Z"},
-		{"path":"github.com/Azure/azure-sdk-for-go/version","checksumSHA1":"FAw+h8wS2QiQEIVC3z/8R2q1bvY=","revision":"767429fcb996dad413936d682c28301e6739bade","revisionTime":"2018-05-01T22:35:11Z"},
-		{"path":"github.com/Azure/go-ansiterm","checksumSHA1":"9NFR6RG8H2fNyKHscGmuGLQhRm4=","revision":"d6e3b3328b783f23731bc4d058875b0371ff8109","revisionTime":"2017-09-29T23:40:23Z","version":"master","versionExact":"master"},
-		{"path":"github.com/Azure/go-ansiterm/winterm","checksumSHA1":"3/UphB+6Hbx5otA4PjFjvObT+L4=","revision":"d6e3b3328b783f23731bc4d058875b0371ff8109","revisionTime":"2017-09-29T23:40:23Z","version":"master","versionExact":"master"},
-		{"path":"github.com/BurntSushi/toml","checksumSHA1":"Pc2ORQp+VY3Un/dkh4QwLC7R6lE=","revision":"3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005","revisionTime":"2018-08-15T10:47:33Z"},
-		{"path":"github.com/DataDog/datadog-go/statsd","checksumSHA1":"WvApwvvSe3i/3KO8300dyeFmkbI=","revision":"b10af4b12965a1ad08d164f57d14195b4140d8de","revisionTime":"2017-08-09T10:47:06Z"},
-		{"path":"github.com/LK4D4/joincontext","checksumSHA1":"Jmf4AnrptgBdQ5TPBJ2M89nooIQ=","revision":"1724345da6d5bcc8b66fefb843b607ab918e175c","revisionTime":"2017-10-26T17:01:39Z"},
-		{"path":"github.com/Microsoft/go-winio","checksumSHA1":"nEVw+80Junfo7iEY7ThP7Ci9Pyk=","origin":"github.com/endocrimes/go-winio","revision":"fb47a8b419480a700368c176bc1d5d7e3393b98d","revisionTime":"2019-06-20T17:03:19Z","version":"dani/safe-relisten","versionExact":"dani/safe-relisten"},
-		{"path":"github.com/Microsoft/go-winio/pkg/guid","checksumSHA1":"/ykkyb7gmtZC68n7T24xwbmlCBc=","origin":"github.com/endocrimes/go-winio/pkg/guid","revision":"fb47a8b419480a700368c176bc1d5d7e3393b98d","revisionTime":"2019-06-20T17:03:19Z","version":"dani/safe-relisten","versionExact":"dani/safe-relisten"},
-		{"path":"github.com/NVIDIA/gpu-monitoring-tools","checksumSHA1":"kF1vk+8Xvb3nGBiw9+qbUc0SZ4M=","revision":"86f2a9fac6c5b597dc494420005144b8ef7ec9fb","revisionTime":"2018-08-29T22:20:09Z"},
-		{"path":"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml","checksumSHA1":"P8FATSSgpe5A17FyPrGpsX95Xw8=","revision":"86f2a9fac6c5b597dc494420005144b8ef7ec9fb","revisionTime":"2018-08-29T22:20:09Z"},
-		{"path":"github.com/NYTimes/gziphandler","checksumSHA1":"jktW57+vJsziNVPeXMCoujTzdW4=","revision":"97ae7fbaf81620fe97840685304a78a306a39c64","revisionTime":"2017-09-16T00:36:49Z"},
-		{"path":"github.com/Nvveen/Gotty","checksumSHA1":"Aqy8/FoAIidY/DeQ5oTYSZ4YFVc=","revision":"cd527374f1e5bff4938207604a14f2e38a9cf512","revisionTime":"2012-06-04T00:48:16Z"},
-		{"path":"github.com/StackExchange/wmi","checksumSHA1":"qtjd74+bErubh+qyv3s+lWmn9wc=","revision":"ea383cf3ba6ec950874b8486cd72356d007c768f","revisionTime":"2017-04-10T19:29:09Z"},
-		{"path":"github.com/agext/levenshtein","checksumSHA1":"jQh1fnoKPKMURvKkpdRjN695nAQ=","revision":"5f10fee965225ac1eecdc234c09daf5cd9e7f7b6","revisionTime":"2017-02-17T06:30:20Z"},
-		{"path":"github.com/apparentlymart/go-textseg/textseg","checksumSHA1":"Ffhtm8iHH7l2ynVVOIGJE3eiuLA=","revision":"b836f5c4d331d1945a2fead7188db25432d73b69","revisionTime":"2017-05-31T20:39:52Z"},
-		{"path":"github.com/appc/spec/schema","checksumSHA1":"uWJDTv0R/NJVYv51LVy6vKP1CZw=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
-		{"path":"github.com/appc/spec/schema/common","checksumSHA1":"Q47G6996hbfQaNp/8CFkGWTVQpw=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
-		{"path":"github.com/appc/spec/schema/types","checksumSHA1":"kYXCle7Ikc8WqiMs7NXz99bUWqo=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
-		{"path":"github.com/appc/spec/schema/types/resource","checksumSHA1":"VgPsPj5PH7LKXMa3ZLe5/+Avydo=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
-		{"path":"github.com/armon/circbuf","checksumSHA1":"l0iFqayYAaEip6Olaq3/LCOa/Sg=","revision":"bbbad097214e2918d8543d5201d12bfd7bca254d"},
-		{"path":"github.com/armon/go-metrics","checksumSHA1":"gaT7FBF9uH5TY4lCo96ySrYXjek=","revision":"c1e99089638e6f1f57fe71461f99f9d00a43ccf1","revisionTime":"2019-04-30T14:02:02Z"},
-		{"path":"github.com/armon/go-metrics/circonus","checksumSHA1":"xCsGGM9TKBogZDfSN536KtQdLko=","revision":"c1e99089638e6f1f57fe71461f99f9d00a43ccf1","revisionTime":"2019-04-30T14:02:02Z"},
-		{"path":"github.com/armon/go-metrics/datadog","checksumSHA1":"Dt0n1sSivvvdZQdzc4Hu/yOG+T0=","revision":"c1e99089638e6f1f57fe71461f99f9d00a43ccf1","revisionTime":"2019-04-30T14:02:02Z"},
-		{"path":"github.com/armon/go-metrics/prometheus","checksumSHA1":"vxr0X6/jCQ4FkMxdhzUaBEWrFGA=","revision":"c1e99089638e6f1f57fe71461f99f9d00a43ccf1","revisionTime":"2019-04-30T14:02:02Z"},
-		{"path":"github.com/armon/go-radix","checksumSHA1":"gNO0JNpLzYOdInGeq7HqMZUzx9M=","revision":"4239b77079c7b5d1243b7b4736304ce8ddb6f0f2","revisionTime":"2016-01-15T23:47:25Z"},
-		{"path":"github.com/aws/aws-sdk-go/aws","checksumSHA1":"gMMx/JVSQVE4KHKoJQC7cqjTIZc=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/awserr","checksumSHA1":"OlpdlsDV2Qv50MuHlpH9heaHjQc=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/awsutil","checksumSHA1":"MoxolxrlsmtDri7ndvx5gkXI2hU=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/client","checksumSHA1":"qZUhjIZT8zU/xdQJ3La948GqEgU=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/client/metadata","checksumSHA1":"ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/corehandlers","checksumSHA1":"VAb9dwYeOW1iViqztJq8DGtlrV4=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/credentials","checksumSHA1":"x1grxMebz9A06jOsLieoExjhltU=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds","checksumSHA1":"nCeVh7E8twNLP887Zanei1wd6ks=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/defaults","checksumSHA1":"9c2Th6//lUUZPehmPkHXJh4hE/s=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/ec2metadata","checksumSHA1":"xyUdqBgj3ltt9LXnY4UvEct2izQ=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/request","checksumSHA1":"0i8r38TS6u3uT2HBM+8tNsozY6w=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/aws/session","checksumSHA1":"S46ej8/Fd7YnczK42I1UnjoeqqM=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/private/endpoints","checksumSHA1":"Rv6k85b5aRb0la07XzRPsrzwrHE=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/private/protocol/query","checksumSHA1":"ndEFDDt1gd5taOeeUrf0T66H+bg=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/private/protocol/query/queryutil","checksumSHA1":"j8UDnDnB59+u1w/qBHKG0PSWH8U=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/private/protocol/rest","checksumSHA1":"WRZcRqV95LFgq5V09PmDmSmNTEw=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/private/protocol/restxml","checksumSHA1":"KVdpXAG2PmIyopNC4jJd/JdjefA=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil","checksumSHA1":"xmKYerjqq1FO8kJK0/4Ds8iGyWg=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/private/signer/v4","checksumSHA1":"H0s7iZn2nk/fq52QaaTeW+gSGgA=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/private/waiter","checksumSHA1":"Pfoou5jtRj8A0SuCl8toNbXQlfw=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/aws/aws-sdk-go/service/s3","checksumSHA1":"NAitp0A1zE3Zry+Z41LOlCr+9lQ=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
-		{"path":"github.com/beorn7/perks/quantile","checksumSHA1":"spyv5/YFBjYyZLZa1U2LBfDR8PM=","revision":"4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9","revisionTime":"2016-08-04T10:47:26Z"},
-		{"path":"github.com/bgentry/go-netrc/netrc","checksumSHA1":"nqw2Qn5xUklssHTubS5HDvEL9L4=","revision":"9fd32a8b3d3d3f9d43c341bfe098430e07609480","revisionTime":"2014-04-22T17:41:19Z"},
-		{"path":"github.com/bgentry/speakeasy","checksumSHA1":"7SbTaY0kaYxgQrG3/9cjrI+BcyU=","revision":"36e9cfdd690967f4f690c6edcc9ffacd006014a0"},
-		{"path":"github.com/bgentry/speakeasy/example","checksumSHA1":"twtRfb6484vfr2qqjiFkLThTjcQ=","revision":"36e9cfdd690967f4f690c6edcc9ffacd006014a0"},
-		{"path":"github.com/boltdb/bolt","checksumSHA1":"R1Q34Pfnt197F/nCOO9kG8c+Z90=","comment":"v1.2.0","revision":"2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8","revisionTime":"2017-07-17T17:11:48Z","version":"v1.3.1","versionExact":"v1.3.1"},
-		{"path":"github.com/checkpoint-restore/go-criu/rpc","checksumSHA1":"k3xD77kpUpECrHCffQKb1nttiDM=","revision":"bdb7599cd87b22701b5c89b37940ea882a7d7dec","revisionTime":"2019-01-09T18:43:17Z"},
-		{"path":"github.com/circonus-labs/circonus-gometrics","checksumSHA1":"H4RhrnI0P34qLB9345G4r7CAwpU=","revision":"d6e3aea90ab9f90fe8456e13fc520f43d102da4d","revisionTime":"2019-01-28T15:50:09Z","version":"=v2","versionExact":"v2"},
-		{"path":"github.com/circonus-labs/circonus-gometrics/api","checksumSHA1":"xtzLG2UjYF1lnD33Wk+Nu/KOO6E=","revision":"d6e3aea90ab9f90fe8456e13fc520f43d102da4d","revisionTime":"2019-01-28T15:50:09Z","version":"=v2","versionExact":"v2"},
-		{"path":"github.com/circonus-labs/circonus-gometrics/api/config","checksumSHA1":"bQhz/fcyZPmuHSH2qwC4ZtATy5c=","revision":"d6e3aea90ab9f90fe8456e13fc520f43d102da4d","revisionTime":"2019-01-28T15:50:09Z","version":"=v2","versionExact":"v2"},
-		{"path":"github.com/circonus-labs/circonus-gometrics/checkmgr","checksumSHA1":"Ij8yB33E0Kk+GfTkNRoF1mG26dc=","revision":"d6e3aea90ab9f90fe8456e13fc520f43d102da4d","revisionTime":"2019-01-28T15:50:09Z","version":"=v2","versionExact":"v2"},
-		{"path":"github.com/circonus-labs/circonusllhist","checksumSHA1":"VbfeVqeOM+dTNxCmpvmYS0LwQn0=","revision":"7d649b46cdc2cd2ed102d350688a75a4fd7778c6","revisionTime":"2016-11-21T13:51:53Z"},
-		{"path":"github.com/containerd/console","checksumSHA1":"IGtuR58l2zmYRcNf8sPDlCSgovE=","origin":"github.com/opencontainers/runc/vendor/github.com/containerd/console","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/containerd/continuity/pathdriver","checksumSHA1":"GqIrOttKaO7k6HIaHQLPr3cY7rY=","origin":"github.com/docker/docker/vendor/github.com/containerd/continuity/pathdriver","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
-		{"path":"github.com/containerd/fifo","checksumSHA1":"Ur3lVmFp+HTGUzQU+/ZBolKe8FU=","revision":"3d5202aec260678c48179c56f40e6f38a095738c","revisionTime":"2018-03-07T16:51:37Z"},
-		{"path":"github.com/containernetworking/cni/libcni","checksumSHA1":"3CsFN6YsShG9EU2oB9vJIqYTxq4=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
-		{"path":"github.com/containernetworking/cni/pkg/invoke","checksumSHA1":"Xf2DxXUyjBO9u4LeyDzS38pdL+I=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
-		{"path":"github.com/containernetworking/cni/pkg/types","checksumSHA1":"Dhi4+8X7U2oVzVkgxPrmLaN8qFI=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
-		{"path":"github.com/containernetworking/cni/pkg/types/020","checksumSHA1":"6+ng8oaM9SB0TyCE7I7N940IpPY=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
-		{"path":"github.com/containernetworking/cni/pkg/types/current","checksumSHA1":"X6dNZ3yc3V9ffW9vz4yIyeKXGD0=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
-		{"path":"github.com/containernetworking/cni/pkg/version","checksumSHA1":"aojwjPoA9XSGB/zVtOGzWvmv/i8=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
-		{"path":"github.com/containernetworking/plugins/pkg/ns","checksumSHA1":"n3dCDigZOU+eD84Cr4Kg30GO4nI=","revision":"2d6d46d308b2c45a0466324c9e3f1330ab5cacd6","revisionTime":"2019-05-01T19:17:48Z"},
-		{"path":"github.com/coreos/go-iptables/iptables","checksumSHA1":"UAPz3mxGiQmd3pRWOTghB2aXzGU=","revision":"969b135e941d8baadca0a40047a38d6aca381855","revisionTime":"2019-07-24T15:17:50Z"},
-		{"path":"github.com/coreos/go-semver/semver","checksumSHA1":"97BsbXOiZ8+Kr+LIuZkQFtSj7H4=","revision":"1817cd4bea52af76542157eeabd74b057d1a199e","revisionTime":"2017-06-13T09:22:38Z"},
-		{"path":"github.com/coreos/go-systemd/dbus","checksumSHA1":"/zxxFPYjUB7Wowz33r5AhTDvoz0=","origin":"github.com/opencontainers/runc/vendor/github.com/coreos/go-systemd/dbus","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/coreos/go-systemd/util","checksumSHA1":"e8qgBHxXbij3RVspqrkeBzMZ564=","origin":"github.com/opencontainers/runc/vendor/github.com/coreos/go-systemd/util","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/coreos/pkg/dlopen","checksumSHA1":"O8c/VKtW34XPJNNlyeb/im8vWSI=","origin":"github.com/opencontainers/runc/vendor/github.com/coreos/pkg/dlopen","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/cyphar/filepath-securejoin","checksumSHA1":"4Cq4wS4l0O8WlugamGEPvooJPAk=","origin":"github.com/opencontainers/runc/vendor/github.com/cyphar/filepath-securejoin","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/davecgh/go-spew/spew","checksumSHA1":"mrz/kicZiUaHxkyfvC/DyQcr8Do=","revision":"ecdeabc65495df2dec95d7c4a4c3e021903035e5","revisionTime":"2017-10-02T20:02:53Z"},
-		{"path":"github.com/docker/cli/cli/config/configfile","checksumSHA1":"wf9Rn3a9cPag5B9Dd+qHHEink+I=","revision":"67f9a3912cf944cf71b31f3fc14e3f2a18d95802","revisionTime":"2018-08-14T14:54:37Z","version":"v18.06.1-ce","versionExact":"v18.06.1-ce"},
-		{"path":"github.com/docker/cli/cli/config/credentials","checksumSHA1":"fJpuGdxgATGNHm+INOPNVIhBnj0=","revision":"deb84a9e4e10b590e6de6aa6081532c87a5a2cfe","revisionTime":"2018-08-29T13:09:58Z"},
-		{"path":"github.com/docker/cli/opts","checksumSHA1":"+yq5Rc1QTapDrr151x0m5ANZZeY=","revision":"67f9a3912cf944cf71b31f3fc14e3f2a18d95802","revisionTime":"2018-08-14T14:54:37Z","version":"v18.06.1-ce","versionExact":"v18.06.1-ce"},
-		{"path":"github.com/docker/distribution","checksumSHA1":"ae06MP/1OVwQ/s/PsEp9wxfnBXM=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
-		{"path":"github.com/docker/distribution/digestset","checksumSHA1":"Gj+xR1VgFKKmFXYOJMnAczC3Znk=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
-		{"path":"github.com/docker/distribution/metrics","checksumSHA1":"yqCaL8oUi3OlR/Mr4oHB5HKpstc=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
-		{"path":"github.com/docker/distribution/reference","checksumSHA1":"2Fe4D6PGaVE2he4fUeenLmhC1lE=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
-		{"path":"github.com/docker/distribution/registry/api/errcode","checksumSHA1":"oFgg0LXTCZuYeI0/eEatdTyLexg=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
-		{"path":"github.com/docker/distribution/registry/api/v2","checksumSHA1":"tjPyswv8NGYxreknmylv5r5tjt4=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
-		{"path":"github.com/docker/distribution/registry/client","checksumSHA1":"72zK3wP1n7UTcSFKZZz77sKXZiU=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
-		{"path":"github.com/docker/distribution/registry/client/auth","checksumSHA1":"UeouykquJzdjJv1+Vv0ikpe7Yvo=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
-		{"path":"github.com/docker/distribution/registry/client/auth/challenge","checksumSHA1":"GWNgNhqeZST7+rgQdC06yEaLuQg=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
-		{"path":"github.com/docker/distribution/registry/client/transport","checksumSHA1":"KjpG7FYMU5ugtc/fTfL1YqhdaV4=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
-		{"path":"github.com/docker/distribution/registry/storage/cache","checksumSHA1":"RjRJSz/ISJEi0uWh5FlXMQetRcg=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
-		{"path":"github.com/docker/distribution/registry/storage/cache/memory","checksumSHA1":"T8G3A63WALmJ3JT/A0r01LG4KI0=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
-		{"path":"github.com/docker/docker-credential-helpers/client","checksumSHA1":"zcDmNPSzI1wVokOiHis5+JSg2Rk=","revision":"73e5f5dbfea31ee3b81111ebbf189785fa69731c","revisionTime":"2018-07-19T07:47:51Z"},
-		{"path":"github.com/docker/docker-credential-helpers/credentials","checksumSHA1":"4u6EMQqD1zIqOHp76zQFLVH5V8U=","revision":"73e5f5dbfea31ee3b81111ebbf189785fa69731c","revisionTime":"2018-07-19T07:47:51Z"},
-		{"path":"github.com/docker/docker/api/types","checksumSHA1":"PM15F2b73fvtlDsjFyXSMd9LJqU=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/blkiodev","checksumSHA1":"/jF0HVFiLzUUuywSjp4F/piM7BM=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/container","checksumSHA1":"+jeShxohzdtOkwAzy9e0X/fq6n4=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/filters","checksumSHA1":"RMZg2+TAla7E2KiiyF5yupWn0lY=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/mount","checksumSHA1":"9OClWW7OCikgz4QCS/sAVcvqcWk=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/network","checksumSHA1":"qZNE4g8YWfV6ryZp8kN9BwWYCeM=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/registry","checksumSHA1":"m4Jg5WnW75I65nvkEno8PElSXik=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/strslice","checksumSHA1":"OQEUS/2J2xVHpfvcsxcXzYqBSeY=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/swarm","checksumSHA1":"NT/DoroAQOev6keoJO0zKQZmjbE=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/swarm/runtime","checksumSHA1":"txs5EKTbKgVyKmKKSnaH3fr+odA=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/api/types/versions","checksumSHA1":"MZsgRjJJ0D/gAsXfKiEys+op6dE=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/errdefs","checksumSHA1":"dF9WiXuwISBPd8bQfqpuoWtB3jk=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/opts","checksumSHA1":"u6EOrZRfhdjr4up14b2JJ7MMMaY=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/archive","checksumSHA1":"wZ8yvJiuW5sK2VmoEniu1yjVlBQ=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/fileutils","checksumSHA1":"eMoRb/diYeuYLojU7ChN5DaETHc=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/homedir","checksumSHA1":"y37I+5AS96wQSiAxOayiMgnZawA=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/idtools","checksumSHA1":"+Ir5nXNDvy3cwbTlBh06lR7zUrI=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/ioutils","checksumSHA1":"Ybq78CnAoQWVBk+lkh3zykmcSjs=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/jsonmessage","checksumSHA1":"KQflv+x9hoJywgvxMwWcJqrmdkQ=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/longpath","checksumSHA1":"EXiIm2xIL7Ds+YsQUx8Z3eUYPtI=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/mount","checksumSHA1":"hx613GafM5hLibNt86ijinN89Ro=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/pools","checksumSHA1":"dj8atalGWftfM9vdzCsh9YF1Seg=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/stdcopy","checksumSHA1":"w0waeTRJ1sFygI0dZXH6l9E1c60=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/stringid","checksumSHA1":"gAUCA6R7F9kObegRGGNX5PzJahE=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/system","checksumSHA1":"RreuHCnt9a8brZsc2Q4f5T8wd+E=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/tarsum","checksumSHA1":"I6mTgOFa7NeZpYw2S5342eenRLY=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/term","checksumSHA1":"GFsDxJkQz407/2nUBmWuafG+uF8=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/pkg/term/windows","checksumSHA1":"TeOtxuBbbZtp6wDK/t4DdaGGSC0=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/registry","checksumSHA1":"0ZOQ9gYPwnxxjSIytDpwvsN5Rl0=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/registry/resumable","checksumSHA1":"jH7uQnDehFQygPP3zLC/mLSqgOk=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/volume","checksumSHA1":"Bs344j8rU7oCQyIcIhO9FJyk3ts=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/docker/volume/mounts","checksumSHA1":"J4wlScrHqr/jCIn82fgVF5mzO34=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
-		{"path":"github.com/docker/go-connections/nat","checksumSHA1":"JbiWTzH699Sqz25XmDlsARpMN9w=","revision":"7da10c8c50cad14494ec818dcdfb6506265c0086","revisionTime":"2017-02-03T23:56:24Z"},
-		{"path":"github.com/docker/go-connections/sockets","checksumSHA1":"jUfDG3VQsA2UZHvvIXncgiddpYA=","origin":"github.com/docker/docker/vendor/github.com/docker/go-connections/sockets","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
-		{"path":"github.com/docker/go-connections/tlsconfig","checksumSHA1":"zUG/J7nb6PWxfSXOoET6NePfyc0=","origin":"github.com/docker/docker/vendor/github.com/docker/go-connections/tlsconfig","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
-		{"path":"github.com/docker/go-metrics","checksumSHA1":"kHVt4M5Pfby2dhurp+hZJfQhzVU=","revision":"399ea8c73916000c64c2c76e8da00ca82f8387ab","revisionTime":"2018-02-09T01:25:29Z"},
-		{"path":"github.com/docker/go-units","checksumSHA1":"18hmvak2Dc9x5cgKeZ2iApviT7w=","comment":"v0.1.0-23-g5d2041e","revision":"5d2041e26a699eaca682e2ea41c8f891e1060444"},
-		{"path":"github.com/docker/libnetwork/ipamutils","checksumSHA1":"vcP3kQNGWKHenrvQxfu4FZkB468=","origin":"github.com/docker/docker/vendor/github.com/docker/libnetwork/ipamutils","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
-		{"path":"github.com/dustin/go-humanize","checksumSHA1":"xteP9Px90oMrg/HZuqvZkpXCR+s=","revision":"8929fe90cee4b2cb9deb468b51fb34eba64d1bf0"},
-		{"path":"github.com/elazarl/go-bindata-assetfs","checksumSHA1":"7DxViusFRJ7UPH0jZqYatwDrOkY=","revision":"30f82fa23fd844bd5bb1e5f216db87fd77b5eb43","revisionTime":"2017-02-27T21:27:28Z"},
-		{"path":"github.com/fatih/color","checksumSHA1":"VsE3zx2d8kpwj97TWhYddzAwBrY=","revision":"507f6050b8568533fb3f5504de8e5205fa62a114","revisionTime":"2018-02-13T13:34:03Z"},
-		{"path":"github.com/fatih/structs","checksumSHA1":"QBkOnLnM6zZ158NJSVLqoE4V6fI=","revision":"14f46232cd7bc732dc67313a9e4d3d210e082587","revisionTime":"2016-07-19T20:45:16Z"},
-		{"path":"github.com/fsouza/go-dockerclient","checksumSHA1":"fvbo1J+cFWDrPDs0Yudwv+POIb4=","revision":"01c3e9bd8551d675a60382c0303ef51f5849ea99","revisionTime":"2018-11-29T02:57:25Z"},
-		{"path":"github.com/fsouza/go-dockerclient/internal/archive","checksumSHA1":"YJ7WR4AVtD2ykYJr+1mTtazkma0=","revision":"01c3e9bd8551d675a60382c0303ef51f5849ea99","revisionTime":"2018-11-29T02:57:25Z"},
-		{"path":"github.com/fsouza/go-dockerclient/internal/jsonmessage","checksumSHA1":"lnUC8fZCqakWnfuMLUrZD2g+reY=","revision":"01c3e9bd8551d675a60382c0303ef51f5849ea99","revisionTime":"2018-11-29T02:57:25Z"},
-		{"path":"github.com/fsouza/go-dockerclient/internal/term","checksumSHA1":"vdjeVhnepWyw3H4g9pVTVACDfV0=","revision":"01c3e9bd8551d675a60382c0303ef51f5849ea99","revisionTime":"2018-11-29T02:57:25Z"},
-		{"path":"github.com/go-ini/ini","checksumSHA1":"U4k9IYSBQcW5DW5QDc44n5dddxs=","comment":"v1.8.5-2-g6ec4abd","revision":"6ec4abd8f8d587536da56f730858f0e27aeb4126"},
-		{"path":"github.com/go-ole/go-ole","checksumSHA1":"IvHj/4iR2nYa/S3cB2GXoyDG/xQ=","comment":"v1.2.0-4-g5005588","revision":"085abb85892dc1949567b726dff00fa226c60c45","revisionTime":"2017-07-12T17:44:59Z"},
-		{"path":"github.com/go-ole/go-ole/oleutil","checksumSHA1":"qLYVTQDhgrVIeZ2KI9eZV51mmug=","comment":"v1.2.0-4-g5005588","revision":"50055884d646dd9434f16bbb5c9801749b9bafe4"},
-		{"path":"github.com/godbus/dbus","checksumSHA1":"bFplS7sPkJNtlKKCIszFQkAsmGI=","origin":"github.com/opencontainers/runc/vendor/github.com/godbus/dbus","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/gogo/protobuf/proto","checksumSHA1":"I460dM/HmGE9DWimQvd1hJkYosU=","revision":"616a82ed12d78d24d4839363e8f3c5d3f20627cf","revisionTime":"2017-11-09T18:15:19Z"},
-		{"path":"github.com/golang/protobuf/proto","checksumSHA1":"Pyou8mceOASSFxc7GeXZuVdSMi0=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
-		{"path":"github.com/golang/protobuf/protoc-gen-go/descriptor","checksumSHA1":"DA2cyOt1W92RTyXAqKQ4JWKGR8U=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1.1.0","versionExact":"v1.1.0"},
-		{"path":"github.com/golang/protobuf/ptypes","checksumSHA1":"/s0InJhSrxhTpqw5FIKgSMknCfM=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
-		{"path":"github.com/golang/protobuf/ptypes/any","checksumSHA1":"3eqU9o+NMZSLM/coY5WDq7C1uKg=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
-		{"path":"github.com/golang/protobuf/ptypes/duration","checksumSHA1":"ZIF0rnVzNLluFPqUebtJrVonMr4=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
-		{"path":"github.com/golang/protobuf/ptypes/empty","checksumSHA1":"7Az4Zl9T11I+xOfjgs/3/YMJ24I=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z"},
-		{"path":"github.com/golang/protobuf/ptypes/timestamp","checksumSHA1":"1FJvuT0UllZaaS43kmPlx8oNiCs=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
-		{"path":"github.com/golang/protobuf/ptypes/wrappers","checksumSHA1":"fs7UwFcU+SkJKA3eHcdhGsO4jrI=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1.1.0","versionExact":"v1.1.0"},
-		{"path":"github.com/golang/snappy","checksumSHA1":"W+E/2xXcE1GmJ0Qb784ald0Fn6I=","revision":"d9eb7a3d35ec988b8585d4a0068e462c27d28380","revisionTime":"2016-05-29T05:00:41Z"},
-		{"path":"github.com/google/btree","checksumSHA1":"cervgtZmEhshueHN64+ILdFHmEE=","revision":"4030bb1f1f0c35b30ca7009e9ebd06849dd45306","revisionTime":"2018-08-13T15:31:12Z"},
-		{"path":"github.com/google/go-cmp/cmp","checksumSHA1":"+suAHHPBmbdZf/HusugaL4/H+NE=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
-		{"path":"github.com/google/go-cmp/cmp/cmpopts","checksumSHA1":"VmBLfV9TChrjNu8Z96wZkYie1aI=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
-		{"path":"github.com/google/go-cmp/cmp/internal/diff","checksumSHA1":"eTwchtMX+RMJUvle2wt295P2h10=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
-		{"path":"github.com/google/go-cmp/cmp/internal/function","checksumSHA1":"kYtvRhMjM0X4bvEjR3pqEHLw1qo=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
-		{"path":"github.com/google/go-cmp/cmp/internal/value","checksumSHA1":"f+mgZLvc4VITtMmBv0bmew4rL2Y=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
-		{"path":"github.com/googleapis/gax-go/v2","checksumSHA1":"WZoHSeTnVjnPIX2+U1Otst5MUKw=","revision":"bd5b16380fd03dc758d11cef74ba2e3bc8b0e8c2","revisionTime":"2019-05-13T18:38:25Z"},
-		{"path":"github.com/gorhill/cronexpr","checksumSHA1":"m8B3L3qJ3tFfP6BI9pIFr9oal3w=","comment":"1.0.0","origin":"github.com/dadgar/cronexpr","revision":"675cac9b2d182dccb5ba8d5f8a0d5988df8a4394","revisionTime":"2017-09-15T18:30:32Z"},
-		{"path":"github.com/gorhill/cronexpr/cronexpr","checksumSHA1":"Nd/7mZb0T6Gj6+AymyOPsNCQSJs=","comment":"1.0.0","revision":"a557574d6c024ed6e36acc8b610f5f211c91568a"},
-		{"path":"github.com/gorilla/context","checksumSHA1":"g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=","revision":"08b5f424b9271eedf6f9f0ce86cb9396ed337a42","revisionTime":"2016-08-17T18:46:32Z"},
-		{"path":"github.com/gorilla/mux","checksumSHA1":"STQSdSj2FcpCf0NLfdsKhNutQT0=","revision":"e48e440e4c92e3251d812f8ce7858944dfa3331c","revisionTime":"2018-08-07T07:52:56Z"},
-		{"path":"github.com/gorilla/websocket","checksumSHA1":"gr0edNJuVv4+olNNZl5ZmwLgscA=","revision":"0ec3d1bd7fe50c503d6df98ee649d81f4857c564","revisionTime":"2019-03-06T00:42:57Z"},
-		{"path":"github.com/hashicorp/consul-template","checksumSHA1":"237KekVBW1eZohSDylZzT+/0NQI=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/child","checksumSHA1":"AhDPiKa7wzh3SE6Gx0WrsDYwBHg=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/config","checksumSHA1":"hjsBe5Qnn0DCttJkSNjy9mreW5Q=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/dependency","checksumSHA1":"S2ktxYTJRgmUE1GC5Bv+ZAmYWgE=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/logging","checksumSHA1":"o5N7SV389Ej+3b1iRNmz1dx5e1M=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/manager","checksumSHA1":"Ozv8RPN8d//DoFpwR2mQ/xMWhcs=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/renderer","checksumSHA1":"DUHtghMoLyrgPhv4lexVniBuWYk=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/signals","checksumSHA1":"YSEUV/9/k85XciRKu0cngxdjZLE=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/template","checksumSHA1":"mmM6LpEgkbLjobfgabon11mz40M=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/version","checksumSHA1":"eWyAvppME/4vsmaazcrf3oEbzGo=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul-template/watch","checksumSHA1":"cJxopvJKg7DBBb8tnDsfmBp5Q8I=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
-		{"path":"github.com/hashicorp/consul/agent/consul/autopilot","checksumSHA1":"+I7fgoQlrnTUGW5krqNLadWwtjg=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
-		{"path":"github.com/hashicorp/consul/api","checksumSHA1":"7JPBtnIgLkdcJ0ldXMTEnVjNEjA=","revision":"40cec98468b829e5cdaacb0629b3e23a028db688","revisionTime":"2019-05-22T20:19:12Z"},
-		{"path":"github.com/hashicorp/consul/command/flags","checksumSHA1":"soNN4xaHTbeXFgNkZ7cX0gbFXQk=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
-		{"path":"github.com/hashicorp/consul/lib","checksumSHA1":"Nrh9BhiivRyJiuPzttstmq9xl/w=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
-		{"path":"github.com/hashicorp/consul/lib/freeport","checksumSHA1":"E28E4zR1FN2v1Xiq4FUER7KVN9M=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
-		{"path":"github.com/hashicorp/consul/test/porter","checksumSHA1":"5XjgqE4UIfwXvkq5VssGNc7uPhQ=","revision":"ad9425ca6353b8afcfebd19130a8cf768f7eac30","revisionTime":"2017-10-21T00:05:25Z"},
-		{"path":"github.com/hashicorp/consul/testutil","checksumSHA1":"T4CeQD+QRsjf1BJ1n7FSojS5zDQ=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
-		{"path":"github.com/hashicorp/consul/testutil/retry","checksumSHA1":"SCb2b91UYiB/23+SNDBlU5OZfFA=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
-		{"path":"github.com/hashicorp/errwrap","checksumSHA1":"cdOCt0Yb+hdErz8NAQqayxPmRsY=","revision":"7554cd9344cec97297fa6649b055a8c98c2a1e55"},
-		{"path":"github.com/hashicorp/go-checkpoint","checksumSHA1":"D267IUMW2rcb+vNe3QU+xhfSrgY=","revision":"1545e56e46dec3bba264e41fde2c1e2aa65b5dd4","revisionTime":"2017-10-09T17:35:28Z"},
-		{"path":"github.com/hashicorp/go-cleanhttp","checksumSHA1":"6ihdHMkDfFx/rJ1A36com2F6bQk=","revision":"a45970658e51fea2c41445ff0f7e07106d007617","revisionTime":"2017-02-11T00:33:01Z"},
-		{"path":"github.com/hashicorp/go-discover","checksumSHA1":"CnY2iYK47tGA9wsFMfH04PpmSoI=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z"},
-		{"path":"github.com/hashicorp/go-discover/provider/aliyun","checksumSHA1":"ZmU/47XUGUQpFP6E8T6Tl8QKszI=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/aws","checksumSHA1":"Vit45xRjrJ6h7IGJndrBjodVUAE=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/azure","checksumSHA1":"dMU80T10KQFZNqpBBjzf7ymFNBw=","revision":"266744fed5f15e5d4488269b2c29b66e25783f6f","revisionTime":"2018-05-21T21:57:50Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/digitalocean","checksumSHA1":"qoy/euk2dwrONYMUsaAPznHHpxQ=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/gce","checksumSHA1":"tnKls5vtzpNQAj7b987N4i81HvY=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/os","checksumSHA1":"LZwn9B00AjulYRCKapmJWFAamoo=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/scaleway","checksumSHA1":"GQ/3AvzdX6T0rtEFeGNYhwt17Zs=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/softlayer","checksumSHA1":"SIyZ44AHIUTBfI336ACpCeybsLg=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/triton","checksumSHA1":"n2iQu2IbTPw2XpWF2CqBrFSMjwI=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
-		{"path":"github.com/hashicorp/go-envparse","checksumSHA1":"FKmqR4DC3nCXtnT9pe02z5CLNWo=","revision":"310ca1881b22af3522e3a8638c0b426629886196","revisionTime":"2018-01-19T21:58:41Z"},
-		{"path":"github.com/hashicorp/go-getter","checksumSHA1":"d4brua17AGQqMNtngK4xKOUwboY=","revision":"f5101da0117392c6e7960c934f05a2fd689a5b5f","revisionTime":"2019-08-22T19:45:07Z"},
-		{"path":"github.com/hashicorp/go-getter/helper/url","checksumSHA1":"9J+kDr29yDrwsdu2ULzewmqGjpA=","revision":"b345bfcec894fb7ff3fdf9b21baf2f56ea423d98","revisionTime":"2018-04-10T17:49:45Z"},
-		{"path":"github.com/hashicorp/go-hclog","checksumSHA1":"dOP7kCX3dACHc9mU79826N411QA=","revision":"ff2cf002a8dd750586d91dddd4470c341f981fe1","revisionTime":"2018-07-09T16:53:50Z"},
-		{"path":"github.com/hashicorp/go-immutable-radix","checksumSHA1":"Cas2nprG6pWzf05A2F/OlnjUu2Y=","revision":"8aac2701530899b64bdea735a1de8da899815220","revisionTime":"2017-07-25T22:12:15Z"},
-		{"path":"github.com/hashicorp/go-memdb","checksumSHA1":"FMAvwDar2bQyYAW4XMFhAt0J5xA=","revision":"20ff6434c1cc49b80963d45bf5c6aa89c78d8d57","revisionTime":"2017-08-31T20:15:40Z"},
-		{"path":"github.com/hashicorp/go-msgpack/codec","checksumSHA1":"LrGV93iKiRWNSxItKr6Os6zC1T8=","origin":"github.com/ugorji/go/codec","revision":"08f7b401aef15f3d544472dd46bf6788cdfe55bf","revisionTime":"2019-05-07T20:14:01Z"},
-		{"path":"github.com/hashicorp/go-multierror","checksumSHA1":"lrSl49G23l6NhfilxPM0XFs5rZo=","revision":"d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"},
-		{"path":"github.com/hashicorp/go-plugin","checksumSHA1":"IFwYSAmxxM+fV0w9LwdWKqFOCgg=","revision":"f444068e8f5a19853177f7aa0aea7e7d95b5b528","revisionTime":"2018-12-12T15:08:38Z"},
-		{"path":"github.com/hashicorp/go-plugin/internal/proto","checksumSHA1":"Ikbb1FngsPR79bHhr2UmKk4CblI=","revision":"f444068e8f5a19853177f7aa0aea7e7d95b5b528","revisionTime":"2018-12-12T15:08:38Z"},
-		{"path":"github.com/hashicorp/go-retryablehttp","checksumSHA1":"9SqwC2BzFbsWulQuBG2+QEliTpo=","revision":"73489d0a1476f0c9e6fb03f9c39241523a496dfd","revisionTime":"2019-01-26T20:33:39Z"},
-		{"path":"github.com/hashicorp/go-rootcerts","checksumSHA1":"A1PcINvF3UiwHRKn8UcgARgvGRs=","revision":"6bb64b370b90e7ef1fa532be9e591a81c3493e00","revisionTime":"2016-05-03T14:34:40Z"},
-		{"path":"github.com/hashicorp/go-safetemp","checksumSHA1":"CduvzBFfTv77nhjtXPGdIjQQLMI=","revision":"b1a1dbde6fdc11e3ae79efd9039009e22d4ae240","revisionTime":"2018-03-26T21:11:50Z"},
-		{"path":"github.com/hashicorp/go-sockaddr","checksumSHA1":"J47ySO1q0gcnmoMnir1q1loKzCk=","revision":"6d291a969b86c4b633730bfc6b8b9d64c3aafed9","revisionTime":"2018-03-20T11:50:54Z"},
-		{"path":"github.com/hashicorp/go-sockaddr/template","checksumSHA1":"PDp9DVLvf3KWxhs4G4DpIwauMSU=","revision":"6d291a969b86c4b633730bfc6b8b9d64c3aafed9","revisionTime":"2018-03-20T11:50:54Z"},
-		{"path":"github.com/hashicorp/go-syslog","checksumSHA1":"eEqQGKsFOdSAwEprYgYnL7+J2e0=","revision":"8d1874e3e8d1862b74e0536851e218c4571066a5","revisionTime":"2019-01-18T15:19:36Z","version":"v1.0.0","versionExact":"v1.0.0"},
-		{"path":"github.com/hashicorp/go-uuid","checksumSHA1":"5AxXPtBqAKyFGcttFzxT5hp/3Tk=","revision":"4f571afc59f3043a65f8fe6bf46d887b10a01d43","revisionTime":"2018-11-28T13:14:45Z"},
-		{"path":"github.com/hashicorp/go-version","checksumSHA1":"r0pj5dMHCghpaQZ3f1BRGoKiSWw=","revision":"b5a281d3160aa11950a6182bd9a9dc2cb1e02d50","revisionTime":"2018-08-24T00:43:55Z"},
-		{"path":"github.com/hashicorp/golang-lru","checksumSHA1":"d9PxF1XQGLMJZRct2R8qVM/eYlE=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4","revisionTime":"2016-02-07T21:47:19Z"},
-		{"path":"github.com/hashicorp/golang-lru/simplelru","checksumSHA1":"2nOpYjx8Sn57bqlZq17yM4YJuM4=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"},
-		{"path":"github.com/hashicorp/hcl","checksumSHA1":"vgGv8zuy7q8c5LBAFO1fnnQRRgE=","revision":"1804807358d86424faacbb42f50f0c04303cef11","revisionTime":"2019-06-10T16:16:27Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/ast","checksumSHA1":"XQmjDva9JCGGkIecOgwtBEMCJhU=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/parser","checksumSHA1":"croNloscHsjX87X+4/cKOURf1EY=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/scanner","checksumSHA1":"lgR7PSAZ0RtvAc9OCtCnNsF/x8g=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/strconv","checksumSHA1":"JlZmnzqdmFFyb1+2afLyR3BOE/8=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/token","checksumSHA1":"c6yprzj06ASwCo18TtbbNNBHljA=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
-		{"path":"github.com/hashicorp/hcl/json/parser","checksumSHA1":"138aCV5n8n7tkGYMsMVQQnnLq+0=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
-		{"path":"github.com/hashicorp/hcl/json/scanner","checksumSHA1":"YdvFsNOMSWMLnY6fcliWQa0O5Fw=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
-		{"path":"github.com/hashicorp/hcl/json/token","checksumSHA1":"fNlXQCQEnb+B3k5UDL/r15xtSJY=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
-		{"path":"github.com/hashicorp/hcl2/gohcl","checksumSHA1":"RFEjfMQWPAVILXE2PhL6wDW8Zg4=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
-		{"path":"github.com/hashicorp/hcl2/hcl","checksumSHA1":"1jDEGh+P7Cu8Lz39VudY6rRS6Jw=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
-		{"path":"github.com/hashicorp/hcl2/hcl/hclsyntax","checksumSHA1":"6FZRBZj+je9sMM5wrhM5phUXxZU=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
-		{"path":"github.com/hashicorp/hcl2/hcl/json","checksumSHA1":"l5KBeDDM1gf7yFth7WGhckpF+oc=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
-		{"path":"github.com/hashicorp/hcl2/hcldec","checksumSHA1":"6JRj4T/iQxIe/CoKXHDjPuupmL8=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
-		{"path":"github.com/hashicorp/hcl2/hclwrite","checksumSHA1":"Hgs10IsC8LdotUKLavgOL35Mbw4=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
-		{"path":"github.com/hashicorp/logutils","checksumSHA1":"vt+P9D2yWDO3gdvdgCzwqunlhxU=","revision":"0dc08b1671f34c4250ce212759ebd880f743d883"},
-		{"path":"github.com/hashicorp/memberlist","checksumSHA1":"yAu2gPVXIh28yJ2If5gZPrf04kU=","revision":"1a62499c21db33d57691001d5e08a71ec857b18f","revisionTime":"2019-01-03T22:22:36Z"},
-		{"path":"github.com/hashicorp/net-rpc-msgpackrpc","checksumSHA1":"qnlqWJYV81ENr61SZk9c65R1mDo=","revision":"a14192a58a694c123d8fe5481d4a4727d6ae82f3"},
-		{"path":"github.com/hashicorp/raft","checksumSHA1":"ujL3Sc5iqc28/En2ndmc2R7oUQM=","revision":"9c733b2b7f53115c5ef261a90ce912a1bb49e970","revisionTime":"2019-01-04T13:37:20Z"},
-		{"path":"github.com/hashicorp/raft-boltdb","checksumSHA1":"QAxukkv54/iIvLfsUP6IK4R0m/A=","revision":"d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee","revisionTime":"2015-02-01T20:08:39Z"},
-		{"path":"github.com/hashicorp/serf","checksumSHA1":"9omt7lEuhBNSdgT32ThEzXn/aTU=","revision":"c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2","revisionTime":"2019-01-04T15:39:47Z"},
-		{"path":"github.com/hashicorp/serf/coordinate","checksumSHA1":"0PeWsO2aI+2PgVYlYlDPKfzCLEQ=","revision":"c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2","revisionTime":"2019-01-04T15:39:47Z"},
-		{"path":"github.com/hashicorp/serf/serf","checksumSHA1":"siLn7zwVHQk070rpd99BTktGfTs=","revision":"c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2","revisionTime":"2019-01-04T15:39:47Z"},
-		{"path":"github.com/hashicorp/vault/api","checksumSHA1":"laYVVZeqao4WdIS/MKd0be7Z3yA=","revision":"85909e3373aa743c34a6a0ab59131f61fd9e8e43","revisionTime":"2019-02-12T14:05:52Z"},
-		{"path":"github.com/hashicorp/vault/helper/compressutil","checksumSHA1":"bSdPFOHaTwEvM4PIvn0PZfn75jM=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
-		{"path":"github.com/hashicorp/vault/helper/consts","checksumSHA1":"3mRK/pBPUH8rIPrILmuJWynWQVo=","revision":"85909e3373aa743c34a6a0ab59131f61fd9e8e43","revisionTime":"2019-02-12T14:05:52Z"},
-		{"path":"github.com/hashicorp/vault/helper/hclutil","checksumSHA1":"RlqPBLOexQ0jj6jomhiompWKaUg=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
-		{"path":"github.com/hashicorp/vault/helper/jsonutil","checksumSHA1":"POgkM3GrjRFw6H3sw95YNEs552A=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
-		{"path":"github.com/hashicorp/vault/helper/parseutil","checksumSHA1":"HA2MV/2XI0HcoThSRxQCaBZR2ps=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
-		{"path":"github.com/hashicorp/vault/helper/strutil","checksumSHA1":"HdVuYhZ5TuxeIFqi0jy2GHW7a4o=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
-		{"path":"github.com/hashicorp/yamux","checksumSHA1":"m9OKUPd/iliwKxs+LCSmAGpDJOs=","revision":"7221087c3d281fda5f794e28c2ea4c6e4d5c4558","revisionTime":"2018-09-17T20:50:41Z"},
-		{"path":"github.com/hpcloud/tail/util","checksumSHA1":"0xM336Lb25URO/1W1/CtGoRygVU=","revision":"37f4271387456dd1bf82ab1ad9229f060cc45386","revisionTime":"2017-08-14T16:06:53Z"},
-		{"path":"github.com/hpcloud/tail/watch","checksumSHA1":"TP4OAv5JMtzj2TB6OQBKqauaKDc=","revision":"37f4271387456dd1bf82ab1ad9229f060cc45386","revisionTime":"2017-08-14T16:06:53Z"},
-		{"path":"github.com/jmespath/go-jmespath","checksumSHA1":"3/Bhy+ua/DCv2ElMD5GzOYSGN6g=","comment":"0.2.2-2-gc01cf91","revision":"c01cf91b011868172fdcd9f41838e80c9d716264"},
-		{"path":"github.com/konsorten/go-windows-terminal-sequences","checksumSHA1":"Aulh7C5SVOA4Jzt5eHNH6197Mbk=","revision":"f55edac94c9bbba5d6182a4be46d86a2c9b5b50e","revisionTime":"2019-02-26T22:47:05Z"},
-		{"path":"github.com/kr/pretty","checksumSHA1":"eOXF2PEvYLMeD8DSzLZJWbjYzco=","revision":"cfb55aafdaf3ec08f0db22699ab822c50091b1c4","revisionTime":"2016-08-23T17:07:15Z"},
-		{"path":"github.com/kr/pty","checksumSHA1":"WD7GMln/NoduJr0DbumjOE59xI8=","revision":"b6e1bdd4a4f88614e0c6e5e8089c7abed98aae17","revisionTime":"2019-04-01T03:15:51Z"},
-		{"path":"github.com/kr/text","checksumSHA1":"uulQHQ7IsRKqDudBC8Go9J0gtAc=","revision":"7cafcd837844e784b526369c9bce262804aebc60","revisionTime":"2016-05-04T02:26:26Z"},
-		{"path":"github.com/mattn/go-colorable","checksumSHA1":"SEnjvwVyfuU2xBaOfXfwPD5MZqk=","revision":"efa589957cd060542a26d2dd7832fd6a6c6c3ade","revisionTime":"2018-03-10T13:32:14Z"},
-		{"path":"github.com/mattn/go-isatty","checksumSHA1":"AZO2VGorXTMDiSVUih3k73vORHY=","revision":"6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c","revisionTime":"2017-11-07T05:05:31Z"},
-		{"path":"github.com/mattn/go-shellwords","checksumSHA1":"ajImwVZHzsI+aNwsgzCSFSbmJqs=","revision":"f4e566c536cf69158e808ec28ef4182a37fdc981","revisionTime":"2015-03-21T17:42:21Z"},
-		{"path":"github.com/matttproud/golang_protobuf_extensions/pbutil","checksumSHA1":"bKMZjd2wPw13VwoE7mBeSv5djFA=","revision":"c12348ce28de40eed0136aa2b644d0ee0650e56c","revisionTime":"2016-04-24T11:30:07Z"},
-		{"path":"github.com/miekg/dns","checksumSHA1":"7C76urB5PLSeqMeydxiUGjX5xMI=","revision":"7e024ce8ce18b21b475ac6baf8fa3c42536bf2fa"},
-		{"path":"github.com/mitchellh/cli","checksumSHA1":"+o0siVvR8q36mKCpT5F/Sn2T7xo=","revision":"c54c85e9bd492bdba226ffdda55d4e293b79f8e8","revisionTime":"2018-04-06T01:10:36Z"},
-		{"path":"github.com/mitchellh/colorstring","checksumSHA1":"ttEN1Aupb7xpPMkQLqb3tzLFdXs=","revision":"8631ce90f28644f54aeedcb3e389a85174e067d1","revisionTime":"2015-09-17T21:48:07Z"},
-		{"path":"github.com/mitchellh/copystructure","checksumSHA1":"+p4JY4wmFQAppCdlrJ8Kxybmht8=","revision":"d23ffcb85de31694d6ccaa23ccb4a03e55c1303f","revisionTime":"2017-05-25T01:39:02Z"},
-		{"path":"github.com/mitchellh/go-homedir","checksumSHA1":"AXacfEchaUqT5RGmPmMXsOWRhv8=","revision":"756f7b183b7ab78acdbbee5c7f392838ed459dda","revisionTime":"2016-06-21T17:42:43Z"},
-		{"path":"github.com/mitchellh/go-ps","checksumSHA1":"DcYIZnMiq/Tj22/ge9os3NwOhs4=","revision":"4fdf99ab29366514c69ccccddab5dc58b8d84062","revisionTime":"2017-03-09T13:30:38Z"},
-		{"path":"github.com/mitchellh/go-testing-interface","checksumSHA1":"bDdhmDk8q6utWrccBhEOa6IoGkE=","revision":"a61a99592b77c9ba629d254a693acffaeb4b7e28","revisionTime":"2017-10-04T22:19:16Z"},
-		{"path":"github.com/mitchellh/go-wordwrap","checksumSHA1":"L3leymg2RT8hFl5uL+5KP/LpBkg=","revision":"ad45545899c7b13c020ea92b2072220eefad42b8","revisionTime":"2015-03-14T17:03:34Z"},
-		{"path":"github.com/mitchellh/hashstructure","checksumSHA1":"Z3FoiV93oUfDoQYMMiHxWCQPlBw=","revision":"1ef5c71b025aef149d12346356ac5973992860bc"},
-		{"path":"github.com/mitchellh/mapstructure","checksumSHA1":"4Js6Jlu93Wa0o6Kjt393L9Z7diE=","revision":"281073eb9eb092240d33ef253c404f1cca550309"},
-		{"path":"github.com/mitchellh/reflectwalk","checksumSHA1":"KqsMqI+Y+3EFYPhyzafpIneaVCM=","revision":"8d802ff4ae93611b807597f639c19f76074df5c6","revisionTime":"2017-05-08T17:38:06Z"},
-		{"path":"github.com/moby/moby/daemon/caps","checksumSHA1":"FoDTHct8ocl470GYc0i+JRWfrys=","revision":"39377bb96d459d2ef59bd2bad75468638a7f86a3","revisionTime":"2018-01-18T19:02:33Z"},
-		{"path":"github.com/mrunalp/fileutils","checksumSHA1":"EKGlMEHq/nwBXQGi9JN/y+H7YMU=","origin":"github.com/opencontainers/runc/vendor/github.com/mrunalp/fileutils","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/oklog/run","checksumSHA1":"nf3UoPNBIut7BL9nWE8Fw2X2j+Q=","revision":"6934b124db28979da51d3470dadfa34d73d72652","revisionTime":"2018-03-08T00:51:04Z"},
-		{"path":"github.com/onsi/ginkgo","checksumSHA1":"cwbidLG1ET7YSqlwca+nSfYxIbg=","revision":"ba8e856bb854d6771a72ddf6497a42dad3a0c971","revisionTime":"2018-03-12T10:34:14Z"},
-		{"path":"github.com/onsi/ginkgo/config","checksumSHA1":"Tarhbqac6rFsGPugPoQ4lyhfc7Q=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/ginkgo","checksumSHA1":"euz7sKjXGezoMq6P5qC/day/mZo=","revision":"ba8e856bb854d6771a72ddf6497a42dad3a0c971","revisionTime":"2018-03-12T10:34:14Z"},
-		{"path":"github.com/onsi/ginkgo/ginkgo/convert","checksumSHA1":"RX2QA4mqBzsogy4OWOCi9mUfAGU=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/ginkgo/interrupthandler","checksumSHA1":"jvjomLV3JcWQ1qa1ZfmvB4/62YI=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/ginkgo/nodot","checksumSHA1":"brZ63GMMr79P/RwClxFRBKMtICg=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/ginkgo/testrunner","checksumSHA1":"qSXx1svgCAAqk+ICAWL1AXdSJmA=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/ginkgo/testsuite","checksumSHA1":"x2Fa0rbgpXQaVc6f10KTRchiF7E=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/ginkgo/watch","checksumSHA1":"yT4efdDV3bfosM49kBvQg3PjcMA=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/codelocation","checksumSHA1":"T1cZh3UWr4Hnx6fQYp+7KDNvxG4=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/containernode","checksumSHA1":"qvz6/+otRkWa1OHaPMKap9D5Ge4=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/failer","checksumSHA1":"882oWW4FC4Nrd8mrMptsDJSTDds=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/leafnodes","checksumSHA1":"IbQFETl8AqMhJ74XP+us5Xk3dS8=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/remote","checksumSHA1":"Z9mfsBI9VL7QqwY+doKRhumHIh4=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/spec","checksumSHA1":"msseWG4Ewk2/V35NKaRokjXPCQs=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/spec_iterator","checksumSHA1":"14UQiFkhUmN5vTG+pNApv5OYgoU=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/specrunner","checksumSHA1":"pDxDXIJ3QPm5UMnzQ+3GedK8WjQ=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/suite","checksumSHA1":"QZ9ekcsrGBcXz4Tv+L7kXAUfqq8=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/testingtproxy","checksumSHA1":"TUBH2aNaARtAZ5vz51xMFRsOOo0=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/internal/writer","checksumSHA1":"BB83CfNg6jFoFNMuXFL+f4EOFpw=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/reporters","checksumSHA1":"m6/gIgdQGdETzUN3JWhAmFNIuNI=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/reporters/stenographer","checksumSHA1":"hdfc3dPx9Jw8v+sd7TEDlboJ1Nc=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable","checksumSHA1":"QeB8m9WhRUiL0YKj3n5L0t4mLCg=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty","checksumSHA1":"4Vn7/7UJmbclxDrV8YKbYOUh65g=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/ginkgo/types","checksumSHA1":"kuzrRJpxmnbuG7VVDIfDcLIRKLU=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
-		{"path":"github.com/onsi/gomega","checksumSHA1":"WQwGlRQksUlZ4HMiYZWR4wE4Suo=","revision":"de89e61d40b75aa971a9fc3eae7f4fefabd6e0ee","revisionTime":"2018-03-05T20:37:22Z"},
-		{"path":"github.com/onsi/gomega/format","checksumSHA1":"W/l0TJN86WNCAZPm1MPSlqxxWYM=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/internal/assertion","checksumSHA1":"H4RBR9kcEWh2lECAzBaOTSvgUuA=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/internal/asyncassertion","checksumSHA1":"N7HhJzMN+STfzI315keM9SxFQAE=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/internal/oraclematcher","checksumSHA1":"EsgeBqN2S5wj8aWvGsS162ZK7xI=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/internal/testingtsupport","checksumSHA1":"M2WqXho4fZaeYkyfuiGTlPhcU8I=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/matchers","checksumSHA1":"D7QESRc8hYaX8wHT0ftzvNTMwuk=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/matchers/support/goraph/bipartitegraph","checksumSHA1":"NMjCfnHie2dgQw0kCObrHRc8S50=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/matchers/support/goraph/edge","checksumSHA1":"zjTC6ady0bJUwzTFAKtv63T7Fmg=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/matchers/support/goraph/node","checksumSHA1":"o2+IscLOPKOiovl2g0/igkD1R4Q=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/matchers/support/goraph/util","checksumSHA1":"yEF1BYQPwS3neYFKiqNQReqnadY=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/onsi/gomega/types","checksumSHA1":"mGI31MBiT3PJ8sgoB/E7NQ+4dJA=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
-		{"path":"github.com/opencontainers/go-digest","checksumSHA1":"NTperEHVh1uBqfTy9+oKceN4tKI=","revision":"21dfd564fd89c944783d00d069f33e3e7123c448","revisionTime":"2017-01-11T18:16:59Z"},
-		{"path":"github.com/opencontainers/image-spec/specs-go","checksumSHA1":"ZGlIwSRjdLYCUII7JLE++N4w7Xc=","revision":"89b51c794e9113108a2914e38e66c826a649f2b5","revisionTime":"2017-11-03T11:36:04Z"},
-		{"path":"github.com/opencontainers/image-spec/specs-go/v1","checksumSHA1":"jdbXRRzeu0njLE9/nCEZG+Yg/Jk=","revision":"89b51c794e9113108a2914e38e66c826a649f2b5","revisionTime":"2017-11-03T11:36:04Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer","checksumSHA1":"OJlgvnpJuV+SDPW48YVUKWDbOnU=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/apparmor","checksumSHA1":"gVVY8k2G3ws+V1czsfxfuRs8log=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/cgroups","checksumSHA1":"aWtm1zkVCz9l2/zQNfnc246yQew=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/cgroups/fs","checksumSHA1":"OnnBJ2WfB/Y9EQpABKetBedf6ts=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/cgroups/systemd","checksumSHA1":"d7B9MiKb1k1Egh5qkNokIfcZ+OY=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/configs","checksumSHA1":"v9sgw4eYRNSsJUSG33OoFIwLqRI=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/configs/validate","checksumSHA1":"hUveFGK1HhGenf0OVoYZWccoW9I=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/criurpc","checksumSHA1":"n7G7Egz/tOPacXuq+nkvnFai3eU=","revision":"369b920277d27630441336775cd728bc0f19e496","revisionTime":"2018-09-07T18:53:11Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/devices","checksumSHA1":"2CwtFvz9kB0RSjFlcCkmq4taJ9U=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/intelrdt","checksumSHA1":"sAbowQ7hjveSH5ADUD9IYXnEAJM=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/keys","checksumSHA1":"mKxBw0il2IWjWYgksX+17ufDw34=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/logs","checksumSHA1":"mBbwlspKSImoGTw4uKE40AX3PYs=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/mount","checksumSHA1":"MJiogPDUU2nFr1fzQU6T+Ry1W8o=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/nsenter","checksumSHA1":"PnGFQdbZhZ4pcxFtQep5MEQ4/8E=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/seccomp","checksumSHA1":"I1Qw/btE1twMqKHpYNsC98cteak=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/stacktrace","checksumSHA1":"yp/kYBgVqKtxlnpq4CmyxLFMAE4=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/system","checksumSHA1":"cjg/UcueM1/2/ExZ3N7010sa+hI=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/user","checksumSHA1":"mdUukOXCVJxmT0CufSKDeMg5JFM=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runc/libcontainer/utils","checksumSHA1":"PqGgeBjTHnyGrTr5ekLFEXpC3iQ=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/runtime-spec/specs-go","checksumSHA1":"AMYc2X2O/IL6EGrq6lTl5vEhLiY=","origin":"github.com/opencontainers/runc/vendor/github.com/opencontainers/runtime-spec/specs-go","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/opencontainers/selinux/go-selinux","checksumSHA1":"X4jufgAG12FCYi0U9VK4DK5vvXo=","origin":"github.com/opencontainers/runc/vendor/github.com/opencontainers/selinux/go-selinux","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/opencontainers/selinux/go-selinux/label","checksumSHA1":"5hHzDoXjeTtGaVzyN8lOowcwvdQ=","origin":"github.com/opencontainers/runc/vendor/github.com/opencontainers/selinux/go-selinux/label","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
-		{"path":"github.com/pkg/errors","checksumSHA1":"ynJSWoF6v+3zMnh9R0QmmG6iGV8=","revision":"248dadf4e9068a0b3e79f02ed0a610d935de5302","revisionTime":"2016-10-29T09:36:37Z"},
-		{"path":"github.com/pmezard/go-difflib/difflib","checksumSHA1":"LuFv4/jlrmFNnDb/5SCSEPAM9vU=","revision":"792786c7400a136282c1664665ae0a8db921c6c2","revisionTime":"2016-01-10T10:55:54Z"},
-		{"path":"github.com/posener/complete","checksumSHA1":"rTNABfFJ9wtLQRH8uYNkEZGQOrY=","revision":"9f41f7636a724791a3b8b1d35e84caa1124f0d3c","revisionTime":"2017-08-29T17:11:12Z"},
-		{"path":"github.com/posener/complete/cmd","checksumSHA1":"NB7uVS0/BJDmNu68vPAlbrq4TME=","revision":"9f41f7636a724791a3b8b1d35e84caa1124f0d3c","revisionTime":"2017-08-29T17:11:12Z"},
-		{"path":"github.com/posener/complete/cmd/install","checksumSHA1":"gSX86Xl0w9hvtntdT8h23DZtSag=","revision":"9f41f7636a724791a3b8b1d35e84caa1124f0d3c","revisionTime":"2017-08-29T17:11:12Z"},
-		{"path":"github.com/posener/complete/match","checksumSHA1":"DMo94FwJAm9ZCYCiYdJU2+bh4no=","revision":"9f41f7636a724791a3b8b1d35e84caa1124f0d3c","revisionTime":"2017-08-29T17:11:12Z"},
-		{"path":"github.com/prometheus/client_golang/prometheus","checksumSHA1":"5dHjKxShYVWVB1Fb00dAnR6kqVk=","revision":"2641b987480bca71fb39738eb8c8b0d577cb1d76","revisionTime":"2019-06-07T14:56:44Z","version":"v0.9.4","versionExact":"v0.9.4"},
-		{"path":"github.com/prometheus/client_golang/prometheus/internal","checksumSHA1":"UBqhkyjCz47+S19MVTigxJ2VjVQ=","revision":"2641b987480bca71fb39738eb8c8b0d577cb1d76","revisionTime":"2019-06-07T14:56:44Z","version":"v0.9.4","versionExact":"v0.9.4"},
-		{"path":"github.com/prometheus/client_golang/prometheus/promhttp","checksumSHA1":"V51yx4gq61QCD9clxnps792Eq2Y=","revision":"2641b987480bca71fb39738eb8c8b0d577cb1d76","revisionTime":"2019-06-07T14:56:44Z","version":"v0.9.4","versionExact":"v0.9.4"},
-		{"path":"github.com/prometheus/client_model/go","checksumSHA1":"DvwvOlPNAgRntBzt3b3OSRMS2N4=","revision":"6f3806018612930941127f2a7c6c453ba2c527d2","revisionTime":"2017-02-16T18:52:47Z"},
-		{"path":"github.com/prometheus/common/expfmt","checksumSHA1":"xfnn0THnqNwjwimeTClsxahYrIo=","revision":"2f17f4a9d485bf34b4bfaccc273805040e4f86c8","revisionTime":"2017-09-08T16:18:22Z"},
-		{"path":"github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg","checksumSHA1":"GWlM3d2vPYyNATtTFgftS10/A9w=","revision":"2f17f4a9d485bf34b4bfaccc273805040e4f86c8","revisionTime":"2017-09-08T16:18:22Z"},
-		{"path":"github.com/prometheus/common/model","checksumSHA1":"3VoqH7TFfzA6Ds0zFzIbKCUvBmw=","revision":"2f17f4a9d485bf34b4bfaccc273805040e4f86c8","revisionTime":"2017-09-08T16:18:22Z"},
-		{"path":"github.com/prometheus/procfs","checksumSHA1":"WB7dFqkmD3R514xql9YM3ZP1dDM=","revision":"833678b5bb319f2d20a475cb165c6cc59c2cc77c","revisionTime":"2019-05-31T16:30:47Z","version":"v0.0.2","versionExact":"v0.0.2"},
-		{"path":"github.com/prometheus/procfs/internal/fs","checksumSHA1":"Kmjs49lbjGmlgUPx3pks0tVDed0=","revision":"833678b5bb319f2d20a475cb165c6cc59c2cc77c","revisionTime":"2019-05-31T16:30:47Z","version":"v0.0.2","versionExact":"v0.0.2"},
-		{"path":"github.com/prometheus/procfs/xfs","checksumSHA1":"xCiFAAwVTrjsfZT1BIJQ3DgeNCY=","revision":"e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2","revisionTime":"2017-07-03T10:12:42Z"},
-		{"path":"github.com/rs/cors","checksumSHA1":"I778b2sbNN/yjwKSdb3y7hz2yUQ=","revision":"eabcc6af4bbe5ad3a949d36450326a2b0b9894b8","revisionTime":"2017-08-01T07:32:01Z"},
-		{"path":"github.com/ryanuber/columnize","checksumSHA1":"M57Rrfc8Z966p+IBtQ91QOcUtcg=","comment":"v2.0.1-8-g983d3a5","revision":"abc90934186a77966e2beeac62ed966aac0561d5","revisionTime":"2017-07-03T20:58:27Z"},
-		{"path":"github.com/ryanuber/go-glob","checksumSHA1":"6JP37UqrI0H80Gpk0Y2P+KXgn5M=","revision":"256dc444b735e061061cf46c809487313d5b0065","revisionTime":"2017-01-28T01:21:29Z"},
-		{"path":"github.com/sean-/seed","checksumSHA1":"tnMZLo/kR9Kqx6GtmWwowtTLlA8=","revision":"e2103e2c35297fb7e17febb81e49b312087a2372","revisionTime":"2017-03-13T16:33:22Z"},
-		{"path":"github.com/seccomp/libseccomp-golang","checksumSHA1":"6Z/chtTVA74eUZTlG5VRDy59K1M=","origin":"github.com/opencontainers/runc/vendor/github.com/seccomp/libseccomp-golang","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/sethgrid/pester","checksumSHA1":"8Lm8nsMCFz4+gr9EvQLqK8+w+Ks=","revision":"8053687f99650573b28fb75cddf3f295082704d7","revisionTime":"2016-04-29T17:20:22Z"},
-		{"path":"github.com/shirou/gopsutil/cpu","checksumSHA1":"k+PmW/6PFt0FVFTTnfMbWwrm9hU=","origin":"github.com/hashicorp/gopsutil/cpu","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
-		{"path":"github.com/shirou/gopsutil/disk","checksumSHA1":"4DZwA8Xf2Zs8vhIc9kx8TIBMmSY=","origin":"github.com/hashicorp/gopsutil/disk","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
-		{"path":"github.com/shirou/gopsutil/host","checksumSHA1":"ib/iKmNEqKrSso+TsSSV/Q4HDSY=","origin":"github.com/hashicorp/gopsutil/host","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
-		{"path":"github.com/shirou/gopsutil/internal/common","checksumSHA1":"S31u6j9yi6MOblZ1x83k/HDuNtA=","origin":"github.com/hashicorp/gopsutil/internal/common","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
-		{"path":"github.com/shirou/gopsutil/mem","checksumSHA1":"1u1St5K2LtEcQsh5ySmvoTZ8k0I=","origin":"github.com/hashicorp/gopsutil/mem","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
-		{"path":"github.com/shirou/gopsutil/net","checksumSHA1":"ME2P9hiaHO/YdVrNInDmb/dB6us=","origin":"github.com/hashicorp/gopsutil/net","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
-		{"path":"github.com/shirou/gopsutil/process","checksumSHA1":"JuBAKUuSyR7RdJELt6tQMn79Y6w=","origin":"github.com/hashicorp/gopsutil/process","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
-		{"path":"github.com/shirou/w32","checksumSHA1":"Nve7SpDmjsv6+rhkXAkfg/UQx94=","revision":"bb4de0191aa41b5507caa14b0650cdbddcd9280b","revisionTime":"2016-09-30T03:27:40Z"},
-		{"path":"github.com/sirupsen/logrus","checksumSHA1":"SVO+Zm6SNwWrpgyc6mcTXbH4aJ8=","revision":"2a22dbedbad1fd454910cd1f44f210ef90c28464","revisionTime":"2019-05-18T13:52:02Z"},
-		{"path":"github.com/skratchdot/open-golang/open","checksumSHA1":"h/HMhokbQHTdLUbruoBBTee+NYw=","revision":"75fb7ed4208cf72d323d7d02fd1a5964a7a9073c","revisionTime":"2016-03-02T14:40:31Z"},
-		{"path":"github.com/spf13/pflag","checksumSHA1":"Q52Y7t0lEtk/wcDn5q7tS7B+jqs=","revision":"7aff26db30c1be810f9de5038ec5ef96ac41fd7c","revisionTime":"2017-08-24T17:57:12Z"},
-		{"path":"github.com/stretchr/objx","checksumSHA1":"K0crHygPTP42i1nLKWphSlvOQJw=","revision":"1a9d0bb9f541897e62256577b352fdbc1fb4fd94","revisionTime":"2015-09-28T12:21:52Z"},
-		{"path":"github.com/stretchr/testify/assert","checksumSHA1":"/7bZ0f2fM9AAsLf3nMca6Gtlm6E=","revision":"221dbe5ed46703ee255b1da0dec05086f5035f62","revisionTime":"2019-05-17T17:51:56Z","version":"v1.4.0","versionExact":"v1.4.0"},
-		{"path":"github.com/stretchr/testify/mock","checksumSHA1":"bg70xAHEu6HRf2iFu8h5iJBjUfg=","revision":"221dbe5ed46703ee255b1da0dec05086f5035f62","revisionTime":"2019-05-17T17:51:56Z","version":"v1.4.0","versionExact":"v1.4.0"},
-		{"path":"github.com/stretchr/testify/require","checksumSHA1":"ABkrw83kq3/d6oSRX+BFq57/BiY=","revision":"221dbe5ed46703ee255b1da0dec05086f5035f62","revisionTime":"2019-05-17T17:51:56Z","version":"v1.4.0","versionExact":"v1.4.0"},
-		{"path":"github.com/syndtr/gocapability/capability","checksumSHA1":"PgEklGW56c5RLHqQhORxt6jS3fY=","revision":"db04d3cc01c8b54962a58ec7e491717d06cfcc16","revisionTime":"2017-07-04T07:02:18Z"},
-		{"path":"github.com/testify/assert","revision":"v1.4.0","version":"v1.4.0"},
-		{"path":"github.com/testify/mock","revision":"v1.4.0","version":"v1.4.0"},
-		{"path":"github.com/testify/require","revision":"v1.4.0","version":"v1.4.0"},
-		{"path":"github.com/tonnerre/golang-text","checksumSHA1":"t24KnvC9jRxiANVhpw2pqFpmEu8=","revision":"048ed3d792f7104850acbc8cfc01e5a6070f4c04","revisionTime":"2013-09-25T19:58:46Z"},
-		{"path":"github.com/tv42/httpunix","checksumSHA1":"2xcr/mhxBFlDjpxe/Mc2Wb4RGR8=","revision":"b75d8614f926c077e48d85f1f8f7885b758c6225","revisionTime":"2015-04-27T01:28:21Z"},
-		{"path":"github.com/ugorji/go/codec","checksumSHA1":"RBRh7hUVcoELofg7TinPuBUG/po=","revision":"08f7b401aef15f3d544472dd46bf6788cdfe55bf","revisionTime":"2019-05-07T20:14:01Z"},
-		{"path":"github.com/ulikunitz/xz","checksumSHA1":"qgMa75aMGbkFY0jIqqqgVnCUoNA=","revision":"0c6b41e72360850ca4f98dc341fd999726ea007f","revisionTime":"2017-06-05T21:53:11Z"},
-		{"path":"github.com/ulikunitz/xz/internal/hash","checksumSHA1":"vjnTkzNrMs5Xj6so/fq0mQ6dT1c=","revision":"0c6b41e72360850ca4f98dc341fd999726ea007f","revisionTime":"2017-06-05T21:53:11Z"},
-		{"path":"github.com/ulikunitz/xz/internal/xlog","checksumSHA1":"m0pm57ASBK/CTdmC0ppRHO17mBs=","revision":"0c6b41e72360850ca4f98dc341fd999726ea007f","revisionTime":"2017-06-05T21:53:11Z"},
-		{"path":"github.com/ulikunitz/xz/lzma","checksumSHA1":"2vZw6zc8xuNlyVz2QKvdlNSZQ1U=","revision":"0c6b41e72360850ca4f98dc341fd999726ea007f","revisionTime":"2017-06-05T21:53:11Z"},
-		{"path":"github.com/vishvananda/netlink","checksumSHA1":"cIkE6EIE7A0IzdhR/Yes8Nzyqtk=","origin":"github.com/opencontainers/runc/vendor/github.com/vishvananda/netlink","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/vishvananda/netlink/nl","checksumSHA1":"r/vcO8YkOWNHKX5HKCukaU4Xzlg=","origin":"github.com/opencontainers/runc/vendor/github.com/vishvananda/netlink/nl","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
-		{"path":"github.com/vmihailenco/msgpack","checksumSHA1":"t9A/EE2GhHFPHzK+ksAKgKW9ZC8=","revision":"b5e691b1eb52a28c05e67ab9df303626c095c23b","revisionTime":"2018-06-13T09:15:15Z"},
-		{"path":"github.com/vmihailenco/msgpack/codes","checksumSHA1":"OcTSGT2v7/2saIGq06nDhEZwm8I=","revision":"b5e691b1eb52a28c05e67ab9df303626c095c23b","revisionTime":"2018-06-13T09:15:15Z"},
-		{"path":"github.com/zclconf/go-cty/cty","checksumSHA1":"0jAKo5tFC1SpRjwB+AiPNfNAzmM=","revision":"4ca19710f0562cab70f0b3c9cbff0ecc70ee06d1","revisionTime":"2019-02-01T22:06:20Z"},
-		{"path":"github.com/zclconf/go-cty/cty/convert","checksumSHA1":"1WGUPe776lvMMbaRerAbqOx19nQ=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
-		{"path":"github.com/zclconf/go-cty/cty/function","checksumSHA1":"MyyLCGg3RREMllTJyK6ehZl/dHk=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
-		{"path":"github.com/zclconf/go-cty/cty/function/stdlib","checksumSHA1":"kcTJOuL131/stXJ4U9tC3SASQLs=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
-		{"path":"github.com/zclconf/go-cty/cty/gocty","checksumSHA1":"tmCzwfNXOEB1sSO7TKVzilb2vjA=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
-		{"path":"github.com/zclconf/go-cty/cty/json","checksumSHA1":"1ApmO+Q33+Oem/3f6BU6sztJWNc=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
-		{"path":"github.com/zclconf/go-cty/cty/msgpack","checksumSHA1":"8H+2pufGi2Eo3d8cXFfJs31wk+I=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
-		{"path":"github.com/zclconf/go-cty/cty/set","checksumSHA1":"y5Sk+n6SOspFj8mlyb8swr4DMIs=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
-		{"path":"go.opencensus.io","checksumSHA1":"w+WRj7WpdItd5iR7PcaQQKMrVB0=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/internal","checksumSHA1":"KLZy3Nh+8JlI04JmBa/Jc8fxrVQ=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/internal/tagencoding","checksumSHA1":"Dw3rpna1DwTa7TCzijInKcU49g4=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/metric/metricdata","checksumSHA1":"r6fbtPwxK4/TYUOWc7y0hXdAG4Q=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/metric/metricproducer","checksumSHA1":"kWj13srwY1SH5KgFecPhEfHnzVc=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/plugin/ochttp","checksumSHA1":"Ur+xijNXCbNHR8Q5VjW1czSAabo=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/plugin/ochttp/propagation/b3","checksumSHA1":"UZhIoErIy1tKLmVT/5huwlp6KFQ=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/resource","checksumSHA1":"q+y8X+5nDONIlJlxfkv+OtA18ds=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/stats","checksumSHA1":"Cc4tRuW0IjlfAFY8BcdfMDqG0R8=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/stats/internal","checksumSHA1":"oIo4NRi6AVCfcwVfHzCXAsoZsdI=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/stats/view","checksumSHA1":"vN9GN1vwD4RU/3ld2tKK00K0i94=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/tag","checksumSHA1":"AoqL/neZwl05Fv08vcXXlhbY12g=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/trace","checksumSHA1":"0O3djqX4bcg5O9LZdcinEoYeQKs=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/trace/internal","checksumSHA1":"JkvEb8oMEFjic5K/03Tyr5Lok+w=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/trace/propagation","checksumSHA1":"FHJParRi8f1GHO7Cx+lk3bMWBq0=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go.opencensus.io/trace/tracestate","checksumSHA1":"UHbxxaMqpEPsubh8kPwzSlyEwqI=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
-		{"path":"go4.org/errorutil","checksumSHA1":"PMr/a5kcnC4toJtVwWhlU5E4tJY=","revision":"034d17a462f7b2dcd1a4a73553ec5357ff6e6c6e","revisionTime":"2017-05-24T23:16:39Z"},
-		{"path":"golang.org/x/crypto/blake2b","checksumSHA1":"ejjxT0+wDWWncfh0Rt3lSH4IbXQ=","revision":"de0752318171da717af4ce24d0a2e8626afaeb11","revisionTime":"2018-08-08T16:52:45Z"},
-		{"path":"golang.org/x/crypto/ssh/terminal","checksumSHA1":"BGm8lKZmvJbf/YOJLeL1rw2WVjA=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
-		{"path":"golang.org/x/net/context","checksumSHA1":"GtamqiJoL7PGHsN454AoffBFMa8=","revision":"c10e9556a7bc0e7c942242b606f0acf024ad5d6a","revisionTime":"2018-11-02T08:55:01Z"},
-		{"path":"golang.org/x/net/context/ctxhttp","checksumSHA1":"WHc3uByvGaMcnSoI21fhzYgbOgg=","revision":"f09c4662a0bd6bd8943ac7b4931e185df9471da4","revisionTime":"2016-09-24T00:10:04Z"},
-		{"path":"golang.org/x/net/html","checksumSHA1":"vqc3a+oTUGX8PmD0TS+qQ7gmN8I=","revision":"66aacef3dd8a676686c7ae3716979581e8b03c47","revisionTime":"2016-09-14T00:11:54Z"},
-		{"path":"golang.org/x/net/html/atom","checksumSHA1":"00eQaGynDYrv3tL+C7l9xH0IDZg=","revision":"66aacef3dd8a676686c7ae3716979581e8b03c47","revisionTime":"2016-09-14T00:11:54Z"},
-		{"path":"golang.org/x/net/html/charset","checksumSHA1":"barUU39reQ7LdgYLA323hQ/UGy4=","revision":"66aacef3dd8a676686c7ae3716979581e8b03c47","revisionTime":"2016-09-14T00:11:54Z"},
-		{"path":"golang.org/x/net/http2","checksumSHA1":"kKuxyoDujo5CopTxAvvZ1rrLdd0=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
-		{"path":"golang.org/x/net/http2/hpack","checksumSHA1":"ezWhc7n/FtqkLDQKeU2JbW+80tE=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
-		{"path":"golang.org/x/net/idna","checksumSHA1":"g/Z/Ka0VgJESgQK7/SJCjm/aX0I=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
-		{"path":"golang.org/x/net/internal/timeseries","checksumSHA1":"UxahDzW2v4mf/+aFxruuupaoIwo=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
-		{"path":"golang.org/x/net/lex/httplex","checksumSHA1":"3xyuaSNmClqG4YWC7g0isQIbUTc=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
-		{"path":"golang.org/x/net/proxy","checksumSHA1":"r9l4r3H6FOLQ0c2JaoXpopFjpnw=","origin":"github.com/docker/docker/vendor/golang.org/x/net/proxy","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
-		{"path":"golang.org/x/net/trace","checksumSHA1":"u/r66lwYfgg682u5hZG7/E7+VCY=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
-		{"path":"golang.org/x/oauth2","checksumSHA1":"uRlaEkyMCxyjj57KBa81GEfvCwg=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
-		{"path":"golang.org/x/oauth2/google","checksumSHA1":"w5SmJwdVFlGE1KO4/AQjY+jvdsI=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
-		{"path":"golang.org/x/oauth2/internal","checksumSHA1":"rnUL+5Yzlt+Ky2dlB61VqfhBOb8=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
-		{"path":"golang.org/x/oauth2/jws","checksumSHA1":"huVltYnXdRFDJLgp/ZP9IALzG7g=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
-		{"path":"golang.org/x/oauth2/jwt","checksumSHA1":"HGS6ig1GfcE2CBHBsi965ZVn9Xw=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
-		{"path":"golang.org/x/sync/errgroup","checksumSHA1":"S0DP7Pn7sZUmXc55IzZnNvERu6s=","revision":"316e794f7b5e3df4e95175a45a5fb8b12f85cb4f","revisionTime":"2016-07-15T18:54:39Z"},
-		{"path":"golang.org/x/sys/cpu","checksumSHA1":"REkmyB368pIiip76LiqMLspgCRk=","revision":"1b2967e3c290b7c545b3db0deeda16e9be4f98a2","revisionTime":"2018-07-06T09:56:39Z"},
-		{"path":"golang.org/x/sys/unix","checksumSHA1":"su2QDjUzrUO0JnOH9m0cNg0QqsM=","revision":"ac767d655b305d4e9612f5f6e33120b9176c4ad4","revisionTime":"2018-07-08T03:57:06Z"},
-		{"path":"golang.org/x/sys/windows","checksumSHA1":"l1jIhK9Y33obLipDvmjVPCdYtJI=","revision":"1b2967e3c290b7c545b3db0deeda16e9be4f98a2","revisionTime":"2018-07-06T09:56:39Z"},
-		{"path":"golang.org/x/text/encoding","checksumSHA1":"Mr4ur60bgQJnQFfJY0dGtwWwMPE=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/encoding/charmap","checksumSHA1":"HgcUFTOQF5jOYtTIj5obR3GVN9A=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/encoding/htmlindex","checksumSHA1":"yBhX1V6U7stq3GqS2x5yzF0lV+I=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/encoding/internal","checksumSHA1":"zeHyHebIZl1tGuwGllIhjfci+wI=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/encoding/internal/identifier","checksumSHA1":"9cg4nSGfKTIWKb6bWV7U4lnuFKA=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/encoding/japanese","checksumSHA1":"f/PWjU17cU5uo0zkdi+Iz80Megk=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/encoding/korean","checksumSHA1":"qHQ79q9peY8ZkCMC8kJAb52BAWg=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/encoding/simplifiedchinese","checksumSHA1":"55UdScb+EMOCPr7OW0hCwDsVxpg=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/encoding/traditionalchinese","checksumSHA1":"9EZF1SHTpjVmaT9sARitvGKUXOY=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/encoding/unicode","checksumSHA1":"G9LfJI9gySazd+MyyC6QbTHx4to=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
-		{"path":"golang.org/x/text/internal","checksumSHA1":"i47RkGDg+mFR2sYXOfVRVkGow3U=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/internal/language","checksumSHA1":"TWgJww5WcPoH39HKMNW0gEcQHts=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/internal/tag","checksumSHA1":"hyNCcTwMQnV6/MK8uUW9E5H0J0M=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/internal/utf8internal","checksumSHA1":"Qk7dljcrEK1BJkAEZguxAbG9dSo=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/language","checksumSHA1":"B2EFJkBRmiAWXqY/4zqUJfp85ag=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/runes","checksumSHA1":"IV4MN7KGBSocu/5NR3le3sxup4Y=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/secure/bidirule","checksumSHA1":"tltivJ/uj/lqLk05IqGfCv2F/E8=","revision":"88f656faf3f37f690df1a32515b479415e1a6769","revisionTime":"2017-10-26T07:52:28Z"},
-		{"path":"golang.org/x/text/transform","checksumSHA1":"ziMb9+ANGRJSSIuxYdRbA+cDRBQ=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/unicode/bidi","checksumSHA1":"iB6/RoQIzBaZxVi+t7tzbkwZTlo=","revision":"88f656faf3f37f690df1a32515b479415e1a6769","revisionTime":"2017-10-26T07:52:28Z"},
-		{"path":"golang.org/x/text/unicode/cldr","checksumSHA1":"jer43nmInsJhYFfpl39FpEYyoC4=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/unicode/norm","checksumSHA1":"BCNYmf4Ek93G4lk5x3ucNi/lTwA=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/unicode/rangetable","checksumSHA1":"1mKbP+ZJSE2oamuShC/hhvJahks=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/text/width","checksumSHA1":"zuieOGXKG9vXxNhEWv3H0X8RSXM=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
-		{"path":"golang.org/x/time/rate","checksumSHA1":"h/06ikMECfJoTkWj2e1nJ30aDDg=","revision":"a4bde12657593d5e90d0533a3e4fd95e635124cb","revisionTime":"2016-02-02T18:34:45Z"},
-		{"path":"google.golang.org/api/gensupport","checksumSHA1":"QyBLCM74VEO9bekzOZGcEkJ7V0o=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/api/googleapi","checksumSHA1":"YIDE68w/xMptf6Nu9hHiOwXOvho=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/api/googleapi/internal/uritemplates","checksumSHA1":"1K0JxrUfDqAB3MyRiU1LKjfHyf4=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/api/googleapi/transport","checksumSHA1":"Mr2fXhMRzlQCgANFm91s536pG7E=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/api/internal","checksumSHA1":"6Tg4dDJKzoSrAA5beVknvnjluOU=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/api/iterator","checksumSHA1":"zh9AcT6oNvhnOqb7w7njY48TkvI=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/api/option","checksumSHA1":"2AyxThTPscWdy49fGsU2tg0Uyw8=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/api/storage/v1","checksumSHA1":"5M3TLPBoDz0A+PsHGDJmjmwqoTI=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/api/transport/http","checksumSHA1":"a+PkIGoiF+p+ghmjmA9gUkMFwYQ=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/api/transport/http/internal/propagation","checksumSHA1":"sJcKCvjPtoysqyelsB2CQzC5oQI=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
-		{"path":"google.golang.org/genproto/googleapis/api/annotations","checksumSHA1":"xmp0GjeJfZUWSmGfoUA/pxlKc0Q=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
-		{"path":"google.golang.org/genproto/googleapis/iam/v1","checksumSHA1":"3hrELKtivO5PZZfzCL4JVOX3/Kw=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
-		{"path":"google.golang.org/genproto/googleapis/rpc/code","checksumSHA1":"74OOKlkosdNECTQ8HvRmtMsqJZg=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
-		{"path":"google.golang.org/genproto/googleapis/rpc/status","checksumSHA1":"Q0bDd8ApwAloBd/JQw0uZD4DbZM=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
-		{"path":"google.golang.org/genproto/googleapis/type/expr","checksumSHA1":"AyISVQkdxcMLS/tagl6PJFTs8Bs=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
-		{"path":"google.golang.org/grpc","checksumSHA1":"UKBaAnKJu1ydInKNkSvnJ4s18QQ=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
-		{"path":"google.golang.org/grpc/codes","checksumSHA1":"/eTpFgjvMq5Bc9hYnw5fzKG4B6I=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"google.golang.org/grpc/credentials","checksumSHA1":"wA6y5rkH1v4bWBe5M1r/Hdtgma4=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
-		{"path":"google.golang.org/grpc/grpclb/grpc_lb_v1","checksumSHA1":"2NbY9kmMweE4VUsruRsvmViVnNg=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"google.golang.org/grpc/grpclog","checksumSHA1":"MCQmohiDJwkgLWu/wpnekweQh8s=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"google.golang.org/grpc/health","checksumSHA1":"pc9cweMiKQ5hVMuO9UoMGdbizaY=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"google.golang.org/grpc/health/grpc_health_v1","checksumSHA1":"W5KfI1NIGJt7JaVnLzefDZr3+4s=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"google.golang.org/grpc/internal","checksumSHA1":"cSdzm5GhbalJbWUNrN8pRdW0uks=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
-		{"path":"google.golang.org/grpc/internal/transport","checksumSHA1":"Z1mhrOEf+PedS4kVtNRlINUDzWg=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
-		{"path":"google.golang.org/grpc/keepalive","checksumSHA1":"hcuHgKp8W0wIzoCnNfKI8NUss5o=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"google.golang.org/grpc/metadata","checksumSHA1":"OjIAi5AzqlQ7kLtdAyjvdgMf6hc=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
-		{"path":"google.golang.org/grpc/naming","checksumSHA1":"Zzb7Xsc3tbTJzrcZbSPyye+yxmw=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"google.golang.org/grpc/peer","checksumSHA1":"n5EgDdBqFMa2KQFhtl+FF/4gIFo=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"google.golang.org/grpc/stats","checksumSHA1":"YclPgme2gT3S0hTkHVdE1zAxJdo=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
-		{"path":"google.golang.org/grpc/status","checksumSHA1":"t/NhHuykWsxY0gEBd2WIv5RVBK8=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
-		{"path":"google.golang.org/grpc/tap","checksumSHA1":"aixGx/Kd0cj9ZlZHacpHe3XgMQ4=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"google.golang.org/grpc/transport","checksumSHA1":"oFGr0JoquaPGVnV86fVL8MVTc3A=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
-		{"path":"gopkg.in/fsnotify.v1","checksumSHA1":"eIhF+hmL/XZhzTiAwhLD0M65vlY=","revision":"629574ca2a5df945712d3079857300b5e4da0236","revisionTime":"2016-10-11T02:33:12Z"},
-		{"path":"gopkg.in/inf.v0","checksumSHA1":"6f8MEU31llHM1sLM/GGH4/Qxu0A=","revision":"3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4","revisionTime":"2015-09-11T12:57:57Z"},
-		{"path":"gopkg.in/tomb.v1","checksumSHA1":"TO8baX+t1Qs7EmOYth80MkbKzFo=","revision":"dd632973f1e7218eb1089048e0798ec9ae7dceb8","revisionTime":"2014-10-24T13:56:13Z"},
-		{"path":"gopkg.in/tomb.v2","checksumSHA1":"WiyCOMvfzRdymImAJ3ME6aoYUdM=","revision":"14b3d72120e8d10ea6e6b7f87f7175734b1faab8","revisionTime":"2014-06-26T14:46:23Z"},
-		{"path":"gopkg.in/yaml.v2","checksumSHA1":"12GqsW8PiRPnezDDy0v4brZrndM=","revision":"a5b47d31c556af34a302ce5d659e6fea44d90de0","revisionTime":"2016-09-28T15:37:09Z"}
+		{
+			"checksumSHA1": "b1KgRkWqz0RmrEBK6IJ8kOJva6w=",
+			"path": "cloud.google.com/go/compute/metadata",
+			"revision": "4bdb329835f9d945a6dad7b2ed60534497faa857",
+			"revisionTime": "2019-08-08T17:09:53Z"
+		},
+		{
+			"checksumSHA1": "+S/9jBntS1iHZwxkR64vsy97Gh8=",
+			"path": "cloud.google.com/go/iam",
+			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
+			"revisionTime": "2019-08-21T09:16:34Z"
+		},
+		{
+			"checksumSHA1": "JfGXEtr79UaxukcL05IERkjYm/g=",
+			"path": "cloud.google.com/go/internal",
+			"revision": "f6872d26e2099733e489f2322a878213384f731a",
+			"revisionTime": "2019-08-26T22:18:59Z"
+		},
+		{
+			"checksumSHA1": "wQ4uGuRwMb24vG16pPQDOOCPkFo=",
+			"path": "cloud.google.com/go/internal/optional",
+			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
+			"revisionTime": "2019-08-21T09:16:34Z"
+		},
+		{
+			"checksumSHA1": "jHOn3QLqvr1luNqyOg24/BXLrsM=",
+			"path": "cloud.google.com/go/internal/trace",
+			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
+			"revisionTime": "2019-08-21T09:16:34Z"
+		},
+		{
+			"checksumSHA1": "CRid/VCcJ3Vfwg/R/gbmzcHVOwQ=",
+			"path": "cloud.google.com/go/internal/version",
+			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
+			"revisionTime": "2019-08-21T09:16:34Z"
+		},
+		{
+			"checksumSHA1": "bZ1XULD+TbAPpn8b6+5dMaWWcqs=",
+			"path": "cloud.google.com/go/storage",
+			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
+			"revisionTime": "2019-08-21T09:16:34Z"
+		},
+		{
+			"checksumSHA1": "Fs6Gcl0nhC0FJ6MsB+Ck7r4huYo=",
+			"path": "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2015-06-15/network",
+			"revision": "767429fcb996dad413936d682c28301e6739bade",
+			"revisionTime": "2018-05-01T22:35:11Z"
+		},
+		{
+			"checksumSHA1": "FAw+h8wS2QiQEIVC3z/8R2q1bvY=",
+			"path": "github.com/Azure/azure-sdk-for-go/version",
+			"revision": "767429fcb996dad413936d682c28301e6739bade",
+			"revisionTime": "2018-05-01T22:35:11Z"
+		},
+		{
+			"checksumSHA1": "9NFR6RG8H2fNyKHscGmuGLQhRm4=",
+			"path": "github.com/Azure/go-ansiterm",
+			"revision": "d6e3b3328b783f23731bc4d058875b0371ff8109",
+			"revisionTime": "2017-09-29T23:40:23Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "3/UphB+6Hbx5otA4PjFjvObT+L4=",
+			"path": "github.com/Azure/go-ansiterm/winterm",
+			"revision": "d6e3b3328b783f23731bc4d058875b0371ff8109",
+			"revisionTime": "2017-09-29T23:40:23Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "Pc2ORQp+VY3Un/dkh4QwLC7R6lE=",
+			"path": "github.com/BurntSushi/toml",
+			"revision": "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005",
+			"revisionTime": "2018-08-15T10:47:33Z"
+		},
+		{
+			"checksumSHA1": "WvApwvvSe3i/3KO8300dyeFmkbI=",
+			"path": "github.com/DataDog/datadog-go/statsd",
+			"revision": "b10af4b12965a1ad08d164f57d14195b4140d8de",
+			"revisionTime": "2017-08-09T10:47:06Z"
+		},
+		{
+			"checksumSHA1": "Jmf4AnrptgBdQ5TPBJ2M89nooIQ=",
+			"path": "github.com/LK4D4/joincontext",
+			"revision": "1724345da6d5bcc8b66fefb843b607ab918e175c",
+			"revisionTime": "2017-10-26T17:01:39Z"
+		},
+		{
+			"checksumSHA1": "nEVw+80Junfo7iEY7ThP7Ci9Pyk=",
+			"origin": "github.com/endocrimes/go-winio",
+			"path": "github.com/Microsoft/go-winio",
+			"revision": "fb47a8b419480a700368c176bc1d5d7e3393b98d",
+			"revisionTime": "2019-06-20T17:03:19Z",
+			"version": "dani/safe-relisten",
+			"versionExact": "dani/safe-relisten"
+		},
+		{
+			"checksumSHA1": "/ykkyb7gmtZC68n7T24xwbmlCBc=",
+			"origin": "github.com/endocrimes/go-winio/pkg/guid",
+			"path": "github.com/Microsoft/go-winio/pkg/guid",
+			"revision": "fb47a8b419480a700368c176bc1d5d7e3393b98d",
+			"revisionTime": "2019-06-20T17:03:19Z",
+			"version": "dani/safe-relisten",
+			"versionExact": "dani/safe-relisten"
+		},
+		{
+			"checksumSHA1": "kF1vk+8Xvb3nGBiw9+qbUc0SZ4M=",
+			"path": "github.com/NVIDIA/gpu-monitoring-tools",
+			"revision": "86f2a9fac6c5b597dc494420005144b8ef7ec9fb",
+			"revisionTime": "2018-08-29T22:20:09Z"
+		},
+		{
+			"checksumSHA1": "P8FATSSgpe5A17FyPrGpsX95Xw8=",
+			"path": "github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml",
+			"revision": "86f2a9fac6c5b597dc494420005144b8ef7ec9fb",
+			"revisionTime": "2018-08-29T22:20:09Z"
+		},
+		{
+			"checksumSHA1": "jktW57+vJsziNVPeXMCoujTzdW4=",
+			"path": "github.com/NYTimes/gziphandler",
+			"revision": "97ae7fbaf81620fe97840685304a78a306a39c64",
+			"revisionTime": "2017-09-16T00:36:49Z"
+		},
+		{
+			"checksumSHA1": "Aqy8/FoAIidY/DeQ5oTYSZ4YFVc=",
+			"path": "github.com/Nvveen/Gotty",
+			"revision": "cd527374f1e5bff4938207604a14f2e38a9cf512",
+			"revisionTime": "2012-06-04T00:48:16Z"
+		},
+		{
+			"checksumSHA1": "qtjd74+bErubh+qyv3s+lWmn9wc=",
+			"path": "github.com/StackExchange/wmi",
+			"revision": "ea383cf3ba6ec950874b8486cd72356d007c768f",
+			"revisionTime": "2017-04-10T19:29:09Z"
+		},
+		{
+			"checksumSHA1": "jQh1fnoKPKMURvKkpdRjN695nAQ=",
+			"path": "github.com/agext/levenshtein",
+			"revision": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6",
+			"revisionTime": "2017-02-17T06:30:20Z"
+		},
+		{
+			"checksumSHA1": "Ffhtm8iHH7l2ynVVOIGJE3eiuLA=",
+			"path": "github.com/apparentlymart/go-textseg/textseg",
+			"revision": "b836f5c4d331d1945a2fead7188db25432d73b69",
+			"revisionTime": "2017-05-31T20:39:52Z"
+		},
+		{
+			"checksumSHA1": "uWJDTv0R/NJVYv51LVy6vKP1CZw=",
+			"path": "github.com/appc/spec/schema",
+			"revision": "cbe99b7160b1397bf89f9c8bb1418f69c9424049",
+			"revisionTime": "2017-09-19T09:55:19Z"
+		},
+		{
+			"checksumSHA1": "Q47G6996hbfQaNp/8CFkGWTVQpw=",
+			"path": "github.com/appc/spec/schema/common",
+			"revision": "cbe99b7160b1397bf89f9c8bb1418f69c9424049",
+			"revisionTime": "2017-09-19T09:55:19Z"
+		},
+		{
+			"checksumSHA1": "kYXCle7Ikc8WqiMs7NXz99bUWqo=",
+			"path": "github.com/appc/spec/schema/types",
+			"revision": "cbe99b7160b1397bf89f9c8bb1418f69c9424049",
+			"revisionTime": "2017-09-19T09:55:19Z"
+		},
+		{
+			"checksumSHA1": "VgPsPj5PH7LKXMa3ZLe5/+Avydo=",
+			"path": "github.com/appc/spec/schema/types/resource",
+			"revision": "cbe99b7160b1397bf89f9c8bb1418f69c9424049",
+			"revisionTime": "2017-09-19T09:55:19Z"
+		},
+		{
+			"checksumSHA1": "l0iFqayYAaEip6Olaq3/LCOa/Sg=",
+			"path": "github.com/armon/circbuf",
+			"revision": "bbbad097214e2918d8543d5201d12bfd7bca254d"
+		},
+		{
+			"checksumSHA1": "gaT7FBF9uH5TY4lCo96ySrYXjek=",
+			"path": "github.com/armon/go-metrics",
+			"revision": "c1e99089638e6f1f57fe71461f99f9d00a43ccf1",
+			"revisionTime": "2019-04-30T14:02:02Z"
+		},
+		{
+			"checksumSHA1": "xCsGGM9TKBogZDfSN536KtQdLko=",
+			"path": "github.com/armon/go-metrics/circonus",
+			"revision": "c1e99089638e6f1f57fe71461f99f9d00a43ccf1",
+			"revisionTime": "2019-04-30T14:02:02Z"
+		},
+		{
+			"checksumSHA1": "Dt0n1sSivvvdZQdzc4Hu/yOG+T0=",
+			"path": "github.com/armon/go-metrics/datadog",
+			"revision": "c1e99089638e6f1f57fe71461f99f9d00a43ccf1",
+			"revisionTime": "2019-04-30T14:02:02Z"
+		},
+		{
+			"checksumSHA1": "vxr0X6/jCQ4FkMxdhzUaBEWrFGA=",
+			"path": "github.com/armon/go-metrics/prometheus",
+			"revision": "c1e99089638e6f1f57fe71461f99f9d00a43ccf1",
+			"revisionTime": "2019-04-30T14:02:02Z"
+		},
+		{
+			"checksumSHA1": "gNO0JNpLzYOdInGeq7HqMZUzx9M=",
+			"path": "github.com/armon/go-radix",
+			"revision": "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2",
+			"revisionTime": "2016-01-15T23:47:25Z"
+		},
+		{
+			"checksumSHA1": "gMMx/JVSQVE4KHKoJQC7cqjTIZc=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "OlpdlsDV2Qv50MuHlpH9heaHjQc=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/awserr",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "MoxolxrlsmtDri7ndvx5gkXI2hU=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "qZUhjIZT8zU/xdQJ3La948GqEgU=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/client",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "VAb9dwYeOW1iViqztJq8DGtlrV4=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "x1grxMebz9A06jOsLieoExjhltU=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/credentials",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "nCeVh7E8twNLP887Zanei1wd6ks=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "9c2Th6//lUUZPehmPkHXJh4hE/s=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/defaults",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "xyUdqBgj3ltt9LXnY4UvEct2izQ=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "0i8r38TS6u3uT2HBM+8tNsozY6w=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/request",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "S46ej8/Fd7YnczK42I1UnjoeqqM=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/aws/session",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "Rv6k85b5aRb0la07XzRPsrzwrHE=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/private/endpoints",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "ndEFDDt1gd5taOeeUrf0T66H+bg=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "j8UDnDnB59+u1w/qBHKG0PSWH8U=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "WRZcRqV95LFgq5V09PmDmSmNTEw=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "KVdpXAG2PmIyopNC4jJd/JdjefA=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "xmKYerjqq1FO8kJK0/4Ds8iGyWg=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "H0s7iZn2nk/fq52QaaTeW+gSGgA=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/private/signer/v4",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "Pfoou5jtRj8A0SuCl8toNbXQlfw=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/private/waiter",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "NAitp0A1zE3Zry+Z41LOlCr+9lQ=",
+			"comment": "v1.0.6-2-g80dd495",
+			"path": "github.com/aws/aws-sdk-go/service/s3",
+			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
+		},
+		{
+			"checksumSHA1": "spyv5/YFBjYyZLZa1U2LBfDR8PM=",
+			"path": "github.com/beorn7/perks/quantile",
+			"revision": "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9",
+			"revisionTime": "2016-08-04T10:47:26Z"
+		},
+		{
+			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",
+			"path": "github.com/bgentry/go-netrc/netrc",
+			"revision": "9fd32a8b3d3d3f9d43c341bfe098430e07609480",
+			"revisionTime": "2014-04-22T17:41:19Z"
+		},
+		{
+			"checksumSHA1": "7SbTaY0kaYxgQrG3/9cjrI+BcyU=",
+			"path": "github.com/bgentry/speakeasy",
+			"revision": "36e9cfdd690967f4f690c6edcc9ffacd006014a0"
+		},
+		{
+			"checksumSHA1": "twtRfb6484vfr2qqjiFkLThTjcQ=",
+			"path": "github.com/bgentry/speakeasy/example",
+			"revision": "36e9cfdd690967f4f690c6edcc9ffacd006014a0"
+		},
+		{
+			"checksumSHA1": "R1Q34Pfnt197F/nCOO9kG8c+Z90=",
+			"comment": "v1.2.0",
+			"path": "github.com/boltdb/bolt",
+			"revision": "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8",
+			"revisionTime": "2017-07-17T17:11:48Z",
+			"version": "v1.3.1",
+			"versionExact": "v1.3.1"
+		},
+		{
+			"checksumSHA1": "k3xD77kpUpECrHCffQKb1nttiDM=",
+			"path": "github.com/checkpoint-restore/go-criu/rpc",
+			"revision": "bdb7599cd87b22701b5c89b37940ea882a7d7dec",
+			"revisionTime": "2019-01-09T18:43:17Z"
+		},
+		{
+			"checksumSHA1": "H4RhrnI0P34qLB9345G4r7CAwpU=",
+			"path": "github.com/circonus-labs/circonus-gometrics",
+			"revision": "d6e3aea90ab9f90fe8456e13fc520f43d102da4d",
+			"revisionTime": "2019-01-28T15:50:09Z",
+			"version": "=v2",
+			"versionExact": "v2"
+		},
+		{
+			"checksumSHA1": "xtzLG2UjYF1lnD33Wk+Nu/KOO6E=",
+			"path": "github.com/circonus-labs/circonus-gometrics/api",
+			"revision": "d6e3aea90ab9f90fe8456e13fc520f43d102da4d",
+			"revisionTime": "2019-01-28T15:50:09Z",
+			"version": "=v2",
+			"versionExact": "v2"
+		},
+		{
+			"checksumSHA1": "bQhz/fcyZPmuHSH2qwC4ZtATy5c=",
+			"path": "github.com/circonus-labs/circonus-gometrics/api/config",
+			"revision": "d6e3aea90ab9f90fe8456e13fc520f43d102da4d",
+			"revisionTime": "2019-01-28T15:50:09Z",
+			"version": "=v2",
+			"versionExact": "v2"
+		},
+		{
+			"checksumSHA1": "Ij8yB33E0Kk+GfTkNRoF1mG26dc=",
+			"path": "github.com/circonus-labs/circonus-gometrics/checkmgr",
+			"revision": "d6e3aea90ab9f90fe8456e13fc520f43d102da4d",
+			"revisionTime": "2019-01-28T15:50:09Z",
+			"version": "=v2",
+			"versionExact": "v2"
+		},
+		{
+			"checksumSHA1": "VbfeVqeOM+dTNxCmpvmYS0LwQn0=",
+			"path": "github.com/circonus-labs/circonusllhist",
+			"revision": "7d649b46cdc2cd2ed102d350688a75a4fd7778c6",
+			"revisionTime": "2016-11-21T13:51:53Z"
+		},
+		{
+			"checksumSHA1": "IGtuR58l2zmYRcNf8sPDlCSgovE=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/containerd/console",
+			"path": "github.com/containerd/console",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "GqIrOttKaO7k6HIaHQLPr3cY7rY=",
+			"origin": "github.com/docker/docker/vendor/github.com/containerd/continuity/pathdriver",
+			"path": "github.com/containerd/continuity/pathdriver",
+			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
+			"revisionTime": "2018-08-16T08:14:46Z"
+		},
+		{
+			"checksumSHA1": "Ur3lVmFp+HTGUzQU+/ZBolKe8FU=",
+			"path": "github.com/containerd/fifo",
+			"revision": "3d5202aec260678c48179c56f40e6f38a095738c",
+			"revisionTime": "2018-03-07T16:51:37Z"
+		},
+		{
+			"checksumSHA1": "O9ClcGJBsp5JQOdetGwWD6+eOJk=",
+			"origin": "github.com/nickethier/go-cni",
+			"path": "github.com/containerd/go-cni",
+			"revision": "ac330f26ed23b10047dfeb864e20ce1721f4bdd9",
+			"revisionTime": "2019-08-29T03:25:06Z",
+			"version": "conflist-bytes",
+			"versionExact": "conflist-bytes"
+		},
+		{
+			"checksumSHA1": "3CsFN6YsShG9EU2oB9vJIqYTxq4=",
+			"path": "github.com/containernetworking/cni/libcni",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "Xf2DxXUyjBO9u4LeyDzS38pdL+I=",
+			"path": "github.com/containernetworking/cni/pkg/invoke",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "Dhi4+8X7U2oVzVkgxPrmLaN8qFI=",
+			"path": "github.com/containernetworking/cni/pkg/types",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "6+ng8oaM9SB0TyCE7I7N940IpPY=",
+			"path": "github.com/containernetworking/cni/pkg/types/020",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "X6dNZ3yc3V9ffW9vz4yIyeKXGD0=",
+			"path": "github.com/containernetworking/cni/pkg/types/current",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "aojwjPoA9XSGB/zVtOGzWvmv/i8=",
+			"path": "github.com/containernetworking/cni/pkg/version",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "n3dCDigZOU+eD84Cr4Kg30GO4nI=",
+			"path": "github.com/containernetworking/plugins/pkg/ns",
+			"revision": "2d6d46d308b2c45a0466324c9e3f1330ab5cacd6",
+			"revisionTime": "2019-05-01T19:17:48Z"
+		},
+		{
+			"checksumSHA1": "UAPz3mxGiQmd3pRWOTghB2aXzGU=",
+			"path": "github.com/coreos/go-iptables/iptables",
+			"revision": "969b135e941d8baadca0a40047a38d6aca381855",
+			"revisionTime": "2019-07-24T15:17:50Z"
+		},
+		{
+			"checksumSHA1": "97BsbXOiZ8+Kr+LIuZkQFtSj7H4=",
+			"path": "github.com/coreos/go-semver/semver",
+			"revision": "1817cd4bea52af76542157eeabd74b057d1a199e",
+			"revisionTime": "2017-06-13T09:22:38Z"
+		},
+		{
+			"checksumSHA1": "/zxxFPYjUB7Wowz33r5AhTDvoz0=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/coreos/go-systemd/dbus",
+			"path": "github.com/coreos/go-systemd/dbus",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "e8qgBHxXbij3RVspqrkeBzMZ564=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/coreos/go-systemd/util",
+			"path": "github.com/coreos/go-systemd/util",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "O8c/VKtW34XPJNNlyeb/im8vWSI=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/coreos/pkg/dlopen",
+			"path": "github.com/coreos/pkg/dlopen",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "4Cq4wS4l0O8WlugamGEPvooJPAk=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/cyphar/filepath-securejoin",
+			"path": "github.com/cyphar/filepath-securejoin",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "mrz/kicZiUaHxkyfvC/DyQcr8Do=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "ecdeabc65495df2dec95d7c4a4c3e021903035e5",
+			"revisionTime": "2017-10-02T20:02:53Z"
+		},
+		{
+			"checksumSHA1": "wf9Rn3a9cPag5B9Dd+qHHEink+I=",
+			"path": "github.com/docker/cli/cli/config/configfile",
+			"revision": "67f9a3912cf944cf71b31f3fc14e3f2a18d95802",
+			"revisionTime": "2018-08-14T14:54:37Z",
+			"version": "v18.06.1-ce",
+			"versionExact": "v18.06.1-ce"
+		},
+		{
+			"checksumSHA1": "fJpuGdxgATGNHm+INOPNVIhBnj0=",
+			"path": "github.com/docker/cli/cli/config/credentials",
+			"revision": "deb84a9e4e10b590e6de6aa6081532c87a5a2cfe",
+			"revisionTime": "2018-08-29T13:09:58Z"
+		},
+		{
+			"checksumSHA1": "+yq5Rc1QTapDrr151x0m5ANZZeY=",
+			"path": "github.com/docker/cli/opts",
+			"revision": "67f9a3912cf944cf71b31f3fc14e3f2a18d95802",
+			"revisionTime": "2018-08-14T14:54:37Z",
+			"version": "v18.06.1-ce",
+			"versionExact": "v18.06.1-ce"
+		},
+		{
+			"checksumSHA1": "ae06MP/1OVwQ/s/PsEp9wxfnBXM=",
+			"path": "github.com/docker/distribution",
+			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
+			"revisionTime": "2018-08-28T23:03:05Z"
+		},
+		{
+			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
+			"path": "github.com/docker/distribution/digestset",
+			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
+			"revisionTime": "2018-03-27T20:24:08Z"
+		},
+		{
+			"checksumSHA1": "yqCaL8oUi3OlR/Mr4oHB5HKpstc=",
+			"path": "github.com/docker/distribution/metrics",
+			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
+			"revisionTime": "2018-08-28T23:03:05Z"
+		},
+		{
+			"checksumSHA1": "2Fe4D6PGaVE2he4fUeenLmhC1lE=",
+			"path": "github.com/docker/distribution/reference",
+			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
+			"revisionTime": "2018-03-27T20:24:08Z"
+		},
+		{
+			"checksumSHA1": "oFgg0LXTCZuYeI0/eEatdTyLexg=",
+			"path": "github.com/docker/distribution/registry/api/errcode",
+			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
+			"revisionTime": "2018-03-27T20:24:08Z"
+		},
+		{
+			"checksumSHA1": "tjPyswv8NGYxreknmylv5r5tjt4=",
+			"path": "github.com/docker/distribution/registry/api/v2",
+			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
+			"revisionTime": "2018-08-28T23:03:05Z"
+		},
+		{
+			"checksumSHA1": "72zK3wP1n7UTcSFKZZz77sKXZiU=",
+			"path": "github.com/docker/distribution/registry/client",
+			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
+			"revisionTime": "2018-08-28T23:03:05Z"
+		},
+		{
+			"checksumSHA1": "UeouykquJzdjJv1+Vv0ikpe7Yvo=",
+			"path": "github.com/docker/distribution/registry/client/auth",
+			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
+			"revisionTime": "2018-03-27T20:24:08Z"
+		},
+		{
+			"checksumSHA1": "GWNgNhqeZST7+rgQdC06yEaLuQg=",
+			"path": "github.com/docker/distribution/registry/client/auth/challenge",
+			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
+			"revisionTime": "2018-03-27T20:24:08Z"
+		},
+		{
+			"checksumSHA1": "KjpG7FYMU5ugtc/fTfL1YqhdaV4=",
+			"path": "github.com/docker/distribution/registry/client/transport",
+			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
+			"revisionTime": "2018-03-27T20:24:08Z"
+		},
+		{
+			"checksumSHA1": "RjRJSz/ISJEi0uWh5FlXMQetRcg=",
+			"path": "github.com/docker/distribution/registry/storage/cache",
+			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
+			"revisionTime": "2018-08-28T23:03:05Z"
+		},
+		{
+			"checksumSHA1": "T8G3A63WALmJ3JT/A0r01LG4KI0=",
+			"path": "github.com/docker/distribution/registry/storage/cache/memory",
+			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
+			"revisionTime": "2018-08-28T23:03:05Z"
+		},
+		{
+			"checksumSHA1": "zcDmNPSzI1wVokOiHis5+JSg2Rk=",
+			"path": "github.com/docker/docker-credential-helpers/client",
+			"revision": "73e5f5dbfea31ee3b81111ebbf189785fa69731c",
+			"revisionTime": "2018-07-19T07:47:51Z"
+		},
+		{
+			"checksumSHA1": "4u6EMQqD1zIqOHp76zQFLVH5V8U=",
+			"path": "github.com/docker/docker-credential-helpers/credentials",
+			"revision": "73e5f5dbfea31ee3b81111ebbf189785fa69731c",
+			"revisionTime": "2018-07-19T07:47:51Z"
+		},
+		{
+			"checksumSHA1": "PM15F2b73fvtlDsjFyXSMd9LJqU=",
+			"path": "github.com/docker/docker/api/types",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "/jF0HVFiLzUUuywSjp4F/piM7BM=",
+			"path": "github.com/docker/docker/api/types/blkiodev",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "+jeShxohzdtOkwAzy9e0X/fq6n4=",
+			"path": "github.com/docker/docker/api/types/container",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "RMZg2+TAla7E2KiiyF5yupWn0lY=",
+			"path": "github.com/docker/docker/api/types/filters",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "9OClWW7OCikgz4QCS/sAVcvqcWk=",
+			"path": "github.com/docker/docker/api/types/mount",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "qZNE4g8YWfV6ryZp8kN9BwWYCeM=",
+			"path": "github.com/docker/docker/api/types/network",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "m4Jg5WnW75I65nvkEno8PElSXik=",
+			"path": "github.com/docker/docker/api/types/registry",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "OQEUS/2J2xVHpfvcsxcXzYqBSeY=",
+			"path": "github.com/docker/docker/api/types/strslice",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "NT/DoroAQOev6keoJO0zKQZmjbE=",
+			"path": "github.com/docker/docker/api/types/swarm",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "txs5EKTbKgVyKmKKSnaH3fr+odA=",
+			"path": "github.com/docker/docker/api/types/swarm/runtime",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "MZsgRjJJ0D/gAsXfKiEys+op6dE=",
+			"path": "github.com/docker/docker/api/types/versions",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "dF9WiXuwISBPd8bQfqpuoWtB3jk=",
+			"path": "github.com/docker/docker/errdefs",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "u6EOrZRfhdjr4up14b2JJ7MMMaY=",
+			"path": "github.com/docker/docker/opts",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "wZ8yvJiuW5sK2VmoEniu1yjVlBQ=",
+			"path": "github.com/docker/docker/pkg/archive",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "eMoRb/diYeuYLojU7ChN5DaETHc=",
+			"path": "github.com/docker/docker/pkg/fileutils",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "y37I+5AS96wQSiAxOayiMgnZawA=",
+			"path": "github.com/docker/docker/pkg/homedir",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "+Ir5nXNDvy3cwbTlBh06lR7zUrI=",
+			"path": "github.com/docker/docker/pkg/idtools",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "Ybq78CnAoQWVBk+lkh3zykmcSjs=",
+			"path": "github.com/docker/docker/pkg/ioutils",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "KQflv+x9hoJywgvxMwWcJqrmdkQ=",
+			"path": "github.com/docker/docker/pkg/jsonmessage",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "EXiIm2xIL7Ds+YsQUx8Z3eUYPtI=",
+			"path": "github.com/docker/docker/pkg/longpath",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "hx613GafM5hLibNt86ijinN89Ro=",
+			"path": "github.com/docker/docker/pkg/mount",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "dj8atalGWftfM9vdzCsh9YF1Seg=",
+			"path": "github.com/docker/docker/pkg/pools",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "w0waeTRJ1sFygI0dZXH6l9E1c60=",
+			"path": "github.com/docker/docker/pkg/stdcopy",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "gAUCA6R7F9kObegRGGNX5PzJahE=",
+			"path": "github.com/docker/docker/pkg/stringid",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "RreuHCnt9a8brZsc2Q4f5T8wd+E=",
+			"path": "github.com/docker/docker/pkg/system",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "I6mTgOFa7NeZpYw2S5342eenRLY=",
+			"path": "github.com/docker/docker/pkg/tarsum",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "GFsDxJkQz407/2nUBmWuafG+uF8=",
+			"path": "github.com/docker/docker/pkg/term",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "TeOtxuBbbZtp6wDK/t4DdaGGSC0=",
+			"path": "github.com/docker/docker/pkg/term/windows",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "0ZOQ9gYPwnxxjSIytDpwvsN5Rl0=",
+			"path": "github.com/docker/docker/registry",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "jH7uQnDehFQygPP3zLC/mLSqgOk=",
+			"path": "github.com/docker/docker/registry/resumable",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "Bs344j8rU7oCQyIcIhO9FJyk3ts=",
+			"path": "github.com/docker/docker/volume",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "J4wlScrHqr/jCIn82fgVF5mzO34=",
+			"path": "github.com/docker/docker/volume/mounts",
+			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
+			"revisionTime": "2018-11-29T15:58:16Z"
+		},
+		{
+			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",
+			"path": "github.com/docker/go-connections/nat",
+			"revision": "7da10c8c50cad14494ec818dcdfb6506265c0086",
+			"revisionTime": "2017-02-03T23:56:24Z"
+		},
+		{
+			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
+			"origin": "github.com/docker/docker/vendor/github.com/docker/go-connections/sockets",
+			"path": "github.com/docker/go-connections/sockets",
+			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
+			"revisionTime": "2018-08-16T08:14:46Z"
+		},
+		{
+			"checksumSHA1": "zUG/J7nb6PWxfSXOoET6NePfyc0=",
+			"origin": "github.com/docker/docker/vendor/github.com/docker/go-connections/tlsconfig",
+			"path": "github.com/docker/go-connections/tlsconfig",
+			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
+			"revisionTime": "2018-08-16T08:14:46Z"
+		},
+		{
+			"checksumSHA1": "kHVt4M5Pfby2dhurp+hZJfQhzVU=",
+			"path": "github.com/docker/go-metrics",
+			"revision": "399ea8c73916000c64c2c76e8da00ca82f8387ab",
+			"revisionTime": "2018-02-09T01:25:29Z"
+		},
+		{
+			"checksumSHA1": "18hmvak2Dc9x5cgKeZ2iApviT7w=",
+			"comment": "v0.1.0-23-g5d2041e",
+			"path": "github.com/docker/go-units",
+			"revision": "5d2041e26a699eaca682e2ea41c8f891e1060444"
+		},
+		{
+			"checksumSHA1": "vcP3kQNGWKHenrvQxfu4FZkB468=",
+			"origin": "github.com/docker/docker/vendor/github.com/docker/libnetwork/ipamutils",
+			"path": "github.com/docker/libnetwork/ipamutils",
+			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
+			"revisionTime": "2018-08-16T08:14:46Z"
+		},
+		{
+			"checksumSHA1": "xteP9Px90oMrg/HZuqvZkpXCR+s=",
+			"path": "github.com/dustin/go-humanize",
+			"revision": "8929fe90cee4b2cb9deb468b51fb34eba64d1bf0"
+		},
+		{
+			"checksumSHA1": "7DxViusFRJ7UPH0jZqYatwDrOkY=",
+			"path": "github.com/elazarl/go-bindata-assetfs",
+			"revision": "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43",
+			"revisionTime": "2017-02-27T21:27:28Z"
+		},
+		{
+			"checksumSHA1": "VsE3zx2d8kpwj97TWhYddzAwBrY=",
+			"path": "github.com/fatih/color",
+			"revision": "507f6050b8568533fb3f5504de8e5205fa62a114",
+			"revisionTime": "2018-02-13T13:34:03Z"
+		},
+		{
+			"checksumSHA1": "QBkOnLnM6zZ158NJSVLqoE4V6fI=",
+			"path": "github.com/fatih/structs",
+			"revision": "14f46232cd7bc732dc67313a9e4d3d210e082587",
+			"revisionTime": "2016-07-19T20:45:16Z"
+		},
+		{
+			"checksumSHA1": "fvbo1J+cFWDrPDs0Yudwv+POIb4=",
+			"path": "github.com/fsouza/go-dockerclient",
+			"revision": "01c3e9bd8551d675a60382c0303ef51f5849ea99",
+			"revisionTime": "2018-11-29T02:57:25Z"
+		},
+		{
+			"checksumSHA1": "YJ7WR4AVtD2ykYJr+1mTtazkma0=",
+			"path": "github.com/fsouza/go-dockerclient/internal/archive",
+			"revision": "01c3e9bd8551d675a60382c0303ef51f5849ea99",
+			"revisionTime": "2018-11-29T02:57:25Z"
+		},
+		{
+			"checksumSHA1": "lnUC8fZCqakWnfuMLUrZD2g+reY=",
+			"path": "github.com/fsouza/go-dockerclient/internal/jsonmessage",
+			"revision": "01c3e9bd8551d675a60382c0303ef51f5849ea99",
+			"revisionTime": "2018-11-29T02:57:25Z"
+		},
+		{
+			"checksumSHA1": "vdjeVhnepWyw3H4g9pVTVACDfV0=",
+			"path": "github.com/fsouza/go-dockerclient/internal/term",
+			"revision": "01c3e9bd8551d675a60382c0303ef51f5849ea99",
+			"revisionTime": "2018-11-29T02:57:25Z"
+		},
+		{
+			"checksumSHA1": "U4k9IYSBQcW5DW5QDc44n5dddxs=",
+			"comment": "v1.8.5-2-g6ec4abd",
+			"path": "github.com/go-ini/ini",
+			"revision": "6ec4abd8f8d587536da56f730858f0e27aeb4126"
+		},
+		{
+			"checksumSHA1": "IvHj/4iR2nYa/S3cB2GXoyDG/xQ=",
+			"comment": "v1.2.0-4-g5005588",
+			"path": "github.com/go-ole/go-ole",
+			"revision": "085abb85892dc1949567b726dff00fa226c60c45",
+			"revisionTime": "2017-07-12T17:44:59Z"
+		},
+		{
+			"checksumSHA1": "qLYVTQDhgrVIeZ2KI9eZV51mmug=",
+			"comment": "v1.2.0-4-g5005588",
+			"path": "github.com/go-ole/go-ole/oleutil",
+			"revision": "50055884d646dd9434f16bbb5c9801749b9bafe4"
+		},
+		{
+			"checksumSHA1": "bFplS7sPkJNtlKKCIszFQkAsmGI=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/godbus/dbus",
+			"path": "github.com/godbus/dbus",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "I460dM/HmGE9DWimQvd1hJkYosU=",
+			"path": "github.com/gogo/protobuf/proto",
+			"revision": "616a82ed12d78d24d4839363e8f3c5d3f20627cf",
+			"revisionTime": "2017-11-09T18:15:19Z"
+		},
+		{
+			"checksumSHA1": "Pyou8mceOASSFxc7GeXZuVdSMi0=",
+			"path": "github.com/golang/protobuf/proto",
+			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
+			"revisionTime": "2018-04-30T18:52:41Z",
+			"version": "v1",
+			"versionExact": "v1.1.0"
+		},
+		{
+			"checksumSHA1": "DA2cyOt1W92RTyXAqKQ4JWKGR8U=",
+			"path": "github.com/golang/protobuf/protoc-gen-go/descriptor",
+			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
+			"revisionTime": "2018-04-30T18:52:41Z",
+			"version": "v1.1.0",
+			"versionExact": "v1.1.0"
+		},
+		{
+			"checksumSHA1": "/s0InJhSrxhTpqw5FIKgSMknCfM=",
+			"path": "github.com/golang/protobuf/ptypes",
+			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
+			"revisionTime": "2018-04-30T18:52:41Z",
+			"version": "v1",
+			"versionExact": "v1.1.0"
+		},
+		{
+			"checksumSHA1": "3eqU9o+NMZSLM/coY5WDq7C1uKg=",
+			"path": "github.com/golang/protobuf/ptypes/any",
+			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
+			"revisionTime": "2018-04-30T18:52:41Z",
+			"version": "v1",
+			"versionExact": "v1.1.0"
+		},
+		{
+			"checksumSHA1": "ZIF0rnVzNLluFPqUebtJrVonMr4=",
+			"path": "github.com/golang/protobuf/ptypes/duration",
+			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
+			"revisionTime": "2018-04-30T18:52:41Z",
+			"version": "v1",
+			"versionExact": "v1.1.0"
+		},
+		{
+			"checksumSHA1": "7Az4Zl9T11I+xOfjgs/3/YMJ24I=",
+			"path": "github.com/golang/protobuf/ptypes/empty",
+			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
+			"revisionTime": "2018-04-30T18:52:41Z"
+		},
+		{
+			"checksumSHA1": "1FJvuT0UllZaaS43kmPlx8oNiCs=",
+			"path": "github.com/golang/protobuf/ptypes/timestamp",
+			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
+			"revisionTime": "2018-04-30T18:52:41Z",
+			"version": "v1",
+			"versionExact": "v1.1.0"
+		},
+		{
+			"checksumSHA1": "fs7UwFcU+SkJKA3eHcdhGsO4jrI=",
+			"path": "github.com/golang/protobuf/ptypes/wrappers",
+			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
+			"revisionTime": "2018-04-30T18:52:41Z",
+			"version": "v1.1.0",
+			"versionExact": "v1.1.0"
+		},
+		{
+			"checksumSHA1": "W+E/2xXcE1GmJ0Qb784ald0Fn6I=",
+			"path": "github.com/golang/snappy",
+			"revision": "d9eb7a3d35ec988b8585d4a0068e462c27d28380",
+			"revisionTime": "2016-05-29T05:00:41Z"
+		},
+		{
+			"checksumSHA1": "cervgtZmEhshueHN64+ILdFHmEE=",
+			"path": "github.com/google/btree",
+			"revision": "4030bb1f1f0c35b30ca7009e9ebd06849dd45306",
+			"revisionTime": "2018-08-13T15:31:12Z"
+		},
+		{
+			"checksumSHA1": "+suAHHPBmbdZf/HusugaL4/H+NE=",
+			"path": "github.com/google/go-cmp/cmp",
+			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
+			"revisionTime": "2017-09-01T21:42:48Z"
+		},
+		{
+			"checksumSHA1": "VmBLfV9TChrjNu8Z96wZkYie1aI=",
+			"path": "github.com/google/go-cmp/cmp/cmpopts",
+			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
+			"revisionTime": "2017-09-01T21:42:48Z"
+		},
+		{
+			"checksumSHA1": "eTwchtMX+RMJUvle2wt295P2h10=",
+			"path": "github.com/google/go-cmp/cmp/internal/diff",
+			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
+			"revisionTime": "2017-09-01T21:42:48Z"
+		},
+		{
+			"checksumSHA1": "kYtvRhMjM0X4bvEjR3pqEHLw1qo=",
+			"path": "github.com/google/go-cmp/cmp/internal/function",
+			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
+			"revisionTime": "2017-09-01T21:42:48Z"
+		},
+		{
+			"checksumSHA1": "f+mgZLvc4VITtMmBv0bmew4rL2Y=",
+			"path": "github.com/google/go-cmp/cmp/internal/value",
+			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
+			"revisionTime": "2017-09-01T21:42:48Z"
+		},
+		{
+			"checksumSHA1": "WZoHSeTnVjnPIX2+U1Otst5MUKw=",
+			"path": "github.com/googleapis/gax-go/v2",
+			"revision": "bd5b16380fd03dc758d11cef74ba2e3bc8b0e8c2",
+			"revisionTime": "2019-05-13T18:38:25Z"
+		},
+		{
+			"checksumSHA1": "m8B3L3qJ3tFfP6BI9pIFr9oal3w=",
+			"comment": "1.0.0",
+			"origin": "github.com/dadgar/cronexpr",
+			"path": "github.com/gorhill/cronexpr",
+			"revision": "675cac9b2d182dccb5ba8d5f8a0d5988df8a4394",
+			"revisionTime": "2017-09-15T18:30:32Z"
+		},
+		{
+			"checksumSHA1": "Nd/7mZb0T6Gj6+AymyOPsNCQSJs=",
+			"comment": "1.0.0",
+			"path": "github.com/gorhill/cronexpr/cronexpr",
+			"revision": "a557574d6c024ed6e36acc8b610f5f211c91568a"
+		},
+		{
+			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
+			"path": "github.com/gorilla/context",
+			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
+			"revisionTime": "2016-08-17T18:46:32Z"
+		},
+		{
+			"checksumSHA1": "STQSdSj2FcpCf0NLfdsKhNutQT0=",
+			"path": "github.com/gorilla/mux",
+			"revision": "e48e440e4c92e3251d812f8ce7858944dfa3331c",
+			"revisionTime": "2018-08-07T07:52:56Z"
+		},
+		{
+			"checksumSHA1": "gr0edNJuVv4+olNNZl5ZmwLgscA=",
+			"path": "github.com/gorilla/websocket",
+			"revision": "0ec3d1bd7fe50c503d6df98ee649d81f4857c564",
+			"revisionTime": "2019-03-06T00:42:57Z"
+		},
+		{
+			"checksumSHA1": "237KekVBW1eZohSDylZzT+/0NQI=",
+			"path": "github.com/hashicorp/consul-template",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "AhDPiKa7wzh3SE6Gx0WrsDYwBHg=",
+			"path": "github.com/hashicorp/consul-template/child",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "hjsBe5Qnn0DCttJkSNjy9mreW5Q=",
+			"path": "github.com/hashicorp/consul-template/config",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "S2ktxYTJRgmUE1GC5Bv+ZAmYWgE=",
+			"path": "github.com/hashicorp/consul-template/dependency",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "o5N7SV389Ej+3b1iRNmz1dx5e1M=",
+			"path": "github.com/hashicorp/consul-template/logging",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "Ozv8RPN8d//DoFpwR2mQ/xMWhcs=",
+			"path": "github.com/hashicorp/consul-template/manager",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "DUHtghMoLyrgPhv4lexVniBuWYk=",
+			"path": "github.com/hashicorp/consul-template/renderer",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "YSEUV/9/k85XciRKu0cngxdjZLE=",
+			"path": "github.com/hashicorp/consul-template/signals",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "mmM6LpEgkbLjobfgabon11mz40M=",
+			"path": "github.com/hashicorp/consul-template/template",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "eWyAvppME/4vsmaazcrf3oEbzGo=",
+			"path": "github.com/hashicorp/consul-template/version",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "cJxopvJKg7DBBb8tnDsfmBp5Q8I=",
+			"path": "github.com/hashicorp/consul-template/watch",
+			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
+			"revisionTime": "2019-08-12T18:34:47Z"
+		},
+		{
+			"checksumSHA1": "+I7fgoQlrnTUGW5krqNLadWwtjg=",
+			"path": "github.com/hashicorp/consul/agent/consul/autopilot",
+			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
+			"revisionTime": "2018-04-13T17:05:42Z"
+		},
+		{
+			"checksumSHA1": "7JPBtnIgLkdcJ0ldXMTEnVjNEjA=",
+			"path": "github.com/hashicorp/consul/api",
+			"revision": "40cec98468b829e5cdaacb0629b3e23a028db688",
+			"revisionTime": "2019-05-22T20:19:12Z"
+		},
+		{
+			"checksumSHA1": "soNN4xaHTbeXFgNkZ7cX0gbFXQk=",
+			"path": "github.com/hashicorp/consul/command/flags",
+			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
+			"revisionTime": "2018-04-13T17:05:42Z"
+		},
+		{
+			"checksumSHA1": "Nrh9BhiivRyJiuPzttstmq9xl/w=",
+			"path": "github.com/hashicorp/consul/lib",
+			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
+			"revisionTime": "2018-04-13T17:05:42Z"
+		},
+		{
+			"checksumSHA1": "E28E4zR1FN2v1Xiq4FUER7KVN9M=",
+			"path": "github.com/hashicorp/consul/lib/freeport",
+			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
+			"revisionTime": "2018-04-13T17:05:42Z"
+		},
+		{
+			"checksumSHA1": "5XjgqE4UIfwXvkq5VssGNc7uPhQ=",
+			"path": "github.com/hashicorp/consul/test/porter",
+			"revision": "ad9425ca6353b8afcfebd19130a8cf768f7eac30",
+			"revisionTime": "2017-10-21T00:05:25Z"
+		},
+		{
+			"checksumSHA1": "T4CeQD+QRsjf1BJ1n7FSojS5zDQ=",
+			"path": "github.com/hashicorp/consul/testutil",
+			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
+			"revisionTime": "2018-04-13T17:05:42Z"
+		},
+		{
+			"checksumSHA1": "SCb2b91UYiB/23+SNDBlU5OZfFA=",
+			"path": "github.com/hashicorp/consul/testutil/retry",
+			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
+			"revisionTime": "2018-04-13T17:05:42Z"
+		},
+		{
+			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",
+			"path": "github.com/hashicorp/errwrap",
+			"revision": "7554cd9344cec97297fa6649b055a8c98c2a1e55"
+		},
+		{
+			"checksumSHA1": "D267IUMW2rcb+vNe3QU+xhfSrgY=",
+			"path": "github.com/hashicorp/go-checkpoint",
+			"revision": "1545e56e46dec3bba264e41fde2c1e2aa65b5dd4",
+			"revisionTime": "2017-10-09T17:35:28Z"
+		},
+		{
+			"checksumSHA1": "6ihdHMkDfFx/rJ1A36com2F6bQk=",
+			"path": "github.com/hashicorp/go-cleanhttp",
+			"revision": "a45970658e51fea2c41445ff0f7e07106d007617",
+			"revisionTime": "2017-02-11T00:33:01Z"
+		},
+		{
+			"checksumSHA1": "CnY2iYK47tGA9wsFMfH04PpmSoI=",
+			"path": "github.com/hashicorp/go-discover",
+			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
+			"revisionTime": "2018-05-03T15:30:45Z"
+		},
+		{
+			"checksumSHA1": "ZmU/47XUGUQpFP6E8T6Tl8QKszI=",
+			"path": "github.com/hashicorp/go-discover/provider/aliyun",
+			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
+			"revisionTime": "2018-05-03T15:30:45Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "Vit45xRjrJ6h7IGJndrBjodVUAE=",
+			"path": "github.com/hashicorp/go-discover/provider/aws",
+			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
+			"revisionTime": "2018-05-03T15:30:45Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "dMU80T10KQFZNqpBBjzf7ymFNBw=",
+			"path": "github.com/hashicorp/go-discover/provider/azure",
+			"revision": "266744fed5f15e5d4488269b2c29b66e25783f6f",
+			"revisionTime": "2018-05-21T21:57:50Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "qoy/euk2dwrONYMUsaAPznHHpxQ=",
+			"path": "github.com/hashicorp/go-discover/provider/digitalocean",
+			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
+			"revisionTime": "2018-05-03T15:30:45Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "tnKls5vtzpNQAj7b987N4i81HvY=",
+			"path": "github.com/hashicorp/go-discover/provider/gce",
+			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
+			"revisionTime": "2018-05-03T15:30:45Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "LZwn9B00AjulYRCKapmJWFAamoo=",
+			"path": "github.com/hashicorp/go-discover/provider/os",
+			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
+			"revisionTime": "2018-05-03T15:30:45Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "GQ/3AvzdX6T0rtEFeGNYhwt17Zs=",
+			"path": "github.com/hashicorp/go-discover/provider/scaleway",
+			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
+			"revisionTime": "2018-05-03T15:30:45Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "SIyZ44AHIUTBfI336ACpCeybsLg=",
+			"path": "github.com/hashicorp/go-discover/provider/softlayer",
+			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
+			"revisionTime": "2018-05-03T15:30:45Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "n2iQu2IbTPw2XpWF2CqBrFSMjwI=",
+			"path": "github.com/hashicorp/go-discover/provider/triton",
+			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
+			"revisionTime": "2018-05-03T15:30:45Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "FKmqR4DC3nCXtnT9pe02z5CLNWo=",
+			"path": "github.com/hashicorp/go-envparse",
+			"revision": "310ca1881b22af3522e3a8638c0b426629886196",
+			"revisionTime": "2018-01-19T21:58:41Z"
+		},
+		{
+			"checksumSHA1": "d4brua17AGQqMNtngK4xKOUwboY=",
+			"path": "github.com/hashicorp/go-getter",
+			"revision": "f5101da0117392c6e7960c934f05a2fd689a5b5f",
+			"revisionTime": "2019-08-22T19:45:07Z"
+		},
+		{
+			"checksumSHA1": "9J+kDr29yDrwsdu2ULzewmqGjpA=",
+			"path": "github.com/hashicorp/go-getter/helper/url",
+			"revision": "b345bfcec894fb7ff3fdf9b21baf2f56ea423d98",
+			"revisionTime": "2018-04-10T17:49:45Z"
+		},
+		{
+			"checksumSHA1": "dOP7kCX3dACHc9mU79826N411QA=",
+			"path": "github.com/hashicorp/go-hclog",
+			"revision": "ff2cf002a8dd750586d91dddd4470c341f981fe1",
+			"revisionTime": "2018-07-09T16:53:50Z"
+		},
+		{
+			"checksumSHA1": "Cas2nprG6pWzf05A2F/OlnjUu2Y=",
+			"path": "github.com/hashicorp/go-immutable-radix",
+			"revision": "8aac2701530899b64bdea735a1de8da899815220",
+			"revisionTime": "2017-07-25T22:12:15Z"
+		},
+		{
+			"checksumSHA1": "FMAvwDar2bQyYAW4XMFhAt0J5xA=",
+			"path": "github.com/hashicorp/go-memdb",
+			"revision": "20ff6434c1cc49b80963d45bf5c6aa89c78d8d57",
+			"revisionTime": "2017-08-31T20:15:40Z"
+		},
+		{
+			"checksumSHA1": "LrGV93iKiRWNSxItKr6Os6zC1T8=",
+			"origin": "github.com/ugorji/go/codec",
+			"path": "github.com/hashicorp/go-msgpack/codec",
+			"revision": "08f7b401aef15f3d544472dd46bf6788cdfe55bf",
+			"revisionTime": "2019-05-07T20:14:01Z"
+		},
+		{
+			"checksumSHA1": "lrSl49G23l6NhfilxPM0XFs5rZo=",
+			"path": "github.com/hashicorp/go-multierror",
+			"revision": "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
+		},
+		{
+			"checksumSHA1": "IFwYSAmxxM+fV0w9LwdWKqFOCgg=",
+			"path": "github.com/hashicorp/go-plugin",
+			"revision": "f444068e8f5a19853177f7aa0aea7e7d95b5b528",
+			"revisionTime": "2018-12-12T15:08:38Z"
+		},
+		{
+			"checksumSHA1": "Ikbb1FngsPR79bHhr2UmKk4CblI=",
+			"path": "github.com/hashicorp/go-plugin/internal/proto",
+			"revision": "f444068e8f5a19853177f7aa0aea7e7d95b5b528",
+			"revisionTime": "2018-12-12T15:08:38Z"
+		},
+		{
+			"checksumSHA1": "9SqwC2BzFbsWulQuBG2+QEliTpo=",
+			"path": "github.com/hashicorp/go-retryablehttp",
+			"revision": "73489d0a1476f0c9e6fb03f9c39241523a496dfd",
+			"revisionTime": "2019-01-26T20:33:39Z"
+		},
+		{
+			"checksumSHA1": "A1PcINvF3UiwHRKn8UcgARgvGRs=",
+			"path": "github.com/hashicorp/go-rootcerts",
+			"revision": "6bb64b370b90e7ef1fa532be9e591a81c3493e00",
+			"revisionTime": "2016-05-03T14:34:40Z"
+		},
+		{
+			"checksumSHA1": "CduvzBFfTv77nhjtXPGdIjQQLMI=",
+			"path": "github.com/hashicorp/go-safetemp",
+			"revision": "b1a1dbde6fdc11e3ae79efd9039009e22d4ae240",
+			"revisionTime": "2018-03-26T21:11:50Z"
+		},
+		{
+			"checksumSHA1": "J47ySO1q0gcnmoMnir1q1loKzCk=",
+			"path": "github.com/hashicorp/go-sockaddr",
+			"revision": "6d291a969b86c4b633730bfc6b8b9d64c3aafed9",
+			"revisionTime": "2018-03-20T11:50:54Z"
+		},
+		{
+			"checksumSHA1": "PDp9DVLvf3KWxhs4G4DpIwauMSU=",
+			"path": "github.com/hashicorp/go-sockaddr/template",
+			"revision": "6d291a969b86c4b633730bfc6b8b9d64c3aafed9",
+			"revisionTime": "2018-03-20T11:50:54Z"
+		},
+		{
+			"checksumSHA1": "eEqQGKsFOdSAwEprYgYnL7+J2e0=",
+			"path": "github.com/hashicorp/go-syslog",
+			"revision": "8d1874e3e8d1862b74e0536851e218c4571066a5",
+			"revisionTime": "2019-01-18T15:19:36Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "5AxXPtBqAKyFGcttFzxT5hp/3Tk=",
+			"path": "github.com/hashicorp/go-uuid",
+			"revision": "4f571afc59f3043a65f8fe6bf46d887b10a01d43",
+			"revisionTime": "2018-11-28T13:14:45Z"
+		},
+		{
+			"checksumSHA1": "r0pj5dMHCghpaQZ3f1BRGoKiSWw=",
+			"path": "github.com/hashicorp/go-version",
+			"revision": "b5a281d3160aa11950a6182bd9a9dc2cb1e02d50",
+			"revisionTime": "2018-08-24T00:43:55Z"
+		},
+		{
+			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
+			"path": "github.com/hashicorp/golang-lru",
+			"revision": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4",
+			"revisionTime": "2016-02-07T21:47:19Z"
+		},
+		{
+			"checksumSHA1": "2nOpYjx8Sn57bqlZq17yM4YJuM4=",
+			"path": "github.com/hashicorp/golang-lru/simplelru",
+			"revision": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
+			"checksumSHA1": "vgGv8zuy7q8c5LBAFO1fnnQRRgE=",
+			"path": "github.com/hashicorp/hcl",
+			"revision": "1804807358d86424faacbb42f50f0c04303cef11",
+			"revisionTime": "2019-06-10T16:16:27Z"
+		},
+		{
+			"checksumSHA1": "XQmjDva9JCGGkIecOgwtBEMCJhU=",
+			"path": "github.com/hashicorp/hcl/hcl/ast",
+			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
+			"revisionTime": "2016-11-01T18:00:25Z"
+		},
+		{
+			"checksumSHA1": "croNloscHsjX87X+4/cKOURf1EY=",
+			"path": "github.com/hashicorp/hcl/hcl/parser",
+			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
+			"revisionTime": "2016-11-01T18:00:25Z"
+		},
+		{
+			"checksumSHA1": "lgR7PSAZ0RtvAc9OCtCnNsF/x8g=",
+			"path": "github.com/hashicorp/hcl/hcl/scanner",
+			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
+			"revisionTime": "2016-11-01T18:00:25Z"
+		},
+		{
+			"checksumSHA1": "JlZmnzqdmFFyb1+2afLyR3BOE/8=",
+			"path": "github.com/hashicorp/hcl/hcl/strconv",
+			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
+			"revisionTime": "2016-11-01T18:00:25Z"
+		},
+		{
+			"checksumSHA1": "c6yprzj06ASwCo18TtbbNNBHljA=",
+			"path": "github.com/hashicorp/hcl/hcl/token",
+			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
+			"revisionTime": "2016-11-01T18:00:25Z"
+		},
+		{
+			"checksumSHA1": "138aCV5n8n7tkGYMsMVQQnnLq+0=",
+			"path": "github.com/hashicorp/hcl/json/parser",
+			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
+			"revisionTime": "2016-11-01T18:00:25Z"
+		},
+		{
+			"checksumSHA1": "YdvFsNOMSWMLnY6fcliWQa0O5Fw=",
+			"path": "github.com/hashicorp/hcl/json/scanner",
+			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
+			"revisionTime": "2016-11-01T18:00:25Z"
+		},
+		{
+			"checksumSHA1": "fNlXQCQEnb+B3k5UDL/r15xtSJY=",
+			"path": "github.com/hashicorp/hcl/json/token",
+			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
+			"revisionTime": "2016-11-01T18:00:25Z"
+		},
+		{
+			"checksumSHA1": "RFEjfMQWPAVILXE2PhL6wDW8Zg4=",
+			"path": "github.com/hashicorp/hcl2/gohcl",
+			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
+			"revisionTime": "2019-06-17T16:00:22Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "1jDEGh+P7Cu8Lz39VudY6rRS6Jw=",
+			"path": "github.com/hashicorp/hcl2/hcl",
+			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
+			"revisionTime": "2019-06-17T16:00:22Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "6FZRBZj+je9sMM5wrhM5phUXxZU=",
+			"path": "github.com/hashicorp/hcl2/hcl/hclsyntax",
+			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
+			"revisionTime": "2019-06-17T16:00:22Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "l5KBeDDM1gf7yFth7WGhckpF+oc=",
+			"path": "github.com/hashicorp/hcl2/hcl/json",
+			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
+			"revisionTime": "2019-06-17T16:00:22Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "6JRj4T/iQxIe/CoKXHDjPuupmL8=",
+			"path": "github.com/hashicorp/hcl2/hcldec",
+			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
+			"revisionTime": "2019-06-17T16:00:22Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "Hgs10IsC8LdotUKLavgOL35Mbw4=",
+			"path": "github.com/hashicorp/hcl2/hclwrite",
+			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
+			"revisionTime": "2019-06-17T16:00:22Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "vt+P9D2yWDO3gdvdgCzwqunlhxU=",
+			"path": "github.com/hashicorp/logutils",
+			"revision": "0dc08b1671f34c4250ce212759ebd880f743d883"
+		},
+		{
+			"checksumSHA1": "yAu2gPVXIh28yJ2If5gZPrf04kU=",
+			"path": "github.com/hashicorp/memberlist",
+			"revision": "1a62499c21db33d57691001d5e08a71ec857b18f",
+			"revisionTime": "2019-01-03T22:22:36Z"
+		},
+		{
+			"checksumSHA1": "qnlqWJYV81ENr61SZk9c65R1mDo=",
+			"path": "github.com/hashicorp/net-rpc-msgpackrpc",
+			"revision": "a14192a58a694c123d8fe5481d4a4727d6ae82f3"
+		},
+		{
+			"checksumSHA1": "ujL3Sc5iqc28/En2ndmc2R7oUQM=",
+			"path": "github.com/hashicorp/raft",
+			"revision": "9c733b2b7f53115c5ef261a90ce912a1bb49e970",
+			"revisionTime": "2019-01-04T13:37:20Z"
+		},
+		{
+			"checksumSHA1": "QAxukkv54/iIvLfsUP6IK4R0m/A=",
+			"path": "github.com/hashicorp/raft-boltdb",
+			"revision": "d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee",
+			"revisionTime": "2015-02-01T20:08:39Z"
+		},
+		{
+			"checksumSHA1": "9omt7lEuhBNSdgT32ThEzXn/aTU=",
+			"path": "github.com/hashicorp/serf",
+			"revision": "c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2",
+			"revisionTime": "2019-01-04T15:39:47Z"
+		},
+		{
+			"checksumSHA1": "0PeWsO2aI+2PgVYlYlDPKfzCLEQ=",
+			"path": "github.com/hashicorp/serf/coordinate",
+			"revision": "c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2",
+			"revisionTime": "2019-01-04T15:39:47Z"
+		},
+		{
+			"checksumSHA1": "siLn7zwVHQk070rpd99BTktGfTs=",
+			"path": "github.com/hashicorp/serf/serf",
+			"revision": "c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2",
+			"revisionTime": "2019-01-04T15:39:47Z"
+		},
+		{
+			"checksumSHA1": "laYVVZeqao4WdIS/MKd0be7Z3yA=",
+			"path": "github.com/hashicorp/vault/api",
+			"revision": "85909e3373aa743c34a6a0ab59131f61fd9e8e43",
+			"revisionTime": "2019-02-12T14:05:52Z"
+		},
+		{
+			"checksumSHA1": "bSdPFOHaTwEvM4PIvn0PZfn75jM=",
+			"path": "github.com/hashicorp/vault/helper/compressutil",
+			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
+			"revisionTime": "2018-09-06T17:45:45Z"
+		},
+		{
+			"checksumSHA1": "3mRK/pBPUH8rIPrILmuJWynWQVo=",
+			"path": "github.com/hashicorp/vault/helper/consts",
+			"revision": "85909e3373aa743c34a6a0ab59131f61fd9e8e43",
+			"revisionTime": "2019-02-12T14:05:52Z"
+		},
+		{
+			"checksumSHA1": "RlqPBLOexQ0jj6jomhiompWKaUg=",
+			"path": "github.com/hashicorp/vault/helper/hclutil",
+			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
+			"revisionTime": "2018-09-06T17:45:45Z"
+		},
+		{
+			"checksumSHA1": "POgkM3GrjRFw6H3sw95YNEs552A=",
+			"path": "github.com/hashicorp/vault/helper/jsonutil",
+			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
+			"revisionTime": "2018-09-06T17:45:45Z"
+		},
+		{
+			"checksumSHA1": "HA2MV/2XI0HcoThSRxQCaBZR2ps=",
+			"path": "github.com/hashicorp/vault/helper/parseutil",
+			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
+			"revisionTime": "2018-09-06T17:45:45Z"
+		},
+		{
+			"checksumSHA1": "HdVuYhZ5TuxeIFqi0jy2GHW7a4o=",
+			"path": "github.com/hashicorp/vault/helper/strutil",
+			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
+			"revisionTime": "2018-09-06T17:45:45Z"
+		},
+		{
+			"checksumSHA1": "m9OKUPd/iliwKxs+LCSmAGpDJOs=",
+			"path": "github.com/hashicorp/yamux",
+			"revision": "7221087c3d281fda5f794e28c2ea4c6e4d5c4558",
+			"revisionTime": "2018-09-17T20:50:41Z"
+		},
+		{
+			"checksumSHA1": "0xM336Lb25URO/1W1/CtGoRygVU=",
+			"path": "github.com/hpcloud/tail/util",
+			"revision": "37f4271387456dd1bf82ab1ad9229f060cc45386",
+			"revisionTime": "2017-08-14T16:06:53Z"
+		},
+		{
+			"checksumSHA1": "TP4OAv5JMtzj2TB6OQBKqauaKDc=",
+			"path": "github.com/hpcloud/tail/watch",
+			"revision": "37f4271387456dd1bf82ab1ad9229f060cc45386",
+			"revisionTime": "2017-08-14T16:06:53Z"
+		},
+		{
+			"checksumSHA1": "3/Bhy+ua/DCv2ElMD5GzOYSGN6g=",
+			"comment": "0.2.2-2-gc01cf91",
+			"path": "github.com/jmespath/go-jmespath",
+			"revision": "c01cf91b011868172fdcd9f41838e80c9d716264"
+		},
+		{
+			"checksumSHA1": "Aulh7C5SVOA4Jzt5eHNH6197Mbk=",
+			"path": "github.com/konsorten/go-windows-terminal-sequences",
+			"revision": "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e",
+			"revisionTime": "2019-02-26T22:47:05Z"
+		},
+		{
+			"checksumSHA1": "eOXF2PEvYLMeD8DSzLZJWbjYzco=",
+			"path": "github.com/kr/pretty",
+			"revision": "cfb55aafdaf3ec08f0db22699ab822c50091b1c4",
+			"revisionTime": "2016-08-23T17:07:15Z"
+		},
+		{
+			"checksumSHA1": "WD7GMln/NoduJr0DbumjOE59xI8=",
+			"path": "github.com/kr/pty",
+			"revision": "b6e1bdd4a4f88614e0c6e5e8089c7abed98aae17",
+			"revisionTime": "2019-04-01T03:15:51Z"
+		},
+		{
+			"checksumSHA1": "uulQHQ7IsRKqDudBC8Go9J0gtAc=",
+			"path": "github.com/kr/text",
+			"revision": "7cafcd837844e784b526369c9bce262804aebc60",
+			"revisionTime": "2016-05-04T02:26:26Z"
+		},
+		{
+			"checksumSHA1": "SEnjvwVyfuU2xBaOfXfwPD5MZqk=",
+			"path": "github.com/mattn/go-colorable",
+			"revision": "efa589957cd060542a26d2dd7832fd6a6c6c3ade",
+			"revisionTime": "2018-03-10T13:32:14Z"
+		},
+		{
+			"checksumSHA1": "AZO2VGorXTMDiSVUih3k73vORHY=",
+			"path": "github.com/mattn/go-isatty",
+			"revision": "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c",
+			"revisionTime": "2017-11-07T05:05:31Z"
+		},
+		{
+			"checksumSHA1": "ajImwVZHzsI+aNwsgzCSFSbmJqs=",
+			"path": "github.com/mattn/go-shellwords",
+			"revision": "f4e566c536cf69158e808ec28ef4182a37fdc981",
+			"revisionTime": "2015-03-21T17:42:21Z"
+		},
+		{
+			"checksumSHA1": "bKMZjd2wPw13VwoE7mBeSv5djFA=",
+			"path": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+			"revision": "c12348ce28de40eed0136aa2b644d0ee0650e56c",
+			"revisionTime": "2016-04-24T11:30:07Z"
+		},
+		{
+			"checksumSHA1": "7C76urB5PLSeqMeydxiUGjX5xMI=",
+			"path": "github.com/miekg/dns",
+			"revision": "7e024ce8ce18b21b475ac6baf8fa3c42536bf2fa"
+		},
+		{
+			"checksumSHA1": "+o0siVvR8q36mKCpT5F/Sn2T7xo=",
+			"path": "github.com/mitchellh/cli",
+			"revision": "c54c85e9bd492bdba226ffdda55d4e293b79f8e8",
+			"revisionTime": "2018-04-06T01:10:36Z"
+		},
+		{
+			"checksumSHA1": "ttEN1Aupb7xpPMkQLqb3tzLFdXs=",
+			"path": "github.com/mitchellh/colorstring",
+			"revision": "8631ce90f28644f54aeedcb3e389a85174e067d1",
+			"revisionTime": "2015-09-17T21:48:07Z"
+		},
+		{
+			"checksumSHA1": "+p4JY4wmFQAppCdlrJ8Kxybmht8=",
+			"path": "github.com/mitchellh/copystructure",
+			"revision": "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f",
+			"revisionTime": "2017-05-25T01:39:02Z"
+		},
+		{
+			"checksumSHA1": "AXacfEchaUqT5RGmPmMXsOWRhv8=",
+			"path": "github.com/mitchellh/go-homedir",
+			"revision": "756f7b183b7ab78acdbbee5c7f392838ed459dda",
+			"revisionTime": "2016-06-21T17:42:43Z"
+		},
+		{
+			"checksumSHA1": "DcYIZnMiq/Tj22/ge9os3NwOhs4=",
+			"path": "github.com/mitchellh/go-ps",
+			"revision": "4fdf99ab29366514c69ccccddab5dc58b8d84062",
+			"revisionTime": "2017-03-09T13:30:38Z"
+		},
+		{
+			"checksumSHA1": "bDdhmDk8q6utWrccBhEOa6IoGkE=",
+			"path": "github.com/mitchellh/go-testing-interface",
+			"revision": "a61a99592b77c9ba629d254a693acffaeb4b7e28",
+			"revisionTime": "2017-10-04T22:19:16Z"
+		},
+		{
+			"checksumSHA1": "L3leymg2RT8hFl5uL+5KP/LpBkg=",
+			"path": "github.com/mitchellh/go-wordwrap",
+			"revision": "ad45545899c7b13c020ea92b2072220eefad42b8",
+			"revisionTime": "2015-03-14T17:03:34Z"
+		},
+		{
+			"checksumSHA1": "Z3FoiV93oUfDoQYMMiHxWCQPlBw=",
+			"path": "github.com/mitchellh/hashstructure",
+			"revision": "1ef5c71b025aef149d12346356ac5973992860bc"
+		},
+		{
+			"checksumSHA1": "4Js6Jlu93Wa0o6Kjt393L9Z7diE=",
+			"path": "github.com/mitchellh/mapstructure",
+			"revision": "281073eb9eb092240d33ef253c404f1cca550309"
+		},
+		{
+			"checksumSHA1": "KqsMqI+Y+3EFYPhyzafpIneaVCM=",
+			"path": "github.com/mitchellh/reflectwalk",
+			"revision": "8d802ff4ae93611b807597f639c19f76074df5c6",
+			"revisionTime": "2017-05-08T17:38:06Z"
+		},
+		{
+			"checksumSHA1": "FoDTHct8ocl470GYc0i+JRWfrys=",
+			"path": "github.com/moby/moby/daemon/caps",
+			"revision": "39377bb96d459d2ef59bd2bad75468638a7f86a3",
+			"revisionTime": "2018-01-18T19:02:33Z"
+		},
+		{
+			"checksumSHA1": "EKGlMEHq/nwBXQGi9JN/y+H7YMU=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/mrunalp/fileutils",
+			"path": "github.com/mrunalp/fileutils",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "nf3UoPNBIut7BL9nWE8Fw2X2j+Q=",
+			"path": "github.com/oklog/run",
+			"revision": "6934b124db28979da51d3470dadfa34d73d72652",
+			"revisionTime": "2018-03-08T00:51:04Z"
+		},
+		{
+			"checksumSHA1": "cwbidLG1ET7YSqlwca+nSfYxIbg=",
+			"path": "github.com/onsi/ginkgo",
+			"revision": "ba8e856bb854d6771a72ddf6497a42dad3a0c971",
+			"revisionTime": "2018-03-12T10:34:14Z"
+		},
+		{
+			"checksumSHA1": "Tarhbqac6rFsGPugPoQ4lyhfc7Q=",
+			"path": "github.com/onsi/ginkgo/config",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "euz7sKjXGezoMq6P5qC/day/mZo=",
+			"path": "github.com/onsi/ginkgo/ginkgo",
+			"revision": "ba8e856bb854d6771a72ddf6497a42dad3a0c971",
+			"revisionTime": "2018-03-12T10:34:14Z"
+		},
+		{
+			"checksumSHA1": "RX2QA4mqBzsogy4OWOCi9mUfAGU=",
+			"path": "github.com/onsi/ginkgo/ginkgo/convert",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "jvjomLV3JcWQ1qa1ZfmvB4/62YI=",
+			"path": "github.com/onsi/ginkgo/ginkgo/interrupthandler",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "brZ63GMMr79P/RwClxFRBKMtICg=",
+			"path": "github.com/onsi/ginkgo/ginkgo/nodot",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "qSXx1svgCAAqk+ICAWL1AXdSJmA=",
+			"path": "github.com/onsi/ginkgo/ginkgo/testrunner",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "x2Fa0rbgpXQaVc6f10KTRchiF7E=",
+			"path": "github.com/onsi/ginkgo/ginkgo/testsuite",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "yT4efdDV3bfosM49kBvQg3PjcMA=",
+			"path": "github.com/onsi/ginkgo/ginkgo/watch",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "T1cZh3UWr4Hnx6fQYp+7KDNvxG4=",
+			"path": "github.com/onsi/ginkgo/internal/codelocation",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "qvz6/+otRkWa1OHaPMKap9D5Ge4=",
+			"path": "github.com/onsi/ginkgo/internal/containernode",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "882oWW4FC4Nrd8mrMptsDJSTDds=",
+			"path": "github.com/onsi/ginkgo/internal/failer",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "IbQFETl8AqMhJ74XP+us5Xk3dS8=",
+			"path": "github.com/onsi/ginkgo/internal/leafnodes",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "Z9mfsBI9VL7QqwY+doKRhumHIh4=",
+			"path": "github.com/onsi/ginkgo/internal/remote",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "msseWG4Ewk2/V35NKaRokjXPCQs=",
+			"path": "github.com/onsi/ginkgo/internal/spec",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "14UQiFkhUmN5vTG+pNApv5OYgoU=",
+			"path": "github.com/onsi/ginkgo/internal/spec_iterator",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "pDxDXIJ3QPm5UMnzQ+3GedK8WjQ=",
+			"path": "github.com/onsi/ginkgo/internal/specrunner",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "QZ9ekcsrGBcXz4Tv+L7kXAUfqq8=",
+			"path": "github.com/onsi/ginkgo/internal/suite",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "TUBH2aNaARtAZ5vz51xMFRsOOo0=",
+			"path": "github.com/onsi/ginkgo/internal/testingtproxy",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "BB83CfNg6jFoFNMuXFL+f4EOFpw=",
+			"path": "github.com/onsi/ginkgo/internal/writer",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "m6/gIgdQGdETzUN3JWhAmFNIuNI=",
+			"path": "github.com/onsi/ginkgo/reporters",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "hdfc3dPx9Jw8v+sd7TEDlboJ1Nc=",
+			"path": "github.com/onsi/ginkgo/reporters/stenographer",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "QeB8m9WhRUiL0YKj3n5L0t4mLCg=",
+			"path": "github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "4Vn7/7UJmbclxDrV8YKbYOUh65g=",
+			"path": "github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "kuzrRJpxmnbuG7VVDIfDcLIRKLU=",
+			"path": "github.com/onsi/ginkgo/types",
+			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
+			"revisionTime": "2018-02-16T17:00:43Z"
+		},
+		{
+			"checksumSHA1": "WQwGlRQksUlZ4HMiYZWR4wE4Suo=",
+			"path": "github.com/onsi/gomega",
+			"revision": "de89e61d40b75aa971a9fc3eae7f4fefabd6e0ee",
+			"revisionTime": "2018-03-05T20:37:22Z"
+		},
+		{
+			"checksumSHA1": "W/l0TJN86WNCAZPm1MPSlqxxWYM=",
+			"path": "github.com/onsi/gomega/format",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "H4RBR9kcEWh2lECAzBaOTSvgUuA=",
+			"path": "github.com/onsi/gomega/internal/assertion",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "N7HhJzMN+STfzI315keM9SxFQAE=",
+			"path": "github.com/onsi/gomega/internal/asyncassertion",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "EsgeBqN2S5wj8aWvGsS162ZK7xI=",
+			"path": "github.com/onsi/gomega/internal/oraclematcher",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "M2WqXho4fZaeYkyfuiGTlPhcU8I=",
+			"path": "github.com/onsi/gomega/internal/testingtsupport",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "D7QESRc8hYaX8wHT0ftzvNTMwuk=",
+			"path": "github.com/onsi/gomega/matchers",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "NMjCfnHie2dgQw0kCObrHRc8S50=",
+			"path": "github.com/onsi/gomega/matchers/support/goraph/bipartitegraph",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "zjTC6ady0bJUwzTFAKtv63T7Fmg=",
+			"path": "github.com/onsi/gomega/matchers/support/goraph/edge",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "o2+IscLOPKOiovl2g0/igkD1R4Q=",
+			"path": "github.com/onsi/gomega/matchers/support/goraph/node",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "yEF1BYQPwS3neYFKiqNQReqnadY=",
+			"path": "github.com/onsi/gomega/matchers/support/goraph/util",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "mGI31MBiT3PJ8sgoB/E7NQ+4dJA=",
+			"path": "github.com/onsi/gomega/types",
+			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
+			"revisionTime": "2018-03-02T08:44:13Z"
+		},
+		{
+			"checksumSHA1": "NTperEHVh1uBqfTy9+oKceN4tKI=",
+			"path": "github.com/opencontainers/go-digest",
+			"revision": "21dfd564fd89c944783d00d069f33e3e7123c448",
+			"revisionTime": "2017-01-11T18:16:59Z"
+		},
+		{
+			"checksumSHA1": "ZGlIwSRjdLYCUII7JLE++N4w7Xc=",
+			"path": "github.com/opencontainers/image-spec/specs-go",
+			"revision": "89b51c794e9113108a2914e38e66c826a649f2b5",
+			"revisionTime": "2017-11-03T11:36:04Z"
+		},
+		{
+			"checksumSHA1": "jdbXRRzeu0njLE9/nCEZG+Yg/Jk=",
+			"path": "github.com/opencontainers/image-spec/specs-go/v1",
+			"revision": "89b51c794e9113108a2914e38e66c826a649f2b5",
+			"revisionTime": "2017-11-03T11:36:04Z"
+		},
+		{
+			"checksumSHA1": "OJlgvnpJuV+SDPW48YVUKWDbOnU=",
+			"path": "github.com/opencontainers/runc/libcontainer",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "gVVY8k2G3ws+V1czsfxfuRs8log=",
+			"path": "github.com/opencontainers/runc/libcontainer/apparmor",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "aWtm1zkVCz9l2/zQNfnc246yQew=",
+			"path": "github.com/opencontainers/runc/libcontainer/cgroups",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "OnnBJ2WfB/Y9EQpABKetBedf6ts=",
+			"path": "github.com/opencontainers/runc/libcontainer/cgroups/fs",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "d7B9MiKb1k1Egh5qkNokIfcZ+OY=",
+			"path": "github.com/opencontainers/runc/libcontainer/cgroups/systemd",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "v9sgw4eYRNSsJUSG33OoFIwLqRI=",
+			"path": "github.com/opencontainers/runc/libcontainer/configs",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "hUveFGK1HhGenf0OVoYZWccoW9I=",
+			"path": "github.com/opencontainers/runc/libcontainer/configs/validate",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "n7G7Egz/tOPacXuq+nkvnFai3eU=",
+			"path": "github.com/opencontainers/runc/libcontainer/criurpc",
+			"revision": "369b920277d27630441336775cd728bc0f19e496",
+			"revisionTime": "2018-09-07T18:53:11Z"
+		},
+		{
+			"checksumSHA1": "2CwtFvz9kB0RSjFlcCkmq4taJ9U=",
+			"path": "github.com/opencontainers/runc/libcontainer/devices",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "sAbowQ7hjveSH5ADUD9IYXnEAJM=",
+			"path": "github.com/opencontainers/runc/libcontainer/intelrdt",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "mKxBw0il2IWjWYgksX+17ufDw34=",
+			"path": "github.com/opencontainers/runc/libcontainer/keys",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "mBbwlspKSImoGTw4uKE40AX3PYs=",
+			"path": "github.com/opencontainers/runc/libcontainer/logs",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "MJiogPDUU2nFr1fzQU6T+Ry1W8o=",
+			"path": "github.com/opencontainers/runc/libcontainer/mount",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "PnGFQdbZhZ4pcxFtQep5MEQ4/8E=",
+			"path": "github.com/opencontainers/runc/libcontainer/nsenter",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "I1Qw/btE1twMqKHpYNsC98cteak=",
+			"path": "github.com/opencontainers/runc/libcontainer/seccomp",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "yp/kYBgVqKtxlnpq4CmyxLFMAE4=",
+			"path": "github.com/opencontainers/runc/libcontainer/stacktrace",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "cjg/UcueM1/2/ExZ3N7010sa+hI=",
+			"path": "github.com/opencontainers/runc/libcontainer/system",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "mdUukOXCVJxmT0CufSKDeMg5JFM=",
+			"path": "github.com/opencontainers/runc/libcontainer/user",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "PqGgeBjTHnyGrTr5ekLFEXpC3iQ=",
+			"path": "github.com/opencontainers/runc/libcontainer/utils",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "AMYc2X2O/IL6EGrq6lTl5vEhLiY=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/opencontainers/runtime-spec/specs-go",
+			"path": "github.com/opencontainers/runtime-spec/specs-go",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "X4jufgAG12FCYi0U9VK4DK5vvXo=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/opencontainers/selinux/go-selinux",
+			"path": "github.com/opencontainers/selinux/go-selinux",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "5hHzDoXjeTtGaVzyN8lOowcwvdQ=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/opencontainers/selinux/go-selinux/label",
+			"path": "github.com/opencontainers/selinux/go-selinux/label",
+			"revision": "6cc515888830787a93d82138821f0309ad970640",
+			"revisionTime": "2019-06-11T12:12:36Z"
+		},
+		{
+			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
+			"path": "github.com/pkg/errors",
+			"revision": "248dadf4e9068a0b3e79f02ed0a610d935de5302",
+			"revisionTime": "2016-10-29T09:36:37Z"
+		},
+		{
+			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+			"revisionTime": "2016-01-10T10:55:54Z"
+		},
+		{
+			"checksumSHA1": "rTNABfFJ9wtLQRH8uYNkEZGQOrY=",
+			"path": "github.com/posener/complete",
+			"revision": "9f41f7636a724791a3b8b1d35e84caa1124f0d3c",
+			"revisionTime": "2017-08-29T17:11:12Z"
+		},
+		{
+			"checksumSHA1": "NB7uVS0/BJDmNu68vPAlbrq4TME=",
+			"path": "github.com/posener/complete/cmd",
+			"revision": "9f41f7636a724791a3b8b1d35e84caa1124f0d3c",
+			"revisionTime": "2017-08-29T17:11:12Z"
+		},
+		{
+			"checksumSHA1": "gSX86Xl0w9hvtntdT8h23DZtSag=",
+			"path": "github.com/posener/complete/cmd/install",
+			"revision": "9f41f7636a724791a3b8b1d35e84caa1124f0d3c",
+			"revisionTime": "2017-08-29T17:11:12Z"
+		},
+		{
+			"checksumSHA1": "DMo94FwJAm9ZCYCiYdJU2+bh4no=",
+			"path": "github.com/posener/complete/match",
+			"revision": "9f41f7636a724791a3b8b1d35e84caa1124f0d3c",
+			"revisionTime": "2017-08-29T17:11:12Z"
+		},
+		{
+			"checksumSHA1": "5dHjKxShYVWVB1Fb00dAnR6kqVk=",
+			"path": "github.com/prometheus/client_golang/prometheus",
+			"revision": "2641b987480bca71fb39738eb8c8b0d577cb1d76",
+			"revisionTime": "2019-06-07T14:56:44Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
+		},
+		{
+			"checksumSHA1": "UBqhkyjCz47+S19MVTigxJ2VjVQ=",
+			"path": "github.com/prometheus/client_golang/prometheus/internal",
+			"revision": "2641b987480bca71fb39738eb8c8b0d577cb1d76",
+			"revisionTime": "2019-06-07T14:56:44Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
+		},
+		{
+			"checksumSHA1": "V51yx4gq61QCD9clxnps792Eq2Y=",
+			"path": "github.com/prometheus/client_golang/prometheus/promhttp",
+			"revision": "2641b987480bca71fb39738eb8c8b0d577cb1d76",
+			"revisionTime": "2019-06-07T14:56:44Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
+		},
+		{
+			"checksumSHA1": "DvwvOlPNAgRntBzt3b3OSRMS2N4=",
+			"path": "github.com/prometheus/client_model/go",
+			"revision": "6f3806018612930941127f2a7c6c453ba2c527d2",
+			"revisionTime": "2017-02-16T18:52:47Z"
+		},
+		{
+			"checksumSHA1": "xfnn0THnqNwjwimeTClsxahYrIo=",
+			"path": "github.com/prometheus/common/expfmt",
+			"revision": "2f17f4a9d485bf34b4bfaccc273805040e4f86c8",
+			"revisionTime": "2017-09-08T16:18:22Z"
+		},
+		{
+			"checksumSHA1": "GWlM3d2vPYyNATtTFgftS10/A9w=",
+			"path": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
+			"revision": "2f17f4a9d485bf34b4bfaccc273805040e4f86c8",
+			"revisionTime": "2017-09-08T16:18:22Z"
+		},
+		{
+			"checksumSHA1": "3VoqH7TFfzA6Ds0zFzIbKCUvBmw=",
+			"path": "github.com/prometheus/common/model",
+			"revision": "2f17f4a9d485bf34b4bfaccc273805040e4f86c8",
+			"revisionTime": "2017-09-08T16:18:22Z"
+		},
+		{
+			"checksumSHA1": "WB7dFqkmD3R514xql9YM3ZP1dDM=",
+			"path": "github.com/prometheus/procfs",
+			"revision": "833678b5bb319f2d20a475cb165c6cc59c2cc77c",
+			"revisionTime": "2019-05-31T16:30:47Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "Kmjs49lbjGmlgUPx3pks0tVDed0=",
+			"path": "github.com/prometheus/procfs/internal/fs",
+			"revision": "833678b5bb319f2d20a475cb165c6cc59c2cc77c",
+			"revisionTime": "2019-05-31T16:30:47Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "xCiFAAwVTrjsfZT1BIJQ3DgeNCY=",
+			"path": "github.com/prometheus/procfs/xfs",
+			"revision": "e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2",
+			"revisionTime": "2017-07-03T10:12:42Z"
+		},
+		{
+			"checksumSHA1": "I778b2sbNN/yjwKSdb3y7hz2yUQ=",
+			"path": "github.com/rs/cors",
+			"revision": "eabcc6af4bbe5ad3a949d36450326a2b0b9894b8",
+			"revisionTime": "2017-08-01T07:32:01Z"
+		},
+		{
+			"checksumSHA1": "M57Rrfc8Z966p+IBtQ91QOcUtcg=",
+			"comment": "v2.0.1-8-g983d3a5",
+			"path": "github.com/ryanuber/columnize",
+			"revision": "abc90934186a77966e2beeac62ed966aac0561d5",
+			"revisionTime": "2017-07-03T20:58:27Z"
+		},
+		{
+			"checksumSHA1": "6JP37UqrI0H80Gpk0Y2P+KXgn5M=",
+			"path": "github.com/ryanuber/go-glob",
+			"revision": "256dc444b735e061061cf46c809487313d5b0065",
+			"revisionTime": "2017-01-28T01:21:29Z"
+		},
+		{
+			"checksumSHA1": "tnMZLo/kR9Kqx6GtmWwowtTLlA8=",
+			"path": "github.com/sean-/seed",
+			"revision": "e2103e2c35297fb7e17febb81e49b312087a2372",
+			"revisionTime": "2017-03-13T16:33:22Z"
+		},
+		{
+			"checksumSHA1": "6Z/chtTVA74eUZTlG5VRDy59K1M=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/seccomp/libseccomp-golang",
+			"path": "github.com/seccomp/libseccomp-golang",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "8Lm8nsMCFz4+gr9EvQLqK8+w+Ks=",
+			"path": "github.com/sethgrid/pester",
+			"revision": "8053687f99650573b28fb75cddf3f295082704d7",
+			"revisionTime": "2016-04-29T17:20:22Z"
+		},
+		{
+			"checksumSHA1": "k+PmW/6PFt0FVFTTnfMbWwrm9hU=",
+			"origin": "github.com/hashicorp/gopsutil/cpu",
+			"path": "github.com/shirou/gopsutil/cpu",
+			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
+			"revisionTime": "2018-04-27T01:21:16Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "4DZwA8Xf2Zs8vhIc9kx8TIBMmSY=",
+			"origin": "github.com/hashicorp/gopsutil/disk",
+			"path": "github.com/shirou/gopsutil/disk",
+			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
+			"revisionTime": "2018-04-27T01:21:16Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "ib/iKmNEqKrSso+TsSSV/Q4HDSY=",
+			"origin": "github.com/hashicorp/gopsutil/host",
+			"path": "github.com/shirou/gopsutil/host",
+			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
+			"revisionTime": "2018-04-27T01:21:16Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "S31u6j9yi6MOblZ1x83k/HDuNtA=",
+			"origin": "github.com/hashicorp/gopsutil/internal/common",
+			"path": "github.com/shirou/gopsutil/internal/common",
+			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
+			"revisionTime": "2018-04-27T01:21:16Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "1u1St5K2LtEcQsh5ySmvoTZ8k0I=",
+			"origin": "github.com/hashicorp/gopsutil/mem",
+			"path": "github.com/shirou/gopsutil/mem",
+			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
+			"revisionTime": "2018-04-27T01:21:16Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "ME2P9hiaHO/YdVrNInDmb/dB6us=",
+			"origin": "github.com/hashicorp/gopsutil/net",
+			"path": "github.com/shirou/gopsutil/net",
+			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
+			"revisionTime": "2018-04-27T01:21:16Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "JuBAKUuSyR7RdJELt6tQMn79Y6w=",
+			"origin": "github.com/hashicorp/gopsutil/process",
+			"path": "github.com/shirou/gopsutil/process",
+			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
+			"revisionTime": "2018-04-27T01:21:16Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "Nve7SpDmjsv6+rhkXAkfg/UQx94=",
+			"path": "github.com/shirou/w32",
+			"revision": "bb4de0191aa41b5507caa14b0650cdbddcd9280b",
+			"revisionTime": "2016-09-30T03:27:40Z"
+		},
+		{
+			"checksumSHA1": "SVO+Zm6SNwWrpgyc6mcTXbH4aJ8=",
+			"path": "github.com/sirupsen/logrus",
+			"revision": "2a22dbedbad1fd454910cd1f44f210ef90c28464",
+			"revisionTime": "2019-05-18T13:52:02Z"
+		},
+		{
+			"checksumSHA1": "h/HMhokbQHTdLUbruoBBTee+NYw=",
+			"path": "github.com/skratchdot/open-golang/open",
+			"revision": "75fb7ed4208cf72d323d7d02fd1a5964a7a9073c",
+			"revisionTime": "2016-03-02T14:40:31Z"
+		},
+		{
+			"checksumSHA1": "Q52Y7t0lEtk/wcDn5q7tS7B+jqs=",
+			"path": "github.com/spf13/pflag",
+			"revision": "7aff26db30c1be810f9de5038ec5ef96ac41fd7c",
+			"revisionTime": "2017-08-24T17:57:12Z"
+		},
+		{
+			"checksumSHA1": "K0crHygPTP42i1nLKWphSlvOQJw=",
+			"path": "github.com/stretchr/objx",
+			"revision": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94",
+			"revisionTime": "2015-09-28T12:21:52Z"
+		},
+		{
+			"checksumSHA1": "/7bZ0f2fM9AAsLf3nMca6Gtlm6E=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "221dbe5ed46703ee255b1da0dec05086f5035f62",
+			"revisionTime": "2019-05-17T17:51:56Z",
+			"version": "v1.4.0",
+			"versionExact": "v1.4.0"
+		},
+		{
+			"checksumSHA1": "bg70xAHEu6HRf2iFu8h5iJBjUfg=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "221dbe5ed46703ee255b1da0dec05086f5035f62",
+			"revisionTime": "2019-05-17T17:51:56Z",
+			"version": "v1.4.0",
+			"versionExact": "v1.4.0"
+		},
+		{
+			"checksumSHA1": "ABkrw83kq3/d6oSRX+BFq57/BiY=",
+			"path": "github.com/stretchr/testify/require",
+			"revision": "221dbe5ed46703ee255b1da0dec05086f5035f62",
+			"revisionTime": "2019-05-17T17:51:56Z",
+			"version": "v1.4.0",
+			"versionExact": "v1.4.0"
+		},
+		{
+			"checksumSHA1": "PgEklGW56c5RLHqQhORxt6jS3fY=",
+			"path": "github.com/syndtr/gocapability/capability",
+			"revision": "db04d3cc01c8b54962a58ec7e491717d06cfcc16",
+			"revisionTime": "2017-07-04T07:02:18Z"
+		},
+		{
+			"path": "github.com/testify/assert",
+			"revision": "v1.4.0",
+			"version": "v1.4.0"
+		},
+		{
+			"path": "github.com/testify/mock",
+			"revision": "v1.4.0",
+			"version": "v1.4.0"
+		},
+		{
+			"path": "github.com/testify/require",
+			"revision": "v1.4.0",
+			"version": "v1.4.0"
+		},
+		{
+			"checksumSHA1": "t24KnvC9jRxiANVhpw2pqFpmEu8=",
+			"path": "github.com/tonnerre/golang-text",
+			"revision": "048ed3d792f7104850acbc8cfc01e5a6070f4c04",
+			"revisionTime": "2013-09-25T19:58:46Z"
+		},
+		{
+			"checksumSHA1": "2xcr/mhxBFlDjpxe/Mc2Wb4RGR8=",
+			"path": "github.com/tv42/httpunix",
+			"revision": "b75d8614f926c077e48d85f1f8f7885b758c6225",
+			"revisionTime": "2015-04-27T01:28:21Z"
+		},
+		{
+			"checksumSHA1": "RBRh7hUVcoELofg7TinPuBUG/po=",
+			"path": "github.com/ugorji/go/codec",
+			"revision": "08f7b401aef15f3d544472dd46bf6788cdfe55bf",
+			"revisionTime": "2019-05-07T20:14:01Z"
+		},
+		{
+			"checksumSHA1": "qgMa75aMGbkFY0jIqqqgVnCUoNA=",
+			"path": "github.com/ulikunitz/xz",
+			"revision": "0c6b41e72360850ca4f98dc341fd999726ea007f",
+			"revisionTime": "2017-06-05T21:53:11Z"
+		},
+		{
+			"checksumSHA1": "vjnTkzNrMs5Xj6so/fq0mQ6dT1c=",
+			"path": "github.com/ulikunitz/xz/internal/hash",
+			"revision": "0c6b41e72360850ca4f98dc341fd999726ea007f",
+			"revisionTime": "2017-06-05T21:53:11Z"
+		},
+		{
+			"checksumSHA1": "m0pm57ASBK/CTdmC0ppRHO17mBs=",
+			"path": "github.com/ulikunitz/xz/internal/xlog",
+			"revision": "0c6b41e72360850ca4f98dc341fd999726ea007f",
+			"revisionTime": "2017-06-05T21:53:11Z"
+		},
+		{
+			"checksumSHA1": "2vZw6zc8xuNlyVz2QKvdlNSZQ1U=",
+			"path": "github.com/ulikunitz/xz/lzma",
+			"revision": "0c6b41e72360850ca4f98dc341fd999726ea007f",
+			"revisionTime": "2017-06-05T21:53:11Z"
+		},
+		{
+			"checksumSHA1": "cIkE6EIE7A0IzdhR/Yes8Nzyqtk=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/vishvananda/netlink",
+			"path": "github.com/vishvananda/netlink",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "r/vcO8YkOWNHKX5HKCukaU4Xzlg=",
+			"origin": "github.com/opencontainers/runc/vendor/github.com/vishvananda/netlink/nl",
+			"path": "github.com/vishvananda/netlink/nl",
+			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
+			"revisionTime": "2018-08-23T14:46:37Z"
+		},
+		{
+			"checksumSHA1": "t9A/EE2GhHFPHzK+ksAKgKW9ZC8=",
+			"path": "github.com/vmihailenco/msgpack",
+			"revision": "b5e691b1eb52a28c05e67ab9df303626c095c23b",
+			"revisionTime": "2018-06-13T09:15:15Z"
+		},
+		{
+			"checksumSHA1": "OcTSGT2v7/2saIGq06nDhEZwm8I=",
+			"path": "github.com/vmihailenco/msgpack/codes",
+			"revision": "b5e691b1eb52a28c05e67ab9df303626c095c23b",
+			"revisionTime": "2018-06-13T09:15:15Z"
+		},
+		{
+			"checksumSHA1": "0jAKo5tFC1SpRjwB+AiPNfNAzmM=",
+			"path": "github.com/zclconf/go-cty/cty",
+			"revision": "4ca19710f0562cab70f0b3c9cbff0ecc70ee06d1",
+			"revisionTime": "2019-02-01T22:06:20Z"
+		},
+		{
+			"checksumSHA1": "1WGUPe776lvMMbaRerAbqOx19nQ=",
+			"path": "github.com/zclconf/go-cty/cty/convert",
+			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
+			"revisionTime": "2018-07-18T22:05:26Z"
+		},
+		{
+			"checksumSHA1": "MyyLCGg3RREMllTJyK6ehZl/dHk=",
+			"path": "github.com/zclconf/go-cty/cty/function",
+			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
+			"revisionTime": "2018-07-18T22:05:26Z"
+		},
+		{
+			"checksumSHA1": "kcTJOuL131/stXJ4U9tC3SASQLs=",
+			"path": "github.com/zclconf/go-cty/cty/function/stdlib",
+			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
+			"revisionTime": "2018-07-18T22:05:26Z"
+		},
+		{
+			"checksumSHA1": "tmCzwfNXOEB1sSO7TKVzilb2vjA=",
+			"path": "github.com/zclconf/go-cty/cty/gocty",
+			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
+			"revisionTime": "2018-07-18T22:05:26Z"
+		},
+		{
+			"checksumSHA1": "1ApmO+Q33+Oem/3f6BU6sztJWNc=",
+			"path": "github.com/zclconf/go-cty/cty/json",
+			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
+			"revisionTime": "2018-07-18T22:05:26Z"
+		},
+		{
+			"checksumSHA1": "8H+2pufGi2Eo3d8cXFfJs31wk+I=",
+			"path": "github.com/zclconf/go-cty/cty/msgpack",
+			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
+			"revisionTime": "2018-07-18T22:05:26Z"
+		},
+		{
+			"checksumSHA1": "y5Sk+n6SOspFj8mlyb8swr4DMIs=",
+			"path": "github.com/zclconf/go-cty/cty/set",
+			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
+			"revisionTime": "2018-07-18T22:05:26Z"
+		},
+		{
+			"checksumSHA1": "w+WRj7WpdItd5iR7PcaQQKMrVB0=",
+			"path": "go.opencensus.io",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "KLZy3Nh+8JlI04JmBa/Jc8fxrVQ=",
+			"path": "go.opencensus.io/internal",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "Dw3rpna1DwTa7TCzijInKcU49g4=",
+			"path": "go.opencensus.io/internal/tagencoding",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "r6fbtPwxK4/TYUOWc7y0hXdAG4Q=",
+			"path": "go.opencensus.io/metric/metricdata",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "kWj13srwY1SH5KgFecPhEfHnzVc=",
+			"path": "go.opencensus.io/metric/metricproducer",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "Ur+xijNXCbNHR8Q5VjW1czSAabo=",
+			"path": "go.opencensus.io/plugin/ochttp",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "UZhIoErIy1tKLmVT/5huwlp6KFQ=",
+			"path": "go.opencensus.io/plugin/ochttp/propagation/b3",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "q+y8X+5nDONIlJlxfkv+OtA18ds=",
+			"path": "go.opencensus.io/resource",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "Cc4tRuW0IjlfAFY8BcdfMDqG0R8=",
+			"path": "go.opencensus.io/stats",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "oIo4NRi6AVCfcwVfHzCXAsoZsdI=",
+			"path": "go.opencensus.io/stats/internal",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "vN9GN1vwD4RU/3ld2tKK00K0i94=",
+			"path": "go.opencensus.io/stats/view",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "AoqL/neZwl05Fv08vcXXlhbY12g=",
+			"path": "go.opencensus.io/tag",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "0O3djqX4bcg5O9LZdcinEoYeQKs=",
+			"path": "go.opencensus.io/trace",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "JkvEb8oMEFjic5K/03Tyr5Lok+w=",
+			"path": "go.opencensus.io/trace/internal",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "FHJParRi8f1GHO7Cx+lk3bMWBq0=",
+			"path": "go.opencensus.io/trace/propagation",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "UHbxxaMqpEPsubh8kPwzSlyEwqI=",
+			"path": "go.opencensus.io/trace/tracestate",
+			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
+			"revisionTime": "2019-07-13T07:22:01Z"
+		},
+		{
+			"checksumSHA1": "PMr/a5kcnC4toJtVwWhlU5E4tJY=",
+			"path": "go4.org/errorutil",
+			"revision": "034d17a462f7b2dcd1a4a73553ec5357ff6e6c6e",
+			"revisionTime": "2017-05-24T23:16:39Z"
+		},
+		{
+			"checksumSHA1": "ejjxT0+wDWWncfh0Rt3lSH4IbXQ=",
+			"path": "golang.org/x/crypto/blake2b",
+			"revision": "de0752318171da717af4ce24d0a2e8626afaeb11",
+			"revisionTime": "2018-08-08T16:52:45Z"
+		},
+		{
+			"checksumSHA1": "BGm8lKZmvJbf/YOJLeL1rw2WVjA=",
+			"path": "golang.org/x/crypto/ssh/terminal",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"revisionTime": "2018-06-20T09:14:27Z"
+		},
+		{
+			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
+			"path": "golang.org/x/net/context",
+			"revision": "c10e9556a7bc0e7c942242b606f0acf024ad5d6a",
+			"revisionTime": "2018-11-02T08:55:01Z"
+		},
+		{
+			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
+			"path": "golang.org/x/net/context/ctxhttp",
+			"revision": "f09c4662a0bd6bd8943ac7b4931e185df9471da4",
+			"revisionTime": "2016-09-24T00:10:04Z"
+		},
+		{
+			"checksumSHA1": "vqc3a+oTUGX8PmD0TS+qQ7gmN8I=",
+			"path": "golang.org/x/net/html",
+			"revision": "66aacef3dd8a676686c7ae3716979581e8b03c47",
+			"revisionTime": "2016-09-14T00:11:54Z"
+		},
+		{
+			"checksumSHA1": "00eQaGynDYrv3tL+C7l9xH0IDZg=",
+			"path": "golang.org/x/net/html/atom",
+			"revision": "66aacef3dd8a676686c7ae3716979581e8b03c47",
+			"revisionTime": "2016-09-14T00:11:54Z"
+		},
+		{
+			"checksumSHA1": "barUU39reQ7LdgYLA323hQ/UGy4=",
+			"path": "golang.org/x/net/html/charset",
+			"revision": "66aacef3dd8a676686c7ae3716979581e8b03c47",
+			"revisionTime": "2016-09-14T00:11:54Z"
+		},
+		{
+			"checksumSHA1": "kKuxyoDujo5CopTxAvvZ1rrLdd0=",
+			"path": "golang.org/x/net/http2",
+			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
+			"revisionTime": "2017-07-19T21:11:51Z"
+		},
+		{
+			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
+			"path": "golang.org/x/net/http2/hpack",
+			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
+			"revisionTime": "2017-07-19T21:11:51Z"
+		},
+		{
+			"checksumSHA1": "g/Z/Ka0VgJESgQK7/SJCjm/aX0I=",
+			"path": "golang.org/x/net/idna",
+			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
+			"revisionTime": "2017-07-19T21:11:51Z"
+		},
+		{
+			"checksumSHA1": "UxahDzW2v4mf/+aFxruuupaoIwo=",
+			"path": "golang.org/x/net/internal/timeseries",
+			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
+			"revisionTime": "2017-07-19T21:11:51Z"
+		},
+		{
+			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
+			"path": "golang.org/x/net/lex/httplex",
+			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
+			"revisionTime": "2017-07-19T21:11:51Z"
+		},
+		{
+			"checksumSHA1": "r9l4r3H6FOLQ0c2JaoXpopFjpnw=",
+			"origin": "github.com/docker/docker/vendor/golang.org/x/net/proxy",
+			"path": "golang.org/x/net/proxy",
+			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
+			"revisionTime": "2018-08-16T08:14:46Z"
+		},
+		{
+			"checksumSHA1": "u/r66lwYfgg682u5hZG7/E7+VCY=",
+			"path": "golang.org/x/net/trace",
+			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
+			"revisionTime": "2017-07-19T21:11:51Z"
+		},
+		{
+			"checksumSHA1": "uRlaEkyMCxyjj57KBa81GEfvCwg=",
+			"path": "golang.org/x/oauth2",
+			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
+			"revisionTime": "2019-05-07T23:52:07Z"
+		},
+		{
+			"checksumSHA1": "w5SmJwdVFlGE1KO4/AQjY+jvdsI=",
+			"path": "golang.org/x/oauth2/google",
+			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
+			"revisionTime": "2019-05-07T23:52:07Z"
+		},
+		{
+			"checksumSHA1": "rnUL+5Yzlt+Ky2dlB61VqfhBOb8=",
+			"path": "golang.org/x/oauth2/internal",
+			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
+			"revisionTime": "2019-05-07T23:52:07Z"
+		},
+		{
+			"checksumSHA1": "huVltYnXdRFDJLgp/ZP9IALzG7g=",
+			"path": "golang.org/x/oauth2/jws",
+			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
+			"revisionTime": "2019-05-07T23:52:07Z"
+		},
+		{
+			"checksumSHA1": "HGS6ig1GfcE2CBHBsi965ZVn9Xw=",
+			"path": "golang.org/x/oauth2/jwt",
+			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
+			"revisionTime": "2019-05-07T23:52:07Z"
+		},
+		{
+			"checksumSHA1": "S0DP7Pn7sZUmXc55IzZnNvERu6s=",
+			"path": "golang.org/x/sync/errgroup",
+			"revision": "316e794f7b5e3df4e95175a45a5fb8b12f85cb4f",
+			"revisionTime": "2016-07-15T18:54:39Z"
+		},
+		{
+			"checksumSHA1": "REkmyB368pIiip76LiqMLspgCRk=",
+			"path": "golang.org/x/sys/cpu",
+			"revision": "1b2967e3c290b7c545b3db0deeda16e9be4f98a2",
+			"revisionTime": "2018-07-06T09:56:39Z"
+		},
+		{
+			"checksumSHA1": "su2QDjUzrUO0JnOH9m0cNg0QqsM=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "ac767d655b305d4e9612f5f6e33120b9176c4ad4",
+			"revisionTime": "2018-07-08T03:57:06Z"
+		},
+		{
+			"checksumSHA1": "l1jIhK9Y33obLipDvmjVPCdYtJI=",
+			"path": "golang.org/x/sys/windows",
+			"revision": "1b2967e3c290b7c545b3db0deeda16e9be4f98a2",
+			"revisionTime": "2018-07-06T09:56:39Z"
+		},
+		{
+			"checksumSHA1": "Mr4ur60bgQJnQFfJY0dGtwWwMPE=",
+			"path": "golang.org/x/text/encoding",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "HgcUFTOQF5jOYtTIj5obR3GVN9A=",
+			"path": "golang.org/x/text/encoding/charmap",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "yBhX1V6U7stq3GqS2x5yzF0lV+I=",
+			"path": "golang.org/x/text/encoding/htmlindex",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "zeHyHebIZl1tGuwGllIhjfci+wI=",
+			"path": "golang.org/x/text/encoding/internal",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "9cg4nSGfKTIWKb6bWV7U4lnuFKA=",
+			"path": "golang.org/x/text/encoding/internal/identifier",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "f/PWjU17cU5uo0zkdi+Iz80Megk=",
+			"path": "golang.org/x/text/encoding/japanese",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "qHQ79q9peY8ZkCMC8kJAb52BAWg=",
+			"path": "golang.org/x/text/encoding/korean",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "55UdScb+EMOCPr7OW0hCwDsVxpg=",
+			"path": "golang.org/x/text/encoding/simplifiedchinese",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "9EZF1SHTpjVmaT9sARitvGKUXOY=",
+			"path": "golang.org/x/text/encoding/traditionalchinese",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "G9LfJI9gySazd+MyyC6QbTHx4to=",
+			"path": "golang.org/x/text/encoding/unicode",
+			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
+			"revisionTime": "2017-08-30T18:54:29Z"
+		},
+		{
+			"checksumSHA1": "i47RkGDg+mFR2sYXOfVRVkGow3U=",
+			"path": "golang.org/x/text/internal",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "TWgJww5WcPoH39HKMNW0gEcQHts=",
+			"path": "golang.org/x/text/internal/language",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "hyNCcTwMQnV6/MK8uUW9E5H0J0M=",
+			"path": "golang.org/x/text/internal/tag",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "Qk7dljcrEK1BJkAEZguxAbG9dSo=",
+			"path": "golang.org/x/text/internal/utf8internal",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "B2EFJkBRmiAWXqY/4zqUJfp85ag=",
+			"path": "golang.org/x/text/language",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "IV4MN7KGBSocu/5NR3le3sxup4Y=",
+			"path": "golang.org/x/text/runes",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "tltivJ/uj/lqLk05IqGfCv2F/E8=",
+			"path": "golang.org/x/text/secure/bidirule",
+			"revision": "88f656faf3f37f690df1a32515b479415e1a6769",
+			"revisionTime": "2017-10-26T07:52:28Z"
+		},
+		{
+			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
+			"path": "golang.org/x/text/transform",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "iB6/RoQIzBaZxVi+t7tzbkwZTlo=",
+			"path": "golang.org/x/text/unicode/bidi",
+			"revision": "88f656faf3f37f690df1a32515b479415e1a6769",
+			"revisionTime": "2017-10-26T07:52:28Z"
+		},
+		{
+			"checksumSHA1": "jer43nmInsJhYFfpl39FpEYyoC4=",
+			"path": "golang.org/x/text/unicode/cldr",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "BCNYmf4Ek93G4lk5x3ucNi/lTwA=",
+			"path": "golang.org/x/text/unicode/norm",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "1mKbP+ZJSE2oamuShC/hhvJahks=",
+			"path": "golang.org/x/text/unicode/rangetable",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "zuieOGXKG9vXxNhEWv3H0X8RSXM=",
+			"path": "golang.org/x/text/width",
+			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
+			"revisionTime": "2018-02-22T12:58:23Z"
+		},
+		{
+			"checksumSHA1": "h/06ikMECfJoTkWj2e1nJ30aDDg=",
+			"path": "golang.org/x/time/rate",
+			"revision": "a4bde12657593d5e90d0533a3e4fd95e635124cb",
+			"revisionTime": "2016-02-02T18:34:45Z"
+		},
+		{
+			"checksumSHA1": "QyBLCM74VEO9bekzOZGcEkJ7V0o=",
+			"path": "google.golang.org/api/gensupport",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "YIDE68w/xMptf6Nu9hHiOwXOvho=",
+			"path": "google.golang.org/api/googleapi",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "1K0JxrUfDqAB3MyRiU1LKjfHyf4=",
+			"path": "google.golang.org/api/googleapi/internal/uritemplates",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "Mr2fXhMRzlQCgANFm91s536pG7E=",
+			"path": "google.golang.org/api/googleapi/transport",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "6Tg4dDJKzoSrAA5beVknvnjluOU=",
+			"path": "google.golang.org/api/internal",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "zh9AcT6oNvhnOqb7w7njY48TkvI=",
+			"path": "google.golang.org/api/iterator",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "2AyxThTPscWdy49fGsU2tg0Uyw8=",
+			"path": "google.golang.org/api/option",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "5M3TLPBoDz0A+PsHGDJmjmwqoTI=",
+			"path": "google.golang.org/api/storage/v1",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "a+PkIGoiF+p+ghmjmA9gUkMFwYQ=",
+			"path": "google.golang.org/api/transport/http",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "sJcKCvjPtoysqyelsB2CQzC5oQI=",
+			"path": "google.golang.org/api/transport/http/internal/propagation",
+			"revision": "035d22e007183e382031a505793aeb0ddb724007",
+			"revisionTime": "2019-08-24T00:08:15Z"
+		},
+		{
+			"checksumSHA1": "xmp0GjeJfZUWSmGfoUA/pxlKc0Q=",
+			"path": "google.golang.org/genproto/googleapis/api/annotations",
+			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
+			"revisionTime": "2019-05-08T19:38:15Z"
+		},
+		{
+			"checksumSHA1": "3hrELKtivO5PZZfzCL4JVOX3/Kw=",
+			"path": "google.golang.org/genproto/googleapis/iam/v1",
+			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
+			"revisionTime": "2019-05-08T19:38:15Z"
+		},
+		{
+			"checksumSHA1": "74OOKlkosdNECTQ8HvRmtMsqJZg=",
+			"path": "google.golang.org/genproto/googleapis/rpc/code",
+			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
+			"revisionTime": "2019-05-08T19:38:15Z"
+		},
+		{
+			"checksumSHA1": "Q0bDd8ApwAloBd/JQw0uZD4DbZM=",
+			"path": "google.golang.org/genproto/googleapis/rpc/status",
+			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
+			"revisionTime": "2019-05-08T19:38:15Z"
+		},
+		{
+			"checksumSHA1": "AyISVQkdxcMLS/tagl6PJFTs8Bs=",
+			"path": "google.golang.org/genproto/googleapis/type/expr",
+			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
+			"revisionTime": "2019-05-08T19:38:15Z"
+		},
+		{
+			"checksumSHA1": "UKBaAnKJu1ydInKNkSvnJ4s18QQ=",
+			"path": "google.golang.org/grpc",
+			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
+			"revisionTime": "2018-07-17T15:26:04Z"
+		},
+		{
+			"checksumSHA1": "/eTpFgjvMq5Bc9hYnw5fzKG4B6I=",
+			"path": "google.golang.org/grpc/codes",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "wA6y5rkH1v4bWBe5M1r/Hdtgma4=",
+			"path": "google.golang.org/grpc/credentials",
+			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
+			"revisionTime": "2018-07-17T15:26:04Z"
+		},
+		{
+			"checksumSHA1": "2NbY9kmMweE4VUsruRsvmViVnNg=",
+			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "MCQmohiDJwkgLWu/wpnekweQh8s=",
+			"path": "google.golang.org/grpc/grpclog",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "pc9cweMiKQ5hVMuO9UoMGdbizaY=",
+			"path": "google.golang.org/grpc/health",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "W5KfI1NIGJt7JaVnLzefDZr3+4s=",
+			"path": "google.golang.org/grpc/health/grpc_health_v1",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "cSdzm5GhbalJbWUNrN8pRdW0uks=",
+			"path": "google.golang.org/grpc/internal",
+			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
+			"revisionTime": "2018-07-17T15:26:04Z"
+		},
+		{
+			"checksumSHA1": "Z1mhrOEf+PedS4kVtNRlINUDzWg=",
+			"path": "google.golang.org/grpc/internal/transport",
+			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
+			"revisionTime": "2018-07-17T15:26:04Z"
+		},
+		{
+			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
+			"path": "google.golang.org/grpc/keepalive",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "OjIAi5AzqlQ7kLtdAyjvdgMf6hc=",
+			"path": "google.golang.org/grpc/metadata",
+			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
+			"revisionTime": "2018-07-17T15:26:04Z"
+		},
+		{
+			"checksumSHA1": "Zzb7Xsc3tbTJzrcZbSPyye+yxmw=",
+			"path": "google.golang.org/grpc/naming",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
+			"path": "google.golang.org/grpc/peer",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "YclPgme2gT3S0hTkHVdE1zAxJdo=",
+			"path": "google.golang.org/grpc/stats",
+			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
+			"revisionTime": "2018-07-17T15:26:04Z"
+		},
+		{
+			"checksumSHA1": "t/NhHuykWsxY0gEBd2WIv5RVBK8=",
+			"path": "google.golang.org/grpc/status",
+			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
+			"revisionTime": "2018-07-17T15:26:04Z"
+		},
+		{
+			"checksumSHA1": "aixGx/Kd0cj9ZlZHacpHe3XgMQ4=",
+			"path": "google.golang.org/grpc/tap",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "oFGr0JoquaPGVnV86fVL8MVTc3A=",
+			"path": "google.golang.org/grpc/transport",
+			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
+			"revisionTime": "2017-07-21T17:58:12Z"
+		},
+		{
+			"checksumSHA1": "eIhF+hmL/XZhzTiAwhLD0M65vlY=",
+			"path": "gopkg.in/fsnotify.v1",
+			"revision": "629574ca2a5df945712d3079857300b5e4da0236",
+			"revisionTime": "2016-10-11T02:33:12Z"
+		},
+		{
+			"checksumSHA1": "6f8MEU31llHM1sLM/GGH4/Qxu0A=",
+			"path": "gopkg.in/inf.v0",
+			"revision": "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4",
+			"revisionTime": "2015-09-11T12:57:57Z"
+		},
+		{
+			"checksumSHA1": "TO8baX+t1Qs7EmOYth80MkbKzFo=",
+			"path": "gopkg.in/tomb.v1",
+			"revision": "dd632973f1e7218eb1089048e0798ec9ae7dceb8",
+			"revisionTime": "2014-10-24T13:56:13Z"
+		},
+		{
+			"checksumSHA1": "WiyCOMvfzRdymImAJ3ME6aoYUdM=",
+			"path": "gopkg.in/tomb.v2",
+			"revision": "14b3d72120e8d10ea6e6b7f87f7175734b1faab8",
+			"revisionTime": "2014-06-26T14:46:23Z"
+		},
+		{
+			"checksumSHA1": "12GqsW8PiRPnezDDy0v4brZrndM=",
+			"path": "gopkg.in/yaml.v2",
+			"revision": "a5b47d31c556af34a302ce5d659e6fea44d90de0",
+			"revisionTime": "2016-09-28T15:37:09Z"
+		}
 	],
 	"rootPath": "github.com/hashicorp/nomad"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2,3127 +2,509 @@
 	"comment": "",
 	"ignore": "test",
 	"package": [
-		{
-			"checksumSHA1": "b1KgRkWqz0RmrEBK6IJ8kOJva6w=",
-			"path": "cloud.google.com/go/compute/metadata",
-			"revision": "4bdb329835f9d945a6dad7b2ed60534497faa857",
-			"revisionTime": "2019-08-08T17:09:53Z"
-		},
-		{
-			"checksumSHA1": "+S/9jBntS1iHZwxkR64vsy97Gh8=",
-			"path": "cloud.google.com/go/iam",
-			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
-			"revisionTime": "2019-08-21T09:16:34Z"
-		},
-		{
-			"checksumSHA1": "JfGXEtr79UaxukcL05IERkjYm/g=",
-			"path": "cloud.google.com/go/internal",
-			"revision": "f6872d26e2099733e489f2322a878213384f731a",
-			"revisionTime": "2019-08-26T22:18:59Z"
-		},
-		{
-			"checksumSHA1": "wQ4uGuRwMb24vG16pPQDOOCPkFo=",
-			"path": "cloud.google.com/go/internal/optional",
-			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
-			"revisionTime": "2019-08-21T09:16:34Z"
-		},
-		{
-			"checksumSHA1": "jHOn3QLqvr1luNqyOg24/BXLrsM=",
-			"path": "cloud.google.com/go/internal/trace",
-			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
-			"revisionTime": "2019-08-21T09:16:34Z"
-		},
-		{
-			"checksumSHA1": "CRid/VCcJ3Vfwg/R/gbmzcHVOwQ=",
-			"path": "cloud.google.com/go/internal/version",
-			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
-			"revisionTime": "2019-08-21T09:16:34Z"
-		},
-		{
-			"checksumSHA1": "bZ1XULD+TbAPpn8b6+5dMaWWcqs=",
-			"path": "cloud.google.com/go/storage",
-			"revision": "511b7f3f2624e2d3c4bf2697da4ab69ed5359aac",
-			"revisionTime": "2019-08-21T09:16:34Z"
-		},
-		{
-			"checksumSHA1": "Fs6Gcl0nhC0FJ6MsB+Ck7r4huYo=",
-			"path": "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2015-06-15/network",
-			"revision": "767429fcb996dad413936d682c28301e6739bade",
-			"revisionTime": "2018-05-01T22:35:11Z"
-		},
-		{
-			"checksumSHA1": "FAw+h8wS2QiQEIVC3z/8R2q1bvY=",
-			"path": "github.com/Azure/azure-sdk-for-go/version",
-			"revision": "767429fcb996dad413936d682c28301e6739bade",
-			"revisionTime": "2018-05-01T22:35:11Z"
-		},
-		{
-			"checksumSHA1": "9NFR6RG8H2fNyKHscGmuGLQhRm4=",
-			"path": "github.com/Azure/go-ansiterm",
-			"revision": "d6e3b3328b783f23731bc4d058875b0371ff8109",
-			"revisionTime": "2017-09-29T23:40:23Z",
-			"version": "master",
-			"versionExact": "master"
-		},
-		{
-			"checksumSHA1": "3/UphB+6Hbx5otA4PjFjvObT+L4=",
-			"path": "github.com/Azure/go-ansiterm/winterm",
-			"revision": "d6e3b3328b783f23731bc4d058875b0371ff8109",
-			"revisionTime": "2017-09-29T23:40:23Z",
-			"version": "master",
-			"versionExact": "master"
-		},
-		{
-			"checksumSHA1": "Pc2ORQp+VY3Un/dkh4QwLC7R6lE=",
-			"path": "github.com/BurntSushi/toml",
-			"revision": "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005",
-			"revisionTime": "2018-08-15T10:47:33Z"
-		},
-		{
-			"checksumSHA1": "WvApwvvSe3i/3KO8300dyeFmkbI=",
-			"path": "github.com/DataDog/datadog-go/statsd",
-			"revision": "b10af4b12965a1ad08d164f57d14195b4140d8de",
-			"revisionTime": "2017-08-09T10:47:06Z"
-		},
-		{
-			"checksumSHA1": "Jmf4AnrptgBdQ5TPBJ2M89nooIQ=",
-			"path": "github.com/LK4D4/joincontext",
-			"revision": "1724345da6d5bcc8b66fefb843b607ab918e175c",
-			"revisionTime": "2017-10-26T17:01:39Z"
-		},
-		{
-			"checksumSHA1": "nEVw+80Junfo7iEY7ThP7Ci9Pyk=",
-			"origin": "github.com/endocrimes/go-winio",
-			"path": "github.com/Microsoft/go-winio",
-			"revision": "fb47a8b419480a700368c176bc1d5d7e3393b98d",
-			"revisionTime": "2019-06-20T17:03:19Z",
-			"version": "dani/safe-relisten",
-			"versionExact": "dani/safe-relisten"
-		},
-		{
-			"checksumSHA1": "/ykkyb7gmtZC68n7T24xwbmlCBc=",
-			"origin": "github.com/endocrimes/go-winio/pkg/guid",
-			"path": "github.com/Microsoft/go-winio/pkg/guid",
-			"revision": "fb47a8b419480a700368c176bc1d5d7e3393b98d",
-			"revisionTime": "2019-06-20T17:03:19Z",
-			"version": "dani/safe-relisten",
-			"versionExact": "dani/safe-relisten"
-		},
-		{
-			"checksumSHA1": "kF1vk+8Xvb3nGBiw9+qbUc0SZ4M=",
-			"path": "github.com/NVIDIA/gpu-monitoring-tools",
-			"revision": "86f2a9fac6c5b597dc494420005144b8ef7ec9fb",
-			"revisionTime": "2018-08-29T22:20:09Z"
-		},
-		{
-			"checksumSHA1": "P8FATSSgpe5A17FyPrGpsX95Xw8=",
-			"path": "github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml",
-			"revision": "86f2a9fac6c5b597dc494420005144b8ef7ec9fb",
-			"revisionTime": "2018-08-29T22:20:09Z"
-		},
-		{
-			"checksumSHA1": "jktW57+vJsziNVPeXMCoujTzdW4=",
-			"path": "github.com/NYTimes/gziphandler",
-			"revision": "97ae7fbaf81620fe97840685304a78a306a39c64",
-			"revisionTime": "2017-09-16T00:36:49Z"
-		},
-		{
-			"checksumSHA1": "Aqy8/FoAIidY/DeQ5oTYSZ4YFVc=",
-			"path": "github.com/Nvveen/Gotty",
-			"revision": "cd527374f1e5bff4938207604a14f2e38a9cf512",
-			"revisionTime": "2012-06-04T00:48:16Z"
-		},
-		{
-			"checksumSHA1": "qtjd74+bErubh+qyv3s+lWmn9wc=",
-			"path": "github.com/StackExchange/wmi",
-			"revision": "ea383cf3ba6ec950874b8486cd72356d007c768f",
-			"revisionTime": "2017-04-10T19:29:09Z"
-		},
-		{
-			"checksumSHA1": "jQh1fnoKPKMURvKkpdRjN695nAQ=",
-			"path": "github.com/agext/levenshtein",
-			"revision": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6",
-			"revisionTime": "2017-02-17T06:30:20Z"
-		},
-		{
-			"checksumSHA1": "Ffhtm8iHH7l2ynVVOIGJE3eiuLA=",
-			"path": "github.com/apparentlymart/go-textseg/textseg",
-			"revision": "b836f5c4d331d1945a2fead7188db25432d73b69",
-			"revisionTime": "2017-05-31T20:39:52Z"
-		},
-		{
-			"checksumSHA1": "uWJDTv0R/NJVYv51LVy6vKP1CZw=",
-			"path": "github.com/appc/spec/schema",
-			"revision": "cbe99b7160b1397bf89f9c8bb1418f69c9424049",
-			"revisionTime": "2017-09-19T09:55:19Z"
-		},
-		{
-			"checksumSHA1": "Q47G6996hbfQaNp/8CFkGWTVQpw=",
-			"path": "github.com/appc/spec/schema/common",
-			"revision": "cbe99b7160b1397bf89f9c8bb1418f69c9424049",
-			"revisionTime": "2017-09-19T09:55:19Z"
-		},
-		{
-			"checksumSHA1": "kYXCle7Ikc8WqiMs7NXz99bUWqo=",
-			"path": "github.com/appc/spec/schema/types",
-			"revision": "cbe99b7160b1397bf89f9c8bb1418f69c9424049",
-			"revisionTime": "2017-09-19T09:55:19Z"
-		},
-		{
-			"checksumSHA1": "VgPsPj5PH7LKXMa3ZLe5/+Avydo=",
-			"path": "github.com/appc/spec/schema/types/resource",
-			"revision": "cbe99b7160b1397bf89f9c8bb1418f69c9424049",
-			"revisionTime": "2017-09-19T09:55:19Z"
-		},
-		{
-			"checksumSHA1": "l0iFqayYAaEip6Olaq3/LCOa/Sg=",
-			"path": "github.com/armon/circbuf",
-			"revision": "bbbad097214e2918d8543d5201d12bfd7bca254d"
-		},
-		{
-			"checksumSHA1": "gaT7FBF9uH5TY4lCo96ySrYXjek=",
-			"path": "github.com/armon/go-metrics",
-			"revision": "c1e99089638e6f1f57fe71461f99f9d00a43ccf1",
-			"revisionTime": "2019-04-30T14:02:02Z"
-		},
-		{
-			"checksumSHA1": "xCsGGM9TKBogZDfSN536KtQdLko=",
-			"path": "github.com/armon/go-metrics/circonus",
-			"revision": "c1e99089638e6f1f57fe71461f99f9d00a43ccf1",
-			"revisionTime": "2019-04-30T14:02:02Z"
-		},
-		{
-			"checksumSHA1": "Dt0n1sSivvvdZQdzc4Hu/yOG+T0=",
-			"path": "github.com/armon/go-metrics/datadog",
-			"revision": "c1e99089638e6f1f57fe71461f99f9d00a43ccf1",
-			"revisionTime": "2019-04-30T14:02:02Z"
-		},
-		{
-			"checksumSHA1": "vxr0X6/jCQ4FkMxdhzUaBEWrFGA=",
-			"path": "github.com/armon/go-metrics/prometheus",
-			"revision": "c1e99089638e6f1f57fe71461f99f9d00a43ccf1",
-			"revisionTime": "2019-04-30T14:02:02Z"
-		},
-		{
-			"checksumSHA1": "gNO0JNpLzYOdInGeq7HqMZUzx9M=",
-			"path": "github.com/armon/go-radix",
-			"revision": "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2",
-			"revisionTime": "2016-01-15T23:47:25Z"
-		},
-		{
-			"checksumSHA1": "gMMx/JVSQVE4KHKoJQC7cqjTIZc=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "OlpdlsDV2Qv50MuHlpH9heaHjQc=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "MoxolxrlsmtDri7ndvx5gkXI2hU=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "qZUhjIZT8zU/xdQJ3La948GqEgU=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "VAb9dwYeOW1iViqztJq8DGtlrV4=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "x1grxMebz9A06jOsLieoExjhltU=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "nCeVh7E8twNLP887Zanei1wd6ks=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "9c2Th6//lUUZPehmPkHXJh4hE/s=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "xyUdqBgj3ltt9LXnY4UvEct2izQ=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "0i8r38TS6u3uT2HBM+8tNsozY6w=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "S46ej8/Fd7YnczK42I1UnjoeqqM=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "Rv6k85b5aRb0la07XzRPsrzwrHE=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/private/endpoints",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "ndEFDDt1gd5taOeeUrf0T66H+bg=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "j8UDnDnB59+u1w/qBHKG0PSWH8U=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "WRZcRqV95LFgq5V09PmDmSmNTEw=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "KVdpXAG2PmIyopNC4jJd/JdjefA=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "xmKYerjqq1FO8kJK0/4Ds8iGyWg=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "H0s7iZn2nk/fq52QaaTeW+gSGgA=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/private/signer/v4",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "Pfoou5jtRj8A0SuCl8toNbXQlfw=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/private/waiter",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "NAitp0A1zE3Zry+Z41LOlCr+9lQ=",
-			"comment": "v1.0.6-2-g80dd495",
-			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "80dd4951fdb3f711d31843b8d87871130ef2df67"
-		},
-		{
-			"checksumSHA1": "spyv5/YFBjYyZLZa1U2LBfDR8PM=",
-			"path": "github.com/beorn7/perks/quantile",
-			"revision": "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9",
-			"revisionTime": "2016-08-04T10:47:26Z"
-		},
-		{
-			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",
-			"path": "github.com/bgentry/go-netrc/netrc",
-			"revision": "9fd32a8b3d3d3f9d43c341bfe098430e07609480",
-			"revisionTime": "2014-04-22T17:41:19Z"
-		},
-		{
-			"checksumSHA1": "7SbTaY0kaYxgQrG3/9cjrI+BcyU=",
-			"path": "github.com/bgentry/speakeasy",
-			"revision": "36e9cfdd690967f4f690c6edcc9ffacd006014a0"
-		},
-		{
-			"checksumSHA1": "twtRfb6484vfr2qqjiFkLThTjcQ=",
-			"path": "github.com/bgentry/speakeasy/example",
-			"revision": "36e9cfdd690967f4f690c6edcc9ffacd006014a0"
-		},
-		{
-			"checksumSHA1": "R1Q34Pfnt197F/nCOO9kG8c+Z90=",
-			"comment": "v1.2.0",
-			"path": "github.com/boltdb/bolt",
-			"revision": "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8",
-			"revisionTime": "2017-07-17T17:11:48Z",
-			"version": "v1.3.1",
-			"versionExact": "v1.3.1"
-		},
-		{
-			"checksumSHA1": "k3xD77kpUpECrHCffQKb1nttiDM=",
-			"path": "github.com/checkpoint-restore/go-criu/rpc",
-			"revision": "bdb7599cd87b22701b5c89b37940ea882a7d7dec",
-			"revisionTime": "2019-01-09T18:43:17Z"
-		},
-		{
-			"checksumSHA1": "H4RhrnI0P34qLB9345G4r7CAwpU=",
-			"path": "github.com/circonus-labs/circonus-gometrics",
-			"revision": "d6e3aea90ab9f90fe8456e13fc520f43d102da4d",
-			"revisionTime": "2019-01-28T15:50:09Z",
-			"version": "=v2",
-			"versionExact": "v2"
-		},
-		{
-			"checksumSHA1": "xtzLG2UjYF1lnD33Wk+Nu/KOO6E=",
-			"path": "github.com/circonus-labs/circonus-gometrics/api",
-			"revision": "d6e3aea90ab9f90fe8456e13fc520f43d102da4d",
-			"revisionTime": "2019-01-28T15:50:09Z",
-			"version": "=v2",
-			"versionExact": "v2"
-		},
-		{
-			"checksumSHA1": "bQhz/fcyZPmuHSH2qwC4ZtATy5c=",
-			"path": "github.com/circonus-labs/circonus-gometrics/api/config",
-			"revision": "d6e3aea90ab9f90fe8456e13fc520f43d102da4d",
-			"revisionTime": "2019-01-28T15:50:09Z",
-			"version": "=v2",
-			"versionExact": "v2"
-		},
-		{
-			"checksumSHA1": "Ij8yB33E0Kk+GfTkNRoF1mG26dc=",
-			"path": "github.com/circonus-labs/circonus-gometrics/checkmgr",
-			"revision": "d6e3aea90ab9f90fe8456e13fc520f43d102da4d",
-			"revisionTime": "2019-01-28T15:50:09Z",
-			"version": "=v2",
-			"versionExact": "v2"
-		},
-		{
-			"checksumSHA1": "VbfeVqeOM+dTNxCmpvmYS0LwQn0=",
-			"path": "github.com/circonus-labs/circonusllhist",
-			"revision": "7d649b46cdc2cd2ed102d350688a75a4fd7778c6",
-			"revisionTime": "2016-11-21T13:51:53Z"
-		},
-		{
-			"checksumSHA1": "IGtuR58l2zmYRcNf8sPDlCSgovE=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/containerd/console",
-			"path": "github.com/containerd/console",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "GqIrOttKaO7k6HIaHQLPr3cY7rY=",
-			"origin": "github.com/docker/docker/vendor/github.com/containerd/continuity/pathdriver",
-			"path": "github.com/containerd/continuity/pathdriver",
-			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
-			"revisionTime": "2018-08-16T08:14:46Z"
-		},
-		{
-			"checksumSHA1": "Ur3lVmFp+HTGUzQU+/ZBolKe8FU=",
-			"path": "github.com/containerd/fifo",
-			"revision": "3d5202aec260678c48179c56f40e6f38a095738c",
-			"revisionTime": "2018-03-07T16:51:37Z"
-		},
-		{
-			"checksumSHA1": "O9ClcGJBsp5JQOdetGwWD6+eOJk=",
-			"origin": "github.com/nickethier/go-cni",
-			"path": "github.com/containerd/go-cni",
-			"revision": "ac330f26ed23b10047dfeb864e20ce1721f4bdd9",
-			"revisionTime": "2019-08-29T03:25:06Z",
-			"version": "conflist-bytes",
-			"versionExact": "conflist-bytes"
-		},
-		{
-			"checksumSHA1": "3CsFN6YsShG9EU2oB9vJIqYTxq4=",
-			"path": "github.com/containernetworking/cni/libcni",
-			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
-			"revisionTime": "2019-06-12T15:24:20Z"
-		},
-		{
-			"checksumSHA1": "Xf2DxXUyjBO9u4LeyDzS38pdL+I=",
-			"path": "github.com/containernetworking/cni/pkg/invoke",
-			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
-			"revisionTime": "2019-06-12T15:24:20Z"
-		},
-		{
-			"checksumSHA1": "Dhi4+8X7U2oVzVkgxPrmLaN8qFI=",
-			"path": "github.com/containernetworking/cni/pkg/types",
-			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
-			"revisionTime": "2019-06-12T15:24:20Z"
-		},
-		{
-			"checksumSHA1": "6+ng8oaM9SB0TyCE7I7N940IpPY=",
-			"path": "github.com/containernetworking/cni/pkg/types/020",
-			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
-			"revisionTime": "2019-06-12T15:24:20Z"
-		},
-		{
-			"checksumSHA1": "X6dNZ3yc3V9ffW9vz4yIyeKXGD0=",
-			"path": "github.com/containernetworking/cni/pkg/types/current",
-			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
-			"revisionTime": "2019-06-12T15:24:20Z"
-		},
-		{
-			"checksumSHA1": "aojwjPoA9XSGB/zVtOGzWvmv/i8=",
-			"path": "github.com/containernetworking/cni/pkg/version",
-			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
-			"revisionTime": "2019-06-12T15:24:20Z"
-		},
-		{
-			"checksumSHA1": "n3dCDigZOU+eD84Cr4Kg30GO4nI=",
-			"path": "github.com/containernetworking/plugins/pkg/ns",
-			"revision": "2d6d46d308b2c45a0466324c9e3f1330ab5cacd6",
-			"revisionTime": "2019-05-01T19:17:48Z"
-		},
-		{
-			"checksumSHA1": "UAPz3mxGiQmd3pRWOTghB2aXzGU=",
-			"path": "github.com/coreos/go-iptables/iptables",
-			"revision": "969b135e941d8baadca0a40047a38d6aca381855",
-			"revisionTime": "2019-07-24T15:17:50Z"
-		},
-		{
-			"checksumSHA1": "97BsbXOiZ8+Kr+LIuZkQFtSj7H4=",
-			"path": "github.com/coreos/go-semver/semver",
-			"revision": "1817cd4bea52af76542157eeabd74b057d1a199e",
-			"revisionTime": "2017-06-13T09:22:38Z"
-		},
-		{
-			"checksumSHA1": "/zxxFPYjUB7Wowz33r5AhTDvoz0=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/coreos/go-systemd/dbus",
-			"path": "github.com/coreos/go-systemd/dbus",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "e8qgBHxXbij3RVspqrkeBzMZ564=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/coreos/go-systemd/util",
-			"path": "github.com/coreos/go-systemd/util",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "O8c/VKtW34XPJNNlyeb/im8vWSI=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/coreos/pkg/dlopen",
-			"path": "github.com/coreos/pkg/dlopen",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "4Cq4wS4l0O8WlugamGEPvooJPAk=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/cyphar/filepath-securejoin",
-			"path": "github.com/cyphar/filepath-securejoin",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "mrz/kicZiUaHxkyfvC/DyQcr8Do=",
-			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "ecdeabc65495df2dec95d7c4a4c3e021903035e5",
-			"revisionTime": "2017-10-02T20:02:53Z"
-		},
-		{
-			"checksumSHA1": "wf9Rn3a9cPag5B9Dd+qHHEink+I=",
-			"path": "github.com/docker/cli/cli/config/configfile",
-			"revision": "67f9a3912cf944cf71b31f3fc14e3f2a18d95802",
-			"revisionTime": "2018-08-14T14:54:37Z",
-			"version": "v18.06.1-ce",
-			"versionExact": "v18.06.1-ce"
-		},
-		{
-			"checksumSHA1": "fJpuGdxgATGNHm+INOPNVIhBnj0=",
-			"path": "github.com/docker/cli/cli/config/credentials",
-			"revision": "deb84a9e4e10b590e6de6aa6081532c87a5a2cfe",
-			"revisionTime": "2018-08-29T13:09:58Z"
-		},
-		{
-			"checksumSHA1": "+yq5Rc1QTapDrr151x0m5ANZZeY=",
-			"path": "github.com/docker/cli/opts",
-			"revision": "67f9a3912cf944cf71b31f3fc14e3f2a18d95802",
-			"revisionTime": "2018-08-14T14:54:37Z",
-			"version": "v18.06.1-ce",
-			"versionExact": "v18.06.1-ce"
-		},
-		{
-			"checksumSHA1": "ae06MP/1OVwQ/s/PsEp9wxfnBXM=",
-			"path": "github.com/docker/distribution",
-			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
-			"revisionTime": "2018-08-28T23:03:05Z"
-		},
-		{
-			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
-			"path": "github.com/docker/distribution/digestset",
-			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
-			"revisionTime": "2018-03-27T20:24:08Z"
-		},
-		{
-			"checksumSHA1": "yqCaL8oUi3OlR/Mr4oHB5HKpstc=",
-			"path": "github.com/docker/distribution/metrics",
-			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
-			"revisionTime": "2018-08-28T23:03:05Z"
-		},
-		{
-			"checksumSHA1": "2Fe4D6PGaVE2he4fUeenLmhC1lE=",
-			"path": "github.com/docker/distribution/reference",
-			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
-			"revisionTime": "2018-03-27T20:24:08Z"
-		},
-		{
-			"checksumSHA1": "oFgg0LXTCZuYeI0/eEatdTyLexg=",
-			"path": "github.com/docker/distribution/registry/api/errcode",
-			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
-			"revisionTime": "2018-03-27T20:24:08Z"
-		},
-		{
-			"checksumSHA1": "tjPyswv8NGYxreknmylv5r5tjt4=",
-			"path": "github.com/docker/distribution/registry/api/v2",
-			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
-			"revisionTime": "2018-08-28T23:03:05Z"
-		},
-		{
-			"checksumSHA1": "72zK3wP1n7UTcSFKZZz77sKXZiU=",
-			"path": "github.com/docker/distribution/registry/client",
-			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
-			"revisionTime": "2018-08-28T23:03:05Z"
-		},
-		{
-			"checksumSHA1": "UeouykquJzdjJv1+Vv0ikpe7Yvo=",
-			"path": "github.com/docker/distribution/registry/client/auth",
-			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
-			"revisionTime": "2018-03-27T20:24:08Z"
-		},
-		{
-			"checksumSHA1": "GWNgNhqeZST7+rgQdC06yEaLuQg=",
-			"path": "github.com/docker/distribution/registry/client/auth/challenge",
-			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
-			"revisionTime": "2018-03-27T20:24:08Z"
-		},
-		{
-			"checksumSHA1": "KjpG7FYMU5ugtc/fTfL1YqhdaV4=",
-			"path": "github.com/docker/distribution/registry/client/transport",
-			"revision": "83389a148052d74ac602f5f1d62f86ff2f3c4aa5",
-			"revisionTime": "2018-03-27T20:24:08Z"
-		},
-		{
-			"checksumSHA1": "RjRJSz/ISJEi0uWh5FlXMQetRcg=",
-			"path": "github.com/docker/distribution/registry/storage/cache",
-			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
-			"revisionTime": "2018-08-28T23:03:05Z"
-		},
-		{
-			"checksumSHA1": "T8G3A63WALmJ3JT/A0r01LG4KI0=",
-			"path": "github.com/docker/distribution/registry/storage/cache/memory",
-			"revision": "b12bd4004afc203f1cbd2072317c8fda30b89710",
-			"revisionTime": "2018-08-28T23:03:05Z"
-		},
-		{
-			"checksumSHA1": "zcDmNPSzI1wVokOiHis5+JSg2Rk=",
-			"path": "github.com/docker/docker-credential-helpers/client",
-			"revision": "73e5f5dbfea31ee3b81111ebbf189785fa69731c",
-			"revisionTime": "2018-07-19T07:47:51Z"
-		},
-		{
-			"checksumSHA1": "4u6EMQqD1zIqOHp76zQFLVH5V8U=",
-			"path": "github.com/docker/docker-credential-helpers/credentials",
-			"revision": "73e5f5dbfea31ee3b81111ebbf189785fa69731c",
-			"revisionTime": "2018-07-19T07:47:51Z"
-		},
-		{
-			"checksumSHA1": "PM15F2b73fvtlDsjFyXSMd9LJqU=",
-			"path": "github.com/docker/docker/api/types",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "/jF0HVFiLzUUuywSjp4F/piM7BM=",
-			"path": "github.com/docker/docker/api/types/blkiodev",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "+jeShxohzdtOkwAzy9e0X/fq6n4=",
-			"path": "github.com/docker/docker/api/types/container",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "RMZg2+TAla7E2KiiyF5yupWn0lY=",
-			"path": "github.com/docker/docker/api/types/filters",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "9OClWW7OCikgz4QCS/sAVcvqcWk=",
-			"path": "github.com/docker/docker/api/types/mount",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "qZNE4g8YWfV6ryZp8kN9BwWYCeM=",
-			"path": "github.com/docker/docker/api/types/network",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "m4Jg5WnW75I65nvkEno8PElSXik=",
-			"path": "github.com/docker/docker/api/types/registry",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "OQEUS/2J2xVHpfvcsxcXzYqBSeY=",
-			"path": "github.com/docker/docker/api/types/strslice",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "NT/DoroAQOev6keoJO0zKQZmjbE=",
-			"path": "github.com/docker/docker/api/types/swarm",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "txs5EKTbKgVyKmKKSnaH3fr+odA=",
-			"path": "github.com/docker/docker/api/types/swarm/runtime",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "MZsgRjJJ0D/gAsXfKiEys+op6dE=",
-			"path": "github.com/docker/docker/api/types/versions",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "dF9WiXuwISBPd8bQfqpuoWtB3jk=",
-			"path": "github.com/docker/docker/errdefs",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "u6EOrZRfhdjr4up14b2JJ7MMMaY=",
-			"path": "github.com/docker/docker/opts",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "wZ8yvJiuW5sK2VmoEniu1yjVlBQ=",
-			"path": "github.com/docker/docker/pkg/archive",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "eMoRb/diYeuYLojU7ChN5DaETHc=",
-			"path": "github.com/docker/docker/pkg/fileutils",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "y37I+5AS96wQSiAxOayiMgnZawA=",
-			"path": "github.com/docker/docker/pkg/homedir",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "+Ir5nXNDvy3cwbTlBh06lR7zUrI=",
-			"path": "github.com/docker/docker/pkg/idtools",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "Ybq78CnAoQWVBk+lkh3zykmcSjs=",
-			"path": "github.com/docker/docker/pkg/ioutils",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "KQflv+x9hoJywgvxMwWcJqrmdkQ=",
-			"path": "github.com/docker/docker/pkg/jsonmessage",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "EXiIm2xIL7Ds+YsQUx8Z3eUYPtI=",
-			"path": "github.com/docker/docker/pkg/longpath",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "hx613GafM5hLibNt86ijinN89Ro=",
-			"path": "github.com/docker/docker/pkg/mount",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "dj8atalGWftfM9vdzCsh9YF1Seg=",
-			"path": "github.com/docker/docker/pkg/pools",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "w0waeTRJ1sFygI0dZXH6l9E1c60=",
-			"path": "github.com/docker/docker/pkg/stdcopy",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "gAUCA6R7F9kObegRGGNX5PzJahE=",
-			"path": "github.com/docker/docker/pkg/stringid",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "RreuHCnt9a8brZsc2Q4f5T8wd+E=",
-			"path": "github.com/docker/docker/pkg/system",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "I6mTgOFa7NeZpYw2S5342eenRLY=",
-			"path": "github.com/docker/docker/pkg/tarsum",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "GFsDxJkQz407/2nUBmWuafG+uF8=",
-			"path": "github.com/docker/docker/pkg/term",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "TeOtxuBbbZtp6wDK/t4DdaGGSC0=",
-			"path": "github.com/docker/docker/pkg/term/windows",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "0ZOQ9gYPwnxxjSIytDpwvsN5Rl0=",
-			"path": "github.com/docker/docker/registry",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "jH7uQnDehFQygPP3zLC/mLSqgOk=",
-			"path": "github.com/docker/docker/registry/resumable",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "Bs344j8rU7oCQyIcIhO9FJyk3ts=",
-			"path": "github.com/docker/docker/volume",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "J4wlScrHqr/jCIn82fgVF5mzO34=",
-			"path": "github.com/docker/docker/volume/mounts",
-			"revision": "baab736a364959f10a5ef86f0cd8a8e44bdcc576",
-			"revisionTime": "2018-11-29T15:58:16Z"
-		},
-		{
-			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",
-			"path": "github.com/docker/go-connections/nat",
-			"revision": "7da10c8c50cad14494ec818dcdfb6506265c0086",
-			"revisionTime": "2017-02-03T23:56:24Z"
-		},
-		{
-			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
-			"origin": "github.com/docker/docker/vendor/github.com/docker/go-connections/sockets",
-			"path": "github.com/docker/go-connections/sockets",
-			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
-			"revisionTime": "2018-08-16T08:14:46Z"
-		},
-		{
-			"checksumSHA1": "zUG/J7nb6PWxfSXOoET6NePfyc0=",
-			"origin": "github.com/docker/docker/vendor/github.com/docker/go-connections/tlsconfig",
-			"path": "github.com/docker/go-connections/tlsconfig",
-			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
-			"revisionTime": "2018-08-16T08:14:46Z"
-		},
-		{
-			"checksumSHA1": "kHVt4M5Pfby2dhurp+hZJfQhzVU=",
-			"path": "github.com/docker/go-metrics",
-			"revision": "399ea8c73916000c64c2c76e8da00ca82f8387ab",
-			"revisionTime": "2018-02-09T01:25:29Z"
-		},
-		{
-			"checksumSHA1": "18hmvak2Dc9x5cgKeZ2iApviT7w=",
-			"comment": "v0.1.0-23-g5d2041e",
-			"path": "github.com/docker/go-units",
-			"revision": "5d2041e26a699eaca682e2ea41c8f891e1060444"
-		},
-		{
-			"checksumSHA1": "vcP3kQNGWKHenrvQxfu4FZkB468=",
-			"origin": "github.com/docker/docker/vendor/github.com/docker/libnetwork/ipamutils",
-			"path": "github.com/docker/libnetwork/ipamutils",
-			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
-			"revisionTime": "2018-08-16T08:14:46Z"
-		},
-		{
-			"checksumSHA1": "xteP9Px90oMrg/HZuqvZkpXCR+s=",
-			"path": "github.com/dustin/go-humanize",
-			"revision": "8929fe90cee4b2cb9deb468b51fb34eba64d1bf0"
-		},
-		{
-			"checksumSHA1": "7DxViusFRJ7UPH0jZqYatwDrOkY=",
-			"path": "github.com/elazarl/go-bindata-assetfs",
-			"revision": "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43",
-			"revisionTime": "2017-02-27T21:27:28Z"
-		},
-		{
-			"checksumSHA1": "VsE3zx2d8kpwj97TWhYddzAwBrY=",
-			"path": "github.com/fatih/color",
-			"revision": "507f6050b8568533fb3f5504de8e5205fa62a114",
-			"revisionTime": "2018-02-13T13:34:03Z"
-		},
-		{
-			"checksumSHA1": "QBkOnLnM6zZ158NJSVLqoE4V6fI=",
-			"path": "github.com/fatih/structs",
-			"revision": "14f46232cd7bc732dc67313a9e4d3d210e082587",
-			"revisionTime": "2016-07-19T20:45:16Z"
-		},
-		{
-			"checksumSHA1": "fvbo1J+cFWDrPDs0Yudwv+POIb4=",
-			"path": "github.com/fsouza/go-dockerclient",
-			"revision": "01c3e9bd8551d675a60382c0303ef51f5849ea99",
-			"revisionTime": "2018-11-29T02:57:25Z"
-		},
-		{
-			"checksumSHA1": "YJ7WR4AVtD2ykYJr+1mTtazkma0=",
-			"path": "github.com/fsouza/go-dockerclient/internal/archive",
-			"revision": "01c3e9bd8551d675a60382c0303ef51f5849ea99",
-			"revisionTime": "2018-11-29T02:57:25Z"
-		},
-		{
-			"checksumSHA1": "lnUC8fZCqakWnfuMLUrZD2g+reY=",
-			"path": "github.com/fsouza/go-dockerclient/internal/jsonmessage",
-			"revision": "01c3e9bd8551d675a60382c0303ef51f5849ea99",
-			"revisionTime": "2018-11-29T02:57:25Z"
-		},
-		{
-			"checksumSHA1": "vdjeVhnepWyw3H4g9pVTVACDfV0=",
-			"path": "github.com/fsouza/go-dockerclient/internal/term",
-			"revision": "01c3e9bd8551d675a60382c0303ef51f5849ea99",
-			"revisionTime": "2018-11-29T02:57:25Z"
-		},
-		{
-			"checksumSHA1": "U4k9IYSBQcW5DW5QDc44n5dddxs=",
-			"comment": "v1.8.5-2-g6ec4abd",
-			"path": "github.com/go-ini/ini",
-			"revision": "6ec4abd8f8d587536da56f730858f0e27aeb4126"
-		},
-		{
-			"checksumSHA1": "IvHj/4iR2nYa/S3cB2GXoyDG/xQ=",
-			"comment": "v1.2.0-4-g5005588",
-			"path": "github.com/go-ole/go-ole",
-			"revision": "085abb85892dc1949567b726dff00fa226c60c45",
-			"revisionTime": "2017-07-12T17:44:59Z"
-		},
-		{
-			"checksumSHA1": "qLYVTQDhgrVIeZ2KI9eZV51mmug=",
-			"comment": "v1.2.0-4-g5005588",
-			"path": "github.com/go-ole/go-ole/oleutil",
-			"revision": "50055884d646dd9434f16bbb5c9801749b9bafe4"
-		},
-		{
-			"checksumSHA1": "bFplS7sPkJNtlKKCIszFQkAsmGI=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/godbus/dbus",
-			"path": "github.com/godbus/dbus",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "I460dM/HmGE9DWimQvd1hJkYosU=",
-			"path": "github.com/gogo/protobuf/proto",
-			"revision": "616a82ed12d78d24d4839363e8f3c5d3f20627cf",
-			"revisionTime": "2017-11-09T18:15:19Z"
-		},
-		{
-			"checksumSHA1": "Pyou8mceOASSFxc7GeXZuVdSMi0=",
-			"path": "github.com/golang/protobuf/proto",
-			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-			"revisionTime": "2018-04-30T18:52:41Z",
-			"version": "v1",
-			"versionExact": "v1.1.0"
-		},
-		{
-			"checksumSHA1": "DA2cyOt1W92RTyXAqKQ4JWKGR8U=",
-			"path": "github.com/golang/protobuf/protoc-gen-go/descriptor",
-			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-			"revisionTime": "2018-04-30T18:52:41Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
-		},
-		{
-			"checksumSHA1": "/s0InJhSrxhTpqw5FIKgSMknCfM=",
-			"path": "github.com/golang/protobuf/ptypes",
-			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-			"revisionTime": "2018-04-30T18:52:41Z",
-			"version": "v1",
-			"versionExact": "v1.1.0"
-		},
-		{
-			"checksumSHA1": "3eqU9o+NMZSLM/coY5WDq7C1uKg=",
-			"path": "github.com/golang/protobuf/ptypes/any",
-			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-			"revisionTime": "2018-04-30T18:52:41Z",
-			"version": "v1",
-			"versionExact": "v1.1.0"
-		},
-		{
-			"checksumSHA1": "ZIF0rnVzNLluFPqUebtJrVonMr4=",
-			"path": "github.com/golang/protobuf/ptypes/duration",
-			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-			"revisionTime": "2018-04-30T18:52:41Z",
-			"version": "v1",
-			"versionExact": "v1.1.0"
-		},
-		{
-			"checksumSHA1": "7Az4Zl9T11I+xOfjgs/3/YMJ24I=",
-			"path": "github.com/golang/protobuf/ptypes/empty",
-			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-			"revisionTime": "2018-04-30T18:52:41Z"
-		},
-		{
-			"checksumSHA1": "1FJvuT0UllZaaS43kmPlx8oNiCs=",
-			"path": "github.com/golang/protobuf/ptypes/timestamp",
-			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-			"revisionTime": "2018-04-30T18:52:41Z",
-			"version": "v1",
-			"versionExact": "v1.1.0"
-		},
-		{
-			"checksumSHA1": "fs7UwFcU+SkJKA3eHcdhGsO4jrI=",
-			"path": "github.com/golang/protobuf/ptypes/wrappers",
-			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-			"revisionTime": "2018-04-30T18:52:41Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
-		},
-		{
-			"checksumSHA1": "W+E/2xXcE1GmJ0Qb784ald0Fn6I=",
-			"path": "github.com/golang/snappy",
-			"revision": "d9eb7a3d35ec988b8585d4a0068e462c27d28380",
-			"revisionTime": "2016-05-29T05:00:41Z"
-		},
-		{
-			"checksumSHA1": "cervgtZmEhshueHN64+ILdFHmEE=",
-			"path": "github.com/google/btree",
-			"revision": "4030bb1f1f0c35b30ca7009e9ebd06849dd45306",
-			"revisionTime": "2018-08-13T15:31:12Z"
-		},
-		{
-			"checksumSHA1": "+suAHHPBmbdZf/HusugaL4/H+NE=",
-			"path": "github.com/google/go-cmp/cmp",
-			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
-			"revisionTime": "2017-09-01T21:42:48Z"
-		},
-		{
-			"checksumSHA1": "VmBLfV9TChrjNu8Z96wZkYie1aI=",
-			"path": "github.com/google/go-cmp/cmp/cmpopts",
-			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
-			"revisionTime": "2017-09-01T21:42:48Z"
-		},
-		{
-			"checksumSHA1": "eTwchtMX+RMJUvle2wt295P2h10=",
-			"path": "github.com/google/go-cmp/cmp/internal/diff",
-			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
-			"revisionTime": "2017-09-01T21:42:48Z"
-		},
-		{
-			"checksumSHA1": "kYtvRhMjM0X4bvEjR3pqEHLw1qo=",
-			"path": "github.com/google/go-cmp/cmp/internal/function",
-			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
-			"revisionTime": "2017-09-01T21:42:48Z"
-		},
-		{
-			"checksumSHA1": "f+mgZLvc4VITtMmBv0bmew4rL2Y=",
-			"path": "github.com/google/go-cmp/cmp/internal/value",
-			"revision": "d5735f74713c51f7450a43d0a98d41ce2c1db3cb",
-			"revisionTime": "2017-09-01T21:42:48Z"
-		},
-		{
-			"checksumSHA1": "WZoHSeTnVjnPIX2+U1Otst5MUKw=",
-			"path": "github.com/googleapis/gax-go/v2",
-			"revision": "bd5b16380fd03dc758d11cef74ba2e3bc8b0e8c2",
-			"revisionTime": "2019-05-13T18:38:25Z"
-		},
-		{
-			"checksumSHA1": "m8B3L3qJ3tFfP6BI9pIFr9oal3w=",
-			"comment": "1.0.0",
-			"origin": "github.com/dadgar/cronexpr",
-			"path": "github.com/gorhill/cronexpr",
-			"revision": "675cac9b2d182dccb5ba8d5f8a0d5988df8a4394",
-			"revisionTime": "2017-09-15T18:30:32Z"
-		},
-		{
-			"checksumSHA1": "Nd/7mZb0T6Gj6+AymyOPsNCQSJs=",
-			"comment": "1.0.0",
-			"path": "github.com/gorhill/cronexpr/cronexpr",
-			"revision": "a557574d6c024ed6e36acc8b610f5f211c91568a"
-		},
-		{
-			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
-			"path": "github.com/gorilla/context",
-			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
-			"revisionTime": "2016-08-17T18:46:32Z"
-		},
-		{
-			"checksumSHA1": "STQSdSj2FcpCf0NLfdsKhNutQT0=",
-			"path": "github.com/gorilla/mux",
-			"revision": "e48e440e4c92e3251d812f8ce7858944dfa3331c",
-			"revisionTime": "2018-08-07T07:52:56Z"
-		},
-		{
-			"checksumSHA1": "gr0edNJuVv4+olNNZl5ZmwLgscA=",
-			"path": "github.com/gorilla/websocket",
-			"revision": "0ec3d1bd7fe50c503d6df98ee649d81f4857c564",
-			"revisionTime": "2019-03-06T00:42:57Z"
-		},
-		{
-			"checksumSHA1": "237KekVBW1eZohSDylZzT+/0NQI=",
-			"path": "github.com/hashicorp/consul-template",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "AhDPiKa7wzh3SE6Gx0WrsDYwBHg=",
-			"path": "github.com/hashicorp/consul-template/child",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "hjsBe5Qnn0DCttJkSNjy9mreW5Q=",
-			"path": "github.com/hashicorp/consul-template/config",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "S2ktxYTJRgmUE1GC5Bv+ZAmYWgE=",
-			"path": "github.com/hashicorp/consul-template/dependency",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "o5N7SV389Ej+3b1iRNmz1dx5e1M=",
-			"path": "github.com/hashicorp/consul-template/logging",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "Ozv8RPN8d//DoFpwR2mQ/xMWhcs=",
-			"path": "github.com/hashicorp/consul-template/manager",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "DUHtghMoLyrgPhv4lexVniBuWYk=",
-			"path": "github.com/hashicorp/consul-template/renderer",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "YSEUV/9/k85XciRKu0cngxdjZLE=",
-			"path": "github.com/hashicorp/consul-template/signals",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "mmM6LpEgkbLjobfgabon11mz40M=",
-			"path": "github.com/hashicorp/consul-template/template",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "eWyAvppME/4vsmaazcrf3oEbzGo=",
-			"path": "github.com/hashicorp/consul-template/version",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "cJxopvJKg7DBBb8tnDsfmBp5Q8I=",
-			"path": "github.com/hashicorp/consul-template/watch",
-			"revision": "9e45d493d7fffa8a61dd315b714c39d1103da051",
-			"revisionTime": "2019-08-12T18:34:47Z"
-		},
-		{
-			"checksumSHA1": "+I7fgoQlrnTUGW5krqNLadWwtjg=",
-			"path": "github.com/hashicorp/consul/agent/consul/autopilot",
-			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
-			"revisionTime": "2018-04-13T17:05:42Z"
-		},
-		{
-			"checksumSHA1": "7JPBtnIgLkdcJ0ldXMTEnVjNEjA=",
-			"path": "github.com/hashicorp/consul/api",
-			"revision": "40cec98468b829e5cdaacb0629b3e23a028db688",
-			"revisionTime": "2019-05-22T20:19:12Z"
-		},
-		{
-			"checksumSHA1": "soNN4xaHTbeXFgNkZ7cX0gbFXQk=",
-			"path": "github.com/hashicorp/consul/command/flags",
-			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
-			"revisionTime": "2018-04-13T17:05:42Z"
-		},
-		{
-			"checksumSHA1": "Nrh9BhiivRyJiuPzttstmq9xl/w=",
-			"path": "github.com/hashicorp/consul/lib",
-			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
-			"revisionTime": "2018-04-13T17:05:42Z"
-		},
-		{
-			"checksumSHA1": "E28E4zR1FN2v1Xiq4FUER7KVN9M=",
-			"path": "github.com/hashicorp/consul/lib/freeport",
-			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
-			"revisionTime": "2018-04-13T17:05:42Z"
-		},
-		{
-			"checksumSHA1": "5XjgqE4UIfwXvkq5VssGNc7uPhQ=",
-			"path": "github.com/hashicorp/consul/test/porter",
-			"revision": "ad9425ca6353b8afcfebd19130a8cf768f7eac30",
-			"revisionTime": "2017-10-21T00:05:25Z"
-		},
-		{
-			"checksumSHA1": "T4CeQD+QRsjf1BJ1n7FSojS5zDQ=",
-			"path": "github.com/hashicorp/consul/testutil",
-			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
-			"revisionTime": "2018-04-13T17:05:42Z"
-		},
-		{
-			"checksumSHA1": "SCb2b91UYiB/23+SNDBlU5OZfFA=",
-			"path": "github.com/hashicorp/consul/testutil/retry",
-			"revision": "fb848fc48818f58690db09d14640513aa6bf3c02",
-			"revisionTime": "2018-04-13T17:05:42Z"
-		},
-		{
-			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",
-			"path": "github.com/hashicorp/errwrap",
-			"revision": "7554cd9344cec97297fa6649b055a8c98c2a1e55"
-		},
-		{
-			"checksumSHA1": "D267IUMW2rcb+vNe3QU+xhfSrgY=",
-			"path": "github.com/hashicorp/go-checkpoint",
-			"revision": "1545e56e46dec3bba264e41fde2c1e2aa65b5dd4",
-			"revisionTime": "2017-10-09T17:35:28Z"
-		},
-		{
-			"checksumSHA1": "6ihdHMkDfFx/rJ1A36com2F6bQk=",
-			"path": "github.com/hashicorp/go-cleanhttp",
-			"revision": "a45970658e51fea2c41445ff0f7e07106d007617",
-			"revisionTime": "2017-02-11T00:33:01Z"
-		},
-		{
-			"checksumSHA1": "CnY2iYK47tGA9wsFMfH04PpmSoI=",
-			"path": "github.com/hashicorp/go-discover",
-			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
-			"revisionTime": "2018-05-03T15:30:45Z"
-		},
-		{
-			"checksumSHA1": "ZmU/47XUGUQpFP6E8T6Tl8QKszI=",
-			"path": "github.com/hashicorp/go-discover/provider/aliyun",
-			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
-			"revisionTime": "2018-05-03T15:30:45Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "Vit45xRjrJ6h7IGJndrBjodVUAE=",
-			"path": "github.com/hashicorp/go-discover/provider/aws",
-			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
-			"revisionTime": "2018-05-03T15:30:45Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "dMU80T10KQFZNqpBBjzf7ymFNBw=",
-			"path": "github.com/hashicorp/go-discover/provider/azure",
-			"revision": "266744fed5f15e5d4488269b2c29b66e25783f6f",
-			"revisionTime": "2018-05-21T21:57:50Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "qoy/euk2dwrONYMUsaAPznHHpxQ=",
-			"path": "github.com/hashicorp/go-discover/provider/digitalocean",
-			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
-			"revisionTime": "2018-05-03T15:30:45Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "tnKls5vtzpNQAj7b987N4i81HvY=",
-			"path": "github.com/hashicorp/go-discover/provider/gce",
-			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
-			"revisionTime": "2018-05-03T15:30:45Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "LZwn9B00AjulYRCKapmJWFAamoo=",
-			"path": "github.com/hashicorp/go-discover/provider/os",
-			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
-			"revisionTime": "2018-05-03T15:30:45Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "GQ/3AvzdX6T0rtEFeGNYhwt17Zs=",
-			"path": "github.com/hashicorp/go-discover/provider/scaleway",
-			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
-			"revisionTime": "2018-05-03T15:30:45Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "SIyZ44AHIUTBfI336ACpCeybsLg=",
-			"path": "github.com/hashicorp/go-discover/provider/softlayer",
-			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
-			"revisionTime": "2018-05-03T15:30:45Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "n2iQu2IbTPw2XpWF2CqBrFSMjwI=",
-			"path": "github.com/hashicorp/go-discover/provider/triton",
-			"revision": "40ccfdee6c0d7136f98f2b54882b86aaf0250d2f",
-			"revisionTime": "2018-05-03T15:30:45Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "FKmqR4DC3nCXtnT9pe02z5CLNWo=",
-			"path": "github.com/hashicorp/go-envparse",
-			"revision": "310ca1881b22af3522e3a8638c0b426629886196",
-			"revisionTime": "2018-01-19T21:58:41Z"
-		},
-		{
-			"checksumSHA1": "d4brua17AGQqMNtngK4xKOUwboY=",
-			"path": "github.com/hashicorp/go-getter",
-			"revision": "f5101da0117392c6e7960c934f05a2fd689a5b5f",
-			"revisionTime": "2019-08-22T19:45:07Z"
-		},
-		{
-			"checksumSHA1": "9J+kDr29yDrwsdu2ULzewmqGjpA=",
-			"path": "github.com/hashicorp/go-getter/helper/url",
-			"revision": "b345bfcec894fb7ff3fdf9b21baf2f56ea423d98",
-			"revisionTime": "2018-04-10T17:49:45Z"
-		},
-		{
-			"checksumSHA1": "dOP7kCX3dACHc9mU79826N411QA=",
-			"path": "github.com/hashicorp/go-hclog",
-			"revision": "ff2cf002a8dd750586d91dddd4470c341f981fe1",
-			"revisionTime": "2018-07-09T16:53:50Z"
-		},
-		{
-			"checksumSHA1": "Cas2nprG6pWzf05A2F/OlnjUu2Y=",
-			"path": "github.com/hashicorp/go-immutable-radix",
-			"revision": "8aac2701530899b64bdea735a1de8da899815220",
-			"revisionTime": "2017-07-25T22:12:15Z"
-		},
-		{
-			"checksumSHA1": "FMAvwDar2bQyYAW4XMFhAt0J5xA=",
-			"path": "github.com/hashicorp/go-memdb",
-			"revision": "20ff6434c1cc49b80963d45bf5c6aa89c78d8d57",
-			"revisionTime": "2017-08-31T20:15:40Z"
-		},
-		{
-			"checksumSHA1": "LrGV93iKiRWNSxItKr6Os6zC1T8=",
-			"origin": "github.com/ugorji/go/codec",
-			"path": "github.com/hashicorp/go-msgpack/codec",
-			"revision": "08f7b401aef15f3d544472dd46bf6788cdfe55bf",
-			"revisionTime": "2019-05-07T20:14:01Z"
-		},
-		{
-			"checksumSHA1": "lrSl49G23l6NhfilxPM0XFs5rZo=",
-			"path": "github.com/hashicorp/go-multierror",
-			"revision": "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
-		},
-		{
-			"checksumSHA1": "IFwYSAmxxM+fV0w9LwdWKqFOCgg=",
-			"path": "github.com/hashicorp/go-plugin",
-			"revision": "f444068e8f5a19853177f7aa0aea7e7d95b5b528",
-			"revisionTime": "2018-12-12T15:08:38Z"
-		},
-		{
-			"checksumSHA1": "Ikbb1FngsPR79bHhr2UmKk4CblI=",
-			"path": "github.com/hashicorp/go-plugin/internal/proto",
-			"revision": "f444068e8f5a19853177f7aa0aea7e7d95b5b528",
-			"revisionTime": "2018-12-12T15:08:38Z"
-		},
-		{
-			"checksumSHA1": "9SqwC2BzFbsWulQuBG2+QEliTpo=",
-			"path": "github.com/hashicorp/go-retryablehttp",
-			"revision": "73489d0a1476f0c9e6fb03f9c39241523a496dfd",
-			"revisionTime": "2019-01-26T20:33:39Z"
-		},
-		{
-			"checksumSHA1": "A1PcINvF3UiwHRKn8UcgARgvGRs=",
-			"path": "github.com/hashicorp/go-rootcerts",
-			"revision": "6bb64b370b90e7ef1fa532be9e591a81c3493e00",
-			"revisionTime": "2016-05-03T14:34:40Z"
-		},
-		{
-			"checksumSHA1": "CduvzBFfTv77nhjtXPGdIjQQLMI=",
-			"path": "github.com/hashicorp/go-safetemp",
-			"revision": "b1a1dbde6fdc11e3ae79efd9039009e22d4ae240",
-			"revisionTime": "2018-03-26T21:11:50Z"
-		},
-		{
-			"checksumSHA1": "J47ySO1q0gcnmoMnir1q1loKzCk=",
-			"path": "github.com/hashicorp/go-sockaddr",
-			"revision": "6d291a969b86c4b633730bfc6b8b9d64c3aafed9",
-			"revisionTime": "2018-03-20T11:50:54Z"
-		},
-		{
-			"checksumSHA1": "PDp9DVLvf3KWxhs4G4DpIwauMSU=",
-			"path": "github.com/hashicorp/go-sockaddr/template",
-			"revision": "6d291a969b86c4b633730bfc6b8b9d64c3aafed9",
-			"revisionTime": "2018-03-20T11:50:54Z"
-		},
-		{
-			"checksumSHA1": "eEqQGKsFOdSAwEprYgYnL7+J2e0=",
-			"path": "github.com/hashicorp/go-syslog",
-			"revision": "8d1874e3e8d1862b74e0536851e218c4571066a5",
-			"revisionTime": "2019-01-18T15:19:36Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
-		},
-		{
-			"checksumSHA1": "5AxXPtBqAKyFGcttFzxT5hp/3Tk=",
-			"path": "github.com/hashicorp/go-uuid",
-			"revision": "4f571afc59f3043a65f8fe6bf46d887b10a01d43",
-			"revisionTime": "2018-11-28T13:14:45Z"
-		},
-		{
-			"checksumSHA1": "r0pj5dMHCghpaQZ3f1BRGoKiSWw=",
-			"path": "github.com/hashicorp/go-version",
-			"revision": "b5a281d3160aa11950a6182bd9a9dc2cb1e02d50",
-			"revisionTime": "2018-08-24T00:43:55Z"
-		},
-		{
-			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
-			"path": "github.com/hashicorp/golang-lru",
-			"revision": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4",
-			"revisionTime": "2016-02-07T21:47:19Z"
-		},
-		{
-			"checksumSHA1": "2nOpYjx8Sn57bqlZq17yM4YJuM4=",
-			"path": "github.com/hashicorp/golang-lru/simplelru",
-			"revision": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
-		},
-		{
-			"checksumSHA1": "vgGv8zuy7q8c5LBAFO1fnnQRRgE=",
-			"path": "github.com/hashicorp/hcl",
-			"revision": "1804807358d86424faacbb42f50f0c04303cef11",
-			"revisionTime": "2019-06-10T16:16:27Z"
-		},
-		{
-			"checksumSHA1": "XQmjDva9JCGGkIecOgwtBEMCJhU=",
-			"path": "github.com/hashicorp/hcl/hcl/ast",
-			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
-			"revisionTime": "2016-11-01T18:00:25Z"
-		},
-		{
-			"checksumSHA1": "croNloscHsjX87X+4/cKOURf1EY=",
-			"path": "github.com/hashicorp/hcl/hcl/parser",
-			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
-			"revisionTime": "2016-11-01T18:00:25Z"
-		},
-		{
-			"checksumSHA1": "lgR7PSAZ0RtvAc9OCtCnNsF/x8g=",
-			"path": "github.com/hashicorp/hcl/hcl/scanner",
-			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
-			"revisionTime": "2016-11-01T18:00:25Z"
-		},
-		{
-			"checksumSHA1": "JlZmnzqdmFFyb1+2afLyR3BOE/8=",
-			"path": "github.com/hashicorp/hcl/hcl/strconv",
-			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
-			"revisionTime": "2016-11-01T18:00:25Z"
-		},
-		{
-			"checksumSHA1": "c6yprzj06ASwCo18TtbbNNBHljA=",
-			"path": "github.com/hashicorp/hcl/hcl/token",
-			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
-			"revisionTime": "2016-11-01T18:00:25Z"
-		},
-		{
-			"checksumSHA1": "138aCV5n8n7tkGYMsMVQQnnLq+0=",
-			"path": "github.com/hashicorp/hcl/json/parser",
-			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
-			"revisionTime": "2016-11-01T18:00:25Z"
-		},
-		{
-			"checksumSHA1": "YdvFsNOMSWMLnY6fcliWQa0O5Fw=",
-			"path": "github.com/hashicorp/hcl/json/scanner",
-			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
-			"revisionTime": "2016-11-01T18:00:25Z"
-		},
-		{
-			"checksumSHA1": "fNlXQCQEnb+B3k5UDL/r15xtSJY=",
-			"path": "github.com/hashicorp/hcl/json/token",
-			"revision": "6e968a3fcdcbab092f5307fd0d85479d5af1e4dc",
-			"revisionTime": "2016-11-01T18:00:25Z"
-		},
-		{
-			"checksumSHA1": "RFEjfMQWPAVILXE2PhL6wDW8Zg4=",
-			"path": "github.com/hashicorp/hcl2/gohcl",
-			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
-			"revisionTime": "2019-06-17T16:00:22Z",
-			"version": "master",
-			"versionExact": "master"
-		},
-		{
-			"checksumSHA1": "1jDEGh+P7Cu8Lz39VudY6rRS6Jw=",
-			"path": "github.com/hashicorp/hcl2/hcl",
-			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
-			"revisionTime": "2019-06-17T16:00:22Z",
-			"version": "master",
-			"versionExact": "master"
-		},
-		{
-			"checksumSHA1": "6FZRBZj+je9sMM5wrhM5phUXxZU=",
-			"path": "github.com/hashicorp/hcl2/hcl/hclsyntax",
-			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
-			"revisionTime": "2019-06-17T16:00:22Z",
-			"version": "master",
-			"versionExact": "master"
-		},
-		{
-			"checksumSHA1": "l5KBeDDM1gf7yFth7WGhckpF+oc=",
-			"path": "github.com/hashicorp/hcl2/hcl/json",
-			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
-			"revisionTime": "2019-06-17T16:00:22Z",
-			"version": "master",
-			"versionExact": "master"
-		},
-		{
-			"checksumSHA1": "6JRj4T/iQxIe/CoKXHDjPuupmL8=",
-			"path": "github.com/hashicorp/hcl2/hcldec",
-			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
-			"revisionTime": "2019-06-17T16:00:22Z",
-			"version": "master",
-			"versionExact": "master"
-		},
-		{
-			"checksumSHA1": "Hgs10IsC8LdotUKLavgOL35Mbw4=",
-			"path": "github.com/hashicorp/hcl2/hclwrite",
-			"revision": "4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52",
-			"revisionTime": "2019-06-17T16:00:22Z",
-			"version": "master",
-			"versionExact": "master"
-		},
-		{
-			"checksumSHA1": "vt+P9D2yWDO3gdvdgCzwqunlhxU=",
-			"path": "github.com/hashicorp/logutils",
-			"revision": "0dc08b1671f34c4250ce212759ebd880f743d883"
-		},
-		{
-			"checksumSHA1": "yAu2gPVXIh28yJ2If5gZPrf04kU=",
-			"path": "github.com/hashicorp/memberlist",
-			"revision": "1a62499c21db33d57691001d5e08a71ec857b18f",
-			"revisionTime": "2019-01-03T22:22:36Z"
-		},
-		{
-			"checksumSHA1": "qnlqWJYV81ENr61SZk9c65R1mDo=",
-			"path": "github.com/hashicorp/net-rpc-msgpackrpc",
-			"revision": "a14192a58a694c123d8fe5481d4a4727d6ae82f3"
-		},
-		{
-			"checksumSHA1": "ujL3Sc5iqc28/En2ndmc2R7oUQM=",
-			"path": "github.com/hashicorp/raft",
-			"revision": "9c733b2b7f53115c5ef261a90ce912a1bb49e970",
-			"revisionTime": "2019-01-04T13:37:20Z"
-		},
-		{
-			"checksumSHA1": "QAxukkv54/iIvLfsUP6IK4R0m/A=",
-			"path": "github.com/hashicorp/raft-boltdb",
-			"revision": "d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee",
-			"revisionTime": "2015-02-01T20:08:39Z"
-		},
-		{
-			"checksumSHA1": "9omt7lEuhBNSdgT32ThEzXn/aTU=",
-			"path": "github.com/hashicorp/serf",
-			"revision": "c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2",
-			"revisionTime": "2019-01-04T15:39:47Z"
-		},
-		{
-			"checksumSHA1": "0PeWsO2aI+2PgVYlYlDPKfzCLEQ=",
-			"path": "github.com/hashicorp/serf/coordinate",
-			"revision": "c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2",
-			"revisionTime": "2019-01-04T15:39:47Z"
-		},
-		{
-			"checksumSHA1": "siLn7zwVHQk070rpd99BTktGfTs=",
-			"path": "github.com/hashicorp/serf/serf",
-			"revision": "c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2",
-			"revisionTime": "2019-01-04T15:39:47Z"
-		},
-		{
-			"checksumSHA1": "laYVVZeqao4WdIS/MKd0be7Z3yA=",
-			"path": "github.com/hashicorp/vault/api",
-			"revision": "85909e3373aa743c34a6a0ab59131f61fd9e8e43",
-			"revisionTime": "2019-02-12T14:05:52Z"
-		},
-		{
-			"checksumSHA1": "bSdPFOHaTwEvM4PIvn0PZfn75jM=",
-			"path": "github.com/hashicorp/vault/helper/compressutil",
-			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
-			"revisionTime": "2018-09-06T17:45:45Z"
-		},
-		{
-			"checksumSHA1": "3mRK/pBPUH8rIPrILmuJWynWQVo=",
-			"path": "github.com/hashicorp/vault/helper/consts",
-			"revision": "85909e3373aa743c34a6a0ab59131f61fd9e8e43",
-			"revisionTime": "2019-02-12T14:05:52Z"
-		},
-		{
-			"checksumSHA1": "RlqPBLOexQ0jj6jomhiompWKaUg=",
-			"path": "github.com/hashicorp/vault/helper/hclutil",
-			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
-			"revisionTime": "2018-09-06T17:45:45Z"
-		},
-		{
-			"checksumSHA1": "POgkM3GrjRFw6H3sw95YNEs552A=",
-			"path": "github.com/hashicorp/vault/helper/jsonutil",
-			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
-			"revisionTime": "2018-09-06T17:45:45Z"
-		},
-		{
-			"checksumSHA1": "HA2MV/2XI0HcoThSRxQCaBZR2ps=",
-			"path": "github.com/hashicorp/vault/helper/parseutil",
-			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
-			"revisionTime": "2018-09-06T17:45:45Z"
-		},
-		{
-			"checksumSHA1": "HdVuYhZ5TuxeIFqi0jy2GHW7a4o=",
-			"path": "github.com/hashicorp/vault/helper/strutil",
-			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
-			"revisionTime": "2018-09-06T17:45:45Z"
-		},
-		{
-			"checksumSHA1": "m9OKUPd/iliwKxs+LCSmAGpDJOs=",
-			"path": "github.com/hashicorp/yamux",
-			"revision": "7221087c3d281fda5f794e28c2ea4c6e4d5c4558",
-			"revisionTime": "2018-09-17T20:50:41Z"
-		},
-		{
-			"checksumSHA1": "0xM336Lb25URO/1W1/CtGoRygVU=",
-			"path": "github.com/hpcloud/tail/util",
-			"revision": "37f4271387456dd1bf82ab1ad9229f060cc45386",
-			"revisionTime": "2017-08-14T16:06:53Z"
-		},
-		{
-			"checksumSHA1": "TP4OAv5JMtzj2TB6OQBKqauaKDc=",
-			"path": "github.com/hpcloud/tail/watch",
-			"revision": "37f4271387456dd1bf82ab1ad9229f060cc45386",
-			"revisionTime": "2017-08-14T16:06:53Z"
-		},
-		{
-			"checksumSHA1": "3/Bhy+ua/DCv2ElMD5GzOYSGN6g=",
-			"comment": "0.2.2-2-gc01cf91",
-			"path": "github.com/jmespath/go-jmespath",
-			"revision": "c01cf91b011868172fdcd9f41838e80c9d716264"
-		},
-		{
-			"checksumSHA1": "Aulh7C5SVOA4Jzt5eHNH6197Mbk=",
-			"path": "github.com/konsorten/go-windows-terminal-sequences",
-			"revision": "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e",
-			"revisionTime": "2019-02-26T22:47:05Z"
-		},
-		{
-			"checksumSHA1": "eOXF2PEvYLMeD8DSzLZJWbjYzco=",
-			"path": "github.com/kr/pretty",
-			"revision": "cfb55aafdaf3ec08f0db22699ab822c50091b1c4",
-			"revisionTime": "2016-08-23T17:07:15Z"
-		},
-		{
-			"checksumSHA1": "WD7GMln/NoduJr0DbumjOE59xI8=",
-			"path": "github.com/kr/pty",
-			"revision": "b6e1bdd4a4f88614e0c6e5e8089c7abed98aae17",
-			"revisionTime": "2019-04-01T03:15:51Z"
-		},
-		{
-			"checksumSHA1": "uulQHQ7IsRKqDudBC8Go9J0gtAc=",
-			"path": "github.com/kr/text",
-			"revision": "7cafcd837844e784b526369c9bce262804aebc60",
-			"revisionTime": "2016-05-04T02:26:26Z"
-		},
-		{
-			"checksumSHA1": "SEnjvwVyfuU2xBaOfXfwPD5MZqk=",
-			"path": "github.com/mattn/go-colorable",
-			"revision": "efa589957cd060542a26d2dd7832fd6a6c6c3ade",
-			"revisionTime": "2018-03-10T13:32:14Z"
-		},
-		{
-			"checksumSHA1": "AZO2VGorXTMDiSVUih3k73vORHY=",
-			"path": "github.com/mattn/go-isatty",
-			"revision": "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c",
-			"revisionTime": "2017-11-07T05:05:31Z"
-		},
-		{
-			"checksumSHA1": "ajImwVZHzsI+aNwsgzCSFSbmJqs=",
-			"path": "github.com/mattn/go-shellwords",
-			"revision": "f4e566c536cf69158e808ec28ef4182a37fdc981",
-			"revisionTime": "2015-03-21T17:42:21Z"
-		},
-		{
-			"checksumSHA1": "bKMZjd2wPw13VwoE7mBeSv5djFA=",
-			"path": "github.com/matttproud/golang_protobuf_extensions/pbutil",
-			"revision": "c12348ce28de40eed0136aa2b644d0ee0650e56c",
-			"revisionTime": "2016-04-24T11:30:07Z"
-		},
-		{
-			"checksumSHA1": "7C76urB5PLSeqMeydxiUGjX5xMI=",
-			"path": "github.com/miekg/dns",
-			"revision": "7e024ce8ce18b21b475ac6baf8fa3c42536bf2fa"
-		},
-		{
-			"checksumSHA1": "+o0siVvR8q36mKCpT5F/Sn2T7xo=",
-			"path": "github.com/mitchellh/cli",
-			"revision": "c54c85e9bd492bdba226ffdda55d4e293b79f8e8",
-			"revisionTime": "2018-04-06T01:10:36Z"
-		},
-		{
-			"checksumSHA1": "ttEN1Aupb7xpPMkQLqb3tzLFdXs=",
-			"path": "github.com/mitchellh/colorstring",
-			"revision": "8631ce90f28644f54aeedcb3e389a85174e067d1",
-			"revisionTime": "2015-09-17T21:48:07Z"
-		},
-		{
-			"checksumSHA1": "+p4JY4wmFQAppCdlrJ8Kxybmht8=",
-			"path": "github.com/mitchellh/copystructure",
-			"revision": "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f",
-			"revisionTime": "2017-05-25T01:39:02Z"
-		},
-		{
-			"checksumSHA1": "AXacfEchaUqT5RGmPmMXsOWRhv8=",
-			"path": "github.com/mitchellh/go-homedir",
-			"revision": "756f7b183b7ab78acdbbee5c7f392838ed459dda",
-			"revisionTime": "2016-06-21T17:42:43Z"
-		},
-		{
-			"checksumSHA1": "DcYIZnMiq/Tj22/ge9os3NwOhs4=",
-			"path": "github.com/mitchellh/go-ps",
-			"revision": "4fdf99ab29366514c69ccccddab5dc58b8d84062",
-			"revisionTime": "2017-03-09T13:30:38Z"
-		},
-		{
-			"checksumSHA1": "bDdhmDk8q6utWrccBhEOa6IoGkE=",
-			"path": "github.com/mitchellh/go-testing-interface",
-			"revision": "a61a99592b77c9ba629d254a693acffaeb4b7e28",
-			"revisionTime": "2017-10-04T22:19:16Z"
-		},
-		{
-			"checksumSHA1": "L3leymg2RT8hFl5uL+5KP/LpBkg=",
-			"path": "github.com/mitchellh/go-wordwrap",
-			"revision": "ad45545899c7b13c020ea92b2072220eefad42b8",
-			"revisionTime": "2015-03-14T17:03:34Z"
-		},
-		{
-			"checksumSHA1": "Z3FoiV93oUfDoQYMMiHxWCQPlBw=",
-			"path": "github.com/mitchellh/hashstructure",
-			"revision": "1ef5c71b025aef149d12346356ac5973992860bc"
-		},
-		{
-			"checksumSHA1": "4Js6Jlu93Wa0o6Kjt393L9Z7diE=",
-			"path": "github.com/mitchellh/mapstructure",
-			"revision": "281073eb9eb092240d33ef253c404f1cca550309"
-		},
-		{
-			"checksumSHA1": "KqsMqI+Y+3EFYPhyzafpIneaVCM=",
-			"path": "github.com/mitchellh/reflectwalk",
-			"revision": "8d802ff4ae93611b807597f639c19f76074df5c6",
-			"revisionTime": "2017-05-08T17:38:06Z"
-		},
-		{
-			"checksumSHA1": "FoDTHct8ocl470GYc0i+JRWfrys=",
-			"path": "github.com/moby/moby/daemon/caps",
-			"revision": "39377bb96d459d2ef59bd2bad75468638a7f86a3",
-			"revisionTime": "2018-01-18T19:02:33Z"
-		},
-		{
-			"checksumSHA1": "EKGlMEHq/nwBXQGi9JN/y+H7YMU=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/mrunalp/fileutils",
-			"path": "github.com/mrunalp/fileutils",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "nf3UoPNBIut7BL9nWE8Fw2X2j+Q=",
-			"path": "github.com/oklog/run",
-			"revision": "6934b124db28979da51d3470dadfa34d73d72652",
-			"revisionTime": "2018-03-08T00:51:04Z"
-		},
-		{
-			"checksumSHA1": "cwbidLG1ET7YSqlwca+nSfYxIbg=",
-			"path": "github.com/onsi/ginkgo",
-			"revision": "ba8e856bb854d6771a72ddf6497a42dad3a0c971",
-			"revisionTime": "2018-03-12T10:34:14Z"
-		},
-		{
-			"checksumSHA1": "Tarhbqac6rFsGPugPoQ4lyhfc7Q=",
-			"path": "github.com/onsi/ginkgo/config",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "euz7sKjXGezoMq6P5qC/day/mZo=",
-			"path": "github.com/onsi/ginkgo/ginkgo",
-			"revision": "ba8e856bb854d6771a72ddf6497a42dad3a0c971",
-			"revisionTime": "2018-03-12T10:34:14Z"
-		},
-		{
-			"checksumSHA1": "RX2QA4mqBzsogy4OWOCi9mUfAGU=",
-			"path": "github.com/onsi/ginkgo/ginkgo/convert",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "jvjomLV3JcWQ1qa1ZfmvB4/62YI=",
-			"path": "github.com/onsi/ginkgo/ginkgo/interrupthandler",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "brZ63GMMr79P/RwClxFRBKMtICg=",
-			"path": "github.com/onsi/ginkgo/ginkgo/nodot",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "qSXx1svgCAAqk+ICAWL1AXdSJmA=",
-			"path": "github.com/onsi/ginkgo/ginkgo/testrunner",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "x2Fa0rbgpXQaVc6f10KTRchiF7E=",
-			"path": "github.com/onsi/ginkgo/ginkgo/testsuite",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "yT4efdDV3bfosM49kBvQg3PjcMA=",
-			"path": "github.com/onsi/ginkgo/ginkgo/watch",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "T1cZh3UWr4Hnx6fQYp+7KDNvxG4=",
-			"path": "github.com/onsi/ginkgo/internal/codelocation",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "qvz6/+otRkWa1OHaPMKap9D5Ge4=",
-			"path": "github.com/onsi/ginkgo/internal/containernode",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "882oWW4FC4Nrd8mrMptsDJSTDds=",
-			"path": "github.com/onsi/ginkgo/internal/failer",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "IbQFETl8AqMhJ74XP+us5Xk3dS8=",
-			"path": "github.com/onsi/ginkgo/internal/leafnodes",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "Z9mfsBI9VL7QqwY+doKRhumHIh4=",
-			"path": "github.com/onsi/ginkgo/internal/remote",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "msseWG4Ewk2/V35NKaRokjXPCQs=",
-			"path": "github.com/onsi/ginkgo/internal/spec",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "14UQiFkhUmN5vTG+pNApv5OYgoU=",
-			"path": "github.com/onsi/ginkgo/internal/spec_iterator",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "pDxDXIJ3QPm5UMnzQ+3GedK8WjQ=",
-			"path": "github.com/onsi/ginkgo/internal/specrunner",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "QZ9ekcsrGBcXz4Tv+L7kXAUfqq8=",
-			"path": "github.com/onsi/ginkgo/internal/suite",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "TUBH2aNaARtAZ5vz51xMFRsOOo0=",
-			"path": "github.com/onsi/ginkgo/internal/testingtproxy",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "BB83CfNg6jFoFNMuXFL+f4EOFpw=",
-			"path": "github.com/onsi/ginkgo/internal/writer",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "m6/gIgdQGdETzUN3JWhAmFNIuNI=",
-			"path": "github.com/onsi/ginkgo/reporters",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "hdfc3dPx9Jw8v+sd7TEDlboJ1Nc=",
-			"path": "github.com/onsi/ginkgo/reporters/stenographer",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "QeB8m9WhRUiL0YKj3n5L0t4mLCg=",
-			"path": "github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "4Vn7/7UJmbclxDrV8YKbYOUh65g=",
-			"path": "github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "kuzrRJpxmnbuG7VVDIfDcLIRKLU=",
-			"path": "github.com/onsi/ginkgo/types",
-			"revision": "9008c7b79f9636c46a0a945141020124702f0ecf",
-			"revisionTime": "2018-02-16T17:00:43Z"
-		},
-		{
-			"checksumSHA1": "WQwGlRQksUlZ4HMiYZWR4wE4Suo=",
-			"path": "github.com/onsi/gomega",
-			"revision": "de89e61d40b75aa971a9fc3eae7f4fefabd6e0ee",
-			"revisionTime": "2018-03-05T20:37:22Z"
-		},
-		{
-			"checksumSHA1": "W/l0TJN86WNCAZPm1MPSlqxxWYM=",
-			"path": "github.com/onsi/gomega/format",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "H4RBR9kcEWh2lECAzBaOTSvgUuA=",
-			"path": "github.com/onsi/gomega/internal/assertion",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "N7HhJzMN+STfzI315keM9SxFQAE=",
-			"path": "github.com/onsi/gomega/internal/asyncassertion",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "EsgeBqN2S5wj8aWvGsS162ZK7xI=",
-			"path": "github.com/onsi/gomega/internal/oraclematcher",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "M2WqXho4fZaeYkyfuiGTlPhcU8I=",
-			"path": "github.com/onsi/gomega/internal/testingtsupport",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "D7QESRc8hYaX8wHT0ftzvNTMwuk=",
-			"path": "github.com/onsi/gomega/matchers",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "NMjCfnHie2dgQw0kCObrHRc8S50=",
-			"path": "github.com/onsi/gomega/matchers/support/goraph/bipartitegraph",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "zjTC6ady0bJUwzTFAKtv63T7Fmg=",
-			"path": "github.com/onsi/gomega/matchers/support/goraph/edge",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "o2+IscLOPKOiovl2g0/igkD1R4Q=",
-			"path": "github.com/onsi/gomega/matchers/support/goraph/node",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "yEF1BYQPwS3neYFKiqNQReqnadY=",
-			"path": "github.com/onsi/gomega/matchers/support/goraph/util",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "mGI31MBiT3PJ8sgoB/E7NQ+4dJA=",
-			"path": "github.com/onsi/gomega/types",
-			"revision": "6e33911c8481405188b3791f916ac125a6a404b4",
-			"revisionTime": "2018-03-02T08:44:13Z"
-		},
-		{
-			"checksumSHA1": "NTperEHVh1uBqfTy9+oKceN4tKI=",
-			"path": "github.com/opencontainers/go-digest",
-			"revision": "21dfd564fd89c944783d00d069f33e3e7123c448",
-			"revisionTime": "2017-01-11T18:16:59Z"
-		},
-		{
-			"checksumSHA1": "ZGlIwSRjdLYCUII7JLE++N4w7Xc=",
-			"path": "github.com/opencontainers/image-spec/specs-go",
-			"revision": "89b51c794e9113108a2914e38e66c826a649f2b5",
-			"revisionTime": "2017-11-03T11:36:04Z"
-		},
-		{
-			"checksumSHA1": "jdbXRRzeu0njLE9/nCEZG+Yg/Jk=",
-			"path": "github.com/opencontainers/image-spec/specs-go/v1",
-			"revision": "89b51c794e9113108a2914e38e66c826a649f2b5",
-			"revisionTime": "2017-11-03T11:36:04Z"
-		},
-		{
-			"checksumSHA1": "OJlgvnpJuV+SDPW48YVUKWDbOnU=",
-			"path": "github.com/opencontainers/runc/libcontainer",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "gVVY8k2G3ws+V1czsfxfuRs8log=",
-			"path": "github.com/opencontainers/runc/libcontainer/apparmor",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "aWtm1zkVCz9l2/zQNfnc246yQew=",
-			"path": "github.com/opencontainers/runc/libcontainer/cgroups",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "OnnBJ2WfB/Y9EQpABKetBedf6ts=",
-			"path": "github.com/opencontainers/runc/libcontainer/cgroups/fs",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "d7B9MiKb1k1Egh5qkNokIfcZ+OY=",
-			"path": "github.com/opencontainers/runc/libcontainer/cgroups/systemd",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "v9sgw4eYRNSsJUSG33OoFIwLqRI=",
-			"path": "github.com/opencontainers/runc/libcontainer/configs",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "hUveFGK1HhGenf0OVoYZWccoW9I=",
-			"path": "github.com/opencontainers/runc/libcontainer/configs/validate",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "n7G7Egz/tOPacXuq+nkvnFai3eU=",
-			"path": "github.com/opencontainers/runc/libcontainer/criurpc",
-			"revision": "369b920277d27630441336775cd728bc0f19e496",
-			"revisionTime": "2018-09-07T18:53:11Z"
-		},
-		{
-			"checksumSHA1": "2CwtFvz9kB0RSjFlcCkmq4taJ9U=",
-			"path": "github.com/opencontainers/runc/libcontainer/devices",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "sAbowQ7hjveSH5ADUD9IYXnEAJM=",
-			"path": "github.com/opencontainers/runc/libcontainer/intelrdt",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "mKxBw0il2IWjWYgksX+17ufDw34=",
-			"path": "github.com/opencontainers/runc/libcontainer/keys",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "mBbwlspKSImoGTw4uKE40AX3PYs=",
-			"path": "github.com/opencontainers/runc/libcontainer/logs",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "MJiogPDUU2nFr1fzQU6T+Ry1W8o=",
-			"path": "github.com/opencontainers/runc/libcontainer/mount",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "PnGFQdbZhZ4pcxFtQep5MEQ4/8E=",
-			"path": "github.com/opencontainers/runc/libcontainer/nsenter",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "I1Qw/btE1twMqKHpYNsC98cteak=",
-			"path": "github.com/opencontainers/runc/libcontainer/seccomp",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "yp/kYBgVqKtxlnpq4CmyxLFMAE4=",
-			"path": "github.com/opencontainers/runc/libcontainer/stacktrace",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "cjg/UcueM1/2/ExZ3N7010sa+hI=",
-			"path": "github.com/opencontainers/runc/libcontainer/system",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "mdUukOXCVJxmT0CufSKDeMg5JFM=",
-			"path": "github.com/opencontainers/runc/libcontainer/user",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "PqGgeBjTHnyGrTr5ekLFEXpC3iQ=",
-			"path": "github.com/opencontainers/runc/libcontainer/utils",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "AMYc2X2O/IL6EGrq6lTl5vEhLiY=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/opencontainers/runtime-spec/specs-go",
-			"path": "github.com/opencontainers/runtime-spec/specs-go",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "X4jufgAG12FCYi0U9VK4DK5vvXo=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/opencontainers/selinux/go-selinux",
-			"path": "github.com/opencontainers/selinux/go-selinux",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "5hHzDoXjeTtGaVzyN8lOowcwvdQ=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/opencontainers/selinux/go-selinux/label",
-			"path": "github.com/opencontainers/selinux/go-selinux/label",
-			"revision": "6cc515888830787a93d82138821f0309ad970640",
-			"revisionTime": "2019-06-11T12:12:36Z"
-		},
-		{
-			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
-			"path": "github.com/pkg/errors",
-			"revision": "248dadf4e9068a0b3e79f02ed0a610d935de5302",
-			"revisionTime": "2016-10-29T09:36:37Z"
-		},
-		{
-			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
-			"path": "github.com/pmezard/go-difflib/difflib",
-			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
-			"revisionTime": "2016-01-10T10:55:54Z"
-		},
-		{
-			"checksumSHA1": "rTNABfFJ9wtLQRH8uYNkEZGQOrY=",
-			"path": "github.com/posener/complete",
-			"revision": "9f41f7636a724791a3b8b1d35e84caa1124f0d3c",
-			"revisionTime": "2017-08-29T17:11:12Z"
-		},
-		{
-			"checksumSHA1": "NB7uVS0/BJDmNu68vPAlbrq4TME=",
-			"path": "github.com/posener/complete/cmd",
-			"revision": "9f41f7636a724791a3b8b1d35e84caa1124f0d3c",
-			"revisionTime": "2017-08-29T17:11:12Z"
-		},
-		{
-			"checksumSHA1": "gSX86Xl0w9hvtntdT8h23DZtSag=",
-			"path": "github.com/posener/complete/cmd/install",
-			"revision": "9f41f7636a724791a3b8b1d35e84caa1124f0d3c",
-			"revisionTime": "2017-08-29T17:11:12Z"
-		},
-		{
-			"checksumSHA1": "DMo94FwJAm9ZCYCiYdJU2+bh4no=",
-			"path": "github.com/posener/complete/match",
-			"revision": "9f41f7636a724791a3b8b1d35e84caa1124f0d3c",
-			"revisionTime": "2017-08-29T17:11:12Z"
-		},
-		{
-			"checksumSHA1": "5dHjKxShYVWVB1Fb00dAnR6kqVk=",
-			"path": "github.com/prometheus/client_golang/prometheus",
-			"revision": "2641b987480bca71fb39738eb8c8b0d577cb1d76",
-			"revisionTime": "2019-06-07T14:56:44Z",
-			"version": "v0.9.4",
-			"versionExact": "v0.9.4"
-		},
-		{
-			"checksumSHA1": "UBqhkyjCz47+S19MVTigxJ2VjVQ=",
-			"path": "github.com/prometheus/client_golang/prometheus/internal",
-			"revision": "2641b987480bca71fb39738eb8c8b0d577cb1d76",
-			"revisionTime": "2019-06-07T14:56:44Z",
-			"version": "v0.9.4",
-			"versionExact": "v0.9.4"
-		},
-		{
-			"checksumSHA1": "V51yx4gq61QCD9clxnps792Eq2Y=",
-			"path": "github.com/prometheus/client_golang/prometheus/promhttp",
-			"revision": "2641b987480bca71fb39738eb8c8b0d577cb1d76",
-			"revisionTime": "2019-06-07T14:56:44Z",
-			"version": "v0.9.4",
-			"versionExact": "v0.9.4"
-		},
-		{
-			"checksumSHA1": "DvwvOlPNAgRntBzt3b3OSRMS2N4=",
-			"path": "github.com/prometheus/client_model/go",
-			"revision": "6f3806018612930941127f2a7c6c453ba2c527d2",
-			"revisionTime": "2017-02-16T18:52:47Z"
-		},
-		{
-			"checksumSHA1": "xfnn0THnqNwjwimeTClsxahYrIo=",
-			"path": "github.com/prometheus/common/expfmt",
-			"revision": "2f17f4a9d485bf34b4bfaccc273805040e4f86c8",
-			"revisionTime": "2017-09-08T16:18:22Z"
-		},
-		{
-			"checksumSHA1": "GWlM3d2vPYyNATtTFgftS10/A9w=",
-			"path": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
-			"revision": "2f17f4a9d485bf34b4bfaccc273805040e4f86c8",
-			"revisionTime": "2017-09-08T16:18:22Z"
-		},
-		{
-			"checksumSHA1": "3VoqH7TFfzA6Ds0zFzIbKCUvBmw=",
-			"path": "github.com/prometheus/common/model",
-			"revision": "2f17f4a9d485bf34b4bfaccc273805040e4f86c8",
-			"revisionTime": "2017-09-08T16:18:22Z"
-		},
-		{
-			"checksumSHA1": "WB7dFqkmD3R514xql9YM3ZP1dDM=",
-			"path": "github.com/prometheus/procfs",
-			"revision": "833678b5bb319f2d20a475cb165c6cc59c2cc77c",
-			"revisionTime": "2019-05-31T16:30:47Z",
-			"version": "v0.0.2",
-			"versionExact": "v0.0.2"
-		},
-		{
-			"checksumSHA1": "Kmjs49lbjGmlgUPx3pks0tVDed0=",
-			"path": "github.com/prometheus/procfs/internal/fs",
-			"revision": "833678b5bb319f2d20a475cb165c6cc59c2cc77c",
-			"revisionTime": "2019-05-31T16:30:47Z",
-			"version": "v0.0.2",
-			"versionExact": "v0.0.2"
-		},
-		{
-			"checksumSHA1": "xCiFAAwVTrjsfZT1BIJQ3DgeNCY=",
-			"path": "github.com/prometheus/procfs/xfs",
-			"revision": "e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2",
-			"revisionTime": "2017-07-03T10:12:42Z"
-		},
-		{
-			"checksumSHA1": "I778b2sbNN/yjwKSdb3y7hz2yUQ=",
-			"path": "github.com/rs/cors",
-			"revision": "eabcc6af4bbe5ad3a949d36450326a2b0b9894b8",
-			"revisionTime": "2017-08-01T07:32:01Z"
-		},
-		{
-			"checksumSHA1": "M57Rrfc8Z966p+IBtQ91QOcUtcg=",
-			"comment": "v2.0.1-8-g983d3a5",
-			"path": "github.com/ryanuber/columnize",
-			"revision": "abc90934186a77966e2beeac62ed966aac0561d5",
-			"revisionTime": "2017-07-03T20:58:27Z"
-		},
-		{
-			"checksumSHA1": "6JP37UqrI0H80Gpk0Y2P+KXgn5M=",
-			"path": "github.com/ryanuber/go-glob",
-			"revision": "256dc444b735e061061cf46c809487313d5b0065",
-			"revisionTime": "2017-01-28T01:21:29Z"
-		},
-		{
-			"checksumSHA1": "tnMZLo/kR9Kqx6GtmWwowtTLlA8=",
-			"path": "github.com/sean-/seed",
-			"revision": "e2103e2c35297fb7e17febb81e49b312087a2372",
-			"revisionTime": "2017-03-13T16:33:22Z"
-		},
-		{
-			"checksumSHA1": "6Z/chtTVA74eUZTlG5VRDy59K1M=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/seccomp/libseccomp-golang",
-			"path": "github.com/seccomp/libseccomp-golang",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "8Lm8nsMCFz4+gr9EvQLqK8+w+Ks=",
-			"path": "github.com/sethgrid/pester",
-			"revision": "8053687f99650573b28fb75cddf3f295082704d7",
-			"revisionTime": "2016-04-29T17:20:22Z"
-		},
-		{
-			"checksumSHA1": "k+PmW/6PFt0FVFTTnfMbWwrm9hU=",
-			"origin": "github.com/hashicorp/gopsutil/cpu",
-			"path": "github.com/shirou/gopsutil/cpu",
-			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
-			"revisionTime": "2018-04-27T01:21:16Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "4DZwA8Xf2Zs8vhIc9kx8TIBMmSY=",
-			"origin": "github.com/hashicorp/gopsutil/disk",
-			"path": "github.com/shirou/gopsutil/disk",
-			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
-			"revisionTime": "2018-04-27T01:21:16Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "ib/iKmNEqKrSso+TsSSV/Q4HDSY=",
-			"origin": "github.com/hashicorp/gopsutil/host",
-			"path": "github.com/shirou/gopsutil/host",
-			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
-			"revisionTime": "2018-04-27T01:21:16Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "S31u6j9yi6MOblZ1x83k/HDuNtA=",
-			"origin": "github.com/hashicorp/gopsutil/internal/common",
-			"path": "github.com/shirou/gopsutil/internal/common",
-			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
-			"revisionTime": "2018-04-27T01:21:16Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "1u1St5K2LtEcQsh5ySmvoTZ8k0I=",
-			"origin": "github.com/hashicorp/gopsutil/mem",
-			"path": "github.com/shirou/gopsutil/mem",
-			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
-			"revisionTime": "2018-04-27T01:21:16Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "ME2P9hiaHO/YdVrNInDmb/dB6us=",
-			"origin": "github.com/hashicorp/gopsutil/net",
-			"path": "github.com/shirou/gopsutil/net",
-			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
-			"revisionTime": "2018-04-27T01:21:16Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "JuBAKUuSyR7RdJELt6tQMn79Y6w=",
-			"origin": "github.com/hashicorp/gopsutil/process",
-			"path": "github.com/shirou/gopsutil/process",
-			"revision": "62d5761ddb7d04fc475d6316c79ff0eed1e5f96b",
-			"revisionTime": "2018-04-27T01:21:16Z",
-			"tree": true
-		},
-		{
-			"checksumSHA1": "Nve7SpDmjsv6+rhkXAkfg/UQx94=",
-			"path": "github.com/shirou/w32",
-			"revision": "bb4de0191aa41b5507caa14b0650cdbddcd9280b",
-			"revisionTime": "2016-09-30T03:27:40Z"
-		},
-		{
-			"checksumSHA1": "SVO+Zm6SNwWrpgyc6mcTXbH4aJ8=",
-			"path": "github.com/sirupsen/logrus",
-			"revision": "2a22dbedbad1fd454910cd1f44f210ef90c28464",
-			"revisionTime": "2019-05-18T13:52:02Z"
-		},
-		{
-			"checksumSHA1": "h/HMhokbQHTdLUbruoBBTee+NYw=",
-			"path": "github.com/skratchdot/open-golang/open",
-			"revision": "75fb7ed4208cf72d323d7d02fd1a5964a7a9073c",
-			"revisionTime": "2016-03-02T14:40:31Z"
-		},
-		{
-			"checksumSHA1": "Q52Y7t0lEtk/wcDn5q7tS7B+jqs=",
-			"path": "github.com/spf13/pflag",
-			"revision": "7aff26db30c1be810f9de5038ec5ef96ac41fd7c",
-			"revisionTime": "2017-08-24T17:57:12Z"
-		},
-		{
-			"checksumSHA1": "K0crHygPTP42i1nLKWphSlvOQJw=",
-			"path": "github.com/stretchr/objx",
-			"revision": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94",
-			"revisionTime": "2015-09-28T12:21:52Z"
-		},
-		{
-			"checksumSHA1": "/7bZ0f2fM9AAsLf3nMca6Gtlm6E=",
-			"path": "github.com/stretchr/testify/assert",
-			"revision": "221dbe5ed46703ee255b1da0dec05086f5035f62",
-			"revisionTime": "2019-05-17T17:51:56Z",
-			"version": "v1.4.0",
-			"versionExact": "v1.4.0"
-		},
-		{
-			"checksumSHA1": "bg70xAHEu6HRf2iFu8h5iJBjUfg=",
-			"path": "github.com/stretchr/testify/mock",
-			"revision": "221dbe5ed46703ee255b1da0dec05086f5035f62",
-			"revisionTime": "2019-05-17T17:51:56Z",
-			"version": "v1.4.0",
-			"versionExact": "v1.4.0"
-		},
-		{
-			"checksumSHA1": "ABkrw83kq3/d6oSRX+BFq57/BiY=",
-			"path": "github.com/stretchr/testify/require",
-			"revision": "221dbe5ed46703ee255b1da0dec05086f5035f62",
-			"revisionTime": "2019-05-17T17:51:56Z",
-			"version": "v1.4.0",
-			"versionExact": "v1.4.0"
-		},
-		{
-			"checksumSHA1": "PgEklGW56c5RLHqQhORxt6jS3fY=",
-			"path": "github.com/syndtr/gocapability/capability",
-			"revision": "db04d3cc01c8b54962a58ec7e491717d06cfcc16",
-			"revisionTime": "2017-07-04T07:02:18Z"
-		},
-		{
-			"path": "github.com/testify/assert",
-			"revision": "v1.4.0",
-			"version": "v1.4.0"
-		},
-		{
-			"path": "github.com/testify/mock",
-			"revision": "v1.4.0",
-			"version": "v1.4.0"
-		},
-		{
-			"path": "github.com/testify/require",
-			"revision": "v1.4.0",
-			"version": "v1.4.0"
-		},
-		{
-			"checksumSHA1": "t24KnvC9jRxiANVhpw2pqFpmEu8=",
-			"path": "github.com/tonnerre/golang-text",
-			"revision": "048ed3d792f7104850acbc8cfc01e5a6070f4c04",
-			"revisionTime": "2013-09-25T19:58:46Z"
-		},
-		{
-			"checksumSHA1": "2xcr/mhxBFlDjpxe/Mc2Wb4RGR8=",
-			"path": "github.com/tv42/httpunix",
-			"revision": "b75d8614f926c077e48d85f1f8f7885b758c6225",
-			"revisionTime": "2015-04-27T01:28:21Z"
-		},
-		{
-			"checksumSHA1": "RBRh7hUVcoELofg7TinPuBUG/po=",
-			"path": "github.com/ugorji/go/codec",
-			"revision": "08f7b401aef15f3d544472dd46bf6788cdfe55bf",
-			"revisionTime": "2019-05-07T20:14:01Z"
-		},
-		{
-			"checksumSHA1": "qgMa75aMGbkFY0jIqqqgVnCUoNA=",
-			"path": "github.com/ulikunitz/xz",
-			"revision": "0c6b41e72360850ca4f98dc341fd999726ea007f",
-			"revisionTime": "2017-06-05T21:53:11Z"
-		},
-		{
-			"checksumSHA1": "vjnTkzNrMs5Xj6so/fq0mQ6dT1c=",
-			"path": "github.com/ulikunitz/xz/internal/hash",
-			"revision": "0c6b41e72360850ca4f98dc341fd999726ea007f",
-			"revisionTime": "2017-06-05T21:53:11Z"
-		},
-		{
-			"checksumSHA1": "m0pm57ASBK/CTdmC0ppRHO17mBs=",
-			"path": "github.com/ulikunitz/xz/internal/xlog",
-			"revision": "0c6b41e72360850ca4f98dc341fd999726ea007f",
-			"revisionTime": "2017-06-05T21:53:11Z"
-		},
-		{
-			"checksumSHA1": "2vZw6zc8xuNlyVz2QKvdlNSZQ1U=",
-			"path": "github.com/ulikunitz/xz/lzma",
-			"revision": "0c6b41e72360850ca4f98dc341fd999726ea007f",
-			"revisionTime": "2017-06-05T21:53:11Z"
-		},
-		{
-			"checksumSHA1": "cIkE6EIE7A0IzdhR/Yes8Nzyqtk=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/vishvananda/netlink",
-			"path": "github.com/vishvananda/netlink",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "r/vcO8YkOWNHKX5HKCukaU4Xzlg=",
-			"origin": "github.com/opencontainers/runc/vendor/github.com/vishvananda/netlink/nl",
-			"path": "github.com/vishvananda/netlink/nl",
-			"revision": "459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a",
-			"revisionTime": "2018-08-23T14:46:37Z"
-		},
-		{
-			"checksumSHA1": "t9A/EE2GhHFPHzK+ksAKgKW9ZC8=",
-			"path": "github.com/vmihailenco/msgpack",
-			"revision": "b5e691b1eb52a28c05e67ab9df303626c095c23b",
-			"revisionTime": "2018-06-13T09:15:15Z"
-		},
-		{
-			"checksumSHA1": "OcTSGT2v7/2saIGq06nDhEZwm8I=",
-			"path": "github.com/vmihailenco/msgpack/codes",
-			"revision": "b5e691b1eb52a28c05e67ab9df303626c095c23b",
-			"revisionTime": "2018-06-13T09:15:15Z"
-		},
-		{
-			"checksumSHA1": "0jAKo5tFC1SpRjwB+AiPNfNAzmM=",
-			"path": "github.com/zclconf/go-cty/cty",
-			"revision": "4ca19710f0562cab70f0b3c9cbff0ecc70ee06d1",
-			"revisionTime": "2019-02-01T22:06:20Z"
-		},
-		{
-			"checksumSHA1": "1WGUPe776lvMMbaRerAbqOx19nQ=",
-			"path": "github.com/zclconf/go-cty/cty/convert",
-			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
-			"revisionTime": "2018-07-18T22:05:26Z"
-		},
-		{
-			"checksumSHA1": "MyyLCGg3RREMllTJyK6ehZl/dHk=",
-			"path": "github.com/zclconf/go-cty/cty/function",
-			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
-			"revisionTime": "2018-07-18T22:05:26Z"
-		},
-		{
-			"checksumSHA1": "kcTJOuL131/stXJ4U9tC3SASQLs=",
-			"path": "github.com/zclconf/go-cty/cty/function/stdlib",
-			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
-			"revisionTime": "2018-07-18T22:05:26Z"
-		},
-		{
-			"checksumSHA1": "tmCzwfNXOEB1sSO7TKVzilb2vjA=",
-			"path": "github.com/zclconf/go-cty/cty/gocty",
-			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
-			"revisionTime": "2018-07-18T22:05:26Z"
-		},
-		{
-			"checksumSHA1": "1ApmO+Q33+Oem/3f6BU6sztJWNc=",
-			"path": "github.com/zclconf/go-cty/cty/json",
-			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
-			"revisionTime": "2018-07-18T22:05:26Z"
-		},
-		{
-			"checksumSHA1": "8H+2pufGi2Eo3d8cXFfJs31wk+I=",
-			"path": "github.com/zclconf/go-cty/cty/msgpack",
-			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
-			"revisionTime": "2018-07-18T22:05:26Z"
-		},
-		{
-			"checksumSHA1": "y5Sk+n6SOspFj8mlyb8swr4DMIs=",
-			"path": "github.com/zclconf/go-cty/cty/set",
-			"revision": "02bd58e97b5759d478019c5a6333edbfdfed16a0",
-			"revisionTime": "2018-07-18T22:05:26Z"
-		},
-		{
-			"checksumSHA1": "w+WRj7WpdItd5iR7PcaQQKMrVB0=",
-			"path": "go.opencensus.io",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "KLZy3Nh+8JlI04JmBa/Jc8fxrVQ=",
-			"path": "go.opencensus.io/internal",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "Dw3rpna1DwTa7TCzijInKcU49g4=",
-			"path": "go.opencensus.io/internal/tagencoding",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "r6fbtPwxK4/TYUOWc7y0hXdAG4Q=",
-			"path": "go.opencensus.io/metric/metricdata",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "kWj13srwY1SH5KgFecPhEfHnzVc=",
-			"path": "go.opencensus.io/metric/metricproducer",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "Ur+xijNXCbNHR8Q5VjW1czSAabo=",
-			"path": "go.opencensus.io/plugin/ochttp",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "UZhIoErIy1tKLmVT/5huwlp6KFQ=",
-			"path": "go.opencensus.io/plugin/ochttp/propagation/b3",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "q+y8X+5nDONIlJlxfkv+OtA18ds=",
-			"path": "go.opencensus.io/resource",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "Cc4tRuW0IjlfAFY8BcdfMDqG0R8=",
-			"path": "go.opencensus.io/stats",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "oIo4NRi6AVCfcwVfHzCXAsoZsdI=",
-			"path": "go.opencensus.io/stats/internal",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "vN9GN1vwD4RU/3ld2tKK00K0i94=",
-			"path": "go.opencensus.io/stats/view",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "AoqL/neZwl05Fv08vcXXlhbY12g=",
-			"path": "go.opencensus.io/tag",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "0O3djqX4bcg5O9LZdcinEoYeQKs=",
-			"path": "go.opencensus.io/trace",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "JkvEb8oMEFjic5K/03Tyr5Lok+w=",
-			"path": "go.opencensus.io/trace/internal",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "FHJParRi8f1GHO7Cx+lk3bMWBq0=",
-			"path": "go.opencensus.io/trace/propagation",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "UHbxxaMqpEPsubh8kPwzSlyEwqI=",
-			"path": "go.opencensus.io/trace/tracestate",
-			"revision": "b4a14686f0a98096416fe1b4cb848e384fb2b22b",
-			"revisionTime": "2019-07-13T07:22:01Z"
-		},
-		{
-			"checksumSHA1": "PMr/a5kcnC4toJtVwWhlU5E4tJY=",
-			"path": "go4.org/errorutil",
-			"revision": "034d17a462f7b2dcd1a4a73553ec5357ff6e6c6e",
-			"revisionTime": "2017-05-24T23:16:39Z"
-		},
-		{
-			"checksumSHA1": "ejjxT0+wDWWncfh0Rt3lSH4IbXQ=",
-			"path": "golang.org/x/crypto/blake2b",
-			"revision": "de0752318171da717af4ce24d0a2e8626afaeb11",
-			"revisionTime": "2018-08-08T16:52:45Z"
-		},
-		{
-			"checksumSHA1": "BGm8lKZmvJbf/YOJLeL1rw2WVjA=",
-			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
-			"revisionTime": "2018-06-20T09:14:27Z"
-		},
-		{
-			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
-			"path": "golang.org/x/net/context",
-			"revision": "c10e9556a7bc0e7c942242b606f0acf024ad5d6a",
-			"revisionTime": "2018-11-02T08:55:01Z"
-		},
-		{
-			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
-			"path": "golang.org/x/net/context/ctxhttp",
-			"revision": "f09c4662a0bd6bd8943ac7b4931e185df9471da4",
-			"revisionTime": "2016-09-24T00:10:04Z"
-		},
-		{
-			"checksumSHA1": "vqc3a+oTUGX8PmD0TS+qQ7gmN8I=",
-			"path": "golang.org/x/net/html",
-			"revision": "66aacef3dd8a676686c7ae3716979581e8b03c47",
-			"revisionTime": "2016-09-14T00:11:54Z"
-		},
-		{
-			"checksumSHA1": "00eQaGynDYrv3tL+C7l9xH0IDZg=",
-			"path": "golang.org/x/net/html/atom",
-			"revision": "66aacef3dd8a676686c7ae3716979581e8b03c47",
-			"revisionTime": "2016-09-14T00:11:54Z"
-		},
-		{
-			"checksumSHA1": "barUU39reQ7LdgYLA323hQ/UGy4=",
-			"path": "golang.org/x/net/html/charset",
-			"revision": "66aacef3dd8a676686c7ae3716979581e8b03c47",
-			"revisionTime": "2016-09-14T00:11:54Z"
-		},
-		{
-			"checksumSHA1": "kKuxyoDujo5CopTxAvvZ1rrLdd0=",
-			"path": "golang.org/x/net/http2",
-			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
-			"revisionTime": "2017-07-19T21:11:51Z"
-		},
-		{
-			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
-			"path": "golang.org/x/net/http2/hpack",
-			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
-			"revisionTime": "2017-07-19T21:11:51Z"
-		},
-		{
-			"checksumSHA1": "g/Z/Ka0VgJESgQK7/SJCjm/aX0I=",
-			"path": "golang.org/x/net/idna",
-			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
-			"revisionTime": "2017-07-19T21:11:51Z"
-		},
-		{
-			"checksumSHA1": "UxahDzW2v4mf/+aFxruuupaoIwo=",
-			"path": "golang.org/x/net/internal/timeseries",
-			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
-			"revisionTime": "2017-07-19T21:11:51Z"
-		},
-		{
-			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
-			"path": "golang.org/x/net/lex/httplex",
-			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
-			"revisionTime": "2017-07-19T21:11:51Z"
-		},
-		{
-			"checksumSHA1": "r9l4r3H6FOLQ0c2JaoXpopFjpnw=",
-			"origin": "github.com/docker/docker/vendor/golang.org/x/net/proxy",
-			"path": "golang.org/x/net/proxy",
-			"revision": "320063a2ad06a1d8ada61c94c29dbe44e2d87473",
-			"revisionTime": "2018-08-16T08:14:46Z"
-		},
-		{
-			"checksumSHA1": "u/r66lwYfgg682u5hZG7/E7+VCY=",
-			"path": "golang.org/x/net/trace",
-			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",
-			"revisionTime": "2017-07-19T21:11:51Z"
-		},
-		{
-			"checksumSHA1": "uRlaEkyMCxyjj57KBa81GEfvCwg=",
-			"path": "golang.org/x/oauth2",
-			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
-			"revisionTime": "2019-05-07T23:52:07Z"
-		},
-		{
-			"checksumSHA1": "w5SmJwdVFlGE1KO4/AQjY+jvdsI=",
-			"path": "golang.org/x/oauth2/google",
-			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
-			"revisionTime": "2019-05-07T23:52:07Z"
-		},
-		{
-			"checksumSHA1": "rnUL+5Yzlt+Ky2dlB61VqfhBOb8=",
-			"path": "golang.org/x/oauth2/internal",
-			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
-			"revisionTime": "2019-05-07T23:52:07Z"
-		},
-		{
-			"checksumSHA1": "huVltYnXdRFDJLgp/ZP9IALzG7g=",
-			"path": "golang.org/x/oauth2/jws",
-			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
-			"revisionTime": "2019-05-07T23:52:07Z"
-		},
-		{
-			"checksumSHA1": "HGS6ig1GfcE2CBHBsi965ZVn9Xw=",
-			"path": "golang.org/x/oauth2/jwt",
-			"revision": "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33",
-			"revisionTime": "2019-05-07T23:52:07Z"
-		},
-		{
-			"checksumSHA1": "S0DP7Pn7sZUmXc55IzZnNvERu6s=",
-			"path": "golang.org/x/sync/errgroup",
-			"revision": "316e794f7b5e3df4e95175a45a5fb8b12f85cb4f",
-			"revisionTime": "2016-07-15T18:54:39Z"
-		},
-		{
-			"checksumSHA1": "REkmyB368pIiip76LiqMLspgCRk=",
-			"path": "golang.org/x/sys/cpu",
-			"revision": "1b2967e3c290b7c545b3db0deeda16e9be4f98a2",
-			"revisionTime": "2018-07-06T09:56:39Z"
-		},
-		{
-			"checksumSHA1": "su2QDjUzrUO0JnOH9m0cNg0QqsM=",
-			"path": "golang.org/x/sys/unix",
-			"revision": "ac767d655b305d4e9612f5f6e33120b9176c4ad4",
-			"revisionTime": "2018-07-08T03:57:06Z"
-		},
-		{
-			"checksumSHA1": "l1jIhK9Y33obLipDvmjVPCdYtJI=",
-			"path": "golang.org/x/sys/windows",
-			"revision": "1b2967e3c290b7c545b3db0deeda16e9be4f98a2",
-			"revisionTime": "2018-07-06T09:56:39Z"
-		},
-		{
-			"checksumSHA1": "Mr4ur60bgQJnQFfJY0dGtwWwMPE=",
-			"path": "golang.org/x/text/encoding",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "HgcUFTOQF5jOYtTIj5obR3GVN9A=",
-			"path": "golang.org/x/text/encoding/charmap",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "yBhX1V6U7stq3GqS2x5yzF0lV+I=",
-			"path": "golang.org/x/text/encoding/htmlindex",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "zeHyHebIZl1tGuwGllIhjfci+wI=",
-			"path": "golang.org/x/text/encoding/internal",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "9cg4nSGfKTIWKb6bWV7U4lnuFKA=",
-			"path": "golang.org/x/text/encoding/internal/identifier",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "f/PWjU17cU5uo0zkdi+Iz80Megk=",
-			"path": "golang.org/x/text/encoding/japanese",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "qHQ79q9peY8ZkCMC8kJAb52BAWg=",
-			"path": "golang.org/x/text/encoding/korean",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "55UdScb+EMOCPr7OW0hCwDsVxpg=",
-			"path": "golang.org/x/text/encoding/simplifiedchinese",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "9EZF1SHTpjVmaT9sARitvGKUXOY=",
-			"path": "golang.org/x/text/encoding/traditionalchinese",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "G9LfJI9gySazd+MyyC6QbTHx4to=",
-			"path": "golang.org/x/text/encoding/unicode",
-			"revision": "e113a52b01bdd1744681b6ce70c2e3d26b58d389",
-			"revisionTime": "2017-08-30T18:54:29Z"
-		},
-		{
-			"checksumSHA1": "i47RkGDg+mFR2sYXOfVRVkGow3U=",
-			"path": "golang.org/x/text/internal",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "TWgJww5WcPoH39HKMNW0gEcQHts=",
-			"path": "golang.org/x/text/internal/language",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "hyNCcTwMQnV6/MK8uUW9E5H0J0M=",
-			"path": "golang.org/x/text/internal/tag",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "Qk7dljcrEK1BJkAEZguxAbG9dSo=",
-			"path": "golang.org/x/text/internal/utf8internal",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "B2EFJkBRmiAWXqY/4zqUJfp85ag=",
-			"path": "golang.org/x/text/language",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "IV4MN7KGBSocu/5NR3le3sxup4Y=",
-			"path": "golang.org/x/text/runes",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "tltivJ/uj/lqLk05IqGfCv2F/E8=",
-			"path": "golang.org/x/text/secure/bidirule",
-			"revision": "88f656faf3f37f690df1a32515b479415e1a6769",
-			"revisionTime": "2017-10-26T07:52:28Z"
-		},
-		{
-			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
-			"path": "golang.org/x/text/transform",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "iB6/RoQIzBaZxVi+t7tzbkwZTlo=",
-			"path": "golang.org/x/text/unicode/bidi",
-			"revision": "88f656faf3f37f690df1a32515b479415e1a6769",
-			"revisionTime": "2017-10-26T07:52:28Z"
-		},
-		{
-			"checksumSHA1": "jer43nmInsJhYFfpl39FpEYyoC4=",
-			"path": "golang.org/x/text/unicode/cldr",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "BCNYmf4Ek93G4lk5x3ucNi/lTwA=",
-			"path": "golang.org/x/text/unicode/norm",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "1mKbP+ZJSE2oamuShC/hhvJahks=",
-			"path": "golang.org/x/text/unicode/rangetable",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "zuieOGXKG9vXxNhEWv3H0X8RSXM=",
-			"path": "golang.org/x/text/width",
-			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
-			"revisionTime": "2018-02-22T12:58:23Z"
-		},
-		{
-			"checksumSHA1": "h/06ikMECfJoTkWj2e1nJ30aDDg=",
-			"path": "golang.org/x/time/rate",
-			"revision": "a4bde12657593d5e90d0533a3e4fd95e635124cb",
-			"revisionTime": "2016-02-02T18:34:45Z"
-		},
-		{
-			"checksumSHA1": "QyBLCM74VEO9bekzOZGcEkJ7V0o=",
-			"path": "google.golang.org/api/gensupport",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "YIDE68w/xMptf6Nu9hHiOwXOvho=",
-			"path": "google.golang.org/api/googleapi",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "1K0JxrUfDqAB3MyRiU1LKjfHyf4=",
-			"path": "google.golang.org/api/googleapi/internal/uritemplates",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "Mr2fXhMRzlQCgANFm91s536pG7E=",
-			"path": "google.golang.org/api/googleapi/transport",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "6Tg4dDJKzoSrAA5beVknvnjluOU=",
-			"path": "google.golang.org/api/internal",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "zh9AcT6oNvhnOqb7w7njY48TkvI=",
-			"path": "google.golang.org/api/iterator",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "2AyxThTPscWdy49fGsU2tg0Uyw8=",
-			"path": "google.golang.org/api/option",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "5M3TLPBoDz0A+PsHGDJmjmwqoTI=",
-			"path": "google.golang.org/api/storage/v1",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "a+PkIGoiF+p+ghmjmA9gUkMFwYQ=",
-			"path": "google.golang.org/api/transport/http",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "sJcKCvjPtoysqyelsB2CQzC5oQI=",
-			"path": "google.golang.org/api/transport/http/internal/propagation",
-			"revision": "035d22e007183e382031a505793aeb0ddb724007",
-			"revisionTime": "2019-08-24T00:08:15Z"
-		},
-		{
-			"checksumSHA1": "xmp0GjeJfZUWSmGfoUA/pxlKc0Q=",
-			"path": "google.golang.org/genproto/googleapis/api/annotations",
-			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
-			"revisionTime": "2019-05-08T19:38:15Z"
-		},
-		{
-			"checksumSHA1": "3hrELKtivO5PZZfzCL4JVOX3/Kw=",
-			"path": "google.golang.org/genproto/googleapis/iam/v1",
-			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
-			"revisionTime": "2019-05-08T19:38:15Z"
-		},
-		{
-			"checksumSHA1": "74OOKlkosdNECTQ8HvRmtMsqJZg=",
-			"path": "google.golang.org/genproto/googleapis/rpc/code",
-			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
-			"revisionTime": "2019-05-08T19:38:15Z"
-		},
-		{
-			"checksumSHA1": "Q0bDd8ApwAloBd/JQw0uZD4DbZM=",
-			"path": "google.golang.org/genproto/googleapis/rpc/status",
-			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
-			"revisionTime": "2019-05-08T19:38:15Z"
-		},
-		{
-			"checksumSHA1": "AyISVQkdxcMLS/tagl6PJFTs8Bs=",
-			"path": "google.golang.org/genproto/googleapis/type/expr",
-			"revision": "b515fa19cec88c32f305a962f34ae60068947aea",
-			"revisionTime": "2019-05-08T19:38:15Z"
-		},
-		{
-			"checksumSHA1": "UKBaAnKJu1ydInKNkSvnJ4s18QQ=",
-			"path": "google.golang.org/grpc",
-			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
-			"revisionTime": "2018-07-17T15:26:04Z"
-		},
-		{
-			"checksumSHA1": "/eTpFgjvMq5Bc9hYnw5fzKG4B6I=",
-			"path": "google.golang.org/grpc/codes",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "wA6y5rkH1v4bWBe5M1r/Hdtgma4=",
-			"path": "google.golang.org/grpc/credentials",
-			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
-			"revisionTime": "2018-07-17T15:26:04Z"
-		},
-		{
-			"checksumSHA1": "2NbY9kmMweE4VUsruRsvmViVnNg=",
-			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "MCQmohiDJwkgLWu/wpnekweQh8s=",
-			"path": "google.golang.org/grpc/grpclog",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "pc9cweMiKQ5hVMuO9UoMGdbizaY=",
-			"path": "google.golang.org/grpc/health",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "W5KfI1NIGJt7JaVnLzefDZr3+4s=",
-			"path": "google.golang.org/grpc/health/grpc_health_v1",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "cSdzm5GhbalJbWUNrN8pRdW0uks=",
-			"path": "google.golang.org/grpc/internal",
-			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
-			"revisionTime": "2018-07-17T15:26:04Z"
-		},
-		{
-			"checksumSHA1": "Z1mhrOEf+PedS4kVtNRlINUDzWg=",
-			"path": "google.golang.org/grpc/internal/transport",
-			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
-			"revisionTime": "2018-07-17T15:26:04Z"
-		},
-		{
-			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
-			"path": "google.golang.org/grpc/keepalive",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "OjIAi5AzqlQ7kLtdAyjvdgMf6hc=",
-			"path": "google.golang.org/grpc/metadata",
-			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
-			"revisionTime": "2018-07-17T15:26:04Z"
-		},
-		{
-			"checksumSHA1": "Zzb7Xsc3tbTJzrcZbSPyye+yxmw=",
-			"path": "google.golang.org/grpc/naming",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
-			"path": "google.golang.org/grpc/peer",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "YclPgme2gT3S0hTkHVdE1zAxJdo=",
-			"path": "google.golang.org/grpc/stats",
-			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
-			"revisionTime": "2018-07-17T15:26:04Z"
-		},
-		{
-			"checksumSHA1": "t/NhHuykWsxY0gEBd2WIv5RVBK8=",
-			"path": "google.golang.org/grpc/status",
-			"revision": "b534d2d20e596ca053e3070dc1745432d0cc91a6",
-			"revisionTime": "2018-07-17T15:26:04Z"
-		},
-		{
-			"checksumSHA1": "aixGx/Kd0cj9ZlZHacpHe3XgMQ4=",
-			"path": "google.golang.org/grpc/tap",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "oFGr0JoquaPGVnV86fVL8MVTc3A=",
-			"path": "google.golang.org/grpc/transport",
-			"revision": "0c41876308d45bc82e587965971e28be659a1aca",
-			"revisionTime": "2017-07-21T17:58:12Z"
-		},
-		{
-			"checksumSHA1": "eIhF+hmL/XZhzTiAwhLD0M65vlY=",
-			"path": "gopkg.in/fsnotify.v1",
-			"revision": "629574ca2a5df945712d3079857300b5e4da0236",
-			"revisionTime": "2016-10-11T02:33:12Z"
-		},
-		{
-			"checksumSHA1": "6f8MEU31llHM1sLM/GGH4/Qxu0A=",
-			"path": "gopkg.in/inf.v0",
-			"revision": "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4",
-			"revisionTime": "2015-09-11T12:57:57Z"
-		},
-		{
-			"checksumSHA1": "TO8baX+t1Qs7EmOYth80MkbKzFo=",
-			"path": "gopkg.in/tomb.v1",
-			"revision": "dd632973f1e7218eb1089048e0798ec9ae7dceb8",
-			"revisionTime": "2014-10-24T13:56:13Z"
-		},
-		{
-			"checksumSHA1": "WiyCOMvfzRdymImAJ3ME6aoYUdM=",
-			"path": "gopkg.in/tomb.v2",
-			"revision": "14b3d72120e8d10ea6e6b7f87f7175734b1faab8",
-			"revisionTime": "2014-06-26T14:46:23Z"
-		},
-		{
-			"checksumSHA1": "12GqsW8PiRPnezDDy0v4brZrndM=",
-			"path": "gopkg.in/yaml.v2",
-			"revision": "a5b47d31c556af34a302ce5d659e6fea44d90de0",
-			"revisionTime": "2016-09-28T15:37:09Z"
-		}
+		{"path":"cloud.google.com/go/compute/metadata","checksumSHA1":"b1KgRkWqz0RmrEBK6IJ8kOJva6w=","revision":"4bdb329835f9d945a6dad7b2ed60534497faa857","revisionTime":"2019-08-08T17:09:53Z"},
+		{"path":"cloud.google.com/go/iam","checksumSHA1":"+S/9jBntS1iHZwxkR64vsy97Gh8=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
+		{"path":"cloud.google.com/go/internal","checksumSHA1":"JfGXEtr79UaxukcL05IERkjYm/g=","revision":"f6872d26e2099733e489f2322a878213384f731a","revisionTime":"2019-08-26T22:18:59Z"},
+		{"path":"cloud.google.com/go/internal/optional","checksumSHA1":"wQ4uGuRwMb24vG16pPQDOOCPkFo=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
+		{"path":"cloud.google.com/go/internal/trace","checksumSHA1":"jHOn3QLqvr1luNqyOg24/BXLrsM=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
+		{"path":"cloud.google.com/go/internal/version","checksumSHA1":"CRid/VCcJ3Vfwg/R/gbmzcHVOwQ=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
+		{"path":"cloud.google.com/go/storage","checksumSHA1":"bZ1XULD+TbAPpn8b6+5dMaWWcqs=","revision":"511b7f3f2624e2d3c4bf2697da4ab69ed5359aac","revisionTime":"2019-08-21T09:16:34Z"},
+		{"path":"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2015-06-15/network","checksumSHA1":"Fs6Gcl0nhC0FJ6MsB+Ck7r4huYo=","revision":"767429fcb996dad413936d682c28301e6739bade","revisionTime":"2018-05-01T22:35:11Z"},
+		{"path":"github.com/Azure/azure-sdk-for-go/version","checksumSHA1":"FAw+h8wS2QiQEIVC3z/8R2q1bvY=","revision":"767429fcb996dad413936d682c28301e6739bade","revisionTime":"2018-05-01T22:35:11Z"},
+		{"path":"github.com/Azure/go-ansiterm","checksumSHA1":"9NFR6RG8H2fNyKHscGmuGLQhRm4=","revision":"d6e3b3328b783f23731bc4d058875b0371ff8109","revisionTime":"2017-09-29T23:40:23Z","version":"master","versionExact":"master"},
+		{"path":"github.com/Azure/go-ansiterm/winterm","checksumSHA1":"3/UphB+6Hbx5otA4PjFjvObT+L4=","revision":"d6e3b3328b783f23731bc4d058875b0371ff8109","revisionTime":"2017-09-29T23:40:23Z","version":"master","versionExact":"master"},
+		{"path":"github.com/BurntSushi/toml","checksumSHA1":"Pc2ORQp+VY3Un/dkh4QwLC7R6lE=","revision":"3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005","revisionTime":"2018-08-15T10:47:33Z"},
+		{"path":"github.com/DataDog/datadog-go/statsd","checksumSHA1":"WvApwvvSe3i/3KO8300dyeFmkbI=","revision":"b10af4b12965a1ad08d164f57d14195b4140d8de","revisionTime":"2017-08-09T10:47:06Z"},
+		{"path":"github.com/LK4D4/joincontext","checksumSHA1":"Jmf4AnrptgBdQ5TPBJ2M89nooIQ=","revision":"1724345da6d5bcc8b66fefb843b607ab918e175c","revisionTime":"2017-10-26T17:01:39Z"},
+		{"path":"github.com/Microsoft/go-winio","checksumSHA1":"nEVw+80Junfo7iEY7ThP7Ci9Pyk=","origin":"github.com/endocrimes/go-winio","revision":"fb47a8b419480a700368c176bc1d5d7e3393b98d","revisionTime":"2019-06-20T17:03:19Z","version":"dani/safe-relisten","versionExact":"dani/safe-relisten"},
+		{"path":"github.com/Microsoft/go-winio/pkg/guid","checksumSHA1":"/ykkyb7gmtZC68n7T24xwbmlCBc=","origin":"github.com/endocrimes/go-winio/pkg/guid","revision":"fb47a8b419480a700368c176bc1d5d7e3393b98d","revisionTime":"2019-06-20T17:03:19Z","version":"dani/safe-relisten","versionExact":"dani/safe-relisten"},
+		{"path":"github.com/NVIDIA/gpu-monitoring-tools","checksumSHA1":"kF1vk+8Xvb3nGBiw9+qbUc0SZ4M=","revision":"86f2a9fac6c5b597dc494420005144b8ef7ec9fb","revisionTime":"2018-08-29T22:20:09Z"},
+		{"path":"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml","checksumSHA1":"P8FATSSgpe5A17FyPrGpsX95Xw8=","revision":"86f2a9fac6c5b597dc494420005144b8ef7ec9fb","revisionTime":"2018-08-29T22:20:09Z"},
+		{"path":"github.com/NYTimes/gziphandler","checksumSHA1":"jktW57+vJsziNVPeXMCoujTzdW4=","revision":"97ae7fbaf81620fe97840685304a78a306a39c64","revisionTime":"2017-09-16T00:36:49Z"},
+		{"path":"github.com/Nvveen/Gotty","checksumSHA1":"Aqy8/FoAIidY/DeQ5oTYSZ4YFVc=","revision":"cd527374f1e5bff4938207604a14f2e38a9cf512","revisionTime":"2012-06-04T00:48:16Z"},
+		{"path":"github.com/StackExchange/wmi","checksumSHA1":"qtjd74+bErubh+qyv3s+lWmn9wc=","revision":"ea383cf3ba6ec950874b8486cd72356d007c768f","revisionTime":"2017-04-10T19:29:09Z"},
+		{"path":"github.com/agext/levenshtein","checksumSHA1":"jQh1fnoKPKMURvKkpdRjN695nAQ=","revision":"5f10fee965225ac1eecdc234c09daf5cd9e7f7b6","revisionTime":"2017-02-17T06:30:20Z"},
+		{"path":"github.com/apparentlymart/go-textseg/textseg","checksumSHA1":"Ffhtm8iHH7l2ynVVOIGJE3eiuLA=","revision":"b836f5c4d331d1945a2fead7188db25432d73b69","revisionTime":"2017-05-31T20:39:52Z"},
+		{"path":"github.com/appc/spec/schema","checksumSHA1":"uWJDTv0R/NJVYv51LVy6vKP1CZw=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
+		{"path":"github.com/appc/spec/schema/common","checksumSHA1":"Q47G6996hbfQaNp/8CFkGWTVQpw=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
+		{"path":"github.com/appc/spec/schema/types","checksumSHA1":"kYXCle7Ikc8WqiMs7NXz99bUWqo=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
+		{"path":"github.com/appc/spec/schema/types/resource","checksumSHA1":"VgPsPj5PH7LKXMa3ZLe5/+Avydo=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
+		{"path":"github.com/armon/circbuf","checksumSHA1":"l0iFqayYAaEip6Olaq3/LCOa/Sg=","revision":"bbbad097214e2918d8543d5201d12bfd7bca254d"},
+		{"path":"github.com/armon/go-metrics","checksumSHA1":"gaT7FBF9uH5TY4lCo96ySrYXjek=","revision":"c1e99089638e6f1f57fe71461f99f9d00a43ccf1","revisionTime":"2019-04-30T14:02:02Z"},
+		{"path":"github.com/armon/go-metrics/circonus","checksumSHA1":"xCsGGM9TKBogZDfSN536KtQdLko=","revision":"c1e99089638e6f1f57fe71461f99f9d00a43ccf1","revisionTime":"2019-04-30T14:02:02Z"},
+		{"path":"github.com/armon/go-metrics/datadog","checksumSHA1":"Dt0n1sSivvvdZQdzc4Hu/yOG+T0=","revision":"c1e99089638e6f1f57fe71461f99f9d00a43ccf1","revisionTime":"2019-04-30T14:02:02Z"},
+		{"path":"github.com/armon/go-metrics/prometheus","checksumSHA1":"vxr0X6/jCQ4FkMxdhzUaBEWrFGA=","revision":"c1e99089638e6f1f57fe71461f99f9d00a43ccf1","revisionTime":"2019-04-30T14:02:02Z"},
+		{"path":"github.com/armon/go-radix","checksumSHA1":"gNO0JNpLzYOdInGeq7HqMZUzx9M=","revision":"4239b77079c7b5d1243b7b4736304ce8ddb6f0f2","revisionTime":"2016-01-15T23:47:25Z"},
+		{"path":"github.com/aws/aws-sdk-go/aws","checksumSHA1":"gMMx/JVSQVE4KHKoJQC7cqjTIZc=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/awserr","checksumSHA1":"OlpdlsDV2Qv50MuHlpH9heaHjQc=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/awsutil","checksumSHA1":"MoxolxrlsmtDri7ndvx5gkXI2hU=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/client","checksumSHA1":"qZUhjIZT8zU/xdQJ3La948GqEgU=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/client/metadata","checksumSHA1":"ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/corehandlers","checksumSHA1":"VAb9dwYeOW1iViqztJq8DGtlrV4=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/credentials","checksumSHA1":"x1grxMebz9A06jOsLieoExjhltU=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds","checksumSHA1":"nCeVh7E8twNLP887Zanei1wd6ks=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/defaults","checksumSHA1":"9c2Th6//lUUZPehmPkHXJh4hE/s=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/ec2metadata","checksumSHA1":"xyUdqBgj3ltt9LXnY4UvEct2izQ=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/request","checksumSHA1":"0i8r38TS6u3uT2HBM+8tNsozY6w=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/aws/session","checksumSHA1":"S46ej8/Fd7YnczK42I1UnjoeqqM=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/private/endpoints","checksumSHA1":"Rv6k85b5aRb0la07XzRPsrzwrHE=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/private/protocol/query","checksumSHA1":"ndEFDDt1gd5taOeeUrf0T66H+bg=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/private/protocol/query/queryutil","checksumSHA1":"j8UDnDnB59+u1w/qBHKG0PSWH8U=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/private/protocol/rest","checksumSHA1":"WRZcRqV95LFgq5V09PmDmSmNTEw=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/private/protocol/restxml","checksumSHA1":"KVdpXAG2PmIyopNC4jJd/JdjefA=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil","checksumSHA1":"xmKYerjqq1FO8kJK0/4Ds8iGyWg=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/private/signer/v4","checksumSHA1":"H0s7iZn2nk/fq52QaaTeW+gSGgA=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/private/waiter","checksumSHA1":"Pfoou5jtRj8A0SuCl8toNbXQlfw=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/aws/aws-sdk-go/service/s3","checksumSHA1":"NAitp0A1zE3Zry+Z41LOlCr+9lQ=","comment":"v1.0.6-2-g80dd495","revision":"80dd4951fdb3f711d31843b8d87871130ef2df67"},
+		{"path":"github.com/beorn7/perks/quantile","checksumSHA1":"spyv5/YFBjYyZLZa1U2LBfDR8PM=","revision":"4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9","revisionTime":"2016-08-04T10:47:26Z"},
+		{"path":"github.com/bgentry/go-netrc/netrc","checksumSHA1":"nqw2Qn5xUklssHTubS5HDvEL9L4=","revision":"9fd32a8b3d3d3f9d43c341bfe098430e07609480","revisionTime":"2014-04-22T17:41:19Z"},
+		{"path":"github.com/bgentry/speakeasy","checksumSHA1":"7SbTaY0kaYxgQrG3/9cjrI+BcyU=","revision":"36e9cfdd690967f4f690c6edcc9ffacd006014a0"},
+		{"path":"github.com/bgentry/speakeasy/example","checksumSHA1":"twtRfb6484vfr2qqjiFkLThTjcQ=","revision":"36e9cfdd690967f4f690c6edcc9ffacd006014a0"},
+		{"path":"github.com/boltdb/bolt","checksumSHA1":"R1Q34Pfnt197F/nCOO9kG8c+Z90=","comment":"v1.2.0","revision":"2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8","revisionTime":"2017-07-17T17:11:48Z","version":"v1.3.1","versionExact":"v1.3.1"},
+		{"path":"github.com/checkpoint-restore/go-criu/rpc","checksumSHA1":"k3xD77kpUpECrHCffQKb1nttiDM=","revision":"bdb7599cd87b22701b5c89b37940ea882a7d7dec","revisionTime":"2019-01-09T18:43:17Z"},
+		{"path":"github.com/circonus-labs/circonus-gometrics","checksumSHA1":"H4RhrnI0P34qLB9345G4r7CAwpU=","revision":"d6e3aea90ab9f90fe8456e13fc520f43d102da4d","revisionTime":"2019-01-28T15:50:09Z","version":"=v2","versionExact":"v2"},
+		{"path":"github.com/circonus-labs/circonus-gometrics/api","checksumSHA1":"xtzLG2UjYF1lnD33Wk+Nu/KOO6E=","revision":"d6e3aea90ab9f90fe8456e13fc520f43d102da4d","revisionTime":"2019-01-28T15:50:09Z","version":"=v2","versionExact":"v2"},
+		{"path":"github.com/circonus-labs/circonus-gometrics/api/config","checksumSHA1":"bQhz/fcyZPmuHSH2qwC4ZtATy5c=","revision":"d6e3aea90ab9f90fe8456e13fc520f43d102da4d","revisionTime":"2019-01-28T15:50:09Z","version":"=v2","versionExact":"v2"},
+		{"path":"github.com/circonus-labs/circonus-gometrics/checkmgr","checksumSHA1":"Ij8yB33E0Kk+GfTkNRoF1mG26dc=","revision":"d6e3aea90ab9f90fe8456e13fc520f43d102da4d","revisionTime":"2019-01-28T15:50:09Z","version":"=v2","versionExact":"v2"},
+		{"path":"github.com/circonus-labs/circonusllhist","checksumSHA1":"VbfeVqeOM+dTNxCmpvmYS0LwQn0=","revision":"7d649b46cdc2cd2ed102d350688a75a4fd7778c6","revisionTime":"2016-11-21T13:51:53Z"},
+		{"path":"github.com/containerd/console","checksumSHA1":"IGtuR58l2zmYRcNf8sPDlCSgovE=","origin":"github.com/opencontainers/runc/vendor/github.com/containerd/console","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/containerd/continuity/pathdriver","checksumSHA1":"GqIrOttKaO7k6HIaHQLPr3cY7rY=","origin":"github.com/docker/docker/vendor/github.com/containerd/continuity/pathdriver","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
+		{"path":"github.com/containerd/fifo","checksumSHA1":"Ur3lVmFp+HTGUzQU+/ZBolKe8FU=","revision":"3d5202aec260678c48179c56f40e6f38a095738c","revisionTime":"2018-03-07T16:51:37Z"},
+		{"path":"github.com/containerd/go-cni","checksumSHA1":"414xGcva33msbOXs7vUQ4ffeJek=","revision":"d20b7eebc7ee1339cb703c4c18be6fd3fa81ad8f","revisionTime":"2019-09-04T15:50:53Z"},
+		{"path":"github.com/containernetworking/cni/libcni","checksumSHA1":"3CsFN6YsShG9EU2oB9vJIqYTxq4=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
+		{"path":"github.com/containernetworking/cni/pkg/invoke","checksumSHA1":"Xf2DxXUyjBO9u4LeyDzS38pdL+I=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
+		{"path":"github.com/containernetworking/cni/pkg/types","checksumSHA1":"Dhi4+8X7U2oVzVkgxPrmLaN8qFI=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
+		{"path":"github.com/containernetworking/cni/pkg/types/020","checksumSHA1":"6+ng8oaM9SB0TyCE7I7N940IpPY=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
+		{"path":"github.com/containernetworking/cni/pkg/types/current","checksumSHA1":"X6dNZ3yc3V9ffW9vz4yIyeKXGD0=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
+		{"path":"github.com/containernetworking/cni/pkg/version","checksumSHA1":"aojwjPoA9XSGB/zVtOGzWvmv/i8=","revision":"dc953e2fd91f9bc624b03cf9ea3706796bfee920","revisionTime":"2019-06-12T15:24:20Z"},
+		{"path":"github.com/containernetworking/plugins/pkg/ns","checksumSHA1":"n3dCDigZOU+eD84Cr4Kg30GO4nI=","revision":"2d6d46d308b2c45a0466324c9e3f1330ab5cacd6","revisionTime":"2019-05-01T19:17:48Z"},
+		{"path":"github.com/coreos/go-iptables/iptables","checksumSHA1":"UAPz3mxGiQmd3pRWOTghB2aXzGU=","revision":"969b135e941d8baadca0a40047a38d6aca381855","revisionTime":"2019-07-24T15:17:50Z"},
+		{"path":"github.com/coreos/go-semver/semver","checksumSHA1":"97BsbXOiZ8+Kr+LIuZkQFtSj7H4=","revision":"1817cd4bea52af76542157eeabd74b057d1a199e","revisionTime":"2017-06-13T09:22:38Z"},
+		{"path":"github.com/coreos/go-systemd/dbus","checksumSHA1":"/zxxFPYjUB7Wowz33r5AhTDvoz0=","origin":"github.com/opencontainers/runc/vendor/github.com/coreos/go-systemd/dbus","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/coreos/go-systemd/util","checksumSHA1":"e8qgBHxXbij3RVspqrkeBzMZ564=","origin":"github.com/opencontainers/runc/vendor/github.com/coreos/go-systemd/util","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/coreos/pkg/dlopen","checksumSHA1":"O8c/VKtW34XPJNNlyeb/im8vWSI=","origin":"github.com/opencontainers/runc/vendor/github.com/coreos/pkg/dlopen","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/cyphar/filepath-securejoin","checksumSHA1":"4Cq4wS4l0O8WlugamGEPvooJPAk=","origin":"github.com/opencontainers/runc/vendor/github.com/cyphar/filepath-securejoin","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/davecgh/go-spew/spew","checksumSHA1":"mrz/kicZiUaHxkyfvC/DyQcr8Do=","revision":"ecdeabc65495df2dec95d7c4a4c3e021903035e5","revisionTime":"2017-10-02T20:02:53Z"},
+		{"path":"github.com/docker/cli/cli/config/configfile","checksumSHA1":"wf9Rn3a9cPag5B9Dd+qHHEink+I=","revision":"67f9a3912cf944cf71b31f3fc14e3f2a18d95802","revisionTime":"2018-08-14T14:54:37Z","version":"v18.06.1-ce","versionExact":"v18.06.1-ce"},
+		{"path":"github.com/docker/cli/cli/config/credentials","checksumSHA1":"fJpuGdxgATGNHm+INOPNVIhBnj0=","revision":"deb84a9e4e10b590e6de6aa6081532c87a5a2cfe","revisionTime":"2018-08-29T13:09:58Z"},
+		{"path":"github.com/docker/cli/opts","checksumSHA1":"+yq5Rc1QTapDrr151x0m5ANZZeY=","revision":"67f9a3912cf944cf71b31f3fc14e3f2a18d95802","revisionTime":"2018-08-14T14:54:37Z","version":"v18.06.1-ce","versionExact":"v18.06.1-ce"},
+		{"path":"github.com/docker/distribution","checksumSHA1":"ae06MP/1OVwQ/s/PsEp9wxfnBXM=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
+		{"path":"github.com/docker/distribution/digestset","checksumSHA1":"Gj+xR1VgFKKmFXYOJMnAczC3Znk=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
+		{"path":"github.com/docker/distribution/metrics","checksumSHA1":"yqCaL8oUi3OlR/Mr4oHB5HKpstc=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
+		{"path":"github.com/docker/distribution/reference","checksumSHA1":"2Fe4D6PGaVE2he4fUeenLmhC1lE=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
+		{"path":"github.com/docker/distribution/registry/api/errcode","checksumSHA1":"oFgg0LXTCZuYeI0/eEatdTyLexg=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
+		{"path":"github.com/docker/distribution/registry/api/v2","checksumSHA1":"tjPyswv8NGYxreknmylv5r5tjt4=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
+		{"path":"github.com/docker/distribution/registry/client","checksumSHA1":"72zK3wP1n7UTcSFKZZz77sKXZiU=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
+		{"path":"github.com/docker/distribution/registry/client/auth","checksumSHA1":"UeouykquJzdjJv1+Vv0ikpe7Yvo=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
+		{"path":"github.com/docker/distribution/registry/client/auth/challenge","checksumSHA1":"GWNgNhqeZST7+rgQdC06yEaLuQg=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
+		{"path":"github.com/docker/distribution/registry/client/transport","checksumSHA1":"KjpG7FYMU5ugtc/fTfL1YqhdaV4=","revision":"83389a148052d74ac602f5f1d62f86ff2f3c4aa5","revisionTime":"2018-03-27T20:24:08Z"},
+		{"path":"github.com/docker/distribution/registry/storage/cache","checksumSHA1":"RjRJSz/ISJEi0uWh5FlXMQetRcg=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
+		{"path":"github.com/docker/distribution/registry/storage/cache/memory","checksumSHA1":"T8G3A63WALmJ3JT/A0r01LG4KI0=","revision":"b12bd4004afc203f1cbd2072317c8fda30b89710","revisionTime":"2018-08-28T23:03:05Z"},
+		{"path":"github.com/docker/docker-credential-helpers/client","checksumSHA1":"zcDmNPSzI1wVokOiHis5+JSg2Rk=","revision":"73e5f5dbfea31ee3b81111ebbf189785fa69731c","revisionTime":"2018-07-19T07:47:51Z"},
+		{"path":"github.com/docker/docker-credential-helpers/credentials","checksumSHA1":"4u6EMQqD1zIqOHp76zQFLVH5V8U=","revision":"73e5f5dbfea31ee3b81111ebbf189785fa69731c","revisionTime":"2018-07-19T07:47:51Z"},
+		{"path":"github.com/docker/docker/api/types","checksumSHA1":"PM15F2b73fvtlDsjFyXSMd9LJqU=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/blkiodev","checksumSHA1":"/jF0HVFiLzUUuywSjp4F/piM7BM=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/container","checksumSHA1":"+jeShxohzdtOkwAzy9e0X/fq6n4=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/filters","checksumSHA1":"RMZg2+TAla7E2KiiyF5yupWn0lY=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/mount","checksumSHA1":"9OClWW7OCikgz4QCS/sAVcvqcWk=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/network","checksumSHA1":"qZNE4g8YWfV6ryZp8kN9BwWYCeM=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/registry","checksumSHA1":"m4Jg5WnW75I65nvkEno8PElSXik=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/strslice","checksumSHA1":"OQEUS/2J2xVHpfvcsxcXzYqBSeY=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/swarm","checksumSHA1":"NT/DoroAQOev6keoJO0zKQZmjbE=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/swarm/runtime","checksumSHA1":"txs5EKTbKgVyKmKKSnaH3fr+odA=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/api/types/versions","checksumSHA1":"MZsgRjJJ0D/gAsXfKiEys+op6dE=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/errdefs","checksumSHA1":"dF9WiXuwISBPd8bQfqpuoWtB3jk=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/opts","checksumSHA1":"u6EOrZRfhdjr4up14b2JJ7MMMaY=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/archive","checksumSHA1":"wZ8yvJiuW5sK2VmoEniu1yjVlBQ=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/fileutils","checksumSHA1":"eMoRb/diYeuYLojU7ChN5DaETHc=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/homedir","checksumSHA1":"y37I+5AS96wQSiAxOayiMgnZawA=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/idtools","checksumSHA1":"+Ir5nXNDvy3cwbTlBh06lR7zUrI=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/ioutils","checksumSHA1":"Ybq78CnAoQWVBk+lkh3zykmcSjs=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/jsonmessage","checksumSHA1":"KQflv+x9hoJywgvxMwWcJqrmdkQ=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/longpath","checksumSHA1":"EXiIm2xIL7Ds+YsQUx8Z3eUYPtI=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/mount","checksumSHA1":"hx613GafM5hLibNt86ijinN89Ro=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/pools","checksumSHA1":"dj8atalGWftfM9vdzCsh9YF1Seg=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/stdcopy","checksumSHA1":"w0waeTRJ1sFygI0dZXH6l9E1c60=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/stringid","checksumSHA1":"gAUCA6R7F9kObegRGGNX5PzJahE=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/system","checksumSHA1":"RreuHCnt9a8brZsc2Q4f5T8wd+E=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/tarsum","checksumSHA1":"I6mTgOFa7NeZpYw2S5342eenRLY=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/term","checksumSHA1":"GFsDxJkQz407/2nUBmWuafG+uF8=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/pkg/term/windows","checksumSHA1":"TeOtxuBbbZtp6wDK/t4DdaGGSC0=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/registry","checksumSHA1":"0ZOQ9gYPwnxxjSIytDpwvsN5Rl0=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/registry/resumable","checksumSHA1":"jH7uQnDehFQygPP3zLC/mLSqgOk=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/volume","checksumSHA1":"Bs344j8rU7oCQyIcIhO9FJyk3ts=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/docker/volume/mounts","checksumSHA1":"J4wlScrHqr/jCIn82fgVF5mzO34=","revision":"baab736a364959f10a5ef86f0cd8a8e44bdcc576","revisionTime":"2018-11-29T15:58:16Z"},
+		{"path":"github.com/docker/go-connections/nat","checksumSHA1":"JbiWTzH699Sqz25XmDlsARpMN9w=","revision":"7da10c8c50cad14494ec818dcdfb6506265c0086","revisionTime":"2017-02-03T23:56:24Z"},
+		{"path":"github.com/docker/go-connections/sockets","checksumSHA1":"jUfDG3VQsA2UZHvvIXncgiddpYA=","origin":"github.com/docker/docker/vendor/github.com/docker/go-connections/sockets","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
+		{"path":"github.com/docker/go-connections/tlsconfig","checksumSHA1":"zUG/J7nb6PWxfSXOoET6NePfyc0=","origin":"github.com/docker/docker/vendor/github.com/docker/go-connections/tlsconfig","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
+		{"path":"github.com/docker/go-metrics","checksumSHA1":"kHVt4M5Pfby2dhurp+hZJfQhzVU=","revision":"399ea8c73916000c64c2c76e8da00ca82f8387ab","revisionTime":"2018-02-09T01:25:29Z"},
+		{"path":"github.com/docker/go-units","checksumSHA1":"18hmvak2Dc9x5cgKeZ2iApviT7w=","comment":"v0.1.0-23-g5d2041e","revision":"5d2041e26a699eaca682e2ea41c8f891e1060444"},
+		{"path":"github.com/docker/libnetwork/ipamutils","checksumSHA1":"vcP3kQNGWKHenrvQxfu4FZkB468=","origin":"github.com/docker/docker/vendor/github.com/docker/libnetwork/ipamutils","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
+		{"path":"github.com/dustin/go-humanize","checksumSHA1":"xteP9Px90oMrg/HZuqvZkpXCR+s=","revision":"8929fe90cee4b2cb9deb468b51fb34eba64d1bf0"},
+		{"path":"github.com/elazarl/go-bindata-assetfs","checksumSHA1":"7DxViusFRJ7UPH0jZqYatwDrOkY=","revision":"30f82fa23fd844bd5bb1e5f216db87fd77b5eb43","revisionTime":"2017-02-27T21:27:28Z"},
+		{"path":"github.com/fatih/color","checksumSHA1":"VsE3zx2d8kpwj97TWhYddzAwBrY=","revision":"507f6050b8568533fb3f5504de8e5205fa62a114","revisionTime":"2018-02-13T13:34:03Z"},
+		{"path":"github.com/fatih/structs","checksumSHA1":"QBkOnLnM6zZ158NJSVLqoE4V6fI=","revision":"14f46232cd7bc732dc67313a9e4d3d210e082587","revisionTime":"2016-07-19T20:45:16Z"},
+		{"path":"github.com/fsouza/go-dockerclient","checksumSHA1":"fvbo1J+cFWDrPDs0Yudwv+POIb4=","revision":"01c3e9bd8551d675a60382c0303ef51f5849ea99","revisionTime":"2018-11-29T02:57:25Z"},
+		{"path":"github.com/fsouza/go-dockerclient/internal/archive","checksumSHA1":"YJ7WR4AVtD2ykYJr+1mTtazkma0=","revision":"01c3e9bd8551d675a60382c0303ef51f5849ea99","revisionTime":"2018-11-29T02:57:25Z"},
+		{"path":"github.com/fsouza/go-dockerclient/internal/jsonmessage","checksumSHA1":"lnUC8fZCqakWnfuMLUrZD2g+reY=","revision":"01c3e9bd8551d675a60382c0303ef51f5849ea99","revisionTime":"2018-11-29T02:57:25Z"},
+		{"path":"github.com/fsouza/go-dockerclient/internal/term","checksumSHA1":"vdjeVhnepWyw3H4g9pVTVACDfV0=","revision":"01c3e9bd8551d675a60382c0303ef51f5849ea99","revisionTime":"2018-11-29T02:57:25Z"},
+		{"path":"github.com/go-ini/ini","checksumSHA1":"U4k9IYSBQcW5DW5QDc44n5dddxs=","comment":"v1.8.5-2-g6ec4abd","revision":"6ec4abd8f8d587536da56f730858f0e27aeb4126"},
+		{"path":"github.com/go-ole/go-ole","checksumSHA1":"IvHj/4iR2nYa/S3cB2GXoyDG/xQ=","comment":"v1.2.0-4-g5005588","revision":"085abb85892dc1949567b726dff00fa226c60c45","revisionTime":"2017-07-12T17:44:59Z"},
+		{"path":"github.com/go-ole/go-ole/oleutil","checksumSHA1":"qLYVTQDhgrVIeZ2KI9eZV51mmug=","comment":"v1.2.0-4-g5005588","revision":"50055884d646dd9434f16bbb5c9801749b9bafe4"},
+		{"path":"github.com/godbus/dbus","checksumSHA1":"bFplS7sPkJNtlKKCIszFQkAsmGI=","origin":"github.com/opencontainers/runc/vendor/github.com/godbus/dbus","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/gogo/protobuf/proto","checksumSHA1":"I460dM/HmGE9DWimQvd1hJkYosU=","revision":"616a82ed12d78d24d4839363e8f3c5d3f20627cf","revisionTime":"2017-11-09T18:15:19Z"},
+		{"path":"github.com/golang/protobuf/proto","checksumSHA1":"Pyou8mceOASSFxc7GeXZuVdSMi0=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
+		{"path":"github.com/golang/protobuf/protoc-gen-go/descriptor","checksumSHA1":"DA2cyOt1W92RTyXAqKQ4JWKGR8U=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1.1.0","versionExact":"v1.1.0"},
+		{"path":"github.com/golang/protobuf/ptypes","checksumSHA1":"/s0InJhSrxhTpqw5FIKgSMknCfM=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
+		{"path":"github.com/golang/protobuf/ptypes/any","checksumSHA1":"3eqU9o+NMZSLM/coY5WDq7C1uKg=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
+		{"path":"github.com/golang/protobuf/ptypes/duration","checksumSHA1":"ZIF0rnVzNLluFPqUebtJrVonMr4=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
+		{"path":"github.com/golang/protobuf/ptypes/empty","checksumSHA1":"7Az4Zl9T11I+xOfjgs/3/YMJ24I=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z"},
+		{"path":"github.com/golang/protobuf/ptypes/timestamp","checksumSHA1":"1FJvuT0UllZaaS43kmPlx8oNiCs=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1","versionExact":"v1.1.0"},
+		{"path":"github.com/golang/protobuf/ptypes/wrappers","checksumSHA1":"fs7UwFcU+SkJKA3eHcdhGsO4jrI=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1.1.0","versionExact":"v1.1.0"},
+		{"path":"github.com/golang/snappy","checksumSHA1":"W+E/2xXcE1GmJ0Qb784ald0Fn6I=","revision":"d9eb7a3d35ec988b8585d4a0068e462c27d28380","revisionTime":"2016-05-29T05:00:41Z"},
+		{"path":"github.com/google/btree","checksumSHA1":"cervgtZmEhshueHN64+ILdFHmEE=","revision":"4030bb1f1f0c35b30ca7009e9ebd06849dd45306","revisionTime":"2018-08-13T15:31:12Z"},
+		{"path":"github.com/google/go-cmp/cmp","checksumSHA1":"+suAHHPBmbdZf/HusugaL4/H+NE=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
+		{"path":"github.com/google/go-cmp/cmp/cmpopts","checksumSHA1":"VmBLfV9TChrjNu8Z96wZkYie1aI=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
+		{"path":"github.com/google/go-cmp/cmp/internal/diff","checksumSHA1":"eTwchtMX+RMJUvle2wt295P2h10=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
+		{"path":"github.com/google/go-cmp/cmp/internal/function","checksumSHA1":"kYtvRhMjM0X4bvEjR3pqEHLw1qo=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
+		{"path":"github.com/google/go-cmp/cmp/internal/value","checksumSHA1":"f+mgZLvc4VITtMmBv0bmew4rL2Y=","revision":"d5735f74713c51f7450a43d0a98d41ce2c1db3cb","revisionTime":"2017-09-01T21:42:48Z"},
+		{"path":"github.com/googleapis/gax-go/v2","checksumSHA1":"WZoHSeTnVjnPIX2+U1Otst5MUKw=","revision":"bd5b16380fd03dc758d11cef74ba2e3bc8b0e8c2","revisionTime":"2019-05-13T18:38:25Z"},
+		{"path":"github.com/gorhill/cronexpr","checksumSHA1":"m8B3L3qJ3tFfP6BI9pIFr9oal3w=","comment":"1.0.0","origin":"github.com/dadgar/cronexpr","revision":"675cac9b2d182dccb5ba8d5f8a0d5988df8a4394","revisionTime":"2017-09-15T18:30:32Z"},
+		{"path":"github.com/gorhill/cronexpr/cronexpr","checksumSHA1":"Nd/7mZb0T6Gj6+AymyOPsNCQSJs=","comment":"1.0.0","revision":"a557574d6c024ed6e36acc8b610f5f211c91568a"},
+		{"path":"github.com/gorilla/context","checksumSHA1":"g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=","revision":"08b5f424b9271eedf6f9f0ce86cb9396ed337a42","revisionTime":"2016-08-17T18:46:32Z"},
+		{"path":"github.com/gorilla/mux","checksumSHA1":"STQSdSj2FcpCf0NLfdsKhNutQT0=","revision":"e48e440e4c92e3251d812f8ce7858944dfa3331c","revisionTime":"2018-08-07T07:52:56Z"},
+		{"path":"github.com/gorilla/websocket","checksumSHA1":"gr0edNJuVv4+olNNZl5ZmwLgscA=","revision":"0ec3d1bd7fe50c503d6df98ee649d81f4857c564","revisionTime":"2019-03-06T00:42:57Z"},
+		{"path":"github.com/hashicorp/consul-template","checksumSHA1":"237KekVBW1eZohSDylZzT+/0NQI=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/child","checksumSHA1":"AhDPiKa7wzh3SE6Gx0WrsDYwBHg=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/config","checksumSHA1":"hjsBe5Qnn0DCttJkSNjy9mreW5Q=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/dependency","checksumSHA1":"S2ktxYTJRgmUE1GC5Bv+ZAmYWgE=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/logging","checksumSHA1":"o5N7SV389Ej+3b1iRNmz1dx5e1M=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/manager","checksumSHA1":"Ozv8RPN8d//DoFpwR2mQ/xMWhcs=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/renderer","checksumSHA1":"DUHtghMoLyrgPhv4lexVniBuWYk=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/signals","checksumSHA1":"YSEUV/9/k85XciRKu0cngxdjZLE=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/template","checksumSHA1":"mmM6LpEgkbLjobfgabon11mz40M=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/version","checksumSHA1":"eWyAvppME/4vsmaazcrf3oEbzGo=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul-template/watch","checksumSHA1":"cJxopvJKg7DBBb8tnDsfmBp5Q8I=","revision":"9e45d493d7fffa8a61dd315b714c39d1103da051","revisionTime":"2019-08-12T18:34:47Z"},
+		{"path":"github.com/hashicorp/consul/agent/consul/autopilot","checksumSHA1":"+I7fgoQlrnTUGW5krqNLadWwtjg=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
+		{"path":"github.com/hashicorp/consul/api","checksumSHA1":"7JPBtnIgLkdcJ0ldXMTEnVjNEjA=","revision":"40cec98468b829e5cdaacb0629b3e23a028db688","revisionTime":"2019-05-22T20:19:12Z"},
+		{"path":"github.com/hashicorp/consul/command/flags","checksumSHA1":"soNN4xaHTbeXFgNkZ7cX0gbFXQk=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
+		{"path":"github.com/hashicorp/consul/lib","checksumSHA1":"Nrh9BhiivRyJiuPzttstmq9xl/w=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
+		{"path":"github.com/hashicorp/consul/lib/freeport","checksumSHA1":"E28E4zR1FN2v1Xiq4FUER7KVN9M=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
+		{"path":"github.com/hashicorp/consul/test/porter","checksumSHA1":"5XjgqE4UIfwXvkq5VssGNc7uPhQ=","revision":"ad9425ca6353b8afcfebd19130a8cf768f7eac30","revisionTime":"2017-10-21T00:05:25Z"},
+		{"path":"github.com/hashicorp/consul/testutil","checksumSHA1":"T4CeQD+QRsjf1BJ1n7FSojS5zDQ=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
+		{"path":"github.com/hashicorp/consul/testutil/retry","checksumSHA1":"SCb2b91UYiB/23+SNDBlU5OZfFA=","revision":"fb848fc48818f58690db09d14640513aa6bf3c02","revisionTime":"2018-04-13T17:05:42Z"},
+		{"path":"github.com/hashicorp/errwrap","checksumSHA1":"cdOCt0Yb+hdErz8NAQqayxPmRsY=","revision":"7554cd9344cec97297fa6649b055a8c98c2a1e55"},
+		{"path":"github.com/hashicorp/go-checkpoint","checksumSHA1":"D267IUMW2rcb+vNe3QU+xhfSrgY=","revision":"1545e56e46dec3bba264e41fde2c1e2aa65b5dd4","revisionTime":"2017-10-09T17:35:28Z"},
+		{"path":"github.com/hashicorp/go-cleanhttp","checksumSHA1":"6ihdHMkDfFx/rJ1A36com2F6bQk=","revision":"a45970658e51fea2c41445ff0f7e07106d007617","revisionTime":"2017-02-11T00:33:01Z"},
+		{"path":"github.com/hashicorp/go-discover","checksumSHA1":"CnY2iYK47tGA9wsFMfH04PpmSoI=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z"},
+		{"path":"github.com/hashicorp/go-discover/provider/aliyun","checksumSHA1":"ZmU/47XUGUQpFP6E8T6Tl8QKszI=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
+		{"path":"github.com/hashicorp/go-discover/provider/aws","checksumSHA1":"Vit45xRjrJ6h7IGJndrBjodVUAE=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
+		{"path":"github.com/hashicorp/go-discover/provider/azure","checksumSHA1":"dMU80T10KQFZNqpBBjzf7ymFNBw=","revision":"266744fed5f15e5d4488269b2c29b66e25783f6f","revisionTime":"2018-05-21T21:57:50Z","tree":true},
+		{"path":"github.com/hashicorp/go-discover/provider/digitalocean","checksumSHA1":"qoy/euk2dwrONYMUsaAPznHHpxQ=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
+		{"path":"github.com/hashicorp/go-discover/provider/gce","checksumSHA1":"tnKls5vtzpNQAj7b987N4i81HvY=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
+		{"path":"github.com/hashicorp/go-discover/provider/os","checksumSHA1":"LZwn9B00AjulYRCKapmJWFAamoo=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
+		{"path":"github.com/hashicorp/go-discover/provider/scaleway","checksumSHA1":"GQ/3AvzdX6T0rtEFeGNYhwt17Zs=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
+		{"path":"github.com/hashicorp/go-discover/provider/softlayer","checksumSHA1":"SIyZ44AHIUTBfI336ACpCeybsLg=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
+		{"path":"github.com/hashicorp/go-discover/provider/triton","checksumSHA1":"n2iQu2IbTPw2XpWF2CqBrFSMjwI=","revision":"40ccfdee6c0d7136f98f2b54882b86aaf0250d2f","revisionTime":"2018-05-03T15:30:45Z","tree":true},
+		{"path":"github.com/hashicorp/go-envparse","checksumSHA1":"FKmqR4DC3nCXtnT9pe02z5CLNWo=","revision":"310ca1881b22af3522e3a8638c0b426629886196","revisionTime":"2018-01-19T21:58:41Z"},
+		{"path":"github.com/hashicorp/go-getter","checksumSHA1":"d4brua17AGQqMNtngK4xKOUwboY=","revision":"f5101da0117392c6e7960c934f05a2fd689a5b5f","revisionTime":"2019-08-22T19:45:07Z"},
+		{"path":"github.com/hashicorp/go-getter/helper/url","checksumSHA1":"9J+kDr29yDrwsdu2ULzewmqGjpA=","revision":"b345bfcec894fb7ff3fdf9b21baf2f56ea423d98","revisionTime":"2018-04-10T17:49:45Z"},
+		{"path":"github.com/hashicorp/go-hclog","checksumSHA1":"dOP7kCX3dACHc9mU79826N411QA=","revision":"ff2cf002a8dd750586d91dddd4470c341f981fe1","revisionTime":"2018-07-09T16:53:50Z"},
+		{"path":"github.com/hashicorp/go-immutable-radix","checksumSHA1":"Cas2nprG6pWzf05A2F/OlnjUu2Y=","revision":"8aac2701530899b64bdea735a1de8da899815220","revisionTime":"2017-07-25T22:12:15Z"},
+		{"path":"github.com/hashicorp/go-memdb","checksumSHA1":"FMAvwDar2bQyYAW4XMFhAt0J5xA=","revision":"20ff6434c1cc49b80963d45bf5c6aa89c78d8d57","revisionTime":"2017-08-31T20:15:40Z"},
+		{"path":"github.com/hashicorp/go-msgpack/codec","checksumSHA1":"LrGV93iKiRWNSxItKr6Os6zC1T8=","origin":"github.com/ugorji/go/codec","revision":"08f7b401aef15f3d544472dd46bf6788cdfe55bf","revisionTime":"2019-05-07T20:14:01Z"},
+		{"path":"github.com/hashicorp/go-multierror","checksumSHA1":"lrSl49G23l6NhfilxPM0XFs5rZo=","revision":"d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"},
+		{"path":"github.com/hashicorp/go-plugin","checksumSHA1":"IFwYSAmxxM+fV0w9LwdWKqFOCgg=","revision":"f444068e8f5a19853177f7aa0aea7e7d95b5b528","revisionTime":"2018-12-12T15:08:38Z"},
+		{"path":"github.com/hashicorp/go-plugin/internal/proto","checksumSHA1":"Ikbb1FngsPR79bHhr2UmKk4CblI=","revision":"f444068e8f5a19853177f7aa0aea7e7d95b5b528","revisionTime":"2018-12-12T15:08:38Z"},
+		{"path":"github.com/hashicorp/go-retryablehttp","checksumSHA1":"9SqwC2BzFbsWulQuBG2+QEliTpo=","revision":"73489d0a1476f0c9e6fb03f9c39241523a496dfd","revisionTime":"2019-01-26T20:33:39Z"},
+		{"path":"github.com/hashicorp/go-rootcerts","checksumSHA1":"A1PcINvF3UiwHRKn8UcgARgvGRs=","revision":"6bb64b370b90e7ef1fa532be9e591a81c3493e00","revisionTime":"2016-05-03T14:34:40Z"},
+		{"path":"github.com/hashicorp/go-safetemp","checksumSHA1":"CduvzBFfTv77nhjtXPGdIjQQLMI=","revision":"b1a1dbde6fdc11e3ae79efd9039009e22d4ae240","revisionTime":"2018-03-26T21:11:50Z"},
+		{"path":"github.com/hashicorp/go-sockaddr","checksumSHA1":"J47ySO1q0gcnmoMnir1q1loKzCk=","revision":"6d291a969b86c4b633730bfc6b8b9d64c3aafed9","revisionTime":"2018-03-20T11:50:54Z"},
+		{"path":"github.com/hashicorp/go-sockaddr/template","checksumSHA1":"PDp9DVLvf3KWxhs4G4DpIwauMSU=","revision":"6d291a969b86c4b633730bfc6b8b9d64c3aafed9","revisionTime":"2018-03-20T11:50:54Z"},
+		{"path":"github.com/hashicorp/go-syslog","checksumSHA1":"eEqQGKsFOdSAwEprYgYnL7+J2e0=","revision":"8d1874e3e8d1862b74e0536851e218c4571066a5","revisionTime":"2019-01-18T15:19:36Z","version":"v1.0.0","versionExact":"v1.0.0"},
+		{"path":"github.com/hashicorp/go-uuid","checksumSHA1":"5AxXPtBqAKyFGcttFzxT5hp/3Tk=","revision":"4f571afc59f3043a65f8fe6bf46d887b10a01d43","revisionTime":"2018-11-28T13:14:45Z"},
+		{"path":"github.com/hashicorp/go-version","checksumSHA1":"r0pj5dMHCghpaQZ3f1BRGoKiSWw=","revision":"b5a281d3160aa11950a6182bd9a9dc2cb1e02d50","revisionTime":"2018-08-24T00:43:55Z"},
+		{"path":"github.com/hashicorp/golang-lru","checksumSHA1":"d9PxF1XQGLMJZRct2R8qVM/eYlE=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4","revisionTime":"2016-02-07T21:47:19Z"},
+		{"path":"github.com/hashicorp/golang-lru/simplelru","checksumSHA1":"2nOpYjx8Sn57bqlZq17yM4YJuM4=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"},
+		{"path":"github.com/hashicorp/hcl","checksumSHA1":"vgGv8zuy7q8c5LBAFO1fnnQRRgE=","revision":"1804807358d86424faacbb42f50f0c04303cef11","revisionTime":"2019-06-10T16:16:27Z"},
+		{"path":"github.com/hashicorp/hcl/hcl/ast","checksumSHA1":"XQmjDva9JCGGkIecOgwtBEMCJhU=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
+		{"path":"github.com/hashicorp/hcl/hcl/parser","checksumSHA1":"croNloscHsjX87X+4/cKOURf1EY=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
+		{"path":"github.com/hashicorp/hcl/hcl/scanner","checksumSHA1":"lgR7PSAZ0RtvAc9OCtCnNsF/x8g=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
+		{"path":"github.com/hashicorp/hcl/hcl/strconv","checksumSHA1":"JlZmnzqdmFFyb1+2afLyR3BOE/8=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
+		{"path":"github.com/hashicorp/hcl/hcl/token","checksumSHA1":"c6yprzj06ASwCo18TtbbNNBHljA=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
+		{"path":"github.com/hashicorp/hcl/json/parser","checksumSHA1":"138aCV5n8n7tkGYMsMVQQnnLq+0=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
+		{"path":"github.com/hashicorp/hcl/json/scanner","checksumSHA1":"YdvFsNOMSWMLnY6fcliWQa0O5Fw=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
+		{"path":"github.com/hashicorp/hcl/json/token","checksumSHA1":"fNlXQCQEnb+B3k5UDL/r15xtSJY=","revision":"6e968a3fcdcbab092f5307fd0d85479d5af1e4dc","revisionTime":"2016-11-01T18:00:25Z"},
+		{"path":"github.com/hashicorp/hcl2/gohcl","checksumSHA1":"RFEjfMQWPAVILXE2PhL6wDW8Zg4=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
+		{"path":"github.com/hashicorp/hcl2/hcl","checksumSHA1":"1jDEGh+P7Cu8Lz39VudY6rRS6Jw=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
+		{"path":"github.com/hashicorp/hcl2/hcl/hclsyntax","checksumSHA1":"6FZRBZj+je9sMM5wrhM5phUXxZU=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
+		{"path":"github.com/hashicorp/hcl2/hcl/json","checksumSHA1":"l5KBeDDM1gf7yFth7WGhckpF+oc=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
+		{"path":"github.com/hashicorp/hcl2/hcldec","checksumSHA1":"6JRj4T/iQxIe/CoKXHDjPuupmL8=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
+		{"path":"github.com/hashicorp/hcl2/hclwrite","checksumSHA1":"Hgs10IsC8LdotUKLavgOL35Mbw4=","revision":"4fba5e1a75e382aed7f7a7993f2c4836a5e1cd52","revisionTime":"2019-06-17T16:00:22Z","version":"master","versionExact":"master"},
+		{"path":"github.com/hashicorp/logutils","checksumSHA1":"vt+P9D2yWDO3gdvdgCzwqunlhxU=","revision":"0dc08b1671f34c4250ce212759ebd880f743d883"},
+		{"path":"github.com/hashicorp/memberlist","checksumSHA1":"yAu2gPVXIh28yJ2If5gZPrf04kU=","revision":"1a62499c21db33d57691001d5e08a71ec857b18f","revisionTime":"2019-01-03T22:22:36Z"},
+		{"path":"github.com/hashicorp/net-rpc-msgpackrpc","checksumSHA1":"qnlqWJYV81ENr61SZk9c65R1mDo=","revision":"a14192a58a694c123d8fe5481d4a4727d6ae82f3"},
+		{"path":"github.com/hashicorp/raft","checksumSHA1":"ujL3Sc5iqc28/En2ndmc2R7oUQM=","revision":"9c733b2b7f53115c5ef261a90ce912a1bb49e970","revisionTime":"2019-01-04T13:37:20Z"},
+		{"path":"github.com/hashicorp/raft-boltdb","checksumSHA1":"QAxukkv54/iIvLfsUP6IK4R0m/A=","revision":"d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee","revisionTime":"2015-02-01T20:08:39Z"},
+		{"path":"github.com/hashicorp/serf","checksumSHA1":"9omt7lEuhBNSdgT32ThEzXn/aTU=","revision":"c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2","revisionTime":"2019-01-04T15:39:47Z"},
+		{"path":"github.com/hashicorp/serf/coordinate","checksumSHA1":"0PeWsO2aI+2PgVYlYlDPKfzCLEQ=","revision":"c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2","revisionTime":"2019-01-04T15:39:47Z"},
+		{"path":"github.com/hashicorp/serf/serf","checksumSHA1":"siLn7zwVHQk070rpd99BTktGfTs=","revision":"c7f3bc96b40972e67dfbe007c1fa825cf59ac8c2","revisionTime":"2019-01-04T15:39:47Z"},
+		{"path":"github.com/hashicorp/vault/api","checksumSHA1":"laYVVZeqao4WdIS/MKd0be7Z3yA=","revision":"85909e3373aa743c34a6a0ab59131f61fd9e8e43","revisionTime":"2019-02-12T14:05:52Z"},
+		{"path":"github.com/hashicorp/vault/helper/compressutil","checksumSHA1":"bSdPFOHaTwEvM4PIvn0PZfn75jM=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
+		{"path":"github.com/hashicorp/vault/helper/consts","checksumSHA1":"3mRK/pBPUH8rIPrILmuJWynWQVo=","revision":"85909e3373aa743c34a6a0ab59131f61fd9e8e43","revisionTime":"2019-02-12T14:05:52Z"},
+		{"path":"github.com/hashicorp/vault/helper/hclutil","checksumSHA1":"RlqPBLOexQ0jj6jomhiompWKaUg=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
+		{"path":"github.com/hashicorp/vault/helper/jsonutil","checksumSHA1":"POgkM3GrjRFw6H3sw95YNEs552A=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
+		{"path":"github.com/hashicorp/vault/helper/parseutil","checksumSHA1":"HA2MV/2XI0HcoThSRxQCaBZR2ps=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
+		{"path":"github.com/hashicorp/vault/helper/strutil","checksumSHA1":"HdVuYhZ5TuxeIFqi0jy2GHW7a4o=","revision":"8575f8fedcf8f5a6eb2b4701cb527b99574b5286","revisionTime":"2018-09-06T17:45:45Z"},
+		{"path":"github.com/hashicorp/yamux","checksumSHA1":"m9OKUPd/iliwKxs+LCSmAGpDJOs=","revision":"7221087c3d281fda5f794e28c2ea4c6e4d5c4558","revisionTime":"2018-09-17T20:50:41Z"},
+		{"path":"github.com/hpcloud/tail/util","checksumSHA1":"0xM336Lb25URO/1W1/CtGoRygVU=","revision":"37f4271387456dd1bf82ab1ad9229f060cc45386","revisionTime":"2017-08-14T16:06:53Z"},
+		{"path":"github.com/hpcloud/tail/watch","checksumSHA1":"TP4OAv5JMtzj2TB6OQBKqauaKDc=","revision":"37f4271387456dd1bf82ab1ad9229f060cc45386","revisionTime":"2017-08-14T16:06:53Z"},
+		{"path":"github.com/jmespath/go-jmespath","checksumSHA1":"3/Bhy+ua/DCv2ElMD5GzOYSGN6g=","comment":"0.2.2-2-gc01cf91","revision":"c01cf91b011868172fdcd9f41838e80c9d716264"},
+		{"path":"github.com/konsorten/go-windows-terminal-sequences","checksumSHA1":"Aulh7C5SVOA4Jzt5eHNH6197Mbk=","revision":"f55edac94c9bbba5d6182a4be46d86a2c9b5b50e","revisionTime":"2019-02-26T22:47:05Z"},
+		{"path":"github.com/kr/pretty","checksumSHA1":"eOXF2PEvYLMeD8DSzLZJWbjYzco=","revision":"cfb55aafdaf3ec08f0db22699ab822c50091b1c4","revisionTime":"2016-08-23T17:07:15Z"},
+		{"path":"github.com/kr/pty","checksumSHA1":"WD7GMln/NoduJr0DbumjOE59xI8=","revision":"b6e1bdd4a4f88614e0c6e5e8089c7abed98aae17","revisionTime":"2019-04-01T03:15:51Z"},
+		{"path":"github.com/kr/text","checksumSHA1":"uulQHQ7IsRKqDudBC8Go9J0gtAc=","revision":"7cafcd837844e784b526369c9bce262804aebc60","revisionTime":"2016-05-04T02:26:26Z"},
+		{"path":"github.com/mattn/go-colorable","checksumSHA1":"SEnjvwVyfuU2xBaOfXfwPD5MZqk=","revision":"efa589957cd060542a26d2dd7832fd6a6c6c3ade","revisionTime":"2018-03-10T13:32:14Z"},
+		{"path":"github.com/mattn/go-isatty","checksumSHA1":"AZO2VGorXTMDiSVUih3k73vORHY=","revision":"6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c","revisionTime":"2017-11-07T05:05:31Z"},
+		{"path":"github.com/mattn/go-shellwords","checksumSHA1":"ajImwVZHzsI+aNwsgzCSFSbmJqs=","revision":"f4e566c536cf69158e808ec28ef4182a37fdc981","revisionTime":"2015-03-21T17:42:21Z"},
+		{"path":"github.com/matttproud/golang_protobuf_extensions/pbutil","checksumSHA1":"bKMZjd2wPw13VwoE7mBeSv5djFA=","revision":"c12348ce28de40eed0136aa2b644d0ee0650e56c","revisionTime":"2016-04-24T11:30:07Z"},
+		{"path":"github.com/miekg/dns","checksumSHA1":"7C76urB5PLSeqMeydxiUGjX5xMI=","revision":"7e024ce8ce18b21b475ac6baf8fa3c42536bf2fa"},
+		{"path":"github.com/mitchellh/cli","checksumSHA1":"+o0siVvR8q36mKCpT5F/Sn2T7xo=","revision":"c54c85e9bd492bdba226ffdda55d4e293b79f8e8","revisionTime":"2018-04-06T01:10:36Z"},
+		{"path":"github.com/mitchellh/colorstring","checksumSHA1":"ttEN1Aupb7xpPMkQLqb3tzLFdXs=","revision":"8631ce90f28644f54aeedcb3e389a85174e067d1","revisionTime":"2015-09-17T21:48:07Z"},
+		{"path":"github.com/mitchellh/copystructure","checksumSHA1":"+p4JY4wmFQAppCdlrJ8Kxybmht8=","revision":"d23ffcb85de31694d6ccaa23ccb4a03e55c1303f","revisionTime":"2017-05-25T01:39:02Z"},
+		{"path":"github.com/mitchellh/go-homedir","checksumSHA1":"AXacfEchaUqT5RGmPmMXsOWRhv8=","revision":"756f7b183b7ab78acdbbee5c7f392838ed459dda","revisionTime":"2016-06-21T17:42:43Z"},
+		{"path":"github.com/mitchellh/go-ps","checksumSHA1":"DcYIZnMiq/Tj22/ge9os3NwOhs4=","revision":"4fdf99ab29366514c69ccccddab5dc58b8d84062","revisionTime":"2017-03-09T13:30:38Z"},
+		{"path":"github.com/mitchellh/go-testing-interface","checksumSHA1":"bDdhmDk8q6utWrccBhEOa6IoGkE=","revision":"a61a99592b77c9ba629d254a693acffaeb4b7e28","revisionTime":"2017-10-04T22:19:16Z"},
+		{"path":"github.com/mitchellh/go-wordwrap","checksumSHA1":"L3leymg2RT8hFl5uL+5KP/LpBkg=","revision":"ad45545899c7b13c020ea92b2072220eefad42b8","revisionTime":"2015-03-14T17:03:34Z"},
+		{"path":"github.com/mitchellh/hashstructure","checksumSHA1":"Z3FoiV93oUfDoQYMMiHxWCQPlBw=","revision":"1ef5c71b025aef149d12346356ac5973992860bc"},
+		{"path":"github.com/mitchellh/mapstructure","checksumSHA1":"4Js6Jlu93Wa0o6Kjt393L9Z7diE=","revision":"281073eb9eb092240d33ef253c404f1cca550309"},
+		{"path":"github.com/mitchellh/reflectwalk","checksumSHA1":"KqsMqI+Y+3EFYPhyzafpIneaVCM=","revision":"8d802ff4ae93611b807597f639c19f76074df5c6","revisionTime":"2017-05-08T17:38:06Z"},
+		{"path":"github.com/moby/moby/daemon/caps","checksumSHA1":"FoDTHct8ocl470GYc0i+JRWfrys=","revision":"39377bb96d459d2ef59bd2bad75468638a7f86a3","revisionTime":"2018-01-18T19:02:33Z"},
+		{"path":"github.com/mrunalp/fileutils","checksumSHA1":"EKGlMEHq/nwBXQGi9JN/y+H7YMU=","origin":"github.com/opencontainers/runc/vendor/github.com/mrunalp/fileutils","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/oklog/run","checksumSHA1":"nf3UoPNBIut7BL9nWE8Fw2X2j+Q=","revision":"6934b124db28979da51d3470dadfa34d73d72652","revisionTime":"2018-03-08T00:51:04Z"},
+		{"path":"github.com/onsi/ginkgo","checksumSHA1":"cwbidLG1ET7YSqlwca+nSfYxIbg=","revision":"ba8e856bb854d6771a72ddf6497a42dad3a0c971","revisionTime":"2018-03-12T10:34:14Z"},
+		{"path":"github.com/onsi/ginkgo/config","checksumSHA1":"Tarhbqac6rFsGPugPoQ4lyhfc7Q=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/ginkgo","checksumSHA1":"euz7sKjXGezoMq6P5qC/day/mZo=","revision":"ba8e856bb854d6771a72ddf6497a42dad3a0c971","revisionTime":"2018-03-12T10:34:14Z"},
+		{"path":"github.com/onsi/ginkgo/ginkgo/convert","checksumSHA1":"RX2QA4mqBzsogy4OWOCi9mUfAGU=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/ginkgo/interrupthandler","checksumSHA1":"jvjomLV3JcWQ1qa1ZfmvB4/62YI=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/ginkgo/nodot","checksumSHA1":"brZ63GMMr79P/RwClxFRBKMtICg=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/ginkgo/testrunner","checksumSHA1":"qSXx1svgCAAqk+ICAWL1AXdSJmA=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/ginkgo/testsuite","checksumSHA1":"x2Fa0rbgpXQaVc6f10KTRchiF7E=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/ginkgo/watch","checksumSHA1":"yT4efdDV3bfosM49kBvQg3PjcMA=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/codelocation","checksumSHA1":"T1cZh3UWr4Hnx6fQYp+7KDNvxG4=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/containernode","checksumSHA1":"qvz6/+otRkWa1OHaPMKap9D5Ge4=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/failer","checksumSHA1":"882oWW4FC4Nrd8mrMptsDJSTDds=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/leafnodes","checksumSHA1":"IbQFETl8AqMhJ74XP+us5Xk3dS8=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/remote","checksumSHA1":"Z9mfsBI9VL7QqwY+doKRhumHIh4=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/spec","checksumSHA1":"msseWG4Ewk2/V35NKaRokjXPCQs=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/spec_iterator","checksumSHA1":"14UQiFkhUmN5vTG+pNApv5OYgoU=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/specrunner","checksumSHA1":"pDxDXIJ3QPm5UMnzQ+3GedK8WjQ=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/suite","checksumSHA1":"QZ9ekcsrGBcXz4Tv+L7kXAUfqq8=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/testingtproxy","checksumSHA1":"TUBH2aNaARtAZ5vz51xMFRsOOo0=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/internal/writer","checksumSHA1":"BB83CfNg6jFoFNMuXFL+f4EOFpw=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/reporters","checksumSHA1":"m6/gIgdQGdETzUN3JWhAmFNIuNI=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/reporters/stenographer","checksumSHA1":"hdfc3dPx9Jw8v+sd7TEDlboJ1Nc=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable","checksumSHA1":"QeB8m9WhRUiL0YKj3n5L0t4mLCg=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty","checksumSHA1":"4Vn7/7UJmbclxDrV8YKbYOUh65g=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/ginkgo/types","checksumSHA1":"kuzrRJpxmnbuG7VVDIfDcLIRKLU=","revision":"9008c7b79f9636c46a0a945141020124702f0ecf","revisionTime":"2018-02-16T17:00:43Z"},
+		{"path":"github.com/onsi/gomega","checksumSHA1":"WQwGlRQksUlZ4HMiYZWR4wE4Suo=","revision":"de89e61d40b75aa971a9fc3eae7f4fefabd6e0ee","revisionTime":"2018-03-05T20:37:22Z"},
+		{"path":"github.com/onsi/gomega/format","checksumSHA1":"W/l0TJN86WNCAZPm1MPSlqxxWYM=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/internal/assertion","checksumSHA1":"H4RBR9kcEWh2lECAzBaOTSvgUuA=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/internal/asyncassertion","checksumSHA1":"N7HhJzMN+STfzI315keM9SxFQAE=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/internal/oraclematcher","checksumSHA1":"EsgeBqN2S5wj8aWvGsS162ZK7xI=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/internal/testingtsupport","checksumSHA1":"M2WqXho4fZaeYkyfuiGTlPhcU8I=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/matchers","checksumSHA1":"D7QESRc8hYaX8wHT0ftzvNTMwuk=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/matchers/support/goraph/bipartitegraph","checksumSHA1":"NMjCfnHie2dgQw0kCObrHRc8S50=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/matchers/support/goraph/edge","checksumSHA1":"zjTC6ady0bJUwzTFAKtv63T7Fmg=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/matchers/support/goraph/node","checksumSHA1":"o2+IscLOPKOiovl2g0/igkD1R4Q=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/matchers/support/goraph/util","checksumSHA1":"yEF1BYQPwS3neYFKiqNQReqnadY=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/onsi/gomega/types","checksumSHA1":"mGI31MBiT3PJ8sgoB/E7NQ+4dJA=","revision":"6e33911c8481405188b3791f916ac125a6a404b4","revisionTime":"2018-03-02T08:44:13Z"},
+		{"path":"github.com/opencontainers/go-digest","checksumSHA1":"NTperEHVh1uBqfTy9+oKceN4tKI=","revision":"21dfd564fd89c944783d00d069f33e3e7123c448","revisionTime":"2017-01-11T18:16:59Z"},
+		{"path":"github.com/opencontainers/image-spec/specs-go","checksumSHA1":"ZGlIwSRjdLYCUII7JLE++N4w7Xc=","revision":"89b51c794e9113108a2914e38e66c826a649f2b5","revisionTime":"2017-11-03T11:36:04Z"},
+		{"path":"github.com/opencontainers/image-spec/specs-go/v1","checksumSHA1":"jdbXRRzeu0njLE9/nCEZG+Yg/Jk=","revision":"89b51c794e9113108a2914e38e66c826a649f2b5","revisionTime":"2017-11-03T11:36:04Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer","checksumSHA1":"OJlgvnpJuV+SDPW48YVUKWDbOnU=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/apparmor","checksumSHA1":"gVVY8k2G3ws+V1czsfxfuRs8log=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/cgroups","checksumSHA1":"aWtm1zkVCz9l2/zQNfnc246yQew=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/cgroups/fs","checksumSHA1":"OnnBJ2WfB/Y9EQpABKetBedf6ts=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/cgroups/systemd","checksumSHA1":"d7B9MiKb1k1Egh5qkNokIfcZ+OY=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/configs","checksumSHA1":"v9sgw4eYRNSsJUSG33OoFIwLqRI=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/configs/validate","checksumSHA1":"hUveFGK1HhGenf0OVoYZWccoW9I=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/criurpc","checksumSHA1":"n7G7Egz/tOPacXuq+nkvnFai3eU=","revision":"369b920277d27630441336775cd728bc0f19e496","revisionTime":"2018-09-07T18:53:11Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/devices","checksumSHA1":"2CwtFvz9kB0RSjFlcCkmq4taJ9U=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/intelrdt","checksumSHA1":"sAbowQ7hjveSH5ADUD9IYXnEAJM=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/keys","checksumSHA1":"mKxBw0il2IWjWYgksX+17ufDw34=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/logs","checksumSHA1":"mBbwlspKSImoGTw4uKE40AX3PYs=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/mount","checksumSHA1":"MJiogPDUU2nFr1fzQU6T+Ry1W8o=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/nsenter","checksumSHA1":"PnGFQdbZhZ4pcxFtQep5MEQ4/8E=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/seccomp","checksumSHA1":"I1Qw/btE1twMqKHpYNsC98cteak=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/stacktrace","checksumSHA1":"yp/kYBgVqKtxlnpq4CmyxLFMAE4=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/system","checksumSHA1":"cjg/UcueM1/2/ExZ3N7010sa+hI=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/user","checksumSHA1":"mdUukOXCVJxmT0CufSKDeMg5JFM=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runc/libcontainer/utils","checksumSHA1":"PqGgeBjTHnyGrTr5ekLFEXpC3iQ=","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/runtime-spec/specs-go","checksumSHA1":"AMYc2X2O/IL6EGrq6lTl5vEhLiY=","origin":"github.com/opencontainers/runc/vendor/github.com/opencontainers/runtime-spec/specs-go","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/opencontainers/selinux/go-selinux","checksumSHA1":"X4jufgAG12FCYi0U9VK4DK5vvXo=","origin":"github.com/opencontainers/runc/vendor/github.com/opencontainers/selinux/go-selinux","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/opencontainers/selinux/go-selinux/label","checksumSHA1":"5hHzDoXjeTtGaVzyN8lOowcwvdQ=","origin":"github.com/opencontainers/runc/vendor/github.com/opencontainers/selinux/go-selinux/label","revision":"6cc515888830787a93d82138821f0309ad970640","revisionTime":"2019-06-11T12:12:36Z"},
+		{"path":"github.com/pkg/errors","checksumSHA1":"ynJSWoF6v+3zMnh9R0QmmG6iGV8=","revision":"248dadf4e9068a0b3e79f02ed0a610d935de5302","revisionTime":"2016-10-29T09:36:37Z"},
+		{"path":"github.com/pmezard/go-difflib/difflib","checksumSHA1":"LuFv4/jlrmFNnDb/5SCSEPAM9vU=","revision":"792786c7400a136282c1664665ae0a8db921c6c2","revisionTime":"2016-01-10T10:55:54Z"},
+		{"path":"github.com/posener/complete","checksumSHA1":"rTNABfFJ9wtLQRH8uYNkEZGQOrY=","revision":"9f41f7636a724791a3b8b1d35e84caa1124f0d3c","revisionTime":"2017-08-29T17:11:12Z"},
+		{"path":"github.com/posener/complete/cmd","checksumSHA1":"NB7uVS0/BJDmNu68vPAlbrq4TME=","revision":"9f41f7636a724791a3b8b1d35e84caa1124f0d3c","revisionTime":"2017-08-29T17:11:12Z"},
+		{"path":"github.com/posener/complete/cmd/install","checksumSHA1":"gSX86Xl0w9hvtntdT8h23DZtSag=","revision":"9f41f7636a724791a3b8b1d35e84caa1124f0d3c","revisionTime":"2017-08-29T17:11:12Z"},
+		{"path":"github.com/posener/complete/match","checksumSHA1":"DMo94FwJAm9ZCYCiYdJU2+bh4no=","revision":"9f41f7636a724791a3b8b1d35e84caa1124f0d3c","revisionTime":"2017-08-29T17:11:12Z"},
+		{"path":"github.com/prometheus/client_golang/prometheus","checksumSHA1":"5dHjKxShYVWVB1Fb00dAnR6kqVk=","revision":"2641b987480bca71fb39738eb8c8b0d577cb1d76","revisionTime":"2019-06-07T14:56:44Z","version":"v0.9.4","versionExact":"v0.9.4"},
+		{"path":"github.com/prometheus/client_golang/prometheus/internal","checksumSHA1":"UBqhkyjCz47+S19MVTigxJ2VjVQ=","revision":"2641b987480bca71fb39738eb8c8b0d577cb1d76","revisionTime":"2019-06-07T14:56:44Z","version":"v0.9.4","versionExact":"v0.9.4"},
+		{"path":"github.com/prometheus/client_golang/prometheus/promhttp","checksumSHA1":"V51yx4gq61QCD9clxnps792Eq2Y=","revision":"2641b987480bca71fb39738eb8c8b0d577cb1d76","revisionTime":"2019-06-07T14:56:44Z","version":"v0.9.4","versionExact":"v0.9.4"},
+		{"path":"github.com/prometheus/client_model/go","checksumSHA1":"DvwvOlPNAgRntBzt3b3OSRMS2N4=","revision":"6f3806018612930941127f2a7c6c453ba2c527d2","revisionTime":"2017-02-16T18:52:47Z"},
+		{"path":"github.com/prometheus/common/expfmt","checksumSHA1":"xfnn0THnqNwjwimeTClsxahYrIo=","revision":"2f17f4a9d485bf34b4bfaccc273805040e4f86c8","revisionTime":"2017-09-08T16:18:22Z"},
+		{"path":"github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg","checksumSHA1":"GWlM3d2vPYyNATtTFgftS10/A9w=","revision":"2f17f4a9d485bf34b4bfaccc273805040e4f86c8","revisionTime":"2017-09-08T16:18:22Z"},
+		{"path":"github.com/prometheus/common/model","checksumSHA1":"3VoqH7TFfzA6Ds0zFzIbKCUvBmw=","revision":"2f17f4a9d485bf34b4bfaccc273805040e4f86c8","revisionTime":"2017-09-08T16:18:22Z"},
+		{"path":"github.com/prometheus/procfs","checksumSHA1":"WB7dFqkmD3R514xql9YM3ZP1dDM=","revision":"833678b5bb319f2d20a475cb165c6cc59c2cc77c","revisionTime":"2019-05-31T16:30:47Z","version":"v0.0.2","versionExact":"v0.0.2"},
+		{"path":"github.com/prometheus/procfs/internal/fs","checksumSHA1":"Kmjs49lbjGmlgUPx3pks0tVDed0=","revision":"833678b5bb319f2d20a475cb165c6cc59c2cc77c","revisionTime":"2019-05-31T16:30:47Z","version":"v0.0.2","versionExact":"v0.0.2"},
+		{"path":"github.com/prometheus/procfs/xfs","checksumSHA1":"xCiFAAwVTrjsfZT1BIJQ3DgeNCY=","revision":"e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2","revisionTime":"2017-07-03T10:12:42Z"},
+		{"path":"github.com/rs/cors","checksumSHA1":"I778b2sbNN/yjwKSdb3y7hz2yUQ=","revision":"eabcc6af4bbe5ad3a949d36450326a2b0b9894b8","revisionTime":"2017-08-01T07:32:01Z"},
+		{"path":"github.com/ryanuber/columnize","checksumSHA1":"M57Rrfc8Z966p+IBtQ91QOcUtcg=","comment":"v2.0.1-8-g983d3a5","revision":"abc90934186a77966e2beeac62ed966aac0561d5","revisionTime":"2017-07-03T20:58:27Z"},
+		{"path":"github.com/ryanuber/go-glob","checksumSHA1":"6JP37UqrI0H80Gpk0Y2P+KXgn5M=","revision":"256dc444b735e061061cf46c809487313d5b0065","revisionTime":"2017-01-28T01:21:29Z"},
+		{"path":"github.com/sean-/seed","checksumSHA1":"tnMZLo/kR9Kqx6GtmWwowtTLlA8=","revision":"e2103e2c35297fb7e17febb81e49b312087a2372","revisionTime":"2017-03-13T16:33:22Z"},
+		{"path":"github.com/seccomp/libseccomp-golang","checksumSHA1":"6Z/chtTVA74eUZTlG5VRDy59K1M=","origin":"github.com/opencontainers/runc/vendor/github.com/seccomp/libseccomp-golang","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/sethgrid/pester","checksumSHA1":"8Lm8nsMCFz4+gr9EvQLqK8+w+Ks=","revision":"8053687f99650573b28fb75cddf3f295082704d7","revisionTime":"2016-04-29T17:20:22Z"},
+		{"path":"github.com/shirou/gopsutil/cpu","checksumSHA1":"k+PmW/6PFt0FVFTTnfMbWwrm9hU=","origin":"github.com/hashicorp/gopsutil/cpu","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
+		{"path":"github.com/shirou/gopsutil/disk","checksumSHA1":"4DZwA8Xf2Zs8vhIc9kx8TIBMmSY=","origin":"github.com/hashicorp/gopsutil/disk","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
+		{"path":"github.com/shirou/gopsutil/host","checksumSHA1":"ib/iKmNEqKrSso+TsSSV/Q4HDSY=","origin":"github.com/hashicorp/gopsutil/host","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
+		{"path":"github.com/shirou/gopsutil/internal/common","checksumSHA1":"S31u6j9yi6MOblZ1x83k/HDuNtA=","origin":"github.com/hashicorp/gopsutil/internal/common","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
+		{"path":"github.com/shirou/gopsutil/mem","checksumSHA1":"1u1St5K2LtEcQsh5ySmvoTZ8k0I=","origin":"github.com/hashicorp/gopsutil/mem","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
+		{"path":"github.com/shirou/gopsutil/net","checksumSHA1":"ME2P9hiaHO/YdVrNInDmb/dB6us=","origin":"github.com/hashicorp/gopsutil/net","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
+		{"path":"github.com/shirou/gopsutil/process","checksumSHA1":"JuBAKUuSyR7RdJELt6tQMn79Y6w=","origin":"github.com/hashicorp/gopsutil/process","revision":"62d5761ddb7d04fc475d6316c79ff0eed1e5f96b","revisionTime":"2018-04-27T01:21:16Z","tree":true},
+		{"path":"github.com/shirou/w32","checksumSHA1":"Nve7SpDmjsv6+rhkXAkfg/UQx94=","revision":"bb4de0191aa41b5507caa14b0650cdbddcd9280b","revisionTime":"2016-09-30T03:27:40Z"},
+		{"path":"github.com/sirupsen/logrus","checksumSHA1":"SVO+Zm6SNwWrpgyc6mcTXbH4aJ8=","revision":"2a22dbedbad1fd454910cd1f44f210ef90c28464","revisionTime":"2019-05-18T13:52:02Z"},
+		{"path":"github.com/skratchdot/open-golang/open","checksumSHA1":"h/HMhokbQHTdLUbruoBBTee+NYw=","revision":"75fb7ed4208cf72d323d7d02fd1a5964a7a9073c","revisionTime":"2016-03-02T14:40:31Z"},
+		{"path":"github.com/spf13/pflag","checksumSHA1":"Q52Y7t0lEtk/wcDn5q7tS7B+jqs=","revision":"7aff26db30c1be810f9de5038ec5ef96ac41fd7c","revisionTime":"2017-08-24T17:57:12Z"},
+		{"path":"github.com/stretchr/objx","checksumSHA1":"K0crHygPTP42i1nLKWphSlvOQJw=","revision":"1a9d0bb9f541897e62256577b352fdbc1fb4fd94","revisionTime":"2015-09-28T12:21:52Z"},
+		{"path":"github.com/stretchr/testify/assert","checksumSHA1":"/7bZ0f2fM9AAsLf3nMca6Gtlm6E=","revision":"221dbe5ed46703ee255b1da0dec05086f5035f62","revisionTime":"2019-05-17T17:51:56Z","version":"v1.4.0","versionExact":"v1.4.0"},
+		{"path":"github.com/stretchr/testify/mock","checksumSHA1":"bg70xAHEu6HRf2iFu8h5iJBjUfg=","revision":"221dbe5ed46703ee255b1da0dec05086f5035f62","revisionTime":"2019-05-17T17:51:56Z","version":"v1.4.0","versionExact":"v1.4.0"},
+		{"path":"github.com/stretchr/testify/require","checksumSHA1":"ABkrw83kq3/d6oSRX+BFq57/BiY=","revision":"221dbe5ed46703ee255b1da0dec05086f5035f62","revisionTime":"2019-05-17T17:51:56Z","version":"v1.4.0","versionExact":"v1.4.0"},
+		{"path":"github.com/syndtr/gocapability/capability","checksumSHA1":"PgEklGW56c5RLHqQhORxt6jS3fY=","revision":"db04d3cc01c8b54962a58ec7e491717d06cfcc16","revisionTime":"2017-07-04T07:02:18Z"},
+		{"path":"github.com/testify/assert","revision":"v1.4.0","version":"v1.4.0"},
+		{"path":"github.com/testify/mock","revision":"v1.4.0","version":"v1.4.0"},
+		{"path":"github.com/testify/require","revision":"v1.4.0","version":"v1.4.0"},
+		{"path":"github.com/tonnerre/golang-text","checksumSHA1":"t24KnvC9jRxiANVhpw2pqFpmEu8=","revision":"048ed3d792f7104850acbc8cfc01e5a6070f4c04","revisionTime":"2013-09-25T19:58:46Z"},
+		{"path":"github.com/tv42/httpunix","checksumSHA1":"2xcr/mhxBFlDjpxe/Mc2Wb4RGR8=","revision":"b75d8614f926c077e48d85f1f8f7885b758c6225","revisionTime":"2015-04-27T01:28:21Z"},
+		{"path":"github.com/ugorji/go/codec","checksumSHA1":"RBRh7hUVcoELofg7TinPuBUG/po=","revision":"08f7b401aef15f3d544472dd46bf6788cdfe55bf","revisionTime":"2019-05-07T20:14:01Z"},
+		{"path":"github.com/ulikunitz/xz","checksumSHA1":"qgMa75aMGbkFY0jIqqqgVnCUoNA=","revision":"0c6b41e72360850ca4f98dc341fd999726ea007f","revisionTime":"2017-06-05T21:53:11Z"},
+		{"path":"github.com/ulikunitz/xz/internal/hash","checksumSHA1":"vjnTkzNrMs5Xj6so/fq0mQ6dT1c=","revision":"0c6b41e72360850ca4f98dc341fd999726ea007f","revisionTime":"2017-06-05T21:53:11Z"},
+		{"path":"github.com/ulikunitz/xz/internal/xlog","checksumSHA1":"m0pm57ASBK/CTdmC0ppRHO17mBs=","revision":"0c6b41e72360850ca4f98dc341fd999726ea007f","revisionTime":"2017-06-05T21:53:11Z"},
+		{"path":"github.com/ulikunitz/xz/lzma","checksumSHA1":"2vZw6zc8xuNlyVz2QKvdlNSZQ1U=","revision":"0c6b41e72360850ca4f98dc341fd999726ea007f","revisionTime":"2017-06-05T21:53:11Z"},
+		{"path":"github.com/vishvananda/netlink","checksumSHA1":"cIkE6EIE7A0IzdhR/Yes8Nzyqtk=","origin":"github.com/opencontainers/runc/vendor/github.com/vishvananda/netlink","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/vishvananda/netlink/nl","checksumSHA1":"r/vcO8YkOWNHKX5HKCukaU4Xzlg=","origin":"github.com/opencontainers/runc/vendor/github.com/vishvananda/netlink/nl","revision":"459bfaec1fc6c17d8bfb12d0a0f69e7e7271ed2a","revisionTime":"2018-08-23T14:46:37Z"},
+		{"path":"github.com/vmihailenco/msgpack","checksumSHA1":"t9A/EE2GhHFPHzK+ksAKgKW9ZC8=","revision":"b5e691b1eb52a28c05e67ab9df303626c095c23b","revisionTime":"2018-06-13T09:15:15Z"},
+		{"path":"github.com/vmihailenco/msgpack/codes","checksumSHA1":"OcTSGT2v7/2saIGq06nDhEZwm8I=","revision":"b5e691b1eb52a28c05e67ab9df303626c095c23b","revisionTime":"2018-06-13T09:15:15Z"},
+		{"path":"github.com/zclconf/go-cty/cty","checksumSHA1":"0jAKo5tFC1SpRjwB+AiPNfNAzmM=","revision":"4ca19710f0562cab70f0b3c9cbff0ecc70ee06d1","revisionTime":"2019-02-01T22:06:20Z"},
+		{"path":"github.com/zclconf/go-cty/cty/convert","checksumSHA1":"1WGUPe776lvMMbaRerAbqOx19nQ=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
+		{"path":"github.com/zclconf/go-cty/cty/function","checksumSHA1":"MyyLCGg3RREMllTJyK6ehZl/dHk=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
+		{"path":"github.com/zclconf/go-cty/cty/function/stdlib","checksumSHA1":"kcTJOuL131/stXJ4U9tC3SASQLs=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
+		{"path":"github.com/zclconf/go-cty/cty/gocty","checksumSHA1":"tmCzwfNXOEB1sSO7TKVzilb2vjA=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
+		{"path":"github.com/zclconf/go-cty/cty/json","checksumSHA1":"1ApmO+Q33+Oem/3f6BU6sztJWNc=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
+		{"path":"github.com/zclconf/go-cty/cty/msgpack","checksumSHA1":"8H+2pufGi2Eo3d8cXFfJs31wk+I=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
+		{"path":"github.com/zclconf/go-cty/cty/set","checksumSHA1":"y5Sk+n6SOspFj8mlyb8swr4DMIs=","revision":"02bd58e97b5759d478019c5a6333edbfdfed16a0","revisionTime":"2018-07-18T22:05:26Z"},
+		{"path":"go.opencensus.io","checksumSHA1":"w+WRj7WpdItd5iR7PcaQQKMrVB0=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/internal","checksumSHA1":"KLZy3Nh+8JlI04JmBa/Jc8fxrVQ=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/internal/tagencoding","checksumSHA1":"Dw3rpna1DwTa7TCzijInKcU49g4=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/metric/metricdata","checksumSHA1":"r6fbtPwxK4/TYUOWc7y0hXdAG4Q=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/metric/metricproducer","checksumSHA1":"kWj13srwY1SH5KgFecPhEfHnzVc=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/plugin/ochttp","checksumSHA1":"Ur+xijNXCbNHR8Q5VjW1czSAabo=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/plugin/ochttp/propagation/b3","checksumSHA1":"UZhIoErIy1tKLmVT/5huwlp6KFQ=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/resource","checksumSHA1":"q+y8X+5nDONIlJlxfkv+OtA18ds=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/stats","checksumSHA1":"Cc4tRuW0IjlfAFY8BcdfMDqG0R8=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/stats/internal","checksumSHA1":"oIo4NRi6AVCfcwVfHzCXAsoZsdI=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/stats/view","checksumSHA1":"vN9GN1vwD4RU/3ld2tKK00K0i94=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/tag","checksumSHA1":"AoqL/neZwl05Fv08vcXXlhbY12g=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/trace","checksumSHA1":"0O3djqX4bcg5O9LZdcinEoYeQKs=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/trace/internal","checksumSHA1":"JkvEb8oMEFjic5K/03Tyr5Lok+w=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/trace/propagation","checksumSHA1":"FHJParRi8f1GHO7Cx+lk3bMWBq0=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go.opencensus.io/trace/tracestate","checksumSHA1":"UHbxxaMqpEPsubh8kPwzSlyEwqI=","revision":"b4a14686f0a98096416fe1b4cb848e384fb2b22b","revisionTime":"2019-07-13T07:22:01Z"},
+		{"path":"go4.org/errorutil","checksumSHA1":"PMr/a5kcnC4toJtVwWhlU5E4tJY=","revision":"034d17a462f7b2dcd1a4a73553ec5357ff6e6c6e","revisionTime":"2017-05-24T23:16:39Z"},
+		{"path":"golang.org/x/crypto/blake2b","checksumSHA1":"ejjxT0+wDWWncfh0Rt3lSH4IbXQ=","revision":"de0752318171da717af4ce24d0a2e8626afaeb11","revisionTime":"2018-08-08T16:52:45Z"},
+		{"path":"golang.org/x/crypto/ssh/terminal","checksumSHA1":"BGm8lKZmvJbf/YOJLeL1rw2WVjA=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
+		{"path":"golang.org/x/net/context","checksumSHA1":"GtamqiJoL7PGHsN454AoffBFMa8=","revision":"c10e9556a7bc0e7c942242b606f0acf024ad5d6a","revisionTime":"2018-11-02T08:55:01Z"},
+		{"path":"golang.org/x/net/context/ctxhttp","checksumSHA1":"WHc3uByvGaMcnSoI21fhzYgbOgg=","revision":"f09c4662a0bd6bd8943ac7b4931e185df9471da4","revisionTime":"2016-09-24T00:10:04Z"},
+		{"path":"golang.org/x/net/html","checksumSHA1":"vqc3a+oTUGX8PmD0TS+qQ7gmN8I=","revision":"66aacef3dd8a676686c7ae3716979581e8b03c47","revisionTime":"2016-09-14T00:11:54Z"},
+		{"path":"golang.org/x/net/html/atom","checksumSHA1":"00eQaGynDYrv3tL+C7l9xH0IDZg=","revision":"66aacef3dd8a676686c7ae3716979581e8b03c47","revisionTime":"2016-09-14T00:11:54Z"},
+		{"path":"golang.org/x/net/html/charset","checksumSHA1":"barUU39reQ7LdgYLA323hQ/UGy4=","revision":"66aacef3dd8a676686c7ae3716979581e8b03c47","revisionTime":"2016-09-14T00:11:54Z"},
+		{"path":"golang.org/x/net/http2","checksumSHA1":"kKuxyoDujo5CopTxAvvZ1rrLdd0=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
+		{"path":"golang.org/x/net/http2/hpack","checksumSHA1":"ezWhc7n/FtqkLDQKeU2JbW+80tE=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
+		{"path":"golang.org/x/net/idna","checksumSHA1":"g/Z/Ka0VgJESgQK7/SJCjm/aX0I=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
+		{"path":"golang.org/x/net/internal/timeseries","checksumSHA1":"UxahDzW2v4mf/+aFxruuupaoIwo=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
+		{"path":"golang.org/x/net/lex/httplex","checksumSHA1":"3xyuaSNmClqG4YWC7g0isQIbUTc=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
+		{"path":"golang.org/x/net/proxy","checksumSHA1":"r9l4r3H6FOLQ0c2JaoXpopFjpnw=","origin":"github.com/docker/docker/vendor/golang.org/x/net/proxy","revision":"320063a2ad06a1d8ada61c94c29dbe44e2d87473","revisionTime":"2018-08-16T08:14:46Z"},
+		{"path":"golang.org/x/net/trace","checksumSHA1":"u/r66lwYfgg682u5hZG7/E7+VCY=","revision":"ab5485076ff3407ad2d02db054635913f017b0ed","revisionTime":"2017-07-19T21:11:51Z"},
+		{"path":"golang.org/x/oauth2","checksumSHA1":"uRlaEkyMCxyjj57KBa81GEfvCwg=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
+		{"path":"golang.org/x/oauth2/google","checksumSHA1":"w5SmJwdVFlGE1KO4/AQjY+jvdsI=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
+		{"path":"golang.org/x/oauth2/internal","checksumSHA1":"rnUL+5Yzlt+Ky2dlB61VqfhBOb8=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
+		{"path":"golang.org/x/oauth2/jws","checksumSHA1":"huVltYnXdRFDJLgp/ZP9IALzG7g=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
+		{"path":"golang.org/x/oauth2/jwt","checksumSHA1":"HGS6ig1GfcE2CBHBsi965ZVn9Xw=","revision":"0f29369cfe4552d0e4bcddc57cc75f4d7e672a33","revisionTime":"2019-05-07T23:52:07Z"},
+		{"path":"golang.org/x/sync/errgroup","checksumSHA1":"S0DP7Pn7sZUmXc55IzZnNvERu6s=","revision":"316e794f7b5e3df4e95175a45a5fb8b12f85cb4f","revisionTime":"2016-07-15T18:54:39Z"},
+		{"path":"golang.org/x/sys/cpu","checksumSHA1":"REkmyB368pIiip76LiqMLspgCRk=","revision":"1b2967e3c290b7c545b3db0deeda16e9be4f98a2","revisionTime":"2018-07-06T09:56:39Z"},
+		{"path":"golang.org/x/sys/unix","checksumSHA1":"su2QDjUzrUO0JnOH9m0cNg0QqsM=","revision":"ac767d655b305d4e9612f5f6e33120b9176c4ad4","revisionTime":"2018-07-08T03:57:06Z"},
+		{"path":"golang.org/x/sys/windows","checksumSHA1":"l1jIhK9Y33obLipDvmjVPCdYtJI=","revision":"1b2967e3c290b7c545b3db0deeda16e9be4f98a2","revisionTime":"2018-07-06T09:56:39Z"},
+		{"path":"golang.org/x/text/encoding","checksumSHA1":"Mr4ur60bgQJnQFfJY0dGtwWwMPE=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/encoding/charmap","checksumSHA1":"HgcUFTOQF5jOYtTIj5obR3GVN9A=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/encoding/htmlindex","checksumSHA1":"yBhX1V6U7stq3GqS2x5yzF0lV+I=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/encoding/internal","checksumSHA1":"zeHyHebIZl1tGuwGllIhjfci+wI=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/encoding/internal/identifier","checksumSHA1":"9cg4nSGfKTIWKb6bWV7U4lnuFKA=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/encoding/japanese","checksumSHA1":"f/PWjU17cU5uo0zkdi+Iz80Megk=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/encoding/korean","checksumSHA1":"qHQ79q9peY8ZkCMC8kJAb52BAWg=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/encoding/simplifiedchinese","checksumSHA1":"55UdScb+EMOCPr7OW0hCwDsVxpg=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/encoding/traditionalchinese","checksumSHA1":"9EZF1SHTpjVmaT9sARitvGKUXOY=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/encoding/unicode","checksumSHA1":"G9LfJI9gySazd+MyyC6QbTHx4to=","revision":"e113a52b01bdd1744681b6ce70c2e3d26b58d389","revisionTime":"2017-08-30T18:54:29Z"},
+		{"path":"golang.org/x/text/internal","checksumSHA1":"i47RkGDg+mFR2sYXOfVRVkGow3U=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/internal/language","checksumSHA1":"TWgJww5WcPoH39HKMNW0gEcQHts=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/internal/tag","checksumSHA1":"hyNCcTwMQnV6/MK8uUW9E5H0J0M=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/internal/utf8internal","checksumSHA1":"Qk7dljcrEK1BJkAEZguxAbG9dSo=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/language","checksumSHA1":"B2EFJkBRmiAWXqY/4zqUJfp85ag=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/runes","checksumSHA1":"IV4MN7KGBSocu/5NR3le3sxup4Y=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/secure/bidirule","checksumSHA1":"tltivJ/uj/lqLk05IqGfCv2F/E8=","revision":"88f656faf3f37f690df1a32515b479415e1a6769","revisionTime":"2017-10-26T07:52:28Z"},
+		{"path":"golang.org/x/text/transform","checksumSHA1":"ziMb9+ANGRJSSIuxYdRbA+cDRBQ=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/unicode/bidi","checksumSHA1":"iB6/RoQIzBaZxVi+t7tzbkwZTlo=","revision":"88f656faf3f37f690df1a32515b479415e1a6769","revisionTime":"2017-10-26T07:52:28Z"},
+		{"path":"golang.org/x/text/unicode/cldr","checksumSHA1":"jer43nmInsJhYFfpl39FpEYyoC4=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/unicode/norm","checksumSHA1":"BCNYmf4Ek93G4lk5x3ucNi/lTwA=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/unicode/rangetable","checksumSHA1":"1mKbP+ZJSE2oamuShC/hhvJahks=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/text/width","checksumSHA1":"zuieOGXKG9vXxNhEWv3H0X8RSXM=","revision":"b7ef84aaf62aa3e70962625c80a571ae7c17cb40","revisionTime":"2018-02-22T12:58:23Z"},
+		{"path":"golang.org/x/time/rate","checksumSHA1":"h/06ikMECfJoTkWj2e1nJ30aDDg=","revision":"a4bde12657593d5e90d0533a3e4fd95e635124cb","revisionTime":"2016-02-02T18:34:45Z"},
+		{"path":"google.golang.org/api/gensupport","checksumSHA1":"QyBLCM74VEO9bekzOZGcEkJ7V0o=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/api/googleapi","checksumSHA1":"YIDE68w/xMptf6Nu9hHiOwXOvho=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/api/googleapi/internal/uritemplates","checksumSHA1":"1K0JxrUfDqAB3MyRiU1LKjfHyf4=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/api/googleapi/transport","checksumSHA1":"Mr2fXhMRzlQCgANFm91s536pG7E=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/api/internal","checksumSHA1":"6Tg4dDJKzoSrAA5beVknvnjluOU=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/api/iterator","checksumSHA1":"zh9AcT6oNvhnOqb7w7njY48TkvI=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/api/option","checksumSHA1":"2AyxThTPscWdy49fGsU2tg0Uyw8=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/api/storage/v1","checksumSHA1":"5M3TLPBoDz0A+PsHGDJmjmwqoTI=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/api/transport/http","checksumSHA1":"a+PkIGoiF+p+ghmjmA9gUkMFwYQ=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/api/transport/http/internal/propagation","checksumSHA1":"sJcKCvjPtoysqyelsB2CQzC5oQI=","revision":"035d22e007183e382031a505793aeb0ddb724007","revisionTime":"2019-08-24T00:08:15Z"},
+		{"path":"google.golang.org/genproto/googleapis/api/annotations","checksumSHA1":"xmp0GjeJfZUWSmGfoUA/pxlKc0Q=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
+		{"path":"google.golang.org/genproto/googleapis/iam/v1","checksumSHA1":"3hrELKtivO5PZZfzCL4JVOX3/Kw=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
+		{"path":"google.golang.org/genproto/googleapis/rpc/code","checksumSHA1":"74OOKlkosdNECTQ8HvRmtMsqJZg=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
+		{"path":"google.golang.org/genproto/googleapis/rpc/status","checksumSHA1":"Q0bDd8ApwAloBd/JQw0uZD4DbZM=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
+		{"path":"google.golang.org/genproto/googleapis/type/expr","checksumSHA1":"AyISVQkdxcMLS/tagl6PJFTs8Bs=","revision":"b515fa19cec88c32f305a962f34ae60068947aea","revisionTime":"2019-05-08T19:38:15Z"},
+		{"path":"google.golang.org/grpc","checksumSHA1":"UKBaAnKJu1ydInKNkSvnJ4s18QQ=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
+		{"path":"google.golang.org/grpc/codes","checksumSHA1":"/eTpFgjvMq5Bc9hYnw5fzKG4B6I=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"google.golang.org/grpc/credentials","checksumSHA1":"wA6y5rkH1v4bWBe5M1r/Hdtgma4=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
+		{"path":"google.golang.org/grpc/grpclb/grpc_lb_v1","checksumSHA1":"2NbY9kmMweE4VUsruRsvmViVnNg=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"google.golang.org/grpc/grpclog","checksumSHA1":"MCQmohiDJwkgLWu/wpnekweQh8s=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"google.golang.org/grpc/health","checksumSHA1":"pc9cweMiKQ5hVMuO9UoMGdbizaY=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"google.golang.org/grpc/health/grpc_health_v1","checksumSHA1":"W5KfI1NIGJt7JaVnLzefDZr3+4s=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"google.golang.org/grpc/internal","checksumSHA1":"cSdzm5GhbalJbWUNrN8pRdW0uks=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
+		{"path":"google.golang.org/grpc/internal/transport","checksumSHA1":"Z1mhrOEf+PedS4kVtNRlINUDzWg=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
+		{"path":"google.golang.org/grpc/keepalive","checksumSHA1":"hcuHgKp8W0wIzoCnNfKI8NUss5o=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"google.golang.org/grpc/metadata","checksumSHA1":"OjIAi5AzqlQ7kLtdAyjvdgMf6hc=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
+		{"path":"google.golang.org/grpc/naming","checksumSHA1":"Zzb7Xsc3tbTJzrcZbSPyye+yxmw=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"google.golang.org/grpc/peer","checksumSHA1":"n5EgDdBqFMa2KQFhtl+FF/4gIFo=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"google.golang.org/grpc/stats","checksumSHA1":"YclPgme2gT3S0hTkHVdE1zAxJdo=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
+		{"path":"google.golang.org/grpc/status","checksumSHA1":"t/NhHuykWsxY0gEBd2WIv5RVBK8=","revision":"b534d2d20e596ca053e3070dc1745432d0cc91a6","revisionTime":"2018-07-17T15:26:04Z"},
+		{"path":"google.golang.org/grpc/tap","checksumSHA1":"aixGx/Kd0cj9ZlZHacpHe3XgMQ4=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"google.golang.org/grpc/transport","checksumSHA1":"oFGr0JoquaPGVnV86fVL8MVTc3A=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
+		{"path":"gopkg.in/fsnotify.v1","checksumSHA1":"eIhF+hmL/XZhzTiAwhLD0M65vlY=","revision":"629574ca2a5df945712d3079857300b5e4da0236","revisionTime":"2016-10-11T02:33:12Z"},
+		{"path":"gopkg.in/inf.v0","checksumSHA1":"6f8MEU31llHM1sLM/GGH4/Qxu0A=","revision":"3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4","revisionTime":"2015-09-11T12:57:57Z"},
+		{"path":"gopkg.in/tomb.v1","checksumSHA1":"TO8baX+t1Qs7EmOYth80MkbKzFo=","revision":"dd632973f1e7218eb1089048e0798ec9ae7dceb8","revisionTime":"2014-10-24T13:56:13Z"},
+		{"path":"gopkg.in/tomb.v2","checksumSHA1":"WiyCOMvfzRdymImAJ3ME6aoYUdM=","revision":"14b3d72120e8d10ea6e6b7f87f7175734b1faab8","revisionTime":"2014-06-26T14:46:23Z"},
+		{"path":"gopkg.in/yaml.v2","checksumSHA1":"12GqsW8PiRPnezDDy0v4brZrndM=","revision":"a5b47d31c556af34a302ce5d659e6fea44d90de0","revisionTime":"2016-09-28T15:37:09Z"}
 	],
 	"rootPath": "github.com/hashicorp/nomad"
 }


### PR DESCRIPTION
This PR uses the go-cni lib from containerd instead of libcni directly. go-cni adds a few abstractions that we can rely on for managing cni configs, runtime configs and portmapping.

This also adds the `forceAddress` flag to the bridge cni configuration. This options forces setting of the bridge IP regardless of if is already set or not. 