### PR TITLE
core: improve job deregister error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.13.0 (Unreleased)
 
 IMPROVEMENTS:
+ * core: Improved job deregistration error logging. [[GH-8745](https://github.com/hashicorp/nomad/issues/8745)]
  * api: Added support for cancellation contexts to HTTP API. [[GH-8836](https://github.com/hashicorp/nomad/issues/8836)]
 
 BUG FIXES:

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -712,6 +712,29 @@ func TestFSM_RegisterJob_BadNamespace(t *testing.T) {
 	}
 }
 
+func TestFSM_DeregisterJob_Error(t *testing.T) {
+	t.Parallel()
+	fsm := testFSM(t)
+
+	job := mock.Job()
+
+	deregReq := structs.JobDeregisterRequest{
+		JobID: job.ID,
+		Purge: true,
+		WriteRequest: structs.WriteRequest{
+			Namespace: job.Namespace,
+		},
+	}
+	buf, err := structs.Encode(structs.JobDeregisterRequestType, deregReq)
+	require.NoError(t, err)
+
+	resp := fsm.Apply(makeLog(buf))
+	require.NotNil(t, resp)
+	respErr, ok := resp.(error)
+	require.Truef(t, ok, "expected response to be an error but found: %T", resp)
+	require.Error(t, respErr)
+}
+
 func TestFSM_DeregisterJob_Purge(t *testing.T) {
 	t.Parallel()
 	fsm := testFSM(t)


### PR DESCRIPTION
Noticed this error in some production logs, and they were far from
helpful. Changes:

1. Include job ID in logs
2. Wrap errors and log once instead of double log lines
3. Test fsm error handling behavior