### PR TITLE
csi: nil-check allocs for claim methods

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2144,14 +2144,16 @@ func (s *StateStore) CSIVolumeDenormalizePlugins(ws memdb.WatchSet, vol *structs
 	return vol, nil
 }
 
-// csiVolumeDenormalizeAllocs returns a CSIVolume with allocations
+// CSIVolumeDenormalize returns a CSIVolume with allocations
 func (s *StateStore) CSIVolumeDenormalize(ws memdb.WatchSet, vol *structs.CSIVolume) (*structs.CSIVolume, error) {
 	for id := range vol.ReadAllocs {
 		a, err := s.AllocByID(ws, id)
 		if err != nil {
 			return nil, err
 		}
-		vol.ReadAllocs[id] = a
+		if a != nil {
+			vol.ReadAllocs[id] = a
+		}
 	}
 
 	for id := range vol.WriteAllocs {
@@ -2159,7 +2161,9 @@ func (s *StateStore) CSIVolumeDenormalize(ws memdb.WatchSet, vol *structs.CSIVol
 		if err != nil {
 			return nil, err
 		}
-		vol.WriteAllocs[id] = a
+		if a != nil {
+			vol.WriteAllocs[id] = a
+		}
 	}
 
 	return vol, nil

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -368,6 +368,9 @@ func (v *CSIVolume) Claim(claim CSIVolumeClaimMode, alloc *Allocation) error {
 
 // ClaimRead marks an allocation as using a volume read-only
 func (v *CSIVolume) ClaimRead(alloc *Allocation) error {
+	if alloc == nil {
+		return fmt.Errorf("allocation missing")
+	}
 	if _, ok := v.ReadAllocs[alloc.ID]; ok {
 		return nil
 	}
@@ -385,6 +388,9 @@ func (v *CSIVolume) ClaimRead(alloc *Allocation) error {
 
 // ClaimWrite marks an allocation as using a volume as a writer
 func (v *CSIVolume) ClaimWrite(alloc *Allocation) error {
+	if alloc == nil {
+		return fmt.Errorf("allocation missing")
+	}
 	if _, ok := v.WriteAllocs[alloc.ID]; ok {
 		return nil
 	}
@@ -411,6 +417,9 @@ func (v *CSIVolume) ClaimWrite(alloc *Allocation) error {
 
 // ClaimRelease is called when the allocation has terminated and already stopped using the volume
 func (v *CSIVolume) ClaimRelease(alloc *Allocation) error {
+	if alloc == nil {
+		return fmt.Errorf("allocation missing")
+	}
 	delete(v.ReadAllocs, alloc.ID)
 	delete(v.WriteAllocs, alloc.ID)
 	return nil


### PR DESCRIPTION
For https://github.com/hashicorp/nomad/issues/7712

Although https://github.com/hashicorp/nomad/pull/7708 has a longer-term fix, this patch should prevent a reported panic.