### PR TITLE
UI: Fix check for Mirage presence setting up sockets

### DIFF
--- a/ui/app/services/sockets.js
+++ b/ui/app/services/sockets.js
@@ -5,7 +5,9 @@ import { getOwner } from '@ember/application';
 export default Service.extend({
   getTaskStateSocket(taskState, command) {
     const mirageEnabled =
-      config['ember-cli-mirage'] && config['ember-cli-mirage'].enabled !== false;
+      config.environment !== 'production' &&
+      config['ember-cli-mirage'] &&
+      config['ember-cli-mirage'].enabled !== false;
 
     if (mirageEnabled) {
       return new Object({


### PR DESCRIPTION
Without this, exec UI doesn’t work at all in the binary. I made an
unfortunate error in not copying the environment check from
`app/utils/fetch.js`.