### PR TITLE
Use AWS SDK to access EC2 Metadata

### DIFF
--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -2,7 +2,6 @@ package fingerprint
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -10,6 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	log "github.com/hashicorp/go-hclog"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
@@ -17,10 +20,6 @@ import (
 )
 
 const (
-	// This is where the AWS metadata server normally resides. We hardcode the
-	// "instance" path as well since it's the only one we access here.
-	DEFAULT_AWS_URL = "http://169.254.169.254/latest/meta-data/"
-
 	// AwsMetadataTimeout is the timeout used when contacting the AWS metadata
 	// service
 	AwsMetadataTimeout = 2 * time.Second
@@ -50,44 +49,50 @@ var ec2InstanceSpeedMap = map[*regexp.Regexp]int{
 // EnvAWSFingerprint is used to fingerprint AWS metadata
 type EnvAWSFingerprint struct {
 	StaticFingerprinter
-	timeout time.Duration
-	logger  log.Logger
+	logger log.Logger
 }
 
 // NewEnvAWSFingerprint is used to create a fingerprint from AWS metadata
 func NewEnvAWSFingerprint(logger log.Logger) Fingerprint {
 	f := &EnvAWSFingerprint{
-		logger:  logger.Named("env_aws"),
-		timeout: AwsMetadataTimeout,
+		logger: logger.Named("env_aws"),
 	}
 	return f
+}
+
+func ec2MetaClient(timeout time.Duration) *ec2metadata.EC2Metadata {
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: cleanhttp.DefaultTransport(),
+	}
+
+	c := aws.NewConfig().WithHTTPClient(client)
+	if endpoint := os.Getenv("AWS_ENV_URL"); endpoint != "" {
+		endpoint = strings.TrimSuffix(endpoint, "/meta-data/")
+		c = c.WithEndpoint(endpoint)
+	}
+	return ec2metadata.New(session.New(), c)
 }
 
 func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *FingerprintResponse) error {
 	cfg := request.Config
 
+	timeout := AwsMetadataTimeout
+
 	// Check if we should tighten the timeout
 	if cfg.ReadBoolDefault(TightenNetworkTimeoutsConfig, false) {
-		f.timeout = 1 * time.Millisecond
+		timeout = 1 * time.Millisecond
 	}
 
-	if !f.isAWS() {
+	ec2meta := ec2MetaClient(timeout)
+
+	if !ec2meta.Available() {
 		return nil
 	}
 
 	// newNetwork is populated and added to the Nodes resources
 	newNetwork := &structs.NetworkResource{
 		Device: "eth0",
-	}
-
-	metadataURL := os.Getenv("AWS_ENV_URL")
-	if metadataURL == "" {
-		metadataURL = DEFAULT_AWS_URL
-	}
-
-	client := &http.Client{
-		Timeout:   f.timeout,
-		Transport: cleanhttp.DefaultTransport(),
 	}
 
 	// Keys and whether they should be namespaced as unique. Any key whose value
@@ -105,23 +110,19 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 		"placement/availability-zone": false,
 	}
 	for k, unique := range keys {
-		res, err := client.Get(metadataURL + k)
-		if err != nil {
+		resp, err := ec2meta.GetMetadata(k)
+		if awsErr, ok := err.(awserr.RequestFailure); ok {
+			f.logger.Debug("could not read attribute value", "attribute", k, "error", awsErr)
+			continue
+		} else if awsErr, ok := err.(awserr.Error); ok {
 			// if it's a URL error, assume we're not in an AWS environment
 			// TODO: better way to detect AWS? Check xen virtualization?
-			if _, ok := err.(*url.Error); ok {
+			if _, ok := awsErr.OrigErr().(*url.Error); ok {
 				return nil
 			}
+
 			// not sure what other errors it would return
 			return err
-		} else if res.StatusCode != http.StatusOK {
-			f.logger.Debug("could not read attribute value", "attribute", k)
-			continue
-		}
-		resp, err := ioutil.ReadAll(res.Body)
-		res.Body.Close()
-		if err != nil {
-			f.logger.Error("error reading response body for AWS attribute", "attribute", k, "error", err)
 		}
 
 		// assume we want blank entries
@@ -130,7 +131,7 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 			key = structs.UniqueNamespace(key)
 		}
 
-		response.AddAttribute(key, strings.Trim(string(resp), "\n"))
+		response.AddAttribute(key, strings.Trim(resp, "\n"))
 	}
 
 	// copy over network specific information
@@ -141,7 +142,7 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 	}
 
 	// find LinkSpeed from lookup
-	throughput := f.linkSpeed()
+	throughput := f.linkSpeed(ec2meta)
 	if cfg.NetworkSpeed != 0 {
 		throughput = cfg.NetworkSpeed
 	} else if throughput == 0 {
@@ -177,75 +178,16 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 	return nil
 }
 
-func (f *EnvAWSFingerprint) isAWS() bool {
-	// Read the internal metadata URL from the environment, allowing test files to
-	// provide their own
-	metadataURL := os.Getenv("AWS_ENV_URL")
-	if metadataURL == "" {
-		metadataURL = DEFAULT_AWS_URL
-	}
-
-	client := &http.Client{
-		Timeout:   f.timeout,
-		Transport: cleanhttp.DefaultTransport(),
-	}
-
-	// Query the metadata url for the ami-id, to verify we're on AWS
-	resp, err := client.Get(metadataURL + "ami-id")
-	if err != nil {
-		f.logger.Debug("error querying AWS Metadata URL, skipping")
-		return false
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		// URL not found, which indicates that this isn't AWS
-		return false
-	}
-
-	instanceID, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		f.logger.Debug("error reading AWS Instance ID, skipping")
-		return false
-	}
-
-	match, err := regexp.MatchString("ami-*", string(instanceID))
-	if err != nil || !match {
-		return false
-	}
-
-	return true
-}
-
 // EnvAWSFingerprint uses lookup table to approximate network speeds
-func (f *EnvAWSFingerprint) linkSpeed() int {
+func (f *EnvAWSFingerprint) linkSpeed(ec2meta *ec2metadata.EC2Metadata) int {
 
-	// Query the API for the instance type, and use the table above to approximate
-	// the network speed
-	metadataURL := os.Getenv("AWS_ENV_URL")
-	if metadataURL == "" {
-		metadataURL = DEFAULT_AWS_URL
-	}
-
-	client := &http.Client{
-		Timeout:   f.timeout,
-		Transport: cleanhttp.DefaultTransport(),
-	}
-
-	res, err := client.Get(metadataURL + "instance-type")
+	resp, err := ec2meta.GetMetadata("instance-type")
 	if err != nil {
 		f.logger.Error("error reading instance-type", "error", err)
 		return 0
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
-	res.Body.Close()
-	if err != nil {
-		f.logger.Error("error reading response body for instance-type", "error", err)
-		return 0
-	}
-
-	key := strings.Trim(string(body), "\n")
+	key := strings.Trim(resp, "\n")
 	netSpeed := 0
 	for reg, speed := range ec2InstanceSpeedMap {
 		if reg.MatchString(key) {

--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -142,10 +142,11 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 	}
 
 	// find LinkSpeed from lookup
-	throughput := f.linkSpeed(ec2meta)
-	if cfg.NetworkSpeed != 0 {
-		throughput = cfg.NetworkSpeed
-	} else if throughput == 0 {
+	throughput := cfg.NetworkSpeed
+	if throughput == 0 {
+		throughput = f.linkSpeed(ec2meta)
+	}
+	if throughput == 0 {
 		// Failed to determine speed. Check if the network fingerprint got it
 		found := false
 		if request.Node.Resources != nil && len(request.Node.Resources.Networks) > 0 {

--- a/client/fingerprint/env_aws_test.go
+++ b/client/fingerprint/env_aws_test.go
@@ -5,17 +5,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnvAWSFingerprint_nonAws(t *testing.T) {
-	os.Setenv("AWS_ENV_URL", "http://127.0.0.1/latest/meta-data/")
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
+	f.(*EnvAWSFingerprint).endpoint = "http://127.0.0.1/latest"
+
 	node := &structs.Node{
 		Attributes: make(map[string]string),
 	}
@@ -23,43 +24,25 @@ func TestEnvAWSFingerprint_nonAws(t *testing.T) {
 	request := &FingerprintRequest{Config: &config.Config{}, Node: node}
 	var response FingerprintResponse
 	err := f.Fingerprint(request, &response)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if len(response.Attributes) > 0 {
-		t.Fatalf("Should not apply")
-	}
+	require.NoError(t, err)
+	require.Empty(t, response.Attributes)
 }
 
 func TestEnvAWSFingerprint_aws(t *testing.T) {
+	endpoint, cleanup := startFakeEC2Metadata(t)
+	defer cleanup()
+
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
+	f.(*EnvAWSFingerprint).endpoint = endpoint
+
 	node := &structs.Node{
 		Attributes: make(map[string]string),
 	}
 
-	// configure mock server with fixture routes, data
-	routes := routes{}
-	if err := json.Unmarshal([]byte(aws_routes), &routes); err != nil {
-		t.Fatalf("Failed to unmarshal JSON in AWS ENV test: %s", err)
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for _, e := range routes.Endpoints {
-			if r.RequestURI == e.Uri {
-				w.Header().Set("Content-Type", e.ContentType)
-				fmt.Fprintln(w, e.Body)
-			}
-		}
-	}))
-	defer ts.Close()
-	os.Setenv("AWS_ENV_URL", ts.URL+"/latest/meta-data/")
-
 	request := &FingerprintRequest{Config: &config.Config{}, Node: node}
 	var response FingerprintResponse
 	err := f.Fingerprint(request, &response)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 
 	keys := []string{
 		"platform.aws.ami-id",
@@ -78,14 +61,121 @@ func TestEnvAWSFingerprint_aws(t *testing.T) {
 		assertNodeAttributeContains(t, response.Attributes, k)
 	}
 
-	if len(response.Links) == 0 {
-		t.Fatalf("Empty links for Node in AWS Fingerprint test")
-	}
+	require.NotEmpty(t, response.Links)
 
 	// confirm we have at least instance-id and ami-id
 	for _, k := range []string{"aws.ec2"} {
 		assertNodeLinksContains(t, response.Links, k)
 	}
+}
+
+func TestNetworkFingerprint_AWS(t *testing.T) {
+	endpoint, cleanup := startFakeEC2Metadata(t)
+	defer cleanup()
+
+	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
+	f.(*EnvAWSFingerprint).endpoint = endpoint
+
+	node := &structs.Node{
+		Attributes: make(map[string]string),
+	}
+
+	request := &FingerprintRequest{Config: &config.Config{}, Node: node}
+	var response FingerprintResponse
+	err := f.Fingerprint(request, &response)
+	require.NoError(t, err)
+
+	assertNodeAttributeContains(t, response.Attributes, "unique.network.ip-address")
+
+	require.NotNil(t, response.NodeResources)
+	require.Len(t, response.NodeResources.Networks, 1)
+
+	// Test at least the first Network Resource
+	net := response.NodeResources.Networks[0]
+	require.NotEmpty(t, net.IP, "Expected Network Resource to have an IP")
+	require.NotEmpty(t, net.CIDR, "Expected Network Resource to have a CIDR")
+	require.NotEmpty(t, net.Device, "Expected Network Resource to have a Device Name")
+}
+
+func TestNetworkFingerprint_AWS_network(t *testing.T) {
+	endpoint, cleanup := startFakeEC2Metadata(t)
+	defer cleanup()
+
+	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
+	f.(*EnvAWSFingerprint).endpoint = endpoint
+
+	{
+		node := &structs.Node{
+			Attributes: make(map[string]string),
+		}
+
+		request := &FingerprintRequest{Config: &config.Config{}, Node: node}
+		var response FingerprintResponse
+		err := f.Fingerprint(request, &response)
+		require.NoError(t, err)
+
+		require.True(t, response.Detected, "expected response to be applicable")
+
+		assertNodeAttributeContains(t, response.Attributes, "unique.network.ip-address")
+
+		require.NotNil(t, response.NodeResources)
+		require.Len(t, response.NodeResources.Networks, 1)
+
+		// Test at least the first Network Resource
+		net := response.NodeResources.Networks[0]
+		require.NotEmpty(t, net.IP, "Expected Network Resource to have an IP")
+		require.NotEmpty(t, net.CIDR, "Expected Network Resource to have a CIDR")
+		require.NotEmpty(t, net.Device, "Expected Network Resource to have a Device Name")
+		require.Equal(t, 1000, net.MBits)
+	}
+
+	// Try again this time setting a network speed in the config
+	{
+		node := &structs.Node{
+			Attributes: make(map[string]string),
+		}
+
+		cfg := &config.Config{
+			NetworkSpeed: 10,
+		}
+
+		request := &FingerprintRequest{Config: cfg, Node: node}
+		var response FingerprintResponse
+		err := f.Fingerprint(request, &response)
+		require.NoError(t, err)
+
+		assertNodeAttributeContains(t, response.Attributes, "unique.network.ip-address")
+
+		require.NotNil(t, response.NodeResources)
+		require.Len(t, response.NodeResources.Networks, 1)
+
+		// Test at least the first Network Resource
+		net := response.NodeResources.Networks[0]
+		require.NotEmpty(t, net.IP, "Expected Network Resource to have an IP")
+		require.NotEmpty(t, net.CIDR, "Expected Network Resource to have a CIDR")
+		require.NotEmpty(t, net.Device, "Expected Network Resource to have a Device Name")
+		require.Equal(t, 10, net.MBits)
+	}
+}
+
+/// Utility functions for tests
+
+func startFakeEC2Metadata(t *testing.T) (endpoint string, cleanup func()) {
+	routes := routes{}
+	if err := json.Unmarshal([]byte(aws_routes), &routes); err != nil {
+		t.Fatalf("Failed to unmarshal JSON in AWS ENV test: %s", err)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, e := range routes.Endpoints {
+			if r.RequestURI == e.Uri {
+				w.Header().Set("Content-Type", e.ContentType)
+				fmt.Fprintln(w, e.Body)
+			}
+		}
+	}))
+
+	return ts.URL + "/latest", ts.Close
 }
 
 type routes struct {
@@ -148,168 +238,3 @@ const aws_routes = `
   ]
 }
 `
-
-func TestNetworkFingerprint_AWS(t *testing.T) {
-	// configure mock server with fixture routes, data
-	routes := routes{}
-	if err := json.Unmarshal([]byte(aws_routes), &routes); err != nil {
-		t.Fatalf("Failed to unmarshal JSON in AWS ENV test: %s", err)
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for _, e := range routes.Endpoints {
-			if r.RequestURI == e.Uri {
-				w.Header().Set("Content-Type", e.ContentType)
-				fmt.Fprintln(w, e.Body)
-			}
-		}
-	}))
-
-	defer ts.Close()
-	os.Setenv("AWS_ENV_URL", ts.URL+"/latest/meta-data/")
-
-	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	node := &structs.Node{
-		Attributes: make(map[string]string),
-	}
-
-	request := &FingerprintRequest{Config: &config.Config{}, Node: node}
-	var response FingerprintResponse
-	err := f.Fingerprint(request, &response)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	assertNodeAttributeContains(t, response.Attributes, "unique.network.ip-address")
-
-	if response.NodeResources == nil || len(response.NodeResources.Networks) == 0 {
-		t.Fatal("Expected to find Network Resources")
-	}
-
-	// Test at least the first Network Resource
-	net := response.NodeResources.Networks[0]
-	if net.IP == "" {
-		t.Fatal("Expected Network Resource to have an IP")
-	}
-	if net.CIDR == "" {
-		t.Fatal("Expected Network Resource to have a CIDR")
-	}
-	if net.Device == "" {
-		t.Fatal("Expected Network Resource to have a Device Name")
-	}
-}
-
-func TestNetworkFingerprint_AWS_network(t *testing.T) {
-	// configure mock server with fixture routes, data
-	routes := routes{}
-	if err := json.Unmarshal([]byte(aws_routes), &routes); err != nil {
-		t.Fatalf("Failed to unmarshal JSON in AWS ENV test: %s", err)
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for _, e := range routes.Endpoints {
-			if r.RequestURI == e.Uri {
-				w.Header().Set("Content-Type", e.ContentType)
-				fmt.Fprintln(w, e.Body)
-			}
-		}
-	}))
-
-	defer ts.Close()
-	os.Setenv("AWS_ENV_URL", ts.URL+"/latest/meta-data/")
-
-	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	{
-		node := &structs.Node{
-			Attributes: make(map[string]string),
-		}
-
-		request := &FingerprintRequest{Config: &config.Config{}, Node: node}
-		var response FingerprintResponse
-		err := f.Fingerprint(request, &response)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		if !response.Detected {
-			t.Fatalf("expected response to be applicable")
-		}
-
-		assertNodeAttributeContains(t, response.Attributes, "unique.network.ip-address")
-
-		if response.NodeResources == nil || len(response.NodeResources.Networks) == 0 {
-			t.Fatal("Expected to find Network Resources")
-		}
-
-		// Test at least the first Network Resource
-		net := response.NodeResources.Networks[0]
-		if net.IP == "" {
-			t.Fatal("Expected Network Resource to have an IP")
-		}
-		if net.CIDR == "" {
-			t.Fatal("Expected Network Resource to have a CIDR")
-		}
-		if net.Device == "" {
-			t.Fatal("Expected Network Resource to have a Device Name")
-		}
-		if net.MBits != 1000 {
-			t.Fatalf("Expected Network Resource to have speed %d; got %d", 1000, net.MBits)
-		}
-	}
-
-	// Try again this time setting a network speed in the config
-	{
-		node := &structs.Node{
-			Attributes: make(map[string]string),
-		}
-
-		cfg := &config.Config{
-			NetworkSpeed: 10,
-		}
-
-		request := &FingerprintRequest{Config: cfg, Node: node}
-		var response FingerprintResponse
-		err := f.Fingerprint(request, &response)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		assertNodeAttributeContains(t, response.Attributes, "unique.network.ip-address")
-
-		if response.NodeResources == nil || len(response.NodeResources.Networks) == 0 {
-			t.Fatal("Expected to find Network Resources")
-		}
-
-		// Test at least the first Network Resource
-		net := response.NodeResources.Networks[0]
-		if net.IP == "" {
-			t.Fatal("Expected Network Resource to have an IP")
-		}
-		if net.CIDR == "" {
-			t.Fatal("Expected Network Resource to have a CIDR")
-		}
-		if net.Device == "" {
-			t.Fatal("Expected Network Resource to have a Device Name")
-		}
-		if net.MBits != 10 {
-			t.Fatalf("Expected Network Resource to have speed %d; got %d", 10, net.MBits)
-		}
-	}
-}
-
-func TestNetworkFingerprint_notAWS(t *testing.T) {
-	os.Setenv("AWS_ENV_URL", "http://127.0.0.1/latest/meta-data/")
-	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	node := &structs.Node{
-		Attributes: make(map[string]string),
-	}
-
-	request := &FingerprintRequest{Config: &config.Config{}, Node: node}
-	var response FingerprintResponse
-	err := f.Fingerprint(request, &response)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if len(response.Attributes) > 0 {
-		t.Fatalf("Should not apply")
-	}
-}

--- a/client/fingerprint/fingerprint_test.go
+++ b/client/fingerprint/fingerprint_test.go
@@ -7,65 +7,37 @@ import (
 
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
 )
 
 func assertFingerprintOK(t *testing.T, fp Fingerprint, node *structs.Node) *FingerprintResponse {
 	request := &FingerprintRequest{Config: new(config.Config), Node: node}
 	var response FingerprintResponse
 	err := fp.Fingerprint(request, &response)
-	if err != nil {
-		t.Fatalf("Failed to fingerprint: %s", err)
-	}
+	require.NoError(t, err)
 
-	if len(response.Attributes) == 0 {
-		t.Fatalf("Failed to apply node attributes")
-	}
+	require.NotEmpty(t, response.Attributes, "Failed to apply node attributes")
 
 	return &response
 }
 
 func assertNodeAttributeContains(t *testing.T, nodeAttributes map[string]string, attribute string) {
-	if nodeAttributes == nil {
-		t.Errorf("expected an initialized map for node attributes")
-		return
-	}
+	require.NotNil(t, nodeAttributes, "expected an initialized map for node attributes")
 
-	actual, found := nodeAttributes[attribute]
-	if !found {
-		t.Errorf("Expected to find Attribute `%s`\n\n[DEBUG] %#v", attribute, nodeAttributes)
-		return
-	}
-	if actual == "" {
-		t.Errorf("Expected non-empty Attribute value for `%s`\n\n[DEBUG] %#v", attribute, nodeAttributes)
-	}
+	require.Contains(t, nodeAttributes, attribute)
+	require.NotEmpty(t, nodeAttributes[attribute])
 }
 
 func assertNodeAttributeEquals(t *testing.T, nodeAttributes map[string]string, attribute string, expected string) {
-	if nodeAttributes == nil {
-		t.Errorf("expected an initialized map for node attributes")
-		return
-	}
-	actual, found := nodeAttributes[attribute]
-	if !found {
-		t.Errorf("Expected to find Attribute `%s`; unable to check value\n\n[DEBUG] %#v", attribute, nodeAttributes)
-		return
-	}
-	if expected != actual {
-		t.Errorf("Expected `%s` Attribute to be `%s`, found `%s`\n\n[DEBUG] %#v", attribute, expected, actual, nodeAttributes)
-	}
+	require.NotNil(t, nodeAttributes, "expected an initialized map for node attributes")
+
+	require.Contains(t, nodeAttributes, attribute)
+	require.Equal(t, expected, nodeAttributes[attribute])
 }
 
 func assertNodeLinksContains(t *testing.T, nodeLinks map[string]string, link string) {
-	if nodeLinks == nil {
-		t.Errorf("expected an initialized map for node links")
-		return
-	}
-	actual, found := nodeLinks[link]
-	if !found {
-		t.Errorf("Expected to find Link `%s`\n\n[DEBUG]", link)
-		return
-	}
-	if actual == "" {
-		t.Errorf("Expected non-empty Link value for `%s`\n\n[DEBUG]", link)
-	}
+	require.NotNil(t, nodeLinks, "expected an initialized map for node links")
+
+	require.Contains(t, nodeLinks, link)
+	require.NotEmpty(t, nodeLinks[link])
 }


### PR DESCRIPTION
One step to address https://github.com/hashicorp/nomad/issues/6744 .

Update AWS Fingerprinter to use the AWS SDK library rather than a hand-rolling httpClient invocations.

I maintained the seemingly arbitrary 2 second timeout (the SDK uses 5 second as timeout) mostly to avoid slowing node node registration outside AWS.

Also, I kept honoring `AWS_URL_ENV`, an environment variable that was used in tests only and never documented, just in case it's used in the wild.

Lastly, one commit cleans up the tests to use testify and other minor changes.

A subsequent PR will update AWS and go-discover vendored libraries.