### PR TITLE
e2e: add --quiet flag to s3 copy to reduce log spam

### DIFF
--- a/e2e/framework/provisioning/deploy.go
+++ b/e2e/framework/provisioning/deploy.go
@@ -45,7 +45,7 @@ func deployLinux(t *testing.T, target *ProvisioningTarget) error {
 			deployment.Platform, deployment.NomadSha,
 		)
 		remoteDir := filepath.Dir(deployment.RemoteBinaryPath)
-		script := fmt.Sprintf(`aws s3 cp %s nomad.tar.gz
+		script := fmt.Sprintf(`aws s3 cp --quiet %s nomad.tar.gz
 			sudo tar -zxvf nomad.tar.gz -C %s
 			sudo chmod 0755 %s
 			sudo chown root:root %s`,


### PR DESCRIPTION
When end-to-end tests run on CI, the progress bar for `aws s3 cp` (which updates in place on an interactive terminal) spams the CI logs. It's not particularly useful for interactive use cases either because the step is reported to the user, so this removes it.