### PR TITLE
driver/java: pass task network isolation to executor

### DIFF
--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -344,17 +344,18 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	}
 
 	execCmd := &executor.ExecCommand{
-		Cmd:            absPath,
-		Args:           args,
-		Env:            cfg.EnvList(),
-		User:           user,
-		ResourceLimits: true,
-		Resources:      cfg.Resources,
-		TaskDir:        cfg.TaskDir().Dir,
-		StdoutPath:     cfg.StdoutPath,
-		StderrPath:     cfg.StderrPath,
-		Mounts:         cfg.Mounts,
-		Devices:        cfg.Devices,
+		Cmd:              absPath,
+		Args:             args,
+		Env:              cfg.EnvList(),
+		User:             user,
+		ResourceLimits:   true,
+		Resources:        cfg.Resources,
+		TaskDir:          cfg.TaskDir().Dir,
+		StdoutPath:       cfg.StdoutPath,
+		StderrPath:       cfg.StderrPath,
+		Mounts:           cfg.Mounts,
+		Devices:          cfg.Devices,
+		NetworkIsolation: cfg.NetworkIsolation,
 	}
 
 	ps, err := exec.Launch(execCmd)


### PR DESCRIPTION
Fixes #6388

Without passing the network isolation configuration to the executor, java tasks are not placed in the same network namespace as the other processes in their task group, which breaks Consul Connect.

For why this worked with the `exec` driver but not the `java` driver, compare:
https://github.com/hashicorp/nomad/blob/38cb49dd3e790278dd6f51acd78545e742978c9d/drivers/exec/driver.go#L348-L361
https://github.com/hashicorp/nomad/blob/38cb49dd3e790278dd6f51acd78545e742978c9d/drivers/java/driver.go#L346-L358