### PR TITLE
Enforce `scaling.[min,max]` when scheduling

### DIFF
--- a/api/scaling.go
+++ b/api/scaling.go
@@ -28,9 +28,19 @@ func (s *Scaling) GetPolicy(ID string, q *QueryOptions) (*ScalingPolicy, *QueryM
 	return &policy, qm, nil
 }
 
-func (p *ScalingPolicy) Canonicalize() {
+func (p *ScalingPolicy) Canonicalize(tg *TaskGroup) {
 	if p.Enabled == nil {
 		p.Enabled = boolToPtr(true)
+	}
+	if p.Min == nil {
+		var m int64
+		if tg.Count != nil {
+			m = int64(*tg.Count)
+		} else {
+			// this should not be at this point, but safeguard here just in case
+			m = 0
+		}
+		p.Min = &m
 	}
 }
 
@@ -51,7 +61,7 @@ type ScalingPolicy struct {
 	ID          string
 	Namespace   string
 	Target      map[string]string
-	Min         int64
+	Min         *int64
 	Max         int64
 	Policy      map[string]interface{}
 	Enabled     *bool

--- a/api/scaling_test.go
+++ b/api/scaling_test.go
@@ -22,7 +22,9 @@ func TestScalingPolicies_ListPolicies(t *testing.T) {
 
 	// Register a job with a scaling policy
 	job := testJob()
-	job.TaskGroups[0].Scaling = &ScalingPolicy{}
+	job.TaskGroups[0].Scaling = &ScalingPolicy{
+		Max: 100,
+	}
 	_, _, err = jobs.Register(job, nil)
 	require.NoError(err)
 
@@ -72,6 +74,8 @@ func TestScalingPolicies_GetPolicy(t *testing.T) {
 	job := testJob()
 	policy := &ScalingPolicy{
 		Enabled: boolToPtr(true),
+		Min: int64ToPtr(1),
+		Max: 1,
 		Policy: map[string]interface{}{
 			"key": "value",
 		},

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -442,7 +442,11 @@ func (g *TaskGroup) Canonicalize(job *Job) {
 		g.Name = stringToPtr("")
 	}
 	if g.Count == nil {
-		g.Count = intToPtr(1)
+		if g.Scaling != nil && g.Scaling.Min != nil {
+			g.Count = intToPtr(int(*g.Scaling.Min))
+		} else {
+			g.Count = intToPtr(1)
+		}
 	}
 	for _, t := range g.Tasks {
 		t.Canonicalize(g, job)
@@ -542,8 +546,9 @@ func (g *TaskGroup) Canonicalize(job *Job) {
 	for _, s := range g.Services {
 		s.Canonicalize(nil, g, job)
 	}
+
 	if g.Scaling != nil {
-		g.Scaling.Canonicalize()
+		g.Scaling.Canonicalize(g)
 	}
 }
 

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -52,6 +52,8 @@ func testJobWithScalingPolicy() *Job {
 	job := testJob()
 	job.TaskGroups[0].Scaling = &ScalingPolicy{
 		Policy:  map[string]interface{}{},
+		Min: int64ToPtr(1),
+		Max: 1,
 		Enabled: boolToPtr(true),
 	}
 	return job

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -814,7 +814,7 @@ func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.Ta
 	}
 
 	if taskGroup.Scaling != nil {
-		tg.Scaling = ApiScalingPolicyToStructs(taskGroup.Scaling).TargetTaskGroup(job, tg)
+		tg.Scaling = ApiScalingPolicyToStructs(tg.Count, taskGroup.Scaling).TargetTaskGroup(job, tg)
 	}
 
 	tg.EphemeralDisk = &structs.EphemeralDisk{

--- a/command/agent/scaling_endpoint.go
+++ b/command/agent/scaling_endpoint.go
@@ -75,12 +75,15 @@ func (s *HTTPServer) scalingPolicyQuery(resp http.ResponseWriter, req *http.Requ
 	return out.Policy, nil
 }
 
-func ApiScalingPolicyToStructs(ap *api.ScalingPolicy) *structs.ScalingPolicy {
-	return &structs.ScalingPolicy{
+func ApiScalingPolicyToStructs(count int, ap *api.ScalingPolicy) *structs.ScalingPolicy {
+	p := structs.ScalingPolicy{
 		Enabled: *ap.Enabled,
-		Min:     ap.Min,
 		Max:     ap.Max,
 		Policy:  ap.Policy,
 		Target:  map[string]string{},
 	}
+	if ap.Min == nil {
+		p.Min = int64(count)
+	}
+	return &p
 }

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1035,6 +1035,8 @@ func JobWithScalingPolicy() (*structs.Job, *structs.ScalingPolicy) {
 	job := Job()
 	policy := &structs.ScalingPolicy{
 		ID:      uuid.Generate(),
+		Min:     int64(job.TaskGroups[0].Count),
+		Max:     int64(job.TaskGroups[0].Count),
 		Policy:  map[string]interface{}{},
 		Enabled: true,
 	}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/helper/uuid"
+
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,54 @@ func TestJob_Validate(t *testing.T) {
 	if !strings.Contains(mErr.Error(), "datacenter must be non-empty string") {
 		t.Fatalf("err: %s", err)
 	}
+}
+
+func TestJob_ValidateScaling(t *testing.T) {
+	require := require.New(t)
+
+	p := &ScalingPolicy{
+		Policy:  nil, // allowed to be nil
+		Min:     5,
+		Max:     5,
+		Enabled: true,
+	}
+	job := testJob()
+	job.TaskGroups[0].Scaling = p
+	job.TaskGroups[0].Count = 5
+
+	require.NoError(job.Validate())
+
+	// min <= max
+	p.Max = 0
+	p.Min = 10
+	err := job.Validate()
+	require.Error(err)
+	mErr := err.(*multierror.Error)
+	require.Len(mErr.Errors, 1)
+	require.Contains(mErr.Errors[0].Error(), "maximum count must not be less than minimum count")
+	require.Contains(mErr.Errors[0].Error(), "task group count must not be less than minimum count in scaling policy")
+	require.Contains(mErr.Errors[0].Error(), "task group count must not be greater than maximum count in scaling policy")
+
+	// count <= max
+	p.Max = 0
+	p.Min = 5
+	job.TaskGroups[0].Count = 5
+	err = job.Validate()
+	require.Error(err)
+	mErr = err.(*multierror.Error)
+	require.Len(mErr.Errors, 1)
+	require.Contains(mErr.Errors[0].Error(), "maximum count must not be less than minimum count")
+	require.Contains(mErr.Errors[0].Error(), "task group count must not be greater than maximum count in scaling policy")
+
+	// min <= count
+	job.TaskGroups[0].Count = 0
+	p.Min = 5
+	p.Max = 5
+	err = job.Validate()
+	require.Error(err)
+	mErr = err.(*multierror.Error)
+	require.Len(mErr.Errors, 1)
+	require.Contains(mErr.Errors[0].Error(), "task group count must not be less than minimum count in scaling policy")
 }
 
 func TestJob_Warnings(t *testing.T) {


### PR DESCRIPTION
resolves #7412 

instead of modifying the scheduler, i implemented enforcement of `Scaling.[Min,Max]` during job validation. 

also, default for TaskGroup.Count and TaskGroup.Scaling.Min are part of this PR; tg.Count defaults to tg.Scaling.Min, falling back to 1 if no scaling policy. tg.Scaling.Min defaults to tg.Count.