### PR TITLE
directory for CSI examples

### DIFF
--- a/demo/csi/README.md
+++ b/demo/csi/README.md
@@ -1,0 +1,14 @@
+# Container Storage Interface (CSI) examples
+
+This directory contains examples of registering CSI plugin jobs and volumes
+for those plugins.
+
+### Contributing
+
+If you'd like to contribute an example, open a PR with a folder for the plugin
+in this directory. This folder should include:
+
+* A `README.md` with any added instructions a user might need to use the
+  plugin. Please include a link to the CSI plugin's source repository.
+* A Nomad job file for the plugin.
+* A [volume specification](https://www.nomadproject.io/docs/commands/volume/register#volume-specification) file.


### PR DESCRIPTION
This is a bit of a placeholder and might get moved to something like an `examples/` directory that combines the existing `demo/` and `integrations/` directories later, but there's been [some interest](https://github.com/hashicorp/nomad/issues/8550#issuecomment-672444997) in community-provided jobspecs for plugins so it's better to give folks a place to start and we can move things around later if we want.