### PR TITLE
csi: validate mount options during volume registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
 
 __BACKWARDS INCOMPATIBILITIES:__
  * core: null characters are prohibited in region, datacenter, job name/ID, task group name, and task name [[GH-9020](https://github.com/hashicorp/nomad/issues/9020)]
+ * csi: registering a CSI volume with a `block-device` attachment mode and `mount_options` now returns a validation error, instead of silently dropping the `mount_options`. [[GH-9044](https://github.com/hashicorp/nomad/issues/9044)]
  * driver/docker: Tasks are now issued SIGTERM instead of SIGINT when stopping [[GH-8932](https://github.com/hashicorp/nomad/issues/8932)]
 
 BUG FIXES:

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -580,7 +580,12 @@ func (v *CSIVolume) Validate() error {
 	}
 	if v.AttachmentMode == CSIVolumeAttachmentModeBlockDevice {
 		if v.MountOptions != nil {
-			errs = append(errs, "mount options not allowed for block-device")
+			if v.MountOptions.FSType != "" {
+				errs = append(errs, "mount options not allowed for block-device")
+			}
+			if v.MountOptions.MountFlags != nil && len(v.MountOptions.MountFlags) != 0 {
+				errs = append(errs, "mount options not allowed for block-device")
+			}
 		}
 	}
 

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -172,7 +172,7 @@ func (o *CSIMountOptions) Merge(p *CSIMountOptions) {
 	}
 }
 
-// VolumeMountOptions implements the Stringer and GoStringer interfaces to prevent
+// CSIMountOptions implements the Stringer and GoStringer interfaces to prevent
 // accidental leakage of sensitive mount flags via logs.
 var _ fmt.Stringer = &CSIMountOptions{}
 var _ fmt.GoStringer = &CSIMountOptions{}
@@ -577,6 +577,11 @@ func (v *CSIVolume) Validate() error {
 	}
 	if v.AttachmentMode == "" {
 		errs = append(errs, "missing attachment mode")
+	}
+	if v.AttachmentMode == CSIVolumeAttachmentModeBlockDevice {
+		if v.MountOptions != nil {
+			errs = append(errs, "mount options not allowed for block-device")
+		}
 	}
 
 	// TODO: Volume Topologies are optional - We should check to see if the plugin


### PR DESCRIPTION
Partial fix for https://github.com/hashicorp/nomad/issues/9021

Volumes using attachment mode `file-system` use the CSI filesystem API when
they're mounted, and can be passed mount options. But `block-device` mode
volumes don't have this option. When RPCs are made to plugins, we are silently
dropping the mount options we don't expect to see, but this results in a poor
operator experience when the mount options aren't honored. This changeset
makes passing mount options to a `block-device` volume a validation error
as opposed to a run-time error.

This doesn't entirely close-out #9021 because there's a question about how we're
supposed to be reconciling the controller plugin response at runtime, but this solves
a real submission-time problem.