### PR TITLE
keep placed canaries aligned in raft store

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3569,6 +3569,7 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 		alloc.DeploymentStatus.ModifyIndex = index
 	}
 
+
 	// Create a copy of the deployment object
 	deploymentCopy := deployment.Copy()
 	deploymentCopy.ModifyIndex = index
@@ -3577,6 +3578,21 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 	state.PlacedAllocs += placed
 	state.HealthyAllocs += healthy
 	state.UnhealthyAllocs += unhealthy
+
+	// Ensure PlacedCanaries accurately reflects the alloc canary status
+	if alloc.DeploymentStatus != nil {
+		if alloc.DeploymentStatus.Canary {
+			found := false
+			for _, canary := range state.PlacedCanaries {
+				if alloc.ID == canary {
+					found = true
+				}
+			}
+			if !found {
+				state.PlacedCanaries = append(state.PlacedCanaries, alloc.ID)
+			}
+		}
+	}
 
 	// Update the progress deadline
 	if pd := state.ProgressDeadline; pd != 0 {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3569,7 +3569,6 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 		alloc.DeploymentStatus.ModifyIndex = index
 	}
 
-
 	// Create a copy of the deployment object
 	deploymentCopy := deployment.Copy()
 	deploymentCopy.ModifyIndex = index
@@ -3580,17 +3579,16 @@ func (s *StateStore) updateDeploymentWithAlloc(index uint64, alloc, existing *st
 	state.UnhealthyAllocs += unhealthy
 
 	// Ensure PlacedCanaries accurately reflects the alloc canary status
-	if alloc.DeploymentStatus != nil {
-		if alloc.DeploymentStatus.Canary {
-			found := false
-			for _, canary := range state.PlacedCanaries {
-				if alloc.ID == canary {
-					found = true
-				}
+	if alloc.DeploymentStatus != nil && alloc.DeploymentStatus.Canary {
+		found := false
+		for _, canary := range state.PlacedCanaries {
+			if alloc.ID == canary {
+				found = true
+				break
 			}
-			if !found {
-				state.PlacedCanaries = append(state.PlacedCanaries, alloc.ID)
-			}
+		}
+		if !found {
+			state.PlacedCanaries = append(state.PlacedCanaries, alloc.ID)
 		}
 	}
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -6382,6 +6382,109 @@ func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_Nonexistent(t *testing.
 	}
 }
 
+// Test that a deployments PlacedCanaries is properly updated
+func TestStateStore_UpsertDeploymentAlloc_Canaries(t *testing.T) {
+	t.Parallel()
+
+	state := testStateStore(t)
+
+	// Create a deployment
+	d1 := mock.Deployment()
+	require.NoError(t, state.UpsertDeployment(2, d1))
+
+	// Create a Job
+	job := mock.Job()
+	require.NoError(t, state.UpsertJob(3, job))
+
+	// Create alloc with canary status
+	a := mock.Alloc()
+	a.JobID = job.ID
+	a.DeploymentID = d1.ID
+	a.DeploymentStatus = &structs.AllocDeploymentStatus{
+		Healthy: helper.BoolToPtr(false),
+		Canary:  true,
+	}
+	require.NoError(t, state.UpsertAllocs(4, []*structs.Allocation{a}))
+
+	// Pull the deployment from state
+	ws := memdb.NewWatchSet()
+	deploy, err := state.DeploymentByID(ws, d1.ID)
+	require.NoError(t, err)
+
+	// Ensure that PlacedCanaries is accurate
+	require.Equal(t, 1, len(deploy.TaskGroups[job.TaskGroups[0].Name].PlacedCanaries))
+
+	// Create alloc without canary status
+	b := mock.Alloc()
+	b.JobID = job.ID
+	b.DeploymentID = d1.ID
+	b.DeploymentStatus = &structs.AllocDeploymentStatus{
+		Healthy: helper.BoolToPtr(false),
+		Canary:  false,
+	}
+	require.NoError(t, state.UpsertAllocs(4, []*structs.Allocation{b}))
+
+	// Pull the deployment from state
+	ws = memdb.NewWatchSet()
+	deploy, err = state.DeploymentByID(ws, d1.ID)
+	require.NoError(t, err)
+
+	// Ensure that PlacedCanaries is accurate
+	require.Equal(t, 1, len(deploy.TaskGroups[job.TaskGroups[0].Name].PlacedCanaries))
+
+	// Create a second deployment
+	d2 := mock.Deployment()
+	require.NoError(t, state.UpsertDeployment(5, d2))
+
+	c := mock.Alloc()
+	c.JobID = job.ID
+	c.DeploymentID = d2.ID
+	c.DeploymentStatus = &structs.AllocDeploymentStatus{
+		Healthy: helper.BoolToPtr(false),
+		Canary:  true,
+	}
+	require.NoError(t, state.UpsertAllocs(6, []*structs.Allocation{c}))
+
+	ws = memdb.NewWatchSet()
+	deploy2, err := state.DeploymentByID(ws, d2.ID)
+	require.NoError(t, err)
+
+	// Ensure that PlacedCanaries is accurate
+	require.Equal(t, 1, len(deploy2.TaskGroups[job.TaskGroups[0].Name].PlacedCanaries))
+}
+
+func TestStateStore_UpsertDeploymentAlloc_NoCanaries(t *testing.T) {
+	t.Parallel()
+
+	state := testStateStore(t)
+
+	// Create a deployment
+	d1 := mock.Deployment()
+	require.NoError(t, state.UpsertDeployment(2, d1))
+
+	// Create a Job
+	job := mock.Job()
+	require.NoError(t, state.UpsertJob(3, job))
+
+	// Create alloc with canary status
+	a := mock.Alloc()
+	a.JobID = job.ID
+	a.DeploymentID = d1.ID
+	a.DeploymentStatus = &structs.AllocDeploymentStatus{
+		Healthy: helper.BoolToPtr(true),
+		Canary:  false,
+	}
+	require.NoError(t, state.UpsertAllocs(4, []*structs.Allocation{a}))
+
+	// Pull the deployment from state
+	ws := memdb.NewWatchSet()
+	deploy, err := state.DeploymentByID(ws, d1.ID)
+	require.NoError(t, err)
+
+	// Ensure that PlacedCanaries is accurate
+	require.Equal(t, 0, len(deploy.TaskGroups[job.TaskGroups[0].Name].PlacedCanaries))
+}
+
 // Test that allocation health can't be set for an alloc with mismatched
 // deployment ids
 func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_MismatchDeployment(t *testing.T) {

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -529,10 +529,6 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 				// If we are placing a canary and we found a match, add the canary
 				// to the deployment state object and mark it as a canary.
 				if missing.Canary() && s.deployment != nil {
-					if state, ok := s.deployment.TaskGroups[tg.Name]; ok {
-						state.PlacedCanaries = append(state.PlacedCanaries, alloc.ID)
-					}
-
 					alloc.DeploymentStatus = &structs.AllocDeploymentStatus{
 						Canary: true,
 					}


### PR DESCRIPTION
Nomad state store must be modified through raft; `DeploymentState.PlacedCanaries` is currently [modified in-place](https://github.com/hashicorp/nomad/blob/master/scheduler/generic_sched.go#L532-L534) which masked a bug in single node clusters, but made evaluations in other nodes unaware of the true state of Canaries during a deployment.

This change reconciles the state of `PlacedCanaries` when committing deployment/alloc updates to raft instead of modifying local state of a specific scheduler.

fixes #6936 
fixes #6864