### PR TITLE
e2e: spread CSI controller plugins across multiple DCs

### DIFF
--- a/e2e/csi/input/plugin-aws-ebs-controller.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-controller.nomad
@@ -3,7 +3,7 @@
 # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/deploy/kubernetes
 
 job "plugin-aws-ebs-controller" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   constraint {
     attribute = "${attr.kernel.name}"

--- a/e2e/csi/input/plugin-aws-ebs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-nodes.nomad
@@ -3,7 +3,7 @@
 # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/deploy/kubernetes
 
 job "plugin-aws-ebs-nodes" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   constraint {
     attribute = "${attr.kernel.name}"
@@ -19,7 +19,7 @@ job "plugin-aws-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v0.5.0"
+        image = "amazon/aws-ebs-csi-driver:v0.6.0"
 
         args = [
           "node",

--- a/e2e/csi/input/use-ebs-volume.nomad
+++ b/e2e/csi/input/use-ebs-volume.nomad
@@ -1,6 +1,6 @@
 # a job that mounts an EBS volume and writes its job ID as a file
 job "use-ebs-volume" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   constraint {
     attribute = "${attr.kernel.name}"


### PR DESCRIPTION
Controller plugins that land on the same node will collide over their CSI
`mount_dir` (ref https://github.com/hashicorp/nomad/issues/8628), so give them enough room in our tests that they don't land on the
same host.

Also, version bump the EBS node plugins to match the controllers (ref https://github.com/hashicorp/nomad/pull/8618)