### PR TITLE
Implement snapshot restore

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -945,6 +945,10 @@ func decodeBody(resp *http.Response, out interface{}) error {
 
 // encodeBody is used to encode a request body
 func encodeBody(obj interface{}) (io.Reader, error) {
+	if reader, ok := obj.(io.Reader); ok {
+		return reader, nil
+	}
+
 	buf := bytes.NewBuffer(nil)
 	enc := json.NewEncoder(buf)
 	if err := enc.Encode(obj); err != nil {

--- a/api/api.go
+++ b/api/api.go
@@ -943,7 +943,10 @@ func decodeBody(resp *http.Response, out interface{}) error {
 	}
 }
 
-// encodeBody is used to encode a request body
+// encodeBody prepares the reader to serve as the request body.
+//
+// Returns the `obj` input if it is a raw io.Reader object; otherwise
+// returns a reader of the json format of the passed argument.
 func encodeBody(obj interface{}) (io.Reader, error) {
 	if reader, ok := obj.(io.Reader); ok {
 		return reader, nil

--- a/api/operator.go
+++ b/api/operator.go
@@ -222,6 +222,17 @@ func (op *Operator) Snapshot(q *QueryOptions) (io.ReadCloser, error) {
 	return cr, nil
 }
 
+// SnapshotRestore is used to restore a running nomad cluster to an original
+// state.
+func (op *Operator) SnapshotRestore(in io.Reader, q *WriteOptions) (*WriteMeta, error) {
+	wm, err := op.c.write("/v1/operator/snapshot", in, nil, q)
+	if err != nil {
+		return nil, err
+	}
+
+	return wm, nil
+}
+
 type License struct {
 	// The unique identifier of the license
 	LicenseID string

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -223,7 +223,8 @@ RETRY:
 
 func (a *TestAgent) start() (*Agent, error) {
 	if a.LogOutput == nil {
-		a.LogOutput = testlog.NewWriter(a.T)
+		prefix := fmt.Sprintf("%v:%v ", a.Config.BindAddr, a.Config.Ports.RPC)
+		a.LogOutput = testlog.NewPrefixWriter(a.T, prefix)
 	}
 
 	inm := metrics.NewInmemSink(10*time.Second, time.Minute)

--- a/command/commands.go
+++ b/command/commands.go
@@ -517,6 +517,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"operator snapshot restore": func() (cli.Command, error) {
+			return &OperatorSnapshotRestoreCommand{
+				Meta: meta,
+			}, nil
+		},
 
 		"plan": func() (cli.Command, error) {
 			return &JobPlanCommand{

--- a/command/operator_snapshot_inspect_test.go
+++ b/command/operator_snapshot_inspect_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,7 @@ import (
 func TestOperatorSnapshotInspect_Works(t *testing.T) {
 	t.Parallel()
 
-	snapPath := generateSnapshotFile(t)
+	snapPath := generateSnapshotFile(t, nil)
 
 	ui := new(cli.MockUi)
 	cmd := &OperatorSnapshotInspectCommand{Meta: Meta{Ui: ui}}
@@ -67,23 +68,28 @@ func TestOperatorSnapshotInspect_HandlesFailure(t *testing.T) {
 
 }
 
-func generateSnapshotFile(t *testing.T) string {
+func generateSnapshotFile(t *testing.T, prepare func(srv *agent.TestAgent, client *api.Client, url string)) string {
 
 	tmpDir, err := ioutil.TempDir("", "nomad-tempdir")
 	require.NoError(t, err)
 
 	t.Cleanup(func() { os.RemoveAll(tmpDir) })
 
-	srv, _, url := testServer(t, false, func(c *agent.Config) {
+	srv, api, url := testServer(t, false, func(c *agent.Config) {
 		c.DevMode = false
 		c.DataDir = filepath.Join(tmpDir, "server")
 
+		c.Client.Enabled = false
 		c.AdvertiseAddrs.HTTP = "127.0.0.1"
 		c.AdvertiseAddrs.RPC = "127.0.0.1"
 		c.AdvertiseAddrs.Serf = "127.0.0.1"
 	})
 
 	defer srv.Shutdown()
+
+	if prepare != nil {
+		prepare(srv, api, url)
+	}
 
 	ui := new(cli.MockUi)
 	cmd := &OperatorSnapshotSaveCommand{Meta: Meta{Ui: ui}}

--- a/command/operator_snapshot_inspect_test.go
+++ b/command/operator_snapshot_inspect_test.go
@@ -79,7 +79,6 @@ func generateSnapshotFile(t *testing.T, prepare func(srv *agent.TestAgent, clien
 		c.DevMode = false
 		c.DataDir = filepath.Join(tmpDir, "server")
 
-		c.Client.Enabled = false
 		c.AdvertiseAddrs.HTTP = "127.0.0.1"
 		c.AdvertiseAddrs.RPC = "127.0.0.1"
 		c.AdvertiseAddrs.Serf = "127.0.0.1"

--- a/command/operator_snapshot_restore.go
+++ b/command/operator_snapshot_restore.go
@@ -64,7 +64,7 @@ func (c *OperatorSnapshotRestoreCommand) Run(args []string) int {
 	// Check for misuse
 	args = flags.Args()
 	if len(args) != 1 {
-		c.Ui.Error("This command takes one: <filename>")
+		c.Ui.Error("This command takes one argument: <filename>")
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/operator_snapshot_restore.go
+++ b/command/operator_snapshot_restore.go
@@ -15,7 +15,7 @@ type OperatorSnapshotRestoreCommand struct {
 
 func (c *OperatorSnapshotRestoreCommand) Help() string {
 	helpText := `
-Usage: nomad snapshot restore [options] FILE
+Usage: nomad operator snapshot restore [options] FILE
 
   Restores an atomic, point-in-time snapshot of the state of the Nomad servers
   which includes jobs, nodes, allocations, periodic jobs, and ACLs.
@@ -30,7 +30,7 @@ Usage: nomad snapshot restore [options] FILE
 
   To restore a snapshot from the file "backup.snap":
 
-    $ nomad snapshot restore backup.snap
+    $ nomad operator snapshot restore backup.snap
 
 General Options:
 
@@ -83,7 +83,7 @@ func (c *OperatorSnapshotRestoreCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Fetch the current configuration.
+	// Call snapshot restore API with backup file.
 	_, err = client.Operator().SnapshotRestore(snap, &api.WriteOptions{})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to get restore snapshot: %v", err))

--- a/command/operator_snapshot_restore.go
+++ b/command/operator_snapshot_restore.go
@@ -1,0 +1,95 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
+)
+
+type OperatorSnapshotRestoreCommand struct {
+	Meta
+}
+
+func (c *OperatorSnapshotRestoreCommand) Help() string {
+	helpText := `
+Usage: nomad snapshot restore [options] FILE
+
+  Restores an atomic, point-in-time snapshot of the state of the Nomad servers
+  which includes jobs, nodes, allocations, periodic jobs, and ACLs.
+
+  Restores involve a potentially dangerous low-level Raft operation that is not
+  designed to handle server failures during a restore. This command is primarily
+  intended to be used when recovering from a disaster, restoring into a fresh
+  cluster of Nomad servers.
+
+  If ACLs are enabled, a management token must be supplied in order to perform
+  snapshot operations.
+
+  To restore a snapshot from the file "backup.snap":
+
+    $ nomad snapshot restore backup.snap
+
+General Options:
+
+  ` + generalOptionsUsage()
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorSnapshotRestoreCommand) AutocompleteFlags() complete.Flags {
+	return c.Meta.AutocompleteFlags(FlagSetClient)
+}
+
+func (c *OperatorSnapshotRestoreCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *OperatorSnapshotRestoreCommand) Synopsis() string {
+	return "Restore snapshot of Nomad server state"
+}
+
+func (c *OperatorSnapshotRestoreCommand) Name() string { return "operator snapshot restore" }
+
+func (c *OperatorSnapshotRestoreCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to parse args: %v", err))
+		return 1
+	}
+
+	// Check for misuse
+	args = flags.Args()
+	if len(args) != 1 {
+		c.Ui.Error("This command takes one: <filename>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	snap, err := os.Open(args[0])
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error opening snapshot file: %q", err))
+		return 1
+	}
+	defer snap.Close()
+
+	// Set up a client.
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	// Fetch the current configuration.
+	_, err = client.Operator().SnapshotRestore(snap, &api.WriteOptions{})
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to get restore snapshot: %v", err))
+		return 1
+	}
+
+	c.Ui.Output("Snapshot Restored")
+	return 0
+}

--- a/command/operator_snapshot_restore_test.go
+++ b/command/operator_snapshot_restore_test.go
@@ -1,0 +1,96 @@
+package command
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/command/agent"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperatorSnapshotRestore_Works(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, err := ioutil.TempDir("", "nomad-tempdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	snapshotPath := generateSnapshotFile(t, func(srv *agent.TestAgent, client *api.Client, url string) {
+		sampleJob := `
+job "snapshot-test-job" {
+	type = "service"
+	datacenters = [ "dc1" ]
+	group "group1" {
+		count = 1
+		task "task1" {
+			driver = "exec"
+			resources = {
+				cpu = 1000
+				memory = 512
+			}
+		}
+	}
+
+}`
+
+		ui := new(cli.MockUi)
+		cmd := &JobRunCommand{Meta: Meta{Ui: ui}}
+		cmd.JobGetter.testStdin = strings.NewReader(sampleJob)
+
+		code := cmd.Run([]string{"--address=" + url, "-detach", "-"})
+		require.Zero(t, code)
+	})
+
+	srv, _, url := testServer(t, false, func(c *agent.Config) {
+		c.DevMode = false
+		c.DataDir = filepath.Join(tmpDir, "server1")
+
+		c.Client.Enabled = false
+		c.AdvertiseAddrs.HTTP = "127.0.0.1"
+		c.AdvertiseAddrs.RPC = "127.0.0.1"
+		c.AdvertiseAddrs.Serf = "127.0.0.1"
+	})
+
+	defer srv.Shutdown()
+
+	// job is not found before restore
+	j, err := srv.Agent.Server().State().JobByID(nil, structs.DefaultNamespace, "snapshot-test-job")
+	require.NoError(t, err)
+	require.Nil(t, j)
+
+	ui := new(cli.MockUi)
+	cmd := &OperatorSnapshotRestoreCommand{Meta: Meta{Ui: ui}}
+
+	code := cmd.Run([]string{"--address=" + url, snapshotPath})
+	require.Empty(t, ui.ErrorWriter.String())
+	require.Zero(t, code)
+	require.Contains(t, ui.OutputWriter.String(), "Snapshot Restored")
+
+	foundJob, err := srv.Agent.Server().State().JobByID(nil, structs.DefaultNamespace, "snapshot-test-job")
+	require.NoError(t, err)
+	require.Equal(t, "snapshot-test-job", foundJob.ID)
+}
+
+func TestOperatorSnapshotRestore_Fails(t *testing.T) {
+	t.Parallel()
+
+	ui := new(cli.MockUi)
+	cmd := &OperatorSnapshotRestoreCommand{Meta: Meta{Ui: ui}}
+
+	// Fails on misuse
+	code := cmd.Run([]string{"some", "bad", "args"})
+	require.Equal(t, 1, code)
+	require.Contains(t, ui.ErrorWriter.String(), commandErrorText(cmd))
+	ui.ErrorWriter.Reset()
+
+	// Fails when specified file does not exist
+	code = cmd.Run([]string{"/unicorns/leprechauns"})
+	require.Equal(t, 1, code)
+	require.Contains(t, ui.ErrorWriter.String(), "no such file")
+}

--- a/command/operator_snapshot_restore_test.go
+++ b/command/operator_snapshot_restore_test.go
@@ -51,7 +51,6 @@ job "snapshot-test-job" {
 		c.DevMode = false
 		c.DataDir = filepath.Join(tmpDir, "server1")
 
-		c.Client.Enabled = false
 		c.AdvertiseAddrs.HTTP = "127.0.0.1"
 		c.AdvertiseAddrs.RPC = "127.0.0.1"
 		c.AdvertiseAddrs.Serf = "127.0.0.1"

--- a/command/operator_snapshot_save_test.go
+++ b/command/operator_snapshot_save_test.go
@@ -49,3 +49,21 @@ func TestOperatorSnapshotSave_Works(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, meta.Index)
 }
+
+func TestOperatorSnapshotSave_Fails(t *testing.T) {
+	t.Parallel()
+
+	ui := new(cli.MockUi)
+	cmd := &OperatorSnapshotSaveCommand{Meta: Meta{Ui: ui}}
+
+	// Fails on misuse
+	code := cmd.Run([]string{"some", "bad", "args"})
+	require.Equal(t, 1, code)
+	require.Contains(t, ui.ErrorWriter.String(), commandErrorText(cmd))
+	ui.ErrorWriter.Reset()
+
+	// Fails when specified file does not exist
+	code = cmd.Run([]string{"/unicorns/leprechauns"})
+	require.Equal(t, 1, code)
+	require.Contains(t, ui.ErrorWriter.String(), "no such file")
+}

--- a/helper/testlog/testlog.go
+++ b/helper/testlog/testlog.go
@@ -71,12 +71,15 @@ func (w *prefixStderr) Write(p []byte) (int, error) {
 	}
 
 	// Skip prefix if only writing whitespace
-	if len(bytes.TrimSpace(p)) > 0 {
-		_, err := os.Stderr.Write(w.prefix)
-		if err != nil {
-			return 0, err
-		}
+	if len(bytes.TrimSpace(p)) == 0 {
+		return os.Stderr.Write(p)
 	}
 
-	return os.Stderr.Write(p)
+	// decrease likely hood of partial line writes that may mess up test
+	// indicator success detection
+	buf := make([]byte, 0, len(w.prefix)+len(p))
+	buf = append(buf, w.prefix...)
+	buf = append(buf, p...)
+
+	return os.Stderr.Write(buf)
 }

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -190,13 +190,16 @@ WAIT:
 		case member := <-reconcileCh:
 			s.reconcileMember(member)
 		case errCh := <-s.reassertLeaderCh:
-			// we can get into this state when the initial
-			// establishLeadership has failed as well as the follow
-			// up leadershipTransfer. Afterwards we will be waiting
-			// for the interval to trigger a reconciliation and can
-			// potentially end up here. There is no point to
-			// reassert because this agent was never leader in the
-			// first place.
+			// Recompute leader state, by asserting leadership and
+			// repopulating leader states.
+
+			// Check first if we are indeed the leaders first. We
+			// can get into this state when the initial
+			// establishLeadership has failed.
+			// Afterwards we will be waiting for the interval to
+			// trigger a reconciliation and can potentially end up
+			// here. There is no point to reassert because this
+			// agent was never leader in the first place.
 			if !establishedLeader {
 				errCh <- fmt.Errorf("leadership has not been established")
 				continue

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -609,6 +609,7 @@ func decodeStreamOutput(decoder *codec.Decoder) (io.Reader, <-chan error) {
 				if err != nil {
 					pw.CloseWithError(err)
 					errCh <- err
+					return
 				}
 			}
 

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"github.com/hashicorp/go-msgpack/codec"
 
 	"github.com/hashicorp/consul/agent/consul/autopilot"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper/snapshot"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/raft"
@@ -23,6 +25,7 @@ type Operator struct {
 
 func (op *Operator) register() {
 	op.srv.streamingRpcs.Register("Operator.SnapshotSave", op.snapshotSave)
+	op.srv.streamingRpcs.Register("Operator.SnapshotRestore", op.snapshotRestore)
 }
 
 // RaftGetConfiguration is used to retrieve the current Raft configuration.
@@ -459,8 +462,7 @@ func (op *Operator) snapshotSave(conn io.ReadWriteCloser) {
 	}
 	defer snap.Close()
 
-	enc := codec.NewEncoder(conn, structs.MsgpackHandle)
-	if err := enc.Encode(&reply); err != nil {
+	if err := encoder.Encode(&reply); err != nil {
 		handleFailure(500, fmt.Errorf("failed to encode response: %v", err))
 		return
 	}
@@ -469,4 +471,121 @@ func (op *Operator) snapshotSave(conn io.ReadWriteCloser) {
 			handleFailure(500, fmt.Errorf("failed to stream snapshot: %v", err))
 		}
 	}
+}
+
+func (op *Operator) snapshotRestore(conn io.ReadWriteCloser) {
+	defer conn.Close()
+
+	var args structs.SnapshotRestoreRequest
+	var reply structs.SnapshotRestoreResponse
+	decoder := codec.NewDecoder(conn, structs.MsgpackHandle)
+	encoder := codec.NewEncoder(conn, structs.MsgpackHandle)
+
+	handleFailure := func(code int, err error) {
+		encoder.Encode(&structs.SnapshotRestoreResponse{
+			ErrorCode: code,
+			ErrorMsg:  err.Error(),
+		})
+	}
+
+	if err := decoder.Decode(&args); err != nil {
+		handleFailure(500, err)
+		return
+	}
+
+	// Forward to appropriate region
+	if args.Region != op.srv.Region() {
+		err := op.forwardStreamingRPC(args.Region, "Operator.SnapshotRestore", args, conn)
+		if err != nil {
+			handleFailure(500, err)
+		}
+		return
+	}
+
+	// forward to leader
+	remoteServer, err := op.srv.getLeaderForRPC()
+	if err != nil {
+		handleFailure(500, err)
+		return
+	}
+	if remoteServer != nil {
+		err := op.forwardStreamingRPCToServer(remoteServer, "Operator.SnapshotRestore", args, conn)
+		if err != nil {
+			handleFailure(500, err)
+		}
+		return
+
+	}
+
+	// Check agent permissions
+	if aclObj, err := op.srv.ResolveToken(args.AuthToken); err != nil {
+		code := 500
+		if err == structs.ErrTokenNotFound {
+			code = 400
+		}
+		handleFailure(code, err)
+		return
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		handleFailure(403, structs.ErrPermissionDenied)
+		return
+	}
+
+	op.srv.setQueryMeta(&reply.QueryMeta)
+
+	reader, errCh := decodeStreamOutput(decoder)
+
+	err = snapshot.Restore(op.logger.Named("snapshot"), reader, op.srv.raft)
+	if err != nil {
+		handleFailure(500, fmt.Errorf("failed to restore from snapshot: %v", err))
+		return
+	}
+
+	err = <-errCh
+	if err != nil {
+		handleFailure(400, fmt.Errorf("failed to read stream: %v", err))
+		return
+	}
+
+	reply.Index, _ = op.srv.State().LatestIndex()
+	op.srv.setQueryMeta(&reply.QueryMeta)
+	encoder.Encode(reply)
+}
+
+func decodeStreamOutput(decoder *codec.Decoder) (io.Reader, <-chan error) {
+	pr, pw := io.Pipe()
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(errCh)
+
+		for {
+			var wrapper cstructs.StreamErrWrapper
+
+			err := decoder.Decode(&wrapper)
+			if err != nil {
+				pw.CloseWithError(fmt.Errorf("failed to decode input: %v", err))
+				errCh <- err
+				return
+			}
+
+			if len(wrapper.Payload) != 0 {
+				_, err = pw.Write(wrapper.Payload)
+				if err != nil {
+					pw.CloseWithError(err)
+					errCh <- err
+				}
+			}
+
+			if errW := wrapper.Error; errW != nil {
+				if errW.Message == io.EOF.Error() {
+					pw.CloseWithError(io.EOF)
+				} else {
+					pw.CloseWithError(errors.New(errW.Message))
+				}
+				return
+			}
+		}
+	}()
+
+	return pr, errCh
 }

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -553,8 +553,8 @@ func (op *Operator) snapshotRestore(conn io.ReadWriteCloser) {
 	lerrCh := make(chan error, 1)
 
 	select {
-	// Tell the leader loop to reassert leader actions since we just
-	// replaced the state store contents.
+	// Reassert leader actions and update all leader related state
+	// with new state store content.
 	case op.srv.reassertLeaderCh <- lerrCh:
 
 	// We might have lost leadership while waiting to kick the loop.

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-msgpack/codec"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
@@ -784,6 +785,13 @@ func testRestoreSnapshot(t *testing.T, req *structs.SnapshotRestoreRequest, snap
 		c.BootstrapExpect = 2
 		c.DevMode = false
 		c.DataDir = path.Join(dir, "server1")
+
+		// increase times outs to account for I/O operations that
+		// snapshot restore performs - some of which require sync calls
+		c.RaftConfig.LeaderLeaseTimeout = 1 * time.Second
+		c.RaftConfig.HeartbeatTimeout = 1 * time.Second
+		c.RaftConfig.ElectionTimeout = 1 * time.Second
+		c.RaftTimeout = 5 * time.Second
 	})
 	defer cleanupLS()
 
@@ -791,6 +799,13 @@ func testRestoreSnapshot(t *testing.T, req *structs.SnapshotRestoreRequest, snap
 		c.BootstrapExpect = 2
 		c.DevMode = false
 		c.DataDir = path.Join(dir, "server2")
+
+		// increase times outs to account for I/O operations that
+		// snapshot restore performs - some of which require sync calls
+		c.RaftConfig.LeaderLeaseTimeout = 1 * time.Second
+		c.RaftConfig.HeartbeatTimeout = 1 * time.Second
+		c.RaftConfig.ElectionTimeout = 1 * time.Second
+		c.RaftTimeout = 5 * time.Second
 	})
 	defer cleanupRS()
 

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -108,7 +108,12 @@ type Server struct {
 	raftInmem     *raft.InmemStore
 	raftTransport *raft.NetworkTransport
 
-	// reassertLeaderCh is used to signal the leader loop should re-run
+	// reassertLeaderCh is used to signal that the leader loop must
+	// re-establish leadership.
+	//
+	// This might be relevant in snapshot restores, where leader in-memory
+	// state changed significantly such that leader state (e.g. periodic
+	// jobs, eval brokers) need to be recomputed.
 	reassertLeaderCh chan chan error
 
 	// autopilot is the Autopilot instance for this server.

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -246,3 +246,14 @@ type SnapshotSaveResponse struct {
 
 	QueryMeta
 }
+
+type SnapshotRestoreRequest struct {
+	WriteRequest
+}
+
+type SnapshotRestoreResponse struct {
+	ErrorCode int    `codec:",omitempty"`
+	ErrorMsg  string `codec:",omitempty"`
+
+	QueryMeta
+}

--- a/vendor/github.com/hashicorp/nomad/api/api.go
+++ b/vendor/github.com/hashicorp/nomad/api/api.go
@@ -945,6 +945,10 @@ func decodeBody(resp *http.Response, out interface{}) error {
 
 // encodeBody is used to encode a request body
 func encodeBody(obj interface{}) (io.Reader, error) {
+	if reader, ok := obj.(io.Reader); ok {
+		return reader, nil
+	}
+
 	buf := bytes.NewBuffer(nil)
 	enc := json.NewEncoder(buf)
 	if err := enc.Encode(obj); err != nil {

--- a/vendor/github.com/hashicorp/nomad/api/operator.go
+++ b/vendor/github.com/hashicorp/nomad/api/operator.go
@@ -222,6 +222,17 @@ func (op *Operator) Snapshot(q *QueryOptions) (io.ReadCloser, error) {
 	return cr, nil
 }
 
+// SnapshotRestore is used to restore a running nomad cluster to an original
+// state.
+func (op *Operator) SnapshotRestore(in io.Reader, q *WriteOptions) (*WriteMeta, error) {
+	wm, err := op.c.write("/v1/operator/snapshot", in, nil, q)
+	if err != nil {
+		return nil, err
+	}
+
+	return wm, nil
+}
+
 type License struct {
 	// The unique identifier of the license
 	LicenseID string


### PR DESCRIPTION
Part 2 of https://github.com/hashicorp/nomad/pull/8047 .  This implements snapshot restore API and CLI.  This allows uploading the snapshot file to `/v1/operator/snapshot` endpoint.

Exposing an API ease operator experience and follow the pattern established by Consul and Vault.  It uses raft's [`raft.Restore`](https://godoc.org/github.com/hashicorp/raft#Raft.Restore).

The overall approach is similar to Consul and Vault.  One significant difference is RPC format.  In Consul, each streaming RPC must start a TCP connection, emit a request header, then streams snapshot file in request body without any encoding.  The streaming RPC relies on being able to half-close the connection to indicate snapshot file end; thus cannot use a multiplex Yamux session.  This quirk complicates forwarding RPCs and rate limiting and hurts reusability with other APIs.

Instead this implementation uses `StreamErrWrapper` (used for alloc fs operations) to stream snapshot file.  While it adds some overhead, it significantly simples the implementation allowing us to reuse the current RPC infrastructure.

I'd encourage review commit by commit - I've made the commits into logical units.

### Abandoned ideas

I have considered an alternative approach: to restore a cluster to a previous state, the cluster agents must be restarted and provided a snapshot at launch time.  The hope is that this approach would be simpler to reason about and has less unexpected behavior (without needing to rollback a running state).

I've abandoned it for few reasons:

First, it's a departure from other HashiCorp tooling that would unnecessarily confuse operators and require them to do custom handling for Nomad.

Second, the raft library does some clever handling to both ease the snapshot restoring (single API to update the entire cluster), and to ensure safety of operation (e.g. updating index so that clients can detect a rollback).  Reimplementing the logic in CLI will be somewhat tricky.

Third, restoring a snapshot at launch time without using the `Restore` method above isn't trivial and may require changes to the Raft library to be effective.

As such, this approach is require more manual steps for operators, inconsistent with other products, and is more difficult to implement.