### PR TITLE
UI: Log streaming bug fix medley

### DIFF
--- a/ui/app/components/task-log.js
+++ b/ui/app/components/task-log.js
@@ -55,6 +55,10 @@ export default Component.extend({
     // AbortControllers don't exist in IE11, so provide a mock if it doesn't exist
     const aborter = window.AbortController ? new AbortController() : new MockAbortController();
     const timing = this.useServer ? this.serverTimeout : this.clientTimeout;
+
+    // Capture the state of useServer at logger create time to avoid a race
+    // between the stdout logger and stderr logger running at once.
+    const useServer = this.useServer;
     return url =>
       RSVP.race([
         this.token.authorizedRequest(url, { signal: aborter.signal }),
@@ -65,7 +69,7 @@ export default Component.extend({
         },
         error => {
           aborter.abort();
-          if (this.useServer) {
+          if (useServer) {
             this.set('noConnection', true);
           } else {
             this.send('failoverToServer');

--- a/ui/app/components/task-log.js
+++ b/ui/app/components/task-log.js
@@ -77,6 +77,7 @@ export default Component.extend({
 
   actions: {
     setMode(mode) {
+      if (this.mode === mode) return;
       this.logger.stop();
       this.set('mode', mode);
     },

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -72,7 +72,8 @@ export default Service.extend({
   // This authorizedRawRequest is necessary in order to fetch data
   // with the guarantee of a token but without the automatic region
   // param since the region cannot be known at this point.
-  authorizedRawRequest(url, options = { credentials: 'include' }) {
+  authorizedRawRequest(url, options = {}) {
+    const credentials = 'include';
     const headers = {};
     const token = this.secret;
 
@@ -80,7 +81,7 @@ export default Service.extend({
       headers['X-Nomad-Token'] = token;
     }
 
-    return fetch(url, assign(options, { headers }));
+    return fetch(url, assign(options, { headers, credentials }));
   },
 
   authorizedRequest(url, options) {

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -1,7 +1,14 @@
 {{#if noConnection}}
   <div data-test-connection-error class="notification is-error">
-    <h3 class="title is-4">Cannot fetch logs</h3>
-    <p>The logs for this task are inaccessible. Check the condition of the node the allocation is on.</p>
+    <div class="columns">
+      <div class="column">
+        <h3 class="title is-4">Cannot fetch logs</h3>
+        <p>The logs for this task are inaccessible. Check the condition of the node the allocation is on.</p>
+      </div>
+      <div class="column is-centered is-minimum">
+        <button data-test-connection-error-dismiss class="button is-danger" onclick={{action (mut noConnection) false}}>Okay</button>
+      </div>
+    </div>
   </div>
 {{/if}}
 <div class="boxed-section-head">

--- a/ui/tests/integration/task-log-test.js
+++ b/ui/tests/integration/task-log-test.js
@@ -219,6 +219,11 @@ module('Integration | Component | task log', function(hooks) {
       this.server.handledRequests.filter(req => req.url.startsWith(serverUrl)).length,
       'Log request was later made to the server'
     );
+
+    assert.ok(
+      this.server.handledRequests.filter(req => clientUrlRegex.test(req.url))[0].aborted,
+      'Client log request was aborted'
+    );
   });
 
   test('When both the client and the server are inaccessible, an error message is shown', async function(assert) {

--- a/ui/tests/integration/task-log-test.js
+++ b/ui/tests/integration/task-log-test.js
@@ -190,6 +190,25 @@ module('Integration | Component | task log', function(hooks) {
     );
   });
 
+  test('Clicking stderr/stdout mode buttons does nothing when the mode remains the same', async function(assert) {
+    const { interval } = commonProps;
+
+    run.later(() => {
+      click('[data-test-log-action="stdout"]');
+      run.later(run, run.cancelTimers, interval * 6);
+    }, interval * 2);
+
+    this.setProperties(commonProps);
+    await render(hbs`{{task-log allocation=allocation task=task}}`);
+
+    await settled();
+    assert.equal(
+      find('[data-test-log-cli]').textContent,
+      streamFrames[0] + streamFrames[0] + streamFrames[1],
+      'Now includes second frame'
+    );
+  });
+
   test('When the client is inaccessible, task-log falls back to requesting logs through the server', async function(assert) {
     run.later(run, run.cancelTimers, allowedConnectionTime * 2);
 

--- a/ui/tests/integration/task-log-test.js
+++ b/ui/tests/integration/task-log-test.js
@@ -279,6 +279,9 @@ module('Integration | Component | task log', function(hooks) {
       'Log request was later made to the server'
     );
     assert.ok(find('[data-test-connection-error]'), 'An error message is shown');
+
+    await click('[data-test-connection-error-dismiss]');
+    assert.notOk(find('[data-test-connection-error]'), 'The error message is dismissable');
   });
 
   test('When the client is inaccessible, the server is accessible, and stderr is pressed before the client timeout occurs, the no connection error is not shown', async function(assert) {


### PR DESCRIPTION
This fixes a couple bugs @Gurpartap reported in #7770 as well as a couple more I found along the way.

#### Bug 1: Switching from stdout to stderr before the stdout request fails or times out causes an error on the stderr log stream despite successfully streaming the logs.

This was a fun race condition. Logs first attempt to connect to the client an allocation is running on before falling back on the server which should always work. When the client request fails, a flag is set to failover to the server. When that server failover flag is already set and another request fails, connecting to logs is deemed a total loss and the "Cannot fetch logs" error is shown.

If a user clicks stderr before stdout triggers the first failure flag then the stderr request will attempt to connect to the client. This causes _both_ stdout and stderr to fail if the client can't be reached. The first failure flips the fallback flag and the second failure flips the total loss flag. However, when the fallback flag is flipped, it still causes a server request to be made, which is why log streaming continued to work.

The fix here was to capture the failover flag state at request time rather than response time. This way both racing client requests flip the same flag (or rather the first one flips it and the second is a no-op).

#### Bug 2: The "Cannot fetch log" error persists when switching between stdout/stderr

This one technically isn't a bug. If the error message is shown, it means no connection can be established. It only seems like a bug when Bug 1 occurs. However, I too dislike error messages that can't be dismissed, so I made it dismissable anyway.

#### Bug 3: Failing over to a server request after a client request takes longer than the client timeout threshold but still eventually responds causes two parallel stream requests, one which never closes.

This one was always known about but [AbortControllers](https://github.com/whatwg/dom/pull/437) where still a relatively new thing [when this was first written](https://github.com/hashicorp/nomad/commit/5346f653a52dac4bcc2f0228222bd4690abfe32b). 

The task logger wisely has its own timeout for client requests to prevent a hanging request from triggering the fallback to making a server request. 9/10 (maybe even 99/100?) times this request will eventually timeout because the client can't be reached, but in the event the client does respond, that connection would remain open indefinitely eating up one of the precious few parallel connections a browser gets to a single host.

The fix here is to use an AbortController as mentioned. They now have broad support. The only browser we are concerned with that does not have them is IE11 which is ok in this instance since IE11 also doesn't support response streaming so it will use the poll logger anyway.

#### Bug 4: Clicking stdout/stderr when already on stdout/stderr stops the log streamer.

This one wasn't tricky by any stretch of the imagination. Just a small detail I overlooked. The fix was to return early if the mode being switched to was already the current mode.

Fixes #7770 