### PR TITLE
plugin: ensure plugin loader maps correct API version to type.

### DIFF
--- a/helper/pluginutils/loader/api_versions.go
+++ b/helper/pluginutils/loader/api_versions.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/device"
+	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
 var (
@@ -10,6 +11,6 @@ var (
 	// Nomad agent by plugin type.
 	AgentSupportedApiVersions = map[string][]string{
 		base.PluginTypeDevice: {device.ApiVersion010},
-		base.PluginTypeDriver: {device.ApiVersion010},
+		base.PluginTypeDriver: {drivers.ApiVersion010},
 	}
 )


### PR DESCRIPTION
The plugin loader supplies a version map to ensure the Nomad agent
can support the plugins at the version they specify. The map was
incorrectly mapping the driver type to the device API supported
version identifier. This currently does not cause a bug as both
device and driver versions are the same string. This could cause
problems in the future, however, if either plugin interface were
to change and require version updates.