### PR TITLE
Add NOMAD_JOB_ID and NOMAD_JOB_PARENT_ID env variables

### DIFF
--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -48,8 +48,14 @@ const (
 	// GroupName is the environment variable for passing the task group name.
 	GroupName = "NOMAD_GROUP_NAME"
 
+	// JobID is the environment variable for passing the job ID.
+	JobID = "NOMAD_JOB_ID"
+
 	// JobName is the environment variable for passing the job name.
 	JobName = "NOMAD_JOB_NAME"
+
+	// JobParentID is the environment variable for passing the ID of the parnt of the job
+	JobParentID = "NOMAD_JOB_PARENT_ID"
 
 	// AllocIndex is the environment variable for passing the allocation index.
 	AllocIndex = "NOMAD_ALLOC_INDEX"
@@ -323,7 +329,9 @@ type Builder struct {
 	vaultToken       string
 	vaultNamespace   string
 	injectVaultToken bool
+	jobID            string
 	jobName          string
+	jobParentID      string
 
 	// otherPorts for tasks in the same alloc
 	otherPorts map[string]string
@@ -417,8 +425,14 @@ func (b *Builder) Build() *TaskEnv {
 	if b.taskName != "" {
 		envMap[TaskName] = b.taskName
 	}
+	if b.jobID != "" {
+		envMap[JobID] = b.jobID
+	}
 	if b.jobName != "" {
 		envMap[JobName] = b.jobName
+	}
+	if b.jobParentID != "" {
+		envMap[JobParentID] = b.jobParentID
 	}
 	if b.datacenter != "" {
 		envMap[Datacenter] = b.datacenter
@@ -580,7 +594,9 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 	b.allocName = alloc.Name
 	b.groupName = alloc.TaskGroup
 	b.allocIndex = int(alloc.Index())
+	b.jobID = alloc.Job.ID
 	b.jobName = alloc.Job.Name
+	b.jobParentID = alloc.Job.ParentID
 	b.namespace = alloc.Namespace
 
 	// Set meta

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -11,6 +11,7 @@ import (
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -141,6 +142,7 @@ func TestEnvironment_AsList(t *testing.T) {
 		"metaKey": "metaVal",
 	}
 	a := mock.Alloc()
+	a.Job.ParentID = fmt.Sprintf("mock-parent-service-%s", uuid.Generate())
 	a.AllocatedResources.Tasks["web"].Networks[0] = &structs.NetworkResource{
 		Device:        "eth0",
 		IP:            "127.0.0.1",
@@ -204,7 +206,9 @@ func TestEnvironment_AsList(t *testing.T) {
 		"NOMAD_META_elb_check_type=http",
 		"NOMAD_META_foo=bar",
 		"NOMAD_META_owner=armon",
+		fmt.Sprintf("NOMAD_JOB_ID=%s", a.Job.ID),
 		"NOMAD_JOB_NAME=my-job",
+		fmt.Sprintf("NOMAD_JOB_PARENT_ID=%s", a.Job.ParentID),
 		fmt.Sprintf("NOMAD_ALLOC_ID=%s", a.ID),
 		"NOMAD_ALLOC_INDEX=0",
 	}
@@ -320,6 +324,7 @@ func TestEnvironment_AsList_Old(t *testing.T) {
 		"NOMAD_META_elb_check_type=http",
 		"NOMAD_META_foo=bar",
 		"NOMAD_META_owner=armon",
+		fmt.Sprintf("NOMAD_JOB_ID=%s", a.Job.ID),
 		"NOMAD_JOB_NAME=my-job",
 		fmt.Sprintf("NOMAD_ALLOC_ID=%s", a.ID),
 		"NOMAD_ALLOC_INDEX=0",
@@ -339,6 +344,7 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"invalid...metakey": "b",
 	}
 	a := mock.ConnectAlloc()
+	a.Job.ParentID = fmt.Sprintf("mock-parent-service-%s", uuid.Generate())
 	a.AllocatedResources.Tasks["web"].Networks[0] = &structs.NetworkResource{
 		Device:        "eth0",
 		IP:            "127.0.0.1",
@@ -463,7 +469,9 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"NOMAD_META_elb_check_type":                 "http",
 		"NOMAD_META_foo":                            "bar",
 		"NOMAD_META_owner":                          "armon",
+		"NOMAD_JOB_ID":                              a.Job.ID,
 		"NOMAD_JOB_NAME":                            "my-job",
+		"NOMAD_JOB_PARENT_ID":                       a.Job.ParentID,
 		"NOMAD_ALLOC_ID":                            a.ID,
 		"NOMAD_ALLOC_INDEX":                         "0",
 		"NOMAD_PORT_connect_proxy_testconnect":      "9999",

--- a/website/pages/docs/runtime/environment.mdx
+++ b/website/pages/docs/runtime/environment.mdx
@@ -22,11 +22,13 @@ environment variable names such as `NOMAD_ADDR_<task>_<label>`.
 
 ## Task Identifiers
 
-Nomad will pass both the allocation ID and name as well as the task, group and
-job's names. These are given as `NOMAD_ALLOC_ID`, `NOMAD_ALLOC_NAME`,
-`NOMAD_ALLOC_INDEX`, `NOMAD_JOB_NAME`, `NOMAD_GROUP_NAME` and `NOMAD_TASK_NAME`.
-The allocation ID and index can be useful when the task being run needs a unique
-identifier or to know its instance count.
+Nomad will pass both the allocation ID and name, the deployment ID that created
+the allocation, the job ID and name, the parent job ID as well as
+the task and group's names. These are given as `NOMAD_ALLOC_ID`, `NOMAD_ALLOC_NAME`,
+`NOMAD_ALLOC_INDEX`, `NOMAD_JOB_NAME`, `NOMAD_JOB_ID`, 
+`NOMAD_JOB_PARENT_ID`, `NOMAD_GROUP_NAME` and `NOMAD_TASK_NAME`. The allocation ID 
+and index can be useful when the task being run needs a unique identifier or to 
+know its instance count.
 
 ## Resources
 

--- a/website/pages/partials/envvars.mdx
+++ b/website/pages/partials/envvars.mdx
@@ -83,9 +83,21 @@
     </tr>
     <tr>
       <td>
+        <code>NOMAD_JOB_ID</code>
+      </td>
+      <td>Job&lsquo;s ID, which is equal to the Job name when submitted through CLI but can be different when using the API</td>
+    </tr>
+    <tr>
+      <td>
         <code>NOMAD_JOB_NAME</code>
       </td>
       <td>Job&lsquo;s name</td>
+    </tr>
+    <tr>
+      <td>
+        <code>NOMAD_JOB_PARENT_ID</code>
+      </td>
+      <td>ID of the Job&lsquo;s parent if it has one</td>
     </tr>
     <tr>
       <td>


### PR DESCRIPTION
[Updated] Beforehand tasks and field replacements did not have access to the
unique ID of their job or information about its parent. This adds this information
as new environment variables.