### PR TITLE
e2e: add flags for provisioning Nomad Enterprise

### DIFF
--- a/e2e/terraform/README.md
+++ b/e2e/terraform/README.md
@@ -57,6 +57,9 @@ You'll need to pass one of the following variables in either your
   [releases.hashicorp.com](https://releases.hashicorp.com/nomad). Ex. `nomad_version
   = "0.10.2+ent"`
 
+If you want to deploy the Enterprise build of a specific SHA, include
+`-var 'nomad_enterprise=true'`.
+
 ## Profiles
 
 The `profile` field selects from a set of configuration files for Nomad,

--- a/e2e/terraform/nomad.tf
+++ b/e2e/terraform/nomad.tf
@@ -19,6 +19,8 @@ module "nomad_server" {
 
   nomad_local_binary = count.index < length(var.nomad_local_binary_server) ? var.nomad_local_binary_server[count.index] : var.nomad_local_binary
 
+  nomad_enterprise = var.nomad_enterprise
+
   connection = {
     type        = "ssh"
     user        = "ubuntu"
@@ -51,6 +53,8 @@ module "nomad_client_linux" {
 
   nomad_local_binary = count.index < length(var.nomad_local_binary_client_linux) ? var.nomad_local_binary_client_linux[count.index] : var.nomad_local_binary
 
+  nomad_enterprise = var.nomad_enterprise
+
   connection = {
     type        = "ssh"
     user        = "ubuntu"
@@ -80,6 +84,11 @@ module "nomad_client_windows" {
   nomad_version = count.index < length(var.nomad_version_client_windows) ? var.nomad_version_client_windows[count.index] : var.nomad_version
 
   nomad_sha = count.index < length(var.nomad_sha_client_windows) ? var.nomad_sha_client_windows[count.index] : var.nomad_sha
+
+  # if nomad_local_binary is in use, you must pass a nomad_local_binary_client_windows!
+  nomad_local_binary = count.index < length(var.nomad_local_binary_client_windows) ? var.nomad_local_binary_client_windows[count.index] : ""
+
+  nomad_enterprise = var.nomad_enterprise
 
   connection = {
     type        = "ssh"

--- a/e2e/terraform/packer/linux/provision.sh
+++ b/e2e/terraform/packer/linux/provision.sh
@@ -17,6 +17,7 @@ Options for configuration:
  --role ROLE                role within config profile directory
  --index INDEX              count of instance, for profiles with per-instance config
  --nostart                  do not start or restart Nomad
+ --enterprise               if nomad_sha is passed, use the ENT version
 
 EOF
 
@@ -33,6 +34,7 @@ install_fn=
 NOMAD_PROFILE=
 NOMAD_ROLE=
 NOMAD_INDEX=
+BUILD_FOLDER="builds-oss"
 
 install_from_s3() {
     # check that we don't already have this version
@@ -41,7 +43,7 @@ install_from_s3() {
             && echo "$NOMAD_SHA already installed" && return
     fi
 
-    S3_URL="s3://nomad-team-dev-test-binaries/builds-oss/nomad_${PLATFORM}_${NOMAD_SHA}.tar.gz"
+    S3_URL="s3://nomad-team-dev-test-binaries/${BUILD_FOLDER}/nomad_${PLATFORM}_${NOMAD_SHA}.tar.gz"
     aws s3 cp --quiet "$S3_URL" nomad.tar.gz
     sudo tar -zxvf nomad.tar.gz -C "$INSTALL_DIR"
     set_ownership
@@ -151,6 +153,10 @@ opt="$1"
         --nostart)
             # for initial packer builds, we don't want to start Nomad
             START=0
+            shift
+            ;;
+        --enterprise)
+            BUILD_FOLDER="builds-ent"
             shift
             ;;
         *) usage ;;

--- a/e2e/terraform/packer/windows/provision.ps1
+++ b/e2e/terraform/packer/windows/provision.ps1
@@ -2,6 +2,7 @@ param(
     [string]$nomad_sha,
     [string]$nomad_version,
     [string]$nomad_binary,
+    [switch]$enterprise = $false,
     [string]$config_profile,
     [string]$role,
     [string]$index,
@@ -23,6 +24,8 @@ Options for configuration:
  -role ROLE               role within config profile directory
  -index INDEX             count of instance, for profiles with per-instance config
  -nostart                 do not start or restart Nomad
+ -enterprise              if nomad_sha is passed, use the ENT version
+
 "@
 
 $RunningAsAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
@@ -57,7 +60,11 @@ function InstallFromS3 {
     }
 
     Try {
-        $key = "builds-oss/nomad_${platform}_${nomad_sha}.zip"
+        $build_folder = "builds-oss"
+        if ($enterprise) {
+            $build_folder = "builds-ent"
+        }
+        $key = "${build_folder}/nomad_${platform}_${nomad_sha}.zip"
 		Read-S3Object -BucketName nomad-team-dev-test-binaries -Key $key -File ./nomad.zip
 		Remove-Item -Path $install_path -Force -ErrorAction Ignore
 		Expand-Archive ./nomad.zip ./ -Force

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -46,7 +46,7 @@ resource "null_resource" "provision_nomad" {
 }
 
 data "template_file" "provision_script" {
-  template = "${local.provision_script}${data.template_file.arg_nomad_sha.rendered}${data.template_file.arg_nomad_version.rendered}${data.template_file.arg_nomad_binary.rendered}${data.template_file.arg_profile.rendered}${data.template_file.arg_role.rendered}${data.template_file.arg_index.rendered}"
+  template = "${local.provision_script}${data.template_file.arg_nomad_sha.rendered}${data.template_file.arg_nomad_version.rendered}${data.template_file.arg_nomad_binary.rendered}${data.template_file.arg_nomad_enterprise.rendered}${data.template_file.arg_profile.rendered}${data.template_file.arg_role.rendered}${data.template_file.arg_index.rendered}"
 }
 
 data "template_file" "arg_nomad_sha" {
@@ -59,6 +59,10 @@ data "template_file" "arg_nomad_version" {
 
 data "template_file" "arg_nomad_binary" {
   template = var.nomad_local_binary != "" ? " ${local._arg}nomad_binary ${var.nomad_local_binary}" : ""
+}
+
+data "template_file" "arg_nomad_enterprise" {
+  template = var.nomad_enterprise != false ? " ${local._arg}enterprise" : ""
 }
 
 data "template_file" "arg_profile" {

--- a/e2e/terraform/provision-nomad/variables.tf
+++ b/e2e/terraform/provision-nomad/variables.tf
@@ -22,6 +22,12 @@ variable "nomad_local_binary" {
   default     = ""
 }
 
+variable "nomad_enterprise" {
+  type        = bool
+  description = "If nomad_sha is used, deploy Nomad Enterprise"
+  default     = false
+}
+
 variable "profile" {
   type        = string
   description = "The name of the configuration profile (ex. 'full-cluster')"

--- a/e2e/terraform/tests/nomad.tf
+++ b/e2e/terraform/tests/nomad.tf
@@ -22,6 +22,8 @@ module "nomad_server" {
   nomad_sha = count.index < length(var.nomad_sha_server) ? var.nomad_sha_server[count.index] : var.nomad_sha
 
   nomad_local_binary = count.index < length(var.nomad_local_binary_server) ? var.nomad_local_binary_server[count.index] : var.nomad_local_binary
+
+  nomad_enterprise = var.nomad_enterprise
 }
 
 module "nomad_client_linux" {
@@ -37,6 +39,8 @@ module "nomad_client_linux" {
   nomad_sha = count.index < length(var.nomad_sha_client_linux) ? var.nomad_sha_client_linux[count.index] : var.nomad_sha
 
   nomad_local_binary = count.index < length(var.nomad_local_binary_client_linux) ? var.nomad_local_binary_client_linux[count.index] : var.nomad_local_binary
+
+  nomad_enterprise = var.nomad_enterprise
 }
 
 module "nomad_client_windows" {
@@ -52,4 +56,6 @@ module "nomad_client_windows" {
   nomad_sha = count.index < length(var.nomad_sha_client_windows) ? var.nomad_sha_client_windows[count.index] : var.nomad_sha
 
   nomad_local_binary = count.index < length(var.nomad_local_binary_client_windows) ? var.nomad_local_binary_client_windows[count.index] : var.nomad_local_binary
+
+  nomad_enterprise = var.nomad_enterprise
 }

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -73,6 +73,11 @@ variable "nomad_local_binary" {
   default     = ""
 }
 
+variable "nomad_enterprise" {
+  type        = bool
+  description = "If nomad_sha is used, deploy Nomad Enterprise"
+  default     = false
+}
 # ----------------------------------------
 # If you want to deploy multiple versions you can use these variables to
 # provide a list of builds to override the values of nomad_sha, nomad_version,


### PR DESCRIPTION
Add a `nomad_enterprise` variable to the Terraform config so that we can pull builds of Nomad Enterprise from S3 after the nightly merge.
