### PR TITLE
Use golang 1.12.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Who Uses Nomad
 Contributing to Nomad
 --------------------
 
-If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.12.10+ is *required*).
+If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.12.11+ is *required*).
 
 See the [`contributing`](contributing/) directory for more developer documentation.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,10 +23,10 @@ install:
       cd %APPVEYOR_BUILD_FOLDER%
       rmdir /Q/S C:\go
 
-  # install go 1.12.10 to match version used for cutting a release
+  # install go 1.12.11 to match version used for cutting a release
   - cmd: |
       mkdir c:\go
-      appveyor DownloadFile "https://dl.google.com/go/go1.12.10.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
+      appveyor DownloadFile "https://dl.google.com/go/go1.12.11.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
       
   - ps: Expand-Archive $Env:TEMP\go.zip -DestinationPath C:\
 

--- a/scripts/release/mac-remote-build
+++ b/scripts/release/mac-remote-build
@@ -56,7 +56,7 @@ REPO_PATH="${TMP_WORKSPACE}/gopath/src/github.com/hashicorp/nomad"
 mkdir -p "${TMP_WORKSPACE}/tmp"
 
 install_go() {
-  local go_version="1.12.10"
+  local go_version="1.12.11"
   local download=
 
   download="https://storage.googleapis.com/golang/go${go_version}.darwin-amd64.tar.gz"

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function install_go() {
-	local go_version=1.12.10
+	local go_version=1.12.11
 	local download=
 
 	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"


### PR DESCRIPTION
To pick up fix for CVE-2019-17596 .

TODO:
* [ ] Update when golang 1.12.11 image is released.