### PR TITLE
e2e: add a convenient creation script

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -53,7 +53,7 @@ Then deploy Nomad to the cluster by passing `-provision.terraform`
 without a Nomad version flag:
 
 ```sh
-go test -v . -nomad.version=0.10.2 -provision.terraform ./provisioning.json -skipTests
+NOMAD_E2E=1 go test -v . -nomad.version=0.10.2 -provision.terraform ./provisioning.json -skipTests
 ```
 
 Because it can take a little while for the cluster to settle, it's

--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -1,0 +1,10 @@
+NOMAD_SHA := $(shell git rev-parse HEAD)
+
+dev-cluster:
+	terraform apply -auto-approve -var-file=terraform.tfvars.dev
+	terraform output provisioning | jq . > ../provisioning.json
+	cd .. && NOMAD_E2E=1 go test -v . -nomad.sha=$(NOMAD_SHA) -provision.terraform ./provisioning.json -skipTests
+	terraform output message
+
+clean:
+	terraform destroy -auto-approve

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -132,7 +132,13 @@ go test -v ./e2e
 
 ssh into nodes with:
 ```
-ssh -i keys/${local.random_name}.pem ubuntu@${aws_instance.client_linux[0].public_ip}
+# server
+ssh -i keys/${local.random_name}.pem ubuntu@${aws_instance.server[0].public_ip}
+
+# clients
+%{ for ip in aws_instance.client_linux.*.public_ip ~}
+ssh -i keys/${local.random_name}.pem ubuntu@${ip}
+%{ endfor ~}
 ```
 EOM
 

--- a/e2e/terraform/terraform.tfvars.dev
+++ b/e2e/terraform/terraform.tfvars.dev
@@ -1,0 +1,5 @@
+region               = "us-east-1"
+instance_type        = "t2.medium"
+server_count         = "3"
+client_count         = "2"
+windows_client_count = "0"


### PR DESCRIPTION
Add a convenience Makefile for creating e2e environment for manual
debugging.

I find myself repeating these commands frequently, so bundling them into a Makefile.

We also should follow up with having a dev binaries expose UI - I'm getting used to it :).