### PR TITLE
multiregion validation fixes

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -145,6 +145,13 @@ func (s *HTTPServer) jobPlan(resp http.ResponseWriter, req *http.Request,
 		return nil, CodedError(400, "Job ID does not match")
 	}
 
+	if args.Job.Multiregion != nil && args.Job.Region != nil {
+		region := *args.Job.Region
+		if !(region == "global" || region == "") {
+			return nil, CodedError(400, "Job can't have both multiregion and region blocks")
+		}
+	}
+
 	var region *string
 
 	// Region in http request query param takes precedence over region in job hcl config


### PR DESCRIPTION
Multi-region jobs need to bypass validating counts otherwise we get spurious
warnings in `Job.Plan`. 

(Found while working on #8190)