### PR TITLE
MRD: reconcile should treat pending deployments as paused

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -197,7 +197,8 @@ func (a *allocReconciler) Compute() *reconcileResults {
 
 	// Detect if the deployment is paused
 	if a.deployment != nil {
-		a.deploymentPaused = a.deployment.Status == structs.DeploymentStatusPaused
+		a.deploymentPaused = a.deployment.Status == structs.DeploymentStatusPaused ||
+			a.deployment.Status == structs.DeploymentStatusPending
 		a.deploymentFailed = a.deployment.Status == structs.DeploymentStatusFailed
 	}
 	if a.deployment == nil {


### PR DESCRIPTION
If a job update includes a task group that has no changes, those allocations have their version bumped in-place. The ends up triggering an eval from `deploymentwatcher` when it verifies their health. Although this eval is a no-op, we were only treating pending deployments the same as paused when the deployment was a new MRD. This means that any eval after the initial one will kick off the deployment, and that caused pending deployments to "jump the queue" and run ahead of schedule, breaking MRD invariants and resulting in a state with all regions blocked.

This behavior can be replicated even in the case of job updates with no in-place updates by patching `deploymentwatcher` to inject a spurious no-op eval. This changeset fixes the behavior by treating pending deployments the same as paused in all cases in the reconciler.

---

There's no meaningful test for this possible in OSS; I'll have an E2E test that exercises MRD once we've got ENT running in nightly.