### PR TITLE
fix 'nomad namespace apply' help message

### DIFF
--- a/command/namespace.go
+++ b/command/namespace.go
@@ -23,7 +23,7 @@ Usage: nomad namespace <subcommand> [options] [args]
 
   Create or update a namespace:
 
-      $ nomad namespace apply <name> -description "My new namespace"
+      $ nomad namespace apply -description "My new namespace" <name> 
 
   List namespaces:
 


### PR DESCRIPTION
Named arguments need to preceed positional arguments.

When passing arguments in wrong order, you get:
```
$ nomad namespace apply mytest -description "My new namespace"
This command takes one argument: <namespace>
For additional help try 'nomad namespace apply -help'
```