### PR TITLE
UI: Fix confirmation position for right-aligned TSBs

### DIFF
--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -26,6 +26,7 @@
         </div>
         {{two-step-button
           data-test-stop
+          alignRight=true
           idleText="Stop"
           cancelText="Cancel"
           confirmText="Yes, Stop"
@@ -35,6 +36,7 @@
           onConfirm=(perform stopAllocation)}}
         {{two-step-button
           data-test-restart
+          alignRight=true
           idleText="Restart"
           cancelText="Cancel"
           confirmText="Yes, Restart"

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -34,6 +34,7 @@
         </div>
         {{two-step-button
           data-test-restart
+          alignRight=true
           idleText="Restart"
           cancelText="Cancel"
           confirmText="Yes, Restart"

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -11,6 +11,7 @@
       </div>
       {{two-step-button
         data-test-stop
+        alignRight=true
         idleText="Stop"
         cancelText="Cancel"
         confirmText="Yes, Stop"
@@ -20,6 +21,7 @@
     {{else}}
       {{two-step-button
         data-test-start
+        alignRight=true
         idleText="Start"
         cancelText="Cancel"
         confirmText="Yes, Start"


### PR DESCRIPTION
Without this, the confirmation text was extending beyond the
edge of the page.