### PR TITLE
new command: nomad debug captures a debug archive of cluster state

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -201,6 +201,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"debug": func() (cli.Command, error) {
+			return &DebugCommand{
+				Meta: meta,
+			}, nil
+		},
 		"deployment": func() (cli.Command, error) {
 			return &DeploymentCommand{
 				Meta: meta,

--- a/command/debug.go
+++ b/command/debug.go
@@ -107,7 +107,6 @@ func (c *DebugCommand) AutocompleteArgs() complete.Predictor {
 
 func (c *DebugCommand) Name() string { return "debug" }
 
-// parse implements just the parsing phase of the
 func (c *DebugCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
@@ -377,7 +376,7 @@ func (c *DebugCommand) collectPprof(path, id string, client *api.Client) {
 	}
 }
 
-// await runs for duration, capturing the cluster state every interval. It flushes and stops
+// collectPeriodic runs for duration, capturing the cluster state every interval. It flushes and stops
 // the monitor requests
 func (c *DebugCommand) collectPeriodic(client *api.Client) {
 	// Not monitoring any logs, just capture the nomad context before exit
@@ -388,6 +387,7 @@ func (c *DebugCommand) collectPeriodic(client *api.Client) {
 	}
 
 	duration := time.After(c.duration)
+	// Set interval to 0 so that we immediately execute, wait the interval next time
 	interval := time.After(0 * time.Second)
 	var intervalCount int
 	var dir string

--- a/command/debug.go
+++ b/command/debug.go
@@ -216,15 +216,18 @@ func (c *DebugCommand) Run(args []string) int {
 	c.writeManifest()
 
 	if output != "" {
+		c.Ui.Output(fmt.Sprintf("Created debug directory: %s", c.collectDir))
 		return 0
 	}
 
-	err = TarCZF(stamped+".tar.gz", tmp)
+	archiveFile := stamped + ".tar.gz"
+	err = TarCZF(archiveFile, tmp)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("error creating archive: %s", err.Error()))
+		c.Ui.Error(fmt.Sprintf("Error creating archive: %s", err.Error()))
 		return 2
 	}
 
+	c.Ui.Output(fmt.Sprintf("Created debug archive: %s", archiveFile))
 	return 0
 }
 
@@ -239,7 +242,7 @@ func (c *DebugCommand) collect(client *api.Client) error {
 
 	self, err := client.Agent().Self()
 	if err != nil {
-		return fmt.Errorf("error agent self: %s", err.Error())
+		return fmt.Errorf("Error agent self: %s", err.Error())
 	}
 	c.writeJSON(dir, "agent-self.json", self)
 

--- a/command/debug.go
+++ b/command/debug.go
@@ -46,8 +46,8 @@ func (c *DebugCommand) Help() string {
 	helpText := `
 Usage: nomad debug [options]
 
-  Build an archive containing Nomad cluster configuration and state information, Nomad
-  server and node logs and pprof data for selected members, and Consul and Vault status.
+  Build an archive containing Nomad cluster configuration and state, and Consul and Vault
+  status. Include logs and pprof profiles for selected servers and client nodes.
 
 General Options:
 
@@ -66,22 +66,22 @@ Debug Options:
    The log level to monitor. Defaults to DEBUG.
 
   -node-id=n1,n2
-   Comma separated list of Nomad client node ids, to monitor for logs and include pprof data.
-   Accepts id prefixes.
+   Comma separated list of Nomad client node ids, to monitor for logs and include pprof
+   profiles. Accepts id prefixes.
 
   -server-id=s1,s2
    Comma separated list of Nomad server names, or "leader" to monitor for logs and include pprof
-   data.
+   profiles.
 
   -output=path
-   Path to the parent directory of the output directory. Defaults to the current directory.
-   If specified, no archive is built.
+   Path to the parent directory of the output directory. If not specified, an archive is built
+   in the current directory.
 
   -consul-token
-   Token use to query Consul. Defaults to CONSUL_TOKEN
+   Token used to query Consul. Defaults to CONSUL_TOKEN
 
   -vault-token
-   Token use to query Vault. Defaults to VAULT_TOKEN
+   Token used to query Vault. Defaults to VAULT_TOKEN
 `
 	return strings.TrimSpace(helpText)
 }
@@ -249,7 +249,7 @@ func (c *DebugCommand) collect(client *api.Client) error {
 
 	self, err := client.Agent().Self()
 	if err != nil {
-		return fmt.Errorf("Error agent self: %s", err.Error())
+		return fmt.Errorf("agent self: %s", err.Error())
 	}
 	c.writeJSON(dir, "agent-self.json", self)
 
@@ -337,7 +337,7 @@ func (c *DebugCommand) startMonitor(path, idKey, nodeID string, client *api.Clie
 			fh.WriteString("\n")
 
 		case err := <-errCh:
-			fh.WriteString(fmt.Sprintf("Error monitoring: %s\n", err.Error()))
+			fh.WriteString(fmt.Sprintf("monitor: %s\n", err.Error()))
 			return
 
 		case <-c.ctx.Done():
@@ -430,43 +430,43 @@ func (c *DebugCommand) collectNomad(dir string, client *api.Client) error {
 
 	js, _, err := client.Jobs().List(qo)
 	if err != nil {
-		return fmt.Errorf("error listing jobs: %s", err.Error())
+		return fmt.Errorf("listing jobs: %s", err.Error())
 	}
 	c.writeJSON(dir, "jobs.json", js)
 
 	ds, _, err := client.Deployments().List(qo)
 	if err != nil {
-		return fmt.Errorf("error listing deployments: %s", err.Error())
+		return fmt.Errorf("listing deployments: %s", err.Error())
 	}
 	c.writeJSON(dir, "deployments.json", ds)
 
 	es, _, err := client.Evaluations().List(qo)
 	if err != nil {
-		return fmt.Errorf("error listing evaluations: %s", err.Error())
+		return fmt.Errorf("listing evaluations: %s", err.Error())
 	}
 	c.writeJSON(dir, "evaluations.json", es)
 
 	as, _, err := client.Allocations().List(qo)
 	if err != nil {
-		return fmt.Errorf("error listing allocations: %s", err.Error())
+		return fmt.Errorf("listing allocations: %s", err.Error())
 	}
 	c.writeJSON(dir, "allocations.json", as)
 
 	ns, _, err := client.Nodes().List(qo)
 	if err != nil {
-		return fmt.Errorf("error listing nodes: %s", err.Error())
+		return fmt.Errorf("listing nodes: %s", err.Error())
 	}
 	c.writeJSON(dir, "nodes.json", ns)
 
 	ps, _, err := client.CSIPlugins().List(qo)
 	if err != nil {
-		return fmt.Errorf("error listing plugins: %s", err.Error())
+		return fmt.Errorf("listing plugins: %s", err.Error())
 	}
 	c.writeJSON(dir, "plugins.json", ps)
 
 	vs, _, err := client.CSIVolumes().List(qo)
 	if err != nil {
-		return fmt.Errorf("error listing volumes: %s", err.Error())
+		return fmt.Errorf("listing volumes: %s", err.Error())
 	}
 	c.writeJSON(dir, "volumes.json", vs)
 

--- a/command/debug.go
+++ b/command/debug.go
@@ -1,0 +1,266 @@
+package command
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
+)
+
+type DebugCommand struct {
+	Meta
+}
+
+func (c *DebugCommand) Help() string {
+	helpText := `
+Usage: nomad debug [options]
+
+  Build an archive containing Nomad cluster configuration and state information, Nomad
+  server and task logs, and logs from the host systems running Nomad servers and clients. If
+  no selection option is provided, the debug archive contains logs from all nodes in the
+  cluster. Multiple selector options may be provided.
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+Debug Options:
+
+  -job <job> [job]
+    Select the context for the job, and any client nodes running the job.
+
+  -node <node> [node]
+    Select the context for the node and all jobs running on the node.
+
+  -plugin <plugin> [plugin]
+    Select the context for the plugin and all jobs providing it.
+
+  -volume <volume> [volume]
+    Select the context for the volume and all jobs providing its plugins or
+    using the volume, and nodes where the volume is mounted.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *DebugCommand) Synopsis() string {
+	return "Build a debug archive"
+}
+
+func (c *DebugCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-job":    complete.PredictAnything,
+			"-node":   complete.PredictAnything,
+			"-plugin": complete.PredictAnything,
+			"-volume": complete.PredictAnything,
+		})
+}
+
+func (c *DebugCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *DebugCommand) Name() string { return "debug" }
+
+func (c *DebugCommand) Run(args []string) int {
+	tmp, err := ioutil.TempDir(os.TempDir(), "nomad-debug-")
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("error creating tmp directory: %s", err.Error()))
+		return 2
+	}
+	defer os.RemoveAll(tmp)
+
+	err = c.collect(tmp)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("error collecting data: %s", err.Error()))
+		return 2
+	}
+
+	format := "2006-01-02-150405Z"
+	archive := "nomad-debug-" + time.Now().UTC().Format(format) + ".tar.gz"
+	err = TarCZF(archive, tmp)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("error creating archive: %s", err.Error()))
+		return 2
+	}
+
+	return 0
+}
+
+// collect collects data from our endpoints and writes the archive bundle
+func (c *DebugCommand) collect(root string) error {
+	client, err := c.Meta.Client()
+	if err != nil {
+		return fmt.Errorf("Error initializing client: %s", err.Error())
+	}
+
+	// Version contains cluster meta information
+	dir := filepath.Join(root, "version")
+	err = os.Mkdir(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	self, err := client.Agent().Self()
+	if err != nil {
+		return fmt.Errorf("error agent self: %s", err.Error())
+	}
+	writeJSON(dir, "agent-self.json", self)
+
+	// consul := self.Config["consul"]
+	// vaultMap := self.Config["vault"].(map[string]interface{})
+	// vault := vaultMap["addr"]
+
+	// For each server, collect the agent host state
+	dir = filepath.Join(root, "server")
+	err = os.Mkdir(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	var qo *api.QueryOptions
+
+	hostdata, _, err := client.Operator().ServerHosts(qo)
+	writeJSON(dir, "operator-server-hosts.json", hostdata)
+
+	// Nomad contains nomad cluster state
+	dir = filepath.Join(root, "nomad")
+	err = os.Mkdir(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	js, _, err := client.Jobs().List(qo)
+	if err != nil {
+		return fmt.Errorf("error listing jobs: %s", err.Error())
+	}
+	writeJSON(dir, "jobs.json", js)
+
+	ds, _, err := client.Deployments().List(qo)
+	if err != nil {
+		return fmt.Errorf("error listing deployments: %s", err.Error())
+	}
+	writeJSON(dir, "deployments.json", ds)
+
+	es, _, err := client.Evaluations().List(qo)
+	if err != nil {
+		return fmt.Errorf("error listing evaluations: %s", err.Error())
+	}
+	writeJSON(dir, "evaluations.json", es)
+
+	as, _, err := client.Allocations().List(qo)
+	if err != nil {
+		return fmt.Errorf("error listing allocations: %s", err.Error())
+	}
+	writeJSON(dir, "allocations.json", as)
+
+	ns, _, err := client.Nodes().List(qo)
+	if err != nil {
+		return fmt.Errorf("error listing nodes: %s", err.Error())
+	}
+	writeJSON(dir, "nodes.json", ns)
+
+	ps, _, err := client.CSIPlugins().List(qo)
+	if err != nil {
+		return fmt.Errorf("error listing plugins: %s", err.Error())
+	}
+	writeJSON(dir, "plugins.json", ps)
+
+	vs, _, err := client.CSIVolumes().List(qo)
+	if err != nil {
+		return fmt.Errorf("error listing volumes: %s", err.Error())
+	}
+	writeJSON(dir, "volumes.json", vs)
+
+	return nil
+}
+
+func writeBytes(path string, data []byte) error {
+	fh, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	_, err = fh.Write(data)
+	return err
+}
+
+func writeJSON(dir, file string, data interface{}) error {
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	file = filepath.Join(dir, file)
+	return writeBytes(file, bytes)
+}
+
+// TarCZF, like the tar command, recursively builds a gzip compressed tar archive from a
+// directory
+func TarCZF(archive string, src string) error {
+	// ensure the src actually exists before trying to tar it
+	if _, err := os.Stat(src); err != nil {
+		return fmt.Errorf("Unable to tar files - %v", err.Error())
+	}
+
+	// create the archive
+	fh, err := os.Create(archive)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	zz := gzip.NewWriter(fh)
+	defer zz.Close()
+
+	tw := tar.NewWriter(zz)
+	defer tw.Close()
+
+	// tar
+	return filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
+
+		// return on any error
+		if err != nil {
+			return err
+		}
+
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		header, err := tar.FileInfoHeader(fi, fi.Name())
+		if err != nil {
+			return err
+		}
+
+		// remove leading path to the src, so files are relative to the archive
+		header.Name = strings.TrimPrefix(strings.Replace(file, src, "", -1), string(filepath.Separator))
+
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		// copy the file contents
+		f, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(tw, f); err != nil {
+			return err
+		}
+
+		f.Close()
+
+		return nil
+	})
+}

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -1,0 +1,104 @@
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugUtils(t *testing.T) {
+	xs := argNodes("foo, bar")
+	require.Equal(t, []string{"foo", "bar"}, xs)
+
+	xs = argNodes("")
+	require.Len(t, xs, 0)
+	require.Empty(t, xs)
+}
+
+func TestDebugFails(t *testing.T) {
+	t.Parallel()
+	srv, _, _ := testServer(t, false, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &DebugCommand{Meta: Meta{Ui: ui}}
+
+	// Fails incorrect args
+	code := cmd.Run([]string{"some", "bad", "args"})
+	require.Equal(t, 1, code)
+
+	// Fails illegal node ids
+	code = cmd.Run([]string{"-node-id", "foo:bar"})
+	require.Equal(t, 1, code)
+
+	// Fails missing node ids
+	code = cmd.Run([]string{"-node-id", "abc,def"})
+	require.Equal(t, 1, code)
+
+	// Fails bad durations
+	code = cmd.Run([]string{"-duration", "foo"})
+	require.Equal(t, 1, code)
+
+	// Fails bad durations
+	code = cmd.Run([]string{"-interval", "bar"})
+	require.Equal(t, 1, code)
+
+	// Fails existing output
+	format := "2006-01-02-150405Z"
+	stamped := "nomad-debug-" + time.Now().UTC().Format(format)
+	path := filepath.Join(os.TempDir(), stamped)
+	os.MkdirAll(path, 0755)
+	defer os.Remove(path)
+	code = cmd.Run([]string{"-output", os.TempDir()})
+	require.Equal(t, 2, code)
+}
+
+func TestDebugCapturedFiles(t *testing.T) {
+	t.Parallel()
+	srv, _, _ := testServer(t, false, nil)
+	defer srv.Shutdown()
+
+	ui := new(cli.MockUi)
+	cmd := &DebugCommand{Meta: Meta{Ui: ui}}
+
+	// Calculate the output name
+	format := "2006-01-02-150405Z"
+	stamped := "nomad-debug-" + time.Now().UTC().Format(format)
+	path := filepath.Join(os.TempDir(), stamped)
+	defer os.Remove(path)
+
+	code := cmd.Run([]string{
+		"-output", os.TempDir(),
+		"-server-id", "leader",
+		"-duration", "1s",
+		"-interval", "500ms",
+	})
+	require.Equal(t, 0, code)
+
+	// Version is always captured
+	require.FileExists(t, filepath.Join(path, "version", "agent-self.json"))
+
+	// Consul and Vault are only captured if they exist
+	_, err := osStat(filepath.Join(path, "version", "consul-agent-self.json"))
+	require.Error(t, err)
+	_, err := osStat(filepath.Join(path, "version", "vault-sys-health.json"))
+	require.Error(t, err)
+
+	// Monitor files are only created when selected
+	require.FileExists(t, filepath.Join(path, "server", "leader", "monitor.log"))
+	require.FileExists(t, filepath.Join(path, "server", "leader", "profile.prof"))
+	require.FileExists(t, filepath.Join(path, "server", "leader", "trace.prof"))
+	require.FileExists(t, filepath.Join(path, "server", "leader", "goroutine.prof"))
+
+	// Multiple snapshots are collected, 00 is always created
+	require.FileExists(t, filepath.Join(path, "nomad", "00", "jobs.json"))
+	require.FileExists(t, filepath.Join(path, "nomad", "00", "nodes.json"))
+
+	// Multiple snapshots are collected, 01 requires two intervals
+	require.FileExists(t, filepath.Join(path, "nomad", "01", "jobs.json"))
+	require.FileExists(t, filepath.Join(path, "nomad", "01", "nodes.json"))
+}

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -77,7 +77,10 @@ func TestDebugCapturedFiles(t *testing.T) {
 		"-duration", "1s",
 		"-interval", "500ms",
 	})
+
+	require.Empty(t, ui.ErrorWriter.String())
 	require.Equal(t, 0, code)
+	ui.ErrorWriter.Reset()
 
 	// Version is always captured
 	require.FileExists(t, filepath.Join(path, "version", "agent-self.json"))

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -83,9 +83,9 @@ func TestDebugCapturedFiles(t *testing.T) {
 	require.FileExists(t, filepath.Join(path, "version", "agent-self.json"))
 
 	// Consul and Vault are only captured if they exist
-	_, err := osStat(filepath.Join(path, "version", "consul-agent-self.json"))
+	_, err := os.Stat(filepath.Join(path, "version", "consul-agent-self.json"))
 	require.Error(t, err)
-	_, err := osStat(filepath.Join(path, "version", "vault-sys-health.json"))
+	_, err = os.Stat(filepath.Join(path, "version", "vault-sys-health.json"))
 	require.Error(t, err)
 
 	// Monitor files are only created when selected


### PR DESCRIPTION
This implements the `nomad debug` command, which creates a local tar archive of Nomad configuration, state and logs, in a format designed to help support address customer issues.

- `debug` command
  - [x] make a tarball
  - [x] command help text
  - [x] use the monitor interface to capture DEBUG logs from nodes & servers
  - [x] query consul and vault state directly
  - [x] manifest

Part 1 of #8273 