### PR TITLE
docs: fix ACL `prefix` param documentation

### DIFF
--- a/website/source/api/acl-policies.html.md
+++ b/website/source/api/acl-policies.html.md
@@ -31,9 +31,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `prefix` `(string: "")` - Specifies a string to filter ACL policies based on
-  a name prefix. Because the value is decoded to bytes, the prefix must have an
-  even number of hexadecimal characters (0-9a-f). This is specified as a query
-  string parameter.
+  a name prefix. This is specified as a query string parameter.
 
 ### Sample Request
 

--- a/website/source/api/acl-tokens.html.md
+++ b/website/source/api/acl-tokens.html.md
@@ -87,7 +87,7 @@ $ curl \
 ```text
 $ curl \
     --request POST \
-    https://localhost:4646/v1/acl/bootstrap?prefix=3da2ed52
+    https://localhost:4646/v1/acl/tokens?prefix=3da2ed52
 ```
 
 ### Sample Response


### PR DESCRIPTION
Fixing copy-and-paste errors.