### PR TITLE
upgrade CNI plugins to 0.8.4

### DIFF
--- a/e2e/terraform/shared/config/provision-client.sh
+++ b/e2e/terraform/shared/config/provision-client.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# installs and configures the desired build of Nomad as a server
+# installs and configures the desired build of Nomad as a client
 set -o errexit
 set -o nounset
 
@@ -74,7 +74,7 @@ sudo mkdir /tmp/data
 # Install CNI plugins
 sudo mkdir -p /opt/cni/bin
 wget -q -O - \
-     https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz \
+     https://github.com/containernetworking/plugins/releases/download/v0.8.4/cni-plugins-linux-amd64-v0.8.4.tgz \
     | sudo tar -C /opt/cni/bin -xz
 
 # enable as a systemd service

--- a/e2e/terraform/shared/config/provision-windows-client.ps1
+++ b/e2e/terraform/shared/config/provision-windows-client.ps1
@@ -40,7 +40,7 @@ md C:\tmp\data
 # TODO(tgross): not sure we even support this for Windows?
 # Write-Output "Install CNI"
 # md C:\opt\cni\bin
-# $cni_url = "https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz"
+# $cni_url = "https://github.com/containernetworking/plugins/releases/download/v0.8.4/cni-plugins-windows-amd64-v0.8.4.tgz"
 # Invoke-WebRequest -Uri "$cni_url" -Outfile cni.tgz
 # Expand-7Zip -ArchiveFileName .\cni.tgz -TargetPath C:\opt\cni\bin\
 

--- a/scripts/vagrant-linux-priv-cni.sh
+++ b/scripts/vagrant-linux-priv-cni.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-VERSION="v0.8.2"
+VERSION="v0.8.4"
 DOWNLOAD=https://github.com/containernetworking/plugins/releases/download/${VERSION}/cni-plugins-linux-amd64-${VERSION}.tgz
 TARGET_DIR=/opt/cni/bin
 

--- a/website/source/guides/integrations/consul-connect/index.html.md
+++ b/website/source/guides/integrations/consul-connect/index.html.md
@@ -110,7 +110,7 @@ must have CNI plugins installed.
 The following commands install CNI plugins:
 
 ```sh
-$ curl -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.3/cni-plugins-linux-amd64-v0.8.3.tgz
+$ curl -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.4/cni-plugins-linux-amd64-v0.8.4.tgz
 $ sudo mkdir -p /opt/cni/bin
 $ sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
 ```


### PR DESCRIPTION
Fixes #6567

When multiple Connect-enabled task groups start on the same client node, a race condition in the CNI plugins for creating iptables chains causes one of the tasks to fail. We upstreamed a patch (https://github.com/containernetworking/plugins/pull/408) to CNI plugins to make iptables chain creation idempotent.

This changeset updates end-to-end testing, development tooling, and documentation to use 0.8.4 which includes our patch.

---

I've tested this out with our Connect E2E testing (see below), as well as running our manual internal testing matrix for the various task drivers.

```
▶ go test -v ./e2e -run 'TestE2E/Connect'
=== RUN   TestE2E
=== RUN   TestE2E/Connect
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest/TestConnectDemo
=== RUN   TestE2E/Connect/*connect.ConnectClientStateE2ETest
=== RUN   TestE2E/Connect/*connect.ConnectClientStateE2ETest/TestClientRestart
--- PASS: TestE2E (29.82s)
    --- PASS: TestE2E/Connect (29.82s)
        --- PASS: TestE2E/Connect/*connect.ConnectE2ETest (7.73s)
            --- PASS: TestE2E/Connect/*connect.ConnectE2ETest/TestConnectDemo (7.55s)
        --- PASS: TestE2E/Connect/*connect.ConnectClientStateE2ETest (21.91s)
            --- PASS: TestE2E/Connect/*connect.ConnectClientStateE2ETest/TestClientRestart (21.72s)
PASS
ok      github.com/hashicorp/nomad/e2e  31.058s
```