### PR TITLE
csi: add PublishContext to CSIVolumeClaimResponse

### DIFF
--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -431,6 +431,20 @@ type CSIVolumeClaimRequest struct {
 }
 
 type CSIVolumeClaimResponse struct {
+	// Opaque static publish properties of the volume. SP MAY use this
+	// field to ensure subsequent `NodeStageVolume` or `NodePublishVolume`
+	// calls calls have contextual information.
+	// The contents of this field SHALL be opaque to nomad.
+	// The contents of this field SHALL NOT be mutable.
+	// The contents of this field SHALL be safe for the nomad to cache.
+	// The contents of this field SHOULD NOT contain sensitive
+	// information.
+	// The contents of this field SHOULD NOT be used for uniquely
+	// identifying a volume. The `volume_id` alone SHOULD be sufficient to
+	// identify the volume.
+	// This field is OPTIONAL and when present MUST be passed to
+	// `NodeStageVolume` or `NodePublishVolume` calls on the client
+	PublishContext map[string]string
 	QueryMeta
 }
 


### PR DESCRIPTION
The [`ControllerPublishVolumeResponse` CSI RPC](https://godoc.org/github.com/container-storage-interface/spec/lib/go/csi#ControllerPublishVolumeResponse) includes the publish context intended to be passed by the orchestrator as an opaque value to the node plugins. This changeset adds it to our response to a volume claim request to proxy the controller's response back to the client node.

ref https://github.com/hashicorp/nomad/pull/7107/files#r377296824, I'm making this as a separate PR so that I don't block client-side work by @endocrimes 