### PR TITLE
Upgrade to using golang 1.12.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.13
+    - GOLANG_VERSION: 1.12.15
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -86,7 +86,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.13
+    - GOLANG_VERSION: 1.12.15
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -162,7 +162,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.13
+    - GOLANG_VERSION: 1.12.15
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -238,7 +238,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.13
+    - GOLANG_VERSION: 1.12.15
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -314,7 +314,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.13
+    - GOLANG_VERSION: 1.12.15
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -413,7 +413,7 @@ jobs:
         name: Ember tests
   lint-go:
     docker:
-    - image: golang:1.12.13
+    - image: golang:1.12.15
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout
@@ -471,7 +471,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.13
+    - GOLANG_VERSION: 1.12.15
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -543,7 +543,7 @@ jobs:
         path: /tmp/test-reports
   test-devices:
     docker:
-    - image: golang:1.12.13
+    - image: golang:1.12.15
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -610,7 +610,7 @@ jobs:
         command: make test-website
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.13
+    - GOLANG_VERSION: 1.12.15
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -622,7 +622,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.13
+    - GOLANG_VERSION: 1.12.15
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -694,7 +694,7 @@ jobs:
         path: /tmp/test-reports
   build-binaries:
     docker:
-    - image: golang:1.12.13
+    - image: golang:1.12.15
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -727,7 +727,7 @@ jobs:
         path: pkg/linux_amd64.zip
   test-e2e:
     docker:
-    - image: golang:1.12.13
+    - image: golang:1.12.15
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout
@@ -758,7 +758,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.13
+    - GOLANG_VERSION: 1.12.15
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml

--- a/.circleci/config/config.yml
+++ b/.circleci/config/config.yml
@@ -21,7 +21,7 @@ executors:
   go:
     working_directory: /go/src/github.com/hashicorp/nomad
     docker:
-      - image: golang:1.12.13
+      - image: golang:1.12.15
     environment:
       <<: *common_envs
       GOPATH: /go
@@ -33,7 +33,7 @@ executors:
     environment: &machine_env
       <<: *common_envs
       GOPATH: /home/circleci/go
-      GOLANG_VERSION: "1.12.13"
+      GOLANG_VERSION: 1.12.15
 
   # uses a more recent image with unattended upgrades disabled properly
   # but seems to break docker builds

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Who Uses Nomad
 Contributing to Nomad
 --------------------
 
-If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.12.13+ is *required*, and `gcc-go` is not supported).
+If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.12.15+ is *required*, and `gcc-go` is not supported).
 
 See the [`contributing`](contributing/) directory for more developer documentation.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   # install the go version used for cutting a release
   - cmd: |
       mkdir c:\go
-      appveyor DownloadFile "https://dl.google.com/go/go1.12.13.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
+      appveyor DownloadFile "https://dl.google.com/go/go1.12.15.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
       
   - ps: Expand-Archive $Env:TEMP\go.zip -DestinationPath C:\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
       cd %APPVEYOR_BUILD_FOLDER%
       rmdir /Q/S C:\go
 
-  # install go 1.12.13 to match version used for cutting a release
+  # install the go version used for cutting a release
   - cmd: |
       mkdir c:\go
       appveyor DownloadFile "https://dl.google.com/go/go1.12.13.windows-amd64.zip" -FileName "%TEMP%\\go.zip"

--- a/scripts/release/mac-remote-build
+++ b/scripts/release/mac-remote-build
@@ -56,7 +56,7 @@ REPO_PATH="${TMP_WORKSPACE}/gopath/src/github.com/hashicorp/nomad"
 mkdir -p "${TMP_WORKSPACE}/tmp"
 
 install_go() {
-  local go_version="1.12.13"
+  local go_version="1.12.15"
   local download=
 
   download="https://storage.googleapis.com/golang/go${go_version}.darwin-amd64.tar.gz"

--- a/scripts/update_golang_version.sh
+++ b/scripts/update_golang_version.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+golang_version="$1"
+
+current_version=$(grep -o -e 'golang:[.0-9]*' .circleci/config.yml | head -n1 | cut -d: -f2)
+
+# To support both GNU and BSD sed, the regex is looser than it needs to be.
+# Specifically, we use "* instead of "?, which relies on GNU extension without much loss of
+sed -i'' -e "s|golang:[.0-9]*|golang:${golang_version}|g" \
+       	.circleci/config/config.yml .circleci/config.yml
+sed -i'' -e "s|GOLANG_VERSION:[ \"]*[.0-9]*\"*|GOLANG_VERSION: ${golang_version}|g" \
+	.circleci/config/config.yml .circleci/config.yml
+
+sed -i'' -e "s|\\(golang.org.*version\\) [.0-9]*|\\1 ${golang_version}|g" \
+	README.md
+
+sed -i'' -e "s|go[.0-9]*.windows-amd64.zip|go${golang_version}.windows-amd64.zip|g" \
+	appveyor.yml
+
+sed -i'' -e "s|go_version=\"*[^\"]*\"*$|go_version=\"${golang_version}\"|g" \
+	scripts/vagrant-linux-priv-go.sh scripts/release/mac-remote-build
+
+# check if there is any remaining references to old versions
+if git grep -I --fixed-strings "${current_version}" | grep -v -e CHANGELOG.md -e vendor/
+then
+	echo "  ^^ files contain references to old golang version" >&2
+	echo "  update script and run again" >&2
+	exit 1
+fi

--- a/scripts/update_golang_version.sh
+++ b/scripts/update_golang_version.sh
@@ -6,6 +6,7 @@ current_version=$(grep -o -e 'golang:[.0-9]*' .circleci/config.yml | head -n1 | 
 
 # To support both GNU and BSD sed, the regex is looser than it needs to be.
 # Specifically, we use "* instead of "?, which relies on GNU extension without much loss of
+# correctness in practice.
 sed -i'' -e "s|golang:[.0-9]*|golang:${golang_version}|g" \
        	.circleci/config/config.yml .circleci/config.yml
 sed -i'' -e "s|GOLANG_VERSION:[ \"]*[.0-9]*\"*|GOLANG_VERSION: ${golang_version}|g" \

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function install_go() {
-	local go_version=1.12.13
+	local go_version="1.12.15"
 	local download=
 
 	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"


### PR DESCRIPTION
Also, add a script to ease updating the golang version we use.  It's a bit hacky but better than manually chasing down version references.

The changes are mostly bug fixes and seem safe:

> go1.12.14 (released 2019/12/04) includes a fix to the runtime. See the [Go 1.12.14 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.12.14+label%3ACherryPickApproved) on our issue tracker for details.
>
> go1.12.15 (released 2020/01/09) includes fixes to the runtime and the net/http package. See the [Go 1.12.15 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.12.15+label%3ACherryPickApproved) on our issue tracker for details.
From https://golang.org/doc/devel/release.html#go1.12.minor
