### PR TITLE
csi: stub methods for server-to-controller RPC calls

### DIFF
--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -394,3 +394,17 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 		}}
 	return v.srv.blockingRPC(&opts)
 }
+
+// controllerPublishVolume sends publish request to the CSI controller
+// plugin associated with a volume, if any.
+func (srv *Server) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, resp *structs.CSIVolumeClaimResponse) error {
+	// TODO(tgross): implement me!
+	return nil
+}
+
+// controllerUnpublishVolume sends an unpublish request to the CSI
+// controller plugin associated with a volume, if any.
+func (srv *Server) controllerUnpublishVolume(req *structs.CSIVolumeClaimRequest, nodeID string) error {
+	// TODO(tgross): implement me!
+	return nil
+}


### PR DESCRIPTION
I've pushed up these RPC stub methods as a separate changeset so that I can break down a larger RPC + GC changeset (covering #6903, #7036, #6904, and #7038),  into easier-to-review PRs that still compile and pass tests.