### PR TITLE
csi: plugin deregistration on plugin job GC

### DIFF
--- a/command/plugin_status_test.go
+++ b/command/plugin_status_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/nomad/nomad"
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/stretchr/testify/require"
@@ -40,11 +40,11 @@ func TestPluginStatusCommand_AutocompleteArgs(t *testing.T) {
 
 	// Create a plugin
 	id := "long-plugin-id"
-	state := srv.Agent.Server().State()
-	cleanup := nomad.CreateTestCSIPlugin(state, id)
+	s := srv.Agent.Server().State()
+	cleanup := state.CreateTestCSIPlugin(s, id)
 	defer cleanup()
 	ws := memdb.NewWatchSet()
-	plug, err := state.CSIPluginByID(ws, id)
+	plug, err := s.CSIPluginByID(ws, id)
 	require.NoError(t, err)
 
 	prefix := plug.ID[:len(plug.ID)-5]

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
@@ -503,7 +504,7 @@ func TestCSIPluginEndpoint_RegisterViaFingerprint(t *testing.T) {
 	defer shutdown()
 	testutil.WaitForLeader(t, srv.RPC)
 
-	deleteNodes := CreateTestCSIPlugin(srv.fsm.State(), "foo")
+	deleteNodes := state.CreateTestCSIPlugin(srv.fsm.State(), "foo")
 	defer deleteNodes()
 
 	state := srv.fsm.State()

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
@@ -761,7 +762,7 @@ func TestSearch_PrefixSearch_CSIPlugin(t *testing.T) {
 	testutil.WaitForLeader(t, s.RPC)
 
 	id := uuid.Generate()
-	CreateTestCSIPlugin(s.fsm.State(), id)
+	state.CreateTestCSIPlugin(s.fsm.State(), id)
 
 	prefix := id[:len(id)-2]
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1089,7 +1089,7 @@ func (s *StateStore) deleteJobFromPlugin(index uint64, txn *memdb.Txn, job *stru
 	}
 
 	type pair struct {
-		p *structs.TaskCSIPluginConfig
+		p string
 		a *structs.Allocation
 	}
 
@@ -1104,7 +1104,7 @@ func (s *StateStore) deleteJobFromPlugin(index uint64, txn *memdb.Txn, job *stru
 		for _, t := range tg.Tasks {
 			if t.CSIPluginConfig != nil {
 				plugAllocs = append(plugAllocs, &pair{
-					p: t.CSIPluginConfig,
+					p: t.CSIPluginConfig.ID,
 					a: a,
 				})
 
@@ -1113,7 +1113,7 @@ func (s *StateStore) deleteJobFromPlugin(index uint64, txn *memdb.Txn, job *stru
 	}
 
 	for _, x := range plugAllocs {
-		plug, err := s.CSIPluginByID(ws, x.p.ID)
+		plug, err := s.CSIPluginByID(ws, x.p)
 		if err != nil {
 			return fmt.Errorf("%v", err)
 		}
@@ -1122,7 +1122,7 @@ func (s *StateStore) deleteJobFromPlugin(index uint64, txn *memdb.Txn, job *stru
 		}
 
 		plug = plug.Copy()
-		plug.DeleteNodeType(x.a.NodeID, x.p.Type)
+		plug.DeleteAlloc(x.a.NodeID, x.a.ID)
 		err = deleteFromPlugin(index, txn, plug)
 		if err != nil {
 			return fmt.Errorf("%v", err)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -3173,6 +3173,9 @@ func TestStateStore_CSIPluginJobs(t *testing.T) {
 			ID:        info.AllocID,
 			Namespace: controllerJob.Namespace,
 			JobID:     controllerJob.ID,
+			Job:       controllerJob,
+			TaskGroup: "web",
+			EvalID:    uuid.Generate(),
 			NodeID:    id,
 		})
 	}
@@ -3181,6 +3184,9 @@ func TestStateStore_CSIPluginJobs(t *testing.T) {
 			ID:        info.AllocID,
 			JobID:     nodeJob.ID,
 			Namespace: nodeJob.Namespace,
+			Job:       nodeJob,
+			TaskGroup: "web",
+			EvalID:    uuid.Generate(),
 			NodeID:    id,
 		})
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -3134,6 +3134,83 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	require.False(t, vol.Schedulable)
 }
 
+func TestStateStore_CSIPluginJobs(t *testing.T) {
+	s := testStateStore(t)
+	deleteNodes := CreateTestCSIPlugin(s, "foo")
+	defer deleteNodes()
+
+	index := uint64(1001)
+
+	controllerJob := mock.Job()
+	controllerJob.TaskGroups[0].Tasks[0].CSIPluginConfig = &structs.TaskCSIPluginConfig{
+		ID:   "foo",
+		Type: structs.CSIPluginTypeController,
+	}
+
+	nodeJob := mock.Job()
+	nodeJob.TaskGroups[0].Tasks[0].CSIPluginConfig = &structs.TaskCSIPluginConfig{
+		ID:   "foo",
+		Type: structs.CSIPluginTypeNode,
+	}
+
+	err := s.UpsertJob(index, controllerJob)
+	require.NoError(t, err)
+	index++
+
+	err = s.UpsertJob(index, nodeJob)
+	require.NoError(t, err)
+	index++
+
+	// Get the plugin, and make better fake allocations for it
+	ws := memdb.NewWatchSet()
+	plug, err := s.CSIPluginByID(ws, "foo")
+	require.NoError(t, err)
+	index++
+
+	as := []*structs.Allocation{}
+	for id, info := range plug.Controllers {
+		as = append(as, &structs.Allocation{
+			ID:        info.AllocID,
+			Namespace: controllerJob.Namespace,
+			JobID:     controllerJob.ID,
+			NodeID:    id,
+		})
+	}
+	for id, info := range plug.Nodes {
+		as = append(as, &structs.Allocation{
+			ID:        info.AllocID,
+			JobID:     nodeJob.ID,
+			Namespace: nodeJob.Namespace,
+			NodeID:    id,
+		})
+	}
+
+	err = s.UpsertAllocs(index, as)
+	require.NoError(t, err)
+	index++
+
+	// Delete a job
+	err = s.DeleteJob(index, controllerJob.Namespace, controllerJob.ID)
+	require.NoError(t, err)
+	index++
+
+	// plugin still exists
+	plug, err = s.CSIPluginByID(ws, "foo")
+	require.NoError(t, err)
+	require.NotNil(t, plug)
+	require.Equal(t, 0, len(plug.Controllers))
+
+	// Delete a job
+	err = s.DeleteJob(index, nodeJob.Namespace, nodeJob.ID)
+	require.NoError(t, err)
+	index++
+
+	// plugin was collected
+	plug, err = s.CSIPluginByID(ws, "foo")
+	require.NoError(t, err)
+	require.Nil(t, plug)
+}
+
 func TestStateStore_Indexes(t *testing.T) {
 	t.Parallel()
 

--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -4,6 +4,9 @@ import (
 	testing "github.com/mitchellh/go-testing-interface"
 
 	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 func TestStateStore(t testing.T) *StateStore {
@@ -20,4 +23,71 @@ func TestStateStore(t testing.T) *StateStore {
 	}
 	TestInitState(t, state)
 	return state
+}
+
+// CreateTestPlugin is a helper that generates the node + fingerprint results necessary to
+// create a CSIPlugin by directly inserting into the state store. It's exported for use in
+// other test packages
+func CreateTestCSIPlugin(s *StateStore, id string) func() {
+	// Create some nodes
+	ns := make([]*structs.Node, 3)
+	for i := range ns {
+		n := mock.Node()
+		ns[i] = n
+	}
+
+	// Install healthy plugin fingerprinting results
+	ns[0].CSIControllerPlugins = map[string]*structs.CSIInfo{
+		id: {
+			PluginID:                 id,
+			AllocID:                  uuid.Generate(),
+			Healthy:                  true,
+			HealthDescription:        "healthy",
+			RequiresControllerPlugin: true,
+			RequiresTopologies:       false,
+			ControllerInfo: &structs.CSIControllerInfo{
+				SupportsReadOnlyAttach:           true,
+				SupportsAttachDetach:             true,
+				SupportsListVolumes:              true,
+				SupportsListVolumesAttachedNodes: false,
+			},
+		},
+	}
+
+	// Install healthy plugin fingerprinting results
+	for _, n := range ns[1:] {
+		n.CSINodePlugins = map[string]*structs.CSIInfo{
+			id: {
+				PluginID:                 id,
+				AllocID:                  uuid.Generate(),
+				Healthy:                  true,
+				HealthDescription:        "healthy",
+				RequiresControllerPlugin: true,
+				RequiresTopologies:       false,
+				NodeInfo: &structs.CSINodeInfo{
+					ID:                      n.ID,
+					MaxVolumes:              64,
+					RequiresNodeStageVolume: true,
+				},
+			},
+		}
+	}
+
+	// Insert them into the state store
+	index := uint64(999)
+	for _, n := range ns {
+		index++
+		s.UpsertNode(index, n)
+	}
+
+	ids := make([]string, len(ns))
+	for i, n := range ns {
+		ids[i] = n.ID
+	}
+
+	// Return cleanup function that deletes the nodes
+	return func() {
+		index++
+		s.DeleteNode(index, ids)
+	}
 }

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -679,6 +679,25 @@ func (p *CSIPlugin) DeleteNodeType(nodeID string, pluginType CSIPluginType) {
 	}
 }
 
+// DeleteAlloc removes the fingerprint info for the allocation
+func (p *CSIPlugin) DeleteAlloc(allocID, nodeID string) {
+	prev, ok := p.Controllers[nodeID]
+	if ok && prev.AllocID == allocID {
+		if prev.Healthy {
+			p.ControllersHealthy -= 1
+		}
+		delete(p.Controllers, nodeID)
+	}
+
+	prev, ok = p.Nodes[nodeID]
+	if ok && prev.AllocID == allocID {
+		if prev.Healthy {
+			p.NodesHealthy -= 1
+		}
+		delete(p.Nodes, nodeID)
+	}
+}
+
 type CSIPluginListStub struct {
 	ID                  string
 	Provider            string

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -15,9 +15,7 @@ import (
 	"github.com/hashicorp/nomad/helper/pluginutils/catalog"
 	"github.com/hashicorp/nomad/helper/pluginutils/singleton"
 	"github.com/hashicorp/nomad/helper/testlog"
-	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
-	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/version"
 )
@@ -154,72 +152,5 @@ func TestJoin(t testing.T, s1 *Server, other ...*Server) {
 		} else if num != 1 {
 			t.Fatalf("bad: %d", num)
 		}
-	}
-}
-
-// CreateTestPlugin is a helper that generates the node + fingerprint results necessary to
-// create a CSIPlugin by directly inserting into the state store. It's exported for use in
-// other test packages
-func CreateTestCSIPlugin(s *state.StateStore, id string) func() {
-	// Create some nodes
-	ns := make([]*structs.Node, 3)
-	for i := range ns {
-		n := mock.Node()
-		ns[i] = n
-	}
-
-	// Install healthy plugin fingerprinting results
-	ns[0].CSIControllerPlugins = map[string]*structs.CSIInfo{
-		id: {
-			PluginID:                 id,
-			AllocID:                  uuid.Generate(),
-			Healthy:                  true,
-			HealthDescription:        "healthy",
-			RequiresControllerPlugin: true,
-			RequiresTopologies:       false,
-			ControllerInfo: &structs.CSIControllerInfo{
-				SupportsReadOnlyAttach:           true,
-				SupportsAttachDetach:             true,
-				SupportsListVolumes:              true,
-				SupportsListVolumesAttachedNodes: false,
-			},
-		},
-	}
-
-	// Install healthy plugin fingerprinting results
-	for _, n := range ns[1:] {
-		n.CSINodePlugins = map[string]*structs.CSIInfo{
-			id: {
-				PluginID:                 id,
-				AllocID:                  uuid.Generate(),
-				Healthy:                  true,
-				HealthDescription:        "healthy",
-				RequiresControllerPlugin: true,
-				RequiresTopologies:       false,
-				NodeInfo: &structs.CSINodeInfo{
-					ID:                      n.ID,
-					MaxVolumes:              64,
-					RequiresNodeStageVolume: true,
-				},
-			},
-		}
-	}
-
-	// Insert them into the state store
-	index := uint64(999)
-	for _, n := range ns {
-		index++
-		s.UpsertNode(index, n)
-	}
-
-	// Return cleanup function that deletes the nodes
-	return func() {
-		ids := make([]string, len(ns))
-		for i, n := range ns {
-			ids[i] = n.ID
-		}
-
-		index++
-		s.DeleteNode(index, ids)
 	}
 }


### PR DESCRIPTION
Remove expected plugin info reports when a job is deleted, and cleanup the entire plugin if it has no more supporting jobs. Closes #7306 