### PR TITLE
ignore VAULT_NAMESPACE

### DIFF
--- a/command/job_run.go
+++ b/command/job_run.go
@@ -103,8 +103,7 @@ Run Options:
 
   -vault-namespace
     If set, the passed Vault namespace is stored in the job before sending to the
-    Nomad servers. This overrides the namespace found in $VAULT_NAMESPACE environment
-    variable and that found in the job.
+    Nomad servers.
 
   -verbose
     Display full information.
@@ -218,11 +217,6 @@ func (c *JobRunCommand) Run(args []string) int {
 
 	if vaultToken != "" {
 		job.VaultToken = helper.StringToPtr(vaultToken)
-	}
-
-	// Parse the Vault namespace
-	if vaultNamespace == "" {
-		vaultNamespace = os.Getenv("VAULT_NAMESPACE")
 	}
 
 	if vaultNamespace != "" {

--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -15,16 +15,6 @@ details provided for their upgrades as a result of new features or changed
 behavior. This page is used to document those details separately from the
 standard upgrade flow.
 
-## Nomad 0.12.2
-
-### Vault Namespace Environment Variable
-
-Nomad 0.12.2 allows Enterprise users to specify a Vault Namespace for a
-particular Job, Group, or Task. Before Nomad 0.12.2 the `VAULT_NAMESPACE`
-environment variable was ignored when submitting jobs. Nomad 0.12.2 changes the
-functionality and uses the `VAULT_NAMESPACE` environment variable when
-submitting jobs.
-
 ## Nomad 0.12.0
 
 ### Enterprise Licensing


### PR DESCRIPTION
VAULT_NAMESPACE in 0.12.1 and previous versions is already ignored. This PR reverts the change that used it as a default since it will break oss users and introduce unexpected behavior for non enterprise users.