### PR TITLE
UI: Change back to released Ember Power Select

### DIFF
--- a/ui/app/components/global-search/control.js
+++ b/ui/app/components/global-search/control.js
@@ -125,7 +125,7 @@ export default class GlobalSearchControl extends Component {
   onCloseEvent(select, event) {
     if (event.key === 'Escape') {
       run.next(() => {
-        this.select.actions.setIsActive(false);
+        this.element.querySelector('.ember-power-select-trigger').blur();
       });
     }
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -87,7 +87,7 @@
     "ember-moment": "^7.8.1",
     "ember-overridable-computed": "^1.0.0",
     "ember-page-title": "^5.0.2",
-    "ember-power-select": "backspace/ember-power-select#setIsActiveAPI",
+    "ember-power-select": "^3.0.4",
     "ember-qunit": "^4.4.1",
     "ember-qunit-nice-errors": "^1.2.0",
     "ember-resolver": "^5.0.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2053,7 +2053,7 @@
     ember-cli-typescript "^2.0.2"
     heimdalljs "^0.3.0"
 
-"@ember-decorators/component@^6.0.0", "@ember-decorators/component@^6.1.0", "@ember-decorators/component@^6.1.1":
+"@ember-decorators/component@^6.1.0", "@ember-decorators/component@^6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@ember-decorators/component/-/component-6.1.1.tgz#b360dc4fa8e576ee1c840879399ef1745fd96e06"
   integrity sha512-Cj8tY/c0MC/rsipqsiWLh3YVN72DK92edPYamD/HzvftwzC6oDwawWk8RmStiBnG9PG/vntAt41l3S7HSSA+1Q==
@@ -7473,7 +7473,7 @@ ember-auto-import@^1.2.19, ember-auto-import@^1.2.21:
     walk-sync "^0.3.3"
     webpack "~4.28"
 
-ember-basic-dropdown@^2.0.0:
+ember-basic-dropdown@^2.0.13:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-2.0.15.tgz#f86600cfa22ff67de6599fcfb701ad851cc3c6a0"
   integrity sha512-gRUCoFLZJ+qu758xDZpfE20LtBRRZWOShtGrPPd18iuseK+6SLkM/uzsL+nANQp3F8hD9kW+aLjsK7E8Khd2Wg==
@@ -8331,13 +8331,14 @@ ember-page-title@^5.0.2:
     ember-cli-htmlbars "^3.0.1"
     ember-copy "^1.0.0"
 
-ember-power-select@backspace/ember-power-select#setIsActiveAPI:
-  version "3.0.3"
-  resolved "https://codeload.github.com/backspace/ember-power-select/tar.gz/6846232f09e9b42d435162134e9055028e0cff8b"
+ember-power-select@^3.0.4:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-3.0.6.tgz#97dcbaf04e6afd9bd4c75cbb150c3a8d5fe50fec"
+  integrity sha512-osS+fbwfaxPo5RCCKDOWzJfaNc+toMmg3MMGmLz3h73Uqd3burRSUBo3DAkEHyYVHCy+oMas4+eZtRcjUrLWjg==
   dependencies:
-    "@ember-decorators/component" "^6.0.0"
-    ember-basic-dropdown "^2.0.0"
-    ember-cli-babel "^7.8.0"
+    "@ember-decorators/component" "^6.1.0"
+    ember-basic-dropdown "^2.0.13"
+    ember-cli-babel "^7.11.0"
     ember-cli-htmlbars "^3.1.0"
     ember-concurrency "^1.0.0"
     ember-text-measurer "^0.5.0"


### PR DESCRIPTION
Thanks to @cibernox’s isActive clarification in
cibernox/ember-power-select#1374, this replaces the use
of a hacked Power Select API with a deliberate blurring
of the trigger element, which is equivalent to setting
the element to inactive.