### PR TITLE
removes nvidia import from docker test

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -17,7 +17,6 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/testutil"
-	"github.com/hashicorp/nomad/devices/gpu/nvidia"
 	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclspecutils"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
@@ -959,7 +958,7 @@ func TestDockerDriver_CreateContainerConfig_RuntimeConflict(t *testing.T) {
 
 	task, cfg, ports := dockerTask(t)
 	defer freeport.Return(ports)
-	task.DeviceEnv[nvidia.NvidiaVisibleDevices] = "GPU_UUID_1"
+	task.DeviceEnv["NVIDIA_VISIBLE_DEVICES"] = "GPU_UUID_1"
 
 	require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
@@ -1202,7 +1201,7 @@ func TestDockerDriver_CreateContainerConfigWithRuntimes(t *testing.T) {
 			driver.gpuRuntime = testCase.gpuRuntimeSet
 			driver.config.GPURuntimeName = testCase.expectedRuntime
 			if testCase.nvidiaDevicesProvided {
-				task.DeviceEnv[nvidia.NvidiaVisibleDevices] = "GPU_UUID_1"
+				task.DeviceEnv["NVIDIA_VISIBLE_DEVICES"] = "GPU_UUID_1"
 			}
 
 			c, err := driver.createContainerConfig(task, cfg, "org/repo:0.1")


### PR DESCRIPTION
swaps out constant with string value to make nomad-driver-podman and other go mod projects that need to import nomad have an easier time. Ultimately we should break out and define go modules for these different sub components but for now just decreasing the surface area of imports brought on by the docker driver

Prior to this running `go mod tidy` would lead to things like the following
```
github.com/hashicorp/nomad-driver-podman imports
        github.com/hashicorp/nomad/helper/pluginutils/hclutils tested by
        github.com/hashicorp/nomad/helper/pluginutils/hclutils.test imports
        github.com/hashicorp/nomad/drivers/docker tested by
        github.com/hashicorp/nomad/drivers/docker.test imports
        github.com/hashicorp/nomad/devices/gpu/nvidia imports
        github.com/hashicorp/nomad/devices/gpu/nvidia/nvml imports
        github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml: no matching versions for query "latest"
```