### PR TITLE
updated /agent/monitor query parameter

### DIFF
--- a/website/pages/api-docs/agent.mdx
+++ b/website/pages/api-docs/agent.mdx
@@ -519,7 +519,7 @@ The table below shows this endpoint's support for
   to filter on, such as `info`. Possible values include `trace`, `debug`,
   `info`, `warn`, `error`
 
-- `json` `(bool: false)` - Specifies if the log format for streamed logs
+- `log_json` `(bool: false)` - Specifies if the log format for streamed logs
   should be JSON.
 
 - `node_id` `(string: "a57b2adb-1a30-2dda-8df0-25abb0881952")` - Specifies a text


### PR DESCRIPTION
query param is `log_json`, not `json`