### PR TITLE
Fix accidental broken Copy

### DIFF
--- a/nomad/job_endpoint_hook_expose_check_test.go
+++ b/nomad/job_endpoint_hook_expose_check_test.go
@@ -139,11 +139,11 @@ func TestJobExposeCheckHook_tgValidateUseOfCheckExpose(t *testing.T) {
 	})
 
 	t.Run("group-service uses custom proxy but no expose", func(t *testing.T) {
-		withCustomProxyTaskNoExpose := &(*withCustomProxyTask)
+		withCustomProxyTaskNoExpose := *withCustomProxyTask
 		withCustomProxyTask.Checks[0].Expose = false
 		require.Nil(t, tgValidateUseOfCheckExpose(&structs.TaskGroup{
 			Name:     "g1",
-			Services: []*structs.Service{withCustomProxyTaskNoExpose},
+			Services: []*structs.Service{&withCustomProxyTaskNoExpose},
 		}))
 	})
 

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/nomad/helper"
 )
 
 // CSISocketName is the filename that Nomad expects plugins to create inside the
@@ -152,7 +154,10 @@ func (o *CSIMountOptions) Copy() *CSIMountOptions {
 	if o == nil {
 		return nil
 	}
-	return &(*o)
+
+	no := *o
+	no.MountFlags = helper.CopySliceString(o.MountFlags)
+	return &no
 }
 
 func (o *CSIMountOptions) Merge(p *CSIMountOptions) {

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -100,11 +100,9 @@ func (v *VolumeRequest) Copy() *VolumeRequest {
 	nv := new(VolumeRequest)
 	*nv = *v
 
-	if v.MountOptions == nil {
-		return nv
+	if v.MountOptions != nil {
+		nv.MountOptions = v.MountOptions.Copy()
 	}
-
-	nv.MountOptions = &(*v.MountOptions)
 
 	return nv
 }


### PR DESCRIPTION
Fix CSIMountOptions.Copy() and VolumeRequest.Copy() where they
accidentally returned a reference to self rather than a deep copy.

`&(*ref)` in Golang apparently equivalent to plain `&ref`. The problem can be seen in https://play.golang.org/p/6xyqSSlz9Y1 .
