### PR TITLE
csi: make volume GC in job deregister safely async

### DIFF
--- a/client/csi_endpoint.go
+++ b/client/csi_endpoint.go
@@ -143,12 +143,12 @@ func (c *CSI) ControllerDetachVolume(req *structs.ClientCSIControllerDetachVolum
 	csiReq := req.ToCSIRequest()
 
 	// Submit the request for a volume to the CSI Plugin.
-	ctx, cancelFn := c.requestContext()
+	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 	// CSI ControllerUnpublishVolume errors for timeout, codes.Unavailable and
 	// codes.ResourceExhausted are retried; all other errors are fatal.
 	_, err = plugin.ControllerUnpublishVolume(ctx, csiReq,
-		grpc_retry.WithPerRetryTimeout(CSIPluginRequestTimeout),
+		grpc_retry.WithPerRetryTimeout(10*time.Second),
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100*time.Millisecond)))
 	if err != nil {

--- a/client/csi_endpoint.go
+++ b/client/csi_endpoint.go
@@ -190,7 +190,7 @@ func (c *CSI) NodeDetachVolume(req *structs.ClientCSINodeDetachVolumeRequest, re
 		AccessMode:     string(req.AccessMode),
 	}
 
-	err = mounter.UnmountVolume(ctx, req.VolumeID, req.AllocID, usageOpts)
+	err = mounter.UnmountVolume(ctx, req.VolumeID, req.ExternalID, req.AllocID, usageOpts)
 	if err != nil {
 		return err
 	}

--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -42,7 +42,7 @@ func (u *UsageOptions) ToFS() string {
 
 type VolumeMounter interface {
 	MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usageOpts *UsageOptions, publishContext map[string]string) (*MountInfo, error)
-	UnmountVolume(ctx context.Context, volID, allocID string, usageOpts *UsageOptions) error
+	UnmountVolume(ctx context.Context, volID, remoteID, allocID string, usageOpts *UsageOptions) error
 }
 
 type Manager interface {

--- a/client/pluginmanager/csimanager/volume_test.go
+++ b/client/pluginmanager/csimanager/volume_test.go
@@ -236,7 +236,8 @@ func TestVolumeManager_unstageVolume(t *testing.T) {
 			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake, tmpPath, tmpPath, true)
 			ctx := context.Background()
 
-			err := manager.unstageVolume(ctx, tc.Volume.ID, tc.UsageOptions)
+			err := manager.unstageVolume(ctx,
+				tc.Volume.ID, tc.Volume.RemoteID(), tc.UsageOptions)
 
 			if tc.ExpectedErr != nil {
 				require.EqualError(t, err, tc.ExpectedErr.Error())
@@ -416,7 +417,8 @@ func TestVolumeManager_unpublishVolume(t *testing.T) {
 			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake, tmpPath, tmpPath, true)
 			ctx := context.Background()
 
-			err := manager.unpublishVolume(ctx, tc.Volume.ID, tc.Allocation.ID, tc.UsageOptions)
+			err := manager.unpublishVolume(ctx,
+				tc.Volume.ID, tc.Volume.RemoteID(), tc.Allocation.ID, tc.UsageOptions)
 
 			if tc.ExpectedErr != nil {
 				require.EqualError(t, err, tc.ExpectedErr.Error())
@@ -476,7 +478,7 @@ func TestVolumeManager_MountVolumeEvents(t *testing.T) {
 	require.Equal(t, "true", e.Details["success"])
 	events = events[1:]
 
-	err = manager.UnmountVolume(ctx, vol.ID, alloc.ID, usage)
+	err = manager.UnmountVolume(ctx, vol.ID, vol.RemoteID(), alloc.ID, usage)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(events))

--- a/client/structs/csi.go
+++ b/client/structs/csi.go
@@ -31,7 +31,7 @@ type CSIControllerQuery struct {
 }
 
 type ClientCSIControllerValidateVolumeRequest struct {
-	VolumeID string
+	VolumeID string // note: this is the external ID
 
 	AttachmentMode structs.CSIVolumeAttachmentMode
 	AccessMode     structs.CSIVolumeAccessMode
@@ -43,7 +43,7 @@ type ClientCSIControllerValidateVolumeResponse struct {
 }
 
 type ClientCSIControllerAttachVolumeRequest struct {
-	// The ID of the volume to be used on a node.
+	// The external ID of the volume to be used on a node.
 	// This field is REQUIRED.
 	VolumeID string
 
@@ -137,10 +137,11 @@ type ClientCSIControllerDetachVolumeResponse struct{}
 // a Nomad client to tell a CSI node plugin on that client to perform
 // NodeUnpublish and NodeUnstage.
 type ClientCSINodeDetachVolumeRequest struct {
-	PluginID string // ID of the plugin that manages the volume (required)
-	VolumeID string // ID of the volume to be unpublished (required)
-	AllocID  string // ID of the allocation we're unpublishing for (required)
-	NodeID   string // ID of the Nomad client targeted
+	PluginID   string // ID of the plugin that manages the volume (required)
+	VolumeID   string // ID of the volume to be unpublished (required)
+	AllocID    string // ID of the allocation we're unpublishing for (required)
+	NodeID     string // ID of the Nomad client targeted
+	ExternalID string // External ID of the volume to be unpublished (required)
 
 	// These fields should match the original volume request so that
 	// we can find the mount points on the client

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -862,7 +862,8 @@ func volumeClaimReapImpl(srv RPCServer, args *volumeClaimReapArgs) (map[string]i
 	// operations or releasing the claim.
 	nReq := &cstructs.ClientCSINodeDetachVolumeRequest{
 		PluginID:       args.plug.ID,
-		VolumeID:       vol.RemoteID(),
+		VolumeID:       vol.ID,
+		ExternalID:     vol.RemoteID(),
 		AllocID:        args.allocID,
 		NodeID:         nodeID,
 		AttachmentMode: vol.AttachmentMode,
@@ -880,13 +881,30 @@ func volumeClaimReapImpl(srv RPCServer, args *volumeClaimReapArgs) (map[string]i
 	// on the node need it, but we also only want to make this
 	// call at most once per node
 	if vol.ControllerRequired && args.nodeClaims[nodeID] < 1 {
+
+		// we need to get the CSI Node ID, which is not the same as
+		// the Nomad Node ID
+		ws := memdb.NewWatchSet()
+		targetNode, err := srv.State().NodeByID(ws, nodeID)
+		if err != nil {
+			return args.nodeClaims, err
+		}
+		if targetNode == nil {
+			return args.nodeClaims, fmt.Errorf("%s: %s",
+				structs.ErrUnknownNodePrefix, nodeID)
+		}
+		targetCSIInfo, ok := targetNode.CSINodePlugins[args.plug.ID]
+		if !ok {
+			return args.nodeClaims, fmt.Errorf("Failed to find NodeInfo for node: %s", targetNode.ID)
+		}
+
 		controllerNodeID, err := nodeForControllerPlugin(srv.State(), args.plug)
-		if err != nil || nodeID == "" {
+		if err != nil || controllerNodeID == "" {
 			return args.nodeClaims, err
 		}
 		cReq := &cstructs.ClientCSIControllerDetachVolumeRequest{
 			VolumeID:        vol.RemoteID(),
-			ClientCSINodeID: nodeID,
+			ClientCSINodeID: targetCSIInfo.NodeInfo.ID,
 		}
 		cReq.PluginID = args.plug.ID
 		cReq.ControllerNodeID = controllerNodeID

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2364,7 +2364,7 @@ func TestCSI_GCVolumeClaims_Reap(t *testing.T) {
 			ClaimsCount:        map[string]int{node.ID: 1},
 			ControllerRequired: true,
 			ExpectedErr: fmt.Sprintf(
-				"no controllers available for plugin %q", plugin.ID),
+				"Unknown node: %s", node.ID),
 			ExpectedClaimsCount:                 0,
 			ExpectedNodeDetachVolumeCount:       1,
 			ExpectedControllerDetachVolumeCount: 0,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -709,10 +709,12 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 
 	// For a job with volumes, find its volumes before deleting the job
 	volumesToGC := make(map[string]*structs.VolumeRequest)
-	for _, tg := range job.TaskGroups {
-		for _, vol := range tg.Volumes {
-			if vol.Type == structs.VolumeTypeCSI {
-				volumesToGC[vol.Source] = vol
+	if job != nil {
+		for _, tg := range job.TaskGroups {
+			for _, vol := range tg.Volumes {
+				if vol.Type == structs.VolumeTypeCSI {
+					volumesToGC[vol.Source] = vol
+				}
 			}
 		}
 	}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -707,9 +707,14 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 		return err
 	}
 
-	// For a job with volumes, run volume claim GC before deleting the job
-	if job != nil {
-		volumeClaimReap(j.srv, j.logger, []*structs.Job{job}, j.srv.getLeaderAcl(), true)
+	// For a job with volumes, find its volumes before deleting the job
+	volumesToGC := make(map[string]*structs.VolumeRequest)
+	for _, tg := range job.TaskGroups {
+		for _, vol := range tg.Volumes {
+			if vol.Type == structs.VolumeTypeCSI {
+				volumesToGC[vol.Source] = vol
+			}
+		}
 	}
 
 	// Commit this update via Raft
@@ -722,43 +727,75 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 	// Populate the reply with job information
 	reply.JobModifyIndex = index
 
-	// If the job is periodic or parameterized, we don't create an eval.
-	if job != nil && (job.IsPeriodic() || job.IsParameterized()) {
-		return nil
-	}
-
-	// Create a new evaluation
-	// XXX: The job priority / type is strange for this, since it's not a high
-	// priority even if the job was.
+	evals := []*structs.Evaluation{}
 	now := time.Now().UTC().UnixNano()
-	eval := &structs.Evaluation{
-		ID:             uuid.Generate(),
-		Namespace:      args.RequestNamespace(),
-		Priority:       structs.JobDefaultPriority,
-		Type:           structs.JobTypeService,
-		TriggeredBy:    structs.EvalTriggerJobDeregister,
-		JobID:          args.JobID,
-		JobModifyIndex: index,
-		Status:         structs.EvalStatusPending,
-		CreateTime:     now,
-		ModifyTime:     now,
-	}
-	update := &structs.EvalUpdateRequest{
-		Evals:        []*structs.Evaluation{eval},
-		WriteRequest: structs.WriteRequest{Region: args.Region},
+
+	// Add an evaluation for garbage collecting the the CSI volume claims
+	// of terminal allocs
+	for _, vol := range volumesToGC {
+		// we have to build this eval by hand rather than calling srv.CoreJob
+		// here because we need to use the volume's namespace
+
+		runningAllocs := ":ok"
+		if args.Purge {
+			runningAllocs = ":purge"
+		}
+
+		eval := &structs.Evaluation{
+			ID:          uuid.Generate(),
+			Namespace:   job.Namespace,
+			Priority:    structs.CoreJobPriority,
+			Type:        structs.JobTypeCore,
+			TriggeredBy: structs.EvalTriggerAllocStop,
+			JobID:       structs.CoreJobCSIVolumeClaimGC + ":" + vol.Source + runningAllocs,
+			LeaderACL:   j.srv.getLeaderAcl(),
+			Status:      structs.EvalStatusPending,
+			CreateTime:  now,
+			ModifyTime:  now,
+		}
+		evals = append(evals, eval)
 	}
 
-	// Commit this evaluation via Raft
-	_, evalIndex, err := j.srv.raftApply(structs.EvalUpdateRequestType, update)
-	if err != nil {
-		j.logger.Error("eval create failed", "error", err, "method", "deregister")
-		return err
+	// If the job is periodic or parameterized, we don't create an eval
+	// for the job, but might still need one for the volumes
+	if job == nil || !(job.IsPeriodic() || job.IsParameterized()) {
+		// Create a new evaluation
+		// XXX: The job priority / type is strange for this, since it's not a high
+		// priority even if the job was.
+		eval := &structs.Evaluation{
+			ID:             uuid.Generate(),
+			Namespace:      args.RequestNamespace(),
+			Priority:       structs.JobDefaultPriority,
+			Type:           structs.JobTypeService,
+			TriggeredBy:    structs.EvalTriggerJobDeregister,
+			JobID:          args.JobID,
+			JobModifyIndex: index,
+			Status:         structs.EvalStatusPending,
+			CreateTime:     now,
+			ModifyTime:     now,
+		}
+		evals = append(evals, eval)
 	}
 
-	// Populate the reply with eval information
-	reply.EvalID = eval.ID
-	reply.EvalCreateIndex = evalIndex
-	reply.Index = evalIndex
+	if len(evals) > 0 {
+		update := &structs.EvalUpdateRequest{
+			Evals:        evals,
+			WriteRequest: structs.WriteRequest{Region: args.Region},
+		}
+
+		// Commit this evaluation via Raft
+		_, evalIndex, err := j.srv.raftApply(structs.EvalUpdateRequestType, update)
+		if err != nil {
+			j.logger.Error("eval create failed", "error", err, "method", "deregister")
+			return err
+		}
+
+		// Populate the reply with eval information
+		reply.EvalID = evals[len(evals)-1].ID
+		reply.EvalCreateIndex = evalIndex
+		reply.Index = evalIndex
+	}
+
 	return nil
 }
 

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -2406,7 +2406,7 @@ func TestClientEndpoint_UpdateAlloc_UnclaimVolumes(t *testing.T) {
 
 	// Verify the eval for the claim GC was emitted
 	// Lookup the evaluations
-	eval, err := state.EvalsByJob(ws, job.Namespace, structs.CoreJobCSIVolumeClaimGC+":"+job.ID)
+	eval, err := state.EvalsByJob(ws, job.Namespace, structs.CoreJobCSIVolumeClaimGC+":"+volId0+":no")
 	require.NotNil(t, eval)
 	require.Nil(t, err)
 }


### PR DESCRIPTION
Partial fix for https://github.com/hashicorp/nomad/issues/7629
Includes commits from https://github.com/hashicorp/nomad/issues/7628

The `Job.Deregister` call will block on the client CSI controller RPCs while the alloc still exists on the Nomad client node. So we need to make the volume claim reaping async from the `Job.Deregister`. This allows `nomad job stop` to return immediately. In order to make this work, I've changed the volume GC so that the GC jobs are on a by-volume basis rather than a by-job basis; we won't have to query the (possibly deleted) job at the time of volume GC. I'm smuggling the volume ID and whether it's a purge into the GC eval ID the same way we smuggled the job ID previously. 

This doesn't entirely fix #7629 because the first GC attempt for volumes with a controller with fail and be re-queued. I've decreased the client-side controller timeout to reduce the wait time as a stop-gap, but we'll want to revisit it.

This leaves the E2E tests with `nomad stop -purge` flaky, depending on timing. For now I've changed them so as not to purge until we've corrected the problem more permanently.