### PR TITLE
api: validate scale count value is not negative.

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -905,6 +905,9 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	if args.Error && args.Count != nil {
 		return structs.NewErrRPCCoded(400, "scaling action should not contain count if error is true")
 	}
+	if args.Count != nil && *args.Count < 0 {
+		return structs.NewErrRPCCoded(400, "scaling action count can't be negative")
+	}
 
 	// Check for submit-job permissions
 	if aclObj, err := j.srv.ResolveToken(args.AuthToken); err != nil {


### PR DESCRIPTION
An operator could submit a scale request including a negative count
value. This negative value caused the Nomad server to panic. The
fix adds validation to the submitted count, returning an error to
the caller if it is negative.

closes #7902 