### PR TITLE
Fix formatting error on preemption docs page

### DIFF
--- a/website/pages/docs/internals/scheduling/preemption.mdx
+++ b/website/pages/docs/internals/scheduling/preemption.mdx
@@ -11,10 +11,7 @@ Preemption allows Nomad to kill existing allocations in order to place allocatio
 The evicted allocation is temporary displaced until the cluster has capacity to run it. This allows operators to
 run high priority jobs even under resource contention across the cluster.
 
-~> **Advanced Topic!** This page covers technical details of Nomad. You do not
-~> need to understand these details to effectively use Nomad. The details are
-~> documented here for those who wish to learn about them without having to
-~> go spelunking through the source code.
+~> **Advanced Topic!** This page covers technical details of Nomad. You do not need to understand these details to effectively use Nomad. The details are documented here for those who wish to learn about them without having to go spelunking through the source code.
 
 # Preemption in Nomad
 


### PR DESCRIPTION
Just a small formatting error in the docs!