### PR TITLE
docs: server configuration metadata was missing a dash

### DIFF
--- a/website/pages/docs/configuration/server.mdx
+++ b/website/pages/docs/configuration/server.mdx
@@ -1,4 +1,4 @@
---
+---
 layout: docs
 page_title: server Stanza - Agent Configuration
 sidebar_title: server


### PR DESCRIPTION
missing `-` meant (i think) that metadata wasn't processed, so this page was rendering incorrectly in the sidebar and on the page
https://www.nomadproject.io/docs/configuration/server/

i already cherry-picked and pushed to `stable-website`