### PR TITLE
UI: Always add the active region as a query param to API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ BUG FIXES:
  * ui: Fixed missing namespace query param after changing acl tokens [[GH-8413](https://github.com/hashicorp/nomad/issues/8413)]
  * ui: Fixed exec to derive group and task when possible from allocation [[GH-8463](https://github.com/hashicorp/nomad/pull/8463)]
  * ui: Fixed runtime error when clicking "Run Job" while a prefix filter is set [[GH-8412](https://github.com/hashicorp/nomad/issues/8412)]
+ * ui: Fixed the absence of the region query parameter on various actions, such as job stop, allocation restart, node drain. [[GH-8477](https://github.com/hashicorp/nomad/issues/8477)]
  * vault: Fixed a bug where vault identity policies not considered in permissions check [[GH-7732](https://github.com/hashicorp/nomad/issues/7732)]
 
 ## 0.12.0 (July 9, 2020)

--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -49,15 +49,18 @@ export default class ApplicationAdapter extends RESTAdapter {
     });
   }
 
-  ajaxOptions(url, type, options = {}) {
+  ajaxOptions(url, verb, options = {}) {
     options.data || (options.data = {});
     if (this.get('system.shouldIncludeRegion')) {
+      // Region should only ever be a query param. The default ajaxOptions
+      // behavior is to include data attributes in the requestBody for PUT
+      // and POST requests. This works around that.
       const region = this.get('system.activeRegion');
       if (region) {
-        options.data.region = region;
+        url = associateRegion(url, region);
       }
     }
-    return super.ajaxOptions(url, type, options);
+    return super.ajaxOptions(url, verb, options);
   }
 
   // In order to remove stale records from the store, findHasMany has to unload
@@ -118,4 +121,8 @@ export default class ApplicationAdapter extends RESTAdapter {
   urlForUpdateRecord() {
     return this.urlForFindRecord(...arguments);
   }
+}
+
+function associateRegion(url, region) {
+  return url.indexOf('?') !== -1 ? `${url}&region=${region}` : `${url}?region=${region}`;
 }

--- a/ui/tests/unit/adapters/allocation-test.js
+++ b/ui/tests/unit/adapters/allocation-test.js
@@ -9,69 +9,108 @@ module('Unit | Adapter | Allocation', function(hooks) {
     this.store = this.owner.lookup('service:store');
     this.subject = () => this.store.adapterFor('allocation');
 
+    window.localStorage.clear();
+
     this.server = startMirage();
 
-    this.server.create('namespace');
-    this.server.create('node');
-    this.server.create('job', { createAllocations: false });
-    this.server.create('allocation', { id: 'alloc-1' });
+    this.initialize = async (allocationId, { region } = {}) => {
+      if (region) window.localStorage.nomadActiveRegion = region;
+
+      this.server.create('namespace');
+      this.server.create('region', { id: 'region-1' });
+      this.server.create('region', { id: 'region-2' });
+
+      this.server.create('node');
+      this.server.create('job', { createAllocations: false });
+      this.server.create('allocation', { id: 'alloc-1' });
+      this.system = this.owner.lookup('service:system');
+      await this.system.get('namespaces');
+      this.system.get('shouldIncludeRegion');
+      await this.system.get('defaultRegion');
+
+      const allocation = await this.store.findRecord('allocation', allocationId);
+      this.server.pretender.handledRequests.length = 0;
+
+      return allocation;
+    };
   });
 
   hooks.afterEach(function() {
     this.server.shutdown();
   });
 
-  test('`stop` makes the correct API call', async function(assert) {
-    const { pretender } = this.server;
-    const allocationId = 'alloc-1';
+  const testCases = [
+    {
+      variation: '',
+      id: 'alloc-1',
+      task: 'task-name',
+      region: null,
+      path: 'some/path',
+      ls: `GET /v1/client/fs/ls/alloc-1?path=${encodeURIComponent('some/path')}`,
+      stat: `GET /v1/client/fs/stat/alloc-1?path=${encodeURIComponent('some/path')}`,
+      stop: 'POST /v1/allocation/alloc-1/stop',
+      restart: 'PUT /v1/client/allocation/alloc-1/restart',
+    },
+    {
+      variation: 'with non-default region',
+      id: 'alloc-1',
+      task: 'task-name',
+      region: 'region-2',
+      path: 'some/path',
+      ls: `GET /v1/client/fs/ls/alloc-1?path=${encodeURIComponent('some/path')}&region=region-2`,
+      stat: `GET /v1/client/fs/stat/alloc-1?path=${encodeURIComponent(
+        'some/path'
+      )}&region=region-2`,
+      stop: 'POST /v1/allocation/alloc-1/stop?region=region-2',
+      restart: 'PUT /v1/client/allocation/alloc-1/restart?region=region-2',
+    },
+  ];
 
-    const allocation = await this.store.findRecord('allocation', allocationId);
-    pretender.handledRequests.length = 0;
+  testCases.forEach(testCase => {
+    test(`ls makes the correct API call ${testCase.variation}`, async function(assert) {
+      const { pretender } = this.server;
+      const allocation = await this.initialize(testCase.id, { region: testCase.region });
 
-    await this.subject().stop(allocation);
-    const req = pretender.handledRequests[0];
-    assert.equal(
-      `${req.method} ${req.url}`,
-      `POST /v1/allocation/${allocationId}/stop`,
-      `POST /v1/allocation/${allocationId}/stop`
-    );
-  });
+      await this.subject().ls(allocation, testCase.path);
+      const req = pretender.handledRequests[0];
+      assert.equal(`${req.method} ${req.url}`, testCase.ls);
+    });
 
-  test('`restart` makes the correct API call', async function(assert) {
-    const { pretender } = this.server;
-    const allocationId = 'alloc-1';
+    test(`stat makes the correct API call ${testCase.variation}`, async function(assert) {
+      const { pretender } = this.server;
+      const allocation = await this.initialize(testCase.id, { region: testCase.region });
 
-    const allocation = await this.store.findRecord('allocation', allocationId);
-    pretender.handledRequests.length = 0;
+      await this.subject().stat(allocation, testCase.path);
+      const req = pretender.handledRequests[0];
+      assert.equal(`${req.method} ${req.url}`, testCase.stat);
+    });
 
-    await this.subject().restart(allocation);
-    const req = pretender.handledRequests[0];
-    assert.equal(
-      `${req.method} ${req.url}`,
-      `PUT /v1/client/allocation/${allocationId}/restart`,
-      `PUT /v1/client/allocation/${allocationId}/restart`
-    );
-  });
+    test(`stop makes the correct API call ${testCase.variation}`, async function(assert) {
+      const { pretender } = this.server;
+      const allocation = await this.initialize(testCase.id, { region: testCase.region });
 
-  test('`restart` takes an optional task name and makes the correct API call', async function(assert) {
-    const { pretender } = this.server;
-    const allocationId = 'alloc-1';
-    const taskName = 'task-name';
+      await this.subject().stop(allocation);
+      const req = pretender.handledRequests[0];
+      assert.equal(`${req.method} ${req.url}`, testCase.stop);
+    });
 
-    const allocation = await this.store.findRecord('allocation', allocationId);
-    pretender.handledRequests.length = 0;
+    test(`restart makes the correct API call ${testCase.variation}`, async function(assert) {
+      const { pretender } = this.server;
+      const allocation = await this.initialize(testCase.id, { region: testCase.region });
 
-    await this.subject().restart(allocation, taskName);
-    const req = pretender.handledRequests[0];
-    assert.equal(
-      `${req.method} ${req.url}`,
-      `PUT /v1/client/allocation/${allocationId}/restart`,
-      `PUT /v1/client/allocation/${allocationId}/restart`
-    );
-    assert.deepEqual(
-      JSON.parse(req.requestBody),
-      { TaskName: taskName },
-      'Request body is correct'
-    );
+      await this.subject().restart(allocation);
+      const req = pretender.handledRequests[0];
+      assert.equal(`${req.method} ${req.url}`, testCase.restart);
+    });
+
+    test(`restart with optional task name makes the correct API call ${testCase.variation}`, async function(assert) {
+      const { pretender } = this.server;
+      const allocation = await this.initialize(testCase.id, { region: testCase.region });
+
+      await this.subject().restart(allocation, testCase.task);
+      const req = pretender.handledRequests[0];
+      assert.equal(`${req.method} ${req.url}`, testCase.restart);
+      assert.deepEqual(JSON.parse(req.requestBody), { TaskName: testCase.task });
+    });
   });
 });

--- a/ui/tests/unit/adapters/deployment-test.js
+++ b/ui/tests/unit/adapters/deployment-test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { startMirage } from 'nomad-ui/initializers/ember-cli-mirage';
+
+module('Unit | Adapter | Deployment', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(async function() {
+    this.store = this.owner.lookup('service:store');
+    this.system = this.owner.lookup('service:system');
+    this.subject = () => this.store.adapterFor('deployment');
+
+    window.localStorage.clear();
+
+    this.server = startMirage();
+
+    this.initialize = async ({ region } = {}) => {
+      if (region) window.localStorage.nomadActiveRegion = region;
+
+      this.server.create('region', { id: 'region-1' });
+      this.server.create('region', { id: 'region-2' });
+
+      this.server.create('node');
+      const job = this.server.create('job', { createAllocations: false });
+      const deploymentRecord = server.schema.deployments.where({ jobId: job.id }).models[0];
+
+      this.system.get('shouldIncludeRegion');
+      await this.system.get('defaultRegion');
+
+      const deployment = await this.store.findRecord('deployment', deploymentRecord.id);
+      this.server.pretender.handledRequests.length = 0;
+
+      return deployment;
+    };
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
+  const testCases = [
+    {
+      variation: '',
+      region: null,
+      promote: id => `POST /v1/deployment/promote/${id}`,
+    },
+    {
+      variation: 'with non-default region',
+      region: 'region-2',
+      promote: id => `POST /v1/deployment/promote/${id}?region=region-2`,
+    },
+  ];
+
+  testCases.forEach(testCase => {
+    test(`promote makes the correct API call ${testCase.variation}`, async function(assert) {
+      const deployment = await this.initialize({ region: testCase.region });
+      await this.subject().promote(deployment);
+
+      const request = this.server.pretender.handledRequests[0];
+
+      assert.equal(`${request.method} ${request.url}`, testCase.promote(deployment.id));
+      assert.deepEqual(JSON.parse(request.requestBody), {
+        DeploymentId: deployment.id,
+        All: true,
+      });
+    });
+  });
+});

--- a/ui/tests/unit/adapters/job-test.js
+++ b/ui/tests/unit/adapters/job-test.js
@@ -18,7 +18,10 @@ module('Unit | Adapter | Job', function(hooks) {
 
     this.server = startMirage();
 
-    this.initializeUI = async () => {
+    this.initializeUI = async ({ region, namespace } = {}) => {
+      if (namespace) window.localStorage.nomadActiveNamespace = namespace;
+      if (region) window.localStorage.nomadActiveRegion = region;
+
       this.server.create('namespace');
       this.server.create('namespace', { id: 'some-namespace' });
       this.server.create('node');
@@ -66,9 +69,7 @@ module('Unit | Adapter | Job', function(hooks) {
   });
 
   test('When a namespace is set in localStorage but a job in the default namespace is requested, the namespace query param is not present', async function(assert) {
-    window.localStorage.nomadActiveNamespace = 'some-namespace';
-
-    await this.initializeUI();
+    await this.initializeUI({ namespace: 'some-namespace' });
 
     const { pretender } = this.server;
     const jobName = 'job-1';
@@ -86,9 +87,7 @@ module('Unit | Adapter | Job', function(hooks) {
   });
 
   test('When a namespace is in localStorage and the requested job is in the default namespace, the namespace query param is left out', async function(assert) {
-    window.localStorage.nomadActiveNamespace = 'red-herring';
-
-    await this.initializeUI();
+    await this.initializeUI({ namespace: 'red-herring' });
 
     const { pretender } = this.server;
     const jobName = 'job-1';
@@ -399,9 +398,8 @@ module('Unit | Adapter | Job', function(hooks) {
 
   test('when there is a region set, requests are made with the region query param', async function(assert) {
     const region = 'region-2';
-    window.localStorage.nomadActiveRegion = region;
 
-    await this.initializeUI();
+    await this.initializeUI({ region });
 
     const { pretender } = this.server;
     const jobName = 'job-1';
@@ -421,9 +419,7 @@ module('Unit | Adapter | Job', function(hooks) {
   });
 
   test('when the region is set to the default region, requests are made without the region query param', async function(assert) {
-    window.localStorage.nomadActiveRegion = 'region-1';
-
-    await this.initializeUI();
+    await this.initializeUI({ region: 'region-1' });
 
     const { pretender } = this.server;
     const jobName = 'job-1';


### PR DESCRIPTION
Fixes #7309 #8195 

This was a straightforward fix but it shone a light on a pretty big test coverage gap. As a consequence, most of this diff is new tests and test refactoring.

**Root issue**
The root issue is a sorta clumsy intersection of a few truths and a lack of testing on our part.

1. To make cross-region API requests, the url requested must _always_ include the `region` query parameter.
2. Using query params with `PUT`, `POST`, and `DELETE` requests is unorthodox. Typically if a request has a request body, it doesn't also have query params.
3. Given this convention, Ember (first by way of jquery, now by way of backwards compatibility) assumes anything passed in as `data` will be encoded as query params for `GET` requests and as `requestBody` properties for all other requests.
4. Without our own intervention, regions were being encoded in the requestBody erroneously instead of as a query param.

**Resolution**
All API requests going through Ember Data eventually hit the `ajaxOptions` method of the application adapter. This is already where the `region` param handling was happening. Now instead of stuffing the property in the `data` hash, it is manually appended to the URL as a query param.

All API requests going through the token service were unaffected since the region was already manually being added as a query param.

To ensure this is true everywhere and to set a precedent going forward, unit tests for all adapter actions now include variations for use with a non-default region. This includes

1. Job
    1. `fetchRawDefinition`
    2. `forcePeriodic`
    3. `stop`
    4. `parse`
    5. `plan`
    6. `run`
    7. `update`
    8. `scale`
2. Allocation
    1. `stop`
    2. `restart`
    3. `ls
    4. `stat`
3. Deployment
    1. `promote`
4. Node
    1. `setEligible`
    2. `setIneligible`
    3. `drain`
    4. `forceDrain`
    5. `cancelDrain`

