### PR TITLE
csi: make volume registration idempotent

### DIFF
--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2968,7 +2968,6 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	vs = slurp(iter)
 	require.True(t, vs[0].ReadSchedulable())
 
-	// Deregister
 	// registration is an error when the volume is in use
 	index++
 	err = state.CSIVolumeRegister(index, []*structs.CSIVolume{v0})


### PR DESCRIPTION
If not in use and not changing external ids, it should not be an error to register a volume again. Closes #7451 