### PR TITLE
Handle Upgrades and Alloc.TaskResources modification

### DIFF
--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -63,16 +63,8 @@ func newServiceHook(c serviceHookConfig) *serviceHook {
 		delay:     c.task.ShutdownDelay,
 	}
 
-	// COMPAT(0.11): AllocatedResources was added in 0.9 so assume its set
-	//               in 0.11.
-	if c.alloc.AllocatedResources != nil {
-		if res := c.alloc.AllocatedResources.Tasks[c.task.Name]; res != nil {
-			h.networks = res.Networks
-		}
-	} else {
-		if res := c.alloc.TaskResources[c.task.Name]; res != nil {
-			h.networks = res.Networks
-		}
+	if res := c.alloc.AllocatedResources.Tasks[c.task.Name]; res != nil {
+		h.networks = res.Networks
 	}
 
 	if c.alloc.DeploymentStatus != nil && c.alloc.DeploymentStatus.Canary {
@@ -116,17 +108,9 @@ func (h *serviceHook) Update(ctx context.Context, req *interfaces.TaskUpdateRequ
 		canary = req.Alloc.DeploymentStatus.Canary
 	}
 
-	// COMPAT(0.11): AllocatedResources was added in 0.9 so assume its set
-	//               in 0.11.
 	var networks structs.Networks
-	if req.Alloc.AllocatedResources != nil {
-		if res := req.Alloc.AllocatedResources.Tasks[h.taskName]; res != nil {
-			networks = res.Networks
-		}
-	} else {
-		if res := req.Alloc.TaskResources[h.taskName]; res != nil {
-			networks = res.Networks
-		}
+	if res := req.Alloc.AllocatedResources.Tasks[h.taskName]; res != nil {
+		networks = res.Networks
 	}
 
 	task := req.Alloc.LookupTask(h.taskName)

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -294,15 +294,15 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 
 	// Pull out the task's resources
 	ares := tr.alloc.AllocatedResources
-	if ares != nil {
-		tres, ok := ares.Tasks[tr.taskName]
-		if !ok {
-			return nil, fmt.Errorf("no task resources found on allocation")
-		}
-		tr.taskResources = tres
-	} else {
+	if ares == nil {
 		return nil, fmt.Errorf("no task resources found on allocation")
 	}
+
+	tres, ok := ares.Tasks[tr.taskName]
+	if !ok {
+		return nil, fmt.Errorf("no task resources found on allocation")
+	}
+	tr.taskResources = tres
 
 	// Build the restart tracker.
 	tg := tr.alloc.Job.LookupTaskGroup(tr.alloc.TaskGroup)

--- a/client/client.go
+++ b/client/client.go
@@ -1995,6 +1995,10 @@ OUTER:
 			// Ensure that we received all the allocations we wanted
 			pulledAllocs = make(map[string]*structs.Allocation, len(allocsResp.Allocs))
 			for _, alloc := range allocsResp.Allocs {
+
+				// handle an old Server
+				alloc.Canonicalize()
+
 				pulledAllocs[alloc.ID] = alloc
 			}
 

--- a/client/state/db_test.go
+++ b/client/state/db_test.go
@@ -76,12 +76,6 @@ func TestStateDB_Allocations(t *testing.T) {
 		alloc1 := mock.Alloc()
 		alloc2 := mock.BatchAlloc()
 
-		//XXX Sadly roundtripping allocs loses time.Duration type
-		//    information from the Config map[string]interface{}. As
-		//    the mock driver itself with unmarshal run_for into the
-		//    proper type, we can safely ignore it here.
-		delete(alloc2.Job.TaskGroups[0].Tasks[0].Config, "run_for")
-
 		require.NoError(db.PutAllocation(alloc1))
 		require.NoError(db.PutAllocation(alloc2))
 

--- a/client/state/state_database.go
+++ b/client/state/state_database.go
@@ -207,6 +207,9 @@ func (s *BoltStateDB) getAllAllocations(tx *boltdd.Tx) ([]*structs.Allocation, m
 			continue
 		}
 
+		// Handle upgrade path
+		ae.Alloc.Canonicalize()
+
 		allocs = append(allocs, ae.Alloc)
 	}
 

--- a/client/state/state_database.go
+++ b/client/state/state_database.go
@@ -209,7 +209,6 @@ func (s *BoltStateDB) getAllAllocations(tx *boltdd.Tx) ([]*structs.Allocation, m
 
 		// Handle upgrade path
 		ae.Alloc.Canonicalize()
-		ae.Alloc.Job.Canonicalize()
 
 		allocs = append(allocs, ae.Alloc)
 	}

--- a/client/state/state_database.go
+++ b/client/state/state_database.go
@@ -209,6 +209,7 @@ func (s *BoltStateDB) getAllAllocations(tx *boltdd.Tx) ([]*structs.Allocation, m
 
 		// Handle upgrade path
 		ae.Alloc.Canonicalize()
+		ae.Alloc.Job.Canonicalize()
 
 		allocs = append(allocs, ae.Alloc)
 	}

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -604,6 +604,9 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
 
 	b.otherPorts = make(map[string]string, len(tg.Tasks)*2)
+
+	// Protect against invalid allocs where AllocatedResources isn't set.
+	// TestClient_AddAllocError explicitly tests for this condition
 	if alloc.AllocatedResources != nil {
 		// Populate task resources
 		if tr, ok := alloc.AllocatedResources.Tasks[b.taskName]; ok {

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -603,7 +603,6 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 
 	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
 
-	// COMPAT(0.11): Remove in 0.11
 	b.otherPorts = make(map[string]string, len(tg.Tasks)*2)
 	if alloc.AllocatedResources != nil {
 		// Populate task resources
@@ -643,30 +642,6 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 			}
 			for _, p := range nw.DynamicPorts {
 				addGroupPort(b.otherPorts, p)
-			}
-		}
-	} else if alloc.TaskResources != nil {
-		if tr, ok := alloc.TaskResources[b.taskName]; ok {
-			// Copy networks to prevent sharing
-			b.networks = make([]*structs.NetworkResource, len(tr.Networks))
-			for i, n := range tr.Networks {
-				b.networks[i] = n.Copy()
-			}
-
-		}
-
-		for taskName, resources := range alloc.TaskResources {
-			// Add ports from other tasks
-			if taskName == b.taskName {
-				continue
-			}
-			for _, nw := range resources.Networks {
-				for _, p := range nw.ReservedPorts {
-					addPort(b.otherPorts, taskName, nw.IP, p.Label, p.Value)
-				}
-				for _, p := range nw.DynamicPorts {
-					addPort(b.otherPorts, taskName, nw.IP, p.Label, p.Value)
-				}
 			}
 		}
 	}

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -266,6 +266,10 @@ func TestEnvironment_AsList_Old(t *testing.T) {
 			},
 		},
 	}
+
+	// simulate canonicalization on restore or fetch
+	a.Canonicalize()
+
 	task := a.Job.TaskGroups[0].Tasks[0]
 	task.Env = map[string]string{
 		"taskEnvKey": "taskEnvVal",

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -191,7 +191,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	}
 	c.Ui.Output(output)
 
-	if len(alloc.AllocatedResources.Shared.Networks) > 0 && alloc.AllocatedResources.Shared.Networks[0].HasPorts() {
+	if alloc.AllocatedResources != nil && len(alloc.AllocatedResources.Shared.Networks) > 0 && alloc.AllocatedResources.Shared.Networks[0].HasPorts() {
 		c.Ui.Output("")
 		c.Ui.Output(formatAllocNetworkInfo(alloc))
 	}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -294,6 +294,11 @@ func (s *StateStore) UpsertPlanResults(index uint64, results *structs.ApplyPlanR
 	allocsToUpsert = append(allocsToUpsert, results.AllocsUpdated...)
 	allocsToUpsert = append(allocsToUpsert, allocsPreempted...)
 
+	// handle upgrade path
+	for _, alloc := range allocsToUpsert {
+		alloc.Canonicalize()
+	}
+
 	if err := s.upsertAllocsImpl(index, allocsToUpsert, txn); err != nil {
 		return err
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7661,9 +7661,7 @@ func (a *Allocation) Canonicalize() {
 		a.AllocatedResources = &ar
 	}
 
-	// TODO: Investigate if we should canonicalize the job
-	// it may be out of sync with respect to the original job
-	// a.Job.Canonicalize()
+	a.Job.Canonicalize()
 }
 
 func (a *Allocation) copyImpl(job bool) *Allocation {


### PR DESCRIPTION
In 0.9, Allocation resources tracking changed, such that `Allocation.{TaskResources|Resources|SharedResources}` was effectively moved to `Allocation.AllocationedResources` and we initially targetted 0.11 to drop checking old fields.

This strategy is not correct.  Because the Allocation is a persisted struct in Raft and Client Store and persisted store may remain untouched despite many nomad upgrades (e.g. if alloc doesn't change), we cannot properly stop relying on the old fields.  Removing the paths would cause a panic.

This change ensures that Allocation modification follows the pattern of Job and Node schema change.  Namely, that we introduce a Canonicalize method that applies a struct schema migration on reads from a persisted store (Raft log, Raft snapshot, Client state store).  This eases compatibility handling, as other components can start relying on `Allocation.AllocatedResources` immediately and no longer need to fallback to `Allocation.TaskResources` anymore.  We used this Canonicalize pattern in `Job.Namespace` and `Node.SchedulingEligibility` introduction, but we missed it here.

It's worth noting that we must preserve `Allocation.TaskResources` effectively forever.  Consider an installation with Nomad 0.1 (pre namespaces, etc) running a single alloc, and then upgraded sequentially through all intermediate versions until 0.11 (or a future version) in a short time.  We cannot assure that the alloc or job was updated or that a Raft Snapshot was created with the latest schema.  As such, we should consul the fallback paths and perform schema migration indefinitely.  We may revisit this if we changed upgrade requirements in a way that enforces making a Snapshot with latest schema.

Though `Allocation.TaskResources` struct must be preserved, `structs.Resources` methods are deadcode now and can be removed.  We only need to preserve the struct type and fields to allow migration.

### To reproduce the issue

1. Spin up a nomad 0.8 agent; single node cluster in non-dev mode suffices
2. Run an example job 
3. Upgrade cluster to 0.9 then to 0.10
4. Run `nomad alloc status -json <alloc_id>` and note that `"AllocatedResources"` is nil, though COMPAT comments suggests otherwise

### Caveats

We don't anticipate schema migrations to add much overhead here.  Canonicalization of already up-to-date allocation structs will be effectively a nil check.

It's unfortunate that `Canonicalize` in the structs package refer to upgrade path schema migration handling.  `Canonicalize` methods in the `api/` package to refer populating struct with defaults.  This overload is a bit confusing.  I opted to keep current pattern and we may consider renaming struct package method name to `UpgradeSchema` in follow up PR.