### PR TITLE
Use the correct Message property instead of Reason in scale POST request

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -69,12 +69,12 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     });
   }
 
-  scale(job, group, count, reason) {
+  scale(job, group, count, message) {
     const url = addToPath(this.urlForFindRecord(job.get('id'), 'job'), '/scale');
     return this.ajax(url, 'POST', {
       data: {
         Count: count,
-        Reason: reason,
+        Message: message,
         Target: {
           Group: group,
         },

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -246,8 +246,9 @@ export default class Job extends Model {
     return promise;
   }
 
-  scale(group, count, reason = 'Manual scaling event from the Nomad UI') {
-    return this.store.adapterFor('job').scale(this, group, count, reason);
+  scale(group, count, message) {
+    if (message == null) message = `Manually scaled to ${count} from the Nomad UI`;
+    return this.store.adapterFor('job').scale(this, group, count, message);
   }
 
   setIdByPayload(payload) {

--- a/ui/app/models/task-group.js
+++ b/ui/app/models/task-group.js
@@ -59,7 +59,7 @@ export default class TaskGroup extends Fragment {
     return maybe(this.get('job.scaleState.taskGroupScales')).findBy('name', this.name);
   }
 
-  scale(count, reason) {
-    return this.job.scale(this.name, count, reason);
+  scale(count, message) {
+    return this.job.scale(this.name, count, message);
   }
 }


### PR DESCRIPTION
Also use a more informative default message (one that includes the new count)

This property changed from `Reason` to `Message` at some point during development. Beta software, amirite?