### PR TITLE
e2e: minor TF refactor to split out vars and outputs

### DIFF
--- a/e2e/terraform/compute.tf
+++ b/e2e/terraform/compute.tf
@@ -73,3 +73,33 @@ resource "aws_instance" "client_windows" {
     delete_on_termination = "true"
   }
 }
+
+data "aws_ami" "linux" {
+  most_recent = true
+  owners      = ["self"]
+
+  filter {
+    name   = "name"
+    values = ["nomad-e2e-*"]
+  }
+
+  filter {
+    name   = "tag:OS"
+    values = ["Ubuntu"]
+  }
+}
+
+data "aws_ami" "windows" {
+  most_recent = true
+  owners      = ["self"]
+
+  filter {
+    name   = "name"
+    values = ["nomad-e2e-windows-2016*"]
+  }
+
+  filter {
+    name   = "tag:OS"
+    values = ["Windows2016"]
+  }
+}

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -1,63 +1,3 @@
-variable "name" {
-  description = "Used to name various infrastructure components"
-  default     = "nomad-e2e"
-}
-
-variable "region" {
-  description = "The AWS region to deploy to."
-  default     = "us-east-1"
-}
-
-variable "availability_zone" {
-  description = "The AWS availability zone to deploy to."
-  default     = "us-east-1a"
-}
-
-variable "indexed" {
-  description = "Different configurations per client/server"
-  default     = true
-}
-
-variable "instance_type" {
-  description = "The AWS instance type to use for both clients and servers."
-  default     = "t2.medium"
-}
-
-variable "server_count" {
-  description = "The number of servers to provision."
-  default     = "3"
-}
-
-variable "client_count" {
-  description = "The number of clients to provision."
-  default     = "4"
-}
-
-variable "windows_client_count" {
-  description = "The number of windows clients to provision."
-  default     = "1"
-}
-
-variable "nomad_sha" {
-  description = "The sha of Nomad to write to provisioning output"
-  default     = ""
-}
-
-variable "aws_assume_role_arn" {
-  description = "The AWS IAM role to assume (not used by human users)"
-  default     = ""
-}
-
-variable "aws_assume_role_session_name" {
-  description = "The AWS IAM session name to assume (not used by human users)"
-  default     = ""
-}
-
-variable "aws_assume_role_external_id" {
-  description = "The AWS IAM external ID to assume (not used by human users)"
-  default     = ""
-}
-
 provider "aws" {
   region = var.region
 
@@ -66,6 +6,9 @@ provider "aws" {
     session_name = var.aws_assume_role_session_name
     external_id  = var.aws_assume_role_external_id
   }
+}
+
+data "aws_caller_identity" "current" {
 }
 
 resource "random_pet" "e2e" {
@@ -87,80 +30,4 @@ module "keys" {
   path    = "${path.root}/keys"
   source  = "mitchellh/dynamic-keys/aws"
   version = "v2.0.0"
-}
-
-data "aws_ami" "linux" {
-  most_recent = true
-  owners      = ["self"]
-
-  filter {
-    name   = "name"
-    values = ["nomad-e2e-*"]
-  }
-
-  filter {
-    name   = "tag:OS"
-    values = ["Ubuntu"]
-  }
-}
-
-data "aws_ami" "windows" {
-  most_recent = true
-  owners      = ["self"]
-
-  filter {
-    name   = "name"
-    values = ["nomad-e2e-windows-2016*"]
-  }
-
-  filter {
-    name   = "tag:OS"
-    values = ["Windows2016"]
-  }
-}
-
-data "aws_caller_identity" "current" {
-}
-
-output "servers" {
-  value = aws_instance.server.*.public_ip
-}
-
-output "linux_clients" {
-  value = aws_instance.client_linux.*.public_ip
-}
-
-output "windows_clients" {
-  value = aws_instance.client_windows.*.public_ip
-}
-
-output "message" {
-  value = <<EOM
-Your cluster has been provisioned! - To prepare your environment, run the
-following:
-
-```
-export NOMAD_ADDR=http://${aws_instance.server[0].public_ip}:4646
-export CONSUL_HTTP_ADDR=http://${aws_instance.server[0].public_ip}:8500
-export NOMAD_E2E=1
-```
-
-Then you can run e2e tests with:
-
-```
-go test -v ./e2e
-```
-
-ssh into nodes with:
-```
-# server
-ssh -i keys/${local.random_name}.pem ubuntu@${aws_instance.server[0].public_ip}
-
-# clients
-%{for ip in aws_instance.client_linux.*.public_ip~}
-ssh -i keys/${local.random_name}.pem ubuntu@${ip}
-%{endfor~}
-```
-EOM
-
 }

--- a/e2e/terraform/outputs.tf
+++ b/e2e/terraform/outputs.tf
@@ -1,0 +1,43 @@
+output "servers" {
+  value = aws_instance.server.*.public_ip
+}
+
+output "linux_clients" {
+  value = aws_instance.client_linux.*.public_ip
+}
+
+output "windows_clients" {
+  value = aws_instance.client_windows.*.public_ip
+}
+
+output "message" {
+  value = <<EOM
+Your cluster has been provisioned! To prepare your environment, run:
+
+   $(terraform output environment)
+
+Then you can run tests from the e2e directory with:
+
+   go test -v .
+
+ssh into servers with:
+
+   ssh -i keys/${local.random_name}.pem ubuntu@${aws_instance.server[0].public_ip}
+
+ssh into clients with:
+
+%{for ip in aws_instance.client_linux.*.public_ip~}
+    ssh -i keys/${local.random_name}.pem ubuntu@${ip}
+%{endfor~}
+
+EOM
+}
+
+output "environment" {
+  description = "get connection config by running: $(terraform output environment)"
+  value = <<EOM
+export NOMAD_ADDR=http://${aws_instance.server[0].public_ip}:4646
+export CONSUL_HTTP_ADDR=http://${aws_instance.server[0].public_ip}:8500
+export NOMAD_E2E=1
+EOM
+}

--- a/e2e/terraform/provisioning.tf
+++ b/e2e/terraform/provisioning.tf
@@ -1,14 +1,5 @@
 # outputs used for E2E testing and provisioning
 
-output "environment" {
-  description = "get connection config by running: $(terraform output environment)"
-  value       = <<EOM
-export NOMAD_ADDR=http://${aws_instance.server[0].public_ip}:4646
-export CONSUL_HTTP_ADDR=http://${aws_instance.server[0].public_ip}:8500
-export NOMAD_E2E=1
-EOM
-}
-
 output "provisioning" {
   description = "output to a file to be use w/ E2E framework -provision.terraform"
   value = jsonencode(

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -1,0 +1,59 @@
+variable "name" {
+  description = "Used to name various infrastructure components"
+  default     = "nomad-e2e"
+}
+
+variable "region" {
+  description = "The AWS region to deploy to."
+  default     = "us-east-1"
+}
+
+variable "availability_zone" {
+  description = "The AWS availability zone to deploy to."
+  default     = "us-east-1a"
+}
+
+variable "indexed" {
+  description = "Different configurations per client/server"
+  default     = true
+}
+
+variable "instance_type" {
+  description = "The AWS instance type to use for both clients and servers."
+  default     = "t2.medium"
+}
+
+variable "server_count" {
+  description = "The number of servers to provision."
+  default     = "3"
+}
+
+variable "client_count" {
+  description = "The number of clients to provision."
+  default     = "4"
+}
+
+variable "windows_client_count" {
+  description = "The number of windows clients to provision."
+  default     = "1"
+}
+
+variable "nomad_sha" {
+  description = "The sha of Nomad to write to provisioning output"
+  default     = ""
+}
+
+variable "aws_assume_role_arn" {
+  description = "The AWS IAM role to assume (not used by human users)"
+  default     = ""
+}
+
+variable "aws_assume_role_session_name" {
+  description = "The AWS IAM session name to assume (not used by human users)"
+  default     = ""
+}
+
+variable "aws_assume_role_external_id" {
+  description = "The AWS IAM external ID to assume (not used by human users)"
+  default     = ""
+}


### PR DESCRIPTION
We currently have a jumble of `data`, `output`, `resource`, and `variable` all in the `main.tf` file. Pull these out so there where folks expect them to be (especially because we're about to add a bunch more variables). This has also been pulled out of #8748 to reduce that changeset.