### PR TITLE
tests: deflake some SetServer related tests

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -421,15 +421,20 @@ func (a *Agent) finalizeClientConfig(c *clientconfig.Config) error {
 	// configured explicitly. This handles both running server and client on one
 	// host and -dev mode.
 	if a.server != nil {
-		if a.config.AdvertiseAddrs == nil || a.config.AdvertiseAddrs.RPC == "" {
+		advertised := a.config.AdvertiseAddrs
+		normalized := a.config.normalizedAddrs
+
+		if advertised == nil || advertised.RPC == "" {
 			return fmt.Errorf("AdvertiseAddrs is nil or empty")
-		} else if a.config.normalizedAddrs == nil || a.config.normalizedAddrs.RPC == "" {
+		} else if normalized == nil || normalized.RPC == "" {
 			return fmt.Errorf("normalizedAddrs is nil or empty")
 		}
 
-		c.Servers = append(c.Servers,
-			a.config.normalizedAddrs.RPC,
-			a.config.AdvertiseAddrs.RPC)
+		if normalized.RPC == advertised.RPC {
+			c.Servers = append(c.Servers, normalized.RPC)
+		} else {
+			c.Servers = append(c.Servers, normalized.RPC, advertised.RPC)
+		}
 	}
 
 	// Setup the plugin loaders

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -711,7 +711,7 @@ func TestHTTP_AgentSetServers(t *testing.T) {
 			}
 			defer conn.Close()
 
-			// Write the Consul RPC byte to set the mode
+			// Write the Nomad RPC byte to set the mode
 			if _, err := conn.Write([]byte{byte(pool.RpcNomad)}); err != nil {
 				return false, err
 			}


### PR DESCRIPTION
Some tests assert on numbers on numbers of servers, e.g.
TestHTTP_AgentSetServers and TestHTTP_AgentListServers_ACL . Though, in dev and
test modes, the agent starts with servers having duplicate entries for
advertised and normalized RPC values, then settles with one unique value after
Raft/Serf re-sets servers with one single unique value.

This leads to flakiness, as the test will fail if assertion runs before Serf
update takes effect.

Here, we update the inital dev handling so it only adds a unique value if the
advertised and normalized values are the same.

Sample log lines illustrating the problem:

```
=== CONT  TestHTTP_AgentSetServers
    TestHTTP_AgentSetServers: testlog.go:34: 2020-04-06T21:47:51.016Z [INFO]  nomad.raft: initial configuration: index=1 servers="[{Suffrage:Voter ID:127.0.0.1:9008 Address:127.0.0.1:9008}]"
    TestHTTP_AgentSetServers: testlog.go:34: 2020-04-06T21:47:51.016Z [INFO]  nomad: serf: EventMemberJoin: TestHTTP_AgentSetServers.global 127.0.0.1
    TestHTTP_AgentSetServers: testlog.go:34: 2020-04-06T21:47:51.035Z [DEBUG] client.server_mgr: new server list: new_servers=[127.0.0.1:9008, 127.0.0.1:9008] old_servers=[]
...
    TestHTTP_AgentSetServers: agent_endpoint_test.go:759:
                Error Trace:    agent_endpoint_test.go:759
                                                        http_test.go:1089
                                                        agent_endpoint_test.go:705
                Error:          "[127.0.0.1:9008 127.0.0.1:9008]" should have 1 item(s), but has 2
                Test:           TestHTTP_AgentSetServers
```