### PR TITLE
CSI: volume and plugin allocations in the API

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -925,6 +925,7 @@ type TaskEvent struct {
 	Time           int64
 	DisplayMessage string
 	Details        map[string]string
+	Message        string
 	// DEPRECATION NOTICE: The following fields are all deprecated. see TaskEvent struct in structs.go for details.
 	FailsTask        bool
 	RestartReason    string
@@ -933,7 +934,6 @@ type TaskEvent struct {
 	DriverMessage    string
 	ExitCode         int
 	Signal           int
-	Message          string
 	KillReason       string
 	KillTimeout      time.Duration
 	KillError        string

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -253,7 +253,7 @@ func (s *HTTPServer) CSIPluginSpecificRequest(resp http.ResponseWriter, req *htt
 		return nil, CodedError(404, "plugin not found")
 	}
 
-	return out.Plugin, nil
+	return structsCSIPluginToApi(out.Plugin), nil
 }
 
 // structsCSIPluginToApi converts CSIPlugin, setting Expected the count of known plugin

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -12,7 +12,7 @@ import (
 func (s *HTTPServer) CSIVolumesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
 	case http.MethodPut, http.MethodPost:
-		return s.csiVolumePost(resp, req)
+		return s.csiVolumePut(resp, req)
 	case http.MethodGet:
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -66,7 +66,7 @@ func (s *HTTPServer) CSIVolumeSpecificRequest(resp http.ResponseWriter, req *htt
 		case http.MethodGet:
 			return s.csiVolumeGet(id, resp, req)
 		case http.MethodPut:
-			return s.csiVolumePut(id, resp, req)
+			return s.csiVolumePut(resp, req)
 		case http.MethodDelete:
 			return s.csiVolumeDelete(id, resp, req)
 		default:
@@ -115,7 +115,7 @@ func (s *HTTPServer) csiVolumeGet(id string, resp http.ResponseWriter, req *http
 	return vol, nil
 }
 
-func (s *HTTPServer) csiVolumePost(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (s *HTTPServer) csiVolumePut(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
 	case http.MethodPost, http.MethodPut:
 	default:
@@ -125,35 +125,6 @@ func (s *HTTPServer) csiVolumePost(resp http.ResponseWriter, req *http.Request) 
 	args0 := structs.CSIVolumeRegisterRequest{}
 	if err := decodeBody(req, &args0); err != nil {
 		return err, CodedError(400, err.Error())
-	}
-
-	args := structs.CSIVolumeRegisterRequest{
-		Volumes: args0.Volumes,
-	}
-	s.parseWriteRequest(req, &args.WriteRequest)
-
-	var out structs.CSIVolumeRegisterResponse
-	if err := s.agent.RPC("CSIVolume.Register", &args, &out); err != nil {
-		return nil, err
-	}
-
-	setMeta(resp, &out.QueryMeta)
-
-	return nil, nil
-}
-
-func (s *HTTPServer) csiVolumePut(id string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != http.MethodPut {
-		return nil, CodedError(405, ErrInvalidMethod)
-	}
-
-	args0 := structs.CSIVolumeRegisterRequest{}
-	if err := decodeBody(req, &args0); err != nil {
-		return err, CodedError(400, err.Error())
-	}
-
-	if len(args0.Volumes) != 1 || id != args0.Volumes[0].ID {
-		return nil, CodedError(400, "URL ID does not match Volume body")
 	}
 
 	args := structs.CSIVolumeRegisterRequest{

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -494,7 +494,7 @@ func structsTaskEventToApi(te *structs.TaskEvent) *api.TaskEvent {
 
 // structsCSITopolgiesToApi converts topologies, part of structsCSIVolumeToApi
 func structsCSITopolgiesToApi(tops []*structs.CSITopology) []*api.CSITopology {
-	out := make([]*api.CSITopology, len(tops))
+	out := make([]*api.CSITopology, 0, len(tops))
 	for _, t := range tops {
 		out = append(out, &api.CSITopology{
 			Segments: t.Segments,

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -143,7 +143,7 @@ func (s *HTTPServer) csiVolumePut(resp http.ResponseWriter, req *http.Request) (
 }
 
 func (s *HTTPServer) csiVolumeDelete(id string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "DELETE" {
+	if req.Method != http.MethodDelete {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -203,7 +203,7 @@ func (s *HTTPServer) csiVolumeDetach(id string, resp http.ResponseWriter, req *h
 
 // CSIPluginsRequest lists CSI plugins
 func (s *HTTPServer) CSIPluginsRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -235,7 +235,7 @@ func (s *HTTPServer) CSIPluginsRequest(resp http.ResponseWriter, req *http.Reque
 
 // CSIPluginSpecificRequest list the job with CSIInfo
 func (s *HTTPServer) CSIPluginSpecificRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -493,7 +493,8 @@ func structsTaskEventToApi(te *structs.TaskEvent) *api.TaskEvent {
 }
 
 // structsCSITopolgiesToApi converts topologies, part of structsCSIVolumeToApi
-func structsCSITopolgiesToApi(tops []*structs.CSITopology) (out []*api.CSITopology) {
+func structsCSITopolgiesToApi(tops []*structs.CSITopology) []*api.CSITopology {
+	out := make([]*api.CSITopology, len(tops))
 	for _, t := range tops {
 		out = append(out, &api.CSITopology{
 			Segments: t.Segments,
@@ -545,7 +546,8 @@ func structsCSIMountOptionsToApi(opts *structs.CSIMountOptions) *api.CSIMountOpt
 	}
 }
 
-func structsCSISecretsToApi(secrets structs.CSISecrets) (out api.CSISecrets) {
+func structsCSISecretsToApi(secrets structs.CSISecrets) api.CSISecrets {
+	out := make(api.CSISecrets, len(secrets))
 	for k, v := range secrets {
 		out[k] = v
 	}

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -487,9 +487,6 @@ func structsTaskEventToApi(te *structs.TaskEvent) *api.TaskEvent {
 		TaskSignalReason: te.TaskSignalReason,
 		TaskSignal:       te.TaskSignal,
 		GenericSource:    te.GenericSource,
-
-		// DiskSize is in the deprecated section of the api struct but is not in structs
-		// DiskSize:         te.DiskSize,
 	}
 
 	return out

--- a/command/agent/csi_endpoint_test.go
+++ b/command/agent/csi_endpoint_test.go
@@ -52,6 +52,7 @@ func TestHTTP_CSIEndpointUtils(t *testing.T) {
 	tops := structsCSITopolgiesToApi([]*structs.CSITopology{{
 		Segments: map[string]string{"foo": "bar"},
 	}})
+
 	require.Equal(t, "bar", tops[0].Segments["foo"])
 }
 

--- a/command/agent/csi_endpoint_test.go
+++ b/command/agent/csi_endpoint_test.go
@@ -42,6 +42,19 @@ func TestHTTP_CSIEndpointPlugin(t *testing.T) {
 	})
 }
 
+func TestHTTP_CSIEndpointUtils(t *testing.T) {
+	secrets := structsCSISecretsToApi(structs.CSISecrets{
+		"foo": "bar",
+	})
+
+	require.Equal(t, "bar", secrets["foo"])
+
+	tops := structsCSITopolgiesToApi([]*structs.CSITopology{{
+		Segments: map[string]string{"foo": "bar"},
+	}})
+	require.Equal(t, "bar", tops[0].Segments["foo"])
+}
+
 func TestHTTP_CSIEndpointVolume(t *testing.T) {
 	t.Parallel()
 	httpTest(t, nil, func(s *TestAgent) {

--- a/command/agent/csi_endpoint_test.go
+++ b/command/agent/csi_endpoint_test.go
@@ -1,0 +1,87 @@
+package agent
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTP_CSIEndpointPlugin(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		server := s.Agent.Server()
+		cleanup := state.CreateTestCSIPlugin(server.State(), "foo")
+		defer cleanup()
+
+		body := bytes.NewBuffer(nil)
+		req, err := http.NewRequest("GET", "/v1/plugin/csi/foo", body)
+		require.NoError(t, err)
+
+		resp := httptest.NewRecorder()
+		obj, err := s.Server.CSIPluginSpecificRequest(resp, req)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.Code)
+
+		out, ok := obj.(*api.CSIPlugin)
+		require.True(t, ok)
+
+		require.Equal(t, 1, out.ControllersExpected)
+		require.Equal(t, 1, out.ControllersHealthy)
+		require.Len(t, out.Controllers, 1)
+
+		require.Equal(t, 2, out.NodesExpected)
+		require.Equal(t, 2, out.NodesHealthy)
+		require.Len(t, out.Nodes, 2)
+	})
+}
+
+func TestHTTP_CSIEndpointVolume(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		server := s.Agent.Server()
+		cleanup := state.CreateTestCSIPluginNodeOnly(server.State(), "foo")
+		defer cleanup()
+
+		args := structs.CSIVolumeRegisterRequest{
+			Volumes: []*structs.CSIVolume{{
+				ID:             "bar",
+				PluginID:       "foo",
+				AccessMode:     structs.CSIVolumeAccessModeMultiNodeSingleWriter,
+				AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
+			}},
+		}
+		body := encodeReq(args)
+		req, err := http.NewRequest("PUT", "/v1/volumes", body)
+		require.NoError(t, err)
+
+		resp := httptest.NewRecorder()
+		_, err = s.Server.CSIVolumesRequest(resp, req)
+		require.NoError(t, err, "put error")
+		require.Equal(t, 200, resp.Code)
+
+		req, err = http.NewRequest("GET", "/v1/volume/csi/bar", nil)
+		require.NoError(t, err)
+
+		resp = httptest.NewRecorder()
+		raw, err := s.Server.CSIVolumeSpecificRequest(resp, req)
+		require.NoError(t, err, "get error")
+		require.Equal(t, 200, resp.Code)
+
+		out, ok := raw.(*api.CSIVolume)
+		require.True(t, ok)
+
+		pretty.Log(out)
+
+		require.Equal(t, 1, out.ControllersExpected)
+		require.Equal(t, 1, out.ControllersHealthy)
+		require.Equal(t, 2, out.NodesExpected)
+		require.Equal(t, 2, out.NodesHealthy)
+	})
+}


### PR DESCRIPTION
API representations of individual plugins and volumes include correct allocation data

Fixes #8362 and similar issue for plugins