### PR TITLE
mrd: remove redundant validation in HTTP endpoint

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -145,13 +145,6 @@ func (s *HTTPServer) jobPlan(resp http.ResponseWriter, req *http.Request,
 		return nil, CodedError(400, "Job ID does not match")
 	}
 
-	if args.Job.Multiregion != nil && args.Job.Region != nil {
-		region := *args.Job.Region
-		if !(region == "global" || region == "") {
-			return nil, CodedError(400, "Job can't have both multiregion and region blocks")
-		}
-	}
-
 	sJob, writeReq := s.apiJobAndRequestToStructs(args.Job, req, args.WriteRequest)
 	planReq := structs.JobPlanRequest{
 		Job:            sJob,
@@ -383,12 +376,6 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 	}
 	if jobName != "" && *args.Job.ID != jobName {
 		return nil, CodedError(400, "Job ID does not match name")
-	}
-	if args.Job.Multiregion != nil && args.Job.Region != nil {
-		region := *args.Job.Region
-		if !(region == "global" || region == "") {
-			return nil, CodedError(400, "Job can't have both multiregion and region blocks")
-		}
 	}
 
 	// GH-8481. Jobs of type system can only have a count of 1 and therefore do


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8354

The `regionForJob` function in the HTTP job endpoint overrides the region for
multiregion jobs to `global`, which is used as a sentinel value in the
server's job endpoint to avoid re-registration loops. This changeset removes
an extraneous check that results in errors in the web UI and makes
round-tripping through the HTTP API cumbersome for all consumers.