### PR TITLE
UI: CSI namespace bugs

### DIFF
--- a/ui/app/components/gutter-menu.js
+++ b/ui/app/components/gutter-menu.js
@@ -37,7 +37,13 @@ export default Component.extend({
   gotoJobsForNamespace(namespace) {
     if (!namespace || !namespace.get('id')) return;
 
-    this.router.transitionTo('jobs', {
+    // Jobs and CSI Volumes are both namespace-sensitive. Changing namespaces is
+    // an intent to reset context, but where to reset to depends on where the namespace
+    // is being switched from. Jobs take precedence, but if the namespace is switched from
+    // a storage-related page, context should be reset to volumes.
+    const destination = this.router.currentRouteName.startsWith('csi.') ? 'csi.volumes' : 'jobs';
+
+    this.router.transitionTo(destination, {
       queryParams: { namespace: namespace.get('id') },
     });
   },

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -51,13 +51,27 @@
         Workload
       </p>
       <ul class="menu-list">
-        <li>{{#link-to "jobs" activeClass="is-active" data-test-gutter-link="jobs"}}Jobs{{/link-to}}</li>
+        <li>
+          {{#link-to "jobs"
+            (query-params jobNamespace=system.activeNamespace.id)
+            activeClass="is-active"
+            data-test-gutter-link="jobs"}}
+            Jobs
+          {{/link-to}}
+        </li>
       </ul>
       <p class="menu-label is-minor">
         Integrations
       </p>
       <ul class="menu-list">
-        <li>{{#link-to "csi" activeClass="is-active" data-test-gutter-link="csi"}}Storage <span class="tag is-small">Beta</span>{{/link-to}}</li>
+        <li>
+          {{#link-to "csi"
+            (query-params volumeNamespace=system.activeNamespace.id)
+            activeClass="is-active"
+            data-test-gutter-link="storage"}}
+            Storage <span class="tag is-small">Beta</span>
+          {{/link-to}}
+        </li>
       </ul>
       <p class="menu-label">
         Cluster

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import pageSizeSelect from './behaviors/page-size-select';
 import JobsList from 'nomad-ui/tests/pages/jobs/list';
+import Layout from 'nomad-ui/tests/pages/layout';
 
 let managementToken, clientToken;
 
@@ -339,6 +340,17 @@ module('Acceptance | jobs list', function(hooks) {
     await JobsList.visit({ type: JSON.stringify(['batch']) });
 
     assert.equal(JobsList.jobs.length, 1, 'Only one job shown due to query param');
+  });
+
+  test('the active namespace is carried over to the storage pages', async function(assert) {
+    server.createList('namespace', 2);
+
+    const namespace = server.db.namespaces[1];
+    await JobsList.visit({ namespace: namespace.id });
+
+    await Layout.gutter.visitStorage();
+
+    assert.equal(currentURL(), `/csi/volumes?namespace=${namespace.id}`);
   });
 
   pageSizeSelect({

--- a/ui/tests/acceptance/volumes-list-test.js
+++ b/ui/tests/acceptance/volumes-list-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import pageSizeSelect from './behaviors/page-size-select';
 import VolumesList from 'nomad-ui/tests/pages/storage/volumes/list';
+import Layout from 'nomad-ui/tests/pages/layout';
 
 const assignWriteAlloc = (volume, alloc) => {
   volume.writeAllocs.add(alloc);
@@ -140,6 +141,17 @@ module('Acceptance | volumes list', function(hooks) {
 
     assert.equal(VolumesList.volumes.length, 1);
     assert.equal(VolumesList.volumes.objectAt(0).name, volume2.id);
+  });
+
+  test('the active namespace is carried over to the jobs pages', async function(assert) {
+    server.createList('namespace', 2);
+
+    const namespace = server.db.namespaces[1];
+    await VolumesList.visit({ namespace: namespace.id });
+
+    await Layout.gutter.visitJobs();
+
+    assert.equal(currentURL(), `/jobs?namespace=${namespace.id}`);
   });
 
   test('when accessing volumes is forbidden, a message is shown with a link to the tokens page', async function(assert) {

--- a/ui/tests/pages/layout.js
+++ b/ui/tests/pages/layout.js
@@ -27,5 +27,6 @@ export default create({
     visitJobs: clickable('[data-test-gutter-link="jobs"]'),
     visitClients: clickable('[data-test-gutter-link="clients"]'),
     visitServers: clickable('[data-test-gutter-link="servers"]'),
+    visitStorage: clickable('[data-test-gutter-link="storage"]'),
   },
 });


### PR DESCRIPTION
**This builds off of #7895. Only the last two commits are original. This should be rebased and merged second.**

There were a couple namespace quirks that the UI wasn't handling well. The combination of the two meant it was impossible to view CSI volumes for any namespace other than Default unless you put the namespace query param in the URL 😳 

**Bug 1: Switching namespaces shouldn't always redirect to Jobs**

This made sense when Jobs were the only namespace-sensitive resource, but volumes are too. Now the UI will reset to the Jobs list for the Volumes list depending on where you are in the app. If you are on a storage page, go to volumes, otherwise, go to jobs.

**Bug 2: Setting a namespace on the Volumes or Jobs page didn't carry over to the other page**

Switching to, say, Namespace 1 when looking at jobs successfully sets the active namespace to Namespace 1, but if you then click on the Storage nav link, the namespace is reset to Default since they have independent query params. Now the namespace query param is provided in the gutter menu link-tos

Since switching namespaces means being forced to the jobs page, and then revisiting storage means resetting the namespace back to Default, you can see how the two bugs work in concert to lock people out of seeing non-default namespaced volumes.