### PR TITLE
csi: volume ids are only unique per namespace

### DIFF
--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -408,7 +408,7 @@ func TestAllocStatusCommand_CSIVolumes(t *testing.T) {
 
 	vols := []*structs.CSIVolume{{
 		ID:             vol0,
-		Namespace:      "notTheNamespace",
+		Namespace:      structs.DefaultNamespace,
 		PluginID:       "minnie",
 		AccessMode:     structs.CSIVolumeAccessModeMultiNodeSingleWriter,
 		AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -753,7 +753,7 @@ func (c *CoreScheduler) volumeClaimReap(jobs []*structs.Job, leaderACL string) e
 					continue // filter to just CSI volumes
 				}
 				volID := tgVolume.Source
-				vol, err := c.srv.State().CSIVolumeByID(ws, volID)
+				vol, err := c.srv.State().CSIVolumeByID(ws, job.Namespace, volID)
 				if err != nil {
 					result = multierror.Append(result, err)
 					continue

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2216,7 +2216,7 @@ func TestCSI_GCVolumeClaims(t *testing.T) {
 	err := state.UpsertNode(99, node)
 	require.NoError(t, err)
 	volId0 := uuid.Generate()
-	ns := "notTheNamespace"
+	ns := structs.DefaultNamespace
 	vols := []*structs.CSIVolume{{
 		ID:             volId0,
 		Namespace:      ns,
@@ -2299,7 +2299,7 @@ func TestCSI_GCVolumeClaims(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the claim was released
-	vol, err = state.CSIVolumeByID(ws, job.Namespace, volId0)
+	vol, err = state.CSIVolumeByID(ws, ns, volId0)
 	require.NoError(t, err)
 	require.Len(t, vol.ReadAllocs, 1)
 	require.Len(t, vol.WriteAllocs, 0)

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2216,16 +2216,17 @@ func TestCSI_GCVolumeClaims(t *testing.T) {
 	err := state.UpsertNode(99, node)
 	require.NoError(t, err)
 	volId0 := uuid.Generate()
+	ns := "notTheNamespace"
 	vols := []*structs.CSIVolume{{
 		ID:             volId0,
-		Namespace:      "notTheNamespace",
+		Namespace:      ns,
 		PluginID:       "csi-plugin-example",
 		AccessMode:     structs.CSIVolumeAccessModeMultiNodeSingleWriter,
 		AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
 	}}
 	err = state.CSIVolumeRegister(100, vols)
 	require.NoError(t, err)
-	vol, err := state.CSIVolumeByID(ws, volId0)
+	vol, err := state.CSIVolumeByID(ws, ns, volId0)
 	require.NoError(t, err)
 	require.Len(t, vol.ReadAllocs, 0)
 	require.Len(t, vol.WriteAllocs, 0)
@@ -2261,11 +2262,11 @@ func TestCSI_GCVolumeClaims(t *testing.T) {
 	require.NoError(t, err)
 
 	// Claim the volumes and verify the claims were set
-	err = state.CSIVolumeClaim(105, volId0, alloc1, structs.CSIVolumeClaimWrite)
+	err = state.CSIVolumeClaim(105, ns, volId0, alloc1, structs.CSIVolumeClaimWrite)
 	require.NoError(t, err)
-	err = state.CSIVolumeClaim(106, volId0, alloc2, structs.CSIVolumeClaimRead)
+	err = state.CSIVolumeClaim(106, ns, volId0, alloc2, structs.CSIVolumeClaimRead)
 	require.NoError(t, err)
-	vol, err = state.CSIVolumeByID(ws, volId0)
+	vol, err = state.CSIVolumeByID(ws, ns, volId0)
 	require.NoError(t, err)
 	require.Len(t, vol.ReadAllocs, 1)
 	require.Len(t, vol.WriteAllocs, 1)
@@ -2298,7 +2299,7 @@ func TestCSI_GCVolumeClaims(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the claim was released
-	vol, err = state.CSIVolumeByID(ws, volId0)
+	vol, err = state.CSIVolumeByID(ws, job.Namespace, volId0)
 	require.NoError(t, err)
 	require.Len(t, vol.ReadAllocs, 1)
 	require.Len(t, vol.WriteAllocs, 0)

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -101,7 +101,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 		return err
 	}
 
-	if !allowCSIAccess(aclObj, vol.Namespace) {
+	if !allowCSIAccess(aclObj, args.RequestNamespace()) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -131,7 +131,6 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 
 			// Collect results, filter by ACL access
 			var vs []*structs.CSIVolListStub
-			cache := map[string]bool{}
 
 			for {
 				raw := iter.Next()
@@ -150,9 +149,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 					continue
 				}
 
-				if allowed {
-					vs = append(vs, vol.Stub())
-				}
+				vs = append(vs, vol.Stub())
 			}
 			reply.Volumes = vs
 			return v.srv.replySetIndex(csiVolumeTable, &reply.QueryMeta)

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -114,11 +114,11 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 			var iter memdb.ResultIterator
 
 			if args.NodeID != "" {
-				iter, err = state.CSIVolumesByNodeID(ws, args.NodeID)
+				iter, err = state.CSIVolumesByNodeID(ws, ns, args.NodeID)
 			} else if args.PluginID != "" {
-				iter, err = state.CSIVolumesByPluginID(ws, args.PluginID)
+				iter, err = state.CSIVolumesByPluginID(ws, ns, args.PluginID)
 			} else {
-				iter, err = state.CSIVolumes(ws)
+				iter, err = state.CSIVolumesByNamespace(ws, ns)
 			}
 
 			if err != nil {
@@ -142,7 +142,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 				}
 
 				// Filter on the request namespace to avoid ACL checks by volume
-				if ns != "" && vol.Namespace != args.RequestNamespace() {
+				if ns != "" && vol.Namespace != ns {
 					continue
 				}
 
@@ -180,7 +180,8 @@ func (v *CSIVolume) Get(args *structs.CSIVolumeGetRequest, reply *structs.CSIVol
 		return err
 	}
 
-	if !allowCSIAccess(aclObj, args.RequestNamespace()) {
+	ns := args.RequestNamespace()
+	if !allowCSIAccess(aclObj, ns) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -191,7 +192,7 @@ func (v *CSIVolume) Get(args *structs.CSIVolumeGetRequest, reply *structs.CSIVol
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
 		run: func(ws memdb.WatchSet, state *state.StateStore) error {
-			vol, err := state.CSIVolumeByID(ws, args.ID)
+			vol, err := state.CSIVolumeByID(ws, ns, args.ID)
 			if err != nil {
 				return err
 			}
@@ -484,7 +485,7 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 // controllerPublishVolume sends publish request to the CSI controller
 // plugin associated with a volume, if any.
 func (srv *Server) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, resp *structs.CSIVolumeClaimResponse) error {
-	plug, vol, err := srv.volAndPluginLookup(req.VolumeID)
+	plug, vol, err := srv.volAndPluginLookup(req.RequestNamespace(), req.VolumeID)
 	if err != nil {
 		return err
 	}
@@ -557,7 +558,7 @@ func (srv *Server) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, r
 // controller plugin associated with a volume, if any.
 // TODO: the only caller of this won't have an alloc pointer handy, should it be its own request arg type?
 func (srv *Server) controllerUnpublishVolume(req *structs.CSIVolumeClaimRequest, targetNomadNodeID string) error {
-	plug, vol, err := srv.volAndPluginLookup(req.VolumeID)
+	plug, vol, err := srv.volAndPluginLookup(req.RequestNamespace(), req.VolumeID)
 	if plug == nil || vol == nil || err != nil {
 		return err // possibly nil if no controller required
 	}
@@ -595,11 +596,11 @@ func (srv *Server) controllerUnpublishVolume(req *structs.CSIVolumeClaimRequest,
 	return srv.RPC(method, cReq, &cstructs.ClientCSIControllerDetachVolumeResponse{})
 }
 
-func (srv *Server) volAndPluginLookup(volID string) (*structs.CSIPlugin, *structs.CSIVolume, error) {
+func (srv *Server) volAndPluginLookup(namespace, volID string) (*structs.CSIPlugin, *structs.CSIVolume, error) {
 	state := srv.fsm.State()
 	ws := memdb.NewWatchSet()
 
-	vol, err := state.CSIVolumeByID(ws, volID)
+	vol, err := state.CSIVolumeByID(ws, namespace, volID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -350,7 +350,7 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 	require.NoError(t, err)
 	vols := []*structs.CSIVolume{{
 		ID:                 id0,
-		Namespace:          "notTheNamespace",
+		Namespace:          ns,
 		PluginID:           "minnie",
 		ControllerRequired: true,
 		AccessMode:         structs.CSIVolumeAccessModeMultiNodeSingleWriter,

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1142,7 +1142,7 @@ func (n *nomadFSM) applyCSIVolumeDeregister(buf []byte, index uint64) interface{
 	}
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_csi_volume_deregister"}, time.Now())
 
-	if err := n.state.CSIVolumeDeregister(index, req.VolumeIDs); err != nil {
+	if err := n.state.CSIVolumeDeregister(index, req.RequestNamespace(), req.VolumeIDs); err != nil {
 		n.logger.Error("CSIVolumeDeregister failed", "error", err)
 		return err
 	}
@@ -1172,7 +1172,7 @@ func (n *nomadFSM) applyCSIVolumeClaim(buf []byte, index uint64) interface{} {
 		return structs.ErrUnknownAllocationPrefix
 	}
 
-	if err := n.state.CSIVolumeClaim(index, req.VolumeID, alloc, req.Claim); err != nil {
+	if err := n.state.CSIVolumeClaim(index, req.RequestNamespace(), req.VolumeID, alloc, req.Claim); err != nil {
 		n.logger.Error("CSIVolumeClaim failed", "error", err)
 		return err
 	}

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -2335,22 +2335,24 @@ func TestClientEndpoint_UpdateAlloc_UnclaimVolumes(t *testing.T) {
 	err := state.UpsertNode(99, node)
 	require.NoError(t, err)
 	volId0 := uuid.Generate()
+	ns := "notTheNamespace"
 	vols := []*structs.CSIVolume{{
 		ID:             volId0,
-		Namespace:      "notTheNamespace",
+		Namespace:      ns,
 		PluginID:       "csi-plugin-example",
 		AccessMode:     structs.CSIVolumeAccessModeMultiNodeSingleWriter,
 		AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
 	}}
 	err = state.CSIVolumeRegister(100, vols)
 	require.NoError(t, err)
-	vol, err := state.CSIVolumeByID(ws, volId0)
+	vol, err := state.CSIVolumeByID(ws, ns, volId0)
 	require.NoError(t, err)
 	require.Len(t, vol.ReadAllocs, 0)
 	require.Len(t, vol.WriteAllocs, 0)
 
 	// Create a job with 2 allocations
 	job := mock.Job()
+	job.Namespace = ns
 	job.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{
 		"_": {
 			Name:     "someVolume",
@@ -2380,11 +2382,11 @@ func TestClientEndpoint_UpdateAlloc_UnclaimVolumes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Claim the volumes and verify the claims were set
-	err = state.CSIVolumeClaim(105, volId0, alloc1, structs.CSIVolumeClaimWrite)
+	err = state.CSIVolumeClaim(105, ns, volId0, alloc1, structs.CSIVolumeClaimWrite)
 	require.NoError(t, err)
-	err = state.CSIVolumeClaim(106, volId0, alloc2, structs.CSIVolumeClaimRead)
+	err = state.CSIVolumeClaim(106, ns, volId0, alloc2, structs.CSIVolumeClaimRead)
 	require.NoError(t, err)
-	vol, err = state.CSIVolumeByID(ws, volId0)
+	vol, err = state.CSIVolumeByID(ws, ns, volId0)
 	require.NoError(t, err)
 	require.Len(t, vol.ReadAllocs, 1)
 	require.Len(t, vol.WriteAllocs, 1)

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -2352,7 +2352,6 @@ func TestClientEndpoint_UpdateAlloc_UnclaimVolumes(t *testing.T) {
 
 	// Create a job with 2 allocations
 	job := mock.Job()
-	job.Namespace = ns
 	job.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{
 		"_": {
 			Name:     "someVolume",

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -689,8 +689,15 @@ func csiVolumeTableSchema() *memdb.TableSchema {
 				Name:         "id",
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: &memdb.StringFieldIndex{
-					Field: "ID",
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.StringFieldIndex{
+							Field: "Namespace",
+						},
+						&memdb.StringFieldIndex{
+							Field: "ID",
+						},
+					},
 				},
 			},
 			"plugin_id": {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1839,15 +1839,6 @@ func (s *StateStore) CSIVolumeDeregister(index uint64, namespace string, ids []s
 			return fmt.Errorf("volume not found: %s", id)
 		}
 
-		vol, ok := existing.(*structs.CSIVolume)
-		if !ok {
-			return fmt.Errorf("volume not found: %s", id)
-		}
-
-		if namespace != vol.Namespace {
-
-		}
-
 		if err = txn.Delete("csi_volumes", existing); err != nil {
 			return fmt.Errorf("volume delete failed: %s: %v", id, err)
 		}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1770,19 +1770,6 @@ func (s *StateStore) CSIVolumesByNamespace(ws memdb.WatchSet, namespace string) 
 	return iter, nil
 }
 
-// CSIVolumes looks up the entire csi_volumes table
-func (s *StateStore) CSIVolumes(ws memdb.WatchSet) (memdb.ResultIterator, error) {
-	txn := s.db.Txn(false)
-
-	iter, err := txn.Get("csi_volumes", "id")
-	if err != nil {
-		return nil, fmt.Errorf("volume lookup failed: %v", err)
-	}
-	ws.Add(iter.WatchCh())
-
-	return iter, nil
-}
-
 // CSIVolumeClaim updates the volume's claim count and allocation list
 func (s *StateStore) CSIVolumeClaim(index uint64, namespace, id string, alloc *structs.Allocation, claim structs.CSIVolumeClaimMode) error {
 	txn := s.db.Txn(true)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1627,7 +1627,7 @@ func (s *StateStore) CSIVolumeRegister(index uint64, volumes []*structs.CSIVolum
 
 	for _, v := range volumes {
 		// Check for volume existence
-		obj, err := txn.First("csi_volumes", "id", v.ID)
+		obj, err := txn.First("csi_volumes", "id", v.Namespace, v.ID)
 		if err != nil {
 			return fmt.Errorf("volume existence check error: %v", err)
 		}
@@ -1656,10 +1656,10 @@ func (s *StateStore) CSIVolumeRegister(index uint64, volumes []*structs.CSIVolum
 
 // CSIVolumeByID is used to lookup a single volume. Returns a copy of the volume
 // because its plugins are denormalized to provide accurate Health.
-func (s *StateStore) CSIVolumeByID(ws memdb.WatchSet, id string) (*structs.CSIVolume, error) {
+func (s *StateStore) CSIVolumeByID(ws memdb.WatchSet, namespace, id string) (*structs.CSIVolume, error) {
 	txn := s.db.Txn(false)
 
-	watchCh, obj, err := txn.FirstWatch("csi_volumes", "id_prefix", id)
+	watchCh, obj, err := txn.FirstWatch("csi_volumes", "id_prefix", namespace, id)
 	if err != nil {
 		return nil, fmt.Errorf("volume lookup failed: %s %v", id, err)
 	}
@@ -1674,28 +1674,13 @@ func (s *StateStore) CSIVolumeByID(ws memdb.WatchSet, id string) (*structs.CSIVo
 }
 
 // CSIVolumes looks up csi_volumes by pluginID
-func (s *StateStore) CSIVolumesByPluginID(ws memdb.WatchSet, pluginID string) (memdb.ResultIterator, error) {
+func (s *StateStore) CSIVolumesByPluginID(ws memdb.WatchSet, namespace, pluginID string) (memdb.ResultIterator, error) {
 	txn := s.db.Txn(false)
 
 	iter, err := txn.Get("csi_volumes", "plugin_id", pluginID)
 	if err != nil {
 		return nil, fmt.Errorf("volume lookup failed: %v", err)
 	}
-	ws.Add(iter.WatchCh())
-
-	return iter, nil
-}
-
-// CSIVolumesByIDPrefix supports search
-func (s *StateStore) CSIVolumesByIDPrefix(ws memdb.WatchSet, namespace, volumeID string) (memdb.ResultIterator, error) {
-	txn := s.db.Txn(false)
-
-	iter, err := txn.Get("csi_volumes", "id_prefix", volumeID)
-	if err != nil {
-		return nil, err
-	}
-
-	ws.Add(iter.WatchCh())
 
 	// Filter the iterator by namespace
 	f := func(raw interface{}) bool {
@@ -1710,8 +1695,21 @@ func (s *StateStore) CSIVolumesByIDPrefix(ws memdb.WatchSet, namespace, volumeID
 	return wrap, nil
 }
 
+// CSIVolumesByIDPrefix supports search
+func (s *StateStore) CSIVolumesByIDPrefix(ws memdb.WatchSet, namespace, volumeID string) (memdb.ResultIterator, error) {
+	txn := s.db.Txn(false)
+
+	iter, err := txn.Get("csi_volumes", "id_prefix", namespace, volumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	ws.Add(iter.WatchCh())
+	return iter, nil
+}
+
 // CSIVolumesByNodeID looks up CSIVolumes in use on a node
-func (s *StateStore) CSIVolumesByNodeID(ws memdb.WatchSet, nodeID string) (memdb.ResultIterator, error) {
+func (s *StateStore) CSIVolumesByNodeID(ws memdb.WatchSet, namespace, nodeID string) (memdb.ResultIterator, error) {
 	allocs, err := s.AllocsByNode(ws, nodeID)
 	if err != nil {
 		return nil, fmt.Errorf("alloc lookup failed: %v", err)
@@ -1749,12 +1747,25 @@ func (s *StateStore) CSIVolumesByNodeID(ws memdb.WatchSet, nodeID string) (memdb
 	iter := NewSliceIterator()
 	txn := s.db.Txn(false)
 	for id := range ids {
-		raw, err := txn.First("csi_volumes", "id", id)
+		raw, err := txn.First("csi_volumes", "id", namespace, id)
 		if err != nil {
 			return nil, fmt.Errorf("volume lookup failed: %s %v", id, err)
 		}
 		iter.Add(raw)
 	}
+
+	return iter, nil
+}
+
+// CSIVolumesByNamespace looks up the entire csi_volumes table
+func (s *StateStore) CSIVolumesByNamespace(ws memdb.WatchSet, namespace string) (memdb.ResultIterator, error) {
+	txn := s.db.Txn(false)
+
+	iter, err := txn.Get("csi_volumes", "id_prefix", namespace, "")
+	if err != nil {
+		return nil, fmt.Errorf("volume lookup failed: %v", err)
+	}
+	ws.Add(iter.WatchCh())
 
 	return iter, nil
 }
@@ -1773,11 +1784,11 @@ func (s *StateStore) CSIVolumes(ws memdb.WatchSet) (memdb.ResultIterator, error)
 }
 
 // CSIVolumeClaim updates the volume's claim count and allocation list
-func (s *StateStore) CSIVolumeClaim(index uint64, id string, alloc *structs.Allocation, claim structs.CSIVolumeClaimMode) error {
+func (s *StateStore) CSIVolumeClaim(index uint64, namespace, id string, alloc *structs.Allocation, claim structs.CSIVolumeClaimMode) error {
 	txn := s.db.Txn(true)
 	defer txn.Abort()
 
-	row, err := txn.First("csi_volumes", "id", id)
+	row, err := txn.First("csi_volumes", "id", namespace, id)
 	if err != nil {
 		return fmt.Errorf("volume lookup failed: %s: %v", id, err)
 	}
@@ -1814,18 +1825,27 @@ func (s *StateStore) CSIVolumeClaim(index uint64, id string, alloc *structs.Allo
 }
 
 // CSIVolumeDeregister removes the volume from the server
-func (s *StateStore) CSIVolumeDeregister(index uint64, ids []string) error {
+func (s *StateStore) CSIVolumeDeregister(index uint64, namespace string, ids []string) error {
 	txn := s.db.Txn(true)
 	defer txn.Abort()
 
 	for _, id := range ids {
-		existing, err := txn.First("csi_volumes", "id_prefix", id)
+		existing, err := txn.First("csi_volumes", "id_prefix", namespace, id)
 		if err != nil {
 			return fmt.Errorf("volume lookup failed: %s: %v", id, err)
 		}
 
 		if existing == nil {
 			return fmt.Errorf("volume not found: %s", id)
+		}
+
+		vol, ok := existing.(*structs.CSIVolume)
+		if !ok {
+			return fmt.Errorf("volume not found: %s", id)
+		}
+
+		if namespace != vol.Namespace {
+
 		}
 
 		if err = txn.Delete("csi_volumes", existing); err != nil {

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2874,9 +2874,11 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	err = state.UpsertAllocs(index, []*structs.Allocation{alloc})
 	require.NoError(t, err)
 
+	ns := structs.DefaultNamespace
+
 	v0 := structs.NewCSIVolume("foo", index)
 	v0.ID = vol0
-	v0.Namespace = "default"
+	v0.Namespace = ns
 	v0.PluginID = "minnie"
 	v0.Schedulable = true
 	v0.AccessMode = structs.CSIVolumeAccessModeMultiNodeSingleWriter
@@ -2885,7 +2887,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	index++
 	v1 := structs.NewCSIVolume("foo", index)
 	v1.ID = vol1
-	v1.Namespace = "default"
+	v1.Namespace = ns
 	v1.PluginID = "adam"
 	v1.Schedulable = true
 	v1.AccessMode = structs.CSIVolumeAccessModeMultiNodeSingleWriter
@@ -2915,25 +2917,25 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	require.Equal(t, 2, len(vs))
 
 	ws = memdb.NewWatchSet()
-	iter, err = state.CSIVolumesByPluginID(ws, "minnie")
+	iter, err = state.CSIVolumesByPluginID(ws, ns, "minnie")
 	require.NoError(t, err)
 	vs = slurp(iter)
 	require.Equal(t, 1, len(vs))
 
 	ws = memdb.NewWatchSet()
-	iter, err = state.CSIVolumesByNodeID(ws, node.ID)
+	iter, err = state.CSIVolumesByNodeID(ws, ns, node.ID)
 	require.NoError(t, err)
 	vs = slurp(iter)
 	require.Equal(t, 1, len(vs))
 
 	index++
-	err = state.CSIVolumeDeregister(index, []string{
+	err = state.CSIVolumeDeregister(index, ns, []string{
 		vol1,
 	})
 	require.NoError(t, err)
 
 	ws = memdb.NewWatchSet()
-	iter, err = state.CSIVolumesByPluginID(ws, "adam")
+	iter, err = state.CSIVolumesByPluginID(ws, ns, "adam")
 	require.NoError(t, err)
 	vs = slurp(iter)
 	require.Equal(t, 0, len(vs))
@@ -2952,22 +2954,22 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	u := structs.CSIVolumeClaimRelease
 
 	index++
-	err = state.CSIVolumeClaim(index, vol0, a0, r)
+	err = state.CSIVolumeClaim(index, ns, vol0, a0, r)
 	require.NoError(t, err)
 	index++
-	err = state.CSIVolumeClaim(index, vol0, a1, w)
+	err = state.CSIVolumeClaim(index, ns, vol0, a1, w)
 	require.NoError(t, err)
 
 	ws = memdb.NewWatchSet()
-	iter, err = state.CSIVolumesByPluginID(ws, "minnie")
+	iter, err = state.CSIVolumesByPluginID(ws, ns, "minnie")
 	require.NoError(t, err)
 	vs = slurp(iter)
 	require.False(t, vs[0].CanWrite())
 
-	err = state.CSIVolumeClaim(2, vol0, a0, u)
+	err = state.CSIVolumeClaim(2, ns, vol0, a0, u)
 	require.NoError(t, err)
 	ws = memdb.NewWatchSet()
-	iter, err = state.CSIVolumesByPluginID(ws, "minnie")
+	iter, err = state.CSIVolumesByPluginID(ws, ns, "minnie")
 	require.NoError(t, err)
 	vs = slurp(iter)
 	require.True(t, vs[0].CanReadOnly())

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2898,7 +2898,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	require.NoError(t, err)
 
 	ws := memdb.NewWatchSet()
-	iter, err := state.CSIVolumes(ws)
+	iter, err := state.CSIVolumesByNamespace(ws, ns)
 	require.NoError(t, err)
 
 	slurp := func(iter memdb.ResultIterator) (vs []*structs.CSIVolume) {
@@ -2941,7 +2941,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	require.Equal(t, 0, len(vs))
 
 	ws = memdb.NewWatchSet()
-	iter, err = state.CSIVolumes(ws)
+	iter, err = state.CSIVolumesByNamespace(ws, ns)
 	require.NoError(t, err)
 	vs = slurp(iter)
 	require.Equal(t, 1, len(vs))

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -199,8 +199,8 @@ func NewCSIVolumeChecker(ctx Context) *CSIVolumeChecker {
 	}
 }
 
-func (c *CSIVolumeChecker) SetJob(job *structs.Job) {
-	c.namespace = job.Namespace
+func (c *CSIVolumeChecker) SetNamespace(namespace string) {
+	c.namespace = namespace
 }
 
 func (c *CSIVolumeChecker) SetVolumes(volumes map[string]*structs.VolumeRequest) {

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -188,14 +188,19 @@ func (h *HostVolumeChecker) hasVolumes(n *structs.Node) bool {
 }
 
 type CSIVolumeChecker struct {
-	ctx     Context
-	volumes map[string]*structs.VolumeRequest
+	ctx       Context
+	namespace string
+	volumes   map[string]*structs.VolumeRequest
 }
 
 func NewCSIVolumeChecker(ctx Context) *CSIVolumeChecker {
 	return &CSIVolumeChecker{
 		ctx: ctx,
 	}
+}
+
+func (c *CSIVolumeChecker) SetJob(job *structs.Job) {
+	c.namespace = job.Namespace
 }
 
 func (c *CSIVolumeChecker) SetVolumes(volumes map[string]*structs.VolumeRequest) {
@@ -237,7 +242,7 @@ func (c *CSIVolumeChecker) hasPlugins(n *structs.Node) (bool, string) {
 	for _, req := range c.volumes {
 		// Get the volume to check that it's healthy (there's a healthy controller
 		// and the volume hasn't encountered an error or been marked for GC
-		vol, err := c.ctx.State().CSIVolumeByID(ws, req.Source)
+		vol, err := c.ctx.State().CSIVolumeByID(ws, c.namespace, req.Source)
 		if err != nil {
 			return false, FilterConstraintCSIVolumesLookupFailed
 		}

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -306,7 +306,7 @@ func TestCSIVolumeChecker(t *testing.T) {
 	}
 
 	checker := NewCSIVolumeChecker(ctx)
-	checker.SetJob(&structs.Job{Namespace: structs.DefaultNamespace})
+	checker.SetNamespace(structs.DefaultNamespace)
 
 	cases := []struct {
 		Node             *structs.Node

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -306,6 +306,8 @@ func TestCSIVolumeChecker(t *testing.T) {
 	}
 
 	checker := NewCSIVolumeChecker(ctx)
+	checker.SetJob(&structs.Job{Namespace: structs.DefaultNamespace})
+
 	cases := []struct {
 		Node             *structs.Node
 		RequestedVolumes map[string]*structs.VolumeRequest

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -93,7 +93,7 @@ type State interface {
 	SchedulerConfig() (uint64, *structs.SchedulerConfiguration, error)
 
 	// CSIVolumeByID fetch CSI volumes, containing controller jobs
-	CSIVolumeByID(memdb.WatchSet, string) (*structs.CSIVolume, error)
+	CSIVolumeByID(memdb.WatchSet, string, string) (*structs.CSIVolume, error)
 }
 
 // Planner interface is used to submit a task allocation plan.

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -96,7 +96,7 @@ func (s *GenericStack) SetJob(job *structs.Job) {
 	s.nodeAffinity.SetJob(job)
 	s.spread.SetJob(job)
 	s.ctx.Eligibility().SetJob(job)
-	s.taskGroupCSIVolumes.SetJob(job)
+	s.taskGroupCSIVolumes.SetNamespace(job.Namespace)
 
 	if contextual, ok := s.quota.(ContextualIterator); ok {
 		contextual.SetJob(job)

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -96,6 +96,7 @@ func (s *GenericStack) SetJob(job *structs.Job) {
 	s.nodeAffinity.SetJob(job)
 	s.spread.SetJob(job)
 	s.ctx.Eligibility().SetJob(job)
+	s.taskGroupCSIVolumes.SetJob(job)
 
 	if contextual, ok := s.quota.(ContextualIterator); ok {
 		contextual.SetJob(job)


### PR DESCRIPTION
CSI volumes have had a namespace field, but it was not used correctly at the schema level to permit duplicate volume ids in different namespaces. This threads the namespace through code that addresses the volume by id. It's required by the volume ACL implementation (and would have presented as bug anyway) #7305 