### PR TITLE
Events/deployment events

### DIFF
--- a/command/agent/event_endpoint_test.go
+++ b/command/agent/event_endpoint_test.go
@@ -79,14 +79,14 @@ func TestEventStream_QueryParse(t *testing.T) {
 			desc:  "all topics and keys specified",
 			query: "?topic=*:*",
 			want: map[stream.Topic][]string{
-				"*": []string{"*"},
+				"*": {"*"},
 			},
 		},
 		{
 			desc:  "all topics and keys inferred",
 			query: "",
 			want: map[stream.Topic][]string{
-				"*": []string{"*"},
+				"*": {"*"},
 			},
 		},
 		{
@@ -103,14 +103,14 @@ func TestEventStream_QueryParse(t *testing.T) {
 			desc:  "single topic and key",
 			query: "?topic=NodeDrain:*",
 			want: map[stream.Topic][]string{
-				"NodeDrain": []string{"*"},
+				"NodeDrain": {"*"},
 			},
 		},
 		{
 			desc:  "single topic multiple keys",
 			query: "?topic=NodeDrain:*&topic=NodeDrain:3caace09-f1f4-4d23-b37a-9ab5eb75069d",
 			want: map[stream.Topic][]string{
-				"NodeDrain": []string{
+				"NodeDrain": {
 					"*",
 					"3caace09-f1f4-4d23-b37a-9ab5eb75069d",
 				},
@@ -120,10 +120,10 @@ func TestEventStream_QueryParse(t *testing.T) {
 			desc:  "multiple topics",
 			query: "?topic=NodeRegister:*&topic=NodeDrain:3caace09-f1f4-4d23-b37a-9ab5eb75069d",
 			want: map[stream.Topic][]string{
-				"NodeDrain": []string{
+				"NodeDrain": {
 					"3caace09-f1f4-4d23-b37a-9ab5eb75069d",
 				},
-				"NodeRegister": []string{
+				"NodeRegister": {
 					"*",
 				},
 			},

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -1,6 +1,7 @@
 package deploymentwatcher
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -917,7 +918,7 @@ func TestDeploymentWatcher_Watch_NoProgressDeadline(t *testing.T) {
 				HealthyAllocationIDs: []string{a.ID},
 			},
 		}
-		require.Nil(m.state.UpdateDeploymentAllocHealth(m.nextIndex(), req), "UpsertDeploymentAllocHealth")
+		require.Nil(m.state.UpdateDeploymentAllocHealth(context.Background(), m.nextIndex(), req), "UpsertDeploymentAllocHealth")
 	}
 
 	// Wait for there to be one eval
@@ -945,7 +946,7 @@ func TestDeploymentWatcher_Watch_NoProgressDeadline(t *testing.T) {
 			UnhealthyAllocationIDs: []string{a.ID},
 		},
 	}
-	require.Nil(m.state.UpdateDeploymentAllocHealth(m.nextIndex(), req2), "UpsertDeploymentAllocHealth")
+	require.Nil(m.state.UpdateDeploymentAllocHealth(context.Background(), m.nextIndex(), req2), "UpsertDeploymentAllocHealth")
 
 	// Wait for there to be one eval
 	testutil.WaitForResult(func() (bool, error) {
@@ -1453,7 +1454,7 @@ func TestDeploymentWatcher_RollbackFailed(t *testing.T) {
 				HealthyAllocationIDs: []string{a.ID},
 			},
 		}
-		require.Nil(m.state.UpdateDeploymentAllocHealth(m.nextIndex(), req), "UpsertDeploymentAllocHealth")
+		require.Nil(m.state.UpdateDeploymentAllocHealth(context.Background(), m.nextIndex(), req), "UpsertDeploymentAllocHealth")
 	}
 
 	// Wait for there to be one eval
@@ -1481,7 +1482,7 @@ func TestDeploymentWatcher_RollbackFailed(t *testing.T) {
 			UnhealthyAllocationIDs: []string{a.ID},
 		},
 	}
-	require.Nil(m.state.UpdateDeploymentAllocHealth(m.nextIndex(), req2), "UpsertDeploymentAllocHealth")
+	require.Nil(m.state.UpdateDeploymentAllocHealth(context.Background(), m.nextIndex(), req2), "UpsertDeploymentAllocHealth")
 
 	// Wait for there to be one eval
 	testutil.WaitForResult(func() (bool, error) {
@@ -1562,7 +1563,7 @@ func TestWatcher_BatchAllocUpdates(t *testing.T) {
 			HealthyAllocationIDs: []string{a1.ID},
 		},
 	}
-	require.Nil(m.state.UpdateDeploymentAllocHealth(m.nextIndex(), req), "UpsertDeploymentAllocHealth")
+	require.Nil(m.state.UpdateDeploymentAllocHealth(context.Background(), m.nextIndex(), req), "UpsertDeploymentAllocHealth")
 
 	req2 := &structs.ApplyDeploymentAllocHealthRequest{
 		DeploymentAllocHealthRequest: structs.DeploymentAllocHealthRequest{
@@ -1570,7 +1571,7 @@ func TestWatcher_BatchAllocUpdates(t *testing.T) {
 			HealthyAllocationIDs: []string{a2.ID},
 		},
 	}
-	require.Nil(m.state.UpdateDeploymentAllocHealth(m.nextIndex(), req2), "UpsertDeploymentAllocHealth")
+	require.Nil(m.state.UpdateDeploymentAllocHealth(context.Background(), m.nextIndex(), req2), "UpsertDeploymentAllocHealth")
 
 	// Wait for there to be one eval for each job
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/deploymentwatcher/testutil_test.go
+++ b/nomad/deploymentwatcher/testutil_test.go
@@ -1,6 +1,7 @@
 package deploymentwatcher
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"sync"
@@ -95,7 +96,7 @@ func (m *mockBackend) UpsertJob(job *structs.Job) (uint64, error) {
 func (m *mockBackend) UpdateDeploymentStatus(u *structs.DeploymentStatusUpdateRequest) (uint64, error) {
 	m.Called(u)
 	i := m.nextIndex()
-	return i, m.state.UpdateDeploymentStatus(i, u)
+	return i, m.state.UpdateDeploymentStatus(context.Background(), i, u)
 }
 
 // matchDeploymentStatusUpdateConfig is used to configure the matching
@@ -179,7 +180,7 @@ func matchDeploymentPromoteRequest(c *matchDeploymentPromoteRequestConfig) func(
 func (m *mockBackend) UpdateDeploymentAllocHealth(req *structs.ApplyDeploymentAllocHealthRequest) (uint64, error) {
 	m.Called(req)
 	i := m.nextIndex()
-	return i, m.state.UpdateDeploymentAllocHealth(i, req)
+	return i, m.state.UpdateDeploymentAllocHealth(context.Background(), i, req)
 }
 
 // matchDeploymentAllocHealthRequestConfig is used to configure the matching

--- a/nomad/deploymentwatcher/testutil_test.go
+++ b/nomad/deploymentwatcher/testutil_test.go
@@ -150,7 +150,7 @@ func matchDeploymentStatusUpdateRequest(c *matchDeploymentStatusUpdateConfig) fu
 func (m *mockBackend) UpdateDeploymentPromotion(req *structs.ApplyDeploymentPromoteRequest) (uint64, error) {
 	m.Called(req)
 	i := m.nextIndex()
-	return i, m.state.UpdateDeploymentPromotion(i, req)
+	return i, m.state.UpdateDeploymentPromotion(context.Background(), i, req)
 }
 
 // matchDeploymentPromoteRequestConfig is used to configure the matching

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -374,7 +375,7 @@ func TestEvalEndpoint_Dequeue_UpdateWaitIndex(t *testing.T) {
 		EvalID: eval.ID,
 	}
 	assert := assert.New(t)
-	err := state.UpsertPlanResults(1000, &res)
+	err := state.UpsertPlanResults(context.Background(), 1000, &res)
 	assert.Nil(err)
 
 	// Dequeue the eval

--- a/nomad/event_endpoint.go
+++ b/nomad/event_endpoint.go
@@ -117,19 +117,16 @@ func (e *Event) stream(conn io.ReadWriteCloser) {
 			}
 
 			// Continue if there are no events
-			if events == nil {
+			if len(events.Events) == 0 {
 				continue
 			}
 
-			// Send each event as its own frame
-			for _, e := range events {
-				if err := jsonStream.Send(e); err != nil {
-					select {
-					case errCh <- err:
-					case <-ctx.Done():
-					}
-					break LOOP
+			if err := jsonStream.Send(events); err != nil {
+				select {
+				case errCh <- err:
+				case <-ctx.Done():
 				}
+				break LOOP
 			}
 		}
 	}()

--- a/nomad/event_endpoint_test.go
+++ b/nomad/event_endpoint_test.go
@@ -91,7 +91,7 @@ OUTER:
 				continue
 			}
 
-			var event stream.Event
+			var event stream.Events
 			err = json.Unmarshal(msg.Event.Data, &event)
 			require.NoError(t, err)
 
@@ -102,7 +102,7 @@ OUTER:
 				Result:   &out,
 			}
 			dec, err := mapstructure.NewDecoder(cfg)
-			dec.Decode(event.Payload)
+			dec.Decode(event.Events[0].Payload)
 			require.NoError(t, err)
 			require.Equal(t, node.ID, out.ID)
 			break OUTER
@@ -123,7 +123,7 @@ func TestEventStream_StreamErr(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 
 	req := structs.EventStreamRequest{
-		Topics: map[stream.Topic][]string{"*": []string{"*"}},
+		Topics: map[stream.Topic][]string{"*": {"*"}},
 		QueryOptions: structs.QueryOptions{
 			Region: s1.Region(),
 		},
@@ -210,7 +210,7 @@ func TestEventStream_RegionForward(t *testing.T) {
 
 	// Create request targed for region foo
 	req := structs.EventStreamRequest{
-		Topics: map[stream.Topic][]string{"*": []string{"*"}},
+		Topics: map[stream.Topic][]string{"*": {"*"}},
 		QueryOptions: structs.QueryOptions{
 			Region: "foo",
 		},
@@ -272,7 +272,7 @@ OUTER:
 				continue
 			}
 
-			var event stream.Event
+			var event stream.Events
 			err = json.Unmarshal(msg.Event.Data, &event)
 			require.NoError(t, err)
 
@@ -282,7 +282,7 @@ OUTER:
 				Result:   &out,
 			}
 			dec, err := mapstructure.NewDecoder(cfg)
-			dec.Decode(event.Payload)
+			dec.Decode(event.Events[0].Payload)
 			require.NoError(t, err)
 			require.Equal(t, node.ID, out.ID)
 			break OUTER

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -310,7 +310,7 @@ func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap
 	// Optimistically apply to our state view
 	if snap != nil {
 		nextIdx := p.raft.AppliedIndex() + 1
-		if err := snap.UpsertPlanResults(nextIdx, &req); err != nil {
+		if err := snap.UpsertPlanResults(context.Background(), nextIdx, &req); err != nil {
 			return future, err
 		}
 	}

--- a/nomad/state/apply_plan_events.go
+++ b/nomad/state/apply_plan_events.go
@@ -1,0 +1,74 @@
+package state
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/stream"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func ApplyPlanResultEventsFromChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
+	var events []stream.Event
+	for _, change := range changes.Changes {
+		switch change.Table {
+		case "deployment":
+			after, ok := change.After.(*structs.Deployment)
+			if !ok {
+				return nil, fmt.Errorf("transaction change was not a Deployment")
+			}
+
+			event := stream.Event{
+				Topic: TopicDeployment,
+				Type:  TypeDeploymentUpdate,
+				Index: changes.Index,
+				Key:   after.ID,
+				Payload: &DeploymentEvent{
+					Deployment: after,
+				},
+			}
+			events = append(events, event)
+		case "evals":
+			after, ok := change.After.(*structs.Evaluation)
+			if !ok {
+				return nil, fmt.Errorf("transaction change was not an Evaluation")
+			}
+
+			event := stream.Event{
+				Topic: TopicEval,
+				Index: changes.Index,
+				Key:   after.ID,
+				Payload: &EvalEvent{
+					Eval: after,
+				},
+			}
+
+			events = append(events, event)
+		case "allocs":
+			after, ok := change.After.(*structs.Allocation)
+			if !ok {
+				return nil, fmt.Errorf("transaction change was not an Allocation")
+			}
+			before := change.Before
+			var msg string
+			if before == nil {
+				msg = TypeAllocCreated
+			} else {
+				msg = TypeAllocUpdated
+			}
+
+			event := stream.Event{
+				Topic: TopicAlloc,
+				Type:  msg,
+				Index: changes.Index,
+				Key:   after.ID,
+				Payload: &AllocEvent{
+					Alloc: after,
+				},
+			}
+
+			events = append(events, event)
+		}
+	}
+
+	return events, nil
+}

--- a/nomad/state/deployment_event_test.go
+++ b/nomad/state/deployment_event_test.go
@@ -1,0 +1,189 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/stream"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeploymentEventFromChanges(t *testing.T) {
+	t.Parallel()
+	s := TestStateStoreCfg(t, TestStateStorePublisher(t))
+	defer s.StopEventPublisher()
+
+	// setup
+	setupTx := s.db.WriteTxn(10)
+
+	j := mock.Job()
+	e := mock.Eval()
+	e.JobID = j.ID
+
+	d := mock.Deployment()
+	d.JobID = j.ID
+
+	require.NoError(t, s.upsertJobImpl(10, j, false, setupTx))
+	require.NoError(t, s.upsertDeploymentImpl(10, d, setupTx))
+
+	setupTx.Txn.Commit()
+
+	ctx := context.WithValue(context.Background(), CtxMsgType, structs.DeploymentStatusUpdateRequestType)
+
+	req := &structs.DeploymentStatusUpdateRequest{
+		DeploymentUpdate: &structs.DeploymentStatusUpdate{
+			DeploymentID:      d.ID,
+			Status:            structs.DeploymentStatusPaused,
+			StatusDescription: structs.DeploymentStatusDescriptionPaused,
+		},
+		Eval: e,
+		// Exlude Job and assert its added
+	}
+
+	require.NoError(t, s.UpdateDeploymentStatus(ctx, 100, req))
+
+	events := WaitForEvents(t, s, 100, 1, 1*time.Second)
+	require.Len(t, events, 2)
+
+	got := events[0]
+	require.Equal(t, uint64(100), got.Index)
+	require.Equal(t, d.ID, got.Key)
+
+	de := got.Payload.(*DeploymentEvent)
+	require.Equal(t, structs.DeploymentStatusPaused, de.Deployment.Status)
+	require.Contains(t, got.FilterKeys, j.ID)
+
+}
+
+func TestDeploymentEventFromChanges_Promotion(t *testing.T) {
+	t.Parallel()
+	s := TestStateStoreCfg(t, TestStateStorePublisher(t))
+	defer s.StopEventPublisher()
+
+	// setup
+	setupTx := s.db.WriteTxn(10)
+
+	j := mock.Job()
+	tg1 := j.TaskGroups[0]
+	tg2 := tg1.Copy()
+	tg2.Name = "foo"
+	j.TaskGroups = append(j.TaskGroups, tg2)
+	require.NoError(t, s.upsertJobImpl(10, j, false, setupTx))
+
+	d := mock.Deployment()
+	d.StatusDescription = structs.DeploymentStatusDescriptionRunningNeedsPromotion
+	d.JobID = j.ID
+	d.TaskGroups = map[string]*structs.DeploymentState{
+		"web": {
+			DesiredTotal:    10,
+			DesiredCanaries: 1,
+		},
+		"foo": {
+			DesiredTotal:    10,
+			DesiredCanaries: 1,
+		},
+	}
+	require.NoError(t, s.upsertDeploymentImpl(10, d, setupTx))
+
+	// create set of allocs
+	c1 := mock.Alloc()
+	c1.JobID = j.ID
+	c1.DeploymentID = d.ID
+	d.TaskGroups[c1.TaskGroup].PlacedCanaries = append(d.TaskGroups[c1.TaskGroup].PlacedCanaries, c1.ID)
+	c1.DeploymentStatus = &structs.AllocDeploymentStatus{
+		Healthy: helper.BoolToPtr(true),
+	}
+	c2 := mock.Alloc()
+	c2.JobID = j.ID
+	c2.DeploymentID = d.ID
+	d.TaskGroups[c2.TaskGroup].PlacedCanaries = append(d.TaskGroups[c2.TaskGroup].PlacedCanaries, c2.ID)
+	c2.TaskGroup = tg2.Name
+	c2.DeploymentStatus = &structs.AllocDeploymentStatus{
+		Healthy: helper.BoolToPtr(true),
+	}
+
+	require.NoError(t, s.upsertAllocsImpl(10, []*structs.Allocation{c1, c2}, setupTx))
+
+	// commit setup transaction
+	setupTx.Txn.Commit()
+
+	e := mock.Eval()
+	// Request to promote canaries
+	ctx := context.WithValue(context.Background(), CtxMsgType, structs.DeploymentPromoteRequestType)
+	req := &structs.ApplyDeploymentPromoteRequest{
+		DeploymentPromoteRequest: structs.DeploymentPromoteRequest{
+			DeploymentID: d.ID,
+			All:          true,
+		},
+		Eval: e,
+	}
+
+	require.NoError(t, s.UpdateDeploymentPromotion(ctx, 100, req))
+
+	events := WaitForEvents(t, s, 100, 1, 1*time.Second)
+	require.Len(t, events, 2)
+
+	got := events[0]
+	require.Equal(t, uint64(100), got.Index)
+	require.Equal(t, d.ID, got.Key)
+
+	de := got.Payload.(*DeploymentEvent)
+	require.Equal(t, structs.DeploymentStatusRunning, de.Deployment.Status)
+}
+
+func WaitForEvents(t *testing.T, s *StateStore, index uint64, minEvents int, timeout time.Duration) []stream.Event {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(timeout):
+			require.Fail(t, "timeout waiting for events")
+		}
+	}()
+
+	maxAttempts := 10
+	for {
+		got := EventsForIndex(t, s, index)
+		if len(got) >= minEvents {
+			return got
+		}
+		maxAttempts--
+		if maxAttempts == 0 {
+			require.Fail(t, "reached max attempts waiting for desired event count")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func EventsForIndex(t *testing.T, s *StateStore, index uint64) []stream.Event {
+	pub, err := s.EventPublisher()
+	require.NoError(t, err)
+
+	sub, err := pub.Subscribe(&stream.SubscribeRequest{
+		Topics: map[stream.Topic][]string{
+			"*": []string{"*"},
+		},
+		Index: index,
+	})
+	defer sub.Unsubscribe()
+
+	require.NoError(t, err)
+
+	var events []stream.Event
+	for {
+		e, err := sub.NextNoBlock()
+		require.NoError(t, err)
+		if e == nil {
+			break
+		}
+		events = append(events, e...)
+	}
+	return events
+}

--- a/nomad/state/deployment_events.go
+++ b/nomad/state/deployment_events.go
@@ -1,0 +1,84 @@
+package state
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/stream"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func DeploymentEventFromChanges(msgType structs.MessageType, tx ReadTxn, changes Changes) ([]stream.Event, error) {
+	var events []stream.Event
+
+	var eventType string
+	switch msgType {
+	case structs.DeploymentStatusUpdateRequestType:
+		eventType = TypeDeploymentUpdate
+	case structs.DeploymentPromoteRequestType:
+		eventType = TypeDeploymentPromotion
+	case structs.DeploymentAllocHealthRequestType:
+		eventType = TypeDeploymentAllocHealth
+	}
+
+	for _, change := range changes.Changes {
+		switch change.Table {
+		case "deployment":
+			after, ok := change.After.(*structs.Deployment)
+			if !ok {
+				return nil, fmt.Errorf("transaction change was not a Deployment")
+			}
+
+			event := stream.Event{
+				Topic:      TopicDeployment,
+				Type:       eventType,
+				Index:      changes.Index,
+				Key:        after.ID,
+				FilterKeys: []string{after.JobID},
+				Payload: &DeploymentEvent{
+					Deployment: after,
+				},
+			}
+
+			events = append(events, event)
+		case "jobs":
+			after, ok := change.After.(*structs.Job)
+			if !ok {
+				return nil, fmt.Errorf("transaction change was not a Job")
+			}
+
+			event := stream.Event{
+				Topic: TopicJob,
+				Type:  eventType,
+				Index: changes.Index,
+				Key:   after.ID,
+				Payload: &JobEvent{
+					Job: after,
+				},
+			}
+
+			events = append(events, event)
+		case "allocs":
+			// TODO(drew) determine how to handle alloc updates during deployment
+		case "evals":
+			after, ok := change.After.(*structs.Evaluation)
+			if !ok {
+				return nil, fmt.Errorf("transaction change was not an Evaluation")
+			}
+
+			event := stream.Event{
+				Topic:      TopicEval,
+				Type:       eventType,
+				Index:      changes.Index,
+				Key:        after.ID,
+				FilterKeys: []string{after.DeploymentID, after.JobID},
+				Payload: &EvalEvent{
+					Eval: after,
+				},
+			}
+
+			events = append(events, event)
+		}
+	}
+
+	return events, nil
+}

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -1,0 +1,78 @@
+package state
+
+import (
+	"github.com/hashicorp/nomad/nomad/stream"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	TopicDeployment         stream.Topic = "Deployment"
+	TopicEval               stream.Topic = "Eval"
+	TopicAlloc              stream.Topic = "Alloc"
+	TopicJob                stream.Topic = "Job"
+	TopicNodeRegistration   stream.Topic = "NodeRegistration"
+	TopicNodeDeregistration stream.Topic = "NodeDeregistration"
+	TopicNodeDrain          stream.Topic = "NodeDrain"
+	TopicNodeEvent          stream.Topic = "NodeEvent"
+	TopicNode               stream.Topic = "Node"
+
+	// TODO(drew) Node Events use TopicNode + Type
+	TypeNodeRegistration   = "NodeRegistration"
+	TypeNodeDeregistration = "NodeDeregistration"
+	TypeNodeDrain          = "NodeDrain"
+	TypeNodeEvent          = "NodeEvent"
+
+	TypeDeploymentUpdate      = "DeploymentStatusUpdate"
+	TypeDeploymentPromotion   = "DeploymentPromotion"
+	TypeDeploymentAllocHealth = "DeploymentAllocHealth"
+
+	TypeAllocCreated = "AllocCreated"
+	TypeAllocUpdated = "AllocUpdated"
+)
+
+type JobEvent struct {
+	Job *structs.Job
+}
+
+type EvalEvent struct {
+	Eval *structs.Evaluation
+}
+
+type AllocEvent struct {
+	Alloc *structs.Allocation
+}
+
+type DeploymentEvent struct {
+	Deployment *structs.Deployment
+}
+
+type NodeRegistrationEvent struct {
+	Event      *structs.NodeEvent
+	NodeStatus string
+}
+
+type NodeDeregistrationEvent struct {
+	NodeID string
+}
+
+type NodeEvent struct {
+	Node *structs.Node
+}
+
+// NNodeDrainEvent is the Payload for a NodeDrain event. It contains
+// information related to the Node being drained as well as high level
+// information about the current allocations on the Node
+type NodeDrainEvent struct {
+	Node      *structs.Node
+	JobAllocs map[string]*JobDrainDetails
+}
+
+type NodeDrainAllocDetails struct {
+	ID      string
+	Migrate *structs.MigrateStrategy
+}
+
+type JobDrainDetails struct {
+	Type         string
+	AllocDetails map[string]NodeDrainAllocDetails
+}

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -6,15 +6,14 @@ import (
 )
 
 const (
-	TopicDeployment         stream.Topic = "Deployment"
-	TopicEval               stream.Topic = "Eval"
-	TopicAlloc              stream.Topic = "Alloc"
-	TopicJob                stream.Topic = "Job"
-	TopicNodeRegistration   stream.Topic = "NodeRegistration"
-	TopicNodeDeregistration stream.Topic = "NodeDeregistration"
-	TopicNodeDrain          stream.Topic = "NodeDrain"
-	TopicNodeEvent          stream.Topic = "NodeEvent"
-	TopicNode               stream.Topic = "Node"
+	TopicDeployment stream.Topic = "Deployment"
+	TopicEval       stream.Topic = "Eval"
+	TopicAlloc      stream.Topic = "Alloc"
+	TopicJob        stream.Topic = "Job"
+	// TopicNodeRegistration   stream.Topic = "NodeRegistration"
+	// TopicNodeDeregistration stream.Topic = "NodeDeregistration"
+	// TopicNodeDrain          stream.Topic = "NodeDrain"
+	TopicNode stream.Topic = "Node"
 
 	// TODO(drew) Node Events use TopicNode + Type
 	TypeNodeRegistration   = "NodeRegistration"
@@ -44,15 +43,6 @@ type AllocEvent struct {
 
 type DeploymentEvent struct {
 	Deployment *structs.Deployment
-}
-
-type NodeRegistrationEvent struct {
-	Event      *structs.NodeEvent
-	NodeStatus string
-}
-
-type NodeDeregistrationEvent struct {
-	NodeID string
 }
 
 type NodeEvent struct {

--- a/nomad/state/node_events.go
+++ b/nomad/state/node_events.go
@@ -20,12 +20,12 @@ func NodeRegisterEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event, 
 			}
 
 			event := stream.Event{
-				Topic: TopicNodeRegistration,
+				Topic: TopicNode,
+				Type:  TypeNodeRegistration,
 				Index: changes.Index,
 				Key:   after.ID,
-				Payload: &NodeRegistrationEvent{
-					Event:      after.Events[len(after.Events)-1],
-					NodeStatus: after.Status,
+				Payload: &NodeEvent{
+					Node: after,
 				},
 			}
 			events = append(events, event)
@@ -47,11 +47,12 @@ func NodeDeregisterEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event
 			}
 
 			event := stream.Event{
-				Topic: TopicNodeDeregistration,
+				Topic: TopicNode,
+				Type:  TypeNodeDeregistration,
 				Index: changes.Index,
 				Key:   before.ID,
-				Payload: &NodeDeregistrationEvent{
-					NodeID: before.ID,
+				Payload: &NodeEvent{
+					Node: before,
 				},
 			}
 			events = append(events, event)
@@ -73,7 +74,8 @@ func NodeEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
 			}
 
 			event := stream.Event{
-				Topic: TopicNodeEvent,
+				Topic: TopicNode,
+				Type:  TypeNodeEvent,
 				Index: changes.Index,
 				Key:   after.ID,
 				Payload: &NodeEvent{
@@ -119,7 +121,8 @@ func NodeDrainEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event, err
 			}
 
 			event := stream.Event{
-				Topic: TopicNodeDrain,
+				Topic: TopicNode,
+				Type:  TypeNodeDrain,
 				Index: changes.Index,
 				Key:   after.ID,
 				Payload: &NodeDrainEvent{

--- a/nomad/state/node_events.go
+++ b/nomad/state/node_events.go
@@ -7,20 +7,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-const (
-	TopicNodeRegistration   = "NodeRegistration"
-	TopicNodeDeregistration = "NodeDeregistration"
-)
-
-type NodeRegistrationEvent struct {
-	Event      *structs.NodeEvent
-	NodeStatus string
-}
-
-type NodeDeregistrationEvent struct {
-	NodeID string
-}
-
 // NodeRegisterEventFromChanges generates a NodeRegistrationEvent from a set
 // of transaction changes.
 func NodeRegisterEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
@@ -66,6 +52,79 @@ func NodeDeregisterEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event
 				Key:   before.ID,
 				Payload: &NodeDeregistrationEvent{
 					NodeID: before.ID,
+				},
+			}
+			events = append(events, event)
+		}
+	}
+	return events, nil
+}
+
+// NodeEventFromChanges generates a NodeDeregistrationEvent from a set
+// of transaction changes.
+func NodeEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
+	var events []stream.Event
+	for _, change := range changes.Changes {
+		switch change.Table {
+		case "nodes":
+			after, ok := change.After.(*structs.Node)
+			if !ok {
+				return nil, fmt.Errorf("transaction change was not a Node")
+			}
+
+			event := stream.Event{
+				Topic: TopicNodeEvent,
+				Index: changes.Index,
+				Key:   after.ID,
+				Payload: &NodeEvent{
+					Node: after,
+				},
+			}
+			events = append(events, event)
+		}
+	}
+	return events, nil
+}
+
+func NodeDrainEventFromChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
+	var events []stream.Event
+	for _, change := range changes.Changes {
+		switch change.Table {
+		case "nodes":
+			after, ok := change.After.(*structs.Node)
+			if !ok {
+				return nil, fmt.Errorf("transaction change was not a Node")
+			}
+
+			// retrieve allocations currently on node
+			allocs, err := allocsByNodeTxn(tx, nil, after.ID)
+			if err != nil {
+				return nil, fmt.Errorf("retrieving allocations for node drain event: %w", err)
+			}
+
+			// build job/alloc details for node drain
+			jobAllocs := make(map[string]*JobDrainDetails)
+			for _, a := range allocs {
+				if _, ok := jobAllocs[a.Job.Name]; !ok {
+					jobAllocs[a.Job.Name] = &JobDrainDetails{
+						AllocDetails: make(map[string]NodeDrainAllocDetails),
+						Type:         a.Job.Type,
+					}
+				}
+
+				jobAllocs[a.Job.Name].AllocDetails[a.ID] = NodeDrainAllocDetails{
+					Migrate: a.MigrateStrategy(),
+					ID:      a.ID,
+				}
+			}
+
+			event := stream.Event{
+				Topic: TopicNodeDrain,
+				Index: changes.Index,
+				Key:   after.ID,
+				Payload: &NodeDrainEvent{
+					Node:      after,
+					JobAllocs: jobAllocs,
 				},
 			}
 			events = append(events, event)

--- a/nomad/state/state_changes.go
+++ b/nomad/state/state_changes.go
@@ -190,6 +190,18 @@ func processDBChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
 		return NodeRegisterEventFromChanges(tx, changes)
 	case structs.NodeDeregisterRequestType:
 		return NodeDeregisterEventFromChanges(tx, changes)
+	case structs.NodeUpdateDrainRequestType:
+		return NodeDrainEventFromChanges(tx, changes)
+	case structs.UpsertNodeEventsType:
+		return NodeEventFromChanges(tx, changes)
+	case structs.DeploymentStatusUpdateRequestType:
+		return DeploymentEventFromChanges(changes.MsgType, tx, changes)
+	case structs.DeploymentPromoteRequestType:
+		return DeploymentEventFromChanges(changes.MsgType, tx, changes)
+	case structs.DeploymentAllocHealthRequestType:
+		return DeploymentEventFromChanges(changes.MsgType, tx, changes)
+	case structs.ApplyPlanResultsRequestType:
+		return ApplyPlanResultEventsFromChanges(tx, changes)
 	}
 	return []stream.Event{}, nil
 }

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -127,7 +127,7 @@ func TestStateStore_UpsertPlanResults_AllocationsCreated_Denormalized(t *testing
 		EvalID: eval.ID,
 	}
 	assert := assert.New(t)
-	err := state.UpsertPlanResults(1000, &res)
+	err := state.UpsertPlanResults(context.Background(), 1000, &res)
 	assert.Nil(err)
 
 	ws := memdb.NewWatchSet()
@@ -203,7 +203,7 @@ func TestStateStore_UpsertPlanResults_AllocationsDenormalized(t *testing.T) {
 	}
 	assert := assert.New(t)
 	planModifyIndex := uint64(1000)
-	err := state.UpsertPlanResults(planModifyIndex, &res)
+	err := state.UpsertPlanResults(context.Background(), planModifyIndex, &res)
 	require.NoError(err)
 
 	ws := memdb.NewWatchSet()
@@ -284,7 +284,7 @@ func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
 		EvalID:     eval.ID,
 	}
 
-	err := state.UpsertPlanResults(1000, &res)
+	err := state.UpsertPlanResults(context.Background(), 1000, &res)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -332,7 +332,7 @@ func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
 		EvalID:     eval.ID,
 	}
 
-	err = state.UpsertPlanResults(1001, &res)
+	err = state.UpsertPlanResults(context.Background(), 1001, &res)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestStateStore_UpsertPlanResults_PreemptedAllocs(t *testing.T) {
 		PreemptionEvals: []*structs.Evaluation{eval2},
 	}
 
-	err = state.UpsertPlanResults(1000, &res)
+	err = state.UpsertPlanResults(context.Background(), 1000, &res)
 	require.NoError(err)
 
 	ws := memdb.NewWatchSet()
@@ -486,7 +486,7 @@ func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 		EvalID:            eval.ID,
 	}
 
-	err := state.UpsertPlanResults(1000, &res)
+	err := state.UpsertPlanResults(context.Background(), 1000, &res)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -6600,7 +6600,7 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Nonexistent(t *testing.T) {
 			Status:       structs.DeploymentStatusRunning,
 		},
 	}
-	err := state.UpdateDeploymentStatus(2, req)
+	err := state.UpdateDeploymentStatus(context.Background(), 2, req)
 	if err == nil || !strings.Contains(err.Error(), "does not exist") {
 		t.Fatalf("expected error updating the status because the deployment doesn't exist")
 	}
@@ -6627,7 +6627,7 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Terminal(t *testing.T) {
 			Status:       structs.DeploymentStatusRunning,
 		},
 	}
-	err := state.UpdateDeploymentStatus(2, req)
+	err := state.UpdateDeploymentStatus(context.Background(), 2, req)
 	if err == nil || !strings.Contains(err.Error(), "has terminal status") {
 		t.Fatalf("expected error updating the status because the deployment is terminal")
 	}
@@ -6661,7 +6661,7 @@ func TestStateStore_UpsertDeploymentStatusUpdate_NonTerminal(t *testing.T) {
 		Job:  j,
 		Eval: e,
 	}
-	err := state.UpdateDeploymentStatus(2, req)
+	err := state.UpdateDeploymentStatus(context.Background(), 2, req)
 	if err != nil {
 		t.Fatalf("bad: %v", err)
 	}
@@ -6722,7 +6722,7 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Successful(t *testing.T) {
 			StatusDescription: structs.DeploymentStatusDescriptionSuccessful,
 		},
 	}
-	err := state.UpdateDeploymentStatus(3, req)
+	err := state.UpdateDeploymentStatus(context.Background(), 3, req)
 	if err != nil {
 		t.Fatalf("bad: %v", err)
 	}
@@ -6820,7 +6820,7 @@ func TestStateStore_UpsertDeploymentPromotion_Nonexistent(t *testing.T) {
 			All:          true,
 		},
 	}
-	err := state.UpdateDeploymentPromotion(2, req)
+	err := state.UpdateDeploymentPromotion(context.Background(), 2, req)
 	if err == nil || !strings.Contains(err.Error(), "does not exist") {
 		t.Fatalf("expected error promoting because the deployment doesn't exist")
 	}
@@ -6847,7 +6847,7 @@ func TestStateStore_UpsertDeploymentPromotion_Terminal(t *testing.T) {
 			All:          true,
 		},
 	}
-	err := state.UpdateDeploymentPromotion(2, req)
+	err := state.UpdateDeploymentPromotion(context.Background(), 2, req)
 	if err == nil || !strings.Contains(err.Error(), "has terminal status") {
 		t.Fatalf("expected error updating the status because the deployment is terminal: %v", err)
 	}
@@ -6897,7 +6897,7 @@ func TestStateStore_UpsertDeploymentPromotion_Unhealthy(t *testing.T) {
 			All:          true,
 		},
 	}
-	err := state.UpdateDeploymentPromotion(4, req)
+	err := state.UpdateDeploymentPromotion(context.Background(), 4, req)
 	require.NotNil(err)
 	require.Contains(err.Error(), `Task group "web" has 0/2 healthy allocations`)
 }
@@ -6926,7 +6926,7 @@ func TestStateStore_UpsertDeploymentPromotion_NoCanaries(t *testing.T) {
 			All:          true,
 		},
 	}
-	err := state.UpdateDeploymentPromotion(4, req)
+	err := state.UpdateDeploymentPromotion(context.Background(), 4, req)
 	require.NotNil(err)
 	require.Contains(err.Error(), `Task group "web" has 0/2 healthy allocations`)
 }
@@ -6997,7 +6997,7 @@ func TestStateStore_UpsertDeploymentPromotion_All(t *testing.T) {
 		},
 		Eval: e,
 	}
-	err := state.UpdateDeploymentPromotion(4, req)
+	err := state.UpdateDeploymentPromotion(context.Background(), 4, req)
 	if err != nil {
 		t.Fatalf("bad: %v", err)
 	}
@@ -7103,7 +7103,7 @@ func TestStateStore_UpsertDeploymentPromotion_Subset(t *testing.T) {
 		},
 		Eval: e,
 	}
-	require.Nil(state.UpdateDeploymentPromotion(4, req))
+	require.Nil(state.UpdateDeploymentPromotion(context.Background(), 4, req))
 
 	// Check that the status per task group was updated properly
 	ws := memdb.NewWatchSet()
@@ -7146,7 +7146,7 @@ func TestStateStore_UpsertDeploymentAllocHealth_Nonexistent(t *testing.T) {
 			HealthyAllocationIDs: []string{uuid.Generate()},
 		},
 	}
-	err := state.UpdateDeploymentAllocHealth(2, req)
+	err := state.UpdateDeploymentAllocHealth(context.Background(), 2, req)
 	if err == nil || !strings.Contains(err.Error(), "does not exist") {
 		t.Fatalf("expected error because the deployment doesn't exist: %v", err)
 	}
@@ -7173,7 +7173,7 @@ func TestStateStore_UpsertDeploymentAllocHealth_Terminal(t *testing.T) {
 			HealthyAllocationIDs: []string{uuid.Generate()},
 		},
 	}
-	err := state.UpdateDeploymentAllocHealth(2, req)
+	err := state.UpdateDeploymentAllocHealth(context.Background(), 2, req)
 	if err == nil || !strings.Contains(err.Error(), "has terminal status") {
 		t.Fatalf("expected error because the deployment is terminal: %v", err)
 	}
@@ -7198,7 +7198,7 @@ func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_Nonexistent(t *testing.
 			HealthyAllocationIDs: []string{uuid.Generate()},
 		},
 	}
-	err := state.UpdateDeploymentAllocHealth(2, req)
+	err := state.UpdateDeploymentAllocHealth(context.Background(), 2, req)
 	if err == nil || !strings.Contains(err.Error(), "unknown alloc") {
 		t.Fatalf("expected error because the alloc doesn't exist: %v", err)
 	}
@@ -7338,7 +7338,7 @@ func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_MismatchDeployment(t *t
 			HealthyAllocationIDs: []string{a.ID},
 		},
 	}
-	err := state.UpdateDeploymentAllocHealth(4, req)
+	err := state.UpdateDeploymentAllocHealth(context.Background(), 4, req)
 	if err == nil || !strings.Contains(err.Error(), "not part of deployment") {
 		t.Fatalf("expected error because the alloc isn't part of the deployment: %v", err)
 	}
@@ -7395,7 +7395,7 @@ func TestStateStore_UpsertDeploymentAllocHealth(t *testing.T) {
 		DeploymentUpdate: u,
 		Timestamp:        ts,
 	}
-	err := state.UpdateDeploymentAllocHealth(3, req)
+	err := state.UpdateDeploymentAllocHealth(context.Background(), 3, req)
 	if err != nil {
 		t.Fatalf("bad: %v", err)
 	}

--- a/nomad/stream/event.go
+++ b/nomad/stream/event.go
@@ -7,8 +7,15 @@ const (
 type Topic string
 
 type Event struct {
-	Topic   Topic
-	Key     string
-	Index   uint64
-	Payload interface{}
+	Topic      Topic
+	Type       string
+	Key        string
+	FilterKeys []string
+	Index      uint64
+	Payload    interface{}
+}
+
+type Events struct {
+	Index  uint64
+	Events []Event
 }

--- a/nomad/stream/event_publisher.go
+++ b/nomad/stream/event_publisher.go
@@ -65,7 +65,7 @@ func NewEventPublisher(ctx context.Context, cfg EventPublisherCfg) *EventPublish
 	e := &EventPublisher{
 		logger:    cfg.Logger.Named("event_publisher"),
 		eventBuf:  buffer,
-		publishCh: make(chan changeEvents),
+		publishCh: make(chan changeEvents, 64),
 		subscriptions: &subscriptions{
 			byToken: make(map[string]map[*SubscribeRequest]*Subscription),
 		},

--- a/nomad/stream/event_publisher_test.go
+++ b/nomad/stream/event_publisher_test.go
@@ -86,7 +86,7 @@ func consumeSubscription(ctx context.Context, sub *Subscription) <-chan subNextR
 		for {
 			es, err := sub.Next(ctx)
 			eventCh <- subNextResult{
-				Events: es,
+				Events: es.Events,
 				Err:    err,
 			}
 			if err != nil {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8944,6 +8944,15 @@ func (a *Allocation) ReschedulePolicy() *ReschedulePolicy {
 	return tg.ReschedulePolicy
 }
 
+// MigrateStrategy returns the migrate strategy based on the task group
+func (a *Allocation) MigrateStrategy() *MigrateStrategy {
+	tg := a.Job.LookupTaskGroup(a.TaskGroup)
+	if tg == nil {
+		return nil
+	}
+	return tg.Migrate
+}
+
 // NextRescheduleTime returns a time on or after which the allocation is eligible to be rescheduled,
 // and whether the next reschedule time is within policy's interval if the policy doesn't allow unlimited reschedules
 func (a *Allocation) NextRescheduleTime() (time.Time, bool) {

--- a/scheduler/testing.go
+++ b/scheduler/testing.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -170,7 +171,7 @@ func (h *Harness) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, State, er
 	}
 
 	// Apply the full plan
-	err := h.State.UpsertPlanResults(index, &req)
+	err := h.State.UpsertPlanResults(context.Background(), index, &req)
 	return result, nil, err
 }
 


### PR DESCRIPTION
Event Changes:
- Use a common NodeEvent for all different types of Node events
- Add a `Type` field on event which will be later used for additional filtering
- Add Deployment events
- Instead of their being multiple events for a given index on each entry of ndjson, a group of events generated in a single index are now wrapped with a `{ Index: index, Events: [events] }` wrapper