### PR TITLE
Add new setUpstreamsLocked function to avoid blocking on Update

### DIFF
--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -656,7 +656,7 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 		}
 	}
 	if len(upstreams) > 0 {
-		b.SetUpstreams(upstreams)
+		b.setUpstreamsLocked(upstreams)
 	}
 
 	return b
@@ -752,8 +752,12 @@ func buildPortEnv(envMap map[string]string, p structs.Port, ip string, driverNet
 // SetUpstreams defined by connect enabled group services
 func (b *Builder) SetUpstreams(upstreams []structs.ConsulUpstream) *Builder {
 	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.setUpstreamsLocked(upstreams)
+}
+
+func (b *Builder) setUpstreamsLocked(upstreams []structs.ConsulUpstream) *Builder {
 	b.upstreams = upstreams
-	b.mu.Unlock()
 	return b
 }
 


### PR DESCRIPTION
This adds a new function **setUpstreamsLocked** to avoid the lock when setting upstreams.

The SetUpstreams function isn't called anywhere else on the code so maybe we could simple remove the lock from there, but I thought that maybe in a future is needed.

Fixes https://github.com/hashicorp/nomad/issues/7540