### PR TITLE
Change Azure attribute for hostname to name

### DIFF
--- a/client/fingerprint/env_azure.go
+++ b/client/fingerprint/env_azure.go
@@ -138,7 +138,7 @@ func (f *EnvAzureFingerprint) Fingerprint(request *FingerprintRequest, response 
 	// marked as unique, the key isn't included in the computed node class.
 	keys := map[string]AzureMetadataPair{
 		"id":             {unique: true, path: "compute/vmId"},
-		"hostname":       {unique: true, path: "compute/name"},
+		"name":           {unique: true, path: "compute/name"}, // name might not be the same as hostname
 		"location":       {unique: false, path: "compute/location"},
 		"resource-group": {unique: false, path: "compute/resourceGroupName"},
 		"scale-set":      {unique: false, path: "compute/vmScaleSetName"},

--- a/client/fingerprint/env_azure_test.go
+++ b/client/fingerprint/env_azure_test.go
@@ -108,7 +108,7 @@ func testFingerprint_Azure(t *testing.T, withExternalIp bool) {
 
 	keys := []string{
 		"unique.platform.azure.id",
-		"unique.platform.azure.hostname",
+		"unique.platform.azure.name",
 		"platform.azure.location",
 		"platform.azure.resource-group",
 		"platform.azure.scale-set",
@@ -134,7 +134,7 @@ func testFingerprint_Azure(t *testing.T, withExternalIp bool) {
 	}
 
 	assertNodeAttributeEquals(t, response.Attributes, "unique.platform.azure.id", "13f56399-bd52-4150-9748-7190aae1ff21")
-	assertNodeAttributeEquals(t, response.Attributes, "unique.platform.azure.hostname", "demo01.internal")
+	assertNodeAttributeEquals(t, response.Attributes, "unique.platform.azure.name", "demo01.internal")
 	assertNodeAttributeEquals(t, response.Attributes, "platform.azure.location", "eastus")
 	assertNodeAttributeEquals(t, response.Attributes, "platform.azure.resource-group", "myrg")
 	assertNodeAttributeEquals(t, response.Attributes, "platform.azure.scale-set", "nomad-clients")


### PR DESCRIPTION
The name metadata doesn't always match the hostname. In the case of scale sets the value will be "{scale-set-name}_{instance-id}" and the hostname would  "{computer-name-prefix}{base-36-instance-id}".  Azure metadata service doesn't have metadata for hostname. 