### PR TITLE
nomad: recanonicalize network after connect hook

### DIFF
--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -178,6 +178,9 @@ func groupConnectHook(job *structs.Job, g *structs.TaskGroup) error {
 			}
 		}
 	}
+
+	// re-canonicalize group network since this hook runs after canonicalizaton
+	g.Networks[0].Canonicalize()
 	return nil
 }
 

--- a/nomad/job_endpoint_hook_connect_test.go
+++ b/nomad/job_endpoint_hook_connect_test.go
@@ -100,6 +100,7 @@ func TestJobEndpointConnect_groupConnectHook(t *testing.T) {
 			To:    -1,
 		},
 	}
+	tgOut.Networks[0].Canonicalize()
 
 	require.NoError(t, groupConnectHook(job, job.TaskGroups[0]))
 	require.Exactly(t, tgOut, job.TaskGroups[0])


### PR DESCRIPTION
With the addition of `host_network` to the `port` block, the group network needs to be re-canonicalized to set correct defaults. 