### PR TITLE
docs: update autoscaling docs for the new query interface

### DIFF
--- a/website/pages/docs/autoscaling/plugins/apm.mdx
+++ b/website/pages/docs/autoscaling/plugins/apm.mdx
@@ -15,9 +15,7 @@ scaling should occur.
 ## Prometheus APM Plugin
 
 Use [Prometheus][prometheus_io] metrics to scale your Nomad job task groups or
-cluster. The query performed on Prometheus should return a single value. You can
-use the [scalar][prometheus_scaler_function] function in your query to achieve
-this.
+cluster.
 
 ### Agent Configuration Options
 
@@ -39,7 +37,7 @@ apm "prometheus" {
 ```hcl
 check {
   source = "prometheus"
-  query  = "scalar(avg((haproxy_server_current_sessions{backend=\"http_back\"}) and (haproxy_server_up{backend=\"http_back\"} == 1)))"
+  query  = "avg((haproxy_server_current_sessions{backend=\"http_back\"}) and (haproxy_server_up{backend=\"http_back\"} == 1))"
   ...
 }
 ```
@@ -74,19 +72,10 @@ configuration parameters take precedence over the environment variables.
 ```hcl
 check {
   source = "datadog"
-  query  = "FROM=2m;TO=0m;QUERY=avg:proxy.backend.response.time{proxy-service:web-app}"
+  query  = "avg:proxy.backend.response.time{proxy-service:web-app}"
   ...
 }
 ```
-
-The query consists of three sections, each separated using a `;` delimiter. More
-information on the arguments can be found on the [Datadog site][datadog_timeseries].
-
-- `FROM` - A time offset which indicates the start of the queried time period.
-
-- `TO` - A time offset which indicates the end of the queried time period.
-
-- `QUERY` - The query string to execute.
 
 ## Nomad APM Plugin
 

--- a/website/pages/docs/autoscaling/policy.mdx
+++ b/website/pages/docs/autoscaling/policy.mdx
@@ -58,8 +58,7 @@ horizontal application scaling or horizontal cluster scaling.
   can be found on the [APM Plugins][apm_plugin_docs] page.
 
 - `query_window` - Defines how far back to query the APM for metrics. It should
-  be provided as a duration (e.g.: `"5s"`, `"1m"`). If omitted only the latest
-  value will be queried.
+  be provided as a duration (e.g.: `"5s"`, `"1m"`). Defaults to `1m`.
 
 - `strategy` - The strategy to use, and it's configuration when calculating the
   desired state based on the current count and the metric returned by the APM.

--- a/website/pages/docs/autoscaling/policy.mdx
+++ b/website/pages/docs/autoscaling/policy.mdx
@@ -57,6 +57,10 @@ horizontal application scaling or horizontal cluster scaling.
   should return a single value. Detailed information on the configuration options
   can be found on the [APM Plugins][apm_plugin_docs] page.
 
+- `query_window` - Defines how far back to query the APM for metrics. It should
+  be provided as a duration (e.g.: `"5s"`, `"1m"`). If omitted only the latest
+  value will be queried.
+
 - `strategy` - The strategy to use, and it's configuration when calculating the
   desired state based on the current count and the metric returned by the APM.
   Detailed information on the configuration options can be found on the
@@ -84,6 +88,7 @@ policy {
   check "active_connections" {
     source = "prometheus"
     query  = "scalar(open_connections_example_cache)"
+    query_window = "5m"
 
     strategy "target_value" {
       target = 10


### PR DESCRIPTION
Add documentation around the new `check` parameter called `query_window`.

This parameter can be used to specify a query window size when calling the APM.