### PR TITLE
ar: support opting into binding host ports to default network IP

### DIFF
--- a/client/allocrunner/network_manager_linux.go
+++ b/client/allocrunner/network_manager_linux.go
@@ -133,12 +133,16 @@ func newNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, config 
 	}
 
 	netMode := strings.ToLower(tg.Networks[0].Mode)
+	ignorePortMappingHostIP := config.BindWildcardDefaultHostNetwork
+	if len(config.HostNetworks) > 0 {
+		ignorePortMappingHostIP = false
+	}
 
 	switch {
 	case netMode == "bridge":
-		return newBridgeNetworkConfigurator(log, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.CNIPath)
+		return newBridgeNetworkConfigurator(log, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.CNIPath, ignorePortMappingHostIP)
 	case strings.HasPrefix(netMode, "cni/"):
-		return newCNINetworkConfigurator(log, config.CNIPath, config.CNIInterfacePrefix, config.CNIConfigDir, netMode[4:])
+		return newCNINetworkConfigurator(log, config.CNIPath, config.CNIInterfacePrefix, config.CNIConfigDir, netMode[4:], ignorePortMappingHostIP)
 	default:
 		return &hostNetworkConfigurator{}, nil
 	}

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -39,7 +39,7 @@ type bridgeNetworkConfigurator struct {
 	logger hclog.Logger
 }
 
-func newBridgeNetworkConfigurator(log hclog.Logger, bridgeName, ipRange, cniPath string) (*bridgeNetworkConfigurator, error) {
+func newBridgeNetworkConfigurator(log hclog.Logger, bridgeName, ipRange, cniPath string, ignorePortMappingHostIP bool) (*bridgeNetworkConfigurator, error) {
 	b := &bridgeNetworkConfigurator{
 		bridgeName:  bridgeName,
 		allocSubnet: ipRange,
@@ -54,7 +54,7 @@ func newBridgeNetworkConfigurator(log hclog.Logger, bridgeName, ipRange, cniPath
 		b.allocSubnet = defaultNomadAllocSubnet
 	}
 
-	c, err := newCNINetworkConfiguratorWithConf(log, cniPath, bridgeNetworkAllocIfPrefix, buildNomadBridgeNetConfig(b.bridgeName, b.allocSubnet))
+	c, err := newCNINetworkConfiguratorWithConf(log, cniPath, bridgeNetworkAllocIfPrefix, ignorePortMappingHostIP, buildNomadBridgeNetConfig(b.bridgeName, b.allocSubnet))
 	if err != nil {
 		return nil, err
 	}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -257,6 +257,16 @@ type Config struct {
 
 	// HostNetworks is a map of the conigured host networks by name.
 	HostNetworks map[string]*structs.ClientHostNetworkConfig
+
+	// BindWildcardDefaultHostNetwork toggles if the default host network should accept all
+	// destinations (true) or only filter on the IP of the default host network (false) when
+	// port mapping. This allows Nomad clients with no defined host networks to accept and
+	// port forward traffic only matching on the destination port. An example use of this
+	// is when a network loadbalancer is utilizing direct server return and the destination
+	// address of incomming packets does not match the IP address of the host interface.
+	//
+	// This configuration is only considered if no host networks are defined.
+	BindWildcardDefaultHostNetwork bool
 }
 
 type ClientTemplateConfig struct {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -638,6 +638,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	for _, hn := range agentConfig.Client.HostNetworks {
 		conf.HostNetworks[hn.Name] = hn
 	}
+	conf.BindWildcardDefaultHostNetwork = agentConfig.Client.BindWildcardDefaultHostNetwork
 
 	return conf, nil
 }

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -290,7 +290,7 @@ type ClientConfig struct {
 	// if the host uses multiple interfaces
 	HostNetworks []*structs.ClientHostNetworkConfig `hcl:"host_network"`
 
-	// BindWildcardDefaultHostNetwork toggles if whe there are no host networks,
+	// BindWildcardDefaultHostNetwork toggles if when there are no host networks,
 	// should the port mapping rules match the default network address (false) or
 	// matching any destination address (true). Defaults to true
 	BindWildcardDefaultHostNetwork bool `hcl:"bind_wildcard_default_host_network"`

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -286,7 +286,14 @@ type ClientConfig struct {
 	// the host
 	BridgeNetworkSubnet string `hcl:"bridge_network_subnet"`
 
+	// HostNetworks describes the different host networks available to the host
+	// if the host uses multiple interfaces
 	HostNetworks []*structs.ClientHostNetworkConfig `hcl:"host_network"`
+
+	// BindWildcardDefaultHostNetwork toggles if whe there are no host networks,
+	// should the port mapping rules match the default network address (false) or
+	// matching any destination address (true). Defaults to true
+	BindWildcardDefaultHostNetwork bool `hcl:"bind_wildcard_default_host_network"`
 
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
@@ -819,6 +826,7 @@ func DevConfig(mode *devModeConfig) *Config {
 		FunctionBlacklist: []string{"plugin"},
 		DisableSandbox:    false,
 	}
+	conf.Client.BindWildcardDefaultHostNetwork = true
 	conf.Telemetry.PrometheusMetrics = true
 	conf.Telemetry.PublishAllocationMetrics = true
 	conf.Telemetry.PublishNodeMetrics = true
@@ -864,6 +872,7 @@ func DefaultConfig() *Config {
 				FunctionBlacklist: []string{"plugin"},
 				DisableSandbox:    false,
 			},
+			BindWildcardDefaultHostNetwork: true,
 		},
 		Server: &ServerConfig{
 			Enabled:   false,
@@ -1539,6 +1548,9 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 		result.HostNetworks = a.HostNetworks
 	}
 
+	if b.BindWildcardDefaultHostNetwork {
+		result.BindWildcardDefaultHostNetwork = true
+	}
 	return &result
 }
 

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -291,6 +291,17 @@ func TestAllocsFit(t *testing.T) {
 					MBits:  100,
 				},
 			},
+			NodeNetworks: []*NodeNetworkResource{
+				{
+					Mode:   "host",
+					Device: "eth0",
+					Addresses: []NodeNetworkAddress{
+						{
+							Address: "10.0.0.1",
+						},
+					},
+				},
+			},
 		},
 		ReservedResources: &NodeReservedResources{
 			Cpu: NodeReservedCpuResources{
@@ -318,18 +329,24 @@ func TestAllocsFit(t *testing.T) {
 					Memory: AllocatedMemoryResources{
 						MemoryMB: 1024,
 					},
-					Networks: []*NetworkResource{
-						{
-							Device:        "eth0",
-							IP:            "10.0.0.1",
-							MBits:         50,
-							ReservedPorts: []Port{{"main", 8000, 0, ""}},
-						},
-					},
 				},
 			},
 			Shared: AllocatedSharedResources{
 				DiskMB: 5000,
+				Networks: Networks{
+					{
+						Mode: "host",
+						IP: "10.0.0.1",
+						ReservedPorts: []Port{{"main", 8000, 0, ""}},
+					},
+				},
+				Ports: AllocatedPorts{
+					{
+						Label:  "main",
+						Value:  8000,
+						HostIP: "10.0.0.1",
+					},
+				},
 			},
 		},
 	}

--- a/nomad/structs/network.go
+++ b/nomad/structs/network.go
@@ -565,13 +565,27 @@ func isPortReserved(haystack []int, needle int) bool {
 }
 
 // COMPAT(1.0) remove when NetworkResource is no longer used for materialized client view of ports
-func AllocatedPortsToNetworkResouce(ask *NetworkResource, ports AllocatedPorts) *NetworkResource {
+func AllocatedPortsToNetworkResouce(ask *NetworkResource, ports AllocatedPorts, node *NodeResources) *NetworkResource {
 	out := ask.Copy()
 
 	for i, port := range ask.DynamicPorts {
 		if p, ok := ports.Get(port.Label); ok {
 			out.DynamicPorts[i].Value = p.Value
 			out.DynamicPorts[i].To = p.To
+		}
+	}
+	if len(node.NodeNetworks) > 0 {
+		for _, nw := range node.NodeNetworks {
+			if nw.Mode == "host" {
+				out.IP = nw.Addresses[0].Address
+				break
+			}
+		}
+	} else {
+		for _, nw := range node.Networks {
+			if nw.Mode == "host" {
+				out.IP = nw.IP
+			}
 		}
 	}
 	return out

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -284,7 +284,7 @@ OUTER:
 			netIdx.AddReservedPorts(offer)
 
 			// Update the network ask to the offer
-			nwRes := structs.AllocatedPortsToNetworkResouce(ask, offer)
+			nwRes := structs.AllocatedPortsToNetworkResouce(ask, offer, option.Node.NodeResources)
 			total.Shared.Networks = []*structs.NetworkResource{nwRes}
 			total.Shared.Ports = offer
 			option.AllocResources = &structs.AllocatedSharedResources{


### PR DESCRIPTION
In 0.12-beta the way port mappings were created changed to use the new multi-interface networking feature. This caused mapped ports to only be exposed if the destination address matched the IP of the default host network. Prior to 0.12-beta this constraint wasn't part of the rule which allowed the port to be exposed to all addresses for the given port, including loopback. Since multi-interface networking is a feature used in special cases, I've added a flag to explicitly opt into the new port mapping logic and keep the pre 0.12-beta logic.

This new flag is in the client config and is `bind_wildcard_default_host_network` and defaults to `true`. When one or more `host_network` blocks are defined, this toggle is ignored and destination address rules are applied for all mapped ports. To opt into this logic without setting a host_network, this field can be set to `false`.