### PR TITLE
Bumping freebsd vagrant to 11.3-STABLE

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 #
 
 LINUX_BASE_BOX = "bento/ubuntu-16.04"
-FREEBSD_BASE_BOX = "freebsd/FreeBSD-11.2-STABLE"
+FREEBSD_BASE_BOX = "freebsd/FreeBSD-11.3-STABLE"
 
 LINUX_IP_ADDRESS = "10.199.0.200"
 


### PR DESCRIPTION
## Description

Update the Vagrant box version since Freebsd 11.2 will be EOL Oct 31st 2019, see the announcement here: https://www.mail-archive.com/freebsd-announce@freebsd.org/msg00919.html

The following patch is still required to build the freebsd binary: https://github.com/hashicorp/nomad/issues/5771 But once applied everything else seems to work as expected:
```
[vagrant@freebsd /opt/gopath/src/github.com/hashicorp/nomad]$ gmake pkg/freebsd_amd64/nomad
==> Building pkg/freebsd_amd64/nomad...
[vagrant@freebsd /opt/gopath/src/github.com/hashicorp/nomad]$ pkg/freebsd_amd64/nomad -v
Nomad v0.10.0-dev (8d97fc8b4a4af4bf83d179b9482d310004f5e2b1+CHANGES)
```

## Previous Behavior
* Freebsd Vagrant Box ran at 11.2-STABLE

## New Behavior
* Freebsd Vagrant Box runs at 11.3-STABLE

## Tests
* `vagrant up freebsd` successful spins up a vm with freebsd 11.3-STABLE and the dev environment:

```
[vagrant@freebsd /opt/gopath/src/github.com/hashicorp/nomad]$ uname -a
FreeBSD freebsd 11.3-STABLE FreeBSD 11.3-STABLE #0 r353406: Fri Oct 11 02:11:03 UTC 2019     root@releng2.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC  amd64
```

## Version Info
`vagrant`:

```
$ vagrant --version                                   
Vagrant 2.2.6
```

`virtualbox`:

```
$ vboxmanage --version                                            
6.0.12r133076
```