### PR TITLE
GetDeployment should not return 500 error

### DIFF
--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -52,14 +52,15 @@ func (d *Deployment) GetDeployment(args *structs.DeploymentSpecificRequest,
 				return err
 			}
 
+			// Re-check namespace in case it differs from request.
+			if out != nil && !allowNsOp(aclObj, out.Namespace) {
+				// 404
+				out = nil
+			}
+
 			// Setup the output
 			reply.Deployment = out
 			if out != nil {
-				// Re-check namespace in case it differs from request.
-				if !allowNsOp(aclObj, out.Namespace) {
-					return structs.NewErrUnknownAllocation(args.DeploymentID)
-				}
-
 				reply.Index = out.ModifyIndex
 			} else {
 				// Use the last index that affected the deployments table

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -54,7 +54,7 @@ func (d *Deployment) GetDeployment(args *structs.DeploymentSpecificRequest,
 
 			// Re-check namespace in case it differs from request.
 			if out != nil && !allowNsOp(aclObj, out.Namespace) {
-				// 404
+				// hide this deployment, caller is not authorized to view it
 				out = nil
 			}
 


### PR DESCRIPTION
check ACLs against deployment namespace on Deployment.GetDeployment, filtering the deployment if the ACL isn't appropriate