### PR TITLE
UI: Fix typo in exec button URL-generation

### DIFF
--- a/ui/app/components/exec/open-button.js
+++ b/ui/app/components/exec/open-button.js
@@ -21,7 +21,7 @@ export default class OpenButton extends Component {
       job: this.job,
       taskGroup: this.taskGroup,
       task: this.task,
-      allocation: this.task,
+      allocation: this.allocation,
     });
   }
 }


### PR DESCRIPTION
This closes #8422, another bug facilitated by the difficulty
of automated testing when opening another window. Thanks to
@notnoop for narrowing this down.