### PR TITLE
csi: implement controller detach RPCs

### DIFF
--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -89,3 +89,81 @@ func TestClientCSIController_AttachVolume_Forwarded(t *testing.T) {
 	// Should recieve an error from the client endpoint
 	require.Contains(err.Error(), "must specify plugin name to dispense")
 }
+
+func TestClientCSIController_DetachVolume_Local(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Start a server and client
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
+		c.Servers = []string{s.config.RPCAddr.String()}
+	})
+	defer cleanupC()
+
+	testutil.WaitForResult(func() (bool, error) {
+		nodes := s.connectedNodes()
+		return len(nodes) == 1, nil
+	}, func(err error) {
+		require.Fail("should have a client")
+	})
+
+	req := &cstructs.ClientCSIControllerDetachVolumeRequest{
+		CSIControllerQuery: cstructs.CSIControllerQuery{ControllerNodeID: c.NodeID()},
+	}
+
+	// Fetch the response
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSIController.DetachVolume", req, &resp)
+	require.NotNil(err)
+	// Should recieve an error from the client endpoint
+	require.Contains(err.Error(), "must specify plugin name to dispense")
+}
+
+func TestClientCSIController_DetachVolume_Forwarded(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// Start a server and client
+	s1, cleanupS1 := TestServer(t, func(c *Config) { c.BootstrapExpect = 2 })
+	defer cleanupS1()
+	s2, cleanupS2 := TestServer(t, func(c *Config) { c.BootstrapExpect = 2 })
+	defer cleanupS2()
+	TestJoin(t, s1, s2)
+	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForLeader(t, s2.RPC)
+	codec := rpcClient(t, s2)
+
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
+		c.Servers = []string{s2.config.RPCAddr.String()}
+		c.GCDiskUsageThreshold = 100.0
+	})
+	defer cleanupC()
+
+	testutil.WaitForResult(func() (bool, error) {
+		nodes := s2.connectedNodes()
+		return len(nodes) == 1, nil
+	}, func(err error) {
+		require.Fail("should have a client")
+	})
+
+	// Force remove the connection locally in case it exists
+	s1.nodeConnsLock.Lock()
+	delete(s1.nodeConns, c.NodeID())
+	s1.nodeConnsLock.Unlock()
+
+	req := &cstructs.ClientCSIControllerDetachVolumeRequest{
+		CSIControllerQuery: cstructs.CSIControllerQuery{ControllerNodeID: c.NodeID()},
+	}
+
+	// Fetch the response
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSIController.DetachVolume", req, &resp)
+	require.NotNil(err)
+	// Should recieve an error from the client endpoint
+	require.Contains(err.Error(), "must specify plugin name to dispense")
+}

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2200,7 +2200,6 @@ func TestCSI_GCVolumeClaims(t *testing.T) {
 	defer shutdown()
 	testutil.WaitForLeader(t, srv.RPC)
 
-	//	codec := rpcClient(t, srv)
 	state := srv.fsm.State()
 	ws := memdb.NewWatchSet()
 
@@ -2301,5 +2300,132 @@ func TestCSI_GCVolumeClaims(t *testing.T) {
 	vol, err = state.CSIVolumeByID(ws, volId0)
 	require.NoError(t, err)
 	require.Len(t, vol.ReadAllocs, 1)
+	require.Len(t, vol.WriteAllocs, 0)
+}
+
+func TestCSI_GCVolumeClaims_Controller(t *testing.T) {
+	t.Parallel()
+	srv, shutdown := TestServer(t, func(c *Config) { c.NumSchedulers = 0 })
+	defer shutdown()
+	testutil.WaitForLeader(t, srv.RPC)
+
+	state := srv.fsm.State()
+	ws := memdb.NewWatchSet()
+
+	// Create a client node, plugin, and volume
+	node := mock.Node()
+	node.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early version
+	node.CSINodePlugins = map[string]*structs.CSIInfo{
+		"csi-plugin-example": {
+			PluginID:                 "csi-plugin-example",
+			Healthy:                  true,
+			RequiresControllerPlugin: true,
+			NodeInfo:                 &structs.CSINodeInfo{},
+		},
+	}
+	node.CSIControllerPlugins = map[string]*structs.CSIInfo{
+		"csi-plugin-example": {
+			PluginID:                 "csi-plugin-example",
+			Healthy:                  true,
+			RequiresControllerPlugin: true,
+			ControllerInfo: &structs.CSIControllerInfo{
+				SupportsReadOnlyAttach:           true,
+				SupportsAttachDetach:             true,
+				SupportsListVolumes:              true,
+				SupportsListVolumesAttachedNodes: false,
+			},
+		},
+	}
+	err := state.UpsertNode(99, node)
+	require.NoError(t, err)
+	volId0 := uuid.Generate()
+	vols := []*structs.CSIVolume{{
+		ID:             volId0,
+		Namespace:      "notTheNamespace",
+		PluginID:       "csi-plugin-example",
+		AccessMode:     structs.CSIVolumeAccessModeMultiNodeSingleWriter,
+		AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
+	}}
+	err = state.CSIVolumeRegister(100, vols)
+	require.NoError(t, err)
+	vol, err := state.CSIVolumeByID(ws, volId0)
+
+	require.NoError(t, err)
+	require.True(t, vol.ControllerRequired)
+	require.Len(t, vol.ReadAllocs, 0)
+	require.Len(t, vol.WriteAllocs, 0)
+
+	// Create a job with 2 allocations
+	job := mock.Job()
+	job.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{
+		"_": {
+			Name:     "someVolume",
+			Type:     structs.VolumeTypeCSI,
+			Source:   volId0,
+			ReadOnly: false,
+		},
+	}
+	err = state.UpsertJob(101, job)
+	require.NoError(t, err)
+
+	alloc1 := mock.Alloc()
+	alloc1.JobID = job.ID
+	alloc1.NodeID = node.ID
+	err = state.UpsertJobSummary(102, mock.JobSummary(alloc1.JobID))
+	require.NoError(t, err)
+	alloc1.TaskGroup = job.TaskGroups[0].Name
+
+	alloc2 := mock.Alloc()
+	alloc2.JobID = job.ID
+	alloc2.NodeID = node.ID
+	err = state.UpsertJobSummary(103, mock.JobSummary(alloc2.JobID))
+	require.NoError(t, err)
+	alloc2.TaskGroup = job.TaskGroups[0].Name
+
+	err = state.UpsertAllocs(104, []*structs.Allocation{alloc1, alloc2})
+	require.NoError(t, err)
+
+	// Claim the volumes and verify the claims were set
+	err = state.CSIVolumeClaim(105, volId0, alloc1, structs.CSIVolumeClaimWrite)
+	require.NoError(t, err)
+	err = state.CSIVolumeClaim(106, volId0, alloc2, structs.CSIVolumeClaimRead)
+	require.NoError(t, err)
+	vol, err = state.CSIVolumeByID(ws, volId0)
+	require.NoError(t, err)
+	require.Len(t, vol.ReadAllocs, 1)
+	require.Len(t, vol.WriteAllocs, 1)
+
+	// Update both allocs as failed/terminated
+	alloc1.ClientStatus = structs.AllocClientStatusFailed
+	alloc2.ClientStatus = structs.AllocClientStatusFailed
+	err = state.UpdateAllocsFromClient(107, []*structs.Allocation{alloc1, alloc2})
+	require.NoError(t, err)
+
+	// Create the GC eval we'd get from Node.UpdateAlloc
+	now := time.Now().UTC()
+	eval := &structs.Evaluation{
+		ID:          uuid.Generate(),
+		Namespace:   job.Namespace,
+		Priority:    structs.CoreJobPriority,
+		Type:        structs.JobTypeCore,
+		TriggeredBy: structs.EvalTriggerAllocStop,
+		JobID:       structs.CoreJobCSIVolumeClaimGC + ":" + job.ID,
+		LeaderACL:   srv.getLeaderAcl(),
+		Status:      structs.EvalStatusPending,
+		CreateTime:  now.UTC().UnixNano(),
+		ModifyTime:  now.UTC().UnixNano(),
+	}
+
+	// Process the eval
+	snap, err := state.Snapshot()
+	require.NoError(t, err)
+	core := NewCoreScheduler(srv, snap)
+	err = core.Process(eval)
+	require.NoError(t, err)
+
+	// Verify both claims were released
+	vol, err = state.CSIVolumeByID(ws, volId0)
+	require.NoError(t, err)
+	require.Len(t, vol.ReadAllocs, 0)
 	require.Len(t, vol.WriteAllocs, 0)
 }

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -220,7 +220,7 @@ func TestCSIVolumeEndpoint_Claim(t *testing.T) {
 	}
 	claimResp := &structs.CSIVolumeClaimResponse{}
 	err := msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
-	require.EqualError(t, err, fmt.Sprintf("controllerPublish: volume not found: %s", id0),
+	require.EqualError(t, err, fmt.Sprintf("controller publish: volume not found: %s", id0),
 		"expected 'volume not found' error because volume hasn't yet been created")
 
 	// Create a client node, plugin, alloc, and volume
@@ -377,7 +377,7 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 	claimResp := &structs.CSIVolumeClaimResponse{}
 	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
 	// Because the node is not registered
-	require.EqualError(t, err, "controllerPublish: attach volume: No path to node")
+	require.EqualError(t, err, "controller publish: attach volume: No path to node")
 }
 
 func TestCSIVolumeEndpoint_List(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7218 and https://github.com/hashicorp/nomad/issues/7332

This changeset implements the remaining controller detach RPCs: server-to-client and client-to-controller. The tests also uncovered a bug in our RPC for claims which is fixed here; the volume claim RPC is used for both claiming and releasing a claim on a volume. We should only submit a controller publish RPC when the claim is new and not when it's being released.

Much of this PR is copy-and-paste from the publish/attach workflows already written. Best reviewed commit-by-commit. 