### PR TITLE
ci: don't run UI tests for e2e branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1398,6 +1398,7 @@ workflows:
             ignore:
             - stable-website
             - /^docs-.*/
+            - /^e2e-.*/
     - test-windows:
         filters:
           branches:

--- a/.circleci/config/workflows/build-test.yml
+++ b/.circleci/config/workflows/build-test.yml
@@ -30,6 +30,7 @@ jobs:
           ignore:
             - stable-website
             - /^docs-.*/
+            - /^e2e-.*/
 
     # Note: comment-out this job in ENT
   - test-windows:


### PR DESCRIPTION
In https://github.com/hashicorp/nomad/pull/8909 we excluded `e2e` branches from running unit tests, because there's no way for those changes to have unit test impact. But we missed the `test-ui` job.