### PR TITLE
client: customize dynamic port range

### DIFF
--- a/api/resources.go
+++ b/api/resources.go
@@ -89,16 +89,22 @@ type Port struct {
 	To    int `mapstructure:"to"`
 }
 
+type PortRange struct {
+	Min int
+	Max int
+}
+
 // NetworkResource is used to describe required network
 // resources of a given task.
 type NetworkResource struct {
-	Mode          string
-	Device        string
-	CIDR          string
-	IP            string
-	MBits         *int
-	ReservedPorts []Port
-	DynamicPorts  []Port
+	Mode             string
+	Device           string
+	CIDR             string
+	IP               string
+	MBits            *int
+	ReservedPorts    []Port
+	DynamicPorts     []Port
+	DynamicPortRange PortRange
 }
 
 func (n *NetworkResource) Canonicalize() {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -972,6 +972,10 @@ func ApiNetworkResourceToStructs(in []*api.NetworkResource) []*structs.NetworkRe
 			CIDR:  nw.CIDR,
 			IP:    nw.IP,
 			MBits: *nw.MBits,
+			DynamicPortRange: structs.PortRange{
+				Min: nw.DynamicPortRange.Min,
+				Max: nw.DynamicPortRange.Max,
+			},
 		}
 
 		if l := len(nw.DynamicPorts); l != 0 {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1641,6 +1641,10 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 											Value: 2000,
 										},
 									},
+									DynamicPortRange: api.PortRange{
+										Min: 1000,
+										Max: 10000,
+									},
 								},
 							},
 							Devices: []*api.RequestedDevice{
@@ -1988,6 +1992,10 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 											Value: 2000,
 										},
 									},
+									DynamicPortRange: structs.PortRange{
+										Min: 1000,
+										Max: 10000,
+									},
 								},
 							},
 							Devices: []*structs.RequestedDevice{
@@ -2154,6 +2162,10 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 											Value: 2000,
 										},
 									},
+									DynamicPortRange: api.PortRange{
+										Min: 1000,
+										Max: 10000,
+									},
 								},
 							},
 						},
@@ -2271,6 +2283,10 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 											Label: "ssh",
 											Value: 2000,
 										},
+									},
+									DynamicPortRange: structs.PortRange{
+										Min: 1000,
+										Max: 10000,
 									},
 								},
 							},

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -270,7 +270,7 @@ func parseTask(item *ast.ObjectItem) (*api.Task, error) {
 		}
 
 		t.DispatchPayload = &api.DispatchPayloadConfig{}
-		if err := mapstructure.WeakDecode(m, t.DispatchPayload); err != nil {
+		if err := mapstructure.WeakDecode(m, &t.DispatchPayload); err != nil {
 			return nil, err
 		}
 	}

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1080,6 +1080,43 @@ func TestParse(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"dynamic-port-range.hcl",
+			&api.Job{
+				ID:   helper.StringToPtr("foo"),
+				Name: helper.StringToPtr("foo"),
+				TaskGroups: []*api.TaskGroup{{
+					Name: helper.StringToPtr("example"),
+					Tasks: []*api.Task{{
+						Name: "server",
+						Resources: &api.Resources{
+							Networks: []*api.NetworkResource{{
+								MBits: helper.IntToPtr(200),
+								ReservedPorts: []api.Port{
+									{
+										Label: "lb",
+										Value: 8889,
+									},
+								},
+								DynamicPorts: []api.Port{
+									{
+										Label: "http",
+									},
+									{
+										Label: "https",
+									},
+								},
+								DynamicPortRange: api.PortRange{
+									Min: 4000,
+									Max: 5000,
+								},
+							}},
+						},
+					}},
+				}},
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/jobspec/test-fixtures/dynamic-port-range.hcl
+++ b/jobspec/test-fixtures/dynamic-port-range.hcl
@@ -1,0 +1,20 @@
+job "foo" {
+  group "example" {
+    task "server" {
+      resources {
+        network {
+          mbits = 200
+          port "http" {}
+          port "https" {}
+          port "lb" {
+            static = "8889"
+          }
+          dynamic_port_range {
+              min = 4000
+              max = 5000
+          }
+        }
+      }
+    }
+  }
+}

--- a/nomad/structs/network.go
+++ b/nomad/structs/network.go
@@ -354,7 +354,14 @@ func getDynamicPortsPrecise(nodeUsed Bitmap, ask *NetworkResource) ([]int, error
 	}
 
 	// Get the indexes of the unset
-	availablePorts := usedSet.IndexesInRange(false, MinDynamicPort, MaxDynamicPort)
+	minDynamicPort, maxDynamicPort := MinDynamicPort, MaxDynamicPort
+
+	// optionally use custom port range
+	if ask.DynamicPortRange.Min > 0 && ask.DynamicPortRange.Max > 0 {
+		minDynamicPort, maxDynamicPort = ask.DynamicPortRange.Min, ask.DynamicPortRange.Max
+	}
+
+	availablePorts := usedSet.IndexesInRange(false, uint(minDynamicPort), uint(maxDynamicPort))
 
 	// Randomize the amount we need
 	numDyn := len(ask.DynamicPorts)
@@ -390,7 +397,13 @@ func getDynamicPortsStochastic(nodeUsed Bitmap, ask *NetworkResource) ([]int, er
 			return nil, fmt.Errorf("stochastic dynamic port selection failed")
 		}
 
-		randPort := MinDynamicPort + rand.Intn(MaxDynamicPort-MinDynamicPort)
+		minDynamicPort, maxDynamicPort := MinDynamicPort, MaxDynamicPort
+
+		// optionally use custom port range
+		if ask.DynamicPortRange.Min > 0 && ask.DynamicPortRange.Max > 0 {
+			minDynamicPort, maxDynamicPort = ask.DynamicPortRange.Min, ask.DynamicPortRange.Max
+		}
+		randPort := minDynamicPort + rand.Intn(maxDynamicPort-minDynamicPort)
 		if nodeUsed != nil && nodeUsed.Check(uint(randPort)) {
 			goto PICK
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2108,16 +2108,22 @@ type Port struct {
 	To    int
 }
 
+type PortRange struct {
+	Min int
+	Max int
+}
+
 // NetworkResource is used to represent available network
 // resources
 type NetworkResource struct {
-	Mode          string // Mode of the network
-	Device        string // Name of the device
-	CIDR          string // CIDR block of addresses
-	IP            string // Host IP address
-	MBits         int    // Throughput
-	ReservedPorts []Port // Host Reserved ports
-	DynamicPorts  []Port // Host Dynamically assigned ports
+	Mode             string    // Mode of the network
+	Device           string    // Name of the device
+	CIDR             string    // CIDR block of addresses
+	IP               string    // Host IP address
+	MBits            int       // Throughput
+	ReservedPorts    []Port    // Host Reserved ports
+	DynamicPorts     []Port    // Host Dynamically assigned ports
+	DynamicPortRange PortRange // Optional dynamic port range
 }
 
 func (nr *NetworkResource) Equals(other *NetworkResource) bool {
@@ -2166,6 +2172,11 @@ func (nr *NetworkResource) Equals(other *NetworkResource) bool {
 		}
 	}
 
+	if nr.DynamicPortRange.Min != other.DynamicPortRange.Min ||
+		nr.DynamicPortRange.Max != other.DynamicPortRange.Max {
+		return false
+	}
+
 	return true
 }
 
@@ -2205,6 +2216,9 @@ func (n *NetworkResource) Copy() *NetworkResource {
 		newR.DynamicPorts = make([]Port, len(n.DynamicPorts))
 		copy(newR.DynamicPorts, n.DynamicPorts)
 	}
+
+	newR.DynamicPortRange = n.DynamicPortRange
+
 	return newR
 }
 


### PR DESCRIPTION
Adds new configuration option to NetworkResource called `dynamic_port_range` for #1087.
This allows tasks to optionally override the default port range of 20000-32000.