### PR TITLE
Ensure we are using the latest go-bindata tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -753,6 +753,8 @@ jobs:
     - run:
         command: make checkscripts
     - run:
+        command: mkdir -p ui/dist && make generate-all static-assets
+    - run:
         command: make -C .circleci CIRCLECI="circleci-local-cli --skip-update-check" ci-verify
         name: check .circleci/config.yml is up-to-date
     environment:

--- a/.circleci/config/jobs/lint-go.yml
+++ b/.circleci/config/jobs/lint-go.yml
@@ -7,6 +7,7 @@ steps:
   - run: make deps lint-deps
   - run: make check
   - run: make checkscripts
+  - run: mkdir -p ui/dist && make generate-all static-assets
   - run:
       name: check .circleci/config.yml is up-to-date
       command: make -C .circleci CIRCLECI="circleci-local-cli --skip-update-check" ci-verify

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -169,8 +169,8 @@ bootstrap: deps lint-deps git-hooks # Install all dependencies
 deps:  ## Install build and development dependencies
 ## Keep versions in sync with tools/go.mod for now (see https://github.com/golang/go/issues/30515)
 	@echo "==> Updating build dependencies..."
-	GO111MODULE=on cd tools && go get github.com/hashicorp/go-bindata/go-bindata@v3.0.7+incompatible
-	GO111MODULE=on cd tools && go get github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs@v1.0.0
+	GO111MODULE=on cd tools && go get github.com/hashicorp/go-bindata/go-bindata@bf7910af899725e4938903fb32048c7c0b15f12e
+	GO111MODULE=on cd tools && go get github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs@234c15e7648ff35458026de92b34c637bae5e6f7
 	GO111MODULE=on cd tools && go get github.com/a8m/tree/cmd/tree
 	GO111MODULE=on cd tools && go get gotest.tools/gotestsum@v0.4.2
 	GO111MODULE=on cd tools && go get github.com/hashicorp/hcl/v2/cmd/hclfmt@v2.5.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,11 +5,11 @@ go 1.14
 require (
 	github.com/a8m/tree v0.0.0-20181222104329-6a0b80129de4
 	github.com/client9/misspell v0.3.4
-	github.com/elazarl/go-bindata-assetfs v1.0.0
+	github.com/elazarl/go-bindata-assetfs v1.0.1-0.20200509193318-234c15e7648f
 	github.com/golang/protobuf v1.3.4
 	github.com/golangci/golangci-lint v1.24.0
 	github.com/google/go-cmp v0.4.0 // indirect
-	github.com/hashicorp/go-bindata v3.0.7+incompatible
+	github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible
 	github.com/hashicorp/go-msgpack v1.1.5
 	github.com/hashicorp/hcl/v2 v2.5.1
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -40,6 +40,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
+github.com/elazarl/go-bindata-assetfs v1.0.1-0.20200509193318-234c15e7648f h1:AwZUiMWfYSmIiHdFJIubTSs8BFIFoMmUFbeuwBzHIPs=
+github.com/elazarl/go-bindata-assetfs v1.0.1-0.20200509193318-234c15e7648f/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -143,6 +145,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/go-bindata v3.0.7+incompatible h1:tnw1ukCrIsFR0IyN3C+ABwePoiAqEVjR9BFiGauTo1M=
 github.com/hashicorp/go-bindata v3.0.7+incompatible/go.mod h1:+IrDq36jUYG0q6TsDY9uO2p77C8f8S5y+RbYHr2UI+U=
+github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible h1:EDTAuh27kAIhxuyK8ef3iHQARA+8NQaXyTeDEiG3Q6o=
+github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible/go.mod h1:+IrDq36jUYG0q6TsDY9uO2p77C8f8S5y+RbYHr2UI+U=
 github.com/hashicorp/go-msgpack v1.1.5 h1:9byZdVjKTe5mce63pRVNP1L7UAmdHOTEMGehn6KvJWs=
 github.com/hashicorp/go-msgpack v1.1.5/go.mod h1:gWVc3sv/wbDmR3rQsj1CAktEZzoz1YNK9NfGLXJ69/4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=


### PR DESCRIPTION
go-bindata released tags are very old, few years old, so ensure we use the latest master as of now.

It is used by Makefile `prerelease`, primarily used by our release scripts and not CI.

I've added a check in the lint-job to detect if `static-assets` breaks, which would have caught this issue, as seen in [this build](https://app.circleci.com/pipelines/github/hashicorp/nomad/9765/workflows/6c872b7a-671e-4a5d-88b8-a84c1312569f/jobs/74435/steps).

A better check would be to actually run `prerelease`; which may make sense in the `build-binaries` job, when we add ui generation there.