### PR TITLE
Test: build quota_apply_test, remove the `ent` tests. Fix `multierror` test string match.

### DIFF
--- a/command/quota_apply_test.go
+++ b/command/quota_apply_test.go
@@ -1,16 +1,11 @@
-// +build ent
-
 package command
 
 import (
-	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,64 +35,6 @@ func TestQuotaApplyCommand_Fails(t *testing.T) {
 		t.Fatalf("name required error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
-}
-
-func TestQuotaApplyCommand_Good_HCL(t *testing.T) {
-	t.Parallel()
-
-	// Create a server
-	srv, client, url := testServer(t, true, nil)
-	defer srv.Shutdown()
-
-	ui := new(cli.MockUi)
-	cmd := &QuotaApplyCommand{Meta: Meta{Ui: ui}}
-
-	fh1, err := ioutil.TempFile("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Remove(fh1.Name())
-	if _, err := fh1.WriteString(defaultHclQuotaSpec); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	// Create a quota spec
-	if code := cmd.Run([]string{"-address=" + url, fh1.Name()}); code != 0 {
-		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
-	}
-
-	quotas, _, err := client.Quotas().List(nil)
-	assert.Nil(t, err)
-	assert.Len(t, quotas, 1)
-}
-
-func TestQuotaApplyCommand_Good_JSON(t *testing.T) {
-	t.Parallel()
-
-	// Create a server
-	srv, client, url := testServer(t, true, nil)
-	defer srv.Shutdown()
-
-	ui := new(cli.MockUi)
-	cmd := &QuotaApplyCommand{Meta: Meta{Ui: ui}}
-
-	fh1, err := ioutil.TempFile("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Remove(fh1.Name())
-	if _, err := fh1.WriteString(defaultJsonQuotaSpec); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	// Create a quota spec
-	if code := cmd.Run([]string{"-address=" + url, "-json", fh1.Name()}); code != 0 {
-		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
-	}
-
-	quotas, _, err := client.Quotas().List(nil)
-	assert.Nil(t, err)
-	assert.Len(t, quotas, 1)
 }
 
 func TestQuotaApplyNetwork(t *testing.T) {

--- a/command/quota_apply_test.go
+++ b/command/quota_apply_test.go
@@ -62,7 +62,7 @@ func TestQuotaApplyNetwork(t *testing.T) {
 	}, {
 		hcl: `limit {region = "global", region_limit {network { mbits = 20, device = "eth0"}}}`,
 		q:   nil,
-		err: "1 error(s) occurred:\n\n* limit -> region_limit -> resources -> network -> invalid key: device",
+		err: "network -> invalid key: device",
 	}}
 
 	for _, c := range cases {
@@ -70,7 +70,7 @@ func TestQuotaApplyNetwork(t *testing.T) {
 			q, err := parseQuotaSpec([]byte(c.hcl))
 			require.Equal(t, c.q, q)
 			if c.err != "" {
-				require.EqualError(t, err, c.err)
+				require.Contains(t, err.Error(), c.err)
 			}
 		})
 	}


### PR DESCRIPTION
An upgrade to the `multierror` library made a test fail because it matched the whole string rather than just a substring. This fixes that error. The test didn't fail when the library was upgraded because it was flagged `// +build ent`. This removes that flag and the tests that need it. We'll move them over to the enterprise repository.