### PR TITLE
docs: show distinct_hosts constraint for CSI plugins

### DIFF
--- a/website/pages/docs/job-specification/csi_plugin.mdx
+++ b/website/pages/docs/job-specification/csi_plugin.mdx
@@ -56,6 +56,11 @@ the `node` or `monolith` plugin for those volumes. You should run `node` or
 flag on `nomad node drain` to ensure that the plugins are running while the
 node is being drained.
 
+~> **Note:** Only one plugin instance of a given plugin ID and type
+(controller or node) should be deployed on any given client node. Use a
+constraint as shown below.
+
+
 ## `csi_plugin` Examples
 
 ```hcl
@@ -65,6 +70,13 @@ job "plugin-efs" {
   # you can run node plugins as service jobs as well, but running
   # as a system job ensures all nodes in the DC have a copy.
   type = "system"
+
+  # only one plugin of a given type and ID should be deployed on
+  # any given client node
+  constraint {
+    operator = "distinct_hosts"
+    value = true
+  }
 
   group "nodes" {
     task "plugin" {


### PR DESCRIPTION
CSI plugins with the same plugin ID and type (controller, node, monolith) will collide on a host, both in the communication socket and in the dynamic plugin registry. Until this can be fixed, leave notice to operators in the documentation.

Related to https://github.com/hashicorp/nomad/issues/8628. That issue probably isn't going to be fixed before 0.13's beta, so updating the documentation in the meantime.