### PR TITLE
only report tasklogger is running if both stdout and stderr are still running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ BUG FIXES:
  * api: Fixed a bug where setting connect sidecar task resources could fail [[GH-7993](https://github.com/hashicorp/nomad/issues/7993)]
  * client: Fixed a bug where artifact downloads failed on redirects [[GH-7854](https://github.com/hashicorp/nomad/issues/7854)]
  * csi: Validate empty volume arguments in API. [[GH-8027](https://github.com/hashicorp/nomad/issues/8027)]
+ * client: Fixed a bug where stdout/stderr were not properly reopened for
+   community task drivers. [[GH-8155](https://github.com/hashicorp/nomad/issues/8155)]
 
 ## 0.11.2 (May 14, 2020)
 

--- a/client/logmon/logmon.go
+++ b/client/logmon/logmon.go
@@ -110,14 +110,10 @@ type TaskLogger struct {
 
 // IsRunning will return true as long as one rotator wrapper is still running
 func (tl *TaskLogger) IsRunning() bool {
-	if tl.lro != nil && tl.lro.isRunning() {
-		return true
-	}
-	if tl.lre != nil && tl.lre.isRunning() {
-		return true
-	}
+	lroRunning := tl.lro != nil && tl.lro.isRunning()
+	lreRunning := tl.lre != nil && tl.lre.isRunning()
 
-	return false
+	return lroRunning && lreRunning
 }
 
 func (tl *TaskLogger) Close() {

--- a/client/logmon/logmon_test.go
+++ b/client/logmon/logmon_test.go
@@ -234,7 +234,8 @@ func TestLogmon_Start_restart(t *testing.T) {
 	})
 	require.True(impl.tl.IsRunning())
 
-	// Close stdout and assert that logmon no longer writes to the file
+	// Close stderr and assert that logmon no longer writes to the file
+	// Keep stdout open to ensure that IsRunning requires both
 	require.NoError(stderr.Close())
 
 	testutil.WaitForResult(func() (bool, error) {

--- a/client/logmon/logmon_test.go
+++ b/client/logmon/logmon_test.go
@@ -235,7 +235,6 @@ func TestLogmon_Start_restart(t *testing.T) {
 	require.True(impl.tl.IsRunning())
 
 	// Close stdout and assert that logmon no longer writes to the file
-	require.NoError(stdout.Close())
 	require.NoError(stderr.Close())
 
 	testutil.WaitForResult(func() (bool, error) {


### PR DESCRIPTION
If stdout or stderr encounters EOF during their copy, we currently require both stdout and stderr to report as not running in order to close and start again.

This changes the check so that if either are closed or have finished copying we will restart the copy