### PR TITLE
website: make build logs public

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "public": true,
   "github": {
     "silent": true
   }


### PR DESCRIPTION
this allows the ability for outside contributors to view website build logs