### PR TITLE
connect: correctly handle missing sidecar_service task stanza

### DIFF
--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -701,6 +701,9 @@ func (s *ConsulSidecarService) HasUpstreams() bool {
 
 // Copy the stanza recursively. Returns nil if nil.
 func (s *ConsulSidecarService) Copy() *ConsulSidecarService {
+	if s == nil {
+		return nil
+	}
 	return &ConsulSidecarService{
 		Tags:  helper.CopySliceString(s.Tags),
 		Port:  s.Port,

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -174,6 +174,8 @@ func TestConsulConnect_CopyEquals(t *testing.T) {
 }
 
 func TestSidecarTask_MergeIntoTask(t *testing.T) {
+	t.Parallel()
+
 	task := MockJob().TaskGroups[0].Tasks[0]
 	sTask := &SidecarTask{
 		Name:   "sidecar",
@@ -300,6 +302,8 @@ func TestConsulExposePath_exposePathsEqual(t *testing.T) {
 }
 
 func TestConsulExposeConfig_Copy(t *testing.T) {
+	t.Parallel()
+
 	require.Nil(t, (*ConsulExposeConfig)(nil).Copy())
 	require.Equal(t, &ConsulExposeConfig{
 		Paths: []ConsulExposePath{{
@@ -313,6 +317,8 @@ func TestConsulExposeConfig_Copy(t *testing.T) {
 }
 
 func TestConsulExposeConfig_Equals(t *testing.T) {
+	t.Parallel()
+
 	require.True(t, (*ConsulExposeConfig)(nil).Equals(nil))
 	require.True(t, (&ConsulExposeConfig{
 		Paths: []ConsulExposePath{{
@@ -323,4 +329,28 @@ func TestConsulExposeConfig_Equals(t *testing.T) {
 			Path: "/health",
 		}},
 	}))
+}
+
+func TestConsulSidecarService_Copy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		s := (*ConsulSidecarService)(nil)
+		result := s.Copy()
+		require.Nil(t, result)
+	})
+
+	t.Run("not nil", func(t *testing.T) {
+		s := &ConsulSidecarService{
+			Tags:  []string{"foo", "bar"},
+			Port:  "port1",
+			Proxy: &ConsulProxy{LocalServiceAddress: "10.0.0.1"},
+		}
+		result := s.Copy()
+		require.Equal(t, &ConsulSidecarService{
+			Tags:  []string{"foo", "bar"},
+			Port:  "port1",
+			Proxy: &ConsulProxy{LocalServiceAddress: "10.0.0.1"},
+		}, result)
+	})
 }


### PR DESCRIPTION
Before, if the `sidecar_service` stanza of a connect enabled service
was missing, the job submission would cause a panic in the nomad
agent. Since the panic was happening in the API handler the agent
itself continued running, but this change will the condition more
gracefully.

By fixing the `Copy` method, the API handler now returns the proper
error.

```bash
$ nomad job run foo.nomad
Error submitting job: Unexpected response code: 500 (1 error occurred:
	* Task group api validation failed: 2 errors occurred:
	* Missing tasks for task group
	* Task group service validation failed: 1 error occurred:
	* Service[0] count-api validation failed: 1 error occurred:
	* Consul Connect must be native or use a sidecar service
```

Fixes #7679
