### PR TITLE
website - add -moz-osx-font-smoothing for smooth firefox osx fonts

### DIFF
--- a/website/source/assets/stylesheets/_global.scss
+++ b/website/source/assets/stylesheets/_global.scss
@@ -7,6 +7,7 @@ html {
 }
 
 body {
+  -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   color: $body-font-color;
   background-color: $white;


### PR DESCRIPTION
Adding `-moz-osx-font-smoothing: grayscale;` to `<body>`  in `global-styles` to smooth out fonts in Firefox on OSX.

Note that we are already using `-webkit-font-smoothing: antialiased;`.

#### Before
![Screen Shot 2019-11-07 at 12 28 21 PM](https://user-images.githubusercontent.com/5368111/68420828-67e58180-015a-11ea-8211-245902ca04ce.png)


---

### After
![Screen Shot 2019-11-07 at 12 28 29 PM](https://user-images.githubusercontent.com/5368111/68420799-5c925600-015a-11ea-8366-277d91aaefb4.png)

