### PR TITLE
command: correctly display host IP in ports of alloc status output

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -482,6 +482,14 @@ type AllocatedTaskResources struct {
 type AllocatedSharedResources struct {
 	DiskMB   int64
 	Networks []*NetworkResource
+	Ports    []PortMapping
+}
+
+type PortMapping struct {
+	Label  string
+	Value  int
+	To     int
+	HostIP string
 }
 
 type AllocatedCpuResources struct {

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -326,20 +326,25 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 
 func formatAllocNetworkInfo(alloc *api.Allocation) string {
 	nw := alloc.AllocatedResources.Shared.Networks[0]
-	addrs := make([]string, len(nw.DynamicPorts)+len(nw.ReservedPorts)+1)
-	addrs[0] = "Label|Dynamic|Address"
-	portFmt := func(port *api.Port, dyn string) string {
-		s := fmt.Sprintf("%s|%s|%s:%d", port.Label, dyn, nw.IP, port.Value)
-		if port.To > 0 {
-			s += fmt.Sprintf(" -> %d", port.To)
+	addrs := []string{"Label|Dynamic|Address"}
+	portFmt := func(label string, value, to int, hostIP, dyn string) string {
+		s := fmt.Sprintf("%s|%s|%s:%d", label, dyn, hostIP, value)
+		if to > 0 {
+			s += fmt.Sprintf(" -> %d", to)
 		}
 		return s
 	}
-	for idx, port := range nw.DynamicPorts {
-		addrs[idx+1] = portFmt(&port, "yes")
-	}
-	for idx, port := range nw.ReservedPorts {
-		addrs[idx+1+len(nw.DynamicPorts)] = portFmt(&port, "yes")
+	if len(alloc.AllocatedResources.Shared.Ports) > 0 {
+		for _, port := range alloc.AllocatedResources.Shared.Ports {
+			addrs = append(addrs, portFmt("*"+port.Label, port.Value, port.To, port.HostIP, "yes"))
+		}
+	} else {
+		for _, port := range nw.DynamicPorts {
+			addrs = append(addrs, portFmt(port.Label, port.Value, port.To, nw.IP, "yes"))
+		}
+		for _, port := range nw.ReservedPorts {
+			addrs = append(addrs, portFmt(port.Label, port.Value, port.To, nw.IP, "yes"))
+		}
 	}
 
 	var mode string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3420,6 +3420,7 @@ func (a AllocatedSharedResources) Copy() AllocatedSharedResources {
 	return AllocatedSharedResources{
 		Networks: a.Networks.Copy(),
 		DiskMB:   a.DiskMB,
+		Ports:    a.Ports,
 	}
 }
 

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -381,7 +381,11 @@ func (c *NetworkChecker) hasNetwork(option *structs.Node) bool {
 	}
 
 	for _, nw := range option.NodeResources.Networks {
-		if nw.Mode == c.networkMode {
+		mode := nw.Mode
+		if mode == "" {
+			mode = "host"
+		}
+		if mode == c.networkMode {
 			return true
 		}
 	}

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -286,6 +286,7 @@ OUTER:
 			// Update the network ask to the offer
 			nwRes := structs.AllocatedPortsToNetworkResouce(ask, offer)
 			total.Shared.Networks = []*structs.NetworkResource{nwRes}
+			total.Shared.Ports = offer
 			option.AllocResources = &structs.AllocatedSharedResources{
 				Networks: []*structs.NetworkResource{nwRes},
 				DiskMB:   int64(iter.taskGroup.EphemeralDisk.SizeMB),

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -1893,6 +1893,19 @@ func TestSystemSched_Preemption(t *testing.T) {
 					MBits:  1000,
 				},
 			},
+			NodeNetworks: []*structs.NodeNetworkResource{
+				{
+					Mode:   "host",
+					Device: "eth0",
+					Addresses: []structs.NodeNetworkAddress{
+						{
+							Family:  structs.NodeNetworkAF_IPv4,
+							Alias:   "default",
+							Address: "192.168.0.100",
+						},
+					},
+				},
+			},
 		}
 		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
 		nodes = append(nodes, node)

--- a/vendor/github.com/hashicorp/nomad/api/allocations.go
+++ b/vendor/github.com/hashicorp/nomad/api/allocations.go
@@ -482,6 +482,14 @@ type AllocatedTaskResources struct {
 type AllocatedSharedResources struct {
 	DiskMB   int64
 	Networks []*NetworkResource
+	Ports    []PortMapping
+}
+
+type PortMapping struct {
+	Label  string
+	Value  int
+	To     int
+	HostIP string
 }
 
 type AllocatedCpuResources struct {


### PR DESCRIPTION
This PR fixes a bug where the Host IP of a mapped port was not displaying in the API or cli output.