### PR TITLE
fix typo in HCL code

### DIFF
--- a/website/source/guides/operating-a-job/resource-utilization.html.md
+++ b/website/source/guides/operating-a-job/resource-utilization.html.md
@@ -67,7 +67,7 @@ plenty of memory headroom. We can use this information to alter our job's
 resources to better reflect is actually needs:
 
 ```hcl
-resource {
+resources {
   cpu    = 200
   memory = 10
 }


### PR DESCRIPTION
Code contains `resource` instead of `resources` (plural).