### PR TITLE
Add scaling policy type

### DIFF
--- a/api/scaling.go
+++ b/api/scaling.go
@@ -1,5 +1,10 @@
 package api
 
+const (
+	// ScalingPolicyTypeHorizontal indicates a policy that does horizontal scaling.
+	ScalingPolicyTypeHorizontal = "horizontal"
+)
+
 // Scaling is used to query scaling-related API endpoints
 type Scaling struct {
 	client *Client
@@ -36,6 +41,9 @@ func (p *ScalingPolicy) Canonicalize(taskGroupCount int) {
 		var m int64 = int64(taskGroupCount)
 		p.Min = &m
 	}
+	if p.Type == "" {
+		p.Type = ScalingPolicyTypeHorizontal
+	}
 }
 
 // ScalingRequest is the payload for a generic scaling action
@@ -54,6 +62,7 @@ type ScalingRequest struct {
 type ScalingPolicy struct {
 	ID          string
 	Namespace   string
+	Type        string
 	Target      map[string]string
 	Min         *int64
 	Max         *int64
@@ -68,6 +77,7 @@ type ScalingPolicy struct {
 type ScalingPolicyListStub struct {
 	ID          string
 	Enabled     bool
+	Type        string
 	Target      map[string]string
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/api/scaling_test.go
+++ b/api/scaling_test.go
@@ -49,6 +49,9 @@ func TestScalingPolicies_ListPolicies(t *testing.T) {
 
 	// Check that the scaling policy references the right group
 	require.Equal(policy.Target["Group"], *job.TaskGroups[0].Name)
+
+	// Check that the scaling policy has the right type
+	require.Equal(ScalingPolicyTypeHorizontal, policy.Type)
 }
 
 func TestScalingPolicies_GetPolicy(t *testing.T) {
@@ -117,4 +120,5 @@ func TestScalingPolicies_GetPolicy(t *testing.T) {
 	require.Equal(policy.Enabled, resp.Enabled)
 	require.Equal(*policy.Min, *resp.Min)
 	require.Equal(policy.Max, resp.Max)
+	require.Equal(ScalingPolicyTypeHorizontal, resp.Type)
 }

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1474,6 +1474,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 				return err
 			}
 
+			// Handle upgrade path:
+			//   - Set policy type if empty
+			scalingPolicy.Canonicalize()
+
 			if err := restore.ScalingPolicyRestore(scalingPolicy); err != nil {
 				return err
 			}

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -5589,7 +5589,7 @@ func TestJobEndpoint_Plan_Scaling(t *testing.T) {
 	job := mock.Job()
 	tg := job.TaskGroups[0]
 	tg.Tasks[0].Resources.MemoryMB = 999999999
-	scaling := &structs.ScalingPolicy{Min: 1, Max: 100}
+	scaling := &structs.ScalingPolicy{Min: 1, Max: 100, Type: structs.ScalingPolicyTypeHorizontal}
 	tg.Scaling = scaling.TargetTaskGroup(job, tg)
 	planReq := &structs.JobPlanRequest{
 		Job:  job,

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1350,13 +1350,15 @@ func ACLManagementToken() *structs.ACLToken {
 
 func ScalingPolicy() *structs.ScalingPolicy {
 	return &structs.ScalingPolicy{
-		ID:  uuid.Generate(),
-		Min: 1,
-		Max: 100,
+		ID:   uuid.Generate(),
+		Min:  1,
+		Max:  100,
+		Type: structs.ScalingPolicyTypeHorizontal,
 		Target: map[string]string{
 			structs.ScalingTargetNamespace: structs.DefaultNamespace,
 			structs.ScalingTargetJob:       uuid.Generate(),
 			structs.ScalingTargetGroup:     uuid.Generate(),
+			structs.ScalingTargetTask:      uuid.Generate(),
 		},
 		Policy: map[string]interface{}{
 			"a": "b",
@@ -1373,6 +1375,7 @@ func JobWithScalingPolicy() (*structs.Job, *structs.ScalingPolicy) {
 		ID:      uuid.Generate(),
 		Min:     int64(job.TaskGroups[0].Count),
 		Max:     int64(job.TaskGroups[0].Count),
+		Type:    structs.ScalingPolicyTypeHorizontal,
 		Policy:  map[string]interface{}{},
 		Enabled: true,
 	}

--- a/nomad/state/schema_test.go
+++ b/nomad/state/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -83,4 +84,63 @@ func TestState_singleRecord(t *testing.T) {
 	setSingleton("three")
 	require.Equal(1, numRecordsInTable())
 	require.Equal("three", first())
+}
+
+func TestState_ScalingPolicyTargetFieldIndex_FromObject(t *testing.T) {
+	require := require.New(t)
+
+	policy := mock.ScalingPolicy()
+	policy.Target["TestField"] = "test"
+
+	// Create test indexers
+	indexersAllowMissingTrue := &ScalingPolicyTargetFieldIndex{Field: "TestField", AllowMissing: true}
+	indexersAllowMissingFalse := &ScalingPolicyTargetFieldIndex{Field: "TestField", AllowMissing: false}
+
+	// Check if box indexers can find the test field
+	ok, val, err := indexersAllowMissingTrue.FromObject(policy)
+	require.True(ok)
+	require.NoError(err)
+	require.Equal("test\x00", string(val))
+
+	ok, val, err = indexersAllowMissingFalse.FromObject(policy)
+	require.True(ok)
+	require.NoError(err)
+	require.Equal("test\x00", string(val))
+
+	// Check for empty field
+	policy.Target["TestField"] = ""
+
+	ok, val, err = indexersAllowMissingTrue.FromObject(policy)
+	require.True(ok)
+	require.NoError(err)
+	require.Equal("\x00", string(val))
+
+	ok, val, err = indexersAllowMissingFalse.FromObject(policy)
+	require.True(ok)
+	require.NoError(err)
+	require.Equal("\x00", string(val))
+
+	// Check for missing field
+	delete(policy.Target, "TestField")
+
+	ok, val, err = indexersAllowMissingTrue.FromObject(policy)
+	require.True(ok)
+	require.NoError(err)
+	require.Equal("\x00", string(val))
+
+	ok, val, err = indexersAllowMissingFalse.FromObject(policy)
+	require.False(ok)
+	require.NoError(err)
+	require.Equal("", string(val))
+
+	// Check for invalid input
+	ok, val, err = indexersAllowMissingTrue.FromObject("not-a-scaling-policy")
+	require.False(ok)
+	require.Error(err)
+	require.Equal("", string(val))
+
+	ok, val, err = indexersAllowMissingFalse.FromObject("not-a-scaling-policy")
+	require.False(ok)
+	require.Error(err)
+	require.Equal("", string(val))
 }

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -13,7 +13,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/hashicorp/nomad/acl"
-	"github.com/mitchellh/copystructure"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -275,32 +274,6 @@ func CopySliceNodeScoreMeta(s []*NodeScoreMeta) []*NodeScoreMeta {
 		c[i] = v.Copy()
 	}
 	return c
-}
-
-func CopyScalingPolicy(p *ScalingPolicy) *ScalingPolicy {
-	if p == nil {
-		return nil
-	}
-
-	opaquePolicyConfig, err := copystructure.Copy(p.Policy)
-	if err != nil {
-		panic(err.Error())
-	}
-
-	c := ScalingPolicy{
-		ID:          p.ID,
-		Policy:      opaquePolicyConfig.(map[string]interface{}),
-		Enabled:     p.Enabled,
-		Min:         p.Min,
-		Max:         p.Max,
-		CreateIndex: p.CreateIndex,
-		ModifyIndex: p.ModifyIndex,
-	}
-	c.Target = make(map[string]string, len(p.Target))
-	for k, v := range p.Target {
-		c.Target[k] = v
-	}
-	return &c
 }
 
 // VaultPoliciesSet takes the structure returned by VaultPolicies and returns

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5079,6 +5079,9 @@ type ScalingPolicy struct {
 	// ID is a generated UUID used for looking up the scaling policy
 	ID string
 
+	// Type is the type of scaling performed by the policy
+	Type string
+
 	// Target contains information about the target of the scaling policy, like job and group
 	Target map[string]string
 
@@ -5102,7 +5105,95 @@ const (
 	ScalingTargetNamespace = "Namespace"
 	ScalingTargetJob       = "Job"
 	ScalingTargetGroup     = "Group"
+	ScalingTargetTask      = "Task"
+
+	ScalingPolicyTypeHorizontal = "horizontal"
 )
+
+func (p *ScalingPolicy) Canonicalize() {
+	if p.Type == "" {
+		p.Type = ScalingPolicyTypeHorizontal
+	}
+}
+
+func (p *ScalingPolicy) Copy() *ScalingPolicy {
+	if p == nil {
+		return nil
+	}
+
+	opaquePolicyConfig, err := copystructure.Copy(p.Policy)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	c := ScalingPolicy{
+		ID:          p.ID,
+		Policy:      opaquePolicyConfig.(map[string]interface{}),
+		Enabled:     p.Enabled,
+		Type:        p.Type,
+		Min:         p.Min,
+		Max:         p.Max,
+		CreateIndex: p.CreateIndex,
+		ModifyIndex: p.ModifyIndex,
+	}
+	c.Target = make(map[string]string, len(p.Target))
+	for k, v := range p.Target {
+		c.Target[k] = v
+	}
+	return &c
+}
+
+func (p *ScalingPolicy) Validate() error {
+	if p == nil {
+		return nil
+	}
+
+	var mErr multierror.Error
+
+	// Check policy type and target
+	if p.Type == "" {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("missing scaling policy type"))
+	} else {
+		mErr.Errors = append(mErr.Errors, p.validateType().Errors...)
+	}
+
+	// Check Min and Max
+	if p.Max < 0 {
+		mErr.Errors = append(mErr.Errors,
+			fmt.Errorf("maximum count must be specified and non-negative"))
+	} else {
+		if p.Max < p.Min {
+			mErr.Errors = append(mErr.Errors,
+				fmt.Errorf("maximum count must not be less than minimum count"))
+		}
+	}
+
+	if p.Min < 0 {
+		mErr.Errors = append(mErr.Errors,
+			fmt.Errorf("minimum count must be specified and non-negative"))
+	}
+
+	return mErr.ErrorOrNil()
+}
+
+func (p *ScalingPolicy) validateTargetHorizontal() (mErr multierror.Error) {
+	if len(p.Target) == 0 {
+		// This is probably not a Nomad horizontal policy
+		return
+	}
+
+	// Nomad horizontal policies should have Namespace, Job and TaskGroup
+	if p.Target[ScalingTargetNamespace] == "" {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("missing target namespace"))
+	}
+	if p.Target[ScalingTargetJob] == "" {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("missing target job"))
+	}
+	if p.Target[ScalingTargetGroup] == "" {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("missing target group"))
+	}
+	return
+}
 
 // Diff indicates whether the specification for a given scaling policy has changed
 func (p *ScalingPolicy) Diff(p2 *ScalingPolicy) bool {
@@ -5125,6 +5216,7 @@ func (p *ScalingPolicy) TargetTaskGroup(job *Job, tg *TaskGroup) *ScalingPolicy 
 func (p *ScalingPolicy) Stub() *ScalingPolicyListStub {
 	stub := &ScalingPolicyListStub{
 		ID:          p.ID,
+		Type:        p.Type,
 		Target:      make(map[string]string),
 		Enabled:     p.Enabled,
 		CreateIndex: p.CreateIndex,
@@ -5154,6 +5246,7 @@ func (j *Job) GetScalingPolicies() []*ScalingPolicy {
 type ScalingPolicyListStub struct {
 	ID          string
 	Enabled     bool
+	Type        string
 	Target      map[string]string
 	CreateIndex uint64
 	ModifyIndex uint64
@@ -5570,7 +5663,7 @@ func (tg *TaskGroup) Copy() *TaskGroup {
 	ntg.Affinities = CopySliceAffinities(ntg.Affinities)
 	ntg.Spreads = CopySliceSpreads(ntg.Spreads)
 	ntg.Volumes = CopyMapVolumeRequest(ntg.Volumes)
-	ntg.Scaling = CopyScalingPolicy(ntg.Scaling)
+	ntg.Scaling = ntg.Scaling.Copy()
 
 	// Copy the network objects
 	if tg.Networks != nil {
@@ -5638,6 +5731,10 @@ func (tg *TaskGroup) Canonicalize(job *Job) {
 	// Set a default ephemeral disk object if the user has not requested for one
 	if tg.EphemeralDisk == nil {
 		tg.EphemeralDisk = DefaultEphemeralDisk()
+	}
+
+	if tg.Scaling != nil {
+		tg.Scaling.Canonicalize()
 	}
 
 	for _, service := range tg.Services {
@@ -5985,19 +6082,19 @@ func (tg *TaskGroup) validateScalingPolicy(j *Job) error {
 
 	var mErr multierror.Error
 
-	// was invalid or not specified; don't bother testing anything else involving max
-	if tg.Scaling.Max < 0 {
+	err := tg.Scaling.Validate()
+	if err != nil {
+		// prefix scaling policy errors
+		if me, ok := err.(*multierror.Error); ok {
+			for _, e := range me.Errors {
+				mErr.Errors = append(mErr.Errors, fmt.Errorf("Scaling policy invalid: %s", e))
+			}
+		}
+	}
+
+	if tg.Scaling.Max < int64(tg.Count) {
 		mErr.Errors = append(mErr.Errors,
-			fmt.Errorf("Scaling policy invalid: maximum count must be specified and non-negative"))
-	} else {
-		if tg.Scaling.Max < tg.Scaling.Min {
-			mErr.Errors = append(mErr.Errors,
-				fmt.Errorf("Scaling policy invalid: maximum count must not be less than minimum count"))
-		}
-		if tg.Scaling.Max < int64(tg.Count) {
-			mErr.Errors = append(mErr.Errors,
-				fmt.Errorf("Scaling policy invalid: task group count must not be greater than maximum count in scaling policy"))
-		}
+			fmt.Errorf("Scaling policy invalid: task group count must not be greater than maximum count in scaling policy"))
 	}
 
 	if int64(tg.Count) < tg.Scaling.Min && !(j.IsMultiregion() && tg.Count == 0 && j.Region == "global") {

--- a/nomad/structs/structs_oss.go
+++ b/nomad/structs/structs_oss.go
@@ -2,7 +2,12 @@
 
 package structs
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+
+	multierror "github.com/hashicorp/go-multierror"
+)
 
 func (m *Multiregion) Validate(jobType string, jobDatacenters []string) error {
 	if m != nil {
@@ -10,4 +15,19 @@ func (m *Multiregion) Validate(jobType string, jobDatacenters []string) error {
 	}
 
 	return nil
+}
+
+func (p *ScalingPolicy) validateType() multierror.Error {
+	var mErr multierror.Error
+
+	// Check policy type and target
+	switch p.Type {
+	case ScalingPolicyTypeHorizontal:
+		targetErr := p.validateTargetHorizontal()
+		mErr.Errors = append(mErr.Errors, targetErr.Errors...)
+	default:
+		mErr.Errors = append(mErr.Errors, fmt.Errorf(`scaling policy type "%s" is not valid`, p.Type))
+	}
+
+	return mErr
 }

--- a/vendor/github.com/hashicorp/nomad/api/scaling.go
+++ b/vendor/github.com/hashicorp/nomad/api/scaling.go
@@ -1,5 +1,10 @@
 package api
 
+const (
+	// ScalingPolicyTypeHorizontal indicates a policy that does horizontal scaling.
+	ScalingPolicyTypeHorizontal = "horizontal"
+)
+
 // Scaling is used to query scaling-related API endpoints
 type Scaling struct {
 	client *Client
@@ -36,6 +41,9 @@ func (p *ScalingPolicy) Canonicalize(taskGroupCount int) {
 		var m int64 = int64(taskGroupCount)
 		p.Min = &m
 	}
+	if p.Type == "" {
+		p.Type = ScalingPolicyTypeHorizontal
+	}
 }
 
 // ScalingRequest is the payload for a generic scaling action
@@ -54,6 +62,7 @@ type ScalingRequest struct {
 type ScalingPolicy struct {
 	ID          string
 	Namespace   string
+	Type        string
 	Target      map[string]string
 	Min         *int64
 	Max         *int64
@@ -68,6 +77,7 @@ type ScalingPolicy struct {
 type ScalingPolicyListStub struct {
 	ID          string
 	Enabled     bool
+	Type        string
 	Target      map[string]string
 	CreateIndex uint64
 	ModifyIndex uint64


### PR DESCRIPTION
This PR introduces a new field to allow specifying the type of scaling a policy provides. Currently the only policy type available is `horizontal` and existing policies are automatically assigned this value on snapshot restore. With this new field, scaling policy uniqueness is now determined by its target and type.