### PR TITLE
tests: swap lib/freeport for tweaked helper/freeport

### DIFF
--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestClient_ACL_resolveTokenValue(t *testing.T) {
-	s1, _, _ := testACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, _, _, cleanupS1 := testACLServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	c1, cleanup := TestClient(t, func(c *config.Config) {
@@ -62,8 +62,8 @@ func TestClient_ACL_resolveTokenValue(t *testing.T) {
 }
 
 func TestClient_ACL_resolvePolicies(t *testing.T) {
-	s1, _, root := testACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, _, root, cleanupS1 := testACLServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	c1, cleanup := TestClient(t, func(c *config.Config) {
@@ -102,8 +102,8 @@ func TestClient_ACL_resolvePolicies(t *testing.T) {
 }
 
 func TestClient_ACL_ResolveToken_Disabled(t *testing.T) {
-	s1, _ := testServer(t, nil)
-	defer s1.Shutdown()
+	s1, _, cleanupS1 := testServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	c1, cleanup := TestClient(t, func(c *config.Config) {
@@ -118,8 +118,8 @@ func TestClient_ACL_ResolveToken_Disabled(t *testing.T) {
 }
 
 func TestClient_ACL_ResolveToken(t *testing.T) {
-	s1, _, _ := testACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, _, _, cleanupS1 := testACLServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	c1, cleanup := TestClient(t, func(c *config.Config) {

--- a/client/agent_endpoint_test.go
+++ b/client/agent_endpoint_test.go
@@ -27,14 +27,14 @@ func TestMonitor_Monitor(t *testing.T) {
 	require := require.New(t)
 
 	// start server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	req := cstructs.MonitorRequest{
 		LogLevel: "debug",
@@ -108,15 +108,15 @@ func TestMonitor_Monitor_ACL(t *testing.T) {
 	require := require.New(t)
 
 	// start server
-	s, root := nomad.TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := nomad.TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.ACLEnabled = true
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	policyBad := mock.NodePolicy(acl.PolicyDeny)
 	tokenBad := mock.CreatePolicyAndToken(t, s.State(), 1005, "invalid", policyBad)

--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -69,14 +69,15 @@ func TestAllocations_Restart(t *testing.T) {
 func TestAllocations_Restart_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	server, addr, root := testACLServer(t, nil)
-	defer server.Shutdown()
 
-	client, cleanup := TestClient(t, func(c *config.Config) {
+	server, addr, root, cleanupS := testACLServer(t, nil)
+	defer cleanupS()
+
+	client, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	job := mock.BatchJob()
 	job.TaskGroups[0].Count = 1
@@ -155,14 +156,15 @@ func TestAllocations_GarbageCollectAll(t *testing.T) {
 func TestAllocations_GarbageCollectAll_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	server, addr, root := testACLServer(t, nil)
-	defer server.Shutdown()
 
-	client, cleanup := TestClient(t, func(c *config.Config) {
+	server, addr, root, cleanupS := testACLServer(t, nil)
+	defer cleanupS()
+
+	client, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Try request without a token and expect failure
 	{
@@ -248,14 +250,15 @@ func TestAllocations_GarbageCollect(t *testing.T) {
 func TestAllocations_GarbageCollect_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	server, addr, root := testACLServer(t, nil)
-	defer server.Shutdown()
 
-	client, cleanup := TestClient(t, func(c *config.Config) {
+	server, addr, root, cleanupS := testACLServer(t, nil)
+	defer cleanupS()
+
+	client, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	job := mock.BatchJob()
 	job.TaskGroups[0].Count = 1
@@ -344,14 +347,15 @@ func TestAllocations_Signal(t *testing.T) {
 func TestAllocations_Signal_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	server, addr, root := testACLServer(t, nil)
-	defer server.Shutdown()
 
-	client, cleanup := TestClient(t, func(c *config.Config) {
+	server, addr, root, cleanupS := testACLServer(t, nil)
+	defer cleanupS()
+
+	client, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	job := mock.BatchJob()
 	job.TaskGroups[0].Count = 1
@@ -448,14 +452,15 @@ func TestAllocations_Stats(t *testing.T) {
 func TestAllocations_Stats_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	server, addr, root := testACLServer(t, nil)
-	defer server.Shutdown()
 
-	client, cleanup := TestClient(t, func(c *config.Config) {
+	server, addr, root, cleanupS := testACLServer(t, nil)
+	defer cleanupS()
+
+	client, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	job := mock.BatchJob()
 	job.TaskGroups[0].Count = 1
@@ -521,14 +526,14 @@ func TestAlloc_ExecStreaming(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	expectedStdout := "Hello from the other side\n"
 	expectedStderr := "Hello from the other side\n"
@@ -625,14 +630,14 @@ func TestAlloc_ExecStreaming_NoAllocation(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Make the request
 	req := &cstructs.AllocExecRequest{
@@ -680,15 +685,15 @@ func TestAlloc_ExecStreaming_DisableRemoteExec(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 		c.DisableRemoteExec = true
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Make the request
 	req := &cstructs.AllocExecRequest{
@@ -735,15 +740,15 @@ func TestAlloc_ExecStreaming_ACL_Basic(t *testing.T) {
 	t.Parallel()
 
 	// Start a server and client
-	s, root := nomad.TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := nomad.TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	client, cleanup := TestClient(t, func(c *config.Config) {
+	client, cleanupC := TestClient(t, func(c *config.Config) {
 		c.ACLEnabled = true
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Create a bad token
 	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityDeny})
@@ -839,11 +844,11 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_Image(t *testing.T) {
 	isolation := drivers.FSIsolationImage
 
 	// Start a server and client
-	s, root := nomad.TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := nomad.TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	client, cleanup := TestClient(t, func(c *config.Config) {
+	client, cleanupC := TestClient(t, func(c *config.Config) {
 		c.ACLEnabled = true
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 
@@ -858,7 +863,7 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_Image(t *testing.T) {
 
 		c.PluginLoader = catalog.TestPluginLoaderWithOptions(t, "", map[string]string{}, pluginConfig)
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Create a bad token
 	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityDeny})
@@ -988,8 +993,8 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_Chroot(t *testing.T) {
 	isolation := drivers.FSIsolationChroot
 
 	// Start a server and client
-	s, root := nomad.TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := nomad.TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	client, cleanup := TestClient(t, func(c *config.Config) {
@@ -1132,8 +1137,8 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_None(t *testing.T) {
 	isolation := drivers.FSIsolationNone
 
 	// Start a server and client
-	s, root := nomad.TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := nomad.TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	client, cleanup := TestClient(t, func(c *config.Config) {

--- a/client/alloc_watcher_e2e_test.go
+++ b/client/alloc_watcher_e2e_test.go
@@ -29,7 +29,7 @@ func TestPrevAlloc_StreamAllocDir_TLS(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	server := nomad.TestServer(t, func(c *nomad.Config) {
+	server, cleanupS := nomad.TestServer(t, func(c *nomad.Config) {
 		c.TLSConfig = &config.TLSConfig{
 			EnableHTTP:           true,
 			EnableRPC:            true,
@@ -39,7 +39,7 @@ func TestPrevAlloc_StreamAllocDir_TLS(t *testing.T) {
 			KeyFile:              serverKeyFn,
 		}
 	})
-	defer server.Shutdown()
+	defer cleanupS()
 	testutil.WaitForLeader(t, server.RPC)
 
 	t.Logf("[TEST] Leader started: %s", server.GetConfig().RPCAddr.String())

--- a/client/client_stats_endpoint_test.go
+++ b/client/client_stats_endpoint_test.go
@@ -28,14 +28,15 @@ func TestClientStats_Stats(t *testing.T) {
 func TestClientStats_Stats_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	server, addr, root := testACLServer(t, nil)
-	defer server.Shutdown()
 
-	client, cleanup := TestClient(t, func(c *config.Config) {
+	server, addr, root, cleanupS := testACLServer(t, nil)
+	defer cleanupS()
+
+	client, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{addr}
 		c.ACLEnabled = true
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Try request without a token and expect failure
 	{

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -80,14 +80,14 @@ func TestFS_Stat(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Create and add an alloc
 	job := mock.BatchJob()
@@ -116,8 +116,8 @@ func TestFS_Stat_ACL(t *testing.T) {
 	t.Parallel()
 
 	// Start a server
-	s, root := nomad.TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := nomad.TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	client, cleanup := TestClient(t, func(c *config.Config) {
@@ -213,14 +213,14 @@ func TestFS_List(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Create and add an alloc
 	job := mock.BatchJob()
@@ -249,8 +249,8 @@ func TestFS_List_ACL(t *testing.T) {
 	t.Parallel()
 
 	// Start a server
-	s, root := nomad.TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := nomad.TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	client, cleanup := TestClient(t, func(c *config.Config) {
@@ -399,8 +399,8 @@ func TestFS_Stream_ACL(t *testing.T) {
 	t.Parallel()
 
 	// Start a server
-	s, root := nomad.TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := nomad.TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	client, cleanup := TestClient(t, func(c *config.Config) {
@@ -528,14 +528,14 @@ func TestFS_Stream(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	expected := "Hello from the other side"
 	job := mock.BatchJob()
@@ -644,14 +644,14 @@ func TestFS_Stream_Follow(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	expectedBase := "Hello from the other side"
 	repeat := 10
@@ -741,8 +741,8 @@ func TestFS_Stream_Limit(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	c, cleanup := TestClient(t, func(c *config.Config) {
@@ -913,14 +913,14 @@ func TestFS_Logs_TaskPending(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	job := mock.BatchJob()
 	job.TaskGroups[0].Count = 1
@@ -1028,8 +1028,8 @@ func TestFS_Logs_ACL(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server
-	s, root := nomad.TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := nomad.TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	client, cleanup := TestClient(t, func(c *config.Config) {
@@ -1159,14 +1159,14 @@ func TestFS_Logs(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	expected := "Hello from the other side\n"
 	job := mock.BatchJob()
@@ -1260,14 +1260,14 @@ func TestFS_Logs_Follow(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := nomad.TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := nomad.TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	expectedBase := "Hello from the other side\n"
 	repeat := 10

--- a/client/gc_test.go
+++ b/client/gc_test.go
@@ -351,8 +351,8 @@ func TestAllocGarbageCollector_MakeRoomFor_MaxAllocs(t *testing.T) {
 	const maxAllocs = 6
 	require := require.New(t)
 
-	server, serverAddr := testServer(t, nil)
-	defer server.Shutdown()
+	server, serverAddr, cleanupS := testServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, server.RPC)
 
 	client, cleanup := TestClient(t, func(c *config.Config) {

--- a/client/rpc_test.go
+++ b/client/rpc_test.go
@@ -15,14 +15,15 @@ import (
 func TestRpc_streamingRpcConn_badEndpoint(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := nomad.TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := nomad.TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s1.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Wait for the client to connect
 	testutil.WaitForResult(func() (bool, error) {
@@ -59,7 +60,7 @@ func TestRpc_streamingRpcConn_badEndpoint_TLS(t *testing.T) {
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
 
-	s1 := nomad.TestServer(t, func(c *nomad.Config) {
+	s1, cleanupS1 := nomad.TestServer(t, func(c *nomad.Config) {
 		c.Region = "regionFoo"
 		c.BootstrapExpect = 1
 		c.DevDisableBootstrap = true
@@ -72,10 +73,10 @@ func TestRpc_streamingRpcConn_badEndpoint_TLS(t *testing.T) {
 			KeyFile:              fookey,
 		}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c, cleanup := TestClient(t, func(c *config.Config) {
+	c, cleanupC := TestClient(t, func(c *config.Config) {
 		c.Region = "regionFoo"
 		c.Servers = []string{s1.GetConfig().RPCAddr.String()}
 		c.TLSConfig = &sconfig.TLSConfig{
@@ -87,7 +88,7 @@ func TestRpc_streamingRpcConn_badEndpoint_TLS(t *testing.T) {
 			KeyFile:              fookey,
 		}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Wait for the client to connect
 	testutil.WaitForResult(func() (bool, error) {

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/lib/freeport"
 	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/stretchr/testify/require"
@@ -594,7 +594,9 @@ func TestConfig_Listener(t *testing.T) {
 	}
 
 	// Works with valid inputs
-	ports := freeport.GetT(t, 2)
+	ports := freeport.MustTake(2)
+	defer freeport.Return(ports)
+
 	ln, err := config.Listener("tcp", "127.0.0.1", ports[0])
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/freeport"
 	tu "github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,8 @@ func TestDockerDriver_PidsLimit(t *testing.T) {
 	testutil.DockerCompatible(t)
 	require := require.New(t)
 
-	task, cfg, _ := dockerTask(t)
+	task, cfg, ports := dockerTask(t)
+	defer freeport.Return(ports)
 	cfg.PidsLimit = 1
 	cfg.Command = "/bin/sh"
 	cfg.Args = []string{"-c", "sleep 2 & sleep 2"}

--- a/drivers/docker/driver_unix_test.go
+++ b/drivers/docker/driver_unix_test.go
@@ -17,6 +17,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	dtestutil "github.com/hashicorp/nomad/plugins/drivers/testutils"
@@ -30,7 +31,8 @@ func TestDockerDriver_User(t *testing.T) {
 		t.Parallel()
 	}
 	testutil.DockerCompatible(t)
-	task, cfg, _ := dockerTask(t)
+	task, cfg, ports := dockerTask(t)
+	defer freeport.Return(ports)
 	task.User = "alice"
 	cfg.Command = "/bin/sleep"
 	cfg.Args = []string{"10000"}
@@ -151,7 +153,8 @@ func TestDockerDriver_CPUCFSPeriod(t *testing.T) {
 	}
 	testutil.DockerCompatible(t)
 
-	task, cfg, _ := dockerTask(t)
+	task, cfg, ports := dockerTask(t)
+	defer freeport.Return(ports)
 	cfg.CPUHardLimit = true
 	cfg.CPUCFSPeriod = 1000000
 	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
@@ -169,7 +172,8 @@ func TestDockerDriver_CPUCFSPeriod(t *testing.T) {
 
 func TestDockerDriver_Sysctl_Ulimit(t *testing.T) {
 	testutil.DockerCompatible(t)
-	task, cfg, _ := dockerTask(t)
+	task, cfg, ports := dockerTask(t)
+	defer freeport.Return(ports)
 	expectedUlimits := map[string]string{
 		"nproc":  "4242",
 		"nofile": "2048:4096",
@@ -237,7 +241,7 @@ func TestDockerDriver_Sysctl_Ulimit_Errors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		task, cfg, _ := dockerTask(t)
+		task, cfg, ports := dockerTask(t)
 		cfg.Ulimit = tc.ulimitConfig
 		require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
@@ -249,6 +253,7 @@ func TestDockerDriver_Sysctl_Ulimit_Errors(t *testing.T) {
 		_, _, err := d.StartTask(task)
 		require.NotNil(t, err, "Expected non nil error")
 		require.Contains(t, err.Error(), tc.err.Error())
+		freeport.Return(ports)
 	}
 }
 
@@ -336,7 +341,8 @@ func TestDockerDriver_BindMountsHonorVolumesEnabledFlag(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
-				task, cfg, _ := dockerTask(t)
+				task, cfg, ports := dockerTask(t)
+				defer freeport.Return(ports)
 				cfg.VolumeDriver = c.volumeDriver
 				cfg.Volumes = c.volumes
 
@@ -362,7 +368,8 @@ func TestDockerDriver_BindMountsHonorVolumesEnabledFlag(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
-				task, cfg, _ := dockerTask(t)
+				task, cfg, ports := dockerTask(t)
+				defer freeport.Return(ports)
 				cfg.VolumeDriver = c.volumeDriver
 				cfg.Volumes = c.volumes
 
@@ -509,7 +516,8 @@ func TestDockerDriver_MountsSerialization(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
-				task, cfg, _ := dockerTask(t)
+				task, cfg, ports := dockerTask(t)
+				defer freeport.Return(ports)
 				cfg.Mounts = c.passedMounts
 
 				task.AllocDir = allocDir
@@ -531,7 +539,8 @@ func TestDockerDriver_MountsSerialization(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
-				task, cfg, _ := dockerTask(t)
+				task, cfg, ports := dockerTask(t)
+				defer freeport.Return(ports)
 				cfg.Mounts = c.passedMounts
 
 				task.AllocDir = allocDir
@@ -559,7 +568,8 @@ func TestDockerDriver_CreateContainerConfig_MountsCombined(t *testing.T) {
 	t.Parallel()
 	testutil.DockerCompatible(t)
 
-	task, cfg, _ := dockerTask(t)
+	task, cfg, ports := dockerTask(t)
+	defer freeport.Return(ports)
 
 	task.Devices = []*drivers.DeviceConfig{
 		{

--- a/drivers/docker/reconciler_test.go
+++ b/drivers/docker/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -56,7 +57,8 @@ func TestDanglingContainerRemoval(t *testing.T) {
 	testutil.DockerCompatible(t)
 
 	// start two containers: one tracked nomad container, and one unrelated container
-	task, cfg, _ := dockerTask(t)
+	task, cfg, ports := dockerTask(t)
+	defer freeport.Return(ports)
 	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
 	client, d, handle, cleanup := dockerSetup(t, task)
@@ -157,7 +159,8 @@ func TestDanglingContainerRemoval(t *testing.T) {
 func TestDanglingContainerRemoval_Stopped(t *testing.T) {
 	testutil.DockerCompatible(t)
 
-	_, cfg, _ := dockerTask(t)
+	_, cfg, ports := dockerTask(t)
+	defer freeport.Return(ports)
 
 	client := newTestDockerClient(t)
 	container, err := client.CreateContainer(docker.CreateContainerOptions{

--- a/helper/freeport/ephemeral_darwin.go
+++ b/helper/freeport/ephemeral_darwin.go
@@ -1,0 +1,46 @@
+//+build darwin
+
+package freeport
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+/*
+$ sysctl net.inet.ip.portrange.first net.inet.ip.portrange.last
+net.inet.ip.portrange.first: 49152
+net.inet.ip.portrange.last: 65535
+*/
+
+const (
+	ephPortFirst = "net.inet.ip.portrange.first"
+	ephPortLast  = "net.inet.ip.portrange.last"
+	command      = "sysctl"
+)
+
+var ephPortRe = regexp.MustCompile(`^\s*(\d+)\s+(\d+)\s*$`)
+
+func getEphemeralPortRange() (int, int, error) {
+	cmd := exec.Command(command, "-n", ephPortFirst, ephPortLast)
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	val := string(out)
+
+	m := ephPortRe.FindStringSubmatch(val)
+	if m != nil {
+		min, err1 := strconv.Atoi(m[1])
+		max, err2 := strconv.Atoi(m[2])
+
+		if err1 == nil && err2 == nil {
+			return min, max, nil
+		}
+	}
+
+	return 0, 0, fmt.Errorf("unexpected sysctl value %q for keys %q %q", val, ephPortFirst, ephPortLast)
+}

--- a/helper/freeport/ephemeral_darwin_test.go
+++ b/helper/freeport/ephemeral_darwin_test.go
@@ -1,0 +1,18 @@
+//+build darwin
+
+package freeport
+
+import (
+	"testing"
+)
+
+func TestGetEphemeralPortRange(t *testing.T) {
+	min, max, err := getEphemeralPortRange()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if min <= 0 || max <= 0 || min > max {
+		t.Fatalf("unexpected values: min=%d, max=%d", min, max)
+	}
+	t.Logf("min=%d, max=%d", min, max)
+}

--- a/helper/freeport/ephemeral_linux.go
+++ b/helper/freeport/ephemeral_linux.go
@@ -1,0 +1,41 @@
+//+build linux
+
+package freeport
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+/*
+$ sysctl -n net.ipv4.ip_local_port_range
+32768	60999
+*/
+
+const ephemeralPortRangeSysctlKey = "net.ipv4.ip_local_port_range"
+
+var ephemeralPortRangePatt = regexp.MustCompile(`^\s*(\d+)\s+(\d+)\s*$`)
+
+func getEphemeralPortRange() (int, int, error) {
+	cmd := exec.Command("sysctl", "-n", ephemeralPortRangeSysctlKey)
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	val := string(out)
+
+	m := ephemeralPortRangePatt.FindStringSubmatch(val)
+	if m != nil {
+		min, err1 := strconv.Atoi(m[1])
+		max, err2 := strconv.Atoi(m[2])
+
+		if err1 == nil && err2 == nil {
+			return min, max, nil
+		}
+	}
+
+	return 0, 0, fmt.Errorf("unexpected sysctl value %q for key %q", val, ephemeralPortRangeSysctlKey)
+}

--- a/helper/freeport/ephemeral_linux_test.go
+++ b/helper/freeport/ephemeral_linux_test.go
@@ -1,0 +1,18 @@
+//+build linux
+
+package freeport
+
+import (
+	"testing"
+)
+
+func TestGetEphemeralPortRange(t *testing.T) {
+	min, max, err := getEphemeralPortRange()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if min <= 0 || max <= 0 || min > max {
+		t.Fatalf("unexpected values: min=%d, max=%d", min, max)
+	}
+	t.Logf("min=%d, max=%d", min, max)
+}

--- a/helper/freeport/ephemeral_windows.go
+++ b/helper/freeport/ephemeral_windows.go
@@ -1,0 +1,11 @@
+//+build windows
+
+package freeport
+
+// For now we hard-code the Windows ephemeral port range, which is documented by
+// Microsoft to be in this range for Vista / Server 2008 and newer.
+//
+// https://support.microsoft.com/en-us/help/832017/service-overview-and-network-port-requirements-for-windows
+func getEphemeralPortRange() (int, int, error) {
+	return 49152, 65535, nil
+}

--- a/helper/freeport/freeport.go
+++ b/helper/freeport/freeport.go
@@ -1,0 +1,297 @@
+// Copied from github.com/hashicorp/consul/sdk/freeport
+//
+// and tweaked for use by Nomad.
+package freeport
+
+import (
+	"container/list"
+	"fmt"
+	"math/rand"
+	"net"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// todo(shoenig)
+//  There is a conflict between this copy of the updated sdk/freeport package
+//  and the lib/freeport package that is vendored as of nomad v0.10.x, which
+//  means we need to be careful to avoid the ports that transitive dependency
+//  is going to use (i.e. 10,000+). For now, we use the 9XXX port range with
+//  small blocks which means some tests will have to wait, and we need to be
+//  very careful not to leak ports.
+
+const (
+	// blockSize is the size of the allocated port block. ports are given out
+	// consecutively from that block and after that point in a LRU fashion.
+	// blockSize = 1500
+	blockSize = 100 // todo(shoenig) revert once consul dependency is updated
+
+	// maxBlocks is the number of available port blocks before exclusions.
+	// maxBlocks = 30
+	maxBlocks = 10 // todo(shoenig) revert once consul dependency is updated
+
+	// lowPort is the lowest port number that should be used.
+	// lowPort = 10000
+	lowPort = 9000 // todo(shoenig) revert once consul dependency is updated
+
+	// attempts is how often we try to allocate a port block
+	// before giving up.
+	attempts = 10
+)
+
+var (
+	// effectiveMaxBlocks is the number of available port blocks.
+	// lowPort + effectiveMaxBlocks * blockSize must be less than 65535.
+	effectiveMaxBlocks int
+
+	// firstPort is the first port of the allocated block.
+	firstPort int
+
+	// lockLn is the system-wide mutex for the port block.
+	lockLn net.Listener
+
+	// mu guards:
+	// - pendingPorts
+	// - freePorts
+	// - total
+	mu sync.Mutex
+
+	// once is used to do the initialization on the first call to retrieve free
+	// ports
+	once sync.Once
+
+	// condNotEmpty is a condition variable to wait for freePorts to be not
+	// empty. Linked to 'mu'
+	condNotEmpty *sync.Cond
+
+	// freePorts is a FIFO of all currently free ports. Take from the front,
+	// and return to the back.
+	freePorts *list.List
+
+	// pendingPorts is a FIFO of recently freed ports that have not yet passed
+	// the not-in-use check.
+	pendingPorts *list.List
+
+	// total is the total number of available ports in the block for use.
+	total int
+)
+
+// initialize is used to initialize freeport.
+func initialize() {
+	var err error
+	effectiveMaxBlocks, err = adjustMaxBlocks()
+	if err != nil {
+		panic("freeport: ephemeral port range detection failed: " + err.Error())
+	}
+	if effectiveMaxBlocks < 0 {
+		panic("freeport: no blocks of ports available outside of ephemeral range")
+	}
+	if lowPort+effectiveMaxBlocks*blockSize > 65535 {
+		panic("freeport: block size too big or too many blocks requested")
+	}
+
+	rand.Seed(time.Now().UnixNano())
+	firstPort, lockLn = alloc()
+
+	condNotEmpty = sync.NewCond(&mu)
+	freePorts = list.New()
+	pendingPorts = list.New()
+
+	// fill with all available free ports
+	for port := firstPort + 1; port < firstPort+blockSize; port++ {
+		if used := isPortInUse(port); !used {
+			freePorts.PushBack(port)
+		}
+	}
+	total = freePorts.Len()
+
+	go checkFreedPorts()
+}
+
+func checkFreedPorts() {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	for {
+		<-ticker.C
+		checkFreedPortsOnce()
+	}
+}
+
+func checkFreedPortsOnce() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	pending := pendingPorts.Len()
+	remove := make([]*list.Element, 0, pending)
+	for elem := pendingPorts.Front(); elem != nil; elem = elem.Next() {
+		port := elem.Value.(int)
+		if used := isPortInUse(port); !used {
+			freePorts.PushBack(port)
+			remove = append(remove, elem)
+		}
+	}
+
+	retained := pending - len(remove)
+
+	if retained > 0 {
+		logf("WARN", "%d out of %d pending ports are still in use; something probably didn't wait around for the port to be closed!", retained, pending)
+	}
+
+	if len(remove) == 0 {
+		return
+	}
+
+	for _, elem := range remove {
+		pendingPorts.Remove(elem)
+	}
+
+	condNotEmpty.Broadcast()
+}
+
+// adjustMaxBlocks avoids having the allocation ranges overlap the ephemeral
+// port range.
+func adjustMaxBlocks() (int, error) {
+	ephemeralPortMin, ephemeralPortMax, err := getEphemeralPortRange()
+	if err != nil {
+		return 0, err
+	}
+
+	if ephemeralPortMin <= 0 || ephemeralPortMax <= 0 {
+		logf("INFO", "ephemeral port range detection not configured for GOOS=%q", runtime.GOOS)
+		return maxBlocks, nil
+	}
+
+	logf("INFO", "detected ephemeral port range of [%d, %d]", ephemeralPortMin, ephemeralPortMax)
+	for block := 0; block < maxBlocks; block++ {
+		min := lowPort + block*blockSize
+		max := min + blockSize
+		overlap := intervalOverlap(min, max-1, ephemeralPortMin, ephemeralPortMax)
+		if overlap {
+			logf("INFO", "reducing max blocks from %d to %d to avoid the ephemeral port range", maxBlocks, block)
+			return block, nil
+		}
+	}
+	return maxBlocks, nil
+}
+
+// alloc reserves a port block for exclusive use for the lifetime of the
+// application. lockLn serves as a system-wide mutex for the port block and is
+// implemented as a TCP listener which is bound to the firstPort and which will
+// be automatically released when the application terminates.
+func alloc() (int, net.Listener) {
+	for i := 0; i < attempts; i++ {
+		block := int(rand.Int31n(int32(effectiveMaxBlocks)))
+		firstPort := lowPort + block*blockSize
+		ln, err := net.ListenTCP("tcp", tcpAddr("127.0.0.1", firstPort))
+		if err != nil {
+			continue
+		}
+		// logf("DEBUG", "allocated port block %d (%d-%d)", block, firstPort, firstPort+blockSize-1)
+		return firstPort, ln
+	}
+	panic("freeport: cannot allocate port block")
+}
+
+// MustTake is the same as Take except it panics on error.
+func MustTake(n int) (ports []int) {
+	ports, err := Take(n)
+	if err != nil {
+		panic(err)
+	}
+	return ports
+}
+
+// Take returns a list of free ports from the allocated port block. It is safe
+// to call this method concurrently. Ports have been tested to be available on
+// 127.0.0.1 TCP but there is no guarantee that they will remain free in the
+// future.
+func Take(n int) (ports []int, err error) {
+	if n <= 0 {
+		return nil, fmt.Errorf("freeport: cannot take %d ports", n)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Reserve a port block
+	once.Do(initialize)
+
+	if n > total {
+		return nil, fmt.Errorf("freeport: block size too small")
+	}
+
+	for len(ports) < n {
+		for freePorts.Len() == 0 {
+			if total == 0 {
+				return nil, fmt.Errorf("freeport: impossible to satisfy request; there are no actual free ports in the block anymore")
+			}
+			condNotEmpty.Wait()
+		}
+
+		elem := freePorts.Front()
+		freePorts.Remove(elem)
+		port := elem.Value.(int)
+
+		if used := isPortInUse(port); used {
+			// Something outside of the test suite has stolen this port, possibly
+			// due to assignment to an ephemeral port, remove it completely.
+			logf("WARN", "leaked port %d due to theft; removing from circulation", port)
+			total--
+			continue
+		}
+
+		ports = append(ports, port)
+	}
+
+	// logf("DEBUG", "free ports: %v", ports)
+	return ports, nil
+}
+
+// Return returns a block of ports back to the general pool. These ports should
+// have been returned from a call to Take().
+func Return(ports []int) {
+	if len(ports) == 0 {
+		return // convenience short circuit for test ergonomics
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, port := range ports {
+		if port > firstPort && port < firstPort+blockSize {
+			pendingPorts.PushBack(port)
+		}
+	}
+}
+
+func isPortInUse(port int) bool {
+	ln, err := net.ListenTCP("tcp", tcpAddr("127.0.0.1", port))
+	if err != nil {
+		return true
+	}
+	_ = ln.Close()
+	return false
+}
+
+func tcpAddr(ip string, port int) *net.TCPAddr {
+	return &net.TCPAddr{IP: net.ParseIP(ip), Port: port}
+}
+
+// intervalOverlap returns true if the doubly-inclusive integer intervals
+// represented by [min1, max1] and [min2, max2] overlap.
+func intervalOverlap(min1, max1, min2, max2 int) bool {
+	if min1 > max1 {
+		logf("WARN", "interval1 is not ordered [%d, %d]", min1, max1)
+		return false
+	}
+	if min2 > max2 {
+		logf("WARN", "interval2 is not ordered [%d, %d]", min2, max2)
+		return false
+	}
+	return min1 <= max2 && min2 <= max1
+}
+
+func logf(severity string, format string, a ...interface{}) {
+	_, _ = fmt.Fprintf(os.Stderr, "["+severity+"] freeport: "+format+"\n", a...)
+}

--- a/helper/freeport/freeport_test.go
+++ b/helper/freeport/freeport_test.go
@@ -1,0 +1,281 @@
+package freeport
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/consul/testutil/retry"
+)
+
+// reset will reverse the setup from initialize() and then redo it (for tests)
+func reset() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	logf("INFO", "resetting the freeport package state")
+
+	effectiveMaxBlocks = 0
+	firstPort = 0
+	if lockLn != nil {
+		lockLn.Close()
+		lockLn = nil
+	}
+
+	once = sync.Once{}
+
+	freePorts = nil
+	pendingPorts = nil
+	total = 0
+}
+
+// peekFree returns the next port that will be returned by Take to aid in testing.
+func peekFree() int {
+	mu.Lock()
+	defer mu.Unlock()
+	return freePorts.Front().Value.(int)
+}
+
+// peekAllFree returns all free ports that could be returned by Take to aid in testing.
+func peekAllFree() []int {
+	mu.Lock()
+	defer mu.Unlock()
+
+	var out []int
+	for elem := freePorts.Front(); elem != nil; elem = elem.Next() {
+		port := elem.Value.(int)
+		out = append(out, port)
+	}
+
+	return out
+}
+
+// stats returns diagnostic data to aid in testing
+func stats() (numTotal, numPending, numFree int) {
+	mu.Lock()
+	defer mu.Unlock()
+	return total, pendingPorts.Len(), freePorts.Len()
+}
+
+func TestTakeReturn(t *testing.T) {
+	// NOTE: for global var reasons this cannot execute in parallel
+	// t.Parallel()
+
+	// Since this test is destructive (i.e. it leaks all ports) it means that
+	// any other test cases in this package will not function after it runs. To
+	// help out we reset the global state after we run this test.
+	defer reset()
+
+	// OK: do a simple take/return cycle to trigger the package initialization
+	func() {
+		ports, err := Take(1)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer Return(ports)
+
+		if len(ports) != 1 {
+			t.Fatalf("expected %d but got %d ports", 1, len(ports))
+		}
+	}()
+
+	waitForStatsReset := func() (numTotal int) {
+		t.Helper()
+		numTotal, numPending, numFree := stats()
+		if numTotal != numFree+numPending {
+			t.Fatalf("expected total (%d) and free+pending (%d) ports to match", numTotal, numFree+numPending)
+		}
+		retry.Run(t, func(r *retry.R) {
+			numTotal, numPending, numFree = stats()
+			if numPending != 0 {
+				r.Fatalf("pending is still non zero: %d", numPending)
+			}
+			if numTotal != numFree {
+				r.Fatalf("total (%d) does not equal free (%d)", numTotal, numFree)
+			}
+		})
+		return numTotal
+	}
+
+	// Reset
+	numTotal := waitForStatsReset()
+
+	// --------------------
+	// OK: take the max
+	func() {
+		ports, err := Take(numTotal)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer Return(ports)
+
+		if len(ports) != numTotal {
+			t.Fatalf("expected %d but got %d ports", numTotal, len(ports))
+		}
+	}()
+
+	// Reset
+	numTotal = waitForStatsReset()
+
+	expectError := func(expected string, got error) {
+		t.Helper()
+		if got == nil {
+			t.Fatalf("expected error but was nil")
+		}
+		if got.Error() != expected {
+			t.Fatalf("expected error %q but got %q", expected, got.Error())
+		}
+	}
+
+	// --------------------
+	// ERROR: take too many ports
+	func() {
+		ports, err := Take(numTotal + 1)
+		defer Return(ports)
+		expectError("freeport: block size too small", err)
+	}()
+
+	// --------------------
+	// ERROR: invalid ports request (negative)
+	func() {
+		_, err := Take(-1)
+		expectError("freeport: cannot take -1 ports", err)
+	}()
+
+	// --------------------
+	// ERROR: invalid ports request (zero)
+	func() {
+		_, err := Take(0)
+		expectError("freeport: cannot take 0 ports", err)
+	}()
+
+	// --------------------
+	// OK: Steal a port under the covers and let freeport detect the theft and compensate
+	leakedPort := peekFree()
+	func() {
+		leakyListener, err := net.ListenTCP("tcp", tcpAddr("127.0.0.1", leakedPort))
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer leakyListener.Close()
+
+		func() {
+			ports, err := Take(3)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			defer Return(ports)
+
+			if len(ports) != 3 {
+				t.Fatalf("expected %d but got %d ports", 3, len(ports))
+			}
+
+			for _, port := range ports {
+				if port == leakedPort {
+					t.Fatalf("did not expect for Take to return the leaked port")
+				}
+			}
+		}()
+
+		newNumTotal := waitForStatsReset()
+		if newNumTotal != numTotal-1 {
+			t.Fatalf("expected total to drop to %d but got %d", numTotal-1, newNumTotal)
+		}
+		numTotal = newNumTotal // update outer variable for later tests
+	}()
+
+	// --------------------
+	// OK: sequence it so that one Take must wait on another Take to Return.
+	func() {
+		mostPorts, err := Take(numTotal - 5)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		type reply struct {
+			ports []int
+			err   error
+		}
+		ch := make(chan reply, 1)
+		go func() {
+			ports, err := Take(10)
+			ch <- reply{ports: ports, err: err}
+		}()
+
+		Return(mostPorts)
+
+		r := <-ch
+		if r.err != nil {
+			t.Fatalf("err: %v", r.err)
+		}
+		defer Return(r.ports)
+
+		if len(r.ports) != 10 {
+			t.Fatalf("expected %d ports but got %d", 10, len(r.ports))
+		}
+	}()
+
+	// Reset
+	numTotal = waitForStatsReset()
+
+	// --------------------
+	// ERROR: Now we end on the crazy "Ocean's 11" level port theft where we
+	// orchestrate a situation where all ports are stolen and we don't find out
+	// until Take.
+	func() {
+		// 1. Grab all of the ports.
+		allPorts := peekAllFree()
+
+		// 2. Leak all of the ports
+		leaked := make([]io.Closer, 0, len(allPorts))
+		defer func() {
+			for _, c := range leaked {
+				c.Close()
+			}
+		}()
+		for _, port := range allPorts {
+			ln, err := net.ListenTCP("tcp", tcpAddr("127.0.0.1", port))
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			leaked = append(leaked, ln)
+		}
+
+		// 3. Request 1 port which will detect the leaked ports and fail.
+		_, err := Take(1)
+		expectError("freeport: impossible to satisfy request; there are no actual free ports in the block anymore", err)
+
+		// 4. Wait for the block to zero out.
+		newNumTotal := waitForStatsReset()
+		if newNumTotal != 0 {
+			t.Fatalf("expected total to drop to %d but got %d", 0, newNumTotal)
+		}
+	}()
+}
+
+func TestIntervalOverlap(t *testing.T) {
+	cases := []struct {
+		min1, max1, min2, max2 int
+		overlap                bool
+	}{
+		{0, 0, 0, 0, true},
+		{1, 1, 1, 1, true},
+		{1, 3, 1, 3, true},  // same
+		{1, 3, 4, 6, false}, // serial
+		{1, 4, 3, 6, true},  // inner overlap
+		{1, 6, 3, 4, true},  // nest
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%d:%d vs %d:%d", tc.min1, tc.max1, tc.min2, tc.max2), func(t *testing.T) {
+			if tc.overlap != intervalOverlap(tc.min1, tc.max1, tc.min2, tc.max2) { // 1 vs 2
+				t.Fatalf("expected %v but got %v", tc.overlap, !tc.overlap)
+			}
+			if tc.overlap != intervalOverlap(tc.min2, tc.max2, tc.min1, tc.max1) { // 2 vs 1
+				t.Fatalf("expected %v but got %v", tc.overlap, !tc.overlap)
+			}
+		})
+	}
+}

--- a/helper/pool/pool_test.go
+++ b/helper/pool/pool_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/lib/freeport"
+	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/yamux"
@@ -22,7 +22,9 @@ func newTestPool(t *testing.T) *ConnPool {
 func TestConnPool_ConnListener(t *testing.T) {
 	require := require.New(t)
 
-	ports := freeport.GetT(t, 1)
+	ports := freeport.MustTake(1)
+	defer freeport.Return(ports)
+
 	addrStr := fmt.Sprintf("127.0.0.1:%d", ports[0])
 	addr, err := net.ResolveTCPAddr("tcp", addrStr)
 	require.Nil(err)

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -20,8 +20,9 @@ import (
 
 func TestACLEndpoint_GetPolicy(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -105,8 +106,9 @@ func TestACLEndpoint_GetPolicy(t *testing.T) {
 
 func TestACLEndpoint_GetPolicy_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -184,8 +186,9 @@ func TestACLEndpoint_GetPolicy_Blocking(t *testing.T) {
 
 func TestACLEndpoint_GetPolicies(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -223,8 +226,9 @@ func TestACLEndpoint_GetPolicies(t *testing.T) {
 
 func TestACLEndpoint_GetPolicies_TokenSubset(t *testing.T) {
 	t.Parallel()
-	s1, _ := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, _, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -263,8 +267,9 @@ func TestACLEndpoint_GetPolicies_TokenSubset(t *testing.T) {
 
 func TestACLEndpoint_GetPolicies_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -343,8 +348,9 @@ func TestACLEndpoint_GetPolicies_Blocking(t *testing.T) {
 func TestACLEndpoint_ListPolicies(t *testing.T) {
 	assert := assert.New(t)
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -412,8 +418,9 @@ func TestACLEndpoint_ListPolicies(t *testing.T) {
 // exists, otherwise, empty
 func TestACLEndpoint_ListPolicies_Unauthenticated(t *testing.T) {
 	t.Parallel()
-	s1, _ := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, _, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -460,8 +467,9 @@ func TestACLEndpoint_ListPolicies_Unauthenticated(t *testing.T) {
 
 func TestACLEndpoint_ListPolicies_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -520,8 +528,9 @@ func TestACLEndpoint_ListPolicies_Blocking(t *testing.T) {
 
 func TestACLEndpoint_DeletePolicies(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -546,8 +555,9 @@ func TestACLEndpoint_DeletePolicies(t *testing.T) {
 
 func TestACLEndpoint_UpsertPolicies(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -576,8 +586,9 @@ func TestACLEndpoint_UpsertPolicies(t *testing.T) {
 
 func TestACLEndpoint_UpsertPolicies_Invalid(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -603,8 +614,9 @@ func TestACLEndpoint_UpsertPolicies_Invalid(t *testing.T) {
 
 func TestACLEndpoint_GetToken(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -648,8 +660,9 @@ func TestACLEndpoint_GetToken(t *testing.T) {
 
 func TestACLEndpoint_GetToken_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -727,8 +740,9 @@ func TestACLEndpoint_GetToken_Blocking(t *testing.T) {
 
 func TestACLEndpoint_GetTokens(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -765,8 +779,9 @@ func TestACLEndpoint_GetTokens(t *testing.T) {
 
 func TestACLEndpoint_GetTokens_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -844,8 +859,9 @@ func TestACLEndpoint_GetTokens_Blocking(t *testing.T) {
 
 func TestACLEndpoint_ListTokens(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -905,8 +921,9 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 
 func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -965,8 +982,9 @@ func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 
 func TestACLEndpoint_DeleteTokens(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -993,8 +1011,8 @@ func TestACLEndpoint_DeleteTokens_WithNonexistentToken(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1018,10 +1036,10 @@ func TestACLEndpoint_DeleteTokens_WithNonexistentToken(t *testing.T) {
 
 func TestACLEndpoint_Bootstrap(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.ACLEnabled = true
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1055,14 +1073,14 @@ func TestACLEndpoint_Bootstrap_Reset(t *testing.T) {
 	t.Parallel()
 	dir := tmpDir(t)
 	defer os.RemoveAll(dir)
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.ACLEnabled = true
 		c.DataDir = dir
 		c.DevMode = false
 		c.Bootstrap = true
 		c.DevDisableBootstrap = false
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1117,8 +1135,9 @@ func TestACLEndpoint_Bootstrap_Reset(t *testing.T) {
 
 func TestACLEndpoint_UpsertTokens(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1173,8 +1192,9 @@ func TestACLEndpoint_UpsertTokens(t *testing.T) {
 
 func TestACLEndpoint_UpsertTokens_Invalid(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1200,8 +1220,8 @@ func TestACLEndpoint_UpsertTokens_Invalid(t *testing.T) {
 
 func TestACLEndpoint_ResolveToken(t *testing.T) {
 	t.Parallel()
-	s1, _ := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, _, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -95,8 +95,8 @@ func TestResolveACLToken(t *testing.T) {
 func TestResolveACLToken_LeaderToken(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-	s1, _ := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, _, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	leaderAcl := s1.getLeaderAcl()

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -18,8 +18,10 @@ import (
 
 func TestAllocEndpoint_List(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -84,8 +86,9 @@ func TestAllocEndpoint_List(t *testing.T) {
 
 func TestAllocEndpoint_List_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -140,8 +143,9 @@ func TestAllocEndpoint_List_ACL(t *testing.T) {
 
 func TestAllocEndpoint_List_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -215,8 +219,9 @@ func TestAllocEndpoint_List_Blocking(t *testing.T) {
 
 func TestAllocEndpoint_GetAlloc(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -255,8 +260,9 @@ func TestAllocEndpoint_GetAlloc(t *testing.T) {
 
 func TestAllocEndpoint_GetAlloc_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -365,8 +371,9 @@ func TestAllocEndpoint_GetAlloc_ACL(t *testing.T) {
 
 func TestAllocEndpoint_GetAlloc_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -420,8 +427,9 @@ func TestAllocEndpoint_GetAlloc_Blocking(t *testing.T) {
 
 func TestAllocEndpoint_GetAllocs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -467,8 +475,9 @@ func TestAllocEndpoint_GetAllocs(t *testing.T) {
 
 func TestAllocEndpoint_GetAllocs_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -524,8 +533,8 @@ func TestAllocEndpoint_UpdateDesiredTransition(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, _ := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, _, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -608,8 +617,8 @@ func TestAllocEndpoint_Stop_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, _ := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, _, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 

--- a/nomad/autopilot_test.go
+++ b/nomad/autopilot_test.go
@@ -77,14 +77,15 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 		c.BootstrapExpect = 3
 		c.RaftConfig.ProtocolVersion = raft.ProtocolVersion(raftVersion)
 	}
-	s1 := TestServer(t, conf)
-	defer s1.Shutdown()
 
-	s2 := TestServer(t, conf)
-	defer s2.Shutdown()
+	s1, cleanupS1 := TestServer(t, conf)
+	defer cleanupS1()
 
-	s3 := TestServer(t, conf)
-	defer s3.Shutdown()
+	s2, cleanupS2 := TestServer(t, conf)
+	defer cleanupS2()
+
+	s3, cleanupS3 := TestServer(t, conf)
+	defer cleanupS3()
 
 	servers := []*Server{s1, s2, s3}
 
@@ -96,8 +97,8 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 	}
 
 	// Bring up a new server
-	s4 := TestServer(t, conf)
-	defer s4.Shutdown()
+	s4, cleanupS4 := TestServer(t, conf)
+	defer cleanupS4()
 
 	// Kill a non-leader server
 	s3.Shutdown()
@@ -125,24 +126,25 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 
 func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 
 	conf := func(c *Config) {
 		c.DevDisableBootstrap = true
 	}
 
-	s2 := TestServer(t, conf)
-	defer s2.Shutdown()
+	s2, cleanupS2 := TestServer(t, conf)
+	defer cleanupS2()
 
-	s3 := TestServer(t, conf)
-	defer s3.Shutdown()
+	s3, cleanupS3 := TestServer(t, conf)
+	defer cleanupS3()
 
-	s4 := TestServer(t, conf)
-	defer s4.Shutdown()
+	s4, cleanupS4 := TestServer(t, conf)
+	defer cleanupS4()
 
-	s5 := TestServer(t, conf)
-	defer s5.Shutdown()
+	s5, cleanupS5 := TestServer(t, conf)
+	defer cleanupS5()
 
 	servers := []*Server{s1, s2, s3, s4, s5}
 
@@ -171,21 +173,22 @@ func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
 
 func TestAutopilot_RollingUpdate(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
 	conf := func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 3
 	}
 
-	s2 := TestServer(t, conf)
-	defer s2.Shutdown()
+	s2, cleanupS2 := TestServer(t, conf)
+	defer cleanupS2()
 
-	s3 := TestServer(t, conf)
-	defer s3.Shutdown()
+	s3, cleanupS3 := TestServer(t, conf)
+	defer cleanupS3()
 
 	// Join the servers to s1, and wait until they are all promoted to
 	// voters.
@@ -199,8 +202,8 @@ func TestAutopilot_RollingUpdate(t *testing.T) {
 	})
 
 	// Add one more server like we are doing a rolling update.
-	s4 := TestServer(t, conf)
-	defer s4.Shutdown()
+	s4, cleanupS4 := TestServer(t, conf)
+	defer cleanupS4()
 	TestJoin(t, s1, s4)
 	servers = append(servers, s4)
 	retry.Run(t, func(r *retry.R) {
@@ -243,22 +246,22 @@ func TestAutopilot_RollingUpdate(t *testing.T) {
 
 func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 	t.Skip("TestAutopilot_CleanupDeadServer is very flaky, removing it for now")
-
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 
 	conf := func(c *Config) {
 		c.DevDisableBootstrap = true
 	}
-	s2 := TestServer(t, conf)
-	defer s2.Shutdown()
+	s2, cleanupS2 := TestServer(t, conf)
+	defer cleanupS2()
 
-	s3 := TestServer(t, conf)
-	defer s3.Shutdown()
+	s3, cleanupS3 := TestServer(t, conf)
+	defer cleanupS3()
 
-	s4 := TestServer(t, conf)
-	defer s4.Shutdown()
+	s4, cleanupS4 := TestServer(t, conf)
+	defer cleanupS4()
 
 	servers := []*Server{s1, s2, s3}
 
@@ -291,19 +294,20 @@ func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 
 func TestAutopilot_PromoteNonVoter(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	defer codec.Close()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 
 	// Make sure we see it as a nonvoter initially. We wait until half

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -28,20 +28,20 @@ func TestMonitor_Monitor_Remote_Client(t *testing.T) {
 	require := require.New(t)
 
 	// start server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.GetConfig().RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s2.connectedNodes()
@@ -122,12 +122,12 @@ func TestMonitor_Monitor_RemoteServer(t *testing.T) {
 	t.Parallel()
 
 	// start servers
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -273,8 +273,8 @@ func TestMonitor_MonitorServer(t *testing.T) {
 	require := require.New(t)
 
 	// start server
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	// No node ID to monitor the remote server
@@ -357,8 +357,8 @@ func TestMonitor_Monitor_ACL(t *testing.T) {
 	require := require.New(t)
 
 	// start server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityReadFS})

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -30,15 +30,15 @@ func TestClientAllocations_GarbageCollectAll_Local(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s.connectedNodes()
@@ -70,8 +70,8 @@ func TestClientAllocations_GarbageCollectAll_Local_ACL(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -130,8 +130,8 @@ func TestClientAllocations_GarbageCollectAll_NoNode(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -153,8 +153,8 @@ func TestClientAllocations_GarbageCollectAll_OldNode(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and fake an old client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	state := s.State()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
@@ -186,22 +186,22 @@ func TestClientAllocations_GarbageCollectAll_Remote(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 		c.GCDiskUsageThreshold = 100.0
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s2.connectedNodes()
@@ -244,8 +244,8 @@ func TestClientAllocations_GarbageCollect_OldNode(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and fake an old client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	state := s.State()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
@@ -284,16 +284,16 @@ func TestClientAllocations_GarbageCollect_Local(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 		c.GCDiskUsageThreshold = 100.0
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -365,8 +365,8 @@ func TestClientAllocations_GarbageCollect_Local_ACL(t *testing.T) {
 	t.Parallel()
 
 	// Start a server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -432,12 +432,12 @@ func TestClientAllocations_GarbageCollect_Remote(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -533,8 +533,8 @@ func TestClientAllocations_Stats_OldNode(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and fake an old client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	state := s.State()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
@@ -572,15 +572,15 @@ func TestClientAllocations_Stats_Local(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -653,8 +653,8 @@ func TestClientAllocations_Stats_Local_ACL(t *testing.T) {
 	t.Parallel()
 
 	// Start a server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -720,21 +720,21 @@ func TestClientAllocations_Stats_Remote(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -809,16 +809,16 @@ func TestClientAllocations_Restart_Local(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 		c.GCDiskUsageThreshold = 100.0
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -915,21 +915,21 @@ func TestClientAllocations_Restart_Remote(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -1003,8 +1003,8 @@ func TestClientAllocations_Restart_Remote(t *testing.T) {
 
 func TestClientAllocations_Restart_ACL(t *testing.T) {
 	// Start a server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -1071,18 +1071,18 @@ func TestAlloc_ExecStreaming(t *testing.T) {
 	t.Parallel()
 
 	////// Nomad clusters topology - not specific to test
-	localServer := TestServer(t, nil)
-	defer localServer.Shutdown()
+	localServer, cleanupLS := TestServer(t, nil)
+	defer cleanupLS()
 
-	remoteServer := TestServer(t, func(c *Config) {
+	remoteServer, cleanupRS := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer remoteServer.Shutdown()
+	defer cleanupRS()
 
-	remoteRegionServer := TestServer(t, func(c *Config) {
+	remoteRegionServer, cleanupRRS := TestServer(t, func(c *Config) {
 		c.Region = "two"
 	})
-	defer remoteRegionServer.Shutdown()
+	defer cleanupRRS()
 
 	TestJoin(t, localServer, remoteServer)
 	TestJoin(t, localServer, remoteRegionServer)

--- a/nomad/client_fs_endpoint_test.go
+++ b/nomad/client_fs_endpoint_test.go
@@ -26,15 +26,15 @@ func TestClientFS_List_Local(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -109,8 +109,8 @@ func TestClientFS_List_ACL(t *testing.T) {
 	t.Parallel()
 
 	// Start a server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -177,21 +177,21 @@ func TestClientFS_List_Remote(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 	codec := rpcClient(t, s2)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -269,8 +269,8 @@ func TestClientFS_Stat_OldNode(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	state := s.State()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
@@ -300,15 +300,15 @@ func TestClientFS_Stat_Local(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	a := mock.Alloc()
@@ -383,8 +383,8 @@ func TestClientFS_Stat_ACL(t *testing.T) {
 	t.Parallel()
 
 	// Start a server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -451,12 +451,12 @@ func TestClientFS_Stat_Remote(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -543,8 +543,8 @@ func TestClientFS_Streaming_NoAlloc(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	// Make the request with bad allocation id
@@ -613,8 +613,8 @@ func TestClientFS_Streaming_ACL(t *testing.T) {
 	t.Parallel()
 
 	// Start a server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	// Create a bad token
@@ -730,8 +730,8 @@ func TestClientFS_Streaming_Local(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	c, cleanup := client.TestClient(t, func(c *config.Config) {
@@ -862,14 +862,14 @@ func TestClientFS_Streaming_Local_Follow(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	expectedBase := "Hello from the other side"
@@ -1000,20 +1000,20 @@ func TestClientFS_Streaming_Remote_Server(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	expected := "Hello from the other side"
@@ -1146,21 +1146,21 @@ func TestClientFS_Streaming_Remote_Region(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.Region = "two"
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 		c.Region = "two"
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	expected := "Hello from the other side"
@@ -1290,8 +1290,8 @@ func TestClientFS_Logs_NoAlloc(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	// Make the request with bad allocation id
@@ -1361,8 +1361,8 @@ func TestClientFS_Logs_OldNode(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	state := s.State()
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -1440,8 +1440,8 @@ func TestClientFS_Logs_ACL(t *testing.T) {
 	t.Parallel()
 
 	// Start a server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	// Create a bad token
@@ -1557,14 +1557,14 @@ func TestClientFS_Logs_Local(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Force an allocation onto the node
 	expected := "Hello from the other side"
@@ -1690,8 +1690,8 @@ func TestClientFS_Logs_Local_Follow(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	testutil.WaitForLeader(t, s.RPC)
 
 	c, cleanup := client.TestClient(t, func(c *config.Config) {
@@ -1829,12 +1829,12 @@ func TestClientFS_Logs_Remote_Server(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -1976,12 +1976,12 @@ func TestClientFS_Logs_Remote_Region(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.Region = "two"
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)

--- a/nomad/client_rpc_test.go
+++ b/nomad/client_rpc_test.go
@@ -30,8 +30,9 @@ func (n namedConnWrapper) LocalAddr() net.Addr {
 func TestServer_removeNodeConn_differentAddrs(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	p1, p2 := net.Pipe()
@@ -86,12 +87,13 @@ func TestServer_removeNodeConn_differentAddrs(t *testing.T) {
 func TestServerWithNodeConn_NoPath(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -105,8 +107,9 @@ func TestServerWithNodeConn_NoPath(t *testing.T) {
 func TestServerWithNodeConn_NoPath_Region(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	nodeID := uuid.Generate()
@@ -118,12 +121,13 @@ func TestServerWithNodeConn_NoPath_Region(t *testing.T) {
 func TestServerWithNodeConn_Path(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -143,12 +147,13 @@ func TestServerWithNodeConn_Path(t *testing.T) {
 func TestServerWithNodeConn_Path_Region(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.Region = "two"
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -168,16 +173,17 @@ func TestServerWithNodeConn_Path_Region(t *testing.T) {
 func TestServerWithNodeConn_Path_Newest(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
-	s3 := TestServer(t, func(c *Config) {
+	defer cleanupS2()
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	TestJoin(t, s1, s2, s3)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -201,16 +207,17 @@ func TestServerWithNodeConn_Path_Newest(t *testing.T) {
 func TestServerWithNodeConn_PathAndErr(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
-	s3 := TestServer(t, func(c *Config) {
+	defer cleanupS2()
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	TestJoin(t, s1, s2, s3)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -234,16 +241,17 @@ func TestServerWithNodeConn_PathAndErr(t *testing.T) {
 func TestServerWithNodeConn_NoPathAndErr(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
-	s3 := TestServer(t, func(c *Config) {
+	defer cleanupS2()
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	TestJoin(t, s1, s2, s3)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -265,14 +273,14 @@ func TestServerWithNodeConn_NoPathAndErr(t *testing.T) {
 func TestNodeStreamingRpc_badEndpoint(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s1.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	// Wait for the client to connect
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/client_stats_endpoint_test.go
+++ b/nomad/client_stats_endpoint_test.go
@@ -21,15 +21,15 @@ func TestClientStats_Stats_Local(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
-	c, cleanup := client.TestClient(t, func(c *config.Config) {
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s.config.RPCAddr.String()}
 	})
-	defer cleanup()
+	defer cleanupC()
 
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s.connectedNodes()
@@ -62,8 +62,8 @@ func TestClientStats_Stats_Local_ACL(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server
-	s, root := TestACLServer(t, nil)
-	defer s.Shutdown()
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -122,8 +122,8 @@ func TestClientStats_Stats_NoNode(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -146,8 +146,8 @@ func TestClientStats_Stats_OldNode(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server
-	s := TestServer(t, nil)
-	defer s.Shutdown()
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
 	state := s.State()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
@@ -173,12 +173,12 @@ func TestClientStats_Stats_Remote(t *testing.T) {
 	require := require.New(t)
 
 	// Start a server and client
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestCoreScheduler_EvalGC(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 	require := require.New(t)
 
@@ -109,8 +110,9 @@ func TestCoreScheduler_EvalGC(t *testing.T) {
 // Tests GC behavior on allocations being rescheduled
 func TestCoreScheduler_EvalGC_ReschedulingAllocs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 	require := require.New(t)
 
@@ -213,8 +215,9 @@ func TestCoreScheduler_EvalGC_ReschedulingAllocs(t *testing.T) {
 // Tests GC behavior on stopped job with reschedulable allocs
 func TestCoreScheduler_EvalGC_StoppedJob_Reschedulable(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 	require := require.New(t)
 
@@ -288,8 +291,9 @@ func TestCoreScheduler_EvalGC_StoppedJob_Reschedulable(t *testing.T) {
 // An EvalGC should never reap a batch job that has not been stopped
 func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -391,8 +395,9 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 // An EvalGC should reap allocations from jobs with an older modify index
 func TestCoreScheduler_EvalGC_Batch_OldVersion(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -513,8 +518,9 @@ func TestCoreScheduler_EvalGC_Batch_OldVersion(t *testing.T) {
 // An EvalGC should  reap a batch job that has been stopped
 func TestCoreScheduler_EvalGC_BatchStopped(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	require := require.New(t)
@@ -609,8 +615,9 @@ func TestCoreScheduler_EvalGC_BatchStopped(t *testing.T) {
 
 func TestCoreScheduler_EvalGC_Partial(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 	require := require.New(t)
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -729,12 +736,13 @@ func TestCoreScheduler_EvalGC_Force(t *testing.T) {
 		t.Run(fmt.Sprintf("with acl %v", withAcl), func(t *testing.T) {
 			require := require.New(t)
 			var server *Server
+			var cleanup func()
 			if withAcl {
-				server, _ = TestACLServer(t, nil)
+				server, _, cleanup = TestACLServer(t, nil)
 			} else {
-				server = TestServer(t, nil)
+				server, cleanup = TestServer(t, nil)
 			}
-			defer server.Shutdown()
+			defer cleanup()
 			testutil.WaitForLeader(t, server.RPC)
 
 			// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -811,12 +819,13 @@ func TestCoreScheduler_NodeGC(t *testing.T) {
 	for _, withAcl := range []bool{false, true} {
 		t.Run(fmt.Sprintf("with acl %v", withAcl), func(t *testing.T) {
 			var server *Server
+			var cleanup func()
 			if withAcl {
-				server, _ = TestACLServer(t, nil)
+				server, _, cleanup = TestACLServer(t, nil)
 			} else {
-				server = TestServer(t, nil)
+				server, cleanup = TestServer(t, nil)
 			}
-			defer server.Shutdown()
+			defer cleanup()
 			testutil.WaitForLeader(t, server.RPC)
 
 			// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -864,8 +873,9 @@ func TestCoreScheduler_NodeGC(t *testing.T) {
 
 func TestCoreScheduler_NodeGC_TerminalAllocs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -919,8 +929,9 @@ func TestCoreScheduler_NodeGC_TerminalAllocs(t *testing.T) {
 
 func TestCoreScheduler_NodeGC_RunningAllocs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -976,8 +987,9 @@ func TestCoreScheduler_NodeGC_RunningAllocs(t *testing.T) {
 
 func TestCoreScheduler_NodeGC_Force(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1019,8 +1031,9 @@ func TestCoreScheduler_NodeGC_Force(t *testing.T) {
 
 func TestCoreScheduler_JobGC_OutstandingEvals(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1142,8 +1155,9 @@ func TestCoreScheduler_JobGC_OutstandingEvals(t *testing.T) {
 
 func TestCoreScheduler_JobGC_OutstandingAllocs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1287,8 +1301,9 @@ func TestCoreScheduler_JobGC_OutstandingAllocs(t *testing.T) {
 // allocs/evals and job or nothing
 func TestCoreScheduler_JobGC_OneShot(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1399,8 +1414,9 @@ func TestCoreScheduler_JobGC_OneShot(t *testing.T) {
 // This test ensures that stopped jobs are GCd
 func TestCoreScheduler_JobGC_Stopped(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1502,12 +1518,13 @@ func TestCoreScheduler_JobGC_Force(t *testing.T) {
 	for _, withAcl := range []bool{false, true} {
 		t.Run(fmt.Sprintf("with acl %v", withAcl), func(t *testing.T) {
 			var server *Server
+			var cleanup func()
 			if withAcl {
-				server, _ = TestACLServer(t, nil)
+				server, _, cleanup = TestACLServer(t, nil)
 			} else {
-				server = TestServer(t, nil)
+				server, cleanup = TestServer(t, nil)
 			}
-			defer server.Shutdown()
+			defer cleanup()
 			testutil.WaitForLeader(t, server.RPC)
 
 			// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1570,8 +1587,9 @@ func TestCoreScheduler_JobGC_Force(t *testing.T) {
 // This test ensures parameterized jobs only get gc'd when stopped
 func TestCoreScheduler_JobGC_Parameterized(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1650,8 +1668,8 @@ func TestCoreScheduler_JobGC_Parameterized(t *testing.T) {
 func TestCoreScheduler_JobGC_Periodic(t *testing.T) {
 	t.Parallel()
 
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1723,8 +1741,9 @@ func TestCoreScheduler_JobGC_Periodic(t *testing.T) {
 
 func TestCoreScheduler_DeploymentGC(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
 
@@ -1776,12 +1795,13 @@ func TestCoreScheduler_DeploymentGC_Force(t *testing.T) {
 	for _, withAcl := range []bool{false, true} {
 		t.Run(fmt.Sprintf("with acl %v", withAcl), func(t *testing.T) {
 			var server *Server
+			var cleanup func()
 			if withAcl {
-				server, _ = TestACLServer(t, nil)
+				server, _, cleanup = TestACLServer(t, nil)
 			} else {
-				server = TestServer(t, nil)
+				server, cleanup = TestServer(t, nil)
 			}
-			defer server.Shutdown()
+			defer cleanup()
 			testutil.WaitForLeader(t, server.RPC)
 			assert := assert.New(t)
 
@@ -1818,8 +1838,9 @@ func TestCoreScheduler_DeploymentGC_Force(t *testing.T) {
 
 func TestCoreScheduler_PartitionEvalReap(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1860,8 +1881,9 @@ func TestCoreScheduler_PartitionEvalReap(t *testing.T) {
 
 func TestCoreScheduler_PartitionDeploymentReap(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// COMPAT Remove in 0.6: Reset the FSM time table since we reconcile which sets index 0
@@ -1897,8 +1919,9 @@ func TestCoreScheduler_PartitionDeploymentReap(t *testing.T) {
 func TestCoreScheduler_PartitionJobReap(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create a core scheduler

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestDeploymentEndpoint_GetDeployment(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -47,8 +48,9 @@ func TestDeploymentEndpoint_GetDeployment(t *testing.T) {
 
 func TestDeploymentEndpoint_GetDeployment_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -100,8 +102,9 @@ func TestDeploymentEndpoint_GetDeployment_ACL(t *testing.T) {
 
 func TestDeploymentEndpoint_GetDeployment_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -149,10 +152,11 @@ func TestDeploymentEndpoint_GetDeployment_Blocking(t *testing.T) {
 
 func TestDeploymentEndpoint_Fail(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -198,10 +202,11 @@ func TestDeploymentEndpoint_Fail(t *testing.T) {
 
 func TestDeploymentEndpoint_Fail_ACL(t *testing.T) {
 	t.Parallel()
-	s1, _ := TestACLServer(t, func(c *Config) {
+
+	s1, _, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -273,10 +278,11 @@ func TestDeploymentEndpoint_Fail_ACL(t *testing.T) {
 
 func TestDeploymentEndpoint_Fail_Rollback(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -350,10 +356,11 @@ func TestDeploymentEndpoint_Fail_Rollback(t *testing.T) {
 
 func TestDeploymentEndpoint_Pause(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -392,10 +399,11 @@ func TestDeploymentEndpoint_Pause(t *testing.T) {
 
 func TestDeploymentEndpoint_Pause_ACL(t *testing.T) {
 	t.Parallel()
-	s1, _ := TestACLServer(t, func(c *Config) {
+
+	s1, _, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -460,10 +468,11 @@ func TestDeploymentEndpoint_Pause_ACL(t *testing.T) {
 
 func TestDeploymentEndpoint_Promote(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -524,10 +533,11 @@ func TestDeploymentEndpoint_Promote(t *testing.T) {
 
 func TestDeploymentEndpoint_Promote_ACL(t *testing.T) {
 	t.Parallel()
-	s1, _ := TestACLServer(t, func(c *Config) {
+
+	s1, _, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -614,10 +624,11 @@ func TestDeploymentEndpoint_Promote_ACL(t *testing.T) {
 
 func TestDeploymentEndpoint_SetAllocHealth(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -681,10 +692,11 @@ func TestDeploymentEndpoint_SetAllocHealth(t *testing.T) {
 
 func TestDeploymentEndpoint_SetAllocHealth_ACL(t *testing.T) {
 	t.Parallel()
-	s1, _ := TestACLServer(t, func(c *Config) {
+
+	s1, _, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -774,10 +786,11 @@ func TestDeploymentEndpoint_SetAllocHealth_ACL(t *testing.T) {
 
 func TestDeploymentEndpoint_SetAllocHealth_Rollback(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -863,10 +876,11 @@ func TestDeploymentEndpoint_SetAllocHealth_Rollback(t *testing.T) {
 // tests rollback upon alloc health failure to job with identical spec does not succeed
 func TestDeploymentEndpoint_SetAllocHealth_NoRollback(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -949,8 +963,9 @@ func TestDeploymentEndpoint_SetAllocHealth_NoRollback(t *testing.T) {
 
 func TestDeploymentEndpoint_List(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -995,8 +1010,9 @@ func TestDeploymentEndpoint_List(t *testing.T) {
 
 func TestDeploymentEndpoint_List_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -1063,8 +1079,9 @@ func TestDeploymentEndpoint_List_ACL(t *testing.T) {
 
 func TestDeploymentEndpoint_List_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -1120,8 +1137,9 @@ func TestDeploymentEndpoint_List_Blocking(t *testing.T) {
 
 func TestDeploymentEndpoint_Allocations(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -1157,8 +1175,9 @@ func TestDeploymentEndpoint_Allocations(t *testing.T) {
 
 func TestDeploymentEndpoint_Allocations_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -1231,8 +1250,9 @@ func TestDeploymentEndpoint_Allocations_ACL(t *testing.T) {
 
 func TestDeploymentEndpoint_Allocations_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -1298,8 +1318,9 @@ func TestDeploymentEndpoint_Allocations_Blocking(t *testing.T) {
 
 func TestDeploymentEndpoint_Reap(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)

--- a/nomad/drainer_int_test.go
+++ b/nomad/drainer_int_test.go
@@ -122,8 +122,9 @@ func getNodeAllocsImpl(nodeID string) func(ws memdb.WatchSet, state *state.State
 func TestDrainer_Simple_ServiceOnly(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -225,8 +226,9 @@ func TestDrainer_Simple_ServiceOnly(t *testing.T) {
 func TestDrainer_Simple_ServiceOnly_Deadline(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -320,8 +322,9 @@ func TestDrainer_Simple_ServiceOnly_Deadline(t *testing.T) {
 func TestDrainer_DrainEmptyNode(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -369,8 +372,9 @@ func TestDrainer_DrainEmptyNode(t *testing.T) {
 func TestDrainer_AllTypes_Deadline(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -534,8 +538,9 @@ func TestDrainer_AllTypes_Deadline(t *testing.T) {
 func TestDrainer_AllTypes_NoDeadline(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -698,8 +703,9 @@ func TestDrainer_AllTypes_NoDeadline(t *testing.T) {
 func TestDrainer_AllTypes_Deadline_GarbageCollectedNode(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -878,8 +884,8 @@ func TestDrainer_Batch_TransitionToForce(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			s1 := TestServer(t, nil)
-			defer s1.Shutdown()
+			s1, cleanupS1 := TestServer(t, nil)
+			defer cleanupS1()
 			codec := rpcClient(t, s1)
 			testutil.WaitForLeader(t, s1.RPC)
 

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -21,8 +21,9 @@ import (
 
 func TestEvalEndpoint_GetEval(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -62,8 +63,9 @@ func TestEvalEndpoint_GetEval(t *testing.T) {
 
 func TestEvalEndpoint_GetEval_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -122,8 +124,9 @@ func TestEvalEndpoint_GetEval_ACL(t *testing.T) {
 
 func TestEvalEndpoint_GetEval_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -200,10 +203,11 @@ func TestEvalEndpoint_GetEval_Blocking(t *testing.T) {
 
 func TestEvalEndpoint_Dequeue(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -244,10 +248,11 @@ func TestEvalEndpoint_Dequeue(t *testing.T) {
 // index will be equal to the highest eval modify index in the state store.
 func TestEvalEndpoint_Dequeue_WaitIndex_Snapshot(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -294,10 +299,10 @@ func TestEvalEndpoint_Dequeue_WaitIndex_Snapshot(t *testing.T) {
 // has not yet been applied from the Raft log to the local node's state store.
 func TestEvalEndpoint_Dequeue_WaitIndex_Eval(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -333,10 +338,10 @@ func TestEvalEndpoint_Dequeue_WaitIndex_Eval(t *testing.T) {
 func TestEvalEndpoint_Dequeue_UpdateWaitIndex(t *testing.T) {
 	// test enqueuing an eval, updating a plan result for the same eval and de-queueing the eval
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -399,10 +404,11 @@ func TestEvalEndpoint_Dequeue_UpdateWaitIndex(t *testing.T) {
 
 func TestEvalEndpoint_Dequeue_Version_Mismatch(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -425,8 +431,9 @@ func TestEvalEndpoint_Dequeue_Version_Mismatch(t *testing.T) {
 
 func TestEvalEndpoint_Ack(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -465,12 +472,13 @@ func TestEvalEndpoint_Ack(t *testing.T) {
 
 func TestEvalEndpoint_Nack(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		// Disable all of the schedulers so we can manually dequeue
 		// evals and check the queue status
 		c.NumSchedulers = 0
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -518,8 +526,9 @@ func TestEvalEndpoint_Nack(t *testing.T) {
 
 func TestEvalEndpoint_Update(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -566,10 +575,11 @@ func TestEvalEndpoint_Update(t *testing.T) {
 
 func TestEvalEndpoint_Create(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -618,8 +628,9 @@ func TestEvalEndpoint_Create(t *testing.T) {
 
 func TestEvalEndpoint_Reap(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -653,8 +664,9 @@ func TestEvalEndpoint_Reap(t *testing.T) {
 
 func TestEvalEndpoint_List(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -708,8 +720,9 @@ func TestEvalEndpoint_List(t *testing.T) {
 
 func TestEvalEndpoint_List_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -773,8 +786,9 @@ func TestEvalEndpoint_List_ACL(t *testing.T) {
 
 func TestEvalEndpoint_List_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -839,8 +853,9 @@ func TestEvalEndpoint_List_Blocking(t *testing.T) {
 
 func TestEvalEndpoint_Allocations(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -877,8 +892,9 @@ func TestEvalEndpoint_Allocations(t *testing.T) {
 
 func TestEvalEndpoint_Allocations_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -941,8 +957,9 @@ func TestEvalEndpoint_Allocations_ACL(t *testing.T) {
 
 func TestEvalEndpoint_Allocations_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -996,10 +1013,11 @@ func TestEvalEndpoint_Allocations_Blocking(t *testing.T) {
 
 func TestEvalEndpoint_Reblock_Nonexistent(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -1032,10 +1050,11 @@ func TestEvalEndpoint_Reblock_Nonexistent(t *testing.T) {
 
 func TestEvalEndpoint_Reblock_NonBlocked(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -1074,10 +1093,11 @@ func TestEvalEndpoint_Reblock_NonBlocked(t *testing.T) {
 
 func TestEvalEndpoint_Reblock(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/heartbeat_test.go
+++ b/nomad/heartbeat_test.go
@@ -15,8 +15,9 @@ import (
 
 func TestHeartbeat_InitializeHeartbeatTimers(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	node := mock.Node()
@@ -41,8 +42,9 @@ func TestHeartbeat_InitializeHeartbeatTimers(t *testing.T) {
 
 func TestHeartbeat_ResetHeartbeatTimer(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create a new timer
@@ -64,11 +66,12 @@ func TestHeartbeat_ResetHeartbeatTimer(t *testing.T) {
 func TestHeartbeat_ResetHeartbeatTimer_Nonleader(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3 // Won't become leader
 		c.DevDisableBootstrap = true
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
 	require.False(s1.IsLeader())
 
@@ -80,8 +83,9 @@ func TestHeartbeat_ResetHeartbeatTimer_Nonleader(t *testing.T) {
 
 func TestHeartbeat_ResetHeartbeatTimerLocked(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	s1.heartbeatTimersLock.Lock()
@@ -101,8 +105,9 @@ func TestHeartbeat_ResetHeartbeatTimerLocked(t *testing.T) {
 
 func TestHeartbeat_ResetHeartbeatTimerLocked_Renew(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	s1.heartbeatTimersLock.Lock()
@@ -141,8 +146,9 @@ func TestHeartbeat_ResetHeartbeatTimerLocked_Renew(t *testing.T) {
 func TestHeartbeat_InvalidateHeartbeat(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create a node
@@ -164,8 +170,9 @@ func TestHeartbeat_InvalidateHeartbeat(t *testing.T) {
 
 func TestHeartbeat_ClearHeartbeatTimer(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	s1.heartbeatTimersLock.Lock()
@@ -184,8 +191,9 @@ func TestHeartbeat_ClearHeartbeatTimer(t *testing.T) {
 
 func TestHeartbeat_ClearAllHeartbeatTimers(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	s1.heartbeatTimersLock.Lock()
@@ -206,18 +214,19 @@ func TestHeartbeat_ClearAllHeartbeatTimers(t *testing.T) {
 
 func TestHeartbeat_Server_HeartbeatTTL_Failover(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
 
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	servers := []*Server{s1, s2, s3}
 	TestJoin(t, s1, s2, s3)
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -22,10 +22,11 @@ import (
 
 func TestJobEndpoint_Register(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -106,12 +107,13 @@ func TestJobEndpoint_Register(t *testing.T) {
 }
 
 func TestJobEndpoint_Register_Connect(t *testing.T) {
-	require := require.New(t)
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+	require := require.New(t)
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -178,12 +180,13 @@ func TestJobEndpoint_Register_Connect(t *testing.T) {
 }
 
 func TestJobEndpoint_Register_ConnectWithSidecarTask(t *testing.T) {
-	require := require.New(t)
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+	require := require.New(t)
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -275,10 +278,10 @@ func TestJobEndpoint_Register_ConnectWithSidecarTask(t *testing.T) {
 func TestJobEndpoint_Register_ACL(t *testing.T) {
 	t.Parallel()
 
-	s1, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	newVolumeJob := func(readonlyVolume bool) *structs.Job {
@@ -400,10 +403,11 @@ func TestJobEndpoint_Register_ACL(t *testing.T) {
 
 func TestJobEndpoint_Register_InvalidNamespace(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -439,10 +443,11 @@ func TestJobEndpoint_Register_InvalidNamespace(t *testing.T) {
 
 func TestJobEndpoint_Register_Payload(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -472,10 +477,11 @@ func TestJobEndpoint_Register_Payload(t *testing.T) {
 
 func TestJobEndpoint_Register_Existing(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -594,10 +600,11 @@ func TestJobEndpoint_Register_Existing(t *testing.T) {
 
 func TestJobEndpoint_Register_Periodic(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -646,10 +653,11 @@ func TestJobEndpoint_Register_Periodic(t *testing.T) {
 
 func TestJobEndpoint_Register_ParameterizedJob(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -694,10 +702,11 @@ func TestJobEndpoint_Register_ParameterizedJob(t *testing.T) {
 func TestJobEndpoint_Register_Dispatched(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -721,10 +730,11 @@ func TestJobEndpoint_Register_Dispatched(t *testing.T) {
 
 func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -852,12 +862,13 @@ func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 // uses Vault when Vault is *disabled* results in an error.
 func TestJobEndpoint_Register_Vault_Disabled(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 		f := false
 		c.VaultConfig.Enabled = &f
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -888,10 +899,11 @@ func TestJobEndpoint_Register_Vault_Disabled(t *testing.T) {
 // allow_unauthenticated=true.
 func TestJobEndpoint_Register_Vault_AllowUnauthenticated(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -944,10 +956,11 @@ func TestJobEndpoint_Register_Vault_AllowUnauthenticated(t *testing.T) {
 // automatically injected one.
 func TestJobEndpoint_Register_Vault_OverrideConstraint(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1000,10 +1013,11 @@ func TestJobEndpoint_Register_Vault_OverrideConstraint(t *testing.T) {
 
 func TestJobEndpoint_Register_Vault_NoToken(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1040,10 +1054,11 @@ func TestJobEndpoint_Register_Vault_NoToken(t *testing.T) {
 
 func TestJobEndpoint_Register_Vault_Policies(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1183,8 +1198,9 @@ func TestJobEndpoint_Register_Vault_Policies(t *testing.T) {
 // used when evaluating semver constraints.
 func TestJobEndpoint_Register_SemverConstraint(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.State()
@@ -1262,10 +1278,11 @@ func TestJobEndpoint_Register_SemverConstraint(t *testing.T) {
 
 func TestJobEndpoint_Revert(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1431,10 +1448,11 @@ func TestJobEndpoint_Revert(t *testing.T) {
 
 func TestJobEndpoint_Revert_Vault_NoToken(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1530,10 +1548,11 @@ func TestJobEndpoint_Revert_Vault_NoToken(t *testing.T) {
 // revert request's Vault token when authorizing policies.
 func TestJobEndpoint_Revert_Vault_Policies(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1644,11 +1663,11 @@ func TestJobEndpoint_Revert_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	state := s1.fsm.State()
 	testutil.WaitForLeader(t, s1.RPC)
@@ -1707,10 +1726,11 @@ func TestJobEndpoint_Revert_ACL(t *testing.T) {
 
 func TestJobEndpoint_Stable(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1772,10 +1792,10 @@ func TestJobEndpoint_Stable_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	state := s1.fsm.State()
 	testutil.WaitForLeader(t, s1.RPC)
@@ -1837,10 +1857,11 @@ func TestJobEndpoint_Stable_ACL(t *testing.T) {
 
 func TestJobEndpoint_Evaluate(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1921,12 +1942,13 @@ func TestJobEndpoint_Evaluate(t *testing.T) {
 }
 
 func TestJobEndpoint_ForceRescheduleEvaluate(t *testing.T) {
-	require := require.New(t)
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+	require := require.New(t)
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2001,10 +2023,10 @@ func TestJobEndpoint_Evaluate_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -2073,10 +2095,11 @@ func TestJobEndpoint_Evaluate_ACL(t *testing.T) {
 
 func TestJobEndpoint_Evaluate_Periodic(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2116,10 +2139,11 @@ func TestJobEndpoint_Evaluate_Periodic(t *testing.T) {
 
 func TestJobEndpoint_Evaluate_ParameterizedJob(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2161,10 +2185,11 @@ func TestJobEndpoint_Evaluate_ParameterizedJob(t *testing.T) {
 func TestJobEndpoint_Deregister(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2252,10 +2277,10 @@ func TestJobEndpoint_Deregister_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -2332,10 +2357,11 @@ func TestJobEndpoint_Deregister_ACL(t *testing.T) {
 
 func TestJobEndpoint_Deregister_Nonexistent(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2398,10 +2424,11 @@ func TestJobEndpoint_Deregister_Nonexistent(t *testing.T) {
 
 func TestJobEndpoint_Deregister_Periodic(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2456,10 +2483,11 @@ func TestJobEndpoint_Deregister_Periodic(t *testing.T) {
 
 func TestJobEndpoint_Deregister_ParameterizedJob(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2516,10 +2544,11 @@ func TestJobEndpoint_Deregister_ParameterizedJob(t *testing.T) {
 func TestJobEndpoint_BatchDeregister(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2609,10 +2638,10 @@ func TestJobEndpoint_BatchDeregister_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -2676,8 +2705,9 @@ func TestJobEndpoint_BatchDeregister_ACL(t *testing.T) {
 
 func TestJobEndpoint_GetJob(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2755,8 +2785,8 @@ func TestJobEndpoint_GetJob_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -2811,8 +2841,9 @@ func TestJobEndpoint_GetJob_ACL(t *testing.T) {
 
 func TestJobEndpoint_GetJob_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -2887,8 +2918,9 @@ func TestJobEndpoint_GetJob_Blocking(t *testing.T) {
 
 func TestJobEndpoint_GetJobVersions(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2961,8 +2993,8 @@ func TestJobEndpoint_GetJobVersions_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -3026,8 +3058,9 @@ func TestJobEndpoint_GetJobVersions_ACL(t *testing.T) {
 
 func TestJobEndpoint_GetJobVersions_Diff(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -3122,8 +3155,9 @@ func TestJobEndpoint_GetJobVersions_Diff(t *testing.T) {
 
 func TestJobEndpoint_GetJobVersions_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -3207,11 +3241,12 @@ func TestJobEndpoint_GetJobVersions_Blocking(t *testing.T) {
 
 func TestJobEndpoint_GetJobSummary(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -3267,15 +3302,15 @@ func TestJobEndpoint_GetJobSummary(t *testing.T) {
 }
 
 func TestJobEndpoint_Summary_ACL(t *testing.T) {
-	require := require.New(t)
 	t.Parallel()
+	require := require.New(t)
 
-	srv, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer srv.Shutdown()
-	codec := rpcClient(t, srv)
-	testutil.WaitForLeader(t, srv.RPC)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create the job
 	job := mock.Job()
@@ -3331,7 +3366,7 @@ func TestJobEndpoint_Summary_ACL(t *testing.T) {
 	require.Equal(expectedJobSummary, mgmtResp.JobSummary)
 
 	// Create the namespace policy and tokens
-	state := srv.fsm.State()
+	state := s1.fsm.State()
 
 	// Expect failure for request with an invalid token
 	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
@@ -3355,8 +3390,9 @@ func TestJobEndpoint_Summary_ACL(t *testing.T) {
 
 func TestJobEndpoint_GetJobSummary_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -3448,8 +3484,9 @@ func TestJobEndpoint_GetJobSummary_Blocking(t *testing.T) {
 
 func TestJobEndpoint_ListJobs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -3508,16 +3545,16 @@ func TestJobEndpoint_ListJobs(t *testing.T) {
 }
 
 func TestJobEndpoint_ListJobs_WithACL(t *testing.T) {
-	require := require.New(t)
 	t.Parallel()
+	require := require.New(t)
 
-	srv, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer srv.Shutdown()
-	codec := rpcClient(t, srv)
-	testutil.WaitForLeader(t, srv.RPC)
-	state := srv.fsm.State()
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+	state := s1.fsm.State()
 
 	var err error
 
@@ -3569,8 +3606,9 @@ func TestJobEndpoint_ListJobs_WithACL(t *testing.T) {
 
 func TestJobEndpoint_ListJobs_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -3635,8 +3673,9 @@ func TestJobEndpoint_ListJobs_Blocking(t *testing.T) {
 
 func TestJobEndpoint_Allocations(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -3678,8 +3717,8 @@ func TestJobEndpoint_Allocations_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -3739,8 +3778,9 @@ func TestJobEndpoint_Allocations_ACL(t *testing.T) {
 
 func TestJobEndpoint_Allocations_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -3798,8 +3838,9 @@ func TestJobEndpoint_Allocations_Blocking(t *testing.T) {
 // request returns an error.
 func TestJobEndpoint_Allocations_NoJobID(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -3819,8 +3860,9 @@ func TestJobEndpoint_Allocations_NoJobID(t *testing.T) {
 
 func TestJobEndpoint_Evaluations(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -3860,8 +3902,8 @@ func TestJobEndpoint_Evaluations_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -3919,8 +3961,9 @@ func TestJobEndpoint_Evaluations_ACL(t *testing.T) {
 
 func TestJobEndpoint_Evaluations_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -3974,8 +4017,9 @@ func TestJobEndpoint_Evaluations_Blocking(t *testing.T) {
 
 func TestJobEndpoint_Deployments(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -4012,8 +4056,8 @@ func TestJobEndpoint_Deployments_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -4074,8 +4118,9 @@ func TestJobEndpoint_Deployments_ACL(t *testing.T) {
 
 func TestJobEndpoint_Deployments_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -4120,8 +4165,9 @@ func TestJobEndpoint_Deployments_Blocking(t *testing.T) {
 
 func TestJobEndpoint_LatestDeployment(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -4160,8 +4206,8 @@ func TestJobEndpoint_LatestDeployment_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -4227,8 +4273,9 @@ func TestJobEndpoint_LatestDeployment_ACL(t *testing.T) {
 
 func TestJobEndpoint_LatestDeployment_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -4274,10 +4321,11 @@ func TestJobEndpoint_LatestDeployment_Blocking(t *testing.T) {
 
 func TestJobEndpoint_Plan_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, func(c *Config) {
+
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -4307,10 +4355,11 @@ func TestJobEndpoint_Plan_ACL(t *testing.T) {
 
 func TestJobEndpoint_Plan_WithDiff(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -4366,10 +4415,11 @@ func TestJobEndpoint_Plan_WithDiff(t *testing.T) {
 
 func TestJobEndpoint_Plan_NoDiff(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -4425,10 +4475,11 @@ func TestJobEndpoint_Plan_NoDiff(t *testing.T) {
 
 func TestJobEndpoint_ImplicitConstraints_Vault(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -4495,8 +4546,8 @@ func TestJobEndpoint_ImplicitConstraints_Vault(t *testing.T) {
 func TestJobEndpoint_ValidateJob_ConsulConnect(t *testing.T) {
 	t.Parallel()
 
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -4586,10 +4637,11 @@ func TestJobEndpoint_ValidateJob_ConsulConnect(t *testing.T) {
 
 func TestJobEndpoint_ImplicitConstraints_Signals(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -4704,10 +4756,10 @@ func TestJobEndpoint_ValidateJobUpdate_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -4740,11 +4792,10 @@ func TestJobEndpoint_Dispatch_ACL(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1, root := TestACLServer(t, func(c *Config) {
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -4985,10 +5036,10 @@ func TestJobEndpoint_Dispatch(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s1 := TestServer(t, func(c *Config) {
+			s1, cleanupS1 := TestServer(t, func(c *Config) {
 				c.NumSchedulers = 0 // Prevent automatic dequeue
 			})
-			defer s1.Shutdown()
+			defer cleanupS1()
 			codec := rpcClient(t, s1)
 			testutil.WaitForLeader(t, s1.RPC)
 

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -20,18 +20,18 @@ import (
 )
 
 func TestLeader_LeftServer(t *testing.T) {
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	servers := []*Server{s1, s2, s3}
 	TestJoin(t, s1, s2, s3)
 
@@ -80,18 +80,18 @@ func TestLeader_LeftServer(t *testing.T) {
 }
 
 func TestLeader_LeftLeader(t *testing.T) {
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	servers := []*Server{s1, s2, s3}
 	TestJoin(t, s1, s2, s3)
 
@@ -132,11 +132,11 @@ func TestLeader_LeftLeader(t *testing.T) {
 }
 
 func TestLeader_MultiBootstrap(t *testing.T) {
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 
-	s2 := TestServer(t, nil)
-	defer s2.Shutdown()
+	s2, cleanupS2 := TestServer(t, nil)
+	defer cleanupS2()
 	servers := []*Server{s1, s2}
 	TestJoin(t, s1, s2)
 
@@ -159,18 +159,18 @@ func TestLeader_MultiBootstrap(t *testing.T) {
 }
 
 func TestLeader_PlanQueue_Reset(t *testing.T) {
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	servers := []*Server{s1, s2, s3}
 	TestJoin(t, s1, s2, s3)
 
@@ -213,22 +213,22 @@ func TestLeader_PlanQueue_Reset(t *testing.T) {
 }
 
 func TestLeader_EvalBroker_Reset(t *testing.T) {
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	servers := []*Server{s1, s2, s3}
 	TestJoin(t, s1, s2, s3)
 
@@ -271,22 +271,22 @@ func TestLeader_EvalBroker_Reset(t *testing.T) {
 }
 
 func TestLeader_PeriodicDispatcher_Restore_Adds(t *testing.T) {
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	servers := []*Server{s1, s2, s3}
 	TestJoin(t, s1, s2, s3)
 
@@ -361,10 +361,10 @@ func TestLeader_PeriodicDispatcher_Restore_Adds(t *testing.T) {
 }
 
 func TestLeader_PeriodicDispatcher_Restore_NoEvals(t *testing.T) {
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Inject a periodic job that will be triggered soon.
@@ -417,10 +417,10 @@ func TestLeader_PeriodicDispatcher_Restore_NoEvals(t *testing.T) {
 }
 
 func TestLeader_PeriodicDispatcher_Restore_Evals(t *testing.T) {
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Inject a periodic job that triggered once in the past, should trigger now
@@ -474,11 +474,11 @@ func TestLeader_PeriodicDispatcher_Restore_Evals(t *testing.T) {
 }
 
 func TestLeader_PeriodicDispatch(t *testing.T) {
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EvalGCInterval = 5 * time.Millisecond
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
 	// Wait for a periodic dispatch
 	testutil.WaitForResult(func() (bool, error) {
@@ -494,11 +494,11 @@ func TestLeader_PeriodicDispatch(t *testing.T) {
 }
 
 func TestLeader_ReapFailedEval(t *testing.T) {
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EvalDeliveryLimit = 1
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Wait for a periodic dispatch
@@ -572,10 +572,10 @@ func TestLeader_ReapFailedEval(t *testing.T) {
 }
 
 func TestLeader_ReapDuplicateEval(t *testing.T) {
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create a duplicate blocked eval
@@ -602,10 +602,10 @@ func TestLeader_ReapDuplicateEval(t *testing.T) {
 }
 
 func TestLeader_RestoreVaultAccessors(t *testing.T) {
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Insert a vault accessor that should be revoked
@@ -631,20 +631,21 @@ func TestLeader_RestoreVaultAccessors(t *testing.T) {
 
 func TestLeader_ReplicateACLPolicies(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, func(c *Config) {
+
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.Region = "region1"
 		c.AuthoritativeRegion = "region1"
 		c.ACLEnabled = true
 	})
-	defer s1.Shutdown()
-	s2, _ := TestACLServer(t, func(c *Config) {
+	defer cleanupS1()
+	s2, _, cleanupS2 := TestACLServer(t, func(c *Config) {
 		c.Region = "region2"
 		c.AuthoritativeRegion = "region1"
 		c.ACLEnabled = true
 		c.ReplicationBackoff = 20 * time.Millisecond
 		c.ReplicationToken = root.SecretID
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -699,20 +700,21 @@ func TestLeader_DiffACLPolicies(t *testing.T) {
 
 func TestLeader_ReplicateACLTokens(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, func(c *Config) {
+
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.Region = "region1"
 		c.AuthoritativeRegion = "region1"
 		c.ACLEnabled = true
 	})
-	defer s1.Shutdown()
-	s2, _ := TestACLServer(t, func(c *Config) {
+	defer cleanupS1()
+	s2, _, cleanupS2 := TestACLServer(t, func(c *Config) {
 		c.Region = "region2"
 		c.AuthoritativeRegion = "region1"
 		c.ACLEnabled = true
 		c.ReplicationBackoff = 20 * time.Millisecond
 		c.ReplicationToken = root.SecretID
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -774,23 +776,24 @@ func TestLeader_DiffACLTokens(t *testing.T) {
 
 func TestLeader_UpgradeRaftVersion(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Datacenter = "dc1"
 		c.RaftConfig.ProtocolVersion = 2
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 1
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 2
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 
 	servers := []*Server{s1, s2, s3}
 
@@ -822,12 +825,12 @@ func TestLeader_UpgradeRaftVersion(t *testing.T) {
 	}
 
 	// Replace the dead server with one running raft protocol v3
-	s4 := TestServer(t, func(c *Config) {
+	s4, cleanupS4 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.Datacenter = "dc1"
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s4.Shutdown()
+	defer cleanupS4()
 	TestJoin(t, s1, s4)
 	servers[1] = s4
 
@@ -872,24 +875,25 @@ func TestLeader_Reelection(t *testing.T) {
 }
 
 func leaderElectionTest(t *testing.T, raftProtocol raft.ProtocolVersion) {
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3
 		c.RaftConfig.ProtocolVersion = raftProtocol
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = raftProtocol
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = raftProtocol
 	})
+	defer cleanupS3() // todo(shoenig) added this, should be here right??
 
 	servers := []*Server{s1, s2, s3}
 
@@ -931,22 +935,23 @@ func leaderElectionTest(t *testing.T, raftProtocol raft.ProtocolVersion) {
 
 func TestLeader_RollRaftServer(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 2
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 2
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 2
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 
 	servers := []*Server{s1, s2, s3}
 
@@ -973,11 +978,11 @@ func TestLeader_RollRaftServer(t *testing.T) {
 	}
 
 	// Replace the dead server with one running raft protocol v3
-	s4 := TestServer(t, func(c *Config) {
+	s4, cleanupS4 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s4.Shutdown()
+	defer cleanupS4()
 	TestJoin(t, s4, s2)
 	servers[0] = s4
 
@@ -996,11 +1001,11 @@ func TestLeader_RollRaftServer(t *testing.T) {
 		})
 	}
 	// Replace another dead server with one running raft protocol v3
-	s5 := TestServer(t, func(c *Config) {
+	s5, cleanupS5 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s5.Shutdown()
+	defer cleanupS5()
 	TestJoin(t, s5, s4)
 	servers[1] = s5
 
@@ -1020,11 +1025,11 @@ func TestLeader_RollRaftServer(t *testing.T) {
 	}
 
 	// Replace the last dead server with one running raft protocol v3
-	s6 := TestServer(t, func(c *Config) {
+	s6, cleanupS6 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s6.Shutdown()
+	defer cleanupS6()
 	TestJoin(t, s6, s4)
 	servers[2] = s6
 
@@ -1055,8 +1060,8 @@ func TestLeader_RollRaftServer(t *testing.T) {
 }
 
 func TestLeader_RevokeLeadership_MultipleTimes(t *testing.T) {
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -1071,8 +1076,8 @@ func TestLeader_RevokeLeadership_MultipleTimes(t *testing.T) {
 }
 
 func TestLeader_TransitionsUpdateConsistencyRead(t *testing.T) {
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -1093,25 +1098,26 @@ func TestLeader_TransitionsUpdateConsistencyRead(t *testing.T) {
 // This verifies that removing the server and adding it back with a uuid works
 // even if the server's address stays the same.
 func TestServer_ReconcileMember(t *testing.T) {
-	// Create a three node cluster
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	// Create a three node cluster
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 		c.RaftConfig.ProtocolVersion = 2
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	TestJoin(t, s1, s2, s3)
 	testutil.WaitForLeader(t, s1.RPC)
 

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -24,8 +24,9 @@ import (
 func TestClientEndpoint_Register(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -86,15 +87,16 @@ func TestClientEndpoint_Register(t *testing.T) {
 func TestClientEndpoint_Register_NodeConn_Forwarded(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 2
 	})
 
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
@@ -175,8 +177,9 @@ func TestClientEndpoint_Register_NodeConn_Forwarded(t *testing.T) {
 
 func TestClientEndpoint_Register_SecretMismatch(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -204,8 +207,9 @@ func TestClientEndpoint_Register_SecretMismatch(t *testing.T) {
 // Test the deprecated single node deregistration path
 func TestClientEndpoint_DeregisterOne(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -249,8 +253,9 @@ func TestClientEndpoint_DeregisterOne(t *testing.T) {
 
 func TestClientEndpoint_Deregister_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -314,8 +319,9 @@ func TestClientEndpoint_Deregister_ACL(t *testing.T) {
 
 func TestClientEndpoint_Deregister_Vault(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -376,8 +382,9 @@ func TestClientEndpoint_Deregister_Vault(t *testing.T) {
 func TestClientEndpoint_UpdateStatus(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -454,8 +461,9 @@ func TestClientEndpoint_UpdateStatus(t *testing.T) {
 
 func TestClientEndpoint_UpdateStatus_Vault(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -513,8 +521,9 @@ func TestClientEndpoint_UpdateStatus_Vault(t *testing.T) {
 func TestClientEndpoint_UpdateStatus_HeartbeatRecovery(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -562,8 +571,9 @@ func TestClientEndpoint_UpdateStatus_HeartbeatRecovery(t *testing.T) {
 
 func TestClientEndpoint_Register_GetEvals(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -656,8 +666,9 @@ func TestClientEndpoint_Register_GetEvals(t *testing.T) {
 
 func TestClientEndpoint_UpdateStatus_GetEvals(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -739,18 +750,19 @@ func TestClientEndpoint_UpdateStatus_GetEvals(t *testing.T) {
 
 func TestClientEndpoint_UpdateStatus_HeartbeatOnly(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
 
-	s2 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
-	s3 := TestServer(t, func(c *Config) {
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.DevDisableBootstrap = true
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	servers := []*Server{s1, s2, s3}
 	TestJoin(t, s1, s2, s3)
 
@@ -820,10 +832,10 @@ func TestClientEndpoint_UpdateStatus_HeartbeatOnly_Advertise(t *testing.T) {
 	adv, err := net.ResolveTCPAddr("tcp", advAddr)
 	require.Nil(err)
 
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.ClientRPCAdvertise = adv
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -854,8 +866,9 @@ func TestClientEndpoint_UpdateStatus_HeartbeatOnly_Advertise(t *testing.T) {
 func TestClientEndpoint_UpdateDrain(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -948,8 +961,9 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 
 func TestClientEndpoint_UpdateDrain_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	require := require.New(t)
@@ -1009,8 +1023,9 @@ func TestClientEndpoint_UpdateDrain_ACL(t *testing.T) {
 // pending/running state to lost when a node is marked as down.
 func TestClientEndpoint_Drain_Down(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	require := require.New(t)
@@ -1140,8 +1155,9 @@ func TestClientEndpoint_Drain_Down(t *testing.T) {
 func TestClientEndpoint_UpdateEligibility(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1196,8 +1212,9 @@ func TestClientEndpoint_UpdateEligibility(t *testing.T) {
 
 func TestClientEndpoint_UpdateEligibility_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	require := require.New(t)
@@ -1251,8 +1268,9 @@ func TestClientEndpoint_UpdateEligibility_ACL(t *testing.T) {
 
 func TestClientEndpoint_GetNode(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1319,8 +1337,9 @@ func TestClientEndpoint_GetNode(t *testing.T) {
 
 func TestClientEndpoint_GetNode_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -1382,8 +1401,9 @@ func TestClientEndpoint_GetNode_ACL(t *testing.T) {
 
 func TestClientEndpoint_GetNode_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -1484,8 +1504,9 @@ func TestClientEndpoint_GetNode_Blocking(t *testing.T) {
 
 func TestClientEndpoint_GetAllocs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1546,8 +1567,9 @@ func TestClientEndpoint_GetAllocs(t *testing.T) {
 
 func TestClientEndpoint_GetAllocs_ACL_Basic(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -1621,8 +1643,9 @@ func TestClientEndpoint_GetAllocs_ACL_Basic(t *testing.T) {
 func TestClientEndpoint_GetClientAllocs(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1699,8 +1722,9 @@ func TestClientEndpoint_GetClientAllocs(t *testing.T) {
 
 func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1821,8 +1845,9 @@ func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 func TestClientEndpoint_GetClientAllocs_Blocking_GC(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1898,8 +1923,8 @@ func TestClientEndpoint_GetClientAllocs_WithoutMigrateTokens(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -1949,8 +1974,9 @@ func TestClientEndpoint_GetClientAllocs_WithoutMigrateTokens(t *testing.T) {
 
 func TestClientEndpoint_GetAllocs_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2041,14 +2067,15 @@ func TestClientEndpoint_GetAllocs_Blocking(t *testing.T) {
 
 func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		// Disabling scheduling in this test so that we can
 		// ensure that the state store doesn't accumulate more evals
 		// than what we expect the unit test to add
 		c.NumSchedulers = 0
 	})
 
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	require := require.New(t)
@@ -2138,8 +2165,9 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 
 func TestClientEndpoint_BatchUpdate(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2195,8 +2223,9 @@ func TestClientEndpoint_BatchUpdate(t *testing.T) {
 
 func TestClientEndpoint_UpdateAlloc_Vault(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2280,8 +2309,9 @@ func TestClientEndpoint_UpdateAlloc_Vault(t *testing.T) {
 
 func TestClientEndpoint_CreateNodeEvals(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Inject fake evaluations
@@ -2374,10 +2404,11 @@ func TestClientEndpoint_CreateNodeEvals(t *testing.T) {
 
 func TestClientEndpoint_Evaluate(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2461,8 +2492,9 @@ func TestClientEndpoint_Evaluate(t *testing.T) {
 
 func TestClientEndpoint_Evaluate_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -2519,8 +2551,9 @@ func TestClientEndpoint_Evaluate_ACL(t *testing.T) {
 
 func TestClientEndpoint_ListNodes(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -2580,8 +2613,9 @@ func TestClientEndpoint_ListNodes(t *testing.T) {
 
 func TestClientEndpoint_ListNodes_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -2634,8 +2668,9 @@ func TestClientEndpoint_ListNodes_ACL(t *testing.T) {
 
 func TestClientEndpoint_ListNodes_Blocking(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -2765,8 +2800,9 @@ func TestClientEndpoint_ListNodes_Blocking(t *testing.T) {
 
 func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -2846,8 +2882,9 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 
 func TestClientEndpoint_DeriveVaultToken(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -2938,8 +2975,9 @@ func TestClientEndpoint_DeriveVaultToken(t *testing.T) {
 
 func TestClientEndpoint_DeriveVaultToken_VaultError(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -2997,9 +3035,9 @@ func TestClientEndpoint_EmitEvents(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	s1 := TestServer(t, nil)
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	state := s1.fsm.State()
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/lib/freeport"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -19,8 +19,9 @@ import (
 
 func TestOperator_RaftGetConfiguration(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -62,8 +63,9 @@ func TestOperator_RaftGetConfiguration(t *testing.T) {
 
 func TestOperator_RaftGetConfiguration_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -125,16 +127,20 @@ func TestOperator_RaftGetConfiguration_ACL(t *testing.T) {
 
 func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = raft.ProtocolVersion(2)
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
+	ports := freeport.MustTake(1)
+	defer freeport.Return(ports)
+
 	// Try to remove a peer that's not there.
 	arg := structs.RaftPeerByAddressRequest{
-		Address: raft.ServerAddress(fmt.Sprintf("127.0.0.1:%d", freeport.GetT(t, 1)[0])),
+		Address: raft.ServerAddress(fmt.Sprintf("127.0.0.1:%d", ports[0])),
 	}
 	arg.Region = s1.config.Region
 	var reply struct{}
@@ -183,11 +189,12 @@ func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
 
 func TestOperator_RaftRemovePeerByAddress_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, func(c *Config) {
+
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = raft.ProtocolVersion(2)
 	})
 
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -196,8 +203,11 @@ func TestOperator_RaftRemovePeerByAddress_ACL(t *testing.T) {
 	// Create ACL token
 	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid", mock.NodePolicy(acl.PolicyWrite))
 
+	ports := freeport.MustTake(1)
+	defer freeport.Return(ports)
+
 	arg := structs.RaftPeerByAddressRequest{
-		Address: raft.ServerAddress(fmt.Sprintf("127.0.0.1:%d", freeport.GetT(t, 1)[0])),
+		Address: raft.ServerAddress(fmt.Sprintf("127.0.0.1:%d", ports[0])),
 	}
 	arg.Region = s1.config.Region
 
@@ -234,10 +244,11 @@ func TestOperator_RaftRemovePeerByAddress_ACL(t *testing.T) {
 
 func TestOperator_RaftRemovePeerByID(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -252,9 +263,12 @@ func TestOperator_RaftRemovePeerByID(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	ports := freeport.MustTake(1)
+	defer freeport.Return(ports)
+
 	// Add it manually to Raft.
 	{
-		future := s1.raft.AddVoter(arg.ID, raft.ServerAddress(fmt.Sprintf("127.0.0.1:%d", freeport.GetT(t, 1)[0])), 0, 0)
+		future := s1.raft.AddVoter(arg.ID, raft.ServerAddress(fmt.Sprintf("127.0.0.1:%d", ports[0])), 0, 0)
 		if err := future.Error(); err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -292,10 +306,11 @@ func TestOperator_RaftRemovePeerByID(t *testing.T) {
 
 func TestOperator_RaftRemovePeerByID_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, func(c *Config) {
+
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	assert := assert.New(t)
@@ -309,9 +324,12 @@ func TestOperator_RaftRemovePeerByID_ACL(t *testing.T) {
 	}
 	arg.Region = s1.config.Region
 
+	ports := freeport.MustTake(1)
+	defer freeport.Return(ports)
+
 	// Add peer manually to Raft.
 	{
-		future := s1.raft.AddVoter(arg.ID, raft.ServerAddress(fmt.Sprintf("127.0.0.1:%d", freeport.GetT(t, 1)[0])), 0, 0)
+		future := s1.raft.AddVoter(arg.ID, raft.ServerAddress(fmt.Sprintf("127.0.0.1:%d", ports[0])), 0, 0)
 		assert.Nil(future.Error())
 	}
 
@@ -342,10 +360,11 @@ func TestOperator_RaftRemovePeerByID_ACL(t *testing.T) {
 
 func TestOperator_SchedulerGetConfiguration(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Build = "0.9.0+unittest"
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -365,10 +384,11 @@ func TestOperator_SchedulerGetConfiguration(t *testing.T) {
 
 func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Build = "0.9.0+unittest"
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -406,11 +426,12 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 
 func TestOperator_SchedulerGetConfiguration_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, func(c *Config) {
+
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
 		c.Build = "0.9.0+unittest"
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()
@@ -452,11 +473,12 @@ func TestOperator_SchedulerGetConfiguration_ACL(t *testing.T) {
 
 func TestOperator_SchedulerSetConfiguration_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, func(c *Config) {
+
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
 		c.Build = "0.9.0+unittest"
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 	state := s1.fsm.State()

--- a/nomad/periodic_endpoint_test.go
+++ b/nomad/periodic_endpoint_test.go
@@ -14,11 +14,12 @@ import (
 
 func TestPeriodicEndpoint_Force(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
+	defer cleanupS1()
 	state := s1.fsm.State()
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -64,10 +65,11 @@ func TestPeriodicEndpoint_Force(t *testing.T) {
 
 func TestPeriodicEndpoint_Force_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, func(c *Config) {
+
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	state := s1.fsm.State()
 	assert := assert.New(t)
 	codec := rpcClient(t, s1)
@@ -144,11 +146,12 @@ func TestPeriodicEndpoint_Force_ACL(t *testing.T) {
 
 func TestPeriodicEndpoint_Force_NonPeriodic(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
+	defer cleanupS1()
 	state := s1.fsm.State()
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 

--- a/nomad/periodic_test.go
+++ b/nomad/periodic_test.go
@@ -655,8 +655,9 @@ func deriveChildJob(parent *structs.Job) *structs.Job {
 
 func TestPeriodicDispatch_RunningChildren_NoEvals(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Insert job.
@@ -678,8 +679,9 @@ func TestPeriodicDispatch_RunningChildren_NoEvals(t *testing.T) {
 
 func TestPeriodicDispatch_RunningChildren_ActiveEvals(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Insert periodic job and child.
@@ -714,8 +716,9 @@ func TestPeriodicDispatch_RunningChildren_ActiveEvals(t *testing.T) {
 
 func TestPeriodicDispatch_RunningChildren_ActiveAllocs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Insert periodic job and child.

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -66,8 +66,9 @@ func testRegisterJob(t *testing.T, s *Server, j *structs.Job) {
 // COMPAT 0.11: Tests the older unoptimized code path for applyPlan
 func TestPlanApply_applyPlan(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Register node
@@ -239,10 +240,11 @@ func TestPlanApply_applyPlan(t *testing.T) {
 // when the plan contains normalized allocs.
 func TestPlanApply_applyPlanWithNormalizedAllocs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Build = "0.9.2"
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Register node

--- a/nomad/plan_endpoint_test.go
+++ b/nomad/plan_endpoint_test.go
@@ -12,10 +12,11 @@ import (
 
 func TestPlanEndpoint_Submit(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 

--- a/nomad/regions_endpoint_test.go
+++ b/nomad/regions_endpoint_test.go
@@ -11,17 +11,18 @@ import (
 
 func TestRegionList(t *testing.T) {
 	t.Parallel()
+
 	// Make the servers
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Region = "region1"
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.Region = "region2"
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
 	// Join the servers
 	s2Addr := fmt.Sprintf("127.0.0.1:%d",

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -27,15 +27,14 @@ func registerAndVerifyJob(s *Server, t *testing.T, prefix string, counter int) *
 }
 
 func TestSearch_PrefixSearch_Job(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
-	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -61,15 +60,14 @@ func TestSearch_PrefixSearch_Job(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_ACL(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	jobID := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
-	t.Parallel()
-	s, root := TestACLServer(t, func(c *Config) {
+	s, root, cleanupS := TestACLServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 	state := s.fsm.State()
@@ -174,15 +172,14 @@ func TestSearch_PrefixSearch_ACL(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_All_JobWithHyphen(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	prefix := "example-test-------" // Assert that a job with more than 4 hyphens works
 
-	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -221,15 +218,14 @@ func TestSearch_PrefixSearch_All_JobWithHyphen(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_All_LongJob(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	prefix := strings.Repeat("a", 100)
 
-	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -268,15 +264,14 @@ func TestSearch_PrefixSearch_All_LongJob(t *testing.T) {
 
 // truncate should limit results to 20
 func TestSearch_PrefixSearch_Truncate(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
-	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -305,15 +300,15 @@ func TestSearch_PrefixSearch_Truncate(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_AllWithJob(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
-	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
 
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -345,13 +340,13 @@ func TestSearch_PrefixSearch_AllWithJob(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_Evals(t *testing.T) {
-	assert := assert.New(t)
 	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	assert := assert.New(t)
+
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -382,13 +377,13 @@ func TestSearch_PrefixSearch_Evals(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_Allocation(t *testing.T) {
-	assert := assert.New(t)
 	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	assert := assert.New(t)
+
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -427,13 +422,13 @@ func TestSearch_PrefixSearch_Allocation(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_All_UUID(t *testing.T) {
-	assert := assert.New(t)
 	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	assert := assert.New(t)
+
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -479,13 +474,13 @@ func TestSearch_PrefixSearch_All_UUID(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_Node(t *testing.T) {
-	assert := assert.New(t)
 	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	assert := assert.New(t)
+
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -520,13 +515,13 @@ func TestSearch_PrefixSearch_Node(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_Deployment(t *testing.T) {
-	assert := assert.New(t)
 	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	assert := assert.New(t)
+
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -557,13 +552,14 @@ func TestSearch_PrefixSearch_Deployment(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_AllContext(t *testing.T) {
-	assert := assert.New(t)
 	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	assert := assert.New(t)
+
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
 
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -607,16 +603,14 @@ func TestSearch_PrefixSearch_AllContext(t *testing.T) {
 
 // Tests that the top 20 matches are returned when no prefix is set
 func TestSearch_PrefixSearch_NoPrefix(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
-
 	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
-	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -644,16 +638,14 @@ func TestSearch_PrefixSearch_NoPrefix(t *testing.T) {
 // Tests that the zero matches are returned when a prefix has no matching
 // results
 func TestSearch_PrefixSearch_NoMatches(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
-
 	prefix := "aaaaaaaa-e8f7-fd38-c855-ab94ceb8970"
 
-	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -678,17 +670,16 @@ func TestSearch_PrefixSearch_NoMatches(t *testing.T) {
 // Prefixes can only be looked up if their length is a power of two. For
 // prefixes which are an odd length, use the length-1 characters.
 func TestSearch_PrefixSearch_RoundDownToEven(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	id1 := "aaafaaaa-e8f7-fd38-c855-ab94ceb89"
 	id2 := "aaafeaaa-e8f7-fd38-c855-ab94ceb89"
 	prefix := "aaafa"
 
-	t.Parallel()
-	s := TestServer(t, func(c *Config) {
+	s, cleanupS := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 	})
-
-	defer s.Shutdown()
+	defer cleanupS()
 	codec := rpcClient(t, s)
 	testutil.WaitForLeader(t, s.RPC)
 
@@ -714,22 +705,21 @@ func TestSearch_PrefixSearch_RoundDownToEven(t *testing.T) {
 }
 
 func TestSearch_PrefixSearch_MultiRegion(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
-
 	jobName := "exampleexample"
 
-	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.Region = "foo"
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
-	s2 := TestServer(t, func(c *Config) {
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.Region = "bar"
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)

--- a/nomad/serf_test.go
+++ b/nomad/serf_test.go
@@ -15,12 +15,13 @@ import (
 
 func TestNomad_JoinPeer(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.Region = "region2"
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -56,12 +57,13 @@ func TestNomad_JoinPeer(t *testing.T) {
 
 func TestNomad_RemovePeer(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.Region = "global"
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	TestJoin(t, s1, s2)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -95,32 +97,34 @@ func TestNomad_RemovePeer(t *testing.T) {
 
 func TestNomad_ReapPeer(t *testing.T) {
 	t.Parallel()
+
 	dir := tmpDir(t)
 	defer os.RemoveAll(dir)
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NodeName = "node1"
 		c.BootstrapExpect = 3
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node1")
 	})
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.NodeName = "node2"
 		c.BootstrapExpect = 3
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node2")
 	})
-	defer s2.Shutdown()
-	s3 := TestServer(t, func(c *Config) {
+	defer cleanupS2()
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.NodeName = "node3"
 		c.BootstrapExpect = 3
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node3")
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	TestJoin(t, s1, s2, s3)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -189,30 +193,31 @@ func TestNomad_ReapPeer(t *testing.T) {
 
 func TestNomad_BootstrapExpect(t *testing.T) {
 	t.Parallel()
+
 	dir := tmpDir(t)
 	defer os.RemoveAll(dir)
 
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node1")
 	})
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node2")
 	})
-	defer s2.Shutdown()
-	s3 := TestServer(t, func(c *Config) {
+	defer cleanupS2()
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node3")
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	TestJoin(t, s1, s2, s3)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -255,13 +260,13 @@ func TestNomad_BootstrapExpect(t *testing.T) {
 
 	// Join a fourth server after quorum has already been formed and ensure
 	// there is no election
-	s4 := TestServer(t, func(c *Config) {
+	s4, cleanupS4 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node4")
 	})
-	defer s4.Shutdown()
+	defer cleanupS4()
 
 	// Make sure a leader is elected, grab the current term and then add in
 	// the fourth server.
@@ -301,32 +306,33 @@ func TestNomad_BootstrapExpect(t *testing.T) {
 
 func TestNomad_BootstrapExpect_NonVoter(t *testing.T) {
 	t.Parallel()
+
 	dir := tmpDir(t)
 	defer os.RemoveAll(dir)
 
-	s1 := TestServer(t, func(c *Config) {
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 2
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node1")
 		c.NonVoter = true
 	})
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 2
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node2")
 		c.NonVoter = true
 	})
-	defer s2.Shutdown()
-	s3 := TestServer(t, func(c *Config) {
+	defer cleanupS2()
+	s3, cleanupS3 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 2
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node3")
 	})
-	defer s3.Shutdown()
+	defer cleanupS3()
 	TestJoin(t, s1, s2, s3)
 
 	// Assert that we do not bootstrap
@@ -342,13 +348,13 @@ func TestNomad_BootstrapExpect_NonVoter(t *testing.T) {
 	})
 
 	// Add the fourth server that is a voter
-	s4 := TestServer(t, func(c *Config) {
+	s4, cleanupS4 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 2
 		c.DevMode = false
 		c.DevDisableBootstrap = true
 		c.DataDir = path.Join(dir, "node4")
 	})
-	defer s4.Shutdown()
+	defer cleanupS4()
 	TestJoin(t, s1, s2, s3, s4)
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -409,16 +415,17 @@ func TestNomad_BootstrapExpect_NonVoter(t *testing.T) {
 
 func TestNomad_BadExpect(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 2
 		c.DevDisableBootstrap = true
 	})
-	defer s1.Shutdown()
-	s2 := TestServer(t, func(c *Config) {
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3
 		c.DevDisableBootstrap = true
 	})
-	defer s2.Shutdown()
+	defer cleanupS2()
 	servers := []*Server{s1, s2}
 	TestJoin(t, s1, s2)
 

--- a/nomad/stats_fetcher_test.go
+++ b/nomad/stats_fetcher_test.go
@@ -17,14 +17,14 @@ func TestStatsFetcher(t *testing.T) {
 		c.BootstrapExpect = 3
 	}
 
-	s1 := TestServer(t, conf)
-	defer s1.Shutdown()
+	s1, cleanupS1 := TestServer(t, conf)
+	defer cleanupS1()
 
-	s2 := TestServer(t, conf)
-	defer s2.Shutdown()
+	s2, cleanupS2 := TestServer(t, conf)
+	defer cleanupS2()
 
-	s3 := TestServer(t, conf)
-	defer s3.Shutdown()
+	s3, cleanupS3 := TestServer(t, conf)
+	defer cleanupS3()
 
 	TestJoin(t, s1, s2, s3)
 	testutil.WaitForLeader(t, s1.RPC)

--- a/nomad/status_endpoint_test.go
+++ b/nomad/status_endpoint_test.go
@@ -15,8 +15,9 @@ import (
 
 func TestStatusVersion(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	arg := &structs.GenericRequest{
@@ -46,8 +47,9 @@ func TestStatusVersion(t *testing.T) {
 
 func TestStatusPing(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	arg := struct{}{}
@@ -59,8 +61,9 @@ func TestStatusPing(t *testing.T) {
 
 func TestStatusLeader(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -81,8 +84,9 @@ func TestStatusLeader(t *testing.T) {
 
 func TestStatusPeers(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
 	arg := &structs.GenericRequest{
@@ -102,8 +106,9 @@ func TestStatusPeers(t *testing.T) {
 
 func TestStatusMembers(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	assert := assert.New(t)
 
@@ -121,8 +126,9 @@ func TestStatusMembers(t *testing.T) {
 
 func TestStatusMembers_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	assert := assert.New(t)
 	state := s1.fsm.State()
@@ -174,8 +180,9 @@ func TestStatusMembers_ACL(t *testing.T) {
 
 func TestStatus_HasClientConn(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	require := require.New(t)
 

--- a/nomad/system_endpoint_test.go
+++ b/nomad/system_endpoint_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestSystemEndpoint_GarbageCollect(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -66,8 +67,9 @@ func TestSystemEndpoint_GarbageCollect(t *testing.T) {
 
 func TestSystemEndpoint_GarbageCollect_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	assert := assert.New(t)
 	testutil.WaitForLeader(t, s1.RPC)
@@ -110,8 +112,9 @@ func TestSystemEndpoint_GarbageCollect_ACL(t *testing.T) {
 
 func TestSystemEndpoint_ReconcileSummaries(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
@@ -172,8 +175,9 @@ func TestSystemEndpoint_ReconcileSummaries(t *testing.T) {
 
 func TestSystemEndpoint_ReconcileJobSummaries_ACL(t *testing.T) {
 	t.Parallel()
-	s1, root := TestACLServer(t, nil)
-	defer s1.Shutdown()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	assert := assert.New(t)
 	testutil.WaitForLeader(t, s1.RPC)

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	testing "github.com/mitchellh/go-testing-interface"
+	"github.com/pkg/errors"
 
-	"github.com/hashicorp/consul/lib/freeport"
 	"github.com/hashicorp/nomad/command/agent/consul"
+	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/helper/pluginutils/catalog"
 	"github.com/hashicorp/nomad/helper/pluginutils/singleton"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -23,8 +24,8 @@ var (
 	nodeNumber uint32 = 0
 )
 
-func TestACLServer(t testing.T, cb func(*Config)) (*Server, *structs.ACLToken) {
-	server := TestServer(t, func(c *Config) {
+func TestACLServer(t testing.T, cb func(*Config)) (*Server, *structs.ACLToken, func()) {
+	server, cleanup := TestServer(t, func(c *Config) {
 		c.ACLEnabled = true
 		if cb != nil {
 			cb(c)
@@ -35,10 +36,10 @@ func TestACLServer(t testing.T, cb func(*Config)) (*Server, *structs.ACLToken) {
 	if err != nil {
 		t.Fatalf("failed to bootstrap ACL token: %v", err)
 	}
-	return server, token
+	return server, token, cleanup
 }
 
-func TestServer(t testing.T, cb func(*Config)) *Server {
+func TestServer(t testing.T, cb func(*Config)) (*Server, func()) {
 	// Setup the default settings
 	config := DefaultConfig()
 	config.Logger = testlog.HCLogger(t)
@@ -91,8 +92,9 @@ func TestServer(t testing.T, cb func(*Config)) *Server {
 	catalog := consul.NewMockCatalog(config.Logger)
 
 	for i := 10; i >= 0; i-- {
-		// Get random ports
-		ports := freeport.GetT(t, 2)
+		// Get random ports, need to cleanup later
+		ports := freeport.MustTake(2)
+
 		config.RPCAddr = &net.TCPAddr{
 			IP:   []byte{127, 0, 0, 1},
 			Port: ports[0],
@@ -102,19 +104,43 @@ func TestServer(t testing.T, cb func(*Config)) *Server {
 		// Create server
 		server, err := NewServer(config, catalog)
 		if err == nil {
-			return server
+			return server, func() {
+				ch := make(chan error)
+				go func() {
+					defer close(ch)
+
+					// Shutdown server
+					err := server.Shutdown()
+					if err != nil {
+						ch <- errors.Wrap(err, "failed to shutdown server")
+					}
+
+					freeport.Return(ports)
+				}()
+
+				select {
+				case e := <-ch:
+					if e != nil {
+						t.Fatal(e.Error())
+					}
+				case <-time.After(1 * time.Minute):
+					t.Fatal("timed out while shutting down server")
+				}
+			}
 		} else if i == 0 {
+			freeport.Return(ports)
 			t.Fatalf("err: %v", err)
 		} else {
 			if server != nil {
-				server.Shutdown()
+				_ = server.Shutdown()
+				freeport.Return(ports)
 			}
 			wait := time.Duration(rand.Int31n(2000)) * time.Millisecond
 			time.Sleep(wait)
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func TestJoin(t testing.T, s1 *Server, other ...*Server) {

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -49,11 +49,12 @@ func init() {
 
 func TestWorker_dequeueEvaluation(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create the evaluation
@@ -85,11 +86,12 @@ func TestWorker_dequeueEvaluation(t *testing.T) {
 // evals for the same job.
 func TestWorker_dequeueEvaluation_SerialJobs(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create the evaluation
@@ -153,11 +155,12 @@ func TestWorker_dequeueEvaluation_SerialJobs(t *testing.T) {
 
 func TestWorker_dequeueEvaluation_paused(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create the evaluation
@@ -200,11 +203,12 @@ func TestWorker_dequeueEvaluation_paused(t *testing.T) {
 
 func TestWorker_dequeueEvaluation_shutdown(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create a worker
@@ -229,11 +233,12 @@ func TestWorker_dequeueEvaluation_shutdown(t *testing.T) {
 
 func TestWorker_sendAck(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create the evaluation
@@ -276,11 +281,12 @@ func TestWorker_sendAck(t *testing.T) {
 
 func TestWorker_waitForIndex(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Get the current index
@@ -314,11 +320,12 @@ func TestWorker_waitForIndex(t *testing.T) {
 
 func TestWorker_invokeScheduler(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 
 	w := &Worker{srv: s1, logger: s1.logger}
 	eval := mock.Eval()
@@ -333,11 +340,12 @@ func TestWorker_invokeScheduler(t *testing.T) {
 
 func TestWorker_SubmitPlan(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Register node
@@ -398,12 +406,13 @@ func TestWorker_SubmitPlan(t *testing.T) {
 
 func TestWorker_SubmitPlanNormalizedAllocations(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 		c.Build = "0.9.2"
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Register node
@@ -449,11 +458,12 @@ func TestWorker_SubmitPlanNormalizedAllocations(t *testing.T) {
 
 func TestWorker_SubmitPlan_MissingNodeRefresh(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Register node
@@ -519,11 +529,12 @@ func TestWorker_SubmitPlan_MissingNodeRefresh(t *testing.T) {
 
 func TestWorker_UpdateEval(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Register node
@@ -566,11 +577,12 @@ func TestWorker_UpdateEval(t *testing.T) {
 
 func TestWorker_CreateEval(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Register node
@@ -614,11 +626,12 @@ func TestWorker_CreateEval(t *testing.T) {
 
 func TestWorker_ReblockEval(t *testing.T) {
 	t.Parallel()
-	s1 := TestServer(t, func(c *Config) {
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
-	defer s1.Shutdown()
+	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Create the blocked eval


### PR DESCRIPTION
Copy the updated version of freeport (sdk/freeport), and tweak it for use
in Nomad tests. This means staying below port 10000 to avoid conflicts with
the lib/freeport that is still transitively used by the old version of
consul that we vendor. Also provide implementations to find ephemeral ports
of macOS and Windows environments.

Ports acquired through freeport are supposed to be returned to freeport,
which this change now also introduces. Many tests are modified to include
calls to a cleanup function for Server objects.

This should help quite a bit with some flakey tests, but not all of them.
Our port problems will not go away completely until we upgrade our vendor
version of consul. With Go modules, we'll probably do a 'replace' to swap
out other copies of freeport with the one now in 'nomad/helper/freeport'.