### PR TITLE
Use GOPATH/src explicitly in proto build target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -244,7 +244,7 @@ generate-structs: ## Update generated code
 proto:
 	@echo "--> Generating proto bindings..."
 	@for file in $$(git ls-files "*.proto" | grep -E -v -- "vendor\/.*.proto|demo\/.*.proto"); do \
-		protoc -I . -I ../../.. --go_out=plugins=grpc:. $$file; \
+		protoc -I . -I $(shell go env GOPATH)/src --go_out=plugins=grpc:. $$file; \
 	done
 
 .PHONY: generate-examples


### PR DESCRIPTION
-I ../../.. is meant to navigate from `GOPATH/src/github.com/hashicorp/nomad` to `GOPATH/src`

This is fine but it assumes a few things about how the dev has setup nomad, which is also fine if that is the expected dev environment, however the `../../..` is not as explicit as "GOPATH/src" and it would also enable a few more scenarios so it seems strictly better to me.

Random example: nomad is a subrepo of ours, but with this change we can symlink from GOPATH/src/github.com/hashicorp/nomad and `make proto` will work.