### PR TITLE
csi: VolumeCapabilities for ControllerPublishVolume

### DIFF
--- a/client/csi_controller_endpoint_test.go
+++ b/client/csi_controller_endpoint_test.go
@@ -64,9 +64,10 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				},
 				VolumeID:        "1234-4321-1234-4321",
 				ClientCSINodeID: "abcde",
+				AttachmentMode:  nstructs.CSIVolumeAttachmentModeFilesystem,
 				AccessMode:      nstructs.CSIVolumeAccessMode("foo"),
 			},
-			ExpectedErr: errors.New("Unknown access mode: foo"),
+			ExpectedErr: errors.New("Unknown volume access mode: foo"),
 		},
 		{
 			Name: "validates attachmentmode is not empty",
@@ -79,7 +80,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				AccessMode:      nstructs.CSIVolumeAccessModeMultiNodeReader,
 				AttachmentMode:  nstructs.CSIVolumeAttachmentMode("bar"),
 			},
-			ExpectedErr: errors.New("Unknown attachment mode: bar"),
+			ExpectedErr: errors.New("Unknown volume attachment mode: bar"),
 		},
 		{
 			Name: "returns transitive errors",

--- a/client/structs/csi.go
+++ b/client/structs/csi.go
@@ -69,16 +69,22 @@ type ClientCSIControllerAttachVolumeRequest struct {
 	CSIControllerQuery
 }
 
-func (c *ClientCSIControllerAttachVolumeRequest) ToCSIRequest() *csi.ControllerPublishVolumeRequest {
+func (c *ClientCSIControllerAttachVolumeRequest) ToCSIRequest() (*csi.ControllerPublishVolumeRequest, error) {
 	if c == nil {
-		return &csi.ControllerPublishVolumeRequest{}
+		return &csi.ControllerPublishVolumeRequest{}, nil
+	}
+
+	caps, err := csi.VolumeCapabilityFromStructs(c.AttachmentMode, c.AccessMode)
+	if err != nil {
+		return nil, err
 	}
 
 	return &csi.ControllerPublishVolumeRequest{
-		VolumeID: c.VolumeID,
-		NodeID:   c.ClientCSINodeID,
-		ReadOnly: c.ReadOnly,
-	}
+		VolumeID:         c.VolumeID,
+		NodeID:           c.ClientCSINodeID,
+		ReadOnly:         c.ReadOnly,
+		VolumeCapability: caps,
+	}, nil
 }
 
 type ClientCSIControllerAttachVolumeResponse struct {

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -228,10 +228,10 @@ func NewControllerCapabilitySet(resp *csipbv1.ControllerGetCapabilitiesResponse)
 }
 
 type ControllerPublishVolumeRequest struct {
-	VolumeID string
-	NodeID   string
-	ReadOnly bool
-	//TODO: Add Capabilities
+	VolumeID         string
+	NodeID           string
+	ReadOnly         bool
+	VolumeCapability *VolumeCapability
 }
 
 func (r *ControllerPublishVolumeRequest) ToCSIRepresentation() *csipbv1.ControllerPublishVolumeRequest {
@@ -240,10 +240,10 @@ func (r *ControllerPublishVolumeRequest) ToCSIRepresentation() *csipbv1.Controll
 	}
 
 	return &csipbv1.ControllerPublishVolumeRequest{
-		VolumeId: r.VolumeID,
-		NodeId:   r.NodeID,
-		Readonly: r.ReadOnly,
-		// TODO: add capabilities
+		VolumeId:         r.VolumeID,
+		NodeId:           r.NodeID,
+		Readonly:         r.ReadOnly,
+		VolumeCapability: r.VolumeCapability.ToCSIRepresentation(),
 	}
 }
 


### PR DESCRIPTION
This commit introduces support for providing VolumeCapabilities during requests
to `ControllerPublishVolumes` as this is a required field.

depends on #7216