### PR TITLE
cli: fix malformed alloc status address list when more than 1 addr

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -580,7 +580,7 @@ func (c *AllocStatusCommand) outputTaskResources(alloc *api.Allocation, task str
 		humanize.IBytes(uint64(*alloc.Resources.DiskMB*bytesPerMegabyte)),
 		firstAddr))
 	for i := 1; i < len(addr); i++ {
-		resourcesOutput = append(resourcesOutput, fmt.Sprintf("||||%v", addr[i]))
+		resourcesOutput = append(resourcesOutput, fmt.Sprintf("|||%v", addr[i]))
 	}
 	c.Ui.Output(formatListWithSpaces(resourcesOutput))
 


### PR DESCRIPTION
Output after change:
```
Task Resources
CPU        Memory          Disk     Addresses
4/200 MHz  16 MiB/256 MiB  300 MiB  api: 172.31.8.253:8081
                                    grafana: 172.31.8.253:3000
                                    prometheus: 172.31.8.253:9090
                                    webapp: 172.31.8.253:80
```

closes #8161 