### PR TITLE
Disable dangling container GC for demo

### DIFF
--- a/demo/vagrant/client1.hcl
+++ b/demo/vagrant/client1.hcl
@@ -21,3 +21,16 @@ client {
 ports {
   http = 5656
 }
+
+# Because we will potentially have two clients talking to the same
+# Docker daemon, we have to disable the dangling container cleanup,
+# otherwise they will stop each other's work thinking it was orphaned.
+plugin "docker" {
+  config {
+    gc {
+      dangling_containers {
+        enabled = false
+      }
+    }
+  }
+}

--- a/demo/vagrant/client2.hcl
+++ b/demo/vagrant/client2.hcl
@@ -21,3 +21,16 @@ client {
 ports {
   http = 5657
 }
+
+# Because we will potentially have two clients talking to the same
+# Docker daemon, we have to disable the dangling container cleanup,
+# otherwise they will stop each other's work thinking it was orphaned.
+plugin "docker" {
+  config {
+    gc {
+      dangling_containers {
+        enabled = false
+      }
+    }
+  }
+}


### PR DESCRIPTION
A learner reported that their Docker workloads were being killed while doing the Getting Started guide. Since this environment uses the same node as client1 and client2, they end up using the same Docker daemon to execute their work.  However, the dangling container cleanup logic does not realize that these are from two different clients and cleans up the containers that do not belong to it, which makes the work die and restart.

Including the configuration to disable this for this demo environment prevents the issue.