### PR TITLE
doc: clarify driver support for netns/connect

### DIFF
--- a/website/source/docs/job-specification/network.html.md
+++ b/website/source/docs/job-specification/network.html.md
@@ -78,7 +78,9 @@ job "docs" {
 
  - “none” - Task group will have an isolated network without any network interfaces.
  - “bridge” - Task group will have an isolated network namespace with an interface
-           that is bridged with the host.
+           that is bridged with the host. Note that bridge networking is only
+           currently supported for the `docker`, `exec`, `raw_exec`, and `java` task
+           drivers.
  - “host” - Each task will join the host network namespace and a shared network
            namespace is not created. This matches the current behavior in Nomad 0.9.
 

--- a/website/source/guides/integrations/consul-connect/index.html.md
+++ b/website/source/guides/integrations/consul-connect/index.html.md
@@ -54,7 +54,7 @@ run in dev mode with the following command:
 **Note**: Nomad's Connect integration requires Consul in your `$PATH`
 
 ```sh
-$ consul agent -dev 
+$ consul agent -dev
 ```
 
 ### Nomad
@@ -262,8 +262,8 @@ dashes (`-`) are converted to underscores (`_`) in environment variables so
  - Consul Connect Native is not yet supported.
  - Consul Connect HTTP and gRPC checks are not yet supported.
  - Consul ACLs are not yet supported.
- - Only the Docker, exec, and raw exec drivers support network namespaces and
-   Connect.
+ - Only the Docker, exec, raw exec, and java drivers support network namespaces
+   and Connect.
  - Variable interpolation for group services and checks are not yet supported.
  - Consul Connect and network namespaces are only supported on Linux.
 


### PR DESCRIPTION
Adds some clarifications to our documentation about support in task drivers for network namespaces (in particular with bridge networking) and Connect.