### PR TITLE
docs: remove mention of custom schedulers

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -258,6 +258,9 @@
 /docs/internals/scheduling.html               /docs/internals/scheduling/scheduling 301!
 /docs/internals/scheduling                    /docs/internals/scheduling/scheduling 301!
 
+# Sometimes code names are too good not to mention
+/heartyeet                                    /docs/job-specification/group#stop_after_client_disconnect 301!
+
 # Moved /docs/operating-a-job/ -> /guides/operating-a-job/
 /docs/operating-a-job                           https://learn.hashicorp.com/nomad?track=managing-jobs#managing-jobs 301!
 /docs/operating-a-job/index.html                https://learn.hashicorp.com/nomad?track=managing-jobs#managing-jobs 301!

--- a/website/pages/docs/internals/scheduling/scheduling.mdx
+++ b/website/pages/docs/internals/scheduling/scheduling.mdx
@@ -42,8 +42,7 @@ and then invoke the appropriate scheduler as specified by the job. Nomad ships
 with a `service` scheduler that optimizes for long-lived services, a `batch`
 scheduler that is used for fast placement of batch jobs, a `system` scheduler
 that is used to run jobs on every node, and a `core` scheduler which is used
-for internal maintenance. Nomad can be extended to support custom schedulers as
-well.
+for internal maintenance.
 
 Schedulers are responsible for processing an evaluation and generating an
 allocation _plan_. The plan is the set of allocations to evict, update, or


### PR DESCRIPTION
Not sure if this was meant to imply adding more schedulers to Nomad is
easy, or that we plan on adding pluggable schedulers. Either way,
neither of those statements is really true unless you really stretch the
definitions of "easy" and "plan".

So remove this sentence as I can't imagine it does anything other than
confuse people.