### PR TITLE
Add a Windows machine to e2e test runner

### DIFF
--- a/e2e/affinities/input/anti_affinities.nomad
+++ b/e2e/affinities/input/anti_affinities.nomad
@@ -2,6 +2,11 @@ job "test1" {
   datacenters = ["dc1", "dc2"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   affinity {
     attribute = "${meta.rack}"
     operator  = "="

--- a/e2e/affinities/input/multiple_affinities.nomad
+++ b/e2e/affinities/input/multiple_affinities.nomad
@@ -2,6 +2,11 @@ job "test1" {
   datacenters = ["dc1", "dc2"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   affinity {
     attribute = "${meta.rack}"
     operator  = "="

--- a/e2e/affinities/input/single_affinity.nomad
+++ b/e2e/affinities/input/single_affinity.nomad
@@ -2,6 +2,11 @@ job "test1" {
   datacenters = ["dc1", "dc2"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "test1" {
     count = 5
 

--- a/e2e/allocstats/input/raw_exec.nomad
+++ b/e2e/allocstats/input/raw_exec.nomad
@@ -2,6 +2,11 @@ job "test_raw" {
   datacenters = ["dc1"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "test" {
     count = 1
 

--- a/e2e/clientstate/restarter.nomad
+++ b/e2e/clientstate/restarter.nomad
@@ -5,6 +5,11 @@
 job "restarter" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "restarter" {
     restart {
       attempts = 100

--- a/e2e/clientstate/sleeper.nomad
+++ b/e2e/clientstate/sleeper.nomad
@@ -4,6 +4,11 @@
 job "sleeper" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   task "sleeper" {
     driver = "raw_exec"
 

--- a/e2e/connect/input/demo.nomad
+++ b/e2e/connect/input/demo.nomad
@@ -1,6 +1,11 @@
 job "countdash" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "api" {
     network {
       mode = "bridge"

--- a/e2e/consul/input/canary_tags.nomad
+++ b/e2e/consul/input/canary_tags.nomad
@@ -1,6 +1,11 @@
 job "consul_canary_test" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "consul_canary_test" {
     count = 2
 

--- a/e2e/consul/input/checks_group.nomad
+++ b/e2e/consul/input/checks_group.nomad
@@ -2,6 +2,11 @@ job "group_check" {
   datacenters = ["dc1"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "group_check" {
     network {
       mode = "bridge"

--- a/e2e/consul/input/checks_group_update.nomad
+++ b/e2e/consul/input/checks_group_update.nomad
@@ -2,6 +2,11 @@ job "group_check" {
   datacenters = ["dc1"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "group_check" {
     network {
       mode = "bridge"

--- a/e2e/consul/input/checks_task.nomad
+++ b/e2e/consul/input/checks_task.nomad
@@ -2,6 +2,11 @@ job "task_check" {
   datacenters = ["dc1"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "task_check" {
     count = 1
 

--- a/e2e/consul/input/checks_task_update.nomad
+++ b/e2e/consul/input/checks_task_update.nomad
@@ -2,6 +2,11 @@ job "task_check" {
   datacenters = ["dc1"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "task_check" {
     count = 1
 

--- a/e2e/consul/input/consul_example.nomad
+++ b/e2e/consul/input/consul_example.nomad
@@ -2,6 +2,11 @@ job "consul-example" {
   datacenters = ["dc1"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   update {
     max_parallel      = 1
     min_healthy_time  = "10s"

--- a/e2e/consultemplate/input/docker.nomad
+++ b/e2e/consultemplate/input/docker.nomad
@@ -2,6 +2,11 @@ job "test1" {
   datacenters = ["dc1", "dc2"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "test1" {
     count = 1
 

--- a/e2e/deployment/input/deployment_auto0.nomad
+++ b/e2e/deployment/input/deployment_auto0.nomad
@@ -1,6 +1,11 @@
 job "deployment_auto.nomad" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "one" {
     count = 3
 

--- a/e2e/deployment/input/deployment_auto1.nomad
+++ b/e2e/deployment/input/deployment_auto1.nomad
@@ -1,6 +1,11 @@
 job "deployment_auto.nomad" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "one" {
     count = 3
 

--- a/e2e/fabio/fabio.nomad
+++ b/e2e/fabio/fabio.nomad
@@ -2,6 +2,11 @@ job "fabio" {
   datacenters = ["dc1", "dc2"]
   type        = "system"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "fabio" {
     task "fabio" {
       driver = "docker"

--- a/e2e/hostvolumes/input/single_mount.nomad
+++ b/e2e/hostvolumes/input/single_mount.nomad
@@ -2,6 +2,11 @@ job "test1" {
   datacenters = ["dc1", "dc2"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "test1" {
     count = 1
 

--- a/e2e/metrics/input/cpustress.nomad
+++ b/e2e/metrics/input/cpustress.nomad
@@ -2,6 +2,11 @@ job "cpustress" {
   datacenters = ["dc1", "dc2"]
   type        = "batch"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "cpustress" {
     count = 1
 

--- a/e2e/metrics/input/diskstress.nomad
+++ b/e2e/metrics/input/diskstress.nomad
@@ -2,6 +2,11 @@ job "diskstress" {
   datacenters = ["dc1", "dc2"]
   type        = "batch"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "diskstress" {
     count = 1
 

--- a/e2e/metrics/input/helloworld.nomad
+++ b/e2e/metrics/input/helloworld.nomad
@@ -1,6 +1,11 @@
 job "hello" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   update {
     max_parallel     = 1
     min_healthy_time = "15s"

--- a/e2e/metrics/input/memstress.nomad
+++ b/e2e/metrics/input/memstress.nomad
@@ -2,6 +2,11 @@ job "memstress" {
   datacenters = ["dc1", "dc2"]
   type        = "batch"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "memstress" {
     count = 1
 

--- a/e2e/metrics/input/redis.nomad
+++ b/e2e/metrics/input/redis.nomad
@@ -1,6 +1,11 @@
 job "redis" {
   datacenters = ["dc1", "dc2"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "cache" {
     count = 4
 

--- a/e2e/metrics/input/simpleweb.nomad
+++ b/e2e/metrics/input/simpleweb.nomad
@@ -2,6 +2,11 @@ job "nginx" {
   datacenters = ["dc1"]
   type        = "system"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "simpleweb" {
     update {
       stagger          = "5s"

--- a/e2e/nomad09upgrade/docker.nomad
+++ b/e2e/nomad09upgrade/docker.nomad
@@ -1,6 +1,11 @@
 job "sleep" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "sleep" {
     task "sleep" {
       driver = "docker"

--- a/e2e/nomad09upgrade/exec.nomad
+++ b/e2e/nomad09upgrade/exec.nomad
@@ -1,6 +1,11 @@
 job "sleep" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "sleep" {
     task "sleep" {
       driver = "exec"

--- a/e2e/nomad09upgrade/rawexec.nomad
+++ b/e2e/nomad09upgrade/rawexec.nomad
@@ -1,6 +1,11 @@
 job "sleep" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "sleep" {
     task "sleep" {
       driver = "raw_exec"

--- a/e2e/nomadexec/testdata/docker.nomad
+++ b/e2e/nomadexec/testdata/docker.nomad
@@ -1,6 +1,11 @@
 job "nomadexec-docker" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "group" {
     task "task" {
       driver = "docker"

--- a/e2e/prometheus/prometheus.nomad
+++ b/e2e/prometheus/prometheus.nomad
@@ -2,6 +2,11 @@ job "prometheus" {
   datacenters = ["dc1", "dc2"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "monitoring" {
     count = 1
 

--- a/e2e/spread/input/even_spread.nomad
+++ b/e2e/spread/input/even_spread.nomad
@@ -2,6 +2,11 @@ job "r1" {
   datacenters = ["dc1", "dc2"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "r1" {
     count = 6
 

--- a/e2e/spread/input/multiple_spread.nomad
+++ b/e2e/spread/input/multiple_spread.nomad
@@ -2,6 +2,11 @@ job "r1" {
   datacenters = ["dc1", "dc2"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   spread {
     attribute = "${node.datacenter}"
     weight    = 100

--- a/e2e/taskevents/input/completed_leader.nomad
+++ b/e2e/taskevents/input/completed_leader.nomad
@@ -2,6 +2,11 @@ job "completed_leader" {
   type        = "batch"
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "completed_leader" {
     restart {
       attempts = 0

--- a/e2e/taskevents/input/failed_batch.nomad
+++ b/e2e/taskevents/input/failed_batch.nomad
@@ -2,6 +2,11 @@ job "failed_batch" {
   type        = "batch"
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "failed_batch" {
     restart {
       attempts = 0

--- a/e2e/taskevents/input/failed_sibling.nomad
+++ b/e2e/taskevents/input/failed_sibling.nomad
@@ -2,6 +2,11 @@ job "failed_sibling" {
   type        = "service"
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "failed_sibling" {
     restart {
       attempts = 0

--- a/e2e/taskevents/input/simple_batch.nomad
+++ b/e2e/taskevents/input/simple_batch.nomad
@@ -2,6 +2,11 @@ job "simple_batch" {
   type        = "batch"
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   task "simple_batch" {
     driver = "raw_exec"
 

--- a/e2e/terraform/compute.tf
+++ b/e2e/terraform/compute.tf
@@ -43,7 +43,7 @@ resource "aws_instance" "server" {
   }
 }
 
-resource "aws_instance" "client" {
+resource "aws_instance" "client_linux" {
   ami                    = data.aws_ami.linux.image_id
   instance_type          = var.instance_type
   key_name               = module.keys.key_name

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -99,8 +99,12 @@ output "servers" {
   value = aws_instance.server.*.public_ip
 }
 
-output "clients" {
-  value = aws_instance.client.*.public_ip
+output "linux_clients" {
+  value = aws_instance.client_linux.*.public_ip
+}
+
+output "windows_clients" {
+  value = aws_instance.client_windows.*.public_ip
 }
 
 output "message" {
@@ -109,8 +113,8 @@ Your cluster has been provisioned! - To prepare your environment, run the
 following:
 
 ```
-export NOMAD_ADDR=http://${aws_instance.client[0].public_ip}:4646
-export CONSUL_HTTP_ADDR=http://${aws_instance.client[0].public_ip}:8500
+export NOMAD_ADDR=http://${aws_instance.server[0].public_ip}:4646
+export CONSUL_HTTP_ADDR=http://${aws_instance.server[0].public_ip}:8500
 export NOMAD_E2E=1
 ```
 
@@ -122,7 +126,7 @@ go test -v ./e2e
 
 ssh into nodes with:
 ```
-ssh -i keys/${local.random_name}.pem ubuntu@${aws_instance.client[0].public_ip}
+ssh -i keys/${local.random_name}.pem ubuntu@${aws_instance.client_linux[0].public_ip}
 ```
 EOM
 

--- a/e2e/terraform/shared/config/provision-windows-client.ps1
+++ b/e2e/terraform/shared/config/provision-windows-client.ps1
@@ -29,7 +29,7 @@ Read-S3Object `
 
 Expand-Archive .\nomad.zip .\
 rm C:\opt\nomad.exe
-mv nomad.exe C:\opt\nomad.exe
+mv .\pkg\windows_amd64\nomad.exe C:\opt\nomad.exe
 
 # install config file
 cp "C:\ops\shared\nomad\client-windows.hcl" "C:\opt\nomad.d\nomad.hcl"

--- a/e2e/terraform/shared/nomad/client-windows.hcl
+++ b/e2e/terraform/shared/nomad/client-windows.hcl
@@ -1,7 +1,8 @@
 enable_debug = true
 
 log_level = "debug"
-log_file = true
+
+log_file = "C:\\opt\\nomad\\nomad.log"
 
 data_dir = "C:\\opt\\nomad\\data"
 

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -2,6 +2,4 @@ region               = "us-east-1"
 instance_type        = "t2.medium"
 server_count         = "3"
 client_count         = "4"
-
-# TODO(tgross): add only once Windows client is working
-windows_client_count = "0"
+windows_client_count = "1"


### PR DESCRIPTION
This PR adds a single Windows 2016 client to our nightly e2e test suite runs, but adds a constraint to ensure no tests land on it. (It also fixes a few config bugs I discovered in testing 0.10.2.)

In future PRs, I'll work through the test suite and remove that constraint as I verify each test works and make any necessary changes, but I'm doing this in small incremental PRs.

~In the meantime, I've added a `nomad node status` call at the end of the test runs so we can see that the node is joining the cluster properly.~ _Edit:_ there's no actual `nomad` binary in the e2e runner, so we'll need to add a test for it, but that's fine for now.

```
▶ nomad node status
ID        DC   Name              Class   Drain  Eligibility  Status
7beb3512  dc1  EC2AMAZ-T5NCUTM   <none>  false  eligible     ready
41ce22bf  dc1  ip-172-31-25-135  <none>  false  eligible     ready
2cc490bc  dc2  ip-172-31-22-166  <none>  false  eligible     ready
aa68f7a9  dc2  ip-172-31-28-119  <none>  false  eligible     ready
a9ff139b  dc1  ip-172-31-21-247  <none>  false  eligible     ready
```

