### PR TITLE
testing: fixup file permissions in some tests

### DIFF
--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	sframer "github.com/hashicorp/nomad/client/lib/streamframer"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/fileperms"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad"
@@ -1854,7 +1855,7 @@ func TestFS_logsImpl_NoFollow(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		logFile := fmt.Sprintf("%s.%s.%d", task, logType, i)
 		logFilePath := filepath.Join(logDir, logFile)
-		err := ioutil.WriteFile(logFilePath, expected[i:i+1], 777)
+		err := ioutil.WriteFile(logFilePath, expected[i:i+1], fileperms.Oct777)
 		if err != nil {
 			t.Fatalf("Failed to create file: %v", err)
 		}
@@ -1911,7 +1912,7 @@ func TestFS_logsImpl_Follow(t *testing.T) {
 	defer os.RemoveAll(ad.AllocDir)
 
 	logDir := filepath.Join(ad.SharedDir, allocdir.LogDirName)
-	if err := os.MkdirAll(logDir, 0777); err != nil {
+	if err := os.MkdirAll(logDir, fileperms.Oct777); err != nil {
 		t.Fatalf("Failed to make log dir: %v", err)
 	}
 
@@ -1924,7 +1925,7 @@ func TestFS_logsImpl_Follow(t *testing.T) {
 	writeToFile := func(index int, data []byte) {
 		logFile := fmt.Sprintf("%s.%s.%d", task, logType, index)
 		logFilePath := filepath.Join(logDir, logFile)
-		err := ioutil.WriteFile(logFilePath, data, 777)
+		err := ioutil.WriteFile(logFilePath, data, fileperms.Oct777)
 		if err != nil {
 			t.Fatalf("Failed to create file: %v", err)
 		}

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	ctestutils "github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/fileperms"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/testtask"
@@ -601,7 +602,7 @@ func TestExecDriver_DevicesAndMounts(t *testing.T) {
 	require.NoError(err)
 	defer os.RemoveAll(tmpDir)
 
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("from-host"), 600)
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("from-host"), fileperms.Oct600)
 	require.NoError(err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -637,8 +638,8 @@ func TestExecDriver_DevicesAndMounts(t *testing.T) {
 		},
 	}
 
-	require.NoError(ioutil.WriteFile(task.StdoutPath, []byte{}, 660))
-	require.NoError(ioutil.WriteFile(task.StderrPath, []byte{}, 660))
+	require.NoError(ioutil.WriteFile(task.StdoutPath, []byte{}, fileperms.Oct660))
+	require.NoError(ioutil.WriteFile(task.StderrPath, []byte{}, fileperms.Oct660))
 
 	tc := &TaskConfig{
 		Command: "/bin/bash",

--- a/e2e/execagent/execagent.go
+++ b/e2e/execagent/execagent.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/helper/fileperms"
 )
 
 type AgentMode int
@@ -123,7 +124,7 @@ type NomadAgent struct {
 // NewMixedAgent creates a new Nomad agent in mixed server+client mode but does
 // not start the agent process until the Start() method is called.
 func NewMixedAgent(bin string) (*NomadAgent, error) {
-	if err := os.MkdirAll(BaseDir, 755); err != nil {
+	if err := os.MkdirAll(BaseDir, fileperms.Oct755); err != nil {
 		return nil, err
 	}
 	dir, err := ioutil.TempDir(BaseDir, "agent")
@@ -157,7 +158,7 @@ func NewMixedAgent(bin string) (*NomadAgent, error) {
 func NewClientServerPair(bin string, serverOut, clientOut io.Writer) (
 	server *NomadAgent, client *NomadAgent, err error) {
 
-	if err := os.MkdirAll(BaseDir, 755); err != nil {
+	if err := os.MkdirAll(BaseDir, fileperms.Oct755); err != nil {
 		return nil, nil, err
 	}
 

--- a/e2e/vault/vault_test.go
+++ b/e2e/vault/vault_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/fileperms"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
 	vapi "github.com/hashicorp/vault/api"
@@ -220,11 +221,8 @@ func createBinDir(binDir string) error {
 	}
 
 	// Create the directory
-	if err := os.Mkdir(binDir, 075); err != nil {
+	if err := os.Mkdir(binDir, fileperms.Oct755); err != nil {
 		return fmt.Errorf("failed to make directory: %v", err)
-	}
-	if err := os.Chmod(binDir, 0755); err != nil {
-		return fmt.Errorf("failed to chmod: %v", err)
 	}
 
 	return nil
@@ -280,7 +278,7 @@ func getVault(dst, url string) error {
 	}
 
 	// Copy the file to its destination
-	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0777)
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_EXCL, fileperms.Oct777)
 	if err != nil {
 		return err
 	}

--- a/helper/fileperms/fileperms.go
+++ b/helper/fileperms/fileperms.go
@@ -1,0 +1,71 @@
+package fileperms
+
+import (
+	"fmt"
+	"os"
+)
+
+// mode represents a simplified octal representation of a Unix file permissions
+// mode interface provided by os.FileMode.
+//
+// This package is intended to prevent accidental incorrect file permissions caused
+// by erroneous octal representations of permissions bits in Go's decimal base. A
+// linter can be configured to assert calls to functions such as os.OpenFile,
+// os.Chmod, os.File.Chmod, etc. are passing a parameter of type fileperms.mode.
+// Anything else will be flagged and must be changed. By not exporting the mode
+// type, getting past the linter means funneling through one of the exported const
+// values in this package.
+//
+// For example, the code `os.Chmod(755)` produces file permissions "-wxrw--wt",
+// whereas the intended octal form `os.Chmod(0755)` produces "rwxr-xr-x".
+type mode = os.FileMode
+
+// 0) no permission
+// 1) execute
+// 2) write
+// 3) execute + write
+// 4) read
+// 5) read + execute
+// 6) read + write
+// 7) read + write + execute
+const (
+	Oct555 mode = 0555
+	Oct600 mode = 0600
+	Oct610 mode = 0610
+	Oct655 mode = 0655
+	Oct660 mode = 0660
+	Oct666 mode = 0666
+	Oct755 mode = 0755
+	Oct777 mode = 0777
+)
+
+// Reduce returns the lowered permissions of m by the mask.
+func Reduce(m, mask mode) mode {
+	return m & mask
+}
+
+// Escalate returns the raised permissions of m by the mask.
+func Escalate(m, mask mode) mode {
+	return m | mask
+}
+
+// Sufficient returns true if m is at least as permissive as the mask.
+func Sufficient(m, mask mode) bool {
+	return Reduce(m, mask) == mask
+}
+
+// Check returns true if the os.FileMode permission bits of f match the
+// expected permissions in exp.
+func Check(f *os.File, exp mode) error {
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	perm := info.Mode().Perm()
+	if perm != exp {
+		return fmt.Errorf("file mode expected %o, got %o", exp, perm)
+	}
+
+	return nil
+}

--- a/helper/fileperms/fileperms_test.go
+++ b/helper/fileperms/fileperms_test.go
@@ -1,0 +1,36 @@
+package fileperms
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Check(t *testing.T) {
+	f, err := ioutil.TempFile("", "fileperms")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, f.Close())
+		require.NoError(t, os.RemoveAll(f.Name()))
+	})
+
+	t.Run("matches", func(t *testing.T) {
+		err := Check(f, Oct600)
+		require.NoError(t, err)
+	})
+
+	t.Run("mismatches", func(t *testing.T) {
+		err := Check(f, Oct777)
+		require.EqualError(t, err, "file mode expected 777, got 600")
+	})
+
+	t.Run("chmod", func(t *testing.T) {
+		err := os.Chmod(f.Name(), Oct655)
+		require.NoError(t, err)
+		err = Check(f, Oct655)
+		require.NoError(t, err)
+	})
+}

--- a/helper/testtask/testtask.go
+++ b/helper/testtask/testtask.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/hashicorp/nomad/helper/fileperms"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
@@ -110,7 +111,7 @@ func execute() {
 			}
 			msg := popArg()
 			file := popArg()
-			ioutil.WriteFile(file, []byte(msg), 0666)
+			ioutil.WriteFile(file, []byte(msg), fileperms.Oct666)
 
 		case "pgrp":
 			if len(args) < 1 {
@@ -135,7 +136,7 @@ func execute() {
 				os.Exit(1)
 			}
 
-			if err := ioutil.WriteFile(pidFile, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 777); err != nil {
+			if err := ioutil.WriteFile(pidFile, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), fileperms.Oct777); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to write pid file: %v\n", err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
Some of our tests make use of decimal numbers to indicate file modes
which result in erroneous permissions. Instead of just correcting these
values to be declared in octal, introduce a new helper class for managing
const values representing filemodes. Starting with these broken tests,
we can migrate the codebase to using the exported const values from the
new package - enabling a future linter to validate the parameters being
passed anywhere an os.FileMode would be used (os.Chmod, os.Mkdir, etc.).

For now, just fix the tests using the proposed new package.