### PR TITLE
docs: add download link to 0.12.4-rc1

### DIFF
--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -12,6 +12,11 @@ export default function DownloadsPage({ releaseData }) {
         version={VERSION}
         releaseData={releaseData}
         community="/resources"
+        prerelease={{
+          type: 'Release Candidate',
+          name: 'v0.12.4',
+          version: '0.12.4-rc1'
+        }}
       />
     </div>
   )


### PR DESCRIPTION
Based off of: https://github.com/hashicorp/nomad/blob/137a94fdd07a58269b3b78db2f99bff2011d0f04/website/pages/downloads/index.jsx#L16-L20