### PR TITLE
website: add ‘intro to nomad’ video to /intro

### DIFF
--- a/website/source/assets/stylesheets/_inner.scss
+++ b/website/source/assets/stylesheets/_inner.scss
@@ -95,4 +95,9 @@
     @extend .table;
     @extend .table-striped;
   }
+
+  iframe {
+    width: 100%;
+    max-width: 560px;
+  }
 }

--- a/website/source/intro/index.html.markdown
+++ b/website/source/intro/index.html.markdown
@@ -16,6 +16,8 @@ Nomad is a flexible workload orchestrator that enables an organization to easily
 
 Nomad enables developers to use declarative infrastructure-as-code for deploying applications.  Nomad uses bin packing to efficiently schedule jobs and optimize for resource utilization.  Nomad is supported on macOS, Windows, and Linux.
 
+<iframe src="https://www.youtube.com/embed/s_Fm9UtL4YU" frameborder="0" allowfullscreen="true"  width="560" height="315" ></iframe>
+
 Nomad is widely adopted and used in production by PagerDuty, Target, Citadel, Trivago, SAP, Pandora, Roblox, eBay, Deluxe Entertainment, and more.   
 
 ## Key Features


### PR DESCRIPTION
the impetus for adding this video comes from a request from Armon Dadgar...

> I do think it would be worth getting some of them onto the IO sites as well, like quick "what is TF" type videos - armon

this PR additionally adds some css to allow the embedded iframe to respond at lower browser sizes

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/49507/69667186-8523b680-105b-11ea-9fb1-248eb25a3bd5.png">

cc @mpron 