### PR TITLE
stop periodic dispatch at end of tests

### DIFF
--- a/nomad/periodic_test.go
+++ b/nomad/periodic_test.go
@@ -82,6 +82,7 @@ func testPeriodicDispatcher(t *testing.T) (*PeriodicDispatch, *MockJobEvalDispat
 	logger := testlog.HCLogger(t)
 	m := NewMockJobEvalDispatcher()
 	d := NewPeriodicDispatch(logger, m)
+	t.Cleanup(func() { d.SetEnabled(false) })
 	d.SetEnabled(true)
 	return d, m
 }


### PR DESCRIPTION
Fixes odd case in https://circleci.com/gh/hashicorp/nomad/73751 where a periodic job test interfered with other tests.