### PR TITLE
Adds Docker Nvidia device request support

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -952,6 +952,17 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 			CgroupPermissions: device.Permissions,
 		})
 	}
+        // Add Nvidia GPUs to request
+        for _, deviceResources := range task.Resources.NomadResources.Devices {
+                if deviceResources.Vendor == "nvidia" {
+                        hostConfig.DeviceRequests = append(hostConfig.DeviceRequests, docker.DeviceRequest{
+                                Driver:         "nvidia",
+                                DeviceIDs:      deviceResources.DeviceIDs,
+                                // TODO This should be able to be left empty
+                                Capabilities:   [][]string{{"gpu"}},
+                        })
+                }
+        }
 
 	// Setup mounts
 	for _, m := range driverConfig.Mounts {


### PR DESCRIPTION
This is an attempt/draft for support of the `--gpus` CLI flag/DeviceRequest configuration for Docker v19.03+ discussed in #8234. Initial testing seems to suggest it works, but more testing is probably need to ensure backwards compatibility. In order for this to work in it's current state, Nomad needs to be configured so that the client option `docker.nvidia_runtime=runc` (I do not know if this is desirable or not).

I understand that support for Docker v19.03+ is underway in #8127, but the PR in fsouza/go-dockerclient#822 seemed to suggest an alternative that works right now.