### PR TITLE
csi: fix panic from assignment to nil map in plugin API

### DIFF
--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -407,6 +407,7 @@ func structsAllocListStubToApi(alloc *structs.AllocListStub) *api.AllocationList
 		DesiredDescription:    alloc.DesiredDescription,
 		ClientStatus:          alloc.ClientStatus,
 		ClientDescription:     alloc.ClientDescription,
+		TaskStates:            make(map[string]*api.TaskState, len(alloc.TaskStates)),
 		FollowupEvalID:        alloc.FollowupEvalID,
 		PreemptedAllocations:  alloc.PreemptedAllocations,
 		PreemptedByAllocation: alloc.PreemptedByAllocation,
@@ -445,7 +446,7 @@ func structsRescheduleTrackerToApi(rt *structs.RescheduleTracker) *api.Reschedul
 	if rt == nil {
 		return nil
 	}
-	out := &api.RescheduleTracker{}
+	out := &api.RescheduleTracker{Events: []*api.RescheduleEvent{}}
 
 	for _, e := range rt.Events {
 		out.Events = append(out.Events, &api.RescheduleEvent{
@@ -470,6 +471,7 @@ func structsTaskStateToApi(ts *structs.TaskState) *api.TaskState {
 		LastRestart: ts.LastRestart,
 		StartedAt:   ts.StartedAt,
 		FinishedAt:  ts.FinishedAt,
+		Events:      []*api.TaskEvent{},
 	}
 
 	for _, te := range ts.Events {


### PR DESCRIPTION
Fixes #8665

E2E suite results:

```
    --- PASS: TestE2E/CSI (114.92s)
        --- PASS: TestE2E/CSI/*csi.CSIVolumesTest (114.82s)
            --- PASS: TestE2E/CSI/*csi.CSIVolumesTest/TestEBSVolumeClaim (69.16s)
            --- PASS: TestE2E/CSI/*csi.CSIVolumesTest/TestEFSVolumeClaim (45.48s)
```

(The rest of the suite had a couple failures around known flakes, see #7724 and #7737. But I monitored the cluster the whole time and there are no panics.)
