### PR TITLE
interpolate environment for services in script checks

### DIFF
--- a/client/allocrunner/taskrunner/script_check_hook.go
+++ b/client/allocrunner/taskrunner/script_check_hook.go
@@ -174,7 +174,8 @@ func (h *scriptCheckHook) Stop(ctx context.Context, req *interfaces.TaskStopRequ
 
 func (h *scriptCheckHook) newScriptChecks() map[string]*scriptCheck {
 	scriptChecks := make(map[string]*scriptCheck)
-	for _, service := range h.task.Services {
+	interpolatedTaskServices := taskenv.InterpolateServices(h.taskEnv, h.task.Services)
+	for _, service := range interpolatedTaskServices {
 		for _, check := range service.Checks {
 			if check.Type != structs.ServiceCheckScript {
 				continue
@@ -204,7 +205,8 @@ func (h *scriptCheckHook) newScriptChecks() map[string]*scriptCheck {
 	// needs are entirely encapsulated within the group service hook which
 	// watches Consul for status changes.
 	tg := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup)
-	for _, service := range tg.Services {
+	interpolatedGroupServices := taskenv.InterpolateServices(h.taskEnv, tg.Services)
+	for _, service := range interpolatedGroupServices {
 		for _, check := range service.Checks {
 			if check.Type != structs.ServiceCheckScript {
 				continue
@@ -293,37 +295,10 @@ func newScriptCheck(config *scriptCheckConfig) *scriptCheck {
 	sc.callback = newScriptCheckCallback(sc)
 	sc.logger = config.logger
 	sc.shutdownCh = config.shutdownCh
-
-	// the hash of the interior structs.ServiceCheck is used by the
-	// Consul client to get the ID to register for the check. So we
-	// update it here so that we have the same ID for UpdateTTL.
-
-	// TODO(tgross): this block is similar to one in service_hook
-	// and we can pull that out to a function so we know we're
-	// interpolating the same everywhere
-	sc.check.Name = config.taskEnv.ReplaceEnv(orig.Name)
-	sc.check.Type = config.taskEnv.ReplaceEnv(orig.Type)
 	sc.check.Command = sc.Command
 	sc.check.Args = sc.Args
-	sc.check.Path = config.taskEnv.ReplaceEnv(orig.Path)
-	sc.check.Protocol = config.taskEnv.ReplaceEnv(orig.Protocol)
-	sc.check.PortLabel = config.taskEnv.ReplaceEnv(orig.PortLabel)
-	sc.check.InitialStatus = config.taskEnv.ReplaceEnv(orig.InitialStatus)
-	sc.check.Method = config.taskEnv.ReplaceEnv(orig.Method)
-	sc.check.GRPCService = config.taskEnv.ReplaceEnv(orig.GRPCService)
-	if len(orig.Header) > 0 {
-		header := make(map[string][]string, len(orig.Header))
-		for k, vs := range orig.Header {
-			newVals := make([]string, len(vs))
-			for i, v := range vs {
-				newVals[i] = config.taskEnv.ReplaceEnv(v)
-			}
-			header[config.taskEnv.ReplaceEnv(k)] = newVals
-		}
-		sc.check.Header = header
-	}
+
 	if config.isGroup {
-		// TODO(tgross):
 		// group services don't have access to a task environment
 		// at creation, so their checks get registered before the
 		// check can be interpolated here. if we don't use the


### PR DESCRIPTION
Fixes #6836 

In 0.10.2 (specifically #6586 / 387b016) we added interpolation to group service blocks and centralized the logic for task environment interpolation. This wasn't also added to script checks, which caused a regression where the IDs for script checks for services w/ interpolated fields (ex. the service name) didn't match the service ID that was registered with Consul.

This changeset calls the same taskenv interpolation logic during `script_check` configuration, and adds tests to reduce the risk of future regressions by comparing the IDs of service hook and the check hook.

---

In addition to the added unit test, I've exercised this with the following jobspec. If you run `nomad job run example.nomad` with this you'll see `nginx-0` as the service name and the checks work, and if you update the value of `PROJECT_VERSION` that'll be properly reflected in the service name.

```hcl
job "example" {
  datacenters = ["dc1"]

  group "webservers" {
    count = 1
    task "nginx" {
      driver = "docker"

      config {
        image = "0x74696d/nginx-with-curl:latest"
        port_map = {
          http = 80
        }
      }

      env {
        PROJECT_VERSION = "0"
      }

      service {
        name = "nginx-${PROJECT_VERSION}"
        port = "http"

        check {
          type     = "script"
          command = "/usr/bin/curl"
          args = ["--fail", "http://localhost/"]
          interval = "5s"
          timeout  = "3s"
        }
      }

      resources {
        memory = 128

        network {
          mbits = 10
          port "http" {}
        }
      }
    }
  }
}
```

cc @jorgemarey