### PR TITLE
Add missing `token list` subcommand in list

### DIFF
--- a/website/pages/docs/commands/acl/index.mdx
+++ b/website/pages/docs/commands/acl/index.mdx
@@ -27,6 +27,7 @@ subcommands are available:
 - [`acl token create`][tokencreate] - Create new ACL token
 - [`acl token delete`][tokendelete] - Delete an existing ACL token
 - [`acl token info`][tokeninfo] - Get info on an existing ACL token
+- [`acl token list`][tokenlist] - List available ACL tokens
 - [`acl token self`][tokenself] - Get info on self ACL token
 - [`acl token update`][tokenupdate] - Update existing ACL token
 
@@ -39,5 +40,6 @@ subcommands are available:
 [tokenupdate]: /docs/commands/acl/token-update
 [tokendelete]: /docs/commands/acl/token-delete
 [tokeninfo]: /docs/commands/acl/token-info
+[tokeninfo]: /docs/commands/acl/token-list
 [tokenself]: /docs/commands/acl/token-self
 [secure-guide]: https://learn.hashicorp.com/nomad/acls/fundamentals

--- a/website/pages/docs/commands/acl/index.mdx
+++ b/website/pages/docs/commands/acl/index.mdx
@@ -40,6 +40,6 @@ subcommands are available:
 [tokenupdate]: /docs/commands/acl/token-update
 [tokendelete]: /docs/commands/acl/token-delete
 [tokeninfo]: /docs/commands/acl/token-info
-[tokeninfo]: /docs/commands/acl/token-list
+[tokenlist]: /docs/commands/acl/token-list
 [tokenself]: /docs/commands/acl/token-self
 [secure-guide]: https://learn.hashicorp.com/nomad/acls/fundamentals


### PR DESCRIPTION
Just a small doc fix, `acl token list` subcommand was missing in the list.


Rebase of https://github.com/hashicorp/nomad/pull/6987 - Thanks @mbertschler !