### PR TITLE
set safe default for CSI plugin MaxVolumes

### DIFF
--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -3,6 +3,7 @@ package csi
 import (
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"time"
 
@@ -373,6 +374,10 @@ func (c *client) NodeGetInfo(ctx context.Context) (*NodeGetInfoResponse, error) 
 
 	result.NodeID = resp.GetNodeId()
 	result.MaxVolumes = resp.GetMaxVolumesPerNode()
+	if result.MaxVolumes == 0 {
+		// set safe default so that scheduler ignores this constraint when not set
+		result.MaxVolumes = math.MaxInt64
+	}
 
 	return result, nil
 }


### PR DESCRIPTION
The CSI spec says the following about `MaxVolumes`:

```go
   // Maximum number of volumes that controller can publish to the node.
   // If value is not set or zero CO SHALL decide how many volumes of
   // this type can be published by the controller to the node. The
   // plugin MUST NOT set negative values here.
   // This field is OPTIONAL.
```

So we need to set the default to maxint so that the scheduler always passes feasibility if the max volumes is not set by the plugin.