### PR TITLE
command: error when no node is found for `monitor`

### DIFF
--- a/command/agent_monitor.go
+++ b/command/agent_monitor.go
@@ -106,6 +106,11 @@ func (c *MonitorCommand) Run(args []string) int {
 			return 1
 		}
 
+		if len(nodes) == 0 {
+			c.Ui.Error(fmt.Sprintf("No node(s) with prefix or id %q found", nodeID))
+			return 1
+		}
+
 		if len(nodes) > 1 {
 			out := formatNodeStubList(nodes, false)
 			c.Ui.Output(fmt.Sprintf("Prefix matched multiple nodes\n\n%s", out))

--- a/command/agent_monitor_test.go
+++ b/command/agent_monitor_test.go
@@ -14,7 +14,7 @@ func TestMonitorCommand_Implements(t *testing.T) {
 
 func TestMonitorCommand_Fails(t *testing.T) {
 	t.Parallel()
-	srv, _, _ := testServer(t, false, nil)
+	srv, _, url := testServer(t, false, nil)
 	defer srv.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -33,4 +33,13 @@ func TestMonitorCommand_Fails(t *testing.T) {
 	if code := cmd.Run([]string{"-address=nope"}); code != 1 {
 		t.Fatalf("exepected exit code 1, got: %d", code)
 	}
+
+	// Fails on nonexistent node
+	if code := cmd.Run([]string{"-address=" + url, "-node-id=12345678-abcd-efab-cdef-123456789abc"}); code != 1 {
+		t.Fatalf("expected exit 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No node(s) with prefix") {
+		t.Fatalf("expected not found error, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
 }


### PR DESCRIPTION
Currently `nomad monitor -node-id` will panic when a node-id does not
match any nodes, as there is no empty result bounds checking. Here we
return an error to the user when no nodes are found.

fixes #6827 