### PR TITLE
website: fix 'edit this page' path

### DIFF
--- a/website/components/docs-page/index.jsx
+++ b/website/components/docs-page/index.jsx
@@ -54,7 +54,7 @@ export default function DocsPage({
       </div>
       <div id="edit-this-page" className="g-container">
         <a
-          href={`https://github.com/hashicorp/vault/blob/master/website/pages/${pageMeta.__resourcePath}`}
+          href={`https://github.com/hashicorp/nomad/blob/master/website/pages/${pageMeta.__resourcePath}`}
         >
           <InlineSvg src={githubIcon} />
           <span>Edit this page</span>


### PR DESCRIPTION
this corrects a bug where the `edit this page` links in our docs layout was wrongly redirecting to the vault repo. 

example docs page to test with: https://deploy-preview-7141--nomad-website.netlify.com/docs/devices/nvidia/