### PR TITLE
e2e: fix flaky TaskEventsTest

### DIFF
--- a/e2e/taskevents/taskevents.go
+++ b/e2e/taskevents/taskevents.go
@@ -95,8 +95,11 @@ func (tc *TaskEventsTest) waitUntilEvents(f *framework.F, jobName string, numEve
 			return false, fmt.Errorf("task state not found for %s", jobName)
 		}
 
-		// Assert expected number of task events
-		if len(taskState.Events) != numEvents {
+		// Assert expected number of task events; we can't check for the exact
+		// count because of a race where Allocation Unhealthy events can be
+		// emitted when a peer task dies, but the caller can assert the
+		// specific events and their order up to that point
+		if len(taskState.Events) < numEvents {
 			return false, fmt.Errorf("expected %d task events but found %d\n%s",
 				numEvents, len(taskState.Events), formatEvents(taskState.Events),
 			)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7737

Assert that we get at least N task events, rather than exactly N. When a
task within an allocation dies, a sibling task can get an Allocation Unhealthy
event after it's also killed, even though it's not the origin of the event.