### PR TITLE
e2e: give containers access to dnsmasq DNS

### DIFF
--- a/e2e/terraform/shared/config/provision-client.sh
+++ b/e2e/terraform/shared/config/provision-client.sh
@@ -22,11 +22,24 @@ sleep 10
 # Add hostname to /etc/hosts
 echo "127.0.0.1 $(hostname)" | sudo tee --append /etc/hosts
 
-# Add Docker bridge network IP to /etc/resolv.conf (at the top)
+# Use dnsmasq first and then docker bridge network for DNS resolution
 DOCKER_BRIDGE_IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetInterfaceIP "docker0"')
-echo "nameserver $DOCKER_BRIDGE_IP_ADDRESS" | sudo tee /etc/resolv.conf.new
-cat /etc/resolv.conf | sudo tee --append /etc/resolv.conf.new
-sudo mv /etc/resolv.conf.new /etc/resolv.conf
+cat <<EOF > /tmp/resolv.conf
+nameserver 127.0.0.1
+nameserver $DOCKER_BRIDGE_IP_ADDRESS
+EOF
+sudo mv /tmp/resolv.conf /etc/resolv.conf
+
+# need to get the AWS DNS address from the VPC...
+# this is pretty hacky but will work for any typical case
+MAC=$(curl -s --fail http://169.254.169.254/latest/meta-data/mac)
+CIDR_BLOCK=$(curl -s --fail "http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-block")
+VPC_DNS_ROOT=$(echo "$CIDR_BLOCK" | cut -d'.' -f1-3)
+echo "nameserver ${VPC_DNS_ROOT}.2" > /tmp/dnsmasq-resolv.conf
+sudo mv /tmp/dnsmasq-resolv.conf /var/run/dnsmasq/resolv.conf
+
+sudo systemctl restart dnsmasq
+sudo systemctl restart docker
 
 # Nomad
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8511

By default, Docker containers get `/etc/resolv.conf` bound into the container
with the localhost entry stripped out. In order to resolve using the host's
dnsmasq, we need to make sure the container uses the docker0 IP as its
nameserver and that dnsmasq is listening on that port and forwarding to either
the AWS VPC DNS (so that we can query private resources like EFS) or to the
Consul DNS.

---

I built this as a new Packer build (namespaced to "test" so as not to break the existing build). Then I deployed a standalone Nomad with that.

Tested inside an allocation via `nomad alloc exec`

```
root@44a8c4357135:/data# nslookup fs-3f1c14bc.efs.us-east-1.amazonaws.com
Server:         172.17.0.1
Address:        172.17.0.1#53

Non-authoritative answer:
Name:   fs-3f1c14bc.efs.us-east-1.amazonaws.com
Address: 172.31.80.83
```

Tested on the host:

```
ubuntu@ip-172-31-95-138:~$ nslookup fs-3f1c14bc.efs.us-east-1.amazonaws.com
Server:         127.0.0.1
Address:        127.0.0.1#53

Non-authoritative answer:
Name:   fs-3f1c14bc.efs.us-east-1.amazonaws.com
Address: 172.31.80.83
```

Once this is merged, I'll build a new Packer build for nightly.