### PR TITLE
nomad: fix dropped test error

### DIFF
--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -380,6 +380,7 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 		Secrets:            structs.CSISecrets{"mysecret": "secretvalue"},
 	}}
 	err = state.CSIVolumeRegister(1003, vols)
+	require.NoError(t, err)
 
 	alloc := mock.BatchAlloc()
 	alloc.NodeID = node.ID


### PR DESCRIPTION
This fixes a dropped error in `nomad/csi_endpoint_test.go `.