### PR TITLE
UI: Change compared page object to match by name

### DIFF
--- a/ui/tests/acceptance/job-deployments-test.js
+++ b/ui/tests/acceptance/job-deployments-test.js
@@ -178,7 +178,7 @@ module('Acceptance | job deployments', function(hooks) {
     );
 
     const taskGroup = taskGroupSummaries[0];
-    const taskGroupRow = deploymentRow.taskGroups.objectAt(0);
+    const taskGroupRow = deploymentRow.taskGroups.findOneBy('name', taskGroup.name);
 
     assert.equal(taskGroupRow.name, taskGroup.name, 'Name');
     assert.equal(taskGroupRow.promotion, promotionTestForTaskGroup(taskGroup), 'Needs Promotion');


### PR DESCRIPTION
I believe this test became flaky after #8833, you can see
an example failure here:
https://app.circleci.com/pipelines/github/hashicorp/nomad/11809/workflows/0dc3c8f4-187c-44af-8bdb-6f010d653081/jobs/100848

My understanding is the aim here is not to assert that the
first task group in the server database matches the first
row displayed, but that before #8833 it could be assumed
that they did match. This changes to find the row corresponding
to the first server task group instead of assuming it’ll
be first.