### PR TITLE
UI: CSI limit how many controller and node allocs are shown on the plugin page

### DIFF
--- a/ui/app/controllers/csi/plugins/plugin.js
+++ b/ui/app/controllers/csi/plugins/plugin.js
@@ -1,13 +1,19 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
 
 export default Controller.extend({
-  sortedControllers: computed('model.controllers.@each.updateTime', function() {
-    return this.model.controllers.sortBy('updateTime').reverse();
+  controllerAllocation: alias('model.controllerAllocation'),
+  nodeAllocation: alias('model.nodeAllocation'),
+
+  plugin: alias('model.plugin'),
+
+  sortedControllers: computed('plugin.controllers.@each.updateTime', function() {
+    return this.plugin.controllers.sortBy('updateTime').reverse();
   }),
 
-  sortedNodes: computed('model.nodes.@each.updateTime', function() {
-    return this.model.nodes.sortBy('updateTime').reverse();
+  sortedNodes: computed('plugin.nodes.@each.updateTime', function() {
+    return this.plugin.nodes.sortBy('updateTime').reverse();
   }),
 
   actions: {

--- a/ui/app/routes/csi/plugins/plugin.js
+++ b/ui/app/routes/csi/plugins/plugin.js
@@ -9,14 +9,14 @@ export default Route.extend(WithWatchers, {
   store: service(),
   system: service(),
 
-  breadcrumbs: plugin => [
+  breadcrumbs: model => [
     {
       label: 'Plugins',
       args: ['csi.plugins'],
     },
     {
-      label: plugin.plainId,
-      args: ['csi.plugins.plugin', plugin.plainId],
+      label: model.plugin.plainId,
+      args: ['csi.plugins.plugin', model.plugin.plainId],
     },
   ],
 
@@ -32,8 +32,22 @@ export default Route.extend(WithWatchers, {
     return { plugin_name: model.get('plainId') };
   },
 
-  model(params) {
-    return this.store.findRecord('plugin', `csi/${params.plugin_name}`).catch(notifyError(this));
+  async model(params) {
+    const plugin = await this.store
+      .findRecord('plugin', `csi/${params.plugin_name}`)
+      .catch(notifyError(this));
+
+    const pluginController = plugin.get('controllers.firstObject');
+    const pluginNode = plugin.get('nodes.firstObject');
+
+    const controllerAllocation = pluginController && (await pluginController.getAllocation());
+    const nodeAllocation = pluginNode && (await pluginNode.getAllocation());
+
+    return {
+      plugin,
+      controllerAllocation,
+      nodeAllocation,
+    };
   },
 
   watch: watchRecord('plugin'),

--- a/ui/app/templates/csi/plugins/plugin.hbs
+++ b/ui/app/templates/csi/plugins/plugin.hbs
@@ -86,7 +86,7 @@
     <div class="boxed-section-body {{if model.controllers "is-full-bleed"}}">
       {{#if model.controllers}}
         {{#list-table
-          source=sortedControllers
+          source=(take 10 sortedControllers)
           class="with-foot" as |t|}}
           {{#t.head}}
             <th class="is-narrow"></th>
@@ -123,7 +123,7 @@
     <div class="boxed-section-body {{if model.nodes "is-full-bleed"}}">
       {{#if model.nodes}}
         {{#list-table
-          source=sortedNodes
+          source=(take 10 sortedNodes)
           class="with-foot" as |t|}}
           {{#t.head}}
             <th class="is-narrow"></th>

--- a/ui/app/templates/csi/plugins/plugin.hbs
+++ b/ui/app/templates/csi/plugins/plugin.hbs
@@ -1,23 +1,23 @@
-{{title "CSI Plugin " model.plainId}}
+{{title "CSI Plugin " plugin.plainId}}
 <section class="section with-headspace">
-  <h1 class="title" data-test-title>{{model.plainId}}</h1>
+  <h1 class="title" data-test-title>{{plugin.plainId}}</h1>
 
   <div class="boxed-section is-small">
     <div class="boxed-section-body inline-definitions">
       <span class="label">Plugin Details</span>
       <span class="pair" data-test-plugin-controller-health>
         <span class="term">Controller Health</span>
-        {{format-percentage model.controllersHealthy total=model.controllersExpected}}
-        ({{model.controllersHealthy}}/{{model.controllersExpected}})
+        {{format-percentage plugin.controllersHealthy total=plugin.controllersExpected}}
+        ({{plugin.controllersHealthy}}/{{plugin.controllersExpected}})
       </span>
       <span class="pair" data-test-plugin-node-health>
         <span class="term">Node Health</span>
-        {{format-percentage model.nodesHealthy total=model.nodesExpected}}
-        ({{model.nodesHealthy}}/{{model.nodesExpected}})
+        {{format-percentage plugin.nodesHealthy total=plugin.nodesExpected}}
+        ({{plugin.nodesHealthy}}/{{plugin.nodesExpected}})
       </span>
       <span class="pair" data-test-plugin-provider>
         <span class="term">Provider</span>
-        {{model.provider}}
+        {{plugin.provider}}
       </span>
     </div>
   </div>
@@ -31,19 +31,19 @@
             <div class="column is-half">
               {{gauge-chart
                 label="Availability"
-                value=model.controllersHealthy
-                total=model.controllersExpected}}
+                value=plugin.controllersHealthy
+                total=plugin.controllersExpected}}
             </div>
             <div class="column">
               <div class="metric">
                 <h3 class="label">Available</h3>
-                <p class="value">{{model.controllersHealthy}}</p>
+                <p class="value">{{plugin.controllersHealthy}}</p>
               </div>
             </div>
             <div class="column">
               <div class="metric">
                 <h3 class="label">Expected</h3>
-                <p class="value">{{model.controllersExpected}}</p>
+                <p class="value">{{plugin.controllersExpected}}</p>
               </div>
             </div>
           </div>
@@ -58,19 +58,19 @@
             <div class="column is-half">
               {{gauge-chart
                 label="Availability"
-                value=model.nodesHealthy
-                total=model.nodesExpected}}
+                value=plugin.nodesHealthy
+                total=plugin.nodesExpected}}
             </div>
             <div class="column">
               <div class="metric">
                 <h3 class="label">Available</h3>
-                <p class="value">{{model.nodesHealthy}}</p>
+                <p class="value">{{plugin.nodesHealthy}}</p>
               </div>
             </div>
             <div class="column">
               <div class="metric">
                 <h3 class="label">Expected</h3>
-                <p class="value">{{model.nodesExpected}}</p>
+                <p class="value">{{plugin.nodesExpected}}</p>
               </div>
             </div>
           </div>
@@ -83,8 +83,8 @@
     <div class="boxed-section-head">
       Controller Allocations
     </div>
-    <div class="boxed-section-body {{if model.controllers "is-full-bleed"}}">
-      {{#if model.controllers}}
+    <div class="boxed-section-body {{if plugin.controllers "is-full-bleed"}}">
+      {{#if plugin.controllers}}
         {{#list-table
           source=(take 10 sortedControllers)
           class="with-foot" as |t|}}
@@ -114,14 +114,25 @@
         </div>
       {{/if}}
     </div>
+    {{#if plugin.controllers}}
+      <div class="boxed-section-foot">
+        <p class="pull-right" data-test-go-to-controller-job>
+          {{#link-to "jobs.job"
+            controllerAllocation.job.plainId
+            (query-params jobNamespace=controllerAllocation.job.namespace.id)}}
+            View Controller Job
+          {{/link-to}}
+        </p>
+      </div>
+    {{/if}}
   </div>
 
   <div class="boxed-section">
     <div class="boxed-section-head">
       Node Allocations
     </div>
-    <div class="boxed-section-body {{if model.nodes "is-full-bleed"}}">
-      {{#if model.nodes}}
+    <div class="boxed-section-body {{if plugin.nodes "is-full-bleed"}}">
+      {{#if plugin.nodes}}
         {{#list-table
           source=(take 10 sortedNodes)
           class="with-foot" as |t|}}
@@ -151,5 +162,16 @@
         </div>
       {{/if}}
     </div>
+    {{#if plugin.controllers}}
+      <div class="boxed-section-foot">
+        <p class="pull-right" data-test-go-to-controller-job>
+          {{#link-to "jobs.job"
+          nodeAllocation.job.plainId
+          (query-params jobNamespace=nodeAllocation.job.namespace.id)}}
+            View Node Job
+          {{/link-to}}
+        </p>
+      </div>
+    {{/if}}
   </div>
 </section>


### PR DESCRIPTION
Closes #7969 

This does two things.

1. Limit the number of controller and node allocations to 10
2. Add links to the respective job pages to see all allocations

To get the jobs for these allocations, the plugin route has to do a tricky thing. The first allocation for both the controller and node allocations lists is loaded in order to get the job ID that should be linked to.

This two hop process may be reduced to just a single hop if #7974 gets implemented.