### PR TITLE
allow version skipping in Job.Register to support version syncing for MRD

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -303,7 +303,11 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 
 	// Submit a multiregion job to other regions (enterprise only).
 	// The job will have its region interpolated.
-	err = j.multiregionRegister(args, reply)
+	var existingVersion uint64
+	if existingJob != nil {
+		existingVersion = existingJob.Version
+	}
+	err = j.multiregionRegister(args, reply, existingVersion)
 	if err != nil {
 		return err
 	}

--- a/nomad/job_endpoint_oss.go
+++ b/nomad/job_endpoint_oss.go
@@ -10,7 +10,9 @@ func (j *Job) enforceSubmitJob(override bool, job *structs.Job) (error, error) {
 }
 
 // multiregionRegister is used to send a job across multiple regions
-func (j *Job) multiregionRegister(args *structs.JobRegisterRequest, reply *structs.JobRegisterResponse) error {
+func (j *Job) multiregionRegister(args *structs.JobRegisterRequest, reply *structs.JobRegisterResponse,
+	existingVersion uint64) error {
+
 	return nil
 }
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1351,12 +1351,16 @@ func (s *StateStore) upsertJobImpl(index uint64, job *structs.Job, keepVersion b
 		job.CreateIndex = existing.(*structs.Job).CreateIndex
 		job.ModifyIndex = index
 
+		existingJob := existing.(*structs.Job)
+
 		// Bump the version unless asked to keep it. This should only be done
 		// when changing an internal field such as Stable. A spec change should
 		// always come with a version bump
 		if !keepVersion {
 			job.JobModifyIndex = index
-			job.Version = existing.(*structs.Job).Version + 1
+			if job.Version <= existingJob.Version {
+				job.Version = existingJob.Version + 1
+			}
 		}
 
 		// Compute the job status


### PR DESCRIPTION
this PR modifies the logic in upsertJobImpl to allow version skipping; i.e., the version in the registered job is used as long as it is larger than the existing version. The preserves the invariant that job versions are monotonically increasing.

