### PR TITLE
UI: Scaling observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
  * **Multiple Vault Namespaces (Enterprise)**: Support for multiple Vault Namespaces [[GH-8453](https://github.com/hashicorp/nomad/issues/8453)]
+ * **Scaling Observability UI**: View changes in task group scale (both manual and automatic) over time. [[GH-8551](https://github.com/hashicorp/nomad/issues/8551)]
 
 BUG FIXES:
 

--- a/ui/app/adapters/job-scale.js
+++ b/ui/app/adapters/job-scale.js
@@ -1,0 +1,3 @@
+import WatchableNamespaceIDs from './watchable-namespace-ids';
+
+export default class JobScaleAdapter extends WatchableNamespaceIDs {}

--- a/ui/app/adapters/job-scale.js
+++ b/ui/app/adapters/job-scale.js
@@ -1,3 +1,7 @@
 import WatchableNamespaceIDs from './watchable-namespace-ids';
 
-export default class JobScaleAdapter extends WatchableNamespaceIDs {}
+export default class JobScaleAdapter extends WatchableNamespaceIDs {
+  urlForFindRecord(id, type, hash) {
+    return super.urlForFindRecord(id, 'job', hash, 'scale');
+  }
+}

--- a/ui/app/adapters/job-summary.js
+++ b/ui/app/adapters/job-summary.js
@@ -1,12 +1,3 @@
-import Watchable from './watchable';
+import WatchableNamespaceIDs from './watchable-namespace-ids';
 
-export default class JobSummaryAdapter extends Watchable {
-  urlForFindRecord(id, type, hash) {
-    const [name, namespace] = JSON.parse(id);
-    let url = super.urlForFindRecord(name, 'job', hash) + '/summary';
-    if (namespace && namespace !== 'default') {
-      url += `?namespace=${namespace}`;
-    }
-    return url;
-  }
-}
+export default class JobSummaryAdapter extends WatchableNamespaceIDs {}

--- a/ui/app/adapters/job-summary.js
+++ b/ui/app/adapters/job-summary.js
@@ -1,3 +1,7 @@
 import WatchableNamespaceIDs from './watchable-namespace-ids';
 
-export default class JobSummaryAdapter extends WatchableNamespaceIDs {}
+export default class JobSummaryAdapter extends WatchableNamespaceIDs {
+  urlForFindRecord(id, type, hash) {
+    return super.urlForFindRecord(id, 'job', hash, 'summary');
+  }
+}

--- a/ui/app/adapters/watchable-namespace-ids.js
+++ b/ui/app/adapters/watchable-namespace-ids.js
@@ -35,9 +35,10 @@ export default class WatchableNamespaceIDs extends Watchable {
     return associateNamespace(url, namespace);
   }
 
-  urlForFindRecord(id, type, hash) {
+  urlForFindRecord(id, type, hash, pathSuffix) {
     const [name, namespace] = JSON.parse(id);
     let url = super.urlForFindRecord(name, type, hash);
+    if (pathSuffix) url += `/${pathSuffix}`;
     return associateNamespace(url, namespace);
   }
 

--- a/ui/app/components/json-viewer.js
+++ b/ui/app/components/json-viewer.js
@@ -1,10 +1,11 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { classNames } from '@ember-decorators/component';
+import { classNames, classNameBindings } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
 
 @classic
 @classNames('json-viewer')
+@classNameBindings('fluidHeight:has-fluid-height')
 export default class JsonViewer extends Component {
   json = null;
 

--- a/ui/app/controllers/jobs/job/task-group.js
+++ b/ui/app/controllers/jobs/job/task-group.js
@@ -1,7 +1,7 @@
 import { inject as service } from '@ember/service';
 import { alias, readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
-import { action, computed } from '@ember/object';
+import { action, computed, get } from '@ember/object';
 import Sortable from 'nomad-ui/mixins/sortable';
 import Searchable from 'nomad-ui/mixins/searchable';
 import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
@@ -50,6 +50,15 @@ export default class TaskGroupController extends Controller.extend(
   @alias('allocations') listToSort;
   @alias('listSorted') listToSearch;
   @alias('listSearched') sortedAllocations;
+
+  @computed('model.scaleState.events.@each.time', function() {
+    const events = get(this, 'model.scaleState.events');
+    if (events) {
+      return events.sortBy('time').reverse();
+    }
+    return [];
+  })
+  sortedScaleEvents;
 
   @computed('model.job.runningDeployment')
   get tooltipText() {

--- a/ui/app/models/job-scale.js
+++ b/ui/app/models/job-scale.js
@@ -1,0 +1,11 @@
+import Model from 'ember-data/model';
+import { belongsTo } from 'ember-data/relationships';
+import { fragmentArray } from 'ember-data-model-fragments/attributes';
+import classic from 'ember-classic-decorator';
+
+@classic
+export default class JobSummary extends Model {
+  @belongsTo('job') job;
+
+  @fragmentArray('task-group-scale') taskGroupScales;
+}

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -119,6 +119,7 @@ export default class Job extends Model {
   @hasMany('deployments') deployments;
   @hasMany('evaluations') evaluations;
   @belongsTo('namespace') namespace;
+  @belongsTo('job-scale') scaleState;
 
   @computed('taskGroups.@each.drivers')
   get drivers() {

--- a/ui/app/models/scale-event.js
+++ b/ui/app/models/scale-event.js
@@ -1,0 +1,18 @@
+import Fragment from 'ember-data-model-fragments/fragment';
+import attr from 'ember-data/attr';
+import { fragmentOwner } from 'ember-data-model-fragments/attributes';
+
+export default class ScaleEvent extends Fragment {
+  @fragmentOwner() taskGroupScale;
+
+  @attr('number') count;
+  @attr('number') previousCount;
+  @attr('boolean') error;
+  @attr('string') evalId;
+
+  @attr('date') time;
+  @attr('number') timeNanos;
+
+  @attr('string') message;
+  @attr() meta;
+}

--- a/ui/app/models/scale-event.js
+++ b/ui/app/models/scale-event.js
@@ -11,6 +11,11 @@ export default class ScaleEvent extends Fragment {
   @attr('boolean') error;
   @attr('string') evalId;
 
+  @computed('count', function() {
+    return this.count != null;
+  })
+  hasCount;
+
   @computed('count', 'previousCount', function() {
     return this.count > this.previousCount;
   })

--- a/ui/app/models/scale-event.js
+++ b/ui/app/models/scale-event.js
@@ -1,3 +1,4 @@
+import { computed } from '@ember/object';
 import Fragment from 'ember-data-model-fragments/fragment';
 import attr from 'ember-data/attr';
 import { fragmentOwner } from 'ember-data-model-fragments/attributes';
@@ -10,9 +11,19 @@ export default class ScaleEvent extends Fragment {
   @attr('boolean') error;
   @attr('string') evalId;
 
+  @computed('count', 'previousCount', function() {
+    return this.count > this.previousCount;
+  })
+  increased;
+
   @attr('date') time;
   @attr('number') timeNanos;
 
   @attr('string') message;
   @attr() meta;
+
+  @computed('meta', function() {
+    return Object.keys(this.meta).length > 0;
+  })
+  hasMeta;
 }

--- a/ui/app/models/task-group-scale.js
+++ b/ui/app/models/task-group-scale.js
@@ -1,0 +1,17 @@
+import Fragment from 'ember-data-model-fragments/fragment';
+import attr from 'ember-data/attr';
+import { fragmentOwner, fragmentArray } from 'ember-data-model-fragments/attributes';
+
+export default class TaskGroupScale extends Fragment {
+  @fragmentOwner() jobScale;
+
+  @attr('string') name;
+
+  @attr('number') desired;
+  @attr('number') placed;
+  @attr('number') running;
+  @attr('number') healthy;
+  @attr('number') unhealthy;
+
+  @fragmentArray('scale-event') events;
+}

--- a/ui/app/models/task-group-scale.js
+++ b/ui/app/models/task-group-scale.js
@@ -1,3 +1,4 @@
+import { computed } from '@ember/object';
 import Fragment from 'ember-data-model-fragments/fragment';
 import attr from 'ember-data/attr';
 import { fragmentOwner, fragmentArray } from 'ember-data-model-fragments/attributes';
@@ -14,4 +15,9 @@ export default class TaskGroupScale extends Fragment {
   @attr('number') unhealthy;
 
   @fragmentArray('scale-event') events;
+
+  @computed('events.length', function() {
+    return this.events.length;
+  })
+  isVisible;
 }

--- a/ui/app/models/task-group.js
+++ b/ui/app/models/task-group.js
@@ -54,6 +54,11 @@ export default class TaskGroup extends Fragment {
     return maybe(this.get('job.taskGroupSummaries')).findBy('name', this.name);
   }
 
+  @computed('job.scaleState.taskGroupScales.[]')
+  get scaleState() {
+    return maybe(this.get('job.scaleState.taskGroupScales')).findBy('name', this.name);
+  }
+
   scale(count, reason) {
     return this.job.scale(this.name, count, reason);
   }

--- a/ui/app/routes/jobs/job/task-group.js
+++ b/ui/app/routes/jobs/job/task-group.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { collect } from '@ember/object/computed';
 import EmberError from '@ember/error';
-import { resolve } from 'rsvp';
+import { resolve, all } from 'rsvp';
 import { watchRecord, watchRelationship } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
 import { qpBuilder } from 'nomad-ui/utils/classes/query-params';
@@ -43,10 +43,9 @@ export default class TaskGroupRoute extends Route.extend(WithWatchers) {
         }
 
         // Refresh job allocations before-hand (so page sort works on load)
-        return job
-          .hasMany('allocations')
-          .reload()
-          .then(() => taskGroup);
+        return all([job.hasMany('allocations').reload(), job.get('scaleState')]).then(
+          () => taskGroup
+        );
       })
       .catch(notifyError(this));
   }
@@ -56,7 +55,8 @@ export default class TaskGroupRoute extends Route.extend(WithWatchers) {
       const job = model.get('job');
       controller.set('watchers', {
         job: this.watchJob.perform(job),
-        summary: this.watchSummary.perform(job.get('summary')),
+        summary: this.watchSummary.perform(job),
+        scale: this.watchScale.perform(job),
         allocations: this.watchAllocations.perform(job),
         latestDeployment: job.get('supportsDeployments') && this.watchLatestDeployment.perform(job),
       });
@@ -64,9 +64,11 @@ export default class TaskGroupRoute extends Route.extend(WithWatchers) {
   }
 
   @watchRecord('job') watchJob;
-  @watchRecord('job-summary') watchSummary;
+  @watchRelationship('job-summary') watchSummary;
+  @watchRelationship('job-scale') watchScale;
   @watchRelationship('allocations') watchAllocations;
   @watchRelationship('latestDeployment') watchLatestDeployment;
 
-  @collect('watchJob', 'watchSummary', 'watchAllocations', 'watchLatestDeployment') watchers;
+  @collect('watchJob', 'watchSummary', 'watchScale', 'watchAllocations', 'watchLatestDeployment')
+  watchers;
 }

--- a/ui/app/routes/jobs/job/task-group.js
+++ b/ui/app/routes/jobs/job/task-group.js
@@ -55,8 +55,8 @@ export default class TaskGroupRoute extends Route.extend(WithWatchers) {
       const job = model.get('job');
       controller.set('watchers', {
         job: this.watchJob.perform(job),
-        summary: this.watchSummary.perform(job),
-        scale: this.watchScale.perform(job),
+        summary: this.watchSummary.perform(job.get('summary')),
+        scale: this.watchScale.perform(job.get('scaleState')),
         allocations: this.watchAllocations.perform(job),
         latestDeployment: job.get('supportsDeployments') && this.watchLatestDeployment.perform(job),
       });
@@ -64,8 +64,8 @@ export default class TaskGroupRoute extends Route.extend(WithWatchers) {
   }
 
   @watchRecord('job') watchJob;
-  @watchRelationship('job-summary') watchSummary;
-  @watchRelationship('job-scale') watchScale;
+  @watchRecord('job-summary') watchSummary;
+  @watchRecord('job-scale') watchScale;
   @watchRelationship('allocations') watchAllocations;
   @watchRelationship('latestDeployment') watchLatestDeployment;
 

--- a/ui/app/serializers/job-scale.js
+++ b/ui/app/serializers/job-scale.js
@@ -1,0 +1,19 @@
+import { assign } from '@ember/polyfills';
+import ApplicationSerializer from './application';
+
+export default class JobScale extends ApplicationSerializer {
+  normalize(modelClass, hash) {
+    // Transform the map-based TaskGroups object into an array-based
+    // TaskGroupScale fragment list
+    hash.PlainJobId = hash.JobID;
+    hash.ID = JSON.stringify([hash.JobID, hash.Namespace || 'default']);
+    hash.JobID = hash.ID;
+
+    const taskGroups = hash.TaskGroups || {};
+    hash.TaskGroupScales = Object.keys(taskGroups).map(key => {
+      return assign(taskGroups[key], { Name: key });
+    });
+
+    return super.normalize(modelClass, hash);
+  }
+}

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -84,7 +84,7 @@ export default class JobSerializer extends ApplicationSerializer {
           related: buildURL(`${jobURL}/evaluations`, { namespace }),
         },
       },
-      scale: {
+      scaleState: {
         links: {
           related: buildURL(`${jobURL}/scale`, { namespace }),
         },

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -84,6 +84,11 @@ export default class JobSerializer extends ApplicationSerializer {
           related: buildURL(`${jobURL}/evaluations`, { namespace }),
         },
       },
+      scale: {
+        links: {
+          related: buildURL(`${jobURL}/scale`, { namespace }),
+        },
+      },
     });
   }
 }

--- a/ui/app/serializers/scale-event.js
+++ b/ui/app/serializers/scale-event.js
@@ -1,0 +1,10 @@
+import ApplicationSerializer from './application';
+
+export default class ScaleEventSerializer extends ApplicationSerializer {
+  normalize(typeHash, hash) {
+    hash.TimeNanos = hash.Time % 1000000;
+    hash.Time = Math.floor(hash.Time / 1000000);
+
+    return super.normalize(typeHash, hash);
+  }
+}

--- a/ui/app/styles/components.scss
+++ b/ui/app/styles/components.scss
@@ -18,6 +18,7 @@
 @import './components/image-file.scss';
 @import './components/inline-definitions';
 @import './components/job-diff';
+@import './components/json-viewer';
 @import './components/lifecycle-chart';
 @import './components/loading-spinner';
 @import './components/metrics';

--- a/ui/app/styles/components/accordion.scss
+++ b/ui/app/styles/components/accordion.scss
@@ -15,6 +15,10 @@
       border-bottom-left-radius: $radius;
       border-bottom-right-radius: $radius;
     }
+
+    &.is-full-bleed {
+      padding: 0;
+    }
   }
 
   .accordion-head {
@@ -24,10 +28,6 @@
 
     &.is-light {
       background: $white;
-    }
-
-    &.is-inactive {
-      color: $grey-light;
     }
 
     .accordion-head-content {

--- a/ui/app/styles/components/inline-definitions.scss
+++ b/ui/app/styles/components/inline-definitions.scss
@@ -8,6 +8,10 @@
     font-weight: $weight-semibold;
   }
 
+  &.is-faded {
+    color: darken($grey-blue, 20%);
+  }
+
   .pair {
     margin-right: 2em;
     white-space: nowrap;
@@ -24,6 +28,14 @@
     .has-emphasis {
       color: $text;
       font-weight: $weight-semibold;
+    }
+  }
+
+  .icon-field {
+    display: flex;
+    margin-left: -1em;
+    .icon-container {
+      width: 1.5em;
     }
   }
 

--- a/ui/app/styles/components/json-viewer.scss
+++ b/ui/app/styles/components/json-viewer.scss
@@ -1,0 +1,5 @@
+.json-viewer {
+  &.has-fluid-height .CodeMirror-scroll {
+    min-height: 0;
+  }
+}

--- a/ui/app/templates/components/json-viewer.hbs
+++ b/ui/app/templates/components/json-viewer.hbs
@@ -1,4 +1,5 @@
 <IvyCodemirror
+  data-test-json-viewer
   @value={{this.jsonStr}}
   @options={{hash
     mode="javascript"

--- a/ui/app/templates/components/list-accordion/accordion-body.hbs
+++ b/ui/app/templates/components/list-accordion/accordion-body.hbs
@@ -1,5 +1,5 @@
 {{#if this.isOpen}}
-  <div data-test-accordion-body class="accordion-body">
+  <div data-test-accordion-body class="accordion-body {{if this.fullBleed "is-full-bleed"}}">
     {{yield}}
   </div>
 {{/if}}

--- a/ui/app/templates/components/scale-events-accordion.hbs
+++ b/ui/app/templates/components/scale-events-accordion.hbs
@@ -11,7 +11,10 @@
       </div>
       <div class="column is-2">
         {{#if a.item.hasCount}}
-          <span data-test-count-icon>
+          <span data-test-count-icon
+            class="tooltip"
+            aria-label="Count {{if a.item.increased "increased" "decreased"}} to {{a.item.count}}"
+          >
             {{#if a.item.increased}}
               {{x-icon "arrow-up" class="is-danger"}}
             {{else}}

--- a/ui/app/templates/components/scale-events-accordion.hbs
+++ b/ui/app/templates/components/scale-events-accordion.hbs
@@ -1,0 +1,32 @@
+<ListAccordion data-test-scale-events @source={{@events}} @key="time" as |a|>
+  <a.head @buttonLabel="details" @isExpandable={{a.item.hasMeta}} class="with-columns">
+    <div class="columns inline-definitions">
+      <div class="column is-3">
+        <span class="icon-field">
+          <span class="icon-container" title="{{if a.item.error "Error event"}}" data-test-error={{a.item.error}}>
+            {{#if a.item.error}}{{x-icon "cancel-circle-fill" class="is-danger"}}{{/if}}
+          </span>
+          <span data-test-time title="{{format-ts a.item.time}}">{{format-month-ts a.item.time}}</span>
+        </span>
+      </div>
+      <div class="column is-2">
+        {{#if (gte a.item.count 0)}}
+          <span data-test-count-icon>
+            {{#if a.item.increased}}
+              {{x-icon "arrow-up" class="is-danger"}}
+            {{else}}
+              {{x-icon "arrow-down" class="is-primary"}}
+            {{/if}}
+          </span>
+          <span data-test-count>{{a.item.count}}</span>
+        {{/if}}
+      </div>
+      <div class="column" data-test-message>
+        {{a.item.message}}
+      </div>
+    </div>
+  </a.head>
+  <a.body @fullBleed={{true}}>
+    <JsonViewer @json={{a.item.meta}} @fluidHeight={{true}} />
+  </a.body>
+</ListAccordion>

--- a/ui/app/templates/components/scale-events-accordion.hbs
+++ b/ui/app/templates/components/scale-events-accordion.hbs
@@ -10,7 +10,7 @@
         </span>
       </div>
       <div class="column is-2">
-        {{#if (gte a.item.count 0)}}
+        {{#if a.item.hasCount}}
           <span data-test-count-icon>
             {{#if a.item.increased}}
               {{x-icon "arrow-up" class="is-danger"}}

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -138,34 +138,35 @@
   <LifecycleChart @tasks={{this.model.tasks}} />
 
   {{#if this.model.scaleState.isVisible}}
-    {{! this is where the accordion goes }}
     <div data-test-scaling-events class="boxed-section">
       <div class="boxed-section-head">
         Recent Scaling Events
       </div>
       <div class="boxed-section-body">
-        <ListAccordion @source={{this.model.scaleState.events}} @key="time" as |a|>
+        <ListAccordion data-test-scale-events @source={{this.sortedScaleEvents}} @key="time" as |a|>
           <a.head @buttonLabel="details" @isExpandable={{a.item.hasMeta}} class="with-columns">
             <div class="columns inline-definitions">
               <div class="column is-3">
                 <span class="icon-field">
-                  <span class="icon-container" title="{{if a.item.error "Error event"}}">
+                  <span class="icon-container" title="{{if a.item.error "Error event"}}" data-test-error={{a.item.error}}>
                     {{#if a.item.error}}{{x-icon "cancel-circle-fill" class="is-danger"}}{{/if}}
                   </span>
-                  <span data-test-time>{{format-ts a.item.time}}</span>
+                  <span data-test-time title="{{format-ts a.item.time}}">{{format-month-ts a.item.time}}</span>
                 </span>
               </div>
               <div class="column is-2">
-                {{#if a.item.count}}
-                  {{#if a.item.increased}}
-                    {{x-icon "arrow-up" class="is-danger"}}
-                  {{else}}
-                    {{x-icon "arrow-down" class="is-primary"}}
-                  {{/if}}
-                  <span>{{a.item.count}}</span>
+                {{#if (gte a.item.count 0)}}
+                  <span data-test-count-icon>
+                    {{#if a.item.increased}}
+                      {{x-icon "arrow-up" class="is-danger"}}
+                    {{else}}
+                      {{x-icon "arrow-down" class="is-primary"}}
+                    {{/if}}
+                  </span>
+                  <span data-test-count>{{a.item.count}}</span>
                 {{/if}}
               </div>
-              <div class="column">
+              <div class="column" data-test-message>
                 {{a.item.message}}
               </div>
             </div>

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -137,6 +137,47 @@
 
   <LifecycleChart @tasks={{this.model.tasks}} />
 
+  {{#if this.model.scaleState.isVisible}}
+    {{! this is where the accordion goes }}
+    <div data-test-scaling-events class="boxed-section">
+      <div class="boxed-section-head">
+        Recent Scaling Events
+      </div>
+      <div class="boxed-section-body">
+        <ListAccordion @source={{this.model.scaleState.events}} @key="time" as |a|>
+          <a.head @buttonLabel="details" @isExpandable={{a.item.hasMeta}} class="with-columns">
+            <div class="columns inline-definitions">
+              <div class="column is-3">
+                <span class="icon-field">
+                  <span class="icon-container" title="{{if a.item.error "Error event"}}">
+                    {{#if a.item.error}}{{x-icon "cancel-circle-fill" class="is-danger"}}{{/if}}
+                  </span>
+                  <span data-test-time>{{format-ts a.item.time}}</span>
+                </span>
+              </div>
+              <div class="column is-2">
+                {{#if a.item.count}}
+                  {{#if a.item.increased}}
+                    {{x-icon "arrow-up" class="is-danger"}}
+                  {{else}}
+                    {{x-icon "arrow-down" class="is-primary"}}
+                  {{/if}}
+                  <span>{{a.item.count}}</span>
+                {{/if}}
+              </div>
+              <div class="column">
+                {{a.item.message}}
+              </div>
+            </div>
+          </a.head>
+          <a.body @fullBleed={{true}}>
+            <JsonViewer @json={{a.item.meta}} @fluidHeight={{true}} />
+          </a.body>
+        </ListAccordion>
+      </div>
+    </div>
+  {{/if}}
+
   {{#if this.model.volumes.length}}
     <div data-test-volumes class="boxed-section">
       <div class="boxed-section-head">

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -143,38 +143,7 @@
         Recent Scaling Events
       </div>
       <div class="boxed-section-body">
-        <ListAccordion data-test-scale-events @source={{this.sortedScaleEvents}} @key="time" as |a|>
-          <a.head @buttonLabel="details" @isExpandable={{a.item.hasMeta}} class="with-columns">
-            <div class="columns inline-definitions">
-              <div class="column is-3">
-                <span class="icon-field">
-                  <span class="icon-container" title="{{if a.item.error "Error event"}}" data-test-error={{a.item.error}}>
-                    {{#if a.item.error}}{{x-icon "cancel-circle-fill" class="is-danger"}}{{/if}}
-                  </span>
-                  <span data-test-time title="{{format-ts a.item.time}}">{{format-month-ts a.item.time}}</span>
-                </span>
-              </div>
-              <div class="column is-2">
-                {{#if (gte a.item.count 0)}}
-                  <span data-test-count-icon>
-                    {{#if a.item.increased}}
-                      {{x-icon "arrow-up" class="is-danger"}}
-                    {{else}}
-                      {{x-icon "arrow-down" class="is-primary"}}
-                    {{/if}}
-                  </span>
-                  <span data-test-count>{{a.item.count}}</span>
-                {{/if}}
-              </div>
-              <div class="column" data-test-message>
-                {{a.item.message}}
-              </div>
-            </div>
-          </a.head>
-          <a.body @fullBleed={{true}}>
-            <JsonViewer @json={{a.item.meta}} @fluidHeight={{true}} />
-          </a.body>
-        </ListAccordion>
+        <ScaleEventsAccordion @events={{this.sortedScaleEvents}} />
       </div>
     </div>
   {{/if}}

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -161,7 +161,6 @@ export default function() {
     '/job/:id/scale',
     withBlockingSupport(function({ jobScales }, { params }) {
       const obj = jobScales.findBy({ jobId: params.id });
-      console.log('Job Scale Object', obj);
       return this.serialize(jobScales.findBy({ jobId: params.id }));
     })
   );

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -157,6 +157,15 @@ export default function() {
     return deployment ? this.serialize(deployment) : new Response(200, {}, 'null');
   });
 
+  this.get(
+    '/job/:id/scale',
+    withBlockingSupport(function({ jobScales }, { params }) {
+      const obj = jobScales.findBy({ jobId: params.id });
+      console.log('Job Scale Object', obj);
+      return this.serialize(jobScales.findBy({ jobId: params.id }));
+    })
+  );
+
   this.post('/job/:id/periodic/force', function(schema, { params }) {
     // Create the child job
     const parent = schema.jobs.find(params.id);

--- a/ui/mirage/factories/job-scale.js
+++ b/ui/mirage/factories/job-scale.js
@@ -1,0 +1,26 @@
+import { Factory, trait } from 'ember-cli-mirage';
+import faker from 'nomad-ui/mirage/faker';
+
+export default Factory.extend({
+  groupNames: [],
+
+  jobId: '',
+  JobID() {
+    return this.jobId;
+  },
+  namespace: null,
+  shallow: false,
+
+  afterCreate(jobScale, server) {
+    const groups = jobScale.groupNames.map(group =>
+      server.create('task-group-scale', {
+        id: group,
+        shallow: jobScale.shallow,
+      })
+    );
+
+    jobScale.update({
+      taskGroupScaleIds: groups.mapBy('id'),
+    });
+  },
+});

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -158,6 +158,17 @@ export default Factory.extend({
       job_summary_id: jobSummary.id,
     });
 
+    const jobScale = server.create('job-scale', {
+      groupNames: groups.mapBy('name'),
+      jobId: job.id,
+      namespace: job.namespace,
+      shallow: job.shallow,
+    });
+
+    job.update({
+      jobScaleId: jobScale.id,
+    });
+
     if (!job.noDeployments) {
       Array(faker.random.number({ min: 1, max: 3 }))
         .fill(null)

--- a/ui/mirage/factories/scale-event.js
+++ b/ui/mirage/factories/scale-event.js
@@ -7,11 +7,14 @@ export default Factory.extend({
   time: () => faker.date.past(2 / 365, REF_TIME) * 1000000,
   count: () => faker.random.number(10),
   previousCount: () => faker.random.number(10),
-  error: () => faker.random.number(10) > 9,
+  error: () => faker.random.number(10) > 8,
   message: 'Sample message for a job scale event',
-  meta: () => ({
-    'nomad_autoscaler.count.capped': true,
-    'nomad_autoscaler.count.original': 0,
-    'nomad_autoscaler.reason_history': ['scaling down because factor is 0.000000'],
-  }),
+  meta: () =>
+    faker.random.number(10) < 8
+      ? {
+          'nomad_autoscaler.count.capped': true,
+          'nomad_autoscaler.count.original': 0,
+          'nomad_autoscaler.reason_history': ['scaling down because factor is 0.000000'],
+        }
+      : {},
 });

--- a/ui/mirage/factories/scale-event.js
+++ b/ui/mirage/factories/scale-event.js
@@ -1,0 +1,17 @@
+import { Factory, trait } from 'ember-cli-mirage';
+import faker from 'nomad-ui/mirage/faker';
+
+const REF_TIME = new Date();
+
+export default Factory.extend({
+  time: () => faker.date.past(2 / 365, REF_TIME) * 1000000,
+  count: () => faker.random.number(10),
+  previousCount: () => faker.random.number(10),
+  error: () => faker.random.number(10) > 9,
+  message: 'Sample message for a job scale event',
+  meta: () => ({
+    'nomad_autoscaler.count.capped': true,
+    'nomad_autoscaler.count.original': 0,
+    'nomad_autoscaler.reason_history': ['scaling down because factor is 0.000000'],
+  }),
+});

--- a/ui/mirage/factories/task-group-scale.js
+++ b/ui/mirage/factories/task-group-scale.js
@@ -2,7 +2,9 @@ import { Factory, trait } from 'ember-cli-mirage';
 import faker from 'nomad-ui/mirage/faker';
 
 export default Factory.extend({
-  name: id => id,
+  name() {
+    return this.id;
+  },
 
   desired: 1,
   placed: 1,

--- a/ui/mirage/factories/task-group-scale.js
+++ b/ui/mirage/factories/task-group-scale.js
@@ -1,0 +1,24 @@
+import { Factory, trait } from 'ember-cli-mirage';
+import faker from 'nomad-ui/mirage/faker';
+
+export default Factory.extend({
+  name: id => id,
+
+  desired: 1,
+  placed: 1,
+  running: 1,
+  healthy: 1,
+  unhealthy: 1,
+
+  shallow: false,
+
+  afterCreate(taskGroupScale, server) {
+    if (!taskGroupScale.shallow) {
+      const events = server.createList('scale-event', faker.random.number({ min: 1, max: 10 }));
+
+      taskGroupScale.update({
+        eventIds: events.mapBy('id'),
+      });
+    }
+  },
+});

--- a/ui/mirage/models/job-scale.js
+++ b/ui/mirage/models/job-scale.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  job: belongsTo(),
+  taskGroupScales: hasMany(),
+});

--- a/ui/mirage/models/job.js
+++ b/ui/mirage/models/job.js
@@ -3,5 +3,5 @@ import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
 export default Model.extend({
   task_groups: hasMany('task-group'),
   job_summary: belongsTo('job-summary'),
-  job_scale: belongsTo('job-scale'),
+  jobScale: belongsTo('job-scale'),
 });

--- a/ui/mirage/models/job.js
+++ b/ui/mirage/models/job.js
@@ -3,4 +3,5 @@ import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
 export default Model.extend({
   task_groups: hasMany('task-group'),
   job_summary: belongsTo('job-summary'),
+  job_scale: belongsTo('job-scale'),
 });

--- a/ui/mirage/models/scale-event.js
+++ b/ui/mirage/models/scale-event.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  taskGroupScale: belongsTo(),
+});

--- a/ui/mirage/models/task-group-scale.js
+++ b/ui/mirage/models/task-group-scale.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  jobScale: belongsTo(),
+  events: hasMany('scale-event'),
+});

--- a/ui/mirage/serializers/job-scale.js
+++ b/ui/mirage/serializers/job-scale.js
@@ -1,0 +1,6 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  embed: true,
+  include: ['taskGroupScales'],
+});

--- a/ui/mirage/serializers/job-scale.js
+++ b/ui/mirage/serializers/job-scale.js
@@ -1,6 +1,21 @@
 import ApplicationSerializer from './application';
+import { arrToObj } from '../utils';
 
 export default ApplicationSerializer.extend({
   embed: true,
   include: ['taskGroupScales'],
+
+  serialize() {
+    var json = ApplicationSerializer.prototype.serialize.apply(this, arguments);
+    if (json instanceof Array) {
+      json.forEach(serializeJobScale);
+    } else {
+      serializeJobScale(json);
+    }
+    return json;
+  },
 });
+
+function serializeJobScale(jobScale) {
+  jobScale.TaskGroups = jobScale.TaskGroupScales.reduce(arrToObj('Name'), {});
+}

--- a/ui/mirage/serializers/task-group-scale.js
+++ b/ui/mirage/serializers/task-group-scale.js
@@ -1,0 +1,6 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  embed: true,
+  include: ['events'],
+});

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -329,7 +329,9 @@ module('Acceptance | task group detail', function(hooks) {
     await TaskGroup.countStepper.increment.click();
     await settled();
 
-    const scaleRequest = server.pretender.handledRequests.find(req => req.url.endsWith('/scale'));
+    const scaleRequest = server.pretender.handledRequests.find(
+      req => req.method === 'POST' && req.url.endsWith('/scale')
+    );
     const requestBody = JSON.parse(scaleRequest.requestBody);
     assert.equal(requestBody.Target.Group, scalingGroup.name);
     assert.equal(requestBody.Count, scalingGroup.count + 1);

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -406,4 +406,39 @@ module('Acceptance | task group detail', function(hooks) {
       await TaskGroup.visit({ id: job.id, name: taskGroup.name });
     },
   });
+
+  test('when a task group has no scaling events, there is no recent scaling events section', async function(assert) {
+    const taskGroupScale = job.jobScale.taskGroupScales.models.find(m => m.name === taskGroup.name);
+    taskGroupScale.update({ events: [] });
+    taskGroupScale.save();
+
+    await TaskGroup.visit({ id: job.id, name: taskGroup.name });
+
+    assert.notOk(TaskGroup.hasScaleEvents);
+  });
+
+  test('the recent scaling events section shows all recent scaling events in reverse chronological order', async function(assert) {
+    const taskGroupScale = job.jobScale.taskGroupScales.models.find(m => m.name === taskGroup.name);
+    const scaleEvents = taskGroupScale.events.models.sortBy('time').reverse();
+    await TaskGroup.visit({ id: job.id, name: taskGroup.name });
+
+    assert.ok(TaskGroup.hasScaleEvents);
+
+    scaleEvents.forEach((scaleEvent, idx) => {
+      const ScaleEvent = TaskGroup.scaleEvents[idx];
+      assert.equal(ScaleEvent.time, moment(scaleEvent.time / 1000000).format('MMM DD HH:mm:ss ZZ'));
+      assert.equal(ScaleEvent.message, scaleEvent.message);
+      assert.equal(ScaleEvent.count, scaleEvent.count);
+
+      if (scaleEvent.error) {
+        assert.ok(ScaleEvent.error);
+      }
+
+      if (Object.keys(scaleEvent.meta).length) {
+        assert.ok(ScaleEvent.isToggleable);
+      } else {
+        assert.notOk(ScaleEvent.isToggleable);
+      }
+    });
+  });
 });

--- a/ui/tests/integration/components/scale-events-accordion-test.js
+++ b/ui/tests/integration/components/scale-events-accordion-test.js
@@ -1,0 +1,133 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, find, findAll, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { startMirage } from 'nomad-ui/initializers/ember-cli-mirage';
+import setupCodeMirror from 'nomad-ui/tests/helpers/codemirror';
+import { initialize as fragmentSerializerInitializer } from 'nomad-ui/initializers/fragment-serializer';
+
+module('Integration | Component | scale-events-accordion', function(hooks) {
+  setupRenderingTest(hooks);
+  setupCodeMirror(hooks);
+
+  hooks.beforeEach(function() {
+    fragmentSerializerInitializer(this.owner);
+    this.store = this.owner.lookup('service:store');
+    this.server = startMirage();
+    this.server.create('node');
+    this.taskGroupWithEvents = async function(events) {
+      const job = this.server.create('job', { createAllocations: false });
+      const group = job.task_groups.models[0];
+      job.jobScale.taskGroupScales.models.findBy('name', group.name).update({ events });
+
+      const jobModel = await this.store.find('job', JSON.stringify([job.id, 'default']));
+      await jobModel.get('scaleState');
+      return jobModel.taskGroups.findBy('name', group.name);
+    };
+  });
+
+  const commonTemplate = hbs`<ScaleEventsAccordion @events={{this.events}} />`;
+
+  test('it shows an accordion with an entry for each event', async function(assert) {
+    const eventCount = 5;
+    const taskGroup = await this.taskGroupWithEvents(server.createList('scale-event', eventCount));
+    this.set('events', taskGroup.scaleState.events);
+
+    await render(commonTemplate);
+
+    assert.equal(findAll('[data-test-scale-events] [data-test-accordion-head]').length, eventCount);
+  });
+
+  test('when an event is an error, an error icon is shown', async function(assert) {
+    const taskGroup = await this.taskGroupWithEvents(
+      server.createList('scale-event', 1, { error: true })
+    );
+    this.set('events', taskGroup.scaleState.events);
+
+    await render(commonTemplate);
+
+    assert.ok(find('[data-test-error]'));
+  });
+
+  test('when an event has a count higher than previous count, a danger up arrow is shown', async function(assert) {
+    const count = 5;
+    const taskGroup = await this.taskGroupWithEvents(
+      server.createList('scale-event', 1, { count, previousCount: count - 1, error: false })
+    );
+    this.set('events', taskGroup.scaleState.events);
+
+    await render(commonTemplate);
+
+    assert.notOk(find('[data-test-error]'));
+    assert.equal(find('[data-test-count]').textContent, count);
+    assert.ok(
+      find('[data-test-count-icon]')
+        .querySelector('.icon')
+        .classList.contains('is-danger')
+    );
+  });
+
+  test('when an event has a count lower than previous count, a primary down arrow is shown', async function(assert) {
+    const count = 5;
+    const taskGroup = await this.taskGroupWithEvents(
+      server.createList('scale-event', 1, { count, previousCount: count + 1, error: false })
+    );
+    this.set('events', taskGroup.scaleState.events);
+
+    await render(commonTemplate);
+
+    assert.notOk(find('[data-test-error]'));
+    assert.equal(find('[data-test-count]').textContent, count);
+    assert.ok(
+      find('[data-test-count-icon]')
+        .querySelector('.icon')
+        .classList.contains('is-primary')
+    );
+  });
+
+  test('when an event has no count, the count is omitted', async function(assert) {
+    const taskGroup = await this.taskGroupWithEvents(
+      server.createList('scale-event', 1, { count: null })
+    );
+    this.set('events', taskGroup.scaleState.events);
+
+    await render(commonTemplate);
+
+    assert.equal(find('[data-test-count]').textContent, '');
+  });
+
+  test('when an event has no meta properties, the accordion entry is not expandable', async function(assert) {
+    const taskGroup = await this.taskGroupWithEvents(
+      server.createList('scale-event', 1, { meta: {} })
+    );
+    this.set('events', taskGroup.scaleState.events);
+
+    await render(commonTemplate);
+
+    assert.ok(find('[data-test-accordion-toggle]').classList.contains('is-invisible'));
+  });
+
+  test('when an event has meta properties, the accordion entry is expanding, presenting the meta properties in a json viewer', async function(assert) {
+    const meta = {
+      prop: 'one',
+      prop2: 'two',
+      deep: {
+        prop: 'here',
+        'dot.separate.prop': 12,
+      },
+    };
+    const taskGroup = await this.taskGroupWithEvents(server.createList('scale-event', 1, { meta }));
+    this.set('events', taskGroup.scaleState.events);
+
+    await render(commonTemplate);
+    assert.notOk(find('[data-test-accordion-body]'));
+
+    await click('[data-test-accordion-toggle]');
+    assert.ok(find('[data-test-accordion-body]'));
+
+    assert.equal(
+      getCodeMirrorInstance('[data-test-json-viewer]').getValue(),
+      JSON.stringify(meta, null, 2)
+    );
+  });
+});

--- a/ui/tests/integration/components/scale-events-accordion-test.js
+++ b/ui/tests/integration/components/scale-events-accordion-test.js
@@ -93,7 +93,8 @@ module('Integration | Component | scale-events-accordion', function(hooks) {
 
     await render(commonTemplate);
 
-    assert.equal(find('[data-test-count]').textContent, '');
+    assert.notOk(find('[data-test-count]'));
+    assert.notOk(find('[data-test-count-icon]'));
   });
 
   test('when an event has no meta properties, the accordion entry is not expandable', async function(assert) {

--- a/ui/tests/pages/jobs/job/task-group.js
+++ b/ui/tests/pages/jobs/job/task-group.js
@@ -53,6 +53,22 @@ export default create({
     permissions: text('[data-test-volume-permissions]'),
   }),
 
+  hasScaleEvents: isPresent('[data-test-scale-events]'),
+  scaleEvents: collection('[data-test-scale-events] [data-test-accordion-head]', {
+    error: isPresent('[data-test-error]'),
+    time: text('[data-test-time]'),
+    count: text('[data-test-count]'),
+    countIcon: { scope: '[data-test-count-icon]' },
+    message: text('[data-test-message]'),
+
+    isToggleable: isPresent('[data-test-accordion-toggle]:not(.is-invisible)'),
+    toggle: clickable('[data-test-accordion-toggle]'),
+  }),
+
+  scaleEventBodies: collection('[data-test-scale-events] [data-test-accordion-body]', {
+    meta: text(),
+  }),
+
   error: error(),
 
   emptyState: {


### PR DESCRIPTION
This adds recent scaling events to the Task Group Detail page.

Scaling events will typically be generated by the nomad autoscaler, but they can also be generated by the UI and any api calls to `POST /v1/:job/scale`.

![image](https://user-images.githubusercontent.com/174740/88696457-274ae100-d0b8-11ea-9ddd-cc219b337063.png)
