### PR TITLE
`debug` command archive content changes

### DIFF
--- a/command/debug.go
+++ b/command/debug.go
@@ -509,7 +509,6 @@ func (c *DebugCommand) collectPeriodic(client *api.Client) {
 		return
 	}
 
-	start := time.Now().Unix()
 	duration := time.After(c.duration)
 	// Set interval to 0 so that we immediately execute, wait the interval next time
 	interval := time.After(0 * time.Second)
@@ -523,7 +522,7 @@ func (c *DebugCommand) collectPeriodic(client *api.Client) {
 			return
 
 		case <-interval:
-			name = fmt.Sprintf("%04d", time.Now().Unix()-start)
+			name = fmt.Sprintf("%04d", intervalCount)
 			dir = filepath.Join("nomad", name)
 			c.Ui.Output(fmt.Sprintf("    Capture interval %s", name))
 			c.collectNomad(dir, client)

--- a/command/debug.go
+++ b/command/debug.go
@@ -35,12 +35,9 @@ type DebugCommand struct {
 	serverIDs  []string
 	consul     *external
 	vault      *external
-
-	consulToken string
-	vaultToken  string
-	manifest    []string
-	ctx         context.Context
-	cancel      context.CancelFunc
+	manifest   []string
+	ctx        context.Context
+	cancel     context.CancelFunc
 }
 
 type external struct {
@@ -275,9 +272,12 @@ func (c *DebugCommand) Run(args []string) int {
 	c.timestamp = time.Now().UTC().Format(format)
 	stamped := "nomad-debug-" + c.timestamp
 
-	c.Ui.Output("==> Starting debugger and capturing cluster data...")
-	c.Ui.Output(fmt.Sprintf("          Interval: '%s'", interval))
-	c.Ui.Output(fmt.Sprintf("          Duration: '%s'", duration))
+	c.Ui.Output("Starting debugger and capturing cluster data...")
+
+	if len(c.nodeIDs) > 0 || len(c.serverIDs) > 0 {
+		c.Ui.Output(fmt.Sprintf("    Interval: '%s'", interval))
+		c.Ui.Output(fmt.Sprintf("    Duration: '%s'", duration))
+	}
 
 	// Create the output path
 	var tmp string
@@ -521,7 +521,7 @@ func (c *DebugCommand) collectPeriodic(client *api.Client) {
 		case <-interval:
 			name = fmt.Sprintf("%04d", time.Now().Unix()-start)
 			dir = filepath.Join("nomad", name)
-			c.Ui.Output(fmt.Sprintf("==> Capture interval %s", name))
+			c.Ui.Output(fmt.Sprintf("    Capture interval %s", name))
 			c.collectNomad(dir, client)
 			c.collectOperator(dir, client)
 			interval = time.After(c.interval)
@@ -627,7 +627,7 @@ func (c *external) addr(addr string) string {
 		return addr
 	}
 	if c.ssl && c.addrVal[0:5] != "https" {
-		return "https" + string(c.addrVal[4:])
+		return "https" + c.addrVal[4:]
 	}
 	return c.addrVal
 }

--- a/command/debug.go
+++ b/command/debug.go
@@ -478,6 +478,10 @@ func (c *DebugCommand) collectPprof(path, id string, client *api.Client) {
 	}
 
 	path = filepath.Join(path, id)
+	err := c.mkdir(path)
+	if err != nil {
+		return
+	}
 
 	bs, err := client.Agent().CPUProfile(opts, nil)
 	if err == nil {

--- a/command/debug.go
+++ b/command/debug.go
@@ -338,23 +338,30 @@ func (c *DebugCommand) collect(client *api.Client) error {
 	// Fetch data directly from consul and vault. Ignore errors
 	var consul, vault string
 
-	m, ok := self.Config["Consul"].(map[string]interface{})
+	r, ok := self.Config["Consul"]
 	if ok {
-		raw := m["Addr"]
-		consul, _ = raw.(string)
-		raw = m["EnableSSL"]
-		ssl, _ := raw.(bool)
-		if ssl {
-			consul = "https://" + consul
-		} else {
-			consul = "http://" + consul
+		m, ok := r.(map[string]interface{})
+		if ok {
+
+			raw := m["Addr"]
+			consul, _ = raw.(string)
+			raw = m["EnableSSL"]
+			ssl, _ := raw.(bool)
+			if ssl {
+				consul = "https://" + consul
+			} else {
+				consul = "http://" + consul
+			}
 		}
 	}
 
-	m, ok = self.Config["Vault"].(map[string]interface{})
+	r, ok = self.Config["Vault"]
 	if ok {
-		raw := m["Addr"]
-		vault, _ = raw.(string)
+		m, ok := r.(map[string]interface{})
+		if ok {
+			raw := m["Addr"]
+			vault, _ = raw.(string)
+		}
 	}
 
 	c.collectConsul(dir, consul)

--- a/command/debug.go
+++ b/command/debug.go
@@ -190,24 +190,24 @@ func (c *DebugCommand) Run(args []string) int {
 	flags.StringVar(&output, "output", "", "")
 
 	c.consul = &external{tls: &api.TLSConfig{}}
-	flags.StringVar(&c.consul.addrVal, "consul-http-addr", "", os.Getenv("CONSUL_HTTP_ADDR"))
+	flags.StringVar(&c.consul.addrVal, "consul-http-addr", os.Getenv("CONSUL_HTTP_ADDR"), "")
 	ssl := os.Getenv("CONSUL_HTTP_SSL")
 	c.consul.ssl, _ = strconv.ParseBool(ssl)
-	flags.StringVar(&c.consul.auth, "consul-auth", "", os.Getenv("CONSUL_HTTP_AUTH"))
-	flags.StringVar(&c.consul.tokenVal, "consul-token", "", os.Getenv("CONSUL_HTTP_TOKEN"))
-	flags.StringVar(&c.consul.tokenFile, "consul-token-file", "", os.Getenv("CONSUL_HTTP_TOKEN_FILE"))
-	flags.StringVar(&c.consul.tls.ClientCert, "consul-client-cert", "", os.Getenv("CONSUL_CLIENT_CERT"))
-	flags.StringVar(&c.consul.tls.ClientKey, "consul-client-key", "", os.Getenv("CONSUL_CLIENT_KEY"))
-	flags.StringVar(&c.consul.tls.CACert, "consul-ca-cert", "", os.Getenv("CONSUL_CACERT"))
-	flags.StringVar(&c.consul.tls.CAPath, "consul-ca-path", "", os.Getenv("CONSUL_CAPATH"))
+	flags.StringVar(&c.consul.auth, "consul-auth", os.Getenv("CONSUL_HTTP_AUTH"), "")
+	flags.StringVar(&c.consul.tokenVal, "consul-token", os.Getenv("CONSUL_HTTP_TOKEN"), "")
+	flags.StringVar(&c.consul.tokenFile, "consul-token-file", os.Getenv("CONSUL_HTTP_TOKEN_FILE"), "")
+	flags.StringVar(&c.consul.tls.ClientCert, "consul-client-cert", os.Getenv("CONSUL_CLIENT_CERT"), "")
+	flags.StringVar(&c.consul.tls.ClientKey, "consul-client-key", os.Getenv("CONSUL_CLIENT_KEY"), "")
+	flags.StringVar(&c.consul.tls.CACert, "consul-ca-cert", os.Getenv("CONSUL_CACERT"), "")
+	flags.StringVar(&c.consul.tls.CAPath, "consul-ca-path", os.Getenv("CONSUL_CAPATH"), "")
 
 	c.vault = &external{tls: &api.TLSConfig{}}
-	flags.StringVar(&c.vault.addrVal, "vault-address", "", os.Getenv("VAULT_ADDR"))
-	flags.StringVar(&c.vault.tokenVal, "vault-token", "", os.Getenv("VAULT_TOKEN"))
-	flags.StringVar(&c.vault.tls.CACert, "vault-ca-cert", "", os.Getenv("VAULT_CACERT"))
-	flags.StringVar(&c.vault.tls.CAPath, "vault-ca-path", "", os.Getenv("VAULT_CAPATH"))
-	flags.StringVar(&c.vault.tls.ClientCert, "vault-client-cert", "", os.Getenv("VAULT_CLIENT_CERT"))
-	flags.StringVar(&c.vault.tls.ClientKey, "vault-client-key", "", os.Getenv("VAULT_CLIENT_KEY"))
+	flags.StringVar(&c.vault.addrVal, "vault-address", os.Getenv("VAULT_ADDR"), "")
+	flags.StringVar(&c.vault.tokenVal, "vault-token", os.Getenv("VAULT_TOKEN"), "")
+	flags.StringVar(&c.vault.tls.CACert, "vault-ca-cert", os.Getenv("VAULT_CACERT"), "")
+	flags.StringVar(&c.vault.tls.CAPath, "vault-ca-path", os.Getenv("VAULT_CAPATH"), "")
+	flags.StringVar(&c.vault.tls.ClientCert, "vault-client-cert", os.Getenv("VAULT_CLIENT_CERT"), "")
+	flags.StringVar(&c.vault.tls.ClientKey, "vault-client-key", os.Getenv("VAULT_CLIENT_KEY"), "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1

--- a/command/debug.go
+++ b/command/debug.go
@@ -331,29 +331,31 @@ func (c *DebugCommand) collect(client *api.Client) error {
 	// Fetch data directly from consul and vault. Ignore errors
 	var consul, vault string
 
-	r, ok := self.Config["Consul"]
-	if ok {
-		m, ok := r.(map[string]interface{})
+	if self != nil {
+		r, ok := self.Config["Consul"]
 		if ok {
+			m, ok := r.(map[string]interface{})
+			if ok {
 
-			raw := m["Addr"]
-			consul, _ = raw.(string)
-			raw = m["EnableSSL"]
-			ssl, _ := raw.(bool)
-			if ssl {
-				consul = "https://" + consul
-			} else {
-				consul = "http://" + consul
+				raw := m["Addr"]
+				consul, _ = raw.(string)
+				raw = m["EnableSSL"]
+				ssl, _ := raw.(bool)
+				if ssl {
+					consul = "https://" + consul
+				} else {
+					consul = "http://" + consul
+				}
 			}
 		}
-	}
 
-	r, ok = self.Config["Vault"]
-	if ok {
-		m, ok := r.(map[string]interface{})
+		r, ok = self.Config["Vault"]
 		if ok {
-			raw := m["Addr"]
-			vault, _ = raw.(string)
+			m, ok := r.(map[string]interface{})
+			if ok {
+				raw := m["Addr"]
+				vault, _ = raw.(string)
+			}
 		}
 	}
 

--- a/command/debug.go
+++ b/command/debug.go
@@ -44,7 +44,7 @@ type DebugCommand struct {
 }
 
 type external struct {
-	api.TLSConfig
+	tls       *api.TLSConfig
 	addrVal   string
 	auth      string
 	ssl       bool
@@ -189,25 +189,25 @@ func (c *DebugCommand) Run(args []string) int {
 	flags.BoolVar(&c.stale, "stale", false, "")
 	flags.StringVar(&output, "output", "", "")
 
-	c.consul = &external{}
+	c.consul = &external{tls: &api.TLSConfig{}}
 	flags.StringVar(&c.consul.addrVal, "consul-http-addr", "", os.Getenv("CONSUL_HTTP_ADDR"))
 	ssl := os.Getenv("CONSUL_HTTP_SSL")
 	c.consul.ssl, _ = strconv.ParseBool(ssl)
 	flags.StringVar(&c.consul.auth, "consul-auth", "", os.Getenv("CONSUL_HTTP_AUTH"))
 	flags.StringVar(&c.consul.tokenVal, "consul-token", "", os.Getenv("CONSUL_HTTP_TOKEN"))
 	flags.StringVar(&c.consul.tokenFile, "consul-token-file", "", os.Getenv("CONSUL_HTTP_TOKEN_FILE"))
-	flags.StringVar(&c.consul.ClientCert, "consul-client-cert", "", os.Getenv("CONSUL_CLIENT_CERT"))
-	flags.StringVar(&c.consul.ClientKey, "consul-client-key", "", os.Getenv("CONSUL_CLIENT_KEY"))
-	flags.StringVar(&c.consul.CACert, "consul-ca-cert", "", os.Getenv("CONSUL_CACERT"))
-	flags.StringVar(&c.consul.CAPath, "consul-ca-path", "", os.Getenv("CONSUL_CAPATH"))
+	flags.StringVar(&c.consul.tls.ClientCert, "consul-client-cert", "", os.Getenv("CONSUL_CLIENT_CERT"))
+	flags.StringVar(&c.consul.tls.ClientKey, "consul-client-key", "", os.Getenv("CONSUL_CLIENT_KEY"))
+	flags.StringVar(&c.consul.tls.CACert, "consul-ca-cert", "", os.Getenv("CONSUL_CACERT"))
+	flags.StringVar(&c.consul.tls.CAPath, "consul-ca-path", "", os.Getenv("CONSUL_CAPATH"))
 
-	c.vault = &external{}
+	c.vault = &external{tls: &api.TLSConfig{}}
 	flags.StringVar(&c.vault.addrVal, "vault-address", "", os.Getenv("VAULT_ADDR"))
 	flags.StringVar(&c.vault.tokenVal, "vault-token", "", os.Getenv("VAULT_TOKEN"))
-	flags.StringVar(&c.vault.CACert, "vault-ca-cert", "", os.Getenv("VAULT_CACERT"))
-	flags.StringVar(&c.vault.CAPath, "vault-ca-path", "", os.Getenv("VAULT_CAPATH"))
-	flags.StringVar(&c.vault.ClientCert, "vault-client-cert", "", os.Getenv("VAULT_CLIENT_CERT"))
-	flags.StringVar(&c.vault.ClientKey, "vault-client-key", "", os.Getenv("VAULT_CLIENT_KEY"))
+	flags.StringVar(&c.vault.tls.CACert, "vault-ca-cert", "", os.Getenv("VAULT_CACERT"))
+	flags.StringVar(&c.vault.tls.CAPath, "vault-ca-path", "", os.Getenv("VAULT_CAPATH"))
+	flags.StringVar(&c.vault.tls.ClientCert, "vault-client-cert", "", os.Getenv("VAULT_CLIENT_CERT"))
+	flags.StringVar(&c.vault.tls.ClientKey, "vault-client-key", "", os.Getenv("VAULT_CLIENT_KEY"))
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -305,10 +305,6 @@ func (c *DebugCommand) Run(args []string) int {
 		return 2
 	}
 
-	if c.ctx.Err() != nil {
-		return 2
-	}
-
 	c.writeManifest()
 
 	if output != "" {
@@ -337,10 +333,7 @@ func (c *DebugCommand) collect(client *api.Client) error {
 	}
 
 	self, err := client.Agent().Self()
-	if err != nil {
-		return fmt.Errorf("agent self: %s", err.Error())
-	}
-	c.writeJSON(dir, "agent-self.json", self)
+	c.writeJSON(dir, "agent-self.json", self, err)
 
 	// Fetch data directly from consul and vault. Ignore errors
 	var consul, vault string
@@ -460,12 +453,7 @@ func (c *DebugCommand) collectAgentHost(path, id string, client *api.Client) {
 
 	path = filepath.Join(path, id)
 
-	if err != nil {
-		c.writeBytes(path, "agent-host.log", []byte(err.Error()))
-		return
-	}
-
-	c.writeJSON(path, "agent-host.json", host)
+	c.writeJSON(path, "agent-host.json", host, err)
 }
 
 // collectPprofs captures the /agent/pprof for each listed node
@@ -535,6 +523,7 @@ func (c *DebugCommand) collectPeriodic(client *api.Client) {
 			dir = filepath.Join("nomad", name)
 			c.Ui.Output(fmt.Sprintf("==> Capture interval %s", name))
 			c.collectNomad(dir, client)
+			c.collectOperator(dir, client)
 			interval = time.After(c.interval)
 			intervalCount += 1
 
@@ -542,6 +531,18 @@ func (c *DebugCommand) collectPeriodic(client *api.Client) {
 			return
 		}
 	}
+}
+
+// collectOperator captures some cluster meta information
+func (c *DebugCommand) collectOperator(dir string, client *api.Client) {
+	rc, err := client.Operator().RaftGetConfiguration(nil)
+	c.writeJSON(dir, "operator-raft.json", rc, err)
+
+	sc, _, err := client.Operator().SchedulerGetConfiguration(nil)
+	c.writeJSON(dir, "operator-scheduler.json", sc, err)
+
+	ah, _, err := client.Operator().AutopilotServerHealth(nil)
+	c.writeJSON(dir, "operator-autopilot-health.json", ah, err)
 }
 
 // collectNomad captures the nomad cluster state
@@ -554,80 +555,38 @@ func (c *DebugCommand) collectNomad(dir string, client *api.Client) error {
 	var qo *api.QueryOptions
 
 	js, _, err := client.Jobs().List(qo)
-	if err != nil {
-		return fmt.Errorf("listing jobs: %s", err.Error())
-	}
-	c.writeJSON(dir, "jobs.json", js)
+	c.writeJSON(dir, "jobs.json", js, err)
 
 	ds, _, err := client.Deployments().List(qo)
-	if err != nil {
-		return fmt.Errorf("listing deployments: %s", err.Error())
-	}
-	c.writeJSON(dir, "deployments.json", ds)
+	c.writeJSON(dir, "deployments.json", ds, err)
 
 	es, _, err := client.Evaluations().List(qo)
-	if err != nil {
-		return fmt.Errorf("listing evaluations: %s", err.Error())
-	}
-	c.writeJSON(dir, "evaluations.json", es)
+	c.writeJSON(dir, "evaluations.json", es, err)
 
 	as, _, err := client.Allocations().List(qo)
-	if err != nil {
-		return fmt.Errorf("listing allocations: %s", err.Error())
-	}
-	c.writeJSON(dir, "allocations.json", as)
+	c.writeJSON(dir, "allocations.json", as, err)
 
 	ns, _, err := client.Nodes().List(qo)
-	if err != nil {
-		return fmt.Errorf("listing nodes: %s", err.Error())
-	}
-	c.writeJSON(dir, "nodes.json", ns)
+	c.writeJSON(dir, "nodes.json", ns, err)
 
 	ps, _, err := client.CSIPlugins().List(qo)
-	if err != nil {
-		return fmt.Errorf("listing plugins: %s", err.Error())
-	}
-	c.writeJSON(dir, "plugins.json", ps)
+	c.writeJSON(dir, "plugins.json", ps, err)
 
 	vs, _, err := client.CSIVolumes().List(qo)
-	if err != nil {
-		return fmt.Errorf("listing volumes: %s", err.Error())
-	}
-	c.writeJSON(dir, "volumes.json", vs)
-
-	rc, err := client.Operator().RaftGetConfiguration(nil)
-	if err != nil {
-		return fmt.Errorf("listing raft configuration: %s", err.Error())
-	}
-	c.writeJSON(dir, "operator-raft.json", rc)
-
-	sc, _, err := client.Operator().SchedulerGetConfiguration(nil)
-	if err != nil {
-		return fmt.Errorf("listing scheduler configuration: %s", err.Error())
-	}
-	c.writeJSON(dir, "operator-scheduler.json", sc)
-
-	ah, _, err := client.Operator().AutopilotServerHealth(nil)
-	if err != nil {
-		return fmt.Errorf("listing autopilot health: %s", err.Error())
-	}
-	c.writeJSON(dir, "operator-autopilot-health.json", ah)
+	c.writeJSON(dir, "volumes.json", vs, err)
 
 	return nil
 }
 
 // collectConsul calls the Consul API directly to collect data
 func (c *DebugCommand) collectConsul(dir, consul string) error {
-	if consul == "" {
+	addr := c.consul.addr(consul)
+	if addr == "" {
 		return nil
 	}
 
-	client := http.Client{
-		Timeout: 2 * time.Second,
-	}
-	api.ConfigureTLS(&client, &c.consul.TLSConfig)
-
-	addr := c.consul.addr(consul)
+	client := api.DefaultHttpClient()
+	api.ConfigureTLS(client, c.consul.tls)
 
 	req, _ := http.NewRequest("GET", addr+"/v1/agent/self", nil)
 	req.Header.Add("X-Consul-Token", c.consul.token())
@@ -646,16 +605,13 @@ func (c *DebugCommand) collectConsul(dir, consul string) error {
 
 // collectVault calls the Vault API directly to collect data
 func (c *DebugCommand) collectVault(dir, vault string) error {
-	if vault == "" {
+	addr := c.vault.addr(vault)
+	if addr == "" {
 		return nil
 	}
 
-	client := http.Client{
-		Timeout: 2 * time.Second,
-	}
-	api.ConfigureTLS(&client, &c.vault.TLSConfig)
-
-	addr := c.vault.addr(vault)
+	client := api.DefaultHttpClient()
+	api.ConfigureTLS(client, c.vault.tls)
 
 	req, _ := http.NewRequest("GET", addr+"/sys/health", nil)
 	req.Header.Add("X-Vault-Token", c.vault.token())
@@ -711,28 +667,47 @@ func (c *DebugCommand) writeBytes(dir, file string, data []byte) error {
 }
 
 // writeJSON writes JSON responses from the Nomad API calls to the archive
-func (c *DebugCommand) writeJSON(dir, file string, data interface{}) error {
+func (c *DebugCommand) writeJSON(dir, file string, data interface{}, err error) error {
+	if err != nil {
+		return c.writeError(dir, file, err)
+	}
 	bytes, err := json.Marshal(data)
+	if err != nil {
+		return c.writeError(dir, file, err)
+	}
+	return c.writeBytes(dir, file, bytes)
+}
+
+// writeError writes a JSON error object to capture errors in the debug bundle without
+// reporting
+func (c *DebugCommand) writeError(dir, file string, err error) error {
+	bytes, err := json.Marshal(errorWrapper{Error: err.Error()})
 	if err != nil {
 		return err
 	}
 	return c.writeBytes(dir, file, bytes)
 }
 
+type errorWrapper struct {
+	Error string
+}
+
 // writeBody is a helper that writes the body of an http.Response to the archive
 func (c *DebugCommand) writeBody(dir, file string, resp *http.Response, err error) {
 	if err != nil {
+		c.writeError(dir, file, err)
 		return
 	}
-	defer resp.Body.Close()
 
 	if resp.ContentLength == 0 {
 		return
 	}
 
+	defer resp.Body.Close()
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return
+		c.writeError(dir, file, err)
 	}
 
 	c.writeBytes(dir, file, body)

--- a/command/debug.go
+++ b/command/debug.go
@@ -648,12 +648,9 @@ func (c *external) token() string {
 	}
 
 	if c.tokenFile != "" {
-		fh, err := os.Open(c.tokenFile)
+		bs, err := ioutil.ReadFile(c.tokenFile)
 		if err == nil {
-			bs, err := ioutil.ReadAll(fh)
-			if err == nil {
-				return strings.TrimSpace(string(bs))
-			}
+			return strings.TrimSpace(string(bs))
 		}
 	}
 

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -93,11 +93,11 @@ func TestDebugCapturedFiles(t *testing.T) {
 	// Version is always captured
 	require.FileExists(t, filepath.Join(path, "version", "agent-self.json"))
 
-	// Consul and Vault are only captured if they exist
+	// Consul and Vault contain results or errors
 	_, err := os.Stat(filepath.Join(path, "version", "consul-agent-self.json"))
-	require.Error(t, err)
+	require.NoError(t, err)
 	_, err = os.Stat(filepath.Join(path, "version", "vault-sys-health.json"))
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	// Monitor files are only created when selected
 	require.FileExists(t, filepath.Join(path, "server", "leader", "monitor.log"))

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -76,7 +76,7 @@ func TestDebugCapturedFiles(t *testing.T) {
 		"-address", url,
 		"-output", os.TempDir(),
 		"-server-id", "leader",
-		"-duration", "1s",
+		"-duration", "1300ms",
 		"-interval", "600ms",
 	})
 

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -72,19 +72,16 @@ func TestDebugCapturedFiles(t *testing.T) {
 	ui := new(cli.MockUi)
 	cmd := &DebugCommand{Meta: Meta{Ui: ui}}
 
-	// Calculate the output name
-	format := "2006-01-02-150405Z"
-	stamped := "nomad-debug-" + time.Now().UTC().Format(format)
-	path := filepath.Join(os.TempDir(), stamped)
-	defer os.Remove(path)
-
 	code := cmd.Run([]string{
 		"-address", url,
 		"-output", os.TempDir(),
 		"-server-id", "leader",
 		"-duration", "1s",
-		"-interval", "500ms",
+		"-interval", "600ms",
 	})
+
+	path := cmd.collectDir
+	defer os.Remove(path)
 
 	require.Empty(t, ui.ErrorWriter.String())
 	require.Equal(t, 0, code)
@@ -106,10 +103,10 @@ func TestDebugCapturedFiles(t *testing.T) {
 	require.FileExists(t, filepath.Join(path, "server", "leader", "goroutine.prof"))
 
 	// Multiple snapshots are collected, 00 is always created
-	require.FileExists(t, filepath.Join(path, "nomad", "00", "jobs.json"))
-	require.FileExists(t, filepath.Join(path, "nomad", "00", "nodes.json"))
+	require.FileExists(t, filepath.Join(path, "nomad", "0000", "jobs.json"))
+	require.FileExists(t, filepath.Join(path, "nomad", "0000", "nodes.json"))
 
 	// Multiple snapshots are collected, 01 requires two intervals
-	require.FileExists(t, filepath.Join(path, "nomad", "01", "jobs.json"))
-	require.FileExists(t, filepath.Join(path, "nomad", "01", "nodes.json"))
+	require.FileExists(t, filepath.Join(path, "nomad", "0001", "jobs.json"))
+	require.FileExists(t, filepath.Join(path, "nomad", "0001", "nodes.json"))
 }

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -17,6 +17,13 @@ func TestDebugUtils(t *testing.T) {
 	xs = argNodes("")
 	require.Len(t, xs, 0)
 	require.Empty(t, xs)
+
+	// address calculation honors CONSUL_HTTP_SSL
+	e := &external{addrVal: "http://127.0.0.1:8500", ssl: true}
+	require.Equal(t, "https://127.0.0.1:8500", e.addr("foo"))
+
+	e = &external{addrVal: "http://127.0.0.1:8500", ssl: false}
+	require.Equal(t, "http://127.0.0.1:8500", e.addr("foo"))
 }
 
 func TestDebugFails(t *testing.T) {

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -24,6 +24,12 @@ func TestDebugUtils(t *testing.T) {
 
 	e = &external{addrVal: "http://127.0.0.1:8500", ssl: false}
 	require.Equal(t, "http://127.0.0.1:8500", e.addr("foo"))
+
+	e = &external{addrVal: "127.0.0.1:8500", ssl: false}
+	require.Equal(t, "http://127.0.0.1:8500", e.addr("foo"))
+
+	e = &external{addrVal: "127.0.0.1:8500", ssl: true}
+	require.Equal(t, "https://127.0.0.1:8500", e.addr("foo"))
 }
 
 func TestDebugFails(t *testing.T) {


### PR DESCRIPTION
A set of usability improvements to nomad debug:

- [x] include the timestamped path in the paths in the archive
- [x] print the duration & interval so the user knows it's working
- [ ] use timestamps to label interval state snapshots
- [x] use extended consul environment to contact consul
- [x] use consul and vault environment addresses if present
- [x] include `operator` endpoints
- [x] `stale` flag allows membership to be queried in stuck clusters

Intervals are still numbered sequentially rather than by timestamp, with the rationale that timestamp precision gets a little awkward: either we use millisecond timestamps that are large, or second timestamps that duration settings can cause to be used more than once, or minimum durations. Open to suggestion!