### PR TITLE
[docs/job-specification sidebar] label csi as beta from 0.11 release notes

### DIFF
--- a/website/pages/docs/job-specification/csi_plugin.mdx
+++ b/website/pages/docs/job-specification/csi_plugin.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: csi_plugin Stanza - Job Specification
-sidebar_title: csi_plugin
+sidebar_title: csi_plugin <sup>Beta</sup>
 description: >-
   The "csi_plugin" stanza allows the task to specify it provides a
   Container Storage Interface plugin to the cluster.


### PR DESCRIPTION
csi plugins are labeled as beta in the 0.11 release notes, this matches what it says for "scaling."