### PR TITLE
UI: Add workaround to exclude emoji from task escaping

### DIFF
--- a/ui/app/utils/escape-task-name.js
+++ b/ui/app/utils/escape-task-name.js
@@ -1,4 +1,4 @@
 export default function escapeTaskName(taskName) {
   // Regular expression is taken from here: https://stackoverflow.com/a/20053121
-  return taskName.replace(/[^a-zA-Z0-9,._+@%/-]/g, '\\$&');
+  return taskName.replace(/[^a-zA-Z0-9,._+@%/-]/gu, '\\$&');
 }

--- a/ui/tests/unit/utils/escape-task-name-test.js
+++ b/ui/tests/unit/utils/escape-task-name-test.js
@@ -6,5 +6,6 @@ module('Unit | Utility | escape-task-name', function() {
     assert.equal(escapeTaskName('plain'), 'plain');
     assert.equal(escapeTaskName('a space'), 'a\\ space');
     assert.equal(escapeTaskName('dollar $ign'), 'dollar\\ \\$ign');
+    assert.equal(escapeTaskName('emoji🥳'), 'emoji\\🥳');
   });
 });


### PR DESCRIPTION
This closes #7459.

While emoji don’t actually need escaping, expanding the
expression that enumerates all task name characters that
don’t need escaping to include emoji is prohibitive, since
it’s a discontinuous range. The emoji-regex project has
such an expression and it’s 12kB.

This fixes the regular expression to property escape emoji
as a single character instead of as its component bytes.
Thanks to @DingoEatingFuzz for the suggestion.