### PR TITLE
fix: static port incorrectly declared as a string

### DIFF
--- a/website/pages/docs/job-specification/network.mdx
+++ b/website/pages/docs/job-specification/network.mdx
@@ -48,7 +48,7 @@ job "docs" {
           port "http" {}
           port "https" {}
           port "lb" {
-            static = "8889"
+            static = 8889
           }
         }
       }


### PR DESCRIPTION
`static` attribute of the `port` stanza is supposed to be an int but is incorrectly declared as a string in the example.