### PR TITLE
fix codegen for ugorji/go

### DIFF
--- a/client/structs/generate.sh
+++ b/client/structs/generate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+codecgen -d 102 -t codegen_generated -o structs.generated.go structs.go
+sed -i'' -e 's|"github.com/ugorji/go/codec|"github.com/hashicorp/go-msgpack/codec|g' structs.generated.go

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -1,6 +1,6 @@
 package structs
 
-//go:generate codecgen -d 102 -t codec_generated -o structs.generated.go structs.go
+//go:generate ./generate.sh
 
 import (
 	"errors"

--- a/nomad/structs/generate.sh
+++ b/nomad/structs/generate.sh
@@ -2,4 +2,5 @@
 set -e
 
 FILES="$(ls ./*.go | grep -v -e _test.go -e .generated.go | tr '\n' ' ')"
-codecgen -d 100 -t codec_generated -o structs.generated.go ${FILES}
+codecgen -d 100 -t codegen_generated -o structs.generated.go ${FILES}
+sed -i'' -e 's|"github.com/ugorji/go/codec|"github.com/hashicorp/go-msgpack/codec|g' structs.generated.go


### PR DESCRIPTION
When generating ugorji/go package, we should use
github.com/hashicorp/go-msgpack/codec instead.

Also fix the reference for codegen_generated.

This is a follow up to https://github.com/hashicorp/nomad/pull/7560