### PR TITLE
Added a markdownlintrc

### DIFF
--- a/website/.markdownlintrc
+++ b/website/.markdownlintrc
@@ -1,0 +1,12 @@
+{
+  "default": true,
+  "MD003": { "style": "atx" },
+  "MD004": { "style": "dash" },
+  "MD007": { "indent": 2 },
+  "MD013": { "code_blocks": false },
+  "MD033": { "allowed_elements": ["a"] },
+  "MD044": { "names": [
+    "HashiCorp",
+    "JavaScript"
+    ]}
+}


### PR DESCRIPTION
This will help us more quickly errorcheck the website for non-conforming
markdown using https://github.com/igorshubovych/markdownlint-cli

More information about the [rules is here](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md).  I tried to bring in some of the specific style rules that are enumerated in the style guide.

(right now, there are a _lot_ of non-conformimg pages)