### PR TITLE
Allow dashes in port labels

### DIFF
--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var reDynamicPorts = regexp.MustCompile("^[a-zA-Z0-9_]+$")
+var reDynamicPorts = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
 var errPortLabel = fmt.Errorf("Port label does not conform to naming requirements %s", reDynamicPorts.String())
 
 // Parse parses the job spec from the given io.Reader.

--- a/jobspec/parse.go
+++ b/jobspec/parse.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var reDynamicPorts = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
+var reDynamicPorts = regexp.MustCompile("^[a-zA-Z0-9_\\-]+$")
 var errPortLabel = fmt.Errorf("Port label does not conform to naming requirements %s", reDynamicPorts.String())
 
 // Parse parses the job spec from the given io.Reader.


### PR DESCRIPTION
I hit this issue earlier, I was trying to rename my services with underscores like this:

```
* service[4] "billettodb_production" validation failed: 1 error(s) occurred:
* service name must be valid per RFC 1123 and can contain only alphanumeric characters or dashes: "billettodb_production"
```

So that wasn't allowed, I then changed my service names to use dashes (and also updated the port labels to match, however, port labels only allows for underscores but not dashes.

I am no expert in Go, and I'm very confused about how the test suite works.

What do you think?