### PR TITLE
Support per-task RestartPolicy

### DIFF
--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -216,10 +216,12 @@ func TestAllocations_GarbageCollect(t *testing.T) {
 
 	a := mock.Alloc()
 	a.Job.TaskGroups[0].Tasks[0].Driver = "mock_driver"
-	a.Job.TaskGroups[0].RestartPolicy = &nstructs.RestartPolicy{
+	rp := &nstructs.RestartPolicy{
 		Attempts: 0,
 		Mode:     nstructs.RestartPolicyModeFail,
 	}
+	a.Job.TaskGroups[0].RestartPolicy = rp
+	a.Job.TaskGroups[0].Tasks[0].RestartPolicy = rp
 	a.Job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
 		"run_for": "10ms",
 	}

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -54,6 +54,7 @@ func TestAllocRunner_TaskLeader_KillTG(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	tr := alloc.AllocatedResources.Tasks[alloc.Job.TaskGroups[0].Tasks[0].Name]
 	alloc.Job.TaskGroups[0].RestartPolicy.Attempts = 0
+	alloc.Job.TaskGroups[0].Tasks[0].RestartPolicy.Attempts = 0
 
 	// Create two tasks in the task group
 	task := alloc.Job.TaskGroups[0].Tasks[0]
@@ -147,6 +148,7 @@ func TestAllocRunner_TaskGroup_ShutdownDelay(t *testing.T) {
 	alloc := mock.Alloc()
 	tr := alloc.AllocatedResources.Tasks[alloc.Job.TaskGroups[0].Tasks[0].Name]
 	alloc.Job.TaskGroups[0].RestartPolicy.Attempts = 0
+	alloc.Job.TaskGroups[0].Tasks[0].RestartPolicy.Attempts = 0
 
 	// Create a group service
 	tg := alloc.Job.TaskGroups[0]
@@ -276,6 +278,7 @@ func TestAllocRunner_TaskLeader_StopTG(t *testing.T) {
 	alloc := mock.Alloc()
 	tr := alloc.AllocatedResources.Tasks[alloc.Job.TaskGroups[0].Tasks[0].Name]
 	alloc.Job.TaskGroups[0].RestartPolicy.Attempts = 0
+	alloc.Job.TaskGroups[0].Tasks[0].RestartPolicy.Attempts = 0
 
 	// Create 3 tasks in the task group
 	task := alloc.Job.TaskGroups[0].Tasks[0]
@@ -374,6 +377,7 @@ func TestAllocRunner_TaskLeader_StopRestoredTG(t *testing.T) {
 	alloc := mock.Alloc()
 	tr := alloc.AllocatedResources.Tasks[alloc.Job.TaskGroups[0].Tasks[0].Name]
 	alloc.Job.TaskGroups[0].RestartPolicy.Attempts = 0
+	alloc.Job.TaskGroups[0].Tasks[0].RestartPolicy.Attempts = 0
 
 	// Create a leader and follower task in the task group
 	task := alloc.Job.TaskGroups[0].Tasks[0]
@@ -900,12 +904,14 @@ func TestAllocRunner_HandlesArtifactFailure(t *testing.T) {
 	t.Parallel()
 
 	alloc := mock.BatchAlloc()
-	alloc.Job.TaskGroups[0].RestartPolicy = &structs.RestartPolicy{
+	rp := &structs.RestartPolicy{
 		Mode:     structs.RestartPolicyModeFail,
 		Attempts: 1,
 		Delay:    time.Nanosecond,
 		Interval: time.Hour,
 	}
+	alloc.Job.TaskGroups[0].RestartPolicy = rp
+	alloc.Job.TaskGroups[0].Tasks[0].RestartPolicy = rp
 
 	// Create a new task with a bad artifact
 	badtask := alloc.Job.TaskGroups[0].Tasks[0].Copy()
@@ -958,6 +964,7 @@ func TestAllocRunner_TaskFailed_KillTG(t *testing.T) {
 	alloc := mock.Alloc()
 	tr := alloc.AllocatedResources.Tasks[alloc.Job.TaskGroups[0].Tasks[0].Name]
 	alloc.Job.TaskGroups[0].RestartPolicy.Attempts = 0
+	alloc.Job.TaskGroups[0].Tasks[0].RestartPolicy.Attempts = 0
 
 	// Create two tasks in the task group
 	task := alloc.Job.TaskGroups[0].Tasks[0]
@@ -1087,6 +1094,7 @@ func TestAllocRunner_TerminalUpdate_Destroy(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	tr := alloc.AllocatedResources.Tasks[alloc.Job.TaskGroups[0].Tasks[0].Name]
 	alloc.Job.TaskGroups[0].RestartPolicy.Attempts = 0
+	alloc.Job.TaskGroups[0].Tasks[0].RestartPolicy.Attempts = 0
 	// Ensure task takes some time
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -340,12 +340,16 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 	tr.taskResources = tres
 
 	// Build the restart tracker.
-	tg := tr.alloc.Job.LookupTaskGroup(tr.alloc.TaskGroup)
-	if tg == nil {
-		tr.logger.Error("alloc missing task group")
-		return nil, fmt.Errorf("alloc missing task group")
+	rp := config.Task.RestartPolicy
+	if rp == nil {
+		tg := tr.alloc.Job.LookupTaskGroup(tr.alloc.TaskGroup)
+		if tg == nil {
+			tr.logger.Error("alloc missing task group")
+			return nil, fmt.Errorf("alloc missing task group")
+		}
+		rp = tg.RestartPolicy
 	}
-	tr.restartTracker = restarts.NewRestartTracker(tg.RestartPolicy, tr.alloc.Job.Type, config.Task.Lifecycle)
+	tr.restartTracker = restarts.NewRestartTracker(rp, tr.alloc.Job.Type, config.Task.Lifecycle)
 
 	// Get the driver
 	if err := tr.initDriver(); err != nil {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -906,6 +906,15 @@ func ApiTaskToStructsTask(apiTask *api.Task, structsTask *structs.Task) {
 	structsTask.Affinities = ApiAffinitiesToStructs(apiTask.Affinities)
 	structsTask.CSIPluginConfig = ApiCSIPluginConfigToStructsCSIPluginConfig(apiTask.CSIPluginConfig)
 
+	if apiTask.RestartPolicy != nil {
+		structsTask.RestartPolicy = &structs.RestartPolicy{
+			Attempts: *apiTask.RestartPolicy.Attempts,
+			Interval: *apiTask.RestartPolicy.Interval,
+			Delay:    *apiTask.RestartPolicy.Delay,
+			Mode:     *apiTask.RestartPolicy.Mode,
+		}
+	}
+
 	if l := len(apiTask.VolumeMounts); l != 0 {
 		structsTask.VolumeMounts = make([]*structs.VolumeMount, l)
 		for i, mount := range apiTask.VolumeMounts {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1674,7 +1674,12 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								Weight:  helper.Int8ToPtr(50),
 							},
 						},
-
+						RestartPolicy: &api.RestartPolicy{
+							Interval: helper.TimeToPtr(2 * time.Second),
+							Attempts: helper.IntToPtr(10),
+							Delay:    helper.TimeToPtr(20 * time.Second),
+							Mode:     helper.StringToPtr("delay"),
+						},
 						Services: []*api.Service{
 							{
 								Id:                "id",
@@ -2022,6 +2027,12 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						},
 						Env: map[string]string{
 							"hello": "world",
+						},
+						RestartPolicy: &structs.RestartPolicy{
+							Interval: 2 * time.Second,
+							Attempts: 10,
+							Delay:    20 * time.Second,
+							Mode:     "delay",
 						},
 						Services: []*structs.Service{
 							{
@@ -2374,6 +2385,12 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 									},
 								},
 							},
+						},
+						RestartPolicy: &structs.RestartPolicy{
+							Interval: 1 * time.Second,
+							Attempts: 5,
+							Delay:    10 * time.Second,
+							Mode:     "delay",
 						},
 						Meta: map[string]string{
 							"lol": "code",

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -66,6 +66,7 @@ func parseTask(item *ast.ObjectItem) (*api.Task, error) {
 		"logs",
 		"meta",
 		"resources",
+		"restart",
 		"service",
 		"shutdown_delay",
 		"template",
@@ -94,6 +95,7 @@ func parseTask(item *ast.ObjectItem) (*api.Task, error) {
 	delete(m, "logs")
 	delete(m, "meta")
 	delete(m, "resources")
+	delete(m, "restart")
 	delete(m, "service")
 	delete(m, "template")
 	delete(m, "vault")
@@ -213,6 +215,13 @@ func parseTask(item *ast.ObjectItem) (*api.Task, error) {
 		}
 
 		t.Resources = &r
+	}
+
+	// Parse restart policy
+	if o := listVal.Filter("restart"); len(o.Items) > 0 {
+		if err := parseRestartPolicy(&t.RestartPolicy, o); err != nil {
+			return nil, multierror.Prefix(err, "restart ->")
+		}
 	}
 
 	// If we have logs then parse that

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -236,6 +236,9 @@ func TestParse(t *testing.T) {
 										Weight:  helper.Int8ToPtr(25),
 									},
 								},
+								RestartPolicy: &api.RestartPolicy{
+									Attempts: helper.IntToPtr(10),
+								},
 								Services: []*api.Service{
 									{
 										Tags:       []string{"foo", "bar"},

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -178,6 +178,10 @@ job "binstore-storagelocker" {
         destination = "/mnt/foo"
       }
 
+      restart {
+        attempts = 10
+      }
+
       logs {
         max_files     = 14
         max_file_size = 101

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5095,7 +5095,7 @@ type TaskGroup struct {
 	// Scaling is the list of autoscaling policies for the TaskGroup
 	Scaling *ScalingPolicy
 
-	//RestartPolicy of a TaskGroup
+	// RestartPolicy of a TaskGroup
 	RestartPolicy *RestartPolicy
 
 	// Tasks are the collection of tasks that this task group needs to run
@@ -5744,6 +5744,9 @@ type Task struct {
 	// Resources is the resources needed by this task
 	Resources *Resources
 
+	// RestartPolicy of a TaskGroup
+	RestartPolicy *RestartPolicy
+
 	// DispatchPayload configures how the task retrieves its input from a dispatch
 	DispatchPayload *DispatchPayloadConfig
 
@@ -5882,6 +5885,10 @@ func (t *Task) Canonicalize(job *Job, tg *TaskGroup) {
 		t.Resources = DefaultResources()
 	} else {
 		t.Resources.Canonicalize()
+	}
+
+	if t.RestartPolicy == nil {
+		t.RestartPolicy = tg.RestartPolicy
 	}
 
 	// Set the default timeout if it is not specified.


### PR DESCRIPTION
Here, we add support for having a per-task RestartPolicy configured by user.  With Task Lifecycle coming in the horizon, tasks may need to have different RestartPolicies, e.g. Sidecar or one-off tasks should have different restart policies from main tasks.

In this iteration, the task restart policy inherits and is merged with the TaskGroup it is in, a common Nomad pattern for other stanzas that apply in many levels:

```hcl
# assuming Task Group restart policy is
restart {
  interval = "30m"
  attempts = 2
  delay    = "15s"
  mode     = "fail"
}

# and individual task group is
restart {
      attempts = 5
}

# then the effective individual task group policy is
restart {
  interval = "30m"
  attempts = 5
  delay    = "15s"
  mode     = "fail"
}
```

One outstanding question for the Task Lifecycle PR is to whether to have different default policies for one-off or sidecar tasks.  It's outside of scope for this PR.