### PR TITLE
docs: fix type for `local_service_port`

### DIFF
--- a/website/pages/docs/job-specification/proxy.mdx
+++ b/website/pages/docs/job-specification/proxy.mdx
@@ -53,7 +53,7 @@ job "countdash" {
 
 - `local_service_address` `(string: "127.0.0.1")` - The address the local service binds to. Useful to
   customize in clusters with mixed Connect and non-Connect services.
-- `local_service_port` `(int:[port][])` - The port the local service binds to.
+- `local_service_port` `(int: <varies>)` - The port the local service binds to.
   Usually the same as the parent service's port, it is useful to customize in clusters with mixed
   Connect and non-Connect services
 - `upstreams` <code>([upstreams][]: nil)</code> - Used to configure details of each upstream service that
@@ -87,5 +87,4 @@ sidecar_service {
 [interpolation]: /docs/runtime/interpolation 'Nomad interpolation'
 [sidecar_service]: /docs/job-specification/sidecar_service 'Nomad sidecar service Specification'
 [upstreams]: /docs/job-specification/upstreams 'Nomad upstream config Specification'
-[port]: /docs/job-specification/network#port-parameters 'Nomad network port configuration'
 [expose]: /docs/job-specification/expose 'Nomad proxy expose configuration'


### PR DESCRIPTION
Since the default value for `local_service_port` depends on the parent service, I used the same syntax `<varies>` syntax as [`reschedule.attempts`](https://www.nomadproject.io/docs/job-specification/reschedule#attempts).

Before:
<img width="374" alt="image" src="https://user-images.githubusercontent.com/775380/91913078-bd0ef880-ec82-11ea-908d-ebd5a378b6fd.png">

After
<img width="403" alt="image" src="https://user-images.githubusercontent.com/775380/91913058-b1bbcd00-ec82-11ea-90cf-27613008a375.png">
