### PR TITLE
mrd: only output evalID if found

### DIFF
--- a/command/job_stop.go
+++ b/command/job_stop.go
@@ -195,7 +195,9 @@ func (c *JobStopCommand) Run(args []string) int {
 				c.Ui.Error(fmt.Sprintf("Error deregistering job in %q: %s", region.Name, err))
 				return 1
 			}
-			c.Ui.Output(evalID)
+			if evalID != "" {
+				c.Ui.Output(evalID)
+			}
 		}
 		return 0
 	}


### PR DESCRIPTION
If the multi-region job is a periodic/dispatch job, stopping them
returns an empty EvalID. This removes some unexpected empty lines.

Before:
<img width="640" alt="Screen Shot 2020-07-22 at 4 45 22 PM" src="https://user-images.githubusercontent.com/136429/88226875-c431f800-cc3a-11ea-8427-d8b0ff3fede6.png">

After:
```
root@east:/# nomad job stop --purge --global example
root@east:/#
```