### PR TITLE
e2e: upgrade consul in packer setup to 1.7.3 from 1.6.1

### DIFF
--- a/e2e/terraform/packer/linux/setup.sh
+++ b/e2e/terraform/packer/linux/setup.sh
@@ -10,7 +10,7 @@ sudo chown -R ubuntu:ubuntu /ops/shared
 
 cd /ops
 
-CONSULVERSION=1.6.1
+CONSULVERSION=1.7.3
 CONSULDOWNLOAD=https://releases.hashicorp.com/consul/${CONSULVERSION}/consul_${CONSULVERSION}_linux_amd64.zip
 CONSULCONFIGDIR=/etc/consul.d
 CONSULDIR=/opt/consul

--- a/e2e/terraform/packer/windows/install-consul.ps1
+++ b/e2e/terraform/packer/windows/install-consul.ps1
@@ -8,7 +8,7 @@ Set-Location C:\opt
 
 Try {
     $releases = "https://releases.hashicorp.com"
-    $version = "1.6.1"
+    $version = "1.7.3"
     $url = "${releases}/consul/${version}/consul_${version}_windows_amd64.zip"
 
     $configDir = "C:\opt\consul.d"


### PR DESCRIPTION
There have been a number of bug fixes and features particularly around
Connect that will help us in Nomad's e2e tests. Upgrade Consul in our
packer builder so e2e can make use of the new version.

Should fix #7920
