### PR TITLE
Docs: correct search API

### DIFF
--- a/website/pages/api-docs/search.mdx
+++ b/website/pages/api-docs/search.mdx
@@ -69,6 +69,12 @@ $ curl \
 }
 ```
 
+#### Field Reference
+
+- `Matches` - A map of contexts to matching arrays of identifiers.
+
+- `Truncations` - Search results are capped at 20; if more matches were found for a particular context, it will be `true`.
+
 ### Sample Payload (for all contexts)
 
 ```javascript

--- a/website/pages/api-docs/search.mdx
+++ b/website/pages/api-docs/search.mdx
@@ -80,7 +80,7 @@ $ curl \
 ```javascript
 {
   "Prefix": "abc",
-  "Context": ""
+  "Context": "all"
 }
 ```
 

--- a/website/pages/api-docs/search.mdx
+++ b/website/pages/api-docs/search.mdx
@@ -39,43 +39,6 @@ job related results will not be returned. If the token is only valid for
   "deployment", "plugins", "volumes" or "all", where "all" means every
   context will be searched.
 
-### Sample Payload (for a specific context)
-
-```javascript
-{
-  "Prefix": "abc",
-  "Context": "evals"
-}
-```
-
-### Sample Request
-
-```shell
-$ curl \
-    --request POST \
-    --data @payload.json \
-    https://localhost:4646/v1/search
-```
-
-### Sample Response
-
-```json
-{
-  "Matches": {
-    "evals": ["abc2fdc0-e1fd-2536-67d8-43af8ca798ac"]
-  },
-  "Truncations": {
-    "evals": "false"
-  }
-}
-```
-
-#### Field Reference
-
-- `Matches` - A map of contexts to matching arrays of identifiers.
-
-- `Truncations` - Search results are capped at 20; if more matches were found for a particular context, it will be `true`.
-
 ### Sample Payload (for all contexts)
 
 ```javascript
@@ -115,6 +78,43 @@ $ curl \
     "nodes": "false",
     "plugins": "false",
     "volumes": "false"
+  }
+}
+```
+
+#### Field Reference
+
+- `Matches` - A map of contexts to matching arrays of identifiers.
+
+- `Truncations` - Search results are capped at 20; if more matches were found for a particular context, it will be `true`.
+
+### Sample Payload (for a specific context)
+
+```javascript
+{
+  "Prefix": "abc",
+  "Context": "evals"
+}
+```
+
+### Sample Request
+
+```shell
+$ curl \
+    --request POST \
+    --data @payload.json \
+    https://localhost:4646/v1/search
+```
+
+### Sample Response
+
+```json
+{
+  "Matches": {
+    "evals": ["abc2fdc0-e1fd-2536-67d8-43af8ca798ac"]
+  },
+  "Truncations": {
+    "evals": "false"
   }
 }
 ```

--- a/website/pages/api-docs/search.mdx
+++ b/website/pages/api-docs/search.mdx
@@ -8,9 +8,9 @@ description: The /search endpoint is used to search for Nomad objects
 # Search HTTP API
 
 The `/search` endpoint returns matches for a given prefix and context, where a
-context can be jobs, allocations, evaluations, nodes, or deployments. When using
-Nomad Enterprise, the allowed contexts include quotas and namespaces.
-Additionally, a prefix can be searched for within every context.
+context can be jobs, allocations, evaluations, nodes, deployments, plugins,
+or volumes. When using Nomad Enterprise, the allowed contexts include quotas
+and namespaces. Additionally, a prefix can be searched for within every context.
 
 | Method | Path         | Produces           |
 | ------ | ------------ | ------------------ |
@@ -36,7 +36,8 @@ job related results will not be returned. If the token is only valid for
   matches might be "abcd", or "aabb".
 - `Context` `(string: <required>)` - Defines the scope in which a search for a
   prefix operates. Contexts can be: "jobs", "evals", "allocs", "nodes",
-  "deployment" or "all", where "all" means every context will be searched.
+  "deployment", "plugins", "volumes" or "all", where "all" means every
+  context will be searched.
 
 ### Sample Payload (for a specific context)
 
@@ -102,14 +103,18 @@ $ curl \
     "deployment": null,
     "evals": ["abc2fdc0-e1fd-2536-67d8-43af8ca798ac"],
     "jobs": ["abcde"],
-    "nodes": null
+    "nodes": null,
+    "plugins": null,
+    "volumes": null
   },
   "Truncations": {
     "allocs": "false",
     "deployment": "false",
     "evals": "false",
     "jobs": "false",
-    "nodes": "false"
+    "nodes": "false",
+    "plugins": "false",
+    "volumes": "false"
   }
 }
 ```

--- a/website/pages/api-docs/search.mdx
+++ b/website/pages/api-docs/search.mdx
@@ -98,11 +98,11 @@ $ curl \
 ```json
 {
   "Matches": {
-    "allocs": [],
-    "deployment": [],
+    "allocs": null,
+    "deployment": null,
     "evals": ["abc2fdc0-e1fd-2536-67d8-43af8ca798ac"],
     "jobs": ["abcde"],
-    "nodes": []
+    "nodes": null
   },
   "Truncations": {
     "allocs": "false",


### PR DESCRIPTION
This closes #7718.

An editorial choice: moving the `all` context search above the specific one; I think this makes the field reference more useful.