### PR TITLE
Fix entrypoint type to string.

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -389,7 +389,7 @@ type TaskConfig struct {
 	DNSSearchDomains  []string           `codec:"dns_search_domains"`
 	DNSOptions        []string           `codec:"dns_options"`
 	DNSServers        []string           `codec:"dns_servers"`
-	Entrypoint        []string           `codec:"entrypoint"`
+	Entrypoint        string             `codec:"entrypoint"`
 	ExtraHosts        []string           `codec:"extra_hosts"`
 	ForcePull         bool               `codec:"force_pull"`
 	Hostname          string             `codec:"hostname"`

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -300,7 +300,7 @@ config {
 	expected := &TaskConfig{
 		Image:             "redis:3.2",
 		AdvertiseIPv6Addr: true,
-		Args:              []string{"command_arg1", "command_arg2"},
+		Args:              []string{"-c", "command_arg1", "command_arg2"},
 		Auth: DockerAuth{
 			Username:   "myusername",
 			Password:   "mypassword",
@@ -328,7 +328,7 @@ config {
 		DNSSearchDomains: []string{"sub.example.com", "sub2.example.com"},
 		DNSOptions:       []string{"debug", "attempts:10"},
 		DNSServers:       []string{"8.8.8.8", "1.1.1.1"},
-		Entrypoint:       []string{"/bin/bash", "-c"},
+		Entrypoint:       "/bin/bash",
 		ExtraHosts:       []string{"127.0.0.1  localhost.example.com"},
 		ForcePull:        true,
 		Hostname:         "self.example.com",

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2311,12 +2311,12 @@ func TestDockerDriver_Entrypoint(t *testing.T) {
 	}
 	testutil.DockerCompatible(t)
 
-	entrypoint := []string{"sh", "-c"}
+	entrypoint := "/bin/echo"
 	task, cfg, ports := dockerTask(t)
 	defer freeport.Return(ports)
 	cfg.Entrypoint = entrypoint
 	cfg.Command = strings.Join(busyboxLongRunningCmd, " ")
-	cfg.Args = []string{}
+	cfg.Args = []string{"hello"}
 
 	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 

--- a/vendor/github.com/fsouza/go-dockerclient/container.go
+++ b/vendor/github.com/fsouza/go-dockerclient/container.go
@@ -312,7 +312,7 @@ type Config struct {
 	VolumeDriver      string              `json:"VolumeDriver,omitempty" yaml:"VolumeDriver,omitempty" toml:"VolumeDriver,omitempty"`
 	WorkingDir        string              `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty" toml:"WorkingDir,omitempty"`
 	MacAddress        string              `json:"MacAddress,omitempty" yaml:"MacAddress,omitempty" toml:"MacAddress,omitempty"`
-	Entrypoint        []string            `json:"Entrypoint" yaml:"Entrypoint" toml:"Entrypoint"`
+	Entrypoint        string              `json:"Entrypoint" yaml:"Entrypoint" toml:"Entrypoint"`
 	SecurityOpts      []string            `json:"SecurityOpts,omitempty" yaml:"SecurityOpts,omitempty" toml:"SecurityOpts,omitempty"`
 	OnBuild           []string            `json:"OnBuild,omitempty" yaml:"OnBuild,omitempty" toml:"OnBuild,omitempty"`
 	Mounts            []Mount             `json:"Mounts,omitempty" yaml:"Mounts,omitempty" toml:"Mounts,omitempty"`

--- a/vendor/github.com/fsouza/go-dockerclient/plugin.go
+++ b/vendor/github.com/fsouza/go-dockerclient/plugin.go
@@ -136,7 +136,7 @@ type PluginConfig struct {
 	Description     string `json:"Description,omitempty" yaml:"Description,omitempty" toml:"Description,omitempty"`
 	Documentation   string
 	Interface       PluginInterface `json:"Interface,omitempty" yaml:"Interface,omitempty" toml:"Interface,omitempty"`
-	Entrypoint      []string        `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty" toml:"Entrypoint,omitempty"`
+	Entrypoint      string          `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty" toml:"Entrypoint,omitempty"`
 	WorkDir         string          `json:"WorkDir,omitempty" yaml:"WorkDir,omitempty" toml:"WorkDir,omitempty"`
 	User            PluginUser      `json:"User,omitempty" yaml:"User,omitempty" toml:"User,omitempty"`
 	Network         PluginNetwork   `json:"Network,omitempty" yaml:"Network,omitempty" toml:"Network,omitempty"`

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -82,7 +82,7 @@ The `docker` driver supports the following configuration in the job spec. Only
 - `dns_servers` - (Optional) A list of DNS servers for the container to use
   (e.g. ["8.8.8.8", "8.8.4.4"]). Requires Docker v1.10 or greater.
 
-- `entrypoint` - (Optional) A string list overriding the image's entrypoint.
+- `entrypoint` - (Optional) A string overriding the image's entrypoint.
 
 - `extra_hosts` - (Optional) A list of hosts, given as host:IP, to be added to
   `/etc/hosts`.


### PR DESCRIPTION
This PR fixes the entrypoint type from the `[]string{}` to `string`.
The existing code is using Entrypoint as a string list, which is correct for image config (i.e. entrypoint in Dockerfile) where it's a list. However entrypoint in nomad is a runtime config, which allows overriding container config (`--entrypoint`) where entrypoint is a string.

I have updated the vendor files directly since I just wanted to see if the tests would pass.
Ideally, at some point, I'll open a PR to fix https://github.com/fsouza/go-dockerclient/blob/a407903ea405b3a902d95084fc7b1f6f16d21a59/container.go#L315

and then it could be vendor'ed into nomad. 

Before I put more effort, I wanted to discuss (and get a sense) on what's the expected type.