### PR TITLE
CSI plugins check `safeCopy` field

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -925,6 +925,7 @@ type TaskEvent struct {
 	Time           int64
 	DisplayMessage string
 	Details        map[string]string
+	Message        string
 	// DEPRECATION NOTICE: The following fields are all deprecated. see TaskEvent struct in structs.go for details.
 	FailsTask        bool
 	RestartReason    string
@@ -933,7 +934,6 @@ type TaskEvent struct {
 	DriverMessage    string
 	ExitCode         int
 	Signal           int
-	Message          string
 	KillReason       string
 	KillTimeout      time.Duration
 	KillError        string

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1346,17 +1346,11 @@ func MultiregionJob() *structs.Job {
 }
 
 func CSIPlugin() *structs.CSIPlugin {
-	return &structs.CSIPlugin{
-		ID:                 uuid.Generate(),
-		Provider:           "com.hashicorp:mock",
-		Version:            "0.1",
-		ControllerRequired: true,
-		Controllers:        map[string]*structs.CSIInfo{},
-		Nodes:              map[string]*structs.CSIInfo{},
-		Allocations:        []*structs.AllocListStub{},
-		ControllersHealthy: 0,
-		NodesHealthy:       0,
-	}
+	plug := structs.NewCSIPlugin(uuid.Generate(), 0)
+	plug.Provider = "com.hashicorp:mock"
+	plug.Version = "0.1"
+	plug.ControllerRequired = true
+	return plug
 }
 
 func CSIVolume(plugin *structs.CSIPlugin) *structs.CSIVolume {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1100,7 +1100,7 @@ func upsertNodeCSIPlugins(txn *memdb.Txn, node *structs.Node, index uint64) erro
 		if raw == nil {
 			break
 		}
-		plug := raw.(*structs.CSIPlugin)
+		plug := raw.(*structs.CSIPlugin).Copy()
 
 		var hadDelete bool
 		if _, ok := inUseController[plug.ID]; !ok {
@@ -4746,6 +4746,7 @@ func (s *StateStore) updatePluginWithAlloc(index uint64, alloc *structs.Allocati
 				// became healthy, just move on
 				return nil
 			}
+			plug = plug.Copy()
 			err = plug.DeleteAlloc(alloc.ID, alloc.NodeID)
 			if err != nil {
 				return err

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -697,11 +697,16 @@ type CSIPlugin struct {
 	Allocations []*AllocListStub
 
 	// Cache the count of healthy plugins
-	ControllersHealthy int
-	NodesHealthy       int
+	ControllersExpected int
+	ControllersHealthy  int
+	NodesExpected       int
+	NodesHealthy        int
 
 	CreateIndex uint64
 	ModifyIndex uint64
+
+	// safeCopy is handled automatically to ensure the object is safe to modify
+	safeCopy bool
 }
 
 // NewCSIPlugin creates the plugin struct. No side-effects
@@ -710,6 +715,7 @@ func NewCSIPlugin(id string, index uint64) *CSIPlugin {
 		ID:          id,
 		CreateIndex: index,
 		ModifyIndex: index,
+		safeCopy:    true,
 	}
 
 	out.newStructs()
@@ -719,6 +725,7 @@ func NewCSIPlugin(id string, index uint64) *CSIPlugin {
 func (p *CSIPlugin) newStructs() {
 	p.Controllers = map[string]*CSIInfo{}
 	p.Nodes = map[string]*CSIInfo{}
+	p.safeCopy = true
 }
 
 func (p *CSIPlugin) Copy() *CSIPlugin {
@@ -734,7 +741,27 @@ func (p *CSIPlugin) Copy() *CSIPlugin {
 		out.Nodes[k] = v
 	}
 
+	// introduced in 0.12.1, these fields may be empty
+	p.ControllersExpected = len(p.Controllers)
+	p.NodesExpected = len(p.Nodes)
+
+	out.safeCopy = true
+
 	return out
+}
+
+func (p *CSIPlugin) SafeToModify() bool {
+	if !p.safeCopy {
+		return false
+	}
+	p.safeCopy = false
+	return true
+}
+
+// Normalize populates derived fields needed in the API
+func (p *CSIPlugin) Normalize() {
+	p.ControllersExpected = len(p.Controllers)
+	p.NodesExpected = len(p.Nodes)
 }
 
 // AddPlugin adds a single plugin running on the node. Called from state.NodeUpdate in a
@@ -761,6 +788,7 @@ func (p *CSIPlugin) AddPlugin(nodeID string, info *CSIInfo) error {
 		// ok
 		if prev != nil || info.Healthy {
 			p.Controllers[nodeID] = info
+			p.ControllersExpected += 1
 		}
 		if info.Healthy {
 			p.ControllersHealthy += 1
@@ -779,6 +807,7 @@ func (p *CSIPlugin) AddPlugin(nodeID string, info *CSIInfo) error {
 		}
 		if prev != nil || info.Healthy {
 			p.Nodes[nodeID] = info
+			p.NodesExpected += 1
 		}
 		if info.Healthy {
 			p.NodesHealthy += 1
@@ -809,6 +838,7 @@ func (p *CSIPlugin) DeleteNodeForType(nodeID string, pluginType CSIPluginType) e
 			}
 		}
 		delete(p.Controllers, nodeID)
+		p.ControllersExpected -= 1
 
 	case CSIPluginTypeNode:
 		prev, ok := p.Nodes[nodeID]
@@ -821,6 +851,7 @@ func (p *CSIPlugin) DeleteNodeForType(nodeID string, pluginType CSIPluginType) e
 			}
 		}
 		delete(p.Nodes, nodeID)
+		p.NodesExpected -= 1
 
 	case CSIPluginTypeMonolith:
 		p.DeleteNodeForType(nodeID, CSIPluginTypeController)


### PR DESCRIPTION
We may not want to leave this (runtime) check in the structs, but this introduces a field flagging whether the current plugin struct is shared with the state store. We do want to keep the commit that fixes two cases where the plugin struct was modified in place.