### PR TITLE
docs: add warnings for CSI plugin jobspec

### DIFF
--- a/website/pages/docs/job-specification/csi_plugin.mdx
+++ b/website/pages/docs/job-specification/csi_plugin.mdx
@@ -44,6 +44,18 @@ csi_plugin {
   container where the plugin will expect a Unix domain socket for
   bidirectional communication with Nomad.
 
+
+~> **Note:** Plugins running as `node` or `monolith` require root
+privileges (or `CAP_SYS_ADMIN` on Linux) to mount volumes on the
+host. With the Docker task driver, you can use the `privileged = true`
+configuration, but no other default task drivers currently have this
+option.
+
+~> **Note:** During node drains, jobs that claim volumes should be
+moved before the `node` or `monolith` plugin for those
+volumes. Because [`system`][system] jobs are moved last during node drains, you
+should run `node` or `monolith` plugins as `system` jobs.
+
 ## `csi_plugin` Examples
 
 ```hcl
@@ -87,3 +99,4 @@ job "plugin-efs" {
 
 [csi]: https://github.com/container-storage-interface/spec
 [csi_volumes]: /docs/job-specification/volume
+[system]: /docs/schedulers/#system


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7623

* Node/monolith plugins require root privileges and this wasn't being made super clear.
* Node/monolith plugins should always be run as system jobs.