### PR TITLE
csi: add -force flag to volume deregister

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+	"net/url"
 	"sort"
 	"time"
 )
@@ -53,8 +55,8 @@ func (v *CSIVolumes) Register(vol *CSIVolume, w *WriteOptions) (*WriteMeta, erro
 	return meta, err
 }
 
-func (v *CSIVolumes) Deregister(id string, w *WriteOptions) error {
-	_, err := v.client.delete("/v1/volume/csi/"+id, nil, w)
+func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?purge=%t", url.PathEscape(id), force), nil, w)
 	return err
 }
 

--- a/api/csi_test.go
+++ b/api/csi_test.go
@@ -86,7 +86,7 @@ func TestCSIVolumes_CRUD(t *testing.T) {
 	require.Equal(t, "bar", vol.Topologies[0].Segments["foo"])
 
 	// Deregister the volume
-	err = v.Deregister(id, wpts)
+	err = v.Deregister(id, true, wpts)
 	require.NoError(t, err)
 
 	// Successful empty result

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -122,8 +123,19 @@ func (s *HTTPServer) csiVolumeDelete(id string, resp http.ResponseWriter, req *h
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
+	raw := req.URL.Query().Get("force")
+	var force bool
+	if raw != "" {
+		var err error
+		force, err = strconv.ParseBool(raw)
+		if err != nil {
+			return nil, CodedError(400, "invalid force value")
+		}
+	}
+
 	args := structs.CSIVolumeDeregisterRequest{
 		VolumeIDs: []string{id},
+		Force:     force,
 	}
 	s.parseWriteRequest(req, &args.WriteRequest)
 

--- a/e2e/csi/csi.go
+++ b/e2e/csi/csi.go
@@ -221,7 +221,7 @@ func (tc *CSIVolumesTest) AfterEach(f *framework.F) {
 	}
 	// Deregister all volumes in test
 	for _, id := range tc.volumeIDs {
-		nomadClient.CSIVolumes().Deregister(id, nil)
+		nomadClient.CSIVolumes().Deregister(id, true, nil)
 	}
 	// Deregister all plugin jobs in test
 	for _, id := range tc.pluginJobIDs {

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1154,7 +1154,7 @@ func (n *nomadFSM) applyCSIVolumeDeregister(buf []byte, index uint64) interface{
 	}
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_csi_volume_deregister"}, time.Now())
 
-	if err := n.state.CSIVolumeDeregister(index, req.RequestNamespace(), req.VolumeIDs); err != nil {
+	if err := n.state.CSIVolumeDeregister(index, req.RequestNamespace(), req.VolumeIDs, req.Force); err != nil {
 		n.logger.Error("CSIVolumeDeregister failed", "error", err)
 		return err
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2991,7 +2991,12 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	require.Error(t, err, fmt.Sprintf("volume exists: %s", vol0))
 	// as is deregistration
 	index++
-	err = state.CSIVolumeDeregister(index, ns, []string{vol0})
+	err = state.CSIVolumeDeregister(index, ns, []string{vol0}, false)
+	require.Error(t, err, fmt.Sprintf("volume in use: %s", vol0))
+
+	// even if forced, because we have a non-terminal claim
+	index++
+	err = state.CSIVolumeDeregister(index, ns, []string{vol0}, true)
 	require.Error(t, err, fmt.Sprintf("volume in use: %s", vol0))
 
 	// release claims to unblock deregister
@@ -3006,7 +3011,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	require.NoError(t, err)
 
 	index++
-	err = state.CSIVolumeDeregister(index, ns, []string{vol0})
+	err = state.CSIVolumeDeregister(index, ns, []string{vol0}, false)
 	require.NoError(t, err)
 
 	// List, now omitting the deregistered volume

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -599,6 +599,7 @@ type CSIVolumeRegisterResponse struct {
 
 type CSIVolumeDeregisterRequest struct {
 	VolumeIDs []string
+	Force     bool
 	WriteRequest
 }
 

--- a/nomad/volumewatcher/volumes_watcher_test.go
+++ b/nomad/volumewatcher/volumes_watcher_test.go
@@ -284,7 +284,7 @@ func TestVolumeWatch_RegisterDeregister(t *testing.T) {
 
 	// deregistering the volume doesn't cause an update that triggers
 	// a watcher; we'll clean up this watcher in a GC later
-	err = srv.State().CSIVolumeDeregister(index, vol.Namespace, []string{vol.ID})
+	err = srv.State().CSIVolumeDeregister(index, vol.Namespace, []string{vol.ID}, false)
 	require.NoError(err)
 	require.Equal(1, len(watcher.watchers))
 	require.False(watcher.watchers[vol.ID+vol.Namespace].isRunning())

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+	"net/url"
 	"sort"
 	"time"
 )
@@ -53,8 +55,8 @@ func (v *CSIVolumes) Register(vol *CSIVolume, w *WriteOptions) (*WriteMeta, erro
 	return meta, err
 }
 
-func (v *CSIVolumes) Deregister(id string, w *WriteOptions) error {
-	_, err := v.client.delete("/v1/volume/csi/"+id, nil, w)
+func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?purge=%t", url.PathEscape(id), force), nil, w)
 	return err
 }
 

--- a/website/pages/api-docs/volumes.mdx
+++ b/website/pages/api-docs/volumes.mdx
@@ -318,11 +318,16 @@ The table below shows this endpoint's support for
   volume. This must be the full ID. This is specified as part of the
   path.
 
+- `force` `(bool: false)`- Force deregistration of the volume and immediately
+  drop claims for terminal allocations. Returns an error if the volume has
+  running allocations. This does not detach the volume from client nodes.
+  This is specified as a query string parameter.
+
 ### Sample Request
 
 ```shell-session
 $ curl \
     --request DELETE \
     --data @payload.json \
-    https://localhost:4646/v1/volume/csi/volume-id1
+    https://localhost:4646/v1/volume/csi/volume-id1?force=false
 ```


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8251

The `nomad volume deregister` command currently returns an error if the volume has any claims, but in cases where the claims can't be dropped because of plugin errors, providing a `-force` flag gives the operator an escape hatch.

If the volume has no allocations or if they are all terminal, this flag deletes the volume from the state store, immediately and implicitly dropping all claims without further CSI RPCs. Note that this will not also unmount/detach the volume, which we'll make the responsibility of a separate `nomad volume detach` command (see #8252)