### PR TITLE
Remove inverse block for list-pagination

### DIFF
--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -35,38 +35,40 @@
         </div>
       </div>
     </div>
-    {{#list-pagination
-      source=sortedNodes
-      size=pageSize
-      page=currentPage as |p|}}
-      {{#list-table
-        source=p.list
-        sortProperty=sortProperty
-        sortDescending=sortDescending
-        class="with-foot" as |t|}}
-        {{#t.head}}
-          <th class="is-narrow"></th>
-          {{#t.sort-by prop="id"}}ID{{/t.sort-by}}
-          {{#t.sort-by class="is-200px is-truncatable" prop="name"}}Name{{/t.sort-by}}
-          {{#t.sort-by prop="status"}}State{{/t.sort-by}}
-          <th>Address</th>
-          {{#t.sort-by prop="datacenter"}}Datacenter{{/t.sort-by}}
-          <th># Allocs</th>
-        {{/t.head}}
-        {{#t.body as |row|}}
-          {{client-node-row data-test-client-node-row node=row.model onClick=(action "gotoNode" row.model)}}
-        {{/t.body}}
-      {{/list-table}}
-      <div class="table-foot">
-        <nav class="pagination" data-test-pagination>
-          <div class="pagination-numbers">
-            {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedNodes.length}}
-          </div>
-          {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
-          {{#p.next class="pagination-next"}} &gt; {{/p.next}}
-          <ul class="pagination-list"></ul>
-        </nav>
-      </div>
+    {{#if sortedNodes}}
+      {{#list-pagination
+        source=sortedNodes
+        size=pageSize
+        page=currentPage as |p|}}
+        {{#list-table
+          source=p.list
+          sortProperty=sortProperty
+          sortDescending=sortDescending
+          class="with-foot" as |t|}}
+          {{#t.head}}
+            <th class="is-narrow"></th>
+            {{#t.sort-by prop="id"}}ID{{/t.sort-by}}
+            {{#t.sort-by class="is-200px is-truncatable" prop="name"}}Name{{/t.sort-by}}
+            {{#t.sort-by prop="status"}}State{{/t.sort-by}}
+            <th>Address</th>
+            {{#t.sort-by prop="datacenter"}}Datacenter{{/t.sort-by}}
+            <th># Allocs</th>
+          {{/t.head}}
+          {{#t.body as |row|}}
+            {{client-node-row data-test-client-node-row node=row.model onClick=(action "gotoNode" row.model)}}
+          {{/t.body}}
+        {{/list-table}}
+        <div class="table-foot">
+          <nav class="pagination" data-test-pagination>
+            <div class="pagination-numbers">
+              {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedNodes.length}}
+            </div>
+            {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
+            {{#p.next class="pagination-next"}} &gt; {{/p.next}}
+            <ul class="pagination-list"></ul>
+          </nav>
+        </div>
+      {{/list-pagination}}
     {{else}}
       <div class="empty-message" data-test-empty-clients-list>
         {{#if (eq nodes.length 0)}}
@@ -84,6 +86,6 @@
           <p class="empty-message-body">No clients match the term <strong>{{searchTerm}}</strong></p>
         {{/if}}
       </div>
-    {{/list-pagination}}
+    {{/if}}
   {{/if}}
 </section>

--- a/ui/app/templates/components/job-page/parts/children.hbs
+++ b/ui/app/templates/components/job-page/parts/children.hbs
@@ -2,41 +2,43 @@
   Job Launches
 </div>
 <div class="boxed-section-body {{if sortedChildren.length "is-full-bleed"}}">
-  {{#list-pagination
-    source=sortedChildren
-    size=pageSize
-    page=currentPage as |p|}}
-    {{#list-table
-      source=p.list
-      sortProperty=sortProperty
-      sortDescending=sortDescending
-      class="with-foot" as |t|}}
-      {{#t.head}}
-        {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
-        {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
-        {{#t.sort-by prop="type"}}Type{{/t.sort-by}}
-        {{#t.sort-by prop="priority"}}Priority{{/t.sort-by}}
-        <th>Groups</th>
-        <th class="is-3">Summary</th>
-      {{/t.head}}
-      {{#t.body key="model.id" as |row|}}
-        {{job-row data-test-job-row job=row.model onClick=(action gotoJob row.model)}}
-      {{/t.body}}
-    {{/list-table}}
-    <div class="table-foot">
-      <nav class="pagination">
-        <div class="pagination-numbers">
-          {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedChildren.length}}
-        </div>
-        {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
-        {{#p.next class="pagination-next"}} &gt; {{/p.next}}
-        <ul class="pagination-list"></ul>
-      </nav>
-    </div>
+  {{#if sortedChildren}}
+    {{#list-pagination
+      source=sortedChildren
+      size=pageSize
+      page=currentPage as |p|}}
+      {{#list-table
+        source=p.list
+        sortProperty=sortProperty
+        sortDescending=sortDescending
+        class="with-foot" as |t|}}
+        {{#t.head}}
+          {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
+          {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
+          {{#t.sort-by prop="type"}}Type{{/t.sort-by}}
+          {{#t.sort-by prop="priority"}}Priority{{/t.sort-by}}
+          <th>Groups</th>
+          <th class="is-3">Summary</th>
+        {{/t.head}}
+        {{#t.body key="model.id" as |row|}}
+          {{job-row data-test-job-row job=row.model onClick=(action gotoJob row.model)}}
+        {{/t.body}}
+      {{/list-table}}
+      <div class="table-foot">
+        <nav class="pagination">
+          <div class="pagination-numbers">
+            {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedChildren.length}}
+          </div>
+          {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
+          {{#p.next class="pagination-next"}} &gt; {{/p.next}}
+          <ul class="pagination-list"></ul>
+        </nav>
+      </div>
+    {{/list-pagination}}
   {{else}}
     <div class="empty-message">
       <h3 class="empty-message-headline">No Job Launches</h3>
       <p class="empty-message-body">No remaining living job launches.</p>
     </div>
-  {{/list-pagination}}
+  {{/if}}
 </div>

--- a/ui/app/templates/components/list-pagination.hbs
+++ b/ui/app/templates/components/list-pagination.hbs
@@ -10,7 +10,5 @@
     startsAt=startsAt
     endsAt=endsAt
     list=list
-)}}
-{{else}}
-  {{yield to="inverse"}}
+  )}}
 {{/if}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -52,40 +52,42 @@
         </div>
       {{/if}}
     </div>
-    {{#list-pagination
-      source=sortedJobs
-      size=pageSize
-      page=currentPage as |p|}}
-      {{#list-table
-        source=p.list
-        sortProperty=sortProperty
-        sortDescending=sortDescending
-        class="with-foot" as |t|}}
-        {{#t.head}}
-          {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
-          {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
-          {{#t.sort-by prop="type"}}Type{{/t.sort-by}}
-          {{#t.sort-by prop="priority"}}Priority{{/t.sort-by}}
-          <th>Groups</th>
-          <th class="is-3">Summary</th>
-        {{/t.head}}
-        {{#t.body key="model.id" as |row|}}
-          {{job-row data-test-job-row=row.model.plainId job=row.model onClick=(action "gotoJob" row.model)}}
-        {{/t.body}}
-      {{/list-table}}
-      <div class="table-foot">
-        <nav class="pagination">
-          <div class="pagination-numbers">
-            {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedJobs.length}}
-            {{#if searchTerm}}
-              <em>({{dec sortedJobs.length filteredJobs.length}} hidden by search term)</em>
-            {{/if}}
-          </div>
-          {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
-          {{#p.next class="pagination-next"}} &gt; {{/p.next}}
-          <ul class="pagination-list"></ul>
-        </nav>
-      </div>
+    {{#if sortedJobs}}
+      {{#list-pagination
+        source=sortedJobs
+        size=pageSize
+        page=currentPage as |p|}}
+        {{#list-table
+          source=p.list
+          sortProperty=sortProperty
+          sortDescending=sortDescending
+          class="with-foot" as |t|}}
+          {{#t.head}}
+            {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
+            {{#t.sort-by prop="status"}}Status{{/t.sort-by}}
+            {{#t.sort-by prop="type"}}Type{{/t.sort-by}}
+            {{#t.sort-by prop="priority"}}Priority{{/t.sort-by}}
+            <th>Groups</th>
+            <th class="is-3">Summary</th>
+          {{/t.head}}
+          {{#t.body key="model.id" as |row|}}
+            {{job-row data-test-job-row=row.model.plainId job=row.model onClick=(action "gotoJob" row.model)}}
+          {{/t.body}}
+        {{/list-table}}
+        <div class="table-foot">
+          <nav class="pagination">
+            <div class="pagination-numbers">
+              {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedJobs.length}}
+              {{#if searchTerm}}
+                <em>({{dec sortedJobs.length filteredJobs.length}} hidden by search term)</em>
+              {{/if}}
+            </div>
+            {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
+            {{#p.next class="pagination-next"}} &gt; {{/p.next}}
+            <ul class="pagination-list"></ul>
+          </nav>
+        </div>
+      {{/list-pagination}}
     {{else}}
       <div data-test-empty-jobs-list class="empty-message">
         {{#if (eq visibleJobs.length 0)}}
@@ -103,6 +105,6 @@
           <p class="empty-message-body">No jobs match the term <strong>{{searchTerm}}</strong></p>
         {{/if}}
       </div>
-    {{/list-pagination}}
+    {{/if}}
   {{/if}}
 </section>

--- a/ui/app/templates/jobs/job/allocations.hbs
+++ b/ui/app/templates/jobs/job/allocations.hbs
@@ -11,46 +11,48 @@
           placeholder="Search allocations..."}}
       </div>
     </div>
-    {{#list-pagination
-      source=sortedAllocations
-      size=pageSize
-      page=currentPage
-      class="allocations" as |p|}}
-      {{#list-table
-        source=p.list
-        sortProperty=sortProperty
-        sortDescending=sortDescending
-        class="with-foot" as |t|}}
-        {{#t.head}}
-          <th class="is-narrow"></th>
-          {{#t.sort-by prop="shortId"}}ID{{/t.sort-by}}
-          {{#t.sort-by prop="taskGroupName"}}Task Group{{/t.sort-by}}
-          {{#t.sort-by prop="createIndex" title="Create Index"}}Created{{/t.sort-by}}
-          {{#t.sort-by prop="modifyIndex" title="Modify Index"}}Modified{{/t.sort-by}}
-          {{#t.sort-by prop="statusIndex"}}Status{{/t.sort-by}}
-          {{#t.sort-by prop="jobVersion"}}Version{{/t.sort-by}}
-          {{#t.sort-by prop="node.shortId"}}Client{{/t.sort-by}}
-          <th>CPU</th>
-          <th>Memory</th>
-        {{/t.head}}
-        {{#t.body as |row|}}
-          {{allocation-row
-            data-test-allocation=row.model.id
-            allocation=row.model
-            context="job"
-            onClick=(action "gotoAllocation" row.model)}}
-        {{/t.body}}
-      {{/list-table}}
-      <div class="table-foot">
-        <nav class="pagination">
-          <div class="pagination-numbers">
-            {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedAllocations.length}}
-          </div>
-          {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
-          {{#p.next class="pagination-next"}} &gt; {{/p.next}}
-          <ul class="pagination-list"></ul>
-        </nav>
-      </div>
+    {{#if sortedAllocations}}
+      {{#list-pagination
+        source=sortedAllocations
+        size=pageSize
+        page=currentPage
+        class="allocations" as |p|}}
+        {{#list-table
+          source=p.list
+          sortProperty=sortProperty
+          sortDescending=sortDescending
+          class="with-foot" as |t|}}
+          {{#t.head}}
+            <th class="is-narrow"></th>
+            {{#t.sort-by prop="shortId"}}ID{{/t.sort-by}}
+            {{#t.sort-by prop="taskGroupName"}}Task Group{{/t.sort-by}}
+            {{#t.sort-by prop="createIndex" title="Create Index"}}Created{{/t.sort-by}}
+            {{#t.sort-by prop="modifyIndex" title="Modify Index"}}Modified{{/t.sort-by}}
+            {{#t.sort-by prop="statusIndex"}}Status{{/t.sort-by}}
+            {{#t.sort-by prop="jobVersion"}}Version{{/t.sort-by}}
+            {{#t.sort-by prop="node.shortId"}}Client{{/t.sort-by}}
+            <th>CPU</th>
+            <th>Memory</th>
+          {{/t.head}}
+          {{#t.body as |row|}}
+            {{allocation-row
+              data-test-allocation=row.model.id
+              allocation=row.model
+              context="job"
+              onClick=(action "gotoAllocation" row.model)}}
+          {{/t.body}}
+        {{/list-table}}
+        <div class="table-foot">
+          <nav class="pagination">
+            <div class="pagination-numbers">
+              {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedAllocations.length}}
+            </div>
+            {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
+            {{#p.next class="pagination-next"}} &gt; {{/p.next}}
+            <ul class="pagination-list"></ul>
+          </nav>
+        </div>
+      {{/list-pagination}}
     {{else}}
       <div class="boxed-section-body">
         <div class="empty-message" data-test-empty-allocations-list>
@@ -58,7 +60,7 @@
           <p class="empty-message-body">No allocations match the term <strong>{{searchTerm}}</strong></p>
         </div>
       </div>
-    {{/list-pagination}}
+    {{/if}}
   {{else}}
     <div class="boxed-section-body">
       <div class="empty-message" data-test-empty-allocations-list>

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -52,41 +52,43 @@
         inputClass="is-compact"}}
     </div>
     <div class="boxed-section-body is-full-bleed">
-      {{#list-pagination
-        source=sortedAllocations
-        size=pageSize
-        page=currentPage
-        class="allocations" as |p|}}
-        {{#list-table
-          source=p.list
-          sortProperty=sortProperty
-          sortDescending=sortDescending
-          class="with-foot" as |t|}}
-          {{#t.head}}
-            <th class="is-narrow"></th>
-            {{#t.sort-by prop="shortId"}}ID{{/t.sort-by}}
-            {{#t.sort-by prop="createIndex" title="Create Index"}}Created{{/t.sort-by}}
-            {{#t.sort-by prop="modifyIndex" title="Modify Index"}}Modified{{/t.sort-by}}
-            {{#t.sort-by prop="statusIndex"}}Status{{/t.sort-by}}
-            {{#t.sort-by prop="jobVersion"}}Version{{/t.sort-by}}
-            {{#t.sort-by prop="node.shortId"}}Client{{/t.sort-by}}
-            <th>CPU</th>
-            <th>Memory</th>
-          {{/t.head}}
-          {{#t.body as |row|}}
-            {{allocation-row data-test-allocation=row.model.id allocation=row.model context="taskGroup" onClick=(action "gotoAllocation" row.model)}}
-          {{/t.body}}
-        {{/list-table}}
-        <div class="table-foot">
-          <nav class="pagination">
-            <div class="pagination-numbers">
-              {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedAllocations.length}}
-            </div>
-            {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
-            {{#p.next class="pagination-next"}} &gt; {{/p.next}}
-            <ul class="pagination-list"></ul>
-          </nav>
-        </div>
+      {{#if sortedAllocations}}
+        {{#list-pagination
+          source=sortedAllocations
+          size=pageSize
+          page=currentPage
+          class="allocations" as |p|}}
+          {{#list-table
+            source=p.list
+            sortProperty=sortProperty
+            sortDescending=sortDescending
+            class="with-foot" as |t|}}
+            {{#t.head}}
+              <th class="is-narrow"></th>
+              {{#t.sort-by prop="shortId"}}ID{{/t.sort-by}}
+              {{#t.sort-by prop="createIndex" title="Create Index"}}Created{{/t.sort-by}}
+              {{#t.sort-by prop="modifyIndex" title="Modify Index"}}Modified{{/t.sort-by}}
+              {{#t.sort-by prop="statusIndex"}}Status{{/t.sort-by}}
+              {{#t.sort-by prop="jobVersion"}}Version{{/t.sort-by}}
+              {{#t.sort-by prop="node.shortId"}}Client{{/t.sort-by}}
+              <th>CPU</th>
+              <th>Memory</th>
+            {{/t.head}}
+            {{#t.body as |row|}}
+              {{allocation-row data-test-allocation=row.model.id allocation=row.model context="taskGroup" onClick=(action "gotoAllocation" row.model)}}
+            {{/t.body}}
+          {{/list-table}}
+          <div class="table-foot">
+            <nav class="pagination">
+              <div class="pagination-numbers">
+                {{p.startsAt}}&ndash;{{p.endsAt}} of {{sortedAllocations.length}}
+              </div>
+              {{#p.prev class="pagination-previous"}} &lt; {{/p.prev}}
+              {{#p.next class="pagination-next"}} &gt; {{/p.next}}
+              <ul class="pagination-list"></ul>
+            </nav>
+          </div>
+        {{/list-pagination}}
       {{else}}
         {{#if allocations.length}}
           <div class="boxed-section-body">
@@ -103,7 +105,7 @@
             </div>
           </div>
         {{/if}}
-      {{/list-pagination}}
+      {{/if}}
     </div>
   </div>
 </section>

--- a/ui/tests/integration/list-pagination-test.js
+++ b/ui/tests/integration/list-pagination-test.js
@@ -160,35 +160,6 @@ module('Integration | Component | list pagination', function(hooks) {
     );
   });
 
-  // when there are no items in source
-  test('when there are no items in source', async function(assert) {
-    this.set('source', []);
-    await render(hbs`
-      {{#list-pagination source=source as |p|}}
-        <span class="page-info">{{p.currentPage}} of {{p.totalPages}}</span>
-        {{#p.first}}<span class="first">first</span>{{/p.first}}
-        {{#p.prev}}<span class="prev">prev</span>{{/p.prev}}
-        {{#each p.pageLinks as |link|}}
-          <span class="link page-{{link.pageNumber}}">{{link.pageNumber}}</span>
-        {{/each}}
-        {{#p.next}}<span class="next">next</span>{{/p.next}}
-        {{#p.last}}<span class="last">last</span>{{/p.last}}
-
-        {{#each p.list as |item|}}
-          <div class="item">{{item}}</div>
-        {{/each}}
-      {{else}}
-        <div class="empty-state">Empty State</div>
-      {{/list-pagination}}
-    `);
-
-    assert.ok(
-      !findAll('.page-info, .first, .prev, .link, .next, .last, .item').length,
-      'Nothing in the yield renders'
-    );
-    assert.ok(findAll('.empty-state').length, 'Empty state is rendered');
-  });
-
   // when there is less pages than the total spread amount
   test('when there is less pages than the total spread amount', async function(assert) {
     this.setProperties({


### PR DESCRIPTION
As the angle bracket invocation RFC says:

> There is no dedicated syntax for passing an "else" block
> directly. If needed, that can be passed using the named
> blocks syntax.

https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md#block

Unfortunately, using a contextual component doesn’t help as
the yield inside that component will still result in content
rendering that would show when the source isn’t empty. So
we decided to change the interface so you have to check
whether the source is empty before using it, which aligns with
how list-table works.