### PR TITLE
Fix/improve "job plan" messaging

### DIFF
--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -17,7 +17,7 @@ const (
 nomad job run -check-index %d %s
 
 When running the job with the check-index flag, the job will only be run if the
-server side version matches the job modify index returned. If the index has
+job modify index given matches the server-side version. If the index has
 changed, another user has modified the job and the plan's results are
 potentially invalid.`
 

--- a/website/pages/docs/commands/job/plan.mdx
+++ b/website/pages/docs/commands/job/plan.mdx
@@ -83,7 +83,7 @@ To submit the job with version verification run:
 nomad job run -check-index 0 example.nomad
 
 When running the job with the check-index flag, the job will only be run if the
-server side version matches the job modify index returned. If the index has
+job modify index given matches the server-side version. If the index has
 changed, another user has modified the job and the plan's results are
 potentially invalid.
 ```
@@ -109,7 +109,7 @@ To submit the job with version verification run:
 nomad job run -check-index 15 example.nomad
 
 When running the job with the check-index flag, the job will only be run if the
-server side version matches the job modify index returned. If the index has
+job modify index given matches the server-side version. If the index has
 changed, another user has modified the job and the plan's results are
 potentially invalid.
 ```
@@ -136,7 +136,7 @@ To submit the job with version verification run:
 nomad job run -check-index 7 example.nomad
 
 When running the job with the check-index flag, the job will only be run if the
-server side version matches the job modify index returned. If the index has
+job modify index given matches the server-side version. If the index has
 changed, another user has modified the job and the plan's results are
 potentially invalid.
 ```
@@ -194,7 +194,7 @@ To submit the job with version verification run:
 nomad job run -check-index 7 example.nomad
 
 When running the job with the check-index flag, the job will only be run if the
-server side version matches the job modify index returned. If the index has
+job modify index given matches the server-side version. If the index has
 changed, another user has modified the job and the plan's results are
 potentially invalid.
 ```

--- a/website/pages/intro/getting-started/jobs.mdx
+++ b/website/pages/intro/getting-started/jobs.mdx
@@ -187,7 +187,7 @@ To submit the job with version verification run:
 nomad job run -check-index 7 example.nomad
 
 When running the job with the check-index flag, the job will only be run if the
-server side version matches the job modify index returned. If the index has
+job modify index given matches the server-side version. If the index has
 changed, another user has modified the job and the plan's results are
 potentially invalid.
 ```
@@ -250,7 +250,7 @@ To submit the job with version verification run:
 nomad job run -check-index 1127 example.nomad
 
 When running the job with the check-index flag, the job will only be run if the
-server side version matches the job modify index returned. If the index has
+job modify index given matches the server-side version. If the index has
 changed, another user has modified the job and the plan's results are
 potentially invalid.
 ```


### PR DESCRIPTION
I think the messaging that `job plan` gives you about how the index is matched needs to be fixed/improved. If anything, the "job modify index" is *given*, rather than "returned"; but I also opted to switch the order around so that it's more intuitive ("job modify index given" <-> "server-side version")