### PR TITLE
csi: ensure volume query is idempotent

### DIFF
--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -134,7 +134,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 				}
 
 				vol := raw.(*structs.CSIVolume)
-				vol, err := state.CSIVolumeDenormalizePlugins(ws, vol)
+				vol, err := state.CSIVolumeDenormalizePlugins(ws, vol.Copy())
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
We denormalize the `CSIVolume` struct when we query it from the state store by getting the plugin and its health. But unless we copy the volume, this denormalization gets synced back to the state store without passing through the fsm (which is invalid).