### PR TITLE
UI: CSI node only support

### DIFF
--- a/ui/app/styles/core/columns.scss
+++ b/ui/app/styles/core/columns.scss
@@ -14,4 +14,13 @@
   &.is-bottom-aligned {
     align-items: flex-end;
   }
+
+  &.is-max-half {
+    max-width: 50%;
+  }
+
+  &.is-centered {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }

--- a/ui/app/templates/csi/plugins/index.hbs
+++ b/ui/app/templates/csi/plugins/index.hbs
@@ -42,8 +42,12 @@
                 {{#link-to "csi.plugins.plugin" row.model.plainId class="is-primary"}}{{row.model.plainId}}{{/link-to}}
               </td>
               <td data-test-plugin-controller-health>
-                {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
-                ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
+                {{#if row.model.controllerRequired}}
+                  {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
+                  ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
+                {{else}}
+                  <em class="is-faded">Node Only</em>
+                {{/if}}
               </td>
               <td data-test-plugin-node-health>
                 {{if (gt row.model.nodesHealthy 0) "Healthy" "Unhealthy"}}

--- a/ui/app/templates/csi/plugins/plugin.hbs
+++ b/ui/app/templates/csi/plugins/plugin.hbs
@@ -5,11 +5,13 @@
   <div class="boxed-section is-small">
     <div class="boxed-section-body inline-definitions">
       <span class="label">Plugin Details</span>
-      <span class="pair" data-test-plugin-controller-health>
-        <span class="term">Controller Health</span>
-        {{format-percentage model.controllersHealthy total=model.controllersExpected}}
-        ({{model.controllersHealthy}}/{{model.controllersExpected}})
-      </span>
+      {{#if model.controllerRequired}}
+        <span class="pair" data-test-plugin-controller-health>
+          <span class="term">Controller Health</span>
+          {{format-percentage model.controllersHealthy total=model.controllersExpected}}
+          ({{model.controllersHealthy}}/{{model.controllersExpected}})
+        </span>
+      {{/if}}
       <span class="pair" data-test-plugin-node-health>
         <span class="term">Node Health</span>
         {{format-percentage model.nodesHealthy total=model.nodesExpected}}
@@ -23,38 +25,40 @@
   </div>
 
   <div class="columns">
-    <div class="column">
-      <div class="boxed-section">
-        <div class="boxed-section-head is-hollow">Controller Health</div>
-        <div class="boxed-section-body">
-          <div class="columns is-bottom-aligned">
-            <div class="column is-half">
-              {{gauge-chart
-                label="Availability"
-                value=model.controllersHealthy
-                total=model.controllersExpected}}
-            </div>
-            <div class="column">
-              <div class="metric">
-                <h3 class="label">Available</h3>
-                <p class="value">{{model.controllersHealthy}}</p>
+    {{#if model.controllerRequired}}
+      <div class="column">
+        <div class="boxed-section">
+          <div class="boxed-section-head is-hollow">Controller Health</div>
+          <div class="boxed-section-body">
+            <div class="columns is-centered is-max-half is-bottom-aligned">
+              <div class="column is-half">
+                {{gauge-chart
+                  label="Availability"
+                  value=model.controllersHealthy
+                  total=model.controllersExpected}}
               </div>
-            </div>
-            <div class="column">
-              <div class="metric">
-                <h3 class="label">Expected</h3>
-                <p class="value">{{model.controllersExpected}}</p>
+              <div class="column">
+                <div class="metric">
+                  <h3 class="label">Available</h3>
+                  <p class="value">{{model.controllersHealthy}}</p>
+                </div>
+              </div>
+              <div class="column">
+                <div class="metric">
+                  <h3 class="label">Expected</h3>
+                  <p class="value">{{model.controllersExpected}}</p>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    {{/if}}
     <div class="column">
       <div class="boxed-section">
         <div class="boxed-section-head is-hollow">Node Health</div>
         <div class="boxed-section-body">
-          <div class="columns is-bottom-aligned">
+          <div class="columns is-centered is-max-half is-bottom-aligned">
             <div class="column is-half">
               {{gauge-chart
                 label="Availability"
@@ -79,42 +83,44 @@
     </div>
   </div>
 
-  <div class="boxed-section">
-    <div class="boxed-section-head">
-      Controller Allocations
+  {{#if model.controllerRequired}}
+    <div class="boxed-section">
+      <div class="boxed-section-head">
+        Controller Allocations
+      </div>
+      <div class="boxed-section-body {{if model.controllers "is-full-bleed"}}">
+        {{#if model.controllers}}
+          {{#list-table
+            source=sortedControllers
+            class="with-foot" as |t|}}
+            {{#t.head}}
+              <th class="is-narrow"></th>
+              <td>ID</td>
+              <th>Created</th>
+              <th>Modified</th>
+              <th>Health</th>
+              <th>Client</th>
+              <th>Job</th>
+              <th>Version</th>
+              <th>Volumes</th>
+              <th>CPU</th>
+              <th>Memory</th>
+            {{/t.head}}
+            {{#t.body key="model.allocID" as |row|}}
+              {{plugin-allocation-row
+                data-test-controller-allocation=row.model.allocID
+                pluginAllocation=row.model}}
+            {{/t.body}}
+          {{/list-table}}
+        {{else}}
+          <div class="empty-message" data-test-empty-controller-allocations>
+            <h3 class="empty-message-headline" data-test-empty-controller-allocations-headline>No Controller Plugin Allocations</h3>
+            <p class="empty-message-body" data-test-empty-controller-allocations-message>No allocations are providing controller plugin service.</p>
+          </div>
+        {{/if}}
+      </div>
     </div>
-    <div class="boxed-section-body {{if model.controllers "is-full-bleed"}}">
-      {{#if model.controllers}}
-        {{#list-table
-          source=sortedControllers
-          class="with-foot" as |t|}}
-          {{#t.head}}
-            <th class="is-narrow"></th>
-            <td>ID</td>
-            <th>Created</th>
-            <th>Modified</th>
-            <th>Health</th>
-            <th>Client</th>
-            <th>Job</th>
-            <th>Version</th>
-            <th>Volumes</th>
-            <th>CPU</th>
-            <th>Memory</th>
-          {{/t.head}}
-          {{#t.body key="model.allocID" as |row|}}
-            {{plugin-allocation-row
-              data-test-controller-allocation=row.model.allocID
-              pluginAllocation=row.model}}
-          {{/t.body}}
-        {{/list-table}}
-      {{else}}
-        <div class="empty-message" data-test-empty-controller-allocations>
-          <h3 class="empty-message-headline" data-test-empty-controller-allocations-headline>No Controller Plugin Allocations</h3>
-          <p class="empty-message-body" data-test-empty-controller-allocations-message>No allocations are providing controller plugin service.</p>
-        </div>
-      {{/if}}
-    </div>
-  </div>
+  {{/if}}
 
   <div class="boxed-section">
     <div class="boxed-section-head">

--- a/ui/app/templates/csi/plugins/plugin.hbs
+++ b/ui/app/templates/csi/plugins/plugin.hbs
@@ -84,7 +84,7 @@
   </div>
 
   {{#if model.controllerRequired}}
-    <div class="boxed-section">
+    <div class="boxed-section" data-test-controller-allocations>
       <div class="boxed-section-head">
         Controller Allocations
       </div>

--- a/ui/app/templates/csi/plugins/plugin.hbs
+++ b/ui/app/templates/csi/plugins/plugin.hbs
@@ -26,7 +26,7 @@
 
   <div class="columns">
     {{#if model.controllerRequired}}
-      <div class="column">
+      <div class="column" data-test-plugin-controller-availability>
         <div class="boxed-section">
           <div class="boxed-section-head is-hollow">Controller Health</div>
           <div class="boxed-section-body">
@@ -55,7 +55,7 @@
       </div>
     {{/if}}
     <div class="column">
-      <div class="boxed-section">
+      <div class="boxed-section" data-test-plugin-node-availability>
         <div class="boxed-section-head is-hollow">Node Health</div>
         <div class="boxed-section-body">
           <div class="columns is-centered is-max-half is-bottom-aligned">

--- a/ui/mirage/factories/csi-plugin.js
+++ b/ui/mirage/factories/csi-plugin.js
@@ -11,9 +11,15 @@ export default Factory.extend({
 
   provider: faker.helpers.randomize(STORAGE_PROVIDERS),
   version: '1.0.1',
+
   controllerRequired: faker.random.boolean,
-  controllersHealthy: () => faker.random.number(3),
+
+  controllersHealthy() {
+    if (!this.controllerRequired) return 0;
+    return faker.random.number(3);
+  },
   controllersExpected() {
+    if (!this.controllerRequired) return 0;
     return this.controllersHealthy + faker.random.number({ min: 1, max: 2 });
   },
 
@@ -25,7 +31,10 @@ export default Factory.extend({
   // Internal property to determine whether or not this plugin
   // Should create one or two Jobs to represent Node and
   // Controller plugins.
-  isMonolith: faker.random.boolean,
+  isMonolith() {
+    if (!this.controllerRequired) return false;
+    return faker.random.boolean;
+  },
 
   // When false, the plugin will not make its own volumes
   createVolumes: true,
@@ -49,11 +58,13 @@ export default Factory.extend({
         shallow: plugin.shallow,
       });
     } else {
-      const controllerJob = server.create('job', {
-        type: 'service',
-        createAllocations: false,
-        shallow: plugin.shallow,
-      });
+      const controllerJob =
+        plugin.controllerRequired &&
+        server.create('job', {
+          type: 'service',
+          createAllocations: false,
+          shallow: plugin.shallow,
+        });
       const nodeJob = server.create('job', {
         type: 'service',
         createAllocations: false,
@@ -63,10 +74,12 @@ export default Factory.extend({
         job: nodeJob,
         shallow: plugin.shallow,
       });
-      storageControllers = server.createList('storage-controller', plugin.controllersExpected, {
-        job: controllerJob,
-        shallow: plugin.shallow,
-      });
+      storageControllers =
+        plugin.controllerRequired &&
+        server.createList('storage-controller', plugin.controllersExpected, {
+          job: controllerJob,
+          shallow: plugin.shallow,
+        });
     }
 
     plugin.update({

--- a/ui/mirage/factories/csi-plugin.js
+++ b/ui/mirage/factories/csi-plugin.js
@@ -19,8 +19,11 @@ export default Factory.extend({
     return faker.random.number(3);
   },
   controllersExpected() {
+    // This property must be read before the conditional
+    // or Mirage will incorrectly sort dependent properties.
+    const healthy = this.controllersHealthy;
     if (!this.controllerRequired) return 0;
-    return this.controllersHealthy + faker.random.number({ min: 1, max: 2 });
+    return healthy + faker.random.number({ min: 1, max: 2 });
   },
 
   nodesHealthy: () => faker.random.number(3),

--- a/ui/tests/acceptance/plugin-detail-test.js
+++ b/ui/tests/acceptance/plugin-detail-test.js
@@ -14,7 +14,7 @@ module('Acceptance | plugin detail', function(hooks) {
 
   hooks.beforeEach(function() {
     server.create('node');
-    plugin = server.create('csi-plugin');
+    plugin = server.create('csi-plugin', { controllerRequired: true });
   });
 
   test('/csi/plugins/:id should have a breadcrumb trail linking back to Plugins and Storage', async function(assert) {
@@ -147,6 +147,7 @@ module('Acceptance | plugin detail', function(hooks) {
 
   test('when there are no plugin allocations, the tables present empty states', async function(assert) {
     const emptyPlugin = server.create('csi-plugin', {
+      controllerRequired: true,
       controllersHealthy: 0,
       controllersExpected: 0,
       nodesHealthy: 0,
@@ -160,5 +161,17 @@ module('Acceptance | plugin detail', function(hooks) {
 
     assert.ok(PluginDetail.nodeTableIsEmpty);
     assert.equal(PluginDetail.nodeEmptyState.headline, 'No Node Plugin Allocations');
+  });
+
+  test('when the plugin is node-only, the controller information is omitted', async function(assert) {
+    const nodeOnlyPlugin = server.create('csi-plugin', { controllerRequired: false });
+
+    await PluginDetail.visit({ id: nodeOnlyPlugin.id });
+
+    assert.notOk(PluginDetail.controllerAvailabilityIsPresent);
+    assert.ok(PluginDetail.nodeAvailabilityIsPresent);
+
+    assert.notOk(PluginDetail.controllerHealthIsPresent);
+    assert.notOk(PluginDetail.controllerTableIsPresent);
   });
 });

--- a/ui/tests/acceptance/plugins-list-test.js
+++ b/ui/tests/acceptance/plugins-list-test.js
@@ -35,7 +35,7 @@ module('Acceptance | plugins list', function(hooks) {
   });
 
   test('each plugin row should contain information about the plugin', async function(assert) {
-    const plugin = server.create('csi-plugin', { shallow: true });
+    const plugin = server.create('csi-plugin', { shallow: true, controllerRequired: true });
 
     await PluginsList.visit();
 
@@ -48,6 +48,23 @@ module('Acceptance | plugins list', function(hooks) {
       pluginRow.controllerHealth,
       `${controllerHealthStr} (${plugin.controllersHealthy}/${plugin.controllersExpected})`
     );
+    assert.equal(
+      pluginRow.nodeHealth,
+      `${nodeHealthStr} (${plugin.nodesHealthy}/${plugin.nodesExpected})`
+    );
+    assert.equal(pluginRow.provider, plugin.provider);
+  });
+
+  test('node only plugins explain that there is no controller health for this plugin type', async function(assert) {
+    const plugin = server.create('csi-plugin', { shallow: true, controllerRequired: false });
+
+    await PluginsList.visit();
+
+    const pluginRow = PluginsList.plugins.objectAt(0);
+    const nodeHealthStr = plugin.nodesHealthy > 0 ? 'Healthy' : 'Unhealthy';
+
+    assert.equal(pluginRow.id, plugin.id);
+    assert.equal(pluginRow.controllerHealth, 'Node Only');
     assert.equal(
       pluginRow.nodeHealth,
       `${nodeHealthStr} (${plugin.nodesHealthy}/${plugin.nodesExpected})`

--- a/ui/tests/integration/plugin-allocation-row-test.js
+++ b/ui/tests/integration/plugin-allocation-row-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | plugin allocation row', function(hooks) {
   });
 
   test('Plugin allocation row immediately fetches the plugin allocation', async function(assert) {
-    const plugin = this.server.create('csi-plugin', { id: 'plugin' });
+    const plugin = this.server.create('csi-plugin', { id: 'plugin', controllerRequired: true });
     const storageController = plugin.controllers.models[0];
 
     const pluginRecord = await this.store.find('plugin', 'csi/plugin');
@@ -42,7 +42,7 @@ module('Integration | Component | plugin allocation row', function(hooks) {
   });
 
   test('After the plugin allocation row fetches the plugin allocation, allocation stats are fetched', async function(assert) {
-    const plugin = this.server.create('csi-plugin', { id: 'plugin' });
+    const plugin = this.server.create('csi-plugin', { id: 'plugin', controllerRequired: true });
     const storageController = plugin.controllers.models[0];
 
     const pluginRecord = await this.store.find('plugin', 'csi/plugin');
@@ -66,6 +66,7 @@ module('Integration | Component | plugin allocation row', function(hooks) {
     const plugin = this.server.create('csi-plugin', {
       id: 'plugin',
       isMonolith: false,
+      controllerRequired: true,
       controllersExpected: 2,
     });
     const storageController = plugin.controllers.models[0];

--- a/ui/tests/pages/storage/plugins/detail.js
+++ b/ui/tests/pages/storage/plugins/detail.js
@@ -19,6 +19,9 @@ export default create({
   nodeHealth: text('[data-test-plugin-node-health]'),
   provider: text('[data-test-plugin-provider]'),
 
+  controllerAvailabilityIsPresent: isPresent('[data-test-plugin-controller-availability]'),
+  nodeAvailabilityIsPresent: isPresent('[data-test-plugin-node-availability]'),
+
   breadcrumbs: collection('[data-test-breadcrumb]', {
     id: attribute('data-test-breadcrumb'),
     text: text(),

--- a/ui/tests/pages/storage/plugins/detail.js
+++ b/ui/tests/pages/storage/plugins/detail.js
@@ -15,6 +15,7 @@ export default create({
 
   title: text('[data-test-title]'),
 
+  controllerHealthIsPresent: isPresent('[data-test-plugin-controller-health]'),
   controllerHealth: text('[data-test-plugin-controller-health]'),
   nodeHealth: text('[data-test-plugin-node-health]'),
   provider: text('[data-test-plugin-provider]'),
@@ -34,6 +35,8 @@ export default create({
 
   ...allocations('[data-test-controller-allocation]', 'controllerAllocations'),
   ...allocations('[data-test-node-allocation]', 'nodeAllocations'),
+
+  controllerTableIsPresent: isPresent('[data-test-controller-allocations]'),
 
   controllerTableIsEmpty: isPresent('[data-test-empty-controller-allocations]'),
   controllerEmptyState: {


### PR DESCRIPTION
Closes #7967 

![image](https://user-images.githubusercontent.com/174740/82270222-eea8c180-9928-11ea-914a-e587ede66f3d.png)

_Node-only plugins mention so where controller health would otherwise be reported on the plugin list page._

![image](https://user-images.githubusercontent.com/174740/82270239-fff1ce00-9928-11ea-821b-802e20b2ffc2.png)

_Controller information is omitted from the plugin detail page when node-only._