### PR TITLE
Add ControllersExpected to the PluginListStub

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -198,13 +198,15 @@ type CSIPlugin struct {
 	Version            string
 	ControllerRequired bool
 	// Map Node.ID to CSIInfo fingerprint results
-	Controllers        map[string]*CSIInfo
-	Nodes              map[string]*CSIInfo
-	Allocations        []*AllocationListStub
-	ControllersHealthy int
-	NodesHealthy       int
-	CreateIndex        uint64
-	ModifyIndex        uint64
+	Controllers         map[string]*CSIInfo
+	Nodes               map[string]*CSIInfo
+	Allocations         []*AllocationListStub
+	ControllersHealthy  int
+	ControllersExpected int
+	NodesHealthy        int
+	NodesExpected       int
+	CreateIndex         uint64
+	ModifyIndex         uint64
 }
 
 type CSIPluginListStub struct {


### PR DESCRIPTION
The diff is bad due to spacing, I really just added `ControllersExpected`. 

It is already on `CSIPlugin` and having it on `CSIPluginListStub` enables calculating health proportions using just the list api endpoint.