### PR TITLE
Fix host volume path

### DIFF
--- a/website/source/guides/stateful-workloads/host-volumes.md
+++ b/website/source/guides/stateful-workloads/host-volumes.md
@@ -107,7 +107,7 @@ Add the following to the `client` stanza of your Nomad configuration:
 
 ```hcl
   host_volume "mysql" {
-    path      = "/data/mysql"
+    path      = "/opt/mysql/data"
     read_only = false
   }
 ```


### PR DESCRIPTION
To keep the example consistent, the host volume path should be the same path that was created in the previous step.