### PR TITLE
UI: add asset size GitHub Action

### DIFF
--- a/.github/workflows/ember-assets.yml
+++ b/.github/workflows/ember-assets.yml
@@ -1,0 +1,24 @@
+name: Ember Asset Sizes
+
+on:
+  pull_request:
+    paths:
+    - 'ui/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2-beta
+        with:
+          fetch-depth: 0
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - uses: backspace/ember-asset-size-action@edit-comment
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          working-directory: "ui"


### PR DESCRIPTION
This uses a fork of the [Ember Asset Size](https://github.com/simplabs/ember-asset-size-action) Action to report on changes to the filesizes of the production UI build as a comment to the PR. The fork includes fixes to make it work with a subdirectory (`ui/` in our case) and to make it update the PR comment if it exists vs posting repeatedly to the thread.

Here’s an example of what it posts:

> ## Ember Asset Size action
> 
> As of e8c87d0
> 
> Files that got Bigger 🚨:
> 
> File | raw | gzip
> --- | --- | ---
> nomad-ui.css|+71 B|+16 B
> 
> Files that stayed the same size 🤷‍:
> 
> File | raw | gzip
> --- | --- | ---
> auto-import-fastboot.js| 0 B| 0 B
> nomad-ui.js| 0 B| 0 B
> vendor.js| 0 B| 0 B
> vendor.css| 0 B| 0 B

I know there’s sometimes reluctance to use forks; I haven’t heard back about [the comment-editing feature suggestion](https://github.com/simplabs/ember-asset-size-action/issues/9) or the [working directory PR](https://github.com/simplabs/ember-asset-size-action/pull/8) and [PR to that PR](https://github.com/NullVoxPopuli/ember-asset-size-action/pull/2) but I could prod further if you’d prefer.