### PR TITLE
docs: Fix Nomad autoscaler Datadog telemetry example

### DIFF
--- a/website/pages/docs/autoscaling/agent.mdx
+++ b/website/pages/docs/autoscaling/agent.mdx
@@ -230,8 +230,8 @@ These `telemetry` parameters apply to [DataDog statsd][datadog_statsd].
 
 ```hcl
 telemetry {
-  datadog_address = "dogstatsd.company.local:8125"
-  datadog_tags    = ["my_tag_name:my_tag_value"]
+  dogstatsd_address = "dogstatsd.company.local:8125"
+  dogstatsd_tags    = ["my_tag_name:my_tag_value"]
 }
 ```
 


### PR DESCRIPTION
The Datadog telemetry example does not use the right attribute names.

I'm not sure what name you want to use, if it is the name of the example that is incorrect or the attributes defined in the [Nomad autoscaler project](https://github.com/hashicorp/nomad-autoscaler/blob/master/agent/config/config.go#L141). Nomad agent use `datadog_address` and `datadog_tags`, Nomad autoscaler use `dogstatsd_address` and `dogstatsd_tags`.