### PR TITLE
fix encoding/decoding tags for api.Task

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -663,7 +663,7 @@ type Task struct {
 	Templates       []*Template
 	DispatchPayload *DispatchPayloadConfig
 	VolumeMounts    []*VolumeMount
-	CSIPluginConfig *TaskCSIPluginConfig `mapstructure:"csi_plugin" json:"csi_plugin,omitempty"`
+	CSIPluginConfig *TaskCSIPluginConfig `mapstructure:"csi_plugin" json:",omitempty"`
 	Leader          bool
 	ShutdownDelay   time.Duration `mapstructure:"shutdown_delay"`
 	KillSignal      string        `mapstructure:"kill_signal"`


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7609

a.k.a. the magic of stringly-typed field tags

~Struct fields with multiple tags need to be comma-separated. Without this change, the `api.Task` struct's `CSIPluginConfig` would appear in the API response bodies but not in the decoded response as output by `nomad job inspect`.~

_Revised:_

When `nomad job inspect` encodes the response, if the decoded JSON from the API doesn't exactly match the API struct, the field value will be omitted even if it has a value. We only want the JSON struct tag to `omitempty`.