### PR TITLE
periodic GC for CSI plugins

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -314,6 +314,13 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		}
 		conf.DeploymentGCThreshold = dur
 	}
+	if gcThreshold := agentConfig.Server.CSIPluginGCThreshold; gcThreshold != "" {
+		dur, err := time.ParseDuration(gcThreshold)
+		if err != nil {
+			return nil, err
+		}
+		conf.CSIPluginGCThreshold = dur
+	}
 
 	if heartbeatGrace := agentConfig.Server.HeartbeatGrace; heartbeatGrace != 0 {
 		conf.HeartbeatGrace = heartbeatGrace

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -389,6 +389,11 @@ type ServerConfig struct {
 	// GCed but the threshold can be used to filter by age.
 	DeploymentGCThreshold string `hcl:"deployment_gc_threshold"`
 
+	// CSIPluginGCThreshold controls how "old" a CSI plugin must be to be
+	// collected by GC. Age is not the only requirement for a plugin to be
+	// GCed but the threshold can be used to filter by age.
+	CSIPluginGCThreshold string `hcl:"csi_plugin_gc_threshold"`
+
 	// HeartbeatGrace is the grace period beyond the TTL to account for network,
 	// processing delays and clock skew before marking a node as "down".
 	HeartbeatGrace    time.Duration
@@ -1322,6 +1327,9 @@ func (a *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 	}
 	if b.DeploymentGCThreshold != "" {
 		result.DeploymentGCThreshold = b.DeploymentGCThreshold
+	}
+	if b.CSIPluginGCThreshold != "" {
+		result.CSIPluginGCThreshold = b.CSIPluginGCThreshold
 	}
 	if b.HeartbeatGrace != 0 {
 		result.HeartbeatGrace = b.HeartbeatGrace

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -104,6 +104,7 @@ var basicConfig = &Config{
 		JobGCInterval:          "3m",
 		JobGCThreshold:         "12h",
 		DeploymentGCThreshold:  "12h",
+		CSIPluginGCThreshold:   "12h",
 		HeartbeatGrace:         30 * time.Second,
 		HeartbeatGraceHCL:      "30s",
 		MinHeartbeatTTL:        33 * time.Second,

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -115,6 +115,7 @@ server {
   job_gc_threshold          = "12h"
   eval_gc_threshold         = "12h"
   deployment_gc_threshold   = "12h"
+  csi_plugin_gc_threshold   = "12h"
   heartbeat_grace           = "30s"
   min_heartbeat_ttl         = "33s"
   max_heartbeats_per_second = 11.0

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -256,6 +256,7 @@
     {
       "authoritative_region": "foobar",
       "bootstrap_expect": 5,
+      "csi_plugin_gc_threshold": "12h",
       "data_dir": "/tmp/data",
       "deployment_gc_threshold": "12h",
       "enabled": true,

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -191,6 +191,13 @@ type Config struct {
 	// for GC. This gives users some time to view terminal deployments.
 	DeploymentGCThreshold time.Duration
 
+	// CSIPluginGCInterval is how often we dispatch a job to GC unused plugins.
+	CSIPluginGCInterval time.Duration
+
+	// CSIPluginGCThreshold is how "old" a plugin must be to be eligible
+	// for GC. This gives users some time to debug plugins.
+	CSIPluginGCThreshold time.Duration
+
 	// EvalNackTimeout controls how long we allow a sub-scheduler to
 	// work on an evaluation before we consider it failed and Nack it.
 	// This allows that evaluation to be handed to another sub-scheduler
@@ -377,6 +384,8 @@ func DefaultConfig() *Config {
 		NodeGCThreshold:                  24 * time.Hour,
 		DeploymentGCInterval:             5 * time.Minute,
 		DeploymentGCThreshold:            1 * time.Hour,
+		CSIPluginGCInterval:              5 * time.Minute,
+		CSIPluginGCThreshold:             1 * time.Hour,
 		EvalNackTimeout:                  60 * time.Second,
 		EvalDeliveryLimit:                3,
 		EvalNackInitialReenqueueDelay:    1 * time.Second,

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -54,6 +54,8 @@ func (c *CoreScheduler) Process(eval *structs.Evaluation) error {
 		return c.deploymentGC(eval)
 	case structs.CoreJobCSIVolumeClaimGC:
 		return c.csiVolumeClaimGC(eval)
+	case structs.CoreJobCSIPluginGC:
+		return c.csiPluginGC(eval)
 	case structs.CoreJobForceGC:
 		return c.forceGC(eval)
 	default:
@@ -735,4 +737,10 @@ func (c *CoreScheduler) csiVolumeClaimGC(eval *structs.Evaluation) error {
 
 	err := c.srv.RPC("CSIVolume.Claim", req, &structs.CSIVolumeClaimResponse{})
 	return err
+}
+
+// csiPluginGC is used to garbage collect unused plugins
+func (c *CoreScheduler) csiPluginGC(eval *structs.Evaluation) error {
+	c.logger.Trace("garbage collecting unused CSI plugins")
+	return nil
 }

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -74,6 +74,9 @@ func (c *CoreScheduler) forceGC(eval *structs.Evaluation) error {
 	if err := c.deploymentGC(eval); err != nil {
 		return err
 	}
+	if err := c.csiPluginGC(eval); err != nil {
+		return err
+	}
 
 	// Node GC must occur after the others to ensure the allocations are
 	// cleared.
@@ -741,6 +744,48 @@ func (c *CoreScheduler) csiVolumeClaimGC(eval *structs.Evaluation) error {
 
 // csiPluginGC is used to garbage collect unused plugins
 func (c *CoreScheduler) csiPluginGC(eval *structs.Evaluation) error {
-	c.logger.Trace("garbage collecting unused CSI plugins")
+
+	ws := memdb.NewWatchSet()
+
+	iter, err := c.snap.CSIPlugins(ws)
+	if err != nil {
+		return err
+	}
+
+	// Get the time table to calculate GC cutoffs.
+	var oldThreshold uint64
+	if eval.JobID == structs.CoreJobForceGC {
+		// The GC was forced, so set the threshold to its maximum so
+		// everything will GC.
+		oldThreshold = math.MaxUint64
+		c.logger.Debug("forced plugin GC")
+	} else {
+		tt := c.srv.fsm.TimeTable()
+		cutoff := time.Now().UTC().Add(-1 * c.srv.config.CSIPluginGCThreshold)
+		oldThreshold = tt.NearestIndex(cutoff)
+	}
+
+	c.logger.Debug("CSI plugin GC scanning before cutoff index",
+		"index", oldThreshold, "csi_plugin_gc_threshold", c.srv.config.CSIPluginGCThreshold)
+
+	for i := iter.Next(); i != nil; i = iter.Next() {
+		plugin := i.(*structs.CSIPlugin)
+
+		// Ignore new plugins
+		if plugin.CreateIndex > oldThreshold {
+			continue
+		}
+
+		req := &structs.CSIPluginDeleteRequest{ID: plugin.ID}
+		req.Region = c.srv.Region()
+		err := c.srv.RPC("CSIPlugin.Delete", req, &structs.CSIPluginDeleteResponse{})
+		if err != nil {
+			if err.Error() == "plugin in use" {
+				continue
+			}
+			c.logger.Error("failed to GC plugin", "plugin_id", plugin.ID, "error", err)
+			return err
+		}
+	}
 	return nil
 }

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -522,6 +522,8 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 	defer jobGC.Stop()
 	deploymentGC := time.NewTicker(s.config.DeploymentGCInterval)
 	defer deploymentGC.Stop()
+	csiPluginGC := time.NewTicker(s.config.CSIPluginGCInterval)
+	defer csiPluginGC.Stop()
 
 	// getLatest grabs the latest index from the state store. It returns true if
 	// the index was retrieved successfully.
@@ -554,6 +556,11 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 			if index, ok := getLatest(); ok {
 				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobDeploymentGC, index))
 			}
+		case <-csiPluginGC.C:
+			if index, ok := getLatest(); ok {
+				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobCSIPluginGC, index))
+			}
+
 		case <-stopCh:
 			return
 		}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2312,6 +2312,34 @@ func (s *StateStore) CSIPluginDenormalize(ws memdb.WatchSet, plug *structs.CSIPl
 	return plug, nil
 }
 
+// UpsertCSIPlugin writes the plugin to the state store. Note: there
+// is currently no raft message for this, as it's intended to support
+// testing use cases.
+func (s *StateStore) UpsertCSIPlugin(index uint64, plug *structs.CSIPlugin) error {
+	txn := s.db.Txn(true)
+	defer txn.Abort()
+
+	existing, err := txn.First("csi_plugins", "id", plug.ID)
+	if err != nil {
+		return fmt.Errorf("csi_plugin lookup error: %s %v", plug.ID, err)
+	}
+
+	plug.ModifyIndex = index
+	if existing != nil {
+		plug.CreateIndex = existing.(*structs.CSIPlugin).CreateIndex
+	}
+
+	err = txn.Insert("csi_plugins", plug)
+	if err != nil {
+		return fmt.Errorf("csi_plugins insert error: %v", err)
+	}
+	if err := txn.Insert("index", &IndexEntry{"csi_plugins", index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+	txn.Commit()
+	return nil
+}
+
 // UpsertPeriodicLaunch is used to register a launch or update it.
 func (s *StateStore) UpsertPeriodicLaunch(index uint64, launch *structs.PeriodicLaunch) error {
 	txn := s.db.Txn(true)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2340,6 +2340,37 @@ func (s *StateStore) UpsertCSIPlugin(index uint64, plug *structs.CSIPlugin) erro
 	return nil
 }
 
+// DeleteCSIPlugin deletes the plugin if it's not in use.
+func (s *StateStore) DeleteCSIPlugin(index uint64, id string) error {
+	txn := s.db.Txn(true)
+	defer txn.Abort()
+	ws := memdb.NewWatchSet()
+
+	plug, err := s.CSIPluginByID(ws, id)
+	if err != nil {
+		return err
+	}
+
+	if plug == nil {
+		return nil
+	}
+
+	plug, err = s.CSIPluginDenormalize(ws, plug.Copy())
+	if err != nil {
+		return err
+	}
+	if !plug.IsEmpty() {
+		return fmt.Errorf("plugin in use")
+	}
+
+	err = txn.Delete("csi_plugins", plug)
+	if err != nil {
+		return fmt.Errorf("csi_plugins delete error: %v", err)
+	}
+	txn.Commit()
+	return nil
+}
+
 // UpsertPeriodicLaunch is used to register a launch or update it.
 func (s *StateStore) UpsertPeriodicLaunch(index uint64, launch *structs.PeriodicLaunch) error {
 	txn := s.db.Txn(true)

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -868,3 +868,12 @@ type CSIPluginGetResponse struct {
 	Plugin *CSIPlugin
 	QueryMeta
 }
+
+type CSIPluginDeleteRequest struct {
+	ID string
+	QueryOptions
+}
+
+type CSIPluginDeleteResponse struct {
+	QueryMeta
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8990,6 +8990,11 @@ const (
 	// claiming them. If so, we unclaim the volume.
 	CoreJobCSIVolumeClaimGC = "csi-volume-claim-gc"
 
+	// CoreJobCSIPluginGC is use for the garbage collection of CSI plugins.
+	// We periodically scan plugins to see if they have no associated volumes
+	// or allocs running them. If so, we delete the plugin.
+	CoreJobCSIPluginGC = "csi-plugin-gc"
+
 	// CoreJobForceGC is used to force garbage collection of all GCable objects.
 	CoreJobForceGC = "force-gc"
 )

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -94,6 +94,7 @@ const (
 	CSIVolumeClaimRequestType
 	ScalingEventRegisterRequestType
 	CSIVolumeClaimBatchRequestType
+	CSIPluginDeleteRequestType
 )
 
 const (

--- a/website/pages/docs/configuration/server.mdx
+++ b/website/pages/docs/configuration/server.mdx
@@ -90,6 +90,10 @@ server {
   deployment must be in the terminal state before it is eligible for garbage
   collection. This is specified using a label suffix like "30s" or "1h".
 
+- `csi_plugin_gc_threshold` `(string: "1h")` - Specifies the minimum age of
+  CSI plugin before it is eligible for garbage collection if not in use.
+  This is specified using a label suffix like "30s" or "1h".
+
 - `default_scheduler_config` <code>([scheduler_configuration][update-scheduler-config]:
   nil)</code> - Specifies the initial default scheduler config when
   bootstrapping cluster. The parameter is ignored once the cluster is bootstrapped or


### PR DESCRIPTION
For the plugin half of https://github.com/hashicorp/nomad/issues/7825

This changeset implements a periodic garbage collection of unused CSI plugins. Plugins are self-cleaning when the last allocation for a plugin is stopped, but this feature will cover any missing edge cases and ensure that upgrades from 0.11.0 and 0.11.1 get any stray plugins cleaned up.

Best reviewed commit-by-commit. 71ad02d includes the addition of a `UpsertCSIPlugin` method on the state store which is primarily to support testing (the normal way plugins get updated is through node updates); we could probably refactor some of our other tests to use this as well.