### PR TITLE
acl: bootstrap master token from config file

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -201,6 +201,9 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	if agentConfig.ACL.ReplicationToken != "" {
 		conf.ReplicationToken = agentConfig.ACL.ReplicationToken
 	}
+	if agentConfig.ACL.MasterToken != "" {
+		conf.ACLMasterToken = agentConfig.ACL.MasterToken
+	}
 	if agentConfig.Sentinel != nil {
 		conf.SentinelConfig = agentConfig.Sentinel
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -323,6 +323,8 @@ type ACLConfig struct {
 	PolicyTTL    time.Duration
 	PolicyTTLHCL string `hcl:"policy_ttl" json:"-"`
 
+	MasterToken string `hcl:"master_token"`
+
 	// ReplicationToken is used by servers to replicate tokens and policies
 	// from the authoritative region. This must be a valid management token
 	// within the authoritative region.
@@ -1286,6 +1288,9 @@ func (a *ACLConfig) Merge(b *ACLConfig) *ACLConfig {
 	}
 	if b.PolicyTTLHCL != "" {
 		result.PolicyTTLHCL = b.PolicyTTLHCL
+	}
+	if b.MasterToken != "" {
+		result.MasterToken = b.MasterToken
 	}
 	if b.ReplicationToken != "" {
 		result.ReplicationToken = b.ReplicationToken

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -280,6 +280,11 @@ type Config struct {
 	// ACLEnabled controls if ACL enforcement and management is enabled.
 	ACLEnabled bool
 
+	// ACLMasterToken is used to bootstrap the ACL system. It should be specified
+	// on the servers in the AuthoritativeRegion. When the leader comes online, it ensures
+	// that the Master token is available. This provides the initial token.
+	ACLMasterToken string
+
 	// ReplicationBackoff is how much we backoff when replication errors.
 	// This is a tunable knob for testing primarily.
 	ReplicationBackoff time.Duration

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9991,8 +9991,8 @@ type ACLTokenDeleteRequest struct {
 
 // ACLTokenBootstrapRequest is used to bootstrap ACLs
 type ACLTokenBootstrapRequest struct {
-	Token      *ACLToken // Not client specifiable
-	ResetIndex uint64    // Reset index is used to clear the bootstrap token
+	Token      *ACLToken
+	ResetIndex uint64 // Reset index is used to clear the bootstrap token
 	WriteRequest
 }
 

--- a/website/pages/docs/configuration/acl.mdx
+++ b/website/pages/docs/configuration/acl.mdx
@@ -40,6 +40,16 @@ acl {
   the request load against servers. If a client cannot reach a server, for example
   because of an outage, the TTL will be ignored and the cached value used.
 
+- `master_token` `(string: "")` - Only used for servers in the
+  [authoritative_region](/docs/configuration/server/#authoritative_region).
+  This token will be created with management-level permissions if it does not exist.
+  It allows operators to bootstrap the ACL system with a token Secret ID that is well-known.
+  The master token is only installed when a server acquires cluster leadership.
+  If you would like to install or change the master_token, set the new value for
+  master in the configuration for all servers. Once this is done, restart the current
+  leader to force a leader election. If the master token is not supplied, then
+  the servers do not create a master token. When you provide a value, it should be a UUID.
+
 - `replication_token` `(string: "")` - Specifies the Secret ID of the ACL token
   to use for replicating policies and tokens. This is used by servers in non-authoritative
   region to mirror the policies and tokens into the local region.


### PR DESCRIPTION
Fixes #7777 
Add support for acl `master_token` like in Consul