### PR TITLE
Use errors.Is() in IsErrEOF()

### DIFF
--- a/vendor/github.com/hashicorp/consul/lib/eof.go
+++ b/vendor/github.com/hashicorp/consul/lib/eof.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"errors"
 	"io"
 	"strings"
 
@@ -13,13 +14,14 @@ var yamuxSessionShutdown = yamux.ErrSessionShutdown.Error()
 // IsErrEOF returns true if we get an EOF error from the socket itself, or
 // an EOF equivalent error from yamux.
 func IsErrEOF(err error) bool {
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return true
 	}
 
 	errStr := err.Error()
 	if strings.Contains(errStr, yamuxStreamClosed) ||
-		strings.Contains(errStr, yamuxSessionShutdown) {
+		strings.Contains(errStr, yamuxSessionShutdown) ||
+		strings.HasSuffix(errStr, io.EOF.Error()) {
 		return true
 	}
 


### PR DESCRIPTION
IsErrEOF returns false when it should return true in a couple of cases:

1. if the error has been wrapped in another error (for example, if EOF
is wrapped in an RPC error)
2. if the error has been created from an Error field in an RPC response
(as it is the case in CallWithCodec)