### PR TITLE
Add the digital marketing team as the code owners for the website dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Code-freeze: Docs will require approval by the Digital Marketing team
+# during the website infrastructure migration.
+/website/ @hashicorp/digital-marketing


### PR DESCRIPTION
This will automatically add @hashicorp/digital-marketing as a reviewer for any PR that touches files in the `website` directory.

This is a temporary ownership to prevent accidental merges while the digital marketing team works on the website infrastructure migration.