### PR TITLE
client: fix panic from 0.8 -> 0.10 upgrade

### DIFF
--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -63,7 +63,8 @@ func newServiceHook(c serviceHookConfig) *serviceHook {
 		delay:     c.task.ShutdownDelay,
 	}
 
-	// COMPAT(0.10): Just use the AllocatedResources
+	// COMPAT(0.11): AllocatedResources was added in 0.9 so assume its set
+	//               in 0.11.
 	if c.alloc.AllocatedResources != nil {
 		if res := c.alloc.AllocatedResources.Tasks[c.task.Name]; res != nil {
 			h.networks = res.Networks
@@ -115,7 +116,8 @@ func (h *serviceHook) Update(ctx context.Context, req *interfaces.TaskUpdateRequ
 		canary = req.Alloc.DeploymentStatus.Canary
 	}
 
-	// COMPAT(0.10): Just use the AllocatedResources
+	// COMPAT(0.11): AllocatedResources was added in 0.9 so assume its set
+	//               in 0.11.
 	var networks structs.Networks
 	if req.Alloc.AllocatedResources != nil {
 		if res := req.Alloc.AllocatedResources.Tasks[h.taskName]; res != nil {

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -301,7 +301,7 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		}
 		tr.taskResources = tres
 	} else {
-		// COMPAT(0.10): Upgrade from old resources to new resources
+		// COMPAT(0.11): Upgrade from 0.8 resources to 0.9+ resources
 		// Grab the old task resources
 		oldTr, ok := tr.alloc.TaskResources[tr.taskName]
 		if !ok {


### PR DESCRIPTION
makeAllocTaskServices did not do a nil check on AllocatedResources
which causes a panic when upgrading directly from 0.8 to 0.10. While
skipping 0.9 is not supported we intend to fix serious crashers caused
by such upgrades to prevent cluster outages.

I did a quick audit of the client package and everywhere else that
accesses AllocatedResources appears to be properly guarded by a nil
check.