### PR TITLE
Use ExternalID in NodeStageVolume RPC

### DIFF
--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -166,7 +166,7 @@ func (v *volumeManager) stageVolume(ctx context.Context, vol *structs.CSIVolume,
 	// CSI NodeStageVolume errors for timeout, codes.Unavailable and
 	// codes.ResourceExhausted are retried; all other errors are fatal.
 	return v.plugin.NodeStageVolume(ctx,
-		vol.ID,
+		vol.ExternalID,
 		publishContext,
 		pluginStagingPath,
 		capability,

--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -166,7 +166,7 @@ func (v *volumeManager) stageVolume(ctx context.Context, vol *structs.CSIVolume,
 	// CSI NodeStageVolume errors for timeout, codes.Unavailable and
 	// codes.ResourceExhausted are retried; all other errors are fatal.
 	return v.plugin.NodeStageVolume(ctx,
-		vol.ExternalID,
+		vol.RemoteID(),
 		publishContext,
 		pluginStagingPath,
 		capability,


### PR DESCRIPTION
This resolves an issue with the gcp-compute-persistent-disk-csi-driver where a volume will fail to mount with the following error:

```
2020-04-20T13:25:29Z  Setup Failure  failed to setup alloc: pre-run hook "csi_hook" failed: rpc error: code = InvalidArgument desc = NodeStageVolume Volume ID is invalid: failed to get id components. Expected projects/{project}/zones/{zone}/disks/{name}. Got: mysql
```

