### PR TITLE
Fix URL schema in `drain` documentation

### DIFF
--- a/website/pages/docs/commands/node/drain.mdx
+++ b/website/pages/docs/commands/node/drain.mdx
@@ -134,4 +134,4 @@ $ nomad node drain -self -monitor
 [eligibility]: /docs/commands/node/eligibility
 [migrate]: /docs/job-specification/migrate
 [node status]: /docs/commands/node/status
-[workload migration guide]: ttps://learn.hashicorp.com/nomad/operating-nomad/node-draining
+[workload migration guide]: https://learn.hashicorp.com/nomad/operating-nomad/node-draining


### PR DESCRIPTION
Fix of a small typo in the HashiCorp Learn link