### PR TITLE
Update consensus.html.md

### DIFF
--- a/website/source/docs/internals/consensus.html.md
+++ b/website/source/docs/internals/consensus.html.md
@@ -14,7 +14,7 @@ description: |-
 Nomad uses a [consensus protocol](https://en.wikipedia.org/wiki/Consensus_(computer_science))
 to provide [Consistency (as defined by CAP)](https://en.wikipedia.org/wiki/CAP_theorem).
 The consensus protocol is based on
-["Raft: In search of an Understandable Consensus Algorithm"](https://ramcloud.stanford.edu/wiki/download/attachments/11370504/raft.pdf).
+["Raft: In search of an Understandable Consensus Algorithm"](https://raft.github.io/raft.pdf).
 For a visual explanation of Raft, see [The Secret Lives of Data](http://thesecretlivesofdata.com/raft).
 
 ~> **Advanced Topic!** This page covers technical details of
@@ -59,7 +59,7 @@ and managing when an entry is considered committed.
 
 Raft is a complex protocol and will not be covered here in detail (for those who
 desire a more comprehensive treatment, the full specification is available in this
-[paper](https://ramcloud.stanford.edu/wiki/download/attachments/11370504/raft.pdf)).
+[paper](https://raft.github.io/raft.pdf)).
 We will, however, attempt to provide a high level description which may be useful
 for building a mental model.
 


### PR DESCRIPTION
The url for raft algorithm pdf is no longer valid. Here is correct url - https://raft.github.io/raft.pdf  and website is https://raft.github.io/