### PR TITLE
multiregion: add support for 'job plan'

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1603,6 +1603,12 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 		return err
 	}
 
+	// Interpolate the job for this region
+	err = j.multiregionPlan(args)
+	if err != nil {
+		return err
+	}
+
 	// Get the original job
 	ws := memdb.NewWatchSet()
 	oldJob, err := snap.JobByID(ws, args.RequestNamespace(), args.Job.ID)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1604,7 +1604,7 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 	}
 
 	// Interpolate the job for this region
-	err = j.multiregionPlan(args)
+	err = j.interpolateMultiregionFields(args)
 	if err != nil {
 		return err
 	}

--- a/nomad/job_endpoint_oss.go
+++ b/nomad/job_endpoint_oss.go
@@ -14,7 +14,7 @@ func (j *Job) multiregionRegister(args *structs.JobRegisterRequest, reply *struc
 	return nil
 }
 
-// multiregionPlan interpolates a job for a specific region
-func (j *Job) multiregionPlan(args *structs.JobPlanRequest) error {
+// interpolateMultiregionFields interpolates a job for a specific region
+func (j *Job) interpolateMultiregionFields(args *structs.JobPlanRequest) error {
 	return nil
 }

--- a/nomad/job_endpoint_oss.go
+++ b/nomad/job_endpoint_oss.go
@@ -13,3 +13,8 @@ func (j *Job) enforceSubmitJob(override bool, job *structs.Job) (error, error) {
 func (j *Job) multiregionRegister(args *structs.JobRegisterRequest, reply *structs.JobRegisterResponse) error {
 	return nil
 }
+
+// multiregionPlan interpolates a job for a specific region
+func (j *Job) multiregionPlan(args *structs.JobPlanRequest) error {
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8190

Add a scatter-gather for multiregion job plans. Each region's servers
interpolate the plan locally in `Job.Plan` but don't distribute the plan as
done in `Job.Run`.

Note that it's not possible to return a usable modify index from a multiregion
plan for use with `-check-index`. Even if we were to force the modify index to
be the same at the start of `Job.Run` the index immediately drifts during each
region's deployments, depending on events local to each region. So we omit
this section of a multiregion plan.