### PR TITLE
csi: docstring and log message fixups

### DIFF
--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -186,7 +186,7 @@ WAITFORREADY:
 		case <-t.C:
 			pluginHealthy, err := h.supervisorLoopOnce(ctx, socketPath)
 			if err != nil || !pluginHealthy {
-				h.logger.Info("CSI Plugin not ready", "error", err)
+				h.logger.Debug("CSI Plugin not ready", "error", err)
 
 				// Plugin is not yet returning healthy, because we want to optimise for
 				// quickly bringing a plugin online, we use a short timeout here.

--- a/client/devicemanager/manager.go
+++ b/client/devicemanager/manager.go
@@ -128,7 +128,7 @@ func New(c *Config) *manager {
 // PluginType identifies this manager to the plugin manager and satisfies the PluginManager interface.
 func (*manager) PluginType() string { return base.PluginTypeDevice }
 
-// Run starts thed device manager. The manager will shutdown any previously
+// Run starts the device manager. The manager will shutdown any previously
 // launched plugin and then begin fingerprinting and stats collection on all new
 // device plugins.
 func (m *manager) Run() {

--- a/client/devicemanager/state/state.go
+++ b/client/devicemanager/state/state.go
@@ -2,10 +2,10 @@ package state
 
 import pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
 
-// PluginState is used to store the device managers state across restarts of the
+// PluginState is used to store the device manager's state across restarts of the
 // agent
 type PluginState struct {
-	// ReattachConfigs are the set of reattach configs for plugin's launched by
+	// ReattachConfigs are the set of reattach configs for plugins launched by
 	// the device manager
 	ReattachConfigs map[string]*pstructs.ReattachConfig
 }

--- a/client/pluginmanager/drivermanager/state/state.go
+++ b/client/pluginmanager/drivermanager/state/state.go
@@ -2,10 +2,10 @@ package state
 
 import pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
 
-// PluginState is used to store the driver managers state across restarts of the
+// PluginState is used to store the driver manager's state across restarts of the
 // agent
 type PluginState struct {
-	// ReattachConfigs are the set of reattach configs for plugin's launched by
+	// ReattachConfigs are the set of reattach configs for plugins launched by
 	// the driver manager
 	ReattachConfigs map[string]*pstructs.ReattachConfig
 }

--- a/client/state/state_database.go
+++ b/client/state/state_database.go
@@ -34,7 +34,7 @@ devicemanager/
 |--> plugin_state -> *dmstate.PluginState
 
 drivermanager/
-|--> plugin_state -> *dmstate.PluginState
+|--> plugin_state -> *driverstate.PluginState
 */
 
 var (


### PR DESCRIPTION
Found a few items while working on #7200 that I don't want to include in a more meaty PR. This fixes a few typos in our docstrings and reduces the log noise during client restarts. A log for the common case where the plugin socket isn't ready yet isn't actionable by the operator so having it at info is just noise.