### PR TITLE
commit code-generated msgpack parser on releases

### DIFF
--- a/scripts/release/Makefile.linux
+++ b/scripts/release/Makefile.linux
@@ -22,6 +22,7 @@ build_releases:
 
 	@echo "======>> committing generated files"
 	git add -A .
+	find . -name '*.generated.go' -not -path './vendor/*' -exec git add -f '{}' \;
 # skip comitting files if there are no generated files
 # if prerelease process was a no-op
 	if ! git diff-index --quiet HEAD --; \


### PR DESCRIPTION
Noticed that the structs code-generated parsers is no longer committed when we cut a release, starting with v0.12.  We've been committing generated code to ease reproduction and rebuilding the tag.

Note for example that `structs.generated.go` was present in the [0.11.3 commit](https://github.com/hashicorp/nomad/commit/8918fc804a0c6758b6e3e9960e4eb2e605e38552)
but not in the [0.12.1 one](https://github.com/hashicorp/nomad/commit/14a6893a250fc5f652eee4c7b52d8f95c3185aef).

We leave the files ignored, so developers don't accidentally commit them in local development.
