### PR TITLE
UI: Add linting to check for acceptance accessibility audits

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -99,6 +99,7 @@
     "ember-truth-helpers": "^2.0.0",
     "eslint": "^5.16.0",
     "eslint-plugin-ember": "^7.7.2",
+    "eslint-plugin-ember-a11y-testing": "a11y-tool-sandbox/eslint-plugin-ember-a11y-testing#ca31c9698c7cb105f1c9761d98fcaca7d6874459",
     "eslint-plugin-node": "^11.0.0",
     "faker": "^4.1.0",
     "flat": "^4.0.0",

--- a/ui/tests/.eslintrc.js
+++ b/ui/tests/.eslintrc.js
@@ -10,4 +10,19 @@ module.exports = {
   env: {
     embertest: true,
   },
+  overrides: {
+    files: ['acceptance/**/*-test.js'],
+    plugins: ['ember-a11y-testing'],
+    rules: {
+      'ember-a11y-testing/a11y-audit-called': 'error',
+    },
+    settings: {
+      'ember-a11y-testing': {
+        auditModule: {
+          package: 'nomad-ui/tests/helpers/a11y-audit',
+          exportName: 'default',
+        },
+      },
+    },
+  },
 };

--- a/ui/tests/acceptance/allocation-fs-test.js
+++ b/ui/tests/acceptance/allocation-fs-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember-a11y-testing/a11y-audit-called */ // Covered in behaviours/fs
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 

--- a/ui/tests/acceptance/search-test.js
+++ b/ui/tests/acceptance/search-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember-a11y-testing/a11y-audit-called */ // TODO
 import { module, test } from 'qunit';
 import { currentURL, triggerEvent, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';

--- a/ui/tests/acceptance/task-fs-test.js
+++ b/ui/tests/acceptance/task-fs-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember-a11y-testing/a11y-audit-called */ // Covered in behaviours/fs
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9452,6 +9452,12 @@ escodegen@^1.11.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-ember-a11y-testing@a11y-tool-sandbox/eslint-plugin-ember-a11y-testing#ca31c9698c7cb105f1c9761d98fcaca7d6874459:
+  version "0.0.0"
+  resolved "https://codeload.github.com/a11y-tool-sandbox/eslint-plugin-ember-a11y-testing/tar.gz/ca31c9698c7cb105f1c9761d98fcaca7d6874459"
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-plugin-ember@^7.7.2:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-7.13.0.tgz#a1df7794f06cdc6e1b8acfe6c59db5cf861f53dc"
@@ -15413,6 +15419,11 @@ require-relative@^0.8.7:
   version "0.8.7"
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
   integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This makes use of the [PR](https://github.com/a11y-tool-sandbox/eslint-plugin-ember-a11y-testing/pull/9) I recently had merged to `eslint-plugin-ember-a11y-testing` to add linting that ensures an accessibility audit is called at least once per acceptance test file. When I have added linting for component tests, it can apply there too.

I added exclusions for the filesystem browser tests, which are covered by `behaviors/fs` and for the search test which will involve significant overrides to Ember Power Select default templates.