### PR TITLE
client: Return empty values when host stats fail

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1335,10 +1335,14 @@ func (tr *TaskRunner) emitStats(ru *cstructs.TaskResourceUsage) {
 
 	if ru.ResourceUsage.MemoryStats != nil {
 		tr.setGaugeForMemory(ru)
+	} else {
+		tr.logger.Debug("Skipping memory stats for allocation", "reason", "MemoryStats is nil")
 	}
 
 	if ru.ResourceUsage.CpuStats != nil {
 		tr.setGaugeForCPU(ru)
+	} else {
+		tr.logger.Debug("Skipping cpu stats for allocation", "reason", "CpuStats is nil")
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -2575,19 +2575,15 @@ func (c *Client) emitStats() {
 	for {
 		select {
 		case <-next.C:
-			start := time.Now()
 			err := c.hostStatsCollector.Collect()
 			next.Reset(c.config.StatsCollectionInterval)
-			end := time.Now()
-			duration := end.Sub(start)
 			if err != nil {
-				c.logger.Warn("error fetching host resource usage stats", "error", err, "collection_duration", duration)
-				continue
-			}
-
-			// Publish Node metrics if operator has opted in
-			if c.config.PublishNodeMetrics {
-				c.emitHostStats()
+				c.logger.Warn("error fetching host resource usage stats", "error", err)
+			} else {
+				// Publish Node metrics if operator has opted in
+				if c.config.PublishNodeMetrics {
+					c.emitHostStats()
+				}
 			}
 
 			c.emitClientMetrics()

--- a/client/client.go
+++ b/client/client.go
@@ -2575,10 +2575,13 @@ func (c *Client) emitStats() {
 	for {
 		select {
 		case <-next.C:
+			start := time.Now()
 			err := c.hostStatsCollector.Collect()
 			next.Reset(c.config.StatsCollectionInterval)
+			end := time.Now()
+			duration := end.Sub(start)
 			if err != nil {
-				c.logger.Warn("error fetching host resource usage stats", "error", err)
+				c.logger.Warn("error fetching host resource usage stats", "error", err, "collection_duration", duration)
 				continue
 			}
 

--- a/command/agent/metrics_endpoint_test.go
+++ b/command/agent/metrics_endpoint_test.go
@@ -121,7 +121,7 @@ func TestHTTP_FreshClientAllocMetrics(t *testing.T) {
 				terminal == float32(numTasks), nil
 		}, func(err error) {
 			require.Fail("timed out waiting for metrics to converge",
-				"pending: %v, running: %v, terminal: %v", pending, running, terminal)
+				"expected: (pending: 0, running: 0, terminal: %v), got: (pending: %v, running: %v, terminal: %v)", numTasks, pending, running, terminal)
 		})
 	})
 }


### PR DESCRIPTION
Currently, there is an issue when running on Windows whereby under some
circumstances the Windows stats API's will begin to return errors (such
as internal timeouts) when a client is under high load, and potentially
other forms of resource contention / system states (and other unknown
cases).

When an error occurs during this collection, we then short circuit
further metrics emission from the client until the next interval.

This can be problematic if it happens for a sustained number of
intervals, as our metrics aggregator will begin to age out older
metrics, and we will eventually stop emitting various types of metrics
including `nomad.client.unallocated.*` metrics.

However, when metrics collection fails on Linux, gopsutil will in many cases
(e.g cpu.Times) silently return 0 values, rather than an error.

Here, we switch to returning empty metrics in these failures, and
logging the error at the source. This brings the behaviour into line
with Linux/Unix platforms, and although making aggregation a little
sadder on intermittent failures, will result in more desireable overall
behaviour of keeping metrics available for further investigation if
things look unusual.

### Alternatives

There are a few alternative approaches, including only merging `client_stats: Always emit client stats`, but this has the downside of keeping the status quo of breaking _many_ metrics for a single host collector failing. We could also try to do something a bit smarter about not emitting `undetected` metrics only rather than 0 values, but I'm not sure how valuable they would be.