### PR TITLE
UI: Facet for host volumes

### DIFF
--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -2663,6 +2663,13 @@ func TestClientEndpoint_ListNodes(t *testing.T) {
 
 	// Create the register request
 	node := mock.Node()
+	node.HostVolumes = map[string]*structs.ClientHostVolumeConfig{
+		"foo": {
+			Name:     "foo",
+			Path:     "/",
+			ReadOnly: true,
+		},
+	}
 	reg := &structs.NodeRegisterRequest{
 		Node:         node,
 		WriteRequest: structs.WriteRequest{Region: "global"},
@@ -2688,12 +2695,11 @@ func TestClientEndpoint_ListNodes(t *testing.T) {
 		t.Fatalf("Bad index: %d %d", resp2.Index, resp.Index)
 	}
 
-	if len(resp2.Nodes) != 1 {
-		t.Fatalf("bad: %#v", resp2.Nodes)
-	}
-	if resp2.Nodes[0].ID != node.ID {
-		t.Fatalf("bad: %#v", resp2.Nodes[0])
-	}
+	require.Len(t, resp2.Nodes, 1)
+	require.Equal(t, node.ID, resp2.Nodes[0].ID)
+
+	// #7344 - Assert HostVolumes are included in stub
+	require.Equal(t, node.HostVolumes, resp2.Nodes[0].HostVolumes)
 
 	// Lookup the node with prefix
 	get = &structs.NodeListRequest{

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1944,6 +1944,7 @@ func (n *Node) Stub() *NodeListStub {
 		Status:                n.Status,
 		StatusDescription:     n.StatusDescription,
 		Drivers:               n.Drivers,
+		HostVolumes:           n.HostVolumes,
 		CreateIndex:           n.CreateIndex,
 		ModifyIndex:           n.ModifyIndex,
 	}
@@ -1963,6 +1964,7 @@ type NodeListStub struct {
 	Status                string
 	StatusDescription     string
 	Drivers               map[string]*DriverInfo
+	HostVolumes           map[string]*ClientHostVolumeConfig
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }

--- a/ui/app/controllers/clients/index.js
+++ b/ui/app/controllers/clients/index.js
@@ -46,7 +46,9 @@ export default Controller.extend(
     selectionVolume: selection('qpVolume'),
 
     optionsClass: computed('nodes.[]', function() {
-      const classes = Array.from(new Set(this.nodes.mapBy('nodeClass'))).compact();
+      const classes = Array.from(new Set(this.nodes.mapBy('nodeClass')))
+        .compact()
+        .without('');
 
       // Remove any invalid node classes from the query param/selection
       scheduleOnce('actions', () => {

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -32,6 +32,12 @@
             options=optionsDatacenter
             selection=selectionDatacenter
             onSelect=(action setFacetQueryParam "qpDatacenter")}}
+          {{multi-select-dropdown
+            data-test-volume-facet
+            label="Volume"
+            options=optionsVolume
+            selection=selectionVolume
+            onSelect=(action setFacetQueryParam "qpVolume")}}
         </div>
       </div>
     </div>

--- a/ui/mirage/factories/node.js
+++ b/ui/mirage/factories/node.js
@@ -72,7 +72,7 @@ export default Factory.extend({
 
   drivers: makeDrivers,
 
-  hostVolumes: makeHostVolumes(),
+  hostVolumes: makeHostVolumes,
 
   resources: generateResources,
 

--- a/ui/tests/acceptance/clients-list-test.js
+++ b/ui/tests/acceptance/clients-list-test.js
@@ -232,6 +232,24 @@ module('Acceptance | clients list', function(hooks) {
     filter: (node, selection) => selection.includes(node.datacenter),
   });
 
+  testFacet('Volumes', {
+    facet: ClientsList.facets.volume,
+    paramName: 'volume',
+    expectedOptions(nodes) {
+      const flatten = (acc, val) => acc.concat(Object.keys(val));
+      return Array.from(new Set(nodes.mapBy('hostVolumes').reduce(flatten, [])));
+    },
+    async beforeEach() {
+      server.create('agent');
+      server.createList('node', 2, { hostVolumes: { One: { Name: 'One' } } });
+      server.createList('node', 2, { hostVolumes: { One: { Name: 'One' }, Two: { Name: 'Two' } } });
+      server.createList('node', 2, { hostVolumes: { Two: { Name: 'Two' } } });
+      await ClientsList.visit();
+    },
+    filter: (node, selection) =>
+      Object.keys(node.hostVolumes).find(volume => selection.includes(volume)),
+  });
+
   test('when the facet selections result in no matches, the empty state states why', async function(assert) {
     server.create('agent');
     server.createList('node', 2, { status: 'ready' });

--- a/ui/tests/pages/clients/list.js
+++ b/ui/tests/pages/clients/list.js
@@ -70,5 +70,6 @@ export default create({
     class: facet('[data-test-class-facet]'),
     state: facet('[data-test-state-facet]'),
     datacenter: facet('[data-test-datacenter-facet]'),
+    volume: facet('[data-test-volume-facet]'),
   },
 });


### PR DESCRIPTION
A new facet for filtering the clients list to only the ones that have selected host volumes. Like the other facets, selecting multiple volumes will include all nodes that match ANY host volume (logical OR). Combining facets will be a logical AND.

![image](https://user-images.githubusercontent.com/174740/76649698-71bf2d00-651e-11ea-9a97-8adaf01c0bf0.png)
