### PR TITLE
Fix some connect connect validation

### DIFF
--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -50,6 +50,15 @@ func (jobConnectHook) Name() string {
 
 func (jobConnectHook) Mutate(job *structs.Job) (_ *structs.Job, warnings []error, err error) {
 	for _, g := range job.TaskGroups {
+		// TG isn't validated yet, but validation
+		// may depend on mutation results.
+		// Do basic validation here and skip mutation,
+		// so Validate can return a meaningful error
+		// messages
+		if len(g.Networks) == 0 {
+			continue
+		}
+
 		if err := groupConnectHook(g); err != nil {
 			return nil, nil, err
 		}

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -53,21 +53,23 @@ func (j *Job) admissionMutators(job *structs.Job) (_ *structs.Job, warnings []er
 
 // admissionValidators returns a slice of validation warnings and a multierror
 // of validation failures.
-func (j *Job) admissionValidators(origJob *structs.Job) (warnings []error, err error) {
+func (j *Job) admissionValidators(origJob *structs.Job) ([]error, error) {
 	// ensure job is not mutated
 	job := origJob.Copy()
 
-	var w []error
-	errs := new(multierror.Error)
+	var warnings []error
+	var errs error
+
 	for _, validator := range j.validators {
-		w, err = validator.Validate(job)
+		w, err := validator.Validate(job)
 		j.logger.Trace("job validate results", "validator", validator.Name(), "warnings", w, "error", err)
 		if err != nil {
-			multierror.Append(errs, err)
+			errs = multierror.Append(errs, err)
 		}
 		warnings = append(warnings, w...)
 	}
-	return warnings, err
+
+	return warnings, errs
 
 }
 


### PR DESCRIPTION
This fixes two bugs:
* admission mutators are invoked before validation, so we must handle invalid input in mutation
* fix validation error aggregation so we always return `nil`

Sample failure is https://circleci.com/gh/hashicorp/nomad/15559 .  The test covers both of these cases, but the panic in one caused test runner to skip running the other failing test case :(.

Fixes #6571 