### PR TITLE
docs: CSI mount_options are available only for filesystem vols

### DIFF
--- a/website/pages/docs/commands/volume/register.mdx
+++ b/website/pages/docs/commands/volume/register.mdx
@@ -85,13 +85,13 @@ context {
 - `attachment_mode` `(string: <required>)` - The storage API that will be used
   by the volume. Most storage providers will support `"file-system"`, to mount
   volumes using the CSI filesystem API. Some storage providers will support
-  `"block-device"`, which mount the volume with the CSI block device API
+  `"block-device"`, which will mount the volume with the CSI block device API
   within the container.
 
-- `mount_options` <code>([mount_options][]:nil)</code> - Options for mounting
-  `file-system` volumes that don't already have a pre-formatted file system.
-  Consult the documentation for your storage provider and CSI plugin as to
-  whether these options are required or neccessary.
+- `mount_options` - Options for mounting `file-system` volumes that don't
+  already have a pre-formatted file system. Consult the documentation for your
+  storage provider and CSI plugin as to whether these options are required or
+  neccessary.
 
   - `fs_type`: file system type (ex. `"ext4"`)
   - `mount_flags`: the flags passed to `mount` (ex. `"ro,noatime"`)

--- a/website/pages/docs/commands/volume/register.mdx
+++ b/website/pages/docs/commands/volume/register.mdx
@@ -82,14 +82,16 @@ context {
   single-node modes. Consult the documentation of the storage provider
   and CSI plugin.
 
-- `attachment_mode` `(string: <required>)` - The storage API that will
-  be used by the volume. Most storage providers will support
-  `"file-system"`, to mount pre-formatted file system volumes. Some
-  storage providers will support `"block-device"`, which will require
-  the job be configured with appropriate mount options.
+- `attachment_mode` `(string: <required>)` - The storage API that will be used
+  by the volume. Most storage providers will support `"file-system"`, to mount
+  volumes using the CSI filesystem API. Some storage providers will support
+  `"block-device"`, which mount the volume with the CSI block device API
+  within the container.
 
-- `mount_options` <code>([mount_options][]:nil)</code> - Options for
-  mounting `block-device`volumes without a pre-formatted file system.
+- `mount_options` <code>([mount_options][]:nil)</code> - Options for mounting
+  `file-system` volumes that don't already have a pre-formatted file system.
+  Consult the documentation for your storage provider and CSI plugin as to
+  whether these options are required or neccessary.
 
   - `fs_type`: file system type (ex. `"ext4"`)
   - `mount_flags`: the flags passed to `mount` (ex. `"ro,noatime"`)

--- a/website/pages/docs/job-specification/volume.mdx
+++ b/website/pages/docs/job-specification/volume.mdx
@@ -55,7 +55,20 @@ the [volume_mount][volume_mount] stanza in the `task` configuration.
   used for validating `host_volume` ACLs and for scheduling when a
   matching `host_volume` requires `read_only` usage.
 
+- `mount_options` <code>([mount_options][]:nil)</code> - Options for mounting
+  CSI volumes that have the `file-system` [attachment mode]. These options
+  override the `mount_options` field from [volume registration].  Consult
+  the documentation for your storage provider and CSI plugin as to whether
+  these options are required or neccessary.
+
+  - `fs_type`: file system type (ex. `"ext4"`)
+  - `mount_flags`: the flags passed to `mount` (ex. `"ro,noatime"`)
+
+
 [volume_mount]: /docs/job-specification/volume_mount 'Nomad volume_mount Job Specification'
 [host_volume]: /docs/configuration/client#host_volume-stanza
 [csi_volume]: /docs/commands/volume/register
 [csi_plugin]: /docs/job-specification/csi_plugin
+[csi_volume]: /docs/commands/volume/register
+[attachment mode]: /docs/commands/volume/register#attachment_mode
+[volume registration]: /docs/commands/volume/register#mount_options

--- a/website/pages/docs/job-specification/volume.mdx
+++ b/website/pages/docs/job-specification/volume.mdx
@@ -55,11 +55,11 @@ the [volume_mount][volume_mount] stanza in the `task` configuration.
   used for validating `host_volume` ACLs and for scheduling when a
   matching `host_volume` requires `read_only` usage.
 
-- `mount_options` <code>([mount_options][]:nil)</code> - Options for mounting
-  CSI volumes that have the `file-system` [attachment mode]. These options
-  override the `mount_options` field from [volume registration].  Consult
-  the documentation for your storage provider and CSI plugin as to whether
-  these options are required or neccessary.
+- `mount_options` - Options for mounting CSI volumes that have the
+  `file-system` [attachment mode]. These options override the `mount_options`
+  field from [volume registration]. Consult the documentation for your storage
+  provider and CSI plugin as to whether these options are required or
+  neccessary.
 
   - `fs_type`: file system type (ex. `"ext4"`)
   - `mount_flags`: the flags passed to `mount` (ex. `"ro,noatime"`)


### PR DESCRIPTION
Partial fix for https://github.com/hashicorp/nomad/issues/9021

The CSI specifcation allows only the `file-system` attachment mode to have
mount options. The `block-device` mode is left "intentionally empty, for now"
in the protocol. We should be validating against this problem, but our
documentation also had it backwards.

Also adds missing docs for `mount_options` on the group's `volume` spec.

Fixing the validation is in https://github.com/hashicorp/nomad/pull/9044