### PR TITLE
e2e: reschedule tests should check for non-zero rescheduled allocs

### DIFF
--- a/e2e/rescheduling/rescheduling.go
+++ b/e2e/rescheduling/rescheduling.go
@@ -265,7 +265,7 @@ func (tc *RescheduleE2ETest) TestRescheduleWithCanaryAutoRevert(f *framework.F) 
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
 			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID) },
-			func(got []string) bool { return len(got) == 0 }, nil,
+			func(got []string) bool { return len(got) > 0 }, nil,
 		),
 		"should have new allocs after update",
 	)
@@ -354,7 +354,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxParallelAutoRevert(f *framework.F)
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
 			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID) },
-			func(got []string) bool { return len(got) == 0 }, nil,
+			func(got []string) bool { return len(got) > 0 }, nil,
 		),
 		"should have new allocs after update",
 	)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8895

The conditional around some of the rescheduling tests was backwards, where we
were waiting for allocations to be rescheduled but testing for a count of
0. The test was passing but flaky because if the check happened quickly enough
before the scheduler rescheduled the allocations, it would pass.

---



```
$ NOMAD_E2E=1 go test -v . -suite=Rescheduling
=== RUN   TestE2E
...
=== RUN   TestE2E/Rescheduling
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestDefaultReschedule
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestNoReschedule
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestNoRescheduleSystem
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxAttempts
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxParallel
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxParallelAutoRevert
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleProgressDeadline
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleSuccess
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithCanary
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithCanaryAutoRevert
=== RUN   TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithUpdate
...
--- PASS: TestE2E (116.23s)
    --- SKIP: TestE2E/Affinity (0.00s)
    --- SKIP: TestE2E/clientstate (0.00s)
    --- SKIP: TestE2E/Connect (0.00s)
    --- SKIP: TestE2E/ConnectACLs (0.00s)
    --- SKIP: TestE2E/Consul (0.00s)
    --- SKIP: TestE2E/Consul_Template (0.00s)
    --- SKIP: TestE2E/CSI (0.00s)
    --- SKIP: TestE2E/Deployment (0.00s)
    --- SKIP: TestE2E/simple (0.00s)
    --- SKIP: TestE2E/Host_Volumes (0.00s)
    --- SKIP: TestE2E/Lifecycle (0.00s)
    --- SKIP: TestE2E/Metrics (0.00s)
    --- SKIP: TestE2E/Nomad_exec (0.00s)
    --- SKIP: TestE2E/Podman (0.00s)
    --- PASS: TestE2E/Rescheduling (116.23s)
        --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest (116.14s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestDefaultReschedule (38.08s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestNoReschedule (0.66s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestNoRescheduleSystem (1.30s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxAttempts (1.90s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxParallel (9.86s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleMaxParallelAutoRevert (7.73s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleProgressDeadline (31.72s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleSuccess (2.64s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithCanary (6.59s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithCanaryAutoRevert (9.86s)
            --- PASS: TestE2E/Rescheduling/*rescheduling.RescheduleE2ETest/TestRescheduleWithUpdate (5.66s)
    --- SKIP: TestE2E/Spread (0.00s)
    --- SKIP: TestE2E/SystemScheduler (0.00s)
    --- SKIP: TestE2E/TaskEvents (0.00s)
PASS
ok      github.com/hashicorp/nomad/e2e  116.362s
```