### PR TITLE
csi: change the API paths to match CLI command layout

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -18,7 +18,7 @@ func (c *Client) CSIVolumes() *CSIVolumes {
 // List returns all CSI volumes
 func (v *CSIVolumes) List(q *QueryOptions) ([]*CSIVolumeListStub, *QueryMeta, error) {
 	var resp []*CSIVolumeListStub
-	qm, err := v.client.query("/v1/csi/volumes", &resp, q)
+	qm, err := v.client.query("/v1/volumes?type=csi", &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -34,7 +34,7 @@ func (v *CSIVolumes) PluginList(pluginID string) ([]*CSIVolumeListStub, *QueryMe
 // Info is used to retrieve a single CSIVolume
 func (v *CSIVolumes) Info(id string, q *QueryOptions) (*CSIVolume, *QueryMeta, error) {
 	var resp CSIVolume
-	qm, err := v.client.query("/v1/csi/volume/"+id, &resp, q)
+	qm, err := v.client.query("/v1/volume/csi/"+id, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -49,12 +49,12 @@ func (v *CSIVolumes) Register(vol *CSIVolume, w *WriteOptions) (*WriteMeta, erro
 	req := CSIVolumeRegisterRequest{
 		Volumes: []*CSIVolume{vol},
 	}
-	meta, err := v.client.write("/v1/csi/volume/"+vol.ID, req, nil, w)
+	meta, err := v.client.write("/v1/volume/csi/"+vol.ID, req, nil, w)
 	return meta, err
 }
 
 func (v *CSIVolumes) Deregister(id string, w *WriteOptions) error {
-	_, err := v.client.delete("/v1/csi/volume/"+id, nil, w)
+	_, err := v.client.delete("/v1/volume/csi/"+id, nil, w)
 	return err
 }
 
@@ -229,7 +229,7 @@ func (c *Client) CSIPlugins() *CSIPlugins {
 // List returns all CSI plugins
 func (v *CSIPlugins) List(q *QueryOptions) ([]*CSIPluginListStub, *QueryMeta, error) {
 	var resp []*CSIPluginListStub
-	qm, err := v.client.query("/v1/csi/plugins", &resp, q)
+	qm, err := v.client.query("/v1/plugins?type=csi", &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -240,7 +240,7 @@ func (v *CSIPlugins) List(q *QueryOptions) ([]*CSIPluginListStub, *QueryMeta, er
 // Info is used to retrieve a single CSI Plugin Job
 func (v *CSIPlugins) Info(id string, q *QueryOptions) (*CSIPlugin, *QueryMeta, error) {
 	var resp *CSIPlugin
-	qm, err := v.client.query("/v1/csi/plugin/"+id, &resp, q)
+	qm, err := v.client.query("/v1/plugin/csi/"+id, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -394,7 +394,7 @@ func (n *Nodes) Allocations(nodeID string, q *QueryOptions) ([]*Allocation, *Que
 
 func (n *Nodes) CSIVolumes(nodeID string, q *QueryOptions) ([]*CSIVolumeListStub, error) {
 	var resp []*CSIVolumeListStub
-	path := fmt.Sprintf("/v1/csi/volumes?node_id=%s", nodeID)
+	path := fmt.Sprintf("/v1/volumes/csi?type=csi&node_id=%s", nodeID)
 	if _, err := n.client.query(path, &resp, q); err != nil {
 		return nil, err
 	}

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -394,7 +394,7 @@ func (n *Nodes) Allocations(nodeID string, q *QueryOptions) ([]*Allocation, *Que
 
 func (n *Nodes) CSIVolumes(nodeID string, q *QueryOptions) ([]*CSIVolumeListStub, error) {
 	var resp []*CSIVolumeListStub
-	path := fmt.Sprintf("/v1/volumes/csi?type=csi&node_id=%s", nodeID)
+	path := fmt.Sprintf("/v1/volumes?type=csi&node_id=%s", nodeID)
 	if _, err := n.client.query(path, &resp, q); err != nil {
 		return nil, err
 	}

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -17,11 +17,12 @@ func (s *HTTPServer) CSIVolumesRequest(resp http.ResponseWriter, req *http.Reque
 	// Type filters volume lists to a specific type. When support for non-CSI volumes is
 	// introduced, we'll need to dispatch here
 	query := req.URL.Query()
-	if qtype, ok := query["type"]; !ok {
+	qtype, ok := query["type"]
+	if !ok {
 		return nil, CodedError(400, errRequiresType)
-		if qtype[0] != "csi" {
-			return nil, nil
-		}
+	}
+	if qtype[0] != "csi" {
+		return nil, nil
 	}
 
 	args := structs.CSIVolumeListRequest{}
@@ -143,11 +144,12 @@ func (s *HTTPServer) CSIPluginsRequest(resp http.ResponseWriter, req *http.Reque
 	// Type filters plugin lists to a specific type. When support for non-CSI plugins is
 	// introduced, we'll need to dispatch here
 	query := req.URL.Query()
-	if qtype, ok := query["type"]; !ok {
+	qtype, ok := query["type"]
+	if !ok {
 		return nil, CodedError(400, errRequiresType)
-		if qtype[0] != "csi" {
-			return nil, nil
-		}
+	}
+	if qtype[0] != "csi" {
+		return nil, nil
 	}
 
 	args := structs.CSIPluginListRequest{}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -253,10 +253,10 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/deployments", s.wrap(s.DeploymentsRequest))
 	s.mux.HandleFunc("/v1/deployment/", s.wrap(s.DeploymentSpecificRequest))
 
-	s.mux.HandleFunc("/v1/csi/volumes", s.wrap(s.CSIVolumesRequest))
-	s.mux.HandleFunc("/v1/csi/volume/", s.wrap(s.CSIVolumeSpecificRequest))
-	s.mux.HandleFunc("/v1/csi/plugins", s.wrap(s.CSIPluginsRequest))
-	s.mux.HandleFunc("/v1/csi/plugin/", s.wrap(s.CSIPluginSpecificRequest))
+	s.mux.HandleFunc("/v1/volumes", s.wrap(s.CSIVolumesRequest))
+	s.mux.HandleFunc("/v1/volume/csi/", s.wrap(s.CSIVolumeSpecificRequest))
+	s.mux.HandleFunc("/v1/plugins", s.wrap(s.CSIPluginsRequest))
+	s.mux.HandleFunc("/v1/plugin/csi/", s.wrap(s.CSIPluginSpecificRequest))
 
 	s.mux.HandleFunc("/v1/acl/policies", s.wrap(s.ACLPoliciesRequest))
 	s.mux.HandleFunc("/v1/acl/policy/", s.wrap(s.ACLPolicySpecificRequest))


### PR DESCRIPTION
Change the CSI API endpoints to `/v1/volumes` and `/v1/volume/csi/id` to match the layout of the CLI, and the same for plugin endpoints. We're using a required `type` filter parameter for the list endpoints.

Fixes #7321