### PR TITLE
docs: vault integration docs should reference new token_period field

### DIFF
--- a/dev/vault/nomad-cluster-role.json
+++ b/dev/vault/nomad-cluster-role.json
@@ -3,6 +3,6 @@
   "explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": false,
-  "period": 259200,
+  "token_period": 259200,
   "renewable": true
 }

--- a/dev/vault/nomad-cluster-role.json
+++ b/dev/vault/nomad-cluster-role.json
@@ -1,6 +1,6 @@
 {
   "disallowed_policies": "nomad-server",
-  "explicit_max_ttl": 0,
+  "token_explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": false,
   "token_period": 259200,

--- a/e2e/vault/consts_test.go
+++ b/e2e/vault/consts_test.go
@@ -35,10 +35,10 @@ var (
 	// role is the recommended nomad cluster role
 	role = map[string]interface{}{
 		"disallowed_policies": "nomad-server",
-		"explicit_max_ttl":    0,
+		"explicit_max_ttl":    0, // use old name for vault compatibility
 		"name":                "nomad-cluster",
 		"orphan":              false,
-		"period":              259200,
+		"period":              259200, // use old name for vault compatibility
 		"renewable":           true,
 	}
 

--- a/website/source/data/vault/nomad-cluster-role.json
+++ b/website/source/data/vault/nomad-cluster-role.json
@@ -1,6 +1,6 @@
 {
   "disallowed_policies": "nomad-server",
-  "explicit_max_ttl": 0,
+  "token_explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": true,
   "token_period": 259200,

--- a/website/source/data/vault/nomad-cluster-role.json
+++ b/website/source/data/vault/nomad-cluster-role.json
@@ -3,6 +3,6 @@
   "explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": true,
-  "period": 259200,
+  "token_period": 259200,
   "renewable": true
 }

--- a/website/source/docs/vault-integration/index.html.md
+++ b/website/source/docs/vault-integration/index.html.md
@@ -138,7 +138,7 @@ An example token role definition is given below:
 ```json
 {
   "disallowed_policies": "nomad-server",
-  "explicit_max_ttl": 0,
+  "token_explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": true,
   "token_period": 259200,
@@ -171,7 +171,7 @@ documentation for all possible fields and more complete documentation.
      Nomad. This was remedied in 0.6.5 and does not effect earlier versions
      of Vault.
 
-* `explicit_max_ttl` - Specifies the max TTL of a token. **Must be set to `0`** to
+* `token_explicit_max_ttl` - Specifies the max TTL of a token. **Must be set to `0`** to
   allow periodic tokens.
 
 * `name` - Specifies the name of the policy. We recommend using the name

--- a/website/source/docs/vault-integration/index.html.md
+++ b/website/source/docs/vault-integration/index.html.md
@@ -141,7 +141,7 @@ An example token role definition is given below:
   "explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": true,
-  "period": 259200,
+  "token_period": 259200,
   "renewable": true
 }
 ```
@@ -196,7 +196,7 @@ documentation for all possible fields and more complete documentation.
   making bootstrapping and upgrading simpler. As such, **setting `orphan = true`
   is the recommended setting**.
 
-* `period` - Specifies the length the TTL is extended by each renewal in
+* `token_period` - Specifies the length the TTL is extended by each renewal in
   seconds. It is suggested to set this value on the order of magnitude of 3 days
   (259200 seconds) to avoid a large renewal request rate to Vault. **Must be set
   to a positive value**.

--- a/website/source/guides/integrations/vault-integration/index.html.md
+++ b/website/source/guides/integrations/vault-integration/index.html.md
@@ -192,7 +192,7 @@ submitted to Nomad. We will use the following token role:
   "explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": true,
-  "period": 259200,
+  "token_period": 259200,
   "renewable": true
 }
 ```
@@ -213,7 +213,7 @@ disallowed policies group. An example of this is shown below:
   "explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": true,
-  "period": 259200,
+  "token_period": 259200,
   "renewable": true
 }
 ```

--- a/website/source/guides/integrations/vault-integration/index.html.md
+++ b/website/source/guides/integrations/vault-integration/index.html.md
@@ -189,7 +189,7 @@ submitted to Nomad. We will use the following token role:
 ```json
 {
   "allowed_policies": "access-tables",
-  "explicit_max_ttl": 0,
+  "token_explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": true,
   "token_period": 259200,
@@ -210,7 +210,7 @@ disallowed policies group. An example of this is shown below:
 ```json
 {
   "disallowed_policies": "nomad-server",
-  "explicit_max_ttl": 0,
+  "token_explicit_max_ttl": 0,
   "name": "nomad-cluster",
   "orphan": true,
   "token_period": 259200,


### PR DESCRIPTION
Vault deprecated `period` in favor of `token_period` in the context of a Token Role. 
https://www.vaultproject.io/api/auth/token/index.html#token_period

This change updates Nomad Vault Integration docs to follow suit