### PR TITLE
Docs: Add documentation for job name parameter

### DIFF
--- a/website/pages/docs/job-specification/job.mdx
+++ b/website/pages/docs/job-specification/job.mdx
@@ -88,6 +88,9 @@ job "docs" {
 - `meta` <code>([Meta][]: nil)</code> - Specifies a key-value map that annotates
   with user-defined metadata.
 
+- `name` `(string: <optional>)` - Specifies a name for the job, which otherwise
+  defaults to the job id.
+
 - `migrate` <code>([Migrate][]: nil)</code> - Specifies the groups strategy for
   migrating off of draining nodes. If omitted, a default migration strategy is
   applied. Only service jobs with a count greater than 1 support migrate stanzas.

--- a/website/pages/docs/job-specification/job.mdx
+++ b/website/pages/docs/job-specification/job.mdx
@@ -89,7 +89,7 @@ job "docs" {
   with user-defined metadata.
 
 - `name` `(string: <optional>)` - Specifies a name for the job, which otherwise
-  defaults to the job id.
+  defaults to the job ID.
 
 - `migrate` <code>([Migrate][]: nil)</code> - Specifies the groups strategy for
   migrating off of draining nodes. If omitted, a default migration strategy is


### PR DESCRIPTION
While the `(string: <optional>)` pattern doesn’t appear elsewhere in this file, it does in various other files, and it seemed more accurate than the `(string: "")` seen in this file. I’m open to suggestions on this though, and the wording of the description!