### PR TITLE
docs: update allocation metrics

### DIFF
--- a/website/pages/docs/telemetry/metrics.mdx
+++ b/website/pages/docs/telemetry/metrics.mdx
@@ -832,118 +832,174 @@ detailed above) but any new metrics will only be available in the new format.
       <th>Description</th>
       <th>Unit</th>
       <th>Type</th>
+      <th>Labels</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.memory.rss
+          nomad.client.allocs.memory.allocated
+        </code>
+      </td>
+      <td>Amount of memory allocated by the task</td>
+      <td>Bytes</td>
+      <td>Gauge</td>
+      <td>alloc_id, host, job, namespace, task, task_group</td>
+    </tr>
+    <tr>
+      <td>
+        <code>
+          nomad.client.allocs.memory.rss
         </code>
       </td>
       <td>Amount of RSS memory consumed by the task</td>
       <td>Bytes</td>
       <td>Gauge</td>
+      <td>alloc_id, host, job, namespace, task, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.memory.cache
+          nomad.client.allocs.memory.cache
         </code>
       </td>
       <td>Amount of memory cached by the task</td>
       <td>Bytes</td>
       <td>Gauge</td>
+      <td>alloc_id, host, job, namespace, task, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.memory.swap
+          nomad.client.allocs.memory.swap
         </code>
       </td>
       <td>Amount of memory swapped by the task</td>
       <td>Bytes</td>
       <td>Gauge</td>
+      <td>alloc_id, host, job, namespace, task, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.memory.max_usage
+          nomad.client.allocs.memory.usage
+        </code>
+      </td>
+      <td>Total amount of memory used by the task</td>
+      <td>Bytes</td>
+      <td>Gauge</td>
+      <td>alloc_id, host, job, namespace, task, task_group</td>
+    </tr>
+    <tr>
+      <td>
+        <code>
+          nomad.client.allocs.memory.max_usage
         </code>
       </td>
       <td>Maximum amount of memory ever used by the task</td>
       <td>Bytes</td>
       <td>Gauge</td>
+      <td>alloc_id, host, job, namespace, task, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.memory.kernel_usage
+          nomad.client.allocs.memory.kernel_usage
         </code>
       </td>
       <td>Amount of memory used by the kernel for this task</td>
       <td>Bytes</td>
       <td>Gauge</td>
+      <td>alloc_id, host, job, namespace, task, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.memory.kernel_max_usage
+          nomad.client.allocs.memory.kernel_max_usage
         </code>
       </td>
       <td>Maximum amount of memory ever used by the kernel for this task</td>
       <td>Bytes</td>
       <td>Gauge</td>
+      <td>alloc_id, host, job, namespace, task, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.cpu.total_percent
+          nomad.client.allocs.cpu.allocated
+        </code>
+      </td>
+      <td>Total CPU resources allocated by the task across all cores</td>
+      <td>Percentage</td>
+      <td>Gauge</td>
+      <td>alloc_id, host, job, namespace, task, task_group</td>
+    </tr>
+    <tr>
+      <td>
+        <code>
+          nomad.client.allocs.cpu.total_percent
         </code>
       </td>
       <td>Total CPU resources consumed by the task across all cores</td>
       <td>Percentage</td>
       <td>Gauge</td>
+      <td>alloc_id, task, namespace, host, job, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.cpu.system
+          nomad.client.allocs.cpu.system
         </code>
       </td>
       <td>Total CPU resources consumed by the task in the system space</td>
       <td>Percentage</td>
       <td>Gauge</td>
+      <td>alloc_id, task, namespace, host, job, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.cpu.user
+          nomad.client.allocs.cpu.user
         </code>
       </td>
       <td>Total CPU resources consumed by the task in the user space</td>
       <td>Percentage</td>
       <td>Gauge</td>
+      <td>alloc_id, task, namespace, host, job, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.cpu.throttled_time
+          nomad.client.allocs.cpu.throttled_time
         </code>
       </td>
       <td>Total time that the task was throttled</td>
       <td>Nanoseconds</td>
       <td>Gauge</td>
+      <td>alloc_id, task, namespace, host, job, task_group</td>
     </tr>
     <tr>
       <td>
         <code>
-          nomad.client.allocs.&lt;Job&gt;.&lt;TaskGroup&gt;.&lt;AllocID&gt;.&lt;Task&gt;.cpu.total_ticks
+          nomad.client.allocs.cpu.throttled_periods
+        </code>
+      </td>
+      <td>Total number of CPU periods that the task was throttled</td>
+      <td>Nanoseconds</td>
+      <td>Gauge</td>
+      <td>alloc_id, task, namespace, host, job, task_group</td>
+    </tr>
+    <tr>
+      <td>
+        <code>
+          nomad.client.allocs.cpu.total_ticks
         </code>
       </td>
       <td>CPU ticks consumed by the process in the last collection interval</td>
       <td>Integer</td>
       <td>Gauge</td>
+      <td>alloc_id, task, namespace, host, job, task_group</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Allocation metrics have job, group and ID as labels, not as part of the metric name.

New on the left; old on the right:
![image](https://user-images.githubusercontent.com/113362/90291629-27c3d580-de35-11ea-85a9-d1135c4c4bdf.png)
