### PR TITLE
Use max-width to ensure the width rule is observed in Firefox

### DIFF
--- a/ui/app/styles/components/page-layout.scss
+++ b/ui/app/styles/components/page-layout.scss
@@ -37,6 +37,7 @@
       &.is-right {
         margin-left: $gutter-width;
         width: calc(100% - #{$gutter-width});
+        max-width: calc(100% - #{$gutter-width});
       }
 
       @media #{$mq-hidden-gutter} {


### PR DESCRIPTION
Fixes #6098 This time for Firefox.

![image](https://user-images.githubusercontent.com/174740/66592810-a59abe80-eb4a-11e9-888f-3d616c0f8039.png)
