### PR TITLE
Docs: correct that exec task flag is not optional

### DIFF
--- a/website/source/docs/commands/alloc/exec.html.md.erb
+++ b/website/source/docs/commands/alloc/exec.html.md.erb
@@ -34,7 +34,7 @@ the given job will be chosen.
 
 ## Exec Options
 
-- `-task`: Sets the task to exec command in.  Defaults to first task.
+- `-task`: Sets the task to exec command in.
 
 - `-job`: Use a random allocation from the specified job ID.
 


### PR DESCRIPTION
The task is required, not optional, there’s no default as was described.

You can see here that I’m unable to run `nomad alloc exec` without a task:

<img width="971" alt="A screenshot of a terminal showing errors requiring a task to be specified when running `nomad alloc exec`" src="https://user-images.githubusercontent.com/43280/69168358-217a1600-0abc-11ea-8553-4587024353a3.png">

Re the duplication of “Please specify the task.”, it also happens with logs:

<img width="384" alt="image" src="https://user-images.githubusercontent.com/43280/69168797-f04e1580-0abc-11ea-87a7-781a078b21f1.png">

I think it’s because [`lookupAllocTask`](https://github.com/hashicorp/nomad/blob/master/command/alloc_logs.go#L299) prints the error, as do the [`logs`](https://github.com/hashicorp/nomad/blob/master/command/alloc_logs.go#L193) and [`exec`](https://github.com/hashicorp/nomad/blob/master/command/alloc_exec.go#L197) functions that call it. I’d guess that the `lookupAllocTask` error-printing could be removed but I’m unsure whether that’s true…? Maybe it’s the callers that shouldn’t be also printing it? Let me know what you think and I could open another PR if you like.