### PR TITLE
docs: add chroot contents to Java driver docs

### DIFF
--- a/website/pages/docs/drivers/java.mdx
+++ b/website/pages/docs/drivers/java.mdx
@@ -150,3 +150,29 @@ running as root, many of these mechanisms cannot be used.
 
 As a baseline, the Java jars will be run inside a Java Virtual Machine,
 providing a minimum amount of isolation.
+
+### Chroot
+
+The chroot created on Linux is populated with data in the following
+directories from the host machine:
+
+```
+[
+  "/bin",
+  "/etc",
+  "/lib",
+  "/lib32",
+  "/lib64",
+  "/run/resolvconf",
+  "/sbin",
+  "/usr",
+]
+```
+
+The task's chroot is populated by linking or copying the data from the host into
+the chroot. Note that this can take considerable disk space. Since Nomad v0.5.3,
+the client manages garbage collection locally which mitigates any issue this may
+create.
+
+This list is configurable through the agent client
+[configuration file](/docs/configuration/client#chroot_env).


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8870

On Linux the `java` task driver creates a chroot for file system isolation. This chroot is the same as the one created by the `exec` driver, but the contents aren't specifically called out other than a bit obliquely in the [`chroot_env`](https://www.nomadproject.io/docs/configuration/client#chroot_env) docs for the client config. Duplicate this section for the Java driver.