### PR TITLE
client: don't retry fingerprinting on shutdown

### DIFF
--- a/client/pluginmanager/drivermanager/instance.go
+++ b/client/pluginmanager/drivermanager/instance.go
@@ -307,6 +307,12 @@ func (i *instanceManager) fingerprint() {
 				continue
 			}
 
+			// avoid fingerprinting again if ctx and fpChan both close
+			if i.ctx.Err() != nil {
+				cancel()
+				return
+			}
+
 			// if the channel is closed attempt to open a new one
 			newFpChan, newCancel, err := i.dispenseFingerprintCh()
 			if err != nil {


### PR DESCRIPTION
At shutdown, driver manager context expires and the fingerprinting
channel closes.  Thus it is undeterministic which clause of The select
statement gets executed, and we may keep retrying until the
`i.ctx.Done()` block is executed.

Here, we check always check ctx expiration before retrying again.