### PR TITLE
drivers: always initialize taskHandle.logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ BUG FIXES:
  * cli: Fixed a bug where a cli user may fail to query FS/Allocation API endpoints if they lack `node:read` capability [[GH-6423](https://github.com/hashicorp/nomad/issues/6423)]
  * client: client: Return empty values when host stats fail [[GH-6349](https://github.com/hashicorp/nomad/issues/6349)]
  * client: Fixed a bug where a client may not restart dead internal processes upon client's restart on Windows [[GH-6426](https://github.com/hashicorp/nomad/issues/6426)]
+ * drivers: Fixed a bug where client may panic if a restored task failed to shutdown cleanly [[GH-6763](https://github.com/hashicorp/nomad/issues/6763)]
  * driver/exec: Fixed a bug where exec tasks can spawn processes that live beyond task lifecycle [[GH-6722](https://github.com/hashicorp/nomad/issues/6722)]
  * driver/docker: Added mechanism for detecting running unexpectedly running docker containers [[GH-6325](https://github.com/hashicorp/nomad/issues/6325)]
  * nomad: Fixed registering multiple connect enabled services in the same task group [[GH-6646](https://github.com/hashicorp/nomad/issues/6646)]

--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -304,6 +304,7 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 		procState:    drivers.TaskStateRunning,
 		startedAt:    taskState.StartedAt,
 		exitResult:   &drivers.ExitResult{},
+		logger:       d.logger,
 	}
 
 	d.tasks.Set(taskState.TaskConfig.ID, h)

--- a/drivers/exec/driver_pre09.go
+++ b/drivers/exec/driver_pre09.go
@@ -36,6 +36,7 @@ func (d *Driver) recoverPre09Task(h *drivers.TaskHandle) error {
 		procState:    drivers.TaskStateRunning,
 		startedAt:    time.Now(),
 		exitResult:   &drivers.ExitResult{},
+		logger:       d.logger,
 	}
 
 	d.tasks.Set(h.Config.ID, th)

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -290,6 +290,7 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 		procState:    drivers.TaskStateRunning,
 		startedAt:    taskState.StartedAt,
 		exitResult:   &drivers.ExitResult{},
+		logger:       d.logger,
 	}
 
 	d.tasks.Set(taskState.TaskConfig.ID, h)

--- a/drivers/java/driver_pre09.go
+++ b/drivers/java/driver_pre09.go
@@ -36,6 +36,7 @@ func (d *Driver) recoverPre09Task(h *drivers.TaskHandle) error {
 		procState:    drivers.TaskStateRunning,
 		startedAt:    time.Now(),
 		exitResult:   &drivers.ExitResult{},
+		logger:       d.logger,
 	}
 
 	d.tasks.Set(h.Config.ID, th)

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -286,6 +286,7 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 		procState:    drivers.TaskStateRunning,
 		startedAt:    taskState.StartedAt,
 		exitResult:   &drivers.ExitResult{},
+		logger:       d.logger,
 	}
 
 	d.tasks.Set(taskState.TaskConfig.ID, h)

--- a/drivers/qemu/driver_pre09.go
+++ b/drivers/qemu/driver_pre09.go
@@ -36,6 +36,7 @@ func (d *Driver) recoverPre09Task(h *drivers.TaskHandle) error {
 		procState:    drivers.TaskStateRunning,
 		startedAt:    time.Now(),
 		exitResult:   &drivers.ExitResult{},
+		logger:       d.logger,
 	}
 
 	d.tasks.Set(h.Config.ID, th)

--- a/drivers/rkt/driver.go
+++ b/drivers/rkt/driver.go
@@ -405,6 +405,7 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 		procState:    drivers.TaskStateRunning,
 		startedAt:    taskState.StartedAt,
 		exitResult:   &drivers.ExitResult{},
+		logger:       d.logger,
 	}
 
 	d.tasks.Set(taskState.TaskConfig.ID, h)

--- a/drivers/rkt/driver_pre09.go
+++ b/drivers/rkt/driver_pre09.go
@@ -36,6 +36,7 @@ func (d *Driver) recoverPre09Task(h *drivers.TaskHandle) error {
 		procState:    drivers.TaskStateRunning,
 		startedAt:    time.Now(),
 		exitResult:   &drivers.ExitResult{},
+		logger:       d.logger,
 	}
 
 	d.tasks.Set(h.Config.ID, th)


### PR DESCRIPTION
Looks like the RecoverTask doesn't set taskHandle.logger field causing
a panic when the handle attempts to log (e.g. when Shutdown or Signaling
fails).

Fixes https://github.com/hashicorp/nomad/issues/6760