### PR TITLE
api: add field filters to /v1/{allocations,nodes}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ IMPROVEMENTS:
  * core: Improved job deregistration error logging. [[GH-8745](https://github.com/hashicorp/nomad/issues/8745)]
  * api: Added support for cancellation contexts to HTTP API. [[GH-8836](https://github.com/hashicorp/nomad/issues/8836)]
  * api: Job Register API now permits non-zero initial Version to accommodate multi-region deployments. [[GH-9071](https://github.com/hashicorp/nomad/issues/9071)]
+ * api: Added ?resources=true query parameter to /v1/nodes and /v1/allocations to include resource allocations in listings. [[GH-9055](https://github.com/hashicorp/nomad/issues/9055)]
+ * api: Added ?task_states=false query parameter to /v1/allocations to remove TaskStates from listings. Defaults to being included as before. [[GH-9055](https://github.com/hashicorp/nomad/issues/9055)]
  * cli: Added `scale` and `scaling-events` subcommands to the `job` command. [[GH-9023](https://github.com/hashicorp/nomad/pull/9023)]
  * cli: Added `scaling` command for interaction with the scaling API endpoint. [[GH-9025](https://github.com/hashicorp/nomad/pull/9025)]
  * client: Use ec2 CPU perf data from AWS API [[GH-7830](https://github.com/hashicorp/nomad/issues/7830)]

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -432,6 +432,7 @@ type AllocationListStub struct {
 	JobType               string
 	JobVersion            uint64
 	TaskGroup             string
+	AllocatedResources    *AllocatedResources `json:",omitempty"`
 	DesiredStatus         string
 	DesiredDescription    string
 	ClientStatus          string

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -786,6 +786,8 @@ type NodeListStub struct {
 	Status                string
 	StatusDescription     string
 	Drivers               map[string]*DriverInfo
+	NodeResources         *NodeResources         `json:",omitempty"`
+	ReservedResources     *NodeReservedResources `json:",omitempty"`
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -24,7 +24,7 @@ func assertWriteMeta(t *testing.T, wm *WriteMeta) {
 }
 
 func testJob() *Job {
-	task := NewTask("task1", "exec").
+	task := NewTask("task1", "raw_exec").
 		SetConfig("command", "/bin/sleep").
 		Require(&Resources{
 			CPU:      intToPtr(100),

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -34,13 +34,23 @@ func (s *HTTPServer) AllocsRequest(resp http.ResponseWriter, req *http.Request) 
 	}
 
 	// Parse resources and task_states field selection
-	var err error
-	args.Fields = structs.NewAllocStubFields()
-	if args.Fields.Resources, err = parseResources(req); err != nil {
+	resources, err := parseBool(req, "resources")
+	if err != nil {
 		return nil, err
 	}
-	if args.Fields.TaskStates, err = parseTaskStates(req); err != nil {
+	taskStates, err := parseBool(req, "task_states")
+	if err != nil {
 		return nil, err
+	}
+
+	if resources != nil || taskStates != nil {
+		args.Fields = structs.NewAllocStubFields()
+		if resources != nil {
+			args.Fields.Resources = *resources
+		}
+		if taskStates != nil {
+			args.Fields.TaskStates = *taskStates
+		}
 	}
 
 	var out structs.AllocListResponse

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -33,6 +33,16 @@ func (s *HTTPServer) AllocsRequest(resp http.ResponseWriter, req *http.Request) 
 		return nil, nil
 	}
 
+	// Parse resources and task_states field selection
+	var err error
+	args.Fields = structs.NewAllocStubFields()
+	if args.Fields.Resources, err = parseResources(req); err != nil {
+		return nil, err
+	}
+	if args.Fields.TaskStates, err = parseTaskStates(req); err != nil {
+		return nil, err
+	}
+
 	var out structs.AllocListResponse
 	if err := s.agent.RPC("Alloc.List", &args, &out); err != nil {
 		return nil, err

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -344,13 +344,13 @@ func structsCSIVolumeToApi(vol *structs.CSIVolume) *api.CSIVolume {
 
 	for _, a := range vol.WriteAllocs {
 		if a != nil {
-			out.Allocations = append(out.Allocations, structsAllocListStubToApi(a.Stub()))
+			out.Allocations = append(out.Allocations, structsAllocListStubToApi(a.Stub(nil)))
 		}
 	}
 
 	for _, a := range vol.ReadAllocs {
 		if a != nil {
-			out.Allocations = append(out.Allocations, structsAllocListStubToApi(a.Stub()))
+			out.Allocations = append(out.Allocations, structsAllocListStubToApi(a.Stub(nil)))
 		}
 	}
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -653,30 +653,18 @@ func parseNamespace(req *http.Request, n *string) {
 	}
 }
 
-// parseResources is used to parse the ?resources parameter
-func parseResources(req *http.Request) (bool, error) {
-	if resourcesStr := req.URL.Query().Get("resources"); resourcesStr != "" {
-		resources, err := strconv.ParseBool(resourcesStr)
-		if err != nil {
-			return false, fmt.Errorf("Failed to parse value of %q (%v) as a bool: %v", "resources", resourcesStr, err)
-		}
-		return resources, nil
-	}
-
-	return false, nil
-}
-
-// parseTaskStates is used to parse the ?task_states parameter
-func parseTaskStates(req *http.Request) (bool, error) {
-	if str := req.URL.Query().Get("task_states"); str != "" {
+// parseBool parses a query parameter to a boolean or returns (nil, nil) if the
+// parameter is not present.
+func parseBool(req *http.Request, field string) (*bool, error) {
+	if str := req.URL.Query().Get(field); str != "" {
 		param, err := strconv.ParseBool(str)
 		if err != nil {
-			return false, fmt.Errorf("Failed to parse value of %q (%v) as a bool: %v", "task_states", str, err)
+			return nil, fmt.Errorf("Failed to parse value of %q (%v) as a bool: %v", field, str, err)
 		}
-		return param, nil
+		return &param, nil
 	}
 
-	return false, nil
+	return nil, nil
 }
 
 // parseToken is used to parse the X-Nomad-Token param

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -653,6 +653,32 @@ func parseNamespace(req *http.Request, n *string) {
 	}
 }
 
+// parseResources is used to parse the ?resources parameter
+func parseResources(req *http.Request) (bool, error) {
+	if resourcesStr := req.URL.Query().Get("resources"); resourcesStr != "" {
+		resources, err := strconv.ParseBool(resourcesStr)
+		if err != nil {
+			return false, fmt.Errorf("Failed to parse value of %q (%v) as a bool: %v", "resources", resourcesStr, err)
+		}
+		return resources, nil
+	}
+
+	return false, nil
+}
+
+// parseTaskStates is used to parse the ?task_states parameter
+func parseTaskStates(req *http.Request) (bool, error) {
+	if str := req.URL.Query().Get("task_states"); str != "" {
+		param, err := strconv.ParseBool(str)
+		if err != nil {
+			return false, fmt.Errorf("Failed to parse value of %q (%v) as a bool: %v", "task_states", str, err)
+		}
+		return param, nil
+	}
+
+	return false, nil
+}
+
 // parseToken is used to parse the X-Nomad-Token param
 func (s *HTTPServer) parseToken(req *http.Request, token *string) {
 	if other := req.Header.Get("X-Nomad-Token"); other != "" {

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -515,6 +515,96 @@ func TestParseToken(t *testing.T) {
 	}
 }
 
+func TestParseResources(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Value     string
+		Resources bool
+		Err       bool // true if an error should be expected
+	}{
+		{
+			Value:     "",
+			Resources: false,
+		},
+		{
+			Value:     "true",
+			Resources: true,
+		},
+		{
+			Value:     "false",
+			Resources: false,
+		},
+		{
+			Value: "1234",
+			Err:   true,
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run("Value-"+tc.Value, func(t *testing.T) {
+			testURL, err := url.Parse("http://localhost/foo?resources=" + tc.Value)
+			require.NoError(t, err)
+			req := &http.Request{
+				URL: testURL,
+			}
+
+			result, err := parseResources(req)
+			if tc.Err {
+				require.Error(t, err)
+			} else {
+				require.Equal(t, tc.Resources, result)
+			}
+		})
+	}
+}
+
+func TestParseTaskStates(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Value      string
+		TaskStates bool
+		Err        bool // true if an error should be expected
+	}{
+		{
+			Value:      "",
+			TaskStates: false,
+		},
+		{
+			Value:      "true",
+			TaskStates: true,
+		},
+		{
+			Value:      "false",
+			TaskStates: false,
+		},
+		{
+			Value: "1234",
+			Err:   true,
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run("Value-"+tc.Value, func(t *testing.T) {
+			testURL, err := url.Parse("http://localhost/foo?task_states=" + tc.Value)
+			require.NoError(t, err)
+			req := &http.Request{
+				URL: testURL,
+			}
+
+			result, err := parseTaskStates(req)
+			if tc.Err {
+				require.Error(t, err)
+			} else {
+				require.Equal(t, tc.TaskStates, result)
+			}
+		})
+	}
+}
+
 // TestHTTP_VerifyHTTPSClient asserts that a client certificate signed by the
 // appropriate CA is required when VerifyHTTPSClient=true.
 func TestHTTP_VerifyHTTPSClient(t *testing.T) {

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -515,91 +515,48 @@ func TestParseToken(t *testing.T) {
 	}
 }
 
-func TestParseResources(t *testing.T) {
+func TestParseBool(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		Value     string
-		Resources bool
-		Err       bool // true if an error should be expected
+		Input    string
+		Expected *bool
+		Err      bool // true if an error should be expected
 	}{
 		{
-			Value:     "",
-			Resources: false,
+			Input:    "",
+			Expected: nil,
 		},
 		{
-			Value:     "true",
-			Resources: true,
+			Input:    "true",
+			Expected: helper.BoolToPtr(true),
 		},
 		{
-			Value:     "false",
-			Resources: false,
+			Input:    "false",
+			Expected: helper.BoolToPtr(false),
 		},
 		{
-			Value: "1234",
+			Input: "1234",
 			Err:   true,
 		},
 	}
 
 	for i := range cases {
 		tc := cases[i]
-		t.Run("Value-"+tc.Value, func(t *testing.T) {
-			testURL, err := url.Parse("http://localhost/foo?resources=" + tc.Value)
+		t.Run("Input-"+tc.Input, func(t *testing.T) {
+			testURL, err := url.Parse("http://localhost/foo?resources=" + tc.Input)
 			require.NoError(t, err)
 			req := &http.Request{
 				URL: testURL,
 			}
 
-			result, err := parseResources(req)
+			result, err := parseBool(req, "resources")
 			if tc.Err {
 				require.Error(t, err)
+				require.Nil(t, result)
 			} else {
-				require.Equal(t, tc.Resources, result)
-			}
-		})
-	}
-}
-
-func TestParseTaskStates(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		Value      string
-		TaskStates bool
-		Err        bool // true if an error should be expected
-	}{
-		{
-			Value:      "",
-			TaskStates: false,
-		},
-		{
-			Value:      "true",
-			TaskStates: true,
-		},
-		{
-			Value:      "false",
-			TaskStates: false,
-		},
-		{
-			Value: "1234",
-			Err:   true,
-		},
-	}
-
-	for i := range cases {
-		tc := cases[i]
-		t.Run("Value-"+tc.Value, func(t *testing.T) {
-			testURL, err := url.Parse("http://localhost/foo?task_states=" + tc.Value)
-			require.NoError(t, err)
-			req := &http.Request{
-				URL: testURL,
-			}
-
-			result, err := parseTaskStates(req)
-			if tc.Err {
-				require.Error(t, err)
-			} else {
-				require.Equal(t, tc.TaskStates, result)
+				require.NoError(t, err)
+				require.Equal(t, tc.Expected, result)
 			}
 		})
 	}

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -21,11 +21,13 @@ func (s *HTTPServer) NodesRequest(resp http.ResponseWriter, req *http.Request) (
 	}
 
 	// Parse resources field selection
-	if resources, err := parseResources(req); err != nil {
+	resources, err := parseBool(req, "resources")
+	if err != nil {
 		return nil, err
-	} else if resources {
+	}
+	if resources != nil {
 		args.Fields = &structs.NodeStubFields{
-			Resources: true,
+			Resources: *resources,
 		}
 	}
 

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -20,6 +20,15 @@ func (s *HTTPServer) NodesRequest(resp http.ResponseWriter, req *http.Request) (
 		return nil, nil
 	}
 
+	// Parse resources field selection
+	if resources, err := parseResources(req); err != nil {
+		return nil, err
+	} else if resources {
+		args.Fields = &structs.NodeStubFields{
+			Resources: true,
+		}
+	}
+
 	var out structs.NodeListResponse
 	if err := s.agent.RPC("Node.List", &args, &out); err != nil {
 		return nil, err

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -72,7 +72,7 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 					break
 				}
 				alloc := raw.(*structs.Allocation)
-				allocs = append(allocs, alloc.Stub())
+				allocs = append(allocs, alloc.Stub(args.Fields))
 			}
 			reply.Allocations = allocs
 

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -478,7 +478,7 @@ func (d *Deployment) Allocations(args *structs.DeploymentSpecificRequest, reply 
 
 			stubs := make([]*structs.AllocListStub, 0, len(allocs))
 			for _, alloc := range allocs {
-				stubs = append(stubs, alloc.Stub())
+				stubs = append(stubs, alloc.Stub(nil))
 			}
 			reply.Allocations = stubs
 

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -899,7 +899,7 @@ func (w *deploymentWatcher) getAllocsImpl(ws memdb.WatchSet, state *state.StateS
 	maxIndex := uint64(0)
 	stubs := make([]*structs.AllocListStub, 0, len(allocs))
 	for _, alloc := range allocs {
-		stubs = append(stubs, alloc.Stub())
+		stubs = append(stubs, alloc.Stub(nil))
 
 		if maxIndex < alloc.ModifyIndex {
 			maxIndex = alloc.ModifyIndex

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -426,7 +426,7 @@ func (e *Eval) Allocations(args *structs.EvalSpecificRequest,
 
 				reply.Allocations = make([]*structs.AllocListStub, 0, len(allocs))
 				for _, alloc := range allocs {
-					reply.Allocations = append(reply.Allocations, alloc.Stub())
+					reply.Allocations = append(reply.Allocations, alloc.Stub(nil))
 				}
 			}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1471,7 +1471,7 @@ func (j *Job) Allocations(args *structs.JobSpecificRequest,
 			if len(allocs) > 0 {
 				reply.Allocations = make([]*structs.AllocListStub, 0, len(allocs))
 				for _, alloc := range allocs {
-					reply.Allocations = append(reply.Allocations, alloc.Stub())
+					reply.Allocations = append(reply.Allocations, alloc.Stub(nil))
 				}
 			}
 

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1295,7 +1295,7 @@ func (n *Node) List(args *structs.NodeListRequest,
 					break
 				}
 				node := raw.(*structs.Node)
-				nodes = append(nodes, node.Stub())
+				nodes = append(nodes, node.Stub(args.Fields))
 			}
 			reply.Nodes = nodes
 

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -2591,6 +2591,10 @@ func TestClientEndpoint_ListNodes(t *testing.T) {
 	// #7344 - Assert HostVolumes are included in stub
 	require.Equal(t, node.HostVolumes, resp2.Nodes[0].HostVolumes)
 
+	// #9055 - Assert Resources are *not* included by default
+	require.Nil(t, resp2.Nodes[0].NodeResources)
+	require.Nil(t, resp2.Nodes[0].ReservedResources)
+
 	// Lookup the node with prefix
 	get = &structs.NodeListRequest{
 		QueryOptions: structs.QueryOptions{Region: "global", Prefix: node.ID[:4]},
@@ -2609,6 +2613,43 @@ func TestClientEndpoint_ListNodes(t *testing.T) {
 	if resp3.Nodes[0].ID != node.ID {
 		t.Fatalf("bad: %#v", resp3.Nodes[0])
 	}
+}
+
+func TestClientEndpoint_ListNodes_Fields(t *testing.T) {
+	t.Parallel()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	node := mock.Node()
+	reg := &structs.NodeRegisterRequest{
+		Node:         node,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+
+	// Fetch the response
+	var resp structs.GenericResponse
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Node.Register", reg, &resp))
+	node.CreateIndex = resp.Index
+	node.ModifyIndex = resp.Index
+
+	// Lookup the node with fields
+	get := &structs.NodeListRequest{
+		QueryOptions: structs.QueryOptions{Region: "global"},
+		Fields: &structs.NodeStubFields{
+			Resources: true,
+		},
+	}
+	var resp2 structs.NodeListResponse
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Node.List", get, &resp2))
+	require.Equal(t, resp.Index, resp2.Index)
+	require.Len(t, resp2.Nodes, 1)
+	require.Equal(t, node.ID, resp2.Nodes[0].ID)
+	require.NotNil(t, resp2.Nodes[0].NodeResources)
+	require.NotNil(t, resp2.Nodes[0].ReservedResources)
 }
 
 func TestClientEndpoint_ListNodes_ACL(t *testing.T) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2421,7 +2421,7 @@ func (s *StateStore) CSIPluginDenormalize(ws memdb.WatchSet, plug *structs.CSIPl
 		if alloc == nil {
 			continue
 		}
-		plug.Allocations = append(plug.Allocations, alloc.Stub())
+		plug.Allocations = append(plug.Allocations, alloc.Stub(nil))
 	}
 
 	return plug, nil

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -751,7 +751,7 @@ func (s *GenericScheduler) handlePreemptions(option *RankedNode, alloc *structs.
 		preemptedAllocIDs = append(preemptedAllocIDs, stop.ID)
 
 		if s.eval.AnnotatePlan && s.plan.Annotations != nil {
-			s.plan.Annotations.PreemptedAllocs = append(s.plan.Annotations.PreemptedAllocs, stop.Stub())
+			s.plan.Annotations.PreemptedAllocs = append(s.plan.Annotations.PreemptedAllocs, stop.Stub(nil))
 			if s.plan.Annotations.DesiredTGUpdates != nil {
 				desired := s.plan.Annotations.DesiredTGUpdates[missing.TaskGroup().Name]
 				desired.Preemptions += 1

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -389,7 +389,7 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 
 				preemptedAllocIDs = append(preemptedAllocIDs, stop.ID)
 				if s.eval.AnnotatePlan && s.plan.Annotations != nil {
-					s.plan.Annotations.PreemptedAllocs = append(s.plan.Annotations.PreemptedAllocs, stop.Stub())
+					s.plan.Annotations.PreemptedAllocs = append(s.plan.Annotations.PreemptedAllocs, stop.Stub(nil))
 					if s.plan.Annotations.DesiredTGUpdates != nil {
 						desired := s.plan.Annotations.DesiredTGUpdates[missing.TaskGroup.Name]
 						desired.Preemptions += 1

--- a/vendor/github.com/hashicorp/nomad/api/allocations.go
+++ b/vendor/github.com/hashicorp/nomad/api/allocations.go
@@ -432,6 +432,7 @@ type AllocationListStub struct {
 	JobType               string
 	JobVersion            uint64
 	TaskGroup             string
+	AllocatedResources    *AllocatedResources `json:",omitempty"`
 	DesiredStatus         string
 	DesiredDescription    string
 	ClientStatus          string

--- a/vendor/github.com/hashicorp/nomad/api/nodes.go
+++ b/vendor/github.com/hashicorp/nomad/api/nodes.go
@@ -786,6 +786,8 @@ type NodeListStub struct {
 	Status                string
 	StatusDescription     string
 	Drivers               map[string]*DriverInfo
+	NodeResources         *NodeResources         `json:",omitempty"`
+	ReservedResources     *NodeReservedResources `json:",omitempty"`
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }

--- a/website/pages/api-docs/allocations.mdx
+++ b/website/pages/api-docs/allocations.mdx
@@ -35,6 +35,15 @@ The table below shows this endpoint's support for
 - `namespace` `(string: "default")` - Specifies the namespace to search. Specifying
   `*` would return all allocations across all the authorized namespaces.
 
+- `resources` `(bool: false)` - Specifies whether or not to include the
+  `AllocatedResources` field in the response.
+
+- `task_states` `(bool: true)` - Specifies whether or not to include the
+  `TaskStates` field in the response. TaskStates are included by default but
+  can represent a large percentage of the overall response size. Clusters with
+  a large number of allocations may set `task_states=false` to significantly
+  reduce the size of the response.
+
 ### Sample Request
 
 ```shell-session

--- a/website/pages/api-docs/nodes.mdx
+++ b/website/pages/api-docs/nodes.mdx
@@ -32,6 +32,9 @@ The table below shows this endpoint's support for
   number of hexadecimal characters (0-9a-f). This is specified as a query
   string parameter.
 
+- `resources` `(bool: false)` - Specifies whether or not to include the
+  `NodeResources` and `ReservedResources` fields in the response.
+
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
Fixes #9017

The ?resources=true query parameter includes resources in the object stub listings. Specifically:

- For `/v1/nodes?resources=true` both the `NodeResources` and `ReservedResources` field are included.
- For `/v1/allocations?resources=true` the `AllocatedResources` field is included.

The ?task_states=false query parameter removes TaskStates from
/v1/allocations responses. (By default TaskStates are included.)
