### PR TITLE
Fix escapingio handling of `\n~\n`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES:
  * csi: Fixed a bug where querying CSI volumes would cause a panic if an allocation that claimed the volume had been garbage collected but the claim was not yet dropped. [[GH-8735](https://github.com/hashicorp/nomad/issues/8735)]
  * deployments (Enterprise): Fixed a bug where counts could not be changed in the web UI for multiregion jobs. [[GH-8685](https://github.com/hashicorp/nomad/issues/8685)]
  * deployments (Enterprise): Fixed a bug in multi-region deployments where a region that was dropped from the jobspec was not deregistered. [[GH-8763](https://github.com/hashicorp/nomad/issues/8763)]
+ * exec: Fixed a bug causing escape characters to be missed in special cases [[GH-8798](https://github.com/hashicorp/nomad/issues/8798)]
  * plan: Fixed a bug where plans always included a change for the `NomadTokenID`. [[GH-8559](https://github.com/hashicorp/nomad/issues/8559)]
 
 ## 0.12.3 (August 13, 2020)

--- a/helper/escapingio/reader.go
+++ b/helper/escapingio/reader.go
@@ -93,6 +93,9 @@ func (r *reader) pipe() {
 						bw.WriteByte(r.escapeChar)
 						bw.WriteByte(rb[0])
 						bw.Flush()
+						if rb[0] == '\n' || rb[0] == '\r' {
+							state = sLookEscapeChar
+						}
 					}
 				}
 			}
@@ -137,6 +140,10 @@ START:
 			bw.Write(buf[wi:i])
 			i = i + 2
 			wi = i
+		} else if nc == '\n' || nc == '\r' {
+			i = i + 2
+			s = sLookEscapeChar
+			goto START
 		} else {
 			i = i + 2
 			// need to write everything keep going

--- a/helper/escapingio/reader_test.go
+++ b/helper/escapingio/reader_test.go
@@ -42,6 +42,7 @@ func TestEscapingReader_Static(t *testing.T) {
 		{"\n~.", "\n", "."},
 		{"~", "~", ""},
 		{"\r~.", "\r", "."},
+		{"b\n~\n~.q", "b\n~\nq", "."},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
The escapingio reader detects new lines followed by an escaping char `\n~`, but apparently if the escape char is followed by another new line, the reader ignores this read line and looks for another new line.  This results into the reader not handling `\n~\n~.` .

This PR fixes the bug, by ensuring that if `\n` follows a `~`, we emit the text and set parser state to `sLookEscapeChar`.

The TestEscapingReader_Static fails in the first commit in 
 https://app.circleci.com/pipelines/github/hashicorp/nomad/11526/workflows/c6193ea7-18a9-439c-8f93-6810845ce224/jobs/96780/tests but succeeds after applying the logic change.

Fixes a bug in https://github.com/hashicorp/nomad/issues/8736 .