### PR TITLE
csi: Fix Controller RPCs

### DIFF
--- a/client/csi_controller_endpoint.go
+++ b/client/csi_controller_endpoint.go
@@ -70,7 +70,7 @@ func (c *CSIController) ValidateVolume(req *structs.ClientCSIControllerValidateV
 // In the future this may be expanded to request dynamic secrets for attachement.
 func (c *CSIController) AttachVolume(req *structs.ClientCSIControllerAttachVolumeRequest, resp *structs.ClientCSIControllerAttachVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"client", "csi_controller", "publish_volume"}, time.Now())
-	plugin, err := c.findControllerPlugin(req.PluginName)
+	plugin, err := c.findControllerPlugin(req.PluginID)
 	if err != nil {
 		return err
 	}
@@ -85,8 +85,8 @@ func (c *CSIController) AttachVolume(req *structs.ClientCSIControllerAttachVolum
 		return errors.New("VolumeID is required")
 	}
 
-	if req.NodeID == "" {
-		return errors.New("NodeID is required")
+	if req.ClientCSINodeID == "" {
+		return errors.New("ClientCSINodeID is required")
 	}
 
 	if !nstructs.ValidCSIVolumeAccessMode(req.AccessMode) {
@@ -107,6 +107,10 @@ func (c *CSIController) AttachVolume(req *structs.ClientCSIControllerAttachVolum
 
 	resp.PublishContext = cresp.PublishContext
 	return nil
+}
+
+func (c *CSIController) DetachVolume(req *structs.ClientCSIControllerDetachVolumeRequest, resp *structs.ClientCSIControllerDetachVolumeResponse) error {
+	return fmt.Errorf("Unimplemented")
 }
 
 func (c *CSIController) findControllerPlugin(name string) (csi.CSIPlugin, error) {

--- a/client/csi_controller_endpoint.go
+++ b/client/csi_controller_endpoint.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hashicorp/nomad/plugins/csi"
 )
 
-// ClientCSI endpoint is used for interacting with CSI plugins on a client.
+// CSIController endpoint is used for interacting with CSI plugins on a client.
 // TODO: Submit metrics with labels to allow debugging per plugin perf problems.
-type ClientCSI struct {
+type CSIController struct {
 	c *Client
 }
 
@@ -30,10 +30,10 @@ var (
 	ErrPluginTypeError = errors.New("CSI Plugin loaded incorrectly")
 )
 
-// CSIControllerValidateVolume is used during volume registration to validate
+// ValidateVolume is used during volume registration to validate
 // that a volume exists and that the capabilities it was registered with are
 // supported by the CSI Plugin and external volume configuration.
-func (c *ClientCSI) CSIControllerValidateVolume(req *structs.ClientCSIControllerValidateVolumeRequest, resp *structs.ClientCSIControllerValidateVolumeResponse) error {
+func (c *CSIController) ValidateVolume(req *structs.ClientCSIControllerValidateVolumeRequest, resp *structs.ClientCSIControllerValidateVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"client", "csi_controller", "validate_volume"}, time.Now())
 
 	if req.VolumeID == "" {
@@ -60,7 +60,7 @@ func (c *ClientCSI) CSIControllerValidateVolume(req *structs.ClientCSIController
 	return plugin.ControllerValidateCapabilties(ctx, req.VolumeID, caps)
 }
 
-// CSIControllerAttachVolume is used to attach a volume from a CSI Cluster to
+// AttachVolume is used to attach a volume from a CSI Cluster to
 // the storage node provided in the request.
 //
 // The controller attachment flow currently works as follows:
@@ -68,7 +68,7 @@ func (c *ClientCSI) CSIControllerValidateVolume(req *structs.ClientCSIController
 // 2. Call ControllerPublishVolume on the CSI Plugin to trigger a remote attachment
 //
 // In the future this may be expanded to request dynamic secrets for attachement.
-func (c *ClientCSI) CSIControllerAttachVolume(req *structs.ClientCSIControllerAttachVolumeRequest, resp *structs.ClientCSIControllerAttachVolumeResponse) error {
+func (c *CSIController) AttachVolume(req *structs.ClientCSIControllerAttachVolumeRequest, resp *structs.ClientCSIControllerAttachVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"client", "csi_controller", "publish_volume"}, time.Now())
 	plugin, err := c.findControllerPlugin(req.PluginName)
 	if err != nil {
@@ -109,12 +109,12 @@ func (c *ClientCSI) CSIControllerAttachVolume(req *structs.ClientCSIControllerAt
 	return nil
 }
 
-func (c *ClientCSI) findControllerPlugin(name string) (csi.CSIPlugin, error) {
+func (c *CSIController) findControllerPlugin(name string) (csi.CSIPlugin, error) {
 	return c.findPlugin(dynamicplugins.PluginTypeCSIController, name)
 }
 
 // TODO: Cache Plugin Clients?
-func (c *ClientCSI) findPlugin(ptype, name string) (csi.CSIPlugin, error) {
+func (c *CSIController) findPlugin(ptype, name string) (csi.CSIPlugin, error) {
 	pIface, err := c.c.dynamicRegistry.DispensePlugin(ptype, name)
 	if err != nil {
 		return nil, err
@@ -128,6 +128,6 @@ func (c *ClientCSI) findPlugin(ptype, name string) (csi.CSIPlugin, error) {
 	return plugin, nil
 }
 
-func (c *ClientCSI) requestContext() (context.Context, context.CancelFunc) {
+func (c *CSIController) requestContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), CSIPluginRequestTimeout)
 }

--- a/client/csi_controller_endpoint_test.go
+++ b/client/csi_controller_endpoint_test.go
@@ -31,43 +31,53 @@ func TestCSIController_AttachVolume(t *testing.T) {
 		{
 			Name: "returns plugin not found errors",
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName: "some-garbage",
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: "some-garbage",
+				},
 			},
 			ExpectedErr: errors.New("plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "validates volumeid is not empty",
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName: fakePlugin.Name,
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
 			},
 			ExpectedErr: errors.New("VolumeID is required"),
 		},
 		{
 			Name: "validates nodeid is not empty",
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName: fakePlugin.Name,
-				VolumeID:   "1234-4321-1234-4321",
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				VolumeID: "1234-4321-1234-4321",
 			},
-			ExpectedErr: errors.New("NodeID is required"),
+			ExpectedErr: errors.New("ClientCSINodeID is required"),
 		},
 		{
 			Name: "validates AccessMode",
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName: fakePlugin.Name,
-				VolumeID:   "1234-4321-1234-4321",
-				NodeID:     "abcde",
-				AccessMode: nstructs.CSIVolumeAccessMode("foo"),
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				VolumeID:        "1234-4321-1234-4321",
+				ClientCSINodeID: "abcde",
+				AccessMode:      nstructs.CSIVolumeAccessMode("foo"),
 			},
 			ExpectedErr: errors.New("Unknown access mode: foo"),
 		},
 		{
 			Name: "validates attachmentmode is not empty",
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName:     fakePlugin.Name,
-				VolumeID:       "1234-4321-1234-4321",
-				NodeID:         "abcde",
-				AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
-				AttachmentMode: nstructs.CSIVolumeAttachmentMode("bar"),
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				VolumeID:        "1234-4321-1234-4321",
+				ClientCSINodeID: "abcde",
+				AccessMode:      nstructs.CSIVolumeAccessModeMultiNodeReader,
+				AttachmentMode:  nstructs.CSIVolumeAttachmentMode("bar"),
 			},
 			ExpectedErr: errors.New("Unknown attachment mode: bar"),
 		},
@@ -77,11 +87,13 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				fc.NextControllerPublishVolumeErr = errors.New("hello")
 			},
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName:     fakePlugin.Name,
-				VolumeID:       "1234-4321-1234-4321",
-				NodeID:         "abcde",
-				AccessMode:     nstructs.CSIVolumeAccessModeSingleNodeWriter,
-				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				VolumeID:        "1234-4321-1234-4321",
+				ClientCSINodeID: "abcde",
+				AccessMode:      nstructs.CSIVolumeAccessModeSingleNodeWriter,
+				AttachmentMode:  nstructs.CSIVolumeAttachmentModeFilesystem,
 			},
 			ExpectedErr: errors.New("hello"),
 		},
@@ -91,11 +103,13 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				fc.NextControllerPublishVolumeResponse = &csi.ControllerPublishVolumeResponse{}
 			},
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName:     fakePlugin.Name,
-				VolumeID:       "1234-4321-1234-4321",
-				NodeID:         "abcde",
-				AccessMode:     nstructs.CSIVolumeAccessModeSingleNodeWriter,
-				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				VolumeID:        "1234-4321-1234-4321",
+				ClientCSINodeID: "abcde",
+				AccessMode:      nstructs.CSIVolumeAccessModeSingleNodeWriter,
+				AttachmentMode:  nstructs.CSIVolumeAttachmentModeFilesystem,
 			},
 			ExpectedResponse: &structs.ClientCSIControllerAttachVolumeResponse{},
 		},
@@ -107,11 +121,13 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				}
 			},
 			Request: &structs.ClientCSIControllerAttachVolumeRequest{
-				PluginName:     fakePlugin.Name,
-				VolumeID:       "1234-4321-1234-4321",
-				NodeID:         "abcde",
-				AccessMode:     nstructs.CSIVolumeAccessModeSingleNodeWriter,
-				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				VolumeID:        "1234-4321-1234-4321",
+				ClientCSINodeID: "abcde",
+				AccessMode:      nstructs.CSIVolumeAccessModeSingleNodeWriter,
+				AttachmentMode:  nstructs.CSIVolumeAttachmentModeFilesystem,
 			},
 			ExpectedResponse: &structs.ClientCSIControllerAttachVolumeResponse{
 				PublishContext: map[string]string{"foo": "bar"},
@@ -161,14 +177,18 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 		{
 			Name: "validates volumeid is not empty",
 			Request: &structs.ClientCSIControllerValidateVolumeRequest{
-				PluginID: fakePlugin.Name,
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
 			},
 			ExpectedErr: errors.New("VolumeID is required"),
 		},
 		{
 			Name: "returns plugin not found errors",
 			Request: &structs.ClientCSIControllerValidateVolumeRequest{
-				PluginID: "some-garbage",
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: "some-garbage",
+				},
 				VolumeID: "foo",
 			},
 			ExpectedErr: errors.New("plugin some-garbage for type csi-controller not found"),
@@ -176,7 +196,9 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 		{
 			Name: "validates attachmentmode",
 			Request: &structs.ClientCSIControllerValidateVolumeRequest{
-				PluginID:       fakePlugin.Name,
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
 				VolumeID:       "1234-4321-1234-4321",
 				AttachmentMode: nstructs.CSIVolumeAttachmentMode("bar"),
 				AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
@@ -186,7 +208,9 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 		{
 			Name: "validates AccessMode",
 			Request: &structs.ClientCSIControllerValidateVolumeRequest{
-				PluginID:       fakePlugin.Name,
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
 				VolumeID:       "1234-4321-1234-4321",
 				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
 				AccessMode:     nstructs.CSIVolumeAccessMode("foo"),
@@ -199,7 +223,9 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				fc.NextControllerValidateVolumeErr = errors.New("hello")
 			},
 			Request: &structs.ClientCSIControllerValidateVolumeRequest{
-				PluginID:       fakePlugin.Name,
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
 				VolumeID:       "1234-4321-1234-4321",
 				AccessMode:     nstructs.CSIVolumeAccessModeSingleNodeWriter,
 				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,

--- a/client/csi_controller_endpoint_test.go
+++ b/client/csi_controller_endpoint_test.go
@@ -18,7 +18,7 @@ var fakePlugin = &dynamicplugins.PluginInfo{
 	ConnectionInfo: &dynamicplugins.PluginConnectionInfo{},
 }
 
-func TestClientCSI_CSIControllerAttachVolume(t *testing.T) {
+func TestCSIController_AttachVolume(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -139,7 +139,7 @@ func TestClientCSI_CSIControllerAttachVolume(t *testing.T) {
 			require.Nil(err)
 
 			var resp structs.ClientCSIControllerAttachVolumeResponse
-			err = client.ClientRPC("ClientCSI.CSIControllerAttachVolume", tc.Request, &resp)
+			err = client.ClientRPC("CSIController.AttachVolume", tc.Request, &resp)
 			require.Equal(tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
 				require.Equal(tc.ExpectedResponse, &resp)
@@ -148,7 +148,7 @@ func TestClientCSI_CSIControllerAttachVolume(t *testing.T) {
 	}
 }
 
-func TestClientCSI_CSIControllerValidateVolume(t *testing.T) {
+func TestCSIController_ValidateVolume(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -228,7 +228,7 @@ func TestClientCSI_CSIControllerValidateVolume(t *testing.T) {
 			require.Nil(err)
 
 			var resp structs.ClientCSIControllerValidateVolumeResponse
-			err = client.ClientRPC("ClientCSI.CSIControllerValidateVolume", tc.Request, &resp)
+			err = client.ClientRPC("CSIController.ValidateVolume", tc.Request, &resp)
 			require.Equal(tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
 				require.Equal(tc.ExpectedResponse, &resp)

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -20,11 +20,11 @@ import (
 
 // rpcEndpoints holds the RPC endpoints
 type rpcEndpoints struct {
-	ClientStats *ClientStats
-	ClientCSI   *ClientCSI
-	FileSystem  *FileSystem
-	Allocations *Allocations
-	Agent       *Agent
+	ClientStats   *ClientStats
+	CSIController *CSIController
+	FileSystem    *FileSystem
+	Allocations   *Allocations
+	Agent         *Agent
 }
 
 // ClientRPC is used to make a local, client only RPC call
@@ -218,7 +218,7 @@ func (c *Client) streamingRpcConn(server *servers.Server, method string) (net.Co
 func (c *Client) setupClientRpc() {
 	// Initialize the RPC handlers
 	c.endpoints.ClientStats = &ClientStats{c}
-	c.endpoints.ClientCSI = &ClientCSI{c}
+	c.endpoints.CSIController = &CSIController{c}
 	c.endpoints.FileSystem = NewFileSystemEndpoint(c)
 	c.endpoints.Allocations = NewAllocationsEndpoint(c)
 	c.endpoints.Agent = NewAgentEndpoint(c)
@@ -236,7 +236,7 @@ func (c *Client) setupClientRpc() {
 func (c *Client) setupClientRpcServer(server *rpc.Server) {
 	// Register the endpoints
 	server.Register(c.endpoints.ClientStats)
-	server.Register(c.endpoints.ClientCSI)
+	server.Register(c.endpoints.CSIController)
 	server.Register(c.endpoints.FileSystem)
 	server.Register(c.endpoints.Allocations)
 	server.Register(c.endpoints.Agent)

--- a/nomad/client_csi_endpoint.go
+++ b/nomad/client_csi_endpoint.go
@@ -1,0 +1,75 @@
+package nomad
+
+import (
+	"errors"
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	log "github.com/hashicorp/go-hclog"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+)
+
+// ClientCSIController is used to forward RPC requests to the targed Nomad client's
+// CSIController endpoint.
+type ClientCSIController struct {
+	srv    *Server
+	logger log.Logger
+}
+
+func (a *ClientCSIController) AttachVolume(args *cstructs.ClientCSIControllerAttachVolumeRequest, reply *cstructs.ClientCSIControllerAttachVolumeResponse) error {
+	defer metrics.MeasureSince([]string{"nomad", "client_csi_controller", "attach_volume"}, time.Now())
+
+	// Verify the arguments.
+	if args.ControllerNodeID == "" {
+		return errors.New("missing ControllerNodeID")
+	}
+
+	// Make sure Node is valid and new enough to support RPC
+	snap, err := a.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	_, err = getNodeForRpc(snap, args.ControllerNodeID)
+	if err != nil {
+		return err
+	}
+
+	// Get the connection to the client
+	state, ok := a.srv.getNodeConn(args.ControllerNodeID)
+	if !ok {
+		return findNodeConnAndForward(a.srv, args.ControllerNodeID, "ClientCSIController.AttachVolume", args, reply)
+	}
+
+	// Make the RPC
+	return NodeRpc(state.Session, "CSIController.AttachVolume", args, reply)
+}
+
+func (a *ClientCSIController) ValidateVolume(args *cstructs.ClientCSIControllerValidateVolumeRequest, reply *cstructs.ClientCSIControllerValidateVolumeResponse) error {
+	defer metrics.MeasureSince([]string{"nomad", "client_csi_controller", "validate_volume"}, time.Now())
+
+	// Verify the arguments.
+	if args.ControllerNodeID == "" {
+		return errors.New("missing ControllerNodeID")
+	}
+
+	// Make sure Node is valid and new enough to support RPC
+	snap, err := a.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	_, err = getNodeForRpc(snap, args.ControllerNodeID)
+	if err != nil {
+		return err
+	}
+
+	// Get the connection to the client
+	state, ok := a.srv.getNodeConn(args.ControllerNodeID)
+	if !ok {
+		return findNodeConnAndForward(a.srv, args.ControllerNodeID, "ClientCSIController.ValidateVolume", args, reply)
+	}
+
+	// Make the RPC
+	return NodeRpc(state.Session, "CSIController.ValidateVolume", args, reply)
+}

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -1,0 +1,93 @@
+package nomad
+
+import (
+	"testing"
+
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/nomad/client"
+	"github.com/hashicorp/nomad/client/config"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientCSIController_AttachVolume_Local(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Start a server and client
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
+		c.Servers = []string{s.config.RPCAddr.String()}
+	})
+	defer cleanupC()
+
+	testutil.WaitForResult(func() (bool, error) {
+		nodes := s.connectedNodes()
+		return len(nodes) == 1, nil
+	}, func(err error) {
+		require.Fail("should have a client")
+	})
+
+	req := &cstructs.ClientCSIControllerAttachVolumeRequest{
+		CSIControllerQuery: cstructs.CSIControllerQuery{ControllerNodeID: c.NodeID()},
+	}
+
+	// Fetch the response
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSIController.AttachVolume", req, &resp)
+	require.NotNil(err)
+	// Should recieve an error from the client endpoint
+	require.Contains(err.Error(), "must specify plugin name to dispense")
+}
+
+func TestClientCSIController_AttachVolume_Forwarded(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Start a server and client
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) {
+		c.DevDisableBootstrap = true
+	})
+	defer cleanupS2()
+	TestJoin(t, s1, s2)
+	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForLeader(t, s2.RPC)
+	codec := rpcClient(t, s2)
+
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
+		c.Servers = []string{s2.config.RPCAddr.String()}
+		c.GCDiskUsageThreshold = 100.0
+	})
+	defer cleanupC()
+
+	testutil.WaitForResult(func() (bool, error) {
+		nodes := s2.connectedNodes()
+		return len(nodes) == 1, nil
+	}, func(err error) {
+		require.Fail("should have a client")
+	})
+
+	// Force remove the connection locally in case it exists
+	s1.nodeConnsLock.Lock()
+	delete(s1.nodeConns, c.NodeID())
+	s1.nodeConnsLock.Unlock()
+
+	req := &cstructs.ClientCSIControllerAttachVolumeRequest{
+		CSIControllerQuery: cstructs.CSIControllerQuery{ControllerNodeID: c.NodeID()},
+	}
+
+	// Fetch the response
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSIController.AttachVolume", req, &resp)
+	require.NotNil(err)
+	// Should recieve an error from the client endpoint
+	require.Contains(err.Error(), "must specify plugin name to dispense")
+}

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -336,6 +336,14 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 			RequiresControllerPlugin: true,
 		},
 	}
+	node.CSINodePlugins = map[string]*structs.CSIInfo{
+		"minnie": {PluginID: "minnie",
+			Healthy:                  true,
+			ControllerInfo:           &structs.CSIControllerInfo{},
+			NodeInfo:                 &structs.CSINodeInfo{},
+			RequiresControllerPlugin: true,
+		},
+	}
 	err := state.UpsertNode(1002, node)
 	require.NoError(t, err)
 	vols := []*structs.CSIVolume{{
@@ -367,6 +375,7 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 	}
 	claimResp := &structs.CSIVolumeClaimResponse{}
 	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
+	// Because the node is not registered
 	require.EqualError(t, err, "No path to node")
 }
 

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -261,10 +261,11 @@ type endpoints struct {
 	Enterprise *EnterpriseEndpoints
 
 	// Client endpoints
-	ClientStats       *ClientStats
-	FileSystem        *FileSystem
-	Agent             *Agent
-	ClientAllocations *ClientAllocations
+	ClientStats         *ClientStats
+	FileSystem          *FileSystem
+	Agent               *Agent
+	ClientAllocations   *ClientAllocations
+	ClientCSIController *ClientCSIController
 }
 
 // NewServer is used to construct a new Nomad server from the
@@ -1110,6 +1111,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 		s.staticEndpoints.ClientStats = &ClientStats{srv: s, logger: s.logger.Named("client_stats")}
 		s.staticEndpoints.ClientAllocations = &ClientAllocations{srv: s, logger: s.logger.Named("client_allocs")}
 		s.staticEndpoints.ClientAllocations.register()
+		s.staticEndpoints.ClientCSIController = &ClientCSIController{srv: s, logger: s.logger.Named("client_csi")}
 
 		// Streaming endpoints
 		s.staticEndpoints.FileSystem = &FileSystem{srv: s, logger: s.logger.Named("client_fs")}
@@ -1137,6 +1139,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 	s.staticEndpoints.Enterprise.Register(server)
 	server.Register(s.staticEndpoints.ClientStats)
 	server.Register(s.staticEndpoints.ClientAllocations)
+	server.Register(s.staticEndpoints.ClientCSIController)
 	server.Register(s.staticEndpoints.FileSystem)
 	server.Register(s.staticEndpoints.Agent)
 


### PR DESCRIPTION
Currently the handling of CSINode RPCs does not correctly handle forwarding
RPCs to Nodes.

This commit fixes this by introducing a shim RPC
(nomad/client_csi_enpdoint) that will correctly forward the request to the
owning node, or submit the RPC to the client.

In the process it also cleans up handling a little bit by adding the
`CSIControllerQuery` embeded struct for required forwarding state.

The CSIControllerQuery embeding the requirement of a `PluginID` also means
we could move node targetting into the shim RPC if wanted in the future.