### PR TITLE
hclfmt nomad jobspecs

### DIFF
--- a/command/assets/example-short.nomad
+++ b/command/assets/example-short.nomad
@@ -19,7 +19,7 @@ job "example" {
 
         network {
           mbits = 10
-          port "db" {}
+          port  "db"  {}
         }
       }
     }

--- a/command/assets/example.nomad
+++ b/command/assets/example.nomad
@@ -316,7 +316,7 @@ job "example" {
 
         network {
           mbits = 10
-          port "db" {}
+          port  "db"  {}
         }
       }
       # The "service" stanza instructs Nomad to register this task as a service

--- a/dev/docker-clients/client.nomad
+++ b/dev/docker-clients/client.nomad
@@ -23,7 +23,7 @@ job "client" {
 
         network {
           mbits = 10
-          port "http" {}
+          port  "http"{}
         }
       }
 

--- a/e2e/consul/input/consul_example.nomad
+++ b/e2e/consul/input/consul_example.nomad
@@ -49,7 +49,7 @@ job "consul-example" {
 
         network {
           mbits = 10
-          port "db" {}
+          port  "db"  {}
         }
       }
 

--- a/e2e/metrics/input/helloworld.nomad
+++ b/e2e/metrics/input/helloworld.nomad
@@ -29,7 +29,7 @@ job "hello" {
 
         network {
           mbits = 10
-          port "web" {}
+          port  "web" {}
         }
       }
 

--- a/e2e/metrics/input/redis.nomad
+++ b/e2e/metrics/input/redis.nomad
@@ -39,7 +39,7 @@ job "redis" {
 
         network {
           mbits = 10
-          port "db" {}
+          port  "db"  {}
         }
       }
 

--- a/e2e/metrics/input/simpleweb.nomad
+++ b/e2e/metrics/input/simpleweb.nomad
@@ -28,7 +28,7 @@ job "nginx" {
 
         network {
           mbits = 1
-          port "http" {}
+          port  "http"{}
         }
       }
 

--- a/e2e/prometheus/prometheus.nomad
+++ b/e2e/prometheus/prometheus.nomad
@@ -64,7 +64,7 @@ EOH
       resources {
         network {
           mbits = 10
-          port "prometheus_ui" {}
+          port  "prometheus_ui"{}
         }
       }
 


### PR DESCRIPTION
Following https://github.com/hashicorp/nomad/pull/6071, running `make dev` runs [`hclfmt`](https://github.com/fatih/hclfmt) on all the Nomad jobspec files in the repo. The files in this commit are the ones that `hclfmt` is modifying.