### PR TITLE
csi: plugins with PUBLISH_READONLY need controllers too

### DIFF
--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -701,7 +701,8 @@ func (p *CSIPlugin) Copy() *CSIPlugin {
 func (p *CSIPlugin) AddPlugin(nodeID string, info *CSIInfo) error {
 	if info.ControllerInfo != nil {
 		p.ControllerRequired = info.RequiresControllerPlugin &&
-			info.ControllerInfo.SupportsAttachDetach
+			(info.ControllerInfo.SupportsAttachDetach ||
+				info.ControllerInfo.SupportsReadOnlyAttach)
 
 		prev, ok := p.Controllers[nodeID]
 		if ok {


### PR DESCRIPTION
All known controllers that support `PUBLISH_READONLY` also support
`PUBLISH_UNPUBLISH_VOLUME` but we shouldn't assume this.

Pulled out of https://github.com/hashicorp/nomad/pull/7844, as it's incidental to that bug.