### PR TITLE
docs: show /etc/passwd in minimal chroot

### DIFF
--- a/website/source/docs/configuration/client.html.md
+++ b/website/source/docs/configuration/client.html.md
@@ -179,6 +179,7 @@ client {
     "/etc/ld.so.cache"  = "/etc/ld.so.cache"
     "/etc/ld.so.conf"   = "/etc/ld.so.conf"
     "/etc/ld.so.conf.d" = "/etc/ld.so.conf.d"
+    "/etc/passwd"       = "/etc/passwd"
     "/lib"              = "/lib"
     "/lib64"            = "/lib64"
   }


### PR DESCRIPTION
Adds `/etc/passwd` to the minimal chroot shown, as that's required for the `nobody` user we use for the `exec` driver. This came up in an issue on discuss.hashicorp.com