### PR TITLE
WIP Experiment in handling Sensitive keys

### DIFF
--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -161,7 +162,7 @@ func TestClient_ACL_ResolveToken(t *testing.T) {
 	}
 
 	// Test bad token
-	out4, err := c1.ResolveToken(uuid.Generate())
+	out4, err := c1.ResolveToken(sensitive.Sensitive(uuid.Generate()))
 	assert.Equal(t, structs.ErrTokenNotFound, err)
 	assert.Nil(t, out4)
 }

--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper/pluginutils/catalog"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -764,7 +765,7 @@ func TestAlloc_ExecStreaming_ACL_Basic(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -897,7 +898,7 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_Image(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -1046,7 +1047,7 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_Chroot(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -1190,7 +1191,7 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_None(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -631,7 +631,8 @@ func newRunnerConfig(config *TaskTemplateManagerConfig,
 	// Setup the Consul config
 	if cc.ConsulConfig != nil {
 		conf.Consul.Address = &cc.ConsulConfig.Addr
-		conf.Consul.Token = &cc.ConsulConfig.Token
+		token := cc.ConsulConfig.Token.Plaintext()
+		conf.Consul.Token = &token
 
 		if cc.ConsulConfig.EnableSSL != nil && *cc.ConsulConfig.EnableSSL {
 			verify := cc.ConsulConfig.VerifySSL != nil && *cc.ConsulConfig.VerifySSL
@@ -644,8 +645,8 @@ func newRunnerConfig(config *TaskTemplateManagerConfig,
 			}
 		}
 
-		if cc.ConsulConfig.Auth != "" {
-			parts := strings.SplitN(cc.ConsulConfig.Auth, ":", 2)
+		if auth := cc.ConsulConfig.Auth.Plaintext(); auth != "" {
+			parts := strings.SplitN(auth, ":", 2)
 			if len(parts) != 2 {
 				return nil, fmt.Errorf("Failed to parse Consul Auth config")
 			}

--- a/client/allocwatcher/alloc_watcher.go
+++ b/client/allocwatcher/alloc_watcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -89,7 +90,7 @@ type Config struct {
 
 	// MigrateToken is used to migrate remote alloc dirs when ACLs are
 	// enabled.
-	MigrateToken string
+	MigrateToken sensitive.Sensitive
 
 	Logger hclog.Logger
 }
@@ -338,7 +339,7 @@ type remotePrevAlloc struct {
 
 	// migrateToken allows a client to migrate data in an ACL-protected remote
 	// volume
-	migrateToken string
+	migrateToken sensitive.Sensitive
 }
 
 // IsWaiting returns true if there's a concurrent call inside Wait
@@ -529,7 +530,7 @@ func (p *remotePrevAlloc) migrateAllocDir(ctx context.Context, nodeAddr string) 
 	}
 
 	url := fmt.Sprintf("/v1/client/allocation/%v/snapshot", p.prevAllocID)
-	qo := &nomadapi.QueryOptions{AuthToken: p.migrateToken}
+	qo := &nomadapi.QueryOptions{AuthToken: p.migrateToken.Plaintext()}
 	resp, err := apiClient.Raw().Response(url, qo)
 	if err != nil {
 		prevAllocDir.Destroy()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/pluginutils/catalog"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad"
@@ -970,7 +971,7 @@ func TestClient_ValidateMigrateToken_InvalidToken(t *testing.T) {
 	assert.Equal(c.ValidateMigrateToken("", ""), false)
 
 	alloc := mock.Alloc()
-	assert.Equal(c.ValidateMigrateToken(alloc.ID, alloc.ID), false)
+	assert.Equal(c.ValidateMigrateToken(alloc.ID, sensitive.Sensitive(alloc.ID)), false)
 	assert.Equal(c.ValidateMigrateToken(alloc.ID, ""), false)
 }
 

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	sframer "github.com/hashicorp/nomad/client/lib/streamframer"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad"
@@ -145,7 +146,7 @@ func TestFS_Stat_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -278,7 +279,7 @@ func TestFS_List_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -428,7 +429,7 @@ func TestFS_Stream_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -1057,7 +1058,7 @@ func TestFS_Logs_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{

--- a/client/vaultclient/vaultclient_test.go
+++ b/client/vaultclient/vaultclient_test.go
@@ -45,7 +45,7 @@ func TestVaultClient_TokenRenewals(t *testing.T) {
 	num := 5
 	tokens := make([]string, num)
 	for i := 0; i < num; i++ {
-		c.client.SetToken(v.Config.Token)
+		c.client.SetToken(v.Config.Token.Plaintext())
 
 		if err := c.client.SetAddress(v.Config.Addr); err != nil {
 			t.Fatal(err)
@@ -251,7 +251,7 @@ func TestVaultClient_RenewNonRenewableLease(t *testing.T) {
 		Renewable:   new(bool),
 	}
 
-	c.client.SetToken(v.Config.Token)
+	c.client.SetToken(v.Config.Token.Plaintext())
 
 	if err := c.client.SetAddress(v.Config.Addr); err != nil {
 		t.Fatal(err)
@@ -293,7 +293,7 @@ func TestVaultClient_RenewNonexistentLease(t *testing.T) {
 	// Sleep a little while to ensure that the renewal loop is active
 	time.Sleep(time.Duration(testutil.TestMultiplier()) * time.Second)
 
-	c.client.SetToken(v.Config.Token)
+	c.client.SetToken(v.Config.Token.Plaintext())
 
 	if err := c.client.SetAddress(v.Config.Addr); err != nil {
 		t.Fatal(err)

--- a/command/acl_policy_apply_test.go
+++ b/command/acl_policy_apply_test.go
@@ -47,7 +47,7 @@ func TestACLPolicyApplyCommand(t *testing.T) {
 	assert.Equal(1, code)
 
 	// Apply a policy with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
+	os.Setenv("NOMAD_TOKEN", token.SecretID.Plaintext())
 	code = cmd.Run([]string{"-address=" + url, "test-policy", f.Name()})
 	assert.Equal(0, code)
 

--- a/command/acl_policy_delete_test.go
+++ b/command/acl_policy_delete_test.go
@@ -42,12 +42,12 @@ func TestACLPolicyDeleteCommand(t *testing.T) {
 
 	// Delete the policy without a valid token fails
 	invalidToken := mock.ACLToken()
-	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
+	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID.Plaintext())
 	code := cmd.Run([]string{"-address=" + url, policy.Name})
 	assert.Equal(1, code)
 
 	// Delete the policy with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
+	os.Setenv("NOMAD_TOKEN", token.SecretID.Plaintext())
 	code = cmd.Run([]string{"-address=" + url, policy.Name})
 	assert.Equal(0, code)
 

--- a/command/acl_policy_info_test.go
+++ b/command/acl_policy_info_test.go
@@ -41,12 +41,12 @@ func TestACLPolicyInfoCommand(t *testing.T) {
 
 	// Attempt to apply a policy without a valid management token
 	invalidToken := mock.ACLToken()
-	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
+	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID.Plaintext())
 	code := cmd.Run([]string{"-address=" + url, policy.Name})
 	assert.Equal(1, code)
 
 	// Apply a policy with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
+	os.Setenv("NOMAD_TOKEN", token.SecretID.Plaintext())
 	code = cmd.Run([]string{"-address=" + url, policy.Name})
 	assert.Equal(0, code)
 

--- a/command/acl_policy_list_test.go
+++ b/command/acl_policy_list_test.go
@@ -40,11 +40,11 @@ func TestACLPolicyListCommand(t *testing.T) {
 
 	// Attempt to list policies without a valid management token
 	invalidToken := mock.ACLToken()
-	code := cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID})
+	code := cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID.Plaintext()})
 	assert.Equal(1, code)
 
 	// Apply a policy with a valid management token
-	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID.Plaintext()})
 	assert.Equal(0, code)
 
 	// Check the output
@@ -54,7 +54,7 @@ func TestACLPolicyListCommand(t *testing.T) {
 	}
 
 	// List json
-	if code := cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, "-json"}); code != 0 {
+	if code := cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID.Plaintext(), "-json"}); code != 0 {
 		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
 	}
 	out = ui.OutputWriter.String()

--- a/command/acl_token_create_test.go
+++ b/command/acl_token_create_test.go
@@ -33,7 +33,7 @@ func TestACLTokenCreateCommand(t *testing.T) {
 	assert.Equal(1, code)
 
 	// Request to create a new token with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
+	os.Setenv("NOMAD_TOKEN", token.SecretID.Plaintext())
 	code = cmd.Run([]string{"-address=" + url, "-policy=foo", "-type=client"})
 	assert.Equal(0, code)
 

--- a/command/acl_token_delete_test.go
+++ b/command/acl_token_delete_test.go
@@ -46,7 +46,7 @@ func TestACLTokenDeleteCommand_ViaEnvVariable(t *testing.T) {
 
 	// Delete a token using a valid management token set via an environment
 	// variable
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
+	os.Setenv("NOMAD_TOKEN", token.SecretID.Plaintext())
 	code = cmd.Run([]string{"-address=" + url, mockToken.AccessorID})
 	assert.Equal(0, code)
 

--- a/command/acl_token_info_test.go
+++ b/command/acl_token_info_test.go
@@ -40,18 +40,18 @@ func TestACLTokenInfoCommand_ViaEnvVar(t *testing.T) {
 	// Attempt to fetch info on a token without providing a valid management
 	// token
 	invalidToken := mock.ACLToken()
-	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
+	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID.Plaintext())
 	code := cmd.Run([]string{"-address=" + url, mockToken.AccessorID})
 	assert.Equal(1, code)
 
 	// Fetch info on a token with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
+	os.Setenv("NOMAD_TOKEN", token.SecretID.Plaintext())
 	code = cmd.Run([]string{"-address=" + url, mockToken.AccessorID})
 	assert.Equal(0, code)
 
 	// Fetch info on a token with a valid management token via a CLI option
 	os.Setenv("NOMAD_TOKEN", "")
-	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, mockToken.AccessorID})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID.Plaintext(), mockToken.AccessorID})
 	assert.Equal(0, code)
 
 	// Check the output

--- a/command/acl_token_list_test.go
+++ b/command/acl_token_list_test.go
@@ -38,11 +38,11 @@ func TestACLTokenListCommand(t *testing.T) {
 
 	// Attempt to list tokens without a valid management token
 	invalidToken := mock.ACLToken()
-	code := cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID})
+	code := cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID.Plaintext()})
 	assert.Equal(1, code)
 
 	// Apply a token with a valid management token
-	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID.Plaintext()})
 	assert.Equal(0, code)
 
 	// Check the output
@@ -52,7 +52,7 @@ func TestACLTokenListCommand(t *testing.T) {
 	}
 
 	// List json
-	if code := cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, "-json"}); code != 0 {
+	if code := cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID.Plaintext(), "-json"}); code != 0 {
 		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
 	}
 	out = ui.OutputWriter.String()

--- a/command/acl_token_self_test.go
+++ b/command/acl_token_self_test.go
@@ -40,12 +40,12 @@ func TestACLTokenSelfCommand_ViaEnvVar(t *testing.T) {
 	// Attempt to fetch info on a token without providing a valid management
 	// token
 	invalidToken := mock.ACLToken()
-	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
+	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID.Plaintext())
 	code := cmd.Run([]string{"-address=" + url})
 	assert.Equal(1, code)
 
 	// Fetch info on a token with a valid token
-	os.Setenv("NOMAD_TOKEN", mockToken.SecretID)
+	os.Setenv("NOMAD_TOKEN", mockToken.SecretID.Plaintext())
 	code = cmd.Run([]string{"-address=" + url})
 	assert.Equal(0, code)
 

--- a/command/acl_token_update_test.go
+++ b/command/acl_token_update_test.go
@@ -37,11 +37,11 @@ func TestACLTokenUpdateCommand(t *testing.T) {
 
 	// Request to update a new token without providing a valid management token
 	invalidToken := mock.ACLToken()
-	code := cmd.Run([]string{"--token=" + invalidToken.SecretID, "-address=" + url, "-name=bar", mockToken.AccessorID})
+	code := cmd.Run([]string{"--token=" + invalidToken.SecretID.Plaintext(), "-address=" + url, "-name=bar", mockToken.AccessorID})
 	assert.Equal(1, code)
 
 	// Request to update a new token with a valid management token
-	code = cmd.Run([]string{"--token=" + token.SecretID, "-address=" + url, "-name=bar", mockToken.AccessorID})
+	code = cmd.Run([]string{"--token=" + token.SecretID.Plaintext(), "-address=" + url, "-name=bar", mockToken.AccessorID})
 	assert.Equal(0, code)
 
 	// Check the output

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/serf/serf"
 	"github.com/mitchellh/copystructure"
@@ -48,7 +49,7 @@ func (s *HTTPServer) AgentSelfRequest(resp http.ResponseWriter, req *http.Reques
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
-	var secret string
+	var secret sensitive.Sensitive
 	s.parseToken(req, &secret)
 
 	var aclObj *acl.ACL
@@ -154,7 +155,7 @@ func (s *HTTPServer) AgentForceLeaveRequest(resp http.ResponseWriter, req *http.
 		return nil, CodedError(501, ErrInvalidMethod)
 	}
 
-	var secret string
+	var secret sensitive.Sensitive
 	s.parseToken(req, &secret)
 
 	// Check agent write permissions
@@ -195,7 +196,7 @@ func (s *HTTPServer) listServers(resp http.ResponseWriter, req *http.Request) (i
 		return nil, CodedError(501, ErrInvalidMethod)
 	}
 
-	var secret string
+	var secret sensitive.Sensitive
 	s.parseToken(req, &secret)
 
 	// Check agent read permissions
@@ -222,7 +223,7 @@ func (s *HTTPServer) updateServers(resp http.ResponseWriter, req *http.Request) 
 		return nil, CodedError(400, "missing server address")
 	}
 
-	var secret string
+	var secret sensitive.Sensitive
 	s.parseToken(req, &secret)
 
 	// Check agent write permissions
@@ -249,7 +250,7 @@ func (s *HTTPServer) KeyringOperationRequest(resp http.ResponseWriter, req *http
 		return nil, CodedError(501, ErrInvalidMethod)
 	}
 
-	var secret string
+	var secret sensitive.Sensitive
 	s.parseToken(req, &secret)
 
 	// Check agent write permissions

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -57,7 +57,7 @@ func TestHTTP_AgentSelf(t *testing.T) {
 		obj, err = s.Server.AgentSelfRequest(respW, req)
 		require.NoError(err)
 		self = obj.(agentSelf)
-		require.Equal("<redacted>", self.Config.ACL.ReplicationToken)
+		require.Equal("<redacted>", self.Config.ACL.ReplicationToken.Plaintext())
 
 		// Check the Consul config
 		require.Empty(self.Config.Consul.Token)

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -68,7 +68,7 @@ func TestHTTP_AgentSelf(t *testing.T) {
 		obj, err = s.Server.AgentSelfRequest(respW, req)
 		require.NoError(err)
 		self = obj.(agentSelf)
-		require.Equal("<redacted>", self.Config.Consul.Token)
+		require.Equal("<redacted>", self.Config.Consul.Token.Plaintext())
 
 		// Check the Circonus config
 		require.Empty(self.Config.Telemetry.CirconusAPIToken)

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -49,7 +49,7 @@ func TestHTTP_AgentSelf(t *testing.T) {
 		obj, err = s.Server.AgentSelfRequest(respW, req)
 		require.NoError(err)
 		self = obj.(agentSelf)
-		require.Equal("<redacted>", self.Config.Vault.Token)
+		require.Equal("<redacted>", self.Config.Vault.Token.Plaintext())
 
 		// Assign a ReplicationToken token and require it is redacted.
 		s.Config.ACL.ReplicationToken = "badc0deb-adc0-deba-dc0d-ebadc0debadc"

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -71,7 +71,7 @@ func TestHTTP_AgentSelf(t *testing.T) {
 		require.Equal("<redacted>", self.Config.Consul.Token.Plaintext())
 
 		// Check the Circonus config
-		require.Empty(self.Config.Telemetry.CirconusAPIToken)
+		require.Empty(self.Config.Telemetry.CirconusAPIToken.Plaintext())
 
 		// Assign a Consul token and require it is redacted.
 		s.Config.Telemetry.CirconusAPIToken = "badc0deb-adc0-deba-dc0d-ebadc0debadc"
@@ -79,7 +79,7 @@ func TestHTTP_AgentSelf(t *testing.T) {
 		obj, err = s.Server.AgentSelfRequest(respW, req)
 		require.NoError(err)
 		self = obj.(agentSelf)
-		require.Equal("<redacted>", self.Config.Telemetry.CirconusAPIToken)
+		require.Equal("<redacted>", self.Config.Telemetry.CirconusAPIToken.Plaintext())
 	})
 }
 

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/snappy"
 	"github.com/gorilla/websocket"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/ugorji/go/codec"
@@ -315,7 +316,7 @@ func (s *HTTPServer) allocSignal(allocID string, resp http.ResponseWriter, req *
 }
 
 func (s *HTTPServer) allocSnapshot(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	var secret string
+	var secret sensitive.Sensitive
 	s.parseToken(req, &secret)
 	if !s.agent.Client().ValidateMigrateToken(allocID, secret) {
 		return nil, structs.ErrPermissionDenied

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -603,7 +603,7 @@ func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
 		req, err = http.NewRequest("GET", url, nil)
 		require.Nil(err)
 
-		req.Header.Set("X-Nomad-Token", validMigrateToken)
+		req.Header.Set("X-Nomad-Token", validMigrateToken.Plaintext())
 
 		// Make the unauthorized request
 		respW = httptest.NewRecorder()

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -119,7 +119,8 @@ func (c *Command) readConfig() *Config {
 	flags.StringVar(&cmdConfig.NodeName, "node", "", "")
 
 	// Consul options
-	flags.StringVar(&cmdConfig.Consul.Auth, "consul-auth", "", "")
+	var consulAuth, consulToken string
+	flags.StringVar(&consulAuth, "consul-auth", "", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
 		cmdConfig.Consul.AutoAdvertise = &b
 		return nil
@@ -149,7 +150,7 @@ func (c *Command) readConfig() *Config {
 		cmdConfig.Consul.EnableSSL = &b
 		return nil
 	}), "consul-ssl", "")
-	flags.StringVar(&cmdConfig.Consul.Token, "consul-token", "", "")
+	flags.StringVar(&consulToken, "consul-token", "", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
 		cmdConfig.Consul.VerifySSL = &b
 		return nil
@@ -195,6 +196,12 @@ func (c *Command) readConfig() *Config {
 
 	if vaultToken != "" {
 		cmdConfig.Vault.Token = sensitive.Sensitive(vaultToken)
+	}
+	if consulAuth != "" {
+		cmdConfig.Consul.Auth = sensitive.Sensitive(consulAuth)
+	}
+	if consulToken != "" {
+		cmdConfig.Consul.Token = sensitive.Sensitive(consulToken)
 	}
 
 	// Parse the meta flags.

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -182,8 +182,9 @@ func (c *Command) readConfig() *Config {
 	flags.StringVar(&cmdConfig.Vault.TLSServerName, "vault-tls-server-name", "", "")
 
 	// ACL options
+	var replicationToken string
 	flags.BoolVar(&cmdConfig.ACL.Enabled, "acl-enabled", false, "")
-	flags.StringVar(&cmdConfig.ACL.ReplicationToken, "acl-replication-token", "", "")
+	flags.StringVar(&replicationToken, "acl-replication-token", "", "")
 
 	if err := flags.Parse(c.args); err != nil {
 		return nil
@@ -202,6 +203,9 @@ func (c *Command) readConfig() *Config {
 	}
 	if consulToken != "" {
 		cmdConfig.Consul.Token = sensitive.Sensitive(consulToken)
+	}
+	if replicationToken != "" {
+		cmdConfig.ACL.ReplicationToken = sensitive.Sensitive(replicationToken)
 	}
 
 	// Parse the meta flags.

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1030,7 +1030,7 @@ func (c *Command) setupTelemetry(config *Config) (*metrics.InmemSink, error) {
 	if telConfig.CirconusAPIToken != "" || telConfig.CirconusCheckSubmissionURL != "" {
 		cfg := &circonus.Config{}
 		cfg.Interval = telConfig.CirconusSubmissionInterval
-		cfg.CheckManager.API.TokenKey = telConfig.CirconusAPIToken
+		cfg.CheckManager.API.TokenKey = telConfig.CirconusAPIToken.Plaintext()
 		cfg.CheckManager.API.TokenApp = telConfig.CirconusAPIApp
 		cfg.CheckManager.API.URL = telConfig.CirconusAPIURL
 		cfg.CheckManager.Check.SubmissionURL = telConfig.CirconusCheckSubmissionURL

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -559,7 +559,7 @@ type Telemetry struct {
 	// CirconusAPIToken is a valid API Token used to create/manage check. If provided,
 	// metric management is enabled.
 	// Default: none
-	CirconusAPIToken string `hcl:"circonus_api_token"`
+	CirconusAPIToken sensitive.Sensitive `hcl:"circonus_api_token"`
 	// CirconusAPIApp is an app name associated with API token.
 	// Default: "nomad"
 	CirconusAPIApp string `hcl:"circonus_api_app"`

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/go-sockaddr/template"
 	client "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -320,7 +321,7 @@ type ACLConfig struct {
 	// ReplicationToken is used by servers to replicate tokens and policies
 	// from the authoritative region. This must be a valid management token
 	// within the authoritative region.
-	ReplicationToken string `hcl:"replication_token"`
+	ReplicationToken sensitive.Sensitive `hcl:"replication_token"`
 
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -17,6 +17,7 @@ import (
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/websocket"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/tlsutil"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/rs/cors"
@@ -447,9 +448,9 @@ func parseNamespace(req *http.Request, n *string) {
 }
 
 // parseToken is used to parse the X-Nomad-Token param
-func (s *HTTPServer) parseToken(req *http.Request, token *string) {
+func (s *HTTPServer) parseToken(req *http.Request, token *sensitive.Sensitive) {
 	if other := req.Header.Get("X-Nomad-Token"); other != "" {
-		*token = other
+		*token = sensitive.Sensitive(other)
 		return
 	}
 }

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -397,7 +398,7 @@ func TestParseToken(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	var token string
+	var token sensitive.Sensitive
 	s.Server.parseToken(req, &token)
 	if token != "foobar" {
 		t.Fatalf("bad %s", token)
@@ -677,7 +678,7 @@ func httpACLTest(t testing.TB, cb func(c *Config), f func(srv *TestAgent)) {
 }
 
 func setToken(req *http.Request, token *structs.ACLToken) {
-	req.Header.Set("X-Nomad-Token", token.SecretID)
+	req.Header.Set("X-Nomad-Token", token.SecretID.Plaintext())
 }
 
 func encodeReq(obj interface{}) io.ReadCloser {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/snappy"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/jobspec"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -410,7 +411,7 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 		PolicyOverride: args.PolicyOverride,
 		WriteRequest: structs.WriteRequest{
 			Region:    sJob.Region,
-			AuthToken: args.WriteRequest.SecretID,
+			AuthToken: sensitive.Sensitive(args.WriteRequest.SecretID),
 		},
 	}
 	// parseWriteRequest overrides Namespace, Region and AuthToken

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -281,7 +281,7 @@ func TestJobStatusCommand_WithAccessPolicy(t *testing.T) {
 	assert.NotNil(token, "failed to bootstrap ACL token")
 
 	// Wait for client ready
-	client.SetSecretID(token.SecretID)
+	client.SetSecretID(token.SecretID.Plaintext())
 	testutil.WaitForResult(func() (bool, error) {
 		nodes, _, err := client.Nodes().List(nil)
 		if err != nil {
@@ -307,23 +307,23 @@ func TestJobStatusCommand_WithAccessPolicy(t *testing.T) {
 	cmd := &JobStatusCommand{Meta: Meta{Ui: ui, flagAddress: url}}
 
 	// registering a job without a token fails
-	client.SetSecretID(invalidToken.SecretID)
+	client.SetSecretID(invalidToken.SecretID.Plaintext())
 	resp, _, err := client.Jobs().Register(j, nil)
 	assert.NotNil(err)
 
 	// registering a job with a valid token succeeds
-	client.SetSecretID(token.SecretID)
+	client.SetSecretID(token.SecretID.Plaintext())
 	resp, _, err = client.Jobs().Register(j, nil)
 	assert.Nil(err)
 	code := waitForSuccess(ui, client, fullId, t, resp.EvalID)
 	assert.Equal(0, code)
 
 	// Request Job List without providing a valid token
-	code = cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID, "-short"})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID.Plaintext(), "-short"})
 	assert.Equal(1, code)
 
 	// Request Job List with a valid token
-	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, "-short"})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID.Plaintext(), "-short"})
 	assert.Equal(0, code)
 
 	out := ui.OutputWriter.String()

--- a/e2e/vault/vault_test.go
+++ b/e2e/vault/vault_test.go
@@ -15,10 +15,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
@@ -207,7 +208,7 @@ func testVaultCompatibility(t *testing.T, vault string, version string) {
 			c.Vault = &config.VaultConfig{}
 		}
 		c.Vault.Enabled = helper.BoolToPtr(true)
-		c.Vault.Token = token
+		c.Vault.Token = sensitive.Sensitive(token)
 		c.Vault.Role = "nomad-cluster"
 		c.Vault.AllowUnauthenticated = helper.BoolToPtr(true)
 		c.Vault.Addr = v.HTTPAddr

--- a/helper/sensitive/sensitive.go
+++ b/helper/sensitive/sensitive.go
@@ -1,0 +1,20 @@
+package sensitive
+
+import "encoding/json"
+
+type Sensitive string
+
+func (s Sensitive) Plaintext() string {
+	return string(s)
+}
+
+func (s Sensitive) String() string {
+	if s == "" {
+		return ""
+	}
+	return "[REDACTED]"
+}
+
+func (s Sensitive) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}

--- a/helper/sensitive/sensitive_test.go
+++ b/helper/sensitive/sensitive_test.go
@@ -1,0 +1,110 @@
+package sensitive
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+	"github.com/ugorji/go/codec"
+)
+
+func TestSensitive_Plaintext(t *testing.T) {
+	s := Sensitive("super-secret-value")
+	require.Equal(t, "super-secret-value", s.Plaintext())
+	require.Equal(t, "[REDACTED]", s.String())
+}
+
+func TestSensitive_Sprintf(t *testing.T) {
+	s := Sensitive("super-secret-value")
+
+	v := fmt.Sprintf("VALUE IS %v %s", s, s)
+	require.Equal(t, "VALUE IS [REDACTED] [REDACTED]", v)
+	require.NotContains(t, v, s.Plaintext())
+}
+
+func TestSensitive_JSON_Marshal(t *testing.T) {
+	s := Sensitive("super-secret-value")
+
+	b, err := json.Marshal([]interface{}{s})
+	require.NoError(t, err)
+	require.Equal(t, `["[REDACTED]"]`, string(b))
+	require.NotContains(t, string(b), s.Plaintext())
+}
+
+func TestSensitive_JSON_Unmarshal(t *testing.T) {
+	var val struct {
+		P string
+		S Sensitive
+	}
+
+	err := json.Unmarshal([]byte(`{"P": "value", "S": "sensitive"}`), &val)
+	require.NoError(t, err)
+	require.Equal(t, "value", val.P)
+	require.Equal(t, "sensitive", val.S.Plaintext())
+}
+
+func TestSensitive_HCLog_Text(t *testing.T) {
+	s := Sensitive("super-secret-value")
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{
+		Output: &buf,
+	})
+
+	logger.Info("my log line", "value", s)
+
+	require.Contains(t, buf.String(), `my log line: value=[REDACTED]`)
+	require.NotContains(t, buf.String(), s.Plaintext())
+}
+
+func TestSensitive_HCLog_Json(t *testing.T) {
+	s := Sensitive("super-secret-value")
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{
+		JSONFormat: true,
+		Output:     &buf,
+	})
+
+	logger.Info("my log line", "value", s)
+
+	require.Contains(t, buf.String(), `"value":"[REDACTED]"`)
+	require.NotContains(t, buf.String(), s.Plaintext())
+}
+
+func TestSensitive_UgorjiGo_Json(t *testing.T) {
+	s := Sensitive("super-secret-value")
+
+	h := &codec.JsonHandle{HTMLCharsAsIs: true}
+
+	var buf bytes.Buffer
+	enc := codec.NewEncoder(&buf, h)
+	require.NoError(t, enc.Encode(s))
+
+	var out Sensitive
+	dec := codec.NewDecoder(&buf, h)
+	require.NoError(t, dec.Decode(&out))
+
+	require.Equal(t, out, s)
+	require.Equal(t, "super-secret-value", out.Plaintext())
+}
+
+func TestSensitive_UgorjiGo_MsgPack(t *testing.T) {
+	s := Sensitive("super-secret-value")
+
+	h := &codec.MsgpackHandle{}
+
+	var buf bytes.Buffer
+	enc := codec.NewEncoder(&buf, h)
+	require.NoError(t, enc.Encode(s))
+
+	var out Sensitive
+	dec := codec.NewDecoder(&buf, h)
+	require.NoError(t, dec.Decode(&out))
+
+	require.Equal(t, out, s)
+	require.Equal(t, "super-secret-value", out.Plaintext())
+}

--- a/internal/testing/apitests/jobs_test.go
+++ b/internal/testing/apitests/jobs_test.go
@@ -56,7 +56,7 @@ func TestJobs_Summary_WithACL(t *testing.T) {
 	invalidToken := mock.ACLToken()
 
 	// Registering with an invalid  token should fail
-	c.SetSecretID(invalidToken.SecretID)
+	c.SetSecretID(invalidToken.SecretID.Plaintext())
 	job := testJob()
 	_, _, err := jobs.Register(job, nil)
 	assert.NotNil(err)
@@ -70,7 +70,7 @@ func TestJobs_Summary_WithACL(t *testing.T) {
 	assertWriteMeta(t, wm)
 
 	// Query the job summary with an invalid token should fail
-	c.SetSecretID(invalidToken.SecretID)
+	c.SetSecretID(invalidToken.SecretID.Plaintext())
 	result, _, err := jobs.Summary(*job.ID, nil)
 	assert.NotNil(err)
 

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -6,13 +6,14 @@ import (
 	metrics "github.com/armon/go-metrics"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // ResolveToken is used to translate an ACL Token Secret ID into
 // an ACL object, nil if ACLs are disabled, or an error.
-func (s *Server) ResolveToken(secretID string) (*acl.ACL, error) {
+func (s *Server) ResolveToken(secretID sensitive.Sensitive) (*acl.ACL, error) {
 	// Fast-path if ACLs are disabled
 	if !s.config.ACLEnabled {
 		return nil, nil
@@ -38,7 +39,7 @@ func (s *Server) ResolveToken(secretID string) (*acl.ACL, error) {
 // resolveTokenFromSnapshotCache is used to resolve an ACL object from a snapshot of state,
 // using a cache to avoid parsing and ACL construction when possible. It is split from resolveToken
 // to simplify testing.
-func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *lru.TwoQueueCache, secretID string) (*acl.ACL, error) {
+func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *lru.TwoQueueCache, secretID sensitive.Sensitive) (*acl.ACL, error) {
 	// Lookup the ACL Token
 	var token *structs.ACLToken
 	var err error

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -11,6 +11,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -382,7 +383,7 @@ func (a *ACL) Bootstrap(args *structs.ACLTokenBootstrapRequest, reply *structs.A
 	// Create a new global management token, override any parameter
 	args.Token = &structs.ACLToken{
 		AccessorID: uuid.Generate(),
-		SecretID:   uuid.Generate(),
+		SecretID:   sensitive.Sensitive(uuid.Generate()),
 		Name:       "Bootstrap Token",
 		Type:       structs.ACLManagementToken,
 		Global:     true,
@@ -500,7 +501,7 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.A
 		// Generate an accessor and secret ID if new
 		if token.AccessorID == "" {
 			token.AccessorID = uuid.Generate()
-			token.SecretID = uuid.Generate()
+			token.SecretID = sensitive.Sensitive(uuid.Generate())
 			token.CreateTime = time.Now().UTC()
 
 		} else {

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -1140,7 +1141,7 @@ func TestACLEndpoint_ResolveToken(t *testing.T) {
 	assert.Equal(t, token, resp.Token)
 
 	// Lookup non-existing token
-	get.SecretID = uuid.Generate()
+	get.SecretID = sensitive.Sensitive(uuid.Generate())
 	if err := msgpackrpc.CallWithCodec(codec, "ACL.ResolveToken", get, &resp); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -5,6 +5,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
@@ -43,7 +44,7 @@ func TestResolveACLToken(t *testing.T) {
 	assert.NotNil(t, aclObj)
 
 	// Attempt resolution of unknown token. Should fail.
-	randID := uuid.Generate()
+	randID := sensitive.Sensitive(uuid.Generate())
 	aclObj, err = resolveTokenFromSnapshotCache(snap, cache, randID)
 	assert.Equal(t, structs.ErrTokenNotFound, err)
 	assert.Nil(t, aclObj)

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/client"
 	"github.com/hashicorp/nomad/client/config"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -84,7 +85,7 @@ func TestClientAllocations_GarbageCollectAll_Local_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -385,7 +386,7 @@ func TestClientAllocations_GarbageCollect_Local_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -673,7 +674,7 @@ func TestClientAllocations_Stats_Local_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -1023,7 +1024,7 @@ func TestClientAllocations_Restart_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{

--- a/nomad/client_fs_endpoint_test.go
+++ b/nomad/client_fs_endpoint_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/client"
 	"github.com/hashicorp/nomad/client/config"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -129,7 +130,7 @@ func TestClientFS_List_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -403,7 +404,7 @@ func TestClientFS_Stat_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -633,7 +634,7 @@ func TestClientFS_Streaming_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{
@@ -1460,7 +1461,7 @@ func TestClientFS_Logs_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{

--- a/nomad/client_stats_endpoint_test.go
+++ b/nomad/client_stats_endpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/nomad/client"
 	"github.com/hashicorp/nomad/client/config"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -76,7 +77,7 @@ func TestClientStats_Stats_Local_ACL(t *testing.T) {
 
 	cases := []struct {
 		Name          string
-		Token         string
+		Token         sensitive.Sensitive
 		ExpectedError string
 	}{
 		{

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -264,7 +265,7 @@ type Config struct {
 
 	// ReplicationToken is the ACL Token Secret ID used to fetch from
 	// the Authoritative Region.
-	ReplicationToken string
+	ReplicationToken sensitive.Sensitive
 
 	// SentinelGCInterval is the interval that we GC unused policies.
 	SentinelGCInterval time.Duration

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler"
@@ -160,7 +161,7 @@ OUTER:
 }
 
 // jobReap contacts the leader and issues a reap on the passed jobs
-func (c *CoreScheduler) jobReap(jobs []*structs.Job, leaderACL string) error {
+func (c *CoreScheduler) jobReap(jobs []*structs.Job, leaderACL sensitive.Sensitive) error {
 	// Call to the leader to issue the reap
 	for _, req := range c.partitionJobReap(jobs, leaderACL) {
 		var resp structs.JobBatchDeregisterResponse
@@ -176,7 +177,7 @@ func (c *CoreScheduler) jobReap(jobs []*structs.Job, leaderACL string) error {
 // partitionJobReap returns a list of JobBatchDeregisterRequests to make,
 // ensuring a single request does not contain too many jobs. This is necessary
 // to ensure that the Raft transaction does not become too large.
-func (c *CoreScheduler) partitionJobReap(jobs []*structs.Job, leaderACL string) []*structs.JobBatchDeregisterRequest {
+func (c *CoreScheduler) partitionJobReap(jobs []*structs.Job, leaderACL sensitive.Sensitive) []*structs.JobBatchDeregisterRequest {
 	option := &structs.JobDeregisterOptions{Purge: true}
 	var requests []*structs.JobBatchDeregisterRequest
 	submittedJobs := 0

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -12,6 +12,7 @@ import (
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -319,7 +320,7 @@ func TestJobEndpoint_Register_ACL(t *testing.T) {
 	cases := []struct {
 		Name        string
 		Job         *structs.Job
-		Token       string
+		Token       sensitive.Sensitive
 		ErrExpected bool
 	}{
 		{

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -17,6 +17,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -182,7 +183,7 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 
 	// Generate a leader ACL token. This will allow the leader to issue work
 	// that requires a valid ACL token.
-	s.setLeaderAcl(uuid.Generate())
+	s.setLeaderAcl(sensitive.Sensitive(uuid.Generate()))
 
 	// Disable workers to free half the cores for use in the plan queue and
 	// evaluation broker

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"
@@ -12,7 +13,7 @@ import (
 func Node() *structs.Node {
 	node := &structs.Node{
 		ID:         uuid.Generate(),
-		SecretID:   uuid.Generate(),
+		SecretID:   sensitive.Sensitive(uuid.Generate()),
 		Datacenter: "dc1",
 		Name:       "foobar",
 		Drivers: map[string]*structs.DriverInfo{
@@ -874,7 +875,7 @@ func ACLPolicy() *structs.ACLPolicy {
 func ACLToken() *structs.ACLToken {
 	tk := &structs.ACLToken{
 		AccessorID:  uuid.Generate(),
-		SecretID:    uuid.Generate(),
+		SecretID:    sensitive.Sensitive(uuid.Generate()),
 		Name:        "my cool token " + uuid.Generate(),
 		Type:        "client",
 		Policies:    []string{"foo", "bar"},
@@ -890,7 +891,7 @@ func ACLToken() *structs.ACLToken {
 func ACLManagementToken() *structs.ACLToken {
 	return &structs.ACLToken{
 		AccessorID:  uuid.Generate(),
-		SecretID:    uuid.Generate(),
+		SecretID:    sensitive.Sensitive(uuid.Generate()),
 		Name:        "management " + uuid.Generate(),
 		Type:        "management",
 		Global:      true,

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -16,6 +16,7 @@ import (
 	vapi "github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -952,7 +953,7 @@ func (n *Node) GetClientAllocs(args *structs.NodeSpecificRequest,
 			}
 
 			reply.Allocs = make(map[string]uint64)
-			reply.MigrateTokens = make(map[string]string)
+			reply.MigrateTokens = make(map[string]sensitive.Sensitive)
 
 			// preferTableIndex is used to determine whether we should build the
 			// response index based on the full table indexes versus the modify

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -11,6 +11,7 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
@@ -194,7 +195,7 @@ func TestClientEndpoint_Register_SecretMismatch(t *testing.T) {
 	}
 
 	// Update the nodes SecretID
-	node.SecretID = uuid.Generate()
+	node.SecretID = sensitive.Sensitive(uuid.Generate())
 	err := msgpackrpc.CallWithCodec(codec, "Node.Register", req, &resp)
 	if err == nil || !strings.Contains(err.Error(), "Not registering") {
 		t.Fatalf("Expecting error regarding mismatching secret id: %v", err)
@@ -2776,7 +2777,7 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 
 	req := &structs.DeriveVaultTokenRequest{
 		NodeID:   node.ID,
-		SecretID: uuid.Generate(),
+		SecretID: sensitive.Sensitive(uuid.Generate()),
 		AllocID:  alloc.ID,
 		Tasks:    tasks,
 		QueryOptions: structs.QueryOptions{

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -15,7 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/agent/consul/autopilot"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/codec"
 	"github.com/hashicorp/nomad/helper/pool"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/stats"
 	"github.com/hashicorp/nomad/helper/tlsutil"
 	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
@@ -213,7 +214,7 @@ type Server struct {
 
 	// leaderAcl is the management ACL token that is valid when resolved by the
 	// current leader.
-	leaderAcl     string
+	leaderAcl     sensitive.Sensitive
 	leaderAclLock sync.Mutex
 
 	// statsFetcher is used by autopilot to check the status of the other
@@ -1390,14 +1391,14 @@ func (s *Server) State() *state.StateStore {
 }
 
 // setLeaderAcl stores the given ACL token as the current leader's ACL token.
-func (s *Server) setLeaderAcl(token string) {
+func (s *Server) setLeaderAcl(token sensitive.Sensitive) {
 	s.leaderAclLock.Lock()
 	s.leaderAcl = token
 	s.leaderAclLock.Unlock()
 }
 
 // getLeaderAcl retrieves the leader's ACL token
-func (s *Server) getLeaderAcl() string {
+func (s *Server) getLeaderAcl() sensitive.Sensitive {
 	s.leaderAclLock.Lock()
 	defer s.leaderAclLock.Unlock()
 	return s.leaderAcl
@@ -1510,7 +1511,7 @@ func (s *Server) GetConfig() *Config {
 
 // ReplicationToken returns the token used for replication. We use a method to support
 // dynamic reloading of this value later.
-func (s *Server) ReplicationToken() string {
+func (s *Server) ReplicationToken() sensitive.Sensitive {
 	return s.config.ReplicationToken
 }
 

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -221,7 +222,7 @@ func TestServer_Reload_Vault(t *testing.T) {
 	tr := true
 	config := DefaultConfig()
 	config.VaultConfig.Enabled = &tr
-	config.VaultConfig.Token = uuid.Generate()
+	config.VaultConfig.Token = sensitive.Sensitive(uuid.Generate())
 
 	if err := s1.Reload(config); err != nil {
 		t.Fatalf("Reload failed: %v", err)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -12,6 +12,7 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -956,10 +957,10 @@ func (s *StateStore) NodesByIDPrefix(ws memdb.WatchSet, nodeID string) (memdb.Re
 }
 
 // NodeBySecretID is used to lookup a node by SecretID
-func (s *StateStore) NodeBySecretID(ws memdb.WatchSet, secretID string) (*structs.Node, error) {
+func (s *StateStore) NodeBySecretID(ws memdb.WatchSet, secretID sensitive.Sensitive) (*structs.Node, error) {
 	txn := s.db.Txn(false)
 
-	watchCh, existing, err := txn.FirstWatch("nodes", "secret_id", secretID)
+	watchCh, existing, err := txn.FirstWatch("nodes", "secret_id", secretID.Plaintext())
 	if err != nil {
 		return nil, fmt.Errorf("node lookup by SecretID failed: %v", err)
 	}
@@ -3784,10 +3785,10 @@ func (s *StateStore) ACLTokenByAccessorID(ws memdb.WatchSet, id string) (*struct
 }
 
 // ACLTokenBySecretID is used to lookup a token by secret ID
-func (s *StateStore) ACLTokenBySecretID(ws memdb.WatchSet, secretID string) (*structs.ACLToken, error) {
+func (s *StateStore) ACLTokenBySecretID(ws memdb.WatchSet, secretID sensitive.Sensitive) (*structs.ACLToken, error) {
 	txn := s.db.Txn(false)
 
-	watchCh, existing, err := txn.FirstWatch("acl_token", "secret", secretID)
+	watchCh, existing, err := txn.FirstWatch("acl_token", "secret", secretID.Plaintext())
 	if err != nil {
 		return nil, fmt.Errorf("acl token lookup failed: %v", err)
 	}

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -3,6 +3,7 @@ package config
 import (
 	"time"
 
+	"github.com/hashicorp/nomad/helper/sensitive"
 	vault "github.com/hashicorp/vault/api"
 )
 
@@ -28,7 +29,7 @@ type VaultConfig struct {
 	// Token is the Vault token given to Nomad such that it can
 	// derive child tokens. Nomad will renew this token at half its lease
 	// lifetime.
-	Token string `hcl:"token"`
+	Token sensitive.Sensitive `hcl:"token"`
 
 	// Role sets the role in which to create tokens from. The Token given to
 	// Nomad does not have to be created from this role but must have "update"

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -742,10 +743,10 @@ func TestCompileACLObject(t *testing.T) {
 func TestGenerateMigrateToken(t *testing.T) {
 	assert := assert.New(t)
 	allocID := uuid.Generate()
-	nodeSecret := uuid.Generate()
+	nodeSecret := sensitive.Sensitive(uuid.Generate())
 	token, err := GenerateMigrateToken(allocID, nodeSecret)
 	assert.Nil(err)
-	_, err = base64.URLEncoding.DecodeString(token)
+	_, err = base64.URLEncoding.DecodeString(token.Plaintext())
 	assert.Nil(err)
 
 	assert.True(CompareMigrateToken(allocID, nodeSecret, token))

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -25,11 +25,12 @@ import (
 
 	"github.com/gorhill/cronexpr"
 	hcodec "github.com/hashicorp/go-msgpack/codec"
-	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-version"
+	multierror "github.com/hashicorp/go-multierror"
+	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/args"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/lib/kheap"
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"
@@ -231,7 +232,7 @@ type QueryOptions struct {
 	Prefix string
 
 	// AuthToken is secret portion of the ACL token used for the request
-	AuthToken string
+	AuthToken sensitive.Sensitive
 
 	InternalRpcInfo
 }
@@ -276,7 +277,7 @@ type WriteRequest struct {
 	Namespace string
 
 	// AuthToken is secret portion of the ACL token used for the request
-	AuthToken string
+	AuthToken sensitive.Sensitive
 
 	InternalRpcInfo
 }
@@ -450,7 +451,7 @@ type NodeEvaluateRequest struct {
 // NodeSpecificRequest is used when we just need to specify a target node
 type NodeSpecificRequest struct {
 	NodeID   string
-	SecretID string
+	SecretID sensitive.Sensitive
 	QueryOptions
 }
 
@@ -835,7 +836,7 @@ type ServerMember struct {
 // following tasks in the given allocation
 type DeriveVaultTokenRequest struct {
 	NodeID   string
-	SecretID string
+	SecretID sensitive.Sensitive
 	AllocID  string
 	Tasks    []string
 	QueryOptions
@@ -1098,7 +1099,7 @@ type NodeClientAllocsResponse struct {
 
 	// MigrateTokens are used when ACLs are enabled to allow cross node,
 	// authenticated access to sticky volumes
-	MigrateTokens map[string]string
+	MigrateTokens map[string]sensitive.Sensitive
 
 	QueryMeta
 }
@@ -1510,7 +1511,7 @@ type Node struct {
 	// SecretID is an ID that is only known by the Node and the set of Servers.
 	// It is not accessible via the API and is used to authenticate nodes
 	// conducting privileged activities.
-	SecretID string
+	SecretID sensitive.Sensitive
 
 	// Datacenter for this node
 	Datacenter string
@@ -8431,7 +8432,7 @@ type Evaluation struct {
 	// LeaderACL provides the ACL token to when issuing RPCs back to the
 	// leader. This will be a valid management token as long as the leader is
 	// active. This should not ever be exposed via the API.
-	LeaderACL string
+	LeaderACL sensitive.Sensitive
 
 	// SnapshotIndex is the Raft index of the snapshot used to process the
 	// evaluation. The index will either be set when it has gone through the
@@ -9159,12 +9160,12 @@ type ACLPolicyUpsertRequest struct {
 
 // ACLToken represents a client token which is used to Authenticate
 type ACLToken struct {
-	AccessorID  string   // Public Accessor ID (UUID)
-	SecretID    string   // Secret ID, private (UUID)
-	Name        string   // Human friendly name
-	Type        string   // Client or Management
-	Policies    []string // Policies this token ties to
-	Global      bool     // Global or Region local
+	AccessorID  string              // Public Accessor ID (UUID)
+	SecretID    sensitive.Sensitive // Secret ID, private (UUID)
+	Name        string              // Human friendly name
+	Type        string              // Client or Management
+	Policies    []string            // Policies this token ties to
+	Global      bool                // Global or Region local
 	Hash        []byte
 	CreateTime  time.Time // Time of creation
 	CreateIndex uint64
@@ -9314,7 +9315,7 @@ type ACLTokenSetResponse struct {
 
 // ResolveACLTokenRequest is used to resolve a specific token
 type ResolveACLTokenRequest struct {
-	SecretID string
+	SecretID sensitive.Sensitive
 	QueryOptions
 }
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -9,7 +9,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
@@ -4516,7 +4517,7 @@ func TestNode_Copy(t *testing.T) {
 
 	node := &Node{
 		ID:         uuid.Generate(),
-		SecretID:   uuid.Generate(),
+		SecretID:   sensitive.Sensitive(uuid.Generate()),
 		Datacenter: "dc1",
 		Name:       "foobar",
 		Attributes: map[string]string{

--- a/nomad/structs/testing.go
+++ b/nomad/structs/testing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/uuid"
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"
 )
@@ -36,7 +37,7 @@ func NodeResourcesToAllocatedResources(n *NodeResources) *AllocatedResources {
 func MockNode() *Node {
 	node := &Node{
 		ID:         uuid.Generate(),
-		SecretID:   uuid.Generate(),
+		SecretID:   sensitive.Sensitive(uuid.Generate()),
 		Datacenter: "dc1",
 		Name:       "foobar",
 		Attributes: map[string]string{

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -15,6 +15,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	vapi "github.com/hashicorp/vault/api"
@@ -198,7 +199,7 @@ type vaultClient struct {
 	connEstablishedErr error
 
 	// token is the raw token used by the client
-	token string
+	token sensitive.Sensitive
 
 	// tokenData is the data of the passed Vault token
 	tokenData *tokenData
@@ -437,7 +438,7 @@ func (v *vaultClient) buildClient() error {
 
 	// Set the token
 	v.token = v.config.Token
-	client.SetToken(v.token)
+	client.SetToken(v.token.Plaintext())
 	v.auth = client.Auth().Token()
 
 	return nil

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -72,7 +73,7 @@ path "secret/*" {
 
 // defaultTestVaultWhitelistRoleAndToken creates a test Vault role and returns a token
 // created in that role
-func defaultTestVaultWhitelistRoleAndToken(v *testutil.TestVault, t *testing.T, rolePeriod int) string {
+func defaultTestVaultWhitelistRoleAndToken(v *testutil.TestVault, t *testing.T, rolePeriod int) sensitive.Sensitive {
 	vaultPolicies := map[string]string{
 		"nomad-role-create":     nomadRoleCreatePolicy,
 		"nomad-role-management": nomadRoleManagementPolicy,
@@ -86,7 +87,7 @@ func defaultTestVaultWhitelistRoleAndToken(v *testutil.TestVault, t *testing.T, 
 
 // defaultTestVaultBlacklistRoleAndToken creates a test Vault role using
 // disallowed_policies and returns a token created in that role
-func defaultTestVaultBlacklistRoleAndToken(v *testutil.TestVault, t *testing.T, rolePeriod int) string {
+func defaultTestVaultBlacklistRoleAndToken(v *testutil.TestVault, t *testing.T, rolePeriod int) sensitive.Sensitive {
 	vaultPolicies := map[string]string{
 		"nomad-role-create":     nomadRoleCreatePolicy,
 		"nomad-role-management": nomadRoleManagementPolicy,
@@ -113,14 +114,14 @@ func defaultTestVaultBlacklistRoleAndToken(v *testutil.TestVault, t *testing.T, 
 		t.Fatalf("bad secret response: %+v", s)
 	}
 
-	return s.Auth.ClientToken
+	return sensitive.Sensitive(s.Auth.ClientToken)
 }
 
 // testVaultRoleAndToken writes the vaultPolicies to vault and then creates a
 // test role with the passed data. After that it derives a token from the role
 // with the tokenPolicies
 func testVaultRoleAndToken(v *testutil.TestVault, t *testing.T, vaultPolicies map[string]string,
-	data map[string]interface{}, tokenPolicies []string) string {
+	data map[string]interface{}, tokenPolicies []string) sensitive.Sensitive {
 	// Write the policies
 	sys := v.Client.Sys()
 	for p, data := range vaultPolicies {
@@ -148,7 +149,7 @@ func testVaultRoleAndToken(v *testutil.TestVault, t *testing.T, vaultPolicies ma
 		t.Fatalf("bad secret response: %+v", s)
 	}
 
-	return s.Auth.ClientToken
+	return sensitive.Sensitive(s.Auth.ClientToken)
 }
 
 func TestVaultClient_BadConfig(t *testing.T) {
@@ -428,7 +429,7 @@ func TestVaultClient_ValidateRole_NonExistant(t *testing.T) {
 	defer v.Stop()
 
 	v.Config.Token = defaultTestVaultWhitelistRoleAndToken(v, t, 5)
-	v.Config.Token = v.RootToken
+	v.Config.Token = sensitive.Sensitive(v.RootToken)
 	logger := testlog.HCLogger(t)
 	v.Config.ConnectionRetryIntv = 100 * time.Millisecond
 	v.Config.Role = "test-nonexistent"
@@ -695,7 +696,7 @@ func TestVaultClient_RenewalLoop(t *testing.T) {
 
 	// Get the current TTL
 	a := v.Client.Auth().Token()
-	s2, err := a.Lookup(v.Config.Token)
+	s2, err := a.Lookup(v.Config.Token.Plaintext())
 	if err != nil {
 		t.Fatalf("failed to lookup token: %v", err)
 	}
@@ -728,7 +729,7 @@ func TestVaultClientRenewUpdatesExpiration(t *testing.T) {
 
 	// Get the current TTL
 	a := v.Client.Auth().Token()
-	s2, err := a.Lookup(v.Config.Token)
+	s2, err := a.Lookup(v.Config.Token.Plaintext())
 	if err != nil {
 		t.Fatalf("failed to lookup token: %v", err)
 	}
@@ -804,7 +805,7 @@ func TestVaultClient_LoopsUntilCannotRenew(t *testing.T) {
 
 	// Get the current TTL
 	a := v.Client.Auth().Token()
-	s2, err := a.Lookup(v.Config.Token)
+	s2, err := a.Lookup(v.Config.Token.Plaintext())
 	if err != nil {
 		t.Fatalf("failed to lookup token: %v", err)
 	}
@@ -850,7 +851,7 @@ func TestVaultClient_LookupToken_Invalid(t *testing.T) {
 	conf := &config.VaultConfig{
 		Enabled: &tr,
 		Addr:    "http://foobar:12345",
-		Token:   uuid.Generate(),
+		Token:   sensitive.Sensitive(uuid.Generate()),
 	}
 
 	// Enable vault but use a bad address so it never establishes a conn
@@ -884,7 +885,7 @@ func TestVaultClient_LookupToken_Root(t *testing.T) {
 	waitForConnection(client, t)
 
 	// Lookup ourselves
-	s, err := client.LookupToken(context.Background(), v.Config.Token)
+	s, err := client.LookupToken(context.Background(), v.Config.Token.Plaintext())
 	if err != nil {
 		t.Fatalf("self lookup failed: %v", err)
 	}
@@ -949,7 +950,7 @@ func TestVaultClient_LookupToken_Role(t *testing.T) {
 	waitForConnection(client, t)
 
 	// Lookup ourselves
-	s, err := client.LookupToken(context.Background(), v.Config.Token)
+	s, err := client.LookupToken(context.Background(), v.Config.Token.Plaintext())
 	if err != nil {
 		t.Fatalf("self lookup failed: %v", err)
 	}
@@ -1021,7 +1022,7 @@ func TestVaultClient_LookupToken_RateLimit(t *testing.T) {
 	for i := 0; i < numRequests; i++ {
 		go func() {
 			// Lookup ourselves
-			_, err := client.LookupToken(ctx, v.Config.Token)
+			_, err := client.LookupToken(ctx, v.Config.Token.Plaintext())
 			if err != nil {
 				if err == context.Canceled {
 					cancels += 1
@@ -1335,7 +1336,7 @@ func TestVaultClient_CreateToken_Prestart(t *testing.T) {
 	t.Parallel()
 	vconfig := &config.VaultConfig{
 		Enabled: helper.BoolToPtr(true),
-		Token:   uuid.Generate(),
+		Token:   sensitive.Sensitive(uuid.Generate()),
 		Addr:    "http://127.0.0.1:0",
 	}
 
@@ -1368,7 +1369,7 @@ func TestVaultClient_RevokeTokens_PreEstablishs(t *testing.T) {
 	t.Parallel()
 	vconfig := &config.VaultConfig{
 		Enabled: helper.BoolToPtr(true),
-		Token:   uuid.Generate(),
+		Token:   sensitive.Sensitive(uuid.Generate()),
 		Addr:    "http://127.0.0.1:0",
 	}
 	logger := testlog.HCLogger(t)

--- a/testutil/vault.go
+++ b/testutil/vault.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/lib/freeport"
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -69,7 +70,7 @@ func NewTestVaultFromPath(t testing.T, binary string) *TestVault {
 			Client:    client,
 			Config: &config.VaultConfig{
 				Enabled: &enable,
-				Token:   token,
+				Token:   sensitive.Sensitive(token),
 				Addr:    http,
 			},
 		}
@@ -157,7 +158,7 @@ func NewTestVaultDelayed(t testing.T) *TestVault {
 		Client:    client,
 		Config: &config.VaultConfig{
 			Enabled: &enable,
-			Token:   token,
+			Token:   sensitive.Sensitive(token),
 			Addr:    http,
 		},
 	}

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/hashicorp/nomad/helper/sensitive"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/kr/pretty"
 	testing "github.com/mitchellh/go-testing-interface"
@@ -127,7 +128,7 @@ func WaitForVotingMembers(t testing.T, rpc rpcFn, nPeers int) {
 }
 
 // RegisterJobWithToken registers a job and uses the job's Region and Namespace.
-func RegisterJobWithToken(t testing.T, rpc rpcFn, job *structs.Job, token string) {
+func RegisterJobWithToken(t testing.T, rpc rpcFn, job *structs.Job, token sensitive.Sensitive) {
 	WaitForResult(func() (bool, error) {
 		args := &structs.JobRegisterRequest{}
 		args.Job = job
@@ -148,7 +149,7 @@ func RegisterJob(t testing.T, rpc rpcFn, job *structs.Job) {
 	RegisterJobWithToken(t, rpc, job, "")
 }
 
-func WaitForRunningWithToken(t testing.T, rpc rpcFn, job *structs.Job, token string) []*structs.AllocListStub {
+func WaitForRunningWithToken(t testing.T, rpc rpcFn, job *structs.Job, token sensitive.Sensitive) []*structs.AllocListStub {
 	RegisterJobWithToken(t, rpc, job, token)
 
 	var resp structs.JobAllocationsResponse


### PR DESCRIPTION
Nomad has sensitive keys (e.g. ACL/Vault/Consul tokens) that Nomad ought not to log or expose in HTTP.  One approach is to wrap the values in types such that they get redacted when logged.

Here, I attempt this approach to report early feedback and finding.

In this implementation, I introduce `Sensitive` string wrapper that is automatically redacted when logged and serialized in json but not when persisted in client state or RPC responses.  To access the value, one must use the `Plaintext()` method to access value.

My experience has been relatively mixed:
* We have many sensitive values that get persisted and returned in APIs (e.g. ACL Tokens is the clear example)
  * Some sensitive keys are never persisted or passed around (e.g. replication/consul/telemetry tokens).
* Redaction on logging but not on API response is quite accidental.
  * HCLLog uses `encoding/json` while agent http handler and persistence uses `ugorji/go` for serialization.
  * Use use serialization to pass values to auxiliary processes (e.g. external drivers) and we may need to pass some sensitive tokens
  * when using the same library, it's not trivial to redacted based on context.

Though the approach is neat, given that we pass secrets around in RPC, I am not fully convinced this is useful as it is.

Some possible next steps:
* introduce a `Secret` level for values that should only be stored in memory and never persisted or returned in API/RPC.
* Change app such that we only expose a secret id once and never again.
  * allowing users to list and query for token secretID provides an additional escalation vector when combined with another data leakage (see https://github.com/hashicorp/nomad/issues/6430).
  * ???