### PR TITLE
api: fix panic when displaying devices w/o stat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
  * api: Fixed a panic when canonicalizing a jobspec with an incorrect job type [[GH-7207]](https://github.com/hashicorp/nomad/pull/7207)
+ * cli: Fixed a panic when displaying device plugins without stats [[GH-7231](https://github.com/hashicorp/nomad/issues/7231)]
 
 ## 0.10.4 (February 19, 2020)
 

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -676,6 +676,8 @@ type StatValue struct {
 
 func (v *StatValue) String() string {
 	switch {
+	case v == nil:
+		return "<none>"
 	case v.BoolVal != nil:
 		return strconv.FormatBool(*v.BoolVal)
 	case v.StringVal != nil:


### PR DESCRIPTION
`"<none>"` matches `node status -verbose` output