### PR TITLE
doc: explain ALLOC_INDEX uniqueness guarantees

### DIFF
--- a/website/source/docs/runtime/_envvars.html.md.erb
+++ b/website/source/docs/runtime/_envvars.html.md.erb
@@ -45,7 +45,7 @@
   </tr>
   <tr>
     <td><tt>NOMAD&lowbar;ALLOC&lowbar;INDEX</tt></td>
-    <td>Allocation index; useful to distinguish instances of task groups. From 0 to (count - 1).</td>
+    <td>Allocation index; useful to distinguish instances of task groups. From 0 to (count - 1). The index is unique within a given version of a job, but failed tasks in a deployment may reuse the index.</td>
   </tr>
   <tr>
     <td><tt>NOMAD&lowbar;TASK&lowbar;NAME</tt></td>

--- a/website/source/docs/runtime/_envvars.html.md.erb
+++ b/website/source/docs/runtime/_envvars.html.md.erb
@@ -45,7 +45,7 @@
   </tr>
   <tr>
     <td><tt>NOMAD&lowbar;ALLOC&lowbar;INDEX</tt></td>
-    <td>Allocation index; useful to distinguish instances of task groups. From 0 to (count - 1). The index is unique within a given version of a job, but failed tasks in a deployment may reuse the index.</td>
+    <td>Allocation index; useful to distinguish instances of task groups. From 0 to (count - 1). The index is unique within a given version of a job, but canaries or failed tasks in a deployment may reuse the index.</td>
   </tr>
   <tr>
     <td><tt>NOMAD&lowbar;TASK&lowbar;NAME</tt></td>


### PR DESCRIPTION
Fixes #5879 (but related to #6829 too)

The `ALLOC_INDEX` isn't guaranteed to be unique, and this has caused some user confusion. The servers make a best-effort attempt to make this value unique from 0 to count-1 but when you have canaries on the task group, there are reused indexes because you have multiple job versions running at the same time. If a user needs a unique number for interpolating a value in your application, they can get this by combining the job version and the alloc index.