### PR TITLE
Change tabs to spaces in `nomad monitor` help text

### DIFF
--- a/command/agent_monitor.go
+++ b/command/agent_monitor.go
@@ -22,14 +22,14 @@ func (c *MonitorCommand) Help() string {
 	helpText := `
 Usage: nomad monitor [options]
 
-	Stream log messages of a nomad agent. The monitor command lets you
-	listen for log levels that may be filtered out of the Nomad agent. For
-	example your agent may only be logging at INFO level, but with the monitor
-	command you can set -log-level DEBUG
+  Stream log messages of a nomad agent. The monitor command lets you
+  listen for log levels that may be filtered out of the Nomad agent. For
+  example your agent may only be logging at INFO level, but with the monitor
+  command you can set -log-level DEBUG
 
 General Options:
 
-	` + generalOptionsUsage() + `
+  ` + generalOptionsUsage() + `
 
 Monitor Specific Options:
 


### PR DESCRIPTION
The `nomad monitor` help has a formatting issue because of tabs in the string which should be spaces.

Before:

```
Usage: nomad monitor [options]

	Stream log messages of a nomad agent. The monitor command lets you
	listen for log levels that may be filtered out of the Nomad agent. For
	example your agent may only be logging at INFO level, but with the monitor
	command you can set -log-level DEBUG

General Options:

	-address=<addr>
    The address of the Nomad server.
    Overrides the NOMAD_ADDR environment variable if set.
    Default = http://127.0.0.1:4646

```

After:
```
Usage: nomad monitor [options]

  Stream log messages of a nomad agent. The monitor command lets you
  listen for log levels that may be filtered out of the Nomad agent. For
  example your agent may only be logging at INFO level, but with the monitor
  command you can set -log-level DEBUG

General Options:

  -address=<addr>
    The address of the Nomad server.
    Overrides the NOMAD_ADDR environment variable if set.
    Default = http://127.0.0.1:4646
```