### PR TITLE
Optimize Nomad uniqueness of consul agent is confusing

### DIFF
--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -35,6 +35,7 @@ type serviceHook struct {
 	consul    consul.ConsulServiceAPI
 	allocID   string
 	taskName  string
+	nodeName  string
 	restarter agentconsul.WorkloadRestarter
 	logger    log.Logger
 
@@ -60,6 +61,7 @@ func newServiceHook(c serviceHookConfig) *serviceHook {
 		consul:    c.consul,
 		allocID:   c.alloc.ID,
 		taskName:  c.task.Name,
+		nodeName:  c.alloc.NodeName,
 		services:  c.task.Services,
 		restarter: c.restarter,
 	}
@@ -189,6 +191,7 @@ func (h *serviceHook) getWorkloadServices() *agentconsul.WorkloadServices {
 	return &agentconsul.WorkloadServices{
 		AllocID:       h.allocID,
 		Task:          h.taskName,
+		Node:          h.nodeName,
 		Restarter:     h.restarter,
 		Services:      interpolatedServices,
 		DriverExec:    h.driverExec,

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1088,6 +1088,7 @@ func (a *Agent) setupConsul(consulConfig *config.ConsulConfig) error {
 		isClient = true
 	}
 	a.consulService = consul.NewServiceClient(client.Agent(), a.logger, isClient)
+	a.consulService.AgentName(a.config.NodeName)
 
 	// Run the Consul service client's sync'ing main loop
 	go a.consulService.Run()

--- a/command/agent/consul/client.go
+++ b/command/agent/consul/client.go
@@ -319,6 +319,7 @@ func (s *ServiceRegistration) copy() *ServiceRegistration {
 type ServiceClient struct {
 	client           AgentAPI
 	logger           log.Logger
+	agentName        string
 	retryInterval    time.Duration
 	maxRetryInterval time.Duration
 	periodicInterval time.Duration
@@ -400,6 +401,10 @@ func NewServiceClient(consulClient AgentAPI, logger log.Logger, isNomadClient bo
 
 // seen is used by markSeen and hasSeen
 const seen = 1
+
+func (c *ServiceClient) AgentName(name string) {
+	c.agentName = name
+}
 
 // markSeen marks Consul as having been seen (meaning at least one operation
 // has succeeded).

--- a/command/agent/consul/structs.go
+++ b/command/agent/consul/structs.go
@@ -17,6 +17,7 @@ type WorkloadServices struct {
 	// group based services, Task will be empty
 	Task  string
 	Group string
+	Node string
 
 	// Canary indicates whether or not the allocation is a canary
 	Canary bool


### PR DESCRIPTION
Fix Issue  https://github.com/hashicorp/nomad/issues/7639

> Nomad agents are expected to have unique mapping to consul agents: No two nomad agents should communicate to the same consul agent.

### Optimize:
- [x] add nomad client name as consul service tag when registration service;
- [x] compare the consul service's tags whether include client name, when consul client remove nomad services in consul but unknown locally.

