### PR TITLE
Fix Vault test flakiness

### DIFF
--- a/e2e/vault/vault_test.go
+++ b/e2e/vault/vault_test.go
@@ -61,6 +61,7 @@ func syncVault(t *testing.T) map[string]string {
 	g, _ := errgroup.WithContext(ctx)
 	for ver, url := range missing {
 		dst := filepath.Join(binDir, ver)
+		url := url
 		g.Go(func() error {
 			sema <- 1
 			defer func() {

--- a/e2e/vault/vault_test.go
+++ b/e2e/vault/vault_test.go
@@ -53,11 +53,9 @@ func syncVault(t *testing.T) ([]*version.Version, map[string]string) {
 	start := time.Now()
 	errCh := make(chan error, len(missing))
 	for ver, url := range missing {
-		dst := filepath.Join(binDir, ver)
-		url := url
-		go func() {
+		go func(dst, url string) {
 			errCh <- getVault(dst, url)
-		}()
+		}(filepath.Join(binDir, ver), url)
 	}
 	for i := 0; i < len(missing); i++ {
 		select {


### PR DESCRIPTION
The entire fix is one line to capture a loop variable before using it in a goroutine :man_facepalming: https://github.com/hashicorp/nomad/commit/6362e32161295fa959ebe46b93cea0ea1a9bdd72

But of course that took me ages to notice, so I also made some other improvements:
 * Only download+test latest Z of each X.Y.Z Vault release
 * Ensure consistent ordering for test runs to ease spotting differences in runs
 * Some other small error handling improvements