### PR TITLE
vault: check token_explicit_max_ttl as well

### DIFF
--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -880,11 +880,12 @@ func (v *vaultClient) validateRole(role string) error {
 
 	// Read and parse the fields
 	var data struct {
-		ExplicitMaxTtl int `mapstructure:"explicit_max_ttl"`
-		Orphan         bool
-		Period         int
-		TokenPeriod    int `mapstructure:"token_period"`
-		Renewable      bool
+		ExplicitMaxTtl      int `mapstructure:"explicit_max_ttl"`
+		TokenExplicitMaxTtl int `mapstructure:"token_explicit_max_ttl"`
+		Orphan              bool
+		Period              int
+		TokenPeriod         int `mapstructure:"token_period"`
+		Renewable           bool
 	}
 	if err := mapstructure.WeakDecode(rsecret.Data, &data); err != nil {
 		return fmt.Errorf("failed to parse Vault role's data block: %v", err)
@@ -896,7 +897,7 @@ func (v *vaultClient) validateRole(role string) error {
 		multierror.Append(&mErr, fmt.Errorf("Role must allow tokens to be renewed"))
 	}
 
-	if data.ExplicitMaxTtl != 0 {
+	if data.ExplicitMaxTtl != 0 || data.TokenExplicitMaxTtl != 0 {
 		multierror.Append(&mErr, fmt.Errorf("Role can not use an explicit max ttl. Token must be periodic."))
 	}
 

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -295,10 +295,10 @@ func TestVaultClient_ValidateRole(t *testing.T) {
 		"nomad-role-management": nomadRoleManagementPolicy,
 	}
 	data := map[string]interface{}{
-		"allowed_policies": "default,root",
-		"orphan":           true,
-		"renewable":        true,
-		"explicit_max_ttl": 10,
+		"allowed_policies":       "default,root",
+		"orphan":                 true,
+		"renewable":              true,
+		"token_explicit_max_ttl": 10,
 	}
 	v.Config.Token = testVaultRoleAndToken(v, t, vaultPolicies, data, nil)
 
@@ -328,6 +328,7 @@ func TestVaultClient_ValidateRole(t *testing.T) {
 	})
 
 	require.Contains(t, connErr.Error(), "explicit max ttl")
+	require.Contains(t, connErr.Error(), "non-zero period")
 }
 
 // TestVaultClient_ValidateRole_Success asserts that a valid token role


### PR DESCRIPTION
Vault 1.2.0 deprecated `explicit_max_ttl` in favor of `token_explicit_max_ttl`.

Follow up to #6574 .