### PR TITLE
Implement 'batch mode' for persisting allocations on the client.

### DIFF
--- a/client/state/db_test.go
+++ b/client/state/db_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"sync"
 	"testing"
 
 	trstate "github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
@@ -57,7 +58,7 @@ func testDB(t *testing.T, f func(*testing.T, StateDB)) {
 	}
 }
 
-// TestStateDB asserts the behavior of GetAllAllocations, PutAllocation, and
+// TestStateDB_Allocations asserts the behavior of GetAllAllocations, PutAllocation, and
 // DeleteAllocationBucket for all operational StateDB implementations.
 func TestStateDB_Allocations(t *testing.T) {
 	t.Parallel()
@@ -133,6 +134,102 @@ func TestStateDB_Allocations(t *testing.T) {
 		require.Contains(allocs, alloc2)
 		require.Contains(allocs, alloc3)
 		require.NotNil(errs)
+		require.Empty(errs)
+	})
+}
+
+// TestStateDB_Batch asserts the behavior of PutAllocation, PutNetworkStatus and
+// DeleteAllocationBucket in batch mode, for all operational StateDB implementations.
+func TestStateDB_Batch(t *testing.T) {
+	t.Parallel()
+
+	testDB(t, func(t *testing.T, db StateDB) {
+		require := require.New(t)
+
+		// For BoltDB, get initial tx_id
+		var getTxID func() int
+		var prevTxID int
+		if boltStateDB, ok := db.(*BoltStateDB); ok {
+			boltdb := boltStateDB.DB().BoltDB()
+			getTxID = func() int {
+				tx, err := boltdb.Begin(true)
+				require.NoError(err)
+				defer tx.Rollback()
+				return tx.ID()
+			}
+			prevTxID = getTxID()
+		}
+
+		// Write 1000 allocations and network statuses in batch mode
+		var allocs []*structs.Allocation
+		for i := 0; i < 1000; i++ {
+			allocs = append(allocs, mock.Alloc())
+		}
+		var wg sync.WaitGroup
+		for _, alloc := range allocs {
+			wg.Add(1)
+			go func(alloc *structs.Allocation) {
+				require.NoError(db.PutNetworkStatus(alloc.ID, mock.AllocNetworkStatus(), WithBatchMode()))
+				require.NoError(db.PutAllocation(alloc, WithBatchMode()))
+				wg.Done()
+			}(alloc)
+		}
+		wg.Wait()
+
+		// Check BoltDB actually combined PutAllocation calls into much fewer transactions.
+		// The actual number of transactions depends on how fast the goroutines are spawned,
+		// with every 10ms period saved in a separate transaction (see boltdb MaxBatchDelay
+		// and MaxBatchSize parameters).
+		if getTxID != nil {
+			numTransactions := getTxID() - prevTxID
+			require.Less(numTransactions, 10)
+			prevTxID = getTxID()
+		}
+
+		// Retrieve allocs and make sure they are the same (order can differ)
+		readAllocs, errs, err := db.GetAllAllocations()
+		require.NoError(err)
+		require.NotNil(readAllocs)
+		require.Len(readAllocs, len(allocs))
+		require.NotNil(errs)
+		require.Empty(errs)
+
+		readAllocsById := make(map[string]*structs.Allocation)
+		for _, readAlloc := range readAllocs {
+			readAllocsById[readAlloc.ID] = readAlloc
+		}
+		for _, alloc := range allocs {
+			readAlloc, ok := readAllocsById[alloc.ID]
+			if !ok {
+				t.Fatalf("no alloc with ID=%q", alloc.ID)
+			}
+			if !reflect.DeepEqual(readAlloc, alloc) {
+				pretty.Ldiff(t, readAlloc, alloc)
+				t.Fatalf("alloc %q unequal", alloc.ID)
+			}
+		}
+
+		// Delete all allocs in batch mode
+		for _, alloc := range allocs {
+			wg.Add(1)
+			go func(alloc *structs.Allocation) {
+				require.NoError(db.DeleteAllocationBucket(alloc.ID, WithBatchMode()))
+				wg.Done()
+			}(alloc)
+		}
+		wg.Wait()
+
+		// Check BoltDB combined DeleteAllocationBucket calls into much fewer transactions.
+		if getTxID != nil {
+			numTransactions := getTxID() - prevTxID
+			require.Less(numTransactions, 10)
+			prevTxID = getTxID()
+		}
+
+		// Check all allocs were deleted.
+		readAllocs, errs, err = db.GetAllAllocations()
+		require.NoError(err)
+		require.Empty(readAllocs)
 		require.Empty(errs)
 	})
 }

--- a/client/state/errdb.go
+++ b/client/state/errdb.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -27,7 +28,7 @@ func (m *ErrDB) GetAllAllocations() ([]*structs.Allocation, map[string]error, er
 	return m.Allocs, nil, nil
 }
 
-func (m *ErrDB) PutAllocation(alloc *structs.Allocation) error {
+func (m *ErrDB) PutAllocation(alloc *structs.Allocation, opts ...WriteOption) error {
 	return fmt.Errorf("Error!")
 }
 
@@ -43,7 +44,7 @@ func (m *ErrDB) GetNetworkStatus(allocID string) (*structs.AllocNetworkStatus, e
 	return nil, fmt.Errorf("Error!")
 }
 
-func (m *ErrDB) PutNetworkStatus(allocID string, ns *structs.AllocNetworkStatus) error {
+func (m *ErrDB) PutNetworkStatus(allocID string, ns *structs.AllocNetworkStatus, opts ...WriteOption) error {
 	return fmt.Errorf("Error!")
 }
 
@@ -63,11 +64,19 @@ func (m *ErrDB) DeleteTaskBucket(allocID, taskName string) error {
 	return fmt.Errorf("Error!")
 }
 
-func (m *ErrDB) DeleteAllocationBucket(allocID string) error {
+func (m *ErrDB) DeleteAllocationBucket(allocID string, opts ...WriteOption) error {
 	return fmt.Errorf("Error!")
 }
 
 func (m *ErrDB) PutDevicePluginState(ps *dmstate.PluginState) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) GetDynamicPluginRegistryState() (*dynamicplugins.RegistryState, error) {
+	return nil, fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) PutDynamicPluginRegistryState(state *dynamicplugins.RegistryState) error {
 	return fmt.Errorf("Error!")
 }
 
@@ -88,3 +97,6 @@ func (m *ErrDB) PutDriverPluginState(ps *driverstate.PluginState) error {
 func (m *ErrDB) Close() error {
 	return fmt.Errorf("Error!")
 }
+
+// Ensure *ErrDB implements StateDB
+var _ StateDB = (*ErrDB)(nil)

--- a/client/state/memdb.go
+++ b/client/state/memdb.go
@@ -73,7 +73,7 @@ func (m *MemDB) GetAllAllocations() ([]*structs.Allocation, map[string]error, er
 	return allocs, map[string]error{}, nil
 }
 
-func (m *MemDB) PutAllocation(alloc *structs.Allocation) error {
+func (m *MemDB) PutAllocation(alloc *structs.Allocation, opts ...WriteOption) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.allocs[alloc.ID] = alloc
@@ -99,7 +99,7 @@ func (m *MemDB) GetNetworkStatus(allocID string) (*structs.AllocNetworkStatus, e
 	return m.networkStatus[allocID], nil
 }
 
-func (m *MemDB) PutNetworkStatus(allocID string, ns *structs.AllocNetworkStatus) error {
+func (m *MemDB) PutNetworkStatus(allocID string, ns *structs.AllocNetworkStatus, opts ...WriteOption) error {
 	m.mu.Lock()
 	m.networkStatus[allocID] = ns
 	defer m.mu.Unlock()
@@ -175,7 +175,7 @@ func (m *MemDB) DeleteTaskBucket(allocID, taskName string) error {
 	return nil
 }
 
-func (m *MemDB) DeleteAllocationBucket(allocID string) error {
+func (m *MemDB) DeleteAllocationBucket(allocID string, opts ...WriteOption) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/client/state/noopdb.go
+++ b/client/state/noopdb.go
@@ -23,7 +23,7 @@ func (n NoopDB) GetAllAllocations() ([]*structs.Allocation, map[string]error, er
 	return nil, nil, nil
 }
 
-func (n NoopDB) PutAllocation(*structs.Allocation) error {
+func (n NoopDB) PutAllocation(alloc *structs.Allocation, opts ...WriteOption) error {
 	return nil
 }
 
@@ -39,7 +39,7 @@ func (n NoopDB) GetNetworkStatus(allocID string) (*structs.AllocNetworkStatus, e
 	return nil, nil
 }
 
-func (n NoopDB) PutNetworkStatus(allocID string, ds *structs.AllocNetworkStatus) error {
+func (n NoopDB) PutNetworkStatus(allocID string, ds *structs.AllocNetworkStatus, opts ...WriteOption) error {
 	return nil
 }
 
@@ -59,7 +59,7 @@ func (n NoopDB) DeleteTaskBucket(allocID, taskName string) error {
 	return nil
 }
 
-func (n NoopDB) DeleteAllocationBucket(allocID string) error {
+func (n NoopDB) DeleteAllocationBucket(allocID string, opts ...WriteOption) error {
 	return nil
 }
 

--- a/helper/boltdd/boltdd.go
+++ b/helper/boltdd/boltdd.go
@@ -141,6 +141,13 @@ func (db *DB) Update(fn func(*Tx) error) error {
 	})
 }
 
+func (db *DB) Batch(fn func(*Tx) error) error {
+	return db.bdb.Batch(func(btx *bolt.Tx) error {
+		tx := newTx(db, btx)
+		return fn(tx)
+	})
+}
+
 func (db *DB) View(fn func(*Tx) error) error {
 	return db.bdb.View(func(btx *bolt.Tx) error {
 		tx := newTx(db, btx)

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1493,3 +1493,15 @@ func Events(index uint64) *structs.Events {
 		},
 	}
 }
+
+func AllocNetworkStatus() *structs.AllocNetworkStatus {
+	return &structs.AllocNetworkStatus{
+		InterfaceName: "eth0",
+		Address:       "192.168.0.100",
+		DNS: &structs.DNSConfig{
+			Servers:  []string{"1.1.1.1"},
+			Searches: []string{"localdomain"},
+			Options:  []string{"ndots:5"},
+		},
+	}
+}


### PR DESCRIPTION
Fixes #9047, see problem details there.

As a solution, we use BoltDB's 'Batch' mode that opportunistically combines multiple parallel writes into a small number of transactions. See https://github.com/boltdb/bolt#batch-read-write-transactions for more information.