### PR TITLE
run 'make hclfmt' so that 'make dev' is idempotent

### DIFF
--- a/jobspec/test-fixtures/tg-network.hcl
+++ b/jobspec/test-fixtures/tg-network.hcl
@@ -22,6 +22,7 @@ job "foo" {
       connect {
         sidecar_service {
           tags = ["side1", "side2"]
+
           proxy {
             local_service_port = 8080
 


### PR DESCRIPTION
If you run `make dev` on the current master branch, it'll modify this file because it runs `hclfmt` as well.