### PR TITLE
api: Return JobVersion for upsert operations on /v1/jobs

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1001,6 +1001,7 @@ type JobRegisterResponse struct {
 	EvalID          string
 	EvalCreateIndex uint64
 	JobModifyIndex  uint64
+	JobVersion      uint64
 
 	// Warnings contains any warnings about the given job. These may include
 	// deprecation warnings.

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -290,10 +290,22 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 		return err
 	}
 
+	// Lookup the job again to get it's version.
+	snap, err = j.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+	currentJob, err := snap.JobByID(ws, args.RequestNamespace(), args.Job.ID)
+	if err != nil {
+		return err
+	}
+
 	// Populate the reply with eval information
 	reply.EvalID = eval.ID
 	reply.EvalCreateIndex = evalIndex
 	reply.Index = evalIndex
+	reply.JobVersion = currentJob.Version
+
 	return nil
 }
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -47,6 +47,10 @@ func TestJobEndpoint_Register(t *testing.T) {
 		t.Fatalf("bad index: %d", resp.Index)
 	}
 
+	if resp.JobVersion != 0 {
+		t.Fatalf("bad job version: %d", resp.JobVersion)
+	}
+
 	// Check for the node in the FSM
 	state := s1.fsm.State()
 	ws := memdb.NewWatchSet()
@@ -142,6 +146,7 @@ func TestJobEndpoint_Register_Connect(t *testing.T) {
 	var resp structs.JobRegisterResponse
 	require.NoError(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
 	require.NotZero(resp.Index)
+	require.GreaterOrEqual(resp.JobVersion, uint64(0))
 
 	// Check for the node in the FSM
 	state := s1.fsm.State()
@@ -163,6 +168,8 @@ func TestJobEndpoint_Register_Connect(t *testing.T) {
 	req.Job = out
 	require.NoError(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
 	require.NotZero(resp.Index)
+	require.GreaterOrEqual(resp.JobVersion, uint64(0))
+
 	// Check for the new node in the FSM
 	state = s1.fsm.State()
 	ws = memdb.NewWatchSet()
@@ -227,6 +234,7 @@ func TestJobEndpoint_Register_ConnectWithSidecarTask(t *testing.T) {
 	var resp structs.JobRegisterResponse
 	require.NoError(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
 	require.NotZero(resp.Index)
+	require.GreaterOrEqual(resp.JobVersion, uint64(0))
 
 	// Check for the node in the FSM
 	state := s1.fsm.State()
@@ -258,6 +266,8 @@ func TestJobEndpoint_Register_ConnectWithSidecarTask(t *testing.T) {
 	req.Job = out
 	require.NoError(msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp))
 	require.NotZero(resp.Index)
+	require.GreaterOrEqual(resp.JobVersion, uint64(0))
+
 	// Check for the new node in the FSM
 	state = s1.fsm.State()
 	ws = memdb.NewWatchSet()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1007,6 +1007,7 @@ type JobRegisterResponse struct {
 	EvalID          string
 	EvalCreateIndex uint64
 	JobModifyIndex  uint64
+	JobVersion      uint64
 
 	// Warnings contains any warnings about the given job. These may include
 	// deprecation warnings.

--- a/website/source/api/jobs.html.md
+++ b/website/source/api/jobs.html.md
@@ -230,6 +230,7 @@ $ curl \
   "Warnings": "",
   "Index": 0,
   "LastContact": 0,
+  "JobVersion": 0,
   "KnownLeader": false
 }
 ```


### PR DESCRIPTION
This change introduces a `JobVersion` field in the response for `PUT` or `POST` calls to the `/v1/jobs` endpoint.

When a new job is added, it returns the version as `0`. On subsequent updates for the same job, it returns the updated versions.

Reference: #3301.