### PR TITLE
e2e: packer builds should not be public

### DIFF
--- a/e2e/terraform/packer/packer-windows.json
+++ b/e2e/terraform/packer/packer-windows.json
@@ -16,9 +16,6 @@
       },
       "instance_type": "t2.medium",
       "ami_name": "nomad-e2e-windows-2016-{{timestamp}}",
-      "ami_groups": [
-        "all"
-      ],
       "communicator": "winrm",
       "user_data_file": "windows/setupwinrm.ps1",
       "winrm_username": "Administrator",

--- a/e2e/terraform/packer/packer.json
+++ b/e2e/terraform/packer/packer.json
@@ -8,9 +8,6 @@
       "ssh_username": "ubuntu",
       "iam_instance_profile": "packer-builder",
       "ami_name": "nomad-e2e-{{timestamp}}",
-      "ami_groups": [
-        "all"
-      ],
       "tags": {
         "OS": "Ubuntu"
       }


### PR DESCRIPTION
While not a matter of exposing secrets, having AMIs for e2e exposed to the public presents an annoying compliance issue. This fixes it in our packer builds and I've run the following to fix it on the existing images:

```sh
aws ec2 describe-images --owners self \
    | jq -r '.Images[] | select(.Public == true) | .ImageId' \
    | xargs -I% aws ec2 modify-image-attribute \
            --image-id % \
            --launch-permission "Remove=[{Group=all}]"
```