### PR TITLE
docs: fix typo in upgrade instructions

### DIFF
--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -34,7 +34,7 @@ the following to the nomad client config file:
 ```hcl
 plugin "docker" {
   config {
-    volume {
+    volumes {
       enabled = true
     }
   }


### PR DESCRIPTION
The suggested plugin configuration to re-enable Docker volumes was erroneously using the singlular `volume` instead of the correct `volumes`, making the client fail to parse the configuration and causing it not to start.