### PR TITLE
Allow the Docker driver to run containers with additional groups

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -279,6 +279,7 @@ var (
 	// a task within a job. It is returned in the TaskConfigSchema RPC
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		"image":                  hclspec.NewAttr("image", "string", true),
+		"additional_groups":      hclspec.NewAttr("additional_groups", "list(string)", false),
 		"advertise_ipv6_address": hclspec.NewAttr("advertise_ipv6_address", "bool", false),
 		"args":                   hclspec.NewAttr("args", "list(string)", false),
 		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
@@ -383,6 +384,7 @@ var (
 
 type TaskConfig struct {
 	Image             string             `codec:"image"`
+	AdditionalGroups  []string           `codec:"additional_groups"`
 	AdvertiseIPv6Addr bool               `codec:"advertise_ipv6_address"`
 	Args              []string           `codec:"args"`
 	Auth              DockerAuth         `codec:"auth"`

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -178,6 +178,8 @@ func TestConfig_ParseAllHCL(t *testing.T) {
 	cfgStr := `
 config {
   image = "redis:3.2"
+
+  additional_groups = ["group1", "group2"]
   advertise_ipv6_address = true
   args = ["command_arg1", "command_arg2"]
   auth {
@@ -300,6 +302,7 @@ config {
 
 	expected := &TaskConfig{
 		Image:             "redis:3.2",
+		AdditionalGroups:  []string{"group1", "group2"},
 		AdvertiseIPv6Addr: true,
 		Args:              []string{"command_arg1", "command_arg2"},
 		Auth: DockerAuth{

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -787,6 +787,8 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		PidsLimit: &driverConfig.PidsLimit,
 
 		Runtime: containerRuntime,
+
+		GroupAdd: driverConfig.AdditionalGroups,
 	}
 
 	// Calculate CPU Quota

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -44,6 +44,9 @@ The `docker` driver supports the following configuration in the job spec. Only
   }
   ```
 
+- `additional_groups` - (Optional) A list of supplementary groups to be applied
+  to the container user.
+
 - `args` - (Optional) A list of arguments to the optional `command`. If no
   `command` is specified, the arguments are passed directly to the container.
   References to environment variables or any [interpretable Nomad


### PR DESCRIPTION
This option is equivalent to `docker run --group-add`.

-----

This is my first attempt at contributing to Nomad, my first contribution in Go anywhere, and in fact my first shot at doing anything in Go, period, so please be gentle. 🙂

A few questions, assuming this change is even directionally correct:
* Have I covered all the areas that need changes?
* Are these tests remotely sane?
* Does this new option have the best name? I haven't thought extremely hard about alternatives but `group_add` didn't seem like the right fit. https://docs.docker.com/engine/reference/run/ describes the option as "Add additional groups to run as."
* Is `master` the correct branch to target to get this into a near release?

Thanks!