### PR TITLE
UI: Fix monitor in Safari

### DIFF
--- a/ui/app/utils/classes/stream-logger.js
+++ b/ui/app/utils/classes/stream-logger.js
@@ -89,16 +89,5 @@ export default class StreamLogger extends EmberObject.extend(AbstractLogger) {
 }
 
 StreamLogger.reopenClass({
-  isSupported: !!window.ReadableStream && !isSafari(),
+  isSupported: !!window.ReadableStream,
 });
-
-// Fetch streaming doesn't work in Safari yet despite all the primitives being in place.
-// Bug: https://bugs.webkit.org/show_bug.cgi?id=185924
-// Until this is fixed, Safari needs to be explicitly targeted for poll-based logging.
-function isSafari() {
-  const oldSafariTest = /constructor/i.test(window.HTMLElement);
-  const newSafariTest = (function(p) {
-    return p.toString() === '[object SafariRemoteNotification]';
-  })(!window['safari'] || (typeof window.safari !== 'undefined' && window.safari.pushNotification));
-  return oldSafariTest || newSafariTest;
-}


### PR DESCRIPTION
Since the beginning of http streaming in the Nomad UI, Safari has been special cased to force use of the PollLogger instead of the StreamLogger. This was because despite Safari having a `window.ReadableStream`, this didn't actually work under certain conditions related to TLS.

That was years ago, it all works now. This is good timing since as of today, the monitor API doesn't have a non-streaming interface.