### PR TITLE
tests: log to stderr directly

### DIFF
--- a/helper/testlog/testlog.go
+++ b/helper/testlog/testlog.go
@@ -12,52 +12,26 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 )
 
-// UseStdout returns true if NOMAD_TEST_STDOUT=1 and sends logs to stdout.
-func UseStdout() bool {
-	return os.Getenv("NOMAD_TEST_STDOUT") == "1"
-}
-
 // LogPrinter is the methods of testing.T (or testing.B) needed by the test
 // logger.
 type LogPrinter interface {
 	Logf(format string, args ...interface{})
 }
 
-// writer implements io.Writer on top of a Logger.
-type writer struct {
-	prefix string
-	t      LogPrinter
-}
-
-// Write to an underlying Logger. Never returns an error.
-func (w *writer) Write(p []byte) (n int, err error) {
-	w.t.Logf("%s%s", w.prefix, p)
-	return len(p), nil
-}
-
 // NewWriter creates a new io.Writer backed by a Logger.
 func NewWriter(t LogPrinter) io.Writer {
-	if UseStdout() {
-		return os.Stdout
-	}
-	return &writer{t: t}
+	return os.Stderr
 }
 
 // NewPrefixWriter creates a new io.Writer backed by a Logger with a custom
 // prefix per Write.
 func NewPrefixWriter(t LogPrinter, prefix string) io.Writer {
-	if UseStdout() {
-		return &prefixStdout{[]byte(prefix)}
-	}
-	return &writer{prefix, t}
+	return &prefixStderr{[]byte(prefix)}
 }
 
 // New returns a new test logger. See https://golang.org/pkg/log/#New
 func New(t LogPrinter, prefix string, flag int) *log.Logger {
-	if UseStdout() {
-		return log.New(os.Stdout, prefix, flag)
-	}
-	return log.New(&writer{t: t}, prefix, flag)
+	return log.New(os.Stderr, prefix, flag)
 }
 
 // WithPrefix returns a new test logger with the Lmicroseconds flag set.
@@ -80,29 +54,29 @@ func HCLogger(t LogPrinter) hclog.InterceptLogger {
 	}
 	opts := &hclog.LoggerOptions{
 		Level:           level,
-		Output:          NewWriter(t),
+		Output:          os.Stderr,
 		IncludeLocation: true,
 	}
 	return hclog.NewInterceptLogger(opts)
 }
 
-type prefixStdout struct {
+type prefixStderr struct {
 	prefix []byte
 }
 
 // Write to stdout with a prefix per call containing non-whitespace characters.
-func (w *prefixStdout) Write(p []byte) (int, error) {
+func (w *prefixStderr) Write(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
 
 	// Skip prefix if only writing whitespace
 	if len(bytes.TrimSpace(p)) > 0 {
-		_, err := os.Stdout.Write(w.prefix)
+		_, err := os.Stderr.Write(w.prefix)
 		if err != nil {
 			return 0, err
 		}
 	}
 
-	return os.Stdout.Write(p)
+	return os.Stderr.Write(p)
 }


### PR DESCRIPTION
Go 1.14 now streams t.Log output as it happens [1], so we no longer need
to maintain our log STDOUT helper.

The primary motivation is to stop test failures due to logs in goroutines after test ends.  While we generally avoid that, some goroutines log their shutdown which trigger failures like ones in https://circleci.com/gh/hashicorp/nomad/69888 .

I preserved the interface, so `testlog` still takes in a `*testing.T`
though unused. Changing it requires so too many changes that I didn't
want to make quite yet.  There are ~565 testlog invocations and changing them provide little value.

[1] https://golang.org/doc/go1.14#go-test