### PR TITLE
job: add loading templates from local file

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -752,6 +752,7 @@ type Template struct {
 	SourcePath   *string        `mapstructure:"source"`
 	DestPath     *string        `mapstructure:"destination"`
 	EmbeddedTmpl *string        `mapstructure:"data"`
+	LocalSource  *string        `mapstructure:"local_source"`
 	ChangeMode   *string        `mapstructure:"change_mode"`
 	ChangeSignal *string        `mapstructure:"change_signal"`
 	Splay        *time.Duration `mapstructure:"splay"`

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -67,6 +67,11 @@ General Options:
 
 Plan Options:
 
+  -context
+    Path to additional local files referred to in the job definition, to be
+    loaded and included when loading the job spec. If unset, and job file
+    definition is not stdin, defaults to the current working directory.
+
   -diff
     Determines whether the diff between the remote job and planned job is shown.
     Defaults to true.
@@ -87,6 +92,7 @@ func (c *JobPlanCommand) Synopsis() string {
 func (c *JobPlanCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
+			"-context":         complete.PredictFiles("*"),
 			"-diff":            complete.PredictNothing,
 			"-policy-override": complete.PredictNothing,
 			"-verbose":         complete.PredictNothing,
@@ -106,6 +112,7 @@ func (c *JobPlanCommand) Run(args []string) int {
 	flags.BoolVar(&diff, "diff", true, "")
 	flags.BoolVar(&policyOverride, "policy-override", false, "")
 	flags.BoolVar(&verbose, "verbose", false, "")
+	flags.StringVar(&c.ContextPath, "context", "", "")
 
 	if err := flags.Parse(args); err != nil {
 		return 255

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -74,6 +74,11 @@ Run Options:
     known state. The use of this flag is most common in conjunction with plan
     command.
 
+  -context
+    Path to additional local files referred to in the job definition, to be
+    loaded and included when loading the job spec. If unset, and job file
+    definition is not stdin, defaults to the current working directory.
+
   -detach
     Return immediately instead of entering monitor mode. After job submission,
     the evaluation ID will be printed to the screen, which can be used to
@@ -112,6 +117,7 @@ func (c *JobRunCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
 			"-check-index":     complete.PredictNothing,
+			"-context":         complete.PredictFiles("*"),
 			"-detach":          complete.PredictNothing,
 			"-verbose":         complete.PredictNothing,
 			"-consul-token":    complete.PredictNothing,
@@ -138,6 +144,7 @@ func (c *JobRunCommand) Run(args []string) int {
 	flags.BoolVar(&output, "output", false, "")
 	flags.BoolVar(&override, "policy-override", false, "")
 	flags.StringVar(&checkIndexStr, "check-index", "", "")
+	flags.StringVar(&c.ContextPath, "context", "", "")
 	flags.StringVar(&consulToken, "consul-token", "", "")
 	flags.StringVar(&vaultToken, "vault-token", "", "")
 

--- a/command/job_validate.go
+++ b/command/job_validate.go
@@ -27,6 +27,13 @@ Alias: nomad validate
   If the supplied path is "-", the jobfile is read from stdin. Otherwise
   it is read from the file at the supplied path or downloaded and
   read from URL specified.
+
+Validate Options:
+
+  -context
+    Path to additional local files referred to in the job definition, to be
+    loaded and included when loading the job spec. If unset, and job file
+    definition is not stdin, defaults to the current working directory.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -36,7 +43,11 @@ func (c *JobValidateCommand) Synopsis() string {
 }
 
 func (c *JobValidateCommand) AutocompleteFlags() complete.Flags {
-	return nil
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-context": complete.PredictFiles("*"),
+		},
+	)
 }
 
 func (c *JobValidateCommand) AutocompleteArgs() complete.Predictor {
@@ -46,8 +57,9 @@ func (c *JobValidateCommand) AutocompleteArgs() complete.Predictor {
 func (c *JobValidateCommand) Name() string { return "job validate" }
 
 func (c *JobValidateCommand) Run(args []string) int {
-	flags := c.Meta.FlagSet(c.Name(), FlagSetNone)
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.StringVar(&c.ContextPath, "context", "", "")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}

--- a/jobspec/context.go
+++ b/jobspec/context.go
@@ -1,0 +1,45 @@
+package jobspec
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+func LoadContext(j *api.Job, dir string) error {
+	for _, groups := range j.TaskGroups {
+		for _, task := range groups.Tasks {
+			for _, tmpl := range task.Templates {
+				if tmpl.LocalSource == nil {
+					continue
+				}
+
+				// Load LocalSource file into tmpl.Data
+				filepath := *tmpl.LocalSource
+				if !path.IsAbs(filepath) {
+					filepath = path.Join(dir, filepath)
+				}
+				rd, err := os.OpenFile(filepath, os.O_RDONLY, 0)
+				if err != nil {
+					return err
+				}
+
+				// Buffer file into memory as a string
+				data, err := ioutil.ReadAll(rd)
+				if err != nil {
+					return err
+				}
+				str := string(data)
+				tmpl.EmbeddedTmpl = &str
+
+				err = rd.Close()
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -423,6 +423,7 @@ func parseTemplates(result *[]*api.Template, list *ast.ObjectList) error {
 			"data",
 			"destination",
 			"left_delimiter",
+			"local_source",
 			"perms",
 			"right_delimiter",
 			"source",


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/3580

Signed-off-by: Joe Groocock <jgroocock@cloudflare.com>

This is early-stage so I may have missed some things. Feedback wanted please

The justification for this change is as already voiced in the above issue. Our use-case is that we need a strong coupling between job definition and configuration shipped with it, as it greatly simplifies rollout. It means we don't have to "assume" that the configuration is present on remote nodes and synchronising signalling becomes much easier.
This is effectively syntactic sugar for `data = "<blob>"`, but makes managing the jobs much easier. We have some several-thousand line files already templated by our configuration management.

One thing that I couldn't identify was the enforcement of this statement here:
https://www.nomadproject.io/docs/job-specification/template/#data
I presume it's not enforced in code, so it's up to the user to do the right thing. I think it would be good to add a check to ensure that a job isn't specifying multiple sources, otherwise it may appear that Nomad is doing the wrong thing by overwriting one source with another.