### PR TITLE
UI: Task group scaling timeline

### DIFF
--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -90,7 +90,7 @@ export default class LineChart extends Component.extend(WindowResizable) {
 
   // Overridable functions that retrurn formatter functions
   xFormat(timeseries) {
-    return timeseries ? d3TimeFormat.timeFormat('%b') : d3Format.format(',');
+    return timeseries ? d3TimeFormat.timeFormat('%b %d, %H:%M') : d3Format.format(',');
   }
 
   yFormat() {

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -50,6 +50,7 @@ export default class LineChart extends Component.extend(WindowResizable) {
 
   data = null;
   annotations = null;
+  activeAnnotation = null;
   onAnnotationClick() {}
   xProp = null;
   yProp = null;

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -271,16 +271,21 @@ export default class LineChart extends Component.extend(WindowResizable) {
 
     if (!annotations || !annotations.length) return null;
 
-    return annotations.map(annotation => {
+    let sortedAnnotations = annotations.sortBy(xProp);
+    if (timeseries) {
+      sortedAnnotations = sortedAnnotations.reverse();
+    }
+
+    return sortedAnnotations.map(annotation => {
       const x = xScale(annotation[xProp]);
       const y = 0; // TODO: prevent overlap by staggering y-offset
-      const time = this.xFormat(timeseries)(annotation[xProp]);
+      const formattedX = this.xFormat(timeseries)(annotation[xProp]);
       return {
         annotation,
         style: `transform:translate(${x}px,${y}px)`,
         icon: iconFor[annotation.type],
         iconClass: iconClassFor[annotation.type],
-        label: `${annotation.type} event at ${time}`,
+        label: `${annotation.type} event at ${formattedX}`,
       };
     });
   }

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -290,15 +290,25 @@ export default class LineChart extends Component.extend(WindowResizable) {
       sortedAnnotations = sortedAnnotations.reverse();
     }
 
+    let prevX = 0;
+    let prevHigh = false;
     return sortedAnnotations.map(annotation => {
       const x = xScale(annotation[xProp]);
-      const y = 0; // TODO: prevent overlap by staggering y-offset
+      if (prevX && !prevHigh && Math.abs(x - prevX) < 30) {
+        prevHigh = true;
+      } else if (prevHigh) {
+        prevHigh = false;
+      }
+      const y = prevHigh ? -15 : 0;
       const formattedX = this.xFormat(timeseries)(annotation[xProp]);
+
+      prevX = x;
       return {
         annotation,
         style: `transform:translate(${x}px,${y}px)`,
         icon: iconFor[annotation.type],
         iconClass: iconClassFor[annotation.type],
+        staggerClass: prevHigh ? 'is-staggered' : '',
         label: `${annotation.type} event at ${formattedX}`,
       };
     });

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -306,7 +306,7 @@ export default class LineChart extends Component.extend(WindowResizable) {
       prevX = x;
       return {
         annotation,
-        style: `transform:translate(${x}px,${y}px)`,
+        style: `transform:translate(${x}px,${y}px)`.htmlSafe(),
         icon: iconFor[annotation.type],
         iconClass: iconClassFor[annotation.type],
         staggerClass: prevHigh ? 'is-staggered' : '',

--- a/ui/app/components/scale-events-chart.js
+++ b/ui/app/components/scale-events-chart.js
@@ -12,7 +12,24 @@ export default class ScaleEventsChart extends Component {
 
   @computed('events.[]')
   get data() {
-    return this.events.filterBy('hasCount').sortBy('time');
+    const data = this.events.filterBy('hasCount');
+
+    // Extend the domain of the chart to the current time
+    data.push({
+      time: new Date(),
+      count: data.lastObject.count,
+    });
+
+    // Make sure the domain of the chart includes the first annotation
+    const firstAnnotation = this.annotations.sortBy('time')[0];
+    if (firstAnnotation && firstAnnotation.time < data[0].time) {
+      data.unshift({
+        time: firstAnnotation.time,
+        count: data[0].count,
+      });
+    }
+
+    return data.sortBy('time');
   }
 
   @computed('events.[]')

--- a/ui/app/components/scale-events-chart.js
+++ b/ui/app/components/scale-events-chart.js
@@ -12,7 +12,7 @@ export default class ScaleEventsChart extends Component {
 
   @computed('events.[]')
   get data() {
-    const data = this.events.filterBy('hasCount');
+    const data = this.events.filterBy('hasCount').sortBy('time');
 
     // Extend the domain of the chart to the current time
     data.push({
@@ -29,7 +29,7 @@ export default class ScaleEventsChart extends Component {
       });
     }
 
-    return data.sortBy('time');
+    return data;
   }
 
   @computed('events.[]')

--- a/ui/app/components/scale-events-chart.js
+++ b/ui/app/components/scale-events-chart.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { copy } from 'ember-copy';
+import { computed, get } from '@ember/object';
 import { tagName } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
 
@@ -37,12 +38,12 @@ export default class ScaleEventsChart extends Component {
     return this.events.rejectBy('hasCount').map(ev => ({
       type: ev.error ? 'error' : 'info',
       time: ev.time,
-      event: ev,
+      event: copy(ev),
     }));
   }
 
   toggleEvent(ev) {
-    if (this.activeEvent === ev) {
+    if (this.activeEvent && get(this.activeEvent, 'event.uid') === get(ev, 'event.uid')) {
       this.closeEventDetails();
     } else {
       this.set('activeEvent', ev);

--- a/ui/app/components/scale-events-chart.js
+++ b/ui/app/components/scale-events-chart.js
@@ -1,0 +1,38 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { tagName } from '@ember-decorators/component';
+import classic from 'ember-classic-decorator';
+
+@classic
+@tagName('')
+export default class ScaleEventsChart extends Component {
+  events = [];
+
+  activeEvent = null;
+
+  @computed('events.[]')
+  get data() {
+    return this.events.filterBy('hasCount').sortBy('time');
+  }
+
+  @computed('events.[]')
+  get annotations() {
+    return this.events.rejectBy('hasCount').map(ev => ({
+      type: ev.error ? 'error' : 'info',
+      time: ev.time,
+      event: ev,
+    }));
+  }
+
+  toggleEvent(ev) {
+    if (this.activeEvent === ev) {
+      this.closeEventDetails();
+    } else {
+      this.set('activeEvent', ev);
+    }
+  }
+
+  closeEventDetails() {
+    this.set('activeEvent', null);
+  }
+}

--- a/ui/app/controllers/jobs/job/task-group.js
+++ b/ui/app/controllers/jobs/job/task-group.js
@@ -60,6 +60,12 @@ export default class TaskGroupController extends Controller.extend(
   })
   sortedScaleEvents;
 
+  @computed('sortedScaleEvents.@each.{hasCount}', function() {
+    const countEventsCount = this.sortedScaleEvents.filterBy('hasCount').length;
+    return countEventsCount > 1 && countEventsCount >= this.sortedScaleEvents.length / 2;
+  })
+  shouldShowScaleEventTimeline;
+
   @computed('model.job.runningDeployment')
   get tooltipText() {
     if (this.can.cannot('scale job')) return "You aren't allowed to scale task groups";

--- a/ui/app/helpers/eq-by.js
+++ b/ui/app/helpers/eq-by.js
@@ -9,7 +9,7 @@ import { helper } from '@ember/component/helper';
  * Returns true when obj1 and obj2 have the same value for property "prop"
  */
 export function eqBy([prop, obj1, obj2]) {
-  if (!obj1 || !obj2) return false;
+  if (!prop || !obj1 || !obj2) return false;
   return get(obj1, prop) === get(obj2, prop);
 }
 

--- a/ui/app/helpers/eq-by.js
+++ b/ui/app/helpers/eq-by.js
@@ -1,0 +1,16 @@
+import { get } from '@ember/object';
+import { helper } from '@ember/component/helper';
+
+/**
+ * Eq By
+ *
+ * Usage: {{eq-by "prop" obj1 obj2}}
+ *
+ * Returns true when obj1 and obj2 have the same value for property "prop"
+ */
+export function eqBy([prop, obj1, obj2]) {
+  if (!obj1 || !obj2) return false;
+  return get(obj1, prop) === get(obj2, prop);
+}
+
+export default helper(eqBy);

--- a/ui/app/models/scale-event.js
+++ b/ui/app/models/scale-event.js
@@ -31,4 +31,10 @@ export default class ScaleEvent extends Fragment {
     return Object.keys(this.meta).length > 0;
   })
   hasMeta;
+
+  // Since scale events don't have proper IDs, this UID is a compromise
+  @computed('time', 'timeNanos', 'message', function() {
+    return `${+this.time}${this.timeNanos}_${this.message}`;
+  })
+  uid;
 }

--- a/ui/app/styles/charts.scss
+++ b/ui/app/styles/charts.scss
@@ -3,6 +3,7 @@
 @import './charts/line-chart';
 @import './charts/tooltip';
 @import './charts/colors';
+@import './charts/chart-annotation.scss';
 
 .inline-chart {
   height: 1.5rem;

--- a/ui/app/styles/charts/chart-annotation.scss
+++ b/ui/app/styles/charts/chart-annotation.scss
@@ -13,11 +13,16 @@
     height: 20px;
     padding: 0;
     border: none;
+    border-radius: 100%;
     background: transparent;
     margin-left: -10px;
     margin-top: -10px;
     cursor: pointer;
     pointer-events: auto;
+
+    &.is-active {
+      box-shadow: inset 0 0 0 2px $blue;
+    }
 
     .icon {
       width: 100%;

--- a/ui/app/styles/charts/chart-annotation.scss
+++ b/ui/app/styles/charts/chart-annotation.scss
@@ -2,6 +2,10 @@
   position: absolute;
   height: 100%;
 
+  &.is-staggered {
+    height: calc(100% + 15px);
+  }
+
   .indicator {
     color: $grey;
     display: block;

--- a/ui/app/styles/charts/chart-annotation.scss
+++ b/ui/app/styles/charts/chart-annotation.scss
@@ -1,0 +1,46 @@
+.chart-annotation {
+  position: absolute;
+  height: 100%;
+
+  .indicator {
+    color: $grey;
+    display: block;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    margin-left: -10px;
+    margin-top: -10px;
+    cursor: pointer;
+    pointer-events: auto;
+
+    .icon {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  @each $name, $pair in $colors {
+    $color: nth($pair, 1);
+
+    &.is-#{$name} .indicator {
+      color: $color;
+
+      &:hover,
+      &.is-hovered {
+        color: darken($color, 2.5%);
+      }
+    }
+  }
+
+  .line {
+    position: absolute;
+    left: 0;
+    top: 8px;
+    width: 1px;
+    height: calc(100% - 8px);
+    background: $grey;
+    z-index: -1;
+  }
+}

--- a/ui/app/styles/charts/line-chart.scss
+++ b/ui/app/styles/charts/line-chart.scss
@@ -4,7 +4,7 @@
   position: relative;
 
   &.with-annotations {
-    margin-top: 1.5em;
+    margin-top: 2em;
   }
 
   & > svg {

--- a/ui/app/styles/charts/line-chart.scss
+++ b/ui/app/styles/charts/line-chart.scss
@@ -1,8 +1,13 @@
 .chart.line-chart {
   display: block;
   height: 100%;
+  position: relative;
 
-  svg {
+  &.with-annotations {
+    margin-top: 1.5em;
+  }
+
+  & > svg {
     display: block;
     height: 100%;
     width: 100%;
@@ -41,6 +46,15 @@
       stroke: lighten($grey-blue, 10%);
       stroke-dasharray: 5 10;
     }
+  }
+
+  .line-chart-annotations {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    top: 0;
+    pointer-events: none;
   }
 
   @each $name, $pair in $colors {

--- a/ui/app/styles/charts/tooltip.scss
+++ b/ui/app/styles/charts/tooltip.scss
@@ -72,6 +72,7 @@
       }
 
       .label {
+        white-space: nowrap;
         font-weight: $weight-bold;
         color: $black;
         margin: 0;
@@ -79,6 +80,10 @@
         &.is-empty {
           color: rgba($grey, 0.6);
         }
+      }
+
+      .value {
+        padding-left: 1em;
       }
     }
 

--- a/ui/app/styles/components.scss
+++ b/ui/app/styles/components.scss
@@ -8,6 +8,7 @@
 @import './components/ember-power-select';
 @import './components/empty-message';
 @import './components/error-container';
+@import './components/event';
 @import './components/exec-button';
 @import './components/exec-window';
 @import './components/fs-explorer';

--- a/ui/app/styles/components/event.scss
+++ b/ui/app/styles/components/event.scss
@@ -1,0 +1,19 @@
+.event {
+  display: flex;
+  margin-top: 1.5em;
+  margin-bottom: 1em;
+
+  .type {
+    margin-right: 0.75em;
+  }
+
+  .timestamp {
+    font-size: $size-7;
+    color: darken($grey-blue, 20%);
+    margin-top: 0.25em;
+  }
+
+  .message {
+    margin-top: 0.5em;
+  }
+}

--- a/ui/app/styles/core/icon.scss
+++ b/ui/app/styles/core/icon.scss
@@ -46,4 +46,9 @@ $icon-dimensions-large: 2rem;
       color: $color;
     }
   }
+
+  &.is-grey {
+    fill: $grey;
+    color: $grey;
+  }
 }

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -31,7 +31,10 @@
   <div data-test-annotation class="chart-annotation {{annotation.iconClass}} {{annotation.staggerClass}}" style={{annotation.style}}>
       <button
         type="button"
-        class="indicator {{if (eq annotation.annotation this.activeAnnotation) "is-active"}}"
+        class="indicator {{if (or
+          (and this.annotationKey (eq-by this.annotationKey annotation.annotation this.activeAnnotation))
+          (and (not this.annotationKey) (eq annotation.annotation this.activeAnnotation))
+        ) "is-active"}}"
         title={{annotation.label}}
         onclick={{action this.annotationClick annotation.annotation}}>
         {{x-icon annotation.icon}}

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -31,7 +31,7 @@
   <div data-test-annotation class="chart-annotation {{annotation.iconClass}} {{annotation.staggerClass}}" style={{annotation.style}}>
       <button
         type="button"
-        class="indicator"
+        class="indicator {{if (eq annotation.annotation this.activeAnnotation) "is-active"}}"
         title={{annotation.label}}
         onclick={{action this.annotationClick annotation.annotation}}>
         {{x-icon annotation.icon}}

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -27,7 +27,7 @@
   <g aria-hidden="true" class="y-axis axis" transform="translate({{this.yAxisOffset}}, 0)"></g>
 </svg>
 <div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}}>
-  {{#each this.processedAnnotations as |annotation|}}
+  {{#each this.processedAnnotations key=this.annotationKey as |annotation|}}
   <div data-test-annotation class="chart-annotation {{annotation.iconClass}} {{annotation.staggerClass}}" style={{annotation.style}}>
       <button
         type="button"

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -28,7 +28,7 @@
 </svg>
 <div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}}>
   {{#each this.processedAnnotations as |annotation|}}
-    <div data-test-annotation class="chart-annotation {{annotation.iconClass}}" style={{annotation.style}}>
+  <div data-test-annotation class="chart-annotation {{annotation.iconClass}} {{annotation.staggerClass}}" style={{annotation.style}}>
       <button
         type="button"
         class="indicator"

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -26,6 +26,20 @@
   <g aria-hidden="true" class="x-axis axis" transform="translate(0, {{this.xAxisOffset}})"></g>
   <g aria-hidden="true" class="y-axis axis" transform="translate({{this.yAxisOffset}}, 0)"></g>
 </svg>
+<div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}}>
+  {{#each this.processedAnnotations as |annotation|}}
+    <div class="chart-annotation {{annotation.iconClass}}" style={{annotation.style}}>
+      <button
+        type="button"
+        class="indicator"
+        title={{annotation.label}}
+        onclick={{action this.annotationClick annotation.annotation}}>
+        {{x-icon annotation.icon}}
+      </button>
+      <div class="line" />
+    </div>
+  {{/each}}
+</div>
 <div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
   <p>
     <span class="label">

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -28,7 +28,7 @@
 </svg>
 <div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}}>
   {{#each this.processedAnnotations as |annotation|}}
-    <div class="chart-annotation {{annotation.iconClass}}" style={{annotation.style}}>
+    <div data-test-annotation class="chart-annotation {{annotation.iconClass}}" style={{annotation.style}}>
       <button
         type="button"
         class="indicator"

--- a/ui/app/templates/components/scale-events-chart.hbs
+++ b/ui/app/templates/components/scale-events-chart.hbs
@@ -8,9 +8,9 @@
   @activeAnnotation={{this.activeEvent}}
   @onAnnotationClick={{action this.toggleEvent}} />
 {{#if this.activeEvent}}
-  <div>
+  <div data-test-event-details>
     <div class="event">
-      <div class="type">
+      <div data-test-type class="type">
         {{#if this.activeEvent.event.error}}
           {{x-icon "cancel-circle-fill" class="is-danger"}}
         {{else}}
@@ -18,8 +18,8 @@
         {{/if}}
       </div>
       <div>
-        <p class="timestamp">{{format-ts this.activeEvent.event.time}}</p>
-        <p class="message">{{this.activeEvent.event.message}}</p>
+        <p data-test-timestamp class="timestamp">{{format-month-ts this.activeEvent.event.time}}</p>
+        <p data-test-message class="message">{{this.activeEvent.event.message}}</p>
       </div>
     </div>
     <JsonViewer @json={{this.activeEvent.event.meta}} @fluidHeight={{true}} />

--- a/ui/app/templates/components/scale-events-chart.hbs
+++ b/ui/app/templates/components/scale-events-chart.hbs
@@ -6,6 +6,7 @@
   @data={{this.data}}
   @annotations={{this.annotations}}
   @activeAnnotation={{this.activeEvent}}
+  @annotationKey="event.uid"
   @onAnnotationClick={{action this.toggleEvent}} />
 {{#if this.activeEvent}}
   <div data-test-event-details>

--- a/ui/app/templates/components/scale-events-chart.hbs
+++ b/ui/app/templates/components/scale-events-chart.hbs
@@ -1,0 +1,1 @@
+<LineChart @data={{this.data}} @annotations={{this.annotations}} @timeseries={{true}} />

--- a/ui/app/templates/components/scale-events-chart.hbs
+++ b/ui/app/templates/components/scale-events-chart.hbs
@@ -1,1 +1,27 @@
-<LineChart @data={{this.data}} @annotations={{this.annotations}} @timeseries={{true}} />
+<LineChart
+  @timeseries={{true}}
+  @curve="stepAfter"
+  @xProp="time"
+  @yProp="count"
+  @data={{this.data}}
+  @annotations={{this.annotations}}
+  @activeAnnotation={{this.activeEvent}}
+  @onAnnotationClick={{action this.toggleEvent}} />
+{{#if this.activeEvent}}
+  <div>
+    <div class="event">
+      <div class="type">
+        {{#if this.activeEvent.event.error}}
+          {{x-icon "cancel-circle-fill" class="is-danger"}}
+        {{else}}
+          {{x-icon "info-circle-fill" class="is-dark"}}
+        {{/if}}
+      </div>
+      <div>
+        <p class="timestamp">{{format-ts this.activeEvent.event.time}}</p>
+        <p class="message">{{this.activeEvent.event.message}}</p>
+      </div>
+    </div>
+    <JsonViewer @json={{this.activeEvent.event.meta}} @fluidHeight={{true}} />
+  </div>
+{{/if}}

--- a/ui/app/templates/components/scale-events-chart.hbs
+++ b/ui/app/templates/components/scale-events-chart.hbs
@@ -14,7 +14,7 @@
         {{#if this.activeEvent.event.error}}
           {{x-icon "cancel-circle-fill" class="is-danger"}}
         {{else}}
-          {{x-icon "info-circle-fill" class="is-dark"}}
+          {{x-icon "info-circle-fill" class="is-grey"}}
         {{/if}}
       </div>
       <div>

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -138,14 +138,25 @@
   <LifecycleChart @tasks={{this.model.tasks}} />
 
   {{#if this.model.scaleState.isVisible}}
-    <div data-test-scaling-events class="boxed-section">
-      <div class="boxed-section-head">
-        Recent Scaling Events
+    {{#if this.shouldShowScaleEventTimeline}}
+      <div data-test-scaling-timeline class="boxed-section">
+        <div class="boxed-section-head is-hollow">
+          Scaling Timeline
+        </div>
+        <div class="boxed-section-body">
+          <ScaleEventsChart @events={{this.sortedScaleEvents}} />
+        </div>
       </div>
-      <div class="boxed-section-body">
-        <ScaleEventsAccordion @events={{this.sortedScaleEvents}} />
+    {{else}}
+      <div data-test-scaling-events class="boxed-section">
+        <div class="boxed-section-head">
+          Recent Scaling Events
+        </div>
+        <div class="boxed-section-body">
+          <ScaleEventsAccordion @events={{this.sortedScaleEvents}} />
+        </div>
       </div>
-    </div>
+    {{/if}}
   {{/if}}
 
   {{#if this.model.volumes.length}}

--- a/ui/mirage/factories/scale-event.js
+++ b/ui/mirage/factories/scale-event.js
@@ -17,4 +17,10 @@ export default Factory.extend({
           'nomad_autoscaler.reason_history': ['scaling down because factor is 0.000000'],
         }
       : {},
+
+  afterCreate(scaleEvent) {
+    if (scaleEvent.error) {
+      scaleEvent.update({ count: null });
+    }
+  },
 });

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -210,3 +210,34 @@ export let Annotations = () => {
     },
   };
 };
+
+export let StepLine = () => {
+  return {
+    template: hbs`
+      <h5 class="title is-5">Line Chart with a Step Line</h5>
+      <div class="block" style="height:250px">
+        {{#if this.data}}
+          <LineChart
+            @xProp="x"
+            @yProp="y"
+            @curve="stepAfter"
+            @data={{this.data}} />
+          <p>{{this.activeAnnotation.info}}</p>
+        {{/if}}
+      </div>
+    `,
+    context: {
+      data: DelayedArray.create([
+        { x: 1, y: 5 },
+        { x: 2, y: 1 },
+        { x: 3, y: 2 },
+        { x: 4, y: 2 },
+        { x: 5, y: 9 },
+        { x: 6, y: 3 },
+        { x: 7, y: 4 },
+        { x: 8, y: 1 },
+        { x: 9, y: 5 },
+      ]),
+    },
+  };
+};

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -159,7 +159,19 @@ export let Annotations = () => {
             @data={{this.data}}
             @annotations={{this.annotations}}
             @onAnnotationClick={{action (mut this.activeAnnotation)}}/>
-          <p>{{this.activeAnnotation.info}}</p>
+        {{/if}}
+      </div>
+      <p style="margin:2em 0; padding: 1em; background:#FFEEAC">{{this.activeAnnotation.info}}</p>
+      <h5 class="title is-5">Line Chart data with staggered annotations</h5>
+      <div class="block" style="height:150px; width:450px">
+        {{#if (and this.data this.annotations)}}
+          <LineChart
+            @timeseries={{true}}
+            @xProp="x"
+            @yProp="y"
+            @data={{this.data}}
+            @annotations={{this.annotations}}
+            @onAnnotationClick={{action (mut this.activeAnnotation)}}/>
         {{/if}}
       </div>
     `,
@@ -191,6 +203,13 @@ export let Annotations = () => {
             .toDate(),
           type: 'info',
           info: 'This is the end of the first period',
+        },
+        {
+          x: moment()
+            .add(96, 'd')
+            .toDate(),
+          type: 'info',
+          info: 'A close annotation for staggering purposes',
         },
         {
           x: moment()

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -145,3 +145,68 @@ export let Gaps = () => {
     },
   };
 };
+
+export let Annotations = () => {
+  return {
+    template: hbs`
+      <h5 class="title is-5">Line Chart data with annotations</h5>
+      <div class="block" style="height:250px">
+        {{#if (and this.data this.annotations)}}
+          <LineChart
+            @timeseries={{true}}
+            @xProp="x"
+            @yProp="y"
+            @data={{this.data}}
+            @annotations={{this.annotations}}
+            @onAnnotationClick={{action (mut this.activeAnnotation)}}/>
+          <p>{{this.activeAnnotation.info}}</p>
+        {{/if}}
+      </div>
+    `,
+    context: {
+      data: DelayedArray.create(
+        new Array(180).fill(null).map((_, idx) => ({
+          y: Math.sin((idx * 4 * Math.PI) / 180) * 100 + 200,
+          x: moment()
+            .add(idx, 'd')
+            .toDate(),
+        }))
+      ),
+      annotations: [
+        {
+          x: moment().toDate(),
+          type: 'info',
+          info: 'Far left',
+        },
+        {
+          x: moment()
+            .add(90 / 4, 'd')
+            .toDate(),
+          type: 'error',
+          info: 'This is the max of the sine curve',
+        },
+        {
+          x: moment()
+            .add(89, 'd')
+            .toDate(),
+          type: 'info',
+          info: 'This is the end of the first period',
+        },
+        {
+          x: moment()
+            .add((90 / 4) * 3, 'd')
+            .toDate(),
+          type: 'error',
+          info: 'This is the min of the sine curve',
+        },
+        {
+          x: moment()
+            .add(179, 'd')
+            .toDate(),
+          type: 'info',
+          info: 'Far right',
+        },
+      ],
+    },
+  };
+};

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -455,7 +455,7 @@ module('Acceptance | task group detail', function(hooks) {
     });
   });
 
-  test('when a task group has at least count scaling events and the count scaling events outnumber the non-count scaling events, a timeline is shown instead of an accordion', async function(assert) {
+  test('when a task group has at least two count scaling events and the count scaling events outnumber the non-count scaling events, a timeline is shown instead of an accordion', async function(assert) {
     const taskGroupScale = job.jobScale.taskGroupScales.models.find(m => m.name === taskGroup.name);
     taskGroupScale.update({
       events: [

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -410,7 +410,6 @@ module('Acceptance | task group detail', function(hooks) {
   test('when a task group has no scaling events, there is no recent scaling events section', async function(assert) {
     const taskGroupScale = job.jobScale.taskGroupScales.models.find(m => m.name === taskGroup.name);
     taskGroupScale.update({ events: [] });
-    taskGroupScale.save();
 
     await TaskGroup.visit({ id: job.id, name: taskGroup.name });
 
@@ -419,16 +418,30 @@ module('Acceptance | task group detail', function(hooks) {
 
   test('the recent scaling events section shows all recent scaling events in reverse chronological order', async function(assert) {
     const taskGroupScale = job.jobScale.taskGroupScales.models.find(m => m.name === taskGroup.name);
+    taskGroupScale.update({
+      events: [
+        server.create('scale-event', { error: true }),
+        server.create('scale-event', { error: true }),
+        server.create('scale-event', { error: true }),
+        server.create('scale-event', { error: true }),
+        server.create('scale-event', { count: 3, error: false }),
+        server.create('scale-event', { count: 1, error: false }),
+      ],
+    });
     const scaleEvents = taskGroupScale.events.models.sortBy('time').reverse();
     await TaskGroup.visit({ id: job.id, name: taskGroup.name });
 
     assert.ok(TaskGroup.hasScaleEvents);
+    assert.notOk(TaskGroup.hasScalingTimeline);
 
     scaleEvents.forEach((scaleEvent, idx) => {
       const ScaleEvent = TaskGroup.scaleEvents[idx];
       assert.equal(ScaleEvent.time, moment(scaleEvent.time / 1000000).format('MMM DD HH:mm:ss ZZ'));
       assert.equal(ScaleEvent.message, scaleEvent.message);
-      assert.equal(ScaleEvent.count, scaleEvent.count);
+
+      if (scaleEvent.count != null) {
+        assert.equal(ScaleEvent.count, scaleEvent.count);
+      }
 
       if (scaleEvent.error) {
         assert.ok(ScaleEvent.error);
@@ -440,5 +453,32 @@ module('Acceptance | task group detail', function(hooks) {
         assert.notOk(ScaleEvent.isToggleable);
       }
     });
+  });
+
+  test('when a task group has at least count scaling events and the count scaling events outnumber the non-count scaling events, a timeline is shown instead of an accordion', async function(assert) {
+    const taskGroupScale = job.jobScale.taskGroupScales.models.find(m => m.name === taskGroup.name);
+    taskGroupScale.update({
+      events: [
+        server.create('scale-event', { error: true }),
+        server.create('scale-event', { error: true }),
+        server.create('scale-event', { count: 7, error: false }),
+        server.create('scale-event', { count: 10, error: false }),
+        server.create('scale-event', { count: 2, error: false }),
+        server.create('scale-event', { count: 3, error: false }),
+        server.create('scale-event', { count: 2, error: false }),
+        server.create('scale-event', { count: 9, error: false }),
+        server.create('scale-event', { count: 1, error: false }),
+      ],
+    });
+    const scaleEvents = taskGroupScale.events.models.sortBy('time').reverse();
+    await TaskGroup.visit({ id: job.id, name: taskGroup.name });
+
+    assert.notOk(TaskGroup.hasScaleEvents);
+    assert.ok(TaskGroup.hasScalingTimeline);
+
+    assert.equal(
+      TaskGroup.scalingAnnotations.length,
+      scaleEvents.filter(ev => ev.count == null).length
+    );
   });
 });

--- a/ui/tests/integration/components/line-chart-test.js
+++ b/ui/tests/integration/components/line-chart-test.js
@@ -1,0 +1,103 @@
+import { findAll, click, render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import moment from 'moment';
+
+const REF_DATE = new Date();
+
+module('Integration | Component | line chart', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('when a chart has annotations, they are rendered in order', async function(assert) {
+    const annotations = [{ x: 2, type: 'info' }, { x: 1, type: 'error' }, { x: 3, type: 'info' }];
+    this.setProperties({
+      annotations,
+      data: [{ x: 1, y: 1 }, { x: 10, y: 10 }],
+    });
+
+    await render(hbs`
+      <LineChart
+        @xProp="x"
+        @yProp="y"
+        @data={{this.data}}
+        @annotations={{this.annotations}} />
+    `);
+
+    const sortedAnnotations = annotations.sortBy('x');
+    findAll('[data-test-annotation]').forEach((annotation, idx) => {
+      const datum = sortedAnnotations[idx];
+      assert.equal(
+        annotation.querySelector('button').getAttribute('title'),
+        `${datum.type} event at ${datum.x}`
+      );
+    });
+  });
+
+  test('when a chart has annotations and is timeseries, annotations are sorted reverse-chronologically', async function(assert) {
+    const annotations = [
+      {
+        x: moment(REF_DATE)
+          .add(2, 'd')
+          .toDate(),
+        type: 'info',
+      },
+      {
+        x: moment(REF_DATE)
+          .add(1, 'd')
+          .toDate(),
+        type: 'error',
+      },
+      {
+        x: moment(REF_DATE)
+          .add(3, 'd')
+          .toDate(),
+        type: 'info',
+      },
+    ];
+    this.setProperties({
+      annotations,
+      data: [{ x: 1, y: 1 }, { x: 10, y: 10 }],
+    });
+
+    await render(hbs`
+      <LineChart
+        @xProp="x"
+        @yProp="y"
+        @timeseries={{true}}
+        @data={{this.data}}
+        @annotations={{this.annotations}} />
+    `);
+
+    const sortedAnnotations = annotations.sortBy('x').reverse();
+    findAll('[data-test-annotation]').forEach((annotation, idx) => {
+      const datum = sortedAnnotations[idx];
+      assert.equal(
+        annotation.querySelector('button').getAttribute('title'),
+        `${datum.type} event at ${moment(datum.x).format('MMM DD, HH:mm')}`
+      );
+    });
+  });
+
+  test('clicking annotations calls the onAnnotationClick action with the annotation as an argument', async function(assert) {
+    const annotations = [{ x: 2, type: 'info', meta: { data: 'here' } }];
+    this.setProperties({
+      annotations,
+      data: [{ x: 1, y: 1 }, { x: 10, y: 10 }],
+      click: sinon.spy(),
+    });
+
+    await render(hbs`
+      <LineChart
+        @xProp="x"
+        @yProp="y"
+        @data={{this.data}}
+        @annotations={{this.annotations}}
+        @onAnnotationClick={{this.click}} />
+    `);
+
+    await click('[data-test-annotation] button');
+    assert.ok(this.click.calledWith(annotations[0]));
+  });
+});

--- a/ui/tests/integration/components/line-chart-test.js
+++ b/ui/tests/integration/components/line-chart-test.js
@@ -100,4 +100,28 @@ module('Integration | Component | line chart', function(hooks) {
     await click('[data-test-annotation] button');
     assert.ok(this.click.calledWith(annotations[0]));
   });
+
+  test('annotations will have staggered heights when too close to be positioned side-by-side', async function(assert) {
+    const annotations = [{ x: 2, type: 'info' }, { x: 2.4, type: 'error' }, { x: 9, type: 'info' }];
+    this.setProperties({
+      annotations,
+      data: [{ x: 1, y: 1 }, { x: 10, y: 10 }],
+      click: sinon.spy(),
+    });
+
+    await render(hbs`
+      <div style="width:200px;">
+        <LineChart
+          @xProp="x"
+          @yProp="y"
+          @data={{this.data}}
+          @annotations={{this.annotations}} />
+      </div>
+    `);
+
+    const annotationEls = findAll('[data-test-annotation]');
+    assert.notOk(annotationEls[0].classList.contains('is-staggered'));
+    assert.ok(annotationEls[1].classList.contains('is-staggered'));
+    assert.notOk(annotationEls[2].classList.contains('is-staggered'));
+  });
 });

--- a/ui/tests/integration/scale-events-chart-test.js
+++ b/ui/tests/integration/scale-events-chart-test.js
@@ -1,0 +1,99 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, find, findAll, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
+import setupCodeMirror from 'nomad-ui/tests/helpers/codemirror';
+
+module('Integration | Component | scale-events-chart', function(hooks) {
+  setupRenderingTest(hooks);
+  setupCodeMirror(hooks);
+
+  const events = [
+    {
+      time: new Date('2020-08-05T04:06:00'),
+      count: 2,
+      hasCount: true,
+      meta: {},
+      message: '',
+      error: false,
+    },
+    {
+      time: new Date('2020-08-06T04:06:00'),
+      count: 3,
+      hasCount: true,
+      meta: {},
+      message: '',
+      error: false,
+    },
+    {
+      time: new Date('2020-08-07T04:06:00'),
+      count: 4,
+      hasCount: true,
+      meta: {},
+      message: '',
+      error: false,
+    },
+    {
+      time: new Date('2020-08-06T04:06:00'),
+      hasCount: false,
+      meta: { prop: { deep: true }, five: 5 },
+      message: 'Something went wrong',
+      error: true,
+    },
+    {
+      time: new Date('2020-08-05T04:06:00'),
+      hasCount: false,
+      meta: {},
+      message: 'Something insightful',
+      error: false,
+    },
+  ];
+
+  test('each event is rendered as an annotation', async function(assert) {
+    this.set('events', events);
+    await render(hbs`<ScaleEventsChart @events={{this.events}} />`);
+
+    assert.equal(
+      findAll('[data-test-annotation]').length,
+      events.filter(ev => ev.count == null).length
+    );
+  });
+
+  test('clicking an annotation presents details for the event', async function(assert) {
+    const annotation = events
+      .rejectBy('hasCount')
+      .sortBy('time')
+      .reverse()[0];
+
+    this.set('events', events);
+    await render(hbs`<ScaleEventsChart @events={{this.events}} />`);
+
+    assert.notOk(find('[data-test-event-details]'));
+    await click('[data-test-annotation] button');
+
+    assert.ok(find('[data-test-event-details]'));
+    assert.equal(
+      find('[data-test-timestamp]').textContent,
+      moment(annotation.time).format('MMM DD HH:mm:ss ZZ')
+    );
+    assert.equal(find('[data-test-message]').textContent, annotation.message);
+    assert.equal(
+      getCodeMirrorInstance('[data-test-json-viewer]').getValue(),
+      JSON.stringify(annotation.meta, null, 2)
+    );
+  });
+
+  test('clicking an active annotation closes event details', async function(assert) {
+    this.set('events', events);
+
+    await render(hbs`<ScaleEventsChart @events={{this.events}} />`);
+    assert.notOk(find('[data-test-event-details]'));
+
+    await click('[data-test-annotation] button');
+    assert.ok(find('[data-test-event-details]'));
+
+    await click('[data-test-annotation] button');
+    assert.notOk(find('[data-test-event-details]'));
+  });
+});

--- a/ui/tests/pages/jobs/job/task-group.js
+++ b/ui/tests/pages/jobs/job/task-group.js
@@ -69,6 +69,11 @@ export default create({
     meta: text(),
   }),
 
+  hasScalingTimeline: isPresent('[data-test-scaling-timeline]'),
+  scalingAnnotations: collection('[data-test-scaling-timeline] [data-test-annotation]', {
+    open: clickable('button'),
+  }),
+
   error: error(),
 
   emptyState: {

--- a/ui/tests/unit/components/scale-events-chart-test.js
+++ b/ui/tests/unit/components/scale-events-chart-test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Component | scale-events-chart', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.refTime = new Date();
+    this.clock = sinon.useFakeTimers(this.refTime);
+  });
+
+  hooks.afterEach(function() {
+    this.clock.restore();
+    delete this.refTime;
+  });
+
+  test('the current date is appended as a datum for the line chart to render', function(assert) {
+    const chart = this.owner.factoryFor('component:scale-events-chart').create();
+    const events = [
+      { time: new Date('2020-08-02T04:06:00'), count: 2, hasCount: true },
+      { time: new Date('2020-08-01T04:06:00'), count: 2, hasCount: true },
+    ];
+
+    chart.set('events', events);
+
+    assert.equal(chart.data.length, events.length + 1);
+    assert.deepEqual(chart.data.slice(0, events.length), events.sortBy('time'));
+
+    const appendedDatum = chart.data[chart.data.length - 1];
+    assert.equal(appendedDatum.count, events.sortBy('time').lastObject.count);
+    assert.equal(+appendedDatum.time, +this.refTime);
+  });
+
+  test('if the earliest annotation is outside the domain of the events, the earliest annotation time is added as a datum for the line chart to render', function(assert) {
+    const chart = this.owner.factoryFor('component:scale-events-chart').create();
+    const annotationOutside = [
+      { time: new Date('2020-08-01T04:06:00'), hasCount: false, error: true },
+      { time: new Date('2020-08-02T04:06:00'), count: 2, hasCount: true },
+      { time: new Date('2020-08-03T04:06:00'), count: 2, hasCount: true },
+    ];
+    const annotationInside = [
+      { time: new Date('2020-08-02T04:06:00'), count: 2, hasCount: true },
+      { time: new Date('2020-08-02T12:06:00'), hasCount: false, error: true },
+      { time: new Date('2020-08-03T04:06:00'), count: 2, hasCount: true },
+    ];
+
+    chart.set('events', annotationOutside);
+
+    assert.equal(chart.data.length, annotationOutside.length + 1);
+    assert.deepEqual(
+      chart.data.slice(1, annotationOutside.length),
+      annotationOutside.filterBy('hasCount')
+    );
+
+    const appendedDatum = chart.data[0];
+    assert.equal(appendedDatum.count, annotationOutside[1].count);
+    assert.equal(+appendedDatum.time, +annotationOutside[0].time);
+
+    chart.set('events', annotationInside);
+
+    assert.equal(chart.data.length, annotationOutside.length);
+    assert.deepEqual(
+      chart.data.slice(0, annotationOutside.length - 1),
+      annotationOutside.filterBy('hasCount')
+    );
+  });
+});


### PR DESCRIPTION
The continuation of #8551. Now the task group detail page will conditionally show the recent scaling events as an accordion of activity or as a timeline visualization with interactive annotations.

The timeline will be shown if there are more count events than non-count events and if there are at least two count events. This should be most of the time for most jobs.

![Scaling events timeline with an error annotation expanded](https://user-images.githubusercontent.com/174740/89452777-0bc48380-d713-11ea-9539-47a9754b893a.png)

This also includes a couple new Stories for the line chart component, including one that demonstrates annotation staggering:

![Line chart with staggered annotations](https://user-images.githubusercontent.com/174740/89452926-4af2d480-d713-11ea-9a55-3f30c57f68ed.png)

