### PR TITLE
core: fix comment on system stack

### DIFF
--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -185,7 +185,7 @@ type SystemStack struct {
 	scoreNorm                  *ScoreNormalizationIterator
 }
 
-// NewSystemStack constructs a stack used for selecting service placements
+// NewSystemStack constructs a stack used for selecting system job placements.
 func NewSystemStack(ctx Context) *SystemStack {
 	// Create a new stack
 	s := &SystemStack{ctx: ctx}


### PR DESCRIPTION
This makes me do a double take every time I run into it, so what if we
just changed it?