### PR TITLE
command: use consistent CONSUL_HTTP_TOKEN name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ BUG FIXES:
  * scheduler: Fixed a bug that caused evicted allocs on a lost node to be stuck in running [[GH-6902](https://github.com/hashicorp/nomad/issues/6902)]
  * scheduler: Fixed a bug where `nomad job plan/apply` returned errors instead of ignoring system job updates for ineligible nodes. [[GH-6996](https://github.com/hashicorp/nomad/issues/6996)]
 
+SECURITY:
+
+ * client: Nomad will no longer pass through the `CONSUL_HTTP_TOKEN` environment variable when launching a task. [[GH-7131](https://github.com/hashicorp/nomad/issues/7131)]
+
 ## 0.10.3 (January 29, 2020)
 
 SECURITY:

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -23,6 +23,7 @@ var (
 	// filtered when passing the environment variables of the host to a task.
 	DefaultEnvBlacklist = strings.Join([]string{
 		"CONSUL_TOKEN",
+		"CONSUL_HTTP_TOKEN",
 		"VAULT_TOKEN",
 		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
 		"GOOGLE_APPLICATION_CREDENTIALS",

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -113,7 +113,7 @@ func (c *JobRevertCommand) Run(args []string) int {
 	// Parse the Consul token
 	if consulToken == "" {
 		// Check the environment variable
-		consulToken = os.Getenv("CONSUL_TOKEN")
+		consulToken = os.Getenv("CONSUL_HTTP_TOKEN")
 	}
 
 	// Parse the Vault token

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -54,7 +54,7 @@ Alias: nomad run
 
   The run command will set the consul_token of the job based on the following
   precedence, going from highest to lowest: the -consul-token flag, the
-  $CONSUL_TOKEN environment variable and finally the value in the job file.
+  $CONSUL_HTTP_TOKEN environment variable and finally the value in the job file.
 
   The run command will set the vault_token of the job based on the following
   precedence, going from highest to lowest: the -vault-token flag, the
@@ -89,7 +89,7 @@ Run Options:
   -consul-token
     If set, the passed Consul token is stored in the job before sending to the
     Nomad servers. This allows passing the Consul token without storing it in
-    the job file. This overrides the token found in $CONSUL_TOKEN environment
+    the job file. This overrides the token found in $CONSUL_HTTP_TOKEN environment
     variable and that found in the job.
 
   -vault-token
@@ -190,7 +190,7 @@ func (c *JobRunCommand) Run(args []string) int {
 	// Parse the Consul token
 	if consulToken == "" {
 		// Check the environment variable
-		consulToken = os.Getenv("CONSUL_TOKEN")
+		consulToken = os.Getenv("CONSUL_HTTP_TOKEN")
 	}
 
 	if consulToken != "" {

--- a/nomad/structs/config/consul.go
+++ b/nomad/structs/config/consul.go
@@ -145,7 +145,7 @@ func DefaultConsulConfig() *ConsulConfig {
 // creation of Consul Service Identity tokens for Consul Connect enabled Tasks.
 //
 // If allow_unauthenticated is false, the operator must provide a token on
-// job submission (i.e. -consul-token or $CONSUL_TOKEN).
+// job submission (i.e. -consul-token or $CONSUL_HTTP_TOKEN).
 func (c *ConsulConfig) AllowsUnauthenticated() bool {
 	return c.AllowUnauthenticated != nil && *c.AllowUnauthenticated
 }


### PR DESCRIPTION
Consul CLI uses `CONSUL_HTTP_TOKEN`, so Nomad should use the same.
Note that `consul-template` uses `CONSUL_TOKEN`, which Nomad also makes use of,
so be careful to preserve any reference to that in the consul-template
context.