### PR TITLE
e2e: turn no-ACLs connect tests back on

### DIFF
--- a/e2e/connect/acls.go
+++ b/e2e/connect/acls.go
@@ -1,7 +1,6 @@
 package connect
 
 import (
-	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -194,7 +193,6 @@ func (tc *ConnectACLsE2ETest) TestConnectACLsRegisterMasterToken(f *framework.F)
 	resp, _, err := jobAPI.Plan(job, false, nil)
 	r.NoError(err)
 	r.NotNil(resp)
-	fmt.Println("resp:", resp)
 }
 
 func (tc *ConnectACLsE2ETest) TestConnectACLsRegisterMissingOperatorToken(f *framework.F) {
@@ -265,18 +263,10 @@ func (tc *ConnectACLsE2ETest) TestConnectACLsConnectDemo(f *framework.F) {
 
 	// === Register the Nomad job ===
 	jobID := "connectACL_connect_demo"
-	//{
-	//
-	//	nomadClient := tc.Nomad()
-	//	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient, demoConnectJob, jobID, operatorToken)
-	//	allocIDs := e2eutil.AllocIDsFromAllocationListStubs(allocs)
-	//	e2eutil.WaitForAllocsRunning(t, nomadClient, allocIDs)
-	//}
 
 	var allocs []*napi.AllocationListStub
 	allocIDs := make(map[string]bool, 2)
 	{
-		// jobID := "connect" + uuid.Generate()[0:8] (nicer name now)
 
 		// parse the example connect jobspec file
 		tc.jobIDs = append(tc.jobIDs, jobID)
@@ -318,8 +308,6 @@ func (tc *ConnectACLsE2ETest) TestConnectACLsConnectDemo(f *framework.F) {
 		r.Len(eval.QueuedAllocations, 2, pretty.Sprint(eval.QueuedAllocations))
 
 		// === Assert allocs are running ===
-		// var allocs []*napi.AllocationListStub // move scope
-
 		for i := 0; i < 20; i++ {
 			allocs, qMeta, err = evalAPI.Allocations(eval.ID, qOpts)
 			r.NoError(err)

--- a/e2e/connect/connect.go
+++ b/e2e/connect/connect.go
@@ -22,15 +22,15 @@ type ConnectE2ETest struct {
 
 func init() {
 	// connect tests without Consul ACLs enabled
-	//framework.AddSuites(&framework.TestSuite{
-	//	Component:   "Connect",
-	//	CanRunLocal: true,
-	//	Consul:      true,
-	//	Cases: []framework.TestCase{
-	//		new(ConnectE2ETest),
-	//		new(ConnectClientStateE2ETest),
-	//	},
-	//})
+	framework.AddSuites(&framework.TestSuite{
+		Component:   "Connect",
+		CanRunLocal: true,
+		Consul:      true,
+		Cases: []framework.TestCase{
+			new(ConnectE2ETest),
+			new(ConnectClientStateE2ETest),
+		},
+	})
 
 	// connect tests with Consul ACLs enabled
 	framework.AddSuites(&framework.TestSuite{


### PR DESCRIPTION
Also cleanup more missed debugging things. Third try is the charm, as they say... 