### PR TITLE
e2e: have TF write-out HCL for CSI volume registration

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,2 +1,1 @@
 provisioning.json
-csi/input/volumes.json

--- a/e2e/csi/csi.go
+++ b/e2e/csi/csi.go
@@ -32,11 +32,6 @@ func init() {
 	})
 }
 
-type volumeConfig struct {
-	EBSVolumeID string `json:"ebs_volume"`
-	EFSVolumeID string `json:"efs_volume"`
-}
-
 func (tc *CSIVolumesTest) BeforeAll(f *framework.F) {
 	t := f.T()
 	// Ensure cluster has leader and at least two client

--- a/e2e/csi/input/.gitignore
+++ b/e2e/csi/input/.gitignore
@@ -1,0 +1,2 @@
+volume-ebs.hcl
+volume-efs.hcl

--- a/e2e/terraform/provisioning.tf
+++ b/e2e/terraform/provisioning.tf
@@ -9,15 +9,6 @@ export NOMAD_E2E=1
 EOM
 }
 
-output "volumes" {
-  description = "get volume IDs needed to register volumes for CSI testing."
-  value = jsonencode(
-    {
-      "ebs_volume" : aws_ebs_volume.csi.id,
-      "efs_volume" : aws_efs_file_system.csi.id,
-  })
-}
-
 output "provisioning" {
   description = "output to a file to be use w/ E2E framework -provision.terraform"
   value = jsonencode(

--- a/e2e/terraform/volumes.tf
+++ b/e2e/terraform/volumes.tf
@@ -22,3 +22,39 @@ resource "aws_ebs_volume" "csi" {
     User = data.aws_caller_identity.current.arn
   }
 }
+
+data "template_file" "ebs_volume_hcl" {
+  template = <<EOT
+type = "csi"
+id = "ebs-vol0"
+name = "ebs-vol0"
+external_id = "${aws_ebs_volume.csi.id}"
+access_mode = "single-node-writer"
+attachment_mode = "file-system"
+plugin_id = "aws-ebs0"
+EOT
+}
+
+data "template_file" "efs_volume_hcl" {
+  template = <<EOT
+type = "csi"
+id = "efs-vol0"
+name = "efs-vol0"
+external_id = "${aws_efs_file_system.csi.id}"
+access_mode = "single-node-writer"
+attachment_mode = "file-system"
+plugin_id = "aws-efs0"
+EOT
+}
+
+resource "local_file" "ebs_volume_hcl" {
+  content         = data.template_file.ebs_volume_hcl.rendered
+  filename        = "${path.module}/../csi/input/volume-ebs.hcl"
+  file_permission = "0664"
+}
+
+resource "local_file" "efs_volume_hcl" {
+  content         = data.template_file.efs_volume_hcl.rendered
+  filename        = "${path.module}/../csi/input/volume-efs.hcl"
+  file_permission = "0664"
+}


### PR DESCRIPTION
This updates the output of our Terraform e2e so that we can use the volumes it outputs for e2e experimentation/testing by-hand in addition to the automated e2e tests. This also removes the guard so that we don't have to do anything special to run these on nightly.