### PR TITLE
tests: non-CAS should be updated

### DIFF
--- a/internal/testing/apitests/operator_test.go
+++ b/internal/testing/apitests/operator_test.go
@@ -36,7 +36,8 @@ func TestAPI_OperatorSchedulerGetSetConfiguration(t *testing.T) {
 	resp, wm, err := operator.SchedulerSetConfiguration(newConf, nil)
 	require.Nil(err)
 	require.NotZero(wm.LastIndex)
-	require.False(resp.Updated)
+	// non CAS requests should update on success
+	require.True(resp.Updated)
 
 	config, _, err = operator.SchedulerGetConfiguration(nil)
 	require.Nil(err)


### PR DESCRIPTION
Fix for a failing test as a result https://github.com/hashicorp/nomad/pull/8017 - I missed that it was failing :(.