### PR TITLE
add notes about delay requirement for reschedule

### DIFF
--- a/website/pages/docs/job-specification/reschedule.mdx
+++ b/website/pages/docs/job-specification/reschedule.mdx
@@ -63,6 +63,7 @@ every node.
 
 - `delay` `(string: <varies>)` - Specifies the duration to wait before attempting
   to reschedule a failed task. This is specified using a label suffix like "30s" or "1h".
+  Delay cannot be less than 5 seconds.
 
 - `delay_function` `(string: <varies>)` - Specifies the function that is used to
   calculate subsequent reschedule delays. The initial delay is specified by the delay parameter.


### PR DESCRIPTION
Nomad doesn't allow Delay to be less than 5s on the Reschedule Stanza.
<img width="585" alt="image" src="https://user-images.githubusercontent.com/34772523/82468480-735e2180-9a88-11ea-8a3b-c988e3300ad5.png">
