### PR TITLE
    Allow operators to configure cleanup_on_shutdown for clients

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -739,8 +739,7 @@ func (c *Client) Shutdown() error {
 	c.garbageCollector.Stop()
 
 	arGroup := group{}
-	if c.config.DevMode {
-		// In DevMode destroy all the running allocations.
+	if c.config.CleanupOnShutdown {
 		for _, ar := range c.getAllocRunners() {
 			ar.Destroy()
 			arGroup.AddCh(ar.DestroyCh())

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -221,6 +221,10 @@ type Config struct {
 	// place, and a small jitter is applied to avoid a thundering herd.
 	RPCHoldTimeout time.Duration
 
+	// CleanupOnShutdown will cause the nomad client to destroy allocations
+	// on shutdown - cleaning up resources but preventing recovery
+	CleanupOnShutdown bool
+
 	// PluginLoader is used to load plugins.
 	PluginLoader loader.PluginCatalog
 
@@ -324,6 +328,7 @@ func DefaultConfig() *Config {
 		},
 		BackwardsCompatibleMetrics: false,
 		RPCHoldTimeout:             5 * time.Second,
+		CleanupOnShutdown:          false,
 		CNIPath:                    "/opt/cni/bin",
 		CNIConfigDir:               "/opt/cni/config",
 		CNIInterfacePrefix:         "eth",

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -629,6 +629,8 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 		conf.NoHostUUID = true
 	}
 
+	conf.CleanupOnShutdown = agentConfig.Client.CleanupOnShutdown
+
 	// Setup the ACLs
 	conf.ACLEnabled = agentConfig.ACL.Enabled
 	conf.ACLTokenTTL = agentConfig.ACL.TokenTTL

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -256,6 +256,10 @@ type ClientConfig struct {
 	// before garbage collection is triggered.
 	GCMaxAllocs int `hcl:"gc_max_allocs"`
 
+	// CleanupOnShutdown will cause the nomad client to destroy allocations
+	// on shutdown - cleaning up resources but preventing recovery
+	CleanupOnShutdown bool `hcl:"cleanup_on_shutdown"`
+
 	// NoHostUUID disables using the host's UUID and will force generation of a
 	// random UUID.
 	NoHostUUID *bool `hcl:"no_host_uuid"`
@@ -831,6 +835,7 @@ func DevConfig(mode *devModeConfig) *Config {
 		DisableSandbox:    false,
 	}
 	conf.Client.BindWildcardDefaultHostNetwork = true
+	conf.Client.CleanupOnShutdown = true
 	conf.Telemetry.PrometheusMetrics = true
 	conf.Telemetry.PublishAllocationMetrics = true
 	conf.Telemetry.PublishNodeMetrics = true
@@ -865,6 +870,7 @@ func DefaultConfig() *Config {
 			GCDiskUsageThreshold:  80,
 			GCInodeUsageThreshold: 70,
 			GCMaxAllocs:           50,
+			CleanupOnShutdown:     false,
 			NoHostUUID:            helper.BoolToPtr(true),
 			DisableRemoteExec:     false,
 			ServerJoin: &ServerJoin{
@@ -1485,6 +1491,9 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 	if b.GCMaxAllocs != 0 {
 		result.GCMaxAllocs = b.GCMaxAllocs
+	}
+	if b.CleanupOnShutdown {
+		result.CleanupOnShutdown = b.CleanupOnShutdown
 	}
 	// NoHostUUID defaults to true, merge if false
 	if b.NoHostUUID != nil {


### PR DESCRIPTION
In dev mode the client will clean up allocation resources on shutdown, but there is no good way to get this in non-dev mode scenarios, and there are use cases for it - such as running a temporary client nodes.

This PR simply exposes a config option and deletes the DevMode test flag prefering to use it instead - defaulting it to true in dev mode.