### PR TITLE
e2e: fix platform path for installing for Linux from s3

### DIFF
--- a/e2e/terraform/packer/linux/install-nomad
+++ b/e2e/terraform/packer/linux/install-nomad
@@ -32,7 +32,7 @@ install_from_s3() {
             && echo "$NOMAD_SHA already installed" && exit 0
     fi
 
-    S3_URL="s3://nomad-team-dev-test-binaries/builds-oss/nomad_linux_${NOMAD_SHA}.tar.gz"
+    S3_URL="s3://nomad-team-dev-test-binaries/builds-oss/nomad_${PLATFORM}_${NOMAD_SHA}.tar.gz"
     aws s3 cp --quiet "$S3_URL" nomad.tar.gz
     sudo tar -zxvf nomad.tar.gz -C "$INSTALL_DIR"
     set_ownership

--- a/e2e/terraform/packer/windows/install-nomad.ps1
+++ b/e2e/terraform/packer/windows/install-nomad.ps1
@@ -30,6 +30,7 @@ if (!$RunningAsAdmin) {
 
 
 $install_path = "C:\opt\nomad.exe"
+$platform = "windows_amd64"
 
 Set-Location C:\opt
 
@@ -50,7 +51,7 @@ function InstallFromS3 {
     }
 
     Try {
-        $key = "builds-oss/nomad_windows_amd64_${nomad_sha}.zip"
+        $key = "builds-oss/nomad_${platform}_${nomad_sha}.zip"
 		Read-S3Object -BucketName nomad-team-dev-test-binaries -Key $key -File ./nomad.zip
 		Remove-Item -Path $install_path -Force -ErrorAction Ignore
 		Expand-Archive ./nomad.zip ./ -Force
@@ -107,7 +108,7 @@ function InstallFromRelease {
 
     Try {
         $releases = "https://releases.hashicorp.com"
-        $url = "${releases}/nomad/${nomad_version}/nomad_${nomad_version}_windows_amd64.zip"
+        $url = "${releases}/nomad/${nomad_version}/nomad_${nomad_version}_${platform}.zip"
 
         Write-Output "Downloading Nomad from: $url"
         Invoke-WebRequest -Uri $url -Outfile nomad.zip


### PR DESCRIPTION
Fixes the broken S3 path for E2E deployments on Linux. Tested by kicking off the new AMI build on TeamCity and following-up with a build of the e2e test runner to ensure it actually works. The testing I'd done in #8706 missed this code path 😊 