### PR TITLE
env_aws: Disable Retries and set Session cfg

### DIFF
--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -77,7 +77,7 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 
 	ec2meta, err := ec2MetaClient(f.endpoint, timeout)
 	if err != nil {
-		return fmt.Errorf("failed to setup ec2 client: %v", err)
+		return fmt.Errorf("failed to setup ec2Metadata client: %v", err)
 	}
 
 	if !ec2meta.Available() {


### PR DESCRIPTION
Previously, Nomad used hand rolled HTTP requests to interact with the
EC2 metadata API. Recently however, we switched to using the AWS SDK for
this fingerprinting.

The default behaviour of the AWS SDK is to perform retries with
exponential backoff when a request fails. This is problematic for Nomad,
because interacting with the EC2 API is in our client start path.

Here we revert to our pre-existing behaviour of not performing retries
in the fast path, as if the metadata service is unavailable, it's likely
that nomad is not running in AWS.

This brings the Nomad agent start time back down from ~20s to ~7s on my
laptop.