### PR TITLE
csi: implement VolumeClaimRPC

### DIFF
--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -430,6 +430,10 @@ type CSIVolumeClaimRequest struct {
 	WriteRequest
 }
 
+type CSIVolumeClaimResponse struct {
+	QueryMeta
+}
+
 type CSIVolumeListRequest struct {
 	PluginID string
 	QueryOptions


### PR DESCRIPTION
Closes #7034

When the client receives an allocation which includes a CSI volume, the alloc runner will block its main `Run` loop. The alloc runner will issue a `VolumeClaim` RPC to the Nomad servers. This changeset implements the portions of the `VolumeClaim` RPC endpoint that have not been previously completed.


---

Tests:

```
▶ go test ./nomad/ -run TestCSIVolumeEndpoint_Claim
ok      github.com/hashicorp/nomad/nomad        1.646s
```

### Endpoint Checklist

* [x] `Request` struct and `*RequestType` constant in `nomad/structs/structs.go`. (Done in #6622)
* [x] In `nomad/fsm.go`, add a dispatch case to the switch statement in `Apply` (Done in #6622)
* [x] State method for modifying objects in a `Txn` in `nomad/state/state_store.go` (Done in #6622)
* [x] Handler for the request in `nomad/foo_endpoint.go` (this PR, including tests)
* ~Wrapper for the HTTP request in `command/agent/foo_endpoint.go`~ (not applicable)
* ~`nomad/core_sched.go` sends many RPCs~ (not applicable)
