### PR TITLE
[test] website: test removing client-side fetches

### DIFF
--- a/website/components/docs-page/index.jsx
+++ b/website/components/docs-page/index.jsx
@@ -3,7 +3,6 @@ import DocsSidenav from '@hashicorp/react-docs-sidenav'
 import Content from '@hashicorp/react-content'
 import InlineSvg from '@hashicorp/react-inline-svg'
 import githubIcon from './img/github-icon.svg?include'
-import Link from 'next/link'
 import Head from 'next/head'
 
 export default function DocsPage({
@@ -42,7 +41,6 @@ export default function DocsPage({
               category={category}
               order={orderData}
               data={frontMatter}
-              Link={Link}
               product="nomad"
             />
           </div>


### PR DESCRIPTION
this reverts to server-side fetching for all sidebar links in an attempt to solve an issue where client-side fetches weren't doing a round-trip to the server and therefore weren't respecting our `_redirects` declarations. 