### PR TITLE
Fix rendered backslash in group "<required>"

### DIFF
--- a/website/pages/docs/job-specification/job.mdx
+++ b/website/pages/docs/job-specification/job.mdx
@@ -81,7 +81,7 @@ job "docs" {
 - `datacenters` `(array<string>: <required>)` - A list of datacenters in the region which are eligible
   for task placement. This must be provided, and does not have a default.
 
-- `group` <code>([Group][group]: \<required\>)</code> - Specifies the start of a
+- `group` `([Group][group]: <required>)` - Specifies the start of a
   group of tasks. This can be provided multiple times to define additional
   groups. Group names must be unique within the job file.
 


### PR DESCRIPTION
The `<require>` tag for group contained backslashes and the first backslash was getting rendered. See on live site: https://nomadproject.io/docs/job-specification/job/#inlinecode-group-7