### PR TITLE
UI: Explicit transparent bg on popover actions

### DIFF
--- a/ui/app/styles/components/popover-menu.scss
+++ b/ui/app/styles/components/popover-menu.scss
@@ -16,6 +16,7 @@
 
   .popover-action {
     border: none;
+    background: transparent;
     height: 2.75em;
     width: 100%;
     margin: 4px;


### PR DESCRIPTION
This fixes a default browser style difference, noticed in Firefox but potentially elsewhere too:

**Before:**
<img width="330" alt="Screen Shot 2020-02-07 at 2 16 32 PM" src="https://user-images.githubusercontent.com/174740/74070060-c36f1780-49b4-11ea-9581-75e1ad2ae00a.png">

**After:**
<img width="331" alt="Screen Shot 2020-02-07 at 2 16 46 PM" src="https://user-images.githubusercontent.com/174740/74070067-c833cb80-49b4-11ea-8f15-7ac2279ee8d0.png">
