### PR TITLE
[docs] more specific link in enterprise docs

### DIFF
--- a/website/pages/docs/enterprise/index.mdx
+++ b/website/pages/docs/enterprise/index.mdx
@@ -91,7 +91,7 @@ See the [Sentinel Policies Guide](https://learn.hashicorp.com/nomad/governance-a
 ### Cross-Namespace Queries
 Cross-Namespace Queries allows operators to query jobs and allocations across all namespaces for faster operator debugging and visibility in multi-tenant clusters. This enterprise feature accelerates and simplifies the debugging process by allowing operators to easily locate faulty jobs and allocations from developers.
 
-See the [Nomad CLI commands](https://www.nomadproject.io/docs/commands/alloc/exec) documentation for a thorough overview.
+See the individual Nomad CLI command documentation (e.g., [alloc exec](https://www.nomadproject.io/docs/commands/alloc/exec#namespace)) for more information.
 
 ## Multi-Cluster & Efficiency
 


### PR DESCRIPTION
linked to an actual example of `-namespace=*` in the command docs