### PR TITLE
UI: Add multiple substring highlights for search

### DIFF
--- a/ui/app/templates/components/global-search/match.hbs
+++ b/ui/app/templates/components/global-search/match.hbs
@@ -1,5 +1,5 @@
-{{#if firstIndices}}
-  <span data-test-match-substring>{{beforeHighlighted}}</span><span class='highlighted' data-test-match-substring>{{highlighted}}</span><span data-test-match-substring>{{afterHighlighted}}</span>
+{{#if substrings}}
+  {{#each substrings as |substring|}}<span class="{{if substring.isHighlighted "highlighted"}}" data-test-match-substring>{{substring.string}}</span>{{/each}}
 {{else}}
   {{label}}
 {{/if}}

--- a/ui/app/templates/components/global-search/match.hbs
+++ b/ui/app/templates/components/global-search/match.hbs
@@ -1,5 +1,5 @@
 {{#if firstIndices}}
-  {{beforeHighlighted}}<span class='highlighted'>{{highlighted}}</span>{{afterHighlighted}}
+  <span data-test-match-substring>{{beforeHighlighted}}</span><span class='highlighted' data-test-match-substring>{{highlighted}}</span><span data-test-match-substring>{{afterHighlighted}}</span>
 {{else}}
   {{label}}
 {{/if}}

--- a/ui/tests/acceptance/search-test.js
+++ b/ui/tests/acceptance/search-test.js
@@ -115,10 +115,10 @@ module('Acceptance | search', function(hooks) {
     PageLayout.navbar.search.as(search => {
       search.groups[0].as(jobs => {
         assert.equal(jobs.options[0].text, 'traefik');
-        assert.equal(jobs.options[0].highlighted, 'trae');
+        assert.equal(jobs.options[0].formattedText, '*trae*fik');
 
         assert.equal(jobs.options[1].text, 'tracking');
-        assert.equal(jobs.options[1].highlighted, 'tra');
+        assert.equal(jobs.options[1].formattedText, '*tra*cking');
       });
     });
 
@@ -126,8 +126,8 @@ module('Acceptance | search', function(hooks) {
 
     PageLayout.navbar.search.as(search => {
       search.groups[0].as(jobs => {
-        assert.equal(jobs.options[0].highlighted, 'ra');
-        assert.equal(jobs.options[1].highlighted, 'ra');
+        assert.equal(jobs.options[0].formattedText, 't*ra*efik');
+        assert.equal(jobs.options[1].formattedText, 't*ra*cking');
       });
     });
   });

--- a/ui/tests/acceptance/search-test.js
+++ b/ui/tests/acceptance/search-test.js
@@ -107,6 +107,7 @@ module('Acceptance | search', function(hooks) {
 
     server.create('job', { id: 'traefik', namespaceId: 'default' });
     server.create('job', { id: 'tracking', namespace: 'default' });
+    server.create('job', { id: 'smtp-sensor', namespaceId: 'default' });
 
     await visit('/');
 
@@ -128,6 +129,14 @@ module('Acceptance | search', function(hooks) {
       search.groups[0].as(jobs => {
         assert.equal(jobs.options[0].formattedText, 't*ra*efik');
         assert.equal(jobs.options[1].formattedText, 't*ra*cking');
+      });
+    });
+
+    await selectSearch(PageLayout.navbar.search.scope, 'sensor');
+
+    PageLayout.navbar.search.as(search => {
+      search.groups[0].as(jobs => {
+        assert.equal(jobs.options[0].formattedText, '*s*mtp-*sensor*');
       });
     });
   });

--- a/ui/tests/pages/layout.js
+++ b/ui/tests/pages/layout.js
@@ -1,4 +1,4 @@
-import { create, clickable, collection, isPresent, text } from 'ember-cli-page-object';
+import { create, clickable, collection, hasClass, isPresent, text } from 'ember-cli-page-object';
 
 export default create({
   navbar: {
@@ -23,10 +23,23 @@ export default create({
         resetScope: true,
         name: text('.ember-power-select-group-name'),
 
-        options: collection('.ember-power-select-option', {
+        options: collection('.ember-power-select-option', create({
           label: text(),
-          highlighted: text('.highlighted'),
-        }),
+
+          substrings: collection('[data-test-match-substring]', {
+            isHighlighted: hasClass('highlighted'),
+          }),
+
+          get formattedText() {
+            return this.substrings.map(string => {
+              if (string.isHighlighted) {
+                return `*${string.text}*`;
+              } else {
+                return string.text;
+              }
+            }).join('');
+          }
+        })),
       }),
 
       field: {


### PR DESCRIPTION
The fuzzy search highlighting was ignoring everything after the first
substring that was matched, this now highlights all substrings.

As @DingoEatingFuzz [pointed out](https://github.com/hashicorp/nomad/pull/8249#issuecomment-649669269). Example:

<img width="432" alt="image" src="https://user-images.githubusercontent.com/43280/85778256-0160a400-b6e8-11ea-825a-ec2829423dba.png">

Fuse actually returns multiple substrings _and_ matches and this still only uses the first match. I haven’t looked deeply into it but I suspect other matches are if another value being searched had a match as well (id vs name for instance). So there’s possibly room for further improvement here.