### PR TITLE
Handle Nomad leadership flapping (attempt 2)

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -103,14 +103,14 @@ func (s *Server) monitorLeadership() {
 				// Raft transitions that haven't been applied to the FSM
 				// yet.
 				// Ensure that that FSM caught up and eval queues are refreshed
-				s.logger.Error("cluster leadership flapped, lost and gained leadership immediately.  Leadership flaps indicate a cluster wide problems (e.g. networking).")
+				s.logger.Warn("cluster leadership lost and gained leadership immediately.  Could indicate network issues, memory paging, or high CPU load.")
 
 				leaderStep(false)
 				leaderStep(true)
 			} else {
 				// Server gained but lost leadership immediately
 				// before it reacted; nothing to do, move on
-				s.logger.Error("cluster leadership flapped, gained and lost leadership immediately.  Leadership flaps indicate a cluster wide problems (e.g. networking).")
+				s.logger.Warn("cluster leadership gained and lost leadership immediately.  Could indicate network issues, memory paging, or high CPU load.")
 			}
 		case <-s.shutdownCh:
 			return

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -61,8 +61,7 @@ func (s *Server) monitorLeadership() {
 	var leaderLoop sync.WaitGroup
 
 	leaderStep := func(isLeader bool) {
-		switch {
-		case isLeader:
+		if isLeader {
 			if weAreLeaderCh != nil {
 				s.logger.Error("attempted to start the leader loop while running")
 				return
@@ -75,19 +74,19 @@ func (s *Server) monitorLeadership() {
 				s.leaderLoop(ch)
 			}(weAreLeaderCh)
 			s.logger.Info("cluster leadership acquired")
-
-		default:
-			if weAreLeaderCh == nil {
-				s.logger.Error("attempted to stop the leader loop while not running")
-				return
-			}
-
-			s.logger.Debug("shutting down leader loop")
-			close(weAreLeaderCh)
-			leaderLoop.Wait()
-			weAreLeaderCh = nil
-			s.logger.Info("cluster leadership lost")
+			return
 		}
+
+		if weAreLeaderCh == nil {
+			s.logger.Error("attempted to stop the leader loop while not running")
+			return
+		}
+
+		s.logger.Debug("shutting down leader loop")
+		close(weAreLeaderCh)
+		leaderLoop.Wait()
+		weAreLeaderCh = nil
+		s.logger.Info("cluster leadership lost")
 	}
 
 	wasLeader := false

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1234,10 +1234,10 @@ func (s *Server) setupRaft() error {
 		}
 	}
 
-	// Setup the leader channel
+	// Setup the leader channel; that keeps the latest leadership alone
 	leaderCh := make(chan bool, 1)
 	s.config.RaftConfig.NotifyCh = leaderCh
-	s.leaderCh = leaderCh
+	s.leaderCh = dropButLastChannel(leaderCh, s.shutdownCh)
 
 	// Setup the Raft store
 	s.raft, err = raft.NewRaft(s.config.RaftConfig, s.fsm, log, stable, snap, trans)

--- a/nomad/util_test.go
+++ b/nomad/util_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -257,4 +258,75 @@ func TestMaxUint64(t *testing.T) {
 	if maxUint64(2, 1) != 2 {
 		t.Fatalf("bad")
 	}
+}
+
+func TestDropButLastChannelDropsValues(t *testing.T) {
+	sourceCh := make(chan bool)
+	shutdownCh := make(chan struct{})
+
+	dstCh := dropButLastChannel(sourceCh, shutdownCh)
+
+	// timeout duration for any channel propagation delay
+	timeoutDuration := 5 * time.Millisecond
+
+	// test that dstCh doesn't emit anything initially
+	select {
+	case <-dstCh:
+		require.Fail(t, "received a message unexpectedly")
+	case <-time.After(timeoutDuration):
+		// yay no message - it could have been a default: but
+		// checking for goroutine effect
+	}
+
+	sourceCh <- false
+	select {
+	case v := <-dstCh:
+		require.False(t, v, "unexpected value from dstCh Ch")
+	case <-time.After(timeoutDuration):
+		require.Fail(t, "timed out waiting for source->dstCh propagation")
+	}
+
+	// channel is drained now
+	select {
+	case v := <-dstCh:
+		require.Failf(t, "received a message unexpectedly", "value: %v", v)
+	case <-time.After(timeoutDuration):
+		// yay no message - it could have been a default: but
+		// checking for goroutine effect
+	}
+
+	// now enqueue many messages and ensure only last one is received
+	// enqueueing should be fast!
+	sourceCh <- false
+	sourceCh <- false
+	sourceCh <- false
+	sourceCh <- false
+	sourceCh <- true
+
+	// I suspect that dstCh may contain a stale (i.e. `false`) value if golang executes
+	// this select before the implementation goroutine dequeues last value.
+	//
+	// However, never got it to fail in test - so leaving it now to see if it ever fails;
+	// and if/when test fails, we can learn of how much of an issue it is and adjust
+	select {
+	case v := <-dstCh:
+		require.True(t, v, "unexpected value from dstCh Ch")
+	case <-time.After(timeoutDuration):
+		require.Fail(t, "timed out waiting for source->dstCh propagation")
+	}
+
+	sourceCh <- true
+	sourceCh <- true
+	sourceCh <- true
+	sourceCh <- true
+	sourceCh <- true
+	sourceCh <- false
+	select {
+	case v := <-dstCh:
+		require.False(t, v, "unexpected value from dstCh Ch")
+	case <-time.After(timeoutDuration):
+		require.Fail(t, "timed out waiting for source->dstCh propagation")
+	}
+
+	close(shutdownCh)
 }

--- a/nomad/util_test.go
+++ b/nomad/util_test.go
@@ -379,3 +379,55 @@ RECEIVE_LOOP:
 	require.Equal(t, 1, receivedFalse)
 	require.LessOrEqual(t, receivedTrue, sentMessages-1)
 }
+
+// TestDropButLastChannel_DeliversMessages_Close asserts that last
+// message is always delivered, some messages are dropped but never
+// introduce new messages, even with a closed signal.
+func TestDropButLastChannel_DeliversMessages_Close(t *testing.T) {
+	sourceCh := make(chan bool)
+	shutdownCh := make(chan struct{})
+
+	dstCh := dropButLastChannel(sourceCh, shutdownCh)
+
+	// timeout duration for any channel propagation delay
+	timeoutDuration := 5 * time.Millisecond
+
+	sentMessages := 100
+	go func() {
+		for i := 0; i < sentMessages-1; i++ {
+			sourceCh <- true
+		}
+		sourceCh <- false
+		close(sourceCh)
+	}()
+
+	receivedTrue, receivedFalse := 0, 0
+	var lastReceived *bool
+
+RECEIVE_LOOP:
+	for {
+		select {
+		case v, ok := <-dstCh:
+			if !ok {
+				break RECEIVE_LOOP
+			}
+			lastReceived = &v
+			if v {
+				receivedTrue++
+			} else {
+				receivedFalse++
+			}
+
+		case <-time.After(timeoutDuration):
+			require.Fail(t, "timed out while waiting for messages")
+		}
+	}
+
+	t.Logf("receiver got %v out %v true messages, and %v out of %v false messages",
+		receivedTrue, sentMessages-1, receivedFalse, 1)
+
+	require.NotNil(t, lastReceived)
+	require.False(t, *lastReceived)
+	require.Equal(t, 1, receivedFalse)
+	require.LessOrEqual(t, receivedTrue, sentMessages-1)
+}

--- a/nomad/util_test.go
+++ b/nomad/util_test.go
@@ -263,6 +263,7 @@ func TestMaxUint64(t *testing.T) {
 func TestDropButLastChannelDropsValues(t *testing.T) {
 	sourceCh := make(chan bool)
 	shutdownCh := make(chan struct{})
+	defer close(shutdownCh)
 
 	dstCh := dropButLastChannel(sourceCh, shutdownCh)
 
@@ -327,8 +328,6 @@ func TestDropButLastChannelDropsValues(t *testing.T) {
 	case <-time.After(timeoutDuration):
 		require.Fail(t, "timed out waiting for source->dstCh propagation")
 	}
-
-	close(shutdownCh)
 }
 
 // TestDropButLastChannel_DeliversMessages asserts that last
@@ -338,6 +337,7 @@ func TestDropButLastChannelDropsValues(t *testing.T) {
 func TestDropButLastChannel_DeliversMessages(t *testing.T) {
 	sourceCh := make(chan bool)
 	shutdownCh := make(chan struct{})
+	defer close(shutdownCh)
 
 	dstCh := dropButLastChannel(sourceCh, shutdownCh)
 
@@ -386,6 +386,7 @@ RECEIVE_LOOP:
 func TestDropButLastChannel_DeliversMessages_Close(t *testing.T) {
 	sourceCh := make(chan bool)
 	shutdownCh := make(chan struct{})
+	defer close(shutdownCh)
 
 	dstCh := dropButLastChannel(sourceCh, shutdownCh)
 


### PR DESCRIPTION
Another attempt at https://github.com/hashicorp/nomad/pull/6951 .

Fixes a deadlock in leadership handling if leadership flapped.

## Context
Raft propagates leadership transition to Nomad through a NotifyCh channel.  Raft blocks when writing to this channel, so channel must be buffered or aggressively consumed[1]. Otherwise, Raft blocks indefinitely in `raft.runLeader` until the channel is consumed[1] and does not move on to executing follower related logic (in `raft.runFollower`).

While Raft `runLeader` defer function blocks, raft cannot process any other raft operations.  For example, `run{Leader|Follower}` methods consume `raft.applyCh`, and while runLeader defer is blocked, all raft log applications or config lookup will block indefinitely.

Sadly, `leaderLoop` and `establishLeader` makes few Raft calls!  `establishLeader` attempts to auto-create autopilot/scheduler config [3]; and `leaderLoop` attempts to check raft configuration [4].  All of these calls occur without a timeout.

Thus, if leadership flapped quickly while `leaderLoop/establishLeadership` is invoked and hit any of these Raft calls, Raft handler _deadlock_ forever.

The above explains some of the observations in https://github.com/hashicorp/nomad/issues/4749 ; though I'm not fully sure I can explain the some of the yamux goroutines - and will follow up there.

## Approach

This PR introduces a a helper channel that effectively proxies NotifyCh but drops all but the last value in leadership notification.  If raft leadership flaps multiple times, while we attempt to gain or drop leadership, we would only make the step once.  One edge case is highlighted when we step down but gain leadership again.

## Follow up PRs:

Consul had a similar issue in https://github.com/hashicorp/consul/issues/6852 .  I chose a slightly different fix from simply increasing the buffered channel.

We should follow up with few changes related to leadership that Consul introduced:
* Upgrade to latest Raft with configuration change: https://github.com/hashicorp/raft/pull/379
* Port https://github.com/hashicorp/consul/pull/5247 to nomad

Additionally, ideally `establishLeadership` needs to be fast so Nomad could be fast and we shouldn't attempt to make a Raft apply log transactions there.  autopilot/scheduler might make more sense as a watcher for Serf membership changes rather than on leadership changes, e.g. we should create a scheduler config when all servers can honor the log which may happen without a leadership transition (e.g. when last follower upgrades).

[1] https://github.com/hashicorp/raft/blob/d90d6d6bdacf1b35d66940b07be515b074d89e88/config.go#L190-L193
[2] https://github.com/hashicorp/raft/blob/d90d6d6bdacf1b35d66940b07be515b074d89e88/raft.go#L425-L436
[3] https://github.com/hashicorp/nomad/blob/2a89e477465adbe6a88987f0dcb9fe80145d7b2f/nomad/leader.go#L198-L202
[4] https://github.com/hashicorp/nomad/blob/2a89e477465adbe6a88987f0dcb9fe80145d7b2f/nomad/leader.go#L877