### PR TITLE
ignore vagrant directory even if symlinked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ _testmain.go
 /tags
 /bin/
 /pkg/
-.vagrant/
+.vagrant
 website/build/
 website/npm-debug.log
 *.old


### PR DESCRIPTION
If you symlink the `.vagrant/` directory so that you can reuse the Vagrant box between Nomad OSS and Nomad Enterprise repositories, git will not ignore it. While this change means we'd be ignoring any file named `.vagrant`, it seems very unlikely we'd actually have one.