### PR TITLE
volumewatcher: stop watcher goroutines when there's no work

### DIFF
--- a/nomad/volumewatcher/volume_watcher.go
+++ b/nomad/volumewatcher/volume_watcher.go
@@ -124,6 +124,9 @@ func (vw *volumeWatcher) watch() {
 				}
 				vw.volumeReap(vol)
 			}
+		default:
+			vw.Stop() // no pending work
+			return
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7837

The watcher goroutines will be automatically started if a volume has updates, but when idle we shouldn't keep a goroutine running and taking up memory.

In addition to the unit test updates, I've tested this out on a real-world cluster and everything seems to work out ok.