### PR TITLE
docs: remove beta flag from connect

### DIFF
--- a/website/source/guides/integrations/consul-connect/index.html.md
+++ b/website/source/guides/integrations/consul-connect/index.html.md
@@ -8,8 +8,7 @@ description: |-
 
 # Consul Connect
 
-~> **Note** This guide describes a new feature available in the [Nomad 0.10.0
-   Beta release][download] of Nomad.
+~> **Note** This guide describes a new feature available in [Nomad 0.10.0][download].
 
 [Consul Connect](https://www.consul.io/docs/connect/index.html) provides
 service-to-service connection authorization and encryption using mutual

--- a/website/source/layouts/guides.erb
+++ b/website/source/layouts/guides.erb
@@ -51,7 +51,7 @@
             <a href="/guides/integrations/consul-integration/index.html">Consul</a>
           </li>
           <li<%= sidebar_current("guides-integrations-consul-connect") %>>
-            <a href="/guides/integrations/consul-connect/index.html">Consul Connect <sup>Beta</sup></a>
+            <a href="/guides/integrations/consul-connect/index.html">Consul Connect</a>
           </li>
           <li<%= sidebar_current("guides-integrations-vault") %>>
             <a href="/guides/integrations/vault-integration/index.html">Vault</a>


### PR DESCRIPTION
Technically we're still in RC, but might as well prep the website for the final release now.