### PR TITLE
api: target servers for allocation requests

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -286,13 +286,8 @@ func (a *Allocations) Stats(alloc *Allocation, q *QueryOptions) (*AllocResourceU
 }
 
 func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
-	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
-	if err != nil {
-		return err
-	}
-
 	var resp struct{}
-	_, err = nodeClient.query("/v1/client/allocation/"+alloc.ID+"/gc", &resp, nil)
+	_, err := a.client.query("/v1/client/allocation/"+alloc.ID+"/gc", &resp, nil)
 	return err
 }
 
@@ -321,18 +316,13 @@ type AllocStopResponse struct {
 }
 
 func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal string) error {
-	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
-	if err != nil {
-		return err
-	}
-
 	req := AllocSignalRequest{
 		Signal: signal,
 		Task:   task,
 	}
 
 	var resp GenericResponse
-	_, err = nodeClient.putQuery("/v1/client/allocation/"+alloc.ID+"/signal", &req, &resp, q)
+	_, err := a.client.putQuery("/v1/client/allocation/"+alloc.ID+"/signal", &req, &resp, q)
 	return err
 }
 

--- a/vendor/github.com/hashicorp/nomad/api/allocations.go
+++ b/vendor/github.com/hashicorp/nomad/api/allocations.go
@@ -286,13 +286,8 @@ func (a *Allocations) Stats(alloc *Allocation, q *QueryOptions) (*AllocResourceU
 }
 
 func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
-	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
-	if err != nil {
-		return err
-	}
-
 	var resp struct{}
-	_, err = nodeClient.query("/v1/client/allocation/"+alloc.ID+"/gc", &resp, nil)
+	_, err := a.client.query("/v1/client/allocation/"+alloc.ID+"/gc", &resp, nil)
 	return err
 }
 
@@ -321,18 +316,13 @@ type AllocStopResponse struct {
 }
 
 func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal string) error {
-	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
-	if err != nil {
-		return err
-	}
-
 	req := AllocSignalRequest{
 		Signal: signal,
 		Task:   task,
 	}
 
 	var resp GenericResponse
-	_, err = nodeClient.putQuery("/v1/client/allocation/"+alloc.ID+"/signal", &req, &resp, q)
+	_, err := a.client.putQuery("/v1/client/allocation/"+alloc.ID+"/signal", &req, &resp, q)
 	return err
 }
 


### PR DESCRIPTION
Allocation requests should target servers, which then can forward the
request to the appropriate clients.

Contacting clients directly is fragile and prune to failures: e.g.
clients maybe firewalled and not accessible from the API client, or have
some internal certificates not trusted by the API client.

FWIW, in contexts where we anticipate lots of traffic (e.g. logs, or
exec), the api package attempts contacting the client directly but then
fallsback to using the server.  This approach seems excessive in these
simple GET/PUT requests.

Fixes https://github.com/hashicorp/nomad/issues/8894