### PR TITLE
UI: Add guard against null scale events collection

### DIFF
--- a/ui/app/serializers/task-group-scale.js
+++ b/ui/app/serializers/task-group-scale.js
@@ -1,0 +1,11 @@
+import ApplicationSerializer from './application';
+
+export default class TaskGroupScaleSerializer extends ApplicationSerializer {
+  normalize(typeHash, hash) {
+    if (!hash.Events) {
+      hash.Events = [];
+    }
+
+    return super.normalize(typeHash, hash);
+  }
+}


### PR DESCRIPTION
This removes some errors in the console if there are no
autoscaling events.

Example error:

![image](https://user-images.githubusercontent.com/43280/89460998-d595fc80-d730-11ea-868d-3fdc0db3d994.png)

The relevant line from the stacktrace:

![image](https://user-images.githubusercontent.com/43280/89461020-ddee3780-d730-11ea-8b8b-fbe1e6fef601.png)

Another seemingly-related error that I didn’t see after making this change:

![image](https://user-images.githubusercontent.com/43280/89461198-2e659500-d731-11ea-8e71-eba8cb5ebba3.png)

Maybe this would be preferable to fix in a serialiser? 🤔 I’m happy to replace this commit if you think so, @DingoEatingFuzz.