### PR TITLE
scheduler: Revert requireCanary logic

### DIFF
--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -5343,6 +5343,74 @@ func TestServiceSched_Preemption(t *testing.T) {
 	require.Equal(expectedPreemptedAllocs, actualPreemptedAllocs)
 }
 
+// TestServiceSched_Migrate_NonCanary asserts that when rescheduling
+// non-canary allocations, a single allocation is migrated
+func TestServiceSched_Migrate_NonCanary(t *testing.T) {
+	h := NewHarness(t)
+
+	node1 := mock.Node()
+	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node1))
+
+	job := mock.Job()
+	job.Stable = true
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Update = &structs.UpdateStrategy{
+		MaxParallel: 1,
+		Canary:      1,
+	}
+	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+
+	deployment := &structs.Deployment{
+		ID:             uuid.Generate(),
+		JobID:          job.ID,
+		Namespace:      job.Namespace,
+		JobVersion:     job.Version,
+		JobModifyIndex: job.JobModifyIndex,
+		JobCreateIndex: job.CreateIndex,
+		TaskGroups: map[string]*structs.DeploymentState{
+			"web": {DesiredTotal: 1},
+		},
+		Status:            structs.DeploymentStatusSuccessful,
+		StatusDescription: structs.DeploymentStatusDescriptionSuccessful,
+	}
+	require.NoError(t, h.State.UpsertDeployment(h.NextIndex(), deployment))
+
+	alloc := mock.Alloc()
+	alloc.Job = job
+	alloc.JobID = job.ID
+	alloc.NodeID = node1.ID
+	alloc.DeploymentID = deployment.ID
+	alloc.Name = "my-job.web[0]"
+	alloc.DesiredStatus = structs.AllocDesiredStatusRun
+	alloc.ClientStatus = structs.AllocClientStatusRunning
+	alloc.DesiredTransition.Migrate = helper.BoolToPtr(true)
+	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+
+	// Create a mock evaluation
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    50,
+		TriggeredBy: structs.EvalTriggerAllocStop,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+
+	// Process the evaluation
+	err := h.Process(NewServiceScheduler, eval)
+	require.NoError(t, err)
+
+	// Ensure a single plan
+	require.Len(t, h.Plans, 1)
+	plan := h.Plans[0]
+
+	require.Contains(t, plan.NodeAllocation, node1.ID)
+	allocs := plan.NodeAllocation[node1.ID]
+	require.Len(t, allocs, 1)
+
+}
+
 // TestServiceSched_Migrate_CanaryStatus asserts that migrations/rescheduling
 // of allocations use the proper versions of allocs rather than latest:
 // Canaries should be replaced by canaries, and non-canaries should be replaced

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -426,9 +426,7 @@ func (a *allocReconciler) computeGroup(group string, all allocSet) bool {
 	// desired means we need to create canaries
 	strategy := tg.Update
 	canariesPromoted := dstate != nil && dstate.Promoted
-	replaceAllAllocs := len(untainted) == 0 && len(migrate)+len(lost) != 0
-	requireCanary := (len(destructive) != 0 || replaceAllAllocs) &&
-		strategy != nil && len(canaries) < strategy.Canary && !canariesPromoted
+	requireCanary := len(destructive) != 0 && strategy != nil && len(canaries) < strategy.Canary && !canariesPromoted
 	if requireCanary {
 		dstate.DesiredCanaries = strategy.Canary
 	}


### PR DESCRIPTION
Revert the `requireCanary` check introduced in https://github.com/hashicorp/nomad/pull/8691/files#diff-1801138ac4d10f2064ba6f2e434ac9b4L430-R431 .

The change was intended to fix a case where a canary alloc may fail to
be rescheduled if all the other allocs fail as well (e.g. if all allocs
happen to be placed on a node that died).

However, it introduced some unintended side-effects: if all allocs of a successful deployment fail, the scheduler will place canary allocs unexpectedly if the service has a single alloc that is to be migrated. Services with multiple allocations can be affected if all allocations are to be migrated or lost at once (e.g. all happen to run on a single client that is drained).

I added a test case for the failure, and it's failing in https://app.circleci.com/pipelines/github/hashicorp/nomad/11698/workflows/e90b6ba6-aad3-484d-8042-b1dce5239e50/jobs/99179 but is green ultimately.

Reverting the change for now and will investigate further.

Fixes https://github.com/hashicorp/nomad/issues/8866 .