### PR TITLE
[docs] Fix version typo

### DIFF
--- a/website/pages/docs/configuration/server.mdx
+++ b/website/pages/docs/configuration/server.mdx
@@ -95,7 +95,7 @@ server {
   bootstrapping cluster. The parameter is ignored once the cluster is bootstrapped or
   value is updated through the [API endpoint][update-scheduler-config]. See [the
   example section](#configuring-scheduler-config) for more details
-  `default_scheduler_config` was introduced in Nomad 0.11.4.
+  `default_scheduler_config` was introduced in Nomad 0.10.4.
 
 - `heartbeat_grace` `(string: "10s")` - Specifies the additional time given as a
   grace period beyond the heartbeat TTL of nodes to account for network and


### PR DESCRIPTION
0.11.4 -> 0.10.4 for `default_scheduler_config`