### PR TITLE
csi: Claim volumes and perform remote attachement

### DIFF
--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -137,6 +137,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 
 	// create hook resource setting shim
 	hrs := &allocHookResourceSetter{ar: ar}
+	hrs.SetAllocHookResources(&cstructs.AllocHookResources{})
 
 	// build the network manager
 	nm, err := newNetworkManager(ar.Alloc(), ar.driverManager)

--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -45,7 +45,7 @@ func (u *UsageOptions) ToFS() string {
 }
 
 type VolumeMounter interface {
-	MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usageOpts *UsageOptions) (*MountInfo, error)
+	MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usageOpts *UsageOptions, publishContext map[string]string) (*MountInfo, error)
 	UnmountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usageOpts *UsageOptions) error
 }
 

--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -164,7 +164,7 @@ func capabilitiesFromVolume(vol *structs.CSIVolume) (*csi.VolumeCapability, erro
 // stageVolume prepares a volume for use by allocations. When a plugin exposes
 // the STAGE_UNSTAGE_VOLUME capability it MUST be called once-per-volume for a
 // given usage mode before the volume can be NodePublish-ed.
-func (v *volumeManager) stageVolume(ctx context.Context, vol *structs.CSIVolume, usage *UsageOptions) error {
+func (v *volumeManager) stageVolume(ctx context.Context, vol *structs.CSIVolume, usage *UsageOptions, publishContext map[string]string) error {
 	logger := hclog.FromContext(ctx)
 	logger.Trace("Preparing volume staging environment")
 	hostStagingPath, isMount, err := v.ensureStagingDir(vol, usage)
@@ -192,7 +192,7 @@ func (v *volumeManager) stageVolume(ctx context.Context, vol *structs.CSIVolume,
 	// https://github.com/container-storage-interface/spec/blob/4731db0e0bc53238b93850f43ab05d9355df0fd9/spec.md#nodestagevolume-errors
 	return v.plugin.NodeStageVolume(ctx,
 		vol.ID,
-		nil, /* TODO: Get publishContext from Server */
+		publishContext,
 		pluginStagingPath,
 		capability,
 		grpc_retry.WithPerRetryTimeout(DefaultMountActionTimeout),
@@ -201,7 +201,7 @@ func (v *volumeManager) stageVolume(ctx context.Context, vol *structs.CSIVolume,
 	)
 }
 
-func (v *volumeManager) publishVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usage *UsageOptions) (*MountInfo, error) {
+func (v *volumeManager) publishVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usage *UsageOptions, publishContext map[string]string) (*MountInfo, error) {
 	logger := hclog.FromContext(ctx)
 	var pluginStagingPath string
 	if v.requiresStaging {
@@ -226,7 +226,7 @@ func (v *volumeManager) publishVolume(ctx context.Context, vol *structs.CSIVolum
 
 	err = v.plugin.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
 		VolumeID:          vol.ID,
-		PublishContext:    nil, // TODO: get publishcontext from server
+		PublishContext:    publishContext,
 		StagingTargetPath: pluginStagingPath,
 		TargetPath:        pluginTargetPath,
 		VolumeCapability:  capabilities,
@@ -244,17 +244,17 @@ func (v *volumeManager) publishVolume(ctx context.Context, vol *structs.CSIVolum
 // configuration for the provided allocation.
 //
 // TODO: Validate remote volume attachment and implement.
-func (v *volumeManager) MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usage *UsageOptions) (*MountInfo, error) {
+func (v *volumeManager) MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usage *UsageOptions, publishContext map[string]string) (*MountInfo, error) {
 	logger := v.logger.With("volume_id", vol.ID, "alloc_id", alloc.ID)
 	ctx = hclog.WithContext(ctx, logger)
 
 	if v.requiresStaging {
-		if err := v.stageVolume(ctx, vol, usage); err != nil {
+		if err := v.stageVolume(ctx, vol, usage, publishContext); err != nil {
 			return nil, err
 		}
 	}
 
-	mountInfo, err := v.publishVolume(ctx, vol, alloc, usage)
+	mountInfo, err := v.publishVolume(ctx, vol, alloc, usage, publishContext)
 	if err != nil {
 		return nil, err
 	}

--- a/client/pluginmanager/csimanager/volume_test.go
+++ b/client/pluginmanager/csimanager/volume_test.go
@@ -177,7 +177,7 @@ func TestVolumeManager_stageVolume(t *testing.T) {
 			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, tmpPath, true)
 			ctx := context.Background()
 
-			err := manager.stageVolume(ctx, tc.Volume, tc.UsageOptions)
+			err := manager.stageVolume(ctx, tc.Volume, tc.UsageOptions, nil)
 
 			if tc.ExpectedErr != nil {
 				require.EqualError(t, err, tc.ExpectedErr.Error())
@@ -294,7 +294,7 @@ func TestVolumeManager_publishVolume(t *testing.T) {
 			manager := newVolumeManager(testlog.HCLogger(t), csiFake, tmpPath, tmpPath, true)
 			ctx := context.Background()
 
-			_, err := manager.publishVolume(ctx, tc.Volume, tc.Allocation, tc.UsageOptions)
+			_, err := manager.publishVolume(ctx, tc.Volume, tc.Allocation, tc.UsageOptions, nil)
 
 			if tc.ExpectedErr != nil {
 				require.EqualError(t, err, tc.ExpectedErr.Error())

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1177,7 +1177,7 @@ func (n *Node) unclaimVolumesForTerminalAllocs(args *structs.AllocUpdateRequest,
 
 		req := &structs.CSIVolumeClaimRequest{
 			VolumeID:     volume.Source,
-			Allocation:   alloc,
+			AllocationID: alloc.ID,
 			Claim:        structs.CSIVolumeClaimRelease,
 			WriteRequest: args.WriteRequest,
 		}

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -426,9 +426,9 @@ const (
 )
 
 type CSIVolumeClaimRequest struct {
-	VolumeID   string
-	Allocation *Allocation
-	Claim      CSIVolumeClaimMode
+	VolumeID     string
+	AllocationID string
+	Claim        CSIVolumeClaimMode
 	WriteRequest
 }
 
@@ -447,6 +447,11 @@ type CSIVolumeClaimResponse struct {
 	// This field is OPTIONAL and when present MUST be passed to
 	// `NodeStageVolume` or `NodePublishVolume` calls on the client
 	PublishContext map[string]string
+
+	// Volume contains the expanded CSIVolume for use on the client after a Claim
+	// has completed.
+	Volume *CSIVolume
+
 	QueryMeta
 }
 


### PR DESCRIPTION
This PR does two major things:

Firstly it changes the CSIEndpoint to take an alloc id and to return the
claimed volume. (More context in commit)

Secondly it makes the client perform a CSIVolume.Claim request during
setup of CSIVolumes rather than a CSIVolume.Get.

It does not yet implement teardown of volumes on shutdown.

Slighly cleans up and depends on #7166

```
curl -X GET http://localhost:4646/v1/csi/volumes | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   361  100   361    0     0   352k      0 --:--:-- --:--:-- --:--:--  352k
[
  {
    "AccessMode": "single-node-writer",
    "AttachmentMode": "file-system",
    "ControllersExpected": 0,
    "ControllersHealthy": 1,
    "CreateIndex": 22,
    "CurrentReaders": 0,
    "CurrentWriters": 1,
    "Healthy": true,
    "ID": "bfa8f7dd-5188-11ea-9f68-0242ac110002",
    "ModifyIndex": 27,    "Namespace": "default",
    "NodesExpected": 1,
    "NodesHealthy": 1,
    "PluginID": "csi-hostpath",
    "Topologies": [],
    "VolumeGC": null
  }
]
```