### PR TITLE
csi: run volume claim GC on `job stop -purge`

### DIFF
--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2306,7 +2306,7 @@ func TestCSI_GCVolumeClaims_Collection(t *testing.T) {
 	vol, err = state.CSIVolumeDenormalize(ws, vol)
 	require.NoError(t, err)
 
-	gcClaims, nodeClaims := collectClaimsToGCImpl(vol)
+	gcClaims, nodeClaims := collectClaimsToGCImpl(vol, false)
 	require.Equal(t, nodeClaims[node.ID], 2)
 	require.Len(t, gcClaims, 2)
 }

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -707,6 +707,9 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 		return err
 	}
 
+	// For a job with volumes, run volume claim GC before deleting the job
+	volumeClaimReap(j.srv, j.logger, []*structs.Job{job}, j.srv.getLeaderAcl())
+
 	// Commit this update via Raft
 	_, index, err := j.srv.raftApply(structs.JobDeregisterRequestType, args)
 	if err != nil {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -708,7 +708,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 	}
 
 	// For a job with volumes, run volume claim GC before deleting the job
-	volumeClaimReap(j.srv, j.logger, []*structs.Job{job}, j.srv.getLeaderAcl())
+	volumeClaimReap(j.srv, j.logger, []*structs.Job{job}, j.srv.getLeaderAcl(), true)
 
 	// Commit this update via Raft
 	_, index, err := j.srv.raftApply(structs.JobDeregisterRequestType, args)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -703,7 +703,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 	}
 	ws := memdb.NewWatchSet()
 	job, err := snap.JobByID(ws, args.RequestNamespace(), args.JobID)
-	if err != nil {
+	if err != nil || job == nil {
 		return err
 	}
 
@@ -721,7 +721,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 	reply.JobModifyIndex = index
 
 	// If the job is periodic or parameterized, we don't create an eval.
-	if job != nil && (job.IsPeriodic() || job.IsParameterized()) {
+	if job.IsPeriodic() || job.IsParameterized() {
 		return nil
 	}
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -2584,12 +2584,13 @@ func TestJobEndpoint_Deregister_ACL(t *testing.T) {
 	require.NotZero(eval.CreateTime)
 	require.NotZero(eval.ModifyTime)
 
-	// Deregistration is idempotent
+	// Deregistration is not idempotent, produces a new eval after the job is
+	// deregistered. TODO(langmartin) make it idempotent.
 	var validResp2 structs.JobDeregisterResponse
 	err = msgpackrpc.CallWithCodec(codec, "Job.Deregister", req, &validResp2)
 	require.NoError(err)
-	require.NotEqual(validResp2.Index, 0)
-	require.Equal("", validResp2.EvalID)
+	require.NotEqual("", validResp2.EvalID)
+	require.NotEqual(validResp.EvalID, validResp2.EvalID)
 }
 
 func TestJobEndpoint_Deregister_Nonexistent(t *testing.T) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1837,7 +1837,7 @@ func (s *StateStore) JobSummaryByPrefix(ws memdb.WatchSet, namespace, id string)
 
 	iter, err := txn.Get("job_summary", "id_prefix", namespace, id)
 	if err != nil {
-		return nil, fmt.Errorf("eval lookup failed: %v", err)
+		return nil, fmt.Errorf("job_summary lookup failed: %v", err)
 	}
 
 	ws.Add(iter.WatchCh())

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1128,6 +1128,8 @@ type JobDeregisterResponse struct {
 	EvalID          string
 	EvalCreateIndex uint64
 	JobModifyIndex  uint64
+	VolumeEvalID    string
+	VolumeEvalIndex uint64
 	QueryMeta
 }
 


### PR DESCRIPTION
Call `volumeClaimReap` on job deregister to a) call the necessary node & controller rpcs and b) release the volume claims. Fixes #7605 