### PR TITLE
Honor CNI and bridge related config fields

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -270,9 +270,6 @@ type ClientConfig struct {
 	// available to jobs running on this node.
 	HostVolumes []*structs.ClientHostVolumeConfig `hcl:"host_volume"`
 
-	// ExtraKeysHCL is used by hcl to surface unexpected keys
-	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
-
 	// CNIPath is the path to search for CNI plugins, multiple paths can be
 	// specified colon delimited
 	CNIPath string `hcl:"cni_path"`
@@ -285,6 +282,9 @@ type ClientConfig struct {
 	// creating allocations with bridge networking mode. This range is local to
 	// the host
 	BridgeNetworkSubnet string `hcl:"bridge_network_subnet"`
+
+	// ExtraKeysHCL is used by hcl to surface unexpected keys
+	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
 
 // ClientTemplateConfig is configuration on the client specific to template
@@ -1478,6 +1478,16 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 		result.HostVolumes = structs.CopySliceClientHostVolumeConfig(b.HostVolumes)
 	} else if len(b.HostVolumes) != 0 {
 		result.HostVolumes = structs.HostVolumeSliceMerge(a.HostVolumes, b.HostVolumes)
+	}
+
+	if b.CNIPath != "" {
+		result.CNIPath = b.CNIPath
+	}
+	if b.BridgeNetworkName != "" {
+		result.BridgeNetworkName = b.BridgeNetworkName
+	}
+	if b.BridgeNetworkSubnet != "" {
+		result.BridgeNetworkSubnet = b.BridgeNetworkSubnet
 	}
 
 	return &result

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -86,6 +86,9 @@ var basicConfig = &Config{
 		HostVolumes: []*structs.ClientHostVolumeConfig{
 			{Name: "tmp", Path: "/tmp"},
 		},
+		CNIPath:             "/tmp/cni_path",
+		BridgeNetworkName:   "custom_bridge_name",
+		BridgeNetworkSubnet: "custom_bridge_subnet",
 	},
 	Server: &ServerConfig{
 		Enabled:                true,
@@ -367,6 +370,29 @@ var nonoptConfig = &Config{
 	TLSConfig:                 nil,
 	HTTPAPIResponseHeaders:    map[string]string{},
 	Sentinel:                  nil,
+}
+
+func TestConfig_ParseMerge(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs(filepath.Join(".", "testdata", "basic.hcl"))
+	require.NoError(t, err)
+
+	actual, err := ParseConfigFile(path)
+	require.NoError(t, err)
+
+	require.Equal(t, basicConfig.Client, actual.Client)
+
+	oldDefault := &Config{
+		Consul:    config.DefaultConsulConfig(),
+		Vault:     config.DefaultVaultConfig(),
+		Autopilot: config.DefaultAutopilotConfig(),
+		Client:    &ClientConfig{},
+		Server:    &ServerConfig{},
+	}
+	merged := oldDefault.Merge(actual)
+	require.Equal(t, basicConfig.Client, merged.Client)
+
 }
 
 func TestConfig_Parse(t *testing.T) {

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -95,6 +95,10 @@ client {
   host_volume "tmp" {
     path = "/tmp"
   }
+
+  cni_path              = "/tmp/cni_path"
+  bridge_network_name   = "custom_bridge_name"
+  bridge_network_subnet = "custom_bridge_subnet"
 }
 
 server {

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -36,6 +36,8 @@
   "client": [
     {
       "alloc_dir": "/tmp/alloc",
+      "bridge_network_name": "custom_bridge_name",
+      "bridge_network_subnet": "custom_bridge_subnet",
       "chroot_env": [
         {
           "/opt/myapp/bin": "/bin",
@@ -44,6 +46,7 @@
       ],
       "client_max_port": 2000,
       "client_min_port": 1000,
+      "cni_path": "/tmp/cni_path",
       "cpu_total_compute": 4444,
       "disable_remote_exec": true,
       "enabled": true,


### PR DESCRIPTION
Nomad agent may silently ignore cni_path and bridge setting, when it
merges configs from multiple files (or against default/dev config).

This PR ensures that the values are merged properly.

To illustrate the problem, `TestConfig_ParseMerge` fails in [first sha build](https://circleci.com/gh/hashicorp/nomad/41267) but succeeds in [the second sha build](https://circleci.com/gh/hashicorp/nomad/41274).

Fixes https://github.com/hashicorp/nomad/issues/7227