### PR TITLE
Stop already rescheduled but somehow running allocs

### DIFF
--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -256,8 +256,10 @@ func (a allocSet) filterByRescheduleable(isBatch bool, now time.Time, evalID str
 		var eligibleNow, eligibleLater bool
 		var rescheduleTime time.Time
 
-		// Ignore allocs that have already been rescheduled
-		if alloc.NextAllocation != "" {
+		// Ignore failing allocs that have already been rescheduled
+		// only failed allocs should be rescheduled, but protect against a bug allowing rescheduling
+		// running allocs
+		if alloc.NextAllocation != "" && alloc.TerminalStatus() {
 			continue
 		}
 


### PR DESCRIPTION
This is a band-aid fix for a case where an alloc has been rescheduled but somehow is left in a running state.  In such case, currently, the alloc is left running uninterrupted as it is removed from consideration by the scheduler.  The alloc will remain running uninterrupted even after a new job version is pushed, resulting into a mixed fleet.  Currently, operators need to manually force stop these "leaked" allocations.

This PR fixes the issue by reconsidering an alloc that has been rescheduled but is still running for scheduling purposes.  The check in reconciler_util.go meant that once an allocation is rescheduled, forever it will never be examined again as it's removed from the untainted allocations.

## But how did it get here
It is very unclear how an alloc can get into this state.  In all of my testing so far, only failed allocs can be rescheduled, and once they are rescheduled, and `alloc.DesiredStatus` is set to `stop`.  So theoretically, we should never see a running allocation with `NextAllocation != ""`.

@cgbaker observed this issue in https://github.com/hashicorp/nomad/issues/5921#issuecomment-510906135. We've also had bugs in the past where finished allocations get to re-run again upon a client restart, e.g. https://github.com/hashicorp/nomad/issues/6354, https://github.com/hashicorp/nomad/issues/5945.

So while we need to keep digging into understanding the underlying cause, I propose this "band-aid" to at least recover smoothly from the bad state.