### PR TITLE
Nomad monitor - target remote servers

### DIFF
--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -44,6 +44,9 @@ type MonitorRequest struct {
 	// NodeID is the node we want to track the logs of
 	NodeID string
 
+	// ServerID is the server we want to track the logs of
+	ServerID string
+
 	// PlainText disables base64 encoding.
 	PlainText bool
 

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -175,9 +175,6 @@ func (s *HTTPServer) AgentMonitor(resp http.ResponseWriter, req *http.Request) (
 		return nil, CodedError(400, fmt.Sprintf("Unknown log level: %s", logLevel))
 	}
 
-	// Determine if we are targeting a server or client
-	nodeID := req.URL.Query().Get("node_id")
-
 	logJSON := false
 	logJSONStr := req.URL.Query().Get("log_json")
 	if logJSONStr != "" {
@@ -198,9 +195,11 @@ func (s *HTTPServer) AgentMonitor(resp http.ResponseWriter, req *http.Request) (
 		plainText = parsed
 	}
 
+	nodeID := req.URL.Query().Get("node_id")
 	// Build the request and parse the ACL token
 	args := cstructs.MonitorRequest{
 		NodeID:    nodeID,
+		ServerID:  req.URL.Query().Get("server_id"),
 		LogLevel:  logLevel,
 		LogJSON:   logJSON,
 		PlainText: plainText,

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -205,6 +205,11 @@ func (s *HTTPServer) AgentMonitor(resp http.ResponseWriter, req *http.Request) (
 		PlainText: plainText,
 	}
 
+	// if node and server were requested return error
+	if args.NodeID != "" && args.ServerID != "" {
+		return nil, CodedError(400, "Cannot target node and server simultaneously")
+	}
+
 	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
 
 	// Make the RPC

--- a/command/agent_monitor.go
+++ b/command/agent_monitor.go
@@ -61,12 +61,14 @@ func (c *MonitorCommand) Run(args []string) int {
 
 	var logLevel string
 	var nodeID string
+	var serverID string
 	var logJSON bool
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.StringVar(&logLevel, "log-level", "", "")
 	flags.StringVar(&nodeID, "node-id", "", "")
+	flags.StringVar(&serverID, "server-id", "", "")
 	flags.BoolVar(&logJSON, "json", false, "")
 
 	if err := flags.Parse(args); err != nil {
@@ -90,6 +92,7 @@ func (c *MonitorCommand) Run(args []string) int {
 	params := map[string]string{
 		"log_level": logLevel,
 		"node_id":   nodeID,
+		"server_id": serverID,
 		"log_json":  strconv.FormatBool(logJSON),
 	}
 

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -117,6 +117,107 @@ OUTER:
 	}
 }
 
+func TestMonitor_MonitorRemoteLeader(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// start servers
+	s1 := TestServer(t, nil)
+	defer s1.Shutdown()
+	s2 := TestServer(t, func(c *Config) {
+		c.DevDisableBootstrap = true
+	})
+	defer s2.Shutdown()
+	TestJoin(t, s1, s2)
+	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForLeader(t, s2.RPC)
+
+	servers := []*Server{s1, s2}
+	var nonLeader *Server
+	var leader *Server
+	for _, s := range servers {
+		if !s.IsLeader() {
+			nonLeader = s
+		} else {
+			leader = s
+		}
+	}
+
+	go func() {
+		for {
+			leader.logger.Warn("leader log")
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	// No node ID to monitor the remote server
+	req := cstructs.MonitorRequest{
+		LogLevel: "warn",
+		NodeID:   "leader",
+	}
+
+	handler, err := nonLeader.StreamingRpcHandler("Agent.Monitor")
+	require.Nil(err)
+
+	// create pipe
+	p1, p2 := net.Pipe()
+	defer p1.Close()
+	defer p2.Close()
+
+	errCh := make(chan error)
+	streamMsg := make(chan *cstructs.StreamErrWrapper)
+
+	go handler(p2)
+
+	// Start decoder
+	go func() {
+		decoder := codec.NewDecoder(p1, structs.MsgpackHandle)
+		for {
+			var msg cstructs.StreamErrWrapper
+			if err := decoder.Decode(&msg); err != nil {
+				if err == io.EOF || strings.Contains(err.Error(), "closed") {
+					return
+				}
+				errCh <- fmt.Errorf("error decoding: %v", err)
+			}
+
+			streamMsg <- &msg
+		}
+	}()
+
+	// send request
+	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
+	require.Nil(encoder.Encode(req))
+
+	timeout := time.After(2 * time.Second)
+	expected := "leader log"
+	received := ""
+
+OUTER:
+	for {
+		select {
+		case <-timeout:
+			t.Fatal("timeout waiting for logs")
+		case err := <-errCh:
+			t.Fatal(err)
+		case msg := <-streamMsg:
+			if msg.Error != nil {
+				t.Fatalf("Got error: %v", msg.Error.Error())
+			}
+
+			var frame sframer.StreamFrame
+			err := json.Unmarshal(msg.Payload, &frame)
+			assert.NoError(t, err)
+
+			received += string(frame.Data)
+			if strings.Contains(received, expected) {
+				require.Nil(p2.Close())
+				break OUTER
+			}
+		}
+	}
+}
+
 func TestMonitor_MonitorServer(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/client"
 	"github.com/hashicorp/nomad/client/config"
@@ -22,7 +23,7 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
-func TestMonitor_Monitor_Remote_Server(t *testing.T) {
+func TestMonitor_Monitor_Remote_Client(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
@@ -117,9 +118,8 @@ OUTER:
 	}
 }
 
-func TestMonitor_MonitorRemoteLeader(t *testing.T) {
+func TestMonitor_Monitor_RemoteServer(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
 	// start servers
 	s1 := TestServer(t, nil)
@@ -132,6 +132,7 @@ func TestMonitor_MonitorRemoteLeader(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 
+	// determine leader and nonleader
 	servers := []*Server{s1, s2}
 	var nonLeader *Server
 	var leader *Server
@@ -143,78 +144,127 @@ func TestMonitor_MonitorRemoteLeader(t *testing.T) {
 		}
 	}
 
-	go func() {
-		for {
-			leader.logger.Warn("leader log")
-			time.Sleep(10 * time.Millisecond)
-		}
-	}()
-
-	// No node ID to monitor the remote server
-	req := cstructs.MonitorRequest{
-		LogLevel: "warn",
-		NodeID:   "leader",
+	cases := []struct {
+		desc        string
+		serverID    string
+		expectedLog string
+		logger      hclog.InterceptLogger
+		origin      *Server
+	}{
+		{
+			desc:        "remote leader",
+			serverID:    "leader",
+			expectedLog: "leader log",
+			logger:      leader.logger,
+			origin:      nonLeader,
+		},
+		{
+			desc:        "remote server",
+			serverID:    nonLeader.serf.LocalMember().Name,
+			expectedLog: "nonleader log",
+			logger:      nonLeader.logger,
+			origin:      leader,
+		},
+		{
+			desc:        "serverID is current leader",
+			serverID:    "leader",
+			expectedLog: "leader log",
+			logger:      leader.logger,
+			origin:      leader,
+		},
+		{
+			desc:        "serverID is current server",
+			serverID:    nonLeader.serf.LocalMember().Name,
+			expectedLog: "non leader log",
+			logger:      nonLeader.logger,
+			origin:      nonLeader,
+		},
 	}
 
-	handler, err := nonLeader.StreamingRpcHandler("Agent.Monitor")
-	require.Nil(err)
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require := require.New(t)
 
-	// create pipe
-	p1, p2 := net.Pipe()
-	defer p1.Close()
-	defer p2.Close()
-
-	errCh := make(chan error)
-	streamMsg := make(chan *cstructs.StreamErrWrapper)
-
-	go handler(p2)
-
-	// Start decoder
-	go func() {
-		decoder := codec.NewDecoder(p1, structs.MsgpackHandle)
-		for {
-			var msg cstructs.StreamErrWrapper
-			if err := decoder.Decode(&msg); err != nil {
-				if err == io.EOF || strings.Contains(err.Error(), "closed") {
-					return
+			// send some specific logs
+			doneCh := make(chan struct{})
+			go func() {
+				for {
+					select {
+					case <-doneCh:
+						return
+					default:
+						tc.logger.Warn(tc.expectedLog)
+						time.Sleep(10 * time.Millisecond)
+					}
 				}
-				errCh <- fmt.Errorf("error decoding: %v", err)
+			}()
+
+			req := cstructs.MonitorRequest{
+				LogLevel: "warn",
+				ServerID: tc.serverID,
 			}
 
-			streamMsg <- &msg
-		}
-	}()
+			handler, err := tc.origin.StreamingRpcHandler("Agent.Monitor")
+			require.Nil(err)
 
-	// send request
-	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+			// create pipe
+			p1, p2 := net.Pipe()
+			defer p1.Close()
+			defer p2.Close()
 
-	timeout := time.After(2 * time.Second)
-	expected := "leader log"
-	received := ""
+			errCh := make(chan error)
+			streamMsg := make(chan *cstructs.StreamErrWrapper)
 
-OUTER:
-	for {
-		select {
-		case <-timeout:
-			t.Fatal("timeout waiting for logs")
-		case err := <-errCh:
-			t.Fatal(err)
-		case msg := <-streamMsg:
-			if msg.Error != nil {
-				t.Fatalf("Got error: %v", msg.Error.Error())
+			go handler(p2)
+
+			// Start decoder
+			go func() {
+				decoder := codec.NewDecoder(p1, structs.MsgpackHandle)
+				for {
+					var msg cstructs.StreamErrWrapper
+					if err := decoder.Decode(&msg); err != nil {
+						if err == io.EOF || strings.Contains(err.Error(), "closed") {
+							return
+						}
+						errCh <- fmt.Errorf("error decoding: %v", err)
+					}
+
+					streamMsg <- &msg
+				}
+			}()
+
+			// send request
+			encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
+			require.Nil(encoder.Encode(req))
+
+			timeout := time.After(2 * time.Second)
+			received := ""
+
+		OUTER:
+			for {
+				select {
+				case <-timeout:
+					t.Fatal("timeout waiting for logs")
+				case err := <-errCh:
+					t.Fatal(err)
+				case msg := <-streamMsg:
+					if msg.Error != nil {
+						t.Fatalf("Got error: %v", msg.Error.Error())
+					}
+
+					var frame sframer.StreamFrame
+					err := json.Unmarshal(msg.Payload, &frame)
+					assert.NoError(t, err)
+
+					received += string(frame.Data)
+					if strings.Contains(received, tc.expectedLog) {
+						close(doneCh)
+						require.Nil(p2.Close())
+						break OUTER
+					}
+				}
 			}
-
-			var frame sframer.StreamFrame
-			err := json.Unmarshal(msg.Payload, &frame)
-			assert.NoError(t, err)
-
-			received += string(frame.Data)
-			if strings.Contains(received, expected) {
-				require.Nil(p2.Close())
-				break OUTER
-			}
-		}
+		})
 	}
 }
 

--- a/website/source/api/agent.html.md
+++ b/website/source/api/agent.html.md
@@ -518,15 +518,19 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `log-level` `(string: "info")` - Specifies a text string containing a log level
+- `log_level` `(string: "info")` - Specifies a text string containing a log level
   to filter on, such as `info`. Possible values include `trace`, `debug`,
   `info`, `warn`, `error`
 
 - `json` `(bool: false)` - Specifies if the log format for streamed logs 
   should be JSON.
 
-- `node-id` `(string: "a57b2adb-1a30-2dda-8df0-25abb0881952")` - Specifies a text
+- `node_id` `(string: "a57b2adb-1a30-2dda-8df0-25abb0881952")` - Specifies a text
   string containing a node-id to target for streaming.
+
+- `server_id` `(string: "server1.global")` - Specifies a text
+  string containing a server name or "leader" to target a specific remote server
+  or leader for streaming.
 
 - `plain` `(bool: false)` - Specifies if the response should be JSON or
   plaintext
@@ -535,7 +539,10 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://localhost:4646/v1/agent/monitor?log-level=debug&node-id=a57b2adb-1a30-2dda-8df0-25abb0881952
+    https://localhost:4646/v1/agent/monitor?log_level=debug&server_id=leader
+
+$ curl \
+    https://localhost:4646/v1/agent/monitor?log_level=debug&node_id=a57b2adb-1a30-2dda-8df0-25abb0881952
 ```
 
 ### Sample Response

--- a/website/source/docs/commands/monitor.html.md.erb
+++ b/website/source/docs/commands/monitor.html.md.erb
@@ -37,6 +37,10 @@ The monitor command also allows you to specify a single client node id to follow
 - `-node-id`: Specifies the client node-id to stream logs from. If no
 node-id is given the nomad server from the -address flag will be used.
 
+- `-server-id`: Specifies the nomad server id to stream logs from. Accepts
+server names from `nomad server members` and also a special `leader` option
+which will target the current leader.
+
 - `-json`: Stream logs in json format
 
 ## Examples


### PR DESCRIPTION
Adds a new flag to nomad monitor `-server-id` which accepts either a server name from `nomad server members` (ex `server1.global`) or `leader` to target the leader server.

fixes #6643