### PR TITLE
the api.ScalingEvent struct was missing the .Count field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ BUG FIXES:
  * core: job scale status endpoint was returning incorrect counts [[GH-7789](https://github.com/hashicorp/nomad/issues/7789)]
  * core: Fixed bugs related to periodic jobs scheduled during daylight saving transition periods [[GH-7894](https://github.com/hashicorp/nomad/issues/7894)]
  * core: Fixed a bug where scores for allocations were biased toward nodes with resource reservations [[GH-7730](https://github.com/hashicorp/nomad/issues/7730)]
+ * api: api.ScalingEvent struct was missing .Count [[GH-7915](https://github.com/hashicorp/nomad/pulls/7915)]
  * api: validate scale count value is not negative [[GH-7902](https://github.com/hashicorp/nomad/issues/7902)]
  * api: autoscaling policies should not be returned for stopped jobs [[GH-7768](https://github.com/hashicorp/nomad/issues/7768)]
  * client: Fixed a bug where an multi-task allocation maybe considered unhealthy if some tasks are slow to start [[GH-7944](https://github.com/hashicorp/nomad/issues/7944)]

--- a/api/scaling.go
+++ b/api/scaling.go
@@ -92,6 +92,7 @@ type TaskGroupScaleStatus struct {
 }
 
 type ScalingEvent struct {
+	Count       *int64
 	Error       bool
 	Message     string
 	Meta        map[string]interface{}


### PR DESCRIPTION
the field was present in the `structs.ScalingEvent` struct, so it was returned from server. however, API client users (as well as the Java SDK, generated from the API client) was missing the field.