### PR TITLE
CI: make split between e2e and integration tests explicit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -807,7 +807,7 @@ jobs:
     - PAGER: cat
     - GOTEST_MOD: ''
     - GOTEST_PKGS: ''
-    - GOTEST_PKGS_EXCLUDE: ./api|./client|./drivers/docker|./drivers/exec|./drivers/shared/executor|./nomad|./devices
+    - GOTEST_PKGS_EXCLUDE: ./api|./client|./drivers/docker|./drivers/exec|./drivers/shared/executor|./nomad|./devices|./e2e
     - GOTESTARCH: amd64
     steps:
     - checkout
@@ -1234,6 +1234,8 @@ jobs:
         name: prepare non-root user
     - run:
         command: sudo -E -H -u circleci PATH=${PATH} make deps
+    - run:
+        command: sudo -E -H -u circleci PATH=${PATH} make integration-test
     - run:
         command: sudo -E -H -u circleci PATH=${PATH} make e2e-test
     environment:

--- a/.circleci/config/jobs/test-e2e.yml
+++ b/.circleci/config/jobs/test-e2e.yml
@@ -14,4 +14,5 @@ steps:
         chown -R circleci:circleci /go
 
   - run: sudo -E -H -u circleci PATH=${PATH} make deps
+  - run: sudo -E -H -u circleci PATH=${PATH} make integration-test
   - run: sudo -E -H -u circleci PATH=${PATH} make e2e-test

--- a/.circleci/config/workflows/build-test.yml
+++ b/.circleci/config/workflows/build-test.yml
@@ -69,7 +69,7 @@ jobs:
       filters: *backend_test_branches_filter
   - test-machine:
       name: "test-other"
-      exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/shared/executor|./nomad|./devices"
+      exclude_packages: "./api|./client|./drivers/docker|./drivers/exec|./drivers/shared/executor|./nomad|./devices|./e2e"
       filters: *backend_test_branches_filter
   - test-machine:
       name: "test-docker"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -353,6 +353,15 @@ e2e-test: dev ## Run the Nomad e2e test suite
 	@echo "==> Running Nomad E2E test suites:"
 	go test \
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
+		-timeout=900s \
+		-tags "$(GO_TAGS)" \
+		github.com/hashicorp/nomad/e2e
+
+.PHONY: integration-test
+integration-test: dev ## Run Nomad integration tests
+	@echo "==> Running Nomad integration test suites:"
+	go test \
+		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
 		-timeout=900s \
 		-tags "$(GO_TAGS)" \


### PR DESCRIPTION
Currently we compile (but don't run) the e2e tests as part of `test-other`,
which is skipped for branches named `e2e-*`. Move this check into the
`test-e2e` job. Split out the vault compatibility integration check as its own
makefile target for clarity.

Prevents issues like https://github.com/hashicorp/nomad/pull/9089 from slipping by e2e branches and into master.
