### PR TITLE
modify Job.Scale RPC to return an error if there is an active deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 IMPROVEMENTS:
 
 * core: support for persisting previous task group counts when updating a job [[GH-8168](https://github.com/hashicorp/nomad/issues/8168)]
+* core: block Job.Scale actions when the job is under active deployment [[GH-8187](https://github.com/hashicorp/nomad/issues/8187)]
 * api: Persist previous count with scaling events [[GH-8167](https://github.com/hashicorp/nomad/issues/8167)]
 * build: Updated to Go 1.14.4 [[GH-8172](https://github.com/hashicorp/nomad/issues/9172)]
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -924,6 +924,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	ws := memdb.NewWatchSet()
 	job, err := snap.JobByID(ws, namespace, args.JobID)
 	if err != nil {
+		j.logger.Error("unable to lookup job", "error", err)
 		return err
 	}
 	if job == nil {
@@ -948,11 +949,46 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	// for now, we'll do this even if count didn't change
 	prevCount := found.Count
 	if args.Count != nil {
+
+		// Lookup the latest deployment, to see whether this scaling event should be blocked
+		d, err := snap.LatestDeploymentByJobID(ws, namespace, args.JobID)
+		if err != nil {
+			j.logger.Error("unable to lookup latest deployment", "error", err)
+			return err
+		}
+		// explicitly filter deployment by JobCreateIndex to be safe, because LatestDeploymentByJobID doesn't
+		if d != nil && d.JobCreateIndex == job.CreateIndex && d.Active() {
+			// attempt to register the scaling event
+			JobScalingBlockedByActiveDeployment := "job scaling blocked due to active deployment"
+			event := &structs.ScalingEventRequest{
+				Namespace: job.Namespace,
+				JobID:     job.ID,
+				TaskGroup: groupName,
+				ScalingEvent: &structs.ScalingEvent{
+					Time:          now,
+					PreviousCount: int64(prevCount),
+					Message:       JobScalingBlockedByActiveDeployment,
+					Error:         true,
+					Meta:          map[string]interface{}{
+						"OriginalMessage": args.Message,
+						"OriginalCount": *args.Count,
+						"OriginalMeta": args.Meta,
+					},
+				},
+			}
+			if _, _, err := j.srv.raftApply(structs.ScalingEventRegisterRequestType, event); err != nil {
+				// just log the error, this was a best-effort attempt
+				j.logger.Error("scaling event create failed during block scaling action", "error", err)
+			}
+			return structs.NewErrRPCCoded(400, JobScalingBlockedByActiveDeployment)
+		}
+
 		truncCount := int(*args.Count)
 		if int64(truncCount) != *args.Count {
 			return structs.NewErrRPCCoded(400,
 				fmt.Sprintf("new scaling count is too large for TaskGroup.Count (int): %v", args.Count))
 		}
+		// update the task group count
 		found.Count = truncCount
 
 		registerReq := structs.JobRegisterRequest{

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -969,10 +969,10 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 					PreviousCount: int64(prevCount),
 					Message:       JobScalingBlockedByActiveDeployment,
 					Error:         true,
-					Meta:          map[string]interface{}{
+					Meta: map[string]interface{}{
 						"OriginalMessage": args.Message,
-						"OriginalCount": *args.Count,
-						"OriginalMeta": args.Meta,
+						"OriginalCount":   *args.Count,
+						"OriginalMeta":    args.Meta,
 					},
 				},
 			}

--- a/website/pages/api-docs/jobs.mdx
+++ b/website/pages/api-docs/jobs.mdx
@@ -1783,6 +1783,7 @@ $ curl \
 
 This endpoint performs a scaling action against a job.
 Currently, this endpoint supports scaling the count for a task group.
+This will return a 400 error if the job has an active deployment.
 
 | Method | Path                    | Produces           |
 | ------ | ----------------------- | ------------------ |


### PR DESCRIPTION
`Job.Scale` will return a 400-coded error if the job has an active deployment. This is a short-term solution to the problem where the autoscaler might attempt to scale the job while it is being updated, which would result in the previous deployment being cancelled and a new deployment being created.

This PR does two things: 
* block the Job.Scale operations
* make a best-effort attempt to register a scaling event in the case that the scaling action was blocked

resolves #8143