### PR TITLE
Upgrade to golang 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -128,7 +128,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -246,7 +246,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -364,7 +364,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -574,7 +574,7 @@ jobs:
         path: c:\tmp\test-reports
     environment:
     - GOBIN: c:\gopath\bin
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOPATH: c:\gopath
     - GOTESTSUM_PATH: c:\tmp\test-reports
     - GOTESTSUM_VERSION: 0.4.2
@@ -587,7 +587,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -732,7 +732,7 @@ jobs:
         path: /tmp/test-reports
   lint-go:
     docker:
-    - image: golang:1.14.7
+    - image: golang:1.15.1
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout
@@ -798,7 +798,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -912,7 +912,7 @@ jobs:
         path: /tmp/test-reports
   test-devices:
     docker:
-    - image: golang:1.14.7
+    - image: golang:1.15.1
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -1041,7 +1041,7 @@ jobs:
         path: pkg/darwin_amd64.zip
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOMAXPROCS: 1
     - GOPATH: /Users/distiller/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -1070,7 +1070,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -1184,7 +1184,7 @@ jobs:
         path: /tmp/test-reports
   build-binaries:
     docker:
-    - image: golang:1.14.7
+    - image: golang:1.15.1
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -1218,7 +1218,7 @@ jobs:
         path: pkg/linux_amd64.zip
   test-e2e:
     docker:
-    - image: golang:1.14.7
+    - image: golang:1.15.1
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout
@@ -1250,7 +1250,7 @@ jobs:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
-    - GOLANG_VERSION: 1.14.7
+    - GOLANG_VERSION: 1.15.1
     - GOMAXPROCS: 1
     - GOPATH: /home/circleci/go
     - GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json

--- a/.circleci/config/config.yml
+++ b/.circleci/config/config.yml
@@ -24,7 +24,7 @@ executors:
   go:
     working_directory: /go/src/github.com/hashicorp/nomad
     docker:
-      - image: golang:1.14.7
+      - image: golang:1.15.1
     environment:
       <<: *common_envs
       GOPATH: /go
@@ -36,7 +36,7 @@ executors:
     environment: &machine_env
       <<: *common_envs
       GOPATH: /home/circleci/go
-      GOLANG_VERSION: 1.14.7
+      GOLANG_VERSION: 1.15.1
 
   # uses a more recent image with unattended upgrades disabled properly
   # but seems to break docker builds
@@ -53,7 +53,7 @@ executors:
     environment:
       <<: *common_envs
       GOPATH: /Users/distiller/go
-      GOLANG_VERSION: 1.14.7
+      GOLANG_VERSION: 1.15.1
 
   go-windows:
     machine:
@@ -65,6 +65,6 @@ executors:
       GOPATH: c:\gopath
       GOBIN: c:\gopath\bin
       GOTESTSUM_PATH: c:\tmp\test-reports
-      GOLANG_VERSION: 1.14.7
+      GOLANG_VERSION: 1.15.1
       GOTESTSUM_VERSION: 0.4.2
       VAULT_VERSION: 1.4.1

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Who Uses Nomad
 Contributing to Nomad
 --------------------
 
-If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.14.7+ is *required*, and `gcc-go` is not supported).
+If you wish to contribute to Nomad, you will  need [Go](https://www.golang.org) installed on your machine (version 1.15.1+ is *required*, and `gcc-go` is not supported).
 
 See the [`contributing`](contributing/) directory for more developer documentation.
 

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -602,7 +602,9 @@ func TestHTTP_VerifyHTTPSClient(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected a *url.Error but received: %T -> %v", err, err)
 	}
-	opErr, ok := urlErr.Err.(*net.OpError)
+
+	var opErr *net.OpError
+	ok = errors.As(urlErr.Err, &opErr)
 	if !ok {
 		t.Fatalf("expected a *net.OpErr but received: %T -> %v", urlErr.Err, urlErr.Err)
 	}

--- a/drivers/shared/executor/pty_unix.go
+++ b/drivers/shared/executor/pty_unix.go
@@ -17,7 +17,6 @@ func sessionCmdAttr(tty *os.File) *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		Setsid:  true,
 		Setctty: true,
-		//Ctty:    int(tty.Fd()),
 	}
 }
 

--- a/drivers/shared/executor/pty_unix.go
+++ b/drivers/shared/executor/pty_unix.go
@@ -17,7 +17,7 @@ func sessionCmdAttr(tty *os.File) *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		Setsid:  true,
 		Setctty: true,
-		Ctty:    int(tty.Fd()),
+		//Ctty:    int(tty.Fd()),
 	}
 }
 

--- a/scripts/release/mac-remote-build
+++ b/scripts/release/mac-remote-build
@@ -56,7 +56,7 @@ REPO_PATH="${TMP_WORKSPACE}/gopath/src/github.com/hashicorp/nomad"
 mkdir -p "${TMP_WORKSPACE}/tmp"
 
 install_go() {
-  local go_version="1.14.7"
+  local go_version="1.15.1"
   local download=
 
   download="https://storage.googleapis.com/golang/go${go_version}.darwin-amd64.tar.gz"

--- a/scripts/update_golang_version.sh
+++ b/scripts/update_golang_version.sh
@@ -27,7 +27,7 @@ sed -i'' -e "s|go_version=\"*[^\"]*\"*$|go_version=\"${golang_version}\"|g" \
 	scripts/vagrant-linux-priv-go.sh scripts/release/mac-remote-build
 
 echo "--> Checking if there is any remaining references to old versions..."
-if git grep -I --fixed-strings "${current_version}" | grep -v -e CHANGELOG.md -e vendor/ -e website/
+if git grep -I --fixed-strings "${current_version}" | grep -v -e CHANGELOG.md -e vendor/ -e website/ -e ui/
 then
 	echo "  ^^ files contain references to old golang version" >&2
 	echo "  update script and run again" >&2

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function install_go() {
-	local go_version="1.14.7"
+	local go_version="1.15.1"
 	local download=
 
 	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"


### PR DESCRIPTION
This upgrades Nomad to use Golang 1.15.

Golang 1.15 introduced two changes that got addressed in the PR.  One is very tiny affecting the error type.

The more significant one is handling of `Ctty` in child processes.  Starting with golang 1.5, setting Ctty value result in `Setctty set but Ctty not valid in child` error, as part of golang/go#29458 .  This commit here lifts the fix in creack/pty#97 .