### PR TITLE
ACL support for scaling APIs

### DIFF
--- a/acl/policy.go
+++ b/acl/policy.go
@@ -11,9 +11,10 @@ const (
 	// The following levels are the only valid values for the `policy = "read"` stanza.
 	// When policies are merged together, the most privilege is granted, except for deny
 	// which always takes precedence and supercedes.
-	PolicyDeny  = "deny"
-	PolicyRead  = "read"
-	PolicyWrite = "write"
+	PolicyDeny       = "deny"
+	PolicyRead       = "read"
+	PolicyWrite      = "write"
+	PolicyAutoscaler = "autoscaler"
 )
 
 const (
@@ -22,18 +23,21 @@ const (
 	// combined we take the union of all capabilities. If the deny capability is present, it
 	// takes precedence and overwrites all other capabilities.
 
-	NamespaceCapabilityDeny             = "deny"
-	NamespaceCapabilityListJobs         = "list-jobs"
-	NamespaceCapabilityReadJob          = "read-job"
-	NamespaceCapabilityScaleJob         = "scale-job"
-	NamespaceCapabilitySubmitJob        = "submit-job"
-	NamespaceCapabilityDispatchJob      = "dispatch-job"
-	NamespaceCapabilityReadLogs         = "read-logs"
-	NamespaceCapabilityReadFS           = "read-fs"
-	NamespaceCapabilityAllocExec        = "alloc-exec"
-	NamespaceCapabilityAllocNodeExec    = "alloc-node-exec"
-	NamespaceCapabilityAllocLifecycle   = "alloc-lifecycle"
-	NamespaceCapabilitySentinelOverride = "sentinel-override"
+	NamespaceCapabilityDeny                = "deny"
+	NamespaceCapabilityListJobs            = "list-jobs"
+	NamespaceCapabilityReadJob             = "read-job"
+	NamespaceCapabilitySubmitJob           = "submit-job"
+	NamespaceCapabilityDispatchJob         = "dispatch-job"
+	NamespaceCapabilityReadLogs            = "read-logs"
+	NamespaceCapabilityReadFS              = "read-fs"
+	NamespaceCapabilityAllocExec           = "alloc-exec"
+	NamespaceCapabilityAllocNodeExec       = "alloc-node-exec"
+	NamespaceCapabilityAllocLifecycle      = "alloc-lifecycle"
+	NamespaceCapabilitySentinelOverride    = "sentinel-override"
+	NamespaceCapabilityListScalingPolicies = "list-scaling-policies"
+	NamespaceCapabilityReadScalingPolicy   = "read-scaling-policy"
+	NamespaceCapabilityReadJobScaling      = "read-job-scaling"
+	NamespaceCapabilityScaleJob            = "scale-job"
 )
 
 var (
@@ -110,7 +114,7 @@ type QuotaPolicy struct {
 // isPolicyValid makes sure the given string matches one of the valid policies.
 func isPolicyValid(policy string) bool {
 	switch policy {
-	case PolicyDeny, PolicyRead, PolicyWrite:
+	case PolicyDeny, PolicyRead, PolicyWrite, PolicyAutoscaler:
 		return true
 	default:
 		return false
@@ -123,7 +127,9 @@ func isNamespaceCapabilityValid(cap string) bool {
 	case NamespaceCapabilityDeny, NamespaceCapabilityListJobs, NamespaceCapabilityReadJob,
 		NamespaceCapabilitySubmitJob, NamespaceCapabilityDispatchJob, NamespaceCapabilityReadLogs,
 		NamespaceCapabilityReadFS, NamespaceCapabilityAllocLifecycle,
-		NamespaceCapabilityAllocExec, NamespaceCapabilityAllocNodeExec:
+		NamespaceCapabilityAllocExec, NamespaceCapabilityAllocNodeExec,
+		NamespaceCapabilityListScalingPolicies, NamespaceCapabilityReadScalingPolicy,
+		NamespaceCapabilityReadJobScaling, NamespaceCapabilityScaleJob:
 		return true
 	// Separate the enterprise-only capabilities
 	case NamespaceCapabilitySentinelOverride:
@@ -143,17 +149,31 @@ func expandNamespacePolicy(policy string) []string {
 		return []string{
 			NamespaceCapabilityListJobs,
 			NamespaceCapabilityReadJob,
+			NamespaceCapabilityReadJobScaling,
+			NamespaceCapabilityListScalingPolicies,
+			NamespaceCapabilityReadScalingPolicy,
 		}
 	case PolicyWrite:
 		return []string{
 			NamespaceCapabilityListJobs,
 			NamespaceCapabilityReadJob,
+			NamespaceCapabilityReadJobScaling,
+			NamespaceCapabilityScaleJob,
 			NamespaceCapabilitySubmitJob,
 			NamespaceCapabilityDispatchJob,
 			NamespaceCapabilityReadLogs,
 			NamespaceCapabilityReadFS,
 			NamespaceCapabilityAllocExec,
 			NamespaceCapabilityAllocLifecycle,
+			NamespaceCapabilityListScalingPolicies,
+			NamespaceCapabilityReadScalingPolicy,
+		}
+	case PolicyAutoscaler:
+		return []string{
+			NamespaceCapabilityReadJobScaling,
+			NamespaceCapabilityScaleJob,
+			NamespaceCapabilityListScalingPolicies,
+			NamespaceCapabilityReadScalingPolicy,
 		}
 	default:
 		return nil

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -30,6 +30,9 @@ func TestParse(t *testing.T) {
 						Capabilities: []string{
 							NamespaceCapabilityListJobs,
 							NamespaceCapabilityReadJob,
+							NamespaceCapabilityReadJobScaling,
+							NamespaceCapabilityListScalingPolicies,
+							NamespaceCapabilityReadScalingPolicy,
 						},
 					},
 				},
@@ -46,6 +49,9 @@ func TestParse(t *testing.T) {
 			namespace "secret" {
 				capabilities = ["deny", "read-logs"]
 			}
+            namespace "prod" {
+                policy = "autoscaler"
+            }
 			agent {
 				policy = "read"
 			}
@@ -68,6 +74,9 @@ func TestParse(t *testing.T) {
 						Capabilities: []string{
 							NamespaceCapabilityListJobs,
 							NamespaceCapabilityReadJob,
+							NamespaceCapabilityReadJobScaling,
+							NamespaceCapabilityListScalingPolicies,
+							NamespaceCapabilityReadScalingPolicy,
 						},
 					},
 					{
@@ -76,12 +85,16 @@ func TestParse(t *testing.T) {
 						Capabilities: []string{
 							NamespaceCapabilityListJobs,
 							NamespaceCapabilityReadJob,
+							NamespaceCapabilityReadJobScaling,
+							NamespaceCapabilityScaleJob,
 							NamespaceCapabilitySubmitJob,
 							NamespaceCapabilityDispatchJob,
 							NamespaceCapabilityReadLogs,
 							NamespaceCapabilityReadFS,
 							NamespaceCapabilityAllocExec,
 							NamespaceCapabilityAllocLifecycle,
+							NamespaceCapabilityListScalingPolicies,
+							NamespaceCapabilityReadScalingPolicy,
 						},
 					},
 					{
@@ -89,6 +102,16 @@ func TestParse(t *testing.T) {
 						Capabilities: []string{
 							NamespaceCapabilityDeny,
 							NamespaceCapabilityReadLogs,
+						},
+					},
+					{
+						Name:   "prod",
+						Policy: PolicyAutoscaler,
+						Capabilities: []string{
+							NamespaceCapabilityReadJobScaling,
+							NamespaceCapabilityScaleJob,
+							NamespaceCapabilityListScalingPolicies,
+							NamespaceCapabilityReadScalingPolicy,
 						},
 					},
 				},

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/gorhill/cronexpr"
+
+	"github.com/hashicorp/nomad/helper"
 )
 
 const (
@@ -155,10 +157,14 @@ func (j *Jobs) Info(jobID string, q *QueryOptions) (*Job, *QueryMeta, error) {
 
 // Scale is used to retrieve information about a particular
 // job given its unique ID.
-func (j *Jobs) Scale(jobID, group string, count int,
+func (j *Jobs) Scale(jobID, group string, count *int,
 	reason, error *string, meta map[string]interface{}, q *WriteOptions) (*JobRegisterResponse, *WriteMeta, error) {
+	var count64 *int64
+	if count != nil {
+		count64 = helper.Int64ToPtr(int64(*count))
+	}
 	req := &ScalingRequest{
-		Count: int64(count),
+		Count: count64,
 		Target: map[string]string{
 			"Job":   jobID,
 			"Group": group,

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/gorhill/cronexpr"
-
-	"github.com/hashicorp/nomad/helper"
 )
 
 const (
@@ -161,7 +159,7 @@ func (j *Jobs) Scale(jobID, group string, count *int,
 	reason, error *string, meta map[string]interface{}, q *WriteOptions) (*JobRegisterResponse, *WriteMeta, error) {
 	var count64 *int64
 	if count != nil {
-		count64 = helper.Int64ToPtr(int64(*count))
+		count64 = int64ToPtr(int64(*count))
 	}
 	req := &ScalingRequest{
 		Count: count64,

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -930,7 +930,7 @@ func TestJobs_ScaleInvalidAction(t *testing.T) {
 		{"i-dont-exist", "me-neither", 1, "404"},
 	}
 	for _, test := range tests {
-		_, _, err := jobs.Scale(test.jobID, test.group, test.value, stringToPtr("reason"), nil, nil, nil)
+		_, _, err := jobs.Scale(test.jobID, test.group, &test.value, stringToPtr("reason"), nil, nil, nil)
 		require.Errorf(err, "expected jobs.Scale(%s, %s) to fail", test.jobID, test.group)
 		require.Containsf(err.Error(), test.want, "jobs.Scale(%s, %s) error doesn't contain %s, got: %s", test.jobID, test.group, test.want, err)
 	}
@@ -943,7 +943,7 @@ func TestJobs_ScaleInvalidAction(t *testing.T) {
 	assertWriteMeta(t, wm)
 
 	// Perform a scaling action with bad group name, verify error
-	_, _, err = jobs.Scale(*job.ID, "incorrect-group-name", 2,
+	_, _, err = jobs.Scale(*job.ID, "incorrect-group-name", intToPtr(2),
 		stringToPtr("because"), nil, nil, nil)
 	require.Error(err)
 	require.Contains(err.Error(), "does not exist")
@@ -1590,7 +1590,7 @@ func TestJobs_ScaleAction(t *testing.T) {
 	groupCount := *job.TaskGroups[0].Count
 
 	// Trying to scale against a target before it exists returns an error
-	_, _, err := jobs.Scale(id, "missing", groupCount+1, stringToPtr("this won't work"), nil, nil, nil)
+	_, _, err := jobs.Scale(id, "missing", intToPtr(groupCount+1), stringToPtr("this won't work"), nil, nil, nil)
 	require.Error(err)
 	require.Contains(err.Error(), "not found")
 
@@ -1602,7 +1602,7 @@ func TestJobs_ScaleAction(t *testing.T) {
 	// Perform scaling action
 	newCount := groupCount + 1
 	resp1, wm, err := jobs.Scale(id, groupName,
-		newCount, stringToPtr("need more instances"), nil, nil, nil)
+		intToPtr(newCount), stringToPtr("need more instances"), nil, nil, nil)
 
 	require.NoError(err)
 	require.NotNil(resp1)

--- a/api/scaling.go
+++ b/api/scaling.go
@@ -46,7 +46,7 @@ func (p *ScalingPolicy) Canonicalize(tg *TaskGroup) {
 
 // ScalingRequest is the payload for a generic scaling action
 type ScalingRequest struct {
-	Count  int64
+	Count  *int64
 	Target map[string]string
 	Reason *string
 	Error  *string

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -52,8 +52,8 @@ func testJobWithScalingPolicy() *Job {
 	job := testJob()
 	job.TaskGroups[0].Scaling = &ScalingPolicy{
 		Policy:  map[string]interface{}{},
-		Min: int64ToPtr(1),
-		Max: 1,
+		Min:     int64ToPtr(1),
+		Max:     1,
 		Enabled: boolToPtr(true),
 	}
 	return job
@@ -93,11 +93,6 @@ func testQuotaSpec() *QuotaSpec {
 
 // conversions utils only used for testing
 // added here to avoid linter warning
-
-// int64ToPtr returns the pointer to an int
-func int64ToPtr(i int64) *int64 {
-	return &i
-}
 
 // float64ToPtr returns the pointer to an float64
 func float64ToPtr(f float64) *float64 {

--- a/api/utils.go
+++ b/api/utils.go
@@ -26,6 +26,11 @@ func uint64ToPtr(u uint64) *uint64 {
 	return &u
 }
 
+// int64ToPtr returns the pointer to a int64
+func int64ToPtr(u int64) *int64 {
+	return &u
+}
+
 // stringToPtr returns the pointer to a string
 func stringToPtr(str string) *string {
 	return &str

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -686,7 +686,7 @@ func TestHTTP_Job_ScaleTaskGroup(t *testing.T) {
 
 		newCount := job.TaskGroups[0].Count + 1
 		scaleReq := &api.ScalingRequest{
-			Count:  int64(newCount),
+			Count:  helper.Int64ToPtr(int64(newCount)),
 			Reason: helper.StringToPtr("testing"),
 			Target: map[string]string{
 				"Job":   job.ID,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1687,13 +1687,16 @@ func (j *Job) ScaleStatus(args *structs.JobScaleStatusRequest,
 	}
 	defer metrics.MeasureSince([]string{"nomad", "job", "scale_status"}, time.Now())
 
-	// FINISH
-	// Check for job-autoscaler permissions
-	// if aclObj, err := j.srv.ResolveToken(args.AuthToken); err != nil {
-	// 	return err
-	// } else if aclObj != nil && !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
-	// 	return structs.ErrPermissionDenied
-	// }
+	// Check for autoscaler permissions
+	if aclObj, err := j.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil {
+		hasReadJob := aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob)
+		hasReadJobScaling := aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJobScaling)
+		if !(hasReadJob || hasReadJobScaling) {
+			return structs.ErrPermissionDenied
+		}
+	}
 
 	// Setup the blocking query
 	opts := blockingOptions{

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -851,12 +851,22 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	if groupName == "" {
 		return structs.NewErrRPCCoded(400, "missing task group name for scaling action")
 	}
+	if args.Error != nil && args.Reason != nil {
+		return structs.NewErrRPCCoded(400, "scaling action should not contain error and scaling reason")
+	}
+	if args.Error != nil && args.Count != nil {
+		return structs.NewErrRPCCoded(400, "scaling action should not contain error and count")
+	}
 
 	// Check for submit-job permissions
 	if aclObj, err := j.srv.ResolveToken(args.AuthToken); err != nil {
 		return err
-	} else if aclObj != nil && !aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityScaleJob) {
-		return structs.ErrPermissionDenied
+	} else if aclObj != nil {
+		hasScaleJob := aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityScaleJob)
+		hasSubmitJob := aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilitySubmitJob)
+		if !(hasScaleJob || hasSubmitJob) {
+			return structs.ErrPermissionDenied
+		}
 	}
 
 	// Lookup the job
@@ -873,38 +883,42 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		return structs.NewErrRPCCoded(404, fmt.Sprintf("job %q not found", args.JobID))
 	}
 
-	found := false
-	for _, tg := range job.TaskGroups {
-		if groupName == tg.Name {
-			tg.Count = int(args.Count) // TODO: not safe, check this above
-			found = true
-			break
+	index := job.ModifyIndex
+	if args.Count != nil {
+		found := false
+		for _, tg := range job.TaskGroups {
+			if groupName == tg.Name {
+				tg.Count = int(*args.Count) // TODO: not safe, check this above
+				found = true
+				break
+			}
 		}
-	}
-	if !found {
-		return structs.NewErrRPCCoded(400,
-			fmt.Sprintf("task group %q specified for scaling does not exist in job", groupName))
-	}
-	registerReq := structs.JobRegisterRequest{
-		Job:            job,
-		EnforceIndex:   true,
-		JobModifyIndex: job.ModifyIndex,
-		PolicyOverride: args.PolicyOverride,
-		WriteRequest:   args.WriteRequest,
-	}
+		if !found {
+			return structs.NewErrRPCCoded(400,
+				fmt.Sprintf("task group %q specified for scaling does not exist in job", groupName))
+		}
+		registerReq := structs.JobRegisterRequest{
+			Job:            job,
+			EnforceIndex:   true,
+			JobModifyIndex: job.ModifyIndex,
+			PolicyOverride: args.PolicyOverride,
+			WriteRequest:   args.WriteRequest,
+		}
 
-	// Commit this update via Raft
-	_, index, err := j.srv.raftApply(structs.JobRegisterRequestType, registerReq)
-	if err != nil {
-		j.logger.Error("job register for scale failed", "error", err)
-		return err
-	}
+		// Commit this update via Raft
+		_, index, err = j.srv.raftApply(structs.JobRegisterRequestType, registerReq)
+		if err != nil {
+			j.logger.Error("job register for scale failed", "error", err)
+			return err
+		}
 
-	// FINISH:
-	// register the scaling event to the scaling_event table, once that exists
+	}
 
 	// Populate the reply with job information
 	reply.JobModifyIndex = index
+
+	// FINISH:
+	// register the scaling event to the scaling_event table, once that exists
 
 	// If the job is periodic or parameterized, we don't create an eval.
 	if job != nil && (job.IsPeriodic() || job.IsParameterized()) {

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -5504,9 +5504,8 @@ func TestJobEndpoint_GetScaleStatus_ACL(t *testing.T) {
 	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
 		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs}))
 	get.AuthToken = invalidToken.SecretID
-	var invalidResp structs.JobScaleStatusResponse
 	require.NotNil(err)
-	err = msgpackrpc.CallWithCodec(codec, "Job.ScaleStatus", get, &invalidResp)
+	err = msgpackrpc.CallWithCodec(codec, "Job.ScaleStatus", get, &resp)
 	require.Contains(err.Error(), "Permission denied")
 
 	type testCase struct {

--- a/nomad/scaling_endpoint_test.go
+++ b/nomad/scaling_endpoint_test.go
@@ -1,13 +1,12 @@
 package nomad
 
 import (
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
+	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -16,7 +15,6 @@ import (
 
 func TestScalingEndpoint_GetPolicy(t *testing.T) {
 	t.Parallel()
-
 	require := require.New(t)
 
 	s1, cleanupS1 := TestServer(t, nil)
@@ -24,7 +22,6 @@ func TestScalingEndpoint_GetPolicy(t *testing.T) {
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
-	// Create the register request
 	p1 := mock.ScalingPolicy()
 	p2 := mock.ScalingPolicy()
 	s1.fsm.State().UpsertScalingPolicies(1000, []*structs.ScalingPolicy{p1, p2})
@@ -39,7 +36,7 @@ func TestScalingEndpoint_GetPolicy(t *testing.T) {
 	var resp structs.SingleScalingPolicyResponse
 	err := msgpackrpc.CallWithCodec(codec, "Scaling.GetPolicy", get, &resp)
 	require.NoError(err)
-	require.Equal(uint64(1000), resp.Index)
+	require.EqualValues(1000, resp.Index)
 	require.Equal(*p1, *resp.Policy)
 
 	// Lookup non-existing policy
@@ -47,24 +44,93 @@ func TestScalingEndpoint_GetPolicy(t *testing.T) {
 	resp = structs.SingleScalingPolicyResponse{}
 	err = msgpackrpc.CallWithCodec(codec, "Scaling.GetPolicy", get, &resp)
 	require.NoError(err)
-	require.Equal(uint64(1000), resp.Index)
+	require.EqualValues(1000, resp.Index)
 	require.Nil(resp.Policy)
 }
 
-func TestScalingEndpoint_ListPolicies(t *testing.T) {
-	assert := assert.New(t)
+func TestScalingEndpoint_GetPolicy_ACL(t *testing.T) {
 	t.Parallel()
+	require := require.New(t)
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+	state := s1.fsm.State()
+
+	p1 := mock.ScalingPolicy()
+	p2 := mock.ScalingPolicy()
+	state.UpsertScalingPolicies(1000, []*structs.ScalingPolicy{p1, p2})
+
+	get := &structs.ScalingPolicySpecificRequest{
+		ID: p1.ID,
+		QueryOptions: structs.QueryOptions{
+			Region: "global",
+		},
+	}
+
+	// lookup without token should fail
+	var resp structs.SingleScalingPolicyResponse
+	err := msgpackrpc.CallWithCodec(codec, "Scaling.GetPolicy", get, &resp)
+	require.Error(err)
+	require.Contains(err.Error(), "Permission denied")
+
+	// Expect failure for request with an invalid token
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListScalingPolicies}))
+	get.AuthToken = invalidToken.SecretID
+	err = msgpackrpc.CallWithCodec(codec, "Scaling.GetPolicy", get, &resp)
+	require.Error(err)
+	require.Contains(err.Error(), "Permission denied")
+	type testCase struct {
+		authToken string
+		name      string
+	}
+	cases := []testCase{
+		{
+			name:      "mgmt token should succeed",
+			authToken: root.SecretID,
+		},
+		{
+			name: "read disposition should succeed",
+			authToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-read",
+				mock.NamespacePolicy(structs.DefaultNamespace, "read", nil)).SecretID,
+		},
+		{
+			name: "write disposition should succeed",
+			authToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-write",
+				mock.NamespacePolicy(structs.DefaultNamespace, "write", nil)).SecretID,
+		},
+		{
+			name: "autoscaler disposition should succeed",
+			authToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-autoscaler",
+				mock.NamespacePolicy(structs.DefaultNamespace, "autoscaler", nil)).SecretID,
+		},
+		{
+			name: "list-jobs+read-job capability should succeed",
+			authToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-read-job-scaling",
+				mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs, acl.NamespaceCapabilityReadJob})).SecretID,
+		},
+	}
+
+	for _, tc := range cases {
+		get.AuthToken = tc.authToken
+		err = msgpackrpc.CallWithCodec(codec, "Scaling.GetPolicy", get, &resp)
+		require.NoError(err, tc.name)
+		require.EqualValues(1000, resp.Index)
+		require.NotNil(resp.Policy)
+	}
+
+}
+
+func TestScalingEndpoint_ListPolicies(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
 
 	s1, cleanupS1 := TestServer(t, nil)
 	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
-
-	// Create the register request
-	p1 := mock.ScalingPolicy()
-	p2 := mock.ScalingPolicy()
-
-	s1.fsm.State().UpsertScalingPolicies(1000, []*structs.ScalingPolicy{p1, p2})
 
 	// Lookup the policies
 	get := &structs.ScalingPolicyListRequest{
@@ -73,16 +139,100 @@ func TestScalingEndpoint_ListPolicies(t *testing.T) {
 		},
 	}
 	var resp structs.ACLPolicyListResponse
-	if err := msgpackrpc.CallWithCodec(codec, "Scaling.ListPolicies", get, &resp); err != nil {
-		t.Fatalf("err: %v", err)
+	err := msgpackrpc.CallWithCodec(codec, "Scaling.ListPolicies", get, &resp)
+	require.NoError(err)
+	require.Empty(resp.Policies)
+
+	p1 := mock.ScalingPolicy()
+	p2 := mock.ScalingPolicy()
+	s1.fsm.State().UpsertScalingPolicies(1000, []*structs.ScalingPolicy{p1, p2})
+
+	err = msgpackrpc.CallWithCodec(codec, "Scaling.ListPolicies", get, &resp)
+	require.NoError(err)
+	require.EqualValues(1000, resp.Index)
+	require.Len(resp.Policies, 2)
+}
+
+func TestScalingEndpoint_ListPolicies_ACL(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+	state := s1.fsm.State()
+
+	p1 := mock.ScalingPolicy()
+	p2 := mock.ScalingPolicy()
+	state.UpsertScalingPolicies(1000, []*structs.ScalingPolicy{p1, p2})
+
+	get := &structs.ScalingPolicyListRequest{
+		QueryOptions: structs.QueryOptions{
+			Region: "global",
+		},
 	}
-	assert.EqualValues(1000, resp.Index)
-	assert.Len(resp.Policies, 2)
+
+	// lookup without token should fail
+	var resp structs.ACLPolicyListResponse
+	err := msgpackrpc.CallWithCodec(codec, "Scaling.ListPolicies", get, &resp)
+	require.Error(err)
+	require.Contains(err.Error(), "Permission denied")
+
+	// Expect failure for request with an invalid token
+	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListScalingPolicies}))
+	get.AuthToken = invalidToken.SecretID
+	require.Error(err)
+	require.Contains(err.Error(), "Permission denied")
+
+	type testCase struct {
+		authToken string
+		name      string
+	}
+	cases := []testCase{
+		{
+			name:      "mgmt token should succeed",
+			authToken: root.SecretID,
+		},
+		{
+			name: "read disposition should succeed",
+			authToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-read",
+				mock.NamespacePolicy(structs.DefaultNamespace, "read", nil)).SecretID,
+		},
+		{
+			name: "write disposition should succeed",
+			authToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-write",
+				mock.NamespacePolicy(structs.DefaultNamespace, "write", nil)).SecretID,
+		},
+		{
+			name: "autoscaler disposition should succeed",
+			authToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-autoscaler",
+				mock.NamespacePolicy(structs.DefaultNamespace, "autoscaler", nil)).SecretID,
+		},
+		{
+			name: "list-scaling-policies capability should succeed",
+			authToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-list-scaling-policies",
+				mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListScalingPolicies})).SecretID,
+		},
+		{
+			name: "list-jobs+read-job capability should succeed",
+			authToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-read-job-scaling",
+				mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs, acl.NamespaceCapabilityReadJob})).SecretID,
+		},
+	}
+
+	for _, tc := range cases {
+		get.AuthToken = tc.authToken
+		err = msgpackrpc.CallWithCodec(codec, "Scaling.ListPolicies", get, &resp)
+		require.NoError(err, tc.name)
+		require.EqualValues(1000, resp.Index)
+		require.Len(resp.Policies, 2)
+	}
 }
 
 func TestScalingEndpoint_ListPolicies_Blocking(t *testing.T) {
 	t.Parallel()
-
 	require := require.New(t)
 
 	s1, cleanupS1 := TestServer(t, nil)
@@ -120,7 +270,7 @@ func TestScalingEndpoint_ListPolicies_Blocking(t *testing.T) {
 	require.NoError(err)
 
 	require.True(time.Since(start) > 200*time.Millisecond, "should block: %#v", resp)
-	require.Equal(uint64(200), resp.Index, "bad index")
+	require.EqualValues(200, resp.Index, "bad index")
 	require.Len(resp.Policies, 2)
 	require.ElementsMatch([]string{p1.ID, p2.ID}, []string{resp.Policies[0].ID, resp.Policies[1].ID})
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -619,7 +619,7 @@ type JobScaleRequest struct {
 	Namespace string
 	JobID     string
 	Target    map[string]string
-	Count     int64
+	Count     *int64
 	Reason    *string
 	Error     *string
 	Meta      map[string]interface{}


### PR DESCRIPTION
Added new ACL capabilities for autoscaling: 
- `read-job-scaling`
- `scale-job`
- `list-scaling-policies`
- `read-scaling-policy`

Updated `read` and `write` policy dispositions, added new `autoscaler` policy disposition

Updated scaling API endpoints to check ACL capabilities

Closes #7411 

One fun bit with this one....  because the scaling policies are embedded in the job, I wrote this to allow hitting those endpoints if you would otherwise have been able to see the scaling policies by looking directly at the encapsulating job.