### PR TITLE
UI: Add rendering of poststop tasks

### DIFF
--- a/ui/app/components/lifecycle-chart.js
+++ b/ui/app/components/lifecycle-chart.js
@@ -17,6 +17,7 @@ export default class LifecycleChart extends Component {
       prestarts: [],
       sidecars: [],
       mains: [],
+      poststops: [],
     };
 
     tasksOrStates.forEach(taskOrState => {
@@ -29,6 +30,7 @@ export default class LifecycleChart extends Component {
     if (lifecycles.prestarts.length || lifecycles.sidecars.length) {
       phases.push({
         name: 'Prestart',
+        class: 'prestart',
         isActive: lifecycles.prestarts.some(state => state.state === 'running'),
       });
     }
@@ -36,7 +38,16 @@ export default class LifecycleChart extends Component {
     if (lifecycles.sidecars.length || lifecycles.mains.length) {
       phases.push({
         name: 'Main',
+        class: 'main',
         isActive: lifecycles.mains.some(state => state.state === 'running'),
+      });
+    }
+
+    if (lifecycles.poststops.length) {
+      phases.push({
+        name: 'Poststop',
+        class: 'poststop',
+        isActive: lifecycles.poststops.some(state => state.state === 'running'),
       });
     }
 
@@ -58,9 +69,10 @@ const lifecycleNameSortPrefix = {
   prestart: 0,
   sidecar: 1,
   main: 2,
+  poststop: 3,
 };
 
 function getTaskSortPrefix(task) {
-  // Prestarts first, then sidecars, then mains
+  // Prestarts first, then sidecars, then mains, then poststops
   return `${lifecycleNameSortPrefix[task.lifecycleName]}-${task.name}`;
 }

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -16,6 +16,7 @@ export default class Task extends Fragment {
   get lifecycleName() {
     if (this.lifecycle && this.lifecycle.sidecar) return 'sidecar';
     if (this.lifecycle && this.lifecycle.hook === 'prestart') return 'prestart';
+    if (this.lifecycle && this.lifecycle.hook === 'poststop') return 'poststop';
     return 'main';
   }
 

--- a/ui/app/styles/components/lifecycle-chart.scss
+++ b/ui/app/styles/components/lifecycle-chart.scss
@@ -11,7 +11,6 @@
 
     .divider {
       position: absolute;
-      left: 25%;
       height: 100%;
 
       stroke: $ui-gray-200;
@@ -19,6 +18,14 @@
       stroke-dasharray: 1, 7;
       stroke-dashoffset: 1;
       stroke-linecap: square;
+
+      &.prestart {
+        left: 25%;
+      }
+
+      &.poststop {
+        left: 75%;
+      }
     }
   }
 
@@ -52,6 +59,11 @@
 
     &.main {
       left: 25%;
+      right: 25%;
+    }
+
+    &.poststop {
+      left: 75%;
       right: 0;
     }
   }
@@ -110,10 +122,19 @@
 
     &.main {
       margin-left: 25%;
+      margin-right: 25%;
     }
 
     &.prestart {
       margin-right: 75%;
+    }
+
+    &.sidecar {
+      margin-right: 25%;
+    }
+
+    &.poststop {
+      margin-left: 75%;
     }
 
     &:last-child .task {

--- a/ui/app/templates/components/lifecycle-chart.hbs
+++ b/ui/app/templates/components/lifecycle-chart.hbs
@@ -7,11 +7,14 @@
 
         <div class="lifecycle-phases">
           {{#each lifecyclePhases as |phase|}}
-            <div class="lifecycle-phase {{if phase.isActive "is-active"}} {{if (eq phase.name "Main") "main" "prestart"}}" data-test-lifecycle-phase>
+            <div class="lifecycle-phase {{if phase.isActive "is-active"}} {{phase.class}}" data-test-lifecycle-phase>
               <div class="name" data-test-name>{{phase.name}}</div>
             </div>
           {{/each}}
-          <svg class="divider">
+          <svg class="divider prestart">
+            <line x1="0" y1="0" x2="0" y2="100%" />
+          </svg>
+          <svg class="divider poststop">
             <line x1="0" y1="0" x2="0" y2="100%" />
           </svg>
         </div>

--- a/ui/mirage/factories/task.js
+++ b/ui/mirage/factories/task.js
@@ -19,14 +19,16 @@ export default Factory.extend({
   Resources: generateResources,
 
   Lifecycle: i => {
-    const cycle = i % 3;
+    const cycle = i % 4;
 
     if (cycle === 0) {
       return null;
     } else if (cycle === 1) {
       return { Hook: 'prestart', Sidecar: false };
-    } else {
+    } else if (cycle === 2) {
       return { Hook: 'prestart', Sidecar: true };
+    } else {
+      return { Hook: 'poststop' };
     }
   },
 });

--- a/ui/tests/integration/components/lifecycle-chart-test.js
+++ b/ui/tests/integration/components/lifecycle-chart-test.js
@@ -24,6 +24,10 @@ const tasks = [
     lifecycleName: 'sidecar',
     name: 'sidecar',
   },
+  {
+    lifecycleName: 'poststop',
+    name: 'poststop',
+  },
 ];
 
 module('Integration | Component | lifecycle-chart', function(hooks) {
@@ -37,20 +41,29 @@ module('Integration | Component | lifecycle-chart', function(hooks) {
 
     assert.equal(Chart.phases[0].name, 'Prestart');
     assert.equal(Chart.phases[1].name, 'Main');
+    assert.equal(Chart.phases[2].name, 'Poststop');
 
     Chart.phases.forEach(phase => assert.notOk(phase.isActive));
 
-    assert.deepEqual(Chart.tasks.mapBy('name'), ['prestart', 'sidecar', 'main one', 'main two']);
+    assert.deepEqual(Chart.tasks.mapBy('name'), [
+      'prestart',
+      'sidecar',
+      'main one',
+      'main two',
+      'poststop',
+    ]);
     assert.deepEqual(Chart.tasks.mapBy('lifecycle'), [
       'Prestart Task',
       'Sidecar Task',
       'Main Task',
       'Main Task',
+      'Poststop Task',
     ]);
 
     assert.ok(Chart.tasks[0].isPrestart);
     assert.ok(Chart.tasks[1].isSidecar);
     assert.ok(Chart.tasks[2].isMain);
+    assert.ok(Chart.tasks[4].isPoststop);
 
     Chart.tasks.forEach(task => {
       assert.notOk(task.isActive);

--- a/ui/tests/pages/components/lifecycle-chart.js
+++ b/ui/tests/pages/components/lifecycle-chart.js
@@ -21,6 +21,7 @@ export default {
     isMain: hasClass('main'),
     isPrestart: hasClass('prestart'),
     isSidecar: hasClass('sidecar'),
+    isPoststop: hasClass('poststop'),
 
     visit: clickable('a'),
   }),


### PR DESCRIPTION
This adds a new poststop lifecycle phase:

<img width="930" alt="image" src="https://user-images.githubusercontent.com/43280/85293045-66a36380-b462-11ea-9c18-5527d7990134.png">

It relies on #8194.