### PR TITLE
temporarily test for 404 until endpoint is ready

### DIFF
--- a/command/license_get_test.go
+++ b/command/license_get_test.go
@@ -22,7 +22,8 @@ func TestCommand_LicenseGet_OSSErr(t *testing.T) {
 	require.Equal(t, 1, code)
 
 	if srv.Enterprise {
-		require.Contains(t, ui.OutputWriter.String(), "License Status")
+		// TODO update assertion once ent licensing implemented
+		require.Contains(t, ui.ErrorWriter.String(), "404")
 	} else {
 		require.Contains(t, ui.ErrorWriter.String(), "Nomad Enterprise only endpoint")
 	}


### PR DESCRIPTION
until licensing work is implemented in ent repo, this test will assert a 404 instead of enterprise only error