### PR TITLE
Hoist Volume.Config.Source into Volume.Source

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -366,9 +366,8 @@ func (m *MigrateStrategy) Copy() *MigrateStrategy {
 type VolumeRequest struct {
 	Name     string
 	Type     string
+	Source   string
 	ReadOnly bool `mapstructure:"read_only"`
-
-	Config map[string]interface{}
 }
 
 // VolumeMount represents the relationship between a destination path in a task

--- a/client/allocrunner/taskrunner/volume_hook.go
+++ b/client/allocrunner/taskrunner/volume_hook.go
@@ -33,20 +33,14 @@ func (*volumeHook) Name() string {
 func validateHostVolumes(requestedByAlias map[string]*structs.VolumeRequest, clientVolumesByName map[string]*structs.ClientHostVolumeConfig) error {
 	var result error
 
-	for n, req := range requestedByAlias {
+	for _, req := range requestedByAlias {
 		if req.Type != structs.VolumeTypeHost {
 			continue
 		}
 
-		cfg, err := structs.ParseHostVolumeConfig(req.Config)
-		if err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to parse config for %s: %v", n, err))
-			continue
-		}
-
-		_, ok := clientVolumesByName[cfg.Source]
+		_, ok := clientVolumesByName[req.Source]
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("missing %s", cfg.Source))
+			result = multierror.Append(result, fmt.Errorf("missing %s", req.Source))
 		}
 	}
 
@@ -65,16 +59,11 @@ func (h *volumeHook) hostVolumeMountConfigurations(taskMounts []*structs.VolumeM
 			return nil, fmt.Errorf("No group volume declaration found named: %s", m.Volume)
 		}
 
-		cfg, err := structs.ParseHostVolumeConfig(req.Config)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse config for %s: %v", m.Volume, err)
-		}
-
-		hostVolume, ok := clientVolumesByName[cfg.Source]
+		hostVolume, ok := clientVolumesByName[req.Source]
 		if !ok {
 			// Should never happen, but unless the client volumes were mutated during
 			// the execution of this hook.
-			return nil, fmt.Errorf("No host volume named: %s", cfg.Source)
+			return nil, fmt.Errorf("No host volume named: %s", req.Source)
 		}
 
 		mcfg := &drivers.MountConfig{

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -753,7 +753,7 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 				Name:     v.Name,
 				Type:     v.Type,
 				ReadOnly: v.ReadOnly,
-				Config:   v.Config,
+				Source:   v.Source,
 			}
 
 			tg.Volumes[k] = vol

--- a/jobspec/parse_group.go
+++ b/jobspec/parse_group.go
@@ -293,7 +293,7 @@ func parseVolumes(out *map[string]*api.VolumeRequest, list *ast.ObjectList) erro
 			"type",
 			"read_only",
 			"hidden",
-			"config",
+			"source",
 		}
 		if err := helper.CheckHCLKeys(item.Val, valid); err != nil {
 			return err
@@ -303,22 +303,6 @@ func parseVolumes(out *map[string]*api.VolumeRequest, list *ast.ObjectList) erro
 		if err := hcl.DecodeObject(&m, item.Val); err != nil {
 			return err
 		}
-
-		// TODO(dani): this is gross but we don't have ObjectList.Filter here
-		var cfg map[string]interface{}
-		if cfgI, ok := m["config"]; ok {
-			cfgL, ok := cfgI.([]map[string]interface{})
-			if !ok {
-				return fmt.Errorf("Incorrect `config` type, expected map")
-			}
-
-			if len(cfgL) != 1 {
-				return fmt.Errorf("Expected single `config`, found %d", len(cfgL))
-			}
-
-			cfg = cfgL[0]
-		}
-		delete(m, "config")
 
 		var result api.VolumeRequest
 		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
@@ -333,8 +317,6 @@ func parseVolumes(out *map[string]*api.VolumeRequest, list *ast.ObjectList) erro
 		}
 
 		result.Name = n
-		result.Config = cfg
-
 		volumes[n] = &result
 	}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -112,21 +112,16 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 					return structs.ErrPermissionDenied
 				}
 
-				cfg, err := structs.ParseHostVolumeConfig(vol.Config)
-				if err != nil {
-					return structs.ErrPermissionDenied
-				}
-
 				// If a volume is readonly, then we allow access if the user has ReadOnly
 				// or ReadWrite access to the volume. Otherwise we only allow access if
 				// they have ReadWrite access.
 				if vol.ReadOnly {
-					if !aclObj.AllowHostVolumeOperation(cfg.Source, acl.HostVolumeCapabilityMountReadOnly) &&
-						!aclObj.AllowHostVolumeOperation(cfg.Source, acl.HostVolumeCapabilityMountReadWrite) {
+					if !aclObj.AllowHostVolumeOperation(vol.Source, acl.HostVolumeCapabilityMountReadOnly) &&
+						!aclObj.AllowHostVolumeOperation(vol.Source, acl.HostVolumeCapabilityMountReadWrite) {
 						return structs.ErrPermissionDenied
 					}
 				} else {
-					if !aclObj.AllowHostVolumeOperation(cfg.Source, acl.HostVolumeCapabilityMountReadWrite) {
+					if !aclObj.AllowHostVolumeOperation(vol.Source, acl.HostVolumeCapabilityMountReadWrite) {
 						return structs.ErrPermissionDenied
 					}
 				}

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -285,10 +285,8 @@ func TestJobEndpoint_Register_ACL(t *testing.T) {
 		tg := j.TaskGroups[0]
 		tg.Volumes = map[string]*structs.VolumeRequest{
 			"ca-certs": {
-				Type: structs.VolumeTypeHost,
-				Config: map[string]interface{}{
-					"source": "prod-ca-certs",
-				},
+				Type:     structs.VolumeTypeHost,
+				Source:   "prod-ca-certs",
 				ReadOnly: readonlyVolume,
 			},
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4925,13 +4925,7 @@ func (tg *TaskGroup) Validate(j *Job) error {
 			continue
 		}
 
-		cfg, err := ParseHostVolumeConfig(decl.Config)
-		if err != nil {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("Volume %s has unparseable config: %v", name, err))
-			continue
-		}
-
-		if cfg.Source == "" {
+		if decl.Source == "" {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Volume %s has an empty source", name))
 		}
 	}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -872,10 +872,8 @@ func TestTaskGroup_Validate(t *testing.T) {
 	tg = &TaskGroup{
 		Volumes: map[string]*VolumeRequest{
 			"foo": {
-				Type: "nothost",
-				Config: map[string]interface{}{
-					"sOuRcE": "foo",
-				},
+				Type:   "nothost",
+				Source: "foo",
 			},
 		},
 		Tasks: []*Task{

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -1,10 +1,5 @@
 package structs
 
-import (
-	"github.com/mitchellh/copystructure"
-	"github.com/mitchellh/mapstructure"
-)
-
 const (
 	VolumeTypeHost = "host"
 )
@@ -74,29 +69,12 @@ func HostVolumeSliceMerge(a, b []*ClientHostVolumeConfig) []*ClientHostVolumeCon
 	return n
 }
 
-// HostVolumeConfig is the struct that is expected inside the `config` section
-// of a `host` type volume.
-type HostVolumeConfig struct {
-	// Source is the name of the desired HostVolume.
-	Source string
-}
-
-func (h *HostVolumeConfig) Copy() *HostVolumeConfig {
-	if h == nil {
-		return nil
-	}
-	nh := new(HostVolumeConfig)
-	*nh = *h
-	return nh
-}
-
 // VolumeRequest is a representation of a storage volume that a TaskGroup wishes to use.
 type VolumeRequest struct {
 	Name     string
 	Type     string
+	Source   string
 	ReadOnly bool
-
-	Config map[string]interface{}
 }
 
 func (v *VolumeRequest) Copy() *VolumeRequest {
@@ -105,12 +83,6 @@ func (v *VolumeRequest) Copy() *VolumeRequest {
 	}
 	nv := new(VolumeRequest)
 	*nv = *v
-
-	if i, err := copystructure.Copy(nv.Config); err != nil {
-		panic(err.Error())
-	} else {
-		nv.Config = i.(map[string]interface{})
-	}
 
 	return nv
 }
@@ -157,11 +129,4 @@ func CopySliceVolumeMount(s []*VolumeMount) []*VolumeMount {
 		c[i] = v.Copy()
 	}
 	return c
-}
-
-func ParseHostVolumeConfig(m map[string]interface{}) (*HostVolumeConfig, error) {
-	var c HostVolumeConfig
-	err := mapstructure.Decode(m, &c)
-
-	return &c, err
 }

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -115,7 +115,7 @@ func NewHostVolumeChecker(ctx Context) *HostVolumeChecker {
 
 // SetVolumes takes the volumes required by a task group and updates the checker.
 func (h *HostVolumeChecker) SetVolumes(volumes map[string]*structs.VolumeRequest) {
-	nm := make(map[string][]*structs.VolumeRequest)
+	lookupMap := make(map[string][]*structs.VolumeRequest)
 
 	// Convert the map from map[DesiredName]Request to map[Source][]Request to improve
 	// lookup performance. Also filter non-host volumes.
@@ -124,15 +124,9 @@ func (h *HostVolumeChecker) SetVolumes(volumes map[string]*structs.VolumeRequest
 			continue
 		}
 
-		cfg, err := structs.ParseHostVolumeConfig(req.Config)
-		if err != nil {
-			// Could not parse host volume config, skip the volume for now.
-			continue
-		}
-
-		nm[cfg.Source] = append(nm[cfg.Source], req)
+		lookupMap[req.Source] = append(lookupMap[req.Source], req)
 	}
-	h.volumes = nm
+	h.volumes = lookupMap
 }
 
 func (h *HostVolumeChecker) Feasible(candidate *structs.Node) bool {

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -110,15 +110,15 @@ func TestHostVolumeChecker(t *testing.T) {
 	volumes := map[string]*structs.VolumeRequest{
 		"foo": {
 			Type:   "host",
-			Config: map[string]interface{}{"source": "foo"},
+			Source: "foo",
 		},
 		"bar": {
 			Type:   "host",
-			Config: map[string]interface{}{"source": "bar"},
+			Source: "bar",
 		},
 		"baz": {
 			Type:   "nothost",
-			Config: map[string]interface{}{"source": "baz"},
+			Source: "baz",
 		},
 	}
 
@@ -183,19 +183,15 @@ func TestHostVolumeChecker_ReadOnly(t *testing.T) {
 
 	readwriteRequest := map[string]*structs.VolumeRequest{
 		"foo": {
-			Type: "host",
-			Config: map[string]interface{}{
-				"source": "foo",
-			},
+			Type:   "host",
+			Source: "foo",
 		},
 	}
 
 	readonlyRequest := map[string]*structs.VolumeRequest{
 		"foo": {
-			Type: "host",
-			Config: map[string]interface{}{
-				"source": "foo",
-			},
+			Type:     "host",
+			Source:   "foo",
 			ReadOnly: true,
 		},
 	}

--- a/website/source/docs/job-specification/volume.html.md
+++ b/website/source/docs/job-specification/volume.html.md
@@ -30,11 +30,8 @@ job "docs" {
   group "example" {
     volume "certs" {
       type      = "host"
+      source    = "ca-certificates"
       read_only = true
-
-      config {
-        source = "ca-certificates"
-      }
     }
   }
 }
@@ -52,14 +49,13 @@ The Nomad client will make the volumes available to tasks according to the
 - `type` `(string: "")` - Specifies the type of a given volume. Currently the
   only possible volume type is `"host"`.
 
+- `source` `(string: "")` - The name of the volume to request. When using
+  `host_volume`'s this should match the published name of the host volume.
+
 - `read_only` `(bool: false)` - Specifies that the group only requires read only
   access to a volume and is used as the default value for the `volume_mount ->
   read_only` configuration. This value is also used for validating `host_volume`
   ACLs and for scheduling when a matching `host_volume` requires `read_only`
   usage.
-
-- `config` `(json/hcl: nil)` - Specifies the configuration for the volume
-  provider. For a `host_volume`, the only key is `source`, which is the name of
-  the volume to request.
 
 [volume_mount]: /docs/job-specification/volume_mount.html "Nomad volume_mount Job Specification"

--- a/website/source/docs/job-specification/volume.html.md
+++ b/website/source/docs/job-specification/volume.html.md
@@ -49,7 +49,7 @@ The Nomad client will make the volumes available to tasks according to the
 - `type` `(string: "")` - Specifies the type of a given volume. Currently the
   only possible volume type is `"host"`.
 
-- `source` `(string: "")` - The name of the volume to request. When using
+- `source` `(string: <required>)` - The name of the volume to request. When using
   `host_volume`'s this should match the published name of the host volume.
 
 - `read_only` `(bool: false)` - Specifies that the group only requires read only

--- a/website/source/guides/stateful-workloads/host-volumes.md
+++ b/website/source/guides/stateful-workloads/host-volumes.md
@@ -147,10 +147,7 @@ job "mysql-server" {
 
     volume "mysql" {
       type = "host"
-
-      config {
-        source = "mysql"
-      }
+      source = "mysql" 
     }
 
     restart {


### PR DESCRIPTION
Currently, using a Volume in a job uses the following configuration:

```
volume "alias-name" {
  type = "volume-type"
  read_only = true

  config {
    source = "host_volume_name"
  }
}
```

This commit migrates to the following:

```
volume "alias-name" {
  type = "volume-type"
  source = "host_volume_name"
  read_only = true
}
```

The original design was based due to being uncertain about the future of storage plugins, and to allow maximum flexibility.

However, this causes a few issues, namely:
- We frequently need to parse this configuration during submission, scheduling, and mounting
- It complicates the configuration from and end users perspective
- It complicates the ability to do validation

As we understand the problem space of CSI a little more, it has become
clear that we won't need the `source` to be in config, as it will be
used in the majority of cases:

- Host Volumes: Always need a source
- Preallocated CSI Volumes: Always needs a source from a volume or claim name
- Dynamic Persistent CSI Volumes*: Always needs a source to attach the volumes to for managing upgrades and to avoid dangling.
- Dynamic Ephemeral CSI Volumes*: Less thought out, but `source` will probably point to the plugin name, and a `config` block will allow you to pass meta to the plugin. Or will point to a pre-configured ephemeral config.

*If implemented

The new design simplifies this by merging the source into the volume stanza to solve the above issues with usability, performance, and error handling.