### PR TITLE
build: use hashicorp hclfmt

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -173,7 +173,7 @@ deps:  ## Install build and development dependencies
 	GO111MODULE=on go get -u github.com/a8m/tree/cmd/tree
 	GO111MODULE=on go get -u github.com/magiconair/vendorfmt/cmd/vendorfmt
 	GO111MODULE=on go get -u gotest.tools/gotestsum
-	GO111MODULE=on go get -u github.com/fatih/hclfmt
+	GO111MODULE=on go get -u github.com/hashicorp/hcl/v2/cmd/hclfmt@v2.5.1
 	GO111MODULE=on go get -u github.com/golang/protobuf/protoc-gen-go@v1.3.4
 	GO111MODULE=on go get -u github.com/hashicorp/go-msgpack/codec/codecgen@v1.1.5
 

--- a/command/assets/example-short.nomad
+++ b/command/assets/example-short.nomad
@@ -19,7 +19,7 @@ job "example" {
 
         network {
           mbits = 10
-          port  "db"  {}
+          port "db" {}
         }
       }
     }

--- a/command/assets/example.nomad
+++ b/command/assets/example.nomad
@@ -316,7 +316,7 @@ job "example" {
 
         network {
           mbits = 10
-          port  "db"  {}
+          port "db" {}
         }
       }
       # The "service" stanza instructs Nomad to register this task as a service

--- a/dev/docker-clients/client.nomad
+++ b/dev/docker-clients/client.nomad
@@ -23,7 +23,7 @@ job "client" {
 
         network {
           mbits = 10
-          port  "http"{}
+          port "http" {}
         }
       }
 

--- a/e2e/consul/input/consul_example.nomad
+++ b/e2e/consul/input/consul_example.nomad
@@ -54,7 +54,7 @@ job "consul-example" {
 
         network {
           mbits = 10
-          port  "db"  {}
+          port "db" {}
         }
       }
 

--- a/e2e/metrics/input/helloworld.nomad
+++ b/e2e/metrics/input/helloworld.nomad
@@ -28,7 +28,7 @@ job "helloworld" {
 
         network {
           mbits = 10
-          port  "web" {}
+          port "web" {}
         }
       }
 

--- a/e2e/metrics/input/simpleweb.nomad
+++ b/e2e/metrics/input/simpleweb.nomad
@@ -25,7 +25,7 @@ job "simpleweb" {
 
         network {
           mbits = 1
-          port  "http"{}
+          port "http" {}
         }
       }
 

--- a/e2e/prometheus/prometheus.nomad
+++ b/e2e/prometheus/prometheus.nomad
@@ -69,7 +69,7 @@ EOH
       resources {
         network {
           mbits = 10
-          port  "prometheus_ui"{}
+          port "prometheus_ui" {}
         }
       }
 

--- a/jobspec/test-fixtures/tg-scaling-policy.hcl
+++ b/jobspec/test-fixtures/tg-scaling-policy.hcl
@@ -9,7 +9,7 @@ job "elastic" {
         foo = "bar"
         b   = true
         val = 5
-        f   = .1
+        f   =.1
       }
     }
   }


### PR DESCRIPTION
We have been using `fatih/hclfmt` which is long abandoned. Instead, switch
to HashiCorp's own `hclfmt` implementation. There are some trivial changes in
behavior around whitespace.