### PR TITLE
CSI RPC Token

### DIFF
--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -96,7 +96,10 @@ func (c *csiHook) Postrun() error {
 				Mode:         structs.CSIVolumeClaimRelease,
 			},
 			WriteRequest: structs.WriteRequest{
-				Region: c.alloc.Job.Region, Namespace: c.alloc.Job.Namespace},
+				Region:    c.alloc.Job.Region,
+				Namespace: c.alloc.Job.Namespace,
+				AuthToken: c.ar.clientConfig.Node.SecretID,
+			},
 		}
 		err := c.rpcClient.RPC("CSIVolume.Unpublish",
 			req, &structs.CSIVolumeUnpublishResponse{})
@@ -158,6 +161,7 @@ func (c *csiHook) claimVolumesFromAlloc() (map[string]*volumeAndRequest, error) 
 			Claim:        claimType,
 		}
 		req.Region = c.alloc.Job.Region
+		req.AuthToken = c.ar.clientConfig.Node.SecretID
 
 		var resp structs.CSIVolumeClaimResponse
 		if err := c.rpcClient.RPC("CSIVolume.Claim", req, &resp); err != nil {

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -159,9 +159,12 @@ func (c *csiHook) claimVolumesFromAlloc() (map[string]*volumeAndRequest, error) 
 			AllocationID: c.alloc.ID,
 			NodeID:       c.alloc.NodeID,
 			Claim:        claimType,
+			WriteRequest: structs.WriteRequest{
+				Region:    c.alloc.Job.Region,
+				Namespace: c.alloc.Job.Namespace,
+				AuthToken: c.ar.clientConfig.Node.SecretID,
+			},
 		}
-		req.Region = c.alloc.Job.Region
-		req.AuthToken = c.ar.clientConfig.Node.SecretID
 
 		var resp structs.CSIVolumeClaimResponse
 		if err := c.rpcClient.RPC("CSIVolume.Claim", req, &resp); err != nil {

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -404,6 +404,13 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
 	// Because the node is not registered
 	require.EqualError(t, err, "controller publish: attach volume: No path to node")
+
+	// The node SecretID is authorized for all policies
+	claimReq.AuthToken = node.SecretID
+	claimReq.Namespace = ""
+	claimResp = &structs.CSIVolumeClaimResponse{}
+	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
+	require.EqualError(t, err, "controller publish: attach volume: No path to node")
 }
 
 func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {


### PR DESCRIPTION
CSI Nodes call RPCs through the server that forward to other client nodes. They should do so with an authorization token that's permitted to execute those RPCs. This PR sends the `Node.SecretID`, which when provided to the endpoints returns the nil `aclObj`. All namespace and policy ACL check funcs treat nil as the flag that ACLs are disabled. The ACL checker returns an error if ACLs are active and an appropriate token isn't provided.

The other alternative is to thread the user token through from job submission. I believe that the `Node.SecretID` is correct since the job could not have been allocated without user permissions at the time of submission, and we don't want an error `Unpublishing` a volume belonging to a job that was started with an expired or revoked token.

Fixes #8373 