### PR TITLE
moved shared variable into shared-build file

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -35,7 +35,7 @@ const (
 )
 
 // ErrMultipleNamespaces is send when multiple namespaces are used in the OSS setup
-var ErrMultipleNamespaces = errors.New("multiple vault namespaces requires Nomad Enterprise")
+var ErrMultipleNamespaces = errors.New("multiple Vault namespaces requires Nomad Enterprise")
 
 var (
 	// allowRescheduleTransition is the transition that allows failed

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -34,6 +34,9 @@ const (
 	DispatchPayloadSizeLimit = 16 * 1024
 )
 
+// ErrMultipleNamespaces is send when multiple namespaces are used in the OSS setup
+var ErrMultipleNamespaces = errors.New("multiple vault namespaces requires Nomad Enterprise")
+
 var (
 	// allowRescheduleTransition is the transition that allows failed
 	// allocations to be force rescheduled. We create a one off

--- a/nomad/job_endpoint_oss.go
+++ b/nomad/job_endpoint_oss.go
@@ -3,16 +3,12 @@
 package nomad
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 	vapi "github.com/hashicorp/vault/api"
 )
-
-// ErrMultipleNamespaces is send when multiple namespaces are used in the OSS setup
-var ErrMultipleNamespaces = errors.New("multiple vault namespaces requires Nomad Enterprise")
 
 // enforceSubmitJob is used to check any Sentinel policies for the submit-job scope
 func (j *Job) enforceSubmitJob(override bool, job *structs.Job) (error, error) {


### PR DESCRIPTION
#8834 introduced a variable into nomad/job_endpoint_oss.go (OSS-only), which is used by nomad/job_endpoint_test.go (OSS and Ent), causing Ent builds to break

this moves that variable out of oss-only build into shared file