### PR TITLE
honor config.NetworkInterface in NodeNetworks

### DIFF
--- a/client/fingerprint/network.go
+++ b/client/fingerprint/network.go
@@ -235,13 +235,17 @@ func deriveAddressAlias(iface net.Interface, addr net.IP, config *config.Config)
 		}
 	}
 
-	ri, err := sockaddr.NewRouteInfo()
-	if err == nil {
+	if config.NetworkInterface != "" {
+		if config.NetworkInterface == iface.Name {
+			return "default"
+		}
+	} else if ri, err := sockaddr.NewRouteInfo(); err == nil {
 		defaultIface, err := ri.GetDefaultInterfaceName()
 		if err == nil && iface.Name == defaultIface {
 			return "default"
 		}
 	}
+
 	return ""
 }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8445 .

Nomad 0.12 introduces `NodeNetworks` structs in https://github.com/hashicorp/nomad/pull/8208 but it looks like it may be out of sync from earlier network interpretation, namely, `.NodeResources.Networks`.  `NodeResources.Networks` honors `network_interface` from config, but looks like `.NodeResources.Networks` uses the "default" network (as specified by `ip route`).  This mis-attribution result into pods getting assigned unexpected ip addresses.

It's notable that `NodeResources` aren't reported when using `nomad node status -json` - we must use `curl`.

To test this, I had a simple nomad agent with `network_interface = "eth2"` config.  Notice how NodeNetworks and Networks report different interface names before, and with the fix both point to `eth2`.

The command:
```
curl -sSL localhost:4646/v1/node/$(nomad node status -self -json | jq -r .ID) | jq '{NodeNetworks: .NodeResources.NodeNetworks, Networks: .NodeResources.Networks}
```

Before
```json
{
  "NodeNetworks": [
    {
      "Mode": "bridge",
      "Device": "",
      "MacAddress": "",
      "Speed": 0,
      "Addresses": null
    },
    {
      "Mode": "host",
      "Device": "eth0",
      "MacAddress": "08:00:27:81:14:5e",
      "Speed": 1000,
      "Addresses": [
        {
          "Family": "ipv4",
          "Alias": "default",
          "Address": "10.0.2.15",
          "ReservedPorts": "",
          "Gateway": ""
        }
      ]
    }
  ],
  "Networks": [
    {
      "Mode": "bridge",
      "Device": "",
      "CIDR": "",
      "IP": "",
      "MBits": 0,
      "DNS": null,
      "ReservedPorts": null,
      "DynamicPorts": null
    },
    {
      "Mode": "host",
      "Device": "eth2",
      "CIDR": "10.199.0.200/32",
      "IP": "10.199.0.200",
      "MBits": 1000,
      "DNS": null,
      "ReservedPorts": null,
      "DynamicPorts": null
    }
  ]
}
```

After
```json
{
  "NodeNetworks": [
    {
      "Addresses": null,
      "Device": "",
      "MacAddress": "",
      "Mode": "bridge",
      "Speed": 0
    },
    {
      "Addresses": [
        {
          "Address": "10.199.0.200",
          "Alias": "default",
          "Family": "ipv4",
          "Gateway": "",
          "ReservedPorts": ""
        }
      ],
      "Device": "eth2",
      "MacAddress": "08:00:27:7c:5f:ec",
      "Mode": "host",
      "Speed": 1000
    }
  ],
  "Networks": [
    {
      "CIDR": "",
      "DNS": null,
      "Device": "",
      "DynamicPorts": null,
      "IP": "",
      "MBits": 0,
      "Mode": "bridge",
      "ReservedPorts": null
    },
    {
      "CIDR": "10.199.0.200/32",
      "DNS": null,
      "Device": "eth2",
      "DynamicPorts": null,
      "IP": "10.199.0.200",
      "MBits": 1000,
      "Mode": "host",
      "ReservedPorts": null
    }
  ]
}
```