### PR TITLE
CLI: Remove duplicated error output

### DIFF
--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -194,7 +194,6 @@ func (l *AllocExecCommand) Run(args []string) int {
 
 		if err != nil {
 			l.Ui.Error(err.Error())
-			l.Ui.Error("\nPlease specify the task.")
 			return 1
 		}
 	}

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -190,7 +190,6 @@ func (l *AllocLogsCommand) Run(args []string) int {
 
 		if err != nil {
 			l.Ui.Error(err.Error())
-			l.Ui.Error("\nPlease specify the task.")
 			return 1
 		}
 	}


### PR DESCRIPTION
As I mentioned in #6729, the message about needing a task is duplicated when it’s missing. This delegates the error-generation to the inner function that both outer functions call, but it’s an arbitrary choice and could easily be the inverse so the outer functions are responsible for printing an error string.