### PR TITLE
UI: Reset the system and refetch namespaces with every token change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 BUG FIXES:
 
  * ui: Fixed order of column headers in client allocations table. [[GH-8409](https://github.com/hashicorp/nomad/pull/8409)]
+ * ui: Fixed stale namespaces after changing acl tokens. [[GH-8413](https://github.com/hashicorp/nomad/issues/8413)]
+ * ui: Fixed missing namespace query param after changing acl tokens [[GH-8413](https://github.com/hashicorp/nomad/issues/8413)]
  * vault: Fixed a bug where vault identity policies not considered in permissions check [[GH-7732](https://github.com/hashicorp/nomad/issues/7732)]
 
 ## 0.12.0 (July 9, 2020)

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -31,6 +31,8 @@ export default class Tokens extends Controller {
       tokenIsValid: false,
       tokenIsInvalid: false,
     });
+    // Clear out all data to ensure only data the anonymous token is privileged to see is shown
+    this.system.reset();
     this.resetStore();
     this.token.reset();
   }
@@ -44,8 +46,7 @@ export default class Tokens extends Controller {
 
     TokenAdapter.findSelf().then(
       () => {
-        // Clear out all data to ensure only data the new token is privileged to
-        // see is shown
+        // Clear out all data to ensure only data the new token is privileged to see is shown
         this.system.reset();
         this.resetStore();
 

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -128,5 +128,6 @@ export default class SystemService extends Service {
 
   reset() {
     this.set('activeNamespace', null);
+    this.notifyPropertyChange('namespaces');
   }
 }

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -12,7 +12,7 @@
             <p>Tokens are stored client-side in <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage">local storage</a>. This will persist your token across sessions. You can manually clear your token here.</p>
           </div>
           <div class="column is-centered is-minimum">
-            <button class="button is-info" {{action "clearTokenProperties"}} type="button">Clear Token</button>
+            <button data-test-token-clear class="button is-info" {{action "clearTokenProperties"}} type="button">Clear Token</button>
           </div>
         </div>
       </div>

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -141,6 +141,23 @@ module('Acceptance | tokens', function(hooks) {
     assert.notOk(find('[data-test-job-row]'), 'No jobs found');
   });
 
+  test('when namespaces are enabled, setting or clearing a token refetches namespaces available with new permissions', async function(assert) {
+    const { secretId } = clientToken;
+
+    server.createList('namespace', 2);
+    await Tokens.visit();
+
+    const requests = server.pretender.handledRequests;
+
+    assert.equal(requests.filter(req => req.url === '/v1/namespaces').length, 1);
+
+    await Tokens.secret(secretId).submit();
+    assert.equal(requests.filter(req => req.url === '/v1/namespaces').length, 2);
+
+    await Tokens.clear();
+    assert.equal(requests.filter(req => req.url === '/v1/namespaces').length, 3);
+  });
+
   function getHeader({ requestHeaders }, name) {
     // Headers are case-insensitive, but object property look up is not
     return (

--- a/ui/tests/pages/settings/tokens.js
+++ b/ui/tests/pages/settings/tokens.js
@@ -13,6 +13,7 @@ export default create({
 
   secret: fillable('[data-test-token-secret]'),
   submit: clickable('[data-test-token-submit]'),
+  clear: clickable('[data-test-token-clear]'),
 
   errorMessage: isVisible('[data-test-token-error]'),
   successMessage: isVisible('[data-test-token-success]'),


### PR DESCRIPTION
Fixes #6492

Curiously, when I attempted to fix the reported issue, I couldn't find the root cause. For some reason, despite the namespace being in localStorage and in the system service, it couldn't be looked up via `this.get('system.activeNamespace.id')`. It would just be `undefined`. More curious yet, `this.get('system.activeNamespace').id` worked.

While poking at that, I noticed that the namespaces list would be stale after a token change, since different tokens will allow access to different sets of namespaces. Fixing that issue coincidentally fixed the reporting issue. I'll take it ¯\_(ツ)_/¯