### PR TITLE
vault: allow overriding implicit vault constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ BUG FIXES:
  * scheduler: Changes to devices in resource stanza should cause rescheduling [[GH-6644](https://github.com/hashicorp/nomad/issues/6644)]
  * api: Decompress web socket response body if gzipped on error responses [[GH-6650](https://github.com/hashicorp/nomad/issues/6650)]
  * api: Return a 404 if endpoint not found instead of redirecting to /ui/ [[GH-6658](https://github.com/hashicorp/nomad/issues/6658)]
+ * vault: Allow overriding implicit Vault version constraint [[GH-6687](https://github.com/hashicorp/nomad/issues/6687)]
 
 ## 0.10.1 (November 4, 2019)
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -33,13 +33,6 @@ const (
 )
 
 var (
-	// vaultConstraint is the implicit constraint added to jobs requesting a
-	// Vault token
-	vaultConstraint = &structs.Constraint{
-		LTarget: "${attr.vault.version}",
-		RTarget: ">= 0.6.1",
-		Operand: structs.ConstraintVersion,
-	}
 
 	// allowRescheduleTransition is the transition that allows failed
 	// allocations to be force rescheduled. We create a one off


### PR DESCRIPTION
There's a bug in version parsing that breaks this constraint when using
a prerelease enterprise version of Vault (eg 1.3.0-beta1+ent). While
this does not fix the underlying bug it does provide a workaround for
future issues related to the implicit constraint. Like the implicit
Connect constraint: *all* implicit constraints should be overridable to
allow users to workaround bugs or other factors should the need arise.

Tested locally with `Vault 1.3.0-beta1+ent` and:

```hcl
job "hello" {
  datacenters = ["dc1"]

  group "echo" {
                constraint {
                        attribute = "${attr.vault.version}"
                        operator  = "is_set"
                    }

    task "echo" {

      driver = "raw_exec"
      config {
        command = "sleep"
        args = ["10000"]
      }

      vault {
        policies    = ["default"]
        change_mode = "restart"
      }

      resources {
        cpu    = 100
        memory = 100
        network {
          mbits = 10
        }
      }
    }
  }
}
```