### PR TITLE
connect: upgrade to envoy 1.11.2 and add sha

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -95,7 +95,8 @@ const (
 
 	// defaultConnectSidecarImage is the image set in the node meta by default
 	// to be used by Consul Connect sidecar tasks
-	defaultConnectSidecarImage = "envoyproxy/envoy:v1.11.1"
+	// Update sidecar_task.html when updating this.
+	defaultConnectSidecarImage = "envoyproxy/envoy:v1.11.2@sha256:a7769160c9c1a55bb8d07a3b71ce5d64f72b1f665f10d81aa1581bc3cf850d09"
 
 	// defaultConnectLogLevel is the log level set in the node meta by default
 	// to be used by Consul Connect sidecar tasks

--- a/website/source/docs/job-specification/sidecar_task.html.md
+++ b/website/source/docs/job-specification/sidecar_task.html.md
@@ -96,8 +96,9 @@ The default sidecar task is equivalent to:
 The `meta.connect.sidecar_image` and `meta.connect.log_level` are [*client*
 configurable][nodemeta] variables with the following defaults:
 
-- `sidecar_image` - `"envoyproxy/envoy:v1.11.1"` - The official upstream Envoy Docker image.
-- `sidecar_log_level` - `"info"` - Debug is useful for debugging Connect related issues.
+- `sidecar_image` - `"envoyproxy/envoy:v1.11.2@sha256:a7769160c9c1a55bb8d07a3b71ce5d64f72b1f665f10d81aa1581bc3cf850d09"` - The official upstream Envoy Docker image.
+- `sidecar_log_level` - `"info"` - Envoy sidecar log level. "`debug`" is useful
+  for debugging Connect related issues.
 
 ## `sidecar_task` Parameters
 - `name` `(string: "connect-proxy-<service>")` - Name of the task. Defaults to


### PR DESCRIPTION
Append the Docker image sha to the Envoy image to ensure users default
to using the version that Nomad was tested against.

Didn't notice any functional differences when testing manually locally.

Will require cherry picking to `release-0100` post-merge.