### PR TITLE
CSI: comment clarifications and dropping no-op work

### DIFF
--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -34,12 +34,10 @@ func (c *csiHook) Prerun() error {
 		return nil
 	}
 
-	// TODO(tgross): the contexts for the CSI RPC calls made during
-	// mounting can have very long timeouts. Until these are better
-	// tuned, there's not a good value to put here for a WithCancel
-	// without risking conflicts with the grpc retries/timeouts in the
-	// pluginmanager package.
-	ctx := context.TODO()
+	// We use this context only to attach hclog to the gRPC context. The
+	// lifetime is the lifetime of the gRPC stream, not specific RPC timeouts,
+	// but we manage the stream lifetime via Close in the pluginmanager.
+	ctx := context.Background()
 
 	volumes, err := c.claimVolumesFromAlloc()
 	if err != nil {

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -521,8 +521,6 @@ func (v *CSIVolume) Unpublish(args *structs.CSIVolumeUnpublishRequest, reply *st
 	metricsStart := time.Now()
 	defer metrics.MeasureSince([]string{"nomad", "volume", "unpublish"}, metricsStart)
 
-	// TODO(tgross): ensure we have pass-thru of token for client-driven RPC
-	// ref https://github.com/hashicorp/nomad/issues/8373
 	allowVolume := acl.NamespaceValidator(acl.NamespaceCapabilityCSIMountVolume)
 	aclObj, err := v.srv.WriteACLObj(&args.WriteRequest, true)
 	if err != nil {

--- a/nomad/volumewatcher/volume_watcher.go
+++ b/nomad/volumewatcher/volume_watcher.go
@@ -177,6 +177,7 @@ func (vw *volumeWatcher) volumeReapImpl(vol *structs.CSIVolume) error {
 	for _, claim := range vol.PastClaims {
 		if claim.AllocationID == "" {
 			vol = vw.collectPastClaims(vol)
+			break // only need to collect once
 		}
 	}
 


### PR DESCRIPTION
A collection of tiny changes:
* Fix an incorrect comment about `csi_hook` context lifetime and change it from `context.TODO()` to `context.Background()`
* Remove stray TODO comment for work completed in #8626
* Make only one pass to collect past claims in volumewatcher: if a volume GC and a `nomad volume detach` command land concurrently, we can end up with multiple claims without an allocation, which results in extra no-op work when finding claims to collect as past claims.