### PR TITLE
System sched ignore ineligible updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ BUG FIXES:
  * drivers: Fixed a bug where exec, java, and raw_exec drivers collected and emited stats every second regardless of the telemetry config [[GH-7043](https://github.com/hashicorp/nomad/issues/7043)]
  * server: Fixed a deadlock that may occur when server leadership flaps very quickly [[GH-6977](https://github.com/hashicorp/nomad/issues/6977)]
  * scheduler: Fixed a bug that caused evicted allocs on a lost node to be stuck in running. [[GH-6902](https://github.com/hashicorp/nomad/issues/6902)]
- * scheduler: Fixed a bug where `nomad job plan/apply` returned errors instead of a partial placement warning for ineligible nodes. [[GH-6968](https://github.com/hashicorp/nomad/issues/6968)]
+ * scheduler: Fixed a bug where `nomad job plan/apply` returned errors instead of ignoring system job updates for ineligible nodes. [[GH-6996](https://github.com/hashicorp/nomad/issues/6996)]
 
 ## 0.10.3 (January 29, 2020)
 

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -276,11 +276,6 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 		node, ok := nodeByID[missing.Alloc.NodeID]
 		if !ok {
 			s.logger.Debug("could not find node %q", missing.Alloc.NodeID)
-			if s.failedTGAllocs == nil {
-				s.failedTGAllocs = make(map[string]*structs.AllocMetric)
-			}
-
-			s.failedTGAllocs[missing.TaskGroup.Name] = s.ctx.Metrics()
 			continue
 		}
 

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -1310,6 +1310,11 @@ func TestSystemSched_Queued_With_Constraints(t *testing.T) {
 
 }
 
+// This test ensures that the scheduler correctly ignores ineligible
+// nodes when scheduling due to a new node being added. The job has two
+// task groups contrained to a particular node class. The desired behavior
+// should be that the TaskGroup constrained to the newly added node class is
+// added and that the TaskGroup constrained to the ineligible node is ignored.
 func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 	h := NewHarness(t)
 
@@ -1376,8 +1381,8 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 	require.Equal(t, 0, val)
 
 	// Single plan with two NodeAllocations
-	require.Equal(t, 1, len(h.Plans))
-	require.Equal(t, 2, len(h.Plans[0].NodeAllocation))
+	require.Len(t, h.Plans, 1)
+	require.Len(t, h.Plans[0].NodeAllocation, 2)
 
 	// Mark the node as ineligible
 	node.SchedulingEligibility = structs.NodeSchedulingIneligible
@@ -1402,7 +1407,7 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 
 	// Ensure all NodeAllocations are from first Eval
 	for _, allocs := range h.Plans[0].NodeAllocation {
-		require.Equal(t, 1, len(allocs))
+		require.Len(t, allocs, 1)
 		require.Equal(t, eval.ID, allocs[0].EvalID)
 	}
 
@@ -1432,11 +1437,11 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 	// Ensure no failed TG allocs
 	require.Equal(t, 0, len(h.Evals[2].FailedTGAllocs))
 
-	require.Equal(t, 2, len(h.Plans))
-	require.Equal(t, 1, len(h.Plans[1].NodeAllocation))
+	require.Len(t, h.Plans, 2)
+	require.Len(t, h.Plans[1].NodeAllocation, 1)
 	// Ensure all NodeAllocations are from first Eval
 	for _, allocs := range h.Plans[1].NodeAllocation {
-		require.Equal(t, 1, len(allocs))
+		require.Len(t, allocs, 1)
 		require.Equal(t, eval3.ID, allocs[0].EvalID)
 	}
 
@@ -1444,15 +1449,15 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 
 	allocsNodeOne, err := h.State.AllocsByNode(ws, node.ID)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allocsNodeOne))
+	require.Len(t, allocsNodeOne, 1)
 
 	allocsNodeTwo, err := h.State.AllocsByNode(ws, nodeB.ID)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allocsNodeTwo))
+	require.Len(t, allocsNodeTwo, 1)
 
 	allocsNodeThree, err := h.State.AllocsByNode(ws, nodeBTwo.ID)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allocsNodeThree))
+	require.Len(t, allocsNodeThree, 1)
 }
 
 // No errors reported when no available nodes prevent placement

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -162,6 +162,8 @@ func diffSystemAllocsForNode(job *structs.Job, nodeID string,
 		// update or ignore above. Ignore placements for tainted or
 		// ineligible nodes
 		if !ok {
+			// Tainted and ineligible nodes for a non existing alloc
+			// should be filtered out and not count towards ignore or place
 			if _, tainted := taintedNodes[nodeID]; tainted {
 				continue
 			}

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -36,6 +36,9 @@ func TestDiffAllocs(t *testing.T) {
 	*oldJob = *job
 	oldJob.JobModifyIndex -= 1
 
+	eligibleNode := mock.Node()
+	eligibleNode.ID = "zip"
+
 	drainNode := mock.Node()
 	drainNode.Drain = true
 
@@ -45,6 +48,10 @@ func TestDiffAllocs(t *testing.T) {
 	tainted := map[string]*structs.Node{
 		"dead":      deadNode,
 		"drainNode": drainNode,
+	}
+
+	eligible := map[string]*structs.Node{
+		eligibleNode.ID: eligibleNode,
 	}
 
 	allocs := []*structs.Allocation{
@@ -113,7 +120,7 @@ func TestDiffAllocs(t *testing.T) {
 		},
 	}
 
-	diff := diffAllocs(job, tainted, required, allocs, terminalAllocs)
+	diff := diffSystemAllocsForNode(job, "zip", eligible, tainted, required, allocs, terminalAllocs)
 	place := diff.place
 	update := diff.update
 	migrate := diff.migrate


### PR DESCRIPTION
If `diffAllocs` returns update or place diffs for a system job on an ineligible node, ignore it instead of computing placements