### PR TITLE
Harmonize go-msgpack/codec/codecgen

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -175,11 +175,7 @@ deps:  ## Install build and development dependencies
 	GO111MODULE=on go get -u gotest.tools/gotestsum
 	GO111MODULE=on go get -u github.com/fatih/hclfmt
 	GO111MODULE=on go get -u github.com/golang/protobuf/protoc-gen-go@v1.3.4
-
-	# The tag here must correspoond to codec version nomad uses, e.g. v1.1.5.
-	# Though, v1.1.5 codecgen has a bug in code generator, so using a specific sha
-	# here instead.
-	GO111MODULE=on go get -u github.com/hashicorp/go-msgpack/codec/codecgen@f51b5189210768cf0d476580cf287620374d4f02
+	GO111MODULE=on go get -u github.com/hashicorp/go-msgpack/codec/codecgen@v1.1.5
 
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies

--- a/client/structs/generate.sh
+++ b/client/structs/generate.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-codecgen -d 102 -t codegen_generated -o structs.generated.go structs.go
-sed -i'' -e 's|"github.com/ugorji/go/codec|"github.com/hashicorp/go-msgpack/codec|g' structs.generated.go

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -1,6 +1,6 @@
 package structs
 
-//go:generate ./generate.sh
+//go:generate codecgen -c github.com/hashicorp/go-msgpack/codec -d 102 -t codegen_generated -o structs.generated.go structs.go
 
 import (
 	"errors"


### PR DESCRIPTION
Use v1.1.5 of go-msgpack/codec/codecgen, so go-msgpack codecgen matches
the library version.

We branched off earlier to pick up https://github.com/hashicorp/go-msgpack/commit/f51b5189210768cf0d476580cf287620374d4f02, but apparently that's not needed as we could customize the package via `-c` argument.

Thanks to @greut for https://github.com/hashicorp/nomad/pull/7818 .