### PR TITLE
e2e: networking test job needs to outlast assert

### DIFF
--- a/e2e/networking/inputs/basic.nomad
+++ b/e2e/networking/inputs/basic.nomad
@@ -1,6 +1,12 @@
 //e2e:service script=validate.sh
 job "networking" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "basic" {
     network {
       mode = "bridge"
@@ -11,7 +17,7 @@ job "networking" {
       config {
         image   = "busybox:1"
         command = "/bin/sleep"
-        args    = ["5"]
+        args    = ["300"]
       }
     }
   }


### PR DESCRIPTION
The `e2ejob` utility asserts that a job is running for 5s, but with a sleep
time of 5s, the networking job can race with that check. Sleeping for a longer
period should guarantee that we're running long enough to pass the assert.

Also constrains the job to Linux because our Windows test targets don't yet
support Docker (LCOW), and expand the set of DCs we can safely land on.