### PR TITLE
docs: update CNI version in connect setup docs

### DIFF
--- a/website/pages/docs/integrations/consul-connect.mdx
+++ b/website/pages/docs/integrations/consul-connect.mdx
@@ -116,7 +116,7 @@ must have CNI plugins installed.
 The following commands install CNI plugins:
 
 ```shell-session
-$ curl -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.4/cni-plugins-linux-amd64-v0.8.4.tgz
+$ curl -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
 $ sudo mkdir -p /opt/cni/bin
 $ sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
 ```


### PR DESCRIPTION
Update reference to CNI from version 0.8.4 to 0.8.6, which includes
bug fixes, new features, etc.

https://github.com/containernetworking/plugins/releases/tag/v0.8.6