### PR TITLE
consul/connect: validate group network on expose port injection

### DIFF
--- a/nomad/job_endpoint_hook_expose_check.go
+++ b/nomad/job_endpoint_hook_expose_check.go
@@ -170,7 +170,7 @@ func serviceUsesConnectEnvoy(s *structs.Service) bool {
 	}
 
 	// A non-nil connect.sidecar_task stanza implies the sidecar task is being
-	// overridden (i.e. the default Envoy is not being uesd).
+	// overridden (i.e. the default Envoy is not being used).
 	if s.Connect.SidecarTask != nil {
 		return false
 	}
@@ -197,6 +197,12 @@ func checkIsExposable(check *structs.ServiceCheck) bool {
 func exposePathForCheck(tg *structs.TaskGroup, s *structs.Service, check *structs.ServiceCheck) (*structs.ConsulExposePath, error) {
 	if !checkIsExposable(check) {
 		return nil, nil
+	}
+
+	// Borrow some of the validation before we start manipulating the group
+	// network, which needs to exist once.
+	if err := tgValidateUseOfBridgeMode(tg); err != nil {
+		return nil, err
 	}
 
 	// If the check is exposable but doesn't have a port label set build


### PR DESCRIPTION
In #7800, Nomad would automatically generate a port label for service
checks making use of the expose feature, if the port was not already
set. This change assumed the group network would be correctly defined
(as is checked in a validation hook later). If the group network was
not definied, a panic would occur on job submisssion. This change
re-uses the group network validation helper to make sure the network
is correctly definied before adding ports to it.

Fixes #8875