### PR TITLE
remove misleading networking log line

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -912,7 +912,6 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 
 	// Setup port mapping and exposed ports
 	if len(task.Resources.NomadResources.Networks) == 0 {
-		logger.Debug("no network interfaces are available")
 		if len(driverConfig.PortMap) > 0 {
 			return c, fmt.Errorf("Trying to map ports but no network interface is available")
 		}


### PR DESCRIPTION
When a job has a task group network, this log line ends up being misleading if you're trying to debug networking issues. We really only care about this when there's no port map set, in which case we get the error returned anyways.

(Relates to #6385 #6567 and #6580)