### PR TITLE
drivers/docker: detect arch for default docker plugin infra_image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
  * core: Improved job deregistration error logging. [[GH-8745](https://github.com/hashicorp/nomad/issues/8745)]
  * api: Added support for cancellation contexts to HTTP API. [[GH-8836](https://github.com/hashicorp/nomad/issues/8836)]
+ * driver/docker: upgrade pause container and detect architecture [[GH-8957](https://github.com/hashicorp/nomad/pull/8957)]
 
 BUG FIXES:
 

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -257,7 +258,10 @@ var (
 		// image to use when creating a network namespace parent container
 		"infra_image": hclspec.NewDefault(
 			hclspec.NewAttr("infra_image", "string", false),
-			hclspec.NewLiteral(`"gcr.io/google_containers/pause-amd64:3.0"`),
+			hclspec.NewLiteral(fmt.Sprintf(
+				`"gcr.io/google_containers/pause-%s:3.1"`,
+				runtime.GOARCH,
+			)),
 		),
 		// timeout to use when pulling the infra image.
 		"infra_image_pull_timeout": hclspec.NewDefault(

--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -824,8 +824,8 @@ plugin "docker" {
     the standard binds in the container.
 
 - `infra_image` - This is the Docker image to use when creating the parent
-  container necessary when sharing network namespaces between tasks. Defaults
-  to "gcr.io/google_containers/pause-amd64:3.0".
+  container necessary when sharing network namespaces between tasks. Defaults to
+   `gcr.io/google_containers/pause-<goarch>:3.1`.
 
 - `infra_image_pull_timeout` - A time duration that controls how long Nomad will
   wait before cancelling an in-progress pull of the Docker image as specified in


### PR DESCRIPTION
The `docker.config.infra_image` would default to an amd64 container.
It is possible to reference the correct image for a platform using
the `runtime.GOARCH` variable, eliminating the need to explicitly set
the `infra_image` on non-amd64 platforms.

Also upgrade to Google's pause container version 3.1 from 3.0, which
includes some enhancements around process management.

Fixes #8926