### PR TITLE
Fix docs on API for volume detaching

### DIFF
--- a/website/pages/api-docs/volumes.mdx
+++ b/website/pages/api-docs/volumes.mdx
@@ -360,12 +360,12 @@ The table below shows this endpoint's support for
   path.
 
 - `node` `(string: <required>)`- The node to detach the volume from.
+This is specified as a query string parameter.
 
 ### Sample Request
 
 ```shell-session
 $ curl \
     --request DELETE \
-    --data @payload.json \
-    https://localhost:4646/v1/volume/csi/volume-id/detach
+    https://localhost:4646/v1/volume/csi/volume-id/detach?node=00000000-0000-0000-0000-000000000000
 ```


### PR DESCRIPTION
`nomad volume detach volume-id 00000000-0000-0000-0000-000000000000` produces an API call containing the UUID as part of the query string. This is the only way the API accepts the request correctly - if you pass it in the payload you get `detach requires node ID`