### PR TITLE
UI: Restore local headless testing

### DIFF
--- a/ui/testem.js
+++ b/ui/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
I’ve been unable to use ember test without --server for a
while. This brings in the fix from ember-cli/ember-cli#8774