### PR TITLE
csi: ensure Read/WriteAllocs aren't released early

### DIFF
--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2996,10 +2996,12 @@ func TestStateStore_CSIVolume(t *testing.T) {
 
 	// release claims to unblock deregister
 	index++
+	claim0.State = structs.CSIVolumeClaimStateReadyToFree
 	err = state.CSIVolumeClaim(index, ns, vol0, claim0)
 	require.NoError(t, err)
 	index++
 	claim1.Mode = u
+	claim1.State = structs.CSIVolumeClaimStateReadyToFree
 	err = state.CSIVolumeClaim(index, ns, vol0, claim1)
 	require.NoError(t, err)
 

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -465,12 +465,11 @@ func (v *CSIVolume) ClaimWrite(claim *CSIVolumeClaim, alloc *Allocation) error {
 // ClaimRelease is called when the allocation has terminated and
 // already stopped using the volume
 func (v *CSIVolume) ClaimRelease(claim *CSIVolumeClaim) error {
-	delete(v.ReadAllocs, claim.AllocationID)
-	delete(v.WriteAllocs, claim.AllocationID)
-	delete(v.ReadClaims, claim.AllocationID)
-	delete(v.WriteClaims, claim.AllocationID)
-
 	if claim.State == CSIVolumeClaimStateReadyToFree {
+		delete(v.ReadAllocs, claim.AllocationID)
+		delete(v.WriteAllocs, claim.AllocationID)
+		delete(v.ReadClaims, claim.AllocationID)
+		delete(v.WriteClaims, claim.AllocationID)
 		delete(v.PastClaims, claim.AllocationID)
 	} else {
 		v.PastClaims[claim.AllocationID] = claim

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -30,6 +30,11 @@ func TestCSIVolumeClaim(t *testing.T) {
 
 	vol.ClaimRelease(claim)
 	require.True(t, vol.ReadSchedulable())
+	require.False(t, vol.WriteFreeClaims())
+
+	claim.State = CSIVolumeClaimStateReadyToFree
+	vol.ClaimRelease(claim)
+	require.True(t, vol.ReadSchedulable())
 	require.True(t, vol.WriteFreeClaims())
 }
 

--- a/nomad/volumewatcher/volumes_watcher_test.go
+++ b/nomad/volumewatcher/volumes_watcher_test.go
@@ -178,6 +178,7 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 	err = srv.State().UpsertAllocs(index, []*structs.Allocation{alloc})
 	require.NoError(err)
 	index++
+	claim.State = structs.CSIVolumeClaimStateReadyToFree
 	err = srv.State().CSIVolumeClaim(index, vol.Namespace, vol.ID, claim)
 	require.NoError(err)
 


### PR DESCRIPTION
We should only remove the `ReadAllocs`/`WriteAllocs` values for a
volume after the claim has entered the "ready to free"
state. The volume will eventually be released as expected. But
querying the volume API will show the volume is released before the
controller unpublish has finished and this can cause a race with
starting new jobs.

Related PR: https://github.com/hashicorp/nomad/pull/7823 