### PR TITLE
spread scheduling algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 FEATURES:
  * **Task dependencies UI**: task lifecycle charts and details
 
+IMPROVEMENTS:
+
+ * core: Allow spreading allocations as an alternative to binpacking [[GH-7810](https://github.com/hashicorp/nomad/issues/7810)]
+
 BUG FIXES:
 
  * api: autoscaling policies should not be returned for stopped jobs [[GH-7768](https://github.com/hashicorp/nomad/issues/7768)]

--- a/api/operator.go
+++ b/api/operator.go
@@ -112,7 +112,11 @@ func (op *Operator) RaftRemovePeerByID(id string, q *WriteOptions) error {
 	return nil
 }
 
+// SchedulerConfiguration is the config for controlling scheduler behavior
 type SchedulerConfiguration struct {
+	// SchedulerAlgorithm lets you select between available scheduling algorithms.
+	SchedulerAlgorithm string
+
 	// PreemptionConfig specifies whether to enable eviction of lower
 	// priority jobs to place higher priority jobs.
 	PreemptionConfig PreemptionConfig
@@ -139,6 +143,11 @@ type SchedulerSetConfigurationResponse struct {
 
 	WriteMeta
 }
+
+// SchedulerAlgorithm is an enum string that encapsulates the valid options for a
+// SchedulerConfiguration stanza's SchedulerAlgorithm. These modes will allow the
+// scheduler to be user-selectable.
+type SchedulerAlgorithm string
 
 // PreemptionConfig specifies whether preemption is enabled based on scheduler type
 type PreemptionConfig struct {

--- a/api/operator.go
+++ b/api/operator.go
@@ -115,7 +115,7 @@ func (op *Operator) RaftRemovePeerByID(id string, q *WriteOptions) error {
 // SchedulerConfiguration is the config for controlling scheduler behavior
 type SchedulerConfiguration struct {
 	// SchedulerAlgorithm lets you select between available scheduling algorithms.
-	SchedulerAlgorithm string
+	SchedulerAlgorithm SchedulerAlgorithm
 
 	// PreemptionConfig specifies whether to enable eviction of lower
 	// priority jobs to place higher priority jobs.
@@ -148,6 +148,11 @@ type SchedulerSetConfigurationResponse struct {
 // SchedulerConfiguration stanza's SchedulerAlgorithm. These modes will allow the
 // scheduler to be user-selectable.
 type SchedulerAlgorithm string
+
+const (
+	SchedulerAlgorithmBinpack SchedulerAlgorithm = "binpack"
+	SchedulerAlgorithmSpread  SchedulerAlgorithm = "spread"
+)
 
 // PreemptionConfig specifies whether preemption is enabled based on scheduler type
 type PreemptionConfig struct {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -184,6 +184,7 @@ func TestAgent_ServerConfig_SchedulerFlags(t *testing.T) {
 			"default case",
 			nil,
 			structs.SchedulerConfiguration{
+				SchedulerAlgorithm: "binpack",
 				PreemptionConfig: structs.PreemptionConfig{
 					SystemSchedulerEnabled: true,
 				},

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -377,6 +377,11 @@ func (c *Command) isValidConfig(config, cmdConfig *Config) bool {
 		c.Ui.Error("WARNING: Bootstrap mode enabled! Potentially unsafe operation.")
 	}
 
+	if err := config.Server.DefaultSchedulerConfig.Validate(); err != nil {
+		c.Ui.Error(err.Error())
+		return false
+	}
+
 	return true
 }
 

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -126,6 +126,7 @@ var basicConfig = &Config{
 			RetryMaxAttempts: 3,
 		},
 		DefaultSchedulerConfig: &structs.SchedulerConfiguration{
+			SchedulerAlgorithm: "spread",
 			PreemptionConfig: structs.PreemptionConfig{
 				SystemSchedulerEnabled:  true,
 				BatchSchedulerEnabled:   true,

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -253,16 +253,16 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 		return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("Error parsing scheduler config: %v", err))
 	}
 
-	if !structs.SchedulerAlgorithmIsValid(conf.SchedulerAlgorithm) {
-		return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("Invalid scheduler algorithm selected."))
-	}
-
 	args.Config = structs.SchedulerConfiguration{
-		SchedulerAlgorithm: conf.SchedulerAlgorithm,
+		SchedulerAlgorithm: structs.SchedulerAlgorithm(conf.SchedulerAlgorithm),
 		PreemptionConfig: structs.PreemptionConfig{
 			SystemSchedulerEnabled:  conf.PreemptionConfig.SystemSchedulerEnabled,
 			BatchSchedulerEnabled:   conf.PreemptionConfig.BatchSchedulerEnabled,
 			ServiceSchedulerEnabled: conf.PreemptionConfig.ServiceSchedulerEnabled},
+	}
+
+	if err := args.Config.Validate(); err != nil {
+		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Check for cas value

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/raft"
 )
 
+// OperatorRequest is used route operator/raft API requests to the implementing
+// functions.
 func (s *HTTPServer) OperatorRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	path := strings.TrimPrefix(req.URL.Path, "/v1/operator/raft/")
 	switch {
@@ -251,7 +253,12 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 		return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("Error parsing scheduler config: %v", err))
 	}
 
+	if !structs.SchedulerAlgorithmIsValid(conf.SchedulerAlgorithm) {
+		return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("Invalid scheduler algorithm selected."))
+	}
+
 	args.Config = structs.SchedulerConfiguration{
+		SchedulerAlgorithm: conf.SchedulerAlgorithm,
 		PreemptionConfig: structs.PreemptionConfig{
 			SystemSchedulerEnabled:  conf.PreemptionConfig.SystemSchedulerEnabled,
 			BatchSchedulerEnabled:   conf.PreemptionConfig.BatchSchedulerEnabled,

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -135,6 +135,8 @@ server {
   }
 
   default_scheduler_config {
+    scheduler_algorithm = "spread"
+
     preemption_config {
       batch_scheduler_enabled   = true
       system_scheduler_enabled  = true

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -297,6 +297,7 @@
         "2.2.2.2"
       ],
       "default_scheduler_config": [{
+        "scheduler_algorithm": "spread",
         "preemption_config": [{
           "batch_scheduler_enabled": true,
           "system_scheduler_enabled": true,

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -403,6 +403,7 @@ func DefaultConfig() *Config {
 		ServerHealthInterval: 2 * time.Second,
 		AutopilotInterval:    10 * time.Second,
 		DefaultSchedulerConfig: structs.SchedulerConfiguration{
+			SchedulerAlgorithm: structs.SchedulerAlgorithmBinpack,
 			PreemptionConfig: structs.PreemptionConfig{
 				SystemSchedulerEnabled:  true,
 				BatchSchedulerEnabled:   false,

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -151,7 +151,7 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 // ScoreFit is used to score the fit based on the Google work published here:
 // http://www.columbia.edu/~cs2035/courses/ieor4405.S13/datacenter_scheduling.ppt
 // This is equivalent to their BestFit v3
-func ScoreFit(node *Node, util *ComparableResources) float64 {
+func ScoreFit(node *Node, util *ComparableResources, algorithm string) float64 {
 	// COMPAT(0.11): Remove in 0.11
 	reserved := node.ComparableReservedResources()
 	res := node.ComparableResources()
@@ -176,6 +176,9 @@ func ScoreFit(node *Node, util *ComparableResources) float64 {
 	// score. Because the floor is 20, we simply use that as an anchor.
 	// This means at a perfect fit, we return 18 as the score.
 	score := 20.0 - total
+	if algorithm == "spread" {
+		score = total - 2
+	}
 
 	// Bound the score, just in case
 	// If the score is over 18, that means we've overfit the node.

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -592,7 +592,7 @@ func TestScoreFitBinPack(t *testing.T) {
 		spreadScore  float64
 	}{
 		{
-			name: "almost filled node, but with just enough whole",
+			name: "almost filled node, but with just enough hole",
 			flattened: AllocatedTaskResources{
 				Cpu:    AllocatedCpuResources{CpuShares: 2048},
 				Memory: AllocatedMemoryResources{MemoryMB: 4096},

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -124,8 +124,37 @@ type AutopilotConfig struct {
 	ModifyIndex uint64
 }
 
+// SchedulerAlgorithm is an enum string that encapsulates the valid options for a
+// SchedulerConfiguration stanza's SchedulerAlgorithm. These modes will allow the
+// scheduler to be user-selectable.
+type SchedulerAlgorithm string
+
+const (
+	// SchedulerAlgorithmBinpack indicates that the scheduler should spread
+	// allocations as evenly as possible over the available hardware.
+	SchedulerAlgorithmBinpack string = "binpack"
+
+	// SchedulerAlgorithmSpread indicates that the scheduler should spread
+	// allocations as evenly as possible over the available hardware.
+	SchedulerAlgorithmSpread string = "spread"
+)
+
+// SchedulerAlgorithmIsValid validates the given SchedulerAlgorithm string and
+// returns true only when a correct algorithm is specified.
+func SchedulerAlgorithmIsValid(alg string) bool {
+	switch alg {
+	case SchedulerAlgorithmBinpack, SchedulerAlgorithmSpread:
+		return true
+	default:
+		return false
+	}
+}
+
 // SchedulerConfiguration is the config for controlling scheduler behavior
 type SchedulerConfiguration struct {
+	// SchedulerAlgorithm lets you select between available scheduling algorithms.
+	SchedulerAlgorithm string `hcl:"scheduler_algorithm"`
+
 	// PreemptionConfig specifies whether to enable eviction of lower
 	// priority jobs to place higher priority jobs.
 	PreemptionConfig PreemptionConfig `hcl:"preemption_config"`

--- a/scheduler/preemption_test.go
+++ b/scheduler/preemption_test.go
@@ -1349,7 +1349,7 @@ func TestPreemption(t *testing.T) {
 				ctx.plan.NodePreemptions[node.ID] = tc.currentPreemptions
 			}
 			static := NewStaticRankIterator(ctx, nodes)
-			binPackIter := NewBinPackIterator(ctx, static, true, tc.jobPriority)
+			binPackIter := NewBinPackIterator(ctx, static, true, tc.jobPriority, structs.SchedulerAlgorithmBinpack)
 			job := mock.Job()
 			job.Priority = tc.jobPriority
 			binPackIter.SetJob(job)

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -151,19 +151,22 @@ type BinPackIterator struct {
 	source    RankIterator
 	evict     bool
 	priority  int
+	algorithm string
 	jobId     *structs.NamespacedID
 	taskGroup *structs.TaskGroup
 }
 
 // NewBinPackIterator returns a BinPackIterator which tries to fit tasks
 // potentially evicting other tasks based on a given priority.
-func NewBinPackIterator(ctx Context, source RankIterator, evict bool, priority int) *BinPackIterator {
+func NewBinPackIterator(ctx Context, source RankIterator, evict bool, priority int, algorithm string) *BinPackIterator {
 	iter := &BinPackIterator{
-		ctx:      ctx,
-		source:   source,
-		evict:    evict,
-		priority: priority,
+		ctx:       ctx,
+		source:    source,
+		evict:     evict,
+		priority:  priority,
+		algorithm: algorithm,
 	}
+	iter.ctx.Logger().Named("binpack").Trace("NewBinPackIterator created", "algorithm", algorithm)
 	return iter
 }
 
@@ -436,7 +439,7 @@ OUTER:
 		}
 
 		// Score the fit normally otherwise
-		fitness := structs.ScoreFit(option.Node, util)
+		fitness := structs.ScoreFit(option.Node, util, iter.algorithm)
 		normalizedFit := fitness / binPackingMaxFitScore
 		option.Scores = append(option.Scores, normalizedFit)
 		iter.ctx.Metrics().ScoreNode(option.Node, "binpack", normalizedFit)

--- a/scheduler/rank_test.go
+++ b/scheduler/rank_test.go
@@ -107,7 +107,7 @@ func TestBinPackIterator_NoExistingAlloc(t *testing.T) {
 			},
 		},
 	}
-	binp := NewBinPackIterator(ctx, static, false, 0)
+	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -220,7 +220,7 @@ func TestBinPackIterator_NoExistingAlloc_MixedReserve(t *testing.T) {
 			},
 		},
 	}
-	binp := NewBinPackIterator(ctx, static, false, 0)
+	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -471,7 +471,7 @@ func TestBinPackIterator_Network_Failure(t *testing.T) {
 		},
 	}
 
-	binp := NewBinPackIterator(ctx, static, false, 0)
+	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -569,7 +569,7 @@ func TestBinPackIterator_PlannedAlloc(t *testing.T) {
 		},
 	}
 
-	binp := NewBinPackIterator(ctx, static, false, 0)
+	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -685,7 +685,7 @@ func TestBinPackIterator_ExistingAlloc(t *testing.T) {
 			},
 		},
 	}
-	binp := NewBinPackIterator(ctx, static, false, 0)
+	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -805,7 +805,7 @@ func TestBinPackIterator_ExistingAlloc_PlannedEvict(t *testing.T) {
 		},
 	}
 
-	binp := NewBinPackIterator(ctx, static, false, 0)
+	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -1110,7 +1110,7 @@ func TestBinPackIterator_Devices(t *testing.T) {
 			}
 
 			static := NewStaticRankIterator(ctx, []*RankedNode{{Node: c.Node}})
-			binp := NewBinPackIterator(ctx, static, false, 0)
+			binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
 			binp.SetTaskGroup(c.TaskGroup)
 
 			out := binp.Next()

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -237,11 +237,10 @@ func NewSystemStack(ctx Context) *SystemStack {
 	// by a particular task group. Enable eviction as system jobs are high
 	// priority.
 	_, schedConfig, _ := s.ctx.State().SchedulerConfig()
+	schedulerAlgorithm := schedConfig.EffectiveSchedulerAlgorithm()
 	enablePreemption := true
-	schedulerAlgorithm := "binpack"
 	if schedConfig != nil {
 		enablePreemption = schedConfig.PreemptionConfig.SystemSchedulerEnabled
-		schedulerAlgorithm = schedConfig.SchedulerAlgorithm
 	}
 
 	s.binPack = NewBinPackIterator(ctx, rankSource, enablePreemption, 0, schedulerAlgorithm)

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -238,10 +238,13 @@ func NewSystemStack(ctx Context) *SystemStack {
 	// priority.
 	_, schedConfig, _ := s.ctx.State().SchedulerConfig()
 	enablePreemption := true
+	schedulerAlgorithm := "binpack"
 	if schedConfig != nil {
 		enablePreemption = schedConfig.PreemptionConfig.SystemSchedulerEnabled
+		schedulerAlgorithm = schedConfig.SchedulerAlgorithm
 	}
-	s.binPack = NewBinPackIterator(ctx, rankSource, enablePreemption, 0)
+
+	s.binPack = NewBinPackIterator(ctx, rankSource, enablePreemption, 0, schedulerAlgorithm)
 
 	// Apply score normalization
 	s.scoreNorm = NewScoreNormalizationIterator(ctx, s.binPack)

--- a/scheduler/stack_oss.go
+++ b/scheduler/stack_oss.go
@@ -61,10 +61,7 @@ func NewGenericStack(batch bool, ctx Context) *GenericStack {
 	// Apply the bin packing, this depends on the resources needed
 	// by a particular task group.
 	_, schedConfig, _ := s.ctx.State().SchedulerConfig()
-	schedulerAlgorithm := "binpack"
-	if schedConfig != nil {
-		schedulerAlgorithm = schedConfig.SchedulerAlgorithm
-	}
+	schedulerAlgorithm := schedConfig.EffectiveSchedulerAlgorithm()
 
 	s.binPack = NewBinPackIterator(ctx, rankSource, false, 0, schedulerAlgorithm)
 

--- a/scheduler/stack_oss.go
+++ b/scheduler/stack_oss.go
@@ -60,7 +60,13 @@ func NewGenericStack(batch bool, ctx Context) *GenericStack {
 
 	// Apply the bin packing, this depends on the resources needed
 	// by a particular task group.
-	s.binPack = NewBinPackIterator(ctx, rankSource, false, 0)
+	_, schedConfig, _ := s.ctx.State().SchedulerConfig()
+	schedulerAlgorithm := "binpack"
+	if schedConfig != nil {
+		schedulerAlgorithm = schedConfig.SchedulerAlgorithm
+	}
+
+	s.binPack = NewBinPackIterator(ctx, rankSource, false, 0, schedulerAlgorithm)
 
 	// Apply the job anti-affinity iterator. This is to avoid placing
 	// multiple allocations on the same node for this job.


### PR DESCRIPTION
This PR introduces spread scheduling algorithm, as an alternative to binpacking.

In mostly-static clusters, some cluster operators prefer to spread the load rather than binpack them.  When spreading, clients will share the workload more evenly.  It also handles failures a bit more gracefully: if an allocation misbehaves and becomes a noisy neighbor by saturating IO or network (currently not isolated by nomad), it will affect less allocations.  Also, if a client becomes an unhealthy, the bounds on number of affected allocations will be tighter.

One significant downside of spreading is management of large allocations in fragmented clusters.  Consider a simple case: 2 nodes with 4GB each, each are running an allocation using 2GB; A new job requiring 3GB of RAM will fail to schedule despite the cluster having 4GB free RAM.  Though possible in binpacking algorithm, it's more likely under spread conditions.  Operators can mitigate this by ensuring that jobs require small fraction of each node resources, sparating large jobs to its own datacenter/region, and/or ensuring that job CPU/RAM requirements are similar.

### Implementation Details

This implementation adds a `SchedulerAlgorithm` option to the operator SchedulerConfiguration knob.

The flag controls the cluster/region level, so it's controlled by cluster operators, rather than job submitters.  Given the advantages (and disadvantages) affect overall cluster performance and management rather than individual jobs, it's operators that can control it.

Future iterations may allow for scheduler config options per datacenter or another layer of pooling.  Depending on demand, we can introduce a `per-DC` config override, for both this scheduling algorithm or for preemption too if demand raises.

@angrycub wrote most of the implementation.  I mostly did some cosmetic changes.