### PR TITLE
doc: add a reminder about field order for diff comparisons

### DIFF
--- a/contributing/checklist-jobspec.md
+++ b/contributing/checklist-jobspec.md
@@ -17,6 +17,7 @@
   * Implement other methods and tests from `api/` package
 * [ ] Add conversion between `api/` and `nomad/structs` in `command/agent/job_endpoint.go`
 * [ ] Add check for job diff in `nomad/structs/diff.go`
+  * Note that fields must be listed in alphabetical order in `FieldDiff` slices in `nomad/structs/diff_test.go`
 * [ ] Test conversion
 
 ## Docs


### PR DESCRIPTION
After spending hours re-learning this lesson more than once,
update the jobspec contribution guide with a reminder about
how to configure `FieldDiff` comparisons.