### PR TITLE
Updated docs on Vault TLS settings

### DIFF
--- a/website/pages/docs/configuration/vault.mdx
+++ b/website/pages/docs/configuration/vault.mdx
@@ -59,14 +59,18 @@ vault {
   this will fallback to the default system CA bundle, which varies by OS and
   version.
 
-- `cert_file` `(string: "")` - Specifies the path to the certificate used
-  for Vault communication. If this is set then you need to also set
-  `tls_key_file`.
+- `cert_file` `(string: "")` - Specifies the path to the certificate used for
+  Vault communication. This must be set if
+  [tls_require_and_verify_client_cert](https://www.vaultproject.io/docs/configuration/listener/tcp/#inlinecode-tls_require_and_verify_client_cert)
+  is enabled in Vault.
 
 - `key_file` `(string: "")` - Specifies the path to the private key used for
-  Vault communication. If this is set then you need to also set `cert_file`.
+  Vault communication. If this is set then you need to also set
+  `cert_file`. This must be set if
+  [tls_require_and_verify_client_cert](https://www.vaultproject.io/docs/configuration/listener/tcp/#inlinecode-tls_require_and_verify_client_cert)
+  is enabled in Vault.
 
-- `namespace` `(string: "")` - Specifies the [Vault namespace](https://www.vaultproject.io/docs/enterprise/namespaces)
+- `namespace` `(string: "")` - Specifies the [Vault namespace](https://www.vaultproject.io/docs/enterprise/namespaces/index.html)
   used by the Vault integration. If non-empty, this namespace will be used on
   all Vault API calls.
 


### PR DESCRIPTION
This PR adds some clarity to the docs for the TLS parameters `_cert_file` and `_key_file` in the vault stanza in the config.