### PR TITLE
docs: fix broken internal link on job plan page

### DIFF
--- a/website/pages/docs/commands/job/plan.mdx
+++ b/website/pages/docs/commands/job/plan.mdx
@@ -203,4 +203,4 @@ potentially invalid.
 [hcl job specification]: /docs/job-specification
 [`go-getter`]: https://github.com/hashicorp/go-getter
 
-[`nomad job run -check-index`] :/docs/commands/job/run#check-index
+[`nomad job run -check-index`]: /docs/commands/job/run#check-index


### PR DESCRIPTION
Saw this one at the bottom of https://nomadproject.io/docs/commands/job/plan/