### PR TITLE
docker: periodically reconcile containers

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -636,8 +636,7 @@ func (d *Driver) SetConfig(c *base.Config) error {
 
 	d.coordinator = newDockerCoordinator(coordinatorConfig)
 
-	reconciler := newReconciler(d)
-	reconciler.Start()
+	d.reconciler = newReconciler(d)
 
 	return nil
 }

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -115,6 +115,8 @@ type Driver struct {
 	// for use during fingerprinting.
 	detected     bool
 	detectedLock sync.RWMutex
+
+	reconciler *containerReconciler
 }
 
 // NewDockerDriver returns a docker implementation of a driver plugin

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -67,10 +67,7 @@ var (
 )
 
 const (
-	dockerLabelTaskID   = "com.hashicorp.nomad.task_id"
-	dockerLabelTaskName = "com.hashicorp.nomad.task_name"
-	dockerLabelAllocID  = "com.hashicorp.nomad.alloc_id"
-	dockerLabelJobName  = "com.hashicorp.nomad.job_name"
+	dockerLabelAllocID = "com.hashicorp.nomad.alloc_id"
 )
 
 type Driver struct {
@@ -992,15 +989,12 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		config.Labels = driverConfig.Labels
 	}
 
-	config.Labels = map[string]string{
-		dockerLabelTaskID:   task.ID,
-		dockerLabelTaskName: task.Name,
-		dockerLabelAllocID:  task.AllocID,
-		dockerLabelJobName:  task.JobName,
-	}
+	labels := make(map[string]string, len(driverConfig.Labels)+1)
 	for k, v := range driverConfig.Labels {
-		config.Labels[k] = v
+		labels[k] = v
 	}
+	labels[dockerLabelAllocID] = task.AllocID
+	config.Labels = labels
 	logger.Debug("applied labels on the container", "labels", config.Labels)
 
 	config.Env = task.EnvList()

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -66,6 +66,13 @@ var (
 	nvidiaVisibleDevices = "NVIDIA_VISIBLE_DEVICES"
 )
 
+const (
+	dockerLabelTaskID   = "com.hashicorp.nomad.task_id"
+	dockerLabelTaskName = "com.hashicorp.nomad.task_name"
+	dockerLabelAllocID  = "com.hashicorp.nomad.alloc_id"
+	dockerLabelJobName  = "com.hashicorp.nomad.job_name"
+)
+
 type Driver struct {
 	// eventer is used to handle multiplexing of TaskEvents calls such that an
 	// event can be broadcast to all callers
@@ -981,8 +988,18 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 
 	if len(driverConfig.Labels) > 0 {
 		config.Labels = driverConfig.Labels
-		logger.Debug("applied labels on the container", "labels", config.Labels)
 	}
+
+	config.Labels = map[string]string{
+		dockerLabelTaskID:   task.ID,
+		dockerLabelTaskName: task.Name,
+		dockerLabelAllocID:  task.AllocID,
+		dockerLabelJobName:  task.JobName,
+	}
+	for k, v := range driverConfig.Labels {
+		config.Labels[k] = v
+	}
+	logger.Debug("applied labels on the container", "labels", config.Labels)
 
 	config.Env = task.EnvList()
 

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -309,6 +309,10 @@ CREATE:
 		// the container is started
 		runningContainer, err := client.InspectContainer(container.ID)
 		if err != nil {
+			client.RemoveContainer(docker.RemoveContainerOptions{
+				ID:    container.ID,
+				Force: true,
+			})
 			msg := "failed to inspect started container"
 			d.logger.Error(msg, "error", err)
 			client.RemoveContainer(docker.RemoveContainerOptions{

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -905,8 +905,8 @@ func TestDockerDriver_Labels(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// expect to see 4 additional standard labels
-	require.Equal(t, len(cfg.Labels)+4, len(container.Config.Labels))
+	// expect to see 1 additional standard labels
+	require.Equal(t, len(cfg.Labels)+1, len(container.Config.Labels))
 	for k, v := range cfg.Labels {
 		require.Equal(t, v, container.Config.Labels[k])
 	}
@@ -1018,6 +1018,10 @@ func TestDockerDriver_CreateContainerConfig_Labels(t *testing.T) {
 
 	cfg.Labels = map[string]string{
 		"user_label": "user_value",
+
+		// com.hashicorp.nomad. labels are reserved and
+		// cannot be overridden
+		"com.hashicorp.nomad.alloc_id": "bad_value",
 	}
 
 	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
@@ -1032,10 +1036,7 @@ func TestDockerDriver_CreateContainerConfig_Labels(t *testing.T) {
 		// user provided labels
 		"user_label": "user_value",
 		// default labels
-		"com.hashicorp.nomad.alloc_id":  task.AllocID,
-		"com.hashicorp.nomad.job_name":  "redis-demo-job",
-		"com.hashicorp.nomad.task_id":   task.ID,
-		"com.hashicorp.nomad.task_name": "redis-demo",
+		"com.hashicorp.nomad.alloc_id": task.AllocID,
 	}
 
 	require.Equal(t, expectedLabels, c.Config.Labels)

--- a/drivers/docker/fingerprint.go
+++ b/drivers/docker/fingerprint.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (d *Driver) Fingerprint(ctx context.Context) (<-chan *drivers.Fingerprint, error) {
+	// start reconciler when we start fingerprinting
+	// this is the only method called when driver is launched properly
+	d.reconciler.Start()
+
 	ch := make(chan *drivers.Fingerprint)
 	go d.handleFingerprint(ctx, ch)
 	return ch, nil

--- a/drivers/docker/reconciler.go
+++ b/drivers/docker/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sync"
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
@@ -25,6 +26,8 @@ type containerReconciler struct {
 	isDriverHealthy   func() bool
 	trackedContainers func() map[string]bool
 	isNomadContainer  func(c docker.APIContainers) bool
+
+	once sync.Once
 }
 
 func newReconciler(d *Driver) *containerReconciler {
@@ -46,7 +49,9 @@ func (r *containerReconciler) Start() {
 		return
 	}
 
-	go r.removeDanglingContainersGoroutine()
+	r.once.Do(func() {
+		go r.removeDanglingContainersGoroutine()
+	})
 }
 
 func (r *containerReconciler) removeDanglingContainersGoroutine() {

--- a/drivers/docker/reconciler.go
+++ b/drivers/docker/reconciler.go
@@ -70,7 +70,8 @@ func (d *Driver) removeDanglingContainersIteration() error {
 	return nil
 }
 
-// untrackedContainers returns the ids of containers that look
+// untrackedContainers returns the ids of containers that suspected
+// to have been started by Nomad but aren't tracked by this driver
 func (d *Driver) untrackedContainers(tracked map[string]bool, creationTimeout time.Duration) ([]string, error) {
 	result := []string{}
 
@@ -116,7 +117,7 @@ func (d *Driver) isNomadContainer(c docker.APIContainers) bool {
 	}
 
 	// double check before killing process
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(d.ctx, 20*time.Second)
 	defer cancel()
 
 	ci, err := client.InspectContainerWithContext(c.ID, ctx)

--- a/drivers/docker/reconciler.go
+++ b/drivers/docker/reconciler.go
@@ -1,0 +1,164 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+func (d *Driver) removeDanglingContainersGoroutine() {
+	if !d.config.GC.DanglingContainers.Enabled {
+		d.logger.Debug("skipping dangling containers handling; is disabled")
+		return
+	}
+
+	period := d.config.GC.DanglingContainers.period
+
+	succeeded := true
+
+	timer := time.NewTimer(period)
+	for {
+		select {
+		case <-timer.C:
+			if d.previouslyDetected() && d.fingerprintSuccessful() {
+				err := d.removeDanglingContainersIteration()
+				if err != nil && succeeded {
+					d.logger.Warn("failed to remove dangling containers", "error", err)
+				}
+				succeeded = (err == nil)
+			}
+
+			timer.Reset(period)
+		case <-d.ctx.Done():
+			return
+		}
+	}
+}
+
+func (d *Driver) removeDanglingContainersIteration() error {
+	tracked := d.trackedContainers()
+	untracked, err := d.untrackedContainers(tracked, d.config.GC.DanglingContainers.creationTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to find untracked containers: %v", err)
+	}
+
+	for _, id := range untracked {
+		d.logger.Info("removing untracked container", "container_id", id)
+		err := client.RemoveContainer(docker.RemoveContainerOptions{
+			ID:    id,
+			Force: true,
+		})
+		if err != nil {
+			d.logger.Warn("failed to remove untracked container", "container_id", id, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// untrackedContainers returns the ids of containers that look
+func (d *Driver) untrackedContainers(tracked map[string]bool, creationTimeout time.Duration) ([]string, error) {
+	result := []string{}
+
+	cc, err := client.ListContainers(docker.ListContainersOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	cutoff := time.Now().Add(-creationTimeout).Unix()
+
+	for _, c := range cc {
+		if tracked[c.ID] {
+			continue
+		}
+
+		if c.Created > cutoff {
+			continue
+		}
+
+		if !d.isNomadContainer(c) {
+			continue
+		}
+
+		result = append(result, c.ID)
+	}
+
+	return result, nil
+}
+
+func (d *Driver) isNomadContainer(c docker.APIContainers) bool {
+	if _, ok := c.Labels["com.hashicorp.nomad.alloc_id"]; ok {
+		return true
+	}
+
+	// pre-0.10 containers aren't tagged or labeled in any way,
+	// so use cheap heauristic based on mount paths
+	// before inspecting container details
+	if !hasMount(c, "/alloc") ||
+		!hasMount(c, "/local") ||
+		!hasMount(c, "/secrets") ||
+		!hasNomadName(c) {
+		return false
+	}
+
+	// double check before killing process
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	ci, err := client.InspectContainerWithContext(c.ID, ctx)
+	if err != nil {
+		return false
+	}
+
+	env := ci.Config.Env
+	return hasEnvVar(env, "NOMAD_ALLOC_ID") &&
+		hasEnvVar(env, "NOMAD_GROUP_NAME")
+}
+
+func hasMount(c docker.APIContainers, p string) bool {
+	for _, m := range c.Mounts {
+		if m.Destination == p {
+			return true
+		}
+	}
+
+	return false
+}
+
+var nomadContainerNamePattern = regexp.MustCompile(`\/.*-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+
+func hasNomadName(c docker.APIContainers) bool {
+	for _, n := range c.Names {
+		if nomadContainerNamePattern.MatchString(n) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasEnvVar(vars []string, key string) bool {
+	for _, v := range vars {
+		if strings.HasPrefix(v, key+"=") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (d *Driver) trackedContainers() map[string]bool {
+	d.tasks.lock.RLock()
+	defer d.tasks.lock.RUnlock()
+
+	r := make(map[string]bool, len(d.tasks.store))
+	for _, h := range d.tasks.store {
+		r[h.containerID] = true
+	}
+
+	return r
+}

--- a/drivers/docker/reconciler.go
+++ b/drivers/docker/reconciler.go
@@ -149,7 +149,7 @@ func (r *containerReconciler) untrackedContainers(tracked map[string]bool, cutof
 }
 
 func isNomadContainer(c docker.APIContainers) bool {
-	if _, ok := c.Labels["com.hashicorp.nomad.alloc_id"]; ok {
+	if _, ok := c.Labels[dockerLabelAllocID]; ok {
 		return true
 	}
 

--- a/drivers/docker/reconciler_test.go
+++ b/drivers/docker/reconciler_test.go
@@ -111,8 +111,6 @@ func TestDanglingContainerRemoval(t *testing.T) {
 	err = client.StartContainer(c.ID, nil)
 	require.NoError(t, err)
 
-	time.Sleep(1 * time.Second)
-
 	dd := d.Impl().(*Driver)
 	trackedContainers := map[string]bool{handle.containerID: true}
 

--- a/drivers/docker/reconciler_test.go
+++ b/drivers/docker/reconciler_test.go
@@ -1,0 +1,150 @@
+package docker
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/uuid"
+	tu "github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var sampleContainerList []docker.APIContainers
+var sampleNomadContainerListItem docker.APIContainers
+var sampleNonNomadContainerListItem docker.APIContainers
+
+func init() {
+	path := "./test-resources/docker/reconciler_containers_list.json"
+
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+
+	err = json.NewDecoder(f).Decode(&sampleContainerList)
+	if err != nil {
+		return
+	}
+
+	sampleNomadContainerListItem = sampleContainerList[0]
+	sampleNonNomadContainerListItem = sampleContainerList[1]
+}
+
+func Test_HasMount(t *testing.T) {
+	require.True(t, hasMount(sampleNomadContainerListItem, "/alloc"))
+	require.True(t, hasMount(sampleNomadContainerListItem, "/data"))
+	require.True(t, hasMount(sampleNomadContainerListItem, "/secrets"))
+	require.False(t, hasMount(sampleNomadContainerListItem, "/random"))
+
+	require.False(t, hasMount(sampleNonNomadContainerListItem, "/alloc"))
+	require.False(t, hasMount(sampleNonNomadContainerListItem, "/data"))
+	require.False(t, hasMount(sampleNonNomadContainerListItem, "/secrets"))
+	require.False(t, hasMount(sampleNonNomadContainerListItem, "/random"))
+}
+
+func Test_HasNomadName(t *testing.T) {
+	require.True(t, hasNomadName(sampleNomadContainerListItem))
+	require.False(t, hasNomadName(sampleNonNomadContainerListItem))
+}
+
+func TestHasEnv(t *testing.T) {
+	envvars := []string{
+		"NOMAD_ALLOC_DIR=/alloc",
+		"NOMAD_ALLOC_ID=72bfa388-024e-a903-45b8-2bc28b74ed69",
+		"NOMAD_ALLOC_INDEX=0",
+		"NOMAD_ALLOC_NAME=example.cache[0]",
+		"NOMAD_CPU_LIMIT=500",
+		"NOMAD_DC=dc1",
+		"NOMAD_GROUP_NAME=cache",
+		"NOMAD_JOB_NAME=example",
+		"NOMAD_MEMORY_LIMIT=256",
+		"NOMAD_NAMESPACE=default",
+		"NOMAD_REGION=global",
+		"NOMAD_SECRETS_DIR=/secrets",
+		"NOMAD_TASK_DIR=/local",
+		"NOMAD_TASK_NAME=redis",
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"GOSU_VERSION=1.10",
+		"REDIS_VERSION=3.2.12",
+		"REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-3.2.12.tar.gz",
+		"REDIS_DOWNLOAD_SHA=98c4254ae1be4e452aa7884245471501c9aa657993e0318d88f048093e7f88fd",
+	}
+
+	require.True(t, hasEnvVar(envvars, "NOMAD_ALLOC_ID"))
+	require.True(t, hasEnvVar(envvars, "NOMAD_ALLOC_DIR"))
+	require.True(t, hasEnvVar(envvars, "GOSU_VERSION"))
+
+	require.False(t, hasEnvVar(envvars, "NOMAD_ALLOC_"))
+	require.False(t, hasEnvVar(envvars, "OTHER_VARIABLE"))
+}
+
+func TestDanglingContainerRemoval(t *testing.T) {
+	if !tu.IsCI() {
+		t.Parallel()
+	}
+	testutil.DockerCompatible(t)
+
+	task, cfg, _ := dockerTask(t)
+	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
+
+	client, d, handle, cleanup := dockerSetup(t, task)
+	defer cleanup()
+	require.NoError(t, d.WaitUntilStarted(task.ID, 5*time.Second))
+
+	c, err := client.CreateContainer(docker.CreateContainerOptions{
+		Name: "mytest-image-" + uuid.Generate(),
+		Config: &docker.Config{
+			Image: cfg.Image,
+			Cmd:   append([]string{cfg.Command}, cfg.Args...),
+		},
+	})
+	require.NoError(t, err)
+	defer client.RemoveContainer(docker.RemoveContainerOptions{
+		ID:    c.ID,
+		Force: true,
+	})
+
+	err = client.StartContainer(c.ID, nil)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	dd := d.Impl().(*Driver)
+	trackedContainers := map[string]bool{handle.containerID: true}
+
+	{
+		tf := dd.trackedContainers()
+		require.Contains(t, tf, handle.containerID)
+		require.NotContains(t, tf, c.ID)
+	}
+
+	untracked, err := dd.untrackedContainers(trackedContainers, 1*time.Minute)
+	require.NoError(t, err)
+	require.NotContains(t, untracked, handle.containerID)
+	require.NotContains(t, untracked, c.ID)
+
+	untracked, err = dd.untrackedContainers(map[string]bool{}, 0)
+	require.NoError(t, err)
+	require.Contains(t, untracked, handle.containerID)
+	require.NotContains(t, untracked, c.ID)
+
+	// Actually try to kill hosts
+	prestineDriver := dockerDriverHarness(t, nil).Impl().(*Driver)
+	prestineDriver.config.GC.DanglingContainers = ContainerGCConfig{
+		Enabled:         true,
+		period:          1 * time.Second,
+		creationTimeout: 1 * time.Second,
+	}
+	require.NoError(t, prestineDriver.removeDanglingContainersIteration())
+
+	_, err = client.InspectContainer(c.ID)
+	require.NoError(t, err)
+
+	_, err = client.InspectContainer(handle.containerID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), NoSuchContainerError)
+}

--- a/drivers/docker/reconciler_test.go
+++ b/drivers/docker/reconciler_test.go
@@ -9,85 +9,53 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/helper/uuid"
-	tu "github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
-var sampleContainerList []docker.APIContainers
-var sampleNomadContainerListItem docker.APIContainers
-var sampleNonNomadContainerListItem docker.APIContainers
-
-func init() {
+func fakeContainerList(t *testing.T) (nomadContainer, nonNomadContainer docker.APIContainers) {
 	path := "./test-resources/docker/reconciler_containers_list.json"
 
 	f, err := os.Open(path)
 	if err != nil {
-		return
+		t.Fatalf("failed to open file: %v", err)
 	}
 
+	var sampleContainerList []docker.APIContainers
 	err = json.NewDecoder(f).Decode(&sampleContainerList)
 	if err != nil {
-		return
+		t.Fatalf("failed to decode container list: %v", err)
 	}
 
-	sampleNomadContainerListItem = sampleContainerList[0]
-	sampleNonNomadContainerListItem = sampleContainerList[1]
+	return sampleContainerList[0], sampleContainerList[1]
 }
 
 func Test_HasMount(t *testing.T) {
-	require.True(t, hasMount(sampleNomadContainerListItem, "/alloc"))
-	require.True(t, hasMount(sampleNomadContainerListItem, "/data"))
-	require.True(t, hasMount(sampleNomadContainerListItem, "/secrets"))
-	require.False(t, hasMount(sampleNomadContainerListItem, "/random"))
+	nomadContainer, nonNomadContainer := fakeContainerList(t)
 
-	require.False(t, hasMount(sampleNonNomadContainerListItem, "/alloc"))
-	require.False(t, hasMount(sampleNonNomadContainerListItem, "/data"))
-	require.False(t, hasMount(sampleNonNomadContainerListItem, "/secrets"))
-	require.False(t, hasMount(sampleNonNomadContainerListItem, "/random"))
+	require.True(t, hasMount(nomadContainer, "/alloc"))
+	require.True(t, hasMount(nomadContainer, "/data"))
+	require.True(t, hasMount(nomadContainer, "/secrets"))
+	require.False(t, hasMount(nomadContainer, "/random"))
+
+	require.False(t, hasMount(nonNomadContainer, "/alloc"))
+	require.False(t, hasMount(nonNomadContainer, "/data"))
+	require.False(t, hasMount(nonNomadContainer, "/secrets"))
+	require.False(t, hasMount(nonNomadContainer, "/random"))
 }
 
 func Test_HasNomadName(t *testing.T) {
-	require.True(t, hasNomadName(sampleNomadContainerListItem))
-	require.False(t, hasNomadName(sampleNonNomadContainerListItem))
+	nomadContainer, nonNomadContainer := fakeContainerList(t)
+
+	require.True(t, hasNomadName(nomadContainer))
+	require.False(t, hasNomadName(nonNomadContainer))
 }
 
-func TestHasEnv(t *testing.T) {
-	envvars := []string{
-		"NOMAD_ALLOC_DIR=/alloc",
-		"NOMAD_ALLOC_ID=72bfa388-024e-a903-45b8-2bc28b74ed69",
-		"NOMAD_ALLOC_INDEX=0",
-		"NOMAD_ALLOC_NAME=example.cache[0]",
-		"NOMAD_CPU_LIMIT=500",
-		"NOMAD_DC=dc1",
-		"NOMAD_GROUP_NAME=cache",
-		"NOMAD_JOB_NAME=example",
-		"NOMAD_MEMORY_LIMIT=256",
-		"NOMAD_NAMESPACE=default",
-		"NOMAD_REGION=global",
-		"NOMAD_SECRETS_DIR=/secrets",
-		"NOMAD_TASK_DIR=/local",
-		"NOMAD_TASK_NAME=redis",
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-		"GOSU_VERSION=1.10",
-		"REDIS_VERSION=3.2.12",
-		"REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-3.2.12.tar.gz",
-		"REDIS_DOWNLOAD_SHA=98c4254ae1be4e452aa7884245471501c9aa657993e0318d88f048093e7f88fd",
-	}
-
-	require.True(t, hasEnvVar(envvars, "NOMAD_ALLOC_ID"))
-	require.True(t, hasEnvVar(envvars, "NOMAD_ALLOC_DIR"))
-	require.True(t, hasEnvVar(envvars, "GOSU_VERSION"))
-
-	require.False(t, hasEnvVar(envvars, "NOMAD_ALLOC_"))
-	require.False(t, hasEnvVar(envvars, "OTHER_VARIABLE"))
-}
-
+// TestDanglingContainerRemoval asserts containers without corresponding tasks
+// are removed after the creation grace period.
 func TestDanglingContainerRemoval(t *testing.T) {
-	if !tu.IsCI() {
-		t.Parallel()
-	}
 	testutil.DockerCompatible(t)
 
+	// start two containers: one tracked nomad container, and one unrelated container
 	task, cfg, _ := dockerTask(t)
 	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
@@ -112,32 +80,42 @@ func TestDanglingContainerRemoval(t *testing.T) {
 	require.NoError(t, err)
 
 	dd := d.Impl().(*Driver)
+
+	reconciler := newReconciler(dd)
 	trackedContainers := map[string]bool{handle.containerID: true}
 
-	{
-		tf := dd.trackedContainers()
-		require.Contains(t, tf, handle.containerID)
-		require.NotContains(t, tf, c.ID)
-	}
+	tf := reconciler.trackedContainers()
+	require.Contains(t, tf, handle.containerID)
+	require.NotContains(t, tf, c.ID)
 
-	untracked, err := dd.untrackedContainers(trackedContainers, 1*time.Minute)
+	// assert tracked containers should never be untracked
+	untracked, err := reconciler.untrackedContainers(trackedContainers, time.Now())
 	require.NoError(t, err)
 	require.NotContains(t, untracked, handle.containerID)
 	require.NotContains(t, untracked, c.ID)
 
-	untracked, err = dd.untrackedContainers(map[string]bool{}, 0)
+	// assert we recognize nomad containers with appropriate cutoff
+	untracked, err = reconciler.untrackedContainers(map[string]bool{}, time.Now())
 	require.NoError(t, err)
 	require.Contains(t, untracked, handle.containerID)
 	require.NotContains(t, untracked, c.ID)
 
-	// Actually try to kill hosts
+	// but ignore if creation happened before cutoff
+	untracked, err = reconciler.untrackedContainers(map[string]bool{}, time.Now().Add(-1*time.Minute))
+	require.NoError(t, err)
+	require.NotContains(t, untracked, handle.containerID)
+	require.NotContains(t, untracked, c.ID)
+
+	// a full integration tests to assert that containers are removed
 	prestineDriver := dockerDriverHarness(t, nil).Impl().(*Driver)
 	prestineDriver.config.GC.DanglingContainers = ContainerGCConfig{
-		Enabled:         true,
-		period:          1 * time.Second,
-		creationTimeout: 1 * time.Second,
+		Enabled:       true,
+		period:        1 * time.Second,
+		CreationGrace: 1 * time.Second,
 	}
-	require.NoError(t, prestineDriver.removeDanglingContainersIteration())
+	nReconciler := newReconciler(prestineDriver)
+
+	require.NoError(t, nReconciler.removeDanglingContainersIteration())
 
 	_, err = client.InspectContainer(c.ID)
 	require.NoError(t, err)
@@ -145,4 +123,62 @@ func TestDanglingContainerRemoval(t *testing.T) {
 	_, err = client.InspectContainer(handle.containerID)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), NoSuchContainerError)
+}
+
+// TestDanglingContainerRemoval_Stopped asserts stopped containers without
+// corresponding tasks are not removed even if after creation grace period.
+func TestDanglingContainerRemoval_Stopped(t *testing.T) {
+	testutil.DockerCompatible(t)
+
+	task, cfg, _ := dockerTask(t)
+	task.Resources.NomadResources.Networks = nil
+	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
+
+	// Start two containers: one nomad container, and one stopped container
+	// that acts like a nomad one
+	client, d, handle, cleanup := dockerSetup(t, task)
+	defer cleanup()
+	require.NoError(t, d.WaitUntilStarted(task.ID, 5*time.Second))
+
+	inspected, err := client.InspectContainer(handle.containerID)
+	require.NoError(t, err)
+
+	stoppedC, err := client.CreateContainer(docker.CreateContainerOptions{
+		Name:       "mytest-image-" + uuid.Generate(),
+		Config:     inspected.Config,
+		HostConfig: inspected.HostConfig,
+	})
+	require.NoError(t, err)
+	defer client.RemoveContainer(docker.RemoveContainerOptions{
+		ID:    stoppedC.ID,
+		Force: true,
+	})
+
+	err = client.StartContainer(stoppedC.ID, nil)
+	require.NoError(t, err)
+
+	err = client.StopContainer(stoppedC.ID, 60)
+	require.NoError(t, err)
+
+	dd := d.Impl().(*Driver)
+	reconciler := newReconciler(dd)
+	trackedContainers := map[string]bool{handle.containerID: true}
+
+	// assert nomad container is tracked, and we ignore stopped one
+	tf := reconciler.trackedContainers()
+	require.Contains(t, tf, handle.containerID)
+	require.NotContains(t, tf, stoppedC.ID)
+
+	untracked, err := reconciler.untrackedContainers(trackedContainers, time.Now())
+	require.NoError(t, err)
+	require.NotContains(t, untracked, handle.containerID)
+	require.NotContains(t, untracked, stoppedC.ID)
+
+	// if we start container again, it'll be marked as untracked
+	require.NoError(t, client.StartContainer(stoppedC.ID, nil))
+
+	untracked, err = reconciler.untrackedContainers(trackedContainers, time.Now())
+	require.NoError(t, err)
+	require.NotContains(t, untracked, handle.containerID)
+	require.Contains(t, untracked, stoppedC.ID)
 }

--- a/drivers/docker/test-resources/docker/reconciler_containers_list.json
+++ b/drivers/docker/test-resources/docker/reconciler_containers_list.json
@@ -1,0 +1,116 @@
+[
+  {
+    "Id": "eb23be71498c2dc0254c029f32b360a000caf33157d1c93e226f4c1a4c9d2218",
+    "Names": [
+      "/redis-72bfa388-024e-a903-45b8-2bc28b74ed69"
+    ],
+    "Image": "redis:3.2",
+    "ImageID": "sha256:87856cc39862cec77541d68382e4867d7ccb29a85a17221446c857ddaebca916",
+    "Command": "docker-entrypoint.sh redis-server",
+    "Created": 1568383081,
+    "Ports": [
+      {
+        "PrivatePort": 6379,
+        "Type": "tcp"
+      }
+    ],
+    "Labels": {},
+    "State": "running",
+    "Status": "Up 9 seconds",
+    "HostConfig": {
+      "NetworkMode": "default"
+    },
+    "NetworkSettings": {
+      "Networks": {
+        "bridge": {
+          "IPAMConfig": null,
+          "Links": null,
+          "Aliases": null,
+          "NetworkID": "6715ed501c1cef14545cd6680f54b4971373ee4441aec2300fff1031c8dbf3a4",
+          "EndpointID": "ed830b4f2f33ab4134aea941611b00b9e576b35a4325d52bacfedd1e2e1ba213",
+          "Gateway": "172.17.0.1",
+          "IPAddress": "172.17.0.3",
+          "IPPrefixLen": 16,
+          "IPv6Gateway": "",
+          "GlobalIPv6Address": "",
+          "GlobalIPv6PrefixLen": 0,
+          "MacAddress": "02:42:ac:11:00:03",
+          "DriverOpts": null
+        }
+      }
+    },
+    "Mounts": [
+      {
+        "Type": "bind",
+        "Source": "/private/var/folders/r6/346cfqyn76b_lx1nrcl5278c0000gp/T/NomadClient831122597/72bfa388-024e-a903-45b8-2bc28b74ed69/alloc",
+        "Destination": "/alloc",
+        "Mode": "",
+        "RW": true,
+        "Propagation": "rprivate"
+      },
+      {
+        "Type": "volume",
+        "Name": "d5d7f0f9a3326414257c57cfca01db96c53a424b43e251516511694554309681",
+        "Source": "",
+        "Destination": "/data",
+        "Driver": "local",
+        "Mode": "",
+        "RW": true,
+        "Propagation": ""
+      },
+      {
+        "Type": "bind",
+        "Source": "/private/var/folders/r6/346cfqyn76b_lx1nrcl5278c0000gp/T/NomadClient831122597/72bfa388-024e-a903-45b8-2bc28b74ed69/redis/local",
+        "Destination": "/local",
+        "Mode": "",
+        "RW": true,
+        "Propagation": "rprivate"
+      },
+      {
+        "Type": "bind",
+        "Source": "/private/var/folders/r6/346cfqyn76b_lx1nrcl5278c0000gp/T/NomadClient831122597/72bfa388-024e-a903-45b8-2bc28b74ed69/redis/secrets",
+        "Destination": "/secrets",
+        "Mode": "",
+        "RW": true,
+        "Propagation": "rprivate"
+      }
+    ]
+  },
+  {
+    "Id": "99c49fbe999f6df7b7d6a891d69fe57d7b771a30d5d2899a922b44698084e5c9",
+    "Names": [
+      "/serene_keller"
+    ],
+    "Image": "ubuntu:16.04",
+    "ImageID": "sha256:9361ce633ff193349d54bed380a5afe86043b09fd6ea8da7549dbbedfc2a7077",
+    "Command": "/bin/bash",
+    "Created": 1567795217,
+    "Ports": [],
+    "Labels": {},
+    "State": "running",
+    "Status": "Up 6 days",
+    "HostConfig": {
+      "NetworkMode": "default"
+    },
+    "NetworkSettings": {
+      "Networks": {
+        "bridge": {
+          "IPAMConfig": null,
+          "Links": null,
+          "Aliases": null,
+          "NetworkID": "6715ed501c1cef14545cd6680f54b4971373ee4441aec2300fff1031c8dbf3a4",
+          "EndpointID": "fab83a0d4089ca9944ca53c882bdf40ad310c6fda30dda0092731feb9bc9fab6",
+          "Gateway": "172.17.0.1",
+          "IPAddress": "172.17.0.2",
+          "IPPrefixLen": 16,
+          "IPv6Gateway": "",
+          "GlobalIPv6Address": "",
+          "GlobalIPv6PrefixLen": 0,
+          "MacAddress": "02:42:ac:11:00:02",
+          "DriverOpts": null
+        }
+      }
+    },
+    "Mounts": []
+  }
+]


### PR DESCRIPTION
When running at scale, it's possible that Docker Engine starts
containers successfully but gets wedged in a way where API call fails.
The Docker Engine may remain unavailable for arbitrary long time.

Here, we introduce a periodic reconciliation process that ensures that any
container started by nomad is tracked, and killed if is running
unexpectedly.

Basically, the periodic job inspects any container that isn't tracked in
its handlers.  A creation grace period is used to prevent killing newly
created containers that aren't registered yet.

Also, we aim to avoid killing unrelated containers started by host or
through raw_exec drivers.  The logic is to pattern against containers
environment variables and mounts to infer if they are an alloc docker
container.

Lastly, the periodic job can be disabled to avoid any interference if
need be.

On client restart, the grace period and period allows client for restorations before killing containers.

## Some background

Nomad 0.8.7 was brittle judging by code in [1], If a container started but we failed to inspect it or docker engine became unavailable, we will leak container without stopping it for example.

Nomad 0.9.0 tried to ensure that we remove container on start failures.  Though it doesn't account for failed creation and doesn't retry: if engine becomes unavailable at start time, it may be awhile until it's available again, so a single removal call isn't sufficient.

[1] https://github.com/hashicorp/nomad/blob/v0.8.7/client/driver/docker.go#L899-L935
[2] https://github.com/hashicorp/nomad/blob/v0.9.0/drivers/docker/driver.go#L279-L284
