### PR TITLE
UI: Migrate page objects away from jQuery

### DIFF
--- a/ui/config/deprecation-workflow.js
+++ b/ui/config/deprecation-workflow.js
@@ -6,5 +6,6 @@ self.deprecationWorkflow.config = {
     { handler: 'throw', matchId: 'ember-runtime.deprecate-copy-copyable' },
     { handler: 'throw', matchId: 'ember-console.deprecate-logger' },
     { handler: 'throw', matchId: 'ember-test-helpers.rendering-context.jquery-element' },
+    { handler: 'throw', matchId: 'ember-cli-page-object.is-property' },
   ],
 };

--- a/ui/config/deprecation-workflow.js
+++ b/ui/config/deprecation-workflow.js
@@ -5,6 +5,6 @@ self.deprecationWorkflow.config = {
     { handler: 'throw', matchId: 'ember-inflector.globals' },
     { handler: 'throw', matchId: 'ember-runtime.deprecate-copy-copyable' },
     { handler: 'throw', matchId: 'ember-console.deprecate-logger' },
-    { handler: 'log', matchId: 'ember-test-helpers.rendering-context.jquery-element' },
+    { handler: 'throw', matchId: 'ember-test-helpers.rendering-context.jquery-element' },
   ],
 };

--- a/ui/package.json
+++ b/ui/package.json
@@ -65,7 +65,7 @@
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-mirage": "^1.1.2",
     "ember-cli-moment-shim": "^3.5.0",
-    "ember-cli-page-object": "^1.15.1",
+    "ember-cli-page-object": "^1.17.2",
     "ember-cli-sass": "^10.0.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-string-helpers": "^1.5.0",

--- a/ui/tests/integration/job-editor-test.js
+++ b/ui/tests/integration/job-editor-test.js
@@ -25,13 +25,10 @@ module('Integration | Component | job-editor', function(hooks) {
 
     // Required for placing allocations (a result of creating jobs)
     this.server.create('node');
-
-    await Editor.setContext(this);
   });
 
   hooks.afterEach(async function() {
     this.server.shutdown();
-    await Editor.removeContext();
   });
 
   const newJobName = 'new-job';

--- a/ui/tests/integration/job-page/service-test.js
+++ b/ui/tests/integration/job-page/service-test.js
@@ -12,7 +12,6 @@ module('Integration | Component | job-page/service', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
-    Job.setContext(this);
     fragmentSerializerInitializer(this.owner);
     window.localStorage.clear();
     this.store = this.owner.lookup('service:store');

--- a/ui/tests/integration/task-file-test.js
+++ b/ui/tests/integration/task-file-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
-import { find } from 'ember-native-dom-helpers';
+import { find, render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Pretender from 'pretender';
 import { logEncode } from '../../mirage/data/logs';

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -4,8 +4,8 @@ import {
   collection,
   clickable,
   fillable,
-  is,
   isPresent,
+  property,
   text,
   visitable,
 } from 'ember-cli-page-object';
@@ -22,7 +22,7 @@ export default create({
 
   runJobButton: {
     scope: '[data-test-run-job]',
-    isDisabled: is('[disabled]'),
+    isDisabled: property('disabled'),
   },
 
   jobs: collection('[data-test-job-row]', {

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -3,6 +3,9 @@ import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import { useNativeEvents } from 'ember-cli-page-object/extend';
+
+useNativeEvents();
 
 setApplication(Application.create(config.APP));
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6906,18 +6906,18 @@ ember-cli-normalize-entity-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-page-object@^1.15.1:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.15.3.tgz#4b1814e270367a455353aeb81019fb8d8c641886"
-  integrity sha512-wGZqQnsyFHcJilf0xcWa53my/bprtZWHXg7m6wZPbWbnJCXNf1aAouj9uwH77r3PnE+/uYt0MIKMfX3Cnd607g==
+ember-cli-page-object@^1.17.2:
+  version "1.17.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.17.2.tgz#746632fdbde30a605901a37ec70f9bdb09d6a52f"
+  integrity sha512-2yOYPbZnHDS5xalPjCf+8RQqWIOxgjR091Vf+WnDtwSed3lXE0dQvY+fDSmjIM96p78TfouQnTDHsnfAbAoIHg==
   dependencies:
     broccoli-file-creator "^2.1.1"
     broccoli-merge-trees "^2.0.0"
     ceibo "~2.0.0"
     ember-cli-babel "^6.16.0"
     ember-cli-node-assets "^0.2.2"
-    ember-native-dom-helpers "^0.5.3"
-    jquery "^3.2.1"
+    ember-native-dom-helpers "^0.6.3"
+    jquery "3.4.1"
     rsvp "^4.7.0"
 
 ember-cli-path-utils@^1.0.0:
@@ -7393,10 +7393,10 @@ ember-moment@^7.8.1:
     ember-getowner-polyfill "^2.2.0"
     ember-macro-helpers "^2.1.0"
 
-ember-native-dom-helpers@^0.5.3:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.10.tgz#9c7172e4ddfa5dd86830c46a936e2f8eca3e5896"
-  integrity sha512-bPJX49vlgnBGwFn/3WJPPJjjyd7/atvzW5j01u1dbyFf3bXvHg9Rs1qaZJdk8js0qZ1FINadIEC9vWtgN3w7tg==
+ember-native-dom-helpers@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.3.tgz#31c88b6eb8e1bb99ee594d19de8f0270d1d5eb35"
+  integrity sha512-eQTHSV4OBS5YmGLvjgCcit79akG98YVRrcNq/rOVntPX1oq0LQqlPiXtDvDcqSdDur8GyUz6jY1Jy8Y6DLFiSw==
   dependencies:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
@@ -10222,7 +10222,7 @@ jquery-deferred@^0.3.0:
   resolved "https://registry.yarnpkg.com/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
   integrity sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=
 
-jquery@^3.2.1, jquery@^3.4.1:
+jquery@3.4.1, jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==


### PR DESCRIPTION
This is part of #7834’s jQuery removal goal. It addresses a couple of jQuery-related deprecation warnings and also uses “native events mode” for ember-cli-page-object, which is needed so it [doesn’t have to use jQuery via the Ember global](http://ember-cli-page-object.js.org/docs/v1.17.x/native-events).

There was no change to `ember build -prod` file sizes, unsurprisingly. `npx ember-test-audit 3` had an average of `3m 38s 738ms` which is not a noteworthy difference from the `3m 39s 700ms` [on `master`](https://github.com/hashicorp/nomad/pull/7839#issuecomment-621969865).