### PR TITLE
command: remove mbits from quota hcl

### DIFF
--- a/command/quota_apply.go
+++ b/command/quota_apply.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/jobspec"
 	"github.com/mitchellh/mapstructure"
 	"github.com/posener/complete"
 )
@@ -262,7 +261,6 @@ func parseQuotaResource(result *api.Resources, list *ast.ObjectList) error {
 	valid := []string{
 		"cpu",
 		"memory",
-		"network",
 	}
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 		return multierror.Prefix(err, "resources ->")
@@ -275,21 +273,6 @@ func parseQuotaResource(result *api.Resources, list *ast.ObjectList) error {
 
 	if err := mapstructure.WeakDecode(m, result); err != nil {
 		return err
-	}
-
-	// Find the network ObjectList, parse it
-	nw := listVal.Filter("network")
-	if len(nw.Items) > 0 {
-		rl, err := jobspec.ParseNetwork(nw)
-		if err != nil {
-			return multierror.Prefix(err, "resources ->")
-		}
-		if rl != nil {
-			if rl.Mode != "" || rl.HasPorts() {
-				return fmt.Errorf("resources -> network only allows mbits")
-			}
-			result.Networks = []*api.NetworkResource{rl}
-		}
 	}
 
 	return nil

--- a/command/quota_apply_test.go
+++ b/command/quota_apply_test.go
@@ -4,9 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/nomad/api"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/require"
 )
 
 func TestQuotaApplyCommand_Implements(t *testing.T) {
@@ -35,43 +33,4 @@ func TestQuotaApplyCommand_Fails(t *testing.T) {
 		t.Fatalf("name required error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
-}
-
-func TestQuotaApplyNetwork(t *testing.T) {
-	t.Parallel()
-
-	mbits := 20
-
-	cases := []struct {
-		hcl string
-		q   *api.QuotaSpec
-		err string
-	}{{
-		hcl: `limit {region = "global", region_limit {network {mbits = 20}}}`,
-		q: &api.QuotaSpec{
-			Limits: []*api.QuotaLimit{{
-				Region: "global",
-				RegionLimit: &api.Resources{
-					Networks: []*api.NetworkResource{{
-						MBits: &mbits,
-					}},
-				},
-			}},
-		},
-		err: "",
-	}, {
-		hcl: `limit {region = "global", region_limit {network { mbits = 20, device = "eth0"}}}`,
-		q:   nil,
-		err: "network -> invalid key: device",
-	}}
-
-	for _, c := range cases {
-		t.Run(c.hcl, func(t *testing.T) {
-			q, err := parseQuotaSpec([]byte(c.hcl))
-			require.Equal(t, c.q, q)
-			if c.err != "" {
-				require.Contains(t, err.Error(), c.err)
-			}
-		})
-	}
 }

--- a/command/quota_init.go
+++ b/command/quota_init.go
@@ -115,9 +115,6 @@ limit {
     region_limit {
         cpu = 2500
         memory = 1000
-        network {
-           mbits = 50
-        }
     }
 }
 `)
@@ -131,10 +128,7 @@ var defaultJsonQuotaSpec = strings.TrimSpace(`
 			"Region": "global",
 			"RegionLimit": {
 				"CPU": 2500,
-				"MemoryMB": 1000,
-                                "Networks": [
-                                        { "MBits": 50 }
-                                ]
+				"MemoryMB": 1000
 			}
 		}
 	]


### PR DESCRIPTION
With the deprecation of `mbits` resource, it should be removed from quotas as well. 