### PR TITLE
UI: Filter out new records from the job list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BUG FIXES:
  * ui: Fixed order of column headers in client allocations table. [[GH-8409](https://github.com/hashicorp/nomad/pull/8409)]
  * ui: Fixed stale namespaces after changing acl tokens. [[GH-8413](https://github.com/hashicorp/nomad/issues/8413)]
  * ui: Fixed missing namespace query param after changing acl tokens [[GH-8413](https://github.com/hashicorp/nomad/issues/8413)]
+ * ui: Fixed runtime error when clicking "Run Job" while a prefix filter is set [[GH-8412](https://github.com/hashicorp/nomad/issues/8412)]
  * vault: Fixed a bug where vault identity policies not considered in permissions check [[GH-7732](https://github.com/hashicorp/nomad/issues/7732)]
 
 ## 0.12.0 (July 9, 2020)

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -163,6 +163,7 @@ export default class IndexController extends Controller.extend(Sortable, Searcha
 
     return this.model
       .compact()
+      .filter(job => !job.isNew)
       .filter(job => !hasNamespaces || job.get('namespace.id') === activeNamespace)
       .filter(job => !job.get('parent.content'));
   }

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -452,5 +452,19 @@ module('Acceptance | jobs list', function(hooks) {
         'URL has the correct query param key and value'
       );
     });
+
+    test('the run job button works when filters are set', async function(assert) {
+      ['pre-one', 'pre-two', 'pre-three'].forEach(name => {
+        server.create('job', { name, createAllocations: false, childrenCount: 0 });
+      });
+
+      await JobsList.visit();
+
+      await JobsList.facets.prefix.toggle();
+      await JobsList.facets.prefix.options[0].toggle();
+
+      await JobsList.runJobButton.click();
+      assert.equal(currentURL(), '/jobs/run');
+    });
   }
 });


### PR DESCRIPTION
When a prefix is set and the run job button is clicked, the new job would cause an error because it has no name yet.

Closes #7032