### PR TITLE
RPC errors must be wrapped in order to wrap internal errors

### DIFF
--- a/helper/pool/pool.go
+++ b/helper/pool/pool.go
@@ -446,7 +446,7 @@ func (p *ConnPool) RPC(region string, addr net.Addr, version int, method string,
 	// Get a usable client
 	conn, sc, err := p.getRPCClient(region, addr, version)
 	if err != nil {
-		return fmt.Errorf("rpc error: %v", err)
+		return fmt.Errorf("rpc error: %w", err)
 	}
 
 	// Make the RPC call
@@ -470,7 +470,7 @@ func (p *ConnPool) RPC(region string, addr net.Addr, version int, method string,
 		}
 
 		// TODO wrap with RPCCoded error instead
-		return fmt.Errorf("rpc error: %v", err)
+		return fmt.Errorf("rpc error: %w", err)
 	}
 
 	// Done with the connection

--- a/nomad/client_csi_endpoint.go
+++ b/nomad/client_csi_endpoint.go
@@ -40,7 +40,7 @@ func (a *ClientCSI) ControllerAttachVolume(args *cstructs.ClientCSIControllerAtt
 		if err == nil {
 			return nil
 		}
-		if a.isRetryable(err, clientID, args.PluginID) {
+		if a.isRetryable(err) {
 			a.logger.Debug("failed to reach controller on client %q: %v", clientID, err)
 			continue
 		}
@@ -69,7 +69,7 @@ func (a *ClientCSI) ControllerValidateVolume(args *cstructs.ClientCSIControllerV
 		if err == nil {
 			return nil
 		}
-		if a.isRetryable(err, clientID, args.PluginID) {
+		if a.isRetryable(err) {
 			a.logger.Debug("failed to reach controller on client %q: %v", clientID, err)
 			continue
 		}
@@ -98,7 +98,7 @@ func (a *ClientCSI) ControllerDetachVolume(args *cstructs.ClientCSIControllerDet
 		if err == nil {
 			return nil
 		}
-		if a.isRetryable(err, clientID, args.PluginID) {
+		if a.isRetryable(err) {
 			a.logger.Debug("failed to reach controller on client %q: %v", clientID, err)
 			continue
 		}
@@ -110,7 +110,7 @@ func (a *ClientCSI) ControllerDetachVolume(args *cstructs.ClientCSIControllerDet
 // we can retry the same RPC on a different controller in the cases where the
 // client has stopped and been GC'd, or where the controller has stopped but
 // we don't have the fingerprint update yet
-func (a *ClientCSI) isRetryable(err error, clientID, pluginID string) bool {
+func (a *ClientCSI) isRetryable(err error) bool {
 	return errors.Is(err, structs.ErrUnknownNode) ||
 		errors.Is(err, structs.ErrCSIClientRPCRetryable)
 }


### PR DESCRIPTION
The CSI client RPC uses error wrapping to detect the type of error bubbling up
from plugins, but if the errors we get aren't wrapped at each layer, we can't
unwrap the inner error.

Also eliminates some unused args.

---

https://play.golang.org/p/NvJbRD-Xhr0 illustrates the problem this solves.