### PR TITLE
multiregion: initial deploymentPaused must match start condition

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -204,7 +204,7 @@ func (a *allocReconciler) Compute() *reconcileResults {
 		// When we create the deployment later, it will be in a paused
 		// state. But we also need to tell Compute we're paused, otherwise we
 		// make placements on the paused deployment.
-		if a.job.IsMultiregion() && a.job.Region != a.job.Multiregion.Regions[0].Name {
+		if !a.job.IsMultiregionStarter() {
 			a.deploymentPaused = true
 		}
 	}


### PR DESCRIPTION
In #8209 we fixed the max_parallel stanza for multiregion by introducing the
IsMultiregionStarter check, but didn't apply it to the earlier place it's
required. The result is that deployments start but don't place allocations.