### PR TITLE
csi: Setup mounts for CSI Volumes

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -156,6 +156,15 @@ type allocRunner struct {
 	// servers have been contacted for the first time in case of a failed
 	// restore.
 	serversContactedCh chan struct{}
+
+	// rpcClient is the RPC Client that should be used by the allocrunner and its
+	// hooks to communicate with Nomad Servers.
+	rpcClient RPCer
+}
+
+// RPCer is the interface needed by hooks to make RPC calls.
+type RPCer interface {
+	RPC(method string, args interface{}, reply interface{}) error
 }
 
 // NewAllocRunner returns a new allocation runner.
@@ -191,6 +200,7 @@ func NewAllocRunner(config *Config) (*allocRunner, error) {
 		devicemanager:            config.DeviceManager,
 		driverManager:            config.DriverManager,
 		serversContactedCh:       config.ServersContactedCh,
+		rpcClient:                config.RPCClient,
 	}
 
 	// Create the logger based on the allocation ID

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -120,6 +120,10 @@ type allocRunner struct {
 	// transistions.
 	runnerHooks []interfaces.RunnerHook
 
+	// hookState is the output of allocrunner hooks
+	hookState   *cstructs.AllocHookResources
+	hookStateMu sync.RWMutex
+
 	// tasks are the set of task runners
 	tasks map[string]*taskrunner.TaskRunner
 

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -134,7 +134,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 			logger:         hookLogger,
 		}),
 		newConsulSockHook(hookLogger, alloc, ar.allocDir, config.ConsulConfig),
-		newCSIHook(hookLogger, alloc, ar.rpcClient),
+		newCSIHook(hookLogger, alloc, ar.rpcClient, ar.csiManager),
 	}
 
 	return nil

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -134,7 +134,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 			logger:         hookLogger,
 		}),
 		newConsulSockHook(hookLogger, alloc, ar.allocDir, config.ConsulConfig),
-		newCSIHook(hookLogger, alloc),
+		newCSIHook(hookLogger, alloc, ar.rpcClient),
 	}
 
 	return nil

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -7,10 +7,40 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	clientconfig "github.com/hashicorp/nomad/client/config"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
+
+type hookResourceSetter interface {
+	GetAllocHookResources() *cstructs.AllocHookResources
+	SetAllocHookResources(*cstructs.AllocHookResources)
+}
+
+type allocHookResourceSetter struct {
+	ar *allocRunner
+}
+
+func (a *allocHookResourceSetter) GetAllocHookResources() *cstructs.AllocHookResources {
+	a.ar.hookStateMu.RLock()
+	defer a.ar.hookStateMu.RUnlock()
+
+	return a.ar.hookState
+}
+
+func (a *allocHookResourceSetter) SetAllocHookResources(res *cstructs.AllocHookResources) {
+	a.ar.hookStateMu.Lock()
+	defer a.ar.hookStateMu.Unlock()
+
+	a.ar.hookState = res
+
+	// Propagate to all of the TRs within the lock to ensure consistent state.
+	// TODO: Refactor so TR's pull state from AR?
+	for _, tr := range a.ar.tasks {
+		tr.SetAllocHookResources(res)
+	}
+}
 
 type networkIsolationSetter interface {
 	SetNetworkIsolation(*drivers.NetworkIsolationSpec)
@@ -105,6 +135,9 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 	// create network isolation setting shim
 	ns := &allocNetworkIsolationSetter{ar: ar}
 
+	// create hook resource setting shim
+	hrs := &allocHookResourceSetter{ar: ar}
+
 	// build the network manager
 	nm, err := newNetworkManager(ar.Alloc(), ar.driverManager)
 	if err != nil {
@@ -134,7 +167,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 			logger:         hookLogger,
 		}),
 		newConsulSockHook(hookLogger, alloc, ar.allocDir, config.ConsulConfig),
-		newCSIHook(hookLogger, alloc, ar.rpcClient, ar.csiManager),
+		newCSIHook(hookLogger, alloc, ar.rpcClient, ar.csiManager, hrs),
 	}
 
 	return nil

--- a/client/allocrunner/config.go
+++ b/client/allocrunner/config.go
@@ -68,4 +68,8 @@ type Config struct {
 	// ServersContactedCh is closed when the first GetClientAllocs call to
 	// servers succeeds and allocs are synced.
 	ServersContactedCh chan struct{}
+
+	// RPCClient is the RPC Client that should be used by the allocrunner and its
+	// hooks to communicate with Nomad Servers.
+	RPCClient RPCer
 }

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -10,8 +10,9 @@ import (
 //
 // It is a noop for allocs that do not depend on CSI Volumes.
 type csiHook struct {
-	alloc  *structs.Allocation
-	logger hclog.Logger
+	alloc     *structs.Allocation
+	logger    hclog.Logger
+	rpcClient RPCer
 }
 
 func (c *csiHook) Name() string {
@@ -27,10 +28,11 @@ func (c *csiHook) Prerun() error {
 	return nil
 }
 
-func newCSIHook(logger hclog.Logger, alloc *structs.Allocation) *csiHook {
+func newCSIHook(logger hclog.Logger, alloc *structs.Allocation, rpcClient RPCer) *csiHook {
 	return &csiHook{
-		alloc:  alloc,
-		logger: logger.Named("csi_hook"),
+		alloc:     alloc,
+		logger:    logger.Named("csi_hook"),
+		rpcClient: rpcClient,
 	}
 }
 

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -1,7 +1,11 @@
 package allocrunner
 
 import (
+	"context"
+	"fmt"
+
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -10,9 +14,10 @@ import (
 //
 // It is a noop for allocs that do not depend on CSI Volumes.
 type csiHook struct {
-	alloc     *structs.Allocation
-	logger    hclog.Logger
-	rpcClient RPCer
+	alloc      *structs.Allocation
+	logger     hclog.Logger
+	csimanager csimanager.Manager
+	rpcClient  RPCer
 }
 
 func (c *csiHook) Name() string {
@@ -24,15 +29,74 @@ func (c *csiHook) Prerun() error {
 		return nil
 	}
 
-	// TODO: Volume attachment flow
+	ctx := context.TODO()
+	volumes, err := c.csiVolumesFromAlloc()
+	if err != nil {
+		return err
+	}
+
+	mounts := make(map[string]*csimanager.MountInfo, len(volumes))
+	for alias, volume := range volumes {
+		mounter, err := c.csimanager.MounterForVolume(ctx, volume)
+		if err != nil {
+			return err
+		}
+
+		mountInfo, err := mounter.MountVolume(ctx, volume, c.alloc)
+		if err != nil {
+			return err
+		}
+
+		mounts[alias] = mountInfo
+	}
+
+	// TODO: Propagate mounts back to the tasks.
+
 	return nil
 }
 
-func newCSIHook(logger hclog.Logger, alloc *structs.Allocation, rpcClient RPCer) *csiHook {
+// csiVolumesFromAlloc finds all the CSI Volume requests from the allocation's
+// task group and then fetches them from the Nomad Server, before returning
+// them in the form of map[RequestedAlias]*structs.CSIVolume.
+//
+// If any volume fails to validate then we return an error.
+func (c *csiHook) csiVolumesFromAlloc() (map[string]*structs.CSIVolume, error) {
+	vols := make(map[string]*structs.VolumeRequest)
+	tg := c.alloc.Job.LookupTaskGroup(c.alloc.TaskGroup)
+	for alias, vol := range tg.Volumes {
+		if vol.Type == structs.VolumeTypeCSI {
+			vols[alias] = vol
+		}
+	}
+
+	csiVols := make(map[string]*structs.CSIVolume, len(vols))
+	for alias, request := range vols {
+		req := &structs.CSIVolumeGetRequest{
+			ID: request.Source,
+		}
+		req.Region = c.alloc.Job.Region
+
+		var resp structs.CSIVolumeGetResponse
+		if err := c.rpcClient.RPC("CSIVolume.Get", req, &resp); err != nil {
+			return nil, err
+		}
+
+		if resp.Volume == nil {
+			return nil, fmt.Errorf("Unexpected nil volume returned for ID: %v", request.Source)
+		}
+
+		csiVols[alias] = resp.Volume
+	}
+
+	return csiVols, nil
+}
+
+func newCSIHook(logger hclog.Logger, alloc *structs.Allocation, rpcClient RPCer, csi csimanager.Manager) *csiHook {
 	return &csiHook{
-		alloc:     alloc,
-		logger:    logger.Named("csi_hook"),
-		rpcClient: rpcClient,
+		alloc:      alloc,
+		logger:     logger.Named("csi_hook"),
+		rpcClient:  rpcClient,
+		csimanager: csi,
 	}
 }
 

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -217,6 +217,8 @@ type TaskRunner struct {
 
 	networkIsolationLock sync.Mutex
 	networkIsolationSpec *drivers.NetworkIsolationSpec
+
+	allocHookResources *cstructs.AllocHookResources
 }
 
 type Config struct {
@@ -1392,4 +1394,8 @@ func (tr *TaskRunner) TaskExecHandler() drivermanager.TaskExecHandler {
 
 func (tr *TaskRunner) DriverCapabilities() (*drivers.Capabilities, error) {
 	return tr.driver.Capabilities()
+}
+
+func (tr *TaskRunner) SetAllocHookResources(res *cstructs.AllocHookResources) {
+	tr.allocHookResources = res
 }

--- a/client/allocrunner/taskrunner/volume_hook.go
+++ b/client/allocrunner/taskrunner/volume_hook.go
@@ -103,7 +103,7 @@ func partitionVolumesByType(xs map[string]*structs.VolumeRequest) map[string]map
 	return result
 }
 
-func (h *volumeHook) prepareHostVolumes(volumes map[string]*structs.VolumeRequest, req *interfaces.TaskPrestartRequest) ([]*drivers.MountConfig, error) {
+func (h *volumeHook) prepareHostVolumes(req *interfaces.TaskPrestartRequest, volumes map[string]*structs.VolumeRequest) ([]*drivers.MountConfig, error) {
 	hostVolumes := h.runner.clientConfig.Node.HostVolumes
 
 	// Always validate volumes to ensure that we do not allow volumes to be used
@@ -171,7 +171,7 @@ func (h *volumeHook) prepareCSIVolumes(req *interfaces.TaskPrestartRequest, volu
 func (h *volumeHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
 	volumes := partitionVolumesByType(h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup).Volumes)
 
-	hostVolumeMounts, err := h.prepareHostVolumes(volumes[structs.VolumeTypeHost], req)
+	hostVolumeMounts, err := h.prepareHostVolumes(req, volumes[structs.VolumeTypeHost])
 	if err != nil {
 		return err
 	}

--- a/client/allocrunner/taskrunner/volume_hook.go
+++ b/client/allocrunner/taskrunner/volume_hook.go
@@ -57,8 +57,10 @@ func (h *volumeHook) hostVolumeMountConfigurations(taskMounts []*structs.VolumeM
 	for _, m := range taskMounts {
 		req, ok := taskVolumesByAlias[m.Volume]
 		if !ok {
-			// Should never happen unless we misvalidated on job submission
-			return nil, fmt.Errorf("No group volume declaration found named: %s", m.Volume)
+			// This function receives only the task volumes that are of type Host,
+			// if we can't find a group volume then we assume the mount is for another
+			// type.
+			continue
 		}
 
 		// This is a defensive check, but this function should only ever receive

--- a/client/allocrunner/taskrunner/volume_hook_test.go
+++ b/client/allocrunner/taskrunner/volume_hook_test.go
@@ -1,0 +1,111 @@
+package taskrunner
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVolumeHook_PartitionMountsByVolume_Works(t *testing.T) {
+	mounts := []*structs.VolumeMount{
+		{
+			Volume:      "foo",
+			Destination: "/tmp",
+			ReadOnly:    false,
+		},
+		{
+			Volume:      "foo",
+			Destination: "/bar",
+			ReadOnly:    false,
+		},
+		{
+			Volume:      "baz",
+			Destination: "/baz",
+			ReadOnly:    false,
+		},
+	}
+
+	expected := map[string][]*structs.VolumeMount{
+		"foo": {
+			{
+				Volume:      "foo",
+				Destination: "/tmp",
+				ReadOnly:    false,
+			},
+			{
+				Volume:      "foo",
+				Destination: "/bar",
+				ReadOnly:    false,
+			},
+		},
+		"baz": {
+			{
+				Volume:      "baz",
+				Destination: "/baz",
+				ReadOnly:    false,
+			},
+		},
+	}
+
+	// Test with a real collection
+
+	partitioned := partitionMountsByVolume(mounts)
+	require.Equal(t, expected, partitioned)
+
+	// Test with nil/emptylist
+
+	partitioned = partitionMountsByVolume(nil)
+	require.Equal(t, map[string][]*structs.VolumeMount{}, partitioned)
+}
+
+func TestVolumeHook_prepareCSIVolumes(t *testing.T) {
+	req := &interfaces.TaskPrestartRequest{
+		Task: &structs.Task{
+			VolumeMounts: []*structs.VolumeMount{
+				{
+					Volume:      "foo",
+					Destination: "/bar",
+				},
+			},
+		},
+	}
+
+	volumes := map[string]*structs.VolumeRequest{
+		"foo": {
+			Type:   "csi",
+			Source: "my-test-volume",
+		},
+	}
+
+	tr := &TaskRunner{
+		allocHookResources: &cstructs.AllocHookResources{
+			CSIMounts: map[string]*csimanager.MountInfo{
+				"foo": &csimanager.MountInfo{
+					Source: "/mnt/my-test-volume",
+				},
+			},
+		},
+	}
+
+	expected := []*drivers.MountConfig{
+		{
+			HostPath: "/mnt/my-test-volume",
+			TaskPath: "/bar",
+		},
+	}
+
+	hook := &volumeHook{
+		logger: testlog.HCLogger(t),
+		alloc:  structs.MockAlloc(),
+		runner: tr,
+	}
+	mounts, err := hook.prepareCSIVolumes(req, volumes)
+	require.NoError(t, err)
+	require.Equal(t, expected, mounts)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -1088,6 +1088,7 @@ func (c *Client) restoreState() error {
 			DeviceManager:       c.devicemanager,
 			DriverManager:       c.drivermanager,
 			ServersContactedCh:  c.serversContactedCh,
+			RPCClient:           c,
 		}
 		c.configLock.RUnlock()
 
@@ -2351,6 +2352,7 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 		CSIManager:          c.csimanager,
 		DeviceManager:       c.devicemanager,
 		DriverManager:       c.drivermanager,
+		RPCClient:           c,
 	}
 	c.configLock.RUnlock()
 

--- a/client/structs/allochook.go
+++ b/client/structs/allochook.go
@@ -1,0 +1,29 @@
+package structs
+
+import (
+	"sync"
+
+	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
+)
+
+// AllocHookResources contains data that is provided by AllocRunner Hooks for
+// consumption by TaskRunners
+type AllocHookResources struct {
+	CSIMounts map[string]*csimanager.MountInfo
+
+	mu sync.RWMutex
+}
+
+func (a *AllocHookResources) GetCSIMounts() map[string]*csimanager.MountInfo {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	return a.CSIMounts
+}
+
+func (a *AllocHookResources) SetCSIMounts(m map[string]*csimanager.MountInfo) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.CSIMounts = m
+}


### PR DESCRIPTION
This PR introduces initial support for mounting CSI Volumes into allocs
and tasks.

That involves doing a few things:
1) Providing an RPC Client to allocrunners and taskrunners so they can
   make server RPCs (not a huge deal, but is a new dependency)
2) Introducing support for the volume manager to correctly stage and
   publish volumes on the node. This is potentially kind of tricky if we
   want to add more in the way of retries, but we should be covered
   already.
3) Providing a way for an alloc hook to send data to taskrunners. This
   is janky, but probably "good enough".
4) Using that provided data to create concrete mount definitions that
   can be used by a nomad task.

It's probably best reviewed commit-by-commit.