### PR TITLE
UI: Guard against a null value for the HostVolumes hash

### DIFF
--- a/ui/app/serializers/node.js
+++ b/ui/app/serializers/node.js
@@ -17,10 +17,8 @@ export default ApplicationSerializer.extend({
       return assign({}, drivers[key], { Name: key });
     });
 
-    if (hash.HostVolumes) {
-      const hostVolumes = hash.HostVolumes;
-      hash.HostVolumes = Object.keys(hostVolumes).map(key => hostVolumes[key]);
-    }
+    const hostVolumes = hash.HostVolumes || {};
+    hash.HostVolumes = Object.keys(hostVolumes).map(key => hostVolumes[key]);
 
     return this._super(modelClass, hash);
   },

--- a/ui/tests/unit/serializers/node-test.js
+++ b/ui/tests/unit/serializers/node-test.js
@@ -163,6 +163,33 @@ module('Unit | Serializer | Node', function(hooks) {
                 healthy: false,
               },
             ],
+            hostVolumes: [],
+          },
+          relationships: {
+            allocations: {
+              links: {
+                related: '/v1/node/test-node/allocations',
+              },
+            },
+          },
+        },
+      },
+    },
+
+    {
+      name: 'Null hash values',
+      in: {
+        ID: 'test-node',
+        Drivers: null,
+        HostVolumes: null,
+      },
+      out: {
+        data: {
+          id: 'test-node',
+          type: 'node',
+          attributes: {
+            hostVolumes: [],
+            drivers: [],
           },
           relationships: {
             allocations: {


### PR DESCRIPTION
When a node has no host volumes, the API response will have a null value for the HostVolumes attribute, which in turn becomes a null value instead of an empty array in the store. This protects against that, ensuring host volumes is always an array.

Closes: #7506 