### PR TITLE
UI: Add exec heartbeat keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 
  * api: Added node purge SDK functionality. [[GH-8142](https://github.com/hashicorp/nomad/issues/8142)]
  * driver/docker: Allow configurable image pull context timeout setting. [[GH-5718](https://github.com/hashicorp/nomad/issues/5718)]
+ * ui: Added exec keepalive heartbeat. [[GH-8759](https://github.com/hashicorp/nomad/pull/8759)]
 
 BUG FIXES:
 


### PR DESCRIPTION
This closes #8727, thanks to @jfcantu for the suggestion.

The CLI implementation of exec already has a 10-second
heartbeat so this mirrors that:
https://github.com/hashicorp/nomad/blob/v0.12.3/api/allocations.go#L161-L173

Here’s a GIF showing the `{}` message being sent after 10 seconds:
![exec-heartbeat](https://user-images.githubusercontent.com/43280/91469664-47a5c100-e859-11ea-8f18-f5dadddceb75.gif)
