### PR TITLE
UI: use lazy-loading for Xterm.js

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     es6: true,
   },
   extends: 'eslint:recommended',
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',

--- a/ui/app/controllers/exec.js
+++ b/ui/app/controllers/exec.js
@@ -7,8 +7,6 @@ import ExecCommandEditorXtermAdapter from 'nomad-ui/utils/classes/exec-command-e
 import ExecSocketXtermAdapter from 'nomad-ui/utils/classes/exec-socket-xterm-adapter';
 import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 
-import { Terminal } from 'xterm';
-
 const ANSI_UI_GRAY_400 = '\x1b[38;2;142;150;163m';
 const ANSI_WHITE = '\x1b[0m';
 
@@ -34,9 +32,7 @@ export default Controller.extend({
   taskGroupSorting: Object.freeze(['name']),
   sortedTaskGroups: sort('uniquePendingAndRunningTaskGroups', 'taskGroupSorting'),
 
-  init() {
-    this._super(...arguments);
-
+  setUpTerminal(Terminal) {
     this.terminal = new Terminal({ fontFamily: 'monospace', fontWeight: '400' });
     window.execTerminal = this.terminal; // Issue to improve: https://github.com/hashicorp/nomad/issues/7457
 

--- a/ui/app/controllers/exec.js
+++ b/ui/app/controllers/exec.js
@@ -7,7 +7,7 @@ import ExecCommandEditorXtermAdapter from 'nomad-ui/utils/classes/exec-command-e
 import ExecSocketXtermAdapter from 'nomad-ui/utils/classes/exec-socket-xterm-adapter';
 import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 
-import { Terminal } from 'xterm-vendor';
+import { Terminal } from 'xterm';
 
 const ANSI_UI_GRAY_400 = '\x1b[38;2;142;150;163m';
 const ANSI_WHITE = '\x1b[0m';

--- a/ui/app/routes/exec.js
+++ b/ui/app/routes/exec.js
@@ -17,12 +17,22 @@ export default Route.extend(WithWatchers, {
     const namespace = transition.to.queryParams.namespace || this.get('system.activeNamespace.id');
     const name = params.job_name;
     const fullId = JSON.stringify([name, namespace || 'default']);
-    return this.store
+
+    const jobPromise = this.store
       .findRecord('job', fullId)
       .then(job => {
         return job.get('allocations').then(() => job);
       })
       .catch(notifyError(this));
+
+    const xtermImport = import('xterm').then(module => module.Terminal);
+
+    return Promise.all([jobPromise, xtermImport]);
+  },
+
+  setupController(controller, [job, Terminal]) {
+    this._super(controller, job);
+    controller.setUpTerminal(Terminal);
   },
 
   startWatchers(controller, model) {

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -17,7 +17,10 @@ module.exports = function(defaults) {
       modes: ['javascript'],
     },
     babel: {
-      plugins: ['@babel/plugin-proposal-object-rest-spread'],
+      plugins: [
+        '@babel/plugin-proposal-object-rest-spread',
+        require.resolve('ember-auto-import/babel-plugin'),
+      ],
     },
     'ember-cli-babel': {
       includePolyfill: isProd,

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -43,12 +43,6 @@ module.exports = function(defaults) {
   // along with the exports of each module as its value.
 
   app.import('node_modules/xterm/css/xterm.css');
-  // Issue to move to typical package.json import when released: https://github.com/hashicorp/nomad/issues/7461
-  app.import('vendor/xterm.js', {
-    using: [
-      { transformation: 'amd', as: 'xterm-vendor' },
-    ],
-  });
 
   return app.toTree();
 };

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,6 +37,7 @@
     "@hashicorp/structure-icons": "^1.3.0",
     "@storybook/ember-cli-storybook": "^0.2.0",
     "anser": "^1.4.8",
+    "babel-eslint": "^10.1.0",
     "base64-js": "^1.3.1",
     "broccoli-asset-rev": "^3.0.0",
     "bulma": "0.6.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -116,7 +116,7 @@
     "testem": "^3.0.3",
     "testem-multi-reporter": "^1.2.0",
     "text-encoder-lite": "^2.0.0",
-    "xterm": "^4.2.0-vscode1",
+    "xterm": "^4.6.0",
     "xterm-addon-fit": "^0.3.0"
   },
   "optionalDependencies": {

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -88,7 +88,7 @@ module('Acceptance | exec', function(hooks) {
     await Exec.visitJob({ job: this.job.id });
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(0)
         .translateToString()
         .trim(),
@@ -243,7 +243,7 @@ module('Acceptance | exec', function(hooks) {
     assert.ok(Exec.taskGroups[0].tasks[0].isActive);
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(2)
         .translateToString()
         .trim(),
@@ -251,7 +251,7 @@ module('Acceptance | exec', function(hooks) {
     );
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(4)
         .translateToString()
         .trim(),
@@ -259,7 +259,7 @@ module('Acceptance | exec', function(hooks) {
     );
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(6)
         .translateToString()
         .trim(),
@@ -291,7 +291,7 @@ module('Acceptance | exec', function(hooks) {
     await settled();
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(4)
         .translateToString()
         .trim(),
@@ -346,7 +346,7 @@ module('Acceptance | exec', function(hooks) {
     await settled();
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(5)
         .translateToString()
         .trim(),
@@ -366,7 +366,7 @@ module('Acceptance | exec', function(hooks) {
     await settled();
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(6)
         .translateToString()
         .trim(),
@@ -485,7 +485,7 @@ module('Acceptance | exec', function(hooks) {
     await settled();
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(6)
         .translateToString()
         .trim(),
@@ -521,7 +521,7 @@ module('Acceptance | exec', function(hooks) {
     await settled();
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(4)
         .translateToString()
         .trim(),
@@ -549,7 +549,7 @@ module('Acceptance | exec', function(hooks) {
     await settled();
 
     assert.equal(
-      window.execTerminal.buffer
+      window.execTerminal.buffer.active
         .getLine(7)
         .translateToString()
         .trim(),

--- a/ui/tests/integration/util/exec-command-editor-xterm-adapter-test.js
+++ b/ui/tests/integration/util/exec-command-editor-xterm-adapter-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { Terminal } from 'xterm-vendor';
+import { Terminal } from 'xterm';
 import KEYS from 'nomad-ui/utils/keys';
 
 module('Integration | Utility | exec-command-editor-xterm-adapter', function(hooks) {
@@ -42,7 +42,7 @@ module('Integration | Utility | exec-command-editor-xterm-adapter', function(hoo
     await settled();
 
     assert.equal(
-      terminal.buffer
+      terminal.buffer.active
         .getLine(0)
         .translateToString()
         .trim(),
@@ -84,11 +84,11 @@ module('Integration | Utility | exec-command-editor-xterm-adapter', function(hoo
 
     await settled();
 
-    assert.equal(terminal.buffer.cursorY, 0);
-    assert.equal(terminal.buffer.cursorX, 10);
+    assert.equal(terminal.buffer.active.cursorY, 0);
+    assert.equal(terminal.buffer.active.cursorX, 10);
 
     assert.equal(
-      terminal.buffer
+      terminal.buffer.active
         .getLine(0)
         .translateToString()
         .trim(),
@@ -124,7 +124,7 @@ module('Integration | Utility | exec-command-editor-xterm-adapter', function(hoo
     await settled();
 
     assert.equal(
-      terminal.buffer
+      terminal.buffer.active
         .getLine(0)
         .translateToString()
         .trim(),

--- a/ui/tests/integration/util/exec-socket-xterm-adapter-test.js
+++ b/ui/tests/integration/util/exec-socket-xterm-adapter-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { Terminal } from 'xterm-vendor';
+import { Terminal } from 'xterm';
 
 module('Integration | Utility | exec-socket-xterm-adapter', function(hooks) {
   setupRenderingTest(hooks);
@@ -149,7 +149,7 @@ module('Integration | Utility | exec-socket-xterm-adapter', function(hooks) {
     await settled();
 
     assert.equal(
-      terminal.buffer
+      terminal.buffer.active
         .getLine(0)
         .translateToString()
         .trim(),

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -16,6 +16,13 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  dependencies:
+    "@babel/highlight" "^7.8.3"
+
 "@babel/core@^7.0.0", "@babel/core@^7.1.6", "@babel/core@^7.3.3", "@babel/core@^7.3.4":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.0.tgz#248fd6874b7d755010bfe61f557461d4f446d9e9"
@@ -96,6 +103,16 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
     trim-right "^1.0.1"
+
+"@babel/generator@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.6.tgz#5408c82ac5de98cda0d77d8124e99fa1f2170a43"
+  integrity sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==
+  dependencies:
+    "@babel/types" "^7.9.6"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
 
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
@@ -180,12 +197,28 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-function-name@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz#2b53820d35275120e1874a82e5aabe1376920a5c"
+  integrity sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.9.5"
+
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
   integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
+  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+  dependencies:
+    "@babel/types" "^7.8.3"
 
 "@babel/helper-hoist-variables@^7.4.4":
   version "7.4.4"
@@ -311,6 +344,18 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
+"@babel/helper-split-export-declaration@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
+  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
@@ -348,6 +393,15 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.8.3":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
+  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.3.4", "@babel/parser@^7.4.4", "@babel/parser@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
@@ -357,6 +411,11 @@
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.2.tgz#205e9c95e16ba3b8b96090677a67c9d6075b70a1"
   integrity sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==
+
+"@babel/parser@^7.7.0", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
+  integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -1040,6 +1099,15 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
+"@babel/template@^7.8.3":
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
+  integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/parser" "^7.8.6"
+    "@babel/types" "^7.8.6"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.6":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.0.tgz#14006967dd1d2b3494cdd650c686db9daf0ddada"
@@ -1085,6 +1153,21 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.7.0":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.6.tgz#5540d7577697bf619cc57b92aa0f1c231a94f442"
+  integrity sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.6"
+    "@babel/helper-function-name" "^7.9.5"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.9.6"
+    "@babel/types" "^7.9.6"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.1.6", "@babel/types@^7.2.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.0.tgz#670724f77d24cce6cc7d8cf64599d511d164894c"
@@ -1119,6 +1202,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
+  integrity sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.5"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":
@@ -2964,6 +3056,18 @@ babel-core@^6.10.4, babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.3:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
+
+babel-eslint@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
+  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/traverse" "^7.7.0"
+    "@babel/types" "^7.7.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 babel-generator@^6.26.0:
   version "6.26.1"
@@ -13347,6 +13451,13 @@ resolve@^1.10.0, resolve@^1.3.3, resolve@^1.8.1:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.12.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15628,10 +15628,10 @@ xterm-addon-fit@^0.3.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.3.0.tgz#341710741027de9d648a9f84415a01ddfdbbe715"
   integrity sha512-kvkiqHVrnMXgyCH9Xn0BOBJ7XaWC/4BgpSWQy3SueqximgW630t/QOankgqkvk11iTOCwWdAY9DTyQBXUMN3lw==
 
-xterm@^4.2.0-vscode1:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.4.0.tgz#5915d3c4c8800fadbcf555a0a603c672ab9df589"
-  integrity sha512-JGIpigWM3EBWvnS3rtBuefkiToIILSK1HYMXy4BCsUpO+O4UeeV+/U1AdAXgCB6qJrnPNb7yLgBsVCQUNMteig==
+xterm@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.6.0.tgz#1b49b32e546409c110fbe8ece0b4a388504a937d"
+  integrity sha512-98211RIDrAECqpsxs6gbilwMcxLtxSDIvtzZUIqP1xIByXtuccJ4pmMhHGJATZeEGe/reARPMqwPINK8T7jGZg==
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This updates Xterm.js to 4.6.0, which includes support for reverse-wraparound
mode, so we no longer need to use a vendored dependency, which closes #7461. 
The interface for accessing the buffer that’s used for test assertions changed.

With the dependency now accessed conventionally, we can have it load only when
it’s needed by an exec popup window, which closes #7516. That saves us
[≈60kb compressed](https://github.com/hashicorp/nomad/pull/7964#issuecomment-628848335) in the dependency bundle! I don’t think there are strong
conventions around how to handle lazy loading, so I’m open to suggestions
if this technique seems subpar.

This reveals that the Ember Asset Size action [filters out](https://github.com/hashicorp/nomad/pull/7964/checks?check_run_id=676015713#step:4:170) the `chunk` file
that the dependency is now split off into. This is maybe acceptable if we don’t
use lazy-loading extensively, but if it becomes a problem I could make another
change to the action to not filter out these files.