### PR TITLE
driver/docker: ensure that defaults are populated for dangling containers config

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -216,11 +216,20 @@ var (
 			),
 			"dangling_containers": hclspec.NewDefault(
 				hclspec.NewBlock("dangling_containers", false, danglingContainersBlock),
-				hclspec.NewLiteral("{}"),
+				hclspec.NewLiteral(`{
+					enabled = true
+					period = "5m"
+					creation_grace = "5m"
+				}`),
 			),
 		})), hclspec.NewLiteral(`{
 			image = true
 			container = true
+			dangling_containers = {
+				enabled = true
+				period = "5m"
+				creation_grace = "5m"
+			}
 		}`)),
 
 		// docker volume options


### PR DESCRIPTION
Looks like we may need to pass default literal at each layer to be able,
so defaults are set properly.