### PR TITLE
csi: volumes listed in `nomad node status`

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -507,18 +507,23 @@ func (a AllocIndexSort) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 
+func (a Allocation) GetTaskGroup() *TaskGroup {
+	for _, tg := range a.Job.TaskGroups {
+		if *tg.Name == a.TaskGroup {
+			return tg
+		}
+	}
+	return nil
+}
+
 // RescheduleInfo is used to calculate remaining reschedule attempts
 // according to the given time and the task groups reschedule policy
 func (a Allocation) RescheduleInfo(t time.Time) (int, int) {
-	var reschedulePolicy *ReschedulePolicy
-	for _, tg := range a.Job.TaskGroups {
-		if *tg.Name == a.TaskGroup {
-			reschedulePolicy = tg.ReschedulePolicy
-		}
-	}
-	if reschedulePolicy == nil {
+	tg := a.GetTaskGroup()
+	if tg == nil || tg.ReschedulePolicy == nil {
 		return 0, 0
 	}
+	reschedulePolicy := tg.ReschedulePolicy
 	availableAttempts := *reschedulePolicy.Attempts
 	interval := *reschedulePolicy.Interval
 	attempted := 0

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -392,6 +392,16 @@ func (n *Nodes) Allocations(nodeID string, q *QueryOptions) ([]*Allocation, *Que
 	return resp, qm, nil
 }
 
+func (n *Nodes) CSIVolumes(nodeID string, q *QueryOptions) ([]*CSIVolumeListStub, error) {
+	var resp []*CSIVolumeListStub
+	path := fmt.Sprintf("/v1/csi/volumes?node_id=%s", nodeID)
+	if _, err := n.client.query(path, &resp, q); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
 // ForceEvaluate is used to force-evaluate an existing node.
 func (n *Nodes) ForceEvaluate(nodeID string, q *WriteOptions) (string, *WriteMeta, error) {
 	var resp nodeEvalResponse

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -18,6 +18,14 @@ func (s *HTTPServer) CSIVolumesRequest(resp http.ResponseWriter, req *http.Reque
 		return nil, nil
 	}
 
+	query := req.URL.Query()
+	if plugin, ok := query["plugin_id"]; ok {
+		args.PluginID = plugin[0]
+	}
+	if node, ok := query["node_id"]; ok {
+		args.NodeID = node[0]
+	}
+
 	var out structs.CSIVolumeListResponse
 	if err := s.agent.RPC("CSIVolume.List", &args, &out); err != nil {
 		return nil, err

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -553,6 +553,9 @@ func (c *NodeStatusCommand) outputNodeCSIVolumeInfo(client *api.Client, node *ap
 			volNames[v.Source] = v.Name
 		}
 	}
+	if len(names) == 0 {
+		return
+	}
 	sort.Strings(names)
 
 	// Fetch the volume objects with current status
@@ -566,15 +569,16 @@ func (c *NodeStatusCommand) outputNodeCSIVolumeInfo(client *api.Client, node *ap
 
 	// Output the volumes in name order
 	output := make([]string, 0, len(names)+1)
-	output = append(output, "ID|Name|Plugin ID|Schedulable|Access Mode")
+	output = append(output, "ID|Name|Plugin ID|Schedulable|Provider|Access Mode")
 	for _, name := range names {
 		v := volumes[name]
 		output = append(output, fmt.Sprintf(
-			"%s|%s|%s|%t|%s",
+			"%s|%s|%s|%t|%s|%s",
 			v.ID,
 			name,
 			v.PluginID,
 			v.Schedulable,
+			v.Provider,
 			v.AccessMode,
 		))
 	}

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -317,6 +317,22 @@ func nodeCSINodeNames(n *api.Node) []string {
 	return names
 }
 
+func nodeCSIVolumeNames(n *api.Node, allocs []*api.Allocation) []string {
+	var names []string
+	for _, alloc := range allocs {
+		tg := alloc.GetTaskGroup()
+		if tg == nil || len(tg.Volumes) == 0 {
+			continue
+		}
+
+		for _, v := range tg.Volumes {
+			names = append(names, v.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 func nodeVolumeNames(n *api.Node) []string {
 	var volumes []string
 	for name := range n.HostVolumes {
@@ -349,6 +365,20 @@ func formatDrain(n *api.Node) string {
 }
 
 func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
+	// Make one API call for allocations
+	nodeAllocs, _, err := client.Nodes().Allocations(node.ID, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying node allocations: %s", err))
+		return 1
+	}
+
+	var runningAllocs []*api.Allocation
+	for _, alloc := range nodeAllocs {
+		if alloc.ClientStatus == "running" {
+			runningAllocs = append(runningAllocs, alloc)
+		}
+	}
+
 	// Format the header output
 	basic := []string{
 		fmt.Sprintf("ID|%s", node.ID),
@@ -364,11 +394,12 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 
 	if c.short {
 		basic = append(basic, fmt.Sprintf("Host Volumes|%s", strings.Join(nodeVolumeNames(node), ",")))
+		basic = append(basic, fmt.Sprintf("CSI Volumes|%s", strings.Join(nodeCSIVolumeNames(node, runningAllocs), ",")))
 		basic = append(basic, fmt.Sprintf("Drivers|%s", strings.Join(nodeDrivers(node), ",")))
 		c.Ui.Output(c.Colorize().Color(formatKV(basic)))
 
 		// Output alloc info
-		if err := c.outputAllocInfo(client, node); err != nil {
+		if err := c.outputAllocInfo(node, nodeAllocs); err != nil {
 			c.Ui.Error(fmt.Sprintf("%s", err))
 			return 1
 		}
@@ -409,12 +440,6 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 	c.outputNodeStatusEvents(node)
 
 	// Get list of running allocations on the node
-	runningAllocs, err := getRunningAllocs(client, node.ID)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error querying node for running allocations: %s", err))
-		return 1
-	}
-
 	allocatedResources := getAllocatedResources(client, runningAllocs, node)
 	c.Ui.Output(c.Colorize().Color("\n[bold]Allocated Resources[reset]"))
 	c.Ui.Output(formatList(allocatedResources))
@@ -452,7 +477,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		}
 	}
 
-	if err := c.outputAllocInfo(client, node); err != nil {
+	if err := c.outputAllocInfo(node, nodeAllocs); err != nil {
 		c.Ui.Error(fmt.Sprintf("%s", err))
 		return 1
 	}
@@ -460,12 +485,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 	return 0
 }
 
-func (c *NodeStatusCommand) outputAllocInfo(client *api.Client, node *api.Node) error {
-	nodeAllocs, _, err := client.Nodes().Allocations(node.ID, nil)
-	if err != nil {
-		return fmt.Errorf("Error querying node allocations: %s", err)
-	}
-
+func (c *NodeStatusCommand) outputAllocInfo(node *api.Node, nodeAllocs []*api.Allocation) error {
 	c.Ui.Output(c.Colorize().Color("\n[bold]Allocations[reset]"))
 	c.Ui.Output(formatAllocList(nodeAllocs, c.verbose, c.length))
 

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -112,12 +112,11 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 			// Query all volumes
 			var err error
 			var iter memdb.ResultIterator
-			var vols []*structs.CSIVolume
 
-			if args.PluginID != "" {
+			if args.NodeID != "" {
+				iter, err = state.CSIVolumesByNodeID(ws, args.NodeID)
+			} else if args.PluginID != "" {
 				iter, err = state.CSIVolumesByPluginID(ws, args.PluginID)
-			} else if args.NodeID != "" {
-				vols, err = state.CSIVolumesByNodeID(ws, args.PluginID)
 			} else {
 				iter, err = state.CSIVolumes(ws)
 			}
@@ -127,33 +126,28 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 			}
 
 			// Collect results, filter by ACL access
-			var vol *structs.CSIVolume
 			var vs []*structs.CSIVolListStub
 			cache := map[string]bool{}
-			i := 0
 
 			for {
-				// Iterate through either the iterator or the slice of volumes
-				if iter != nil {
-					raw := iter.Next()
-					if raw == nil {
-						break
-					}
+				raw := iter.Next()
+				if raw == nil {
+					break
+				}
 
-					vol = raw.(*structs.CSIVolume)
-					vol, err = state.CSIVolumeDenormalizePlugins(ws, vol.Copy())
-					if err != nil {
-						return err
-					}
-				} else {
-					if i == len(vs) {
-						break
-					}
-					vol = vols[i]
+				vol := raw.(*structs.CSIVolume)
+				vol, err := state.CSIVolumeDenormalizePlugins(ws, vol.Copy())
+				if err != nil {
+					return err
 				}
 
 				// Filter on the request namespace to avoid ACL checks by volume
 				if ns != "" && vol.Namespace != args.RequestNamespace() {
+					continue
+				}
+
+				// Filter (possibly again) on PluginID to handle passing both NodeID and PluginID
+				if args.PluginID != "" && args.PluginID != vol.PluginID {
 					continue
 				}
 

--- a/nomad/state/iterator.go
+++ b/nomad/state/iterator.go
@@ -1,0 +1,30 @@
+package state
+
+type SliceIterator struct {
+	data []interface{}
+	idx  int
+}
+
+func NewSliceIterator() *SliceIterator {
+	return &SliceIterator{
+		data: []interface{}{},
+		idx:  0,
+	}
+}
+
+func (i *SliceIterator) Add(datum interface{}) {
+	i.data = append(i.data, datum)
+}
+
+func (i *SliceIterator) Next() interface{} {
+	if i.idx == len(i.data) {
+		return nil
+	}
+	idx := i.idx
+	i.idx += 1
+	return i.data[idx]
+}
+
+func (i *SliceIterator) WatchCh() <-chan struct{} {
+	return nil
+}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1718,12 +1718,12 @@ func (s *StateStore) CSIVolumesByNodeID(ws memdb.WatchSet, nodeID string) (memdb
 	}
 	snap, err := s.Snapshot()
 	if err != nil {
-		return nil, fmt.Errorf("snapshot failed: %v", err)
+		return nil, fmt.Errorf("alloc lookup failed: %v", err)
 	}
 
 	allocs, err = snap.DenormalizeAllocationSlice(allocs)
 	if err != nil {
-		return nil, fmt.Errorf("alloc denormalize failed: %v", err)
+		return nil, fmt.Errorf("alloc lookup failed: %v", err)
 	}
 
 	// Find volume ids for CSI volumes in running allocs, or allocs that we desire to run

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -449,6 +449,7 @@ type CSIVolumeClaimResponse struct {
 
 type CSIVolumeListRequest struct {
 	PluginID string
+	NodeID   string
 	QueryOptions
 }
 


### PR DESCRIPTION
Fixes #6991 For consideration: we show `Schedulable` in the verbose status, which is maybe a bit confusing in this context?