### PR TITLE
UI: Change exec URL-generation to use Ember get

### DIFF
--- a/ui/app/utils/generate-exec-url.js
+++ b/ui/app/utils/generate-exec-url.js
@@ -1,18 +1,20 @@
+import { get } from '@ember/object';
+
 export default function generateExecUrl(router, { job, taskGroup, task, allocation }) {
   const queryParams = router.currentRoute.queryParams;
 
   if (task) {
-    return router.urlFor('exec.task-group.task', job.plainId, taskGroup.name, task.name, {
+    return router.urlFor('exec.task-group.task', get(job, 'plainId'), get(taskGroup, 'name'), get(task, 'name'), {
       queryParams: {
-        allocation: allocation.shortId,
+        allocation: get(allocation, 'shortId'),
         ...queryParams,
       },
     });
   } else if (taskGroup) {
-    return router.urlFor('exec.task-group', job.plainId, taskGroup.name, { queryParams });
+    return router.urlFor('exec.task-group', get(job, 'plainId'), get(taskGroup, 'name'), { queryParams });
   } else if (allocation) {
-    return router.urlFor('exec', job.plainId, { queryParams: { allocation: allocation.shortId, ...queryParams } });
+    return router.urlFor('exec', get(job, 'plainId'), { queryParams: { allocation: get(allocation, 'shortId'), ...queryParams } });
   } else {
-    return router.urlFor('exec', job.plainId, { queryParams });
+    return router.urlFor('exec', get(job, 'plainId'), { queryParams });
   }
 }


### PR DESCRIPTION
This fixes a bug in #7815 where you can’t open an exec window from
the allocation overview because accessing `allocation.job.plainId`
fails across the proxied relationship.