### PR TITLE
UI: Add handling for allocation-less exec URL

### DIFF
--- a/ui/app/utils/generate-exec-url.js
+++ b/ui/app/utils/generate-exec-url.js
@@ -4,16 +4,21 @@ export default function generateExecUrl(router, { job, taskGroup, task, allocati
   const queryParams = router.currentRoute.queryParams;
 
   if (task) {
+    const queryParamsOptions = {
+      ...queryParams,
+    };
+
+    if (allocation) {
+      queryParamsOptions.allocation = get(allocation, 'shortId');
+    }
+
     return router.urlFor(
       'exec.task-group.task',
       get(job, 'plainId'),
       get(taskGroup, 'name'),
       get(task, 'name'),
       {
-        queryParams: {
-          allocation: get(allocation, 'shortId'),
-          ...queryParams,
-        },
+        queryParams: queryParamsOptions,
       }
     );
   } else if (taskGroup) {

--- a/ui/tests/unit/utils/generate-exec-url-test.js
+++ b/ui/tests/unit/utils/generate-exec-url-test.js
@@ -84,6 +84,18 @@ module('Unit | Utility | generate-exec-url', function(hooks) {
     );
   });
 
+  test('it generates an exec task URL without an allocation', function(assert) {
+    generateExecUrl(this.router, {
+      job: { plainId: 'job-name' },
+      taskGroup: { name: 'task-group-name' },
+      task: { name: 'task-name' },
+    });
+
+    assert.ok(
+      this.urlForSpy.calledWith('exec.task-group.task', 'job-name', 'task-group-name', 'task-name')
+    );
+  });
+
   test('it includes query parameters from the current route', function(assert) {
     this.router.currentRoute.queryParams = {
       namespace: 'a-namespace',


### PR DESCRIPTION
This closes #8769. This new-window-opening code is not possible
to properly exercise within Ember’s testing facilities 😞