### PR TITLE
Add support for logging to a file

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -57,6 +57,18 @@ type Config struct {
 	// LogJson enables log output in a JSON format
 	LogJson bool `hcl:"log_json"`
 
+	// LogFile enables logging to a file
+	LogFile string `hcl:"log_file"`
+
+	// LogRotateDuration is the time period that logs should be rotated in
+	LogRotateDuration string `hcl:"log_rotate_duration"`
+
+	// LogRotateBytes is the max number of bytes that should be written to a file
+	LogRotateBytes int `hcl:"log_rotate_bytes"`
+
+	// LogRotateMaxFiles is the max number of log files to keep
+	LogRotateMaxFiles int `hcl:"log_rotate_max_files"`
+
 	// BindAddr is the address on which all of nomad's services will
 	// be bound. If not specified, this defaults to 127.0.0.1.
 	BindAddr string `hcl:"bind_addr"`
@@ -897,6 +909,18 @@ func (c *Config) Merge(b *Config) *Config {
 	}
 	if b.LogJson {
 		result.LogJson = true
+	}
+	if b.LogFile != "" {
+		result.LogFile = b.LogFile
+	}
+	if b.LogRotateDuration != "" {
+		result.LogRotateDuration = b.LogRotateDuration
+	}
+	if b.LogRotateBytes != 0 {
+		result.LogRotateBytes = b.LogRotateBytes
+	}
+	if b.LogRotateMaxFiles != 0 {
+		result.LogRotateMaxFiles = b.LogRotateMaxFiles
 	}
 	if b.BindAddr != "" {
 		result.BindAddr = b.BindAddr

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -19,6 +19,7 @@ var basicConfig = &Config{
 	NodeName:    "my-web",
 	DataDir:     "/tmp/nomad",
 	PluginDir:   "/tmp/nomad-plugins",
+	LogFile:     "/var/log/nomad.log",
 	LogLevel:    "ERR",
 	LogJson:     true,
 	BindAddr:    "192.168.0.1",
@@ -409,14 +410,10 @@ func TestConfig_Parse(t *testing.T) {
 		t.Run(tc.File, func(t *testing.T) {
 			require := require.New(t)
 			path, err := filepath.Abs(filepath.Join("./testdata", tc.File))
-			if err != nil {
-				t.Fatalf("file: %s\n\n%s", tc.File, err)
-			}
+			require.NoError(err)
 
 			actual, err := ParseConfigFile(path)
-			if (err != nil) != tc.Err {
-				t.Fatalf("file: %s\n\n%s", tc.File, err)
-			}
+			require.NoError(err)
 
 			// ParseConfig used to re-merge defaults for these three objects,
 			// despite them already being merged in LoadConfig. The test structs

--- a/command/agent/log_file.go
+++ b/command/agent/log_file.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -104,6 +105,11 @@ func (l *logFile) pruneFiles() error {
 	if err != nil {
 		return err
 	}
+
+	// Stort the strings as filepath.Glob does not publicly guarantee that files
+	// are sorted, so here we add an extra defensive sort.
+	sort.Strings(matches)
+
 	// Prune if there are more files stored than the configured max
 	stale := len(matches) - l.MaxFiles
 	for i := 0; i < stale; i++ {

--- a/command/agent/log_file.go
+++ b/command/agent/log_file.go
@@ -121,7 +121,7 @@ func (l *logFile) pruneFiles() error {
 }
 
 // Write is used to implement io.Writer
-func (l *logFile) Write(b []byte) (n int, err error) {
+func (l *logFile) Write(b []byte) (int, error) {
 	// Filter out log entries that do not match log level criteria
 	if !l.logFilter.Check(b) {
 		return 0, nil
@@ -139,6 +139,8 @@ func (l *logFile) Write(b []byte) (n int, err error) {
 	if err := l.rotate(); err != nil {
 		return 0, err
 	}
-	l.BytesWritten += int64(len(b))
-	return l.FileInfo.Write(b)
+
+	n, err := l.FileInfo.Write(b)
+	l.BytesWritten += int64(n)
+	return n, err
 }

--- a/command/agent/log_file.go
+++ b/command/agent/log_file.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/logutils"
+)
+
+var (
+	now = time.Now
+)
+
+// logFile is used to setup a file based logger that also performs log rotation
+type logFile struct {
+	// Log level Filter to filter out logs that do not matcch LogLevel criteria
+	logFilter *logutils.LevelFilter
+
+	//Name of the log file
+	fileName string
+
+	//Path to the log file
+	logPath string
+
+	//Duration between each file rotation operation
+	duration time.Duration
+
+	//LastCreated represents the creation time of the latest log
+	LastCreated time.Time
+
+	//FileInfo is the pointer to the current file being written to
+	FileInfo *os.File
+
+	//MaxBytes is the maximum number of desired bytes for a log file
+	MaxBytes int
+
+	//BytesWritten is the number of bytes written in the current log file
+	BytesWritten int64
+
+	// Max rotated files to keep before removing them.
+	MaxFiles int
+
+	//acquire is the mutex utilized to ensure we have no concurrency issues
+	acquire sync.Mutex
+}
+
+func (l *logFile) fileNamePattern() string {
+	// Extract the file extension
+	fileExt := filepath.Ext(l.fileName)
+	// If we have no file extension we append .log
+	if fileExt == "" {
+		fileExt = ".log"
+	}
+	// Remove the file extension from the filename
+	return strings.TrimSuffix(l.fileName, fileExt) + "-%s" + fileExt
+}
+
+func (l *logFile) openNew() error {
+	fileNamePattern := l.fileNamePattern()
+	// New file name has the format : filename-timestamp.extension
+	createTime := now()
+	newfileName := fmt.Sprintf(fileNamePattern, strconv.FormatInt(createTime.UnixNano(), 10))
+	newfilePath := filepath.Join(l.logPath, newfileName)
+	// Try creating a file. We truncate the file because we are the only authority to write the logs
+	filePointer, err := os.OpenFile(newfilePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0640)
+	if err != nil {
+		return err
+	}
+
+	l.FileInfo = filePointer
+	// New file, new bytes tracker, new creation time :)
+	l.LastCreated = createTime
+	l.BytesWritten = 0
+	return nil
+}
+
+func (l *logFile) rotate() error {
+	// Get the time from the last point of contact
+	timeElapsed := time.Since(l.LastCreated)
+	// Rotate if we hit the byte file limit or the time limit
+	if (l.BytesWritten >= int64(l.MaxBytes) && (l.MaxBytes > 0)) || timeElapsed >= l.duration {
+		l.FileInfo.Close()
+		if err := l.pruneFiles(); err != nil {
+			return err
+		}
+		return l.openNew()
+	}
+	return nil
+}
+
+func (l *logFile) pruneFiles() error {
+	if l.MaxFiles == 0 {
+		return nil
+	}
+	pattern := l.fileNamePattern()
+	//get all the files that match the log file pattern
+	globExpression := filepath.Join(l.logPath, fmt.Sprintf(pattern, "*"))
+	matches, err := filepath.Glob(globExpression)
+	if err != nil {
+		return err
+	}
+	// Prune if there are more files stored than the configured max
+	stale := len(matches) - l.MaxFiles
+	for i := 0; i < stale; i++ {
+		if err := os.Remove(matches[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Write is used to implement io.Writer
+func (l *logFile) Write(b []byte) (n int, err error) {
+	// Filter out log entries that do not match log level criteria
+	if !l.logFilter.Check(b) {
+		return 0, nil
+	}
+
+	l.acquire.Lock()
+	defer l.acquire.Unlock()
+	//Create a new file if we have no file to write to
+	if l.FileInfo == nil {
+		if err := l.openNew(); err != nil {
+			return 0, err
+		}
+	}
+	// Check for the last contact and rotate if necessary
+	if err := l.rotate(); err != nil {
+		return 0, err
+	}
+	l.BytesWritten += int64(len(b))
+	return l.FileInfo.Write(b)
+}

--- a/command/agent/log_file_test.go
+++ b/command/agent/log_file_test.go
@@ -140,7 +140,7 @@ func TestLogFile_deleteArchives(t *testing.T) {
 		}
 		contents := string(bytes)
 
-		require.NotEqual("[INFO] Hellow World", contents, "oldest log should have been deleted")
+		require.NotEqual("[INFO] Hello World", contents, "oldest log should have been deleted")
 	}
 }
 

--- a/command/agent/log_file_test.go
+++ b/command/agent/log_file_test.go
@@ -1,0 +1,171 @@
+package agent
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/logutils"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFileName = "Nomad.log"
+	testDuration = 2 * time.Second
+	testBytes    = 10
+)
+
+func TestLogFile_timeRotation(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	tempDir, err := ioutil.TempDir("", "LogWriterTimeTest")
+	require.NoError(err)
+
+	defer os.Remove(tempDir)
+
+	filt := LevelFilter()
+	logFile := logFile{
+		logFilter: filt,
+		fileName:  testFileName,
+		logPath:   tempDir,
+		duration:  testDuration,
+	}
+	logFile.Write([]byte("Hello World"))
+	time.Sleep(2 * time.Second)
+	logFile.Write([]byte("Second File"))
+	want := 2
+	if got, _ := ioutil.ReadDir(tempDir); len(got) != want {
+		t.Errorf("Expected %d files, got %v file(s)", want, len(got))
+	}
+}
+
+func TestLogFile_openNew(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	tempDir, err := ioutil.TempDir("", "LogWriterOpenTest")
+	require.NoError(err)
+	defer os.Remove(tempDir)
+
+	logFile := logFile{fileName: testFileName, logPath: tempDir, duration: testDuration}
+	require.NoError(logFile.openNew())
+
+	_, err = ioutil.ReadFile(logFile.FileInfo.Name())
+	require.NoError(err)
+}
+
+func TestLogFile_byteRotation(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	tempDir, err := ioutil.TempDir("", "LogWriterByteTest")
+	require.NoError(err)
+	defer os.Remove(tempDir)
+
+	filt := LevelFilter()
+	filt.MinLevel = logutils.LogLevel("INFO")
+	logFile := logFile{
+		logFilter: filt,
+		fileName:  testFileName,
+		logPath:   tempDir,
+		MaxBytes:  testBytes,
+		duration:  24 * time.Hour,
+	}
+	logFile.Write([]byte("Hello World"))
+	logFile.Write([]byte("Second File"))
+	want := 2
+	tempFiles, _ := ioutil.ReadDir(tempDir)
+	require.Equal(want, len(tempFiles))
+}
+
+func TestLogFile_logLevelFiltering(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	tempDir, err := ioutil.TempDir("", "LogWriterFilterTest")
+	require.NoError(err)
+	defer os.Remove(tempDir)
+	filt := LevelFilter()
+	logFile := logFile{
+		logFilter: filt,
+		fileName:  testFileName,
+		logPath:   tempDir,
+		MaxBytes:  testBytes,
+		duration:  testDuration,
+	}
+	logFile.Write([]byte("[INFO] This is an info message"))
+	logFile.Write([]byte("[DEBUG] This is a debug message"))
+	logFile.Write([]byte("[ERR] This is an error message"))
+	want := 2
+	tempFiles, _ := ioutil.ReadDir(tempDir)
+	require.Equal(want, len(tempFiles))
+}
+
+func TestLogFile_deleteArchives(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	tempDir, err := ioutil.TempDir("", "LogWriterDeleteArchivesTest")
+	require.NoError(err)
+	defer os.Remove(tempDir)
+
+	filt := LevelFilter()
+	filt.MinLevel = logutils.LogLevel("INFO")
+	logFile := logFile{
+		logFilter: filt,
+		fileName:  testFileName,
+		logPath:   tempDir,
+		MaxBytes:  testBytes,
+		duration:  24 * time.Hour,
+		MaxFiles:  1,
+	}
+	logFile.Write([]byte("[INFO] Hello World"))
+	logFile.Write([]byte("[INFO] Second File"))
+	logFile.Write([]byte("[INFO] Third File"))
+	want := 2
+	tempFiles, _ := ioutil.ReadDir(tempDir)
+
+	require.Equal(want, len(tempFiles))
+
+	for _, tempFile := range tempFiles {
+		var bytes []byte
+		var err error
+		path := filepath.Join(tempDir, tempFile.Name())
+		if bytes, err = ioutil.ReadFile(path); err != nil {
+			t.Errorf(err.Error())
+			return
+		}
+		contents := string(bytes)
+
+		require.NotEqual("[INFO] Hellow World", contents, "oldest log should have been deleted")
+	}
+}
+
+func TestLogFile_deleteArchivesDisabled(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	tempDir, err := ioutil.TempDir("", "LogWriterDeleteArchivesDisabledTest")
+	require.NoError(err)
+	defer os.Remove(tempDir)
+
+	filt := LevelFilter()
+	filt.MinLevel = logutils.LogLevel("INFO")
+	logFile := logFile{
+		logFilter: filt,
+		fileName:  testFileName,
+		logPath:   tempDir,
+		MaxBytes:  testBytes,
+		duration:  24 * time.Hour,
+		MaxFiles:  0,
+	}
+	logFile.Write([]byte("[INFO] Hello World"))
+	logFile.Write([]byte("[INFO] Second File"))
+	logFile.Write([]byte("[INFO] Third File"))
+	want := 3
+	tempFiles, _ := ioutil.ReadDir(tempDir)
+	require.Equal(want, len(tempFiles))
+}

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -13,6 +13,8 @@ log_level = "ERR"
 
 log_json = true
 
+log_file = "/var/log/nomad.log"
+
 bind_addr = "192.168.0.1"
 
 enable_debug = true

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -143,6 +143,7 @@
   ],
   "leave_on_interrupt": true,
   "leave_on_terminate": true,
+  "log_file": "/var/log/nomad.log",
   "log_json": true,
   "log_level": "ERR",
   "name": "my-web",


### PR DESCRIPTION
This PR introduces support for file logging in Nomad.

The implementation of `logFile` is a lift and shift from Consul's `logger/LogFile`.

It introduces a few new configuration options:

| field_name | default | description |
| --------------- | --------- | --------------- |
| log_file       | "" |  This can be specified with the complete path along with the name of the log. In case the path doesn't have the filename, the filename defaults to nomad-{timestamp}.log. Can be combined with log_rotate_bytes and log_rotate_duration for a fine-grained log rotation control. |
| log_rotate_bytes | 0 | to specify the number of bytes that should be written to a log before it needs to be rotated. Unless specified, there is no limit to the number of bytes that can be written to a log file. |
| log_rotate_duration | 24 hours | to specify the maximum duration a log should be written to before it needs to be rotated. Must be a duration value such as 30s. |
| log_rotate_max_files | 0 | to specify the maximum number of older log file archives to keep. If 0 no files are ever deleted. |

It also updates the command/agent log setup to more easily allow extra logging backends in the future, alongside wiring up configuration for logFile.

required for #6372 