### PR TITLE
UI: Change job search navigation to use id

### DIFF
--- a/ui/app/components/global-search/control.js
+++ b/ui/app/components/global-search/control.js
@@ -92,7 +92,7 @@ export default class GlobalSearchControl extends Component {
     const itemModelName = model.constructor.modelName;
 
     if (itemModelName === 'job') {
-      this.router.transitionTo('jobs.job', model.name, {
+      this.router.transitionTo('jobs.job', model.plainId, {
         queryParams: { namespace: model.get('namespace.name') },
       });
     } else if (itemModelName === 'node') {

--- a/ui/tests/acceptance/search-test.js
+++ b/ui/tests/acceptance/search-test.js
@@ -22,7 +22,7 @@ module('Acceptance | search', function(hooks) {
     const otherNode = server.create('node', { name: 'aaa' });
 
     server.create('job', { id: 'vwxyz', namespaceId: 'default' });
-    server.create('job', { id: 'xyz', namespace: 'default' });
+    server.create('job', { id: 'xyz', name: 'xyz job', namespace: 'default' });
     server.create('job', { id: 'abc', namespace: 'default' });
 
     await visit('/');
@@ -43,7 +43,7 @@ module('Acceptance | search', function(hooks) {
       search.groups[0].as(jobs => {
         assert.equal(jobs.name, 'Jobs (2)');
         assert.equal(jobs.options.length, 2);
-        assert.equal(jobs.options[0].text, 'xyz');
+        assert.equal(jobs.options[0].text, 'xyz job');
         assert.equal(jobs.options[1].text, 'vwxyz');
       });
 


### PR DESCRIPTION
This fixes #8548. It was a significant oversight to use the
name instead of the id!