### PR TITLE
e2e: namespace support for CLI helpers

### DIFF
--- a/e2e/e2eutil/deployments.go
+++ b/e2e/e2eutil/deployments.go
@@ -7,14 +7,23 @@ import (
 	"github.com/hashicorp/nomad/testutil"
 )
 
-func WaitForLastDeploymentStatus(jobID, status string, wc *WaitConfig) error {
+func WaitForLastDeploymentStatus(jobID, ns, status string, wc *WaitConfig) error {
+	var nsArg = []string{}
+	if ns != "" {
+		nsArg = []string{"-namespace", ns}
+	}
+
 	var got string
 	var err error
 	interval, retries := wc.OrDefault()
 	testutil.WaitForResultRetries(retries, func() (bool, error) {
 		time.Sleep(interval)
 
-		out, err := Command("nomad", "job", "status", jobID)
+		cmd := []string{"nomad", "job", "status"}
+		cmd = append(cmd, nsArg...)
+		cmd = append(cmd, jobID)
+
+		out, err := Command(cmd[0], cmd[1:]...)
 		if err != nil {
 			return false, fmt.Errorf("could not get job status: %v\n%v", err, out)
 		}

--- a/e2e/rescheduling/rescheduling.go
+++ b/e2e/rescheduling/rescheduling.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/nomad/jobspec"
 )
 
+const ns = ""
+
 type RescheduleE2ETest struct {
 	framework.TC
 	jobIds []string
@@ -57,7 +59,7 @@ func (tc *RescheduleE2ETest) TestNoReschedule(f *framework.F) {
 
 	expected := []string{"failed", "failed", "failed"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 3 failed allocs",
 	)
 }
@@ -70,7 +72,7 @@ func (tc *RescheduleE2ETest) TestNoRescheduleSystem(f *framework.F) {
 
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
-			func() ([]string, error) { return e2e.AllocStatuses(jobID) },
+			func() ([]string, error) { return e2e.AllocStatuses(jobID, ns) },
 			func(got []string) bool {
 				for _, status := range got {
 					if status != "failed" {
@@ -93,7 +95,7 @@ func (tc *RescheduleE2ETest) TestDefaultReschedule(f *framework.F) {
 
 	expected := []string{"failed", "failed", "failed"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 3 failed allocs",
 	)
 
@@ -102,7 +104,7 @@ func (tc *RescheduleE2ETest) TestDefaultReschedule(f *framework.F) {
 	time.Sleep(time.Second * 35)
 	expected = []string{"failed", "failed", "failed", "failed", "failed", "failed"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 6 failed allocs after 35s",
 	)
 }
@@ -116,7 +118,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxAttempts(f *framework.F) {
 
 	expected := []string{"failed", "failed", "failed"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 3 failed allocs",
 	)
 
@@ -129,7 +131,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxAttempts(f *framework.F) {
 
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
-			func() ([]string, error) { return e2e.AllocStatuses(jobID) },
+			func() ([]string, error) { return e2e.AllocStatuses(jobID, ns) },
 			func(got []string) bool {
 				for _, status := range got {
 					if status == "running" {
@@ -152,7 +154,7 @@ func (tc *RescheduleE2ETest) TestRescheduleSuccess(f *framework.F) {
 
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
-			func() ([]string, error) { return e2e.AllocStatuses(jobID) },
+			func() ([]string, error) { return e2e.AllocStatuses(jobID, ns) },
 			func(got []string) bool {
 				for _, status := range got {
 					if status == "running" {
@@ -176,7 +178,7 @@ func (tc *RescheduleE2ETest) TestRescheduleWithUpdate(f *framework.F) {
 
 	expected := []string{"running", "running", "running"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 3 running allocs",
 	)
 
@@ -190,7 +192,7 @@ func (tc *RescheduleE2ETest) TestRescheduleWithUpdate(f *framework.F) {
 
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
-			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID) },
+			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID, ns) },
 			func(got []string) bool { return len(got) > 0 }, nil,
 		),
 		"should have rescheduled allocs until progress deadline",
@@ -207,12 +209,12 @@ func (tc *RescheduleE2ETest) TestRescheduleWithCanary(f *framework.F) {
 
 	expected := []string{"running", "running", "running"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 3 running allocs",
 	)
 
 	f.NoError(
-		e2e.WaitForLastDeploymentStatus(jobID, "successful", nil),
+		e2e.WaitForLastDeploymentStatus(jobID, ns, "successful", nil),
 		"deployment should be successful")
 
 	// reschedule to make fail
@@ -225,14 +227,14 @@ func (tc *RescheduleE2ETest) TestRescheduleWithCanary(f *framework.F) {
 
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
-			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID) },
+			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID, ns) },
 			func(got []string) bool { return len(got) > 0 }, nil,
 		),
 		"should have rescheduled allocs until progress deadline",
 	)
 
 	f.NoError(
-		e2e.WaitForLastDeploymentStatus(jobID, "running", nil),
+		e2e.WaitForLastDeploymentStatus(jobID, ns, "running", nil),
 		"deployment should be running")
 }
 
@@ -246,12 +248,12 @@ func (tc *RescheduleE2ETest) TestRescheduleWithCanaryAutoRevert(f *framework.F) 
 
 	expected := []string{"running", "running", "running"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 3 running allocs",
 	)
 
 	f.NoError(
-		e2e.WaitForLastDeploymentStatus(jobID, "successful", nil),
+		e2e.WaitForLastDeploymentStatus(jobID, ns, "successful", nil),
 		"deployment should be successful")
 
 	// reschedule to make fail
@@ -264,7 +266,7 @@ func (tc *RescheduleE2ETest) TestRescheduleWithCanaryAutoRevert(f *framework.F) 
 
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
-			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID) },
+			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID, ns) },
 			func(got []string) bool { return len(got) > 0 }, nil,
 		),
 		"should have new allocs after update",
@@ -273,12 +275,12 @@ func (tc *RescheduleE2ETest) TestRescheduleWithCanaryAutoRevert(f *framework.F) 
 	// then we'll fail and revert
 	expected = []string{"failed", "failed", "failed", "running", "running", "running"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 3 running reverted allocs",
 	)
 
 	f.NoError(
-		e2e.WaitForLastDeploymentStatus(jobID, "successful", nil),
+		e2e.WaitForLastDeploymentStatus(jobID, ns, "successful", nil),
 		"deployment should be successful")
 }
 
@@ -291,12 +293,12 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxParallel(f *framework.F) {
 
 	expected := []string{"running", "running", "running"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 3 running allocs",
 	)
 
 	f.NoError(
-		e2e.WaitForLastDeploymentStatus(jobID, "successful", nil),
+		e2e.WaitForLastDeploymentStatus(jobID, ns, "successful", nil),
 		"deployment should be successful")
 
 	// reschedule to make fail
@@ -311,7 +313,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxParallel(f *framework.F) {
 
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
-			func() ([]string, error) { return e2e.AllocStatuses(jobID) },
+			func() ([]string, error) { return e2e.AllocStatuses(jobID, ns) },
 			func(got []string) bool {
 				sort.Strings(got)
 				return reflect.DeepEqual(got, expected)
@@ -321,7 +323,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxParallel(f *framework.F) {
 	)
 
 	f.NoError(
-		e2e.WaitForLastDeploymentStatus(jobID, "running", nil),
+		e2e.WaitForLastDeploymentStatus(jobID, ns, "running", nil),
 		"deployment should be running")
 }
 
@@ -335,12 +337,12 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxParallelAutoRevert(f *framework.F)
 
 	expected := []string{"running", "running", "running"}
 	f.NoError(
-		e2e.WaitForAllocStatusExpected(jobID, expected),
+		e2e.WaitForAllocStatusExpected(jobID, ns, expected),
 		"should have exactly 3 running allocs",
 	)
 
 	f.NoError(
-		e2e.WaitForLastDeploymentStatus(jobID, "successful", nil),
+		e2e.WaitForLastDeploymentStatus(jobID, ns, "successful", nil),
 		"deployment should be successful")
 
 	// reschedule to make fail
@@ -353,7 +355,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxParallelAutoRevert(f *framework.F)
 
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
-			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID) },
+			func() ([]string, error) { return e2e.AllocStatusesRescheduled(jobID, ns) },
 			func(got []string) bool { return len(got) > 0 }, nil,
 		),
 		"should have new allocs after update",
@@ -363,7 +365,7 @@ func (tc *RescheduleE2ETest) TestRescheduleMaxParallelAutoRevert(f *framework.F)
 	expected = []string{"complete", "failed", "running", "running", "running"}
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
-			func() ([]string, error) { return e2e.AllocStatuses(jobID) },
+			func() ([]string, error) { return e2e.AllocStatuses(jobID, ns) },
 			func(got []string) bool {
 				sort.Strings(got)
 				return reflect.DeepEqual(got, expected)
@@ -400,6 +402,6 @@ func (tc *RescheduleE2ETest) TestRescheduleProgressDeadline(f *framework.F) {
 	// wait until first exponential delay kicks in and rescheduling is attempted
 	time.Sleep(time.Second * 30)
 	f.NoError(
-		e2e.WaitForLastDeploymentStatus(jobID, "successful", nil),
+		e2e.WaitForLastDeploymentStatus(jobID, ns, "successful", nil),
 		"deployment should be successful")
 }

--- a/e2e/volumes/volumes.go
+++ b/e2e/volumes/volumes.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/nomad/jobspec"
 )
 
+const ns = ""
+
 type VolumesTest struct {
 	framework.TC
 	jobIDs []string
@@ -56,20 +58,20 @@ func (tc *VolumesTest) TestVolumeMounts(f *framework.F) {
 	tc.jobIDs = append(tc.jobIDs, jobID)
 
 	expected := []string{"running"}
-	f.NoError(e2e.WaitForAllocStatusExpected(jobID, expected), "job should be running")
+	f.NoError(e2e.WaitForAllocStatusExpected(jobID, ns, expected), "job should be running")
 
-	allocs, err := e2e.AllocsForJob(jobID)
+	allocs, err := e2e.AllocsForJob(jobID, ns)
 	f.NoError(err, "could not get allocs for job")
 	allocID := allocs[0]["ID"]
 	nodeID := allocs[0]["Node ID"]
 
 	cmdToExec := fmt.Sprintf("cat /tmp/foo/%s", allocID)
 
-	out, err := e2e.AllocExec(allocID, "docker_task", cmdToExec, nil)
+	out, err := e2e.AllocExec(allocID, "docker_task", cmdToExec, ns, nil)
 	f.NoError(err, "could not exec into task: docker_task")
 	f.Equal(out, allocID+"\n", "alloc data is missing from docker_task")
 
-	out, err = e2e.AllocExec(allocID, "exec_task", cmdToExec, nil)
+	out, err = e2e.AllocExec(allocID, "exec_task", cmdToExec, ns, nil)
 	f.NoError(err, "could not exec into task: exec_task")
 	f.Equal(out, allocID+"\n", "alloc data is missing from exec_task")
 
@@ -92,25 +94,25 @@ func (tc *VolumesTest) TestVolumeMounts(f *framework.F) {
 	_, _, err = tc.Nomad().Jobs().Register(job, nil)
 	f.NoError(err, "could not register updated job")
 
-	allocs, err = e2e.AllocsForJob(jobID)
+	allocs, err = e2e.AllocsForJob(jobID, ns)
 	f.NoError(err, "could not get allocs for job")
 	newAllocID := allocs[0]["ID"]
 
 	newCmdToExec := fmt.Sprintf("cat /tmp/foo/%s", newAllocID)
 
-	out, err = e2e.AllocExec(newAllocID, "docker_task", cmdToExec, nil)
+	out, err = e2e.AllocExec(newAllocID, "docker_task", cmdToExec, ns, nil)
 	f.NoError(err, "could not exec into task: docker_task")
 	f.Equal(out, allocID+"\n", "previous alloc data is missing from docker_task")
 
-	out, err = e2e.AllocExec(newAllocID, "docker_task", newCmdToExec, nil)
+	out, err = e2e.AllocExec(newAllocID, "docker_task", newCmdToExec, ns, nil)
 	f.NoError(err, "could not exec into task: docker_task")
 	f.Equal(out, newAllocID+"\n", "new alloc data is missing from docker_task")
 
-	out, err = e2e.AllocExec(newAllocID, "exec_task", cmdToExec, nil)
+	out, err = e2e.AllocExec(newAllocID, "exec_task", cmdToExec, ns, nil)
 	f.NoError(err, "could not exec into task: exec_task")
 	f.Equal(out, allocID+"\n", "previous alloc data is missing from exec_task")
 
-	out, err = e2e.AllocExec(newAllocID, "exec_task", newCmdToExec, nil)
+	out, err = e2e.AllocExec(newAllocID, "exec_task", newCmdToExec, ns, nil)
 	f.NoError(err, "could not exec into task: exec_task")
 	f.Equal(out, newAllocID+"\n", "new alloc data is missing from exec_task")
 }


### PR DESCRIPTION
Required to support tests for namespaces and other ENT features.