### PR TITLE
pending node allocs are "running"

### DIFF
--- a/command/node_status.go
+++ b/command/node_status.go
@@ -772,7 +772,8 @@ func getRunningAllocs(client *api.Client, nodeID string) ([]*api.Allocation, err
 	nodeAllocs, _, err := client.Nodes().Allocations(nodeID, nil)
 	// Filter list to only running allocations
 	for _, alloc := range nodeAllocs {
-		if alloc.ClientStatus == "running" {
+		switch alloc.ClientStatus {
+		case api.AllocClientStatusRunning, api.AllocClientStatusPending:
 			allocs = append(allocs, alloc)
 		}
 	}

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -47,8 +47,10 @@ export default Model.extend({
   completeAllocations: computed('allocations.@each.clientStatus', function() {
     return this.allocations.filterBy('clientStatus', 'complete');
   }),
-  runningAllocations: computed('allocations.@each.isRunning', function() {
-    return this.allocations.filterBy('isRunning');
+  runningAllocations: computed('allocations.@each.clientStatus', function() {
+    return this.allocations.filter(
+      a => a.get('clientStatus') === 'pending' || a.get('clientStatus') === 'running'
+    );
   }),
   migratingAllocations: computed('allocations.@each.{isMigrating,isRunning}', function() {
     return this.allocations.filter(alloc => alloc.isRunning && alloc.isMigrating);

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -16,9 +16,9 @@
 <td data-test-client-datacenter>{{node.datacenter}}</td>
 <td data-test-client-volumes>{{if node.hostVolumes.length node.hostVolumes.length}}</td>
 <td data-test-client-allocations>
-  {{#if node.allocations.isPending}}
+  {{#if node.runningAllocations.isPending}}
     ...
   {{else}}
-    {{node.allocations.length}}
+    {{node.runningAllocations.length}}
   {{/if}}
 </td>


### PR DESCRIPTION
When showing the count of allocations in client views, show the count of
pending+running allocs.  A pending job is basically a promise that a job
will eminently run, but is in pending state because the client hasn't
picked it up yet, or because the client is preparing the task (e.g.
downloading the docker image).  As such, pending jobs should count when
reviewing cluster utilization or when assessing how loaded a node is.

This PR fixes two bugs and reconciles the reporting of UI Client View
and CLI `nomad node status --allocs`:

* `nomad alloc status --allocs` reported only running jobs but not
pending jobs.  An operator may notice a long lag until their job is
accounted for, because of the delay of downloading the image.

* The UI class view reported all allocations, including completed ones!
This is very confusing, specially as it doesn't match operator
expectations and seem arbitrary.