### PR TITLE
Fix: Docs Node Eligibility header

### DIFF
--- a/website/source/docs/commands/node/eligibility.html.md.erb
+++ b/website/source/docs/commands/node/eligibility.html.md.erb
@@ -44,7 +44,7 @@ operation is desired.
 
 <%= partial "docs/commands/_general_options" %>
 
-## Drain Options
+## Eligibility Options
 
 - `-enable`: Enable scheduling eligibility.
 - `-disable`: Disable scheduling eligibility.


### PR DESCRIPTION
probably Eligibility docs were Copy pasted from the Drain docs, and one of the headers remained as is