### PR TITLE
Docs: Fix placement invocations

### DIFF
--- a/website/pages/docs/job-specification/job.mdx
+++ b/website/pages/docs/job-specification/job.mdx
@@ -10,7 +10,7 @@ description: |-
 
 # `job` Stanza
 
-<Placement group={['job']} />
+<Placement groups={['job']} />
 
 The `job` stanza is the top-most configuration option in the job specification.
 A job is a declarative specification of tasks that Nomad should run. Jobs have

--- a/website/pages/docs/job-specification/logs.mdx
+++ b/website/pages/docs/job-specification/logs.mdx
@@ -10,7 +10,7 @@ description: |-
 
 # `logs` Stanza
 
-<Placement group={['job', 'group', 'task', 'logs']} />
+<Placement groups={['job', 'group', 'task', 'logs']} />
 
 The `logs` stanza configures the log rotation policy for a task's `stdout` and
 `stderr`. Logging is enabled by default with sane defaults (provided in the


### PR DESCRIPTION
I noticed the placement was blank while looking at the job documentation:

<img width="279" alt="image" src="https://user-images.githubusercontent.com/43280/88819040-1025f500-d185-11ea-8dd9-9c58b487847d.png">

I checked for any other such typos and found one.