### PR TITLE
ui: only count running allocations in client view

### DIFF
--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -16,9 +16,9 @@
 <td data-test-client-datacenter>{{node.datacenter}}</td>
 <td data-test-client-volumes>{{if node.hostVolumes.length node.hostVolumes.length}}</td>
 <td data-test-client-allocations>
-  {{#if node.allocations.isPending}}
+  {{#if node.runningAllocations.isPending}}
     ...
   {{else}}
-    {{node.allocations.length}}
+    {{node.runningAllocations.length}}
   {{/if}}
 </td>


### PR DESCRIPTION
Alternative to https://github.com/hashicorp/nomad/pull/7868 - but smaller in scope.

In the client view list, only show running allocations count for each
client, rather than include already completed tasks.

This is done for two reasons:

First, consitency with the CLI: `nomad node status --allocs` only
shows running allocs.

Second, and more importantly, the count is useful to estimate how loaded
the clients are.  Allocs that have completed (but not GCed yet) have
very little value to operators.