### PR TITLE
command/agent: Prune Dead Code

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -832,40 +832,6 @@ func (a *Agent) reservePortsForClient(conf *clientconfig.Config) error {
 	return nil
 }
 
-// findLoopbackDevice iterates through all the interfaces on a machine and
-// returns the ip addr, mask of the loopback device
-func (a *Agent) findLoopbackDevice() (string, string, string, error) {
-	var ifcs []net.Interface
-	var err error
-	ifcs, err = net.Interfaces()
-	if err != nil {
-		return "", "", "", err
-	}
-	for _, ifc := range ifcs {
-		addrs, err := ifc.Addrs()
-		if err != nil {
-			return "", "", "", err
-		}
-		for _, addr := range addrs {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-			if ip.IsLoopback() {
-				if ip.To4() == nil {
-					continue
-				}
-				return ifc.Name, ip.String(), addr.String(), nil
-			}
-		}
-	}
-
-	return "", "", "", fmt.Errorf("no loopback devices with IPV4 addr found")
-}
-
 // Leave is used gracefully exit. Clients will inform servers
 // of their departure so that allocations can be rescheduled.
 func (a *Agent) Leave() error {

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -532,15 +532,6 @@ func assertIndex(t *testing.T, resp *httptest.ResponseRecorder) {
 	}
 }
 
-// checkIndex is like assertIndex but returns an error
-func checkIndex(resp *httptest.ResponseRecorder) error {
-	header := resp.Header().Get("X-Nomad-Index")
-	if header == "" || header == "0" {
-		return fmt.Errorf("Bad: %v", header)
-	}
-	return nil
-}
-
 func TestHTTP_VerifyHTTPSClient_AfterConfigReload(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"testing"
 	"time"
 
@@ -642,19 +641,6 @@ func TestHTTP_VerifyHTTPSClient_AfterConfigReload(t *testing.T) {
 		resp.Body.Close()
 		assert.Equal(resp.StatusCode, 200)
 	}
-}
-
-// getIndex parses X-Nomad-Index
-func getIndex(t *testing.T, resp *httptest.ResponseRecorder) uint64 {
-	header := resp.Header().Get("X-Nomad-Index")
-	if header == "" {
-		t.Fatalf("Bad: %v", header)
-	}
-	val, err := strconv.Atoi(header)
-	if err != nil {
-		t.Fatalf("Bad: %v", header)
-	}
-	return uint64(val)
 }
 
 func httpTest(t testing.TB, cb func(c *Config), f func(srv *TestAgent)) {

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -524,14 +524,6 @@ func TestHTTP_VerifyHTTPSClient(t *testing.T) {
 	}
 }
 
-// assertIndex tests that X-Nomad-Index is set and non-zero
-func assertIndex(t *testing.T, resp *httptest.ResponseRecorder) {
-	header := resp.Header().Get("X-Nomad-Index")
-	if header == "" || header == "0" {
-		t.Fatalf("Bad: %v", header)
-	}
-}
-
 func TestHTTP_VerifyHTTPSClient_AfterConfigReload(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/command/agent/testingutils_test.go
+++ b/command/agent/testingutils_test.go
@@ -99,17 +99,6 @@ func MockJob() *api.Job {
 	return job
 }
 
-func MockPeriodicJob() *api.Job {
-	j := MockJob()
-	j.Type = helper.StringToPtr("batch")
-	j.Periodic = &api.PeriodicConfig{
-		Enabled:  helper.BoolToPtr(true),
-		SpecType: helper.StringToPtr("cron"),
-		Spec:     helper.StringToPtr("*/30 * * * *"),
-	}
-	return j
-}
-
 func MockRegionalJob() *api.Job {
 	j := MockJob()
 	j.Region = helper.StringToPtr("north-america")


### PR DESCRIPTION
This PR drops four unused test helper functions and one other function from `command/agent`.