### PR TITLE
structs: filter NomadTokenID from job diff

### DIFF
--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -61,7 +61,7 @@ func (j *Job) Diff(other *Job, contextual bool) (*JobDiff, error) {
 	diff := &JobDiff{Type: DiffTypeNone}
 	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
 	filter := []string{"ID", "Status", "StatusDescription", "Version", "Stable", "CreateIndex",
-		"ModifyIndex", "JobModifyIndex", "Update", "SubmitTime"}
+		"ModifyIndex", "JobModifyIndex", "Update", "SubmitTime", "NomadTokenID"}
 
 	if j == nil && other == nil {
 		return diff, nil

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -1185,6 +1185,7 @@ func TestJobDiff(t *testing.T) {
 		{
 			// Multiregion: region added
 			Old: &Job{
+				NomadTokenID: "abcdef",
 				Multiregion: &Multiregion{
 					Strategy: &MultiregionStrategy{
 						MaxParallel: 1,
@@ -1202,6 +1203,7 @@ func TestJobDiff(t *testing.T) {
 			},
 
 			New: &Job{
+				NomadTokenID: "12345",
 				Multiregion: &Multiregion{
 					Strategy: &MultiregionStrategy{
 						MaxParallel: 2,


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8559

Multiregion deployments use the `NomadTokenID` to allow the deploymentwatcher
to send RPCs between regions with the original submitter's ACL token. This ID
should be filtered from diffs so that it doesn't cause a difference for
purposes of job plans.