### PR TITLE
ar/bridge_networking: ensure cni configuration is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ BUG FIXES:
  * client: Fixed a bug where a multi-task allocation maybe considered healthy despite a task restarting [[GH-7383](https://github.com/hashicorp/nomad/issues/7383)]
  * consul: Fixed a bug where modified Consul service definitions would not be updated [[GH-6459](https://github.com/hashicorp/nomad/issues/6459)]
  * connect: Fixed a bug where Connect enabled allocation would not stop after promotion [[GH-7540](https://github.com/hashicorp/nomad/issues/7540)]
+ * connect: Fixed a bug where restarting a client would prevent Connect enabled allocations from cleaning up properly [[GH-7643](https://github.com/hashicorp/nomad/issues/7643)]
  * driver/docker: Fixed handling of seccomp `security_opts` option [[GH-7554](https://github.com/hashicorp/nomad/issues/7554)]
  * driver/docker: Fixed a bug causing docker containers to use swap memory unexpectedly [[GH-7550](https://github.com/hashicorp/nomad/issues/7550)]
  * scheduler: Fixed a bug where changes to task group `shutdown_delay` were not persisted or displayed in plan output [[GH-7618](https://github.com/hashicorp/nomad/issues/7618)]

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -184,11 +184,11 @@ func (b *bridgeNetworkConfigurator) Teardown(ctx context.Context, alloc *structs
 }
 
 func (b *bridgeNetworkConfigurator) ensureCNIInitialized() error {
-	err := b.cni.Status()
-	if err == cni.ErrCNINotInitialized {
+	if err := b.cni.Status(); cni.IsCNINotInitialized(err) {
 		return b.cni.Load(cni.WithConfListBytes(b.buildNomadNetConfig()))
+	} else {
+		return err
 	}
-	return err
 }
 
 // getPortMapping builds a list of portMapping structs that are used as the

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -184,10 +184,11 @@ func (b *bridgeNetworkConfigurator) Teardown(ctx context.Context, alloc *structs
 }
 
 func (b *bridgeNetworkConfigurator) ensureCNIInitialized() error {
-	if b.cni.Status() == cni.ErrCNINotInitialized {
+	err := b.cni.Status()
+	if err == cni.ErrCNINotInitialized {
 		return b.cni.Load(cni.WithConfListBytes(b.buildNomadNetConfig()))
 	}
-	return nil
+	return err
 }
 
 // getPortMapping builds a list of portMapping structs that are used as the

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -148,7 +148,7 @@ func (b *bridgeNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Al
 		return fmt.Errorf("failed to initialize table forwarding rules: %v", err)
 	}
 
-	if err := b.cni.Load(cni.WithConfListBytes(b.buildNomadNetConfig())); err != nil {
+	if err := b.ensureCNIInitialized(); err != nil {
 		return err
 	}
 
@@ -176,7 +176,18 @@ func (b *bridgeNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Al
 
 // Teardown calls the CNI plugins with the delete action
 func (b *bridgeNetworkConfigurator) Teardown(ctx context.Context, alloc *structs.Allocation, spec *drivers.NetworkIsolationSpec) error {
+	if err := b.ensureCNIInitialized(); err != nil {
+		return err
+	}
+
 	return b.cni.Remove(ctx, alloc.ID, spec.Path, cni.WithCapabilityPortMap(getPortMapping(alloc)))
+}
+
+func (b *bridgeNetworkConfigurator) ensureCNIInitialized() error {
+	if b.cni.Status() == cni.ErrCNINotInitialized {
+		return b.cni.Load(cni.WithConfListBytes(b.buildNomadNetConfig()))
+	}
+	return nil
 }
 
 // getPortMapping builds a list of portMapping structs that are used as the


### PR DESCRIPTION
After a client restart, a recovered alloc would never load cni configuration necessary for cleanly destroying it. This PR ensures that cni configuration is loading during both Setup and Teardown.

fixes #7537 