### PR TITLE
Scheduler Algorithm Defaults handling and docs

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -285,6 +285,8 @@ func (c *Command) readConfig() *Config {
 		config.PluginDir = filepath.Join(config.DataDir, "plugins")
 	}
 
+	config.Server.DefaultSchedulerConfig.Canonicalize()
+
 	if !c.isValidConfig(config, cmdConfig) {
 		return nil
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1120,6 +1120,8 @@ func (n *nomadFSM) applySchedulerConfigUpdate(buf []byte, index uint64) interfac
 	}
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_scheduler_config"}, time.Now())
 
+	req.Config.Canonicalize()
+
 	if req.CAS {
 		applied, err := n.state.SchedulerCASConfig(index, req.Config.ModifyIndex, &req.Config)
 		if err != nil {
@@ -1417,6 +1419,7 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(schedConfig); err != nil {
 				return err
 			}
+			schedConfig.Canonicalize()
 			if err := restore.SchedulerConfigRestore(schedConfig); err != nil {
 				return err
 			}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2823,6 +2823,7 @@ func TestFSM_SnapshotRestore_SchedulerConfiguration(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	schedConfig := &structs.SchedulerConfiguration{
+		SchedulerAlgorithm: "spread",
 		PreemptionConfig: structs.PreemptionConfig{
 			SystemSchedulerEnabled: true,
 		},

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -162,6 +162,12 @@ func (s *SchedulerConfiguration) EffectiveSchedulerAlgorithm() SchedulerAlgorith
 	return s.SchedulerAlgorithm
 }
 
+func (s *SchedulerConfiguration) Canonicalize() {
+	if s != nil && s.SchedulerAlgorithm == "" {
+		s.SchedulerAlgorithm = SchedulerAlgorithmBinpack
+	}
+}
+
 func (s *SchedulerConfiguration) Validate() error {
 	if s == nil {
 		return nil

--- a/website/pages/api-docs/operator.mdx
+++ b/website/pages/api-docs/operator.mdx
@@ -356,6 +356,7 @@ The table below shows this endpoint's support for
   "SchedulerConfig": {
     "CreateIndex": 5,
     "ModifyIndex": 5,
+    "SchedulerAlgorithm": "spread",
     "PreemptionConfig": {
       "SystemSchedulerEnabled": true,
       "BatchSchedulerEnabled": false,
@@ -373,10 +374,19 @@ The table below shows this endpoint's support for
 - `SchedulerConfig` `(SchedulerConfig)` - The returned `SchedulerConfig` object has configuration
   settings mentioned below.
 
-  - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for various schedulers. - `SystemSchedulerEnabled` `(bool: true)` - Specifies whether preemption for system jobs is enabled. Note that
-    this defaults to true. - `BatchSchedulerEnabled` `(bool: false)` (Enterprise Only) - Specifies whether preemption for batch jobs is enabled. Note that
-    this defaults to false and must be explicitly enabled. - `ServiceSchedulerEnabled` `(bool: false)` (Enterprise Only) - Specifies whether preemption for service jobs is enabled. Note that
+  - `SchedulerAlgorithm` `(string: "binpack")` - Specifies whether scheduler binpacks or spreads allocations on available nodes.
+
+  - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for various schedulers.
+
+    - `SystemSchedulerEnabled` `(bool: true)` - Specifies whether preemption for system jobs is enabled. Note that
+    this defaults to true.
+
+    - `BatchSchedulerEnabled` `(bool: false)` (Enterprise Only) - Specifies whether preemption for batch jobs is enabled. Note that
     this defaults to false and must be explicitly enabled.
+
+    - `ServiceSchedulerEnabled` `(bool: false)` (Enterprise Only) - Specifies whether preemption for service jobs is enabled. Note that
+    this defaults to false and must be explicitly enabled.
+
   - `CreateIndex` - The Raft index at which the config was created.
   - `ModifyIndex` - The Raft index at which the config was modified.
 
@@ -406,6 +416,7 @@ The table below shows this endpoint's support for
 
 ```json
 {
+  "SchedulerAlgorithm": "spread",
   "PreemptionConfig": {
     "SystemSchedulerEnabled": true,
     "BatchSchedulerEnabled": false,
@@ -414,6 +425,7 @@ The table below shows this endpoint's support for
 }
 ```
 
+- `SchedulerAlgorithm` `(string: "binpack")` - Specifies whether scheduler binpacks or spreads allocations on available nodes.  Possible values are `"binpack"` and `"spread"`
 - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for various schedulers.
 - `SystemSchedulerEnabled` `(bool: true)` - Specifies whether preemption for system jobs is enabled. Note that
   if this is set to true, then system jobs can preempt any other jobs.

--- a/website/pages/docs/configuration/server.mdx
+++ b/website/pages/docs/configuration/server.mdx
@@ -242,6 +242,8 @@ This example shows enabling preemption for all schedulers.
 ```hcl
 server {
   default_scheduler_config {
+    scheduler_algorithm = "binpack"
+
     preemption_config {
       batch_scheduler_enabled   = true
       system_scheduler_enabled  = true


### PR DESCRIPTION
Ensure that `""` Scheduler Algorithm gets explicitly set to binpack on
upgrades or on API handling when user misses the value.

The scheduler already treats `""` value as binpack.  This PR merely
ensures that the operator API returns the effective value.

Also update docs with scheduler algorithm.