### PR TITLE
Add alloc_index as base label for metrics

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -354,6 +355,10 @@ func (tr *TaskRunner) initLabels() {
 		{
 			Name:  "alloc_id",
 			Value: tr.allocID,
+		},
+		{
+			Name:  "alloc_index",
+			Value: strconv.Itoa(int(tr.alloc.Index())),
 		},
 		{
 			Name:  "task",


### PR DESCRIPTION
Adds `alloc_index` as a label for all allocation metrics to allow consumers to build more human-friendly dashboards using something like `task-{index}` to identify an alloc as opposed to a GUID.

I am not sure as to how the backwards compability for these metrics is handled - Technically we could break setups if someone were to rely on the order of the labels. Feedback here would be appreciated.