### PR TITLE
csi: make claims on volumes idempotent for the same alloc

### DIFF
--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -291,6 +291,10 @@ func (v *CSIVolume) Claim(claim CSIVolumeClaimMode, alloc *Allocation) bool {
 
 // ClaimRead marks an allocation as using a volume read-only
 func (v *CSIVolume) ClaimRead(alloc *Allocation) bool {
+	if _, ok := v.ReadAllocs[alloc.ID]; ok {
+		return true
+	}
+
 	if !v.CanReadOnly() {
 		return false
 	}
@@ -303,6 +307,10 @@ func (v *CSIVolume) ClaimRead(alloc *Allocation) bool {
 
 // ClaimWrite marks an allocation as using a volume as a writer
 func (v *CSIVolume) ClaimWrite(alloc *Allocation) bool {
+	if _, ok := v.WriteAllocs[alloc.ID]; ok {
+		return true
+	}
+
 	if !v.CanWrite() {
 		return false
 	}

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -11,7 +11,8 @@ func TestCSIVolumeClaim(t *testing.T) {
 	vol.AccessMode = CSIVolumeAccessModeMultiNodeSingleWriter
 	vol.Schedulable = true
 
-	alloc := &Allocation{ID: "al"}
+	alloc := &Allocation{ID: "a1"}
+	alloc2 := &Allocation{ID: "a2"}
 
 	vol.ClaimRead(alloc)
 	require.True(t, vol.CanReadOnly())
@@ -21,7 +22,7 @@ func TestCSIVolumeClaim(t *testing.T) {
 	vol.ClaimWrite(alloc)
 	require.True(t, vol.CanReadOnly())
 	require.False(t, vol.CanWrite())
-	require.False(t, vol.ClaimWrite(alloc))
+	require.False(t, vol.ClaimWrite(alloc2))
 
 	vol.ClaimRelease(alloc)
 	require.True(t, vol.CanReadOnly())


### PR DESCRIPTION
This is a partial fix for https://github.com/hashicorp/nomad/issues/7200

Nomad clients will push node updates during client restart which can cause an extra claim for a volume by the same alloc. If an alloc already claims a volume, we can allow it to be treated as a valid claim and continue.