### PR TITLE
api: canonicalize connect components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ IMPROVEMENTS:
 
  * build: Updated to Go 1.14.3 [[GH-7431](https://github.com/hashicorp/nomad/issues/7970)]
 
+BUG FIXES:
+
+ * api: Fixed a bug where setting connect sidecar task resources could fail [[GH-7993](https://github.com/hashicorp/nomad/issues/7993)]
+
 ## 0.11.2 (May 14, 2020)
 
 FEATURES:

--- a/api/services_test.go
+++ b/api/services_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,22 +44,110 @@ func TestService_CheckRestart(t *testing.T) {
 	}
 
 	service.Canonicalize(task, tg, job)
-	assert.Equal(t, service.Checks[0].CheckRestart.Limit, 22)
-	assert.Equal(t, *service.Checks[0].CheckRestart.Grace, 22*time.Second)
-	assert.True(t, service.Checks[0].CheckRestart.IgnoreWarnings)
+	require.Equal(t, service.Checks[0].CheckRestart.Limit, 22)
+	require.Equal(t, *service.Checks[0].CheckRestart.Grace, 22*time.Second)
+	require.True(t, service.Checks[0].CheckRestart.IgnoreWarnings)
 
-	assert.Equal(t, service.Checks[1].CheckRestart.Limit, 33)
-	assert.Equal(t, *service.Checks[1].CheckRestart.Grace, 33*time.Second)
-	assert.True(t, service.Checks[1].CheckRestart.IgnoreWarnings)
+	require.Equal(t, service.Checks[1].CheckRestart.Limit, 33)
+	require.Equal(t, *service.Checks[1].CheckRestart.Grace, 33*time.Second)
+	require.True(t, service.Checks[1].CheckRestart.IgnoreWarnings)
 
-	assert.Equal(t, service.Checks[2].CheckRestart.Limit, 11)
-	assert.Equal(t, *service.Checks[2].CheckRestart.Grace, 11*time.Second)
-	assert.True(t, service.Checks[2].CheckRestart.IgnoreWarnings)
+	require.Equal(t, service.Checks[2].CheckRestart.Limit, 11)
+	require.Equal(t, *service.Checks[2].CheckRestart.Grace, 11*time.Second)
+	require.True(t, service.Checks[2].CheckRestart.IgnoreWarnings)
 }
 
-// TestService_Connect asserts Service.Connect settings are properly
-// inherited by Checks.
-func TestService_Connect(t *testing.T) {
+func TestService_Connect_Canonicalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil connect", func(t *testing.T) {
+		cc := (*ConsulConnect)(nil)
+		cc.Canonicalize()
+		require.Nil(t, cc)
+	})
+
+	t.Run("empty connect", func(t *testing.T) {
+		cc := new(ConsulConnect)
+		cc.Canonicalize()
+		require.False(t, cc.Native)
+		require.Nil(t, cc.SidecarService)
+		require.Nil(t, cc.SidecarTask)
+	})
+}
+
+func TestService_Connect_ConsulSidecarService_Canonicalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil sidecar_service", func(t *testing.T) {
+		css := (*ConsulSidecarService)(nil)
+		css.Canonicalize()
+		require.Nil(t, css)
+	})
+
+	t.Run("empty sidecar_service", func(t *testing.T) {
+		css := new(ConsulSidecarService)
+		css.Canonicalize()
+		require.Empty(t, css.Tags)
+		require.Nil(t, css.Proxy)
+	})
+
+	t.Run("non-empty sidecar_service", func(t *testing.T) {
+		css := &ConsulSidecarService{
+			Tags: make([]string, 0),
+			Port: "port",
+			Proxy: &ConsulProxy{
+				LocalServiceAddress: "lsa",
+				LocalServicePort:    80,
+			},
+		}
+		css.Canonicalize()
+		require.Equal(t, &ConsulSidecarService{
+			Tags: nil,
+			Port: "port",
+			Proxy: &ConsulProxy{
+				LocalServiceAddress: "lsa",
+				LocalServicePort:    80},
+		}, css)
+	})
+}
+
+func TestService_Connect_ConsulProxy_Canonicalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil proxy", func(t *testing.T) {
+		cp := (*ConsulProxy)(nil)
+		cp.Canonicalize()
+		require.Nil(t, cp)
+	})
+
+	t.Run("empty proxy", func(t *testing.T) {
+		cp := new(ConsulProxy)
+		cp.Canonicalize()
+		require.Empty(t, cp.LocalServiceAddress)
+		require.Zero(t, cp.LocalServicePort)
+		require.Nil(t, cp.ExposeConfig)
+		require.Nil(t, cp.Upstreams)
+		require.Empty(t, cp.Config)
+	})
+
+	t.Run("non empty proxy", func(t *testing.T) {
+		cp := &ConsulProxy{
+			LocalServiceAddress: "127.0.0.1",
+			LocalServicePort:    80,
+			ExposeConfig:        new(ConsulExposeConfig),
+			Upstreams:           make([]*ConsulUpstream, 0),
+			Config:              make(map[string]interface{}),
+		}
+		cp.Canonicalize()
+		require.Equal(t, "127.0.0.1", cp.LocalServiceAddress)
+		require.Equal(t, 80, cp.LocalServicePort)
+		require.Equal(t, &ConsulExposeConfig{}, cp.ExposeConfig)
+		require.Nil(t, cp.Upstreams)
+		require.Nil(t, cp.Config)
+	})
+}
+
+func TestService_Connect_proxy_settings(t *testing.T) {
 	t.Parallel()
 
 	job := &Job{Name: stringToPtr("job")}
@@ -84,9 +171,9 @@ func TestService_Connect(t *testing.T) {
 
 	service.Canonicalize(task, tg, job)
 	proxy := service.Connect.SidecarService.Proxy
-	assert.Equal(t, proxy.Upstreams[0].LocalBindPort, 80)
-	assert.Equal(t, proxy.Upstreams[0].DestinationName, "upstream")
-	assert.Equal(t, proxy.LocalServicePort, 8000)
+	require.Equal(t, proxy.Upstreams[0].LocalBindPort, 80)
+	require.Equal(t, proxy.Upstreams[0].DestinationName, "upstream")
+	require.Equal(t, proxy.LocalServicePort, 8000)
 }
 
 func TestService_Tags(t *testing.T) {
@@ -107,4 +194,36 @@ func TestService_Tags(t *testing.T) {
 	r.True(service.EnableTagOverride)
 	r.Equal([]string{"a", "b"}, service.Tags)
 	r.Equal([]string{"c", "d"}, service.CanaryTags)
+}
+
+func TestService_Connect_SidecarTask_Canonicalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil sidecar_task", func(t *testing.T) {
+		st := (*SidecarTask)(nil)
+		st.Canonicalize()
+		require.Nil(t, st)
+	})
+
+	t.Run("empty sidecar_task", func(t *testing.T) {
+		st := new(SidecarTask)
+		st.Canonicalize()
+		require.Nil(t, st.Config)
+		require.Nil(t, st.Env)
+		require.Equal(t, DefaultResources(), st.Resources)
+		require.Equal(t, DefaultLogConfig(), st.LogConfig)
+		require.Nil(t, st.Meta)
+		require.Equal(t, 5*time.Second, *st.KillTimeout)
+		require.Equal(t, 0*time.Second, *st.ShutdownDelay)
+	})
+
+	t.Run("non empty sidecar_task resources", func(t *testing.T) {
+		exp := DefaultResources()
+		exp.MemoryMB = intToPtr(333)
+		st := &SidecarTask{
+			Resources: &Resources{MemoryMB: intToPtr(333)},
+		}
+		st.Canonicalize()
+		require.Equal(t, exp, st.Resources)
+	})
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -444,6 +444,7 @@ func (g *TaskGroup) Canonicalize(job *Job) {
 	if g.Name == nil {
 		g.Name = stringToPtr("")
 	}
+
 	if g.Count == nil {
 		if g.Scaling != nil && g.Scaling.Min != nil {
 			g.Count = intToPtr(int(*g.Scaling.Min))
@@ -676,6 +677,7 @@ func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
 		t.Resources = &Resources{}
 	}
 	t.Resources.Canonicalize()
+
 	if t.KillTimeout == nil {
 		t.KillTimeout = timeToPtr(5 * time.Second)
 	}


### PR DESCRIPTION
Add `Canonicalize` methods to the connect components of a service definition in the `api` package. Without these, we have been relying on good input for the connect stanza.

Fixes #7993