### PR TITLE
docs: notice to operators about script check timeouts

### DIFF
--- a/website/pages/docs/job-specification/service.mdx
+++ b/website/pages/docs/job-specification/service.mdx
@@ -241,6 +241,15 @@ scripts.
   health check query to succeed. This is specified using a label suffix like
   "30s" or "1h". This must be greater than or equal to "1s"
 
+  ~> **Caveat:** Script checks use the task driver to execute in the task's
+  environment. For task drivers with namespace isolation such as `docker` or
+  `exec`, setting up the context for the script check may take an unexpectedly
+  long amount of time (a full second or two), especially on busy hosts. The
+  timeout configuration should allow for both this setup and the execution of
+  the script. Operators should use long timeouts (5 or more seconds) for script
+  checks, and monitor telemetry for
+  `client.allocrunner.taskrunner.tasklet_timeout`.
+
 - `type` `(string: <required>)` - This indicates the check types supported by
   Nomad. Valid options are `grpc`, `http`, `script`, and `tcp`. gRPC health
   checks require Consul 1.0.5 or later.

--- a/website/pages/docs/job-specification/service.mdx
+++ b/website/pages/docs/job-specification/service.mdx
@@ -245,7 +245,7 @@ scripts.
   environment. For task drivers with namespace isolation such as `docker` or
   `exec`, setting up the context for the script check may take an unexpectedly
   long amount of time (a full second or two), especially on busy hosts. The
-  timeout configuration should allow for both this setup and the execution of
+  timeout configuration must allow for both this setup and the execution of
   the script. Operators should use long timeouts (5 or more seconds) for script
   checks, and monitor telemetry for
   `client.allocrunner.taskrunner.tasklet_timeout`.


### PR DESCRIPTION
For https://github.com/hashicorp/nomad/issues/7719, with details of debugging in https://github.com/hashicorp/nomad/issues/7719#issuecomment-630876412

Preview at https://deploy-preview-8015--nomad-website.netlify.app/docs/job-specification/service/#timeout

The tasklet passes the timeout for the script check into the task driver's `Exec`, and its up to the task driver to enforce that via a golang `context.WithDeadline`. In practice, this deadline is started before the task driver starts setting up the execution environment (because we need it to do things like timeout Docker API calls).

Under even moderate load, the time it takes to set up the execution context for the script check regularly exceeds a full second or two. This can cause script checks to unexpectedly timeout or even never execute if the context expires before the task driver ever gets a chance to `execve`.

This changeset adds a notice to operators about setting script check timeouts with plenty of padding and what to monitor for problems.