### PR TITLE
UI: Unclosed log streams

### DIFF
--- a/ui/app/utils/classes/stream-logger.js
+++ b/ui/app/utils/classes/stream-logger.js
@@ -28,10 +28,6 @@ export default EmberObject.extend(AbstractLogger, {
     const url = this.fullUrl;
     const logFetch = this.logFetch;
 
-    let streamClosed = false;
-    let buffer = '';
-
-    const decoder = new TextDecoder();
     const reader = yield logFetch(url).then(res => {
       const reader = res.body.getReader();
       // It's possible that the logger was stopped between the time
@@ -49,6 +45,10 @@ export default EmberObject.extend(AbstractLogger, {
     }
 
     this.set('reader', reader);
+
+    let streamClosed = false;
+    let buffer = '';
+    const decoder = new TextDecoder();
 
     while (!streamClosed) {
       yield reader.read().then(({ value, done }) => {

--- a/ui/tests/unit/utils/stream-logger-test.js
+++ b/ui/tests/unit/utils/stream-logger-test.js
@@ -1,0 +1,96 @@
+import { module, test } from 'qunit';
+import { Promise } from 'rsvp';
+import sinon from 'sinon';
+import StreamLogger from 'nomad-ui/utils/classes/stream-logger';
+
+module('Unit | Util | StreamLogger', function() {
+  test('when a StreamLogger is stopped before the poll request responds, the request is immediately canceled upon completion', async function(assert) {
+    const fetchMock = new FetchMock();
+    const fetch = fetchMock.request();
+
+    const logger = StreamLogger.create({
+      logFetch: () => fetch,
+    });
+
+    logger.start();
+    logger.stop();
+
+    assert.notOk(logger.poll.isRunning);
+    assert.equal(fetchMock.reader.cancel.callCount, 0);
+
+    fetchMock.closeRequest();
+    await fetch;
+
+    assert.equal(fetchMock.reader.cancel.callCount, 1);
+  });
+
+  test('when the streaming request sends the done flag, the poll task completes', async function(assert) {
+    const fetchMock = new FetchMock();
+    const fetch = fetchMock.request();
+
+    const logger = StreamLogger.create({
+      logFetch: () => fetch,
+    });
+
+    logger.start();
+
+    assert.ok(logger.poll.isRunning);
+    assert.equal(fetchMock.reader.readSpy.callCount, 0);
+
+    fetchMock.closeRequest();
+    await fetch;
+
+    assert.notOk(logger.poll.isRunning);
+    assert.equal(fetchMock.reader.readSpy.callCount, 1);
+  });
+});
+
+class FetchMock {
+  constructor() {
+    this._closeRequest = null;
+    this.reader = new ReadableStreamMock();
+    this.response = new FetchResponseMock(this.reader);
+  }
+
+  request() {
+    if (this._closeRequest) {
+      throw new Error('Can only call FetchMock.request once');
+    }
+    return new Promise(resolve => {
+      this._closeRequest = resolve;
+    });
+  }
+
+  closeRequest() {
+    if (this._closeRequest) {
+      this._closeRequest(this.response);
+    } else {
+      throw new Error('Must call FetchMock.request() before FetchMock.closeRequest');
+    }
+  }
+}
+
+class FetchResponseMock {
+  constructor(reader) {
+    this.reader = reader;
+    this.body = {
+      getReader() {
+        return reader;
+      },
+    };
+  }
+}
+
+class ReadableStreamMock {
+  constructor() {
+    this.cancel = sinon.spy();
+    this.readSpy = sinon.spy();
+  }
+
+  read() {
+    this.readSpy();
+    return new Promise(resolve => {
+      resolve({ value: new ArrayBuffer(0), done: true });
+    });
+  }
+}


### PR DESCRIPTION
Fixes #6797 

If you are speedy* enough, you can click the `stderr` button before the `stdout` log request responds.

If this happens, the `stdout` log object will be stopped (as it should) which in turn cancels the stream reader (as it should) before the stream reader exists, since the response hasn't come in yet (uh oh).

This changes makes it so when the response comes in, the state of the logger is checked to see if the reader should be immediately canceled.

I wrote a couple tests I've been putting off since mocking the entire fetch + readable stream thing seemed like a mess. Turns out it wasn't so bad for just this one case!

<sub>* You don't actually have to be that fast, within a second when running services locally. This is going to be dependent on network conditions and the task driver</sub>