### PR TITLE
Fix inplace updates bug with group level networks

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -509,9 +509,11 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 					AllocatedResources: resources,
 					DesiredStatus:      structs.AllocDesiredStatusRun,
 					ClientStatus:       structs.AllocClientStatusPending,
+					// SharedResources is considered deprecated, will be removed in 0.11.
+					// It is only set for compat reasons.
 					SharedResources: &structs.Resources{
 						DiskMB:   tg.EphemeralDisk.SizeMB,
-						Networks: tg.Networks,
+						Networks: resources.Shared.Networks,
 					},
 				}
 

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -363,9 +363,11 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 			AllocatedResources: resources,
 			DesiredStatus:      structs.AllocDesiredStatusRun,
 			ClientStatus:       structs.AllocClientStatusPending,
+			// SharedResources is considered deprecated, will be removed in 0.11.
+			// It is only set for compat reasons
 			SharedResources: &structs.Resources{
 				DiskMB:   missing.TaskGroup.EphemeralDisk.SizeMB,
-				Networks: missing.TaskGroup.Networks,
+				Networks: resources.Shared.Networks,
 			},
 		}
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -840,6 +840,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateTy
 				DiskMB: int64(newTG.EphemeralDisk.SizeMB),
 				// Since this is an inplace update, we should copy network
 				// information from the original alloc. This is similar to
+				// how we copy network info for task level networks above.
 				Networks: existing.AllocatedResources.Shared.Networks,
 			},
 		}

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -822,7 +822,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateTy
 				networks = tr.Networks
 			}
 
-			// Add thhe networks back
+			// Add the networks back
 			resources.Networks = networks
 		}
 
@@ -837,8 +837,10 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateTy
 		newAlloc.AllocatedResources = &structs.AllocatedResources{
 			Tasks: option.TaskResources,
 			Shared: structs.AllocatedSharedResources{
-				DiskMB:   int64(newTG.EphemeralDisk.SizeMB),
-				Networks: newTG.Networks,
+				DiskMB: int64(newTG.EphemeralDisk.SizeMB),
+				// Since this is an inplace update, we should copy network
+				// information from the original alloc. This is similar to
+				Networks: existing.AllocatedResources.Shared.Networks,
 			},
 		}
 


### PR DESCRIPTION
During inplace updates, we should be using network information
from the previous allocation being updated. Instead in commit https://github.com/hashicorp/nomad/commit/4cb99a111224d57c0ab1c892e043cd5af0d7ba5f we copied task group level network fields into the allocation. This caused fields set by the scheduler such as the network device, IP and CIDR range to get overridden to empty, causing inplace upgrades to fail. 

I also did a couple of drive by fixes in compatability code for `SharedResources` which is not used anywhere but should be set to the correct value in order of us to be able to deprecate/remove sharedResources in a future release. 