### PR TITLE
parsing should error if scaling block includes multiple policy blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.11.2 (Unreleased)
 
+BUG FIXES:
+
+ * api: autoscaling policies should not be returned for stopped jobs [[GH-7768](https://github.com/hashicorp/nomad/issues/7768)]
+ * jobspec: autoscaling policy block should return a parsing error multiple `policy` blocks are provided [[GH-7716](https://github.com/hashicorp/nomad/issues/7716)]
+
 ## 0.11.1 (April 22, 2020)
 
 BUG FIXES:

--- a/jobspec/parse_group.go
+++ b/jobspec/parse_group.go
@@ -366,15 +366,16 @@ func parseScalingPolicy(out **api.ScalingPolicy, list *ast.ObjectList) error {
 
 	// If we have policy, then parse that
 	if o := listVal.Filter("policy"); len(o.Items) > 0 {
-		for _, o := range o.Elem().Items {
-			var m map[string]interface{}
-			if err := hcl.DecodeObject(&m, o.Val); err != nil {
-				return err
-			}
-
-			if err := mapstructure.WeakDecode(m, &result.Policy); err != nil {
-				return err
-			}
+		if len(o.Elem().Items) > 1 {
+			return fmt.Errorf("only one 'policy' block allowed per 'scaling' block")
+		}
+		p := o.Elem().Items[0]
+		var m map[string]interface{}
+		if err := hcl.DecodeObject(&m, p.Val); err != nil {
+			return err
+		}
+		if err := mapstructure.WeakDecode(m, &result.Policy); err != nil {
+			return err
 		}
 	}
 

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1310,6 +1310,32 @@ func TestParse(t *testing.T) {
 			},
 			false,
 		},
+
+		{
+			"tg-scaling-policy-minimal.hcl",
+			&api.Job{
+				ID:   helper.StringToPtr("elastic"),
+				Name: helper.StringToPtr("elastic"),
+				TaskGroups: []*api.TaskGroup{
+					{
+						Name: helper.StringToPtr("group"),
+						Scaling: &api.ScalingPolicy{
+							Min:     nil,
+							Max:     0,
+							Policy:  nil,
+							Enabled: nil,
+						},
+					},
+				},
+			},
+			false,
+		},
+
+		{
+			"tg-scaling-policy-multi-policy.hcl",
+			nil,
+			true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/jobspec/test-fixtures/tg-scaling-policy-minimal.hcl
+++ b/jobspec/test-fixtures/tg-scaling-policy-minimal.hcl
@@ -1,0 +1,6 @@
+job "elastic" {
+  group "group" {
+    scaling {
+    }
+  }
+}

--- a/jobspec/test-fixtures/tg-scaling-policy-multi-policy.hcl
+++ b/jobspec/test-fixtures/tg-scaling-policy-multi-policy.hcl
@@ -1,0 +1,20 @@
+job "elastic" {
+  group "group" {
+    scaling {
+      enabled = false
+      min     = 5
+      max     = 100
+
+      policy {
+        foo = "right"
+        b   = true
+      }
+
+      policy {
+        foo = "wrong"
+        c = false
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
resolves #7716 

updated scaling policy parsing so that multiple policy blocks result in an error (previously, they were merged). also expanded testing to make sure that a minimal block doesn't return an error (these checks are performed later during job validation)