### PR TITLE
consul: annotate Consul interfaces with ACLs

### DIFF
--- a/client/consul/consul.go
+++ b/client/consul/consul.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ConsulServiceAPI is the interface the Nomad Client uses to register and
-// remove services and checks from Consul.css
+// remove services and checks from Consul.
 //
 // ACL requirements
 // - service:write

--- a/client/consul/consul.go
+++ b/client/consul/consul.go
@@ -6,7 +6,10 @@ import (
 )
 
 // ConsulServiceAPI is the interface the Nomad Client uses to register and
-// remove services and checks from Consul.
+// remove services and checks from Consul.css
+//
+// ACL requirements
+// - service:write
 type ConsulServiceAPI interface {
 	// RegisterWorkload with Consul. Adds all service entries and checks to Consul.
 	RegisterWorkload(*consul.WorkloadServices) error
@@ -31,6 +34,9 @@ type TokenDeriverFunc func(*structs.Allocation, []string) (map[string]string, er
 
 // ServiceIdentityAPI is the interface the Nomad Client uses to request Consul
 // Service Identity tokens through Nomad Server.
+//
+// ACL requirements
+// - acl:write (used by Server only)
 type ServiceIdentityAPI interface {
 	// DeriveSITokens contacts the nomad server and requests consul service
 	// identity tokens be generated for tasks in the allocation.

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -75,13 +75,25 @@ const (
 	deregisterProbationPeriod = time.Minute
 )
 
+// Additional Consul ACLs required
+// - Consul Template: key:read
+//   Used in tasks with template stanza that use Consul keys.
+
 // CatalogAPI is the consul/api.Catalog API used by Nomad.
+//
+// ACL requirements
+// - node:read (listing datacenters)
+// - service:read
 type CatalogAPI interface {
 	Datacenters() ([]string, error)
 	Service(service, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error)
 }
 
 // AgentAPI is the consul/api.Agent API used by Nomad.
+//
+// ACL requirements
+// - agent:read
+// - service:write
 type AgentAPI interface {
 	Services() (map[string]*api.AgentService, error)
 	Checks() (map[string]*api.AgentCheck, error)
@@ -94,6 +106,9 @@ type AgentAPI interface {
 }
 
 // ACLsAPI is the consul/api.ACL API subset used by Nomad Server.
+//
+// ACL requirements
+// - acl:write (server only)
 type ACLsAPI interface {
 	// We are looking up by [operator token] SecretID, which implies we need
 	// to use this method instead of the normal TokenRead, which can only be

--- a/e2e/consulacls/nomad-client-policy.hcl
+++ b/e2e/consulacls/nomad-client-policy.hcl
@@ -4,10 +4,10 @@ service_prefix "" {
   policy = "write"
 }
 
-node_prefix "" {
-  policy = "write"
+agent_prefix "" {
+  policy = "read"
 }
 
-agent_prefix "" {
+node_prefix "" {
   policy = "read"
 }

--- a/e2e/consulacls/nomad-server-policy.hcl
+++ b/e2e/consulacls/nomad-server-policy.hcl
@@ -7,10 +7,10 @@ service_prefix "" {
   policy = "write"
 }
 
-node_prefix "" {
-  policy = "write"
+agent_prefix "" {
+  policy = "read"
 }
 
-agent_prefix "" {
+node_prefix "" {
   policy = "read"
 }

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -30,9 +30,9 @@ const (
 	// revocation requests Nomad will make against Consul.
 	siTokenMaxParallelRevokes = 64
 
-	// siTokenRevocationIterval is the interval at which SI tokens that failed
+	// siTokenRevocationInterval is the interval at which SI tokens that failed
 	// initial revocation are retried.
-	siTokenRevocationIterval = 5 * time.Minute
+	siTokenRevocationInterval = 5 * time.Minute
 )
 
 const (
@@ -77,6 +77,9 @@ func (sii ServiceIdentityIndex) Description() string {
 
 // ConsulACLsAPI is an abstraction over the consul/api.ACL API used by Nomad
 // Server.
+//
+// ACL requirements
+// - acl:write (transitive through ACLsAPI)
 type ConsulACLsAPI interface {
 
 	// CheckSIPolicy checks that the given operator token has the equivalent ACL
@@ -350,7 +353,7 @@ func (c *consulACLsAPI) singleRevoke(ctx context.Context, accessor *structs.SITo
 }
 
 func (c *consulACLsAPI) bgRetryRevokeDaemon() {
-	ticker := time.NewTicker(siTokenRevocationIterval)
+	ticker := time.NewTicker(siTokenRevocationInterval)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
minimal Consul ACLs required on the Nomad agent's `consul.token`.
```
# server only, and only if using Connect
acl = "write"

service_prefix "" {
  policy = "write"
}

node_prefix "" {
  policy = "read"
}

agent_prefix "" {
  policy = "read"
}

# client only, and only if using Consul templates
key_prefix "" {
  policy = "read"
}
```