### PR TITLE
connect: set task lifecycle config for injected sidecar task

### DIFF
--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -166,7 +166,7 @@ func newConnectTask(serviceName string) *structs.Task {
 		},
 		Resources: connectSidecarResources(),
 		Lifecycle: &structs.TaskLifecycleConfig{
-			Hook: structs.TaskLifecycleHookPrestart,
+			Hook:    structs.TaskLifecycleHookPrestart,
 			Sidecar: true,
 		},
 		Constraints: structs.Constraints{

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -165,6 +165,10 @@ func newConnectTask(serviceName string) *structs.Task {
 			MaxFileSizeMB: 2,
 		},
 		Resources: connectSidecarResources(),
+		Lifecycle: &structs.TaskLifecycleConfig{
+			Hook: structs.TaskLifecycleHookPrestart,
+			Sidecar: true,
+		},
 		Constraints: structs.Constraints{
 			connectVersionConstraint(),
 		},

--- a/website/pages/docs/job-specification/sidecar_task.mdx
+++ b/website/pages/docs/job-specification/sidecar_task.mdx
@@ -61,6 +61,11 @@ The default sidecar task is equivalent to:
    sidecar_task {
      name   = "connect-proxy-<service>"
 
+     lifecycle {
+       hook = "prestart"
+       sidecar = true
+     }
+
      driver = "docker"
      config {
        image = "${meta.connect.sidecar_image}"


### PR DESCRIPTION
Sets the lifecycle stanza for injected Connect proxy tasks

fixes #7593