### PR TITLE
e2e: use unique CSI token

### DIFF
--- a/e2e/terraform/volumes.tf
+++ b/e2e/terraform/volumes.tf
@@ -1,5 +1,5 @@
 resource "aws_efs_file_system" "csi" {
-  creation_token = "CSI"
+  creation_token = "${local.random_name}-CSI"
 
   tags = {
     Name = "${local.random_name}-efs"


### PR DESCRIPTION
Use a unique per-cluster efs creation token, as https://www.terraform.io/docs/providers/aws/r/efs_file_system.html#creation_token.

Using a static value prevents having multiple test clusters with output like:

```
Error: Error creating EFS file system: FileSystemAlreadyExists: File system 'fs-xxxx' already exists with creation token 'CSI'
[01:05:02]	{
[01:05:02]	  ErrorCode: "FileSystemAlreadyExists",
[01:05:02]	  FileSystemId: "fs-xxxx",
[01:05:02]	  Message_: "File system 'fs-xxxx' already exists with creation token 'CSI'"
[01:05:02]	}
```