### PR TITLE
api: `nomad debug` new /agent/host

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -470,7 +470,6 @@ type HostData struct {
 	Network     []map[string]string
 	ResolvConf  string
 	Hosts       string
-	Systemd     string
 	Environment map[string]string
 	Disk        map[string]DiskUsage
 }

--- a/api/agent.go
+++ b/api/agent.go
@@ -467,7 +467,7 @@ type AgentHealth struct {
 
 type HostData struct {
 	OS          string
-	Network     string
+	Network     []map[string]string
 	ResolvConf  string
 	Hosts       string
 	Systemd     string

--- a/api/agent.go
+++ b/api/agent.go
@@ -239,6 +239,32 @@ func (a *Agent) Health() (*AgentHealthResponse, error) {
 	return nil, fmt.Errorf("unable to unmarshal response with status %d: %v", resp.StatusCode, err)
 }
 
+// Host returns debugging context about the agent's host operating system
+func (a *Agent) Host(serverID, nodeID string, q *QueryOptions) (*HostDataResponse, error) {
+	if q == nil {
+		q = &QueryOptions{}
+	}
+	if q.Params == nil {
+		q.Params = make(map[string]string)
+	}
+
+	if serverID != "" {
+		q.Params["server_id"] = serverID
+	}
+
+	if nodeID != "" {
+		q.Params["node_id"] = nodeID
+	}
+
+	var resp HostDataResponse
+	_, err := a.client.query("/v1/agent/host", &resp, q)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 // Monitor returns a channel which will receive streaming logs from the agent
 // Providing a non-nil stopCh can be used to close the connection and stop log streaming
 func (a *Agent) Monitor(stopCh <-chan struct{}, q *QueryOptions) (<-chan *StreamFrame, <-chan error) {
@@ -437,4 +463,24 @@ type AgentHealth struct {
 
 	// Message describes why the agent is unhealthy
 	Message string `json:"message"`
+}
+
+type HostData struct {
+	OS          string
+	Network     string
+	ResolvConf  string
+	Hosts       string
+	Systemd     string
+	Environment map[string]string
+	Disk        map[string]DiskUsage
+}
+
+type DiskUsage struct {
+	DiskMB int64
+	UsedMB int64
+}
+
+type HostDataResponse struct {
+	AgentID  string
+	HostData *HostData `json:",omitempty"`
 }

--- a/client/agent_endpoint.go
+++ b/client/agent_endpoint.go
@@ -217,7 +217,9 @@ func (a *Agent) Host(args *structs.QueryOptions, reply *structs.HostDataResponse
 	aclObj, err := a.c.ResolveToken(args.AuthToken)
 	if err != nil {
 		return err
-	} else if aclObj != nil && !aclObj.AllowAgentRead() {
+	}
+	if (aclObj != nil && !aclObj.AllowAgentRead()) ||
+		(aclObj == nil && !a.c.config.EnableDebug) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -21,6 +21,7 @@ import (
 var (
 	// DefaultEnvBlacklist is the default set of environment variables that are
 	// filtered when passing the environment variables of the host to a task.
+	// duplicated in command/agent/host, update that if this changes.
 	DefaultEnvBlacklist = strings.Join([]string{
 		"CONSUL_TOKEN",
 		"CONSUL_HTTP_TOKEN",

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/nomad/acl"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/command/agent/host"
 	"github.com/hashicorp/nomad/command/agent/pprof"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/serf/serf"
@@ -656,4 +657,68 @@ func (h healthResponse) ok() bool {
 type healthResponseAgent struct {
 	Ok      bool   `json:"ok"`
 	Message string `json:"message,omitempty"`
+}
+
+// AgentHostRequest runs on servers and clients, and captures information about the host system to add
+// to the nomad debug archive.
+func (s *HTTPServer) AgentHostRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != "GET" {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	var secret string
+	s.parseToken(req, &secret)
+
+	// Check agent read permissions
+	if aclObj, err := s.agent.Client().ResolveToken(secret); err != nil {
+		return nil, err
+	} else if aclObj != nil && !aclObj.AllowAgentRead() {
+		return nil, structs.ErrPermissionDenied
+	}
+
+	serverID := req.URL.Query().Get("server_id")
+	nodeID := req.URL.Query().Get("node_id")
+
+	if serverID != "" && nodeID != "" {
+		return nil, CodedError(400, "Can only forward to either client node or server")
+	}
+
+	// If no other node is specified, return our local host's data
+	if serverID == "" && nodeID == "" {
+		data, err := host.MakeHostData()
+		if err != nil {
+			return nil, CodedError(500, err.Error())
+		}
+		return data, nil
+	}
+
+	args := &structs.HostDataRequest{
+		ServerID: serverID,
+		NodeID:   nodeID,
+	}
+
+	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
+
+	var reply structs.HostDataResponse
+	var rpcErr error
+
+	// serverID is set, so forward to that server
+	if serverID != "" {
+		rpcErr = s.agent.Server().RPC("Agent.Host", &args, &reply)
+		return reply, rpcErr
+	}
+
+	// Make the RPC. The RPC endpoint actually forwards the request to the correct
+	// agent, but we need to use the correct RPC interface.
+	localClient, remoteClient, _ := s.rpcHandlerForNode(nodeID)
+
+	if localClient {
+		rpcErr = s.agent.Client().ClientRPC("Agent.Host", &args, &reply)
+	} else if remoteClient {
+		rpcErr = s.agent.Client().RPC("Agent.Host", &args, &reply)
+	} else {
+		rpcErr = fmt.Errorf("node not found: %s", nodeID)
+	}
+
+	return reply, rpcErr
 }

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -670,9 +670,13 @@ func (s *HTTPServer) AgentHostRequest(resp http.ResponseWriter, req *http.Reques
 	s.parseToken(req, &secret)
 
 	// Check agent read permissions
-	if aclObj, err := s.agent.Client().ResolveToken(secret); err != nil {
-		return nil, err
-	} else if aclObj != nil && !aclObj.AllowAgentRead() {
+	if srv := s.agent.Server(); srv != nil {
+		aclObj, err = srv.ResolveToken(secret)
+	} else {
+		// Not a Server; use the Client for token resolution
+		aclObj, err = s.agent.Client().ResolveToken(secret)
+	}
+	if aclObj != nil && !aclObj.AllowAgentRead() {
 		return nil, structs.ErrPermissionDenied
 	}
 

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -662,7 +662,7 @@ type healthResponseAgent struct {
 // AgentHostRequest runs on servers and clients, and captures information about the host system to add
 // to the nomad debug archive.
 func (s *HTTPServer) AgentHostRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -671,18 +671,22 @@ func (s *HTTPServer) AgentHostRequest(resp http.ResponseWriter, req *http.Reques
 
 	// Check agent read permissions
 	var aclObj *acl.ACL
+	var enableDebug bool
 	var err error
 	if srv := s.agent.Server(); srv != nil {
 		aclObj, err = srv.ResolveToken(secret)
+		enableDebug = srv.GetConfig().EnableDebug
 	} else {
 		// Not a Server; use the Client for token resolution
 		aclObj, err = s.agent.Client().ResolveToken(secret)
+		enableDebug = s.agent.Client().GetConfig().EnableDebug
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	if aclObj != nil && !aclObj.AllowAgentRead() {
+	if (aclObj != nil && !aclObj.AllowAgentRead()) ||
+		(aclObj == nil && !enableDebug) {
 		return nil, structs.ErrPermissionDenied
 	}
 

--- a/command/agent/host/darwin.go
+++ b/command/agent/host/darwin.go
@@ -2,53 +2,10 @@
 
 package host
 
-import (
-	"bufio"
-	"strings"
-)
-
 func network() string {
-	return call("ifconfig")
+	return ""
 }
 
-func resolvConf() string {
-	return call("scutil", "--dns")
-}
-
-func mountedPaths() (paths []string) {
-	// TODO (langmartin) diskutil list -plist physical is a better source for disks to
-	// check, but needs a little xml parsing
-	out := call("mount")
-	rd := bufio.NewReader(strings.NewReader(out))
-
-	for {
-		str, err := rd.ReadString('\n')
-		if err != nil {
-			break
-		}
-
-		// find the last ( in the line, it's the beginning of the args
-		i := len(str) - 1
-		for ; ; i-- {
-			if str[i] == '(' {
-				break
-			}
-		}
-
-		// split the args part of the string
-		args := strings.Split(str[i+1:len(str)-2], ", ")
-
-		// split the device and mountpoint
-		mnt := strings.Split(str[:i-1], " on ")
-
-		switch args[0] {
-		case "devfs", "autofs":
-			continue
-		default:
-		}
-
-		paths = append(paths, mnt[1])
-	}
-
-	return paths
+func mountedPaths() []string {
+	return []string{"/"}
 }

--- a/command/agent/host/darwin.go
+++ b/command/agent/host/darwin.go
@@ -1,0 +1,54 @@
+// +build darwin
+
+package host
+
+import (
+	"bufio"
+	"strings"
+)
+
+func network() string {
+	return call("ifconfig")
+}
+
+func resolvConf() string {
+	return call("scutil", "--dns")
+}
+
+func mountedPaths() (paths []string) {
+	// TODO (langmartin) diskutil list -plist physical is a better source for disks to
+	// check, but needs a little xml parsing
+	out := call("mount")
+	rd := bufio.NewReader(strings.NewReader(out))
+
+	for {
+		str, err := rd.ReadString('\n')
+		if err != nil {
+			break
+		}
+
+		// find the last ( in the line, it's the beginning of the args
+		i := len(str) - 1
+		for ; ; i-- {
+			if str[i] == '(' {
+				break
+			}
+		}
+
+		// split the args part of the string
+		args := strings.Split(str[i+1:len(str)-2], ", ")
+
+		// split the device and mountpoint
+		mnt := strings.Split(str[:i-1], " on ")
+
+		switch args[0] {
+		case "devfs", "autofs":
+			continue
+		default:
+		}
+
+		paths = append(paths, mnt[1])
+	}
+
+	return paths
+}

--- a/command/agent/host/darwin.go
+++ b/command/agent/host/darwin.go
@@ -2,10 +2,6 @@
 
 package host
 
-func network() string {
-	return ""
-}
-
 func mountedPaths() []string {
 	return []string{"/"}
 }

--- a/command/agent/host/host.go
+++ b/command/agent/host/host.go
@@ -1,0 +1,93 @@
+package host
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type HostData struct {
+	OS         string
+	Network    string
+	ResolvConf string
+	Hosts      string
+	Systemd    string
+	Disk       map[string]DiskUsage
+}
+
+type DiskUsage struct {
+	DiskMB int64
+	UsedMB int64
+}
+
+func MakeHostData() (*HostData, error) {
+	uname, err := uname()
+	if err != nil {
+		return nil, fmt.Errorf("error uname: %s", err.Error())
+	}
+	du := make(map[string]DiskUsage)
+	for _, path := range mountedPaths() {
+		u, err := diskUsage(path)
+		if err != nil {
+			continue
+		}
+		du[path] = u
+	}
+
+	return &HostData{
+		OS:         uname,
+		Network:    network(),
+		ResolvConf: resolvConf(),
+		Hosts:      etcHosts(),
+		Systemd:    slurp("/etc/systemd/nomad.conf"),
+		Disk:       du,
+	}, nil
+}
+
+// diskUsage calculates the DiskUsage
+func diskUsage(path string) (du DiskUsage, err error) {
+	s, err := makeDf(path)
+	if err != nil {
+		return du, err
+	}
+
+	disk := float64(s.total())
+	// Bavail is blocks available to unprivileged users, Bfree includes reserved blocks
+	free := float64(s.available())
+	used := disk - free
+	mb := float64(1048576)
+
+	disk = disk / mb
+	used = used / mb
+
+	du.DiskMB = int64(disk)
+	du.UsedMB = int64(used)
+	return du, nil
+}
+
+// call executes the command line and returns stdout, ignoring errors
+func call(cmd string, args ...string) string {
+	// cmd = which(cmd)
+	out, _ := exec.Command(cmd, args...).Output()
+	return string(out)
+}
+
+// slurp returns the file contents as a string, ignoring errors
+func slurp(path string) string {
+	var sb strings.Builder
+	buf := make([]byte, 512)
+	fh, err := os.Open(path)
+	var l int
+	for {
+		l, err = fh.Read(buf)
+		if err != nil {
+			if l > 0 {
+				sb.Write(buf[0 : l-1])
+			}
+			break
+		}
+		sb.Write(buf[0 : l-1])
+	}
+	return sb.String()
+}

--- a/command/agent/host/host.go
+++ b/command/agent/host/host.go
@@ -7,7 +7,7 @@ import (
 
 type HostData struct {
 	OS          string
-	Network     string
+	Network     []map[string]string
 	ResolvConf  string
 	Hosts       string
 	Environment map[string]string

--- a/command/agent/host/host.go
+++ b/command/agent/host/host.go
@@ -1,7 +1,6 @@
 package host
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
@@ -21,10 +20,6 @@ type DiskUsage struct {
 }
 
 func MakeHostData() (*HostData, error) {
-	uname, err := uname()
-	if err != nil {
-		return nil, fmt.Errorf("error uname: %s", err.Error())
-	}
 	du := make(map[string]DiskUsage)
 	for _, path := range mountedPaths() {
 		u, err := diskUsage(path)
@@ -35,7 +30,7 @@ func MakeHostData() (*HostData, error) {
 	}
 
 	return &HostData{
-		OS:          uname,
+		OS:          uname(),
 		Network:     network(),
 		ResolvConf:  resolvConf(),
 		Hosts:       etcHosts(),

--- a/command/agent/host/host.go
+++ b/command/agent/host/host.go
@@ -76,6 +76,10 @@ func slurp(path string) string {
 	var sb strings.Builder
 	buf := make([]byte, 512)
 	fh, err := os.Open(path)
+	if err != nil {
+		return err.Error()
+	}
+
 	var l int
 	for {
 		l, err = fh.Read(buf)

--- a/command/agent/host/host_test.go
+++ b/command/agent/host/host_test.go
@@ -20,7 +20,7 @@ func TestMakeHostData(t *testing.T) {
 	host, err := MakeHostData()
 	require.NoError(t, err)
 	require.NotEmpty(t, host.OS)
-	require.Empty(t, host.Network)
+	require.NotEmpty(t, host.Network)
 	require.NotEmpty(t, host.ResolvConf)
 	require.NotEmpty(t, host.Hosts)
 	require.NotEmpty(t, host.Disk)

--- a/command/agent/host/host_test.go
+++ b/command/agent/host/host_test.go
@@ -1,0 +1,25 @@
+package host
+
+import (
+	"testing"
+
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostUtils(t *testing.T) {
+	mounts := mountedPaths()
+	require.NotEmpty(t, mounts)
+
+	du, err := diskUsage("/")
+	require.NoError(t, err)
+	require.NotZero(t, du.DiskMB)
+	require.NotZero(t, du.UsedMB)
+
+	out := call("echo", "1")
+	require.Equal(t, "1\n", out)
+}
+
+func TestMakeHostData(t *testing.T) {
+	pretty.Log(MakeHostData())
+}

--- a/command/agent/host/host_test.go
+++ b/command/agent/host/host_test.go
@@ -3,7 +3,6 @@ package host
 import (
 	"testing"
 
-	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,5 +20,11 @@ func TestHostUtils(t *testing.T) {
 }
 
 func TestMakeHostData(t *testing.T) {
-	pretty.Log(MakeHostData())
+	host, err := MakeHostData()
+	require.NoError(t, err)
+	require.NotEmpty(t, host.OS)
+	require.NotEmpty(t, host.Network)
+	require.NotEmpty(t, host.ResolvConf)
+	require.NotEmpty(t, host.Hosts)
+	require.NotEmpty(t, host.Disk)
 }

--- a/command/agent/host/host_test.go
+++ b/command/agent/host/host_test.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,15 @@ func TestHostUtils(t *testing.T) {
 }
 
 func TestMakeHostData(t *testing.T) {
+	// setenv variables that should be redacted
+	prev := os.Getenv("VAULT_TOKEN")
+	os.Setenv("VAULT_TOKEN", "foo")
+	defer os.Setenv("VAULT_TOKEN", prev)
+
+	os.Setenv("BOGUS_TOKEN", "foo")
+	os.Setenv("BOGUS_SECRET", "foo")
+	os.Setenv("ryanSECRETS", "foo")
+
 	host, err := MakeHostData()
 	require.NoError(t, err)
 	require.NotEmpty(t, host.OS)
@@ -24,4 +34,9 @@ func TestMakeHostData(t *testing.T) {
 	require.NotEmpty(t, host.ResolvConf)
 	require.NotEmpty(t, host.Hosts)
 	require.NotEmpty(t, host.Disk)
+	require.NotEmpty(t, host.Environment)
+	require.Equal(t, "<redacted>", host.Environment["VAULT_TOKEN"])
+	require.Equal(t, "<redacted>", host.Environment["BOGUS_TOKEN"])
+	require.Equal(t, "<redacted>", host.Environment["BOGUS_SECRET"])
+	require.Equal(t, "<redacted>", host.Environment["ryanSECRETS"])
 }

--- a/command/agent/host/host_test.go
+++ b/command/agent/host/host_test.go
@@ -14,16 +14,13 @@ func TestHostUtils(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, du.DiskMB)
 	require.NotZero(t, du.UsedMB)
-
-	out := call("echo", "1")
-	require.Equal(t, "1\n", out)
 }
 
 func TestMakeHostData(t *testing.T) {
 	host, err := MakeHostData()
 	require.NoError(t, err)
 	require.NotEmpty(t, host.OS)
-	require.NotEmpty(t, host.Network)
+	require.Empty(t, host.Network)
 	require.NotEmpty(t, host.ResolvConf)
 	require.NotEmpty(t, host.Hosts)
 	require.NotEmpty(t, host.Disk)

--- a/command/agent/host/linux.go
+++ b/command/agent/host/linux.go
@@ -1,0 +1,33 @@
+// +build linux
+
+package host
+
+import (
+	"bufio"
+	"strings"
+)
+
+func network() string {
+	return call("ip", "address", "list")
+}
+
+func resolvConf() string {
+	return slurp("/etc/resolv.conf")
+}
+
+// mountedPaths produces a list of mounts
+func mountedPaths() []string {
+	out := call("findmnt", "-D", "-tnotmpfs,nodevtmpfs", "-o", "TARGET")
+	rd := bufio.NewReader(strings.NewReader(out))
+
+	var paths []string
+	for {
+		str, err := rd.ReadString('\n')
+		if err != nil {
+			break
+		}
+		paths = append(paths, str)
+	}
+
+	return paths
+}

--- a/command/agent/host/linux.go
+++ b/command/agent/host/linux.go
@@ -8,10 +8,6 @@ import (
 	"strings"
 )
 
-func network() string {
-	return ""
-}
-
 // mountedPaths produces a list of mounts
 func mountedPaths() []string {
 	fh, err := os.Open("/proc/mounts")

--- a/command/agent/host/network.go
+++ b/command/agent/host/network.go
@@ -1,0 +1,83 @@
+package host
+
+import (
+	"fmt"
+
+	sockaddr "github.com/hashicorp/go-sockaddr"
+)
+
+// network uses go-sockaddr to capture our view of the network
+// on error, return the text of the error
+func network() (output []map[string]string) {
+	ifaddrs, err := sockaddr.GetAllInterfaces()
+	if err != nil {
+		output = append(output, map[string]string{"error": err.Error()})
+		return output
+	}
+
+	for _, inf := range ifaddrs {
+		output = append(output, dumpSockAddr(inf.SockAddr))
+	}
+
+	return output
+}
+
+// dumpSockAddr is adapted from
+// https://github.com/hashicorp/go-sockaddr/blob/c7188e74f6acae5a989bdc959aa779f8b9f42faf/cmd/sockaddr/command/dump.go#L144-L244
+func dumpSockAddr(sa sockaddr.SockAddr) map[string]string {
+	output := make(map[string]string)
+
+	// Attributes for all SockAddr types
+	for _, attr := range sockaddr.SockAddrAttrs() {
+		output[string(attr)] = sockaddr.SockAddrAttr(sa, attr)
+	}
+
+	// Attributes for all IP types (both IPv4 and IPv6)
+	if sa.Type()&sockaddr.TypeIP != 0 {
+		ip := *sockaddr.ToIPAddr(sa)
+		for _, attr := range sockaddr.IPAttrs() {
+			output[string(attr)] = sockaddr.IPAddrAttr(ip, attr)
+		}
+	}
+
+	if sa.Type() == sockaddr.TypeIPv4 {
+		ipv4 := *sockaddr.ToIPv4Addr(sa)
+		for _, attr := range sockaddr.IPv4Attrs() {
+			output[string(attr)] = sockaddr.IPv4AddrAttr(ipv4, attr)
+		}
+	}
+
+	if sa.Type() == sockaddr.TypeIPv6 {
+		ipv6 := *sockaddr.ToIPv6Addr(sa)
+		for _, attr := range sockaddr.IPv6Attrs() {
+			output[string(attr)] = sockaddr.IPv6AddrAttr(ipv6, attr)
+		}
+	}
+
+	if sa.Type() == sockaddr.TypeUnix {
+		us := *sockaddr.ToUnixSock(sa)
+		for _, attr := range sockaddr.UnixSockAttrs() {
+			output[string(attr)] = sockaddr.UnixSockAttr(us, attr)
+		}
+	}
+
+	// Developer-focused arguments
+	{
+		arg1, arg2 := sa.DialPacketArgs()
+		output["DialPacket"] = fmt.Sprintf("%+q %+q", arg1, arg2)
+	}
+	{
+		arg1, arg2 := sa.DialStreamArgs()
+		output["DialStream"] = fmt.Sprintf("%+q %+q", arg1, arg2)
+	}
+	{
+		arg1, arg2 := sa.ListenPacketArgs()
+		output["ListenPacket"] = fmt.Sprintf("%+q %+q", arg1, arg2)
+	}
+	{
+		arg1, arg2 := sa.ListenStreamArgs()
+		output["ListenStream"] = fmt.Sprintf("%+q %+q", arg1, arg2)
+	}
+
+	return output
+}

--- a/command/agent/host/unix.go
+++ b/command/agent/host/unix.go
@@ -1,0 +1,65 @@
+// +build !windows
+
+package host
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// uname returns the syscall like `uname -a`
+func uname() (string, error) {
+	u := &unix.Utsname{}
+	err := unix.Uname(u)
+	if err != nil {
+		return "", fmt.Errorf("error uname: %s", err.Error())
+	}
+
+	uname := strings.Join([]string{
+		nullStr(u.Machine[:]),
+		nullStr(u.Nodename[:]),
+		nullStr(u.Release[:]),
+		nullStr(u.Sysname[:]),
+		nullStr(u.Version[:]),
+	}, " ")
+
+	return uname, nil
+}
+
+func etcHosts() string {
+	return slurp("/etc/hosts")
+}
+
+func nullStr(bs []byte) string {
+	// find the null byte
+	var i int
+	var b byte
+	for i, b = range bs {
+		if b == 0 {
+			break
+		}
+	}
+
+	return string(bs[:i])
+}
+
+type df struct {
+	s *syscall.Statfs_t
+}
+
+func makeDf(path string) (*df, error) {
+	var s syscall.Statfs_t
+	err := syscall.Statfs(path, &s)
+	return &df{s: &s}, err
+}
+
+func (d *df) total() uint64 {
+	return d.s.Blocks * uint64(d.s.Bsize)
+}
+
+func (d *df) available() uint64 {
+	return d.s.Bavail * uint64(d.s.Bsize)
+}

--- a/command/agent/host/unix.go
+++ b/command/agent/host/unix.go
@@ -33,6 +33,10 @@ func etcHosts() string {
 	return slurp("/etc/hosts")
 }
 
+func resolvConf() string {
+	return slurp("/etc/resolv.conf")
+}
+
 func nullStr(bs []byte) string {
 	// find the null byte
 	var i int

--- a/command/agent/host/unix.go
+++ b/command/agent/host/unix.go
@@ -3,7 +3,6 @@
 package host
 
 import (
-	"fmt"
 	"strings"
 	"syscall"
 
@@ -11,11 +10,11 @@ import (
 )
 
 // uname returns the syscall like `uname -a`
-func uname() (string, error) {
+func uname() string {
 	u := &unix.Utsname{}
 	err := unix.Uname(u)
 	if err != nil {
-		return "", fmt.Errorf("error uname: %s", err.Error())
+		return err.Error()
 	}
 
 	uname := strings.Join([]string{
@@ -26,7 +25,7 @@ func uname() (string, error) {
 		nullStr(u.Version[:]),
 	}, " ")
 
-	return uname, nil
+	return uname
 }
 
 func etcHosts() string {

--- a/command/agent/host/windows.go
+++ b/command/agent/host/windows.go
@@ -32,10 +32,11 @@ func mountedPaths() (disks []string) {
 			disks = append(disks, d)
 		}
 	}
+	return disks
 }
 
 type df struct {
-	total int64
+	size  int64
 	avail int64
 }
 
@@ -46,14 +47,14 @@ func makeDf(path string) (*df, error) {
 	df := &df{}
 
 	c.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))),
-		uintptr(unsafe.Pointer(&df.total)),
+		uintptr(unsafe.Pointer(&df.size)),
 		uintptr(unsafe.Pointer(&df.avail)))
 
 	return df, nil
 }
 
 func (d *df) total() uint64 {
-	return uint64(d.total)
+	return uint64(d.size)
 }
 
 func (d *df) available() uint64 {

--- a/command/agent/host/windows.go
+++ b/command/agent/host/windows.go
@@ -2,9 +2,31 @@
 
 package host
 
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func uname() string {
+	return ""
+}
+
+func network() string {
+	return ""
+}
+
+func resolvConf() string {
+	return ""
+}
+
+func etcHosts() string {
+	return ""
+}
+
 func mountedPaths() (disks []string) {
 	for _, c := range "ABCDEFGHIJKLMNOPQRSTUVWXYZ" {
-		_, err := os.Stat(c + ":\\")
+		_, err := os.Stat(string(c) + ":\\")
 		if err == nil {
 
 			disks = append(disks, c)

--- a/command/agent/host/windows.go
+++ b/command/agent/host/windows.go
@@ -26,10 +26,10 @@ func etcHosts() string {
 
 func mountedPaths() (disks []string) {
 	for _, c := range "ABCDEFGHIJKLMNOPQRSTUVWXYZ" {
-		_, err := os.Stat(string(c) + ":\\")
+		d := string(c) + ":\\"
+		_, err := os.Stat(d)
 		if err == nil {
-
-			disks = append(disks, c)
+			disks = append(disks, d)
 		}
 	}
 }
@@ -39,7 +39,7 @@ type df struct {
 	avail int64
 }
 
-func makeDf(path string) *df {
+func makeDf(path string) (*df, error) {
 	h := syscall.MustLoadDLL("kernel32.dll")
 	c := h.MustFindProc("GetDiskFreeSpaceExW")
 
@@ -49,7 +49,7 @@ func makeDf(path string) *df {
 		uintptr(unsafe.Pointer(&df.total)),
 		uintptr(unsafe.Pointer(&df.avail)))
 
-	return df
+	return df, nil
 }
 
 func (d *df) total() uint64 {

--- a/command/agent/host/windows.go
+++ b/command/agent/host/windows.go
@@ -12,10 +12,6 @@ func uname() string {
 	return ""
 }
 
-func network() string {
-	return ""
-}
-
 func resolvConf() string {
 	return ""
 }

--- a/command/agent/host/windows.go
+++ b/command/agent/host/windows.go
@@ -1,0 +1,39 @@
+// +build windows
+
+package host
+
+func mountedPaths() (disks []string) {
+	for _, c := range "ABCDEFGHIJKLMNOPQRSTUVWXYZ" {
+		_, err := os.Stat(c + ":\\")
+		if err == nil {
+
+			disks = append(disks, c)
+		}
+	}
+}
+
+type df struct {
+	total int64
+	avail int64
+}
+
+func makeDf(path string) *df {
+	h := syscall.MustLoadDLL("kernel32.dll")
+	c := h.MustFindProc("GetDiskFreeSpaceExW")
+
+	df := &df{}
+
+	c.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))),
+		uintptr(unsafe.Pointer(&df.total)),
+		uintptr(unsafe.Pointer(&df.avail)))
+
+	return df
+}
+
+func (d *df) total() uint64 {
+	return uint64(d.total)
+}
+
+func (d *df) available() uint64 {
+	return uint64(d.avail)
+}

--- a/command/agent/host/windows.go
+++ b/command/agent/host/windows.go
@@ -37,8 +37,15 @@ type df struct {
 }
 
 func makeDf(path string) (*df, error) {
-	h := syscall.MustLoadDLL("kernel32.dll")
-	c := h.MustFindProc("GetDiskFreeSpaceExW")
+	h, err := syscall.LoadDLL("kernel32.dll")
+	if err != nil {
+		return err
+	}
+
+	c, err := h.FindProc("GetDiskFreeSpaceExW")
+	if err != nil {
+		return err
+	}
 
 	df := &df{}
 

--- a/command/agent/host/windows.go
+++ b/command/agent/host/windows.go
@@ -39,12 +39,12 @@ type df struct {
 func makeDf(path string) (*df, error) {
 	h, err := syscall.LoadDLL("kernel32.dll")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	c, err := h.FindProc("GetDiskFreeSpaceExW")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	df := &df{}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -291,6 +291,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/agent/servers", s.wrap(s.AgentServersRequest))
 	s.mux.HandleFunc("/v1/agent/keyring/", s.wrap(s.KeyringOperationRequest))
 	s.mux.HandleFunc("/v1/agent/health", s.wrap(s.HealthRequest))
+	s.mux.HandleFunc("/v1/agent/host", s.wrap(s.AgentHostRequest))
 
 	// Monitor is *not* an untrusted endpoint despite the log contents
 	// potentially containing unsanitized user input. Monitor, like
@@ -661,6 +662,7 @@ func (s *HTTPServer) parseToken(req *http.Request, token *string) {
 }
 
 // parse is a convenience method for endpoints that need to parse multiple flags
+// It sets r to the region and b to the QueryOptions in req
 func (s *HTTPServer) parse(resp http.ResponseWriter, req *http.Request, r *string, b *structs.QueryOptions) bool {
 	s.parseRegion(req, r)
 	s.parseToken(req, &b.AuthToken)

--- a/command/debug.go
+++ b/command/debug.go
@@ -368,11 +368,14 @@ func (c *DebugCommand) collectAgentHost(path, id string, client *api.Client) {
 	} else {
 		host, err = client.Agent().Host("", id, nil)
 	}
+
+	path = filepath.Join(path, id)
+
 	if err != nil {
+		c.writeBytes(path, "agent-host.log", []byte(err.Error()))
 		return
 	}
 
-	path = filepath.Join(path, id)
 	c.writeJSON(path, "agent-host.json", host)
 }
 

--- a/command/debug.go
+++ b/command/debug.go
@@ -281,6 +281,7 @@ func (c *DebugCommand) collect(client *api.Client) error {
 	c.startMonitors(client)
 	c.collectPeriodic(client)
 	c.collectPprofs(client)
+	c.collectAgentHosts(client)
 
 	return nil
 }
@@ -344,6 +345,35 @@ func (c *DebugCommand) startMonitor(path, idKey, nodeID string, client *api.Clie
 			return
 		}
 	}
+}
+
+// collectAgentHosts calls collectAgentHost for each selected node
+func (c *DebugCommand) collectAgentHosts(client *api.Client) {
+	for _, n := range c.nodeIDs {
+		c.collectAgentHost("client", n, client)
+	}
+
+	for _, n := range c.serverIDs {
+		c.collectAgentHost("server", n, client)
+	}
+
+}
+
+// collectAgentHost gets the agent host data
+func (c *DebugCommand) collectAgentHost(path, id string, client *api.Client) {
+	var host *api.HostDataResponse
+	var err error
+	if path == "server" {
+		host, err = client.Agent().Host(id, "", nil)
+	} else {
+		host, err = client.Agent().Host("", id, nil)
+	}
+	if err != nil {
+		return
+	}
+
+	path = filepath.Join(path, id)
+	c.writeJSON(path, "agent-host.json", host)
 }
 
 // collectPprofs captures the /agent/pprof for each listed node

--- a/nomad/client_agent_endpoint.go
+++ b/nomad/client_agent_endpoint.go
@@ -401,7 +401,9 @@ func (a *Agent) Host(args *structs.HostDataRequest, reply *structs.HostDataRespo
 	aclObj, err := a.srv.ResolveToken(args.AuthToken)
 	if err != nil {
 		return err
-	} else if aclObj != nil && !aclObj.AllowAgentRead() {
+	}
+	if (aclObj != nil && !aclObj.AllowAgentRead()) ||
+		(aclObj == nil && !a.srv.config.EnableDebug) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -809,3 +809,183 @@ func TestAgentProfile_ACL(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentHost_Server(t *testing.T) {
+	t.Parallel()
+
+	// start servers
+	s1, cleanup := TestServer(t, func(c *Config) {
+		c.BootstrapExpect = 2
+		c.EnableDebug = true
+	})
+	defer cleanup()
+
+	s2, cleanup := TestServer(t, func(c *Config) {
+		c.BootstrapExpect = 2
+		c.EnableDebug = true
+	})
+	defer cleanup()
+
+	TestJoin(t, s1, s2)
+	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForLeader(t, s2.RPC)
+
+	// determine leader and nonleader
+	servers := []*Server{s1, s2}
+	var nonLeader *Server
+	var leader *Server
+	for _, s := range servers {
+		if !s.IsLeader() {
+			nonLeader = s
+		} else {
+			leader = s
+		}
+	}
+
+	c, cleanupC := client.TestClient(t, func(c *config.Config) {
+		c.Servers = []string{s2.GetConfig().RPCAddr.String()}
+		c.EnableDebug = true
+	})
+	defer cleanupC()
+
+	testutil.WaitForResult(func() (bool, error) {
+		nodes := s2.connectedNodes()
+		return len(nodes) == 1, nil
+	}, func(err error) {
+		t.Fatalf("should have a clients")
+	})
+
+	cases := []struct {
+		desc            string
+		serverID        string
+		nodeID          string
+		origin          *Server
+		expectedErr     string
+		expectedAgentID string
+	}{
+		{
+			desc:            "remote leader",
+			serverID:        "leader",
+			origin:          nonLeader,
+			expectedAgentID: leader.serf.LocalMember().Name,
+		},
+		{
+			desc:            "remote server",
+			serverID:        nonLeader.serf.LocalMember().Name,
+			origin:          leader,
+			expectedAgentID: nonLeader.serf.LocalMember().Name,
+		},
+		{
+			desc:            "serverID is current leader",
+			serverID:        "leader",
+			origin:          leader,
+			expectedAgentID: leader.serf.LocalMember().Name,
+		},
+		{
+			desc:            "serverID is current server",
+			serverID:        nonLeader.serf.LocalMember().Name,
+			origin:          nonLeader,
+			expectedAgentID: nonLeader.serf.LocalMember().Name,
+		},
+		{
+			desc:            "serverID is unknown",
+			serverID:        uuid.Generate(),
+			origin:          nonLeader,
+			expectedErr:     "unknown Nomad server",
+			expectedAgentID: "",
+		},
+		{
+			desc:            "local client",
+			nodeID:          c.NodeID(),
+			origin:          s2,
+			expectedErr:     "",
+			expectedAgentID: c.NodeID(),
+		},
+		{
+			desc:            "remote client",
+			nodeID:          c.NodeID(),
+			origin:          s1,
+			expectedErr:     "",
+			expectedAgentID: c.NodeID(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			req := structs.HostDataRequest{
+				ServerID:     tc.serverID,
+				NodeID:       tc.nodeID,
+				QueryOptions: structs.QueryOptions{Region: "global"},
+			}
+
+			reply := structs.HostDataResponse{}
+
+			err := tc.origin.RPC("Agent.Host", &req, &reply)
+			if tc.expectedErr != "" {
+				require.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				require.Nil(t, err)
+				require.NotEmpty(t, reply.HostData)
+			}
+
+			require.Equal(t, tc.expectedAgentID, reply.AgentID)
+		})
+	}
+}
+
+func TestAgentHost_ACL(t *testing.T) {
+	t.Parallel()
+
+	// start server
+	s, root, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
+	testutil.WaitForLeader(t, s.RPC)
+
+	policyBad := mock.NamespacePolicy("other", "", []string{acl.NamespaceCapabilityReadFS})
+	tokenBad := mock.CreatePolicyAndToken(t, s.State(), 1005, "invalid", policyBad)
+
+	policyGood := mock.AgentPolicy(acl.PolicyRead)
+	tokenGood := mock.CreatePolicyAndToken(t, s.State(), 1009, "valid", policyGood)
+
+	cases := []struct {
+		Name        string
+		Token       string
+		ExpectedErr string
+	}{
+		{
+			Name:        "bad token",
+			Token:       tokenBad.SecretID,
+			ExpectedErr: "Permission denied",
+		},
+		{
+			Name:  "good token",
+			Token: tokenGood.SecretID,
+		},
+		{
+			Name:  "root token",
+			Token: root.SecretID,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			req := structs.HostDataRequest{
+				QueryOptions: structs.QueryOptions{
+					Namespace: structs.DefaultNamespace,
+					Region:    "global",
+					AuthToken: tc.Token,
+				},
+			}
+
+			var resp structs.HostDataResponse
+
+			err := s.RPC("Agent.Host", &req, &resp)
+			if tc.ExpectedErr != "" {
+				require.Equal(t, tc.ExpectedErr, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp.HostData)
+			}
+		})
+	}
+}

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -989,3 +989,26 @@ func TestAgentHost_ACL(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentHost_ACLDebugRequired(t *testing.T) {
+	t.Parallel()
+
+	// start server
+	s, cleanupS := TestServer(t, func(c *Config) {
+		c.EnableDebug = false
+	})
+	defer cleanupS()
+	testutil.WaitForLeader(t, s.RPC)
+
+	req := structs.HostDataRequest{
+		QueryOptions: structs.QueryOptions{
+			Namespace: structs.DefaultNamespace,
+			Region:    "global",
+		},
+	}
+
+	var resp structs.HostDataResponse
+
+	err := s.RPC("Agent.Host", &req, &resp)
+	require.Equal(t, "Permission denied", err.Error())
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1483,13 +1483,15 @@ type NodeConnQueryResponse struct {
 	QueryMeta
 }
 
-// HostDataRequest
+// HostDataRequest is used by /agent/host to retrieve data about the agent's host system. If
+// ServerID or NodeID is specified, the request is forwarded to the remote agent
 type HostDataRequest struct {
 	ServerID string
 	NodeID   string
 	QueryOptions
 }
 
+// HostDataResponse contains the HostData content
 type HostDataResponse struct {
 	AgentID  string
 	HostData *host.HostData

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/crypto/blake2b"
 
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/command/agent/host"
 	"github.com/hashicorp/nomad/command/agent/pprof"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/args"
@@ -1480,6 +1481,18 @@ type NodeConnQueryResponse struct {
 	Established time.Time
 
 	QueryMeta
+}
+
+// HostDataRequest
+type HostDataRequest struct {
+	ServerID string
+	NodeID   string
+	QueryOptions
+}
+
+type HostDataResponse struct {
+	AgentID  string
+	HostData *host.HostData
 }
 
 // EmitNodeEventsRequest is a request to update the node events source

--- a/vendor/github.com/hashicorp/nomad/api/agent.go
+++ b/vendor/github.com/hashicorp/nomad/api/agent.go
@@ -470,7 +470,6 @@ type HostData struct {
 	Network     []map[string]string
 	ResolvConf  string
 	Hosts       string
-	Systemd     string
 	Environment map[string]string
 	Disk        map[string]DiskUsage
 }

--- a/vendor/github.com/hashicorp/nomad/api/agent.go
+++ b/vendor/github.com/hashicorp/nomad/api/agent.go
@@ -467,7 +467,7 @@ type AgentHealth struct {
 
 type HostData struct {
 	OS          string
-	Network     string
+	Network     []map[string]string
 	ResolvConf  string
 	Hosts       string
 	Systemd     string

--- a/vendor/github.com/hashicorp/nomad/api/agent.go
+++ b/vendor/github.com/hashicorp/nomad/api/agent.go
@@ -239,6 +239,32 @@ func (a *Agent) Health() (*AgentHealthResponse, error) {
 	return nil, fmt.Errorf("unable to unmarshal response with status %d: %v", resp.StatusCode, err)
 }
 
+// Host returns debugging context about the agent's host operating system
+func (a *Agent) Host(serverID, nodeID string, q *QueryOptions) (*HostDataResponse, error) {
+	if q == nil {
+		q = &QueryOptions{}
+	}
+	if q.Params == nil {
+		q.Params = make(map[string]string)
+	}
+
+	if serverID != "" {
+		q.Params["server_id"] = serverID
+	}
+
+	if nodeID != "" {
+		q.Params["node_id"] = nodeID
+	}
+
+	var resp HostDataResponse
+	_, err := a.client.query("/v1/agent/host", &resp, q)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 // Monitor returns a channel which will receive streaming logs from the agent
 // Providing a non-nil stopCh can be used to close the connection and stop log streaming
 func (a *Agent) Monitor(stopCh <-chan struct{}, q *QueryOptions) (<-chan *StreamFrame, <-chan error) {
@@ -437,4 +463,24 @@ type AgentHealth struct {
 
 	// Message describes why the agent is unhealthy
 	Message string `json:"message"`
+}
+
+type HostData struct {
+	OS          string
+	Network     string
+	ResolvConf  string
+	Hosts       string
+	Systemd     string
+	Environment map[string]string
+	Disk        map[string]DiskUsage
+}
+
+type DiskUsage struct {
+	DiskMB int64
+	UsedMB int64
+}
+
+type HostDataResponse struct {
+	AgentID  string
+	HostData *HostData `json:",omitempty"`
 }


### PR DESCRIPTION
`/agent/host` is a new API endpoint that provides debug information about the agent's host environment from the perspective of the nomad process. #8306 