### PR TITLE
migrate AMI builds to new account

### DIFF
--- a/e2e/terraform/packer/linux/setup.sh
+++ b/e2e/terraform/packer/linux/setup.sh
@@ -37,7 +37,7 @@ sudo apt-get install -y python-setuptools python-pip
 sudo pip install numpy
 
 # Install sockaddr
-aws s3 cp "s3://nomad-team-test-binary/tools/sockaddr_linux_amd64" /tmp/sockaddr
+aws s3 cp "s3://nomad-team-dev-test-binaries/tools/sockaddr_linux_amd64" /tmp/sockaddr
 sudo mv /tmp/sockaddr /usr/local/bin
 sudo chmod +x /usr/local/bin/sockaddr
 sudo chown root:root /usr/local/bin/sockaddr

--- a/e2e/terraform/packer/packer.json
+++ b/e2e/terraform/packer/packer.json
@@ -6,7 +6,7 @@
       "source_ami": "ami-7ad76705",
       "instance_type": "t2.medium",
       "ssh_username": "ubuntu",
-      "iam_instance_profile": "packer-builder",
+      "iam_instance_profile": "packer_build",
       "ami_name": "nomad-e2e-{{timestamp}}",
       "tags": {
         "OS": "Ubuntu"


### PR DESCRIPTION
Changes a few names to point to resources in the new AWS account.