### PR TITLE
update `restart` documentation

### DIFF
--- a/website/pages/docs/job-specification/restart.mdx
+++ b/website/pages/docs/job-specification/restart.mdx
@@ -7,10 +7,16 @@ description: The "restart" stanza configures a group's behavior on task failure.
 
 # `restart` Stanza
 
-<Placement groups={['job', 'group', 'restart']} />
+<Placement
+  groups={[
+    ['job', 'group', 'restart'],
+    ['job', 'group', 'task', 'restart']
+  ]}
+/>
 
-The `restart` stanza configures a group's behavior on task failure. Restarts
-happen on the client that is running the task.
+The `restart` stanza configures a tasks's behavior on task failure. Restarts
+happen on the client that is running the task. If specified at the group level,
+the configuration will apply to all tasks within the group.
 
 ```hcl
 job "docs" {

--- a/website/pages/docs/job-specification/restart.mdx
+++ b/website/pages/docs/job-specification/restart.mdx
@@ -15,8 +15,7 @@ description: The "restart" stanza configures a group's behavior on task failure.
 />
 
 The `restart` stanza configures a tasks's behavior on task failure. Restarts
-happen on the client that is running the task. If specified at the group level,
-the configuration will apply to all tasks within the group.
+happen on the client that is running the task.
 
 ```hcl
 job "docs" {
@@ -26,6 +25,35 @@ job "docs" {
       delay    = "30s"
     }
   }
+}
+```
+
+If specified at the group level, the configuration is inherited by all
+tasks in the group. If present on the task, the policy is merged with
+the restart policy from the encapsulating task group.
+
+For example, assuming that the task group restart policy is: 
+```hcl
+restart {
+  interval = "30m"
+  attempts = 2
+  delay    = "15s"
+  mode     = "fail"
+}
+```
+and the individual task restart policy is: 
+```hcl
+restart {
+  attempts = 5
+}
+```
+then the effective restart policy for the task will be: 
+```
+restart {
+  interval = "30m"
+  attempts = 5
+  delay    = "15s"
+  mode     = "fail"
 }
 ```
 

--- a/website/pages/docs/job-specification/restart.mdx
+++ b/website/pages/docs/job-specification/restart.mdx
@@ -48,7 +48,7 @@ restart {
 }
 ```
 then the effective restart policy for the task will be: 
-```
+```hcl
 restart {
   interval = "30m"
   attempts = 5


### PR DESCRIPTION
#7288 added support for task-specific `restart` policy. this PR updates the docs to reflect that.