### PR TITLE
vagrant: fix docker install script

### DIFF
--- a/scripts/vagrant-linux-priv-docker.sh
+++ b/scripts/vagrant-linux-priv-docker.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
+# Source: https://docs.docker.com/engine/install/ubuntu/
+
 # Add the Docker repository
-apt-key adv \
-	      --keyserver hkp://p80.pool.sks-keyservers.net:80 \
-	      --recv-keys 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository \
 	  "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
 	$(lsb_release -cs) \
@@ -12,7 +12,7 @@ add-apt-repository \
 # Update with i386, Go and Docker
 apt-get update
 
-apt-get install -y docker-ce
+apt-get install -y docker-ce docker-ce-cli containerd.io
 
 # Restart Docker in case it got upgraded
 systemctl restart docker.service


### PR DESCRIPTION
The key fingerprint doesn't seem to have changed, but something about the old key installation command failed for me and broke vagrant up. I'd rather rely on HTTPS than SKS anyway: Docker's root of trust is docker.com.