### PR TITLE
UI: Add handling for not-running task filesystem query

### DIFF
--- a/ui/app/routes/allocations/allocation/task/fs.js
+++ b/ui/app/routes/allocations/allocation/task/fs.js
@@ -9,6 +9,13 @@ export default Route.extend({
 
     const pathWithTaskName = `${task.name}${decodedPath.startsWith('/') ? '' : '/'}${decodedPath}`;
 
+    if (!task.isRunning) {
+      return {
+        path: decodedPath,
+        task,
+      };
+    }
+
     return RSVP.all([task.stat(pathWithTaskName), task.get('allocation.node')])
       .then(([statJson]) => {
         if (statJson.IsDir) {

--- a/ui/tests/acceptance/task-fs-test.js
+++ b/ui/tests/acceptance/task-fs-test.js
@@ -69,6 +69,11 @@ module('Acceptance | task fs', function(hooks) {
   });
 
   test('when the task is not running, an empty state is shown', async function(assert) {
+    // The API 500s on stat when not running
+    this.server.get('/client/fs/stat/:allocation_id', () => {
+      return new Response(500, {}, 'no such file or directory');
+    });
+
     task.update({
       finishedAt: new Date(),
     });


### PR DESCRIPTION
Without this, I was seeing this failure:

![fs-stat-failure](https://user-images.githubusercontent.com/43280/64292505-29e89900-cf30-11e9-9a40-7b5fd9128cb0.gif)

This is the intended display:

![image](https://user-images.githubusercontent.com/43280/64292528-353bc480-cf30-11e9-89b4-3fe32942542a.png)
