### PR TITLE
scheduler: DesiredCanaries can be set on every pass safely

### DIFF
--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -190,8 +190,8 @@ func (w *deploymentWatcher) SetAllocHealth(
 			}
 
 			// Check if the group has autorevert set
-			group, ok := w.getDeployment().TaskGroups[alloc.TaskGroup]
-			if !ok || !group.AutoRevert {
+			dstate, ok := w.getDeployment().TaskGroups[alloc.TaskGroup]
+			if !ok || !dstate.AutoRevert {
 				continue
 			}
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3768,8 +3768,8 @@ func (s *StateStore) UpdateDeploymentPromotion(index uint64, req *structs.ApplyD
 
 	// canaryIndex is the set of placed canaries in the deployment
 	canaryIndex := make(map[string]struct{}, len(deployment.TaskGroups))
-	for _, state := range deployment.TaskGroups {
-		for _, c := range state.PlacedCanaries {
+	for _, dstate := range deployment.TaskGroups {
+		for _, c := range dstate.PlacedCanaries {
 			canaryIndex[c] = struct{}{}
 		}
 	}
@@ -3810,12 +3810,12 @@ func (s *StateStore) UpdateDeploymentPromotion(index uint64, req *structs.ApplyD
 
 	// Determine if we have enough healthy allocations
 	var unhealthyErr multierror.Error
-	for tg, state := range deployment.TaskGroups {
+	for tg, dstate := range deployment.TaskGroups {
 		if _, ok := groupIndex[tg]; !req.All && !ok {
 			continue
 		}
 
-		need := state.DesiredCanaries
+		need := dstate.DesiredCanaries
 		if need == 0 {
 			continue
 		}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -1798,12 +1798,12 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 	if plan.Deployment == nil {
 		t.Fatalf("bad: %#v", plan)
 	}
-	state, ok := plan.Deployment.TaskGroups[job.TaskGroups[0].Name]
+	dstate, ok := plan.Deployment.TaskGroups[job.TaskGroups[0].Name]
 	if !ok {
 		t.Fatalf("bad: %#v", plan)
 	}
-	if state.DesiredTotal != 10 && state.DesiredCanaries != 0 {
-		t.Fatalf("bad: %#v", state)
+	if dstate.DesiredTotal != 10 && dstate.DesiredCanaries != 0 {
+		t.Fatalf("bad: %#v", dstate)
 	}
 }
 
@@ -1922,12 +1922,12 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 	if plan.Deployment == nil {
 		t.Fatalf("bad: %#v", plan)
 	}
-	state, ok := plan.Deployment.TaskGroups[job.TaskGroups[0].Name]
+	dstate, ok := plan.Deployment.TaskGroups[job.TaskGroups[0].Name]
 	if !ok {
 		t.Fatalf("bad: %#v", plan)
 	}
-	if state.DesiredTotal != 5 || state.DesiredCanaries != 0 {
-		t.Fatalf("bad: %#v", state)
+	if dstate.DesiredTotal != 5 || dstate.DesiredCanaries != 0 {
+		t.Fatalf("bad: %#v", dstate)
 	}
 }
 
@@ -2032,10 +2032,10 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 	}
 
 	// Ensure local state was not altered in scheduler
-	staleState, ok := plan.Deployment.TaskGroups[job.TaskGroups[0].Name]
+	staleDState, ok := plan.Deployment.TaskGroups[job.TaskGroups[0].Name]
 	require.True(t, ok)
 
-	require.Equal(t, 0, len(staleState.PlacedCanaries))
+	require.Equal(t, 0, len(staleDState.PlacedCanaries))
 
 	ws := memdb.NewWatchSet()
 

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -617,18 +617,18 @@ func (a *allocReconciler) handleGroupCanaries(all allocSet, desiredChanges *stru
 
 	// Cancel any non-promoted canaries from the older deployment
 	if a.oldDeployment != nil {
-		for _, s := range a.oldDeployment.TaskGroups {
-			if !s.Promoted {
-				stop = append(stop, s.PlacedCanaries...)
+		for _, dstate := range a.oldDeployment.TaskGroups {
+			if !dstate.Promoted {
+				stop = append(stop, dstate.PlacedCanaries...)
 			}
 		}
 	}
 
 	// Cancel any non-promoted canaries from a failed deployment
 	if a.deployment != nil && a.deployment.Status == structs.DeploymentStatusFailed {
-		for _, s := range a.deployment.TaskGroups {
-			if !s.Promoted {
-				stop = append(stop, s.PlacedCanaries...)
+		for _, dstate := range a.deployment.TaskGroups {
+			if !dstate.Promoted {
+				stop = append(stop, dstate.PlacedCanaries...)
 			}
 		}
 	}
@@ -644,8 +644,8 @@ func (a *allocReconciler) handleGroupCanaries(all allocSet, desiredChanges *stru
 	// needed by just stopping them.
 	if a.deployment != nil {
 		var canaryIDs []string
-		for _, s := range a.deployment.TaskGroups {
-			canaryIDs = append(canaryIDs, s.PlacedCanaries...)
+		for _, dstate := range a.deployment.TaskGroups {
+			canaryIDs = append(canaryIDs, dstate.PlacedCanaries...)
 		}
 
 		canaries = all.fromKeys(canaryIDs)

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -431,9 +431,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 	if requireCanary && !a.deploymentPaused && !a.deploymentFailed {
 		number := strategy.Canary - len(canaries)
 		desiredChanges.Canary += uint64(number)
-		if !existingDeployment {
-			dstate.DesiredCanaries = strategy.Canary
-		}
+		dstate.DesiredCanaries = strategy.Canary
 
 		for _, name := range nameIndex.NextCanaries(uint(number), canaries, destructive) {
 			a.result.place = append(a.result.place, allocPlaceResult{


### PR DESCRIPTION
The reconcile loop sets `DeploymentState.DesiredCanaries` only on the first pass through the loop. In MRD, deployments will make one pass though the loop while "pending", and are not ever getting `DesiredCanaries` set. This value is static for a given version of a job because it's coming from the update stanza, so it's entirely safe to re-assign the value on subsequent passes.


Includes a minor refactor to make it clear where we're accessing dstate. The field name `Deployment.TaskGroups` contains a map of `DeploymentState`, which makes it a little harder to follow state updates when combined with inconsistent naming conventions. Change all uses to `dstate` so as not to be confused with actual TaskGroups. This is a separate commit.