### PR TITLE
tests: Avoid StartAsLeader raft config flag

### DIFF
--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -345,7 +345,6 @@ func (a *TestAgent) config() *Config {
 	config.RaftConfig.LeaderLeaseTimeout = 20 * time.Millisecond
 	config.RaftConfig.HeartbeatTimeout = 40 * time.Millisecond
 	config.RaftConfig.ElectionTimeout = 40 * time.Millisecond
-	config.RaftConfig.StartAsLeader = true
 	config.RaftTimeout = 500 * time.Millisecond
 
 	// Tighten the autopilot timing

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1213,7 +1213,7 @@ func (s *Server) setupRaft() error {
 
 	// If we are in bootstrap or dev mode and the state is clean then we can
 	// bootstrap now.
-	if s.config.Bootstrap || s.config.DevMode {
+	if s.config.Bootstrap || (s.config.DevMode && !s.config.DevDisableBootstrap) {
 		hasState, err := raft.HasExistingState(log, stable, snap)
 		if err != nil {
 			return err

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -86,9 +86,6 @@ func TestServer(t testing.T, cb func(*Config)) (*Server, func()) {
 		cb(config)
 	}
 
-	// Enable raft as leader if we have bootstrap on
-	config.RaftConfig.StartAsLeader = !config.DevDisableBootstrap
-
 	catalog := consul.NewMockCatalog(config.Logger)
 
 	for i := 10; i >= 0; i-- {


### PR DESCRIPTION
`StartAsLeader` is being deprecated and removed in https://github.com/hashicorp/raft/pull/386 .  It doesn't seem we need it, so let's remove it from our test setup in preparation.