### PR TITLE
Potential fixes for flapping leadership

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -148,16 +148,18 @@ RECONCILE:
 	// updates
 	reconcileCh = s.reconcileCh
 
+WAIT:
 	// Poll the stop channel to give it priority so we don't waste time
 	// trying to perform the other operations if we have been asked to shut
 	// down.
 	select {
 	case <-stopCh:
 		return
+	case <-s.shutdownCh:
+		return
 	default:
 	}
 
-WAIT:
 	// Wait until leadership is lost
 	for {
 		select {

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1234,8 +1234,8 @@ func (s *Server) setupRaft() error {
 		}
 	}
 
-	// Setup the leader channel
-	leaderCh := make(chan bool, 1)
+	// Set up a channel for reliable leader notifications.
+	leaderCh := make(chan bool, 10)
 	s.config.RaftConfig.NotifyCh = leaderCh
 	s.leaderCh = leaderCh
 


### PR DESCRIPTION
This PR attempts to pick up some issues found in https://github.com/hashicorp/nomad/issues/4749 .  Issue 4749 has some other issues, but this addresses one of the problems associated with leadership flapping.

In particular, this PR addresses two issues:

First, if a non-leader is promoted but then immediately loses leadership, don't bother establishing it and attempting Barrier raft transactions.  By using a buffered channel, before establishing leadership, we peek into rest of channel to see lost it before attempting to establish leadership.  This should only occur when leadership is flapping while `leaderLoop` is running/shutting down.

Second, this fixes a condition where we may reattempt to reconcile and establish leadership even after we lost raft leadership.

Consider the case where a step down occurs during the leaderLoop Barrier call and/or it times out.  The Barrier call times out after 2m by default, but reconcile interval defaults to 1m.  Thus, both `<-stopCh` and `<-interval` clauses are ready in the `WAIT` select statement.  Golang may arbitrary chose one, resulting into potentially unnecessary Barrier call.

Here, we prioritize honoring `stopCh` and ensure we return early if Barrier or reconciliation fails.

