### PR TITLE
e2e: Terraform updates to support framework deploys

### DIFF
--- a/e2e/terraform/compute.tf
+++ b/e2e/terraform/compute.tf
@@ -14,33 +14,6 @@ resource "aws_instance" "server" {
   }
 
   iam_instance_profile = aws_iam_instance_profile.instance_profile.name
-
-  # copy up all provisioning scripts and configs
-  provisioner "file" {
-    source      = "shared/"
-    destination = "/ops/shared"
-
-    connection {
-      host        = coalesce(self.public_ip, self.private_ip)
-      type        = "ssh"
-      user        = "ubuntu"
-      private_key = module.keys.private_key_pem
-    }
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "chmod +x /ops/shared/config/provision-server.sh",
-      "/ops/shared/config/provision-server.sh aws ${var.server_count} '${var.nomad_sha}' '${var.indexed == false ? "server.hcl" : "indexed/server-${count.index}.hcl"}'",
-    ]
-
-    connection {
-      host        = coalesce(self.public_ip, self.private_ip)
-      type        = "ssh"
-      user        = "ubuntu"
-      private_key = module.keys.private_key_pem
-    }
-  }
 }
 
 resource "aws_instance" "client_linux" {
@@ -67,45 +40,6 @@ resource "aws_instance" "client_linux" {
   }
 
   iam_instance_profile = aws_iam_instance_profile.instance_profile.name
-
-  # copy up all provisioning scripts and configs
-  provisioner "file" {
-    source      = "shared/"
-    destination = "/ops/shared"
-
-    connection {
-      host        = coalesce(self.public_ip, self.private_ip)
-      type        = "ssh"
-      user        = "ubuntu"
-      private_key = module.keys.private_key_pem
-    }
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "chmod +x /ops/shared/config/provision-client.sh",
-      "/ops/shared/config/provision-client.sh aws '${var.nomad_sha}' '${var.indexed == false ? "client.hcl" : "indexed/client-${count.index}.hcl"}'",
-    ]
-
-    connection {
-      host        = coalesce(self.public_ip, self.private_ip)
-      type        = "ssh"
-      user        = "ubuntu"
-      private_key = module.keys.private_key_pem
-    }
-  }
-}
-data "template_file" "user_data_client_windows" {
-  template = file("${path.root}/shared/config/userdata-windows.ps1")
-  vars = {
-    nomad_sha = var.nomad_sha
-  }
-}
-
-data "archive_file" "windows_configs" {
-  type        = "zip"
-  source_dir  = "./shared"
-  output_path = "./windows_configs.zip"
 }
 
 resource "aws_instance" "client_windows" {
@@ -115,12 +49,14 @@ resource "aws_instance" "client_windows" {
   vpc_security_group_ids = [aws_security_group.primary.id]
   count                  = var.windows_client_count
   depends_on             = [aws_instance.server]
-  iam_instance_profile   = "${aws_iam_instance_profile.instance_profile.name}"
+  iam_instance_profile   = aws_iam_instance_profile.instance_profile.name
 
   # Instance tags
   tags = {
     Name           = "${local.random_name}-client-windows-${count.index}"
     ConsulAutoJoin = "auto-join"
+    SHA            = var.nomad_sha
+    User           = data.aws_caller_identity.current.arn
   }
 
   ebs_block_device {
@@ -132,34 +68,6 @@ resource "aws_instance" "client_windows" {
 
   # We need this userdata script because Windows machines don't
   # configure ssh with cloud-init by default.
-  user_data = data.template_file.user_data_client_windows.rendered
-
-  # Note:
-  # we're copying up all the provisioning scripts and configs as
-  # a zipped bundle because TF's file provisioner dies in the middle
-  # of pushing up multiple files (whereas 'scp -r' works fine).
-  #
-  # We're also running all the provisioning scripts inside the
-  # userdata by polling for the zip file to show up. (Gross!)
-  # This is because remote-exec provisioners are failing on Windows
-  # with the same symptoms as:
-  # https://github.com/hashicorp/terraform/issues/17728
-  #
-  # If we can't fix this, it'll prevent us from having multiple
-  # Windows clients running until TF supports count interpolation
-  # in the template_file, which is planned for a later 0.12 release
-  #
-  provisioner "file" {
-    source      = "./windows_configs.zip"
-    destination = "C:/ops/windows_configs.zip"
-
-    connection {
-      host        = coalesce(self.public_ip, self.private_ip)
-      type        = "ssh"
-      user        = "Administrator"
-      private_key = module.keys.private_key_pem
-      timeout     = "10m"
-    }
-  }
+  user_data = file("${path.root}/shared/config/userdata-windows.ps1")
 
 }

--- a/e2e/terraform/provisioning.tf
+++ b/e2e/terraform/provisioning.tf
@@ -1,0 +1,93 @@
+# outputs used for E2E testing and provisioning
+
+output "environment" {
+  description = "get connection config by running: $(terraform output environment)"
+  value       = <<EOM
+export NOMAD_ADDR=http://${aws_instance.server[0].public_ip}:4646
+export CONSUL_HTTP_ADDR=http://${aws_instance.server[0].public_ip}:8500
+export NOMAD_E2E=1
+EOM
+}
+
+output "provisioning" {
+  description = "output to a file to be use w/ E2E framework -provision.terraform"
+  value = jsonencode(
+    {
+      "servers" : [for server in aws_instance.server.* :
+        {
+          "runner" : {
+            "key" : abspath(module.keys.private_key_filepath),
+            "user" : "ubuntu",
+            "host" : "${server.public_ip}",
+            "port" : 22
+          },
+          "deployment" : {
+            "nomad_sha" : var.nomad_sha,
+            "platform" : "linux_amd64",
+            "remote_binary_path" : "/usr/local/bin/nomad",
+            "bundles" : [
+              {
+                "source" : abspath("./shared"),
+                "destination" : "/ops/shared"
+              }
+            ],
+            "steps" : [
+              "sudo chmod +x /ops/shared/config/provision-server.sh",
+              "sudo /ops/shared/config/provision-server.sh aws ${var.server_count} 'indexed/server-${index(aws_instance.server, server)}.hcl'"
+            ],
+          }
+        }
+      ],
+      "clients" : concat([for client in aws_instance.client_linux.* :
+        {
+          "runner" : {
+            "key" : abspath(module.keys.private_key_filepath),
+            "user" : "ubuntu",
+            "host" : "${client.public_ip}",
+            "port" : 22
+          },
+          "deployment" : {
+            "nomad_sha" : var.nomad_sha,
+            "platform" : "linux_amd64",
+            "remote_binary_path" : "/usr/local/bin/nomad",
+            "bundles" : [
+              {
+                "source" : abspath("./shared"),
+                "destination" : "/ops/shared"
+              }
+            ],
+            "steps" : [
+              "sudo chmod +x /ops/shared/config/provision-client.sh",
+              "sudo /ops/shared/config/provision-client.sh aws 'indexed/client-${index(aws_instance.client_linux, client)}.hcl'"
+            ],
+          }
+        }
+        ],
+        [for client in aws_instance.client_windows.* :
+          {
+            "runner" : {
+              "key" : abspath(module.keys.private_key_filepath),
+              "user" : "Administrator",
+              "host" : "${client.public_ip}",
+              "port" : 22
+            },
+            "deployment" : {
+              "nomad_sha" : var.nomad_sha,
+              "platform" : "windows_amd64",
+              # need to use the / here for golang filepath handling to work
+              # on the Unix test runner environment
+              "remote_binary_path" : "C:/opt/nomad.exe",
+              "bundles" : [
+                {
+                  "source" : abspath("./shared"),
+                  "destination" : "C:/ops/shared"
+                }
+              ],
+              "steps" : [
+                "& C:\\ops\\shared\\config\\provision-windows-client.ps1 -Cloud aws -Index 1"
+              ]
+            }
+          }
+      ])
+  })
+}

--- a/e2e/terraform/shared/config/provision-client.sh
+++ b/e2e/terraform/shared/config/provision-client.sh
@@ -4,8 +4,7 @@ set -o errexit
 set -o nounset
 
 CLOUD="$1"
-NOMAD_SHA="$2"
-NOMAD_CONFIG="$3"
+NOMAD_CONFIG="$2"
 
 # Consul
 CONSUL_SRC=/ops/shared/consul
@@ -35,19 +34,17 @@ NOMAD_SRC=/ops/shared/nomad
 NOMAD_DEST=/etc/nomad.d
 NOMAD_CONFIG_FILENAME=$(basename "$NOMAD_CONFIG")
 
-# download
-aws s3 cp "s3://nomad-team-test-binary/builds-oss/nomad_linux_amd64_${NOMAD_SHA}.tar.gz" nomad.tar.gz
-
-# unpack and install
-sudo tar -zxvf nomad.tar.gz -C /usr/local/bin/
-sudo chmod 0755 /usr/local/bin/nomad
-sudo chown root:root /usr/local/bin/nomad
+# assert Nomad binary's permissions
+if [[ -f /usr/local/bin/nomad ]]; then
+    sudo chmod 0755 /usr/local/bin/nomad
+    sudo chown root:root /usr/local/bin/nomad
+fi
 
 sudo cp "$NOMAD_SRC/base.hcl" "$NOMAD_DEST/"
 sudo cp "$NOMAD_SRC/$NOMAD_CONFIG" "$NOMAD_DEST/$NOMAD_CONFIG_FILENAME"
 
 # Setup Host Volumes
-sudo mkdir /tmp/data
+sudo mkdir -p /tmp/data
 
 # Install CNI plugins
 sudo mkdir -p /opt/cni/bin

--- a/e2e/terraform/shared/config/provision-server.sh
+++ b/e2e/terraform/shared/config/provision-server.sh
@@ -5,8 +5,7 @@ set -o nounset
 
 CLOUD="$1"
 SERVER_COUNT="$2"
-NOMAD_SHA="$3"
-NOMAD_CONFIG="$4"
+NOMAD_CONFIG="$3"
 
 # Consul
 CONSUL_SRC=/ops/shared/consul
@@ -49,13 +48,11 @@ NOMAD_SRC=/ops/shared/nomad
 NOMAD_DEST=/etc/nomad.d
 NOMAD_CONFIG_FILENAME=$(basename "$NOMAD_CONFIG")
 
-# download
-aws s3 cp "s3://nomad-team-test-binary/builds-oss/nomad_linux_amd64_${NOMAD_SHA}.tar.gz" nomad.tar.gz
-
-# unpack and install
-sudo tar -zxvf nomad.tar.gz -C /usr/local/bin/
-sudo chmod 0755 /usr/local/bin/nomad
-sudo chown root:root /usr/local/bin/nomad
+# assert Nomad binary's permissions
+if [[ -f /usr/local/bin/nomad ]]; then
+    sudo chmod 0755 /usr/local/bin/nomad
+    sudo chown root:root /usr/local/bin/nomad
+fi
 
 sudo cp "$NOMAD_SRC/base.hcl" "$NOMAD_DEST/"
 

--- a/e2e/terraform/shared/config/provision-windows-client.ps1
+++ b/e2e/terraform/shared/config/provision-windows-client.ps1
@@ -1,6 +1,5 @@
 param(
     [string]$Cloud = "aws",
-    [string]$NomadSha = "",
     [string]$Index=0
 )
 
@@ -8,45 +7,49 @@ param(
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 # Consul
-cp "C:\ops\shared\consul\base.json" "C:\opt\consul.d\base.json"
-cp "C:\ops\shared\consul\retry_$Cloud.json" "C:\opt\consul.d\retry_$Cloud.json"
-sc.exe create "Consul" binPath= "C:\opt\consul.exe agent -config-dir C:\opt\consul.d -log-file C:\opt\consul\consul.log" start= auto
-sc.exe start "Consul"
+Copy-Item -Force `
+  -Path "C:\ops\shared\consul\base.json" `
+  -Destination "C:\opt\consul.d\base.json"
+Copy-Item -Force `
+  -Path "C:\ops\shared\consul\retry_$Cloud.json" `
+  -Destination "C:\opt\consul.d\retry_$Cloud.json"
+New-Service `
+  -Name "Consul" `
+  -BinaryPathName "C:\opt\consul.exe agent -config-dir C:\opt\consul.d -log-file C:\opt\consul\consul.log" `
+  -StartupType "Automatic" `
+  -ErrorAction Ignore
+Start-Service "Consul"
 
 # Vault
 # TODO(tgross): we don't need Vault for clients
 # cp "C:\ops\shared\vault\vault.hcl" C:\opt\vault.d\vault.hcl
 # sc.exe create "Vault" binPath= "C:\opt\vault.exe" agent -config-dir "C:\opt\vault.d" start= auto
 
-# Nomad
-
-md C:\opt\nomad
-
-Read-S3Object `
-  -BucketName nomad-team-test-binary `
-  -Key "builds-oss/nomad_windows_amd64_$NomadSha.zip" `
-  -File .\nomad.zip
-
-Expand-Archive .\nomad.zip .\
-rm C:\opt\nomad.exe
-mv .\pkg\windows_amd64\nomad.exe C:\opt\nomad.exe
-
 # install config file
-cp "C:\ops\shared\nomad\client-windows.hcl" "C:\opt\nomad.d\nomad.hcl"
+New-Item -ItemType "directory" -Path "C:\opt\nomad" -Force
+Copy-Item "C:\ops\shared\nomad\client-windows.hcl" `
+  -Destination "C:\opt\nomad.d\nomad.hcl" -Force
 
 # Setup Host Volumes
-md C:\tmp\data
+New-Item -ItemType "directory" -Path "C:\tmp\data" -Force
 
 # TODO(tgross): not sure we even support this for Windows?
 # Write-Output "Install CNI"
 # md C:\opt\cni\bin
 # $cni_url = "https://github.com/containernetworking/plugins/releases/download/v0.8.4/cni-plugins-windows-amd64-v0.8.4.tgz"
 # Invoke-WebRequest -Uri "$cni_url" -Outfile cni.tgz
-# Expand-7Zip -ArchiveFileName .\cni.tgz -TargetPath C:\opt\cni\bin\
+# Expand-7Zip -ArchiveFileName .\cni.tgz -TargetPath C:\opt\cni\bin\ -Force
 
 # needed for metrics scraping HTTP API calls to the client
 New-NetFirewallRule -DisplayName 'Nomad HTTP Inbound' -Profile @('Public', 'Domain', 'Private') -Direction Inbound -Action Allow -Protocol TCP -LocalPort @('4646')
 
-# enable as a service
-sc.exe create "Nomad" binPath= "C:\opt\nomad.exe agent -config C:\opt\nomad.d" start= auto
-sc.exe start "Nomad"
+# idempotently enable as a service
+New-Service `
+  -Name "Nomad" `
+  -BinaryPathName "C:\opt\nomad.exe agent -config C:\opt\nomad.d" `
+  -StartupType "Automatic" `
+  -ErrorAction Ignore
+
+Start-Service "Nomad"
+
+Write-Output "Nomad started!"

--- a/e2e/terraform/shared/config/userdata-windows.ps1
+++ b/e2e/terraform/shared/config/userdata-windows.ps1
@@ -20,11 +20,4 @@ icacls $adminKey /inheritance:r
 icacls $adminKey /grant BUILTIN\Administrators:`(F`)
 icacls $adminKey /grant SYSTEM:`(F`)
 
-$archiveFile = "C:\ops\windows_configs.zip"
-while (!(Test-Path $archiveFile)) { Start-Sleep 10 }
-
-Expand-Archive $archiveFile "C:\ops\shared"
-
-& C:\ops\shared\config\provision-windows-client.ps1 -Cloud aws -NomadSha ${nomad_sha} -Index 1
-
 </powershell>


### PR DESCRIPTION
The e2e framework instantiates clients for Nomad/Consul but the provisioning of the actual Nomad cluster is left to Terraform. The Terraform provisioning process uses `remote-exec` to deploy specific versions of Nomad so that we don't have to bake an AMI every time we want to test a new version. But Terraform treats the resulting instances as immutable, so we can't use the same tooling to update the version of Nomad in-place. This is a prerequisite for upgrade testing.

This changeset:
* provides Terraform output that written to JSON used by the framework to configure provisioning via `terraform output provisioning` (consumed by #6949)
* provides Terraform output that can be used by test operators to configure their shell via `$(terraform output environment)`
* drops `remote-exec` provisioning steps from Terraform
* makes changes to the deployment scripts to ensure they can be run multiple times w/ different versions against the same host.