### PR TITLE
docs: fix references to consul environment variable

### DIFF
--- a/website/pages/docs/commands/job/revert.mdx
+++ b/website/pages/docs/commands/job/revert.mdx
@@ -13,7 +13,7 @@ job. The available versions to revert to can be found using [`job history`]
 command.
 
 The revert command will use a Consul token with the following preference:
-first the `-consul-token` flag, then the `$CONSUL_TOKEN` environment variable.
+first the `-consul-token` flag, then the `$CONSUL_HTTP_TOKEN` environment variable.
 Because the consul token used to [run] the targeted job version was not
 persisted, it must be provided to revert if the targeted job version includes
 Consul Connect enabled services and the Nomad servers were configured to require
@@ -47,7 +47,7 @@ job to revert to.
 
 - `-consul-token`: If set, the passed Consul token is sent along with the revert
   request to the Nomad servers. This overrides the token found in the
-  \$CONSUL_TOKEN environment variable.
+  \$CONSUL_HTTP_TOKEN environment variable.
 
 - `-vault-token`: If set, the passed Vault token is sent along with the revert
   request to the Nomad servers. This overrides the token found in the

--- a/website/pages/docs/commands/job/run.mdx
+++ b/website/pages/docs/commands/job/run.mdx
@@ -36,12 +36,12 @@ there are job placement issues encountered (unsatisfiable constraints, resource
 exhaustion, etc), then the exit code will be 2. Any other errors, including
 client connection issues or internal errors, are indicated by exit code 1.
 
-If the job has specified the region, the -region flag and NOMAD_REGION
+If the job has specified the region, the -region flag and `\$NOMAD_REGION`
 environment variable are overridden and the job's region is used.
 
 The run command will set the `consul_token` of the job based on the following
 precedence, going from highest to lowest: the `-consul-token` flag, the
-`$CONSUL_TOKEN` environment variable and finally the value in the job file.
+`$CONSUL_HTTP_TOKEN` environment variable and finally the value in the job file.
 
 The run command will set the `vault_token` of the job based on the following
 precedence, going from highest to lowest: the `-vault-token` flag, the
@@ -72,7 +72,7 @@ precedence, going from highest to lowest: the `-vault-token` flag, the
 
 - `-consul-token`: If set, the passed Consul token is stored in the job before
   sending to the Nomad servers. This allows passing the Consul token without
-  storing it in the job file. This overrides the token found in the \$CONSUL_TOKEN
+  storing it in the job file. This overrides the token found in the \$CONSUL_HTTP_TOKEN
   environment variable and that found in the job.
 
 - `-vault-token`: If set, the passed Vault token is stored in the job before

--- a/website/pages/docs/job-specification/job.mdx
+++ b/website/pages/docs/job-specification/job.mdx
@@ -137,7 +137,7 @@ job "docs" {
 
   !> It is **strongly discouraged** to place the token as a configuration
   parameter like this, since the token could be checked into source control
-  accidentally. Users should set the `CONSUL_TOKEN` environment variable when
+  accidentally. Users should set the `CONSUL_HTTP_TOKEN` environment variable when
   running the job instead.
 
 ## `job` Examples


### PR DESCRIPTION
We mistakenly reference `CONSUL_TOKEN` where we should be using `CONSUL_HTTP_TOKEN`.
There is one case where `CONSUL_TOKEN` is correct - in `client.mdx` there is a list of
default filtered environment variables, which for legacy reasons `CONSUL_TOKEN` will
always be one.

Completes https://github.com/hashicorp/nomad/issues/7126