### PR TITLE
docs: add Go versioning policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* build: Updated to Go 1.12.15 [[GH-6950](https://github.com/hashicorp/nomad/issues/6950)]
 * cli: Added option to change the name of the file created by the `nomad init` command [[GH-6520]](https://github.com/hashicorp/nomad/pull/6520)
 * cli: Included namespace in output when querying job stauts. [[GH-6912](https://github.com/hashicorp/nomad/issues/6912)]
 * scheduler: Removed penalty for allocation's previous node if the allocation did not fail. [[GH-6781](https://github.com/hashicorp/nomad/issues/6781)]

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -39,3 +39,7 @@ developers and reviewers confidence that the proper changes have been made:
 * [New `jobspec` entry](checklist-jobspec.md)
 * [New CLI command](checklist-command.md)
 * [New RPC endpoint](checklist-rpc-endpoint.md)
+
+## Tooling
+
+* [Go tool versions](golang.md)

--- a/contributing/golang.md
+++ b/contributing/golang.md
@@ -1,0 +1,30 @@
+# Nomad Go Version
+
+Nomad is intended to be built with a specific version of the Go toolchain for
+each release. Generally, each Y release of Nomad (where 0.9.5 means X=0, Y=9,
+Z=5) will update to the latest version of the Go toolchain available at the
+time.
+
+Nomad Z releases update to the latest Go Z release but do *not* change Go's Y
+version.
+
+## Version Table
+
+| Nomad Version | Go Version |
+|:-------------:|:----------:|
+| 0.11          | 1.13       |
+| 0.10          | 1.12       |
+| 0.9           | 1.11       |
+
+## Code
+
+The
+[`update_golang_version.sh`](https://github.com/hashicorp/nomad/blob/master/scripts/update_golang_version.sh)
+script is used to update the Go version for all build tools.
+
+The [Changelog](https://github.com/hashicorp/nomad/blob/v0.10.2/CHANGELOG.md)
+will note when the Go version has changed in the Improvements section:
+
+```
+* build: Updated to Go 1.12.13 [GH-6606]
+```


### PR DESCRIPTION
I don't intend this little doc to contain an up-to-date list of Go versions necessarily, but I thought it might be useful to document our policy and provide links to where people can discover the exact version used (Changelog or build scripts).