### PR TITLE
reduce memory required for logmon, docker_logger and executor processes

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,8 +9,11 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	_ "github.com/hashicorp/nomad/client/logmon"
+	_ "github.com/hashicorp/nomad/drivers/docker/docklog"
+	_ "github.com/hashicorp/nomad/drivers/shared/executor"
+
 	"github.com/hashicorp/nomad/command"
-	"github.com/hashicorp/nomad/drivers/docker/docklog"
 	"github.com/hashicorp/nomad/version"
 	"github.com/mattn/go-colorable"
 	"github.com/mitchellh/cli"
@@ -38,7 +41,7 @@ var (
 		"server-join",
 		"server-members",
 		"syslog",
-		docklog.PluginName,
+		"docker_logger",
 	}
 
 	// aliases is the list of aliases we want users to be aware of. We hide

--- a/main.go
+++ b/main.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	// These packages have init() funcs which check os.Args and drop directly
+	// into their command logic. This is because they are run as seperate
+	// processes along side of a task. By early importing them we can avoid
+	// additional code being imported and thus reserving memory
 	_ "github.com/hashicorp/nomad/client/logmon"
 	_ "github.com/hashicorp/nomad/drivers/docker/docklog"
 	_ "github.com/hashicorp/nomad/drivers/shared/executor"


### PR DESCRIPTION
The `init()` funcs in each of these packages checks the cli args and runs the processes before ever hitting the main cli run logic. If we load these packages first then it stops additional packages form ever getting a chance to be imported thus saving some memory overhead. On my machine this reduced the RSS by ~10MB for these processes.

