### PR TITLE
CI: exclude unit test runs from e2e branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1385,76 +1385,6 @@ workflows:
             - /^.-ui\b.*/
             - /^docs-.*/
             - stable-website
-    - test-windows:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
-    - test-client:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
-    - test-nomad:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
-    - test-api:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
-    - test-devices:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
-    - test-other:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
-    - test-docker:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
-    - test-exec:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
-    - test-shared-exec:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
-    - test-32bit:
-        filters:
-          branches:
-            ignore:
-            - /^.-ui\b.*/
-            - /^docs-.*/
-            - stable-website
     - test-e2e:
         filters:
           branches:
@@ -1468,6 +1398,86 @@ workflows:
             ignore:
             - stable-website
             - /^docs-.*/
+    - test-windows:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
+    - test-client:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
+    - test-nomad:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
+    - test-api:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
+    - test-devices:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
+    - test-other:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
+    - test-docker:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
+    - test-exec:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
+    - test-shared-exec:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
+    - test-32bit:
+        filters:
+          branches:
+            ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
   website:
     jobs:
     - website-docker-image:

--- a/.circleci/config/workflows/build-test.yml
+++ b/.circleci/config/workflows/build-test.yml
@@ -7,41 +7,58 @@ jobs:
           ignore:
             - stable-website
             - /^.-ui\b.*/
+
   - lint-go:
-      filters: &backend_branches_filter
+      # check branches are almost all the backend branches
+      filters: &backend_check_branches_filter
         branches:
           ignore:
             - /^.-ui\b.*/
             - /^docs-.*/
             - stable-website
-
   - build-darwin-binaries:
-      filters: *backend_branches_filter
-  - test-windows:
-      filters: *backend_branches_filter
+      filters: *backend_check_branches_filter
+  - test-e2e:
+      filters: *backend_check_branches_filter
 
+  - test-ui:
+      filters:
+        branches:
+          ignore:
+            - stable-website
+            - /^docs-.*/
+
+  - test-windows:
+      # test branches are the branches that can impact unit tests
+      filters: &backend_test_branches_filter
+        branches:
+          ignore:
+            - /^.-ui\b.*/
+            - /^docs-.*/
+            - /^e2e-.*/
+            - stable-website
   - test-machine:
       name: "test-client"
       test_packages: "./client/..."
-      filters: *backend_branches_filter
+      filters: *backend_test_branches_filter
   - test-machine:
       name: "test-nomad"
       test_packages: "./nomad/..."
-      filters: *backend_branches_filter
+      filters: *backend_test_branches_filter
   - test-machine:
       # API Tests run in a VM rather than container due to the FS tests
       # requiring `mount` priviliges.
       name: "test-api"
       test_module: "api"
-      filters: *backend_branches_filter
+      filters: *backend_test_branches_filter
   - test-container:
       name: "test-devices"
       test_packages: "./devices/..."
-      filters: *backend_branches_filter
+      filters: *backend_test_branches_filter
   - test-machine:
       name: "test-other"
       exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/shared/executor|./nomad|./devices"
-      filters: *backend_branches_filter
+      filters: *backend_test_branches_filter
   - test-machine:
       name: "test-docker"
       test_packages: "./drivers/docker"
@@ -49,27 +66,19 @@ jobs:
       # and we get unexpected failures
       # e.g. https://circleci.com/gh/hashicorp/nomad/3854
       executor: go-machine
-      filters: *backend_branches_filter
+      filters: *backend_test_branches_filter
   - test-machine:
       name: "test-exec"
       test_packages: "./drivers/exec"
-      filters: *backend_branches_filter
+      filters: *backend_test_branches_filter
   - test-machine:
       name: "test-shared-exec"
       test_packages: "./drivers/shared/executor"
-      filters: *backend_branches_filter
+      filters: *backend_test_branches_filter
   - test-machine:
       name: "test-32bit"
       # Currently we only explicitly test fingerprinting on 32bit
       # architectures.
       test_packages: "./client/fingerprint"
       goarch: "386"
-      filters: *backend_branches_filter
-  - test-e2e:
-      filters: *backend_branches_filter
-  - test-ui:
-      filters:
-        branches:
-          ignore:
-            - stable-website
-            - /^docs-.*/
+      filters: *backend_test_branches_filter


### PR DESCRIPTION
Branches for the e2e code base can't have impact on the unit tests, so running
those tests just extends the time it takes to ship e2e updates. This changeset
updates the CircleCI config so that e2e branches run linting, build the
binary, and run the e2e unit tests (currently just vault compatibility).