### PR TITLE
ci: add build-binaries job for artifact storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
     jobs:
       - lint-go:
           <<: *IGNORE_FOR_UI_BRANCHES
+      - build-binaries
       - test-machine:
           name: "test-client"
           test_packages: "./client/..."
@@ -114,6 +115,27 @@ jobs:
       - run: make deps lint-deps
       - run: make check
       - run: make checkscripts
+
+  build-binaries:
+    executor: go
+    environment:
+      <<: *COMMON_ENVS
+      GOPATH: /go
+      # TODO: add ui tag here
+      GO_TAGS: "codegen_generated"
+    steps:
+      - checkout
+      - run: apt-get update; apt-get install -y sudo unzip zip
+      - run: make deps
+      - install-protoc
+      - run: sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make generate-structs
+      - run: make pkg/windows_amd64.zip pkg/linux_amd64.zip
+      - store_artifacts:
+          path: pkg/windows_amd64.zip
+          destination: /builds/nomad_windows_amd64.zip
+      - store_artifacts:
+          path: pkg/linux_amd64.tar.gz
+          destination: /builds/nomad_linux_amd64.tar.gz
 
   test-container:
     executor: go


### PR DESCRIPTION
This PR stores build artifacts as CircleCI artifacts. They will not yet be in use.

* The intent is to replace the existing use of S3 for purposes of e2e testing. The test consumer will be under separate work but having this merged will make sure we're building both artifacts and that we have them ready once that other work is complete.
* The current Windows packaging for e2e omits the `-j` flag added here, which results in the build directory being included in the archive (so that `nomad.exe` is in `pkg/windows_amd64/` after being unpacked). Because we're going to need to change the artifact fetching to use this anyways, I included the change to make it match what we're doing on Linux.
* There's no SHA in the CircleCI artifacts because Circle apparently doesn't interpolate `CIRCLE_SHA1` to the `store_artifacts` step's parameters. Consumers will need to query the CircleCI API to get the appropriate build number but that was going to be the case anyways.

Example outputs: https://app.circleci.com/jobs/github/hashicorp/nomad/21320/artifacts