### PR TITLE
csi: fix filesystem write paths in e2e tests

### DIFF
--- a/e2e/csi/input/use-ebs-volume.nomad
+++ b/e2e/csi/input/use-ebs-volume.nomad
@@ -13,13 +13,13 @@ job "use-ebs-volume" {
 
       config {
         image   = "busybox:1"
-        command = "bash"
-        args    = ["-c", "touch /test/${NOMAD_JOB_NAME}; sleep 3600"]
+        command = "/bin/sh"
+        args    = ["-c", "touch /local/test/${NOMAD_ALLOC_ID}; sleep 3600"]
       }
 
       volume_mount {
         volume      = "test"
-        destination = "/test"
+        destination = "${NOMAD_TASK_DIR}/test"
         read_only   = false
       }
 

--- a/e2e/csi/input/use-efs-volume-read.nomad
+++ b/e2e/csi/input/use-efs-volume-read.nomad
@@ -14,13 +14,13 @@ job "use-efs-volume" {
 
       config {
         image   = "busybox:1"
-        command = "bash"
+        command = "/bin/sh"
         args    = ["-c", "sleep 3600"]
       }
 
       volume_mount {
         volume      = "test"
-        destination = "/test"
+        destination = "${NOMAD_TASK_DIR}/test"
         read_only   = true
       }
 

--- a/e2e/csi/input/use-efs-volume-write.nomad
+++ b/e2e/csi/input/use-efs-volume-write.nomad
@@ -13,13 +13,13 @@ job "use-efs-volume" {
 
       config {
         image   = "busybox:1"
-        command = "bash"
-        args    = ["-c", "touch /test/${NOMAD_JOB_NAME}; sleep 3600"]
+        command = "/bin/sh"
+        args    = ["-c", "touch /local/test/${NOMAD_ALLOC_ID}; sleep 3600"]
       }
 
       volume_mount {
         volume      = "test"
-        destination = "/test"
+        destination = "${NOMAD_TASK_DIR}/test"
         read_only   = false
       }
 


### PR DESCRIPTION
Fixing a few bugs in the e2e test suite for CSI following testing of #7356. 

The writer jobs for the CSI e2e tests will write to locations in the alloc dir and not arbitrary locations at the root. This changeset mounts the CSI volume at a location within the alloc dir, uses the alloc ID as a better-namespaced identifier of the file we write, and corrects the shell used by the busybox container.

This PR doesn't quite bring us to a working state; we'll need to fix #7338, #7360, and #7362 at least.

