### PR TITLE
driver/docker: enable setting hard/soft memory limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ IMPROVEMENTS:
  * csi: Return better error messages [[GH-7984](https://github.com/hashicorp/nomad/issues/7984)] [[GH-8030](https://github.com/hashicorp/nomad/issues/8030)]
  * csi: Move volume claim releases out of evaluation workers [[GH-8021](https://github.com/hashicorp/nomad/issues/8021)]
  * csi: Added support for `VolumeContext` and `VolumeParameters` [[GH-7957](https://github.com/hashicorp/nomad/issues/7957)]
- * driver/docker: Added support for memory_hard_limit configuration in docker task driver [[GH-2093](https://github.com/hashicorp/nomad/issues/2093)]
+ * driver/docker: Added support for `memory_hard_limit` configuration in docker task driver [[GH-2093](https://github.com/hashicorp/nomad/issues/2093)]
  * logging: Remove spurious error log on task shutdown [[GH-8028](https://github.com/hashicorp/nomad/issues/8028)]
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ IMPROVEMENTS:
  * csi: Return better error messages [[GH-7984](https://github.com/hashicorp/nomad/issues/7984)] [[GH-8030](https://github.com/hashicorp/nomad/issues/8030)]
  * csi: Move volume claim releases out of evaluation workers [[GH-8021](https://github.com/hashicorp/nomad/issues/8021)]
  * csi: Added support for `VolumeContext` and `VolumeParameters` [[GH-7957](https://github.com/hashicorp/nomad/issues/7957)]
+ * driver/docker: Added support for memory_hard_limit configuration in docker task driver [[GH-2093](https://github.com/hashicorp/nomad/issues/2093)]
  * logging: Remove spurious error log on task shutdown [[GH-8028](https://github.com/hashicorp/nomad/issues/8028)]
 
 BUG FIXES:

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -319,7 +319,8 @@ var (
 			"driver": hclspec.NewAttr("driver", "string", false),
 			"config": hclspec.NewAttr("config", "list(map(string))", false),
 		})),
-		"mac_address": hclspec.NewAttr("mac_address", "string", false),
+		"mac_address":       hclspec.NewAttr("mac_address", "string", false),
+		"memory_hard_limit": hclspec.NewAttr("memory_hard_limit", "number", false),
 		"mounts": hclspec.NewBlockList("mounts", hclspec.NewObject(map[string]*hclspec.Spec{
 			"type": hclspec.NewDefault(
 				hclspec.NewAttr("type", "string", false),
@@ -408,6 +409,7 @@ type TaskConfig struct {
 	LoadImage         string             `codec:"load"`
 	Logging           DockerLogging      `codec:"logging"`
 	MacAddress        string             `codec:"mac_address"`
+	MemoryHardLimit   int64              `codec:"memory_hard_limit"`
 	Mounts            []DockerMount      `codec:"mounts"`
 	NetworkAliases    []string           `codec:"network_aliases"`
 	NetworkMode       string             `codec:"network_mode"`

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -222,6 +222,7 @@ config {
     }
   }
   mac_address = "02:42:ac:11:00:02"
+  memory_hard_limit = 512
   mounts = [
     {
       type = "bind"
@@ -349,7 +350,8 @@ config {
 				"max-file": "3",
 				"max-size": "10m",
 			}},
-		MacAddress: "02:42:ac:11:00:02",
+		MacAddress:      "02:42:ac:11:00:02",
+		MemoryHardLimit: 512,
 		Mounts: []DockerMount{
 			{
 				Type:     "bind",
@@ -524,7 +526,6 @@ func TestConfig_InternalCapabilities(t *testing.T) {
 			require.Equal(t, c.expected, d.InternalCapabilities())
 		})
 	}
-
 }
 
 func TestConfig_DriverConfig_PullActivityTimeout(t *testing.T) {
@@ -582,5 +583,4 @@ func TestConfig_DriverConfig_AllowRuntimes(t *testing.T) {
 			require.Equal(t, c.expected, d.config.allowRuntimes)
 		})
 	}
-
 }

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -741,7 +741,7 @@ func parseSecurityOpts(securityOpts []string) ([]string, error) {
 // unset.
 //
 // Returns (memory (hard), memory_reservation (soft)) values in bytes.
-func (Driver) memoryLimits(driverHardLimitMB, taskMemoryLimitBytes int64) (int64, int64) {
+func (_ *Driver) memoryLimits(driverHardLimitMB, taskMemoryLimitBytes int64) (int64, int64) {
 	if driverHardLimitMB <= 0 {
 		return taskMemoryLimitBytes, 0
 	}

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2681,3 +2681,19 @@ func TestDockerDriver_CreateContainerConfig_CPUHardLimit(t *testing.T) {
 	require.NotZero(t, c.HostConfig.CPUQuota)
 	require.NotZero(t, c.HostConfig.CPUPeriod)
 }
+
+func TestDockerDriver_memoryLimits(t *testing.T) {
+	t.Parallel()
+
+	t.Run("driver hard limit not set", func(t *testing.T) {
+		memory, memoryReservation := new(Driver).memoryLimits(0, 256*1024*1024)
+		require.Equal(t, int64(256*1024*1024), memory)
+		require.Equal(t, int64(0), memoryReservation)
+	})
+
+	t.Run("driver hard limit is set", func(t *testing.T) {
+		memory, memoryReservation := new(Driver).memoryLimits(512, 256*1024*1024)
+		require.Equal(t, int64(512*1024*1024), memory)
+		require.Equal(t, int64(256*1024*1024), memoryReservation)
+	})
+}

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -184,7 +184,7 @@ The `docker` driver supports the following configuration in the job spec. Only
   "02:68:b3:29:da:98").
 
 - `memory_hard_limit` - (Optional) The maximum allowable amount of memory used
-  (megabytes) by the container. If set, the [`memory`](http://localhost:3000/docs/job-specification/resources#memory)
+  (megabytes) by the container. If set, the [`memory`](/docs/job-specification/resources#memory)
   parameter of the task resource configuration becomes a soft limit passed to the
   docker driver as [`--memory_reservation`](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory),
   and `memory_hard_limit` is passed as the [`--memory`](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory)

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -188,7 +188,8 @@ The `docker` driver supports the following configuration in the job spec. Only
   parameter of the task resource configuration becomes a soft limit passed to the
   docker driver as [`--memory_reservation`](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory),
   and `memory_hard_limit` is passed as the [`--memory`](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory)
-  hard limit.
+  hard limit. When the host is under memory pressure, the behavior of soft limit
+  activation is governed by the [Kernel](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt).
 
 - `network_aliases` - (Optional) A list of network-scoped aliases, provide a way for a
   container to be discovered by an alternate name by any other container within

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -183,6 +183,13 @@ The `docker` driver supports the following configuration in the job spec. Only
 - `mac_address` - (Optional) The MAC address for the container to use (e.g.
   "02:68:b3:29:da:98").
 
+- `memory_hard_limit` - (Optional) The maximum allowable amount of memory used
+  (megabytes) by the container. If set, the [`memory`](http://localhost:3000/docs/job-specification/resources#memory)
+  parameter of the task resource configuration becomes a soft limit passed to the
+  docker driver as [`--memory_reservation`](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory),
+  and `memory_hard_limit` is passed as the [`--memory`](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory)
+  hard limit.
+
 - `network_aliases` - (Optional) A list of network-scoped aliases, provide a way for a
   container to be discovered by an alternate name by any other container within
   the scope of a particular network. Network-scoped alias is supported only for


### PR DESCRIPTION
Fixes #2093

Enable configuring `memory_hard_limit` in the docker config stanza for tasks.
If set, this field will be passed to the container runtime as `--memory`, and
the `memory` configuration from the task resource configuration will be passed
as `--memory_reservation`, creating hard and soft memory limits for tasks using
the docker task driver.