### PR TITLE
Fix multi-interface networking in the system scheduler

### DIFF
--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -349,6 +349,7 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 
 		if option.AllocResources != nil {
 			resources.Shared.Networks = option.AllocResources.Networks
+			resources.Shared.Ports = option.AllocResources.Ports
 		}
 
 		// Create an allocation for this


### PR DESCRIPTION
This was originally mentioned in https://github.com/hashicorp/nomad/pull/8208#discussion_r443067187, and purportedly fixed in #8230, but we noticed our system job appeared to bind on all interfaces instead of the specified `host_network`.

We noticed we were always evaluating to the first half of this conditional which didn't seem right:  https://github.com/hashicorp/nomad/blob/4ba3afa44b389aa1e29743e81a83b33598be95a9/client/allocrunner/networking_cni.go#L170

This is a proposed fix, it seems correct given previous discussion but we are new to Nomad internals.