### PR TITLE
e2e: documentation and minor tweaks to configs

### DIFF
--- a/e2e/terraform/README.md
+++ b/e2e/terraform/README.md
@@ -14,9 +14,10 @@ framework uses.
 
 ## Setup
 
-You'll need Terraform 0.12+, as well as AWS credentials (`AWS_ACCESS_KEY_ID`
-and `AWS_SECRET_ACCESS_KEY`) to create the Nomad cluster. Use
-[envchain](https://github.com/sorah/envchain) to store your AWS credentials.
+You'll need Terraform 0.13+, as well as AWS credentials to create the Nomad
+cluster. This Terraform stack assumes that an appropriate instance role has
+been configured elsewhere and that you have the ability to `AssumeRole` into
+the AWS account.
 
 Optionally, edit the `terraform.tfvars` file to change the number of
 Linux clients or Windows clients.
@@ -33,7 +34,7 @@ Run Terraform apply to deploy the infrastructure:
 
 ```sh
 cd e2e/terraform/
-envchain nomadaws terraform apply
+terraform apply
 ```
 
 ## Outputs
@@ -73,5 +74,5 @@ The terraform state file stores all the info.
 
 ```sh
 cd e2e/terraform/
-envchain nomadaws terraform destroy
+terraform destroy
 ```

--- a/e2e/terraform/config/dev-cluster/consul/server/server.json
+++ b/e2e/terraform/config/dev-cluster/consul/server/server.json
@@ -1,7 +1,7 @@
 {
   "server": true,
   "ui": true,
-  "bootstrap_expect": SERVER_COUNT,
+  "bootstrap_expect": 3,
   "service": {
     "name": "consul"
   }

--- a/e2e/terraform/packer/linux/provision.sh
+++ b/e2e/terraform/packer/linux/provision.sh
@@ -29,7 +29,7 @@ install_from_s3() {
     # check that we don't already have this version
     if [ "$(command -v nomad)" ]; then
         nomad -version | grep -q "${NOMAD_SHA}" \
-            && echo "$NOMAD_SHA already installed" && exit 0
+            && echo "$NOMAD_SHA already installed" && return
     fi
 
     S3_URL="s3://nomad-team-dev-test-binaries/builds-oss/nomad_${PLATFORM}_${NOMAD_SHA}.tar.gz"
@@ -52,7 +52,7 @@ install_from_release() {
     # check that we don't already have this version
     if [ "$(command -v nomad)" ]; then
         nomad -version | grep -v 'dev' | grep -q "${NOMAD_VERSION}" \
-            && echo "$NOMAD_VERSION already installed" && exit 0
+            && echo "$NOMAD_VERSION already installed" && return
     fi
 
     RELEASE_URL="https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_${PLATFORM}.zip"

--- a/e2e/terraform/userdata/ubuntu-bionic.sh
+++ b/e2e/terraform/userdata/ubuntu-bionic.sh
@@ -14,6 +14,9 @@ nameserver $DOCKER_BRIDGE_IP_ADDRESS
 EOF
 sudo mv /tmp/resolv.conf /etc/resolv.conf
 
+# For host volume testing
+sudo mkdir -p /tmp/data
+
 # need to get the AWS DNS address from the VPC...
 # this is pretty hacky but will work for any typical case
 MAC=$(curl -s --fail http://169.254.169.254/latest/meta-data/mac)

--- a/e2e/terraform/userdata/windows-2016.ps1
+++ b/e2e/terraform/userdata/windows-2016.ps1
@@ -20,4 +20,7 @@ icacls $adminKey /inheritance:r
 icacls $adminKey /grant BUILTIN\Administrators:`(F`)
 icacls $adminKey /grant SYSTEM:`(F`)
 
+# for host volume testing
+New-Item -ItemType Directory -Force -Path C:\tmp\data
+
 </powershell>


### PR DESCRIPTION
A few minor items pulled out of https://github.com/hashicorp/nomad/pull/8748 to reduce the line count slightly:

* remove outdated references to envchain in documentation
* add new host volume locations in userdata
* don't exit the entire script during provisioning, just return