### PR TITLE
UI: Fix layering so logo is clickable

### DIFF
--- a/ui/app/styles/core/navbar.scss
+++ b/ui/app/styles/core/navbar.scss
@@ -41,6 +41,10 @@
       }
     }
 
+    .navbar-brand {
+      z-index: $z-gutter;
+    }
+
     .navbar-end {
       display: flex;
       align-items: stretch;


### PR DESCRIPTION
The CSS I added in #8249 to make the search be properly
centred also made the logo unclickable as it was hidden
behind the centred element! This makes the logo stay
above the search container.