### PR TITLE
allow all build contexts to use noOpAuditor

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1006,7 +1006,7 @@ func (a *Agent) Reload(newConfig *Config) error {
 
 	// Update eventer config
 	if newConfig.Audit != nil {
-		if err := a.entReloadEventer(a.config.Audit); err != nil {
+		if err := a.entReloadEventer(newConfig.Audit); err != nil {
 			return err
 		}
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1010,6 +1010,12 @@ func (a *Agent) Reload(newConfig *Config) error {
 			return err
 		}
 	}
+	// Allow auditor to call reopen regardless of config changes
+	// This is primarily for enterprise audit logging to allow the underlying
+	// file to be reopened if necessary
+	if err := a.auditor.Reopen(); err != nil {
+		return err
+	}
 
 	fullUpdateTLSConfig := func() {
 		// Completely reload the agent's TLS configuration (moving from non-TLS to

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1081,3 +1082,26 @@ func (a *Agent) setupConsul(consulConfig *config.ConsulConfig) error {
 	go a.consulService.Run()
 	return nil
 }
+
+// noOpAuditor is a no-op Auditor that fulfills the
+// event.Auditor interface.
+type noOpAuditor struct{}
+
+// Ensure noOpAuditor is an Auditor
+var _ event.Auditor = &noOpAuditor{}
+
+func (e *noOpAuditor) Event(ctx context.Context, eventType string, payload interface{}) error {
+	return nil
+}
+
+func (e *noOpAuditor) Enabled() bool {
+	return false
+}
+
+func (e *noOpAuditor) Reopen() error {
+	return nil
+}
+
+func (e *noOpAuditor) SetEnabled(enabled bool) {}
+
+func (e *noOpAuditor) DeliveryEnforced() bool { return false }

--- a/command/agent/agent_oss.go
+++ b/command/agent/agent_oss.go
@@ -3,33 +3,9 @@
 package agent
 
 import (
-	"context"
-
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/nomad/command/agent/event"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 )
-
-type noOpAuditor struct{}
-
-// Ensure noOpAuditor is an Eventer
-var _ event.Auditor = &noOpAuditor{}
-
-func (e *noOpAuditor) Event(ctx context.Context, eventType string, payload interface{}) error {
-	return nil
-}
-
-func (e *noOpAuditor) Enabled() bool {
-	return false
-}
-
-func (e *noOpAuditor) Reopen() error {
-	return nil
-}
-
-func (e *noOpAuditor) SetEnabled(enabled bool) {}
-
-func (e *noOpAuditor) DeliveryEnforced() bool { return false }
 
 func (a *Agent) setupEnterpriseAgent(log hclog.Logger) error {
 	// configure eventer

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -657,7 +657,8 @@ func TestServer_Reload_TLS_Certificate(t *testing.T) {
 	}
 
 	agent := &Agent{
-		config: agentConfig,
+		auditor: &noOpAuditor{},
+		config:  agentConfig,
 	}
 
 	newConfig := &Config{
@@ -785,8 +786,9 @@ func TestServer_Reload_TLS_UpgradeToTLS(t *testing.T) {
 	}
 
 	agent := &Agent{
-		logger: logger,
-		config: agentConfig,
+		auditor: &noOpAuditor{},
+		logger:  logger,
+		config:  agentConfig,
 	}
 
 	newConfig := &Config{

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -705,7 +705,8 @@ func TestServer_Reload_TLS_Certificate_Invalid(t *testing.T) {
 	}
 
 	agent := &Agent{
-		config: agentConfig,
+		auditor: &noOpAuditor{},
+		config:  agentConfig,
 	}
 
 	newConfig := &Config{

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -513,7 +513,7 @@ func (s *HTTPServer) wrapNonJSON(handler func(resp http.ResponseWriter, req *htt
 		defer func() {
 			s.logger.Debug("request complete", "method", req.Method, "path", reqURL, "duration", time.Now().Sub(start))
 		}()
-		obj, err := s.auditByteHandler(handler)(resp, req)
+		obj, err := s.auditNonJSONHandler(handler)(resp, req)
 
 		// Check for an error
 		if err != nil {

--- a/command/agent/http_oss.go
+++ b/command/agent/http_oss.go
@@ -27,7 +27,7 @@ func (s HTTPServer) auditHandler(h handlerFn) handlerFn {
 	return h
 }
 
-func (s *HTTPServer) auditByteHandler(h handlerByteFn) handlerByteFn {
+func (s *HTTPServer) auditNonJSONHandler(h handlerByteFn) handlerByteFn {
 	return h
 }
 


### PR DESCRIPTION
allow noOpAuditor to be accessed from all build contexts

a few oss files were edited in ent repo that need to be aligned which this PR takes care of