### PR TITLE
deflake some commands package tests

### DIFF
--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -84,6 +84,9 @@ type TestAgent struct {
 
 	// Enterprise specifies if the agent is enterprise or not
 	Enterprise bool
+
+	// shutdown is set to true if agent has been shutdown
+	shutdown bool
 }
 
 // NewTestAgent returns a started agent with the given name and
@@ -259,6 +262,11 @@ func (a *TestAgent) start() (*Agent, error) {
 // Shutdown stops the agent and removes the data directory if it is
 // managed by the test agent.
 func (a *TestAgent) Shutdown() error {
+	if a.shutdown {
+		return nil
+	}
+	a.shutdown = true
+
 	defer freeport.Return(a.ports)
 
 	defer func() {


### PR DESCRIPTION
Avoid double freeing ports if an agent.Shutdown() is called multiple times.

This deflakes many `command/` package tests, where `freeport` was returning the same port twice!  For example, in [this job](https://app.circleci.com/pipelines/github/hashicorp/nomad/10377/workflows/10e7b571-7acc-4266-8614-81d41c8a6ed9/jobs/81540), `TestPlanCommand_Fails` got port 9416 as both the http and RPC ports, and as expected, the http server fails to start due to the port conflict.

This issue is due to double shutting down the agent.  When an `agent.Shutdown` is called twice, `freeport` package attempts to add the freedports to pool of available ports multiple times, risking multiple assignments of the port!

The issue was exacerbated in https://github.com/hashicorp/nomad/pull/8296.  The PR attempted to ensure that a test server is always shutdown but we didn't remove all shutdown calls.