### PR TITLE
[docs] Another missing redirect

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -200,6 +200,7 @@
 /docs/jobspec/servicediscovery                /docs/job-specification/service 301!
 /docs/jobspec/networking.html                 /docs/job-specification/network 301!
 /docs/jobspec/networking                      /docs/job-specification/network 301!
+/docs/job-specification/index.html            /docs/job-specification 301!
 /docs/cluster/automatic.html                  https://learn.hashicorp.com/nomad/operating-nomad/clustering 301!
 /docs/cluster/automatic                       https://learn.hashicorp.com/nomad/operating-nomad/clustering 301!
 /docs/cluster/manual.html                     https://learn.hashicorp.com/nomad/operating-nomad/clustering 301!


### PR DESCRIPTION
https://deploy-preview-8308--nomad-website.netlify.app/docs/job-specification/index.html now redirects to job specification top page.