### PR TITLE
docs and changelog entry for `nomad volume deregister -force`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ IMPROVEMENTS:
 * build: Updated to Go 1.14.4 [[GH-8172](https://github.com/hashicorp/nomad/issues/9172)]
 * build: Switched to Go modules for dependency management [[GH-8041](https://github.com/hashicorp/nomad/pull/8041)]
 * connect: Infer service task parameter where possible [[GH-8274](https://github.com/hashicorp/nomad/issues/8274)]
+* csi: Added `-force` flag to `nomad volume deregister` [[GH-8251](https://github.com/hashicorp/nomad/issues/8251)]
 * server: Added `raft_multiplier` config to tweak Raft related timeouts [[GH-8082](https://github.com/hashicorp/nomad/issues/8082)]
 
 BUG FIXES:

--- a/website/pages/docs/commands/volume/deregister.mdx
+++ b/website/pages/docs/commands/volume/deregister.mdx
@@ -28,4 +28,10 @@ unpublished.
 
 @include 'general_options.mdx'
 
+## Deregister Options
+
+- `-force`: Force deregistration of the volume and immediately drop claims for
+  terminal allocations. Returns an error if the volume has running
+  allocations. This does not detach the volume from client nodes.
+
 [csi]: https://github.com/container-storage-interface/spec


### PR DESCRIPTION
Originally merged in https://github.com/hashicorp/nomad/pull/8295 and shipped in 0.12.0. Somehow this got missed.