### PR TITLE
consul/connect: add support for bridge networks with connect native tasks

### DIFF
--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -64,6 +64,10 @@ var (
 	// AllocGRPCSocket is the path relative to the task dir root for the
 	// unix socket connected to Consul's gRPC endpoint.
 	AllocGRPCSocket = filepath.Join(SharedAllocName, TmpDirName, "consul_grpc.sock")
+
+	// AllocHTTPSocket is the path relative to the task dir root for the unix
+	// socket connected to Consul's HTTP endpoint.
+	AllocHTTPSocket = filepath.Join(SharedAllocName, TmpDirName, "consul_http.sock")
 )
 
 // AllocDir allows creating, destroying, and accessing an allocation's

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -167,7 +167,8 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 			taskEnvBuilder: taskenv.NewBuilder(config.Node, ar.Alloc(), nil, config.Region).SetAllocDir(ar.allocDir.AllocDir),
 			logger:         hookLogger,
 		}),
-		newConsulSockHook(hookLogger, alloc, ar.allocDir, config.ConsulConfig),
+		newConsulGRPCSocketHook(hookLogger, alloc, ar.allocDir, config.ConsulConfig),
+		newConsulHTTPSocketHook(hookLogger, alloc, ar.allocDir, config.ConsulConfig),
 		newCSIHook(ar, hookLogger, alloc, ar.rpcClient, ar.csiManager, hrs),
 	}
 

--- a/client/allocrunner/consul_grpc_sock_hook.go
+++ b/client/allocrunner/consul_grpc_sock_hook.go
@@ -57,8 +57,14 @@ func (*consulGRPCSocketHook) Name() string {
 // Requires the mutex to be held.
 func (h *consulGRPCSocketHook) shouldRun() bool {
 	tg := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup)
+
+	// we must be in bridge networking and at least one connect sidecar task
+	if !tgFirstNetworkIsBridge(tg) {
+		return false
+	}
+
 	for _, s := range tg.Services {
-		if s.Connect.HasSidecar() { // todo(shoenig) check we are in bridge mode
+		if s.Connect.HasSidecar() {
 			return true
 		}
 	}

--- a/client/allocrunner/consul_grpc_sock_hook.go
+++ b/client/allocrunner/consul_grpc_sock_hook.go
@@ -33,12 +33,12 @@ var (
 // Noop for allocations without a group Connect stanza using bridge networking.
 type consulGRPCSocketHook struct {
 	logger hclog.Logger
-	alloc  *structs.Allocation
-	proxy  *grpcSocketProxy
 
-	// mu synchronizes proxy as they may be mutated and accessed
-	// concurrently via Prerun, Update, Postrun.
-	mu sync.Mutex
+	// mu synchronizes proxy and alloc which may be mutated and read concurrently
+	// via Prerun, Update, Postrun.
+	mu    sync.Mutex
+	alloc *structs.Allocation
+	proxy *grpcSocketProxy
 }
 
 func newConsulGRPCSocketHook(logger hclog.Logger, alloc *structs.Allocation, allocDir *allocdir.AllocDir, config *config.ConsulConfig) *consulGRPCSocketHook {

--- a/client/allocrunner/consul_grpc_sock_hook.go
+++ b/client/allocrunner/consul_grpc_sock_hook.go
@@ -21,6 +21,10 @@ import (
 
 const (
 	consulGRPCSockHookName = "consul_grpc_socket"
+
+	// socketProxyStopWaitTime is the amount of time to wait for a socket proxy
+	// to stop before assuming something went awry and return a timeout error.
+	socketProxyStopWaitTime = 3 * time.Second
 )
 
 var (
@@ -222,7 +226,7 @@ func (p *grpcSocketProxy) stop() error {
 	select {
 	case <-p.doneCh:
 		return nil
-	case <-time.After(3 * time.Second):
+	case <-time.After(socketProxyStopWaitTime):
 		return errSocketProxyTimeout
 	}
 }

--- a/client/allocrunner/consul_http_sock_hook.go
+++ b/client/allocrunner/consul_http_sock_hook.go
@@ -1,0 +1,202 @@
+package allocrunner
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/pkg/errors"
+)
+
+const (
+	consulHTTPSocketHookName = "consul_http_socket"
+)
+
+type consulHTTPSockHook struct {
+	logger hclog.Logger
+	alloc  *structs.Allocation
+	proxy  *httpSocketProxy
+
+	// lock synchronizes proxy which may be mutated and read concurrently via
+	// Prerun, Update, and Postrun.
+	lock sync.Mutex
+}
+
+func newConsulHTTPSocketHook(logger hclog.Logger, alloc *structs.Allocation, allocDir *allocdir.AllocDir, config *config.ConsulConfig) *consulHTTPSockHook {
+	return &consulHTTPSockHook{
+		alloc:  alloc,
+		proxy:  newHTTPSocketProxy(logger, allocDir, config),
+		logger: logger.Named(consulHTTPSocketHookName),
+	}
+}
+
+func (*consulHTTPSockHook) Name() string {
+	return consulHTTPSocketHookName
+}
+
+// shouldRun returns true if the alloc contains at least one connect native
+// task and has a network configured in bridge mode
+//
+// todo(shoenig): what about CNI networks?
+func (h *consulHTTPSockHook) shouldRun() bool {
+	// we must be in bridge networking and at least one connect native task
+	tg := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup)
+	if len(tg.Networks) < 1 || tg.Networks[0].Mode != "bridge" {
+		return false
+	}
+
+	for _, service := range tg.Services {
+		if service.Connect.IsNative() {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *consulHTTPSockHook) Prerun() error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	if !h.shouldRun() {
+		return nil
+	}
+
+	return h.proxy.run(h.alloc)
+}
+
+func (h *consulHTTPSockHook) Update(req *interfaces.RunnerUpdateRequest) error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	h.alloc = req.Alloc
+
+	if !h.shouldRun() {
+		return nil
+	}
+
+	return h.proxy.run(h.alloc)
+}
+
+func (h *consulHTTPSockHook) Postrun() error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	if err := h.proxy.stop(); err != nil {
+		// Only log a failure to stop, worst case is the proxy leaks a goroutine.
+		h.logger.Debug("error stopping Consul HTTP proxy", "error", err)
+	}
+
+	return nil
+}
+
+type httpSocketProxy struct {
+	logger   hclog.Logger
+	allocDir *allocdir.AllocDir
+	config   *config.ConsulConfig
+
+	ctx     context.Context
+	cancel  func()
+	doneCh  chan struct{}
+	runOnce bool
+}
+
+func newHTTPSocketProxy(logger hclog.Logger, allocDir *allocdir.AllocDir, config *config.ConsulConfig) *httpSocketProxy {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &httpSocketProxy{
+		logger:   logger,
+		allocDir: allocDir,
+		config:   config,
+		ctx:      ctx,
+		cancel:   cancel,
+		doneCh:   make(chan struct{}),
+	}
+}
+
+// run the httpSocketProxy for the given allocation.
+//
+// Assumes locking done by the calling alloc runner.
+func (p *httpSocketProxy) run(alloc *structs.Allocation) error {
+	// Only run once.
+	if p.runOnce {
+		return nil
+	}
+
+	// Never restart.
+	select {
+	case <-p.doneCh:
+		p.logger.Trace("consul http socket proxy already shutdown; exiting")
+		return nil
+	case <-p.ctx.Done():
+		p.logger.Trace("consul http socket proxy already done; exiting")
+		return nil
+	default:
+	}
+
+	// consul http dest addr
+	destAddr := p.config.Addr
+	if destAddr == "" {
+		return errors.New("consul address must be set on nomad client")
+	}
+
+	hostHTTPSockPath := filepath.Join(p.allocDir.AllocDir, allocdir.AllocHTTPSocket)
+	if err := maybeRemoveOldSocket(hostHTTPSockPath); err != nil {
+		return err
+	}
+
+	listener, err := net.Listen("unix", hostHTTPSockPath)
+	if err != nil {
+		return errors.Wrap(err, "unable to create unix socket for Consul HTTP endpoint")
+	}
+
+	// The Consul HTTP socket should be usable by all users in case a task is
+	// running as a non-privileged user. Unix does not allow setting domain
+	// socket permissions when creating the file, so we must manually call
+	// chmod afterwords.
+	if err := os.Chmod(hostHTTPSockPath, os.ModePerm); err != nil {
+		return errors.Wrap(err, "unable to set permissions on unix socket")
+	}
+
+	go func() {
+		proxy(p.ctx, p.logger, destAddr, listener)
+		p.cancel()
+		close(p.doneCh)
+	}()
+
+	p.runOnce = true
+	return nil
+}
+
+func (p *httpSocketProxy) stop() error {
+	p.cancel()
+
+	// if proxy was never run, no need to wait before shutdown
+	if !p.runOnce {
+		return nil
+	}
+
+	select {
+	case <-p.doneCh:
+	case <-time.After(3 * time.Second):
+		return errSocketProxyTimeout
+	}
+
+	return nil
+}
+
+func maybeRemoveOldSocket(socketPath string) error {
+	_, err := os.Stat(socketPath)
+	if err == nil {
+		if err = os.Remove(socketPath); err != nil {
+			return errors.Wrap(err, "unable to remove existing unix socket")
+		}
+	}
+	return nil
+}

--- a/client/allocrunner/consul_http_sock_hook.go
+++ b/client/allocrunner/consul_http_sock_hook.go
@@ -29,12 +29,12 @@ const (
 
 type consulHTTPSockHook struct {
 	logger hclog.Logger
-	alloc  *structs.Allocation
-	proxy  *httpSocketProxy
 
-	// lock synchronizes proxy which may be mutated and read concurrently via
-	// Prerun, Update, and Postrun.
-	lock sync.Mutex
+	// lock synchronizes proxy and alloc which may be mutated and read concurrently
+	// via Prerun, Update, and Postrun.
+	lock  sync.Mutex
+	alloc *structs.Allocation
+	proxy *httpSocketProxy
 }
 
 func newConsulHTTPSocketHook(logger hclog.Logger, alloc *structs.Allocation, allocDir *allocdir.AllocDir, config *config.ConsulConfig) *consulHTTPSockHook {

--- a/client/allocrunner/consul_http_sock_hook.go
+++ b/client/allocrunner/consul_http_sock_hook.go
@@ -16,6 +16,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+func tgFirstNetworkIsBridge(tg *structs.TaskGroup) bool {
+	if len(tg.Networks) < 1 || tg.Networks[0].Mode != "bridge" {
+		return false
+	}
+	return true
+}
+
 const (
 	consulHTTPSocketHookName = "consul_http_socket"
 )
@@ -47,9 +54,10 @@ func (*consulHTTPSockHook) Name() string {
 //
 // todo(shoenig): what about CNI networks?
 func (h *consulHTTPSockHook) shouldRun() bool {
-	// we must be in bridge networking and at least one connect native task
 	tg := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup)
-	if len(tg.Networks) < 1 || tg.Networks[0].Mode != "bridge" {
+
+	// we must be in bridge networking and at least one connect native task
+	if !tgFirstNetworkIsBridge(tg) {
 		return false
 	}
 

--- a/client/allocrunner/consul_http_sock_hook.go
+++ b/client/allocrunner/consul_http_sock_hook.go
@@ -99,7 +99,7 @@ func (h *consulHTTPSockHook) Postrun() error {
 
 	if err := h.proxy.stop(); err != nil {
 		// Only log a failure to stop, worst case is the proxy leaks a goroutine.
-		h.logger.Debug("error stopping Consul HTTP proxy", "error", err)
+		h.logger.Warn("error stopping Consul HTTP proxy", "error", err)
 	}
 
 	return nil
@@ -167,7 +167,7 @@ func (p *httpSocketProxy) run(alloc *structs.Allocation) error {
 	// The Consul HTTP socket should be usable by all users in case a task is
 	// running as a non-privileged user. Unix does not allow setting domain
 	// socket permissions when creating the file, so we must manually call
-	// chmod afterwords.
+	// chmod afterwards.
 	if err := os.Chmod(hostHTTPSockPath, os.ModePerm); err != nil {
 		return errors.Wrap(err, "unable to set permissions on unix socket")
 	}
@@ -192,7 +192,7 @@ func (p *httpSocketProxy) stop() error {
 
 	select {
 	case <-p.doneCh:
-	case <-time.After(3 * time.Second):
+	case <-time.After(socketProxyStopWaitTime):
 		return errSocketProxyTimeout
 	}
 

--- a/client/allocrunner/consul_http_sock_hook_test.go
+++ b/client/allocrunner/consul_http_sock_hook_test.go
@@ -1,0 +1,122 @@
+package allocrunner
+
+import (
+	"bytes"
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsulSocketHook_PrerunPostrun_Ok(t *testing.T) {
+	t.Parallel()
+
+	fakeConsul, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer fakeConsul.Close()
+
+	consulConfig := &config.ConsulConfig{
+		Addr: fakeConsul.Addr().String(),
+	}
+
+	alloc := mock.ConnectNativeAlloc("bridge")
+
+	logger := testlog.HCLogger(t)
+
+	allocDir, cleanupDir := allocdir.TestAllocDir(t, logger, "ConnectNativeTask")
+	defer cleanupDir()
+
+	// start unix socket proxy
+	h := newConsulHTTPSocketHook(logger, alloc, allocDir, consulConfig)
+	require.NoError(t, h.Prerun())
+
+	httpSocket := filepath.Join(allocDir.AllocDir, allocdir.AllocHTTPSocket)
+	taskCon, err := net.Dial("unix", httpSocket)
+	require.NoError(t, err)
+
+	// write to consul from task to ensure data is proxied out of the netns
+	input := bytes.Repeat([]byte{'X'}, 5*1024)
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := taskCon.Write(input)
+		errCh <- err
+	}()
+
+	// accept the connection from inside the netns
+	consulConn, err := fakeConsul.Accept()
+	require.NoError(t, err)
+	defer consulConn.Close()
+
+	output := make([]byte, len(input))
+	_, err = consulConn.Read(output)
+	require.NoError(t, err)
+	require.NoError(t, <-errCh)
+	require.Equal(t, input, output)
+
+	// read from consul to ensure http response bodies can come back
+	input = bytes.Repeat([]byte{'Y'}, 5*1024)
+	go func() {
+		_, err := consulConn.Write(input)
+		errCh <- err
+	}()
+
+	output = make([]byte, len(input))
+	_, err = taskCon.Read(output)
+	require.NoError(t, err)
+	require.NoError(t, <-errCh)
+	require.Equal(t, input, output)
+
+	// stop the unix socket proxy
+	require.NoError(t, h.Postrun())
+
+	// consul reads should now error
+	n, err := consulConn.Read(output)
+	require.Error(t, err)
+	require.Zero(t, n)
+
+	// task reads and writes should error
+	n, err = taskCon.Write(input)
+	require.Error(t, err)
+	require.Zero(t, n)
+	n, err = taskCon.Read(output)
+	require.Error(t, err)
+	require.Zero(t, n)
+}
+
+func TestConsulHTTPSocketHook_Prerun_Error(t *testing.T) {
+	t.Parallel()
+
+	logger := testlog.HCLogger(t)
+
+	allocDir, cleanupDir := allocdir.TestAllocDir(t, logger, "ConnectNativeTask")
+	defer cleanupDir()
+
+	consulConfig := new(config.ConsulConfig)
+
+	alloc := mock.Alloc()
+	connectNativeAlloc := mock.ConnectNativeAlloc("bridge")
+
+	{
+		// an alloc without a connect native task should not return an error
+		h := newConsulHTTPSocketHook(logger, alloc, allocDir, consulConfig)
+		require.NoError(t, h.Prerun())
+
+		// postrun should be a noop
+		require.NoError(t, h.Postrun())
+	}
+
+	{
+		// an alloc with a native task should return an error when consul is not
+		// configured
+		h := newConsulHTTPSocketHook(logger, connectNativeAlloc, allocDir, consulConfig)
+		require.EqualError(t, h.Prerun(), "consul address must be set on nomad client")
+
+		// Postrun should be a noop
+		require.NoError(t, h.Postrun())
+	}
+}

--- a/client/allocrunner/taskrunner/connect_native_hook_test.go
+++ b/client/allocrunner/taskrunner/connect_native_hook_test.go
@@ -162,6 +162,46 @@ func TestConnectNativeHook_tlsEnv(t *testing.T) {
 	})
 }
 
+func TestConnectNativeHook_bridgeEnv_bridge(t *testing.T) {
+	t.Parallel()
+
+	hook := new(connectNativeHook)
+	hook.alloc = mock.ConnectNativeAlloc("bridge")
+
+	t.Run("consul address env not preconfigured", func(t *testing.T) {
+		result := hook.bridgeEnv(nil)
+		require.Equal(t, map[string]string{
+			"CONSUL_HTTP_ADDR": "unix:///alloc/tmp/consul_http.sock",
+		}, result)
+	})
+
+	t.Run("consul address env is preconfigured", func(t *testing.T) {
+		result := hook.bridgeEnv(map[string]string{
+			"CONSUL_HTTP_ADDR": "10.1.1.1",
+		})
+		require.Empty(t, result)
+	})
+}
+
+func TestConnectNativeHook_bridgeEnv_host(t *testing.T) {
+	t.Parallel()
+
+	hook := new(connectNativeHook)
+	hook.alloc = mock.ConnectNativeAlloc("host")
+
+	t.Run("consul address env not preconfigured", func(t *testing.T) {
+		result := hook.bridgeEnv(nil)
+		require.Empty(t, result)
+	})
+
+	t.Run("consul address env is preconfigured", func(t *testing.T) {
+		result := hook.bridgeEnv(map[string]string{
+			"CONSUL_HTTP_ADDR": "10.1.1.1",
+		})
+		require.Empty(t, result)
+	})
+}
+
 func TestTaskRunner_ConnectNativeHook_Noop(t *testing.T) {
 	t.Parallel()
 	logger := testlog.HCLogger(t)

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -636,22 +636,34 @@ func MaxParallelJob() *structs.Job {
 func ConnectJob() *structs.Job {
 	job := Job()
 	tg := job.TaskGroups[0]
-	tg.Networks = []*structs.NetworkResource{
-		{
-			Mode: "bridge",
+	tg.Services = []*structs.Service{{
+		Name:      "testconnect",
+		PortLabel: "9999",
+		Connect: &structs.ConsulConnect{
+			SidecarService: new(structs.ConsulSidecarService),
 		},
-	}
-	tg.Services = []*structs.Service{
-		{
-			Name:      "testconnect",
-			PortLabel: "9999",
-			Connect: &structs.ConsulConnect{
-				SidecarService: &structs.ConsulSidecarService{},
-			},
-		},
-	}
+	}}
 	tg.Networks = structs.Networks{{
 		Mode: "bridge", // always bridge ... for now?
+	}}
+	return job
+}
+
+func ConnectNativeJob(mode string) *structs.Job {
+	job := Job()
+	tg := job.TaskGroups[0]
+	tg.Networks = []*structs.NetworkResource{{
+		Mode: mode,
+	}}
+	tg.Services = []*structs.Service{{
+		Name:      "test_connect_native",
+		PortLabel: "9999",
+		Connect: &structs.ConsulConnect{
+			Native: true,
+		},
+	}}
+	tg.Tasks = []*structs.Task{{
+		Name: "native_task",
 	}}
 	return job
 }
@@ -917,6 +929,16 @@ func ConnectAlloc() *structs.Allocation {
 			},
 		},
 	}
+	return alloc
+}
+
+func ConnectNativeAlloc(mode string) *structs.Allocation {
+	alloc := Alloc()
+	alloc.Job = ConnectNativeJob(mode)
+	alloc.AllocatedResources.Shared.Networks = []*structs.NetworkResource{{
+		Mode: mode,
+		IP:   "10.0.0.1",
+	}}
 	return alloc
 }
 


### PR DESCRIPTION
Before, Connect Native Tasks needed one of these to work:

- To be run in host networking mode
- To have the Consul agent configured to listen to a unix socket
- To have the Consul agent configured to listen to a public interface

None of these are a great experience, though running in host networking is
still the best solution for non-Linux hosts. This PR establishes a connection
proxy between the Consul HTTP listener and a unix socket inside the alloc fs,
bypassing the network namespace for any Connect Native task. Similar to and
re-uses a bunch of code from the gRPC listener version for envoy sidecar proxies.

Proxy is established only if the alloc is configured for bridge networking and
there is at least one Connect Native task in the Task Group.

Fixes #8290