### PR TITLE
Update go-multierror library

### DIFF
--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -338,7 +338,7 @@ func TestAllocations_Signal(t *testing.T) {
 	err = client.ClientRPC("Allocations.Signal", &req, &resp2)
 
 	require.Error(t, err, "Expected error, got: %s, resp: %#+v", err, resp2)
-	require.Equal(t, "1 error(s) occurred:\n\n* Failed to signal task: web, err: Task not running", err.Error())
+	require.Contains(t, err.Error(), "Failed to signal task: web, err: Task not running")
 }
 
 func TestAllocations_Signal_ACL(t *testing.T) {

--- a/vendor/github.com/hashicorp/go-multierror/Makefile
+++ b/vendor/github.com/hashicorp/go-multierror/Makefile
@@ -1,0 +1,31 @@
+TEST?=./...
+
+default: test
+
+# test runs the test suite and vets the code.
+test: generate
+	@echo "==> Running tests..."
+	@go list $(TEST) \
+		| grep -v "/vendor/" \
+		| xargs -n1 go test -timeout=60s -parallel=10 ${TESTARGS}
+
+# testrace runs the race checker
+testrace: generate
+	@echo "==> Running tests (race)..."
+	@go list $(TEST) \
+		| grep -v "/vendor/" \
+		| xargs -n1 go test -timeout=60s -race ${TESTARGS}
+
+# updatedeps installs all the dependencies needed to run and build.
+updatedeps:
+	@sh -c "'${CURDIR}/scripts/deps.sh' '${NAME}'"
+
+# generate runs `go generate` to build the dynamically generated source files.
+generate:
+	@echo "==> Generating..."
+	@find . -type f -name '.DS_Store' -delete
+	@go list ./... \
+		| grep -v "/vendor/" \
+		| xargs -n1 go generate
+
+.PHONY: default test testrace updatedeps generate

--- a/vendor/github.com/hashicorp/go-multierror/README.md
+++ b/vendor/github.com/hashicorp/go-multierror/README.md
@@ -1,5 +1,11 @@
 # go-multierror
 
+[![Build Status](http://img.shields.io/travis/hashicorp/go-multierror.svg?style=flat-square)][travis]
+[![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godocs]
+
+[travis]: https://travis-ci.org/hashicorp/go-multierror
+[godocs]: https://godoc.org/github.com/hashicorp/go-multierror
+
 `go-multierror` is a package for Go that provides a mechanism for
 representing a list of `error` values as a single `error`.
 

--- a/vendor/github.com/hashicorp/go-multierror/append.go
+++ b/vendor/github.com/hashicorp/go-multierror/append.go
@@ -18,9 +18,13 @@ func Append(err error, errs ...error) *Error {
 		for _, e := range errs {
 			switch e := e.(type) {
 			case *Error:
-				err.Errors = append(err.Errors, e.Errors...)
+				if e != nil {
+					err.Errors = append(err.Errors, e.Errors...)
+				}
 			default:
-				err.Errors = append(err.Errors, e)
+				if e != nil {
+					err.Errors = append(err.Errors, e)
+				}
 			}
 		}
 

--- a/vendor/github.com/hashicorp/go-multierror/format.go
+++ b/vendor/github.com/hashicorp/go-multierror/format.go
@@ -12,12 +12,16 @@ type ErrorFormatFunc func([]error) string
 // ListFormatFunc is a basic formatter that outputs the number of errors
 // that occurred along with a bullet point list of the errors.
 func ListFormatFunc(es []error) string {
+	if len(es) == 1 {
+		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", es[0])
+	}
+
 	points := make([]string, len(es))
 	for i, err := range es {
 		points[i] = fmt.Sprintf("* %s", err)
 	}
 
 	return fmt.Sprintf(
-		"%d error(s) occurred:\n\n%s",
-		len(es), strings.Join(points, "\n"))
+		"%d errors occurred:\n\t%s\n\n",
+		len(es), strings.Join(points, "\n\t"))
 }

--- a/vendor/github.com/hashicorp/go-multierror/go.mod
+++ b/vendor/github.com/hashicorp/go-multierror/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/go-multierror
+
+require github.com/hashicorp/errwrap v1.0.0

--- a/vendor/github.com/hashicorp/go-multierror/go.sum
+++ b/vendor/github.com/hashicorp/go-multierror/go.sum
@@ -1,0 +1,2 @@
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/vendor/github.com/hashicorp/go-multierror/group.go
+++ b/vendor/github.com/hashicorp/go-multierror/group.go
@@ -1,0 +1,38 @@
+package multierror
+
+import "sync"
+
+// Group is a collection of goroutines which return errors that need to be
+// coalesced.
+type Group struct {
+	mutex sync.Mutex
+	err   *Error
+	wg    sync.WaitGroup
+}
+
+// Go calls the given function in a new goroutine.
+//
+// If the function returns an error it is added to the group multierror which
+// is returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.mutex.Lock()
+			g.err = Append(g.err, err)
+			g.mutex.Unlock()
+		}
+	}()
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the multierror.
+func (g *Group) Wait() *Error {
+	g.wg.Wait()
+	g.mutex.Lock()
+	defer g.mutex.Unlock()
+	return g.err
+}

--- a/vendor/github.com/hashicorp/go-multierror/multierror.go
+++ b/vendor/github.com/hashicorp/go-multierror/multierror.go
@@ -40,11 +40,11 @@ func (e *Error) GoString() string {
 }
 
 // WrappedErrors returns the list of errors that this Error is wrapping.
-// It is an implementatin of the errwrap.Wrapper interface so that
+// It is an implementation of the errwrap.Wrapper interface so that
 // multierror.Error can be used with that library.
 //
 // This method is not safe to be called concurrently and is no different
-// than accessing the Errors field directly. It is implementd only to
+// than accessing the Errors field directly. It is implemented only to
 // satisfy the errwrap.Wrapper interface.
 func (e *Error) WrappedErrors() []error {
 	return e.Errors

--- a/vendor/github.com/hashicorp/go-multierror/sort.go
+++ b/vendor/github.com/hashicorp/go-multierror/sort.go
@@ -1,0 +1,16 @@
+package multierror
+
+// Len implements sort.Interface function for length
+func (err Error) Len() int {
+	return len(err.Errors)
+}
+
+// Swap implements sort.Interface function for swapping elements
+func (err Error) Swap(i, j int) {
+	err.Errors[i], err.Errors[j] = err.Errors[j], err.Errors[i]
+}
+
+// Less implements sort.Interface function for determining order
+func (err Error) Less(i, j int) bool {
+	return err.Errors[i].Error() < err.Errors[j].Error()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -213,7 +213,7 @@
 		{"path":"github.com/hashicorp/go-immutable-radix","checksumSHA1":"Cas2nprG6pWzf05A2F/OlnjUu2Y=","revision":"8aac2701530899b64bdea735a1de8da899815220","revisionTime":"2017-07-25T22:12:15Z"},
 		{"path":"github.com/hashicorp/go-memdb","checksumSHA1":"FMAvwDar2bQyYAW4XMFhAt0J5xA=","revision":"20ff6434c1cc49b80963d45bf5c6aa89c78d8d57","revisionTime":"2017-08-31T20:15:40Z"},
 		{"path":"github.com/hashicorp/go-msgpack/codec","checksumSHA1":"CKGYNUDKre3Z2g4hHNVfp5nTcfA=","revision":"23165f7bc3c2dda1891434ebb9da1511a7bafc1c","revisionTime":"2019-09-27T12:33:13Z","version":"upstream-08f7b40","versionExact":"upstream-08f7b40"},
-		{"path":"github.com/hashicorp/go-multierror","checksumSHA1":"QGgN03VUP9+jV+bcETFIBG0o0fM=","revision":"bdca7bb83f603b80ef756bb953fe1dafa9cd00a2","revisionTime":"2019-07-22T21:38:33Z"},
+		{"path":"github.com/hashicorp/go-multierror","checksumSHA1":"qb0WcbXXZyWv538gMYVHAq/qOlw=","revision":"72917a1559e17f38638ade54020ab372ba848d67","revisionTime":"2019-11-20T19:21:20Z"},
 		{"path":"github.com/hashicorp/go-plugin","checksumSHA1":"Nwod22KYiOycjys2ITllhNE9mtE=","revision":"809113480b559c989ea9cfcff62e9d387961f60b","revisionTime":"2019-10-04T17:18:45Z"},
 		{"path":"github.com/hashicorp/go-plugin/internal/plugin","checksumSHA1":"uTvnRQ5UWn/bhRxbW/UCfYFseSc=","revision":"809113480b559c989ea9cfcff62e9d387961f60b","revisionTime":"2019-10-04T17:18:45Z"},
 		{"path":"github.com/hashicorp/go-plugin/internal/proto","checksumSHA1":"Ikbb1FngsPR79bHhr2UmKk4CblI=","revision":"f444068e8f5a19853177f7aa0aea7e7d95b5b528","revisionTime":"2018-12-12T15:08:38Z"},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -213,7 +213,7 @@
 		{"path":"github.com/hashicorp/go-immutable-radix","checksumSHA1":"Cas2nprG6pWzf05A2F/OlnjUu2Y=","revision":"8aac2701530899b64bdea735a1de8da899815220","revisionTime":"2017-07-25T22:12:15Z"},
 		{"path":"github.com/hashicorp/go-memdb","checksumSHA1":"FMAvwDar2bQyYAW4XMFhAt0J5xA=","revision":"20ff6434c1cc49b80963d45bf5c6aa89c78d8d57","revisionTime":"2017-08-31T20:15:40Z"},
 		{"path":"github.com/hashicorp/go-msgpack/codec","checksumSHA1":"CKGYNUDKre3Z2g4hHNVfp5nTcfA=","revision":"23165f7bc3c2dda1891434ebb9da1511a7bafc1c","revisionTime":"2019-09-27T12:33:13Z","version":"upstream-08f7b40","versionExact":"upstream-08f7b40"},
-		{"path":"github.com/hashicorp/go-multierror","checksumSHA1":"lrSl49G23l6NhfilxPM0XFs5rZo=","revision":"d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"},
+		{"path":"github.com/hashicorp/go-multierror","checksumSHA1":"QGgN03VUP9+jV+bcETFIBG0o0fM=","revision":"bdca7bb83f603b80ef756bb953fe1dafa9cd00a2","revisionTime":"2019-07-22T21:38:33Z"},
 		{"path":"github.com/hashicorp/go-plugin","checksumSHA1":"Nwod22KYiOycjys2ITllhNE9mtE=","revision":"809113480b559c989ea9cfcff62e9d387961f60b","revisionTime":"2019-10-04T17:18:45Z"},
 		{"path":"github.com/hashicorp/go-plugin/internal/plugin","checksumSHA1":"uTvnRQ5UWn/bhRxbW/UCfYFseSc=","revision":"809113480b559c989ea9cfcff62e9d387961f60b","revisionTime":"2019-10-04T17:18:45Z"},
 		{"path":"github.com/hashicorp/go-plugin/internal/proto","checksumSHA1":"Ikbb1FngsPR79bHhr2UmKk4CblI=","revision":"f444068e8f5a19853177f7aa0aea7e7d95b5b528","revisionTime":"2018-12-12T15:08:38Z"},


### PR DESCRIPTION
Update multierror to latest as of now.  Our version is very old and
dates back to Sep 2015[1].  Here, we aim to pick up a panic fix found in
n https://github.com/hashicorp/go-multierror/pull/11 (Dec 2016).

This is a purely hygiene maintenance change.  I am unaware of any causes
of the panic in our current dependencies.  Though, some private internal
libraries did rely on the "recent" behavior of go-multierror, and I
aimed to update here to ease our adoption of other libraries later.

[1] https://github.com/hashicorp/go-multierror/commits/d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5