### PR TITLE
csi: Basic volume usage tracking

### DIFF
--- a/client/pluginmanager/csimanager/usage_tracker.go
+++ b/client/pluginmanager/csimanager/usage_tracker.go
@@ -1,0 +1,71 @@
+package csimanager
+
+import (
+	"sync"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// volumeUsageTracker tracks the allocations that depend on a given volume
+type volumeUsageTracker struct {
+	// state is a map of volumeUsageKey to a slice of allocation ids
+	state   map[volumeUsageKey][]string
+	stateMu sync.Mutex
+}
+
+func newVolumeUsageTracker() *volumeUsageTracker {
+	return &volumeUsageTracker{
+		state: make(map[volumeUsageKey][]string),
+	}
+}
+
+type volumeUsageKey struct {
+	volume    *structs.CSIVolume
+	usageOpts UsageOptions
+}
+
+func (v *volumeUsageTracker) allocsForKey(key volumeUsageKey) []string {
+	return v.state[key]
+}
+
+func (v *volumeUsageTracker) appendAlloc(key volumeUsageKey, alloc *structs.Allocation) {
+	allocs := v.allocsForKey(key)
+	allocs = append(allocs, alloc.ID)
+	v.state[key] = allocs
+}
+
+func (v *volumeUsageTracker) removeAlloc(key volumeUsageKey, needle *structs.Allocation) {
+	allocs := v.allocsForKey(key)
+	var newAllocs []string
+	for _, allocID := range allocs {
+		if allocID != needle.ID {
+			newAllocs = append(newAllocs, allocID)
+		}
+	}
+
+	if len(newAllocs) == 0 {
+		delete(v.state, key)
+	} else {
+		v.state[key] = newAllocs
+	}
+}
+
+func (v *volumeUsageTracker) Claim(alloc *structs.Allocation, volume *structs.CSIVolume, usage *UsageOptions) {
+	v.stateMu.Lock()
+	defer v.stateMu.Unlock()
+
+	key := volumeUsageKey{volume: volume, usageOpts: *usage}
+	v.appendAlloc(key, alloc)
+}
+
+// Free removes the allocation from the state list for the given alloc. If the
+// alloc is the last allocation for the volume then it returns true.
+func (v *volumeUsageTracker) Free(alloc *structs.Allocation, volume *structs.CSIVolume, usage *UsageOptions) bool {
+	v.stateMu.Lock()
+	defer v.stateMu.Unlock()
+
+	key := volumeUsageKey{volume: volume, usageOpts: *usage}
+	v.removeAlloc(key, alloc)
+	allocs := v.allocsForKey(key)
+	return len(allocs) == 0
+}

--- a/client/pluginmanager/csimanager/usage_tracker_test.go
+++ b/client/pluginmanager/csimanager/usage_tracker_test.go
@@ -1,0 +1,62 @@
+package csimanager
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsageTracker(t *testing.T) {
+	mockAllocs := []*structs.Allocation{
+		mock.Alloc(),
+		mock.Alloc(),
+		mock.Alloc(),
+		mock.Alloc(),
+		mock.Alloc(),
+	}
+
+	cases := []struct {
+		Name string
+
+		RegisterAllocs []*structs.Allocation
+		FreeAllocs     []*structs.Allocation
+
+		ExpectedResult bool
+	}{
+		{
+			Name:           "Register and deregister all allocs",
+			RegisterAllocs: mockAllocs,
+			FreeAllocs:     mockAllocs,
+			ExpectedResult: true,
+		},
+		{
+			Name:           "Register all and deregister partial allocs",
+			RegisterAllocs: mockAllocs,
+			FreeAllocs:     mockAllocs[0:3],
+			ExpectedResult: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			tracker := newVolumeUsageTracker()
+
+			volume := &structs.CSIVolume{
+				ID: "foo",
+			}
+			for _, alloc := range tc.RegisterAllocs {
+				tracker.Claim(alloc, volume, &UsageOptions{})
+			}
+
+			result := false
+
+			for _, alloc := range tc.FreeAllocs {
+				result = tracker.Free(alloc, volume, &UsageOptions{})
+			}
+
+			require.Equal(t, tc.ExpectedResult, result, "Tracker State: %#v", tracker.state)
+		})
+	}
+}

--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -34,8 +34,7 @@ type volumeManager struct {
 	logger hclog.Logger
 	plugin csi.CSIPlugin
 
-	volumes map[string]interface{}
-	// volumesMu sync.Mutex
+	usageTracker *volumeUsageTracker
 
 	// mountRoot is the root of where plugin directories and mounts may be created
 	// e.g /opt/nomad.d/statedir/csi/my-csi-plugin/
@@ -57,7 +56,7 @@ func newVolumeManager(logger hclog.Logger, plugin csi.CSIPlugin, rootDir, contai
 		mountRoot:           rootDir,
 		containerMountPoint: containerRootDir,
 		requiresStaging:     requiresStaging,
-		volumes:             make(map[string]interface{}),
+		usageTracker:        newVolumeUsageTracker(),
 	}
 }
 
@@ -255,7 +254,14 @@ func (v *volumeManager) MountVolume(ctx context.Context, vol *structs.CSIVolume,
 		}
 	}
 
-	return v.publishVolume(ctx, vol, alloc, usage)
+	mountInfo, err := v.publishVolume(ctx, vol, alloc, usage)
+	if err != nil {
+		return nil, err
+	}
+
+	v.usageTracker.Claim(alloc, vol, usage)
+
+	return mountInfo, nil
 }
 
 // unstageVolume is the inverse operation of `stageVolume` and must be called
@@ -327,11 +333,10 @@ func (v *volumeManager) UnmountVolume(ctx context.Context, vol *structs.CSIVolum
 		return err
 	}
 
-	if !v.requiresStaging {
+	canRelease := v.usageTracker.Free(alloc, vol, usage)
+	if !v.requiresStaging || !canRelease {
 		return nil
 	}
 
-	// TODO(GH-7029): Implement volume usage tracking and only unstage volumes
-	//                when the last alloc stops using it.
 	return v.unstageVolume(ctx, vol, usage)
 }


### PR DESCRIPTION
This PR implements support for tracking the usage of volumes on a given
node and only unstages volumes after the last usage of the volume has
been unpublished.

It closes #7029 and has support for UsageOptions when #7166 is merged.