### PR TITLE
docs: fix broken link in server config

### DIFF
--- a/website/pages/docs/configuration/server.mdx
+++ b/website/pages/docs/configuration/server.mdx
@@ -156,8 +156,8 @@ server {
   unreliable networks to wait longer before electing a new leader. The tradeoff
   when raising this value is that during network partitions or other events
   (server crash) where a leader is lost, Nomad will not elect a new leader for
-  a longer period of time than the default. The ['nomad.nomad.leader.barrier' and
-  `nomad.raft.leader.lastContact` metrics](/docs/telemetry/metrics is a good
+  a longer period of time than the default. The [`nomad.nomad.leader.barrier` and
+  `nomad.raft.leader.lastContact` metrics](/docs/telemetry/metrics) are a good
   indicator of how often leader elections occur and raft latency.
 
 - `redundancy_zone` `(string: "")` - (Enterprise-only) Specifies the redundancy


### PR DESCRIPTION
Fixes https://www.nomadproject.io/docs/configuration/server as follows:

* missing the trailing `)`
* consistency with the code span
* minor grammar fix ("is" to "are")

Before:
<img width="905" alt="Screen Shot 2020-06-24 at 11 42 48 AM" src="https://user-images.githubusercontent.com/1409219/85587604-ecb0dd00-b60f-11ea-833c-d04ac5f3de67.png">

After:
<img width="921" alt="Screen Shot 2020-06-24 at 11 43 16 AM" src="https://user-images.githubusercontent.com/1409219/85587621-f0446400-b60f-11ea-91a1-d082c98f7d46.png">

