### PR TITLE
e2e: add tests for connect native

### DIFF
--- a/e2e/connect/client.go
+++ b/e2e/connect/client.go
@@ -35,6 +35,7 @@ func (tc *ConnectClientStateE2ETest) AfterEach(f *framework.F) {
 func (tc *ConnectClientStateE2ETest) TestClientRestart(f *framework.F) {
 	t := f.T()
 	require := require.New(t)
+
 	jobID := "connect" + uuid.Generate()[0:8]
 	tc.jobIds = append(tc.jobIds, jobID)
 	client := tc.Nomad()

--- a/e2e/connect/connect.go
+++ b/e2e/connect/connect.go
@@ -55,9 +55,7 @@ func (tc *ConnectE2ETest) AfterEach(f *framework.F) {
 }
 
 func connectJobID() string {
-	id := uuid.Generate()
-	jobID := "connect" + id[0:8]
-	return jobID
+	return "connect" + uuid.Generate()[0:8]
 }
 
 // TestConnectDemo tests the demo job file used in Connect Integration examples.

--- a/e2e/connect/connect.go
+++ b/e2e/connect/connect.go
@@ -2,17 +2,10 @@ package connect
 
 import (
 	"os"
-	"strings"
-	"time"
 
-	consulapi "github.com/hashicorp/consul/api"
-	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/e2e/e2eutil"
 	"github.com/hashicorp/nomad/e2e/framework"
 	"github.com/hashicorp/nomad/helper/uuid"
-	"github.com/hashicorp/nomad/jobspec"
-	"github.com/kr/pretty"
-	"github.com/stretchr/testify/require"
 )
 
 type ConnectE2ETest struct {
@@ -61,127 +54,32 @@ func (tc *ConnectE2ETest) AfterEach(f *framework.F) {
 	tc.Nomad().System().GarbageCollect()
 }
 
-// TestConnectDemo tests the demo job file from the Consul Connect Technology
-// Preview.
-//
-// https://github.com/hashicorp/nomad/blob/v0.9.5/website/source/guides/integrations/consul-connect/index.html.md#run-the-connect-enabled-services
-//
+func connectJobID() string {
+	id := uuid.Generate()
+	jobID := "connect" + id[0:8]
+	return jobID
+}
+
+// TestConnectDemo tests the demo job file used in Connect Integration examples.
 func (tc *ConnectE2ETest) TestConnectDemo(f *framework.F) {
 	t := f.T()
-	uuid := uuid.Generate()
-	jobID := "connect" + uuid[0:8]
+
+	jobID := connectJobID()
 	tc.jobIds = append(tc.jobIds, jobID)
-	jobapi := tc.Nomad().Jobs()
 
-	job, err := jobspec.ParseFile("connect/input/demo.nomad")
-	require.NoError(t, err)
-	job.ID = &jobID
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, tc.Nomad(), demoConnectJob, jobID, "")
+	allocIDs := e2eutil.AllocIDsFromAllocationListStubs(allocs)
+	e2eutil.WaitForAllocsRunning(t, tc.Nomad(), allocIDs)
+}
 
-	resp, _, err := jobapi.Register(job, nil)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.Zero(t, resp.Warnings)
+// TestConnectNativeDemo tests the demo job file used in Connect Native Integration examples.
+func (tc *ConnectE2ETest) TestConnectNativeDemo(f *framework.F) {
+	t := f.T()
 
-EVAL:
-	qopts := &api.QueryOptions{
-		WaitIndex: resp.EvalCreateIndex,
-	}
-	evalapi := tc.Nomad().Evaluations()
-	eval, qmeta, err := evalapi.Info(resp.EvalID, qopts)
-	require.NoError(t, err)
-	qopts.WaitIndex = qmeta.LastIndex
+	jobID := connectJobID()
+	tc.jobIds = append(tc.jobIds, jobID)
 
-	switch eval.Status {
-	case "pending":
-		goto EVAL
-	case "complete":
-		// Ok!
-	case "failed", "canceled", "blocked":
-		t.Fatalf("eval %s\n%s\n", eval.Status, pretty.Sprint(eval))
-	default:
-		t.Fatalf("unknown eval status: %s\n%s\n", eval.Status, pretty.Sprint(eval))
-	}
-
-	// Assert there were 0 placement failures
-	require.Zero(t, eval.FailedTGAllocs, pretty.Sprint(eval.FailedTGAllocs))
-	require.Len(t, eval.QueuedAllocations, 2, pretty.Sprint(eval.QueuedAllocations))
-
-	// Assert allocs are running
-	for i := 0; i < 20; i++ {
-		allocs, qmeta, err := evalapi.Allocations(eval.ID, qopts)
-		require.NoError(t, err)
-		require.Len(t, allocs, 2)
-		qopts.WaitIndex = qmeta.LastIndex
-
-		running := 0
-		for _, alloc := range allocs {
-			switch alloc.ClientStatus {
-			case "running":
-				running++
-			case "pending":
-				// keep trying
-			default:
-				t.Fatalf("alloc failed: %s", pretty.Sprint(alloc))
-			}
-		}
-
-		if running == len(allocs) {
-			break
-		}
-
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	allocs, _, err := evalapi.Allocations(eval.ID, qopts)
-	require.NoError(t, err)
-	allocIDs := make(map[string]bool, 2)
-	for _, a := range allocs {
-		if a.ClientStatus != "running" || a.DesiredStatus != "run" {
-			t.Fatalf("alloc %s (%s) terminal; client=%s desired=%s", a.TaskGroup, a.ID, a.ClientStatus, a.DesiredStatus)
-		}
-		allocIDs[a.ID] = true
-	}
-
-	// Check Consul service health
-	agentapi := tc.Consul().Agent()
-
-	failing := map[string]*consulapi.AgentCheck{}
-	for i := 0; i < 60; i++ {
-		checks, err := agentapi.Checks()
-		require.NoError(t, err)
-
-		// Filter out checks for other services
-		for cid, check := range checks {
-			found := false
-			for allocID := range allocIDs {
-				if strings.Contains(check.ServiceID, allocID) {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				delete(checks, cid)
-			}
-		}
-
-		// Ensure checks are all passing
-		failing = map[string]*consulapi.AgentCheck{}
-		for _, check := range checks {
-			if check.Status != "passing" {
-				failing[check.CheckID] = check
-				break
-			}
-		}
-
-		if len(failing) == 0 {
-			break
-		}
-
-		t.Logf("still %d checks not passing", len(failing))
-
-		time.Sleep(time.Second)
-	}
-
-	require.Len(t, failing, 0, pretty.Sprint(failing))
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, tc.Nomad(), demoConnectNativeJob, jobID, "")
+	allocIDs := e2eutil.AllocIDsFromAllocationListStubs(allocs)
+	e2eutil.WaitForAllocsRunning(t, tc.Nomad(), allocIDs)
 }

--- a/e2e/connect/input/native-demo.nomad
+++ b/e2e/connect/input/native-demo.nomad
@@ -1,0 +1,71 @@
+job "cn-demo" {
+  datacenters = ["dc1"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "generator" {
+    network {
+      port "api" {}
+    }
+
+    service {
+      name = "uuid-api"
+      port = "${NOMAD_PORT_api}"
+      task = "generate"
+
+      connect {
+        native = true
+      }
+    }
+
+    task "generate" {
+      driver = "docker"
+
+      config {
+        image        = "hashicorpnomad/uuid-api:v1"
+        network_mode = "host"
+      }
+
+      env {
+        BIND = "0.0.0.0"
+        PORT = "${NOMAD_PORT_api}"
+      }
+    }
+  }
+
+  group "frontend" {
+    network {
+      port "http" {
+        static = 9800
+      }
+    }
+
+    service {
+      name = "uuid-fe"
+      port = "9800"
+      task = "frontend"
+
+      connect {
+        native = true
+      }
+    }
+
+    task "frontend" {
+      driver = "docker"
+
+      config {
+        image        = "hashicorpnomad/uuid-fe:v1"
+        network_mode = "host"
+      }
+
+      env {
+        UPSTREAM = "uuid-api"
+        BIND     = "0.0.0.0"
+        PORT     = "9800"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds 2 tests around Connect Native. Both make use of the example connect native
services in https://github.com/hashicorp/nomad-connect-examples

One of them runs without Consul ACLs enabled, the other with.

Also replaces a bunch of Connect test's manual alloc setup & waiting & checking with e2e helpers. 