### PR TITLE
UI: Add linting for classic decorator

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -33,6 +33,8 @@ module.exports = {
         checkLoops: false,
       },
     ],
+    'ember/classic-decorator-hooks': 'error',
+    'ember/classic-decorator-no-classic-methods': 'error',
   },
   overrides: [
     // node files

--- a/ui/app/abilities/client.js
+++ b/ui/app/abilities/client.js
@@ -1,7 +1,9 @@
 import AbstractAbility from './abstract';
 import { computed, get } from '@ember/object';
 import { or } from '@ember/object/computed';
+import classic from 'ember-classic-decorator';
 
+@classic
 export default class Client extends AbstractAbility {
   // Map abilities to policy options (which are coarse for nodes)
   // instead of specific behaviors.

--- a/ui/app/adapters/watchable-namespace-ids.js
+++ b/ui/app/adapters/watchable-namespace-ids.js
@@ -1,6 +1,8 @@
 import { inject as service } from '@ember/service';
 import Watchable from './watchable';
+import classic from 'ember-classic-decorator';
 
+@classic
 export default class WatchableNamespaceIDs extends Watchable {
   @service system;
 

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -7,7 +7,9 @@ import { fragment, fragmentArray } from 'ember-data-model-fragments/attributes';
 import RSVP from 'rsvp';
 import shortUUIDProperty from '../utils/properties/short-uuid';
 import ipParts from '../utils/ip-parts';
+import classic from 'ember-classic-decorator';
 
+@classic
 export default class Node extends Model {
   // Available from list response
   @attr('string') name;

--- a/ui/app/routes/csi/volumes/volume.js
+++ b/ui/app/routes/csi/volumes/volume.js
@@ -5,7 +5,9 @@ import notifyError from 'nomad-ui/utils/notify-error';
 import { qpBuilder } from 'nomad-ui/utils/classes/query-params';
 import { watchRecord } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
+import classic from 'ember-classic-decorator';
 
+@classic
 export default class VolumeRoute extends Route.extend(WithWatchers) {
   @service store;
   @service system;

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -3,7 +3,9 @@ import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import notifyError from 'nomad-ui/utils/notify-error';
 import { jobCrumbs } from 'nomad-ui/utils/breadcrumb-utils';
+import classic from 'ember-classic-decorator';
 
+@classic
 export default class JobRoute extends Route {
   @service store;
   @service token;

--- a/ui/app/serializers/allocation.js
+++ b/ui/app/serializers/allocation.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
 import ApplicationSerializer from './application';
+import classic from 'ember-classic-decorator';
 
 const taskGroupFromJob = (job, taskGroupName) => {
   const taskGroups = job && job.TaskGroups;
@@ -8,6 +9,7 @@ const taskGroupFromJob = (job, taskGroupName) => {
   return taskGroup ? taskGroup : null;
 };
 
+@classic
 export default class AllocationSerializer extends ApplicationSerializer {
   @service system;
 

--- a/ui/app/serializers/evaluation.js
+++ b/ui/app/serializers/evaluation.js
@@ -2,7 +2,9 @@ import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import ApplicationSerializer from './application';
+import classic from 'ember-classic-decorator';
 
+@classic
 export default class Evaluation extends ApplicationSerializer {
   @service system;
 


### PR DESCRIPTION
This completes the [second installation step](https://github.com/emberjs/ember-classic-decorator#installation) I missed when making the class migration PR and marks classes as @classic that are using the EmberObject APIs.