### PR TITLE
build: update from Go 1.14.4 to Go 1.14.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -128,7 +128,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -246,7 +246,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -364,7 +364,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -574,7 +574,7 @@ jobs:
         path: c:\tmp\test-reports
     environment:
     - GOBIN: c:\gopath\bin
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOPATH: c:\gopath
     - GOTESTSUM_PATH: c:\tmp\test-reports
     - GOTESTSUM_VERSION: 0.4.2
@@ -587,7 +587,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -732,7 +732,7 @@ jobs:
         path: /tmp/test-reports
   lint-go:
     docker:
-    - image: golang:1.14.4
+    - image: golang:1.14.5
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout
@@ -798,7 +798,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -912,7 +912,7 @@ jobs:
         path: /tmp/test-reports
   test-devices:
     docker:
-    - image: golang:1.14.4
+    - image: golang:1.14.5
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -1041,7 +1041,7 @@ jobs:
         path: pkg/darwin_amd64.zip
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOMAXPROCS: 1
     - GOPATH: /Users/distiller/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -1070,7 +1070,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -1184,7 +1184,7 @@ jobs:
         path: /tmp/test-reports
   build-binaries:
     docker:
-    - image: golang:1.14.4
+    - image: golang:1.14.5
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -1218,7 +1218,7 @@ jobs:
         path: pkg/linux_amd64.zip
   test-e2e:
     docker:
-    - image: golang:1.14.4
+    - image: golang:1.14.5
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout
@@ -1250,7 +1250,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.4
+    - GOLANG_VERSION: 1.14.5
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json

--- a/.circleci/config/config.yml
+++ b/.circleci/config/config.yml
@@ -24,7 +24,7 @@ executors:
   go:
     working_directory: /go/src/github.com/hashicorp/nomad
     docker:
-      - image: golang:1.14.4
+      - image: golang:1.14.5
     environment:
       <<: *common_envs
       GOPATH: /go
@@ -36,7 +36,7 @@ executors:
     environment: &machine_env
       <<: *common_envs
       GOPATH: /home/circleci/go
-      GOLANG_VERSION: 1.14.4
+      GOLANG_VERSION: 1.14.5
 
   # uses a more recent image with unattended upgrades disabled properly
   # but seems to break docker builds
@@ -53,7 +53,7 @@ executors:
     environment:
       <<: *common_envs
       GOPATH: /Users/distiller/go
-      GOLANG_VERSION: 1.14.4
+      GOLANG_VERSION: 1.14.5
 
   go-windows:
     machine:
@@ -65,6 +65,6 @@ executors:
       GOPATH: c:\gopath
       GOBIN: c:\gopath\bin
       GOTESTSUM_PATH: c:\tmp\test-reports
-      GOLANG_VERSION: 1.14.4
+      GOLANG_VERSION: 1.14.5
       GOTESTSUM_VERSION: 0.4.2
       VAULT_VERSION: 1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.12.1 (Unreleased)
 
+SECURITY:
+
+ * build: Updated to Go 1.14.5. Go 1.14.4 contained 2 CVEs which are low severity for Nomad. [[GH-8441](https://github.com/hashicorp/nomad/issues/8441)]
+
 BUG FIXES:
 
  * jobspec: Fixed validation of multi-region datacenters to allow empty region `datacenters` to default to job-level `datacenters`. [[GH-8426](https://github.com/hashicorp/nomad/issues/8426)]

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Who Uses Nomad
 Contributing to Nomad
 --------------------
 
-If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.14.4+ is *required*, and `gcc-go` is not supported).
+If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.14.5+ is *required*, and `gcc-go` is not supported).
 
 See the [`contributing`](contributing/) directory for more developer documentation.
 

--- a/scripts/release/mac-remote-build
+++ b/scripts/release/mac-remote-build
@@ -56,7 +56,7 @@ REPO_PATH="${TMP_WORKSPACE}/gopath/src/github.com/hashicorp/nomad"
 mkdir -p "${TMP_WORKSPACE}/tmp"
 
 install_go() {
-  local go_version="1.14.4"
+  local go_version="1.14.5"
   local download=
 
   download="https://storage.googleapis.com/golang/go${go_version}.darwin-amd64.tar.gz"

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function install_go() {
-	local go_version="1.14.4"
+	local go_version="1.14.5"
 	local download=
 
 	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"


### PR DESCRIPTION
Go 1.14.4 contains two CVEs which are fixed in 1.14.5:

 - [CVE-2020-15586](https://golang.org/issue/34902)
 - [CVE-2020-14039](https://golang.org/issue/39360)

Upon consideration with HashiCorp security these CVEs are considered low
severity for Nomad and no new security fix binary will be released.