### PR TITLE
csi: Fingerprint Controller Capabilities

### DIFF
--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -100,7 +100,23 @@ func (n *CSINodeInfo) Copy() *CSINodeInfo {
 // CSIControllerInfo is the fingerprinted data from a CSI Plugin that is specific to
 // the Controller API.
 type CSIControllerInfo struct {
-	// Currently empty
+	// SupportsReadOnlyAttach is set to true when the controller returns the
+	// ATTACH_READONLY capability.
+	SupportsReadOnlyAttach bool
+
+	// SupportsPublishVolume is true when the controller implements the methods
+	// required to attach and detach volumes. If this is false Nomad should skip
+	// the controller attachment flow.
+	SupportsAttachDetach bool
+
+	// SupportsListVolums is true when the controller implements the ListVolumes
+	// RPC. NOTE: This does not guaruntee that attached nodes will be returned
+	// unless SupportsListVolumesAttachedNodes is also true.
+	SupportsListVolumes bool
+
+	// SupportsListVolumesAttachedNodes indicates whether the plugin will return
+	// attached nodes data when making ListVolume RPCs
+	SupportsListVolumesAttachedNodes bool
 }
 
 func (c *CSIControllerInfo) Copy() *CSIControllerInfo {

--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -198,6 +198,22 @@ func (c *client) PluginGetCapabilities(ctx context.Context) (*PluginCapabilitySe
 // Controller Endpoints
 //
 
+func (c *client) ControllerGetCapabilities(ctx context.Context) (*ControllerCapabilitySet, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Client not initialized")
+	}
+	if c.controllerClient == nil {
+		return nil, fmt.Errorf("controllerClient not initialized")
+	}
+
+	resp, err := c.controllerClient.ControllerGetCapabilities(ctx, &csipbv1.ControllerGetCapabilitiesRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return NewControllerCapabilitySet(resp), nil
+}
+
 func (c *client) ControllerPublishVolume(ctx context.Context, req *ControllerPublishVolumeRequest) (*ControllerPublishVolumeResponse, error) {
 	if c == nil {
 		return nil, fmt.Errorf("Client not initialized")

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -35,6 +35,10 @@ type Client struct {
 	NextPluginGetCapabilitiesErr      error
 	PluginGetCapabilitiesCallCount    int64
 
+	NextControllerGetCapabilitiesResponse *csi.ControllerCapabilitySet
+	NextControllerGetCapabilitiesErr      error
+	ControllerGetCapabilitiesCallCount    int64
+
 	NextControllerPublishVolumeResponse *csi.ControllerPublishVolumeResponse
 	NextControllerPublishVolumeErr      error
 	ControllerPublishVolumeCallCount    int64
@@ -97,6 +101,15 @@ func (c *Client) PluginGetCapabilities(ctx context.Context) (*csi.PluginCapabili
 	c.PluginGetCapabilitiesCallCount++
 
 	return c.NextPluginGetCapabilitiesResponse, c.NextPluginGetCapabilitiesErr
+}
+
+func (c *Client) ControllerGetCapabilities(ctx context.Context) (*csi.ControllerCapabilitySet, error) {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+
+	c.ControllerGetCapabilitiesCallCount++
+
+	return c.NextControllerGetCapabilitiesResponse, c.NextControllerGetCapabilitiesErr
 }
 
 // ControllerPublishVolume is used to attach a remote volume to a node


### PR DESCRIPTION
This PR introduces the `ControllerGetCapabilities` RPC and adds fingerprinting of the controller to the CSIManager for use when making scheduling and validation decisions.

Currently we only validate a minimal number of capabilities as required by the initial version of CSI-in-Nomad