### PR TITLE
csi: use `ExternalID`, when set, to identify volumes for outside RPC calls

### DIFF
--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -181,7 +181,7 @@ func (v *volumeManager) publishVolume(ctx context.Context, vol *structs.CSIVolum
 	}
 
 	err = v.plugin.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
-		VolumeID:          vol.ID,
+		VolumeID:          vol.RemoteID(),
 		PublishContext:    publishContext,
 		StagingTargetPath: pluginStagingPath,
 		TargetPath:        pluginTargetPath,

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -247,7 +247,7 @@ func (srv *Server) controllerValidateVolume(req *structs.CSIVolumeRegisterReques
 
 	method := "ClientCSIController.ValidateVolume"
 	cReq := &cstructs.ClientCSIControllerValidateVolumeRequest{
-		VolumeID:       vol.ID,
+		VolumeID:       vol.RemoteID(),
 		AttachmentMode: vol.AttachmentMode,
 		AccessMode:     vol.AccessMode,
 	}
@@ -532,7 +532,7 @@ func (srv *Server) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, r
 
 	method := "ClientCSIController.AttachVolume"
 	cReq := &cstructs.ClientCSIControllerAttachVolumeRequest{
-		VolumeID:        req.VolumeID,
+		VolumeID:        vol.RemoteID(),
 		ClientCSINodeID: targetCSIInfo.NodeInfo.ID,
 		AttachmentMode:  vol.AttachmentMode,
 		AccessMode:      vol.AccessMode,
@@ -587,7 +587,7 @@ func (srv *Server) controllerUnpublishVolume(req *structs.CSIVolumeClaimRequest,
 
 	method := "ClientCSIController.DetachVolume"
 	cReq := &cstructs.ClientCSIControllerDetachVolumeRequest{
-		VolumeID:        req.VolumeID,
+		VolumeID:        vol.RemoteID(),
 		ClientCSINodeID: targetCSIInfo.NodeInfo.ID,
 	}
 	cReq.PluginID = plug.ID

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -212,6 +212,13 @@ func (v *CSIVolume) newStructs() {
 	v.WriteAllocs = map[string]*Allocation{}
 }
 
+func (v *CSIVolume) RemoteID() string {
+	if v.ExternalID != "" {
+		return v.ExternalID
+	}
+	return v.ID
+}
+
 func (v *CSIVolume) Stub() *CSIVolListStub {
 	stub := CSIVolListStub{
 		ID:                 v.ID,


### PR DESCRIPTION
`ExternalID` remains optional, but when set we'll use it to for `VolumeId` in calls to the CSI plugin implementations. Testing the outgoing calls is challenging, the highest value test seems to be using this field for one of the e2e tests #7316 

closes #7302 