### PR TITLE
docker: drain fingerprint timer

### DIFF
--- a/drivers/docker/fingerprint.go
+++ b/drivers/docker/fingerprint.go
@@ -61,6 +61,14 @@ func (d *Driver) fingerprintSuccessful() bool {
 func (d *Driver) handleFingerprint(ctx context.Context, ch chan *drivers.Fingerprint) {
 	defer close(ch)
 	ticker := time.NewTimer(0)
+
+	defer func() {
+		// Ensures that the channel is empty by stopping and draining the ticker.
+		if !ticker.Stop() {
+			<-ticker.C
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/drivers/docker/fingerprint.go
+++ b/drivers/docker/fingerprint.go
@@ -62,12 +62,7 @@ func (d *Driver) handleFingerprint(ctx context.Context, ch chan *drivers.Fingerp
 	defer close(ch)
 
 	ticker := time.NewTimer(0)
-	defer func() {
-		// Ensures that the channel is empty by stopping and draining the ticker.
-		if !ticker.Stop() {
-			<-ticker.C
-		}
-	}()
+	defer ticker.Stop()
 
 	for {
 		select {

--- a/drivers/docker/fingerprint.go
+++ b/drivers/docker/fingerprint.go
@@ -60,8 +60,8 @@ func (d *Driver) fingerprintSuccessful() bool {
 
 func (d *Driver) handleFingerprint(ctx context.Context, ch chan *drivers.Fingerprint) {
 	defer close(ch)
-	ticker := time.NewTimer(0)
 
+	ticker := time.NewTimer(0)
 	defer func() {
 		// Ensures that the channel is empty by stopping and draining the ticker.
 		if !ticker.Stop() {


### PR DESCRIPTION
According to the go documentation, it seems nice to stop and drain a ticker.