### PR TITLE
Skip checking Vault health

### DIFF
--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -1229,7 +1229,7 @@ func (v *vaultClient) revokeDaemon() {
 		case <-v.tomb.Dying():
 			return
 		case now := <-ticker.C:
-			if established, _ := v.ConnectionEstablished(); !established {
+			if established, err := v.ConnectionEstablished(); !established || err != nil {
 				continue
 			}
 

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -458,22 +458,12 @@ func (v *vaultClient) establishConnection() {
 	// Create the retry timer and set initial duration to zero so it fires
 	// immediately
 	retryTimer := time.NewTimer(0)
-	initStatus := false
 OUTER:
 	for {
 		select {
 		case <-v.tomb.Dying():
 			return
 		case <-retryTimer.C:
-			// Ensure the API is reachable
-			if !initStatus {
-				if _, err := v.clientSys.Sys().InitStatus(); err != nil {
-					v.logger.Warn("failed to contact Vault API", "retry", v.config.ConnectionRetryIntv, "error", err)
-					retryTimer.Reset(v.config.ConnectionRetryIntv)
-					continue OUTER
-				}
-				initStatus = true
-			}
 			// Retry validating the token till success
 			if err := v.parseSelfToken(); err != nil {
 				v.logger.Error("failed to validate self token/role", "retry", v.config.ConnectionRetryIntv, "error", err)

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -1015,6 +1015,7 @@ func TestVaultClient_LookupToken_RateLimit(t *testing.T) {
 
 	// Spin up many requests. These should block
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	cancels := 0
 	numRequests := 20
@@ -1028,7 +1029,7 @@ func TestVaultClient_LookupToken_RateLimit(t *testing.T) {
 					cancels += 1
 					return
 				}
-				t.Fatalf("self lookup failed: %v", err)
+				t.Errorf("self lookup failed: %v", err)
 				return
 			}
 


### PR DESCRIPTION
To check if token is valid, we should simply check if the API valid, without needing to check if Vault is healthy/initialized.  If it's not, we'll get a proper error.

Back in the day, we used to distinguish between errors related to Vault not initializing (where we'd retry) and errors due to token being invalid (where treated such errors as permanent).  However, that changed in https://github.com/hashicorp/nomad/pull/3957 .  In this world of retries, it doesn't really make sense to do the pre-check.

Fixes https://github.com/hashicorp/nomad/issues/8512