### PR TITLE
UI Plumb proxy config to proxy

### DIFF
--- a/ui/.ember-cli
+++ b/ui/.ember-cli
@@ -5,5 +5,6 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
+  "disableAnalytics": false,
+  "proxy": "http://127.0.0.1:4646"
 }

--- a/ui/server/proxies/api.js
+++ b/ui/server/proxies/api.js
@@ -7,6 +7,20 @@ module.exports = function(app, options) {
   // For options, see:
   // https://github.com/nodejitsu/node-http-proxy
 
+  // This is probably not safe to do, but it works for now.
+  let cacheKey = `${options.project.configPath()}|${options.environment}`;
+  let config = options.project.configCache.get(cacheKey);
+
+  // Disable the proxy completely when Mirage is enabled. No requests to the API
+  // will be being made, and having the proxy attempt to connect to Nomad when it
+  // is not running can result in socket max connections that block the livereload
+  // server from reloading.
+  if (config['ember-cli-mirage'].enabled !== false) {
+    options.ui.writeInfoLine('Mirage is enabled. Not starting proxy');
+    delete options.proxy;
+    return;
+  }
+
   let proxyAddress = options.proxy;
 
   let server = options.httpServer;

--- a/ui/server/proxies/api.js
+++ b/ui/server/proxies/api.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// Issue to improve: https://github.com/hashicorp/nomad/issues/7465
 const proxyPath = '/v1';
 
 module.exports = function(app, options) {

--- a/ui/server/proxies/api.js
+++ b/ui/server/proxies/api.js
@@ -7,11 +7,13 @@ module.exports = function(app, options) {
   // For options, see:
   // https://github.com/nodejitsu/node-http-proxy
 
+  let proxyAddress = options.proxy;
+
   let server = options.httpServer;
   let proxy = require('http-proxy').createProxyServer({
-    target: 'http://localhost:4646',
+    target: proxyAddress,
     ws: true,
-    changeOrigin: true
+    changeOrigin: true,
   });
 
   proxy.on('error', function(err, req) {
@@ -19,16 +21,16 @@ module.exports = function(app, options) {
     console.error(err, req.url);
   });
 
-  app.use(proxyPath, function(req, res){
+  app.use(proxyPath, function(req, res) {
     // include root path in proxied request
     req.url = proxyPath + req.url;
-    proxy.web(req, res, { target: 'http://localhost:4646'});
+    proxy.web(req, res, { target: proxyAddress });
   });
 
-  server.on('upgrade', function (req, socket, head) {
+  server.on('upgrade', function(req, socket, head) {
     if (req.url.startsWith('/v1/client/allocation') && req.url.includes('exec?')) {
-      req.headers.origin = 'http://localhost:4646';
-      proxy.ws(req, socket, head, { target: 'http://localhost:4646'});
+      req.headers.origin = proxyAddress;
+      proxy.ws(req, socket, head, { target: proxyAddress });
     }
   });
 };


### PR DESCRIPTION
This reinstates the `.embercli`/`--proxy` proxy address as the canonical address for backend proxying.

While I was in that code, I had a go at disabling the proxy entirely when Mirage is enabled. I have run into socket connection issues when running the ember server without Nomad running at the same time. I believe this will fix that (at the cost of doing some grimy things with private APIs 😬).