### PR TITLE
Run task shutdown_delay regardless of service registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 
+ * core: Fixed a bug that only ran a task `shutdown_delay` if the task had service [[GH-7663](https://github.com/hashicorp/nomad/issues/7663)]
  * vault: Upgrade http2 library to fix Vault API calls that fail with `http2: no cached connection was available` [[GH-7673](https://github.com/hashicorp/nomad/issues/7673)]
 
 ## 0.11.0 (April 8, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
- * core: Fixed a bug that only ran a task `shutdown_delay` if the task had service [[GH-7663](https://github.com/hashicorp/nomad/issues/7663)]
+ * core: Fixed a bug that only ran a task `shutdown_delay` if the task had a registered service [[GH-7663](https://github.com/hashicorp/nomad/issues/7663)]
  * vault: Upgrade http2 library to fix Vault API calls that fail with `http2: no cached connection was available` [[GH-7673](https://github.com/hashicorp/nomad/issues/7673)]
 
 ## 0.11.0 (April 8, 2020)

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -844,6 +844,14 @@ func (tr *TaskRunner) handleKill() *drivers.ExitResult {
 	// Run the pre killing hooks
 	tr.preKill()
 
+	// Wait for task ShutdownDelay after running prekill hooks
+	// This allows for things like service de-registration to run
+	// before waiting to kill task
+	if delay := tr.Task().ShutdownDelay; delay != 0 {
+		tr.logger.Debug("waiting before killing task", "shutdown_delay", delay)
+		time.Sleep(delay)
+	}
+
 	// Tell the restart tracker that the task has been killed so it doesn't
 	// attempt to restart it.
 	tr.restartTracker.SetKilled()


### PR DESCRIPTION
task shutdown_delay will currently only run if there are registered
services for the task. This implementation detail isn't explicity stated
anywhere and is defined outside of the service stanza.

This change moves shutdown_delay to be evaluated after prekill hooks are
run, outside of any task runner hooks.

fixes #7271 