### PR TITLE
Implement raft multipler flag

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -43,6 +43,14 @@ const (
 	// roles used in identifying Consul entries for Nomad agents
 	consulRoleServer = "server"
 	consulRoleClient = "client"
+
+	// DefaultRaftMultiplier is used as a baseline Raft configuration that
+	// will be reliable on a very basic server.
+	DefaultRaftMultiplier = 1
+
+	// MaxRaftMultiplier is a fairly arbitrary upper bound that limits the
+	// amount of performance detuning that's possible.
+	MaxRaftMultiplier = 10
 )
 
 // Agent is a long running daemon that is used to run both
@@ -180,6 +188,18 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	if agentConfig.Server.RaftProtocol != 0 {
 		conf.RaftConfig.ProtocolVersion = raft.ProtocolVersion(agentConfig.Server.RaftProtocol)
 	}
+	raftMultiplier := int(DefaultRaftMultiplier)
+	if agentConfig.Server.RaftMultiplier != nil && *agentConfig.Server.RaftMultiplier != 0 {
+		raftMultiplier = *agentConfig.Server.RaftMultiplier
+		if raftMultiplier < 1 || raftMultiplier > MaxRaftMultiplier {
+			return nil, fmt.Errorf("raft_multiplier cannot be %d. Must be between 1 and %d", *agentConfig.Server.RaftMultiplier, MaxRaftMultiplier)
+		}
+	}
+	conf.RaftConfig.ElectionTimeout *= time.Duration(raftMultiplier)
+	conf.RaftConfig.HeartbeatTimeout *= time.Duration(raftMultiplier)
+	conf.RaftConfig.LeaderLeaseTimeout *= time.Duration(raftMultiplier)
+	conf.RaftConfig.CommitTimeout *= time.Duration(raftMultiplier)
+
 	if agentConfig.Server.NumSchedulers != nil {
 		conf.NumSchedulers = *agentConfig.Server.NumSchedulers
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -355,6 +355,9 @@ type ServerConfig struct {
 	// RaftProtocol is the Raft protocol version to speak. This must be from [1-3].
 	RaftProtocol int `hcl:"raft_protocol"`
 
+	// RaftMultiplier scales the Raft timing parameters
+	RaftMultiplier *int `hcl:"raft_multiplier"`
+
 	// NumSchedulers is the number of scheduler thread that are run.
 	// This can be as many as one per core, or zero to disable this server
 	// from doing any scheduling work.
@@ -1314,6 +1317,10 @@ func (a *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 	}
 	if b.RaftProtocol != 0 {
 		result.RaftProtocol = b.RaftProtocol
+	}
+	if b.RaftMultiplier != nil {
+		c := *b.RaftMultiplier
+		result.RaftMultiplier = &c
 	}
 	if b.NumSchedulers != nil {
 		result.NumSchedulers = helper.IntToPtr(*b.NumSchedulers)

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -97,6 +97,7 @@ var basicConfig = &Config{
 		DataDir:                   "/tmp/data",
 		ProtocolVersion:           3,
 		RaftProtocol:              3,
+		RaftMultiplier:            helper.IntToPtr(4),
 		NumSchedulers:             helper.IntToPtr(2),
 		EnabledSchedulers:         []string{"test"},
 		NodeGCThreshold:           "12h",

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -132,6 +132,7 @@ func TestConfig_Merge(t *testing.T) {
 			DataDir:                "/tmp/data1",
 			ProtocolVersion:        1,
 			RaftProtocol:           1,
+			RaftMultiplier:         helper.IntToPtr(5),
 			NumSchedulers:          helper.IntToPtr(1),
 			NodeGCThreshold:        "1h",
 			HeartbeatGrace:         30 * time.Second,
@@ -317,6 +318,7 @@ func TestConfig_Merge(t *testing.T) {
 			DataDir:                "/tmp/data2",
 			ProtocolVersion:        2,
 			RaftProtocol:           2,
+			RaftMultiplier:         helper.IntToPtr(6),
 			NumSchedulers:          helper.IntToPtr(2),
 			EnabledSchedulers:      []string{structs.JobTypeBatch},
 			NodeGCThreshold:        "12h",
@@ -425,9 +427,7 @@ func TestConfig_Merge(t *testing.T) {
 	result := c0.Merge(c1)
 	result = result.Merge(c2)
 	result = result.Merge(c3)
-	if !reflect.DeepEqual(result, c3) {
-		t.Fatalf("bad:\n%#v\n%#v", result, c3)
-	}
+	require.Equal(t, c3, result)
 }
 
 func TestConfig_ParseConfigFile(t *testing.T) {

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -129,6 +129,7 @@ server {
   redundancy_zone               = "foo"
   upgrade_version               = "0.8.0"
   encrypt                       = "abc"
+  raft_multiplier               = 4
 
   server_join {
     retry_join     = ["1.1.1.1", "2.2.2.2"]

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -276,6 +276,7 @@
       "num_schedulers": 2,
       "protocol_version": 3,
       "raft_protocol": 3,
+      "raft_multiplier": 4,
       "redundancy_zone": "foo",
       "rejoin_after_leave": true,
       "retry_interval": "15s",

--- a/website/pages/docs/configuration/server.mdx
+++ b/website/pages/docs/configuration/server.mdx
@@ -141,6 +141,14 @@ server {
   features and is typically not required as the agent internally knows the
   latest version, but may be useful in some upgrade scenarios.
 
+- `raft_multiplier` `(int: 1)` - An integer multiplier used by Nomad servers to
+  scale key Raft timing parameters. Omitting this value or setting it to 0 uses
+  default timing described below. Lower values are used to tighten timing and
+  increase sensitivity while higher values relax timings and reduce sensitivity.
+  Tuning this affects the time it takes Nomad to detect leader failures and to
+  perform leader elections, at the expense of requiring more network and CPU
+  resources for better performance. The maximum allowed value is 10.
+
 - `redundancy_zone` `(string: "")` - (Enterprise-only) Specifies the redundancy
   zone that this server will be a part of for Autopilot management. For more
   information, see the [Autopilot Guide](https://learn.hashicorp.com/nomad/operating-nomad/autopilot).

--- a/website/pages/docs/configuration/server.mdx
+++ b/website/pages/docs/configuration/server.mdx
@@ -149,6 +149,17 @@ server {
   perform leader elections, at the expense of requiring more network and CPU
   resources for better performance. The maximum allowed value is 10.
 
+  By default, Nomad will use the highest-performance timing, currently equivalent
+  to setting this to a value of 1. Increasing the timings makes leader election
+  less likely during periods of networking issues or resource starvation. Since
+  leader elections pause Nomad's normal work, it may be beneficial for slow or
+  unreliable networks to wait longer before electing a new leader. The tradeoff
+  when raising this value is that during network partitions or other events
+  (server crash) where a leader is lost, Nomad will not elect a new leader for
+  a longer period of time than the default. The ['nomad.nomad.leader.barrier' and
+  `nomad.raft.leader.lastContact` metrics](/docs/telemetry/metrics is a good
+  indicator of how often leader elections occur and raft latency.
+
 - `redundancy_zone` `(string: "")` - (Enterprise-only) Specifies the redundancy
   zone that this server will be a part of for Autopilot management. For more
   information, see the [Autopilot Guide](https://learn.hashicorp.com/nomad/operating-nomad/autopilot).


### PR DESCRIPTION
This ports `raft_multiplier` flag from Consul to Nomad: https://www.consul.io/docs/agent/options.html#raft_multiplier .

It allows users to set tweak raft related timeouts and leases, which is important in low/moderate performance network or disks.  Consul has some guides for raft_multipliers in https://www.consul.io/docs/install/performance.html - not sure how it fully maps to nomad yet, but at least we can expose the knob and give recommendations later.

This doesn't change the defaults, and operators can increase the defaults.  I infer that the current defaults are adequate, as we haven't gotten many requests or support issues related to raft defaults.

Closes https://github.com/hashicorp/nomad/issues/5872 .