### PR TITLE
fixed incorrect CLI `-help` in `job deployments`

### DIFF
--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -36,7 +36,7 @@ Deployments Options:
   -verbose
     Display full information.
 
-  -all-allocs
+  -all
     Display all deployments matching the job ID, including those 
     from an older instance of the job.
 `


### PR DESCRIPTION
`job deployments -help` previously documented `-all-allocs` instead of `-all`

Probably a copy-paste error from `job allocations`, you can see the usage of the `all` parameter in the parsing: 
https://github.com/hashicorp/nomad/blob/05fd8a068c1cca135794f4d15921fcf0b618d8d7/command/job_deployments.go#L57

Update: `test-ui` is failing at the moment in CircleCI, but not locally. Is apparently flaky at the moment.