### PR TITLE
UI: Fix flapping status light test

### DIFF
--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -440,6 +440,7 @@ module('Acceptance | client detail', function(hooks) {
 
   test('the status light indicates when the node is ineligible for scheduling', async function(assert) {
     node = server.create('node', {
+      drain: false,
       schedulingEligibility: 'ineligible',
     });
 


### PR DESCRIPTION
I unintentionally introduced a flapping test in #6817. The
draining status of the node will be randomly chosen and
that flag takes precedence over eligibility. This forces
the draining flag to be false rather than random so the
test should no longer flap.

See here for an example failure:
https://circleci.com/gh/hashicorp/nomad/26368