### PR TITLE
csi: Fingerprint node capabilities

### DIFF
--- a/client/pluginmanager/csimanager/instance.go
+++ b/client/pluginmanager/csimanager/instance.go
@@ -161,6 +161,12 @@ func (i *instanceManager) buildNodeFingerprint(ctx context.Context, base *struct
 	}
 	fp.SetHealthy(healthy)
 
+	caps, err := i.client.NodeGetCapabilities(ctx)
+	if err != nil {
+		return fp, err
+	}
+	fp.NodeInfo.RequiresNodeStageVolume = caps.HasStageUnstageVolume
+
 	return fp, nil
 }
 

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -83,6 +83,10 @@ type CSINodeInfo struct {
 	// Indicates the node exists within the "region" "R1" and the "zone"
 	// "Z2" within the storage provider.
 	AccessibleTopology *CSITopology
+
+	// RequiresNodeStageVolume indicates whether the client should Stage/Unstage
+	// volumes on this node.
+	RequiresNodeStageVolume bool
 }
 
 func (n *CSINodeInfo) Copy() *CSINodeInfo {

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -43,6 +43,10 @@ type Client struct {
 	NextControllerPublishVolumeErr      error
 	ControllerPublishVolumeCallCount    int64
 
+	NextNodeGetCapabilitiesResponse *csi.NodeCapabilitySet
+	NextNodeGetCapabilitiesErr      error
+	NodeGetCapabilitiesCallCount    int64
+
 	NextNodeGetInfoResponse *csi.NodeGetInfoResponse
 	NextNodeGetInfoErr      error
 	NodeGetInfoCallCount    int64
@@ -120,6 +124,15 @@ func (c *Client) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	c.ControllerPublishVolumeCallCount++
 
 	return c.NextControllerPublishVolumeResponse, c.NextControllerPublishVolumeErr
+}
+
+func (c *Client) NodeGetCapabilities(ctx context.Context) (*csi.NodeCapabilitySet, error) {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+
+	c.NodeGetCapabilitiesCallCount++
+
+	return c.NextNodeGetCapabilitiesResponse, c.NextNodeGetCapabilitiesErr
 }
 
 // NodeGetInfo is used to return semantic data about the current node in

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -77,3 +77,29 @@ func (c *ControllerClient) ControllerUnpublishVolume(ctx context.Context, in *cs
 func (c *ControllerClient) ValidateVolumeCapabilities(ctx context.Context, in *csipbv1.ValidateVolumeCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.ValidateVolumeCapabilitiesResponse, error) {
 	panic("not implemented") // TODO: Implement
 }
+
+// NodeClient is a CSI Node client used for testing
+type NodeClient struct {
+	NextErr                  error
+	NextCapabilitiesResponse *csipbv1.NodeGetCapabilitiesResponse
+	NextGetInfoResponse      *csipbv1.NodeGetInfoResponse
+}
+
+// NewNodeClient returns a new ControllerClient
+func NewNodeClient() *NodeClient {
+	return &NodeClient{}
+}
+
+func (f *NodeClient) Reset() {
+	f.NextErr = nil
+	f.NextCapabilitiesResponse = nil
+	f.NextGetInfoResponse = nil
+}
+
+func (c *NodeClient) NodeGetCapabilities(ctx context.Context, in *csipbv1.NodeGetCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.NodeGetCapabilitiesResponse, error) {
+	return c.NextCapabilitiesResponse, c.NextErr
+}
+
+func (c *NodeClient) NodeGetInfo(ctx context.Context, in *csipbv1.NodeGetInfoRequest, opts ...grpc.CallOption) (*csipbv1.NodeGetInfoResponse, error) {
+	return c.NextGetInfoResponse, c.NextErr
+}


### PR DESCRIPTION
This PR introduces the NodeGetCapabilities RPC and adds fingerprinting of the node service to the CSIManager for use when attaching/detaching volumes and debugging.

Currently we only validate a minimal number of capabilities as required by the initial version of CSI-in-Nomad