### PR TITLE
Removes checking constraints for inplace update

### DIFF
--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -363,11 +363,6 @@ func tasksUpdated(jobA, jobB *structs.Job, taskGroup string) bool {
 		return true
 	}
 
-	// Check Constraints
-	if constraintsUpdated(jobA, jobB, taskGroup) {
-		return true
-	}
-
 	// Check Spreads
 	if spreadsUpdated(jobA, jobB, taskGroup) {
 		return true
@@ -489,38 +484,6 @@ func affinitiesUpdated(jobA, jobB *structs.Job, taskGroup string) bool {
 	}
 
 	return !reflect.DeepEqual(aAffinities, bAffinities)
-}
-
-func constraintsUpdated(jobA, jobB *structs.Job, taskGroup string) bool {
-	var aConstraints []*structs.Constraint
-	var bConstraints []*structs.Constraint
-
-	tgA := jobA.LookupTaskGroup(taskGroup)
-	tgB := jobB.LookupTaskGroup(taskGroup)
-
-	// Append jobA job and task group level constraints
-	aConstraints = append(aConstraints, jobA.Constraints...)
-	aConstraints = append(aConstraints, tgA.Constraints...)
-
-	// Append jobB job and task group level constraints
-	bConstraints = append(bConstraints, jobB.Constraints...)
-	bConstraints = append(bConstraints, tgB.Constraints...)
-
-	// Append task constraints
-	for _, task := range tgA.Tasks {
-		aConstraints = append(aConstraints, task.Constraints...)
-	}
-
-	for _, task := range tgB.Tasks {
-		bConstraints = append(bConstraints, task.Constraints...)
-	}
-
-	// Check for equality
-	if len(aConstraints) != len(bConstraints) {
-		return true
-	}
-
-	return !reflect.DeepEqual(aConstraints, bConstraints)
 }
 
 func spreadsUpdated(jobA, jobB *structs.Job, taskGroup string) bool {

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -427,7 +427,7 @@ func TestTaskUpdatedAffinity(t *testing.T) {
 
 	require.True(t, tasksUpdated(j1, j4, name))
 
-	// check different level of same constraint
+	// check different level of same affinity
 	j5 := mock.Job()
 	j5.Affinities = []*structs.Affinity{
 		{
@@ -446,75 +446,6 @@ func TestTaskUpdatedAffinity(t *testing.T) {
 			RTarget: "dc1",
 			Operand: "=",
 			Weight:  100,
-		},
-	}
-
-	require.False(t, tasksUpdated(j5, j6, name))
-}
-
-func TestTaskUpdated_Constraint(t *testing.T) {
-	j1 := mock.Job()
-	j1.Constraints = make([]*structs.Constraint, 0)
-
-	j2 := mock.Job()
-	j2.Constraints = make([]*structs.Constraint, 0)
-
-	name := j1.TaskGroups[0].Name
-	require.False(t, tasksUpdated(j1, j2, name))
-
-	// TaskGroup Constraint
-	j2.TaskGroups[0].Constraints = []*structs.Constraint{
-		{
-			LTarget: "kernel",
-			RTarget: "linux",
-			Operand: "=",
-		},
-	}
-
-	// TaskGroup Task Constraint
-	j3 := mock.Job()
-	j3.Constraints = make([]*structs.Constraint, 0)
-
-	j3.TaskGroups[0].Tasks[0].Constraints = []*structs.Constraint{
-		{
-			LTarget: "kernel",
-			RTarget: "linux",
-			Operand: "=",
-		},
-	}
-
-	require.True(t, tasksUpdated(j1, j3, name))
-
-	j4 := mock.Job()
-	j4.Constraints = make([]*structs.Constraint, 0)
-
-	j4.TaskGroups[0].Tasks[0].Constraints = []*structs.Constraint{
-		{
-			LTarget: "kernel",
-			RTarget: "linux",
-			Operand: "=",
-		},
-	}
-
-	require.True(t, tasksUpdated(j1, j4, name))
-
-	// check different level of same constraint
-	j5 := mock.Job()
-	j5.Constraints = []*structs.Constraint{
-		{
-			LTarget: "kernel",
-			RTarget: "linux",
-			Operand: "=",
-		},
-	}
-
-	j6 := mock.Job()
-	j6.Constraints = make([]*structs.Constraint, 0)
-	j6.TaskGroups[0].Constraints = []*structs.Constraint{
-		{
-			LTarget: "kernel",
-			RTarget: "linux",
-			Operand: "=",
 		},
 	}
 


### PR DESCRIPTION
Checks for feasibility for a particular constraint happen elsewhere so its redundant to check again here.