### PR TITLE
Docker runtimes

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -341,7 +341,7 @@ var (
 		})),
 		"network_aliases": hclspec.NewAttr("network_aliases", "list(string)", false),
 		"network_mode":    hclspec.NewAttr("network_mode", "string", false),
-		"oci_runtime":     hclspec.NewAttr("oci_runtime", "string", false),
+		"runtime":         hclspec.NewAttr("runtime", "string", false),
 		"pids_limit":      hclspec.NewAttr("pids_limit", "number", false),
 		"pid_mode":        hclspec.NewAttr("pid_mode", "string", false),
 		"port_map":        hclspec.NewAttr("port_map", "list(map(number))", false),
@@ -405,7 +405,7 @@ type TaskConfig struct {
 	Mounts            []DockerMount      `codec:"mounts"`
 	NetworkAliases    []string           `codec:"network_aliases"`
 	NetworkMode       string             `codec:"network_mode"`
-	OCIRuntime        string             `codec:"oci_runtime"`
+	Runtime           string             `codec:"runtime"`
 	PidsLimit         int64              `codec:"pids_limit"`
 	PidMode           string             `codec:"pid_mode"`
 	PortMap           hclutils.MapStrInt `codec:"port_map"`

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -341,6 +341,7 @@ var (
 		})),
 		"network_aliases": hclspec.NewAttr("network_aliases", "list(string)", false),
 		"network_mode":    hclspec.NewAttr("network_mode", "string", false),
+		"oci_runtime":     hclspec.NewAttr("oci_runtime", "string", false),
 		"pids_limit":      hclspec.NewAttr("pids_limit", "number", false),
 		"pid_mode":        hclspec.NewAttr("pid_mode", "string", false),
 		"port_map":        hclspec.NewAttr("port_map", "list(map(number))", false),
@@ -404,6 +405,7 @@ type TaskConfig struct {
 	Mounts            []DockerMount      `codec:"mounts"`
 	NetworkAliases    []string           `codec:"network_aliases"`
 	NetworkMode       string             `codec:"network_mode"`
+	OCIRuntime        string             `codec:"oci_runtime"`
 	PidsLimit         int64              `codec:"pids_limit"`
 	PidMode           string             `codec:"pid_mode"`
 	PortMap           hclutils.MapStrInt `codec:"port_map"`

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -252,8 +252,8 @@ var (
 			hclspec.NewLiteral(`"nvidia"`),
 		),
 		// list of docker runtimes allowed to be used
-		"allowed_runtimes": hclspec.NewDefault(
-			hclspec.NewAttr("allowed_runtimes", "list(string)", false),
+		"allow_runtimes": hclspec.NewDefault(
+			hclspec.NewAttr("allow_runtimes", "list(string)", false),
 			hclspec.NewLiteral(`["runc", "nvidia"]`),
 		),
 		// image to use when creating a network namespace parent container
@@ -579,8 +579,8 @@ type DriverConfig struct {
 	PullActivityTimeout         string        `codec:"pull_activity_timeout"`
 	pullActivityTimeoutDuration time.Duration `codec:"-"`
 
-	AllowedRuntimesList []string            `codec:"allowed_runtimes"`
-	allowedRuntimes     map[string]struct{} `codec:"-"`
+	AllowRuntimesList []string            `codec:"allow_runtimes"`
+	allowRuntimes     map[string]struct{} `codec:"-"`
 }
 
 type AuthConfig struct {
@@ -666,9 +666,9 @@ func (d *Driver) SetConfig(c *base.Config) error {
 		d.config.pullActivityTimeoutDuration = dur
 	}
 
-	d.config.allowedRuntimes = make(map[string]struct{}, len(d.config.AllowedRuntimesList))
-	for _, r := range d.config.AllowedRuntimesList {
-		d.config.allowedRuntimes[r] = struct{}{}
+	d.config.allowRuntimes = make(map[string]struct{}, len(d.config.AllowRuntimesList))
+	for _, r := range d.config.AllowRuntimesList {
+		d.config.allowRuntimes[r] = struct{}{}
 	}
 
 	if c.AgentConfig != nil {

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -554,7 +554,7 @@ func TestConfig_DriverConfig_PullActivityTimeout(t *testing.T) {
 	}
 }
 
-func TestConfig_DriverConfig_AllowedRuntimes(t *testing.T) {
+func TestConfig_DriverConfig_AllowRuntimes(t *testing.T) {
 	cases := []struct {
 		name     string
 		config   string
@@ -567,7 +567,7 @@ func TestConfig_DriverConfig_AllowedRuntimes(t *testing.T) {
 		},
 		{
 			name:     "custom",
-			config:   `{ allowed_runtimes = ["runc", "firecracker"]}`,
+			config:   `{ allow_runtimes = ["runc", "firecracker"]}`,
 			expected: map[string]struct{}{"runc": struct{}{}, "firecracker": struct{}{}},
 		},
 	}
@@ -579,7 +579,7 @@ func TestConfig_DriverConfig_AllowedRuntimes(t *testing.T) {
 
 			dh := dockerDriverHarness(t, tc)
 			d := dh.Impl().(*Driver)
-			require.Equal(t, c.expected, d.config.allowedRuntimes)
+			require.Equal(t, c.expected, d.config.allowRuntimes)
 		})
 	}
 

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -270,6 +270,7 @@ config {
   }
   privileged = true
   readonly_rootfs = true
+  runtime = "runc"
   security_opt = [
     "credentialspec=file://gmsaUser.json"
   ],
@@ -398,6 +399,7 @@ config {
 		},
 		Privileged:     true,
 		ReadonlyRootfs: true,
+		Runtime:        "runc",
 		SecurityOpt: []string{
 			"credentialspec=file://gmsaUser.json",
 		},
@@ -550,4 +552,35 @@ func TestConfig_DriverConfig_PullActivityTimeout(t *testing.T) {
 			require.Equal(t, c.expected, tc.PullActivityTimeout)
 		})
 	}
+}
+
+func TestConfig_DriverConfig_AllowedRuntimes(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   string
+		expected map[string]struct{}
+	}{
+		{
+			name:     "pure default",
+			config:   `{}`,
+			expected: map[string]struct{}{"runc": struct{}{}, "nvidia": struct{}{}},
+		},
+		{
+			name:     "custom",
+			config:   `{ allowed_runtimes = ["runc", "firecracker"]}`,
+			expected: map[string]struct{}{"runc": struct{}{}, "firecracker": struct{}{}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var tc map[string]interface{}
+			hclutils.NewConfigParser(configSpec).ParseHCL(t, "config "+c.config, &tc)
+
+			dh := dockerDriverHarness(t, tc)
+			d := dh.Impl().(*Driver)
+			require.Equal(t, c.expected, d.config.allowedRuntimes)
+		})
+	}
+
 }

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -742,7 +742,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	containerRuntime := driverConfig.Runtime
 	if _, ok := task.DeviceEnv[nvidiaVisibleDevices]; ok {
 		if !d.gpuRuntime {
-			return c, fmt.Errorf("requested docker-runtime %q was not found", d.config.GPURuntimeName)
+			return c, fmt.Errorf("requested docker runtime %q was not found", d.config.GPURuntimeName)
 		}
 		if containerRuntime != "" && containerRuntime != d.config.GPURuntimeName {
 			return c, fmt.Errorf("conflicting runtime requests: gpu runtime %q conflicts with task runtime %q", d.config.GPURuntimeName, containerRuntime)
@@ -750,7 +750,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		containerRuntime = d.config.GPURuntimeName
 	}
 	if _, ok := d.config.allowedRuntimes[containerRuntime]; !ok && containerRuntime != "" {
-		return c, fmt.Errorf("requested runtime is not allowed: %q", containerRuntime)
+		return c, fmt.Errorf("requested runtime %q is not allowed", containerRuntime)
 	}
 
 	hostConfig := &docker.HostConfig{

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -760,11 +760,11 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		}
 		hostConfig.Runtime = d.config.GPURuntimeName
 	}
-	if driverConfig.OCIRuntime != "" {
+	if driverConfig.Runtime != "" && driverConfig.Runtime != hostConfig.Runtime {
 		if hostConfig.Runtime != "" {
-			return c, fmt.Errorf("oci_runtime '%s' requested conflicts with gpu runtime '%s'", driverConfig.OCIRuntime, hostConfig.Runtime)
+			return c, fmt.Errorf("runtime '%s' requested conflicts with gpu runtime '%s'", driverConfig.Runtime, hostConfig.Runtime)
 		}
-		hostConfig.Runtime = driverConfig.OCIRuntime
+		hostConfig.Runtime = driverConfig.Runtime
 	}
 
 	// Calculate CPU Quota

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -749,7 +749,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		}
 		containerRuntime = d.config.GPURuntimeName
 	}
-	if _, ok := d.config.allowedRuntimes[containerRuntime]; !ok && containerRuntime != "" {
+	if _, ok := d.config.allowRuntimes[containerRuntime]; !ok && containerRuntime != "" {
 		return c, fmt.Errorf("requested runtime %q is not allowed", containerRuntime)
 	}
 

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -760,6 +760,12 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		}
 		hostConfig.Runtime = d.config.GPURuntimeName
 	}
+	if driverConfig.OCIRuntime != "" {
+		if hostConfig.Runtime != "" {
+			return c, fmt.Errorf("oci_runtime '%s' requested conflicts with gpu runtime '%s'", driverConfig.OCIRuntime, hostConfig.Runtime)
+		}
+		hostConfig.Runtime = driverConfig.OCIRuntime
+	}
 
 	// Calculate CPU Quota
 	// cfs_quota_us is the time per core, so we must

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1101,18 +1101,18 @@ func TestDockerDriver_CreateContainerConfig_RuntimeConflict(t *testing.T) {
 	require.Contains(t, err.Error(), "conflicting runtime requests")
 }
 
-func TestDockerDriver_CreateContainerConfig_ChecksAllowedRuntimes(t *testing.T) {
+func TestDockerDriver_CreateContainerConfig_ChecksAllowRuntimes(t *testing.T) {
 	t.Parallel()
 
 	dh := dockerDriverHarness(t, nil)
 	driver := dh.Impl().(*Driver)
 	driver.gpuRuntime = true
-	driver.config.allowedRuntimes = map[string]struct{}{
+	driver.config.allowRuntimes = map[string]struct{}{
 		"runc":   struct{}{},
 		"custom": struct{}{},
 	}
 
-	allowedRuntime := []string{
+	allowRuntime := []string{
 		"", // default always works
 		"runc",
 		"custom",
@@ -1122,7 +1122,7 @@ func TestDockerDriver_CreateContainerConfig_ChecksAllowedRuntimes(t *testing.T) 
 	defer freeport.Return(ports)
 	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
-	for _, runtime := range allowedRuntime {
+	for _, runtime := range allowRuntime {
 		t.Run(runtime, func(t *testing.T) {
 			cfg.Runtime = runtime
 			c, err := driver.createContainerConfig(task, cfg, "org/repo:0.1")

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -407,12 +407,12 @@ The `docker` driver supports the following configuration in the job spec. Only
   the container's filesystem as read only.
 
 - `runtime` - (Optional) A string representing a configured runtime to pass to docker.
-  This is equivilent to the --runtime argument in the docker CLI
+  This is equivalent to the `--runtime` argument in the docker CLI
   For example, to use gvisor:
 
   ```hcl
   config {
-    runtime = "runsc"
+    runtime = "runc"
   }
   ```
 

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -406,6 +406,16 @@ The `docker` driver supports the following configuration in the job spec. Only
 - `readonly_rootfs` - (Optional) `true` or `false` (default). Mount
   the container's filesystem as read only.
 
+- `oci_runtime` - (Optional) A string representing a configured OCI runtime to pass to docker.
+  This is equivilent to the --runtime argument in the docker CLI.
+  For example, to use gvisor:
+
+  ```hcl
+  config {
+    oci_runtime = "runsc"
+  }
+  ```
+
 - `pids_limit` - (Optional) An integer value that specifies the pid limit for
   the container. Defaults to unlimited.
 

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -406,13 +406,13 @@ The `docker` driver supports the following configuration in the job spec. Only
 - `readonly_rootfs` - (Optional) `true` or `false` (default). Mount
   the container's filesystem as read only.
 
-- `oci_runtime` - (Optional) A string representing a configured OCI runtime to pass to docker.
-  This is equivilent to the --runtime argument in the docker CLI.
+- `runtime` - (Optional) A string representing a configured runtime to pass to docker.
+  This is equivilent to the --runtime argument in the docker CLI
   For example, to use gvisor:
 
   ```hcl
   config {
-    oci_runtime = "runsc"
+    runtime = "runsc"
   }
   ```
 

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -408,11 +408,12 @@ The `docker` driver supports the following configuration in the job spec. Only
 
 - `runtime` - (Optional) A string representing a configured runtime to pass to docker.
   This is equivalent to the `--runtime` argument in the docker CLI
-  For example, to use gvisor:
+  For example, to use gVisor:
 
   ```hcl
   config {
-    runtime = "runc"
+    # gVisor runtime is runsc
+    runtime = "runsc"
   }
   ```
 
@@ -708,6 +709,9 @@ plugin "docker" {
   operator to control which capabilities can be obtained by tasks using cap_add
   and cap_drop options. Supports the value "ALL" as a shortcut for whitelisting
   all capabilities.
+
+- `allow_runtimes` - defaults to `["runc", "nvidia"]` - A list of the allowed
+  docker runtimes a task may use.
 
 - `auth` stanza:
 


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/nomad/pull/7589 to add more tests and have an allow list for runtimes.  The allowed list defaults to runc and nvidia.

Thanks @benbuzbee !