### PR TITLE
driver: set correct network isolation caps for exec and java drivers

### DIFF
--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -74,6 +74,10 @@ var (
 		SendSignals: true,
 		Exec:        true,
 		FSIsolation: drivers.FSIsolationChroot,
+		NetIsolationModes: []drivers.NetIsolationMode{
+			drivers.NetIsolationModeHost,
+			drivers.NetIsolationModeGroup,
+		},
 	}
 )
 

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -83,6 +83,10 @@ var (
 		SendSignals: false,
 		Exec:        false,
 		FSIsolation: drivers.FSIsolationNone,
+		NetIsolationModes: []drivers.NetIsolationMode{
+			drivers.NetIsolationModeHost,
+			drivers.NetIsolationModeGroup,
+		},
 	}
 
 	_ drivers.DriverPlugin = (*Driver)(nil)


### PR DESCRIPTION
Fixes bridge network mode for exec/java drivers