### PR TITLE
UI: Add exec loading template

### DIFF
--- a/ui/app/styles/components/exec.scss
+++ b/ui/app/styles/components/exec.scss
@@ -21,6 +21,13 @@
       }
     }
   }
+
+  &.loading {
+    justify-content: center;
+    align-items: center;
+    background: black;
+    height: 100%;
+  }
 }
 
 .task-group-tree {

--- a/ui/app/templates/exec-loading.hbs
+++ b/ui/app/templates/exec-loading.hbs
@@ -1,0 +1,17 @@
+{{title "Exec"}}
+<nav class="navbar is-popup">
+  <div class="navbar-brand">
+    <div class="navbar-item is-logo">
+      {{partial "partials/nomad-logo"}}
+    </div>
+  </div>
+
+  <div class="navbar-end">
+    <a href="https://nomadproject.io/docs" target="_blank" rel="noopener" class="navbar-item">Documentation</a>
+    {{x-icon "lock-closed"}}
+  </div>
+</nav>
+
+<div class="tree-and-terminal loading">
+  {{partial "partials/loading-spinner"}}
+</div>

--- a/ui/app/templates/exec.hbs
+++ b/ui/app/templates/exec.hbs
@@ -1,6 +1,4 @@
 {{title "Exec"}}
-{{!-- the application shows briefly in the background, shouldn’t render at all 😳 --}}
-{{!-- issue to fix: https://github.com/hashicorp/nomad/issues/7460 --}}
 <nav class="navbar is-popup">
   <div class="navbar-brand">
     <div class="navbar-item is-logo">


### PR DESCRIPTION
This closes #7460. Before this, there was an incongruous flash
of the non-exec UI during loading.

Here’s a GIF with the network throttled to “Fast 3G” to slow loading down:
![loading-no-sidebar-shifted](https://user-images.githubusercontent.com/43280/78064103-d4a22800-7356-11ea-9e15-73c9e6d6578e.gif)
