### PR TITLE
docs: port name requires quotes in hcl

### DIFF
--- a/website/source/docs/job-specification/service.html.md
+++ b/website/source/docs/job-specification/service.html.md
@@ -567,13 +567,13 @@ job "example" {
 
       service {
         name = "ipv6-redis"
-        port = db
+        port = "db"
         check {
           name     = "ipv6-redis-check"
           type     = "tcp"
           interval = "10s"
           timeout  = "2s"
-          port     = db
+          port     = "db"
           address_mode = "driver"
         }
       }


### PR DESCRIPTION
When trying to run this example, Nomad v0.10.2 raises the following error:
`Error getting job struct: Error parsing job file from example-ipv6.hcl: error parsing: At 33:22: Unknown token: 27:16 IDENT db`

Adding quotes around the port map `db` fixes the problem and the job works as expected.