### PR TITLE
e2e: add allocstats test for Windows

### DIFF
--- a/e2e/allocstats/allocstats.go
+++ b/e2e/allocstats/allocstats.go
@@ -1,17 +1,16 @@
 package allocstats
 
 import (
-	"github.com/hashicorp/nomad/e2e/framework"
-	"github.com/stretchr/testify/require"
-
 	"fmt"
-
 	"time"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/e2e/framework"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/testutil"
+
+	"github.com/stretchr/testify/require"
 )
 
 type BasicAllocStatsTest struct {
@@ -32,7 +31,7 @@ func init() {
 func (tc *BasicAllocStatsTest) BeforeAll(f *framework.F) {
 	// Ensure cluster has leader before running tests
 	e2eutil.WaitForLeader(f.T(), tc.Nomad())
-	// Ensure that we have four client nodes in ready state
+	// Ensure that we have at least one client node in ready state
 	e2eutil.WaitForNodesReady(f.T(), tc.Nomad(), 1)
 }
 
@@ -41,10 +40,45 @@ func (tc *BasicAllocStatsTest) BeforeAll(f *framework.F) {
 // TODO(preetha) - add more test cases with more realistic resource utilization
 func (tc *BasicAllocStatsTest) TestResourceStats(f *framework.F) {
 	nomadClient := tc.Nomad()
+
+	clientNodes, err := e2eutil.ListLinuxClientNodes(nomadClient)
+	if err != nil {
+		f.T().Fatalf("could not list client nodes: %v", err)
+	}
+	if len(clientNodes) == 0 {
+		f.T().Skip("no Linux clients")
+	}
+
 	uuid := uuid.Generate()
-	jobId := "allocstats" + uuid[0:8]
-	tc.jobIds = append(tc.jobIds, jobId)
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "allocstats/input/raw_exec.nomad", jobId)
+	jobID := "allocstats" + uuid[0:8]
+	tc.jobIds = append(tc.jobIds, jobID)
+	runResourceStatsTest(f, nomadClient, jobID,
+		"allocstats/input/raw_exec.nomad")
+}
+
+// TestResourceStatsWindows is an end to end test for resource utilization.
+// This runs a raw exec job.
+func (tc *BasicAllocStatsTest) TestResourceStatsWindows(f *framework.F) {
+	nomadClient := tc.Nomad()
+
+	clientNodes, err := e2eutil.ListWindowsClientNodes(nomadClient)
+	if err != nil {
+		f.T().Fatalf("could not list client nodes: %v", err)
+	}
+	if len(clientNodes) == 0 {
+		f.T().Skip("no Windows clients")
+	}
+
+	uuid := uuid.Generate()
+	jobID := "allocstats_windows" + uuid[0:8]
+	tc.jobIds = append(tc.jobIds, jobID)
+	runResourceStatsTest(f, nomadClient, jobID,
+		"allocstats/input/raw_exec_windows.nomad")
+}
+
+func runResourceStatsTest(f *framework.F, nomadClient *api.Client, jobID, jobSpec string) {
+
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, jobSpec, jobID)
 
 	require := require.New(f.T())
 	require.Len(allocs, 1)
@@ -70,7 +104,6 @@ func (tc *BasicAllocStatsTest) TestResourceStats(f *framework.F) {
 	}, func(err error) {
 		f.T().Fatalf("invalid resource usage : %v", err)
 	})
-
 }
 
 func (tc *BasicAllocStatsTest) AfterEach(f *framework.F) {

--- a/e2e/allocstats/input/raw_exec_windows.nomad
+++ b/e2e/allocstats/input/raw_exec_windows.nomad
@@ -1,0 +1,34 @@
+job "test_raw_windows" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "windows"
+  }
+
+  group "test" {
+    count = 1
+
+    task "test1" {
+      driver = "raw_exec"
+
+      template {
+        data = <<EOH
+foreach ($loopnumber in 1..2147483647) {
+  $result=1;foreach ($number in 1..2147483647) {
+    $result = $result * $number
+  };$result
+}
+  EOH
+
+        destination = "local/factorial.ps1"
+      }
+
+      config {
+        command = "powershell"
+        args    = ["local/factorial.ps1"]
+      }
+    }
+  }
+}

--- a/e2e/e2eutil/node.go
+++ b/e2e/e2eutil/node.go
@@ -112,3 +112,35 @@ func newRestartJob(nodeID string) *api.Job {
 	job.Canonicalize()
 	return job
 }
+
+// ListWindowsClientNodes returns a list of Windows client IDs, so that tests
+// can skip operating-specific tests if there are no Windows clients available.
+// Returns an error only on client errors.
+func ListWindowsClientNodes(client *api.Client) ([]string, error) {
+	return listClientNodesByOS(client, "windows")
+}
+
+// ListLinuxClientNodes returns a list of Linux client IDs, so that tests
+// can skip operating-specific tests if there are no Linux clients available
+// Returns an error only on client errors.
+func ListLinuxClientNodes(client *api.Client) ([]string, error) {
+	return listClientNodesByOS(client, "linux")
+}
+
+func listClientNodesByOS(client *api.Client, osName string) ([]string, error) {
+	nodeIDs := []string{}
+	nodes, _, err := client.Nodes().List(&api.QueryOptions{})
+	if err != nil {
+		return nodeIDs, fmt.Errorf("could not query nodes: %v", err)
+	}
+	for _, stubNode := range nodes {
+		node, _, err := client.Nodes().Info(stubNode.ID, nil)
+		if err != nil {
+			return nodeIDs, fmt.Errorf("could not query nodes: %v", err)
+		}
+		if name, ok := node.Attributes["kernel.name"]; ok && name == osName {
+			nodeIDs = append(nodeIDs, stubNode.ID)
+		}
+	}
+	return nodeIDs, nil
+}


### PR DESCRIPTION
Extends the BasicAllocStats test to include a test for Windows clients, exercising stats via a powershell `raw_exec` job.

Adds `ListLinuxClientNodes` and `ListWindowsClientNodes` utils so that we can scope tests to run only when Linux or Windows clients are available. This prevents waiting on timeouts when running a subset of the tests against a development cluster (vs our nightly test cluster).

Two out-of-scope items for this PR:
* In the future I'd like to turn the skip-if-there's-no-Windows into something clever we can do to annotate a test. But until I have a bigger base of Windows E2E tests I don't want to paint myself into a corner on how to develop that.
* I'm not intending to improve upon the existing alloc stats test here. That's important to do (and there's a TODO already), but I'm really just interested in getting it running vs Windows at all first.

Sample test output:

```sh
▶ export NOMAD_ADDR="http://$IP:4646"
▶ export NOMAD_E2E=1
▶ go test -v ./e2e -run 'TestE2E/AllocationStats'
=== RUN   TestE2E
=== RUN   TestE2E/AllocationStats
=== RUN   TestE2E/AllocationStats/*allocstats.BasicAllocStatsTest
=== RUN   TestE2E/AllocationStats/*allocstats.BasicAllocStatsTest/TestResourceStats
=== RUN   TestE2E/AllocationStats/*allocstats.BasicAllocStatsTest/TestResourceStatsWindows
--- PASS: TestE2E (6.15s)
    --- PASS: TestE2E/AllocationStats (6.15s)
        --- PASS: TestE2E/AllocationStats/*allocstats.BasicAllocStatsTest (6.06s)
            --- PASS: TestE2E/AllocationStats/*allocstats.BasicAllocStatsTest/TestResourceStats (2.63s)
            --- PASS: TestE2E/AllocationStats/*allocstats.BasicAllocStatsTest/TestResourceStatsWindows (3.25s)
PASS
ok      github.com/hashicorp/nomad/e2e  7.469s

```