### PR TITLE
doc: clarify command path requirements for exec

### DIFF
--- a/website/source/docs/drivers/exec.html.md
+++ b/website/source/docs/drivers/exec.html.md
@@ -32,9 +32,10 @@ task "webservice" {
 The `exec` driver supports the following configuration in the job spec:
 
 * `command` - The command to execute. Must be provided. If executing a binary
-  that exists on the host, the path must be absolute. If executing a binary that
-  is downloaded from an [`artifact`](/docs/job-specification/artifact.html), the
-  path can be relative from the allocations's root directory.
+  that exists on the host, the path must be absolute and within the task's
+  [chroot](exec.html#chroot). If executing a binary that is downloaded from
+  an [`artifact`](/docs/job-specification/artifact.html), the path can be
+  relative from the allocations's root directory.
 
 * `args` - (Optional) A list of arguments to the `command`. References
   to environment variables or any [interpretable Nomad


### PR DESCRIPTION
If the `exec` driver tries to run something outside the chroot, the user gets an error like:

```
2019-09-25T19:20:31Z  Driver Failure  failed to launch command with executor: rpc error: code = Unknown desc = file /opt/countdash/bin/counting-service not found under path /var/nomad/alloc/4aa41650-f772-5bcf-7717-a90908c0cc80/web
```

The behavior is correct (and "obvious" if one thinks a bit about the security implications) but the docs could be a bit clearer.