### PR TITLE
cli: show full id for single node or alloc status

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -234,7 +234,7 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 	}
 
 	basic := []string{
-		fmt.Sprintf("ID|%s", limit(alloc.ID, uuidLength)),
+		fmt.Sprintf("ID|%s", alloc.ID),
 		fmt.Sprintf("Eval ID|%s", limit(alloc.EvalID, uuidLength)),
 		fmt.Sprintf("Name|%s", alloc.Name),
 		fmt.Sprintf("Node ID|%s", limit(alloc.NodeID, uuidLength)),

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -333,7 +333,7 @@ func formatDrain(n *api.Node) string {
 func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 	// Format the header output
 	basic := []string{
-		fmt.Sprintf("ID|%s", limit(node.ID, c.length)),
+		fmt.Sprintf("ID|%s", node.ID),
 		fmt.Sprintf("Name|%s", node.Name),
 		fmt.Sprintf("Class|%s", node.NodeClass),
 		fmt.Sprintf("DC|%s", node.Datacenter),

--- a/command/node_status_test.go
+++ b/command/node_status_test.go
@@ -137,11 +137,8 @@ func TestNodeStatusCommand_Run(t *testing.T) {
 	if !strings.Contains(out, "mynode") {
 		t.Fatalf("expect to find mynode, got: %s", out)
 	}
-	if strings.Contains(out, nodeID) {
-		t.Fatalf("expected truncated node id, got: %s", out)
-	}
-	if !strings.Contains(out, nodeID[:8]) {
-		t.Fatalf("expected node id %q, got: %s", nodeID[:8], out)
+	if !strings.Contains(out, nodeID) {
+		t.Fatalf("expected node id %q, got: %s", nodeID, out)
 	}
 	ui.OutputWriter.Reset()
 


### PR DESCRIPTION
Show full ID on individual alloc or node status views.  Shortening
the ID isn't very helpful in these cases, and makes looking up the full
id slightly more complicated when user needs to interact with API.

List views are unmodified and show short id unless `-vebose` flag is passed.

Before
```
$ nomad node status -self | head -n2
ID            = 21fc51f9
Name          = mars-2.local

$ nomad alloc status 15ae54cd | head -n3
ID                  = 15ae54cd-08dd-3681-03cf-4c23ace7e7c3
Eval ID             = a6b15f86
Name                = example.cache[0]
```

After:
```
$ nomad node status -self | head -n2
ID            = 21fc51f9-fd39-0fa0-fb41-f34c7aa36101
Name          = mars-2.local

$ nomad alloc status 15ae54cd | head -n3
ID                  = 15ae54cd-08dd-3681-03cf-4c23ace7e7c3
Eval ID             = a6b15f86
Name                = example.cache[0]
```