### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Nomad Security
+
+We understand that many users place a high level of trust in HashiCorp
+and the tools we build. We apply best practices and focus on security to
+make sure we can maintain the trust of the community.
+
+We deeply appreciate any effort to disclose vulnerabilities responsibly.
+
+## Reporting a Vulnerability
+If you would like to report a vulnerability, please see the
+[HashiCorp security page](https://www.hashicorp.com/security.html),
+which has the proper email to communicate with as well as our
+PGP key. ***Please do not create a GitHub issue for security
+concerns***.


### PR DESCRIPTION
This PR copies our security policy from nomadproject.io to GitHub in order to use their [security policy](https://help.github.com/en/articles/adding-a-security-policy-to-your-repository#about-security-policies) feature.