### PR TITLE
docs: drop raft from 0.10.0 upgrade guide

### DIFF
--- a/website/source/guides/upgrade/upgrade-specific.html.md
+++ b/website/source/guides/upgrade/upgrade-specific.html.md
@@ -30,20 +30,6 @@ You can regain this behavior and disable deployments by setting `max_parallel` t
 
 For more information, see [`update` stanza][update].
 
-### Raft 3
-Nomad 0.10 defaults to Raft 3 which includes [Autopilot](/guides/operations/autopilot.html), 
-operator-friendly automatic cluster management.
-Once all servers are upgraded and running with Raft protocol version 3, autopilot features are enabled.
-
-If existing servers are still on Raft protocol version 1,
-new servers will need [`raft_protocol`](/docs/configuration/server.html#raft_protocol)
-set to 2, in order to maintain backwards compatibility with
-the old servers during the upgrade.  After the servers have been migrated to
-version 0.10.0 with Raft protocol version 2, `raft_protocol` can be moved up to 3 and the servers restarted
-to match the default.
-
-For more information on upgrading Raft, see [Upgrading to Raft Protocol 3](/guides/upgrade/upgrade-specific.html#upgrading-to-raft-protocol-3).
-
 ## Nomad 0.9.5
 
 ### Template Rendering


### PR DESCRIPTION
Unfortunately we are not changing the default for 0.10.0 and the 0.8
upgrade docs are more detailed when it comes to manually updating your
version.