### PR TITLE
docs: update Datadog agent telemetry link to rewritten version.

### DIFF
--- a/website/pages/docs/configuration/telemetry.mdx
+++ b/website/pages/docs/configuration/telemetry.mdx
@@ -114,7 +114,7 @@ telemetry {
 ### `datadog`
 
 These `telemetry` parameters apply to
-[DataDog statsd](https://github.com/DataDog/dd-agent).
+[DataDog statsd](https://github.com/DataDog/datadog-agent).
 
 - `datadog_address` `(string: "")` - Specifies the address of a DataDog statsd
   server to forward metrics to.


### PR DESCRIPTION
The Datadog agent was rewritten in Go from version 6. This means
the codebase resides in a new GitHub repository. This change
updates the Nomad telemetry configuration documentation to point
to the latest repo.