### PR TITLE
csi: volumes use `Schedulable` rather than `Healthy`

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -88,10 +88,7 @@ type CSIVolume struct {
 	// Combine structs.{Read,Write,Past}Allocs
 	Allocations []*AllocationListStub
 
-	// Healthy is true iff all the denormalized plugin health fields are true, and the
-	// volume has not been marked for garbage collection
-	Healthy             bool
-	VolumeGC            time.Time
+	Schedulable         bool
 	PluginID            string
 	ControllerRequired  bool
 	ControllersHealthy  int
@@ -120,16 +117,12 @@ func (v CSIVolumeIndexSort) Swap(i, j int) {
 
 // CSIVolumeListStub omits allocations. See also nomad/structs/csi.go
 type CSIVolumeListStub struct {
-	ID             string
-	Namespace      string
-	Topologies     []*CSITopology
-	AccessMode     CSIVolumeAccessMode
-	AttachmentMode CSIVolumeAttachmentMode
-
-	// Healthy is true iff all the denormalized plugin health fields are true, and the
-	// volume has not been marked for garbage collection
-	Healthy             bool
-	VolumeGC            time.Time
+	ID                  string
+	Namespace           string
+	Topologies          []*CSITopology
+	AccessMode          CSIVolumeAccessMode
+	AttachmentMode      CSIVolumeAttachmentMode
+	Schedulable         bool
 	PluginID            string
 	ControllerRequired  bool
 	ControllersHealthy  int

--- a/api/csi.go
+++ b/api/csi.go
@@ -93,6 +93,7 @@ type CSIVolume struct {
 	Healthy             bool
 	VolumeGC            time.Time
 	PluginID            string
+	ControllerRequired  bool
 	ControllersHealthy  int
 	ControllersExpected int
 	NodesHealthy        int
@@ -130,6 +131,7 @@ type CSIVolumeListStub struct {
 	Healthy             bool
 	VolumeGC            time.Time
 	PluginID            string
+	ControllerRequired  bool
 	ControllersHealthy  int
 	ControllersExpected int
 	NodesHealthy        int
@@ -156,7 +158,8 @@ type CSIPlugins struct {
 }
 
 type CSIPlugin struct {
-	ID string
+	ID                 string
+	ControllerRequired bool
 	// Map Node.ID to CSIInfo fingerprint results
 	Controllers        map[string]*CSIInfo
 	Nodes              map[string]*CSIInfo
@@ -168,6 +171,7 @@ type CSIPlugin struct {
 
 type CSIPluginListStub struct {
 	ID                  string
+	ControllerRequired  bool
 	ControllersHealthy  int
 	ControllersExpected int
 	NodesHealthy        int

--- a/api/csi.go
+++ b/api/csi.go
@@ -81,6 +81,8 @@ const (
 type CSIVolume struct {
 	ID             string
 	Namespace      string
+	Name           string
+	ExternalID     string
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode
 	AttachmentMode CSIVolumeAttachmentMode
@@ -119,6 +121,8 @@ func (v CSIVolumeIndexSort) Swap(i, j int) {
 type CSIVolumeListStub struct {
 	ID                  string
 	Namespace           string
+	Name                string
+	ExternalID          string
 	Topologies          []*CSITopology
 	AccessMode          CSIVolumeAccessMode
 	AttachmentMode      CSIVolumeAttachmentMode

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1783,7 +1783,7 @@ func (s *StateStore) CSIVolumeDenormalizePlugins(ws memdb.WatchSet, vol *structs
 	if plug == nil {
 		vol.ControllersHealthy = 0
 		vol.NodesHealthy = 0
-		vol.Healthy = false
+		vol.Schedulable = false
 		return vol, nil
 	}
 
@@ -1795,9 +1795,9 @@ func (s *StateStore) CSIVolumeDenormalizePlugins(ws memdb.WatchSet, vol *structs
 	vol.ControllersExpected = len(plug.Controllers)
 	vol.NodesExpected = len(plug.Nodes)
 
-	vol.Healthy = vol.NodesHealthy > 0
+	vol.Schedulable = vol.NodesHealthy > 0
 	if vol.ControllerRequired {
-		vol.Healthy = vol.ControllersHealthy > 0 && vol.Healthy
+		vol.Schedulable = vol.ControllersHealthy > 0 && vol.Schedulable
 	}
 
 	return vol, nil

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2837,7 +2837,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	v0.ID = id0
 	v0.Namespace = "default"
 	v0.PluginID = "minnie"
-	v0.Healthy = true
+	v0.Schedulable = true
 	v0.AccessMode = structs.CSIVolumeAccessModeMultiNodeSingleWriter
 	v0.AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem
 
@@ -2846,7 +2846,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	v1.ID = id1
 	v1.Namespace = "default"
 	v1.PluginID = "adam"
-	v1.Healthy = true
+	v1.Schedulable = true
 	v1.AccessMode = structs.CSIVolumeAccessModeMultiNodeSingleWriter
 	v1.AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem
 

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -137,10 +137,13 @@ func ValidCSIVolumeWriteAccessMode(accessMode CSIVolumeAccessMode) bool {
 
 // CSIVolume is the full representation of a CSI Volume
 type CSIVolume struct {
-	ID             string
-	Namespace      string
-	Name           string
+	// ID is a namespace unique URL safe identifier for the volume
+	ID string
+	// Name is a display name for the volume, not required to be unique
+	Name string
+	// ExternalID identifies the volume for the CSI interface, may be URL unsafe
 	ExternalID     string
+	Namespace      string
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode
 	AttachmentMode CSIVolumeAttachmentMode

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -140,6 +140,7 @@ type CSIVolume struct {
 	ID             string
 	Namespace      string
 	Name           string
+	ExternalID     string
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode
 	AttachmentMode CSIVolumeAttachmentMode
@@ -148,9 +149,9 @@ type CSIVolume struct {
 	ReadAllocs  map[string]*Allocation
 	WriteAllocs map[string]*Allocation
 
-	// Healthy is true if all the denormalized plugin health fields are true, and the
+	// Schedulable is true if all the denormalized plugin health fields are true, and the
 	// volume has not been marked for garbage collection
-	Healthy             bool
+	Schedulable         bool
 	PluginID            string
 	ControllerRequired  bool
 	ControllersHealthy  int
@@ -212,7 +213,7 @@ func (v *CSIVolume) Stub() *CSIVolListStub {
 		AttachmentMode:     v.AttachmentMode,
 		CurrentReaders:     len(v.ReadAllocs),
 		CurrentWriters:     len(v.WriteAllocs),
-		Schedulable:        v.Healthy,
+		Schedulable:        v.Schedulable,
 		PluginID:           v.PluginID,
 		ControllersHealthy: v.ControllersHealthy,
 		NodesHealthy:       v.NodesHealthy,
@@ -225,7 +226,7 @@ func (v *CSIVolume) Stub() *CSIVolListStub {
 }
 
 func (v *CSIVolume) CanReadOnly() bool {
-	if !v.Healthy {
+	if !v.Schedulable {
 		return false
 	}
 
@@ -233,7 +234,7 @@ func (v *CSIVolume) CanReadOnly() bool {
 }
 
 func (v *CSIVolume) CanWrite() bool {
-	if !v.Healthy {
+	if !v.Schedulable {
 		return false
 	}
 

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -139,6 +139,7 @@ func ValidCSIVolumeWriteAccessMode(accessMode CSIVolumeAccessMode) bool {
 type CSIVolume struct {
 	ID             string
 	Namespace      string
+	Name           string
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode
 	AttachmentMode CSIVolumeAttachmentMode
@@ -150,7 +151,6 @@ type CSIVolume struct {
 	// Healthy is true if all the denormalized plugin health fields are true, and the
 	// volume has not been marked for garbage collection
 	Healthy             bool
-	VolumeGC            time.Time
 	PluginID            string
 	ControllerRequired  bool
 	ControllersHealthy  int
@@ -172,8 +172,7 @@ type CSIVolListStub struct {
 	AttachmentMode      CSIVolumeAttachmentMode
 	CurrentReaders      int
 	CurrentWriters      int
-	Healthy             bool
-	VolumeGC            time.Time
+	Schedulable         bool
 	PluginID            string
 	ControllersHealthy  int
 	ControllersExpected int
@@ -213,8 +212,7 @@ func (v *CSIVolume) Stub() *CSIVolListStub {
 		AttachmentMode:     v.AttachmentMode,
 		CurrentReaders:     len(v.ReadAllocs),
 		CurrentWriters:     len(v.WriteAllocs),
-		Healthy:            v.Healthy,
-		VolumeGC:           v.VolumeGC,
+		Schedulable:        v.Healthy,
 		PluginID:           v.PluginID,
 		ControllersHealthy: v.ControllersHealthy,
 		NodesHealthy:       v.NodesHealthy,
@@ -555,6 +553,7 @@ func (p *CSIPlugin) DeleteNode(nodeID string) {
 
 type CSIPluginListStub struct {
 	ID                  string
+	ControllerRequired  bool
 	ControllersHealthy  int
 	ControllersExpected int
 	NodesHealthy        int
@@ -566,6 +565,7 @@ type CSIPluginListStub struct {
 func (p *CSIPlugin) Stub() *CSIPluginListStub {
 	return &CSIPluginListStub{
 		ID:                  p.ID,
+		ControllerRequired:  p.ControllerRequired,
 		ControllersHealthy:  p.ControllersHealthy,
 		ControllersExpected: len(p.Controllers),
 		NodesHealthy:        p.NodesHealthy,

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -168,6 +168,8 @@ type CSIVolume struct {
 type CSIVolListStub struct {
 	ID                  string
 	Namespace           string
+	Name                string
+	ExternalID          string
 	Topologies          []*CSITopology
 	AccessMode          CSIVolumeAccessMode
 	AttachmentMode      CSIVolumeAttachmentMode
@@ -208,6 +210,8 @@ func (v *CSIVolume) Stub() *CSIVolListStub {
 	stub := CSIVolListStub{
 		ID:                 v.ID,
 		Namespace:          v.Namespace,
+		Name:               v.Name,
+		ExternalID:         v.ExternalID,
 		Topologies:         v.Topologies,
 		AccessMode:         v.AccessMode,
 		AttachmentMode:     v.AttachmentMode,

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -9,7 +9,7 @@ import (
 func TestCSIVolumeClaim(t *testing.T) {
 	vol := NewCSIVolume("", 0)
 	vol.AccessMode = CSIVolumeAccessModeMultiNodeSingleWriter
-	vol.Healthy = true
+	vol.Schedulable = true
 
 	alloc := &Allocation{ID: "al"}
 


### PR DESCRIPTION
Fixes #7249 