### PR TITLE
Use secret ID for NOMAD_TOKEN

### DIFF
--- a/website/source/docs/commands/acl/token-self.html.md.erb
+++ b/website/source/docs/commands/acl/token-self.html.md.erb
@@ -27,7 +27,7 @@ nomad acl token self
 Fetch information about an existing ACL token:
 
 ```shell
-$ export NOMAD_TOKEN=d532c40a-30f1-695c-19e5-c35b882b0efd
+$ export NOMAD_TOKEN=85310d07-9afa-ef53-0933-0c043cd673c7
 
 $ nomad acl token self
 Accessor ID  = d532c40a-30f1-695c-19e5-c35b882b0efd


### PR DESCRIPTION
Use secret ID for NOMAD_TOKEN as the accessor ID doesn't seem to work.

I tried with a local micro cluster following the tutorials, and if I do:

```console
$ export NOMAD_TOKEN=85310d07-9afa-ef53-0933-0c043cd673c7
```

Using the accessor ID as in this example, I get an error:

```
Error querying jobs: Unexpected response code: 403 (ACL token not found)
```

But when using the secret ID in that env var it seems to work correctly.