### PR TITLE
nomad: fix dropped error in TestJobEndpoint_Deregister_ACL

### DIFF
--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -2117,6 +2117,7 @@ func TestJobEndpoint_Deregister_ACL(t *testing.T) {
 	// Create and register a job
 	job := mock.Job()
 	err := state.UpsertJob(100, job)
+	require.Nil(err)
 
 	// Deregister and purge
 	req := &structs.JobDeregisterRequest{


### PR DESCRIPTION
This PR picks up a dropped error variable in the `TestJobEndpoint_Deregister_ACL()` function in the `nomad` package.