### PR TITLE
Fix `volume_mount` attribute in the docs and formatting

### DIFF
--- a/website/source/docs/job-specification/volume.html.md
+++ b/website/source/docs/job-specification/volume.html.md
@@ -19,7 +19,7 @@ description: |-
   </tr>
 </table>
 
-The "volume" stanza allows the group to specify that it requires a given volume
+The `volume` stanza allows the group to specify that it requires a given volume
 from the cluster.
 
 The key of the stanza is the name of the volume as it will be exposed to task
@@ -29,7 +29,7 @@ configuration.
 job "docs" {
   group "example" {
     volume "certs" {
-      type = "host"
+      type      = "host"
       read_only = true
 
       config {
@@ -41,7 +41,7 @@ job "docs" {
 ```
 
 The Nomad server will ensure that the allocations are only scheduled on hosts
-that have a set of volumes that meet the criteria specified in the volume
+that have a set of volumes that meet the criteria specified in the `volume`
 stanzas.
 
 The Nomad client will make the volumes available to tasks according to the

--- a/website/source/docs/job-specification/volume_mount.html.md
+++ b/website/source/docs/job-specification/volume_mount.html.md
@@ -18,8 +18,8 @@ description: |-
   </tr>
 </table>
 
-The "volume_mount" stanza allows the task to specify how a group
-[`volume`][volume] should be mounted into the task. 
+The `volume_mount` stanza allows the task to specify how a group
+[`volume`][volume] should be mounted into the task.
 
 ```hcl
 job "docs" {
@@ -56,7 +56,7 @@ updates to remove a volume that it depends on.
   inside the tasks container.
 
 - `read_only` `(bool: false)` - When a group volume is writeable, you may
-  specify that it is read_only on a per mount level using the `read_only` option
-  here.
+  specify that it is `read_only` on a per mount level using the `read_only`
+  option here.
 
 [volume]: /docs/job-specification/volume.html "Nomad volume Job Specification"


### PR DESCRIPTION
The current documentation page for `volume_mount` stanza has an attribute named `source` where it should be `volume`.