### PR TITLE
UI: Fix flaky Volume serializer test

### DIFF
--- a/ui/tests/unit/serializers/volume-test.js
+++ b/ui/tests/unit/serializers/volume-test.js
@@ -9,7 +9,10 @@ module('Unit | Serializer | Volume', function(hooks) {
     this.subject = () => this.store.serializerFor('volume');
   });
 
+  // Set the milliseconds to avoid possible floating point precision
+  // issue that arises from converting to nanos and back.
   const REF_DATE = new Date();
+  REF_DATE.setMilliseconds(0);
 
   const normalizationTestCases = [
     {


### PR DESCRIPTION
The embedded records volume serializer unit test would fail whenever the milliseconds for the reference data satisfied `n % 8 == 2` (1 in 8 chance to fail).

This is a result of floating point precision and implicit type coercion. Here's a fun science experiment you can run at home:

1. Open your browser developer tools
2. Head over to the console tab
3. Execute `+new Date() * 1000000 / 1000000`
4. Do this enough times and you'll see something like this:

![image](https://user-images.githubusercontent.com/174740/78189964-eb647f80-7427-11ea-8059-5f2500bf830b.png)

Unfortunately, if you take that number and stick it back into the Date constructor, you'll get this:

![image](https://user-images.githubusercontent.com/174740/78190036-0c2cd500-7428-11ea-8e74-a2f4130f393d.png)

Instead of rounding, the number is cast to an `int` (or whatever black magic your JS VM decides to do).

Losing 1ms of precision occasionally is acceptable for the UI, since it's just presenting numbers and not actually responsible for Nomad's core guarantees. However, when a test expects strict equality, you better give it strict equality.