### PR TITLE
correcting CSI Plugins API sample response

### DIFF
--- a/website/pages/api-docs/plugins.mdx
+++ b/website/pages/api-docs/plugins.mdx
@@ -88,10 +88,6 @@ $ curl \
 [
   {
     "ID": "example_plugin_id",
-    "Topologies": [
-      {"key": "val"},
-      {"key": "val2"}
-    ],
     "Provider": "aws.ebs",
     "Version": "1.0.1",
     "ControllersRequired": true,


### PR DESCRIPTION
neither `structs.CSIPlugin` nor `api.CSIPlugin` contain `topologies`