### PR TITLE
csi: server-to-controller publish/unpublish RPCs

### DIFF
--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -481,9 +481,9 @@ type CSIPlugin struct {
 
 	ControllerRequired bool
 	ControllersHealthy int
-	Controllers        map[string]*CSIInfo
+	Controllers        map[string]*CSIInfo // map of client IDs to CSI Controllers
 	NodesHealthy       int
-	Nodes              map[string]*CSIInfo
+	Nodes              map[string]*CSIInfo // map of client IDs to CSI Nodes
 
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -200,6 +200,20 @@ func (c *CSIInfo) Equal(o *CSIInfo) bool {
 	return reflect.DeepEqual(nc, no)
 }
 
+func (c *CSIInfo) IsController() bool {
+	if c == nil || c.ControllerInfo == nil {
+		return false
+	}
+	return true
+}
+
+func (c *CSIInfo) IsNode() bool {
+	if c == nil || c.NodeInfo == nil {
+		return false
+	}
+	return true
+}
+
 // DriverInfo is the current state of a single driver. This is updated
 // regularly as driver health changes on the node.
 type DriverInfo struct {


### PR DESCRIPTION
Nomad servers need to make requests to CSI controller plugins running
on a client for publish/unpublish. The RPC needs to look up the client
node based on the plugin, load balancing across controllers, and then
perform the required client RPC to that node (via server forwarding if
necessary).