### PR TITLE
updates default consul version to 1.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ commands:
     parameters:
       version:
         type: string
-        default: 1.6.0-rc1
+        default: 1.6.1
     steps:
       - run:
           name: Install Consul << parameters.version >>

--- a/e2e/terraform/packer/linux/setup.sh
+++ b/e2e/terraform/packer/linux/setup.sh
@@ -10,7 +10,7 @@ sudo chown -R ubuntu:ubuntu /ops/shared
 
 cd /ops
 
-CONSULVERSION=1.6.0
+CONSULVERSION=1.6.1
 CONSULDOWNLOAD=https://releases.hashicorp.com/consul/${CONSULVERSION}/consul_${CONSULVERSION}_linux_amd64.zip
 CONSULCONFIGDIR=/etc/consul.d
 CONSULDIR=/opt/consul

--- a/scripts/vagrant-linux-priv-consul.sh
+++ b/scripts/vagrant-linux-priv-consul.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-VERSION="1.6.0"
+VERSION="1.6.1"
 DOWNLOAD=https://releases.hashicorp.com/consul/${VERSION}/consul_${VERSION}_linux_amd64.zip
 
 function install_consul() {


### PR DESCRIPTION
Circle CI consul version is currently on an RC version, bumps to 1.6.1