### PR TITLE
docs: fix link to envoy proxy documentation on consul site

### DIFF
--- a/website/pages/docs/job-specification/proxy.mdx
+++ b/website/pages/docs/job-specification/proxy.mdx
@@ -60,7 +60,7 @@ job "countdash" {
   for more information.
 - `config` `(map: nil)` - Proxy configuration that's opaque to Nomad and
   passed directly to Consul. See [Consul Connect's
-  documentation](https://www.consul.io/docs/connect/proxies/envoy#dynamic-configuration)
+  documentation](https://www.consul.io/docs/connect/proxies/envoy.html#dynamic-configuration)
   for details.
 
 ## `proxy` Examples


### PR DESCRIPTION
Fixes #7677