### PR TITLE
docs: fix license command index page formatting.

### DIFF
--- a/website/pages/docs/commands/license/index.mdx
+++ b/website/pages/docs/commands/license/index.mdx
@@ -25,5 +25,5 @@ subcommands are available:
 - [`license get`][get] - Get the current license
 - [`license put`][put] - Set the current license
 
-[get]: /docs/commands/license/get `Get the current license`
-[put]: /docs/commands/license/put `Set the current license`
+[get]: /docs/commands/license/get 'Get the current license'
+[put]: /docs/commands/license/put 'Set the current license'


### PR DESCRIPTION
Current render:
![image](https://user-images.githubusercontent.com/2980562/85507809-3d660d00-b5f3-11ea-9082-e2f2461d85d9.png)
