### PR TITLE
command/operator_debug: mkdir before storing agent-host

### DIFF
--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -454,6 +454,7 @@ func (c *OperatorDebugCommand) collectAgentHost(path, id string, client *api.Cli
 	}
 
 	path = filepath.Join(path, id)
+	c.mkdir(path)
 
 	c.writeJSON(path, "agent-host.json", host, err)
 }


### PR DESCRIPTION
The api calls were reordered, the new order omits the
`agent-host.json` result by fetching it before the directory is
created.