### PR TITLE
Use golang 1.12.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ executors:
   go:
     working_directory: /go/src/github.com/hashicorp/nomad
     docker:
-      - image: circleci/golang:1.12.10
+      - image: golang:1.12.12
   go-machine:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     machine:
@@ -271,7 +271,7 @@ commands:
     parameters:
       version:
         type: string
-        default: "1.12.10"
+        default: "1.12.12"
     steps:
       - run:
           name: install golang << parameters.version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,8 +153,20 @@ jobs:
       GOPATH: /go
     steps:
       - checkout
-      - run: make deps
-      - run: make e2e-test
+      - run: apt-get update; apt-get install -y sudo unzip
+      # e2e tests require privileged mount/umount permissions when running as root
+      # TODO: switch to using machine executor and run as root to test e2e path
+      - run:
+          name: prepare non-root user
+          command: |
+            groupadd --gid 3434 circleci
+            useradd --uid 3434 --gid circleci --shell /bin/bash --create-home circleci
+            echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci
+            echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
+            chown -R circleci:circleci /go
+
+      - run: sudo -E -H -u circleci PATH=${PATH} make deps
+      - run: sudo -E -H -u circleci PATH=${PATH} make e2e-test
 
   test-website:
     executor: go-machine-recent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,8 +109,8 @@ jobs:
       GOPATH: /go
     steps:
       - checkout
+      - run: apt-get update; apt-get install -y shellcheck sudo unzip
       - install-protoc
-      - run: sudo apt-get update && sudo apt-get install shellcheck
       - run: make deps lint-deps
       - run: make check
       - run: make checkscripts
@@ -135,6 +135,7 @@ jobs:
       GOTESTARCH: "<< parameters.goarch >>"
     steps:
       - checkout
+      - run: apt-get update; apt-get install -y shellcheck sudo unzip
       - run: make deps
       - install-protoc
       - install-consul

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Who Uses Nomad
 Contributing to Nomad
 --------------------
 
-If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.12.10+ is *required*).
+If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.12.12+ is *required*).
 
 See the [`contributing`](contributing/) directory for more developer documentation.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,10 +23,10 @@ install:
       cd %APPVEYOR_BUILD_FOLDER%
       rmdir /Q/S C:\go
 
-  # install go 1.12.10 to match version used for cutting a release
+  # install go 1.12.12 to match version used for cutting a release
   - cmd: |
       mkdir c:\go
-      appveyor DownloadFile "https://dl.google.com/go/go1.12.10.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
+      appveyor DownloadFile "https://dl.google.com/go/go1.12.12.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
       
   - ps: Expand-Archive $Env:TEMP\go.zip -DestinationPath C:\
 

--- a/scripts/release/mac-remote-build
+++ b/scripts/release/mac-remote-build
@@ -56,7 +56,7 @@ REPO_PATH="${TMP_WORKSPACE}/gopath/src/github.com/hashicorp/nomad"
 mkdir -p "${TMP_WORKSPACE}/tmp"
 
 install_go() {
-  local go_version="1.12.10"
+  local go_version="1.12.12"
   local download=
 
   download="https://storage.googleapis.com/golang/go${go_version}.darwin-amd64.tar.gz"

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function install_go() {
-	local go_version=1.12.10
+	local go_version=1.12.12
 	local download=
 
 	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"


### PR DESCRIPTION
Also, use base official golang image in CircleCI, as it gets refreshed
more quickly compared to circleci/golang, and we don't benefit from
circleci image customizations much.
