### PR TITLE
e2e: use AMI filter for Ubuntu packer image

### DIFF
--- a/e2e/terraform/packer/packer.json
+++ b/e2e/terraform/packer/packer.json
@@ -3,7 +3,19 @@
     {
       "type": "amazon-ebs",
       "region": "us-east-1",
-      "source_ami": "ami-7ad76705",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "architecture": "x86_64",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*",
+          "block-device-mapping.volume-type": "gp2",
+          "root-device-type": "ebs"
+        },
+        "owners": [
+          "099720109477"
+        ],
+        "most_recent": true
+      },
       "instance_type": "t2.medium",
       "ssh_username": "ubuntu",
       "iam_instance_profile": "packer_build",


### PR DESCRIPTION
Follow-up to https://github.com/hashicorp/nomad/pull/9076

Instead of hard-coding the base AMI for our Packer image for Ubuntu, use the
latest from Canonical so that we always have their current kernel patches.