### PR TITLE
Docs: Vault integration token creation docs missing command

### DIFF
--- a/website/pages/docs/vault-integration/index.mdx
+++ b/website/pages/docs/vault-integration/index.mdx
@@ -243,7 +243,8 @@ $ vault write /auth/token/roles/nomad-cluster @nomad-cluster-role.json
 After the token role is created, a token suitable for the Nomad servers may be
 retrieved by issuing the following Vault command:
 
-```shell-sessionvault token create -policy nomad-server -period 72h -orphan
+```shell-session
+vault token create -policy nomad-server -period 72h -orphan
 Key             Value
 ---             -----
 token           f02f01c2-c0d1-7cb7-6b88-8a14fada58c0


### PR DESCRIPTION
On the Vault integration page, a snippet is shown to generate the token, but the command itself is missing:
```
Key             Value
---             -----
token           f02f01c2-c0d1-7cb7-6b88-8a14fada58c0
token_accessor  8cb7fcb3-9a4f-6fbf-0efc-83092bb0cb1c
token_duration  259200s
token_renewable true
token_policies  [default nomad-server]
```

This due to a missing line end. This PR fixes this.