### PR TITLE
UI: Remove minor version from audit comparison action

### DIFF
--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: pr-audit
-      - uses: backspace/ember-test-audit-comparison-action@v1.0
+      - uses: backspace/ember-test-audit-comparison-action@v1
         with:
           base-report-path: base-audit.json
           comparison-report-path: pr-audit.json


### PR DESCRIPTION
Making this less specific means we can benefit from updates
to the action without needing to change the workflow, such
as the bug fix in backspace/ember-test-audit-comparison-action@a87d252,
which addresses the incorrect duration delta here:
https://github.com/hashicorp/nomad/pull/7964#issuecomment-632351171