### PR TITLE
e2e/cli/command: close after error handling

### DIFF
--- a/e2e/cli/command/run.go
+++ b/e2e/cli/command/run.go
@@ -192,7 +192,6 @@ func (c *Run) runTest(opts *runOpts) (*TestReport, error) {
 	cmd := exec.Command(goBin, opts.goArgs()...)
 	cmd.Env = opts.goEnv()
 	out, err := cmd.StdoutPipe()
-	defer out.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -200,6 +199,13 @@ func (c *Run) runTest(opts *runOpts) (*TestReport, error) {
 	err = cmd.Start()
 	if err != nil {
 		return nil, err
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		// should command fail, log here then proceed to generate test report
+		// to report more informative info about which tests fail
+		c.logger.Error("test command failed", "error", err)
 	}
 
 	dec := NewDecoder(out)


### PR DESCRIPTION
Fix for a spot in `e2e/cli/command` where a deferred `Close()` was happening prior to error handling EDIT: and turn it into a `Wait()`.