### PR TITLE
csi: ensure GET for plugin is idempotent

### DIFF
--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -459,7 +459,7 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 			}
 
 			if plug != nil {
-				plug, err = state.CSIPluginDenormalize(ws, plug)
+				plug, err = state.CSIPluginDenormalize(ws, plug.Copy())
 			}
 			if err != nil {
 				return err

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -517,6 +517,11 @@ func TestCSIPluginEndpoint_RegisterViaFingerprint(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(resp3.Plugins))
 
+	// ensure that plugin->alloc denormalization does COW correctly
+	err = msgpackrpc.CallWithCodec(codec, "CSIPlugin.List", req3, resp3)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(resp3.Plugins))
+
 	// Deregistration works
 	deleteNodes()
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7295

We denormalize the `CSIPlugin` struct when we query it from the state store by getting the current set of allocations that provide the plugin. But unless we copy the plugin, this denormalization gets synced back to the state store and each time we query we'll add another copy of the current allocations.