### PR TITLE
rpc: Use MultiplexV2 for connections

### DIFF
--- a/helper/pool/pool.go
+++ b/helper/pool/pool.go
@@ -421,7 +421,7 @@ START:
 }
 
 // StreamingRPC is used to make an streaming RPC call.  Callers must
-// close the channel when done.
+// close the connection when done.
 func (p *ConnPool) StreamingRPC(region string, addr net.Addr, version int) (net.Conn, error) {
 	conn, err := p.acquire(region, addr, version)
 	if err != nil {

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -530,7 +530,10 @@ func TestRPC_handleMultiplexV2(t *testing.T) {
 	require.NotEmpty(l)
 
 	// Make a streaming RPC
-	_, err = s.streamingRpcImpl(s2, s.Region(), "Bogus")
+	_, err = s2.Write([]byte{byte(pool.RpcStreaming)})
+	require.Nil(err)
+
+	_, err = s.streamingRpcImpl(s2, "Bogus")
 	require.NotNil(err)
 	require.Contains(err.Error(), "Bogus")
 	require.True(structs.IsErrUnknownMethod(err))


### PR DESCRIPTION
MultiplexV2 is a new connection multiplex header that supports multiplex both RPC and streaming requests over the same Yamux connection.  This reduces the number of open connections between servers/clients.

MultiplexV2 was added in 0.8.0 as part of #3892 .  So Nomad 0.11 can expect it to be supported.  Though, some more rigorous testing is required before merging.

I want to call out some implementation details:

First, the current connection pool reuses the Yamux stream for multiple RPC calls, and doesn't close them until an error is encountered.  This commit doesn't change it, and sets the `RpcNomad` byte only at stream creation.

Second, the StreamingRPC session gets closed by callers and cannot be reused.  Every StreamingRPC opens a new Yamux session.

I did some basic testing, but I want to do more rigorous testing before merging it.  Also, this seems like a change we should target a major release for? Nomad 0.11?

Closes https://github.com/hashicorp/nomad/issues/6878