### PR TITLE
Clarify Msgpack handling of json tags

### DIFF
--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -1,6 +1,6 @@
 package structs
 
-//go:generate codecgen -c github.com/hashicorp/go-msgpack/codec -d 102 -t codegen_generated -o structs.generated.go structs.go
+//go:generate codecgen -c github.com/hashicorp/go-msgpack/codec -st codec -d 102 -t codegen_generated -o structs.generated.go structs.go
 
 import (
 	"errors"

--- a/helper/pool/pool.go
+++ b/helper/pool/pool.go
@@ -21,12 +21,12 @@ import (
 
 // NewClientCodec returns a new rpc.ClientCodec to be used to make RPC calls.
 func NewClientCodec(conn io.ReadWriteCloser) rpc.ClientCodec {
-	return msgpackrpc.NewCodecFromHandle(true, true, conn, structs.HashiMsgpackHandle)
+	return msgpackrpc.NewCodecFromHandle(true, true, conn, structs.MsgpackHandle)
 }
 
 // NewServerCodec returns a new rpc.ServerCodec to be used to handle RPCs.
 func NewServerCodec(conn io.ReadWriteCloser) rpc.ServerCodec {
-	return msgpackrpc.NewCodecFromHandle(true, true, conn, structs.HashiMsgpackHandle)
+	return msgpackrpc.NewCodecFromHandle(true, true, conn, structs.MsgpackHandle)
 }
 
 // streamClient is used to wrap a stream with an RPC client

--- a/nomad/structs/generate.sh
+++ b/nomad/structs/generate.sh
@@ -4,6 +4,7 @@ set -e
 FILES="$(ls ./*.go | grep -v -e _test.go -e .generated.go | tr '\n' ' ')"
 codecgen \
     -c github.com/hashicorp/go-msgpack/codec \
+    -st codec \
     -d 100 \
     -t codegen_generated \
     -o structs.generated.go \

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gorhill/cronexpr"
 	"github.com/hashicorp/go-msgpack/codec"
-	hcodec "github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-version"
 	"github.com/mitchellh/copystructure"
@@ -9576,23 +9575,6 @@ var (
 		Indent:        4,
 	}
 )
-
-// TODO Figure out if we can remove this. This is our fork that is just way
-// behind. I feel like its original purpose was to pin at a stable version but
-// now we can accomplish this with vendoring.
-var HashiMsgpackHandle = func() *hcodec.MsgpackHandle {
-	h := &hcodec.MsgpackHandle{}
-	h.RawToString = true
-
-	// maintain binary format from time prior to upgrading latest ugorji
-	h.BasicHandle.TimeNotBuiltin = true
-
-	// Sets the default type for decoding a map into a nil interface{}.
-	// This is necessary in particular because we store the driver configs as a
-	// nil interface{}.
-	h.MapType = reflect.TypeOf(map[string]interface{}(nil))
-	return h
-}()
 
 // Decode is used to decode a MsgPack encoded object
 func Decode(buf []byte, out interface{}) error {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9561,6 +9561,9 @@ var MsgpackHandle = func() *codec.MsgpackHandle {
 	// nil interface{}.
 	h.MapType = reflect.TypeOf(map[string]interface{}(nil))
 
+	// only review struct codec tags
+	h.TypeInfos = codec.NewTypeInfos([]string{"codec"})
+
 	return h
 }()
 

--- a/plugins/base/plugin.go
+++ b/plugins/base/plugin.go
@@ -65,6 +65,10 @@ var MsgpackHandle = func() *codec.MsgpackHandle {
 	h.BasicHandle.TimeNotBuiltin = true
 
 	h.MapType = reflect.TypeOf(map[string]interface{}(nil))
+
+	// only review struct codec tags - ignore `json` flags
+	h.TypeInfos = codec.NewTypeInfos([]string{"codec"})
+
 	return h
 }()
 


### PR DESCRIPTION
When serializing structs with msgpack, only consider type tags of
`codec`.

Hashicorp/go-msgpack (based on ugorji/go) defaults to interpretting
`codec` tag if it's available, but falls to using `json` if `codec`
isn't present.

This behavior is surprising in cases where we want to serialize json
differently from msgpack, e.g. serializing `ConsulExposeConfig`.


This is a follow up to https://github.com/hashicorp/nomad/pull/7690