### PR TITLE
UI: Add cycling to factory healthy flags

### DIFF
--- a/ui/mirage/factories/storage-controller.js
+++ b/ui/mirage/factories/storage-controller.js
@@ -7,7 +7,7 @@ export default Factory.extend({
   provider: faker.helpers.randomize(STORAGE_PROVIDERS),
   providerVersion: '1.0.1',
 
-  healthy: faker.random.boolean,
+  healthy: i => [true, false][i % 2],
   healthDescription() {
     this.healthy ? 'healthy' : 'unhealthy';
   },

--- a/ui/mirage/factories/storage-node.js
+++ b/ui/mirage/factories/storage-node.js
@@ -7,7 +7,7 @@ export default Factory.extend({
   provider: faker.helpers.randomize(STORAGE_PROVIDERS),
   providerVersion: '1.0.1',
 
-  healthy: faker.random.boolean,
+  healthy: i => [true, false][i % 2],
   healthDescription() {
     this.healthy ? 'healthy' : 'unhealthy';
   },


### PR DESCRIPTION
This is meant to address the plugin test failure seen here:
https://app.circleci.com/pipelines/github/hashicorp/nomad/10015/workflows/ace5d615-db03-4cfc-86b2-31e9e00473ec/jobs/77014/tests

I believe the problem was that on rare occasions, the set
of mock storage controllers and nodes were all unhealthy,
so the facet test had no rows to iterate through. Since
there are always three of each, this guarantees some
healthy ones will be present.