### PR TITLE
Removed version tag

### DIFF
--- a/website/pages/docs/drivers/external/containerd.mdx
+++ b/website/pages/docs/drivers/external/containerd.mdx
@@ -27,11 +27,11 @@ See the project's [`homepage`](https://github.com/Roblox/nomad-driver-containerd
 
 ## Client Requirements
 
-The containerd task driver is not built into Nomad. It must be [`downloaded`](https://github.com/Roblox/nomad-driver-containerd/releases/tag/v0.1)
+The containerd task driver is not built into Nomad. It must be [`downloaded`](https://github.com/Roblox/nomad-driver-containerd/releases/)
 onto the client host in the configured plugin directory.
 
 - Linux (Ubuntu >=16.04) with [`containerd`](https://containerd.io/downloads/) (>=1.3) installed.
-- [`containerd-driver`](https://github.com/Roblox/nomad-driver-containerd/releases/tag/v0.1) binary in Nomad's [plugin_dir][plugin_dir].
+- [`containerd-driver`](https://github.com/Roblox/nomad-driver-containerd/releases/) binary in Nomad's [plugin_dir][plugin_dir].
 
 ## Capabilities
 


### PR DESCRIPTION
In order to prevent staleness, changed driver links to point to releases page rather than a specific version.

Co-authored-by: Michael Schurter <mschurter@hashicorp.com>