### PR TITLE
add PreviousCount to ScalingEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
  * **Preemption**: Preemption is now an open source feature
  * **Licensing (Enterprise)**: Nomad Enterprise now requires a license [[GH-8076](https://github.com/hashicorp/nomad/issues/8076)]
 
+IMPROVEMENTS:
+
+* api: Persist previous count with scaling events [[GH-8167](https://github.com/hashicorp/nomad/issues/8167)]
+
 ## 0.11.3 (June 5, 2020)
 
 IMPROVEMENTS:

--- a/api/scaling.go
+++ b/api/scaling.go
@@ -92,11 +92,12 @@ type TaskGroupScaleStatus struct {
 }
 
 type ScalingEvent struct {
-	Count       *int64
-	Error       bool
-	Message     string
-	Meta        map[string]interface{}
-	EvalID      *string
-	Time        uint64
-	CreateIndex uint64
+	Count         *int64
+	PreviousCount int64
+	Error         bool
+	Message       string
+	Meta          map[string]interface{}
+	EvalID        *string
+	Time          uint64
+	CreateIndex   uint64
 }

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -933,6 +933,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 
 	// If the count is present, commit the job update via Raft
 	// for now, we'll do this even if count didn't change
+	prevCount := found.Count
 	if args.Count != nil {
 		truncCount := int(*args.Count)
 		if int64(truncCount) != *args.Count {
@@ -997,11 +998,12 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		JobID:     job.ID,
 		TaskGroup: groupName,
 		ScalingEvent: &structs.ScalingEvent{
-			Time:    now,
-			Count:   args.Count,
-			Message: args.Message,
-			Error:   args.Error,
-			Meta:    args.Meta,
+			Time:          now,
+			PreviousCount: int64(prevCount),
+			Count:         args.Count,
+			Message:       args.Message,
+			Error:         args.Error,
+			Meta:          args.Meta,
 		},
 	}
 	if reply.EvalID != "" {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4701,6 +4701,9 @@ type ScalingEvent struct {
 	// Count is the new scaling count, if provided
 	Count *int64
 
+	// PreviousCount is the count at the time of the scaling event
+	PreviousCount int64
+
 	// Message is the message describing a scaling event
 	Message string
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible
 	github.com/hashicorp/go-msgpack v1.1.5
 	github.com/hashicorp/hcl/v2 v2.5.1
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -38,8 +38,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=
-github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/elazarl/go-bindata-assetfs v1.0.1-0.20200509193318-234c15e7648f h1:AwZUiMWfYSmIiHdFJIubTSs8BFIFoMmUFbeuwBzHIPs=
 github.com/elazarl/go-bindata-assetfs v1.0.1-0.20200509193318-234c15e7648f/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -143,8 +141,6 @@ github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.m
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/hashicorp/go-bindata v3.0.7+incompatible h1:tnw1ukCrIsFR0IyN3C+ABwePoiAqEVjR9BFiGauTo1M=
-github.com/hashicorp/go-bindata v3.0.7+incompatible/go.mod h1:+IrDq36jUYG0q6TsDY9uO2p77C8f8S5y+RbYHr2UI+U=
 github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible h1:EDTAuh27kAIhxuyK8ef3iHQARA+8NQaXyTeDEiG3Q6o=
 github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible/go.mod h1:+IrDq36jUYG0q6TsDY9uO2p77C8f8S5y+RbYHr2UI+U=
 github.com/hashicorp/go-msgpack v1.1.5 h1:9byZdVjKTe5mce63pRVNP1L7UAmdHOTEMGehn6KvJWs=
@@ -164,8 +160,6 @@ github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod 
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=


### PR DESCRIPTION
adds `PreviousCount` to scaling events. this provides better UX, allowing (e.g.,) the UI to plot the count as-it-was along with the new requested count.

failing tests (`test-nomad`, `test-api`) in the first commit show the newly-added development tests. they should pass in the second commit.

resolves #8090

