### PR TITLE
CSI: Add Client RPCs for interacting with Controller Plugins

### DIFF
--- a/client/client_csi_endpoint.go
+++ b/client/client_csi_endpoint.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/nomad/client/dynamicplugins"
+	"github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/plugins/csi"
+)
+
+// ClientCSI endpoint is used for interacting with CSI plugins on a client.
+// TODO: Submit metrics with labels to allow debugging per plugin perf problems.
+type ClientCSI struct {
+	c *Client
+}
+
+const (
+	// CSIPluginRequestTimeout is the timeout that should be used when making reqs
+	// against CSI Plugins. It is copied from Kubernetes as an initial seed value.
+	// https://github.com/kubernetes/kubernetes/blob/e680ad7156f263a6d8129cc0117fda58602e50ad/pkg/volume/csi/csi_plugin.go#L52
+	CSIPluginRequestTimeout = 2 * time.Minute
+)
+
+var (
+	ErrPluginTypeError = errors.New("CSI Plugin loaded incorrectly")
+)
+
+// CSIControllerPublishVolume is used to attach a volume from a CSI Cluster to
+// the storage node provided in the request.
+func (c *ClientCSI) CSIControllerPublishVolume(req *structs.ClientCSIControllerPublishVolumeRequest, resp *structs.ClientCSIControllerPublishVolumeResponse) error {
+	defer metrics.MeasureSince([]string{"client", "csi_controller", "publish_volume"}, time.Now())
+	client, err := c.findControllerPlugin(req.PluginName)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if req.VolumeID == "" {
+		return errors.New("VolumeID is required")
+	}
+
+	if req.NodeID == "" {
+		return errors.New("NodeID is required")
+	}
+
+	ctx, cancelFn := c.requestContext()
+	defer cancelFn()
+	cresp, err := client.ControllerPublishVolume(ctx, req.ToCSIRequest())
+	if err != nil {
+		return err
+	}
+
+	resp.PublishContext = cresp.PublishContext
+	return nil
+}
+
+func (c *ClientCSI) findControllerPlugin(name string) (csi.CSIPlugin, error) {
+	return c.findPlugin(dynamicplugins.PluginTypeCSIController, name)
+}
+
+// TODO: Cache Plugin Clients?
+func (c *ClientCSI) findPlugin(ptype, name string) (csi.CSIPlugin, error) {
+	pIface, err := c.c.dynamicRegistry.DispensePlugin(ptype, name)
+	if err != nil {
+		return nil, err
+	}
+
+	plugin, ok := pIface.(csi.CSIPlugin)
+	if !ok {
+		return nil, ErrPluginTypeError
+	}
+
+	return plugin, nil
+}
+
+func (c *ClientCSI) requestContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), CSIPluginRequestTimeout)
+}

--- a/client/client_csi_endpoint.go
+++ b/client/client_csi_endpoint.go
@@ -28,9 +28,15 @@ var (
 	ErrPluginTypeError = errors.New("CSI Plugin loaded incorrectly")
 )
 
-// CSIControllerPublishVolume is used to attach a volume from a CSI Cluster to
+// CSIControllerAttachVolume is used to attach a volume from a CSI Cluster to
 // the storage node provided in the request.
-func (c *ClientCSI) CSIControllerPublishVolume(req *structs.ClientCSIControllerPublishVolumeRequest, resp *structs.ClientCSIControllerPublishVolumeResponse) error {
+//
+// The controller attachment flow currently works as follows:
+// 1. Validate the volume request
+// 2. Call ControllerPublishVolume on the CSI Plugin to trigger a remote attachment
+//
+// In the future this may be expanded to request dynamic secrets for attachement.
+func (c *ClientCSI) CSIControllerAttachVolume(req *structs.ClientCSIControllerAttachVolumeRequest, resp *structs.ClientCSIControllerAttachVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"client", "csi_controller", "publish_volume"}, time.Now())
 	client, err := c.findControllerPlugin(req.PluginName)
 	if err != nil {

--- a/client/client_csi_endpoint_test.go
+++ b/client/client_csi_endpoint_test.go
@@ -1,0 +1,121 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/nomad/client/dynamicplugins"
+	"github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/plugins/csi"
+	"github.com/hashicorp/nomad/plugins/csi/fake"
+	"github.com/stretchr/testify/require"
+)
+
+var fakePlugin = &dynamicplugins.PluginInfo{
+	Name:           "test-plugin",
+	Type:           "csi-controller",
+	ConnectionInfo: &dynamicplugins.PluginConnectionInfo{},
+}
+
+func TestClientCSI_CSIControllerPublishVolume(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name             string
+		ClientSetupFunc  func(*fake.Client)
+		Request          *structs.ClientCSIControllerPublishVolumeRequest
+		ExpectedErr      error
+		ExpectedResponse *structs.ClientCSIControllerPublishVolumeResponse
+	}{
+		{
+			Name: "returns plugin not found errors",
+			Request: &structs.ClientCSIControllerPublishVolumeRequest{
+				PluginName: "some-garbage",
+			},
+			ExpectedErr: errors.New("plugin some-garbage for type csi-controller not found"),
+		},
+		{
+			Name: "validates volumeid is not empty",
+			Request: &structs.ClientCSIControllerPublishVolumeRequest{
+				PluginName: fakePlugin.Name,
+			},
+			ExpectedErr: errors.New("VolumeID is required"),
+		},
+		{
+			Name: "validates nodeid is not empty",
+			Request: &structs.ClientCSIControllerPublishVolumeRequest{
+				PluginName: fakePlugin.Name,
+				VolumeID:   "1234-4321-1234-4321",
+			},
+			ExpectedErr: errors.New("NodeID is required"),
+		},
+		{
+			Name: "returns transitive errors",
+			ClientSetupFunc: func(fc *fake.Client) {
+				fc.NextControllerPublishVolumeErr = errors.New("hello")
+			},
+			Request: &structs.ClientCSIControllerPublishVolumeRequest{
+				PluginName: fakePlugin.Name,
+				VolumeID:   "1234-4321-1234-4321",
+				NodeID:     "abcde",
+			},
+			ExpectedErr: errors.New("hello"),
+		},
+		{
+			Name: "handles nil PublishContext",
+			ClientSetupFunc: func(fc *fake.Client) {
+				fc.NextControllerPublishVolumeResponse = &csi.ControllerPublishVolumeResponse{}
+			},
+			Request: &structs.ClientCSIControllerPublishVolumeRequest{
+				PluginName: fakePlugin.Name,
+				VolumeID:   "1234-4321-1234-4321",
+				NodeID:     "abcde",
+			},
+			ExpectedResponse: &structs.ClientCSIControllerPublishVolumeResponse{},
+		},
+		{
+			Name: "handles non-nil PublishContext",
+			ClientSetupFunc: func(fc *fake.Client) {
+				fc.NextControllerPublishVolumeResponse = &csi.ControllerPublishVolumeResponse{
+					PublishContext: map[string]string{"foo": "bar"},
+				}
+			},
+			Request: &structs.ClientCSIControllerPublishVolumeRequest{
+				PluginName: fakePlugin.Name,
+				VolumeID:   "1234-4321-1234-4321",
+				NodeID:     "abcde",
+			},
+			ExpectedResponse: &structs.ClientCSIControllerPublishVolumeResponse{
+				PublishContext: map[string]string{"foo": "bar"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+			client, cleanup := TestClient(t, nil)
+			defer cleanup()
+
+			fakeClient := &fake.Client{}
+			if tc.ClientSetupFunc != nil {
+				tc.ClientSetupFunc(fakeClient)
+			}
+
+			dispenserFunc := func(*dynamicplugins.PluginInfo) (interface{}, error) {
+				return fakeClient, nil
+			}
+			client.dynamicRegistry.StubDispenserForType(dynamicplugins.PluginTypeCSIController, dispenserFunc)
+
+			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
+			require.Nil(err)
+
+			var resp structs.ClientCSIControllerPublishVolumeResponse
+			err = client.ClientRPC("ClientCSI.CSIControllerPublishVolume", tc.Request, &resp)
+			require.Equal(tc.ExpectedErr, err)
+			if tc.ExpectedResponse != nil {
+				require.Equal(tc.ExpectedResponse, &resp)
+			}
+		})
+	}
+}

--- a/client/client_csi_endpoint_test.go
+++ b/client/client_csi_endpoint_test.go
@@ -90,9 +90,11 @@ func TestClientCSI_CSIControllerAttachVolume(t *testing.T) {
 				fc.NextControllerPublishVolumeResponse = &csi.ControllerPublishVolumeResponse{}
 			},
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName: fakePlugin.Name,
-				VolumeID:   "1234-4321-1234-4321",
-				NodeID:     "abcde",
+				PluginName:     fakePlugin.Name,
+				VolumeID:       "1234-4321-1234-4321",
+				NodeID:         "abcde",
+				AccessMode:     structs.CSIVolumeAccessModeSingleNodeWriter,
+				AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
 			},
 			ExpectedResponse: &structs.ClientCSIControllerAttachVolumeResponse{},
 		},
@@ -104,9 +106,11 @@ func TestClientCSI_CSIControllerAttachVolume(t *testing.T) {
 				}
 			},
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName: fakePlugin.Name,
-				VolumeID:   "1234-4321-1234-4321",
-				NodeID:     "abcde",
+				PluginName:     fakePlugin.Name,
+				VolumeID:       "1234-4321-1234-4321",
+				NodeID:         "abcde",
+				AccessMode:     structs.CSIVolumeAccessModeSingleNodeWriter,
+				AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
 			},
 			ExpectedResponse: &structs.ClientCSIControllerAttachVolumeResponse{
 				PublishContext: map[string]string{"foo": "bar"},

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -21,6 +21,7 @@ import (
 // rpcEndpoints holds the RPC endpoints
 type rpcEndpoints struct {
 	ClientStats *ClientStats
+	ClientCSI   *ClientCSI
 	FileSystem  *FileSystem
 	Allocations *Allocations
 	Agent       *Agent
@@ -217,6 +218,7 @@ func (c *Client) streamingRpcConn(server *servers.Server, method string) (net.Co
 func (c *Client) setupClientRpc() {
 	// Initialize the RPC handlers
 	c.endpoints.ClientStats = &ClientStats{c}
+	c.endpoints.ClientCSI = &ClientCSI{c}
 	c.endpoints.FileSystem = NewFileSystemEndpoint(c)
 	c.endpoints.Allocations = NewAllocationsEndpoint(c)
 	c.endpoints.Agent = NewAgentEndpoint(c)
@@ -234,6 +236,7 @@ func (c *Client) setupClientRpc() {
 func (c *Client) setupClientRpcServer(server *rpc.Server) {
 	// Register the endpoints
 	server.Register(c.endpoints.ClientStats)
+	server.Register(c.endpoints.ClientCSI)
 	server.Register(c.endpoints.FileSystem)
 	server.Register(c.endpoints.Allocations)
 }

--- a/client/structs/csi.go
+++ b/client/structs/csi.go
@@ -1,0 +1,58 @@
+package structs
+
+import "github.com/hashicorp/nomad/plugins/csi"
+
+type ClientCSIControllerPublishVolumeRequest struct {
+	PluginName string
+
+	// The ID of the volume to be used on a node.
+	// This field is REQUIRED.
+	VolumeID string
+
+	// The ID of the node. This field is REQUIRED. This must match the NodeID that
+	// is fingerprinted by the target node for this plugin name.
+	NodeID string
+
+	// TODO: Fingerprint the following correctly:
+
+	// Volume capability describing how the CO intends to use this volume.
+	// SP MUST ensure the CO can use the published volume as described.
+	// Otherwise SP MUST return the appropriate gRPC error code.
+	// This is a REQUIRED field.
+	// VolumeCapability *VolumeCapability `protobuf:"bytes,3,opt,name=volume_capability,json=volumeCapability,proto3" json:"volume_capability,omitempty"`
+
+	// Indicates SP MUST publish the volume in readonly mode.
+	// CO MUST set this field to false if SP does not have the
+	// PUBLISH_READONLY controller capability.
+	// This is a REQUIRED field.
+	ReadOnly bool
+}
+
+func (c *ClientCSIControllerPublishVolumeRequest) ToCSIRequest() *csi.ControllerPublishVolumeRequest {
+	if c == nil {
+		return &csi.ControllerPublishVolumeRequest{}
+	}
+
+	return &csi.ControllerPublishVolumeRequest{
+		VolumeID: c.VolumeID,
+		NodeID:   c.NodeID,
+		ReadOnly: c.ReadOnly,
+	}
+}
+
+type ClientCSIControllerPublishVolumeResponse struct {
+	// Opaque static publish properties of the volume. SP MAY use this
+	// field to ensure subsequent `NodeStageVolume` or `NodePublishVolume`
+	// calls calls have contextual information.
+	// The contents of this field SHALL be opaque to nomad.
+	// The contents of this field SHALL NOT be mutable.
+	// The contents of this field SHALL be safe for the nomad to cache.
+	// The contents of this field SHOULD NOT contain sensitive
+	// information.
+	// The contents of this field SHOULD NOT be used for uniquely
+	// identifying a volume. The `volume_id` alone SHOULD be sufficient to
+	// identify the volume.
+	// This field is OPTIONAL and when present MUST be passed to
+	// subsequent `NodeStageVolume` or `NodePublishVolume` calls
+	PublishContext map[string]string
+}

--- a/client/structs/csi.go
+++ b/client/structs/csi.go
@@ -64,7 +64,7 @@ type CSIVolumeMountOptions struct {
 	MountFlags []string
 }
 
-type ClientCSIControllerPublishVolumeRequest struct {
+type ClientCSIControllerAttachVolumeRequest struct {
 	PluginName string
 
 	// The ID of the volume to be used on a node.
@@ -91,7 +91,7 @@ type ClientCSIControllerPublishVolumeRequest struct {
 	ReadOnly bool
 }
 
-func (c *ClientCSIControllerPublishVolumeRequest) ToCSIRequest() *csi.ControllerPublishVolumeRequest {
+func (c *ClientCSIControllerAttachVolumeRequest) ToCSIRequest() *csi.ControllerPublishVolumeRequest {
 	if c == nil {
 		return &csi.ControllerPublishVolumeRequest{}
 	}
@@ -103,7 +103,7 @@ func (c *ClientCSIControllerPublishVolumeRequest) ToCSIRequest() *csi.Controller
 	}
 }
 
-type ClientCSIControllerPublishVolumeResponse struct {
+type ClientCSIControllerAttachVolumeResponse struct {
 	// Opaque static publish properties of the volume. SP MAY use this
 	// field to ensure subsequent `NodeStageVolume` or `NodePublishVolume`
 	// calls calls have contextual information.

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -35,6 +35,10 @@ type Client struct {
 	NextPluginGetCapabilitiesErr      error
 	PluginGetCapabilitiesCallCount    int64
 
+	NextControllerPublishVolumeResponse *csi.ControllerPublishVolumeResponse
+	NextControllerPublishVolumeErr      error
+	ControllerPublishVolumeCallCount    int64
+
 	NextNodeGetInfoResponse *csi.NodeGetInfoResponse
 	NextNodeGetInfoErr      error
 	NodeGetInfoCallCount    int64
@@ -93,6 +97,16 @@ func (c *Client) PluginGetCapabilities(ctx context.Context) (*csi.PluginCapabili
 	c.PluginGetCapabilitiesCallCount++
 
 	return c.NextPluginGetCapabilitiesResponse, c.NextPluginGetCapabilitiesErr
+}
+
+// ControllerPublishVolume is used to attach a remote volume to a node
+func (c *Client) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+
+	c.ControllerPublishVolumeCallCount++
+
+	return c.NextControllerPublishVolumeResponse, c.NextControllerPublishVolumeErr
 }
 
 // NodeGetInfo is used to return semantic data about the current node in

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -26,6 +26,9 @@ type CSIPlugin interface {
 	// Accessible Topology Support
 	PluginGetCapabilities(ctx context.Context) (*PluginCapabilitySet, error)
 
+	// ControllerPublishVolume is used to attach a remote volume to a cluster node.
+	ControllerPublishVolume(ctx context.Context, req *ControllerPublishVolumeRequest) (*ControllerPublishVolumeResponse, error)
+
 	// NodeGetInfo is used to return semantic data about the current node in
 	// respect to the SP.
 	NodeGetInfo(ctx context.Context) (*NodeGetInfoResponse, error)
@@ -82,4 +85,16 @@ func NewPluginCapabilitySet(capabilities *csipbv1.GetPluginCapabilitiesResponse)
 	}
 
 	return cs
+}
+
+type ControllerPublishVolumeRequest struct {
+	VolumeID string
+	NodeID   string
+	ReadOnly bool
+
+	//TODO: Add Capabilities
+}
+
+type ControllerPublishVolumeResponse struct {
+	PublishContext map[string]string
 }

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -41,3 +41,39 @@ func (f *IdentityClient) GetPluginCapabilities(ctx context.Context, in *csipbv1.
 func (f *IdentityClient) Probe(ctx context.Context, in *csipbv1.ProbeRequest, opts ...grpc.CallOption) (*csipbv1.ProbeResponse, error) {
 	return f.NextPluginProbe, f.NextErr
 }
+
+// ControllerClient is a CSI controller client used for testing
+type ControllerClient struct {
+	NextErr                     error
+	NextCapabilitiesResponse    *csipbv1.ControllerGetCapabilitiesResponse
+	NextPublishVolumeResponse   *csipbv1.ControllerPublishVolumeResponse
+	NextUnpublishVolumeResponse *csipbv1.ControllerUnpublishVolumeResponse
+}
+
+// NewControllerClient returns a new ControllerClient
+func NewControllerClient() *ControllerClient {
+	return &ControllerClient{}
+}
+
+func (f *ControllerClient) Reset() {
+	f.NextErr = nil
+	f.NextCapabilitiesResponse = nil
+	f.NextPublishVolumeResponse = nil
+	f.NextUnpublishVolumeResponse = nil
+}
+
+func (c *ControllerClient) ControllerGetCapabilities(ctx context.Context, in *csipbv1.ControllerGetCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.ControllerGetCapabilitiesResponse, error) {
+	return c.NextCapabilitiesResponse, c.NextErr
+}
+
+func (c *ControllerClient) ControllerPublishVolume(ctx context.Context, in *csipbv1.ControllerPublishVolumeRequest, opts ...grpc.CallOption) (*csipbv1.ControllerPublishVolumeResponse, error) {
+	return c.NextPublishVolumeResponse, c.NextErr
+}
+
+func (c *ControllerClient) ControllerUnpublishVolume(ctx context.Context, in *csipbv1.ControllerUnpublishVolumeRequest, opts ...grpc.CallOption) (*csipbv1.ControllerUnpublishVolumeResponse, error) {
+	return c.NextUnpublishVolumeResponse, c.NextErr
+}
+
+func (c *ControllerClient) ValidateVolumeCapabilities(ctx context.Context, in *csipbv1.ValidateVolumeCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.ValidateVolumeCapabilitiesResponse, error) {
+	panic("not implemented") // TODO: Implement
+}


### PR DESCRIPTION
This PR introduces the initial Client RPCs required for a Nomad Server to interact with a CSI Controller plugin to attach volumes from a Nomad Client. It also adds some basic testing infrastructure.

Although this PR is somewhat unused in isolation it unblocks further work in other smaller branches.

## Checklist

- [x] Add ControllerPublishVolume RPCs to the CSI Client / fakes
- [x] Setup CSI RPC endpoint on the client
- [x] Add ControllerAttachVolume RPC to the CSI Endpoint

## Future Work
- Figure out ACLs/Validation for Server-Only RPCs
  - Most likely tagging ClientCSI RPCs as non-forwardable?
- Figure out Retryable RPCs / Exponential Backoff for retriable failures #6863