### PR TITLE
Getter: allow the GCS download scheme

### DIFF
--- a/client/allocrunner/taskrunner/getter/getter.go
+++ b/client/allocrunner/taskrunner/getter/getter.go
@@ -18,7 +18,7 @@ var (
 	lock    sync.Mutex
 
 	// supported is the set of download schemes supported by Nomad
-	supported = []string{"http", "https", "s3", "hg", "git"}
+	supported = []string{"http", "https", "s3", "hg", "git", "gcs"}
 )
 
 const (

--- a/client/allocrunner/taskrunner/getter/getter_test.go
+++ b/client/allocrunner/taskrunner/getter/getter_test.go
@@ -343,6 +343,13 @@ func TestGetGetterUrl_Queries(t *testing.T) {
 			output: "bucket.s3-eu-west-1.amazonaws.com/foo/bar?aws_access_key_id=abcd1234",
 		},
 		{
+			name: "gcs",
+			artifact: &structs.TaskArtifact{
+				GetterSource: "gcs::https://www.googleapis.com/storage/v1/b/d/f",
+			},
+			output: "gcs::https://www.googleapis.com/storage/v1/b/d/f",
+		},
+		{
 			name: "local file",
 			artifact: &structs.TaskArtifact{
 				GetterSource: "/foo/bar",


### PR DESCRIPTION
We're already using a go-getter version that supports GCS downloads, but need to enable the download scheme. This still does not support symlinks in tarballs as referenced in #5445, pending the go-getter merge in https://github.com/hashicorp/go-getter/pull/192