### PR TITLE
decompress response body from websocket error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
  * nomad: Multiple connect enabled services in the same taskgroup failed to
    register [[GH-6646](https://github.com/hashicorp/nomad/issues/6646)]
  * scheduler: Changes to devices in resource stanza should cause rescheduling [[GH-6644](https://github.com/hashicorp/nomad/issues/6644)]
+ * api: Decompress web socket response body if gzipped on error responses [[GH-6650](https://github.com/hashicorp/nomad/issues/6650)]
  
 ## 0.10.1 (November 4, 2019)
 

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -9,7 +9,7 @@ import (
 
 	"time"
 
-	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -148,20 +148,12 @@ func TestAllocations_RescheduleInfo(t *testing.T) {
 	}
 	job.Canonicalize()
 
-	uuidGen := func() string {
-		ret, err := uuid.GenerateUUID()
-		if err != nil {
-			t.Fatal(err)
-		}
-		return ret
-	}
-
 	alloc := &Allocation{
-		ID:        uuidGen(),
+		ID:        uuid.Generate(),
 		Namespace: DefaultNamespace,
-		EvalID:    uuidGen(),
+		EvalID:    uuid.Generate(),
 		Name:      "foo-bar[1]",
-		NodeID:    uuidGen(),
+		NodeID:    uuid.Generate(),
 		TaskGroup: *job.TaskGroups[0].Name,
 		JobID:     *job.ID,
 		Job:       job,
@@ -273,20 +265,12 @@ func TestAllocations_ExecErrors(t *testing.T) {
 	}
 	job.Canonicalize()
 
-	uuidGen := func() string {
-		ret, err := uuid.GenerateUUID()
-		if err != nil {
-			t.Fatal(err)
-		}
-		return ret
-	}
-
 	alloc := &Allocation{
 		ID:        "",
 		Namespace: DefaultNamespace,
-		EvalID:    uuidGen(),
+		EvalID:    uuid.Generate(),
 		Name:      "foo-bar[1]",
-		NodeID:    uuidGen(),
+		NodeID:    uuid.Generate(),
 		TaskGroup: *job.TaskGroups[0].Name,
 		JobID:     *job.ID,
 		Job:       job,


### PR DESCRIPTION
If a websocket connection errors we currently return the error with a
copy of the response body. The response body from the websocket can
often times be gzipped, so check if the content-encoding was gzipped
and decompress.

Example error responses that were getting appended:

```
 �JK��IMQ(�W�M,*�H�QH���M�KQ��+�W�*�ϳR��P��W04��'�~�-
```
which was the result of the following response body
```
 Reader: (*bytes.Reader)(0xc00014a540)({
  s: ([]uint8) (len=69 cap=1024) {
   00000000  1f 8b 08 00 00 00 00 00  00 ff 4a 4b cc cc 49 4d  |..........JK..IM|
   00000010  51 28 c9 57 c8 4d 2c 2a  ce 48 cc 51 48 ce cf cd  |Q(.W.M,*.H.QH...|
   00000020  4d cc 4b 51 c8 cc 2b c9  57 c8 2a ce cf b3 52 c8  |M.KQ..+.W.*...R.|
   00000030  cf 50 c8 cb 57 30 34 00  04 00 00 ff ff 27 ea 7e  |.P..W04......'.~|
   00000040  f4 2d 00 00 00                                    |.-...|
  },

```

fixes #6545 