### PR TITLE
Remove Nomad-spark reference from use-cases.mdx

### DIFF
--- a/website/pages/intro/use-cases.mdx
+++ b/website/pages/intro/use-cases.mdx
@@ -52,7 +52,7 @@ easier to adopt the paradigm.
 
 As data science and analytics teams grow in size and complexity, they increasingly
 benefit from highly performant and scalable tools that can run batch workloads with
-minimal operational overhead. Nomad can natively run batch jobs, [parameterized](https://www.hashicorp.com/blog/replacing-queues-with-nomad-dispatch) jobs, and [Spark](https://github.com/hashicorp/nomad-spark)
+minimal operational overhead. Nomad can natively run batch jobs and  [parameterized](https://www.hashicorp.com/blog/replacing-queues-with-nomad-dispatch) jobs. 
 workloads. Nomad's architecture enables easy scalability and an optimistically
 concurrent scheduling strategy that can yield [thousands of container deployments per
 second](https://www.hashicorp.com/c1m). Alternatives are overly complex and limited


### PR DESCRIPTION
Removed ref to [Spark](https://github.com/hashicorp/nomad-spark) based on 
https://github.com/hashicorp/nomad-spark/commit/2c6092a2a6df6236282d2777e7de4a11c76f7cd6