### PR TITLE
Tweak parallelism for plugin processes

### DIFF
--- a/client/logmon/plugin.go
+++ b/client/logmon/plugin.go
@@ -35,6 +35,10 @@ func LaunchLogMon(logger hclog.Logger, reattachConfig *plugin.ReattachConfig) (L
 	// Only set one of Cmd or Reattach
 	if reattachConfig == nil {
 		conf.Cmd = exec.Command(bin, "logmon")
+		conf.Cmd.Env = append(conf.Cmd.Env,
+			// 2 threads: for stdout and stderr copying
+			"GOMAXPROCS=2",
+		)
 	} else {
 		conf.Reattach = reattachConfig
 	}

--- a/drivers/shared/executor/utils.go
+++ b/drivers/shared/executor/utils.go
@@ -61,6 +61,10 @@ func CreateExecutor(logger hclog.Logger, driverConfig *base.ClientDriverConfig,
 	// setting the setsid of the plugin process so that it doesn't get signals sent to
 	// the nomad client.
 	if config.Cmd != nil {
+		config.Cmd.Env = append(config.Cmd.Env,
+			// 1 thread is sufficient
+			"GOMAXPROCS=1",
+		)
 		isolateCommand(config.Cmd)
 	}
 


### PR DESCRIPTION
Nomad runs many auxilary processes per alloc or task: logmon,
docker_logger, and executor.

These are typically not highly parallel ones.  Generally, they use few
goroutines that blocked most of the time (till task completes or wait
for GRPC requests), but one active goroutine or two:

* `logmon`: has two active goroutine for copying stdout/stderr fifos
into final files.
* `docker_logger`: one goroutine for calling docker logging API which
parses output and copy apporpriatly to stdout/stderr fifo files.
* `executor`: mostly one goroutine to setup and block until command
executes.  some additional goroutines may be used for handling `exec` or
task signal handling, but they aren't cpu/io bound.

I want to do some benchmarking or research before merging this into master.