### PR TITLE
e2e: CSI EBS test should expect 2 controllers

### DIFF
--- a/e2e/csi/csi.go
+++ b/e2e/csi/csi.go
@@ -70,7 +70,7 @@ func (tc *CSIVolumesTest) TestEBSVolumeClaim(f *framework.F) {
 		if err != nil {
 			return false
 		}
-		if plugin.ControllersHealthy != 1 || plugin.NodesHealthy < 2 {
+		if plugin.ControllersHealthy < 2 || plugin.NodesHealthy < 2 {
 			return false
 		}
 		return true


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/8573 added a 2nd controller to our EBS test, but I forgot to change the test expectation to match.

---

With this fix:

```
$ go test -v . -suite=CSI
=== RUN   TestE2E
=== RUN   TestE2E/Affinity
    TestE2E/Affinity: framework.go:181: skipping suite 'Affinity': only running suite "CSI"
=== RUN   TestE2E/clientstate
    TestE2E/clientstate: framework.go:181: skipping suite 'clientstate': only running suite "CSI"
=== RUN   TestE2E/Connect
    TestE2E/Connect: framework.go:181: skipping suite 'Connect': only running suite "CSI"
=== RUN   TestE2E/ConnectACLs
    TestE2E/ConnectACLs: framework.go:181: skipping suite 'ConnectACLs': only running suite "CSI"
=== RUN   TestE2E/Consul
    TestE2E/Consul: framework.go:181: skipping suite 'Consul': only running suite "CSI"
=== RUN   TestE2E/Consul_Template
    TestE2E/Consul_Template: framework.go:181: skipping suite 'Consul Template': only running suite "CSI"
=== RUN   TestE2E/CSI
=== RUN   TestE2E/CSI/*csi.CSIVolumesTest
=== RUN   TestE2E/CSI/*csi.CSIVolumesTest/TestEBSVolumeClaim
=== RUN   TestE2E/CSI/*csi.CSIVolumesTest/TestEFSVolumeClaim
=== RUN   TestE2E/Deployment
    TestE2E/Deployment: framework.go:181: skipping suite 'Deployment': only running suite "CSI"
=== RUN   TestE2E/simple
    TestE2E/simple: framework.go:181: skipping suite 'simple': only running suite "CSI"
=== RUN   TestE2E/Host_Volumes
    TestE2E/Host_Volumes: framework.go:181: skipping suite 'Host Volumes': only running suite "CSI"
=== RUN   TestE2E/Metrics
    TestE2E/Metrics: framework.go:181: skipping suite 'Metrics': only running suite "CSI"
=== RUN   TestE2E/Nomad_exec
    TestE2E/Nomad_exec: framework.go:181: skipping suite 'Nomad exec': only running suite "CSI"
=== RUN   TestE2E/Podman
    TestE2E/Podman: framework.go:181: skipping suite 'Podman': only running suite "CSI"
=== RUN   TestE2E/Spread
    TestE2E/Spread: framework.go:181: skipping suite 'Spread': only running suite "CSI"
=== RUN   TestE2E/SystemScheduler
    TestE2E/SystemScheduler: framework.go:181: skipping suite 'SystemScheduler': only running suite "CSI"
=== RUN   TestE2E/TaskEvents
    TestE2E/TaskEvents: framework.go:181: skipping suite 'TaskEvents': only running suite "CSI"
--- PASS: TestE2E (132.13s)
    --- SKIP: TestE2E/Affinity (0.00s)
    --- SKIP: TestE2E/clientstate (0.00s)
    --- SKIP: TestE2E/Connect (0.00s)
    --- SKIP: TestE2E/ConnectACLs (0.00s)
    --- SKIP: TestE2E/Consul (0.00s)
    --- SKIP: TestE2E/Consul_Template (0.00s)
    --- PASS: TestE2E/CSI (132.13s)
        --- PASS: TestE2E/CSI/*csi.CSIVolumesTest (132.05s)
            --- PASS: TestE2E/CSI/*csi.CSIVolumesTest/TestEBSVolumeClaim (78.86s)
            --- PASS: TestE2E/CSI/*csi.CSIVolumesTest/TestEFSVolumeClaim (53.01s)
    --- SKIP: TestE2E/Deployment (0.00s)
    --- SKIP: TestE2E/simple (0.00s)
    --- SKIP: TestE2E/Host_Volumes (0.00s)
    --- SKIP: TestE2E/Metrics (0.00s)
    --- SKIP: TestE2E/Nomad_exec (0.00s)
    --- SKIP: TestE2E/Podman (0.00s)
    --- SKIP: TestE2E/Spread (0.00s)
    --- SKIP: TestE2E/SystemScheduler (0.00s)
    --- SKIP: TestE2E/TaskEvents (0.00s)
PASS
ok      github.com/hashicorp/nomad/e2e  132.252s
```