### PR TITLE
Use 32-byte key for gossip encryption to enable AES-256 

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -807,7 +807,7 @@ func (a *Agent) setupKeyrings(config *nomad.Config) error {
 		goto LOAD
 	}
 	if _, err := os.Stat(file); err != nil {
-		if err := initKeyring(file, a.config.Server.EncryptKey); err != nil {
+		if err := initKeyring(file, a.config.Server.EncryptKey, a.logger); err != nil {
 			return err
 		}
 	}

--- a/command/agent/keyring_test.go
+++ b/command/agent/keyring_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 func TestAgent_LoadKeyrings(t *testing.T) {
@@ -56,8 +58,10 @@ func TestAgent_InitKeyring(t *testing.T) {
 
 	file := filepath.Join(dir, "keyring")
 
+	logger := hclog.NewNullLogger()
+
 	// First initialize the keyring
-	if err := initKeyring(file, key1); err != nil {
+	if err := initKeyring(file, key1, logger); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -70,7 +74,7 @@ func TestAgent_InitKeyring(t *testing.T) {
 	}
 
 	// Try initializing again with a different key
-	if err := initKeyring(file, key2); err != nil {
+	if err := initKeyring(file, key2, logger); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -143,11 +143,15 @@ RETRY:
 		a.Config.NodeName = fmt.Sprintf("Node %d", a.Config.Ports.RPC)
 	}
 
+	// Create a null logger before initializing the keyring. This is typically
+	// done using the agent's logger. However, it hasn't been created yet.
+	logger := hclog.NewNullLogger()
+
 	// write the keyring
 	if a.Key != "" {
 		writeKey := func(key, filename string) {
 			path := filepath.Join(a.Config.DataDir, filename)
-			if err := initKeyring(path, key, a.logger); err != nil {
+			if err := initKeyring(path, key, logger); err != nil {
 				a.T.Fatalf("Error creating keyring %s: %s", path, err)
 			}
 		}

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -147,7 +147,7 @@ RETRY:
 	if a.Key != "" {
 		writeKey := func(key, filename string) {
 			path := filepath.Join(a.Config.DataDir, filename)
-			if err := initKeyring(path, key); err != nil {
+			if err := initKeyring(path, key, a.logger); err != nil {
 				a.T.Fatalf("Error creating keyring %s: %s", path, err)
 			}
 		}

--- a/command/operator_keygen.go
+++ b/command/operator_keygen.go
@@ -21,7 +21,7 @@ func (c *OperatorKeygenCommand) Help() string {
 	helpText := `
 Usage: nomad operator keygen
 
-  Generates a new encryption key that can be used to configure the
+  Generates a new 32-byte encryption key that can be used to configure the
   agent to encrypt traffic. The output of this command is already
   in the proper format that the agent expects.
 `
@@ -31,13 +31,13 @@ Usage: nomad operator keygen
 func (c *OperatorKeygenCommand) Name() string { return "operator keygen" }
 
 func (c *OperatorKeygenCommand) Run(_ []string) int {
-	key := make([]byte, 16)
+	key := make([]byte, 32)
 	n, err := rand.Reader.Read(key)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error reading random data: %s", err))
 		return 1
 	}
-	if n != 16 {
+	if n != 32 {
 		c.Ui.Error(fmt.Sprintf("Couldn't read enough entropy. Generate more entropy!"))
 		return 1
 	}

--- a/command/operator_keygen_test.go
+++ b/command/operator_keygen_test.go
@@ -22,7 +22,7 @@ func TestKeygenCommand(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if len(result) != 16 {
+	if len(result) != 32 {
 		t.Fatalf("bad: %#v", result)
 	}
 }

--- a/website/pages/docs/commands/operator/keygen.mdx
+++ b/website/pages/docs/commands/operator/keygen.mdx
@@ -24,5 +24,5 @@ nomad operator keygen
 
 ```shell-session
 $ nomad operator keygen
-YgZOXLMhC7TtZqeghMT8+w==
+6RhfKFZ5uYEaU6RgWzx69ssLcpiIkvnEZs5KBOQxvxA=
 ```

--- a/website/pages/docs/configuration/server.mdx
+++ b/website/pages/docs/configuration/server.mdx
@@ -55,7 +55,7 @@ server {
   worker threads will dequeue for processing.
 
 - `encrypt` `(string: "")` - Specifies the secret key to use for encryption of
-  Nomad server's gossip network traffic. This key must be 16 bytes that are
+  Nomad server's gossip network traffic. This key must be 32 bytes that are
   base64-encoded. The provided key is automatically persisted to the data
   directory and loaded automatically whenever the agent is restarted. This means
   that to encrypt Nomad server's gossip protocol, this option only needs to be


### PR DESCRIPTION
Nomad's gossip protocol utilizes AES GCM under-the-hood for encryption which relies on [`crypto/aes`](https://golang.org/pkg/crypto/aes/#NewCipher). The 16-byte key currently used enables AES-128, while a 32-byte key enables AES-256. The larger key size is ultimately preferable from a security standpoint, and this PR updates the CLI key generation command + documentation to reference/use 32-byte keys.

Consul already defaults to generating a 32-byte gossip key: https://github.com/hashicorp/consul/commit/1a14b94441dbd715fcb83d78c99fe87de9ad01ea