### PR TITLE
Add sprig for command templates

### DIFF
--- a/.changelog/9053.txt
+++ b/.changelog/9053.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added sprig function support for `-t` templates
+```

--- a/command/data_format.go
+++ b/command/data_format.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
@@ -56,21 +55,21 @@ type TemplateFormat struct {
 
 // TransformData returns template format string data.
 func (p *TemplateFormat) TransformData(data interface{}) (string, error) {
-	var out io.Writer = new(bytes.Buffer)
+	var out bytes.Buffer
 	if len(p.tmpl) == 0 {
 		return "", fmt.Errorf("template needs to be specified the golang templates.")
 	}
 
-	t, err := template.New("format").Funcs(makeFuncMap()).Parse(p.tmpl)
+	t, err := template.New("").Funcs(makeFuncMap()).Parse(p.tmpl)
 	if err != nil {
 		return "", err
 	}
 
-	err = t.Execute(out, data)
+	err = t.Execute(&out, data)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprint(out), nil
+	return out.String(), nil
 }
 
 func Format(json bool, template string, data interface{}) (string, error) {

--- a/command/data_format.go
+++ b/command/data_format.go
@@ -57,7 +57,7 @@ type TemplateFormat struct {
 func (p *TemplateFormat) TransformData(data interface{}) (string, error) {
 	var out bytes.Buffer
 	if len(p.tmpl) == 0 {
-		return "", fmt.Errorf("template needs to be specified the golang templates.")
+		return "", fmt.Errorf("template needs to be specified in golang's text/template format.")
 	}
 
 	t, err := template.New("").Funcs(makeFuncMap()).Parse(p.tmpl)

--- a/command/data_format.go
+++ b/command/data_format.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/hashicorp/go-msgpack/codec"
 )
 
@@ -62,7 +63,7 @@ func (p *TemplateFormat) TransformData(data interface{}) (string, error) {
 		return "", fmt.Errorf("template needs to be specified the golang templates.")
 	}
 
-	t, err := template.New("format").Parse(p.tmpl)
+	t, err := template.New("format").Funcs(makeFuncMap()).Parse(p.tmpl)
 	if err != nil {
 		return "", err
 	}
@@ -97,4 +98,17 @@ func Format(json bool, template string, data interface{}) (string, error) {
 	}
 
 	return out, nil
+}
+
+func makeFuncMap() template.FuncMap {
+	fm := template.FuncMap{}
+
+	// Add the Sprig functions to the funcmap. These functions are decorated
+	// with `sprig_` to match how they are treated in consul-template
+	for k, v := range sprig.FuncMap() {
+		target := "sprig_" + k
+		fm[target] = v
+	}
+
+	return fm
 }

--- a/command/data_format.go
+++ b/command/data_format.go
@@ -91,7 +91,7 @@ func Format(json bool, template string, data interface{}) (string, error) {
 
 	out, err := f.TransformData(data)
 	if err != nil {
-		return "", fmt.Errorf("Error formatting the data: %s", err)
+		return "", fmt.Errorf("Error formatting the data: %w", err)
 	}
 
 	return out, nil

--- a/command/data_format.go
+++ b/command/data_format.go
@@ -37,14 +37,12 @@ func DataFormat(format, tmpl string) (DataFormatter, error) {
 	return nil, fmt.Errorf("Unsupported format is specified.")
 }
 
-type JSONFormat struct {
-}
+type JSONFormat struct{}
 
 // TransformData returns JSON format string data.
 func (p *JSONFormat) TransformData(data interface{}) (string, error) {
 	var buf bytes.Buffer
-	enc := codec.NewEncoder(&buf, jsonHandlePretty)
-	err := enc.Encode(data)
+	err := codec.NewEncoder(&buf, jsonHandlePretty).Encode(data)
 	if err != nil {
 		return "", err
 	}

--- a/command/data_format_test.go
+++ b/command/data_format_test.go
@@ -17,11 +17,13 @@ func TestDataFormat(t *testing.T) {
 
 	var tData = testData{"global", "1", "example"}
 
+	// Note: this variable is space indented (4) and requires the final brace to
+	// be at char 1
 	const expectJSON = `{
-			"ID": "1",
-			"Name": "example",
-			"Region": "global"
-	}`
+    "ID": "1",
+    "Name": "example",
+    "Region": "global"
+}`
 
 	var tcs = map[string]struct {
 		format   string
@@ -60,8 +62,8 @@ func TestDataFormat(t *testing.T) {
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			ci.Parallel(t)
 			tc := tc
+			ci.Parallel(t)
 			fm, err := DataFormat(tc.format, tc.template)
 			must.NoError(t, err)
 			result, err := fm.TransformData(tData)

--- a/command/data_format_test.go
+++ b/command/data_format_test.go
@@ -1,10 +1,10 @@
 package command
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
 )
 
 type testData struct {
@@ -13,56 +13,59 @@ type testData struct {
 	Name   string
 }
 
+var tData = testData{"global", "1", "example"}
+
 const expectJSON = `{
     "ID": "1",
     "Name": "example",
     "Region": "global"
 }`
 
-var (
-	tData        = testData{"global", "1", "example"}
-	testFormat   = map[string]string{"json": "", "template": "{{.Region}}"}
-	expectOutput = map[string]string{"json": expectJSON, "template": "global"}
-)
+var tcs = map[string]struct {
+	format   string
+	template string
+	expect   string
+	isError  bool
+}{
+	"json_good": {
+		format:   "json",
+		template: "",
+		expect:   expectJSON,
+	},
+	"template_good": {
+		format:   "template",
+		template: "{{.Region}}",
+		expect:   "global",
+	},
+	"template_bad": {
+		format:   "template",
+		template: "{{.foo}}",
+		isError:  true,
+		expect:   "can't evaluate field foo",
+	},
+	"template_empty": {
+		format:   "template",
+		template: "",
+		isError:  true,
+		expect:   "template needs to be specified the golang templates.",
+	},
+}
 
 func TestDataFormat(t *testing.T) {
 	ci.Parallel(t)
-	for k, v := range testFormat {
-		fm, err := DataFormat(k, v)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		result, err := fm.TransformData(tData)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		if result != expectOutput[k] {
-			t.Fatalf("expected output:\n%s\nactual:\n%s", expectOutput[k], result)
-		}
-	}
-}
-
-func TestInvalidJSONTemplate(t *testing.T) {
-	ci.Parallel(t)
-	// Invalid template {{.foo}}
-	fm, err := DataFormat("template", "{{.foo}}")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	_, err = fm.TransformData(tData)
-	if !strings.Contains(err.Error(), "can't evaluate field foo") {
-		t.Fatalf("expected invalid template error, got: %s", err.Error())
-	}
-
-	// No template is specified
-	fm, err = DataFormat("template", "")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	_, err = fm.TransformData(tData)
-	if !strings.Contains(err.Error(), "template needs to be specified the golang templates.") {
-		t.Fatalf("expected not specified template error, got: %s", err.Error())
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			ci.Parallel(t)
+			tc := tc
+			fm, err := DataFormat(tc.format, tc.template)
+			must.NoError(t, err)
+			result, err := fm.TransformData(tData)
+			if tc.isError {
+				must.ErrorContains(t, err, tc.expect)
+				return
+			}
+			must.NoError(t, err)
+			must.Eq(t, tc.expect, result)
+		})
 	}
 }

--- a/command/data_format_test.go
+++ b/command/data_format_test.go
@@ -47,7 +47,7 @@ var tcs = map[string]struct {
 		format:   "template",
 		template: "",
 		isError:  true,
-		expect:   "template needs to be specified the golang templates.",
+		expect:   "template needs to be specified in golang's text/template format.",
 	},
 	"template_sprig": {
 		format:   "template",

--- a/command/data_format_test.go
+++ b/command/data_format_test.go
@@ -49,6 +49,11 @@ var tcs = map[string]struct {
 		isError:  true,
 		expect:   "template needs to be specified the golang templates.",
 	},
+	"template_sprig": {
+		format:   "template",
+		template: `{{$a := 1}}{{ $a | sprig_add 1 }}`,
+		expect:   "2",
+	},
 }
 
 func TestDataFormat(t *testing.T) {

--- a/command/data_format_test.go
+++ b/command/data_format_test.go
@@ -7,57 +7,57 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-type testData struct {
-	Region string
-	ID     string
-	Name   string
-}
-
-var tData = testData{"global", "1", "example"}
-
-const expectJSON = `{
-    "ID": "1",
-    "Name": "example",
-    "Region": "global"
-}`
-
-var tcs = map[string]struct {
-	format   string
-	template string
-	expect   string
-	isError  bool
-}{
-	"json_good": {
-		format:   "json",
-		template: "",
-		expect:   expectJSON,
-	},
-	"template_good": {
-		format:   "template",
-		template: "{{.Region}}",
-		expect:   "global",
-	},
-	"template_bad": {
-		format:   "template",
-		template: "{{.foo}}",
-		isError:  true,
-		expect:   "can't evaluate field foo",
-	},
-	"template_empty": {
-		format:   "template",
-		template: "",
-		isError:  true,
-		expect:   "template needs to be specified in golang's text/template format.",
-	},
-	"template_sprig": {
-		format:   "template",
-		template: `{{$a := 1}}{{ $a | sprig_add 1 }}`,
-		expect:   "2",
-	},
-}
-
 func TestDataFormat(t *testing.T) {
 	ci.Parallel(t)
+	type testData struct {
+		Region string
+		ID     string
+		Name   string
+	}
+
+	var tData = testData{"global", "1", "example"}
+
+	const expectJSON = `{
+			"ID": "1",
+			"Name": "example",
+			"Region": "global"
+	}`
+
+	var tcs = map[string]struct {
+		format   string
+		template string
+		expect   string
+		isError  bool
+	}{
+		"json_good": {
+			format:   "json",
+			template: "",
+			expect:   expectJSON,
+		},
+		"template_good": {
+			format:   "template",
+			template: "{{.Region}}",
+			expect:   "global",
+		},
+		"template_bad": {
+			format:   "template",
+			template: "{{.foo}}",
+			isError:  true,
+			expect:   "can't evaluate field foo",
+		},
+		"template_empty": {
+			format:   "template",
+			template: "",
+			isError:  true,
+			expect:   "template needs to be specified in golang's text/template format.",
+		},
+		"template_sprig": {
+			format:   "template",
+			template: `{{$a := 1}}{{ $a | sprig_add 1 }}`,
+			expect:   "2",
+		},
+	}
+
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			ci.Parallel(t)

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
-	github.com/Masterminds/sprig/v3 v3.2.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.1
 	github.com/Microsoft/hcsshim v0.9.5 // indirect
 	github.com/VividCortex/ewma v1.1.1 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect


### PR DESCRIPTION
This PR adds the https://github.com/Masterminds/sprig function library to be available when using the -t flag to format output with a go template.

