### PR TITLE
tests: parallelize state store tests

### DIFF
--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -24,6 +24,7 @@ func testStateStore(t *testing.T) *StateStore {
 
 func TestStateStore_Blocking_Error(t *testing.T) {
 	t.Parallel()
+
 	expected := fmt.Errorf("test error")
 	errFn := func(memdb.WatchSet, *StateStore) (interface{}, uint64, error) {
 		return nil, 0, expected
@@ -37,6 +38,7 @@ func TestStateStore_Blocking_Error(t *testing.T) {
 
 func TestStateStore_Blocking_Timeout(t *testing.T) {
 	t.Parallel()
+
 	noopFn := func(memdb.WatchSet, *StateStore) (interface{}, uint64, error) {
 		return nil, 5, nil
 	}
@@ -53,6 +55,8 @@ func TestStateStore_Blocking_Timeout(t *testing.T) {
 }
 
 func TestStateStore_Blocking_MinQuery(t *testing.T) {
+	t.Parallel()
+
 	node := mock.Node()
 	count := 0
 	queryFn := func(ws memdb.WatchSet, s *StateStore) (interface{}, uint64, error) {
@@ -93,6 +97,8 @@ func TestStateStore_Blocking_MinQuery(t *testing.T) {
 // 1) The job is denormalized
 // 2) Allocations are created
 func TestStateStore_UpsertPlanResults_AllocationsCreated_Denormalized(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	job := alloc.Job
@@ -146,6 +152,8 @@ func TestStateStore_UpsertPlanResults_AllocationsCreated_Denormalized(t *testing
 // 2) Allocations are denormalized and updated with the diff
 // That stopped allocs Job is unmodified
 func TestStateStore_UpsertPlanResults_AllocationsDenormalized(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	job := alloc.Job
@@ -239,6 +247,8 @@ func TestStateStore_UpsertPlanResults_AllocationsDenormalized(t *testing.T) {
 // This test checks that the deployment is created and allocations count towards
 // the deployment
 func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	alloc2 := mock.Alloc()
@@ -344,6 +354,7 @@ func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
 // 1) Preempted allocations in plan results are updated
 // 2) Evals are inserted for preempted jobs
 func TestStateStore_UpsertPlanResults_PreemptedAllocs(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	state := testStateStore(t)
@@ -424,6 +435,7 @@ func TestStateStore_UpsertPlanResults_PreemptedAllocs(t *testing.T) {
 
 // This test checks that deployment updates are applied correctly
 func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
+	t.Parallel()
 	state := testStateStore(t)
 
 	// Create a job that applies to all
@@ -506,6 +518,8 @@ func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 }
 
 func TestStateStore_UpsertDeployment(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	deployment := mock.Deployment()
 
@@ -549,6 +563,8 @@ func TestStateStore_UpsertDeployment(t *testing.T) {
 
 // Tests that deployments of older create index and same job id are not returned
 func TestStateStore_OldDeployment(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 	job.ID = "job1"
@@ -585,6 +601,8 @@ func TestStateStore_OldDeployment(t *testing.T) {
 }
 
 func TestStateStore_DeleteDeployment(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	d1 := mock.Deployment()
 	d2 := mock.Deployment()
@@ -636,6 +654,8 @@ func TestStateStore_DeleteDeployment(t *testing.T) {
 }
 
 func TestStateStore_Deployments(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var deployments []*structs.Deployment
 
@@ -680,6 +700,8 @@ func TestStateStore_Deployments(t *testing.T) {
 }
 
 func TestStateStore_DeploymentsByIDPrefix(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	deploy := mock.Deployment()
 
@@ -766,6 +788,8 @@ func TestStateStore_DeploymentsByIDPrefix(t *testing.T) {
 }
 
 func TestStateStore_UpsertNode_Node(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	state := testStateStore(t)
 	node := mock.Node()
@@ -808,6 +832,8 @@ func TestStateStore_UpsertNode_Node(t *testing.T) {
 }
 
 func TestStateStore_DeleteNode_Node(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Create and insert two nodes, which we'll delete
@@ -851,7 +877,9 @@ func TestStateStore_DeleteNode_Node(t *testing.T) {
 }
 
 func TestStateStore_UpdateNodeStatus_Node(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 	node := mock.Node()
 
@@ -887,7 +915,9 @@ func TestStateStore_UpdateNodeStatus_Node(t *testing.T) {
 }
 
 func TestStateStore_BatchUpdateNodeDrain(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 
 	n1, n2 := mock.Node(), mock.Node()
@@ -946,7 +976,9 @@ func TestStateStore_BatchUpdateNodeDrain(t *testing.T) {
 }
 
 func TestStateStore_UpdateNodeDrain_Node(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 	node := mock.Node()
 
@@ -988,7 +1020,9 @@ func TestStateStore_UpdateNodeDrain_Node(t *testing.T) {
 }
 
 func TestStateStore_AddSingleNodeEvent(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 
 	node := mock.Node()
@@ -1030,7 +1064,9 @@ func TestStateStore_AddSingleNodeEvent(t *testing.T) {
 // To prevent stale node events from accumulating, we limit the number of
 // stored node events to 10.
 func TestStateStore_NodeEvents_RetentionWindow(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 
 	node := mock.Node()
@@ -1077,7 +1113,9 @@ func TestStateStore_NodeEvents_RetentionWindow(t *testing.T) {
 }
 
 func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 	node := mock.Node()
 	require.Nil(state.UpsertNode(1000, node))
@@ -1126,7 +1164,9 @@ func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
 }
 
 func TestStateStore_UpdateNodeEligibility(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 	node := mock.Node()
 
@@ -1180,6 +1220,8 @@ func TestStateStore_UpdateNodeEligibility(t *testing.T) {
 }
 
 func TestStateStore_Nodes(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var nodes []*structs.Node
 
@@ -1222,6 +1264,8 @@ func TestStateStore_Nodes(t *testing.T) {
 }
 
 func TestStateStore_NodesByIDPrefix(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	node := mock.Node()
 
@@ -1308,6 +1352,8 @@ func TestStateStore_NodesByIDPrefix(t *testing.T) {
 }
 
 func TestStateStore_RestoreNode(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	node := mock.Node()
 
@@ -1334,6 +1380,8 @@ func TestStateStore_RestoreNode(t *testing.T) {
 }
 
 func TestStateStore_UpsertJob_Job(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 
@@ -1412,6 +1460,8 @@ func TestStateStore_UpsertJob_Job(t *testing.T) {
 }
 
 func TestStateStore_UpdateUpsertJob_Job(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 
@@ -1515,6 +1565,8 @@ func TestStateStore_UpdateUpsertJob_Job(t *testing.T) {
 }
 
 func TestStateStore_UpdateUpsertJob_PeriodicJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.PeriodicJob()
 
@@ -1569,6 +1621,8 @@ func TestStateStore_UpdateUpsertJob_PeriodicJob(t *testing.T) {
 }
 
 func TestStateStore_UpsertJob_BadNamespace(t *testing.T) {
+	t.Parallel()
+
 	assert := assert.New(t)
 	state := testStateStore(t)
 	job := mock.Job()
@@ -1586,6 +1640,8 @@ func TestStateStore_UpsertJob_BadNamespace(t *testing.T) {
 // Upsert a job that is the child of a parent job and ensures its summary gets
 // updated.
 func TestStateStore_UpsertJob_ChildJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Create a watchset so we can test that upsert fires the watch
@@ -1628,6 +1684,8 @@ func TestStateStore_UpsertJob_ChildJob(t *testing.T) {
 }
 
 func TestStateStore_UpdateUpsertJob_JobVersion(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Create a job and mark it as stable
@@ -1717,6 +1775,8 @@ func TestStateStore_UpdateUpsertJob_JobVersion(t *testing.T) {
 }
 
 func TestStateStore_DeleteJob_Job(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 
@@ -1796,6 +1856,8 @@ func TestStateStore_DeleteJob_Job(t *testing.T) {
 }
 
 func TestStateStore_DeleteJobTxn_BatchDeletes(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	const testJobCount = 10
@@ -1865,6 +1927,8 @@ func TestStateStore_DeleteJobTxn_BatchDeletes(t *testing.T) {
 }
 
 func TestStateStore_DeleteJob_MultipleVersions(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	assert := assert.New(t)
 
@@ -1920,6 +1984,8 @@ func TestStateStore_DeleteJob_MultipleVersions(t *testing.T) {
 }
 
 func TestStateStore_DeleteJob_ChildJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	parent := mock.Job()
@@ -1971,6 +2037,8 @@ func TestStateStore_DeleteJob_ChildJob(t *testing.T) {
 }
 
 func TestStateStore_Jobs(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var jobs []*structs.Job
 
@@ -2011,6 +2079,8 @@ func TestStateStore_Jobs(t *testing.T) {
 }
 
 func TestStateStore_JobVersions(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var jobs []*structs.Job
 
@@ -2051,6 +2121,8 @@ func TestStateStore_JobVersions(t *testing.T) {
 }
 
 func TestStateStore_JobsByIDPrefix(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 
@@ -2133,6 +2205,8 @@ func TestStateStore_JobsByIDPrefix(t *testing.T) {
 }
 
 func TestStateStore_JobsByPeriodic(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var periodic, nonPeriodic []*structs.Job
 
@@ -2203,6 +2277,8 @@ func TestStateStore_JobsByPeriodic(t *testing.T) {
 }
 
 func TestStateStore_JobsByScheduler(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var serviceJobs []*structs.Job
 	var sysJobs []*structs.Job
@@ -2275,6 +2351,8 @@ func TestStateStore_JobsByScheduler(t *testing.T) {
 }
 
 func TestStateStore_JobsByGC(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	gc, nonGc := make(map[string]struct{}), make(map[string]struct{})
 
@@ -2347,6 +2425,8 @@ func TestStateStore_JobsByGC(t *testing.T) {
 }
 
 func TestStateStore_RestoreJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 
@@ -2373,6 +2453,8 @@ func TestStateStore_RestoreJob(t *testing.T) {
 }
 
 func TestStateStore_UpsertPeriodicLaunch(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 	launch := &structs.PeriodicLaunch{
@@ -2426,6 +2508,8 @@ func TestStateStore_UpsertPeriodicLaunch(t *testing.T) {
 }
 
 func TestStateStore_UpdateUpsertPeriodicLaunch(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 	launch := &structs.PeriodicLaunch{
@@ -2489,6 +2573,8 @@ func TestStateStore_UpdateUpsertPeriodicLaunch(t *testing.T) {
 }
 
 func TestStateStore_DeletePeriodicLaunch(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 	launch := &structs.PeriodicLaunch{
@@ -2541,6 +2627,8 @@ func TestStateStore_DeletePeriodicLaunch(t *testing.T) {
 }
 
 func TestStateStore_PeriodicLaunches(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var launches []*structs.PeriodicLaunch
 
@@ -2602,6 +2690,8 @@ func TestStateStore_PeriodicLaunches(t *testing.T) {
 }
 
 func TestStateStore_RestorePeriodicLaunch(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 	launch := &structs.PeriodicLaunch{
@@ -2637,6 +2727,8 @@ func TestStateStore_RestorePeriodicLaunch(t *testing.T) {
 }
 
 func TestStateStore_RestoreJobVersion(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 
@@ -2667,6 +2759,8 @@ func TestStateStore_RestoreJobVersion(t *testing.T) {
 }
 
 func TestStateStore_RestoreDeployment(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	d := mock.Deployment()
 
@@ -2697,6 +2791,8 @@ func TestStateStore_RestoreDeployment(t *testing.T) {
 }
 
 func TestStateStore_RestoreJobSummary(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 	jobSummary := &structs.JobSummary{
@@ -2731,6 +2827,8 @@ func TestStateStore_RestoreJobSummary(t *testing.T) {
 }
 
 func TestStateStore_Indexes(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	node := mock.Node()
 
@@ -2774,6 +2872,8 @@ func TestStateStore_Indexes(t *testing.T) {
 }
 
 func TestStateStore_LatestIndex(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	if err := state.UpsertNode(1000, mock.Node()); err != nil {
@@ -2796,6 +2896,8 @@ func TestStateStore_LatestIndex(t *testing.T) {
 }
 
 func TestStateStore_RestoreIndex(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	restore, err := state.Restore()
@@ -2822,6 +2924,8 @@ func TestStateStore_RestoreIndex(t *testing.T) {
 }
 
 func TestStateStore_UpsertEvals_Eval(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	eval := mock.Eval()
 
@@ -2864,6 +2968,8 @@ func TestStateStore_UpsertEvals_Eval(t *testing.T) {
 }
 
 func TestStateStore_UpsertEvals_CancelBlocked(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Create two blocked evals for the same job
@@ -2941,6 +3047,8 @@ func TestStateStore_UpsertEvals_CancelBlocked(t *testing.T) {
 }
 
 func TestStateStore_Update_UpsertEvals_Eval(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	eval := mock.Eval()
 
@@ -3006,6 +3114,8 @@ func TestStateStore_Update_UpsertEvals_Eval(t *testing.T) {
 }
 
 func TestStateStore_UpsertEvals_Eval_ChildJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	parent := mock.Job()
@@ -3094,6 +3204,8 @@ func TestStateStore_UpsertEvals_Eval_ChildJob(t *testing.T) {
 }
 
 func TestStateStore_DeleteEval_Eval(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	eval1 := mock.Eval()
 	eval2 := mock.Eval()
@@ -3226,6 +3338,8 @@ func TestStateStore_DeleteEval_Eval(t *testing.T) {
 }
 
 func TestStateStore_DeleteEval_ChildJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	parent := mock.Job()
@@ -3294,6 +3408,8 @@ func TestStateStore_DeleteEval_ChildJob(t *testing.T) {
 }
 
 func TestStateStore_EvalsByJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	eval1 := mock.Eval()
@@ -3330,6 +3446,8 @@ func TestStateStore_EvalsByJob(t *testing.T) {
 }
 
 func TestStateStore_Evals(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var evals []*structs.Evaluation
 
@@ -3371,6 +3489,8 @@ func TestStateStore_Evals(t *testing.T) {
 }
 
 func TestStateStore_EvalsByIDPrefix(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var evals []*structs.Evaluation
 
@@ -3443,6 +3563,8 @@ func TestStateStore_EvalsByIDPrefix(t *testing.T) {
 }
 
 func TestStateStore_RestoreEval(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	eval := mock.Eval()
 
@@ -3469,6 +3591,8 @@ func TestStateStore_RestoreEval(t *testing.T) {
 }
 
 func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	parent := mock.Job()
 	if err := state.UpsertJob(998, parent); err != nil {
@@ -3556,6 +3680,8 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 }
 
 func TestStateStore_UpdateAllocsFromClient_ChildJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc1 := mock.Alloc()
 	alloc2 := mock.Alloc()
@@ -3690,6 +3816,8 @@ func TestStateStore_UpdateAllocsFromClient_ChildJob(t *testing.T) {
 }
 
 func TestStateStore_UpdateMultipleAllocsFromClient(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
@@ -3759,7 +3887,9 @@ func TestStateStore_UpdateMultipleAllocsFromClient(t *testing.T) {
 }
 
 func TestStateStore_UpdateAllocsFromClient_Deployment(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 
 	alloc := mock.Alloc()
@@ -3801,9 +3931,10 @@ func TestStateStore_UpdateAllocsFromClient_Deployment(t *testing.T) {
 
 // This tests that the deployment state is merged correctly
 func TestStateStore_UpdateAllocsFromClient_DeploymentStateMerges(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
-	state := testStateStore(t)
 
+	state := testStateStore(t)
 	alloc := mock.Alloc()
 	now := time.Now()
 	alloc.CreateTime = now.UnixNano()
@@ -3841,6 +3972,8 @@ func TestStateStore_UpdateAllocsFromClient_DeploymentStateMerges(t *testing.T) {
 }
 
 func TestStateStore_UpsertAlloc_Alloc(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
@@ -3914,7 +4047,9 @@ func TestStateStore_UpsertAlloc_Alloc(t *testing.T) {
 }
 
 func TestStateStore_UpsertAlloc_Deployment(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	now := time.Now()
@@ -3966,6 +4101,8 @@ func TestStateStore_UpsertAlloc_Deployment(t *testing.T) {
 // Testing to ensure we keep issue
 // https://github.com/hashicorp/nomad/issues/2583 fixed
 func TestStateStore_UpsertAlloc_No_Job(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	alloc.Job = nil
@@ -3977,6 +4114,8 @@ func TestStateStore_UpsertAlloc_No_Job(t *testing.T) {
 }
 
 func TestStateStore_UpsertAlloc_ChildJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	parent := mock.Job()
@@ -4034,6 +4173,8 @@ func TestStateStore_UpsertAlloc_ChildJob(t *testing.T) {
 }
 
 func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
@@ -4133,6 +4274,8 @@ func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 // This test ensures that the state store will mark the clients status as lost
 // when set rather than preferring the existing status.
 func TestStateStore_UpdateAlloc_Lost(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	alloc.ClientStatus = "foo"
@@ -4168,6 +4311,8 @@ func TestStateStore_UpdateAlloc_Lost(t *testing.T) {
 // associated with it. This will happen when a job is stopped by an user which
 // has non-terminal allocations on clients
 func TestStateStore_UpdateAlloc_NoJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
@@ -4278,6 +4423,8 @@ func TestStateStore_UpdateAllocDesiredTransition(t *testing.T) {
 }
 
 func TestStateStore_JobSummary(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Add a job
@@ -4400,6 +4547,8 @@ func TestStateStore_JobSummary(t *testing.T) {
 }
 
 func TestStateStore_ReconcileJobSummary(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Create an alloc
@@ -4491,6 +4640,7 @@ func TestStateStore_ReconcileJobSummary(t *testing.T) {
 func TestStateStore_ReconcileParentJobSummary(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
+
 	state := testStateStore(t)
 
 	// Add a node
@@ -4578,6 +4728,8 @@ func TestStateStore_ReconcileParentJobSummary(t *testing.T) {
 }
 
 func TestStateStore_UpdateAlloc_JobNotPresent(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	alloc := mock.Alloc()
@@ -4627,6 +4779,8 @@ func TestStateStore_UpdateAlloc_JobNotPresent(t *testing.T) {
 }
 
 func TestStateStore_EvictAlloc_Alloc(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
@@ -4664,6 +4818,8 @@ func TestStateStore_EvictAlloc_Alloc(t *testing.T) {
 }
 
 func TestStateStore_AllocsByNode(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var allocs []*structs.Allocation
 
@@ -4701,6 +4857,8 @@ func TestStateStore_AllocsByNode(t *testing.T) {
 }
 
 func TestStateStore_AllocsByNodeTerminal(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var allocs, term, nonterm []*structs.Allocation
 
@@ -4758,6 +4916,8 @@ func TestStateStore_AllocsByNodeTerminal(t *testing.T) {
 }
 
 func TestStateStore_AllocsByJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var allocs []*structs.Allocation
 
@@ -4795,6 +4955,8 @@ func TestStateStore_AllocsByJob(t *testing.T) {
 }
 
 func TestStateStore_AllocsForRegisteredJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var allocs []*structs.Allocation
 	var allocs1 []*structs.Allocation
@@ -4858,6 +5020,8 @@ func TestStateStore_AllocsForRegisteredJob(t *testing.T) {
 }
 
 func TestStateStore_AllocsByIDPrefix(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var allocs []*structs.Allocation
 
@@ -4934,6 +5098,8 @@ func TestStateStore_AllocsByIDPrefix(t *testing.T) {
 }
 
 func TestStateStore_Allocs(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var allocs []*structs.Allocation
 
@@ -4978,6 +5144,8 @@ func TestStateStore_Allocs(t *testing.T) {
 }
 
 func TestStateStore_Allocs_PrevAlloc(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	var allocs []*structs.Allocation
 
@@ -5030,6 +5198,8 @@ func TestStateStore_Allocs_PrevAlloc(t *testing.T) {
 }
 
 func TestStateStore_RestoreAlloc(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
@@ -5061,6 +5231,8 @@ func TestStateStore_RestoreAlloc(t *testing.T) {
 }
 
 func TestStateStore_SetJobStatus_ForceStatus(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	txn := state.db.Txn(true)
 
@@ -5094,6 +5266,8 @@ func TestStateStore_SetJobStatus_ForceStatus(t *testing.T) {
 }
 
 func TestStateStore_SetJobStatus_NoOp(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	txn := state.db.Txn(true)
 
@@ -5122,6 +5296,8 @@ func TestStateStore_SetJobStatus_NoOp(t *testing.T) {
 }
 
 func TestStateStore_SetJobStatus(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	txn := state.db.Txn(true)
 
@@ -5155,6 +5331,8 @@ func TestStateStore_SetJobStatus(t *testing.T) {
 }
 
 func TestStateStore_GetJobStatus_NoEvalsOrAllocs(t *testing.T) {
+	t.Parallel()
+
 	job := mock.Job()
 	state := testStateStore(t)
 	txn := state.db.Txn(false)
@@ -5169,6 +5347,8 @@ func TestStateStore_GetJobStatus_NoEvalsOrAllocs(t *testing.T) {
 }
 
 func TestStateStore_GetJobStatus_NoEvalsOrAllocs_Periodic(t *testing.T) {
+	t.Parallel()
+
 	job := mock.PeriodicJob()
 	state := testStateStore(t)
 	txn := state.db.Txn(false)
@@ -5183,6 +5363,8 @@ func TestStateStore_GetJobStatus_NoEvalsOrAllocs_Periodic(t *testing.T) {
 }
 
 func TestStateStore_GetJobStatus_NoEvalsOrAllocs_EvalDelete(t *testing.T) {
+	t.Parallel()
+
 	job := mock.Job()
 	state := testStateStore(t)
 	txn := state.db.Txn(false)
@@ -5197,6 +5379,8 @@ func TestStateStore_GetJobStatus_NoEvalsOrAllocs_EvalDelete(t *testing.T) {
 }
 
 func TestStateStore_GetJobStatus_DeadEvalsAndAllocs(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 
@@ -5229,6 +5413,8 @@ func TestStateStore_GetJobStatus_DeadEvalsAndAllocs(t *testing.T) {
 }
 
 func TestStateStore_GetJobStatus_RunningAlloc(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 
@@ -5253,6 +5439,8 @@ func TestStateStore_GetJobStatus_RunningAlloc(t *testing.T) {
 }
 
 func TestStateStore_GetJobStatus_PeriodicJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.PeriodicJob()
 
@@ -5279,6 +5467,8 @@ func TestStateStore_GetJobStatus_PeriodicJob(t *testing.T) {
 }
 
 func TestStateStore_GetJobStatus_ParameterizedJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 	job.ParameterizedJob = &structs.ParameterizedJobConfig{}
@@ -5306,6 +5496,8 @@ func TestStateStore_GetJobStatus_ParameterizedJob(t *testing.T) {
 }
 
 func TestStateStore_SetJobStatus_PendingEval(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.Job()
 
@@ -5331,6 +5523,8 @@ func TestStateStore_SetJobStatus_PendingEval(t *testing.T) {
 // TestStateStore_SetJobStatus_SystemJob asserts that system jobs are still
 // considered running until explicitly stopped.
 func TestStateStore_SetJobStatus_SystemJob(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	job := mock.SystemJob()
 
@@ -5366,6 +5560,8 @@ func TestStateStore_SetJobStatus_SystemJob(t *testing.T) {
 }
 
 func TestStateJobSummary_UpdateJobCount(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	job := alloc.Job
@@ -5495,6 +5691,8 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 }
 
 func TestJobSummary_UpdateClientStatus(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	job := alloc.Job
@@ -5569,6 +5767,8 @@ func TestJobSummary_UpdateClientStatus(t *testing.T) {
 
 // Test that nonexistent deployment can't be updated
 func TestStateStore_UpsertDeploymentStatusUpdate_Nonexistent(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Update the nonexistent deployment
@@ -5586,6 +5786,8 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Nonexistent(t *testing.T) {
 
 // Test that terminal deployment can't be updated
 func TestStateStore_UpsertDeploymentStatusUpdate_Terminal(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Insert a terminal deployment
@@ -5612,6 +5814,8 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Terminal(t *testing.T) {
 // Test that a non terminal deployment is updated and that a job and eval are
 // created.
 func TestStateStore_UpsertDeploymentStatusUpdate_NonTerminal(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Insert a deployment
@@ -5672,6 +5876,8 @@ func TestStateStore_UpsertDeploymentStatusUpdate_NonTerminal(t *testing.T) {
 // Test that when a deployment is updated to successful the job is updated to
 // stable
 func TestStateStore_UpsertDeploymentStatusUpdate_Successful(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Insert a job
@@ -5727,6 +5933,8 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Successful(t *testing.T) {
 }
 
 func TestStateStore_UpdateJobStability(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Insert a job twice to get two versions
@@ -5779,6 +5987,8 @@ func TestStateStore_UpdateJobStability(t *testing.T) {
 
 // Test that nonexistent deployment can't be promoted
 func TestStateStore_UpsertDeploymentPromotion_Nonexistent(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Promote the nonexistent deployment
@@ -5796,6 +6006,8 @@ func TestStateStore_UpsertDeploymentPromotion_Nonexistent(t *testing.T) {
 
 // Test that terminal deployment can't be updated
 func TestStateStore_UpsertDeploymentPromotion_Terminal(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Insert a terminal deployment
@@ -5821,6 +6033,8 @@ func TestStateStore_UpsertDeploymentPromotion_Terminal(t *testing.T) {
 
 // Test promoting unhealthy canaries in a deployment.
 func TestStateStore_UpsertDeploymentPromotion_Unhealthy(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	require := require.New(t)
 
@@ -5868,6 +6082,8 @@ func TestStateStore_UpsertDeploymentPromotion_Unhealthy(t *testing.T) {
 
 // Test promoting a deployment with no canaries
 func TestStateStore_UpsertDeploymentPromotion_NoCanaries(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	require := require.New(t)
 
@@ -5895,6 +6111,8 @@ func TestStateStore_UpsertDeploymentPromotion_NoCanaries(t *testing.T) {
 
 // Test promoting all canaries in a deployment.
 func TestStateStore_UpsertDeploymentPromotion_All(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Create a job with two task groups
@@ -5992,8 +6210,10 @@ func TestStateStore_UpsertDeploymentPromotion_All(t *testing.T) {
 
 // Test promoting a subset of canaries in a deployment.
 func TestStateStore_UpsertDeploymentPromotion_Subset(t *testing.T) {
-	state := testStateStore(t)
+	t.Parallel()
 	require := require.New(t)
+
+	state := testStateStore(t)
 
 	// Create a job with two task groups
 	j := mock.Job()
@@ -6093,6 +6313,8 @@ func TestStateStore_UpsertDeploymentPromotion_Subset(t *testing.T) {
 
 // Test that allocation health can't be set against a nonexistent deployment
 func TestStateStore_UpsertDeploymentAllocHealth_Nonexistent(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Set health against the nonexistent deployment
@@ -6110,6 +6332,8 @@ func TestStateStore_UpsertDeploymentAllocHealth_Nonexistent(t *testing.T) {
 
 // Test that allocation health can't be set against a terminal deployment
 func TestStateStore_UpsertDeploymentAllocHealth_Terminal(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Insert a terminal deployment
@@ -6135,6 +6359,8 @@ func TestStateStore_UpsertDeploymentAllocHealth_Terminal(t *testing.T) {
 
 // Test that allocation health can't be set against a nonexistent alloc
 func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_Nonexistent(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Insert a deployment
@@ -6159,6 +6385,8 @@ func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_Nonexistent(t *testing.
 // Test that allocation health can't be set for an alloc with mismatched
 // deployment ids
 func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_MismatchDeployment(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Insert two  deployment
@@ -6193,6 +6421,8 @@ func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_MismatchDeployment(t *t
 
 // Test that allocation health is properly set
 func TestStateStore_UpsertDeploymentAllocHealth(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 
 	// Insert a deployment
@@ -6299,6 +6529,8 @@ func TestStateStore_UpsertDeploymentAllocHealth(t *testing.T) {
 }
 
 func TestStateStore_UpsertVaultAccessors(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	a := mock.VaultAccessor()
 	a2 := mock.VaultAccessor()
@@ -6378,6 +6610,8 @@ func TestStateStore_UpsertVaultAccessors(t *testing.T) {
 }
 
 func TestStateStore_DeleteVaultAccessors(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	a1 := mock.VaultAccessor()
 	a2 := mock.VaultAccessor()
@@ -6432,6 +6666,8 @@ func TestStateStore_DeleteVaultAccessors(t *testing.T) {
 }
 
 func TestStateStore_VaultAccessorsByAlloc(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	var accessors []*structs.VaultAccessor
@@ -6478,6 +6714,8 @@ func TestStateStore_VaultAccessorsByAlloc(t *testing.T) {
 }
 
 func TestStateStore_VaultAccessorsByNode(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	node := mock.Node()
 	var accessors []*structs.VaultAccessor
@@ -6524,6 +6762,8 @@ func TestStateStore_VaultAccessorsByNode(t *testing.T) {
 }
 
 func TestStateStore_RestoreVaultAccessor(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	a := mock.VaultAccessor()
 
@@ -6554,6 +6794,8 @@ func TestStateStore_RestoreVaultAccessor(t *testing.T) {
 }
 
 func TestStateStore_UpsertACLPolicy(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	policy := mock.ACLPolicy()
 	policy2 := mock.ACLPolicy()
@@ -6615,6 +6857,8 @@ func TestStateStore_UpsertACLPolicy(t *testing.T) {
 }
 
 func TestStateStore_DeleteACLPolicy(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	policy := mock.ACLPolicy()
 	policy2 := mock.ACLPolicy()
@@ -6682,6 +6926,8 @@ func TestStateStore_DeleteACLPolicy(t *testing.T) {
 }
 
 func TestStateStore_ACLPolicyByNamePrefix(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	names := []string{
 		"foo",
@@ -6729,6 +6975,8 @@ func TestStateStore_ACLPolicyByNamePrefix(t *testing.T) {
 }
 
 func TestStateStore_BootstrapACLTokens(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	tk1 := mock.ACLToken()
 	tk2 := mock.ACLToken()
@@ -6811,6 +7059,8 @@ func TestStateStore_BootstrapACLTokens(t *testing.T) {
 }
 
 func TestStateStore_UpsertACLTokens(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	tk1 := mock.ACLToken()
 	tk2 := mock.ACLToken()
@@ -6880,6 +7130,8 @@ func TestStateStore_UpsertACLTokens(t *testing.T) {
 }
 
 func TestStateStore_DeleteACLTokens(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	tk1 := mock.ACLToken()
 	tk2 := mock.ACLToken()
@@ -6947,6 +7199,8 @@ func TestStateStore_DeleteACLTokens(t *testing.T) {
 }
 
 func TestStateStore_ACLTokenByAccessorIDPrefix(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	prefixes := []string{
 		"aaaa",
@@ -6994,6 +7248,8 @@ func TestStateStore_ACLTokenByAccessorIDPrefix(t *testing.T) {
 }
 
 func TestStateStore_RestoreACLPolicy(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	policy := mock.ACLPolicy()
 
@@ -7017,6 +7273,8 @@ func TestStateStore_RestoreACLPolicy(t *testing.T) {
 }
 
 func TestStateStore_ACLTokensByGlobal(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	tk1 := mock.ACLToken()
 	tk2 := mock.ACLToken()
@@ -7049,6 +7307,8 @@ func TestStateStore_ACLTokensByGlobal(t *testing.T) {
 }
 
 func TestStateStore_RestoreACLToken(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	token := mock.ACLToken()
 
@@ -7072,6 +7332,8 @@ func TestStateStore_RestoreACLToken(t *testing.T) {
 }
 
 func TestStateStore_SchedulerConfig(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	schedConfig := &structs.SchedulerConfiguration{
 		PreemptionConfig: structs.PreemptionConfig{
@@ -7099,6 +7361,8 @@ func TestStateStore_SchedulerConfig(t *testing.T) {
 }
 
 func TestStateStore_Abandon(t *testing.T) {
+	t.Parallel()
+
 	s := testStateStore(t)
 	abandonCh := s.AbandonCh()
 	s.Abandon()
@@ -7111,6 +7375,8 @@ func TestStateStore_Abandon(t *testing.T) {
 
 // Verifies that an error is returned when an allocation doesn't exist in the state store.
 func TestStateSnapshot_DenormalizeAllocationDiffSlice_AllocDoesNotExist(t *testing.T) {
+	t.Parallel()
+
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 	require := require.New(t)


### PR DESCRIPTION
It has been decided we're going to live in a many core world.
Let's take advantage of that and parallelize these state store
tests which all run in memory and are largely CPU bound.

An unscientific benchmark demonstrating the improvement:

before
```
[mp state (master)] $ go test
PASS
ok  	github.com/hashicorp/nomad/nomad/state	5.162s
```

after
```
[mp state (f-parallelize-state-store-tests)] $ go test
PASS
ok  	github.com/hashicorp/nomad/nomad/state	1.527s
```