### PR TITLE
fix params for Agent.Host client RPC

### DIFF
--- a/client/agent_endpoint.go
+++ b/client/agent_endpoint.go
@@ -213,7 +213,7 @@ OUTER:
 }
 
 // Host collects data about the host evironment running the agent
-func (a *Agent) Host(args *structs.QueryOptions, reply *structs.HostDataResponse) error {
+func (a *Agent) Host(args *structs.HostDataRequest, reply *structs.HostDataResponse) error {
 	aclObj, err := a.c.ResolveToken(args.AuthToken)
 	if err != nil {
 		return err

--- a/client/agent_endpoint_test.go
+++ b/client/agent_endpoint_test.go
@@ -369,7 +369,7 @@ func TestAgentHost(t *testing.T) {
 	})
 	defer cleanupC()
 
-	req := structs.QueryOptions{}
+	req := structs.HostDataRequest{}
 	var resp structs.HostDataResponse
 
 	err := c.ClientRPC("Agent.Host", &req, &resp)
@@ -420,8 +420,10 @@ func TestAgentHost_ACL(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := structs.QueryOptions{
-				AuthToken: tc.Token,
+			req := structs.HostDataRequest{
+				QueryOptions: structs.QueryOptions{
+					AuthToken: tc.Token,
+				},
 			}
 			var resp structs.HostDataResponse
 


### PR DESCRIPTION
The parameters for the receiving side of the `Agent.Host` client RPC did not
take the arguments serialized at the server side. This results in a panic.