### PR TITLE
storage: add volumes to 'nomad alloc status' CLI

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/restarts"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/posener/complete"
 )
 
@@ -210,7 +211,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 				c.Ui.Output("Omitting resource statistics since the node is down.")
 			}
 		}
-		c.outputTaskDetails(alloc, stats, displayStats)
+		c.outputTaskDetails(alloc, stats, displayStats, verbose)
 	}
 
 	// Format the detailed status
@@ -344,12 +345,13 @@ func futureEvalTimePretty(evalID string, client *api.Client) string {
 
 // outputTaskDetails prints task details for each task in the allocation,
 // optionally printing verbose statistics if displayStats is set
-func (c *AllocStatusCommand) outputTaskDetails(alloc *api.Allocation, stats *api.AllocResourceUsage, displayStats bool) {
+func (c *AllocStatusCommand) outputTaskDetails(alloc *api.Allocation, stats *api.AllocResourceUsage, displayStats bool, verbose bool) {
 	for task := range c.sortedTaskStateIterator(alloc.TaskStates) {
 		state := alloc.TaskStates[task]
 		c.Ui.Output(c.Colorize().Color(fmt.Sprintf("\n[bold]Task %q is %q[reset]", task, state.State)))
 		c.outputTaskResources(alloc, task, stats, displayStats)
 		c.Ui.Output("")
+		c.outputTaskVolumes(alloc, task, verbose)
 		c.outputTaskStatus(state)
 	}
 }
@@ -688,4 +690,78 @@ func (c *AllocStatusCommand) sortedTaskStateIterator(m map[string]*api.TaskState
 
 	close(output)
 	return output
+}
+
+func (c *AllocStatusCommand) outputTaskVolumes(alloc *api.Allocation, taskName string, verbose bool) {
+	var task *api.Task
+	var tg *api.TaskGroup
+FOUND:
+	for _, tg = range alloc.Job.TaskGroups {
+		for _, task = range tg.Tasks {
+			if task.Name == taskName {
+				break FOUND
+			}
+		}
+	}
+	if task == nil || tg == nil {
+		c.Ui.Error(fmt.Sprintf("Could not find task data for %q", taskName))
+		return
+	}
+	if len(task.VolumeMounts) == 0 {
+		return
+	}
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return
+	}
+
+	var hostVolumesOutput []string
+	var csiVolumesOutput []string
+	hostVolumesOutput = append(hostVolumesOutput, "ID|Read Only")
+	if verbose {
+		csiVolumesOutput = append(csiVolumesOutput,
+			"ID|Plugin|Provider|Schedulable|Mount Options")
+	} else {
+		csiVolumesOutput = append(csiVolumesOutput, "ID")
+	}
+
+	for _, volMount := range task.VolumeMounts {
+		volReq := tg.Volumes[*volMount.Volume]
+		switch volReq.Type {
+		case structs.VolumeTypeHost:
+			hostVolumesOutput = append(hostVolumesOutput,
+				fmt.Sprintf("%s|%v", volReq.Name, *volMount.ReadOnly))
+		case structs.VolumeTypeCSI:
+			if verbose {
+				// there's an extra API call per volume here so we toggle it
+				// off with the -verbose flag
+				vol, _, err := client.CSIVolumes().Info(volReq.Name, nil)
+				if err != nil {
+					c.Ui.Error(fmt.Sprintf("Error retrieving volume info for %q: %s",
+						volReq.Name, err))
+					continue
+				}
+				csiVolumesOutput = append(csiVolumesOutput,
+					fmt.Sprintf("%s|%s|%s|%v|%s",
+						volReq.Name, vol.PluginID,
+						"n/a", // TODO(tgross): https://github.com/hashicorp/nomad/issues/7248
+						vol.Schedulable,
+						"n/a", // TODO(tgross): https://github.com/hashicorp/nomad/issues/7007
+					))
+			} else {
+				csiVolumesOutput = append(csiVolumesOutput, volReq.Name)
+			}
+		}
+	}
+	if len(hostVolumesOutput) > 1 {
+		c.Ui.Output("Host Volumes:")
+		c.Ui.Output(formatList(hostVolumesOutput))
+		c.Ui.Output("") // line padding to next stanza
+	}
+	if len(csiVolumesOutput) > 1 {
+		c.Ui.Output("CSI Volumes:")
+		c.Ui.Output(formatList(csiVolumesOutput))
+		c.Ui.Output("") // line padding to next stanza
+	}
 }

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -721,9 +721,9 @@ FOUND:
 	hostVolumesOutput = append(hostVolumesOutput, "ID|Read Only")
 	if verbose {
 		csiVolumesOutput = append(csiVolumesOutput,
-			"ID|Plugin|Provider|Schedulable|Mount Options")
+			"ID|Plugin|Provider|Schedulable|Read Only|Mount Options")
 	} else {
-		csiVolumesOutput = append(csiVolumesOutput, "ID")
+		csiVolumesOutput = append(csiVolumesOutput, "ID|Read Only")
 	}
 
 	for _, volMount := range task.VolumeMounts {
@@ -743,14 +743,16 @@ FOUND:
 					continue
 				}
 				csiVolumesOutput = append(csiVolumesOutput,
-					fmt.Sprintf("%s|%s|%s|%v|%s",
+					fmt.Sprintf("%s|%s|%s|%v|%v|%s",
 						volReq.Name, vol.PluginID,
 						"n/a", // TODO(tgross): https://github.com/hashicorp/nomad/issues/7248
 						vol.Schedulable,
+						volReq.ReadOnly,
 						"n/a", // TODO(tgross): https://github.com/hashicorp/nomad/issues/7007
 					))
 			} else {
-				csiVolumesOutput = append(csiVolumesOutput, volReq.Name)
+				csiVolumesOutput = append(csiVolumesOutput,
+					fmt.Sprintf("%s|%v", volReq.Name, volReq.ReadOnly))
 			}
 		}
 	}


### PR DESCRIPTION
Implements #7159

Adds a stanza for both Host Volumes and CSI Volumes to the the CLI output for `nomad alloc status`. Mostly relies on information already in the API structs, but in the case where there are CSI Volumes we need to make extra API calls to get the volume status. To reduce overhead, these extra calls are hidden behind the `-verbose` flag.

--- 

~This PR has some placeholders for #7250 #7249 #7248 but we should probably only hold it up for #7250 (at most). Marking it as draft until we decide what to wait on.~ Ready for review.