### PR TITLE
scheduler: allow configuring default preemption for system scheduler

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -322,6 +322,13 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		return nil, fmt.Errorf("server_service_name must be set when auto_advertise is enabled")
 	}
 
+	// handle system scheduler preemption default
+	if agentConfig.Server.SystemSchedulerPreemptionEnabledDefault != nil {
+		conf.SystemSchedulerPreemptionEnabledDefault = *agentConfig.Server.SystemSchedulerPreemptionEnabledDefault
+	} else {
+		conf.SystemSchedulerPreemptionEnabledDefault = true
+	}
+
 	// Add the Consul and Vault configs
 	conf.ConsulConfig = agentConfig.Consul
 	conf.VaultConfig = agentConfig.Vault

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -323,10 +323,8 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	}
 
 	// handle system scheduler preemption default
-	if agentConfig.Server.SystemSchedulerPreemptionEnabledDefault != nil {
-		conf.SystemSchedulerPreemptionEnabledDefault = *agentConfig.Server.SystemSchedulerPreemptionEnabledDefault
-	} else {
-		conf.SystemSchedulerPreemptionEnabledDefault = true
+	if agentConfig.Server.DefaultSchedulerConfig != nil {
+		conf.DefaultSchedulerConfig = *agentConfig.Server.DefaultSchedulerConfig
 	}
 
 	// Add the Consul and Vault configs

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -444,6 +444,9 @@ type ServerConfig struct {
 	// ServerJoin contains information that is used to attempt to join servers
 	ServerJoin *ServerJoin `hcl:"server_join"`
 
+	// SystemSchedulerPreemptionEnabledDefault is used to determin whether to enable system preemption by default in a new cluster
+	SystemSchedulerPreemptionEnabledDefault *bool `hcl:"system_scheduler_preemption_enabled_default"`
+
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -444,8 +444,10 @@ type ServerConfig struct {
 	// ServerJoin contains information that is used to attempt to join servers
 	ServerJoin *ServerJoin `hcl:"server_join"`
 
-	// SystemSchedulerPreemptionEnabledDefault is used to determin whether to enable system preemption by default in a new cluster
-	SystemSchedulerPreemptionEnabledDefault *bool `hcl:"system_scheduler_preemption_enabled_default"`
+	// DefaultSchedulerConfig configures the initial scheduler config to be persisted in Raft.
+	// Once the cluster is bootstrapped, and Raft persists the config (from here or through API),
+	// This value is ignored.
+	DefaultSchedulerConfig *structs.SchedulerConfiguration `hcl:"default_scheduler_config"`
 
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
@@ -1338,6 +1340,11 @@ func (a *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 	}
 	if b.ServerJoin != nil {
 		result.ServerJoin = result.ServerJoin.Merge(b.ServerJoin)
+	}
+
+	if b.DefaultSchedulerConfig != nil {
+		c := *b.DefaultSchedulerConfig
+		result.DefaultSchedulerConfig = &c
 	}
 
 	// Add the schedulers

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -305,6 +305,9 @@ type Config struct {
 	// dead servers.
 	AutopilotInterval time.Duration
 
+	// SystemSchedulerPreemptionEnabledDefault is used to determin whether to enable system preemption by default in a new cluster
+	SystemSchedulerPreemptionEnabledDefault bool
+
 	// PluginLoader is used to load plugins.
 	PluginLoader loader.PluginCatalog
 
@@ -377,8 +380,9 @@ func DefaultConfig() *Config {
 			MaxTrailingLogs:         250,
 			ServerStabilizationTime: 10 * time.Second,
 		},
-		ServerHealthInterval: 2 * time.Second,
-		AutopilotInterval:    10 * time.Second,
+		ServerHealthInterval:                    2 * time.Second,
+		AutopilotInterval:                       10 * time.Second,
+		SystemSchedulerPreemptionEnabledDefault: true,
 	}
 
 	// Enable all known schedulers by default

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -305,8 +305,10 @@ type Config struct {
 	// dead servers.
 	AutopilotInterval time.Duration
 
-	// SystemSchedulerPreemptionEnabledDefault is used to determin whether to enable system preemption by default in a new cluster
-	SystemSchedulerPreemptionEnabledDefault bool
+	// DefaultSchedulerConfig configures the initial scheduler config to be persisted in Raft.
+	// Once the cluster is bootstrapped, and Raft persists the config (from here or through API),
+	// This value is ignored.
+	DefaultSchedulerConfig structs.SchedulerConfiguration `hcl:"default_scheduler_config"`
 
 	// PluginLoader is used to load plugins.
 	PluginLoader loader.PluginCatalog
@@ -380,9 +382,15 @@ func DefaultConfig() *Config {
 			MaxTrailingLogs:         250,
 			ServerStabilizationTime: 10 * time.Second,
 		},
-		ServerHealthInterval:                    2 * time.Second,
-		AutopilotInterval:                       10 * time.Second,
-		SystemSchedulerPreemptionEnabledDefault: true,
+		ServerHealthInterval: 2 * time.Second,
+		AutopilotInterval:    10 * time.Second,
+		DefaultSchedulerConfig: structs.SchedulerConfiguration{
+			PreemptionConfig: structs.PreemptionConfig{
+				SystemSchedulerEnabled:  true,
+				BatchSchedulerEnabled:   false,
+				ServiceSchedulerEnabled: false,
+			},
+		},
 	}
 
 	// Enable all known schedulers by default

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -45,12 +45,14 @@ var minAutopilotVersion = version.Must(version.NewVersion("0.8.0"))
 var minSchedulerConfigVersion = version.Must(version.NewVersion("0.9.0"))
 
 // Default configuration for scheduler with preemption enabled for system jobs
-var defaultSchedulerConfig = &structs.SchedulerConfiguration{
-	PreemptionConfig: structs.PreemptionConfig{
-		SystemSchedulerEnabled:  true,
-		BatchSchedulerEnabled:   false,
-		ServiceSchedulerEnabled: false,
-	},
+func (s *Server) defaultSchedulerConfig() structs.SchedulerConfiguration {
+	return structs.SchedulerConfiguration{
+		PreemptionConfig: structs.PreemptionConfig{
+			SystemSchedulerEnabled:  s.config.SystemSchedulerPreemptionEnabledDefault,
+			BatchSchedulerEnabled:   false,
+			ServiceSchedulerEnabled: false,
+		},
+	}
 }
 
 // monitorLeadership is used to monitor if we acquire or lose our role
@@ -1319,7 +1321,7 @@ func (s *Server) getOrCreateSchedulerConfig() *structs.SchedulerConfiguration {
 		return nil
 	}
 
-	req := structs.SchedulerSetConfigRequest{Config: *defaultSchedulerConfig}
+	req := structs.SchedulerSetConfigRequest{Config: s.defaultSchedulerConfig()}
 	if _, _, err = s.raftApply(structs.SchedulerConfigRequestType, req); err != nil {
 		s.logger.Named("core").Error("failed to initialize config", "error", err)
 		return nil

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -44,17 +44,6 @@ var minAutopilotVersion = version.Must(version.NewVersion("0.8.0"))
 
 var minSchedulerConfigVersion = version.Must(version.NewVersion("0.9.0"))
 
-// Default configuration for scheduler with preemption enabled for system jobs
-func (s *Server) defaultSchedulerConfig() structs.SchedulerConfiguration {
-	return structs.SchedulerConfiguration{
-		PreemptionConfig: structs.PreemptionConfig{
-			SystemSchedulerEnabled:  s.config.SystemSchedulerPreemptionEnabledDefault,
-			BatchSchedulerEnabled:   false,
-			ServiceSchedulerEnabled: false,
-		},
-	}
-}
-
 // monitorLeadership is used to monitor if we acquire or lose our role
 // as the leader in the Raft cluster. There is some work the leader is
 // expected to do, so we must react to changes
@@ -1321,7 +1310,7 @@ func (s *Server) getOrCreateSchedulerConfig() *structs.SchedulerConfiguration {
 		return nil
 	}
 
-	req := structs.SchedulerSetConfigRequest{Config: s.defaultSchedulerConfig()}
+	req := structs.SchedulerSetConfigRequest{Config: s.config.DefaultSchedulerConfig}
 	if _, _, err = s.raftApply(structs.SchedulerConfigRequestType, req); err != nil {
 		s.logger.Named("core").Error("failed to initialize config", "error", err)
 		return nil

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -124,7 +124,7 @@ type AutopilotConfig struct {
 type SchedulerConfiguration struct {
 	// PreemptionConfig specifies whether to enable eviction of lower
 	// priority jobs to place higher priority jobs.
-	PreemptionConfig PreemptionConfig
+	PreemptionConfig PreemptionConfig `hcl:"preemption_config"`
 
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
@@ -152,13 +152,13 @@ type SchedulerSetConfigurationResponse struct {
 // PreemptionConfig specifies whether preemption is enabled based on scheduler type
 type PreemptionConfig struct {
 	// SystemSchedulerEnabled specifies if preemption is enabled for system jobs
-	SystemSchedulerEnabled bool
+	SystemSchedulerEnabled bool `hcl:"system_scheduler_enabled"`
 
 	// BatchSchedulerEnabled specifies if preemption is enabled for batch jobs
-	BatchSchedulerEnabled bool
+	BatchSchedulerEnabled bool `hcl:"batch_scheduler_enabled"`
 
 	// ServiceSchedulerEnabled specifies if preemption is enabled for service jobs
-	ServiceSchedulerEnabled bool
+	ServiceSchedulerEnabled bool `hcl:"service_Scheduler_enabled"`
 }
 
 // SchedulerSetConfigRequest is used by the Operator endpoint to update the


### PR DESCRIPTION
Some operators want a greater control over when preemption is enabled,
especially during an upgrade to limit potential side-effects.

However, I lean towards exposing it as a general flag.  The preemption code is relatively new and had few panic bugs (e.g. #6792 and #5794), so it's understandable that operators would like to control its enablement more.  Additional, current server config parameters[1] have many esoteric knobs, and I suspect this flag passes that threshold.  Granted, disabling preemption can lead to surprising behavior (e.g. system jobs not running on every node), and operators should be warned in our docs/guides.  I'm open for alternative views.

[1] https://www.nomadproject.io/docs/configuration/server.html#server-parameters