### PR TITLE
cli: Fix sample connect check example

### DIFF
--- a/command/assets/connect.nomad
+++ b/command/assets/connect.nomad
@@ -274,8 +274,10 @@ job "countdash" {
       #
       # check {
       #   name     = "alive"
-      #   type     = "tcp"
-      #   task     = "api"
+      #   type     = "script"
+      #   task     = "web"
+      #   command  = "/bin/echo"
+      #   args     = ["I", "am", "alive"]
       #   interval = "10s"
       #   timeout  = "2s"
       # }


### PR DESCRIPTION
Update the check example to be a script check, as group level checks
don't support tcp checks.  Also, fix the task name.