### PR TITLE
csi: add empty CSI volume GC to scheduled core job loop

### DIFF
--- a/nomad/config.go
+++ b/nomad/config.go
@@ -188,6 +188,10 @@ type Config struct {
 	// for GC. This gives users some time to view terminal deployments.
 	DeploymentGCThreshold time.Duration
 
+	// CSIVolumePublicationGCInterval is how often we dispatch a job to GC
+	// unclaimed CSI volume publications.
+	CSIVolumePublicationGCInterval time.Duration
+
 	// EvalNackTimeout controls how long we allow a sub-scheduler to
 	// work on an evaluation before we consider it failed and Nack it.
 	// This allows that evaluation to be handed to another sub-scheduler
@@ -359,6 +363,7 @@ func DefaultConfig() *Config {
 		NodeGCThreshold:                  24 * time.Hour,
 		DeploymentGCInterval:             5 * time.Minute,
 		DeploymentGCThreshold:            1 * time.Hour,
+		CSIVolumePublicationGCInterval:   60 * time.Second,
 		EvalNackTimeout:                  60 * time.Second,
 		EvalDeliveryLimit:                3,
 		EvalNackInitialReenqueueDelay:    1 * time.Second,

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -50,6 +50,8 @@ func (c *CoreScheduler) Process(eval *structs.Evaluation) error {
 		return c.jobGC(eval)
 	case structs.CoreJobDeploymentGC:
 		return c.deploymentGC(eval)
+	case structs.CoreJobCSIVolumePublicationGC:
+		return c.csiVolumePublicationGC(eval)
 	case structs.CoreJobForceGC:
 		return c.forceGC(eval)
 	default:
@@ -702,4 +704,11 @@ func allocGCEligible(a *structs.Allocation, job *structs.Job, gcTime time.Time, 
 	timeDiff := gcTime.UTC().UnixNano() - lastRescheduleEvent.RescheduleTime
 
 	return timeDiff > interval.Nanoseconds()
+}
+
+// csiVolumeGC is used to garbage collect CSI volume publications
+func (c *CoreScheduler) csiVolumePublicationGC(eval *structs.Evaluation) error {
+	// TODO: implement me!
+	c.logger.Trace("garbage collecting unclaimed CSI volume publications")
+	return nil
 }

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -460,6 +460,8 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 	defer jobGC.Stop()
 	deploymentGC := time.NewTicker(s.config.DeploymentGCInterval)
 	defer deploymentGC.Stop()
+	csiVolumePublicationGC := time.NewTicker(s.config.CSIVolumePublicationGCInterval)
+	defer csiVolumePublicationGC.Stop()
 
 	// getLatest grabs the latest index from the state store. It returns true if
 	// the index was retrieved successfully.
@@ -491,6 +493,10 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 		case <-deploymentGC.C:
 			if index, ok := getLatest(); ok {
 				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobDeploymentGC, index))
+			}
+		case <-csiVolumePublicationGC.C:
+			if index, ok := getLatest(); ok {
+				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobCSIVolumePublicationGC, index))
 			}
 		case <-stopCh:
 			return

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8488,6 +8488,11 @@ const (
 	// check if they are terminal. If so, we delete these out of the system.
 	CoreJobDeploymentGC = "deployment-gc"
 
+	// CoreJobCSIVolumePublicationGC is use for the garbage collection of CSI
+	// volume publications. We periodically scan volumes to see if no allocs are
+	// claiming them. If so, we unpublish the volume.
+	CoreJobCSIVolumePublicationGC = "csi-volume-publication-gc"
+
 	// CoreJobForceGC is used to force garbage collection of all GCable objects.
 	CoreJobForceGC = "force-gc"
 )


### PR DESCRIPTION
This changeset adds a new core job type `CoreJobCSIVolumeGC` to the
leader's loop for scheduling core job evals. Right now this is an
empty method body without even a config file stanza. Later changesets
will implement the logic of volume GC.

---

Running with trace-level logging:

```
2020-01-29T16:12:06.030Z [TRACE] core.sched: garbage collecting unclaimed CSI volumes
```

Placeholder tests:

```
▶ go test ./nomad -run TestCoreScheduler_CSIVolumeGC
ok      github.com/hashicorp/nomad/nomad        1.440s
```