### PR TITLE
acl: check ACL against object namespace

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -481,3 +481,25 @@ func (a *ACL) AllowQuotaWrite() bool {
 func (a *ACL) IsManagement() bool {
 	return a.management
 }
+
+// NamespaceValidator returns a func that wraps ACL.AllowNamespaceOperation in
+// a list of operations. Returns true (allowed) if acls are disabled or if
+// *any* capabilities match.
+func NamespaceValidator(ops ...string) func(*ACL, string) bool {
+	return func(acl *ACL, ns string) bool {
+		// Always allow if ACLs are disabled.
+		if acl == nil {
+			return true
+		}
+
+		for _, op := range ops {
+			if acl.AllowNamespaceOperation(ns, op) {
+				// An operation is allowed, return true
+				return true
+			}
+		}
+
+		// No operations are allowed by this ACL, return false
+		return false
+	}
+}

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -114,7 +114,6 @@ func TestFS_Stat(t *testing.T) {
 
 func TestFS_Stat_ACL(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
 	// Start a server
 	s, root := nomad.TestACLServer(t, nil)
@@ -135,6 +134,15 @@ func TestFS_Stat_ACL(t *testing.T) {
 		[]string{acl.NamespaceCapabilityReadLogs, acl.NamespaceCapabilityReadFS})
 	tokenGood := mock.CreatePolicyAndToken(t, s.State(), 1009, "valid2", policyGood)
 
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for": "20s",
+	}
+
+	// Wait for client to be running job
+	alloc := testutil.WaitForRunningWithToken(t, s.RPC, job, root.SecretID)[0]
+
 	cases := []struct {
 		Name          string
 		Token         string
@@ -146,22 +154,19 @@ func TestFS_Stat_ACL(t *testing.T) {
 			ExpectedError: structs.ErrPermissionDenied.Error(),
 		},
 		{
-			Name:          "good token",
-			Token:         tokenGood.SecretID,
-			ExpectedError: structs.ErrUnknownAllocationPrefix,
+			Name:  "good token",
+			Token: tokenGood.SecretID,
 		},
 		{
-			Name:          "root token",
-			Token:         root.SecretID,
-			ExpectedError: structs.ErrUnknownAllocationPrefix,
+			Name:  "root token",
+			Token: root.SecretID,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			// Make the request with bad allocation id
 			req := &cstructs.FsStatRequest{
-				AllocID: uuid.Generate(),
+				AllocID: alloc.ID,
 				Path:    "/",
 				QueryOptions: structs.QueryOptions{
 					Region:    "global",
@@ -172,8 +177,12 @@ func TestFS_Stat_ACL(t *testing.T) {
 
 			var resp cstructs.FsStatResponse
 			err := client.ClientRPC("FileSystem.Stat", req, &resp)
-			require.NotNil(err)
-			require.Contains(err.Error(), c.ExpectedError)
+			if c.ExpectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), c.ExpectedError)
+			}
 		})
 	}
 }
@@ -238,7 +247,6 @@ func TestFS_List(t *testing.T) {
 
 func TestFS_List_ACL(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
 	// Start a server
 	s, root := nomad.TestACLServer(t, nil)
@@ -259,6 +267,15 @@ func TestFS_List_ACL(t *testing.T) {
 		[]string{acl.NamespaceCapabilityReadLogs, acl.NamespaceCapabilityReadFS})
 	tokenGood := mock.CreatePolicyAndToken(t, s.State(), 1009, "valid2", policyGood)
 
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for": "20s",
+	}
+
+	// Wait for client to be running job
+	alloc := testutil.WaitForRunningWithToken(t, s.RPC, job, root.SecretID)[0]
+
 	cases := []struct {
 		Name          string
 		Token         string
@@ -270,14 +287,12 @@ func TestFS_List_ACL(t *testing.T) {
 			ExpectedError: structs.ErrPermissionDenied.Error(),
 		},
 		{
-			Name:          "good token",
-			Token:         tokenGood.SecretID,
-			ExpectedError: structs.ErrUnknownAllocationPrefix,
+			Name:  "good token",
+			Token: tokenGood.SecretID,
 		},
 		{
-			Name:          "root token",
-			Token:         root.SecretID,
-			ExpectedError: structs.ErrUnknownAllocationPrefix,
+			Name:  "root token",
+			Token: root.SecretID,
 		},
 	}
 
@@ -285,7 +300,7 @@ func TestFS_List_ACL(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			// Make the request with bad allocation id
 			req := &cstructs.FsListRequest{
-				AllocID: uuid.Generate(),
+				AllocID: alloc.ID,
 				Path:    "/",
 				QueryOptions: structs.QueryOptions{
 					Region:    "global",
@@ -296,8 +311,11 @@ func TestFS_List_ACL(t *testing.T) {
 
 			var resp cstructs.FsListResponse
 			err := client.ClientRPC("FileSystem.List", req, &resp)
-			require.NotNil(err)
-			require.Contains(err.Error(), c.ExpectedError)
+			if c.ExpectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, c.ExpectedError)
+			}
 		})
 	}
 }
@@ -379,7 +397,6 @@ OUTER:
 
 func TestFS_Stream_ACL(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
 	// Start a server
 	s, root := nomad.TestACLServer(t, nil)
@@ -400,6 +417,15 @@ func TestFS_Stream_ACL(t *testing.T) {
 		[]string{acl.NamespaceCapabilityReadLogs, acl.NamespaceCapabilityReadFS})
 	tokenGood := mock.CreatePolicyAndToken(t, s.State(), 1009, "valid2", policyGood)
 
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for": "20s",
+	}
+
+	// Wait for client to be running job
+	alloc := testutil.WaitForRunningWithToken(t, s.RPC, job, root.SecretID)[0]
+
 	cases := []struct {
 		Name          string
 		Token         string
@@ -411,14 +437,12 @@ func TestFS_Stream_ACL(t *testing.T) {
 			ExpectedError: structs.ErrPermissionDenied.Error(),
 		},
 		{
-			Name:          "good token",
-			Token:         tokenGood.SecretID,
-			ExpectedError: structs.ErrUnknownAllocationPrefix,
+			Name:  "good token",
+			Token: tokenGood.SecretID,
 		},
 		{
-			Name:          "root token",
-			Token:         root.SecretID,
-			ExpectedError: structs.ErrUnknownAllocationPrefix,
+			Name:  "root token",
+			Token: root.SecretID,
 		},
 	}
 
@@ -426,7 +450,7 @@ func TestFS_Stream_ACL(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			// Make the request with bad allocation id
 			req := &cstructs.FsStreamRequest{
-				AllocID: uuid.Generate(),
+				AllocID: alloc.ID,
 				Path:    "foo",
 				Origin:  "start",
 				QueryOptions: structs.QueryOptions{
@@ -438,7 +462,7 @@ func TestFS_Stream_ACL(t *testing.T) {
 
 			// Get the handler
 			handler, err := client.StreamingRpcHandler("FileSystem.Stream")
-			require.Nil(err)
+			require.Nil(t, err)
 
 			// Create a pipe
 			p1, p2 := net.Pipe()
@@ -457,10 +481,8 @@ func TestFS_Stream_ACL(t *testing.T) {
 				for {
 					var msg cstructs.StreamErrWrapper
 					if err := decoder.Decode(&msg); err != nil {
-						if err == io.EOF || strings.Contains(err.Error(), "closed") {
-							return
-						}
-						errCh <- fmt.Errorf("error decoding: %v", err)
+						errCh <- err
+						return
 					}
 
 					streamMsg <- &msg
@@ -469,7 +491,7 @@ func TestFS_Stream_ACL(t *testing.T) {
 
 			// Send the request
 			encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-			require.Nil(encoder.Encode(req))
+			require.NoError(t, encoder.Encode(req))
 
 			timeout := time.After(5 * time.Second)
 
@@ -479,6 +501,11 @@ func TestFS_Stream_ACL(t *testing.T) {
 				case <-timeout:
 					t.Fatal("timeout")
 				case err := <-errCh:
+					eof := err == io.EOF || strings.Contains(err.Error(), "closed")
+					if c.ExpectedError == "" && eof {
+						// No error was expected!
+						return
+					}
 					t.Fatal(err)
 				case msg := <-streamMsg:
 					if msg.Error == nil {
@@ -1019,6 +1046,15 @@ func TestFS_Logs_ACL(t *testing.T) {
 		[]string{acl.NamespaceCapabilityReadLogs, acl.NamespaceCapabilityReadFS})
 	tokenGood := mock.CreatePolicyAndToken(t, s.State(), 1009, "valid2", policyGood)
 
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for": "20s",
+	}
+
+	// Wait for client to be running job
+	alloc := testutil.WaitForRunningWithToken(t, s.RPC, job, root.SecretID)[0]
+
 	cases := []struct {
 		Name          string
 		Token         string
@@ -1030,14 +1066,12 @@ func TestFS_Logs_ACL(t *testing.T) {
 			ExpectedError: structs.ErrPermissionDenied.Error(),
 		},
 		{
-			Name:          "good token",
-			Token:         tokenGood.SecretID,
-			ExpectedError: structs.ErrUnknownAllocationPrefix,
+			Name:  "good token",
+			Token: tokenGood.SecretID,
 		},
 		{
-			Name:          "root token",
-			Token:         root.SecretID,
-			ExpectedError: structs.ErrUnknownAllocationPrefix,
+			Name:  "root token",
+			Token: root.SecretID,
 		},
 	}
 
@@ -1045,8 +1079,8 @@ func TestFS_Logs_ACL(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			// Make the request with bad allocation id
 			req := &cstructs.FsLogsRequest{
-				AllocID: uuid.Generate(),
-				Task:    "foo",
+				AllocID: alloc.ID,
+				Task:    job.TaskGroups[0].Tasks[0].Name,
 				LogType: "stdout",
 				Origin:  "start",
 				QueryOptions: structs.QueryOptions{
@@ -1077,10 +1111,8 @@ func TestFS_Logs_ACL(t *testing.T) {
 				for {
 					var msg cstructs.StreamErrWrapper
 					if err := decoder.Decode(&msg); err != nil {
-						if err == io.EOF || strings.Contains(err.Error(), "closed") {
-							return
-						}
-						errCh <- fmt.Errorf("error decoding: %v", err)
+						errCh <- err
+						return
 					}
 
 					streamMsg <- &msg
@@ -1099,6 +1131,11 @@ func TestFS_Logs_ACL(t *testing.T) {
 				case <-timeout:
 					t.Fatal("timeout")
 				case err := <-errCh:
+					eof := err == io.EOF || strings.Contains(err.Error(), "closed")
+					if c.ExpectedError == "" && eof {
+						// No error was expected!
+						return
+					}
 					t.Fatal(err)
 				case msg := <-streamMsg:
 					if msg.Error == nil {
@@ -1106,6 +1143,7 @@ func TestFS_Logs_ACL(t *testing.T) {
 					}
 
 					if strings.Contains(msg.Error.Error(), c.ExpectedError) {
+						// Ok! Error matched expectation.
 						break OUTER
 					} else {
 						t.Fatalf("Bad error: %v", msg.Error)

--- a/client/testutil/rpc.go
+++ b/client/testutil/rpc.go
@@ -1,0 +1,86 @@
+package testutil
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+	"github.com/ugorji/go/codec"
+)
+
+// StreamingRPC may be satisfied by client.Client or server.Server.
+type StreamingRPC interface {
+	StreamingRpcHandler(method string) (structs.StreamingRpcHandler, error)
+}
+
+// StreamingRPCErrorTestCase is a test case to be passed to the
+// assertStreamingRPCError func.
+type StreamingRPCErrorTestCase struct {
+	Name   string
+	RPC    string
+	Req    interface{}
+	Assert func(error) bool
+}
+
+// AssertStreamingRPCError asserts a streaming RPC's error matches the given
+// assertion in the test case.
+func AssertStreamingRPCError(t *testing.T, s StreamingRPC, tc StreamingRPCErrorTestCase) {
+	handler, err := s.StreamingRpcHandler(tc.RPC)
+	require.NoError(t, err)
+
+	// Create a pipe
+	p1, p2 := net.Pipe()
+	defer p1.Close()
+	defer p2.Close()
+
+	errCh := make(chan error, 1)
+	streamMsg := make(chan *cstructs.StreamErrWrapper, 1)
+
+	// Start the handler
+	go handler(p2)
+
+	// Start the decoder
+	go func() {
+		decoder := codec.NewDecoder(p1, structs.MsgpackHandle)
+		for {
+			var msg cstructs.StreamErrWrapper
+			if err := decoder.Decode(&msg); err != nil {
+				if err == io.EOF || strings.Contains(err.Error(), "closed") {
+					return
+				}
+				errCh <- fmt.Errorf("error decoding: %v", err)
+			}
+
+			streamMsg <- &msg
+		}
+	}()
+
+	// Send the request
+	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
+	require.NoError(t, encoder.Encode(tc.Req))
+
+	timeout := time.After(5 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			t.Fatal("timeout")
+		case err := <-errCh:
+			require.NoError(t, err)
+		case msg := <-streamMsg:
+			// Convert RpcError to error
+			var err error
+			if msg.Error != nil {
+				err = msg.Error
+			}
+			require.True(t, tc.Assert(err), "(%T) %s", msg.Error, msg.Error)
+			return
+		}
+	}
+}

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -346,7 +346,7 @@ func TestHTTP_AllocRestart_ACL(t *testing.T) {
 			respW := httptest.NewRecorder()
 			_, err = s.Server.ClientAllocRequest(respW, req)
 			require.NotNil(err)
-			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+			require.True(structs.IsErrUnknownAllocation(err), "(%T) %v", err, err)
 		}
 
 		// Try request with an invalid token and expect it to fail
@@ -360,7 +360,7 @@ func TestHTTP_AllocRestart_ACL(t *testing.T) {
 			setToken(req, token)
 			_, err = s.Server.ClientAllocRequest(respW, req)
 			require.NotNil(err)
-			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+			require.True(structs.IsErrUnknownAllocation(err), "(%T) %v", err, err)
 		}
 
 		// Try request with a valid token
@@ -376,7 +376,7 @@ func TestHTTP_AllocRestart_ACL(t *testing.T) {
 			setToken(req, token)
 			_, err = s.Server.ClientAllocRequest(respW, req)
 			require.NotNil(err)
-			require.True(structs.IsErrUnknownAllocation(err))
+			require.True(structs.IsErrUnknownAllocation(err), "(%T) %v", err, err)
 		}
 
 		// Try request with a management token
@@ -523,7 +523,7 @@ func TestHTTP_AllocStats_ACL(t *testing.T) {
 			respW := httptest.NewRecorder()
 			_, err := s.Server.ClientAllocRequest(respW, req)
 			require.NotNil(err)
-			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+			require.True(structs.IsErrUnknownAllocation(err), "(%T) %v", err, err)
 		}
 
 		// Try request with an invalid token and expect failure
@@ -533,7 +533,7 @@ func TestHTTP_AllocStats_ACL(t *testing.T) {
 			setToken(req, token)
 			_, err := s.Server.ClientAllocRequest(respW, req)
 			require.NotNil(err)
-			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+			require.True(structs.IsErrUnknownAllocation(err), "(%T) %v", err, err)
 		}
 
 		// Try request with a valid token
@@ -545,7 +545,7 @@ func TestHTTP_AllocStats_ACL(t *testing.T) {
 			setToken(req, token)
 			_, err := s.Server.ClientAllocRequest(respW, req)
 			require.NotNil(err)
-			require.True(structs.IsErrUnknownAllocation(err))
+			require.True(structs.IsErrUnknownAllocation(err), "(%T) %v", err, err)
 		}
 
 		// Try request with a management token
@@ -812,7 +812,7 @@ func TestHTTP_AllocGC_ACL(t *testing.T) {
 			respW := httptest.NewRecorder()
 			_, err := s.Server.ClientAllocRequest(respW, req)
 			require.NotNil(err)
-			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+			require.True(structs.IsErrUnknownAllocation(err), "(%T) %v", err, err)
 		}
 
 		// Try request with an invalid token and expect failure
@@ -822,7 +822,7 @@ func TestHTTP_AllocGC_ACL(t *testing.T) {
 			setToken(req, token)
 			_, err := s.Server.ClientAllocRequest(respW, req)
 			require.NotNil(err)
-			require.Equal(err.Error(), structs.ErrPermissionDenied.Error())
+			require.True(structs.IsErrUnknownAllocation(err), "(%T) %v", err, err)
 		}
 
 		// Try request with a valid token
@@ -834,7 +834,7 @@ func TestHTTP_AllocGC_ACL(t *testing.T) {
 			setToken(req, token)
 			_, err := s.Server.ClientAllocRequest(respW, req)
 			require.NotNil(err)
-			require.True(structs.IsErrUnknownAllocation(err))
+			require.True(structs.IsErrUnknownAllocation(err), "(%T) %v", err, err)
 		}
 
 		// Try request with a management token

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -86,8 +86,10 @@ func (a *Alloc) GetAlloc(args *structs.AllocSpecificRequest,
 	}
 	defer metrics.MeasureSince([]string{"nomad", "alloc", "get_alloc"}, time.Now())
 
-	// Check namespace read-job permissions
-	if aclObj, err := a.srv.ResolveToken(args.AuthToken); err != nil {
+	// Check namespace read-job permissions before performing blocking query.
+	allowNsOp := acl.NamespaceValidator(acl.NamespaceCapabilityReadJob)
+	aclObj, err := a.srv.ResolveToken(args.AuthToken)
+	if err != nil {
 		// If ResolveToken had an unexpected error return that
 		if err != structs.ErrTokenNotFound {
 			return err
@@ -107,8 +109,6 @@ func (a *Alloc) GetAlloc(args *structs.AllocSpecificRequest,
 		if node == nil {
 			return structs.ErrTokenNotFound
 		}
-	} else if aclObj != nil && !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
-		return structs.ErrPermissionDenied
 	}
 
 	// Setup the blocking query
@@ -125,6 +125,11 @@ func (a *Alloc) GetAlloc(args *structs.AllocSpecificRequest,
 			// Setup the output
 			reply.Alloc = out
 			if out != nil {
+				// Re-check namespace in case it differs from request.
+				if !allowNsOp(aclObj, out.Namespace) {
+					return structs.NewErrUnknownAllocation(args.AllocID)
+				}
+
 				reply.Index = out.ModifyIndex
 			} else {
 				// Use the last index that affected the allocs table
@@ -214,25 +219,18 @@ func (a *Alloc) Stop(args *structs.AllocStopRequest, reply *structs.AllocStopRes
 	}
 	defer metrics.MeasureSince([]string{"nomad", "alloc", "stop"}, time.Now())
 
-	// Check that it is a management token.
-	if aclObj, err := a.srv.ResolveToken(args.AuthToken); err != nil {
-		return err
-	} else if aclObj != nil && !aclObj.AllowNsOp(args.Namespace, acl.NamespaceCapabilityAllocLifecycle) {
-		return structs.ErrPermissionDenied
-	}
-
-	if args.AllocID == "" {
-		return fmt.Errorf("must provide an alloc id")
-	}
-
-	ws := memdb.NewWatchSet()
-	alloc, err := a.srv.State().AllocByID(ws, args.AllocID)
+	alloc, err := getAlloc(a.srv.State(), args.AllocID)
 	if err != nil {
 		return err
 	}
 
-	if alloc == nil {
-		return fmt.Errorf(structs.ErrUnknownAllocationPrefix)
+	// Check for namespace alloc-lifecycle permissions.
+	allowNsOp := acl.NamespaceValidator(acl.NamespaceCapabilityAllocLifecycle)
+	aclObj, err := a.srv.ResolveToken(args.AuthToken)
+	if err != nil {
+		return err
+	} else if !allowNsOp(aclObj, alloc.Namespace) {
+		return structs.ErrPermissionDenied
 	}
 
 	now := time.Now().UTC().UnixNano()

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -276,54 +276,90 @@ func TestAllocEndpoint_GetAlloc_ACL(t *testing.T) {
 	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
 		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 
-	get := &structs.AllocSpecificRequest{
-		AllocID:      alloc.ID,
-		QueryOptions: structs.QueryOptions{Region: "global"},
+	getReq := func() *structs.AllocSpecificRequest {
+		return &structs.AllocSpecificRequest{
+			AllocID: alloc.ID,
+			QueryOptions: structs.QueryOptions{
+				Region: "global",
+			},
+		}
 	}
 
-	// Lookup the alloc without a token and expect failure
-	{
-		var resp structs.SingleAllocResponse
-		err := msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", get, &resp)
-		assert.Equal(structs.ErrPermissionDenied.Error(), err.Error())
+	cases := []struct {
+		Name string
+		F    func(t *testing.T)
+	}{
+		// Lookup the alloc without a token and expect failure
+		{
+			Name: "no-token",
+			F: func(t *testing.T) {
+				var resp structs.SingleAllocResponse
+				err := msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", getReq(), &resp)
+				require.True(t, structs.IsErrUnknownAllocation(err), "expected unknown alloc but found: %v", err)
+			},
+		},
+
+		// Try with a valid ACL token
+		{
+			Name: "valid-token",
+			F: func(t *testing.T) {
+				get := getReq()
+				get.AuthToken = validToken.SecretID
+				get.AllocID = alloc.ID
+				var resp structs.SingleAllocResponse
+				require.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", get, &resp), "RPC")
+				require.EqualValues(t, resp.Index, 1000, "resp.Index")
+				require.Equal(t, alloc, resp.Alloc, "Returned alloc not equal")
+			},
+		},
+
+		// Try with a valid Node.SecretID
+		{
+			Name: "valid-node-secret",
+			F: func(t *testing.T) {
+				node := mock.Node()
+				assert.Nil(state.UpsertNode(1005, node))
+				get := getReq()
+				get.AuthToken = node.SecretID
+				get.AllocID = alloc.ID
+				var resp structs.SingleAllocResponse
+				require.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", get, &resp), "RPC")
+				require.EqualValues(t, resp.Index, 1000, "resp.Index")
+				require.Equal(t, alloc, resp.Alloc, "Returned alloc not equal")
+			},
+		},
+
+		// Try with a invalid token
+		{
+			Name: "invalid-token",
+			F: func(t *testing.T) {
+				get := getReq()
+				get.AuthToken = invalidToken.SecretID
+				get.AllocID = alloc.ID
+				var resp structs.SingleAllocResponse
+				err := msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", get, &resp)
+				require.NotNil(t, err, "RPC")
+				require.True(t, structs.IsErrUnknownAllocation(err), "expected unknown alloc but found: %v", err)
+			},
+		},
+
+		// Try with a root token
+		{
+			Name: "root-token",
+			F: func(t *testing.T) {
+				get := getReq()
+				get.AuthToken = root.SecretID
+				get.AllocID = alloc.ID
+				var resp structs.SingleAllocResponse
+				require.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", get, &resp), "RPC")
+				require.EqualValues(t, resp.Index, 1000, "resp.Index")
+				require.Equal(t, alloc, resp.Alloc, "Returned alloc not equal")
+			},
+		},
 	}
 
-	// Try with a valid ACL token
-	{
-		get.AuthToken = validToken.SecretID
-		var resp structs.SingleAllocResponse
-		assert.Nil(msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", get, &resp), "RPC")
-		assert.EqualValues(resp.Index, 1000, "resp.Index")
-		assert.Equal(alloc, resp.Alloc, "Returned alloc not equal")
-	}
-
-	// Try with a valid Node.SecretID
-	{
-		node := mock.Node()
-		assert.Nil(state.UpsertNode(1005, node))
-		get.AuthToken = node.SecretID
-		var resp structs.SingleAllocResponse
-		assert.Nil(msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", get, &resp), "RPC")
-		assert.EqualValues(resp.Index, 1000, "resp.Index")
-		assert.Equal(alloc, resp.Alloc, "Returned alloc not equal")
-	}
-
-	// Try with a invalid token
-	{
-		get.AuthToken = invalidToken.SecretID
-		var resp structs.SingleAllocResponse
-		err := msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", get, &resp)
-		assert.NotNil(err, "RPC")
-		assert.Equal(err.Error(), structs.ErrPermissionDenied.Error())
-	}
-
-	// Try with a root token
-	{
-		get.AuthToken = root.SecretID
-		var resp structs.SingleAllocResponse
-		assert.Nil(msgpackrpc.CallWithCodec(codec, "Alloc.GetAlloc", get, &resp), "RPC")
-		assert.EqualValues(resp.Index, 1000, "resp.Index")
-		assert.Equal(alloc, resp.Alloc, "Returned alloc not equal")
+	for _, tc := range cases {
+		t.Run(tc.Name, tc.F)
 	}
 }
 

--- a/nomad/structs/errors.go
+++ b/nomad/structs/errors.go
@@ -16,6 +16,7 @@ const (
 	errUnknownMethod              = "Unknown rpc method"
 	errUnknownNomadVersion        = "Unable to determine Nomad version"
 	errNodeLacksRpc               = "Node does not support RPC; requires 0.8 or later"
+	errMissingAllocID             = "Missing allocation ID"
 
 	// Prefix based errors that are used to check if the error is of a given
 	// type. These errors should be created with the associated constructor.
@@ -36,6 +37,7 @@ var (
 	ErrUnknownMethod              = errors.New(errUnknownMethod)
 	ErrUnknownNomadVersion        = errors.New(errUnknownNomadVersion)
 	ErrNodeLacksRpc               = errors.New(errNodeLacksRpc)
+	ErrMissingAllocID             = errors.New(errMissingAllocID)
 )
 
 // IsErrNoLeader returns whether the error is due to there being no leader.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -207,6 +207,13 @@ type QueryOptions struct {
 	Region string
 
 	// Namespace is the target namespace for the query.
+	//
+	// Since handlers do not have a default value set they should access
+	// the Namespace via the RequestNamespace method.
+	//
+	// Requests accessing specific namespaced objects must check ACLs
+	// against the namespace of the object, not the namespace in the
+	// request.
 	Namespace string
 
 	// If set, wait until query exceeds given index. Must be provided
@@ -233,6 +240,11 @@ func (q QueryOptions) RequestRegion() string {
 	return q.Region
 }
 
+// RequestNamespace returns the request's namespace or the default namespace if
+// no explicit namespace was sent.
+//
+// Requests accessing specific namespaced objects must check ACLs against the
+// namespace of the object, not the namespace in the request.
 func (q QueryOptions) RequestNamespace() string {
 	if q.Namespace == "" {
 		return DefaultNamespace
@@ -254,6 +266,13 @@ type WriteRequest struct {
 	Region string
 
 	// Namespace is the target namespace for the write.
+	//
+	// Since RPC handlers do not have a default value set they should
+	// access the Namespace via the RequestNamespace method.
+	//
+	// Requests accessing specific namespaced objects must check ACLs
+	// against the namespace of the object, not the namespace in the
+	// request.
 	Namespace string
 
 	// AuthToken is secret portion of the ACL token used for the request
@@ -267,6 +286,11 @@ func (w WriteRequest) RequestRegion() string {
 	return w.Region
 }
 
+// RequestNamespace returns the request's namespace or the default namespace if
+// no explicit namespace was sent.
+//
+// Requests accessing specific namespaced objects must check ACLs against the
+// namespace of the object, not the namespace in the request.
 func (w WriteRequest) RequestNamespace() string {
 	if w.Namespace == "" {
 		return DefaultNamespace

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/kr/pretty"
 	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 )
@@ -125,13 +126,14 @@ func WaitForVotingMembers(t testing.T, rpc rpcFn, nPeers int) {
 	})
 }
 
+// RegisterJobWithToken registers a job and uses the job's Region and Namespace.
 func RegisterJobWithToken(t testing.T, rpc rpcFn, job *structs.Job, token string) {
 	WaitForResult(func() (bool, error) {
 		args := &structs.JobRegisterRequest{}
 		args.Job = job
-		args.WriteRequest.Region = "global"
+		args.WriteRequest.Region = job.Region
 		args.AuthToken = token
-		args.Namespace = structs.DefaultNamespace
+		args.Namespace = job.Namespace
 		var jobResp structs.JobRegisterResponse
 		err := rpc("Job.Register", args, &jobResp)
 		return err == nil, fmt.Errorf("Job.Register error: %v", err)
@@ -154,16 +156,18 @@ func WaitForRunningWithToken(t testing.T, rpc rpcFn, job *structs.Job, token str
 	WaitForResult(func() (bool, error) {
 		args := &structs.JobSpecificRequest{}
 		args.JobID = job.ID
-		args.QueryOptions.Region = "global"
+		args.QueryOptions.Region = job.Region
 		args.AuthToken = token
-		args.Namespace = structs.DefaultNamespace
+		args.Namespace = job.Namespace
 		err := rpc("Job.Allocations", args, &resp)
 		if err != nil {
 			return false, fmt.Errorf("Job.Allocations error: %v", err)
 		}
 
 		if len(resp.Allocations) == 0 {
-			return false, fmt.Errorf("0 allocations")
+			evals := structs.JobEvaluationsResponse{}
+			require.NoError(t, rpc("Job.Evaluations", args, &evals), "error looking up evals")
+			return false, fmt.Errorf("0 allocations; evals: %s", pretty.Sprint(evals.Evaluations))
 		}
 
 		for _, alloc := range resp.Allocations {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/6432 .

Fix a bug where a malicious user can access or manipulate an alloc in a
namespace they don't have access to.  The allocation endpoints perform
ACL checks against the request namespace, not the allocation namespace,
and performs the allocation lookup independently from namespaces.

Here, we check that the requested can access the alloc namespace
regardless of the declared request namespace.

Ideally, we'd enforce that the declared request namespace matches
the actual allocation namespace.  Unfortunately, we haven't documented
alloc endpoints as namespaced functions; we suspect starting to enforce
this will be very disruptive and inappropriate for a nomad point
release.  As such, we maintain current behavior that doesn't require
passing the proper namespace in request.  A future major release may
start enforcing checking declared namespace.