### PR TITLE
nomad: ensure a unique ClusterID exists when leader (gh-6702)

### DIFF
--- a/nomad/server.go
+++ b/nomad/server.go
@@ -3,6 +3,7 @@ package nomad
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -215,6 +216,10 @@ type Server struct {
 	// current leader.
 	leaderAcl     string
 	leaderAclLock sync.Mutex
+
+	// clusterIDLock ensures the server does not try to concurrently establish
+	// a cluster ID, racing against itself in calls of ClusterID
+	clusterIDLock sync.Mutex
 
 	// statsFetcher is used by autopilot to check the status of the other
 	// Nomad router.
@@ -1516,6 +1521,45 @@ func (s *Server) GetConfig() *Config {
 // dynamic reloading of this value later.
 func (s *Server) ReplicationToken() string {
 	return s.config.ReplicationToken
+}
+
+// ClusterID returns the unique ID for this cluster.
+//
+// Any Nomad server agent may call this method to get at the ID.
+// If we are the leader and the ID has not yet been created, it will
+// be created now. Otherwise an error is returned.
+//
+// The ID will not be created until all participating servers have reached
+// a minimum version (0.10.3).
+func (s *Server) ClusterID() (string, error) {
+	s.clusterIDLock.Lock()
+	defer s.clusterIDLock.Unlock()
+
+	// try to load the cluster ID from state store
+	fsmState := s.fsm.State()
+	existingMeta, err := fsmState.ClusterMetadata()
+	if err != nil {
+		s.logger.Named("core").Error("failed to get cluster ID", "error", err)
+		return "", err
+	}
+
+	// got the cluster ID from state store, cache that and return it
+	if existingMeta != nil && existingMeta.ClusterID != "" {
+		return existingMeta.ClusterID, nil
+	}
+
+	// if we are not the leader, nothing more we can do
+	if !s.IsLeader() {
+		return "", errors.New("cluster ID not ready yet")
+	}
+
+	// we are the leader, try to generate the ID now
+	generatedID, err := s.generateClusterID()
+	if err != nil {
+		return "", err
+	}
+
+	return generatedID, nil
 }
 
 // peersInfoContent is used to help operators understand what happened to the

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -45,6 +45,7 @@ func init() {
 		aclTokenTableSchema,
 		autopilotConfigTableSchema,
 		schedulerConfigTableSchema,
+		clusterMetaTableSchema,
 	}...)
 }
 
@@ -601,6 +602,12 @@ func aclTokenTableSchema() *memdb.TableSchema {
 	}
 }
 
+// singletonRecord can be used to describe tables which should contain only 1 entry.
+// Example uses include storing node config or cluster metadata blobs.
+var singletonRecord = &memdb.ConditionalIndex{
+	Conditional: func(interface{}) (bool, error) { return true, nil },
+}
+
 // schedulerConfigTableSchema returns the MemDB schema for the scheduler config table.
 // This table is used to store configuration options for the scheduler
 func schedulerConfigTableSchema() *memdb.TableSchema {
@@ -611,10 +618,22 @@ func schedulerConfigTableSchema() *memdb.TableSchema {
 				Name:         "id",
 				AllowMissing: true,
 				Unique:       true,
-				// This indexer ensures that this table is a singleton
-				Indexer: &memdb.ConditionalIndex{
-					Conditional: func(obj interface{}) (bool, error) { return true, nil },
-				},
+				Indexer:      singletonRecord, // we store only 1 scheduler config
+			},
+		},
+	}
+}
+
+// clusterMetaTableSchema returns the MemDB schema for the scheduler config table.
+func clusterMetaTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "cluster_meta",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": {
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer:      singletonRecord, // we store only 1 cluster metadata
 			},
 		},
 	}

--- a/nomad/state/schema_test.go
+++ b/nomad/state/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStateStoreSchema(t *testing.T) {
@@ -12,4 +13,74 @@ func TestStateStoreSchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+}
+
+func TestState_singleRecord(t *testing.T) {
+	require := require.New(t)
+
+	const (
+		singletonTable = "cluster_meta"
+		singletonIDIdx = "id"
+	)
+
+	db, err := memdb.NewMemDB(&memdb.DBSchema{
+		Tables: map[string]*memdb.TableSchema{
+			singletonTable: clusterMetaTableSchema(),
+		},
+	})
+	require.NoError(err)
+
+	// numRecords in table counts all the items in the table, which is expected
+	// to always be 1 since that's the point of the singletonRecord Indexer.
+	numRecordsInTable := func() int {
+		txn := db.Txn(false)
+		defer txn.Abort()
+
+		iter, err := txn.Get(singletonTable, singletonIDIdx)
+		require.NoError(err)
+
+		num := 0
+		for item := iter.Next(); item != nil; item = iter.Next() {
+			num++
+		}
+		return num
+	}
+
+	// setSingleton "updates" the singleton record in the singletonTable,
+	// which requires that the singletonRecord Indexer is working as
+	// expected.
+	setSingleton := func(s string) {
+		txn := db.Txn(true)
+		err := txn.Insert(singletonTable, s)
+		require.NoError(err)
+		txn.Commit()
+	}
+
+	// first retrieves the one expected entry in the singletonTable - use the
+	// numRecordsInTable helper function to make the cardinality assertion,
+	// this is just for fetching the value.
+	first := func() string {
+		txn := db.Txn(false)
+		defer txn.Abort()
+		record, err := txn.First(singletonTable, singletonIDIdx)
+		require.NoError(err)
+		s, ok := record.(string)
+		require.True(ok)
+		return s
+	}
+
+	// Ensure that multiple Insert & Commit calls result in only
+	// a single "singleton" record existing in the table.
+
+	setSingleton("one")
+	require.Equal(1, numRecordsInTable())
+	require.Equal("one", first())
+
+	setSingleton("two")
+	require.Equal(1, numRecordsInTable())
+	require.Equal("two", first())
+
+	setSingleton("three")
+	require.Equal(1, numRecordsInTable())
+	require.Equal("three", first())
 }

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -7083,7 +7083,6 @@ func TestStateStore_SchedulerConfig(t *testing.T) {
 
 	require := require.New(t)
 	restore, err := state.Restore()
-
 	require.Nil(err)
 
 	err = restore.SchedulerConfigRestore(schedConfig)
@@ -7096,6 +7095,45 @@ func TestStateStore_SchedulerConfig(t *testing.T) {
 	require.Equal(schedConfig.ModifyIndex, modIndex)
 
 	require.Equal(schedConfig, out)
+}
+
+func TestStateStore_ClusterMetadata(t *testing.T) {
+	require := require.New(t)
+
+	state := testStateStore(t)
+	clusterID := "12345678-1234-1234-1234-1234567890"
+	now := time.Now().UnixNano()
+	meta := &structs.ClusterMetadata{ClusterID: clusterID, CreateTime: now}
+
+	err := state.ClusterSetMetadata(100, meta)
+	require.NoError(err)
+
+	result, err := state.ClusterMetadata()
+	require.NoError(err)
+	require.Equal(clusterID, result.ClusterID)
+	require.Equal(now, result.CreateTime)
+}
+
+func TestStateStore_ClusterMetadataRestore(t *testing.T) {
+	require := require.New(t)
+
+	state := testStateStore(t)
+	clusterID := "12345678-1234-1234-1234-1234567890"
+	now := time.Now().UnixNano()
+	meta := &structs.ClusterMetadata{ClusterID: clusterID, CreateTime: now}
+
+	restore, err := state.Restore()
+	require.NoError(err)
+
+	err = restore.ClusterMetadataRestore(meta)
+	require.NoError(err)
+
+	restore.Commit()
+
+	out, err := state.ClusterMetadata()
+	require.NoError(err)
+	require.Equal(clusterID, out.ClusterID)
+	require.Equal(now, out.CreateTime)
 }
 
 func TestStateStore_Abandon(t *testing.T) {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -82,6 +82,7 @@ const (
 	BatchNodeUpdateDrainRequestType
 	SchedulerConfigRequestType
 	NodeBatchDeregisterRequestType
+	ClusterMetadataRequestType
 )
 
 const (
@@ -836,6 +837,12 @@ type ServerMember struct {
 	DelegateMin uint8
 	DelegateMax uint8
 	DelegateCur uint8
+}
+
+// ClusterMetadata is used to store per-cluster metadata.
+type ClusterMetadata struct {
+	ClusterID  string
+	CreateTime int64
 }
 
 // DeriveVaultTokenRequest is used to request wrapped Vault tokens for the


### PR DESCRIPTION
As leader, check to see if a ClusterID has already been generated
and replicated through the raft log. If one has not been generated,
generate a UUID and push it through. If a ClusterID has been generated,
its value is applied into the state store. The value is not actually
used anywhere in this changeset, but is a prerequisite for gh-6701.

Similar [prior art](https://github.com/hashicorp/consul/blob/master/agent/consul/leader_connect.go#L57) in consul. 