### PR TITLE
docs: fix minor incorrect syntax in autoscaling plugin docs.

### DIFF
--- a/website/pages/docs/autoscaling/plugins/apm.mdx
+++ b/website/pages/docs/autoscaling/plugins/apm.mdx
@@ -54,7 +54,7 @@ ensuring it is not put under excessive load pressure.
 ### Agent Configuration Options
 
 ```hcl
-target "nomad-apm" {
+apm "nomad-apm" {
   driver = "nomad-apm"
 }
 ```

--- a/website/pages/docs/job-specification/scaling.mdx
+++ b/website/pages/docs/job-specification/scaling.mdx
@@ -10,7 +10,8 @@ description: The "scaling" stanza allows specifying scaling policy for a task gr
 <Placement groups={['job', 'group']} />
 
 The `scaling` stanza allows configuring scaling options for a task group, for the purpose
-of supporting external autoscalers like the [Nomad Autoscaler](https://github.com/hashicorp/nomad-autoscaler).
+of supporting external autoscalers like the [Nomad Autoscaler](https://github.com/hashicorp/nomad-autoscaler)
+and scaling via the Nomad UI.
 
 ```hcl
 job "example" {


### PR DESCRIPTION
This changes fixes a syntax error in the autoscaling apm plugin
docs as well as updates the scaling stanza doc. The stazna wording
implied its use was only for external autoscalers, whereas it also
is used by the UI.