### PR TITLE
lifecycle: add poststop hook

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -633,6 +633,7 @@ type DispatchPayloadConfig struct {
 const (
 	TaskLifecycleHookPrestart  = "prestart"
 	TaskLifecycleHookPoststart = "poststart"
+	TaskLifecycleHookPoststop = "poststop"
 )
 
 type TaskLifecycle struct {

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -633,7 +633,7 @@ type DispatchPayloadConfig struct {
 const (
 	TaskLifecycleHookPrestart  = "prestart"
 	TaskLifecycleHookPoststart = "poststart"
-	TaskLifecycleHookPoststop = "poststop"
+	TaskLifecycleHookPoststop  = "poststop"
 )
 
 type TaskLifecycle struct {

--- a/client/allocrunner/taskrunner/restarts/restarts.go
+++ b/client/allocrunner/taskrunner/restarts/restarts.go
@@ -34,6 +34,11 @@ func NewRestartTracker(policy *structs.RestartPolicy, jobType string, tlc *struc
 		onSuccess = tlc.Sidecar
 	}
 
+	// Poststop should never be restarted on success
+	if tlc != nil && tlc.Hook == structs.TaskLifecycleHookPoststop {
+		onSuccess = false
+	}
+
 	return &RestartTracker{
 		startTime: time.Now(),
 		onSuccess: onSuccess,

--- a/client/allocrunner/taskrunner/task_runner_getters.go
+++ b/client/allocrunner/taskrunner/task_runner_getters.go
@@ -28,6 +28,11 @@ func (tr *TaskRunner) IsLeader() bool {
 	return tr.taskLeader
 }
 
+// IsPoststopTask returns true if this task is a poststop task in its task group.
+func (tr *TaskRunner) IsPoststopTask() bool {
+	return tr.Task().Lifecycle != nil && tr.Task().Lifecycle.Hook == structs.TaskLifecycleHookPoststop
+}
+
 func (tr *TaskRunner) Task() *structs.Task {
 	tr.taskLock.RLock()
 	defer tr.taskLock.RUnlock()

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -165,8 +165,7 @@ func (tr *TaskRunner) emitHookError(err error, hookName string) {
 func (tr *TaskRunner) prestart() error {
 	// Determine if the allocation is terminal and we should avoid running
 	// prestart hooks.
-	alloc := tr.Alloc()
-	if alloc.TerminalStatus() {
+	if tr.shouldShutdown() {
 		tr.logger.Trace("skipping prestart hooks since allocation is terminal")
 		return nil
 	}

--- a/e2e/lifecycle/inputs/batch.nomad
+++ b/e2e/lifecycle/inputs/batch.nomad
@@ -111,8 +111,7 @@ touch ${NOMAD_ALLOC_DIR}/poststart-ran
 touch ${NOMAD_ALLOC_DIR}/poststart-running
 touch ${NOMAD_ALLOC_DIR}/poststart-started
 sleep 10
-# THIS IS WHERE THE ACTUAL TESTING HAPPENS
-# IF init-ran doesn't exist, then the init task hasn't run yet, so fail
+
 if [ ! -f ${NOMAD_ALLOC_DIR}/init-ran ]; then exit 12; fi
 if [ ! -f ${NOMAD_ALLOC_DIR}/main-started ]; then exit 15; fi
 if [ -f ${NOMAD_ALLOC_DIR}/init-running ]; then exit 14; fi
@@ -128,5 +127,43 @@ EOT
       }
     }
 
+    task "poststop" {
+
+      lifecycle {
+        hook = "poststop"
+      }
+
+      driver = "docker"
+
+      config {
+        image   = "busybox:1"
+        command = "/bin/sh"
+        args    = ["local/poststop.sh"]
+      }
+
+      template {
+        data = <<EOT
+#!/bin/sh
+sleep 1
+touch ${NOMAD_ALLOC_DIR}/poststop-ran
+touch ${NOMAD_ALLOC_DIR}/poststop-running
+touch ${NOMAD_ALLOC_DIR}/poststop-started
+sleep 5
+
+if [ ! -f ${NOMAD_ALLOC_DIR}/init-ran ]; then exit 12; fi
+if [ ! -f ${NOMAD_ALLOC_DIR}/main-started ]; then exit 15; fi
+if [ -f ${NOMAD_ALLOC_DIR}/init-running ]; then exit 14; fi
+if [ -f ${NOMAD_ALLOC_DIR}/main-running ]; then exit 17; fi
+rm ${NOMAD_ALLOC_DIR}/poststop-running
+EOT
+
+        destination = "local/poststop.sh"
+      }
+
+      resources {
+        cpu    = 64
+        memory = 64
+      }
+    }
   }
 }

--- a/e2e/lifecycle/lifecycle.go
+++ b/e2e/lifecycle/lifecycle.go
@@ -55,7 +55,7 @@ func (tc *LifecycleE2ETest) TestBatchJob(f *framework.F) {
 	afi, _, err := nomadClient.AllocFS().List(alloc, "alloc", nil)
 	require.NoError(err)
 	expected := map[string]bool{
-		"init-ran": true, "main-ran": true, "poststart-ran": true,
+		"init-ran": true, "main-ran": true, "poststart-ran": true, "poststop-ran": true,
 		"init-running": false, "main-running": false, "poststart-running": false}
 	got := checkFiles(expected, afi)
 	require.Equal(expected, got)
@@ -115,13 +115,15 @@ func (tc *LifecycleE2ETest) TestServiceJob(f *framework.F) {
 	require.NoError(err)
 	e2eutil.WaitForAllocStopped(t, nomadClient, allocID)
 
+	require.False(alloc.TaskStates["poststop"].Failed)
+
 	// assert the files were written as expected
 	afi, _, err := nomadClient.AllocFS().List(alloc, "alloc", nil)
 	require.NoError(err)
 	expected := map[string]bool{
-		"init-ran": true, "sidecar-ran": true, "main-ran": true, "poststart-ran": true,
-		"poststart-started": true, "main-started": true,
-		"init-running": false, "poststart-running": false,
+		"init-ran": true, "sidecar-ran": true, "main-ran": true, "poststart-ran": true, "poststop-ran": true,
+		"poststart-started": true, "main-started": true, "poststop-started": true,
+		"init-running": false, "poststart-running": false, "poststop-running": false,
 		"main-checked": true}
 	got := checkFiles(expected, afi)
 	require.Equal(expected, got)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3347,6 +3347,7 @@ func (a *AllocatedResources) Comparable() *ComparableResources {
 	prestartSidecarTasks := &AllocatedTaskResources{}
 	prestartEphemeralTasks := &AllocatedTaskResources{}
 	main := &AllocatedTaskResources{}
+	poststopTasks := &AllocatedTaskResources{}
 
 	for taskName, r := range a.Tasks {
 		lc := a.TaskLifecycles[taskName]
@@ -3358,11 +3359,14 @@ func (a *AllocatedResources) Comparable() *ComparableResources {
 			} else {
 				prestartEphemeralTasks.Add(r)
 			}
+		} else if lc.Hook == TaskLifecycleHookPoststop {
+			poststopTasks.Add(r)
 		}
 	}
 
 	// update this loop to account for lifecycle hook
 	prestartEphemeralTasks.Max(main)
+	prestartEphemeralTasks.Max(poststopTasks)
 	prestartSidecarTasks.Add(prestartEphemeralTasks)
 	c.Flattened.Add(prestartSidecarTasks)
 
@@ -5087,6 +5091,7 @@ func (d *DispatchPayloadConfig) Validate() error {
 const (
 	TaskLifecycleHookPrestart  = "prestart"
 	TaskLifecycleHookPoststart = "poststart"
+	TaskLifecycleHookPoststop  = "poststop"
 )
 
 type TaskLifecycleConfig struct {
@@ -5111,6 +5116,7 @@ func (d *TaskLifecycleConfig) Validate() error {
 	switch d.Hook {
 	case TaskLifecycleHookPrestart:
 	case TaskLifecycleHookPoststart:
+	case TaskLifecycleHookPoststop:
 	case "":
 		return fmt.Errorf("no lifecycle hook provided")
 	default:


### PR DESCRIPTION
For https://github.com/hashicorp/nomad/issues/8193

## Overview
A `poststop` hook has been added to the `lifecycle` stanza to allow users to run tasks after all other tasks in an allocation have completed.

## Behavior

This `poststop` task will run after main tasks are finished running. It will run no matter the final status of the main tasks, whether it is completed, failed or killed.

* batch job: `poststop` waits until main tasks have finished before starting
* service & system jobs: since services & system jobs are long-lived, `poststop` will only run poststop tasks after the allocation receives a kill signal or a main task fails


## Future Development
I plan to make these improvements in separate pull requests
* increased e2e testing
* refactor to move behavior out of the allocrunner Run() & back into the TaskHookCoordinator
* expose prior task state to poststop task << this requires a ticket for usability research & user feedback (we could have an environment variable and also put the full task state into the alloc filesystem, but we need to figure out what a user would expect)