### PR TITLE
build: Update to Go 1.13.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.16
+    - GOLANG_VERSION: 1.13.8
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -86,7 +86,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.16
+    - GOLANG_VERSION: 1.13.8
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -162,7 +162,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.16
+    - GOLANG_VERSION: 1.13.8
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -238,7 +238,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.16
+    - GOLANG_VERSION: 1.13.8
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -314,7 +314,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.16
+    - GOLANG_VERSION: 1.13.8
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -413,7 +413,7 @@ jobs:
         name: Ember tests
   lint-go:
     docker:
-    - image: golang:1.12.16
+    - image: golang:1.13.8
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout
@@ -472,7 +472,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.16
+    - GOLANG_VERSION: 1.13.8
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -544,7 +544,7 @@ jobs:
         path: /tmp/test-reports
   test-devices:
     docker:
-    - image: golang:1.12.16
+    - image: golang:1.13.8
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -607,7 +607,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.16
+    - GOLANG_VERSION: 1.13.8
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
@@ -679,7 +679,7 @@ jobs:
         path: /tmp/test-reports
   build-binaries:
     docker:
-    - image: golang:1.12.16
+    - image: golang:1.13.8
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -712,7 +712,7 @@ jobs:
         path: pkg/linux_amd64.zip
   test-e2e:
     docker:
-    - image: golang:1.12.16
+    - image: golang:1.13.8
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout
@@ -743,7 +743,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.12.16
+    - GOLANG_VERSION: 1.13.8
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml

--- a/.circleci/config/config.yml
+++ b/.circleci/config/config.yml
@@ -21,7 +21,7 @@ executors:
   go:
     working_directory: /go/src/github.com/hashicorp/nomad
     docker:
-      - image: golang:1.12.16
+      - image: golang:1.13.8
     environment:
       <<: *common_envs
       GOPATH: /go
@@ -33,7 +33,7 @@ executors:
     environment: &machine_env
       <<: *common_envs
       GOPATH: /home/circleci/go
-      GOLANG_VERSION: 1.12.16
+      GOLANG_VERSION: 1.13.8
 
   # uses a more recent image with unattended upgrades disabled properly
   # but seems to break docker builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.11.0 (Unreleased)
+
+IMPROVEMENTS:
+
+ * build: Updated to Go 1.13.8 [[GH-7147](https://github.com/hashicorp/nomad/issues/7147)]
+
 ## 0.10.4 (Unreleased)
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Who Uses Nomad
 Contributing to Nomad
 --------------------
 
-If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.12.16+ is *required*, and `gcc-go` is not supported).
+If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.13.8+ is *required*, and `gcc-go` is not supported).
 
 See the [`contributing`](contributing/) directory for more developer documentation.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   # install the go version used for cutting a release
   - cmd: |
       mkdir c:\go
-      appveyor DownloadFile "https://dl.google.com/go/go1.12.16.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
+      appveyor DownloadFile "https://dl.google.com/go/go1.13.8.windows-amd64.zip" -FileName "%TEMP%\\go.zip"
       
   - ps: Expand-Archive $Env:TEMP\go.zip -DestinationPath C:\
 

--- a/scripts/release/mac-remote-build
+++ b/scripts/release/mac-remote-build
@@ -56,7 +56,7 @@ REPO_PATH="${TMP_WORKSPACE}/gopath/src/github.com/hashicorp/nomad"
 mkdir -p "${TMP_WORKSPACE}/tmp"
 
 install_go() {
-  local go_version="1.12.16"
+  local go_version="1.13.8"
   local download=
 
   download="https://storage.googleapis.com/golang/go${go_version}.darwin-amd64.tar.gz"

--- a/scripts/update_golang_version.sh
+++ b/scripts/update_golang_version.sh
@@ -3,6 +3,7 @@
 golang_version="$1"
 
 current_version=$(grep -o -e 'golang:[.0-9]*' .circleci/config.yml | head -n1 | cut -d: -f2)
+echo "--> Replacing Go ${current_version} with Go ${golang_version} ..."
 
 # To support both GNU and BSD sed, the regex is looser than it needs to be.
 # Specifically, we use "* instead of "?, which relies on GNU extension without much loss of
@@ -21,8 +22,8 @@ sed -i'' -e "s|go[.0-9]*.windows-amd64.zip|go${golang_version}.windows-amd64.zip
 sed -i'' -e "s|go_version=\"*[^\"]*\"*$|go_version=\"${golang_version}\"|g" \
 	scripts/vagrant-linux-priv-go.sh scripts/release/mac-remote-build
 
-# check if there is any remaining references to old versions
-if git grep -I --fixed-strings "${current_version}" | grep -v -e CHANGELOG.md -e vendor/
+echo "--> Checking if there is any remaining references to old versions..."
+if git grep -I --fixed-strings "${current_version}" | grep -v -e CHANGELOG.md -e vendor/ -e website/
 then
 	echo "  ^^ files contain references to old golang version" >&2
 	echo "  update script and run again" >&2

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function install_go() {
-	local go_version="1.12.16"
+	local go_version="1.13.8"
 	local download=
 
 	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"


### PR DESCRIPTION
Ran `scripts/update_golang_version.sh` script (and prettied it up a bit).

Excluding `website/` from the final check in that script is a bit risky, but the regex matches tons of false positives.