### PR TITLE
Documentation for network quotas

### DIFF
--- a/command/quota_init.go
+++ b/command/quota_init.go
@@ -115,6 +115,9 @@ limit {
     region_limit {
         cpu = 2500
         memory = 1000
+        network {
+           mbits = 50
+        }
     }
 }
 `)
@@ -128,7 +131,10 @@ var defaultJsonQuotaSpec = strings.TrimSpace(`
 			"Region": "global",
 			"RegionLimit": {
 				"CPU": 2500,
-				"MemoryMB": 1000
+				"MemoryMB": 1000,
+                                "Networks": [
+                                        { "MBits": 50 }
+                                ]
 			}
 		}
 	]

--- a/command/quota_status.go
+++ b/command/quota_status.go
@@ -155,7 +155,7 @@ func formatQuotaLimits(spec *api.QuotaSpec, usages map[string]*api.QuotaUsage) s
 	sort.Sort(api.QuotaLimitSort(spec.Limits))
 
 	limits := make([]string, len(spec.Limits)+1)
-	limits[0] = "Region|CPU Usage|Memory Usage"
+	limits[0] = "Region|CPU Usage|Memory Usage|Network Usage"
 	i := 0
 	for _, specLimit := range spec.Limits {
 		i++
@@ -171,17 +171,27 @@ func formatQuotaLimits(spec *api.QuotaSpec, usages map[string]*api.QuotaUsage) s
 			return used, ok
 		}
 
+		specBits := 0
+		if len(specLimit.RegionLimit.Networks) == 1 {
+			specBits = *specLimit.RegionLimit.Networks[0].MBits
+		}
+
 		used, ok := lookupUsage()
 		if !ok {
 			cpu := fmt.Sprintf("- / %s", formatQuotaLimitInt(specLimit.RegionLimit.CPU))
 			memory := fmt.Sprintf("- / %s", formatQuotaLimitInt(specLimit.RegionLimit.MemoryMB))
-			limits[i] = fmt.Sprintf("%s|%s|%s", specLimit.Region, cpu, memory)
+			net := fmt.Sprintf("- / %s", formatQuotaLimitInt(&specBits))
+			limits[i] = fmt.Sprintf("%s|%s|%s|%s", specLimit.Region, cpu, memory, net)
 			continue
 		}
 
 		cpu := fmt.Sprintf("%d / %s", *used.RegionLimit.CPU, formatQuotaLimitInt(specLimit.RegionLimit.CPU))
 		memory := fmt.Sprintf("%d / %s", *used.RegionLimit.MemoryMB, formatQuotaLimitInt(specLimit.RegionLimit.MemoryMB))
-		limits[i] = fmt.Sprintf("%s|%s|%s", specLimit.Region, cpu, memory)
+		net := fmt.Sprintf("- / %s", formatQuotaLimitInt(&specBits))
+		if len(used.RegionLimit.Networks) == 1 {
+			net = fmt.Sprintf("%d / %s", *used.RegionLimit.Networks[0].MBits, formatQuotaLimitInt(&specBits))
+		}
+		limits[i] = fmt.Sprintf("%s|%s|%s|%s", specLimit.Region, cpu, memory, net)
 	}
 
 	return formatList(limits)

--- a/website/source/api/quotas.html.md
+++ b/website/source/api/quotas.html.md
@@ -62,7 +62,17 @@ $ curl \
           "CPU": 2500,
           "DiskMB": 0,
           "MemoryMB": 2000,
-          "Networks": null
+          "Networks": [
+            {
+              "CIDR": "",
+              "Device": "",
+              "DynamicPorts": null,
+              "IP": "",
+              "MBits": 50,
+              "Mode": "",
+              "ReservedPorts": null
+            }
+          ]
         }
       }
     ],
@@ -115,7 +125,17 @@ $ curl \
         "CPU": 2500,
         "DiskMB": 0,
         "MemoryMB": 2000,
-        "Networks": null
+        "Networks": [
+          {
+            "CIDR": "",
+            "Device": "",
+            "DynamicPorts": null,
+            "IP": "",
+            "MBits": 50,
+            "Mode": "",
+            "ReservedPorts": null
+          }
+        ]
       }
     }
   ],
@@ -157,12 +177,17 @@ object](https://github.com/hashicorp/nomad/blob/master/api/quota.go#L100-L131).
       "Region": "global",
       "RegionLimit": {
         "CPU": 2500,
-        "MemoryMB": 1000
+        "MemoryMB": 1000,
+        "Networks": [
+          {
+            "Mbits": 50
+          }
+        ]
       }
     }
   ]
 }
-```      
+```
 
 ### Sample Request
 
@@ -305,7 +330,17 @@ $ curl \
         "CPU": 500,
         "MemoryMB": 256,
         "DiskMB": 0,
-        "Networks": null
+        "Networks": [
+          {
+            "CIDR": "",
+            "Device": "",
+            "DynamicPorts": null,
+            "IP": "",
+            "MBits": 50,
+            "Mode": "",
+            "ReservedPorts": null
+          }
+        ]
       },
       "Hash": "NLOoV2WBU8ieJIrYXXx8NRb5C2xU61pVVWRDLEIMxlU="
     }

--- a/website/source/docs/commands/quota/inspect.html.md.erb
+++ b/website/source/docs/commands/quota/inspect.html.md.erb
@@ -68,7 +68,17 @@ $ nomad quota inspect default-quota
                         "CPU": 500,
                         "DiskMB": 0,
                         "MemoryMB": 256,
-                        "Networks": null
+                        "Networks": [
+                            {
+                                "CIDR": "",
+                                "Device": "",
+                                "DynamicPorts": null,
+                                "IP": "",
+                                "MBits": 0,
+                                "Mode": "",
+                                "ReservedPorts": null
+                            }
+                        ]
                     }
                 }
             }

--- a/website/source/docs/commands/quota/status.html.md.erb
+++ b/website/source/docs/commands/quota/status.html.md.erb
@@ -36,6 +36,6 @@ Description = Limit the shared default namespace
 Limits      = 1
 
 Quota Limits
-Region  CPU Usage   Memory Usage
-global  500 / 2500  256 / 2000
+Region  CPU Usage   Memory Usage  Network Usage
+global  500 / 2500  256 / 2000    30 / 50
 ```

--- a/website/source/guides/governance-and-policy/quotas.html.md
+++ b/website/source/guides/governance-and-policy/quotas.html.md
@@ -65,13 +65,18 @@ limit {
     region_limit {
         cpu = 2500
         memory = 1000
+		networks = [
+			{ mbits = 50 }
+		]
     }
 }
 ```
 
 A quota specification is composed of one or more resource limits. Each limit
 applies to a particular Nomad region. Within the limit object, operators can
-specify the allowed CPU and memory usage.
+specify the allowed CPU, memory usage, and network bandwidth. Network bandwidth
+limits may only specify a single limit for all interfaces. Network quotas were
+introduced in 0.10.2 and are optional, they will not be enforced if omitted.
 
 To create the particular quota, it is as simple as running:
 


### PR DESCRIPTION
In addition to documentation changes for the website, this pr updates the default quota files written by `nomad quota init` and adds memory consumption to `nomad quota status`. Closes #6626 