### PR TITLE
UI: Revert AbortController polyfill to use native AbortController on logs page

### DIFF
--- a/ui/app/components/task-log.js
+++ b/ui/app/components/task-log.js
@@ -4,9 +4,14 @@ import { action, computed } from '@ember/object';
 import RSVP from 'rsvp';
 import { logger } from 'nomad-ui/utils/classes/log';
 import timeout from 'nomad-ui/utils/timeout';
-import { AbortController } from 'fetch';
 import { classNames } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
+
+class MockAbortController {
+  abort() {
+    /* noop */
+  }
+}
 
 @classic
 @classNames('boxed-section', 'task-log')
@@ -51,7 +56,7 @@ export default class TaskLog extends Component {
     // If the log request can't settle in one second, the client
     // must be unavailable and the server should be used instead
 
-    const aborter = new AbortController();
+    const aborter = window.AbortController ? new AbortController() : new MockAbortController();
     const timing = this.useServer ? this.serverTimeout : this.clientTimeout;
 
     // Capture the state of useServer at logger create time to avoid a race


### PR DESCRIPTION
When replacing jQuery with ember-fetch, I applied the pattern of using the AbortController polyfill from ember-fetch to the task log streamer, which had its own way of mocking AbortController.

This seemed good, but it was not. Since logs use HTTP streaming and the fetch polyfill doesn't support this, logs (and the related filesystem and monitor) have to use native fetch or fallback to the inferior simple polling strategy.

The AbortController polyfill is incompatible with native fetch. Attempting to make a fetch request with a signal object from the AbortController polyfill results in an error thrown due to interface mismatch.

This reverts changes back to the native AbortController and revives task logs.

------------------

Abort behavior for task logs is already covered by an integration test, but our tests always use the fetch polyfill because it's necessary for use with Pretender. Due to this, I'm not sure how exactly we could catch this type of regression. I'm open to ideas!