### PR TITLE
job, task group, and task IDs should not allow null characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ IMPROVEMENTS:
  * jobspec: Lowered minimum CPU allowed from 10 to 1. [[GH-8996](https://github.com/hashicorp/nomad/issues/8996)]
 
 __BACKWARDS INCOMPATIBILITIES:__
- * core: job IDs, task group names, and task names are not allowed to contain null characters [[GH-9020](https://github.com/hashicorp/nomad/issues/9020)]
+ * core: null characters are prohibited in region, datacenter, job name/ID, task group name, and task name [[GH-9020](https://github.com/hashicorp/nomad/issues/9020)]
  * driver/docker: Tasks are now issued SIGTERM instead of SIGINT when stopping [[GH-8932](https://github.com/hashicorp/nomad/issues/8932)]
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ IMPROVEMENTS:
  * jobspec: Lowered minimum CPU allowed from 10 to 1. [[GH-8996](https://github.com/hashicorp/nomad/issues/8996)]
 
 __BACKWARDS INCOMPATIBILITIES:__
+ * core: job IDs, task group names, and task names are not allowed to contain null characters [[GH-9020](https://github.com/hashicorp/nomad/issues/9020)]
  * driver/docker: Tasks are now issued SIGTERM instead of SIGINT when stopping [[GH-8932](https://github.com/hashicorp/nomad/issues/8932)]
 
 BUG FIXES:

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1291,7 +1291,7 @@ func TestJobs_Info(t *testing.T) {
 
 	// Trying to retrieve a job by ID before it exists
 	// returns an error
-	id := "job-id/with\\troublesome:characters\n?&字\000"
+	id := "job-id/with\\troublesome:characters\n?&字"
 	_, _, err := jobs.Info(id, nil)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("expected not found error, got: %#v", err)
@@ -1993,7 +1993,7 @@ func TestJobs_ScaleAction(t *testing.T) {
 	defer s.Stop()
 	jobs := c.Jobs()
 
-	id := "job-id/with\\troublesome:characters\n?&字\000"
+	id := "job-id/with\\troublesome:characters\n?&字"
 	job := testJobWithScalingPolicy()
 	job.ID = &id
 	groupName := *job.TaskGroups[0].Name
@@ -2054,7 +2054,7 @@ func TestJobs_ScaleAction_Error(t *testing.T) {
 	defer s.Stop()
 	jobs := c.Jobs()
 
-	id := "job-id/with\\troublesome:characters\n?&字\000"
+	id := "job-id/with\\troublesome:characters\n?&字"
 	job := testJobWithScalingPolicy()
 	job.ID = &id
 	groupName := *job.TaskGroups[0].Name
@@ -2106,7 +2106,7 @@ func TestJobs_ScaleAction_Noop(t *testing.T) {
 	defer s.Stop()
 	jobs := c.Jobs()
 
-	id := "job-id/with\\troublesome:characters\n?&字\000"
+	id := "job-id/with\\troublesome:characters\n?&字"
 	job := testJobWithScalingPolicy()
 	job.ID = &id
 	groupName := *job.TaskGroups[0].Name
@@ -2161,7 +2161,7 @@ func TestJobs_ScaleStatus(t *testing.T) {
 	jobs := c.Jobs()
 
 	// Trying to retrieve a status before it exists returns an error
-	id := "job-id/with\\troublesome:characters\n?&字\000"
+	id := "job-id/with\\troublesome:characters\n?&字"
 	_, _, err := jobs.ScaleStatus(id, nil)
 	require.Error(err)
 	require.Contains(err.Error(), "not found")

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -302,6 +302,18 @@ func (c *Command) isValidConfig(config, cmdConfig *Config) bool {
 		return false
 	}
 
+	// Check that the region does not contain invalid characters
+	if strings.ContainsAny(config.Region, "\000") {
+		c.Ui.Error("Region contains invalid characters")
+		return false
+	}
+
+	// Check that the datacenter name does not contain invalid characters
+	if strings.ContainsAny(config.Datacenter, "\000") {
+		c.Ui.Error("Datacenter contains invalid characters")
+		return false
+	}
+
 	// Set up the TLS configuration properly if we have one.
 	// XXX chelseakomlo: set up a TLSConfig New method which would wrap
 	// constructor-type actions like this.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3943,6 +3943,8 @@ func (j *Job) Validate() error {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing job ID"))
 	} else if strings.Contains(j.ID, " ") {
 		mErr.Errors = append(mErr.Errors, errors.New("Job ID contains a space"))
+	} else if strings.Contains(j.ID, "\000") {
+		mErr.Errors = append(mErr.Errors, errors.New("Job ID contains a null chararacter"))
 	}
 	if j.Name == "" {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing job name"))
@@ -5740,6 +5742,8 @@ func (tg *TaskGroup) Validate(j *Job) error {
 	var mErr multierror.Error
 	if tg.Name == "" {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing task group name"))
+	} else if strings.Contains(tg.Name, "\000") {
+		mErr.Errors = append(mErr.Errors, errors.New("Task group name contains null character"))
 	}
 	if tg.Count < 0 {
 		mErr.Errors = append(mErr.Errors, errors.New("Task group count can't be negative"))
@@ -6462,6 +6466,8 @@ func (t *Task) Validate(ephemeralDisk *EphemeralDisk, jobType string, tgServices
 		// We enforce this so that when creating the directory on disk it will
 		// not have any slashes.
 		mErr.Errors = append(mErr.Errors, errors.New("Task name cannot include slashes"))
+	} else if strings.Contains(t.Name, "\000") {
+		mErr.Errors = append(mErr.Errors, errors.New("Task name cannot include null characters"))
 	}
 	if t.Driver == "" {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing task driver"))

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3948,6 +3948,8 @@ func (j *Job) Validate() error {
 	}
 	if j.Name == "" {
 		mErr.Errors = append(mErr.Errors, errors.New("Missing job name"))
+	} else if strings.Contains(j.Name, "\000") {
+		mErr.Errors = append(mErr.Errors, errors.New("Job Name contains a null chararacter"))
 	}
 	if j.Namespace == "" {
 		mErr.Errors = append(mErr.Errors, errors.New("Job must be in a namespace"))

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -170,6 +170,25 @@ func TestJob_ValidateScaling(t *testing.T) {
 	require.Contains(mErr.Errors[0].Error(), "task group count must not be less than minimum count in scaling policy")
 }
 
+func TestJob_ValidateNullChar(t *testing.T) {
+	assert := assert.New(t)
+
+	// job id should not allow null characters
+	job := testJob()
+	job.ID = "id_with\000null_character"
+	assert.Error(job.Validate(), "null character in job ID should not validate")
+
+	// task group name should not allow null characters
+	job.ID = "happy_little_job_id"
+	job.TaskGroups[0].Name = "oh_no_another_\000_char"
+	assert.Error(job.Validate(), "null character in task group name should not validate")
+
+	// task name should not allow null characters
+	job.TaskGroups[0].Name = "so_much_better"
+	job.TaskGroups[0].Tasks[0].Name = "what_is_with_these_\000_chars"
+	assert.Error(job.Validate(), "null character in task name should not validate")
+}
+
 func TestJob_Warnings(t *testing.T) {
 	cases := []struct {
 		Name     string

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -178,8 +178,13 @@ func TestJob_ValidateNullChar(t *testing.T) {
 	job.ID = "id_with\000null_character"
 	assert.Error(job.Validate(), "null character in job ID should not validate")
 
-	// task group name should not allow null characters
+	// job name should not allow null characters
 	job.ID = "happy_little_job_id"
+	job.Name = "my job name with \000 characters"
+	assert.Error(job.Validate(), "null character in job name should not validate")
+
+	// task group name should not allow null characters
+	job.Name = "my job"
 	job.TaskGroups[0].Name = "oh_no_another_\000_char"
 	assert.Error(job.Validate(), "null character in task group name should not validate")
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -185,7 +185,7 @@ func TestJob_ValidateNullChar(t *testing.T) {
 
 	// task name should not allow null characters
 	job.TaskGroups[0].Name = "so_much_better"
-	job.TaskGroups[0].Tasks[0].Name = "what_is_with_these_\000_chars"
+	job.TaskGroups[0].Tasks[0].Name = "ive_had_it_with_these_\000_chars_in_these_names"
 	assert.Error(job.Validate(), "null character in task name should not validate")
 }
 

--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -24,11 +24,13 @@ When stopping tasks running with the Docker task driver, Nomad documents that a
 versions of Nomad would issue `SIGINT` instead. Starting again with Nomad v0.13.0
 `SIGTERM` will be sent by default when stopping Docker tasks.
 
-### Null characters in job, task group, and task IDs
+### Null characters in region, datacenter, job name/ID, task group name, and task names
 
-Starting with Nomad v0.13.0, job will fail validation if any of the following
-contain null character: the job ID, the task group name, or the task name. Any
-jobs meeting this requirement should be modified before an update to v0.13.0.
+Starting with Nomad v0.13.0, jobs will fail validation if any of the following
+contain null character: the job ID or name, the task group name, or the task name. Any
+jobs meeting this requirement should be modified before an update to v0.13.0. Similarly,
+client and server config validation will prohibit either the region or the datacenter
+from containing null characters.
 
 ## Nomad 0.12.0
 

--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -24,6 +24,12 @@ When stopping tasks running with the Docker task driver, Nomad documents that a
 versions of Nomad would issue `SIGINT` instead. Starting again with Nomad v0.13.0
 `SIGTERM` will be sent by default when stopping Docker tasks.
 
+### Null characters in job, task group, and task IDs
+
+Starting with Nomad v0.13.0, job will fail validation if any of the following
+contain null character: the job ID, the task group name, or the task name. Any
+jobs meeting this requirement should be modified before an update to v0.13.0.
+
 ## Nomad 0.12.0
 
 ### `mbits` and Task Network Resource deprecation


### PR DESCRIPTION
resolves #8796 

null characters in region, datacenter, job ID/name, task group name, and task name can break a lot of things, including:
* memdb compound indexing
* default task environment variables

changelog summary:
* d4ef12e42ebfde8575caa86e8b649cf0d6fcb2e5 is a documenting test
* 39c73f1b3256b1f780d329de381a3bf2d1a21d9b introduces the additional validation, but fails, because other tests actually rely on the ability to use null characters 😦 . also, updates CHANGELOG and upgrade guide.
* 5062e74b3e644887ffc39b41e07f341c1ba9af47 relaxes the tests which protect this backwards compatibility
* b0c2e5176a8e0dff88c152460f3d59f9310df62a adds additional tests for agent Region and Datacenter, as well as Job.Name