### PR TITLE
UI: Persist the log stream/mode setting to localStorage

### DIFF
--- a/ui/app/components/task-log.js
+++ b/ui/app/components/task-log.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
 import RSVP from 'rsvp';
 import { logger } from 'nomad-ui/utils/classes/log';
 import timeout from 'nomad-ui/utils/timeout';
@@ -17,6 +18,7 @@ class MockAbortController {
 @classNames('boxed-section', 'task-log')
 export default class TaskLog extends Component {
   @service token;
+  @service userSettings;
 
   allocation = null;
   task = null;
@@ -33,7 +35,7 @@ export default class TaskLog extends Component {
   isStreaming = true;
   streamMode = 'streaming';
 
-  mode = 'stdout';
+  @alias('userSettings.logMode') mode;
 
   @computed('allocation.{id,node.httpAddr}', 'useServer')
   get logUrl() {

--- a/ui/app/services/user-settings.js
+++ b/ui/app/services/user-settings.js
@@ -3,4 +3,5 @@ import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 
 export default class UserSettingsService extends Service {
   @localStorageProperty('nomadPageSize', 25) pageSize;
+  @localStorageProperty('nomadLogMode', 'stdout') logMode;
 }


### PR DESCRIPTION
This is just a small quality of life improvement for people who find themselves clicking `stderr` all the time. Now the UI will remember that setting and load `stderr` by default until you click `stdout` again.