### PR TITLE
[docs] Fix syntax error in docs

### DIFF
--- a/website/pages/docs/job-specification/service.mdx
+++ b/website/pages/docs/job-specification/service.mdx
@@ -413,7 +413,7 @@ service {
     name     = "Postgres Check"
     type     = "script"
     command  = "/usr/local/bin/pg-tools"
-    args     = ["verify", "database" "prod", "up"]
+    args     = ["verify", "database", "prod", "up"]
     interval = "5s"
     timeout  = "2s"
   }


### PR DESCRIPTION
Prior to this commit, the HCL syntax was invalid. This commit adds a `,`
to make the example pass syntax checks.

FYI this error was found while testing a new syntax check system I am looking to port to the .io sites

```shell
# Location is optional
mkdir -p ~/src
git clone git@github.com:hashicorp/nomad.git ~/src/nomad

# Run syntax checks
git clone git@github.com:hashicorp/learn-inspec.git
cd learn-inspec
./run.sh -d ~/src/nomad -p nomad.io
```

This is running `hclfmt` under the hood.
