### PR TITLE
allocrunner: terminate sidecars in the end

### DIFF
--- a/client/allocrunner/task_hook_coordinator.go
+++ b/client/allocrunner/task_hook_coordinator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/taskrunner"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -107,4 +108,28 @@ func (c *taskHookCoordinator) taskStateUpdated(states map[string]*structs.TaskSt
 	if !c.hasPrestartTasks() {
 		c.mainTaskCtxCancel()
 	}
+}
+
+// hasNonSidecarTasks returns false if all the passed tasks are sidecar tasks
+func hasNonSidecarTasks(tasks []*taskrunner.TaskRunner) bool {
+	for _, tr := range tasks {
+		lc := tr.Task().Lifecycle
+		if lc == nil || !lc.Sidecar {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasSidecarTasks returns true if all the passed tasks are sidecar tasks
+func hasSidecarTasks(tasks map[string]*taskrunner.TaskRunner) bool {
+	for _, tr := range tasks {
+		lc := tr.Task().Lifecycle
+		if lc != nil && lc.Sidecar {
+			return true
+		}
+	}
+
+	return false
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6996,6 +6996,9 @@ const (
 	// TaskLeaderDead indicates that the leader task within the has finished.
 	TaskLeaderDead = "Leader Task Dead"
 
+	// TaskMainDead indicates that the main tasks have dead
+	TaskMainDead = "Main Tasks Dead"
+
 	// TaskHookFailed indicates that one of the hooks for a task failed.
 	TaskHookFailed = "Task hook failed"
 
@@ -7217,6 +7220,8 @@ func (event *TaskEvent) PopulateEventDisplayMessage() {
 		desc = event.DriverMessage
 	case TaskLeaderDead:
 		desc = "Leader Task in Group dead"
+	case TaskMainDead:
+		desc = "Main tasks in the group died"
 	default:
 		desc = event.Message
 	}


### PR DESCRIPTION
This fixes a bug where a batch allocation fails to complete if it has
sidecars.

If the only remaining running tasks in an allocations are sidecars - we
must kill them and mark the allocation as complete.

I attempt to keep overhead minimal in the typical case where sidecars aren't used.

Fixes https://github.com/hashicorp/nomad/issues/8165 