### PR TITLE
Speed up leadership establishment

### DIFF
--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -146,6 +146,10 @@ type consulACLsAPI struct {
 }
 
 func NewConsulACLsAPI(aclClient consul.ACLsAPI, logger hclog.Logger, purgeFunc PurgeSITokenAccessorFunc) *consulACLsAPI {
+	if purgeFunc == nil {
+		purgeFunc = func([]*structs.SITokenAccessor) error { return nil }
+	}
+
 	c := &consulACLsAPI{
 		aclClient: aclClient,
 		limiter:   rate.NewLimiter(siTokenRequestRateLimit, int(siTokenRequestRateLimit)),

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -438,8 +438,8 @@ func (s *Server) revokeSITokenAccessorsOnRestore() error {
 	}
 
 	if len(toRevoke) > 0 {
-		ctx := context.Background()
-		s.consulACLs.RevokeTokens(ctx, toRevoke, true)
+		s.logger.Info("revoking consul accessors on restore", "accessors", len(toRevoke))
+		s.consulACLs.MarkForRevocation(toRevoke)
 	}
 
 	return nil

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -395,7 +395,7 @@ func (s *Server) revokeVaultAccessorsOnRestore() error {
 	}
 
 	if len(revoke) != 0 {
-		s.logger.Info("revoking vault accessors on restore", "accessors", len(revoke))
+		s.logger.Info("revoking vault accessors after becoming leader", "accessors", len(revoke))
 
 		if err := s.vault.MarkForRevocation(revoke); err != nil {
 			return fmt.Errorf("failed to revoke tokens: %v", err)
@@ -443,7 +443,7 @@ func (s *Server) revokeSITokenAccessorsOnRestore() error {
 	}
 
 	if len(toRevoke) > 0 {
-		s.logger.Info("revoking consul accessors on restore", "accessors", len(toRevoke))
+		s.logger.Info("revoking consul accessors after becoming leader", "accessors", len(toRevoke))
 		s.consulACLs.MarkForRevocation(toRevoke)
 	}
 

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -255,8 +255,9 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	// Enable the periodic dispatcher, since we are now the leader.
 	s.periodicDispatcher.SetEnabled(true)
 
-	// Activate RPCs after all leadership components are enabled
-	// and the server can handle write RPCs
+	// Activate RPC now that local FSM caught up with Raft (as evident by Barrier call success)
+	// and all leader related components (e.g. broker queue) are enabled.
+	// Auxiliary processes (e.g. background, bookkeeping, and cleanup tasks can start after)
 	s.setConsistentReadReady()
 
 	// Further clean ups and follow up that don't block RPC consistency

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -390,7 +390,9 @@ func (s *Server) revokeVaultAccessorsOnRestore() error {
 	}
 
 	if len(revoke) != 0 {
-		if err := s.vault.RevokeTokens(context.Background(), revoke, true); err != nil {
+		s.logger.Info("revoking vault accessors on restore", "accessors", len(revoke))
+
+		if err := s.vault.MarkForRevocation(revoke); err != nil {
 			return fmt.Errorf("failed to revoke tokens: %v", err)
 		}
 	}

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -252,6 +252,9 @@ func NewVaultClient(c *config.VaultConfig, logger log.Logger, purgeFn PurgeVault
 	if logger == nil {
 		return nil, fmt.Errorf("must pass valid logger")
 	}
+	if purgeFn == nil {
+		purgeFn = func(accessors []*structs.VaultAccessor) error { return nil }
+	}
 
 	v := &vaultClient{
 		config:   c,

--- a/nomad/vault_testing.go
+++ b/nomad/vault_testing.go
@@ -135,6 +135,11 @@ func (v *TestVaultClient) RevokeTokens(ctx context.Context, accessors []*structs
 	return nil
 }
 
+func (v *TestVaultClient) MarkForRevocation(accessors []*structs.VaultAccessor) error {
+	v.RevokedTokens = append(v.RevokedTokens, accessors...)
+	return nil
+}
+
 func (v *TestVaultClient) Stop()                                                  {}
 func (v *TestVaultClient) SetActive(enabled bool)                                 {}
 func (v *TestVaultClient) SetConfig(config *config.VaultConfig) error             { return nil }


### PR DESCRIPTION
Establishing leadership should be very fast and never make potentially slow external API calls.

This PR makes the following changes:

* Move Vault and Consul token revocation to background to avoid block leadership establishment.
* Reorder leadership establishment steps: mark RPC ready as soon as the leader components are enabled, and move cleanup steps that aren't necessary immediate to the end.

## Context and Motivation

Upon upgrading to 0.11.2, a cluster suffered many errors related to Nomad being slow to establish leadership and failing to respond to RPCs with "Not ready to serve consistent reads".  The cause was that `revokeVaultAccessorsOnRestore` was running for along time and blocking the leader from performing its duties.

There are few moving parts in 0.11.2 that contributed to the issue:

The cluster had a very large number of vault tokens to be revoked.  In one instance in the cluster history, over a million Vault tokens were revoked all at once!  Presumably when the server gained leadership, many of the tokens were already revoked, either because Token TTL expired or because the previous leader revoke them prior before it lost leadership.

In processing this, two problems happen:

First, Nomad attempts to revoke the tokens in leadership establishment goroutine and block further leadership establishment.  Changes in https://github.com/hashicorp/nomad/pull/5911 made the situation more visible.  Prior to that PR, long vault revocation causes the leader to be half-wedged state, it may respond to RPCs but will not establish node heartbeat timers or schedule periodic jobs.  That PR made the situation more obvious.

However, a second bug lessened the severity of the first bug: Vault revocation call is flaky and may terminate quickly.  Prior to https://github.com/hashicorp/nomad/pull/7959 , if some of the tokens were already revoked or expired already, `RevokeToken` call fails fast and but it retries indefinitely in the background as none of the retries will succeed; this probably revokeDaemon may never actually revoke any tokens as the retries will keep failing with these tokens.  PR #7959 made vault revocation thread keep going even with already revoked tokens.  However, this also means that now that the revocation thread will process that long list of tokens in leader establishment thread and slow everything to a halt!

This PR addresses both of these problems by ensuring that the leadership establishment is fast, that token revocation always happen in background.  Also, given that cleanup processes aren't critical or time sensitive to leader functionality, we move their order so we prioritize other more critical functionality (periodic jobs, node heartbeat tracking, etc).

Furthermore, when processing a super long list of revocation, we only check for the token TTL at the start to avoid revoking already expired tokens.  But if the token TTLs are short (~60 seconds) relative to revocation of the long list, we may overwhelm Vault by making a lot of unnecessary API calls.  Also, if any of their revocation fails, nomad reattempts to revoke all of them again!

This PR breaks the background revocation to be in 1000-token batches.  This reduces the burden on Vault a bit and makes the retry handle for failed tokens a tad better (retry at most 1000 instead of 1 million tokens).