### PR TITLE
fix broken test expectation from message change

### DIFF
--- a/command/node_drain_test.go
+++ b/command/node_drain_test.go
@@ -238,7 +238,7 @@ func TestNodeDrainCommand_Monitor(t *testing.T) {
 			require.Contains(out, fmt.Sprintf("Alloc %q draining", a.ID))
 		}
 
-		expected := fmt.Sprintf("All allocations on node %q have stopped.\n", nodeID)
+		expected := fmt.Sprintf("All allocations on node %q have stopped\n", nodeID)
 		if !strings.HasSuffix(out, expected) {
 			t.Fatalf("expected output to end with:\n%s", expected)
 		}


### PR DESCRIPTION
Fixes a failing test that has been broken on master since I merged in the seemingly innocuous https://github.com/hashicorp/nomad/pull/5956 yesterday. This will also let us get the tests green for the open PRs from dependabot