### PR TITLE
sentinel: copy jobs to prevent mutation

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -242,8 +242,9 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 		}
 	}
 
-	// Enforce Sentinel policies
-	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job)
+	// Enforce Sentinel policies. Pass a copy of the job to prevent
+	// sentinel from altering it.
+	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job.Copy())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It's unclear whether Sentinel code can mutate values passed to the eval,
so ensure it cannot by copying the job.

This change was initially committed to the private Enterprise repo and was shipped as part of 0.9.3.  The change is not relevant to OSS, but the OSS repo seems a better target for the change.