### PR TITLE
website: fix path for spellchecking and correct errors

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -200,7 +200,7 @@ check: ## Lint the source code
 	@golangci-lint run -j 1
 
 	@echo "==> Spell checking website..."
-	@misspell -error -source=text website/source/
+	@misspell -error -source=text website/pages/
 
 	@echo "==> Check proto files are in-sync..."
 	@$(MAKE) proto

--- a/website/pages/docs/job-specification/scaling.mdx
+++ b/website/pages/docs/job-specification/scaling.mdx
@@ -35,11 +35,11 @@ job "example" {
 
 ## `scaling` Parameters
 
-- `min` - <code>(int: nil)</code> - The minimum acceptible count for the task group.
+- `min` - <code>(int: nil)</code> - The minimum acceptable count for the task group.
   This should be honored by the external autoscaler. It will also be honored by Nomad
   during job updates and scaling operations. Defaults to the specified task group [count][].
 
-- `max` - <code>(int: &lt;required&gt;)</code> - The maximum acceptible count for the task group.
+- `max` - <code>(int: &lt;required&gt;)</code> - The maximum acceptable count for the task group.
   This should be honored by the external autoscaler. It will also be honored by Nomad
   during job updates and scaling operations.
 

--- a/website/pages/docs/job-specification/volume.mdx
+++ b/website/pages/docs/job-specification/volume.mdx
@@ -47,7 +47,7 @@ the [volume_mount][volume_mount] stanza in the `task` configuration.
 - `source` `(string: <required>)` - The name of the volume to
   request. When using `host_volume`'s this should match the published
   name of the host volume. When using `csi` volumes, this should match
-  the ID of the registed volume.
+  the ID of the registered volume.
 
 - `read_only` `(bool: false)` - Specifies that the group only requires
   read only access to a volume and is used as the default value for


### PR DESCRIPTION
When we updated the website source, we didn't update the linter for spell-checking. This fixes the linter and some errors that crept in.