### PR TITLE
connect: enable configuring sidecar_task.name

### DIFF
--- a/jobspec/parse_service.go
+++ b/jobspec/parse_service.go
@@ -263,32 +263,7 @@ func parseSidecarService(o *ast.ObjectItem) (*api.ConsulSidecarService, error) {
 }
 
 func parseSidecarTask(item *ast.ObjectItem) (*api.SidecarTask, error) {
-	// We need this later
-	var listVal *ast.ObjectList
-	if ot, ok := item.Val.(*ast.ObjectType); ok {
-		listVal = ot.List
-	} else {
-		return nil, fmt.Errorf("should be an object")
-	}
-
-	// Check for invalid keys
-	valid := []string{
-		"config",
-		"driver",
-		"env",
-		"kill_timeout",
-		"logs",
-		"meta",
-		"resources",
-		"shutdown_delay",
-		"user",
-		"kill_signal",
-	}
-	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
-		return nil, err
-	}
-
-	task, err := parseTask(item)
+	task, err := parseTask(item, sidecarTaskKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -13,45 +13,38 @@ import (
 )
 
 var (
-	normalTaskKeys = []string{
-		"artifact",
+	commonTaskKeys = []string{
+		"driver",
+		"user",
 		"config",
+		"env",
+		"resources",
+		"meta",
+		"logs",
+		"kill_timeout",
+		"shutdown_delay",
+		"kill_signal",
+	}
+
+	normalTaskKeys = append(commonTaskKeys,
+		"artifact",
 		"constraint",
 		"affinity",
 		"dispatch_payload",
 		"lifecycle",
-		"driver",
-		"env",
-		"kill_timeout",
 		"leader",
-		"logs",
-		"meta",
-		"resources",
 		"restart",
 		"service",
-		"shutdown_delay",
 		"template",
-		"user",
 		"vault",
-		"kill_signal",
 		"kind",
 		"volume_mount",
 		"csi_plugin",
-	}
+	)
 
-	sidecarTaskKeys = []string{
+	sidecarTaskKeys = append(commonTaskKeys,
 		"name",
-		"driver",
-		"user",
-		"config",
-		"env",
-		"resources",
-		"meta",
-		"logs",
-		"kill_timeout",
-		"shutdown_delay",
-		"kill_signal",
-	}
+	)
 )
 
 func parseTasks(result *[]*api.Task, list *ast.ObjectList) error {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -895,6 +895,28 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"service-connect-sidecar_task-name.hcl",
+			&api.Job{
+				ID:   helper.StringToPtr("sidecar_task_name"),
+				Name: helper.StringToPtr("sidecar_task_name"),
+				Type: helper.StringToPtr("service"),
+				TaskGroups: []*api.TaskGroup{{
+					Name: helper.StringToPtr("group"),
+					Services: []*api.Service{{
+						Name: "example",
+						Connect: &api.ConsulConnect{
+							Native:         false,
+							SidecarService: &api.ConsulSidecarService{},
+							SidecarTask: &api.SidecarTask{
+								Name: "my-sidecar",
+							},
+						},
+					}},
+				}},
+			},
+			false,
+		},
+		{
 			"reschedule-job.hcl",
 			&api.Job{
 				ID:          helper.StringToPtr("foo"),

--- a/jobspec/test-fixtures/service-connect-sidecar_task-name.hcl
+++ b/jobspec/test-fixtures/service-connect-sidecar_task-name.hcl
@@ -1,0 +1,15 @@
+job "sidecar_task_name" {
+  type = "service"
+
+  group "group" {
+    service {
+      name = "example"
+      connect {
+        sidecar_service {}
+        sidecar_task {
+          name = "my-sidecar"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Before, the submitted jobspec for `sidecar_task` would pass
through 2 HCL key validation steps - once for the subset specific
to connect sidecar task definitions, and once again for the set
of normal task definition.

The valid keys for the normal task definition did not include
`name`, which is supposed to be configurable for the sidecar
task. To fix this, just eliminate the double validation for sidecars,
and instead pass in the correct set of keys to validate against
to the one generic task parser.

Fixes #7680

Example)

```bash
$ cat example.nomad 
job "countdash" {
  datacenters = ["dc1"]

  group "api" {
    network {
      mode = "bridge"
    }

    service {
      name = "count-api"
      port = "9001"

      connect {
	sidecar_service {}
	sidecar_task {
	  name = "sidecar-for-api"
	}
      }
    }

    task "web" {
      driver = "docker"

      config {
        image = "hashicorpnomad/counter-api:v1"
      }
    }
  }

  group "dashboard" {
    network {
      mode = "bridge"

      port "http" {
        static = 9002
        to     = 9002
      }
    }

    service {
      name = "count-dashboard"
      port = "9002"

      connect {
        sidecar_service {
          proxy {
            upstreams {
              destination_name = "count-api"
              local_bind_port  = 8080
            }
          }
	}
	sidecar_task {
	  name = "sidecar-for-dashboard"
	}
      }
    }

    task "dashboard" {
      driver = "docker"

      env {
        COUNTING_SERVICE_URL = "http://${NOMAD_UPSTREAM_ADDR_count_api}"
      }

      config {
        image = "hashicorpnomad/counter-dashboard:v1"
      }
    }
  }
}
```

```bash
$ nomad job run example.nomad
==> Monitoring evaluation "bba4c500"
    Evaluation triggered by job "countdash"
    Allocation "c146aa5b" created: node "452bfc95", group "dashboard"
    Allocation "d08ba27e" created: node "452bfc95", group "api"
    Evaluation within deployment: "5ac8764c"
    Evaluation status changed: "pending" -> "complete"
==> Evaluation "bba4c500" finished with status "complete"
```

```bash
$ nomad alloc status c1
ID                  = c146aa5b-3430-935d-1045-458415e51b5a
Eval ID             = bba4c500
Name                = countdash.dashboard[0]
Node ID             = 452bfc95
Node Name           = NUC10
Job ID              = countdash
Job Version         = 0
Client Status       = running
Client Description  = Tasks are running
Desired Status      = run
Desired Description = <none>
Created             = 19s ago
Modified            = 7s ago
Deployment ID       = 5ac8764c
Deployment Health   = healthy

Allocation Addresses (mode = "bridge")
Label                          Dynamic  Address
connect-proxy-count-dashboard  yes      192.168.1.53:30194 -> 30194
http                           yes      192.168.1.53:9002 -> 9002

Task "sidecar-for-dashboard" (prestart sidecar) is "running"
Task Resources
CPU        Memory          Disk     Addresses
7/250 MHz  11 MiB/128 MiB  300 MiB  

Task Events:
Started At     = 2020-04-10T03:06:49Z
Finished At    = N/A
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2020-04-09T21:06:49-06:00  Started     Task started by client
2020-04-09T21:06:48-06:00  Task Setup  Building Task Directory
2020-04-09T21:06:47-06:00  Received    Task received by client

Task "dashboard" is "running"
Task Resources
CPU        Memory           Disk     Addresses
0/100 MHz  1.4 MiB/300 MiB  300 MiB  

Task Events:
Started At     = 2020-04-10T03:06:49Z
Finished At    = N/A
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2020-04-09T21:06:49-06:00  Started     Task started by client
2020-04-09T21:06:49-06:00  Task Setup  Building Task Directory
2020-04-09T21:06:47-06:00  Received    Task received by client
```

```bash
$ nomad alloc status d0
ID                  = d08ba27e-06d0-b397-2a62-42b39ea684fb
Eval ID             = bba4c500
Name                = countdash.api[0]
Node ID             = 452bfc95
Node Name           = NUC10
Job ID              = countdash
Job Version         = 0
Client Status       = running
Client Description  = Tasks are running
Desired Status      = run
Desired Description = <none>
Created             = 27s ago
Modified            = 15s ago
Deployment ID       = 5ac8764c
Deployment Health   = healthy

Allocation Addresses (mode = "bridge")
Label                    Dynamic  Address
connect-proxy-count-api  yes      192.168.1.53:21489 -> 21489
Task "sidecar-for-api" (prestart sidecar) is "running"
Task Resources
CPU        Memory          Disk     Addresses
8/250 MHz  10 MiB/128 MiB  300 MiB  

Task Events:
Started At     = 2020-04-10T03:06:49Z
Finished At    = N/A
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2020-04-09T21:06:49-06:00  Started     Task started by client
2020-04-09T21:06:48-06:00  Task Setup  Building Task Directory
2020-04-09T21:06:47-06:00  Received    Task received by client

Task "web" is "running"
Task Resources
CPU        Memory           Disk     Addresses
0/100 MHz  536 KiB/300 MiB  300 MiB  

Task Events:
Started At     = 2020-04-10T03:06:49Z
Finished At    = N/A
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2020-04-09T21:06:49-06:00  Started     Task started by client
2020-04-09T21:06:49-06:00  Task Setup  Building Task Directory
2020-04-09T21:06:47-06:00  Received    Task received by client
```