### PR TITLE
e2e: add helper to Makefile for local file deployments

### DIFF
--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -1,9 +1,16 @@
 NOMAD_SHA ?= $(shell git rev-parse HEAD)
+PKG_PATH = $(shell pwd)/../../pkg/linux_amd64/nomad
 
 dev-cluster:
 	terraform apply -auto-approve -var-file=terraform.tfvars.dev
 	terraform output provisioning | jq . > ../provisioning.json
 	cd .. && NOMAD_E2E=1 go test -v . -nomad.sha=$(NOMAD_SHA) -provision.terraform ./provisioning.json -skipTests
+	terraform output message
+
+dev-cluster-from-local:
+	terraform apply -auto-approve -var-file=terraform.tfvars.dev
+	terraform output provisioning | jq . > ../provisioning.json
+	cd .. && NOMAD_E2E=1 go test -v . -nomad.local_file=$(PKG_PATH) -provision.terraform ./provisioning.json -skipTests
 	terraform output message
 
 clean:


### PR DESCRIPTION
This extends the `make dev-cluster` target with a target that will deploy a locally-built version of Nomad and not just one that's been pushed to the public repo. (This is handy for developing private Nomad forks.)