### PR TITLE
remove accidental project leakage in api/ package

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -196,7 +196,7 @@ check: ## Lint the source code
 	@if (git status | grep -q .pb.go); then echo the following proto files are out of sync; git status |grep .pb.go; exit 1; fi
 
 	@echo "==> Check API package is isolated from rest"
-	@! go list -f '{{ join .Deps "\n" }}' ./api | grep github.com/hashicorp/nomad/ | grep -v -e /vendor/ -e /nomad/api/
+	@! go list --test -f '{{ join .Deps "\n" }}' ./api | grep github.com/hashicorp/nomad/ | grep -v -e /vendor/ -e /nomad/api/
 
 .PHONY: checkscripts
 checkscripts: ## Lint shell scripts

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -196,7 +196,7 @@ check: ## Lint the source code
 	@if (git status | grep -q .pb.go); then echo the following proto files are out of sync; git status |grep .pb.go; exit 1; fi
 
 	@echo "==> Check API package is isolated from rest"
-	@! go list --test -f '{{ join .Deps "\n" }}' ./api | grep github.com/hashicorp/nomad/ | grep -v -e /vendor/ -e /nomad/api/
+	@! go list --test -f '{{ join .Deps "\n" }}' ./api | grep github.com/hashicorp/nomad/ | grep -v -e /vendor/ -e /nomad/api/ -e nomad/api.test
 
 .PHONY: checkscripts
 checkscripts: ## Lint shell scripts

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -10,7 +10,6 @@ import (
 
 	"time"
 
-	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -150,11 +149,11 @@ func TestAllocations_RescheduleInfo(t *testing.T) {
 	job.Canonicalize()
 
 	alloc := &Allocation{
-		ID:        uuid.Generate(),
+		ID:        generateUUID(),
 		Namespace: DefaultNamespace,
-		EvalID:    uuid.Generate(),
+		EvalID:    generateUUID(),
 		Name:      "foo-bar[1]",
-		NodeID:    uuid.Generate(),
+		NodeID:    generateUUID(),
 		TaskGroup: *job.TaskGroups[0].Name,
 		JobID:     *job.ID,
 		Job:       job,
@@ -266,14 +265,14 @@ func TestAllocations_ExecErrors(t *testing.T) {
 	}
 	job.Canonicalize()
 
-	allocID := uuid.Generate()
+	allocID := generateUUID()
 
 	alloc := &Allocation{
 		ID:        allocID,
 		Namespace: DefaultNamespace,
-		EvalID:    uuid.Generate(),
+		EvalID:    generateUUID(),
 		Name:      "foo-bar[1]",
-		NodeID:    uuid.Generate(),
+		NodeID:    generateUUID(),
 		TaskGroup: *job.TaskGroups[0].Name,
 		JobID:     *job.ID,
 		Job:       job,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -318,24 +317,16 @@ func TestQueryString(t *testing.T) {
 func TestClient_NodeClient(t *testing.T) {
 	http := "testdomain:4646"
 	tlsNode := func(string, *QueryOptions) (*Node, *QueryMeta, error) {
-		uu, err := uuid.GenerateUUID()
-		if err != nil {
-			t.Fatal(err)
-		}
 		return &Node{
-			ID:         uu,
+			ID:         generateUUID(),
 			Status:     "ready",
 			HTTPAddr:   http,
 			TLSEnabled: true,
 		}, nil, nil
 	}
 	noTlsNode := func(string, *QueryOptions) (*Node, *QueryMeta, error) {
-		uu, err := uuid.GenerateUUID()
-		if err != nil {
-			t.Fatal(err)
-		}
 		return &Node{
-			ID:         uu,
+			ID:         generateUUID(),
 			Status:     "ready",
 			HTTPAddr:   http,
 			TLSEnabled: false,

--- a/api/go.mod
+++ b/api/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/gorilla/websocket v1.4.1
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-rootcerts v1.0.0
-	github.com/hashicorp/go-uuid v1.0.1
 	github.com/kr/pretty v0.1.0
 	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/stretchr/testify v1.3.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -10,8 +10,6 @@ github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVo
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82kpwzSwCI=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
-github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
-github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	crand "crypto/rand"
+	"fmt"
 	"testing"
 )
 
@@ -89,4 +91,19 @@ func int64ToPtr(i int64) *int64 {
 // float64ToPtr returns the pointer to an float64
 func float64ToPtr(f float64) *float64 {
 	return &f
+}
+
+// generateUUID generates a uuid useful for testing only
+func generateUUID() string {
+	buf := make([]byte, 16)
+	if _, err := crand.Read(buf); err != nil {
+		panic(fmt.Errorf("failed to read random bytes: %v", err))
+	}
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
+		buf[0:4],
+		buf[4:6],
+		buf[6:8],
+		buf[8:10],
+		buf[10:16])
 }


### PR DESCRIPTION
nomad /api package should be divested from rest of nomad, to ease go mod adoption; but looks like we accidentally relied on `helper/uuid` due to my bad advice in https://github.com/hashicorp/nomad/pull/6650#discussion_r343906012 .

Removed the accidental complexity, and inlined function to avoid declaring yet another go mod dependency for tests alone.

For some context, go mod treats test dependencies just like regular dependencies; and if github.com/hashicorp/nomad is marked as a dependency, then api users may need to declaring dependency on all of nomad main project transitively, which causes sadness given main app isn't go mod friendly yet and the project dependencies are many and large.