### PR TITLE
csi: add Provider field to CSI CLIs and APIs

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -101,6 +101,8 @@ type CSIVolume struct {
 	// Schedulable is true if all the denormalized plugin health fields are true
 	Schedulable         bool
 	PluginID            string `hcl:"plugin_id"`
+	Provider            string
+	ProviderVersion     string
 	ControllerRequired  bool
 	ControllersHealthy  int
 	ControllersExpected int
@@ -151,6 +153,7 @@ type CSIVolumeListStub struct {
 	AttachmentMode      CSIVolumeAttachmentMode
 	Schedulable         bool
 	PluginID            string
+	Provider            string
 	ControllerRequired  bool
 	ControllersHealthy  int
 	ControllersExpected int
@@ -179,6 +182,8 @@ type CSIPlugins struct {
 
 type CSIPlugin struct {
 	ID                 string
+	Provider           string
+	Version            string
 	ControllerRequired bool
 	// Map Node.ID to CSIInfo fingerprint results
 	Controllers        map[string]*CSIInfo
@@ -192,6 +197,7 @@ type CSIPlugin struct {
 
 type CSIPluginListStub struct {
 	ID                  string
+	Provider            string
 	ControllerRequired  bool
 	ControllersHealthy  int
 	ControllersExpected int

--- a/client/pluginmanager/csimanager/fingerprint.go
+++ b/client/pluginmanager/csimanager/fingerprint.go
@@ -86,6 +86,8 @@ func (p *pluginFingerprinter) buildBasicFingerprint(ctx context.Context) (*struc
 	info := &structs.CSIInfo{
 		PluginID:          p.info.Name,
 		AllocID:           p.info.AllocID,
+		Provider:          p.info.Options["Provider"],
+		ProviderVersion:   p.info.Version,
 		Healthy:           false,
 		HealthDescription: "initial fingerprint not completed",
 	}

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -744,8 +744,9 @@ FOUND:
 				}
 				csiVolumesOutput = append(csiVolumesOutput,
 					fmt.Sprintf("%s|%s|%s|%v|%v|%s",
-						volReq.Name, vol.PluginID,
-						"n/a", // TODO(tgross): https://github.com/hashicorp/nomad/issues/7248
+						volReq.Name,
+						vol.PluginID,
+						vol.Provider,
 						vol.Schedulable,
 						volReq.ReadOnly,
 						"n/a", // TODO(tgross): https://github.com/hashicorp/nomad/issues/7007

--- a/command/plugin_status_csi.go
+++ b/command/plugin_status_csi.go
@@ -66,12 +66,12 @@ func (c *PluginStatusCommand) csiFormatPlugins(plugs []*api.CSIPluginListStub) (
 		return out, nil
 	}
 
-	// TODO(langmartin) add Provider https://github.com/hashicorp/nomad/issues/7248
 	rows := make([]string, len(plugs)+1)
-	rows[0] = "ID|Controllers Healthy/Expected|Nodes Healthy/Expected"
+	rows[0] = "ID|Provider|Controllers Healthy/Expected|Nodes Healthy/Expected"
 	for i, p := range plugs {
-		rows[i+1] = fmt.Sprintf("%s|%d/%d|%d/%d",
+		rows[i+1] = fmt.Sprintf("%s|%s|%d/%d|%d/%d",
 			limit(p.ID, c.length),
+			p.Provider,
 			p.ControllersHealthy,
 			p.ControllersExpected,
 			p.NodesHealthy,
@@ -92,6 +92,8 @@ func (c *PluginStatusCommand) csiFormatPlugin(plug *api.CSIPlugin) (string, erro
 
 	output := []string{
 		fmt.Sprintf("ID|%s", plug.ID),
+		fmt.Sprintf("Provider|%s", plug.Provider),
+		fmt.Sprintf("Version|%s", plug.Version),
 		fmt.Sprintf("Controllers Healthy|%d", plug.ControllersHealthy),
 		fmt.Sprintf("Controllers Expected|%d", len(plug.Controllers)),
 		fmt.Sprintf("Nodes Healthy|%d", plug.NodesHealthy),

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -90,12 +90,13 @@ func (c *VolumeStatusCommand) formatBasic(vol *api.CSIVolume) (string, error) {
 		return out, nil
 	}
 
-	// TODO(langmartin) add Provider https://github.com/hashicorp/nomad/issues/7248
 	output := []string{
 		fmt.Sprintf("ID|%s", vol.ID),
 		fmt.Sprintf("Name|%s", vol.Name),
 		fmt.Sprintf("External ID|%s", vol.ExternalID),
-
+		fmt.Sprintf("Plugin ID|%s", vol.PluginID),
+		fmt.Sprintf("Provider|%s", vol.Provider),
+		fmt.Sprintf("Version|%s", vol.ProviderVersion),
 		fmt.Sprintf("Schedulable|%t", vol.Schedulable),
 		fmt.Sprintf("Controllers Healthy|%d", vol.ControllersHealthy),
 		fmt.Sprintf("Controllers Expected|%d", vol.ControllersExpected),

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -958,6 +958,8 @@ func upsertNodeCSIPlugins(txn *memdb.Txn, node *structs.Node, index uint64) erro
 		} else {
 			plug = structs.NewCSIPlugin(info.PluginID, index)
 			plug.ControllerRequired = info.RequiresControllerPlugin
+			plug.Provider = info.Provider
+			plug.Version = info.ProviderVersion
 		}
 
 		plug.AddPlugin(node.ID, info)
@@ -1811,6 +1813,8 @@ func (s *StateStore) CSIVolumeDenormalizePlugins(ws memdb.WatchSet, vol *structs
 		return vol, nil
 	}
 
+	vol.Provider = plug.Provider
+	vol.ProviderVersion = plug.Version
 	vol.ControllerRequired = plug.ControllerRequired
 	vol.ControllersHealthy = plug.ControllersHealthy
 	vol.NodesHealthy = plug.NodesHealthy

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -156,6 +156,8 @@ type CSIVolume struct {
 	// volume has not been marked for garbage collection
 	Schedulable         bool
 	PluginID            string
+	Provider            string
+	ProviderVersion     string
 	ControllerRequired  bool
 	ControllersHealthy  int
 	ControllersExpected int
@@ -180,6 +182,7 @@ type CSIVolListStub struct {
 	CurrentWriters      int
 	Schedulable         bool
 	PluginID            string
+	Provider            string
 	ControllersHealthy  int
 	ControllersExpected int
 	NodesHealthy        int
@@ -222,6 +225,7 @@ func (v *CSIVolume) Stub() *CSIVolListStub {
 		CurrentWriters:     len(v.WriteAllocs),
 		Schedulable:        v.Schedulable,
 		PluginID:           v.PluginID,
+		Provider:           v.Provider,
 		ControllersHealthy: v.ControllersHealthy,
 		NodesHealthy:       v.NodesHealthy,
 		NodesExpected:      v.NodesExpected,
@@ -466,6 +470,8 @@ type CSIVolumeGetResponse struct {
 // CSIPlugin collects fingerprint info context for the plugin for clients
 type CSIPlugin struct {
 	ID                 string
+	Provider           string // the vendor name from CSI GetPluginInfoResponse
+	Version            string // the vendor verson from  CSI GetPluginInfoResponse
 	ControllerRequired bool
 
 	// Map Node.IDs to fingerprint results, split by type. Monolith type plugins have
@@ -561,6 +567,7 @@ func (p *CSIPlugin) DeleteNode(nodeID string) {
 
 type CSIPluginListStub struct {
 	ID                  string
+	Provider            string
 	ControllerRequired  bool
 	ControllersHealthy  int
 	ControllersExpected int
@@ -573,6 +580,7 @@ type CSIPluginListStub struct {
 func (p *CSIPlugin) Stub() *CSIPluginListStub {
 	return &CSIPluginListStub{
 		ID:                  p.ID,
+		Provider:            p.Provider,
 		ControllerRequired:  p.ControllerRequired,
 		ControllersHealthy:  p.ControllersHealthy,
 		ControllersExpected: len(p.Controllers),

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -151,6 +151,9 @@ type CSIInfo struct {
 	HealthDescription string
 	UpdateTime        time.Time
 
+	Provider        string // vendor name from CSI GetPluginInfoResponse
+	ProviderVersion string // vendor version from CSI GetPluginInfoResponse
+
 	// RequiresControllerPlugin is set when the CSI Plugin returns the
 	// CONTROLLER_SERVICE capability. When this is true, the volumes should not be
 	// scheduled on this client until a matching controller plugin is available.

--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -85,11 +85,12 @@ func TestClient_RPC_PluginProbe(t *testing.T) {
 
 func TestClient_RPC_PluginInfo(t *testing.T) {
 	cases := []struct {
-		Name             string
-		ResponseErr      error
-		InfoResponse     *csipbv1.GetPluginInfoResponse
-		ExpectedResponse string
-		ExpectedErr      error
+		Name                    string
+		ResponseErr             error
+		InfoResponse            *csipbv1.GetPluginInfoResponse
+		ExpectedResponseName    string
+		ExpectedResponseVersion string
+		ExpectedErr             error
 	}{
 		{
 			Name:        "handles underlying grpc errors",
@@ -99,16 +100,19 @@ func TestClient_RPC_PluginInfo(t *testing.T) {
 		{
 			Name: "returns an error if we receive an empty `name`",
 			InfoResponse: &csipbv1.GetPluginInfoResponse{
-				Name: "",
+				Name:          "",
+				VendorVersion: "",
 			},
 			ExpectedErr: fmt.Errorf("PluginGetInfo: plugin returned empty name field"),
 		},
 		{
 			Name: "returns the name when successfully retrieved and not empty",
 			InfoResponse: &csipbv1.GetPluginInfoResponse{
-				Name: "com.hashicorp.storage",
+				Name:          "com.hashicorp.storage",
+				VendorVersion: "1.0.1",
 			},
-			ExpectedResponse: "com.hashicorp.storage",
+			ExpectedResponseName:    "com.hashicorp.storage",
+			ExpectedResponseVersion: "1.0.1",
 		},
 	}
 
@@ -120,12 +124,13 @@ func TestClient_RPC_PluginInfo(t *testing.T) {
 			ic.NextErr = c.ResponseErr
 			ic.NextPluginInfo = c.InfoResponse
 
-			resp, err := client.PluginGetInfo(context.TODO())
+			name, version, err := client.PluginGetInfo(context.TODO())
 			if c.ExpectedErr != nil {
 				require.Error(t, c.ExpectedErr, err)
 			}
 
-			require.Equal(t, c.ExpectedResponse, resp)
+			require.Equal(t, c.ExpectedResponseName, name)
+			require.Equal(t, c.ExpectedResponseVersion, version)
 		})
 	}
 

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -28,9 +28,10 @@ type Client struct {
 	NextPluginProbeErr      error
 	PluginProbeCallCount    int64
 
-	NextPluginGetInfoResponse string
-	NextPluginGetInfoErr      error
-	PluginGetInfoCallCount    int64
+	NextPluginGetInfoNameResponse    string
+	NextPluginGetInfoVersionResponse string
+	NextPluginGetInfoErr             error
+	PluginGetInfoCallCount           int64
 
 	NextPluginGetCapabilitiesResponse *csi.PluginCapabilitySet
 	NextPluginGetCapabilitiesErr      error
@@ -106,13 +107,13 @@ func (c *Client) PluginProbe(ctx context.Context) (bool, error) {
 // PluginGetInfo is used to return semantic data about the plugin.
 // Response:
 //  - string: name, the name of the plugin in domain notation format.
-func (c *Client) PluginGetInfo(ctx context.Context) (string, error) {
+func (c *Client) PluginGetInfo(ctx context.Context) (string, string, error) {
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 
 	c.PluginGetInfoCallCount++
 
-	return c.NextPluginGetInfoResponse, c.NextPluginGetInfoErr
+	return c.NextPluginGetInfoNameResponse, c.NextPluginGetInfoVersionResponse, c.NextPluginGetInfoErr
 }
 
 // PluginGetCapabilities is used to return the available capabilities from the

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -23,7 +23,8 @@ type CSIPlugin interface {
 	// PluginGetInfo is used to return semantic data about the plugin.
 	// Response:
 	//  - string: name, the name of the plugin in domain notation format.
-	PluginGetInfo(ctx context.Context) (string, error)
+	//  - string: version, the vendor version of the plugin
+	PluginGetInfo(ctx context.Context) (string, string, error)
 
 	// PluginGetCapabilities is used to return the available capabilities from the
 	// identity service. This currently only looks for the CONTROLLER_SERVICE and


### PR DESCRIPTION
Implements #7248

Derive a provider name and version for plugins (and the volumes that use them) from the CSI identity API `GetPluginInfo`. Expose the vendor name as `Provider` in the API and CLI commands.

---

Resulting command line outputs after this changeset.

<details><summary>Plugin jobspec</summary>

```hcl
job "csi-plugin" {
  datacenters = ["dc1"]

  group "csi" {
    task "plugin" {
      driver = "docker"

      config {
        image = "quay.io/k8scsi/hostpathplugin:v1.2.0"

        args = [
          "--drivername=csi-hostpath",
          "--v=5",
          "--endpoint=unix://csi/csi.sock",
          "--nodeid=foo",
        ]

        /* privileged = true */
      }

      csi_plugin {
        id        = "hostpath-plugin0"
        type      = "monolith"
        mount_dir = "/csi"
      }

      resources {
        cpu    = 500
        memory = 256

        network {
          mbits = 10
          port  "plugin"{}
        }
      }
    }
  }
}
```

</details>

```
$ nomad plugin status
Container Storage Interface
ID        Provider      Controllers Healthy/Expected  Nodes Healthy/Expected
hostpath  csi-hostpath  1/1                           1/1
```

```
$ nomad plugin status hostpath
ID                   = hostpath-plugin0
Provider             = csi-hostpath
Version              = v1.2.0-0-g83590990
Controllers Healthy  = 1
Controllers Expected = 1
Nodes Healthy        = 1
Nodes Expected       = 1

Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
1eee51bf  1c6cb5d7  csi         0        run      running  32s ago  21s ago

```
<details><summary>Volume creation steps</summary>

```bash
#!/bin/bash

# dev mode path is going to be in a tempdir
PLUGIN_DOCKER_ID=$(docker ps | grep hostpath | awk -F' +' '{print $1}')
CSI_ENDPOINT=$(docker inspect $PLUGIN_DOCKER_ID | jq -r '.[0].Mounts[] | select(.Destination == "/csi") | .Source')/csi.sock

echo "creating volume..."

UUID=$(sudo csc --endpoint $CSI_ENDPOINT controller create-volume test-volume --cap 1,2,ext4 | grep -o '".*"' | tr -d '"')

echo "registering volume $UUID..."

echo $(printf 'id = "%s"
name = "test-volume"
type = "csi"
external_id = "%s"
plugin_id = "hostpath-plugin0"
access_mode = "single-node-writer"
attachment_mode = "file-system"' $UUID $UUID) | nomad volume register -
```

</details>

```
$ nomad volume status
Container Storage Interface
ID        Name         Plugin ID         Schedulable  Access Mode
1ef21ca2  test-volume  hostpath-plugin0  true         single-node-writer
```

```
$ nomad volume status 1ef
ID                   = 1ef21ca2-5fed-11ea-be93-0242ac110002
Name                 = test-volume
External ID          = 1ef21ca2-5fed-11ea-be93-0242ac110002
Plugin ID            = hostpath-plugin0
Provider             = csi-hostpath
Version              = v1.2.0-0-g83590990
Schedulable          = true
Controllers Healthy  = 1
Controllers Expected = 1
Nodes Healthy        = 1
Nodes Expected       = 1
Access Mode          = single-node-writer
Attachment Mode      = file-system
Namespace            = default
```