### PR TITLE
Revert "Add the digital marketing team as the code owners for the website dir"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# Code-freeze: Docs will require approval by the Digital Marketing team
-# during the website infrastructure migration.
-/website/ @hashicorp/digital-marketing


### PR DESCRIPTION
Reverts hashicorp/nomad#6979

The docs code freeze is over, and the digital marketing team no longer needs to be monitoring doc changes.