### PR TITLE
e2e test for connect with consul acls

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1095,7 +1095,7 @@ func (_ *mockEnvoyBootstrapHook) Name() string {
 	return "mock_envoy_bootstrap"
 }
 
-func (m *mockEnvoyBootstrapHook) Prestart(_ context.Context, _ *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
+func (_ *mockEnvoyBootstrapHook) Prestart(_ context.Context, _ *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
 	resp.Done = true
 	return nil
 }
@@ -1126,6 +1126,10 @@ func TestTaskRunner_BlockForSIDSToken(t *testing.T) {
 
 	trConfig, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
 	defer cleanup()
+
+	// set a consul token on the Nomad client's consul config, because that is
+	// what gates the action of requesting SI token(s)
+	trConfig.ClientConfig.ConsulConfig.Token = uuid.Generate()
 
 	// control when we get a Consul SI token
 	token := uuid.Generate()
@@ -1191,6 +1195,10 @@ func TestTaskRunner_DeriveSIToken_Retry(t *testing.T) {
 	trConfig, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
 	defer cleanup()
 
+	// set a consul token on the Nomad client's consul config, because that is
+	// what gates the action of requesting SI token(s)
+	trConfig.ClientConfig.ConsulConfig.Token = uuid.Generate()
+
 	// control when we get a Consul SI token (recoverable failure on first call)
 	token := uuid.Generate()
 	deriveCount := 0
@@ -1250,6 +1258,10 @@ func TestTaskRunner_DeriveSIToken_Unrecoverable(t *testing.T) {
 
 	trConfig, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
 	defer cleanup()
+
+	// set a consul token on the Nomad client's consul config, because that is
+	// what gates the action of requesting SI token(s)
+	trConfig.ClientConfig.ConsulConfig.Token = uuid.Generate()
 
 	// SI token derivation suffers a non-retryable error
 	siClient := trConfig.ConsulSI.(*consulapi.MockServiceIdentitiesClient)

--- a/e2e/affinities/affinities.go
+++ b/e2e/affinities/affinities.go
@@ -35,7 +35,7 @@ func (tc *BasicAffinityTest) TestSingleAffinities(f *framework.F) {
 	uuid := uuid.Generate()
 	jobId := "aff" + uuid[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "affinities/input/single_affinity.nomad", jobId)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "affinities/input/single_affinity.nomad", jobId, "")
 
 	jobAllocs := nomadClient.Allocations()
 	require := require.New(f.T())
@@ -59,7 +59,7 @@ func (tc *BasicAffinityTest) TestMultipleAffinities(f *framework.F) {
 	uuid := uuid.Generate()
 	jobId := "multiaff" + uuid[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "affinities/input/multiple_affinities.nomad", jobId)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "affinities/input/multiple_affinities.nomad", jobId, "")
 
 	jobAllocs := nomadClient.Allocations()
 	require := require.New(f.T())
@@ -101,7 +101,7 @@ func (tc *BasicAffinityTest) TestAntiAffinities(f *framework.F) {
 	uuid := uuid.Generate()
 	jobId := "antiaff" + uuid[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "affinities/input/anti_affinities.nomad", jobId)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "affinities/input/anti_affinities.nomad", jobId, "")
 
 	jobAllocs := nomadClient.Allocations()
 	require := require.New(f.T())

--- a/e2e/clientstate/clientstate.go
+++ b/e2e/clientstate/clientstate.go
@@ -100,7 +100,7 @@ func (tc *ClientStateTC) TestClientState_Kill(f *framework.F) {
 	f.NoError(err)
 
 	jobID := "sleeper-" + uuid.Generate()[:8]
-	allocs := e2eutil.RegisterAndWaitForAllocs(t, client, "clientstate/sleeper.nomad", jobID)
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, client, "clientstate/sleeper.nomad", jobID, "")
 	f.Len(allocs, 1)
 
 	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
@@ -242,7 +242,7 @@ func (tc *ClientStateTC) TestClientState_KillDuringRestart(f *framework.F) {
 	f.NoError(err)
 
 	jobID := "restarter-" + uuid.Generate()[:8]
-	allocs := e2eutil.RegisterAndWaitForAllocs(t, client, "clientstate/restarter.nomad", jobID)
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, client, "clientstate/restarter.nomad", jobID, "")
 	f.Len(allocs, 1)
 
 	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
@@ -363,7 +363,7 @@ func (tc *ClientStateTC) TestClientState_Corrupt(f *framework.F) {
 	f.NoError(err)
 
 	jobID := "sleeper-" + uuid.Generate()[:8]
-	allocs := e2eutil.RegisterAndWaitForAllocs(t, client, "clientstate/sleeper.nomad", jobID)
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, client, "clientstate/sleeper.nomad", jobID, "")
 	f.Len(allocs, 1)
 
 	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)

--- a/e2e/connect/acls.go
+++ b/e2e/connect/acls.go
@@ -159,40 +159,31 @@ func (tc *ConnectACLsE2ETest) createOperatorToken(policyID string, f *framework.
 	return token.SecretID
 }
 
-// TODO: This is test is broken and requires an actual fix.
-//  We currently do not check if the provided operator token is a master token,
-//  and we need to do that to be consistent with the semantics of the Consul ACL
-//  system. Fix will be covered in a separate issue.
-//
-//func (tc *ConnectACLsE2ETest) TestConnectACLsRegister_MasterToken(f *framework.F) {
-//	t := f.T()
-//	r := require.New(t)
-//
-//	t.Log("test register Connect job w/ ACLs enabled w/ master token")
-//
-//	jobID := "connect" + uuid.Generate()[0:8]
-//	tc.jobIDs = append(tc.jobIDs, jobID)
-//
-//	jobAPI := tc.Nomad().Jobs()
-//
-//	job, err := jobspec.ParseFile(demoConnectJob)
-//	r.NoError(err)
-//
-//	// Set the job file to use the consul master token.
-//	// One should never do this in practice, but, it should work.
-//	// https://www.consul.io/docs/acl/acl-system.html#builtin-tokens
-//	//
-//	// note: We cannot just set the environment variable when using the API
-//	// directly - that only works when using the nomad CLI command which does
-//	// the step of converting the environment variable into a set option.
-//	job.ConsulToken = &tc.consulMasterToken
-//
-//	resp, _, err := jobAPI.Register(job, nil)
-//	r.NoError(err)
-//	r.NotNil(resp)
-//	r.Zero(resp.Warnings)
-//}
-//
+func (tc *ConnectACLsE2ETest) TestConnectACLsRegister_MasterToken(f *framework.F) {
+	t := f.T()
+	r := require.New(t)
+
+	t.Log("test register Connect job w/ ACLs enabled w/ master token")
+
+	jobID := "connect" + uuid.Generate()[0:8]
+	tc.jobIDs = append(tc.jobIDs, jobID)
+
+	jobAPI := tc.Nomad().Jobs()
+
+	job, err := jobspec.ParseFile(demoConnectJob)
+	r.NoError(err)
+
+	// Set the job file to use the consul master token.
+	// One should never do this in practice, but, it should work.
+	// https://www.consul.io/docs/acl/acl-system.html#builtin-tokens
+	job.ConsulToken = &tc.consulMasterToken
+
+	resp, _, err := jobAPI.Register(job, nil)
+	r.NoError(err)
+	r.NotNil(resp)
+	r.Zero(resp.Warnings)
+}
+
 func (tc *ConnectACLsE2ETest) TestConnectACLsRegister_MissingOperatorToken(f *framework.F) {
 	t := f.T()
 	r := require.New(t)

--- a/e2e/connect/acls.go
+++ b/e2e/connect/acls.go
@@ -1,0 +1,410 @@
+package connect
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	capi "github.com/hashicorp/consul/api"
+	consulapi "github.com/hashicorp/consul/api"
+	napi "github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/e2e/consulacls"
+	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/e2e/framework"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/jobspec"
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// envConsulToken is the consul http token environment variable
+	envConsulToken = "CONSUL_HTTP_TOKEN"
+
+	// demoConnectJob is the example connect enabled job useful for testing
+	demoConnectJob = "connect/input/demo.nomad"
+)
+
+type ConnectACLsE2ETest struct {
+	framework.TC
+
+	// manageConsulACLs is used to 'enable' and 'disable' Consul ACLs in the
+	// Consul Cluster that has been setup for e2e testing.
+	manageConsulACLs consulacls.Manager
+	// consulMasterToken is set to the generated Consul ACL token after using
+	// the consul-acls-manage.sh script to enable ACLs.
+	consulMasterToken string
+
+	// things to cleanup after each test case
+	jobIDs          []string
+	consulPolicyIDs []string
+	consulTokenIDs  []string
+}
+
+func (tc *ConnectACLsE2ETest) BeforeAll(f *framework.F) {
+	// Wait for Nomad to be ready before doing anything.
+	e2eutil.WaitForLeader(f.T(), tc.Nomad())
+	e2eutil.WaitForNodesReady(f.T(), tc.Nomad(), 2)
+
+	// Now enable Consul ACLs, the bootstrapping process for which will be
+	// managed automatically if needed.
+	var err error
+	tc.manageConsulACLs, err = consulacls.New(consulacls.DefaultTFStateFile)
+	require.NoError(f.T(), err)
+	tc.enableConsulACLs(f)
+
+	// Sanity check the consul master token exists, otherwise tests are just
+	// going to be a train wreck.
+	tokenLength := len(tc.consulMasterToken)
+	require.Equal(f.T(), 36, tokenLength, "consul master token wrong length")
+
+	// Sanity check the CONSUL_HTTP_TOKEN is NOT set, because that will cause
+	// the agent checks to fail (which do not allow having a token set (!)).
+	consulTokenEnv := os.Getenv(envConsulToken)
+	require.Empty(f.T(), consulTokenEnv)
+
+	// Wait for Nomad to be ready _again_, since everything was restarted during
+	// the bootstrap process.
+	e2eutil.WaitForLeader(f.T(), tc.Nomad())
+	e2eutil.WaitForNodesReady(f.T(), tc.Nomad(), 2)
+}
+
+// enableConsulACLs effectively executes `consul-acls-manage.sh enable`, which
+// will activate Consul ACLs, going through the bootstrap process if necessary.
+func (tc *ConnectACLsE2ETest) enableConsulACLs(f *framework.F) {
+	tc.consulMasterToken = tc.manageConsulACLs.Enable(f.T())
+}
+
+// AfterAll runs after all tests are complete.
+//
+// We disable ConsulACLs in here to isolate the use of Consul ACLs only to
+// test suites that explicitly want to test with them enabled.
+func (tc *ConnectACLsE2ETest) AfterAll(f *framework.F) {
+	tc.disableConsulACLs(f)
+}
+
+// disableConsulACLs effectively executes `consul-acls-manage.sh disable`, which
+// will de-activate Consul ACLs.
+func (tc *ConnectACLsE2ETest) disableConsulACLs(f *framework.F) {
+	tc.manageConsulACLs.Disable(f.T())
+}
+
+// AfterEach does cleanup of Consul ACL objects that were created during each
+// test case. Each test case may assume it is starting from a "fresh" state -
+// as if the consul ACL bootstrap process had just taken place.
+func (tc *ConnectACLsE2ETest) AfterEach(f *framework.F) {
+	if os.Getenv("NOMAD_TEST_SKIPCLEANUP") == "1" {
+		return
+	}
+
+	t := f.T()
+	r := require.New(t)
+
+	// cleanup jobs
+	for _, id := range tc.jobIDs {
+		t.Log("cleanup: deregister nomad job id:", id)
+		_, _, err := tc.Nomad().Jobs().Deregister(id, true, nil)
+		r.NoError(err)
+	}
+
+	// cleanup consul tokens
+	for _, id := range tc.consulTokenIDs {
+		t.Log("cleanup: delete consul token id:", id)
+		_, err := tc.Consul().ACL().TokenDelete(id, &capi.WriteOptions{Token: tc.consulMasterToken})
+		r.NoError(err)
+	}
+
+	// cleanup consul policies
+	for _, id := range tc.consulPolicyIDs {
+		t.Log("cleanup: delete consul policy id:", id)
+		_, err := tc.Consul().ACL().PolicyDelete(id, &capi.WriteOptions{Token: tc.consulMasterToken})
+		r.NoError(err)
+	}
+
+	// do garbage collection
+	err := tc.Nomad().System().GarbageCollect()
+	r.NoError(err)
+
+	tc.jobIDs = []string{}
+	tc.consulTokenIDs = []string{}
+	tc.consulPolicyIDs = []string{}
+}
+
+type consulPolicy struct {
+	Name  string // e.g. nomad-operator
+	Rules string // e.g. service "" { policy="write" }
+}
+
+func (tc *ConnectACLsE2ETest) createConsulPolicy(p consulPolicy, f *framework.F) string {
+	r := require.New(f.T())
+	result, _, err := tc.Consul().ACL().PolicyCreate(&capi.ACLPolicy{
+		Name:        p.Name,
+		Description: "test policy " + p.Name,
+		Rules:       p.Rules,
+	}, &capi.WriteOptions{Token: tc.consulMasterToken})
+	r.NoError(err, "failed to create consul policy")
+	tc.consulPolicyIDs = append(tc.consulPolicyIDs, result.ID)
+	return result.ID
+}
+
+func (tc *ConnectACLsE2ETest) createOperatorToken(policyID string, f *framework.F) string {
+	r := require.New(f.T())
+	token, _, err := tc.Consul().ACL().TokenCreate(&capi.ACLToken{
+		Description: "operator token",
+		Policies:    []*capi.ACLTokenPolicyLink{{ID: policyID}},
+	}, &capi.WriteOptions{Token: tc.consulMasterToken})
+	r.NoError(err, "failed to create operator token")
+	tc.consulTokenIDs = append(tc.consulTokenIDs, token.AccessorID)
+	return token.SecretID
+}
+
+// TODO: This is test is broken and requires an actual fix.
+//  We currently do not check if the provided operator token is a master token,
+//  and we need to do that to be consistent with the semantics of the Consul ACL
+//  system. Fix will be covered in a separate issue.
+//
+//func (tc *ConnectACLsE2ETest) TestConnectACLsRegister_MasterToken(f *framework.F) {
+//	t := f.T()
+//	r := require.New(t)
+//
+//	t.Log("test register Connect job w/ ACLs enabled w/ master token")
+//
+//	jobID := "connect" + uuid.Generate()[0:8]
+//	tc.jobIDs = append(tc.jobIDs, jobID)
+//
+//	jobAPI := tc.Nomad().Jobs()
+//
+//	job, err := jobspec.ParseFile(demoConnectJob)
+//	r.NoError(err)
+//
+//	// Set the job file to use the consul master token.
+//	// One should never do this in practice, but, it should work.
+//	// https://www.consul.io/docs/acl/acl-system.html#builtin-tokens
+//	//
+//	// note: We cannot just set the environment variable when using the API
+//	// directly - that only works when using the nomad CLI command which does
+//	// the step of converting the environment variable into a set option.
+//	job.ConsulToken = &tc.consulMasterToken
+//
+//	resp, _, err := jobAPI.Register(job, nil)
+//	r.NoError(err)
+//	r.NotNil(resp)
+//	r.Zero(resp.Warnings)
+//}
+//
+func (tc *ConnectACLsE2ETest) TestConnectACLsRegister_MissingOperatorToken(f *framework.F) {
+	t := f.T()
+	r := require.New(t)
+
+	t.Log("test register Connect job w/ ACLs enabled w/o operator token")
+
+	job, err := jobspec.ParseFile(demoConnectJob)
+	r.NoError(err)
+
+	jobAPI := tc.Nomad().Jobs()
+
+	// Explicitly show the ConsulToken is not set
+	job.ConsulToken = nil
+
+	_, _, err = jobAPI.Register(job, nil)
+	r.Error(err)
+
+	t.Log("job correctly rejected, with error:", err)
+}
+
+func (tc *ConnectACLsE2ETest) TestConnectACLsRegister_FakeOperatorToken(f *framework.F) {
+	t := f.T()
+	r := require.New(t)
+
+	t.Log("test register Connect job w/ ACLs enabled w/ operator token")
+
+	policyID := tc.createConsulPolicy(consulPolicy{
+		Name:  "nomad-operator-policy",
+		Rules: `service "count-api" { policy = "write" } service "count-dashboard" { policy = "write" }`,
+	}, f)
+	t.Log("created operator policy:", policyID)
+
+	// generate a fake consul token token
+	fakeToken := uuid.Generate()
+	job := tc.parseJobSpecFile(t, demoConnectJob)
+
+	jobAPI := tc.Nomad().Jobs()
+
+	// deliberately set the fake Consul token
+	job.ConsulToken = &fakeToken
+
+	// should fail, because the token is fake
+	_, _, err := jobAPI.Register(job, nil)
+	r.Error(err)
+	t.Log("job correctly rejected, with error:", err)
+}
+
+func (tc *ConnectACLsE2ETest) TestConnectACLs_ConnectDemo(f *framework.F) {
+	t := f.T()
+	r := require.New(t)
+
+	t.Log("test register Connect job w/ ACLs enabled w/ operator token")
+
+	// === Setup ACL policy and token ===
+
+	// create a policy allowing writes of services "count-api" and "count-dashboard"
+	policyID := tc.createConsulPolicy(consulPolicy{
+		Name:  "nomad-operator-policy",
+		Rules: `service "count-api" { policy = "write" } service "count-dashboard" { policy = "write" }`,
+	}, f)
+	t.Log("created operator policy:", policyID)
+
+	// create a Consul "operator token" blessed with the above policy
+	operatorToken := tc.createOperatorToken(policyID, f)
+	t.Log("created operator token:", operatorToken)
+
+	// === Register the Nomad job ===
+
+	// parse the example connect jobspec file
+	jobID := "connect" + uuid.Generate()[0:8]
+	tc.jobIDs = append(tc.jobIDs, jobID)
+	job := tc.parseJobSpecFile(t, demoConnectJob)
+	job.ID = &jobID
+	jobAPI := tc.Nomad().Jobs()
+
+	// set the valid consul operator token
+	job.ConsulToken = &operatorToken
+
+	// registering the job should succeed
+	resp, _, err := jobAPI.Register(job, nil)
+	r.NoError(err)
+	r.NotNil(resp)
+	r.Empty(resp.Warnings)
+	t.Log("job has been registered with evalID:", resp.EvalID)
+
+	// === Make sure the evaluation actually succeeds ===
+EVAL:
+	qOpts := &napi.QueryOptions{WaitIndex: resp.EvalCreateIndex}
+	evalAPI := tc.Nomad().Evaluations()
+	eval, qMeta, err := evalAPI.Info(resp.EvalID, qOpts)
+	r.NoError(err)
+	qOpts.WaitIndex = qMeta.LastIndex
+
+	switch eval.Status {
+	case "pending":
+		goto EVAL
+	case "complete":
+	// ok!
+	case "failed", "canceled", "blocked":
+		r.Failf("eval %s\n%s\n", eval.Status, pretty.Sprint(eval))
+	default:
+		r.Failf("unknown eval status: %s\n%s\n", eval.Status, pretty.Sprint(eval))
+	}
+
+	// assert there were no placement failures
+	r.Zero(eval.FailedTGAllocs, pretty.Sprint(eval.FailedTGAllocs))
+	r.Len(eval.QueuedAllocations, 2, pretty.Sprint(eval.QueuedAllocations))
+
+	// === Assert allocs are running ===
+	for i := 0; i < 20; i++ {
+		allocs, qMeta, err := evalAPI.Allocations(eval.ID, qOpts)
+		r.NoError(err)
+		r.Len(allocs, 2)
+		qOpts.WaitIndex = qMeta.LastIndex
+
+		running := 0
+		for _, alloc := range allocs {
+			switch alloc.ClientStatus {
+			case "running":
+				running++
+			case "pending":
+				// keep trying
+			default:
+				r.Failf("alloc failed", "alloc: %s", pretty.Sprint(alloc))
+			}
+		}
+
+		if running == len(allocs) {
+			break
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	allocs, _, err := evalAPI.Allocations(eval.ID, qOpts)
+	r.NoError(err)
+	allocIDs := make(map[string]bool, 2)
+	for _, a := range allocs {
+		if a.ClientStatus != "running" || a.DesiredStatus != "run" {
+			r.Failf("terminal alloc", "alloc %s (%s) terminal; client=%s desired=%s", a.TaskGroup, a.ID, a.ClientStatus, a.DesiredStatus)
+		}
+		allocIDs[a.ID] = true
+	}
+
+	// === Check Consul service health ===
+	agentAPI := tc.Consul().Agent()
+
+	failing := map[string]*capi.AgentCheck{}
+	for i := 0; i < 60; i++ {
+		checks, err := agentAPI.Checks()
+		require.NoError(t, err)
+
+		// filter out checks for other services
+		for cid, check := range checks {
+			found := false
+			for allocID := range allocIDs {
+				if strings.Contains(check.ServiceID, allocID) {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				delete(checks, cid)
+			}
+		}
+
+		// ensure checks are all passing
+		failing = map[string]*consulapi.AgentCheck{}
+		for _, check := range checks {
+			if check.Status != "passing" {
+				failing[check.CheckID] = check
+				break
+			}
+		}
+
+		if len(failing) == 0 {
+			break
+		}
+
+		t.Logf("still %d checks not passing", len(failing))
+
+		time.Sleep(time.Second)
+	}
+
+	require.Len(t, failing, 0, pretty.Sprint(failing))
+
+	// === Check Consul SI tokens were generated for sidecars ===
+	aclAPI := tc.Consul().ACL()
+
+	entries, _, err := aclAPI.TokenList(&capi.QueryOptions{
+		Token: tc.consulMasterToken,
+	})
+	r.NoError(err)
+
+	foundSITokenForCountDash := false
+	foundSITokenForCountAPI := false
+	for _, entry := range entries {
+		if strings.Contains(entry.Description, "[connect-proxy-count-dashboard]") {
+			foundSITokenForCountDash = true
+		} else if strings.Contains(entry.Description, "[connect-proxy-count-api]") {
+			foundSITokenForCountAPI = true
+		}
+	}
+	r.True(foundSITokenForCountDash, "no SI token found for count-dash")
+	r.True(foundSITokenForCountAPI, "no SI token found for count-api")
+
+	t.Log("connect job with ACLs enable finished")
+}
+
+func (tc *ConnectACLsE2ETest) parseJobSpecFile(t *testing.T, filename string) *napi.Job {
+	job, err := jobspec.ParseFile(filename)
+	require.NoError(t, err)
+	return job
+}

--- a/e2e/connect/acls.go
+++ b/e2e/connect/acls.go
@@ -293,8 +293,10 @@ EVAL:
 	r.Len(eval.QueuedAllocations, 2, pretty.Sprint(eval.QueuedAllocations))
 
 	// === Assert allocs are running ===
+	var allocs []*napi.AllocationListStub
+
 	for i := 0; i < 20; i++ {
-		allocs, qMeta, err := evalAPI.Allocations(eval.ID, qOpts)
+		allocs, qMeta, err = evalAPI.Allocations(eval.ID, qOpts)
 		r.NoError(err)
 		r.Len(allocs, 2)
 		qOpts.WaitIndex = qMeta.LastIndex
@@ -318,8 +320,6 @@ EVAL:
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	allocs, _, err := evalAPI.Allocations(eval.ID, qOpts)
-	r.NoError(err)
 	allocIDs := make(map[string]bool, 2)
 	for _, a := range allocs {
 		if a.ClientStatus != "running" || a.DesiredStatus != "run" {

--- a/e2e/connect/acls_test.go
+++ b/e2e/connect/acls_test.go
@@ -1,0 +1,19 @@
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_serviceOfSIToken(t *testing.T) {
+	try := func(description, exp string) {
+		tc := new(ConnectACLsE2ETest)
+		result := tc.serviceofSIToken(description)
+		require.Equal(t, exp, result)
+	}
+
+	try("", "")
+	try("foobarbaz", "")
+	try("_nomad_si [8b1a5d3f-7e61-4a5a-8a57-7e7ad91e63b6] [8b1a5d3f-7e61-4a5a-8a57-7e7ad91e63b6] [foo-service]", "foo-service")
+}

--- a/e2e/connect/client.go
+++ b/e2e/connect/client.go
@@ -41,7 +41,7 @@ func (tc *ConnectClientStateE2ETest) TestClientRestart(f *framework.F) {
 	consulClient := tc.Consul()
 
 	allocs := e2eutil.RegisterAndWaitForAllocs(t, client,
-		"connect/input/demo.nomad", jobID)
+		"connect/input/demo.nomad", jobID, "")
 	require.Equal(2, len(allocs))
 
 	e2eutil.RequireConsulStatus(require, consulClient,

--- a/e2e/connect/connect.go
+++ b/e2e/connect/connect.go
@@ -21,6 +21,7 @@ type ConnectE2ETest struct {
 }
 
 func init() {
+	// connect tests without Consul ACLs enabled
 	framework.AddSuites(&framework.TestSuite{
 		Component:   "Connect",
 		CanRunLocal: true,
@@ -28,6 +29,16 @@ func init() {
 		Cases: []framework.TestCase{
 			new(ConnectE2ETest),
 			new(ConnectClientStateE2ETest),
+		},
+	})
+
+	// connect tests with Consul ACLs enabled
+	framework.AddSuites(&framework.TestSuite{
+		Component:   "ConnectACLs",
+		CanRunLocal: false,
+		Consul:      true,
+		Cases: []framework.TestCase{
+			new(ConnectACLsE2ETest),
 		},
 	})
 }

--- a/e2e/connect/connect.go
+++ b/e2e/connect/connect.go
@@ -22,21 +22,22 @@ type ConnectE2ETest struct {
 
 func init() {
 	// connect tests without Consul ACLs enabled
-	framework.AddSuites(&framework.TestSuite{
-		Component:   "Connect",
-		CanRunLocal: true,
-		Consul:      true,
-		Cases: []framework.TestCase{
-			new(ConnectE2ETest),
-			new(ConnectClientStateE2ETest),
-		},
-	})
+	//framework.AddSuites(&framework.TestSuite{
+	//	Component:   "Connect",
+	//	CanRunLocal: true,
+	//	Consul:      true,
+	//	Cases: []framework.TestCase{
+	//		new(ConnectE2ETest),
+	//		new(ConnectClientStateE2ETest),
+	//	},
+	//})
 
 	// connect tests with Consul ACLs enabled
 	framework.AddSuites(&framework.TestSuite{
 		Component:   "ConnectACLs",
 		CanRunLocal: false,
 		Consul:      true,
+		Parallel:    false,
 		Cases: []framework.TestCase{
 			new(ConnectACLsE2ETest),
 		},

--- a/e2e/connect/multi_service.go
+++ b/e2e/connect/multi_service.go
@@ -55,7 +55,7 @@ EVAL:
 	require.Len(t, eval.QueuedAllocations, 1, pretty.Sprint(eval.QueuedAllocations))
 
 	// Assert allocs are running
-	require.Eventually(t, func() bool {
+	for i := 0; i < 20; i++ {
 		allocs, qmeta, err := evalapi.Allocations(eval.ID, qopts)
 		require.NoError(t, err)
 		require.Len(t, allocs, 1)
@@ -69,15 +69,16 @@ EVAL:
 			case "pending":
 				// keep trying
 			default:
-				t.Fatalf("alloc failed: %s", pretty.Sprint(alloc))
+				require.Failf(t, "alloc failed", "alloc: %s", pretty.Sprint(alloc))
 			}
 		}
 
 		if running == len(allocs) {
-			return true
+			break
 		}
-		return false
-	}, 10*time.Second, 500*time.Millisecond)
+
+		time.Sleep(500 * time.Millisecond)
+	}
 
 	allocs, _, err := evalapi.Allocations(eval.ID, qopts)
 	require.NoError(t, err)

--- a/e2e/consul/consul.go
+++ b/e2e/consul/consul.go
@@ -47,7 +47,7 @@ func (tc *ConsulE2ETest) TestConsulRegistration(f *framework.F) {
 	jobId := "consul" + uuid[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
 
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "consul/input/consul_example.nomad", jobId)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "consul/input/consul_example.nomad", jobId, "")
 	consulClient := tc.Consul()
 	require := require.New(f.T())
 	require.Equal(3, len(allocs))
@@ -105,7 +105,7 @@ func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
 	jobId := "consul" + uuid[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
 
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "consul/input/canary_tags.nomad", jobId)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "consul/input/canary_tags.nomad", jobId, "")
 	consulClient := tc.Consul()
 	require := require.New(f.T())
 	require.Equal(2, len(allocs))

--- a/e2e/consul/script_checks.go
+++ b/e2e/consul/script_checks.go
@@ -42,7 +42,7 @@ func (tc *ScriptChecksE2ETest) TestGroupScriptCheck(f *framework.F) {
 
 	// Job run: verify that checks were registered in Consul
 	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(),
-		nomadClient, "consul/input/checks_group.nomad", jobId)
+		nomadClient, "consul/input/checks_group.nomad", jobId, "")
 	require.Equal(1, len(allocs))
 	e2eutil.RequireConsulStatus(require, consulClient, "group-service-1", capi.HealthPassing)
 	e2eutil.RequireConsulStatus(require, consulClient, "group-service-2", capi.HealthWarning)
@@ -56,7 +56,7 @@ func (tc *ScriptChecksE2ETest) TestGroupScriptCheck(f *framework.F) {
 
 	// Job update: verify checks are re-registered in Consul
 	allocs = e2eutil.RegisterAndWaitForAllocs(f.T(),
-		nomadClient, "consul/input/checks_group_update.nomad", jobId)
+		nomadClient, "consul/input/checks_group_update.nomad", jobId, "")
 	require.Equal(1, len(allocs))
 	e2eutil.RequireConsulStatus(require, consulClient, "group-service-1", capi.HealthPassing)
 	e2eutil.RequireConsulStatus(require, consulClient, "group-service-2", capi.HealthPassing)
@@ -76,7 +76,7 @@ func (tc *ScriptChecksE2ETest) TestGroupScriptCheck(f *framework.F) {
 
 	// Restore for next test
 	allocs = e2eutil.RegisterAndWaitForAllocs(f.T(),
-		nomadClient, "consul/input/checks_group.nomad", jobId)
+		nomadClient, "consul/input/checks_group.nomad", jobId, "")
 	require.Equal(2, len(allocs))
 	e2eutil.RequireConsulStatus(require, consulClient, "group-service-1", capi.HealthPassing)
 	e2eutil.RequireConsulStatus(require, consulClient, "group-service-2", capi.HealthWarning)
@@ -109,7 +109,7 @@ func (tc *ScriptChecksE2ETest) TestTaskScriptCheck(f *framework.F) {
 
 	// Job run: verify that checks were registered in Consul
 	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(),
-		nomadClient, "consul/input/checks_task.nomad", jobId)
+		nomadClient, "consul/input/checks_task.nomad", jobId, "")
 	require.Equal(1, len(allocs))
 	e2eutil.RequireConsulStatus(require, consulClient, "task-service-1", capi.HealthPassing)
 	e2eutil.RequireConsulStatus(require, consulClient, "task-service-2", capi.HealthWarning)
@@ -123,7 +123,7 @@ func (tc *ScriptChecksE2ETest) TestTaskScriptCheck(f *framework.F) {
 
 	// Job update: verify checks are re-registered in Consul
 	allocs = e2eutil.RegisterAndWaitForAllocs(f.T(),
-		nomadClient, "consul/input/checks_task_update.nomad", jobId)
+		nomadClient, "consul/input/checks_task_update.nomad", jobId, "")
 	require.Equal(1, len(allocs))
 	e2eutil.RequireConsulStatus(require, consulClient, "task-service-1", capi.HealthPassing)
 	e2eutil.RequireConsulStatus(require, consulClient, "task-service-2", capi.HealthPassing)
@@ -143,7 +143,7 @@ func (tc *ScriptChecksE2ETest) TestTaskScriptCheck(f *framework.F) {
 
 	// Restore for next test
 	allocs = e2eutil.RegisterAndWaitForAllocs(f.T(),
-		nomadClient, "consul/input/checks_task.nomad", jobId)
+		nomadClient, "consul/input/checks_task.nomad", jobId, "")
 	require.Equal(2, len(allocs))
 	e2eutil.RequireConsulStatus(require, consulClient, "task-service-1", capi.HealthPassing)
 	e2eutil.RequireConsulStatus(require, consulClient, "task-service-2", capi.HealthWarning)

--- a/e2e/consulacls/README.md
+++ b/e2e/consulacls/README.md
@@ -7,7 +7,8 @@ provisioned e2e environment to enable Consul ACLs.
 
 The `consul-acls-manage.sh` script can be used to manipulate the Consul cluster
 to activate or de-activate Consul ACLs. There are 3 targets into the script, only
-2 of which should be used from e2e framework tests.
+2 of which should be used from e2e framework tests. The script should be run from
+the e2e directory (i.e. the directory from wich the e2e framework also runs).
 
 ### bootstrap
 

--- a/e2e/consulacls/README.md
+++ b/e2e/consulacls/README.md
@@ -1,0 +1,45 @@
+# Configure Consul ACLs
+
+This directory contains a set of scripts for re-configuring Consul in the TF
+provisioned e2e environment to enable Consul ACLs.
+
+## Usage
+
+The `consul-acls-manage.sh` script can be used to manipulate the Consul cluster
+to activate or de-activate Consul ACLs. There are 3 targets into the script, only
+2 of which should be used from e2e framework tests.
+
+### bootstrap
+
+The command `consul-acls-manage.sh bootstrap` should *NOT* be used from e2e
+framework tests. It's merely a convenience entry-point for doing development /
+debugging on the script itself.
+
+The bootstrap process will upload "reasonable" ACL policy files to Consul Servers,
+Consul Clients, Nomad Servers, and Nomad Clients.
+
+The bootstrap process creates a file on local disk which contains the generated
+Consul ACL master token. The file is named based on the current TF state file
+serial number. `/tmp/e2e-consul-bootstrap-<serial>.token`
+
+### enable
+
+The command `consul-acls-manage.sh enable` will enable Consul ACLs, going through
+the bootstrap process only if necessary. Whether the bootstrap process is necessary
+depends on the existence of a token file that matches the current TF state serial
+number. If no associated token file exists for the current TF state, the bootstrap
+process is required. Otherwise, the bootstrap process is skipped.
+
+If the bootstrap process was not required (i.e. it already occurred and a
+Consul master token already exists for the current TF state), the script will
+activate ACLs in the Consul Server configurations and restart those agents. After
+using `enable`, the `disable` command can be used to turn Consul ACLs back off,
+without destroying any of the existing ACL configuration.
+
+### disable
+
+The command `consul-acls-manage.sh disable` will disable Consul ACLs. This does
+not "cleanup" the policy files for Consul / Nomad agents, it merely deactivates
+ACLs in the Consul Server configurations and restarts those agents. After using
+`disable`, the `enable` command can be used to turn Consul ACLs back on, using
+the same ACL token(s) generated before.

--- a/e2e/consulacls/acl-disable.hcl
+++ b/e2e/consulacls/acl-disable.hcl
@@ -1,0 +1,6 @@
+# This partial consul configuration file will disable Consul ACLs. The
+# consul-acls-manage.sh script uploads this file as "acl.hcl" to Consul Server
+# configuration directories, and restarts those agents.
+acl = {
+  enabled = false
+}

--- a/e2e/consulacls/acl-enable.hcl
+++ b/e2e/consulacls/acl-enable.hcl
@@ -1,0 +1,8 @@
+# This partial consul configuration file will enable Consul ACLs. The
+# consul-acls-manage.sh script uploads this file as "acl.hcl" to Consul Server
+# configuration directories, and restarts those agents.
+acl = {
+  enabled = true
+  default_policy = "deny"
+  enable_token_persistence = true
+}

--- a/e2e/consulacls/acl-enable.hcl
+++ b/e2e/consulacls/acl-enable.hcl
@@ -2,7 +2,7 @@
 # consul-acls-manage.sh script uploads this file as "acl.hcl" to Consul Server
 # configuration directories, and restarts those agents.
 acl = {
-  enabled = true
-  default_policy = "deny"
+  enabled                  = true
+  default_policy           = "deny"
   enable_token_persistence = true
 }

--- a/e2e/consulacls/acl-pre-enable.hcl
+++ b/e2e/consulacls/acl-pre-enable.hcl
@@ -1,0 +1,13 @@
+# This partial consul configuration file will enable Consul ACLs in the default:allow
+# mode, which is nessessary for the ACL bootstrapping process of a pre-existing cluster.
+#
+# The consul-acls-manage.sh script uploads this file as "acl.hcl" to Consul Server
+# configuration directories, and restarts those agents.
+#
+# Later the consul-acls-manage.sh script will replace this configuration with the
+# one found in acl-enable.sh so as to enforce ACLs.
+acl = {
+  enabled                  = true
+  default_policy           = "allow"
+  enable_token_persistence = true
+}

--- a/e2e/consulacls/consul-acls-manage.sh
+++ b/e2e/consulacls/consul-acls-manage.sh
@@ -24,7 +24,7 @@ linux_clients=$(jq -r .outputs.linux_clients.value[] <"${tfstatefile}" | xargs)
 windows_clients=$(jq -r .outputs.windows_clients.value[] <"${tfstatefile}" | xargs)
 
 # Combine all the clients together
-clients="${linux_clients} ${windows_clients}"
+# clients="${linux_clients} ${windows_clients}"
 
 # Load Server Node IPs from terraform/terraform.tfstate
 servers=$(jq -r .outputs.servers.value[] <"${tfstatefile}" | xargs)
@@ -93,15 +93,14 @@ function doBootstrap() {
   # Stop all Nomad agents.
   stopNomad
 
-  # Stop all Consul agents.
-  stopConsul
-
-  # Run the activation step, which uploads the ACLs-enabled acl.hcl file
+  # Run the pre-activation step, which uploads an acl.hcl file (with default:allow)
   # to each Consul configuration directory, then (re)starts each
   # Consul agent.
-  doActivate
+  doPreActivateACLs
 
   echo "=== Bootstrap: Consul ACL Bootstrap ==="
+  echo "sleeping 2 minutes to let Consul agents settle (avoid Legacy mode error)..."
+  sleep 120
 
   # Bootstrap Consul ACLs on server[0]
   echo "-> bootstrap ACL using ${server0}"
@@ -126,9 +125,9 @@ function doBootstrap() {
     echo "---> done setting agent token for server ${server}"
   done
 
-  # Wait 10s before continuing with configuring consul clients.
-  echo "-> sleep 10s before continuing with clients"
-  sleep 10
+  # Wait 30s before continuing with configuring consul clients.
+  echo "-> sleep 3s before continuing with clients"
+  sleep 3
 
   # Create Consul Client Policy & Client agent tokens
   echo "-> configure consul client policy"
@@ -140,8 +139,12 @@ function doBootstrap() {
     client_agent_token=$(consul acl token create -description "consul client agent token" -policy-name client-policy | grep SecretID | awk '{print $2}')
     echo "---> setting consul token for consul client ${linux_client} -> ${client_agent_token}"
     (export CONSUL_HTTP_ADDR="${linux_client}:8500"; consul acl set-agent-token agent "${client_agent_token}")
-    echo "---> done setting consul agent token for client ${linux_client}"
+    echo "---> done setting agent token for client ${linux_client}"
   done
+
+  # Now, upload the ACL policy file with default:deny so that ACL are actually
+  # enforced.
+  doActivateACLs
 
   echo "=== Bootstrap: Nomad Configs ==="
 
@@ -178,13 +181,40 @@ function doBootstrap() {
   echo "=== Activate: DONE ==="
 }
 
-function doEnable() {
+function doSetAllowUnauthenticated {
+  value="${1}"
+  [ "${value}" == "true" ] || [ "${value}" == "false" ] || ( echo "allow_unauthenticated must be 'true' or 'false'" && exit 1)
+  for server in ${servers}; do
+    if [ "${value}" == "true" ]; then
+      echo "---> setting consul.allow_unauthenticated=true on ${server}"
+      doSSH "${server}" "sudo sed -i 's/allow_unauthenticated = false/allow_unauthenticated = true/g' ${nomad_configs}/nomad-server-consul.hcl"
+    else
+      echo "---> setting consul.allow_unauthenticated=false on ${server}"
+      doSSH "${server}" "sudo sed -i 's/allow_unauthenticated = true/allow_unauthenticated = false/g' ${nomad_configs}/nomad-server-consul.hcl"
+    fi
+    doSSH "${server}" "sudo systemctl restart nomad"
+  done
+
+  for linux_client in ${linux_clients}; do
+    if [ "${value}" == "true" ]; then
+      echo "---> comment out consul token for Nomad client ${linux_client}"
+      doSSH "${linux_client}" "sudo sed -i 's!token =!// token =!g' ${nomad_configs}/nomad-client-consul.hcl"
+    else
+      echo "---> un-comment consul token for Nomad client ${linux_client}"
+      doSSH "${linux_client}" "sudo sed -i 's!// token =!token =!g' ${nomad_configs}/nomad-client-consul.hcl"
+    fi
+    doSSH "${linux_client}" "sudo systemctl restart nomad"
+  done
+}
+
+function doEnable {
   if [ ! -f "${token_file}" ]; then
     echo "ENABLE: token file does not exist, doing a full ACL bootstrap"
     doBootstrap
   else
     echo "ENABLE: token file already exists, will activate ACLs"
-    doActivate
+    doSetAllowUnauthenticated "false"
+    doActivateACLs
   fi
 
   echo "=== Enable: DONE ==="
@@ -197,13 +227,14 @@ function doEnable() {
   doStatus
 }
 
-function doDisable() {
+function doDisable {
   if [ ! -f "${token_file}" ]; then
     echo "DISABLE: token file does not exist, did bootstrap ever happen?"
     exit 1
   else
     echo "DISABLE: token file exists, will deactivate ACLs"
-    doDeactivate
+    doSetAllowUnauthenticated "true"
+    doDeactivateACLs
   fi
 
   echo "=== Disable: DONE ==="
@@ -213,8 +244,29 @@ function doDisable() {
   doStatus
 }
 
-function doActivate() {
-  echo "=== Activate ==="
+function doPreActivateACLs {
+  echo "=== PreActivate (set default:allow) ==="
+
+  stopConsul
+
+  # Upload acl-pre-enable.hcl to each Consul agent's configuration directory.
+  for agent in ${servers} ${linux_clients}; do
+    echo " pre-activate: upload acl-pre-enable.hcl to ${agent}::acl.hcl"
+    doSCP "consulacls/acl-pre-enable.hcl" "${user}" "${agent}" "/tmp/acl.hcl"
+    doSSH "${agent}" "sudo mv /tmp/acl.hcl ${consul_configs}/acl.hcl"
+  done
+
+  # Start each Consul agent to pickup the new config.
+  for agent in ${servers} ${linux_clients}; do
+    echo " pre-activate: start Consul agent on ${agent}"
+    doSSH "${agent}" "sudo systemctl start consul"
+  done
+
+  echo "=== PreActivate: DONE ==="
+}
+
+function doActivateACLs {
+  echo "=== Activate (set default:deny) ==="
 
   stopConsul
 
@@ -225,14 +277,14 @@ function doActivate() {
     doSSH "${agent}" "sudo mv /tmp/acl.hcl ${consul_configs}/acl.hcl"
   done
 
-  # Restart each Consul agent to pickup the new config.
+  # Start each Consul agent to pickup the new config.
   for agent in ${servers} ${linux_clients}; do
     echo " activate: restart Consul agent on ${agent} ..."
     doSSH "${agent}" "sudo systemctl start consul"
-    sleep 1
   done
 
-  sleep 10
+  echo "--> activate ACLs sleep for 2 minutes to let Consul figure things out"
+  sleep 120
   echo "=== Activate: DONE ==="
 }
 
@@ -312,20 +364,19 @@ function startConsulClients {
     echo "... all consul clients started"
 }
 
-function doDeactivate {
+function doDeactivateACLs {
   echo "=== Deactivate ==="
-  # Upload acl-disable.hcl to each Consul Server agent's configuration directory.
-  for server in ${servers}; do
-    echo " deactivate: upload acl-disable.hcl to ${server}::acl.hcl"
-    doSCP "consulacls/acl-disable.hcl" "${user}" "${server}" "/tmp/acl.hcl"
-    doSSH "${server}" "sudo mv /tmp/acl.hcl ${consul_configs}/acl.hcl"
+  # Upload acl-disable.hcl to each Consul agent's configuration directory.
+  for agent in ${servers} ${linux_clients}; do
+    echo " deactivate: upload acl-disable.hcl to ${agent}::acl.hcl"
+    doSCP "consulacls/acl-disable.hcl" "${user}" "${agent}" "/tmp/acl.hcl"
+    doSSH "${agent}" "sudo mv /tmp/acl.hcl ${consul_configs}/acl.hcl"
   done
 
-  # Restart each Consul server agent to pickup the new config.
-  for server in ${servers}; do
-    echo " deactivate: restart Consul Server on ${server} ..."
-    doSSH "${server}" "sudo systemctl restart consul"
-    sleep 3 # let the agent settle
+  # Restart each Consul agent to pickup the new config.
+  for agent in ${servers} ${linux_clients}; do
+    echo " deactivate: restart Consul on ${agent} ..."
+    doSSH "${agent}" "sudo systemctl restart consul"
   done
 
   # Wait 10s before moving on, Consul needs a second to calm down.
@@ -348,12 +399,6 @@ function doStatus {
 
 # It's the entrypoint to our script!
 case "${subcommand}" in
-  bootstrap)
-    # The bootstrap target exists to make some local development easier. Test
-    # cases running from the e2e framework should always use "enable" which aims
-    # to be idempotent.
-    doBootstrap
-    ;;
   enable)
     doEnable
     ;;

--- a/e2e/consulacls/consul-acls-manage.sh
+++ b/e2e/consulacls/consul-acls-manage.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+
+# must be run from e2e directory
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+tfstatefile="terraform/terraform.tfstate"
+
+# Make sure we are running from the e2e/ directory
+[ "$(basename "$(pwd)")" == "e2e" ] || (echo "must be run from nomad/e2e directory" && exit 1)
+
+# Make sure one argument was provided (subcommand)
+[ ${#} -eq 1 ] || (echo "expect one argument (subcommand)" && exit 1)
+
+# Make sure terraform state file exists
+[ -f "${tfstatefile}" ] || (echo "file ${tfstatefile} must exist (run terraform?)" && exit 1)
+
+# Load Linux Client Node IPs from terraform state file
+linux_clients=$(jq -r .outputs.linux_clients.value[] <"${tfstatefile}" | xargs)
+
+# Load Windows Client Node IPs from terraform state file
+windows_clients=$(jq -r .outputs.windows_clients.value[] <"${tfstatefile}" | xargs)
+
+# Combine all the clients together
+clients="${linux_clients} ${windows_clients}"
+
+# Load Server Node IPs from terraform/terraform.tfstate
+servers=$(jq -r .outputs.servers.value[] <"${tfstatefile}" | xargs)
+
+# Use the 0th server as the ACL bootstrap server
+server0=$(echo "${servers}" | cut -d' ' -f1)
+
+# Find the .pem file to use
+pemfile="terraform/$(jq -r '.resources[] | select(.name=="private_key_pem") | .instances[0].attributes.filename' <"terraform/terraform.tfstate")"
+
+# See AWS service file
+consul_configs="/etc/consul.d"
+nomad_configs="/etc/nomad.d"
+
+# Not really present in the config
+user=ubuntu
+
+# Create a filename based on the TF state file (.serial), where we will store and/or
+# lookup the consul master token. The presense of this file is what determines
+# whether a full ACL bootstrap must occur, or if we only need to activate ACLs
+# whenever the "enable" sub-command is chosen.
+token_file="/tmp/e2e-consul-bootstrap-$(jq .serial <${tfstatefile}).token"
+
+# One argument - the subcommand to run which may be: bootstrap, enable, or disable
+subcommand="${1}"
+
+echo "==== SETUP configuration ====="
+echo "SETUP command is: ${subcommand}"
+echo "SETUP token file: ${token_file}"
+echo "SETUP servers: ${servers}"
+echo "SETUP linux clients: ${linux_clients}"
+echo "SETUP windows clients: ${windows_clients}"
+echo "SETUP pem file: ${pemfile}"
+echo "SETUP consul configs: ${consul_configs}"
+echo "SETUP nomad configs: ${nomad_configs}"
+echo "SETUP aws user: ${user}"
+echo "SETUP bootstrap server: ${server0}"
+
+function doSSH() {
+  hostname="$1"
+  command="$2"
+  echo "-----> will ssh command '${command}' on ${hostname}"
+  ssh \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -i "${pemfile}" \
+    "${user}@${hostname}" "${command}"
+}
+
+function doSCP() {
+  original="$1"
+  username="$2"
+  hostname="$3"
+  destination="$4"
+  echo "------> will scp ${original} to ${hostname}"
+  scp \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -i "${pemfile}" \
+    "${original}" "${username}@${hostname}:${destination}"
+}
+
+function doBootstrap() {
+  echo "=== Bootstrap: Consul Configs ==="
+
+  # Stop all Nomad agents.
+  stopNomad
+
+  # Stop all Consul agents.
+  stopConsul
+
+  # Run the activation step, which uploads the ACLs-enabled acl.hcl file
+  # to each Consul Server's configuration directory, then (re)starts each
+  # Consul Server agent.
+  doActivate
+
+  echo "=== Bootstrap: Consul ACL Bootstrap ==="
+
+  # Bootstrap Consul ACLs on server[0]
+  echo "-> bootstrap ACL using ${server0}"
+  consul_http_token=$(doSSH "${server0}" "/usr/local/bin/consul acl bootstrap" | grep SecretID | awk '{print $2}')
+  consul_http_addr="http://${server0}:8500"
+  export CONSUL_HTTP_TOKEN=${consul_http_token}
+  export CONSUL_HTTP_ADDR=${consul_http_addr}
+  echo "  consul http: ${CONSUL_HTTP_ADDR}"
+  echo "  consul root: ${CONSUL_HTTP_TOKEN}"
+  echo "${CONSUL_HTTP_TOKEN}" > "${token_file}"
+
+  # Create Consul Server Policy & Consul Server agent tokens
+  echo "-> configure consul server policy"
+  consul acl policy create -name server-policy -rules @consulacls/consul-server-policy.hcl
+
+  # Create & Set agent token for each Consul Server
+  for server in ${servers}; do
+    echo "---> will create agent token for server ${server}"
+    server_agent_token=$(consul acl token create -description "consul server agent token" -policy-name server-policy | grep SecretID | awk '{print $2}')
+    echo "---> setting token for server agent: ${server} -> ${server_agent_token}"
+    consul acl set-agent-token agent "${server_agent_token}"
+    echo "---> done setting agent token for server ${server}"
+  done
+
+  # Wait 10s before continuing with configuring consul clients.
+  echo "-> sleep 10s"
+  sleep 10
+
+  # Start the Consul Clients back up so we can set their tokens now
+  startConsulClients
+
+  # Create Consul Client Policy & Client agent tokens
+  echo "-> configure consul client policy"
+  consul acl policy create -name client-policy -rules @consulacls/consul-client-policy.hcl
+
+  # Create & Set agent token for each Consul Client (including windows)
+  for client in ${clients}; do
+    echo "---> will create consul agent token for client ${client}"
+    client_agent_token=$(consul acl token create -description "consul client agent token" -policy-name client-policy | grep SecretID | awk '{print $2}')
+    echo "---> setting consul token for consul client ${client} -> ${client_agent_token}"
+    consul acl set-agent-token agent "${client_agent_token}"
+    echo "---> done setting consul agent token for client ${client}"
+  done
+
+  echo "=== Bootstrap: Nomad Configs ==="
+
+  # Create Nomad Server consul Policy and Nomad Server consul tokens
+  echo "-> configure nomad server policy & consul token"
+  consul acl policy create -name nomad-server-policy -rules @consulacls/nomad-server-policy.hcl
+  nomad_server_consul_token=$(consul acl token create -description "nomad server consul token" -policy-name nomad-server-policy | grep SecretID | awk '{print $2}')
+  nomad_server_consul_token_tmp=$(mktemp)
+  cp consulacls/nomad-server-consul.hcl "${nomad_server_consul_token_tmp}"
+  sed -i "s/CONSUL_TOKEN/${nomad_server_consul_token}/g" "${nomad_server_consul_token_tmp}"
+  for server in ${servers}; do
+    echo "---> upload nomad-server-consul.hcl to ${server}"
+    doSCP "${nomad_server_consul_token_tmp}" "${user}" "${server}" "/tmp/nomad-server-consul.hcl"
+    doSSH "${server}" "sudo mv /tmp/nomad-server-consul.hcl ${nomad_configs}/nomad-server-consul.hcl"
+  done
+
+  # Create Nomad Client consul Policy and Nomad Client consul token
+  echo "-> configure nomad client policy & consul token"
+  consul acl policy create -name nomad-client-policy -rules @consulacls/nomad-client-policy.hcl
+  nomad_client_consul_token=$(consul acl token create -description "nomad client consul token" -policy-name nomad-client-policy | grep SecretID | awk '{print $2}')
+  nomad_client_consul_token_tmp=$(mktemp)
+  cp consulacls/nomad-client-consul.hcl "${nomad_client_consul_token_tmp}"
+  sed -i "s/CONSUL_TOKEN/${nomad_client_consul_token}/g" "${nomad_client_consul_token_tmp}"
+  for linux_client in ${linux_clients}; do
+    echo "---> upload nomad-client-token.hcl to ${linux_client}"
+    doSCP "${nomad_client_consul_token_tmp}" "${user}" "${linux_client}" "/tmp/nomad-client-consul.hcl"
+    doSSH "${linux_client}" "sudo mv /tmp/nomad-client-consul.hcl ${nomad_configs}/nomad-client-consul.hcl"
+  done
+
+  startNomad
+
+  export NOMAD_ADDR="http://${server0}:4646"
+
+  echo "=== Activate: DONE ==="
+}
+
+function doEnable() {
+  if [ ! -f "${token_file}" ]; then
+    echo "ENABLE: token file does not exist, doing a full ACL bootstrap"
+    doBootstrap
+  else
+    echo "ENABLE: token file already exists, will activate ACLs"
+    doActivate
+  fi
+
+  echo "=== Enable: DONE ==="
+
+  # show the status of all the agents
+  echo "---> token file is ${token_file}"
+  consul_http_token=$(cat "${token_file}")
+  export CONSUL_HTTP_TOKEN="${consul_http_token}"
+  echo "export CONSUL_HTTP_TOKEN=${CONSUL_HTTP_TOKEN}"
+  doStatus
+}
+
+function doDisable() {
+  if [ ! -f "${token_file}" ]; then
+    echo "DISABLE: token file does not exist, did bootstrap ever happen?"
+    exit 1
+  else
+    echo "DISABLE: token file exists, will deactivate ACLs"
+    doDeactivate
+  fi
+
+  echo "=== Disable: DONE ==="
+
+  # show the status of all the agents
+  unset CONSUL_HTTP_TOKEN
+  doStatus
+}
+
+function doActivate() {
+  echo "=== Activate ==="
+
+  stopConsul
+
+  # Upload acl-enable.hcl to each Consul Server agent's configuration directory.
+  for server in ${servers}; do
+    echo " activate: upload acl-enable.hcl to ${server}::acl.hcl"
+    doSCP "consulacls/acl-enable.hcl" "${user}" "${server}" "/tmp/acl.hcl"
+    doSSH "${server}" "sudo mv /tmp/acl.hcl ${consul_configs}/acl.hcl"
+  done
+
+  # Restart each Consul Server agent to pickup the new config.
+  for server in ${servers}; do
+    echo " activate: restart Consul Server on ${server} ..."
+    doSSH "${server}" "sudo systemctl start consul"
+    sleep 1
+  done
+
+  sleep 10
+
+  startConsulClients
+
+  sleep 10
+
+  echo "=== Activate: DONE ==="
+}
+
+function stopNomad {
+  echo "=== Stop Nomad agents ==="
+  # Stop every Nomad agent (clients and servers) in preperation for Consul ACL
+  # bootstrapping.
+  for server in ${servers}; do
+    echo " stop Nomad Server on ${server}"
+    doSSH "${server}" "sudo systemctl stop nomad"
+    sleep 1
+  done
+
+  for linux_client in ${linux_clients}; do
+    echo " stop Nomad Client on ${linux_client}"
+    doSSH "${linux_client}" "sudo systemctl stop nomad"
+    sleep 1
+  done
+
+  echo "... all nomad agents stopped"
+}
+
+function startNomad {
+  echo "=== Start Nomad agents ==="
+  # Start every Nomad agent (clients and servers) after having Consul ACL
+  # bootstrapped and configurations set for Nomad.
+  for server in ${servers}; do
+    echo " start Nomad Server on ${server}"
+    doSSH "${server}" "sudo systemctl start nomad"
+    sleep 1
+  done
+
+  # give the servers a chance to settle
+  sleep 10
+
+  for linux_client in ${linux_clients}; do
+    echo " start Nomad Client on ${linux_client}"
+    doSSH "${linux_client}" "sudo systemctl start nomad"
+    sleep 3
+  done
+
+  # give the clients a long time to settle
+  sleep 30
+
+  echo "... all nomad agents started"
+}
+
+function stopConsul {
+  echo "=== Stop Consul agents ==="
+  # Stop every Nonsul agent (clients and servers) in preperation for Consul ACL
+  # bootstrapping.
+  for server in ${servers}; do
+    echo " stop Consul Server on ${server}"
+    doSSH "${server}" "sudo systemctl stop consul"
+    sleep 1
+  done
+
+  for linux_client in ${linux_clients}; do
+    echo " stop Consul Client on ${linux_client}"
+    doSSH "${linux_client}" "sudo systemctl stop consul"
+    sleep 1
+  done
+
+  echo "... all consul agents stopped"
+}
+
+function startConsulClients {
+    echo "=== Start Consul Clients ==="
+    # Start Consul Clients
+    for linux_client in ${linux_clients}; do
+      echo " start Consul Client on ${linux_client}"
+      doSSH "${linux_client}" "sudo systemctl start consul"
+      sleep 2
+    done
+
+    sleep 5 # let them settle
+    echo "... all consul clients started"
+}
+
+function doDeactivate {
+  echo "=== Deactivate ==="
+  # Upload acl-disable.hcl to each Consul Server agent's configuration directory.
+  for server in ${servers}; do
+    echo " deactivate: upload acl-disable.hcl to ${server}::acl.hcl"
+    doSCP "consulacls/acl-disable.hcl" "${user}" "${server}" "/tmp/acl.hcl"
+    doSSH "${server}" "sudo mv /tmp/acl.hcl ${consul_configs}/acl.hcl"
+  done
+
+  # Restart each Consul server agent to pickup the new config.
+  for server in ${servers}; do
+    echo " deactivate: restart Consul Server on ${server} ..."
+    doSSH "${server}" "sudo systemctl restart consul"
+    sleep 3 # let the agent settle
+  done
+
+  # Wait 10s before moving on, Consul needs a second to calm down.
+  echo " deactivate: sleep 10s ..."
+  sleep 10
+}
+
+function doStatus {
+  # assumes CONSUL_HTTP_TOKEN is set (or not)
+  echo "consul members"
+  consul members
+  echo ""
+  echo "nomad server members"
+  nomad server members
+  echo ""
+  echo "nomad node status"
+  nomad node status
+  echo ""
+}
+
+# It's the entrypoint to our script!
+case "${subcommand}" in
+  bootstrap)
+    # The bootstrap target exists to make some local development easier. Test
+    # cases running from the e2e framework should always use "enable" which aims
+    # to be idempotent.
+    doBootstrap
+    ;;
+  enable)
+    doEnable
+    ;;
+  disable)
+    doDisable
+    ;;
+  *)
+    echo "incorrect subcommand ${subcommand}"
+    exit 1
+    ;;
+esac

--- a/e2e/consulacls/consul-client-default-token.hcl
+++ b/e2e/consulacls/consul-client-default-token.hcl
@@ -1,0 +1,7 @@
+acl {
+  tokens {
+    agent = "CONSUL_TOKEN"
+    agent_master = "CONSUL_TOKEN"
+    default = "CONSUL_TOKEN"
+  }
+}

--- a/e2e/consulacls/consul-client-policy.hcl
+++ b/e2e/consulacls/consul-client-policy.hcl
@@ -1,0 +1,25 @@
+acl = "write"
+
+agent "" {
+  policy = "write"
+}
+
+event "" {
+  policy = "write"
+}
+
+key "" {
+  policy = "write"
+}
+
+node "" {
+  policy = "write"
+}
+
+query "" {
+  policy = "write"
+}
+
+service "" {
+  policy = "write"
+}

--- a/e2e/consulacls/consul-client-policy.hcl
+++ b/e2e/consulacls/consul-client-policy.hcl
@@ -1,25 +1,25 @@
 acl = "write"
 
-agent "" {
+agent_prefix "" {
   policy = "write"
 }
 
-event "" {
+event_prefix "" {
   policy = "write"
 }
 
-key "" {
+key_prefix "" {
   policy = "write"
 }
 
-node "" {
+node_prefix "" {
   policy = "write"
 }
 
-query "" {
+query_prefix "" {
   policy = "write"
 }
 
-service "" {
+service_prefix "" {
   policy = "write"
 }

--- a/e2e/consulacls/consul-server-policy.hcl
+++ b/e2e/consulacls/consul-server-policy.hcl
@@ -1,0 +1,26 @@
+acl = "write"
+
+agent "" {
+  policy = "write"
+}
+
+event "" {
+  policy = "write"
+}
+
+key "" {
+  policy = "write"
+}
+
+node "" {
+  policy = "write"
+}
+
+query "" {
+  policy = "write"
+}
+
+service "" {
+  policy = "write"
+}
+

--- a/e2e/consulacls/consul-server-policy.hcl
+++ b/e2e/consulacls/consul-server-policy.hcl
@@ -1,25 +1,25 @@
 acl = "write"
 
-agent "" {
+agent_prefix "" {
   policy = "write"
 }
 
-event "" {
+event_prefix "" {
   policy = "write"
 }
 
-key "" {
+key_prefix "" {
   policy = "write"
 }
 
-node "" {
+node_prefix "" {
   policy = "write"
 }
 
-query "" {
+query_prefix "" {
   policy = "write"
 }
 
-service "" {
+service_prefix "" {
   policy = "write"
 }

--- a/e2e/consulacls/consul-server-policy.hcl
+++ b/e2e/consulacls/consul-server-policy.hcl
@@ -23,4 +23,3 @@ query "" {
 service "" {
   policy = "write"
 }
-

--- a/e2e/consulacls/manage.go
+++ b/e2e/consulacls/manage.go
@@ -37,7 +37,6 @@ type Manager interface {
 
 type tfManager struct {
 	serial int
-	token  string
 }
 
 func New(tfStateFile string) (*tfManager, error) {

--- a/e2e/consulacls/manage.go
+++ b/e2e/consulacls/manage.go
@@ -1,0 +1,125 @@
+package consulacls
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/nomad/e2e/framework/provisioning"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// DefaultTFStateFile is the location of the TF state file, as created for the
+// e2e test framework. This file is used to extract the TF serial number, which
+// is used to determine whether the consul bootstrap process is necessary or has
+// already taken place.
+const DefaultTFStateFile = "terraform/terraform.tfstate"
+
+// A Manager is used to manipulate whether Consul ACLs are enabled or disabled.
+// Only works with TF provisioned clusters.
+type Manager interface {
+	// Enable Consul ACLs in the Consul cluster. The Consul ACL master token
+	// associated with the Consul cluster is returned.
+	//
+	// A complete bootstrap process will take place if necessary.
+	//
+	// Once enabled, Consul ACLs can be disabled with Disable.
+	Enable(t *testing.T) string
+
+	// Disable Consul ACLs in the Consul Cluster.
+	//
+	// Once disabled, Consul ACLs can be re-enabled with Enable.
+	Disable(t *testing.T)
+}
+
+type tfManager struct {
+	serial int
+	token  string
+}
+
+func New(tfStateFile string) (*tfManager, error) {
+	serial, err := extractSerial(tfStateFile)
+	if err != nil {
+		return nil, err
+	}
+	return &tfManager{
+		serial: serial,
+	}, nil
+}
+
+func (m *tfManager) Enable(t *testing.T) string {
+	// Create the local script runner that will be used to run the ACL management
+	// script, this time with the "enable" sub-command.
+	var runner provisioning.LinuxRunner
+	err := runner.Open(t)
+	require.NoError(t, err)
+
+	// Run the consul ACL bootstrap script, which will store the master token
+	// in the deterministic path based on the TF state serial number. If the
+	// bootstrap process had already taken place, ACLs will be activated but
+	// without going through the bootstrap process again, re-using the already
+	// existing Consul ACL master token.
+	err = runner.Run(strings.Join([]string{
+		"consulacls/consul-acls-manage.sh", "enable",
+	}, " "))
+	require.NoError(t, err)
+
+	// Read the Consul ACL master token that was generated (or if the token
+	// already existed because the bootstrap process had already taken place,
+	// that one).
+	token, err := m.readToken()
+	require.NoError(t, err)
+	return token
+}
+
+type tfState struct {
+	Serial int `json:"serial"`
+}
+
+// extractSerial will parse the TF state file looking for the serial number.
+func extractSerial(filename string) (int, error) {
+	if filename == "" {
+		filename = DefaultTFStateFile
+	}
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to extract TF serial")
+	}
+	var state tfState
+	if err := json.Unmarshal(b, &state); err != nil {
+		return 0, errors.Wrap(err, "failed to extract TF serial")
+	}
+	return state.Serial, nil
+}
+
+// tokenPath returns the expected path for the Consul ACL master token generated
+// by the consul-acls-manage.sh bootstrap script for the current TF serial version.
+func (m *tfManager) tokenPath() string {
+	return fmt.Sprintf("/tmp/e2e-consul-bootstrap-%d.token", m.serial)
+}
+
+func (m *tfManager) readToken() (string, error) {
+	b, err := ioutil.ReadFile(m.tokenPath())
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func (m *tfManager) Disable(t *testing.T) {
+	// Create the local script runner that will be used to run the ACL management
+	// script, this time with the "disable" sub-command.
+	var runner provisioning.LinuxRunner
+	err := runner.Open(t)
+	require.NoError(t, err)
+
+	// Run the consul ACL bootstrap script, which will modify the Consul Server
+	// ACL policies to disable ACLs, and then restart those agents.
+	err = runner.Run(strings.Join([]string{
+		"consulacls/consul-acls-manage.sh", "disable",
+	}, " "))
+	require.NoError(t, err)
+}

--- a/e2e/consulacls/nomad-client-consul.hcl
+++ b/e2e/consulacls/nomad-client-consul.hcl
@@ -1,0 +1,4 @@
+// The provided consul.token value must be blessed with service=write ACLs.
+consul {
+  token="CONSUL_TOKEN"
+}

--- a/e2e/consulacls/nomad-client-consul.hcl
+++ b/e2e/consulacls/nomad-client-consul.hcl
@@ -1,4 +1,4 @@
 // The provided consul.token value must be blessed with service=write ACLs.
 consul {
-  token="CONSUL_TOKEN"
+  token = "CONSUL_TOKEN"
 }

--- a/e2e/consulacls/nomad-client-policy.hcl
+++ b/e2e/consulacls/nomad-client-policy.hcl
@@ -1,0 +1,6 @@
+// The Nomad Client will be registering things into its buddy Consul Client.
+
+service "" {
+  policy = "write"
+}
+

--- a/e2e/consulacls/nomad-client-policy.hcl
+++ b/e2e/consulacls/nomad-client-policy.hcl
@@ -3,4 +3,3 @@
 service "" {
   policy = "write"
 }
-

--- a/e2e/consulacls/nomad-client-policy.hcl
+++ b/e2e/consulacls/nomad-client-policy.hcl
@@ -1,5 +1,13 @@
 // The Nomad Client will be registering things into its buddy Consul Client.
 
-service "" {
+service_prefix "" {
   policy = "write"
+}
+
+node_prefix "" {
+  policy = "write"
+}
+
+agent_prefix "" {
+  policy = "read"
 }

--- a/e2e/consulacls/nomad-server-consul.hcl
+++ b/e2e/consulacls/nomad-server-consul.hcl
@@ -1,0 +1,8 @@
+// Nomad Server needs to set allow_unauthenticated=false to enforce the use
+// of a Consul Operator Token on job submission for Connect enabled jobs.
+//
+// The provided consul.token value must be blessed with acl=write ACLs.
+consul {
+  allow_unauthenticated = false
+  token="CONSUL_TOKEN"
+}

--- a/e2e/consulacls/nomad-server-consul.hcl
+++ b/e2e/consulacls/nomad-server-consul.hcl
@@ -4,5 +4,5 @@
 // The provided consul.token value must be blessed with acl=write ACLs.
 consul {
   allow_unauthenticated = false
-  token="CONSUL_TOKEN"
+  token                 = "CONSUL_TOKEN"
 }

--- a/e2e/consulacls/nomad-server-policy.hcl
+++ b/e2e/consulacls/nomad-server-policy.hcl
@@ -1,0 +1,6 @@
+// The Nomad Server requires total access to Consul ACLs, because the Server
+// will be requesting new SI tokens from Consul.
+
+acl = "write"
+
+

--- a/e2e/consulacls/nomad-server-policy.hcl
+++ b/e2e/consulacls/nomad-server-policy.hcl
@@ -2,5 +2,3 @@
 // will be requesting new SI tokens from Consul.
 
 acl = "write"
-
-

--- a/e2e/consulacls/nomad-server-policy.hcl
+++ b/e2e/consulacls/nomad-server-policy.hcl
@@ -2,3 +2,15 @@
 // will be requesting new SI tokens from Consul.
 
 acl = "write"
+
+service_prefix "" {
+  policy = "write"
+}
+
+node_prefix "" {
+  policy = "write"
+}
+
+agent_prefix "" {
+  policy = "read"
+}

--- a/e2e/deployment/deployment.go
+++ b/e2e/deployment/deployment.go
@@ -41,13 +41,13 @@ func (tc *DeploymentTest) TestDeploymentAutoPromote(f *framework.F) {
 	// unique each run, cluster could have previous jobs
 	jobId := "deployment" + uuid[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
-	e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "deployment/input/deployment_auto0.nomad", jobId)
+	e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "deployment/input/deployment_auto0.nomad", jobId, "")
 	ds := e2eutil.DeploymentsForJob(t, nomadClient, jobId)
 	require.Equal(t, 1, len(ds))
 	deploy := ds[0]
 
 	// Upgrade
-	e2eutil.RegisterAllocs(t, nomadClient, "deployment/input/deployment_auto1.nomad", jobId)
+	e2eutil.RegisterAllocs(t, nomadClient, "deployment/input/deployment_auto1.nomad", jobId, "")
 
 	// Find the deployment we don't already have
 	testutil.WaitForResult(func() (bool, error) {

--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -54,12 +54,25 @@ func WaitForNodesReady(t *testing.T, nomadClient *api.Client, nodes int) {
 	})
 }
 
-func RegisterAllocs(t *testing.T, nomadClient *api.Client, jobFile string, jobID string) []*api.AllocationListStub {
+func stringToPtrOrNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return helper.StringToPtr(s)
+}
+
+func RegisterAllocs(t *testing.T, nomadClient *api.Client, jobFile, jobID, cToken string) []*api.AllocationListStub {
+	r := require.New(t)
+
 	// Parse job
 	job, err := jobspec.ParseFile(jobFile)
-	require := require.New(t)
-	require.Nil(err)
+	r.Nil(err)
+
+	// Set custom job ID (distinguish among tests)
 	job.ID = helper.StringToPtr(jobID)
+
+	// Set a Consul "operator" token for the job, if provided.
+	job.ConsulToken = stringToPtrOrNil(cToken)
 
 	// Register job
 	var idx uint64
@@ -72,30 +85,32 @@ func RegisterAllocs(t *testing.T, nomadClient *api.Client, jobFile string, jobID
 		idx = meta.LastIndex
 		return resp.EvalID != "", fmt.Errorf("expected EvalID:%s", pretty.Sprint(resp))
 	}, func(err error) {
-		require.NoError(err)
+		r.NoError(err)
 	})
 
-	allocs, _, _ := jobs.Allocations(jobID, false, &api.QueryOptions{WaitIndex: idx})
+	allocs, _, err := jobs.Allocations(jobID, false, &api.QueryOptions{WaitIndex: idx})
+	require.NoError(t, err)
 	return allocs
 }
 
-func RegisterAndWaitForAllocs(t *testing.T, nomadClient *api.Client, jobFile string, jobID string) []*api.AllocationListStub {
-	require := require.New(t)
+func RegisterAndWaitForAllocs(t *testing.T, nomadClient *api.Client, jobFile, jobID, cToken string) []*api.AllocationListStub {
+	r := require.New(t)
 	g := NewGomegaWithT(t)
 	jobs := nomadClient.Jobs()
 
 	// Start allocations
-	RegisterAllocs(t, nomadClient, jobFile, jobID)
+	RegisterAllocs(t, nomadClient, jobFile, jobID, cToken)
 
 	// Wrap in retry to wait until placement
 	g.Eventually(func() []*api.AllocationListStub {
 		// Look for allocations
 		allocs, _, _ := jobs.Allocations(jobID, false, nil)
+		fmt.Println("!! Eventually Allocations:", allocs)
 		return allocs
 	}, 30*time.Second, time.Second).ShouldNot(BeEmpty())
 
 	allocs, _, err := jobs.Allocations(jobID, false, nil)
-	require.NoError(err)
+	r.NoError(err)
 	return allocs
 }
 
@@ -111,6 +126,20 @@ func WaitForAllocRunning(t *testing.T, nomadClient *api.Client, allocID string) 
 	}, func(err error) {
 		t.Fatalf("failed to wait on alloc: %v", err)
 	})
+}
+
+func WaitForAllocsRunning(t *testing.T, nomadClient *api.Client, allocIDs []string) {
+	for _, allocID := range allocIDs {
+		WaitForAllocRunning(t, nomadClient, allocID)
+	}
+}
+
+func AllocIDsFromAllocationListStubs(allocs []*api.AllocationListStub) []string {
+	allocIDs := make([]string, 0, len(allocs))
+	for _, alloc := range allocs {
+		allocIDs = append(allocIDs, alloc.ID)
+	}
+	return allocIDs
 }
 
 func DeploymentsForJob(t *testing.T, nomadClient *api.Client, jobID string) []*api.Deployment {

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -303,6 +303,7 @@ func isTestMethod(m string) bool {
 	if !strings.HasPrefix(m, "Test") {
 		return false
 	}
+
 	// THINKING: adding flag to target a specific test or test regex?
 	return true
 }

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -183,7 +183,6 @@ func (f *Framework) Run(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 // Run starts the package scoped Framework, running each TestSuite

--- a/e2e/framework/provisioning/runner_linux.go
+++ b/e2e/framework/provisioning/runner_linux.go
@@ -1,25 +1,57 @@
 package provisioning
 
 import (
+	"context"
+	"fmt"
+	"log"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/pkg/errors"
 )
 
 // LinuxRunner is a ProvisioningRunner that runs on the executing host only.
 // The Nomad configurations used with this runner will need to avoid port
 // conflicts!
-type LinuxRunner struct{}
+//
+// Must call Open before other methods.
+type LinuxRunner struct {
+	// populated on Open.
+	t *testing.T
+}
 
-func (runner *LinuxRunner) Open(_ *testing.T) error { return nil }
+// Open sets up the LinuxRunner to run using t as a logging mechanism.
+func (runner *LinuxRunner) Open(t *testing.T) error {
+	runner.t = t
+	return nil
+}
 
+func parseCommand(command string) (string, []string) {
+	fields := strings.Fields(strings.TrimSpace(command))
+	if len(fields) == 1 {
+		return fields[0], nil
+	}
+	return fields[0], fields[1:]
+}
+
+// Run the script (including any arguments)
 func (runner *LinuxRunner) Run(script string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
 	commands := strings.Split(script, "\n")
 	for _, command := range commands {
-		cmd := exec.Command(strings.TrimSpace(command))
-		err := cmd.Run()
+		executable, args := parseCommand(command)
+		response, err := exec.CommandContext(ctx, executable, args...).CombinedOutput()
+
+		// Nothing fancy around separating stdin from stdout, or failed vs
+		// successful commands for now.
+		runner.LogOutput(string(response))
+
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to execute command %q", command)
 		}
 	}
 	return nil
@@ -31,3 +63,22 @@ func (runner *LinuxRunner) Copy(local, remote string) error {
 }
 
 func (runner *LinuxRunner) Close() {}
+
+func (runner *LinuxRunner) Logf(format string, args ...interface{}) {
+	if runner.t == nil {
+		log.Fatal("no t.Testing configured for LinuxRunner")
+	}
+	if testing.Verbose() {
+		fmt.Printf("[local] "+format+"\n", args...)
+	} else {
+		runner.t.Logf("[local] "+format, args...)
+	}
+}
+
+func (runner *LinuxRunner) LogOutput(output string) {
+	if testing.Verbose() {
+		fmt.Println("\033[32m" + output + "\033[0m")
+	} else {
+		runner.t.Log(output)
+	}
+}

--- a/e2e/hostvolumes/host_volumes.go
+++ b/e2e/hostvolumes/host_volumes.go
@@ -39,7 +39,7 @@ func (tc *BasicHostVolumeTest) TestSingleHostVolume(f *framework.F) {
 	uuid := uuid.Generate()
 	jobID := "hostvol" + uuid[0:8]
 	tc.jobIds = append(tc.jobIds, jobID)
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "hostvolumes/input/single_mount.nomad", jobID)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "hostvolumes/input/single_mount.nomad", jobID, "")
 
 	waitForTaskState := func(desiredState string) {
 		require.Eventually(func() bool {

--- a/e2e/metrics/metrics.go
+++ b/e2e/metrics/metrics.go
@@ -117,7 +117,7 @@ func (tc *MetricsTest) runWorkloads(t *testing.T, workloads map[string]string) {
 		jobID := "metrics-" + jobName + "-" + uuid[0:8]
 		tc.jobIDs = append(tc.jobIDs, jobID)
 		file := "metrics/input/" + jobName + ".nomad"
-		allocs := e2eutil.RegisterAndWaitForAllocs(t, tc.Nomad(), file, jobID)
+		allocs := e2eutil.RegisterAndWaitForAllocs(t, tc.Nomad(), file, jobID, "")
 		if len(allocs) == 0 {
 			t.Fatalf("failed to register %s", jobID)
 		}

--- a/e2e/metrics/prometheus.go
+++ b/e2e/metrics/prometheus.go
@@ -17,7 +17,7 @@ func (tc *MetricsTest) setUpPrometheus(f *framework.F) error {
 	uuid := uuid.Generate()
 	fabioID := "fabio" + uuid[0:8]
 	fabioAllocs := e2eutil.RegisterAndWaitForAllocs(f.T(), tc.Nomad(),
-		"fabio/fabio.nomad", fabioID)
+		"fabio/fabio.nomad", fabioID, "")
 	if len(fabioAllocs) < 1 {
 		return fmt.Errorf("fabio failed to start")
 	}
@@ -36,7 +36,7 @@ func (tc *MetricsTest) setUpPrometheus(f *framework.F) error {
 	tc.fabioAddress = fmt.Sprintf("http://%s:9999", publicIP)
 	prometheusID := "prometheus" + uuid[0:8]
 	prometheusAllocs := e2eutil.RegisterAndWaitForAllocs(f.T(), tc.Nomad(),
-		"prometheus/prometheus.nomad", prometheusID)
+		"prometheus/prometheus.nomad", prometheusID, "")
 	if len(prometheusAllocs) < 1 {
 		return fmt.Errorf("prometheus failed to start")
 	}

--- a/e2e/nomad09upgrade/upgrade.go
+++ b/e2e/nomad09upgrade/upgrade.go
@@ -160,7 +160,7 @@ func (tc *UpgradePathTC) testUpgradeForJob(t *testing.T, ver string, jobfile str
 	// Register a sleep job
 	jobID := "sleep-" + uuid.Generate()[:8]
 	t.Logf("registering exec job with id %s", jobID)
-	e2eutil.RegisterAndWaitForAllocs(t, client, jobfile, jobID)
+	e2eutil.RegisterAndWaitForAllocs(t, client, jobfile, jobID, "")
 	allocs, _, err := client.Jobs().Allocations(jobID, false, nil)
 	require.NoError(err)
 	require.Len(allocs, 1)

--- a/e2e/nomadexec/exec.go
+++ b/e2e/nomadexec/exec.go
@@ -57,7 +57,7 @@ func (tc *NomadExecE2ETest) BeforeAll(f *framework.F) {
 
 	// register a job for execing into
 	tc.jobID = "nomad-exec" + uuid.Generate()[:8]
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), tc.Nomad(), tc.jobFilePath, tc.jobID)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), tc.Nomad(), tc.jobFilePath, tc.jobID, "")
 	f.Len(allocs, 1)
 
 	e2eutil.WaitForAllocRunning(f.T(), tc.Nomad(), allocs[0].ID)

--- a/e2e/spread/spread.go
+++ b/e2e/spread/spread.go
@@ -34,7 +34,7 @@ func (tc *SpreadTest) TestEvenSpread(f *framework.F) {
 	uuid := uuid.Generate()
 	jobId := "spread" + uuid[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "spread/input/even_spread.nomad", jobId)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "spread/input/even_spread.nomad", jobId, "")
 
 	jobAllocs := nomadClient.Allocations()
 	dcToAllocs := make(map[string]int)
@@ -61,7 +61,7 @@ func (tc *SpreadTest) TestMultipleSpreads(f *framework.F) {
 	uuid := uuid.Generate()
 	jobId := "spread" + uuid[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "spread/input/multiple_spread.nomad", jobId)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "spread/input/multiple_spread.nomad", jobId, "")
 
 	jobAllocs := nomadClient.Allocations()
 	dcToAllocs := make(map[string]int)

--- a/e2e/taskevents/taskevents.go
+++ b/e2e/taskevents/taskevents.go
@@ -67,7 +67,7 @@ func (tc *TaskEventsTest) waitUntilEvents(f *framework.F, jobName string, numEve
 	tc.jobIds = append(tc.jobIds, uniqJobId)
 
 	jobFile := fmt.Sprintf("taskevents/input/%s.nomad", jobName)
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, jobFile, uniqJobId)
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, jobFile, uniqJobId, "")
 
 	require.Len(t, allocs, 1)
 	allocID := allocs[0].ID


### PR DESCRIPTION
This PR introduces a way to enable Consul ACLs in our e2e environment (as provisioned with TF), and adds some basic tests for using Consul Connect from Nomad with Consul ACLs enabled.

The bootstrap script is meant to be re-usable inside a single e2e run, so future tests could also make use of it if they wish. It's very slow on the first run, and kind of slow on subsequent runs since agents need to be restarted to pick up ACL config changes. Hopefully this will all be made obsolete by `shipyard` in the near future!


The queue of branches to merge for connect w/ acls
master <- dev-connect-acls (tracking) <- f-connect-acl-cleanup (#6905) <- f-e2e-consul-acls (this)

Addresses #6917 (at least to the point needed for these Connect tests)
