### PR TITLE
e2e: minor rename and cleanup

### DIFF
--- a/e2e/framework/provisioning/deploy.go
+++ b/e2e/framework/provisioning/deploy.go
@@ -38,14 +38,14 @@ func deployLinux(t *testing.T, target *ProvisioningTarget) error {
 		}
 	} else if deployment.NomadSha != "" {
 		script := fmt.Sprintf(
-			`/opt/install-nomad --nomad_sha %s --nostart`, deployment.NomadSha)
+			`/opt/provision.sh --nomad_sha %s --nostart`, deployment.NomadSha)
 		err = runner.Run(script)
 		if err != nil {
 			return err
 		}
 	} else if deployment.NomadVersion != "" {
 		script := fmt.Sprintf(
-			`/opt/install-nomad --nomad_version %s --nostart`, deployment.NomadVersion)
+			`/opt/provision.sh --nomad_version %s --nostart`, deployment.NomadVersion)
 		err = runner.Run(script)
 		if err != nil {
 			return err
@@ -96,14 +96,14 @@ func deployWindows(t *testing.T, target *ProvisioningTarget) error {
 		}
 	} else if deployment.NomadSha != "" {
 		script := fmt.Sprintf(
-			`C:/opt/install-nomad.ps1 -nomad_sha %s -nostart`, deployment.NomadSha)
+			`C:/opt/provision.ps1 -nomad_sha %s -nostart`, deployment.NomadSha)
 		err = runner.Run(script)
 		if err != nil {
 			return err
 		}
 	} else if deployment.NomadVersion != "" {
 		script := fmt.Sprintf(
-			`C:/opt/install-nomad.ps1 -nomad_version %s -nostart`, deployment.NomadVersion)
+			`C:/opt/provision.ps1 -nomad_version %s -nostart`, deployment.NomadVersion)
 		err = runner.Run(script)
 		if err != nil {
 			return err

--- a/e2e/terraform/packer/linux/provision.sh
+++ b/e2e/terraform/packer/linux/provision.sh
@@ -6,7 +6,7 @@ set +x
 
 usage() {
     cat <<EOF
-Usage: install-nomad [options...]
+Usage: provision.sh [options...]
 Options (use one of the following):
  --nomad_sha SHA          full git sha to install from S3
  --nomad_version VERSION  release version number (ex. 0.12.3+ent)

--- a/e2e/terraform/packer/linux/setup.sh
+++ b/e2e/terraform/packer/linux/setup.sh
@@ -72,9 +72,9 @@ mkdir_for_root $NOMAD_PLUGIN_DIR
 sudo mv /tmp/linux/nomad.service /etc/systemd/system/nomad.service
 
 echo "Install Nomad"
-sudo mv /tmp/linux/install-nomad /opt/install-nomad
-sudo chmod +x /opt/install-nomad
-/opt/install-nomad --nomad_version $NOMADVERSION --nostart
+sudo mv /tmp/linux/provision.sh /opt/provision.sh
+sudo chmod +x /opt/provision.sh
+/opt/provision.sh --nomad_version $NOMADVERSION --nostart
 
 echo "Installing third-party apt repositories"
 

--- a/e2e/terraform/packer/packer-windows.json
+++ b/e2e/terraform/packer/packer-windows.json
@@ -38,7 +38,9 @@
         "windows/install-tools.ps1",
         "windows/install-docker.ps1",
         "windows/setup-directories.ps1",
-        "windows/install-openssh.ps1"
+        "windows/install-openssh.ps1",
+        "windows/install-consul.ps1",
+        "windows/install-vault.ps1"
       ]
     },
     {
@@ -46,23 +48,14 @@
     },
     {
       "type": "file",
-      "source": "./windows/install-nomad.ps1",
-      "destination": "/opt/install-nomad.ps1"
+      "source": "./windows/provision.ps1",
+      "destination": "/opt/provision.ps1"
     },
     {
       "type": "powershell",
       "elevated_user": "Administrator",
       "elevated_password": "{{.WinRMPassword}}",
-      "inline": ["/opt/install-nomad.ps1 -nomad_version 0.9.6 -nostart"]
-    },
-    {
-      "type": "powershell",
-      "elevated_user": "Administrator",
-      "elevated_password": "{{.WinRMPassword}}",
-      "scripts": [
-        "windows/install-consul.ps1",
-        "windows/install-vault.ps1"
-      ]
+      "inline": ["/opt/provision.ps1 -nomad_version 0.9.6 -nostart"]
     },
     {
       "type": "powershell",

--- a/e2e/terraform/packer/windows/install-consul.ps1
+++ b/e2e/terraform/packer/windows/install-consul.ps1
@@ -11,9 +11,8 @@ Try {
     $version = "1.7.3"
     $url = "${releases}/consul/${version}/consul_${version}_windows_amd64.zip"
 
-    $configDir = "C:\opt\consul.d"
-    md $configDir
-    md C:\opt\consul
+    New-Item -ItemType Directory -Force -Path C:\opt\consul
+    New-Item -ItemType Directory -Force -Path C:\opt\consul.d
 
     # TODO: check sha!
     Write-Output "Downloading Consul from: $url"

--- a/e2e/terraform/packer/windows/install-vault.ps1
+++ b/e2e/terraform/packer/windows/install-vault.ps1
@@ -11,8 +11,8 @@ Try {
     $version = "1.2.3"
     $url = "${releases}/vault/${version}/vault_${version}_windows_amd64.zip"
 
-    $configDir = "C:\opt\vault.d"
-    md $configDir
+    New-Item -ItemType Directory -Force -Path C:\opt\vault
+    New-Item -ItemType Directory -Force -Path C:\opt\vault.d
 
     # TODO: check sha!
     Write-Output "Downloading Vault from: $url"

--- a/e2e/terraform/packer/windows/provision.ps1
+++ b/e2e/terraform/packer/windows/provision.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = "Stop"
 
 
 $usage = @"
-Usage: install-nomad [options...]
+Usage: provision.ps1 [options...]
 Options (use one of the following):
  --nomad_sha SHA          full git sha to install from S3
  --nomad_version VERSION  release version number (ex. 0.12.3+ent)


### PR DESCRIPTION
Pulled out of https://github.com/hashicorp/nomad/pull/8748, where the single provisioning script will be responsible for everything including configuration of Consul and Vault, so leaving it as `install-nomad` was goofy but changing it balloons #8748 a bit because git isn't picking up the rename across multiple commits.