### PR TITLE
csi: add dynamicplugins registry to client state store

### DIFF
--- a/client/pluginmanager/csimanager/manager.go
+++ b/client/pluginmanager/csimanager/manager.go
@@ -85,6 +85,9 @@ func (c *csiManager) MounterForVolume(ctx context.Context, vol *structs.CSIVolum
 
 // Run starts a plugin manager and should return early
 func (c *csiManager) Run() {
+	// Ensure we have at least one full sync before starting
+	c.resyncPluginsFromRegistry("csi-controller")
+	c.resyncPluginsFromRegistry("csi-node")
 	go c.runLoop()
 }
 

--- a/client/pluginmanager/csimanager/manager_test.go
+++ b/client/pluginmanager/csimanager/manager_test.go
@@ -21,6 +21,7 @@ var fakePlugin = &dynamicplugins.PluginInfo{
 
 func setupRegistry() dynamicplugins.Registry {
 	return dynamicplugins.NewRegistry(
+		nil,
 		map[string]dynamicplugins.PluginDispenser{
 			"csi-controller": func(*dynamicplugins.PluginInfo) (interface{}, error) {
 				return nil, nil

--- a/client/state/db_test.go
+++ b/client/state/db_test.go
@@ -8,6 +8,7 @@ import (
 
 	trstate "github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -232,6 +233,31 @@ func TestStateDB_DriverManager(t *testing.T) {
 
 		// Getting should return the available state
 		ps, err = db.GetDriverPluginState()
+		require.NoError(err)
+		require.NotNil(ps)
+		require.Equal(state, ps)
+	})
+}
+
+// TestStateDB_DynamicRegistry asserts the behavior of dynamic registry state related StateDB
+// methods.
+func TestStateDB_DynamicRegistry(t *testing.T) {
+	t.Parallel()
+
+	testDB(t, func(t *testing.T, db StateDB) {
+		require := require.New(t)
+
+		// Getting nonexistent state should return nils
+		ps, err := db.GetDynamicPluginRegistryState()
+		require.NoError(err)
+		require.Nil(ps)
+
+		// Putting PluginState should work
+		state := &dynamicplugins.RegistryState{}
+		require.NoError(db.PutDynamicPluginRegistryState(state))
+
+		// Getting should return the available state
+		ps, err = db.GetDynamicPluginRegistryState()
 		require.NoError(err)
 		require.NotNil(ps)
 		require.Equal(state, ps)

--- a/client/state/interface.go
+++ b/client/state/interface.go
@@ -3,6 +3,7 @@ package state
 import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -68,6 +69,12 @@ type StateDB interface {
 	// PutDriverPluginState is used to store the driver manager's plugin
 	// state.
 	PutDriverPluginState(state *driverstate.PluginState) error
+
+	// GetDynamicPluginRegistryState is used to retrieve a dynamic plugin manager's state.
+	GetDynamicPluginRegistryState() (*dynamicplugins.RegistryState, error)
+
+	// PutDynamicPluginRegistryState is used to store the dynamic plugin managers's state.
+	PutDynamicPluginRegistryState(state *dynamicplugins.RegistryState) error
 
 	// Close the database. Unsafe for further use after calling regardless
 	// of return value.

--- a/client/state/memdb.go
+++ b/client/state/memdb.go
@@ -6,6 +6,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -28,6 +29,9 @@ type MemDB struct {
 
 	// drivermanager -> plugin-state
 	driverManagerPs *driverstate.PluginState
+
+	// dynamicmanager -> registry-state
+	dynamicManagerPs *dynamicplugins.RegistryState
 
 	logger hclog.Logger
 
@@ -190,6 +194,19 @@ func (m *MemDB) PutDriverPluginState(ps *driverstate.PluginState) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.driverManagerPs = ps
+	return nil
+}
+
+func (m *MemDB) GetDynamicPluginRegistryState() (*dynamicplugins.RegistryState, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.dynamicManagerPs, nil
+}
+
+func (m *MemDB) PutDynamicPluginRegistryState(ps *dynamicplugins.RegistryState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dynamicManagerPs = ps
 	return nil
 }
 

--- a/client/state/noopdb.go
+++ b/client/state/noopdb.go
@@ -3,6 +3,7 @@ package state
 import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -67,6 +68,14 @@ func (n NoopDB) PutDriverPluginState(ps *driverstate.PluginState) error {
 }
 
 func (n NoopDB) GetDriverPluginState() (*driverstate.PluginState, error) {
+	return nil, nil
+}
+
+func (n NoopDB) PutDynamicPluginRegistryState(ps *dynamicplugins.RegistryState) error {
+	return nil
+}
+
+func (n NoopDB) GetDynamicPluginRegistryState() (*dynamicplugins.RegistryState, error) {
 	return nil, nil
 }
 

--- a/client/state/state_database.go
+++ b/client/state/state_database.go
@@ -11,6 +11,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	trstate "github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/helper/boltdd"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -35,6 +36,9 @@ devicemanager/
 
 drivermanager/
 |--> plugin_state -> *driverstate.PluginState
+
+dynamicplugins/
+|--> registry_state -> *dynamicplugins.RegistryState
 */
 
 var (
@@ -73,13 +77,20 @@ var (
 	// data
 	devManagerBucket = []byte("devicemanager")
 
-	// driverManagerBucket is the bucket name container all driver manager
+	// driverManagerBucket is the bucket name containing all driver manager
 	// related data
 	driverManagerBucket = []byte("drivermanager")
 
 	// managerPluginStateKey is the key by which plugin manager plugin state is
 	// stored at
 	managerPluginStateKey = []byte("plugin_state")
+
+	// dynamicPluginBucket is the bucket name containing all dynamic plugin
+	// registry data. each dynamic plugin registry will have its own subbucket.
+	dynamicPluginBucket = []byte("dynamicplugins")
+
+	// registryStateKey is the key at which dynamic plugin registry state is stored
+	registryStateKey = []byte("registry_state")
 )
 
 // taskBucketName returns the bucket name for the given task name.
@@ -582,6 +593,52 @@ func (s *BoltStateDB) GetDriverPluginState() (*driverstate.PluginState, error) {
 		if err := driverBkt.Get(managerPluginStateKey, ps); err != nil {
 			if !boltdd.IsErrNotFound(err) {
 				return fmt.Errorf("failed to read driver manager plugin state: %v", err)
+			}
+
+			// Key not found, reset ps to nil
+			ps = nil
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ps, nil
+}
+
+// PutDynamicPluginRegistryState stores the dynamic plugin registry's
+// state or returns an error.
+func (s *BoltStateDB) PutDynamicPluginRegistryState(ps *dynamicplugins.RegistryState) error {
+	return s.db.Update(func(tx *boltdd.Tx) error {
+		// Retrieve the root dynamic plugin manager bucket
+		dynamicBkt, err := tx.CreateBucketIfNotExists(dynamicPluginBucket)
+		if err != nil {
+			return err
+		}
+		return dynamicBkt.Put(registryStateKey, ps)
+	})
+}
+
+// GetDynamicPluginRegistryState stores the dynamic plugin registry's
+// registry state or returns an error.
+func (s *BoltStateDB) GetDynamicPluginRegistryState() (*dynamicplugins.RegistryState, error) {
+	var ps *dynamicplugins.RegistryState
+
+	err := s.db.View(func(tx *boltdd.Tx) error {
+		dynamicBkt := tx.Bucket(dynamicPluginBucket)
+		if dynamicBkt == nil {
+			// No state, return
+			return nil
+		}
+
+		// Restore Plugin State if it exists
+		ps = &dynamicplugins.RegistryState{}
+		if err := dynamicBkt.Get(registryStateKey, ps); err != nil {
+			if !boltdd.IsErrNotFound(err) {
+				return fmt.Errorf("failed to read dynamic plugin registry state: %v", err)
 			}
 
 			// Key not found, reset ps to nil


### PR DESCRIPTION
This is another piece of the fix for #7200 and will also lay the groundwork for #7296 which I'll be fixing under a separate PR.

In order to correctly fingerprint dynamic plugins on client restarts, we need to persist a handle to the plugin (that is, connection info) to the client state store. The dynamic registry will sync automatically to the client state whenever it receives a register/deregister call.