### PR TITLE
Authenticate alloc/exec websocket requests

### DIFF
--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -407,9 +407,11 @@ func (s *HTTPServer) allocExec(allocID string, resp http.ResponseWriter, req *ht
 	return s.execStreamImpl(conn, &args)
 }
 
+// readWsHandshake reads the websocket handshake message and sets
+// query authentication token, if request requires a handshake
 func readWsHandshake(readFn func(interface{}) error, req *http.Request, q *structs.QueryOptions) error {
 
-	// avoid handshake if request doesn't require one
+	// Avoid handshake if request doesn't require one
 	if hv := req.URL.Query().Get("ws_handshake"); hv == "" {
 		return nil
 	} else if h, err := strconv.ParseBool(hv); err != nil {
@@ -418,15 +420,14 @@ func readWsHandshake(readFn func(interface{}) error, req *http.Request, q *struc
 		return nil
 	}
 
-	fmt.Println("HERE")
-
 	var h wsHandshakeMessage
 	err := readFn(&h)
 	if err != nil {
 		return err
 	}
 
-	if h.Version != 1 {
+	supportedWSHandshakeVersion := 1
+	if h.Version != supportedWSHandshakeVersion {
 		return fmt.Errorf("unexpected handshake value: %v", h.Version)
 	}
 

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -398,7 +398,45 @@ func (s *HTTPServer) allocExec(allocID string, resp http.ResponseWriter, req *ht
 		return nil, fmt.Errorf("failed to upgrade connection: %v", err)
 	}
 
+	if err := readWsHandshake(conn.ReadJSON, req, &args.QueryOptions); err != nil {
+		conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(toWsCode(400), err.Error()))
+		return nil, err
+	}
+
 	return s.execStreamImpl(conn, &args)
+}
+
+func readWsHandshake(readFn func(interface{}) error, req *http.Request, q *structs.QueryOptions) error {
+
+	// avoid handshake if request doesn't require one
+	if hv := req.URL.Query().Get("ws_handshake"); hv == "" {
+		return nil
+	} else if h, err := strconv.ParseBool(hv); err != nil {
+		return fmt.Errorf("ws_handshake value is not a boolean: %v", err)
+	} else if !h {
+		return nil
+	}
+
+	fmt.Println("HERE")
+
+	var h wsHandshakeMessage
+	err := readFn(&h)
+	if err != nil {
+		return err
+	}
+
+	if h.Version != 1 {
+		return fmt.Errorf("unexpected handshake value: %v", h.Version)
+	}
+
+	q.AuthToken = h.AuthToken
+	return nil
+}
+
+type wsHandshakeMessage struct {
+	Version   int    `json:"version"`
+	AuthToken string `json:"auth_token"`
 }
 
 func (s *HTTPServer) execStreamImpl(ws *websocket.Conn, args *cstructs.AllocExecRequest) (interface{}, error) {

--- a/ui/app/controllers/exec.js
+++ b/ui/app/controllers/exec.js
@@ -14,6 +14,7 @@ const ANSI_WHITE = '\x1b[0m';
 export default Controller.extend({
   sockets: service(),
   system: service(),
+  token: service(),
 
   queryParams: ['allocation'],
 
@@ -78,6 +79,6 @@ export default Controller.extend({
     this.set('command', command);
     this.socket = this.sockets.getTaskStateSocket(this.taskState, command);
 
-    new ExecSocketXtermAdapter(this.terminal, this.socket);
+    new ExecSocketXtermAdapter(this.terminal, this.socket, this.token.secret);
   },
 });

--- a/ui/app/services/sockets.js
+++ b/ui/app/services/sockets.js
@@ -30,7 +30,7 @@ export default Service.extend({
 
       return new WebSocket(
         `${protocol}//${prefix}/client/allocation/${taskState.allocation.id}` +
-          `/exec?task=${taskState.name}&tty=true` +
+          `/exec?task=${taskState.name}&tty=true&ws_handshake=true` +
           `&command=${encodeURIComponent(`["${command}"]`)}`
       );
     }

--- a/ui/app/utils/classes/exec-socket-xterm-adapter.js
+++ b/ui/app/utils/classes/exec-socket-xterm-adapter.js
@@ -4,11 +4,13 @@ import base64js from 'base64-js';
 import { TextDecoderLite, TextEncoderLite } from 'text-encoder-lite';
 
 export default class ExecSocketXtermAdapter {
-  constructor(terminal, socket) {
+  constructor(terminal, socket, token) {
     this.terminal = terminal;
     this.socket = socket;
+    this.token = token;
 
     socket.onopen = () => {
+      this.sendWsHandshake();
       this.sendTtySize();
 
       terminal.onData(data => {
@@ -41,6 +43,10 @@ export default class ExecSocketXtermAdapter {
     this.socket.send(
       JSON.stringify({ tty_size: { width: this.terminal.cols, height: this.terminal.rows } })
     );
+  }
+
+  sendWsHandshake() {
+    this.socket.send(JSON.stringify({ version: 1, auth_token: this.token || '' }));
   }
 
   handleData(data) {

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -10,8 +10,8 @@ module('Acceptance | exec', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function() {
-    localStorage.clear();
-    sessionStorage.clear();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
 
     server.create('agent');
     server.create('node');
@@ -347,7 +347,7 @@ module('Acceptance | exec', function(hooks) {
     let mockSockets = Service.extend({
       getTaskStateSocket(taskState, command) {
         assert.equal(command, '/sh');
-        localStorage.getItem('nomadExecCommand', JSON.stringify('/sh'));
+        window.localStorage.getItem('nomadExecCommand', JSON.stringify('/sh'));
 
         assert.step('Socket built');
 
@@ -407,7 +407,7 @@ module('Acceptance | exec', function(hooks) {
   });
 
   test('a persisted customised command is recalled', async function(assert) {
-    localStorage.setItem('nomadExecCommand', JSON.stringify('/bin/sh'));
+    window.localStorage.setItem('nomadExecCommand', JSON.stringify('/bin/sh'));
 
     let taskGroup = this.job.task_groups.models[0];
     let task = taskGroup.tasks.models[0];

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -285,8 +285,6 @@ module('Acceptance | exec', function(hooks) {
     let mockSocket = new MockSocket();
     let mockSockets = Service.extend({
       getTaskStateSocket() {
-        assert.step('Socket built');
-
         return mockSocket;
       },
     });
@@ -311,8 +309,6 @@ module('Acceptance | exec', function(hooks) {
     await Exec.terminal.pressEnter();
     await settled();
     mockSocket.onopen();
-
-    assert.verifySteps(['Socket built']);
 
     await Exec.terminal.pressEnter();
     await settled();

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -308,8 +308,6 @@ module('Acceptance | exec', function(hooks) {
       allocation: allocation.id.split('-')[0],
     });
 
-    await settled();
-
     await Exec.terminal.pressEnter();
     await settled();
     mockSocket.onopen();

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -279,10 +279,7 @@ module('Acceptance | exec', function(hooks) {
   });
 
   test('running the command opens the socket and authenticates', async function(assert) {
-    let managementToken = server.create('token');
-
-    const { secretId } = managementToken;
-
+    const { secretId } = server.create('token');
     window.localStorage.nomadTokenSecret = secretId;
 
     let mockSocket = new MockSocket();

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -278,6 +278,7 @@ module('Acceptance | exec', function(hooks) {
       'The connection has closed.'
     );
   });
+
   test('running the command opens the socket and authenticates', async function(assert) {
     let managementToken = server.create('token');
 

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -278,7 +278,7 @@ module('Acceptance | exec', function(hooks) {
     );
   });
 
-  test('running the command opens the socket and authenticates', async function(assert) {
+  test('the opening message includes the token if it exists', async function(assert) {
     const { secretId } = server.create('token');
     window.localStorage.nomadTokenSecret = secretId;
 
@@ -321,39 +321,10 @@ module('Acceptance | exec', function(hooks) {
 
     assert.verifySteps(['Socket built']);
 
-    mockSocket.onmessage({
-      data: '{"stdout":{"data":"c2gtMy4yIPCfpbMk"}}',
-    });
-
-    await settled();
-
-    assert.equal(
-      window.execTerminal.buffer
-        .getLine(5)
-        .translateToString()
-        .trim(),
-      'sh-3.2 🥳$'
-    );
-
     await Exec.terminal.pressEnter();
     await settled();
 
-    assert.deepEqual(mockSocket.sent, [
-      `{"version":1,"auth_token":"${secretId}"}`,
-      `{"tty_size":{"width":${window.execTerminal.cols},"height":${window.execTerminal.rows}}}`,
-      '{"stdin":{"data":"DQ=="}}',
-    ]);
-
-    await mockSocket.onclose();
-    await settled();
-
-    assert.equal(
-      window.execTerminal.buffer
-        .getLine(6)
-        .translateToString()
-        .trim(),
-      'The connection has closed.'
-    );
+    assert.equal(mockSocket.sent[0], `{"version":1,"auth_token":"${secretId}"}`);
   });
 
   test('only one socket is opened after switching between tasks', async function(assert) {

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { currentURL, settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import Tokens from 'nomad-ui/tests/pages/settings/tokens';
 import Service from '@ember/service';
 import Exec from 'nomad-ui/tests/pages/exec';
 
@@ -284,8 +283,7 @@ module('Acceptance | exec', function(hooks) {
 
     const { secretId } = managementToken;
 
-    await Tokens.visit();
-    await Tokens.secret(secretId).submit();
+    window.localStorage.nomadTokenSecret = secretId;
 
     let mockSocket = new MockSocket();
     let mockSockets = Service.extend({

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -284,12 +284,7 @@ module('Acceptance | exec', function(hooks) {
 
     let mockSocket = new MockSocket();
     let mockSockets = Service.extend({
-      getTaskStateSocket(taskState, command) {
-        assert.equal(taskState.name, task.name);
-        assert.equal(taskState.allocation.id, allocation.id);
-
-        assert.equal(command, '/bin/bash');
-
+      getTaskStateSocket() {
         assert.step('Socket built');
 
         return mockSocket;

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -17,8 +17,8 @@ module('Acceptance | tokens', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function() {
-    localStorage.clear();
-    sessionStorage.clear();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
 
     server.create('agent');
     node = server.create('node');


### PR DESCRIPTION
This change ensures that browser alloc/exec websocket requests are authenticated.

The javascript Websocket API doesn't support setting custom headers (e.g. `X-Nomad-Token`).  Here, we introduce an authenticating handshake message (enabled by setting a `ws_handshake` query parameter).  The web UI always sets it and then passes the authentication token in the first message on socket opening.

This is a backward compatible change: it does not affect nomad CLI path or existing API - this authentication path is only enabled when `ws_handshake` url query parameter is true.

Some resources I've consulted but didn't follow the approaches there:
* https://devcenter.heroku.com/articles/websocket-security#authentication-authorization
* https://stackoverflow.com/questions/4361173/http-headers-in-websockets-client-api

Fixes https://github.com/hashicorp/nomad/issues/7606 
