### PR TITLE
csi: test volume denormalize without plugin

### DIFF
--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -244,9 +244,9 @@ type CSIVolListStub struct {
 }
 
 // NewCSIVolume creates the volume struct. No side-effects
-func NewCSIVolume(pluginID string, index uint64) *CSIVolume {
+func NewCSIVolume(volumeID string, index uint64) *CSIVolume {
 	out := &CSIVolume{
-		ID:          pluginID,
+		ID:          volumeID,
 		CreateIndex: index,
 		ModifyIndex: index,
 	}

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -26,3 +26,36 @@ func TestCSIVolumeClaim(t *testing.T) {
 	require.True(t, vol.ReadSchedulable())
 	require.True(t, vol.WriteFreeClaims())
 }
+
+func TestCSIPluginCleanup(t *testing.T) {
+	plug := NewCSIPlugin("foo", 1000)
+	plug.AddPlugin("n0", &CSIInfo{
+		PluginID:                 "foo",
+		AllocID:                  "a0",
+		Healthy:                  true,
+		Provider:                 "foo-provider",
+		RequiresControllerPlugin: true,
+		RequiresTopologies:       false,
+		ControllerInfo:           &CSIControllerInfo{},
+	})
+
+	plug.AddPlugin("n0", &CSIInfo{
+		PluginID:                 "foo",
+		AllocID:                  "a0",
+		Healthy:                  true,
+		Provider:                 "foo-provider",
+		RequiresControllerPlugin: true,
+		RequiresTopologies:       false,
+		NodeInfo:                 &CSINodeInfo{},
+	})
+
+	require.Equal(t, 1, plug.ControllersHealthy)
+	require.Equal(t, 1, plug.NodesHealthy)
+
+	plug.DeleteNode("n0")
+	require.Equal(t, 0, plug.ControllersHealthy)
+	require.Equal(t, 0, plug.NodesHealthy)
+
+	require.Equal(t, 0, len(plug.Controllers))
+	require.Equal(t, 0, len(plug.Nodes))
+}


### PR DESCRIPTION
This pr only affects testing (although it does rename a mis-named local variable). No rush, I decided that I'd like this behavior baked in tests so we don't lose this property in the future.