### PR TITLE
csi: Validate Volumes during registration

### DIFF
--- a/api/csi_test.go
+++ b/api/csi_test.go
@@ -31,12 +31,24 @@ func TestCSIVolumes_CRUD(t *testing.T) {
 		AuthToken: root.SecretID,
 	}
 
+	// Register a plugin job
+	j := c.Jobs()
+	job := testJob()
+	job.Namespace = stringToPtr("default")
+	job.TaskGroups[0].Tasks[0].CSIPluginConfig = &TaskCSIPluginConfig{
+		ID:       "foo",
+		Type:     "monolith",
+		MountDir: "/not-empty",
+	}
+	_, _, err = j.Register(job, wpts)
+	require.NoError(t, err)
+
 	// Register a volume
 	id := "DEADBEEF-31B5-8F78-7986-DD404FDA0CD1"
 	_, err = v.Register(&CSIVolume{
 		ID:             id,
 		Namespace:      "default",
-		PluginID:       "adam",
+		PluginID:       "foo",
 		AccessMode:     CSIVolumeAccessModeMultiNodeSingleWriter,
 		AttachmentMode: CSIVolumeAttachmentModeFilesystem,
 		Topologies:     []*CSITopology{{Segments: map[string]string{"foo": "bar"}}},

--- a/client/client_csi_endpoint.go
+++ b/client/client_csi_endpoint.go
@@ -30,6 +30,36 @@ var (
 	ErrPluginTypeError = errors.New("CSI Plugin loaded incorrectly")
 )
 
+// CSIControllerValidateVolume is used during volume registration to validate
+// that a volume exists and that the capabilities it was registered with are
+// supported by the CSI Plugin and external volume configuration.
+func (c *ClientCSI) CSIControllerValidateVolume(req *structs.ClientCSIControllerValidateVolumeRequest, resp *structs.ClientCSIControllerValidateVolumeResponse) error {
+	defer metrics.MeasureSince([]string{"client", "csi_controller", "validate_volume"}, time.Now())
+
+	if req.VolumeID == "" {
+		return errors.New("VolumeID is required")
+	}
+
+	if req.PluginID == "" {
+		return errors.New("PluginID is required")
+	}
+
+	plugin, err := c.findControllerPlugin(req.PluginID)
+	if err != nil {
+		return err
+	}
+	defer plugin.Close()
+
+	caps, err := csi.VolumeCapabilityFromStructs(req.AttachmentMode, req.AccessMode)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancelFn := c.requestContext()
+	defer cancelFn()
+	return plugin.ControllerValidateCapabilties(ctx, req.VolumeID, caps)
+}
+
 // CSIControllerAttachVolume is used to attach a volume from a CSI Cluster to
 // the storage node provided in the request.
 //

--- a/client/client_csi_endpoint_test.go
+++ b/client/client_csi_endpoint_test.go
@@ -147,3 +147,92 @@ func TestClientCSI_CSIControllerAttachVolume(t *testing.T) {
 		})
 	}
 }
+
+func TestClientCSI_CSIControllerValidateVolume(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name             string
+		ClientSetupFunc  func(*fake.Client)
+		Request          *structs.ClientCSIControllerValidateVolumeRequest
+		ExpectedErr      error
+		ExpectedResponse *structs.ClientCSIControllerValidateVolumeResponse
+	}{
+		{
+			Name: "validates volumeid is not empty",
+			Request: &structs.ClientCSIControllerValidateVolumeRequest{
+				PluginID: fakePlugin.Name,
+			},
+			ExpectedErr: errors.New("VolumeID is required"),
+		},
+		{
+			Name: "returns plugin not found errors",
+			Request: &structs.ClientCSIControllerValidateVolumeRequest{
+				PluginID: "some-garbage",
+				VolumeID: "foo",
+			},
+			ExpectedErr: errors.New("plugin some-garbage for type csi-controller not found"),
+		},
+		{
+			Name: "validates attachmentmode",
+			Request: &structs.ClientCSIControllerValidateVolumeRequest{
+				PluginID:       fakePlugin.Name,
+				VolumeID:       "1234-4321-1234-4321",
+				AttachmentMode: nstructs.CSIVolumeAttachmentMode("bar"),
+				AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
+			},
+			ExpectedErr: errors.New("Unknown volume attachment mode: bar"),
+		},
+		{
+			Name: "validates AccessMode",
+			Request: &structs.ClientCSIControllerValidateVolumeRequest{
+				PluginID:       fakePlugin.Name,
+				VolumeID:       "1234-4321-1234-4321",
+				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
+				AccessMode:     nstructs.CSIVolumeAccessMode("foo"),
+			},
+			ExpectedErr: errors.New("Unknown volume access mode: foo"),
+		},
+		{
+			Name: "returns transitive errors",
+			ClientSetupFunc: func(fc *fake.Client) {
+				fc.NextControllerValidateVolumeErr = errors.New("hello")
+			},
+			Request: &structs.ClientCSIControllerValidateVolumeRequest{
+				PluginID:       fakePlugin.Name,
+				VolumeID:       "1234-4321-1234-4321",
+				AccessMode:     nstructs.CSIVolumeAccessModeSingleNodeWriter,
+				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
+			},
+			ExpectedErr: errors.New("hello"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+			client, cleanup := TestClient(t, nil)
+			defer cleanup()
+
+			fakeClient := &fake.Client{}
+			if tc.ClientSetupFunc != nil {
+				tc.ClientSetupFunc(fakeClient)
+			}
+
+			dispenserFunc := func(*dynamicplugins.PluginInfo) (interface{}, error) {
+				return fakeClient, nil
+			}
+			client.dynamicRegistry.StubDispenserForType(dynamicplugins.PluginTypeCSIController, dispenserFunc)
+
+			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
+			require.Nil(err)
+
+			var resp structs.ClientCSIControllerValidateVolumeResponse
+			err = client.ClientRPC("ClientCSI.CSIControllerValidateVolume", tc.Request, &resp)
+			require.Equal(tc.ExpectedErr, err)
+			if tc.ExpectedResponse != nil {
+				require.Equal(tc.ExpectedResponse, &resp)
+			}
+		})
+	}
+}

--- a/client/structs/csi.go
+++ b/client/structs/csi.go
@@ -20,6 +20,17 @@ type CSIVolumeMountOptions struct {
 	MountFlags []string
 }
 
+type ClientCSIControllerValidateVolumeRequest struct {
+	PluginID string
+	VolumeID string
+
+	AttachmentMode structs.CSIVolumeAttachmentMode
+	AccessMode     structs.CSIVolumeAccessMode
+}
+
+type ClientCSIControllerValidateVolumeResponse struct {
+}
+
 type ClientCSIControllerAttachVolumeRequest struct {
 	PluginName string
 

--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -274,6 +274,45 @@ func (c *client) ControllerUnpublishVolume(ctx context.Context, req *ControllerU
 	return &ControllerUnpublishVolumeResponse{}, nil
 }
 
+func (c *client) ControllerValidateCapabilties(ctx context.Context, volumeID string, capabilities *VolumeCapability) error {
+	if c == nil {
+		return fmt.Errorf("Client not initialized")
+	}
+	if c.controllerClient == nil {
+		return fmt.Errorf("controllerClient not initialized")
+	}
+
+	if volumeID == "" {
+		return fmt.Errorf("missing VolumeID")
+	}
+
+	if capabilities == nil {
+		return fmt.Errorf("missing Capabilities")
+	}
+
+	req := &csipbv1.ValidateVolumeCapabilitiesRequest{
+		VolumeId: volumeID,
+		VolumeCapabilities: []*csipbv1.VolumeCapability{
+			capabilities.ToCSIRepresentation(),
+		},
+	}
+
+	resp, err := c.controllerClient.ValidateVolumeCapabilities(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if resp.Confirmed == nil {
+		if resp.Message != "" {
+			return fmt.Errorf("Volume validation failed, message: %s", resp.Message)
+		}
+
+		return fmt.Errorf("Volume validation failed")
+	}
+
+	return nil
+}
+
 //
 // Node Endpoints
 //

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -48,6 +48,9 @@ type Client struct {
 	NextControllerUnpublishVolumeErr      error
 	ControllerUnpublishVolumeCallCount    int64
 
+	NextControllerValidateVolumeErr   error
+	ControllerValidateVolumeCallCount int64
+
 	NextNodeGetCapabilitiesResponse *csi.NodeCapabilitySet
 	NextNodeGetCapabilitiesErr      error
 	NodeGetCapabilitiesCallCount    int64
@@ -151,6 +154,15 @@ func (c *Client) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 	c.ControllerUnpublishVolumeCallCount++
 
 	return c.NextControllerUnpublishVolumeResponse, c.NextControllerUnpublishVolumeErr
+}
+
+func (c *Client) ControllerValidateCapabilties(ctx context.Context, volumeID string, capabilities *csi.VolumeCapability) error {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+
+	c.ControllerValidateVolumeCallCount++
+
+	return c.NextControllerValidateVolumeErr
 }
 
 func (c *Client) NodeGetCapabilities(ctx context.Context) (*csi.NodeCapabilitySet, error) {

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -40,6 +40,10 @@ type CSIPlugin interface {
 	// ControllerUnpublishVolume is used to deattach a remote volume from a cluster node.
 	ControllerUnpublishVolume(ctx context.Context, req *ControllerUnpublishVolumeRequest) (*ControllerUnpublishVolumeResponse, error)
 
+	// ControllerValidateCapabilities is used to validate that a volume exists and
+	// supports the requested capability.
+	ControllerValidateCapabilties(ctx context.Context, volumeID string, capabilities *VolumeCapability) error
+
 	// NodeGetCapabilities is used to return the available capabilities from the
 	// Node Service.
 	NodeGetCapabilities(ctx context.Context) (*NodeCapabilitySet, error)


### PR DESCRIPTION
Best reviewed commit by commit.

This introduces support for validating volume permissions when they're being registered with Nomad. This allows us to return richer error messages to users and moves issues with configuration around Access and Attachment modes to registration rather than Usage time when using the majority of CSI Plugins.