### PR TITLE
docker: use constant from nvidia

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -21,6 +21,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/taskenv"
+	"github.com/hashicorp/nomad/devices/gpu/nvidia"
 	"github.com/hashicorp/nomad/drivers/docker/docklog"
 	"github.com/hashicorp/nomad/drivers/shared/eventer"
 	nstructs "github.com/hashicorp/nomad/nomad/structs"
@@ -64,9 +65,6 @@ var (
 	// taskHandleVersion is the version of task handle which this driver sets
 	// and understands how to decode driver state
 	taskHandleVersion = 1
-
-	// Nvidia-container-runtime environment variable names
-	nvidiaVisibleDevices = "NVIDIA_VISIBLE_DEVICES"
 )
 
 const (
@@ -759,7 +757,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		PidsLimit: &driverConfig.PidsLimit,
 	}
 
-	if _, ok := task.DeviceEnv[nvidiaVisibleDevices]; ok {
+	if _, ok := task.DeviceEnv[nvidia.NvidiaVisibleDevices]; ok {
 		if !d.gpuRuntime {
 			return c, fmt.Errorf("requested docker-runtime %q was not found", d.config.GPURuntimeName)
 		}


### PR DESCRIPTION
the test is using the constant from nvidia when the driver redefines it.