### PR TITLE
[website] CircleCI Script Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,7 +452,11 @@ jobs:
     - setup_remote_docker
     - run:
         command: |
+          # There is an edge case that would cause an issue here - if dependencies are updated to an exact copy
+          # of a previous version, for example if packge-lock.json is reverted, we need to manually push the new
+          # image to the "latest" tag
           IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+          echo "Using $IMAGE_TAG"
           if ! curl https://hub.docker.com/v2/repositories/hashicorp/nomad-website/tags/$IMAGE_TAG -fsL > /dev/null; then
             cd website/
             docker build -t hashicorp/nomad-website:$IMAGE_TAG .
@@ -460,7 +464,7 @@ jobs:
             docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
             docker push hashicorp/nomad-website
           else
-            echo "Not building a new website docker image - branch is not master and/or dependencies have not changed."
+            echo "Dependencies have not changed, not building a new website docker image."
           fi
         name: Build Docker Image if Necessary
   test-other:
@@ -908,6 +912,5 @@ workflows:
           branches:
             only:
             - master
-            - website-ci-updates
         context: static-sites
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,15 +452,12 @@ jobs:
     - setup_remote_docker
     - run:
         command: |
-          echo 'export PACKAGE_LOCK_CHANGED=$(git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | grep -c website/package-lock.json)' >> $BASH_ENV
-        name: Diff package-lock.json
-    - run:
-        command: |
-          if [ "$CIRCLE_BRANCH" = "master" ] && [ $PACKAGE_LOCK_CHANGED -gt 0 ]; then
+          IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+          if ! curl https://hub.docker.com/v2/repositories/hashicorp/nomad-website/tags/$IMAGE_TAG -fsL > /dev/null; then
             cd website/
-            docker build -t hashicorp/nomad-website:$CIRCLE_SHA1 .
-            docker tag hashicorp/nomad-website:$CIRCLE_SHA1 hashicorp/nomad-website:latest
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker build -t hashicorp/nomad-website:$IMAGE_TAG .
+            docker tag hashicorp/nomad-website:$IMAGE_TAG hashicorp/nomad-website:latest
+            docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
             docker push hashicorp/nomad-website
           else
             echo "Not building a new website docker image - branch is not master and/or dependencies have not changed."
@@ -907,5 +904,10 @@ workflows:
   website:
     jobs:
     - website-docker-image:
+        filters:
+          branches:
+            only:
+            - master
+            - website-ci-updates
         context: static-sites
   version: 2

--- a/.circleci/config/jobs/website-docker-image.yml
+++ b/.circleci/config/jobs/website-docker-image.yml
@@ -8,6 +8,7 @@ steps:
       name: Build Docker Image if Necessary
       command: |
         IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+        echo "Using $IMAGE_TAG"
         if ! curl https://hub.docker.com/v2/repositories/hashicorp/nomad-website/tags/$IMAGE_TAG -fsL > /dev/null; then
           cd website/
           docker build -t hashicorp/nomad-website:$IMAGE_TAG .
@@ -15,5 +16,5 @@ steps:
           docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
           docker push hashicorp/nomad-website
         else
-          echo "Not building a new website docker image - branch is not master and/or dependencies have not changed."
+          echo "Dependencies have not changed, not building a new website docker image."
         fi

--- a/.circleci/config/jobs/website-docker-image.yml
+++ b/.circleci/config/jobs/website-docker-image.yml
@@ -5,17 +5,14 @@ steps:
   - checkout
   - setup_remote_docker
   - run:
-      name: Diff package-lock.json
-      command: |
-        echo 'export PACKAGE_LOCK_CHANGED=$(git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | grep -c website/package-lock.json)' >> $BASH_ENV
-  - run:
       name: Build Docker Image if Necessary
       command: |
-        if [ "$CIRCLE_BRANCH" = "master" ] && [ $PACKAGE_LOCK_CHANGED -gt 0 ]; then
+        IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+        if ! curl https://hub.docker.com/v2/repositories/hashicorp/nomad-website/tags/$IMAGE_TAG -fsL > /dev/null; then
           cd website/
-          docker build -t hashicorp/nomad-website:$CIRCLE_SHA1 .
-          docker tag hashicorp/nomad-website:$CIRCLE_SHA1 hashicorp/nomad-website:latest
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
+          docker build -t hashicorp/nomad-website:$IMAGE_TAG .
+          docker tag hashicorp/nomad-website:$IMAGE_TAG hashicorp/nomad-website:latest
+          docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
           docker push hashicorp/nomad-website
         else
           echo "Not building a new website docker image - branch is not master and/or dependencies have not changed."

--- a/.circleci/config/jobs/website-docker-image.yml
+++ b/.circleci/config/jobs/website-docker-image.yml
@@ -7,6 +7,9 @@ steps:
   - run:
       name: Build Docker Image if Necessary
       command: |
+        # There is an edge case that would cause an issue here - if dependencies are updated to an exact copy
+        # of a previous version, for example if packge-lock.json is reverted, we need to manually push the new
+        # image to the "latest" tag
         IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
         echo "Using $IMAGE_TAG"
         if ! curl https://hub.docker.com/v2/repositories/hashicorp/nomad-website/tags/$IMAGE_TAG -fsL > /dev/null; then

--- a/.circleci/config/workflows/website.yml
+++ b/.circleci/config/workflows/website.yml
@@ -5,4 +5,3 @@ jobs:
         branches:
           only:
             - master
-            - website-ci-updates

--- a/.circleci/config/workflows/website.yml
+++ b/.circleci/config/workflows/website.yml
@@ -1,3 +1,8 @@
 jobs:
   - website-docker-image:
       context: static-sites
+      filters:
+        branches:
+          only:
+            - master
+            - website-ci-updates

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "nomad-docs-platform",
-  "test": true,
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,5 +1,6 @@
 {
   "name": "nomad-docs-platform",
+  "test": true,
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
This PR makes some upgrades to the website docker image releasing script:

- Only runs on master using a circleci filter, rather than running on all branches but short circuiting via bash within the task, should reduce noise a little bit
- Changes the diffing strategy on package-lock to be more reliable than simply checking against the last commit, also diffs the dockerfile for changes