### PR TITLE
nvidia: support disabling the nvidia plugin

### DIFF
--- a/client/devicemanager/instance.go
+++ b/client/devicemanager/instance.go
@@ -336,7 +336,11 @@ START:
 
 	// Start fingerprinting
 	fingerprintCh, err := devicePlugin.Fingerprint(i.ctx)
-	if err != nil {
+	if err == device.ErrPluginDisabled {
+		i.logger.Info("fingerprinting failed: plugin is not enabled")
+		i.handleFingerprintError()
+		return
+	} else if err != nil {
 		i.logger.Error("fingerprinting failed", "error", err)
 		i.handleFingerprintError()
 		return

--- a/devices/gpu/nvidia/device.go
+++ b/devices/gpu/nvidia/device.go
@@ -70,8 +70,6 @@ var (
 			hclspec.NewLiteral("\"1m\""),
 		),
 	})
-
-	errDeviceNotEnabled = fmt.Errorf("Nvidia device is not enabled")
 )
 
 // Config contains configuration information for the plugin.
@@ -160,7 +158,7 @@ func (d *NvidiaDevice) SetConfig(cfg *base.Config) error {
 // devices health changes, messages will be emitted.
 func (d *NvidiaDevice) Fingerprint(ctx context.Context) (<-chan *device.FingerprintResponse, error) {
 	if !d.enabled {
-		return nil, errDeviceNotEnabled
+		return nil, device.ErrPluginDisabled
 	}
 
 	outCh := make(chan *device.FingerprintResponse)
@@ -184,7 +182,7 @@ func (d *NvidiaDevice) Reserve(deviceIDs []string) (*device.ContainerReservation
 		return &device.ContainerReservation{}, nil
 	}
 	if !d.enabled {
-		return nil, errDeviceNotEnabled
+		return nil, device.ErrPluginDisabled
 	}
 
 	// Due to the asynchronous nature of NvidiaPlugin, there is a possibility
@@ -221,7 +219,7 @@ func (d *NvidiaDevice) Reserve(deviceIDs []string) (*device.ContainerReservation
 // Stats streams statistics for the detected devices.
 func (d *NvidiaDevice) Stats(ctx context.Context, interval time.Duration) (<-chan *device.StatsResponse, error) {
 	if !d.enabled {
-		return nil, errDeviceNotEnabled
+		return nil, device.ErrPluginDisabled
 	}
 
 	outCh := make(chan *device.StatsResponse)

--- a/devices/gpu/nvidia/device_test.go
+++ b/devices/gpu/nvidia/device_test.go
@@ -26,7 +26,7 @@ func (c *MockNvmlClient) GetStatsData() ([]*nvml.StatsData, error) {
 }
 
 func TestReserve(t *testing.T) {
-	for _, testCase := range []struct {
+	cases := []struct {
 		Name                string
 		ExpectedReservation *device.ContainerReservation
 		ExpectedError       error
@@ -47,7 +47,8 @@ func TestReserve(t *testing.T) {
 				"UUID3",
 			},
 			Device: &NvidiaDevice{
-				logger: hclog.NewNullLogger(),
+				logger:  hclog.NewNullLogger(),
+				enabled: true,
 			},
 		},
 		{
@@ -66,7 +67,8 @@ func TestReserve(t *testing.T) {
 				devices: map[string]struct{}{
 					"UUID3": {},
 				},
-				logger: hclog.NewNullLogger(),
+				logger:  hclog.NewNullLogger(),
+				enabled: true,
 			},
 		},
 		{
@@ -88,7 +90,8 @@ func TestReserve(t *testing.T) {
 					"UUID2": {},
 					"UUID3": {},
 				},
-				logger: hclog.NewNullLogger(),
+				logger:  hclog.NewNullLogger(),
+				enabled: true,
 			},
 		},
 		{
@@ -102,13 +105,36 @@ func TestReserve(t *testing.T) {
 					"UUID2": {},
 					"UUID3": {},
 				},
-				logger: hclog.NewNullLogger(),
+				logger:  hclog.NewNullLogger(),
+				enabled: true,
 			},
 		},
-	} {
-		actualReservation, actualError := testCase.Device.Reserve(testCase.RequestedIDs)
-		req := require.New(t)
-		req.Equal(testCase.ExpectedReservation, actualReservation)
-		req.Equal(testCase.ExpectedError, actualError)
+		{
+			Name:                "Device is disabled",
+			ExpectedReservation: nil,
+			ExpectedError:       errDeviceNotEnabled,
+			RequestedIDs: []string{
+				"UUID1",
+				"UUID2",
+				"UUID3",
+			},
+			Device: &NvidiaDevice{
+				devices: map[string]struct{}{
+					"UUID1": {},
+					"UUID2": {},
+					"UUID3": {},
+				},
+				logger:  hclog.NewNullLogger(),
+				enabled: false,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			actualReservation, actualError := c.Device.Reserve(c.RequestedIDs)
+			require.Equal(t, c.ExpectedReservation, actualReservation)
+			require.Equal(t, c.ExpectedError, actualError)
+		})
 	}
 }

--- a/devices/gpu/nvidia/device_test.go
+++ b/devices/gpu/nvidia/device_test.go
@@ -112,7 +112,7 @@ func TestReserve(t *testing.T) {
 		{
 			Name:                "Device is disabled",
 			ExpectedReservation: nil,
-			ExpectedError:       errDeviceNotEnabled,
+			ExpectedError:       device.ErrPluginDisabled,
 			RequestedIDs: []string{
 				"UUID1",
 				"UUID2",

--- a/plugins/device/device.go
+++ b/plugins/device/device.go
@@ -15,6 +15,11 @@ const (
 	DeviceTypeGPU = "gpu"
 )
 
+var (
+	// ErrPluginDisabled indicates that the device plugin is disabled
+	ErrPluginDisabled = fmt.Errorf("device is not enabled")
+)
+
 // DevicePlugin is the interface for a plugin that can expose detected devices
 // to Nomad and inform it how to mount them.
 type DevicePlugin interface {


### PR DESCRIPTION
This provides a workaround for where nomad does not support the nvidia driver library installed on host.  The crash in https://github.com/hashicorp/nomad/issues/8303 is a result of an attempt to fingerprint using a C function that's not resolved, so process crashes.  Because this happens before agent is up, the logs are completely hidden.

To disable the plugin, one adds the following to the agent config:

```hcl
plugin "nvidia-gpu" {
  config {
    enabled = false
  }
}
```

Fixes https://github.com/hashicorp/nomad/issues/8303