### PR TITLE
consul/connect: make use of task kind to determine service name in consul token checks

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4230,25 +4230,24 @@ func (j *Job) VaultPolicies() map[string]map[string]*Vault {
 	return policies
 }
 
-// Connect tasks returns the set of Consul Connect enabled tasks that will
-// require a Service Identity token, if Consul ACLs are enabled.
+// ConnectTasks returns the set of Consul Connect enabled tasks defined on the
+// job that will require a Service Identity token in the case that Consul ACLs
+// are enabled. The TaskKind.Value is the name of the Consul service.
 //
 // This method is meaningful only after the Job has passed through the job
 // submission Mutator functions.
-//
-// task group -> []task
-func (j *Job) ConnectTasks() map[string][]string {
-	m := make(map[string][]string)
+func (j *Job) ConnectTasks() []TaskKind {
+	var kinds []TaskKind
 	for _, tg := range j.TaskGroups {
 		for _, task := range tg.Tasks {
 			if task.Kind.IsConnectProxy() ||
 				task.Kind.IsConnectNative() ||
 				task.Kind.IsAnyConnectGateway() {
-				m[tg.Name] = append(m[tg.Name], task.Name)
+				kinds = append(kinds, task.Kind)
 			}
 		}
 	}
-	return m
+	return kinds
 }
 
 // ConfigEntries accumulates the Consul Configuration Entries defined in task groups

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -608,9 +608,6 @@ func TestJob_ConnectTasks(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)
 
-	// todo(shoenig): this will need some updates when we support connect native
-	//  tasks, which will have a different Kind format, probably.
-
 	j0 := &Job{
 		TaskGroups: []*TaskGroup{{
 			Name: "tg1",
@@ -633,15 +630,35 @@ func TestJob_ConnectTasks(t *testing.T) {
 				Name: "connect-proxy-task2",
 				Kind: "connect-proxy:task2",
 			}},
+		}, {
+			Name: "tg3",
+			Tasks: []*Task{{
+				Name: "ingress",
+				Kind: "connect-ingress:ingress",
+			}},
+		}, {
+			Name: "tg4",
+			Tasks: []*Task{{
+				Name: "frontend",
+				Kind: "connect-native:uuid-fe",
+			}, {
+				Name: "generator",
+				Kind: "connect-native:uuid-api",
+			}},
 		}},
 	}
 
 	connectTasks := j0.ConnectTasks()
 
-	exp := map[string][]string{
-		"tg1": {"connect-proxy-task1", "connect-proxy-task3"},
-		"tg2": {"connect-proxy-task2"},
+	exp := []TaskKind{
+		NewTaskKind(ConnectProxyPrefix, "task1"),
+		NewTaskKind(ConnectProxyPrefix, "task3"),
+		NewTaskKind(ConnectProxyPrefix, "task2"),
+		NewTaskKind(ConnectIngressPrefix, "ingress"),
+		NewTaskKind(ConnectNativePrefix, "uuid-fe"),
+		NewTaskKind(ConnectNativePrefix, "uuid-api"),
 	}
+
 	r.Equal(exp, connectTasks)
 }
 


### PR DESCRIPTION
When `consul.allow_unauthenticated` is set to false, the job_endpoint hook validates
that a `-consul-token` is provided and validates the token against the privileges
inherent to a Consul Service Identity policy for all the Connect enabled services
defined in the job.

Before, the check was assuming the service was of type `connect-sidecar`. This fixes the
check to use the `TaskKind` of the task so we can distinguish between the different connect
types.