### PR TITLE
csi: dynamically update plugin registration

### DIFF
--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -309,10 +309,14 @@ func (h *csiPluginSupervisorHook) registerPlugin(socketPath string) (func(), err
 			return nil, err
 		}
 
+		// need to rebind these so that each deregistration function
+		// closes over its own registration
+		rname := reg.Name
+		rtype := reg.Type
 		deregistrationFns = append(deregistrationFns, func() {
-			err := h.runner.dynamicRegistry.DeregisterPlugin(reg.Type, reg.Name)
+			err := h.runner.dynamicRegistry.DeregisterPlugin(rtype, rname)
 			if err != nil {
-				h.logger.Error("failed to deregister csi plugin", "name", reg.Name, "type", reg.Type, "error", err)
+				h.logger.Error("failed to deregister csi plugin", "name", rname, "type", rtype, "error", err)
 			}
 		})
 	}

--- a/client/dynamicplugins/registry_test.go
+++ b/client/dynamicplugins/registry_test.go
@@ -171,6 +171,30 @@ func TestDynamicRegistry_DispensePlugin_Works(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDynamicRegistry_IsolatePluginTypes(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry(nil, nil)
+
+	err := r.RegisterPlugin(&PluginInfo{
+		Type:           PluginTypeCSIController,
+		Name:           "my-plugin",
+		ConnectionInfo: &PluginConnectionInfo{},
+	})
+	require.NoError(t, err)
+
+	err = r.RegisterPlugin(&PluginInfo{
+		Type:           PluginTypeCSINode,
+		Name:           "my-plugin",
+		ConnectionInfo: &PluginConnectionInfo{},
+	})
+	require.NoError(t, err)
+
+	err = r.DeregisterPlugin(PluginTypeCSIController, "my-plugin")
+	require.NoError(t, err)
+	require.Equal(t, len(r.ListPlugins(PluginTypeCSINode)), 1)
+	require.Equal(t, len(r.ListPlugins(PluginTypeCSIController)), 0)
+}
+
 func TestDynamicRegistry_StateStore(t *testing.T) {
 	t.Parallel()
 	dispenseFn := func(i *PluginInfo) (interface{}, error) {

--- a/client/pluginmanager/csimanager/instance.go
+++ b/client/pluginmanager/csimanager/instance.go
@@ -86,7 +86,7 @@ func (i *instanceManager) run() {
 
 func (i *instanceManager) setupVolumeManager() {
 	if i.info.Type != dynamicplugins.PluginTypeCSINode {
-		i.logger.Debug("Skipping volume manager setup - not managing a Node plugin", "type", i.info.Type)
+		i.logger.Debug("not a node plugin, skipping volume manager setup", "type", i.info.Type)
 		return
 	}
 
@@ -95,7 +95,7 @@ func (i *instanceManager) setupVolumeManager() {
 		return
 	case <-i.fp.hadFirstSuccessfulFingerprintCh:
 		i.volumeManager = newVolumeManager(i.logger, i.client, i.mountPoint, i.containerMountPoint, i.fp.requiresStaging)
-		i.logger.Debug("Setup volume manager")
+		i.logger.Debug("volume manager setup complete")
 		close(i.volumeManagerSetupCh)
 		return
 	}

--- a/client/pluginmanager/csimanager/manager_test.go
+++ b/client/pluginmanager/csimanager/manager_test.go
@@ -110,3 +110,52 @@ func TestManager_DeregisterPlugin(t *testing.T) {
 		return !ok
 	}, 5*time.Second, 10*time.Millisecond)
 }
+
+// TestManager_MultiplePlugins ensures that multiple plugins with the same
+// name but different types (as found with monolith plugins) don't interfere
+// with each other.
+func TestManager_MultiplePlugins(t *testing.T) {
+	registry := setupRegistry()
+	defer registry.Shutdown()
+
+	require.NotNil(t, registry)
+
+	cfg := &Config{
+		Logger:                testlog.HCLogger(t),
+		DynamicRegistry:       registry,
+		UpdateNodeCSIInfoFunc: func(string, *structs.CSIInfo) {},
+		PluginResyncPeriod:    500 * time.Millisecond,
+	}
+	pm := New(cfg).(*csiManager)
+	defer pm.Shutdown()
+
+	require.NotNil(t, pm.registry)
+
+	err := registry.RegisterPlugin(fakePlugin)
+	require.Nil(t, err)
+
+	fakeNodePlugin := *fakePlugin
+	fakeNodePlugin.Type = "csi-node"
+	err = registry.RegisterPlugin(&fakeNodePlugin)
+	require.Nil(t, err)
+
+	pm.Run()
+
+	require.Eventually(t, func() bool {
+		_, ok := pm.instances[fakePlugin.Type][fakePlugin.Name]
+		return ok
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		_, ok := pm.instances[fakeNodePlugin.Type][fakeNodePlugin.Name]
+		return ok
+	}, 5*time.Second, 10*time.Millisecond)
+
+	err = registry.DeregisterPlugin(fakePlugin.Type, fakePlugin.Name)
+	require.Nil(t, err)
+
+	require.Eventually(t, func() bool {
+		_, ok := pm.instances[fakePlugin.Type][fakePlugin.Name]
+		return !ok
+	}, 5*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
This changeset is a partial fix for the client-side aspects of #7338 which will also improve #7296 (but not totally fix yet until we can somehow trigger node updates to fire).

Includes:
* The deregistration function closures that we pass up to the CSI plugin manager don't properly close over the name and type of the registration, causing monolith-type plugins to deregister only one of their two plugins on alloc shutdown. This corrects that by rebinding those variables.
* Subscribe to plugin registry events, allowing for faster updates to plugin status when allocations become terminal. The events in the registry are triggered by the plugin supervisor hook.

TODO under a separate PR:
* the server-side updates to plugin health for #7338