### PR TITLE
Use scroll-margin with floating navigation

### DIFF
--- a/website/pages/style.css
+++ b/website/pages/style.css
@@ -99,22 +99,8 @@
 }
 
 /* Permalink adjustment for sticky nav */
-.g-content {
-  & h1,
-  & h2,
-  & h3,
-  & h4,
-  & h5,
-  & h6,
-  & li {
-    position: relative;
-
-    & .__target-h,
-    & .__target-lic {
-      position: absolute;
-      top: -75px;
-    }
-  }
+.g-subnav ~ * :target {
+  scroll-margin-top: calc(64px + 0.5em);
 }
 
 /* Web Fonts */

--- a/website/pages/style.css
+++ b/website/pages/style.css
@@ -98,7 +98,19 @@
   color: white;
 }
 
-/* Permalink adjustment for sticky nav */
+/*
+ * About this selector:
+ * `.g-subnav ~ *` finds all elements after the navigation.
+ * `:target` finds the active permalink on the page.
+ *
+ * About this style:
+ * `scroll-margin-top` adjusts the vertical scroll of a permalink.
+ * `64px` adjusts the scroll to account for the navigation.
+ * `0.5em` further adjusts the scroll to give the permalink breathing room.
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/CSS/:target
+ * See: https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top
+ */
 .g-subnav ~ * :target {
   scroll-margin-top: calc(64px + 0.5em);
 }


### PR DESCRIPTION
- 🔍 [Preview](https://deploy-preview-7528--nomad-website.netlify.com/docs/configuration/tls/#ca_file)

This changes fragment links to use [`scroll-margin-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top) to offset their vertical scroll position when experienced alongside the floating navigation.

This also changes the vertical offset from `75px` to `calc(64px + 0.5em)`. The `64px` accounts for the height of the **SubNav**, which is computed from `px` units. The `0.5em` accounts for the visual breathing room of the **target itself**, which is often text and thusly defined by its `em` size.

Here are some examples of how the `px` and `em` work best together:

- 🔍 [Example, link within `<li>`](https://deploy-preview-7528--nomad-website.netlify.com/docs/commands/eval-status/#no-color)
- 🔍 [Example, link within `<h2>`](https://deploy-preview-7528--nomad-website.netlify.com/docs/configuration/tls/#enabling-tls)
- 🔍 [Example, link within `<h3>`](https://deploy-preview-7528--nomad-website.netlify.com/docs/configuration/tls/#tls-examples)

This change also updates the CSS selector used for this effect so that it applies to all active [targets](https://developer.mozilla.org/en-US/docs/Web/CSS/:target) that appear after the **SubNav**. This allows non-link destinations like the Sidebar or "Edit this page" button to receive the same treatment, as well as any links that may not conform to the exact DOM tree presently required.

> *Note*: If the Sidebar "Filter" `<input>` had a `name` or `id`, you would also see that a link to that fragment would correctly scroll the page _and_ focus the input.

- 🔍 [Example, Sidebar, link without `<a>`](https://deploy-preview-7528--nomad-website.netlify.com/docs/commands/eval-status/#sidebar)
- 🔍 [Example, "Edit this page", link without `<a>`, best experienced with a small screen](https://deploy-preview-7528--nomad-website.netlify.com/docs/commands/eval-status/#edit-this-page)

#### Coincidenting benefits

The use of the `:target` selector clearly communicates the intent of the rule while reducing the present complexity of the selector.

The use of a `scroll-margin` property clearly communicates the intent of the declaration, while the removal of the `position` and its related styles reduce layout complexity.

The `scroll-margin` property is not supported by **Internet Explorer 11**, which is _a good thing_ because IE11 users do not experience the sticky navigation either. This prevents the unideal situation where an IE11 visitor is presented the wrong definition on a page, because the correct definition happens to be `75px` below it.