### PR TITLE
Revert "fix go.mod replace for api by using older semantics (#8113)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad
 
-go 1.13
+go 1.14
 
 replace (
 	github.com/Microsoft/go-winio => github.com/endocrimes/go-winio v0.4.13-0.20190628114223-fb47a8b41948


### PR DESCRIPTION
This reverts commit e3db589c09ee14c3c427d21662b71e98811e8722 because it broke the ENT repo.