### PR TITLE
fix multiregion plan output flags

### DIFF
--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -195,7 +195,7 @@ func (c *JobPlanCommand) multiregionPlan(client *api.Client, job *api.Job, opts 
 
 	for regionName, resp := range plans {
 		c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[bold]Region: %q[reset]", regionName)))
-		regionExitCode := c.outputPlannedJob(job, resp, verbose, diff)
+		regionExitCode := c.outputPlannedJob(job, resp, diff, verbose)
 		if regionExitCode > exitCode {
 			exitCode = regionExitCode
 		}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8376

The call to render the output diff swapped the `diff` and `verbose` bool parameters, resulting in dropping the diff output in multi-region plans but not single-region plans.