### PR TITLE
e2e: tfvars.dev file must override default tfvars file

### DIFF
--- a/e2e/terraform/terraform.tfvars.dev
+++ b/e2e/terraform/terraform.tfvars.dev
@@ -4,6 +4,8 @@ server_count         = "3"
 client_count         = "2"
 windows_client_count = "0"
 profile              = "dev-cluster"
+nomad_acls           = false
+nomad_enterprise     = false
 
 # Example overrides:
 # nomad_local_binary = "../../pkg/linux_amd/nomad"


### PR DESCRIPTION
The `-var-file` flag for loading variables into Terraform overlays the default
variables file if present. This means that variables that are set in the
default variables file will take precedence if the overlay file does not have
them set.

Set `nomad_acls` and `nomad_enterprise` to `false` in the dev cluster.

ref [Variable Definition Precedence docs](https://www.terraform.io/docs/configuration/variables.html#variable-definition-precedence) and a very confused hour of my afternoon