### PR TITLE
reorder volume claim batch request raft message

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -51,6 +51,8 @@ var (
 
 type MessageType uint8
 
+// note: new raft message types need to be added to the end of this
+// list of contents
 const (
 	NodeRegisterRequestType MessageType = iota
 	NodeDeregisterRequestType
@@ -90,8 +92,8 @@ const (
 	CSIVolumeRegisterRequestType
 	CSIVolumeDeregisterRequestType
 	CSIVolumeClaimRequestType
-	CSIVolumeClaimBatchRequestType
 	ScalingEventRegisterRequestType
+	CSIVolumeClaimBatchRequestType
 )
 
 const (


### PR DESCRIPTION
Fixes a regression I introduced in https://github.com/hashicorp/nomad/pull/7794 but we never shipped as a release.

For backwards compatibility of in-flight requests during upgrades, new raft message types
need to come at the end of the enum. But if we look at [0.11.1](https://github.com/hashicorp/nomad/blob/v0.11.1/nomad/structs/structs.go#L93) we can see that wasn't done here.
