### PR TITLE
Prevent nomad alloc status output inconsistency

### DIFF
--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -286,6 +286,9 @@ func TestAllocStatusCommand_ScoreMetrics(t *testing.T) {
 	require.Contains(out, "Placement Metrics")
 	require.Contains(out, mockNode1.ID)
 	require.Contains(out, mockNode2.ID)
+
+	// assert we sort headers alphabetically
+	require.Contains(out, "binpack  node-affinity")
 	require.Contains(out, "final score")
 }
 

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -380,7 +381,16 @@ func formatAllocMetrics(metrics *api.AllocationMetric, scores bool, prefix strin
 				// Add header as first row
 				if i == 0 {
 					scoreOutput[0] = "Node|"
-					for scorerName := range scoreMeta.Scores {
+
+					// sort scores alphabetically
+					scores := make([]string, 0, len(scoreMeta.Scores))
+					for score := range scoreMeta.Scores {
+						scores = append(scores, score)
+					}
+					sort.Strings(scores)
+
+					// build score header output
+					for _, scorerName := range scores {
 						scoreOutput[0] += fmt.Sprintf("%v|", scorerName)
 						scorerNames = append(scorerNames, scorerName)
 					}


### PR DESCRIPTION
Prevent random map ordering and sort alphabetically

Fixes #6335