### PR TITLE
add validation for job_gc_interval

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -278,7 +278,7 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	if gcInterval := agentConfig.Server.JobGCInterval; gcInterval != "" {
 		dur, err := time.ParseDuration(gcInterval)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse job_gc_interval: %v", err)
 		} else if dur <= time.Duration(0) {
 			return nil, fmt.Errorf("job_gc_interval should be greater than 0s")
 		}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -279,6 +279,8 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		dur, err := time.ParseDuration(gcInterval)
 		if err != nil {
 			return nil, err
+		} else if dur <= time.Duration(0) {
+			return nil, fmt.Errorf("job_gc_interval should be greater than 0s")
 		}
 		conf.JobGCInterval = dur
 	}


### PR DESCRIPTION
## Overview
follow-up to https://github.com/hashicorp/nomad/pull/5978

The command/agent currently panics if the duration is an invalid value, this pull request adds validation.

## Behavior
#### The panic
```
panic: non-positive interval for NewTicker                                                                               [190/1172]
                                                                                                                                   
goroutine 188 [running]:                                                                                                           
time.NewTicker(0xfffffffdabf41c00, 0x240c218)                                                                                      
        /usr/local/go/src/time/tick.go:23 +0x190                                                                                   
github.com/hashicorp/nomad/nomad.(*Server).schedulePeriodic(0xc0000e2000, 0xc0004a6240)                                            
        /home/jasmine/go/src/github.com/hashicorp/nomad/nomad/leader.go:446 +0xe1                                                  
created by github.com/hashicorp/nomad/nomad.(*Server).establishLeadership                                                          
        /home/jasmine/go/src/github.com/hashicorp/nomad/nomad/leader.go:243 +0x3c8
```

#### The fix w/ command/agent config validation for job_gc_interval
![Screenshot from 2019-09-05 10-44-26](https://user-images.githubusercontent.com/1182129/64366308-d11a0e80-cfca-11e9-88b0-49e72b0c948f.png)
