### PR TITLE
nomad/state/state_store: handle type conversion failure explicitly

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1099,7 +1099,11 @@ func upsertNodeCSIPlugins(txn *memdb.Txn, node *structs.Node, index uint64) erro
 		if raw == nil {
 			break
 		}
-		plug := raw.(*structs.CSIPlugin).Copy()
+		plug, ok := raw.(*structs.CSIPlugin)
+		if !ok {
+			continue
+		}
+		plug = plug.Copy()
 
 		var hadDelete bool
 		if _, ok := inUseController[plug.ID]; !ok {


### PR DESCRIPTION
In the case we get an object from the store that can't be type converted back to a `CSIPlugin`, calling `Copy` will panic.