### PR TITLE
e2e: ensure group script check tests interpolation

### DIFF
--- a/e2e/consul/input/checks_group.nomad
+++ b/e2e/consul/input/checks_group.nomad
@@ -51,7 +51,7 @@ job "group_check" {
         interval = "2s"
         timeout  = "2s"
         command  = "cat"
-        args     = ["alive-2b"]
+        args     = ["/tmp/${NOMAD_ALLOC_ID}-alive-2b"]
       }
     }
 

--- a/e2e/consul/script_checks.go
+++ b/e2e/consul/script_checks.go
@@ -50,7 +50,7 @@ func (tc *ScriptChecksE2ETest) TestGroupScriptCheck(f *framework.F) {
 
 	// Check in warning state becomes healthy after check passes
 	_, _, err := exec(nomadClient, allocs,
-		[]string{"/bin/sh", "-c", "touch ${NOMAD_TASK_DIR}/alive-2b"})
+		[]string{"/bin/sh", "-c", "touch /tmp/${NOMAD_ALLOC_ID}-alive-2b"})
 	require.NoError(err)
 	e2eutil.RequireConsulStatus(require, consulClient, "group-service-2", capi.HealthPassing)
 


### PR DESCRIPTION
Fixes a bug introduced in 0aa58b9 (#6967) where we're writing a test file to a taskdir-interpolated location, which works when we `alloc exec` but not in the jobspec for a group script check.

This changeset also makes the test safe to run multiple times by namespacing the file with the alloc ID, which has the added bonus of exercising our alloc interpolation code for group script checks.

---

@shoenig I'm not sure how this slipped through in the previous PR (I probably tested, made a "trivial" change, and then didn't run the test again 😊 ), but I've run this against a new E2E cluster and got passing tests now:

```
▶ go test -v ./e2e -run 'TestE2E/Consul/\*consul\.ScriptChecksE2ETest/TestGroup'
=== RUN   TestE2E
=== RUN   TestE2E/Consul
=== RUN   TestE2E/Consul/*consul.ScriptChecksE2ETest
=== RUN   TestE2E/Consul/*consul.ScriptChecksE2ETest/TestGroupScriptCheck
=== RUN   TestE2E/Consul_Template
--- PASS: TestE2E (38.22s)
    --- PASS: TestE2E/Consul (38.12s)
        --- PASS: TestE2E/Consul/*consul.ScriptChecksE2ETest (37.96s)
            --- PASS: TestE2E/Consul/*consul.ScriptChecksE2ETest/TestGroupScriptCheck (37.78s)
    --- PASS: TestE2E/Consul_Template (0.09s)
PASS
ok      github.com/hashicorp/nomad/e2e  39.487s
```