### PR TITLE
hcllint: add a linting check for HCL files

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -204,7 +204,11 @@ check: ## Lint the source code
 
 	@echo "==> Check proto files are in-sync..."
 	@$(MAKE) proto
-	@if (git status | grep -q .pb.go); then echo the following proto files are out of sync; git status |grep .pb.go; exit 1; fi
+	@if (git status -s | grep -q .pb.go); then echo the following proto files are out of sync; git status -s | grep .pb.go; exit 1; fi
+
+	@echo "==> Check format of jobspecs and HCL files..."
+	@$(MAKE) hclfmt
+	@if (git status -s | grep -q -e '\.hcl$$' -e '\.nomad$$'); then echo the following HCL files are out of sync; git status -s | grep -e '\.hcl$$' -e '\.nomad$$'; exit 1; fi
 
 	@echo "==> Check API package is isolated from rest"
 	@if go list --test -f '{{ join .Deps "\n" }}' ./api | grep github.com/hashicorp/nomad/ | grep -v -e /vendor/ -e /nomad/api/ -e nomad/api.test; then echo "  /api package depends the ^^ above internal nomad packages.  Remove such dependency"; exit 1; fi

--- a/jobspec/test-fixtures/tg-scaling-policy-minimal.hcl
+++ b/jobspec/test-fixtures/tg-scaling-policy-minimal.hcl
@@ -1,6 +1,5 @@
 job "elastic" {
   group "group" {
-    scaling {
-    }
+    scaling {}
   }
 }

--- a/jobspec/test-fixtures/tg-scaling-policy-multi-policy.hcl
+++ b/jobspec/test-fixtures/tg-scaling-policy-multi-policy.hcl
@@ -12,9 +12,8 @@ job "elastic" {
 
       policy {
         foo = "wrong"
-        c = false
+        c   = false
       }
-
     }
   }
 }

--- a/jobspec/test-fixtures/tg-service-connect-local-service.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-local-service.hcl
@@ -4,6 +4,7 @@ job "connect-proxy-local-service" {
   group "group" {
     service {
       name = "example"
+
       connect {
         sidecar_service {
           proxy {

--- a/jobspec/test-fixtures/tg-service-connect-proxy.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-proxy.hcl
@@ -4,19 +4,23 @@ job "service-connect-proxy" {
   group "group" {
     service {
       name = "example"
+
       connect {
         sidecar_service {
           proxy {
             local_service_port    = 8080
             local_service_address = "10.0.1.2"
+
             upstreams {
               destination_name = "upstream1"
               local_bind_port  = 2001
             }
+
             upstreams {
               destination_name = "upstream2"
               local_bind_port  = 2002
             }
+
             expose {
               path {
                 path            = "/metrics"
@@ -24,6 +28,7 @@ job "service-connect-proxy" {
                 local_path_port = 9001
                 listener_port   = "metrics"
               }
+
               path {
                 path            = "/health"
                 protocol        = "http"
@@ -31,6 +36,7 @@ job "service-connect-proxy" {
                 listener_port   = "health"
               }
             }
+
             config {
               foo = "bar"
             }

--- a/jobspec/test-fixtures/tg-service-connect-sidecar_task-name.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-sidecar_task-name.hcl
@@ -4,8 +4,10 @@ job "sidecar_task_name" {
   group "group" {
     service {
       name = "example"
+
       connect {
-        sidecar_service {}
+        sidecar_service = {}
+
         sidecar_task {
           name = "my-sidecar"
         }


### PR DESCRIPTION
Running `make dev` runs `hclfmt`, but this isn't checked as part of CI. That makes it possible to merge un-formatted HCL and Nomad jobspecs that later will make for dirty git staging areas when developers pull master. (Examples: https://github.com/hashicorp/nomad/pull/7584 https://github.com/hashicorp/nomad/pull/7011 https://github.com/hashicorp/nomad/pull/6724)

This adds a `make hcllint` target and wires it up to CI. Note that `hclfmt` doesn't return a non-0 exit code if it makes changes, which is why we can't just re-use `make hclfmt` here.

---

Looks like the following when run:

```
▶ make hcllint
6a7
>
17c18
< }
\ No newline at end of file
---
> }
6a7
>
11a13
>
15a18
>
19a23
>
26a31
>
33a39
>
42c48
< }
\ No newline at end of file
---
> }
6a7
>
8c9,10
<         sidecar_service {}
---
>         sidecar_service = {}
>
15c17
< }
\ No newline at end of file
---
> }
make: *** [hcllint] Error 1

▶ echo $?
2

▶ make hclfmt
--> Formatting HCL

▶ make hcllint

▶ echo $?
0
```