### PR TITLE
[docs] Add note Nomad Connect requires namespaces...

### DIFF
--- a/website/pages/guides/integrations/consul-connect.mdx
+++ b/website/pages/guides/integrations/consul-connect.mdx
@@ -12,6 +12,10 @@ description: >-
 ~> **Note:** This guide requires Nomad 0.10.0 or later and Consul 1.6.0 or
 later.
 
+~> **Note:** Nomad's Connect integration requires that your underlying operating
+   system to support linux network namespaces. Nomad Connect will not run on
+   Windows or macOS.
+
 [Consul Connect](https://www.consul.io/docs/connect) provides
 service-to-service connection authorization and encryption using mutual
 Transport Layer Security (TLS). Applications can use sidecar proxies in a


### PR DESCRIPTION
and can only run on linux oses at the moment.