### PR TITLE
Deploy #8077 to website

### DIFF
--- a/website/data/alert-banner.js
+++ b/website/data/alert-banner.js
@@ -3,8 +3,8 @@ export const ALERT_BANNER_ACTIVE = true
 // https://github.com/hashicorp/web-components/tree/master/packages/alert-banner
 export default {
   url:
-    'https://www.hashicorp.com/webinars/nomad-virtual-day-cloud-bursting-with-nomad-and-consul-betterhelp-customer-story/',
-  tag: 'Livestream',
+    'https://www.nomadproject.io/downloads/',
+  tag: 'NEW',
   text:
-    'Nomad Virtual Day: cloud bursting use case, customer talk from BetterHelp and more. Register now.',
+    'Nomad 0.11 is now generally available, with CSI integration, autoscaling, and more. Download now',
 }


### PR DESCRIPTION
#8077 replaces the Virtual Day banner with the 0.11 GA banner.