### PR TITLE
csi: Add NodeUnstageVolume RPCs

### DIFF
--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -326,3 +326,31 @@ func (c *client) NodeStageVolume(ctx context.Context, volumeID string, publishCo
 	_, err := c.nodeClient.NodeStageVolume(ctx, req)
 	return err
 }
+
+func (c *client) NodeUnstageVolume(ctx context.Context, volumeID string, stagingTargetPath string) error {
+	if c == nil {
+		return fmt.Errorf("Client not initialized")
+	}
+	if c.nodeClient == nil {
+		return fmt.Errorf("Client not initialized")
+	}
+
+	// These errors should not be returned during production use but exist as aids
+	// during Nomad Development
+	if volumeID == "" {
+		return fmt.Errorf("missing volumeID")
+	}
+	if stagingTargetPath == "" {
+		return fmt.Errorf("missing stagingTargetPath")
+	}
+
+	req := &csipbv1.NodeUnstageVolumeRequest{
+		VolumeId:          volumeID,
+		StagingTargetPath: stagingTargetPath,
+	}
+
+	// NodeUnstageVolume's response contains no extra data. If err == nil, we were
+	// successful.
+	_, err := c.nodeClient.NodeUnstageVolume(ctx, req)
+	return err
+}

--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -68,7 +68,7 @@ type CSINodeClient interface {
 	NodeGetCapabilities(ctx context.Context, in *csipbv1.NodeGetCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.NodeGetCapabilitiesResponse, error)
 	NodeGetInfo(ctx context.Context, in *csipbv1.NodeGetInfoRequest, opts ...grpc.CallOption) (*csipbv1.NodeGetInfoResponse, error)
 	NodeStageVolume(ctx context.Context, in *csipbv1.NodeStageVolumeRequest, opts ...grpc.CallOption) (*csipbv1.NodeStageVolumeResponse, error)
-	// NodeUnstageVolume(ctx context.Context, in *NodeUnstageVolumeRequest, opts ...grpc.CallOption) (*NodeUnstageVolumeResponse, error)
+	NodeUnstageVolume(ctx context.Context, in *csipbv1.NodeUnstageVolumeRequest, opts ...grpc.CallOption) (*csipbv1.NodeUnstageVolumeResponse, error)
 }
 
 type client struct {

--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -445,3 +445,40 @@ func TestClient_RPC_NodeStageVolume(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_RPC_NodeUnstageVolume(t *testing.T) {
+	cases := []struct {
+		Name        string
+		ResponseErr error
+		Response    *csipbv1.NodeUnstageVolumeResponse
+		ExpectedErr error
+	}{
+		{
+			Name:        "handles underlying grpc errors",
+			ResponseErr: fmt.Errorf("some grpc error"),
+			ExpectedErr: fmt.Errorf("some grpc error"),
+		},
+		{
+			Name:        "handles success",
+			ResponseErr: nil,
+			ExpectedErr: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			_, _, nc, client := newTestClient()
+			defer client.Close()
+
+			nc.NextErr = c.ResponseErr
+			nc.NextUnstageVolumeResponse = c.Response
+
+			err := client.NodeUnstageVolume(context.TODO(), "foo", "/foo")
+			if c.ExpectedErr != nil {
+				require.Error(t, c.ExpectedErr, err)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -53,6 +53,9 @@ type Client struct {
 
 	NextNodeStageVolumeErr   error
 	NodeStageVolumeCallCount int64
+
+	NextNodeUnstageVolumeErr   error
+	NodeUnstageVolumeCallCount int64
 }
 
 // PluginInfo describes the type and version of a plugin.
@@ -159,6 +162,20 @@ func (c *Client) NodeStageVolume(ctx context.Context, volumeID string, publishCo
 	c.NodeStageVolumeCallCount++
 
 	return c.NextNodeStageVolumeErr
+}
+
+// NodeUnstageVolume is used when a plugin has the STAGE_UNSTAGE volume capability
+// to undo the work performed by NodeStageVolume. If a volume has been staged,
+// this RPC must be called before freeing the volume.
+//
+// If err == nil, the response should be assumed to be successful.
+func (c *Client) NodeUnstageVolume(ctx context.Context, volumeID string, stagingTargetPath string) error {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+
+	c.NodeUnstageVolumeCallCount++
+
+	return c.NextNodeUnstageVolumeErr
 }
 
 // Shutdown the client and ensure any connections are cleaned up.

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -47,6 +47,13 @@ type CSIPlugin interface {
 	// be assumed to be successful.
 	NodeStageVolume(ctx context.Context, volumeID string, publishContext map[string]string, stagingTargetPath string, capabilities *VolumeCapability) error
 
+	// NodeUnstageVolume is used when a plugin has the STAGE_UNSTAGE volume capability
+	// to undo the work performed by NodeStageVolume. If a volume has been staged,
+	// this RPC must be called before freeing the volume.
+	//
+	// If err == nil, the response should be assumed to be successful.
+	NodeUnstageVolume(ctx context.Context, volumeID string, stagingTargetPath string) error
+
 	// Shutdown the client and ensure any connections are cleaned up.
 	Close() error
 }

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -80,10 +80,11 @@ func (c *ControllerClient) ValidateVolumeCapabilities(ctx context.Context, in *c
 
 // NodeClient is a CSI Node client used for testing
 type NodeClient struct {
-	NextErr                  error
-	NextCapabilitiesResponse *csipbv1.NodeGetCapabilitiesResponse
-	NextGetInfoResponse      *csipbv1.NodeGetInfoResponse
-	NextStageVolumeResponse  *csipbv1.NodeStageVolumeResponse
+	NextErr                   error
+	NextCapabilitiesResponse  *csipbv1.NodeGetCapabilitiesResponse
+	NextGetInfoResponse       *csipbv1.NodeGetInfoResponse
+	NextStageVolumeResponse   *csipbv1.NodeStageVolumeResponse
+	NextUnstageVolumeResponse *csipbv1.NodeUnstageVolumeResponse
 }
 
 // NewNodeClient returns a new ControllerClient
@@ -96,6 +97,7 @@ func (f *NodeClient) Reset() {
 	f.NextCapabilitiesResponse = nil
 	f.NextGetInfoResponse = nil
 	f.NextStageVolumeResponse = nil
+	f.NextUnstageVolumeResponse = nil
 }
 
 func (c *NodeClient) NodeGetCapabilities(ctx context.Context, in *csipbv1.NodeGetCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.NodeGetCapabilitiesResponse, error) {
@@ -108,4 +110,8 @@ func (c *NodeClient) NodeGetInfo(ctx context.Context, in *csipbv1.NodeGetInfoReq
 
 func (c *NodeClient) NodeStageVolume(ctx context.Context, in *csipbv1.NodeStageVolumeRequest, opts ...grpc.CallOption) (*csipbv1.NodeStageVolumeResponse, error) {
 	return c.NextStageVolumeResponse, c.NextErr
+}
+
+func (c *NodeClient) NodeUnstageVolume(ctx context.Context, in *csipbv1.NodeUnstageVolumeRequest, opts ...grpc.CallOption) (*csipbv1.NodeUnstageVolumeResponse, error) {
+	return c.NextUnstageVolumeResponse, c.NextErr
 }


### PR DESCRIPTION
This PR adds the required RPC for Unstaging a volume. It's use will be
in follow up PRs but filing this because of boilerplate.