### PR TITLE
e2e: ensure tests are constrained to Linux

### DIFF
--- a/e2e/lifecycle/inputs/batch.nomad
+++ b/e2e/lifecycle/inputs/batch.nomad
@@ -9,6 +9,11 @@ job "batch-lifecycle" {
 
   type = "batch"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "test" {
 
     task "init" {

--- a/e2e/lifecycle/inputs/service.nomad
+++ b/e2e/lifecycle/inputs/service.nomad
@@ -10,6 +10,11 @@ job "service-lifecycle" {
 
   type = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "test" {
 
     task "init" {

--- a/e2e/podman/input/redis.nomad
+++ b/e2e/podman/input/redis.nomad
@@ -2,6 +2,11 @@ job "podman-redis" {
   datacenters = ["dc1"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "redis" {
     task "redis" {
       driver = "podman"

--- a/e2e/volumes/input/volumes.nomad
+++ b/e2e/volumes/input/volumes.nomad
@@ -1,6 +1,11 @@
 job "volumes" {
   datacenters = ["dc1", "dc2"]
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "group" {
 
     volume "data" {


### PR DESCRIPTION
Until we have LCOW (#2633) support in the E2E environment (which requires a Windows
2019 test target #7767), we need to constrain E2E tests to the appropriate kernel.