### PR TITLE
docs: improve documentation for `prefix` param on API endpoints

### DIFF
--- a/website/source/api/acl-policies.html.md
+++ b/website/source/api/acl-policies.html.md
@@ -28,12 +28,21 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------ |
 | `YES`            | `all`             | `management` for all policies.<br>Output when given a non-management token will be limited to the policies on the token itself |
 
+### Parameters
+
+- `prefix` `(string: "")` - Specifies a string to filter ACL policies based on
+  a name prefix. This is specified as a query string parameter.
 
 ### Sample Request
 
 ```text
 $ curl \
     https://localhost:4646/v1/acl/policies
+```
+
+```text
+$ curl \
+    https://localhost:4646/v1/acl/policies?prefix=prod
 ```
 
 ### Sample Response

--- a/website/source/api/acl-policies.html.md
+++ b/website/source/api/acl-policies.html.md
@@ -31,7 +31,9 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")` - Specifies a string to filter ACL policies based on
-  a name prefix. This is specified as a query string parameter.
+  a name prefix. Because the value is decoded to bytes, the prefix must have an
+  even number of hexadecimal characters (0-9a-f). This is specified as a query
+  string parameter.
 
 ### Sample Request
 

--- a/website/source/api/acl-tokens.html.md
+++ b/website/source/api/acl-tokens.html.md
@@ -70,12 +70,22 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------ |
 | `YES`            | `all`             | `management` |
 
+### Parameters
+
+- `prefix` `(string: "")` - Specifies a string to filter ACL tokens based on an
+  accessor ID prefix. This is specified as a query string parameter.
 
 ### Sample Request
 
 ```text
 $ curl \
     https://localhost:4646/v1/acl/tokens
+```
+
+```text
+$ curl \
+    --request POST \
+    https://localhost:4646/v1/acl/bootstrap?prefix=3da2ed52
 ```
 
 ### Sample Response

--- a/website/source/api/acl-tokens.html.md
+++ b/website/source/api/acl-tokens.html.md
@@ -73,7 +73,9 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")` - Specifies a string to filter ACL tokens based on an
-  accessor ID prefix. This is specified as a query string parameter.
+  accessor ID prefix. Because the value is decoded to bytes, the prefix must
+  have an even number of hexadecimal characters (0-9a-f). This is specified as
+  a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/allocations.html.md
+++ b/website/source/api/allocations.html.md
@@ -28,8 +28,10 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `prefix` `(string: "")`- Specifies a string to filter allocations on based on
-  an index prefix. This is specified as a query string parameter.
+- `prefix` `(string: "")`- Specifies a string to filter allocations based on an
+  ID prefix. Because the value is decoded to bytes, the prefix must have an
+  even number of hexadecimal characters (0-9a-f). This is specified as a query
+  string parameter.
 
 ### Sample Request
 

--- a/website/source/api/deployments.html.md
+++ b/website/source/api/deployments.html.md
@@ -29,7 +29,9 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")`- Specifies a string to filter deployments based on
-  an index prefix. This is specified as a query string parameter.
+  an ID prefix. Because the value is decoded to bytes, the prefix must have an
+  even number of hexadecimal characters (0-9a-f) .This is specified as a query
+  string parameter.
 
 ### Sample Request
 

--- a/website/source/api/evaluations.html.md
+++ b/website/source/api/evaluations.html.md
@@ -28,8 +28,10 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `prefix` `(string: "")`- Specifies a string to filter evaluations on based on
-  an index prefix. This is specified as a query string parameter.
+- `prefix` `(string: "")`- Specifies a string to filter evaluations based on an
+  ID prefix. Because the value is decoded to bytes, the prefix must have an
+  even number of hexadecimal characters (0-9a-f). This is specified as a query
+  string parameter.
 
 ### Sample Request
 
@@ -40,7 +42,7 @@ $ curl \
 
 ```text
 $ curl \
-    https://localhost:4646/v1/evaluations?prefix=25ba81c
+    https://localhost:4646/v1/evaluations?prefix=25ba81
 ```
 
 ### Sample Response

--- a/website/source/api/nodes.html.md
+++ b/website/source/api/nodes.html.md
@@ -28,8 +28,10 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `prefix` `(string: "")`- Specifies a string to filter nodes on based on an
-  index prefix. This is specified as a query string parameter.
+- `prefix` `(string: "")`- Specifies a string to filter nodes based on an ID
+  prefix. Because the value is decoded to bytes, the prefix must have an even
+  number of hexadecimal characters (0-9a-f). This is specified as a query
+  string parameter.
 
 ### Sample Request
 
@@ -40,7 +42,7 @@ $ curl \
 
 ```text
 $ curl \
-    http://localhost:4646/v1/nodes?prefix=prod
+    http://localhost:4646/v1/nodes?prefix=f7476465
 ```
 
 ### Sample Response


### PR DESCRIPTION
The documentation pages for listing [ACL Policies](https://www.nomadproject.io/api/acl-policies.html#list-policies) and [ACL Tokens](https://www.nomadproject.io/api/acl-tokens.html#list-tokens) are missing the `prefix` parameter used to filter results.

This parameter is supported by the API:
* https://github.com/hashicorp/nomad/blob/master/nomad/acl_endpoint.go#L165-L167
* https://github.com/hashicorp/nomad/blob/master/nomad/acl_endpoint.go#L656-L658