### PR TITLE
nomad/structs/structs: add to Job.Validate

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3996,7 +3996,7 @@ func (j *Job) Validate() error {
 				!(j.Type == JobTypeBatch || j.Type == JobTypeService) {
 				mErr.Errors = append(mErr.Errors, errors.New("stop_after_client_disconnect can only be set in batch and service jobs"))
 			} else if *tg.StopAfterClientDisconnect < 0 {
-				mErr.Errors = append(mErr.Errors, errors.New("StopAfterClientDisconnect must be a positive value"))
+				mErr.Errors = append(mErr.Errors, errors.New("stop_after_client_disconnect must be a positive value"))
 			}
 		}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3994,7 +3994,7 @@ func (j *Job) Validate() error {
 		if tg.StopAfterClientDisconnect != nil && *tg.StopAfterClientDisconnect != 0 {
 			if *tg.StopAfterClientDisconnect > 0 &&
 				!(j.Type == JobTypeBatch || j.Type == JobTypeService) {
-				mErr.Errors = append(mErr.Errors, errors.New("StopAfterClientDisconnect can only be used with batch and service jobs"))
+				mErr.Errors = append(mErr.Errors, errors.New("stop_after_client_disconnect can only be set in batch and service jobs"))
 			} else if *tg.StopAfterClientDisconnect < 0 {
 				mErr.Errors = append(mErr.Errors, errors.New("StopAfterClientDisconnect must be a positive value"))
 			}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3991,8 +3991,13 @@ func (j *Job) Validate() error {
 			mErr.Errors = append(mErr.Errors, errors.New("ShutdownDelay must be a positive value"))
 		}
 
-		if tg.StopAfterClientDisconnect != nil && *tg.StopAfterClientDisconnect < 0 {
-			mErr.Errors = append(mErr.Errors, errors.New("StopAfterClientDisconnect must be a positive value"))
+		if tg.StopAfterClientDisconnect != nil && *tg.StopAfterClientDisconnect != 0 {
+			if *tg.StopAfterClientDisconnect > 0 &&
+				!(j.Type == JobTypeBatch || j.Type == JobTypeService) {
+				mErr.Errors = append(mErr.Errors, errors.New("StopAfterClientDisconnect can only be used with batch and service jobs"))
+			} else if *tg.StopAfterClientDisconnect < 0 {
+				mErr.Errors = append(mErr.Errors, errors.New("StopAfterClientDisconnect must be a positive value"))
+			}
 		}
 
 		if j.Type == "system" && tg.Count > 1 {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -4751,7 +4751,7 @@ func TestJobConfig_Validate_StopAferClientDisconnect(t *testing.T) {
 
 	err := job.Validate()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "stop_after_client_disconnect can only be set for batch and service jobs")
+	require.Contains(t, err.Error(), "stop_after_client_disconnect can only be set in batch and service jobs")
 
 	// Modify the job to a batch job with an invalid stop_after_client_disconnect value
 	job.Type = JobTypeBatch

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -4742,6 +4742,29 @@ func TestParameterizedJobConfig_Validate_NonBatch(t *testing.T) {
 	}
 }
 
+func TestJobConfig_Validate_StopAferClientDisconnect(t *testing.T) {
+	job := testJob()
+	job.Type = JobTypeSystem
+	stop := 1 * time.Minute
+	job.TaskGroups[0].StopAfterClientDisconnect = &stop
+
+	err := job.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "StopAfterClientDisconnect can only be used")
+
+	job.Type = JobTypeBatch
+	fail := -1 * time.Minute
+	job.TaskGroups[0].StopAfterClientDisconnect = &fail
+
+	err = job.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "StopAfterClientDisconnect must be")
+
+	job.TaskGroups[0].StopAfterClientDisconnect = &stop
+	err = job.Validate()
+	require.NoError(t, err)
+}
+
 func TestParameterizedJobConfig_Canonicalize(t *testing.T) {
 	d := &ParameterizedJobConfig{}
 	d.Canonicalize()

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -4743,6 +4743,7 @@ func TestParameterizedJobConfig_Validate_NonBatch(t *testing.T) {
 }
 
 func TestJobConfig_Validate_StopAferClientDisconnect(t *testing.T) {
+	// Setup a system Job with stop_after_client_disconnect set, which is invalid
 	job := testJob()
 	job.Type = JobTypeSystem
 	stop := 1 * time.Minute
@@ -4750,16 +4751,19 @@ func TestJobConfig_Validate_StopAferClientDisconnect(t *testing.T) {
 
 	err := job.Validate()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "StopAfterClientDisconnect can only be used")
+	require.Contains(t, err.Error(), "stop_after_client_disconnect can only be set for batch and service jobs")
 
+	// Modify the job to a batch job with an invalid stop_after_client_disconnect value
 	job.Type = JobTypeBatch
-	fail := -1 * time.Minute
-	job.TaskGroups[0].StopAfterClientDisconnect = &fail
+	invalid := -1 * time.Minute
+	job.TaskGroups[0].StopAfterClientDisconnect = &invalid
 
 	err = job.Validate()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "StopAfterClientDisconnect must be")
+	require.Contains(t, err.Error(), "stop_after_client_disconnect must be a positive value")
 
+	// Modify the job to a batch job with a valid stop_after_client_disconnect value
+	job.Type = JobTypeBatch
 	job.TaskGroups[0].StopAfterClientDisconnect = &stop
 	err = job.Validate()
 	require.NoError(t, err)


### PR DESCRIPTION
Job Validation checks that `stop_after_client_disconnect` jobs are of the correct type. closes #8404 