### PR TITLE
drivers/exec: fix DNS resolution in systemd hosts

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -57,6 +57,11 @@ var (
 		"/run/resolvconf": "/run/resolvconf",
 		"/sbin":           "/sbin",
 		"/usr":            "/usr",
+
+		// embed systemd-resolved paths for systemd-resolved paths:
+		// /etc/resolv.conf is a symlink to /run/systemd/resolve/stub-resolv.conf in such systems.
+		// In non-systemd systems, this mount is a no-op and the path is ignored if not present.
+		"/run/systemd/resolve": "/run/systemd/resolve",
 	}
 )
 


### PR DESCRIPTION
Host with systemd-resolved have `/etc/resolv.conf` is a symlink to `/run/systemd/resolve/stub-resolv.conf`. By bind-mounting /etc/resolv.conf only, the exec container DNS resolution fail very badly.

This change fixes DNS resolution by binding /run/systemd/resolve as well.

Note that this assumes that the systemd resolver (default to 127.0.0.53) is accessible within the container. This is the case here because exec containers share the same network namespace by default.

Jobs with custom network dns configurations are not affected, and Nomad will continue to use the job dns settings rather than host one.

Anecdote about systemd and docker: In a docker container, the host systemd resolver isn't accessible, as each container is in separate namespace.  So docker copies `/run/systemd/resolve/resolv.conf` content into /etc/resolv.conf instead.  The logic is in https://github.com/moby/libnetwork/blob/d0951081b35fa4216fc4f0064bf065beeb55a74b/resolvconf/resolvconf.go#L29-L39


Fixes: https://github.com/hashicorp/nomad/issues/7753