### PR TITLE
client: Fail startup if host volumes do not exist

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1279,11 +1279,13 @@ func (c *Client) setupNode() error {
 	if node.Name == "" {
 		node.Name, _ = os.Hostname()
 	}
-	// TODO(dani): Fingerprint these to handle volumes that don't exist/have bad perms.
 	if node.HostVolumes == nil {
 		if l := len(c.config.HostVolumes); l != 0 {
 			node.HostVolumes = make(map[string]*structs.ClientHostVolumeConfig, l)
 			for k, v := range c.config.HostVolumes {
+				if _, err := os.Stat(v.Path); err != nil {
+					return fmt.Errorf("failed to validate volume %s, err: %v", v.Name, err)
+				}
 				node.HostVolumes[k] = v.Copy()
 			}
 		}


### PR DESCRIPTION
Some drivers will automatically create directories when trying to mount
a path into a container, but some will not. This results in inconsistent
behaviour when using host volumes depending on your driver.

This also raises questions of default permissions and behaviour changes
based on things like docker version.

To simplify this behaviour and to be explicit about the requirement that they
exist, here we require that host volumes already exist, and can be stat'd by
the Nomad Agent during client startup.