### PR TITLE
tests: failover to copying when symlinking fails

### DIFF
--- a/drivers/java/driver_test.go
+++ b/drivers/java/driver_test.go
@@ -332,9 +332,6 @@ func copyFile(src, dst string, t *testing.T) {
 	if _, err = io.Copy(out, in); err != nil {
 		t.Fatalf("copying %v -> %v failed: %v", src, dst, err)
 	}
-	if err := out.Sync(); err != nil {
-		t.Fatalf("copying %v -> %v failed: %v", src, dst, err)
-	}
 }
 
 func TestConfig_ParseAllHCL(t *testing.T) {


### PR DESCRIPTION
Symlinking busybox may fail when the test code and the test temporary
directory live on different volumes/partitions; so we should copy
instead.  This situation arises in the Vagrant setup, where the code
repository live on special file sharing volume.

Somewhat unrelated, remove `f.Sync()` invocation from a test copyFile
helper function.  Sync is useful only for crash recovery, and isn't
necessary in our test setup.  The sync invocation is a significant
overhead as it requires the OS to flush any cached writes to disk.

Related to #8970