### PR TITLE
e2e: upgrade CNI to 0.8.6

### DIFF
--- a/e2e/terraform/shared/config/provision-client.sh
+++ b/e2e/terraform/shared/config/provision-client.sh
@@ -49,7 +49,7 @@ sudo mkdir -p /tmp/data
 # Install CNI plugins
 sudo mkdir -p /opt/cni/bin
 wget -q -O - \
-     https://github.com/containernetworking/plugins/releases/download/v0.8.4/cni-plugins-linux-amd64-v0.8.4.tgz \
+     https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz \
     | sudo tar -C /opt/cni/bin -xz
 
 # enable as a systemd service

--- a/e2e/terraform/shared/config/provision-windows-client.ps1
+++ b/e2e/terraform/shared/config/provision-windows-client.ps1
@@ -36,7 +36,7 @@ New-Item -ItemType "directory" -Path "C:\tmp\data" -Force
 # TODO(tgross): not sure we even support this for Windows?
 # Write-Output "Install CNI"
 # md C:\opt\cni\bin
-# $cni_url = "https://github.com/containernetworking/plugins/releases/download/v0.8.4/cni-plugins-windows-amd64-v0.8.4.tgz"
+# $cni_url = "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-windows-amd64-v0.8.6.tgz"
 # Invoke-WebRequest -Uri "$cni_url" -Outfile cni.tgz
 # Expand-7Zip -ArchiveFileName .\cni.tgz -TargetPath C:\opt\cni\bin\ -Force
 

--- a/scripts/vagrant-linux-priv-cni.sh
+++ b/scripts/vagrant-linux-priv-cni.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-VERSION="v0.8.4"
+VERSION="v0.8.6"
 DOWNLOAD=https://github.com/containernetworking/plugins/releases/download/${VERSION}/cni-plugins-linux-amd64-${VERSION}.tgz
 TARGET_DIR=/opt/cni/bin
 


### PR DESCRIPTION
CNI has published a new release: https://github.com/containernetworking/plugins/releases/tag/v0.8.6. This changeset ensures we're testing it on E2E and in our vagrant setups.

The Linux AMI for E2E testing has been rebuilt with this change and published to our internal account: `ami-0e8b037a8d0ee07ea`.