### PR TITLE
state: support snapshot of CSI plugin and volume tables

### DIFF
--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1286,3 +1286,40 @@ func JobWithScalingPolicy() (*structs.Job, *structs.ScalingPolicy) {
 	job.TaskGroups[0].Scaling = policy
 	return job, policy
 }
+
+func CSIPlugin() *structs.CSIPlugin {
+	return &structs.CSIPlugin{
+		ID:                 uuid.Generate(),
+		Provider:           "com.hashicorp:mock",
+		Version:            "0.1",
+		ControllerRequired: true,
+		Controllers:        map[string]*structs.CSIInfo{},
+		Nodes:              map[string]*structs.CSIInfo{},
+		Allocations:        []*structs.AllocListStub{},
+		ControllersHealthy: 0,
+		NodesHealthy:       0,
+	}
+}
+
+func CSIVolume(plugin *structs.CSIPlugin) *structs.CSIVolume {
+	return &structs.CSIVolume{
+		ID:                  uuid.Generate(),
+		Name:                "test-vol",
+		ExternalID:          "vol-01",
+		Namespace:           "default",
+		Topologies:          []*structs.CSITopology{},
+		AccessMode:          structs.CSIVolumeAccessModeSingleNodeWriter,
+		AttachmentMode:      structs.CSIVolumeAttachmentModeFilesystem,
+		MountOptions:        &structs.CSIMountOptions{},
+		ReadAllocs:          map[string]*structs.Allocation{},
+		WriteAllocs:         map[string]*structs.Allocation{},
+		PluginID:            plugin.ID,
+		Provider:            plugin.Provider,
+		ProviderVersion:     plugin.Version,
+		ControllerRequired:  plugin.ControllerRequired,
+		ControllersHealthy:  plugin.ControllersHealthy,
+		ControllersExpected: len(plugin.Controllers),
+		NodesHealthy:        plugin.NodesHealthy,
+		NodesExpected:       len(plugin.Nodes),
+	}
+}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -3217,6 +3217,47 @@ func TestStateStore_CSIPluginJobs(t *testing.T) {
 	require.Nil(t, plug)
 }
 
+func TestStateStore_RestoreCSIPlugin(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	state := testStateStore(t)
+	plugin := mock.CSIPlugin()
+
+	restore, err := state.Restore()
+	require.NoError(err)
+
+	err = restore.CSIPluginRestore(plugin)
+	require.NoError(err)
+	restore.Commit()
+
+	ws := memdb.NewWatchSet()
+	out, err := state.CSIPluginByID(ws, plugin.ID)
+	require.NoError(err)
+	require.EqualValues(out, plugin)
+}
+
+func TestStateStore_RestoreCSIVolume(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	state := testStateStore(t)
+	plugin := mock.CSIPlugin()
+	volume := mock.CSIVolume(plugin)
+
+	restore, err := state.Restore()
+	require.NoError(err)
+
+	err = restore.CSIVolumeRestore(volume)
+	require.NoError(err)
+	restore.Commit()
+
+	ws := memdb.NewWatchSet()
+	out, err := state.CSIVolumeByID(ws, "default", volume.ID)
+	require.NoError(err)
+	require.EqualValues(out, volume)
+}
+
 func TestStateStore_Indexes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7544

The `csi_plugins` and `csi_volumes` tables were missing support for snapshot persist and restore. This means restoring a snapshot would result in missing information for CSI.