### PR TITLE
connect: set consul TLS options on envoy bootstrap

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -128,11 +128,9 @@ func (tr *TaskRunner) initHooks() {
 		}
 
 		// envoy bootstrap must execute after sidsHook maybe sets SI token
-		tr.runnerHooks = append(tr.runnerHooks, newEnvoyBootstrapHook(&envoyBootstrapHookConfig{
-			alloc:          alloc,
-			consulHTTPAddr: tr.clientConfig.ConsulConfig.Addr,
-			logger:         hookLogger,
-		}))
+		tr.runnerHooks = append(tr.runnerHooks, newEnvoyBootstrapHook(
+			newEnvoyBootstrapHookConfig(alloc, tr.clientConfig.ConsulConfig, hookLogger),
+		))
 	}
 
 	// If there are any script checks, add the hook


### PR DESCRIPTION
Fixes #6594 #6711 #6714 #7567

e2e testing is still TBD in #6502

Before, we only passed the Nomad agent's configured Consul HTTP
address onto the `consul connect envoy ...` bootstrap command.
This meant any Consul setup with TLS enabled would not work with
Nomad's Connect integration.

This change now sets CLI args and Environment Variables for
configuring TLS options for communicating with Consul when doing
the envoy bootstrap, as described in
https://www.consul.io/docs/commands/connect/envoy.html#usage