### PR TITLE
manage dev deps in vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,8 @@
 LINUX_BASE_BOX = "bento/ubuntu-16.04"
 FREEBSD_BASE_BOX = "freebsd/FreeBSD-11.2-STABLE"
 
+LINUX_IP_ADDRESS = "10.199.0.200"
+
 Vagrant.configure(2) do |config|
 	# Compilation and development boxes
 	config.vm.define "linux", autostart: true, primary: true do |vmCfg|
@@ -21,6 +23,10 @@ Vagrant.configure(2) do |config|
 		vmCfg.vm.provision "shell",
 			privileged: false,
 			path: './scripts/vagrant-linux-unpriv-bootstrap.sh'
+
+		vmCfg.vm.provider "virtualbox" do |_|
+			vmCfg.vm.network :private_network, ip: LINUX_IP_ADDRESS
+		end
 	end
 
 	config.vm.define "linux-ui", autostart: false, primary: false do |vmCfg|

--- a/scripts/vagrant-linux-priv-config.sh
+++ b/scripts/vagrant-linux-priv-config.sh
@@ -20,19 +20,12 @@ apt-get install -y \
 	libpcre3-dev \
 	linux-libc-dev:i386 \
 	pkg-config \
-	zip
-
-# Install Development utilities
-apt-get install -y \
+	zip \
 	curl \
-	default-jre \
-	htop \
 	jq \
-	qemu \
-	silversearcher-ag \
 	tree \
 	unzip \
-	vim
+	wget
 
 # Install ARM build utilities
 apt-get install -y \

--- a/scripts/vagrant-linux-priv-dev.sh
+++ b/scripts/vagrant-linux-priv-dev.sh
@@ -8,6 +8,11 @@ apt-get install -y \
 	      silversearcher-ag \
 	      vim
 
+# Install Chrome for running tests (in headless mode)
+wget -qO- - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+apt-get update
+apt-get install -y google-chrome-stable
 
 # Set hostname -> IP to make advertisement work as expected
 ip=$(ip route get 1 | awk '{print $NF; exit}')

--- a/scripts/vagrant-linux-priv-dev.sh
+++ b/scripts/vagrant-linux-priv-dev.sh
@@ -2,14 +2,10 @@
 
 # Install Development utilities
 apt-get install -y \
-	      curl \
 	      default-jre \
 	      htop \
-	      jq \
 	      qemu \
 	      silversearcher-ag \
-	      tree \
-	      unzip \
 	      vim
 
 

--- a/scripts/vagrant-linux-unpriv-ui.sh
+++ b/scripts/vagrant-linux-unpriv-ui.sh
@@ -15,9 +15,3 @@ npm install -g ember-cli
 
 # Install Yarn for front-end dependency management
 curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
-
-# Install Chrome for running tests (in headless mode)
-wget -qO- - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-sudo sh -c 'echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-sudo apt-get update
-sudo apt-get install -y google-chrome-stable


### PR DESCRIPTION
Ensure that dev dependencies are only installed from scripts/vagrant-linux-priv-dev.sh , to avoid them being installed in our binary release docker container that doesn't run tests.

Also, expose vagrant linux box with a stable ip address without needing port maps.