### PR TITLE
csi: gRPC Logging Middlware

### DIFF
--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -294,7 +294,7 @@ func (h *csiPluginSupervisorHook) supervisorLoopOnce(ctx context.Context, socket
 		return false, fmt.Errorf("failed to stat socket: %v", err)
 	}
 
-	client, err := csi.NewClient(socketPath)
+	client, err := csi.NewClient(socketPath, h.logger.Named("csi_client").With("plugin.name", h.task.CSIPluginConfig.ID, "plugin.type", h.task.CSIPluginConfig.Type))
 	defer client.Close()
 	if err != nil {
 		return false, fmt.Errorf("failed to create csi client: %v", err)

--- a/client/client.go
+++ b/client/client.go
@@ -339,10 +339,10 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulServic
 		serversContactedOnce: sync.Once{},
 		dynamicRegistry: dynamicplugins.NewRegistry(map[string]dynamicplugins.PluginDispenser{
 			dynamicplugins.PluginTypeCSIController: func(info *dynamicplugins.PluginInfo) (interface{}, error) {
-				return csi.NewClient(info.ConnectionInfo.SocketPath)
+				return csi.NewClient(info.ConnectionInfo.SocketPath, logger.Named("csi_client").With("plugin.name", info.Name, "plugin.type", "controller"))
 			},
 			dynamicplugins.PluginTypeCSINode: func(info *dynamicplugins.PluginInfo) (interface{}, error) {
-				return csi.NewClient(info.ConnectionInfo.SocketPath)
+				return csi.NewClient(info.ConnectionInfo.SocketPath, logger.Named("csi_client").With("plugin.name", info.Name, "plugin.type", "client"))
 			},
 		}),
 	}

--- a/client/pluginmanager/csimanager/instance.go
+++ b/client/pluginmanager/csimanager/instance.go
@@ -50,7 +50,7 @@ func newInstanceManager(logger hclog.Logger, updater UpdateNodeCSIInfoFunc, p *d
 }
 
 func (i *instanceManager) run() {
-	c, err := csi.NewClient(i.info.ConnectionInfo.SocketPath)
+	c, err := csi.NewClient(i.info.ConnectionInfo.SocketPath, i.logger.Named("csi_client").With("plugin.name", i.info.Name, "plugin.type", i.info.Type))
 	if err != nil {
 		i.logger.Error("failed to setup instance manager client", "error", err)
 		close(i.shutdownCh)

--- a/helper/grpc-middleware/logging/client_interceptors.go
+++ b/helper/grpc-middleware/logging/client_interceptors.go
@@ -1,0 +1,42 @@
+package logging
+
+import (
+	"context"
+	"path"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+// UnaryClientInterceptor returns a new unary client interceptor that logs the execution of gRPC calls.
+func UnaryClientInterceptor(logger hclog.Logger, opts ...Option) grpc.UnaryClientInterceptor {
+	o := evaluateClientOpt(opts)
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		startTime := time.Now()
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		emitClientLog(logger, o, method, startTime, err, "finished client unary call")
+		return err
+	}
+}
+
+// StreamClientInterceptor returns a new streaming client interceptor that logs the execution of gRPC calls.
+func StreamClientInterceptor(logger hclog.Logger, opts ...Option) grpc.StreamClientInterceptor {
+	o := evaluateClientOpt(opts)
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		startTime := time.Now()
+		clientStream, err := streamer(ctx, desc, cc, method, opts...)
+		emitClientLog(logger, o, method, startTime, err, "finished client streaming call")
+		return clientStream, err
+	}
+}
+
+func emitClientLog(logger hclog.Logger, o *options, fullMethodString string, startTime time.Time, err error, msg string) {
+	code := status.Code(err)
+	logLevel := o.levelFunc(code)
+	reqDuration := time.Now().Sub(startTime)
+	service := path.Dir(fullMethodString)[1:]
+	method := path.Base(fullMethodString)
+	logger.Log(logLevel, msg, "grpc.code", code, "duration", reqDuration, "grpc.service", service, "grpc.method", method)
+}

--- a/helper/grpc-middleware/logging/options.go
+++ b/helper/grpc-middleware/logging/options.go
@@ -1,0 +1,89 @@
+package logging
+
+import (
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc/codes"
+)
+
+type options struct {
+	levelFunc CodeToLevel
+}
+
+var defaultOptions = &options{}
+
+type Option func(*options)
+
+func evaluateClientOpt(opts []Option) *options {
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultCodeToLevel
+	for _, o := range opts {
+		o(optCopy)
+	}
+	return optCopy
+}
+
+func WithStatusCodeToLevelFunc(fn CodeToLevel) Option {
+	return func(opts *options) {
+		opts.levelFunc = fn
+	}
+}
+
+// CodeToLevel function defines the mapping between gRPC return codes and hclog level.
+type CodeToLevel func(code codes.Code) hclog.Level
+
+func DefaultCodeToLevel(code codes.Code) hclog.Level {
+	switch code {
+	// Trace Logs -- Useful for Nomad developers but not necessarily always wanted
+	case codes.OK:
+		return hclog.Trace
+
+	// Debug logs
+	case codes.Canceled:
+		return hclog.Debug
+	case codes.InvalidArgument:
+		return hclog.Debug
+	case codes.ResourceExhausted:
+		return hclog.Debug
+	case codes.FailedPrecondition:
+		return hclog.Debug
+	case codes.Aborted:
+		return hclog.Debug
+	case codes.OutOfRange:
+		return hclog.Debug
+	case codes.NotFound:
+		return hclog.Debug
+	case codes.AlreadyExists:
+		return hclog.Debug
+
+	// Info Logs - More curious/interesting than debug, but not necessarily critical
+	case codes.Unknown:
+		return hclog.Info
+	case codes.DeadlineExceeded:
+		return hclog.Info
+	case codes.PermissionDenied:
+		return hclog.Info
+	case codes.Unauthenticated:
+		// unauthenticated requests are probably usually fine?
+		return hclog.Info
+	case codes.Unavailable:
+		// unavailable errors indicate the upstream is not currently available. Info
+		// because I would guess these are usually transient and will be handled by
+		// retry mechanisms before being served as a higher level warning.
+		return hclog.Info
+
+	// Warn Logs - These are almost definitely bad in most cases - usually because
+	//             the upstream is broken.
+	case codes.Unimplemented:
+		return hclog.Warn
+	case codes.Internal:
+		return hclog.Warn
+	case codes.DataLoss:
+		return hclog.Warn
+
+	default:
+		// Codes that aren't implemented as part of a CodeToLevel case are probably
+		// unknown and should be surfaced.
+		return hclog.Info
+	}
+}

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -95,6 +95,9 @@ type Logger interface {
 	// Args are alternating key, val pairs
 	// keys must be strings
 	// vals can be any type, but display is implementation specific
+	// Emit a message and key/value pairs at a provided log level
+	Log(level Level, msg string, args ...interface{})
+
 	// Emit a message and key/value pairs at the TRACE level
 	Trace(msg string, args ...interface{})
 

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -15,6 +15,8 @@ func NewNullLogger() Logger {
 
 type nullLogger struct{}
 
+func (l *nullLogger) Log(level Level, msg string, args ...interface{}) {}
+
 func (l *nullLogger) Trace(msg string, args ...interface{}) {}
 
 func (l *nullLogger) Debug(msg string, args ...interface{}) {}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -233,7 +233,7 @@
 		{"path":"github.com/hashicorp/go-envparse","checksumSHA1":"FKmqR4DC3nCXtnT9pe02z5CLNWo=","revision":"310ca1881b22af3522e3a8638c0b426629886196","revisionTime":"2018-01-19T21:58:41Z"},
 		{"path":"github.com/hashicorp/go-getter","checksumSHA1":"d4brua17AGQqMNtngK4xKOUwboY=","revision":"f5101da0117392c6e7960c934f05a2fd689a5b5f","revisionTime":"2019-08-22T19:45:07Z"},
 		{"path":"github.com/hashicorp/go-getter/helper/url","checksumSHA1":"9J+kDr29yDrwsdu2ULzewmqGjpA=","revision":"b345bfcec894fb7ff3fdf9b21baf2f56ea423d98","revisionTime":"2018-04-10T17:49:45Z"},
-		{"path":"github.com/hashicorp/go-hclog","checksumSHA1":"p0y3e3+Oj9GJXM/OW3ISDXap5+w=","revision":"e8a977f5d6b14a15e6672edf8b1d6cd545388c7a","revisionTime":"2019-12-18T17:30:18Z","version":"v0.10.1","versionExact":"v0.10.1"},
+		{"path":"github.com/hashicorp/go-hclog","checksumSHA1":"tNgHh706sto5/99XYD5jIuBDqa8=","revision":"0e86804c9e4bede0738cbbc370e705ef82580e7e","revisionTime":"2020-01-11T00:06:39Z","version":"v0.11.0","versionExact":"v0.11.0"},
 		{"path":"github.com/hashicorp/go-immutable-radix","checksumSHA1":"Cas2nprG6pWzf05A2F/OlnjUu2Y=","revision":"8aac2701530899b64bdea735a1de8da899815220","revisionTime":"2017-07-25T22:12:15Z"},
 		{"path":"github.com/hashicorp/go-memdb","checksumSHA1":"FMAvwDar2bQyYAW4XMFhAt0J5xA=","revision":"20ff6434c1cc49b80963d45bf5c6aa89c78d8d57","revisionTime":"2017-08-31T20:15:40Z"},
 		{"path":"github.com/hashicorp/go-msgpack/codec","checksumSHA1":"CKGYNUDKre3Z2g4hHNVfp5nTcfA=","revision":"23165f7bc3c2dda1891434ebb9da1511a7bafc1c","revisionTime":"2019-09-27T12:33:13Z","version":"upstream-08f7b40","versionExact":"upstream-08f7b40"},


### PR DESCRIPTION
This PR sets up some initial middleware for providing logging to gRPC Clients in Nomad. Initially, it decorates the completion log lines with some simple metadata:

- `grpc.service` the gRPC Service that is being targeted (e.g `csi.v1.Node`)
- `grpc.method` the gPRC Method that is being called on the service (e.g `NodeGetCapabilities`)
- `grpc.code` the gRPC Status Code that was returned by the server
- `duration` the duration of the gRPC Request

It also uses configurable options to set the function that will convert a gRPC Response Code to a logging level, which allows us to surface failure to logs easily for debugging Nomad installations.

An example of the initial uses output in a success case is here:

```
2020-01-13T13:15:01.919+0100 [TRACE] client.csi-hostpath.csi_client: finished client unary call: plugin.name=csi-hostpath plugin.type=csi-controller grpc.code=OK duration=935.764µs grpc.service=csi.v1.Identity grpc.method=Probe
2020-01-13T13:15:01.921+0100 [TRACE] client.csi-hostpath.csi_client: finished client unary call: plugin.name=csi-hostpath plugin.type=csi-controller grpc.code=OK duration=2.014818ms grpc.service=csi.v1.Controller grpc.method=ControllerGetCapabilities
2020-01-13T13:15:01.922+0100 [TRACE] client.csi-hostpath.csi_client: finished client unary call: plugin.name=csi-hostpath plugin.type=csi-node grpc.code=OK duration=737.259µs grpc.service=csi.v1.Identity grpc.method=Probe
2020-01-13T13:15:01.924+0100 [TRACE] client.csi-hostpath.csi_client: finished client unary call: plugin.name=csi-hostpath plugin.type=csi-node grpc.code=OK duration=1.648892ms grpc.service=csi.v1.Node grpc.method=NodeGetCapabilities
```