### PR TITLE
skip podman e2e

### DIFF
--- a/e2e/podman/input/redis.nomad
+++ b/e2e/podman/input/redis.nomad
@@ -1,4 +1,4 @@
-job "redis" {
+job "podman-redis" {
   datacenters = ["dc1"]
   type        = "service"
 

--- a/e2e/podman/podman.go
+++ b/e2e/podman/podman.go
@@ -29,6 +29,8 @@ func (tc *PodmanTest) BeforeAll(f *framework.F) {
 
 func (tc *PodmanTest) TestRedisDeployment(f *framework.F) {
 	t := f.T()
+	// https://github.com/hashicorp/nomad-driver-podman/issues/57
+	t.Skip("skipping podman test until driver api issue is resolved")
 	nomadClient := tc.Nomad()
 	uuid := uuid.Generate()
 	jobID := "deployment" + uuid[0:8]


### PR DESCRIPTION
Pr that should make this runnable again is in the works https://github.com/hashicorp/nomad-driver-podman/pull/58 but in the mean time lets skip this test