### PR TITLE
fix swapped old/new multiregion plan diffs

### DIFF
--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1054,7 +1054,7 @@ func multiregionDiff(old, new *Multiregion, contextual bool) *ObjectDiff {
 	for name, oldRegion := range oldMap {
 		// Diff the same, deleted and edited
 		newRegion := newMap[name]
-		rdiff := multiregionRegionDiff(newRegion, oldRegion, contextual)
+		rdiff := multiregionRegionDiff(oldRegion, newRegion, contextual)
 		if rdiff != nil {
 			diff.Objects = append(diff.Objects, rdiff)
 		}

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -1210,8 +1210,8 @@ func TestJobDiff(t *testing.T) {
 					Regions: []*MultiregionRegion{
 						{
 							Name:        "west",
-							Count:       1,
-							Datacenters: []string{"west-1"},
+							Count:       3,
+							Datacenters: []string{"west-2"},
 							Meta:        map[string]string{"region_code": "W"},
 						},
 						{
@@ -1223,7 +1223,6 @@ func TestJobDiff(t *testing.T) {
 					},
 				},
 			},
-
 			Expected: &JobDiff{
 				Type: DiffTypeEdited,
 				Objects: []*ObjectDiff{
@@ -1231,6 +1230,38 @@ func TestJobDiff(t *testing.T) {
 						Type: DiffTypeEdited,
 						Name: "Multiregion",
 						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "Region",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeEdited,
+										Name: "Count",
+										Old:  "1",
+										New:  "3",
+									},
+								},
+								Objects: []*ObjectDiff{
+									{
+										Type: DiffTypeEdited,
+										Name: "Datacenters",
+										Fields: []*FieldDiff{
+											{
+												Type: DiffTypeAdded,
+												Name: "Datacenters",
+												Old:  "",
+												New:  "west-2",
+											},
+											{
+												Type: DiffTypeDeleted,
+												Name: "Datacenters",
+												Old:  "west-1",
+												New:  "",
+											},
+										},
+									},
+								},
+							},
 							{
 								Type: DiffTypeAdded,
 								Name: "Region",


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8377

The multiregion plan diffs swap the old and new versions for each region when they're edited (rather than added/removed). The `multiregionRegionDiff` function call incorrectly reversed its arguments for existing regions.