### PR TITLE
GNUmakefile: report failed path on hclfmt error

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -222,7 +222,8 @@ changelogfmt:
 .PHONY: hclfmt
 hclfmt:
 	@echo "--> Formatting HCL"
-	@find . -path ./terraform -prune -o -name 'upstart.nomad' -prune -o \( -name '*.nomad' -o -name '*.hcl' \) -exec hclfmt -w {} +
+	@find . -path ./terraform -prune -o -name 'upstart.nomad' -prune -o \( -name '*.nomad' -o -name '*.hcl' \) -exec \
+sh -c 'hclfmt -w {} || echo in path {}' ';'
 
 .PHONY: dev
 dev: GOOS=$(shell go env GOOS)


### PR DESCRIPTION
`hclfmt` checks would report an error, but not which hcl file caused the error. This fixes that.