### PR TITLE
[Feature] Configure nomad cluster to use a Consul Namespace [Consul Enterprise]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS:
  * api: Added support for cancellation contexts to HTTP API. [[GH-8836](https://github.com/hashicorp/nomad/issues/8836)]
  * client: Added support for Azure fingerprinting. [[GH-8979](https://github.com/hashicorp/nomad/issues/8979)]
  * client: Updated consul-template to v0.25.0 - config function_blacklist deprecated and replaced with function_denylist [[GH-8988](https://github.com/hashicorp/nomad/pull/8988)]
+ * consul: Support consul namespace (consul enterprise) in client configuration. [[GH-8849](https://github.com/hashicorp/nomad/pull/8849)]
  * driver/docker: Upgrade pause container and detect architecture [[GH-8957](https://github.com/hashicorp/nomad/pull/8957)]
  * jobspec: Lowered minimum CPU allowed from 10 to 1. [[GH-8996](https://github.com/hashicorp/nomad/issues/8996)]
 

--- a/client/allocrunner/taskrunner/envoybootstrap_hook.go
+++ b/client/allocrunner/taskrunner/envoybootstrap_hook.go
@@ -30,6 +30,7 @@ type consulTransportConfig struct {
 	CAFile    string // optional, arg -ca-file
 	CertFile  string // optional, arg -client-cert
 	KeyFile   string // optional, arg -client-key
+	Namespace string // optional, only consul Enterprise, env CONSUL_NAMESPACE
 	// CAPath (dir) not supported by Nomad's config object
 }
 
@@ -42,6 +43,7 @@ func newConsulTransportConfig(consul *config.ConsulConfig) consulTransportConfig
 		CAFile:    consul.CAFile,
 		CertFile:  consul.CertFile,
 		KeyFile:   consul.KeyFile,
+		Namespace: consul.Namespace,
 	}
 }
 
@@ -416,6 +418,10 @@ func (e envoyBootstrapArgs) args() []string {
 		arguments = append(arguments, "-client-key", v)
 	}
 
+	if v := e.consulConfig.Namespace; v != "" {
+		arguments = append(arguments, "-namespace", v)
+	}
+
 	return arguments
 }
 
@@ -434,6 +440,9 @@ func (e envoyBootstrapArgs) env(env []string) []string {
 	}
 	if v := e.consulConfig.VerifySSL; v != "" {
 		env = append(env, fmt.Sprintf("%s=%s", "CONSUL_HTTP_SSL_VERIFY", v))
+	}
+	if v := e.consulConfig.Namespace; v != "" {
+		env = append(env, fmt.Sprintf("%s=%s", "CONSUL_NAMESPACE", v))
 	}
 	return env
 }

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -624,6 +624,7 @@ func newRunnerConfig(config *TaskTemplateManagerConfig,
 	if cc.ConsulConfig != nil {
 		conf.Consul.Address = &cc.ConsulConfig.Addr
 		conf.Consul.Token = &cc.ConsulConfig.Token
+		conf.Consul.Namespace = &cc.ConsulConfig.Namespace
 
 		if cc.ConsulConfig.EnableSSL != nil && *cc.ConsulConfig.EnableSSL {
 			verify := cc.ConsulConfig.VerifySSL != nil && *cc.ConsulConfig.VerifySSL

--- a/nomad/structs/config/consul.go
+++ b/nomad/structs/config/consul.go
@@ -118,6 +118,10 @@ type ConsulConfig struct {
 
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
+
+	// Namespace sets the Consul namespace used for all calls against the
+	// Consul API. If this is unset, then Nomad does not specify a consul namespace.
+	Namespace string `hcl:"namespace"`
 }
 
 // DefaultConsulConfig() returns the canonical defaults for the Nomad
@@ -144,6 +148,7 @@ func DefaultConsulConfig() *ConsulConfig {
 		EnableSSL: helper.BoolToPtr(def.Scheme == "https"),
 		VerifySSL: helper.BoolToPtr(!def.TLSConfig.InsecureSkipVerify),
 		CAFile:    def.TLSConfig.CAFile,
+		Namespace: def.Namespace,
 	}
 }
 
@@ -230,6 +235,9 @@ func (c *ConsulConfig) Merge(b *ConsulConfig) *ConsulConfig {
 	if b.AllowUnauthenticated != nil {
 		result.AllowUnauthenticated = helper.BoolToPtr(*b.AllowUnauthenticated)
 	}
+	if b.Namespace != "" {
+		result.Namespace = b.Namespace
+	}
 	return result
 }
 
@@ -284,6 +292,9 @@ func (c *ConsulConfig) ApiConfig() (*consul.Config, error) {
 			return nil, err
 		}
 		config.Transport.TLSClientConfig = tlsConfig
+	}
+	if c.Namespace != "" {
+		config.Namespace = c.Namespace
 	}
 	return config, nil
 }

--- a/website/pages/docs/configuration/consul.mdx
+++ b/website/pages/docs/configuration/consul.mdx
@@ -87,6 +87,10 @@ configuring Nomad to talk to Consul via DNS such as consul.service.consul
 - `key_file` `(string: "")` - Specifies the path to the private key used for
   Consul communication. If this is set then you need to also set `cert_file`.
 
+- `namespace` `(string: "")` - Specifies the [Consul namespace](https://www.consul.io/docs/enterprise/namespaces)
+  used by the Consul integration. If non-empty, this namespace will be used on
+  all Consul API calls and for Consul Connect configurations.
+
 - `server_service_name` `(string: "nomad")` - Specifies the name of the service
   in Consul for the Nomad servers.
 


### PR DESCRIPTION
Currently Nomad has the option of setting a global [Vault namespace configuration](https://www.nomadproject.io/docs/configuration/vault#namespace)
This PR brings feature parity, by allowing a global option to be set for [Consul namespaces](https://www.consul.io/docs/enterprise/namespaces) in the [consul configuration](https://www.nomadproject.io/docs/configuration/consul)