### PR TITLE
csi: Provide plugin-scoped paths during RPCs

### DIFF
--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -258,7 +258,8 @@ func (h *csiPluginSupervisorHook) registerPlugin(socketPath string) (func(), err
 				SocketPath: socketPath,
 			},
 			Options: map[string]string{
-				"MountPoint": h.mountPoint,
+				"MountPoint":          h.mountPoint,
+				"ContainerMountPoint": h.task.CSIPluginConfig.MountDir,
 			},
 		}
 	}

--- a/client/pluginmanager/csimanager/instance.go
+++ b/client/pluginmanager/csimanager/instance.go
@@ -90,7 +90,7 @@ func (i *instanceManager) setupVolumeManager() {
 	case <-i.shutdownCtx.Done():
 		return
 	case <-i.fp.hadFirstSuccessfulFingerprintCh:
-		i.volumeManager = newVolumeManager(i.logger, i.client, i.mountPoint, i.fp.requiresStaging)
+		i.volumeManager = newVolumeManager(i.logger, i.client, i.mountPoint, i.containerMountPoint, i.fp.requiresStaging)
 		i.logger.Debug("Setup volume manager")
 		close(i.volumeManagerSetupCh)
 		return

--- a/client/pluginmanager/csimanager/instance.go
+++ b/client/pluginmanager/csimanager/instance.go
@@ -27,6 +27,10 @@ type instanceManager struct {
 	// stored and where mount points will be created
 	mountPoint string
 
+	// containerMountPoint is the location _inside_ the plugin container that the
+	// `mountPoint` is bound in to.
+	containerMountPoint string
+
 	fp *pluginFingerprinter
 
 	volumeManager        *volumeManager
@@ -51,7 +55,8 @@ func newInstanceManager(logger hclog.Logger, updater UpdateNodeCSIInfoFunc, p *d
 			hadFirstSuccessfulFingerprintCh: make(chan struct{}),
 		},
 
-		mountPoint: p.Options["MountPoint"],
+		mountPoint:          p.Options["MountPoint"],
+		containerMountPoint: p.Options["ContainerMountPoint"],
 
 		volumeManagerSetupCh: make(chan struct{}),
 

--- a/client/pluginmanager/csimanager/volume_test.go
+++ b/client/pluginmanager/csimanager/volume_test.go
@@ -74,8 +74,8 @@ func TestVolumeManager_ensureStagingDir(t *testing.T) {
 			defer os.RemoveAll(tmpPath)
 
 			csiFake := &csifake.Client{}
-			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, true)
-			expectedStagingPath := manager.stagingDirForVolume(tc.Volume)
+			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, tmpPath, true)
+			expectedStagingPath := manager.stagingDirForVolume(tmpPath, tc.Volume)
 
 			if tc.CreateDirAheadOfTime {
 				err := os.MkdirAll(expectedStagingPath, 0700)
@@ -164,10 +164,10 @@ func TestVolumeManager_stageVolume(t *testing.T) {
 			csiFake := &csifake.Client{}
 			csiFake.NextNodeStageVolumeErr = tc.PluginErr
 
-			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, true)
+			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, tmpPath, true)
 			ctx := context.Background()
 
-			_, err := manager.stageVolume(ctx, tc.Volume)
+			err := manager.stageVolume(ctx, tc.Volume)
 
 			if tc.ExpectedErr != nil {
 				require.EqualError(t, err, tc.ExpectedErr.Error())
@@ -215,7 +215,7 @@ func TestVolumeManager_unstageVolume(t *testing.T) {
 			csiFake := &csifake.Client{}
 			csiFake.NextNodeUnstageVolumeErr = tc.PluginErr
 
-			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, true)
+			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, tmpPath, true)
 			ctx := context.Background()
 
 			err := manager.unstageVolume(ctx, tc.Volume)
@@ -275,10 +275,10 @@ func TestVolumeManager_publishVolume(t *testing.T) {
 			csiFake := &csifake.Client{}
 			csiFake.NextNodePublishVolumeErr = tc.PluginErr
 
-			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, true)
+			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, tmpPath, true)
 			ctx := context.Background()
 
-			_, err := manager.publishVolume(ctx, tc.Volume, tc.Allocation, "")
+			_, err := manager.publishVolume(ctx, tc.Volume, tc.Allocation)
 
 			if tc.ExpectedErr != nil {
 				require.EqualError(t, err, tc.ExpectedErr.Error())


### PR DESCRIPTION
When providing paths to plugins, the path needs to be in the scope of
the plugins container, rather than that of the host.

Here we enable that by providing the mount point through the plugin
registration and then use it when constructing request target paths.