### PR TITLE
csi: NodeStageVolume RPC implementation

### DIFF
--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -296,3 +296,33 @@ func (c *client) NodeGetInfo(ctx context.Context) (*NodeGetInfoResponse, error) 
 
 	return result, nil
 }
+
+func (c *client) NodeStageVolume(ctx context.Context, volumeID string, publishContext map[string]string, stagingTargetPath string, capabilities *VolumeCapability) error {
+	if c == nil {
+		return fmt.Errorf("Client not initialized")
+	}
+	if c.nodeClient == nil {
+		return fmt.Errorf("Client not initialized")
+	}
+
+	// These errors should not be returned during production use but exist as aids
+	// during Nomad Development
+	if volumeID == "" {
+		return fmt.Errorf("missing volumeID")
+	}
+	if stagingTargetPath == "" {
+		return fmt.Errorf("missing stagingTargetPath")
+	}
+
+	req := &csipbv1.NodeStageVolumeRequest{
+		VolumeId:          volumeID,
+		PublishContext:    publishContext,
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability:  capabilities.ToCSIRepresentation(),
+	}
+
+	// NodeStageVolume's response contains no extra data. If err == nil, we were
+	// successful.
+	_, err := c.nodeClient.NodeStageVolume(ctx, req)
+	return err
+}

--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -67,6 +67,8 @@ type CSIControllerClient interface {
 type CSINodeClient interface {
 	NodeGetCapabilities(ctx context.Context, in *csipbv1.NodeGetCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.NodeGetCapabilitiesResponse, error)
 	NodeGetInfo(ctx context.Context, in *csipbv1.NodeGetInfoRequest, opts ...grpc.CallOption) (*csipbv1.NodeGetInfoResponse, error)
+	NodeStageVolume(ctx context.Context, in *csipbv1.NodeStageVolumeRequest, opts ...grpc.CallOption) (*csipbv1.NodeStageVolumeResponse, error)
+	// NodeUnstageVolume(ctx context.Context, in *NodeUnstageVolumeRequest, opts ...grpc.CallOption) (*NodeUnstageVolumeResponse, error)
 }
 
 type client struct {

--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -408,3 +408,40 @@ func TestClient_RPC_ControllerPublishVolume(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_RPC_NodeStageVolume(t *testing.T) {
+	cases := []struct {
+		Name        string
+		ResponseErr error
+		Response    *csipbv1.NodeStageVolumeResponse
+		ExpectedErr error
+	}{
+		{
+			Name:        "handles underlying grpc errors",
+			ResponseErr: fmt.Errorf("some grpc error"),
+			ExpectedErr: fmt.Errorf("some grpc error"),
+		},
+		{
+			Name:        "handles success",
+			ResponseErr: nil,
+			ExpectedErr: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			_, _, nc, client := newTestClient()
+			defer client.Close()
+
+			nc.NextErr = c.ResponseErr
+			nc.NextStageVolumeResponse = c.Response
+
+			err := client.NodeStageVolume(context.TODO(), "foo", nil, "/foo", &VolumeCapability{})
+			if c.ExpectedErr != nil {
+				require.Error(t, c.ExpectedErr, err)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -50,6 +50,9 @@ type Client struct {
 	NextNodeGetInfoResponse *csi.NodeGetInfoResponse
 	NextNodeGetInfoErr      error
 	NodeGetInfoCallCount    int64
+
+	NextNodeStageVolumeErr   error
+	NodeStageVolumeCallCount int64
 }
 
 // PluginInfo describes the type and version of a plugin.
@@ -144,6 +147,18 @@ func (c *Client) NodeGetInfo(ctx context.Context) (*csi.NodeGetInfoResponse, err
 	c.NodeGetInfoCallCount++
 
 	return c.NextNodeGetInfoResponse, c.NextNodeGetInfoErr
+}
+
+// NodeStageVolume is used when a plugin has the STAGE_UNSTAGE volume capability
+// to prepare a volume for usage on a host. If err == nil, the response should
+// be assumed to be successful.
+func (c *Client) NodeStageVolume(ctx context.Context, volumeID string, publishContext map[string]string, stagingTargetPath string, capabilities *csi.VolumeCapability) error {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+
+	c.NodeStageVolumeCallCount++
+
+	return c.NextNodeStageVolumeErr
 }
 
 // Shutdown the client and ensure any connections are cleaned up.

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -2,6 +2,7 @@ package csi
 
 import (
 	"context"
+	"fmt"
 
 	csipbv1 "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/hashicorp/nomad/plugins/base"
@@ -157,4 +158,107 @@ func NewNodeCapabilitySet(resp *csipbv1.NodeGetCapabilitiesResponse) *NodeCapabi
 	}
 
 	return cs
+}
+
+// VolumeAccessMode represents the desired access mode of the CSI Volume
+type VolumeAccessMode csipbv1.VolumeCapability_AccessMode_Mode
+
+var _ fmt.Stringer = VolumeAccessModeUnknown
+
+var (
+	VolumeAccessModeUnknown               = VolumeAccessMode(csipbv1.VolumeCapability_AccessMode_UNKNOWN)
+	VolumeAccessModeSingleNodeWriter      = VolumeAccessMode(csipbv1.VolumeCapability_AccessMode_SINGLE_NODE_WRITER)
+	VolumeAccessModeSingleNodeReaderOnly  = VolumeAccessMode(csipbv1.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY)
+	VolumeAccessModeMultiNodeReaderOnly   = VolumeAccessMode(csipbv1.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY)
+	VolumeAccessModeMultiNodeSingleWriter = VolumeAccessMode(csipbv1.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER)
+	VolumeAccessModeMultiNodeMultiWriter  = VolumeAccessMode(csipbv1.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER)
+)
+
+func (a VolumeAccessMode) String() string {
+	return a.ToCSIRepresentation().String()
+}
+
+func (a VolumeAccessMode) ToCSIRepresentation() csipbv1.VolumeCapability_AccessMode_Mode {
+	return csipbv1.VolumeCapability_AccessMode_Mode(a)
+}
+
+// VolumeAccessType represents the filesystem apis that the user intends to use
+// with the volume. E.g whether it will be used as a block device or if they wish
+// to have a mounted filesystem.
+type VolumeAccessType int32
+
+var _ fmt.Stringer = VolumeAccessTypeBlock
+
+var (
+	VolumeAccessTypeBlock VolumeAccessType = 1
+	VolumeAccessTypeMount VolumeAccessType = 2
+)
+
+func (v VolumeAccessType) String() string {
+	if v == VolumeAccessTypeBlock {
+		return "VolumeAccessType.Block"
+	} else if v == VolumeAccessTypeMount {
+		return "VolumeAccessType.Mount"
+	} else {
+		return "VolumeAccessType.Unspecified"
+	}
+}
+
+// VolumeMountOptions contain optional additional configuration that can be used
+// when specifying that a Volume should be used with VolumeAccessTypeMount.
+type VolumeMountOptions struct {
+	// FSType is an optional field that allows an operator to specify the type
+	// of the filesystem.
+	FSType string
+
+	// MountFlags contains additional options that may be used when mounting the
+	// volume by the plugin. This may contain sensitive data and should not be
+	// leaked.
+	MountFlags []string
+}
+
+// VolumeMountOptions implements the Stringer and GoStringer interfaces to prevent
+// accidental leakage of sensitive mount flags via logs.
+var _ fmt.Stringer = &VolumeMountOptions{}
+var _ fmt.GoStringer = &VolumeMountOptions{}
+
+func (v *VolumeMountOptions) String() string {
+	mountFlagsString := "nil"
+	if len(v.MountFlags) != 0 {
+		mountFlagsString = "[REDACTED]"
+	}
+
+	return fmt.Sprintf("csi.VolumeMountOptions(FSType: %s, MountFlags: %s)", v.FSType, mountFlagsString)
+}
+
+func (v *VolumeMountOptions) GoString() string {
+	return v.String()
+}
+
+// VolumeCapability describes the overall usage requirements for a given CSI Volume
+type VolumeCapability struct {
+	AccessType         VolumeAccessType
+	AccessMode         VolumeAccessMode
+	VolumeMountOptions *VolumeMountOptions
+}
+
+func (c *VolumeCapability) ToCSIRepresentation() *csipbv1.VolumeCapability {
+	vc := &csipbv1.VolumeCapability{
+		AccessMode: &csipbv1.VolumeCapability_AccessMode{
+			Mode: c.AccessMode.ToCSIRepresentation(),
+		},
+	}
+
+	if c.AccessType == VolumeAccessTypeMount {
+		vc.AccessType = &csipbv1.VolumeCapability_Mount{
+			Mount: &csipbv1.VolumeCapability_MountVolume{
+				FsType:     c.VolumeMountOptions.FSType,
+				MountFlags: c.VolumeMountOptions.MountFlags,
+			},
+		}
+	} else {
+		vc.AccessType = &csipbv1.VolumeCapability_Block{Block: &csipbv1.VolumeCapability_BlockVolume{}}
+	}
+
+	return vc
 }

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -42,6 +42,11 @@ type CSIPlugin interface {
 	// respect to the SP.
 	NodeGetInfo(ctx context.Context) (*NodeGetInfoResponse, error)
 
+	// NodeStageVolume is used when a plugin has the STAGE_UNSTAGE volume capability
+	// to prepare a volume for usage on a host. If err == nil, the response should
+	// be assumed to be successful.
+	NodeStageVolume(ctx context.Context, volumeID string, publishContext map[string]string, stagingTargetPath string, capabilities *VolumeCapability) error
+
 	// Shutdown the client and ensure any connections are cleaned up.
 	Close() error
 }

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -83,6 +83,7 @@ type NodeClient struct {
 	NextErr                  error
 	NextCapabilitiesResponse *csipbv1.NodeGetCapabilitiesResponse
 	NextGetInfoResponse      *csipbv1.NodeGetInfoResponse
+	NextStageVolumeResponse  *csipbv1.NodeStageVolumeResponse
 }
 
 // NewNodeClient returns a new ControllerClient
@@ -102,4 +103,8 @@ func (c *NodeClient) NodeGetCapabilities(ctx context.Context, in *csipbv1.NodeGe
 
 func (c *NodeClient) NodeGetInfo(ctx context.Context, in *csipbv1.NodeGetInfoRequest, opts ...grpc.CallOption) (*csipbv1.NodeGetInfoResponse, error) {
 	return c.NextGetInfoResponse, c.NextErr
+}
+
+func (c *NodeClient) NodeStageVolume(ctx context.Context, in *csipbv1.NodeStageVolumeRequest, opts ...grpc.CallOption) (*csipbv1.NodeStageVolumeResponse, error) {
+	return c.NextStageVolumeResponse, c.NextErr
 }

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -95,6 +95,7 @@ func (f *NodeClient) Reset() {
 	f.NextErr = nil
 	f.NextCapabilitiesResponse = nil
 	f.NextGetInfoResponse = nil
+	f.NextStageVolumeResponse = nil
 }
 
 func (c *NodeClient) NodeGetCapabilities(ctx context.Context, in *csipbv1.NodeGetCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.NodeGetCapabilitiesResponse, error) {


### PR DESCRIPTION
This PR implements the NodeStageVolume RPCs as required for implementing
node level attachment/detachment of CSI Volumes. It's an isolated PR due
to the amount of boilerplate.

See individual commits for further explaination of implementation
details as necessary.