### PR TITLE
e2e: fixes for race conditions in testing

### DIFF
--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -62,18 +62,20 @@ func RegisterAllocs(t *testing.T, nomadClient *api.Client, jobFile string, jobID
 	job.ID = helper.StringToPtr(jobID)
 
 	// Register job
+	var idx uint64
 	jobs := nomadClient.Jobs()
 	testutil.WaitForResult(func() (bool, error) {
-		resp, _, err := jobs.Register(job, nil)
+		resp, meta, err := jobs.Register(job, nil)
 		if err != nil {
 			return false, err
 		}
+		idx = meta.LastIndex
 		return resp.EvalID != "", fmt.Errorf("expected EvalID:%s", pretty.Sprint(resp))
 	}, func(err error) {
 		require.NoError(err)
 	})
 
-	allocs, _, _ := jobs.Allocations(jobID, false, nil)
+	allocs, _, _ := jobs.Allocations(jobID, false, &api.QueryOptions{WaitIndex: idx})
 	return allocs
 }
 


### PR DESCRIPTION
- In script checks, ensure we're running `Exec` against the new running
  allocation and not the earlier stopped one.
- In script checks, allocate a pty for `Exec` calls to avoid spurious
  errors when we use the exec to kill the task.
- In `utils.go/RegisterAllocs`, force query for allocations to wait on
  wait index returned by registration call.