### PR TITLE
docs: job volume spec tasks source, not config > source

### DIFF
--- a/website/source/docs/job-specification/volume_mount.html.md
+++ b/website/source/docs/job-specification/volume_mount.html.md
@@ -27,10 +27,7 @@ job "docs" {
     volume "certs" {
       type = "host"
       read_only = true
-
-      config {
-        source = "ca-certificates"
-      }
+      source = "ca-certificates"
     }
 
     task "example" {


### PR DESCRIPTION
the `job > group > volume` stanza uses a `source` key for the source and not a `config` object. The documentation for `volume_mount` showed volume with a `config` object. Fixes #6535 