### PR TITLE
Add orphaned job detail page hanging bugfix to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ BUG FIXES:
  * ui: Fixed exec to derive group and task when possible from allocation [[GH-8463](https://github.com/hashicorp/nomad/pull/8463)]
  * ui: Fixed runtime error when clicking "Run Job" while a prefix filter is set [[GH-8412](https://github.com/hashicorp/nomad/issues/8412)]
  * ui: Fixed the absence of the region query parameter on various actions, such as job stop, allocation restart, node drain. [[GH-8477](https://github.com/hashicorp/nomad/issues/8477)]
+ * ui: Fixed issue where an orphaned child job would make it so navigating to a job detail page would hang the UI [[GH-8319](https://github.com/hashicorp/nomad/issues/8319)]
  * vault: Fixed a bug where vault identity policies not considered in permissions check [[GH-7732](https://github.com/hashicorp/nomad/issues/7732)]
 
 ## 0.12.0 (July 9, 2020)


### PR DESCRIPTION
My earlier investigations of #5946, #7698. and #7710 led me to believe that the root issue of a 404'd parent relationship would be fixed with an Ember upgrade. It had something to do with a quirk with `alias` that had since been fixed.

I just verified that now that we are on Ember 3.16, all of these issues are fixed* so I think this can be added to the changelog.

**Steps to reproduce my verification**

1. Run a parameterized job
2. Dispatch an instance of the parameterized job
3. Observe that the jobs list page shows the parameterized job
4. Observe that clicking the parameterized job lists the dispatched child job
5. Execute `nomad stop purge <parameterized job>`
6. Observe that the jobs list page shows the now orphaned dispatched child job
7. Observe that clicking the orphaned dispatched child job goes to the job detail page

_*Fixed means the UI no longer breaks and freezes on the loading indicator. There is still a runtime error that should be handled in one way or another._