### PR TITLE
e2e: constrain rescheduling test workloads to Linux

### DIFF
--- a/e2e/rescheduling/helpers.go
+++ b/e2e/rescheduling/helpers.go
@@ -97,7 +97,7 @@ func register(f *framework.F, jobFile, jobID string) {
 func waitForAllocStatusComparison(query func() ([]string, error), comparison func([]string) bool) error {
 	var got []string
 	var err error
-	testutil.WaitForResultRetries(30, func() (bool, error) {
+	testutil.WaitForResultRetries(50, func() (bool, error) {
 		time.Sleep(time.Millisecond * 100)
 		got, err = query()
 		if err != nil {
@@ -113,7 +113,7 @@ func waitForAllocStatusComparison(query func() ([]string, error), comparison fun
 func waitForLastDeploymentStatus(f *framework.F, jobID, status string) error {
 	var got string
 	var err error
-	testutil.WaitForResultRetries(30, func() (bool, error) {
+	testutil.WaitForResultRetries(50, func() (bool, error) {
 		time.Sleep(time.Millisecond * 100)
 
 		out, err := e2eutil.Command("nomad", "job", "status", jobID)

--- a/e2e/rescheduling/input/norescheduling.nomad
+++ b/e2e/rescheduling/input/norescheduling.nomad
@@ -1,5 +1,12 @@
 job "test1" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t1" {

--- a/e2e/rescheduling/input/norescheduling.nomad
+++ b/e2e/rescheduling/input/norescheduling.nomad
@@ -7,7 +7,7 @@ job "test1" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t1" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_canary.nomad
+++ b/e2e/rescheduling/input/rescheduling_canary.nomad
@@ -1,5 +1,12 @@
 job "test5" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t5" {

--- a/e2e/rescheduling/input/rescheduling_canary.nomad
+++ b/e2e/rescheduling/input/rescheduling_canary.nomad
@@ -7,7 +7,7 @@ job "test5" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t5" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_canary_autorevert.nomad
+++ b/e2e/rescheduling/input/rescheduling_canary_autorevert.nomad
@@ -1,5 +1,12 @@
 job "test" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t1" {

--- a/e2e/rescheduling/input/rescheduling_canary_autorevert.nomad
+++ b/e2e/rescheduling/input/rescheduling_canary_autorevert.nomad
@@ -7,7 +7,7 @@ job "test" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t1" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_default.nomad
+++ b/e2e/rescheduling/input/rescheduling_default.nomad
@@ -1,5 +1,12 @@
 job "test" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t" {

--- a/e2e/rescheduling/input/rescheduling_default.nomad
+++ b/e2e/rescheduling/input/rescheduling_default.nomad
@@ -7,7 +7,7 @@ job "test" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_fail.nomad
+++ b/e2e/rescheduling/input/rescheduling_fail.nomad
@@ -7,7 +7,7 @@ job "test2" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t2" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_fail.nomad
+++ b/e2e/rescheduling/input/rescheduling_fail.nomad
@@ -1,5 +1,12 @@
 job "test2" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t2" {

--- a/e2e/rescheduling/input/rescheduling_maxp.nomad
+++ b/e2e/rescheduling/input/rescheduling_maxp.nomad
@@ -7,7 +7,7 @@ job "demo2" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t2" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_maxp.nomad
+++ b/e2e/rescheduling/input/rescheduling_maxp.nomad
@@ -1,5 +1,12 @@
 job "demo2" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t2" {

--- a/e2e/rescheduling/input/rescheduling_maxp_autorevert.nomad
+++ b/e2e/rescheduling/input/rescheduling_maxp_autorevert.nomad
@@ -7,7 +7,7 @@ job "demo3" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t2" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_maxp_autorevert.nomad
+++ b/e2e/rescheduling/input/rescheduling_maxp_autorevert.nomad
@@ -1,5 +1,12 @@
 job "demo3" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t2" {

--- a/e2e/rescheduling/input/rescheduling_progressdeadline.nomad
+++ b/e2e/rescheduling/input/rescheduling_progressdeadline.nomad
@@ -7,7 +7,7 @@ job "demo2" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t2" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_progressdeadline.nomad
+++ b/e2e/rescheduling/input/rescheduling_progressdeadline.nomad
@@ -1,5 +1,12 @@
 job "demo2" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t2" {

--- a/e2e/rescheduling/input/rescheduling_success.nomad
+++ b/e2e/rescheduling/input/rescheduling_success.nomad
@@ -7,7 +7,7 @@ job "test3" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t3" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_success.nomad
+++ b/e2e/rescheduling/input/rescheduling_success.nomad
@@ -1,5 +1,12 @@
 job "test3" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t3" {

--- a/e2e/rescheduling/input/rescheduling_system.nomad
+++ b/e2e/rescheduling/input/rescheduling_system.nomad
@@ -1,5 +1,12 @@
 job "test" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "system"
 
   group "t" {

--- a/e2e/rescheduling/input/rescheduling_system.nomad
+++ b/e2e/rescheduling/input/rescheduling_system.nomad
@@ -7,7 +7,7 @@ job "test" {
     value     = "linux"
   }
 
-  type        = "system"
+  type = "system"
 
   group "t" {
     count = 1

--- a/e2e/rescheduling/input/rescheduling_update.nomad
+++ b/e2e/rescheduling/input/rescheduling_update.nomad
@@ -7,7 +7,7 @@ job "test4" {
     value     = "linux"
   }
 
-  type        = "service"
+  type = "service"
 
   group "t4" {
     count = 3

--- a/e2e/rescheduling/input/rescheduling_update.nomad
+++ b/e2e/rescheduling/input/rescheduling_update.nomad
@@ -1,5 +1,12 @@
 job "test4" {
-  datacenters = ["dc1"]
+
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   type        = "service"
 
   group "t4" {

--- a/e2e/rescheduling/rescheduling.go
+++ b/e2e/rescheduling/rescheduling.go
@@ -51,7 +51,7 @@ func (tc *RescheduleE2ETest) AfterEach(f *framework.F) {
 
 // TestNoReschedule runs a job that should fail and never reschedule
 func (tc *RescheduleE2ETest) TestNoReschedule(f *framework.F) {
-	jobID := "test-no-reschedule" + uuid.Generate()[0:8]
+	jobID := "test-no-reschedule-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/norescheduling.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -65,7 +65,7 @@ func (tc *RescheduleE2ETest) TestNoReschedule(f *framework.F) {
 
 // TestNoRescheduleSystem runs a system job that should fail and never reschedule
 func (tc *RescheduleE2ETest) TestNoRescheduleSystem(f *framework.F) {
-	jobID := "test-reschedule-system" + uuid.Generate()[0:8]
+	jobID := "test-reschedule-system-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_system.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -86,7 +86,7 @@ func (tc *RescheduleE2ETest) TestNoRescheduleSystem(f *framework.F) {
 // TestDefaultReschedule runs a job that should reschedule after delay
 func (tc *RescheduleE2ETest) TestDefaultReschedule(f *framework.F) {
 
-	jobID := "test-default-reschedule" + uuid.Generate()[0:8]
+	jobID := "test-default-reschedule-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_default.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -111,7 +111,7 @@ func (tc *RescheduleE2ETest) TestDefaultReschedule(f *framework.F) {
 // TestRescheduleMaxAttempts runs a job with a maximum reschedule attempts
 func (tc *RescheduleE2ETest) TestRescheduleMaxAttempts(f *framework.F) {
 
-	jobID := "test-reschedule-fail" + uuid.Generate()[0:8]
+	jobID := "test-reschedule-fail-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_fail.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -146,7 +146,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxAttempts(f *framework.F) {
 // TestRescheduleSuccess runs a job that should be running after rescheduling
 func (tc *RescheduleE2ETest) TestRescheduleSuccess(f *framework.F) {
 
-	jobID := "test-reschedule-success" + uuid.Generate()[0:8]
+	jobID := "test-reschedule-success-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_success.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -168,7 +168,7 @@ func (tc *RescheduleE2ETest) TestRescheduleSuccess(f *framework.F) {
 // it gets rescheduled
 func (tc *RescheduleE2ETest) TestRescheduleWithUpdate(f *framework.F) {
 
-	jobID := "test-reschedule-update" + uuid.Generate()[0:8]
+	jobID := "test-reschedule-update-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_update.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -198,7 +198,7 @@ func (tc *RescheduleE2ETest) TestRescheduleWithUpdate(f *framework.F) {
 // canary gets rescheduled
 func (tc *RescheduleE2ETest) TestRescheduleWithCanary(f *framework.F) {
 
-	jobID := "test-reschedule-canary" + uuid.Generate()[0:8]
+	jobID := "test-reschedule-canary-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_canary.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -234,7 +234,7 @@ func (tc *RescheduleE2ETest) TestRescheduleWithCanary(f *framework.F) {
 // the job gets reverted
 func (tc *RescheduleE2ETest) TestRescheduleWithCanaryAutoRevert(f *framework.F) {
 
-	jobID := "test-reschedule-canary-revert" + uuid.Generate()[0:8]
+	jobID := "test-reschedule-canary-revert-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_canary_autorevert.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -277,7 +277,7 @@ func (tc *RescheduleE2ETest) TestRescheduleWithCanaryAutoRevert(f *framework.F) 
 // TestRescheduleMaxParallel updates a job with a max_parallel config
 func (tc *RescheduleE2ETest) TestRescheduleMaxParallel(f *framework.F) {
 
-	jobID := "test-reschedule-maxp" + uuid.Generate()[0:8]
+	jobID := "test-reschedule-maxp-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_maxp.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -317,7 +317,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxParallel(f *framework.F) {
 // config that will autorevert on failure
 func (tc *RescheduleE2ETest) TestRescheduleMaxParallelAutoRevert(f *framework.F) {
 
-	jobID := "test-reschedule-maxp-revert" + uuid.Generate()[0:8]
+	jobID := "test-reschedule-maxp-revert-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_maxp_autorevert.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 
@@ -376,7 +376,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxParallelAutoRevert(f *framework.F)
 // progress deadline
 func (tc *RescheduleE2ETest) TestRescheduleProgressDeadline(f *framework.F) {
 
-	jobID := "test-reschedule-deadline" + uuid.Generate()[0:8]
+	jobID := "test-reschedule-deadline-" + uuid.Generate()[0:8]
 	register(f, "rescheduling/input/rescheduling_progressdeadline.nomad", jobID)
 	tc.jobIds = append(tc.jobIds, jobID)
 


### PR DESCRIPTION
The rescheduling test workloads were created before we had Windows targets in
the E2E nightly run. When these were recently ported to the e2e framework (#8860) they
were missing the constraint to Linux machines.

Also added a little extra time to polling to avoid some flakiness on the first
run, and a minor readability adjustment to the job names.

<details><summary>Test results vs a full nightly cluster</summary>

```
$ NOMAD_E2E=1 go test -v . -suite Rescheduling
=== RUN   TestE2E
=== RUN   TestE2E/Affinity
    framework.go:181: skipping suite 'Affinity': only running suite "Rescheduling"
=== RUN   TestE2E/clientstate
    framework.go:181: skipping suite 'clientstate': only running suite "Rescheduling"
=== RUN   TestE2E/Connect
    framework.go:181: skipping suite 'Connect': only running suite "Rescheduling"
=== RUN   TestE2E/ConnectACLs
    framework.go:181: skipping suite 'ConnectACLs': only running suite "Rescheduling"
=== RUN   TestE2E/Consul
    framework.go:181: skipping suite 'Consul': only running suite "Rescheduling"
=== RUN   TestE2E/Consul_Template
    framework.go:181: skipping suite 'Consul Template': only running suite "Rescheduling"
=== RUN   TestE2E/CSI
    framework.go:181: skipping suite 'CSI': only running suite "Rescheduling"
=== RUN   TestE2E/Deployment
    framework.go:181: skipping suite 'Deployment': only running suite "Rescheduling"
=== RUN   TestE2E/simple
    framework.go:181: skipping suite 'simple': only running suite "Rescheduling"
=== RUN   TestE2E/Host_Volumes
    framework.go:181: skipping suite 'Host Volumes': only running suite "Rescheduling"
=== RUN   TestE2E/Lifecycle
    framework.go:181: skipping suite 'Lifecycle': only running suite "Rescheduling"
=== RUN   TestE2E/Metrics
    framework.go:181: skipping suite 'Metrics': only running suite "Rescheduling"
=== RUN   TestE2E/Nomad_exec
    framework.go:181: skipping suite 'Nomad exec': only running suite "Rescheduling"
=== RUN   TestE2E/Podman
    framework.go:181: skipping suite 'Podman': only running suite "Rescheduling"
=== RUN   TestE2E/Rescheduling
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestDefaultReschedule
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestNoReschedule
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestNoRescheduleSystem
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxAttempts
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxParallel
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxParallelAutoRevert
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleProgressDeadline
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleSuccess
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithCanary
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithCanaryAutoRevert
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithUpdate
=== RUN   TestE2E/Spread
    framework.go:181: skipping suite 'Spread': only running suite "Rescheduling"
=== RUN   TestE2E/SystemScheduler
    framework.go:181: skipping suite 'SystemScheduler': only running suite "Rescheduling"
=== RUN   TestE2E/TaskEvents
    framework.go:181: skipping suite 'TaskEvents': only running suite "Rescheduling"
--- PASS: TestE2E (131.22s)
    --- SKIP: TestE2E/Affinity (0.00s)
    --- SKIP: TestE2E/clientstate (0.00s)
    --- SKIP: TestE2E/Connect (0.00s)
    --- SKIP: TestE2E/ConnectACLs (0.00s)
    --- SKIP: TestE2E/Consul (0.00s)
    --- SKIP: TestE2E/Consul_Template (0.00s)
    --- SKIP: TestE2E/CSI (0.00s)
    --- SKIP: TestE2E/Deployment (0.00s)
    --- SKIP: TestE2E/simple (0.00s)
    --- SKIP: TestE2E/Host_Volumes (0.00s)
    --- SKIP: TestE2E/Lifecycle (0.00s)
    --- SKIP: TestE2E/Metrics (0.00s)
    --- SKIP: TestE2E/Nomad_exec (0.00s)
    --- SKIP: TestE2E/Podman (0.00s)
    --- PASS: TestE2E/Rescheduling (131.22s)
        --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest (131.13s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestDefaultReschedule (38.66s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestNoReschedule (3.21s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestNoRescheduleSystem (3.25s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxAttempts (4.01s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxParallel (11.49s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxParallelAutoRevert (8.29s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleProgressDeadline (33.18s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleSuccess (2.14s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithCanary (9.67s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithCanaryAutoRevert (11.41s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithUpdate (5.62s)
    --- SKIP: TestE2E/Spread (0.00s)
    --- SKIP: TestE2E/SystemScheduler (0.00s)
    --- SKIP: TestE2E/TaskEvents (0.00s)
PASS
ok      github.com/hashicorp/nomad/e2e  131.347s
```

</details>