### PR TITLE
connect: check if consul is on PATH

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"runtime"
@@ -704,6 +705,10 @@ func newDevModeConfig(devMode, connectMode bool) (*devModeConfig, error) {
 		if u.Uid != "0" {
 			return nil, fmt.Errorf(
 				"-dev-connect uses network namespaces and is only supported for root.")
+		}
+		// Ensure Consul is on PATH
+		if _, err := exec.LookPath("consul"); err != nil {
+			return nil, fmt.Errorf("-dev-connect requires a 'consul' binary in Nomad's $PATH")
 		}
 		mode.connectMode = true
 	}


### PR DESCRIPTION
Only in -dev-connect mode for now since it's valid to install Consul
after Nomad has started in production.

![image](https://user-images.githubusercontent.com/113362/64371583-c3b65180-cfd5-11e9-910e-f0617c04dc79.png)
