### PR TITLE
always check `default_scheduler_config` config

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -349,39 +349,36 @@ func (c *Command) isValidConfig(config, cmdConfig *Config) bool {
 		}
 	}
 
-	if config.DevMode {
-		// Skip the rest of the validation for dev mode
-		return true
-	}
-
-	// Ensure that we have the directories we need to run.
-	if config.Server.Enabled && config.DataDir == "" {
-		c.Ui.Error("Must specify data directory")
-		return false
-	}
-
-	// The config is valid if the top-level data-dir is set or if both
-	// alloc-dir and state-dir are set.
-	if config.Client.Enabled && config.DataDir == "" {
-		if config.Client.AllocDir == "" || config.Client.StateDir == "" || config.PluginDir == "" {
-			c.Ui.Error("Must specify the state, alloc dir, and plugin dir if data-dir is omitted.")
-			return false
-		}
-	}
-
-	// Check the bootstrap flags
-	if !config.Server.Enabled && cmdConfig.Server.BootstrapExpect > 0 {
-		// report an error if BootstrapExpect is set in CLI but server is disabled
-		c.Ui.Error("Bootstrap requires server mode to be enabled")
-		return false
-	}
-	if config.Server.Enabled && config.Server.BootstrapExpect == 1 {
-		c.Ui.Error("WARNING: Bootstrap mode enabled! Potentially unsafe operation.")
-	}
-
 	if err := config.Server.DefaultSchedulerConfig.Validate(); err != nil {
 		c.Ui.Error(err.Error())
 		return false
+	}
+
+	if !config.DevMode {
+		// Ensure that we have the directories we need to run.
+		if config.Server.Enabled && config.DataDir == "" {
+			c.Ui.Error("Must specify data directory")
+			return false
+		}
+
+		// The config is valid if the top-level data-dir is set or if both
+		// alloc-dir and state-dir are set.
+		if config.Client.Enabled && config.DataDir == "" {
+			if config.Client.AllocDir == "" || config.Client.StateDir == "" || config.PluginDir == "" {
+				c.Ui.Error("Must specify the state, alloc dir, and plugin dir if data-dir is omitted.")
+				return false
+			}
+		}
+
+		// Check the bootstrap flags
+		if !config.Server.Enabled && cmdConfig.Server.BootstrapExpect > 0 {
+			// report an error if BootstrapExpect is set in CLI but server is disabled
+			c.Ui.Error("Bootstrap requires server mode to be enabled")
+			return false
+		}
+		if config.Server.Enabled && config.Server.BootstrapExpect == 1 {
+			c.Ui.Error("WARNING: Bootstrap mode enabled! Potentially unsafe operation.")
+		}
 	}
 
 	return true


### PR DESCRIPTION
Also, avoid early return on validation to avoid masking some validation
bugs in dev setup.  Best viewed with `?w=1`

Fixes https://github.com/hashicorp/nomad/issues/7960 .