### PR TITLE
csi: missing plugins during node delete are not an error

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1158,7 +1158,9 @@ func deleteNodeCSIPlugins(txn *memdb.Txn, node *structs.Node, index uint64) erro
 			return fmt.Errorf("csi_plugins lookup error %s: %v", id, err)
 		}
 		if raw == nil {
-			return fmt.Errorf("csi_plugins missing plugin %s", id)
+			// plugin may have been deregistered but we didn't
+			// update the fingerprint yet
+			continue
 		}
 
 		plug := raw.(*structs.CSIPlugin).Copy()


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8121

When deregistering a client, CSI plugins running on that client may not get a
chance to fingerprint before being stopped. Account for the case where a
plugin allocation is the last instance of the plugin and has been deleted from
the state store to avoid errors during node deregistration.