### PR TITLE
docs: note bridge-nf-call-iptables requirement for Connect

### DIFF
--- a/website/source/guides/install/production/requirements.html.md
+++ b/website/source/guides/install/production/requirements.html.md
@@ -87,3 +87,23 @@ $ cat /proc/sys/net/ipv4/ip_local_port_range
 32768   60999
 $ echo "49152 65535" > /proc/sys/net/ipv4/ip_local_port_range
 ```
+
+## Bridge Networking and `iptables`
+
+Nomad's task group networks and Consul Connect integration use bridge networking and iptables to send traffic between containers. The Linux kernel bridge module has three "tunables" that control whether traffic crossing the bridge are processed by iptables. Some operating systems (RedHat, CentOS, and Fedora in particular) configure these tunables to optimize for VM workloads where iptables rules might not be correctly configured for guest traffic.
+
+These tunables can be set to allow iptables processing for the bridge network as follows:
+
+```
+$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
+$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
+$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
+```
+
+To preserve these settings on startup of a client node, add a file including the following to `/etc/sysctl.d/` or remove the file your Linux distribution puts in that directory.
+
+```
+net.bridge.bridge-nf-call-arptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+```

--- a/website/source/guides/integrations/consul-connect/index.html.md
+++ b/website/source/guides/integrations/consul-connect/index.html.md
@@ -115,6 +115,27 @@ $ sudo mkdir -p /opt/cni/bin
 $ sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
 ```
 
+Ensure the your Linux operating system distribution has been configured to allow
+container traffic through the bridge network to be routed via iptables. These
+tunables can be set as follows:
+
+```
+$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
+$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
+$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
+```
+
+To preserve these settings on startup of a client node, add a file including the
+following to `/etc/sysctl.d/` or remove the file your Linux distribution puts in
+that directory.
+
+```
+net.bridge.bridge-nf-call-arptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+```
+
+
 ## Run the Connect-enabled Services
 
 Once Nomad and Consul are running, submit the following Connect-enabled services


### PR DESCRIPTION
For #6580

The Connect integration uses bridge networking and iptables to send traffic between containers. But the RedHat family of Linux distros sets some of the kernel tunables we need to be optimized for VMs rather than containers. We can document this behavior for now and consider better operator feedback for pre-flight checking later.

Note that arguably this is something that should get fixed in the upstream CNI plugins, but changing this kernel tunable silently sounds problematic from Nomad's perspective as it would probably break workloads running with the QEMU task driver.