### PR TITLE
Delayed evaluations for `stop_after_client_disconnect` can cause unwanted extra followup evaluations around job garbage collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
  * api: Fixed a bug where setting connect sidecar task resources could fail [[GH-7993](https://github.com/hashicorp/nomad/issues/7993)]
+ * core: Fixed a bug where stop_after_client_disconnect could cause the server to become unresponsive [[GH-8098](https://github.com/hashicorp/nomad/issues/8098)
  * client: Fixed a bug where artifact downloads failed on redirects [[GH-7854](https://github.com/hashicorp/nomad/issues/7854)]
  * csi: Validate empty volume arguments in API. [[GH-8027](https://github.com/hashicorp/nomad/issues/8027)]
 

--- a/client/heartbeatstop.go
+++ b/client/heartbeatstop.go
@@ -60,7 +60,7 @@ func (h *heartbeatStop) shouldStop(alloc *structs.Allocation) bool {
 func (h *heartbeatStop) shouldStopAfter(now time.Time, interval time.Duration) bool {
 	lastOk := h.getLastOk()
 	if lastOk.IsZero() {
-		return h.startupGrace.After(now)
+		return now.After(h.startupGrace)
 	}
 	return now.After(lastOk.Add(interval))
 }

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -474,7 +474,7 @@ func evaluatePlanPlacements(pool *EvaluatePool, snap *state.StateSnapshot, plan 
 		if !fit {
 			// Log the reason why the node's allocations could not be made
 			if reason != "" {
-				logger.Debug("plan for node rejected", "node_id", nodeID, "reason", reason)
+				logger.Debug("plan for node rejected", "node_id", nodeID, "reason", reason, "eval_id", plan.EvalID)
 			}
 			// Set that this is a partial commit
 			partialCommit = true

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -2846,8 +2846,8 @@ func TestServiceSched_StopAfterClientDisconnect(t *testing.T) {
 			require.Equal(t, h.Evals[0].Status, structs.EvalStatusComplete)
 			require.Len(t, h.Plans, 1, "plan")
 
-			// Followup eval created
-			require.True(t, len(h.CreateEvals) > 0)
+			// One followup eval created, either delayed or blocked
+			require.Len(t, h.CreateEvals, 1)
 			e := h.CreateEvals[0]
 			require.Equal(t, eval.ID, e.PreviousEval)
 


### PR DESCRIPTION
A couple of very small changes, and then the changes in `generic_sched` and `reconciler`. The risk should be limited to the extra `delayInstead` condition check, which is also applied to evals that are delayed for the `reschedule` block.

Manual testing (e2e version coming): https://github.com/langmartin/nomad-dev/tree/master/cfg/heartyeet

Fixes #8098 