### PR TITLE
Restart task's that uses secrets that rendered throw consultemplate when nomad client restarts

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -203,6 +203,8 @@ type TaskRunner struct {
 	// closed.
 	waitOnServers bool
 
+	restored bool
+
 	networkIsolationLock sync.Mutex
 	networkIsolationSpec *drivers.NetworkIsolationSpec
 }
@@ -944,6 +946,8 @@ func (tr *TaskRunner) Restore() error {
 		ts.Canonicalize()
 		tr.state = ts
 	}
+
+	tr.restored = true
 
 	// If a TaskHandle was persisted, ensure it is valid or destroy it.
 	if taskHandle := tr.localState.TaskHandle; taskHandle != nil {

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"strconv"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
@@ -168,6 +169,14 @@ func (tr *TaskRunner) prestart() error {
 
 			// Give the hook it's old data
 			req.PreviousState = origHookState.Data
+		}
+
+		if name == "template" {
+			if req.PreviousState == nil {
+				req.PreviousState = make(map[string]string)
+			}
+
+			req.PreviousState["hoookRestoredFromRestart"] = strconv.FormatBool(tr.restored)
 		}
 
 		req.VaultToken = tr.getVaultToken()


### PR DESCRIPTION
This pull request was created as replacement for https://github.com/hashicorp/nomad/pull/6059 

This PR try solve problem which described in #4226

This is a second our try to push this in nomad mainline, first was declined due huge code changes between 0.8.x and 0.9.x

The key idea of this patch is, in fact that consul-template doesn't persisted it state between nomad agent restarts(for example systemctl restart nomad) and regenerate dynamic secrets(for example https://www.vaultproject.io/docs/secrets/aws/index.html) but in case of restart nomad doesn't inform about this fact tasks(this happens only when agent restarts), and there can be situations when secrets already revoked by vault, but task still running

Some remarks from @nickethier (from https://github.com/hashicorp/nomad/pull/6059) we will fix, after some times

Sorry for our mistake in git branches management :-(