### PR TITLE
demo: create build scripts for our countdash demo

### DIFF
--- a/demo/countdash/README.md
+++ b/demo/countdash/README.md
@@ -1,0 +1,33 @@
+# countdash
+
+Nomad makes use of the [demo-consul-101](https://github.com/hashicorp/demo-consul-101)
+education material throughout our examples for using Consul Connect. There are many
+example jobs that launch tasks with [counting-service](https://github.com/hashicorp/demo-consul-101/tree/master/services/counting-service)
+and [dashboard-service](https://github.com/hashicorp/demo-consul-101/tree/master/services/dashboard-service)
+configured to communicate under various conditions.
+
+## Publishing
+
+When making changes to the `countdash` demo, open a PR against the [demo-consul-101](https://github.com/hashicorp/demo-consul-101)
+project. Be sure to preserve backwards compatibility, as these demo files are used
+extensively, including with other Consul integrations.
+
+The docker images specific to Nomad can be rebuilt using [counter-dashboard](counter-dashboard/Dockerfile)
+and [counter-api](counter-api/Dockerfile).
+
+#### Testing locally
+```bash
+$ docker build -t hashicorpnomad/counter-api:test .
+$ docker build -t hashicorpnomad/counter-dashboard:test .
+
+$ docker run --rm --net=host hashicorpnomad/counter-api:test
+$ docker run --rm --net=host --env COUNTING_SERVICE_URL="http://localhost:9001" hashicorpnomad/counter-dashboard:test
+```
+
+#### Upload to Docker Hub
+```bash
+# replace <version> with the next version number
+docker login
+docker build -t hashicorpnomad/counter-dashboard:<version> .
+docker push hashicorpnomad/counter-dashboard:<version>
+```

--- a/demo/countdash/counter-api/Dockerfile
+++ b/demo/countdash/counter-api/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:alpine as builder
+WORKDIR /build
+ADD ./Dockerfile /build
+
+RUN apk add git && \
+    git clone -b 0.0.3 https://github.com/hashicorp/demo-consul-101.git
+
+WORKDIR /build/demo-consul-101/services/counting-service
+ADD ./go.mod .
+
+RUN go version && \
+    go env && \
+    go generate && \
+    GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build
+
+FROM alpine:latest
+MAINTAINER nomadproject.io
+
+WORKDIR /opt
+COPY --from=builder /build/demo-consul-101/services/counting-service/counter-api /opt
+
+EXPOSE 9001
+ENV PORT 9001
+
+ENTRYPOINT ["/opt/counter-api"]

--- a/demo/countdash/counter-api/go.mod
+++ b/demo/countdash/counter-api/go.mod
@@ -1,0 +1,1 @@
+module nomadproject.io/demo/counter-api

--- a/demo/countdash/counter-dashboard/Dockerfile
+++ b/demo/countdash/counter-dashboard/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:alpine as builder
+WORKDIR /build
+ADD ./Dockerfile /build
+
+RUN apk add git && \
+    git clone -b 0.0.3 https://github.com/hashicorp/demo-consul-101.git
+
+WORKDIR /build/demo-consul-101/services/dashboard-service
+ADD ./go.mod .
+
+RUN go version && \
+    go env && \
+    go generate && \
+    GO111MODULE=on go run github.com/GeertJohan/go.rice/rice embed-go && \
+    GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build
+
+FROM alpine:latest
+MAINTAINER nomadproject.io
+
+WORKDIR /opt
+COPY --from=builder /build/demo-consul-101/services/dashboard-service/counter-dashboard /opt
+
+EXPOSE 9002
+ENV PORT 9002
+
+ENTRYPOINT ["/opt/counter-dashboard"]

--- a/demo/countdash/counter-dashboard/go.mod
+++ b/demo/countdash/counter-dashboard/go.mod
@@ -1,0 +1,5 @@
+module nomadproject.io/demo/counter-dashboard
+
+require (
+    github.com/GeertJohan/go.rice v1.0.0
+)


### PR DESCRIPTION
We use the education team's "countdash" demo in many places
to showcase Nomad's Consul Connect integration. This change
adds a Dockerfile for each of `counter-dashboard` and
`counter-api` that can be used to build artifacts to publish
to Nomad's Docker Hub organization.

The recent "0.0.3" release of the `countdash` demo includes
changes we want in order to demo task group service checks.