### PR TITLE
Line 60 in JSON produces syntax error

### DIFF
--- a/website/source/api/json-jobs.html.md
+++ b/website/source/api/json-jobs.html.md
@@ -57,7 +57,7 @@ Below is the JSON representation of the job outputted by `$ nomad init`:
                         "cache"
                     ],
                     "Meta": {
-                      "meta": "for my service",
+                      "meta": "for my service"
                     },
                     "PortLabel": "db",
                     "AddressMode": "",


### PR DESCRIPTION
Line 60 should not end in a comma as there are no add'l key/vals.  The line produces a syntax error in Ruby (JSON.parse) and https://jsonlint.com:
Error: Parse error on line 37:
...r my service",					},					"PortLabel":
----------------------^
Expecting 'STRING', got '}'