### PR TITLE
docs: add some links to the acl guide

### DIFF
--- a/website/pages/docs/commands/acl/index.mdx
+++ b/website/pages/docs/commands/acl/index.mdx
@@ -8,7 +8,9 @@ description: |
 
 # Command: acl
 
-The `acl` command is used to interact with ACL policies and tokens.
+The `acl` command is used to interact with ACL policies and tokens. Learn more
+about using Nomad's ACL system in the [Secure Nomad with Access Control
+guide][secure-guide].
 
 ## Usage
 
@@ -38,3 +40,4 @@ subcommands are available:
 [tokendelete]: /docs/commands/acl/token-delete
 [tokeninfo]: /docs/commands/acl/token-info
 [tokenself]: /docs/commands/acl/token-self
+[secure-guide]: https://learn.hashicorp.com/nomad/acls/fundamentals

--- a/website/pages/docs/configuration/acl.mdx
+++ b/website/pages/docs/configuration/acl.mdx
@@ -11,7 +11,9 @@ description: >-
 
 <Placement groups={['acl']} />
 
-The `acl` stanza configures the Nomad agent to enable ACLs and tunes various ACL parameters.
+The `acl` stanza configures the Nomad agent to enable ACLs and tunes various
+ACL parameters. Learn more about configuring Nomad's ACL system in the [Secure
+Nomad with Access Control guide][secure-guide].
 
 ```hcl
 acl {
@@ -41,3 +43,5 @@ acl {
 - `replication_token` `(string: "")` - Specifies the Secret ID of the ACL token
   to use for replicating policies and tokens. This is used by servers in non-authoritative
   region to mirror the policies and tokens into the local region.
+
+[secure-guide]: https://learn.hashicorp.com/nomad/acls/fundamentals


### PR DESCRIPTION
ACL APIs already have osme links, but the command and configuration
pages did not.