### PR TITLE
Fix demo vagrant provision hung when libssl asks for confirmation

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -5,6 +5,7 @@ $script = <<SCRIPT
 echo "Installing Docker..."
 sudo apt-get update
 sudo apt-get remove docker docker-engine docker.io
+echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections
 sudo apt-get install apt-transport-https ca-certificates curl software-properties-common -y
 sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg |  sudo apt-key add -
 sudo apt-key fingerprint 0EBFCD88


### PR DESCRIPTION
The provision shell script tries to install `libssl1.1` package as dependency of `ca-certificates` package.

The installing of `libssl` requires to restart some services, and it asks for confirmation of this.
But there are no interactive session at this stage, so Vagrant provisioning just **hungs**.

This commit add a `libraries/restart-without-asking boolean true` setting before installing `libssl`,
so it doesn't ask confirmation anymore and the provisioning works again.

See more about this problem and how the confirmation screen looks if you start provisioning script from interactive ssh session: https://unix.stackexchange.com/questions/146283/how-to-prevent-prompt-that-ask-to-restart-services-when-installing-libpq-dev