### PR TITLE
consul: fix validation of task in group-level script-checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
  * core: Fixed a bug where blocking queries would not include the query's maximum wait time when calculating whether it was safe to retry. [[GH-8921](https://github.com/hashicorp/nomad/issues/8921)]
+ * consul: Fixed a bug to correctly validate task when using script-checks in group-level services [[GH-8952](https://github.com/hashicorp/nomad/issues/8952)]
 
 ## 0.12.5 (September 17, 2020)
 

--- a/client/allocrunner/taskrunner/script_check_hook_test.go
+++ b/client/allocrunner/taskrunner/script_check_hook_test.go
@@ -286,3 +286,27 @@ func TestScript_TaskEnvInterpolation(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "my-job-backend-check", check.check.Name)
 }
+
+func TestScript_associated(t *testing.T) {
+	t.Run("neither set", func(t *testing.T) {
+		require.False(t, new(scriptCheckHook).associated("task1", "", ""))
+	})
+
+	t.Run("service set", func(t *testing.T) {
+		require.True(t, new(scriptCheckHook).associated("task1", "task1", ""))
+		require.False(t, new(scriptCheckHook).associated("task1", "task2", ""))
+	})
+
+	t.Run("check set", func(t *testing.T) {
+		require.True(t, new(scriptCheckHook).associated("task1", "", "task1"))
+		require.False(t, new(scriptCheckHook).associated("task1", "", "task2"))
+	})
+
+	t.Run("both set", func(t *testing.T) {
+		// ensure check.task takes precedence over service.task
+		require.True(t, new(scriptCheckHook).associated("task1", "task1", "task1"))
+		require.False(t, new(scriptCheckHook).associated("task1", "task1", "task2"))
+		require.True(t, new(scriptCheckHook).associated("task1", "task2", "task1"))
+		require.False(t, new(scriptCheckHook).associated("task1", "task2", "task2"))
+	})
+}

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -478,6 +478,7 @@ func TestJobEndpoint_Register_ConnectExposeCheck(t *testing.T) {
 			Name:     "check2",
 			Type:     "script",
 			Command:  "/bin/true",
+			TaskName: "web",
 			Interval: 1 * time.Second,
 			Timeout:  1 * time.Second,
 		}, {

--- a/website/pages/docs/job-specification/service.mdx
+++ b/website/pages/docs/job-specification/service.mdx
@@ -246,7 +246,8 @@ scripts.
 - `task` `(string: <required>)` - Specifies the task associated with this
   check. Scripts are executed within the task's environment, and
   `check_restart` stanzas will apply to the specified task. For `checks` on group
-  level `services` only.
+  level `services` only. Inherits the [`service.task`][service_task] value if not
+  set.
 
 - `timeout` `(string: <required>)` - Specifies how long Consul will wait for a
   health check query to succeed. This is specified using a label suffix like
@@ -714,3 +715,4 @@ advertise and check directly since Nomad isn't managing any port assignments.
 [shutdowndelay]: /docs/job-specification/task#shutdown_delay
 [killsignal]: /docs/job-specification/task#kill_signal
 [killtimeout]: /docs/job-specification/task#kill_timeout
+[service_task]: /docs/job-specification/service#task-1


### PR DESCRIPTION
When defining a script-check in a group-level service, Nomad needs to
know which task is associated with the check so that it can use the
correct task driver to execute the check.

This PR fixes two bugs:
1) validate service.task or service.check.task is configured
2) make service.check.task inherit service.task if it is itself unset

Fixes #8952