### PR TITLE
Document service lifecycle

### DIFF
--- a/website/pages/docs/job-specification/service.mdx
+++ b/website/pages/docs/job-specification/service.mdx
@@ -265,6 +265,38 @@ service {
 }
 ```
 
+## `service` Lifecycle
+
+Nomad manages registering, updating, and deregistering services with Consul. It
+is important to understand when each of these steps happens and how they can be
+customized.
+
+**Registration**: Nomad will only register a service and its checks into
+Consul after the task has started.
+
+**Updating**: If the service or check definition is updated Nomad will update
+the service in Consul as well. This occurs without restarting a task.
+
+**Deregistering**: If a running task with a service stanza exits, the services
+and checks are immediately deregistered from Consul without delay. If however
+Nomad needs to kill a running task, the task is killed in the following order:
+
+1. Immediately remove the services and checks from Consul. This stops new
+   traffic from being routed to the task that is being killed.
+2. If [`shutdown_delay`][shutdowndelay] is set, wait the configured duration
+   before proceeding to step 3. Setting a [`shutdown_delay`][shutdowndelay] can
+   be useful if the application itself doesn't handle graceful shutdowns based
+   on the [`kill_signal`][killsignal]. The configured delay will provide a
+   period of time in which the service is no longer registered in Consul, and
+   thus is not receiving additional requests, but hasn't been signalled to
+   shutdown. This allows the application time to complete the requests and
+   become idle.
+3. Send the [`kill_signal`][killsignal] to the task and wait for the task to
+   exit. The task should use this time to gracefully drain and finish any
+   existing requests.
+4. If the task hasn't exited itself after the [`kill_timeout`][killtimeout],
+   Nomad will force kill the application.
+
 ## `service` Examples
 
 The following examples only show the `service` stanzas. Remember that the
@@ -651,3 +683,6 @@ advertise and check directly since Nomad isn't managing any port assignments.
 [qemu]: /docs/drivers/qemu 'Nomad qemu Driver'
 [restart_stanza]: /docs/job-specification/restart 'restart stanza'
 [connect]: /docs/job-specification/connect 'Nomad Consul Connect Integration'
+[shutdowndelay]: /docs/job-specification/task#inlinecode-shutdown_delay
+[killsignal]: /docs/job-specification/task#inlinecode-kill_signal
+[killtimeout]: /docs/job-specification/task#inlinecode-kill_timeout

--- a/website/pages/docs/job-specification/service.mdx
+++ b/website/pages/docs/job-specification/service.mdx
@@ -271,11 +271,12 @@ Nomad manages registering, updating, and deregistering services with Consul. It
 is important to understand when each of these steps happens and how they can be
 customized.
 
-**Registration**: Nomad will only register a service and its checks into
-Consul after the task has started.
+**Registration**: Nomad will register `group` services and checks *before*
+starting any tasks. Services and checks for a specific `task` are registered
+*after* the task has started.
 
-**Updating**: If the service or check definition is updated Nomad will update
-the service in Consul as well. This occurs without restarting a task.
+**Updating**: If a service or check definition is updated, Nomad will update
+the service in Consul as well. Consul is updated without restarting a task.
 
 **Deregistering**: If a running task with a service stanza exits, the services
 and checks are immediately deregistered from Consul without delay. If however
@@ -294,8 +295,8 @@ Nomad needs to kill a running task, the task is killed in the following order:
 3. Send the [`kill_signal`][killsignal] to the task and wait for the task to
    exit. The task should use this time to gracefully drain and finish any
    existing requests.
-4. If the task hasn't exited itself after the [`kill_timeout`][killtimeout],
-   Nomad will force kill the application.
+4. If the task has not exited after the [`kill_timeout`][killtimeout], Nomad
+   will force kill the application.
 
 ## `service` Examples
 


### PR DESCRIPTION
There were some questions on how services were deregistered from Consul and realized it wasn't really documented so took a stab at it. Some of this may be wrong based on the service stanza being registered on the task group, so feel free to adjust.

<img width="929" alt="Screen Shot 2020-02-05 at 2 16 04 PM" src="https://user-images.githubusercontent.com/1047914/73875718-b838b200-4823-11ea-997f-9b13858a28f8.png">
