### PR TITLE
docs: add link to golang api GoDoc webpage

### DIFF
--- a/website/pages/api-docs/libraries-and-sdks.mdx
+++ b/website/pages/api-docs/libraries-and-sdks.mdx
@@ -17,7 +17,7 @@ the community.
 ## Official Libraries
 
 - [`api`](https://github.com/hashicorp/nomad/tree/master/api) - Official Golang
-  client for the Nomad HTTP API
+  client for the Nomad HTTP API ([GoDoc](https://godoc.org/github.com/hashicorp/nomad/api))
 
 - [`nomad-java-sdk`](https://github.com/hashicorp/nomad-java-sdk) - Official
   Java client for the Nomad HTTP API.


### PR DESCRIPTION
Just linking to the golang API source is not that useful/user-friendly - have added a link in to the GoDoc webpage.