### PR TITLE
client: recreate script checks on Update

### DIFF
--- a/client/allocrunner/taskrunner/script_check_hook_test.go
+++ b/client/allocrunner/taskrunner/script_check_hook_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/interfaces"
+	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/require"
@@ -17,16 +18,19 @@ import (
 
 func newScriptMock(hb heartbeater, exec interfaces.ScriptExecutor, logger hclog.Logger, interval, timeout time.Duration) *scriptCheck {
 	script := newScriptCheck(&scriptCheckConfig{
-		allocID:  "allocid",
-		taskName: "testtask",
-		agent:    hb,
-		service:  &structs.Service{Name: "xx"},
-		check:    &structs.ServiceCheck{},
+		allocID:   "allocid",
+		taskName:  "testtask",
+		serviceID: "serviceid",
+		check: &structs.ServiceCheck{
+			Interval: interval,
+			Timeout:  timeout,
+		},
+		agent:      hb,
+		driverExec: exec,
+		taskEnv:    &taskenv.TaskEnv{},
+		logger:     logger,
+		shutdownCh: nil,
 	})
-	script.exec = exec
-	script.logger = logger
-	script.Interval = interval
-	script.Timeout = timeout
 	script.callback = newScriptCheckCallback(script)
 	script.lastCheckOk = true
 	return script


### PR DESCRIPTION
This PR fixes a bug uncovered in e2e testing in https://github.com/hashicorp/nomad/pull/6252

Splitting the immutable and mutable components of the `scriptCheck` led to a bug where the environment interpolation wasn't being incorporated into the check's ID, which caused the `UpdateTTL` to update for a check ID that Consul didn't have (because our Consul client creates the ID from the `structs.ServiceCheck` each time we update).