### PR TITLE
csi: nomad volume detach command

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -60,6 +60,11 @@ func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 	return err
 }
 
+func (v *CSIVolumes) Detach(volID, nodeID string, w *WriteOptions) error {
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?detach=true&node=%v", url.PathEscape(volID), nodeID), nil, w)
+	return err
+}
+
 // CSIVolumeAttachmentMode duplicated in nomad/structs/csi.go
 type CSIVolumeAttachmentMode string
 

--- a/api/csi.go
+++ b/api/csi.go
@@ -61,7 +61,7 @@ func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 }
 
 func (v *CSIVolumes) Detach(volID, nodeID string, w *WriteOptions) error {
-	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?detach=true&node=%v", url.PathEscape(volID), nodeID), nil, w)
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/detach?node=%v", url.PathEscape(volID), nodeID), nil, w)
 	return err
 }
 

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -164,7 +164,7 @@ func (s *HTTPServer) csiVolumeDelete(id string, resp http.ResponseWriter, req *h
 }
 
 func (s *HTTPServer) csiVolumeDetach(id string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "DELETE" {
+	if req.Method != http.MethodDelete {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -51,21 +51,35 @@ func (s *HTTPServer) CSIVolumeSpecificRequest(resp http.ResponseWriter, req *htt
 	// Tokenize the suffix of the path to get the volume id
 	reqSuffix := strings.TrimPrefix(req.URL.Path, "/v1/volume/csi/")
 	tokens := strings.Split(reqSuffix, "/")
-	if len(tokens) > 2 || len(tokens) < 1 {
+	if len(tokens) < 1 {
 		return nil, CodedError(404, resourceNotFoundErr)
 	}
 	id := tokens[0]
 
-	switch req.Method {
-	case "GET":
-		return s.csiVolumeGet(id, resp, req)
-	case "PUT":
-		return s.csiVolumePut(id, resp, req)
-	case "DELETE":
-		return s.csiVolumeDelete(id, resp, req)
-	default:
-		return nil, CodedError(405, ErrInvalidMethod)
+	if len(tokens) == 1 {
+		switch req.Method {
+		case http.MethodGet:
+			return s.csiVolumeGet(id, resp, req)
+		case http.MethodPut:
+			return s.csiVolumePut(id, resp, req)
+		case http.MethodDelete:
+			return s.csiVolumeDelete(id, resp, req)
+		default:
+			return nil, CodedError(405, ErrInvalidMethod)
+		}
 	}
+
+	if len(tokens) == 2 {
+		if tokens[1] != "detach" {
+			return nil, CodedError(404, resourceNotFoundErr)
+		}
+		if req.Method != http.MethodDelete {
+			return nil, CodedError(405, ErrInvalidMethod)
+		}
+		return s.csiVolumeDetach(id, resp, req)
+	}
+
+	return nil, CodedError(404, resourceNotFoundErr)
 }
 
 func (s *HTTPServer) csiVolumeGet(id string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -123,17 +137,7 @@ func (s *HTTPServer) csiVolumeDelete(id string, resp http.ResponseWriter, req *h
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
-	raw := req.URL.Query().Get("detach")
-	var detach bool
-	if raw != "" {
-		var err error
-		detach, err = strconv.ParseBool(raw)
-		if err != nil {
-			return nil, CodedError(400, "invalid detach value")
-		}
-	}
-
-	raw = req.URL.Query().Get("force")
+	raw := req.URL.Query().Get("force")
 	var force bool
 	if raw != "" {
 		var err error
@@ -141,30 +145,6 @@ func (s *HTTPServer) csiVolumeDelete(id string, resp http.ResponseWriter, req *h
 		if err != nil {
 			return nil, CodedError(400, "invalid force value")
 		}
-	}
-
-	if detach {
-		nodeID := req.URL.Query().Get("node")
-		if nodeID == "" {
-			return nil, CodedError(400, "detach requires node ID")
-		}
-
-		args := structs.CSIVolumeUnpublishRequest{
-			VolumeID: id,
-			Claim: &structs.CSIVolumeClaim{
-				NodeID: nodeID,
-				Mode:   structs.CSIVolumeClaimRelease,
-			},
-		}
-		s.parseWriteRequest(req, &args.WriteRequest)
-
-		var out structs.CSIVolumeUnpublishResponse
-		if err := s.agent.RPC("CSIVolume.Unpublish", &args, &out); err != nil {
-			return nil, err
-		}
-
-		setMeta(resp, &out.QueryMeta)
-		return nil, nil
 	}
 
 	args := structs.CSIVolumeDeregisterRequest{
@@ -180,6 +160,34 @@ func (s *HTTPServer) csiVolumeDelete(id string, resp http.ResponseWriter, req *h
 
 	setMeta(resp, &out.QueryMeta)
 
+	return nil, nil
+}
+
+func (s *HTTPServer) csiVolumeDetach(id string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != "DELETE" {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	nodeID := req.URL.Query().Get("node")
+	if nodeID == "" {
+		return nil, CodedError(400, "detach requires node ID")
+	}
+
+	args := structs.CSIVolumeUnpublishRequest{
+		VolumeID: id,
+		Claim: &structs.CSIVolumeClaim{
+			NodeID: nodeID,
+			Mode:   structs.CSIVolumeClaimRelease,
+		},
+	}
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	var out structs.CSIVolumeUnpublishResponse
+	if err := s.agent.RPC("CSIVolume.Unpublish", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
 	return nil, nil
 }
 

--- a/command/commands.go
+++ b/command/commands.go
@@ -723,6 +723,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"volume detach": func() (cli.Command, error) {
+			return &VolumeDetachCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 
 	deprecated := map[string]cli.CommandFactory{

--- a/command/volume.go
+++ b/command/volume.go
@@ -28,6 +28,10 @@ Usage: nomad volume <subcommand> [options]
 
       $ nomad volume deregister <id>
 
+  Detach an unused volume:
+
+      $ nomad volume detach <vol id> <node id>
+
   Please see the individual subcommand help for detailed usage information.
 `
 	return strings.TrimSpace(helpText)

--- a/command/volume_detach.go
+++ b/command/volume_detach.go
@@ -1,0 +1,97 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
+)
+
+type VolumeDetachCommand struct {
+	Meta
+}
+
+func (c *VolumeDetachCommand) Help() string {
+	helpText := `
+Usage: nomad volume detach [options] <vol id> <node id>
+
+  Detach a volume from a Nomad client.
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *VolumeDetachCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{})
+}
+
+func (c *VolumeDetachCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := c.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Volumes, nil)
+		if err != nil {
+			return []string{}
+		}
+		matches := resp.Matches[contexts.Volumes]
+
+		resp, _, err = client.Search().PrefixSearch(a.Last, contexts.Nodes, nil)
+		if err != nil {
+			return []string{}
+		}
+		for _, match := range resp.Matches[contexts.Nodes] {
+			matches = append(matches, match)
+		}
+		return matches
+	})
+}
+
+func (c *VolumeDetachCommand) Synopsis() string {
+	return "Detach a volume"
+}
+
+func (c *VolumeDetachCommand) Name() string { return "volume detach" }
+
+func (c *VolumeDetachCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing arguments %s", err))
+		return 1
+	}
+
+	// Check that we get exactly two arguments
+	args = flags.Args()
+	if l := len(args); l != 2 {
+		c.Ui.Error("This command takes two arguments: <vol id> <node id>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+	volID := args[0]
+	nodeID := args[1]
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	err = client.CSIVolumes().Detach(volID, nodeID, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error detaching volume: %s", err))
+		return 1
+	}
+
+	return 0
+}

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -60,6 +60,11 @@ func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 	return err
 }
 
+func (v *CSIVolumes) Detach(volID, nodeID string, w *WriteOptions) error {
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?detach=true&node=%v", url.PathEscape(volID), nodeID), nil, w)
+	return err
+}
+
 // CSIVolumeAttachmentMode duplicated in nomad/structs/csi.go
 type CSIVolumeAttachmentMode string
 

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -61,7 +61,7 @@ func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 }
 
 func (v *CSIVolumes) Detach(volID, nodeID string, w *WriteOptions) error {
-	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?detach=true&node=%v", url.PathEscape(volID), nodeID), nil, w)
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/detach?node=%v", url.PathEscape(volID), nodeID), nil, w)
 	return err
 }
 

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -148,7 +148,7 @@ export default [
       { category: 'system', content: ['gc', 'reconcile-summaries'] },
       'ui',
       'version',
-      { category: 'volume', content: ['register', 'deregister', 'status'] }
+      { category: 'volume', content: ['deregister', 'detach', 'status', 'register'] }
     ]
   },
   '----------',

--- a/website/pages/api-docs/volumes.mdx
+++ b/website/pages/api-docs/volumes.mdx
@@ -297,8 +297,8 @@ $ curl \
 
 ## Delete Volume
 
-This endpoint deregisters an external volume with Nomad. It is an
-error to deregister a volume that is in use.
+This endpoint deregisters an external volume with Nomad or detaches the volume
+from a node. It is an error to deregister or detach a volume that is in use.
 
 | Method  | Path                         | Produces           |
 | ------- | ---------------------------- | ------------------ |
@@ -322,6 +322,12 @@ The table below shows this endpoint's support for
   drop claims for terminal allocations. Returns an error if the volume has
   running allocations. This does not detach the volume from client nodes.
   This is specified as a query string parameter.
+
+- `detach` `(bool: false)`- Detach the volume from the node given by the `node`
+  parameter, rather than deregister it.
+
+- `node` `(string: "")`- The node to detach the volume from. This parameter is
+  required if the `detach` parameter is `true`.
 
 ### Sample Request
 

--- a/website/pages/api-docs/volumes.mdx
+++ b/website/pages/api-docs/volumes.mdx
@@ -297,8 +297,8 @@ $ curl \
 
 ## Delete Volume
 
-This endpoint deregisters an external volume with Nomad or detaches the volume
-from a node. It is an error to deregister or detach a volume that is in use.
+This endpoint deregisters an external volume with Nomad. It is an error to
+deregister a volume that is in use.
 
 | Method  | Path                         | Produces           |
 | ------- | ---------------------------- | ------------------ |
@@ -323,12 +323,6 @@ The table below shows this endpoint's support for
   running allocations. This does not detach the volume from client nodes.
   This is specified as a query string parameter.
 
-- `detach` `(bool: false)`- Detach the volume from the node given by the `node`
-  parameter, rather than deregister it.
-
-- `node` `(string: "")`- The node to detach the volume from. This parameter is
-  required if the `detach` parameter is `true`.
-
 ### Sample Request
 
 ```shell-session
@@ -336,4 +330,38 @@ $ curl \
     --request DELETE \
     --data @payload.json \
     https://localhost:4646/v1/volume/csi/volume-id1?force=false
+```
+
+## Detach Volume
+
+This endpoint detaches an external volume from a Nomad client node.  It is an
+error to detach a volume that is in use.
+
+| Method  | Path                                | Produces           |
+| ------- | ----------------------------------- | ------------------ |
+| `DELETE` | `/v1/volume/csi/:volume_id/detach` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/api-docs#blocking-queries) and
+[required ACLs](/api-docs#acls).
+
+| Blocking Queries | ACL Required                 |
+| ---------------- | ---------------------------- |
+| `NO`             | `namespace:csi-write-volume` |
+
+### Parameters
+
+- `:volume_id` `(string: <required>)`- Specifies the ID of the
+  volume. This must be the full ID. This is specified as part of the
+  path.
+
+- `node` `(string: <required>)`- The node to detach the volume from.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request DELETE \
+    --data @payload.json \
+    https://localhost:4646/v1/volume/csi/volume-id/detach
 ```

--- a/website/pages/docs/commands/volume/detach.mdx
+++ b/website/pages/docs/commands/volume/detach.mdx
@@ -8,9 +8,8 @@ description: |
 
 # Command: volume detach
 
-The `volume detach` command detachs external storage volumes with Nomad's
-[Container Storage Interface (CSI)][csi] support. The volume must exist on the
-remote storage provider before it can be detached and used by a task.
+The `volume detach` command detaches external storage volumes with Nomad's
+[Container Storage Interface (CSI)][csi] support.
 
 ## Usage
 
@@ -20,7 +19,7 @@ nomad volume detach [options] [volume] [node]
 
 The `volume detach` command requires two arguments, specifying the ID of the
 volume to be detached and the node to detach it from. Detaching will fail if
-fail if the volume is still in use by an allocation.
+the volume is still in use by an allocation.
 
 ## General Options
 

--- a/website/pages/docs/commands/volume/detach.mdx
+++ b/website/pages/docs/commands/volume/detach.mdx
@@ -1,0 +1,29 @@
+---
+layout: docs
+page_title: 'Commands: volume detach'
+sidebar_title: detach
+description: |
+  Detach volumes with CSI plugins.
+---
+
+# Command: volume detach
+
+The `volume detach` command detachs external storage volumes with Nomad's
+[Container Storage Interface (CSI)][csi] support. The volume must exist on the
+remote storage provider before it can be detached and used by a task.
+
+## Usage
+
+```plaintext
+nomad volume detach [options] [volume] [node]
+```
+
+The `volume detach` command requires two arguments, specifying the ID of the
+volume to be detached and the node to detach it from. Detaching will fail if
+fail if the volume is still in use by an allocation.
+
+## General Options
+
+@include 'general_options.mdx'
+
+[csi]: https://github.com/container-storage-interface/spec

--- a/website/pages/docs/commands/volume/index.mdx
+++ b/website/pages/docs/commands/volume/index.mdx
@@ -17,10 +17,12 @@ Usage: `nomad volume <subcommand> [options]`
 Run `nomad volume <subcommand> -h` for help on that subcommand. The following
 subcommands are available:
 
-- [`volume register`][register] - Register a volume.
 - [`volume deregister`][deregister] - Deregister a volume.
+- [`volume detach`][detach] - Detach a volume.
+- [`volume register`][register] - Register a volume.
 - [`volume status`][status] - Display status information about a volume
 
-[register]: /docs/commands/volume/register 'Register a volume'
 [deregister]: /docs/commands/volume/deregister 'Deregister a volume'
+[detach]: /docs/commands/volume/detach 'Detach a volume'
+[register]: /docs/commands/volume/register 'Register a volume'
 [status]: /docs/commands/volume/status 'Display status information about a volume'


### PR DESCRIPTION
For https://github.com/hashicorp/nomad/issues/8252

The soundness guarantees of the CSI specification leave a little to be desired
in our ability to provide a 100% reliable automated solution for managing
volumes. This changeset provides a new command to bridge this gap by providing
the operator the ability to intervene.

The command doesn't take an allocation ID so that the operator doesn't have to
keep track of alloc IDs that may have been GC'd. Handle this case in the
unpublish RPC by sending the client RPC for all the terminal/nil allocs on the
selected node.