### PR TITLE
nomad: fix vault.CreateToken log message printing wrong error

### DIFF
--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -1012,7 +1012,7 @@ func (v *vaultClient) CreateToken(ctx context.Context, a *structs.Allocation, ta
 		validationErr = fmt.Errorf("Vault returned WrapInfo without WrappedAccessor. Secret warnings: %v", secret.Warnings)
 	}
 	if validationErr != nil {
-		v.logger.Warn("ailed to CreateToken", "error", err)
+		v.logger.Warn("failed to CreateToken", "error", validationErr)
 		return nil, structs.NewRecoverableError(validationErr, true)
 	}
 


### PR DESCRIPTION
Fixes typo in word "failed".

Fixes bug where incorrect error is printed. The old code would only
ever print a `nil` error, instead of the `validationErr` which is being
created.