### PR TITLE
csi: use single-node-writer for EFS plugin e2e test

### DIFF
--- a/e2e/csi/csi.go
+++ b/e2e/csi/csi.go
@@ -183,7 +183,7 @@ func (tc *CSIVolumesTest) TestEFSVolumeClaim(f *framework.F) {
 		ID:             volID,
 		Name:           volID,
 		ExternalID:     tc.volumeIDs.EFSVolumeID,
-		AccessMode:     "multi-node-single-writer",
+		AccessMode:     "single-node-writer",
 		AttachmentMode: "file-system",
 		PluginID:       "aws-efs0",
 	}


### PR DESCRIPTION
Fixes #7360

Multi-node-single-writer isn't supported by the AWS EFS plugin, as expected for node-only plugins.