### PR TITLE
endpoint to expose all jobs across all namespaces

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -874,6 +874,7 @@ type JobListStub struct {
 	ID                string
 	ParentID          string
 	Name              string
+	Namespace         string `json:",omitempty"`
 	Datacenters       []string
 	Type              string
 	Priority          int

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -142,6 +142,13 @@ func (j *Jobs) PrefixList(prefix string) ([]*JobListStub, *QueryMeta, error) {
 	return j.List(&QueryOptions{Prefix: prefix})
 }
 
+// ListAll is used to list all of the existing jobs in all namespaces.
+func (j *Jobs) ListAll() ([]*JobListStub, *QueryMeta, error) {
+	return j.List(&QueryOptions{
+		Params: map[string]string{"all_namespaces": "true"},
+	})
+}
+
 // Info is used to retrieve information about a particular
 // job given its unique ID.
 func (j *Jobs) Info(jobID string, q *QueryOptions) (*Job, *QueryMeta, error) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -31,6 +31,7 @@ func (s *HTTPServer) jobListRequest(resp http.ResponseWriter, req *http.Request)
 		return nil, nil
 	}
 
+	args.AllNamespaces, _ = strconv.ParseBool(req.URL.Query().Get("all_namespaces"))
 	var out structs.JobListResponse
 	if err := s.agent.RPC("Job.List", &args, &out); err != nil {
 		return nil, err

--- a/nomad/state/state_store_oss.go
+++ b/nomad/state/state_store_oss.go
@@ -17,3 +17,7 @@ func (s *StateStore) namespaceExists(txn *memdb.Txn, namespace string) (bool, er
 func (s *StateStore) updateEntWithAlloc(index uint64, new, existing *structs.Allocation, txn *memdb.Txn) error {
 	return nil
 }
+
+func (s *StateStore) NamespaceNames() ([]string, error) {
+	return []string{structs.DefaultNamespace}, nil
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -609,6 +609,7 @@ type JobSpecificRequest struct {
 
 // JobListRequest is used to parameterize a list request
 type JobListRequest struct {
+	AllNamespaces bool
 	QueryOptions
 }
 
@@ -4105,6 +4106,7 @@ type JobListStub struct {
 	ID                string
 	ParentID          string
 	Name              string
+	Namespace         string `json:",omitempty"`
 	Datacenters       []string
 	Type              string
 	Priority          int

--- a/website/pages/api-docs/jobs.mdx
+++ b/website/pages/api-docs/jobs.mdx
@@ -31,10 +31,8 @@ The table below shows this endpoint's support for
   an index prefix. This is specified as a query string parameter.
 
 - `all_namespaces` `(bool: false)` - Specifies whether to return the all
-  known jobs across all namespaces. When set to `true`, the list stubs will
-  contain a `Namespace` field indicating the job namespace.
-  The option requires `namespace:list-jobs` ACL capability on all existing
-  namespaces.
+  known jobs across all namespaces the token has `namespace:list-jobs` ACL
+  capability on.
 
 ### Sample Request
 
@@ -60,6 +58,7 @@ The table below shows this endpoint's support for
     "StatusDescription": "",
     "JobSummary": {
       "JobID": "example",
+      "Namespace": "default",
       "Summary": {
         "cache": {
           "Queued": 1,

--- a/website/pages/api-docs/jobs.mdx
+++ b/website/pages/api-docs/jobs.mdx
@@ -30,6 +30,12 @@ The table below shows this endpoint's support for
 - `prefix` `(string: "")` - Specifies a string to filter jobs on based on
   an index prefix. This is specified as a query string parameter.
 
+- `all_namespaces` `(bool: false)` - Specifies whether to return the all
+  known jobs across all namespaces. When set to `true`, the list stubs will
+  contain a `Namespace` field indicating the job namespace.
+  The option requires `namespace:list-jobs` ACL capability on all existing
+  namespaces.
+
 ### Sample Request
 
 ```shell-sessioncurl \


### PR DESCRIPTION
Allow a `/v1/jobs?all_namespaces=true` parameter to list all jobs across all
namespaces.  The returned list is to contain a `Namespace` field
indicating the job namespace.

If ACL is enabled, the request token needs to be a management token or
have `namespace:list-jobs` capability on all existing namespaces.