### PR TITLE
UI: Add missing server shutdown

### DIFF
--- a/ui/tests/integration/components/scale-events-accordion-test.js
+++ b/ui/tests/integration/components/scale-events-accordion-test.js
@@ -26,6 +26,10 @@ module('Integration | Component | scale-events-accordion', function(hooks) {
     };
   });
 
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
   const commonTemplate = hbs`<ScaleEventsAccordion @events={{this.events}} />`;
 
   test('it shows an accordion with an entry for each event', async function(assert) {


### PR DESCRIPTION
I found many instances of this message while adding component accessibility audits: `You created a second Pretender instance while there was already one running. …` You can see examples in [this CircleCI log](https://app.circleci.com/pipelines/github/hashicorp/nomad/11179/workflows/89cb9769-a506-40e9-a961-4fd9fcf1bbf2/jobs/92059/parallel-runs/0/steps/0-107). Adding this missed server shutdown makes the warnings go away.