### PR TITLE
UI: Host Volumes

### DIFF
--- a/ui/app/controllers/clients/client.js
+++ b/ui/app/controllers/clients/client.js
@@ -62,6 +62,10 @@ export default Controller.extend(Sortable, Searchable, {
     return this.get('model.drivers').sortBy('name');
   }),
 
+  sortedHostVolumes: computed('model.hostVolumes.@each.name', function() {
+    return this.model.hostVolumes.sortBy('name');
+  }),
+
   setEligibility: task(function*(value) {
     try {
       yield value ? this.model.setEligible() : this.model.setIneligible();

--- a/ui/app/models/host-volume.js
+++ b/ui/app/models/host-volume.js
@@ -1,0 +1,11 @@
+import Fragment from 'ember-data-model-fragments/fragment';
+import attr from 'ember-data/attr';
+import { fragmentOwner } from 'ember-data-model-fragments/attributes';
+
+export default Fragment.extend({
+  node: fragmentOwner(),
+
+  name: attr('string'),
+  path: attr('string'),
+  readOnly: attr('boolean'),
+});

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -66,6 +66,7 @@ export default Model.extend({
 
   drivers: fragmentArray('node-driver'),
   events: fragmentArray('node-event'),
+  hostVolumes: fragmentArray('host-volume'),
 
   detectedDrivers: computed('drivers.@each.detected', function() {
     return this.drivers.filterBy('detected');

--- a/ui/app/models/task-group.js
+++ b/ui/app/models/task-group.js
@@ -16,6 +16,8 @@ export default Fragment.extend({
 
   services: fragmentArray('service'),
 
+  volumes: fragmentArray('volume'),
+
   drivers: computed('tasks.@each.driver', function() {
     return this.tasks.mapBy('driver').uniq();
   }),

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -1,5 +1,6 @@
 import attr from 'ember-data/attr';
 import Fragment from 'ember-data-model-fragments/fragment';
+import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default Fragment.extend({
   name: attr('string'),
@@ -10,4 +11,6 @@ export default Fragment.extend({
   reservedCPU: attr('number'),
   reservedDisk: attr('number'),
   reservedEphemeralDisk: attr('number'),
+
+  volumeMounts: fragmentArray('volume-mount', { defaultValue: () => [] }),
 });

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -1,8 +1,10 @@
 import attr from 'ember-data/attr';
 import Fragment from 'ember-data-model-fragments/fragment';
-import { fragmentArray } from 'ember-data-model-fragments/attributes';
+import { fragmentArray, fragmentOwner } from 'ember-data-model-fragments/attributes';
 
 export default Fragment.extend({
+  taskGroup: fragmentOwner(),
+
   name: attr('string'),
   driver: attr('string'),
   kind: attr('string'),

--- a/ui/app/models/volume-mount.js
+++ b/ui/app/models/volume-mount.js
@@ -1,0 +1,10 @@
+import attr from 'ember-data/attr';
+import Fragment from 'ember-data-model-fragments/fragment';
+
+export default Fragment.extend({
+  volume: attr('string'),
+
+  destination: attr('string'),
+  propagationMode: attr('string'),
+  readOnly: attr('boolean'),
+});

--- a/ui/app/models/volume-mount.js
+++ b/ui/app/models/volume-mount.js
@@ -7,7 +7,7 @@ export default Fragment.extend({
   task: fragmentOwner(),
 
   volume: attr('string'),
-  source: computed('task.taskGroup.volumes.@each.{name,source}', function() {
+  source: computed('volume', 'task.taskGroup.volumes.@each.{name,source}', function() {
     return this.task.taskGroup.volumes.findBy('name', this.volume).source;
   }),
 

--- a/ui/app/models/volume-mount.js
+++ b/ui/app/models/volume-mount.js
@@ -1,8 +1,15 @@
+import { computed } from '@ember/object';
 import attr from 'ember-data/attr';
 import Fragment from 'ember-data-model-fragments/fragment';
+import { fragmentOwner } from 'ember-data-model-fragments/attributes';
 
 export default Fragment.extend({
+  task: fragmentOwner(),
+
   volume: attr('string'),
+  source: computed('task.taskGroup.volumes.@each.{name,source}', function() {
+    return this.task.taskGroup.volumes.findBy('name', this.volume).source;
+  }),
 
   destination: attr('string'),
   propagationMode: attr('string'),

--- a/ui/app/models/volume.js
+++ b/ui/app/models/volume.js
@@ -1,0 +1,10 @@
+import attr from 'ember-data/attr';
+import Fragment from 'ember-data-model-fragments/fragment';
+
+export default Fragment.extend({
+  name: attr('string'),
+
+  source: attr('string'),
+  type: attr('string'),
+  readOnly: attr('boolean'),
+});

--- a/ui/app/serializers/node.js
+++ b/ui/app/serializers/node.js
@@ -11,11 +11,14 @@ export default ApplicationSerializer.extend({
   },
 
   normalize(modelClass, hash) {
-    // Transform the map-based Drivers object into an array-based NodeDriver fragment list
+    // Transform map-based objects into an array-based fragment lists
     const drivers = hash.Drivers || {};
     hash.Drivers = Object.keys(drivers).map(key => {
       return assign({}, drivers[key], { Name: key });
     });
+
+    const hostVolumes = hash.HostVolumes || {};
+    hash.HostVolumes = Object.keys(hostVolumes).map(key => hostVolumes[key]);
 
     return this._super(modelClass, hash);
   },

--- a/ui/app/serializers/node.js
+++ b/ui/app/serializers/node.js
@@ -17,8 +17,10 @@ export default ApplicationSerializer.extend({
       return assign({}, drivers[key], { Name: key });
     });
 
-    const hostVolumes = hash.HostVolumes || {};
-    hash.HostVolumes = Object.keys(hostVolumes).map(key => hostVolumes[key]);
+    if (hash.HostVolumes) {
+      const hostVolumes = hash.HostVolumes;
+      hash.HostVolumes = Object.keys(hostVolumes).map(key => hostVolumes[key]);
+    }
 
     return this._super(modelClass, hash);
   },

--- a/ui/app/serializers/node.js
+++ b/ui/app/serializers/node.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   },
 
   normalize(modelClass, hash) {
-    // Transform map-based objects into an array-based fragment lists
+    // Transform map-based objects into array-based fragment lists
     const drivers = hash.Drivers || {};
     hash.Drivers = Object.keys(drivers).map(key => {
       return assign({}, drivers[key], { Name: key });

--- a/ui/app/serializers/task-group.js
+++ b/ui/app/serializers/task-group.js
@@ -11,6 +11,9 @@ export default ApplicationSerializer.extend({
     hash.ReservedEphemeralDisk = hash.EphemeralDisk.SizeMB;
     hash.Services = hash.Services || [];
 
+    const volumes = hash.Volumes || {};
+    hash.Volumes = Object.keys(volumes).map(key => volumes[key]);
+
     return this._super(typeHash, hash);
   },
 });

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -95,6 +95,7 @@
             {{#t.sort-by prop="state"}}State{{/t.sort-by}}
             <th>Last Event</th>
             {{#t.sort-by prop="events.lastObject.time"}}Time{{/t.sort-by}}
+            <th>Volumes</th>
             <th>Addresses</th>
             <th>CPU</th>
             <th>Memory</th>

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -105,6 +105,32 @@
     </div>
   {{/if}}
 
+  {{#if model.task.volumeMounts.length}}
+    <div data-test-volumes class="boxed-section">
+      <div class="boxed-section-head">
+        Volumes
+      </div>
+      <div class="boxed-section-body is-full-bleed">
+        {{#list-table source=model.task.volumeMounts as |t|}}
+          {{#t.head}}
+            <th>Name</th>
+            <th>Destination</th>
+            <th>Permissions</th>
+            <th>Client Source</th>
+          {{/t.head}}
+          {{#t.body as |row|}}
+            <tr data-test-volume>
+              <td data-test-volume-name>{{row.model.volume}}</td>
+              <td data-test-volume-destination><code>{{row.model.destination}}</code></td>
+              <td data-test-volume-permissions>{{if row.model.readOnly "Read" "Read/Write"}}</td>
+              <td data-test-volume-client-source>{{row.model.source}}</td>
+            </tr>
+          {{/t.body}}
+        {{/list-table}}
+      </div>
+    </div>
+  {{/if}}
+
   <div class="boxed-section">
     <div class="boxed-section-head">
       Recent Events

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -361,6 +361,28 @@
     </div>
   </div>
 
+  <div data-test-client-host-volumes class="boxed-section">
+    <div class="boxed-section-head">
+      Host Volumes
+    </div>
+    <div class="boxed-section-body is-full-bleed">
+      {{#list-table source=sortedHostVolumes class="is-striped" as |t|}}
+        {{#t.head}}
+          <th>Name</th>
+          <th>Source</th>
+          <th>Mode</th>
+        {{/t.head}}
+        {{#t.body as |row|}}
+          <tr data-test-client-host-volume>
+            <td>{{row.model.name}}</td>
+            <td><code>{{row.model.path}}</code></td>
+            <td>{{if row.model.readOnly "read" "read/write"}}</td>
+          </tr>
+        {{/t.body}}
+      {{/list-table}}
+    </div>
+  </div>
+
   <div data-test-driver-status class="boxed-section">
     <div class="boxed-section-head">
       Driver Status

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -361,27 +361,29 @@
     </div>
   </div>
 
-  <div data-test-client-host-volumes class="boxed-section">
-    <div class="boxed-section-head">
-      Host Volumes
+  {{#if sortedHostVolumes.length}}
+    <div data-test-client-host-volumes class="boxed-section">
+      <div class="boxed-section-head">
+        Host Volumes
+      </div>
+      <div class="boxed-section-body is-full-bleed">
+        {{#list-table source=sortedHostVolumes class="is-striped" as |t|}}
+          {{#t.head}}
+            <th>Name</th>
+            <th>Source</th>
+            <th>Permissions</th>
+          {{/t.head}}
+          {{#t.body as |row|}}
+            <tr data-test-client-host-volume>
+              <td data-test-name>{{row.model.name}}</td>
+              <td data-test-path><code>{{row.model.path}}</code></td>
+              <td data-test-permissions>{{if row.model.readOnly "Read" "Read/Write"}}</td>
+            </tr>
+          {{/t.body}}
+        {{/list-table}}
+      </div>
     </div>
-    <div class="boxed-section-body is-full-bleed">
-      {{#list-table source=sortedHostVolumes class="is-striped" as |t|}}
-        {{#t.head}}
-          <th>Name</th>
-          <th>Source</th>
-          <th>Mode</th>
-        {{/t.head}}
-        {{#t.body as |row|}}
-          <tr data-test-client-host-volume>
-            <td>{{row.model.name}}</td>
-            <td><code>{{row.model.path}}</code></td>
-            <td>{{if row.model.readOnly "read" "read/write"}}</td>
-          </tr>
-        {{/t.body}}
-      {{/list-table}}
-    </div>
-  </div>
+  {{/if}}
 
   <div data-test-driver-status class="boxed-section">
     <div class="boxed-section-head">

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -305,6 +305,7 @@
             {{#t.sort-by prop="statusIndex"}}Status{{/t.sort-by}}
             {{#t.sort-by prop="job.name"}}Job{{/t.sort-by}}
             {{#t.sort-by prop="jobVersion"}}Version{{/t.sort-by}}
+            <th>Volume</th>
             <th>CPU</th>
             <th>Memory</th>
           {{/t.head}}

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -52,6 +52,7 @@
             {{#t.sort-by prop="compositeStatus"}}State{{/t.sort-by}}
             <th>Address</th>
             {{#t.sort-by prop="datacenter"}}Datacenter{{/t.sort-by}}
+            <th># Volumes</th>
             <th># Allocs</th>
           {{/t.head}}
           {{#t.body as |row|}}

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -50,6 +50,7 @@
   </td>
   <td data-test-job-version class="is-1">{{allocation.jobVersion}}</td>
 {{/if}}
+<td data-test-volume>{{if allocation.taskGroup.volumes.length "Yes"}}</td>
 <td data-test-cpu class="is-1 has-text-centered">
   {{#if allocation.isRunning}}
     {{#if (and (not cpu) fetchStats.isRunning)}}

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -14,6 +14,7 @@
 </td>
 <td data-test-client-address>{{node.httpAddr}}</td>
 <td data-test-client-datacenter>{{node.datacenter}}</td>
+<td data-test-client-volumes>{{if node.hostVolumes.length node.hostVolumes.length}}</td>
 <td data-test-client-allocations>
   {{#if node.allocations.isPending}}
     ...

--- a/ui/app/templates/components/job-deployment/deployment-allocations.hbs
+++ b/ui/app/templates/components/job-deployment/deployment-allocations.hbs
@@ -15,6 +15,7 @@
         <th>Status</th>
         <th>Version</th>
         <th>Node</th>
+        <th>Volume</th>
         <th>CPU</th>
         <th>Memory</th>
       {{/t.head}}

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -106,6 +106,7 @@
             <th>Status</th>
             <th>Version</th>
             <th>Node</th>
+            <th>Volume</th>
             <th>CPU</th>
             <th>Memory</th>
           {{/t.head}}

--- a/ui/app/templates/components/job-page/parts/recent-allocations.hbs
+++ b/ui/app/templates/components/job-page/parts/recent-allocations.hbs
@@ -18,6 +18,7 @@
           <th>Status</th>
           <th>Version</th>
           <th>Client</th>
+          <th>Volume</th>
           <th>CPU</th>
           <th>Memory</th>
         {{/t.head}}

--- a/ui/app/templates/components/job-page/parts/task-groups.hbs
+++ b/ui/app/templates/components/job-page/parts/task-groups.hbs
@@ -11,6 +11,7 @@
         {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
         {{#t.sort-by prop="count"}}Count{{/t.sort-by}}
         {{#t.sort-by prop="queuedOrStartingAllocs" class="is-3"}}Allocation Status{{/t.sort-by}}
+        {{#t.sort-by prop="volumes.length"}}Volume?{{/t.sort-by}}
         {{#t.sort-by prop="reservedCPU"}}Reserved CPU{{/t.sort-by}}
         {{#t.sort-by prop="reservedMemory"}}Reserved Memory{{/t.sort-by}}
         {{#t.sort-by prop="reservedEphemeralDisk"}}Reserved Disk{{/t.sort-by}}

--- a/ui/app/templates/components/job-page/parts/task-groups.hbs
+++ b/ui/app/templates/components/job-page/parts/task-groups.hbs
@@ -11,7 +11,7 @@
         {{#t.sort-by prop="name"}}Name{{/t.sort-by}}
         {{#t.sort-by prop="count"}}Count{{/t.sort-by}}
         {{#t.sort-by prop="queuedOrStartingAllocs" class="is-3"}}Allocation Status{{/t.sort-by}}
-        {{#t.sort-by prop="volumes.length"}}Volume?{{/t.sort-by}}
+        {{#t.sort-by prop="volumes.length"}}Volume{{/t.sort-by}}
         {{#t.sort-by prop="reservedCPU"}}Reserved CPU{{/t.sort-by}}
         {{#t.sort-by prop="reservedMemory"}}Reserved Memory{{/t.sort-by}}
         {{#t.sort-by prop="reservedEphemeralDisk"}}Reserved Disk{{/t.sort-by}}

--- a/ui/app/templates/components/task-group-row.hbs
+++ b/ui/app/templates/components/task-group-row.hbs
@@ -7,6 +7,7 @@
 <td data-test-task-group-allocs>
   <div class="inline-chart">{{allocation-status-bar allocationContainer=taskGroup.summary isNarrow=true}}</div>
 </td>
+<td data-test-task-group-volume>{{if taskGroup.volumes.length "Yes"}}</td>
 <td data-test-task-group-cpu>{{taskGroup.reservedCPU}} MHz</td>
 <td data-test-task-group-mem>{{taskGroup.reservedMemory}} MiB</td>
 <td data-test-task-group-disk>{{taskGroup.reservedEphemeralDisk}} MiB</td>

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -22,16 +22,26 @@
   {{/if}}
 </td>
 <td data-test-time>{{format-ts task.events.lastObject.time}}</td>
+<td data-test-volumes>
+  <ul>
+    {{#each task.task.volumeMounts as |volume|}}
+      <li data-test-volume>
+        <strong>{{volume.volume}}:</strong>
+        {{volume.source}}
+      </li>
+    {{/each}}
+  </ul>
+</td>
 <td data-test-ports>
   <ul>
-    {{#with task.resources.networks.firstObject as |network|}}
+    {{#let task.resources.networks.firstObject as |network|}}
       {{#each network.ports as |port|}}
         <li data-test-port>
           <strong>{{port.name}}:</strong>
           <a href="http://{{network.ip}}:{{port.port}}" target="_blank" rel="noopener noreferrer">{{network.ip}}:{{port.port}}</a>
         </li>
       {{/each}}
-    {{/with}}
+    {{/let}}
   </ul>
 </td>
 <td data-test-cpu class="is-1 has-text-centered">

--- a/ui/app/templates/jobs/job/allocations.hbs
+++ b/ui/app/templates/jobs/job/allocations.hbs
@@ -31,6 +31,7 @@
             {{#t.sort-by prop="statusIndex"}}Status{{/t.sort-by}}
             {{#t.sort-by prop="jobVersion"}}Version{{/t.sort-by}}
             {{#t.sort-by prop="node.shortId"}}Client{{/t.sort-by}}
+            <th>Volume</th>
             <th>CPU</th>
             <th>Memory</th>
           {{/t.head}}

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -71,6 +71,7 @@
               {{#t.sort-by prop="statusIndex"}}Status{{/t.sort-by}}
               {{#t.sort-by prop="jobVersion"}}Version{{/t.sort-by}}
               {{#t.sort-by prop="node.shortId"}}Client{{/t.sort-by}}
+              <th>Volume</th>
               <th>CPU</th>
               <th>Memory</th>
             {{/t.head}}

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -109,4 +109,30 @@
       {{/if}}
     </div>
   </div>
+
+  {{#if model.volumes.length}}
+    <div data-test-volumes class="boxed-section">
+      <div class="boxed-section-head">
+        Volume Requirements
+      </div>
+      <div class="boxed-section-body is-full-bleed">
+        {{#list-table source=model.volumes as |t|}}
+          {{#t.head}}
+            <th>Name</th>
+            <th>Type</th>
+            <th>Source</th>
+            <th>Permissions</th>
+          {{/t.head}}
+          {{#t.body as |row|}}
+            <tr data-test-volume>
+              <td data-test-volume-name>{{row.model.name}}</td>
+              <td data-test-volume-type>{{row.model.type}}</td>
+              <td data-test-volume-source>{{row.model.source}}</td>
+              <td data-test-volume-permissions>{{if row.model.readOnly "Read" "Read/Write"}}</td>
+            </tr>
+          {{/t.body}}
+        {{/list-table}}
+      </div>
+    </div>
+  {{/if}}
 </section>

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -1,7 +1,7 @@
 import { assign } from '@ember/polyfills';
 import { Factory, trait } from 'ember-cli-mirage';
 import faker from 'nomad-ui/mirage/faker';
-import { provide, provider, pickOne } from '../utils';
+import { provide, pickOne } from '../utils';
 import { DATACENTERS } from '../common';
 
 const JOB_PREFIXES = provide(5, faker.hacker.abbreviation);
@@ -96,6 +96,9 @@ export default Factory.extend({
   // When true, no evaluations have failed placements
   noFailedPlacements: false,
 
+  // When true, all task groups get the noHostVolumes trait
+  noHostVolumes: false,
+
   // When true, allocations for this job will fail and reschedule, randomly succeeding or not
   withRescheduling: false,
 
@@ -118,13 +121,16 @@ export default Factory.extend({
       });
     }
 
-    const groups = server.createList('task-group', job.groupsCount, {
+    const groupProps = {
       job,
       createAllocations: job.createAllocations,
       withRescheduling: job.withRescheduling,
       withServices: job.withGroupServices,
       shallow: job.shallow,
-    });
+    };
+    const groups = job.noHostVolumes
+      ? server.createList('task-group', job.groupsCount, 'noHostVolumes', groupProps)
+      : server.createList('task-group', job.groupsCount, groupProps);
 
     job.update({
       taskGroupIds: groups.mapBy('id'),

--- a/ui/mirage/factories/node.js
+++ b/ui/mirage/factories/node.js
@@ -171,7 +171,7 @@ function makeHostVolumes() {
     ReadOnly: faker.random.boolean(),
   });
 
-  const volumes = provide(faker.random.number(5), generate);
+  const volumes = provide(faker.random.number({ min: 1, max: 5 }), generate);
   return volumes.reduce((hash, volume) => {
     hash[volume.Name] = volume;
     return hash;

--- a/ui/mirage/factories/node.js
+++ b/ui/mirage/factories/node.js
@@ -64,9 +64,15 @@ export default Factory.extend({
     },
   }),
 
+  noHostVolumes: trait({
+    hostVolumes: () => ({}),
+  }),
+
   drainStrategy: null,
 
   drivers: makeDrivers,
+
+  hostVolumes: makeHostVolumes(),
 
   resources: generateResources,
 
@@ -156,4 +162,18 @@ function makeDrivers() {
     raw_exec: generate('raw_exec'),
     java: generate('java'),
   };
+}
+
+function makeHostVolumes() {
+  const generate = () => ({
+    Name: faker.internet.domainWord(),
+    Path: `/${faker.internet.userName()}/${faker.internet.domainWord()}/${faker.internet.color()}`,
+    ReadOnly: faker.random.boolean(),
+  });
+
+  const volumes = provide(faker.random.number(5), generate);
+  return volumes.reduce((hash, volume) => {
+    hash[volume.Name] = volume;
+    return hash;
+  }, {});
 }

--- a/ui/mirage/factories/task-group.js
+++ b/ui/mirage/factories/task-group.js
@@ -1,5 +1,6 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
 import faker from 'nomad-ui/mirage/faker';
+import { provide } from '../utils';
 
 const DISK_RESERVATIONS = [200, 500, 1000, 2000, 5000, 10000, 100000];
 
@@ -12,6 +13,12 @@ export default Factory.extend({
     SizeMB: faker.helpers.randomize(DISK_RESERVATIONS),
     Migrate: faker.random.boolean(),
   }),
+
+  noHostVolumes: trait({
+    hostVolumes: () => ({}),
+  }),
+
+  volumes: makeHostVolumes(),
 
   // Directive used to control whether or not allocations are automatically
   // created.
@@ -29,10 +36,20 @@ export default Factory.extend({
 
   afterCreate(group, server) {
     let taskIds = [];
+    let volumes = Object.keys(group.volumes);
 
     if (!group.shallow) {
-      const tasks = server.createList('task', group.count, {
-        taskGroup: group,
+      const tasks = provide(group.count, () => {
+        const mounts = faker.helpers.shuffle(volumes).slice(0, faker.random.number(2));
+        return server.create('task', {
+          taskGroup: group,
+          volumeMounts: mounts.map(mount => ({
+            Volume: mount,
+            Destination: `/${faker.internet.userName()}/${faker.internet.domainWord()}/${faker.internet.color()}`,
+            PropagationMode: '',
+            ReadOnly: faker.random.boolean(),
+          })),
+        });
       });
       taskIds = tasks.mapBy('id');
     }
@@ -76,3 +93,18 @@ export default Factory.extend({
     }
   },
 });
+
+function makeHostVolumes() {
+  const generate = () => ({
+    Name: faker.internet.domainWord(),
+    Type: 'host',
+    source: faker.internet.domainWord(),
+    ReadOnly: faker.random.boolean(),
+  });
+
+  const volumes = provide(faker.random.number({ min: 1, max: 5 }), generate);
+  return volumes.reduce((hash, volume) => {
+    hash[volume.Name] = volume;
+    return hash;
+  }, {});
+}

--- a/ui/mirage/factories/task-group.js
+++ b/ui/mirage/factories/task-group.js
@@ -15,7 +15,7 @@ export default Factory.extend({
   }),
 
   noHostVolumes: trait({
-    hostVolumes: () => ({}),
+    volumes: () => ({}),
   }),
 
   volumes: makeHostVolumes(),
@@ -40,7 +40,9 @@ export default Factory.extend({
 
     if (!group.shallow) {
       const tasks = provide(group.count, () => {
-        const mounts = faker.helpers.shuffle(volumes).slice(0, faker.random.number(2));
+        const mounts = faker.helpers
+          .shuffle(volumes)
+          .slice(0, faker.random.number({ min: 1, max: 3 }));
         return server.create('task', {
           taskGroup: group,
           volumeMounts: mounts.map(mount => ({
@@ -98,7 +100,7 @@ function makeHostVolumes() {
   const generate = () => ({
     Name: faker.internet.domainWord(),
     Type: 'host',
-    source: faker.internet.domainWord(),
+    Source: faker.internet.domainWord(),
     ReadOnly: faker.random.boolean(),
   });
 

--- a/ui/mirage/factories/task.js
+++ b/ui/mirage/factories/task.js
@@ -8,6 +8,9 @@ export default Factory.extend({
   // Hidden property used to compute the Summary hash
   groupNames: [],
 
+  // Set in the TaskGroup factory
+  volumeMounts: [],
+
   JobID: '',
 
   name: id => `task-${faker.hacker.noun().dasherize()}-${id}`,

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -91,6 +91,17 @@ module('Acceptance | allocation detail', function(hooks) {
     const events = server.db.taskEvents.where({ taskStateId: task.id });
     const event = events[events.length - 1];
 
+    const taskGroup = server.schema.taskGroups.where({
+      jobId: allocation.jobId,
+      name: allocation.taskGroup,
+    }).models[0];
+
+    const jobTask = taskGroup.tasks.models.find(m => m.name === task.name);
+    const volumes = jobTask.volumeMounts.map(volume => ({
+      name: volume.Volume,
+      source: taskGroup.volumes[volume.Volume].Source,
+    }));
+
     Allocation.tasks[0].as(taskRow => {
       assert.equal(taskRow.name, task.name, 'Name');
       assert.equal(taskRow.state, task.state, 'State');
@@ -112,6 +123,12 @@ module('Acceptance | allocation detail', function(hooks) {
       dynamicPorts.forEach(port => {
         assert.ok(addressesText.includes(port.Label), `Found label ${port.Label}`);
         assert.ok(addressesText.includes(port.Value), `Found value ${port.Value}`);
+      });
+
+      const volumesText = taskRow.volumes;
+      volumes.forEach(volume => {
+        assert.ok(volumesText.includes(volume.name), `Found label ${volume.name}`);
+        assert.ok(volumesText.includes(volume.source), `Found value ${volume.source}`);
       });
     });
   });

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -88,30 +88,31 @@ module('Acceptance | allocation detail', function(hooks) {
       .sortBy('name')[0];
     const reservedPorts = taskResources.resources.Networks[0].ReservedPorts;
     const dynamicPorts = taskResources.resources.Networks[0].DynamicPorts;
-    const taskRow = Allocation.tasks.objectAt(0);
     const events = server.db.taskEvents.where({ taskStateId: task.id });
     const event = events[events.length - 1];
 
-    assert.equal(taskRow.name, task.name, 'Name');
-    assert.equal(taskRow.state, task.state, 'State');
-    assert.equal(taskRow.message, event.displayMessage, 'Event Message');
-    assert.equal(
-      taskRow.time,
-      moment(event.time / 1000000).format("MMM DD, 'YY HH:mm:ss ZZ"),
-      'Event Time'
-    );
+    Allocation.tasks[0].as(taskRow => {
+      assert.equal(taskRow.name, task.name, 'Name');
+      assert.equal(taskRow.state, task.state, 'State');
+      assert.equal(taskRow.message, event.displayMessage, 'Event Message');
+      assert.equal(
+        taskRow.time,
+        moment(event.time / 1000000).format("MMM DD, 'YY HH:mm:ss ZZ"),
+        'Event Time'
+      );
 
-    assert.ok(reservedPorts.length, 'The task has reserved ports');
-    assert.ok(dynamicPorts.length, 'The task has dynamic ports');
+      assert.ok(reservedPorts.length, 'The task has reserved ports');
+      assert.ok(dynamicPorts.length, 'The task has dynamic ports');
 
-    const addressesText = taskRow.ports;
-    reservedPorts.forEach(port => {
-      assert.ok(addressesText.includes(port.Label), `Found label ${port.Label}`);
-      assert.ok(addressesText.includes(port.Value), `Found value ${port.Value}`);
-    });
-    dynamicPorts.forEach(port => {
-      assert.ok(addressesText.includes(port.Label), `Found label ${port.Label}`);
-      assert.ok(addressesText.includes(port.Value), `Found value ${port.Value}`);
+      const addressesText = taskRow.ports;
+      reservedPorts.forEach(port => {
+        assert.ok(addressesText.includes(port.Label), `Found label ${port.Label}`);
+        assert.ok(addressesText.includes(port.Value), `Found value ${port.Value}`);
+      });
+      dynamicPorts.forEach(port => {
+        assert.ok(addressesText.includes(port.Label), `Found label ${port.Label}`);
+        assert.ok(addressesText.includes(port.Value), `Found value ${port.Value}`);
+      });
     });
   });
 

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -900,6 +900,36 @@ module('Acceptance | client detail', function(hooks) {
     assert.ok(ClientDetail.eligibilityToggle.isDisabled);
     assert.ok(ClientDetail.drainPopover.isDisabled);
   });
+
+  test('the host volumes table lists all host volumes in alphabetical order by name', async function(assert) {
+    await ClientDetail.visit({ id: node.id });
+
+    assert.ok(ClientDetail.hasHostVolumes);
+    assert.equal(ClientDetail.hostVolumes.length, Object.keys(node.hostVolumes).length);
+  });
+
+  test('each host volume row contains information about the host volume', async function(assert) {
+    await ClientDetail.visit({ id: node.id });
+
+    const sortedHostVolumes = Object.keys(node.hostVolumes)
+      .map(key => node.hostVolumes[key])
+      .sortBy('Name');
+
+    ClientDetail.hostVolumes[0].as(volume => {
+      const volumeRow = sortedHostVolumes[0];
+      assert.equal(volume.name, volumeRow.Name);
+      assert.equal(volume.path, volumeRow.Path);
+      assert.equal(volume.permissions, volumeRow.ReadOnly ? 'Read' : 'Read/Write');
+    });
+  });
+
+  test('the host volumes table is not shown if the client has no host volumes', async function(assert) {
+    node = server.create('node', 'noHostVolumes');
+
+    await ClientDetail.visit({ id: node.id });
+
+    assert.notOk(ClientDetail.hasHostVolumes);
+  });
 });
 
 module('Acceptance | client detail (multi-namespace)', function(hooks) {

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -905,8 +905,16 @@ module('Acceptance | client detail', function(hooks) {
   test('the host volumes table lists all host volumes in alphabetical order by name', async function(assert) {
     await ClientDetail.visit({ id: node.id });
 
+    const sortedHostVolumes = Object.keys(node.hostVolumes)
+      .map(key => node.hostVolumes[key])
+      .sortBy('Name');
+
     assert.ok(ClientDetail.hasHostVolumes);
     assert.equal(ClientDetail.hostVolumes.length, Object.keys(node.hostVolumes).length);
+
+    ClientDetail.hostVolumes.forEach((volume, index) => {
+      assert.equal(volume.name, sortedHostVolumes[index].Name);
+    });
   });
 
   test('each host volume row contains information about the host volume', async function(assert) {

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -150,6 +150,7 @@ module('Acceptance | client detail', function(hooks) {
     assert.equal(allocationRow.job, server.db.jobs.find(allocation.jobId).name, 'Job name');
     assert.ok(allocationRow.taskGroup, 'Task group name');
     assert.ok(allocationRow.jobVersion, 'Job Version');
+    assert.equal(allocationRow.volume, 'Yes', 'Volume');
     assert.equal(
       allocationRow.cpu,
       Math.floor(allocStats.resourceUsage.CpuStats.TotalTicks) / cpuUsed,

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -128,6 +128,44 @@ module('Acceptance | task detail', function(hooks) {
     assert.equal(Task.events.length, events.length, `Lists ${events.length} events`);
   });
 
+  test('when a task has volumes, the volumes table is shown', async function(assert) {
+    const taskGroup = server.schema.taskGroups.where({
+      jobId: allocation.jobId,
+      name: allocation.taskGroup,
+    }).models[0];
+
+    const jobTask = taskGroup.tasks.models.find(m => m.name === task.name);
+
+    assert.ok(Task.hasVolumes);
+    assert.equal(Task.volumes.length, jobTask.volumeMounts.length);
+  });
+
+  test('when a task does not have volumes, the volumes table is not shown', async function(assert) {
+    const job = server.create('job', { createAllocations: false, noHostVolumes: true });
+    allocation = server.create('allocation', { jobId: job.id, clientStatus: 'running' });
+    task = server.db.taskStates.where({ allocationId: allocation.id })[0];
+
+    await Task.visit({ id: allocation.id, name: task.name });
+    assert.notOk(Task.hasVolumes);
+  });
+
+  test('each volume in the volumes table shows information about the volume', async function(assert) {
+    const taskGroup = server.schema.taskGroups.where({
+      jobId: allocation.jobId,
+      name: allocation.taskGroup,
+    }).models[0];
+
+    const jobTask = taskGroup.tasks.models.find(m => m.name === task.name);
+    const volume = jobTask.volumeMounts[0];
+
+    Task.volumes[0].as(volumeRow => {
+      assert.equal(volumeRow.name, volume.Volume);
+      assert.equal(volumeRow.destination, volume.Destination);
+      assert.equal(volumeRow.permissions, volume.ReadOnly ? 'Read' : 'Read/Write');
+      assert.equal(volumeRow.clientSource, taskGroup.volumes[volume.Volume].Source);
+    });
+  });
+
   test('each recent event should list the time, type, and description of the event', async function(assert) {
     const event = server.db.taskEvents.where({ taskStateId: task.id })[0];
     const recentEvent = Task.events.objectAt(Task.events.length - 1);

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -161,6 +161,11 @@ module('Acceptance | task group detail', function(hooks) {
       server.db.nodes.find(allocation.nodeId).id.split('-')[0],
       'Node ID'
     );
+    assert.equal(
+      allocationRow.volume,
+      Object.keys(taskGroup.volumes).length ? 'Yes' : '',
+      'Volumes'
+    );
 
     await allocationRow.visitClient();
 

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -226,6 +226,30 @@ module('Acceptance | task group detail', function(hooks) {
     assert.notOk(normalRow.rescheduled, 'Normal row has no reschedule icon');
   });
 
+  test('when the task group depends on volumes, the volumes table is shown', async function(assert) {
+    assert.ok(TaskGroup.hasVolumes);
+    assert.equal(TaskGroup.volumes.length, Object.keys(taskGroup.volumes).length);
+  });
+
+  test('when the task group does not depend on volumes, the volumes table is not shown', async function(assert) {
+    job = server.create('job', { noHostVolumes: true, shallow: true });
+    taskGroup = server.db.taskGroups.where({ jobId: job.id })[0];
+
+    await TaskGroup.visit({ id: job.id, name: taskGroup.name });
+
+    assert.notOk(TaskGroup.hasVolumes);
+  });
+
+  test('each row in the volumes table lists information about the volume', async function(assert) {
+    TaskGroup.volumes[0].as(volumeRow => {
+      const volume = taskGroup.volumes[volumeRow.name];
+      assert.equal(volumeRow.name, volume.Name);
+      assert.equal(volumeRow.type, volume.Type);
+      assert.equal(volumeRow.source, volume.Source);
+      assert.equal(volumeRow.permissions, volume.ReadOnly ? 'Read' : 'Read/Write');
+    });
+  });
+
   test('when the job for the task group is not found, an error message is shown, but the URL persists', async function(assert) {
     await TaskGroup.visit({ id: 'not-a-real-job', name: 'not-a-real-task-group' });
 

--- a/ui/tests/integration/job-page/parts/task-groups-test.js
+++ b/ui/tests/integration/job-page/parts/task-groups-test.js
@@ -96,6 +96,11 @@ module('Integration | Component | job-page/parts/task-groups', function(hooks) {
       'Count'
     );
     assert.equal(
+      taskGroupRow.querySelector('[data-test-task-group-volume]').textContent.trim(),
+      taskGroup.get('volumes.length') ? 'Yes' : '',
+      'Volumes'
+    );
+    assert.equal(
       taskGroupRow.querySelector('[data-test-task-group-cpu]').textContent.trim(),
       `${taskGroup.get('reservedCPU')} MHz`,
       'Reserved CPU'

--- a/ui/tests/pages/allocations/detail.js
+++ b/ui/tests/pages/allocations/detail.js
@@ -42,6 +42,7 @@ export default create({
     message: text('[data-test-message]'),
     time: text('[data-test-time]'),
     ports: text('[data-test-ports]'),
+    volumes: text('[data-test-volumes]'),
 
     hasUnhealthyDriver: isPresent('[data-test-icon="unhealthy-driver"]'),
     hasProxyTag: isPresent('[data-test-proxy-tag]'),

--- a/ui/tests/pages/allocations/task/detail.js
+++ b/ui/tests/pages/allocations/task/detail.js
@@ -50,6 +50,14 @@ export default create({
     address: text('[data-test-task-address-address]'),
   }),
 
+  hasVolumes: isPresent('[data-test-volumes]'),
+  volumes: collection('[data-test-volume]', {
+    name: text('[data-test-volume-name]'),
+    destination: text('[data-test-volume-destination]'),
+    permissions: text('[data-test-volume-permissions]'),
+    clientSource: text('[data-test-volume-client-source]'),
+  }),
+
   events: collection('[data-test-task-event]', {
     time: text('[data-test-task-event-time]'),
     type: text('[data-test-task-event-type]'),

--- a/ui/tests/pages/clients/detail.js
+++ b/ui/tests/pages/clients/detail.js
@@ -77,6 +77,13 @@ export default create({
     message: text('[data-test-client-event-message]'),
   }),
 
+  hasHostVolumes: isPresent('[data-test-client-host-volumes'),
+  hostVolumes: collection('[data-test-client-host-volume]', {
+    name: text('[data-test-name]'),
+    path: text('[data-test-path]'),
+    permissions: text('[data-test-permissions]'),
+  }),
+
   driverHeads: collection('[data-test-driver-status] [data-test-accordion-head]', {
     name: text('[data-test-name]'),
     detected: text('[data-test-detected]'),

--- a/ui/tests/pages/clients/detail.js
+++ b/ui/tests/pages/clients/detail.js
@@ -77,7 +77,7 @@ export default create({
     message: text('[data-test-client-event-message]'),
   }),
 
-  hasHostVolumes: isPresent('[data-test-client-host-volumes'),
+  hasHostVolumes: isPresent('[data-test-client-host-volumes]'),
   hostVolumes: collection('[data-test-client-host-volume]', {
     name: text('[data-test-name]'),
     path: text('[data-test-path]'),

--- a/ui/tests/pages/components/allocations.js
+++ b/ui/tests/pages/components/allocations.js
@@ -12,6 +12,7 @@ export default function(selector = '[data-test-allocation]', propKey = 'allocati
       taskGroup: text('[data-test-task-group]'),
       client: text('[data-test-client]'),
       jobVersion: text('[data-test-job-version]'),
+      volume: text('[data-test-volume]'),
       cpu: text('[data-test-cpu]'),
       cpuTooltip: attribute('aria-label', '[data-test-cpu] .tooltip'),
       mem: text('[data-test-mem]'),

--- a/ui/tests/pages/jobs/job/task-group.js
+++ b/ui/tests/pages/jobs/job/task-group.js
@@ -38,6 +38,14 @@ export default create({
 
   isEmpty: isPresent('[data-test-empty-allocations-list]'),
 
+  hasVolumes: isPresent('[data-test-volumes]'),
+  volumes: collection('[data-test-volumes] [data-test-volume]', {
+    name: text('[data-test-volume-name]'),
+    type: text('[data-test-volume-type]'),
+    source: text('[data-test-volume-source]'),
+    permissions: text('[data-test-volume-permissions]'),
+  }),
+
   error: error(),
 
   emptyState: {

--- a/ui/tests/unit/serializers/node-test.js
+++ b/ui/tests/unit/serializers/node-test.js
@@ -104,6 +104,7 @@ module('Unit | Serializer | Node', function(hooks) {
                 healthy: false,
               },
             ],
+            hostVolumes: [],
           },
           relationships: {
             allocations: {
@@ -152,6 +153,7 @@ module('Unit | Serializer | Node', function(hooks) {
                 healthy: false,
               },
             ],
+            hostVolumes: [],
           },
           relationships: {
             allocations: {

--- a/ui/tests/unit/serializers/node-test.js
+++ b/ui/tests/unit/serializers/node-test.js
@@ -89,6 +89,16 @@ module('Unit | Serializer | Node', function(hooks) {
             Healthy: false,
           },
         },
+        HostVolumes: {
+          one: {
+            Name: 'one',
+            ReadOnly: true,
+          },
+          two: {
+            Name: 'two',
+            ReadOnly: false,
+          },
+        },
       },
       out: {
         data: {
@@ -104,7 +114,7 @@ module('Unit | Serializer | Node', function(hooks) {
                 healthy: false,
               },
             ],
-            hostVolumes: [],
+            hostVolumes: [{ name: 'one', readOnly: true }, { name: 'two', readOnly: false }],
           },
           relationships: {
             allocations: {
@@ -153,7 +163,6 @@ module('Unit | Serializer | Node', function(hooks) {
                 healthy: false,
               },
             ],
-            hostVolumes: [],
           },
           relationships: {
             allocations: {


### PR DESCRIPTION
Show host volume information throughout the Web UI. Closes #6362 

#### This includes changes to:
1. Task group page
2. Allocation page
3. Task page
4. Client page
5. Allocation tables
6. Task tables
7. Task group tables
8. Client table

The primary benefit is you can now inspect what volumes an allocation and a task require and trace that back to the host volumes as declared in client configurations.

#### Screenshots
![image](https://user-images.githubusercontent.com/174740/74493149-1a2d9300-4e86-11ea-9194-dd0e1e59f860.png)
_Volume Requirements table on the task group detail page._

![image](https://user-images.githubusercontent.com/174740/74493111-fff3b500-4e85-11ea-93d9-3ee928953644.png)
_New Volume columns in the task group table and allocation table_.

![image](https://user-images.githubusercontent.com/174740/74493182-36c9cb00-4e86-11ea-8089-93b3e4b9034b.png)
_New Volume column in the task table on the allocation detail page._

![image](https://user-images.githubusercontent.com/174740/74493215-477a4100-4e86-11ea-9371-cd9aabf3bacf.png)
_Volumes table on the task detail page._

![image](https://user-images.githubusercontent.com/174740/74493245-62e54c00-4e86-11ea-8ef1-34d03da9dc45.png)
_New Volumes column in the clients table._

![image](https://user-images.githubusercontent.com/174740/74493269-7c869380-4e86-11ea-93a5-c1fdd7585587.png)
_Volumes table on the client detail page._