### PR TITLE
run commands for duration and interval without needing to specify server or node

### DIFF
--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -267,10 +267,8 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 
 	c.Ui.Output("Starting debugger and capturing cluster data...")
 
-	if len(c.nodeIDs) > 0 || len(c.serverIDs) > 0 {
-		c.Ui.Output(fmt.Sprintf("    Interval: '%s'", interval))
-		c.Ui.Output(fmt.Sprintf("    Duration: '%s'", duration))
-	}
+	c.Ui.Output(fmt.Sprintf("    Interval: '%s'", interval))
+	c.Ui.Output(fmt.Sprintf("    Duration: '%s'", duration))
 
 	// Create the output path
 	var tmp string
@@ -505,13 +503,6 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client)
 // collectPeriodic runs for duration, capturing the cluster state every interval. It flushes and stops
 // the monitor requests
 func (c *OperatorDebugCommand) collectPeriodic(client *api.Client) {
-	// Not monitoring any logs, just capture the nomad context before exit
-	if len(c.nodeIDs) == 0 && len(c.serverIDs) == 0 {
-		dir := filepath.Join("nomad", "0000")
-		c.collectNomad(dir, client)
-		return
-	}
-
 	duration := time.After(c.duration)
 	// Set interval to 0 so that we immediately execute, wait the interval next time
 	interval := time.After(0 * time.Second)


### PR DESCRIPTION
I wasn't sure why a set of Nodes or servers were required to run on interval or duration, so removing those checks

This allows to just run ` nomad operator debug -interval=5s -duration=10s -output=test` with default api address settings