### PR TITLE
Add artifact caching option

### DIFF
--- a/client/allocrunner/taskrunner/artifact_hook.go
+++ b/client/allocrunner/taskrunner/artifact_hook.go
@@ -15,11 +15,13 @@ import (
 type artifactHook struct {
 	eventEmitter ti.EventEmitter
 	logger       log.Logger
+	cacheDir     string
 }
 
-func newArtifactHook(e ti.EventEmitter, logger log.Logger) *artifactHook {
+func newArtifactHook(e ti.EventEmitter, cacheDir string, logger log.Logger) *artifactHook {
 	h := &artifactHook{
 		eventEmitter: e,
+		cacheDir:     cacheDir,
 	}
 	h.logger = logger.Named(h.Name())
 	return h
@@ -52,7 +54,7 @@ func (h *artifactHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 
 		h.logger.Debug("downloading artifact", "artifact", artifact.GetterSource)
 		//XXX add ctx to GetArtifact to allow cancelling long downloads
-		if err := getter.GetArtifact(req.TaskEnv, artifact, req.TaskDir.Dir); err != nil {
+		if err := getter.GetArtifact(req.TaskEnv, artifact, req.TaskDir.Dir, h.cacheDir); err != nil {
 			wrapped := structs.NewRecoverableError(
 				fmt.Errorf("failed to download artifact %q: %v", artifact.GetterSource, err),
 				true,

--- a/client/allocrunner/taskrunner/artifact_hook_test.go
+++ b/client/allocrunner/taskrunner/artifact_hook_test.go
@@ -36,7 +36,7 @@ func TestTaskRunner_ArtifactHook_Recoverable(t *testing.T) {
 	t.Parallel()
 
 	me := &mockEmitter{}
-	artifactHook := newArtifactHook(me, testlog.HCLogger(t))
+	artifactHook := newArtifactHook(me, "", testlog.HCLogger(t))
 
 	req := &interfaces.TaskPrestartRequest{
 		TaskEnv: taskenv.NewEmptyTaskEnv(),
@@ -69,7 +69,7 @@ func TestTaskRunner_ArtifactHook_PartialDone(t *testing.T) {
 	t.Parallel()
 
 	me := &mockEmitter{}
-	artifactHook := newArtifactHook(me, testlog.HCLogger(t))
+	artifactHook := newArtifactHook(me, "", testlog.HCLogger(t))
 
 	// Create a source directory with 1 of the 2 artifacts
 	srcdir, err := ioutil.TempDir("", "nomadtest-src")

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -64,7 +64,7 @@ func (tr *TaskRunner) initHooks() {
 		newLogMonHook(tr, hookLogger),
 		newDispatchHook(alloc, hookLogger),
 		newVolumeHook(tr, hookLogger),
-		newArtifactHook(tr, hookLogger),
+		newArtifactHook(tr, tr.clientConfig.ArtifactCachingPath, hookLogger),
 		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, hookLogger),
 		newDeviceHook(tr.devicemanager, hookLogger),
 	}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -245,6 +245,10 @@ type Config struct {
 
 	// HostVolumes is a map of the configured host volumes by name.
 	HostVolumes map[string]*structs.ClientHostVolumeConfig
+
+	// ArtifactCachingPath is the path to folder used to cache artifact downloads.
+	// A single path can be provided that defaults to "" (i.e. no caching) if not set
+	ArtifactCachingPath string
 }
 
 type ClientTemplateConfig struct {
@@ -301,6 +305,7 @@ func DefaultConfig() *Config {
 		},
 		BackwardsCompatibleMetrics: false,
 		RPCHoldTimeout:             5 * time.Second,
+		ArtifactCachingPath:        "",
 	}
 }
 


### PR DESCRIPTION
To use Nomad without always depending on the artifact source being available (or when looking to increase efficiency) using a local cache for artifacts helps. This aims to cover #5217

This is my first contribution to a golang open source project, please let me know if I am missing any steps or my approach is not idiomatic.