### PR TITLE
api: Pruning

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -786,7 +786,7 @@ func TestJobs_EnforceRegister(t *testing.T) {
 
 	// Create a job and attempt to register it with an incorrect index.
 	job := testJob()
-	resp2, _, err := jobs.EnforceRegister(job, 10, nil)
+	_, _, err = jobs.EnforceRegister(job, 10, nil)
 	require.NotNil(err)
 	require.Contains(err.Error(), RegisterEnforceIndexErrPrefix)
 
@@ -806,7 +806,7 @@ func TestJobs_EnforceRegister(t *testing.T) {
 
 	// Fail at incorrect index
 	curIndex := resp[0].JobModifyIndex
-	resp2, _, err = jobs.EnforceRegister(job, 123456, nil)
+	_, _, err = jobs.EnforceRegister(job, 123456, nil)
 	require.NotNil(err)
 	require.Contains(err.Error(), RegisterEnforceIndexErrPrefix)
 

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -57,29 +57,6 @@ func testPeriodicJob() *Job {
 	return job
 }
 
-func testNamespace() *Namespace {
-	return &Namespace{
-		Name:        "test-namespace",
-		Description: "Testing namespaces",
-	}
-}
-
-func testQuotaSpec() *QuotaSpec {
-	return &QuotaSpec{
-		Name:        "test-namespace",
-		Description: "Testing namespaces",
-		Limits: []*QuotaLimit{
-			{
-				Region: "global",
-				RegionLimit: &Resources{
-					CPU:      intToPtr(2000),
-					MemoryMB: intToPtr(2000),
-				},
-			},
-		},
-	}
-}
-
 // conversions utils only used for testing
 // added here to avoid linter warning
 


### PR DESCRIPTION
Explicitly drop two unused test variables as `_`, remove the unused functions `testNamespace()` and `testQuotaSpec()`.