### PR TITLE
CLI Allow querying all namespaces for jobs and allocations - Try 2

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -28,6 +28,12 @@ var (
 	ClientConnTimeout = 1 * time.Second
 )
 
+const (
+	// AllNamespacesNamespace is a sentinel Namespace value to indicate that api should search for
+	// jobs and allocations in all the namespaces the requester can access.
+	AllNamespacesNamespace = "*"
+)
+
 // QueryOptions are used to parametrize a query
 type QueryOptions struct {
 	// Providing a datacenter overwrites the region provided

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -142,13 +142,6 @@ func (j *Jobs) PrefixList(prefix string) ([]*JobListStub, *QueryMeta, error) {
 	return j.List(&QueryOptions{Prefix: prefix})
 }
 
-// ListAll is used to list all of the existing jobs in all namespaces.
-func (j *Jobs) ListAll() ([]*JobListStub, *QueryMeta, error) {
-	return j.List(&QueryOptions{
-		Params: map[string]string{"all_namespaces": "true"},
-	})
-}
-
 // Info is used to retrieve information about a particular
 // job given its unique ID.
 func (j *Jobs) Info(jobID string, q *QueryOptions) (*Job, *QueryMeta, error) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -31,7 +31,6 @@ func (s *HTTPServer) jobListRequest(resp http.ResponseWriter, req *http.Request)
 		return nil, nil
 	}
 
-	args.AllNamespaces, _ = strconv.ParseBool(req.URL.Query().Get("all_namespaces"))
 	var out structs.JobListResponse
 	if err := s.agent.RPC("Job.List", &args, &out); err != nil {
 		return nil, err

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -146,7 +146,7 @@ func TestHTTP_JobsList_AllNamespaces_OSS(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/jobs?all_namespaces=true", nil)
+		req, err := http.NewRequest("GET", "/v1/jobs?namespace=*", nil)
 		require.NoError(t, err)
 		respW := httptest.NewRecorder()
 

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -183,7 +183,8 @@ func (l *AllocExecCommand) Run(args []string) int {
 		return 1
 	}
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		l.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -196,7 +196,8 @@ func (f *AllocFSCommand) Run(args []string) int {
 		return 1
 	}
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		f.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -171,7 +171,8 @@ func (l *AllocLogsCommand) Run(args []string) int {
 		return 1
 	}
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		l.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_restart.go
+++ b/command/alloc_restart.go
@@ -96,7 +96,8 @@ func (c *AllocRestartCommand) Run(args []string) int {
 	}
 
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
@@ -100,7 +101,8 @@ func (c *AllocSignalCommand) Run(args []string) int {
 	}
 
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -166,7 +166,8 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		return 0
 	}
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/alloc_stop.go
+++ b/command/alloc_stop.go
@@ -3,6 +3,8 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad/api"
 )
 
 type AllocStopCommand struct {
@@ -102,7 +104,8 @@ func (c *AllocStopCommand) Run(args []string) int {
 	}
 
 	// Prefix lookup matched a single allocation
-	alloc, _, err := client.Allocations().Info(allocs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
 		return 1

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -119,7 +119,7 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
+	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
 		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
@@ -119,10 +120,11 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}
 	jobID = jobs[0].ID
+	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
 
 	// Truncate the id unless full length is requested
 	length := shortId
@@ -131,7 +133,7 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 	}
 
 	if latest {
-		deploy, _, err := client.Jobs().LatestDeployment(jobID, nil)
+		deploy, _, err := client.Jobs().LatestDeployment(jobID, q)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error retrieving deployments: %s", err))
 			return 1
@@ -152,7 +154,7 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 		return 0
 	}
 
-	deploys, _, err := client.Jobs().Deployments(jobID, all, nil)
+	deploys, _, err := client.Jobs().Deployments(jobID, all, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving deployments: %s", err))
 		return 1

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -131,12 +131,14 @@ func (c *JobHistoryCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}
 
+	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
+
 	// Prefix lookup matched a single job
-	versions, diffs, _, err := client.Jobs().Versions(jobs[0].ID, diff, nil)
+	versions, diffs, _, err := client.Jobs().Versions(jobs[0].ID, diff, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s", err))
 		return 1

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -130,7 +130,7 @@ func (c *JobHistoryCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
+	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
 		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}

--- a/command/job_inspect.go
+++ b/command/job_inspect.go
@@ -127,7 +127,7 @@ func (c *JobInspectCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}
 
@@ -143,7 +143,7 @@ func (c *JobInspectCommand) Run(args []string) int {
 	}
 
 	// Prefix lookup matched a single job
-	job, err := getJob(client, jobs[0].ID, version)
+	job, err := getJob(client, jobs[0].JobSummary.Namespace, jobs[0].ID, version)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error inspecting job: %s", err))
 		return 1
@@ -183,13 +183,17 @@ func (c *JobInspectCommand) Run(args []string) int {
 }
 
 // getJob retrieves the job optionally at a particular version.
-func getJob(client *api.Client, jobID string, version *uint64) (*api.Job, error) {
+func getJob(client *api.Client, namespace, jobID string, version *uint64) (*api.Job, error) {
+	var q *api.QueryOptions
+	if namespace != "" {
+		q = &api.QueryOptions{Namespace: namespace}
+	}
 	if version == nil {
-		job, _, err := client.Jobs().Info(jobID, nil)
+		job, _, err := client.Jobs().Info(jobID, q)
 		return job, err
 	}
 
-	versions, _, _, err := client.Jobs().Versions(jobID, false, nil)
+	versions, _, _, err := client.Jobs().Versions(jobID, false, q)
 	if err != nil {
 		return nil, err
 	}

--- a/command/job_inspect.go
+++ b/command/job_inspect.go
@@ -126,7 +126,7 @@ func (c *JobInspectCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
+	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
 		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}

--- a/command/job_periodic_force.go
+++ b/command/job_periodic_force.go
@@ -127,13 +127,14 @@ func (c *JobPeriodicForceCommand) Run(args []string) int {
 		return 1
 	}
 	if len(periodicJobs) > 1 {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple periodic jobs\n\n%s", createStatusListOutput(periodicJobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple periodic jobs\n\n%s", createStatusListOutput(periodicJobs, c.allNamespaces())))
 		return 1
 	}
 	jobID = periodicJobs[0].ID
+	q := &api.WriteOptions{Namespace: periodicJobs[0].JobSummary.Namespace}
 
 	// force the evaluation
-	evalID, _, err := client.Jobs().PeriodicForce(jobID, nil)
+	evalID, _, err := client.Jobs().PeriodicForce(jobID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error forcing periodic job %q: %s", jobID, err))
 		return 1

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -124,7 +124,7 @@ func (c *JobPromoteCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
+	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
 		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -125,13 +125,14 @@ func (c *JobPromoteCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}
 	jobID = jobs[0].ID
+	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
 
 	// Do a prefix lookup
-	deploy, _, err := client.Jobs().LatestDeployment(jobID, nil)
+	deploy, _, err := client.Jobs().LatestDeployment(jobID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving deployment: %s", err))
 		return 1
@@ -142,11 +143,12 @@ func (c *JobPromoteCommand) Run(args []string) int {
 		return 1
 	}
 
+	wq := &api.WriteOptions{Namespace: jobs[0].JobSummary.Namespace}
 	var u *api.DeploymentUpdateResponse
 	if len(groups) == 0 {
-		u, _, err = client.Deployments().PromoteAll(deploy.ID, nil)
+		u, _, err = client.Deployments().PromoteAll(deploy.ID, wq)
 	} else {
-		u, _, err = client.Deployments().PromoteGroups(deploy.ID, groups, nil)
+		u, _, err = client.Deployments().PromoteGroups(deploy.ID, groups, wq)
 	}
 
 	if err != nil {

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -144,7 +144,7 @@ func (c *JobRevertCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
+	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
 		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
@@ -144,12 +145,13 @@ func (c *JobRevertCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}
 
 	// Prefix lookup matched a single job
-	resp, _, err := client.Jobs().Revert(jobs[0].ID, revertVersion, nil, nil, consulToken, vaultToken)
+	q := &api.WriteOptions{Namespace: jobs[0].JobSummary.Namespace}
+	resp, _, err := client.Jobs().Revert(jobs[0].ID, revertVersion, nil, q, consulToken, vaultToken)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s", err))
 		return 1

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -122,9 +122,12 @@ func (c *JobStatusCommand) Run(args []string) int {
 		return 1
 	}
 
+	allNamespaces := c.allNamespaces()
+
 	// Invoke list mode if no job ID.
 	if len(args) == 0 {
 		jobs, _, err := client.Jobs().List(nil)
+
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error querying jobs: %s", err))
 			return 1
@@ -134,7 +137,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 			// No output if we have no jobs
 			c.Ui.Output("No running jobs")
 		} else {
-			c.Ui.Output(createStatusListOutput(jobs))
+			c.Ui.Output(createStatusListOutput(jobs, allNamespaces))
 		}
 		return 0
 	}
@@ -152,11 +155,12 @@ func (c *JobStatusCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, allNamespaces)))
 		return 1
 	}
 	// Prefix lookup matched a single job
-	job, _, err := client.Jobs().Info(jobs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
+	job, _, err := client.Jobs().Info(jobs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying job: %s", err))
 		return 1
@@ -313,20 +317,24 @@ func (c *JobStatusCommand) outputParameterizedInfo(client *api.Client, job *api.
 // outputJobInfo prints information about the passed non-periodic job. If a
 // request fails, an error is returned.
 func (c *JobStatusCommand) outputJobInfo(client *api.Client, job *api.Job) error {
+	var q *api.QueryOptions
+	if job.Namespace != nil {
+		q = &api.QueryOptions{Namespace: *job.Namespace}
+	}
 
 	// Query the allocations
-	jobAllocs, _, err := client.Jobs().Allocations(*job.ID, c.allAllocs, nil)
+	jobAllocs, _, err := client.Jobs().Allocations(*job.ID, c.allAllocs, q)
 	if err != nil {
 		return fmt.Errorf("Error querying job allocations: %s", err)
 	}
 
 	// Query the evaluations
-	jobEvals, _, err := client.Jobs().Evaluations(*job.ID, nil)
+	jobEvals, _, err := client.Jobs().Evaluations(*job.ID, q)
 	if err != nil {
 		return fmt.Errorf("Error querying job evaluations: %s", err)
 	}
 
-	latestDeployment, _, err := client.Jobs().LatestDeployment(*job.ID, nil)
+	latestDeployment, _, err := client.Jobs().LatestDeployment(*job.ID, q)
 	if err != nil {
 		return fmt.Errorf("Error querying latest job deployment: %s", err)
 	}
@@ -505,7 +513,8 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 // where appropriate
 func (c *JobStatusCommand) outputJobSummary(client *api.Client, job *api.Job) error {
 	// Query the summary
-	summary, _, err := client.Jobs().Summary(*job.ID, nil)
+	q := &api.QueryOptions{Namespace: *job.Namespace}
+	summary, _, err := client.Jobs().Summary(*job.ID, q)
 	if err != nil {
 		return fmt.Errorf("Error querying job summary: %s", err)
 	}
@@ -650,16 +659,29 @@ func (c *JobStatusCommand) outputFailedPlacements(failedEval *api.Evaluation) {
 }
 
 // list general information about a list of jobs
-func createStatusListOutput(jobs []*api.JobListStub) string {
+func createStatusListOutput(jobs []*api.JobListStub, displayNS bool) string {
 	out := make([]string, len(jobs)+1)
-	out[0] = "ID|Type|Priority|Status|Submit Date"
-	for i, job := range jobs {
-		out[i+1] = fmt.Sprintf("%s|%s|%d|%s|%s",
-			job.ID,
-			getTypeString(job),
-			job.Priority,
-			getStatusString(job.Status, &job.Stop),
-			formatTime(time.Unix(0, job.SubmitTime)))
+	if displayNS {
+		out[0] = "ID|Namespace|Type|Priority|Status|Submit Date"
+		for i, job := range jobs {
+			out[i+1] = fmt.Sprintf("%s|%s|%s|%d|%s|%s",
+				job.ID,
+				job.JobSummary.Namespace,
+				getTypeString(job),
+				job.Priority,
+				getStatusString(job.Status, &job.Stop),
+				formatTime(time.Unix(0, job.SubmitTime)))
+		}
+	} else {
+		out[0] = "ID|Type|Priority|Status|Submit Date"
+		for i, job := range jobs {
+			out[i+1] = fmt.Sprintf("%s|%s|%d|%s|%s",
+				job.ID,
+				getTypeString(job),
+				job.Priority,
+				getStatusString(job.Status, &job.Stop),
+				formatTime(time.Unix(0, job.SubmitTime)))
+		}
 	}
 	return formatList(out)
 }

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -154,7 +154,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
+	if len(jobs) > 1 && (allNamespaces || strings.TrimSpace(jobID) != jobs[0].ID) {
 		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, allNamespaces)))
 		return 1
 	}

--- a/command/job_stop.go
+++ b/command/job_stop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
@@ -126,11 +127,12 @@ func (c *JobStopCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs)))
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}
 	// Prefix lookup matched a single job
-	job, _, err := client.Jobs().Info(jobs[0].ID, nil)
+	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
+	job, _, err := client.Jobs().Info(jobs[0].ID, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error deregistering job: %s", err))
 		return 1
@@ -160,7 +162,8 @@ func (c *JobStopCommand) Run(args []string) int {
 	}
 
 	// Invoke the stop
-	evalID, _, err := client.Jobs().Deregister(*job.ID, purge, nil)
+	wq := &api.WriteOptions{Namespace: jobs[0].JobSummary.Namespace}
+	evalID, _, err := client.Jobs().Deregister(*job.ID, purge, wq)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error deregistering job: %s", err))
 		return 1

--- a/command/job_stop.go
+++ b/command/job_stop.go
@@ -126,7 +126,7 @@ func (c *JobStopCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && strings.TrimSpace(jobID) != jobs[0].ID {
+	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
 		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 		return 1
 	}

--- a/command/meta.go
+++ b/command/meta.go
@@ -113,7 +113,7 @@ type ApiClientFactory func() (*api.Client, error)
 
 // Client is used to initialize and return a new API client using
 // the default command line arguments and env vars.
-func (m *Meta) Client() (*api.Client, error) {
+func (m *Meta) clientConfig() *api.Config {
 	config := api.DefaultConfig()
 	if m.flagAddress != "" {
 		config.Address = m.flagAddress
@@ -142,7 +142,15 @@ func (m *Meta) Client() (*api.Client, error) {
 		config.SecretID = m.token
 	}
 
-	return api.NewClient(config)
+	return config
+}
+
+func (m *Meta) Client() (*api.Client, error) {
+	return api.NewClient(m.clientConfig())
+}
+
+func (m *Meta) allNamespaces() bool {
+	return m.clientConfig().Namespace == api.AllNamespacesNamespace
 }
 
 func (m *Meta) Colorize() *colorstring.Colorize {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1216,7 +1216,7 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 	}
 	defer metrics.MeasureSince([]string{"nomad", "job", "list"}, time.Now())
 
-	if args.AllNamespaces {
+	if args.RequestNamespace() == structs.AllNamespacesSentinel {
 		return j.listAllNamespaces(args, reply)
 	}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1183,7 +1183,7 @@ func (j *Job) GetJobVersions(args *structs.JobVersionsRequest,
 // allowedNSes returns a set (as map of ns->true) of the namespaces a token has access to.
 // Returns `nil` set if the token has access to all namespaces
 // and ErrPermissionDenied if the token has no capabilities on any namespace.
-func (j *Job) allowedNSes(aclObj *acl.ACL, state *state.StateStore) (map[string]bool, error) {
+func allowedNSes(aclObj *acl.ACL, state *state.StateStore) (map[string]bool, error) {
 	if aclObj == nil || aclObj.IsManagement() {
 		return nil, nil
 	}
@@ -1292,7 +1292,7 @@ func (j *Job) listAllNamespaces(args *structs.JobListRequest, reply *structs.Job
 		queryMeta: &reply.QueryMeta,
 		run: func(ws memdb.WatchSet, state *state.StateStore) error {
 			// check if user has permission to all namespaces
-			allowedNSes, err := j.allowedNSes(aclObj, state)
+			allowedNSes, err := allowedNSes(aclObj, state)
 			if err == structs.ErrPermissionDenied {
 				// return empty jobs if token isn't authorized for any
 				// namespace, matching other endpoints

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -152,7 +152,7 @@ func TestJobEndpoint_Register_PreserveCounts(t *testing.T) {
 
 	// Perform the update
 	require.NoError(msgpackrpc.CallWithCodec(codec, "Job.Register", &structs.JobRegisterRequest{
-		Job: job,
+		Job:            job,
 		PreserveCounts: true,
 		WriteRequest: structs.WriteRequest{
 			Region:    "global",
@@ -165,9 +165,8 @@ func TestJobEndpoint_Register_PreserveCounts(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(out)
 	require.Equal(10, out.TaskGroups[0].Count) // should not change
-	require.Equal(2, out.TaskGroups[1].Count) // should be as in job spec
+	require.Equal(2, out.TaskGroups[1].Count)  // should be as in job spec
 }
-
 
 func TestJobEndpoint_Register_Connect(t *testing.T) {
 	t.Parallel()
@@ -3864,10 +3863,9 @@ func TestJobEndpoint_ListJobs_AllNamespaces_OSS(t *testing.T) {
 
 	// Lookup the jobs
 	get := &structs.JobListRequest{
-		AllNamespaces: true,
 		QueryOptions: structs.QueryOptions{
 			Region:    "global",
-			Namespace: job.Namespace,
+			Namespace: "*",
 		},
 	}
 	var resp2 structs.JobListResponse
@@ -3880,10 +3878,9 @@ func TestJobEndpoint_ListJobs_AllNamespaces_OSS(t *testing.T) {
 
 	// Lookup the jobs by prefix
 	get = &structs.JobListRequest{
-		AllNamespaces: true,
 		QueryOptions: structs.QueryOptions{
 			Region:    "global",
-			Namespace: job.Namespace,
+			Namespace: "*",
 			Prefix:    resp2.Jobs[0].ID[:4],
 		},
 	}
@@ -3897,10 +3894,9 @@ func TestJobEndpoint_ListJobs_AllNamespaces_OSS(t *testing.T) {
 
 	// Lookup the jobs by prefix
 	get = &structs.JobListRequest{
-		AllNamespaces: true,
 		QueryOptions: structs.QueryOptions{
 			Region:    "global",
-			Namespace: job.Namespace,
+			Namespace: "*",
 			Prefix:    "z" + resp2.Jobs[0].ID[:4],
 		},
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -137,6 +137,10 @@ const (
 	DefaultNamespace            = "default"
 	DefaultNamespaceDescription = "Default shared namespace"
 
+	// AllNamespacesSentinel is the value used as a namespace RPC value
+	// to indicate that endpoints must search in all namespaces
+	AllNamespacesSentinel = "*"
+
 	// JitterFraction is a the limit to the amount of jitter we apply
 	// to a user specified MaxQueryTime. We divide the specified time by
 	// the fraction. So 16 == 6.25% limit of jitter. This jitter is also
@@ -614,7 +618,6 @@ type JobSpecificRequest struct {
 
 // JobListRequest is used to parameterize a list request
 type JobListRequest struct {
-	AllNamespaces bool
 	QueryOptions
 }
 

--- a/vendor/github.com/hashicorp/nomad/api/api.go
+++ b/vendor/github.com/hashicorp/nomad/api/api.go
@@ -28,6 +28,12 @@ var (
 	ClientConnTimeout = 1 * time.Second
 )
 
+const (
+	// AllNamespacesNamespace is a sentinel Namespace value to indicate that api should search for
+	// jobs and allocations in all the namespaces the requester can access.
+	AllNamespacesNamespace = "*"
+)
+
 // QueryOptions are used to parametrize a query
 type QueryOptions struct {
 	// Providing a datacenter overwrites the region provided

--- a/vendor/github.com/hashicorp/nomad/api/jobs.go
+++ b/vendor/github.com/hashicorp/nomad/api/jobs.go
@@ -142,13 +142,6 @@ func (j *Jobs) PrefixList(prefix string) ([]*JobListStub, *QueryMeta, error) {
 	return j.List(&QueryOptions{Prefix: prefix})
 }
 
-// ListAll is used to list all of the existing jobs in all namespaces.
-func (j *Jobs) ListAll() ([]*JobListStub, *QueryMeta, error) {
-	return j.List(&QueryOptions{
-		Params: map[string]string{"all_namespaces": "true"},
-	})
-}
-
 // Info is used to retrieve information about a particular
 // job given its unique ID.
 func (j *Jobs) Info(jobID string, q *QueryOptions) (*Job, *QueryMeta, error) {

--- a/website/pages/api-docs/jobs.mdx
+++ b/website/pages/api-docs/jobs.mdx
@@ -30,10 +30,6 @@ The table below shows this endpoint's support for
 - `prefix` `(string: "")` - Specifies a string to filter jobs on based on
   an index prefix. This is specified as a query string parameter.
 
-- `all_namespaces` `(bool: false)` - Specifies whether to return the all
-  known jobs across all namespaces the token has `namespace:list-jobs` ACL
-  capability on.
-
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
This is attempt 2 of https://github.com/hashicorp/nomad/pull/8183 .

This is almost the same approach, but reuses current namespace field but with specially handling `*` to mean all namespaces.

### UX

When `-namespace=*` command line argument is set, or if `NOMAD_NAMESPACES` env var is set to `*`, `nomad job` and `nomad alloc` commands will lookup relevant jobs/allocations in all namespaces they are authorized to.

`nomad job status -namespace=*` will emit all the jobs across namespaces (with a namespace column added).  `nomad job status -namespace=* foo` will return the job info for `foo` job regardless of which namespace is in; if there multiple foo jobs, the CLI will emit back an error message, indicating the possible values.

```
# namespace specific status
$ nomad job status
ID        Type   Priority  Status   Submit Date
example1  batch  50        running  2020-06-17T10:49:26-04:00

# list jobs across all namespaces
$ nomad job status -namespace=*
ID        Namespace  Type   Priority  Status   Submit Date
example1  default    batch  50        running  2020-06-17T10:49:26-04:00
example1  qa         batch  50        running  2020-06-17T10:49:37-04:00
qa-job    qa         batch  50        running  2020-06-17T10:50:28-04:00

# get job status for a job in a specific namespace
$ nomad job status -short ex
ID            = example1
Name          = example1
Submit Date   = 2020-06-17T10:49:26-04:00
Type          = batch
Priority      = 50
Datacenters   = dc1
Namespace     = default
Status        = running
Periodic      = false
Parameterized = false

# when checking multiple namespaces, report an error message if multiples are found
$ nomad job status -short -namespace=* ex
Prefix matched multiple jobs

ID        Namespace  Type   Priority  Status   Submit Date
example1  default    batch  50        running  2020-06-17T10:49:26-04:00
example1  qa         batch  50        running  2020-06-17T10:49:37-04:00

# but namespace can always be specified to disambiguate
$ nomad job status -short -namespace qa ex
ID            = example1
Name          = example1
Submit Date   = 2020-06-17T10:49:37-04:00
Type          = batch
Priority      = 50
Datacenters   = dc1
Namespace     = qa
Status        = running
Periodic      = false
Parameterized = false

# querying with a prefix if a uniue job is found works
$ nomad job status -short -namespace=* qa
ID            = qa-job
Name          = qa-job
Submit Date   = 2020-06-17T10:50:28-04:00
Type          = batch
Priority      = 50
Datacenters   = dc1
Namespace     = qa
Status        = running
Periodic      = false
Parameterized = false
```

### Implementation

The implementation is very identical to other approach

## Trade-offs?

The advantage of this approach is that it's simpler to explain, has fewer moving parts, and provides a simple generalizable approach for other fields.

The downside though is that operators may need to fine tune `namespace` parameter in invocation basis.  If a user sets `NOMAD_NAMESPACE=*`, they may get odd errors if hitting endpoints that don't support this yet (e.g. evals).  Though, we should try to extend them to eliminate this annoying inconsistency if they exist.