### PR TITLE
e2e: tag instances with origin

### DIFF
--- a/e2e/terraform/compute.tf
+++ b/e2e/terraform/compute.tf
@@ -37,6 +37,8 @@ resource "aws_instance" "server" {
   tags {
     Name           = "${local.random_name}-server-${count.index}"
     ConsulAutoJoin = "auto-join"
+    SHA            = "${var.nomad_sha}"
+    User           = "${data.aws_caller_identity.current.arn}"
   }
 
   user_data            = "${data.template_file.user_data_server.rendered}"
@@ -83,6 +85,8 @@ resource "aws_instance" "client" {
   tags {
     Name           = "${local.random_name}-client-${count.index}"
     ConsulAutoJoin = "auto-join"
+    SHA            = "${var.nomad_sha}"
+    User           = "${data.aws_caller_identity.current.arn}"
   }
 
   ebs_block_device =  {
@@ -126,4 +130,3 @@ resource "aws_instance" "client" {
     }
   }
 }
-

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -71,6 +71,8 @@ data "aws_ami" "main" {
 
 }
 
+data "aws_caller_identity" "current" {}
+
 output "servers" {
   value = "${aws_instance.server.*.public_ip}"
 }


### PR DESCRIPTION
When multiple developers are working on e2e testing, it helps to be able to identify which infrastructure belongs to which Nomad SHA and which developer. This adds tags to the EC2 instances.