### PR TITLE
e2e: improve reusability of provisioning scripts

### DIFF
--- a/e2e/terraform/shared/config/core-site.xml
+++ b/e2e/terraform/shared/config/core-site.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
-<configuration>
-    <property>
-        <name>fs.defaultFS</name>
-        <value>hdfs://hdfs.service.consul/</value>
-    </property>
-</configuration>

--- a/e2e/terraform/shared/config/provision-client.sh
+++ b/e2e/terraform/shared/config/provision-client.sh
@@ -3,15 +3,6 @@
 set -o errexit
 set -o nounset
 
-CONFIGDIR=/ops/shared/config
-
-HADOOP_VERSION=hadoop-2.7.7
-HADOOPCONFIGDIR=/usr/local/$HADOOP_VERSION/etc/hadoop
-HOME_DIR=ubuntu
-
-IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetPrivateIP')
-DOCKER_BRIDGE_IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetInterfaceIP "docker0"')
-
 CLOUD="$1"
 NOMAD_SHA="$2"
 NOMAD_CONFIG="$3"
@@ -25,31 +16,18 @@ sudo cp "$CONSUL_SRC/retry_$CLOUD.json" "$CONSUL_DEST/"
 sudo cp "$CONSUL_SRC/consul_$CLOUD.service" /etc/systemd/system/consul.service
 
 sudo systemctl enable consul.service
-sudo systemctl start  consul.service
+sudo systemctl daemon-reload
+sudo systemctl restart consul.service
 sleep 10
 
 # Add hostname to /etc/hosts
 echo "127.0.0.1 $(hostname)" | sudo tee --append /etc/hosts
 
 # Add Docker bridge network IP to /etc/resolv.conf (at the top)
+DOCKER_BRIDGE_IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetInterfaceIP "docker0"')
 echo "nameserver $DOCKER_BRIDGE_IP_ADDRESS" | sudo tee /etc/resolv.conf.new
 cat /etc/resolv.conf | sudo tee --append /etc/resolv.conf.new
 sudo mv /etc/resolv.conf.new /etc/resolv.conf
-
-# Hadoop config file to enable HDFS CLI
-sudo cp $CONFIGDIR/core-site.xml $HADOOPCONFIGDIR
-
-# Move examples directory to $HOME
-sudo mv /ops/examples /home/$HOME_DIR
-sudo chown -R $HOME_DIR:$HOME_DIR /home/$HOME_DIR/examples
-sudo chmod -R 775 /home/$HOME_DIR/examples
-
-# Set env vars for tool CLIs
-echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre"  | sudo tee --append /home/$HOME_DIR/.bashrc
-
-# Update PATH
-echo "export PATH=$PATH:/usr/local/bin/spark/bin:/usr/local/$HADOOP_VERSION/bin" | sudo tee --append /home/$HOME_DIR/.bashrc
 
 # Nomad
 
@@ -79,5 +57,7 @@ wget -q -O - \
 
 # enable as a systemd service
 sudo cp "$NOMAD_SRC/nomad.service" /etc/systemd/system/nomad.service
+
 sudo systemctl enable nomad.service
-sudo systemctl start nomad.service
+sudo systemctl daemon-reload
+sudo systemctl restart nomad.service

--- a/e2e/terraform/shared/config/provision-server.sh
+++ b/e2e/terraform/shared/config/provision-server.sh
@@ -3,15 +3,6 @@
 set -o errexit
 set -o nounset
 
-CONFIGDIR=/ops/shared/config
-
-HADOOP_VERSION=hadoop-2.7.7
-HADOOPCONFIGDIR=/usr/local/$HADOOP_VERSION/etc/hadoop
-HOME_DIR=ubuntu
-
-IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetPrivateIP')
-DOCKER_BRIDGE_IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetInterfaceIP "docker0"')
-
 CLOUD="$1"
 SERVER_COUNT="$2"
 NOMAD_SHA="$3"
@@ -28,10 +19,9 @@ sudo cp "$CONSUL_SRC/retry_$CLOUD.json" "$CONSUL_DEST/"
 sudo cp "$CONSUL_SRC/consul_$CLOUD.service" /etc/systemd/system/consul.service
 
 sudo systemctl enable consul.service
-sudo systemctl start  consul.service
+sudo systemctl daemon-reload
+sudo systemctl restart consul.service
 sleep 10
-export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500
-export CONSUL_RPC_ADDR=$IP_ADDRESS:8400
 
 # Vault
 VAULT_SRC=/ops/shared/vault
@@ -41,34 +31,17 @@ sudo cp "$VAULT_SRC/vault.hcl" "$VAULT_DEST"
 sudo cp "$VAULT_SRC/vault.service" /etc/systemd/system/vault.service
 
 sudo systemctl enable vault.service
-sudo systemctl start  vault.service
+sudo systemctl daemon-reload
+sudo systemctl restart vault.service
 
 # Add hostname to /etc/hosts
 echo "127.0.0.1 $(hostname)" | sudo tee --append /etc/hosts
 
 # Add Docker bridge network IP to /etc/resolv.conf (at the top)
-
+DOCKER_BRIDGE_IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetInterfaceIP "docker0"')
 echo "nameserver $DOCKER_BRIDGE_IP_ADDRESS" | sudo tee /etc/resolv.conf.new
 cat /etc/resolv.conf | sudo tee --append /etc/resolv.conf.new
 sudo mv /etc/resolv.conf.new /etc/resolv.conf
-
-# Hadoop
-sudo cp $CONFIGDIR/core-site.xml $HADOOPCONFIGDIR
-
-# Move examples directory to $HOME
-sudo mv /ops/examples /home/$HOME_DIR
-sudo chown -R $HOME_DIR:$HOME_DIR /home/$HOME_DIR/examples
-sudo chmod -R 775 /home/$HOME_DIR/examples
-
-# Set env vars for tool CLIs
-echo "export CONSUL_RPC_ADDR=$IP_ADDRESS:8400" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export VAULT_ADDR=http://$IP_ADDRESS:8200" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre"  | sudo tee --append /home/$HOME_DIR/.bashrc
-
-# Update PATH
-echo "export PATH=$PATH:/usr/local/bin/spark/bin:/usr/local/$HADOOP_VERSION/bin" | sudo tee --append /home/$HOME_DIR/.bashrc
 
 # Nomad
 
@@ -92,5 +65,7 @@ sudo mv "/tmp/$NOMAD_CONFIG_FILENAME" "$NOMAD_DEST/$NOMAD_CONFIG_FILENAME"
 
 # enable as a systemd service
 sudo cp "$NOMAD_SRC/nomad.service" /etc/systemd/system/nomad.service
+
 sudo systemctl enable nomad.service
-sudo systemctl start nomad.service
+sudo systemctl daemon-reload
+sudo systemctl restart nomad.service


### PR DESCRIPTION
This changeset is part of the work to improve our E2E provisioning process to allow our upgrade tests:
* Move more of the setup into the AMI image creation so it's a little more obvious to provisioning config authors which bits are essential to deploying a specific version of Nomad.
* Make the service file update do a systemd daemon-reload so that we can update an already-running cluster with the same script we use to deploy it initially.