### PR TITLE
Fix bugs around docker start retries

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -468,7 +468,7 @@ func (d *Driver) startContainer(c *docker.Container) error {
 	attempted := 0
 START:
 	startErr := client.StartContainer(c.ID, c.HostConfig)
-	if startErr == nil {
+	if startErr == nil || strings.Contains(startErr.Error(), "Container already running") {
 		return nil
 	}
 


### PR DESCRIPTION
Noticed that docker driver attempts to retry container creation and start.

This fixes a couple of bugs, where we either don't retry transient errors, or we retry in such away that makes retry invocation fails.