### PR TITLE
return a 404 if not found instead of redirect to ui

### DIFF
--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"reflect"
 	"sort"
@@ -265,8 +266,10 @@ func TestAllocations_ExecErrors(t *testing.T) {
 	}
 	job.Canonicalize()
 
+	allocID := uuid.Generate()
+
 	alloc := &Allocation{
-		ID:        "",
+		ID:        allocID,
 		Namespace: DefaultNamespace,
 		EvalID:    uuid.Generate(),
 		Name:      "foo-bar[1]",
@@ -280,9 +283,10 @@ func TestAllocations_ExecErrors(t *testing.T) {
 
 	// make a request that will result in an error
 	// ensure the error is what we expect
-	_, err := a.Exec(context.Background(), alloc, "bar", false, []string{"command"}, os.Stdin, os.Stdout, os.Stderr, sizeCh, nil)
-	require.Contains(t, err.Error(), "Unexpected response code: 301")
-	require.Contains(t, err.Error(), "Moved Permanently")
+	exitCode, err := a.Exec(context.Background(), alloc, "bar", false, []string{"command"}, os.Stdin, os.Stdout, os.Stderr, sizeCh, nil)
+
+	require.Equal(t, exitCode, -2)
+	require.Equal(t, err.Error(), fmt.Sprintf("Unknown allocation \"%s\"", allocID))
 }
 
 func TestAllocations_ShouldMigrate(t *testing.T) {

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -277,6 +277,11 @@ func handleUI(h http.Handler) http.Handler {
 
 func handleRootRedirect() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
 		http.Redirect(w, req, "/ui/", 307)
 		return
 	})

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -213,7 +213,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 			w.Write([]byte(stubHTML))
 		})
 	}
-	s.mux.Handle("/", handleRootRedirect())
+	s.mux.Handle("/", handleRootFallthrough())
 
 	if enableDebug {
 		s.mux.HandleFunc("/debug/pprof/", pprof.Index)
@@ -275,15 +275,13 @@ func handleUI(h http.Handler) http.Handler {
 	})
 }
 
-func handleRootRedirect() http.Handler {
+func handleRootFallthrough() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path != "/" {
+		if req.URL.Path == "/" {
+			http.Redirect(w, req, "/ui/", 307)
+		} else {
 			w.WriteHeader(http.StatusNotFound)
-			return
 		}
-
-		http.Redirect(w, req, "/ui/", 307)
-		return
 	})
 }
 


### PR DESCRIPTION
If the request path is not equal to `/` 404 instead of redirecting to `/ui`. 

fixes #6656