### PR TITLE
docs: remove Nomad binary size specifics from documentation.

### DIFF
--- a/website/pages/intro/index.mdx
+++ b/website/pages/intro/index.mdx
@@ -32,7 +32,7 @@ Nomad is widely adopted and used in production by PagerDuty, Target, Citadel, Tr
 
 - **Deploy Containers and Legacy Applications**: Nomad’s flexibility as an orchestrator enables an organization to run containers, legacy, and batch applications together on the same infrastructure. Nomad brings core orchestration benefits to legacy applications without needing to containerize via pluggable [task drivers](/docs/drivers).
 
-- **Simple & Reliable**: Nomad runs as a single 75MB binary and is entirely self contained - combining resource management and scheduling into a single system. Nomad does not require any external services for storage or coordination. Nomad automatically handles application, node, and driver failures. Nomad is distributed and resilient, using leader election and state replication to provide high availability in the event of failures.
+- **Simple & Reliable**: Nomad runs as a single binary and is entirely self contained - combining resource management and scheduling into a single system. Nomad does not require any external services for storage or coordination. Nomad automatically handles application, node, and driver failures. Nomad is distributed and resilient, using leader election and state replication to provide high availability in the event of failures.
 
 - **Device Plugins & GPU Support**: Nomad offers built-in support for GPU workloads such as machine learning (ML) and artificial intelligence (AI). Nomad uses [device plugins](/docs/devices) to automatically detect and utilize resources from hardware devices such as GPU, FPGAs, and TPUs.
 

--- a/website/pages/use-cases/simple-container-orchestration.jsx
+++ b/website/pages/use-cases/simple-container-orchestration.jsx
@@ -7,7 +7,7 @@ export default function SimpleContainerOrchestrationPage() {
   return (
     <UseCasesLayout
       title="Simple Container Orchestration"
-      description="Nomad runs as a 35 MB single binary with a small resource footprint. Developers use a declarative job specification to define how an application should be deployed.  Nomad handles deployment and automatically recovers applications from failures."
+      description="Nomad runs as a single binary with a small resource footprint. Developers use a declarative job specification to define how an application should be deployed.  Nomad handles deployment and automatically recovers applications from failures."
     >
       <TextSplitWithCode
         textSplit={{


### PR DESCRIPTION
closes #7240 