### PR TITLE
docker: image_delay default missing without gc stanza

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -229,6 +229,7 @@ var (
 			),
 		})), hclspec.NewLiteral(`{
 			image = true
+			image_delay = "3m"
 			container = true
 			dangling_containers = {
 				enabled = true


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9045

In the Docker driver plugin config for garbage collection, the `image_delay`
field was missing from the default we set if the entire `gc` stanza is
missing. This results in a default of 0s and immediate GC of Docker images.