### PR TITLE
UI: Override the max-width on mobile to avoid losing space due to non-existent gutter menu

### DIFF
--- a/ui/app/styles/components/page-layout.scss
+++ b/ui/app/styles/components/page-layout.scss
@@ -54,6 +54,7 @@
         &.is-right {
           margin-left: 0;
           width: 100%;
+          max-width: 100%;
         }
       }
     }


### PR DESCRIPTION
At some point we switched to `max-width` to subtract the gutter menu width but didn't adjust the property within the media query to match. The result is that even when the gutter menu is collapsed, the main page body is subtracting width.

**Before**
<img width="918" alt="Screen Shot 2020-02-07 at 2 21 08 PM" src="https://user-images.githubusercontent.com/174740/74070235-69bb1d00-49b5-11ea-94bb-4e8d82b77532.png">

**After:**
![image](https://user-images.githubusercontent.com/174740/74070280-7fc8dd80-49b5-11ea-8dc1-3690db27b230.png)
