### PR TITLE
e2e/csi: update EFS plugin test to use v1.0

### DIFF
--- a/e2e/csi/input/plugin-aws-efs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-efs-nodes.nomad
@@ -19,7 +19,7 @@ job "plugin-aws-efs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-efs-csi-driver:v0.3.0"
+        image = "amazon/aws-efs-csi-driver:v1.0.0"
 
         # note: the EFS driver doesn't seem to respect the --endpoint
         # flag and always sets up the listener at '/tmp/csi.sock'


### PR DESCRIPTION
The EFS plugin was recently released to 1.0: https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/tag/v1.0.0

---

Test run:

```
$ go test -v . -suite=CSI
=== RUN   TestE2E
...
--- PASS: TestE2E (139.20s)
...
    --- PASS: TestE2E/CSI (139.19s)
        --- PASS: TestE2E/CSI/*csi.CSIVolumesTest (139.12s)
            --- PASS: TestE2E/CSI/*csi.CSIVolumesTest/TestEBSVolumeClaim (89.33s)
            --- PASS: TestE2E/CSI/*csi.CSIVolumesTest/TestEFSVolumeClaim (49.60s)
...
PASS
ok      github.com/hashicorp/nomad/e2e  139.215s
```