### PR TITLE
Deflake TestServer_ReconcileMember and some leadership related tests

### DIFF
--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -83,9 +83,9 @@ type rpcFn func(string, interface{}, interface{}) error
 
 // WaitForLeader blocks until a leader is elected.
 func WaitForLeader(t testing.T, rpc rpcFn) {
+	t.Helper()
 	WaitForResult(func() (bool, error) {
 		args := &structs.GenericRequest{}
-		args.AllowStale = true
 		var leader string
 		err := rpc("Status.Leader", args, &leader)
 		return leader != "", err


### PR DESCRIPTION
Fix TestServer_ReconcileMembers - the test assumes that s3 isn't the leader:
`reconcileMembers` call would fail when attempting to remove itself with "not the leader" error, as it steps down half way through the process.  This explains why the test fails 1/3 of the time (~ chance s3 is the leader).

The second fix addresses issues in many builds by reverting d5c7d6e491e36a11159211f5236c19a41bed4d8e .  Test must wait until the leader has finished establishLeadership call (including persisting a Barrier call and set up leadership ACL among other things).  Using AllowStale causes tests to wait until Raft leadership is done but not necessarily that the leader is ready for work.