### PR TITLE
csi: volume claim garbage collection

### DIFF
--- a/jobspec/test-fixtures/service-enable-tag-override.hcl
+++ b/jobspec/test-fixtures/service-enable-tag-override.hcl
@@ -1,9 +1,10 @@
 job "service_eto" {
   type = "service"
+
   group "group" {
     task "task" {
       service {
-        name = "example"
+        name                = "example"
         enable_tag_override = true
       }
     }

--- a/jobspec/test-fixtures/tg-service-enable-tag-override.hcl
+++ b/jobspec/test-fixtures/tg-service-enable-tag-override.hcl
@@ -1,7 +1,7 @@
 job "group_service_eto" {
   group "group" {
     service {
-      name = "example"
+      name                = "example"
       enable_tag_override = true
     }
   }

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -188,10 +188,6 @@ type Config struct {
 	// for GC. This gives users some time to view terminal deployments.
 	DeploymentGCThreshold time.Duration
 
-	// CSIVolumePublicationGCInterval is how often we dispatch a job to GC
-	// unclaimed CSI volume publications.
-	CSIVolumePublicationGCInterval time.Duration
-
 	// EvalNackTimeout controls how long we allow a sub-scheduler to
 	// work on an evaluation before we consider it failed and Nack it.
 	// This allows that evaluation to be handed to another sub-scheduler
@@ -378,7 +374,6 @@ func DefaultConfig() *Config {
 		NodeGCThreshold:                  24 * time.Hour,
 		DeploymentGCInterval:             5 * time.Minute,
 		DeploymentGCThreshold:            1 * time.Hour,
-		CSIVolumePublicationGCInterval:   60 * time.Second,
 		EvalNackTimeout:                  60 * time.Second,
 		EvalDeliveryLimit:                3,
 		EvalNackInitialReenqueueDelay:    1 * time.Second,

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -774,10 +774,10 @@ func (c *CoreScheduler) volumeClaimReap(jobs []*structs.Job, leaderACL string) e
 
 				collectFunc := func(allocs map[string]*structs.Allocation) {
 					for _, alloc := range allocs {
-						// we call denormalize on the volume above to make sure the Allocation
-						// pointer in PastAllocs isn't nil. But the alloc might have been
-						// garbage collected concurrently, so if the alloc is still nil we can
-						// safely skip it.
+						// we call denormalize on the volume above to populate
+						// Allocation pointers. But the alloc might have been
+						// garbage collected concurrently, so if the alloc is
+						// still nil we can safely skip it.
 						if alloc == nil {
 							continue
 						}
@@ -796,7 +796,7 @@ func (c *CoreScheduler) volumeClaimReap(jobs []*structs.Job, leaderACL string) e
 				req := &structs.CSIVolumeClaimRequest{
 					VolumeID:   volID,
 					Allocation: nil, // unpublish never uses this field
-					Claim:      structs.CSIVolumeClaimGC,
+					Claim:      structs.CSIVolumeClaimRelease,
 					WriteRequest: structs.WriteRequest{
 						Region:    job.Region,
 						Namespace: job.Namespace,

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -472,6 +472,7 @@ func (srv *Server) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, r
 
 // controllerUnpublishVolume sends an unpublish request to the CSI
 // controller plugin associated with a volume, if any.
+// TODO: the only caller of this won't have an alloc pointer handy, should it be its own request arg type?
 func (srv *Server) controllerUnpublishVolume(req *structs.CSIVolumeClaimRequest, nodeID string) error {
 	plug, vol, err := srv.volAndPluginLookup(req.VolumeID)
 	if plug == nil || vol == nil || err != nil {

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -519,8 +519,6 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 	defer jobGC.Stop()
 	deploymentGC := time.NewTicker(s.config.DeploymentGCInterval)
 	defer deploymentGC.Stop()
-	csiVolumePublicationGC := time.NewTicker(s.config.CSIVolumePublicationGCInterval)
-	defer csiVolumePublicationGC.Stop()
 
 	// getLatest grabs the latest index from the state store. It returns true if
 	// the index was retrieved successfully.
@@ -552,10 +550,6 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 		case <-deploymentGC.C:
 			if index, ok := getLatest(); ok {
 				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobDeploymentGC, index))
-			}
-		case <-csiVolumePublicationGC.C:
-			if index, ok := getLatest(); ok {
-				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobCSIVolumePublicationGC, index))
 			}
 		case <-stopCh:
 			return

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1078,6 +1078,10 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 	now := time.Now()
 	var evals []*structs.Evaluation
 
+	// A set of de-duplicated IDs for jobs that need volume claim GC.
+	// Later we'll create a gc eval for each job.
+	jobsWithVolumeGCs := make(map[string]*structs.Job)
+
 	for _, allocToUpdate := range args.Alloc {
 		allocToUpdate.ModifyTime = now.UTC().UnixNano()
 
@@ -1105,11 +1109,12 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 			continue
 		}
 
-		err = n.unclaimVolumesForTerminalAllocs(args, alloc, taskGroup)
-		if err != nil {
-			n.logger.Error("UpdateAlloc unable to release CSI volume",
-				"alloc", alloc.ID, "error", err)
-			continue
+		// If the terminal alloc has CSI volumes, add its job to the list
+		// of jobs we're going to call volume claim GC on.
+		for _, vol := range taskGroup.Volumes {
+			if vol.Type == structs.VolumeTypeCSI {
+				jobsWithVolumeGCs[job.ID] = job
+			}
 		}
 
 		// Add an evaluation if this is a failed alloc that is eligible for rescheduling
@@ -1127,6 +1132,26 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 			}
 			evals = append(evals, eval)
 		}
+	}
+
+	// Add an evaluation for garbage collecting the the CSI volume claims
+	// of jobs with terminal allocs
+	for _, job := range jobsWithVolumeGCs {
+		// we have to build this eval by hand rather than calling srv.CoreJob
+		// here because we need to use the alloc's namespace
+		eval := &structs.Evaluation{
+			ID:          uuid.Generate(),
+			Namespace:   job.Namespace,
+			Priority:    structs.CoreJobPriority,
+			Type:        structs.JobTypeCore,
+			TriggeredBy: structs.EvalTriggerAllocStop,
+			JobID:       structs.CoreJobCSIVolumeClaimGC + ":" + job.ID,
+			LeaderACL:   n.srv.getLeaderAcl(),
+			Status:      structs.EvalStatusPending,
+			CreateTime:  now.UTC().UnixNano(),
+			ModifyTime:  now.UTC().UnixNano(),
+		}
+		evals = append(evals, eval)
 	}
 
 	// Add this to the batch
@@ -1164,32 +1189,6 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 
 	// Setup the response
 	reply.Index = future.Index()
-	return nil
-}
-
-// unclaimVolumesForTerminalAllocs unpublishes and unclaims CSI volumes
-// that belong to the alloc if it is terminal.
-func (n *Node) unclaimVolumesForTerminalAllocs(args *structs.AllocUpdateRequest, alloc *structs.Allocation, taskGroup *structs.TaskGroup) error {
-	for _, volume := range taskGroup.Volumes {
-
-		// TODO(tgross): we also need to call ControllerUnpublishVolume CSI RPC here
-		// but the server-side CSI client + routing hasn't been implemented yet
-
-		req := &structs.CSIVolumeClaimRequest{
-			VolumeID:     volume.Source,
-			AllocationID: alloc.ID,
-			Claim:        structs.CSIVolumeClaimRelease,
-			WriteRequest: args.WriteRequest,
-		}
-
-		resp, _, err := n.srv.raftApply(structs.CSIVolumeClaimRequestType, req)
-		if err != nil {
-			return err
-		}
-		if respErr, ok := resp.(error); ok {
-			return respErr
-		}
-	}
 	return nil
 }
 

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -2320,21 +2320,18 @@ func TestClientEndpoint_UpdateAlloc_UnclaimVolumes(t *testing.T) {
 	state := srv.fsm.State()
 	ws := memdb.NewWatchSet()
 
-	// Create a client node with a plugin
+	// Create a client node, plugin, and volume
 	node := mock.Node()
+	node.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early version
 	node.CSINodePlugins = map[string]*structs.CSIInfo{
 		"csi-plugin-example": {PluginID: "csi-plugin-example",
-			Healthy:  true,
-			NodeInfo: &structs.CSINodeInfo{},
+			Healthy:        true,
+			NodeInfo:       &structs.CSINodeInfo{},
+			ControllerInfo: &structs.CSIControllerInfo{},
 		},
 	}
-	plugin := structs.NewCSIPlugin("csi-plugin-example", 1)
-	plugin.ControllerRequired = false
-	plugin.AddPlugin(node.ID, &structs.CSIInfo{})
 	err := state.UpsertNode(99, node)
 	require.NoError(t, err)
-
-	// Create the volume for the plugin
 	volId0 := uuid.Generate()
 	vols := []*structs.CSIVolume{{
 		ID:             volId0,
@@ -2342,19 +2339,20 @@ func TestClientEndpoint_UpdateAlloc_UnclaimVolumes(t *testing.T) {
 		PluginID:       "csi-plugin-example",
 		AccessMode:     structs.CSIVolumeAccessModeMultiNodeSingleWriter,
 		AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
-		Topologies: []*structs.CSITopology{{
-			Segments: map[string]string{"foo": "bar"},
-		}},
 	}}
-	err = state.CSIVolumeRegister(4, vols)
+	err = state.CSIVolumeRegister(100, vols)
 	require.NoError(t, err)
+	vol, err := state.CSIVolumeByID(ws, volId0)
+	require.NoError(t, err)
+	require.Len(t, vol.ReadAllocs, 0)
+	require.Len(t, vol.WriteAllocs, 0)
 
 	// Create a job with 2 allocations
 	job := mock.Job()
 	job.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{
 		"_": {
 			Name:     "someVolume",
-			Type:     "",
+			Type:     structs.VolumeTypeCSI,
 			Source:   volId0,
 			ReadOnly: false,
 		},
@@ -2378,12 +2376,6 @@ func TestClientEndpoint_UpdateAlloc_UnclaimVolumes(t *testing.T) {
 
 	err = state.UpsertAllocs(104, []*structs.Allocation{alloc1, alloc2})
 	require.NoError(t, err)
-
-	// Verify no claims are set
-	vol, err := state.CSIVolumeByID(ws, volId0)
-	require.NoError(t, err)
-	require.Len(t, vol.ReadAllocs, 0)
-	require.Len(t, vol.WriteAllocs, 0)
 
 	// Claim the volumes and verify the claims were set
 	err = state.CSIVolumeClaim(105, volId0, alloc1, structs.CSIVolumeClaimWrite)
@@ -2409,11 +2401,11 @@ func TestClientEndpoint_UpdateAlloc_UnclaimVolumes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, structs.AllocClientStatusFailed, out.ClientStatus)
 
-	// Verify the claim was released
-	vol, err = state.CSIVolumeByID(ws, volId0)
-	require.NoError(t, err)
-	require.Len(t, vol.ReadAllocs, 1)
-	require.Len(t, vol.WriteAllocs, 0)
+	// Verify the eval for the claim GC was emitted
+	// Lookup the evaluations
+	eval, err := state.EvalsByJob(ws, job.Namespace, structs.CoreJobCSIVolumeClaimGC+":"+job.ID)
+	require.NotNil(t, eval)
+	require.Nil(t, err)
 }
 
 func TestClientEndpoint_CreateNodeEvals(t *testing.T) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1929,14 +1929,6 @@ func (s *StateStore) CSIVolumeDenormalize(ws memdb.WatchSet, vol *structs.CSIVol
 		vol.WriteAllocs[id] = a
 	}
 
-	for id := range vol.PastAllocs {
-		a, err := s.AllocByID(ws, id)
-		if err != nil {
-			return nil, err
-		}
-		vol.PastAllocs[id] = a
-	}
-
 	return vol, nil
 }
 

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -281,6 +281,8 @@ func (v *CSIVolume) Claim(claim CSIVolumeClaimMode, alloc *Allocation) bool {
 		return v.ClaimWrite(alloc)
 	case CSIVolumeClaimRelease:
 		return v.ClaimRelease(alloc)
+	case CSIVolumeClaimGC:
+		return v.ClaimGC(alloc)
 	}
 	return false
 }
@@ -321,11 +323,12 @@ func (v *CSIVolume) ClaimRelease(alloc *Allocation) bool {
 	return true
 }
 
-// GCAlloc is called on Allocation gc, by following the alloc's pointer back to the volume
-func (v *CSIVolume) GCAlloc(alloc *Allocation) {
+// ClaimGC is called on Allocation gc, by following the alloc's pointer back to the volume
+func (v *CSIVolume) ClaimGC(alloc *Allocation) bool {
 	delete(v.ReadAllocs, alloc.ID)
 	delete(v.WriteAllocs, alloc.ID)
 	delete(v.PastAllocs, alloc.ID)
+	return true
 }
 
 // Equality by value
@@ -423,6 +426,7 @@ const (
 	CSIVolumeClaimRead CSIVolumeClaimMode = iota
 	CSIVolumeClaimWrite
 	CSIVolumeClaimRelease
+	CSIVolumeClaimGC
 )
 
 type CSIVolumeClaimRequest struct {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8557,10 +8557,10 @@ const (
 	// check if they are terminal. If so, we delete these out of the system.
 	CoreJobDeploymentGC = "deployment-gc"
 
-	// CoreJobCSIVolumePublicationGC is use for the garbage collection of CSI
-	// volume publications. We periodically scan volumes to see if no allocs are
-	// claiming them. If so, we unpublish the volume.
-	CoreJobCSIVolumePublicationGC = "csi-volume-publication-gc"
+	// CoreJobCSIVolumeClaimGC is use for the garbage collection of CSI
+	// volume claims. We periodically scan volumes to see if no allocs are
+	// claiming them. If so, we unclaim the volume.
+	CoreJobCSIVolumeClaimGC = "csi-volume-claim-gc"
 
 	// CoreJobForceGC is used to force garbage collection of all GCable objects.
 	CoreJobForceGC = "force-gc"


### PR DESCRIPTION
When an alloc is marked terminal (and after node unstage/unpublish
have been called), the client syncs the terminal alloc state with the
server via `Node.UpdateAlloc RPC`.

For each job that has a terminal alloc, the `Node.UpdateAlloc` RPC
handler at the server will emit an eval for a new core job to garbage
collect CSI volume claims. When this eval is handled on the core
scheduler, it will call a `volumeReap` method to release the claims
for all terminal allocs on the job.

The volume reap will issue a `ControllerUnpublishVolume` RPC for any
alloc that has volumes with a controller plugin. Once this returns (or
is skipped), the volume reap will send a new `CSIVolume.Claim` RPC
that releases the volume claim for that allocation in the state store,
making it available for scheduling again.

This same `volumeReap` method will be called from the core job GC,
which gives us a second chance to reclaim volumes during GC if there
were controller RPC failures.
