### PR TITLE
docs: reseting bootstrap doesn't invalidate token

### DIFF
--- a/website/source/guides/security/acl.html.markdown
+++ b/website/source/guides/security/acl.html.markdown
@@ -419,6 +419,8 @@ Error bootstrapping: Unexpected response code: 500 (Invalid bootstrap reset inde
 
 This is because the reset file is in place, but with the incorrect index. The reset file can be deleted, but Nomad will not reset the bootstrap until the index is corrected.
 
+Resetting ACL Bootstrap does not automatically invalidate previous ACL tokens: Previous bootstrap token remains a valid, and existing tools that utilize it remain functional. If the token is unused, or if a management token is suspected of being vulnerable, then we should invalidate it, update any existing system with new tokens, and audit all existing tokens.
+
 ## Vault Integration
 
 HashiCorp Vault has a secret backend for generating short-lived Nomad tokens. As Vault has a number of authentication backends, it could provide a workflow where a user or orchestration system authenticates using an pre-existing identity service (LDAP, Okta, Amazon IAM, etc.) in order to obtain a short-lived Nomad token.

--- a/website/source/guides/security/acl.html.markdown
+++ b/website/source/guides/security/acl.html.markdown
@@ -419,7 +419,7 @@ Error bootstrapping: Unexpected response code: 500 (Invalid bootstrap reset inde
 
 This is because the reset file is in place, but with the incorrect index. The reset file can be deleted, but Nomad will not reset the bootstrap until the index is corrected.
 
-Resetting ACL Bootstrap does not automatically invalidate previous ACL tokens: Previous bootstrap token remains a valid, and existing tools that utilize it remain functional. If the token is unused, or if a management token is suspected of being vulnerable, then we should invalidate it, update any existing system with new tokens, and audit all existing tokens.
+Resetting ACL Bootstrap does not automatically invalidate previous ACL tokens: the previous bootstrap token remains valid, and existing tools that utilize it remain functional. If the token is unused, or if a management token is suspected of being compromised, then we should invalidate it, update any existing system with new tokens, and audit all existing tokens.
 
 ## Vault Integration
 


### PR DESCRIPTION
Documenting that reseting bootstrap doesn't invalidate bootstrap token.

Closes https://github.com/hashicorp/nomad/issues/6937 .
