### PR TITLE
UI: Remove Connect proxy tag tests again

### DIFF
--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -1,7 +1,7 @@
 import { run } from '@ember/runloop';
 import { currentURL } from '@ember/test-helpers';
 import { assign } from '@ember/polyfills';
-import { module, test } from 'qunit';
+import { module, skip, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import Allocation from 'nomad-ui/tests/pages/allocations/detail';
@@ -140,7 +140,7 @@ module('Acceptance | allocation detail', function(hooks) {
     assert.ok(Allocation.firstUnhealthyTask().hasUnhealthyDriver, 'Warning is shown');
   });
 
-  test('proxy task has a proxy tag', async function(assert) {
+  skip('proxy task has a proxy tag', async function(assert) {
     // Must create a new job as existing one has loaded and it contains the tasks
     job = server.create('job', {
       groupsCount: 1,

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -1,5 +1,5 @@
 import { currentURL } from '@ember/test-helpers';
-import { module, test } from 'qunit';
+import { module, skip, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import Task from 'nomad-ui/tests/pages/allocations/task/detail';
@@ -326,7 +326,7 @@ module('Acceptance | proxy task detail', function(hooks) {
     await Task.visit({ id: allocation.id, name: taskState.name });
   });
 
-  test('a proxy tag is shown', async function(assert) {
+  skip('a proxy tag is shown', async function(assert) {
     assert.ok(Task.title.proxyTag.isPresent);
   });
 });


### PR DESCRIPTION
This semi-reverts #6275, as the tests are intermittently
failing in CI.