### PR TITLE
client: fix trace log message in alloc hook update

### DIFF
--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -203,7 +203,7 @@ func (ar *allocRunner) update(update *structs.Allocation) error {
 		var start time.Time
 		if ar.logger.IsTrace() {
 			start = time.Now()
-			ar.logger.Trace("running pre-run hook", "name", name, "start", start)
+			ar.logger.Trace("running update hook", "name", name, "start", start)
 		}
 
 		if err := h.Update(req); err != nil {


### PR DESCRIPTION
The log message here was for the wrong hook method, which led to me spinning my wheels a bit while trying to debug #6459 😀 