### PR TITLE
Use debug logging for scheduler internals

### DIFF
--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -260,7 +260,7 @@ OUTER:
 
 				offer, err = netIdx.AssignNetwork(ask)
 				if offer == nil {
-					iter.ctx.Logger().Named("binpack").Error("unexpected error, unable to create network offer after considering preemption", "error", err)
+					iter.ctx.Logger().Named("binpack").Debug("unexpected error, unable to create network offer after considering preemption", "error", err)
 					netIdx.Release()
 					continue OUTER
 				}
@@ -324,7 +324,7 @@ OUTER:
 
 					offer, err = netIdx.AssignNetwork(ask)
 					if offer == nil {
-						iter.ctx.Logger().Named("binpack").Error("unexpected error, unable to create network offer after considering preemption", "error", err)
+						iter.ctx.Logger().Named("binpack").Debug("unexpected error, unable to create network offer after considering preemption", "error", err)
 						netIdx.Release()
 						continue OUTER
 					}
@@ -368,7 +368,7 @@ OUTER:
 					// Try offer again
 					offer, sumAffinities, err = devAllocator.AssignDevice(req)
 					if offer == nil {
-						iter.ctx.Logger().Named("binpack").Error("unexpected error, unable to create device offer after considering preemption", "error", err)
+						iter.ctx.Logger().Named("binpack").Debug("unexpected error, unable to create device offer after considering preemption", "error", err)
 						continue OUTER
 					}
 				}

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -243,7 +243,7 @@ OUTER:
 
 				netPreemptions := preemptor.PreemptForNetwork(ask, netIdx)
 				if netPreemptions == nil {
-					iter.ctx.Logger().Named("binpack").Error("preemption not possible ", "network_resource", ask)
+					iter.ctx.Logger().Named("binpack").Debug("preemption not possible ", "network_resource", ask)
 					netIdx.Release()
 					continue OUTER
 				}
@@ -307,7 +307,7 @@ OUTER:
 
 					netPreemptions := preemptor.PreemptForNetwork(ask, netIdx)
 					if netPreemptions == nil {
-						iter.ctx.Logger().Named("binpack").Error("preemption not possible ", "network_resource", ask)
+						iter.ctx.Logger().Named("binpack").Debug("preemption not possible ", "network_resource", ask)
 						netIdx.Release()
 						continue OUTER
 					}
@@ -352,7 +352,7 @@ OUTER:
 					devicePreemptions := preemptor.PreemptForDevice(req, devAllocator)
 
 					if devicePreemptions == nil {
-						iter.ctx.Logger().Named("binpack").Error("preemption not possible", "requested_device", req)
+						iter.ctx.Logger().Named("binpack").Debug("preemption not possible", "requested_device", req)
 						netIdx.Release()
 						continue OUTER
 					}

--- a/scheduler/spread.go
+++ b/scheduler/spread.go
@@ -127,7 +127,7 @@ func (iter *SpreadIterator) Next() *RankedNode {
 			usedCount += 1
 			// Set score to -1 if there were errors in building this attribute
 			if errorMsg != "" {
-				iter.ctx.Logger().Named("spread").Warn("error building spread attributes for task group", "task_group", tgName, "error", errorMsg)
+				iter.ctx.Logger().Named("spread").Debug("error building spread attributes for task group", "task_group", tgName, "error", errorMsg)
 				totalSpreadScore -= 1.0
 				continue
 			}


### PR DESCRIPTION
We currently log an error if preemption is unable to find a suitable set of
allocations to preempt. This commit changes that to debug level since not finding
preemptable allocations is not an error condition.