### PR TITLE
docs: fix escaping in job run env vars

### DIFF
--- a/website/pages/docs/commands/job/run.mdx
+++ b/website/pages/docs/commands/job/run.mdx
@@ -75,13 +75,13 @@ precedence, going from highest to lowest: the `-vault-token` flag, the
 
 - `-consul-token`: If set, the passed Consul token is stored in the job before
   sending to the Nomad servers. This allows passing the Consul token without
-  storing it in the job file. This overrides the token found in the \$CONSUL_HTTP_TOKEN
-  environment variable and that found in the job.
+  storing it in the job file. This overrides the token found in the
+  `$CONSUL_HTTP_TOKEN` environment variable and that found in the job.
 
 - `-vault-token`: If set, the passed Vault token is stored in the job before
   sending to the Nomad servers. This allows passing the Vault token without
-  storing it in the job file. This overrides the token found in the \$VAULT_TOKEN
-  environment variable and that found in the job.
+  storing it in the job file. This overrides the token found in the
+  `$VAULT_TOKEN` environment variable and that found in the job.
 
 - `-verbose`: Show full information.
 


### PR DESCRIPTION
Broken escaping:
* https://www.nomadproject.io/docs/commands/job/run#consul-token
* https://www.nomadproject.io/docs/commands/job/run#vault-token

Fixed with this PR:
* https://deploy-preview-8944--nomad-website.netlify.app/docs/commands/job/run#consul-token
* https://deploy-preview-8944--nomad-website.netlify.app/docs/commands/job/run#vault-token