### PR TITLE
client: enable nomad client to request and set SI tokens for tasks

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -62,6 +62,10 @@ type allocRunner struct {
 	// registering services and checks
 	consulClient consul.ConsulServiceAPI
 
+	// sidsClient is the client used by the service identity hook for
+	// managing SI tokens
+	sidsClient consul.ServiceIdentityAPI
+
 	// vaultClient is the used to manage Vault tokens
 	vaultClient vaultclient.VaultClient
 
@@ -157,6 +161,7 @@ func NewAllocRunner(config *Config) (*allocRunner, error) {
 		alloc:                    alloc,
 		clientConfig:             config.ClientConfig,
 		consulClient:             config.Consul,
+		sidsClient:               config.ConsulSI,
 		vaultClient:              config.Vault,
 		tasks:                    make(map[string]*taskrunner.TaskRunner, len(tg.Tasks)),
 		waitCh:                   make(chan struct{}),
@@ -202,14 +207,16 @@ func NewAllocRunner(config *Config) (*allocRunner, error) {
 func (ar *allocRunner) initTaskRunners(tasks []*structs.Task) error {
 	for _, task := range tasks {
 		config := &taskrunner.Config{
-			Alloc:               ar.alloc,
-			ClientConfig:        ar.clientConfig,
-			Task:                task,
-			TaskDir:             ar.allocDir.NewTaskDir(task.Name),
-			Logger:              ar.logger,
-			StateDB:             ar.stateDB,
-			StateUpdater:        ar,
-			Consul:              ar.consulClient,
+			Alloc:        ar.alloc,
+			ClientConfig: ar.clientConfig,
+			Task:         task,
+			TaskDir:      ar.allocDir.NewTaskDir(task.Name),
+			Logger:       ar.logger,
+			StateDB:      ar.stateDB,
+			StateUpdater: ar,
+			Consul:       ar.consulClient,
+			ConsulSI:     ar.sidsClient,
+
 			Vault:               ar.vaultClient,
 			DeviceStatsReporter: ar.deviceStatsReporter,
 			DeviceManager:       ar.devicemanager,

--- a/client/allocrunner/config.go
+++ b/client/allocrunner/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	// Consul is the Consul client used to register task services and checks
 	Consul consul.ConsulServiceAPI
 
+	// ConsulSI is the Consul client used to manage service identity tokens.
+	ConsulSI consul.ServiceIdentityAPI
+
 	// Vault is the Vault client to use to retrieve Vault tokens
 	Vault vaultclient.VaultClient
 

--- a/client/allocrunner/taskrunner/sids_hook.go
+++ b/client/allocrunner/taskrunner/sids_hook.go
@@ -1,0 +1,193 @@
+package taskrunner
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/consul"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/pkg/errors"
+)
+
+const (
+	// the name of this hook, used in logs
+	sidsHookName = "consul_sids"
+
+	// sidsBackoffBaseline is the baseline time for exponential backoff when
+	// attempting to retrieve a Consul SI token
+	sidsBackoffBaseline = 5 * time.Second
+
+	// sidsBackoffLimit is the limit of the exponential backoff when attempting
+	// to retrieve a Consul SI token
+	sidsBackoffLimit = 3 * time.Minute
+
+	// sidsTokenFile is the name of the file holding the Consul SI token inside
+	// the task's secret directory
+	sidsTokenFile = "sids_token"
+
+	// sidsTokenFilePerms is the level of file permissions granted on the file
+	// in the secrets directory for the task
+	sidsTokenFilePerms = 0440
+)
+
+type sidsHookConfig struct {
+	alloc      *structs.Allocation
+	task       *structs.Task
+	sidsClient consul.ServiceIdentityAPI
+	logger     hclog.Logger
+}
+
+// Service Identities hook for managing SI tokens of connect enabled tasks.
+type sidsHook struct {
+	alloc      *structs.Allocation
+	taskName   string
+	sidsClient consul.ServiceIdentityAPI
+	logger     hclog.Logger
+
+	lock     sync.Mutex
+	firstRun bool
+}
+
+func newSIDSHook(c sidsHookConfig) *sidsHook {
+	return &sidsHook{
+		alloc:      c.alloc,
+		taskName:   c.task.Name,
+		sidsClient: c.sidsClient,
+		logger:     c.logger.Named(sidsHookName),
+		firstRun:   true,
+	}
+}
+
+func (h *sidsHook) Name() string {
+	return sidsHookName
+}
+
+func (h *sidsHook) Prestart(
+	ctx context.Context,
+	req *interfaces.TaskPrestartRequest,
+	_ *interfaces.TaskPrestartResponse) error {
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	// do nothing if we have already done things
+	if h.earlyExit() {
+		return nil
+	}
+
+	// optimistically try to recover token from disk
+	token, err := h.recoverToken(req.TaskDir.SecretsDir)
+	if err != nil {
+		return err
+	}
+
+	// need to ask for a new SI token & persist it to disk
+	if token == "" {
+		if token, err = h.deriveSIToken(ctx); err != nil {
+			return err
+		}
+		if err := h.writeToken(req.TaskDir.SecretsDir, token); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// earlyExit returns true if the Prestart hook has already been executed during
+// the instantiation of this task runner.
+//
+// assumes h is locked
+func (h *sidsHook) earlyExit() bool {
+	if h.firstRun {
+		h.firstRun = false
+		return false
+	}
+	return true
+}
+
+// writeToken writes token into the secrets directory for the task.
+func (h *sidsHook) writeToken(dir string, token string) error {
+	tokenPath := filepath.Join(dir, sidsTokenFile)
+	if err := ioutil.WriteFile(tokenPath, []byte(token), sidsTokenFilePerms); err != nil {
+		return errors.Wrap(err, "failed to write SI token")
+	}
+	return nil
+}
+
+// recoverToken returns the token saved to disk in the secrets directory for the
+// task if it exists, or the empty string if the file does not exist. an error
+// is returned only for some other (e.g. disk IO) error.
+func (h *sidsHook) recoverToken(dir string) (string, error) {
+	tokenPath := filepath.Join(dir, sidsTokenFile)
+	token, err := ioutil.ReadFile(tokenPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", errors.Wrap(err, "failed to recover SI token")
+		}
+		h.logger.Trace("no pre-existing SI token to recover", "task", h.taskName)
+		return "", nil // token file does not exist yet
+	}
+	h.logger.Trace("recovered pre-existing SI token", "task", h.taskName)
+	return string(token), nil
+}
+
+// deriveSIToken spawns and waits on a goroutine which will make attempts to
+// derive an SI token until a token is successfully created, or ctx is signaled
+// done.
+func (h *sidsHook) deriveSIToken(ctx context.Context) (string, error) {
+	tokenCh := make(chan string)
+
+	// keep trying to get the token in the background
+	go h.tryDerive(ctx, tokenCh)
+
+	// wait until we get a token, or we get a signal to quit
+	for {
+		select {
+		case token := <-tokenCh:
+			return token, nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+}
+
+// tryDerive loops forever until a token is created, or ctx is done.
+func (h *sidsHook) tryDerive(ctx context.Context, ch chan<- string) {
+	for i := 0; backoff(ctx, i); i++ {
+		tokens, err := h.sidsClient.DeriveSITokens(h.alloc, []string{h.taskName})
+		if err != nil {
+			h.logger.Warn("failed to derive SI token", "attempt", i, "error", err)
+			continue
+		}
+		ch <- tokens[h.taskName]
+		return
+	}
+}
+
+func backoff(ctx context.Context, i int) bool {
+	next := computeBackoff(i)
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(next):
+		return true
+	}
+}
+
+func computeBackoff(attempt int) time.Duration {
+	switch {
+	case attempt <= 0:
+		return 0
+	case attempt >= 4:
+		return sidsBackoffLimit
+	default:
+		return (1 << (2 * uint(attempt))) * sidsBackoffBaseline
+	}
+}

--- a/client/allocrunner/taskrunner/sids_hook_test.go
+++ b/client/allocrunner/taskrunner/sids_hook_test.go
@@ -1,0 +1,122 @@
+package taskrunner
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/consul"
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+var _ interfaces.TaskPrestartHook = (*sidsHook)(nil)
+
+func tmpDir(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "sids-")
+	require.NoError(t, err)
+	return dir
+}
+
+func cleanupDir(t *testing.T, dir string) {
+	err := os.RemoveAll(dir)
+	require.NoError(t, err)
+}
+
+func TestSIDSHook_recoverToken(t *testing.T) {
+	t.Parallel()
+
+	r := require.New(t)
+	secrets := tmpDir(t)
+	defer cleanupDir(t, secrets)
+
+	h := newSIDSHook(sidsHookConfig{
+		task:   &structs.Task{Name: "task1"},
+		logger: testlog.HCLogger(t),
+	})
+
+	expected := "12345678-1234-1234-1234-1234567890"
+	err := h.writeToken(secrets, expected)
+	r.NoError(err)
+
+	token, err := h.recoverToken(secrets)
+	r.NoError(err)
+	r.Equal(expected, token)
+}
+
+func TestSIDSHook_recoverToken_empty(t *testing.T) {
+	t.Parallel()
+
+	r := require.New(t)
+	secrets := tmpDir(t)
+	defer cleanupDir(t, secrets)
+
+	h := newSIDSHook(sidsHookConfig{
+		task:   &structs.Task{Name: "task1"},
+		logger: testlog.HCLogger(t),
+	})
+
+	token, err := h.recoverToken(secrets)
+	r.NoError(err)
+	r.Empty(token)
+}
+
+func TestSIDSHook_deriveSIToken(t *testing.T) {
+	t.Parallel()
+
+	r := require.New(t)
+	secrets := tmpDir(t)
+	defer cleanupDir(t, secrets)
+
+	h := newSIDSHook(sidsHookConfig{
+		alloc:      &structs.Allocation{ID: "a1"},
+		task:       &structs.Task{Name: "task1"},
+		logger:     testlog.HCLogger(t),
+		sidsClient: consul.NewMockServiceIdentitiesClient(),
+	})
+
+	ctx := context.Background()
+	token, err := h.deriveSIToken(ctx)
+	r.NoError(err)
+	r.True(helper.IsUUID(token))
+}
+
+func TestSIDSHook_computeBackoff(t *testing.T) {
+	t.Parallel()
+
+	try := func(i int, exp time.Duration) {
+		result := computeBackoff(i)
+		require.Equal(t, exp, result)
+	}
+
+	try(0, time.Duration(0))
+	try(1, 20*time.Second)
+	try(2, 80*time.Second)
+	try(3, 320*time.Second)
+	try(4, sidsBackoffLimit)
+}
+
+func TestSIDSHook_backoff(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	ctx := context.Background()
+	stop := !backoff(ctx, 0)
+	r.False(stop)
+}
+
+func TestSIDSHook_backoffKilled(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1)
+	defer cancel()
+
+	stop := !backoff(ctx, 1000)
+	r.True(stop)
+}

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -50,7 +50,7 @@ const (
 	// giving up and potentially leaking resources.
 	killFailureLimit = 5
 
-	// triggerUpdatechCap is the capacity for the triggerUpdateCh used for
+	// triggerUpdateChCap is the capacity for the triggerUpdateCh used for
 	// triggering updates. It should be exactly 1 as even if multiple
 	// updates have come in since the last one was handled, we only need to
 	// handle the last one.
@@ -158,6 +158,10 @@ type TaskRunner struct {
 	// registering services and checks
 	consulClient consul.ConsulServiceAPI
 
+	// sidsClient is the client used by the service identity hook for managing
+	// service identity tokens
+	siClient consul.ServiceIdentityAPI
+
 	// vaultClient is the client to use to derive and renew Vault tokens
 	vaultClient vaultclient.VaultClient
 
@@ -210,10 +214,15 @@ type TaskRunner struct {
 type Config struct {
 	Alloc        *structs.Allocation
 	ClientConfig *config.Config
-	Consul       consul.ConsulServiceAPI
 	Task         *structs.Task
 	TaskDir      *allocdir.TaskDir
 	Logger       log.Logger
+
+	// Consul is the client to use for managing Consul service registrations
+	Consul consul.ConsulServiceAPI
+
+	// ConsulSI is the client to use for managing Consul SI tokens
+	ConsulSI consul.ServiceIdentityAPI
 
 	// Vault is the client to use to derive and renew Vault tokens
 	Vault vaultclient.VaultClient
@@ -271,6 +280,7 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		taskLeader:          config.Task.Leader,
 		envBuilder:          envBuilder,
 		consulClient:        config.Consul,
+		siClient:            config.ConsulSI,
 		vaultClient:         config.Vault,
 		state:               tstate,
 		localState:          state.NewLocalState(),

--- a/client/allocrunner/testing.go
+++ b/client/allocrunner/testing.go
@@ -60,6 +60,7 @@ func testAllocRunnerConfig(t *testing.T, alloc *structs.Allocation) (*Config, fu
 		ClientConfig:       clientConf,
 		StateDB:            state.NoopDB{},
 		Consul:             consul.NewMockConsulServiceClient(t, clientConf.Logger),
+		ConsulSI:           consul.NewMockServiceIdentitiesClient(),
 		Vault:              vaultclient.NewMockVaultClient(),
 		StateUpdater:       &MockStateUpdater{},
 		PrevAllocWatcher:   allocwatcher.NoopPrevAlloc{},

--- a/client/consul/consul.go
+++ b/client/consul/consul.go
@@ -2,14 +2,37 @@ package consul
 
 import (
 	"github.com/hashicorp/nomad/command/agent/consul"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // ConsulServiceAPI is the interface the Nomad Client uses to register and
 // remove services and checks from Consul.
 type ConsulServiceAPI interface {
+	// RegisterWorkload with Consul. Adds all service entries and checks to Consul.
 	RegisterWorkload(*consul.WorkloadServices) error
+
+	// RemoveWorkload from Consul. Removes all service entries and checks.
 	RemoveWorkload(*consul.WorkloadServices)
+
+	// UpdateWorkload in Consul. Does not alter the service if only checks have
+	// changed.
 	UpdateWorkload(old, newTask *consul.WorkloadServices) error
+
+	// AllocRegistrations returns the registrations for the given allocation.
 	AllocRegistrations(allocID string) (*consul.AllocRegistration, error)
+
+	// UpdateTTL is used to update the TTL of a check.
 	UpdateTTL(id, output, status string) error
+}
+
+// TokenDeriverFunc takes an allocation and a set of tasks and derives a
+// service identity token for each. Requests go through nomad server.
+type TokenDeriverFunc func(*structs.Allocation, []string) (map[string]string, error)
+
+// ServiceIdentityAPI is the interface the Nomad Client uses to request Consul
+// Service Identity tokens through Nomad Server.
+type ServiceIdentityAPI interface {
+	// DeriveSITokens contacts the nomad server and requests consul service
+	// identity tokens be generated for tasks in the allocation.
+	DeriveSITokens(alloc *structs.Allocation, tasks []string) (map[string]string, error)
 }

--- a/client/consul/consul_testing.go
+++ b/client/consul/consul_testing.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	log "github.com/hashicorp/go-hclog"
-
 	"github.com/hashicorp/nomad/command/agent/consul"
 	testing "github.com/mitchellh/go-testing-interface"
 )

--- a/client/consul/identities.go
+++ b/client/consul/identities.go
@@ -1,0 +1,32 @@
+package consul
+
+import (
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// Implementation of ServiceIdentityAPI used to interact with Nomad Server from
+// Nomad Client for acquiring Consul Service Identity tokens.
+//
+// This client is split from the other consul client(s) to avoid a circular
+// dependency between themselves and client.Client
+type identitiesClient struct {
+	tokenDeriver TokenDeriverFunc
+	logger       hclog.Logger
+}
+
+func NewIdentitiesClient(logger hclog.Logger, tokenDeriver TokenDeriverFunc) *identitiesClient {
+	return &identitiesClient{
+		tokenDeriver: tokenDeriver,
+		logger:       logger,
+	}
+}
+
+func (c *identitiesClient) DeriveSITokens(alloc *structs.Allocation, tasks []string) (map[string]string, error) {
+	tokens, err := c.tokenDeriver(alloc, tasks)
+	if err != nil {
+		c.logger.Error("error deriving SI token", "error", err, "alloc_id", alloc.ID, "task_names", tasks)
+		return nil, err
+	}
+	return tokens, nil
+}

--- a/client/consul/identities_test.go
+++ b/client/consul/identities_test.go
@@ -1,0 +1,31 @@
+package consul
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCSI_DeriveTokens(t *testing.T) {
+	logger := testlog.HCLogger(t)
+	dFunc := func(alloc *structs.Allocation, taskNames []string) (map[string]string, error) {
+		return map[string]string{"a": "b"}, nil
+	}
+	tc := NewIdentitiesClient(logger, dFunc)
+	tokens, err := tc.DeriveSITokens(nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"a": "b"}, tokens)
+}
+
+func TestCSI_DeriveTokens_error(t *testing.T) {
+	logger := testlog.HCLogger(t)
+	dFunc := func(alloc *structs.Allocation, taskNames []string) (map[string]string, error) {
+		return nil, errors.New("some failure")
+	}
+	tc := NewIdentitiesClient(logger, dFunc)
+	_, err := tc.DeriveSITokens(&structs.Allocation{ID: "a1"}, nil)
+	require.Error(t, err)
+}

--- a/client/consul/identities_testing.go
+++ b/client/consul/identities_testing.go
@@ -1,0 +1,85 @@
+package consul
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// MockServiceIdentitiesClient is used for testing the client for managing consul service
+// identity tokens.
+type MockServiceIdentitiesClient struct {
+	// deriveTokenErrors maps an allocation ID and tasks to an error when the
+	// token is derived
+	deriveTokenErrors map[string]map[string]error
+
+	// DeriveTokenFn allows the caller to control the DeriveToken function. If
+	// not set an error is returned if found in DeriveTokenErrors and otherwise
+	// a token is generated and returned
+	DeriveTokenFn TokenDeriverFunc
+
+	// lock around everything
+	lock sync.Mutex
+}
+
+var _ ServiceIdentityAPI = (*MockServiceIdentitiesClient)(nil)
+
+// NewMockServiceIdentitiesClient returns a MockServiceIdentitiesClient for testing.
+func NewMockServiceIdentitiesClient() *MockServiceIdentitiesClient {
+	return &MockServiceIdentitiesClient{
+		deriveTokenErrors: make(map[string]map[string]error),
+	}
+}
+
+func (mtc *MockServiceIdentitiesClient) DeriveSITokens(alloc *structs.Allocation, tasks []string) (map[string]string, error) {
+	mtc.lock.Lock()
+	defer mtc.lock.Unlock()
+
+	fmt.Println("MockServiceIdentitiesClient.DeriveSITokens running!")
+
+	// if the DeriveTokenFn is explicitly set, use that
+	if mtc.DeriveTokenFn != nil {
+		return mtc.DeriveTokenFn(alloc, tasks)
+	}
+
+	// generate a token for each task, unless the mock has an error ready for
+	// one or more of the tasks in which case return that
+	tokens := make(map[string]string, len(tasks))
+	for _, task := range tasks {
+		if m, ok := mtc.deriveTokenErrors[alloc.ID]; ok {
+			if err, ok := m[task]; ok {
+				return nil, err
+			}
+		}
+		tokens[task] = uuid.Generate()
+	}
+	return tokens, nil
+}
+
+func (mtc *MockServiceIdentitiesClient) SetDeriveTokenError(allocID string, tasks []string, err error) {
+	mtc.lock.Lock()
+	defer mtc.lock.Unlock()
+
+	if _, ok := mtc.deriveTokenErrors[allocID]; !ok {
+		mtc.deriveTokenErrors[allocID] = make(map[string]error, 10)
+	}
+
+	for _, task := range tasks {
+		mtc.deriveTokenErrors[allocID][task] = err
+	}
+}
+
+func (mtc *MockServiceIdentitiesClient) DeriveTokenErrors() map[string]map[string]error {
+	mtc.lock.Lock()
+	defer mtc.lock.Unlock()
+
+	m := make(map[string]map[string]error)
+	for aID, tasks := range mtc.deriveTokenErrors {
+		for task, err := range tasks {
+			m[aID][task] = err
+		}
+	}
+	return m
+}

--- a/client/vaultclient/vaultclient_testing.go
+++ b/client/vaultclient/vaultclient_testing.go
@@ -67,6 +67,7 @@ func (vc *MockVaultClient) SetDeriveTokenError(allocID string, tasks []string, e
 		vc.deriveTokenErrors = make(map[string]map[string]error, 10)
 	}
 
+	// todo(shoenig): this seems like a bug
 	if _, ok := vc.renewTokenErrors[allocID]; !ok {
 		vc.deriveTokenErrors[allocID] = make(map[string]error, 10)
 	}
@@ -111,8 +112,10 @@ func (vc *MockVaultClient) StopRenewToken(token string) error {
 	return nil
 }
 
-func (vc *MockVaultClient) Start()                                                {}
-func (vc *MockVaultClient) Stop()                                                 {}
+func (vc *MockVaultClient) Start() {}
+
+func (vc *MockVaultClient) Stop() {}
+
 func (vc *MockVaultClient) GetConsulACL(string, string) (*vaultapi.Secret, error) { return nil, nil }
 
 // StoppedTokens tracks the tokens that have stopped renewing

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -879,7 +879,28 @@ type DeriveVaultTokenResponse struct {
 	Tasks map[string]string
 
 	// Error stores any error that occurred. Errors are stored here so we can
-	// communicate whether it is retriable
+	// communicate whether it is retryable
+	Error *RecoverableError
+
+	QueryMeta
+}
+
+// DeriveSITokenRequest is used to request Consul Service Identity tokens from
+// the Nomad Server for the named tasks in the given allocation.
+type DeriveSITokenRequest struct {
+	NodeID   string
+	SecretID string
+	AllocID  string
+	Tasks    []string
+	QueryOptions
+}
+
+type DeriveSITokenResponse struct {
+	// Tokens maps from Task Name to its associated SI token
+	Tokens map[string]string
+
+	// Error stores any error that occurred. Errors are stored here so we can
+	// communicate whether it is retryable
 	Error *RecoverableError
 
 	QueryMeta


### PR DESCRIPTION
When a job is configured with Consul Connect aware tasks (i.e. sidecar),
the Nomad Client should be able to request from Consul (through Nomad Server)
Service Identity tokens specific to those tasks.

This doesn't set the token yet for `envoy` which is covered in another issue. 

For now this just assumes Consul ACLs are enabled - we'll need to figure out a way for Nomad Client, Server, and Consul to communicate whether ACLs are actually enabled, and whether the Client should bother making the SI RPC request (or maybe always do the request, but accept `not enabled` as a reply, e.g.)

The details of the RPC may get tweaked, as the `Server` half gets fleshed out 