### PR TITLE
csi: add grpc retries to client controller RPCs

### DIFF
--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -129,7 +129,11 @@ func newGrpcConn(addr string, logger hclog.Logger) (*grpc.ClientConn, error) {
 // PluginInfo describes the type and version of a plugin as required by the nomad
 // base.BasePlugin interface.
 func (c *client) PluginInfo() (*base.PluginInfoResponse, error) {
-	name, version, err := c.PluginGetInfo(context.TODO())
+	// note: no grpc retries needed here, as this is called in
+	// fingerprinting and will get retried by the caller.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	name, version, err := c.PluginGetInfo(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -159,6 +159,7 @@ func (c *client) SetConfig(_ *base.Config) error {
 }
 
 func (c *client) PluginProbe(ctx context.Context) (bool, error) {
+	// note: no grpc retries should be done here
 	req, err := c.identityClient.Probe(ctx, &csipbv1.ProbeRequest{})
 	if err != nil {
 		return false, err
@@ -209,7 +210,10 @@ func (c *client) PluginGetCapabilities(ctx context.Context) (*PluginCapabilitySe
 		return nil, fmt.Errorf("Client not initialized")
 	}
 
-	resp, err := c.identityClient.GetPluginCapabilities(ctx, &csipbv1.GetPluginCapabilitiesRequest{})
+	// note: no grpc retries needed here, as this is called in
+	// fingerprinting and will get retried by the caller
+	resp, err := c.identityClient.GetPluginCapabilities(ctx,
+		&csipbv1.GetPluginCapabilitiesRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +233,10 @@ func (c *client) ControllerGetCapabilities(ctx context.Context) (*ControllerCapa
 		return nil, fmt.Errorf("controllerClient not initialized")
 	}
 
-	resp, err := c.controllerClient.ControllerGetCapabilities(ctx, &csipbv1.ControllerGetCapabilitiesRequest{})
+	// note: no grpc retries needed here, as this is called in
+	// fingerprinting and will get retried by the caller
+	resp, err := c.controllerClient.ControllerGetCapabilities(ctx,
+		&csipbv1.ControllerGetCapabilitiesRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -333,6 +340,8 @@ func (c *client) NodeGetCapabilities(ctx context.Context) (*NodeCapabilitySet, e
 		return nil, fmt.Errorf("Client not initialized")
 	}
 
+	// note: no grpc retries needed here, as this is called in
+	// fingerprinting and will get retried by the caller
 	resp, err := c.nodeClient.NodeGetCapabilities(ctx, &csipbv1.NodeGetCapabilitiesRequest{})
 	if err != nil {
 		return nil, err
@@ -351,6 +360,8 @@ func (c *client) NodeGetInfo(ctx context.Context) (*NodeGetInfoResponse, error) 
 
 	result := &NodeGetInfoResponse{}
 
+	// note: no grpc retries needed here, as this is called in
+	// fingerprinting and will get retried by the caller
 	resp, err := c.nodeClient.NodeGetInfo(ctx, &csipbv1.NodeGetInfoRequest{})
 	if err != nil {
 		return nil, err

--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -233,7 +233,7 @@ func (c *client) ControllerGetCapabilities(ctx context.Context) (*ControllerCapa
 	return NewControllerCapabilitySet(resp), nil
 }
 
-func (c *client) ControllerPublishVolume(ctx context.Context, req *ControllerPublishVolumeRequest) (*ControllerPublishVolumeResponse, error) {
+func (c *client) ControllerPublishVolume(ctx context.Context, req *ControllerPublishVolumeRequest, opts ...grpc.CallOption) (*ControllerPublishVolumeResponse, error) {
 	if c == nil {
 		return nil, fmt.Errorf("Client not initialized")
 	}
@@ -247,7 +247,7 @@ func (c *client) ControllerPublishVolume(ctx context.Context, req *ControllerPub
 	}
 
 	pbrequest := req.ToCSIRepresentation()
-	resp, err := c.controllerClient.ControllerPublishVolume(ctx, pbrequest)
+	resp, err := c.controllerClient.ControllerPublishVolume(ctx, pbrequest, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (c *client) ControllerPublishVolume(ctx context.Context, req *ControllerPub
 	}, nil
 }
 
-func (c *client) ControllerUnpublishVolume(ctx context.Context, req *ControllerUnpublishVolumeRequest) (*ControllerUnpublishVolumeResponse, error) {
+func (c *client) ControllerUnpublishVolume(ctx context.Context, req *ControllerUnpublishVolumeRequest, opts ...grpc.CallOption) (*ControllerUnpublishVolumeResponse, error) {
 	if c == nil {
 		return nil, fmt.Errorf("Client not initialized")
 	}
@@ -270,7 +270,7 @@ func (c *client) ControllerUnpublishVolume(ctx context.Context, req *ControllerU
 	}
 
 	upbrequest := req.ToCSIRepresentation()
-	_, err = c.controllerClient.ControllerUnpublishVolume(ctx, upbrequest)
+	_, err = c.controllerClient.ControllerUnpublishVolume(ctx, upbrequest, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func (c *client) ControllerUnpublishVolume(ctx context.Context, req *ControllerU
 	return &ControllerUnpublishVolumeResponse{}, nil
 }
 
-func (c *client) ControllerValidateCapabilties(ctx context.Context, volumeID string, capabilities *VolumeCapability) error {
+func (c *client) ControllerValidateCapabilities(ctx context.Context, volumeID string, capabilities *VolumeCapability, opts ...grpc.CallOption) error {
 	if c == nil {
 		return fmt.Errorf("Client not initialized")
 	}
@@ -301,7 +301,7 @@ func (c *client) ControllerValidateCapabilties(ctx context.Context, volumeID str
 		},
 	}
 
-	resp, err := c.controllerClient.ValidateVolumeCapabilities(ctx, req)
+	resp, err := c.controllerClient.ValidateVolumeCapabilities(ctx, req, opts...)
 	if err != nil {
 		return err
 	}

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -140,7 +140,7 @@ func (c *Client) ControllerGetCapabilities(ctx context.Context) (*csi.Controller
 }
 
 // ControllerPublishVolume is used to attach a remote volume to a node
-func (c *Client) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+func (c *Client) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest, opts ...grpc.CallOption) (*csi.ControllerPublishVolumeResponse, error) {
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 
@@ -150,7 +150,7 @@ func (c *Client) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 }
 
 // ControllerUnpublishVolume is used to attach a remote volume to a node
-func (c *Client) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+func (c *Client) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest, opts ...grpc.CallOption) (*csi.ControllerUnpublishVolumeResponse, error) {
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 
@@ -159,7 +159,7 @@ func (c *Client) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 	return c.NextControllerUnpublishVolumeResponse, c.NextControllerUnpublishVolumeErr
 }
 
-func (c *Client) ControllerValidateCapabilties(ctx context.Context, volumeID string, capabilities *csi.VolumeCapability) error {
+func (c *Client) ControllerValidateCapabilities(ctx context.Context, volumeID string, capabilities *csi.VolumeCapability, opts ...grpc.CallOption) error {
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -36,14 +36,14 @@ type CSIPlugin interface {
 	ControllerGetCapabilities(ctx context.Context) (*ControllerCapabilitySet, error)
 
 	// ControllerPublishVolume is used to attach a remote volume to a cluster node.
-	ControllerPublishVolume(ctx context.Context, req *ControllerPublishVolumeRequest) (*ControllerPublishVolumeResponse, error)
+	ControllerPublishVolume(ctx context.Context, req *ControllerPublishVolumeRequest, opts ...grpc.CallOption) (*ControllerPublishVolumeResponse, error)
 
 	// ControllerUnpublishVolume is used to deattach a remote volume from a cluster node.
-	ControllerUnpublishVolume(ctx context.Context, req *ControllerUnpublishVolumeRequest) (*ControllerUnpublishVolumeResponse, error)
+	ControllerUnpublishVolume(ctx context.Context, req *ControllerUnpublishVolumeRequest, opts ...grpc.CallOption) (*ControllerUnpublishVolumeResponse, error)
 
 	// ControllerValidateCapabilities is used to validate that a volume exists and
 	// supports the requested capability.
-	ControllerValidateCapabilties(ctx context.Context, volumeID string, capabilities *VolumeCapability) error
+	ControllerValidateCapabilities(ctx context.Context, volumeID string, capabilities *VolumeCapability, opts ...grpc.CallOption) error
 
 	// NodeGetCapabilities is used to return the available capabilities from the
 	// Node Service.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/6863

The [CSI Specification](https://github.com/container-storage-interface/spec/blob/master/spec.md) defines various gRPC Errors and how they may be retried. After auditing all our CSI RPC callas in https://github.com/hashicorp/nomad/issues/6863#issuecomment-606085131, this changeset:

- adds retries and backoffs to the where they were needed but not implemented
- annotates those CSI RPCs that do _not_ need retries so that we don't wonder whether it's been left off accidentally
- added a timeout and cancellation context to the `Probe` call, which didn't have one.