### PR TITLE
UI: Change node stats to use reserved when present

### DIFF
--- a/ui/app/utils/classes/node-stats-tracker.js
+++ b/ui/app/utils/classes/node-stats-tracker.js
@@ -1,5 +1,5 @@
 import EmberObject, { computed } from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { or } from '@ember/object/computed';
 import RollingArray from 'nomad-ui/utils/classes/rolling-array';
 import AbstractStatsTracker from 'nomad-ui/utils/classes/abstract-stats-tracker';
 import classic from 'ember-classic-decorator';
@@ -48,8 +48,8 @@ class NodeStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
   }
 
   // Static figures, denominators for stats
-  @alias('node.resources.cpu') reservedCPU;
-  @alias('node.resources.memory') reservedMemory;
+  @or('node.reserved.cpu', 'node.resources.cpu') reservedCPU;
+  @or('node.reserved.memory', 'node.resources.memory') reservedMemory;
 
   // Dynamic figures, collected over time
   // []{ timestamp: Date, used: Number, percent: Number }

--- a/ui/tests/unit/utils/node-stats-tracker-test.js
+++ b/ui/tests/unit/utils/node-stats-tracker-test.js
@@ -55,7 +55,7 @@ module('Unit | Util | NodeStatsTracker', function() {
     );
   });
 
-  test('reservedCPU and reservedMemory properties come from the node', async function(assert) {
+  test('reservedCPU and reservedMemory properties come from the node resources by default', async function(assert) {
     const node = MockNode();
     const tracker = NodeStatsTracker.create({ fetch, node });
 
@@ -65,6 +65,19 @@ module('Unit | Util | NodeStatsTracker', function() {
       node.resources.memory,
       'reservedMemory comes from the node'
     );
+  });
+
+  test('reservedCPU and reservedMemory properties come from the node reserved resources when present', async function(assert) {
+    const node = MockNode({
+      reserved: {
+        cpu: 1000,
+        memory: 2000,
+      },
+    });
+    const tracker = NodeStatsTracker.create({ fetch, node });
+
+    assert.equal(tracker.get('reservedCPU'), 1000);
+    assert.equal(tracker.get('reservedMemory'), 2000);
   });
 
   test('poll results in requesting the url and calling append with the resulting JSON', async function(assert) {


### PR DESCRIPTION
This is a naïve fix for #8694. It changes NodeStatsTracker to use `reserved` values when present and fall back to `resources` when the former are 0.

Before:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/43280/90679383-b2397a00-e225-11ea-97b7-78c34b02da45.png">

After:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/43280/90679434-c8dfd100-e225-11ea-820f-59a34f8d423a.png">

Both of these are with the following client configuration:

```
client {
  options = {
    "driver.raw_exec.enable" = "1"
  }

  reserved = {
    memory = 2000
    cpu = 1000
  }
}
```

It’s strange to have percentages greater than 100 after this so maybe there’s something missing here 🤔

Also, I tried running with the reserved values set to 0 and then the fallback was used, understandably… I’m not sure of a good way to distinguish between deliberate 0 (which, should that even be possible?) and the happenstance 0 that the API returns when `reserved` isn’t set:

<img width="111" alt="image" src="https://user-images.githubusercontent.com/43280/90680054-d34e9a80-e226-11ea-9ed4-3c95189b6493.png">

Thanks to @scalp42 for the report!