### PR TITLE
[Doc] Improve vault language (Trivial Fix)

### DIFF
--- a/website/pages/docs/job-specification/vault.mdx
+++ b/website/pages/docs/job-specification/vault.mdx
@@ -45,7 +45,7 @@ The Nomad client will make the Vault token available to the task by writing it
 to the secret directory at `secrets/vault_token` and by injecting a `VAULT_TOKEN`
 environment variable. If the Nomad cluster is [configured](/docs/configuration/vault#namespace)
 to use [Vault Namespaces](https://www.vaultproject.io/docs/enterprise/namespaces),
-a `VAULT_NAMESPACE` environment variable will be injected whenever `VAULT_TOKEN` is.
+a `VAULT_NAMESPACE` environment variable will be injected whenever `VAULT_TOKEN` is set.
 
 If Nomad is unable to renew the Vault token (perhaps due to a Vault outage or
 network error), the client will attempt to retrieve a new Vault token. If successful, the


### PR DESCRIPTION
The phrasing of this sentence is confusing. The sentence abruptly stops. I had to read it multiple times to realize that there wasn't a missing word after `is`. 

> If the Nomad cluster is configured to use Vault Namespaces a `VAULT_NAMESPACE` environment variable will be injected whenever `VAULT_TOKEN` is.	

Documentation page: 

https://nomadproject.io/docs/job-specification/vault/
