### PR TITLE
e2e: csi tests can only run on linux

### DIFF
--- a/e2e/csi/input/plugin-aws-ebs-controller.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-controller.nomad
@@ -5,6 +5,11 @@
 job "plugin-aws-ebs-controller" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "controller" {
     task "plugin" {
       driver = "docker"

--- a/e2e/csi/input/plugin-aws-ebs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-nodes.nomad
@@ -5,6 +5,11 @@
 job "plugin-aws-ebs-nodes" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   # you can run node plugins as service jobs as well, but this ensures
   # that all nodes in the DC have a copy.
   type = "system"

--- a/e2e/csi/input/plugin-aws-efs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-efs-nodes.nomad
@@ -5,6 +5,11 @@
 job "plugin-aws-efs-nodes" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   # you can run node plugins as service jobs as well, but this ensures
   # that all nodes in the DC have a copy.
   type = "system"

--- a/e2e/csi/input/use-ebs-volume.nomad
+++ b/e2e/csi/input/use-ebs-volume.nomad
@@ -2,6 +2,11 @@
 job "use-ebs-volume" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "group" {
     volume "test" {
       type   = "csi"

--- a/e2e/csi/input/use-efs-volume-read.nomad
+++ b/e2e/csi/input/use-efs-volume-read.nomad
@@ -3,6 +3,11 @@
 job "use-efs-volume" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "group" {
     volume "test" {
       type   = "csi"

--- a/e2e/csi/input/use-efs-volume-write.nomad
+++ b/e2e/csi/input/use-efs-volume-write.nomad
@@ -2,6 +2,11 @@
 job "use-efs-volume" {
   datacenters = ["dc1"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "group" {
     volume "test" {
       type   = "csi"


### PR DESCRIPTION
Our Windows 2016 e2e test environment doesn't support Linux containers, so this will cause e2e tests to fail.