### PR TITLE
Add CSI Plugin info to `nomad node status`

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -466,6 +466,8 @@ type Node struct {
 	Events                []*NodeEvent
 	Drivers               map[string]*DriverInfo
 	HostVolumes           map[string]*HostVolumeInfo
+	CSIControllerPlugins  map[string]*CSIInfo
+	CSINodePlugins        map[string]*CSIInfo
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }
@@ -511,6 +513,41 @@ type NodeReservedDiskResources struct {
 
 type NodeReservedNetworkResources struct {
 	ReservedHostPorts string
+}
+
+type CSITopology struct {
+	Segments map[string]string
+}
+
+// CSINodeInfo is the fingerprinted data from a CSI Plugin that is specific to
+// the Node API.
+type CSINodeInfo struct {
+	ID                      string
+	MaxVolumes              int64
+	AccessibleTopology      *CSITopology
+	RequiresNodeStageVolume bool
+}
+
+// CSIControllerInfo is the fingerprinted data from a CSI Plugin that is specific to
+// the Controller API.
+type CSIControllerInfo struct {
+	SupportsReadOnlyAttach           bool
+	SupportsAttachDetach             bool
+	SupportsListVolumes              bool
+	SupportsListVolumesAttachedNodes bool
+}
+
+// CSIInfo is the current state of a single CSI Plugin. This is updated regularly
+// as plugin health changes on the node.
+type CSIInfo struct {
+	PluginID                 string
+	Healthy                  bool
+	HealthDescription        string
+	UpdateTime               time.Time
+	RequiresControllerPlugin bool
+	RequiresTopologies       bool
+	ControllerInfo           *CSIControllerInfo `json:",omitempty"`
+	NodeInfo                 *CSINodeInfo       `json:",omitempty"`
 }
 
 // DrainStrategy describes a Node's drain behavior.

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -299,6 +299,24 @@ func nodeDrivers(n *api.Node) []string {
 	return drivers
 }
 
+func nodeCSIControllerNames(n *api.Node) []string {
+	var names []string
+	for name := range n.CSIControllerPlugins {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func nodeCSINodeNames(n *api.Node) []string {
+	var names []string
+	for name := range n.CSINodePlugins {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func nodeVolumeNames(n *api.Node) []string {
 	var volumes []string
 	for name := range n.HostVolumes {
@@ -340,6 +358,8 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		fmt.Sprintf("Drain|%v", formatDrain(node)),
 		fmt.Sprintf("Eligibility|%s", node.SchedulingEligibility),
 		fmt.Sprintf("Status|%s", node.Status),
+		fmt.Sprintf("CSI Controllers|%s", strings.Join(nodeCSIControllerNames(node), ",")),
+		fmt.Sprintf("CSI Drivers|%s", strings.Join(nodeCSINodeNames(node), ",")),
 	}
 
 	if c.short {


### PR DESCRIPTION
This PR adds a lightweight version of CSI plugin info to nomad node status to simplify development. A more detailed `-verbose` version can be designed later.

```
[nomad(f-csi-node-status)] $ nomad node status -self  
ID              = 5f5bbef9-57a7-ff31-6e57-bf89ae00364a                                            
Name            = mew                            
Class           = <none>                         
DC              = dc1                            
Drain           = false                          
Eligibility     = eligible                       
Status          = ready                          
CSI Controllers = csi-hostpath                   
CSI Drivers     = <none>                   
Uptime          = 27h2m44s                       
Host Volumes    = <none>                         
Driver Status   = docker,exec,mock_driver,raw_exec                                                
```


