### PR TITLE
e2e: use more recent instance type

### DIFF
--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -1,5 +1,5 @@
 region               = "us-east-1"
-instance_type        = "t2.medium"
+instance_type        = "t3.medium"
 server_count         = "3"
 client_count         = "4"
 windows_client_count = "1"

--- a/e2e/terraform/terraform.tfvars.dev
+++ b/e2e/terraform/terraform.tfvars.dev
@@ -1,5 +1,5 @@
 region               = "us-east-1"
-instance_type        = "t2.medium"
+instance_type        = "t3.medium"
 server_count         = "3"
 client_count         = "2"
 windows_client_count = "0"

--- a/e2e/terraform/userdata/ubuntu-bionic.sh
+++ b/e2e/terraform/userdata/ubuntu-bionic.sh
@@ -17,6 +17,22 @@ sudo mv /tmp/resolv.conf /etc/resolv.conf
 # For host volume testing
 sudo mkdir -p /tmp/data
 
+# need to get the interface for dnsmasq config so that we can
+# accomodate both "predictable" and old-style interface names
+IFACE=$(/usr/local/bin/sockaddr eval 'GetDefaultInterfaces | attr "Name"')
+
+cat <<EOF > /tmp/dnsmasq
+port=53
+resolv-file=/var/run/dnsmasq/resolv.conf
+bind-interfaces
+interface=docker0
+interface=lo
+interface=$IFACE
+listen-address=127.0.0.1
+server=/consul/127.0.0.1#8600
+EOF
+sudo mv /tmp/dnsmasq /etc/dnsmasq.d/default
+
 # need to get the AWS DNS address from the VPC...
 # this is pretty hacky but will work for any typical case
 MAC=$(curl -s --fail http://169.254.169.254/latest/meta-data/mac)


### PR DESCRIPTION
Newer EC2 instances are cheaper and have generally better performance.

The dnsmasq configuration had a hard-coded interface name, so in order to
accomodate instances with more recent networking that result in so-called
predictable interface names, the dnsmasq configuration needs to be replaced at
runtime with userdata to select the default interface.

--- 

Tested end-to-end:

```
$ nomad server members
Name                     Address        Port  Status  Leader  Protocol  Build       Datacenter  Region
ip-172-31-0-181.global   172.31.0.181   4648  alive   false   2         0.13.0-dev  dc1         global
ip-172-31-1-84.global    172.31.1.84    4648  alive   false   2         0.13.0-dev  dc1         global
ip-172-31-10-115.global  172.31.10.115  4648  alive   true    2         0.13.0-dev  dc1         global

$ nomad node status
ID        DC   Name              Class   Drain  Eligibility  Status
e084743e  dc1  EC2AMAZ-DQGNBVC   <none>  false  eligible     ready
eccd28b0  dc1  ip-172-31-5-231   <none>  false  eligible     ready
d0f38a29  dc2  ip-172-31-4-67    <none>  false  eligible     ready
05af173f  dc1  ip-172-31-13-126  <none>  false  eligible     ready
c33a9082  dc2  ip-172-31-0-118   <none>  false  eligible     ready
```