### PR TITLE
bad conversion between api.ScalingPolicy and structs.ScalingPolicy meant

### DIFF
--- a/api/scaling_test.go
+++ b/api/scaling_test.go
@@ -74,8 +74,8 @@ func TestScalingPolicies_GetPolicy(t *testing.T) {
 	job := testJob()
 	policy := &ScalingPolicy{
 		Enabled: boolToPtr(true),
-		Min: int64ToPtr(1),
-		Max: 1,
+		Min:     int64ToPtr(1),
+		Max:     1,
 		Policy: map[string]interface{}{
 			"key": "value",
 		},
@@ -115,4 +115,6 @@ func TestScalingPolicies_GetPolicy(t *testing.T) {
 	require.Equal(expectedTarget, resp.Target)
 	require.Equal(policy.Policy, resp.Policy)
 	require.Equal(policy.Enabled, resp.Enabled)
+	require.Equal(*policy.Min, *resp.Min)
+	require.Equal(policy.Max, resp.Max)
 }

--- a/command/agent/scaling_endpoint.go
+++ b/command/agent/scaling_endpoint.go
@@ -82,7 +82,9 @@ func ApiScalingPolicyToStructs(count int, ap *api.ScalingPolicy) *structs.Scalin
 		Policy:  ap.Policy,
 		Target:  map[string]string{},
 	}
-	if ap.Min == nil {
+	if ap.Min != nil {
+		p.Min = *ap.Min
+	} else {
 		p.Min = int64(count)
 	}
 	return &p


### PR DESCRIPTION
that we were throwing away .Min if provided