### PR TITLE
volumewatcher: remove spurious nil-check

### DIFF
--- a/nomad/volumewatcher/volume_watcher.go
+++ b/nomad/volumewatcher/volume_watcher.go
@@ -117,7 +117,7 @@ func (vw *volumeWatcher) watch() {
 		case vol := <-vw.updateCh:
 			// while we won't make raft writes if we get a stale update,
 			// we can still fire extra CSI RPC calls if we don't check this
-			if vol == nil || vw.v == nil || vol.ModifyIndex >= vw.v.ModifyIndex {
+			if vol.ModifyIndex >= vw.v.ModifyIndex {
 				vol = vw.getVolume(vol)
 				if vol == nil {
 					return


### PR DESCRIPTION
The nil-check here is left-over from an earlier approach that didn't
get merged. It doesn't do anything for us now as we can't ever pass it
`nil` and if we leave it in, the `getVolume` call the check guards will 
panic anyways.