### PR TITLE
Tweaks for algolia job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1050,7 +1050,7 @@ jobs:
     - PAGER: cat
   algolia_index:
     docker:
-    - image: node:10
+    - image: node:12
     steps:
     - checkout
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1050,15 +1050,18 @@ jobs:
     - PAGER: cat
   algolia_index:
     docker:
-    - image: circleci/buildpack-deps
-    shell: /usr/bin/env bash -euo pipefail -c
+    - image: node:10
     steps:
     - checkout
-    - setup_remote_docker
     - run:
         command: |
+          if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/nomad.git" ]; then
+            echo "Not Nomad OSS Repo, not indexing Algolia"
+            exit 0
+          fi
+
           cd website/
-          npm i
+          npm install
           node scripts/index_search_content.js
         name: Push content to Algolia Index
   test-docker:

--- a/.circleci/config/jobs/algolia_index.yml
+++ b/.circleci/config/jobs/algolia_index.yml
@@ -1,12 +1,15 @@
 docker:
-  - image: circleci/buildpack-deps
-shell: /usr/bin/env bash -euo pipefail -c
+  - image: node:10
 steps:
   - checkout
-  - setup_remote_docker
   - run:
       name: Push content to Algolia Index
       command: |
+        if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/nomad.git" ]; then
+          echo "Not Nomad OSS Repo, not indexing Algolia"
+          exit 0
+        fi
+
         cd website/
-        npm i
+        npm install
         node scripts/index_search_content.js

--- a/.circleci/config/jobs/algolia_index.yml
+++ b/.circleci/config/jobs/algolia_index.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: node:10
+  - image: node:12
 steps:
   - checkout
   - run:

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5931,6 +5931,12 @@
         }
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
     "download": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "dart-linkcheck": "^2.0.15",
     "husky": "^4.2.5",
+    "dotenv": "^8.2.0",
     "prettier": "^2.0.5"
   },
   "husky": {


### PR DESCRIPTION
Few tweaks for algolia job:
* explicitly set the node version needed
* avoid launching a docker engine
* declare `dotenv` as a dependency
* avoid running the scripts in forks repositories 