### PR TITLE
test: deflake consul e2e tests

### DIFF
--- a/e2e/consul/consul.go
+++ b/e2e/consul/consul.go
@@ -1,14 +1,22 @@
 package consul
 
 import (
-	"time"
+	"fmt"
+	"os"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/e2e/e2eutil"
 	"github.com/hashicorp/nomad/e2e/framework"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
-	. "github.com/onsi/gomega"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	consulJobBasic      = "consul/input/consul_example.nomad"
+	consulJobCanaryTags = "consul/input/canary_tags.nomad"
 )
 
 type ConsulE2ETest struct {
@@ -29,199 +37,197 @@ func init() {
 }
 
 func (tc *ConsulE2ETest) BeforeAll(f *framework.F) {
-	// Ensure cluster has leader before running tests
 	e2eutil.WaitForLeader(f.T(), tc.Nomad())
-	// Ensure that we have four client nodes in ready state
 	e2eutil.WaitForNodesReady(f.T(), tc.Nomad(), 1)
 }
 
-type serviceNameTagPair struct {
-	serviceName string
-	tags        map[string]struct{}
+func (tc *ConsulE2ETest) AfterEach(f *framework.F) {
+	if os.Getenv("NOMAD_TEST_SKIPCLEANUP") == "1" {
+		return
+	}
+
+	for _, id := range tc.jobIds {
+		tc.Nomad().Jobs().Deregister(id, true, nil)
+	}
+	tc.jobIds = []string{}
+	tc.Nomad().System().GarbageCollect()
 }
 
-// This test runs a job that registers in Consul with specific tags
+// TestConsulRegistration asserts that a job registers services with tags in Consul.
 func (tc *ConsulE2ETest) TestConsulRegistration(f *framework.F) {
+	t := f.T()
+
 	nomadClient := tc.Nomad()
-	uuid := uuid.Generate()
-	jobId := "consul" + uuid[0:8]
+	catalog := tc.Consul().Catalog()
+	jobId := "consul" + uuid.Generate()[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
 
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "consul/input/consul_example.nomad", jobId, "")
-	consulClient := tc.Consul()
-	require := require.New(f.T())
-	require.Equal(3, len(allocs))
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, consulJobBasic, jobId, "")
+	require.Equal(t, 3, len(allocs))
+	allocIDs := e2eutil.AllocIDsFromAllocationListStubs(allocs)
+	e2eutil.WaitForAllocsRunning(t, tc.Nomad(), allocIDs)
 
-	// Query consul catalog for service
-	catalog := consulClient.Catalog()
-	g := NewGomegaWithT(f.T())
-
-	expectedTags := map[string]struct{}{}
-	expectedTags["global"] = struct{}{}
-	expectedTags["cache"] = struct{}{}
-
-	g.Eventually(func() []serviceNameTagPair {
-		consulService, _, err := catalog.Service("redis-cache", "", nil)
-		require.Nil(err)
-		var serviceInfo []serviceNameTagPair
-		for _, serviceInstance := range consulService {
-			tags := map[string]struct{}{}
-			for _, tag := range serviceInstance.ServiceTags {
-				tags[tag] = struct{}{}
-			}
-			serviceInfo = append(serviceInfo, serviceNameTagPair{serviceInstance.ServiceName, tags})
-		}
-		return serviceInfo
-	}, 5*time.Second, time.Second).Should(ConsistOf([]serviceNameTagPair{
-		{"redis-cache", expectedTags},
-		{"redis-cache", expectedTags},
-		{"redis-cache", expectedTags},
-	}))
-
-	jobs := nomadClient.Jobs()
-	// Stop all jobs in test
-	for _, id := range tc.jobIds {
-		jobs.Deregister(id, true, nil)
+	expectedTags := []string{
+		"cache",
+		"global",
 	}
-	// Garbage collect
-	nomadClient.System().GarbageCollect()
+
+	// Assert services get registered
+	testutil.WaitForResult(func() (bool, error) {
+		services, _, err := catalog.Service("consul-example", "", nil)
+		if err != nil {
+			return false, fmt.Errorf("error contacting Consul: %v", err)
+		}
+		if expected := 3; len(services) != expected {
+			return false, fmt.Errorf("expected %d services but found %d", expected, len(services))
+		}
+		for _, s := range services {
+			// If we've made it this far the tags should *always* match
+			require.True(t, helper.CompareSliceSetString(expectedTags, s.ServiceTags))
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("error waiting for services to be registered: %v", err)
+	})
+
+	// Stop the job
+	e2eutil.WaitForJobStopped(t, nomadClient, jobId)
 
 	// Verify that services were deregistered in Consul
-	g.Eventually(func() []string {
-		consulService, _, err := catalog.Service("redis-cache", "", nil)
-		require.Nil(err)
-		var serviceIDs []string
-		for _, serviceInstance := range consulService {
-			serviceIDs = append(serviceIDs, serviceInstance.ServiceID)
+	testutil.WaitForResult(func() (bool, error) {
+		s, _, err := catalog.Service("consul-example", "", nil)
+		if err != nil {
+			return false, err
 		}
-		return serviceIDs
-	}, 5*time.Second, time.Second).Should(BeEmpty())
+
+		return len(s) == 0, fmt.Errorf("expected 0 services but found: %v", s)
+	}, func(err error) {
+		t.Fatalf("error waiting for services to be deregistered: %v", err)
+	})
 }
 
-// This test verifies setting and unsetting canary tags
+// TestCanaryInplaceUpgrades verifies setting and unsetting canary tags
 func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
+	t := f.T()
 	nomadClient := tc.Nomad()
-	uuid := uuid.Generate()
-	jobId := "consul" + uuid[0:8]
+	consulClient := tc.Consul()
+	jobId := "consul" + uuid.Generate()[0:8]
 	tc.jobIds = append(tc.jobIds, jobId)
 
-	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, "consul/input/canary_tags.nomad", jobId, "")
-	consulClient := tc.Consul()
-	require := require.New(f.T())
-	require.Equal(2, len(allocs))
+	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(), nomadClient, consulJobCanaryTags, jobId, "")
+	require.Equal(t, 2, len(allocs))
 
-	jobs := nomadClient.Jobs()
-	g := NewGomegaWithT(f.T())
-
-	g.Eventually(func() []string {
-		deploys, _, err := jobs.Deployments(jobId, false, nil)
-		require.Nil(err)
-		healthyDeploys := make([]string, 0, len(deploys))
-		for _, d := range deploys {
-			if d.Status == "successful" {
-				healthyDeploys = append(healthyDeploys, d.ID)
-			}
-		}
-		return healthyDeploys
-	}, 5*time.Second, 20*time.Millisecond).Should(HaveLen(1))
+	allocIDs := e2eutil.AllocIDsFromAllocationListStubs(allocs)
+	e2eutil.WaitForAllocsRunning(t, nomadClient, allocIDs)
 
 	// Start a deployment
-	job, _, err := jobs.Info(jobId, nil)
-	require.Nil(err)
+	job, _, err := nomadClient.Jobs().Info(jobId, nil)
+	require.NoError(t, err)
 	job.Meta = map[string]string{"version": "2"}
-	resp, _, err := jobs.Register(job, nil)
-	require.Nil(err)
-	require.NotEmpty(resp.EvalID)
+	resp, _, err := nomadClient.Jobs().Register(job, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.EvalID)
 
 	// Eventually have a canary
-	var deploys []*api.Deployment
-	g.Eventually(func() []*api.Deployment {
-		deploys, _, err = jobs.Deployments(*job.ID, false, nil)
-		require.Nil(err)
-		return deploys
-	}, 2*time.Second, 20*time.Millisecond).Should(HaveLen(2))
-
-	deployments := nomadClient.Deployments()
-	var deploy *api.Deployment
-	g.Eventually(func() []string {
-		deploy, _, err = deployments.Info(deploys[0].ID, nil)
-		require.Nil(err)
-		return deploy.TaskGroups["consul_canary_test"].PlacedCanaries
-	}, 2*time.Second, 20*time.Millisecond).Should(HaveLen(1))
-
-	allocations := nomadClient.Allocations()
-	g.Eventually(func() bool {
-		allocID := deploy.TaskGroups["consul_canary_test"].PlacedCanaries[0]
-		alloc, _, err := allocations.Info(allocID, nil)
-		require.Nil(err)
-		return alloc.DeploymentStatus != nil && alloc.DeploymentStatus.Healthy != nil && *alloc.DeploymentStatus.Healthy
-	}, 3*time.Second, 20*time.Millisecond).Should(BeTrue())
-
-	// Query consul catalog for service
-	catalog := consulClient.Catalog()
-	// Check Consul for canary tags
-	g.Eventually(func() []string {
-		consulServices, _, err := catalog.Service("canarytest", "", nil)
-		require.Nil(err)
-
-		for _, serviceInstance := range consulServices {
-			for _, tag := range serviceInstance.ServiceTags {
-				if tag == "canary" {
-					return serviceInstance.ServiceTags
-				}
-			}
+	var activeDeploy *api.Deployment
+	testutil.WaitForResult(func() (bool, error) {
+		deploys, _, err := nomadClient.Jobs().Deployments(jobId, false, nil)
+		if err != nil {
+			return false, err
+		}
+		if expected := 2; len(deploys) != expected {
+			return false, fmt.Errorf("expected 2 deploys but found %v", deploys)
 		}
 
-		return nil
-	}, 2*time.Second, 20*time.Millisecond).Should(
-		Equal([]string{"foo", "canary"}))
+		for _, d := range deploys {
+			if d.Status == structs.DeploymentStatusRunning {
+				activeDeploy = d
+				break
+			}
+		}
+		if activeDeploy == nil {
+			return false, fmt.Errorf("no running deployments: %v", deploys)
+		}
+		if expected := 1; len(activeDeploy.TaskGroups["consul_canary_test"].PlacedCanaries) != expected {
+			return false, fmt.Errorf("expected %d placed canaries but found %#v",
+				expected, activeDeploy.TaskGroups["consul_canary_test"])
+		}
 
-	// Manually promote
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("error while waiting for deploys: %v", err)
+	})
+
+	allocID := activeDeploy.TaskGroups["consul_canary_test"].PlacedCanaries[0]
+	testutil.WaitForResult(func() (bool, error) {
+		alloc, _, err := nomadClient.Allocations().Info(allocID, nil)
+		if err != nil {
+			return false, err
+		}
+
+		if alloc.DeploymentStatus == nil {
+			return false, fmt.Errorf("canary alloc %s has no deployment status", allocID)
+		}
+		if alloc.DeploymentStatus.Healthy == nil {
+			return false, fmt.Errorf("canary alloc %s has no deployment health: %#v",
+				allocID, alloc.DeploymentStatus)
+		}
+		return *alloc.DeploymentStatus.Healthy, fmt.Errorf("expected healthy canary but found: %#v",
+			alloc.DeploymentStatus)
+	}, func(err error) {
+		t.Fatalf("error waiting for canary to be healthy: %v", err)
+	})
+
+	// Check Consul for canary tags
+	testutil.WaitForResult(func() (bool, error) {
+		consulServices, _, err := consulClient.Catalog().Service("canarytest", "", nil)
+		if err != nil {
+			return false, err
+		}
+		for _, s := range consulServices {
+			if helper.CompareSliceSetString([]string{"canary", "foo"}, s.ServiceTags) {
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf(`could not find service tags {"canary", "foo"}: %#v`, consulServices)
+	}, func(err error) {
+		t.Fatalf("error waiting for canary tags: %v", err)
+	})
+
+	// Promote canary
 	{
-		resp, _, err := deployments.PromoteAll(deploys[0].ID, nil)
-		require.Nil(err)
-		require.NotEmpty(resp.EvalID)
+		resp, _, err := nomadClient.Deployments().PromoteAll(activeDeploy.ID, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.EvalID)
 	}
 
-	// Eventually canary is removed
-	g.Eventually(func() bool {
-		allocID := deploy.TaskGroups["consul_canary_test"].PlacedCanaries[0]
-		alloc, _, err := allocations.Info(allocID, nil)
-		require.Nil(err)
-		return alloc.DeploymentStatus.Canary
-	}, 2*time.Second, 20*time.Millisecond).Should(BeFalse())
+	// Eventually canary is promoted
+	testutil.WaitForResult(func() (bool, error) {
+		alloc, _, err := nomadClient.Allocations().Info(allocID, nil)
+		if err != nil {
+			return false, err
+		}
+		return !alloc.DeploymentStatus.Canary, fmt.Errorf("still a canary")
+	}, func(err error) {
+		t.Fatalf("error waiting for canary to be promoted: %v", err)
+	})
 
 	// Verify that no instances have canary tags
-	expectedTags := map[string]struct{}{}
-	expectedTags["foo"] = struct{}{}
-	expectedTags["bar"] = struct{}{}
-
-	g.Eventually(func() []serviceNameTagPair {
-		consulServices, _, err := catalog.Service("canarytest", "", nil)
-		require.Nil(err)
-		var serviceInfo []serviceNameTagPair
-		for _, serviceInstance := range consulServices {
-			tags := map[string]struct{}{}
-			for _, tag := range serviceInstance.ServiceTags {
-				tags[tag] = struct{}{}
-			}
-			serviceInfo = append(serviceInfo, serviceNameTagPair{serviceInstance.ServiceName, tags})
+	expected := []string{"foo", "bar"}
+	testutil.WaitForResult(func() (bool, error) {
+		consulServices, _, err := consulClient.Catalog().Service("canarytest", "", nil)
+		if err != nil {
+			return false, err
 		}
-		return serviceInfo
-	}, 3*time.Second, 20*time.Millisecond).Should(ConsistOf([]serviceNameTagPair{
-		{"canarytest", expectedTags},
-		{"canarytest", expectedTags},
-	}))
+		for _, s := range consulServices {
+			if !helper.CompareSliceSetString(expected, s.ServiceTags) {
+				return false, fmt.Errorf("expected %#v Consul tags but found %#v",
+					expected, s.ServiceTags)
+			}
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("error waiting for non-canary tags: %v", err)
+	})
 
-}
-
-func (tc *ConsulE2ETest) AfterEach(f *framework.F) {
-	nomadClient := tc.Nomad()
-	jobs := nomadClient.Jobs()
-	// Stop all jobs in test
-	for _, id := range tc.jobIds {
-		jobs.Deregister(id, true, nil)
-	}
-	// Garbage collect
-	nomadClient.System().GarbageCollect()
 }

--- a/e2e/consul/input/canary_tags.nomad
+++ b/e2e/consul/input/canary_tags.nomad
@@ -10,11 +10,25 @@ job "consul_canary_test" {
     count = 2
 
     task "consul_canary_test" {
-      driver = "mock_driver"
+      driver = "docker"
 
       config {
-        run_for   = "10m"
-        exit_code = 9
+        image   = "busybox:1"
+        command = "nc"
+        args    = ["-ll", "-p", "1234", "-e", "/bin/cat"]
+
+        port_map {
+          db = 1234
+        }
+      }
+
+      resources {
+        cpu    = 100
+        memory = 100
+
+        network {
+          port "db" {}
+        }
       }
 
       service {

--- a/e2e/consul/input/consul_example.nomad
+++ b/e2e/consul/input/consul_example.nomad
@@ -41,25 +41,26 @@ job "consul-example" {
       driver = "docker"
 
       config {
-        image = "redis:3.2"
+        image   = "busybox:1"
+        command = "nc"
+        args    = ["-ll", "-p", "1234", "-e", "/bin/cat"]
 
         port_map {
-          db = 6379
+          db = 1234
         }
       }
 
       resources {
-        cpu    = 500 # 500 MHz
-        memory = 256 # 256MB
+        cpu    = 100
+        memory = 100
 
         network {
-          mbits = 10
           port "db" {}
         }
       }
 
       service {
-        name = "redis-cache"
+        name = "consul-example"
         tags = ["global", "cache"]
         port = "db"
 


### PR DESCRIPTION
Modernize test patterns by removing gomega and avoiding the mock_driver.

Fixes #7724