### PR TITLE
csi: add mount_options to volumes and volume requests

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -81,15 +81,21 @@ const (
 	CSIVolumeAccessModeMultiNodeMultiWriter  CSIVolumeAccessMode = "multi-node-multi-writer"
 )
 
+type CSIOptions struct {
+	FSType     string
+	MountFlags []string
+}
+
 // CSIVolume is used for serialization, see also nomad/structs/csi.go
 type CSIVolume struct {
-	ID             string                  `hcl:"id"`
-	Name           string                  `hcl:"name"`
-	ExternalID     string                  `hcl:"external_id"`
-	Namespace      string                  `hcl:"namespace"`
-	Topologies     []*CSITopology          `hcl:"topologies"`
+	ID             string
+	Name           string
+	ExternalID     string `hcl:"external_id"`
+	Namespace      string
+	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
 	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
+	Options        *CSIOptions
 
 	// Allocations, tracking claim status
 	ReadAllocs  map[string]*Allocation

--- a/api/csi.go
+++ b/api/csi.go
@@ -82,8 +82,9 @@ const (
 )
 
 type CSIOptions struct {
-	FSType     string
-	MountFlags []string
+	FSType       string   `hcl:"fs_type"`
+	MountFlags   []string `hcl:"mount_flags"`
+	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"` // report unexpected keys
 }
 
 // CSIVolume is used for serialization, see also nomad/structs/csi.go
@@ -95,7 +96,7 @@ type CSIVolume struct {
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
 	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
-	Options        *CSIOptions
+	MountOptions   *CSIOptions             `hcl:"mount_options"`
 
 	// Allocations, tracking claim status
 	ReadAllocs  map[string]*Allocation

--- a/api/csi.go
+++ b/api/csi.go
@@ -81,7 +81,7 @@ const (
 	CSIVolumeAccessModeMultiNodeMultiWriter  CSIVolumeAccessMode = "multi-node-multi-writer"
 )
 
-type CSIOptions struct {
+type CSIMountOptions struct {
 	FSType       string   `hcl:"fs_type"`
 	MountFlags   []string `hcl:"mount_flags"`
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"` // report unexpected keys
@@ -96,7 +96,7 @@ type CSIVolume struct {
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
 	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
-	MountOptions   *CSIOptions             `hcl:"mount_options"`
+	MountOptions   *CSIMountOptions        `hcl:"mount_options"`
 
 	// Allocations, tracking claim status
 	ReadAllocs  map[string]*Allocation

--- a/api/csi.go
+++ b/api/csi.go
@@ -158,6 +158,7 @@ type CSIVolumeListStub struct {
 	Topologies          []*CSITopology
 	AccessMode          CSIVolumeAccessMode
 	AttachmentMode      CSIVolumeAttachmentMode
+	MountOptions        *CSIMountOptions
 	Schedulable         bool
 	PluginID            string
 	Provider            string

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -377,10 +377,12 @@ func (m *MigrateStrategy) Copy() *MigrateStrategy {
 
 // VolumeRequest is a representation of a storage volume that a TaskGroup wishes to use.
 type VolumeRequest struct {
-	Name     string
-	Type     string
-	Source   string
-	ReadOnly bool `mapstructure:"read_only"`
+	Name         string
+	Type         string
+	Source       string
+	ReadOnly     bool        `hcl:"read_only"`
+	MountOptions *CSIOptions `hcl:"mount_options"`
+	ExtraKeysHCL []string    `hcl:",unusedKeys" json:"-"`
 }
 
 const (

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -380,9 +380,9 @@ type VolumeRequest struct {
 	Name         string
 	Type         string
 	Source       string
-	ReadOnly     bool        `hcl:"read_only"`
-	MountOptions *CSIOptions `hcl:"mount_options"`
-	ExtraKeysHCL []string    `hcl:",unusedKeys" json:"-"`
+	ReadOnly     bool             `hcl:"read_only"`
+	MountOptions *CSIMountOptions `hcl:"mount_options"`
+	ExtraKeysHCL []string         `hcl:",unusedKeys" json:"-"`
 }
 
 const (

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -44,10 +44,15 @@ func (c *csiHook) Prerun() error {
 			return err
 		}
 
+		fs, flags := pair.request.MountOptions()
 		usageOpts := &csimanager.UsageOptions{
 			ReadOnly:       pair.request.ReadOnly,
 			AttachmentMode: string(pair.volume.AttachmentMode),
 			AccessMode:     string(pair.volume.AccessMode),
+			MountOptions: &structs.CSIOptions{
+				FSType:     fs,
+				MountFlags: flags,
+			},
 		}
 
 		mountInfo, err := mounter.MountVolume(ctx, pair.volume, c.alloc, usageOpts, pair.publishContext)

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -44,15 +44,14 @@ func (c *csiHook) Prerun() error {
 			return err
 		}
 
-		fs, flags := pair.request.MountOptions()
+		options := pair.volume.MountOptions.Copy()
+		options.Merge(pair.request.MountOptions)
+
 		usageOpts := &csimanager.UsageOptions{
 			ReadOnly:       pair.request.ReadOnly,
 			AttachmentMode: string(pair.volume.AttachmentMode),
 			AccessMode:     string(pair.volume.AccessMode),
-			MountOptions: &structs.CSIOptions{
-				FSType:     fs,
-				MountFlags: flags,
-			},
+			MountOptions:   options,
 		}
 
 		mountInfo, err := mounter.MountVolume(ctx, pair.volume, c.alloc, usageOpts, pair.publishContext)

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -44,14 +44,11 @@ func (c *csiHook) Prerun() error {
 			return err
 		}
 
-		options := pair.volume.MountOptions.Copy()
-		options.Merge(pair.request.MountOptions)
-
 		usageOpts := &csimanager.UsageOptions{
 			ReadOnly:       pair.request.ReadOnly,
 			AttachmentMode: string(pair.volume.AttachmentMode),
 			AccessMode:     string(pair.volume.AccessMode),
-			MountOptions:   options,
+			MountOptions:   pair.request.MountOptions,
 		}
 
 		mountInfo, err := mounter.MountVolume(ctx, pair.volume, c.alloc, usageOpts, pair.publishContext)

--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -22,7 +22,7 @@ type UsageOptions struct {
 	ReadOnly       bool
 	AttachmentMode string
 	AccessMode     string
-	MountOptions   *structs.CSIOptions
+	MountOptions   *structs.CSIMountOptions
 }
 
 // ToFS is used by a VolumeManager to construct the path to where a volume

--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -22,6 +22,7 @@ type UsageOptions struct {
 	ReadOnly       bool
 	AttachmentMode string
 	AccessMode     string
+	MountOptions   *structs.CSIOptions
 }
 
 // ToFS is used by a VolumeManager to construct the path to where a volume

--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -123,10 +123,11 @@ func volumeCapability(vol *structs.CSIVolume, usage *UsageOptions) (*csi.VolumeC
 		return nil, err
 	}
 
-	opts := vol.MountOptions.Copy()
-	if opts == nil {
+	var opts *structs.CSIMountOptions
+	if vol.MountOptions == nil {
 		opts = usage.MountOptions
 	} else {
+		opts = vol.MountOptions.Copy()
 		opts.Merge(usage.MountOptions)
 	}
 

--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -123,7 +123,14 @@ func volumeCapability(vol *structs.CSIVolume, usage *UsageOptions) (*csi.VolumeC
 		return nil, err
 	}
 
-	capability.MountOptions = usage.MountOptions
+	opts := vol.MountOptions.Copy()
+	if opts == nil {
+		opts = usage.MountOptions
+	} else {
+		opts.Merge(usage.MountOptions)
+	}
+
+	capability.MountVolume = opts
 
 	return capability, nil
 }

--- a/client/pluginmanager/csimanager/volume_test.go
+++ b/client/pluginmanager/csimanager/volume_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/csi"
 	csifake "github.com/hashicorp/nomad/plugins/csi/fake"
-	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
 
@@ -358,7 +357,6 @@ func TestVolumeManager_publishVolume(t *testing.T) {
 			require.Equal(t, tc.ExpectedCSICallCount, csiFake.NodePublishVolumeCallCount)
 
 			if tc.ExpectedVolumeCapability != nil {
-				pretty.Log(csiFake.PrevVolumeCapability)
 				require.Equal(t, tc.ExpectedVolumeCapability, csiFake.PrevVolumeCapability)
 			}
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -762,6 +762,13 @@ func ApiTgToStructsTG(taskGroup *api.TaskGroup, tg *structs.TaskGroup) {
 				Source:   v.Source,
 			}
 
+			if v.MountOptions != nil {
+				vol.MountOptions = &structs.CSIMountOptions{
+					FSType:     v.MountOptions.FSType,
+					MountFlags: v.MountOptions.MountFlags,
+				}
+			}
+
 			tg.Volumes[k] = vol
 		}
 	}

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -781,7 +781,7 @@ FOUND:
 						vol.Provider,
 						vol.Schedulable,
 						volReq.ReadOnly,
-						volMountOptionString(vol.MountOptions, volReq.MountOptions)
+						csiVolMountOption(vol.MountOptions, volReq.MountOptions),
 					))
 			} else {
 				csiVolumesOutput = append(csiVolumesOutput,
@@ -799,25 +799,4 @@ FOUND:
 		c.Ui.Output(formatList(csiVolumesOutput))
 		c.Ui.Output("") // line padding to next stanza
 	}
-}
-
-func volMountOptionString(volume, request *api.CSIMountOptions) string {
-	var opts *structs.CSIMountOptions
-	if vol.MountOptions == nil {
-		opts = usage.MountOptions
-	} else {
-		opts = vol.MountOptions.Copy()
-		opts.Merge(usage.MountOptions)
-	}
-
-	out := "<none>"
-	if opts.FSType {
-		out = fmt.Sprintf("fs_type: %s", opts.FSType)
-	}
-
-	if len(opts.MountFlags) > 0 {
-		out = fmt.Sprintf("%s %s", out, strings.Join(opts.MountFlags, ", "))
-	}
-
-	return out
 }

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -781,7 +781,7 @@ FOUND:
 						vol.Provider,
 						vol.Schedulable,
 						volReq.ReadOnly,
-						"n/a", // TODO(tgross): https://github.com/hashicorp/nomad/issues/7007
+						volMountOptionString(vol.MountOptions, volReq.MountOptions)
 					))
 			} else {
 				csiVolumesOutput = append(csiVolumesOutput,
@@ -799,4 +799,25 @@ FOUND:
 		c.Ui.Output(formatList(csiVolumesOutput))
 		c.Ui.Output("") // line padding to next stanza
 	}
+}
+
+func volMountOptionString(volume, request *api.CSIMountOptions) string {
+	var opts *structs.CSIMountOptions
+	if vol.MountOptions == nil {
+		opts = usage.MountOptions
+	} else {
+		opts = vol.MountOptions.Copy()
+		opts.Merge(usage.MountOptions)
+	}
+
+	out := "<none>"
+	if opts.FSType {
+		out = fmt.Sprintf("fs_type: %s", opts.FSType)
+	}
+
+	if len(opts.MountFlags) > 0 {
+		out = fmt.Sprintf("%s %s", out, strings.Join(opts.MountFlags, ", "))
+	}
+
+	return out
 }

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -155,14 +155,7 @@ func (c *VolumeStatusCommand) formatTopologies(vol *api.CSIVolume) string {
 }
 
 func csiVolMountOption(volume, request *api.CSIMountOptions) string {
-	var vol, req, opts *structs.CSIMountOptions
-
-	if volume != nil {
-		vol = &structs.CSIMountOptions{
-			FSType:     volume.FSType,
-			MountFlags: volume.MountFlags,
-		}
-	}
+	var req, opts *structs.CSIMountOptions
 
 	if request != nil {
 		req = &structs.CSIMountOptions{
@@ -174,7 +167,10 @@ func csiVolMountOption(volume, request *api.CSIMountOptions) string {
 	if volume == nil {
 		opts = req
 	} else {
-		opts = vol.Copy()
+		opts = &structs.CSIMountOptions{
+			FSType:     volume.FSType,
+			MountFlags: volume.MountFlags,
+		}
 		opts.Merge(req)
 	}
 
@@ -188,7 +184,7 @@ func csiVolMountOption(volume, request *api.CSIMountOptions) string {
 	}
 
 	if len(opts.MountFlags) > 0 {
-		out = fmt.Sprintf("%s %s", out, strings.Join(opts.MountFlags, ", "))
+		out = fmt.Sprintf("%s flags: %s", out, strings.Join(opts.MountFlags, ", "))
 	}
 
 	return out

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -166,8 +166,8 @@ func csiVolMountOption(volume, request *api.CSIMountOptions) string {
 
 	if request != nil {
 		req = &structs.CSIMountOptions{
-			FSType:     volume.FSType,
-			MountFlags: volume.MountFlags,
+			FSType:     request.FSType,
+			MountFlags: request.MountFlags,
 		}
 	}
 

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -122,6 +122,12 @@ func TestParse(t *testing.T) {
 							"foo": {
 								Name: "foo",
 								Type: "host",
+								MountOptions: &api.CSIOptions{
+									MountFlags: []string{
+										"ro",
+									},
+								},
+								ExtraKeysHCL: nil,
 							},
 						},
 						Affinities: []*api.Affinity{

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -122,7 +122,7 @@ func TestParse(t *testing.T) {
 							"foo": {
 								Name: "foo",
 								Type: "host",
-								MountOptions: &api.CSIOptions{
+								MountOptions: &api.CSIMountOptions{
 									MountFlags: []string{
 										"ro",
 									},

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -117,11 +117,26 @@ func TestParse(t *testing.T) {
 								Operand: "=",
 							},
 						},
-
 						Volumes: map[string]*api.VolumeRequest{
 							"foo": {
-								Name: "foo",
-								Type: "host",
+								Name:         "foo",
+								Type:         "host",
+								Source:       "/path",
+								ExtraKeysHCL: nil,
+							},
+							"bar": {
+								Name:   "bar",
+								Type:   "csi",
+								Source: "bar-vol",
+								MountOptions: &api.CSIMountOptions{
+									FSType: "ext4",
+								},
+								ExtraKeysHCL: nil,
+							},
+							"baz": {
+								Name:   "baz",
+								Type:   "csi",
+								Source: "bar-vol",
 								MountOptions: &api.CSIMountOptions{
 									MountFlags: []string{
 										"ro",

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -72,6 +72,9 @@ job "binstore-storagelocker" {
 
     volume "foo" {
       type = "host"
+      mount_options {
+	mount_flags = ["ro"]
+      }
     }
 
     restart {
@@ -156,7 +159,7 @@ job "binstore-storagelocker" {
 
       volume_mount {
         volume      = "foo"
-        destination = "/mnt/foo"
+	destination = "/mnt/foo"
       }
 
       logs {

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -72,6 +72,20 @@ job "binstore-storagelocker" {
 
     volume "foo" {
       type = "host"
+      source = "/path"
+    }
+
+    volume "bar" {
+      type = "csi"
+      source = "bar-vol"
+      mount_options {
+	fs_type = "ext4"
+      }
+    }
+
+    volume "baz" {
+      type = "csi"
+      source = "bar-vol"
       mount_options {
 	mount_flags = ["ro"]
       }

--- a/jobspec/test-fixtures/basic.hcl
+++ b/jobspec/test-fixtures/basic.hcl
@@ -71,23 +71,25 @@ job "binstore-storagelocker" {
     count = 5
 
     volume "foo" {
-      type = "host"
+      type   = "host"
       source = "/path"
     }
 
     volume "bar" {
-      type = "csi"
+      type   = "csi"
       source = "bar-vol"
+
       mount_options {
-	fs_type = "ext4"
+        fs_type = "ext4"
       }
     }
 
     volume "baz" {
-      type = "csi"
+      type   = "csi"
       source = "bar-vol"
+
       mount_options {
-	mount_flags = ["ro"]
+        mount_flags = ["ro"]
       }
     }
 
@@ -173,7 +175,7 @@ job "binstore-storagelocker" {
 
       volume_mount {
         volume      = "foo"
-	destination = "/mnt/foo"
+        destination = "/mnt/foo"
       }
 
       logs {

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -551,9 +551,6 @@ func (srv *Server) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, r
 		AttachmentMode:  vol.AttachmentMode,
 		AccessMode:      vol.AccessMode,
 		ReadOnly:        req.Claim == structs.CSIVolumeClaimRead,
-		// TODO(tgross): we don't have a way of setting these yet.
-		// ref https://github.com/hashicorp/nomad/issues/7007
-		// MountOptions:   vol.MountOptions,
 	}
 	cReq.PluginID = plug.ID
 	cReq.ControllerNodeID = nodeID

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -135,9 +135,9 @@ func ValidCSIVolumeWriteAccessMode(accessMode CSIVolumeAccessMode) bool {
 	}
 }
 
-// CSIOptions contain optional additional configuration that can be used
+// CSIMountOptions contain optional additional configuration that can be used
 // when specifying that a Volume should be used with VolumeAccessTypeMount.
-type CSIOptions struct {
+type CSIMountOptions struct {
 	// FSType is an optional field that allows an operator to specify the type
 	// of the filesystem.
 	FSType string
@@ -148,11 +148,11 @@ type CSIOptions struct {
 	MountFlags []string
 }
 
-func (o *CSIOptions) Copy() *CSIOptions {
+func (o *CSIMountOptions) Copy() *CSIMountOptions {
 	return &(*o)
 }
 
-func (o *CSIOptions) Merge(p *CSIOptions) {
+func (o *CSIMountOptions) Merge(p *CSIMountOptions) {
 	if p == nil {
 		return
 	}
@@ -166,10 +166,10 @@ func (o *CSIOptions) Merge(p *CSIOptions) {
 
 // VolumeMountOptions implements the Stringer and GoStringer interfaces to prevent
 // accidental leakage of sensitive mount flags via logs.
-var _ fmt.Stringer = &CSIOptions{}
-var _ fmt.GoStringer = &CSIOptions{}
+var _ fmt.Stringer = &CSIMountOptions{}
+var _ fmt.GoStringer = &CSIMountOptions{}
 
-func (v *CSIOptions) String() string {
+func (v *CSIMountOptions) String() string {
 	mountFlagsString := "nil"
 	if len(v.MountFlags) != 0 {
 		mountFlagsString = "[REDACTED]"
@@ -178,7 +178,7 @@ func (v *CSIOptions) String() string {
 	return fmt.Sprintf("csi.CSIOptions(FSType: %s, MountFlags: %s)", v.FSType, mountFlagsString)
 }
 
-func (v *CSIOptions) GoString() string {
+func (v *CSIMountOptions) GoString() string {
 	return v.String()
 }
 
@@ -194,7 +194,7 @@ type CSIVolume struct {
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode
 	AttachmentMode CSIVolumeAttachmentMode
-	MountOptions   *CSIOptions
+	MountOptions   *CSIMountOptions
 
 	// Allocations, tracking claim status
 	ReadAllocs  map[string]*Allocation

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -149,6 +149,9 @@ type CSIMountOptions struct {
 }
 
 func (o *CSIMountOptions) Copy() *CSIMountOptions {
+	if o == nil {
+		return nil
+	}
 	return &(*o)
 }
 

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -229,6 +229,7 @@ type CSIVolListStub struct {
 	Topologies          []*CSITopology
 	AccessMode          CSIVolumeAccessMode
 	AttachmentMode      CSIVolumeAttachmentMode
+	MountOptions        *CSIMountOptions
 	CurrentReaders      int
 	CurrentWriters      int
 	Schedulable         bool
@@ -279,6 +280,7 @@ func (v *CSIVolume) Stub() *CSIVolListStub {
 		Topologies:         v.Topologies,
 		AccessMode:         v.AccessMode,
 		AttachmentMode:     v.AttachmentMode,
+		MountOptions:       v.MountOptions,
 		CurrentReaders:     len(v.ReadAllocs),
 		CurrentWriters:     len(v.WriteAllocs),
 		Schedulable:        v.Schedulable,

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -86,10 +86,11 @@ func HostVolumeSliceMerge(a, b []*ClientHostVolumeConfig) []*ClientHostVolumeCon
 
 // VolumeRequest is a representation of a storage volume that a TaskGroup wishes to use.
 type VolumeRequest struct {
-	Name     string
-	Type     string
-	Source   string
-	ReadOnly bool
+	Name         string
+	Type         string
+	Source       string
+	ReadOnly     bool
+	MountOptions *CSIOptions
 }
 
 func (v *VolumeRequest) Copy() *VolumeRequest {
@@ -98,6 +99,8 @@ func (v *VolumeRequest) Copy() *VolumeRequest {
 	}
 	nv := new(VolumeRequest)
 	*nv = *v
+
+	nv.MountOptions = &(*v.MountOptions)
 
 	return nv
 }

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -90,7 +90,7 @@ type VolumeRequest struct {
 	Type         string
 	Source       string
 	ReadOnly     bool
-	MountOptions *CSIOptions
+	MountOptions *CSIMountOptions
 }
 
 func (v *VolumeRequest) Copy() *VolumeRequest {

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -100,6 +100,10 @@ func (v *VolumeRequest) Copy() *VolumeRequest {
 	nv := new(VolumeRequest)
 	*nv = *v
 
+	if v.MountOptions == nil {
+		return nv
+	}
+
 	nv.MountOptions = &(*v.MountOptions)
 
 	return nv

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -67,6 +67,7 @@ type Client struct {
 	NextNodeUnstageVolumeErr   error
 	NodeUnstageVolumeCallCount int64
 
+	PrevVolumeCapability       *csi.VolumeCapability
 	NextNodePublishVolumeErr   error
 	NodePublishVolumeCallCount int64
 
@@ -217,6 +218,7 @@ func (c *Client) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 
+	c.PrevVolumeCapability = req.VolumeCapability
 	c.NodePublishVolumeCallCount++
 
 	return c.NextNodePublishVolumeErr

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -361,7 +361,7 @@ func (v VolumeAccessType) String() string {
 type VolumeCapability struct {
 	AccessType   VolumeAccessType
 	AccessMode   VolumeAccessMode
-	MountOptions *structs.CSIOptions
+	MountOptions *structs.CSIMountOptions
 }
 
 func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sAccessMode structs.CSIVolumeAccessMode) (*VolumeCapability, error) {

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -431,11 +431,8 @@ func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sA
 	}
 
 	return &VolumeCapability{
-		AccessType:         accessType,
-		AccessMode:         accessMode,
-		VolumeMountOptions: &VolumeMountOptions{
-			// GH-7007: Currently we have no way to provide these
-		},
+		AccessType: accessType,
+		AccessMode: accessMode,
 	}, nil
 }
 

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -357,42 +357,11 @@ func (v VolumeAccessType) String() string {
 	}
 }
 
-// VolumeMountOptions contain optional additional configuration that can be used
-// when specifying that a Volume should be used with VolumeAccessTypeMount.
-type VolumeMountOptions struct {
-	// FSType is an optional field that allows an operator to specify the type
-	// of the filesystem.
-	FSType string
-
-	// MountFlags contains additional options that may be used when mounting the
-	// volume by the plugin. This may contain sensitive data and should not be
-	// leaked.
-	MountFlags []string
-}
-
-// VolumeMountOptions implements the Stringer and GoStringer interfaces to prevent
-// accidental leakage of sensitive mount flags via logs.
-var _ fmt.Stringer = &VolumeMountOptions{}
-var _ fmt.GoStringer = &VolumeMountOptions{}
-
-func (v *VolumeMountOptions) String() string {
-	mountFlagsString := "nil"
-	if len(v.MountFlags) != 0 {
-		mountFlagsString = "[REDACTED]"
-	}
-
-	return fmt.Sprintf("csi.VolumeMountOptions(FSType: %s, MountFlags: %s)", v.FSType, mountFlagsString)
-}
-
-func (v *VolumeMountOptions) GoString() string {
-	return v.String()
-}
-
 // VolumeCapability describes the overall usage requirements for a given CSI Volume
 type VolumeCapability struct {
-	AccessType         VolumeAccessType
-	AccessMode         VolumeAccessMode
-	VolumeMountOptions *VolumeMountOptions
+	AccessType   VolumeAccessType
+	AccessMode   VolumeAccessMode
+	MountOptions *structs.CSIOptions
 }
 
 func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sAccessMode structs.CSIVolumeAccessMode) (*VolumeCapability, error) {
@@ -450,8 +419,8 @@ func (c *VolumeCapability) ToCSIRepresentation() *csipbv1.VolumeCapability {
 	if c.AccessType == VolumeAccessTypeMount {
 		vc.AccessType = &csipbv1.VolumeCapability_Mount{
 			Mount: &csipbv1.VolumeCapability_MountVolume{
-				FsType:     c.VolumeMountOptions.FSType,
-				MountFlags: c.VolumeMountOptions.MountFlags,
+				FsType:     c.MountOptions.FSType,
+				MountFlags: c.MountOptions.MountFlags,
 			},
 		}
 	} else {

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -419,12 +419,12 @@ func (c *VolumeCapability) ToCSIRepresentation() *csipbv1.VolumeCapability {
 	}
 
 	if c.AccessType == VolumeAccessTypeMount {
-		vc.AccessType = &csipbv1.VolumeCapability_Mount{
-			Mount: &csipbv1.VolumeCapability_MountVolume{
-				FsType:     c.MountVolume.FSType,
-				MountFlags: c.MountVolume.MountFlags,
-			},
+		opts := &csipbv1.VolumeCapability_MountVolume{}
+		if c.MountVolume != nil {
+			opts.FsType = c.MountVolume.FSType
+			opts.MountFlags = c.MountVolume.MountFlags
 		}
+		vc.AccessType = &csipbv1.VolumeCapability_Mount{Mount: opts}
 	} else {
 		vc.AccessType = &csipbv1.VolumeCapability_Block{Block: &csipbv1.VolumeCapability_BlockVolume{}}
 	}

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -359,9 +359,11 @@ func (v VolumeAccessType) String() string {
 
 // VolumeCapability describes the overall usage requirements for a given CSI Volume
 type VolumeCapability struct {
-	AccessType   VolumeAccessType
-	AccessMode   VolumeAccessMode
-	MountOptions *structs.CSIMountOptions
+	AccessType VolumeAccessType
+	AccessMode VolumeAccessMode
+
+	// Indicate that the volume will be accessed via the filesystem API.
+	MountVolume *structs.CSIMountOptions
 }
 
 func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sAccessMode structs.CSIVolumeAccessMode) (*VolumeCapability, error) {
@@ -419,8 +421,8 @@ func (c *VolumeCapability) ToCSIRepresentation() *csipbv1.VolumeCapability {
 	if c.AccessType == VolumeAccessTypeMount {
 		vc.AccessType = &csipbv1.VolumeCapability_Mount{
 			Mount: &csipbv1.VolumeCapability_MountVolume{
-				FsType:     c.MountOptions.FSType,
-				MountFlags: c.MountOptions.MountFlags,
+				FsType:     c.MountVolume.FSType,
+				MountFlags: c.MountVolume.MountFlags,
 			},
 		}
 	} else {


### PR DESCRIPTION
Add `mount_options` to both the volume definition on registration and to the `volume` block in the group where the volume is requested. If both are specified, the options provided in the request replace the options defined in the volume. They get passed to the `NodePublishVolume`, which causes the node plugin to actually mount the volume on the host.

Individual tasks just mount bind into the host mounted volume (unchanged behavior). An operator can mount the same volume with different options by specifying it twice in the group context.

closes #7007 