### PR TITLE
docs: fix for multiregion count explanation

### DIFF
--- a/website/pages/docs/job-specification/multiregion.mdx
+++ b/website/pages/docs/job-specification/multiregion.mdx
@@ -122,9 +122,11 @@ final region will unblock the regions to mark them as `successful`.
 
 The name of a region must match the name of one of the [federated regions].
 
-- `count` `(int: <optional>)` - Specifies a default count for task
-  groups in the region. If a task group specifies its own `count`, this value
-  will be ignored. This value must be non-negative.
+- `count` `(int: <optional>)` - Specifies a count override for task groups in
+  the region. If a task group specifies a `count = 0`, its count will be
+  replaced with this value. If a task group specifies its own `count` or omits
+  the `count` field, this value will be ignored. This value must be
+  non-negative.
 
 - `datacenters` `(array<string>: <optional>)` - A list of
   datacenters in the region which are eligible for task placement. If not
@@ -212,7 +214,9 @@ multiregion {
   }
 }
 
-group "worker" {}
+group "worker" {
+  count = 0
+}
 
 group "controller" {
   count = 1


### PR DESCRIPTION
The originally described behavior wasn't accurate; we can't override the omitted/default count of a task group because it's set to 1. Having the behavior of an omitted count be different between MRD and single-region would be confusing, but more importantly it would create a mandatory field for `multiregion.region[n].count`.

We may revisit this behavior post-beta after some user feedback, but this changeset ensures the docs accurately reflect the current behavior.