### PR TITLE
Tweak declared hcl key casing in structs

### DIFF
--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -125,6 +125,13 @@ var basicConfig = &Config{
 			RetryIntervalHCL: "15s",
 			RetryMaxAttempts: 3,
 		},
+		DefaultSchedulerConfig: &structs.SchedulerConfiguration{
+			PreemptionConfig: structs.PreemptionConfig{
+				SystemSchedulerEnabled:  true,
+				BatchSchedulerEnabled:   true,
+				ServiceSchedulerEnabled: true,
+			},
+		},
 	},
 	ACL: &ACLConfig{
 		Enabled:          true,

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -133,6 +133,14 @@ server {
     retry_max      = 3
     retry_interval = "15s"
   }
+
+  default_scheduler_config {
+    preemption_config {
+      batch_scheduler_enabled   = true
+      system_scheduler_enabled  = true
+      service_scheduler_enabled = true
+    }
+  }
 }
 
 acl {

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -296,6 +296,13 @@
         "1.1.1.1",
         "2.2.2.2"
       ],
+      "default_scheduler_config": [{
+        "preemption_config": [{
+          "batch_scheduler_enabled": true,
+          "system_scheduler_enabled": true,
+          "service_scheduler_enabled": true
+        }]
+      }],
       "upgrade_version": "0.8.0"
     }
   ],

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -162,7 +162,7 @@ type PreemptionConfig struct {
 	BatchSchedulerEnabled bool `hcl:"batch_scheduler_enabled"`
 
 	// ServiceSchedulerEnabled specifies if preemption is enabled for service jobs
-	ServiceSchedulerEnabled bool `hcl:"service_Scheduler_enabled"`
+	ServiceSchedulerEnabled bool `hcl:"service_scheduler_enabled"`
 }
 
 // SchedulerSetConfigRequest is used by the Operator endpoint to update the


### PR DESCRIPTION
Add a test for default_scheduler_config parsing, and make the declared `service_scheduler_enabled` name lower case.

@angrycub noticed the odd casing of `service_Scheduler_enabled`.

Confirmed that it's not a bug or a change in behavior, because hcl key matching is case insensitive.  I've added the test in the first command, and both commits are green.