### PR TITLE
csi: fix plugin counts on node update

### DIFF
--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -560,10 +560,12 @@ func TestCSI_RPCVolumeAndPluginLookup(t *testing.T) {
 
 	// Create a client node with a plugin
 	node := mock.Node()
-	node.CSINodePlugins = map[string]*structs.CSIInfo{
+	node.CSIControllerPlugins = map[string]*structs.CSIInfo{
 		"minnie": {PluginID: "minnie", Healthy: true, RequiresControllerPlugin: true,
 			ControllerInfo: &structs.CSIControllerInfo{SupportsAttachDetach: true},
 		},
+	}
+	node.CSINodePlugins = map[string]*structs.CSIInfo{
 		"adam": {PluginID: "adam", Healthy: true},
 	}
 	err := state.UpsertNode(3, node)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1037,6 +1037,12 @@ func upsertNodeCSIPlugins(txn *memdb.Txn, node *structs.Node, index uint64) erro
 		if raw != nil {
 			plug = raw.(*structs.CSIPlugin).Copy()
 		} else {
+			if !info.Healthy {
+				// we don't want to create new plugins for unhealthy
+				// allocs, otherwise we'd recreate the plugin when we
+				// get the update for the alloc becoming terminal
+				return nil
+			}
 			plug = structs.NewCSIPlugin(info.PluginID, index)
 			plug.Provider = info.Provider
 			plug.Version = info.ProviderVersion

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -701,7 +701,8 @@ func (p *CSIPlugin) Copy() *CSIPlugin {
 func (p *CSIPlugin) AddPlugin(nodeID string, info *CSIInfo) error {
 	if info.ControllerInfo != nil {
 		p.ControllerRequired = info.RequiresControllerPlugin &&
-			info.ControllerInfo.SupportsAttachDetach
+			(info.ControllerInfo.SupportsAttachDetach ||
+				info.ControllerInfo.SupportsReadOnlyAttach)
 
 		prev, ok := p.Controllers[nodeID]
 		if ok {

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -718,7 +718,6 @@ func (p *CSIPlugin) AddPlugin(nodeID string, info *CSIInfo) error {
 		// controller for a given plugin can be on a given Nomad
 		// client, they also conflict on the client so this should be
 		// ok
-		p.Controllers[nodeID] = info
 		if prev != nil || info.Healthy {
 			p.Controllers[nodeID] = info
 		}

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -719,7 +719,7 @@ func (p *CSIPlugin) AddPlugin(nodeID string, info *CSIInfo) error {
 		// client, they also conflict on the client so this should be
 		// ok
 		p.Controllers[nodeID] = info
-		if prev != nil || prev == nil && info.Healthy {
+		if prev != nil || info.Healthy {
 			p.Controllers[nodeID] = info
 		}
 		if info.Healthy {
@@ -737,7 +737,7 @@ func (p *CSIPlugin) AddPlugin(nodeID string, info *CSIInfo) error {
 				p.NodesHealthy -= 1
 			}
 		}
-		if prev != nil || prev == nil && info.Healthy {
+		if prev != nil || info.Healthy {
 			p.Nodes[nodeID] = info
 		}
 		if info.Healthy {

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -713,11 +713,15 @@ func (p *CSIPlugin) AddPlugin(nodeID string, info *CSIInfo) error {
 				p.ControllersHealthy -= 1
 			}
 		}
+
 		// note: for this to work as expected, only a single
 		// controller for a given plugin can be on a given Nomad
 		// client, they also conflict on the client so this should be
 		// ok
 		p.Controllers[nodeID] = info
+		if prev != nil || prev == nil && info.Healthy {
+			p.Controllers[nodeID] = info
+		}
 		if info.Healthy {
 			p.ControllersHealthy += 1
 		}
@@ -733,7 +737,9 @@ func (p *CSIPlugin) AddPlugin(nodeID string, info *CSIInfo) error {
 				p.NodesHealthy -= 1
 			}
 		}
-		p.Nodes[nodeID] = info
+		if prev != nil || prev == nil && info.Healthy {
+			p.Nodes[nodeID] = info
+		}
 		if info.Healthy {
 			p.NodesHealthy += 1
 		}


### PR DESCRIPTION
For https://github.com/hashicorp/nomad/issues/7817 and https://github.com/hashicorp/nomad/issues/7743. Best reviewed commit-by-commit, but unfortunately all the changes are required to finish out this multi-layered bug. The bulk of the new lines of code are tests... it was a bit of a pain to suss-out this behavior!

In this changeset:

* If a Nomad client node is running both a controller and a node plugin (which is a common case), then if only the controller or the node is removed, the plugin was not being updated with the correct counts.
* The existing test for plugin cleanup didn't go back to the state store, which normally is ok but is complicated in this case by denormalization which changes the behavior. This commit makes the test more comprehensive.
* Set "controller required" when plugin has `PUBLISH_READONLY`. All known controllers that support `PUBLISH_READONLY` also support `PUBLISH_UNPUBLISH_VOLUME` but we shouldn't assume this.
* Only create plugins when the allocs for those plugins are healthy. If we allow a plugin to be created for the first time when the alloc is not healthy, then we'll recreate deleted plugins when the job's allocs all get marked terminal.
* Terminal plugin alloc updates should cleanup the plugin. The client fingerprint can't tell if the plugin is unhealthy intentionally (for the case of updates or job stop). Allocations that are
server-terminal should delete themselves from the plugin and trigger a plugin self-GC, the same as an unused node.
