### PR TITLE
api: alloc exec recovers from bad client connection

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"sort"
 	"strconv"
 	"sync"
@@ -234,11 +233,7 @@ func (a *Allocations) execFrames(ctx context.Context, alloc *Allocation, task st
 	var conn *websocket.Conn
 
 	if nodeClient != nil {
-		conn, _, err = nodeClient.websocket(reqPath, q)
-		if _, ok := err.(net.Error); err != nil && !ok {
-			errCh <- err
-			return nil, nil
-		}
+		conn, _, _ = nodeClient.websocket(reqPath, q)
 	}
 
 	if conn == nil {


### PR DESCRIPTION
If alloc exec fails to connect to the nomad client associated with the
alloc, fail over to using a server.

The code attempted to special case `net.Error` for failover to rule out
other permanent non-networking errors, by reusing a pattern in the
logging handling.

But this pattern does not apply here.  `net/http.Http` wraps all errors
as `*url.Error` that is net.Error.  The websocket doesn't, and instead
returns the raw error.  If the raw error isn't a `net.Error`, like in
the case of TLS handshake errors, the api package would fail immediately
rather than failover.

Fixes #7233 .