### PR TITLE
docker: remove containers on creation failures

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -275,6 +275,10 @@ CREATE:
 	container, err := d.createContainer(client, containerCfg, driverConfig.Image)
 	if err != nil {
 		d.logger.Error("failed to create container", "error", err)
+		client.RemoveContainer(docker.RemoveContainerOptions{
+			ID:    containerCfg.Name,
+			Force: true,
+		})
 		return nil, nil, nstructs.WrapRecoverable(fmt.Sprintf("failed to create container: %v", err), err)
 	}
 
@@ -307,6 +311,10 @@ CREATE:
 		if err != nil {
 			msg := "failed to inspect started container"
 			d.logger.Error(msg, "error", err)
+			client.RemoveContainer(docker.RemoveContainerOptions{
+				ID:    container.ID,
+				Force: true,
+			})
 			return nil, nil, nstructs.NewRecoverableError(fmt.Errorf("%s %s: %s", msg, container.ID, err), true)
 		}
 		container = runningContainer


### PR DESCRIPTION
The docker creation API calls may fail with http errors (e.g. timeout)
even if container was successfully created.

Here, we force remove container if we got unexpected failure.  We
already do this in some error handlers, and this commit updates all
paths.

I stopped short from a more aggressive refactoring, as the code is ripe
for refactoring and would rather do that in another PR.

This is an extraction of the non-reconciliation bits of https://github.com/hashicorp/nomad/pull/6325 so it can target 0.10.0.