### PR TITLE
csi: use node MaxVolumes during scheduling

### DIFF
--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -121,7 +121,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 			var iter memdb.ResultIterator
 
 			if args.NodeID != "" {
-				iter, err = state.CSIVolumesByNodeID(ws, ns, args.NodeID)
+				iter, err = state.CSIVolumesByNodeID(ws, args.NodeID)
 			} else if args.PluginID != "" {
 				iter, err = state.CSIVolumesByPluginID(ws, ns, args.PluginID)
 			} else {
@@ -147,8 +147,13 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 					return err
 				}
 
-				// Filter (possibly again) on PluginID to handle passing both NodeID and PluginID
+				// Remove (possibly again) by PluginID to handle passing both NodeID and PluginID
 				if args.PluginID != "" && args.PluginID != vol.PluginID {
+					continue
+				}
+
+				// Remove by Namespace, since CSIVolumesByNodeID hasn't used the Namespace yet
+				if vol.Namespace != ns {
 					continue
 				}
 

--- a/nomad/state/iterator.go
+++ b/nomad/state/iterator.go
@@ -20,9 +20,10 @@ func (i *SliceIterator) Next() interface{} {
 	if i.idx == len(i.data) {
 		return nil
 	}
-	idx := i.idx
+
+	datum := i.data[i.idx]
 	i.idx += 1
-	return i.data[idx]
+	return datum
 }
 
 func (i *SliceIterator) WatchCh() <-chan struct{} {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1873,15 +1873,6 @@ func (s *StateStore) CSIVolumesByNodeID(ws memdb.WatchSet, nodeID string) (memdb
 	if err != nil {
 		return nil, fmt.Errorf("alloc lookup failed: %v", err)
 	}
-	snap, err := s.Snapshot()
-	if err != nil {
-		return nil, fmt.Errorf("alloc lookup failed: %v", err)
-	}
-
-	allocs, err = snap.DenormalizeAllocationSlice(allocs)
-	if err != nil {
-		return nil, fmt.Errorf("alloc lookup failed: %v", err)
-	}
 
 	// Find volume ids for CSI volumes in running allocs, or allocs that we desire to run
 	ids := map[string]string{} // Map volumeID to Namespace
@@ -5067,6 +5058,8 @@ func (s *StateSnapshot) DenormalizeAllocationsMap(nodeAllocations map[string][]*
 // DenormalizeAllocationSlice queries the Allocation for each allocation diff
 // represented as an Allocation and merges the updated attributes with the existing
 // Allocation, and attaches the Job provided.
+//
+// This should only be called on terminal allocs, particularly stopped or preempted allocs
 func (s *StateSnapshot) DenormalizeAllocationSlice(allocs []*structs.Allocation) ([]*structs.Allocation, error) {
 	allocDiffs := make([]*structs.AllocationDiff, len(allocs))
 	for i, alloc := range allocs {

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2936,7 +2936,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	require.Equal(t, 1, len(vs))
 
 	ws = memdb.NewWatchSet()
-	iter, err = state.CSIVolumesByNodeID(ws, ns, node.ID)
+	iter, err = state.CSIVolumesByNodeID(ws, node.ID)
 	require.NoError(t, err)
 	vs = slurp(iter)
 	require.Equal(t, 1, len(vs))

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -253,21 +253,21 @@ func TestCSIVolumeChecker(t *testing.T) {
 		"foo": {
 			PluginID: "foo",
 			Healthy:  true,
-			NodeInfo: &structs.CSINodeInfo{},
+			NodeInfo: &structs.CSINodeInfo{MaxVolumes: 1},
 		},
 	}
 	nodes[1].CSINodePlugins = map[string]*structs.CSIInfo{
 		"foo": {
 			PluginID: "foo",
 			Healthy:  false,
-			NodeInfo: &structs.CSINodeInfo{},
+			NodeInfo: &structs.CSINodeInfo{MaxVolumes: 1},
 		},
 	}
 	nodes[2].CSINodePlugins = map[string]*structs.CSIInfo{
 		"bar": {
 			PluginID: "bar",
 			Healthy:  true,
-			NodeInfo: &structs.CSINodeInfo{},
+			NodeInfo: &structs.CSINodeInfo{MaxVolumes: 1},
 		},
 	}
 

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -239,6 +239,7 @@ func TestCSIVolumeChecker(t *testing.T) {
 		mock.Node(),
 		mock.Node(),
 		mock.Node(),
+		mock.Node(),
 	}
 
 	// Register running plugins on some nodes
@@ -270,6 +271,13 @@ func TestCSIVolumeChecker(t *testing.T) {
 			NodeInfo: &structs.CSINodeInfo{MaxVolumes: 1},
 		},
 	}
+	nodes[4].CSINodePlugins = map[string]*structs.CSIInfo{
+		"foo": {
+			PluginID: "foo",
+			Healthy:  true,
+			NodeInfo: &structs.CSINodeInfo{MaxVolumes: 1},
+		},
+	}
 
 	// Create the plugins in the state store
 	index := uint64(999)
@@ -288,6 +296,37 @@ func TestCSIVolumeChecker(t *testing.T) {
 	vol.AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem
 	err := state.CSIVolumeRegister(index, []*structs.CSIVolume{vol})
 	require.NoError(t, err)
+	index++
+
+	// Create some other volumes in use on nodes[3] to trip MaxVolumes
+	vid2 := uuid.Generate()
+	vol2 := structs.NewCSIVolume(vid2, index)
+	vol2.PluginID = "foo"
+	vol2.Namespace = structs.DefaultNamespace
+	vol2.AccessMode = structs.CSIVolumeAccessModeMultiNodeSingleWriter
+	vol2.AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem
+	err = state.CSIVolumeRegister(index, []*structs.CSIVolume{vol2})
+	require.NoError(t, err)
+	index++
+
+	alloc := mock.Alloc()
+	alloc.NodeID = nodes[4].ID
+	alloc.Job.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{
+		vid2: {
+			Name:   vid2,
+			Type:   "csi",
+			Source: vid2,
+		},
+	}
+	err = state.UpsertJob(index, alloc.Job)
+	require.NoError(t, err)
+	index++
+	summary := mock.JobSummary(alloc.JobID)
+	require.NoError(t, state.UpsertJobSummary(index, summary))
+	index++
+	err = state.UpsertAllocs(index, []*structs.Allocation{alloc})
+	require.NoError(t, err)
+	index++
 
 	// Create volume requests
 	noVolumes := map[string]*structs.VolumeRequest{}
@@ -340,6 +379,11 @@ func TestCSIVolumeChecker(t *testing.T) {
 		},
 		{ // Volumes requested, none available
 			Node:             nodes[3],
+			RequestedVolumes: volumes,
+			Result:           false,
+		},
+		{ // Volumes requested, MaxVolumes exceeded
+			Node:             nodes[4],
 			RequestedVolumes: volumes,
 			Result:           false,
 		},

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -97,6 +97,9 @@ type State interface {
 
 	// CSIVolumeByID fetch CSI volumes, containing controller jobs
 	CSIVolumeByID(memdb.WatchSet, string, string) (*structs.CSIVolume, error)
+
+	// CSIVolumeByID fetch CSI volumes, containing controller jobs
+	CSIVolumesByNodeID(memdb.WatchSet, string) (memdb.ResultIterator, error)
 }
 
 // Planner interface is used to submit a task allocation plan.


### PR DESCRIPTION
Select volumes by node during scheduling, use them to enforce `MaxVolumes` at the scheduler. Closes #7025 