### PR TITLE
Some fixes to connection pooling

### DIFF
--- a/helper/pool/pool.go
+++ b/helper/pool/pool.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hashicorp/consul/lib"
 	hclog "github.com/hashicorp/go-hclog"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/helper/tlsutil"
@@ -36,6 +37,7 @@ type StreamClient struct {
 
 func (sc *StreamClient) Close() {
 	sc.stream.Close()
+	sc.codec.Close()
 }
 
 // Conn is a pooled connection to a Nomad server
@@ -426,6 +428,13 @@ func (p *ConnPool) RPC(region string, addr net.Addr, version int, method string,
 	if err != nil {
 		sc.Close()
 		p.releaseConn(conn)
+
+		// If we read EOF, the session is toast. Clear it and open a
+		// new session next time
+		// See https://github.com/hashicorp/consul/blob/v1.6.3/agent/pool/pool.go#L471-L477
+		if lib.IsErrEOF(err) {
+			p.clearConn(conn)
+		}
 
 		// If the error is an RPC Coded error
 		// return the coded error without wrapping

--- a/helper/pool/pool.go
+++ b/helper/pool/pool.go
@@ -427,7 +427,6 @@ func (p *ConnPool) RPC(region string, addr net.Addr, version int, method string,
 	err = msgpackrpc.CallWithCodec(sc.codec, method, args, reply)
 	if err != nil {
 		sc.Close()
-		p.releaseConn(conn)
 
 		// If we read EOF, the session is toast. Clear it and open a
 		// new session next time
@@ -435,6 +434,8 @@ func (p *ConnPool) RPC(region string, addr net.Addr, version int, method string,
 		if lib.IsErrEOF(err) {
 			p.clearConn(conn)
 		}
+
+		p.releaseConn(conn)
 
 		// If the error is an RPC Coded error
 		// return the coded error without wrapping


### PR DESCRIPTION
Pick up some fixes from Consul:

* If a stream returns an EOF error, clear session from cache/pool and start a new one.
* Close the codec when closing StreamClient