### PR TITLE
Change connectDriverConfig to be a func

### DIFF
--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -20,13 +20,15 @@ var (
 
 	// connectDriverConfig is the driver configuration used by the injected
 	// connect proxy sidecar task
-	connectDriverConfig = map[string]interface{}{
-		"image": "${meta.connect.sidecar_image}",
-		"args": []interface{}{
-			"-c", structs.EnvoyBootstrapPath,
-			"-l", "${meta.connect.log_level}",
-			"--disable-hot-restart",
-		},
+	connectDriverConfig = func() map[string]interface{} {
+		return map[string]interface{}{
+			"image": "${meta.connect.sidecar_image}",
+			"args": []interface{}{
+				"-c", structs.EnvoyBootstrapPath,
+				"-l", "${meta.connect.log_level}",
+				"--disable-hot-restart",
+			},
+		}
 	}
 
 	// connectVersionConstraint is used when building the sidecar task to ensure
@@ -172,7 +174,7 @@ func newConnectTask(serviceName string) *structs.Task {
 		Name:          fmt.Sprintf("%s-%s", structs.ConnectProxyPrefix, serviceName),
 		Kind:          structs.NewTaskKind(structs.ConnectProxyPrefix, serviceName),
 		Driver:        "docker",
-		Config:        connectDriverConfig,
+		Config:        connectDriverConfig(),
 		ShutdownDelay: 5 * time.Second,
 		LogConfig: &structs.LogConfig{
 			MaxFiles:      2,

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -420,7 +420,7 @@ func TestJobEndpoint_Register_ConnectWithSidecarTask(t *testing.T) {
 	require.Equal("test", sidecarTask.Meta["source"])
 	require.Equal(500, sidecarTask.Resources.CPU)
 	require.Equal(connectSidecarResources().MemoryMB, sidecarTask.Resources.MemoryMB)
-	cfg := connectDriverConfig
+	cfg := connectDriverConfig()
 	cfg["labels"] = map[string]interface{}{
 		"foo": "bar",
 	}
@@ -5597,9 +5597,9 @@ func TestJobEndpoint_Scale_DeploymentBlocking(t *testing.T) {
 
 		// attempt to scale
 		originalCount := job.TaskGroups[0].Count
-		newCount := int64(originalCount+1)
+		newCount := int64(originalCount + 1)
 		groupName := job.TaskGroups[0].Name
-		scalingMetadata :=	map[string]interface{}{
+		scalingMetadata := map[string]interface{}{
 			"meta": "data",
 		}
 		scalingMessage := "original reason for scaling"
@@ -5692,7 +5692,7 @@ func TestJobEndpoint_Scale_InformationalEventsShouldNotBeBlocked(t *testing.T) {
 
 		// register informational scaling event
 		groupName := job.TaskGroups[0].Name
-		scalingMetadata :=	map[string]interface{}{
+		scalingMetadata := map[string]interface{}{
 			"meta": "data",
 		}
 		scalingMessage := "original reason for scaling"


### PR DESCRIPTION
This fixes #8337

Change the connectDriverConfig to be a function that returns the configuration map. Otherwise when that map is modified,
all new sidecar task will get that same configuration.