### PR TITLE
Fix error parsing config when setting consul.timeout.

### DIFF
--- a/nomad/structs/config/consul.go
+++ b/nomad/structs/config/consul.go
@@ -65,8 +65,8 @@ type ConsulConfig struct {
 	GRPCAddr string `hcl:"grpc_address"`
 
 	// Timeout is used by Consul HTTP Client
-	Timeout    time.Duration
-	TimeoutHCL string `hcl:"timeout" json:"-"`
+	Timeout    time.Duration `hcl:"-"`
+	TimeoutHCL string        `hcl:"timeout" json:"-"`
 
 	// Token is used to provide a per-request ACL token. This options overrides
 	// the agent's default token


### PR DESCRIPTION
When parsing a config file which had the consul.timeout param set,
Nomad was reporting an error causing startup to fail. This seems
to be caused by the HCL decoder interpreting the timeout type as
an int rather than a string. This is caused by the struct
TimeoutHCL param having a hcl key of timeout alongside a Timeout
struct param of type time.Duration (int). Ensuring the decoder
ignores the Timeout struct param ensure the decoder runs
correctly.

closes #6893 