### PR TITLE
documents the scaling block in the JSON Job docs

### DIFF
--- a/website/pages/api-docs/json-jobs.mdx
+++ b/website/pages/api-docs/json-jobs.mdx
@@ -315,7 +315,6 @@ attributes:
 - `Scaling` - Specifies the autoscaling policy for the task group. This is primarily for supporting
   external autoscalers. See the [scaling policy reference](#scaling_policy) for more details.
 
-
 - `EphemeralDisk` - Specifies the group's ephemeral disk requirements. See the
   [ephemeral disk reference](#ephemeral_disk) for more details.
 
@@ -1065,4 +1064,3 @@ The `Scaling` object supports the following keys:
 [ct]: https://github.com/hashicorp/consul-template 'Consul Template by HashiCorp'
 [drain]: /docs/commands/node/drain
 [env]: /docs/runtime/environment 'Nomad Runtime Environment'
-

--- a/website/pages/api-docs/json-jobs.mdx
+++ b/website/pages/api-docs/json-jobs.mdx
@@ -396,6 +396,11 @@ The `Task` object supports the following keys:
 - `Resources` - Provides the resource requirements of the task.
   See the resources reference for more details.
 
+- `RestartPolicy` - Specifies the task-specific restart policy.
+  If omitted, the restart policy from the encapsulating task group is used. If both
+  are present, they are merged. See the [restart policy reference](#restart_policy)
+  for more details.
+
 - `Services` - `Services` is a list of `Service` objects. Nomad integrates with
   Consul for service discovery. A `Service` object represents a routable and
   discoverable service on the network. Nomad automatically registers when a task

--- a/website/pages/api-docs/json-jobs.mdx
+++ b/website/pages/api-docs/json-jobs.mdx
@@ -1042,23 +1042,24 @@ The `Spread` object supports the following keys:
 ### Scaling
 
 Scaling policies allow operators to attach autoscaling configuration to a task group. This information
-can be queried by external autoscalers; Nomad does not currently provide any built-in autoscaling
-capability. 
+can be queried by [external autoscalers](https://github.com/hashicorp/nomad-autoscaler).
 
 The `Scaling` object supports the following keys:
 
 - `Min` - The minimum allowable count for the task group. This is optional; if absent, the default
-  is the count specified with the task group. Attempts to set the task group count below `Min` will
-  result in a 400 error.
+  is the `Count` specified in the task group. Attempts to set the task group `Count` below `Min` will
+  result in a 400 error during job registration.
 
-- `Max` - The maximum allowable count for the task group. This is required and must be larger than
-  `Min`. Attempts to set the task group count above `Max` wil result in a 400 error.
+- `Max` - The maximum allowable count for the task group. This is required if a scaling policy is provided.
+   This must be larger than `Min`. Attempts to set the task group `Count` above `Max` wil result in a 400
+   error during job registration.
 
-- `Enabled` - An optional boolean, defaulting to false. This indicates to the autoscaler that this
-   scaling policy should be ignored.
+- `Enabled` - An optional boolean (default: `true`). This indicates to the autoscaler that this
+   scaling policy should be ignored. It is intended to allow autoscaling to be temporarily disabled
+   for a task group.
 
 - `Policy` - An optional JSON block. This is opaque to Nomad; see the documentation for the external
-   autoscaler.
+   autoscaler (e.g., [nomad-autoscaler](https://github.com/hashicorp/nomad-autoscaler)).
 
 
 [ct]: https://github.com/hashicorp/consul-template 'Consul Template by HashiCorp'

--- a/website/pages/api-docs/json-jobs.mdx
+++ b/website/pages/api-docs/json-jobs.mdx
@@ -312,6 +312,10 @@ attributes:
   If omitted, a default policy is used for batch and service jobs. System jobs are not eligible
   for rescheduling. See the [reschedule policy reference](#reschedule_policy) for more details.
 
+- `Scaling` - Specifies the autoscaling policy for the task group. This is primarily for supporting
+  external autoscalers. See the [scaling policy reference](#scaling_policy) for more details.
+
+
 - `EphemeralDisk` - Specifies the group's ephemeral disk requirements. See the
   [ephemeral disk reference](#ephemeral_disk) for more details.
 
@@ -1028,6 +1032,31 @@ The `Spread` object supports the following keys:
 - `Weight` - A non zero weight, valid values are from -100 to 100. Used to express
   relative preference when there is more than one spread or affinity.
 
+<a id="scaling_policy"></a>
+
+### Scaling
+
+Scaling policies allow operators to attach autoscaling configuration to a task group. This information
+can be queried by external autoscalers; Nomad does not currently provide any built-in autoscaling
+capability. 
+
+The `Scaling` object supports the following keys:
+
+- `Min` - The minimum allowable count for the task group. This is optional; if absent, the default
+  is the count specified with the task group. Attempts to set the task group count below `Min` will
+  result in a 400 error.
+
+- `Max` - The maximum allowable count for the task group. This is required and must be larger than
+  `Min`. Attempts to set the task group count above `Max` wil result in a 400 error.
+
+- `Enabled` - An optional boolean, defaulting to false. This indicates to the autoscaler that this
+   scaling policy should be ignored.
+
+- `Policy` - An optional JSON block. This is opaque to Nomad; see the documentation for the external
+   autoscaler.
+
+
 [ct]: https://github.com/hashicorp/consul-template 'Consul Template by HashiCorp'
 [drain]: /docs/commands/node/drain
 [env]: /docs/runtime/environment 'Nomad Runtime Environment'
+


### PR DESCRIPTION
documents the `Scaling` block in the JSON Job docs. also documents the `RestartPolicy` support at the task level (see #7603)

resolves #7656