### PR TITLE
csi: remove client from plugin on client node update

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -942,9 +942,6 @@ func appendNodeEvents(index uint64, node *structs.Node, events []*structs.NodeEv
 // upsertNodeCSIPlugins indexes csi plugins for volume retrieval, with health. It's called
 // on upsertNodeEvents, so that event driven health changes are updated
 func upsertNodeCSIPlugins(txn *memdb.Txn, node *structs.Node, index uint64) error {
-	if len(node.CSIControllerPlugins) == 0 && len(node.CSINodePlugins) == 0 {
-		return nil
-	}
 
 	loop := func(info *structs.CSIInfo) error {
 		raw, err := txn.First("csi_plugins", "id", info.PluginID)
@@ -972,17 +969,45 @@ func upsertNodeCSIPlugins(txn *memdb.Txn, node *structs.Node, index uint64) erro
 		return nil
 	}
 
+	inUse := map[string]struct{}{}
 	for _, info := range node.CSIControllerPlugins {
 		err := loop(info)
 		if err != nil {
 			return err
 		}
+		inUse[info.PluginID] = struct{}{}
 	}
 
 	for _, info := range node.CSINodePlugins {
 		err := loop(info)
 		if err != nil {
 			return err
+		}
+		inUse[info.PluginID] = struct{}{}
+	}
+
+	// remove the client node from any plugin that's not
+	// running on it.
+	iter, err := txn.Get("csi_plugins", "id")
+	if err != nil {
+		return fmt.Errorf("csi_plugins lookup failed: %v", err)
+	}
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		plug := raw.(*structs.CSIPlugin)
+		_, ok := inUse[plug.ID]
+		if !ok {
+			_, asController := plug.Controllers[node.ID]
+			_, asNode := plug.Nodes[node.ID]
+			if asController || asNode {
+				err = deleteNodeFromPlugin(txn, plug.Copy(), node, index)
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -1017,19 +1042,9 @@ func deleteNodeCSIPlugins(txn *memdb.Txn, node *structs.Node, index uint64) erro
 		}
 
 		plug := raw.(*structs.CSIPlugin).Copy()
-		plug.DeleteNode(node.ID)
-		plug.ModifyIndex = index
-
-		if plug.IsEmpty() {
-			err = txn.Delete("csi_plugins", plug)
-			if err != nil {
-				return fmt.Errorf("csi_plugins delete error: %v", err)
-			}
-		} else {
-			err = txn.Insert("csi_plugins", plug)
-			if err != nil {
-				return fmt.Errorf("csi_plugins update error %s: %v", id, err)
-			}
+		err = deleteNodeFromPlugin(txn, plug, node, index)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -1037,6 +1052,30 @@ func deleteNodeCSIPlugins(txn *memdb.Txn, node *structs.Node, index uint64) erro
 		return fmt.Errorf("index update failed: %v", err)
 	}
 
+	return nil
+}
+
+func deleteNodeFromPlugin(txn *memdb.Txn, plug *structs.CSIPlugin, node *structs.Node, index uint64) error {
+	plug.DeleteNode(node.ID)
+	plug.ModifyIndex = index
+
+	if plug.IsEmpty() {
+		_, err := txn.Get("csi_volumes", "plugin_id", plug.ID)
+		if err != nil {
+			// don't delete a plugin that has associated volumes, even
+			// if there are no plugin instances running for it
+			return nil
+		}
+		err = txn.Delete("csi_plugins", plug)
+		if err != nil {
+			return fmt.Errorf("csi_plugins delete error: %v", err)
+		}
+	} else {
+		err := txn.Insert("csi_plugins", plug)
+		if err != nil {
+			return fmt.Errorf("csi_plugins update error %s: %v", plug.ID, err)
+		}
+	}
 	return nil
 }
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2996,7 +2996,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 
 func testStateStore_CSIPluginNodes(t *testing.T, index uint64, state *StateStore) (uint64, *StateStore) {
 	// Create Nodes fingerprinting the plugins
-	ns := []*structs.Node{mock.Node(), mock.Node(), mock.Node()}
+	ns := []*structs.Node{mock.Node(), mock.Node()}
 
 	for _, n := range ns {
 		index++
@@ -3025,7 +3025,7 @@ func testStateStore_CSIPluginNodes(t *testing.T, index uint64, state *StateStore
 	require.NoError(t, err)
 
 	// Fingerprint two running node plugins
-	for _, n := range ns[1:] {
+	for _, n := range ns[:] {
 		n = n.Copy()
 		n.CSINodePlugins = map[string]*structs.CSIInfo{
 			"foo": {
@@ -3050,6 +3050,55 @@ func testStateStore_CSIPluginNodes(t *testing.T, index uint64, state *StateStore
 	require.Equal(t, "foo", plug.ID)
 	require.Equal(t, 1, plug.ControllersHealthy)
 	require.Equal(t, 2, plug.NodesHealthy)
+
+	// Controller is unhealthy
+	n0.CSIControllerPlugins = map[string]*structs.CSIInfo{
+		"foo": {
+			PluginID:                 "foo",
+			Healthy:                  false,
+			UpdateTime:               time.Now(),
+			RequiresControllerPlugin: true,
+			RequiresTopologies:       false,
+			ControllerInfo: &structs.CSIControllerInfo{
+				SupportsReadOnlyAttach: true,
+				SupportsListVolumes:    true,
+			},
+		},
+	}
+
+	index++
+	err = state.UpsertNode(index, n0)
+	require.NoError(t, err)
+
+	plug, err = state.CSIPluginByID(ws, "foo")
+	require.NoError(t, err)
+	require.Equal(t, "foo", plug.ID)
+	require.Equal(t, 0, plug.ControllersHealthy)
+	require.Equal(t, 2, plug.NodesHealthy)
+
+	// Node plugin is removed
+	n1 := ns[1].Copy()
+	n1.CSINodePlugins = map[string]*structs.CSIInfo{}
+	index++
+	err = state.UpsertNode(index, n1)
+	require.NoError(t, err)
+
+	plug, err = state.CSIPluginByID(ws, "foo")
+	require.NoError(t, err)
+	require.Equal(t, "foo", plug.ID)
+	require.Equal(t, 0, plug.ControllersHealthy)
+	require.Equal(t, 1, plug.NodesHealthy)
+
+	// Last plugin is removed
+	n0 = ns[0].Copy()
+	n0.CSINodePlugins = map[string]*structs.CSIInfo{}
+	index++
+	err = state.UpsertNode(index, n0)
+	require.NoError(t, err)
+
+	plug, err = state.CSIPluginByID(ws, "foo")
+	require.NoError(t, err)
+	require.Nil(t, plug)
 
 	return index, state
 }


### PR DESCRIPTION
For #7338

Plugins track the client nodes where they are placed. On client
updates, remove the client from the plugin tracking if the client is
no longer running an instance of that controller/node plugin.

Extends the state store tests to ensure deregistration works as
expected and that controllers and nodes are being tracked
independently.