### PR TITLE
Various Accessibility Improvements

### DIFF
--- a/website/components/features-list/index.jsx
+++ b/website/components/features-list/index.jsx
@@ -9,7 +9,7 @@ export default function FeaturesList({ title, items }) {
               <img src={icon} alt="" />
             </div>
             <div className="content">
-              <h4 className="g-type-display-4">{title}</h4>
+              <h3 className="g-type-display-4">{title}</h3>
               <p className="g-type-body-small">{content}</p>
             </div>
           </div>

--- a/website/components/features-list/index.jsx
+++ b/website/components/features-list/index.jsx
@@ -6,7 +6,7 @@ export default function FeaturesList({ title, items }) {
         {items.map(({ title, content, icon }) => (
           <div key={title} className="item">
             <div className="item-icon">
-              <img src={icon} alt={title} />
+              <img src={icon} alt="" />
             </div>
             <div className="content">
               <h4 className="g-type-display-4">{title}</h4>

--- a/website/components/learn-nomad/index.jsx
+++ b/website/components/learn-nomad/index.jsx
@@ -20,7 +20,7 @@ export default function LearnNomad({ items }) {
               />
             </div>
           </div>
-          {items.map(item => {
+          {items.map((item) => {
             return (
               <a
                 key={item.title}
@@ -31,7 +31,7 @@ export default function LearnNomad({ items }) {
                 <div className="course">
                   <div className="image">
                     <div className="g-type-label-strong time">{item.time}</div>
-                    <img src={item.image} alt={item.title} />
+                    <img src={item.image} alt="" />
                   </div>
                   <div className="content">
                     <div>

--- a/website/pages/_document.js
+++ b/website/pages/_document.js
@@ -9,7 +9,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <html>
+      <html lang="en-US">
         <HashiHead is={Head} />
         <body>
           <Main />
@@ -17,7 +17,7 @@ export default class MyDocument extends Document {
           <script
             noModule
             dangerouslySetInnerHTML={{
-              __html: `window.MSInputMethodContext && document.documentMode && document.write('<script src="/ie-custom-properties.js"><\\x2fscript>');`
+              __html: `window.MSInputMethodContext && document.documentMode && document.write('<script src="/ie-custom-properties.js"><\\x2fscript>');`,
             }}
           />
         </body>


### PR DESCRIPTION
This PR addresses multiple accessibility issues.

1. 🎟️ [Asana](https://app.asana.com/0/1190884011356649/1190884011356685/f) — This replaces the `alt` attribute on decorative images to remove a duplicative title that’s already visible beside it in a heading. ([see change](https://github.com/hashicorp/nomad/pull/8775/commits/9d349af17f672bc040dbe973f3e74e11f1a012e7))
2. 🎟️  [Asana](https://app.asana.com/0/1190884011356649/1190884011356687/f) — This changes the features list component from `<h2>` and `<h4>` headings to sequential `<h2>` and `<h3>` headings. The visual style of the newly `<h3>`’d headings, determined by their `g-type-display-4` class name, are not changed. ([see change](https://github.com/hashicorp/nomad/pull/8775/commits/4ae829129cb9cb27eeed78a26853eb11cced2759))
3. 🎟️ [Asana](https://app.asana.com/0/1190884011356649/1190884011356664/f) — This changes the root `<html>` tag to include a `lang="en-US"` attribute in order to help assistive technology such as screen readers pronounce content correctly. ([see change](https://github.com/hashicorp/nomad/pull/8775/commits/dc002e0b123a755085fa214bc134e544c1b9c52c))