### PR TITLE
SetConfig bug in plugin launcher tool

### DIFF
--- a/plugins/shared/cmd/launcher/command/device.go
+++ b/plugins/shared/cmd/launcher/command/device.go
@@ -209,7 +209,7 @@ func (c *Device) setConfig(spec hcldec.Spec, apiVersion string, config []byte, n
 	}
 
 	req := &base.Config{
-		PluginConfig: config,
+		PluginConfig: cdata,
 		AgentConfig:  nmdCfg,
 		ApiVersion:   apiVersion,
 	}


### PR DESCRIPTION
the plugin launcher tool was passing the wrong byte array into SetConfig, resulting in msgpack decoding errors: 
> failed to set config: error="rpc error: code = Unknown desc = SetConfig failed: msgpack decode error [pos 1]: only encoded map or array can be decoded into a struct"

instead of the marshalled cty.Value, it was passing the raw (unparsed, unverified) HCL bytearray.