### PR TITLE
UI: Model new CSI controller and node plugin jobs relationships

### DIFF
--- a/ui/app/models/plugin.js
+++ b/ui/app/models/plugin.js
@@ -1,6 +1,7 @@
 import { computed } from '@ember/object';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
+import { hasMany } from 'ember-data/relationships';
 import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default class Plugin extends Model {
@@ -12,6 +13,9 @@ export default class Plugin extends Model {
 
   @fragmentArray('storage-controller', { defaultValue: () => [] }) controllers;
   @fragmentArray('storage-node', { defaultValue: () => [] }) nodes;
+
+  @hasMany('job') controllerJobs;
+  @hasMany('job') nodeJobs;
 
   @attr('boolean') controllerRequired;
   @attr('number') controllersHealthy;

--- a/ui/app/serializers/plugin.js
+++ b/ui/app/serializers/plugin.js
@@ -28,6 +28,13 @@ export default class Plugin extends ApplicationSerializer {
     hash.Nodes = unmap(nodes, 'NodeID');
     hash.Controllers = unmap(controllers, 'NodeID');
 
+    hash.ControllerJobIDs = (hash.ControllerJobs || []).map(job =>
+      JSON.stringify([job.ID, job.Namespace || 'default'])
+    );
+    hash.NodeJobIDs = (hash.NodeJobs || []).map(job =>
+      JSON.stringify([job.ID, job.Namespace || 'default'])
+    );
+
     return super.normalize(typeHash, hash);
   }
 }

--- a/ui/mirage/factories/csi-plugin.js
+++ b/ui/mirage/factories/csi-plugin.js
@@ -48,27 +48,29 @@ export default Factory.extend({
   afterCreate(plugin, server) {
     let storageNodes;
     let storageControllers;
+    let controllerJob;
+    let nodeJob;
 
     if (plugin.isMonolith) {
-      const pluginJob = server.create('job', { type: 'service', createAllocations: false });
+      nodeJob = server.create('job', { type: 'service', createAllocations: false });
       const count = plugin.nodesExpected;
       storageNodes = server.createList('storage-node', count, {
-        job: pluginJob,
+        job: nodeJob,
         shallow: plugin.shallow,
       });
       storageControllers = server.createList('storage-controller', count, {
-        job: pluginJob,
+        job: nodeJob,
         shallow: plugin.shallow,
       });
     } else {
-      const controllerJob =
+      controllerJob =
         plugin.controllerRequired &&
         server.create('job', {
           type: 'service',
           createAllocations: false,
           shallow: plugin.shallow,
         });
-      const nodeJob = server.create('job', {
+      nodeJob = server.create('job', {
         type: 'service',
         createAllocations: false,
         shallow: plugin.shallow,
@@ -88,6 +90,8 @@ export default Factory.extend({
     plugin.update({
       controllers: storageControllers,
       nodes: storageNodes,
+      controllerJobs: controllerJob ? [controllerJob] : null,
+      nodeJobs: [nodeJob],
     });
 
     if (plugin.createVolumes) {

--- a/ui/mirage/models/csi-plugin.js
+++ b/ui/mirage/models/csi-plugin.js
@@ -3,4 +3,6 @@ import { Model, hasMany } from 'ember-cli-mirage';
 export default Model.extend({
   nodes: hasMany('storage-node'),
   controllers: hasMany('storage-controller'),
+  controllerJobs: hasMany('job'),
+  nodeJobs: hasMany('job'),
 });

--- a/ui/mirage/serializers/csi-plugin.js
+++ b/ui/mirage/serializers/csi-plugin.js
@@ -2,5 +2,29 @@ import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
   embed: true,
-  include: ['nodes', 'controllers'],
+  include: ['nodes', 'controllers', 'controllerJobs', 'nodeJobs'],
+  serialize() {
+    var json = ApplicationSerializer.prototype.serialize.apply(this, arguments);
+    if (json instanceof Array) {
+      json.forEach(serializePlugin);
+    } else {
+      serializePlugin(json);
+    }
+    return json;
+  },
 });
+
+function serializePlugin(plugin) {
+  plugin.ControllerJobs = plugin.ControllerJobs.map(({ ID, Namespace, Version }) => ({
+    ID,
+    Namespace,
+    Version,
+  }));
+  plugin.NodeJobs = plugin.NodeJobs.map(({ ID, Namespace, Version }) => ({
+    ID,
+    Namespace,
+    Version,
+  }));
+
+  if (!plugin.ControllerJobs.length) plugin.ControllerJobs = null;
+}


### PR DESCRIPTION
The CSI plugin API now has job information for the jobs that power the node and controller portions of the plugin. These can be modeled as `hasMany`s in ember data.

The original plan was to use these relationships to save on allocation requests.

**Current behavior**
1. Fetch plugin
2. From plugin, get the set of controller allocs and node allocs
3. Fetch all controller and node allocs
4. Fetch jobs associated with allocs as needed

The downside here is that each allocation needs to be fetched independently.

**Intended new behavior**
1. Fetch plugin
2. From plugin, get the set of controller and node jobs
3. Fetch each controller and node jobs (generally 1 or 2 jobs)
4. For each job, fetch all job allocs

This would result in 1 + 2m requests instead of 1 + n + m requests (where n = count of allocs and m = count of jobs is always <= n)

**Unfortunate truth**
Allocations need to be fetched independently to get preemption and reschedule information. I have been taught this listen this way, like, three times. You'd think I'd learn.

I don't know if we actually want to accept this PR but it's technically still useful? Or maybe I'm just upset I wasted an hour?