### PR TITLE
UI: Disable client write actions when ACL token only allows client read

### DIFF
--- a/ui/app/abilities/client.js
+++ b/ui/app/abilities/client.js
@@ -1,15 +1,16 @@
 import { Ability } from 'ember-can';
 import { inject as service } from '@ember/service';
 import { computed, get } from '@ember/object';
-import { equal, or } from '@ember/object/computed';
+import { equal, or, not } from '@ember/object/computed';
 
 export default Ability.extend({
   token: service(),
 
   // Map abilities to policy options (which are coarse for nodes)
   // instead of specific behaviors.
-  canWrite: or('selfTokenIsManagement', 'policiesIncludeNodeWrite'),
+  canWrite: or('bypassAuthorization', 'selfTokenIsManagement', 'policiesIncludeNodeWrite'),
 
+  bypassAuthorization: not('token.aclEnabled'),
   selfTokenIsManagement: equal('token.selfToken.type', 'management'),
 
   policiesIncludeNodeWrite: computed('token.selfTokenPolicies.[]', function() {

--- a/ui/app/abilities/client.js
+++ b/ui/app/abilities/client.js
@@ -1,0 +1,25 @@
+import { Ability } from 'ember-can';
+import { inject as service } from '@ember/service';
+import { computed, get } from '@ember/object';
+import { equal, or } from '@ember/object/computed';
+
+export default Ability.extend({
+  token: service(),
+
+  // Map abilities to policy options (which are coarse for nodes)
+  // instead of specific behaviors.
+  canWrite: or('selfTokenIsManagement', 'policiesIncludeNodeWrite'),
+
+  selfTokenIsManagement: equal('token.selfToken.type', 'management'),
+
+  policiesIncludeNodeWrite: computed('token.selfTokenPolicies.[]', function() {
+    // For each policy record, extract the Node policy
+    const policies = (this.get('token.selfTokenPolicies') || [])
+      .toArray()
+      .map(policy => get(policy, 'rulesJSON.Node.Policy'))
+      .compact();
+
+    // Node write is allowed if any policy allows it
+    return policies.some(policy => policy === 'write');
+  }),
+});

--- a/ui/app/abilities/job.js
+++ b/ui/app/abilities/job.js
@@ -1,14 +1,15 @@
 import { Ability } from 'ember-can';
 import { inject as service } from '@ember/service';
 import { computed, get } from '@ember/object';
-import { equal, or } from '@ember/object/computed';
+import { equal, or, not } from '@ember/object/computed';
 
 export default Ability.extend({
   system: service(),
   token: service(),
 
-  canRun: or('selfTokenIsManagement', 'policiesSupportRunning'),
+  canRun: or('bypassAuthorization', 'selfTokenIsManagement', 'policiesSupportRunning'),
 
+  bypassAuthorization: not('token.aclEnabled'),
   selfTokenIsManagement: equal('token.selfToken.type', 'management'),
 
   activeNamespace: computed('system.activeNamespace.name', function() {

--- a/ui/app/components/drain-popover.js
+++ b/ui/app/components/drain-popover.js
@@ -9,6 +9,7 @@ export default Component.extend({
   tagName: '',
 
   client: null,
+  isDisabled: false,
 
   onError() {},
   onDrain() {},

--- a/ui/app/components/popover-menu.js
+++ b/ui/app/components/popover-menu.js
@@ -16,6 +16,7 @@ export default Component.extend({
 
   triggerClass: '',
   isOpen: false,
+  isDisabled: false,
   label: '',
 
   dropdown: null,

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import { reads } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { getOwner } from '@ember/application';
+import { alias } from '@ember/object/computed';
 
 export default Controller.extend({
   token: service(),
@@ -12,7 +13,7 @@ export default Controller.extend({
 
   tokenIsValid: false,
   tokenIsInvalid: false,
-  tokenRecord: null,
+  tokenRecord: alias('token.selfToken'),
 
   resetStore() {
     this.store.unloadAll();
@@ -26,9 +27,9 @@ export default Controller.extend({
       this.setProperties({
         tokenIsValid: false,
         tokenIsInvalid: false,
-        tokenRecord: null,
       });
       this.resetStore();
+      this.token.reset();
     },
 
     verifyToken() {
@@ -52,7 +53,6 @@ export default Controller.extend({
           this.setProperties({
             tokenIsValid: true,
             tokenIsInvalid: false,
-            tokenRecord: this.token.selfToken,
           });
         },
         () => {
@@ -60,7 +60,6 @@ export default Controller.extend({
           this.setProperties({
             tokenIsValid: false,
             tokenIsInvalid: true,
-            tokenRecord: null,
           });
         }
       );

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -38,22 +38,21 @@ export default Controller.extend({
       this.set('token.secret', secret);
 
       TokenAdapter.findSelf().then(
-        token => {
-          // Capture the token ID before clearing the store
-          const tokenId = token.get('id');
-
+        () => {
           // Clear out all data to ensure only data the new token is privileged to
           // see is shown
           this.system.reset();
           this.resetStore();
 
-          // Immediately refetch the token now that the store is empty
-          const newToken = this.store.findRecord('token', tokenId);
+          // Refetch the token and associated policies
+          this.get('token.fetchSelfTokenAndPolicies')
+            .perform()
+            .catch();
 
           this.setProperties({
             tokenIsValid: true,
             tokenIsInvalid: false,
-            tokenRecord: newToken,
+            tokenRecord: this.token.selfToken,
           });
         },
         () => {

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -78,16 +78,13 @@ export default Service.extend({
     'defaultRegion.region',
     'shouldShowRegions',
     function() {
-      return this.shouldShowRegions &&
-      this.activeRegion !== this.get('defaultRegion.region');
+      return this.shouldShowRegions && this.activeRegion !== this.get('defaultRegion.region');
     }
   ),
 
   namespaces: computed('activeRegion', function() {
     return PromiseArray.create({
-      promise: this.store
-        .findAll('namespace')
-        .then(namespaces => namespaces.compact()),
+      promise: this.store.findAll('namespace').then(namespaces => namespaces.compact()),
     });
   }),
 

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -35,7 +35,9 @@ export default Service.extend({
     }
   }),
 
-  selfToken: alias('fetchSelfToken.lastSuccessful.value'),
+  selfToken: computed('secret', 'fetchSelfToken.lastSuccessful.value', function() {
+    if (this.secret) return this.get('fetchSelfToken.lastSuccessful.value');
+  }),
 
   fetchSelfTokenPolicies: task(function*() {
     try {
@@ -82,6 +84,12 @@ export default Service.extend({
     }
 
     return this.authorizedRawRequest(url, options);
+  },
+
+  reset() {
+    this.fetchSelfToken.cancelAll({ resetState: true });
+    this.fetchSelfTokenPolicies.cancelAll({ resetState: true });
+    this.fetchSelfTokenAndPolicies.cancelAll({ resetState: true });
   },
 });
 

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -43,6 +43,17 @@ $button-box-shadow-standard: 0 2px 0 0 rgba($grey, 0.2);
     box-shadow: none;
   }
 
+  &.is-disabled {
+    opacity: 0.7;
+    box-shadow: none;
+    cursor: not-allowed;
+    border-color: transparent;
+
+    &:hover {
+      border-color: transparent;
+    }
+  }
+
   @each $name, $pair in $colors {
     $color: nth($pair, 1);
     $color-invert: nth($pair, 2);
@@ -113,6 +124,24 @@ $button-box-shadow-standard: 0 2px 0 0 rgba($grey, 0.2);
           background-color: rgba($color-invert, 0.1);
           border-color: $color-invert;
           color: $color-invert;
+          box-shadow: none;
+        }
+      }
+
+      // The is-disabled styles MUST trump other modifier specificites
+      &.is-disabled {
+        background-color: $color;
+        border-color: darken($color, 5%);
+        box-shadow: none;
+
+        &:hover,
+        &:active,
+        &:focus,
+        &.is-hovered,
+        &.is-active,
+        &.is-focused {
+          background-color: $color;
+          border-color: darken($color, 5%);
           box-shadow: none;
         }
       }

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -93,7 +93,7 @@
           {{#toggle
             data-test-eligibility-toggle
             isActive=model.isEligible
-            isDisabled=(or setEligibility.isRunning model.isDraining)
+            isDisabled=(or setEligibility.isRunning model.isDraining (cannot "write client"))
             onToggle=(perform setEligibility (not model.isEligible))}}
             Eligible
           {{/toggle}}

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -122,6 +122,7 @@
     <div class="toolbar-item is-right-aligned is-top-aligned">
       {{drain-popover
         client=model
+        isDisabled=(cannot "write client")
         onDrain=(action "drainNotify")
         onError=(action "drainError")}}
     </div>

--- a/ui/app/templates/components/drain-popover.hbs
+++ b/ui/app/templates/components/drain-popover.hbs
@@ -2,7 +2,12 @@
   data-test-drain-popover
   isDisabled=isDisabled
   label=(if client.isDraining "Update Drain" "Drain")
-  triggerClass=(concat "is-small " (if drain.isRunning "is-loading")) as |m|}}
+  tooltip=(if isDisabled "Not allowed to drain clients")
+  triggerClass=(concat
+    "is-small "
+    (if drain.isRunning "is-loading ")
+    (if isDisabled "tooltip is-right-aligned")
+  ) as |m|}}
   <form data-test-drain-popover-form onsubmit={{action (queue (action preventDefault) (perform drain m.actions.close))}} class="form is-small">
     <h4 class="group-heading">Drain Options</h4>
     <div class="field">

--- a/ui/app/templates/components/drain-popover.hbs
+++ b/ui/app/templates/components/drain-popover.hbs
@@ -1,5 +1,6 @@
 {{#popover-menu
   data-test-drain-popover
+  isDisabled=isDisabled
   label=(if client.isDraining "Update Drain" "Drain")
   triggerClass=(concat "is-small " (if drain.isRunning "is-loading")) as |m|}}
   <form data-test-drain-popover-form onsubmit={{action (queue (action preventDefault) (perform drain m.actions.close))}} class="form is-small">

--- a/ui/app/templates/components/popover-menu.hbs
+++ b/ui/app/templates/components/popover-menu.hbs
@@ -1,9 +1,14 @@
 <BasicDropdown
   @horizontalPosition="right"
+  @disabled={{isDisabled}}
   @onOpen={{action (queue (action (mut isOpen) true) (action capture))}}
   @onClose={{action (mut isOpen) false}} as |dd|
 >
-  <dd.Trigger data-test-popover-trigger class={{concat "popover-trigger button is-primary " triggerClass}} {{on "keydown" (action "openOnArrowDown" dd)}}>
+  <dd.Trigger
+    data-test-popover-trigger
+    class={{concat "popover-trigger button is-primary " triggerClass (if isDisabled "is-disabled")}}
+    {{on "keydown" (action "openOnArrowDown" dd)}}
+  >
     {{label}} {{x-icon "chevron-down" class="is-text"}}
   </dd.Trigger>
   <dd.Content data-test-popover-menu class="popover-content">

--- a/ui/app/templates/components/popover-menu.hbs
+++ b/ui/app/templates/components/popover-menu.hbs
@@ -6,7 +6,8 @@
 >
   <dd.Trigger
     data-test-popover-trigger
-    class={{concat "popover-trigger button is-primary " triggerClass (if isDisabled "is-disabled")}}
+    class={{concat "popover-trigger button is-primary " triggerClass (if isDisabled " is-disabled")}}
+    aria-label={{tooltip}}
     {{on "keydown" (action "openOnArrowDown" dd)}}
   >
     {{label}} {{x-icon "chevron-down" class="is-text"}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -18,7 +18,12 @@
           {{#if (can "run job")}}
             {{#link-to "jobs.run" data-test-run-job class="button is-primary"}}Run Job{{/link-to}}
           {{else}}
-            <button data-test-run-job class="button tooltip is-right-aligned" aria-label="You don’t have permission to run jobs" disabled>Run Job</button>
+            <button
+              data-test-run-job
+              class="button is-primary is-disabled tooltip is-right-aligned"
+              aria-label="You don’t have permission to run jobs"
+              disabled
+            >Run Job</button>
           {{/if}}
         </div>
       {{/if}}
@@ -55,7 +60,12 @@
           {{#if (can "run job")}}
             {{#link-to "jobs.run" data-test-run-job class="button is-primary"}}Run Job{{/link-to}}
           {{else}}
-            <button data-test-run-job class="button tooltip is-right-aligned" aria-label="You don’t have permission to run jobs" disabled>Run Job</button>
+            <button
+              data-test-run-job
+              class="button is-primary is-disabled tooltip is-right-aligned"
+              aria-label="You don’t have permission to run jobs"
+              disabled
+            >Run Job</button>
           {{/if}}
         </div>
       {{/if}}

--- a/ui/stories/components/buttons.stories.js
+++ b/ui/stories/components/buttons.stories.js
@@ -75,7 +75,7 @@ export let Sizes = () => {
 export let Disabled = () => {
   return {
     template: hbs`
-      <h5 class="title is-5">Buttons</h5>
+      <h5 class="title is-5">Anchor elements as buttons</h5>
       <div class="block">
         <a class="button is-disabled">Button</a>
         <a class="button is-white is-disabled">White</a>
@@ -90,6 +90,40 @@ export let Disabled = () => {
         <a class="button is-success is-disabled">Success</a>
         <a class="button is-warning is-disabled">Warning</a>
         <a class="button is-danger is-disabled">Danger</a>
+      </div>
+
+      <h5 class="title is-5">Button elements with <code>disabled</code> attribute</h5>
+      <div class="block">
+        <button class="button is-disabled" disabled>Button</button>
+        <button class="button is-white is-disabled" disabled>White</button>
+        <button class="button is-light is-disabled" disabled>Light</button>
+        <button class="button is-dark is-disabled" disabled>Dark</button>
+        <button class="button is-black is-disabled" disabled>Black</button>
+        <button class="button is-link is-disabled" disabled>Link</button>
+      </div>
+      <div class="block">
+        <button class="button is-primary is-disabled" disabled>Primary</button>
+        <button class="button is-info is-disabled" disabled>Info</button>
+        <button class="button is-success is-disabled" disabled>Success</button>
+        <button class="button is-warning is-disabled" disabled>Warning</button>
+        <button class="button is-danger is-disabled" disabled>Danger</button>
+      </div>
+
+      <h5 class="title is-5">Button elements with <code>aria-disabled="true"</code></h5>
+      <div class="block">
+        <button class="button is-disabled" aria-disabled="true">Button</button>
+        <button class="button is-white is-disabled" aria-disabled="true">White</button>
+        <button class="button is-light is-disabled" aria-disabled="true">Light</button>
+        <button class="button is-dark is-disabled" aria-disabled="true">Dark</button>
+        <button class="button is-black is-disabled" aria-disabled="true">Black</button>
+        <button class="button is-link is-disabled" aria-disabled="true">Link</button>
+      </div>
+      <div class="block">
+        <button class="button is-primary is-disabled" aria-disabled="true">Primary</button>
+        <button class="button is-info is-disabled" aria-disabled="true">Info</button>
+        <button class="button is-success is-disabled" aria-disabled="true">Success</button>
+        <button class="button is-warning is-disabled" aria-disabled="true">Warning</button>
+        <button class="button is-danger is-disabled" aria-disabled="true">Danger</button>
       </div>
       `,
   };

--- a/ui/stories/components/buttons.stories.js
+++ b/ui/stories/components/buttons.stories.js
@@ -71,3 +71,26 @@ export let Sizes = () => {
       `,
   };
 };
+
+export let Disabled = () => {
+  return {
+    template: hbs`
+      <h5 class="title is-5">Buttons</h5>
+      <div class="block">
+        <a class="button is-disabled">Button</a>
+        <a class="button is-white is-disabled">White</a>
+        <a class="button is-light is-disabled">Light</a>
+        <a class="button is-dark is-disabled">Dark</a>
+        <a class="button is-black is-disabled">Black</a>
+        <a class="button is-link is-disabled">Link</a>
+      </div>
+      <div class="block">
+        <a class="button is-primary is-disabled">Primary</a>
+        <a class="button is-info is-disabled">Info</a>
+        <a class="button is-success is-disabled">Success</a>
+        <a class="button is-warning is-disabled">Warning</a>
+        <a class="button is-danger is-disabled">Danger</a>
+      </div>
+      `,
+  };
+};

--- a/ui/tests/helpers/setup-ability.js
+++ b/ui/tests/helpers/setup-ability.js
@@ -1,0 +1,9 @@
+export default ability => hooks => {
+  hooks.beforeEach(function() {
+    this.ability = this.owner.lookup(`ability:${ability}`);
+  });
+
+  hooks.afterEach(function() {
+    delete this.ability;
+  });
+};

--- a/ui/tests/pages/clients/detail.js
+++ b/ui/tests/pages/clients/detail.js
@@ -117,6 +117,7 @@ export default create({
     label: text('[data-test-drain-popover] [data-test-popover-trigger]'),
     isOpen: isPresent('[data-test-drain-popover-form]'),
     toggle: clickable('[data-test-drain-popover] [data-test-popover-trigger]'),
+    isDisabled: attribute('aria-disabled', '[data-test-popover-trigger]'),
 
     deadlineToggle: toggle('[data-test-drain-deadline-toggle]'),
     deadlineOptions: {

--- a/ui/tests/unit/abilities/client-test.js
+++ b/ui/tests/unit/abilities/client-test.js
@@ -1,0 +1,88 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+
+function setupAbility(ability, hooks) {
+  hooks.beforeEach(function() {
+    this.ability = this.owner.lookup(`ability:${ability}`);
+  });
+
+  hooks.afterEach(function() {
+    delete this.ability;
+  });
+}
+
+module('Unit | Ability | client', function(hooks) {
+  setupTest(hooks);
+  setupAbility('client', hooks);
+
+  test('it permits client write for management tokens', function(assert) {
+    const mockToken = Service.extend({
+      selfToken: { type: 'management' },
+    });
+    this.owner.register('service:token', mockToken);
+
+    assert.ok(this.ability.canWrite);
+  });
+
+  test('it permits client write for tokens with a policy that has node-write', function(assert) {
+    const mockToken = Service.extend({
+      selfToken: { type: 'client' },
+      selfTokenPolicies: [
+        {
+          rulesJSON: {
+            Node: {
+              Policy: 'write',
+            },
+          },
+        },
+      ],
+    });
+    this.owner.register('service:token', mockToken);
+
+    assert.ok(this.ability.canWrite);
+  });
+
+  test('it permits client write for tokens with a policy that allows write and another policy that disallows it', function(assert) {
+    const mockToken = Service.extend({
+      selfToken: { type: 'client' },
+      selfTokenPolicies: [
+        {
+          rulesJSON: {
+            Node: {
+              Policy: 'write',
+            },
+          },
+        },
+        {
+          rulesJSON: {
+            Node: {
+              Policy: 'read',
+            },
+          },
+        },
+      ],
+    });
+    this.owner.register('service:token', mockToken);
+
+    assert.ok(this.ability.canWrite);
+  });
+
+  test('it blocks client write for tokens with a policy that does not allow node-write', function(assert) {
+    const mockToken = Service.extend({
+      selfToken: { type: 'client' },
+      selfTokenPolicies: [
+        {
+          rulesJSON: {
+            Node: {
+              Policy: 'read',
+            },
+          },
+        },
+      ],
+    });
+    this.owner.register('service:token', mockToken);
+
+    assert.notOk(this.ability.canWrite);
+  });
+});

--- a/ui/tests/unit/abilities/client-test.js
+++ b/ui/tests/unit/abilities/client-test.js
@@ -7,8 +7,18 @@ module('Unit | Ability | client', function(hooks) {
   setupTest(hooks);
   setupAbility('client')(hooks);
 
+  test('it permits client write when ACLs are disabled', function(assert) {
+    const mockToken = Service.extend({
+      aclEnabled: false,
+    });
+    this.owner.register('service:token', mockToken);
+
+    assert.ok(this.ability.canWrite);
+  });
+
   test('it permits client write for management tokens', function(assert) {
     const mockToken = Service.extend({
+      aclEnabled: true,
       selfToken: { type: 'management' },
     });
     this.owner.register('service:token', mockToken);
@@ -18,6 +28,7 @@ module('Unit | Ability | client', function(hooks) {
 
   test('it permits client write for tokens with a policy that has node-write', function(assert) {
     const mockToken = Service.extend({
+      aclEnabled: true,
       selfToken: { type: 'client' },
       selfTokenPolicies: [
         {
@@ -36,6 +47,7 @@ module('Unit | Ability | client', function(hooks) {
 
   test('it permits client write for tokens with a policy that allows write and another policy that disallows it', function(assert) {
     const mockToken = Service.extend({
+      aclEnabled: true,
       selfToken: { type: 'client' },
       selfTokenPolicies: [
         {
@@ -61,6 +73,7 @@ module('Unit | Ability | client', function(hooks) {
 
   test('it blocks client write for tokens with a policy that does not allow node-write', function(assert) {
     const mockToken = Service.extend({
+      aclEnabled: true,
       selfToken: { type: 'client' },
       selfTokenPolicies: [
         {

--- a/ui/tests/unit/abilities/client-test.js
+++ b/ui/tests/unit/abilities/client-test.js
@@ -1,20 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
-
-function setupAbility(ability, hooks) {
-  hooks.beforeEach(function() {
-    this.ability = this.owner.lookup(`ability:${ability}`);
-  });
-
-  hooks.afterEach(function() {
-    delete this.ability;
-  });
-}
+import setupAbility from 'nomad-ui/tests/helpers/setup-ability';
 
 module('Unit | Ability | client', function(hooks) {
   setupTest(hooks);
-  setupAbility('client', hooks);
+  setupAbility('client')(hooks);
 
   test('it permits client write for management tokens', function(assert) {
     const mockToken = Service.extend({

--- a/ui/tests/unit/abilities/job-test.js
+++ b/ui/tests/unit/abilities/job-test.js
@@ -7,8 +7,19 @@ module('Unit | Ability | job', function(hooks) {
   setupTest(hooks);
   setupAbility('job')(hooks);
 
+  test('it permits job run when ACLs are disabled', function(assert) {
+    const mockToken = Service.extend({
+      aclEnabled: false,
+    });
+
+    this.owner.register('service:token', mockToken);
+
+    assert.ok(this.ability.canRun);
+  });
+
   test('it permits job run for management tokens', function(assert) {
     const mockToken = Service.extend({
+      aclEnabled: true,
       selfToken: { type: 'management' },
     });
 
@@ -19,12 +30,14 @@ module('Unit | Ability | job', function(hooks) {
 
   test('it permits job run for client tokens with a policy that has namespace submit-job', function(assert) {
     const mockSystem = Service.extend({
+      aclEnabled: true,
       activeNamespace: {
         name: 'aNamespace',
       },
     });
 
     const mockToken = Service.extend({
+      aclEnabled: true,
       selfToken: { type: 'client' },
       selfTokenPolicies: [
         {
@@ -48,12 +61,14 @@ module('Unit | Ability | job', function(hooks) {
 
   test('it permits job run for client tokens with a policy that has default namespace submit-job and no capabilities for active namespace', function(assert) {
     const mockSystem = Service.extend({
+      aclEnabled: true,
       activeNamespace: {
         name: 'anotherNamespace',
       },
     });
 
     const mockToken = Service.extend({
+      aclEnabled: true,
       selfToken: { type: 'client' },
       selfTokenPolicies: [
         {
@@ -81,12 +96,14 @@ module('Unit | Ability | job', function(hooks) {
 
   test('it blocks job run for client tokens with a policy that has no submit-job capability', function(assert) {
     const mockSystem = Service.extend({
+      aclEnabled: true,
       activeNamespace: {
         name: 'aNamespace',
       },
     });
 
     const mockToken = Service.extend({
+      aclEnabled: true,
       selfToken: { type: 'client' },
       selfTokenPolicies: [
         {
@@ -110,12 +127,14 @@ module('Unit | Ability | job', function(hooks) {
 
   test('it handles globs in namespace names', function(assert) {
     const mockSystem = Service.extend({
+      aclEnabled: true,
       activeNamespace: {
         name: 'aNamespace',
       },
     });
 
     const mockToken = Service.extend({
+      aclEnabled: true,
       selfToken: { type: 'client' },
       selfTokenPolicies: [
         {

--- a/ui/tests/unit/abilities/job-test.js
+++ b/ui/tests/unit/abilities/job-test.js
@@ -1,9 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
+import setupAbility from 'nomad-ui/tests/helpers/setup-ability';
 
 module('Unit | Ability | job', function(hooks) {
   setupTest(hooks);
+  setupAbility('job')(hooks);
 
   test('it permits job run for management tokens', function(assert) {
     const mockToken = Service.extend({
@@ -12,8 +14,7 @@ module('Unit | Ability | job', function(hooks) {
 
     this.owner.register('service:token', mockToken);
 
-    const jobAbility = this.owner.lookup('ability:job');
-    assert.ok(jobAbility.canRun);
+    assert.ok(this.ability.canRun);
   });
 
   test('it permits job run for client tokens with a policy that has namespace submit-job', function(assert) {
@@ -42,8 +43,7 @@ module('Unit | Ability | job', function(hooks) {
     this.owner.register('service:system', mockSystem);
     this.owner.register('service:token', mockToken);
 
-    const jobAbility = this.owner.lookup('ability:job');
-    assert.ok(jobAbility.canRun);
+    assert.ok(this.ability.canRun);
   });
 
   test('it permits job run for client tokens with a policy that has default namespace submit-job and no capabilities for active namespace', function(assert) {
@@ -76,8 +76,7 @@ module('Unit | Ability | job', function(hooks) {
     this.owner.register('service:system', mockSystem);
     this.owner.register('service:token', mockToken);
 
-    const jobAbility = this.owner.lookup('ability:job');
-    assert.ok(jobAbility.canRun);
+    assert.ok(this.ability.canRun);
   });
 
   test('it blocks job run for client tokens with a policy that has no submit-job capability', function(assert) {
@@ -106,8 +105,7 @@ module('Unit | Ability | job', function(hooks) {
     this.owner.register('service:system', mockSystem);
     this.owner.register('service:token', mockToken);
 
-    const jobAbility = this.owner.lookup('ability:job');
-    assert.notOk(jobAbility.canRun);
+    assert.notOk(this.ability.canRun);
   });
 
   test('it handles globs in namespace names', function(assert) {
@@ -156,28 +154,27 @@ module('Unit | Ability | job', function(hooks) {
     this.owner.register('service:system', mockSystem);
     this.owner.register('service:token', mockToken);
 
-    const jobAbility = this.owner.lookup('ability:job');
     const systemService = this.owner.lookup('service:system');
 
     systemService.set('activeNamespace.name', 'production-web');
-    assert.notOk(jobAbility.canRun);
+    assert.notOk(this.ability.canRun);
 
     systemService.set('activeNamespace.name', 'production-api');
-    assert.ok(jobAbility.canRun);
+    assert.ok(this.ability.canRun);
 
     systemService.set('activeNamespace.name', 'production-other');
-    assert.ok(jobAbility.canRun);
+    assert.ok(this.ability.canRun);
 
     systemService.set('activeNamespace.name', 'something-suffixed');
-    assert.ok(jobAbility.canRun);
+    assert.ok(this.ability.canRun);
 
     systemService.set('activeNamespace.name', 'something-more-suffixed');
     assert.notOk(
-      jobAbility.canRun,
+      this.ability.canRun,
       'expected the namespace with the greatest number of matched characters to be chosen'
     );
 
     systemService.set('activeNamespace.name', '000-abc-999');
-    assert.ok(jobAbility.canRun, 'expected to be able to match against more than one wildcard');
+    assert.ok(this.ability.canRun, 'expected to be able to match against more than one wildcard');
   });
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/174740/73514952-6538a800-43a8-11ea-902b-fbfa7e7f9818.png)

This PR took me a couple places. There are two notable "out of scope" things here that I decided to fix while I was at it.

**1. Token/Policy refresh on setting new token.**

Prior to this, setting a new token would not rerun the token service tasks that the ember-can abilities use. 

This was a bit tricky to fix just because the token controller was written before the token service was making API requests, so I reworked the controller a bit to leverage the service more. It also required a rarely seen Ember Concurrency trick to reset the internal state of `lastSuccessful` since it was hanging onto a refresh of a token that gets removed from the store after the store is completely unloaded as an outcome of setting a token.

**2. Disabled button states.**

We had disabled buttons, but no design rigor around them to make sure there was consistency. I added a disabled buttons Story and updated the disabled job run button to be the disabled primary button rather than the disabled plain button.

In addition to those semi-unrelated tasks, I refactored the job ability tests a wee-bit to use a hook to assign the ability under test to the test context rather than looking it up repeatedly. This is pretty minor.

I have Thoughts™ on how to make writing abilities nicer than they are right now, but I refrained from doing a bunch of refactoring there too, lol. We'll see if we have to write many more abilities, if so then I think creating a nicer token/policy interface is worth discussing.