### PR TITLE
Cleanup for command package tests

### DIFF
--- a/command/acl_policy_apply_test.go
+++ b/command/acl_policy_apply_test.go
@@ -42,13 +42,11 @@ func TestACLPolicyApplyCommand(t *testing.T) {
 	assert.Nil(err)
 
 	// Attempt to apply a policy without a valid management token
-	os.Setenv("NOMAD_TOKEN", "foo")
-	code := cmd.Run([]string{"-address=" + url, "test-policy", f.Name()})
+	code := cmd.Run([]string{"-address=" + url, "-token=foo", "test-policy", f.Name()})
 	assert.Equal(1, code)
 
 	// Apply a policy with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
-	code = cmd.Run([]string{"-address=" + url, "test-policy", f.Name()})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, "test-policy", f.Name()})
 	assert.Equal(0, code)
 
 	// Check the output

--- a/command/acl_policy_delete_test.go
+++ b/command/acl_policy_delete_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -42,13 +41,11 @@ func TestACLPolicyDeleteCommand(t *testing.T) {
 
 	// Delete the policy without a valid token fails
 	invalidToken := mock.ACLToken()
-	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
-	code := cmd.Run([]string{"-address=" + url, policy.Name})
+	code := cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID, policy.Name})
 	assert.Equal(1, code)
 
 	// Delete the policy with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
-	code = cmd.Run([]string{"-address=" + url, policy.Name})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, policy.Name})
 	assert.Equal(0, code)
 
 	// Check the output

--- a/command/acl_policy_info_test.go
+++ b/command/acl_policy_info_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -40,13 +39,11 @@ func TestACLPolicyInfoCommand(t *testing.T) {
 
 	// Attempt to apply a policy without a valid management token
 	invalidToken := mock.ACLToken()
-	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
-	code := cmd.Run([]string{"-address=" + url, policy.Name})
+	code := cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID, policy.Name})
 	assert.Equal(1, code)
 
 	// Apply a policy with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
-	code = cmd.Run([]string{"-address=" + url, policy.Name})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, policy.Name})
 	assert.Equal(0, code)
 
 	// Check the output

--- a/command/acl_token_create_test.go
+++ b/command/acl_token_create_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -28,13 +27,11 @@ func TestACLTokenCreateCommand(t *testing.T) {
 	cmd := &ACLTokenCreateCommand{Meta: Meta{Ui: ui, flagAddress: url}}
 
 	// Request to create a new token without providing a valid management token
-	os.Setenv("NOMAD_TOKEN", "foo")
-	code := cmd.Run([]string{"-address=" + url, "-policy=foo", "-type=client"})
+	code := cmd.Run([]string{"-address=" + url, "-token=foo", "-policy=foo", "-type=client"})
 	assert.Equal(1, code)
 
 	// Request to create a new token with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
-	code = cmd.Run([]string{"-address=" + url, "-policy=foo", "-type=client"})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, "-policy=foo", "-type=client"})
 	assert.Equal(0, code)
 
 	// Check the output

--- a/command/acl_token_delete_test.go
+++ b/command/acl_token_delete_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -40,14 +39,12 @@ func TestACLTokenDeleteCommand_ViaEnvVariable(t *testing.T) {
 
 	// Attempt to delete a token without providing a valid token with delete
 	// permissions
-	os.Setenv("NOMAD_TOKEN", "foo")
-	code := cmd.Run([]string{"-address=" + url, mockToken.AccessorID})
+	code := cmd.Run([]string{"-address=" + url, "-token=foo", mockToken.AccessorID})
 	assert.Equal(1, code)
 
 	// Delete a token using a valid management token set via an environment
 	// variable
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
-	code = cmd.Run([]string{"-address=" + url, mockToken.AccessorID})
+	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, mockToken.AccessorID})
 	assert.Equal(0, code)
 
 	// Check the output

--- a/command/acl_token_info_test.go
+++ b/command/acl_token_info_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestACLTokenInfoCommand_ViaEnvVar(t *testing.T) {
+	defer os.Setenv("NOMAD_TOKEN", os.Getenv("NOMAD_TOKEN"))
+
 	assert := assert.New(t)
 	t.Parallel()
 	config := func(c *agent.Config) {

--- a/command/acl_token_self_test.go
+++ b/command/acl_token_self_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestACLTokenSelfCommand_ViaEnvVar(t *testing.T) {
+	defer os.Setenv("NOMAD_TOKEN", os.Getenv("NOMAD_TOKEN"))
+
 	assert := assert.New(t)
 	t.Parallel()
 	config := func(c *agent.Config) {

--- a/command/job_plan_test.go
+++ b/command/job_plan_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -21,13 +20,13 @@ func TestPlanCommand_Implements(t *testing.T) {
 
 func TestPlanCommand_Fails(t *testing.T) {
 	t.Parallel()
-	ui := new(cli.MockUi)
-	cmd := &JobPlanCommand{Meta: Meta{Ui: ui}}
 
 	// Create a server
 	s := testutil.NewTestServer(t, nil)
 	defer s.Stop()
-	os.Setenv("NOMAD_ADDR", fmt.Sprintf("http://%s", s.HTTPAddr))
+
+	ui := new(cli.MockUi)
+	cmd := &JobPlanCommand{Meta: Meta{Ui: ui, flagAddress: "http://" + s.HTTPAddr}}
 
 	// Fails on misuse
 	if code := cmd.Run([]string{"some", "bad", "args"}); code != 255 {

--- a/command/job_run_test.go
+++ b/command/job_run_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -54,13 +53,13 @@ job "job1" {
 
 func TestRunCommand_Fails(t *testing.T) {
 	t.Parallel()
-	ui := new(cli.MockUi)
-	cmd := &JobRunCommand{Meta: Meta{Ui: ui}}
 
 	// Create a server
 	s := testutil.NewTestServer(t, nil)
 	defer s.Stop()
-	os.Setenv("NOMAD_ADDR", fmt.Sprintf("http://%s", s.HTTPAddr))
+
+	ui := new(cli.MockUi)
+	cmd := &JobRunCommand{Meta: Meta{Ui: ui, flagAddress: "http://" + s.HTTPAddr}}
 
 	// Fails on misuse
 	if code := cmd.Run([]string{"some", "bad", "args"}); code != 1 {

--- a/command/job_validate_test.go
+++ b/command/job_validate_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -18,13 +17,12 @@ func TestValidateCommand_Implements(t *testing.T) {
 
 func TestValidateCommand(t *testing.T) {
 	t.Parallel()
-	ui := new(cli.MockUi)
-	cmd := &JobValidateCommand{Meta: Meta{Ui: ui}}
-
 	// Create a server
 	s := testutil.NewTestServer(t, nil)
 	defer s.Stop()
-	os.Setenv("NOMAD_ADDR", fmt.Sprintf("http://%s", s.HTTPAddr))
+
+	ui := new(cli.MockUi)
+	cmd := &JobValidateCommand{Meta: Meta{Ui: ui, flagAddress: "http://" + s.HTTPAddr}}
 
 	fh, err := ioutil.TempFile("", "nomad")
 	if err != nil {
@@ -122,15 +120,15 @@ func TestValidateCommand_From_STDIN(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	ui := new(cli.MockUi)
-	cmd := &JobValidateCommand{
-		Meta:      Meta{Ui: ui},
-		JobGetter: JobGetter{testStdin: stdinR},
-	}
 	// Create a server
 	s := testutil.NewTestServer(t, nil)
 	defer s.Stop()
-	os.Setenv("NOMAD_ADDR", fmt.Sprintf("http://%s", s.HTTPAddr))
+
+	ui := new(cli.MockUi)
+	cmd := &JobValidateCommand{
+		Meta:      Meta{Ui: ui, flagAddress: "http://" + s.HTTPAddr},
+		JobGetter: JobGetter{testStdin: stdinR},
+	}
 
 	go func() {
 		stdinW.WriteString(`

--- a/command/server_members_test.go
+++ b/command/server_members_test.go
@@ -88,7 +88,7 @@ func TestServerMembersCommand_MultiRegion_Leave(t *testing.T) {
 	}
 
 	srv2, _, _ := testServer(t, false, config2)
-	defer srv1.Shutdown()
+	defer srv2.Shutdown()
 
 	// Join with srv1
 	addr := fmt.Sprintf("127.0.0.1:%d",

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -17,6 +17,7 @@ func testServer(t *testing.T, runClient bool, cb func(*agent.Config)) (*agent.Te
 			cb(config)
 		}
 	})
+	t.Cleanup(func() { a.Shutdown() })
 
 	c := a.Client()
 	return a, c, a.HTTPAddr()


### PR DESCRIPTION
Some clean up to avoid inter-test interference - mostly by avoiding setting env-vars and ensuring that test servers get shutdown.