### PR TITLE
Fix cmd.Name() for NodeEligibilityCommand

### DIFF
--- a/command/node_eligibility.go
+++ b/command/node_eligibility.go
@@ -69,7 +69,7 @@ func (c *NodeEligibilityCommand) AutocompleteArgs() complete.Predictor {
 	})
 }
 
-func (c *NodeEligibilityCommand) Name() string { return "node-eligibility" }
+func (c *NodeEligibilityCommand) Name() string { return "node eligibility" }
 
 func (c *NodeEligibilityCommand) Run(args []string) int {
 	var enable, disable, self bool


### PR DESCRIPTION
First up, my apologies if this isn't really as vetted as it should be. I'm not entirely certain that this affects its use as called from `c.Meta.FlagSet` within the same file. What I do know and can tell is that this same string is used for the help output... which gives you misleading text:
```
# nomad node eligibility
Either the '-enable' or '-disable' flag must be set
For additional help try 'nomad node-eligibility -help'
#
```

It really should be `nomad node eligibility -help` instead.

I also see other `Name()` funcs for other commands that might need fixing, btw. If I can get some confirmation that all of the Name() funcs within `command/*.go` only affect help text, then I can go about fixing them.