### PR TITLE
e2e: use valid jobspec for group check test

### DIFF
--- a/e2e/consul/input/checks_group.nomad
+++ b/e2e/consul/input/checks_group.nomad
@@ -51,7 +51,7 @@ job "group_check" {
         interval = "2s"
         timeout  = "2s"
         command  = "cat"
-        args     = ["${NOMAD_TASK_DIR}/alive-2b"]
+        args     = ["alive-2b"]
       }
     }
 


### PR DESCRIPTION
Group service checks cannot interpolate task fields, because the task fields are not available at the time the script check hook is created for the group service. When f31482a was merged this e2e test began failing because we are now correctly matching the script check ID to the service ID, which revealed this jobspec was invalid.