### PR TITLE
UI: Add a key to the alloc table on the task group detail page

### DIFF
--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -98,7 +98,7 @@
               <th>CPU</th>
               <th>Memory</th>
             </t.head>
-            <t.body as |row|>
+            <t.body @key="model.id" as |row|>
               <AllocationRow @data-test-allocation={{row.model.id}} @allocation={{row.model}} @context="taskGroup" @onClick={{action "gotoAllocation" row.model}} />
             </t.body>
           </ListTable>


### PR DESCRIPTION
Adding keys tells Ember to rerender matching entries instead of destroying and recreating.

Without this key, every time the allocation collection changes, every allocation row gets destroyed and recreated.

This happens a lot, since each allocation needs to be reloaded which dirties the collection.

Since allocation rows fetch stats on init, each of these many many renders results in a stats request.

By using a key and rerendering matching records, this all goes away. Since the rows aren't being destroyed and recreated, the init stats request isn't being made overnumerously.

Before and after screenshots of a page with five running allocations and a list of 10+ total allocations.

**Before:** 181 stats requests, 10 of which are from steady-state polling.
![image](https://user-images.githubusercontent.com/174740/85169635-fc4fb080-b220-11ea-93e3-eb953fb61c33.png)

**After:** 15 stats requests, 10 of which are from steady-state polling. 
![image](https://user-images.githubusercontent.com/174740/85169701-1ab5ac00-b221-11ea-9aa5-672dfc39c4c3.png)
