### PR TITLE
e2e scripts for local development

### DIFF
--- a/e2e/bin/run
+++ b/e2e/bin/run
@@ -7,9 +7,9 @@ if [ "$1" == "" ]; then
     exit 1
 fi
 
-nodes=$(terraform output -json -state=terraform/terraform.tfstate | jq -r '(.clients,.servers).value[]')
+nodes=$(terraform output -json -state=terraform/terraform.tfstate | jq -r '(.linux_clients,.servers).value[]')
 for node in $nodes
 do
-    echo Executing: ssh -i terraform/keys/*.pem ubuntu@$node "$@"
-    ssh -o StrictHostKeyChecking=accept-new -i terraform/keys/*.pem ubuntu@$node "$@"
+    echo Executing: ssh -i terraform/keys/*.pem ubuntu@"$node" "$@"
+    ssh -o StrictHostKeyChecking=accept-new -i terraform/keys/*.pem ubuntu@"$node" "$@"
 done

--- a/e2e/bin/update
+++ b/e2e/bin/update
@@ -7,11 +7,11 @@ fi
 
 set -e
 
-nodes=$(terraform output -json -state=terraform/terraform.tfstate | jq -r '(.clients,.servers).value[]')
+nodes=$(terraform output -json -state=terraform/terraform.tfstate | jq -r '(.linux_clients,.servers).value[]')
 for node in $nodes
 do
-    echo Executing: scp -C -i terraform/keys/*.pem "$1" ubuntu@$node:"$2"
-    # scp -o StrictHostKeyChecking=accept-new -C -i terraform/keys/*.pem "$1" ubuntu@$node:"$2"
-    scp -o StrictHostKeyChecking=accept-new -C -i terraform/keys/*.pem "$1" ubuntu@$node:/tmp/uploaded
-    ssh -i terraform/keys/*.pem ubuntu@$node sudo mv /tmp/uploaded "$2"
+    echo Executing: scp -C -i terraform/keys/*.pem "$1" ubuntu@"$node":"$2"
+    # scp -o StrictHostKeyChecking=accept-new -C -i terraform/keys/*.pem "$1" ubuntu@"$node":"$2"
+    scp -o StrictHostKeyChecking=accept-new -C -i terraform/keys/*.pem "$1" ubuntu@"$node":/tmp/uploaded
+    ssh -i terraform/keys/*.pem ubuntu@"$node" sudo mv /tmp/uploaded "$2"
 done


### PR DESCRIPTION
the scripts for pushing updates to an e2e cluster from local uncommitted code had rotted a little bit, so this version:

1. works for all the `linux_clients` and ignores the `windows_clients`
~2. handles host keys in a way compatible with the nomad vagrant image~

the vagrant image has been updated to ubuntu 18 which includes a version of ssh that supports `StrictHostKeyChecking=accept-new`, so this can be just a tiny change. unnecessary quoting in the for loop body makes shellcheck happy.