### PR TITLE
UI: add handling for command-editing UX expectations

### DIFF
--- a/ui/app/utils/classes/exec-command-editor-xterm-adapter.js
+++ b/ui/app/utils/classes/exec-command-editor-xterm-adapter.js
@@ -1,7 +1,12 @@
 const REVERSE_WRAPAROUND_MODE = '\x1b[?45h';
 const BACKSPACE_ONE_CHARACTER = '\x08 \x08';
+const MOVE_CURSOR_BACKWARD = '\x1b[D';
+const MOVE_CURSOR_FORWARD = '\x1b[C';
+const INSERT_BLANK_CHARACTER = '\x1b[@';
 
 export default class ExecCommandEditorXtermAdapter {
+  insertionOffsetFromEnd = 0;
+
   constructor(terminal, setCommandCallback, command) {
     this.terminal = terminal;
     this.setCommandCallback = setCommandCallback;
@@ -26,18 +31,59 @@ export default class ExecCommandEditorXtermAdapter {
       }
 
       this.command = '';
+    } else if (e.domEvent.key === 'ArrowLeft') {
+      if (this.insertionOffsetFromEnd < this.command.length) {
+        this.terminal.write(MOVE_CURSOR_BACKWARD);
+        this.insertionOffsetFromEnd += 1;
+      }
+    } else if (e.domEvent.key === 'ArrowRight') {
+      if (this.insertionOffsetFromEnd > 0) {
+        this.terminal.write(MOVE_CURSOR_FORWARD);
+        this.insertionOffsetFromEnd -= 1;
+      }
     } else if (e.domEvent.key === 'Enter') {
       this.terminal.writeln('');
       this.setCommandCallback(this.command);
       this.keyListener.dispose();
     } else if (e.domEvent.key === 'Backspace') {
       if (this.command.length > 0) {
-        this.terminal.write(BACKSPACE_ONE_CHARACTER);
-        this.command = this.command.slice(0, -1);
+        if (this.insertionOffsetFromEnd == 0) {
+          this.terminal.write(BACKSPACE_ONE_CHARACTER);
+          this.command = this.command.slice(0, -1);
+        } else if (this.insertionOffsetFromEnd < this.command.length) {
+          this.terminal.write(MOVE_CURSOR_BACKWARD);
+
+          const commandLength = this.command.length;
+          const insertionOffsetFromStart = commandLength - this.insertionOffsetFromEnd;
+          const commandBeforeInsertionOffset = this.command.substring(
+            0,
+            insertionOffsetFromStart - 1
+          );
+          const commandAfterInsertionOffset = this.command.substring(insertionOffsetFromStart);
+
+          this.command = `${commandBeforeInsertionOffset}${commandAfterInsertionOffset}`;
+
+          this.terminal.write(commandAfterInsertionOffset);
+          this.terminal.write(' ');
+
+          for (let i = 0; i < commandAfterInsertionOffset.length + 1; i++) {
+            this.terminal.write(MOVE_CURSOR_BACKWARD);
+          }
+        }
       }
     } else if (e.key.length > 0) {
+      if (this.insertionOffsetFromEnd > 0) {
+        this.terminal.write(INSERT_BLANK_CHARACTER);
+      }
+
       this.terminal.write(e.key);
-      this.command = `${this.command}${e.key}`;
+
+      const commandLength = this.command.length;
+      const insertionOffsetFromStart = commandLength - this.insertionOffsetFromEnd;
+      const commandBeforeInsertionOffset = this.command.substring(0, insertionOffsetFromStart);
+      const commandAfterInsertionOffset = this.command.substring(insertionOffsetFromStart);
+
+      this.command = `${commandBeforeInsertionOffset}${e.key}${commandAfterInsertionOffset}`;
     }
   }
 

--- a/ui/app/utils/classes/exec-command-editor-xterm-adapter.js
+++ b/ui/app/utils/classes/exec-command-editor-xterm-adapter.js
@@ -20,7 +20,13 @@ export default class ExecCommandEditorXtermAdapter {
 
   handleKeyEvent(e) {
     // Issue to handle arrow keys etc: https://github.com/hashicorp/nomad/issues/7463
-    if (e.domEvent.key === 'Enter') {
+    if (e.domEvent.key === 'u' && e.domEvent.ctrlKey) {
+      for (let i = 0; i < this.command.length; i++) {
+        this.terminal.write(BACKSPACE_ONE_CHARACTER);
+      }
+
+      this.command = '';
+    } else if (e.domEvent.key === 'Enter') {
       this.terminal.writeln('');
       this.setCommandCallback(this.command);
       this.keyListener.dispose();

--- a/ui/tests/integration/util/exec-command-editor-xterm-adapter-test.js
+++ b/ui/tests/integration/util/exec-command-editor-xterm-adapter-test.js
@@ -50,4 +50,41 @@ module('Integration | Utility | exec-command-editor-xterm-adapter', function(hoo
 
     await terminal.simulateCommandKeyEvent({ domEvent: { key: 'Enter' } });
   });
+
+  test('it supports typing ^U to delete the entire command', async function(assert) {
+    let done = assert.async();
+
+    await render(hbs`
+      <div id='terminal'></div>
+    `);
+
+    let terminal = new Terminal({ cols: 10 });
+    terminal.open(document.getElementById('terminal'));
+
+    terminal.write('to-delete');
+
+    new ExecCommandEditorXtermAdapter(
+      terminal,
+      command => {
+        assert.equal(command, '!');
+        done();
+      },
+      'to-delete'
+    );
+
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'u', ctrlKey: true } });
+
+    await settled();
+
+    assert.equal(
+      terminal.buffer
+        .getLine(0)
+        .translateToString()
+        .trim(),
+      ''
+    );
+
+    await terminal.simulateCommandKeyEvent({ key: '!', domEvent: {} });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'Enter' } });
+  });
 });

--- a/ui/tests/integration/util/exec-command-editor-xterm-adapter-test.js
+++ b/ui/tests/integration/util/exec-command-editor-xterm-adapter-test.js
@@ -87,4 +87,88 @@ module('Integration | Utility | exec-command-editor-xterm-adapter', function(hoo
     await terminal.simulateCommandKeyEvent({ key: '!', domEvent: {} });
     await terminal.simulateCommandKeyEvent({ domEvent: { key: 'Enter' } });
   });
+
+  test('it supports left and right arrow keys for moving around within the command', async function(assert) {
+    let done = assert.async();
+
+    await render(hbs`
+      <div id='terminal'></div>
+    `);
+
+    let terminal = new Terminal({ cols: 72 });
+    terminal.open(document.getElementById('terminal'));
+
+    terminal.write('command: ');
+    terminal.write('to-edit');
+
+    new ExecCommandEditorXtermAdapter(
+      terminal,
+      command => {
+        assert.equal(command, 'did-edit!');
+        done();
+      },
+      'to-edit'
+    );
+
+    await settled();
+
+    assert.equal(terminal.buffer.cursorX, 16);
+
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowLeft' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowLeft' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowLeft' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowLeft' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowLeft' } });
+
+    await settled();
+
+    assert.equal(terminal.buffer.cursorX, 11);
+
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'Backspace' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'Backspace' } });
+
+    await terminal.simulateCommandKeyEvent({ key: 'i', domEvent: {} });
+    await terminal.simulateCommandKeyEvent({ key: 'd', domEvent: {} });
+
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowLeft' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowLeft' } });
+
+    // Try to move beyond the beginning of the command
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowLeft' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'Backspace' } });
+
+    await settled();
+
+    assert.equal(terminal.buffer.cursorX, 9);
+
+    await terminal.simulateCommandKeyEvent({ key: 'd', domEvent: {} });
+
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowRight' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowRight' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowRight' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowRight' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowRight' } });
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowRight' } });
+
+    // Try to move beyond the end of the command
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'ArrowRight' } });
+
+    await settled();
+
+    assert.equal(terminal.buffer.cursorX, 17);
+
+    await terminal.simulateCommandKeyEvent({ key: '!', domEvent: {} });
+
+    await settled();
+
+    assert.equal(
+      terminal.buffer
+        .getLine(0)
+        .translateToString()
+        .trim(),
+      'command: did-edit!'
+    );
+
+    await terminal.simulateCommandKeyEvent({ domEvent: { key: 'Enter' } });
+  });
 });


### PR DESCRIPTION
This will close #7463. So far it only supports ^U to delete the entire line, but see that issue for a todo list.