### PR TITLE
fix: panic introduced by #8453

### DIFF
--- a/nomad/job_endpoint_oss.go
+++ b/nomad/job_endpoint_oss.go
@@ -11,8 +11,8 @@ import (
 	vapi "github.com/hashicorp/vault/api"
 )
 
-// MultipleNamespacesErr is send when multiple namespaces are used in the OSS setup
-var MultipleNamespacesErr = errors.New("multiple vault namespaces requires Nomad Enterprise")
+// ErrMultipleNamespaces is send when multiple namespaces are used in the OSS setup
+var ErrMultipleNamespaces = errors.New("multiple vault namespaces requires Nomad Enterprise")
 
 // enforceSubmitJob is used to check any Sentinel policies for the submit-job scope
 func (j *Job) enforceSubmitJob(override bool, job *structs.Job) (error, error) {
@@ -55,7 +55,7 @@ func (j *Job) multiVaultNamespaceValidation(
 ) error {
 	requestedNamespaces := structs.VaultNamespaceSet(policies)
 	if len(requestedNamespaces) > 0 {
-		return fmt.Errorf("%w, Namespaces: %s", MultipleNamespacesErr, strings.Join(requestedNamespaces, ", "))
+		return fmt.Errorf("%w, Namespaces: %s", ErrMultipleNamespaces, strings.Join(requestedNamespaces, ", "))
 	}
 	return nil
 }

--- a/nomad/job_endpoint_oss.go
+++ b/nomad/job_endpoint_oss.go
@@ -3,12 +3,16 @@
 package nomad
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 	vapi "github.com/hashicorp/vault/api"
 )
+
+// MultipleNamespacesErr is send when multiple namespaces are used in the OSS setup
+var MultipleNamespacesErr = errors.New("multiple vault namespaces requires Nomad Enterprise")
 
 // enforceSubmitJob is used to check any Sentinel policies for the submit-job scope
 func (j *Job) enforceSubmitJob(override bool, job *structs.Job) (error, error) {
@@ -51,7 +55,7 @@ func (j *Job) multiVaultNamespaceValidation(
 ) error {
 	requestedNamespaces := structs.VaultNamespaceSet(policies)
 	if len(requestedNamespaces) > 0 {
-		return fmt.Errorf("multiple vault namespaces requires Nomad Enterprise, Namespaces: %s", strings.Join(requestedNamespaces, ", "))
+		return fmt.Errorf("%w, Namespaces: %s", MultipleNamespacesErr, strings.Join(requestedNamespaces, ", "))
 	}
 	return nil
 }

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1736,8 +1736,9 @@ func TestJobEndpoint_Register_Vault_MultiNamespaces(t *testing.T) {
 	var resp structs.JobRegisterResponse
 	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
 	// OSS or Ent check
-	if s1.EnterpriseState.Features() == 0 {
-		require.True(t, errors.Is(err, ErrMultipleNamespaces))
+	if err != nil && s1.EnterpriseState.Features() == 0 {
+		// errors.Is cannot be used because the RPC call break error wrapping.
+		require.Contains(t, err.Error(), ErrMultipleNamespaces.Error())
 	} else {
 		require.NoError(t, err)
 	}

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1737,7 +1737,7 @@ func TestJobEndpoint_Register_Vault_MultiNamespaces(t *testing.T) {
 	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
 	// OSS or Ent check
 	if s1.EnterpriseState.Features() == 0 {
-		require.True(t, errors.Is(err, MultipleNamespacesErr))
+		require.True(t, errors.Is(err, ErrMultipleNamespaces))
 	} else {
 		require.NoError(t, err)
 	}

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1737,7 +1737,7 @@ func TestJobEndpoint_Register_Vault_MultiNamespaces(t *testing.T) {
 	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
 	// OSS or Ent check
 	if s1.EnterpriseState.Features() == 0 {
-		require.Contains(t, err.Error(), "multiple vault namespaces requires Nomad Enterprise")
+		require.True(t, errors.Is(err, MultipleNamespacesErr))
 	} else {
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
if `err` is nil, then doing `err.Error()` triggers a panic.