### PR TITLE
nomad: build dynamic port for exposed checks if not specified

### DIFF
--- a/nomad/job_endpoint_hook_expose_check.go
+++ b/nomad/job_endpoint_hook_expose_check.go
@@ -233,9 +233,7 @@ func exposePathForCheck(tg *structs.TaskGroup, s *structs.Service, check *struct
 	}
 
 	// The Path, Protocol, and PortLabel are just copied over from the service
-	// check definition. It is required that the user configure their own port
-	// mapping for each check, including setting the 'to = -1' sentinel value
-	// enabling the network namespace pass-through.
+	// check definition.
 	return &structs.ConsulExposePath{
 		Path:          check.Path,
 		Protocol:      check.Protocol,


### PR DESCRIPTION
This PR makes allocation a port for exposed checks optional and will instead build a dynamic port with an unique label if the check port is not set.