### PR TITLE
Events/event source node

### DIFF
--- a/nomad/state/node_events.go
+++ b/nomad/state/node_events.go
@@ -1,0 +1,62 @@
+package state
+
+import (
+	"github.com/hashicorp/nomad/nomad/stream"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	TopicNodeRegistration   = "NodeRegistration"
+	TopicNodeDeregistration = "NodeDeregistration"
+)
+
+type NodeRegistrationEvent struct {
+	Event      *structs.NodeEvent
+	NodeStatus string
+}
+
+type NodeDeregistrationEvent struct {
+	NodeID string
+}
+
+func NodeRegisterEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
+	var events []stream.Event
+	for _, change := range changes.Changes {
+		switch change.Table {
+		case "nodes":
+			after := change.After.(*structs.Node)
+
+			event := stream.Event{
+				Topic: TopicNodeRegistration,
+				Index: changes.Index,
+				Key:   after.ID,
+				Payload: &NodeRegistrationEvent{
+					Event:      after.Events[len(after.Events)-1],
+					NodeStatus: after.Status,
+				},
+			}
+			events = append(events, event)
+		}
+	}
+	return events, nil
+}
+
+func NodeDeregisterEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
+	var event stream.Event
+	for _, change := range changes.Changes {
+		switch change.Table {
+		case "nodes":
+			before := change.Before.(*structs.Node)
+
+			event = stream.Event{
+				Topic: TopicNodeDeregistration,
+				Index: changes.Index,
+				Key:   before.ID,
+				Payload: &NodeDeregistrationEvent{
+					NodeID: before.ID,
+				},
+			}
+		}
+	}
+	return []stream.Event{event}, nil
+}

--- a/nomad/state/node_events_test.go
+++ b/nomad/state/node_events_test.go
@@ -1,0 +1,172 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/stream"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeRegisterEventFromChanges(t *testing.T) {
+	cases := []struct {
+		Name       string
+		MsgType    structs.MessageType
+		Setup      func(s *StateStore, tx *txn) error
+		Mutate     func(s *StateStore, tx *txn) error
+		WantEvents []stream.Event
+		WantErr    bool
+		WantTopic  string
+	}{
+		{
+			MsgType:   structs.NodeRegisterRequestType,
+			WantTopic: TopicNodeRegistration,
+			Name:      "node registered",
+			Mutate: func(s *StateStore, tx *txn) error {
+				return upsertNodeTxn(tx, tx.Index, testNode())
+			},
+			WantEvents: []stream.Event{{
+				Topic: TopicNodeRegistration,
+				Key:   testNodeID(),
+				Index: 100,
+				Payload: &NodeRegistrationEvent{
+					Event: &structs.NodeEvent{
+						Message:   "Node registered",
+						Subsystem: "Cluster",
+					},
+					NodeStatus: structs.NodeStatusReady,
+				},
+			}},
+			WantErr: false,
+		},
+		{
+			MsgType:   structs.NodeRegisterRequestType,
+			WantTopic: TopicNodeRegistration,
+			Name:      "node registered initializing",
+			Mutate: func(s *StateStore, tx *txn) error {
+				return upsertNodeTxn(tx, tx.Index, testNode(nodeNotReady))
+			},
+			WantEvents: []stream.Event{{
+				Topic: TopicNodeRegistration,
+				Key:   testNodeID(),
+				Index: 100,
+				Payload: &NodeRegistrationEvent{
+					Event: &structs.NodeEvent{
+						Message:   "Node registered",
+						Subsystem: "Cluster",
+					},
+					NodeStatus: structs.NodeStatusInit,
+				},
+			}},
+			WantErr: false,
+		},
+		{
+			MsgType:   structs.NodeDeregisterRequestType,
+			WantTopic: TopicNodeDeregistration,
+			Name:      "node deregistered",
+			Setup: func(s *StateStore, tx *txn) error {
+				return upsertNodeTxn(tx, tx.Index, testNode())
+			},
+			Mutate: func(s *StateStore, tx *txn) error {
+				return deleteNodeTxn(tx, tx.Index, []string{testNodeID()})
+			},
+			WantEvents: []stream.Event{{
+				Topic: TopicNodeDeregistration,
+				Key:   testNodeID(),
+				Index: 100,
+				Payload: &NodeDeregistrationEvent{
+					NodeID: testNodeID(),
+				},
+			}},
+			WantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			s := TestStateStoreCfg(t, TestStateStorePublisher(t))
+			defer s.StopEventPublisher()
+
+			if tc.Setup != nil {
+				// Bypass publish mechanism for setup
+				setupTx := s.db.WriteTxn(10)
+				require.NoError(t, tc.Setup(s, setupTx))
+				setupTx.Txn.Commit()
+			}
+
+			tx := s.db.WriteTxn(100)
+			require.NoError(t, tc.Mutate(s, tx))
+
+			changes := Changes{Changes: tx.Changes(), Index: 100, MsgType: tc.MsgType}
+			got, err := processDBChanges(tx, changes)
+
+			if tc.WantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			require.Equal(t, len(tc.WantEvents), len(got))
+			for idx, g := range got {
+				switch tc.MsgType {
+				case structs.NodeRegisterRequestType:
+					requireNodeRegistrationEventEqual(t, tc.WantEvents[idx], g)
+				case structs.NodeDeregisterRequestType:
+					requireNodeDeregistrationEventEqual(t, tc.WantEvents[idx], g)
+				}
+			}
+		})
+	}
+}
+
+func requireNodeRegistrationEventEqual(t *testing.T, want, got stream.Event) {
+	t.Helper()
+
+	require.Equal(t, want.Index, got.Index)
+	require.Equal(t, want.Key, got.Key)
+	require.Equal(t, want.Topic, got.Topic)
+
+	wantPayload := want.Payload.(*NodeRegistrationEvent)
+	gotPayload := got.Payload.(*NodeRegistrationEvent)
+
+	// Check payload equality for the fields that we can easily control
+	require.Equal(t, wantPayload.NodeStatus, gotPayload.NodeStatus)
+	require.Equal(t, wantPayload.Event.Message, gotPayload.Event.Message)
+	require.Equal(t, wantPayload.Event.Subsystem, gotPayload.Event.Subsystem)
+}
+
+func requireNodeDeregistrationEventEqual(t *testing.T, want, got stream.Event) {
+	t.Helper()
+
+	require.Equal(t, want.Index, got.Index)
+	require.Equal(t, want.Key, got.Key)
+	require.Equal(t, want.Topic, got.Topic)
+
+	wantPayload := want.Payload.(*NodeDeregistrationEvent)
+	gotPayload := got.Payload.(*NodeDeregistrationEvent)
+
+	require.Equal(t, wantPayload, gotPayload)
+}
+
+type nodeOpts func(n *structs.Node)
+
+func nodeNotReady(n *structs.Node) {
+	n.Status = structs.NodeStatusInit
+}
+
+func testNode(opts ...nodeOpts) *structs.Node {
+	n := mock.Node()
+	n.ID = testNodeID()
+
+	n.SecretID = "ab9812d3-6a21-40d3-973d-d9d2174a23ee"
+
+	for _, opt := range opts {
+		opt(n)
+	}
+	return n
+}
+
+func testNodeID() string {
+	return "9d5741c1-3899-498a-98dd-eb3c05665863"
+}

--- a/nomad/state/state_changes.go
+++ b/nomad/state/state_changes.go
@@ -88,7 +88,8 @@ func (c *changeTrackerDB) WriteTxn(idx uint64) *txn {
 	return t
 }
 
-func (c *changeTrackerDB) WriteTxnWithCtx(ctx context.Context, idx uint64) *txn {
+// WriteTxnCtx is identical to WriteTxn but takes a ctx used for event sourcing
+func (c *changeTrackerDB) WriteTxnCtx(ctx context.Context, idx uint64) *txn {
 	t := &txn{
 		ctx:     ctx,
 		Txn:     c.db.Txn(true),
@@ -198,6 +199,5 @@ func processDBChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
 	case structs.NodeDeregisterRequestType:
 		return NodeDeregisterEventFromChanges(tx, changes)
 	}
-	// TODO: add  handlers here.
 	return []stream.Event{}, nil
 }

--- a/nomad/state/state_changes.go
+++ b/nomad/state/state_changes.go
@@ -1,10 +1,16 @@
 package state
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/stream"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	CtxMsgType = "type"
 )
 
 // ReadTxn is implemented by memdb.Txn to perform read operations.
@@ -21,6 +27,7 @@ type Changes struct {
 	// Index is the latest index at the time these changes were committed.
 	Index   uint64
 	Changes memdb.Changes
+	MsgType structs.MessageType
 }
 
 // changeTrackerDB is a thin wrapper around memdb.DB which enables TrackChanges on
@@ -81,6 +88,17 @@ func (c *changeTrackerDB) WriteTxn(idx uint64) *txn {
 	return t
 }
 
+func (c *changeTrackerDB) WriteTxnWithCtx(ctx context.Context, idx uint64) *txn {
+	t := &txn{
+		ctx:     ctx,
+		Txn:     c.db.Txn(true),
+		Index:   idx,
+		publish: c.publish,
+	}
+	t.Txn.TrackChanges()
+	return t
+}
+
 func (c *changeTrackerDB) publish(changes Changes) error {
 	readOnlyTx := c.db.Txn(false)
 	defer readOnlyTx.Abort()
@@ -113,6 +131,9 @@ func (c *changeTrackerDB) WriteTxnRestore() *txn {
 // error. Any errors from the callback would be lost,  which would result in a
 // missing change event, even though the state store had changed.
 type txn struct {
+	// ctx is used to hold message type information from an FSM request
+	ctx context.Context
+
 	*memdb.Txn
 	// Index in raft where the write is occurring. The value is zero for a
 	// read-only, or WriteTxnRestore transaction.
@@ -136,6 +157,7 @@ func (tx *txn) Commit() error {
 		changes := Changes{
 			Index:   tx.Index,
 			Changes: tx.Txn.Changes(),
+			MsgType: tx.MsgType(),
 		}
 		if err := tx.publish(changes); err != nil {
 			return err
@@ -146,7 +168,36 @@ func (tx *txn) Commit() error {
 	return nil
 }
 
+// MsgType returns a MessageType from the txn's context.
+// If the context is empty or the value isn't set IgnoreUnknownTypeFlag will
+// be returned to signal that the MsgType is unknown.
+func (tx *txn) MsgType() structs.MessageType {
+	if tx.ctx == nil {
+		return structs.IgnoreUnknownTypeFlag
+	}
+
+	raw := tx.ctx.Value(CtxMsgType)
+	if raw == nil {
+		return structs.IgnoreUnknownTypeFlag
+	}
+
+	msgType, ok := raw.(structs.MessageType)
+	if !ok {
+		return structs.IgnoreUnknownTypeFlag
+	}
+	return msgType
+}
+
 func processDBChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
+	switch changes.MsgType {
+	case structs.IgnoreUnknownTypeFlag:
+		// unknown event type
+		return []stream.Event{}, nil
+	case structs.NodeRegisterRequestType:
+		return NodeRegisterEventFromChanges(tx, changes)
+	case structs.NodeDeregisterRequestType:
+		return NodeDeregisterEventFromChanges(tx, changes)
+	}
 	// TODO: add  handlers here.
 	return []stream.Event{}, nil
 }

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -210,6 +210,10 @@ func (s *StateStore) Abandon() {
 	close(s.abandonCh)
 }
 
+func (s *StateStore) StopEventPublisher() {
+	s.stopEventPublisher()
+}
+
 // QueryFn is the definition of a function that can be used to implement a basic
 // blocking query against the state store.
 type QueryFn func(memdb.WatchSet, *StateStore) (resp interface{}, index uint64, err error)
@@ -740,6 +744,18 @@ func (s *StateStore) ScalingEventsByJob(ws memdb.WatchSet, namespace, jobID stri
 	return nil, 0, nil
 }
 
+func (s *StateStore) UpsertNodeCtx(ctx context.Context, index uint64, node *structs.Node) error {
+	txn := s.db.WriteTxnWithCtx(ctx, index)
+	defer txn.Abort()
+
+	err := upsertNodeTxn(txn, index, node)
+	if err != nil {
+		return nil
+	}
+	txn.Commit()
+	return nil
+}
+
 // UpsertNode is used to register a node or update a node definition
 // This is assumed to be triggered by the client, so we retain the value
 // of drain/eligibility which is set by the scheduler.
@@ -747,6 +763,15 @@ func (s *StateStore) UpsertNode(index uint64, node *structs.Node) error {
 	txn := s.db.WriteTxn(index)
 	defer txn.Abort()
 
+	err := upsertNodeTxn(txn, index, node)
+	if err != nil {
+		return nil
+	}
+	txn.Commit()
+	return nil
+}
+
+func upsertNodeTxn(txn *txn, index uint64, node *structs.Node) error {
 	// Check if the node already exists
 	existing, err := txn.First("nodes", "id", node.ID)
 	if err != nil {
@@ -795,18 +820,38 @@ func (s *StateStore) UpsertNode(index uint64, node *structs.Node) error {
 		return fmt.Errorf("csi plugin update failed: %v", err)
 	}
 
+	return nil
+}
+
+func (s *StateStore) DeleteNodeCtx(ctx context.Context, index uint64, nodes []string) error {
+	txn := s.db.WriteTxnWithCtx(ctx, index)
+	defer txn.Abort()
+
+	err := deleteNodeTxn(txn, index, nodes)
+	if err != nil {
+		return nil
+	}
 	txn.Commit()
 	return nil
 }
 
 // DeleteNode deregisters a batch of nodes
 func (s *StateStore) DeleteNode(index uint64, nodes []string) error {
+	txn := s.db.WriteTxn(index)
+	defer txn.Abort()
+
+	err := deleteNodeTxn(txn, index, nodes)
+	if err != nil {
+		return nil
+	}
+	txn.Commit()
+	return nil
+}
+
+func deleteNodeTxn(txn *txn, index uint64, nodes []string) error {
 	if len(nodes) == 0 {
 		return fmt.Errorf("node ids missing")
 	}
-
-	txn := s.db.WriteTxn(index)
-	defer txn.Abort()
 
 	for _, nodeID := range nodes {
 		existing, err := txn.First("nodes", "id", nodeID)
@@ -832,7 +877,6 @@ func (s *StateStore) DeleteNode(index uint64, nodes []string) error {
 		return fmt.Errorf("index update failed: %v", err)
 	}
 
-	txn.Commit()
 	return nil
 }
 

--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -24,6 +24,25 @@ func TestStateStore(t testing.T) *StateStore {
 	return state
 }
 
+func TestStateStorePublisher(t testing.T) *StateStoreConfig {
+	return &StateStoreConfig{
+		Logger:          testlog.HCLogger(t),
+		Region:          "global",
+		EnablePublisher: true,
+	}
+}
+func TestStateStoreCfg(t testing.T, cfg *StateStoreConfig) *StateStore {
+	state, err := NewStateStore(cfg)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if state == nil {
+		t.Fatalf("missing state")
+	}
+	return state
+}
+
 // CreateTestCSIPlugin is a helper that generates the node + fingerprint results necessary
 // to create a CSIPlugin by directly inserting into the state store. The plugin requires a
 // controller.


### PR DESCRIPTION
Source node registration and deregistration events from the FSM

This PR updates the FSM to pass in the message type to apply functions. A Context is added to state store methods to allow retrieving the msg type during event creation.

The bodies of the two events here, NodeRegisration and NodeDeregistration may change some, but depending on feedback to the FSM / state store this is how all events will be generated