### PR TITLE
fix issues in Job.ScaleStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 
  * api: autoscaling policies should not be returned for stopped jobs [[GH-7768](https://github.com/hashicorp/nomad/issues/7768)]
+ * core: job scale status endpoint was returning incorrect counts [[GH-7789](https://github.com/hashicorp/nomad/issues/7789)]
  * jobspec: autoscaling policy block should return a parsing error multiple `policy` blocks are provided [[GH-7716](https://github.com/hashicorp/nomad/issues/7716)]
 
 ## 0.11.1 (April 22, 2020)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1806,10 +1806,6 @@ func (j *Job) ScaleStatus(args *structs.JobScaleStatusRequest,
 				reply.JobScaleStatus = nil
 				return nil
 			}
-			deployment, err := state.LatestDeploymentByJobID(ws, args.RequestNamespace(), args.JobID)
-			if err != nil {
-				return err
-			}
 
 			events, eventsIndex, err := state.ScalingEventsByJob(ws, args.RequestNamespace(), args.JobID)
 			if err != nil {
@@ -1817,6 +1813,13 @@ func (j *Job) ScaleStatus(args *structs.JobScaleStatusRequest,
 			}
 			if events == nil {
 				events = make(map[string][]*structs.ScalingEvent)
+			}
+
+			var allocs []*structs.Allocation
+			var allocsIndex uint64
+			allocs, err = state.AllocsByJob(ws, job.Namespace, job.ID, false)
+			if err != nil {
+				return err
 			}
 
 			// Setup the output
@@ -1832,23 +1835,44 @@ func (j *Job) ScaleStatus(args *structs.JobScaleStatusRequest,
 				tgScale := &structs.TaskGroupScaleStatus{
 					Desired: tg.Count,
 				}
-				if deployment != nil {
-					if ds, ok := deployment.TaskGroups[tg.Name]; ok {
-						tgScale.Placed = ds.PlacedAllocs
-						tgScale.Healthy = ds.HealthyAllocs
-						tgScale.Unhealthy = ds.UnhealthyAllocs
-					}
-				}
 				tgScale.Events = events[tg.Name]
 				reply.JobScaleStatus.TaskGroups[tg.Name] = tgScale
 			}
 
-			maxIndex := job.ModifyIndex
-			if deployment != nil && deployment.ModifyIndex > maxIndex {
-				maxIndex = deployment.ModifyIndex
+			for _, alloc := range allocs {
+				// TODO: ignore canaries until we figure out what we should do with canaries
+				if alloc.DeploymentStatus != nil && alloc.DeploymentStatus.Canary {
+					continue
+				}
+				if alloc.TerminalStatus() {
+					continue
+				}
+				tgScale, ok := reply.JobScaleStatus.TaskGroups[alloc.TaskGroup]
+				if !ok || tgScale == nil {
+					continue
+				}
+				tgScale.Placed++
+				if alloc.ClientStatus == structs.AllocClientStatusRunning {
+					tgScale.Running++
+				}
+				if alloc.DeploymentStatus != nil && alloc.DeploymentStatus.HasHealth() {
+					if alloc.DeploymentStatus.IsHealthy() {
+						tgScale.Healthy++
+					} else if alloc.DeploymentStatus.IsUnhealthy() {
+						tgScale.Unhealthy++
+					}
+				}
+				if alloc.ModifyIndex > allocsIndex {
+					allocsIndex = alloc.ModifyIndex
+				}
 			}
+
+			maxIndex := job.ModifyIndex
 			if eventsIndex > maxIndex {
 				maxIndex = eventsIndex
+			}
+			if allocsIndex > maxIndex {
+				maxIndex = allocsIndex
 			}
 			reply.Index = maxIndex
 


### PR DESCRIPTION
resolves #7789 

Job.ScaleStatus was not returning `running`. also, this endpoint was using the current deployment, which was associated with a number of issues. modified this endpoint to count allocations instead of relying on the "latest" deployment. for now, ignoring canaries and terminal allocations.