### PR TITLE
script check: ensure that scripts are running for already registered checks

### DIFF
--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -573,7 +573,15 @@ func (c *ServiceClient) sync() error {
 	// Add Nomad checks missing from Consul
 	for id, check := range c.checks {
 		if _, ok := consulChecks[id]; ok {
-			// Already in Consul; skipping
+			// Already in Consul
+			// Ensure linked script is running
+			if script, ok := c.scripts[id]; ok {
+				// If it's not running yet, start and store the handle
+				if _, running := c.runningScripts[id]; !running {
+					c.runningScripts[id] = script.run()
+				}
+			}
+			// Skip registration
 			continue
 		}
 


### PR DESCRIPTION
This PR fixes the issue https://github.com/hashicorp/nomad/issues/6332. It may happen that after Nomad agent has been restarted, its services and script check may still stay registered in Consul so that we have skipped the code that handles starting scripts. 

The main point of this proposal is simply to check whether the script, linked with the already registered check, is running and if it's not, just launch it.