### PR TITLE
Add AWS `mac` address and `public-ipv6`

### DIFF
--- a/client/fingerprint/env_aws_test.go
+++ b/client/fingerprint/env_aws_test.go
@@ -342,6 +342,11 @@ var awsStubs = []endpoint{
 		ContentType: "text/plain",
 		Body:        "54.191.117.175",
 	},
+	{
+		Uri:         "/latest/meta-data/mac",
+		ContentType: "text/plain",
+		Body:        "0a:20:d2:42:b3:55",
+	},
 }
 
 var unknownInstanceType = []endpoint{


### PR DESCRIPTION
If available, get the first IPv6 address assigned to the `eth0` interface via the AWS metadata API.  This gives access to `attr.unique.platform.aws.public-ipv6` for variable interpolation.