### PR TITLE
UI: Fix layout of title component elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES:
  * scheduler: Fixed a bug in Nomad Enterprise where canaries were not being created during multi-region deployments [[GH-8456](https://github.com/hashicorp/nomad/pull/8456)]
  * ui: Fixed stale namespaces after changing acl tokens [[GH-8413](https://github.com/hashicorp/nomad/issues/8413)]
  * ui: Fixed inclusion of allocation when opening exec window [[GH-8460](https://github.com/hashicorp/nomad/pull/8460)]
+ * ui: Fixed layout of parameterized/periodic job title elemetns [[GH-8495](https://github.com/hashicorp/nomad/pull/8495)]
  * ui: Fixed order of column headers in client allocations table [[GH-8409](https://github.com/hashicorp/nomad/pull/8409)]
  * ui: Fixed missing namespace query param after changing acl tokens [[GH-8413](https://github.com/hashicorp/nomad/issues/8413)]
  * ui: Fixed exec to derive group and task when possible from allocation [[GH-8463](https://github.com/hashicorp/nomad/pull/8463)]

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -2,8 +2,8 @@
   <div>
     {{or this.title this.job.name}}
     <span class="bumper-left tag {{this.job.statusClass}}" data-test-job-status>{{this.job.status}}</span>
+    {{yield}}
   </div>
-  {{yield}}
   <div>
     {{#if (not (eq this.job.status "dead"))}}
       <div class="two-step-button">


### PR DESCRIPTION
Before this change:
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/43280/88185756-ef482780-cbf9-11ea-8682-089fc674f098.png">

After this change:
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/43280/88185863-0be45f80-cbfa-11ea-974f-fba97df41be1.png">

0.10.4:
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/43280/88185974-3209ff80-cbfa-11ea-8e67-4fdbf86c432c.png">

The spacing has been off since I added the exec button but I didn’t notice until looking to confirm #8489. This is a quick fix that makes it less unsightly but doesn’t respect the logical grouping.