### PR TITLE
UI: Change CSI to Storage and mark it as beta

### DIFF
--- a/ui/app/styles/core/menu.scss
+++ b/ui/app/styles/core/menu.scss
@@ -21,6 +21,16 @@
         }
       }
 
+      &.is-beta::after {
+        content: 'beta';
+        color: $grey;
+        font-size: 0.8em;
+        font-weight: $weight-normal;
+        position: relative;
+        top: -0.8em;
+        left: -0.8em;
+      }
+
       .icon {
         margin-right: 0.5em;
         fill: lighten($text, 30%);

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -57,7 +57,7 @@
         Integrations
       </p>
       <ul class="menu-list">
-        <li>{{#link-to "csi" activeClass="is-active" data-test-gutter-link="csi"}}CSI{{/link-to}}</li>
+        <li>{{#link-to "csi" class="is-beta" activeClass="is-active" data-test-gutter-link="csi"}}Storage{{/link-to}}</li>
       </ul>
       <p class="menu-label">
         Cluster


### PR DESCRIPTION
When 0.11 goes GA, CSI will still be beta, so the UI will reflect that. Also Storage is a more general purpose name with the added benefit of avoiding an acronym.

![image](https://user-images.githubusercontent.com/174740/78089635-de3e8680-737c-11ea-9926-22c87b826eef.png)
