### PR TITLE
csi: allow more than 1 writer claim for multi-writer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ BUG FIXES:
 
  * core: Fixed a bug where blocking queries would not include the query's maximum wait time when calculating whether it was safe to retry. [[GH-8921](https://github.com/hashicorp/nomad/issues/8921)]
  * consul: Fixed a bug to correctly validate task when using script-checks in group-level services [[GH-8952](https://github.com/hashicorp/nomad/issues/8952)]
+ * csi: Fixed a bug where multi-writer volumes were allowed only 1 write claim. [[GH-9040](https://github.com/hashicorp/nomad/issues/9040)]
 
 ## 0.12.5 (September 17, 2020)
 

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -384,8 +384,13 @@ func (v *CSIVolume) WriteSchedulable() bool {
 // WriteFreeClaims determines if there are any free write claims available
 func (v *CSIVolume) WriteFreeClaims() bool {
 	switch v.AccessMode {
-	case CSIVolumeAccessModeSingleNodeWriter, CSIVolumeAccessModeMultiNodeSingleWriter, CSIVolumeAccessModeMultiNodeMultiWriter:
+	case CSIVolumeAccessModeSingleNodeWriter, CSIVolumeAccessModeMultiNodeSingleWriter:
 		return len(v.WriteAllocs) == 0
+	case CSIVolumeAccessModeMultiNodeMultiWriter:
+		// the CSI spec doesn't allow for setting a max number of writers.
+		// we track node resource exhaustion through v.ResourceExhausted
+		// which is checked in WriteSchedulable
+		return true
 	default:
 		return false
 	}

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -36,6 +36,11 @@ func TestCSIVolumeClaim(t *testing.T) {
 	vol.ClaimRelease(claim)
 	require.True(t, vol.ReadSchedulable())
 	require.True(t, vol.WriteFreeClaims())
+
+	vol.AccessMode = CSIVolumeAccessModeMultiNodeMultiWriter
+	require.NoError(t, vol.ClaimWrite(claim, alloc))
+	require.NoError(t, vol.ClaimWrite(claim, alloc))
+	require.True(t, vol.WriteFreeClaims())
 }
 
 func TestCSIPluginJobs(t *testing.T) {

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -292,7 +292,7 @@ func TestCSIVolumeChecker(t *testing.T) {
 	vol := structs.NewCSIVolume(vid, index)
 	vol.PluginID = "foo"
 	vol.Namespace = structs.DefaultNamespace
-	vol.AccessMode = structs.CSIVolumeAccessModeMultiNodeSingleWriter
+	vol.AccessMode = structs.CSIVolumeAccessModeMultiNodeMultiWriter
 	vol.AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem
 	err := state.CSIVolumeRegister(index, []*structs.CSIVolume{vol})
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8968

Fixes a bug where CSI volumes with the `MULTI_NODE_MULTI_WRITER` access mode
were using the same logic as `MULTI_NODE_SINGLE_WRITER` to determine whether
the volume had writer claims available for scheduling.