### PR TITLE
e2e: use sockaddr for IP address configuration

### DIFF
--- a/e2e/terraform/packer/linux/setup.sh
+++ b/e2e/terraform/packer/linux/setup.sh
@@ -38,8 +38,13 @@ sudo apt-get install -y python-setuptools
 sudo easy_install pip
 sudo pip install numpy
 
-# Disable the firewall
+# Install sockaddr
+aws s3 cp "s3://nomad-team-test-binary/tools/sockaddr_linux_amd64" /tmp/sockaddr
+sudo mv /tmp/sockaddr /usr/local/bin
+sudo chmod +x /usr/local/bin/sockaddr
+sudo chown root:root /usr/local/bin/sockaddr
 
+# Disable the firewall
 sudo ufw disable || echo "ufw not installed"
 
 echo "Install Consul"

--- a/e2e/terraform/packer/packer.json
+++ b/e2e/terraform/packer/packer.json
@@ -6,6 +6,7 @@
       "source_ami": "ami-80861296",
       "instance_type": "t2.medium",
       "ssh_username": "ubuntu",
+      "iam_instance_profile": "packer-builder",
       "ami_name": "nomad-e2e-{{timestamp}}",
       "ami_groups": [
         "all"

--- a/e2e/terraform/shared/config/consul.json
+++ b/e2e/terraform/shared/config/consul.json
@@ -5,7 +5,7 @@
   "data_dir": "/opt/consul/data",
   "bind_addr": "0.0.0.0",
   "client_addr": "0.0.0.0",
-  "advertise_addr": "IP_ADDRESS",
+  "advertise_addr": "{{ GetPrivateIP }}",
   "bootstrap_expect": SERVER_COUNT,
   "service": {
     "name": "consul"

--- a/e2e/terraform/shared/config/consul_client.json
+++ b/e2e/terraform/shared/config/consul_client.json
@@ -4,7 +4,7 @@
   "data_dir": "/opt/consul/data",
   "bind_addr": "0.0.0.0",
   "client_addr": "0.0.0.0",
-  "advertise_addr": "IP_ADDRESS",
+  "advertise_addr": "{{ GetPrivateIP }}",
   "retry_join": ["RETRY_JOIN"],
   "connect": {
     "enabled": true

--- a/e2e/terraform/shared/config/provision-client.sh
+++ b/e2e/terraform/shared/config/provision-client.sh
@@ -11,19 +11,14 @@ HADOOP_VERSION=hadoop-2.7.7
 HADOOPCONFIGDIR=/usr/local/$HADOOP_VERSION/etc/hadoop
 HOME_DIR=ubuntu
 
-# Wait for network
-sleep 15
-
-# IP_ADDRESS=$(curl http://instance-data/latest/meta-data/local-ipv4)
-IP_ADDRESS="$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
-DOCKER_BRIDGE_IP_ADDRESS=(`ifconfig docker0 2>/dev/null|awk '/inet addr:/ {print $2}'|sed 's/addr://'`)
+IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetPrivateIP')
+DOCKER_BRIDGE_IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetInterfaceIP "docker0"')
 
 CLOUD="$1"
 RETRY_JOIN="$2"
 nomad_sha="$3"
 
 # Consul
-sed -i "s/IP_ADDRESS/$IP_ADDRESS/g" $CONFIGDIR/consul_client.json
 sed -i "s/RETRY_JOIN/$RETRY_JOIN/g" $CONFIGDIR/consul_client.json
 sudo cp $CONFIGDIR/consul_client.json $CONSULCONFIGDIR/consul.json
 sudo cp $CONFIGDIR/consul_$CLOUD.service /etc/systemd/system/consul.service

--- a/e2e/terraform/shared/config/provision-server.sh
+++ b/e2e/terraform/shared/config/provision-server.sh
@@ -12,12 +12,8 @@ HADOOP_VERSION=hadoop-2.7.7
 HADOOPCONFIGDIR=/usr/local/$HADOOP_VERSION/etc/hadoop
 HOME_DIR=ubuntu
 
-# Wait for network
-sleep 15
-
-# IP_ADDRESS=$(curl http://instance-data/latest/meta-data/local-ipv4)
-IP_ADDRESS="$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
-DOCKER_BRIDGE_IP_ADDRESS=(`ifconfig docker0 2>/dev/null|awk '/inet addr:/ {print $2}'|sed 's/addr://'`)
+IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetPrivateIP')
+DOCKER_BRIDGE_IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetInterfaceIP "docker0"')
 
 CLOUD="$1"
 SERVER_COUNT="$2"
@@ -25,7 +21,6 @@ RETRY_JOIN="$3"
 nomad_sha="$4"
 
 # Consul
-sed -i "s/IP_ADDRESS/$IP_ADDRESS/g" $CONFIGDIR/consul.json
 sed -i "s/SERVER_COUNT/$SERVER_COUNT/g" $CONFIGDIR/consul.json
 sed -i "s/RETRY_JOIN/$RETRY_JOIN/g" $CONFIGDIR/consul.json
 sudo cp $CONFIGDIR/consul.json $CONSULCONFIGDIR
@@ -38,7 +33,6 @@ export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500
 export CONSUL_RPC_ADDR=$IP_ADDRESS:8400
 
 # Vault
-sed -i "s/IP_ADDRESS/$IP_ADDRESS/g" $CONFIGDIR/vault.hcl
 sudo cp $CONFIGDIR/vault.hcl $VAULTCONFIGDIR
 sudo cp $CONFIGDIR/vault.service /etc/systemd/system/vault.service
 

--- a/e2e/terraform/shared/config/vault.hcl
+++ b/e2e/terraform/shared/config/vault.hcl
@@ -1,12 +1,12 @@
 backend "consul" {
   path          = "vault/"
-  address       = "IP_ADDRESS:8500"
-  cluster_addr  = "https://IP_ADDRESS:8201"
-  redirect_addr = "http://IP_ADDRESS:8200"
+  address       = "{{ GetPrivateIP }}:8500"
+  cluster_addr  = "https://{{ GetPrivateIP }}:8201"
+  redirect_addr = "http://{{ GetPrivateIP }}:8200"
 }
 
 listener "tcp" {
-  address         = "IP_ADDRESS:8200"
-  cluster_address = "IP_ADDRESS:8201"
+  address         = "{{ GetPrivateIP }}:8200"
+  cluster_address = "{{ GetPrivateIP }}:8201"
   tls_disable     = 1
 }


### PR DESCRIPTION
Update the Consul and Vault configs to take advantage of their included `go-sockaddr` library for getting the IP addresses we need in a portable way. This particularly avoids problems with "predictable" interface names provided by systemd. (And will make our lives a little easier for Windows.)

Also adds the `sockaddr` binary to the Packer build so we can use it in our provisioning scripts.

---

Like with #6542, I've tested this out (without impacting current e2e test suite runs) by swapping out the `OS: Ubuntu` tag for `OS: TestUbuntu` in both `packer.json` and `main.tf`, and then running:

```sh
# build the AMI
cd ./e2e/terraform/packer
packer build packer.json

# deploy via Terraform
cd ../
terraform plan
terraform apply

# run e2e tests
cd ../..
go test -v ./e2e
```