### PR TITLE
UI: Make monitor log output full-width

### DIFF
--- a/ui/app/styles/core/section.scss
+++ b/ui/app/styles/core/section.scss
@@ -5,8 +5,8 @@
   &.with-headspace {
     margin-top: 1.5rem;
   }
-}
 
-.full-width-section {
-  max-width: 100%;
+  &.is-full-width {
+    max-width: 100%;
+  }
 }

--- a/ui/app/templates/allocations/allocation/task/logs.hbs
+++ b/ui/app/templates/allocations/allocation/task/logs.hbs
@@ -1,5 +1,5 @@
 {{title "Task " model.name " logs"}}
 <TaskSubnav @task={{model}} />
-<section class="section full-width-section">
+<section class="section is-full-width">
   <TaskLog data-test-task-log @allocation={{model.allocation}} @task={{model.name}} />
 </section>

--- a/ui/app/templates/clients/client/monitor.hbs
+++ b/ui/app/templates/clients/client/monitor.hbs
@@ -1,6 +1,6 @@
 {{title "Client " (or model.name model.shortId)}}
 <ClientSubnav @client={{model}} />
-<section class="section">
+<section class="section is-full-width">
   {{#if (can "read agent")}}
     <AgentMonitor
       @level={{level}}

--- a/ui/app/templates/components/fs/browser.hbs
+++ b/ui/app/templates/components/fs/browser.hbs
@@ -1,4 +1,4 @@
-<section class="section is-closer {{if isFile "full-width-section"}}">
+<section class="section is-closer {{if isFile "is-full-width"}}">
   {{#if model.isRunning}}
     {{#if isFile}}
       <Fs::File @allocation={{allocation}} @taskState={{taskState}} @file={{path}} @stat={{stat}} @class="fs-explorer">

--- a/ui/app/templates/servers/server/monitor.hbs
+++ b/ui/app/templates/servers/server/monitor.hbs
@@ -1,6 +1,6 @@
 {{title "Server " model.name}}
 <ServerSubnav @server={{model}} />
-<section class="section">
+<section class="section is-full-width">
   {{#if (can "read agent")}}
     <AgentMonitor
       @level={{level}}


### PR DESCRIPTION
It was an oversight that this wasn't full-width to begin with since the file and log views are also full-width.

![image](https://user-images.githubusercontent.com/174740/85650549-a2a11900-b65a-11ea-970d-8280df2011d7.png)

While touching this code, I also did a small CSS refactor to follow our modifier naming convention.