### PR TITLE
Use latest go-bindata and go-bindata-assetfs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -158,8 +158,8 @@ bootstrap: deps lint-deps git-hooks # Install all dependencies
 deps:  ## Install build and development dependencies
 	@echo "==> Updating build dependencies..."
 	GO111MODULE=on go get -u github.com/kardianos/govendor
-	GO111MODULE=on go get -u github.com/hashicorp/go-bindata/go-bindata
-	GO111MODULE=on go get -u github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs
+	go get -u github.com/hashicorp/go-bindata/go-bindata
+	go get -u github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs
 	GO111MODULE=on go get -u github.com/a8m/tree/cmd/tree
 	GO111MODULE=on go get -u github.com/magiconair/vendorfmt/cmd/vendorfmt
 	GO111MODULE=on go get -u gotest.tools/gotestsum


### PR DESCRIPTION
These dep tools aren't tagged properly so shouldn't be installed with go
mod