### PR TITLE
fix port forwarding of TCP/4646

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -74,7 +74,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: $script, privileged: false
 
   # Expose the nomad api and ui to the host
-  config.vm.network "forwarded_port", guest: 4646, host: 4646, auto_correct: true
+  config.vm.network "forwarded_port", guest: 4646, host: 4646, auto_correct: true, host_ip: "127.0.0.1"
 
   # Increase memory for Parallels Desktop
   config.vm.provider "parallels" do |p, o|


### PR DESCRIPTION
Fixes the port forwarding of TCP/4646 on my Arch linux:

```console
me@me:~$ uname -a
Linux me 5.5.3-arch1-1 #1 SMP PREEMPT Tue, 11 Feb 2020 15:35:41 +0000 x86_64 GNU/Linux
me@me:~$ virtualbox --help
Oracle VM VirtualBox VM Selector v6.1.2
me@me:~$ vagrant --version
Vagrant 2.2.7
```

source: https://github.com/hashicorp/vagrant/issues/5827#issuecomment-112015670