### PR TITLE
UI: CSI Bug, Imperatively load controller/node plugin allocations

### DIFF
--- a/ui/app/components/allocation-row.js
+++ b/ui/app/components/allocation-row.js
@@ -80,7 +80,9 @@ async function qualifyAllocation() {
 
   // Make sure the allocation is a complete record and not a partial so we
   // can show information such as preemptions and rescheduled allocation.
-  await allocation.reload();
+  if (allocation.isPartial) {
+    await allocation.reload();
+  }
 
   if (allocation.get('job.isPending')) {
     // Make sure the job is loaded before starting the stats tracker

--- a/ui/app/components/allocation-row.js
+++ b/ui/app/components/allocation-row.js
@@ -46,6 +46,10 @@ export default Component.extend({
   },
 
   didReceiveAttrs() {
+    this.updateStatsTracker();
+  },
+
+  updateStatsTracker() {
     const allocation = this.allocation;
 
     if (allocation) {

--- a/ui/app/components/plugin-allocation-row.js
+++ b/ui/app/components/plugin-allocation-row.js
@@ -1,7 +1,23 @@
-import { alias } from '@ember/object/computed';
 import AllocationRow from 'nomad-ui/components/allocation-row';
 
 export default AllocationRow.extend({
   pluginAllocation: null,
-  allocation: alias('pluginAllocation.allocation'),
+  allocation: null,
+
+  didReceiveAttrs() {
+    this.setAllocation();
+  },
+
+  // The allocation for the plugin's controller or storage plugin needs
+  // to be imperatively fetched since these plugins are Fragments which
+  // can't have relationships.
+  async setAllocation() {
+    if (this.pluginAllocation && !this.allocation) {
+      const allocation = await this.pluginAllocation.getAllocation();
+      if (!this.isDestroyed) {
+        this.set('allocation', allocation);
+        this.updateStatsTracker();
+      }
+    }
+  },
 });

--- a/ui/app/components/plugin-allocation-row.js
+++ b/ui/app/components/plugin-allocation-row.js
@@ -5,6 +5,8 @@ export default AllocationRow.extend({
   allocation: null,
 
   didReceiveAttrs() {
+    // Allocation is always set through pluginAllocation
+    this.set('allocation', null);
     this.setAllocation();
   },
 

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -1,6 +1,6 @@
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
+import { equal, none } from '@ember/object/computed';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
@@ -42,6 +42,11 @@ export default Model.extend({
 
   isRunning: equal('clientStatus', 'running'),
   isMigrating: attr('boolean'),
+
+  // An allocation model created from any allocation list response will be lacking
+  // many properties (some of which can always be null). This is an indicator that
+  // the allocation needs to be reloaded to get the complete allocation state.
+  isPartial: none('allocationTaskGroup'),
 
   // When allocations are server-side rescheduled, a paper trail
   // is left linking all reschedule attempts.

--- a/ui/app/models/storage-controller.js
+++ b/ui/app/models/storage-controller.js
@@ -1,25 +1,13 @@
-import { computed } from '@ember/object';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
 import Fragment from 'ember-data-model-fragments/fragment';
 import { fragmentOwner } from 'ember-data-model-fragments/attributes';
-import PromiseObject from 'nomad-ui/utils/classes/promise-object';
 
 export default Fragment.extend({
   plugin: fragmentOwner(),
 
   node: belongsTo('node'),
   allocID: attr('string'),
-
-  // Model fragments don't support relationships, but with an allocation ID
-  // a "belongsTo" can be sufficiently mocked.
-  allocation: computed('allocID', function() {
-    if (!this.allocID) return null;
-    return PromiseObject.create({
-      promise: this.store.findRecord('allocation', this.allocID),
-      reload: () => this.store.findRecord('allocation', this.allocID),
-    });
-  }),
 
   provider: attr('string'),
   version: attr('string'),
@@ -30,4 +18,9 @@ export default Fragment.extend({
   requiresTopologies: attr('boolean'),
 
   controllerInfo: attr(),
+
+  // Fragments can't have relationships, so provider a manual getter instead.
+  async getAllocation() {
+    return this.store.findRecord('allocation', this.allocID);
+  },
 });

--- a/ui/app/models/storage-node.js
+++ b/ui/app/models/storage-node.js
@@ -1,25 +1,13 @@
-import { computed } from '@ember/object';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
 import Fragment from 'ember-data-model-fragments/fragment';
 import { fragmentOwner } from 'ember-data-model-fragments/attributes';
-import PromiseObject from 'nomad-ui/utils/classes/promise-object';
 
 export default Fragment.extend({
   plugin: fragmentOwner(),
 
   node: belongsTo('node'),
   allocID: attr('string'),
-
-  // Model fragments don't support relationships, but with an allocation ID
-  // a "belongsTo" can be sufficiently mocked.
-  allocation: computed('allocID', function() {
-    if (!this.allocID) return null;
-    return PromiseObject.create({
-      promise: this.store.findRecord('allocation', this.allocID),
-      reload: () => this.store.findRecord('allocation', this.allocID),
-    });
-  }),
 
   provider: attr('string'),
   version: attr('string'),
@@ -30,4 +18,9 @@ export default Fragment.extend({
   requiresTopologies: attr('boolean'),
 
   nodeInfo: attr(),
+
+  // Fragments can't have relationships, so provider a manual getter instead.
+  async getAllocation() {
+    return this.store.findRecord('allocation', this.allocID);
+  },
 });

--- a/ui/app/templates/csi/plugins/plugin.hbs
+++ b/ui/app/templates/csi/plugins/plugin.hbs
@@ -44,7 +44,7 @@
             <th>CPU</th>
             <th>Memory</th>
           {{/t.head}}
-          {{#t.body as |row|}}
+          {{#t.body key="model.allocID" as |row|}}
             {{plugin-allocation-row
               data-test-controller-allocation=row.model.allocID
               pluginAllocation=row.model}}
@@ -81,7 +81,7 @@
             <th>CPU</th>
             <th>Memory</th>
           {{/t.head}}
-          {{#t.body as |row|}}
+          {{#t.body key="model.allocID" as |row|}}
             {{plugin-allocation-row
               data-test-node-allocation=row.model.allocID
               pluginAllocation=row.model}}

--- a/ui/tests/integration/plugin-allocation-row-test.js
+++ b/ui/tests/integration/plugin-allocation-row-test.js
@@ -1,0 +1,101 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { startMirage } from 'nomad-ui/initializers/ember-cli-mirage';
+import { render, settled } from '@ember/test-helpers';
+import { initialize as fragmentSerializerInitializer } from 'nomad-ui/initializers/fragment-serializer';
+
+module('Integration | Component | plugin allocation row', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    fragmentSerializerInitializer(this.owner);
+    this.store = this.owner.lookup('service:store');
+    this.server = startMirage();
+    this.server.create('node');
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
+  test('Plugin allocation row immediately fetches the plugin allocation', async function(assert) {
+    const plugin = this.server.create('csi-plugin', { id: 'plugin' });
+    const storageController = plugin.controllers.models[0];
+
+    const pluginRecord = await this.store.find('plugin', 'csi/plugin');
+
+    this.setProperties({
+      plugin: pluginRecord.get('controllers.firstObject'),
+    });
+
+    await render(hbs`
+      {{plugin-allocation-row pluginAllocation=plugin}}
+    `);
+
+    await settled();
+
+    const allocationRequest = this.server.pretender.handledRequests.find(req =>
+      req.url.startsWith('/v1/allocation')
+    );
+    assert.equal(allocationRequest.url, `/v1/allocation/${storageController.allocID}`);
+  });
+
+  test('After the plugin allocation row fetches the plugin allocation, allocation stats are fetched', async function(assert) {
+    const plugin = this.server.create('csi-plugin', { id: 'plugin' });
+    const storageController = plugin.controllers.models[0];
+
+    const pluginRecord = await this.store.find('plugin', 'csi/plugin');
+
+    this.setProperties({
+      plugin: pluginRecord.get('controllers.firstObject'),
+    });
+
+    await render(hbs`
+      {{plugin-allocation-row pluginAllocation=plugin}}
+    `);
+
+    await settled();
+
+    const [statsRequest] = this.server.pretender.handledRequests.slice(-1);
+
+    assert.equal(statsRequest.url, `/v1/client/allocation/${storageController.allocID}/stats`);
+  });
+
+  test('Setting a new plugin fetches the new plugin allocation', async function(assert) {
+    const plugin = this.server.create('csi-plugin', {
+      id: 'plugin',
+      isMonolith: false,
+      controllersExpected: 2,
+    });
+    const storageController = plugin.controllers.models[0];
+    const storageController2 = plugin.controllers.models[1];
+
+    const pluginRecord = await this.store.find('plugin', 'csi/plugin');
+
+    this.setProperties({
+      plugin: pluginRecord.get('controllers.firstObject'),
+    });
+
+    await render(hbs`
+      {{plugin-allocation-row pluginAllocation=plugin}}
+    `);
+
+    await settled();
+
+    const allocationRequest = this.server.pretender.handledRequests.find(req =>
+      req.url.startsWith('/v1/allocation')
+    );
+
+    assert.equal(allocationRequest.url, `/v1/allocation/${storageController.allocID}`);
+
+    this.set('plugin', pluginRecord.get('controllers').toArray()[1]);
+    await settled();
+
+    const latestAllocationRequest = this.server.pretender.handledRequests
+      .filter(req => req.url.startsWith('/v1/allocation'))
+      .reverse()[0];
+
+    assert.equal(latestAllocationRequest.url, `/v1/allocation/${storageController2.allocID}`);
+  });
+});


### PR DESCRIPTION
The data model goes like this:

Plugin (model) -> [Controllers (fragments)] -> Allocation (ID)
Plugin (model) -> [Nodes (fragments)] -> Allocation (ID)

The `PluginAllocationRow` needs to load the Allocation referenced by these controller and node fragments, however fragments can't have relationships.

Right now these relationships are mocked with a computed property, but this is unsatisfactory. Since allocations can be unloaded throughout the long-lived session of a UI and computed properties cache their values with no way of dirtying based on records being unloaded.

Since this ideal, idiomatic, workaround is just fantasy, Take 2 here sidesteps modeling the relationship altogether and loads the requisite allocation imperatively within the component.