### PR TITLE
docs: s/hearbeat/heartbeat and fix link

### DIFF
--- a/client/heartbeatstop_test.go
+++ b/client/heartbeatstop_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHearbeatStop_allocHook(t *testing.T) {
+func TestHeartbeatStop_allocHook(t *testing.T) {
 	t.Parallel()
 
 	server, _, cleanupS1 := testServer(t, nil)

--- a/website/pages/docs/job-specification/group.mdx
+++ b/website/pages/docs/job-specification/group.mdx
@@ -83,7 +83,7 @@ job "docs" {
   will stop allocations based on this task group. By default, a client
   will not stop an allocation until explicitly told to by a server. A
   client that fails to heartbeat to a server within the
-  `hearbeat_grace` window and any allocations running on it will be
+  [`heartbeat_grace`] window and any allocations running on it will be
   marked "lost" and Nomad will schedule replacement
   allocations. However, these replaced allocations will continue to
   run on the non-responsive client; an operator may desire that these
@@ -247,7 +247,7 @@ group "second" {
 [spread]: /docs/job-specification/spread 'Nomad spread Job Specification'
 [affinity]: /docs/job-specification/affinity 'Nomad affinity Job Specification'
 [ephemeraldisk]: /docs/job-specification/ephemeral_disk 'Nomad ephemeral_disk Job Specification'
-[`heartbeat_grace`]: /docs/configuration/server/#heartbeat_grace
+[`heartbeat_grace`]: /docs/configuration/server#heartbeat_grace
 [meta]: /docs/job-specification/meta 'Nomad meta Job Specification'
 [migrate]: /docs/job-specification/migrate 'Nomad migrate Job Specification'
 [network]: /docs/job-specification/network 'Nomad network Job Specification'


### PR DESCRIPTION
Also fixed the same typo in a test. Fixing the typo fixes the link, but
the link was still broken when running the website locally due to the
trailing slash. It would have worked in prod thanks to redirects, but
using the canonical URL seems ideal.