### PR TITLE
executor: run exec commands in netns if set

### DIFF
--- a/drivers/shared/executor/exec_utils.go
+++ b/drivers/shared/executor/exec_utils.go
@@ -18,6 +18,9 @@ import (
 type execHelper struct {
 	logger hclog.Logger
 
+	// networkSpec is the network isolation spec, set when platforms support network namespaces
+	networkSpec *drivers.NetworkIsolationSpec
+
 	// newTerminal function creates a tty appropriate for the command
 	// The returned pty end of tty function is to be called after process start.
 	newTerminal func() (pty func() (*os.File, error), tty *os.File, err error)

--- a/drivers/shared/executor/exec_utils.go
+++ b/drivers/shared/executor/exec_utils.go
@@ -18,9 +18,6 @@ import (
 type execHelper struct {
 	logger hclog.Logger
 
-	// networkSpec is the network isolation spec, set when platforms support network namespaces
-	networkSpec *drivers.NetworkIsolationSpec
-
 	// newTerminal function creates a tty appropriate for the command
 	// The returned pty end of tty function is to be called after process start.
 	newTerminal func() (pty func() (*os.File, error), tty *os.File, err error)

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -309,7 +309,7 @@ func (e *UniversalExecutor) Launch(command *ExecCommand) (*ProcessState, error) 
 	e.childCmd.Env = e.commandCfg.Env
 
 	// Start the process
-	if err = e.start(command); err != nil {
+	if err = wrapNetns(e.childCmd.Start, command.NetworkIsolation); err != nil {
 		return nil, fmt.Errorf("failed to start command path=%q --- args=%q: %v", path, e.childCmd.Args, err)
 	}
 
@@ -322,13 +322,14 @@ func (e *UniversalExecutor) Launch(command *ExecCommand) (*ProcessState, error) 
 func (e *UniversalExecutor) Exec(deadline time.Time, name string, args []string) ([]byte, int, error) {
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
-	return ExecScript(ctx, e.childCmd.Dir, e.commandCfg.Env, e.childCmd.SysProcAttr, name, args)
+	return ExecScript(ctx, e.childCmd.Dir, e.commandCfg.Env, e.childCmd.SysProcAttr, e.commandCfg.NetworkIsolation, name, args)
 }
 
 // ExecScript executes cmd with args and returns the output, exit code, and
 // error. Output is truncated to drivers/shared/structs.CheckBufSize
 func ExecScript(ctx context.Context, dir string, env []string, attrs *syscall.SysProcAttr,
-	name string, args []string) ([]byte, int, error) {
+	netSpec *drivers.NetworkIsolationSpec, name string, args []string) ([]byte, int, error) {
+
 	cmd := exec.CommandContext(ctx, name, args...)
 
 	// Copy runtime environment from the main command
@@ -341,7 +342,7 @@ func ExecScript(ctx context.Context, dir string, env []string, attrs *syscall.Sy
 	cmd.Stdout = buf
 	cmd.Stderr = buf
 
-	if err := cmd.Run(); err != nil {
+	if err := wrapNetns(cmd.Run, netSpec); err != nil {
 		exitErr, ok := err.(*exec.ExitError)
 		if !ok {
 			// Non-exit error, return it and let the caller treat
@@ -399,7 +400,9 @@ func (e *UniversalExecutor) ExecStreaming(ctx context.Context, command []string,
 			cmd.Stderr = stderr
 			return nil
 		},
-		processStart: cmd.Start,
+		processStart: func() error {
+			return wrapNetns(cmd.Start, e.commandCfg.NetworkIsolation)
+		},
 		processWait: func() (*os.ProcessState, error) {
 			err := cmd.Wait()
 			return cmd.ProcessState, err

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -309,7 +309,7 @@ func (e *UniversalExecutor) Launch(command *ExecCommand) (*ProcessState, error) 
 	e.childCmd.Env = e.commandCfg.Env
 
 	// Start the process
-	if err = wrapNetns(e.childCmd.Start, command.NetworkIsolation); err != nil {
+	if err = withNetworkIsolation(e.childCmd.Start, command.NetworkIsolation); err != nil {
 		return nil, fmt.Errorf("failed to start command path=%q --- args=%q: %v", path, e.childCmd.Args, err)
 	}
 
@@ -342,7 +342,7 @@ func ExecScript(ctx context.Context, dir string, env []string, attrs *syscall.Sy
 	cmd.Stdout = buf
 	cmd.Stderr = buf
 
-	if err := wrapNetns(cmd.Run, netSpec); err != nil {
+	if err := withNetworkIsolation(cmd.Run, netSpec); err != nil {
 		exitErr, ok := err.(*exec.ExitError)
 		if !ok {
 			// Non-exit error, return it and let the caller treat
@@ -401,7 +401,7 @@ func (e *UniversalExecutor) ExecStreaming(ctx context.Context, command []string,
 			return nil
 		},
 		processStart: func() error {
-			return wrapNetns(cmd.Start, e.commandCfg.NetworkIsolation)
+			return withNetworkIsolation(cmd.Start, e.commandCfg.NetworkIsolation)
 		},
 		processWait: func() (*os.ProcessState, error) {
 			err := cmd.Wait()

--- a/drivers/shared/executor/executor_basic.go
+++ b/drivers/shared/executor/executor_basic.go
@@ -4,6 +4,7 @@ package executor
 
 import (
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
 func NewExecutorWithIsolation(logger hclog.Logger) Executor {
@@ -22,4 +23,8 @@ func (e *UniversalExecutor) getAllPids() (map[int]*nomadPid, error) {
 
 func (e *UniversalExecutor) start(command *ExecCommand) error {
 	return e.childCmd.Start()
+}
+
+func wrapNetns(f func() error, _ *drivers.NetworkIsolationSpec) error {
+	return f()
 }

--- a/drivers/shared/executor/executor_basic.go
+++ b/drivers/shared/executor/executor_basic.go
@@ -25,6 +25,6 @@ func (e *UniversalExecutor) start(command *ExecCommand) error {
 	return e.childCmd.Start()
 }
 
-func wrapNetns(f func() error, _ *drivers.NetworkIsolationSpec) error {
+func withNetworkIsolation(f func() error, _ *drivers.NetworkIsolationSpec) error {
 	return f()
 }

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	cgroupFs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	lconfigs "github.com/opencontainers/runc/libcontainer/configs"
@@ -173,19 +174,19 @@ func DestroyCgroup(groups *lconfigs.Cgroup, executorPid int) error {
 	return mErrs.ErrorOrNil()
 }
 
-func (e *UniversalExecutor) start(command *ExecCommand) error {
-	if command.NetworkIsolation != nil && command.NetworkIsolation.Path != "" {
+func wrapNetns(f func() error, spec *drivers.NetworkIsolationSpec) error {
+	if spec != nil && spec.Path != "" {
 		// Get a handle to the target network namespace
-		netns, err := ns.GetNS(command.NetworkIsolation.Path)
+		netns, err := ns.GetNS(spec.Path)
 		if err != nil {
 			return err
 		}
 
 		// Start the container in the network namespace
 		return netns.Do(func(ns.NetNS) error {
-			return e.childCmd.Start()
+			return f()
 		})
 	}
 
-	return e.childCmd.Start()
+	return f()
 }

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -174,9 +174,8 @@ func DestroyCgroup(groups *lconfigs.Cgroup, executorPid int) error {
 	return mErrs.ErrorOrNil()
 }
 
-// wrapNetns takes a given function and calls it inside the network namespace
-// given in the NetworkIsolationSpec
-func wrapNetns(f func() error, spec *drivers.NetworkIsolationSpec) error {
+// withNetworkIsolation calls the passed function the network namespace `spec`
+func withNetworkIsolation(f func() error, spec *drivers.NetworkIsolationSpec) error {
 	if spec != nil && spec.Path != "" {
 		// Get a handle to the target network namespace
 		netns, err := ns.GetNS(spec.Path)

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -174,6 +174,8 @@ func DestroyCgroup(groups *lconfigs.Cgroup, executorPid int) error {
 	return mErrs.ErrorOrNil()
 }
 
+// wrapNetns takes a given function and calls it inside the network namespace
+// given in the NetworkIsolationSpec
 func wrapNetns(f func() error, spec *drivers.NetworkIsolationSpec) error {
 	if spec != nil && spec.Path != "" {
 		// Get a handle to the target network namespace


### PR DESCRIPTION
This PR fixes a bug where the netns was not being set during calls to Exec or ExecStreaming in the executor. 

It also switches the method which the libcontainer uses to enter the netns. Previously we wrapped the start command in a func that switched the parent netns when making the start call. Now we are setting the netns path in the libcontainer configuration which is used both at launch time and when we launch additional processes for Exec/ExecStreaming.