### PR TITLE
docs: document docker signal fix, add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ IMPROVEMENTS:
  * driver/docker: Upgrade pause container and detect architecture [[GH-8957](https://github.com/hashicorp/nomad/pull/8957)]
  * jobspec: Lowered minimum CPU allowed from 10 to 1. [[GH-8996](https://github.com/hashicorp/nomad/issues/8996)]
 
+__BACKWARDS INCOMPATIBILITIES:__
+ * driver/docker: Tasks are now issued SIGTERM instead of SIGINT when stopping [[GH-8932](https://github.com/hashicorp/nomad/issues/8932)]
+
 BUG FIXES:
 
  * core: Fixed a bug where blocking queries would not include the query's maximum wait time when calculating whether it was safe to retry. [[GH-8921](https://github.com/hashicorp/nomad/issues/8921)]

--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -15,6 +15,15 @@ details provided for their upgrades as a result of new features or changed
 behavior. This page is used to document those details separately from the
 standard upgrade flow.
 
+## Nomad 0.13.0
+
+### Signal used when stopping Docker tasks
+
+When stopping tasks running with the Docker task driver, Nomad documents that a
+`SIGTERM` will be issued (unless configured with `kill_signal`). However, recent
+versions of Nomad would issue `SIGINT` instead. Starting again with Nomad v0.13.0
+`SIGTERM` will be sent by default when stopping Docker tasks.
+
 ## Nomad 0.12.0
 
 ### `mbits` and Task Network Resource deprecation


### PR DESCRIPTION
This PR adds a version specific upgrade note about the docker stop
signal behavior. Also adds test for the signal logic in docker driver.

Closes #8932 which was fixed in #8933

tagging @jf 