### PR TITLE
e2e: testing reliability

### DIFF
--- a/e2e/csi/csi.go
+++ b/e2e/csi/csi.go
@@ -92,6 +92,7 @@ func (tc *CSIVolumesTest) TestEBSVolumeClaim(f *framework.F) {
 	writeAllocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient,
 		"csi/input/use-ebs-volume.nomad", writeJobID, "")
 	writeAllocID := writeAllocs[0].ID
+	tc.testJobIDs = append(tc.testJobIDs, writeJobID) // ensure failed tests clean up
 	e2eutil.WaitForAllocRunning(t, nomadClient, writeAllocID)
 
 	// read data from volume and assert the writer wrote a file to it
@@ -177,6 +178,7 @@ func (tc *CSIVolumesTest) TestEFSVolumeClaim(f *framework.F) {
 	writeAllocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient,
 		"csi/input/use-efs-volume-write.nomad", writeJobID, "")
 	writeAllocID := writeAllocs[0].ID
+	tc.testJobIDs = append(tc.testJobIDs, writeJobID) // ensure failed tests clean up
 	e2eutil.WaitForAllocRunning(t, nomadClient, writeAllocID)
 
 	// read data from volume and assert the writer wrote a file to it

--- a/e2e/csi/input/plugin-aws-ebs-controller.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-controller.nomad
@@ -15,7 +15,7 @@ job "plugin-aws-ebs-controller" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:latest"
+        image = "amazon/aws-ebs-csi-driver:v0.5.0"
 
         args = [
           "controller",

--- a/e2e/csi/input/plugin-aws-ebs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-nodes.nomad
@@ -19,7 +19,7 @@ job "plugin-aws-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:latest"
+        image = "amazon/aws-ebs-csi-driver:v0.5.0"
 
         args = [
           "node",

--- a/e2e/csi/input/plugin-aws-efs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-efs-nodes.nomad
@@ -19,7 +19,7 @@ job "plugin-aws-efs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-efs-csi-driver:latest"
+        image = "amazon/aws-efs-csi-driver:v0.3.0"
 
         # note: the EFS driver doesn't seem to respect the --endpoint
         # flag and always sets up the listener at '/tmp/csi.sock'

--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -1,4 +1,4 @@
-NOMAD_SHA := $(shell git rev-parse HEAD)
+NOMAD_SHA ?= $(shell git rev-parse HEAD)
 
 dev-cluster:
 	terraform apply -auto-approve -var-file=terraform.tfvars.dev


### PR DESCRIPTION
This changeset makes 3 changes to improve reliability and usability of e2e tests:
* pin the Docker image version of the CSI plugins, which recently caused nightly tests to fail because of a bad image push from upstream
* ensure _all_ the jobs get cleaned up during CSI's e2e testing, even the ones we expect to "never fail" (because, see above 😀)
* update the Makefile for `make dev-cluster` to accept an env var override.