### PR TITLE
Handle migration of non-deployment jobs

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -453,6 +453,13 @@ func (s *GenericScheduler) downgradedJobForPlacement(p placementResult) (string,
 		}
 	}
 
+	// check if the non-promoted version is a job without update stanza. This version should be the latest "stable" version,
+	// as all subsequent versions must be canaried deployments.  Otherwise, we would have found a deployment above,
+	// or the alloc would have been replaced already by a newer non-deployment job.
+	if job, err := s.state.JobByIDAndVersion(nil, ns, jobID, p.MinJobVersion()); err == nil && job != nil && job.Update.IsEmpty() {
+		return "", job, err
+	}
+
 	return "", nil, nil
 }
 


### PR DESCRIPTION
This handles the case where a job went from no-deployment to deployment
with canaries.

Consider a case where a `max_parallel=0` job is submitted as version 0,
then an update is submitted with `max_parallel=1, canary=1` as verion 1.
In this case, we will have 1 canary alloc, and all remaining allocs will
be version 0.  Until the deployment is promoted, we ought to replace the
canaries with version 0 job (which isn't associated with a deployment).

Opening to get feedback and will submit tests soon.