### PR TITLE
Set Updated to true for all non-CAS requests on v1/operator/scheduler/configuration

### DIFF
--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -316,10 +316,9 @@ func (op *Operator) SchedulerSetConfiguration(args *structs.SchedulerSetConfigRe
 	} else if respErr, ok := resp.(error); ok {
 		return respErr
 	}
-	// Unless this is a CAS request, Updated is always true at this point.
+	//  If CAS request, raft returns a boolean indicating if the update was applied.
+	// Otherwise, assume success
 	reply.Updated = true
-	// Check if the return type is a bool and optionally overwrite Updated
-	// Only applies to CAS requests
 	if respBool, ok := resp.(bool); ok {
 		reply.Updated = respBool
 	}

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -304,7 +304,7 @@ func (op *Operator) SchedulerSetConfiguration(args *structs.SchedulerSetConfigRe
 		return structs.ErrPermissionDenied
 	}
 
-	// All servers should be at or above 0.9.0 to apply this operatation
+	// All servers should be at or above 0.9.0 to apply this operation
 	if !ServersMeetMinimumVersion(op.srv.Members(), minSchedulerConfigVersion, false) {
 		return fmt.Errorf("All servers should be running version %v to update scheduler config", minSchedulerConfigVersion)
 	}
@@ -316,8 +316,9 @@ func (op *Operator) SchedulerSetConfiguration(args *structs.SchedulerSetConfigRe
 	} else if respErr, ok := resp.(error); ok {
 		return respErr
 	}
-
-	// Check if the return type is a bool
+	// Unless this is a CAS request, Updated is always true at this point.
+	reply.Updated = true
+	// Check if the return type is a bool and optionally overwrite Updated
 	// Only applies to CAS requests
 	if respBool, ok := resp.(bool); ok {
 		reply.Updated = respBool


### PR DESCRIPTION
An approach that sets Updated to true and overwrites that value in the CAS case.

Fixes #8016 