### PR TITLE
csi: add VolumeContext to NodeStage/Publish RPCs

### DIFF
--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -628,8 +628,11 @@ func TestClient_RPC_NodeStageVolume(t *testing.T) {
 			nc.NextErr = tc.ResponseErr
 			nc.NextStageVolumeResponse = tc.Response
 
-			err := client.NodeStageVolume(context.TODO(), "foo", nil, "/path",
-				&VolumeCapability{}, structs.CSISecrets{})
+			err := client.NodeStageVolume(context.TODO(), &NodeStageVolumeRequest{
+				ExternalID:        "foo",
+				StagingTargetPath: "/path",
+				VolumeCapability:  &VolumeCapability{},
+			})
 			if tc.ExpectedErr != nil {
 				require.EqualError(t, err, tc.ExpectedErr.Error())
 			} else {

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/csi"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
@@ -192,7 +191,7 @@ func (c *Client) NodeGetInfo(ctx context.Context) (*csi.NodeGetInfoResponse, err
 // NodeStageVolume is used when a plugin has the STAGE_UNSTAGE volume capability
 // to prepare a volume for usage on a host. If err == nil, the response should
 // be assumed to be successful.
-func (c *Client) NodeStageVolume(ctx context.Context, volumeID string, publishContext map[string]string, stagingTargetPath string, capabilities *csi.VolumeCapability, secrets structs.CSISecrets, opts ...grpc.CallOption) error {
+func (c *Client) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest, opts ...grpc.CallOption) error {
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7771

In #7957 we added support for passing a volume context to the controller RPCs.
This is an opaque map that's created by `CreateVolume` or, in Nomad's case,
in the volume registration spec.

However, we missed passing this field to the `NodeStage` and `NodePublish` RPC,
which prevents certain plugins (such as MooseFS) from making node RPCs.