### PR TITLE
[docs] Update credential helper example in docker.mdx

### DIFF
--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -490,7 +490,9 @@ client {
 plugin "docker" {
   config {
     auth {
-      helper = "docker-credential-ecr"
+      # Nomad will prepend "docker-credential-" to the helper value and call 
+      # that script name.  
+      helper = "ecr"
     }
   }
 }


### PR DESCRIPTION
Example shouldn’t have “docker-credential-“ as part of the value, because it is added by the driver. 