### PR TITLE
api: prevent panic if volume has nil alloc

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -128,10 +128,14 @@ type CSIVolume struct {
 // allocations for the UI
 func (v *CSIVolume) allocs() {
 	for _, a := range v.WriteAllocs {
-		v.Allocations = append(v.Allocations, a.Stub())
+		if a != nil {
+			v.Allocations = append(v.Allocations, a.Stub())
+		}
 	}
 	for _, a := range v.ReadAllocs {
-		v.Allocations = append(v.Allocations, a.Stub())
+		if a != nil {
+			v.Allocations = append(v.Allocations, a.Stub())
+		}
 	}
 }
 


### PR DESCRIPTION
If an allocation is failed and the job is GC'd, it looks like it's possible to get into a situation where a volume has references to a nil allocation, despite #7329. This panics the CLI.

```
▶ nomad volume deregister ebs-vol0
Error deregistering volume: Unexpected response code: 500 (rpc error: volume in use: ebs-vol0)

▶ nomad volume status ebs-vol0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4a9a35f]

goroutine 1 [running]:
github.com/hashicorp/nomad/api.(*Allocation).Stub(...)
        ~/go/src/github.com/hashicorp/nomad/api/allocations.go:405
github.com/hashicorp/nomad/api.(*CSIVolume).allocs(0xc00119c000)
        ~/go/src/github.com/hashicorp/nomad/api/csi.go:131 +0xbf
github.com/hashicorp/nomad/api.(*CSIVolumes).Info(0xc00104dc40, 0x7ffeefbff93c, 0x8, 0x0, 0xc000289c20, 0xc00104dc60, 0x5e382bb, 0xc000289c20)
        ~/go/src/github.com/hashicorp/nomad/api/csi.go:43 +0x11f
github.com/hashicorp/nomad/command.(*VolumeStatusCommand).csiStatus(0xc000d92b60, 0xc000121030, 0x7ffeefbff93c, 0x8, 0x0)
        ~/go/src/github.com/hashicorp/nomad/command/volume_status_csi.go:43 +0x293
github.com/hashicorp/nomad/command.(*VolumeStatusCommand).Run(0xc000d92b60, 0xc0001b6030, 0x1, 0x1, 0xc000b4cac0)
        ~/go/src/github.com/hashicorp/nomad/command/volume_status.go:126 +0x466
github.com/hashicorp/nomad/vendor/github.com/mitchellh/cli.(*CLI).Run(0xc0001e2b40, 0xc0001e2b40, 0xc0002194c0, 0x44)
        ~/go/src/github.com/hashicorp/nomad/vendor/github.com/mitchellh/cli/cli.go:255 +0x1da
main.RunCustom(0xc0001b6010, 0x3, 0x3, 0xc00018e058)
        ~/go/src/github.com/hashicorp/nomad/main.go:138 +0x482
main.Run(...)
        ~/go/src/github.com/hashicorp/nomad/main.go:83
main.main()
        ~/go/src/github.com/hashicorp/nomad/main.go:79 +0x64
```