### PR TITLE
Binding nomad task to nebula interface if it exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -717,7 +717,7 @@ jobs:
         command: "CCI_VERSION=\"0.1.5879\"\nCCI_SHA256=\"f178ea62c781aec06267017404f87983c87f171fd0e66ef3737916246ae66dd6\"\n\nURL=\"https://github.com/CircleCI-Public/circleci-cli/releases/download/v${CCI_VERSION}/circleci-cli_${CCI_VERSION}_linux_amd64.tar.gz\"\n\nmkdir -p /tmp/circleci-cli/\ncurl --fail --show-error --location \\\n  -o /tmp/circleci-cli/cli.tar.gz \"${URL}\"\n\necho \"$CCI_SHA256 /tmp/circleci-cli/cli.tar.gz\" | sha256sum -c\n\ntar -xz --strip-components=1 \\\n  -C /tmp/circleci-cli \\\n  -f /tmp/circleci-cli/cli.tar.gz \\\n  \"circleci-cli_${CCI_VERSION}_linux_amd64/circleci\" \n\nsudo cp /tmp/circleci-cli/circleci /usr/bin/circleci-local-cli\n\ncircleci-local-cli version\n"
         name: Install CircleCI CLI 0.1.5879
     - run:
-        command: make deps lint-deps
+        command: make deps
     - run:
         command: make check
     - run:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -162,7 +162,7 @@ endef
 $(foreach t,$(ALL_TARGETS),$(eval $(call makePackageTarget,$(t))))
 
 .PHONY: bootstrap
-bootstrap: deps lint-deps git-hooks # Install all dependencies
+bootstrap: deps git-hooks # Install all dependencies
 
 .PHONY: deps
 deps:  ## Install build and development dependencies
@@ -193,6 +193,7 @@ $(git-dir)/hooks/%: dev/hooks/%
 .PHONY: check
 check: ## Lint the source code
 	@echo "==> Linting source code..."
+	GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 	@golangci-lint run -j 1
 
 	@echo "==> Spell checking website..."

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -289,6 +289,7 @@
 		{"path":"github.com/kr/pretty","checksumSHA1":"eOXF2PEvYLMeD8DSzLZJWbjYzco=","revision":"cfb55aafdaf3ec08f0db22699ab822c50091b1c4","revisionTime":"2016-08-23T17:07:15Z"},
 		{"path":"github.com/kr/pty","checksumSHA1":"WD7GMln/NoduJr0DbumjOE59xI8=","revision":"b6e1bdd4a4f88614e0c6e5e8089c7abed98aae17","revisionTime":"2019-04-01T03:15:51Z"},
 		{"path":"github.com/kr/text","checksumSHA1":"uulQHQ7IsRKqDudBC8Go9J0gtAc=","revision":"7cafcd837844e784b526369c9bce262804aebc60","revisionTime":"2016-05-04T02:26:26Z"},
+		{"path":"github.com/kr/text","version":"v0.2.0"},
 		{"path":"github.com/mattn/go-colorable","checksumSHA1":"SEnjvwVyfuU2xBaOfXfwPD5MZqk=","revision":"efa589957cd060542a26d2dd7832fd6a6c6c3ade","revisionTime":"2018-03-10T13:32:14Z"},
 		{"path":"github.com/mattn/go-isatty","checksumSHA1":"AZO2VGorXTMDiSVUih3k73vORHY=","revision":"6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c","revisionTime":"2017-11-07T05:05:31Z"},
 		{"path":"github.com/mattn/go-shellwords","checksumSHA1":"ajImwVZHzsI+aNwsgzCSFSbmJqs=","revision":"f4e566c536cf69158e808ec28ef4182a37fdc981","revisionTime":"2015-03-21T17:42:21Z"},


### PR DESCRIPTION
# Description
Bind nomad task to `nebula` interface in addition to the normal `br0` interface.

Nomad will still schedule tasks on the normal interface (viewed on Nomad UI the task is associated with normal IP). But  task's ports will also be listening on the Nebula interface. 

# Testing
Tested in Dave H's Vagrant sandbox. Verified nomad job listening on both interfaces when client is set to use the normal interface.

```
2b05bd1f2761        registry-app.b1-prv.qops.net:5001/daveh/simpleserver:latest   "go run /app/simples…"   23 hours ago        Up 23 hours         10.111.0.5:8084->8084/tcp, 10.111.0.5:8084->8084/udp, 192.168.51.103:8084->8084/tcp, 192.168.51.103:8084->8084/udp   ddd-app-3962a192-4c92-11ae-106f-1823e77757ae
```

Verified it also works when client stanza contains `network_interface = "nebula1"` (listening only to the `nebula1` interface). Don't know if we will ever configure it this way though. 

### unit tests
* CircleCI is running


# Deployment
Need to sync up with darren/dev-tools team on the best way to execute.
