### PR TITLE
volumewatcher: set maximum batch size for raft update

### DIFF
--- a/nomad/volumewatcher/batcher.go
+++ b/nomad/volumewatcher/batcher.go
@@ -77,6 +77,7 @@ func (b *VolumeUpdateBatcher) batcher() {
 		future: NewBatchFuture(),
 	}}
 	ticker := time.NewTicker(b.batchDuration)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-b.ctx.Done():


### PR DESCRIPTION
For https://github.com/hashicorp/nomad/issues/7838

The `volumewatcher` has a 250ms batch window so claim updates will not typically be large enough to risk exceeding the maximum raft message size. But large jobs might have enough volume claims that this could be a danger. Set a maximum batch size of 100 messages per batch (roughly 31K), as a very conservative safety/robustness guard.

In the future I'd like to factor this same logic out of the `deploymentwatcher` batcher so we could share implementations.