### PR TITLE
demo: Fix Vagrantfile when building staging VM for Cloud build.

### DIFF
--- a/terraform/Vagrantfile
+++ b/terraform/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/bionic64"
   config.vm.provision "shell", inline: <<-SHELL
     
     cd /tmp
@@ -14,20 +14,32 @@ Vagrant.configure(2) do |config|
     TERRAFORMDOWNLOAD=https://releases.hashicorp.com/terraform/${TERRAFORMVERSION}/terraform_${TERRAFORMVERSION}_linux_amd64.zip
 
     echo "Dependencies..."
-    sudo apt-get install -y unzip tree
+    sudo apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg \
+        gnupg-agent \
+        lsb-release \
+        software-properties-common \
+        unzip
 
     # Azure CLI
-    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-    sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893
-    sudo apt-get install apt-transport-https
-    sudo apt-get update && sudo apt-get install azure-cli
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc |
+        gpg --dearmor |
+        sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null
+    AZ_REPO=$(lsb_release -cs)
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
+        sudo tee /etc/apt/sources.list.d/azure-cli.list
+    sudo apt-get update
+    sudo apt-get install azure-cli
 
     # Disable the firewall
     sudo ufw disable
 
     ## Packer
     echo Fetching Packer...
-    curl -L $PACKERDOWNLOAD > packer.zip
+    curl -s -L $PACKERDOWNLOAD > packer.zip
     echo Installing Packer...
     unzip packer.zip -d /usr/local/bin
     chmod 0755 /usr/local/bin/packer
@@ -35,17 +47,24 @@ Vagrant.configure(2) do |config|
 
     ## Terraform
     echo Fetching Terraform...
-    curl -L $TERRAFORMDOWNLOAD > terraform.zip
+    curl -s -L $TERRAFORMDOWNLOAD > terraform.zip
     echo Installing Terraform...
     unzip terraform.zip -d /usr/local/bin
     chmod 0755 /usr/local/bin/terraform
     chown root:root /usr/local/bin/terraform
 
-    ## Docker
-    echo deb https://apt.dockerproject.org/repo ubuntu-`lsb_release -c | awk '{print $2}'` main | sudo tee /etc/apt/sources.list.d/docker.list
-    sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-    sudo apt-get update
-    sudo apt-get install -y docker-engine
+    # Download and install Docker.
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) \
+      stable"
+    apt-get update
+    apt-get install -y \
+      docker-ce \
+      docker-ce-cli \
+      containerd.io
+    usermod -aG docker vagrant
 
   SHELL
 


### PR DESCRIPTION
Updates the base VM image used as well as fixes install failures
with Azure CLI and Docker.

closes #8179 