### PR TITLE
doc: spread is inherited from job to group

### DIFF
--- a/website/source/docs/job-specification/spread.html.md
+++ b/website/source/docs/job-specification/spread.html.md
@@ -4,7 +4,7 @@ page_title: "spread Stanza - Job Specification"
 sidebar_current: "docs-job-specification-spread"
 description: |-
   The "spread" stanza is used to spread placements across a certain node attributes such as datacenter.
-  Spread may be specified at the job, group, or task levels for ultimate flexibility.
+  Spread may be specified at the job or group levels for ultimate flexibility.
   More than one spread stanza may be specified with relative weights between each.
 ---
 
@@ -60,7 +60,7 @@ Spread criteria are treated as a soft preference by the Nomad scheduler.
 If no nodes match a given spread criteria, placement is still successful.
 
 Spread may be expressed on [attributes][interpolation] or [client metadata][client-meta].
-Additionally, spread may be specified at the [job][job] and [group][group] levels for ultimate flexibility.
+Additionally, spread may be specified at the [job][job] and [group][group] levels for ultimate flexibility. Job level spread criteria are inherited by all task groups in the job.
 
 
 ## `spread` Parameters


### PR DESCRIPTION
Fixes #6835 

The spread stanza spreads allocations across nodes, but the spread happens at the task group level. The [docs for spread](https://www.nomadproject.io/docs/job-specification/spread.html) and the [guide for spread](https://www.nomadproject.io/guides/operating-a-job/advanced-scheduling/spread.html) are missing this important detail. It's present in the spread feature's announcement [blog post](https://www.hashicorp.com/blog/spreads-and-affinites-in-nomad/), but that's not the docs.