### PR TITLE
UI: Temporarily remove poststop from the lifecycle chart

### DIFF
--- a/ui/app/components/lifecycle-chart.js
+++ b/ui/app/components/lifecycle-chart.js
@@ -47,11 +47,6 @@ export default class LifecycleChart extends Component {
       phases.push({
         name: 'Poststart',
       });
-
-      phases.push({
-        name: 'Poststop',
-        isActive: lifecycles.poststops.some(stateActiveIterator),
-      });
     }
 
     return phases;

--- a/ui/app/styles/components/lifecycle-chart.scss
+++ b/ui/app/styles/components/lifecycle-chart.scss
@@ -33,7 +33,6 @@
     position: absolute;
     bottom: 0;
     top: 0;
-
     border-top: 2px solid transparent;
 
     .name {
@@ -59,12 +58,12 @@
 
     &.main {
       left: 25%;
-      right: 25%;
+      right: 0;
     }
 
     &.poststart {
-      left: 35%;
-      right: 25%;
+      left: 40%;
+      right: 0;
     }
 
     &.poststop {
@@ -127,28 +126,20 @@
 
     &.main {
       margin-left: 25%;
-      margin-right: 25%;
+      margin-right: 0;
     }
 
     &.prestart-ephemeral {
       margin-right: 75%;
     }
 
-    &.prestart-sidecar {
-      margin-right: 25%;
-    }
-
     &.poststart-ephemeral,
     &.poststart-sidecar {
-      margin-left: 35%;
-    }
-
-    &.poststart-sidecar {
-      margin-right: 25%;
+      margin-left: 40%;
     }
 
     &.poststart-ephemeral {
-      margin-right: 35%;
+      margin-right: 10%;
     }
 
     &.poststop {

--- a/ui/app/templates/components/lifecycle-chart.hbs
+++ b/ui/app/templates/components/lifecycle-chart.hbs
@@ -14,9 +14,6 @@
           <svg class="divider prestart">
             <line x1="0" y1="0" x2="0" y2="100%" />
           </svg>
-          <svg class="divider poststop">
-            <line x1="0" y1="0" x2="0" y2="100%" />
-          </svg>
         </div>
 
         <div class="lifecycle-chart-rows">

--- a/ui/mirage/factories/task.js
+++ b/ui/mirage/factories/task.js
@@ -19,7 +19,7 @@ export default Factory.extend({
   Resources: generateResources,
 
   Lifecycle: i => {
-    const cycle = i % 6;
+    const cycle = i % 5;
 
     if (cycle === 0) {
       return null;
@@ -31,8 +31,6 @@ export default Factory.extend({
       return { Hook: 'poststart', Sidecar: false };
     } else if (cycle === 4) {
       return { Hook: 'poststart', Sidecar: true };
-    } else if (cycle === 5) {
-      return { Hook: 'poststop' };
     }
   },
 });

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -96,13 +96,14 @@ module('Acceptance | allocation detail', function(hooks) {
 
     assert.ok(Allocation.lifecycleChart.isPresent);
     assert.equal(Allocation.lifecycleChart.title, 'Task Lifecycle Status');
-    assert.equal(Allocation.lifecycleChart.phases.length, 4);
+    assert.equal(Allocation.lifecycleChart.phases.length, 3);
     assert.equal(Allocation.lifecycleChart.tasks.length, 6);
 
     await Allocation.lifecycleChart.tasks[0].visit();
 
     const prestartEphemeralTask = server.db.taskStates
       .where({ allocationId: allocation.id })
+      .sortBy('name')
       .find(taskState => {
         const task = server.db.tasks.findBy({ name: taskState.name });
         return task.Lifecycle && task.Lifecycle.Hook === 'prestart' && !task.Lifecycle.Sidecar;

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -37,8 +37,13 @@ module('Acceptance | task detail', function(hooks) {
     );
 
     const lifecycle = server.db.tasks.where({ name: task.name })[0].Lifecycle;
-    const prestartString = lifecycle && lifecycle.Sidecar ? 'sidecar' : 'prestart';
-    assert.equal(Task.lifecycle, lifecycle ? prestartString : 'main');
+
+    let lifecycleName = 'main';
+    if (lifecycle && (lifecycle.Hook === 'prestart' || lifecycle.Hook === 'poststart')) {
+      lifecycleName = `${lifecycle.Hook}-${lifecycle.Sidecar ? 'sidecar' : 'ephemeral'}`;
+    }
+
+    assert.equal(Task.lifecycle, lifecycleName);
 
     assert.equal(document.title, `Task ${task.name} - Nomad`);
   });

--- a/ui/tests/integration/components/lifecycle-chart-test.js
+++ b/ui/tests/integration/components/lifecycle-chart-test.js
@@ -34,10 +34,6 @@ const tasks = [
     lifecycleName: 'poststart-sidecar',
     name: 'poststart sidecar: 4',
   },
-  {
-    lifecycleName: 'poststop',
-    name: 'poststop: 6',
-  },
 ];
 
 module('Integration | Component | lifecycle-chart', function(hooks) {
@@ -52,7 +48,6 @@ module('Integration | Component | lifecycle-chart', function(hooks) {
     assert.equal(Chart.phases[0].name, 'Prestart');
     assert.equal(Chart.phases[1].name, 'Main');
     assert.equal(Chart.phases[2].name, 'Poststart');
-    assert.equal(Chart.phases[3].name, 'Poststop');
 
     Chart.phases.forEach(phase => assert.notOk(phase.isActive));
 
@@ -63,7 +58,6 @@ module('Integration | Component | lifecycle-chart', function(hooks) {
       'main two: 3',
       'poststart sidecar: 4',
       'poststart ephemeral: 5',
-      'poststop: 6',
     ]);
     assert.deepEqual(Chart.tasks.mapBy('lifecycle'), [
       'Prestart Task',
@@ -72,7 +66,6 @@ module('Integration | Component | lifecycle-chart', function(hooks) {
       'Main Task',
       'Sidecar Task',
       'Poststart Task',
-      'Poststop Task',
     ]);
 
     assert.ok(Chart.tasks[0].isPrestartEphemeral);
@@ -80,7 +73,6 @@ module('Integration | Component | lifecycle-chart', function(hooks) {
     assert.ok(Chart.tasks[2].isMain);
     assert.ok(Chart.tasks[4].isPoststartSidecar);
     assert.ok(Chart.tasks[5].isPoststartEphemeral);
-    assert.ok(Chart.tasks[6].isPoststop);
 
     Chart.tasks.forEach(task => {
       assert.notOk(task.isActive);
@@ -102,10 +94,10 @@ module('Integration | Component | lifecycle-chart', function(hooks) {
   });
 
   test('it renders all phases when there are any non-main tasks', async function(assert) {
-    this.set('tasks', [tasks[0], tasks[6]]);
+    this.set('tasks', [tasks[0], tasks[2]]);
 
     await render(hbs`<LifecycleChart @tasks={{tasks}} />`);
-    assert.ok(Chart.phases.length, 4);
+    assert.equal(Chart.phases.length, 3);
   });
 
   test('it reflects phase and task states when states are passed in', async function(assert) {
@@ -149,8 +141,8 @@ module('Integration | Component | lifecycle-chart', function(hooks) {
   [
     {
       testName: 'expected active phases',
-      runningTaskNames: ['prestart ephemeral', 'main one', 'poststop'],
-      activePhaseNames: ['Prestart', 'Main', 'Poststop'],
+      runningTaskNames: ['prestart ephemeral', 'main one'],
+      activePhaseNames: ['Prestart', 'Main'],
     },
     {
       testName: 'sidecar task states don’t affect phase active states',

--- a/ui/tests/pages/components/lifecycle-chart.js
+++ b/ui/tests/pages/components/lifecycle-chart.js
@@ -23,7 +23,6 @@ export default {
     isPrestartSidecar: hasClass('prestart-sidecar'),
     isPoststartEphemeral: hasClass('poststart-ephemeral'),
     isPoststartSidecar: hasClass('poststart-sidecar'),
-    isPoststop: hasClass('poststop'),
 
     visit: clickable('a'),
   }),


### PR DESCRIPTION
Since poststart and poststop are shipping separately, we can't ship them both in the UI at the same time.

![image](https://user-images.githubusercontent.com/174740/91876406-7e048700-ec31-11ea-9a62-62db357daec5.png)

While working on this I found a couple flaky tests too, so the revert of this will have to reimplement the test corrections.

1. Allocation detail acceptance test requires task states to be sorted by name in the event there are two prestart tasks
2. Task detail acceptance test needs to account for all lifecycle names
3. Lifecycle chart integration test has an `ok` where there should be an `equal` 
