### PR TITLE
quota: parse network stanza in quotas

### DIFF
--- a/command/quota_apply.go
+++ b/command/quota_apply.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/jobspec"
 	"github.com/mitchellh/mapstructure"
 	"github.com/posener/complete"
 )
@@ -261,6 +262,7 @@ func parseQuotaResource(result *api.Resources, list *ast.ObjectList) error {
 	valid := []string{
 		"cpu",
 		"memory",
+		"network",
 	}
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 		return multierror.Prefix(err, "resources ->")
@@ -273,6 +275,22 @@ func parseQuotaResource(result *api.Resources, list *ast.ObjectList) error {
 
 	if err := mapstructure.WeakDecode(m, result); err != nil {
 		return err
+	}
+
+	// Find the network ObjectList, parse it
+	nw := listVal.Filter("network")
+	if len(nw.Items) < 1 {
+		return nil
+	}
+	rl, err := jobspec.ParseNetwork(nw)
+	if err != nil {
+		return multierror.Prefix(err, "resources ->")
+	}
+	if rl != nil {
+		if rl.Mode != "" || rl.HasPorts() {
+			return fmt.Errorf("resources -> network only allows mbits")
+		}
+		result.Networks = []*api.NetworkResource{rl}
 	}
 
 	return nil

--- a/command/quota_apply.go
+++ b/command/quota_apply.go
@@ -279,18 +279,17 @@ func parseQuotaResource(result *api.Resources, list *ast.ObjectList) error {
 
 	// Find the network ObjectList, parse it
 	nw := listVal.Filter("network")
-	if len(nw.Items) < 1 {
-		return nil
-	}
-	rl, err := jobspec.ParseNetwork(nw)
-	if err != nil {
-		return multierror.Prefix(err, "resources ->")
-	}
-	if rl != nil {
-		if rl.Mode != "" || rl.HasPorts() {
-			return fmt.Errorf("resources -> network only allows mbits")
+	if len(nw.Items) > 0 {
+		rl, err := jobspec.ParseNetwork(nw)
+		if err != nil {
+			return multierror.Prefix(err, "resources ->")
 		}
-		result.Networks = []*api.NetworkResource{rl}
+		if rl != nil {
+			if rl.Mode != "" || rl.HasPorts() {
+				return fmt.Errorf("resources -> network only allows mbits")
+			}
+			result.Networks = []*api.NetworkResource{rl}
+		}
 	}
 
 	return nil

--- a/command/quota_apply_test.go
+++ b/command/quota_apply_test.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestQuotaApplyCommand_Implements(t *testing.T) {
@@ -96,4 +98,50 @@ func TestQuotaApplyCommand_Good_JSON(t *testing.T) {
 	quotas, _, err := client.Quotas().List(nil)
 	assert.Nil(t, err)
 	assert.Len(t, quotas, 1)
+}
+
+func TestQuotaApplyNetwork(t *testing.T) {
+	t.Parallel()
+	// srv, _, _ := testServer(t, true, nil)
+	// defer srv.Shutdown()
+
+	type example struct {
+		q *api.QuotaSpec
+		e string
+	}
+
+	intPtr := func(x int) *int {
+		return &x
+	}
+
+	cases := map[string]example{
+		`limit {region = "global", region_limit {network {mbits = 20}}}`: {
+			&api.QuotaSpec{
+				Limits: []*api.QuotaLimit{{
+					Region: "global",
+					RegionLimit: &api.Resources{
+						Networks: []*api.NetworkResource{{
+							MBits: intPtr(20),
+						}},
+					},
+				}},
+			},
+			"",
+		},
+		`limit {region = "global", region_limit {network { mbits = 20, device = "eth0"}}}`: {
+			nil,
+			"1 error(s) occurred:\n\n* limit -> region_limit -> resources -> network -> invalid key: device",
+		},
+	}
+
+	for hcl, expected := range cases {
+		q, e := parseQuotaSpec([]byte(hcl))
+		s := ""
+		if e != nil {
+			s = e.Error()
+		}
+
+		require.Equal(t, expected.q, q)
+		require.Equal(t, expected.e, s)
+	}
 }

--- a/command/quota_apply_test.go
+++ b/command/quota_apply_test.go
@@ -103,15 +103,13 @@ func TestQuotaApplyCommand_Good_JSON(t *testing.T) {
 func TestQuotaApplyNetwork(t *testing.T) {
 	t.Parallel()
 
-	type example struct {
+	mbits := 20
+
+	cases := []struct {
 		hcl string
 		q   *api.QuotaSpec
 		e   string
-	}
-
-	mbits := 20
-
-	cases := []example{{
+	}{{
 		hcl: `limit {region = "global", region_limit {network {mbits = 20}}}`,
 		q: &api.QuotaSpec{
 			Limits: []*api.QuotaLimit{{

--- a/command/quota_apply_test.go
+++ b/command/quota_apply_test.go
@@ -1,5 +1,3 @@
-// +build ent
-
 package command
 
 import (
@@ -108,7 +106,7 @@ func TestQuotaApplyNetwork(t *testing.T) {
 	cases := []struct {
 		hcl string
 		q   *api.QuotaSpec
-		e   string
+		err string
 	}{{
 		hcl: `limit {region = "global", region_limit {network {mbits = 20}}}`,
 		q: &api.QuotaSpec{
@@ -121,19 +119,19 @@ func TestQuotaApplyNetwork(t *testing.T) {
 				},
 			}},
 		},
-		e: "",
+		err: "",
 	}, {
 		hcl: `limit {region = "global", region_limit {network { mbits = 20, device = "eth0"}}}`,
 		q:   nil,
-		e:   "1 error(s) occurred:\n\n* limit -> region_limit -> resources -> network -> invalid key: device",
+		err: "1 error(s) occurred:\n\n* limit -> region_limit -> resources -> network -> invalid key: device",
 	}}
 
 	for _, c := range cases {
 		t.Run(c.hcl, func(t *testing.T) {
-			q, e := parseQuotaSpec([]byte(c.hcl))
+			q, err := parseQuotaSpec([]byte(c.hcl))
 			require.Equal(t, c.q, q)
-			if c.e != "" {
-				require.EqualError(t, e, c.e)
+			if c.err != "" {
+				require.EqualError(t, err, c.err)
 			}
 		})
 	}

--- a/command/quota_apply_test.go
+++ b/command/quota_apply_test.go
@@ -1,3 +1,5 @@
+// +build ent
+
 package command
 
 import (

--- a/jobspec/parse_group.go
+++ b/jobspec/parse_group.go
@@ -114,7 +114,7 @@ func parseGroups(result *api.Job, list *ast.ObjectList) error {
 
 		// Parse network
 		if o := listVal.Filter("network"); len(o.Items) > 0 {
-			networks, err := parseNetwork(o)
+			networks, err := ParseNetwork(o)
 			if err != nil {
 				return err
 			}

--- a/jobspec/parse_network.go
+++ b/jobspec/parse_network.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func parseNetwork(o *ast.ObjectList) (*api.NetworkResource, error) {
+func ParseNetwork(o *ast.ObjectList) (*api.NetworkResource, error) {
 	if len(o.Items) > 1 {
 		return nil, fmt.Errorf("only one 'network' resource allowed")
 	}

--- a/jobspec/parse_network.go
+++ b/jobspec/parse_network.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// ParseNetwork parses a collection containing exactly one NetworkResource
 func ParseNetwork(o *ast.ObjectList) (*api.NetworkResource, error) {
 	if len(o.Items) > 1 {
 		return nil, fmt.Errorf("only one 'network' resource allowed")

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -440,7 +440,7 @@ func parseResources(result *api.Resources, list *ast.ObjectList) error {
 
 	// Parse the network resources
 	if o := listVal.Filter("network"); len(o.Items) > 0 {
-		r, err := parseNetwork(o)
+		r, err := ParseNetwork(o)
 		if err != nil {
 			return fmt.Errorf("resource, %v", err)
 		}


### PR DESCRIPTION
This exports `parseNetwork` so that it can be used for parsing quota network stanzas. Parsing this stanza supports the enterprise feature of enforcing it.