### PR TITLE
remove resolved TODO from UpdateTTL docstring

### DIFF
--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -1144,7 +1144,8 @@ func (c *ServiceClient) AllocRegistrations(allocID string) (*AllocRegistration, 
 	return reg, nil
 }
 
-// TODO(tgross): make sure this is properly nil-checked, etc.
+// UpdateTTL is used to update the TTL of a check. Typically this will only be
+// called to heartbeat script checks.
 func (c *ServiceClient) UpdateTTL(id, output, status string) error {
 	return c.client.UpdateTTL(id, output, status)
 }


### PR DESCRIPTION
This TODO was left behind during Consul Connect work, but it's been resolved and we don't want it to show up in the godocs.