### PR TITLE
script checks: Update needs to update Alloc as well

### DIFF
--- a/client/allocrunner/taskrunner/script_check_hook.go
+++ b/client/allocrunner/taskrunner/script_check_hook.go
@@ -116,6 +116,7 @@ func (h *scriptCheckHook) Update(ctx context.Context, req *interfaces.TaskUpdate
 	if task == nil {
 		return fmt.Errorf("task %q not found in updated alloc", h.task.Name)
 	}
+	h.alloc = req.Alloc
 	h.task = task
 	h.taskEnv = req.TaskEnv
 


### PR DESCRIPTION
Without updating the alloc during the `Update` hook, we won't change any values in the script check and the check IDs will mismatch between the script runner and Consul.