### PR TITLE
UI: Node drain status light icons

### DIFF
--- a/ui/app/components/client-node-row.js
+++ b/ui/app/components/client-node-row.js
@@ -54,6 +54,8 @@ export default Component.extend(WithVisibilityDetection, {
       return 'status-text is-info';
     } else if (compositeStatus === 'ineligible') {
       return 'status-text is-warning';
+    } else if (compositeStatus === 'down') {
+      return 'status-text is-danger';
     } else {
       return '';
     }

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -91,6 +91,21 @@ export default Model.extend({
     }
   }),
 
+  compositeStatusIcon: computed('isDraining', 'isEligible', 'status', function() {
+    // ineligible = exclamation point
+    // ready = checkmark
+    // down = x
+    // initializing = exclamation???
+    if (this.isDraining || !this.isEligible) {
+      return 'alert-circle-fill';
+    } else if (this.status === 'down') {
+      return 'cancel-plain';
+    } else if (this.status === 'initializing') {
+      return 'run';
+    }
+    return 'check-plain';
+  }),
+
   setEligible() {
     if (this.isEligible) return RSVP.resolve();
     // Optimistically update schedulingEligibility for immediate feedback

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -92,18 +92,14 @@ export default Model.extend({
   }),
 
   compositeStatusIcon: computed('isDraining', 'isEligible', 'status', function() {
-    // ineligible = exclamation point
-    // ready = checkmark
-    // down = x
-    // initializing = exclamation???
     if (this.isDraining || !this.isEligible) {
       return 'alert-circle-fill';
     } else if (this.status === 'down') {
-      return 'cancel-plain';
+      return 'cancel-circle-fill';
     } else if (this.status === 'initializing') {
-      return 'run';
+      return 'node-init-circle-fill';
     }
-    return 'check-plain';
+    return 'check-circle-fill';
   }),
 
   setEligible() {

--- a/ui/app/styles/components/node-status-light.scss
+++ b/ui/app/styles/components/node-status-light.scss
@@ -1,13 +1,16 @@
 $size: 1.3rem;
 
 .node-status-light {
-  display: inline-block;
+  display: inline-flex;
   height: $size;
   width: $size;
   border-radius: $size / 2;
   vertical-align: middle;
+  align-items: center;
+  justify-content: center;
 
   background: $black;
+  color: $white;
 
   &.ready {
     background: $primary;
@@ -18,17 +21,16 @@ $size: 1.3rem;
   }
 
   &.initializing {
-    background: repeating-linear-gradient(
-      -45deg,
-      $grey-lighter,
-      $grey-lighter 3px,
-      darken($grey-lighter, 25%) 3px,
-      darken($grey-lighter, 25%) 6px
-    );
+    background: $grey-lighter;
   }
 
   &.ineligible,
   &.draining {
     background: $warning;
+  }
+
+  .icon {
+    width: $size - 0.2rem;
+    height: $size - 0.2rem;
   }
 }

--- a/ui/app/styles/components/node-status-light.scss
+++ b/ui/app/styles/components/node-status-light.scss
@@ -24,6 +24,10 @@ $size: 1.6rem;
 
   &.initializing {
     color: $grey-light;
+
+    .blinking {
+      animation: node-status-light-initializing 0.7s infinite alternate ease-in-out;
+    }
   }
 
   &.ineligible,
@@ -34,5 +38,15 @@ $size: 1.6rem;
   .icon {
     width: $size;
     height: $size;
+  }
+}
+
+@keyframes node-status-light-initializing {
+  0% {
+    opacity: 0.2;
+  }
+
+  100% {
+    opacity: 0.7;
   }
 }

--- a/ui/app/styles/components/node-status-light.scss
+++ b/ui/app/styles/components/node-status-light.scss
@@ -1,4 +1,4 @@
-$size: 1.3rem;
+$size: 1.6rem;
 
 .node-status-light {
   display: inline-flex;
@@ -9,28 +9,30 @@ $size: 1.3rem;
   align-items: center;
   justify-content: center;
 
-  background: $black;
-  color: $white;
+  // Compensate for the padding within the SVG
+  // (between the circle paths and the viewBox)
+  margin-left: -1px;
+  margin-right: -1px;
 
   &.ready {
-    background: $primary;
+    color: $primary;
   }
 
   &.down {
-    background: $danger;
+    color: $danger;
   }
 
   &.initializing {
-    background: $grey-lighter;
+    color: $grey-light;
   }
 
   &.ineligible,
   &.draining {
-    background: $warning;
+    color: $warning;
   }
 
   .icon {
-    width: $size - 0.2rem;
-    height: $size - 0.2rem;
+    width: $size;
+    height: $size;
   }
 }

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -81,7 +81,9 @@
   <div class="toolbar">
     <div class="toolbar-item is-top-aligned is-minimum">
       <span class="title">
-        <span data-test-node-status="{{model.compositeStatus}}" class="node-status-light {{model.compositeStatus}}"></span>
+        <span data-test-node-status="{{model.compositeStatus}}" class="node-status-light {{model.compositeStatus}}">
+          {{x-icon model.compositeStatusIcon}}
+        </span>
       </span>
     </div>
     <div class="toolbar-item">

--- a/ui/public/images/icons/node-init-circle-fill.svg
+++ b/ui/public/images/icons/node-init-circle-fill.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <g fill="none" fill-rule="evenodd">
+    <circle cx="10" cy="10" r="10" fill="currentColor" transform="translate(2 2)"/>
+    <path fill="#FFF" d="M18 13v4H6v-4h12zM8 14a1 1 0 1 0 0 2 1 1 0 0 0 0-2z"/>
+    <path class="blinking" fill="#FFF" d="M18 7v4H6V7h12zM8 8a1 1 0 1 0 0 2 1 1 0 0 0 0-2z" opacity=".502"/>
+  </g>
+</svg>


### PR DESCRIPTION
Augment the existing colored node status light/indicator with icons. This does a better job communicating state and it's also an accessibility no-no to communicate exclusively with color.

![image](https://user-images.githubusercontent.com/174740/73573999-69f17080-4429-11ea-9541-122850b96a47.png)

![image](https://user-images.githubusercontent.com/174740/73574022-7e356d80-4429-11ea-96cb-8807597577bb.png)

![image](https://user-images.githubusercontent.com/174740/73574182-ea17d600-4429-11ea-8f92-ec164e9c4305.png)

![image](https://user-images.githubusercontent.com/174740/73574245-103d7600-442a-11ea-8fe8-20e85c4e9dea.png)


I also took this moment to emphasize Down clients on the list view:

![image](https://user-images.githubusercontent.com/174740/73574212-fbf97900-4429-11ea-8a47-a7c20fc44037.png)
