### PR TITLE
consul/connect: in-place update sidecar service registrations on changes

### DIFF
--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -14,7 +14,7 @@ func TestService_Hash(t *testing.T) {
 	original := &Service{
 		Name:      "myService",
 		PortLabel: "portLabel",
-		// AddressMode: "bridge", // not hashed
+		// AddressMode: "bridge", // not hashed (used internally by Nomad)
 		Tags:       []string{"original", "tags"},
 		CanaryTags: []string{"canary", "tags"},
 		// Checks:      nil, // not hashed (managed independently)


### PR DESCRIPTION
Fix a bug where consul service definitions would not be updated if changes
were made to the service in the Nomad job. Currently this only fixes the
bug for cases where the fix is a matter of updating consul agent's service
registration. There is related bug where destructive changes are required
(see #6877) which will be fixed in another PR.

The `enable_tag_override` configuration setting for the parent service is
applied to the sidecar service.

Partially addresses #6459