### PR TITLE
e2e: cleanup errors should use assert, not require

### DIFF
--- a/e2e/nodedrain/nodedrain.go
+++ b/e2e/nodedrain/nodedrain.go
@@ -44,18 +44,18 @@ func (tc *NodeDrainE2ETest) AfterEach(f *framework.F) {
 
 	for _, id := range tc.jobIDs {
 		_, err := e2e.Command("nomad", "job", "stop", "-purge", id)
-		f.NoError(err)
+		f.Assert().NoError(err)
 	}
 	tc.jobIDs = []string{}
 
 	for _, id := range tc.nodeIDs {
 		_, err := e2e.Command("nomad", "node", "drain", "-disable", "-yes", id)
-		f.NoError(err)
+		f.Assert().NoError(err)
 	}
 	tc.nodeIDs = []string{}
 
 	_, err := e2e.Command("nomad", "system", "gc")
-	f.NoError(err)
+	f.Assert().NoError(err)
 }
 
 func nodesForJob(jobID string) ([]string, error) {

--- a/e2e/rescheduling/rescheduling.go
+++ b/e2e/rescheduling/rescheduling.go
@@ -44,11 +44,11 @@ func (tc *RescheduleE2ETest) AfterEach(f *framework.F) {
 
 	for _, id := range tc.jobIds {
 		_, err := e2e.Command("nomad", "job", "stop", "-purge", id)
-		f.NoError(err)
+		f.Assert().NoError(err)
 	}
 	tc.jobIds = []string{}
 	_, err := e2e.Command("nomad", "system", "gc")
-	f.NoError(err)
+	f.Assert().NoError(err)
 }
 
 // TestNoReschedule runs a job that should fail and never reschedule

--- a/e2e/volumes/volumes.go
+++ b/e2e/volumes/volumes.go
@@ -40,12 +40,12 @@ func (tc *VolumesTest) AfterEach(f *framework.F) {
 
 	for _, id := range tc.jobIDs {
 		_, err := e2e.Command("nomad", "job", "stop", "-purge", id)
-		f.NoError(err)
+		f.Assert().NoError(err)
 	}
 	tc.jobIDs = []string{}
 
 	_, err := e2e.Command("nomad", "system", "gc")
-	f.NoError(err)
+	f.Assert().NoError(err)
 }
 
 // TestVolumeMounts exercises host volume and Docker volume functionality for


### PR DESCRIPTION
The E2E framework wraps testify's `require` so that by default we can stop
tests on errors, but the cleanup functions should use `assert` so that we
continue to try to cleanup the test environment even if there's a failure.