### PR TITLE
website: indent `mode` bullets in network params

### DIFF
--- a/website/pages/docs/job-specification/network.mdx
+++ b/website/pages/docs/job-specification/network.mdx
@@ -66,13 +66,13 @@ job "docs" {
 
 - `mode` `(string: "host")` - Mode of the network. The following modes are available:
 
-- `none` - Task group will have an isolated network without any network interfaces.
-- `bridge` - Task group will have an isolated network namespace with an interface
-  that is bridged with the host. Note that bridge networking is only
-  currently supported for the `docker`, `exec`, `raw_exec`, and `java` task
-  drivers.
-- `host` - Each task will join the host network namespace and a shared network
-  namespace is not created. This matches the current behavior in Nomad 0.9.
+  - `none` - Task group will have an isolated network without any network interfaces.
+  - `bridge` - Task group will have an isolated network namespace with an interface
+    that is bridged with the host. Note that bridge networking is only
+    currently supported for the `docker`, `exec`, `raw_exec`, and `java` task
+    drivers.
+  - `host` - Each task will join the host network namespace and a shared network
+    namespace is not created. This matches the current behavior in Nomad 0.9.
 
 ### `port` Parameters
 


### PR DESCRIPTION
per slack convo with @schmichael, this indents the sub-params of `mode` in our job-specification/network params docs