### PR TITLE
command/agent: Dropped Test Errors

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -162,7 +162,7 @@ func TestAgent_ServerConfig(t *testing.T) {
 	if err := conf.normalizeAddrs(); err != nil {
 		t.Fatalf("error normalizing config: %v", err)
 	}
-	out, err = a.serverConfig()
+	_, err = a.serverConfig()
 	if err == nil || !strings.Contains(err.Error(), "unknown unit") {
 		t.Fatalf("expected unknown unit error, got: %#v", err)
 	}
@@ -172,24 +172,36 @@ func TestAgent_ServerConfig(t *testing.T) {
 		t.Fatalf("error normalizing config: %v", err)
 	}
 	out, err = a.serverConfig()
+	if err != nil {
+		t.Fatalf("error getting server config: %s", err)
+	}
 	if threshold := out.NodeGCThreshold; threshold != time.Second*10 {
 		t.Fatalf("expect 10s, got: %s", threshold)
 	}
 
 	conf.Server.HeartbeatGrace = 37 * time.Second
 	out, err = a.serverConfig()
+	if err != nil {
+		t.Fatalf("error getting server config: %s", err)
+	}
 	if threshold := out.HeartbeatGrace; threshold != time.Second*37 {
 		t.Fatalf("expect 37s, got: %s", threshold)
 	}
 
 	conf.Server.MinHeartbeatTTL = 37 * time.Second
 	out, err = a.serverConfig()
+	if err != nil {
+		t.Fatalf("error getting server config: %s", err)
+	}
 	if min := out.MinHeartbeatTTL; min != time.Second*37 {
 		t.Fatalf("expect 37s, got: %s", min)
 	}
 
 	conf.Server.MaxHeartbeatsPerSecond = 11.0
 	out, err = a.serverConfig()
+	if err != nil {
+		t.Fatalf("error getting server config: %s", err)
+	}
 	if max := out.MaxHeartbeatsPerSecond; max != 11.0 {
 		t.Fatalf("expect 11, got: %v", max)
 	}


### PR DESCRIPTION
This PR picks up four dropped test errors in `command/agent'.