### PR TITLE
connect: fix bug where absent connect.proxy stanza needs default config

### DIFF
--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -58,7 +58,7 @@ func connectSidecarRegistration(serviceName string, css *structs.ConsulSidecarSe
 
 func connectProxy(proxy *structs.ConsulProxy, cPort int, networks structs.Networks) (*api.AgentServiceConnectProxyConfig, error) {
 	if proxy == nil {
-		return nil, nil
+		proxy = new(structs.ConsulProxy)
 	}
 
 	expose, err := connectProxyExpose(proxy.Expose, networks)

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -52,6 +52,12 @@ func TestConnect_newConnect(t *testing.T) {
 			Tags:    []string{"foo", "bar"},
 			Port:    3000,
 			Address: "192.168.30.1",
+			Proxy: &api.AgentServiceConnectProxyConfig{
+				Config: map[string]interface{}{
+					"bind_address": "0.0.0.0",
+					"bind_port":    3000,
+				},
+			},
 		}, asr.SidecarService)
 	})
 }
@@ -95,6 +101,12 @@ func TestConnect_connectSidecarRegistration(t *testing.T) {
 			Tags:    []string{"foo", "bar"},
 			Port:    3000,
 			Address: "192.168.30.1",
+			Proxy: &api.AgentServiceConnectProxyConfig{
+				Config: map[string]interface{}{
+					"bind_address": "0.0.0.0",
+					"bind_port":    3000,
+				},
+			},
 		}, proxy)
 	})
 }
@@ -102,10 +114,21 @@ func TestConnect_connectSidecarRegistration(t *testing.T) {
 func TestConnect_connectProxy(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil", func(t *testing.T) {
-		proxy, err := connectProxy(nil, 2000, nil)
+	// If the input proxy is nil, we expect the output to be a proxy with its
+	// config set to default values.
+	t.Run("nil proxy", func(t *testing.T) {
+		proxy, err := connectProxy(nil, 2000, testConnectNetwork)
 		require.NoError(t, err)
-		require.Nil(t, proxy)
+		require.Equal(t, &api.AgentServiceConnectProxyConfig{
+			LocalServiceAddress: "",
+			LocalServicePort:    0,
+			Upstreams:           nil,
+			Expose:              api.ExposeConfig{},
+			Config: map[string]interface{}{
+				"bind_address": "0.0.0.0",
+				"bind_port":    2000,
+			},
+		}, proxy)
 	})
 
 	t.Run("bad proxy", func(t *testing.T) {


### PR DESCRIPTION
In some refactoring, a bug was introduced where if the connect.proxy
stanza in a submitted job was absent, the default proxy configuration
would not be initialized with default values, effectively breaking the 
connect proxy to make connections.

```hcl
connect {
  sidecar_service {} # should work, but didn't
}
```

In contrast, by setting an empty proxy stanza, the config values would
be inserted correctly.

```hcl
connect {
  sidecar_service {
    proxy {} # workaround, but shouldn't be necessary
  }
}
```

This commit restores the original behavior, where having a proxy
stanza present is not required.

The unit test for this case has also been corrected.