### PR TITLE
hclfmt test fixtures

### DIFF
--- a/jobspec/test-fixtures/tg-service-check-expose.hcl
+++ b/jobspec/test-fixtures/tg-service-check-expose.hcl
@@ -2,20 +2,20 @@ job "group_service_proxy_expose" {
   group "group" {
     service {
       name = "example"
+
       connect {
         sidecar_service {
-          proxy {
-          }
+          proxy {}
         }
       }
 
       check {
-        name = "example-check1"
+        name   = "example-check1"
         expose = true
       }
 
       check {
-        name = "example-check2"
+        name   = "example-check2"
         expose = false
       }
     }

--- a/jobspec/test-fixtures/tg-service-proxy-expose.hcl
+++ b/jobspec/test-fixtures/tg-service-proxy-expose.hcl
@@ -2,22 +2,23 @@ job "group_service_proxy_expose" {
   group "group" {
     service {
       name = "example"
+
       connect {
         sidecar_service {
           proxy {
             expose {
               path = {
-                path = "/health"
-                protocol = "http"
+                path            = "/health"
+                protocol        = "http"
                 local_path_port = 2222
-                listener_port = "healthcheck"
+                listener_port   = "healthcheck"
               }
 
               path = {
-                path = "/metrics"
-                protocol = "grpc"
+                path            = "/metrics"
+                protocol        = "grpc"
                 local_path_port = 3000
-                listener_port = "metrics"
+                listener_port   = "metrics"
               }
             }
           }


### PR DESCRIPTION
`make dev` runs hclfmt, leaving changes in the git working tree if these aren't formatted correctly.