### PR TITLE
dev: expose Consul port 8500 in linux-ui Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,12 +38,13 @@ Vagrant.configure(2) do |config|
 			privileged: false,
 			path: './scripts/vagrant-linux-unpriv-bootstrap.sh'
 
-        # Expose the nomad api and ui to the host
-        vmCfg.vm.network "forwarded_port", guest: 4646, host: 4646, auto_correct: true
+		# Expose the nomad api and ui to the host
+		vmCfg.vm.network :forwarded_port, guest: 4646, host: 4646, auto_correct: true
+		vmCfg.vm.network :forwarded_port, guest: 8500, host: 8500, auto_correct: true
 
-        # Expose Ember ports to the host (one for the site, one for livereload)
-        vmCfg.vm.network :forwarded_port, guest: 4201, host: 4201, auto_correct: true
-        vmCfg.vm.network :forwarded_port, guest: 49153, host: 49153, auto_correct: true
+		# Expose Ember ports to the host (one for the site, one for livereload)
+		vmCfg.vm.network :forwarded_port, guest: 4201, host: 4201, auto_correct: true
+		vmCfg.vm.network :forwarded_port, guest: 49153, host: 49153, auto_correct: true
 	end
 
 	config.vm.define "freebsd", autostart: false, primary: false do |vmCfg|


### PR DESCRIPTION
For local development with Vagrant, particularly for manual and e2e testing of service/check registration, it's useful to have the Consul API and web UI exposed.