### PR TITLE
client/networking: wrap error message from CNI plugin

### DIFF
--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -163,7 +163,7 @@ func (b *bridgeNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Al
 		if _, err := b.cni.Setup(ctx, alloc.ID, spec.Path, cni.WithCapabilityPortMap(getPortMapping(alloc))); err != nil {
 			b.logger.Warn("failed to configure bridge network", "err", err, "attempt", attempt)
 			if attempt == retry {
-				return err
+				return fmt.Errorf("failed to configure bridge network: %v", err)
 			}
 			// Sleep for 1 second + jitter
 			time.Sleep(time.Second + (time.Duration(b.rand.Int63n(1000)) * time.Millisecond))


### PR DESCRIPTION
The error messages from `go-cni`'s [`Setup()`](https://github.com/containerd/go-cni/blob/d20b7eebc7ee1339cb703c4c18be6fd3fa81ad8f/cni.go#L142-L160) method aren't annotated, so it makes the message that a job operator receives a little unclear.

@endocrimes reported an issue with the [Connect demo job](https://github.com/hashicorp/nomad/blob/master/e2e/connect/input/demo.nomad) which turned out to be a problem with laptop networking. But the job operator messages (see below) weren't very helpful because there was no eth0 on the laptop. Wrapping the error better would at least give us an entry point into the CNI library where the problem is happening.

```
Recent Events:
Time                       Type           Description
2019-09-12T19:35:37+02:00  Killing        Sent interrupt. Waiting 5s before force killing
2019-09-12T19:35:36+02:00  Setup Failure  failed to setup alloc: pre-run hook "network" failed: failed to configure networking for alloc: container veth name provided (eth0) already exists       
2019-09-12T19:35:31+02:00  Received       Task received by client
```