### PR TITLE
stats_hook: log normal shutdown condition as debug, not error

### DIFF
--- a/client/allocrunner/taskrunner/stats_hook.go
+++ b/client/allocrunner/taskrunner/stats_hook.go
@@ -137,7 +137,7 @@ MAIN:
 	// check if the error is terminal otherwise it's likely a
 	// transport error and we should retry
 	if re, ok := err.(*structs.RecoverableError); ok && re.IsUnrecoverable() {
-		h.logger.Error("failed to start stats collection for task with unrecoverable error", "error", err)
+		h.logger.Debug("failed to start stats collection for task with unrecoverable error", "error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/6073

The `stats_hook` writes an Error log every time an allocation becomes
terminal. This is a normal condition, not an error. A real error
condition like a failure to collect the stats is logged later. It just
creates log noise, and this is a particularly bad operator experience
for heavy batch workloads.