### PR TITLE
acl_endpoint: permission denied for unauthenticated requests

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -137,7 +137,7 @@ func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.AC
 	mgt := acl.IsManagement()
 	var policies map[string]struct{}
 	if !mgt {
-		token, err := a.requestAuthToken(args.AuthToken)
+		token, err := a.requestACLToken(args.AuthToken)
 		if err != nil {
 			return err
 		}
@@ -221,7 +221,7 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 	// If it is not a management token determine if it can get this policy
 	mgt := acl.IsManagement()
 	if !mgt && args.Name != "anonymous" {
-		token, err := a.requestAuthToken(args.AuthToken)
+		token, err := a.requestACLToken(args.AuthToken)
 		if err != nil {
 			return err
 		}
@@ -276,7 +276,7 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 	return a.srv.blockingRPC(&opts)
 }
 
-func (a *ACL) requestAuthToken(secretID string) (*structs.ACLToken, error) {
+func (a *ACL) requestACLToken(secretID string) (*structs.ACLToken, error) {
 	if secretID == "" {
 		return structs.AnonymousACLToken, nil
 	}
@@ -302,7 +302,7 @@ func (a *ACL) GetPolicies(args *structs.ACLPolicySetRequest, reply *structs.ACLP
 	// For client typed tokens, allow them to query any policies associated with that token.
 	// This is used by clients which are resolving the policies to enforce. Any associated
 	// policies need to be fetched so that the client can determine what to allow.
-	token, err := a.requestAuthToken(args.AuthToken)
+	token, err := a.requestACLToken(args.AuthToken)
 	if err != nil {
 		return err
 	}

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -119,6 +119,7 @@ func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.AC
 	if !a.srv.config.ACLEnabled {
 		return aclDisabled
 	}
+
 	if done, err := a.srv.forward("ACL.ListPolicies", args, args, reply); done {
 		return err
 	}
@@ -136,12 +137,7 @@ func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.AC
 	mgt := acl.IsManagement()
 	var policies map[string]struct{}
 	if !mgt {
-		snap, err := a.srv.fsm.State().Snapshot()
-		if err != nil {
-			return err
-		}
-
-		token, err := snap.ACLTokenBySecretID(nil, args.AuthToken)
+		token, err := a.requestAuthToken(args.AuthToken)
 		if err != nil {
 			return err
 		}
@@ -207,6 +203,7 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 	if !a.srv.config.ACLEnabled {
 		return aclDisabled
 	}
+
 	if done, err := a.srv.forward("ACL.GetPolicy", args, args, reply); done {
 		return err
 	}
@@ -224,12 +221,7 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 	// If it is not a management token determine if it can get this policy
 	mgt := acl.IsManagement()
 	if !mgt && args.Name != "anonymous" {
-		snap, err := a.srv.fsm.State().Snapshot()
-		if err != nil {
-			return err
-		}
-
-		token, err := snap.ACLTokenBySecretID(nil, args.AuthToken)
+		token, err := a.requestAuthToken(args.AuthToken)
 		if err != nil {
 			return err
 		}
@@ -284,6 +276,19 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 	return a.srv.blockingRPC(&opts)
 }
 
+func (a *ACL) requestAuthToken(secretID string) (*structs.ACLToken, error) {
+	if secretID == "" {
+		return structs.AnonymousACLToken, nil
+	}
+
+	snap, err := a.srv.fsm.State().Snapshot()
+	if err != nil {
+		return nil, err
+	}
+
+	return snap.ACLTokenBySecretID(nil, secretID)
+}
+
 // GetPolicies is used to get a set of policies
 func (a *ACL) GetPolicies(args *structs.ACLPolicySetRequest, reply *structs.ACLPolicySetResponse) error {
 	if !a.srv.config.ACLEnabled {
@@ -294,19 +299,12 @@ func (a *ACL) GetPolicies(args *structs.ACLPolicySetRequest, reply *structs.ACLP
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "get_policies"}, time.Now())
 
-	var token *structs.ACLToken
-	var err error
-	if args.AuthToken == "" {
-		// No need to look up the anonymous token
-		token = structs.AnonymousACLToken
-	} else {
-		// For client typed tokens, allow them to query any policies associated with that token.
-		// This is used by clients which are resolving the policies to enforce. Any associated
-		// policies need to be fetched so that the client can determine what to allow.
-		token, err = a.srv.State().ACLTokenBySecretID(nil, args.AuthToken)
-		if err != nil {
-			return err
-		}
+	// For client typed tokens, allow them to query any policies associated with that token.
+	// This is used by clients which are resolving the policies to enforce. Any associated
+	// policies need to be fetched so that the client can determine what to allow.
+	token, err := a.requestAuthToken(args.AuthToken)
+	if err != nil {
+		return err
 	}
 
 	if token == nil {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3769,6 +3769,10 @@ func (s *StateStore) DeleteACLTokens(index uint64, ids []string) error {
 
 // ACLTokenByAccessorID is used to lookup a token by accessor ID
 func (s *StateStore) ACLTokenByAccessorID(ws memdb.WatchSet, id string) (*structs.ACLToken, error) {
+	if id == "" {
+		return nil, fmt.Errorf("acl token lookup failed: missing accessor id")
+	}
+
 	txn := s.db.Txn(false)
 
 	watchCh, existing, err := txn.FirstWatch("acl_token", "id", id)
@@ -3785,6 +3789,10 @@ func (s *StateStore) ACLTokenByAccessorID(ws memdb.WatchSet, id string) (*struct
 
 // ACLTokenBySecretID is used to lookup a token by secret ID
 func (s *StateStore) ACLTokenBySecretID(ws memdb.WatchSet, secretID string) (*structs.ACLToken, error) {
+	if secretID == "" {
+		return nil, fmt.Errorf("acl token lookup failed: missing secret id")
+	}
+
 	txn := s.db.Txn(false)
 
 	watchCh, existing, err := txn.FirstWatch("acl_token", "secret", secretID)


### PR DESCRIPTION
If ACL Request is unauthenticated, we should honor the anonymous token.
This PR makes few changes:

* `GetPolicy` endpoints may return policy if anonymous policy allows it,
or return permission denied otherwise.
* `ListPolicies` returns an empty policy list, or one with anonymous
policy if one exists.

Without this PR, the we return an incomprehensible error.

Before:
```
$ curl http://localhost:4646/v1/acl/policy/doesntexist; echo
acl token lookup failed: index error: UUID must be 36 characters
$ curl http://localhost:4646/v1/acl/policies; echo
acl token lookup failed: index error: UUID must be 36 characters
```

After:
```
$ curl http://localhost:4646/v1/acl/policy/doesntexist; echo
Permission denied
$ curl http://localhost:4646/v1/acl/policies; echo
[]
```