### PR TITLE
csi: Pass through usage options to the csimanager

### DIFF
--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -3,6 +3,7 @@ package csimanager
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/hashicorp/nomad/client/pluginmanager"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -17,9 +18,31 @@ type MountInfo struct {
 	IsDevice bool
 }
 
+type UsageOptions struct {
+	ReadOnly       bool
+	AttachmentMode string
+	AccessMode     string
+}
+
+func (u *UsageOptions) ToFS() string {
+	var sb strings.Builder
+
+	if u.ReadOnly {
+		sb.WriteString("ro-")
+	} else {
+		sb.WriteString("rw-")
+	}
+
+	sb.WriteString(u.AttachmentMode)
+	sb.WriteString("-")
+	sb.WriteString(u.AccessMode)
+
+	return sb.String()
+}
+
 type VolumeMounter interface {
-	MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation) (*MountInfo, error)
-	UnmountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation) error
+	MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usageOpts *UsageOptions) (*MountInfo, error)
+	UnmountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usageOpts *UsageOptions) error
 }
 
 type Manager interface {

--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -24,6 +24,10 @@ type UsageOptions struct {
 	AccessMode     string
 }
 
+// ToFS is used by a VolumeManager to construct the path to where a volume
+// should be staged/published. It should always return a string that is easy
+// enough to manage as a filesystem path segment (e.g avoid starting the string
+// with a special character).
 func (u *UsageOptions) ToFS() string {
 	var sb strings.Builder
 


### PR DESCRIPTION
The CSI Spec requires us to attach and stage volumes based on different
types of usage information when it may effect how they are bound.

Here we pass through some basic usage options in the CSI Hook (specifically
the volume aliases ReadOnly field), and the attachment/access mode from
the volume. We pass the attachment/access mode seperately from the
volume as it simplifies some handling and doesn't necessarily force
every attachment to use the same mode should more be supported (I.e if
we let each `volume "foo" {}` specify an override in the future).