### PR TITLE
csi: allow for volume detach to work with gc'd nodes

### DIFF
--- a/website/pages/docs/commands/volume/detach.mdx
+++ b/website/pages/docs/commands/volume/detach.mdx
@@ -21,6 +21,10 @@ The `volume detach` command requires two arguments, specifying the ID of the
 volume to be detached and the node to detach it from. Detaching will fail if
 the volume is still in use by an allocation.
 
+Note that you can use a node ID prefix just as you can with other Nomad
+commands, but if the node has been garbage collected, you may need to pass the
+full node ID.
+
 ## General Options
 
 @include 'general_options.mdx'


### PR DESCRIPTION
Follow-up to https://github.com/hashicorp/nomad/pull/9041

When we try to prefix match the `nomad volume detach` node ID argument, the
node may have been already GC'd. The volume unpublish workflow gracefully
handles this case so that we can free the claim. So make a best effort to find
a node ID among the volume's claimed allocations, or otherwise just use the
node ID we've been given by the user as-is.

ref https://github.com/hashicorp/nomad/blob/v0.12.5/nomad/csi_endpoint.go#L664-L671 for the graceful handling of missing nodes.