### PR TITLE
UI: Fix text alignment for the "view raw file" button/link on the fs file viewer

### DIFF
--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -5,7 +5,6 @@ $button-box-shadow-standard: 0 2px 0 0 rgba($grey, 0.2);
   box-shadow: $button-box-shadow-standard;
   border: 1px solid transparent;
   text-decoration: none;
-  line-height: 1;
 
   &:hover,
   &.is-hovered {


### PR DESCRIPTION
Remove line-height override that breaks text alignment for anchors that look like buttons.

**Before**
<img alt="Screen Shot 2020-06-24 at 9 30 33 PM" src="https://user-images.githubusercontent.com/174740/85653701-3d512600-b662-11ea-8a56-62e2660b8255.png">


**After**
![image](https://user-images.githubusercontent.com/174740/85653729-45a96100-b662-11ea-827c-d7d490b5c9a1.png)
