### PR TITLE
ui: protect against no services

### DIFF
--- a/ui/app/serializers/task-group.js
+++ b/ui/app/serializers/task-group.js
@@ -9,6 +9,7 @@ export default ApplicationSerializer.extend({
     });
 
     hash.ReservedEphemeralDisk = hash.EphemeralDisk.SizeMB;
+    hash.Services = hash.Services || [];
 
     return this._super(typeHash, hash);
   },

--- a/ui/mirage/serializers/job.js
+++ b/ui/mirage/serializers/job.js
@@ -3,4 +3,22 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
   embed: true,
   include: ['task_groups', 'job_summary'],
+
+  serialize() {
+    var json = ApplicationSerializer.prototype.serialize.apply(this, arguments);
+    if (json instanceof Array) {
+      json.forEach(serializeJob);
+    } else {
+      serializeJob(json);
+    }
+    return json;
+  },
 });
+
+function serializeJob(job) {
+  job.TaskGroups.forEach(group => {
+    if (group.Services.length === 0) {
+      group.Services = null;
+    }
+  });
+}


### PR DESCRIPTION
Protect against case where an alloc has no services and avoid
dereferencing null.

Looking at https://github.com/hashicorp/nomad/pull/6108/files - it's not obvious to me how to best test this change.

Here, we ensure that the model and test serializers mimic the API by having null TaskGroup.Services instead of an empty array.

Fixes https://github.com/hashicorp/nomad/issues/6320