### PR TITLE
Add cpuset_cpus to docker driver.

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -300,6 +300,7 @@ var (
 		"cap_add":        hclspec.NewAttr("cap_add", "list(string)", false),
 		"cap_drop":       hclspec.NewAttr("cap_drop", "list(string)", false),
 		"command":        hclspec.NewAttr("command", "string", false),
+		"cpuset_cpus":    hclspec.NewAttr("cpuset_cpus", "string", false),
 		"cpu_hard_limit": hclspec.NewAttr("cpu_hard_limit", "bool", false),
 		"cpu_cfs_period": hclspec.NewDefault(
 			hclspec.NewAttr("cpu_cfs_period", "number", false),
@@ -407,6 +408,7 @@ type TaskConfig struct {
 	Command           string             `codec:"command"`
 	CPUCFSPeriod      int64              `codec:"cpu_cfs_period"`
 	CPUHardLimit      bool               `codec:"cpu_hard_limit"`
+	CPUSetCPUs        string             `codec:"cpuset_cpus"`
 	Devices           []DockerDevice     `codec:"devices"`
 	DNSSearchDomains  []string           `codec:"dns_search_domains"`
 	DNSOptions        []string           `codec:"dns_options"`

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -826,7 +826,6 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	// This translates to docker create/run --cpuset-cpus option.
 	// --cpuset-cpus limit the specific CPUs or cores a container can use.
 	if driverConfig.CPUSetCPUs != "" {
-		logger.Debug(fmt.Sprintf("Setting CPUSetCPUs to %s", driverConfig.CPUSetCPUs))
 		hostConfig.CPUSetCPUs = driverConfig.CPUSetCPUs
 	}
 

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -823,6 +823,13 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		Runtime: containerRuntime,
 	}
 
+	// This translates to docker create/run --cpuset-cpus option.
+	// --cpuset-cpus limit the specific CPUs or cores a container can use.
+	if driverConfig.CPUSetCPUs != "" {
+		logger.Debug(fmt.Sprintf("Setting CPUSetCPUs to %s", driverConfig.CPUSetCPUs))
+		hostConfig.CPUSetCPUs = driverConfig.CPUSetCPUs
+	}
+
 	// Calculate CPU Quota
 	// cfs_quota_us is the time per core, so we must
 	// multiply the time by the number of cores available

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1381,6 +1381,53 @@ func TestDockerDriver_DNS(t *testing.T) {
 
 }
 
+func TestDockerDriver_CPUSetCPUs(t *testing.T) {
+	if !tu.IsCI() {
+		t.Parallel()
+	}
+	testutil.DockerCompatible(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support CPUSetCPUs.")
+	}
+
+	testCases := []struct {
+		Name       string
+		CPUSetCPUs string
+	}{
+		{
+			Name:       "Single CPU",
+			CPUSetCPUs: "0",
+		},
+		{
+			Name:       "Comma separated list of CPUs",
+			CPUSetCPUs: "0,1,2",
+		},
+		{
+			Name:       "Range of CPUs",
+			CPUSetCPUs: "0-3",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			task, cfg, ports := dockerTask(t)
+			defer freeport.Return(ports)
+
+			cfg.CPUSetCPUs = testCase.CPUSetCPUs
+			require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
+
+			client, d, handle, cleanup := dockerSetup(t, task, nil)
+			defer cleanup()
+			require.NoError(t, d.WaitUntilStarted(task.ID, 5*time.Second))
+
+			container, err := client.InspectContainer(handle.containerID)
+			require.NoError(t, err)
+
+			require.Equal(t, cfg.CPUSetCPUs, container.HostConfig.CPUSetCPUs)
+		})
+	}
+}
+
 func TestDockerDriver_MemoryHardLimit(t *testing.T) {
 	if !tu.IsCI() {
 		t.Parallel()

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1400,11 +1400,11 @@ func TestDockerDriver_CPUSetCPUs(t *testing.T) {
 		},
 		{
 			Name:       "Comma separated list of CPUs",
-			CPUSetCPUs: "0,1,2",
+			CPUSetCPUs: "0,1",
 		},
 		{
 			Name:       "Range of CPUs",
-			CPUSetCPUs: "0-3",
+			CPUSetCPUs: "0-1",
 		},
 	}
 

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -78,8 +78,13 @@ The `docker` driver supports the following configuration in the job spec. Only
   }
   ```
 - `cpuset_cpus` - (Optional) CPUs in which to allow execution (0-3, 0,1).
+Limit the specific CPUs or cores a container can use. A comma-separated list
+or hyphen-separated range of CPUs a container can use, if you have more than
+one CPU. The first CPU is numbered 0. A valid value might be 0-3 (to use the
+first, second, third, and fourth CPU) or 1,3 (to use the second and fourth CPU).
 
-Limit the specific CPUs or cores a container can use. A comma-separated list or hyphen-separated range of CPUs a container can use, if you have more than one CPU. The first CPU is numbered 0. A valid value might be 0-3 (to use the first, second, third, and fourth CPU) or 1,3 (to use the second and fourth CPU).
+Note: `cpuset_cpus` pins the workload to the CPUs but doesn't give the workload
+exclusive access to those CPUs.
 
   ```hcl
   config {

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -77,6 +77,15 @@ The `docker` driver supports the following configuration in the job spec. Only
     command = "my-command"
   }
   ```
+- `cpuset_cpus` - (Optional) CPUs in which to allow execution (0-3, 0,1).
+
+Limit the specific CPUs or cores a container can use. A comma-separated list or hyphen-separated range of CPUs a container can use, if you have more than one CPU. The first CPU is numbered 0. A valid value might be 0-3 (to use the first, second, third, and fourth CPU) or 1,3 (to use the second and fourth CPU).
+
+  ```hcl
+  config {
+    cpuset_cpus = "0-3"
+  }
+  ```
 
 - `dns_search_domains` - (Optional) A list of DNS search domains for the container
   to use.


### PR DESCRIPTION
Fixes #2303 

We have an internal HPC customer who could also benefit from the ability to pin CPUs to a docker container.

It would be ideal to have:

1) `--cpuset-cpus` which will allow pinning CPUs to a docker container.
2) If the user tries to pin the same CPU (e.g. CPU 0) to another docker container, it should error out (if on the same node) OR
schedule on CPU 0 on a different node.

Currently (2) is not supported by docker. This PR only addresses (1).
As a follow-up, we can try nomad docker driver to do some bookkeeping, and achieve (2).