### PR TITLE
csi/e2e: add 2nd controller for node drain testing

### DIFF
--- a/e2e/csi/input/plugin-aws-ebs-controller.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-controller.nomad
@@ -10,7 +10,14 @@ job "plugin-aws-ebs-controller" {
     value     = "linux"
   }
 
+  spread {
+    attribute = "${node.unique.id}"
+  }
+
   group "controller" {
+
+    count = 2 // HA for node drain testing
+
     task "plugin" {
       driver = "docker"
 


### PR DESCRIPTION
This changeset adds an extra controller plugin to our E2E suite, to enable node drain testing. I've got this in another branch for fixing the CSI node drain bug(s), but pulled this out of work into its own PR for reviewability.