### PR TITLE
drivers/docker/driver.go: change default signal for docker driver to SIGTERM?

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1299,7 +1299,7 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	}
 
 	if signal == "" {
-		signal = "SIGINT"
+		signal = "SIGTERM"
 	}
 
 	// Windows Docker daemon does not support SIGINT, SIGTERM is the semantic equivalent that


### PR DESCRIPTION
Partial #8932 (needs docs)

NOTE: I'm guessing ideally, the standard messaging in various places (`nomad/structs/structs.go`, `command/alloc_status.go`) with text like 'Sent interrupt' might have to change as well, but maybe that can be part of a bigger discussion. For now, I think updating the default from SIGINT to SIGTERM makes sense.

References: https://www.nomadproject.io/docs/job-specification/task#kill_signal, https://docs.docker.com/engine/reference/commandline/stop/