### PR TITLE
CLI Allow querying all namespaces for jobs and allocations

### DIFF
--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -32,6 +32,7 @@ func (s *HTTPServer) AllocsRequest(resp http.ResponseWriter, req *http.Request) 
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil
 	}
+	args.AllNamespaces, _ = strconv.ParseBool(req.URL.Query().Get("all_namespaces"))
 
 	var out structs.AllocListResponse
 	if err := s.agent.RPC("Alloc.List", &args, &out); err != nil {

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -183,7 +183,8 @@ func (l *AllocExecCommand) Run(args []string) int {
 		return 1
 	}
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		l.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -196,7 +196,8 @@ func (f *AllocFSCommand) Run(args []string) int {
 		return 1
 	}
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		f.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -171,7 +171,8 @@ func (l *AllocLogsCommand) Run(args []string) int {
 		return 1
 	}
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		l.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_restart.go
+++ b/command/alloc_restart.go
@@ -96,7 +96,8 @@ func (c *AllocRestartCommand) Run(args []string) int {
 	}
 
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
@@ -100,7 +101,8 @@ func (c *AllocSignalCommand) Run(args []string) int {
 	}
 
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -166,7 +166,8 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		return 0
 	}
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_stop.go
+++ b/command/alloc_stop.go
@@ -3,6 +3,8 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad/api"
 )
 
 type AllocStopCommand struct {
@@ -102,7 +104,8 @@ func (c *AllocStopCommand) Run(args []string) int {
 	}
 
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
@@ -119,10 +120,11 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.AllNamespaces())))
 		return 1
 	}
 	jobID = jobs[0].ID
+	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
 
 	// Truncate the id unless full length is requested
 	length := shortId
@@ -131,7 +133,7 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 	}
 
 	if latest {
-		deploy, _, err := client.Jobs().LatestDeployment(jobID, nil)
+		deploy, _, err := client.Jobs().LatestDeployment(jobID, q)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error retrieving deployments: %s", err))
 			return 1
@@ -152,7 +154,7 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 		return 0
 	}
 
-	deploys, _, err := client.Jobs().Deployments(jobID, all, nil)
+	deploys, _, err := client.Jobs().Deployments(jobID, all, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving deployments: %s", err))
 		return 1

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -131,12 +131,14 @@ func (c *JobHistoryCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.AllNamespaces())))
 		return 1
 	}
 
+	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
+
 	// Prefix lookup matched a single job
-	versions, diffs, _, err := client.Jobs().Versions(jobs[0].ID, diff, nil)
+	versions, diffs, _, err := client.Jobs().Versions(jobs[0].ID, diff, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s", err))
 		return 1

--- a/command/job_periodic_force.go
+++ b/command/job_periodic_force.go
@@ -127,13 +127,14 @@ func (c *JobPeriodicForceCommand) Run(args []string) int {
 		return 1
 	}
 	if len(periodicJobs) > 1 {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple periodic jobs\n\n%s", createStatusListOutput(periodicJobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple periodic jobs\n\n%s", createStatusListOutput(periodicJobs, c.AllNamespaces())))
 		return 1
 	}
 	jobID = periodicJobs[0].ID
+	q := &api.WriteOptions{Namespace: periodicJobs[0].JobSummary.Namespace}
 
 	// force the evaluation
-	evalID, _, err := client.Jobs().PeriodicForce(jobID, nil)
+	evalID, _, err := client.Jobs().PeriodicForce(jobID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error forcing periodic job %q: %s", jobID, err))
 		return 1

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -125,13 +125,14 @@ func (c *JobPromoteCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.AllNamespaces())))
 		return 1
 	}
 	jobID = jobs[0].ID
+	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
 
 	// Do a prefix lookup
-	deploy, _, err := client.Jobs().LatestDeployment(jobID, nil)
+	deploy, _, err := client.Jobs().LatestDeployment(jobID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving deployment: %s", err))
 		return 1
@@ -142,11 +143,12 @@ func (c *JobPromoteCommand) Run(args []string) int {
 		return 1
 	}
 
+	wq := &api.WriteOptions{Namespace: jobs[0].JobSummary.Namespace}
 	var u *api.DeploymentUpdateResponse
 	if len(groups) == 0 {
-		u, _, err = client.Deployments().PromoteAll(deploy.ID, nil)
+		u, _, err = client.Deployments().PromoteAll(deploy.ID, wq)
 	} else {
-		u, _, err = client.Deployments().PromoteGroups(deploy.ID, groups, nil)
+		u, _, err = client.Deployments().PromoteGroups(deploy.ID, groups, wq)
 	}
 
 	if err != nil {

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
@@ -144,12 +145,13 @@ func (c *JobRevertCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.AllNamespaces())))
 		return 1
 	}
 
 	// Prefix lookup matched a single job
-	resp, _, err := client.Jobs().Revert(jobs[0].ID, revertVersion, nil, nil, consulToken, vaultToken)
+	q := &api.WriteOptions{Namespace: jobs[0].JobSummary.Namespace}
+	resp, _, err := client.Jobs().Revert(jobs[0].ID, revertVersion, nil, q, consulToken, vaultToken)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s", err))
 		return 1

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -24,6 +24,7 @@ func TestMeta_FlagSet(t *testing.T) {
 				"no-color",
 				"region",
 				"namespace",
+				"all-namespaces",
 				"ca-cert",
 				"ca-path",
 				"client-cert",

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -30,7 +30,8 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 	defer metrics.MeasureSince([]string{"nomad", "alloc", "list"}, time.Now())
 
 	// Check namespace read-job permissions
-	if aclObj, err := a.srv.ResolveToken(args.AuthToken); err != nil {
+	aclObj, err := a.srv.ResolveToken(args.AuthToken)
+	if err != nil {
 		return err
 	} else if aclObj != nil && !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
 		return structs.ErrPermissionDenied
@@ -44,7 +45,18 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 			// Capture all the allocations
 			var err error
 			var iter memdb.ResultIterator
-			if prefix := args.QueryOptions.Prefix; prefix != "" {
+
+			prefix := args.QueryOptions.Prefix
+			if args.AllNamespaces {
+				allowedNSes, err := allowedNSes(aclObj, state)
+				if err != nil {
+					return err
+				}
+				iter, err = state.AllocsByIDPrefixInNSes(ws, allowedNSes, prefix)
+				if err != nil {
+					return err
+				}
+			} else if prefix != "" {
 				iter, err = state.AllocsByIDPrefix(ws, args.RequestNamespace(), prefix)
 			} else {
 				iter, err = state.AllocsByNamespace(ws, args.RequestNamespace())

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1140,7 +1140,7 @@ func (j *Job) GetJobVersions(args *structs.JobVersionsRequest,
 // allowedNSes returns a set (as map of ns->true) of the namespaces a token has access to.
 // Returns `nil` set if the token has access to all namespaces
 // and ErrPermissionDenied if the token has no capabilities on any namespace.
-func (j *Job) allowedNSes(aclObj *acl.ACL, state *state.StateStore) (map[string]bool, error) {
+func allowedNSes(aclObj *acl.ACL, state *state.StateStore) (map[string]bool, error) {
 	if aclObj == nil || aclObj.IsManagement() {
 		return nil, nil
 	}
@@ -1249,7 +1249,7 @@ func (j *Job) listAllNamespaces(args *structs.JobListRequest, reply *structs.Job
 		queryMeta: &reply.QueryMeta,
 		run: func(ws memdb.WatchSet, state *state.StateStore) error {
 			// check if user has permission to all namespaces
-			allowedNSes, err := j.allowedNSes(aclObj, state)
+			allowedNSes, err := allowedNSes(aclObj, state)
 			if err == structs.ErrPermissionDenied {
 				// return empty jobs if token isn't authorized for any
 				// namespace, matching other endpoints

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -859,6 +859,7 @@ type AllocStopResponse struct {
 
 // AllocListRequest is used to request a list of allocations
 type AllocListRequest struct {
+	AllNamespaces bool
 	QueryOptions
 }
 


### PR DESCRIPTION
This allows an Enterprise operator to query for lists in jobs and allocations across all namespaces they have capabilities in.

## UX

When `-all-namespaces` command line argument is set, or if `NOMAD_ALL_NAMESPACES` env var is set to truthy value (e.g. `1`, `true`), `nomad job` and `nomad alloc` commands will lookup relevant jobs/allocations in all namespaces they are authorized to.

`nomad job status -all-namespaces` will emit all the jobs across namespaces (with a namespace column added).  `nomad job status -all-namespaces foo` will return the job info for `foo` job regardless of which namespace is in; if there multiple foo jobs, the CLI will emit back an error message, indicating the possible values.

```
# namespace specific status
$ nomad job status
ID        Type   Priority  Status   Submit Date
example1  batch  50        running  2020-06-17T10:49:26-04:00

# list jobs across all namespaces
$ nomad job status -all-namespaces
ID        Namespace  Type   Priority  Status   Submit Date
example1  default    batch  50        running  2020-06-17T10:49:26-04:00
example1  qa         batch  50        running  2020-06-17T10:49:37-04:00
qa-job    qa         batch  50        running  2020-06-17T10:50:28-04:00

# get job status for a job in a specific namespace
$ nomad job status -short ex
ID            = example1
Name          = example1
Submit Date   = 2020-06-17T10:49:26-04:00
Type          = batch
Priority      = 50
Datacenters   = dc1
Namespace     = default
Status        = running
Periodic      = false
Parameterized = false

# when checking multiple namespaces, report an error message if multiples are found
$ nomad job status -short -all-namespaces ex
Prefix matched multiple jobs

ID        Namespace  Type   Priority  Status   Submit Date
example1  default    batch  50        running  2020-06-17T10:49:26-04:00
example1  qa         batch  50        running  2020-06-17T10:49:37-04:00

# but namespace can always be specified to disambiguate
$ nomad job status -short -namespace qa ex
ID            = example1
Name          = example1
Submit Date   = 2020-06-17T10:49:37-04:00
Type          = batch
Priority      = 50
Datacenters   = dc1
Namespace     = qa
Status        = running
Periodic      = false
Parameterized = false

# querying with a prefix if a uniue job is found works
$ nomad job status -short -all-namespaces qa
ID            = qa-job
Name          = qa-job
Submit Date   = 2020-06-17T10:50:28-04:00
Type          = batch
Priority      = 50
Datacenters   = dc1
Namespace     = qa
Status        = running
Periodic      = false
Parameterized = false
```


### Abandoned ideas

#### Defaulting to `-all-namespaces`

I considered avoiding the additional argument and defaulting to all namespaces if no `--namespace` is specified.  Such change would be a significant change in behavior that will surprise users.

#### Using a sentinel namespace value

We could reserve a sentinel namespace value (e.g. `--namespace global`) to indicate querying all namespaces.  However, operators currently can create any namespace, and introducing a special reserved value might collide with an existing namespace and result into confusion.

## Implementation Details

The implementation has three main components:

The RPC Handlers for `Job.List` and `Alloc.List` accept `AllNamespaces` argument to indicate whether one should search all namespaces the request token has access to.  This PR implements `Allocations.List`, as `Job.List` was already updated in https://github.com/hashicorp/nomad/pull/8001 .

Then the API and CLI components need to pass `AllNamespaces` appropriately.  Due to the sheer number of endpoints this affects, I made the flags a global Client Meta/Config options.

The CLI subcommands typically adhere to the following implementation pattern:
1. attempt to find all job/allocation matches with given prefix - passing AllNamespaces as appropriate
2. If a job is found, do a specific lookup while passing the namespace found earlier.

As such, `{Job|Alloc}.Get` RPC endpoints aren't modified, and as before must require the correct namespace being passed.

Incidentally, we didn't need to add any indexes to the state store to accomodate this.  `Alloc.List` already isn't indexed by namespaces, so checking multiple namespaces is roughly the same computationally intensive operation as the namespaced ones.

## Potential follow ups

* [ ] We could implement the same logic for Evals as well but I'm uncertain if it's needed, so waiting for some customer feedback.
* [ ] Add tests in the private Enterprise repository.  Hard to test this in OSS where namespaces aren't supported.