### PR TITLE
csi: Add /dev mounts to CSI Plugins

### DIFF
--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -113,8 +113,15 @@ func (h *csiPluginSupervisorHook) Prestart(ctx context.Context,
 		Readonly:        false,
 		PropagationMode: "bidirectional",
 	}
+	devMount := &drivers.MountConfig{
+		TaskPath: "/dev",
+		HostPath: "/dev",
+		Readonly: false,
+	}
 
 	mounts := ensureMountpointInserted(h.runner.hookResources.getMounts(), configMount)
+	mounts = ensureMountpointInserted(mounts, devMount)
+
 	h.runner.hookResources.setMounts(mounts)
 
 	resp.Done = true


### PR DESCRIPTION
CSI Plugins that manage devices need not just access to the CSI
directory, but also to manage devices inside `/dev`.

This commit introduces a `/dev:/dev` mount to the container so that they
may do so.