### PR TITLE
CSI: Use Plugin not Driver

### DIFF
--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	DriverNotFoundErr = errors.New("Driver not found")
+	PluginNotFoundErr = errors.New("Plugin not found")
 )
 
 type MountInfo struct {
@@ -25,7 +25,7 @@ type Manager interface {
 	PluginManager() pluginmanager.PluginManager
 
 	// MounterForVolume returns a VolumeMounter for the given requested volume.
-	// If there is no plugin registered for this volume type, a DriverNotFoundErr
+	// If there is no plugin registered for this volume type, a PluginNotFoundErr
 	// will be returned.
 	MounterForVolume(ctx context.Context, volume *structs.CSIVolume) (VolumeMounter, error)
 

--- a/client/pluginmanager/csimanager/manager.go
+++ b/client/pluginmanager/csimanager/manager.go
@@ -72,12 +72,12 @@ func (c *csiManager) PluginManager() pluginmanager.PluginManager {
 func (c *csiManager) MounterForVolume(ctx context.Context, vol *structs.CSIVolume) (VolumeMounter, error) {
 	nodePlugins, hasAnyNodePlugins := c.instances["csi-node"]
 	if !hasAnyNodePlugins {
-		return nil, DriverNotFoundErr
+		return nil, PluginNotFoundErr
 	}
 
-	mgr, hasDriver := nodePlugins[vol.Driver]
-	if !hasDriver {
-		return nil, DriverNotFoundErr
+	mgr, hasPlugin := nodePlugins[vol.PluginID]
+	if !hasPlugin {
+		return nil, PluginNotFoundErr
 	}
 
 	return mgr.VolumeMounter(ctx)


### PR DESCRIPTION
This standardizes calling everything a CSI Plugin and `PluginID` in code. The ecosystem is split sometimes using Plugin and sometimes Driver (often on the same page). The spec uses Plugin, and Nomad already has a Driver concept. Either way we'll need to clarify in documentation.