### PR TITLE
Add 404 Page

### DIFF
--- a/website/pages/404/index.js
+++ b/website/pages/404/index.js
@@ -1,0 +1,35 @@
+import Link from 'next/link'
+import { useEffect } from 'react'
+
+function FourOhFour() {
+  useEffect(() => {
+    if (
+      typeof window === 'object' &&
+      typeof window?.analytics?.track === 'function' &&
+      typeof window?.document?.referrer === 'string' &&
+      typeof window?.location?.href === 'string'
+    )
+      window.analytics.track({
+        event: '404 Response',
+        action: window.location.href,
+        label: window.document.referrer
+      })
+  }, [])
+
+  return (
+    <header id="p-404">
+      <h1>Page Not Found</h1>
+      <p>
+        We&apos;re sorry but we can&apos;t find the page you&apos;re looking
+        for.
+      </p>
+      <p>
+        <Link href="/">
+          <a>Back to Home</a>
+        </Link>
+      </p>
+    </header>
+  )
+}
+
+export default FourOhFour

--- a/website/pages/404/style.css
+++ b/website/pages/404/style.css
@@ -1,0 +1,31 @@
+#p-404 {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 64px auto; /* this is being overridden at the request of the learn team */
+  max-width: 784px;
+  min-height: 50vh;
+  padding-inline: 32px;
+  text-align: center;
+
+  @media (--large) {
+    padding-inline: 24px;
+  }
+
+  & h1 {
+    font-size: 1.5rem;
+    letter-spacing: -0.004em;
+    line-height: 1.375em;
+
+    @media (--medium-up) {
+      font-size: 1.75rem;
+      line-height: 1.321em;
+    }
+
+    @media (--large) {
+      font-size: 2rem;
+      letter-spacing: -0.006em;
+      line-height: 1.313em;
+    }
+  }
+}


### PR DESCRIPTION
<p align="center"><strong>🚧🚧🚧 WORK IN PROGRESS 🚧🚧🚧 DO NOT MERGE 🚧🚧🚧</strong></p>

---

- 🔍 [Preview](https://deploy-preview-7311--nomad-website.netlify.com/four/ohfour)
- 🎩 [Production](https://nomadproject.io/four/ohfour)
- 🎟 [Asana](https://app.asana.com/0/1100423001970639/1165187009160473/f)

This adds analytics tracking of visits to 404 pages.

#### Problem

There isn't currently a clear way to see a report of 404s encountered on Learn or other .io sites. This could be a problem if we have a lot of traffic to dead pages which could otherwise be redirected or if they represent useful content that practitioners want to find but can't.

#### Solution

This change adds tracking to 404 pages, allowing us to see any often-requested pages that are not available.

#### Impact

Discovering 404s and fixing them could significantly improve our ability to show practitioners what they need.

#### Implementation Details

This tracks a "_404 Response_" event, with the `action` being the current `href`, and the `label` being the `document.referrer`. i.e:

```js
window.analytics.track({
  event: '404 Response',
  action: window.location.href,
  label: window.document.referrer
})
```

---

<p align="center"><strong>🚧🚧🚧 WORK IN PROGRESS 🚧🚧🚧 DO NOT MERGE 🚧🚧🚧</strong></p>