### PR TITLE
client/fingerprint: lookup kernel builtin bridge modules

### DIFF
--- a/client/fingerprint/bridge_linux.go
+++ b/client/fingerprint/bridge_linux.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shirou/gopsutil/host"
 )
 
 const bridgeKernelModuleName = "bridge"
@@ -35,6 +36,20 @@ func (f *BridgeFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpri
 }
 
 func (f *BridgeFingerprint) checkKMod(mod string) error {
+	dynErr := f.checkKDynMod(mod)
+	if dynErr == nil {
+		return nil
+	}
+
+	builtinErr := f.checkKBuiltinMod(mod)
+	if builtinErr == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%v, %v", dynErr, builtinErr)
+}
+
+func (f *BridgeFingerprint) checkKDynMod(mod string) error {
 	file, err := os.Open("/proc/modules")
 	if err != nil {
 		return fmt.Errorf("could not read /proc/modules: %v", err)
@@ -51,5 +66,31 @@ func (f *BridgeFingerprint) checkKMod(mod string) error {
 		}
 	}
 
-	return fmt.Errorf("could not detect kernel module %s", mod)
+	return fmt.Errorf("could not detect dynamic kernel module %s", mod)
+}
+
+func (f *BridgeFingerprint) checkKBuiltinMod(mod string) error {
+	hostInfo, err := host.Info()
+	if err != nil {
+		return err
+	}
+
+	fileName := fmt.Sprintf("/lib/modules/%s/modules.builtin", hostInfo.KernelVersion)
+	file, err := os.Open(fileName)
+	if err != nil {
+		return fmt.Errorf("could not read %s: %v", fileName, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	pattern := fmt.Sprintf(".+\\/%s.ko$", mod)
+	for scanner.Scan() {
+		if matched, err := regexp.MatchString(pattern, scanner.Text()); matched {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("could not parse %s: %v", fileName, err)
+		}
+	}
+
+	return fmt.Errorf("could not detect builtin kernel module %s", mod)
 }

--- a/client/fingerprint/bridge_linux_test.go
+++ b/client/fingerprint/bridge_linux_test.go
@@ -10,5 +10,6 @@ func TestBridgeFingerprint_checkKMod(t *testing.T) {
 	require := require.New(t)
 	f := &BridgeFingerprint{}
 	require.NoError(f.checkKMod("ip_tables"))
+	require.NoError(f.checkKMod("bridge"))
 	require.Error(f.checkKMod("nonexistentmodule"))
 }

--- a/client/fingerprint/bridge_linux_test.go
+++ b/client/fingerprint/bridge_linux_test.go
@@ -10,6 +10,5 @@ func TestBridgeFingerprint_checkKMod(t *testing.T) {
 	require := require.New(t)
 	f := &BridgeFingerprint{}
 	require.NoError(f.checkKMod("ip_tables"))
-	require.NoError(f.checkKMod("bridge"))
 	require.Error(f.checkKMod("nonexistentmodule"))
 }


### PR DESCRIPTION
centos epel kernel 4.x(kernel-lt) and 5.x(kernel-ml) changed `bridge` module to kernel-builtin, so centos with newer kernel(from epel repo) cannot detect `bridge` module.

I think it's better to lookup builtin modules too.

I have followed centos kernel upgrade instruction here: https://phoenixnap.com/kb/how-to-upgrade-kernel-centos
