### PR TITLE
Fix server.mdx page header

### DIFF
--- a/website/pages/docs/configuration/server.mdx
+++ b/website/pages/docs/configuration/server.mdx
@@ -1,4 +1,4 @@
---
+---
 layout: docs
 page_title: server Stanza - Agent Configuration
 sidebar_title: server


### PR DESCRIPTION
Reverts header change from 8192aa6, which "broke" the 'server' link and page:

![image](https://user-images.githubusercontent.com/7580803/82136539-125ef100-97dd-11ea-8f4d-78cbc8aee56e.png)

![image](https://user-images.githubusercontent.com/7580803/82136559-3c181800-97dd-11ea-8ec1-13efbc347704.png)

