### PR TITLE
docs: Update redirects to use a broader catch-all for routes ending in .html

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -395,7 +395,7 @@ There is still one caveat though: redirects do not apply to client-side navigati
 Let's look at an example. Say you have a page called `/docs/foo` which needs to be moved to `/docs/nested/foo`. Additionally, this is a page that has been around for a while and we know there are links into `/docs/foo.html` left over from our previous website structure. First, we move the page, then adjust the docs sidenav, in `data/docs-navigation.js`. Find the category the page is in, and move it into the appropriate subcategory. Next, we add to redirects as such:
 
 ```js
-{ source: '/foo(.html)?', destination: '/nested/foo', permanent: true }
+{ source: '/foo', destination: '/nested/foo', permanent: true }
 ```
 
 Next, we run a global search for internal links to `/foo`, and make sure to adjust them to be `/nested/foo` - this is to ensure that client-side navigation still works correctly. _Adding a redirect alone is not enough_.

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -2,7 +2,6 @@ module.exports = [
   // Define your custom redirects within this file.
   // Vercel's redirect documentation: https://vercel.com/docs/configuration#project/redirects
   // Playground for testing url pattern matching: https://npm.runkit.com/path-to-regexp
-  // Note that `(.html)?` and `(index.html)?` are only needed for supporting legacy middleman routes
 
   {
     source: '/docs/telemetry/overview',
@@ -20,34 +19,34 @@ module.exports = [
 
   // Nomad Learn Redirects
   {
-    source: '/intro/getting-started/install(.html)?',
+    source: '/intro/getting-started/install',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/get-started-install',
     permanent: true,
   },
   {
-    source: '/intro/getting-started/running(.html)?',
+    source: '/intro/getting-started/running',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/get-started-run',
     permanent: true,
   },
   {
-    source: '/intro/getting-started/jobs(.html)?',
+    source: '/intro/getting-started/jobs',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/get-started-jobs',
     permanent: true,
   },
   {
-    source: '/intro/getting-started/cluster(.html)?',
+    source: '/intro/getting-started/cluster',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/get-started-cluster',
     permanent: true,
   },
   {
-    source: '/intro/getting-started/ui(.html)?',
+    source: '/intro/getting-started/ui',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/get-started-ui',
     permanent: true,
   },
   {
-    source: '/intro/getting-started/next-steps(.html)?',
+    source: '/intro/getting-started/next-steps',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/get-started-learn-more',
     permanent: true,
@@ -59,25 +58,25 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/guides/load-balancing/fabio(.html)?',
+    source: '/guides/load-balancing/fabio',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/load-balancing-fabio',
     permanent: true,
   },
   {
-    source: '/guides/load-balancing/nginx(.html)?',
+    source: '/guides/load-balancing/nginx',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/load-balancing-nginx',
     permanent: true,
   },
   {
-    source: '/guides/load-balancing/haproxy(.html)?',
+    source: '/guides/load-balancing/haproxy',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/load-balancing-haproxy',
     permanent: true,
   },
   {
-    source: '/guides/load-balancing/traefik(.html)?',
+    source: '/guides/load-balancing/traefik',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/load-balancing-traefik',
     permanent: true,
@@ -90,13 +89,13 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/guides/stateful-workloads/host-volumes(.html)?',
+    source: '/guides/stateful-workloads/host-volumes',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/stateful-workloads-host-volumes',
     permanent: true,
   },
   {
-    source: '/guides/stateful-workloads/portworx(.html)?',
+    source: '/guides/stateful-workloads/portworx',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/stateful-workloads-portworx',
     permanent: true,
@@ -118,25 +117,25 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/guides/web-ui/submitting-a-job(.html)?',
+    source: '/guides/web-ui/submitting-a-job',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/web-ui-workload-info',
     permanent: true,
   },
   {
-    source: '/guides/web-ui/operating-a-job(.html)?',
+    source: '/guides/web-ui/operating-a-job',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/web-ui-submit-job',
     permanent: true,
   },
   {
-    source: '/guides/web-ui/inspecting-the-cluster(.html)?',
+    source: '/guides/web-ui/inspecting-the-cluster',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/web-ui-cluster-info',
     permanent: true,
   },
   {
-    source: '/guides/web-ui/securing(.html)?',
+    source: '/guides/web-ui/securing',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/web-ui-access#access-an-acl-enabled-ui',
     permanent: true,
@@ -149,22 +148,22 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/guides/governance-and-policy/namespaces(.html)?',
+    source: '/guides/governance-and-policy/namespaces',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/namespaces',
     permanent: true,
   },
   {
-    source: '/guides/governance-and-policy/quotas(.html)?',
+    source: '/guides/governance-and-policy/quotas',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/quotas',
     permanent: true,
   },
   {
-    source: '/guides/governance-and-policy/sentinel/sentinel-policy(.html)?',
+    source: '/guides/governance-and-policy/sentinel/sentinel-policy',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/sentinel',
     permanent: true,
   },
   {
-    source: '/guides/governance-and-policy/sentinel/job(.html)?',
+    source: '/guides/governance-and-policy/sentinel/job',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/sentinel',
     permanent: true,
   },
@@ -193,469 +192,462 @@ module.exports = [
   // These are subsumed in the splat over analytical-workloads, but I'm keeping them here in case
   // we want to reclaim the slug "analytical-workloads" at some point and deal with some bad links.
   // {
-  //   source: '/guides/analytical-workloads/spark/spark(.html)?',
+  //   source: '/guides/analytical-workloads/spark/spark',
   //   destination: 'https://github.com/hashicorp/nomad-spark',
   //   permanent: true,
   // },
 
   {
-    source: '/guides/operating-a-job/(index.html)?',
+    source: '/guides/operating-a-job',
     destination: 'https://learn.hashicorp.com/collections/nomad/manage-jobs',
     permanent: true,
   },
   {
-    source: '/guides/operating-a-job/accessing-logs(.html)?',
+    source: '/guides/operating-a-job/accessing-logs',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/jobs-accessing-logs',
     permanent: true,
   },
   {
-    source: '/guides/operating-a-job/configuring-tasks(.html)?',
+    source: '/guides/operating-a-job/configuring-tasks',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-configuring',
     permanent: true,
   },
   {
-    source: '/guides/operating-a-job/external/(index.html)?',
+    source: '/guides/operating-a-job/external',
     destination: 'https://learn.hashicorp.com/collections/nomad/plugins',
     permanent: true,
   },
   {
-    source: '/guides/operating-a-job/external/lxc(.html)?',
+    source: '/guides/operating-a-job/external/lxc',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/plugin-lxc',
     permanent: true,
   },
   {
-    source: '/guides/operating-a-job/inspecting-state(.html)?',
+    source: '/guides/operating-a-job/inspecting-state',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-inspec',
     permanent: true,
   },
   {
-    source: '/guides/operating-a-job/resource-utilization(.html)?',
+    source: '/guides/operating-a-job/resource-utilization',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-utilization',
     permanent: true,
   },
   {
-    source: '/guides/operating-a-job/submitting-jobs(.html)?',
+    source: '/guides/operating-a-job/submitting-jobs',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-submit',
     permanent: true,
   },
 
   {
-    source:
-      '/guides/operating-a-job/advanced-scheduling/advanced-scheduling(.html)?',
+    source: '/guides/operating-a-job/advanced-scheduling/advanced-scheduling',
     destination:
       'https://learn.hashicorp.com/collections/nomad/advanced-scheduling',
     permanent: true,
   },
   {
-    source: '/guides/operating-a-job/advanced-scheduling/affinity(.html)?',
+    source: '/guides/operating-a-job/advanced-scheduling/affinity',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/affinity',
     permanent: true,
   },
   {
     source:
-      '/guides/operating-a-job/advanced-scheduling/preemption-service-batch(.html)?',
+      '/guides/operating-a-job/advanced-scheduling/preemption-service-batch',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/preemption',
     permanent: true,
   },
   {
-    source: '/guides/operating-a-job/advanced-scheduling/spread(.html)?',
+    source: '/guides/operating-a-job/advanced-scheduling/spread',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/spread',
     permanent: true,
   },
 
   {
-    source: '/guides/operating-a-job/failure-handling-strategies/(index.html)?',
+    source: '/guides/operating-a-job/failure-handling-strategies',
     destination:
       'https://learn.hashicorp.com/collections/nomad/job-failure-handling',
     permanent: true,
   },
   {
-    source:
-      '/guides/operating-a-job/failure-handling-strategies/check-restart(.html)?',
+    source: '/guides/operating-a-job/failure-handling-strategies/check-restart',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/failures-check-restart',
     permanent: true,
   },
   {
-    source:
-      '/guides/operating-a-job/failure-handling-strategies/reschedule(.html)?',
+    source: '/guides/operating-a-job/failure-handling-strategies/reschedule',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/failures-reschedule',
     permanent: true,
   },
   {
-    source:
-      '/guides/operating-a-job/failure-handling-strategies/restart(.html)?',
+    source: '/guides/operating-a-job/failure-handling-strategies/restart',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/failures-restart',
     permanent: true,
   },
 
   {
-    source: '/guides/operating-a-job/update-strategies/(index.html)?',
+    source: '/guides/operating-a-job/update-strategies',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/job-update-strategies',
     permanent: true,
   },
   {
     source:
-      '/guides/operating-a-job/update-strategies/blue-green-and-canary-deployments(.html)?',
+      '/guides/operating-a-job/update-strategies/blue-green-and-canary-deployments',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/job-blue-green-and-canary-deployments',
     permanent: true,
   },
   {
-    source:
-      '/guides/operating-a-job/update-strategies/handling-signals(.html)?',
+    source: '/guides/operating-a-job/update-strategies/handling-signals',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/job-update-handle-signals',
     permanent: true,
   },
   {
-    source:
-      '/guides/operating-a-job/update-strategies/rolling-upgrades(.html)?',
+    source: '/guides/operating-a-job/update-strategies/rolling-upgrades',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/job-rolling-update',
     permanent: true,
   },
 
   {
-    source: '/guides/operations/(index.html)?',
+    source: '/guides/operations',
     destination:
       'https://learn.hashicorp.com/collections/nomad/manage-clusters',
     permanent: true,
   },
   {
-    source: '/guides/operations/autopilot(.html)?',
+    source: '/guides/operations/autopilot',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/autopilot',
     permanent: true,
   },
   {
-    source: '/guides/operations/cluster/automatic(.html)?',
+    source: '/guides/operations/cluster/automatic',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/guides/operations/cluster/bootstrapping(.html)?',
+    source: '/guides/operations/cluster/bootstrapping',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/guides/operations/cluster/cloud_auto_join(.html)?',
+    source: '/guides/operations/cluster/cloud_auto_join',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/guides/operations/cluster/manual(.html)?',
+    source: '/guides/operations/cluster/manual',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/guides/operations/federation(.html)?',
+    source: '/guides/operations/federation',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/federation',
     permanent: true,
   },
   {
-    source: '/guides/operations/monitoring-and-alerting/monitoring(.html)?',
+    source: '/guides/operations/monitoring-and-alerting/monitoring',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/prometheus-metrics',
     permanent: true,
   },
   {
-    source:
-      '/guides/operations/monitoring-and-alerting/prometheus-metrics(.html)?',
+    source: '/guides/operations/monitoring-and-alerting/prometheus-metrics',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/prometheus-metrics',
     permanent: true,
   },
   {
-    source: '/guides/operations/monitoring/nomad-metrics(.html)?',
+    source: '/guides/operations/monitoring/nomad-metrics',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/prometheus-metrics',
     permanent: true,
   },
   {
-    source: '/guides/operations/node-draining(.html)?',
+    source: '/guides/operations/node-draining',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/node-drain',
     permanent: true,
   },
   {
-    source: '/guides/operations/outage(.html)?',
+    source: '/guides/operations/outage',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/outage-recovery',
     permanent: true,
   },
 
   {
-    source: '/guides/security/(index.html)?',
+    source: '/guides/security',
     destination: 'https://learn.hashicorp.com/collections/nomad/access-control',
     permanent: true,
   },
   {
-    source: '/guides/security/acl(.html)?',
+    source: '/guides/security/acl',
     destination: 'https://learn.hashicorp.com/collections/nomad/access-control',
     permanent: true,
   },
   {
-    source: '/guides/security/encryption(.html)?',
+    source: '/guides/security/encryption',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/security-gossip-encryption',
     permanent: true,
   },
   {
-    source: '/guides/security/securing-nomad(.html)?',
+    source: '/guides/security/securing-nomad',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/security-enable-tls',
     permanent: true,
   },
   {
-    source: '/guides/security/vault-pki-integration(.html)?',
+    source: '/guides/security/vault-pki-integration',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/vault-pki-nomad',
     permanent: true,
   },
 
   // Multi-part UI guides
   {
-    source: '/guides/ui(.html)?',
+    source: '/guides/ui',
     destination: 'https://learn.hashicorp.com/collections/nomad/web-ui',
     permanent: true,
   },
 
   // Website
   {
-    source: '/community(.html)?',
+    source: '/community',
     destination: '/resources',
     permanent: true,
   },
 
   // Docs
   {
-    source: '/docs/index(.html)?',
+    source: '/docs/index',
     destination: '/docs',
     permanent: true,
   },
   {
-    source: '/api/index(.html)?',
+    source: '/api/index',
     destination: '/api-docs',
     permanent: true,
   },
   {
-    source: '/api-docs/index(.html)?',
+    source: '/api-docs/index',
     destination: '/api-docs',
     permanent: true,
   },
   {
-    source: '/docs/agent/config(.html)?',
+    source: '/docs/agent/config',
     destination: '/docs/configuration',
     permanent: true,
   },
   {
-    source: '/docs/jobops/(index.html)?',
+    source: '/docs/jobops',
     destination: 'https://learn.hashicorp.com/collections/nomad/manage-jobs',
     permanent: true,
   },
   {
-    source: '/docs/jobops/taskconfig(.html)?',
+    source: '/docs/jobops/taskconfig',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-configuring',
     permanent: true,
   },
   {
-    source: '/docs/jobops/inspecting(.html)?',
+    source: '/docs/jobops/inspecting',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-inspect',
     permanent: true,
   },
   {
-    source: '/docs/jobops/resources(.html)?',
+    source: '/docs/jobops/resources',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-utilization',
     permanent: true,
   },
   {
-    source: '/docs/jobops/logs(.html)?',
+    source: '/docs/jobops/logs',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/jobs-accessing-logs',
     permanent: true,
   },
   {
-    source: '/docs/jobops/updating(.html)?',
+    source: '/docs/jobops/updating',
     destination: 'https://learn.hashicorp.com/collections/nomad/job-updates',
     permanent: true,
   },
   {
-    source: '/docs/jobops/servicediscovery(.html)?',
+    source: '/docs/jobops/servicediscovery',
     destination: '/docs/integrations/consul-integration',
     permanent: true,
   },
   {
-    source: '/docs/jobspec/(index.html)?',
+    source: '/docs/jobspec',
     destination: '/docs/job-specification',
     permanent: true,
   },
   {
-    source: '/docs/jobspec/interpreted(.html)?',
+    source: '/docs/jobspec/interpreted',
     destination: '/docs/runtime/interpolation',
     permanent: true,
   },
   {
-    source: '/docs/jobspec/json(.html)?',
+    source: '/docs/jobspec/json',
     destination: '/api-docs/json-jobs',
     permanent: true,
   },
   {
-    source: '/docs/jobspec/environment(.html)?',
+    source: '/docs/jobspec/environment',
     destination: '/docs/runtime/environment',
     permanent: true,
   },
   {
-    source: '/docs/jobspec/schedulers(.html)?',
+    source: '/docs/jobspec/schedulers',
     destination: '/docs/schedulers',
     permanent: true,
   },
   {
-    source: '/docs/jobspec/servicediscovery(.html)?',
+    source: '/docs/jobspec/servicediscovery',
     destination: '/docs/job-specification/service',
     permanent: true,
   },
   {
-    source: '/docs/jobspec/networking(.html)?',
+    source: '/docs/jobspec/networking',
     destination: '/docs/job-specification/network',
     permanent: true,
   },
   {
-    source: '/docs/job-specification/index.html',
+    source: '/docs/job-specification/index',
     destination: '/docs/job-specification',
     permanent: true,
   },
   {
-    source: '/docs/cluster/automatic(.html)?',
+    source: '/docs/cluster/automatic',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/docs/cluster/manual(.html)?',
+    source: '/docs/cluster/manual',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/docs/cluster/federation(.html)?',
+    source: '/docs/cluster/federation',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/federation',
     permanent: true,
   },
   {
-    source: '/docs/cluster/requirements(.html)?',
+    source: '/docs/cluster/requirements',
     destination: '/docs/install/production/requirements/',
     permanent: true,
   },
   {
-    source: '/docs/commands/operator-index(.html)?',
+    source: '/docs/commands/operator-index',
     destination: '/docs/commands/operator',
     permanent: true,
   },
   {
-    source: '/docs/commands/operator-raft-list-peers(.html)?',
+    source: '/docs/commands/operator-raft-list-peers',
     destination: '/docs/commands/operator/raft-list-peers',
     permanent: true,
   },
   {
-    source: '/docs/commands/operator-raft-remove-peer(.html)?',
+    source: '/docs/commands/operator-raft-remove-peer',
     destination: '/docs/commands/operator/raft-remove-peer',
     permanent: true,
   },
   {
-    source: '/docs/commands/job-dispatch(.html)?',
+    source: '/docs/commands/job-dispatch',
     destination: '/docs/commands/job/dispatch',
     permanent: true,
   },
   {
-    source: '/docs/commands/alloc-status(.html)?',
+    source: '/docs/commands/alloc-status',
     destination: '/docs/commands/alloc/status',
     permanent: true,
   },
   {
-    source: '/docs/commands/fs(.html)?',
+    source: '/docs/commands/fs',
     destination: '/docs/commands/alloc/fs',
     permanent: true,
   },
   {
-    source: '/docs/commands/logs(.html)?',
+    source: '/docs/commands/logs',
     destination: '/docs/commands/alloc/logs',
     permanent: true,
   },
   {
-    source: '/docs/commands/init(.html)?',
+    source: '/docs/commands/init',
     destination: '/docs/commands/job/init',
     permanent: true,
   },
   {
-    source: '/docs/commands/inspect(.html)?',
+    source: '/docs/commands/inspect',
     destination: '/docs/commands/job/inspect',
     permanent: true,
   },
   {
-    source: '/docs/commands/run(.html)?',
+    source: '/docs/commands/run',
     destination: '/docs/commands/job/run',
     permanent: true,
   },
   {
-    source: '/docs/commands/stop(.html)?',
+    source: '/docs/commands/stop',
     destination: '/docs/commands/job/stop',
     permanent: true,
   },
   {
-    source: '/docs/commands/plan(.html)?',
+    source: '/docs/commands/plan',
     destination: '/docs/commands/job/plan',
     permanent: true,
   },
   {
-    source: '/docs/commands/validate(.html)?',
+    source: '/docs/commands/validate',
     destination: '/docs/commands/job/validate',
     permanent: true,
   },
   {
-    source: '/docs/commands/client-config(.html)?',
+    source: '/docs/commands/client-config',
     destination: '/docs/commands/node/config',
     permanent: true,
   },
   {
-    source: '/docs/commands/node-drain(.html)?',
+    source: '/docs/commands/node-drain',
     destination: '/docs/commands/node/drain',
     permanent: true,
   },
   {
-    source: '/docs/commands/node-status(.html)?',
+    source: '/docs/commands/node-status',
     destination: '/docs/commands/node/status',
     permanent: true,
   },
   {
-    source: '/docs/commands/keygen(.html)?',
+    source: '/docs/commands/keygen',
     destination: '/docs/commands/operator/keygen',
     permanent: true,
   },
   {
-    source: '/docs/commands/keyring(.html)?',
+    source: '/docs/commands/keyring',
     destination: '/docs/commands/operator/keyring',
     permanent: true,
   },
   {
-    source: '/docs/commands/server-force-leave(.html)?',
+    source: '/docs/commands/server-force-leave',
     destination: '/docs/commands/server/force-leave',
     permanent: true,
   },
   {
-    source: '/docs/commands/server-join(.html)?',
+    source: '/docs/commands/server-join',
     destination: '/docs/commands/server/join',
     permanent: true,
   },
   {
-    source: '/docs/commands/server-members(.html)?',
+    source: '/docs/commands/server-members',
     destination: '/docs/commands/server/members',
     permanent: true,
   },
   {
-    source: '/docs/runtime/schedulers(.html)?',
+    source: '/docs/runtime/schedulers',
     destination: '/docs/schedulers',
     permanent: true,
   },
   {
-    source: '/docs/internals/scheduling(.html)?',
+    source: '/docs/internals/scheduling',
     destination: '/docs/internals/scheduling/scheduling',
     permanent: true,
   },
@@ -676,83 +668,81 @@ module.exports = [
 
   // Moved /docs/operating-a-job/ -> /guides/operating-a-job/
   {
-    source: '/docs/operating-a-job/(index.html)?',
+    source: '/docs/operating-a-job',
     destination: 'https://learn.hashicorp.com/collections/nomad/manage-jobs',
     permanent: true,
   },
   {
-    source: '/docs/operating-a-job/accessing-logs(.html)?',
+    source: '/docs/operating-a-job/accessing-logs',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/jobs-accessing-logs',
     permanent: true,
   },
   {
-    source: '/docs/operating-a-job/inspecting-state(.html)?',
+    source: '/docs/operating-a-job/inspecting-state',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-inspect',
     permanent: true,
   },
   {
-    source: '/docs/operating-a-job/resource-utilization(.html)?',
+    source: '/docs/operating-a-job/resource-utilization',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-utilization',
     permanent: true,
   },
   {
-    source: '/docs/operating-a-job/configuring-tasks(.html)?',
+    source: '/docs/operating-a-job/configuring-tasks',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-configuring',
     permanent: true,
   },
   {
-    source: '/docs/operating-a-job/submitting-jobs(.html)?',
+    source: '/docs/operating-a-job/submitting-jobs',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/jobs-submit',
     permanent: true,
   },
 
   {
-    source: '/docs/operating-a-job/failure-handling-strategies/(index.html)?',
+    source: '/docs/operating-a-job/failure-handling-strategies',
     destination:
       'https://learn.hashicorp.com/collections/nomad/job-failure-handling',
     permanent: true,
   },
   {
-    source:
-      '/docs/operating-a-job/failure-handling-strategies/check-restart(.html)?',
+    source: '/docs/operating-a-job/failure-handling-strategies/check-restart',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/failures-check-restart',
     permanent: true,
   },
   {
-    source:
-      '/docs/operating-a-job/failure-handling-strategies/reschedule(.html)?',
+    source: '/docs/operating-a-job/failure-handling-strategies/reschedule',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/failures-reschedule',
     permanent: true,
   },
   {
-    source: '/docs/operating-a-job/failure-handling-strategies/restart(.html)?',
+    source: '/docs/operating-a-job/failure-handling-strategies/restart',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/failures-restart',
     permanent: true,
   },
 
   {
-    source: '/docs/operating-a-job/update-strategies/(index.html)?',
+    source: '/docs/operating-a-job/update-strategies',
     destination: 'https://learn.hashicorp.com/collections/nomad/job-updates',
     permanent: true,
   },
   {
     source:
-      '/docs/operating-a-job/update-strategies/blue-green-and-canary-deployments(.html)?',
+      '/docs/operating-a-job/update-strategies/blue-green-and-canary-deployments',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/job-blue-green-and-canary-deployments',
     permanent: true,
   },
   {
-    source: '/docs/operating-a-job/update-strategies/handling-signals(.html)?',
+    source: '/docs/operating-a-job/update-strategies/handling-signals',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/job-update-handle-signals',
     permanent: true,
   },
   {
-    source: '/docs/operating-a-job/update-strategies/rolling-upgrades(.html)?',
+    source: '/docs/operating-a-job/update-strategies/rolling-upgrades',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/job-rolling-update',
     permanent: true,
@@ -760,210 +750,210 @@ module.exports = [
 
   // Moved /docs/agent/configuration/ -> /docs/configuration/ 301!
   {
-    source: '/docs/agent/configuration/(index.html)?',
+    source: '/docs/agent/configuration',
     destination: '/docs/configuration',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/acl(.html)?',
+    source: '/docs/agent/configuration/acl',
     destination: '/docs/configuration/acl',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/autopilot(.html)?',
+    source: '/docs/agent/configuration/autopilot',
     destination: '/docs/configuration/autopilot',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/client(.html)?',
+    source: '/docs/agent/configuration/client',
     destination: '/docs/configuration/client',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/consul(.html)?',
+    source: '/docs/agent/configuration/consul',
     destination: '/docs/configuration/consul',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/sentinel(.html)?',
+    source: '/docs/agent/configuration/sentinel',
     destination: '/docs/configuration/sentinel',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/server(.html)?',
+    source: '/docs/agent/configuration/server',
     destination: '/docs/configuration/server',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/server_join(.html)?',
+    source: '/docs/agent/configuration/server_join',
     destination: '/docs/configuration/server_join',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/telemetry(.html)?',
+    source: '/docs/agent/configuration/telemetry',
     destination: '/docs/configuration/telemetry',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/tls(.html)?',
+    source: '/docs/agent/configuration/tls',
     destination: '/docs/configuration/tls',
     permanent: true,
   },
   {
-    source: '/docs/agent/configuration/vault(.html)?',
+    source: '/docs/agent/configuration/vault',
     destination: '/docs/configuration/vault',
     permanent: true,
   },
 
   // Moved guide-like docs to /guides
   {
-    source: '/docs/agent/(index.html)?',
+    source: '/docs/agent',
     destination: '/docs/install/production/nomad-agent/',
     permanent: true,
   },
   {
-    source: '/docs/agent/cloud_auto_join(.html)?',
+    source: '/docs/agent/cloud_auto_join',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/docs/agent/telemetry(.html)?',
+    source: '/docs/agent/telemetry',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/prometheus-metrics',
     permanent: true,
   },
   {
-    source: '/docs/agent/encryption(.html)?',
+    source: '/docs/agent/encryption',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/security-gossip-encryption',
     permanent: true,
   },
   {
-    source: '/docs/service-discovery/(index.html)?',
+    source: '/docs/service-discovery',
     destination: '/docs/integrations/consul-integration',
     permanent: true,
   },
 
   // Redirect old LXC driver doc to new one in /docs/external
   {
-    source: '/docs/drivers/lxc(.html)?',
+    source: '/docs/drivers/lxc',
     destination: '/docs/drivers/external/lxc',
     permanent: true,
   },
   {
-    source: '/docs/drivers/rkt(.html)?',
+    source: '/docs/drivers/rkt',
     destination: '/docs/drivers/external/rkt',
     permanent: true,
   },
 
   // API
   {
-    source: '/docs/http/agent-force-leave(.html)?',
+    source: '/docs/http/agent-force-leave',
     destination: '/api-docs/agent',
     permanent: true,
   },
   {
-    source: '/docs/http/agent-join(.html)?',
+    source: '/docs/http/agent-join',
     destination: '/api-docs/agent',
     permanent: true,
   },
   {
-    source: '/docs/http/agent-members(.html)?',
+    source: '/docs/http/agent-members',
     destination: '/api-docs/agent',
     permanent: true,
   },
   {
-    source: '/docs/http/agent-self(.html)?',
+    source: '/docs/http/agent-self',
     destination: '/api-docs/agent',
     permanent: true,
   },
   {
-    source: '/docs/http/agent-servers(.html)?',
+    source: '/docs/http/agent-servers',
     destination: '/api-docs/agent',
     permanent: true,
   },
   {
-    source: '/docs/http/alloc(.html)?',
+    source: '/docs/http/alloc',
     destination: '/api-docs/allocations',
     permanent: true,
   },
   {
-    source: '/docs/http/allocs(.html)?',
+    source: '/docs/http/allocs',
     destination: '/api-docs/allocations',
     permanent: true,
   },
   {
-    source: '/docs/http/client-allocation-stats(.html)?',
+    source: '/docs/http/client-allocation-stats',
     destination: '/api-docs/client',
     permanent: true,
   },
   {
-    source: '/docs/http/client-fs(.html)?',
+    source: '/docs/http/client-fs',
     destination: '/api-docs/client',
     permanent: true,
   },
   {
-    source: '/docs/http/client-stats(.html)?',
+    source: '/docs/http/client-stats',
     destination: '/api-docs/client',
     permanent: true,
   },
   {
-    source: '/docs/http/eval(.html)?',
+    source: '/docs/http/eval',
     destination: '/api-docs/evaluations',
     permanent: true,
   },
   {
-    source: '/docs/http/evals(.html)?',
+    source: '/docs/http/evals',
     destination: '/api-docs/evaluations',
     permanent: true,
   },
   {
-    source: '/docs/http/(index.html)?',
+    source: '/docs/http',
     destination: '/api-docs',
     permanent: true,
   },
   {
-    source: '/docs/http/job(.html)?',
+    source: '/docs/http/job',
     destination: '/api-docs/jobs',
     permanent: true,
   },
   {
-    source: '/docs/http/jobs(.html)?',
+    source: '/docs/http/jobs',
     destination: '/api-docs/jobs',
     permanent: true,
   },
   {
-    source: '/docs/http/json-jobs(.html)?',
+    source: '/docs/http/json-jobs',
     destination: '/api-docs/json-jobs',
     permanent: true,
   },
   {
-    source: '/docs/http/node(.html)?',
+    source: '/docs/http/node',
     destination: '/api-docs/nodes',
     permanent: true,
   },
   {
-    source: '/docs/http/nodes(.html)?',
+    source: '/docs/http/nodes',
     destination: '/api-docs/nodes',
     permanent: true,
   },
   {
-    source: '/docs/http/operator(.html)?',
+    source: '/docs/http/operator',
     destination: '/api-docs/operator',
     permanent: true,
   },
   {
-    source: '/docs/http/regions(.html)?',
+    source: '/docs/http/regions',
     destination: '/api-docs/regions',
     permanent: true,
   },
   {
-    source: '/docs/http/status(.html)?',
+    source: '/docs/http/status',
     destination: '/api-docs/status',
     permanent: true,
   },
   {
-    source: '/docs/http/system(.html)?',
+    source: '/docs/http/system',
     destination: '/api-docs/system',
     permanent: true,
   },
@@ -972,190 +962,190 @@ module.exports = [
 
   // Reorganized Guides by Persona
   {
-    source: '/guides/autopilot(.html)?',
+    source: '/guides/autopilot',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/autopilot',
     permanent: true,
   },
   {
-    source: '/guides/cluster/automatic(.html)?',
+    source: '/guides/cluster/automatic',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/guides/cluster/bootstrapping(.html)?',
+    source: '/guides/cluster/bootstrapping',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/guides/operations/cluster/bootstrapping(.html)?',
+    source: '/guides/operations/cluster/bootstrapping',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/guides/cluster/manual(.html)?',
+    source: '/guides/cluster/manual',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/clustering',
     permanent: true,
   },
   {
-    source: '/guides/cluster/federation/(index.html)?',
+    source: '/guides/cluster/federation',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/federation',
     permanent: true,
   },
   {
-    source: '/guides/cluster/requirements/(index.html)?',
+    source: '/guides/cluster/requirements',
     destination: '/docs/install/production/requirements',
     permanent: true,
   },
   {
-    source: '/guides/nomad-metrics(.html)?',
+    source: '/guides/nomad-metrics',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/prometheus-metrics',
     permanent: true,
   },
   {
-    source: '/guides/node-draining(.html)?',
+    source: '/guides/node-draining',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/node-drain',
     permanent: true,
   },
   {
-    source: '/guides/outage/(index.html)?',
+    source: '/guides/outage',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/outage-recovery',
     permanent: true,
   },
   {
-    source: '/guides/acl(.html)?',
+    source: '/guides/acl',
     destination: 'https://learn.hashicorp.com/collections/nomad/access-control',
     permanent: true,
   },
   {
-    source: '/guides/namespaces(.html)?',
+    source: '/guides/namespaces',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/namespaces',
     permanent: true,
   },
   {
-    source: '/guides/quotas(.html)?',
+    source: '/guides/quotas',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/quotas',
     permanent: true,
   },
   {
-    source: '/guides/securing-nomad(.html)?',
+    source: '/guides/securing-nomad',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/security-enable-tls',
     permanent: true,
   },
   {
-    source: '/guides/sentinel-policy(.html)?',
+    source: '/guides/sentinel-policy',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/sentinel',
     permanent: true,
   },
   {
-    source: '/guides/sentinel/job(.html)?',
+    source: '/guides/sentinel/job',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/sentinel',
     permanent: true,
   },
 
   {
-    source: '/guides/security/namespaces(.html)?',
+    source: '/guides/security/namespaces',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/namespaces',
     permanent: true,
   },
   {
-    source: '/guides/security/quotas(.html)?',
+    source: '/guides/security/quotas',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/quotas',
     permanent: true,
   },
   {
-    source: '/guides/security/sentinel/job(.html)?',
+    source: '/guides/security/sentinel/job',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/quotas',
     permanent: true,
   },
   {
-    source: '/guides/security/sentinel-policy(.html)?',
+    source: '/guides/security/sentinel-policy',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/sentinel',
     permanent: true,
   },
   {
-    source: '/guides/operations/install/index(.html)?',
+    source: '/guides/operations/install/index',
     destination: '/docs/install',
     permanent: true,
   },
   {
-    source: '/guides/operations/agent/index(.html)?',
+    source: '/guides/operations/agent/index',
     destination: '/docs/install/production/nomad-agent',
     permanent: true,
   },
   {
-    source: '/guides/operations/requirements(.html)?',
+    source: '/guides/operations/requirements',
     destination: '/docs/install/production/requirements',
     permanent: true,
   },
   {
-    source: '/guides/operations/consul-integration/index(.html)?',
+    source: '/guides/operations/consul-integration/index',
     destination: '/docs/integrations/consul-integration',
     permanent: true,
   },
   {
-    source: '/guides/operations/vault-integration/index(.html)?',
+    source: '/guides/operations/vault-integration/index',
     destination: '/docs/integrations/vault-integration',
     permanent: true,
   },
   {
-    source: '/guides/advanced-scheduling/(index.html)?',
+    source: '/guides/advanced-scheduling',
     destination:
       'https://learn.hashicorp.com/collections/nomad/advanced-scheduling',
     permanent: true,
   },
   {
-    source: '/guides/external/(index.html)?',
+    source: '/guides/external',
     destination: 'https://learn.hashicorp.com/collections/nomad/plugins',
     permanent: true,
   },
   {
-    source: '/guides/external/lxc(.html)?',
+    source: '/guides/external/lxc',
     destination: 'https://learn.hashicorp.com/tutorials/nomad/plugin-lxc',
     permanent: true,
   },
   {
-    source: '/guides/operations/upgrade/(index.html)?',
+    source: '/guides/operations/upgrade',
     destination: '/docs/upgrade',
     permanent: true,
   },
   {
-    source: '/guides/operations/upgrade/upgrade-specific(.html)?',
+    source: '/guides/operations/upgrade/upgrade-specific',
     destination: '/docs/upgrade/upgrade-specific',
     permanent: true,
   },
   {
-    source: '/guides/upgrade/(index.html)?',
+    source: '/guides/upgrade',
     destination: '/docs/upgrade',
     permanent: true,
   },
   {
-    source: '/guides/upgrade/upgrade-specific(.html)?',
+    source: '/guides/upgrade/upgrade-specific',
     destination: '/docs/upgrade/upgrade-specific',
     permanent: true,
   },
 
   {
-    source: '/guides/operations/deployment-guide(.html)?',
+    source: '/guides/operations/deployment-guide',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/production-deployment-guide-vm-with-consul',
     permanent: true,
   },
   {
-    source: '/guides/operations/reference-architecture(.html)?',
+    source: '/guides/operations/reference-architecture',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/production-reference-architecture-vm-with-consul',
     permanent: true,
   },
   {
-    source: '/docs/install/production/deployment-guide/(index.html)?',
+    source: '/docs/install/production/deployment-guide',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/production-deployment-guide-vm-with-consul',
     permanent: true,
   },
   {
-    source: '/docs/install/production/reference-architecture/(index.html)?',
+    source: '/docs/install/production/reference-architecture',
     destination:
       'https://learn.hashicorp.com/tutorials/nomad/production-reference-architecture-vm-with-consul',
     permanent: true,
@@ -1165,27 +1155,27 @@ module.exports = [
 
   // Reorganized Enterprise into single pager
   {
-    source: '/docs/enterprise/namespaces/(index.html)?',
+    source: '/docs/enterprise/namespaces',
     destination: '/docs/enterprise#namespaces',
     permanent: true,
   },
   {
-    source: '/docs/enterprise/quotas/(index.html)?',
+    source: '/docs/enterprise/quotas',
     destination: '/docs/enterprise#resource-quotas',
     permanent: true,
   },
   {
-    source: '/docs/enterprise/preemption/(index.html)?',
+    source: '/docs/enterprise/preemption',
     destination: '/docs/enterprise#preemption',
     permanent: true,
   },
   {
-    source: '/docs/enterprise/sentinel/(index.html)?',
+    source: '/docs/enterprise/sentinel',
     destination: '/docs/enterprise#sentinel-policies',
     permanent: true,
   },
   {
-    source: '/docs/enterprise/autopilot/(index.html)?',
+    source: '/docs/enterprise/autopilot',
     destination: '/docs/enterprise#nomad-enterprise-platform',
     permanent: true,
   },
@@ -1199,8 +1189,21 @@ module.exports = [
 
   // Vault Integration
   {
-    source: '/docs/vault-integration/(index.html)?',
+    source: '/docs/vault-integration',
     destination: '/docs/integrations/vault-integration',
+    permanent: true,
+  },
+
+  // `/<path>/index.html` to /<path>
+  {
+    source: '/:splat*/index.html',
+    destination: '/:splat*',
+    permanent: true,
+  },
+  // `.html` to non-`.html`
+  {
+    source: '/:splat(.*).html',
+    destination: '/:splat',
     permanent: true,
   },
 ]


### PR DESCRIPTION
This is a follow-up to https://github.com/hashicorp/nomad/pull/9036

@jescalan and I agreed to update the `redirects.js` file to use a more general-purpose catch-all for our routes ending in `.html` (eg. routes that may have been used with middleman). We lose some granularity in terms of _intent_ for some of our redirects, but according to our Google Analytics, there are still a significant number of routes ending in `.html` that do not properly redirect. This change fixes all of those routes at once, and as an added benefit, makes the redirects file a bit cleaner.