### PR TITLE
api: acl bootstrap errors aren't 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES:
  * api: Return a 404 if endpoint not found instead of redirecting to /ui/ [[GH-6658](https://github.com/hashicorp/nomad/issues/6658)]
  * api: Decompress web socket response body if gzipped on error responses [[GH-6650](https://github.com/hashicorp/nomad/issues/6650)]
  * api: Fixed a bug where some FS/Allocation API endpoints didn't return error messages [[GH-6427](https://github.com/hashicorp/nomad/issues/6427)]
+ * api: Return 40X status code for failing ACL requests, rather than 500 [[GH-6421](https://github.com/hashicorp/nomad/issues/6421)]
  * cli: Make scoring column orders consistent `nomad alloc status` [[GH-6609](https://github.com/hashicorp/nomad/issues/6609)]
  * cli: Fixed a bug where a cli user may fail to query FS/Allocation API endpoints if they lack `node:read` capability [[GH-6423](https://github.com/hashicorp/nomad/issues/6423)]
  * client: Fixed a bug where a client may not restart dead internal processes upon client's restart on Windows [[GH-6426](https://github.com/hashicorp/nomad/issues/6426)]

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -304,6 +304,9 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 			errMsg := err.Error()
 			if http, ok := err.(HTTPCodedError); ok {
 				code = http.Code()
+			} else if ecode, emsg, ok := structs.CodeFromRPCCodedErr(err); ok {
+				code = ecode
+				errMsg = emsg
 			} else {
 				// RPC errors get wrapped, so manually unwrap by only looking at their suffix
 				if strings.HasSuffix(errMsg, structs.ErrPermissionDenied.Error()) {

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -510,7 +510,7 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.A
 				return structs.NewErrRPCCodedf(400, "token lookup failed: %v", err)
 			}
 			if out == nil {
-				return structs.NewErrRPCCodedf(400, "cannot find token %s", token.AccessorID)
+				return structs.NewErrRPCCodedf(404, "cannot find token %s", token.AccessorID)
 			}
 
 			// Cannot toggle the "Global" mode

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -931,7 +931,7 @@ func TestACLEndpoint_DeleteTokens_WithNonexistentToken(t *testing.T) {
 
 	assert.NotNil(err)
 	expectedError := fmt.Sprintf("Cannot delete nonexistent tokens: %s", nonexistentToken.AccessorID)
-	assert.Contains(expectedError, err.Error())
+	assert.Contains(err.Error(), expectedError)
 }
 
 func TestACLEndpoint_Bootstrap(t *testing.T) {

--- a/nomad/structs/errors.go
+++ b/nomad/structs/errors.go
@@ -27,7 +27,7 @@ const (
 	ErrUnknownEvaluationPrefix = "Unknown evaluation"
 	ErrUnknownDeploymentPrefix = "Unknown deployment"
 
-	errRPCCodedErrorPrefix = "RPC_ERROR::"
+	errRPCCodedErrorPrefix = "RPC Error:: "
 )
 
 var (
@@ -148,15 +148,22 @@ func IsErrNodeLacksRpc(err error) bool {
 	return err != nil && strings.Contains(err.Error(), errNodeLacksRpc)
 }
 
+// NewErrRPCCoded wraps an RPC error with a code to be converted to HTTP status
+// code
 func NewErrRPCCoded(code int, msg string) error {
 	return fmt.Errorf("%s%d,%s", errRPCCodedErrorPrefix, code, msg)
 }
 
+// NewErrRPCCoded wraps an RPC error with a code to be converted to HTTP status
+// code
 func NewErrRPCCodedf(code int, format string, args ...interface{}) error {
 	msg := fmt.Sprintf(format, args...)
 	return fmt.Errorf("%s%d,%s", errRPCCodedErrorPrefix, code, msg)
 }
 
+// CodeFromRPCCodedErr returns the code and message of error if it's an RPC error
+// created through NewErrRPCCoded function.  Returns `ok` false if error is not
+// an rpc error
 func CodeFromRPCCodedErr(err error) (code int, msg string, ok bool) {
 	if err == nil || !strings.HasPrefix(err.Error(), errRPCCodedErrorPrefix) {
 		return 0, "", false

--- a/nomad/structs/errors.go
+++ b/nomad/structs/errors.go
@@ -3,6 +3,7 @@ package structs
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -25,6 +26,8 @@ const (
 	ErrUnknownJobPrefix        = "Unknown job"
 	ErrUnknownEvaluationPrefix = "Unknown evaluation"
 	ErrUnknownDeploymentPrefix = "Unknown deployment"
+
+	errRPCCodedErrorPrefix = "RPC_ERROR::"
 )
 
 var (
@@ -143,4 +146,32 @@ func IsErrUnknownNomadVersion(err error) bool {
 // unable to connect to a client node because the client is too old (pre-v0.8).
 func IsErrNodeLacksRpc(err error) bool {
 	return err != nil && strings.Contains(err.Error(), errNodeLacksRpc)
+}
+
+func NewErrRPCCoded(code int, msg string) error {
+	return fmt.Errorf("%s%d,%s", errRPCCodedErrorPrefix, code, msg)
+}
+
+func NewErrRPCCodedf(code int, format string, args ...interface{}) error {
+	msg := fmt.Sprintf(format, args...)
+	return fmt.Errorf("%s%d,%s", errRPCCodedErrorPrefix, code, msg)
+}
+
+func CodeFromRPCCodedErr(err error) (code int, msg string, ok bool) {
+	if err == nil || !strings.HasPrefix(err.Error(), errRPCCodedErrorPrefix) {
+		return 0, "", false
+	}
+
+	headerLen := len(errRPCCodedErrorPrefix)
+	parts := strings.SplitN(err.Error()[headerLen:], ",", 2)
+	if len(parts) != 2 {
+		return 0, "", false
+	}
+
+	code, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, "", false
+	}
+
+	return code, parts[1], true
 }

--- a/nomad/structs/errors_test.go
+++ b/nomad/structs/errors_test.go
@@ -1,0 +1,49 @@
+package structs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRPCCodedErrors(t *testing.T) {
+	cases := []struct {
+		err     error
+		code    int
+		message string
+	}{
+		{
+			NewErrRPCCoded(400, "a test message,here"),
+			400,
+			"a test message,here",
+		},
+		{
+			NewErrRPCCodedf(500, "a test message,here %s %s", "and,here%s", "second"),
+			500,
+			"a test message,here and,here%s second",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.err.Error(), func(t *testing.T) {
+			code, msg, ok := CodeFromRPCCodedErr(c.err)
+			assert.True(t, ok)
+			assert.Equal(t, c.code, code)
+			assert.Equal(t, c.message, msg)
+		})
+	}
+
+	negativeCases := []string{
+		"random error",
+		errRPCCodedErrorPrefix,
+		errRPCCodedErrorPrefix + "123",
+		errRPCCodedErrorPrefix + "qwer,asdf",
+	}
+	for _, c := range negativeCases {
+		t.Run(c, func(t *testing.T) {
+			_, _, ok := CodeFromRPCCodedErr(errors.New(c))
+			assert.False(t, ok)
+		})
+	}
+}


### PR DESCRIPTION
Noticed that ACL endpoints return 500 status code for user errors.  This
is confusing and can lead to false monitoring alerts.

Here, I introduce a concept of RPCCoded errors to be returned by RPC
that signal a code in addition to error message.  Codes for now match
HTTP codes to ease reasoning.

Here, I start with ACL endpoints, but we can propagate status code for other endpoints as necessary.

I see that we have special cased permission and not found errors for some endpoints, but I didn't want to follow this pattern as it seems brittle and wrapping seems like too much magic for my taste.

```
# before
$ nomad acl bootstrap
Error bootstrapping: Unexpected response code: 500 (ACL bootstrap already done (reset index: 9))

# after
$ nomad acl bootstrap
Error bootstrapping: Unexpected response code: 400 (ACL bootstrap already done (reset index: 9))
```