### PR TITLE
client/allocrunner/taskrunner: client.Close after err check

### DIFF
--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -260,10 +260,10 @@ func (h *csiPluginSupervisorHook) registerPlugin(socketPath string) (func(), err
 	// At this point we know the plugin is ready and we can fingerprint it
 	// to get its vendor name and version
 	client, err := csi.NewClient(socketPath, h.logger.Named("csi_client").With("plugin.name", h.task.CSIPluginConfig.ID, "plugin.type", h.task.CSIPluginConfig.Type))
-	defer client.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create csi client: %v", err)
 	}
+	defer client.Close()
 
 	info, err := client.PluginInfo()
 	if err != nil {


### PR DESCRIPTION
This moves `defer client.Close()` after the check for a non-nil `err` to prevent `Close()` from being called on a nil `CSIPlugin`.