### PR TITLE
docs: explicitly detail IAM instance profile S3 artifact auth.

### DIFF
--- a/website/pages/docs/job-specification/artifact.mdx
+++ b/website/pages/docs/job-specification/artifact.mdx
@@ -152,8 +152,9 @@ artifact {
 }
 ```
 
-If a bucket requires authentication, it may be supplied via the `options`
-parameter:
+If a bucket requires authentication, you can avoid the use of credentials by
+using [EC2 IAM instance profiles][iam-instance-profiles]. If this is not possible,
+credentials may be supplied via the `options` parameter:
 
 ```hcl
 artifact {
@@ -185,3 +186,4 @@ artifact {
 [minio]: https://www.minio.io/
 [s3-bucket-addr]: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro 'Amazon S3 Bucket Addressing'
 [s3-region-endpoints]: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region 'Amazon S3 Region Endpoints'
+[iam-instance-profiles]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html 'EC2 IAM instance profiles'


### PR DESCRIPTION
Previously the S3 artifact documentation only referenced using
options populated with access credentails when pulling from a
bucket that required authentication. This change upadtes the doc
to also detail using IAM instance profiles.

closes #7294 